### PR TITLE
Avoid double-deinit upon throws from a forall loop

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -25,7 +25,8 @@
 #include "bitVec.h"
 #include "CForLoop.h"
 #include "driver.h"
-#include "expr.h"
+#include "errorHandling.h"
+#include "ForallStmt.h"
 #include "ForLoop.h"
 #include "optimizations.h"
 #include "passes.h"
@@ -1205,15 +1206,27 @@ buildZip4(IteratorInfo* ii, std::vector<BaseAST*>& asts, BlockStmt* singleLoop) 
 //
 // See also isIBBCondStmt() and the PR message for #12963.
 //
+// Update: if the yield is inside a forall loop, IBB should not pretend to
+// return out of the enclosing function, see #18773. Instead, it should
+// pretend to throw an error into the forall's error handler. Mimicking
+// the control flow is sufficient for that.
+//
 void createIteratorBreakBlocks() {
   for_alive_in_Vec(CallExpr, yield, gCallExprs)
     if (yield->isPrimitive(PRIM_YIELD))
       if (FnSymbol* parent = toFnSymbol(yield->parentSymbol)) {
         SET_LINENO(yield);
-        // An empty IBB is: if gIteratorBreakToken then return;
-        Symbol* epLab = parent->getOrCreateEpilogueLabel();
+        BlockStmt* ibbBody = new BlockStmt();
+        if (ForallStmt* fs = enclosingForallStmt(yield)) {
+          // An empty IBB is: if gIteratorBreakToken then throw;
+          ibbBody->insertAtTail(gotoForallErrorHandler(fs));
+        } else {
+          // An empty IBB is: if gIteratorBreakToken then return;
+          Symbol* epLab = parent->getOrCreateEpilogueLabel();
+          ibbBody->insertAtTail(new GotoStmt(GOTO_RETURN, epLab));
+        }
         yield->insertAfter(new CondStmt(new SymExpr(gIteratorBreakToken),
-                             new BlockStmt(new GotoStmt(GOTO_RETURN, epLab))));
+                                        ibbBody));
       }
 }
 

--- a/compiler/include/errorHandling.h
+++ b/compiler/include/errorHandling.h
@@ -23,8 +23,11 @@
 
 class BlockStmt;
 class BaseAST;
+class GotoStmt;
 class Expr;
 class FnSymbol;
+class ForallStmt;
+class LabelSymbol;
 class Symbol;
 
 void lowerErrorHandling();
@@ -36,5 +39,8 @@ Symbol* getErrorSymbolFromCheckErrorStmt(Expr* e);
 // Returns true for functions which should propagate errors
 // if they have throws within (i.e. are automatically throwing).
 bool canFunctionImplicitlyThrow(FnSymbol* fn);
+Symbol* findErrorVarForHandlerLabel(LabelSymbol* handlerLabel);
+// Builds the error handler if there isn't one.
+GotoStmt* gotoForallErrorHandler(ForallStmt* fs);
 
 #endif

--- a/test/errhandling/parallel/forall-calls-throwing-fn2.future
+++ b/test/errhandling/parallel/forall-calls-throwing-fn2.future
@@ -1,8 +1,0 @@
-bug: use-after-free when calling throwing function within forall loop
-
-This test exhibits a behavior in which the invocation of a throwing
-function within a 'forall' loop over a distributed array results in a
-use-after-free error being detected by valgrind (and a segmentation
-fault without).
-
-#18773

--- a/test/errhandling/parallel/forall-calls-throwing-fn2.prediff
+++ b/test/errhandling/parallel/forall-calls-throwing-fn2.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Suppress the output of -memleaks testing.
+
+grep -v -E '^$|^===================|^Allocated Memory|0x[0-9a-f]*' < $2 > $2.tmp
+mv $2.tmp $2

--- a/test/errhandling/parallel/forall-calls-throwing-fn2.skipif
+++ b/test/errhandling/parallel/forall-calls-throwing-fn2.skipif
@@ -1,1 +1,0 @@
-CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
Resolves #18773.

This PR changes the iterator deinitialization actions performed upon a yield
when the yield occurs inside a forall. Formerly these actions included
everything needed to be deinitialized upon returning from the iterator.
Now they include everything upon exiting the forall loop. The impact is
observable when the loop that is using the iterator throws exceptions
in multiple tasks. Before the iterator variables outside the forall loop
would be deinitialized by each task, i.e., multiple times. Now they are
deinitialized just once after the forall loop completed. In this example:
```chpl
iterator IT() { // assume it is the standalone iterator
  var D: domain(1);
  forall i in IT2() {
    yield i;
  }
  writeln();
}

forall idx in IT() {
  throwingFunction();
}
```
the forall loop would be lowered into:
```chpl
var D: domain(1)
forall i in IT2() {
  throwingFunction();
  if it threw an error {
    deinit D;
    goto end_IT;
  }
}
writeln();
deinit D;
end_IT:;
```
now it is lowered into:
```chpl
var D: domain(1)
forall i in IT2() {
  throwingFunction();
  if it threw an error {
    goto forall_IBB_break_label;
  }
}
forall_IBB_break_label:
if there was an error {
  deinit D;
  goto end_IT;
}
deinit D;
writeln();
end_IT:;
```

Testing:
* [x] standard paratest
* [x] multilocale paratest
* [x] asan paratest
* [x] memleaks paratest