### PR TITLE
Add module index to sidebar

### DIFF
--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -353,7 +353,7 @@ void ModuleSymbol::printDocs(std::ostream* file,
     // effect of making references to the :mod: tag for the module
     // illegal, which is appropriate since the modules are not
     // user-facing.
-    if (strncmp(this->filename, "internal/", 9) == 0) {
+    if (this->modTag == MOD_INTERNAL) {
       *file << "   :noindex:" << std::endl;
     } else if (this->doc != NULL) {
       this->printTabs(file, tabs + 1);

--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -353,12 +353,7 @@ void ModuleSymbol::printDocs(std::ostream* file,
     // effect of making references to the :mod: tag for the module
     // illegal, which is appropriate since the modules are not
     // user-facing.
-    if ((strncmp(this->name, "Chapel", 6) == 0 && strcmp(this->name, "ChapelIO") != 0) ||
-        strcmp(this->name, "Atomics") == 0 ||
-        strcmp(this->name, "Bytes") == 0 ||
-        strcmp(this->name, "OwnedObject") == 0 ||
-        strcmp(this->name, "SharedObject") == 0 ||
-        strcmp(this->name, "String") == 0) {
+    if (strncmp(this->filename, "internal/", 9) == 0) {
       *file << "   :noindex:" << std::endl;
     } else if (this->doc != NULL) {
       this->printTabs(file, tabs + 1);

--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -348,8 +348,19 @@ void ModuleSymbol::printDocs(std::ostream* file,
       return;
     }
     *file << ".. module:: " << this->docsName() << std::endl;
-
-    if (this->doc != NULL) {
+    // Don't index internal modules since that will make them show up
+    // in the module index (chpl-modindex.html).  This has the side
+    // effect of making references to the :mod: tag for the module
+    // illegal, which is appropriate since the modules are not
+    // user-facing.
+    if ((strncmp(this->name, "Chapel", 6) == 0 && strcmp(this->name, "ChapelIO") != 0) ||
+        strcmp(this->name, "Atomics") == 0 ||
+        strcmp(this->name, "Bytes") == 0 ||
+        strcmp(this->name, "OwnedObject") == 0 ||
+        strcmp(this->name, "SharedObject") == 0 ||
+        strcmp(this->name, "String") == 0) {
+      *file << "   :noindex:" << std::endl;
+    } else if (this->doc != NULL) {
       this->printTabs(file, tabs + 1);
 
       *file << ":synopsis: ";

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -413,6 +413,19 @@ std::string filenameFromMod(ModuleSymbol *mod, std::string docsWorkDir) {
     size_t location = filename.rfind("/");
     if (location != std::string::npos) {
       filename = filename.substr(0, location + 1);
+
+      // Check for files starting with the CHPL_HOME internal modules
+      // path, and if we find one, chop everything but 'internal/' and
+      // whatever follows out of the path in order to create the
+      // appropriate relative path within the sphinx output directory.
+      // Also label such modules as MOD_INTERNAL for subsequent
+      // checks, like the one in ModuleSymbol::printDocs()
+      static const char* modPath = astr(CHPL_HOME, "/modules/");
+      static const char* intModPath = astr(modPath, "internal/");
+      if (strncmp(intModPath, filename.c_str(), strlen(intModPath)) == 0) {
+        filename = filename.substr(strlen(modPath));
+        mod->modTag = MOD_INTERNAL;
+      }
     } else {
       filename = "";
     }

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -90,8 +90,7 @@ strategy*. Four memory management strategies are available: ``owned``,
 managed by the compiler. In other words, the compiler automatically calls
 ``delete`` on these instances to reclaim their memory. For these
 instances, ``=`` and copy initialization can result in the transfer or
-sharing of ownership. See the module documentation for :mod:`owned
-<OwnedObject>` and :mod:`shared <SharedObject>`.  When ``borrowed`` is
+sharing of ownership. See the module documentation for :record:`~OwnedObject.owned` and :record:`~SharedObject.shared`.  When ``borrowed`` is
 used as a memory management strategy in a ``new-expression``, it also
 creates an instance that has its lifetime managed by the compiler
 (:ref:`Class_New`).
@@ -205,11 +204,11 @@ The memory management strategies have the following meaning:
 -  ``owned`` the instance will be deleted automatically when the
    ``owned`` variable goes out of scope, but only one ``owned`` variable
    can refer to the instance at a time. See the module documentation for
-   :mod:`owned <OwnedObject>`.
+   :record:`~OwnedObject.owned`.
 
 -  ``shared`` will be deleted when all of the ``shared`` variables
    referring to the instance go out of scope. See
-   the module documentation for :mod:`shared <SharedObject>`.
+   the module documentation for :record:`~SharedObject.shared`.
 
 -  ``borrowed`` refers to a class instance that has a lifetime managed
    by another variable.

--- a/doc/rst/language/spec/input-and-output.rst
+++ b/doc/rst/language/spec/input-and-output.rst
@@ -11,4 +11,4 @@ See Library Documentation
 
 Chapel includes an extensive library for input and output that is
 documented in the standard library documentation. See
-the :mod:`IO` and :mod:`ChapelIO` module documentation.
+the :mod:`ChapelIO` and :mod:`IO` module documentation.

--- a/doc/rst/meta/templates/layout.html
+++ b/doc/rst/meta/templates/layout.html
@@ -24,8 +24,9 @@ include "{{ pathto('',1) }}/versionButton.php";
 
 {% block menu %}
   {{ super() }}
-  <p class="caption" role="heading"><span class="caption-text">Chapel Documentation Index</span></p>
+  <p class="caption" role="heading"><span class="caption-text">Indexes</span></p>
   <ul>
-    <li class="toctree-11"><a class="reference internal" href="{{pathto('genindex.html', 1)}}">Index</a></li>
+    <li class="toctree-11"><a class="reference internal" href="{{pathto('chpl-modindex.html', 1)}}">Chapel Module Index</a></li>
+    <li class="toctree-11"><a class="reference internal" href="{{pathto('genindex.html', 1)}}">Complete Docs Index</a></li>
   </ul>
 {% endblock %}

--- a/doc/rst/technotes/atomics.rst
+++ b/doc/rst/technotes/atomics.rst
@@ -9,9 +9,10 @@ Runtime Support for Atomics
 The following information is meant to describe the underlying
 runtime support for Chapel's Atomic Variables.
 
-For more information on Atomic Variables refer to the :ref:`Chapel
-Language Specification <chapel-spec>`, or for a list of available functions on
-Atomics see :mod:`Atomics`
+For more information on Atomic Variables refer to the
+:ref:`Atomic_Variables` section of the Chapel language
+specification.
+
 
 For code examples using atomics, see the
 :ref:`atomics.chpl <primers-atomics>` primer.

--- a/doc/rst/users-guide/locality/localeTypeAndVariables.rst
+++ b/doc/rst/users-guide/locality/localeTypeAndVariables.rst
@@ -23,7 +23,7 @@ Locale values support methods that permit a programmer to make queries
 about the target architecture's capabilities, such as the maximum
 amount of task parallelism supported or the amount of physical memory
 available on the locale.  For details on this interface, refer to
-:chpl:mod:`ChapelLocale`.
+:ref:`Locale_Methods` in the Chapel language specification.
 
 As a simple example, each locale value supports an ``id`` method that
 reports its unique (0-based) ID.  We'll see the use of this method in

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -169,18 +169,18 @@ DISTS_TO_DOCUMENT = \
 	layouts/LayoutCS.chpl \
 
 
-INTERNAL_MODULES_TO_DOCUMENT =                \
-	internal/Atomics.chpl                 \
-	internal/Bytes.chpl                   \
-	internal/ChapelArray.chpl             \
-	internal/ChapelDomain.chpl            \
-	internal/ChapelLocale.chpl            \
-	internal/ChapelRange.chpl             \
-	internal/ChapelSyncvar.chpl           \
-	internal/ChapelTuple.chpl             \
-	internal/OwnedObject.chpl             \
-	internal/SharedObject.chpl            \
-	internal/String.chpl                  \
+INTERNAL_MODULES_TO_DOCUMENT =                        \
+	$(CHPL_MAKE_HOME)/modules/internal/Atomics.chpl       \
+	$(CHPL_MAKE_HOME)/modules/internal/Bytes.chpl         \
+	$(CHPL_MAKE_HOME)/modules/internal/ChapelArray.chpl   \
+	$(CHPL_MAKE_HOME)/modules/internal/ChapelDomain.chpl  \
+	$(CHPL_MAKE_HOME)/modules/internal/ChapelLocale.chpl  \
+	$(CHPL_MAKE_HOME)/modules/internal/ChapelRange.chpl   \
+	$(CHPL_MAKE_HOME)/modules/internal/ChapelSyncvar.chpl \
+	$(CHPL_MAKE_HOME)/modules/internal/ChapelTuple.chpl   \
+	$(CHPL_MAKE_HOME)/modules/internal/OwnedObject.chpl   \
+	$(CHPL_MAKE_HOME)/modules/internal/SharedObject.chpl  \
+	$(CHPL_MAKE_HOME)/modules/internal/String.chpl        \
 
 
 documentation: $(SYS_CTYPES_MODULE_DOC)

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -19,30 +19,37 @@
  */
 
 /*
+
 The following document shows functions and methods used to manipulate and
-process Chapel bytes variables. :mod:`bytes <Bytes>` is similar to a string but
-allows arbitrary data to be stored in it. Methods on bytes that interpret the
-data as characters assume that the bytes are ASCII characters.
+process Chapel bytes variables.
 
-Creating :mod:`bytes <Bytes>`
------------------------------
+.. type:: bytes
 
-- A :mod:`bytes <Bytes>` can be created using the literals similar to strings:
+The :type:`bytes` type is similar to a string but allows arbitrary
+data to be stored in it. Methods on bytes that interpret the data as
+characters assume that the bytes are ASCII characters.
+
+
+
+Creating :type:`bytes`
+--------------------------------
+
+- A :type:`bytes` can be created using the literals similar to strings:
 
 .. code-block:: chapel
 
    var b = b"my bytes";
 
-- If you need to create :mod:`bytes <Bytes>` using a specific buffer (i.e. data
-  in another :mod:`bytes <Bytes>`, a `c_string` or a C pointer) you can use the
+- If you need to create :type:`bytes` using a specific buffer (i.e. data
+  in another :type:`bytes`, a `c_string` or a C pointer) you can use the
   factory functions shown below, such as :proc:`createBytesWithNewBuffer`.
 
-:mod:`bytes <Bytes>` and :mod:`string <String>`
------------------------------------------------
+:type:`bytes` and :type:`~String.string`
+--------------------------------------------------
 
-As :mod:`bytes <Bytes>` can store arbitrary data, any :mod:`string <String>` can
-be cast to :mod:`bytes <Bytes>`. In that event, the bytes will store UTF-8
-encoded character data. However, a :mod:`bytes <Bytes>` can contain non-UTF-8
+As :type:`bytes` can store arbitrary data, any :type:`~String.string` can
+be cast to :type:`bytes`. In that event, the bytes will store UTF-8
+encoded character data. However, a :type:`bytes` can contain non-UTF-8
 bytes and needs to be decoded to be converted to string.
 
 .. code-block:: chapel
@@ -60,19 +67,19 @@ bytes and needs to be decoded to be converted to string.
 
 See the documentation for the :proc:`~bytes.decode` method for details.
 
-Similarly, a :mod:`bytes <Bytes>` can be initialized using a string:
+Similarly, a :type:`bytes` can be initialized using a string:
 
 .. code-block:: chapel
 
    var s = "my string";
    var b: bytes = s;
 
-Casts from :mod:`bytes <Bytes>` to a Numeric Type
--------------------------------------------------
+Casts from :type:`bytes` to a Numeric Type
+----------------------------------------------------
 
-This module supports casts from :mod:`bytes <Bytes>` to numeric types. Such
-casts will interpret the :mod:`bytes <Bytes>` as ASCII characters and convert it
-to the numeric type and throw an error if the :mod:`bytes <Bytes>` does not
+This module supports casts from :type:`bytes` to numeric types. Such
+casts will interpret the :type:`bytes` as ASCII characters and convert it
+to the numeric type and throw an error if the :type:`bytes` does not
 match the expected format of a number. For example:
 
 .. code-block:: chapel
@@ -109,13 +116,13 @@ module Bytes {
   //
 
   /*
-    Creates a new :mod:`bytes <Bytes>` which borrows the internal buffer of
-    another :mod:`bytes <Bytes>`. If the buffer is freed before the :mod:`bytes
-    <Bytes>` returned from this function, accessing it is undefined behavior.
+    Creates a new :type:`bytes` which borrows the internal buffer of
+    another :type:`bytes`. If the buffer is freed before the :type:`bytes`
+    returned from this function, accessing it is undefined behavior.
 
-    :arg s: The :mod:`bytes <Bytes>` to borrow the buffer from
+    :arg s: The :type:`bytes` to borrow the buffer from
 
-    :returns: A new :mod:`bytes <Bytes>`
+    :returns: A new :type:`bytes`
   */
   inline proc createBytesWithBorrowedBuffer(x: bytes) : bytes {
     var ret: bytes;
@@ -124,8 +131,8 @@ module Bytes {
   }
 
   /*
-    Creates a new :mod:`bytes <Bytes>` which borrows the internal buffer of a
-    `c_string`. If the buffer is freed before the :mod:`bytes <Bytes>` returned
+    Creates a new :type:`bytes` which borrows the internal buffer of a
+    `c_string`. If the buffer is freed before the :type:`bytes` returned
     from this function, accessing it is undefined behavior.
 
     :arg s: `c_string` to borrow the buffer from
@@ -134,7 +141,7 @@ module Bytes {
                  null byte.
     :type length: `int`
 
-    :returns: A new :mod:`bytes <Bytes>`
+    :returns: A new :type:`bytes`
   */
   inline proc createBytesWithBorrowedBuffer(x: c_string,
                                             length=x.size) : bytes {
@@ -161,8 +168,8 @@ module Bytes {
   }
 
   /*
-     Creates a new :mod:`bytes <Bytes>` which borrows the memory allocated for a
-     `c_ptr`. If the buffer is freed before the :mod:`bytes <Bytes>` returned
+     Creates a new :type:`bytes` which borrows the memory allocated for a
+     `c_ptr`. If the buffer is freed before the :type:`bytes` returned
      from this function, accessing it is undefined behavior.
 
      :arg s: Buffer to borrow
@@ -172,7 +179,7 @@ module Bytes {
 
      :arg size: Size of memory allocated for `s` in bytes
 
-     :returns: A new :mod:`bytes <Bytes>`
+     :returns: A new :type:`bytes`
   */
   inline proc createBytesWithBorrowedBuffer(x: c_ptr(?t), length: int,
                                             size: int) : bytes {
@@ -191,16 +198,16 @@ module Bytes {
   }
 
   /*
-    Creates a new :mod:`bytes <Bytes>` which takes ownership of the internal
-    buffer of a `c_string`.The buffer will be freed when the :mod:`bytes
-    <Bytes>` is deinitialized.
+    Creates a new :type:`bytes` which takes ownership of the internal
+    buffer of a `c_string`.The buffer will be freed when the :type:`bytes`
+    is deinitialized.
 
     :arg s: The `c_string` to take ownership of the buffer from
 
     :arg length: Length of `s`'s buffer, excluding the terminating null byte.
     :type length: `int`
 
-    :returns: A new :mod:`bytes <Bytes>`
+    :returns: A new :type:`bytes`
   */
   inline proc createBytesWithOwnedBuffer(x: c_string, length=x.size) : bytes {
     return createBytesWithOwnedBuffer(x: bufferType, length=length,
@@ -208,9 +215,9 @@ module Bytes {
   }
 
   /*
-     Creates a new :mod:`bytes <Bytes>` which takes ownership of the memory
+     Creates a new :type:`bytes` which takes ownership of the memory
      allocated for a `c_ptr`. The buffer will be freed when the
-     :mod:`bytes <Bytes>` is deinitialized.
+     :type:`bytes` is deinitialized.
 
      :arg s: The buffer to take ownership of
      :type x: `c_ptr(uint(8))` or `c_ptr(c_char)`
@@ -219,7 +226,7 @@ module Bytes {
 
      :arg size: Size of memory allocated for `s` in bytes
 
-     :returns: A new :mod:`bytes <Bytes>`
+     :returns: A new :type:`bytes`
   */
   inline proc createBytesWithOwnedBuffer(x: c_ptr(?t), length: int,
                                          size: int) : bytes {
@@ -232,12 +239,12 @@ module Bytes {
   }
 
   /*
-    Creates a new :mod:`bytes <Bytes>` by creating a copy of the buffer of
-    another :mod:`bytes <Bytes>`.
+    Creates a new :type:`bytes` by creating a copy of the buffer of
+    another :type:`bytes`.
 
-    :arg s: The :mod:`bytes <Bytes>` to copy the buffer from
+    :arg s: The :type:`bytes` to copy the buffer from
 
-    :returns: A new :mod:`bytes <Bytes>`
+    :returns: A new :type:`bytes`
   */
   inline proc createBytesWithNewBuffer(x: bytes) : bytes {
     var ret: bytes;
@@ -246,7 +253,7 @@ module Bytes {
   }
 
   /*
-    Creates a new :mod:`bytes <Bytes>` by creating a copy of the buffer of a
+    Creates a new :type:`bytes` by creating a copy of the buffer of a
     `c_string`.
 
     :arg s: The `c_string` to copy the buffer from
@@ -254,7 +261,7 @@ module Bytes {
     :arg length: Length of `s`'s buffer, excluding the terminating null byte.
     :type length: `int`
 
-    :returns: A new :mod:`bytes <Bytes>`
+    :returns: A new :type:`bytes`
   */
   inline proc createBytesWithNewBuffer(x: c_string, length=x.size) : bytes {
     return createBytesWithNewBuffer(x: bufferType, length=length,
@@ -262,7 +269,7 @@ module Bytes {
   }
 
   /*
-     Creates a new :mod:`bytes <Bytes>` by creating a copy of a buffer.
+     Creates a new :type:`bytes` by creating a copy of a buffer.
 
      :arg s: The buffer to copy
      :type x: `c_ptr(uint(8))` or `c_ptr(c_char)`
@@ -271,7 +278,7 @@ module Bytes {
 
      :arg size: Size of memory allocated for `s` in bytes
 
-     :returns: A new :mod:`bytes <Bytes>`
+     :returns: A new :type:`bytes`
   */
   inline proc createBytesWithNewBuffer(x: c_ptr(?t), length: int,
                                        size=length+1) : bytes {
@@ -410,7 +417,7 @@ module Bytes {
   } // end of record bytes
 
   /*
-    :returns: The number of bytes in the :mod:`bytes <Bytes>`.
+    :returns: The number of bytes in the :type:`bytes`.
     */
   inline proc bytes.size : int return buffLen;
 
@@ -421,15 +428,15 @@ module Bytes {
   proc bytes.indices : range return 0..<size;
 
   /*
-    :returns: The number of bytes in the :mod:`bytes <Bytes>`.
+    :returns: The number of bytes in the :type:`bytes`.
     */
   inline proc bytes.numBytes : int return buffLen;
 
   /*
-     Gets a version of the :mod:`bytes <Bytes>` that is on the currently
+     Gets a version of the :type:`bytes` that is on the currently
      executing locale.
 
-     :returns: A shallow copy if the :mod:`bytes <Bytes>` is already on the
+     :returns: A shallow copy if the :type:`bytes` is already on the
                current locale, otherwise a deep copy is performed.
   */
   inline proc bytes.localize() : bytes {
@@ -443,12 +450,12 @@ module Bytes {
 
 
   /*
-    Gets a `c_string` from a :mod:`bytes <Bytes>`. The returned `c_string`
-    shares the buffer with the :mod:`bytes <Bytes>`.
+    Gets a `c_string` from a :type:`bytes`. The returned `c_string`
+    shares the buffer with the :type:`bytes`.
 
     .. warning::
 
-      This can only be called safely on a :mod:`bytes <Bytes>` whose home is
+      This can only be called safely on a :type:`bytes` whose home is
       the current locale.  This property can be enforced by calling
       :proc:`bytes.localize()` before :proc:`~bytes.c_str()`. If the
       bytes is remote, the program will halt.
@@ -463,7 +470,7 @@ module Bytes {
         }
 
     :returns: A `c_string` that points to the underlying buffer used by this
-        :mod:`bytes <Bytes>`. The returned `c_string` is only valid when used
+        :type:`bytes`. The returned `c_string` is only valid when used
         on the same locale as the bytes.
    */
   inline proc bytes.c_str(): c_string {
@@ -471,11 +478,11 @@ module Bytes {
   }
 
   /*
-    Gets an ASCII character from the :mod:`bytes <Bytes>`
+    Gets an ASCII character from the :type:`bytes`
 
     :arg i: The index
 
-    :returns: A 1-length :mod:`bytes <Bytes>`
+    :returns: A 1-length :type:`bytes`
    */
   proc bytes.item(i: int): bytes {
     if boundsChecking && (i < 0 || i >= this.buffLen)
@@ -486,7 +493,7 @@ module Bytes {
   }
 
   /*
-    Gets a byte from the :mod:`bytes <Bytes>`
+    Gets a byte from the :type:`bytes`
 
     :arg i: The index
 
@@ -497,7 +504,7 @@ module Bytes {
   }
 
   /*
-    :returns: The value of a single-byte :mod:`bytes <Bytes>` as an integer.
+    :returns: The value of a single-byte :type:`bytes` as an integer.
   */
   proc bytes.toByte(): uint(8) {
     if this.buffLen != 1 {
@@ -507,7 +514,7 @@ module Bytes {
   }
 
   /*
-    Gets a byte from the :mod:`bytes <Bytes>`
+    Gets a byte from the :type:`bytes`
 
     :arg i: The index
 
@@ -519,9 +526,9 @@ module Bytes {
     return bufferGetByte(buf=this.buff, off=i, loc=this.locale_id);
   }
   /*
-    Iterates over the :mod:`bytes <Bytes>`, yielding ASCII characters.
+    Iterates over the :type:`bytes`, yielding ASCII characters.
 
-    :yields: 1-length :mod:`bytes <Bytes>`
+    :yields: 1-length :type:`bytes`
    */
   iter bytes.items(): bytes {
     if this.isEmpty() then return;
@@ -530,7 +537,7 @@ module Bytes {
   }
 
   /*
-    Iterates over the :mod:`bytes <Bytes>`
+    Iterates over the :type:`bytes`
 
     :yields: uint(8)
    */
@@ -540,7 +547,7 @@ module Bytes {
   }
 
   /*
-    Iterates over the :mod:`bytes <Bytes>` byte by byte.
+    Iterates over the :type:`bytes` byte by byte.
 
     :yields: uint(8)
   */
@@ -550,23 +557,23 @@ module Bytes {
   }
 
   /*
-    Slices the :mod:`bytes <Bytes>`. Halts if r is non-empty and not completely
+    Slices the :type:`bytes`. Halts if r is non-empty and not completely
     inside the range ``this.indices`` when compiled with `--checks`.
     `--fast` disables this check.
 
-    :arg r: The range of indices the new :mod:`bytes <Bytes>` should be made
+    :arg r: The range of indices the new :type:`bytes` should be made
             from
 
-    :returns: a new :mod:`bytes <Bytes>` that is a slice within
+    :returns: a new :type:`bytes` that is a slice within
               ``this.indices``. If the length of `r` is zero, an empty
-              :mod:`bytes <Bytes>` is returned.
+              :type:`bytes` is returned.
    */
   inline proc bytes.this(r: range(?)) : bytes {
     return getSlice(this, r);
   }
 
   /*
-    Checks if the :mod:`bytes <Bytes>` is empty.
+    Checks if the :type:`bytes` is empty.
 
     :returns: * `true`  -- when empty
               * `false` -- otherwise
@@ -576,11 +583,11 @@ module Bytes {
   }
 
   /*
-    Checks if the :mod:`bytes <Bytes>` starts with any of the given arguments.
+    Checks if the :type:`bytes` starts with any of the given arguments.
 
-    :arg patterns: :mod:`bytes <Bytes>` (s) to match against.
+    :arg patterns: :type:`bytes` (s) to match against.
 
-    :returns: * `true`--when the :mod:`bytes <Bytes>` begins with one or more of
+    :returns: * `true`--when the :type:`bytes` begins with one or more of
                 the `patterns`
               * `false`--otherwise
    */
@@ -589,11 +596,11 @@ module Bytes {
   }
 
   /*
-    Checks if the :mod:`bytes <Bytes>` ends with any of the given arguments.
+    Checks if the :type:`bytes` ends with any of the given arguments.
 
-    :arg patterns: :mod:`bytes <Bytes>` (s) to match against.
+    :arg patterns: :type:`bytes` (s) to match against.
 
-    :returns: * `true`--when the :mod:`bytes <Bytes>` ends with one or more of
+    :returns: * `true`--when the :type:`bytes` ends with one or more of
                 the `patterns`
               * `false`--otherwise
    */
@@ -609,17 +616,17 @@ module Bytes {
   }
 
   /*
-    Finds the argument in the :mod:`bytes <Bytes>`
+    Finds the argument in the :type:`bytes`
 
-    :arg pattern: :mod:`bytes <Bytes>` to search for
+    :arg pattern: :type:`bytes` to search for
 
     :arg indices: an optional range defining the indices to search
                  within, default is the whole. Halts if the range is not
                  within ``this.indices``
 
     :returns: the index of the first occurrence from the left of `pattern`
-              within the :mod:`bytes <Bytes>`, or -1 if the `pattern` is not in the
-              :mod:`bytes <Bytes>`.
+              within the :type:`bytes`, or -1 if the `pattern` is not in the
+              :type:`bytes`.
    */
   inline proc bytes.find(pattern: bytes,
                          indices: range(?) = this.indices) : idxType {
@@ -634,17 +641,17 @@ module Bytes {
   }
 
   /*
-    Finds the argument in the :mod:`bytes <Bytes>`
+    Finds the argument in the :type:`bytes`
 
-    :arg pattern: The :mod:`bytes <Bytes>` to search for
+    :arg pattern: The :type:`bytes` to search for
 
     :arg indices: an optional range defining the indices to search within,
                  default is the whole. Halts if the range is not
                  within ``this.indices``
 
     :returns: the index of the first occurrence from the right of `pattern`
-              within the :mod:`bytes <Bytes>`, or -1 if the `pattern` is not in the
-              :mod:`bytes <Bytes>`.
+              within the :type:`bytes`, or -1 if the `pattern` is not in the
+              :type:`bytes`.
    */
   inline proc bytes.rfind(pattern: bytes,
                           indices: range(?) = this.indices) : idxType {
@@ -660,15 +667,15 @@ module Bytes {
   }
 
   /*
-    Counts the number of occurrences of the argument in the :mod:`bytes <Bytes>`
+    Counts the number of occurrences of the argument in the :type:`bytes`
 
-    :arg pattern: The :mod:`bytes <Bytes>` to search for
+    :arg pattern: The :type:`bytes` to search for
 
     :arg indices: an optional range defining the substring to search within,
                  default is the whole. Halts if the range is not
                  within ``this.indices``
 
-    :returns: the number of times `pattern` occurs in the :mod:`bytes <Bytes>`
+    :returns: the number of times `pattern` occurs in the :type:`bytes`
    */
   inline proc bytes.count(pattern: bytes,
                           indices: range(?) = this.indices) : int {
@@ -685,16 +692,16 @@ module Bytes {
 
 
   /*
-    Replaces occurrences of a :mod:`bytes <Bytes>` with another.
+    Replaces occurrences of a :type:`bytes` with another.
 
-    :arg pattern: The :mod:`bytes <Bytes>` to search for
+    :arg pattern: The :type:`bytes` to search for
 
-    :arg replacement: The :mod:`bytes <Bytes>` to replace `pattern` with
+    :arg replacement: The :type:`bytes` to replace `pattern` with
 
     :arg count: an optional argument specifying the number of replacements to
                 make, values less than zero will replace all occurrences
 
-    :returns: a copy of the :mod:`bytes <Bytes>` where `replacement` replaces
+    :returns: a copy of the :type:`bytes` where `replacement` replaces
               `pattern` up to `count` times
    */
   inline proc bytes.replace(pattern: bytes,
@@ -704,18 +711,18 @@ module Bytes {
   }
 
   /*
-    Splits the :mod:`bytes <Bytes>` on `sep` yielding the bytes between each
+    Splits the :type:`bytes` on `sep` yielding the bytes between each
     occurrence, up to `maxsplit` times.
 
-    :arg sep: The delimiter used to break the :mod:`bytes <Bytes>` into chunks.
+    :arg sep: The delimiter used to break the :type:`bytes` into chunks.
 
-    :arg maxsplit: The number of times to split the :mod:`bytes <Bytes>`,
+    :arg maxsplit: The number of times to split the :type:`bytes`,
                    negative values indicate no limit.
 
-    :arg ignoreEmpty: * `true`-- Empty :mod:`bytes <Bytes>` will not be yielded,
-                      * `false`-- Empty :mod:`bytes <Bytes>` will be yielded
+    :arg ignoreEmpty: * `true`-- Empty :type:`bytes` will not be yielded,
+                      * `false`-- Empty :type:`bytes` will be yielded
 
-    :yields: :mod:`bytes <Bytes>`
+    :yields: :type:`bytes`
    */
   iter bytes.split(sep: bytes, maxsplit: int = -1,
              ignoreEmpty: bool = false): bytes {
@@ -725,18 +732,18 @@ module Bytes {
   /*
     Works as above, but uses runs of whitespace as the delimiter.
 
-    :arg maxsplit: The maximum number of times to split the :mod:`bytes <Bytes>`,
+    :arg maxsplit: The maximum number of times to split the :type:`bytes`,
                    negative values indicate no limit.
 
-    :yields: :mod:`bytes <Bytes>`
+    :yields: :type:`bytes`
    */
   iter bytes.split(maxsplit: int = -1) : bytes {
     for s in doSplitWSNoEnc(this, maxsplit) do yield s;
   }
 
   /*
-    Returns a new :mod:`bytes <Bytes>`, which is the concatenation of all of
-    the :mod:`bytes <Bytes>` passed in with the contents of the method
+    Returns a new :type:`bytes`, which is the concatenation of all of
+    the :type:`bytes` passed in with the contents of the method
     receiver inserted between them.
 
     .. code-block:: chapel
@@ -744,17 +751,17 @@ module Bytes {
         var myBytes = b"|".join(b"a",b"10",b"d");
         writeln(myBytes); // prints: "a|10|d"
 
-    :arg x: :mod:`bytes <Bytes>` values to be joined
+    :arg x: :type:`bytes` values to be joined
 
-    :returns: A :mod:`bytes <Bytes>`
+    :returns: A :type:`bytes`
   */
   inline proc bytes.join(const ref x: bytes ...) : bytes {
     return doJoin(this, x);
   }
 
   /*
-    Returns a new :mod:`bytes <Bytes>`, which is the concatenation of all of
-    the :mod:`bytes <Bytes>` passed in with the contents of the method
+    Returns a new :type:`bytes`, which is the concatenation of all of
+    the :type:`bytes` passed in with the contents of the method
     receiver inserted between them.
 
     .. code-block:: chapel
@@ -766,9 +773,9 @@ module Bytes {
         var myJoinedArray = b"|".join([b"a",b"10",b"d"]);
         writeln(myJoinedArray); // prints: "a|10|d"
 
-    :arg x: An array or tuple of :mod:`bytes <Bytes>` values to be joined
+    :arg x: An array or tuple of :type:`bytes` values to be joined
 
-    :returns: A :mod:`bytes <Bytes>`
+    :returns: A :type:`bytes`
   */
   inline proc bytes.join(const ref x) : bytes  {
     // this overload serves as a catch-all for unsupported types.
@@ -789,7 +796,7 @@ module Bytes {
     :arg trailing: Indicates if trailing occurrences should be removed.
                     Defaults to `true`.
 
-    :returns: A new :mod:`bytes <Bytes>` with `leading` and/or `trailing`
+    :returns: A new :type:`bytes` with `leading` and/or `trailing`
               occurrences of characters in `chars` removed as appropriate.
   */
   proc bytes.strip(chars = b" \t\r\n", leading=true, trailing=true) : bytes {
@@ -797,14 +804,14 @@ module Bytes {
   }
 
   /*
-    Splits the :mod:`bytes <Bytes>` on a given separator
+    Splits the :type:`bytes` on a given separator
 
     :arg sep: The separator
 
     :returns: a `3*bytes` consisting of the section before `sep`,
               `sep`, and the section after `sep`. If `sep` is not found, the
-              tuple will contain the whole :mod:`bytes <Bytes>`, and then two
-              empty :mod:`bytes <Bytes>`.
+              tuple will contain the whole :type:`bytes`, and then two
+              empty :type:`bytes`.
   */
   inline proc const bytes.partition(sep: bytes) : 3*bytes {
     return doPartition(this, sep);
@@ -832,7 +839,7 @@ module Bytes {
                         common leading whitespace, and make no changes to the
                         first line.
 
-      :returns: A new :mod:`bytes <Bytes>` with indentation removed.
+      :returns: A new :type:`bytes` with indentation removed.
 
       .. warning::
 
@@ -846,7 +853,7 @@ module Bytes {
   }
 
   /*
-    Returns a UTF-8 string from the given :mod:`bytes <Bytes>`. If the data is
+    Returns a UTF-8 string from the given :type:`bytes`. If the data is
     malformed for UTF-8, `policy` argument determines the action.
 
     :arg policy: - `decodePolicy.strict` raises an error
@@ -857,7 +864,7 @@ module Bytes {
                     private use codepoints
 
     :throws: `DecodeError` if `decodePolicy.strict` is passed to the `policy`
-              argument and the :mod:`bytes <Bytes>` contains non-UTF-8 characters.
+              argument and the :type:`bytes` contains non-UTF-8 characters.
 
     :returns: A UTF-8 string.
   */
@@ -868,7 +875,7 @@ module Bytes {
   }
 
   /*
-    Checks if all the characters in the :mod:`bytes <Bytes>` are uppercase
+    Checks if all the characters in the :type:`bytes` are uppercase
     (A-Z) in ASCII.  Ignores uncased (not a letter) and extended ASCII
     characters (decimal value larger than 127)
 
@@ -892,7 +899,7 @@ module Bytes {
   }
 
   /*
-    Checks if all the characters in the :mod:`bytes <Bytes>` are lowercase
+    Checks if all the characters in the :type:`bytes` are lowercase
     (a-z) in ASCII.  Ignores uncased (not a letter) and extended ASCII
     characters (decimal value larger than 127)
 
@@ -917,7 +924,7 @@ module Bytes {
   }
 
   /*
-    Checks if all the characters in the :mod:`bytes <Bytes>` are whitespace
+    Checks if all the characters in the :type:`bytes` are whitespace
     (' ', '\\t', '\\n', '\\v', '\\f', '\\r') in ASCII.
 
     :returns: * `true`  -- when all the characters are whitespace.
@@ -940,7 +947,7 @@ module Bytes {
   }
 
   /*
-    Checks if all the characters in the :mod:`bytes <Bytes>` are alphabetic
+    Checks if all the characters in the :type:`bytes` are alphabetic
     (a-zA-Z) in ASCII.
 
     :returns: * `true`  -- when the characters are alphabetic.
@@ -963,7 +970,7 @@ module Bytes {
   }
 
   /*
-    Checks if all the characters in the :mod:`bytes <Bytes>` are digits (0-9)
+    Checks if all the characters in the :type:`bytes` are digits (0-9)
     in ASCII.
 
     :returns: * `true`  -- when the characters are digits.
@@ -986,7 +993,7 @@ module Bytes {
   }
 
   /*
-    Checks if all the characters in the :mod:`bytes <Bytes>` are alphanumeric
+    Checks if all the characters in the :type:`bytes` are alphanumeric
     (a-zA-Z0-9) in ASCII.
 
     :returns: * `true`  -- when the characters are alphanumeric.
@@ -1010,7 +1017,7 @@ module Bytes {
   }
 
   /*
-    Checks if all the characters in the :mod:`bytes <Bytes>` are printable in
+    Checks if all the characters in the :type:`bytes` are printable in
     ASCII.
 
     :returns: * `true`  -- when the characters are printable.
@@ -1074,10 +1081,10 @@ module Bytes {
   }
 
   /*
-    Creates a new :mod:`bytes <Bytes>` with all applicable characters
+    Creates a new :type:`bytes` with all applicable characters
     converted to lowercase.
 
-    :returns: A new :mod:`bytes <Bytes>` with all uppercase characters (A-Z)
+    :returns: A new :type:`bytes` with all uppercase characters (A-Z)
               replaced with their lowercase counterpart in ASCII. Other
               characters remain untouched.
   */
@@ -1091,10 +1098,10 @@ module Bytes {
   }
 
   /*
-    Creates a new :mod:`bytes <Bytes>` with all applicable characters
+    Creates a new :type:`bytes` with all applicable characters
     converted to uppercase.
 
-    :returns: A new :mod:`bytes <Bytes>` with all lowercase characters (a-z)
+    :returns: A new :type:`bytes` with all lowercase characters (a-z)
               replaced with their uppercase counterpart in ASCII. Other
               characters remain untouched.
   */
@@ -1108,10 +1115,10 @@ module Bytes {
   }
 
   /*
-    Creates a new :mod:`bytes <Bytes>` with all applicable characters
+    Creates a new :type:`bytes` with all applicable characters
     converted to title capitalization.
 
-    :returns: A new :mod:`bytes <Bytes>` with all cased characters(a-zA-Z)
+    :returns: A new :type:`bytes` with all cased characters(a-zA-Z)
               following an uncased character converted to uppercase, and all
               cased characters following another cased character converted to
               lowercase.
@@ -1150,14 +1157,14 @@ module Bytes {
 
 
   /*
-     Appends the :mod:`bytes <Bytes>` `rhs` to the :mod:`bytes <Bytes>` `lhs`.
+     Appends the :type:`bytes` `rhs` to the :type:`bytes` `lhs`.
   */
   operator bytes.+=(ref lhs: bytes, const ref rhs: bytes) : void {
     doAppend(lhs, rhs);
   }
 
   /*
-     Copies the :mod:`bytes <Bytes>` `rhs` into the :mod:`bytes <Bytes>` `lhs`.
+     Copies the :type:`bytes` `rhs` into the :type:`bytes` `lhs`.
   */
   operator bytes.=(ref lhs: bytes, rhs: bytes) : void {
     doAssign(lhs, rhs);
@@ -1176,7 +1183,7 @@ module Bytes {
   // Concatenation
   //
   /*
-     :returns: A new :mod:`bytes <Bytes>` which is the result of concatenating
+     :returns: A new :type:`bytes` which is the result of concatenating
                `s0` and `s1`
   */
   operator bytes.+(s0: bytes, s1: bytes) : bytes {
@@ -1188,7 +1195,7 @@ module Bytes {
     return __primitive("string_concat", s0, s1);
 
   /*
-     :returns: A new :mod:`bytes <Bytes>` which is the result of repeating `s`
+     :returns: A new :type:`bytes` which is the result of repeating `s`
                `n` times.  If `n` is less than or equal to 0, an empty bytes is
                returned.
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -40,6 +40,12 @@
 The following documentation shows functions and methods used to
 manipulate and process Chapel strings.
 
+.. type:: string
+
+The :type:`string` type in Chapel represents a sequence of UTF-8
+characters and is most often used to represent textual data.
+
+
 Methods Available in Other Modules
 ----------------------------------
 
@@ -53,7 +59,7 @@ within strings.
 Casts from String to a Numeric Type
 -----------------------------------
 
-The :mod:`string <String>` type supports casting to numeric types. Such casts
+The :type:`string` type supports casting to numeric types. Such casts
 will convert the string to the numeric type and throw an error if the string is
 invalid. For example:
 
@@ -86,8 +92,8 @@ Non-Unicode Data and Chapel Strings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For doing string operations on non-Unicode or arbitrary data, consider using
-:mod:`bytes <Bytes>` instead of string. However, there may be cases where
-:mod:`string <String>` must be used with non-Unicode data. Examples of this are
+:type:`~Bytes.bytes` instead of string. However, there may be cases where
+:type:`string` must be used with non-Unicode data. Examples of this are
 file system and path operations on systems where UTF-8 file names are not
 enforced.
 
@@ -1233,10 +1239,10 @@ module String {
   }
 
   /*
-     Gets a version of the :mod:`string <String>` that is on the currently
+     Gets a version of the :type:`string` that is on the currently
      executing locale.
 
-     :returns: A shallow copy if the :mod:`string <String>` is already on the
+     :returns: A shallow copy if the :type:`string` is already on the
                current locale, otherwise a deep copy is performed.
   */
   inline proc string.localize() : string {
@@ -1249,11 +1255,11 @@ module String {
   }
 
   /*
-    Get a `c_string` from a :mod:`string <String>`.
+    Get a `c_string` from a :type:`string`.
 
     .. warning::
 
-        This can only be called safely on a :mod:`string <String>` whose home is
+        This can only be called safely on a :type:`string` whose home is
         the current locale.  This property can be enforced by calling
         :proc:`string.localize()` before :proc:`~string.c_str()`. If the
         string is remote, the program will halt.
@@ -1269,7 +1275,7 @@ module String {
 
     :returns:
         A `c_string` that points to the underlying buffer used by this
-        :mod:`string <String>`. The returned `c_string` is only valid when used
+        :type:`string`. The returned `c_string` is only valid when used
         on the same locale as the string.
    */
   inline proc string.c_str() : c_string {
@@ -1277,7 +1283,7 @@ module String {
   }
 
   /*
-    Returns a :mod:`bytes <Bytes>` from the given :mod:`string <String>`. If the
+    Returns a :type:`~Bytes.bytes` from the given :type:`string`. If the
     string contains some escaped non-UTF8 bytes, `policy` argument determines
     the action.
 
@@ -1285,7 +1291,7 @@ module String {
                   data, `encodePolicy.unescape` recovers the escaped bytes
                   back.
 
-    :returns: :mod:`bytes <Bytes>`
+    :returns: :type:`~Bytes.bytes`
   */
   proc string.encode(policy=encodePolicy.pass) : bytes {
     var localThis: string = this.localize();
@@ -1759,8 +1765,8 @@ module String {
   }
 
   /*
-    Returns a new :mod:`string <String>`, which is the concatenation of all of
-    the :mod:`string <String>` passed in with the contents of the method
+    Returns a new :type:`string`, which is the concatenation of all of
+    the :type:`string` passed in with the contents of the method
     receiver inserted between them.
 
     .. code-block:: chapel
@@ -1768,17 +1774,17 @@ module String {
         var myString = "|".join("a","10","d");
         writeln(myString); // prints: "a|10|d"
 
-    :arg x: :mod:`string <String>` values to be joined
+    :arg x: :type:`string` values to be joined
 
-    :returns: A :mod:`string <String>`
+    :returns: A :type:`string`
   */
   inline proc string.join(const ref x: string ...) : string {
     return doJoin(this, x);
   }
 
   /*
-    Returns a new :mod:`string <String>`, which is the concatenation of all of
-    the :mod:`string <String>` passed in with the contents of the method
+    Returns a new :type:`string`, which is the concatenation of all of
+    the :type:`string` passed in with the contents of the method
     receiver inserted between them.
 
     .. code-block:: chapel
@@ -1790,9 +1796,9 @@ module String {
         var myJoinedArray = "|".join(["a","10","d"]);
         writeln(myJoinedArray); // prints: "a|10|d"
 
-    :arg x: An array or tuple of :mod:`string <String>` values to be joined
+    :arg x: An array or tuple of :type:`string` values to be joined
 
-    :returns: A :mod:`string <String>`
+    :returns: A :type:`string`
   */
   inline proc string.join(const ref x) : string {
     // this overload serves as a catch-all for unsupported types.

--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/*  Support for atomic operations on pointers to 'unmanaged' classes.
+
   .. warning::
 
     This module has several platform restrictions in its current state:

--- a/modules/packages/Channel.chpl
+++ b/modules/packages/Channel.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for channels that can transfer typed data between tasks.
+
  This module contains the implementation of channels which can be used to move
  typed data between Chapel tasks.
 

--- a/modules/packages/Collection.chpl
+++ b/modules/packages/Collection.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/*
+/* Provides an abstract class representing a 'Collection' interface.
 
   Summary
   _______

--- a/modules/packages/ConcurrentMap.chpl
+++ b/modules/packages/ConcurrentMap.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* This module provides a fast, scalable, fine-grained concurrent map.
+
   .. warning::
 
     This module relies on the :mod:`AtomicObjects` package module, which
@@ -34,7 +35,7 @@
 
     .. _CMPXCHG16B: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
 
-  This module provides a fast, scalable, fine-grained concurrent map. It was
+  This module was
   inspired by the Interlocked Hash Table [#]_. It allows large critical
   sections that access a single table element, and can easily support multikey
   atomic operations. At the time of its development, ConcurrentMap outperformed

--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Provides support for aggregated copies/assignments for trivial types.
+
    .. warning::
      This module represents work in progress. The API is unstable and likely to
      change over time.

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -18,8 +18,11 @@
  * limitations under the License.
  */
 
-/*  A cryptographic library based on `OpenSSL <https://www.openssl.org/>`_, targeted at
-    flexible encryption purposes.
+/*  A cryptographic library based on 'OpenSSL'.
+
+    This module provides a cryptographic library based on `OpenSSL
+    <https://www.openssl.org/>`_, targeted at flexible encryption
+    purposes.
 
     The Crypto module focuses on providing various cryptographic utilities such as
 
@@ -1180,7 +1183,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
   }
 
   /*
-      Support for low-level native C_OpenSSL bindings.
+      Support for low-level native OpenSSL bindings in C.
       This submodule wraps the C_OpenSSL implementation, providing access to
       most of the C_OpenSSL calls.
 

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -20,7 +20,7 @@
 
 /*
 
-Low-level support for many network protocols with libcurl
+Low-level support for many network protocols with 'libcurl'.
 
 This module provides support for libcurl, enabling Chapel programs
 to work with many network protocols. This module is a low-level C

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -64,7 +64,7 @@
 */
 
 
-/*
+/* Implements a highly parallel segmented multiset.
 
   Summary
   _______

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -60,7 +60,7 @@
 
 
 
-/*
+/* Implements a parallel-safe scalable distributed deque.
 
   Summary
   ________

--- a/modules/packages/DistributedIters.chpl
+++ b/modules/packages/DistributedIters.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for dynamic iterators distributed across multiple locales.
+
   This module contains iterators that can be used to distribute a `forall`
   loop for a range or domain by dynamically splitting iterations between
   locales.

--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for Epoch-based Memory Reclamation.
+
   .. warning::
 
     This module relies on the :mod:`AtomicObjects` package module, which

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -38,7 +38,7 @@
 //
 
 /*
-  FFT computations via key routines from FFTW (version 3)
+  FFT computations via key routines from FFTW (version 3).
 
   This module defines Chapel wrappers for key 64-bit
   routines from FFTW (http://www.fftw.org), version 3. The routines

--- a/modules/packages/FunctionalOperations.chpl
+++ b/modules/packages/FunctionalOperations.chpl
@@ -18,7 +18,9 @@
  * limitations under the License.
  */
 
-/* The `FunctionalOperations` module provides operations that act on
+/* Support for acting on iterators in a functional style.
+
+   The `FunctionalOperations` module provides operations that act on
    iterators in a functional programming style.
  */
 module FunctionalOperations {

--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -20,7 +20,7 @@
 
 /* Containers for accessing the results of asynchronous execution.
 
-.. |---| unicode:: U+2014   TODO: What is this?
+.. |---| unicode:: U+2014
 
 A :record:`Future` object is a container that can store the result of an
 asynchronous operation, which can be retrieved when the result is ready.

--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -18,11 +18,9 @@
  * limitations under the License.
  */
 
-/*
+/* Containers for accessing the results of asynchronous execution.
 
-.. |---| unicode:: U+2014
-
-Containers for accessing the results of asynchronous execution.
+.. |---| unicode:: U+2014   TODO: What is this?
 
 A :record:`Future` object is a container that can store the result of an
 asynchronous operation, which can be retrieved when the result is ready.

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/* HDF5 bindings for Chapel
+/* HDF5 bindings for Chapel.
 
 This module implements the C-API for HDF5 version 1.10.1, as well as some
 functionality for reading and writing HDF5 files built on top of the C-API.
@@ -69,7 +69,7 @@ module HDF5 {
     C_HDF5.H5open();
   }
 
-  /* The C_HDF5 module defines the interface to the HDF5 library.
+  /* Defines the C interface to the HDF5 library.
      Documentation for its functions, types, and constants can be found
      at the official HDF5 web site:
      https://portal.hdfgroup.org/display/HDF5/HDF5
@@ -3901,7 +3901,9 @@ module HDF5 {
     var A: [D] eltType;
   }
 
-  /* A module to encapsulate functions that use the MPI module so that it
+  /* HDF5 routines that rely on MPI.
+
+     A module to encapsulate functions that use the MPI module so that it
      is not initialized unless these functions are actually used.
    */
   module IOusingMPI {

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/*
+/* Support for the Hadoop Distributed File System.
 
 This module implements support for the
 `Hadoop <http://hadoop.apache.org/>`_

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -2587,7 +2587,7 @@ private proc epsilon(type t) param : real {
   return 0.0;
 }
 
-/* Linear Algebra Sparse Submodule
+/* Support for Linear Algebra routines involving sparse data.
 
 A high-level interface to linear algebra operations and procedures for sparse
 matrices (2D arrays).

--- a/modules/packages/LockFreeQueue.chpl
+++ b/modules/packages/LockFreeQueue.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* A lock-free queue using the Michael and Scott algorithm.
+
   .. warning::
 
     This module relies on the :mod:`AtomicObjects` package module, which

--- a/modules/packages/LockFreeStack.chpl
+++ b/modules/packages/LockFreeStack.chpl
@@ -19,7 +19,8 @@
  */
 
 
-/*
+/* Support for a lock-free Treiber stack.
+
   .. warning::
 
     This module relies on the :mod:`AtomicObjects` package module, which

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -728,7 +728,7 @@ module MPI {
    } // End C_MPI
 
 
-  module C_Env {
+  private module C_Env {
     use CTypes;
     // Helper routines to access the environment
     extern proc getenv(name : c_string) : c_string;

--- a/modules/packages/NetCDF.chpl
+++ b/modules/packages/NetCDF.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/* NetCDF bindings for Chapel
+/* NetCDF bindings for Chapel.
 
 This module implements the C-API for netCDF version 4.6.1.
 
@@ -41,7 +41,7 @@ On Cray systems with the ``cray-netcdf`` module loaded, no compiler flags
 are necessary to use the HDF5 module.
 */
 module NetCDF {
-  /* The NetCDF module defines the interface to the netCDF library.
+  /* This module defines the C interface to the netCDF library.
      Documentation for its functions, types, and constants can be found
      at the official netCDF web site:
      https://www.unidata.ucar.edu/software/netcdf/docs

--- a/modules/packages/PeekPoke.chpl
+++ b/modules/packages/PeekPoke.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for directly accessing an 'atomic' variable's value.
+
    .. warning::
      This module is unstable and the API is likely to change over time.
 

--- a/modules/packages/RangeChunk.chpl
+++ b/modules/packages/RangeChunk.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Utility routines for splitting a range into multiple chunks.
+
    The ``RangeChunk`` module assists with dividing a bounded ``range`` of any ``idxType``
    and stride into ``numChunks``. Chunks are 0-based, with the ``0`` index chunk including
    ``range.low`` and the ``numChunks - 1`` index chunk including ``range.high``.

--- a/modules/packages/RecordParser.chpl
+++ b/modules/packages/RecordParser.chpl
@@ -21,7 +21,7 @@
 
 /*
 
-Read records using regular expressions.
+Support for reading records using regular expressions.
 
 A general purpose record reader/parser for channels. Uses a regular expression
 to capture portions of the input, and then assigns each capture to each

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -18,9 +18,7 @@
  * limitations under the License.
  */
 
-/*
-   The `Search` module is designed to support standard search routines on 1D
-   arrays
+/* Support for standard search routines on 1D arrays.
  */
 module Search {
   public use Sort only defaultComparator, DefaultComparator,

--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -793,7 +793,7 @@ private extern proc sys_recvfrom(sockfd:fd_t, buff:c_void_ptr, len:c_size_t, fla
   :arg timeout: time to wait for data to arrive.
   :type timeval: :type:`~Sys.timeval`
   :return: tuple of (data, address)
-  :rtype: `tuple(:mod:`bytes <Bytes>`, :type:ipAddr)`
+  :rtype: (:type:`~Bytes.bytes`, :type:`ipAddr`)
   :throws SystemError: Upon failure to receive any data
                     within given `timeout`.
 */
@@ -874,7 +874,7 @@ proc udpSocket.recvfrom(bufferLen: int, timeout: real, flags:c_int = 0):(bytes, 
   :arg timeout: time to wait for data to arrive.
   :type timeval: :type:`~Sys.timeval`
   :return: data
-  :rtype: :mod:`bytes <Bytes>`
+  :rtype: :type:`~Bytes.bytes`
   :throws SystemError: Upon failure to receive any data
                         within given `timeout`.
 */
@@ -901,7 +901,7 @@ private extern proc sys_sendto(sockfd:fd_t, buff:c_void_ptr, len:c_long, flags:c
     const sentBytes = socket.send("hello world!":bytes, timeout);
 
   :arg data: data to send to address
-  :type data: :mod:`bytes <Bytes>`
+  :type data: :type:`~Bytes.bytes`
   :arg address: socket address for sending data
   :type address: :type:`ipAddr`
   :arg timeout: time to wait for data to arrive.
@@ -1026,10 +1026,10 @@ proc setSockOpt(socketFd:fd_t, level: c_int, optname: c_int, ref value: bytes) t
 }
 
 /*
-  Overload for :proc:`setSockOpt` that allows setting a :mod:`bytes <Bytes>` value
+  Overload for :proc:`setSockOpt` that allows setting a :type:`~Bytes.bytes` value
   on socket option. This is useful for `setsockopt` calls that work with a C struct,
   including `SO_LINGER`, `SO_RCVTIMEO`, and `SO_SNDTIMEO`. It is up to the caller to
-  ensure that the `value` which is a :type::mod:`bytes <Bytes>` parameter contains
+  ensure that the `value` which is a :type:`~Bytes.bytes` parameter contains
   the proper bits.
 
   :arg socket: socket to set option on
@@ -1039,7 +1039,7 @@ proc setSockOpt(socketFd:fd_t, level: c_int, optname: c_int, ref value: bytes) t
   :arg optname: option to set.
   :type optname: `int(32)`
   :arg value: value to set on option
-  :type value: :mod:`bytes <Bytes>`
+  :type value: :type:`~Bytes.bytes`
   :throws SystemError: Upon incompatible arguments
                         and socket.
 */
@@ -1133,7 +1133,7 @@ proc getSockOpt(socketFd:fd_t, level: c_int, optname: c_int, buflen: uint(16)) t
 
 /*
   Returns the value of the given socket option which is expected to be of type
-  :mod:`bytes <Bytes>` on provided :type:`tcpConn`. The needed symbolic constants (SO_* etc.)
+  :type:`~Bytes.bytes` on provided :type:`tcpConn`. The needed symbolic constants (SO_* etc.)
   are defined in :mod:`Sys` module.
 
   :arg socket: socket to set option on
@@ -1143,7 +1143,7 @@ proc getSockOpt(socketFd:fd_t, level: c_int, optname: c_int, buflen: uint(16)) t
   :arg optname: option to set.
   :type optname: `int(32)`
   :return: value of socket option
-  :rtype: :mod:`bytes <Bytes>`
+  :rtype: :type:`~Bytes.bytes`
   :throws SystemError: Upon incompatible arguments
                         and socket.
 */

--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -18,7 +18,7 @@
  */
 
 /*
-  Socket Module library, specifically related to IP Sockets.
+  Supports inter-process communication through IP sockets.
 
   The Socket module focuses on connecting, accepting sockets and providing interface for
   communication between them. Also provided are some constant values representing

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -22,7 +22,7 @@
 // TODO -- performance test sort routines and optimize (see other TODO's)
 /*
 
-The Sort module is designed to support standard sort routines.
+Supports standard algorithms for sorting data.
 
 .. _comparators:
 

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -18,9 +18,7 @@
  * limitations under the License.
  */
 
-/*
-  This module contains the implementation of the sortedMap type
-  which is a container that stores key-value associations.
+/* Provides the 'sortedMap' type for storing sorted key-value associations.
 
   sortedMaps are not parallel safe by default, but can be made parallel safe by
   setting the param formal `parSafe` to true in any sortedMap constructor. When

--- a/modules/packages/SortedSet.chpl
+++ b/modules/packages/SortedSet.chpl
@@ -18,7 +18,7 @@
  */
 
 /*
-  This module contains the implementation of the 'sortedSet' type.
+  Provides the 'sortedSet' type for storing sorted unique elements.
 
   An ``sortedSet`` is a collection of unique and sorted elements. The
   ``sortedSet`` accepts a :ref:`comparator <comparators>` to determine how

--- a/modules/packages/SortedSet.chpl
+++ b/modules/packages/SortedSet.chpl
@@ -18,7 +18,7 @@
  */
 
 /*
-  This module contains the implementation of the ``sortedSet`` type.
+  This module contains the implementation of the 'sortedSet' type.
 
   An ``sortedSet`` is a collection of unique and sorted elements. The
   ``sortedSet`` accepts a :ref:`comparator <comparators>` to determine how

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -18,11 +18,10 @@
  * limitations under the License.
  */
 
-/*
+/* Support for parsing and writing TOML files.
+
 Chapel's Library for `Tom's Obvious, Minimal Language (TOML)
 <https://github.com/toml-lang/toml>`_.
-This module provides support for parsing and writing toml files.
-
 
   .. note::
 

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -19,7 +19,7 @@
  */
 
 /*
-The UnitTest module provides support for automated testing in Chapel.
+Support for automated testing in Chapel.
 
 The UnitTest module is intended to be used with the `mason test
 <https://chapel-lang.org/docs/tools/mason/mason.html>`_ command, which

--- a/modules/packages/UnorderedAtomics.chpl
+++ b/modules/packages/UnorderedAtomics.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for unordered non-fetching atomic operations.
+
    .. warning::
      This module represents work in progress. The API is unstable and likely to
      change over time.

--- a/modules/packages/UnorderedCopy.chpl
+++ b/modules/packages/UnorderedCopy.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for unordered copies/assignments for trivial types.
+
    .. warning::
      This module represents work in progress. The API is unstable and likely to
      change over time.

--- a/modules/packages/UnrolledLinkedList.chpl
+++ b/modules/packages/UnrolledLinkedList.chpl
@@ -19,7 +19,7 @@
  */
 
 /*
-  This module contains the implementation of the unrolledLinkedList type.
+  This module contains the implementation of the 'unrolledLinkedList' type.
 
   An unrolled linked list is a linked list of small arrays, all of the same size
   where each is so small that the insertion or deletion is fast and quick, but

--- a/modules/packages/VisualDebug.chpl
+++ b/modules/packages/VisualDebug.chpl
@@ -18,11 +18,12 @@
  * limitations under the License.
  */
 
-/*
+/* Support for the 'chplvis' visualization tool.
 
-   Support for the visualization tool :ref:`chplvis`.
+   This module provides support for the execution visualization tool
+   :ref:`chplvis`.
 
-   This module provides access to and enables hooks to dump out
+   It provides access to and enables hooks to dump out
    task and communication information for post-run visualization
    of the tasks and communication.
 

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -20,7 +20,7 @@
 
 /*
 
-Lightweight messaging with ZeroMQ (or ØMQ)
+Lightweight messaging with ZeroMQ (or ØMQ).
 
 This module provides high-level Chapel bindings to the
 `ZeroMQ messaging library <https://zeromq.org/>`_.

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/* Support for task barriers.
+/* Support for barriers between tasks.
 
    The Barrier type provided in this module can be used to prevent tasks
    from proceeding until all other related tasks have also reached the

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Provides a 'bigint' type and supporting math operations.
+
 The ``bigint`` record supports arithmetic operations on arbitrary
 precision integers in a manner that is broadly consistent with
 the conventional operations on primitive fixed length integers.

--- a/modules/standard/CPtr.chpl
+++ b/modules/standard/CPtr.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/*
+/* Support for C pointers and related routines (deprecated).
 
 In previous releases, this module contained Chapel types that
 represent C pointers and related routines.  It has been deprecated and

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -24,7 +24,7 @@
 
 /*
 
-Defines C types and related routines to support interoperability
+Defines C types and related routines to support interoperability.
 
 This module provides access to common C types for the purpose of
 calling between Chapel and C, declaring variables using C's types,

--- a/modules/standard/ChapelEnv.chpl
+++ b/modules/standard/ChapelEnv.chpl
@@ -24,7 +24,7 @@
 
 /*
 
-Access to Chapel Environment Variables
+Access to Chapel Environment Variables (deprecated)
 
 The values of Chapel's environment variables upon compile time are
 accessible through the built-in parameters shown below. This information

--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -19,7 +19,7 @@
  */
 
 /*
-Access to configuration information for the 'chpl' compiler
+Access to configuration information for the 'chpl' compiler.
 
 This module's contents provide access to compile-time aspects of
 Chapel's configuration, such as those specified by ``CHPL_*``

--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -19,7 +19,7 @@
  */
 
 /*
-Access to configuration information for the ``chpl`` compiler
+Access to configuration information for the 'chpl' compiler
 
 This module's contents provide access to compile-time aspects of
 Chapel's configuration, such as those specified by ``CHPL_*``

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Supports reasoning about Chapel code's communication requirements.
+
   This module provides support for reporting and counting
   communication operations between network-connected locales.  The
   operations include various kinds of remote reads (GETs), remote

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/* Supports reasoning about Chapel code's communication requirements.
+/* Supports counting and reporting network communication operations.
 
   This module provides support for reporting and counting
   communication operations between network-connected locales.  The

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -18,7 +18,9 @@
  * limitations under the License.
  */
 
-/* Support for representing dates, times, combined dates and times and
+/* This module supports reasoning about real-world dates and times.
+
+   Support for representing dates, times, combined dates and times and
    timedeltas.  This module is modeled heavily off of the python module
    'datetime'.
 

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for dynamic distribution of a 'forall' loop's iterations.
+
   This module contains several iterators that can be used to drive a `forall`
   loop by performing dynamic and adaptive splitting of a range's iterations.
 

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for error conditions and error-handling.
+
    This module contains several features related to error conditions and error
    handling:
 

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/* A file utilities library
+/* A file utilities library.
 
    The FileSystem module focuses on file and directory properties and
    operations.  It does not cover every interaction involving a file--- for

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -20,7 +20,7 @@
 
 /*
 
-Support for GNU Multiple Precision Arithmetic
+Support for GNU Multiple Precision Arithmetic.
 
 This module provides a low-level interface to a substantial fraction
 of the GMP library (the GNU Multiple Precision arithmetic library).

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -18,7 +18,7 @@
  */
 
 /*
-  This module contains the implementation of the heap type.
+  This module contains the implementation of a 'heap' type.
 
   A heap is a specialized tree-based data structure
   that supports extracting the maximal or the minimal element quickly,

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -19,7 +19,7 @@
  */
 
 /*
-  This module contains the implementation of the list type.
+  This module contains the implementation of Chapel's standard 'list' type.
 
   A list is a lightweight container similar to an array that is suitable for
   building up and iterating over a collection of elements in a structured

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Chapel's standard 'map' type for key-value storage.
+
   This module contains the implementation of the map type which is a container
   that stores key-value associations.
 

--- a/modules/standard/Memory.chpl
+++ b/modules/standard/Memory.chpl
@@ -18,9 +18,7 @@
  * limitations under the License.
  */
 
-/*
-  The :mod:`Memory` module provides submodules that contain operations
-  related to memory usage and memory initialization.
+/* Support for operations related to memory usage and initialization.
 */
 module Memory {
 

--- a/modules/standard/Memory/Diagnostics.chpl
+++ b/modules/standard/Memory/Diagnostics.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Provides routines for reasoning about memory usage.
+
   The :mod:`Diagnostics` module provides procedures which report information
   about memory usage.  With one exception, to use these procedures you
   must enable memory tracking.  Do this by setting one or more of the

--- a/modules/standard/Memory/Initialization.chpl
+++ b/modules/standard/Memory/Initialization.chpl
@@ -18,7 +18,8 @@
  * limitations under the License.
  */
 
-/*
+/* Support for move-initializing and deinitializing values.
+
   The :mod:`Initialization` module provides functions which enable users to
   move-initialize and deinitialize values.
 

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/* A file utilities library, specifically related to path operations
+/* A file utilities library focusing on path operations.
 
    The Path module focuses on manipulation of the path to a file or directory.
    Also provided are constant values representing common idioms that may vary

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -19,7 +19,7 @@
  */
 
 /*
-   Support for pseudorandom number generation
+   Support for pseudorandom number generation.
 
    This module defines an abstraction for a stream of pseudorandom numbers,
    :class:`~RandomStreamInterface`. Use :proc:`createRandomStream` to
@@ -696,7 +696,7 @@ module Random {
 
 
   /*
-     Seed generation for pseudorandom number generation
+     Seed generation for pseudorandom number generation.
 
 
      .. note::
@@ -2427,7 +2427,7 @@ module Random {
   } // end PCGRandomLib
 
   /*
-     NAS Parallel Benchmark RNG
+     NAS Parallel Benchmark Random Number Generator.
 
      The pseudorandom number generator (PRNG) implemented by
      this module uses the algorithm from the NAS Parallel Benchmarks

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -750,7 +750,7 @@ module Random {
 
 
   /*
-     Permuted Linear Congruential Random Number Generator
+     Permuted Linear Congruential Random Number Generator.
 
      This module provides PCG random number generation routines.
      See http://www.pcg-random.org/

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/*
+/* Support for reflecting about properties of a Chapel program's code.
 
    Functions for reflecting about language elements, such as fields,
    functions, and methods.

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -63,7 +63,7 @@ Now you can use these methods on regular expressions: :proc:`regex.search`,
 
 You can also use the string versions of these methods: :proc:`string.search`,
 :proc:`string.match`, :proc:`string.split`, or :proc:`string.matches`. Methods
-with same prototypes exist for :mod:`Bytes` type, as well.
+with same prototypes exist for :type:`~Bytes.bytes` type, as well.
 
 Lastly, you can include regular expressions in the format string for
 :proc:`~FormattedIO.readf` for searching on QIO channels using the ``%/<regex>/``

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -19,7 +19,7 @@
  */
 
 /*
-  This module contains the implementation of the set type.
+  This module contains the implementation of Chapel's standard 'set' type.
 
   A set is a collection of unique elements. Sets are unordered and unindexed.
 

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -19,7 +19,7 @@
  */
 
 /*
-Support launching and interacting with other programs.
+Support launching and interacting with other programs (deprecated).
 
 .. warning::
 

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/* Types for low-level system error integration
+/* Types for low-level system error integration.
 
    This module defines the error types :type:`syserr` and :type:`err_t`.
 

--- a/modules/standard/SysCTypes.chpl
+++ b/modules/standard/SysCTypes.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/*
+/* Support for C integer types (deprecated).
 
 In previous releases, this module contained Chapel types that
 represent C integer types.  It has been deprecated and its contents

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -21,7 +21,8 @@
 
 
 
-/*
+/* Support for routines related to measuring the passing of time.
+
    This module provides support for querying wall time in the local
    timezone and implements a record :record:`~Timer` that provides basic
    stopwatch behavior.  The stopwatch has the potential for microsecond

--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-/*
+/* Support for reasoning about version numbers.
 
 .. highlight:: chapel
 

--- a/test/release/examples/primers/LinearAlgebralib.chpl
+++ b/test/release/examples/primers/LinearAlgebralib.chpl
@@ -63,8 +63,8 @@ assert(matrix1.type == matrix2.type);    // ... produces same result
   This section demonstrates some of the functionality built into Chapel
   arrays that can be useful in a linear algebra context. None of the operations
   in this section require usage of :mod:`LinearAlgebra`.
-  Learn more about Chapel arrays in the :mod:`ChapelArray` documentation and
-  the :ref:`Array Primer <primers-arrays>`.
+  Learn more about Chapel arrays in the :ref:`Chapter-Arrays` chapter of the
+  language specification and the :ref:`Array Primer <primers-arrays>`.
 
 */
 


### PR DESCRIPTION
This adds a module index to our sidebar.    I'd seen mentions of this
index, but couldn't find it when I was adding other indices last month.
Stumbled across it today, so added it to the sidebar and renamed
things in the sidebar a bit to reflect it as well.

While here, I did a cleanup of the one-line summaries of each of the
module files to make the index cleaner than the (unlinked) file that
had been available through the website.  I also added some special-
case code to the compiler to hide internal modules from the index,
which also had the impact of making them not cross-referenceable.
I think this is appropriate, though, since the internal module names
aren't meant to be things that the user knows about or can refer to.
So then I had to update links to internal modules to link to other
things instead (a pre-existing type or section name, on in the case
of bytes and string, a new type annotation).