### PR TITLE
Fix race in copy-elision-control-flow

### DIFF
--- a/test/types/records/copy-elision/copy-elision-control-flow.chpl
+++ b/test/types/records/copy-elision/copy-elision-control-flow.chpl
@@ -175,7 +175,10 @@ proc test5d() {
   var x = new R(1);
   var done: sync int;
   begin {
-    var y = x;
+    {
+      var y = x;
+      // deinit y here, before signalling sync var
+    }
     done.writeEF(1);
   }
 


### PR DESCRIPTION
We were seeing some sporadic failures for the test 

    types/records/copy-elision/copy-elision-control-flow.chpl

especially in linux32. Fortunately, I was able to reproduce and learn that the test itself had a race where a deinit of a variable prints out something after the sync variable signals to continue the rest of the program.

This PR fixes the issue by adding a `{ }` block around the code introducing the variable which ensures that the deinit runs before the sync variable is signalled.

Test change only - not reviewed.