### PR TITLE
Compiler performance optimizations

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -168,47 +168,6 @@ bool Symbol::inTree() {
 }
 
 
-static Qualifier qualifierForArgIntent(IntentTag intent)
-{
-  switch (intent) {
-    case INTENT_IN:        return QUAL_VAL;
-    case INTENT_OUT:       return QUAL_REF;
-    case INTENT_INOUT:     return QUAL_REF;
-    case INTENT_CONST:     return QUAL_CONST;
-    case INTENT_CONST_IN:  return QUAL_CONST_VAL;
-    case INTENT_REF:       return QUAL_REF;
-    case INTENT_CONST_REF: return QUAL_CONST_REF;
-    case INTENT_PARAM:     return QUAL_PARAM; // TODO
-    case INTENT_TYPE:      return QUAL_UNKNOWN; // TODO
-    case INTENT_BLANK:     return QUAL_UNKNOWN;
-    case INTENT_REF_MAYBE_CONST:
-           return QUAL_REF; // a white lie until cullOverReferences
-
-    // no default to get compiler warning if other intents are added
-  }
-  INT_FATAL("unknown intent");
-  return QUAL_UNKNOWN;
-}
-
-QualifiedType Symbol::qualType() {
-  QualifiedType ret(dtUnknown, QUAL_UNKNOWN);
-
-  if (ArgSymbol* arg = toArgSymbol(this)) {
-    Qualifier q = qualifierForArgIntent(arg->intent);
-    if (qual == QUAL_WIDE_REF && (q == QUAL_REF || q == QUAL_CONST_REF)) {
-      q = QUAL_WIDE_REF;
-      // MPF: Should this be CONST_WIDE_REF in some cases?
-    }
-    ret = QualifiedType(type, q);
-  } else {
-    ret = QualifiedType(type, qual);
-    if (hasFlag(FLAG_CONST))
-      ret = ret.toConst();
-  }
-
-  return ret;
-}
-
 
 bool Symbol::isConstant() const {
   return false;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -102,10 +102,9 @@ ResolveScope* ResolveScope::findOrCreateScopeFor(DefExpr* def) {
 }
 
 ResolveScope* ResolveScope::getScopeFor(BaseAST* ast) {
-  std::map<BaseAST*, ResolveScope*>::iterator it;
   ResolveScope*                               retval = NULL;
 
-  it = sScopeMap.find(ast);
+  auto it = sScopeMap.find(ast);
 
   if (it != sScopeMap.end()) {
     retval = it->second;
@@ -115,9 +114,7 @@ ResolveScope* ResolveScope::getScopeFor(BaseAST* ast) {
 }
 
 void ResolveScope::destroyAstMap() {
-  std::map<BaseAST*, ResolveScope*>::iterator it;
-
-  for (it = sScopeMap.begin(); it != sScopeMap.end(); it++) {
+  for (auto it = sScopeMap.begin(); it != sScopeMap.end(); it++) {
     delete it->second;
   }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -590,7 +590,9 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
   // Phase 1
   //
   {
-    std::vector<CallExpr*> calls1;
+    // static variable here is only for performance
+    static std::vector<CallExpr*> calls1;
+    calls1.clear();
 
     collectCallExprs(base, calls1);
 
@@ -607,7 +609,9 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
   //
   // Phase 2
   //
-  std::vector<Symbol*> symbols;
+  // static variable here is only for performance
+  static std::vector<Symbol*> symbols;
+  symbols.clear();
 
   collectSymbols(base, symbols);
 
@@ -666,7 +670,9 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
   //
   // Phase 4
   //
-  std::vector<CallExpr*> calls2;
+  // static variable here is only for performance
+  static std::vector<CallExpr*> calls2;
+  calls2.clear();
 
   collectCallExprs(base, calls2);
 
@@ -707,15 +713,19 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
 static Symbol* theDefinedSymbol(BaseAST* ast);
 
 void checkUseBeforeDefs(FnSymbol* fn) {
+  // static variables here are just intended to be a performance improvement
+  static std::set<Symbol*> defined; // typically 32
+  static std::set<Symbol*> undefined;      // typically 0
+  static std::set<const char*> undeclared; // typically 0
+  static std::vector<BaseAST*> asts; // typically large
+
   if (fn->defPoint->parentSymbol) {
     ModuleSymbol*         mod = fn->getModule();
 
-    std::set<Symbol*>     defined;
-
-    std::set<Symbol*>     undefined;
-    std::set<const char*> undeclared;
-
-    std::vector<BaseAST*> asts;
+    defined.clear();
+    undefined.clear();
+    undeclared.clear();
+    asts.clear();
 
     collect_asts_postorder(fn, asts);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4886,7 +4886,7 @@ static void filterCandidate(CallInfo&                  info,
                             VisibilityInfo&            visInfo,
                             FnSymbol*                  fn,
                             Vec<ResolutionCandidate*>& candidates) {
-  ResolutionCandidate* candidate = new ResolutionCandidate(fn);
+  ResolutionCandidate candidate(fn);
 
   if (fExplainVerbose &&
       ((explainCallLine && explainCallMatch(info.call)) ||
@@ -4898,10 +4898,8 @@ static void filterCandidate(CallInfo&                  info,
     }
   }
 
-  if (candidate->isApplicable(info, &visInfo)) {
-    candidates.add(candidate);
-  } else {
-    delete candidate;
+  if (candidate.isApplicable(info, &visInfo)) {
+    candidates.add(new ResolutionCandidate(candidate));
   }
 }
 


### PR DESCRIPTION
PR message TODO

All of the changes here were authored by @aconsroe-hpe in https://github.com/Cray/chapel-private/issues/2834


Hello World compile times - built with quickstart + CHPL_LLVM=system - showing times from two runs
 * main 0432111a06 4.48 / 4.54 / 4.47 s
 * inline Symbol::qualType 4.49 / 4.51 s
 * ResolutionCandidate adjustment 4.48 / 4.51 s
 * simplify ResolveScope 4.48 / 4.54 s
 * optimize normalize 4.43 / 4.48 s

For the normalize opt here are compile times for the fft-timecomp compile
 * before: 7.46 / 7.50 / 7.53 s
 * after: 7.5 / 7.46 / 7.46 s