### PR TITLE
Fix a domain equality comparison in SSCA2

### DIFF
--- a/test/studies/ssca2/main/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/main/SSCA2_Modules/SSCA2_kernels.chpl
@@ -476,7 +476,8 @@ module SSCA2_kernels
 
 	const n_edges          = G.num_edges;
 	const N_VERTICES       = vertex_domain.size;
-	const N_START_VERTICES = if starting_vertices == G.vertices
+	const N_START_VERTICES = if chpl_sameDomainKind(starting_vertices, G.vertices) &&
+	                            starting_vertices == G.vertices
                                  then N_VERTICES
                                       - + reduce [v in vertex_domain]
                                         (G.n_Neighbors (v) == 0)

--- a/test/studies/ssca2/rachels/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/rachels/SSCA2_kernels.chpl
@@ -501,7 +501,8 @@ module SSCA2_kernels
 
 	const n_edges          = G.num_edges;
 	const N_VERTICES       = vertex_domain.size;
-	const N_START_VERTICES = if starting_vertices == G.vertices
+	const N_START_VERTICES = if chpl_sameDomainKind(starting_vertices, G.vertices) &&
+	                            starting_vertices == G.vertices
                                  then N_VERTICES
                                       - + reduce [v in vertex_domain]
                                         (G.n_Neighbors (v) == 0)


### PR DESCRIPTION
SSCA2 used to compare domains of different kind, which is illegal
as of #19356. This adds a guard that enables the comparison only
when the two domains are of the same kind.

Digging deeper, there are two uses of the enclosing function:
when the two domains are distinct and when they are the same domain.
So perhaps the domain comparison is used to distinguish these two uses.

Testing: tested the modified tests under linux64 and gasnet;
also the formerly-breaking test with -performance.