### PR TITLE
Alphabetize package modules to document

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -108,16 +108,20 @@ MODULES_TO_DOCUMENT = \
 	standard/Version.chpl
 
 PACKAGES_TO_DOCUMENT = \
-	packages/ArgumentParser.chpl \
 	packages/AllLocalesBarriers.chpl \
+	packages/ArgumentParser.chpl \
 	packages/AtomicObjects.chpl \
 	packages/BLAS.chpl \
 	packages/Buffers.chpl \
 	packages/Channel.chpl \
+	packages/Collection.chpl \
 	packages/ConcurrentMap.chpl \
 	packages/CopyAggregation.chpl \
 	packages/Crypto.chpl \
 	packages/Curl.chpl \
+	packages/DistributedBag.chpl \
+	packages/DistributedDeque.chpl \
+	packages/DistributedIters.chpl \
 	packages/EpochManager.chpl \
 	packages/FFTW.chpl \
 	packages/FunctionalOperations.chpl \
@@ -131,8 +135,6 @@ PACKAGES_TO_DOCUMENT = \
 	packages/LockFreeStack.chpl \
 	packages/MPI.chpl \
 	packages/NetCDF.chpl \
-	packages/SortedMap.chpl \
-	packages/SortedSet.chpl \
 	packages/PeekPoke.chpl \
 	packages/RangeChunk.chpl \
 	packages/RecordParser.chpl \
@@ -140,18 +142,16 @@ PACKAGES_TO_DOCUMENT = \
 	packages/Search.chpl \
 	packages/Socket.chpl \
 	packages/Sort.chpl \
-	packages/UnrolledLinkedList.chpl \
-	packages/VisualDebug.chpl \
-	packages/ZMQ.chpl \
-	packages/Collection.chpl \
-	packages/DistributedBag.chpl \
-	packages/DistributedDeque.chpl \
-	packages/DistributedIters.chpl \
+	packages/SortedMap.chpl \
+	packages/SortedSet.chpl \
 	packages/TOML.chpl \
+	packages/URL.chpl \
 	packages/UnitTest.chpl \
 	packages/UnorderedAtomics.chpl \
 	packages/UnorderedCopy.chpl \
-	packages/URL.chpl \
+	packages/UnrolledLinkedList.chpl \
+	packages/VisualDebug.chpl \
+	packages/ZMQ.chpl \
 
 
 DISTS_TO_DOCUMENT = \


### PR DESCRIPTION
While trying to sort out which package modules were or were not
documented today, I ended up sorting this list (well, I shouldn't
claim that... turns out I'm horrible at alphabetizing.  But it's at least
closer to being sorted).
