### PR TITLE
Use LLVM ADTs to improve compile times

### DIFF
--- a/compiler/AST/ImportStmt.cpp
+++ b/compiler/AST/ImportStmt.cpp
@@ -406,15 +406,15 @@ void ImportStmt::validateUnqualified() {
 * to find its methods.                                                        *
 *                                                                             *
 ************************************** | *************************************/
-std::set<const char*> ImportStmt::typeWasNamed(Type* t) const {
-  std::set<const char*> namedTypes;
+ImportStmt::PtrSet<const char*> ImportStmt::typeWasNamed(Type* t) const {
+  PtrSet<const char*> namedTypes;
 
   typeWasNamed(t, &namedTypes);
   return namedTypes;
 }
 
 void ImportStmt::typeWasNamed(Type* t,
-                              std::set<const char*>* namedTypes) const {
+                              PtrSet<const char*>* namedTypes) const {
   // We don't define any symbols for unqualified access, so the type was not
   // listed
   if (!providesUnqualifiedAccess()) {

--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -32,6 +32,8 @@
 
 #include <algorithm>
 
+#include "llvm/ADT/SmallPtrSet.h"
+
 UseStmt::UseStmt(BaseAST* source, const char* modRename,
                  bool isPrivate) : VisibilityStmt(E_UseStmt) {
   this->isPrivate = isPrivate;
@@ -428,14 +430,14 @@ void UseStmt::writeListPredicate(FILE* mFP) const {
 * to find its methods.                                                        *
 *                                                                             *
 ************************************** | *************************************/
-std::set<const char*> UseStmt::typeWasNamed(Type* t) const {
-  std::set<const char*> namedTypes;
+PtrSet<const char*> UseStmt::typeWasNamed(Type* t) const {
+  PtrSet<const char*> namedTypes;
 
   typeWasNamed(t, &namedTypes);
   return namedTypes;
 }
 
-void UseStmt::typeWasNamed(Type* t, std::set<const char*>* namedTypes) const {
+void UseStmt::typeWasNamed(Type* t, PtrSet<const char*>* namedTypes) const {
   if (isPlainUse() == true) {
     // We don't limit the use in any way, so we don't need special handling to
     // find methods

--- a/compiler/include/ImportStmt.h
+++ b/compiler/include/ImportStmt.h
@@ -28,7 +28,12 @@
 
 class ResolveScope;
 
+#include "llvm/ADT/SmallPtrSet.h"
+
 class ImportStmt final : public VisibilityStmt {
+
+  template <typename T, size_t N = 8> using PtrSet = llvm::SmallPtrSet<T, N>;
+
  public:
   ImportStmt(BaseAST* source, bool isPrivate = true);
   ImportStmt(BaseAST* source, const char* rename, bool isPrivate = true);
@@ -53,8 +58,8 @@ class ImportStmt final : public VisibilityStmt {
 
   BaseAST* getSearchScope() const override;
 
-  std::set<const char*> typeWasNamed(Type* t) const override;
-  void typeWasNamed(Type* t, std::set<const char*>* namedTypes) const;
+  PtrSet<const char*> typeWasNamed(Type* t) const override;
+  void typeWasNamed(Type* t, PtrSet<const char*>* namedTypes) const;
 
   bool skipSymbolSearch(const char* name) const override;
 

--- a/compiler/include/ResolutionCandidate.h
+++ b/compiler/include/ResolutionCandidate.h
@@ -24,6 +24,8 @@
 #include "baseAST.h"
 #include "vec.h"
 
+#include "llvm/ADT/SmallVector.h"
+
 #include <map>
 #include <vector>
 
@@ -100,8 +102,8 @@ public:
                                        VisibilityInfo* visInfo);
 
   FnSymbol*               fn;
-  std::vector<Symbol*>    formalIdxToActual;
-  std::vector<ArgSymbol*> actualIdxToFormal;
+  llvm::SmallVector<Symbol*, 8>    formalIdxToActual;
+  llvm::SmallVector<ArgSymbol*, 8> actualIdxToFormal;
 
   // One ImplementsStmt per IfcConstraint when 'fn' is CG
   std::vector<ImplementsStmt*> witnessIstms;

--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -23,10 +23,16 @@
 
 #include "stmt.h"
 
+#include "llvm/ADT/SmallPtrSet.h"
+
+
 class ResolveScope;
 
 class UseStmt final : public VisibilityStmt {
-public:
+
+  template <typename T, size_t N = 8> using PtrSet = llvm::SmallPtrSet<T, N>;
+
+ public:
   UseStmt(BaseAST* source, const char* modRename, bool isPrivate);
 
   UseStmt(BaseAST*                            source,
@@ -62,8 +68,8 @@ public:
   UseStmt*        applyOuterUse(const UseStmt* outer);
   ImportStmt*     applyOuterImport(const ImportStmt* outer);
 
-  std::set<const char*> typeWasNamed(Type* t) const override;
-  void typeWasNamed(Type* t, std::set<const char*>* namedTypes) const;
+  PtrSet<const char*> typeWasNamed(Type* t) const override;
+  void typeWasNamed(Type* t, PtrSet<const char*>* namedTypes) const;
 
   bool            skipSymbolSearch(const char* name)            const override;
 

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -23,6 +23,8 @@
 
 #include "baseAST.h"
 #include "alist.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include <vector>
 #include <set>
@@ -66,6 +68,7 @@ void collect_top_asts(BaseAST* ast, std::vector<BaseAST*>& asts);
 void collectExprs(BaseAST* ast, std::vector<Expr*>& exprs);
 void collect_stmts(BaseAST* ast, std::vector<Expr*>& stmts);
 void collectDefExprs(BaseAST* ast, std::vector<DefExpr*>& defExprs);
+void collectDefExprs(BaseAST* ast, llvm::SmallVectorImpl<DefExpr*>& defExprs);
 void collectForallStmts(BaseAST* ast, std::vector<ForallStmt*>& forallStmts);
 void collectCallExprs(BaseAST* ast, std::vector<CallExpr*>& callExprs);
 void collectMyCallExprs(BaseAST* ast,
@@ -73,6 +76,7 @@ void collectMyCallExprs(BaseAST* ast,
                         FnSymbol* fn);
 void collectGotoStmts(BaseAST* ast, std::vector<GotoStmt*>& gotoStmts);
 void collectSymExprs(BaseAST* ast, std::vector<SymExpr*>& symExprs);
+void collectSymExprs(BaseAST* ast, llvm::SmallVectorImpl<SymExpr*>& symExprs);
 void collectSymExprsFor(BaseAST* ast, Symbol* sym, std::vector<SymExpr*>& symExprs);
 void collectSymExprsFor(BaseAST* ast, const Symbol* sym1, const Symbol* sym2,
                         std::vector<SymExpr*>& symExprs);
@@ -106,6 +110,7 @@ void collectSymbolSetSymExprVec(BaseAST* ast,
 //
 void collectSymbolSet(BaseAST* ast, Vec<Symbol*>& symSet);
 void collectSymbolSet(BaseAST* ast, std::set<Symbol*>& symSet);
+void collectSymbolSet(BaseAST* ast, llvm::SmallPtrSetImpl<Symbol*>& symSet);
 
 
 //

--- a/compiler/include/scopeResolve.h
+++ b/compiler/include/scopeResolve.h
@@ -21,6 +21,9 @@
 #ifndef _SCOPE_RESOLVE_H_
 #define _SCOPE_RESOLVE_H_
 
+#include "llvm/ADT/SmallVector.h"
+
+class astlocT;
 class BaseAST;
 class CallExpr;
 class DefExpr;
@@ -42,7 +45,7 @@ Symbol*  lookup(const char*           name,
 
 void     lookup(const char*           name,
                 BaseAST*              context,
-                std::vector<Symbol*>& symbols,
+                llvm::SmallVectorImpl<Symbol*>& symbols,
                 std::map<Symbol*, astlocT*>& renameLocs,
                 std::map<Symbol*, VisibilityStmt*>& reexportPts,
                 bool storeRenames = false);
@@ -60,7 +63,7 @@ Symbol*  lookupAndCount(const char*           name,
 Symbol* lookupInModuleOrBuiltins(ModuleSymbol* mod, const char* name,
                                 int& nSymbolsFound);
 
-void checkConflictingSymbols(std::vector<Symbol *>& symbols,
+void checkConflictingSymbols(llvm::SmallVectorImpl<Symbol *>& symbols,
                              const char* name,
                              BaseAST* context,
                              bool storeRenames,

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -28,6 +28,8 @@
 #include <map>
 #include <set>
 
+#include "llvm/ADT/SmallPtrSet.h"
+
 #ifdef HAVE_LLVM
 
 #define FNAME(str) (llvm::Twine(getFunction()->cname)            + \
@@ -60,6 +62,9 @@ class ResolveScope;
 
 // parent base class for UseStmt and ImportStmt
 class VisibilityStmt : public Stmt {
+
+  template <typename T, size_t N = 8> using PtrSet = llvm::SmallPtrSet<T, N>;
+
  public:
   VisibilityStmt(AstTag astTag);
  ~VisibilityStmt() override = default;
@@ -69,7 +74,7 @@ class VisibilityStmt : public Stmt {
   const char* getRename() const;
   const char* getRenamedSym(const char* name) const;
 
-  virtual std::set<const char*> typeWasNamed(Type* t) const = 0;
+  virtual PtrSet<const char*> typeWasNamed(Type* t) const = 0;
 
   virtual bool skipSymbolSearch(const char* name) const = 0;
 

--- a/compiler/include/visibleFunctions.h
+++ b/compiler/include/visibleFunctions.h
@@ -31,6 +31,11 @@ class CallInfo;
 class Expr;
 class FnSymbol;
 
+#include "llvm/ADT/SmallPtrSet.h"
+
+template <typename T, size_t N=8>
+using PtrSet = llvm::SmallPtrSet<T, N>;
+
 class VisibilityInfo {
 public:
   // for proper scope traversal
@@ -58,14 +63,14 @@ void       findVisibleFunctionsAllPOIs(CallInfo&       info,
 
 void       findVisibleFunctions(CallInfo&             info,
                                 VisibilityInfo*       visInfo,
-                                std::set<BlockStmt*>* visited,
+                                PtrSet<BlockStmt*>* visited,
                                 int*                  numVisitedP,
                                 Vec<FnSymbol*>&       visibleFns);
 
 void       getMoreVisibleFunctionsOrMethods(const char*  name,
                                 CallExpr*                call,
                                 VisibilityInfo*          visInfo,
-                                std::set<BlockStmt*>*    visited,
+                                PtrSet<BlockStmt*>*    visited,
                                 Vec<FnSymbol*>&          visibleFns);
 
 void       getVisibleFunctions(const char*      name,

--- a/compiler/include/wrappers.h
+++ b/compiler/include/wrappers.h
@@ -23,20 +23,22 @@
 
 #include <vector>
 
+#include "llvm/ADT/SmallVector.h"
+
 class ArgSymbol;
 class CallInfo;
 class FnSymbol;
 
 FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
                                 CallInfo&                info,
-                                std::vector<ArgSymbol*>& actualIdxToFormal,
+                                llvm::SmallVectorImpl<ArgSymbol*>& actualIdxToFormal,
                                 bool                     fastFollowerChecks);
 
 const char* unwrapFnName(FnSymbol* fn);
 
 bool isPromotionRequired(FnSymbol* fn,
                          CallInfo& info,
-                         std::vector<ArgSymbol*>& actualIdxToFormal);
+                         llvm::SmallVectorImpl<ArgSymbol*>& actualIdxToFormal);
 
 FnSymbol* findExistingDefaultedActualFn(FnSymbol* fn, ArgSymbol* formal);
 FnSymbol* getOrCreateDefaultedActualFn(FnSymbol* fn, ArgSymbol* formal);

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -87,12 +87,13 @@ static bool isDeadVariable(Symbol* var) {
 }
 
 void deadVariableElimination(FnSymbol* fn) {
-  std::set<Symbol*> symSet;
+  llvm::SmallPtrSet<Symbol*, 32> symSet;
   collectSymbolSet(fn, symSet);
 
   // Use 'symSet' and 'todo' together for a unique queue of symbols to process
   std::queue<Symbol*> todo;
-  for_set(Symbol, sym, symSet) {
+  // for_set(Symbol, sym, symSet) {
+  for(Symbol* sym : symSet) {
     todo.push(sym);
   }
 

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -102,10 +102,9 @@ ResolveScope* ResolveScope::findOrCreateScopeFor(DefExpr* def) {
 }
 
 ResolveScope* ResolveScope::getScopeFor(BaseAST* ast) {
-  std::map<BaseAST*, ResolveScope*>::iterator it;
   ResolveScope*                               retval = NULL;
 
-  it = sScopeMap.find(ast);
+  auto it = sScopeMap.find(ast);
 
   if (it != sScopeMap.end()) {
     retval = it->second;
@@ -115,9 +114,7 @@ ResolveScope* ResolveScope::getScopeFor(BaseAST* ast) {
 }
 
 void ResolveScope::destroyAstMap() {
-  std::map<BaseAST*, ResolveScope*>::iterator it;
-
-  for (it = sScopeMap.begin(); it != sScopeMap.end(); it++) {
+  for (auto it = sScopeMap.begin(); it != sScopeMap.end(); it++) {
     delete it->second;
   }
 

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -52,10 +52,11 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "view.h"
+#include "llvm/ADT/DenseMap.h"
 
 ResolveScope* rootScope;
 
-static std::map<BaseAST*, ResolveScope*> sScopeMap;
+static llvm::DenseMap<BaseAST*, ResolveScope*> sScopeMap;
 
 ResolveScope* ResolveScope::getRootModule() {
   ResolveScope* retval = new ResolveScope(theProgram, NULL);
@@ -1203,7 +1204,7 @@ ResolveScope::lookupPublicUnqualAccessSyms(const char* name,
               bool followUses) {
   if (!this->canReexport) return NULL;
 
-  std::vector<Symbol *> symbols;
+  llvm::SmallVector<Symbol *, 4> symbols;
 
   bool traversedRenames = false;
   bool hasPublicVisStmt = false;

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1419,7 +1419,7 @@ void addMentionToEndOfStatement(Expr* node, CallExpr* existingEndOfStatement) {
     return;
 
   // Gather symexprs used in the statement
-  std::vector<SymExpr*> mentions;
+  llvm::SmallVector<SymExpr*, 32> mentions;
   collectSymExprs(node, mentions);
 
   SET_LINENO(node);
@@ -1444,7 +1444,7 @@ void addMentionToEndOfStatement(Expr* node, CallExpr* existingEndOfStatement) {
   // the variable lifetime still matches the user's view of the code.
   // A reasonable alternative would be for transformations such as
   // the removal of .type blocks to add such SymExprs.
-  for_vector(SymExpr, se, mentions) {
+  for (SymExpr* se : mentions) {
     if (VarSymbol* var = toVarSymbol(se->symbol())) {
       if (!var->hasFlag(FLAG_TEMP) &&
           !var->isParameter() &&

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -43,6 +43,8 @@
 #include "view.h"
 #include "visibleFunctions.h"
 #include "wellknown.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include "global-ast-vecs.h"
 
@@ -50,6 +52,9 @@
 #include <map>
 #include <set>
 #include <stack>
+
+template<typename T, size_t N=8>
+using SmallVector = llvm::SmallVector<T, N>;
 
 /************************************* | **************************************
 *                                                                             *
@@ -90,7 +95,7 @@ static
 bool lookupThisScopeAndUses(const char*           name,
                             BaseAST*              context,
                             BaseAST*              scope,
-                            std::vector<Symbol*>& symbols,
+                            llvm::SmallVectorImpl<Symbol*>& symbols,
                             bool skipExternBlocks,
                             std::map<Symbol*, astlocT*>& renameLocs,
                             bool storeRenames,
@@ -1669,23 +1674,24 @@ static void lookup(const char*           name,
                    BaseAST*              context,
 
                    BaseAST*              scope,
-                   Vec<BaseAST*>&        visited,
+                   llvm::SmallPtrSetImpl<BaseAST*>&        visited,
 
-                   std::vector<Symbol*>& symbols,
+                   llvm::SmallVectorImpl<Symbol*>& symbols,
                    std::map<Symbol*, astlocT*>& renameLocs,
                    bool storeRenames,
                    std::map<Symbol*, VisibilityStmt*>& reexportPts);
 
 // Show what symbols from 'symbols' conflict with the given 'sym'.
 static void
-printConflictingSymbols(std::vector<Symbol*>& symbols, Symbol* sym,
+printConflictingSymbols(llvm::SmallVectorImpl<Symbol*>& symbols, Symbol* sym,
                         const char* nameUsed, bool storeRenames,
                         std::map<Symbol*, astlocT*> renameLocs,
                         std::map<Symbol*, VisibilityStmt*>& reexportPts)
 {
   Symbol* sampleFunction = NULL;
-  for_vector(Symbol, another, symbols) if (another != sym)
+  for(Symbol* another : symbols)
   {
+    if (another == sym) continue;
     if (isFnSymbol(another))
       sampleFunction = another;
     else {
@@ -1712,7 +1718,7 @@ printConflictingSymbols(std::vector<Symbol*>& symbols, Symbol* sym,
               "also defined as a function here (and possibly elsewhere)");
 }
 
-void checkConflictingSymbols(std::vector<Symbol *>& symbols,
+void checkConflictingSymbols(llvm::SmallVectorImpl<Symbol *>& symbols,
                              const char* name,
                              BaseAST* context,
                              bool storeRenames,
@@ -1722,7 +1728,7 @@ void checkConflictingSymbols(std::vector<Symbol *>& symbols,
   // If they're all functions
   //   then      assume function resolution will be applied
   //   otherwise fail
-  for_vector(Symbol, sym, symbols) {
+  for(Symbol* sym : symbols) {
     if (!isFnSymbol(sym)) {
       if (std::count(failedUSymExprs.begin(),
                      failedUSymExprs.end(),
@@ -1747,7 +1753,7 @@ void checkConflictingSymbols(std::vector<Symbol *>& symbols,
   }
 }
 
-static void eliminateLastResortSyms(std::vector<Symbol*>& symbols) {
+static void eliminateLastResortSyms(SmallVector<Symbol*>& symbols) {
   bool anyLastResort = false;
   bool anyNotLastResort = false;
   for (auto sym : symbols) {
@@ -1762,7 +1768,7 @@ static void eliminateLastResortSyms(std::vector<Symbol*>& symbols) {
 
   if (anyLastResort && anyNotLastResort) {
     // Gather the not-last-resort symbols into tmp and swap
-    std::vector<Symbol*> tmp;
+    SmallVector<Symbol*> tmp;
     for (auto sym : symbols) {
       if (!sym->hasFlag(FLAG_LAST_RESORT))
         tmp.push_back(sym);
@@ -1780,7 +1786,7 @@ Symbol* lookupAndCount(const char*           name,
                        astlocT** renameLoc,
                        bool issueErrors) {
 
-  std::vector<Symbol*> symbols;
+  SmallVector<Symbol*> symbols;
   std::map<Symbol*, astlocT*> renameLocs;
   std::map<Symbol*, VisibilityStmt*> reexportPts;
   Symbol*              retval = NULL;
@@ -1837,11 +1843,11 @@ Symbol* lookup(const char* name, BaseAST* context) {
 
 void lookup(const char*           name,
             BaseAST*              context,
-            std::vector<Symbol*>& symbols,
+            llvm::SmallVectorImpl<Symbol*>& symbols,
             std::map<Symbol*, astlocT*>& renameLocs,
             std::map<Symbol*, VisibilityStmt*>& reexportPts,
             bool storeRenames) {
-  Vec<BaseAST*> visited;
+  llvm::SmallPtrSet<BaseAST*, 32> visited;
 
   lookup(name, context, context, visited, symbols, renameLocs, storeRenames,
          reexportPts);
@@ -1851,15 +1857,15 @@ static void lookup(const char*           name,
                    BaseAST*              context,
 
                    BaseAST*              scope,
-                   Vec<BaseAST*>&        visited,
+                   llvm::SmallPtrSetImpl<BaseAST*>&        visited,
 
-                   std::vector<Symbol*>& symbols,
+                   llvm::SmallVectorImpl<Symbol*>& symbols,
                    std::map<Symbol*, astlocT*>& renameLocs,
                    bool storeRenames,
                    std::map<Symbol*, VisibilityStmt*>& reexportPts) {
 
-  if (!visited.set_in(scope)) {
-    visited.set_add(scope);
+  if (!visited.contains(scope)) {
+    visited.insert(scope);
 
     if (lookupThisScopeAndUses(name, context, scope, symbols,
                                /* skipExternBlocks */ false,
@@ -1941,7 +1947,8 @@ static void lookup(const char*           name,
 *                                                                             *
 ************************************** | *************************************/
 
-static bool      isRepeat(Symbol* toAdd, const std::vector<Symbol*>& symbols);
+static bool      isRepeat(Symbol* toAdd,
+                          const llvm::SmallVectorImpl<Symbol*>& symbols);
 
 static Symbol*   inSymbolTable(const char* name, BaseAST* scope);
 
@@ -1954,7 +1961,7 @@ static FnSymbol* getMethod(const char* name, Type* type);
 static void lookupUseImport(const char*           name,
                             BaseAST*              context,
                             BaseAST*              scope,
-                            std::vector<Symbol*>& symbols,
+                            llvm::SmallVectorImpl<Symbol*>& symbols,
                             std::map<Symbol*, astlocT*>& renameLocs,
                             bool storeRenames,
                             std::map<Symbol*, VisibilityStmt*>& reexportPts,
@@ -1965,7 +1972,7 @@ static void lookupUseImport(const char*           name,
 static void lookupUsedImportedMod(const char*           name,
                                   BaseAST*              context,
                                   BaseAST*              scope,
-                                  std::vector<Symbol*>& symbols,
+                                  llvm::SmallVectorImpl<Symbol*>& symbols,
                                   std::map<Symbol*, astlocT*>& renameLocs,
                                   bool storeRenames,
                                   bool forShadowScope,
@@ -1976,7 +1983,7 @@ static
 bool lookupThisScopeAndUses(const char*           name,
                             BaseAST*              context,
                             BaseAST*              scope,
-                            std::vector<Symbol*>& symbols,
+                            llvm::SmallVectorImpl<Symbol*>& symbols,
                             bool skipExternBlocks,
                             std::map<Symbol*, astlocT*>& renameLocs,
                             bool storeRenames,
@@ -2098,7 +2105,7 @@ bool lookupThisScopeAndUses(const char*           name,
 static void lookupUseImport(const char*           name,
                             BaseAST*              context,
                             BaseAST*              scope,
-                            std::vector<Symbol*>& symbols,
+                            llvm::SmallVectorImpl<Symbol*>& symbols,
                             std::map<Symbol*, astlocT*>& renameLocs,
                             bool storeRenames,
                             std::map<Symbol*, VisibilityStmt*>& reexportPts,
@@ -2295,7 +2302,7 @@ static void lookupUseImport(const char*           name,
 static void lookupUsedImportedMod(const char*           name,
                                   BaseAST*              context,
                                   BaseAST*              scope,
-                                  std::vector<Symbol*>& symbols,
+                                  llvm::SmallVectorImpl<Symbol*>& symbols,
                                   std::map<Symbol*, astlocT*>& renameLocs,
                                   bool storeRenames,
                                   bool forShadowScope,
@@ -2360,16 +2367,9 @@ static void lookupUsedImportedMod(const char*           name,
 
 
 // Returns true if the symbol is present in the vector, false otherwise
-static bool isRepeat(Symbol* toAdd, const std::vector<Symbol*>& symbols) {
-  for (std::vector<Symbol* >::const_iterator it = symbols.begin();
-       it != symbols.end();
-       ++it) {
-    if (*it == toAdd) {
-      return true;
-    }
-  }
-
-  return false;
+static bool isRepeat(Symbol* toAdd,
+                     const llvm::SmallVectorImpl<Symbol*>& symbols) {
+  return std::find(symbols.begin(), symbols.end(), toAdd) != symbols.end();
 }
 
 // Is this name defined in this scope?
@@ -2402,7 +2402,7 @@ Symbol* lookupInModuleOrBuiltins(ModuleSymbol* mod, const char* name,
 
   // also check the uses of the module (e.g., for use CTypes, to find c_int),
   // but don't look in extern blocks (that would lead to an infinite loop).
-  std::vector<Symbol*> syms;
+  SmallVector<Symbol*> syms;
   std::map<Symbol*, astlocT*> renameLocs;
   std::map<Symbol*, VisibilityStmt*> reexportPts;
   lookupThisScopeAndUses(name, scope, scope, syms,

--- a/compiler/passes/splitInit.cpp
+++ b/compiler/passes/splitInit.cpp
@@ -702,9 +702,9 @@ static void noteUse(VarSymbol* var, VarToCopyElisionState& map) {
 }
 
 static void noteUses(Expr* e, VarToCopyElisionState& map) {
-  std::vector<SymExpr*> symExprs;
+  llvm::SmallVector<SymExpr*, 16> symExprs;
   collectSymExprs(e, symExprs);
-  for_vector (SymExpr, se, symExprs) {
+  for (SymExpr* se : symExprs) {
     if (VarSymbol* var = toVarSymbol(se->symbol())) {
       noteUse(var, map);
     }

--- a/compiler/resolution/caches.cpp
+++ b/compiler/resolution/caches.cpp
@@ -473,7 +473,7 @@ static void visitMorePOIs(std::vector<CalledFunInfo*>& toProcess,
   advanceCurrStart(visInfo);
 
   Vec<FnSymbol*> visibleFns;
-  std::set<BlockStmt*> visited(visInfoOrig.visitedScopes.begin(),
+  PtrSet<BlockStmt*> visited(visInfoOrig.visitedScopes.begin(),
                                visInfoOrig.visitedScopes.end());
   do {
     visInfo.poiDepth++;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4853,7 +4853,7 @@ static BlockStmt* findVisibleFunctionsAndCandidates(
   // to avoid revisiting those functions for the next POI.
   int numVisitedVis = 0, numVisitedMA = 0;
   LastResortCandidates lrc;
-  std::set<BlockStmt*> visited;
+  PtrSet<BlockStmt*> visited;
   visInfo.currStart = getVisibilityScope(call);
   INT_ASSERT(visInfo.poiDepth == -1); // we have not used it
   BlockStmt* scopeUsed = nullptr;

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -40,6 +40,7 @@
 #include "visibleFunctions.h"
 #include "wellknown.h"
 #include "wrappers.h"
+#include <llvm/ADT/SmallVector.h>
 
 static void resolveInitCall(CallExpr* call, AggregateType* newExprAlias = NULL, bool forNewExpr = false);
 
@@ -52,7 +53,7 @@ static void resolveInitializerMatch(FnSymbol* fn);
 static void makeRecordInitWrappers(CallExpr* call);
 
 static void makeActualsVector(const CallInfo&          info,
-                              std::vector<ArgSymbol*>& actualIdxToFormal);
+                              llvm::SmallVectorImpl<ArgSymbol*>& actualIdxToFormal);
 
 static AggregateType* resolveNewFindType(CallExpr* newExpr);
 
@@ -349,7 +350,7 @@ void resolveNewInitializer(CallExpr* newExpr, Type* manager) {
     info.haltNotWellFormed();
   }
 
-  std::vector<ArgSymbol*> actualIdxToFormal;
+  llvm::SmallVector<ArgSymbol*, 8> actualIdxToFormal;
 
   makeActualsVector(info, actualIdxToFormal);
 
@@ -711,7 +712,7 @@ static void makeRecordInitWrappers(CallExpr* call) {
   CallInfo info;
 
   if (info.isWellFormed(call) == true) {
-    std::vector<ArgSymbol*> actualIdxToFormal;
+    llvm::SmallVector<ArgSymbol*, 8> actualIdxToFormal;
     FnSymbol*               wrap = NULL;
 
     makeActualsVector(info, actualIdxToFormal);
@@ -739,7 +740,7 @@ static void makeRecordInitWrappers(CallExpr* call) {
 // so the "failure" modes should never get triggered.  The information we need
 // was cleaned up, though, so we are just going to recreate the parts we need.
 static void makeActualsVector(const CallInfo&          info,
-                              std::vector<ArgSymbol*>& actualIdxToFormal) {
+                              llvm::SmallVectorImpl<ArgSymbol*>& actualIdxToFormal) {
   const CallExpr*   call = info.call;
   FnSymbol*         fn   = call->resolvedFunction();
   std::vector<bool> formalIdxToActual;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -48,6 +48,7 @@
 #include "TryStmt.h"
 #include "view.h"
 #include "WhileStmt.h"
+#include "llvm/ADT/DenseSet.h"
 
 #include <set>
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -98,8 +98,10 @@ void resolveSignatureAndFunction(FnSymbol* fn) {
 void resolveSignature(FnSymbol* fn) {
   // Don't resolve formals for concrete functions
   // more often than necessary.
-  static std::set<FnSymbol*> done;
+  static llvm::DenseSet<FnSymbol*> done;
 
+  // This gets called about 10M times in arkouda and
+  // resolve goes from 30s to 28s
   if (done.find(fn) == done.end()) {
     done.insert(fn);
 


### PR DESCRIPTION
This PR adjusts the compiler to use LLVM ADTs from the LLVMSupport library. This PR depends on #19565 to build LLVMSupport even with CHPL_LLVM=none. This provides an approximately 6% performance improvement to the performance of compiling Hello World. 

Changes here were authored by @aconsroe-hpe in https://github.com/Cray/chapel-private/issues/2834

Hello World C backend compile times on my home system - built with quickstart + CHPL_LLVM=none (which includes the LLVM support library after #19565) - showing times from three runs
 * main 195a37574cd5a748cbbc9156bbe732bcc6d63eb4 5.1s 5.1s 5.2s
 * this PR 7f6272e2de525cf8f701f080376f8eac8794c384 4.8s 4.8s 4.9s

And with CHPL_LLVM=system (so using the LLVM backend):
 * main 195a37574cd5a748cbbc9156bbe732bcc6d63eb4 4.8s 4.7s 4.7s
 * this PR 7f6272e2de525cf8f701f080376f8eac8794c384 4.4s 4.4s 4.3s

Reviewed by @benharsh - thanks!

- [x] full local testing