### PR TITLE
Add checks for division by 0 to the bigint division methods

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -1071,19 +1071,7 @@ module BigInteger {
   // Division
   operator bigint./(const ref a: bigint, const ref b: bigint) {
     var c = new bigint();
-
-    if _local {
-      mpz_tdiv_q(c.mpz, a.mpz, b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_tdiv_q(c.mpz, a.mpz, b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      mpz_tdiv_q(c.mpz, a_.mpz, b_.mpz);
-    }
+    c.divQ(a, b, round.zero);
 
     return c;
   }
@@ -1872,21 +1860,7 @@ module BigInteger {
 
   // /=
   operator bigint./=(ref a: bigint, const ref b: bigint) {
-    if _local {
-      mpz_tdiv_q(a.mpz, a.mpz, b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_tdiv_q(a.mpz, a.mpz, b.mpz);
-
-    } else {
-      const aLoc = chpl_buildLocaleID(a.localeId, c_sublocid_any);
-
-      on __primitive("chpl_on_locale_num", aLoc) {
-        const b_ = b;
-
-        mpz_tdiv_q(a.mpz, a.mpz, b_.mpz);
-      }
-    }
+    a.divQ(a, b, round.zero);
   }
 
   operator bigint./=(ref a: bigint, b: integral) {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2386,6 +2386,10 @@ module BigInteger {
 
   // documented in bigint, integral version
   proc bigint.divexact(const ref numer: bigint, const ref denom: bigint) {
+    if (chpl_checkDivByZero) then
+      if denom == 0 then
+        halt("Attempt to divide by zero");
+
     if _local {
       mpz_divexact(this.mpz, numer.mpz, denom.mpz);
 
@@ -4558,6 +4562,10 @@ module BigInteger {
   proc bigint.divQ(const ref numer: bigint,
                    const ref denom: bigint,
                    param rounding = round.zero) {
+    if (chpl_checkDivByZero) then
+      if denom == 0 then
+        halt("Attempt to divide by zero");
+
     if _local {
       select rounding {
         when round.up   do mpz_cdiv_q(this.mpz, numer.mpz,  denom.mpz);
@@ -4661,6 +4669,10 @@ module BigInteger {
   proc bigint.divR(const ref numer: bigint,
                    const ref denom: bigint,
                    param     rounding = round.zero) {
+    if (chpl_checkDivByZero) then
+      if denom == 0 then
+        halt("Attempt to divide by zero");
+
     if _local {
       select rounding {
         when round.up   do mpz_cdiv_r(this.mpz, numer.mpz,  denom.mpz);
@@ -4766,6 +4778,10 @@ module BigInteger {
                     const ref numer: bigint,
                     const ref denom: bigint,
                     param     rounding = round.zero) {
+    if (chpl_checkDivByZero) then
+      if denom == 0 then
+        halt("Attempt to divide by zero");
+
     if _local {
       select rounding {
         when round.up do mpz_cdiv_qr(this.mpz, remain.mpz, numer.mpz,

--- a/test/library/standard/BigInteger/divQByZero.chpl
+++ b/test/library/standard/BigInteger/divQByZero.chpl
@@ -1,0 +1,6 @@
+use BigInteger;
+
+var a: bigint = 15;
+var b = 0;
+var res: bigint;
+res.divQ(a, b);

--- a/test/library/standard/BigInteger/divQByZero.compopts
+++ b/test/library/standard/BigInteger/divQByZero.compopts
@@ -1,0 +1,2 @@
+--checks
+--div-by-zero-checks

--- a/test/library/standard/BigInteger/divQByZero.good
+++ b/test/library/standard/BigInteger/divQByZero.good
@@ -1,0 +1,1 @@
+divQByZero.chpl:6: error: halt reached - Attempt to divide by zero

--- a/test/library/standard/BigInteger/divQRByZero.chpl
+++ b/test/library/standard/BigInteger/divQRByZero.chpl
@@ -1,0 +1,7 @@
+use BigInteger;
+
+var a: bigint = 15;
+var b = 0;
+var res: bigint;
+var remainder: bigint;
+res.divQR(remainder, a, b);

--- a/test/library/standard/BigInteger/divQRByZero.compopts
+++ b/test/library/standard/BigInteger/divQRByZero.compopts
@@ -1,0 +1,2 @@
+--checks
+--div-by-zero-checks

--- a/test/library/standard/BigInteger/divQRByZero.good
+++ b/test/library/standard/BigInteger/divQRByZero.good
@@ -1,0 +1,1 @@
+divQRByZero.chpl:7: error: halt reached - Attempt to divide by zero

--- a/test/library/standard/BigInteger/divRByZero.chpl
+++ b/test/library/standard/BigInteger/divRByZero.chpl
@@ -1,0 +1,6 @@
+use BigInteger;
+
+var a: bigint = 15;
+var b = 0;
+var res: bigint;
+res.divR(a, b);

--- a/test/library/standard/BigInteger/divRByZero.compopts
+++ b/test/library/standard/BigInteger/divRByZero.compopts
@@ -1,0 +1,2 @@
+--checks
+--div-by-zero-checks

--- a/test/library/standard/BigInteger/divRByZero.good
+++ b/test/library/standard/BigInteger/divRByZero.good
@@ -1,0 +1,1 @@
+divRByZero.chpl:6: error: halt reached - Attempt to divide by zero

--- a/test/library/standard/BigInteger/divexactByZero.chpl
+++ b/test/library/standard/BigInteger/divexactByZero.chpl
@@ -1,0 +1,6 @@
+use BigInteger;
+
+var a: bigint = 15;
+var b = 0;
+var res: bigint;
+res.divexact(a, b);

--- a/test/library/standard/BigInteger/divexactByZero.compopts
+++ b/test/library/standard/BigInteger/divexactByZero.compopts
@@ -1,0 +1,2 @@
+--checks
+--div-by-zero-checks

--- a/test/library/standard/BigInteger/divexactByZero.good
+++ b/test/library/standard/BigInteger/divexactByZero.good
@@ -1,0 +1,1 @@
+divexactByZero.chpl:6: error: halt reached - Attempt to divide by zero

--- a/test/library/standard/BigInteger/divideByZero.chpl
+++ b/test/library/standard/BigInteger/divideByZero.chpl
@@ -1,0 +1,5 @@
+use BigInteger;
+
+var a: bigint = 15;
+var b = 0;
+var res: bigint = a / b;

--- a/test/library/standard/BigInteger/divideByZero.compopts
+++ b/test/library/standard/BigInteger/divideByZero.compopts
@@ -1,0 +1,2 @@
+--checks
+--div-by-zero-checks

--- a/test/library/standard/BigInteger/divideByZero.good
+++ b/test/library/standard/BigInteger/divideByZero.good
@@ -1,0 +1,1 @@
+divideByZero.chpl:5: error: halt reached - Attempt to divide by zero

--- a/test/library/standard/BigInteger/divideEqualsByZero.chpl
+++ b/test/library/standard/BigInteger/divideEqualsByZero.chpl
@@ -1,0 +1,5 @@
+use BigInteger;
+
+var a: bigint = 15;
+var b = 0;
+a /= b;

--- a/test/library/standard/BigInteger/divideEqualsByZero.compopts
+++ b/test/library/standard/BigInteger/divideEqualsByZero.compopts
@@ -1,0 +1,2 @@
+--checks
+--div-by-zero-checks

--- a/test/library/standard/BigInteger/divideEqualsByZero.good
+++ b/test/library/standard/BigInteger/divideEqualsByZero.good
@@ -1,0 +1,1 @@
+divideEqualsByZero.chpl:5: error: halt reached - Attempt to divide by zero


### PR DESCRIPTION
These checks are controlled by the `--div-by-zero-checks` flag.  Now the bigint
division methods match the behavior of regular integer division operators,
generating a halt when checking for division by 0 and when such checks are
turned off, relying on the GMP implementation's behavior.

Resolves #18007 

Adds tests that check:
- divexact
- divQ
- divR
- divQR
- / operator
- /= operator

These tests will only run with `--checks` and `--div-by-zero-checks`.  I could
have chosen to skip the tests when `--no-check` or `--fast` are in the compopts,
but I think this makes more sense.

Does not check:
- isDivisible (the function explicitly calls out that division by 0 is okay)
- isDivisibleBy2Pow (will not result in a division by 0)
- divQ2Exp (will not result in a division by 0)
- divR2Exp (will not result in a division by 0)

Passed a full paratest with futures