### PR TITLE
Have build version print for developers *or* non-zero BUILD_VERSIONs

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -34,7 +34,7 @@ get_version(char *v) {
   v += sprintf(v, "%d.%d.%d", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (!officialRelease) {
     sprintf(v, " pre-release (%s)", BUILD_VERSION);
-  } else if (developer && strcmp(BUILD_VERSION, "0") != 0) {
+  } else if (developer || strcmp(BUILD_VERSION, "0") != 0) {
     sprintf(v, ".%s", BUILD_VERSION);
   }
 }


### PR DESCRIPTION
It appears that in https://github.com/chapel-lang/chapel/pull/13191
I got my boolean logic mixed up while refactoring how we print
versions such that the build version would only print for official
releases if developer was set.  Prior to that PR, it was printed
for official releases if non-zero even if developer was un-set, and
this seems like a smarter default (such that we'd print 1.26.0 for
the first of any official releases and then 1.26.0.1 if the build
version was bumped).  The reason being that if we want a user
to report to us which version they're using, we'd prefer not to have
them re-run `--devel --version` to find out what version they're
_really_ on in the rare cases where we do create new build versions.
