### PR TITLE
Add/fix performance annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1461,8 +1461,10 @@ memleaksfull:
     - Add module ConcurrentMap (#16704)
   03/18/22:
     - Avoid double-deinit upon throws from a forall loop (#19479)
-  04/03/22:
+  04/02/22:
     - DistributedMap and Aggregator tests added that had leaks (#19554)
+  04/13/22:
+    - Skip memleaks testing of DistributedMap (#19629)
 # End memleaksfull
 
 meteor:


### PR DESCRIPTION
Fixes an annotation's date and adds a new one.

Both adjustments are about the known-leaky tests that went in and out.