### PR TITLE
Adjust 2 ugni-specific tests so that they pass for non-sh/bash users.

### DIFF
--- a/test/runtime/configMatters/comm/ugni/hugepage-sanity.skipif
+++ b/test/runtime/configMatters/comm/ugni/hugepage-sanity.skipif
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+# The .wrap file for this test is a bash script that needs the module
+# system to be set up already, although it's okay if it's set up for
+# some other shell.
+
+import os
+print(os.getenv('MODULESHOME') != None)
+

--- a/test/runtime/configMatters/comm/ugni/hugepage-sanity.wrap
+++ b/test/runtime/configMatters/comm/ugni/hugepage-sanity.wrap
@@ -1,8 +1,10 @@
 #! /usr/bin/env bash
 
-# Pluck the execOptsNum out of the execution command line.
+# Pluck the execOptsNum out of the execution command line and do
+# execopts-specific things needed before the test runs.
 case $(echo $1 | sed "s/^.*=\([0-9]\)/\1/") in
-1) module unload $(module -t list 2>&1 | grep craype-hugepages);;
+1) module list &> /dev/null || . $MODULESHOME/init/bash
+   module unload $(module -t list 2>&1 | grep craype-hugepages);;
 esac
 
 exec ./$(basename ${0})-2 $*

--- a/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.skipif
+++ b/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.skipif
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+# The .wrap file for this test is a bash script that needs the module
+# system to be set up already, although it's okay if it's set up for
+# some other shell.
+
+import os
+print(os.getenv('MODULESHOME') != None)
+

--- a/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.wrap
+++ b/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.wrap
@@ -6,6 +6,7 @@
 # heap size so that it's just big enough to cause the message
 # we're testing here.
 #
+module list &> /dev/null || . $MODULESHOME/init/bash
 hpm=$(module -t list 2>&1 | grep craype-hugepages)
 if [[ -n "$hpm" ]] ; then module unload $hpm ; fi
 


### PR DESCRIPTION
The `hugepage-sanity` and `overflow-nic-tlb` test wrappers are `bash`
scripts that need to be able to do `module` commands.  They didn't work
for users whose shell isn't `sh`-derived.  Here, make them do so, by
running the appropriate `module` init script if no parent shell has
already done so.
