### PR TITLE
Support multiple GPUs in one node

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -64,7 +64,7 @@ CUcontext *chpl_gpu_primary_ctx;
 
 void chpl_gpu_init() {
   int         num_devices;
-  
+
   // CUDA initialization
   CUDA_CALL(cuInit(0));
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -172,11 +172,12 @@ static void chpl_gpu_launch_kernel_help(const char* fatbinData,
                                         va_list args) {
   chpl_gpu_ensure_context();
 
-  CHPL_GPU_LOG("Kernel launcher called.\n"
+  CHPL_GPU_LOG("Kernel launcher called. (subloc %d)\n"
                "\tKernel: %s\n"
                "\tGrid: %d,%d,%d\n"
                "\tBlock: %d,%d,%d\n"
                "\tNumArgs: %d\n",
+               chpl_task_getRequestedSubloc(),
                name,
                grd_dim_x, grd_dim_y, grd_dim_z,
                blk_dim_x, blk_dim_y, blk_dim_z,

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -28,6 +28,7 @@
 #include "chpl-comm.h"
 #include "chplexit.h"
 #include "chplio.h"
+#include "chpl-gpu.h"
 #include "chpl-init.h"
 #include "chpl-mem.h"
 #include "chplmemtrack.h"
@@ -280,6 +281,10 @@ void chpl_rt_init(int argc, char* argv[]) {
   chpl_comm_post_task_init();
 #ifdef HAS_CHPL_CACHE_FNS
   chpl_cache_init();
+#endif
+
+#ifdef HAS_GPU_LOCALE
+  chpl_gpu_init();
 #endif
   chpl_comm_rollcall();
 

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
@@ -43,15 +43,21 @@ export proc add_nums(dst_ptr: c_ptr(real(64))){
   dst_ptr[0] = dst_ptr[0]+5;
 }
 
-
 proc main() {
 
 var output: real(64);
-var deviceBuffer = getDeviceBufferPointer();
 
-// arguments are: fatbin path, function name, grid size, block size, arguments
-__primitive("gpu kernel launch flat", c"add_nums", 1, 1, deviceBuffer);
-output = getDataFromDevice(deviceBuffer);
+
+on here.getChild(1) {
+
+  var dummy = [1,2,3]; // to ensure that the CUDA context is attached to the
+                       // thread
+
+  var deviceBuffer = getDeviceBufferPointer();
+  // arguments are: fatbin path, function name, grid size, block size, arguments
+  __primitive("gpu kernel launch flat", c"add_nums", 1, 1, deviceBuffer);
+  output = getDataFromDevice(deviceBuffer);
+}
 
 writeln(output);
 }

--- a/test/gpu/native/multiGPU/multiGPU.chpl
+++ b/test/gpu/native/multiGPU/multiGPU.chpl
@@ -1,0 +1,29 @@
+config const n = 10;
+
+config const alpha = 10;
+
+config const writeArrays = true;
+
+for subloc in 1..here.getChildCount()-1 do on here.getChild(subloc) {
+  var A: [1..n] int;
+  var B: [1..n] int;
+  var C: [1..n] int;
+
+  A = 1;                            writeArr(A);
+  B = 2;                            writeArr(B);
+  C = 3;                            writeArr(C);
+  A = B + alpha * C;                writeArr(A);
+}
+
+proc writeArr(A) {
+  if writeArrays {
+    // normally we can just do writeln(A), but we don't have a good way of
+    // having verbose GPU execution. So, if we do that the output is just too
+    // messy with verbose. If we had verbosity for only launches, things would
+    // have been much easier.
+    write("Array: ");
+    for a in A do
+      write(a, " ");
+    writeln();
+  }
+}

--- a/test/gpu/native/multiGPU/multiGPU.execopts
+++ b/test/gpu/native/multiGPU/multiGPU.execopts
@@ -1,0 +1,1 @@
+--verbose

--- a/test/gpu/native/multiGPU/multiGPU.good
+++ b/test/gpu/native/multiGPU/multiGPU.good
@@ -1,0 +1,8 @@
+      4 Kernel launcher called. (subloc 1)
+      4 Kernel launcher called. (subloc 2)
+      4 Kernel launcher called. (subloc 3)
+      4 Kernel launcher called. (subloc 4)
+      4 Kernel launcher called. (subloc 5)
+      4 Kernel launcher called. (subloc 6)
+      4 Kernel launcher called. (subloc 7)
+      4 Kernel launcher called. (subloc 8)

--- a/test/gpu/native/multiGPU/multiGPU.prediff
+++ b/test/gpu/native/multiGPU/multiGPU.prediff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+grep 'Kernel launch' $2 | sort | uniq -c > $2.new
+mv $2.new $2

--- a/test/gpu/native/threadBlockAndGridPrimitives.chpl
+++ b/test/gpu/native/threadBlockAndGridPrimitives.chpl
@@ -114,15 +114,20 @@ proc runExample(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ) {
 }
 
 proc main() {
-  runExample(1,1,1, 1,1,1);
+  on here.getChild(1) {
+    var dummy = [1,2,3]; // to ensure that the CUDA context is attached to the
+                         // thread
 
-  runExample(1,1,1, 2,2,2);
-  runExample(1,1,1, 2,3,4);
+    runExample(1,1,1, 1,1,1);
 
-  runExample(2,2,2, 1,1,1);
-  runExample(2,3,4, 1,1,1);
+    runExample(1,1,1, 2,2,2);
+    runExample(1,1,1, 2,3,4);
 
-  runExample(2,2,2, 2,2,2);
-  runExample(2,3,4, 2,3,4);
+    runExample(2,2,2, 1,1,1);
+    runExample(2,3,4, 1,1,1);
+
+    runExample(2,2,2, 2,2,2);
+    runExample(2,3,4, 2,3,4);
+  }
 }
 


### PR DESCRIPTION
This PR overhauls the context creation to be able to handle multiple GPUs.

Previously, we were using `cuCtxCreate` to create new CUDA contexts. However,
this had a TODO for us to take a look at primary contexts. Primary contexts are
retained per device and the recommended way for interacting with devices.

With this PR, we initialize GPU layer eagerly at runtime init time. During this
initialization, we create and retain a context per device. These contexts are
stored in an array where the sublocale ID can be used to access an appropriate
context that will use an appropriate device.

We also adjust `chpl_gpu_ensure_context` to push/pop contexts as necessary. 

Future work:
CUDA contexts are CPU-thread-private. We need to establish/understand how CPU
thread to GPU mappings work, and potentially do some pinning. If we can do that,
some of the stuff in this PR can be removed.

Test:
- [x] gpu/native
