### PR TITLE
Fasta based on gcc#9 version

### DIFF
--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -111,7 +111,7 @@ proc randomMake(desc, nuclInfo, n) {
       buffer: [0..<buffSize] uint(8);
 
   // add linefeeds
-  for i in lineLen..<buffSize by lineLen+1 do
+  for i in lineLen..<buffSize by lineLen+1 do  // TODO: try forall?
     buffer[i] = newline;
   
   for 0..<numBuffs {
@@ -126,11 +126,11 @@ proc randomMake(desc, nuclInfo, n) {
     for k in 0..<lineLen do
       buffer[j*LfLineLen+k] = hash[getNextRand()];
   
-  var partials = n - lineLen*(numBuffs*buffLines + numLines);
+  var partials = n % lineLen;
   for k in 0..<partials do
     buffer[numLines*LfLineLen+k] = hash[getNextRand()];
 
-  if (n % lineLen != 0) {
+  if (partials != 0) {
     buffer[numLines*LfLineLen+partials] = newline;
     partials += 1;
   }

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -106,9 +106,9 @@ proc randomMake(desc, nuclInfo, n) {
 
   param LfLineLen = lineLen + 1,
         buffSize = LfLineLen*buffLines;
-  const numLines = n/lineLen,
-        numBuffs = numLines/buffLines;
-  var buffer: [0..<buffSize] uint(8);
+  var numLines = n/lineLen,
+      numBuffs = numLines/buffLines,
+      buffer: [0..<buffSize] uint(8);
 
   // add linefeeds
   for i in lineLen..<buffSize by lineLen+1 do
@@ -120,23 +120,22 @@ proc randomMake(desc, nuclInfo, n) {
         buffer[j*LfLineLen+k] = hash[getNextRand()];
     stdout.write(buffer);
   }
+  numLines -= numBuffs*buffLines;
 
-  const extraLines = numLines - numBuffs*buffLines;
-  for j in 0..<extraLines do
+  for j in 0..<numLines do
     for k in 0..<lineLen do
       buffer[j*LfLineLen+k] = hash[getNextRand()];
-  var extra = extraLines * lineLen;
   
-  var partials = n - lineLen*(numBuffs*buffLines + extraLines);
+  var partials = n - lineLen*(numBuffs*buffLines + numLines);
   for k in 0..<partials do
-    buffer[extraLines*LfLineLen+k] = hash[getNextRand()];
+    buffer[numLines*LfLineLen+k] = hash[getNextRand()];
 
   if (n % lineLen != 0) {
-    buffer[extraLines*LfLineLen+partials] = newline;
+    buffer[numLines*LfLineLen+partials] = newline;
     partials += 1;
   }
   
-  stdout.write(buffer[0..<extraLines*LfLineLen+partials]);
+  stdout.write(buffer[0..<numLines*LfLineLen+partials]);
 }
 
 proc b(s) {

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -2,9 +2,8 @@
    http://benchmarksgame.alioth.debian.org/
 
    contributed by Brad Chamberlain
-   derived from the GNU C version by Аноним Легионов and Jeremy Zerfas
-     as well as previous Chapel versions by Casey Battaglino, Kyle Brady,
-     and Preston Sahabu.
+   derived from the Chapel #5 version
+   and the C gcc #9 version by Drake Diedrich
 */
 
 use IO;

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -86,6 +86,7 @@ proc repeatMake(desc, param alu, n) {
 // sequence of length 'n'
 //
 proc randomMake(desc, nuclInfo, n) {
+  
   stdout.writeln(desc);
 
   var hash: [0..<IM] uint(8),
@@ -103,8 +104,10 @@ proc randomMake(desc, nuclInfo, n) {
     hash[i] = ch;
   }
 
-  param buffSize = (lineLen+1)*buffLines;
-  const numBuffs = n/lineLen/buffLines;
+  param LfLineLen = lineLen + 1,
+        buffSize = LfLineLen*buffLines;
+  const numLines = n/lineLen,
+        numBuffs = numLines/buffLines;
   var buffer: [0..<buffSize] uint(8);
 
   // add linefeeds
@@ -114,26 +117,26 @@ proc randomMake(desc, nuclInfo, n) {
   for 0..<numBuffs {
     for j in 0..<buffLines do // TODO: make PARAM?
       for k in 0..<lineLen do // TODO: make PARAM?
-        buffer[j*(lineLen+1)+k] = hash[getNextRand()];
+        buffer[j*LfLineLen+k] = hash[getNextRand()];
     stdout.write(buffer);
   }
 
-  const lines = n/lineLen - numBuffs*buffLines;
-  for j in 0..<lines do
+  const extraLines = numLines - numBuffs*buffLines;
+  for j in 0..<extraLines do
     for k in 0..<lineLen do
-      buffer[j*(lineLen+1)+k] = hash[getNextRand()];
-  var extra = lines * lineLen;
+      buffer[j*LfLineLen+k] = hash[getNextRand()];
+  var extra = extraLines * lineLen;
   
-  var partials = n - lineLen*lines - numBuffs*buffLines*lineLen;
+  var partials = n - lineLen*(numBuffs*buffLines + extraLines);
   for k in 0..<partials do
-    buffer[lines*(lineLen+1)+k] = hash[getNextRand()];
+    buffer[extraLines*LfLineLen+k] = hash[getNextRand()];
 
   if (n % lineLen != 0) {
-    buffer[lines*(lineLen+1)+partials] = newline;
+    buffer[extraLines*LfLineLen+partials] = newline;
     partials += 1;
   }
   
-  stdout.write(buffer[0..<lines*(lineLen+1)+partials]);
+  stdout.write(buffer[0..<extraLines*LfLineLen+partials]);
 }
 
 proc b(s) {


### PR DESCRIPTION
Here's a completely serial version of fasta that looks to be both faster
and more compact than our previous one, based on the gcc # 9 version.
I've only copied the logic for the two random cases; it looks like there's
potential speedup (though also code bloat) to be had if we adopted the
strategy for the repeat version as well.  Future work.