### PR TITLE
Remove reference to deleted file from adding-a-comm-layer.rst

### DIFF
--- a/doc/rst/developer/implementation/adding-a-comm-layer.rst
+++ b/doc/rst/developer/implementation/adding-a-comm-layer.rst
@@ -42,10 +42,6 @@ a comm layer implementation.
   Defines the macro ``CHPL_COMM_PRELAUNCH`` to be executed before launching the user
   program.
 
-- **runtime/include/comm/chpl-comm-heap-macros.h**: 
-
-  Defines the macro ``CHPL_HEAP_REGISTER_GLOBAL_VAR_EXTRA`` which is used to do anything special needed to register global heap variables.
-
 - **runtime/include/comm/chpl-comm-impl.h**: 
 
   This file contains any additional runtime interface declarations that need to be provided by the specific comm layer implementation.


### PR DESCRIPTION
The file was removed in

```
commit 430120cc126a79a1a4ae1612385722099b9ffff7
Author: Greg Titus <gbtitus@users.noreply.github.com>
Date:   Thu May 16 16:03:50 2019 -0500

    Move global registration and broadcast mostly into common code.
```

and the CHPL_HEAP_REGISTER_GLOBAL_VAR_EXTRA variable was eliminated.
Drop this reference to it.