### PR TITLE
Add test locking in that #17323 (internal error for missing type) is resolved

### DIFF
--- a/test/classes/initializers/errors/missingType.chpl
+++ b/test/classes/initializers/errors/missingType.chpl
@@ -1,0 +1,1 @@
+proc R.init(arg: int) { } // error: 'R' undeclared (first use this function)

--- a/test/classes/initializers/errors/missingType.good
+++ b/test/classes/initializers/errors/missingType.good
@@ -1,0 +1,2 @@
+missingType.chpl:1: In initializer:
+missingType.chpl:1: error: 'R' undeclared (first use this function)


### PR DESCRIPTION
Not sure when that happened, but it's good that it is fixed

Double checked fresh checkout of the test.