### PR TITLE
Extend the title of the section on generic compiler generated initializers

### DIFF
--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -903,8 +903,8 @@ being generic over any other argument that is generic.
 
 .. _Generic_Compiler_Generated_Initializers:
 
-The Compiler-Generated Initializer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Compiler-Generated Generic Initializer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If no user-defined initializers are supplied for a given generic class,
 the compiler generates one in a manner similar to that for


### PR DESCRIPTION
Prior to this change, the title was indistinguishable from that for concrete
compiler-generated initializers.  This was a problem when both links were
side-by-side, as is the case in the first paragraph of the concrete
compiler-generated initializer section, making it look like it linked to itself.

With this change, the section is now distinguishable.

This impacts a total of six links to that section.  Since the references all
indicate that the generic compiler-generated initializer is desired, I think it
is fine for their reference to be updated, but it would be reasonable to double
check me.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>