### PR TITLE
Extend documentation of using the deprecated keyword, and lock in examples with tests

### DIFF
--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -228,3 +228,45 @@ using the old name:
    var f = new Foo(30);
    f.oldName += 3; // Should warn, but still function
    writeln(f.newName); // Should be 33
+
+While this strategy enables positional initialization calls to continue to work
+without adjustment, it does break named initialization calls, e.g ``new
+Foo(oldName=30)``.  The only solution for this is to add an initializer overload
+with the old name that will generate a deprecation warning.  However, without
+support for opting in to maintaining the default initializer (which is planned
+but not currently implemented), this will also require the addition of an
+equivalent replacement for the default initializer, which is a burden.
+
+.. code-block:: chapel
+
+   record Foo {
+     var newName: int;
+
+     proc oldName ref: int {
+       return this.newName;
+     }
+
+     pragma "last resort"
+     deprecated "'new Foo(oldName=val)' is deprecated, please use 'new Foo(newName=val)' or 'new Foo(val)' instead"
+     proc init(oldName: int) {
+       this.newName = oldName;
+     }
+
+     // Required because previous initializer prevented the generation of the
+     // default initializer
+     // Could also write `newName: int = 0` to avoid writing two initializers
+     proc init(newName: int) {
+       this.newName = newName;
+     }
+
+     // Required because first initializer prevented the generation of the
+     // default initializer
+     // Relies on omitted field initialization
+     proc init() {
+     }
+   }
+
+   var f = new Foo(oldName=30); // Now warns
+   var f2 = new Foo(newName=30); // Still works without warning
+   var f3 = new Foo(30); // Still works without warning
+   var f4 = new Foo(); // Still works without warning

--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -113,7 +113,7 @@ that responds to it to the deprecated function and its replacement:
    proc foo(): bool where fooReturnsBool { ... }
 
 When the deprecated function is removed, the flag should also be deprecated (and
-removed from the new function to avoid generating noise for the user:
+removed from the new function to avoid generating noise for the user):
 
 .. code-block:: chapel
 
@@ -154,9 +154,10 @@ ordering:
 
 In this case, we still want to generate warnings when the old argument name is
 used, but we want positional ordering to work without indicating anything has
-changed.  To accomplish this, mark the deprecated version with `pragma "last
-resort"` - this will avoid conflicts in the positional ordering case while still
-keeping the old argument name available to generate the deprecation warning:
+changed.  To accomplish this, mark the deprecated version with ``pragma "last
+resort"`` - this will avoid conflicts in the positional ordering case while
+still keeping the old argument name available to generate the deprecation
+warning:
 
 .. code-block:: chapel
 
@@ -230,7 +231,7 @@ using the old name:
    writeln(f.newName); // Should be 33
 
 While this strategy enables positional initialization calls to continue to work
-without adjustment, it does break named initialization calls, e.g ``new
+without adjustment, it does still break named initialization calls, e.g ``new
 Foo(oldName=30)``.  The only solution for this is to add an initializer overload
 with the old name that will generate a deprecation warning.  However, without
 support for opting in to maintaining the default initializer (which is planned

--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -163,7 +163,9 @@ warning:
 
    pragma "last resort"
    deprecated "argument name 'a' is deprecated, use 'b' instead"
-   proc foo(a: int) { ... }
+   proc foo(a: int) {
+     foo(a); // Call function with new argument name
+   }
 
    proc foo(b: int) { ... }
 

--- a/test/deprecated-keyword/depReturnTypeOnly.chpl
+++ b/test/deprecated-keyword/depReturnTypeOnly.chpl
@@ -1,0 +1,16 @@
+config param fooReturnsBool = false;
+
+deprecated "foo returning 'int' is deprecated, please compile with '-sfooReturnsBool=true' to get the new return type"
+proc foo(): int where !fooReturnsBool {
+  writeln("In old foo");
+  return 0;
+}
+
+proc foo(): bool where fooReturnsBool {
+  writeln("In new foo");
+  return false;
+}
+
+proc main() {
+  foo();
+}

--- a/test/deprecated-keyword/depReturnTypeOnly.compopts
+++ b/test/deprecated-keyword/depReturnTypeOnly.compopts
@@ -1,0 +1,3 @@
+ # depReturnTypeOnly.off.good
+-sfooReturnsBool=false # depReturnTypeOnly.off.good
+-sfooReturnsBool=true # depReturnTypeOnly.on.good

--- a/test/deprecated-keyword/depReturnTypeOnly.off.good
+++ b/test/deprecated-keyword/depReturnTypeOnly.off.good
@@ -1,0 +1,3 @@
+depReturnTypeOnly.chpl:14: In function 'main':
+depReturnTypeOnly.chpl:15: warning: foo returning 'int' is deprecated, please compile with '-sfooReturnsBool=true' to get the new return type
+In old foo

--- a/test/deprecated-keyword/depReturnTypeOnly.on.good
+++ b/test/deprecated-keyword/depReturnTypeOnly.on.good
@@ -1,0 +1,1 @@
+In new foo

--- a/test/deprecated-keyword/handleField-explicitInits.chpl
+++ b/test/deprecated-keyword/handleField-explicitInits.chpl
@@ -1,0 +1,37 @@
+record Foo {
+  var newName: int;
+
+  proc oldName ref: int {
+    return this.newName;
+  }
+
+  pragma "last resort"
+  deprecated "'new Foo(oldName=val)' is deprecated, please use 'new Foo(newName=val)' or 'new Foo(val)' instead"
+  proc init(oldName: int) {
+    this.newName = oldName;
+  }
+
+  // Required because previous initializer prevented the generation of the
+  // default initializer
+  // Could also write `newName: int = 0` to avoid writing two initializers
+  proc init(newName: int) {
+    this.newName = newName;
+  }
+
+  // Required because first initializer prevented the generation of the
+  // default initializer
+  // Relies on omitted field initialization
+  proc init() {
+  }
+}
+
+proc main() {
+  var f = new Foo(oldName=30);
+  writeln(f);
+  var f2 = new Foo(newName=30); // Still works without warning
+  writeln(f2);
+  var f3 = new Foo(30); // Still works without warning
+  writeln(f3);
+  var f4 = new Foo(); // Still works without warning
+  writeln(f4);
+}

--- a/test/deprecated-keyword/handleField-explicitInits.good
+++ b/test/deprecated-keyword/handleField-explicitInits.good
@@ -1,0 +1,6 @@
+handleField-explicitInits.chpl:28: In function 'main':
+handleField-explicitInits.chpl:29: warning: 'new Foo(oldName=val)' is deprecated, please use 'new Foo(newName=val)' or 'new Foo(val)' instead
+(newName = 30)
+(newName = 30)
+(newName = 30)
+(newName = 0)

--- a/test/deprecated-keyword/handleField.chpl
+++ b/test/deprecated-keyword/handleField.chpl
@@ -1,15 +1,255 @@
-class Foo {
-  deprecated "Field p1 is deprecated, use p2 instead"
-  param p1 = 3;
-  param p2 = 3;
+class ReplaceVarConcrete {
+  var newName: int;
 
-  proc init(param val) {
-    p2 = val;
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName ref: int {
+    return this.newName;
+  }
+}
+
+record ReplaceVarConcrete2 {
+  var newName: int;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName ref: int {
+    return this.newName;
+  }
+}
+
+class ReplaceType {
+  type newName;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName type {
+    return this.newName;
+  }
+}
+
+record ReplaceType2 {
+  type newName;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName type {
+    return this.newName;
+  }
+}
+
+class ReplaceParam {
+  param newName;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName param {
+    return this.newName;
+  }
+}
+
+record ReplaceParam2 {
+  param newName;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName param {
+    return this.newName;
+  }
+}
+
+class ReplaceConstConcrete {
+  const newName: int;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName: int {
+    return this.newName;
+  }
+}
+
+record ReplaceConstConcrete2 {
+  const newName: int;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName: int {
+    return this.newName;
+  }
+}
+
+class ReplaceVarGeneric {
+  var newName;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName ref {
+    return this.newName;
+  }
+}
+
+record ReplaceVarGeneric2 {
+  var newName;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName ref{
+    return this.newName;
+  }
+}
+
+class ReplaceConstGeneric {
+  const newName;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName {
+    return this.newName;
+  }
+}
+
+record ReplaceConstGeneric2 {
+  const newName;
+
+  deprecated "The field 'oldName' is deprecated, please use 'newName'"
+  proc oldName {
+    return this.newName;
   }
 }
 
 proc main() {
-  var f = new Foo(5);
-  writeln(f.p1);
-  writeln(f.p2);
+  // Check various declarations of a class with the new field present
+  var c1: ReplaceVarConcrete = new ReplaceVarConcrete(10);
+  var c2 = new ReplaceVarConcrete();
+  // Check direct references
+  writeln(c1.newName);
+  writeln(c1.oldName); // Should warn, but show the same value
+  // Check that the two "fields" stay in sync if new field is updated
+  c2.newName += 3;
+  writeln(c2.newName);
+  writeln(c2.oldName); // Should warn, but show the same value
+  // Check that the two "fields" stay in sync if old "field" is updated
+  c2.oldName -= 2; // Should warn
+  writeln(c2.newName);
+  writeln(c2.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a record with the new field present
+  var r1: ReplaceVarConcrete2 = new ReplaceVarConcrete2(10);
+  var r2 = new ReplaceVarConcrete2();
+  var r3: ReplaceVarConcrete2;
+  // Check direct references
+  writeln(r1.newName);
+  writeln(r1.oldName); // Should warn, but show the same value
+  // Check that the two "fields" stay in sync if new field is updated
+  r2.newName += 3;
+  writeln(r2.newName);
+  writeln(r2.oldName); // Should warn, but show the same value
+  // Check that the two "fields" stay in sync if old "field" is updated
+  r3.oldName -= 2; // Should warn
+  writeln(r3.newName);
+  writeln(r3.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a class with the new field present
+  var c4: ReplaceType = new ReplaceType(uint);
+  var c5: ReplaceType(int) = new ReplaceType(int);
+  // Check direct references
+  writeln(c4.newName: string);
+  writeln(c4.oldName: string); // Should warn, but show the same value
+  writeln(c5.newName: string);
+  writeln(c5.oldName: string); // Should warn, but show the same value
+
+  // Check various declarations of a record with the new field present
+  var r4: ReplaceType2 = new ReplaceType2(uint);
+  var r5 = new ReplaceType2(int);
+  var r6: ReplaceType2(bool);
+  // Check direct references
+  writeln(r4.newName: string);
+  writeln(r4.oldName: string); // Should warn, but show the same value
+  writeln(r5.newName: string);
+  writeln(r5.oldName: string); // Should warn, but show the same value
+  writeln(r6.newName: string);
+  writeln(r6.oldName: string); // Should warn, but show the same value
+
+  // Check various declarations of a class with the new field present
+  var c7: ReplaceParam = new ReplaceParam(4);
+  var c8: ReplaceParam(2) = new ReplaceParam(2);
+  // Check direct references
+  writeln(c7.newName);
+  writeln(c7.oldName); // Should warn, but show the same value
+  writeln(c8.newName);
+  writeln(c8.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a record with the new field present
+  var r7: ReplaceParam2 = new ReplaceParam2(4);
+  var r8 = new ReplaceParam2(2);
+  var r9: ReplaceParam2(1);
+  // Check direct references
+  writeln(r7.newName);
+  writeln(r7.oldName); // Should warn, but show the same value
+  writeln(r8.newName);
+  writeln(r8.oldName); // Should warn, but show the same value
+  writeln(r9.newName);
+  writeln(r9.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a class with the new field present
+  var c10: ReplaceConstConcrete = new ReplaceConstConcrete(3);
+  var c11 = new ReplaceConstConcrete(17);
+  // Check direct references
+  writeln(c10.newName);
+  writeln(c10.oldName); // Should warn, but show the same value
+  writeln(c11.newName);
+  writeln(c11.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a record with the new field present
+  var r10: ReplaceConstConcrete2 = new ReplaceConstConcrete2(3);
+  var r11 = new ReplaceConstConcrete2(17);
+  var r12: ReplaceConstConcrete2;
+  // Check direct references
+  writeln(r10.newName);
+  writeln(r10.oldName); // Should warn, but show the same value
+  writeln(r11.newName);
+  writeln(r11.oldName); // Should warn, but show the same value
+  writeln(r12.newName);
+  writeln(r12.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a class with the new field present
+  var c13: ReplaceVarGeneric = new ReplaceVarGeneric(10);
+  var c14 = new ReplaceVarGeneric(0);
+  // Check direct references
+  writeln(c13.newName);
+  writeln(c13.oldName); // Should warn, but show the same value
+  // Check that the two "fields" stay in sync if new field is updated
+  c14.newName += 3;
+  writeln(c14.newName);
+  writeln(c14.oldName); // Should warn, but show the same value
+  // Check that the two "fields" stay in sync if old "field" is updated
+  c14.oldName -= 2; // Should warn
+  writeln(c14.newName);
+  writeln(c14.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a record with the new field present
+  var r13: ReplaceVarGeneric2 = new ReplaceVarGeneric2(10);
+  var r14 = new ReplaceVarGeneric2(0);
+  var r15: ReplaceVarGeneric2(int);
+  // Check direct references
+  writeln(r13.newName);
+  writeln(r13.oldName); // Should warn, but show the same value
+  // Check that the two "fields" stay in sync if new field is updated
+  r14.newName += 3;
+  writeln(r14.newName);
+  writeln(r14.oldName); // Should warn, but show the same value
+  // Check that the two "fields" stay in sync if old "field" is updated
+  r15.oldName -= 2; // Should warn
+  writeln(r15.newName);
+  writeln(r15.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a class with the new field present
+  var c16: ReplaceConstGeneric = new ReplaceConstGeneric(3);
+  var c17 = new ReplaceConstGeneric(17);
+  // Check direct references
+  writeln(c16.newName);
+  writeln(c16.oldName); // Should warn, but show the same value
+  writeln(c17.newName);
+  writeln(c17.oldName); // Should warn, but show the same value
+
+  // Check various declarations of a record with the new field present
+  var r16: ReplaceConstGeneric2 = new ReplaceConstGeneric2(3);
+  var r17 = new ReplaceConstGeneric2(17);
+  var r18: ReplaceConstGeneric2(int);
+  // Check direct references
+  writeln(r16.newName);
+  writeln(r16.oldName); // Should warn, but show the same value
+  writeln(r17.newName);
+  writeln(r17.oldName); // Should warn, but show the same value
+  writeln(r18.newName);
+  writeln(r18.oldName); // Should warn, but show the same value
 }

--- a/test/deprecated-keyword/handleField.good
+++ b/test/deprecated-keyword/handleField.good
@@ -1,4 +1,101 @@
-handleField.chpl:11: In function 'main':
-handleField.chpl:13: warning: Field p1 is deprecated, use p2 instead
+handleField.chpl:109: In function 'main':
+handleField.chpl:115: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:119: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:121: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:123: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:131: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:135: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:137: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:139: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:146: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:148: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:156: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:158: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:160: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:167: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:169: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:177: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:179: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:181: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:188: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:190: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:198: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:200: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:202: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:209: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:213: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:215: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:217: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:225: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:229: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:231: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:233: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:240: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:242: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:250: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:252: warning: The field 'oldName' is deprecated, please use 'newName'
+handleField.chpl:254: warning: The field 'oldName' is deprecated, please use 'newName'
+10
+10
 3
-5
+3
+1
+1
+10
+10
+3
+3
+-2
+-2
+uint(64)
+uint(64)
+int(64)
+int(64)
+uint(64)
+uint(64)
+int(64)
+int(64)
+bool
+bool
+4
+4
+2
+2
+4
+4
+2
+2
+1
+1
+3
+3
+17
+17
+3
+3
+17
+17
+0
+0
+10
+10
+3
+3
+1
+1
+10
+10
+3
+3
+-2
+-2
+3
+3
+17
+17
+3
+3
+17
+17
+0
+0


### PR DESCRIPTION
This PR adds some examples for unclear cases to the deprecated keyword
documentation.  Specifically, it covers:
- changing only a function's return type
- changing only a function's argument name
- deprecating a field

These cases involve a little extra work to maintain the user's experience,
and it would be easy to deprecate them in a way that did not.

Adds tests to the test system that demonstrate these examples:
- deprecating a return type
- deprecating various fields (replaces old "handleField.chpl" test file)
- deprecating a field and adding an explicit initializer so that `Foo(fieldName=val)`
also gives a warning (which also demonstrates the use of "last resort" for changing
argument names

Checked the built docs and the tests individually.  The directory they are in passed
a fresh checkout