### PR TITLE
Remove deprecated task and thread counters.

### DIFF
--- a/doc/rst/usingchapel/tasks.rst
+++ b/doc/rst/usingchapel/tasks.rst
@@ -381,31 +381,6 @@ are running on a given locale.
 In order to use this method, you have to specify the locale you wish to
 query, as in here.runningTasks(), where 'here' is the current locale.
 
-The following methods are also available, but these are all deprecated
-and we expect to remove them in the next release unless a need for
-them is identified.
-
-  queuedTasks()
-    returns the number of tasks that are ready to run, but
-    have not yet begun executing.
-
-  blockedTasks()
-    returns the number of tasks that are blocked because
-    they are waiting on a sync or single variable.
-
-  totalThreads()
-    returns the number of threads that have been created
-    since the program started executing, regardless of whether they
-    are busy or idle.
-
-  idleThreads()
-    returns the number of threads are idle, i.e., not assigned to any task.
-
-(Note that all these methods are available for all tasking options,
-but currently only runningTasks() returns meaningful values in all
-configurations.  The others only return meaningful values for
-``CHPL_TASKS=fifo``, which is partly why they have been deprecated.)
-
 
 -------------------------
 Future Tasking Directions

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -793,46 +793,6 @@ module ChapelLocale {
     }
   }
 
-//########################################################################{
-//# Locale diagnostics
-//#
-
-  pragma "no doc"
-  deprecated "locale.totalThreads() is deprecated; please let us know if this is a problem for you"
-  proc locale.totalThreads() {
-    var totalThreads: int;
-    extern proc chpl_task_getNumThreads() : uint(32);
-    on this do totalThreads = chpl_task_getNumThreads();
-    return totalThreads;
-  }
-
-  pragma "no doc"
-  deprecated "locale.idleThreads() is deprecated; please let us know if this is a problem for you"
-  proc locale.idleThreads() {
-    var idleThreads: int;
-    extern proc chpl_task_getNumIdleThreads() : uint(32);
-    on this do idleThreads = chpl_task_getNumIdleThreads();
-    return idleThreads;
-  }
-
-  pragma "no doc"
-  deprecated "locale.queuedTasks() is deprecated; please let us know if this is a problem for you"
-  proc locale.queuedTasks() {
-    var queuedTasks: int;
-    extern proc chpl_task_getNumQueuedTasks() : uint(32);
-    on this do queuedTasks = chpl_task_getNumQueuedTasks();
-    return queuedTasks;
-  }
-
-  pragma "no doc"
-  deprecated "locale.blockedTasks() is deprecated; please let us know if this is a problem for you"
-  proc locale.blockedTasks() {
-    var blockedTasks: int;
-    extern proc chpl_task_getNumBlockedTasks() : int(32);
-    on this do blockedTasks = chpl_task_getNumBlockedTasks();
-    return blockedTasks;
-  }
-
 //########################################################################}
 
   //

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -351,21 +351,6 @@ size_t chpl_task_getCallStackSize(void);
 //
 chpl_bool chpl_task_guardPagesInUse(void);
 
-//
-// returns the number of tasks that are ready to run on the current locale,
-// not including any that have already started running.
-//
-uint32_t chpl_task_getNumQueuedTasks(void);
-
-//
-// returns the number of tasks that are blocked waiting on a sync or single
-// variable.
-// Note that this information may only available if the program is run with
-// the -b switch, which enables block reporting and deadlock detection.
-// If this switch is not specified, -1 may be returned.
-//
-int32_t chpl_task_getNumBlockedTasks(void);
-
 
 // Threads
 
@@ -412,17 +397,6 @@ static inline
 uint32_t chpl_task_canMigrateThreads(void) {
   return CHPL_TASK_IMPL_CAN_MIGRATE_THREADS();
 }
-
-//
-// returns the total number of threads that currently exist, whether running,
-// blocked, or idle
-//
-uint32_t chpl_task_getNumThreads(void);
-
-//
-// returns the number of threads that are currently idle
-//
-uint32_t chpl_task_getNumIdleThreads(void);
 
 //
 // Warn about a num threads setting

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1001,35 +1001,11 @@ chpl_bool chpl_task_guardPagesInUse(void)
   return guardPagesInUse;
 }
 
-// XXX: Should probably reflect all shepherds
-uint32_t chpl_task_getNumQueuedTasks(void)
-{
-    return qthread_readstate(NODE_BUSYNESS);
-}
-
-int32_t chpl_task_getNumBlockedTasks(void)
-{
-    // This isn't accurate, but in the absence of better information
-    // it's the best we can do.
-    return 0;
-}
-
 // Threads
 
 uint32_t chpl_task_impl_getFixedNumThreads(void) {
     assert(chpl_qthread_done_initializing);
     return (uint32_t)qthread_num_workers();
-}
-
-uint32_t chpl_task_getNumThreads(void)
-{
-    return (uint32_t)qthread_num_workers();
-}
-
-// Ew. Talk about excessive bookkeeping.
-uint32_t chpl_task_getNumIdleThreads(void)
-{
-    return 0;
 }
 
 /* vim:set expandtab: */

--- a/test/deprecated/locale.blockedTasks.chpl
+++ b/test/deprecated/locale.blockedTasks.chpl
@@ -1,2 +1,0 @@
-// Deprecated blockedTasks() in Chapel 1.25, to be removed in Chapel 1.26
-writeln(here.blockedTasks() >= 0);

--- a/test/deprecated/locale.blockedTasks.good
+++ b/test/deprecated/locale.blockedTasks.good
@@ -1,2 +1,0 @@
-locale.blockedTasks.chpl:2: warning: locale.blockedTasks() is deprecated; please let us know if this is a problem for you
-true

--- a/test/deprecated/locale.idleThreads.chpl
+++ b/test/deprecated/locale.idleThreads.chpl
@@ -1,2 +1,0 @@
-// Deprecated idleThreads() in Chapel 1.25, to be removed in Chapel 1.26
-writeln(here.idleThreads() >= 0);

--- a/test/deprecated/locale.idleThreads.good
+++ b/test/deprecated/locale.idleThreads.good
@@ -1,2 +1,0 @@
-locale.idleThreads.chpl:2: warning: locale.idleThreads() is deprecated; please let us know if this is a problem for you
-true

--- a/test/deprecated/locale.queuedTasks.chpl
+++ b/test/deprecated/locale.queuedTasks.chpl
@@ -1,2 +1,0 @@
-// Deprecated queuedTasks() in Chapel 1.25, to be removed in Chapel 1.26
-writeln(here.queuedTasks() >= 0);

--- a/test/deprecated/locale.queuedTasks.good
+++ b/test/deprecated/locale.queuedTasks.good
@@ -1,2 +1,0 @@
-locale.queuedTasks.chpl:2: warning: locale.queuedTasks() is deprecated; please let us know if this is a problem for you
-true

--- a/test/deprecated/locale.totalThreads.chpl
+++ b/test/deprecated/locale.totalThreads.chpl
@@ -1,2 +1,0 @@
-// Deprecated totalThreads() in Chapel 1.25, to be removed in Chapel 1.26
-writeln(here.totalThreads() >= 0);

--- a/test/deprecated/locale.totalThreads.good
+++ b/test/deprecated/locale.totalThreads.good
@@ -1,2 +1,0 @@
-locale.totalThreads.chpl:2: warning: locale.totalThreads() is deprecated; please let us know if this is a problem for you
-true


### PR DESCRIPTION
Remove `locale.blockedTasks()`, `.queuedTasks()`, `.idleThreads()`, and
`.totalThreads()`, which were deprecated in 1.25.  Also (transitive
closure) remove the underlying `chpl_task_getNum*()` functions, which
are now unused, and a little bit of fifo tasking layer code which thus
becomes dead.

Signed-off-by: Greg Titus <gbtitus@users.noreply.github.com>