### PR TITLE
Improve the portability of `touch` used in hwloc to prevent docs build

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -70,8 +70,9 @@ hwloc-config: FORCE
 # newer than $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag prevents make from
 # trying to do that step.
 #
-	touch -m -r  $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -d '+1 sec' $(HWLOC_SUBDIR)/README 2>/dev/null || \
-		touch -m -r $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -A '01' $(HWLOC_SUBDIR)/README
+	-touch -m -r  $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -d '+1 sec' $(HWLOC_SUBDIR)/README 2>/dev/null || \
+		touch -m -r $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -A '01' $(HWLOC_SUBDIR)/README 2>/dev/null || \
+		touch $(HWLOC_SUBDIR)/README
 #
 # Then configure
 #


### PR DESCRIPTION
We have some `touch` commands to prevent hwloc from trying to build the
docs that were added in 19a6dbb6af / 10fd4c9700 and made portable to bsd
in 89da1a2dd1. Recently, we've found the touch commands were failing on
alpine and had reports from users on other distros. To alleviate this,
fallback to a plain touch with no options and allow the command to fail
outright. If the command fails, worst case scenario is the user hits the
original issue where hwloc will try and fail to build the docs, but this
is no worse than our touch causing a fatal error.

Resolves #19444