### PR TITLE
Give Language Spec table of contents some structure

### DIFF
--- a/doc/rst/language/spec/index.rst
+++ b/doc/rst/language/spec/index.rst
@@ -4,8 +4,9 @@
 Chapel Language Specification
 |||||||||||||||||||||||||||||
 
+Introductory Material
+---------------------
 .. toctree::
-   :caption: Introductory Material
    :maxdepth: 1
 
    scope
@@ -14,8 +15,9 @@ Chapel Language Specification
    acknowledgements
    language-overview
 
+Language Basics
+---------------
 .. toctree::
-   :caption: Language Basics
    :maxdepth: 1
 
    lexical-structure
@@ -25,8 +27,9 @@ Chapel Language Specification
    expressions
    statements
 
+Code Encapsulation
+------------------
 .. toctree::
-   :caption: Code Encapsulation
    :maxdepth: 1
 
    modules
@@ -35,8 +38,9 @@ Chapel Language Specification
    methods
    error-handling
 
+Composite Types
+---------------
 .. toctree::
-   :caption: Composite Types
    :maxdepth: 1
 
    tuples
@@ -47,28 +51,32 @@ Chapel Language Specification
    domains
    arrays
 
+Generic Programming
+-------------------
 .. toctree::
-   :caption: Generic Programming
    :maxdepth: 1
 
    generics
 
+Parallel Programming
+--------------------
 .. toctree::
-   :caption: Parallel Programming
    :maxdepth: 1
 
    task-parallelism-and-synchronization
    data-parallelism
 
+Distributed Programming
+-----------------------
 .. toctree::
-   :caption: Distributed Programming
    :maxdepth: 1
 
    locales
    domain-maps
 
+Additional Topics
+-----------------
 .. toctree::
-   :caption: Additional Topics
    :maxdepth: 1
 
    input-and-output
@@ -76,8 +84,9 @@ Chapel Language Specification
    interoperability
    user-defined-reductions-and-scans
 
+Appendices
+----------
 .. toctree::
-   :caption: Appendices
    :maxdepth: 1
 
    syntax

--- a/doc/rst/language/spec/index.rst
+++ b/doc/rst/language/spec/index.rst
@@ -5,7 +5,7 @@ Chapel Language Specification
 |||||||||||||||||||||||||||||
 
 .. toctree::
-   :caption: Chapters
+   :caption: Introductory Material
    :maxdepth: 1
 
    scope
@@ -13,16 +13,32 @@ Chapel Language Specification
    organization
    acknowledgements
    language-overview
+
+.. toctree::
+   :caption: Language Basics
+   :maxdepth: 1
+
    lexical-structure
    types
    variables
    conversions
    expressions
    statements
+
+.. toctree::
+   :caption: Code Encapsulation
+   :maxdepth: 1
+
    modules
    procedures
+   iterators
    methods
    error-handling
+
+.. toctree::
+   :caption: Composite Types
+   :maxdepth: 1
+
    tuples
    classes
    records
@@ -30,14 +46,38 @@ Chapel Language Specification
    ranges
    domains
    arrays
-   iterators
+
+.. toctree::
+   :caption: Generic Programming
+   :maxdepth: 1
+
    generics
-   input-and-output
+
+.. toctree::
+   :caption: Parallel Programming
+   :maxdepth: 1
+
    task-parallelism-and-synchronization
    data-parallelism
+
+.. toctree::
+   :caption: Distributed Programming
+   :maxdepth: 1
+
    locales
    domain-maps
-   user-defined-reductions-and-scans
+
+.. toctree::
+   :caption: Additional Topics
+   :maxdepth: 1
+
+   input-and-output
    memory-consistency-model
    interoperability
+   user-defined-reductions-and-scans
+
+.. toctree::
+   :caption: Appendices
+   :maxdepth: 1
+
    syntax

--- a/doc/rst/language/spec/index.rst
+++ b/doc/rst/language/spec/index.rst
@@ -26,9 +26,10 @@ Language Basics
    conversions
    expressions
    statements
+   input-and-output
 
-Code Encapsulation
-------------------
+Code Structures
+---------------
 .. toctree::
    :maxdepth: 1
 
@@ -79,7 +80,6 @@ Additional Topics
 .. toctree::
    :maxdepth: 1
 
-   input-and-output
    memory-consistency-model
    interoperability
    user-defined-reductions-and-scans


### PR DESCRIPTION
Lately, when surfing the Chapel documentation, I've found myself
increasingly annoyed by the flat structure of some of our long lists—
notably, the language spec table of contents and package modules list.
This PR tries to address the first by sorting language specification
chapters into rough categories.  For the most part, I think this change is
a no-brainer, but in doing it, I did reorder some chapters.  And admittedly,
I did that reordering without thinking too much about what it would do to
the "read it from front-to-back" experience, somewhat due to lack of time,
but mostly because I don't think anybody reads the spec in book form
anymore now that it's all online.

More specifically, the ordering changes I made were:

* moved iterators up next to procedures because I think of them as siblings.
  The methods chapter which followed procedures mentioned iterators, so
  there was already a use-before-def issue, and I've probably just changed it
  around a bit (e.g., iterators refer to arrays, which  now come later)
* moved I/O towards the back of the spec.  I expect that this should ultimately
  be moved out of the spec
* moved user-defined-reductions-and-scans to the very back of the spec
   since it's primarily a placeholder and statement of intent

Here's the proposed grouping, ordering, and section names, all up for discussion:
<img width="189" alt="Screen Shot 2022-03-18 at 11 31 20 AM" src="https://user-images.githubusercontent.com/7536222/159062748-ca631715-fb73-43c1-9cc3-a405c1e19705.png">

