### PR TITLE
Remove printchplbuilds.

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1634,8 +1634,8 @@ static void checkRuntimeBuilt(void) {
                 "configuration.");
     } else {
       USR_FATAL_CONT("The runtime has not been built for this configuration. "
-                     "Check $CHPL_HOME/util/printchplenv and try rebuilding "
-                     "with $CHPL_MAKE from $CHPL_HOME.");
+                     "Run $CHPL_HOME/util/chplenv/printchplbuilds.py for information "
+                     "on available runtimes.");
     }
     if (developer) {
       USR_PRINT("Expected runtime library in %s", runtime_dir.c_str());

--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -179,8 +179,8 @@ ifeq ($(CHPL_MODULE_HOME),$(CHPL_HOME))
 	        $$CHPL_HOME/util/printchplenv and request support for this \
 	        configuration)
 else
-	$(error The runtime has not been built for this configuration. Check \
-	        $$CHPL_HOME/util/printchplenv and try rebuilding with \
-	        '$(CHPL_MAKE_MAKE)' from $$CHPL_HOME)
+	$(error The runtime has not been built for this configuration. Run \
+	        $$CHPL_HOME/util/chplenv/printchplbuilds.py for information on \
+	        available runtimes.)
 endif
 endif

--- a/test/runtime/thomasvandoren/rerun_compiler_with_opposite_hwloc.bash
+++ b/test/runtime/thomasvandoren/rerun_compiler_with_opposite_hwloc.bash
@@ -22,7 +22,7 @@ esac
 
 #main_o=$($CHPL_HOME/util/config/compileline --main.o)
 
-# /Users/tvandoren/src/chapel/runtime/etc/Makefile.include:83: *** The runtime has not been built for this configuration. Check $CHPL_HOME/util/printchplenv and try (re)building runtime.  Stop.
+# /Users/tvandoren/src/chapel/runtime/etc/Makefile.include:83: *** error: The runtime has not been built for this configuration. Run $CHPL_HOME/util/chplenv/printchplbuilds.py for information on available runtimes.
 $compiler "${test_executable}.chpl" 2>&1 | \
     grep '^error\|runtime/etc/Makefile.include' | \
     grep -v 'Expected runtime library' | \

--- a/test/runtime/thomasvandoren/rtLibDirWarnings.good
+++ b/test/runtime/thomasvandoren/rtLibDirWarnings.good
@@ -1,1 +1,1 @@
-The runtime has not been built for this configuration. Check $CHPL_HOME/util/printchplenv and try rebuilding with $CHPL_MAKE from $CHPL_HOME.
+The runtime has not been built for this configuration. Run $CHPL_HOME/util/chplenv/printchplbuilds.py for information on available runtimes.

--- a/test/runtime/thomasvandoren/rtLibDirWarningsWithDeveloper.good
+++ b/test/runtime/thomasvandoren/rtLibDirWarningsWithDeveloper.good
@@ -1,1 +1,1 @@
-The runtime has not been built for this configuration. Check $CHPL_HOME/util/printchplenv and try rebuilding with $CHPL_MAKE from $CHPL_HOME.
+The runtime has not been built for this configuration. Run $CHPL_HOME/util/chplenv/printchplbuilds.py for information on available runtimes.

--- a/util/printchplbuilds
+++ b/util/printchplbuilds
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-
-CWD=$(cd $(dirname $0) ; pwd)
-
-PY=`"$CWD/config/find-python.sh"`
-$PY "$CWD/chplenv/printchplbuilds.py" "$@"


### PR DESCRIPTION

Eventually `printchplbuilds` will be a subcommand of `printchplenv`, but for now users will have to run `util/chplenv/printchplbuilds.py`. The "missing runtime" error messages have been updated to refer to `printchplbuilds.py`.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>