### PR TITLE
inline all _getIterator calls

### DIFF
--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -388,7 +388,7 @@ module ChapelIteratorSupport {
     return _getIterator(x.these());
   }
 
-  proc _getIterator(type t) {
+  inline proc _getIterator(type t) {
     return _getIterator(t.these());
   }
 

--- a/test/types/enum/enumIterMemCheck.chpl
+++ b/test/types/enum/enumIterMemCheck.chpl
@@ -1,0 +1,5 @@
+use Memory.Diagnostics;
+enum color { red, green, blue };
+startVerboseMem();
+for c in color {}
+stopVerboseMem();


### PR DESCRIPTION
In a thread starting at https://github.com/chapel-lang/chapel/pull/18708#issuecomment-965516936,
@ronawho found that by not having the `inline` keyword on this
`_getIterator()` call, we generated some extra/dead code
unnecessarily.  This adds the keyword to remove that.

Specifically, given a loop like:

```chapel
enum color { red, green, blue };
for c in color do
  writeln(c);
```

Prior to this PR, the generated loop in C looks has an extra
allocation and free like this:

```c
  _ic_these_color_chpl _iterator_chpl = NULL;
...
  _iterator_chpl = _getIterator_chpl(INT64(6), INT32(64));
...
  call_tmp_chpl37 = ((void*)(_iterator_chpl));
  chpl_here_free(call_tmp_chpl37, INT64(6), INT32(64));
```

whereas these lines disappear with the `inline` keyword
added.