### PR TITLE
Remove deprecated version of array.indices that just returned the domain

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -45,7 +45,8 @@ module ChapelArray {
   // This permits a user to opt into upcoming behavior to always have
   // .indices return local indices for an array
   pragma "no doc"
-  config param arrayIndicesAlwaysLocal = false;
+  deprecated "'arrayIndicesAlwaysLocal' is deprecated and no longer has an effect"
+  config param arrayIndicesAlwaysLocal = true;
 
   pragma "no doc"
   config param debugBulkTransfer = false;
@@ -887,40 +888,17 @@ module ChapelArray {
     /* The number of dimensions in the array */
     proc rank param return this.domain.rank;
 
-    /* Return the array's indices as a copy of its domain.
-
-       .. note::
-
-         In a forthcoming release, we expect ``.indices`` to change in
-         behavior to return/yield indices using a local representation
-         rather than as a clone of the array's domain.  In order to
-         preserve the legacy behavior in your program, please use
-         ``.domain`` instead (or a copy thereof).
-
-         If you'd like to opt into a prototype of the new behavior,
-         recompile with ``-sarrayIndicesAlwaysLocal=true``.  For
-         dense, rectangular arrays, this will have the effect of
-         returning a local domain representing the array's indices;
-         for a sparse or associative array, it will invoke a serial
-         iterator that yields the array's indices.
-
-         See https://github.com/chapel-lang/chapel/issues/17883 for
-         further details.
+    /*
+      Return a dense rectangular array's indices as a default domain.
     */
-    deprecated "the current behavior of  '.indices' on arrays is deprecated; see https://chapel-lang.org/docs/1.25/builtins/ChapelArray.html#ChapelArray.indices for details"
-    proc indices where arrayIndicesAlwaysLocal == false {
-      return _dom;
-    }
-
-    pragma "no doc"
-    proc indices where arrayIndicesAlwaysLocal == true &&
-                       !this.isSparse() && !this.isAssociative() {
+    proc indices where !this.isSparse() && !this.isAssociative() {
       return {(..._dom.getIndices())};
     }
 
-    pragma "no doc"
-    iter indices where arrayIndicesAlwaysLocal == true &&
-                       (this.isSparse() || this.isAssociative()) {
+    /*
+      Yield an irregular array's indices.
+    */
+    iter indices where (this.isSparse() || this.isAssociative()) {
       for i in _dom do
         yield i;
     }

--- a/test/deprecated/arrayIndices.good
+++ b/test/deprecated/arrayIndices.good
@@ -1,2 +1,0 @@
-arrayIndices.chpl:2: warning: the current behavior of  '.indices' on arrays is deprecated; see https://chapel-lang.org/docs/1.25/builtins/ChapelArray.html#ChapelArray.indices for details
-{1..10}

--- a/test/deprecated/arrayIndicesAlwaysLocal.chpl
+++ b/test/deprecated/arrayIndicesAlwaysLocal.chpl
@@ -1,3 +1,2 @@
 var A: [1..10] real;
 writeln(A.indices);
-

--- a/test/deprecated/arrayIndicesAlwaysLocal.compopts
+++ b/test/deprecated/arrayIndicesAlwaysLocal.compopts
@@ -1,0 +1,1 @@
+-sarrayIndicesAlwaysLocal=false

--- a/test/deprecated/arrayIndicesAlwaysLocal.good
+++ b/test/deprecated/arrayIndicesAlwaysLocal.good
@@ -1,0 +1,3 @@
+warning: 'arrayIndicesAlwaysLocal' is deprecated and no longer has an effect
+note: 'arrayIndicesAlwaysLocal' was set via a compiler flag
+{1..10}

--- a/test/distributions/robust/arithmetic/trivial/test_dot_dims.compopts
+++ b/test/distributions/robust/arithmetic/trivial/test_dot_dims.compopts
@@ -1,1 +1,0 @@
--s arrayIndicesAlwaysLocal=true

--- a/test/types/collections/arrIndicesAreCopy.compopts
+++ b/test/types/collections/arrIndicesAreCopy.compopts
@@ -1,1 +1,0 @@
--sarrayIndicesAlwaysLocal=true

--- a/test/types/collections/arrIndicesAreLoc.compopts
+++ b/test/types/collections/arrIndicesAreLoc.compopts
@@ -1,1 +1,0 @@
--sarrayIndicesAlwaysLocal=true

--- a/test/types/collections/indices.compopts
+++ b/test/types/collections/indices.compopts
@@ -1,1 +1,0 @@
--sarrayIndicesAlwaysLocal=true


### PR DESCRIPTION
This continues the work of #18274 by removing the version of
array.indices that simply returns the domain, documenting the new
array.indices routines, and deprecating the temporary config param
that was used to opt into the new/current behavior ahead of time.
