### PR TITLE
Fix memory fragmentation tests on 32-bit systems

### DIFF
--- a/test/runtime/configMatters/mem/fragmentation/MemUtil.chpl
+++ b/test/runtime/configMatters/mem/fragmentation/MemUtil.chpl
@@ -10,5 +10,9 @@ proc availMem() {
   chpl_comm_regMemHeapInfo(unused, heap_size);
   if heap_size != 0 then
     return heap_size.safeCast(int);
-  return here.physicalMemory(unit = MemUnits.Bytes);
+
+  var physMem = here.physicalMemory(unit = MemUnits.Bytes);
+  if numBits(c_size_t) < 64 then
+    physMem = min(physMem, 2**30);
+  return physMem;
 }


### PR DESCRIPTION
These tests use ~1/4 of physical memory, but on 32-bit systems there can
be more physical memory than a single process can access. Adjust here to
say there's only 1 GB available on 32-bit systems.