### PR TITLE
Add a test for automatic local access optimization

### DIFF
--- a/test/optimizations/autoLocalAccess/distSliceofDR.chpl
+++ b/test/optimizations/autoLocalAccess/distSliceofDR.chpl
@@ -1,0 +1,12 @@
+use BlockDist;
+
+var blockDom = newBlockDom(3..8);
+var localArr: [1..10] int;
+
+ref slice = localArr[blockDom];
+
+forall i in slice.domain {        // I expect this to be a distributed loop
+  slice[i] += 1;                  // but this shouldn't be a localAccess (?)
+}
+
+writeln(localArr);

--- a/test/optimizations/autoLocalAccess/distSliceofDR.good
+++ b/test/optimizations/autoLocalAccess/distSliceofDR.good
@@ -1,0 +1,13 @@
+
+Start analyzing forall (distSliceofDR.chpl:8)
+| Found loop domain (distSliceofDR.chpl:6)
+| Will attempt static and dynamic optimizations (distSliceofDR.chpl:8)
+|
+|  Start analyzing call (distSliceofDR.chpl:9)
+|   Can optimize: Access base is the iterator's base (distSliceofDR.chpl:9)
+|  This call is a static optimization candidate (distSliceofDR.chpl:9)
+|
+End analyzing forall (distSliceofDR.chpl:8)
+
+Local access attempt reverted. All static checks failed or code is unreachable.(distSliceofDR.chpl:9)
+0 0 1 1 1 1 1 1 0 0


### PR DESCRIPTION
This PR adds a test for a behavior fixed in https://github.com/chapel-lang/chapel/pull/17746.

Resolves https://github.com/Cray/chapel-private/issues/2113

Test passes under gasnet. 

