### PR TITLE
Fix nightly memleak failure in DistributedMap

### DIFF
--- a/test/library/draft/DistributedMap/use-distributed-map.chpl
+++ b/test/library/draft/DistributedMap/use-distributed-map.chpl
@@ -3,7 +3,7 @@ use Map, DistributedMap, Aggregator, BlockDist, Random;
 /////////////////////////////////
 // randomStrings parameters and reference
 config const defaultSeed = 3141592;
-config const numStrings  = 200_000;
+config const numStrings  = 20_000;
 
 // int(8) means the maps will have only 256 keys with large histogram counts
 // use bigger-sized types to have more keys with smaller counts

--- a/test/library/draft/DistributedMap/use-distributed-map.comm-none.good
+++ b/test/library/draft/DistributedMap/use-distributed-map.comm-none.good
@@ -1,35 +1,11 @@
 
 
-
-
-
-
-
-
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
-./DistributedMap.chpl:226        64       56       3584     array elements                   prediffed  
+./DistributedMap.chpl:226        256      56       14336    array elements                   prediffed  
+./DistributedMap.chpl:226        256      56       14336    array elements                   prediffed  
+./DistributedMap.chpl:226        256      56       14336    array elements                   prediffed  
+./DistributedMap.chpl:226        256      56       14336    array elements                   prediffed  
+./DistributedMap.chpl:226        256      56       14336    array elements                   prediffed  
+./DistributedMap.chpl:226        256      56       14336    array elements                   prediffed  
 ./DistributedMap.chpl:229        1        8        8        string copy data                 prediffed  
 ./DistributedMap.chpl:229        1        8        8        string copy data                 prediffed  
 ./DistributedMap.chpl:229        1        8        8        string copy data                 prediffed  
@@ -543,93 +519,27 @@
 ./DistributedMap.chpl:229        1        8        8        string copy data                 prediffed  
 ./DistributedMap.chpl:229        1        8        8        string copy data                 prediffed  
 ./DistributedMap.chpl:229        1        8        8        string copy data                 prediffed  
-./DistributedMap.chpl:38         1        96       96       DistributedMapImpl(string,int(64))prediffed  
-./DistributedMap.chpl:38         1        96       96       DistributedMapImpl(string,int(64))prediffed  
-./DistributedMap.chpl:57         1        88       88       domain(1,int(64),false)          prediffed  
-./DistributedMap.chpl:57         1        88       88       domain(1,int(64),false)          prediffed  
-./DistributedMap.chpl:57         1        88       88       domain(1,int(64),false)          prediffed  
-./DistributedMap.chpl:57         1        88       88       domain(1,int(64),false)          prediffed  
-./DistributedMap.chpl:57         1        88       88       domain(1,int(64),false)          prediffed  
-./DistributedMap.chpl:57         1        88       88       domain(1,int(64),false)          prediffed  
-./DistributedMap.chpl:57         1        88       88       domain(1,int(64),false)          prediffed  
-./DistributedMap.chpl:57         1        88       88       domain(1,int(64),false)          prediffed  
+./DistributedMap.chpl:38         1        80       80       DistributedMapImpl(string,int(64))prediffed  
+./DistributedMap.chpl:38         1        80       80       DistributedMapImpl(string,int(64))prediffed  
+./DistributedMap.chpl:57         1        72       72       domain(1,int(64),false)          prediffed  
+./DistributedMap.chpl:57         1        72       72       domain(1,int(64),false)          prediffed  
 ./DistributedMap.chpl:63         1        12       12       _LockWrapper                     prediffed  
 ./DistributedMap.chpl:63         1        12       12       _LockWrapper                     prediffed  
 ./DistributedMap.chpl:63         1        12       12       _LockWrapper                     prediffed  
 ./DistributedMap.chpl:63         1        12       12       _LockWrapper                     prediffed  
 ./DistributedMap.chpl:63         1        12       12       _LockWrapper                     prediffed  
 ./DistributedMap.chpl:63         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:63         1        168      168      [domain(1,int(64),false)] locale prediffed  
-./DistributedMap.chpl:63         1        168      168      [domain(1,int(64),false)] locale prediffed  
-./DistributedMap.chpl:63         1        168      168      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
-./DistributedMap.chpl:63         1        168      168      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
-./DistributedMap.chpl:63         3        104      312      array elements                   prediffed  
-./DistributedMap.chpl:63         3        104      312      array elements                   prediffed  
-./DistributedMap.chpl:63         4        16       64       array elements                   prediffed  
-./DistributedMap.chpl:63         4        16       64       array elements                   prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        12       12       _LockWrapper                     prediffed  
-./DistributedMap.chpl:67         1        168      168      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
-./DistributedMap.chpl:67         1        168      168      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
-./DistributedMap.chpl:67         1        168      168      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
-./DistributedMap.chpl:67         1        168      168      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
-./DistributedMap.chpl:67         1        168      168      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
-./DistributedMap.chpl:67         1        168      168      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
-./DistributedMap.chpl:67         3        104      312      array elements                   prediffed  
-./DistributedMap.chpl:67         3        104      312      array elements                   prediffed  
-./DistributedMap.chpl:67         3        104      312      array elements                   prediffed  
-./DistributedMap.chpl:67         3        104      312      array elements                   prediffed  
-./DistributedMap.chpl:67         3        104      312      array elements                   prediffed  
-./DistributedMap.chpl:67         3        104      312      array elements                   prediffed  
-./DistributedMap.chpl:70         1        168      168      [domain(1,int(64),false)] locale prediffed  
-./DistributedMap.chpl:70         1        168      168      [domain(1,int(64),false)] locale prediffed  
-./DistributedMap.chpl:70         1        168      168      [domain(1,int(64),false)] locale prediffed  
-./DistributedMap.chpl:70         1        168      168      [domain(1,int(64),false)] locale prediffed  
-./DistributedMap.chpl:70         1        168      168      [domain(1,int(64),false)] locale prediffed  
-./DistributedMap.chpl:70         1        168      168      [domain(1,int(64),false)] locale prediffed  
-./DistributedMap.chpl:70         4        16       64       array elements                   prediffed  
-./DistributedMap.chpl:70         4        16       64       array elements                   prediffed  
-./DistributedMap.chpl:70         4        16       64       array elements                   prediffed  
-./DistributedMap.chpl:70         4        16       64       array elements                   prediffed  
-./DistributedMap.chpl:70         4        16       64       array elements                   prediffed  
-./DistributedMap.chpl:70         4        16       64       array elements                   prediffed  
-./DistributedMap.chpl:79         1        96       96       DistributedMapImpl(string,int(64))prediffed  
-./DistributedMap.chpl:79         1        96       96       DistributedMapImpl(string,int(64))prediffed  
-./DistributedMap.chpl:79         1        96       96       DistributedMapImpl(string,int(64))prediffed  
-./DistributedMap.chpl:79         1        96       96       DistributedMapImpl(string,int(64))prediffed  
-./DistributedMap.chpl:79         1        96       96       DistributedMapImpl(string,int(64))prediffed  
-./DistributedMap.chpl:79         1        96       96       DistributedMapImpl(string,int(64))prediffed  
-================================================= Memory Leaks ==================================================
-================================================= Memory Leaks ==================================================
-================================================= Memory Leaks ==================================================
+./DistributedMap.chpl:63         1        128      128      [domain(1,int(64),false)] locale prediffed  
+./DistributedMap.chpl:63         1        128      128      [domain(1,int(64),false)] locale prediffed  
+./DistributedMap.chpl:63         1        128      128      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
+./DistributedMap.chpl:63         1        128      128      [domain(1,int(64),false)] map(string,int(64),true)prediffed  
+./DistributedMap.chpl:63         1        8        8        array elements                   prediffed  
+./DistributedMap.chpl:63         1        8        8        array elements                   prediffed  
+./DistributedMap.chpl:63         3        80       240      array elements                   prediffed  
+./DistributedMap.chpl:63         3        80       240      array elements                   prediffed  
 ================================================= Memory Leaks ==================================================
 =================================================================================================================
 =================================================================================================================
-=================================================================================================================
-=================================================================================================================
-=================================================================================================================
-=================================================================================================================
-=================================================================================================================
-=================================================================================================================
-Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
-Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
-Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
 Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
 check1 passed
 check2 passed

--- a/test/library/draft/DistributedMap/use-distributed-map.execopts
+++ b/test/library/draft/DistributedMap/use-distributed-map.execopts
@@ -1,0 +1,1 @@
+--memLeaks --dataParTasksPerLocale=4

--- a/test/library/draft/DistributedMap/use-distributed-map.prediff
+++ b/test/library/draft/DistributedMap/use-distributed-map.prediff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat $2 | sed -E "s/0x[0-9a-f]*/prediffed/" | sort > $2.predifftmp
+mv $2.predifftmp $2


### PR DESCRIPTION
This PR does not fix the memleaks. It sets up a prediff
so that the test passes nightly testing, following the lead of:

    test/memory/ferguson/test1.chpl

plus sorting the output, which is needed to match .good reliably.

While there, reduce the problem size so that the test runs quickly.
If we want a stress test with higher problem size,
we should run it without --memLeaks.

Future work: do the same for these tests:
```
test/errhandling/parallel/forall-calls-throwing-fn2.chpl
test/library/packages/ConcurrentMap/testAddSet.chpl
test/library/packages/ConcurrentMap/testClear.chpl
test/library/packages/ConcurrentMap/testContains.chpl
test/library/packages/ConcurrentMap/testEquality.chpl
test/library/packages/ConcurrentMap/testExtend.chpl
test/library/packages/ConcurrentMap/testGetRemove.chpl
test/library/packages/EpochManager/distributedMemory/distributedMemory.chpl
test/library/packages/EpochManager/sharedMemory/sharedMemory.chpl
test/library/packages/LockFreeQueue/consistencyCheck.chpl
test/library/packages/LockFreeQueue/interleavedTest.chpl
test/library/packages/LockFreeStack/consistencyCheck.chpl
test/library/packages/LockFreeStack/interleavedTest.chpl
test/types/records/ferguson/leak-futures/iterate-loop-break.chpl
test/types/records/ferguson/leak-futures/iterate-loop-break2.chpl
test/types/records/ferguson/leak-futures/iterate-twice-break.chpl
```
