### PR TITLE
Fix cross-reference to new module

### DIFF
--- a/modules/standard/ChapelEnv.chpl
+++ b/modules/standard/ChapelEnv.chpl
@@ -33,7 +33,7 @@ program with the ``--about`` flag.
 
 .. warning::
 
-    This module has been deprecated - please use :mod:`Subprocess` instead.
+    This module has been deprecated - please use :mod:`ChplConfig` instead.
  */
 pragma "module included by default"
 module ChapelEnv {


### PR DESCRIPTION
Apparently in adopting the "this module is deprecated" text from the
Spawn module to make sure I adhered to the prescribed wording, I
didn't even take the time to update the name of the module that
replaces ChapelEnv — embarrassing!  Thanks Andrew, for catching this.
Even more embarrassing...  This is not the first time I've done this
this calendar year.
