### PR TITLE
Update README and QUICKSTART.rst for LLVM-13

### DIFF
--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -98,7 +98,7 @@ rebuild Chapel from source in a different configuration:
   - ensure that you have a compatible version of LLVM installed on
     your system and set ``CHPL_LLVM=system`` (or leave it unset and
     Chapel should find it if it's in your path.) Currently compatible
-    versions are LLVM-11 and LLVM-12.
+    versions are LLVM-11, LLVM-12 and LLVM-13.
 
   - set ``CHPL_LLVM=bundled`` to have Chapel build and use the bundled
     version of LLVM (note that building the bundled version of LLVM

--- a/third-party/llvm/README
+++ b/third-party/llvm/README
@@ -2,7 +2,7 @@
 LLVM for Chapel release
 =======================
 
-This copy of LLVM 12.0.1 is being released with Chapel for
+This copy of LLVM 13.0.0 is being released with Chapel for
 convenience and was obtained from
 
 https://www.llvm.org/
@@ -54,12 +54,12 @@ un-tarballed LLVM package contents.  Version updates should be done as
 follows, assuming CWD is $CHPL_HOME/third-party/llvm/:
 
 1.  un-tarball the new LLVM version into the directory it specifies,
-    for example llvm-12.0.1.src
+    for example llvm-13.0.0.src
 2.  un-tarball the new Clang version into the directory it specifies,
-    for example clang-12.0.1.src
-3.  mv clang-12.0.1.src llvm-12.0.1.src/tools/clang
+    for example clang-13.0.0.src
+3.  mv clang-13.0.0.src llvm-13.0.0.src/tools/clang
 4.  git rm -r llvm-src
-5.  mv llvm-12.0.1.src llvm-src
+5.  mv llvm-13.0.0.src llvm-src
 6.  rm -r llvm-src/test llvm-src/tools/clang/test
 7.  git add --force llvm-src
     ('--force' is needed to ensure git adds all files in the subdirectory)


### PR DESCRIPTION
Update third-party/llvm/README and doc/rst/usingchapel/QUICKSTART.rst for the
LLVM-13 upgrade.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>