### PR TITLE
Remove CPU sublocale and have first GPU sublocale use id 0

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -430,13 +430,13 @@ static void outlineGPUKernels() {
 
           fn->defPoint->insertBefore(new DefExpr(outlinedFunction));
 
-          // if (chpl_task_getRequestedSubloc() > 0) {
+          // if (chpl_task_getRequestedSubloc() >= 0) {
           //   call the generated GPU kernel
           // } else {
           //   run the existing loop on the CPU
           // }
           Expr* condExpr =
-            new CallExpr(PRIM_GREATER,
+            new CallExpr(PRIM_GREATEROREQUAL,
                          new CallExpr(PRIM_GET_REQUESTED_SUBLOC),
                          new_IntSymbol(0));
           BlockStmt* thenBlock = new BlockStmt();

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -457,12 +457,6 @@ module ChapelLocale {
       return 0;
     }
 
-    pragma "no doc"
-    proc numGpus() : int {
-      HaltWrappers.pureVirtualMethodHalt();
-      return 0;
-    }
-
 // Part of the required locale interface.
 // Commented out because presently iterators are statically bound.
 //    iter getChildIndices() : int {
@@ -481,9 +475,14 @@ module ChapelLocale {
       HaltWrappers.pureVirtualMethodHalt();
     }
 
+    // Return array of gpu sublocale
+    proc gpus {
+      return gpusImpl();
+    }
+
     pragma "no doc"
-    proc getGpu(idx:int) : locale {
-      HaltWrappers.pureVirtualMethodHalt();
+    proc gpusImpl() const ref {
+      return chpl_emptyLocales;
     }
 
     pragma "no doc"

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -457,6 +457,12 @@ module ChapelLocale {
       return 0;
     }
 
+    pragma "no doc"
+    proc numGpus() : int {
+      HaltWrappers.pureVirtualMethodHalt();
+      return 0;
+    }
+
 // Part of the required locale interface.
 // Commented out because presently iterators are statically bound.
 //    iter getChildIndices() : int {
@@ -474,6 +480,14 @@ module ChapelLocale {
     proc getChild(idx:int) : locale {
       HaltWrappers.pureVirtualMethodHalt();
     }
+
+    pragma "no doc"
+    proc getGpu(idx:int) : locale {
+      HaltWrappers.pureVirtualMethodHalt();
+    }
+
+    pragma "no doc"
+    proc isGpu() : bool { return false; }
 
 // Part of the required locale interface.
 // Commented out because presently iterators are statically bound.

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -115,7 +115,7 @@ module LocaleModelHelpSetup {
     var root_accum:chpl_root_locale_accum;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
-      chpl_task_setSubloc(c_sublocid_any);
+      chpl_task_setSubloc(c_sublocid_none);
       const node = new locale(new unmanaged LocaleModel(new locale (dst)));
       dst.myLocales[locIdx] = node;
       root_accum.accum(node);
@@ -232,7 +232,7 @@ module LocaleModelHelpSetup {
   }
 
   proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string,
-      numSublocales: int, /*type CPULocale,*/ type GPULocale){
+      numSublocales: int, type GPULocale){
 
     var childSpace = {0..#numSublocales};
 
@@ -240,13 +240,8 @@ module LocaleModelHelpSetup {
 
     for i in childSpace {
       chpl_task_setSubloc(i:chpl_sublocID_t);
-      /*if i == 0 {
-        dst.childLocales[i] = new unmanaged CPULocale(i:chpl_sublocID_t, dst);
-      }
-      else {*/
-        dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
-        dst.childLocales[i].maxTaskPar = 1;
-      //}
+      dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
+      dst.childLocales[i].maxTaskPar = 1;
     }
     chpl_task_setSubloc(origSubloc);
   }

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -242,6 +242,8 @@ module LocaleModelHelpSetup {
       chpl_task_setSubloc(i:chpl_sublocID_t);
       dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
       dst.childLocales[i].maxTaskPar = 1;
+
+      dst.gpuSublocales = new locale(dst.childLocales[i]);
     }
     chpl_task_setSubloc(origSubloc);
   }

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -232,7 +232,7 @@ module LocaleModelHelpSetup {
   }
 
   proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string,
-      numSublocales: int, type CPULocale, type GPULocale){
+      numSublocales: int, /*type CPULocale,*/ type GPULocale){
 
     var childSpace = {0..#numSublocales};
 
@@ -240,13 +240,13 @@ module LocaleModelHelpSetup {
 
     for i in childSpace {
       chpl_task_setSubloc(i:chpl_sublocID_t);
-      if i == 0 {
+      /*if i == 0 {
         dst.childLocales[i] = new unmanaged CPULocale(i:chpl_sublocID_t, dst);
       }
-      else {
+      else {*/
         dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
         dst.childLocales[i].maxTaskPar = 1;
-      }
+      //}
     }
     chpl_task_setSubloc(origSubloc);
   }

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -182,7 +182,7 @@ module LocaleModel {
 
     override proc chpl_id() return _node_id;     // top-level locale (node) number
     override proc chpl_localeid() {
-      return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_any);
+      return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_none);
     }
     override proc chpl_name() return local_name;
 

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -267,9 +267,6 @@ module LocaleModel {
   pragma "unsafe"
   const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
 
-  pragma "unsafe"
-  const chpl_emptyLocalesModels: [chpl_emptyLocaleSpace] unmanaged AbstractLocaleModel;
-
   //
   // A concrete class representing the nodes in this architecture.
   //
@@ -367,7 +364,7 @@ module LocaleModel {
     }
 
     proc getChildArray() {
-      return childLocales;
+      return [loc in childLocales] loc;
     }
 
     //------------------------------------------------------------------------{

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -41,8 +41,7 @@ module LocaleModel {
 
   private inline
   proc runningOnGPUSublocale(): bool {
-    extern proc chpl_gpu_has_context(): bool;
-    return chpl_task_getRequestedSubloc()>0;
+    return chpl_task_getRequestedSubloc()>=0;
   }
 
   private inline
@@ -215,45 +214,6 @@ module LocaleModel {
     return execution_subloc;  // no info needed from full sublocale
   }
 
-  class CPULocale : AbstractLocaleModel {
-    const sid: chpl_sublocID_t;
-    const name: string;
-
-    override proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
-    override proc chpl_localeid() {
-      return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
-                                sid);
-    }
-    override proc chpl_name() return name;
-
-    proc init() {
-    }
-
-    proc init(_sid, _parent) {
-      super.init(new locale(_parent));
-      sid = _sid;
-      name = "node" + _parent._node_id:string + "-CPU" + sid:string;
-    }
-
-    override proc writeThis(f) throws {
-      parent.writeThis(f);
-      f <~> '.'+name;
-    }
-
-    override proc getChildCount(): int { return 0; }
-    iter getChildIndices() : int {
-      halt("No children to iterate over.");
-      yield -1;
-    }
-    proc addChild(loc:locale) {
-      halt("Cannot add children to this locale type.");
-    }
-    override proc getChild(idx:int) : locale {
-      halt("requesting a child from a CPULocale locale");
-      return new locale(this);
-    }
-  }
-
   class GPULocale : AbstractLocaleModel {
     const sid: chpl_sublocID_t;
     const name: string;
@@ -284,7 +244,7 @@ module LocaleModel {
 
     override proc writeThis(f) throws {
       parent.writeThis(f);
-      f <~> '.'+name;
+      f <~> '.'+name + " (gpu locale)";
     }
 
     override proc getChildCount(): int { return 0; }
@@ -299,6 +259,8 @@ module LocaleModel {
       halt("requesting a child from a GPULocale locale");
       return new locale(this);
     }
+
+    override proc isGpu() : bool { return true; }
   }
 
   const chpl_emptyLocaleSpace: domain(1) = {1..0};
@@ -314,9 +276,10 @@ module LocaleModel {
 
     var numSublocales: int;
     var GPU: unmanaged GPULocale?;
-    var CPU: unmanaged CPULocale?;
+    //var CPU: unmanaged CPULocale?;
 
     const childSpace: domain(1);
+    param firstGpuSubLocId = 0;
 
     pragma "unsafe"
     var childLocales: [childSpace] unmanaged AbstractLocaleModel;
@@ -336,7 +299,7 @@ module LocaleModel {
       cudaGetDeviceCount(nDevices);
 
       //1 cpu and number of GPU devices on a node
-      numSublocales = 1 + nDevices;
+      numSublocales = nDevices;
       childSpace = {0..#numSublocales};
 
       this.complete();
@@ -358,7 +321,7 @@ module LocaleModel {
       cudaGetDeviceCount(nDevices);
 
       //1 cpu and number of GPU devices on a node
-      numSublocales = 1 + nDevices;
+      numSublocales = nDevices;
       childSpace = {0..#numSublocales};
 
       this.complete();
@@ -378,6 +341,8 @@ module LocaleModel {
 
     override proc getChildCount() return numSublocales;
 
+    override proc numGpus() : int { return getChildCount(); }
+
     iter getChildIndices() : int {
       for idx in {0..#numSublocales} do // chpl_emptyLocaleSpace do
         yield idx;
@@ -388,6 +353,13 @@ module LocaleModel {
         if (idx < 0) || (idx >= numSublocales) then
           halt("sublocale child index out of bounds (",idx,")");
       return new locale(childLocales[idx]);
+    }
+
+    override proc getGpu(idx:int) : locale {
+      if boundsChecking then
+        if (idx < 0) || (idx >= numGpus()) then
+          halt("gpu index out of bounds (",idx,")");
+      return getChild(idx + firstGpuSubLocId);
     }
 
     iter getChildren() : locale  {
@@ -403,7 +375,7 @@ module LocaleModel {
     //- Implementation (private)
     //-
     proc setup() {
-      helpSetupLocaleGPU(this, local_name, numSublocales, CPULocale, GPULocale);
+      helpSetupLocaleGPU(this, local_name, numSublocales, GPULocale);
     }
     //------------------------------------------------------------------------}
   }
@@ -449,7 +421,7 @@ module LocaleModel {
     proc local_name() return "rootLocale";
 
     override proc writeThis(f) throws {
-      f <~> name;
+      f <~> "rootLocale:" + name;
     }
 
     override proc getChildCount() return this.myLocaleSpace.size;

--- a/runtime/include/chpl-mem-array.h
+++ b/runtime/include/chpl-mem-array.h
@@ -189,7 +189,7 @@ void chpl_mem_array_free(void* p,
                          size_t nmemb, size_t eltSize, c_sublocid_t subloc,
                          int32_t lineno, int32_t filename) {
 #ifdef HAS_GPU_LOCALE
-  if (subloc > 0) {
+  if (subloc >= 0) {
     chpl_gpu_mem_free(p, lineno, filename);
   }
   else {

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -32,7 +32,7 @@ extern __constant__ int32_t chpl_nodeID;
 __device__ static inline c_sublocid_t chpl_task_getRequestedSubloc(void)
 {
   // TODO
-  return 1;
+  return 0;
 }
 
 __device__ static inline chpl_localeID_t chpl_gen_getLocaleID(void)

--- a/runtime/include/localeModels/gpu/chpl-locale-model.h
+++ b/runtime/include/localeModels/gpu/chpl-locale-model.h
@@ -42,6 +42,8 @@ typedef struct {
 //
 #define CHPL_LOCALEID_T_INIT  {0, 0}
 
+#define INITIAL_SUBLOCALE -1
+
 //
 // This is the external copy constructor for a chpl_localeID_t, specified
 // by the module code for a numa locale model.

--- a/runtime/include/localeModels/gpu/chpl-locale-model.h
+++ b/runtime/include/localeModels/gpu/chpl-locale-model.h
@@ -42,8 +42,6 @@ typedef struct {
 //
 #define CHPL_LOCALEID_T_INIT  {0, 0}
 
-#define INITIAL_SUBLOCALE -1
-
 //
 // This is the external copy constructor for a chpl_localeID_t, specified
 // by the module code for a numa locale model.

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -172,7 +172,7 @@ static inline
 void chpl_task_setSubloc(c_sublocid_t full_subloc)
 {
     qthread_shepherd_id_t curr_shep;
-  
+
     // We allow using c_sublocid_none to represent the CPU in the gpu locale
     // model. This isn't currently used by the numa (or other locale) models.
     assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_any ||

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -173,8 +173,6 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
 {
     qthread_shepherd_id_t curr_shep;
 
-    assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_any);
-
     // Only change sublocales if the caller asked for a particular one,
     // which is not the current one, and we're a (movable) task.
     //

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -172,6 +172,11 @@ static inline
 void chpl_task_setSubloc(c_sublocid_t full_subloc)
 {
     qthread_shepherd_id_t curr_shep;
+  
+    // We allow using c_sublocid_none to represent the CPU in the gpu locale
+    // model. This isn't currently used by the numa (or other locale) models.
+    assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_any ||
+        !strcmp(CHPL_LOCALE_MODEL, "gpu"));
 
     // Only change sublocales if the caller asked for a particular one,
     // which is not the current one, and we're a (movable) task.

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -157,7 +157,7 @@ size_t chpl_gpu_get_alloc_size(void* ptr) {
 }
 
 bool chpl_gpu_running_on_gpu_locale() {
-  return chpl_task_getRequestedSubloc()>0;
+  return chpl_task_getRequestedSubloc()>=0;
 }
 
 static void chpl_gpu_launch_kernel_help(const char* fatbinData,

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -86,7 +86,7 @@ void chpl_gpu_init() {
 }
 
 static void chpl_gpu_ensure_context() {
-  CUcontext next_context = chpl_gpu_primary_ctx[chpl_task_getRequestedSubloc()-1];
+  CUcontext next_context = chpl_gpu_primary_ctx[chpl_task_getRequestedSubloc()];
 
   if (!chpl_gpu_has_context()) {
     CUDA_CALL(cuCtxPushCurrent(next_context));

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -810,8 +810,6 @@ void chpl_task_addTask(chpl_fn_int_t       fid,
 {
     chpl_fn_p requested_fn = chpl_ftable[fid];
 
-    assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_any);
-
     PROFILE_INCR(profile_task_addTask,1);
 
     c_sublocid_t execution_subloc =

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -810,6 +810,11 @@ void chpl_task_addTask(chpl_fn_int_t       fid,
 {
     chpl_fn_p requested_fn = chpl_ftable[fid];
 
+    // We allow using c_sublocid_none to represent the CPU in the gpu locale
+    // model. This isn't currently used by the numa (or other locale) models.
+    assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_any ||
+        !strcmp(CHPL_LOCALE_MODEL, "gpu"));
+
     PROFILE_INCR(profile_task_addTask,1);
 
     c_sublocid_t execution_subloc =

--- a/test/gpu/native/PREDIFF
+++ b/test/gpu/native/PREDIFF
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 awk '!/Unknown CUDA version/ {print};' $2 > $2.no_version_warn
-mv $2.no_version_warn $2
+cp $2.no_version_warn $2
 
 awk '!/ptxas warning : Unresolved extern variable/ {print};' $2 > $2.no_extern_warn
 mv $2.no_extern_warn $2
+
+awk '!/warning: 2 NUMA domains but only 1 Qthreads shepherds; may get internal errors/ {print};' $2 > $2.no_numa_thread_mismatch_warn
+mv $2.no_numa_thread_mismatch_warn $2

--- a/test/gpu/native/PREDIFF
+++ b/test/gpu/native/PREDIFF
@@ -1,10 +1,7 @@
 #!/bin/sh
 
 awk '!/Unknown CUDA version/ {print};' $2 > $2.no_version_warn
-cp $2.no_version_warn $2
+mv $2.no_version_warn $2
 
 awk '!/ptxas warning : Unresolved extern variable/ {print};' $2 > $2.no_extern_warn
 mv $2.no_extern_warn $2
-
-awk '!/warning: 2 NUMA domains but only 1 Qthreads shepherds; may get internal errors/ {print};' $2 > $2.no_numa_thread_mismatch_warn
-mv $2.no_numa_thread_mismatch_warn $2

--- a/test/gpu/native/distArray/blockInsideOn.chpl
+++ b/test/gpu/native/distArray/blockInsideOn.chpl
@@ -2,7 +2,7 @@ use BlockDist;
 
 config const n = 10;
 
-on here.getChild(1) {
+on here.getGpu(0) {
   var space = {1..n};
   var dom = space dmapped Block(space, targetLocales=[here,]);
   var arr: [dom] int;

--- a/test/gpu/native/distArray/blockInsideOn.chpl
+++ b/test/gpu/native/distArray/blockInsideOn.chpl
@@ -2,7 +2,7 @@ use BlockDist;
 
 config const n = 10;
 
-on here.getGpu(0) {
+on here.gpus[0] {
   var space = {1..n};
   var dom = space dmapped Block(space, targetLocales=[here,]);
   var arr: [dom] int;

--- a/test/gpu/native/distArray/blockOutsideOnWorkaround.chpl
+++ b/test/gpu/native/distArray/blockOutsideOnWorkaround.chpl
@@ -3,7 +3,7 @@ use BlockDist;
 config const n = 10;
 
 var space = {1..n};
-var dom = space dmapped Block(space, targetLocales=[here.getChild(1),]);
+var dom = space dmapped Block(space, targetLocales=[here.getGpu(0),]);
 var arr: [dom] int;
 
 ref data = arr._value.myLocArr!.myElems;

--- a/test/gpu/native/distArray/blockOutsideOnWorkaround.chpl
+++ b/test/gpu/native/distArray/blockOutsideOnWorkaround.chpl
@@ -3,7 +3,7 @@ use BlockDist;
 config const n = 10;
 
 var space = {1..n};
-var dom = space dmapped Block(space, targetLocales=[here.getGpu(0),]);
+var dom = space dmapped Block(space, targetLocales=[here.gpus[0],]);
 var arr: [dom] int;
 
 ref data = arr._value.myLocArr!.myElems;

--- a/test/gpu/native/jacobi/jacobi.chpl
+++ b/test/gpu/native/jacobi/jacobi.chpl
@@ -7,7 +7,7 @@ config const n = 10;
 */
 
 writeln("on GPU:");
-jacobi(here.getGpu(0));
+jacobi(here.gpus[0]);
 writeln("on CPU:");
 jacobi(here);
 

--- a/test/gpu/native/jacobi/jacobi.chpl
+++ b/test/gpu/native/jacobi/jacobi.chpl
@@ -7,7 +7,7 @@ config const n = 10;
 */
 
 writeln("on GPU:");
-jacobi(here.getChild(1));
+jacobi(here.getGpu(0));
 writeln("on CPU:");
 jacobi(here);
 

--- a/test/gpu/native/memory/basic.chpl
+++ b/test/gpu/native/memory/basic.chpl
@@ -18,7 +18,7 @@ var ptrHstResult = chpl_here_alloc(n, 0): c_ptr(c_uchar);
 var expandedPtrHst = chpl_here_alloc(n*2, 0): c_ptr(c_uchar);
 
 var s: uint;
-on here.getChild(1) {
+on here.getGpu(0) {
 
   ////////////////////////////////////////////////////
 

--- a/test/gpu/native/memory/basic.chpl
+++ b/test/gpu/native/memory/basic.chpl
@@ -18,7 +18,7 @@ var ptrHstResult = chpl_here_alloc(n, 0): c_ptr(c_uchar);
 var expandedPtrHst = chpl_here_alloc(n*2, 0): c_ptr(c_uchar);
 
 var s: uint;
-on here.getGpu(0) {
+on here.gpus[0] {
 
   ////////////////////////////////////////////////////
 

--- a/test/gpu/native/memory/sharedMemory.chpl
+++ b/test/gpu/native/memory/sharedMemory.chpl
@@ -3,7 +3,7 @@ use CTypes;
 config param N=16;
 config param BLOCK_SIZE;
 
-on here.getGpu(0) {
+on here.gpus[0] {
   var A : [0..<N] uint;
 
   forall i in 0..<N {

--- a/test/gpu/native/memory/sharedMemory.chpl
+++ b/test/gpu/native/memory/sharedMemory.chpl
@@ -3,7 +3,7 @@ use CTypes;
 config param N=16;
 config param BLOCK_SIZE;
 
-on here.getChild(1) {
+on here.getGpu(0) {
   var A : [0..<N] uint;
 
   forall i in 0..<N {

--- a/test/gpu/native/multiGPU/multiGPU.chpl
+++ b/test/gpu/native/multiGPU/multiGPU.chpl
@@ -4,9 +4,9 @@ config const alpha = 10;
 
 config const writeArrays = true;
 
-writeln("Number of sublocales: ", here.getChildCount());
+writeln("Number of sublocales: ", here.gpus.size);
 
-for subloc in 1..here.getChildCount()-1 do on here.getChild(subloc) {
+for subloc in 0..<here.getChildCount() do on here.gpus[subloc] {
   var A: [1..n] int;
   var B: [1..n] int;
   var C: [1..n] int;

--- a/test/gpu/native/multiGPU/worksharing.chpl
+++ b/test/gpu/native/multiGPU/worksharing.chpl
@@ -1,6 +1,6 @@
 use Time;
 
-writeln("Number of sublocales: ", here.getChildCount());
+writeln("Number of sublocales: ", here.gpus.size);
 
 config const validate = true;
 config const printStats = false;
@@ -28,7 +28,7 @@ for i in 1..numIters {
     A = B + alpha * C;
   }
   else {
-    const numPUs = here.getChildCount(); 
+    const numPUs = here.gpus.size; 
     const numGPUs = numPUs-1;
     const chunkDiv = numGPUs+cpuToGpuRatio;
     var chunkSize = (n/chunkDiv):int;
@@ -40,7 +40,7 @@ for i in 1..numIters {
     cobegin {
       A[cpuRange] = B[cpuRange] + alpha * C[cpuRange];
 
-      coforall sublocID in 1..#numGPUs do on here.getChild(sublocID) {
+      coforall sublocID in 0..#numGPUs do on here.gpu[sublocID] {
         const myChunk = cpuSize+(sublocID-1)*gpuChunkSize..#gpuChunkSize;
         if debug then writeln(sublocID, ": ", myChunk);
 

--- a/test/gpu/native/multiGPU/worksharingBasic.chpl
+++ b/test/gpu/native/multiGPU/worksharingBasic.chpl
@@ -1,10 +1,10 @@
 config const n = 1024;
 
-writeln("Number of sublocales: ", here.getChildCount());
+writeln("Number of sublocales: ", here.gpus.size);
 
 var A: [0..#n] int;
 // assign half the work to CPU, the rest to GPUs. Assume divisibility
-const numGPUs = here.getChildCount()-1;
+const numGPUs = here.gpus.size;
 const cpuSize = n/2; 
 const gpuSize = (n/2)/numGPUs;
 
@@ -14,7 +14,7 @@ assert((n/2)%numGPUs == 0);
 cobegin {
   A[0..#cpuSize] += 1;
   
-  coforall subloc in 1..numGPUs do on here.getChild(subloc) {
+  coforall subloc in 0..<numGPUs do on here.gpu[subloc] {
     const myShare = cpuSize+gpuSize*(subloc-1)..#gpuSize;
     
     var AonThisGPU = A[myShare];

--- a/test/gpu/native/promotion.chpl
+++ b/test/gpu/native/promotion.chpl
@@ -1,5 +1,5 @@
 config const n = 10;
-on here.getGpu(0) {
+on here.gpus[0] {
   var A: [1..n] int;
 
   A = 1;

--- a/test/gpu/native/promotion.chpl
+++ b/test/gpu/native/promotion.chpl
@@ -1,5 +1,5 @@
 config const n = 10;
-on here.getChild(1) {
+on here.getGpu(0) {
   var A: [1..n] int;
 
   A = 1;

--- a/test/gpu/native/streamPrototype/dr.chpl
+++ b/test/gpu/native/streamPrototype/dr.chpl
@@ -1,6 +1,6 @@
 config const n = 10;
 
-on here.getGpu(0) {
+on here.gpus[0] {
   var a, b: [0..n] int;
   var value = 20;
 

--- a/test/gpu/native/streamPrototype/dr.chpl
+++ b/test/gpu/native/streamPrototype/dr.chpl
@@ -1,6 +1,6 @@
 config const n = 10;
 
-on here.getChild(1) {
+on here.getGpu(0) {
   var a, b: [0..n] int;
   var value = 20;
 

--- a/test/gpu/native/streamPrototype/forallOverArray.chpl
+++ b/test/gpu/native/streamPrototype/forallOverArray.chpl
@@ -1,7 +1,7 @@
 config const start = 1;
 config const end = 10;
 
-on here.getGpu(0) {
+on here.gpus[0] {
   var a: [start..end] int;
   var value = 20;
 

--- a/test/gpu/native/streamPrototype/forallOverArray.chpl
+++ b/test/gpu/native/streamPrototype/forallOverArray.chpl
@@ -1,7 +1,7 @@
 config const start = 1;
 config const end = 10;
 
-on here.getChild(1) {
+on here.getGpu(0) {
   var a: [start..end] int;
   var value = 20;
 

--- a/test/gpu/native/streamPrototype/forallOverDomain.chpl
+++ b/test/gpu/native/streamPrototype/forallOverDomain.chpl
@@ -1,7 +1,7 @@
 config const start = 1;
 config const end = 10;
 
-on here.getChild(1) {
+on here.getGpu(0) {
   var a, b: [start..end] int;
   var value = 20;
 

--- a/test/gpu/native/streamPrototype/forallOverDomain.chpl
+++ b/test/gpu/native/streamPrototype/forallOverDomain.chpl
@@ -1,7 +1,7 @@
 config const start = 1;
 config const end = 10;
 
-on here.getGpu(0) {
+on here.gpus[0] {
   var a, b: [start..end] int;
   var value = 20;
 

--- a/test/gpu/native/streamPrototype/forallOverZipArray.chpl
+++ b/test/gpu/native/streamPrototype/forallOverZipArray.chpl
@@ -1,7 +1,7 @@
 config const start = 1;
 config const end = 10;
 
-on here.getChild(1) {
+on here.getGpu(0) {
   var a, b: [start..end] int;
 
   forall  (x,i) in zip(b, b.domain) do x = i+12;

--- a/test/gpu/native/streamPrototype/forallOverZipArray.chpl
+++ b/test/gpu/native/streamPrototype/forallOverZipArray.chpl
@@ -1,7 +1,7 @@
 config const start = 1;
 config const end = 10;
 
-on here.getGpu(0) {
+on here.gpus[0] {
   var a, b: [start..end] int;
 
   forall  (x,i) in zip(b, b.domain) do x = i+12;

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -56,7 +56,7 @@ config const printParams = true,
 proc main() {
   printConfiguration();   // print the problem size, number of trials, etc.
 
-  on here.getChild(1) {
+  on here.getGpu(0) {
     //
     // ProblemSpace describes the index set for the three vectors.  It
     // is a 1D domain that has indices 1 to m.

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -56,7 +56,7 @@ config const printParams = true,
 proc main() {
   printConfiguration();   // print the problem size, number of trials, etc.
 
-  on here.getGpu(0) {
+  on here.gpus[0] {
     //
     // ProblemSpace describes the index set for the three vectors.  It
     // is a 1D domain that has indices 1 to m.


### PR DESCRIPTION
This PR removse the CPU sublocale and have the first GPU sublocale use id 0. I add `proc gpus` (a parenless function that returns a const ref to an array of sublocales) and isGpu. So now instead of writing

```chpl
on here.getChild(1) { ... }
```

You would do:

```chpl
on here.gpus[0] { ... }
```

Another thing this PR does is make the sublocale id for the main locale (the locale for each node) be `none` instead of `any`.

This is necessary since the expected behavior/policy of running on the locale now is meant to be "run on the CPU" rather than "run on any of the sublocales".

If this weren't the case then when you "switch" from a sublocale back to the main locale it might not actually update the sublocale id for the task. This is why today if you run the following code:

```chpl
const cpuLocale = here;
writeln("A here = ", here);
on here.getChild(1) {
  writeln("B here = ", here);
  on cpuLocale {
    writeln("C here = ", here);
  }
}
```

The output will (somewhat suprisingly) not change `here` between `B` and `C`:
```chpl
A here = LOCALE0
B here = LOCALE0.node0-GPU1
C here = LOCALE0.node0-GPU1
```
