### PR TITLE
Drop M1 mac testing to just hellos

### DIFF
--- a/util/cron/test-darwin-m1.bash
+++ b/util/cron/test-darwin-m1.bash
@@ -8,4 +8,4 @@ source $CWD/common-darwin.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
 
-$CWD/nightly -cron -examples
+$CWD/nightly -cron -hellos


### PR DESCRIPTION
Our build node is disconnecting frequently, so limit to just hellos in
the hopes that those finish before any disconnects. We'll want to
increase testing in the future, but in the short-term I'd still like to
know about build failures.

Part of Cray/chapel-private#2625