### PR TITLE
Deprecate bigint.gcdext in favor of gcd overload with same arguments, and doc

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -3286,11 +3286,37 @@ module BigInteger {
 
   // sets this to gcd(a,b)
   // set s and t to to coefficients satisfying a*s + b*t == g
+  deprecated "gcdext is deprecated, please use the new overload of :proc:`bigint.gcd` with s and t arguments instead"
   proc bigint.gcdext(ref s: bigint,
                      ref t: bigint,
                      const ref a: bigint,
                      const ref b: bigint) {
+    this.gcd(a, b, s, t);
+  }
 
+  /* Set ``this`` to the greatest common divisor of ``a`` and ``b``, and
+     set ``s`` and ``t`` to coefficients such that ``a*s + b*t == this``.
+
+     .. note::
+        The result stored in ``this`` is always positive, even if one or
+        both of ``a`` and ``b`` are negative (or zero if both are zero).
+
+     This fulfills the same role as the GMP function ``mpz_gcdext``.
+
+     :arg a: One of the numbers to compute the greatest common divisor of
+     :type a: ``bigint``
+
+     :arg b: One of the numbers to compute the greatest common divisor of
+     :type b: ``bigint``
+
+     :arg s: The returned coefficient that can be multiplied by ``a``.
+     :type s: ``bigint``
+
+     :arg t: The returned coefficient that can be multiplied by ``b``.
+     :type t: ``bigint``
+   */
+  proc bigint.gcd(const ref a: bigint, const ref b: bigint,
+                  ref s: bigint, ref t: bigint): void {
     if _local {
       mpz_gcdext(this.mpz, s.mpz, t.mpz, a.mpz, b.mpz);
 

--- a/test/deprecated/BigInteger/deprecateGcdext.chpl
+++ b/test/deprecated/BigInteger/deprecateGcdext.chpl
@@ -1,0 +1,12 @@
+use BigInteger;
+
+var a   = new bigint(27);
+var b   = new bigint(19);
+var c   = new bigint(720);
+var d   = new bigint(1000);
+var e   = new bigint(375);
+
+a.gcdext(e, b, c, d);
+
+writeln("gcd(", c, ", ", d, ") = ", a);
+writeln(c, " * ", e, " + ", d, " * ", b, " = ", a);

--- a/test/deprecated/BigInteger/deprecateGcdext.good
+++ b/test/deprecated/BigInteger/deprecateGcdext.good
@@ -1,0 +1,3 @@
+deprecateGcdext.chpl:9: warning: gcdext is deprecated, please use the new overload of bigint.gcd with s and t arguments instead
+gcd(720, 1000) = 40
+720 * 7 + 1000 * -5 = 40

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_number_theoretic.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_number_theoretic.chpl
@@ -68,7 +68,7 @@ writeln("gcd(120, 100) = ", a);
 
 c.set(720);
 d.set(1000);
-a.gcdext(e, b, c, d);
+a.gcd(c, d, e, b);
 
 writeln("gcd(", c, ", ", d, ") = ", a);
 writeln(c, " * ", e, " + ", d, " * ", b, " = ", a);


### PR DESCRIPTION
The method performs gcd computation with a little extra information returned.
We believe it is appropriate for this to be an overload of gcd on bigints
instead of a separately named method.

While here, add documentation for the method describing its behavior and its
arguments.

Resolves #17731 

Updated a test that was using gcdext to use the new gcd overload instead.

Add a test locking in the deprecation message.

Passed a full paratest with futures.  Double checked the built documentation.