### PR TITLE
Suppress elegant CoMD on linux32

### DIFF
--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.suppressif
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.suppressif
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+# https://github.com/Cray/chapel-private/issues/3235
+
+import os
+
+platform = os.getenv('CHPL_TARGET_PLATFORM')
+
+print(platform == 'linux32')


### PR DESCRIPTION
Our elegant CoMD started failing on linux32 since switching it to a new
machine. Suppress the failure until we have time/interest in looking
into the failure.

For more info see https://github.com/Cray/chapel-private/issues/3235