### PR TITLE
Document CHPL_LLVM_GCC_PREFIX

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -777,11 +777,15 @@ CHPL_LLVM
    See :ref:`readme-prereqs` for more information about currently
    supported LLVM versions.
 
+   **CHPL_LLVM_CONFIG**
+
    In some cases, it is useful to be able to select a particular LLVM
    installation for use with ``CHPL_LLVM=system``. In that event, in
    addition to setting ``CHPL_LLVM=system``, you can set
    ``CHPL_LLVM_CONFIG`` to the llvm-config command from the LLVM
    installation you wish to use.
+
+   **CHPL_LLVM_GCC_PREFIX**
 
    Additionally, in some cases, the configured ``clang`` will not work
    correctly without a ``--gcc-toolchain`` flag. The Chapel compiler

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -783,6 +783,14 @@ CHPL_LLVM
    ``CHPL_LLVM_CONFIG`` to the llvm-config command from the LLVM
    installation you wish to use.
 
+   Additionally, in some cases, the configured ``clang`` will not work
+   correctly without a ``--gcc-toolchain`` flag. The Chapel compiler
+   tries to infer this flag but it does not always do so correctly. As a
+   result, it is sometimes necessary to override it.  You can set
+   ``CHPL_LLVM_GCC_PREFIX`` to ``none`` to  disable passing the
+   ``--gcc-toolchain`` flag; or you can set it to a directory to pass to
+   ``clang`` with the ``--gcc-toolchain`` flag.
+
 .. _readme-chplenv.CHPL_UNWIND:
 
 CHPL_UNWIND


### PR DESCRIPTION
The environment variable `CHPL_LLVM_GCC_PREFIX` has so far been undocumented. However, recent experience indicates that sometimes setting it is necessary to get things working.

 * https://chapel.discourse.group/t/build-of-1-25-1-with-bundled-llvm-on-system-with-multiple-gcc-g-installed/11179
 * for homebrew linux builds when a homebrew GCC is installed (see also #19504)

So, this PR documents it within the description of the `CHPL_LLVM` setting.

Note that `CHPL_LLVM_GCC_PREFIX` is not currently shown with `printchplenv --all` and arguably it should be. However this PR focuses only on documentation.

Reviewed by @daviditen - thanks!