### PR TITLE
Remove a 'rm' designed to help with SysCTypes change

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -61,7 +61,6 @@ MAKE_SYS_BASIC_TYPES=$(CHPL_MAKE_HOME)/util/config/make_sys_basic_types.py
 
 $(SYS_CTYPES_MODULE): $(MAKE_SYS_BASIC_TYPES)
 	mkdir -p $(@D)
-	rm -f $(@D)/SysCTypes.chpl # TODO: Can remove once people are caught up
 	cd $(@D) && $(CHPL_MAKE_PYTHON) $(MAKE_SYS_BASIC_TYPES) $(@F)
 
 $(SYS_CTYPES_MODULE_DOC): $(MAKE_SYS_BASIC_TYPES)


### PR DESCRIPTION
This was designed to help developers adjust to the SysCTypes
name change.  Now that it's been in for awhile, removing this
to make things cleaner for the release.