### PR TITLE
Remove file that should've been removed with #19621

### DIFF
--- a/test/studies/shootout/fasta/bradc/fasta-blc.execopts
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.execopts
@@ -1,1 +1,0 @@
---blockSize=4


### PR DESCRIPTION
I'd removed this file locally, but forgotten to remove it in GitHub...
It breaks the compiler because it refers to a config that no longer exists.