### PR TITLE
Remove unused bitmapZero from ofi comm layer

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -734,11 +734,6 @@ size_t bitmapSizeof(size_t len) {
 }
 
 static inline
-void bitmapZero(struct bitmap_t* b) {
-  memset(&b->map, 0, bitmapSizeofMap(b->len));
-}
-
-static inline
 bitmapBaseType_t bitmapElemBit(size_t i) {
   return ((bitmapBaseType_t) 1) << bitmapOff(i);
 }


### PR DESCRIPTION
This is no longer used after #19638, so remove it.