### PR TITLE
Set the find_package path for dyno linters

### DIFF
--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -36,6 +36,18 @@ include Makefile.include
 
 CMAKE ?= cmake
 
+# Get the path to where a ClangConfig.cmake might be found; used by the linters
+# example --cmakedir is /usr/lib/llvm-11/lib/cmake/llvm so then the
+LLVM_CMAKE_DIR  := $(shell $(CHPL_MAKE_LLVM_CONFIG) --cmakedir)
+ifeq ($(LLVM_CMAKE_DIR),)
+CLANG_CMAKE_DIR :=
+else
+CLANG_CMAKE_DIR := $(LLVM_CMAKE_DIR)/..
+endif
+
+$(info CHPL_MAKE_LLVM_CONFIG $(CHPL_MAKE_LLVM_CONFIG))
+$(info CLANG_CMAKE_DIR $(CLANG_CMAKE_DIR))
+
 $(LIBCOMPILER_BUILD_DIR):
 	@echo "Configuring the compiler library..."
 	@mkdir -p $(LIBCOMPILER_BUILD_DIR)
@@ -48,6 +60,7 @@ $(LIBCOMPILER_BUILD_DIR):
 	    -DCMAKE_CXX_FLAGS='$(COMP_CXXFLAGS)' \
 	    -DCMAKE_EXE_LINKER_FLAGS='$(LDFLAGS)' \
 	    -DCMAKE_MODULE_LINKER_FLAGS='$(LDFLAGS)' \
+	    -DDYNO_LINTERS_CLANG_CMAKE_PATH='$(CLANG_CMAKE_DIR)' \
 	    -DBUILD_SHARED_LIBS=OFF
 
 dyno-parser: $(LIBCOMPILER_BUILD_DIR) FORCE

--- a/compiler/dyno/util/linters/CMakeLists.txt
+++ b/compiler/dyno/util/linters/CMakeLists.txt
@@ -17,11 +17,21 @@
 
 add_executable(fieldsUsed "fieldsUsed.cpp")
 
-# this finds the target clang-cpp and also finds an appropriate LLVM version
-# Not marked as required since this linter is optional
-find_package(Clang)
+option(DYNO_LINTERS_CLANG_CMAKE_PATH "Override the path to find a ClangConfig.cmake")
 
-message("Using LLVM version ${LLVM_FIND_VERSION}")
+if(DYNO_LINTERS_CLANG_CMAKE_PATH)
+  # this finds the target clang-cpp and also finds an appropriate LLVM version
+  # Not marked as required since this linter is optional
+  find_package(Clang
+    PATHS ${DYNO_LINTERS_CLANG_CMAKE_PATH}
+    NO_DEFAULT_PATH)
+
+else()
+  find_package(Clang)
+endif()
+
+
+message("Using libclang from ${Clang_DIR}")
 
 # Using LLVM here links against the shared library.
 # Linking against LLVMSupport (which grabs libLLVMSupport.a) was giving me issues


### PR DESCRIPTION
In #19232, we encountered an issue where find_package from cmake
throws an uncatchable error because of multiple llvm/clang versions
installed and the way Ubuntu packages them, which looks like

```
CMake Error at /usr/lib/llvm-12/lib/cmake/clang/ClangTargets.cmake:699 (message):
  The imported target "clangBasic" references the file

     "/usr/lib/llvm-12/lib/libclangBasic.a"
...
```

This then reoccurred due to Github runner version changes which
changed the packages available by default.

The fix here is to explicitly pass the find_package search path by
setting the new cmake option DYNO_LINTERS_CLANG_CMAKE_PATH which we
compute using llvm-config --cmakedir using the llvm-config as
determined by CHPL_LLVM

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>