### PR TITLE
Fix problem compiling with GCC 5

### DIFF
--- a/compiler/dyno/include/chpl/uast/AstTag.h
+++ b/compiler/dyno/include/chpl/uast/AstTag.h
@@ -130,4 +130,18 @@ template<> struct stringify<uast::AstTag> {
 
 } // end namespace chpl
 
+namespace std {
+
+
+template<> struct hash<chpl::uast::AstTag>
+{
+  size_t operator()(const chpl::uast::AstTag& key) const {
+    return key;
+  }
+};
+
+
+} // end namespace std
+
+
 #endif


### PR DESCRIPTION
Follow-up to PR #19359.

GCC 5 doesn't include `std::hash` for enum types so we have to
add our own versions for our enum types when they are needed.

Trivial and not reviewed.

- [x] verified that `CC=gcc-5 CXX=g++-5 make` works on my system
