### PR TITLE
Use llvm 11 for Arkouda release testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -40,6 +40,9 @@ fi
 
 # test against Chapel release (checking our current test/cron directories)
 function test_release() {
+  # source older system llvm until we upgrade to 1.26
+  source $COMMON_DIR/setup_system_llvm.bash 11.0
+
   export CHPL_TEST_PERF_DESCRIPTION=release
   export CHPL_TEST_PERF_CONFIGS="release:v,nightly"
   currentSha=`git rev-parse HEAD`


### PR DESCRIPTION
Default nightly version is 13, but we can't use that for release testing
until we upgrade to 1.26