### PR TITLE
Workaround sporadic cygwin compilation errors

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -374,13 +374,22 @@ def KillProc(p, timeout):
     return
 
 # clean up after the test has been built
-def cleanup(execname):
+def cleanup(execname, test_ran_and_more_compopts=False):
     try:
         if execname is not None:
             if os.path.isfile(execname):
                 os.unlink(execname)
             if os.path.isfile(execname+'_real'):
                 os.unlink(execname+'_real')
+            # Hopefully short term workaround on cygwin where we've been seeing
+            # an issue where after a test is run, some other process has a
+            # handle on the executable and we can't create a new executable
+            # with the same name for a bit. If a test ran and we have
+            # additional compopts (which means the exec name will be reused)
+            # wait a second while cleaning up the executable to give the other
+            # process time to release its handle.
+            if test_ran_and_more_compopts and 'cygwin' in platform:
+                time.sleep(1)
     except (IOError, OSError) as ex:
         # If the error is "Device or resource busy", call lsof on the file (or
         # handle for windows) to see what is holding the file handle, to help
@@ -2405,7 +2414,7 @@ for testname in testsrc:
                     if exectimeout or status != 0:
                         break
 
-        cleanup(execname)
+        cleanup(execname, len(compoptslist) > 1)
 
     del execoptslist
     del compoptslist


### PR DESCRIPTION
On cygwin we've been seeing an issue where after a test is run,
some other process has a handle on the executable and we can't create a new
executable with the same name for a bit. If a test ran and we have
additional compopts (which means the exec name will be reused) wait a
second while cleaning up the executable to give the other process time
to release its handle.

See Cray/chapel-private#3143 for more info