### PR TITLE
Skip this new memlog test in --baseline

### DIFF
--- a/test/types/enum/enumIterMemCheck.skipif
+++ b/test/types/enum/enumIterMemCheck.skipif
@@ -1,0 +1,2 @@
+# without inlining, this test's memory check will not come back clean
+COMPOPTS <= --baseline


### PR DESCRIPTION
The memory usage is different when inlining is turned off, as with
--baseline testing, so let's just skip the test in that configuration.
