### PR TITLE
Add container for Github CI actions

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -1,0 +1,39 @@
+name: build-CI-container
+
+env:
+  REGISTRY: ghcr.io
+  # NOTE: IMAGE_NAME must be lowercase
+  IMAGE_NAME: chapel-github-ci
+
+  DOCKERFILE: util/dockerfiles/github-ci/Dockerfile
+
+on:
+  push:
+    branches: [ main ]
+    # This limits the action so it only builds when this file changes
+    paths:
+      - ${{ env.DOCKERFILE }}
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v2.9.0
+        with:
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          # example: ghcr.io/chapel-lang/chapel-github-ci:latest
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest

--- a/util/dockerfiles/github-ci/Dockerfile
+++ b/util/dockerfiles/github-ci/Dockerfile
@@ -1,0 +1,29 @@
+# This is a container used to run CI jobs on GH
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    bash \
+    clang-13 \
+    cmake \
+    cscope \
+    doxygen \
+    g++ \
+    gcc \
+    git \
+    libclang-13-dev \
+    libclang-cpp13-dev \
+    libedit-dev \
+    llvm-13 \
+    llvm-13-dev \
+    llvm-13-tools \
+    m4 \
+    make \
+    mawk \
+    perl \
+    pkg-config \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-venv

--- a/util/dockerfiles/github-ci/Dockerfile
+++ b/util/dockerfiles/github-ci/Dockerfile
@@ -1,4 +1,6 @@
 # This is a container used to run CI jobs on GH
+
+# We use 22.04 to get llvm-13
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/util/dockerfiles/github-ci/Readme.md
+++ b/util/dockerfiles/github-ci/Readme.md
@@ -1,0 +1,11 @@
+`docker` or `podman` should both work:
+
+```
+docker build -f util/dockerfiles/github-ci/Dockerfile -t chapel-lang/chapel-github-ci:latest
+# -w working directory
+# -v volume mount
+# -it interactive with tty
+# --rm remove container at exit
+docker run -w="$(pwd)" -v"$(pwd)":"$(pwd)":z -it --rm chapel-lang/chapel-github-ci:latest
+# NOTE: this mounts `build` and any `third-party/**/{build,install}` into the container, so be aware
+```


### PR DESCRIPTION
This adds a Dockerfile for use with our CI actions to reduce their
worst case-execution time by eliminating the need to download dependencies.

This is just phase 1 of 2, where we build the dockerfile and push it
to ghcr (github container registry). The second phase is to actually
use it in CI.yml -- I just don't know how to order these actions
correctly so I'm doing in two PRs

The container image should only get rebuilt when its Dockerfile
changes -- in other words, 99% of PRs shouldn't run this action

Links:
  * https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
  * https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>