### PR TITLE
Optimize `myLocaleSpace` assignment in aggregators

### DIFF
--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -87,7 +87,7 @@ module ChapelAutoAggregation {
     use CTypes;
     use super.AggregationPrimitives;
 
-    param defaultBuffSize = if CHPL_COMM == "ugni" then 4096 else 8096;
+    param defaultBuffSize = if CHPL_COMM == "ugni" then 4096 else 8192;
     private const yieldFrequency = getEnvInt("CHPL_AGGREGATION_YIELD_FREQUENCY", 1024);
     private const dstBuffSize = getEnvInt("CHPL_AGGREGATION_DST_BUFF_SIZE", defaultBuffSize);
     private const srcBuffSize = getEnvInt("CHPL_AGGREGATION_SRC_BUFF_SIZE", defaultBuffSize);
@@ -101,7 +101,7 @@ module ChapelAutoAggregation {
       type elemType;
       type aggType = (c_ptr(elemType), elemType);
       const bufferSize = dstBuffSize;
-      const myLocaleSpace = LocaleSpace;
+      const myLocaleSpace = 0..<numLocales;
       var opsUntilYield = yieldFrequency;
       var lBuffers: c_ptr(c_ptr(aggType));
       var rBuffers: [myLocaleSpace] remoteBuffer(aggType);
@@ -198,7 +198,7 @@ module ChapelAutoAggregation {
       type elemType;
       type aggType = c_ptr(elemType);
       const bufferSize = srcBuffSize;
-      const myLocaleSpace = LocaleSpace;
+      const myLocaleSpace = 0..<numLocales;
       var opsUntilYield = yieldFrequency;
       var dstAddrs: c_ptr(c_ptr(aggType));
       var lSrcAddrs: c_ptr(c_ptr(aggType));


### PR DESCRIPTION
Change `myLocaleSpace = LocaleSpace` to `myLocaleSpace = 0..<numLocales`
to eliminate communication when creating aggregators. `LocaleSpace`
lives on locale 0, so there was some communication to copy it. Using
`numLocales` eliminates that because `numLocales` is just an `int` that
is replicated at program startup. This eliminates a many-to-one GET,
which may have a minor performance benefit, particularly at scale.

While here, also change the non-ugni default buffer size from `8096` to
`8192`. I meant for this to be a power of two in #18326 but either made a
typo or a think-o.

Note that this is a clone of changes made in Bears-R-Us/arkouda#1082