### PR TITLE
Update my "ref arguments should get default values" test to use `new int`

### DIFF
--- a/test/studies/adventOfCode/2021/bradc/futures/day18-defaultRefVar.bad
+++ b/test/studies/adventOfCode/2021/bradc/futures/day18-defaultRefVar.bad
@@ -1,1 +1,2 @@
-day18-defaultRefVar.chpl:11: error: const actual is passed to 'ref' formal 'pos' of countDown()
+day18-defaultRefVar.chpl:1: In function 'countDown':
+day18-defaultRefVar.chpl:1: error: invalid use of 'new' on primitive int(64)

--- a/test/studies/adventOfCode/2021/bradc/futures/day18-defaultRefVar.chpl
+++ b/test/studies/adventOfCode/2021/bradc/futures/day18-defaultRefVar.chpl
@@ -1,4 +1,4 @@
-proc countDown(x: int, ref pos = 0) {
+proc countDown(x: int, ref pos = new int(0)) {
   if x == 0 then
     writeln(pos);
   else {

--- a/test/studies/adventOfCode/2021/bradc/futures/day18-defaultRefVar.future
+++ b/test/studies/adventOfCode/2021/bradc/futures/day18-defaultRefVar.future
@@ -1,7 +1,12 @@
 feature request/error message: 'ref' arguments with defaults
 
-It seems as though we should support 'ref' arguments that have default
-intents, which can be useful in recursive settings.  Otherwise, either
-the callee must pass in a variable they may not care about, or the
-routine must create a bootstrapping overload of itself that doesn't
-take the additional arg.
+It seems as though we should support 'ref' arguments that have new
+default values, which can be useful in recursive settings like this
+one.  Otherwise, either the callee must pass in a variable they may
+not care about, or the routine must create a bootstrapping overload of
+itself that doesn't take the additional arg.
+
+I was originally thinking that maybe we should just permit '0' to be
+passed in for such cases, but in #19116, Paul and Michael talked me
+down from this, so I'm updating the issue to support the ability to
+say 'new int()' instead.


### PR DESCRIPTION
This was proposed by @cassella as a more principled way
of solving #19116, and I agree, so I'm updating my future
based on that idea and opening #19403 to capture the
idea.

Resolves #19116.