### PR TITLE
dyno: use dyno parser for config parsing and updating of uAST

### DIFF
--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -25,7 +25,7 @@
 #include "chpl/queries/ID.h"
 #include "chpl/queries/Location.h"
 #include "chpl/uast/AstNode.h"
-#include "chpl/uast/Builder.h"
+#include "chpl/uast/BuilderResult.h"
 #include "chpl/uast/Function.h"
 #include "chpl/uast/Module.h"
 
@@ -151,6 +151,14 @@ void setConfigParams(Context* context, std::vector<std::pair<std::string,std::st
 
 const
 std::vector<std::pair<std::string,std::string>>& configParams(Context* context);
+
+// TODO: Should these queries be private
+// use the config param by storing the ID where it was used
+void
+useConfigParam(Context* context, UniqueString name, ID id);
+
+// check if config was used already
+const ID& nameToConfigParamId(Context*, UniqueString name);
 
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -160,13 +160,6 @@ const
 ConfigSettingsList& configSettings(Context* context);
 
 
-// note the ID to which we have associated a config set on the compile command-line
-void
-useConfigSetting(Context* context, std::string name, ID id);
-
-// check if config set from the commmand-line was used already
-const ID& nameToConfigSettingId(Context* context, std::string name);
-
 } // end namespace parsing
 } // end namespace chpl
 #endif

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -158,7 +158,7 @@ void
 useConfigParam(Context* context, UniqueString name, ID id);
 
 // check if config was used already
-const ID& nameToConfigParamId(Context*, UniqueString name);
+const ID& nameToConfigParamId(Context* context, UniqueString name);
 
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -148,8 +148,14 @@ uast::Function::ReturnIntent idToFnReturnIntent(Context* context, ID id);
  */
 bool functionWithIdHasWhere(Context* context, ID id);
 
+/**
+ * Store config settings that were set from the command line using -s flags
+ */
 void setConfigSettings(Context* context, ConfigSettingsList keys);
 
+/**
+ * Get any config settings that were set from the command line and stored
+ */
 const
 ConfigSettingsList& configSettings(Context* context);
 

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -34,6 +34,7 @@
 namespace chpl {
 namespace parsing {
 
+using ConfigParamList = std::vector<std::pair<std::string, std::string>>;
 
 /**
  This query returns the contents of a file as the string field in the
@@ -147,10 +148,10 @@ uast::Function::ReturnIntent idToFnReturnIntent(Context* context, ID id);
  */
 bool functionWithIdHasWhere(Context* context, ID id);
 
-void setConfigParams(Context* context, std::vector<std::pair<std::string,std::string>> keys);
+void setConfigParams(Context* context, ConfigParamList keys);
 
 const
-std::vector<std::pair<std::string,std::string>>& configParams(Context* context);
+ConfigParamList& configParams(Context* context);
 
 // TODO: Should these queries be private
 // use the config param by storing the ID where it was used

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -34,7 +34,7 @@
 namespace chpl {
 namespace parsing {
 
-using ConfigParamList = std::vector<std::pair<std::string, std::string>>;
+using ConfigSettingsList = std::vector<std::pair<std::string, std::string>>;
 
 /**
  This query returns the contents of a file as the string field in the
@@ -148,18 +148,18 @@ uast::Function::ReturnIntent idToFnReturnIntent(Context* context, ID id);
  */
 bool functionWithIdHasWhere(Context* context, ID id);
 
-void setConfigParams(Context* context, ConfigParamList keys);
+void setConfigSettings(Context* context, ConfigSettingsList keys);
 
 const
-ConfigParamList& configParams(Context* context);
+ConfigSettingsList& configSettings(Context* context);
 
-// TODO: Should these queries be private
-// use the config param by storing the ID where it was used
+
+// note the ID to which we have associated a config set on the compile command-line
 void
-useConfigParam(Context* context, std::string name, ID id);
+useConfigSetting(Context* context, std::string name, ID id);
 
-// check if config was used already
-const ID& nameToConfigParamId(Context* context, std::string name);
+// check if config set from the commmand-line was used already
+const ID& nameToConfigSettingId(Context* context, std::string name);
 
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -155,10 +155,10 @@ std::vector<std::pair<std::string,std::string>>& configParams(Context* context);
 // TODO: Should these queries be private
 // use the config param by storing the ID where it was used
 void
-useConfigParam(Context* context, UniqueString name, ID id);
+useConfigParam(Context* context, std::string name, ID id);
 
 // check if config was used already
-const ID& nameToConfigParamId(Context* context, UniqueString name);
+const ID& nameToConfigParamId(Context* context, std::string name);
 
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -147,6 +147,10 @@ uast::Function::ReturnIntent idToFnReturnIntent(Context* context, ID id);
  */
 bool functionWithIdHasWhere(Context* context, ID id);
 
+void setConfigParams(Context* context, std::vector<std::pair<std::string,std::string>> keys);
+
+const
+std::vector<std::pair<std::string,std::string>>& configParams(Context* context);
 
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/dyno/include/chpl/queries/mark-functions.h
+++ b/compiler/dyno/include/chpl/queries/mark-functions.h
@@ -96,11 +96,11 @@ template<typename K, typename V> struct mark<std::unordered_map<K,V>> {
 };
 
 template<typename A, typename B> struct mark<std::pair<A,B>> {
-  void operator()(Context* context, std::pair<A,B>& keep) const {
+  void operator()(Context* context, const std::pair<A,B>& keep) const {
     chpl::mark<A> firstMarker;
     chpl::mark<B> secondMarker;
-    firstMarker.mark(context, keep.first);
-    secondMarker.mark(context, keep.second);
+    firstMarker(context, keep.first);
+    secondMarker(context, keep.second);
   }
 };
 /// \endcond

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -159,6 +159,9 @@ class Builder final {
   // build a dummy input string and parse it, extracting the initExpr and returning it
   owned <AstNode> parseDummyNodeForInitExpr(Variable* var, std::string value);
 
+  // check that all the configs passed from the command line were consumed
+  static bool checkAllConfigVarsAssigned(Context* context);
+
   /// \endcond
 
 };

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -149,6 +149,10 @@ class Builder final {
   void noteChildrenLocations(AstNode* ast, Location loc);
 
   void checkConfigPreviouslyUsed(const AstNode* ast, std::string& configNameUsed);
+
+  std::pair<std::string, std::string> nodeMatchesConfig(AstNode* ast, pathVecT &pathVec);
+
+  AstNode* checkAndUpdateConfig(AstNode* ast, std::pair<std::string, std::string> configPair);
 };
 
 } // end namespace uast

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -142,9 +142,10 @@ class Builder final {
 
   // Use this to get a temporary location while parsing.
   Location getLocation(const AstNode* ast);
+  std::tuple<AstNode*,std::string> checkAndUpdateConfig(AstNode *ast, pathVecT& pathVec);
 
   /// \endcond
-  AstNode *checkAndUpdateConfig(AstNode *ast);
+
 };
 
 } // end namespace uast

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -26,6 +26,7 @@
 #include "chpl/queries/update-functions.h"
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/BuilderResult.h"
+#include "chpl/uast/Variable.h"
 
 #include <vector>
 #include <unordered_map>
@@ -123,6 +124,11 @@ class Builder final {
     return ast->children_;
   }
 
+  void addOrReplaceInitExpr(Variable* var, AstNode* ie) {
+    var->setInitExprForConfig(ie);
+  }
+
+
   // Use this to take the children of an AST node. The AST node is marked
   // as owned because it is consumed.
   AstList takeChildren(owned<AstNode> ast) {
@@ -138,6 +144,7 @@ class Builder final {
   Location getLocation(const AstNode* ast);
 
   /// \endcond
+  AstNode *checkAndUpdateConfig(AstNode *ast);
 };
 
 } // end namespace uast

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -146,6 +146,7 @@ class Builder final {
 
   /// \endcond
 
+  void noteChildrenLocations(AstNode *ast, Location loc);
 };
 
 } // end namespace uast

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -124,8 +124,8 @@ class Builder final {
     return ast->children_;
   }
 
-  void addOrReplaceInitExpr(Variable* var, AstNode* ie) {
-    var->setInitExprForConfig(ie);
+  void addOrReplaceInitExpr(Variable* var, owned<AstNode> ie) {
+    var->setInitExprForConfig(std::move(ie));
   }
 
 

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -144,15 +144,17 @@ class Builder final {
   Location getLocation(const AstNode* ast);
   std::tuple<AstNode*, std::string> checkAndUpdateConfig(AstNode *ast, pathVecT& pathVec);
 
-  /// \endcond
+  std::pair<std::string, std::string> nodeMatchesConfig(AstNode* ast, pathVecT& pathVec);
+
+  AstNode* checkAndUpdateConfig(AstNode* ast, std::pair<std::string, std::string> configPair);
 
   void noteChildrenLocations(AstNode* ast, Location loc);
 
   void checkConfigPreviouslyUsed(const AstNode* ast, std::string& configNameUsed);
 
-  std::pair<std::string, std::string> nodeMatchesConfig(AstNode* ast, pathVecT &pathVec);
+  /// \endcond
 
-  AstNode* checkAndUpdateConfig(AstNode* ast, std::pair<std::string, std::string> configPair);
+
 };
 
 } // end namespace uast

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -142,18 +142,24 @@ class Builder final {
 
   // Use this to get a temporary location while parsing.
   Location getLocation(const AstNode* ast);
-  std::tuple<AstNode*, std::string> checkAndUpdateConfig(AstNode *ast, pathVecT& pathVec);
 
-  std::pair<std::string, std::string> nodeMatchesConfig(AstNode* ast, pathVecT& pathVec);
+  // check for the existence of new config values (from the command line) for this var
+  void lookupConfigSettingsForVar(Variable* var, pathVecT& pathVec, std::string& name, std::string& value);
 
-  AstNode* checkAndUpdateConfig(AstNode* ast, std::pair<std::string, std::string> configPair);
+  // update the initExpr of a config with values passed from the command line
+  AstNode* updateConfig(Variable* var, std::string configName, std::string configVal);
 
+  // recursively note the location of a nodes children as the location of the parent
+  // used when updating a config with a new initExpr
   void noteChildrenLocations(AstNode* ast, Location loc);
 
-  void checkConfigPreviouslyUsed(const AstNode* ast, std::string& configNameUsed);
+  // used to check if a config assignment was used in a previous assignment
+  void checkConfigPreviouslyUsed(const Variable* var, std::string& configNameUsed);
+
+  // build a dummy input string and parse it, extracting the initExpr and returning it
+  owned <AstNode> parseDummyNodeForInitExpr(Variable* var, std::string value);
 
   /// \endcond
-
 
 };
 

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -142,11 +142,13 @@ class Builder final {
 
   // Use this to get a temporary location while parsing.
   Location getLocation(const AstNode* ast);
-  std::tuple<AstNode*,std::string> checkAndUpdateConfig(AstNode *ast, pathVecT& pathVec);
+  std::tuple<AstNode*, std::string> checkAndUpdateConfig(AstNode *ast, pathVecT& pathVec);
 
   /// \endcond
 
-  void noteChildrenLocations(AstNode *ast, Location loc);
+  void noteChildrenLocations(AstNode* ast, Location loc);
+
+  void checkConfigPreviouslyUsed(const AstNode* ast, std::string& configNameUsed);
 };
 
 } // end namespace uast

--- a/compiler/dyno/include/chpl/uast/Variable.h
+++ b/compiler/dyno/include/chpl/uast/Variable.h
@@ -49,6 +49,7 @@ namespace uast {
   each of a-f are Variables.
  */
 class Variable final : public VarLikeDecl {
+ friend class Builder;
  public:
   enum Kind {
     // Use IntentList here for consistent enum values.
@@ -97,6 +98,22 @@ class Variable final : public VarLikeDecl {
 
   bool isConfig_;
   bool isField_;
+
+  void setInitExprForConfig(AstNode* ie) {
+    if (this->initExpressionChildNum_ > -1) {
+      auto lst = makeAstList(toOwned(ie));
+      updateAstList(children_, lst);
+    } else if (this->typeExpressionChildNum_ > -1 || this->attributesChildNum() > -1) {
+      initExpressionChildNum_ = children_.size();
+      children_.push_back(toOwned(ie));
+      assert(numChildren() > 1);
+    } else {
+      initExpressionChildNum_ = children_.size();
+      auto lst = makeAstList(toOwned(ie));
+      assert(updateAstList(children_, lst));
+    }
+
+  }
 
  public:
   ~Variable() override = default;

--- a/compiler/dyno/include/chpl/uast/Variable.h
+++ b/compiler/dyno/include/chpl/uast/Variable.h
@@ -101,16 +101,19 @@ class Variable final : public VarLikeDecl {
 
   void setInitExprForConfig(AstNode* ie) {
     if (this->initExpressionChildNum_ > -1) {
-      auto lst = makeAstList(toOwned(ie));
-      updateAstList(children_, lst);
+      // have an existing initExpr, swap it
+      auto newInit = toOwned(ie);
+      this->children_[this->initExpressionChildNum_].swap(newInit);
     } else if (this->typeExpressionChildNum_ > -1 || this->attributesChildNum() > -1) {
+      // no initExpr, but do have either typeExpr or attribute, append children
       initExpressionChildNum_ = children_.size();
       children_.push_back(toOwned(ie));
       assert(numChildren() > 1);
     } else {
+      // no initExpr and no typeExpr nor attribute
       initExpressionChildNum_ = children_.size();
-      auto lst = makeAstList(toOwned(ie));
-      assert(updateAstList(children_, lst));
+      children_.push_back(toOwned(ie));
+      assert(numChildren() == 1);
     }
 
   }

--- a/compiler/dyno/include/chpl/uast/Variable.h
+++ b/compiler/dyno/include/chpl/uast/Variable.h
@@ -99,23 +99,20 @@ class Variable final : public VarLikeDecl {
   bool isConfig_;
   bool isField_;
 
-  void setInitExprForConfig(AstNode* ie) {
+  void setInitExprForConfig(owned<AstNode> ie) {
     if (this->initExpressionChildNum_ > -1) {
       // have an existing initExpr, swap it
-      auto newInit = toOwned(ie);
-      this->children_[this->initExpressionChildNum_].swap(newInit);
-    } else if (this->typeExpressionChildNum_ > -1 || this->attributesChildNum() > -1) {
-      // no initExpr, but do have either typeExpr or attribute, append children
-      initExpressionChildNum_ = children_.size();
-      children_.push_back(toOwned(ie));
-      assert(numChildren() > 1);
+      this->children_[this->initExpressionChildNum_].swap(ie);
     } else {
       // no initExpr and no typeExpr nor attribute
       initExpressionChildNum_ = children_.size();
-      children_.push_back(toOwned(ie));
-      assert(numChildren() == 1);
+      children_.push_back(std::move(ie));
+      if (this->typeExpressionChildNum_ > -1 || this->attributesChildNum() > -1) {
+        assert(numChildren() > 1);
+      } else {
+        assert(numChildren() == 1);
+      }
     }
-
   }
 
  public:

--- a/compiler/dyno/include/chpl/uast/Variable.h
+++ b/compiler/dyno/include/chpl/uast/Variable.h
@@ -99,21 +99,11 @@ class Variable final : public VarLikeDecl {
   bool isConfig_;
   bool isField_;
 
-  void setInitExprForConfig(owned<AstNode> ie) {
-    if (this->initExpressionChildNum_ > -1) {
-      // have an existing initExpr, swap it
-      this->children_[this->initExpressionChildNum_].swap(ie);
-    } else {
-      // no initExpr and no typeExpr nor attribute
-      initExpressionChildNum_ = children_.size();
-      children_.push_back(std::move(ie));
-      if (this->typeExpressionChildNum_ > -1 || this->attributesChildNum() > -1) {
-        assert(numChildren() > 1);
-      } else {
-        assert(numChildren() == 1);
-      }
-    }
-  }
+  /**
+   * Allows for setting a new initExpr when this Variable is a config
+   * Can only be used while the uAST is mutable in the Builder
+   */
+  void setInitExprForConfig(owned<AstNode> ie);
 
  public:
   ~Variable() override = default;

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -364,7 +364,6 @@ useConfigParam(Context* context, UniqueString name, ID id) {
 const ID& nameToConfigParamId(Context* context, UniqueString name) {
   QUERY_BEGIN_INPUT(nameToConfigParamId, context, name);
   ID result;
-  // context->
   return QUERY_END(result);
 }
 

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -355,19 +355,6 @@ ConfigSettingsList& configSettings(Context* context) {
   return QUERY_END(result);
 }
 
-void
-useConfigSetting(Context* context, std::string name, ID id) {
-  QUERY_STORE_INPUT_RESULT(nameToConfigSettingId, context, id, name);
-}
-
-// check if config was used already
-const ID& nameToConfigSettingId(Context* context, std::string name) {
-  QUERY_BEGIN_INPUT(nameToConfigSettingId, context, name);
-
-  // return empty ID if ID not already set using useConfigSetting
-  ID result;
-  return QUERY_END(result);
-}
 
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -355,5 +355,18 @@ std::vector<std::pair<std::string,std::string>>& configParams(Context* context) 
   return QUERY_END(result);
 }
 
+void
+useConfigParam(Context* context, UniqueString name, ID id) {
+  QUERY_STORE_INPUT_RESULT(nameToConfigParamId, context, id, name);
+}
+
+// check if config was used already
+const ID& nameToConfigParamId(Context* context, UniqueString name) {
+  QUERY_BEGIN_INPUT(nameToConfigParamId, context, name);
+  ID result;
+  // context->
+  return QUERY_END(result);
+}
+
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -341,28 +341,30 @@ bool functionWithIdHasWhere(Context* context, ID id) {
   return functionWithIdHasWhereQuery(context, id);
 }
 
-void setConfigParams(Context* context, std::vector<std::pair<std::string,std::string>> keys) {
-  QUERY_STORE_INPUT_RESULT(configParams, context, keys);
+void setConfigSettings(Context* context, ConfigSettingsList keys) {
+  QUERY_STORE_INPUT_RESULT(configSettings, context, keys);
 }
 
 const
-std::vector<std::pair<std::string,std::string>>& configParams(Context* context) {
-  QUERY_BEGIN_INPUT(configParams, context);
+ConfigSettingsList& configSettings(Context* context) {
+  QUERY_BEGIN_INPUT(configSettings, context);
 
-  // return empty configParams if not already set using setConfigParams
-  std::vector<std::pair<std::string, std::string>> result;
+  // return empty configSettings if not already set using setConfigSettings
+  ConfigSettingsList result;
 
   return QUERY_END(result);
 }
 
 void
-useConfigParam(Context* context, std::string name, ID id) {
-  QUERY_STORE_INPUT_RESULT(nameToConfigParamId, context, id, name);
+useConfigSetting(Context* context, std::string name, ID id) {
+  QUERY_STORE_INPUT_RESULT(nameToConfigSettingId, context, id, name);
 }
 
 // check if config was used already
-const ID& nameToConfigParamId(Context* context, std::string name) {
-  QUERY_BEGIN_INPUT(nameToConfigParamId, context, name);
+const ID& nameToConfigSettingId(Context* context, std::string name) {
+  QUERY_BEGIN_INPUT(nameToConfigSettingId, context, name);
+
+  // return empty ID if ID not already set using useConfigSetting
   ID result;
   return QUERY_END(result);
 }

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -341,6 +341,19 @@ bool functionWithIdHasWhere(Context* context, ID id) {
   return functionWithIdHasWhereQuery(context, id);
 }
 
+void setConfigParams(Context* context, std::vector<std::pair<std::string,std::string>> keys) {
+  QUERY_STORE_INPUT_RESULT(configParams, context, keys);
+}
+
+const
+std::vector<std::pair<std::string,std::string>>& configParams(Context* context) {
+  QUERY_BEGIN_INPUT(configParams, context);
+
+  // return empty configParams if not already set using setConfigParams
+  std::vector<std::pair<std::string, std::string>> result;
+
+  return QUERY_END(result);
+}
 
 } // end namespace parsing
 } // end namespace chpl

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -356,12 +356,12 @@ std::vector<std::pair<std::string,std::string>>& configParams(Context* context) 
 }
 
 void
-useConfigParam(Context* context, UniqueString name, ID id) {
+useConfigParam(Context* context, std::string name, ID id) {
   QUERY_STORE_INPUT_RESULT(nameToConfigParamId, context, id, name);
 }
 
 // check if config was used already
-const ID& nameToConfigParamId(Context* context, UniqueString name) {
+const ID& nameToConfigParamId(Context* context, std::string name) {
   QUERY_BEGIN_INPUT(nameToConfigParamId, context, name);
   ID result;
   return QUERY_END(result);

--- a/compiler/dyno/lib/uast/Builder.cpp
+++ b/compiler/dyno/lib/uast/Builder.cpp
@@ -339,6 +339,15 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
             // found a config that was set via cmd line: replace the node
             // need to build up a new Variable from the old one, copying all the
             // internals
+            
+            // handle deprecations
+            if (auto attribs = var->attributes()) {
+              if (attribs->isDeprecated()) {
+                std::string msg = "'" + var->name().str() + "' was set via a compiler flag";
+                std::cout << "warning: " + attribs->deprecationMessage().str() << std::endl;
+                std::cout << "note: " + msg << std::endl;
+              }
+            }
             auto parser = parsing::Parser::build(context());
             parsing::Parser* p = parser.get();
             std::string inputText;

--- a/compiler/dyno/lib/uast/Builder.cpp
+++ b/compiler/dyno/lib/uast/Builder.cpp
@@ -348,7 +348,11 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
               if (attribs->isDeprecated()) {
                 // TODO: Need proper message handling here
                 std::string msg = "'" + var->name().str() + "' was set via a compiler flag";
-                std::cerr << "warning: " + attribs->deprecationMessage().str() << std::endl;
+                if (attribs->deprecationMessage().isEmpty()) {
+                  std::cerr << "warning: " + var->name().str() + " is deprecated" << std::endl;
+                } else {
+                  std::cerr << "warning: " + attribs->deprecationMessage().str() << std::endl;
+                }
                 std::cerr << "note: " + msg << std::endl;
               }
             }

--- a/compiler/dyno/lib/uast/Builder.cpp
+++ b/compiler/dyno/lib/uast/Builder.cpp
@@ -202,7 +202,6 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     return;
   }
 
-// TODO: Le extract me
   AstNode* ieNode = nullptr;
   ieNode = checkAndUpdateConfig(ast);
 
@@ -291,6 +290,17 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     idToLocation_[ast->id()] = search->second;
     if (ieNode) {
       parsing::useConfigParam(this->context(), ast->toVariable()->name(), ast->id());
+      auto usedId = parsing::nameToConfigParamId(this->context(), ast->toVariable()->name());
+      // TODO: Why is this ID always coming back empty?
+      if (usedId != ast->id()) {
+        std::string err = "ambiguous config name (";
+        err += ast->toVariable()->name().c_str();
+        err += ")";
+        assert(false && err.c_str());
+        //            USR_FATAL_CONT(var, "ambiguous config name (%s)", var->name());
+        //            USR_PRINT(usedId, "also defined here");
+        //            USR_PRINT(usedId, "(disambiguate using -s<modulename>.%s...)", var->name());
+      }
     }
   } else {
     assert(false && "Location for all ast should be set by noteLocation");
@@ -309,17 +319,6 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
             // found a config that was set via cmd line: replace the node
             // need to build up a new Variable from the old one, copying all the
             // internals
-            auto usedId = parsing::nameToConfigParamId(this->context(), var->name());
-            // TODO: Why is this ID always coming back empty?
-            if (!usedId.isEmpty()) {
-              std::string err = "ambiguous config name (";
-              err += var->name().c_str();
-              err += ")";
-              assert(false && err.c_str());
-  //            USR_FATAL_CONT(var, "ambiguous config name (%s)", var->name());
-  //            USR_PRINT(usedId, "also defined here");
-  //            USR_PRINT(usedId, "(disambiguate using -s<modulename>.%s...)", var->name());
-            }
             auto parser = parsing::Parser::build(context());
             parsing::Parser* p = parser.get();
             // do we need to parse the name for a module path here? Seems likely

--- a/compiler/dyno/lib/uast/Variable.cpp
+++ b/compiler/dyno/lib/uast/Variable.cpp
@@ -77,6 +77,22 @@ Variable::build(Builder* builder, Location loc,
   return toOwned(ret);
 }
 
+void Variable::setInitExprForConfig(owned<AstNode> ie) {
+  if (this->initExpressionChildNum_ > -1) {
+    // have an existing initExpr, swap it
+    this->children_[this->initExpressionChildNum_].swap(ie);
+  } else {
+    // no initExpr and no typeExpr nor attribute
+    initExpressionChildNum_ = children_.size();
+    children_.push_back(std::move(ie));
+    if (this->typeExpressionChildNum_ > -1 || this->attributesChildNum() > -1) {
+      assert(numChildren() > 1);
+    } else {
+      assert(numChildren() == 1);
+    }
+  }
+}
+
 
 } // namespace uast
 } // namespace chpl

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -286,4 +286,6 @@ namespace chpl {
 
 extern chpl::Context* gContext;
 
+extern std::vector<std::pair<std::string,std::string>> gDynoParams;
+
 #endif

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -286,6 +286,6 @@ namespace chpl {
 
 extern chpl::Context* gContext;
 
-extern std::vector<std::pair<std::string,std::string>> gDynoParams;
+extern std::vector<std::pair<std::string, std::string>> gDynoParams;
 
 #endif

--- a/compiler/main/config.cpp
+++ b/compiler/main/config.cpp
@@ -26,7 +26,7 @@
 #include "parser.h"
 #include "stmt.h"
 #include "stringutil.h"
-#include "chpl/parsing/parsing-queries.h"
+#include "chpl/uast/Builder.h"
 #include <utility>
 
 
@@ -43,15 +43,7 @@ void checkConfigs() {
     bool             anyBadConfigParams = false;
     if (fDynoCompilerLibrary) {
       // check that all config vars that were set from the command line were assigned
-      auto configs = parsing::configSettings(gContext);
-      for (auto config : configs) {
-        auto usedId = parsing::nameToConfigSettingId(gContext, config.first);
-        if (usedId.isEmpty()) {
-          USR_FATAL_CONT("Trying to set unrecognized config '%s' via -s flag",
-                         config.first.c_str());
-          anyBadConfigParams = true;
-        }
-      }
+      anyBadConfigParams = uast::Builder::checkAllConfigVarsAssigned(gContext);
     } else {
       Vec<const char *> configParamSetNames;
 

--- a/compiler/main/config.cpp
+++ b/compiler/main/config.cpp
@@ -43,9 +43,9 @@ void checkConfigs() {
     bool             anyBadConfigParams = false;
     if (fDynoCompilerLibrary) {
       // check that all config vars that were set from the command line were assigned
-      auto configs = parsing::configParams(gContext);
+      auto configs = parsing::configSettings(gContext);
       for (auto config : configs) {
-        auto usedId = parsing::nameToConfigParamId(gContext, config.first);
+        auto usedId = parsing::nameToConfigSettingId(gContext, config.first);
         if (usedId.isEmpty()) {
           USR_FATAL_CONT("Trying to set unrecognized config '%s' via -s flag",
                          config.first.c_str());
@@ -90,11 +90,8 @@ void parseCmdLineConfig(const char* name, const char* value) {
   // it to work, --dyno must come before -sConfigVar=Val or it will not try
   // to use the dyno parser for command line input
   if (fDynoCompilerLibrary) {
-    // emplace the record for dyno parser
-    std::string symbol(name);
-    std::string val(value);
-    std::pair<std::string, std::string> dynoParam (symbol,val);
-    gDynoParams.push_back(dynoParam);
+    // save the name/value pair for dyno parser
+    gDynoParams.push_back(std::make_pair(std::string(name), std::string(value)));
   } else {
 
     // Generate a C-string for a nominal Chapel assignment statement

--- a/compiler/main/config.cpp
+++ b/compiler/main/config.cpp
@@ -27,6 +27,15 @@
 #include "stmt.h"
 #include "stringutil.h"
 
+#include <ostream>
+
+#include "chpl/queries/Context.h"
+#include "chpl/parsing/Parser.h"
+#include "chpl/uast/all-uast.h"
+#include "AstToText.h"
+
+using namespace chpl;
+
 static Map<const char*, Expr*> configMap; // map from configs to vals
 static Map<const char*, VarSymbol*> usedConfigParams; // map from configs to uses
 
@@ -73,6 +82,32 @@ void parseCmdLineConfig(const char* name, const char* value) {
   const char* parseFn  = astr("Command-line arg (", name, ")");
   const char* parseMsg = astr("parsing '", value, "'");
 
+  // unfortunately this is parsed in the order from the command line, so for
+  // it to work, --dyno must come before -sConfigVar=Val or it will not try
+  // to use the dyno parser for command line input
+  if (fDynoCompilerLibrary) {
+    // build some tooling for using dyno parser here
+    Context context;
+    Context* ctx = &context;
+    auto parser = parsing::Parser::build(ctx);
+    parsing::Parser* p = parser.get();
+
+    // print out the old stmtText for reference:
+    std::cerr << "old parse input: " << stmtText << std::endl;
+    // build up input for the dyno parser
+    const char* dynoText = (value[0] != '\0') ? astr( name, "=", value, ";") : astr("dummyConfig=true;");
+    // shadow the old parsing, using the dyno parser and input
+    auto parseResult = p->parseString("CompilationConfigs", dynoText);
+    assert(!parseResult.numErrors());
+    auto mod = parseResult.singleModule();
+    assert(mod);
+    std::cerr << "dyno parse input: " << dynoText <<std::endl;
+    mod->stringify(std::cerr, CHPL_SYNTAX);
+    // manually adding a new line here because chpl syntax visitor doesn't handle
+    // them well at the moment
+    std::cerr << std::endl;
+  }
+
   // Invoke the parser to generate AST
   BlockStmt*  stmt     = parseString(stmtText, parseFn, parseMsg);
 
@@ -100,6 +135,11 @@ void parseCmdLineConfig(const char* name, const char* value) {
   }
 
   configMap.put(astr(name), newExpr);
+
+  // print the result of parsing the input
+  std::cerr << astr(name) << "=";
+  newExpr->prettyPrint(&std::cerr);
+  std::cerr << std::endl;
 
   INT_ASSERT(newExpr == configMap.get(astr(name)));
 }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#define EXTERN
+// #define EXTERN
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
@@ -49,6 +49,7 @@
 #include "visibleFunctions.h"
 
 #include "chpl/queries/Context.h"
+#include "chpl/parsing/parsing-queries.h"
 
 #include <inttypes.h>
 #include <string>
@@ -308,6 +309,7 @@ int fGPUBlockSize = 0;
 char fCUDAArch[16] = "sm_60";
 
 chpl::Context* gContext = nullptr;
+std::vector<std::pair<std::string,std::string>> gDynoParams;
 
 static bool compilerSetChplLLVM = false;
 
@@ -1806,6 +1808,9 @@ int main(int argc, char* argv[]) {
     process_args(&sArgState, argc, argv);
 
     setupChplGlobals(argv[0]);
+    if (fDynoCompilerLibrary)
+      // set the config params we parsed earlier
+      chpl::parsing::setConfigParams(gContext, gDynoParams);
 
     postprocess_args();
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-// #define EXTERN
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
@@ -309,7 +308,7 @@ int fGPUBlockSize = 0;
 char fCUDAArch[16] = "sm_60";
 
 chpl::Context* gContext = nullptr;
-std::vector<std::pair<std::string,std::string>> gDynoParams;
+std::vector<std::pair<std::string, std::string>> gDynoParams;
 
 static bool compilerSetChplLLVM = false;
 
@@ -1808,10 +1807,12 @@ int main(int argc, char* argv[]) {
     process_args(&sArgState, argc, argv);
 
     setupChplGlobals(argv[0]);
-    if (fDynoCompilerLibrary)
-      // set the config params we parsed earlier
-      chpl::parsing::setConfigParams(gContext, gDynoParams);
-
+    if (fDynoCompilerLibrary) {
+      // set the config names/values we processed earlier
+      chpl::parsing::setConfigSettings(gContext, gDynoParams);
+      // this should not be used after this point!
+      gDynoParams.clear();
+    }
     postprocess_args();
 
     if (gContext != nullptr) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2673,36 +2673,18 @@ struct Converter {
 
     auto ret = new DefExpr(varSym, initExpr, typeExpr);
 
+    // Handle this when building the AST, so should not need to convert it
+    // with a special case anymore
     // Replace init expressions for config variables with values passed
     // in on the command-line, if necessary.
-    if (node->isConfig()) {
+    // if (node->isConfig()) {
 
-      // Set some global state for module name and privacy.
-      auto savedModuleName = currentModuleName;
-      auto savedParsingPrivate = parsingPrivate;
-      INT_ASSERT(this->modNameStack.size());
-      currentModuleName = this->modNameStack.back();
-      parsingPrivate = node->visibility() == uast::Decl::PRIVATE;
-
-      // TODO (dlongnecke): This call should be replaced by an equivalent
-      // one from the new frontend.
-      if (Expr* commandLineInit = lookupConfigVal(varSym)) {
-        ret->init = commandLineInit;
-      }
-
-      // Restore the state (janky, will be replaced by work from Ahmad).
-      currentModuleName = savedModuleName;
-      parsingPrivate = savedParsingPrivate;
-
-      // Possibly emit a deprecation warning.
-      if (varSym->hasFlag(FLAG_DEPRECATED)) {
-        if (isUsedCmdLineConfig(varSym->name)) {
-          astlocMarker emptyAstLoc(0, nullptr);
-          USR_WARN("%s", varSym->getDeprecationMsg());
-          USR_PRINT("'%s' was set via a compiler flag", varSym->name);
-        }
-      }
-    }
+    //   // TODO (dlongnecke): This call should be replaced by an equivalent
+    //   // one from the new frontend.
+    //   if (Expr* commandLineInit = lookupConfigVal(varSym)) {
+    //     ret->init = commandLineInit;
+    //   }
+    // }
 
     // If the init expression of this variable is a domain and this
     // variable is not const, propagate that information by setting

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2673,19 +2673,6 @@ struct Converter {
 
     auto ret = new DefExpr(varSym, initExpr, typeExpr);
 
-    // Handle this when building the AST, so should not need to convert it
-    // with a special case anymore
-    // Replace init expressions for config variables with values passed
-    // in on the command-line, if necessary.
-    // if (node->isConfig()) {
-
-    //   // TODO (dlongnecke): This call should be replaced by an equivalent
-    //   // one from the new frontend.
-    //   if (Expr* commandLineInit = lookupConfigVal(varSym)) {
-    //     ret->init = commandLineInit;
-    //   }
-    // }
-
     // If the init expression of this variable is a domain and this
     // variable is not const, propagate that information by setting
     // 'definedConst' in the domain to false.

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -799,7 +799,10 @@ void handleError(astlocT astloc, const char *fmt, ...) {
 }
 
 void handleError(chpl::Location loc, const char *fmt, ...) {
-  astlocT astloc(loc.firstLine(), loc.path().c_str());
+  astlocT astloc = astlocT(0, nullptr);
+  if (!loc.isEmpty()) {
+    astloc = astlocT(loc.firstLine(), loc.path().c_str());
+  }
 
   va_list args;
 

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -799,10 +799,7 @@ void handleError(astlocT astloc, const char *fmt, ...) {
 }
 
 void handleError(chpl::Location loc, const char *fmt, ...) {
-  astlocT astloc = astlocT(0, nullptr);
-  if (!loc.isEmpty()) {
-    astloc = astlocT(loc.firstLine(), loc.path().c_str());
-  }
+  astlocT astloc(loc.firstLine(), loc.path().c_str());
 
   va_list args;
 


### PR DESCRIPTION
This PR adds dyno handling of command-line config `var`/`const`/`param`/`type` 
parsing and assignment when using compiler flags that begin with `-s`.

Since uAST is only mutable during the `assignId` step in the builder, that
process was hijacked to also accommodate the modification of initialization 
expressions.

The previous process of doing this assignment when converting uAST to AST
has been removed.

TESTING:

- [x] paratest passes
- [x] paratest with `--dyno` (31 vs. 31 failures)

reviewed by @mppf, with feedback from @dlongnecke-cray - thank you!

*note the number of failures doesn't change because we were previously handling
config assignment in the conversion from uAST to AST.

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>