### PR TITLE
Update CI image builder workflow

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -5,6 +5,7 @@ env:
   # NOTE: IMAGE_NAME must be lowercase
   IMAGE_NAME: chapel-github-ci
 
+  # NOTE: if this filename changes, also update in the on.paths section below
   DOCKERFILE: util/dockerfiles/github-ci/Dockerfile
 
 on:
@@ -12,7 +13,12 @@ on:
     branches: [ main ]
     # This limits the action so it only builds when this file changes
     paths:
-      - ${{ env.DOCKERFILE }}
+      # NOTE: I can't get either $DOCKERFILE or ${{env.DOCKERFILE}} to work
+      # properly here
+      - util/dockerfiles/github-ci/Dockerfile
+
+  # Adds a "manual run" option in the GH UI
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
In #19425 I added a new GH Action to build a container. It used the
"on push to main" trigger, but while the new Workflow shows up at [1],
it did not run. I incorrectly assumed we could use variable
substitution in the on.paths section, but I can't get that to work.

I've also added the "on workflow_dispatch" trigger (see [2]) to
allow it to be manually run.

I've tested this in my own fork and verified:
  * a manual run will build the image and push to ghcr
  * a change to util/dockerfiles/github-ci/Dockerfile triggers a
  rebuild after merging to main

[1] https://github.com/chapel-lang/chapel/actions/workflows/build-CI-container.yml
[2] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>