### PR TITLE
Improve printing of operator methods when printing a call stack at compilation

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -1588,7 +1588,8 @@ std::string FnSymbol::nameAndArgsToString(const char* sep,
       }
     }
 
-    if (foundThis) {
+    // Don't print "this" for operator methods, but do print it otherwise
+    if (foundThis && !fn->hasFlag(FLAG_OPERATOR)) {
       std::string argString = argToString(fn,
                                           name, thisFormal, thisSubstitution,
                                           /*isThis*/ true,

--- a/test/functions/operatorOverloads/operatorMethods/inCallStack.chpl
+++ b/test/functions/operatorOverloads/operatorMethods/inCallStack.chpl
@@ -1,0 +1,21 @@
+// Test to exercise printing of operators in call stack when failure occurs
+record bar {
+  var x: int;
+}
+
+// Must be generic to turn up in call stack
+operator bar.+(lhs, rhs: bar) {
+  someBrokenFunc(lhs.x); // Expected to fail
+  return new bar(lhs.x + rhs.x);
+}
+
+// Intentionally not a match for the call above
+proc someBrokenFunc(y: string) {
+  writeln(y);
+}
+
+proc main() {
+  var a = new bar(3);
+  var b = new bar(17);
+  writeln(a + b);
+}

--- a/test/functions/operatorOverloads/operatorMethods/inCallStack.good
+++ b/test/functions/operatorOverloads/operatorMethods/inCallStack.good
@@ -1,0 +1,6 @@
+inCallStack.chpl:7: In method '+':
+inCallStack.chpl:8: error: unresolved call 'someBrokenFunc(int(64))'
+inCallStack.chpl:13: note: this candidate did not match: someBrokenFunc(y: string)
+inCallStack.chpl:8: note: because actual argument #1 with type 'int(64)'
+inCallStack.chpl:13: note: is passed to formal 'y: string'
+  inCallStack.chpl:20: called as +(lhs: bar, rhs: bar)

--- a/test/types/errors/assignTypes.good
+++ b/test/types/errors/assignTypes.good
@@ -1,3 +1,3 @@
 assignTypes.chpl:17: In method '=':
 assignTypes.chpl:18: error: illegal assignment to type
-  assignTypes.chpl:21: called as R.=(lhs: R(int(64)), rhs: R(int(64)))
+  assignTypes.chpl:21: called as =(lhs: R(int(64)), rhs: R(int(64)))


### PR DESCRIPTION
Resolves #17539

Prior to this change, if a call failed and reports a call stack involving an operator
method, we would print that operator method as:
```
called as MyRecord.=(lhs: MyRecord(0), rhs: MyRecord(0)
```
This was confusing, because the user did not write the call like that and cannot
do so.  This change modifies the output so that operator methods are printed
like standalone operators:
```
called as =(lhs: MyRecord(0), rhs: MyRecord(0)
```

<details>
Adjust nameAndArgsToString of operator methods to not include `this` arg.
Let the function remove `this` from the list of arguments it found but don't
prepend its type to the return string.  `nameAndArgsToString` is only called by
`printCallstack` to create the output when a generic function has encountered
a failure when calling other functions.
</details>

Add a test to track this output and updated a different one.

Passed a full paratest with futures