### PR TITLE
Further limit Arkouda XC node type

### DIFF
--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -24,7 +24,7 @@ module load craype-x86-cascadelake
 
 module list
 
-export CHPL_LAUNCHER_CONSTRAINT=CL48
+export CHPL_LAUNCHER_CONSTRAINT="CL48,192GB"
 export CHPL_LAUNCHER_CORES_PER_LOCALE=96
 export CHPL_LAUNCHER=slurm-srun
 nightly_args="${nightly_args} -no-buildcheck"

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -24,7 +24,7 @@ module load craype-sandybridge # use craype-x86-cascadelake with 1.26
 
 module list
 
-export CHPL_LAUNCHER_CONSTRAINT=CL48
+export CHPL_LAUNCHER_CONSTRAINT="CL48,192GB"
 export CHPL_LAUNCHER_CORES_PER_LOCALE=96
 export CHPL_LAUNCHER=slurm-srun
 nightly_args="${nightly_args} -no-buildcheck"


### PR DESCRIPTION
Further limit our node selection to 192GB nodes (to avoid getting jobs
with mixed amounts of memory)