### PR TITLE
Increase nodepara for chapcs testing

### DIFF
--- a/util/cron/test-asan.bash
+++ b/util/cron/test-asan.bash
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="asan"
 
-$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 6)
+$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 8)

--- a/util/cron/test-fast.bash
+++ b/util/cron/test-fast.bash
@@ -10,4 +10,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="fast"
 
-$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args)
+$CWD/nightly -cron ${nightly_args} $(get_nightly_paratest_args 8)

--- a/util/cron/test-gasnet-asan.bash
+++ b/util/cron/test-gasnet-asan.bash
@@ -23,5 +23,5 @@ export CHPL_RT_CACHE_QUIET=true
 export CHPL_COMM_SUBSTRATE=udp
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -multilocale ${nightly_args} $(get_nightly_paratest_args 6)
+$CWD/nightly -cron -multilocale ${nightly_args} $(get_nightly_paratest_args 8)
 

--- a/util/cron/test-gasnet-everything.bash
+++ b/util/cron/test-gasnet-everything.bash
@@ -13,4 +13,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -futures $(get_nightly_paratest_args 6)
+$CWD/nightly -cron -futures $(get_nightly_paratest_args 8)

--- a/util/cron/test-gasnet-fast.bash
+++ b/util/cron/test-gasnet-fast.bash
@@ -13,4 +13,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the fast segment
 export CHPL_GASNET_SEGMENT=fast
 
-$CWD/nightly -cron -multilocale $(get_nightly_paratest_args 6)
+$CWD/nightly -cron -multilocale $(get_nightly_paratest_args 8)

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
-$CWD/nightly -cron -mason -protobuf -futures ${nightly_args} $(get_nightly_paratest_args 6)
+$CWD/nightly -cron -mason -protobuf -futures ${nightly_args} $(get_nightly_paratest_args 8)

--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -12,4 +12,4 @@ unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrind"
 
-$CWD/nightly -cron -valgrind -examples ${nightly_args} $(get_nightly_paratest_args 6)
+$CWD/nightly -cron -valgrind -examples ${nightly_args} $(get_nightly_paratest_args 8)

--- a/util/cron/test-valgrindexe.bash
+++ b/util/cron/test-valgrindexe.bash
@@ -12,4 +12,4 @@ unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrindexe"
 
-$CWD/nightly -cron -valgrindexe ${nightly_args} $(get_nightly_paratest_args 6)
+$CWD/nightly -cron -valgrindexe ${nightly_args} $(get_nightly_paratest_args 8)


### PR DESCRIPTION
Increase the amount of oversubscription we use for chapcs testing so
it's available earlier for paratests. Note that `--fast` testing was
moved to chapcs from a weaker machine since it was taking ~24 hours,
hence the bump from 2->8 nodepara compared to 6->8 for other configs.