### PR TITLE
dyno: add input type to reduce uAST node

### DIFF
--- a/compiler/dyno/include/chpl/uast/Reduce.h
+++ b/compiler/dyno/include/chpl/uast/Reduce.h
@@ -33,12 +33,22 @@ namespace uast {
 */
 class Reduce final : public Call {
  private:
+
   Reduce(AstList children, UniqueString op)
     : Call(asttags::Reduce, std::move(children),
            /*hasCalledExpression*/ false),
       op_(op) {
     assert(numChildren() == 1);
     assert(!op_.isEmpty());
+  }
+
+  Reduce(AstList children, UniqueString op, UniqueString inputType)
+      : Call(asttags::Reduce, std::move(children),
+      /*hasCalledExpression*/ false),
+        op_(op) {
+    assert(numChildren() == 1);
+    assert(!op_.isEmpty());
+    inputType_ = inputType;
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -50,9 +60,13 @@ class Reduce final : public Call {
   void markUniqueStringsInner(Context* context) const override {
     callMarkUniqueStringsInner(context);
     op_.mark(context);
+    if (!inputType_.isEmpty()) {
+      inputType_.mark(context);
+    }
   }
 
   UniqueString op_;
+  UniqueString inputType_;
 
  public:
   ~Reduce() override = default;
@@ -65,12 +79,26 @@ class Reduce final : public Call {
                              UniqueString op,
                              owned<AstNode> expr);
 
+  static owned<Reduce> build(Builder* builder,
+                             Location loc,
+                             UniqueString op,
+                             UniqueString inputType,
+                             owned<AstNode> expr);
+
   /**
     Returns the reduction operator. It may be either a regular operator
     (e.g. '+', '-') or the name of a class.
   */
   UniqueString op() const {
     return op_;
+  }
+
+  /**
+   Returns the input type, which may be empty.
+   An input type is specified as int in `(minmax(int) reduce sum)`
+*/
+  UniqueString inputType() const {
+    return inputType_;
   }
 
 };

--- a/compiler/dyno/lib/parsing/ParserContextImpl.h
+++ b/compiler/dyno/lib/parsing/ParserContextImpl.h
@@ -1967,24 +1967,18 @@ AstNode* ParserContext::buildCustomReduce(YYLTYPE location,
     if (!lhs->toFnCall()->calledExpression()->isIdentifier()) {
       const char* msg = "Expected identifier for reduction name";
       return raiseError(locIdent, msg);
-    } else if (lhs->toFnCall()->numChildren() != 2 ) {
-      const char* msg = "for a reduce intent, the 'reduce' keyword must be preceded by the reduction operator or the name of the reduction class with the single optional argument indicating the type of the reduction input";
-      return raiseError(locIdent, msg);
     }
-    UniqueString identifier = lhs->toFnCall()->calledExpression()->toIdentifier()->name();
-    UniqueString inputType = lhs->toFnCall()->actual(0)->toIdentifier()->name();
+    AstNode* inputType = (AstNode*) lhs->toFnCall();
     auto node = Reduce::build(builder, convertLocation(location),
-                              identifier,
-                                  inputType,
+                              toOwned(inputType),
                               toOwned(rhs));
     return node.release();
   } else if (!lhs->isIdentifier()) {
     const char* msg = "Expected identifier for reduction name";
     return raiseError(locIdent, msg);
   } else {
-    auto identName = lhs->toIdentifier()->name();
     auto node = Reduce::build(builder, convertLocation(location),
-                              identName,
+                              toOwned(lhs->toIdentifier()),
                               toOwned(rhs));
     return node.release();
   }

--- a/compiler/dyno/lib/parsing/bison-chpl-lib.cpp
+++ b/compiler/dyno/lib/parsing/bison-chpl-lib.cpp
@@ -930,8 +930,8 @@ static const yytype_int16 yyrline[] =
     3590,  3594,  3598,  3607,  3612,  3621,  3622,  3623,  3624,  3625,
     3626,  3627,  3628,  3629,  3630,  3631,  3632,  3633,  3634,  3635,
     3636,  3637,  3638,  3639,  3640,  3641,  3642,  3643,  3647,  3648,
-    3649,  3650,  3651,  3652,  3655,  3659,  3663,  3667,  3671,  3678,
-    3682,  3686,  3690,  3698,  3699,  3700,  3701,  3702,  3703,  3704
+    3649,  3650,  3651,  3652,  3655,  3659,  3663,  3667,  3672,  3680,
+    3684,  3688,  3692,  3700,  3701,  3702,  3703,  3704,  3705,  3706
 };
 #endif
 
@@ -10592,8 +10592,8 @@ yyreduce:
 
   case 591: /* intent_expr: reduce_scan_op_expr TREDUCE ident_expr  */
 #line 3268 "chpl.ypp"
-  {
-    (yyval.expr) = Reduce::build(BUILDER, LOC((yyloc)), (yyvsp[-2].uniqueStr), toOwned((yyvsp[0].expr))).release();
+  { auto ident = Identifier::build(BUILDER, LOC((yylsp[-2])), (yyvsp[-2].uniqueStr));
+    (yyval.expr) = Reduce::build(BUILDER, LOC((yyloc)), std::move(ident), toOwned((yyvsp[0].expr))).release();
   }
 #line 10599 "bison-chpl-lib.cpp"
     break;
@@ -11315,53 +11315,55 @@ yyreduce:
   case 707: /* reduce_expr: reduce_scan_op_expr TREDUCE expr  */
 #line 3668 "chpl.ypp"
   {
-    (yyval.expr) = Reduce::build(BUILDER, LOC((yyloc)), (yyvsp[-2].uniqueStr), toOwned((yyvsp[0].expr))).release();
+    auto ident = Identifier::build(BUILDER, LOC((yylsp[-2])), (yyvsp[-2].uniqueStr));
+    (yyval.expr) = Reduce::build(BUILDER, LOC((yyloc)), std::move(ident), toOwned((yyvsp[0].expr))).release();
   }
-#line 11321 "bison-chpl-lib.cpp"
+#line 11322 "bison-chpl-lib.cpp"
     break;
 
   case 708: /* reduce_expr: reduce_scan_op_expr TREDUCE zippered_iterator  */
-#line 3672 "chpl.ypp"
+#line 3673 "chpl.ypp"
   {
-    (yyval.expr) = Reduce::build(BUILDER, LOC((yyloc)), (yyvsp[-2].uniqueStr), toOwned((yyvsp[0].expr))).release();
+    auto ident = Identifier::build(BUILDER, LOC((yylsp[-2])), (yyvsp[-2].uniqueStr));
+    (yyval.expr) = Reduce::build(BUILDER, LOC((yyloc)), std::move(ident), toOwned((yyvsp[0].expr))).release();
   }
-#line 11329 "bison-chpl-lib.cpp"
+#line 11331 "bison-chpl-lib.cpp"
     break;
 
   case 709: /* scan_expr: expr TSCAN expr  */
-#line 3679 "chpl.ypp"
+#line 3681 "chpl.ypp"
   {
     (yyval.expr) = context->buildCustomScan((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
   }
-#line 11337 "bison-chpl-lib.cpp"
+#line 11339 "bison-chpl-lib.cpp"
     break;
 
   case 710: /* scan_expr: expr TSCAN zippered_iterator  */
-#line 3683 "chpl.ypp"
+#line 3685 "chpl.ypp"
   {
     (yyval.expr) = context->buildCustomScan((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
   }
-#line 11345 "bison-chpl-lib.cpp"
+#line 11347 "bison-chpl-lib.cpp"
     break;
 
   case 711: /* scan_expr: reduce_scan_op_expr TSCAN expr  */
-#line 3687 "chpl.ypp"
+#line 3689 "chpl.ypp"
   {
     (yyval.expr) = Scan::build(BUILDER, LOC((yyloc)), (yyvsp[-2].uniqueStr), toOwned((yyvsp[0].expr))).release();
   }
-#line 11353 "bison-chpl-lib.cpp"
+#line 11355 "bison-chpl-lib.cpp"
     break;
 
   case 712: /* scan_expr: reduce_scan_op_expr TSCAN zippered_iterator  */
-#line 3691 "chpl.ypp"
+#line 3693 "chpl.ypp"
   {
     (yyval.expr) = Scan::build(BUILDER, LOC((yyloc)), (yyvsp[-2].uniqueStr), toOwned((yyvsp[0].expr))).release();
   }
-#line 11361 "bison-chpl-lib.cpp"
+#line 11363 "bison-chpl-lib.cpp"
     break;
 
 
-#line 11365 "bison-chpl-lib.cpp"
+#line 11367 "bison-chpl-lib.cpp"
 
       default: break;
     }

--- a/compiler/dyno/lib/parsing/chpl.ypp
+++ b/compiler/dyno/lib/parsing/chpl.ypp
@@ -3265,8 +3265,8 @@ intent_expr:
     }
   }
 | reduce_scan_op_expr TREDUCE ident_expr
-  {
-    $$ = Reduce::build(BUILDER, LOC(@$), $1, toOwned($3)).release();
+  { auto ident = Identifier::build(BUILDER, LOC(@1), $1);
+    $$ = Reduce::build(BUILDER, LOC(@$), std::move(ident), toOwned($3)).release();
   }
 | expr                TREDUCE ident_expr
   {
@@ -3666,11 +3666,13 @@ reduce_expr:
   }
 | reduce_scan_op_expr TREDUCE expr
   {
-    $$ = Reduce::build(BUILDER, LOC(@$), $1, toOwned($3)).release();
+    auto ident = Identifier::build(BUILDER, LOC(@1), $1);
+    $$ = Reduce::build(BUILDER, LOC(@$), std::move(ident), toOwned($3)).release();
   }
 | reduce_scan_op_expr TREDUCE zippered_iterator
   {
-    $$ = Reduce::build(BUILDER, LOC(@$), $1, toOwned($3)).release();
+    auto ident = Identifier::build(BUILDER, LOC(@1), $1);
+    $$ = Reduce::build(BUILDER, LOC(@$), std::move(ident), toOwned($3)).release();
   }
 ;
 

--- a/compiler/dyno/lib/parsing/flex-chpl-lib.cpp
+++ b/compiler/dyno/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 1 "flex-chpl-lib.cpp"
+#line 2 "flex-chpl-lib.cpp"
 
-#line 3 "flex-chpl-lib.cpp"
+#line 4 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1084,10 +1084,10 @@ static void processInvalidToken(yyscan_t scanner);
 static bool yy_has_state(yyscan_t scanner);
 }
 
-#line 1087 "flex-chpl-lib.cpp"
+#line 1088 "flex-chpl-lib.cpp"
 /* hex float literals, have decimal exponents indicating the power of 2 */
 
-#line 1090 "flex-chpl-lib.cpp"
+#line 1091 "flex-chpl-lib.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -1377,7 +1377,7 @@ YY_DECL
 #line 113 "chpl.lex"
 
 
-#line 1380 "flex-chpl-lib.cpp"
+#line 1381 "flex-chpl-lib.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2382,7 +2382,7 @@ YY_RULE_SETUP
 #line 329 "chpl.lex"
 ECHO;
 	YY_BREAK
-#line 2385 "flex-chpl-lib.cpp"
+#line 2386 "flex-chpl-lib.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();

--- a/compiler/dyno/lib/parsing/flex-chpl-lib.h
+++ b/compiler/dyno/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 5 "flex-chpl-lib.h"
+#line 6 "flex-chpl-lib.h"
 
-#line 7 "flex-chpl-lib.h"
+#line 8 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -730,6 +730,6 @@ extern int yylex \
 #line 329 "chpl.lex"
 
 
-#line 733 "flex-chpl-lib.h"
+#line 734 "flex-chpl-lib.h"
 #undef yychpl_IN_HEADER
 #endif /* yychpl_HEADER_H */

--- a/compiler/dyno/lib/uast/Reduce.cpp
+++ b/compiler/dyno/lib/uast/Reduce.cpp
@@ -41,6 +41,22 @@ owned<Reduce> Reduce::build(Builder* builder,
   return toOwned(ret);
 }
 
+owned<Reduce> Reduce::build(Builder* builder,
+                            Location loc,
+                            UniqueString op,
+                            UniqueString inputType,
+                            owned<AstNode> expr) {
+  assert(expr.get() != nullptr);
+  assert(!op.isEmpty());
+
+  AstList lst;
+
+  lst.push_back(std::move(expr));
+
+  Reduce* ret = new Reduce(std::move(lst), op, inputType);
+  builder->noteLocation(ret, loc);
+  return toOwned(ret);
+}
 
 } // namespace uast
 } // namespace chpl

--- a/compiler/dyno/lib/uast/Reduce.cpp
+++ b/compiler/dyno/lib/uast/Reduce.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "chpl/uast/Reduce.h"
-
 #include "chpl/uast/Builder.h"
 
 namespace chpl {
@@ -27,36 +26,20 @@ namespace uast {
 
 owned<Reduce> Reduce::build(Builder* builder,
                             Location loc,
-                            UniqueString op,
+                            owned<AstNode> lhs,
                             owned<AstNode> expr) {
   assert(expr.get() != nullptr);
-  assert(!op.isEmpty());
+  assert(lhs->isIdentifier() || lhs->isFnCall());
 
   AstList lst;
-
   lst.push_back(std::move(expr));
+  lst.push_back(std::move(lhs));
 
-  Reduce* ret = new Reduce(std::move(lst), op);
+  Reduce* ret = new Reduce(std::move(lst));
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }
 
-owned<Reduce> Reduce::build(Builder* builder,
-                            Location loc,
-                            UniqueString op,
-                            UniqueString inputType,
-                            owned<AstNode> expr) {
-  assert(expr.get() != nullptr);
-  assert(!op.isEmpty());
-
-  AstList lst;
-
-  lst.push_back(std::move(expr));
-
-  Reduce* ret = new Reduce(std::move(lst), op, inputType);
-  builder->noteLocation(ret, loc);
-  return toOwned(ret);
-}
 
 } // namespace uast
 } // namespace chpl

--- a/compiler/dyno/lib/uast/chpl-syntax-printer.cpp
+++ b/compiler/dyno/lib/uast/chpl-syntax-printer.cpp
@@ -803,9 +803,14 @@ struct ChplSyntaxVisitor {
   }
 
   void visit(const Reduce* node) {
-    ss_ << node->op() << " ";
+    if (node->opExpr()) {
+      printChapelSyntax(ss_, node->opExpr());
+    } else {
+      ss_ << node->op();
+    }
+    ss_ << " ";
     ss_ << "reduce ";
-    interpose(node->actuals(), ", ");
+    printChapelSyntax(ss_, node->actual(0));
   }
 
   void visit(const Require* node) {

--- a/compiler/dyno/test/uast/testStringify.cpp
+++ b/compiler/dyno/test/uast/testStringify.cpp
@@ -242,6 +242,10 @@ static void test1(Parser* parser) {
                forall myIterator() with (+ reduce x) {
                  x = 1;
                }
+               forall elm in A with (PlusReduceOp(int) reduce sum) {
+                 sum reduce= elm;   // bools are implicitly coerced to 'int' input type
+                 writeln(sum);      // accumulation state: int
+               }
                __primitive("=", x, y);
                let x = 0 in writeln(x);
                var x = if foo then bar else baz;


### PR DESCRIPTION
This PR adds the ability for uAST `Reduce` nodes to store either an
input type or a simple identifier. 

Previously, the uAST node for `reduce` did not allow for an input type
`minmax(int) reduce x` for example. This change removes the `op_`
field that stored a `UniqueString`. Instead, we store a child node
that is either an `Identifier` or a `FnCall` at index 1 in the list
of children. 

The converter for uAST to AST and the Chapel syntax printer have been
updated to account for the changes to `Reduce` node.

TESTING:

- [x] paratest
- [x] parstest with `--dyno` (115 vs. 119 failures on main)

reviewed by @dlongnecke-cray - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>