### PR TITLE
Fix segfaults in gpu codegen after the LLVM-13 upgrade

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -259,8 +259,13 @@ static void genGlobalRawString(const char *cname, std::string &value, size_t len
               info->module->getOrInsertGlobal(
                       cname, llvm::IntegerType::getInt8PtrTy(info->module->getContext())));
       auto globalStringIr = info->irBuilder->CreateGlobalString(value);
+      llvm::Type* ty = nullptr;
+#if HAVE_LLVM_VER >= 130
+      ty = llvm::cast<llvm::PointerType>(
+        globalStringIr->getType()->getScalarType())->getElementType();
+#endif
       auto correctlyTypedValue = info->irBuilder->CreateConstInBoundsGEP2_32(
-        NULL, globalStringIr, 0, 0);
+        ty, globalStringIr, 0, 0);
       globalString->setInitializer(llvm::cast<llvm::Constant>(correctlyTypedValue));
       globalString->setConstant(true);
       info->lvt->addGlobalValue(cname, globalString, GEN_PTR, true);


### PR DESCRIPTION
The function CreateConstInBoundsGEP2_32 was updated to require a type instead
of allowing NULL and using a default value. Update it with the expected type.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>