### PR TITLE
Add nightly M1 Mac testing

### DIFF
--- a/test/release/examples/primers/fileIO.suppressif
+++ b/test/release/examples/primers/fileIO.suppressif
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import os
+
+platform = os.getenv('CHPL_TARGET_PLATFORM')
+arch = os.getenv('CHPL_TARGET_ARCH')
+comp = os.getenv('CHPL_TARGET_COMPILER')
+
+print(platform == 'darwin' and arch == 'arm64' and comp == 'llvm')

--- a/util/cron/test-darwin-m1.bash
+++ b/util/cron/test-darwin-m1.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Test examples for default configuration on M1 darwin
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+source $CWD/common-darwin.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
+
+$CWD/nightly -cron -examples


### PR DESCRIPTION
Add comm=none release/example M1 testing. We want to increase the amount
of testing we do over time, but to start we just want to get some
testing going. Note that this adds a suppression for a known bug with
the fileIO primer on M1 (#19218)

Part of Cray/chapel-private#2625