### PR TITLE
Fix a prediff of a new-ish GPU test

### DIFF
--- a/test/gpu/native/multiGPU/multiGPU.prediff
+++ b/test/gpu/native/multiGPU/multiGPU.prediff
@@ -1,13 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 # create the good file based on the number of children reported by the locale
 # model
 num_gpus=$(awk '/Number of sublocales.*/ {print $NF;}' < $2)
 num_gpus=$((num_gpus-1))
 
+rm -f $1.good
 for i in $(seq 1 $num_gpus);
 do
-  echo "      4 Kernel launcher called. (subloc $i)" > $1.good
+  echo "      4 Kernel launcher called. (subloc $i)" >> $1.good
 done
 
 # filter kernel launches and count them


### PR DESCRIPTION
This prediff creates the good file, and the main issue with that was that it
wasn't really appending to the output (ie, was using `>` instead of `>>`). This
PR fixes that and makes the prediff use `sh` instead of `bash` to avoid some
module warning.

