### PR TITLE
Make printing of PRECOMP line more verbose in start_test

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1570,7 +1570,7 @@ for testname in testsrc:
         # Run the precompile script
         #
         if globalPrecomp:
-            sys.stdout.write('[Executing ./PRECOMP]\n')
+            sys.stdout.write('[Executing ./PRECOMP %s %s %s]\n'%(execname, complog. compiler))
             sys.stdout.flush()
             p = py3_compat.Popen(['./PRECOMP', execname, complog, compiler],
                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1570,7 +1570,7 @@ for testname in testsrc:
         # Run the precompile script
         #
         if globalPrecomp:
-            sys.stdout.write('[Executing ./PRECOMP %s %s %s]\n'%(execname, complog. compiler))
+            sys.stdout.write('[Executing ./PRECOMP %s %s %s]\n'%(execname, complog, compiler))
             sys.stdout.flush()
             p = py3_compat.Popen(['./PRECOMP', execname, complog, compiler],
                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
While debugging a failing test today I found myself frustrated that
our start_test log didn't print out the whole PRECOMP command
so that I could reproduce it manually, so made the simple change to
cause it to do so.  There are other such commands that the test
system is not as verbose about as it could be, but I don't have the
time currently to update other cases, and figured improving one
was better than dropping it on the floor and running into it again
later.