### PR TITLE
Bump Sphinx Chapel domain version number

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 sphinx-rtd-theme==1.0.0
-sphinxcontrib-chapeldomain==0.0.21
+sphinxcontrib-chapeldomain==0.0.22
 breathe==4.31.0


### PR DESCRIPTION
Not really very much important in the new version, it's mostly repo clean ups,
but we might as well track the latest release.

Passed `make docs` and a full standard paratest