### PR TITLE
Fix a bug that was causing assertions with nested blocks in GPU kernels

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -242,7 +242,7 @@ static VarSymbol* generateAssignmentToPrimitive(
 
 static Symbol* addKernelArgument(OutlineInfo& info, Symbol* symInLoop) {
   Type* symType = symInLoop->typeInfo();
-  ArgSymbol* newFormal = new ArgSymbol(INTENT_IN, "data_formal", symType);
+  ArgSymbol* newFormal = new ArgSymbol(INTENT_IN, symInLoop->name, symType);
   info.fn->insertFormalAtTail(newFormal);
 
   info.kernelActuals.push_back(symInLoop);

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -525,8 +525,14 @@ static void outlineGPUKernels() {
           update_symbols(outlinedFunction->body, &info.copyMap);
           normalize(outlinedFunction);
 
-          // We'll get an end of statement for the index we add. I am not sure
-          // how much it matters for the long term, for now just remove it.
+          // normalization above adds PRIM_END_OF_STATEMENTs. It is probably too
+          // wide of a brush. We can:
+          //  (a) generate the AST we are generating from scratch inside some
+          //      block, normalize that block, weed out these primitives inside
+          //      that block only, flatten and remove
+          //  (b) generate the new AST in the normalized form and never call
+          //      normalize
+          //  (c) keep things as is until this becomes an issue
           std::vector<CallExpr*> callsInBody;
           collectCallExprs(outlinedFunction, callsInBody);
           for_vector (CallExpr, call, callsInBody) {

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -527,14 +527,13 @@ static void outlineGPUKernels() {
 
           // We'll get an end of statement for the index we add. I am not sure
           // how much it matters for the long term, for now just remove it.
-          for_alist (node, outlinedFunction->body->body) {
-            if (CallExpr* call = toCallExpr(node)) {
-              if (call->isPrimitive(PRIM_END_OF_STATEMENT)) {
-                call->remove();
-              }
+          std::vector<CallExpr*> callsInBody;
+          collectCallExprs(outlinedFunction, callsInBody);
+          for_vector (CallExpr, call, callsInBody) {
+            if (call->isPrimitive(PRIM_END_OF_STATEMENT)) {
+              call->remove();
             }
           }
-
 
           VarSymbol *numThreads = generateNumThreads(gpuLaunchBlock, info);
           CallExpr* gpuCall = generateGPUCall(info, numThreads);

--- a/test/gpu/native/innerBlock.chpl
+++ b/test/gpu/native/innerBlock.chpl
@@ -1,58 +1,62 @@
 on here.getChild(1) {
   var A = [1,2,3,4,5];
+  var outerVar = 10;
 
   forall a in A {
     for i in 0..5 {
-      a += i;
+      a += i * outerVar;
     }
   }
 
   writeArr(A);
 }
 
-/*on here.getChild(1) {*/
-  /*var A = [1,2,3,4,5];*/
+on here.getChild(1) {
+  var A = [1,2,3,4,5];
+  var outerVar = 10;
 
-  /*forall a in A {*/
-    /*var i = 0;*/
-    /*while i <= 5 {*/
-      /*a += i;*/
-      /*i += 1;*/
-    /*}*/
-  /*}*/
+  forall a in A {
+    var i = 0;
+    while i <= 5 {
+      a += i * outerVar;
+      i += 1;
+    }
+  }
 
-  /*writeArr(A);*/
-/*}*/
+  writeArr(A);
+}
 
-/*on here.getChild(1) {*/
-  /*var A = [1,2,3,4,5];*/
+on here.getChild(1) {
+  var A = [1,2,3,4,5];
+  var outerVar = 10;
 
-  /*forall a in A {*/
-    /*var i = 0;*/
-    /*do {*/
-      /*a += i;*/
-      /*i += 1;*/
-    /*} while i<= 5;*/
-  /*}*/
+  forall a in A {
+    var i = 0;
+    do {
+      a += i * outerVar;
+      i += 1;
+    } while i<= 5;
+  }
 
-  /*writeArr(A);*/
-/*}*/
+  writeArr(A);
+}
 
-/*on here.getChild(1) {*/
-  /*var A = [1,2,3,4,5];*/
+on here.getChild(1) {
+  var A = [1,2,3,4,5];
+  var outerVar = 10;
 
-  /*forall a in A {*/
-    /*for i in 0..5 {*/
-      /*if i%2 == 0 then*/
-        /*a += i;*/
-      /*else*/
-        /*a -= i;*/
-    /*}*/
-  /*}*/
+  forall a in A {
+    for i in 0..5 {
+      if i%2 == 0 then
+        a += i * outerVar;
+      else
+        a -= i * outerVar;
+    }
+  }
 
-  /*writeArr(A);*/
+  writeArr(A);
 
-/*}*/
+}
 
 proc writeArr(A) {
   write("Array: ");

--- a/test/gpu/native/innerBlock.chpl
+++ b/test/gpu/native/innerBlock.chpl
@@ -10,49 +10,49 @@ on here.getChild(1) {
   writeArr(A);
 }
 
-on here.getChild(1) {
-  var A = [1,2,3,4,5];
+/*on here.getChild(1) {*/
+  /*var A = [1,2,3,4,5];*/
 
-  forall a in A {
-    var i = 0;
-    while i <= 5 {
-      a += i;
-      i += 1;
-    }
-  }
+  /*forall a in A {*/
+    /*var i = 0;*/
+    /*while i <= 5 {*/
+      /*a += i;*/
+      /*i += 1;*/
+    /*}*/
+  /*}*/
 
-  writeArr(A);
-}
+  /*writeArr(A);*/
+/*}*/
 
-on here.getChild(1) {
-  var A = [1,2,3,4,5];
+/*on here.getChild(1) {*/
+  /*var A = [1,2,3,4,5];*/
 
-  forall a in A {
-    var i = 0;
-    do {
-      a += i;
-      i += 1;
-    } while i<= 5;
-  }
+  /*forall a in A {*/
+    /*var i = 0;*/
+    /*do {*/
+      /*a += i;*/
+      /*i += 1;*/
+    /*} while i<= 5;*/
+  /*}*/
 
-  writeArr(A);
-}
+  /*writeArr(A);*/
+/*}*/
 
-on here.getChild(1) {
-  var A = [1,2,3,4,5];
+/*on here.getChild(1) {*/
+  /*var A = [1,2,3,4,5];*/
 
-  forall a in A {
-    for i in 0..5 {
-      if i%2 == 0 then
-        a += i;
-      else
-        a -= i;
-    }
-  }
+  /*forall a in A {*/
+    /*for i in 0..5 {*/
+      /*if i%2 == 0 then*/
+        /*a += i;*/
+      /*else*/
+        /*a -= i;*/
+    /*}*/
+  /*}*/
 
-  writeArr(A);
+  /*writeArr(A);*/
 
-}
+/*}*/
 
 proc writeArr(A) {
   write("Array: ");

--- a/test/gpu/native/innerBlock.chpl
+++ b/test/gpu/native/innerBlock.chpl
@@ -1,0 +1,61 @@
+on here.getChild(1) {
+  var A = [1,2,3,4,5];
+
+  forall a in A {
+    for i in 0..5 {
+      a += i;
+    }
+  }
+
+  writeArr(A);
+}
+
+on here.getChild(1) {
+  var A = [1,2,3,4,5];
+
+  forall a in A {
+    var i = 0;
+    while i <= 5 {
+      a += i;
+      i += 1;
+    }
+  }
+
+  writeArr(A);
+}
+
+on here.getChild(1) {
+  var A = [1,2,3,4,5];
+
+  forall a in A {
+    var i = 0;
+    do {
+      a += i;
+      i += 1;
+    } while i<= 5;
+  }
+
+  writeArr(A);
+}
+
+on here.getChild(1) {
+  var A = [1,2,3,4,5];
+
+  forall a in A {
+    for i in 0..5 {
+      if i%2 == 0 then
+        a += i;
+      else
+        a -= i;
+    }
+  }
+
+  writeArr(A);
+
+}
+
+proc writeArr(A) {
+  write("Array: ");
+  for a in A do write(a, " ");
+  writeln();
+}

--- a/test/gpu/native/innerBlock.execopts
+++ b/test/gpu/native/innerBlock.execopts
@@ -1,0 +1,1 @@
+--verbose

--- a/test/gpu/native/innerBlock.good
+++ b/test/gpu/native/innerBlock.good
@@ -1,0 +1,5 @@
+Array: 16 17 18 19 20 
+Array: 16 17 18 19 20 
+Array: 16 17 18 19 20 
+Array: -2 -1 0 1 2 
+Number of kernel launches: 4

--- a/test/gpu/native/innerBlock.good
+++ b/test/gpu/native/innerBlock.good
@@ -1,5 +1,5 @@
-Array: 16 17 18 19 20 
-Array: 16 17 18 19 20 
-Array: 16 17 18 19 20 
-Array: -2 -1 0 1 2 
+Array: 151 152 153 154 155 
+Array: 151 152 153 154 155 
+Array: 151 152 153 154 155 
+Array: -29 -28 -27 -26 -25 
 Number of kernel launches: 4

--- a/test/gpu/native/innerBlock.prediff
+++ b/test/gpu/native/innerBlock.prediff
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+grep "Array:" $2 > $2.new
+echo -n "Number of kernel launches: " >> $2.new
+grep "Kernel launcher called" $2 | wc -l >> $2.new
+
+mv $2.new $2


### PR DESCRIPTION
We needed to clean up `PRIM_END_OF_STATEMENT`s from the outlined GPU kernel.

However, that cleanup was going over the top level statements of the kernel body
without recursing into the blocks to look for that primitive. This PR changes
that logic to clean them all up. This allows loops to appear inside
forall/foreach bodies that are kernelized.

While there, this PR also renames the kernel formals from the generic
`data_formal` to the symbol name that they refer to. The generic name was only
helpful at the very early stages, now it makes debugging difficult.

Test:

- [x] gpu/native
