### PR TITLE
Fix future test failure by updating .bad file for test

### DIFF
--- a/test/functions/nspark/generic-varargs2.bad
+++ b/test/functions/nspark/generic-varargs2.bad
@@ -1,4 +1,4 @@
 generic-varargs2.chpl:15: error: unresolved call 'Foo.init(4, 8, 15, 16, 23, 42)'
-generic-varargs2.chpl:5: note: this candidate did not match: Foo.init(args ..., type eltType = args.type )
+generic-varargs2.chpl:5: note: this candidate did not match: Foo.init(args ..., type eltType = args.type)
 generic-varargs2.chpl:15: note: because non-type actual argument #6
 generic-varargs2.chpl:5: note: is passed to formal 'eltType'


### PR DESCRIPTION
This PR fixes a future test that began failing when we stopped printing an 
extra space between the last keyword token and a closing paren in 
the function signature.

TESTING: 

- [x] `start_test` reports future instead of failure
- [x] tested with `--dyno` flag

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>