### PR TITLE
Ignore unusable providers when checking should we create a fixed heap.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3285,7 +3285,8 @@ void init_fixedHeap(void) {
     for (info = infoList; info != NULL; info = info->next) {
       if (isGoodCoreProvider(info)
           && (!isInProvider("verbs", info)
-              || !isInProvider("ofi_rxd", info))) {
+              || !isInProvider("ofi_rxd", info))
+          && isUseableProvider(info)) {
         break;
       }
     }


### PR DESCRIPTION
TL,DR: During the pre-scan of providers to see if there's a "good" one
that needs a fixed heap, skip unusable ones.

This prevents us from creating a fixed heap with the "tcp;ofi_rxm"
provider which can't use it, on our internal testing cluster and similar
systems.

Full explanation: we have to determine whether or not we'll use a fixed
heap well before we pick a libfabric provider, despite that those two
decisions are quite closely related.  (Notably, some higher-performance
providers such as verbs need a fixed heap because they can only register
memory whose pages already exist (`FI_MR_ALLOCATED`).)  But we have to
decide on a fixed heap before we initialize the memory layer, which will
manage it.  That comes before initializing the tasking layer, because
the tasking layer requires Chapel-managed memory.  And tasking init in
turn must be done before the main part of initalizing the comm layer
which picks the provider because picking the provider requires knowing,
among other things, whether the tasking layer uses fixed worker threads.
To deal with this, as part of the early fixed-heap decision we pre-scan
the providers to see if there is a higher-performing ("good") one that
needs a fixed heap, on the assumption that if so, creating such a heap
will enable using that provider.  But there's a check for unusable
(effectively, broken) providers during provider selection, which can
sometimes prevent using verbs.  We weren't doing that check during the
pre-scan, so we we sometimes thought we could use a fixed heap when we
actually couldn't.  Therefore here, include the unusable-provider check
in the pre-scan.

This resolves https://github.com/Cray/chapel-private/issues/2830.