### PR TITLE
Explicitly compile the release version of CHAMPS executables

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -60,7 +60,7 @@ function test_compile() {
   local kind=$@
 
   test_start "make $kind"
-  make MOD=$kind 2> $kind.comp.out.tmp
+  make release MOD=$kind 2> $kind.comp.out.tmp
   local status=$?
   cat $kind.comp.out.tmp
 


### PR DESCRIPTION
CHAMPS changed its default compilation to single-locale for fast development. However, our testing is rigged for performance, so we need their release version. This PR adjusts our testing to explicitly build the release version of CHAMPS.