### PR TITLE
Bump the docs version button to reflect that 1.26 is now the default

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -87,8 +87,8 @@ if (pagePath == "") {
   pagePath = "index";
 }
 function dropSetup() {
-  var currentRelease = "1.25"; // what does the public have?
-  var stagedRelease = "1.26";  // is there a release staged but not yet public?
+  var currentRelease = "1.26"; // what does the public have?
+  var stagedRelease = "1.27";  // is there a release staged but not yet public?
   var nextRelease = "1.27";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle


### PR DESCRIPTION
This is 1.26's version of #18445 