### PR TITLE
Discontinue use of the fallback "system" libfabric install for EX builds.

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -93,14 +93,6 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_LLVM=bundled       # llvm requires py27 and cmake
     export CHPL_AUX_FILESYS=none
 
-    # We default to CHPL_LIBFABRIC=system for EX.  We need to point to
-    # a libfabric install for the builds.  On EX a module will supply
-    # this but on XC we have to reference a private build.
-    if ! pkg-config --exists libfabric ; then
-      private_libfab_dir=/cray/css/users/chapelu/libfabric/install
-      export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}${private_libfab_dir}/cray-xc/lib/pkgconfig
-    fi
-
     # As a general rule, more CPUs --> faster make.
     # To use all available CPUs, export CHPL_MAKE_MAX_CPU_COUNT=0 before running this setenv.
 
@@ -157,17 +149,6 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
         # NOTE: don't rebuild compiler above (or else problems with switching GCC versions)
         # NOTE: "--target-compiler" values shown above will be discarded by the setenv callback.
-
-        if [ $private_libfab_dir ] ; then
-          # Remove references to our private libfabric directory from
-          # the list* files in the built runtime library subdirs.  Our
-          # private dir won't be present in that environment and we'll
-          # be using the system libfabric module anyway.
-          log_info "Wipe $private_libfab_dir refs in $CHPL_HOME/lib/.../list-*"
-          find $CHPL_HOME/lib/. -type f -name list-\* \
-            | grep '\(list-includes-and-defines\|list-libraries\)$' \
-            | xargs sed --in-place "s= *[^ ]*${private_libfab_dir}/[^ ]*==g"
-        fi
         ;;
     ( * )
         log_info "NO building Chapel component: runtime"


### PR DESCRIPTION
We've been maintaining a fallback "system" libfabric install from `css`,
which the HPE Cray EX module build was using if `pkg-config` didn't
already know about a real one.  But that fallback was only used when we
were building the EX module on an XC (early days!).  Now we always build
it in a virtual environment which doesn't even mount that `css` path.
Therefore here, get rid of all the logic associated with the fallback
"system" libfabric install.