### PR TITLE
Fasta version that buffers the repeated sequence

### DIFF
--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -28,17 +28,17 @@ param IM = 139968,                      // values for random number generation
 //
 // Probability tables for sequences to be randomly generated
 //
-const IUB = [(b("a"), 0.27), (b("c"), 0.12), (b("g"), 0.12), (b("t"), 0.27),
-             (b("B"), 0.02), (b("D"), 0.02), (b("H"), 0.02), (b("K"), 0.02),
-             (b("M"), 0.02), (b("N"), 0.02), (b("R"), 0.02), (b("S"), 0.02),
-             (b("V"), 0.02), (b("W"), 0.02), (b("Y"), 0.02)],
+const IUB = [(b"a", 0.27), (b"c", 0.12), (b"g", 0.12), (b"t", 0.27),
+             (b"B", 0.02), (b"D", 0.02), (b"H", 0.02), (b"K", 0.02),
+             (b"M", 0.02), (b"N", 0.02), (b"R", 0.02), (b"S", 0.02),
+             (b"V", 0.02), (b"W", 0.02), (b"Y", 0.02)],
 
-      HomoSapiens = [(b("a"), 0.3029549426680),
-                     (b("c"), 0.1979883004921),
-                     (b("g"), 0.1975473066391),
-                     (b("t"), 0.3015094502008)],
+      HomoSapiens = [(b"a", 0.3029549426680),
+                     (b"c", 0.1979883004921),
+                     (b"g", 0.1975473066391),
+                     (b"t", 0.3015094502008)],
 
-      newline = b("\n"),   // newline's byte value
+      newline = b"\n"[0],   // newline's byte value
 
       // Redefine stdout to use lock-free binary I/O
       stdout = openfd(1).writer(kind=iokind.native, locking=false);
@@ -95,12 +95,12 @@ proc randomMake(nuclInfo, n) {
 
   var j = 0;
   for i in 0..<IM {
-    if 1.0 * i / IM >= sum {
+    if i:real / IM >= sum {
       j += 1;
       (ch, prob) = nuclInfo[j];
       sum += prob;
     }
-    hash[i] = ch;
+    hash[i] = ch[0];
   }
 
   param buffSize = buffLines * bytesPerLine;
@@ -110,10 +110,11 @@ proc randomMake(nuclInfo, n) {
       buffer: [0..<buffSize] uint(8);
 
   // add linefeeds
-  for i in lineLen..<buffSize by bytesPerLine do  // TODO: try forall?
+  for i in lineLen..<buffSize by bytesPerLine {
     buffer[i] = newline;
+  }
 
-  // write out most of the data in full buffers
+  // write out most of the data as full buffers
   for 0..<numBuffs {
     for j in 0..<buffLines {
       for k in 0..<lineLen {
@@ -149,14 +150,8 @@ proc randomMake(nuclInfo, n) {
   stdout.write(buffer[0..<offset+extra]);
 }
 
-// Utility to convert single-character strings to bytes
-proc b(s) {
-  return s.toByte();
-}
-
 //
 // Deterministic random number generator
-// (lastRand really wants to be a local static...)
 //
 var lastRand = 42: uint(32);
 

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -44,25 +44,27 @@ const IUB = [(b("a"), 0.27), (b("c"), 0.12), (b("g"), 0.12), (b("t"), 0.27),
       stdout = openfd(1).writer(kind=iokind.native, locking=false);
 
 proc main() {
-  // TODO: move writes of descriptions here?
-  repeatMake(">ONE Homo sapiens alu", ALU, 2*n);
-  randomMake(">TWO IUB ambiguity codes", IUB, 3*n);
-  randomMake(">THREE Homo sapiens frequency", HomoSapiens, 5*n);
+  stdout.writeln(">ONE Homo sapiens alu");
+  repeatMake(ALU, 2*n);
+  stdout.writeln(">TWO IUB ambiguity codes");
+  randomMake(IUB, 3*n);
+  stdout.writeln(">THREE Homo sapiens frequency");
+  randomMake(HomoSapiens, 5*n);
 }
 
 //
 // Repeat 'alu' to generate a sequence of length 'n'
 //
-proc repeatMake(desc, param alu, n) {
-  stdout.writeln(desc);
-
+proc repeatMake(param alu, n) {
   param len = alu.size,
         alu2 = alu + alu,
         buffLen = len*bytesPerLine;
 
   var buffer: [0..<buffLen] uint(8);
-  for i in 0..buffLen by bytesPerLine do
-    buffer[i..#lineLen] = alu2[i%len..#lineLen];
+  for i in 0..<len {
+    buffer[i*bytesPerLine..#lineLen] = alu2[(i*lineLen)%len..#lineLen];
+    buffer[i*bytesPerLine+lineLen] = newline;
+  }
 
   const wholeBuffers = n / (len*lineLen);
   for i in 0..<wholeBuffers do
@@ -80,9 +82,7 @@ proc repeatMake(desc, param alu, n) {
 // Use 'nuclInfo's probability distribution to generate a random
 // sequence of length 'n'
 //
-proc randomMake(desc, nuclInfo, n) {
-  stdout.writeln(desc);
-
+proc randomMake(nuclInfo, n) {
   var hash: [0..<IM] uint(8),
       (ch, prob) = nuclInfo[0],
       sum = prob;
@@ -99,12 +99,12 @@ proc randomMake(desc, nuclInfo, n) {
 
   param buffSize = buffLines * bytesPerLine;
 
-  var numLines = n/lineLen,
-      numBuffs = numLines/buffLines,
+  var numLines = n / lineLen,
+      numBuffs = numLines / buffLines,
       buffer: [0..<buffSize] uint(8);
 
   // add linefeeds
-  for i in lineLen..<buffSize by lineLen+1 do  // TODO: try forall?
+  for i in lineLen..<buffSize by bytesPerLine do  // TODO: try forall?
     buffer[i] = newline;
 
   // write out most of the data in full buffers

--- a/test/studies/shootout/fasta/bradc/fasta-blc.chpl
+++ b/test/studies/shootout/fasta/bradc/fasta-blc.chpl
@@ -43,14 +43,18 @@ const IUB = [(b("a"), 0.27), (b("c"), 0.12), (b("g"), 0.12), (b("t"), 0.27),
       // Redefine stdout to use lock-free binary I/O
       stdout = openfd(1).writer(kind=iokind.native, locking=false);
 
+
 proc main() {
   stdout.writeln(">ONE Homo sapiens alu");
   repeatMake(ALU, 2*n);
+
   stdout.writeln(">TWO IUB ambiguity codes");
   randomMake(IUB, 3*n);
+
   stdout.writeln(">THREE Homo sapiens frequency");
   randomMake(HomoSapiens, 5*n);
 }
+
 
 //
 // Repeat 'alu' to generate a sequence of length 'n'
@@ -58,24 +62,26 @@ proc main() {
 proc repeatMake(param alu, n) {
   param len = alu.size,
         alu2 = alu + alu,
-        buffLen = len*bytesPerLine;
+        buffLen = len * bytesPerLine;
 
   var buffer: [0..<buffLen] uint(8);
   for i in 0..<len {
     buffer[i*bytesPerLine..#lineLen] = alu2[(i*lineLen)%len..#lineLen];
-    buffer[i*bytesPerLine+lineLen] = newline;
+    buffer[i*bytesPerLine + lineLen] = newline;
   }
 
   const wholeBuffers = n / (len*lineLen);
-  for i in 0..<wholeBuffers do
+  for i in 0..<wholeBuffers {
     stdout.write(buffer);
+  }
 
-  var extra = n - wholeBuffers * len * lineLen;
-  extra += extra / lineLen;
+  var extra = n - wholeBuffers*len*lineLen;
+  extra += extra/lineLen;
   stdout.write(buffer[..<extra]);
 
-  if n % lineLen != 0 then
+  if n % lineLen != 0 {
     stdout.write("\n");
+  }
 }
 
 //
@@ -109,25 +115,30 @@ proc randomMake(nuclInfo, n) {
 
   // write out most of the data in full buffers
   for 0..<numBuffs {
-    for j in 0..<buffLines do
-      for k in 0..<lineLen do
+    for j in 0..<buffLines {
+      for k in 0..<lineLen {
         buffer[j*bytesPerLine + k] = hash[getNextRand()];
+      }
+    }
     stdout.write(buffer);
   }
 
   // compute number of complete lines remaining and fill them in
   numLines -= numBuffs * buffLines;
 
-  for j in 0..<numLines do
-    for k in 0..<lineLen do
+  for j in 0..<numLines {
+    for k in 0..<lineLen {
       buffer[j*bytesPerLine + k] = hash[getNextRand()];
+    }
+  }
 
   // compute number of extra characters and fill them in
   var extra = n % lineLen,
       offset = numLines * bytesPerLine;
 
-  for k in 0..<extra do
+  for k in 0..<extra {
     buffer[offset + k] = hash[getNextRand()];
+  }
 
   // add a final linefeed if needed
   if (extra != 0) {


### PR DESCRIPTION
This incorporates the repeatMake() step of the gcc # 9 version and does some
other cleanup.

On my Mac, this gives about a 12% speedup over the current submitted version
and an 8% speedup over the current version on main, with a gz size of 1134
compared to 1391 for the current submitted version and 1060 for the version on
main.