### PR TITLE
Improve the ordering of non-matching resolution candidates

### DIFF
--- a/compiler/include/ResolutionCandidate.h
+++ b/compiler/include/ResolutionCandidate.h
@@ -80,6 +80,9 @@ typedef enum {
   // Named argument uses argument name not present
   RESOLUTION_CANDIDATE_NO_NAMED_ARGUMENT,
 
+  // The receiver types differ, although may be related
+  RESOLUTION_CANDIDATE_DIFFERENT_RECEIVER_TYPES,
+
   // expand if var args failure (shouldn't be user facing)
   // computeSubstitutions failure
   // failure to instantiate signature

--- a/test/classes/deitz/method/method_call2.good
+++ b/test/classes/deitz/method/method_call2.good
@@ -3,4 +3,5 @@ method_call2.chpl:10: error: unresolved call 'bar.foo(2)'
 method_call2.chpl:6: note: this candidate did not match: bar.foo()
 method_call2.chpl:10: note: because call includes 1 argument
 method_call2.chpl:6: note: but function can only accept 0 arguments
-note: there is also 1 other candidate, use --print-all-candidates to see it
+method_call2.chpl:10: note: other candidates are:
+method_call2.chpl:1: note:   foo(i: int)

--- a/test/classes/nilability/cycle-generic.bad
+++ b/test/classes/nilability/cycle-generic.bad
@@ -1,0 +1,2 @@
+cycle-generic.chpl:1: In module 'cycle':
+cycle-generic.chpl:3: error: initialization requires an argument for next

--- a/test/classes/nilability/multiple-errors.1.good
+++ b/test/classes/nilability/multiple-errors.1.good
@@ -9,7 +9,8 @@ multiple-errors.chpl:17: note: this candidate did not match: C.bar()
 multiple-errors.chpl:42: note: because method call receiver with type 'borrowed C?'
 multiple-errors.chpl:17: note: is passed to formal 'this: borrowed C'
 multiple-errors.chpl:42: note: try to apply the postfix ! operator to method call receiver
-note: there is also 1 other candidate, use --print-all-candidates to see it
+multiple-errors.chpl:42: note: other candidates are:
+multiple-errors.chpl:24: note:   bar()
 multiple-errors.chpl:43: error: unresolved call 'baz(borrowed C?)'
 multiple-errors.chpl:20: note: this candidate did not match: baz(arg: C)
 multiple-errors.chpl:43: note: because actual argument #1 with type 'borrowed C?'

--- a/test/classes/nilability/multiple-errors.2.good
+++ b/test/classes/nilability/multiple-errors.2.good
@@ -9,7 +9,8 @@ multiple-errors.chpl:17: note: this candidate did not match: C.bar()
 multiple-errors.chpl:42: note: because method call receiver with type 'borrowed C?'
 multiple-errors.chpl:17: note: is passed to formal 'this: borrowed C'
 multiple-errors.chpl:42: note: try to apply the postfix ! operator to method call receiver
-note: there is also 1 other candidate, use --print-all-candidates to see it
+multiple-errors.chpl:42: note: other candidates are:
+multiple-errors.chpl:24: note:   bar()
 multiple-errors.chpl:43: error: unresolved call 'baz(borrowed C?)'
 multiple-errors.chpl:20: note: this candidate did not match: baz(arg: C)
 multiple-errors.chpl:43: note: because actual argument #1 with type 'borrowed C?'

--- a/test/errhandling/parallel/taskerrors-write.bad
+++ b/test/errhandling/parallel/taskerrors-write.bad
@@ -1,0 +1,2 @@
+TaskErrors: 3 errors: Error:  ... Error: 
+TaskErrors: 3 errors: Error: aaa ... Error: ccc

--- a/test/errhandling/parallel/taskerrors-write.chpl
+++ b/test/errhandling/parallel/taskerrors-write.chpl
@@ -1,0 +1,26 @@
+// TaskErrors uses an ordering among the errors it contains
+// to determine the first and the last error to show in its message().
+// Currently the ordering is based on message() of individual errors.
+//
+// This test requests the ordering to be based on chpl_describe_error()
+// of the individual errors. Rationale: those are the strings reflected
+// in TaskErrors.message(). For example, consider a TaskErrors that contains
+// three errors: Error1, Error2, Error1, in this order, each with an empty
+// message(). Currently TaskErrors.message() contains "Error1: ... Error1:".
+// Instead, it makes more sense if it contained "Error1: ... Error2:".
+
+var te1: chpl_TaskErrors;
+te1.append(new unmanaged Error());
+te1.append(new unmanaged IllegalArgumentError());
+te1.append(new unmanaged Error());
+var TE1 = new TaskErrors(te1);
+writeln(TE1);
+
+// Even when individual errors contain messages, the sorted order
+// that reflects the contents of TaskErrors.message() makes more sense.
+var te2: chpl_TaskErrors;
+te2.append(new unmanaged Error("aaa"));
+te2.append(new unmanaged IllegalArgumentError("bbb"));
+te2.append(new unmanaged Error("ccc"));
+var TE2 = new TaskErrors(te2);
+writeln(TE2);

--- a/test/errhandling/parallel/taskerrors-write.future
+++ b/test/errhandling/parallel/taskerrors-write.future
@@ -1,0 +1,2 @@
+bug: unintuitive order when printing TaskErrors
+#19697

--- a/test/errhandling/parallel/taskerrors-write.good
+++ b/test/errhandling/parallel/taskerrors-write.good
@@ -1,0 +1,2 @@
+TaskErrors: 3 errors: Error:  ... IllegalArgumentError: 
+TaskErrors: 3 errors: Error: aaa ... IllegalArgumentError: bbb

--- a/test/functions/bradc/resolution/badEnumDispatch.good
+++ b/test/functions/bradc/resolution/badEnumDispatch.good
@@ -101,7 +101,7 @@ badEnumDispatch.chpl:35: note: is passed to formal 'param x: int(8)'
 badEnumDispatch.chpl:104: note: other candidates are:
 badEnumDispatch.chpl:39: note:   param8Or32OrNot(x: int(8))
 badEnumDispatch.chpl:43: note:   param8Or32OrNot(param x: int(32))
-note: and 1 other candidate, use --print-all-candidates to see it
+badEnumDispatch.chpl:47: note:   param8Or32OrNot(x: int(32))
 badEnumDispatch.chpl:105: error: unresolved call 'param8Or32OrNot(sizes)'
 badEnumDispatch.chpl:35: note: this candidate did not match: param8Or32OrNot(param x: int(8))
 badEnumDispatch.chpl:105: note: because actual argument #1 with type 'sizes'
@@ -109,7 +109,7 @@ badEnumDispatch.chpl:35: note: is passed to formal 'param x: int(8)'
 badEnumDispatch.chpl:105: note: other candidates are:
 badEnumDispatch.chpl:39: note:   param8Or32OrNot(x: int(8))
 badEnumDispatch.chpl:43: note:   param8Or32OrNot(param x: int(32))
-note: and 1 other candidate, use --print-all-candidates to see it
+badEnumDispatch.chpl:47: note:   param8Or32OrNot(x: int(32))
 badEnumDispatch.chpl:106: error: unresolved call 'param8Or32OrNot(sizes)'
 badEnumDispatch.chpl:39: note: this candidate did not match: param8Or32OrNot(x: int(8))
 badEnumDispatch.chpl:106: note: because actual argument #1 with type 'sizes'
@@ -117,7 +117,7 @@ badEnumDispatch.chpl:39: note: is passed to formal 'x: int(8)'
 badEnumDispatch.chpl:106: note: other candidates are:
 badEnumDispatch.chpl:47: note:   param8Or32OrNot(x: int(32))
 badEnumDispatch.chpl:35: note:   param8Or32OrNot(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+badEnumDispatch.chpl:43: note:   param8Or32OrNot(param x: int(32))
 badEnumDispatch.chpl:107: error: unresolved call 'param8Or32OrNot(sizes)'
 badEnumDispatch.chpl:39: note: this candidate did not match: param8Or32OrNot(x: int(8))
 badEnumDispatch.chpl:107: note: because actual argument #1 with type 'sizes'
@@ -125,7 +125,7 @@ badEnumDispatch.chpl:39: note: is passed to formal 'x: int(8)'
 badEnumDispatch.chpl:107: note: other candidates are:
 badEnumDispatch.chpl:47: note:   param8Or32OrNot(x: int(32))
 badEnumDispatch.chpl:35: note:   param8Or32OrNot(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+badEnumDispatch.chpl:43: note:   param8Or32OrNot(param x: int(32))
 badEnumDispatch.chpl:111: error: unresolved call 'allSigs(sizes)'
 badEnumDispatch.chpl:51: note: this candidate did not match: allSigs(x: int(8))
 badEnumDispatch.chpl:111: note: because actual argument #1 with type 'sizes'
@@ -133,7 +133,7 @@ badEnumDispatch.chpl:51: note: is passed to formal 'x: int(8)'
 badEnumDispatch.chpl:111: note: other candidates are:
 badEnumDispatch.chpl:55: note:   allSigs(x: int(64))
 badEnumDispatch.chpl:59: note:   allSigs(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+badEnumDispatch.chpl:63: note:   allSigs(param x: int(64))
 badEnumDispatch.chpl:112: error: unresolved call 'allSigs(sizes)'
 badEnumDispatch.chpl:51: note: this candidate did not match: allSigs(x: int(8))
 badEnumDispatch.chpl:112: note: because actual argument #1 with type 'sizes'
@@ -141,7 +141,7 @@ badEnumDispatch.chpl:51: note: is passed to formal 'x: int(8)'
 badEnumDispatch.chpl:112: note: other candidates are:
 badEnumDispatch.chpl:55: note:   allSigs(x: int(64))
 badEnumDispatch.chpl:59: note:   allSigs(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+badEnumDispatch.chpl:63: note:   allSigs(param x: int(64))
 badEnumDispatch.chpl:113: error: unresolved call 'allSigs(sizes)'
 badEnumDispatch.chpl:51: note: this candidate did not match: allSigs(x: int(8))
 badEnumDispatch.chpl:113: note: because actual argument #1 with type 'sizes'
@@ -149,7 +149,7 @@ badEnumDispatch.chpl:51: note: is passed to formal 'x: int(8)'
 badEnumDispatch.chpl:113: note: other candidates are:
 badEnumDispatch.chpl:55: note:   allSigs(x: int(64))
 badEnumDispatch.chpl:59: note:   allSigs(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+badEnumDispatch.chpl:63: note:   allSigs(param x: int(64))
 badEnumDispatch.chpl:114: error: unresolved call 'allSigs(sizes)'
 badEnumDispatch.chpl:51: note: this candidate did not match: allSigs(x: int(8))
 badEnumDispatch.chpl:114: note: because actual argument #1 with type 'sizes'
@@ -157,4 +157,4 @@ badEnumDispatch.chpl:51: note: is passed to formal 'x: int(8)'
 badEnumDispatch.chpl:114: note: other candidates are:
 badEnumDispatch.chpl:55: note:   allSigs(x: int(64))
 badEnumDispatch.chpl:59: note:   allSigs(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+badEnumDispatch.chpl:63: note:   allSigs(param x: int(64))

--- a/test/functions/ferguson/query/query-generic-star-tuple-error.good
+++ b/test/functions/ferguson/query/query-generic-star-tuple-error.good
@@ -1,4 +1,5 @@
 query-generic-star-tuple-error.chpl:17: error: unresolved call 'f((Wrapper(int(64)),Wrapper(owned GenericClass(int(64)))))'
 query-generic-star-tuple-error.chpl:10: note: this candidate did not match: f(x: 2*Wrapper)
 query-generic-star-tuple-error.chpl:10: note: because an argument was incompatible
-note: there is also 1 other candidate, use --print-all-candidates to see it
+query-generic-star-tuple-error.chpl:17: note: other candidates are:
+query-generic-star-tuple-error.chpl:7: note:   Wrapper.f

--- a/test/functions/ferguson/query/query-generic-type-leaf-borrowed.good
+++ b/test/functions/ferguson/query/query-generic-type-leaf-borrowed.good
@@ -1,4 +1,5 @@
 query-generic-type-leaf-borrowed.chpl:34: error: unresolved call 'f(Wrapper(OtherGenericClass(int(64))))'
 query-generic-type-leaf-borrowed.chpl:15: note: this candidate did not match: f(x: Wrapper(borrowed GenericClass))
 query-generic-type-leaf-borrowed.chpl:15: note: because an argument was incompatible
-note: there is also 1 other candidate, use --print-all-candidates to see it
+query-generic-type-leaf-borrowed.chpl:34: note: other candidates are:
+query-generic-type-leaf-borrowed.chpl:12: note:   Wrapper.f

--- a/test/functions/ferguson/query/query-generic-type-leaf.good
+++ b/test/functions/ferguson/query/query-generic-type-leaf.good
@@ -1,4 +1,5 @@
 query-generic-type-leaf.chpl:34: error: unresolved call 'f(Wrapper(OtherGenericClass(int(64))))'
 query-generic-type-leaf.chpl:15: note: this candidate did not match: f(x: Wrapper(GenericClass))
 query-generic-type-leaf.chpl:15: note: because an argument was incompatible
-note: there is also 1 other candidate, use --print-all-candidates to see it
+query-generic-type-leaf.chpl:34: note: other candidates are:
+query-generic-type-leaf.chpl:12: note:   Wrapper.f

--- a/test/functions/lydia/method-iter-resolution-bug.bad
+++ b/test/functions/lydia/method-iter-resolution-bug.bad
@@ -3,4 +3,5 @@ method-iter-resolution-bug.chpl:7: error: unresolved call 'C.iTerate(int(64), in
 method-iter-resolution-bug.chpl:4: note: this candidate did not match: C.iTerate(x: int)
 method-iter-resolution-bug.chpl:7: note: because call includes 2 arguments
 method-iter-resolution-bug.chpl:4: note: but function can only accept 1 argument
-note: there is also 1 other candidate, use --print-all-candidates to see it
+method-iter-resolution-bug.chpl:7: note: other candidates are:
+method-iter-resolution-bug.chpl:11: note:   iTerate(start: int, end: int)

--- a/test/functions/resolution/errors/receiver-type-mismatch.1.good
+++ b/test/functions/resolution/errors/receiver-type-mismatch.1.good
@@ -1,0 +1,8 @@
+receiver-type-mismatch.chpl:45: error: unresolved call 'S.foo()'
+receiver-type-mismatch.chpl:30: note: this candidate did not match: S.foo(x: int)
+receiver-type-mismatch.chpl:45: note: because call does not supply enough arguments
+receiver-type-mismatch.chpl:30: note: it is missing a value for formal 'x: int(64)'
+receiver-type-mismatch.chpl:45: note: other candidates are:
+receiver-type-mismatch.chpl:6: note:   C.foo()
+receiver-type-mismatch.chpl:14: note:   D.foo()
+note: and 2 other candidates, use --print-all-candidates to see them

--- a/test/functions/resolution/errors/receiver-type-mismatch.2.good
+++ b/test/functions/resolution/errors/receiver-type-mismatch.2.good
@@ -1,0 +1,8 @@
+receiver-type-mismatch.chpl:46: error: unresolved call 'S.bar(1)'
+receiver-type-mismatch.chpl:33: note: this candidate did not match: S.bar()
+receiver-type-mismatch.chpl:46: note: because call includes 1 argument
+receiver-type-mismatch.chpl:33: note: but function can only accept 0 arguments
+receiver-type-mismatch.chpl:46: note: other candidates are:
+receiver-type-mismatch.chpl:9: note:   C.bar(x: int)
+receiver-type-mismatch.chpl:17: note:   D.bar(x: real)
+note: and 2 other candidates, use --print-all-candidates to see them

--- a/test/functions/resolution/errors/receiver-type-mismatch.chpl
+++ b/test/functions/resolution/errors/receiver-type-mismatch.chpl
@@ -1,0 +1,46 @@
+// #18565
+
+config param testNum = 0;
+
+class C {
+  proc foo() {
+  }
+
+  proc bar(x: int) {
+  }
+}
+
+class D {
+  proc foo() {
+  }
+
+  proc bar(x: real) {
+  }
+}
+
+class E {
+  proc foo() {
+  }
+
+  proc bar(x: string) {
+  }
+}
+
+record S {
+  proc foo(x: int) {
+  }
+
+  proc bar() {
+  }
+}
+
+proc int.foo() {
+}
+
+proc int.bar(x: bool) {
+}
+
+var myS: S;
+
+if testNum == 1 then myS.foo();
+if testNum == 2 then myS.bar(1);

--- a/test/functions/resolution/errors/receiver-type-mismatch.compopts
+++ b/test/functions/resolution/errors/receiver-type-mismatch.compopts
@@ -1,0 +1,2 @@
+-stestNum=1 # receiver-type-mismatch.1.good
+-stestNum=2 # receiver-type-mismatch.2.good

--- a/test/functions/resolution/errors/testBadCallCandidates.1-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.1-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:71: In function 'main':
 testBadCallCandidates.chpl:76: error: unresolved call 'owned C.foo(42)'
-testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
-testBadCallCandidates.chpl:76: note: because method call receiver with type 'owned C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
+testBadCallCandidates.chpl:76: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:5: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:76: note: other candidates are:
-testBadCallCandidates.chpl:5: note:   C.foo(x: string)
+testBadCallCandidates.chpl:33: note:   D.foo(x: C)
 testBadCallCandidates.chpl:59: note:   foo(x: C)
 testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.1.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.1.good
@@ -1,8 +1,9 @@
 testBadCallCandidates.chpl:71: In function 'main':
 testBadCallCandidates.chpl:76: error: unresolved call 'owned C.foo(42)'
-testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
-testBadCallCandidates.chpl:76: note: because method call receiver with type 'owned C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
+testBadCallCandidates.chpl:76: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:5: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:76: note: other candidates are:
-testBadCallCandidates.chpl:5: note:   C.foo(x: string)
-note: and 2 other candidates, use --print-all-candidates to see them
+testBadCallCandidates.chpl:33: note:   D.foo(x: C)
+testBadCallCandidates.chpl:59: note:   foo(x: C)
+testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.10-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.10-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:14: In method 'test':
 testBadCallCandidates.chpl:16: error: unresolved call 'C.foo(42)'
-testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
-testBadCallCandidates.chpl:16: note: because method call receiver with type 'borrowed C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
+testBadCallCandidates.chpl:16: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:5: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:16: note: other candidates are:
-testBadCallCandidates.chpl:5: note:   C.foo(x: string)
+testBadCallCandidates.chpl:33: note:   D.foo(x: C)
 testBadCallCandidates.chpl:59: note:   foo(x: C)
 testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.10.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.10.good
@@ -1,8 +1,9 @@
 testBadCallCandidates.chpl:14: In method 'test':
 testBadCallCandidates.chpl:16: error: unresolved call 'C.foo(42)'
-testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
-testBadCallCandidates.chpl:16: note: because method call receiver with type 'borrowed C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
+testBadCallCandidates.chpl:16: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:5: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:16: note: other candidates are:
-testBadCallCandidates.chpl:5: note:   C.foo(x: string)
-note: and 2 other candidates, use --print-all-candidates to see them
+testBadCallCandidates.chpl:33: note:   D.foo(x: C)
+testBadCallCandidates.chpl:59: note:   foo(x: C)
+testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.11-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.11-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:14: In method 'test':
 testBadCallCandidates.chpl:18: error: unresolved call 'C.foo(42)'
-testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
-testBadCallCandidates.chpl:18: note: because method call receiver with type 'borrowed C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
+testBadCallCandidates.chpl:18: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:5: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:18: note: other candidates are:
-testBadCallCandidates.chpl:5: note:   C.foo(x: string)
+testBadCallCandidates.chpl:33: note:   D.foo(x: C)
 testBadCallCandidates.chpl:59: note:   foo(x: C)
 testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.11.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.11.good
@@ -1,8 +1,9 @@
 testBadCallCandidates.chpl:14: In method 'test':
 testBadCallCandidates.chpl:18: error: unresolved call 'C.foo(42)'
-testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
-testBadCallCandidates.chpl:18: note: because method call receiver with type 'borrowed C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
+testBadCallCandidates.chpl:18: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:5: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:18: note: other candidates are:
-testBadCallCandidates.chpl:5: note:   C.foo(x: string)
-note: and 2 other candidates, use --print-all-candidates to see them
+testBadCallCandidates.chpl:33: note:   D.foo(x: C)
+testBadCallCandidates.chpl:59: note:   foo(x: C)
+testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.12-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.12-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:14: In method 'test':
 testBadCallCandidates.chpl:20: error: unresolved call 'C.bar(42)'
-testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
-testBadCallCandidates.chpl:20: note: because method call receiver with type 'borrowed C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
+testBadCallCandidates.chpl:20: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:8: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:20: note: other candidates are:
-testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
+testBadCallCandidates.chpl:36: note:   D.bar(x: int)
 testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.12.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.12.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:14: In method 'test':
 testBadCallCandidates.chpl:20: error: unresolved call 'C.bar(42)'
-testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
-testBadCallCandidates.chpl:20: note: because method call receiver with type 'borrowed C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
+testBadCallCandidates.chpl:20: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:8: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:20: note: other candidates are:
-testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-note: and 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:36: note:   D.bar(x: int)
+testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.13-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.13-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:14: In method 'test':
 testBadCallCandidates.chpl:22: error: unresolved call 'C.bar(42)'
-testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
-testBadCallCandidates.chpl:22: note: because method call receiver with type 'borrowed C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
+testBadCallCandidates.chpl:22: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:8: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:22: note: other candidates are:
-testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
+testBadCallCandidates.chpl:36: note:   D.bar(x: int)
 testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.13.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.13.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:14: In method 'test':
 testBadCallCandidates.chpl:22: error: unresolved call 'C.bar(42)'
-testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
-testBadCallCandidates.chpl:22: note: because method call receiver with type 'borrowed C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
+testBadCallCandidates.chpl:22: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:8: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:22: note: other candidates are:
-testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-note: and 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:36: note:   D.bar(x: int)
+testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.14.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.14.good
@@ -3,4 +3,5 @@ testBadCallCandidates.chpl:24: error: unresolved call 'C.baz(42)'
 testBadCallCandidates.chpl:39: note: this candidate did not match: D.baz(x: C)
 testBadCallCandidates.chpl:24: note: because method call receiver with type 'borrowed C'
 testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
-note: there is also 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:24: note: other candidates are:
+testBadCallCandidates.chpl:68: note:   baz(x: C)

--- a/test/functions/resolution/errors/testBadCallCandidates.15.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.15.good
@@ -3,4 +3,5 @@ testBadCallCandidates.chpl:26: error: unresolved call 'baz(42)'
 testBadCallCandidates.chpl:68: note: this candidate did not match: baz(x: C)
 testBadCallCandidates.chpl:26: note: because actual argument #1 with type 'int(64)'
 testBadCallCandidates.chpl:68: note: is passed to formal 'x: C'
-note: there is also 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:26: note: other candidates are:
+testBadCallCandidates.chpl:39: note:   D.baz(x: C)

--- a/test/functions/resolution/errors/testBadCallCandidates.16-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.16-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:42: In method 'test':
 testBadCallCandidates.chpl:44: error: unresolved call 'D.foo("hi")'
-testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
-testBadCallCandidates.chpl:44: note: because method call receiver with type 'borrowed D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
+testBadCallCandidates.chpl:44: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:33: note: is passed to formal 'x: C'
 testBadCallCandidates.chpl:44: note: other candidates are:
-testBadCallCandidates.chpl:33: note:   D.foo(x: C)
+testBadCallCandidates.chpl:5: note:   C.foo(x: string)
 testBadCallCandidates.chpl:59: note:   foo(x: C)
 testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.16.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.16.good
@@ -1,8 +1,9 @@
 testBadCallCandidates.chpl:42: In method 'test':
 testBadCallCandidates.chpl:44: error: unresolved call 'D.foo("hi")'
-testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
-testBadCallCandidates.chpl:44: note: because method call receiver with type 'borrowed D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
+testBadCallCandidates.chpl:44: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:33: note: is passed to formal 'x: C'
 testBadCallCandidates.chpl:44: note: other candidates are:
-testBadCallCandidates.chpl:33: note:   D.foo(x: C)
-note: and 2 other candidates, use --print-all-candidates to see them
+testBadCallCandidates.chpl:5: note:   C.foo(x: string)
+testBadCallCandidates.chpl:59: note:   foo(x: C)
+testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.17-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.17-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:42: In method 'test':
 testBadCallCandidates.chpl:46: error: unresolved call 'D.foo("hi")'
-testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
-testBadCallCandidates.chpl:46: note: because method call receiver with type 'borrowed D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
+testBadCallCandidates.chpl:46: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:33: note: is passed to formal 'x: C'
 testBadCallCandidates.chpl:46: note: other candidates are:
-testBadCallCandidates.chpl:33: note:   D.foo(x: C)
+testBadCallCandidates.chpl:5: note:   C.foo(x: string)
 testBadCallCandidates.chpl:59: note:   foo(x: C)
 testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.17.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.17.good
@@ -1,8 +1,9 @@
 testBadCallCandidates.chpl:42: In method 'test':
 testBadCallCandidates.chpl:46: error: unresolved call 'D.foo("hi")'
-testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
-testBadCallCandidates.chpl:46: note: because method call receiver with type 'borrowed D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
+testBadCallCandidates.chpl:46: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:33: note: is passed to formal 'x: C'
 testBadCallCandidates.chpl:46: note: other candidates are:
-testBadCallCandidates.chpl:33: note:   D.foo(x: C)
-note: and 2 other candidates, use --print-all-candidates to see them
+testBadCallCandidates.chpl:5: note:   C.foo(x: string)
+testBadCallCandidates.chpl:59: note:   foo(x: C)
+testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.18-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.18-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:42: In method 'test':
 testBadCallCandidates.chpl:48: error: unresolved call 'D.bar("hi")'
-testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
-testBadCallCandidates.chpl:48: note: because method call receiver with type 'borrowed D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
+testBadCallCandidates.chpl:48: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:36: note: is passed to formal 'x: int(64)'
 testBadCallCandidates.chpl:48: note: other candidates are:
+testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-testBadCallCandidates.chpl:36: note:   D.bar(x: int)
 testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.18.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.18.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:42: In method 'test':
 testBadCallCandidates.chpl:48: error: unresolved call 'D.bar("hi")'
-testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
-testBadCallCandidates.chpl:48: note: because method call receiver with type 'borrowed D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
+testBadCallCandidates.chpl:48: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:36: note: is passed to formal 'x: int(64)'
 testBadCallCandidates.chpl:48: note: other candidates are:
+testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-testBadCallCandidates.chpl:36: note:   D.bar(x: int)
-note: and 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.19-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.19-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:42: In method 'test':
 testBadCallCandidates.chpl:50: error: unresolved call 'D.bar("hi")'
-testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
-testBadCallCandidates.chpl:50: note: because method call receiver with type 'borrowed D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
+testBadCallCandidates.chpl:50: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:36: note: is passed to formal 'x: int(64)'
 testBadCallCandidates.chpl:50: note: other candidates are:
+testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-testBadCallCandidates.chpl:36: note:   D.bar(x: int)
 testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.19.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.19.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:42: In method 'test':
 testBadCallCandidates.chpl:50: error: unresolved call 'D.bar("hi")'
-testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
-testBadCallCandidates.chpl:50: note: because method call receiver with type 'borrowed D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
+testBadCallCandidates.chpl:50: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:36: note: is passed to formal 'x: int(64)'
 testBadCallCandidates.chpl:50: note: other candidates are:
+testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-testBadCallCandidates.chpl:36: note:   D.bar(x: int)
-note: and 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.2-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.2-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:71: In function 'main':
 testBadCallCandidates.chpl:79: error: unresolved call 'owned D.foo("hi")'
-testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
-testBadCallCandidates.chpl:79: note: because method call receiver with type 'owned D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
+testBadCallCandidates.chpl:79: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:33: note: is passed to formal 'x: C'
 testBadCallCandidates.chpl:79: note: other candidates are:
-testBadCallCandidates.chpl:33: note:   D.foo(x: C)
+testBadCallCandidates.chpl:5: note:   C.foo(x: string)
 testBadCallCandidates.chpl:59: note:   foo(x: C)
 testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.2.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.2.good
@@ -1,8 +1,9 @@
 testBadCallCandidates.chpl:71: In function 'main':
 testBadCallCandidates.chpl:79: error: unresolved call 'owned D.foo("hi")'
-testBadCallCandidates.chpl:5: note: this candidate did not match: C.foo(x: string)
-testBadCallCandidates.chpl:79: note: because method call receiver with type 'owned D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:33: note: this candidate did not match: D.foo(x: C)
+testBadCallCandidates.chpl:79: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:33: note: is passed to formal 'x: C'
 testBadCallCandidates.chpl:79: note: other candidates are:
-testBadCallCandidates.chpl:33: note:   D.foo(x: C)
-note: and 2 other candidates, use --print-all-candidates to see them
+testBadCallCandidates.chpl:5: note:   C.foo(x: string)
+testBadCallCandidates.chpl:59: note:   foo(x: C)
+testBadCallCandidates.chpl:62: note:   foo(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.20.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.20.good
@@ -3,4 +3,5 @@ testBadCallCandidates.chpl:52: error: unresolved call 'D.baz("hi")'
 testBadCallCandidates.chpl:39: note: this candidate did not match: D.baz(x: C)
 testBadCallCandidates.chpl:52: note: because actual argument #1 with type 'string'
 testBadCallCandidates.chpl:39: note: is passed to formal 'x: C'
-note: there is also 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:52: note: other candidates are:
+testBadCallCandidates.chpl:68: note:   baz(x: C)

--- a/test/functions/resolution/errors/testBadCallCandidates.21.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.21.good
@@ -3,4 +3,5 @@ testBadCallCandidates.chpl:54: error: unresolved call 'D.baz("hi")'
 testBadCallCandidates.chpl:39: note: this candidate did not match: D.baz(x: C)
 testBadCallCandidates.chpl:54: note: because actual argument #1 with type 'string'
 testBadCallCandidates.chpl:39: note: is passed to formal 'x: C'
-note: there is also 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:54: note: other candidates are:
+testBadCallCandidates.chpl:68: note:   baz(x: C)

--- a/test/functions/resolution/errors/testBadCallCandidates.3.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.3.good
@@ -5,4 +5,5 @@ testBadCallCandidates.chpl:82: note: because actual argument #1 with type 'int(6
 testBadCallCandidates.chpl:59: note: is passed to formal 'x: C'
 testBadCallCandidates.chpl:82: note: other candidates are:
 testBadCallCandidates.chpl:62: note:   foo(x: D)
-note: and 2 other candidates, use --print-all-candidates to see them
+testBadCallCandidates.chpl:5: note:   C.foo(x: string)
+testBadCallCandidates.chpl:33: note:   D.foo(x: C)

--- a/test/functions/resolution/errors/testBadCallCandidates.4-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.4-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:71: In function 'main':
 testBadCallCandidates.chpl:85: error: unresolved call 'owned C.bar(42)'
-testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
-testBadCallCandidates.chpl:85: note: because method call receiver with type 'owned C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
+testBadCallCandidates.chpl:85: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:8: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:85: note: other candidates are:
-testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
+testBadCallCandidates.chpl:36: note:   D.bar(x: int)
 testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.4.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.4.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:71: In function 'main':
 testBadCallCandidates.chpl:85: error: unresolved call 'owned C.bar(42)'
-testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
-testBadCallCandidates.chpl:85: note: because method call receiver with type 'owned C'
-testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
+testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
+testBadCallCandidates.chpl:85: note: because actual argument #1 with type 'int(64)'
+testBadCallCandidates.chpl:8: note: is passed to formal 'x: string'
 testBadCallCandidates.chpl:85: note: other candidates are:
-testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-note: and 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:36: note:   D.bar(x: int)
+testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.5-all.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.5-all.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:71: In function 'main':
 testBadCallCandidates.chpl:88: error: unresolved call 'owned D.bar("hi")'
-testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
-testBadCallCandidates.chpl:88: note: because method call receiver with type 'owned D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
+testBadCallCandidates.chpl:88: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:36: note: is passed to formal 'x: int(64)'
 testBadCallCandidates.chpl:88: note: other candidates are:
+testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-testBadCallCandidates.chpl:36: note:   D.bar(x: int)
 testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.5.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.5.good
@@ -1,9 +1,9 @@
 testBadCallCandidates.chpl:71: In function 'main':
 testBadCallCandidates.chpl:88: error: unresolved call 'owned D.bar("hi")'
-testBadCallCandidates.chpl:8: note: this candidate did not match: C.bar(x: string)
-testBadCallCandidates.chpl:88: note: because method call receiver with type 'owned D'
-testBadCallCandidates.chpl:4: note: is passed to formal 'this: borrowed C'
+testBadCallCandidates.chpl:36: note: this candidate did not match: D.bar(x: int)
+testBadCallCandidates.chpl:88: note: because actual argument #1 with type 'string'
+testBadCallCandidates.chpl:36: note: is passed to formal 'x: int(64)'
 testBadCallCandidates.chpl:88: note: other candidates are:
+testBadCallCandidates.chpl:8: note:   C.bar(x: string)
 testBadCallCandidates.chpl:11: note:   C.bar(x: D)
-testBadCallCandidates.chpl:36: note:   D.bar(x: int)
-note: and 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:65: note:   bar(x: D)

--- a/test/functions/resolution/errors/testBadCallCandidates.6.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.6.good
@@ -3,4 +3,7 @@ testBadCallCandidates.chpl:91: error: unresolved call 'bar("hi")'
 testBadCallCandidates.chpl:65: note: this candidate did not match: bar(x: D)
 testBadCallCandidates.chpl:91: note: because actual argument #1 with type 'string'
 testBadCallCandidates.chpl:65: note: is passed to formal 'x: D'
-note: there are also 3 other candidates, use --print-all-candidates to see them
+testBadCallCandidates.chpl:91: note: other candidates are:
+testBadCallCandidates.chpl:8: note:   C.bar(x: string)
+testBadCallCandidates.chpl:11: note:   C.bar(x: D)
+testBadCallCandidates.chpl:36: note:   D.bar(x: int)

--- a/test/functions/resolution/errors/testBadCallCandidates.7.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.7.good
@@ -3,4 +3,5 @@ testBadCallCandidates.chpl:94: error: unresolved call 'owned C.baz(42)'
 testBadCallCandidates.chpl:39: note: this candidate did not match: D.baz(x: C)
 testBadCallCandidates.chpl:94: note: because method call receiver with type 'owned C'
 testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
-note: there is also 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:94: note: other candidates are:
+testBadCallCandidates.chpl:68: note:   baz(x: C)

--- a/test/functions/resolution/errors/testBadCallCandidates.8.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.8.good
@@ -3,4 +3,5 @@ testBadCallCandidates.chpl:97: error: unresolved call 'owned C.baz("hi")'
 testBadCallCandidates.chpl:39: note: this candidate did not match: D.baz(x: C)
 testBadCallCandidates.chpl:97: note: because method call receiver with type 'owned C'
 testBadCallCandidates.chpl:32: note: is passed to formal 'this: borrowed D'
-note: there is also 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:97: note: other candidates are:
+testBadCallCandidates.chpl:68: note:   baz(x: C)

--- a/test/functions/resolution/errors/testBadCallCandidates.9.good
+++ b/test/functions/resolution/errors/testBadCallCandidates.9.good
@@ -3,4 +3,5 @@ testBadCallCandidates.chpl:100: error: unresolved call 'baz(42)'
 testBadCallCandidates.chpl:68: note: this candidate did not match: baz(x: C)
 testBadCallCandidates.chpl:100: note: because actual argument #1 with type 'int(64)'
 testBadCallCandidates.chpl:68: note: is passed to formal 'x: C'
-note: there is also 1 other candidate, use --print-all-candidates to see it
+testBadCallCandidates.chpl:100: note: other candidates are:
+testBadCallCandidates.chpl:39: note:   D.baz(x: C)

--- a/test/functions/resolution/functionAndMethodWithSameNameBug.bad
+++ b/test/functions/resolution/functionAndMethodWithSameNameBug.bad
@@ -3,5 +3,6 @@ functionAndMethodWithSameNameBug.chpl:7: error: unresolved call 'R.foo(int(64), 
 functionAndMethodWithSameNameBug.chpl:5: note: this candidate did not match: R.foo(arg1)
 functionAndMethodWithSameNameBug.chpl:7: note: because call includes 2 arguments
 functionAndMethodWithSameNameBug.chpl:5: note: but function can only accept 1 argument
-note: there is also 1 other candidate, use --print-all-candidates to see it
+functionAndMethodWithSameNameBug.chpl:7: note: other candidates are:
+functionAndMethodWithSameNameBug.chpl:1: note:   foo(arg1, arg2)
   functionAndMethodWithSameNameBug.chpl:11: called as R.foo(arg1: int(64))

--- a/test/types/bool/resolution/resolveQueryTypeW.bad
+++ b/test/types/bool/resolution/resolveQueryTypeW.bad
@@ -5,4 +5,4 @@ resolveQueryTypeW.chpl:1: note: is passed to formal 'const ref x: bool(8)'
 resolveQueryTypeW.chpl:6: note: other candidates are:
 resolveQueryTypeW.chpl:1: note:   bar(x: bool(16))
 resolveQueryTypeW.chpl:1: note:   bar(x: bool(32))
-note: and 1 other candidate, use --print-all-candidates to see it
+resolveQueryTypeW.chpl:1: note:   bar(x: bool(64))

--- a/test/types/enum/bradc/dispatch/dispatchenums.good
+++ b/test/types/enum/bradc/dispatch/dispatchenums.good
@@ -12,7 +12,7 @@ dispatchenums.chpl:77: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:16: note: other candidates are:
 dispatchenums.chpl:81: note:   int8vs32(param x: int(8))
 dispatchenums.chpl:85: note:   int8vs32(x: int(32))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:89: note:   int8vs32(param x: int(32))
 dispatchenums.chpl:17: error: unresolved call 'int8vs32(numeral)'
 dispatchenums.chpl:77: note: this candidate did not match: int8vs32(x: int(8))
 dispatchenums.chpl:17: note: because actual argument #1 with type 'numeral'
@@ -20,7 +20,7 @@ dispatchenums.chpl:77: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:17: note: other candidates are:
 dispatchenums.chpl:81: note:   int8vs32(param x: int(8))
 dispatchenums.chpl:85: note:   int8vs32(x: int(32))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:89: note:   int8vs32(param x: int(32))
 dispatchenums.chpl:18: error: unresolved call 'int8vs32(numeral)'
 dispatchenums.chpl:77: note: this candidate did not match: int8vs32(x: int(8))
 dispatchenums.chpl:18: note: because actual argument #1 with type 'numeral'
@@ -28,7 +28,7 @@ dispatchenums.chpl:77: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:18: note: other candidates are:
 dispatchenums.chpl:85: note:   int8vs32(x: int(32))
 dispatchenums.chpl:81: note:   int8vs32(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:89: note:   int8vs32(param x: int(32))
 dispatchenums.chpl:19: error: unresolved call 'int8vs32(numeral)'
 dispatchenums.chpl:77: note: this candidate did not match: int8vs32(x: int(8))
 dispatchenums.chpl:19: note: because actual argument #1 with type 'numeral'
@@ -36,7 +36,7 @@ dispatchenums.chpl:77: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:19: note: other candidates are:
 dispatchenums.chpl:85: note:   int8vs32(x: int(32))
 dispatchenums.chpl:81: note:   int8vs32(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:89: note:   int8vs32(param x: int(32))
 dispatchenums.chpl:20: error: unresolved call 'int8vs32(numeral)'
 dispatchenums.chpl:77: note: this candidate did not match: int8vs32(x: int(8))
 dispatchenums.chpl:20: note: because actual argument #1 with type 'numeral'
@@ -44,7 +44,7 @@ dispatchenums.chpl:77: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:20: note: other candidates are:
 dispatchenums.chpl:81: note:   int8vs32(param x: int(8))
 dispatchenums.chpl:85: note:   int8vs32(x: int(32))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:89: note:   int8vs32(param x: int(32))
 dispatchenums.chpl:21: error: unresolved call 'int8vs32(numeral)'
 dispatchenums.chpl:77: note: this candidate did not match: int8vs32(x: int(8))
 dispatchenums.chpl:21: note: because actual argument #1 with type 'numeral'
@@ -52,7 +52,7 @@ dispatchenums.chpl:77: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:21: note: other candidates are:
 dispatchenums.chpl:81: note:   int8vs32(param x: int(8))
 dispatchenums.chpl:85: note:   int8vs32(x: int(32))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:89: note:   int8vs32(param x: int(32))
 dispatchenums.chpl:25: error: unresolved call 'int8paramVsNot(numeral)'
 dispatchenums.chpl:96: note: this candidate did not match: int8paramVsNot(x: int(8))
 dispatchenums.chpl:25: note: because actual argument #1 with type 'numeral'
@@ -132,7 +132,7 @@ dispatchenums.chpl:118: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:43: note: other candidates are:
 dispatchenums.chpl:122: note:   int8vs16(param x: int(8))
 dispatchenums.chpl:126: note:   int8vs16(x: int(16))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:130: note:   int8vs16(param x: int(16))
 dispatchenums.chpl:44: error: unresolved call 'int8vs16(numeral)'
 dispatchenums.chpl:118: note: this candidate did not match: int8vs16(x: int(8))
 dispatchenums.chpl:44: note: because actual argument #1 with type 'numeral'
@@ -140,7 +140,7 @@ dispatchenums.chpl:118: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:44: note: other candidates are:
 dispatchenums.chpl:122: note:   int8vs16(param x: int(8))
 dispatchenums.chpl:126: note:   int8vs16(x: int(16))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:130: note:   int8vs16(param x: int(16))
 dispatchenums.chpl:45: error: unresolved call 'int8vs16(numeral)'
 dispatchenums.chpl:118: note: this candidate did not match: int8vs16(x: int(8))
 dispatchenums.chpl:45: note: because actual argument #1 with type 'numeral'
@@ -148,7 +148,7 @@ dispatchenums.chpl:118: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:45: note: other candidates are:
 dispatchenums.chpl:126: note:   int8vs16(x: int(16))
 dispatchenums.chpl:122: note:   int8vs16(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:130: note:   int8vs16(param x: int(16))
 dispatchenums.chpl:46: error: unresolved call 'int8vs16(numeral)'
 dispatchenums.chpl:118: note: this candidate did not match: int8vs16(x: int(8))
 dispatchenums.chpl:46: note: because actual argument #1 with type 'numeral'
@@ -156,7 +156,7 @@ dispatchenums.chpl:118: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:46: note: other candidates are:
 dispatchenums.chpl:126: note:   int8vs16(x: int(16))
 dispatchenums.chpl:122: note:   int8vs16(param x: int(8))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:130: note:   int8vs16(param x: int(16))
 dispatchenums.chpl:47: error: unresolved call 'int8vs16(numeral)'
 dispatchenums.chpl:118: note: this candidate did not match: int8vs16(x: int(8))
 dispatchenums.chpl:47: note: because actual argument #1 with type 'numeral'
@@ -164,7 +164,7 @@ dispatchenums.chpl:118: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:47: note: other candidates are:
 dispatchenums.chpl:122: note:   int8vs16(param x: int(8))
 dispatchenums.chpl:126: note:   int8vs16(x: int(16))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:130: note:   int8vs16(param x: int(16))
 dispatchenums.chpl:48: error: unresolved call 'int8vs16(numeral)'
 dispatchenums.chpl:118: note: this candidate did not match: int8vs16(x: int(8))
 dispatchenums.chpl:48: note: because actual argument #1 with type 'numeral'
@@ -172,7 +172,7 @@ dispatchenums.chpl:118: note: is passed to formal 'x: int(8)'
 dispatchenums.chpl:48: note: other candidates are:
 dispatchenums.chpl:122: note:   int8vs16(param x: int(8))
 dispatchenums.chpl:126: note:   int8vs16(x: int(16))
-note: and 1 other candidate, use --print-all-candidates to see it
+dispatchenums.chpl:130: note:   int8vs16(param x: int(16))
 dispatchenums.chpl:52: error: unresolved call 'int8vs16vsDefault(numeral)'
 dispatchenums.chpl:138: note: this candidate did not match: int8vs16vsDefault(x: int(8))
 dispatchenums.chpl:52: note: because actual argument #1 with type 'numeral'

--- a/test/visibility/shadow-overload.good
+++ b/test/visibility/shadow-overload.good
@@ -3,4 +3,5 @@ shadow-overload.chpl:14: error: unresolved call 'R.shadow(10)'
 shadow-overload.chpl:11: note: this candidate did not match: R.shadow()
 shadow-overload.chpl:14: note: because call includes 1 argument
 shadow-overload.chpl:11: note: but function can only accept 0 arguments
-note: there is also 1 other candidate, use --print-all-candidates to see it
+shadow-overload.chpl:14: note: other candidates are:
+shadow-overload.chpl:5: note:   shadow(x)


### PR DESCRIPTION
Resolves #18565

This changes the order and sometimes the number of resolution candidates
that the compiler prints upon an "unresolved call" error message as
"note: this candidate did not match" and "note: other candidates are".

* Print all the candidates if there are 4 or fewer.
  There should no longer be "note: there is also 1 other candidate".
  Instead the compiler just shows that 1 other candidate.

* Print the candidates with the same method-ness as the unresolved call
  BEFORE the other-methodness candidates.
  Ex. if the call is a method call, print the candidates that are methods
  before those that are standalone functions.
  Note that this is not perfect in the current compiler, which treats
  as "method calls" some calls written without an explicit receiver.

* Towards [#18565](https://github.com/chapel-lang/chapel/issues/18565), print the candidate methods with the same receiver type
  as the call (if it is a method call) BEFORE those with different
  receiver types.

The last bullet is implemented by adding another "reason" for rejecting
a resolution candidate: `RESOLUTION_CANDIDATE_DIFFERENT_RECEIVER_TYPES`
which is ordered after most other reasons.

Potential future improvement: order the candidates whose receiver type
is a supertype of the receiver type of the call BEFORE the other
different-receiver-type candidates.

As before, the compiler explains the first non-matching candidate in detail
with "note: this candidate did not match: ..." and "note: because ...".
It can be a different candidate now than it would have been before this PR.

While there:
* Add .bad: `test/classes/nilability/cycle-generic.bad`
* Add .future for [#19697](https://github.com/chapel-lang/chapel/issues/19697): `test/errhandling/parallel/taskerrors-write.chpl`
