### PR TITLE
Index loop fix

### DIFF
--- a/compiler/dyno/include/chpl/queries/all-global-strings.h
+++ b/compiler/dyno/include/chpl/queries/all-global-strings.h
@@ -87,10 +87,11 @@ X(logicalOr      , "||")
 X(plus           , "+")
 X(times          , "*")
 X(compareEqual   , "==")
-X(greaterOrEqual , ">=" )
+X(greaterOrEqual , ">=")
 X(greaterThan    , ">")
 X(lessThan       , "<")
 X(lessOrEqual    , "<=")
+X(underscore     , "_")
 
 /* A string too long is checked at compile time */
 /* X(somethingtoolong      , "somethingtoolongforthemacro") */

--- a/compiler/dyno/lib/parsing/ParserContext.h
+++ b/compiler/dyno/lib/parsing/ParserContext.h
@@ -212,6 +212,11 @@ struct ParserContext {
     noteWarning(ParserError(location, std::move(msg), ErrorMessage::WARNING));
   }
 
+  void noteNote(YYLTYPE location, std::string msg) {
+    auto err = ParserError(location, std::move(msg), ErrorMessage::NOTE);
+    errors.push_back(std::move(err));
+  }
+
   ErroneousExpression* raiseError(ParserError error) {
     assert(error.kind == ErrorMessage::ERROR);
     Location ll = convertLocation(error.location);

--- a/compiler/dyno/lib/parsing/ParserContextImpl.h
+++ b/compiler/dyno/lib/parsing/ParserContextImpl.h
@@ -32,6 +32,16 @@
 
 using chpl::types::Param;
 
+static const char* kindToString(VisibilityClause::LimitationKind kind) {
+  switch (kind) {
+    case VisibilityClause::LimitationKind::NONE: assert(false);
+    case VisibilityClause::LimitationKind::ONLY: return "only";
+    case VisibilityClause::LimitationKind::EXCEPT: return "except";
+    case VisibilityClause::LimitationKind::BRACES: assert(false);
+    default: return "";
+  }
+}
+
 static bool locationLessEq(YYLTYPE lhs, YYLTYPE rhs) {
   return (lhs.first_line < rhs.first_line) ||
          (lhs.first_line == rhs.first_line &&
@@ -1519,7 +1529,9 @@ buildVisibilityClause(YYLTYPE location, owned<Expression> symbol,
         expr->isComment()) {
       continue;
     } else {
-      auto msg = "Expected symbol in limitation list";
+      std::string msg = "incorrect expression in '";
+      msg += kindToString(limitationKind);
+      msg += "' list, identifier expected";
       return raiseError(location, msg);
     }
   }

--- a/compiler/dyno/lib/parsing/ParserContextImpl.h
+++ b/compiler/dyno/lib/parsing/ParserContextImpl.h
@@ -1828,7 +1828,8 @@ ParserContext::buildAggregateTypeDecl(YYLTYPE location,
   if (optInherit != nullptr) {
     if (optInherit->size() > 0) {
       if (parts.tag == asttags::Record) {
-        noteError(inheritLoc, "records cannot inherit");
+        noteError(inheritLoc, "inheritance is not currently supported for records");
+        noteNote(inheritLoc, "thoughts on what record inheritance should entail can be added to https://github.com/chapel-lang/chapel/issues/6851");
       } else if (parts.tag == asttags::Union) {
         noteError(inheritLoc, "unions cannot inherit");
       } else {

--- a/compiler/dyno/lib/parsing/bison-chpl-lib.cpp
+++ b/compiler/dyno/lib/parsing/bison-chpl-lib.cpp
@@ -10213,7 +10213,7 @@ yyreduce:
   case 556: /* for_expr: TFOR expr TDO expr  */
 #line 2950 "chpl.ypp"
   {
-    (yyval.expr) = For::build(BUILDER, LOC((yyloc)), /*index*/ nullptr, toOwned((yyvsp[0].expr)),
+    (yyval.expr) = For::build(BUILDER, LOC((yyloc)), /*index*/ nullptr, toOwned((yyvsp[-2].expr)),
                     BlockStyle::IMPLICIT,
                     context->consumeToBlock((yylsp[0]), (yyvsp[0].expr)),
                     /*isExpressionLevel*/ true,
@@ -10305,7 +10305,7 @@ yyreduce:
   case 562: /* for_expr: TFORALL expr TDO expr  */
 #line 3018 "chpl.ypp"
   {
-    (yyval.expr) = Forall::build(BUILDER, LOC((yyloc)), /*index*/ nullptr, toOwned((yyvsp[0].expr)),
+    (yyval.expr) = Forall::build(BUILDER, LOC((yyloc)), /*index*/ nullptr, toOwned((yyvsp[-2].expr)),
                        /*withClause*/ nullptr,
                        BlockStyle::IMPLICIT,
                        context->consumeToBlock((yylsp[0]), (yyvsp[0].expr)),
@@ -11195,13 +11195,13 @@ yyreduce:
 
   case 699: /* unary_op_expr: TMINUSMINUS expr  */
 #line 3568 "chpl.ypp"
-                                 { (yyval.expr) = TODOEXPR((yyloc)); /* warn */ }
+                                 { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
 #line 11200 "bison-chpl-lib.cpp"
     break;
 
   case 700: /* unary_op_expr: TPLUSPLUS expr  */
 #line 3569 "chpl.ypp"
-                                 { (yyval.expr) = TODOEXPR((yyloc)); /* warn */ }
+                                 { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
 #line 11206 "bison-chpl-lib.cpp"
     break;
 

--- a/compiler/dyno/lib/parsing/chpl.ypp
+++ b/compiler/dyno/lib/parsing/chpl.ypp
@@ -2948,7 +2948,7 @@ for_expr:
   }
 | TFOR expr TDO expr %prec TFOR
   {
-    $$ = For::build(BUILDER, LOC(@$), /*index*/ nullptr, toOwned($4),
+    $$ = For::build(BUILDER, LOC(@$), /*index*/ nullptr, toOwned($2),
                     BlockStyle::IMPLICIT,
                     context->consumeToBlock(@4, $4),
                     /*isExpressionLevel*/ true,
@@ -3016,7 +3016,7 @@ for_expr:
   }
 | TFORALL expr TDO expr %prec TFOR
   {
-    $$ = Forall::build(BUILDER, LOC(@$), /*index*/ nullptr, toOwned($4),
+    $$ = Forall::build(BUILDER, LOC(@$), /*index*/ nullptr, toOwned($2),
                        /*withClause*/ nullptr,
                        BlockStyle::IMPLICIT,
                        context->consumeToBlock(@4, $4),

--- a/compiler/dyno/lib/parsing/flex-chpl-lib.cpp
+++ b/compiler/dyno/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 1 "flex-chpl-lib.cpp"
+#line 2 "flex-chpl-lib.cpp"
 
-#line 3 "flex-chpl-lib.cpp"
+#line 4 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1084,10 +1084,10 @@ static void processInvalidToken(yyscan_t scanner);
 static bool yy_has_state(yyscan_t scanner);
 }
 
-#line 1087 "flex-chpl-lib.cpp"
+#line 1088 "flex-chpl-lib.cpp"
 /* hex float literals, have decimal exponents indicating the power of 2 */
 
-#line 1090 "flex-chpl-lib.cpp"
+#line 1091 "flex-chpl-lib.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -1377,7 +1377,7 @@ YY_DECL
 #line 113 "chpl.lex"
 
 
-#line 1380 "flex-chpl-lib.cpp"
+#line 1381 "flex-chpl-lib.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2382,7 +2382,7 @@ YY_RULE_SETUP
 #line 329 "chpl.lex"
 ECHO;
 	YY_BREAK
-#line 2385 "flex-chpl-lib.cpp"
+#line 2386 "flex-chpl-lib.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();

--- a/compiler/dyno/lib/parsing/flex-chpl-lib.h
+++ b/compiler/dyno/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 5 "flex-chpl-lib.h"
+#line 6 "flex-chpl-lib.h"
 
-#line 7 "flex-chpl-lib.h"
+#line 8 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -730,6 +730,6 @@ extern int yylex \
 #line 329 "chpl.lex"
 
 
-#line 733 "flex-chpl-lib.h"
+#line 734 "flex-chpl-lib.h"
 #undef yychpl_IN_HEADER
 #endif /* yychpl_HEADER_H */

--- a/compiler/dyno/lib/parsing/lexer-help.h
+++ b/compiler/dyno/lib/parsing/lexer-help.h
@@ -332,7 +332,10 @@ static std::string eatStringLiteral(yyscan_t scanner,
         s += "\\";
         break; // EOF reached, so stop
       } else {
-        noteErrInString(scanner, nLines, nCols, "unexpected string escape");
+        std::string msg = "Unexpected string escape: '\\";
+        msg+=c;
+        msg+="'";
+        noteErrInString(scanner, nLines, nCols, msg.c_str());
         isErroneousOut = true;
       }
     } else {

--- a/compiler/dyno/lib/types/Param.cpp
+++ b/compiler/dyno/lib/types/Param.cpp
@@ -383,7 +383,7 @@ uint64_t Param::binStr2uint64(const char* str, size_t len, std::string& err) {
   if (len-startPos > 64) {
     err = "Integer literal overflow: '";
     err += str;
-    err += "' is too big for type uint64";
+    err += "' is too big for type 'uint64'";
     return 0;
   }
   uint64_t val = 0;
@@ -424,7 +424,7 @@ uint64_t Param::octStr2uint64(const char* str, size_t len, std::string& err) {
   if (len-startPos > 22 || (len-startPos == 22 && str[startPos] != '1')) {
     err = "Integer literal overflow: '";
     err += str;
-    err += "' is too big for type uint64";
+    err += "' is too big for type 'uint64'";
     return 0;
   }
 
@@ -489,7 +489,7 @@ uint64_t Param::decStr2uint64(const char* str, size_t len, std::string& err) {
   if (strcmp(str+startPos, checkStr) != 0) {
     err = "Integer literal overflow: '";
     err += str;
-    err += "' is too big for type uint64";
+    err += "' is too big for type 'uint64'";
     return 0;
   }
   free(checkStr);
@@ -543,7 +543,7 @@ int64_t Param::decStr2int64(const char* str, size_t len, std::string& err) {
   if (strcmp(str+startPos, checkStr) != 0) {
     err = "Integer literal overflow: '";
     err += str;
-    err += "' is too big for type uint64";
+    err += "' is too big for type 'uint64'";
     return 0;
   }
   free(checkStr);
@@ -577,7 +577,7 @@ uint64_t Param::hexStr2uint64(const char* str, size_t len, std::string &err) {
   if (len-startPos > 16) {
     err = "Integer literal overflow: '";
     err += str;
-    err += "' is too big for type uint64";
+    err += "' is too big for type 'uint64'";
     return 0;
   }
 

--- a/compiler/dyno/lib/uast/chpl-syntax-printer.cpp
+++ b/compiler/dyno/lib/uast/chpl-syntax-printer.cpp
@@ -220,16 +220,6 @@ struct ChplSyntaxVisitor {
       interpose(it.begin() + numThisFormal, it.end(), ", ", "(", ")");
     }
 
-    // Return Intent
-    if (node->returnIntent() != Function::ReturnIntent::DEFAULT_RETURN_INTENT) {
-      ss_ << " " << kindToString((IntentList) node->returnIntent());
-    }
-
-    // Return type
-    if (const Expression* e = node->returnType()) {
-      ss_ << ": ";
-      printChapelSyntax(ss_, e);
-    }
   }
 
   /*
@@ -241,6 +231,12 @@ struct ChplSyntaxVisitor {
       ss_ << kindToString(node->visibility()) << " ";
     }
     printFunctionHelper(node);
+
+    // Return type
+    if (const Expression* e = node->returnType()) {
+      ss_ << ": ";
+      printChapelSyntax(ss_, e);
+    }
   }
 
   void printLinkage(const Decl* node) {
@@ -546,6 +542,17 @@ struct ChplSyntaxVisitor {
     ss_ << " ";
 
     printFunctionHelper(node);
+
+    // Return Intent
+    if (node->returnIntent() != Function::ReturnIntent::DEFAULT_RETURN_INTENT) {
+      ss_ << " " << kindToString((IntentList) node->returnIntent());
+    }
+
+    // Return type
+    if (const Expression* e = node->returnType()) {
+      ss_ << ": ";
+      printChapelSyntax(ss_, e);
+    }
     ss_ << " ";
 
     // where clause
@@ -687,14 +694,21 @@ struct ChplSyntaxVisitor {
     // ex: !(this && that)
     // is different than !this && that
     if (node->isUnaryOp()) {
-      ss_ << node->op().c_str();
+      bool isPostFixBang = false;
+      if (strncmp(node->op().c_str(),"postfix!", 8) == 0) {
+        isPostFixBang = true;
+      } else {
+        ss_ << node->op().c_str();
+      }
       assert(node->numActuals() == 1);
       printChapelSyntax(ss_, node->actual(0));
-
+      if (isPostFixBang) {
+        ss_ << "!";
+      }
     } else if (node->isBinaryOp()) {
       assert(node->numActuals() == 2);
       printChapelSyntax(ss_, node->actual(0));
-      ss_ << " " << node->op().c_str() << " ";
+      ss_ << node->op().c_str();
       printChapelSyntax(ss_, node->actual(1));
     }
   }

--- a/compiler/dyno/lib/uast/chpl-syntax-printer.cpp
+++ b/compiler/dyno/lib/uast/chpl-syntax-printer.cpp
@@ -915,16 +915,17 @@ struct ChplSyntaxVisitor {
 
   void visit(const VisibilityClause* node) {
     VisibilityClause::LimitationKind limit = node->limitationKind();
-    if (limit == VisibilityClause::LimitationKind::ONLY ||
-        limit == VisibilityClause::LimitationKind::EXCEPT) {
-      ss_ << kindToString(limit);
-      printChapelSyntax(ss_, node->symbol());
-      interpose(node->limitations(), ", ");
-    } else if (limit == VisibilityClause::LimitationKind::BRACES) {
-      printChapelSyntax(ss_, node->symbol());
+    printChapelSyntax(ss_, node->symbol());
+    if (limit == VisibilityClause::LimitationKind::BRACES) {
+      ss_ << ".";
       interpose(node->limitations(), ", ", "{","}");
-    } else { //NONE
-      printChapelSyntax(ss_, node->symbol());
+    } else {
+      ss_ << " ";
+      if (limit == VisibilityClause::LimitationKind::ONLY ||
+          limit == VisibilityClause::LimitationKind::EXCEPT) {
+        ss_ << kindToString(limit);
+        ss_ << " ";
+      }
       interpose(node->limitations(), ", ");
     }
   }

--- a/compiler/dyno/test/uast/testStringify.cpp
+++ b/compiler/dyno/test/uast/testStringify.cpp
@@ -247,6 +247,8 @@ static void test1(Parser* parser) {
                var x = if foo then bar else baz;
                manage myManager() as myResource do
                  myResource.doSomething();
+               var C = for 1..10 do 5;
+               var C = forall 1..10 do 5;
              }
              )"""";
   auto parseResult = parser->parseString("Test4.chpl",

--- a/compiler/dyno/test/uast/testStringify.cpp
+++ b/compiler/dyno/test/uast/testStringify.cpp
@@ -249,6 +249,54 @@ static void test1(Parser* parser) {
                  myResource.doSomething();
                var C = for 1..10 do 5;
                var C = forall 1..10 do 5;
+
+module DefinesOp {
+  class Foo {
+    var x: int;
+  }
+
+  operator align(r: range(?i), count: Foo) {
+    writeln("In DefinesOp.align");
+    return r align count.x;
+  }
+
+  operator by(r: range(?i), count: Foo) {
+    writeln("In DefinesOp.by");
+    return r by count.x;
+  }
+}
+
+proc main() {
+
+  {
+    use DefinesOp only align, Foo;
+
+    var r1 = 0..6;
+    var a = new Foo(3);
+    var r1b = r1 by 4 align a;
+    writeln(r1b);
+    for i in r1b {
+      writeln(i);
+    }
+  }
+
+  {
+    use DefinesOp only by, Foo;
+
+    var r1 = 0..6;
+    var foo = new Foo(3);
+    writeln(r1 by foo);
+  }
+}
+
+module M2 {
+  proc main() {
+    import M1.{foo};
+    import M1.foo;
+    writeln("In M2's main.");
+    foo();
+  }
+}
              }
              )"""";
   auto parseResult = parser->parseString("Test4.chpl",

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -108,6 +108,7 @@ void        setupError(const char* subdir, const char* filename, int lineno, int
 void        handleError(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 void        handleError(const BaseAST* ast, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
 void        handleError(astlocT astloc, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
+void        handleError(chpl::Location, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
 
 void        exitIfFatalErrorsEncountered();
 

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -27,7 +27,7 @@
 #include "version_num.h"
 
 // this include sets CONFIGURED_PREFIX
-#include "configured_prefix.h"
+//#include "configured_prefix.h"
 
 void
 get_version(char *v) {
@@ -46,7 +46,7 @@ get_major_minor_version(char *v) {
 
 const char*
 get_configured_prefix() {
-  return CONFIGURED_PREFIX;
+  return "configured_prefix.h";
 }
 
 int get_major_version() {

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -27,7 +27,7 @@
 #include "version_num.h"
 
 // this include sets CONFIGURED_PREFIX
-//#include "configured_prefix.h"
+#include "configured_prefix.h"
 
 void
 get_version(char *v) {
@@ -46,7 +46,7 @@ get_major_minor_version(char *v) {
 
 const char*
 get_configured_prefix() {
-  return "configured_prefix.h";
+  return CONFIGURED_PREFIX;
 }
 
 int get_major_version() {

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -870,16 +870,18 @@ static ModuleSymbol* parseFile(const char* path,
 }
 
 static void uASTDisplayError(const chpl::ErrorMessage& err) {
-  astlocMarker locMarker(err.location());
+  //astlocMarker locMarker(err.location());
+
+  auto loc = err.location();
 
   const char* msg = err.message().c_str();
 
   switch (err.kind()) {
     case chpl::ErrorMessage::NOTE:
-      USR_PRINT("%s", msg);
+      USR_PRINT(loc,"%s", msg);
       break;
     case chpl::ErrorMessage::WARNING:
-      USR_WARN("%s", msg);
+      USR_WARN(loc,"%s", msg);
       break;
     case chpl::ErrorMessage::SYNTAX: {
       const char* path = err.path().c_str();
@@ -894,7 +896,7 @@ static void uASTDisplayError(const chpl::ErrorMessage& err) {
       }
     } break;
     case chpl::ErrorMessage::ERROR:
-      USR_FATAL_CONT("%s", msg);
+      USR_FATAL_CONT(loc,"%s", msg);
       break;
     default:
       INT_FATAL("Should not reach here!");

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1774,7 +1774,9 @@ struct Converter {
     } else if (node->expr()->isVariable()) {
         auto child = node->expr()->toVariable();
         return buildForwardingDeclStmt((BlockStmt*)visit(child));
-    } else if (node->expr()->isIdentifier() || node->expr()->isFnCall()) {
+    } else if (node->expr()->isIdentifier()
+               || node->expr()->isFnCall()
+               || node->expr()->isOpCall()) {
       return buildForwardingStmt(convertExprOrNull(node->expr()));
     }
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -190,6 +190,8 @@ struct Converter {
       return new UnresolvedSymExpr("chpl_align");
     } else if (name == USTR("by")) {
       return new UnresolvedSymExpr("chpl_by");
+    } else if (name == USTR("_")) {
+      return new UnresolvedSymExpr("chpl__tuple_blank");
     }
 
     return nullptr;
@@ -951,8 +953,12 @@ struct Converter {
 
     // Simple variables just get reverted to UnresolvedSymExpr.
     if (const uast::Variable* var = node->toVariable()) {
-      return new UnresolvedSymExpr(var->name().c_str());
-
+      auto name = var->name();
+      if (auto remap = reservedWordRemapForIdent(name)) {
+        return remap;
+      } else {
+        return new UnresolvedSymExpr(name.c_str());
+      }
     // For tuples, recursively call 'convertLoopIndexDecl' on each element.
     } else if (const uast::TupleDecl* td = node->toTupleDecl()) {
       CallExpr* actualList = new CallExpr(PRIM_ACTUALS_LIST);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -186,6 +186,10 @@ struct Converter {
       return new SymExpr(dtReal[FLOAT_SIZE_DEFAULT]->symbol);
     } else if (name == USTR("complex")) {
       return new SymExpr(dtComplex[COMPLEX_SIZE_DEFAULT]->symbol);
+    } else if (name == USTR("align")) {
+      return new UnresolvedSymExpr("chpl_align");
+    } else if (name == USTR("by")) {
+      return new UnresolvedSymExpr("chpl_by");
     }
 
     return nullptr;

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -989,17 +989,22 @@ struct Converter {
     bool maybeArrayType = isLoopMaybeArrayType(node);
     bool zippered = node->iterand()->isZip();
 
-      // Unpack things differently if body is a conditional.
-      if (auto origCond = node->stmt(0)->toConditional()) {
-        INT_ASSERT(origCond->numThenStmts() == 1);
-        INT_ASSERT(!origCond->hasElseBlock());
-        expr = singleExprFromStmts(origCond->thenStmts());
+    // Unpack things differently if body is a conditional.
+    if (auto origCond = node->stmt(0)->toConditional()) {
+      INT_ASSERT(origCond->numThenStmts() == 1);
+      // a filter expression
+      if (!origCond->hasElseBlock()) {
         cond = convertAST(origCond->condition());
+        expr = singleExprFromStmts(origCond->thenStmts());
         INT_ASSERT(cond);
       } else {
+        // an assignment expression
+        INT_ASSERT(origCond->numElseStmts() == 1);
         expr = singleExprFromStmts(node->stmts());
       }
-
+    } else { // not a conditional
+      expr = singleExprFromStmts(node->stmts());
+    }
     INT_ASSERT(expr != nullptr);
 
     return buildForallLoopExpr(indices, iteratorExpr, expr, cond,

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2325,7 +2325,17 @@ struct Converter {
       }
     }
 
-    Expr* initExpr = convertExprOrNull(node->initExpression());
+    Expr* initExpr = nullptr;
+
+    if (const uast::Expression* ie = node->initExpression()) {
+      if (node->kind() == uast::Variable::TYPE) {
+        if (const uast::BracketLoop* bkt = ie->toBracketLoop()) {
+          initExpr = convertArrayType(bkt);
+        }
+      } else {
+        initExpr = toExpr(convertAST(ie));
+      }
+    }
 
     auto ret = new DefExpr(varSym, initExpr, typeExpr);
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -748,9 +748,10 @@ struct Converter {
         // TODO: Might need to do something different on this path.
         conv = convertAST(decl);
       }
-
-      INT_ASSERT(conv);
-      decls->insertAtTail(conv);
+      if (!decl->isComment()) {
+        INT_ASSERT(conv);
+        decls->insertAtTail(conv);
+      }
     }
 
     Expr* expr = convertAST(node->expression());

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1000,11 +1000,13 @@ struct Converter {
       } else {
         // an assignment expression
         INT_ASSERT(origCond->numElseStmts() == 1);
-        expr = singleExprFromStmts(node->stmts());
       }
-    } else { // not a conditional
+    }
+
+    if (!expr) {
       expr = singleExprFromStmts(node->stmts());
     }
+
     INT_ASSERT(expr != nullptr);
 
     return buildForallLoopExpr(indices, iteratorExpr, expr, cond,
@@ -1070,10 +1072,15 @@ struct Converter {
       // Unpack things differently if body is a conditional.
       if (auto origCond = node->stmt(0)->toConditional()) {
         INT_ASSERT(origCond->numThenStmts() == 1);
-        INT_ASSERT(!origCond->hasElseBlock());
-        body = singleExprFromStmts(origCond->thenStmts());
-        cond = toExpr(convertAST(origCond->condition()));
-      } else {
+        if (!origCond->hasElseBlock()) {
+          body = singleExprFromStmts(origCond->thenStmts());
+          cond = toExpr(convertAST(origCond->condition()));
+        } else {
+          INT_ASSERT(origCond->numElseStmts() == 1);
+        }
+      }
+
+      if (!body) {
         body = singleExprFromStmts(node->stmts());
       }
 

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -795,6 +795,18 @@ void handleError(astlocT astloc, const char *fmt, ...) {
   va_end(args);
 }
 
+void handleError(chpl::Location loc, const char *fmt, ...) {
+  astlocT astloc(loc.firstLine(), loc.path().c_str());
+
+  va_list args;
+
+  va_start(args, fmt);
+
+  vhandleError(NULL, astloc, fmt, args);
+
+  va_end(args);
+}
+
 
 static void vhandleError(const BaseAST* ast,
                          astlocT        astloc,

--- a/compiler/util/stringutil.cpp
+++ b/compiler/util/stringutil.cpp
@@ -109,11 +109,11 @@ const char* asubstr(const char* s, const char* e) {
     if (strcmp(str+startPos, checkStr) != 0) {                    \
       if (userSupplied) {                                         \
         astlocT astloc(line, filename);                           \
-        USR_FATAL(astloc, "Integer literal overflow: %s is too"   \
-                  " big for type " #type, str);                   \
+        USR_FATAL(astloc, "Integer literal overflow: '%s' is too" \
+                  " big for type '" #type "'", str);              \
       } else {                                                    \
-        INT_FATAL("Integer literal overflow: %s is too "          \
-                  "big for type " #type, str);                    \
+        INT_FATAL("Integer literal overflow: '%s' is too "        \
+                  "big for type '" #type "'", str);               \
       }                                                           \
     }                                                             \
     return val;                                                   \
@@ -148,10 +148,10 @@ uint64_t binStr2uint64(const char* str, bool userSupplied,
     if (userSupplied) {
       astlocT astloc(line, filename);
       USR_FATAL(astloc, "Integer literal overflow: '%s' is too big "
-                "for type uint64", str);
+                "for type 'uint64'", str);
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
-                "for type uint64", str);
+                "for type 'uint64'", str);
     }
   }
   uint64_t val = 0;
@@ -190,10 +190,10 @@ uint64_t octStr2uint64(const char* str, bool userSupplied,
     if (userSupplied) {
       astlocT astloc(line, filename);
       USR_FATAL(astloc, "Integer literal overflow: '%s' is too big "
-                "for type uint64", str);
+                "for type 'uint64'", str);
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
-                "for type uint64", str);
+                "for type 'uint64'", str);
     }
   }
 
@@ -225,10 +225,10 @@ uint64_t hexStr2uint64(const char* str, bool userSupplied,
     if (userSupplied) {
       astlocT astloc(line, filename);
       USR_FATAL(astloc, "Integer literal overflow: '%s' is too big "
-                "for type uint64", str);
+                "for type 'uint64'", str);
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
-                "for type uint64", str);
+                "for type 'uint64'", str);
     }
   }
 

--- a/test/expressions/diten/uintBinaryOverflow.good
+++ b/test/expressions/diten/uintBinaryOverflow.good
@@ -1,1 +1,1 @@
-uintBinaryOverflow.chpl:1: error: Integer literal overflow: '0b10000000000000000000000000000000000000000000000000000000000000000' is too big for type `uint64`
+uintBinaryOverflow.chpl:1: error: Integer literal overflow: '0b10000000000000000000000000000000000000000000000000000000000000000' is too big for type 'uint64'

--- a/test/expressions/diten/uintBinaryOverflow.good
+++ b/test/expressions/diten/uintBinaryOverflow.good
@@ -1,1 +1,1 @@
-uintBinaryOverflow.chpl:1: error: Integer literal overflow: '0b10000000000000000000000000000000000000000000000000000000000000000' is too big for type uint64
+uintBinaryOverflow.chpl:1: error: Integer literal overflow: '0b10000000000000000000000000000000000000000000000000000000000000000' is too big for type `uint64`

--- a/test/expressions/diten/uintDecimalOverflow.good
+++ b/test/expressions/diten/uintDecimalOverflow.good
@@ -1,1 +1,1 @@
-uintDecimalOverflow.chpl:1: error: Integer literal overflow: 18446744073709551616 is too big for type uint64
+uintDecimalOverflow.chpl:1: error: Integer literal overflow: `18446744073709551616` is too big for type `uint64`

--- a/test/expressions/diten/uintDecimalOverflow.good
+++ b/test/expressions/diten/uintDecimalOverflow.good
@@ -1,1 +1,1 @@
-uintDecimalOverflow.chpl:1: error: Integer literal overflow: `18446744073709551616` is too big for type `uint64`
+uintDecimalOverflow.chpl:1: error: Integer literal overflow: '18446744073709551616' is too big for type 'uint64'

--- a/test/expressions/diten/uintHexOverflow.good
+++ b/test/expressions/diten/uintHexOverflow.good
@@ -1,1 +1,1 @@
-uintHexOverflow.chpl:1: error: Integer literal overflow: '0x10000000000000000' is too big for type uint64
+uintHexOverflow.chpl:1: error: Integer literal overflow: '0x10000000000000000' is too big for type `uint64`

--- a/test/expressions/diten/uintHexOverflow.good
+++ b/test/expressions/diten/uintHexOverflow.good
@@ -1,1 +1,1 @@
-uintHexOverflow.chpl:1: error: Integer literal overflow: '0x10000000000000000' is too big for type `uint64`
+uintHexOverflow.chpl:1: error: Integer literal overflow: '0x10000000000000000' is too big for type 'uint64'

--- a/test/expressions/diten/uintOctalOverflow.good
+++ b/test/expressions/diten/uintOctalOverflow.good
@@ -1,1 +1,1 @@
-uintOctalOverflow.chpl:1: error: Integer literal overflow: '0o2000000000000000000000' is too big for type uint64
+uintOctalOverflow.chpl:1: error: Integer literal overflow: '0o2000000000000000000000' is too big for type 'uint64'

--- a/test/types/integral/tooBig.good
+++ b/test/types/integral/tooBig.good
@@ -1,1 +1,1 @@
-tooBig.chpl:1: error: Integer literal overflow: 1000000000000000000000000000000 is too big for type uint64
+tooBig.chpl:1: error: Integer literal overflow: '1000000000000000000000000000000' is too big for type 'uint64'


### PR DESCRIPTION
This PR implements many fixes for bugs that were affecting the dyno parser's
ability to handle our existing test suite. Prior to this effort, there were 
approximately 600+ failing tests. This work brings the number of failing 
tests down to <500.

Implemented changes include:

- Fix a typo where the `do` expression was used in place of the
  loop expression in some `for` and `forall` productions

- When converting from uAST to AST, add special handling
  on the initializer expression for the case that the
  variable is an array type

- When converting a uAST conditional node, add checking that
  the condition doesn't contain an assignment operation. This
  was previously handled by the old parser, and in the future
  we expect the dyno resolver to handle this.

- Add else terms when converting variable initialization
  expression when the variable is not a bracket loop or
  an initialization expression doesn't exist.

- Add missing keywords `align` and `by` to the remap
  function when converting uAST to AST nodes. This caused failures
  for some tests that were defining operators with these names and
  then `use`ing them later

- The error message on record ineritance was updated to match
  what was in the old parser, including a note on the github issue

- Create an overload of handleError that takes a chpl::Location
  and converts it to an astloc so many error messages will stop
  false reports of "this source location is a guess"

- Align old and dyno parser errors to include wrapping single-quotes
  around literal value and type in overlow error messages, update
  the affected tests' .good files

- Fix a couple of tests that were failing in the dyno parser
  conversion from uAST to AST because we weren't handling `OpCalls`
  in the conversion process, so forwarding  expressions ending
  with a bang `!` were failing.

- Add handling of conditional assignment in forall loop
  where previously we treated all conditionals as filters

- Add handling for if/then/else assignment statements in for loops,
  similar to forall loops

- Stop printing the return intent when printing function signatures
  (for userString on old AST).

- Update error message to include the bad character that was encountered
  when parsing an escape sequence.

- Adjust chapel syntax printing for nested tuples to not print kind/intent
  when printing inner tuples in a nested tuple.

- Ignore comments when converting let stmts from uAST

- Treat `_` as a reserved symbol when it is in
  a tuple decl, to avoid complaints about multiple definitions.

- Add "underscore" to the list of global strings

- Update the error message when an incorrect expression is found in
  an except or only statement to align with old parser errors.

- Add a `kindToString` function for converting `LimitationKind` to
  string for including in the error output.


TESTING:

- [x] paratest (0 failures)
- [x] paratest with `--dyno` (475 failures) 