### PR TITLE
Implement a better fix for an MCM issue in ofi msg-order-fence

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3677,9 +3677,9 @@ void mcmReleaseAllNodes(struct bitmap_t* b1, struct bitmap_t* b2,
         if (skipNode < 0 || node != skipNode) {
           (*tcip->checkTxCmplsFn)(tcip);
           mcmReleaseOneNode(node, tcip, dbgOrderStr);
+          bitmapClear(b2, node);
         }
       } BITMAP_FOREACH_SET_END
-      bitmapZero(b2);
     }
   } else {
     if (b2 == NULL) {
@@ -3687,18 +3687,18 @@ void mcmReleaseAllNodes(struct bitmap_t* b1, struct bitmap_t* b2,
         if (skipNode < 0 || node != skipNode) {
           (*tcip->checkTxCmplsFn)(tcip);
           mcmReleaseOneNode(node, tcip, dbgOrderStr);
+          bitmapClear(b1, node);
         }
       } BITMAP_FOREACH_SET_END
-      bitmapZero(b1);
     } else {
       BITMAP_FOREACH_SET_OR(b1, b2, node) {
         if (skipNode < 0 || node != skipNode) {
           (*tcip->checkTxCmplsFn)(tcip);
           mcmReleaseOneNode(node, tcip, dbgOrderStr);
+          bitmapClear(b1, node);
+          bitmapClear(b2, node);
         }
       } BITMAP_FOREACH_SET_END
-      bitmapZero(b1);
-      bitmapZero(b2);
     }
   }
 }
@@ -4288,7 +4288,8 @@ void amReqFn_msgOrdFence(c_nodeid_t node,
   // to any node are visible.  Similarly, for GETs we have to ensure
   // that previous AMOs and PUTs to the target node are visible, and for
   // PUTs we have to ensure that previous AMOs to the target node are
-  // visible.  Do that here for all nodes.
+  // visible.  Do that here for all nodes except this op's target.  For
+  // that node, we'll use a fenced send instead.
   //
   chpl_bool havePutsOut = false;
   chpl_bool haveAmosOut = false;
@@ -4297,7 +4298,7 @@ void amReqFn_msgOrdFence(c_nodeid_t node,
   case am_opExecOn:
   case am_opExecOnLrg:
     forceMemFxVisAllNodes(true /*checkPuts*/, true /*checkAmos*/,
-                          -1 /*skipNode*/, tcip);
+                          node /*skipNode*/, tcip);
     havePutsOut = (tcip->putVisBitmap != NULL
                    && bitmapTest(tcip->putVisBitmap, node));
     haveAmosOut = (tcip->amoVisBitmap != NULL
@@ -4307,7 +4308,7 @@ void amReqFn_msgOrdFence(c_nodeid_t node,
     {
       chpl_bool amoHasMemFx = (req->amo.ofiOp != FI_ATOMIC_READ);
       forceMemFxVisAllNodes(amoHasMemFx /*checkPuts*/, true /*checkAmos*/,
-                            -1 /*skipNode*/, tcip);
+                            node /*skipNode*/, tcip);
       havePutsOut = (amoHasMemFx
                      && tcip->putVisBitmap != NULL
                      && bitmapTest(tcip->putVisBitmap, node));


### PR DESCRIPTION
Implement a better fix for #19575. In that PR we forced memory visibility
for all nodes before doing an AM to fix a MCM race. This was because a
fenced send did not appear to be fencing, but it turns out that we were
clearing the bitmask used to track outstanding operations for all nodes
instead of excluding the current one. That resulted in issuing a regular
non-fenced send. Fix that by only clearing pending ops for the nodes we
forced visibility for. This allows us to revert the previous workaround.

Part of Cray/chapel-private#3146