### PR TITLE
Move documentation index to sidebar and remove from bottoms of pages

### DIFF
--- a/doc/rst/meta/modules/layoutdist.rst
+++ b/doc/rst/meta/modules/layoutdist.rst
@@ -27,11 +27,3 @@ and describe how domains and arrays are stored across them.
    :glob:
 
    dists/**
-
-
-Index
------
-
-* :ref:`Chapel Online Documentation Index <genindex>`
-
-.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`

--- a/doc/rst/meta/modules/packages.rst
+++ b/doc/rst/meta/modules/packages.rst
@@ -17,11 +17,3 @@ inclusion there.
    :glob:
 
    packages/*
-
-
-Index
------
-
-* :ref:`Chapel Online Documentation Index <genindex>`
-
-.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -116,12 +116,3 @@ Utilities
    Regex <standard/Regex>
    Time <standard/Time>
    Version <standard/Version>
-
-
-
-Index
------
-
-* :ref:`Chapel Online Documentation Index <genindex>`
-
-.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`

--- a/doc/rst/meta/templates/layout.html
+++ b/doc/rst/meta/templates/layout.html
@@ -21,3 +21,11 @@ include "{{ pathto('',1) }}/versionButton.php";
 {% include "searchbox.html" %}
 
 {% endblock %}
+
+{% block menu %}
+  {{ super() }}
+  <p class="caption" role="heading"><span class="caption-text">Chapel Documentation Index</span></p>
+  <ul>
+    <li class="toctree-11"><a class="reference internal" href="{{pathto('genindex.html', 1)}}">Index</a></li>
+  </ul>
+{% endblock %}


### PR DESCRIPTION
While our online documentation index is a bit overwhelmingly large and
badly formatted, it still seems useful, but difficult to discover by
not being on our docs sidebar.  This PR moves it there and removes it
from other places it was mentioned.

It turns out that because of the way the index is generated by Sphinx,
it's not trivial to get it onto the sidebar, which is why I think it
was not there before, and was instead at the bottom of several
module-based pages.  Here, I took a tip from

https://stackoverflow.com/questions/25243482/how-to-add-sphinx-generated-index-to-the-sidebar-when-using-read-the-docs-theme

and wedged it in there, though to make it look proper on the web and
in the generated HTML, I had to embed more HTML than that solution
included.

I removed it from the bottoms of the other pages because it seemed
unnecessary (it's not specific to those pages in any way) and
clutter-y.
