### PR TITLE
docs: update example help output in ArgumentParser docs

### DIFF
--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -168,6 +168,7 @@
 
     OPTIONS:
             -h, --help      Display this message and exit
+            --debug
             --optional <OPTIONAL>
 
 


### PR DESCRIPTION
This PR updates the example output in the `ArgumentParser` docs
to include the `--debug` flag in the output, as the example
quickstart code would produce.

TESTING:

- [x] `make docs` and manually inspect `ArgumentParser` page

I believe this update is trivial and falls below the bar of needing a review.

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>