### PR TITLE
Skip this test under valgrind

### DIFF
--- a/test/associative/ferguson/check-hashing-statistics.skipif
+++ b/test/associative/ferguson/check-hashing-statistics.skipif
@@ -1,1 +1,2 @@
 COMPOPTS <= --baseline
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Skip the test

    associative/ferguson/check-hashing-statistics.chpl

under valgrind because it was taking around 900 seconds there which
is close to the timeout of 1000 seconds.

Test change only - not reviewed.