### PR TITLE
Fix split of directory name into prefix and value

### DIFF
--- a/util/chplenv/printchplbuilds.py
+++ b/util/chplenv/printchplbuilds.py
@@ -106,7 +106,7 @@ def Parse(path):
         nextState = nextStates[state]
         j = i + 1
         if state == State.PREFIX and '-' in component:
-            fields = component.split('-')
+            fields = component.split('-', 1)
             (prefix, value) = fields[0:2]
             var = prefixes[prefix]
             config[var] = value


### PR DESCRIPTION
A value may contain '-', so only split the prefix from the value based on the first '-'.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>