### PR TITLE
Deprecate constant pipe styles for Subprocess and replace with an enum

### DIFF
--- a/test/arrays/skyline/spawnPromoteBug.chpl
+++ b/test/arrays/skyline/spawnPromoteBug.chpl
@@ -1,7 +1,7 @@
 use Subprocess;
 
 proc f(s: string) {
-  var p = spawnshell(s, stdout=PIPE, stderr=PIPE);
+  var p = spawnshell(s, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
   p.communicate();
   return p;
 }

--- a/test/chplenv/autocomplete/autocomplete.chpl
+++ b/test/chplenv/autocomplete/autocomplete.chpl
@@ -13,8 +13,8 @@ var home = CHPL_HOME;
 var genScript = home + "/util/devel/gen-chpl-bash-completion";
 var completeScript = home + "/util/chpl-completion.bash";
 
-var diff = spawn(["diff", "-", completeScript], stdin=PIPE);
-var runScript = spawn([genScript], stdout=PIPE);
+var diff = spawn(["diff", "-", completeScript], stdin=pipeStyle.pipe);
+var runScript = spawn([genScript], stdout=pipeStyle.pipe);
 
 for line in runScript.stdout.lines() {
   diff.stdin.write(line);

--- a/test/classes/initializers/initequals/useOnly.chpl
+++ b/test/classes/initializers/initequals/useOnly.chpl
@@ -1,4 +1,4 @@
-use Subprocess only spawnshell, PIPE, subprocess;
+use Subprocess only spawnshell, pipeStyle, subprocess;
 use IO;
 
 proc main() throws {
@@ -6,6 +6,6 @@ proc main() throws {
   p = run('ls');
 }
 proc run(cmd: string): subprocess(kind=iokind.dynamic, locking=true) throws {
-  var p = spawnshell(cmd, stdout=PIPE, stderr=PIPE);
+  var p = spawnshell(cmd, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
   return p;
 }

--- a/test/deprecated/subprocess-pipe-types.chpl
+++ b/test/deprecated/subprocess-pipe-types.chpl
@@ -1,0 +1,7 @@
+use Subprocess;
+
+var f = FORWARD;
+var c = CLOSE;
+var p = PIPE;
+var s = STDOUT;
+var b = BUFFERED_PIPE;

--- a/test/deprecated/subprocess-pipe-types.good
+++ b/test/deprecated/subprocess-pipe-types.good
@@ -1,0 +1,5 @@
+subprocess-pipe-types.chpl:3: warning: 'FORWARD' is deprecated, please use 'pipeStyle.forward' instead
+subprocess-pipe-types.chpl:4: warning: 'CLOSE' is deprecated, please use 'pipeStyle.close' instead
+subprocess-pipe-types.chpl:5: warning: 'PIPE' is deprecated, please use 'pipeStyle.pipe' instead
+subprocess-pipe-types.chpl:6: warning: 'STDOUT' is deprecated, please use 'pipeStyle.stdout' instead
+subprocess-pipe-types.chpl:7: warning: 'BUFFERED_PIPE' is deprecated, please use 'pipeStyle.bufferAll' instead

--- a/test/library/packages/Curl/RunServer.chpl
+++ b/test/library/packages/Curl/RunServer.chpl
@@ -11,7 +11,7 @@ var server:subprocess(kind=iokind.dynamic, locking=true);
 proc startServer() {
   // Run a curl command to check if the server is already up
   var check = spawn(["curl", "http://" + host + ":" + port + "/test.txt"],
-                     stdin=CLOSE, stdout=PIPE, stderr=PIPE);
+                     stdin=pipeStyle.close, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
   check.communicate();
 
   if check.exitCode == 0 {
@@ -21,7 +21,7 @@ proc startServer() {
 
   // Start a little HTTP server
   server = spawn(["python3", "-m", "http.server", port, "--bind", host],
-                 stdin=CLOSE, stdout=PIPE, stderr=PIPE);
+                 stdin=pipeStyle.close, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
 
   var ok = false;
 
@@ -30,7 +30,7 @@ proc startServer() {
     // We could use curl to do the retries, but not all curl versions
     // have the relevant options.
     var check = spawn(["curl", "http://" + host + ":" + port + "/test.txt"],
-                       stdin=CLOSE, stdout=PIPE, stderr=PIPE);
+                       stdin=pipeStyle.close, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
     check.communicate();
 
     if check.exitCode == 0 {

--- a/test/library/packages/HDF5/HDF5Preprocessors.chpl
+++ b/test/library/packages/HDF5/HDF5Preprocessors.chpl
@@ -38,7 +38,7 @@ module HDF5Preprocessors {
         chmod(scriptName, 0o755);
 
         // spawn the script, connect stdin and stdout
-        var sub = spawn([scriptName], stdin=PIPE, stdout=PIPE);
+        var sub = spawn([scriptName], stdin=pipeStyle.pipe, stdout=pipeStyle.pipe);
 
         cobegin {
           // dump the array to the script's stdin

--- a/test/library/packages/ProtobufProtocolSupport/endToEndRunnerUtils.chpl
+++ b/test/library/packages/ProtobufProtocolSupport/endToEndRunnerUtils.chpl
@@ -23,7 +23,7 @@ proc endToEndTest(package: string) {
   shell2.wait();
   shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl");
   shell2.wait();
-  shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=PIPE);
+  shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=pipeStyle.pipe);
   while shell2.stdout.readline(line1) {
     if(line1.strip() != "true") then writeln("Chapel to Chapel failed");
   }
@@ -34,7 +34,7 @@ proc endToEndTest(package: string) {
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./write -nl 1");
   shell2.wait();
-  shell2 = spawnshell("python3 "+packageDir+"/read.py", stdout=PIPE);
+  shell2 = spawnshell("python3 "+packageDir+"/read.py", stdout=pipeStyle.pipe);
   while shell2.stdout.readline(line1) {
     if(line1.strip() != "true") then writeln("Chapel to Python failed");
   }
@@ -45,7 +45,7 @@ proc endToEndTest(package: string) {
   shell2.wait();
   shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl");
   shell2.wait();
-  shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=PIPE);
+  shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=pipeStyle.pipe);
   while shell2.stdout.readline(line1) {
     if(line1.strip() != "true") then writeln("Python to Chapel failed");
   }

--- a/test/library/standard/Path/victor-ludorum/testcases_isAbsPath.chpl
+++ b/test/library/standard/Path/victor-ludorum/testcases_isAbsPath.chpl
@@ -21,7 +21,7 @@
 
    proc getPythonsAbspath() {
      var command = "python3 -c 'import os; print(os.getcwd())'";
-     var sub = spawnshell(command, stdout=PIPE);
+     var sub = spawnshell(command, stdout=pipeStyle.pipe);
 
      var absPath:string;
      sub.stdout.readline(absPath);

--- a/test/library/standard/Spawn/cat-test.chpl
+++ b/test/library/standard/Spawn/cat-test.chpl
@@ -16,14 +16,14 @@ for i in 1..n {
   test[i] = i:string;
 }
 
-writeln("Test 1: stdin=BUFFERED_PIPE stdout=PIPE with 1 task");
+writeln("Test 1: stdin=bufferAll stdout=pipe with 1 task");
 {
-  // note: if BUFFERED_PIPE is not used in this case,
+  // note: if pipeStyle.bufferAll is not used in this case,
   // this program will hang if n is large enough (e.g. 10000)
   // since cat will be waiting for this program to consume
   // the output - but we're not consuming the output while we
   // are in the loop writing to cat.
-  var sub = spawn(["cat"], stdin=BUFFERED_PIPE, stdout=PIPE);
+  var sub = spawn(["cat"], stdin=pipeStyle.bufferAll, stdout=pipeStyle.pipe);
   for x in test {
     sub.stdin.writeln(x);
   }
@@ -46,7 +46,7 @@ writeln("Test 1: stdin=BUFFERED_PIPE stdout=PIPE with 1 task");
 
 writeln("Test 2: pipe stdin, stdout in 2 tasks");
 {
-  var sub = spawn(["cat"], stdin=PIPE, stdout=PIPE);
+  var sub = spawn(["cat"], stdin=pipeStyle.pipe, stdout=pipeStyle.pipe);
   cobegin {
     {
       for x in test {

--- a/test/library/standard/Spawn/cat-test.good
+++ b/test/library/standard/Spawn/cat-test.good
@@ -1,2 +1,2 @@
-Test 1: stdin=BUFFERED_PIPE stdout=PIPE with 1 task
+Test 1: stdin=bufferAll stdout=pipe with 1 task
 Test 2: pipe stdin, stdout in 2 tasks

--- a/test/library/standard/Spawn/redirect-stderr-stdout.chpl
+++ b/test/library/standard/Spawn/redirect-stderr-stdout.chpl
@@ -1,6 +1,6 @@
 use Subprocess;
 const cmd = ["sh", "-c", "echo stderr 1>&2; echo stdout;"];
-var sub = spawn(cmd, stdout=PIPE, stderr=STDOUT);
+var sub = spawn(cmd, stdout=pipeStype.pipe, stderr=pipeStyle.stdout);
 var line: string;
 while (sub.stdout.readline(line)) {
   write('*'+line);

--- a/test/library/standard/Spawn/spawn-error2.chpl
+++ b/test/library/standard/Spawn/spawn-error2.chpl
@@ -1,7 +1,7 @@
 use Subprocess;
 
 {
-  var sub = spawn(["./some-command-that-does-not-exist"], stdout=PIPE);
+  var sub = spawn(["./some-command-that-does-not-exist"], stdout=pipeStyle.pipe);
   var line:string;
   var count:int;
   while sub.stdout.readline(line) {

--- a/test/library/standard/Spawn/spawn-popen-input-error-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-error-long.chpl
@@ -1,6 +1,6 @@
 use Subprocess;
 
-var sub = spawnshell("cat 1>&2", stdin=BUFFERED_PIPE, stdout=FORWARD, stderr=PIPE);
+var sub = spawnshell("cat 1>&2", stdin=pipeStyle.bufferAll, stdout=pipeStyle.forward, stderr=pipeStyle.pipe);
 
 assert(sub.running == true);
 

--- a/test/library/standard/Spawn/spawn-popen-input-output-error-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-error-long.chpl
@@ -6,7 +6,7 @@ use Subprocess;
   assert(comp.exitCode == 0);
 }
 
-var sub = spawn(["./stdout-stderr", "-nl", "1"], stdin=BUFFERED_PIPE, stdout=PIPE, stderr=PIPE);
+var sub = spawn(["./stdout-stderr", "-nl", "1"], stdin=pipeStyle.bufferAll, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
 
 config const n = 10000;
 for i in 1..n {

--- a/test/library/standard/Spawn/spawn-popen-input-output-error.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-error.chpl
@@ -6,7 +6,7 @@ use Subprocess;
   assert(comp.exitCode == 0);
 }
 
-var sub = spawn(["./stdout-stderr", "-nl", "1"], stdin=BUFFERED_PIPE, stdout=PIPE, stderr=PIPE);
+var sub = spawn(["./stdout-stderr", "-nl", "1"], stdin=pipeStyle.bufferAll, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
 
 sub.stdin.writeln("Hello");
 sub.stdin.writeln("Everybody");

--- a/test/library/standard/Spawn/spawn-popen-input-output-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-long.chpl
@@ -1,6 +1,6 @@
 use Subprocess;
 
-var sub = spawn(["cat"], stdin=BUFFERED_PIPE, stdout=PIPE, stderr=FORWARD);
+var sub = spawn(["cat"], stdin=pipeStyle.bufferAll, stdout=pipeStyle.pipe, stderr=pipeStyle.forward);
 
 config const n = 10000;
 for i in 1..n {

--- a/test/library/standard/Spawn/spawn-popen-input-output.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output.chpl
@@ -1,6 +1,6 @@
 use Subprocess;
 
-var sub = spawn(["cat"], stdin=BUFFERED_PIPE, stdout=PIPE);
+var sub = spawn(["cat"], stdin=pipeStyle.bufferAll, stdout=pipeStyle.pipe);
 
 sub.stdin.writeln("Hello");
 sub.stdin.writeln("World");

--- a/test/library/standard/Spawn/spawn-popen-input.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input.chpl
@@ -1,6 +1,6 @@
 use Subprocess;
 
-var sub = spawn(["cat"], stdin=PIPE);
+var sub = spawn(["cat"], stdin=pipeStyle.pipe);
 
 sub.stdin.writeln("Hello");
 sub.stdin.writeln("World");

--- a/test/library/standard/Spawn/spawn-popen-wait.chpl
+++ b/test/library/standard/Spawn/spawn-popen-wait.chpl
@@ -19,7 +19,7 @@ config const showtime = false;
 
 var timer:Timer;
 
-var sub = spawn(["bash", "waiting.bash"], stdout=PIPE);
+var sub = spawn(["bash", "waiting.bash"], stdout=pipeStyle.pipe);
 
 timer.start();
 

--- a/test/library/standard/Spawn/spawn-popen.chpl
+++ b/test/library/standard/Spawn/spawn-popen.chpl
@@ -1,6 +1,6 @@
 use Subprocess;
 
-var sub = spawn(["cat", "test.txt"], stdout=PIPE);
+var sub = spawn(["cat", "test.txt"], stdout=pipeStyle.pipe);
 
 var line:string;
 while sub.stdout.readline(line) {

--- a/test/library/standard/Spawn/spawn-popen2.chpl
+++ b/test/library/standard/Spawn/spawn-popen2.chpl
@@ -1,6 +1,6 @@
 use Subprocess;
 
-var sub = spawn(["cat", "test.txt"], stdout=PIPE);
+var sub = spawn(["cat", "test.txt"], stdout=pipeStyle.pipe);
 
 var line:string;
 while sub.stdout.readline(line) {

--- a/test/library/standard/Spawn/two-waits.chpl
+++ b/test/library/standard/Spawn/two-waits.chpl
@@ -8,7 +8,7 @@ if pipes then
   buffer = true;
 
 var process = if pipes
-              then spawn(['ls', 'two-waits.chpl'], stdout=PIPE, stderr=PIPE)
+              then spawn(['ls', 'two-waits.chpl'], stdout=pipeStyle.pipe, stderr=pipeStyle.pipe)
               else spawn(['ls', 'two-waits.chpl']);
 
 

--- a/test/library/standard/Spawn/ugni/spawn-system.chpl
+++ b/test/library/standard/Spawn/ugni/spawn-system.chpl
@@ -5,8 +5,8 @@ use Subprocess;
 
 config const pipeStdout = false;
 
-var stdoutArg=FORWARD;
-if pipeStdout then stdoutArg=PIPE;
+var stdoutArg=pipeStyle.forward;
+if pipeStdout then stdoutArg=pipeStyle.pipe;
 
 var sub = spawn(["ls", "../test.txt"], stdout=stdoutArg);
 sub.wait();

--- a/test/mason/MasonTestHelpers.chpl
+++ b/test/mason/MasonTestHelpers.chpl
@@ -1,7 +1,7 @@
 use Subprocess;
 
 proc checkExitStatus(cmd: [] string, exitStatus: int) {
-  var p = spawn(cmd, stdout=PIPE);
+  var p = spawn(cmd, stdout=pipeStyle.pipe);
   var cmdString = " ".join(cmd);
   p.wait();
   if p.exitCode == exitStatus {

--- a/test/mason/mason-help-tests/masonHelpTests.chpl
+++ b/test/mason/mason-help-tests/masonHelpTests.chpl
@@ -30,7 +30,7 @@ proc main() {
 
 proc checkOutput(cmd: string) {
   var splitCmd = cmd.split();
-  var p = spawn(splitCmd,stdout=PIPE);
+  var p = spawn(splitCmd,stdout=pipeStyle.pipe);
   writeln("$ " + cmd);
   var line:string;
   while p.stdout.readline(line) {

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.chpl
@@ -69,7 +69,7 @@ proc printSystemInfo() {
     if ugni || gn_ibv then return "unknown";
 
     use Subprocess;
-    var sub = spawn(["uname", cmd], stdout=PIPE);
+    var sub = spawn(["uname", cmd], stdout=pipeStyle.pipe);
     sub.wait();
 
     if sub.exitCode == 0 {

--- a/test/studies/dedup/dedup-distributed-ints.chpl
+++ b/test/studies/dedup/dedup-distributed-ints.chpl
@@ -40,7 +40,7 @@ proc main(args:[] string)
   forall (id,path) in zip(distributedPaths.domain, distributedPaths) {
     if verbose then
       writeln("Running sha1sum ", path);
-    var sub = spawn(["sha1sum", path], stdout=PIPE);
+    var sub = spawn(["sha1sum", path], stdout=pipeStyle.pipe);
     var hashString:string;
     sub.stdout.read(hashString);
     if verbose then

--- a/test/studies/dedup/dedup-distributed-strings.chpl
+++ b/test/studies/dedup/dedup-distributed-strings.chpl
@@ -52,9 +52,9 @@ proc main(args:[] string)
     if verbose then
       writeln("Running sha1sum ", path);
     // The spawn call creates a subprocess. By specifying
-    // stdout=PIPE, we are requesting that the output of the subprocess
-    // be sent to a pipe that we can read from.
-    var sub = spawn(["sha1sum", path], stdout=PIPE);
+    // stdout=pipeStyle.pipe, we are requesting that the output of the
+    // subprocess be sent to a pipe that we can read from.
+    var sub = spawn(["sha1sum", path], stdout=pipeStyle.pipe);
     // Read the hash value from the output of sha1sum.
     // Note that sha1sum output looks like this:
     // d556d22d3e7b3ae55108442b36b5833523c923b7  dedup-distributed-strings.chpl

--- a/test/studies/dedup/dedup-local.chpl
+++ b/test/studies/dedup/dedup-local.chpl
@@ -29,7 +29,7 @@ proc main(args:[] string)
   forall (id,path) in zip(pathsArray.domain, pathsArray) {
     if verbose then
       writeln("Running sha1sum ", path);
-    var sub = spawn(["sha1sum", path], stdout=PIPE);
+    var sub = spawn(["sha1sum", path], stdout=pipeStyle.pipe);
     var hashString:string;
     sub.stdout.read(hashString);
     if verbose then

--- a/test/studies/dedup/dedup-spawn-sort.chpl
+++ b/test/studies/dedup/dedup-spawn-sort.chpl
@@ -35,7 +35,7 @@ proc main(args:[] string)
   // Compute the SHA1 sums using the external program
   // Do so in parallel across all locales
   forall path in distributedPaths {
-    var sub = spawn(["sha1sum", path], stdout=pipeStype.pipe);
+    var sub = spawn(["sha1sum", path], stdout=pipeStyle.pipe);
     var hash:string;
     sub.stdout.read(hash);
     distributedWriters[here.id].writeln(hash, " ", path);
@@ -45,7 +45,7 @@ proc main(args:[] string)
   for w in distributedWriters do
     w.close();
  
-  var sorter = spawn(["sort"], stdin=pipeStype.pipe, stdout=pipeStype.pipe);
+  var sorter = spawn(["sort"], stdin=pipeStyle.pipe, stdout=pipeStyle.pipe);
   cobegin {
     {
       // Output all of the to the sort process

--- a/test/studies/dedup/dedup-spawn-sort.chpl
+++ b/test/studies/dedup/dedup-spawn-sort.chpl
@@ -35,7 +35,7 @@ proc main(args:[] string)
   // Compute the SHA1 sums using the external program
   // Do so in parallel across all locales
   forall path in distributedPaths {
-    var sub = spawn(["sha1sum", path], stdout=PIPE);
+    var sub = spawn(["sha1sum", path], stdout=pipeStype.pipe);
     var hash:string;
     sub.stdout.read(hash);
     distributedWriters[here.id].writeln(hash, " ", path);
@@ -45,7 +45,7 @@ proc main(args:[] string)
   for w in distributedWriters do
     w.close();
  
-  var sorter = spawn(["sort"], stdin=PIPE, stdout=PIPE);
+  var sorter = spawn(["sort"], stdin=pipeStype.pipe, stdout=pipeStype.pipe);
   cobegin {
     {
       // Output all of the to the sort process

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -252,7 +252,7 @@ proc process_json(fname: string, ref Pairs)
 
   var last3chars = fname[fname.size-3..];
   if last3chars == ".gz" {
-    var sub = spawn(["gunzip", "-c", fname], stdout=PIPE);
+    var sub = spawn(["gunzip", "-c", fname], stdout=pipeStyle.pipe);
     process_json(sub.stdout, fname, Pairs);
   } else {
     var logfile = openreader(fname);

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -182,7 +182,7 @@ proc checkRegistryPath(registryPath : string, trueIfLocal : bool) throws {
     }
     else {
       var command = ('git ls-remote ' + registryPath).split();
-      var checkRemote = spawn(command, stdout=PIPE);
+      var checkRemote = spawn(command, stdout=pipeStyle.pipe);
       checkRemote.wait();
       if checkRemote.exitCode == 0 then return true;
       else {
@@ -255,7 +255,7 @@ private proc commitSubProcess(dir: string, command: [] string) throws {
   var spawnArgs = command;
   const oldDir = here.cwd();
   here.chdir(dir);
-  var commitSpawn = spawn(spawnArgs, stdout=PIPE, stderr=PIPE);
+  var commitSpawn = spawn(spawnArgs, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
   commitSpawn.wait();
   here.chdir(oldDir);
   return commitSpawn;
@@ -693,7 +693,7 @@ private proc checkLicense(projectHome: string) throws {
 /* Attempts to build the package/
  */
 private proc attemptToBuild() throws {
-  var sub = spawn(['mason','build','--force'], stdout=PIPE);
+  var sub = spawn(['mason','build','--force'], stdout=pipeStyle.pipe);
   sub.wait();
   if sub.exitCode == 1 {
   writeln('(FAILED) Please make sure your package builds');

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -95,7 +95,7 @@ proc pkgSearch(args) throws {
   const pattern = compile(pkgName, ignoreCase=true);
   const command = "pkg-config --list-all";
   const cmd = command.split();
-  var sub = spawn(cmd, stdout=PIPE);
+  var sub = spawn(cmd, stdout=pipeStyle.pipe);
   sub.wait();
 
   // TODO: Test if this ever worked
@@ -179,7 +179,7 @@ proc getPkgVariable(pkgName: string, option: string) {
 
   var lines: list(string);
   var cmd = command.split();
-  var sub = spawn(cmd, stdout=PIPE);
+  var sub = spawn(cmd, stdout=pipeStyle.pipe);
   sub.wait();
 
   var line:string;

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -428,13 +428,13 @@ proc getRuntimeComm() throws {
   var line: string;
   var python: string;
   var findPython = spawn([CHPL_HOME:string+"/util/config/find-python.sh"],
-                         stdout = PIPE);
+                         stdout = pipeStyle.pipe);
   while findPython.stdout.readline(line) {
     python = line.strip();
   }
 
   var checkComm = spawn([python, CHPL_HOME:string+"/util/chplenv/chpl_comm.py"],
-                        stdout = PIPE);
+                        stdout = pipeStyle.pipe);
   while checkComm.stdout.readline(line) {
     comm = line.strip();
   }
@@ -458,7 +458,7 @@ proc getRuntimeComm() throws {
 proc runUnitTest(ref cmdLineCompopts: list(string), show: bool) {
   var comm_c: c_string;
   try! {
-    var checkChpl = spawn(["which","chpl"],stdout = PIPE);
+    var checkChpl = spawn(["which","chpl"],stdout = pipeStyle.pipe);
     checkChpl.wait();
     var line: string;
     if checkChpl.stdout.readline(line) {
@@ -604,8 +604,8 @@ proc runAndLog(executable, fileName, ref result, reqNumLocales: int = numLocales
   var exec = spawn([executable, "-nl", reqNumLocales: string, "--testNames",
             testNamesStr,"--failedTestNames", failedTestNamesStr, "--errorTestNames",
             erroredTestNamesStr, "--ranTests", passedTestStr, "--skippedTestNames",
-            skippedTestNamesStr], stdout = PIPE,
-            stderr = PIPE); //Executing the file
+            skippedTestNamesStr], stdout = pipeStyle.pipe,
+            stderr = pipeStyle.pipe); //Executing the file
   //std output pipe
   while exec.stdout.readline(line) {
     if line.strip() == separator1 then sep1Found = true;

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -100,7 +100,7 @@ proc runCommand(cmd, quiet=false) : string throws {
   try {
 
     var splitCmd = cmd.split();
-    var process = spawn(splitCmd, stdout=PIPE);
+    var process = spawn(splitCmd, stdout=pipeStyle.pipe);
 
     for line in process.stdout.lines() {
       ret += line;
@@ -122,7 +122,7 @@ proc runWithStatus(command, quiet=false): int {
 
   try {
     var cmd = command.split();
-    var sub = spawn(cmd, stdout=PIPE, stderr=PIPE);
+    var sub = spawn(cmd, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
 
     var line:string;
     if !quiet {
@@ -140,7 +140,7 @@ proc runWithStatus(command, quiet=false): int {
 proc runWithProcess(command, quiet=false) throws {
   try {
     var cmd = command.split();
-    var process = spawn(cmd, stdout=PIPE, stderr=PIPE);
+    var process = spawn(cmd, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
 
     return process;
   }
@@ -178,7 +178,7 @@ proc getSpackResult(cmd, quiet=false) : string throws {
     " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
     " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
     var splitCmd = prefix + cmd;
-    var process = spawnshell(splitCmd, stdout=PIPE, executable="bash");
+    var process = spawnshell(splitCmd, stdout=pipeStyle.pipe, executable="bash");
 
     for line in process.stdout.lines() {
       ret += line;
@@ -205,7 +205,7 @@ proc runSpackCommand(command, quiet=false) {
     " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
 
   var cmd = (prefix + command);
-  var sub = spawnshell(cmd, stdout=PIPE, stderr=PIPE, executable="bash");
+  var sub = spawnshell(cmd, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe, executable="bash");
 
   // quiet flag necessary for tests to be portable
   if !quiet {
@@ -332,7 +332,7 @@ proc getChapelVersionInfo(): VersionInfo {
 
       var ret : VersionInfo;
 
-      var process = spawn(["chpl", "--version"], stdout=PIPE);
+      var process = spawn(["chpl", "--version"], stdout=pipeStyle.pipe);
       process.wait();
       if process.exitCode != 0 {
         throw new owned MasonError("Failed to run 'chpl --version'");


### PR DESCRIPTION
Deprecate the Subprocess constants FORWARD, CLOSE, PIPE, STDOUT, BUFFERED_PIPE
and make them an enum with values forward, close, pipe, stdout, bufferAll.

Update tests and Mason to use the new names. Add a deprecation test.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>