### PR TITLE
Fix second argument to wrap_fi_writemsg

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -5960,7 +5960,7 @@ void ofi_put_V(int v_len, void** addr_v, void** local_mr_v,
   }
 
   for (int vi = 0; vi < v_len; vi++) {
-    (void) wrap_fi_writemsg(addr_v[vi], &local_mr_v[vi],
+    (void) wrap_fi_writemsg(addr_v[vi], local_mr_v[vi],
                             locale_v[vi],
                             (uint64_t) raddr_v[vi], remote_mr_v[vi],
                             size_v[vi], txnTrkEncodeId(__LINE__),


### PR DESCRIPTION
The second argument to `wrap_fi_writemsg` should be of type `void *`, `ofi_put_V` was calling it with a `void **`, causing a segmentation fault with `prov=verbs;ofi_rxm`. The argument should be a pointer to a MR descriptor, not a pointer to a pointer.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>