### PR TITLE
Update the test to handle different number of GPUs per locale

### DIFF
--- a/test/gpu/native/multiGPU/multiGPU.chpl
+++ b/test/gpu/native/multiGPU/multiGPU.chpl
@@ -4,6 +4,8 @@ config const alpha = 10;
 
 config const writeArrays = true;
 
+writeln("Number of sublocales: ", here.getChildCount());
+
 for subloc in 1..here.getChildCount()-1 do on here.getChild(subloc) {
   var A: [1..n] int;
   var B: [1..n] int;

--- a/test/gpu/native/multiGPU/multiGPU.good
+++ b/test/gpu/native/multiGPU/multiGPU.good
@@ -1,8 +1,0 @@
-      4 Kernel launcher called. (subloc 1)
-      4 Kernel launcher called. (subloc 2)
-      4 Kernel launcher called. (subloc 3)
-      4 Kernel launcher called. (subloc 4)
-      4 Kernel launcher called. (subloc 5)
-      4 Kernel launcher called. (subloc 6)
-      4 Kernel launcher called. (subloc 7)
-      4 Kernel launcher called. (subloc 8)

--- a/test/gpu/native/multiGPU/multiGPU.prediff
+++ b/test/gpu/native/multiGPU/multiGPU.prediff
@@ -1,4 +1,15 @@
 #!/bin/bash
 
+# create the good file based on the number of children reported by the locale
+# model
+num_gpus=$(awk '/Number of sublocales.*/ {print $NF;}' < $2)
+num_gpus=$((num_gpus-1))
+
+for i in $(seq 1 $num_gpus);
+do
+  echo "      4 Kernel launcher called. (subloc $i)" > $1.good
+done
+
+# filter kernel launches and count them
 grep 'Kernel launch' $2 | sort | uniq -c > $2.new
 mv $2.new $2


### PR DESCRIPTION
This test was added to test the multiple GPU support. However, its good file was
pretty hardwired for 8 GPUs per node, which matches our current nightly testing
machine. It caused this test to fail for any other number of GPUs in the node.

This PR adjusts the test in question to report number of sublocales first. Then,
the prediff generates the expected good file based on that number.


Test:
- [x] The test passes on two other systems
