### PR TITLE
Fix a compiler assert and more

### DIFF
--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -115,7 +115,7 @@ enum ForallIntentTag {
   TFI_CONST_REF,                   //   "
   TFI_REDUCE,                      //   AS    (for Accumulation State)
   TFI_TASK_PRIVATE,                //   TPV
-  // compiler-added helpers
+  // compiler-added helpers; note isCompilerAdded()
   TFI_IN_PARENT,                   //   INP
   TFI_REDUCE_OP,                   //   RP    (for Reduce oP)
   TFI_REDUCE_PARENT_AS,            //   PAS
@@ -456,6 +456,7 @@ public:
   const char* intentDescrString() const;
   bool  isReduce()          const { return intent == TFI_REDUCE;       }
   bool  isTaskPrivate()     const { return intent == TFI_TASK_PRIVATE; }
+  bool  isCompilerAdded()   const;
 
   static ShadowVarSymbol* buildForPrefix(ShadowVarPrefix prefix,
                                          Expr* name, Expr* type, Expr* init);
@@ -712,6 +713,19 @@ inline bool Symbol::isWideRef() {
 
 inline bool Symbol::isRefOrWideRef() {
   return isRef() || isWideRef();
+}
+
+// Is this a compiler-added helper / not to be reported to user?
+inline bool ShadowVarSymbol::isCompilerAdded() const {
+  switch (intent) {
+    case TFI_IN_PARENT:
+    case TFI_REDUCE_OP:
+    case TFI_REDUCE_PARENT_AS:
+    case TFI_REDUCE_PARENT_OP:
+      return true;
+    default:
+      return false;
+  }
 }
 
 

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -2354,6 +2354,10 @@ static void removeAggregationFromRecursiveForallHelp(BlockStmt *block) {
   for_alist(stmt, block->body) {
     if (CondStmt *condStmt = toCondStmt(stmt)) {
       SymExpr *condExpr = toSymExpr(condStmt->condExpr);
+      if (condExpr == nullptr)
+        if (CallExpr* call = toCallExpr(condStmt->condExpr))
+          if (call->isPrimitive(PRIM_CHECK_ERROR))
+            continue; // error check blocks should not have aggregation code
       INT_ASSERT(condExpr);
 
       Symbol *aggMarkerSym = condExpr->symbol();

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -1134,6 +1134,26 @@ static void reorderShadowVsTaskPrivateVars(ForallStmt* fs) {
 
 /////////// recursive iterators ///////////
 
+static void warnRecursiveIterNonrefSVar(ForallStmt* fs, FnSymbol* parIterFn,
+                                        ShadowVarSymbol* svar,
+                                        bool& gotNonRefs, bool& implWarn) {
+  if (gotNonRefs == false) {
+    USR_FATAL_CONT(fs, "forall loop over a recursive parallel iterator");
+    USR_PRINT(fs, "such loops are currently implemented only if\n"
+                  "  all their shadow variables have a ref or const ref intent");
+    USR_PRINT(parIterFn, "the parallel iterator is here");
+  }
+  gotNonRefs = true;
+
+  if (! svar->isCompilerAdded()) {
+    if (implWarn == false)
+      USR_PRINT(fs, "a shadow variable may be implicit");
+    implWarn = true;
+    USR_PRINT(svar, "'%s' shadow variable has %s", svar->name,
+                                                   svar->intentDescrString());
+  }
+}
+
 //
 // If 'fs' has only ref intents, or none at all,
 // revert to old iterator-record-based implementation.
@@ -1150,20 +1170,14 @@ static void handleRecursiveIter(ForallStmt* fs,
 
   // Check for non-ref intents.
   SymbolMap sv2ov;
-  bool gotNonRefs = false;
+  bool gotNonRefs = false, implWarn = false;;
   for_shadow_vars(svar, temp, fs) {
     if (svar->intent == TFI_REF || svar->intent == TFI_CONST_REF)
       sv2ov.put(svar, svar->outerVarSym());
     else
-      { gotNonRefs = true; break; }
+      warnRecursiveIterNonrefSVar(fs, parIterFn, svar, gotNonRefs, implWarn);
   }
-
-  if (gotNonRefs) {
-    USR_FATAL_CONT(fs, "forall loops over recursive parallel iterators are currently not implemented");
-    USR_PRINT(fs, "in the presence of non-ref intents");
-    USR_PRINT(parIterFn, "the parallel iterator is here");
-    return;
-  }
+  if (gotNonRefs) return; // currently not implemented
 
   // We assume these in the foregoing.
   INT_ASSERT(parIterCall == fs->firstIteratedExpr());

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1205,12 +1205,9 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
     return chpl_rt_direntptr_getname(this);
   }
 
-  var dir: DIRptr;
-  var ent: direntptr;
-  var err:syserr = ENOERR;
-  dir = opendir(unescape(path).c_str());
+  var dir: DIRptr = opendir(unescape(path).c_str());
   if (!is_c_nil(dir)) {
-    ent = readdir(dir);
+    var ent: direntptr = readdir(dir);
     while (!is_c_nil(ent)) {
       var filename: string;
       try! {
@@ -1243,7 +1240,7 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
     closedir(dir);
   } else {
     extern proc perror(s: c_string);
-    perror("error in listdir(): ");
+    perror(("error in listdir(): " + path).c_str());
   }
 }
 

--- a/test/library/standard/FileSystem/filerator/listdir-errors.chpl
+++ b/test/library/standard/FileSystem/filerator/listdir-errors.chpl
@@ -1,0 +1,10 @@
+// inspired by #19301
+// exercises 'perror' in listdir
+// the .good assumes the existence of listdir-errors.chpl
+
+use FileSystem;
+
+for file in listdir("no/such/dir/ever") do
+  writeln(file);
+for file in listdir("listdir-errors.chpl") do
+  writeln(file);

--- a/test/library/standard/FileSystem/filerator/listdir-errors.good
+++ b/test/library/standard/FileSystem/filerator/listdir-errors.good
@@ -1,0 +1,2 @@
+error in listdir(): no/such/dir/ever: No such file or directory
+error in listdir(): listdir-errors.chpl: Not a directory

--- a/test/parallel/forall/vass/reciter/forall-reciter-alt.chpl
+++ b/test/parallel/forall/vass/reciter/forall-reciter-alt.chpl
@@ -1,0 +1,15 @@
+// This test is a slimmed-down version of the code in OP of #19301.
+// It is essentially the same as forall-reciter-todo.chpl
+// except:
+// * it uses findfiles() as the recursive iterator
+// * it is not a .future, so the error messages are in a .good file.
+
+use FileSystem;
+
+config const inputDir = "InputFiles";
+config const debug = true;
+config const minCount = 1000;
+
+forall file in findfiles(inputDir) {
+  writeln((file, debug, minCount));
+}

--- a/test/parallel/forall/vass/reciter/forall-reciter-alt.good
+++ b/test/parallel/forall/vass/reciter/forall-reciter-alt.good
@@ -1,0 +1,7 @@
+forall-reciter-alt.chpl:13: error: forall loop over a recursive parallel iterator
+forall-reciter-alt.chpl:13: note: such loops are currently implemented only if
+  all their shadow variables have a ref or const ref intent
+$CHPL_HOME/modules/standard/FileSystem.chpl:nnnn: note: the parallel iterator is here
+forall-reciter-alt.chpl:13: note: a shadow variable may be implicit
+forall-reciter-alt.chpl:13: note: 'debug' shadow variable has 'const in' intent
+forall-reciter-alt.chpl:13: note: 'minCount' shadow variable has 'const in' intent

--- a/test/parallel/forall/vass/reciter/forall-reciter-alt.prediff
+++ b/test/parallel/forall/vass/reciter/forall-reciter-alt.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/parallel/forall/vass/reciter/forall-reciter-todo.bad
+++ b/test/parallel/forall/vass/reciter/forall-reciter-todo.bad
@@ -1,7 +1,13 @@
 forall-reciter-todo.chpl:45: In function 'main':
-forall-reciter-todo.chpl:50: error: forall loops over recursive parallel iterators are currently not implemented
-forall-reciter-todo.chpl:50: note: in the presence of non-ref intents
+forall-reciter-todo.chpl:50: error: forall loop over a recursive parallel iterator
+forall-reciter-todo.chpl:50: note: such loops are currently implemented only if
+  all their shadow variables have a ref or const ref intent
 forall-reciter-todo.chpl:19: note: the parallel iterator is here
-forall-reciter-todo.chpl:58: error: forall loops over recursive parallel iterators are currently not implemented
-forall-reciter-todo.chpl:58: note: in the presence of non-ref intents
+forall-reciter-todo.chpl:50: note: a shadow variable may be implicit
+forall-reciter-todo.chpl:50: note: 'ovarPR' shadow variable has 'reduce' intent
+forall-reciter-todo.chpl:58: error: forall loop over a recursive parallel iterator
+forall-reciter-todo.chpl:58: note: such loops are currently implemented only if
+  all their shadow variables have a ref or const ref intent
 forall-reciter-todo.chpl:19: note: the parallel iterator is here
+forall-reciter-todo.chpl:58: note: a shadow variable may be implicit
+forall-reciter-todo.chpl:58: note: 'ovarIn' shadow variable has 'in' intent


### PR DESCRIPTION
Resolves #19301.

This PR fixes an assertion failure reported in 19301 and makes the compiler handle that case safely.

While there:

Report more information upon the compiler error that parallel loops over recursive iterators are not implemented unless all shadow variables have [const] ref intents. Specifically, report the names and intents of the non-compliant shadow variables.

Report the path - in addition to the error message already reported - when `FileSystem.listdir()` encounters certain errors.
