### PR TITLE
Throw `-DCHPL_COMM_DEBUG` when building user programs, when appropriate.

### DIFF
--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -39,12 +39,16 @@ def get_runtime_includes_and_defines():
     bundled.append("-I" + os.path.join(incl, "qio"))
     bundled.append("-I" + os.path.join(incl, "atomics", atomics))
     bundled.append("-I" + os.path.join(incl, "mem", mem))
-    bundled.append("-I" + os.path.join(incl, "mem", mem))
     bundled.append("-I" + os.path.join(third_party, "utf8-decoder"))
 
     if platform.startswith("cygwin"):
         # w32api is provided by cygwin32-w32api-runtime
         system.append("-I" + os.path.join("usr", "include", "w32api"))
+
+    if os.environ.get('CHPL_COMM_DEBUG', None):
+        # add -DCHPL_COMM_DEBUG_
+        # this is needed since it affects code inside of headers
+        bundled.append("-DCHPL_COMM_DEBUG")
 
     if locale_model == "gpu":
         # this -D is needed since it affects code inside of headers


### PR DESCRIPTION
When the environment variable `CHPL_COMM_DEBUG` is defined we need to
define the C preprocessor variable of the same name when building user
programs, to adjust certain declarations in the runtime include files
that are shared with the Chapel module code.  Here, ensure that we do
so.

Support for this was inadvertently removed in #18880.

This resolves https://github.com/Cray/chapel-private/issues/3194.