### PR TITLE
Minor build/printchplenv adjustments to support Homebrew

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -184,7 +184,7 @@ print "[gen_release] CHPL_HOME is set to: $ENV{'CHPL_HOME'}\n";
 
 if (not exists($ENV{"CHPL_GEN_RELEASE_SKIP_DOCS"})) {
   print "[gen_release] Building the html docs...\n";
-  SystemOrDie("make -j docs");
+  SystemOrDie("make docs");
 
   # TODO - make this more elegant / maintainable
   print "[gen_release] Pruning the docs directory...\n";

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -306,6 +306,10 @@ def llvm_enabled():
 def get_gcc_prefix():
     gcc_prefix = overrides.get('CHPL_LLVM_GCC_PREFIX', '')
 
+    # allow CHPL_LLVM_GCC_PREFIX=none to disable inferring it
+    if gcc_prefix == 'none':
+        return ''
+
     if not gcc_prefix:
         # darwin and FreeBSD default to clang
         # so shouldn't need GCC prefix

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -448,6 +448,13 @@ def get_system_llvm_built_sdkroot():
                             return path
     return None
 
+@memoize
+def apply_homebrew_workaround():
+    homebrew_prefix = chpl_platform.get_homebrew_prefix()
+    homebrew_var = overrides.get('CHPL_HOMEBREW_WORKAROUND', '')
+
+    return (homebrew_prefix or homebrew_var)
+
 # On some systems, we need to give clang some arguments for it to
 # find the correct system headers.
 #  * when PrgEnv-gnu is loaded on an XC, we should provide
@@ -610,9 +617,8 @@ def get_host_compile_args():
         # This avoids finding headers in the libc++ installed by llvm@12 e.g.
         host_platform = chpl_platform.get('host')
         if host_platform == "darwin":
-            homebrew_prefix = chpl_platform.get_homebrew_prefix()
             sdkroot = get_system_llvm_built_sdkroot()
-            if homebrew_prefix and sdkroot:
+            if sdkroot and apply_homebrew_workaround():
                 system.append("-isysroot")
                 system.append(sdkroot)
                 system.append("-I" + os.path.join(sdkroot, "usr", "include"))
@@ -682,9 +688,8 @@ def get_host_link_args():
         # This avoids linking with the libc++ installed by llvm@12 e.g.
         host_platform = chpl_platform.get('host')
         if host_platform == "darwin":
-            homebrew_prefix = chpl_platform.get_homebrew_prefix()
             sdkroot = get_system_llvm_built_sdkroot()
-            if homebrew_prefix and sdkroot:
+            if sdkroot and apply_homebrew_workaround():
                 # Note: -isysroot only affects includes and -Wl,-syslibroot seems to have no effect
                 system.append("-L" + os.path.join(sdkroot, "usr", "lib"))
 

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -51,7 +51,7 @@ chplvars = [
              'CHPL_SANITIZE',
              'CHPL_SANITIZE_EXE',
              'CHPL_LLVM_GCC_PREFIX',
-             'CHPL_HOMEBREW_WORKAROUND',
+             'CHPL_HOST_USE_SYSTEM_LIBCXX',
            ]
 
 

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -51,6 +51,7 @@ chplvars = [
              'CHPL_SANITIZE',
              'CHPL_SANITIZE_EXE',
              'CHPL_LLVM_GCC_PREFIX',
+             'CHPL_HOMEBREW_WORKAROUND',
            ]
 
 

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -50,6 +50,7 @@ chplvars = [
              'CHPL_LIB_PIC',
              'CHPL_SANITIZE',
              'CHPL_SANITIZE_EXE',
+             'CHPL_LLVM_GCC_PREFIX',
            ]
 
 


### PR DESCRIPTION
This PR fixes two problems I ran into when trying to get a linuxbrew build of Chapel 1.26 working and one problem with trying the Homebrew (on Mac OS X) formula

* don't `make -j` in gen_release to build the docs
  * this originated in #2709, potentially inadvertently
  * unbounded `make -j` can run out of memory
* allow `CHPL_LLVM_GCC_PREFIX` to be set in `chplconfig` and allow it to be set to `none`
  * so that the linuxbrew formula can leave out the `--gcc-toolchain` flag since it should not be necessary there
* Add `CHPL_HOST_USE_SYSTEM_LIBCXX` environment variable to enable the workaround from PR #19445. This environment variable is necessary (instead of just detecting the existence of `brew`) because otherwise the workaround is not applied when building the `chapel` formula itself.

Reviewed by @e-kayrakli, @tzinsky and @ronawho - thanks!

- [x] full local testing
- [x] hello works on Mac OS X with Homebrew LLVM 13
- [x] draft homebrew formula succeeds on Mac OS X