### PR TITLE
Update doc to use term "type name" when casting type to string

### DIFF
--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -695,7 +695,7 @@ The normal comparison operators are also available to compare types:
    :proc:`<= <Types.<=>`)
 
 It is possible to cast a type to a ``param`` string. This allows a type
-to be printed out.
+name to be printed out.
 
   *Example (type-to-string.chpl)*.
 

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -19,8 +19,10 @@
  */
 
 /*
-Functions related to predefined types.
+This module contains functions that relate to predefined types.
 
+Further information about types and the operations that may be applied to them
+is available in :ref:`Chapter-Types`.
 */
 pragma "module included by default"
 module Types {


### PR DESCRIPTION
A while back I was trying to figure out how to do this (print out a type name) and I had a hard time finding it by CTRL+Fing the doc. 

I go into a bunch of detail about it here: https://github.com/chapel-lang/chapel/issues/18935

In the issue I suggest making a couple small doc changes to make it easier to find this information.

This is a pretty small PR. But specifically what I do is:

* Add the word “name” to the sentence describing casting from a type to a string so if I ctrl+f the term "name" or "type name" I’m likely to find it.
* Add a link from the "Standard Modules > Types" to the "Language Specification > Types” section, so if I end up looking at the doc for the module instead and don't find the information I want I might notice there's a related page.
  * There's another (more general) issue about cross-referencing doc pages in the spec here: #18934. I'm leaving it as future work.