### PR TITLE
Fix bug with importing private submodules

### DIFF
--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -543,7 +543,9 @@ Symbol* ResolveScope::followImportUseChains(const char* name) const {
 
         if (ResolveScope* next = getScopeFor(scopeToUse)) {
           if (Symbol* sym = next->lookupNameLocallyForImport(nameToUse)) {
-            if (isRepeat(sym, symbols) == false) {
+            if (sym->hasFlag(FLAG_PRIVATE) == true) {
+              continue;
+            } else if (isRepeat(sym, symbols) == false) {
               if (FnSymbol* fn = toFnSymbol(sym)) {
                 if (fn->isMethod() == false) {
                   symbols.push_back(fn);
@@ -582,7 +584,9 @@ Symbol* ResolveScope::followImportUseChains(const char* name) const {
 
         if (ResolveScope* next = getScopeFor(scopeToUse)) {
           if (Symbol* sym = next->lookupNameLocallyForImport(nameToUse)) {
-            if (isRepeat(sym, symbols) == false) {
+            if (sym->hasFlag(FLAG_PRIVATE) == true) {
+              continue;
+            } else if (isRepeat(sym, symbols) == false) {
               if (FnSymbol* fn = toFnSymbol(sym)) {
                 if (fn->isMethod() == false) {
                   symbols.push_back(fn);

--- a/test/modules/vass/use-a-Math-function.bad
+++ b/test/modules/vass/use-a-Math-function.bad
@@ -1,1 +1,0 @@
-use-a-Math-function.chpl:6: error: 'use' of non-module/enum symbol fabs

--- a/test/modules/vass/use-a-Math-function.future
+++ b/test/modules/vass/use-a-Math-function.future
@@ -1,2 +1,0 @@
-incorrect error for some cases of 'use FN;'
-#14535

--- a/test/visibility/private/moduleSymbols/importPrivateSubmodule.bad
+++ b/test/visibility/private/moduleSymbols/importPrivateSubmodule.bad
@@ -1,2 +1,0 @@
-importPrivateSubmodule.chpl:11: In function 'main':
-importPrivateSubmodule.chpl:15: error: Symbol 'do_my_impl' undeclared in module 'Details'

--- a/test/visibility/private/moduleSymbols/importPrivateSubmodule.future
+++ b/test/visibility/private/moduleSymbols/importPrivateSubmodule.future
@@ -1,2 +1,0 @@
-bug: private submodule able to be imported from outside parent's scope
-#18257


### PR DESCRIPTION
The resolution of import/use statements was failing to consider whether the
symbol it was matching against was private to the module in which it was found
via a use/import chain.  This adjusts ResolveScope::followImportUseChains to
skip including symbols that are private.

Resolves #18257
Resolves #14535

Passed a full paratest with futures