### PR TITLE
Remove `regex.ok` and `regex.error()`

### DIFF
--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -710,23 +710,6 @@ record regex {
     return ret;
   }
 
-  /* did this regular expression compile ? */
-  pragma "no doc"
-  proc ok:bool {
-    compilerWarning("regex: 'ok' is deprecated; errors are used to detect regex compile errors");
-    return qio_regex_ok(_regex);
-  }
-  /*
-     returns a string describing any error encountered when compiling this
-               regular expression
-   */
-  pragma "no doc"
-  proc error():string {
-    param msg = "regex: 'error()' is deprecated; errors are used to detect regex compile errors";
-    compilerWarning(msg);
-    return msg;
-  }
-
   // note - more = overloads are below.
   pragma "no doc"
   proc ref deinit() {

--- a/test/deprecated/regexp_error.chpl
+++ b/test/deprecated/regexp_error.chpl
@@ -2,23 +2,12 @@ use Regex;
 
 {
   var re : regex(string);
-  writeln(re.ok);
   writeln("111111111111111111111");
   try! {
     re = compile("*");
     writeln("Should not reach here");
   } catch (e: BadRegexpError) {
-    writeln("222222222222222222222");
-    writeln(re.ok);
-    writeln("333333333333333333333");
-    writeln(re.error());
-    writeln("444444444444444444444");
     writeln(e.message());
   }
 }
 
-{
-  writeln("555555555555555555555");
-  var re = compile(".");
-  writeln(re.ok);
-}

--- a/test/deprecated/regexp_error.good
+++ b/test/deprecated/regexp_error.good
@@ -1,16 +1,4 @@
-regexp_error.chpl:10: warning: Regex: 'BadRegexpError' is deprecated; please use 'BadRegexError' instead
-regexp_error.chpl:10: warning: Regex: 'BadRegexpError' is deprecated; please use 'BadRegexError' instead
-regexp_error.chpl:5: warning: regex: 'ok' is deprecated; errors are used to detect regex compile errors
-regexp_error.chpl:12: warning: regex: 'ok' is deprecated; errors are used to detect regex compile errors
-regexp_error.chpl:14: warning: regex: 'error()' is deprecated; errors are used to detect regex compile errors
-regexp_error.chpl:23: warning: regex: 'ok' is deprecated; errors are used to detect regex compile errors
-false
+regexp_error.chpl:9: warning: Regex: 'BadRegexpError' is deprecated; please use 'BadRegexError' instead
+regexp_error.chpl:9: warning: Regex: 'BadRegexpError' is deprecated; please use 'BadRegexError' instead
 111111111111111111111
-222222222222222222222
-false
-333333333333333333333
-regex: 'error()' is deprecated; errors are used to detect regex compile errors
-444444444444444444444
 no argument for repetition operator: * when compiling regex '*'
-555555555555555555555
-true


### PR DESCRIPTION
These were deprecated in a previous release. This PR removes them.