### PR TITLE
Fix auto aggregation tests

### DIFF
--- a/modules/internal/ChapelAutoAggregation.chpl
+++ b/modules/internal/ChapelAutoAggregation.chpl
@@ -23,13 +23,13 @@ module ChapelAutoAggregation {
 
   pragma "aggregator generator"
   proc chpl_srcAggregatorFor(arr: []) {
-    return new SrcAggregator(arr.eltType);
+    return new SrcAggregatorImpl(arr.eltType);
   }
 
   // we can't do dom: domain here, it causes resolution issues
   pragma "aggregator generator"
   proc chpl_srcAggregatorFor(dom) where isDomain(dom) {
-    return new SrcAggregator(dom.idxType);
+    return new SrcAggregatorImpl(dom.idxType);
   }
 
   pragma "aggregator generator"
@@ -39,7 +39,7 @@ module ChapelAutoAggregation {
 
   pragma "aggregator generator"
   proc chpl_dstAggregatorFor(arr: []) {
-    return new DstAggregator(arr.eltType);
+    return new DstAggregatorImpl(arr.eltType);
   }
 
   pragma "aggregator generator"

--- a/test/optimizations/autoAggregation/COMPOPTS
+++ b/test/optimizations/autoAggregation/COMPOPTS
@@ -1,2 +1,2 @@
---auto-aggregation --report-auto-aggregation -sverboseAggregation=true
---auto-aggregation --report-auto-aggregation -sverboseAggregation=true --no-auto-local-access
+--auto-aggregation --report-auto-aggregation -sCopyAggregation.verboseAggregation=true
+--auto-aggregation --report-auto-aggregation -sCopyAggregation.verboseAggregation=true --no-auto-local-access

--- a/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.compopts
+++ b/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.compopts
@@ -1,1 +1,1 @@
--M ../../../release/examples/benchmarks/hpcc --auto-aggregation --report-auto-aggregation -sverboseAggregation=true --no-local
+-M ../../../release/examples/benchmarks/hpcc --auto-aggregation --report-auto-aggregation -sCopyAggregation.verboseAggregation=true --no-local


### PR DESCRIPTION
Fix auto aggregation tests that print verbose output and have
auto-aggregation call the aggregator implementation directly

The auto aggregation tests compile with `verboseAggregation`, but that
param was made private in #19386, so we need to give the fully qualified
path now.

In #19386 I added a wrapper to avoid aggregating for comm=none and to
make documenting easier. This was causing some compiler failures for
`cleanupRemainingAggCondStmts()` because the AST now had an additional
wrapper. I didn't feel comfortable updating this code, so for now I just
updated the code to call the non-wrapped aggregator directly.