### PR TITLE
Pin CCE 13 for CHAMPS nightly testing

### DIFF
--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -18,6 +18,10 @@ loadCSModule PrgEnv-cray
 loadCSModule intel
 loadCSModule cray-mvapich2_nogpu
 
+# CHAMPS dependencies were built with cce 13. Until we rebuild them,
+# pin that version
+module swap cce cce/13.0.2
+
 module list
 
 # Perf configuration


### PR DESCRIPTION
On the test system, default CCE was upgraded to 14. But I'd built the CHAMPS
dependencies with 13. We may need to rebuild them to use 14 as I am getting
bunch of link-time errors. For now, pin version 13.
