### PR TITLE
Update CI container: add tzdata and locales

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -13,8 +13,8 @@ on:
     branches: [ main ]
     # This limits the action so it only builds when this file changes
     paths:
-      # NOTE: I can't get either $DOCKERFILE or ${{env.DOCKERFILE}} to work
-      # properly here
+      # unfortunately we can't use ${{env.DOCKERFILE}} here
+      # see https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
       - util/dockerfiles/github-ci/Dockerfile
 
   # Adds a "manual run" option in the GH UI

--- a/util/dockerfiles/github-ci/Dockerfile
+++ b/util/dockerfiles/github-ci/Dockerfile
@@ -1,4 +1,6 @@
 # This is a container used to run CI jobs on GH
+# tzdata is necessary for util/test/check_annotations.py to function properly (get the right dates)
+# locales is necessary for util/buildRelease/smokeTest docs
 
 # We use 22.04 to get llvm-13
 FROM ubuntu:22.04
@@ -20,6 +22,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     llvm-13 \
     llvm-13-dev \
     llvm-13-tools \
+    locales \
     m4 \
     make \
     mawk \
@@ -28,4 +31,13 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3 \
     python3-dev \
     python3-pip \
-    python3-venv
+    python3-venv \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Configure locale (taken from util/dockerfiles/Dockerfile)
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8


### PR DESCRIPTION
In preparing a container to use with CI.yml, I identified two
additional packages we need for testing: tzdata and locales.

tzdata is used to get the correct merge date for perf annotations

locales is necessary to avoid an error when testing the docs:

```
[Working on file chpldoc.doc.chpl]
...
[Executing diff chpldoc.doc.good chpldoc.doc.1.comp.out.tmp]
0a1,9
> perl: warning: Setting locale failed.
> perl: warning: Please check that your locale settings:
> 	LANGUAGE = (unset),
> 	LC_ALL = (unset),
> 	LC_CTYPE = "C.UTF-8",
> 	LC_COLLATE = "C",
> 	LANG = "en_US.UTF-8"
>     are supported and installed on your system.
> perl: warning: Falling back to the standard locale ("C").
[Error matching compiler output for $CHPL_HOME/chapel/chapel-test-MH818I/chpldoc.doc]
```

This needs to get merged so the updated container image is available
before changing CI.yml to actually use the container

Tested in a fork to confirm CI.yml tests pass using this container

Signed-off-by: Andrew Consroe <andrew.consroe@hpe.com>