### PR TITLE
Bump build version to 1 on 1.26 branch to reflect late-breaking changes

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -143,7 +143,7 @@ UPDATE_BUILD_VERSION = $(CHPL_MAKE_HOME)/util/devel/updateBuildVersion
 $(BUILD_VERSION_FILE): FORCE
 	@({ test -e $(CHPL_MAKE_HOME)/.git ; } && \
 	test -x $(UPDATE_BUILD_VERSION) && $(UPDATE_BUILD_VERSION) $@ $(CHPL_MAKE_HOME)) || \
-	test -r $(BUILD_VERSION_FILE) || (echo '"0"' > $@);
+	test -r $(BUILD_VERSION_FILE) || (echo '"1"' > $@);
 
 $(CHPL_MAKE_HOME)/configured-prefix:
 	echo > $(CHPL_MAKE_HOME)/configured-prefix


### PR DESCRIPTION
If I've kept my facts straight, this should bump the build version for the
1.26 branch to "1" the next time we respin the tarball, reflecting the
changes in https://github.com/chapel-lang/chapel/pull/19575.
Unfortunately, I won't feel confident that this is working as intended
until we merge and try to respin the tarball (either manually or via
Jenkins).