### PR TITLE
Compact revcomp

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -6,10 +6,6 @@
    and the Chapel #2 version by myself and Ben Harshbarger
 */
 
-param eol = "\n".toByte();      // end-of-line, as an integer
-
-const table = createTable();    // create the table of code complements
-
 proc main(args: [] string) {
   use IO;
   const stdinBin = openfd(0).reader(iokind.native, locking=false,
@@ -53,7 +49,14 @@ proc main(args: [] string) {
 
 
 proc revcomp(buf: [?inds]) {
-  param cols = 61;  // the number of characters per full row (including '\n')
+  param eol = "\n".toByte(),  // end-of-line, as an integer
+        cols = 61,            // # of characters per full row (including '\n')
+        // A 'bytes' value that stores the complement of each base at its index
+        cmp = b"          \n                                                  "
+            + b"    TVGH  CD  M KN   YSAABW R       TVGH  CD  M KN   YSAABW R";
+              //    ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑       ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑
+              //    ABCDEFGHIJKLMNOPQRSTUVWXYZ      abcdefghijklmnopqrstuvwxyz
+
   var lo = inds.low,
       hi = inds.high;
 
@@ -77,27 +80,5 @@ proc revcomp(buf: [?inds]) {
 
   // walk from both ends of the sequence, complementing and swapping
   forall (i,j) in zip(lo..#(len/2), ..<hi by -1) do
-    (buf[i], buf[j]) = (table[buf[j]], table[buf[i]]);
-}
-
-
-proc createTable() {
-  // `pairs` compactly represents the table we're creating, where the
-  // first byte of each pair (in either case) maps to the second:
-  //   A|a -> T, C|c -> G, G|g -> C, T|t -> A, etc.
-  param pairs = b"ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN",
-        upperToLower = "a".toByte() - "A".toByte();
-
-  var table: [0..127] uint(8);
-
-  for i in pairs.indices by 2 {
-    const src = pairs[i],
-          dst = pairs[i+1];
-
-    table[src] = dst;
-    table[src+upperToLower] = dst;
-  }
-  table[eol] = eol;
-
-  return table;
+    (buf[i], buf[j]) = (cmp[buf[j]], cmp[buf[i]]);
 }

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -2,8 +2,8 @@
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Brad Chamberlain
-   based on the C gcc #5 version by Mr Ledrug
-   and the Chapel #2 version by myself and Ben Harshbarger
+   based on the Chapel #3 version with some inspiration taken from the
+   C gcc #6 version by Jeremy Zerfas
 */
 
 proc main(args: [] string) {
@@ -59,6 +59,7 @@ proc revcomp(buf, bufflo, hi) {
 
   var lo = bufflo;
 
+  // skip past header line
   do {
     lo += 1;
   } while buf[lo-1] != eol;

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -9,9 +9,9 @@
 proc main(args: [] string) {
   use IO;
   const stdinBin = openfd(0).reader(iokind.native, locking=false,
-                                 hints = QIO_CH_ALWAYS_UNBUFFERED),
+                                    hints = QIO_CH_ALWAYS_UNBUFFERED),
         stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                  hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
 
   // read in the data using an incrementally growing buffer
   var bufLen = 8 * 1024,

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -38,7 +38,7 @@ proc main(args: [] string) {
       lo -= 1;
 
     // reverse and complement the sequence once we find it
-    revcomp(buf[lo..hi]);
+    revcomp(buf, lo, hi);
 
     hi = lo - 1;
   }
@@ -48,7 +48,7 @@ proc main(args: [] string) {
 }
 
 
-proc revcomp(buf: [?inds]) {
+proc revcomp(buf, bufflo, hi) {
   param eol = "\n".toByte(),  // end-of-line, as an integer
         cols = 61,            // # of characters per full row (including '\n')
         // A 'bytes' value that stores the complement of each base at its index
@@ -57,10 +57,8 @@ proc revcomp(buf: [?inds]) {
               //    ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑       ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑
               //    ABCDEFGHIJKLMNOPQRSTUVWXYZ      abcdefghijklmnopqrstuvwxyz
 
-  var lo = inds.low,
-      hi = inds.high;
+  var lo = bufflo;
 
-  // skip past header line
   do {
     lo += 1;
   } while buf[lo-1] != eol;


### PR DESCRIPTION
This is essentially the submitted revcomp3 program
with some changes to the code to make it more compact
without throwing away its idiomatic nature.  The main
change is to use a bytes array to implement the byte->byte
mapping efficiently rather than a table that took a lot of code
to set up.  In addition, while passing in an array slice seemed
cute, the fact that we then query its bounds back out again
once we enter the routine felt like a waste of code, so I
switched to just passing in the bounds as distinct arguments.

This required a lame temp variable because using the `in`
intent led to a compiler bug, captured in #19596 and #19598.