### PR TITLE
Call init_ofiFabricDomain from chpl_comm_post_mem_init

### DIFF
--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -370,6 +370,21 @@ uint32_t chpl_task_getFixedNumThreads(void) {
 }
 
 //
+// Similar to the above, but only indicates whether or not the tasking
+// layer uses a fixed number of threads. This may be called prior to
+// the initialization of the tasking layer when the number of threads
+// is not yet known.
+//
+
+#ifndef CHPL_TASK_IMPL_HAS_FIXED_NUM_THREADS
+#define CHPL_TASK_IMPL_HAS_FIXED_NUM_THREADS() false
+#endif
+static inline
+chpl_bool chpl_task_hasFixedNumThreads(void) {
+  return CHPL_TASK_IMPL_HAS_FIXED_NUM_THREADS();
+}
+
+//
 // If the tasking layer runs tasks on a fixed number of threads and
 // the calling thread is one of those, this returns true.  Otherwise,
 // it returns false.

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -207,6 +207,10 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
     chpl_task_impl_getFixedNumThreads()
 uint32_t chpl_task_impl_getFixedNumThreads(void);
 
+#define CHPL_TASK_IMPL_HAS_FIXED_NUM_THREADS() \
+    chpl_task_impl_hasFixedNumThreads()
+chpl_bool chpl_task_impl_hasFixedNumThreads(void);
+
 #define CHPL_TASK_IMPL_IS_FIXED_THREAD() (qthread_shep() != NO_SHEPHERD)
 
 #define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() CHPL_QTHREAD_TASKS_CAN_MIGRATE_THREADS

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1043,6 +1043,16 @@ void chpl_comm_post_mem_init(void) {
 
   chpl_comm_init_prv_bcast_tab();
   init_broadcast_private();
+
+  /*
+    Previously this was called by init_ofi which is called by
+    chpl_comm_post_task_init. It's been moved here because fi_domain,
+    which this function calls, is not thread-safe and may cause crashes
+    if threads are using malloc when it is called. Moving it here
+    causes fi_domain to be called before the worker threads are
+    created, avoiding the issue.
+  */
+  init_ofiFabricDomain();
 }
 
 
@@ -1073,7 +1083,21 @@ void chpl_comm_post_task_init(void) {
 
 static
 void init_ofi(void) {
-  init_ofiFabricDomain();
+  if (verbosity >= 2) {
+    if (chpl_nodeID == 0) {
+      void* start;
+      size_t size;
+      chpl_comm_regMemHeapInfo(&start, &size);
+      char buf[10];
+      printf("COMM=ofi: %s MCM mode, \"%s\" provider, \"%s\" device, %s fixed heap\n",
+             mcmModeNames[mcmMode], ofi_info->fabric_attr->prov_name,
+             ofi_info->domain_attr->name,
+             ((size == 0)
+              ? "no"
+              : chpl_snprintf_KMG_z(buf, sizeof(buf), size)));
+    }
+  }
+
   init_ofiDoProviderChecks();
   init_ofiEp();
   init_ofiExchangeAvInfo();
@@ -1575,7 +1599,6 @@ static fnIsProv_t isMsgOrderFenceProv;
 static fnIsProv_t isMsgOrderProv;
 static fnIsProv_t isDlvrCmpltProv;
 
-
 static
 struct fi_info* setCheckMsgOrderFenceProv(struct fi_info* info,
                                           chpl_bool set) {
@@ -1585,6 +1608,10 @@ struct fi_info* setCheckMsgOrderFenceProv(struct fi_info* info,
                              | FI_ORDER_ATOMIC_WAW
                              | FI_ORDER_SAS;
   if (set) {
+    // Only use this mode if the tasking layer has a fixed number of threads.
+    if (chpl_task_hasFixedNumThreads() == false) {
+      return NULL;
+    }
     info = fi_dupinfo(info);
     info->caps |= need_caps;
     info->tx_attr->msg_order = need_msg_orders;
@@ -1593,14 +1620,14 @@ struct fi_info* setCheckMsgOrderFenceProv(struct fi_info* info,
   } else {
     //
     // In addition to needing to be able to support the specific message
-    // ordering settings we require, for message-order-fence mode the
-    // provider has to support bound tx contexts so that we can benefit
-    // from delaying memory visibility.
+    // ordering settings we require, for message-order-fence mode there
+    // must be a fixed number of worker threads so that we can bind
+    // tx contexts to threads and delay memory visibility.
     //
     return ((info->caps & need_caps) == need_caps
             && (info->tx_attr->msg_order & need_msg_orders) == need_msg_orders
             && (info->rx_attr->msg_order & need_msg_orders) == need_msg_orders
-            && canBindTxCtxs(info))
+            && chpl_task_hasFixedNumThreads())
            ? info
            : NULL;
   }
@@ -1623,14 +1650,19 @@ chpl_bool findMsgOrderFenceProv(struct fi_info** p_infoOut,
   const chpl_bool accept_RxM_provs = isInProvName("ofi_rxm", prov_name);
   const chpl_bool accept_sockets_provs = isInProvName("sockets", prov_name);
   enum mcmMode_t mcmm = mcmm_msgOrdFence;
-  chpl_bool ret;
+  chpl_bool ret = false;
 
   if (inputIsHints) {
     struct fi_info* infoAdj = setCheckMsgOrderFenceProv(infoIn, true /*set*/);
-    ret = findProvGivenHints(p_infoOut, infoAdj,
-                             accept_RxD_provs, accept_RxM_provs,
-                             accept_sockets_provs, mcmm);
-    fi_freeinfo(infoAdj);
+    if (infoAdj) {
+      ret = findProvGivenHints(p_infoOut, infoAdj,
+                              accept_RxD_provs, accept_RxM_provs,
+                              accept_sockets_provs, mcmm);
+      fi_freeinfo(infoAdj);
+    } else {
+      DBG_PRINTF_NODE0(DBG_PROV, "** ignoring providers with %s",
+                   mcmModeNames[mcmm]);
+    }
   } else {
     ret = findProvGivenList(p_infoOut, infoIn,
                             accept_RxD_provs, accept_RxM_provs,
@@ -1688,14 +1720,19 @@ chpl_bool findMsgOrderProv(struct fi_info** p_infoOut,
   const chpl_bool accept_RxM_provs = true;
   const chpl_bool accept_sockets_provs = isInProvName("sockets", prov_name);
   enum mcmMode_t mcmm = mcmm_msgOrd;
-  chpl_bool ret;
+  chpl_bool ret = false;
 
   if (inputIsHints) {
     struct fi_info* infoAdj = setCheckMsgOrderProv(infoIn, true /*set*/);
-    ret = findProvGivenHints(p_infoOut, infoAdj,
-                             accept_RxD_provs, accept_RxM_provs,
-                             accept_sockets_provs, mcmm);
-    fi_freeinfo(infoAdj);
+    if (infoAdj) {
+      ret = findProvGivenHints(p_infoOut, infoAdj,
+                              accept_RxD_provs, accept_RxM_provs,
+                              accept_sockets_provs, mcmm);
+      fi_freeinfo(infoAdj);
+    } else {
+      DBG_PRINTF_NODE0(DBG_PROV, "** ignoring providers with %s",
+                   mcmModeNames[mcmm]);
+    }
   } else {
     ret = findProvGivenList(p_infoOut, infoIn,
                             accept_RxD_provs, accept_RxM_provs,
@@ -1747,14 +1784,19 @@ chpl_bool findDlvrCmpltProv(struct fi_info** p_infoOut,
   const chpl_bool accept_RxM_provs = isInProvName("ofi_rxm", prov_name);
   const chpl_bool accept_sockets_provs = isInProvName("sockets", prov_name);
   enum mcmMode_t mcmm = mcmm_dlvrCmplt;
-  chpl_bool ret;
+  chpl_bool ret = false;
 
   if (inputIsHints) {
     struct fi_info* infoAdj = setCheckDlvrCmpltProv(infoIn, true /*set*/);
-    ret = findProvGivenHints(p_infoOut, infoAdj,
-                             accept_RxD_provs, accept_RxM_provs,
-                             accept_sockets_provs, mcmm);
-    fi_freeinfo(infoAdj);
+    if (infoAdj) {
+      ret = findProvGivenHints(p_infoOut, infoAdj,
+                              accept_RxD_provs, accept_RxM_provs,
+                              accept_sockets_provs, mcmm);
+      fi_freeinfo(infoAdj);
+    } else {
+      DBG_PRINTF_NODE0(DBG_PROV, "** ignoring providers with %s",
+                   mcmModeNames[mcmm]);
+    }
   } else {
     ret = findProvGivenList(p_infoOut, infoIn,
                             accept_RxD_provs, accept_RxM_provs,
@@ -1861,7 +1903,7 @@ void init_ofiFabricDomain(void) {
   if (ofi_info == NULL) {
     // Search for a good provider.
     for (int i = 0; ofi_info == NULL && i < capTryLen; i++) {
-      struct fi_info* info;
+      struct fi_info* info = NULL;
       enum mcmMode_t mcmm;
       if ((*capTry[i].fnFind)(&info, &mcmm, hints, true /*inputIsHints*/)) {
         ofi_info = info;
@@ -1929,21 +1971,6 @@ void init_ofiFabricDomain(void) {
 
   DBG_PRINTF_NODE0(DBG_PROV | DBG_PROV_ALL,
                    "====================");
-
-  if (verbosity >= 2) {
-    if (chpl_nodeID == 0) {
-      void* start;
-      size_t size;
-      chpl_comm_regMemHeapInfo(&start, &size);
-      char buf[10];
-      printf("COMM=ofi: %s MCM mode, \"%s\" provider, \"%s\" device, %s fixed heap\n",
-             mcmModeNames[mcmMode], ofi_info->fabric_attr->prov_name,
-             ofi_info->domain_attr->name,
-             ((size == 0)
-              ? "no"
-              : chpl_snprintf_KMG_z(buf, sizeof(buf), size)));
-    }
-  }
 
   //
   // Create the fabric domain and associated fabric access domain.

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1008,4 +1008,10 @@ uint32_t chpl_task_impl_getFixedNumThreads(void) {
     return (uint32_t)qthread_num_workers();
 }
 
+chpl_bool chpl_task_impl_hasFixedNumThreads(void)
+{
+  return true;
+}
+
+
 /* vim:set expandtab: */


### PR DESCRIPTION
Previously `init_ofiFabricDomain` was called by `init_ofi` which is called by `chpl_comm_post_task_init`. This led to seg faults with the `verbs` provider because its implementation of `fi_domain` patches memory-related system calls, causing threads that were already using those system calls to seg fault. Calling `init_ofiFabricDomain` from `chpl_comm_post_mem_init` eliminates the problem because the worker threads have not yet been created, avoiding the race.

Resolves Cray/chapel-private#3193.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>