### PR TITLE
Stop localizing module-scope const tuples

### DIFF
--- a/compiler/optimizations/localizeGlobals.cpp
+++ b/compiler/optimizations/localizeGlobals.cpp
@@ -73,7 +73,8 @@ void LocalizeGlobals::process(FnSymbol* fn) {
         !lhsOfMove &&
         var->hasFlag(FLAG_CONST) &&
         !var->hasFlag(FLAG_EXTERN) &&
-        var->defPoint->parentSymbol != rootModule) {
+        var->defPoint->parentSymbol != rootModule &&
+        !var->type->symbol->hasFlag(FLAG_TUPLE)) {
       VarSymbol* local_global = globals.get(var);
       SET_LINENO(se); // Set the se line number for output
       if (!local_global) {


### PR DESCRIPTION
Stop localizing const tuples (where "local" is in the sense of "local
vs. global variables", not "local vs.  remote" ones) because it can be
ridiculously expensive in code size, and in execution time in a tight
loop, as well as seeming a bit pointless.  As an example compare the
generated output of

```chapel
const tup = ("hi", "there", "elliot");
const tup2 = ("hi", 42, 5.4);
proc foo(i: int) {
  writeln(tup(i));
}
foo(1);

proc bar(param i: int) {
  writeln(tup2(i));
}
bar(1);
```

with or without this PR.

Elliot and I both wonder whether this localization optimization has
outlived its utility, though we did also see regressions when applying
it slightly more broadly, e.g., to arrays in the release version of
revcomp.chpl.  And it seems conceivable that removing it altogether
may make the C compiler have to be more conservative about C
file-scope variables.  I opened #19434 to capture this future work.