### PR TITLE
dyno: Fix a recursion bug for interfaces

### DIFF
--- a/compiler/dyno/include/chpl/uast/Interface.h
+++ b/compiler/dyno/include/chpl/uast/Interface.h
@@ -145,7 +145,7 @@ class Interface final : public NamedDecl {
   */
   const AstNode* formal(int i) const {
     assert(i >= 0 && i < numBodyStmts_);
-    auto ret = stmt(i + interfaceFormalsChildNum_);
+    auto ret = child(i + interfaceFormalsChildNum_);
     assert(ret);
     return ret;
   }
@@ -171,7 +171,7 @@ class Interface final : public NamedDecl {
   */
   const AstNode* stmt(int i) const {
     assert(i >= 0 && i < numBodyStmts_);
-    auto ret = stmt(i + bodyChildNum_);
+    auto ret = child(i + bodyChildNum_);
     assert(ret);
     return ret;
   }

--- a/compiler/dyno/test/parsing/testParseInterface.cpp
+++ b/compiler/dyno/test/parsing/testParseInterface.cpp
@@ -19,12 +19,10 @@
 
 #include "chpl/parsing/Parser.h"
 #include "chpl/uast/AstNode.h"
-#include "chpl/uast/Begin.h"
-#include "chpl/uast/Block.h"
 #include "chpl/uast/Comment.h"
-#include "chpl/uast/Identifier.h"
+#include "chpl/uast/Interface.h"
+#include "chpl/uast/Implements.h"
 #include "chpl/uast/Module.h"
-#include "chpl/uast/Sync.h"
 #include "chpl/queries/Context.h"
 
 
@@ -53,6 +51,12 @@ static void test0(Parser* parser) {
   assert(mod->stmt(0)->isComment());
   assert(mod->stmt(1)->isInterface());
   assert(mod->stmt(2)->isComment());
+  auto intf = mod->stmt(1)->toInterface();
+  assert(intf);
+  assert(intf->isFormalListPresent());
+  assert(intf->numFormals() == 3);
+  assert(intf->numStmts() == 1);
+  assert(intf->stmt(0)->isFunction());
 }
 
 


### PR DESCRIPTION
dyno: Fix a recursion bug for interfaces (#19640)

Fix a bug in which two accessors on the interface class were
incorrectly calling the `stmt` accessor.

Add the buggy cases to the parsing test for interfaces.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>