### PR TITLE
Workaround an AddressSanitizer bug with some gcc versions

### DIFF
--- a/doc/rst/developer/bestPractices/Sanitizers.rst
+++ b/doc/rst/developer/bestPractices/Sanitizers.rst
@@ -23,6 +23,7 @@ To use AddressSanitizer with Chapel (compiler and executables):
      export CHPL_TASKS=fifo
      export CHPL_LLVM=none
      export CHPL_SANITIZE=address
+     export ASAN_OPTIONS="use_sigaltstack=0,detect_leaks=0"
      export ASAN_OPTIONS=detect_leaks=0
 
      cd $CHPL_HOME
@@ -48,8 +49,9 @@ To get better stack traces when optimizations are enabled:
 
      Non-chplenv environment variables aren't propagated by paratest. So,
      to turn off leak checking, it is necessary to either pass
-     ``-env ASAN_OPTIONS=detect_leaks=0`` or to include
-     ``export ASAN_OPTIONS=detect_leaks=0`` in .bashrc or the equivalent.
+     ``-env ASAN_OPTIONS="use_sigaltstack=0,detect_leaks=0"`` or to include
+     ``export ASAN_OPTIONS="use_sigaltstack=0,detect_leaks=0"`` in .bashrc or
+     the equivalent.
 
 Limitations
 -----------
@@ -100,6 +102,10 @@ sanitizers. In particular:
   Chapel intentionally leaks some memory in the runtime, so we disable
   that tracking for now. See :ref:`readme-debugging` for more info about
   debugging memory leaks in Chapel.
+- An upstream bug_ can result in false-positives for some gcc versions.
+  ``use_sigaltstack=0`` works around this.
+
+  .. _bug: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=101476
 
 
 Other Sanitizers

--- a/util/cron/common-asan.bash
+++ b/util/cron/common-asan.bash
@@ -8,5 +8,5 @@ export CHPL_MEM=cstdlib
 export CHPL_TASKS=fifo
 export CHPL_LLVM=none
 export CHPL_SANITIZE=address
-export ASAN_OPTIONS=detect_leaks=0
+export ASAN_OPTIONS="use_sigaltstack=0,detect_leaks=0"
 export CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET=yes


### PR DESCRIPTION
For some gcc versions we've been seeing stack overflows when destroying
our pthreads. When running with `chpl_alloc_stack_in_heap=false` we see

```
CHECK failed: "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)
```

Which matches https://gcc.gnu.org/bugzilla//show_bug.cgi?id=101476. Work
around this for now by setting ASAN_OPTIONS="use_sigaltstack=0"

Resolves Cray/chapel-private#3154