### PR TITLE
Update good file and add bad file for const-ref-tuple-decl test

### DIFF
--- a/test/types/tuple/ferguson/const-ref-tuple-decl.bad
+++ b/test/types/tuple/ferguson/const-ref-tuple-decl.bad
@@ -4,8 +4,18 @@ init 10
 init 20
 init 30
 in commonPrefixLength
+init= 1
+init= 2
+init= 10
+init= 20
+init= 30
 (x = 1, ptr = {})
 (x = 2, ptr = {})
+deinit 10
+deinit 20
+deinit 30
+deinit 1
+deinit 2
 end commonPrefixLength
 deinit 10
 deinit 20

--- a/test/types/tuple/ferguson/const-ref-tuple-decl.chpl
+++ b/test/types/tuple/ferguson/const-ref-tuple-decl.chpl
@@ -33,20 +33,26 @@ proc val(arg: R) {
 
 proc commonPrefixLength(const a1: [] R, const a2: [] R) {
   writeln("in commonPrefixLength");
-  const ref (a, b) = if a1.size < a2.size then (a1, a2) else (a2, a1);
-  /* this alternative functions correctly:
-  const ref a;
-  const ref b;
-  if a1.size < a2.size {
-    a = a1;
-    b = a2;
-  } else {
-    a = a2;
-    b = a1;
-  }*/
 
-  for x in a {
-    writeln(x);
+  // The serial statement is only for deterministic output from the
+  // undesired copies.  Once the copies are eliminated and the future
+  // retired, the serial statement may be removed.
+  serial {
+    const ref (a, b) = if a1.size < a2.size then (a1, a2) else (a2, a1);
+    /* this alternative functions correctly:
+       const ref a;
+       const ref b;
+       if a1.size < a2.size {
+       a = a1;
+       b = a2;
+     } else {
+       a = a2;
+       b = a1;
+     }*/
+
+    for x in a {
+      writeln(x);
+    }
   }
 
   writeln("end commonPrefixLength");

--- a/test/types/tuple/ferguson/const-ref-tuple-decl.future
+++ b/test/types/tuple/ferguson/const-ref-tuple-decl.future
@@ -1,2 +1,5 @@
 bug: problem with const ref tuple declaration
 #14778
+
+Note when retiring the future, the serial statement in the test may be
+removed.


### PR DESCRIPTION
The good file had gone stale wrt the arrays in main() no longer being
separately default inited and then assigned to.  They're now
initialized directly.  Update the .good file by removing the default
init of the array elements, the assignments, and the deinit of the
temporaries the array had been initialized from.

Add a .bad file.  This required adding a serial block around the body
of commonPrefixLength().  The undesired array copying was parallel and
nondeterministic.  Add a serial block around it all so that the output
is deterministic.  This does not appear to affect the behavior of the
code under test or of the correctly-functioning alternative.

Add a note to remove the serial block once the future is retired.

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>