### PR TITLE
Ensure uGNI comm domain IDs really are unique within nodes.

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2251,7 +2251,7 @@ void gni_setup_per_comm_dom(int cdi)
   //
   // Create communication domain.
   //
-  gni_init(&cd->nih, cdi);
+  gni_init(&cd->nih, (chpl_nodeID * comm_dom_cnt_max) + cdi);
 
   //
   // Create completion queue.

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2251,7 +2251,7 @@ void gni_setup_per_comm_dom(int cdi)
   //
   // Create communication domain.
   //
-  gni_init(&cd->nih, (chpl_nodeID * comm_dom_cnt_max) + cdi);
+  gni_init(&cd->nih, cdi);
 
   //
   // Create completion queue.
@@ -2312,7 +2312,12 @@ void gni_init(gni_nic_handle_t* nih, int cdi)
   GNI_CDM_MODES:
   - Check _FORK options for the data server
 \* -------------------------------------------------------------------------- */
-  GNI_CHECK(GNI_CdmCreate(cdi, ptag, cookie, modes, &cdm_handle));
+  //
+  // The instance ID must be node-unique.  The one we specify
+  // here is job-unique, even.
+  //
+  const int inst_id = (chpl_nodeID * comm_dom_cnt_max) + cdi;
+  GNI_CHECK(GNI_CdmCreate(inst_id, ptag, cookie, modes, &cdm_handle));
   GNI_CHECK(GNI_CdmAttach(cdm_handle, device_id, &local_address, nih));
 }
 


### PR DESCRIPTION
The `GNI_CdmCreate()` documentation says, in effect, that the instance
identifiers associated with all the communication domains defined on a
given NIC (node) have to be unique.  Prior to this, we've just been
using the intra-process comm domain index, but that isn't unique when
we're running more than one locale per node.  Admittedly running more
than one locale per node is not an execution model we recommend for
production use, but still it ought to work.  Here, make sure the comm
domain instance IDs are unique within the job.  That's overkill, but
making them merely unique within the node would have required a larger
change.

With this change in place I've successfully run `hello6-taskpar-dist` at
16 locales per node.