### PR TITLE
docs: update docs regarding TOML printing and sorted tables/keys

### DIFF
--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -349,13 +349,13 @@ Tests can be listed in the ``Mason.toml`` as a TOML array of strings for the
 .. code-block:: text
 
    [brick]
-   name = "myPackage"
-   version = "0.1.0"
    chplVersion = "1.18.0"
    license = "None"
+   name = "myPackage"
    tests = ["test1.chpl",
             "test2.chpl",
             "test3.chpl"]
+   version = "0.1.0"
 
 An user may also set the ``CHPL_COMM`` value for running the tests, e.g. ``none``, ``gasnet``, ``ugni`` using ``mason test --setComm``.
 
@@ -425,10 +425,10 @@ in their ``Mason.toml`` as follows:
 .. code-block:: text
 
    [brick]
-   name = "myPackage"
-   version = "0.1.0"
    chplVersion = "1.18.0"
    license = "None"
+   name = "myPackage"
+   version = "0.1.0"
 
    [dependencies]
 
@@ -436,8 +436,8 @@ in their ``Mason.toml`` as follows:
    examples = ["myPackageExample.chpl"]
 
    [examples.myPackageExample]
-   execopts = "--count=20"
    compopts = "--savec tmp"
+   execopts = "--count=20"
 
 
 Documenting a Package
@@ -467,10 +467,10 @@ file of the package as follows:
 
 
    [brick]
-   name = "myPackage"
-   version = "0.1.0"
    chplVersion = "1.18.0"
    license = "None"
+   name = "myPackage"
+   version = "0.1.0"
 
    [dependencies]
    MatrixMarket = 0.1.0
@@ -546,10 +546,10 @@ The ``Mason.toml`` now looks like:
 .. code-block:: text
 
    [brick]
-   name = "myPackage"
-   version = "0.1.0"
    chplVersion = "1.18.0"
    license = "None"
+   name = "myPackage"
+   version = "0.1.0"
 
    [system]
    openSSL = "0.9.8zh"
@@ -765,10 +765,10 @@ The ``Mason.toml`` now looks like:
 .. code-block:: text
 
    [brick]
-   name = "myPackage"
-   version = "0.1.0"
    chplVersion = "1.18.0"
    license = "None"
+   name = "myPackage"
+   version = "0.1.0"
 
    [external]
    openSSL = "1.0.2k"
@@ -824,12 +824,12 @@ Continuing the example from before, the 'registry' ``0.1.0.toml`` would include 
 .. code-block:: text
 
      [brick]
-     name = "MyPackage"
-     version = "0.1.0"
+     authors = ["Sam Partee <Sam@Partee.com>"]
      chplVersion = "1.16.0"
      license = "None"
-     authors = ["Sam Partee <Sam@Partee.com>"]
+     name = "MyPackage"
      source = "https://github.com/Spartee/MyPackage"
+     version = "0.1.0"
 
      [dependencies]
      curl = '1.0.0'
@@ -967,11 +967,11 @@ For example, ``Mason.toml``:
 .. code-block:: text
 
     [brick]
-    name = "MyPackage"
-    version = "0.1.0"
+    authors = ["Sam Partee <Sam@Partee.com>"]
     chplVersion = "1.16.0"
     license = "None"
-    authors = ["Sam Partee <Sam@Partee.com>"]
+    name = "MyPackage"
+    version = "0.1.0"
 
     [dependencies]
     curl = '1.0.0'
@@ -1095,22 +1095,22 @@ a lock file is written below as if generated from the earlier example of a ``Mas
 
 .. code-block:: text
 
-     [curl]
-     name = 'curl'
-     version = '1.0.0'
-     chplVersion = "1.16.0..1.16.0"
-     license = "None"
-     source = 'https://github.com/username/curl'
-
-
      [root]
+     authors = ["Sam Partee <Sam@Partee.com>"]
+     chplVersion = "1.16.0..1.16.0"
+     dependencies = ['curl 1.0.0 https://github.com/username/curl']
+     license = "None"
      name = "MyPackage"
+     source = "https://github.com/Spartee/MyPackage"
      version = "0.1.0"
+
+
+     [curl]
      chplVersion = "1.16.0..1.16.0"
      license = "None"
-     authors = ["Sam Partee <Sam@Partee.com>"]
-     source = "https://github.com/Spartee/MyPackage"
-     dependencies = ['curl 1.0.0 https://github.com/username/curl']
+     name = 'curl'
+     source = 'https://github.com/username/curl'
+     version = '1.0.0'
 
 
 Dependency Code

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -58,9 +58,9 @@ to access to the following TOML file's project name,
 .. code-block:: yaml
 
      [root]
+     author = "Sam Partee"
      name = "example"
      version = "1.0.0"
-     author = "Sam Partee"
 
 Use the following code in chapel.
 
@@ -73,6 +73,16 @@ Use the following code in chapel.
      const projectName = ["root"]["name"] // returns a TOML object
      writeln(projectName.toString());     // to turn TOML object into string representation
 
+
+.. note::
+
+  As of Chapel 1.26.0, TOML objects will print their values in the following manner:
+  If the object contains a `root` table, it will be printed first.
+  Keys within the root table will be printed in sorted order.
+  All other tables will be printed in a sorted order after `root`, if it exists.
+  All table keys will be printed in a sorted order. Prior to this change, the `root`
+  table would print first, followed by keys and other tables in what may have been
+  a non-deterministic manner.
 
 */
 proc parseToml(input: file) : unmanaged Toml {


### PR DESCRIPTION
This PR adds a note to the TOML docs to indicate that the contents
will be printed in order.

* the docs for TOML didn't indicate that printing a TOML object
  would result in a special sort order for the tables (root first)
  and then that the keys and all other tables would be sorted and then
  printed.

* adjust the mason docs to show .toml files with sorted tables/keys
  according to the TOML printing logic.

Testing:

- [x] manual review of the TOML and Mason docs

Reviewed by @dlongnecke-cray - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>