### PR TITLE
Improve documentation around definition of subtype

### DIFF
--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -1342,7 +1342,8 @@ according to the concrete intent of :math:`F_X`:
  * if :math:`F_X` uses ``ref`` intent, then :math:`T_A`
    must be the same type as :math:`T_X`
  * if :math:`F_X` uses ``const ref`` intent, then :math:`T_A` and
-   :math:`T_X` must be the same type or a subtype of :math:`T_X`
+   :math:`T_X` must be the same type or a subtype of :math:`T_X` (see
+   :ref:`Subtype_Arg_Conversions`)
  * if :math:`F_X` uses ``in`` or ``inout`` intent, then :math:`T_A`
    must be the same type, a subtype of, or implicitly convertible to
    :math:`T_X`.
@@ -1352,7 +1353,8 @@ according to the concrete intent of :math:`F_X`:
    possible then a compilation error will be emitted if this function
    is chosen as the best candidate.
  * if :math:`F_X` uses the ``type`` intent, then :math:`T_A`
-   must be the same type or a subtype of :math:`T_X`.
+   must be the same type or a subtype of :math:`T_X` (see
+   :ref:`Subtype_Arg_Conversions`).
 
 Finally, if the above compatibility cannot be established, the mapping is
 checked for promotion. If :math:`T_A` is scalar promotable to :math:`T_X`

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -914,7 +914,8 @@ inline proc _bxor_id(type t) return 0:t;
 // and only used for chpldoc.
 
 /* Returns `true` if the type `from` is coercible to the type `to`,
-   or if ``isSubtype(from, to)`` would return `true`.
+   or if ``isSubtype(from, to)`` would return `true`. See
+   :ref:`Implicit_Conversion_Call`.
  */
 pragma "docs only"
 proc isCoercible(type from, type to) param {
@@ -922,11 +923,15 @@ proc isCoercible(type from, type to) param {
 }
 
 /* Returns `true` if the type `sub` is a subtype of the type `super`.
+   See also :ref:`Subtype`.
+
    In particular, returns `true` in any of these cases:
 
      * `sub` is the same type as `super`
      * `sub` is an instantiation of a generic type `super`
      * `sub` is a class type inheriting from `super`
+     * `sub` is non-nilable class type and `super` is the nilable version of the
+       same class type
 
    Note that ``isSubtype(a,b)`` can also be written as
    ``a <= b`` or ``b >= a``.


### PR DESCRIPTION
Follow-up to PR #18798 and #15210.

This PR improves the language specification and docs for isSubtype to be
clearer about the definition of when one thing is a subtype of another.
It also adds more cross references.
