### PR TITLE
Followup fix to #19676

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -734,7 +734,8 @@ static void convertNilToObject()
       if (CallExpr* parent = toCallExpr(se->parentExpr))
       {
         // Assignment to void should already have been flagged as an error.
-        if (parent->isPrimitive(PRIM_MOVE) && parent->get(1) == se)
+        if ((parent->isPrimitive(PRIM_MOVE)  ||
+             parent->isPrimitive(PRIM_ASSIGN) ) && parent->get(1) == se)
           parent->remove();
         else if (parent->isPrimitive(PRIM_SET_MEMBER) && parent->get(2) == se)
           parent->remove();


### PR DESCRIPTION
An AST pattern was exposed by #19676 while compiling with `--baseline`
that caused compilation failure. This PR makes a straightforward fix.
