### PR TITLE
Fix the default value for ranges in the spec

### DIFF
--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -275,7 +275,7 @@ bytes       b""
 enums       first enum constant
 classes     nil
 records     default constructed record
-ranges      1..0 :math:`` :math:`` (empty sequence)
+ranges      1..0 (empty range)
 arrays      elements are default values
 tuples      components are default values
 sync/single base default value and *empty* status


### PR DESCRIPTION
The default value for ranges had some left over formatting text that was
showing up in the document. Remove it and change the word 'sequence' to 'range'.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>