### PR TITLE
Add testing for llvm 11 and 12

### DIFF
--- a/util/cron/test-linux64-llvm11.bash
+++ b/util/cron/test-linux64-llvm11.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with llvm 11
+
+export OFFICIAL_SYSTEM_LLVM=true
+source /data/cf/chapel/setup_system_llvm.bash 11.0
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+clang_version=$(clang -dumpversion)
+if [ "$clang_version" != "11.0.1" ]; then
+  echo "Wrong clang version"
+  echo "Expected Version: 11.0.1 Actual Version: $clang_version"
+  exit 2
+fi
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm11"
+
+$CWD/nightly -cron -examples ${nightly_args}

--- a/util/cron/test-linux64-llvm12.bash
+++ b/util/cron/test-linux64-llvm12.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with llvm 12
+
+export OFFICIAL_SYSTEM_LLVM=true
+source /data/cf/chapel/setup_system_llvm.bash 12
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+clang_version=$(clang -dumpversion)
+if [ "$clang_version" != "12.0.1" ]; then
+  echo "Wrong clang version"
+  echo "Expected Version: 12.0.1 Actual Version: $clang_version"
+  exit 2
+fi
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm12"
+
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
Now that we support multiple versions of llvm, add some explicit testing
for older versions. The current plan is to default to and recommend 13,
but we want some level of testing on 11 and 12 still so add that here.
Currently this just tests `release/examples` for 11 and 12 on x86 with
comm none, but we may want to add more coverage in the future (more
tests, add gasnet, check on arm too.)

Part of Cray/chapel-private#1031
