### PR TITLE
Remove the deprecated range.ident()

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -977,20 +977,6 @@ module ChapelRange {
 
   operator !=(r1: range(?), r2: range(?))  return !(r1 == r2);
 
-  /*
-    .. warning::
-      This procedure is deprecated - please let us know if you were
-      relying on it.
-
-    Returns true if the two ranges are the same in every respect: i.e. the
-     two ranges have the same ``idxType``, ``boundedType``, ``stridable``,
-     ``low``, ``high``, ``stride`` and ``alignment`` values.
-   */
-  deprecated "ident() on ranges is deprecated; please let us know if this is problematic for you"
-  proc ident(r1: range(?), r2: r1.type) {
-    return chpl_ident(r1, r2);
-  }
-
   proc chpl_ident(r1: range(?), r2: range(?))
     where r1.idxType == r2.idxType &&
     r1.boundedType == r2.boundedType &&

--- a/test/deprecated/rangeIdent.chpl
+++ b/test/deprecated/rangeIdent.chpl
@@ -1,8 +1,0 @@
-var r = 1..10 by 2;
-var r2 = 1..10 by 2;
-var r3 = 1..9 by 2;
-var r4 = 1..10;
-
-writeln(ident(r, r2));
-writeln(ident(r, r3));
-writeln(ident(r, r4));

--- a/test/deprecated/rangeIdent.good
+++ b/test/deprecated/rangeIdent.good
@@ -1,6 +1,0 @@
-rangeIdent.chpl:6: warning: ident() on ranges is deprecated; please let us know if this is problematic for you
-rangeIdent.chpl:7: warning: ident() on ranges is deprecated; please let us know if this is problematic for you
-rangeIdent.chpl:8: warning: ident() on ranges is deprecated; please let us know if this is problematic for you
-false
-false
-false


### PR DESCRIPTION
This continues the work of #18247 by removing the
deprecated range.ident() call.