### PR TITLE
Use an older CPU targeting module for XC Arkouda release testing

### DIFF
--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -20,7 +20,7 @@ module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base
 module unload atp
-module load craype-x86-cascadelake
+module load craype-sandybridge # use craype-x86-cascadelake with 1.26
 
 module list
 


### PR DESCRIPTION
We only added support for cascade lake CPU targeting on XC in 19413, so
we can't use it with the 1.25.1 Arkouda testing. For now just switch to
the XC LCD of sandybridge until we switch to testing 1.26.