### PR TITLE
Switch test-memLog to use a catfile

### DIFF
--- a/test/memory/gbt/test-memLog.catfiles
+++ b/test/memory/gbt/test-memLog.catfiles
@@ -1,0 +1,2 @@
+test-memLog.memLog.0
+test-memLog.memLog.1

--- a/test/memory/gbt/test-memLog.good
+++ b/test/memory/gbt/test-memLog.good
@@ -1,6 +1,4 @@
-========== Locale 0 memLog ==========
 0: test-memLog.chpl:10: allocate <BYTES> of C at <ADDR>
 0: test-memLog.chpl:11: free at <ADDR>
-========== Locale 1 memLog ==========
 1: test-memLog.chpl:10: allocate <BYTES> of C at <ADDR>
 1: test-memLog.chpl:11: free at <ADDR>

--- a/test/memory/gbt/test-memLog.prediff
+++ b/test/memory/gbt/test-memLog.prediff
@@ -1,12 +1,7 @@
 #!/bin/sh
 
-for loc in 0 1 ; do
-  echo "========== Locale $loc memLog ==========" >> $2
-  if [ -f $1.memLog.$loc ] ; then
-    sed -e 's/ allocate [0-9]*B of C at 0x[0-9a-f]*$/ allocate <BYTES> of C at <ADDR>/' \
-        -e 's/ free \([0-9]*B of C \)\{0,1\}at 0x[0-9a-f]*$/ free at <ADDR>/' \
-        -e '/.*<internal>.*/d' \
-	< $1.memLog.$loc \
-	>> $2
-  fi
-done
+sed -e 's/ allocate [0-9]*B of C at 0x[0-9a-f]*$/ allocate <BYTES> of C at <ADDR>/' \
+    -e 's/ free \([0-9]*B of C \)\{0,1\}at 0x[0-9a-f]*$/ free at <ADDR>/' \
+    -e '/.*<internal>.*/d' \
+    $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Previously, the test was manually looking at some memory log files, but
recently on some systems files generated on compute nodes aren't visible
to the login node for a bit. We added a wait for catfiles to work around
this, so just switch this test to use a catfile instead of manually
opening the files.

Part of Cray/chapel-private#3147