### PR TITLE
Do not fork Chapel compiler to do GPU code generation

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2713,30 +2713,48 @@ void codegen() {
     // name uses the PID).
     ensureTmpDirExists();
 
-    pid_t pid = fork();
+    //pid_t pid = fork();
 
-    if (pid == 0) {
+    //if (pid == 0) {
       // child process
-      gCodegenGPU = true;
+
+    gCodegenGPU = true;
       codegenPartTwo();
       makeBinary();
-      clean_exit(0);
-    } else {
+      //clean_exit(0);
+    //} else {
       // parent process
-      INT_ASSERT(!gCodegenGPU);
-      int status = 0;
-      while (wait(&status) != pid) {
+    gCodegenGPU = false;
+    //INT_ASSERT(!gCodegenGPU);
+      //int status = 0;
+      //while (wait(&status) != pid) {
         // wait for child process
-      }
+      //}
       // If there was an error in GPU code generation then the .fatbin file (containing
       // the generated GPU code) was not created and we won't be able to continue.
-      if(status != 0) {
-        clean_exit(status);
-      }
+      //if(status != 0) {
+        //clean_exit(status);
+      //}
+    //}
+
+    // Types cache their code generated result we need to re codegen them into the new
+    // llvm context between our first invocation of clang (where we generate the GPU
+    // code) and the second (where we generate everything else).
+    forv_Vec(TypeSymbol, ts, gTypeSymbols) {
+      ts->llvmType = nullptr;
+      ts->llvmTbaaTypeDescriptor = nullptr;
+      ts->llvmTbaaAccessTag = nullptr;
+      ts->llvmConstTbaaAccessTag = nullptr;
+      ts->llvmTbaaAggTypeDescriptor = nullptr;
+      ts->llvmTbaaAggAccessTag = nullptr;
+      ts->llvmConstTbaaAggAccessTag = nullptr;
+      ts->llvmTbaaStructCopyNode = nullptr;
+      ts->llvmConstTbaaStructCopyNode = nullptr;
+      ts->llvmDIType = nullptr;
     }
   }
 
-  codegenPartTwo();
+      codegenPartTwo();
 }
 
 void makeBinary(void) {


### PR DESCRIPTION
Having Chapel fork a new process to do GPU based code generation is a major painpoint when it comes to debugging it with gdb (gdb won't break on an assertion in the forked process for example).  It's especially silly given that we do this because we end up doing the codegens serially anyway (we fork the process then immediately wait for the child process to finish).

I think the reason we did this was as a hack to deal with some global state that needs to get "reset" between the first call to `codegenPartTwo()` and the second.  Well I think I figured out where this state is: we cache various "code generation" results in `TypeSymbol`.  If I simply "reset" those cached values to nullptr then we'll regen them on the next call to `codegenPartTwo()` and everything works --- or atleast I'm able to run all the GPU-based tests on my desktop succcesfully (I haven't tested that I didn't break any non-GPU code)

Anyway, consider this a draft PR (I know I need to clean this code up a little), but I'm posting it now to:

(1) Show off that I figured this out :-), and
(2) Get any feedback on why this might be a bad idea in case I'm misunderstanding something (maybe there's some other global state we need to be concerned with or some other reason we're forking).
