### PR TITLE
Fix bad smoke-test from #19260

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -249,6 +249,7 @@ class RemoveUnnecessaryAutoCopyCalls : public PassT<FnSymbol*> {
 
 // insertLineNumbers.cpp
 class InsertNilChecksPass : public PassT<CallExpr*> {
+ public:
   bool shouldProcess(CallExpr* call) override;
   void process(CallExpr* call) override;
 };

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -36,6 +36,7 @@
 #include <algorithm>
 #include <queue>
 #include <unordered_set>
+#include <vector>
 
 //
 // insertLineNumbers() inserts line numbers and filenames into
@@ -464,7 +465,12 @@ void insertLineNumbers() {
 
   // refactoring  TODO: why is InsertNilChecks in this pass?
   if (!fNoNilChecks) {
-    pm.runPass<CallExpr*>(InsertNilChecksPass(), gCallExprs);
+    // TODO: this is a temporary workaround to avoid iterating over a vector
+    // that changes size during iteration. gCallExprs grows during
+    // insertNilChecks because it creates new CallExpr's, but we also know that
+    // those new CallExpr's don't need to get processed
+    std::vector<CallExpr*> toProcess(gCallExprs.begin(), gCallExprs.end());
+    pm.runPass<CallExpr*>(InsertNilChecksPass(), toProcess);
   }
 
   // TODO: this is a WIP state on integrating with the PassManager

--- a/make/compiler/Makefile.sanitizers
+++ b/make/compiler/Makefile.sanitizers
@@ -31,6 +31,9 @@ ifneq ($(CHPL_MAKE_SANITIZE), none)
   ifneq ($(CHPL_MAKE_TARGET_MEM), cstdlib)
     $(error CHPL_MEM=cstdlib is required for sanitizers)
   endif
+  ifneq ($(CHPL_MAKE_HOST_MEM), cstdlib)
+    $(error CHPL_HOST_MEM=cstdlib is required for sanitizers)
+  endif
 
   # enable sanitizers
   SANITIZER_CFLAGS += -fsanitize=$(CHPL_MAKE_SANITIZE)


### PR DESCRIPTION
I missed a bug in #19260 which relates to #19240. Here, gCallExprs
changed size during iteration while running InsertNilChecks b/c it
creates new CallExpr's.

Luckily this showed up in linux32 smoke testing (I assume b/c
elsewhere the vector happens to be reallocated in place)

I did run san testing on this (see Cray/chapel-private#3154), but
all the compiler san testing was masked because I was using
CHPL_HOST_MEM=jemalloc and Makefile.sanitizers was never updated as
part of #2558

Also, missing a public visibility specifier in InsertNilChecksPass

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>