### PR TITLE
Stop using /data/sea filesystem

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -134,7 +134,7 @@ export CHPL_LLVM=none
 
 
 # Set some vars that nightly cares about.
-export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/data/sea/chapel/Nightly}
+export CHPL_NIGHTLY_LOGDIR=${CHPL_NIGHTLY_LOGDIR:-/cray/css/users/chapelu/Nightly}
 export CHPL_NIGHTLY_CRON_LOGDIR="$CHPL_NIGHTLY_LOGDIR"
 
 # Ensure compatible CPU targeting module is loaded. Unload any existing one

--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -101,11 +101,11 @@ export CHPL_TARGET_CPU=none
 
 explicit_prefix=${CHPL_NIGHTLY_LOG_PREFIX}
 default_prefix=${TMPDIR:-/tmp}/chapel_logs
-sea_prefix=/data/sea/chapel
+css_prefix=/cray/css/users/chapelu
 if [ -n "$explicit_prefix" ]; then
     LOGDIR_PREFIX=$explicit_prefix
-elif [ -d $sea_prefix ] ; then
-    LOGDIR_PREFIX=$sea_prefix
+elif [ -d $css_prefix ] ; then
+    LOGDIR_PREFIX=$css_prefix
 else
     LOGDIR_PREFIX=$default_prefix
     if [ ! -d $LOGDIR_PREFIX ] ; then

--- a/util/cron/historify-logs
+++ b/util/cron/historify-logs
@@ -13,25 +13,14 @@ if [ -n "$*" ]; then
   exit 1
 fi
 
-loghome=/data/sea/chapel
-loghistdir=/data/sea/chapel/NightlyHistory
+loghome=/cray/css/users/chapelu
+loghistdir=/cray/css/users/chapelu/NightlyHistory
 logsources="\
-Nightly \
-"
-
-# logs for "Cray hardware" configurations
-loghomeCrayHW=/cray/css/users/chapelu
-logsourcesCrayHW="\
 Nightly \
 NightlyWbOnCray \
 NightlyMemLeaks \
-NightlyPerformance/chap01 \
-NightlyPerformance/chap04 \
-NightlyPerformance/chap08 \
-NightlyPerformance/chap12 \
 NightlyPerformance/chapcs \
 NightlyPerformance/chapcs.comm-counts \
-NightlyPerformance/shootout \
 "
 
 verbose=false
@@ -79,11 +68,6 @@ cd $loghome
 
 # day* eliminates debug-* and memory leaks summaries
 find $logsources -maxdepth 1 -name day\*.log | doall
-
-# we put these in the same directory as the above
-msg starting Cray HW logs
-cd $loghomeCrayHW
-find $logsourcesCrayHW -maxdepth 1 -name day\*.log | doall
 
 if [ -z "$numerrors" ]; then
   msg succeeded

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -307,7 +307,7 @@ if ($cronlogdir eq "") {
     if ($performance == 1) {
         $cronlogdir = "/cray/css/users/chapelu/NightlyPerformance/$perfConfigName";
     } else {
-        $cronlogdir = "/data/sea/chapel/Nightly";
+        $cronlogdir = "/cray/css/users/chapelu/Nightly";
     }
 }
 


### PR DESCRIPTION
The `/data/sea` filesystem is going away, replace usage with `/cray/css`

Part of Cray/chapel-private#2540