### PR TITLE
Adjust 'unsafeAssignManager.initialize()' method to halt

### DIFF
--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1561,9 +1561,13 @@ module ChapelDomain {
 
       /*
         Initialize a newly added array element at an index with a new value.
-        If the array element at `idx` has already been initialized, this
-        method will silently perform assignment instead. This method will
-        error if `idx` is not a valid indice in `arr`.
+
+        If checks is ``true`` and the array element at `idx` has already
+        been initialized, this method will halt. If checks is ``false``,
+        then this method will overwrite the memory at `arr[idx]` in a
+        potentially unsafe manner.
+
+        It is an error if `idx` is not a valid indice in `arr`.
       */
       proc initialize(arr: [?d], idx, in value: arr.eltType) {
 
@@ -1598,22 +1602,14 @@ module ChapelDomain {
         // Get a reference to the array slot.
         ref elem = arr[idx];
 
-        // If there are checks, we can fall back on assignment should a slot
-        // already be move-initialized.
         if _checks {
-          if !isElementInitialized(arr, idx) {
-            _moveInitializeElement(arr, idx, value);
-          } else {
-
-            // TODO: Halt instead of assigning?
-            elem = value;
+          if isElementInitialized(arr, idx) {
+            halt('Element at array index \'' + idx:string + '\' ' +
+                 'is already initialized');
           }
-
-        // If there are no checks, all we can do is destructively
-        // move-initialize.
-        } else {
-          _moveInitializeElement(arr, idx, value);
         }
+
+        _moveInitializeElement(arr, idx, value);
       }
 
       pragma "no doc"

--- a/test/domains/unsafeAssign/HaltChecksDuplicateInit.chpl
+++ b/test/domains/unsafeAssign/HaltChecksDuplicateInit.chpl
@@ -1,0 +1,19 @@
+class C {
+  var x = 0;
+}
+
+proc test() {
+  var D = {0..0};
+  var A: [D] shared C = [new shared C(0)];
+  writeln(A);
+
+  // Initialize the same slot twice to trigger a halt.
+  manage D.unsafeAssign({0..1}, checks=true) as mgr {
+    mgr.initialize(A, 1, new shared C(1));
+    mgr.initialize(A, 1, new shared C(1));
+  }
+
+  writeln(A);
+}
+test();
+

--- a/test/domains/unsafeAssign/HaltChecksDuplicateInit.good
+++ b/test/domains/unsafeAssign/HaltChecksDuplicateInit.good
@@ -1,0 +1,2 @@
+{x = 0}
+HaltChecksDuplicateInit.chpl:13: error: halt reached - Element at array index '1' is already initialized


### PR DESCRIPTION
Adjust 'unsafeAssignManager.initialize()' method to halt (#19485)

While reviewing the docs for the new `domain.unsafeAssign()` method,
I saw a TODO I had left to consider making the `initialize()`
method on the manager halt if `checks == true` and an already
initialized slot was initialized again. I decided to make that change
in this PR, along with updating the docs for the method.

I think this is the correct thing to do for now because it is more
strict (we can always revert this decision later, but cannot go in
the other direction without breaking changes).

TESTING

- [x] `ALL` on `linux64` when `COMM=none`
- [x] Updated docs checked locally

Reviewed by @vasslitvinov. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>