### PR TITLE
New version of nbody

### DIFF
--- a/test/studies/shootout/nbody/bradc/nbody-blc.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc.chpl
@@ -1,15 +1,15 @@
 /* The Computer Language Benchmarks Game
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
-   contributed by Albert Sidelnik and Brad Chamberlain
-   derived from the Java version by Mark C. Lewis and Chad Whipkey
+   contributed by Brad Chamberlain
+   derived from the Chapel version by Albert Sidelnik and myself
 */
 
 
 config const n = 10000;       // The number of timesteps to simulate
 
-const pi = 3.141592653589793,
-      solarMass = 4 * pi**2,
+param pi = 3.141592653589793,
+      solarMass = 4 * pi * pi,
       daysPerYear = 365.24;
 
 
@@ -24,9 +24,9 @@ record body {
 }
 
 //
-// the array of bodies that we'll be simulating
+// the bodies that we'll be simulating
 //
-var bodies = [/* sun */
+var bodies = (/* sun */
               new body(mass = solarMass),
 
               /* jupiter */
@@ -64,10 +64,9 @@ var bodies = [/* sun */
                                1.62824170038242295e-03 * daysPerYear,
                               -9.51592254519715870e-05 * daysPerYear),
                       mass =   5.15138902046611451e-05 * solarMass)
-              ];
+              );
 
-const numBodies = bodies.size;    // the number of bodies being simulated
-
+param numBodies = 5;
 
 proc main() {
   initSun();                      // initialize the sun's velocity
@@ -92,21 +91,20 @@ proc initSun() {
 // advance the positions and velocities of all the bodies
 //
 proc advance(dt) {
-  for i in 0..<numBodies {
-    for j in i+1..<numBodies {
-      ref b1 = bodies[i],
-          b2 = bodies[j];
+  for param i in 0..<numBodies {
+    for param j in i+1..<numBodies {
+      const dpos = bodies[i].pos - bodies[j].pos,
+            sumOfSq = sumOfSquares(dpos),
+            mag = dt / (sumOfSq*sqrt(sumOfSq));
 
-      const dpos = b1.pos - b2.pos,
-            mag = dt / sqrt(sumOfSquares(dpos))**3;
-
-      b1.vel -= dpos * b2.mass * mag;
-      b2.vel += dpos * b1.mass * mag;
+      bodies[i].vel -= dpos * bodies[j].mass * mag;
+      bodies[j].vel += dpos * bodies[i].mass * mag;
     }
   }
 
-  for b in bodies do
-    b.pos += dt * b.vel;
+  for param i in 0..<numBodies {
+    bodies[i].pos += dt * bodies[i].vel;
+  }
 }
 
 //
@@ -116,14 +114,10 @@ proc energy() {
   var e = 0.0;
 
   for i in 0..<numBodies {
-    const b1 = bodies[i];
-
-    e += 0.5 * b1.mass * sumOfSquares(b1.vel);
-
+    e += 0.5 * bodies[i].mass * sumOfSquares(bodies[i].vel);
     for j in i+1..<numBodies {
-      const b2 = bodies[j];
-
-      e -= (b1.mass * b2.mass) / sqrt(sumOfSquares(b1.pos - b2.pos));
+      e -= (bodies[i].mass * bodies[j].mass)
+           / sqrt(sumOfSquares(bodies[i].pos - bodies[j].pos));
     }
   }
 

--- a/test/studies/shootout/nbody/bradc/nbody-blc.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc.chpl
@@ -5,11 +5,11 @@
    derived from the Chapel version by Albert Sidelnik and myself
 */
 
+use Math;                     // to get access to 'pi'
 
 config const n = 10000;       // The number of timesteps to simulate
 
-param pi = 3.141592653589793,
-      solarMass = 4 * pi * pi,
+param solarMass = 4 * pi * pi,
       daysPerYear = 365.24;
 
 
@@ -66,7 +66,7 @@ var bodies = (/* sun */
                       mass =   5.15138902046611451e-05 * solarMass)
               );
 
-param numBodies = 5;
+param numBodies = bodies.size;
 
 proc main() {
   initSun();                      // initialize the sun's velocity

--- a/test/studies/shootout/nbody/bradc/nbody-blc.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc.chpl
@@ -94,17 +94,15 @@ proc advance(dt) {
   for param i in 0..<numBodies {
     for param j in i+1..<numBodies {
       const dpos = bodies[i].pos - bodies[j].pos,
-            sumOfSq = sumOfSquares(dpos),
-            mag = dt / (sumOfSq*sqrt(sumOfSq));
+            mag = dt / sqrt(sumOfSquares(dpos))**3;
 
       bodies[i].vel -= dpos * bodies[j].mass * mag;
       bodies[j].vel += dpos * bodies[i].mass * mag;
     }
   }
 
-  for param i in 0..<numBodies {
+  for param i in 0..<numBodies do
     bodies[i].pos += dt * bodies[i].vel;
-  }
 }
 
 //

--- a/test/studies/shootout/nbody/bradc/nbody-blc.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc.chpl
@@ -66,7 +66,7 @@ var bodies = (/* sun */
                       mass =   5.15138902046611451e-05 * solarMass)
               );
 
-param numBodies = bodies.size;
+param numBodies = bodies.size;    // the number of bodies being simulated
 
 proc main() {
   initSun();                      // initialize the sun's velocity


### PR DESCRIPTION
This is a new version of the nbody shootout I made for fun last night
that:
* changes consts to params
* changes an array to a tuple
* changes loops to param loops
* gets rid of the refs (used to be crucial for perf, here don't seem to be)

In the commit history of this PR, you'll also find:
* implements a little numerical change to the sqrt of the sum of squares
  (which may be in the noise)
though I ended up backing this out because the impact was modest and
it felt slightly too heroic for my tastes / I was trying to minimize diffs with
the previously submitted version.

On my personal Mac laptop where I was developing this, I saw these
changes improve the performance from 2.53s to 1.56s.  On my (older)
work Mac, the changes were more modest as a percentage:  from
4.28s down to 3.18s.

Elliot took the following more precise timings:

```sh
chpl test/studies/shootout/nbody/bradc/nbody-blc.chpl --fast
time -p ./nbody-blc --n=50000000 >/dev/null
```

| Config | Time  |
| ------ | ----: |
| before | 4.95s |
| now    | 3.91s |


And checking which components make the biggest difference:

| Config          | Time  |
| --------------- | ----: |
| before          | 4.95s |
| param pi        | 4.95s |
| tuple bodies    | 4.22s |
| param numBodies | 4.06s |
| param loops     | 3.91s |
| sumOfSq trick   | 3.70s |
| now             | 3.91s |

Testing:
- [x] correctness
- [x] performance
- [x] valgrind
- [x] memleaks
- [x] asan