### PR TITLE
Make seq field in chpl_comm_bundleData_t unconditional

### DIFF
--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -57,9 +57,7 @@ typedef struct {
   c_sublocid_t subloc;          // target sublocale
   size_t argSize;               // #bytes in whole arg bundle
   void* pAmDone;                // initiator's 'amDone' flag; NULL means nonblk
-#ifdef CHPL_COMM_DEBUG
   uint64_t seq;
-#endif
 } chpl_comm_bundleData_t;
 
 // The type of the communication handle.

--- a/runtime/include/comm/ugni/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ugni/chpl-comm-task-decls.h
@@ -52,9 +52,7 @@ typedef struct {
   c_sublocid_t subloc;
   size_t size;
   void* rf_done; // where to indicate completion on caller
-#ifdef CHPL_COMM_DEBUG
   uint_least64_t seq;
-#endif
 } chpl_comm_bundleData_t;
 
 // The type of the communication handle.

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1189,7 +1189,8 @@ void debugOverrideHints(struct fi_info* hints) {
                                   CFG_HINT(FI_TAGGED),
                                   CFG_HINT(FI_TRIGGER),
                                   CFG_HINT(FI_VARIABLE_MSG),
-                                  CFG_HINT(FI_WRITE), };
+                                  CFG_HINT(FI_WRITE),
+                                  CFG_HINT_NULL, };
     if (getCfgHint("COMM_OFI_HINTS_CAPS",
                    hintVals, false /*justOne*/, &val)) {
       hints->caps = val;


### PR DESCRIPTION
Previously the `seq` field in `chpl_comm_bundleData_t` was conditionally defined based on `CHPL_COMM_DEBUG`. Since `chpl_comm_bundleData_t` is used in the API between the application and the runtime, this meant that both had to be compiled with `CHPL_COMM_DEBUG` either set or not set. Unfortunately, the application makefiles did not set the `CHPL_COMM_DEBUG` compiler flag properly causing a wild store in the runtime. This change makes the `seq` field unconditional, avoiding the dependency on `CHPL_COMM_DEBUG`. The field is generally useful and the bytes saved by not including it when `CHPL_COMM_DEBUG` is not set isn't worth the complexity and the danger of a wild store.

While tracking down this bug I fixed a missing `CFG_HINT_NULL` in `hintVals`.

This was tested on a Cray CS and XC by running `release/examples` and `runtime/configMatters`.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>