### PR TITLE
Link chpl with the same libc++ that built the Homebrew LLVM

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -181,24 +181,25 @@ def validate_llvm_config():
                   " with one of the supported versions: {0}".format(
                   llvm_versions_string()))
 
-        else:
-            bindir = get_system_llvm_config_bindir()
-            if not (bindir and os.path.isdir(bindir)):
-                error("llvm-config command {0} provides missing bin dir {0}"
-                      .format(llvm_config, bindir))
-            clang_c = get_llvm_clang('c')[0]
-            clang_cxx = get_llvm_clang('c++')[0]
-            if not os.path.exists(clang_c):
-                error("Missing clang command at {0}".format(clang_c))
-            if not os.path.exists(clang_cxx):
-                error("Missing clang++ command at {0}".format(clang_cxx))
-
     if (llvm_val == 'system' or
         (llvm_val == 'bundled' and os.path.exists(llvm_config))):
         version, config_error = check_llvm_config(llvm_config)
         if config_error:
             error("Problem with llvm-config at {0} -- {1}"
                   .format(llvm_config, config_error))
+
+    if llvm_val == 'system':
+        bindir = get_system_llvm_config_bindir()
+        if not (bindir and os.path.isdir(bindir)):
+            error("llvm-config command {0} provides missing bin dir {1}"
+                  .format(llvm_config, bindir))
+        clang_c = get_llvm_clang('c')[0]
+        clang_cxx = get_llvm_clang('c++')[0]
+        if not os.path.exists(clang_c):
+            error("Missing clang command at {0}".format(clang_c))
+        if not os.path.exists(clang_cxx):
+            error("Missing clang++ command at {0}".format(clang_cxx))
+
 
 
 @memoize

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -360,12 +360,15 @@ def get_gcc_prefix():
 
     return gcc_prefix
 
+
 # The bundled LLVM does not currently know to look in a particular Mac OS X SDK
 # so we provide a -isysroot arg to indicate which is used.
 #
 # Potential alternatives to -isysroot here include:
 #  * using the environment variable SDKROOT
 #  * providing a cmake argument to adjust the clang build
+#    e.g.
+#      DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 #  * using -mmacosx-version-min=11.2 e.g.
 #
 # Additionally the -resource-dir arg indicates where to find some clang

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -399,6 +399,47 @@ def get_sysroot_resource_dir_args():
 
     return args
 
+# When a system LLVM is installed with Homebrew, it's very important
+# to use the same Mac OS X libraries as what the Homebrew LLVM used.
+# This function helps us to do that.
+# Note that the goal here is to find the Mac OS X system libraries
+# version that the system LLVM was built with, rather than
+# to find out what it is currently configured to compile for;
+# so e.g. setting SDKROOT should not change the value returned here.
+@memoize
+def get_system_llvm_built_sdkroot():
+    # Homebrew installs of clang configure it with DEFAULT_SYSROOT
+    # set to the SDKROOT being used when building.
+    #
+    # We could alternatively run
+    #   dyld_info -platform /usr/local/opt/llvm@12/lib/libLLVM.dylib
+    #     (on Monterey or later), or
+    #   otool -lL /usr/local/opt/llvm@12/lib/libLLVM.dylib | grep sdk
+    #
+    # and then give that version to xcrun (say it is 12.1):
+    #   xcrun --sdk macosx12.1 --show-sdk-path
+    # and this should be the same as the DEFAULT_SYSROOT but
+    # there might be a symlink pointing to the same place.
+
+    llvm_val = get()
+    host_platform = chpl_platform.get('host')
+    if llvm_val == 'system' and host_platform == 'darwin':
+        llvm_config = get_llvm_config()
+        include_dir = run_command([llvm_config, '--includedir']).strip()
+        if os.path.isdir(include_dir):
+            clang_config = os.path.join(include_dir,
+                                       'clang', 'Config', 'config.h')
+            if os.path.exists(clang_config):
+                with open(clang_config) as f:
+                    for line in f.readlines():
+                        # Looking for /some/path in #define DEFAULT_SYSROOT "/some/path"
+                        if 'DEFAULT_SYSROOT' in line:
+                            path = line.split('DEFAULT_SYSROOT')[1].strip()
+                            # remove quotes around it
+                            path = path.strip('"')
+                            return path
+    return None
+
 # On some systems, we need to give clang some arguments for it to
 # find the correct system headers.
 #  * when PrgEnv-gnu is loaded on an XC, we should provide
@@ -557,6 +598,17 @@ def get_host_compile_args():
     llvm_config = get_llvm_config()
 
     if llvm_val == 'system':
+        # On Mac OS X with Homebrew, apply a workaround for issue #19217.
+        # This avoids finding headers in the libc++ installed by llvm@12 e.g.
+        host_platform = chpl_platform.get('host')
+        if host_platform == "darwin":
+            homebrew_prefix = chpl_platform.get_homebrew_prefix()
+            sdkroot = get_system_llvm_built_sdkroot()
+            if homebrew_prefix and sdkroot:
+                system.append("-isysroot")
+                system.append(sdkroot)
+                system.append("-I" + os.path.join(sdkroot, "usr", "include"))
+
         # Ubuntu 16.04 needed -fno-rtti for LLVM 3.7
         # tested on that system after installing
         #   llvm-3.7-dev llvm-3.7 clang-3.7 libclang-3.7-dev libedit-dev
@@ -618,6 +670,16 @@ def get_host_link_args():
 
 
     if llvm_val == 'system':
+        # On Mac OS X with Homebrew, apply a workaround for issue #19217.
+        # This avoids linking with the libc++ installed by llvm@12 e.g.
+        host_platform = chpl_platform.get('host')
+        if host_platform == "darwin":
+            homebrew_prefix = chpl_platform.get_homebrew_prefix()
+            sdkroot = get_system_llvm_built_sdkroot()
+            if homebrew_prefix and sdkroot:
+                # Note: -isysroot only affects includes and -Wl,-syslibroot seems to have no effect
+                system.append("-L" + os.path.join(sdkroot, "usr", "lib"))
+
         # Decide whether to try to link statically or dynamically.
         # Future work: consider using 'llvm-config --shared-mode'
         # to make this choice.


### PR DESCRIPTION
Resolves #19217

This PR adds a workaround to solve #19217. The problem we were seeing is that the Homebrew LLVM is built with one C++ standard library, but it includes a different version of a C++ standard library that our include and link paths were picking up. This can be detected with comparing output of `otool -L chpl` vs `otool -l libLLVM.dylib` (with appropriate paths).

To fix it, this PR adjusts `chpl_llvm.py` to:
 * compute the sdk used when building the llvm/clang Homebrew package. The current strategy is to find the `DEFAULT_SYSROOT` define from `clang/Config/config.h`. This strategy relies on the Homebrew formula passing `-DDEFAULT_SYSROOT=#{macos_sdk}` when cmake'ing llvm and clang. The main alternative strategy that I know of for this is more complex and relies on running both `otool` and `xcrun`.
 * Put -I and -L paths based on this sdk first in the system compile options so that we find the sdk libc++ rather than one from the Homebrew package

While there, I fixed some problems in error reporting when checking an llvm-config.

Reviewed by @ronawho - thanks!

Testing:
- thanks to @ronawho and @aconsroe-hpe for helping test some of these configs
- [x] full local testing
- [x] Ubuntu 21.10 system still works with system LLVM
- [x] Ubuntu 21.10 system with homebrew works with homebrew llvm@12
- [x] Monterey (12.2) ARM Mac with llvm@11, llvm@12, and llvm@13
- [x] Monterey (12.2) x86 Mac with llvm@11, llvm@12, and llvm@13
- [x] Big Sur (11.6) x86 Mac with llvm@12 and llvm@13
- [x] Catalina (10.15.7) x86 Mac with llvm@11, llvm@12, and llvm@13
- [x] some of the above Mac systems have xcode and some only have command line tools