### PR TITLE
Re-enable the task-overload test with comm=ofi.

### DIFF
--- a/test/runtime/configMatters/comm/task-overload.skipif
+++ b/test/runtime/configMatters/comm/task-overload.skipif
@@ -1,4 +1,1 @@
 CHPL_TASKS != qthreads
-# At present it isn't possible to get this to pass with comm=ofi,
-# so skip it for now.
-CHPL_COMM == ofi


### PR DESCRIPTION
As part of issue cleanup I just tried the `task-overload` test with
comm=ofi on our testing cluster and it worked just fine.  Therefore
here, undo our previous disablement of this test in that config.

This resolves https://github.com/Cray/chapel-private/issues/502.