### PR TITLE
Make --incremental compile distinct .c files for every module

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2560,9 +2560,6 @@ static void codegenPartTwo() {
   if( fLlvmCodegen ) {
 #ifdef HAVE_LLVM
 
-    if(fIncrementalCompilation)
-      USR_FATAL("Incremental compilation is not yet supported with LLVM");
-
     if(debugCCode)
     {
       debug_info = new debug_data(*info->module);
@@ -2609,15 +2606,13 @@ static void codegenPartTwo() {
       forv_Vec(ModuleSymbol, currentModule, allModules) {
         const char* filename = NULL;
         filename = generateFileName(fileNameHashMap, filename, currentModule->name);
-        if(currentModule->modTag == MOD_USER) {
-          openCFile(&modulefile, filename, "c");
-          int modulePathLen = strlen(astr(modulefile.pathname));
-          char path[FILENAME_MAX];
-          strncpy(path, astr(modulefile.pathname), modulePathLen-2);
-          path[modulePathLen-2]='\0';
-          userFileName.push_back(astr(path));
-          closeCFile(&modulefile);
-        }
+        openCFile(&modulefile, filename, "c");
+        int modulePathLen = strlen(astr(modulefile.pathname));
+        char path[FILENAME_MAX];
+        strncpy(path, astr(modulefile.pathname), modulePathLen-2);
+        path[modulePathLen-2]='\0';
+        userFileName.push_back(astr(path));
+        closeCFile(&modulefile);
       }
     }
     codegen_makefile(&mainfile, NULL, NULL, false, userFileName);
@@ -2668,13 +2663,13 @@ static void codegenPartTwo() {
 
       openCFile(&modulefile, filename, "c");
       info->cfile = modulefile.fptr;
-      if(fIncrementalCompilation && (currentModule->modTag == MOD_USER))
+      if(fIncrementalCompilation)
         fprintf(modulefile.fptr, "#include \"chpl__header.h\"\n");
       currentModule->codegenDef();
 
       closeCFile(&modulefile);
 
-      if(!(fIncrementalCompilation && (currentModule->modTag == MOD_USER)))
+      if(!(fIncrementalCompilation))
         fprintf(mainfile.fptr, "#include \"%s%s\"\n", filename, ".c");
     }
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1556,15 +1556,22 @@ static void setGPUFlags() {
 
 static void checkLLVMCodeGen() {
 #ifdef HAVE_LLVM
-  // LLVM does not currently work on 32-bit x86
-  bool unsupportedLlvmConfiguration = (0 == strcmp(CHPL_TARGET_ARCH, "i686"));
-  if (fLlvmCodegen && unsupportedLlvmConfiguration)
-    USR_FATAL("CHPL_TARGET_COMPILER=llvm not yet supported for this architecture");
+  if (fLlvmCodegen) {
+    // LLVM does not currently work on 32-bit x86
+    bool unsupportedLlvmConfiguration = (0 == strcmp(CHPL_TARGET_ARCH, "i686"));
+    if (unsupportedLlvmConfiguration) {
+      USR_FATAL("CHPL_TARGET_COMPILER=llvm not yet supported for this architecture");
+    }
+
+    if (fIncrementalCompilation)
+      USR_FATAL("Incremental compilation is not yet supported with LLVM");
+  }
 
   if (0 == strcmp(CHPL_LLVM, "none")) {
     if (fLlvmCodegen)
       USR_FATAL("CHPL_TARGET_COMPILER=llvm not supported when CHPL_LLVM=none");
   }
+
 #else
   // compiler wasn't built with LLVM, so if LLVM is enabled, error
   if (fLlvmCodegen)


### PR DESCRIPTION
The --incremental compiler flag generates a distinct C file per *user*
module, but standard and internal modules still get rolled
(conceptually, via #includes) into a single _main.c file.  The result
is that the compilation of the _main.c file tends to be a bottleneck
relative to the other ones.

This PR changes this so that every module is compiled as its own
distinct C file.

While here, I also moved the user error for compiling with
target-compiler=llvm and --incremental earlier in the compiler
so that time isn't wasted before hitting it.

Resolves #19377 