### PR TITLE
Eureka feature proposal

### DIFF
--- a/compiler/dyno/include/chpl/uast/PragmaList.h
+++ b/compiler/dyno/include/chpl/uast/PragmaList.h
@@ -175,6 +175,10 @@ PRAGMA(DEFAULT_INTENT_IS_REF_MAYBE_CONST, ypr,
        "The default intent for this type is ref if modified const "
        "ref otherwise")
 
+PRAGMA(DEFAULT_TFI_IN, ypr,
+       "default task intent in",
+       "force the const/default task intent to [const] in")
+
 PRAGMA(COPY_INIT, npr, "copy initializer", ncm)
 PRAGMA(DESTRUCTOR, npr,
        "destructor",

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -735,6 +735,9 @@ static void resolveShadowVarTypeIntent(Type*& type, ForallIntentTag& intent,
       IntentTag argInt = (intent == TFI_DEFAULT) ? INTENT_BLANK : INTENT_CONST;
       intent = forallIntentForArgIntent(concreteIntent(argInt, valType));
 
+      if (valType->symbol->hasFlag(FLAG_DEFAULT_TFI_IN))
+        intent = argInt == INTENT_BLANK ? TFI_IN : TFI_CONST_IN;
+
       break;
     }
 

--- a/test/library/draft/Eureka/Eureka.chpl
+++ b/test/library/draft/Eureka/Eureka.chpl
@@ -1,0 +1,92 @@
+/*
+This is a sketch implementation of support for eurekas.
+It is currently overly-simplistic for readability.
+
+Here is a typical use of this feature:
+
+    use Eureka;
+    var e: eureka;
+
+    forall ..... {
+      e.check(); // this could be inserted automatically by the compiler
+      doWork();
+      if checkForEureka() then
+        e.notify()
+    }
+
+Within the loop body 'e' carries a task-private flag.
+
+'e.notify()' sets this flag for all tasks created by the forall loop,
+then (or concurrently) throws a EurekaNotified error.
+
+'e.check()' checks if the current task's flag has been set.
+If so, it throws a EurekaChecked error.
+Otherwise, it is a cheap operation -- read and branch on an atomic bool.
+
+Using this feature in a task-parallel construct requires an explicit
+in intent, due to a shortcoming of the current implementation.
+For example, the above code snippet could be switched to a coforall loop
+by replacing `forall .....` with:
+
+    coforall ..... with (in e)
+*/
+
+private use List;
+
+/* thrown by notify() */
+class EurekaNotified : Error {
+}
+
+/* thrown by check() if appropriate */
+class EurekaChecked  : Error {
+}
+
+pragma "default task intent in"
+record eureka {
+  forwarding const e: owned EurekaImpl;
+  proc init()               { e = new EurekaImpl();        }
+  proc init=(other: eureka) { e = new EurekaImpl(other.e); }
+}
+
+pragma "no doc"
+/*private*/ class EurekaImpl {
+  var   notified: atomic bool;
+  const parent:   unmanaged EurekaImpl?;
+  var   children: list(unmanaged EurekaImpl);
+
+  proc init() {
+  }
+  proc init(parent: borrowed EurekaImpl) {
+    this.parent = parent: unmanaged;
+    complete();
+    // todo: do not append if this task has been _setNotified
+    parent.children.append(this: unmanaged);
+  }
+  proc deinit() {
+    // todo: ensure that _setNotified() will not be invoked on this instance,
+    // esp. through parent.children, once it is deinitialized
+  }
+
+  proc check() throws {
+    if notified.read() then
+      throw new EurekaChecked();
+  }
+  proc notify() throws {
+    _setNotified();
+    throw new EurekaNotified();
+  }
+  /*private*/ proc _setNotified() {
+    const success = notified.compareAndSwap(false, true);
+    if !success then
+      return; // has already been _setNotified; do not repeat the actions below
+
+    if const parentNN = parent then
+      parentNN._setNotified(); // todo: 'parent' not to _setNotified this child
+    for child in children do
+      child._setNotified(); // todo: 'child' not to _setNotified its parent
+  }
+}
+
+operator =(ref lhs: eureka, rhs: eureka) {
+  compilerError("assignment between eurekas is not allowed");
+}

--- a/test/library/draft/Eureka/test-eureka.chpl
+++ b/test/library/draft/Eureka/test-eureka.chpl
@@ -1,0 +1,40 @@
+// todo: set it up so that one of 'e.check()' throws reliably,
+//       to illustrate this aspect of the eureka feature
+
+
+use Eureka;
+
+config const n = 8;
+config const p = 3;
+
+proc testForall() throws {
+  var e: eureka;
+  forall idx in 1..n {
+    e.check();
+    if idx == p then
+      e.notify();
+  }
+}
+
+proc testCoforall() throws {
+  var e: eureka;
+  coforall idx in 1..n with (in e) {
+    e.check();
+    if idx == p then
+      e.notify();
+  }
+}
+
+proc main {
+  try { testForall(); }
+  catch errForall { verifyEureka("testForall", errForall); }
+
+  try { testCoforall(); }
+  catch errCoforall { verifyEureka("testCoforall", errCoforall); }
+}
+
+proc verifyEureka(msg, taskErr) {
+  for err in taskErr: borrowed TaskErrors do
+    if err: EurekaNotified? then
+      writeln(msg, ": got EurekaNotified");
+}

--- a/test/library/draft/Eureka/test-eureka.execopts
+++ b/test/library/draft/Eureka/test-eureka.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/library/draft/Eureka/test-eureka.good
+++ b/test/library/draft/Eureka/test-eureka.good
@@ -1,0 +1,11 @@
+
+
+./Eureka.chpl:48                 1        48       48       EurekaImpl                       prediffed  
+./Eureka.chpl:48                 16       8        128      array elements                   prediffed  
+./Eureka.chpl:48                 8        8        64       array elements                   prediffed  
+================================================= Memory Leaks ==================================================
+=================================================================================================================
+=================================================================================================================
+Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
+testCoforall: got EurekaNotified
+testForall: got EurekaNotified

--- a/test/library/draft/Eureka/test-eureka.prediff
+++ b/test/library/draft/Eureka/test-eureka.prediff
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# follow the lead of test/memory/ferguson/test1.chpl
+# add sorting, for deterministic output
+
+sed -E "s/0x[0-9a-f]*/prediffed/" $2 | sort >$2.predifftmp
+mv $2.predifftmp $2


### PR DESCRIPTION
This is a sketch implementation of support for eurekas, #12700.
See also design questions in https://github.com/chapel-lang/chapel/issues/12700#issuecomment-1106837084
and an alternative approach in #12815.

User code using this feature looks like this:
```chpl
use Eureka;
var e: eureka;

forall ..... {
  e.check(); // this could be inserted automatically by the compiler
  doWork();
  if checkForEureka() then
    e.notify()
}
```
Within the loop body `e` carries a task-private flag.

`e.notify()` sets this flag for all tasks created by the forall loop, then (or concurrently) throws a EurekaNotified error.

`e.check()` checks if the current task's flag has been set. If so, it throws a EurekaChecked error. Otherwise, it is a cheap operation -- read and branch on an atomic bool.

The implementation is intentionally simplistic for ease of understanding. Here are steps to productize it, starting with the most immediate concerns:

* Beef up the implementation to prevent race conditions.
  See todo comments in the code.

* Tune performance, esp. for multilocale programs.

* When using this feature for task-parallel constructs,
  do not require explicit in-intent on the eureka variable.
  For that, account for FLAG_DEFAULT_TFI_IN in task intents.

* Have `e.check()` be inserted automatically by the compiler.

* (optional) Make `eureka` customizable. Ex. allow argument(s) to `e.notify()`
  that are passed into the exceptions that get thrown.

* Allow the use of this feature via `break` instead of `e.notify()`
  and error handling. This would entail automatic insertion of
  `var e: eureka` and error handling; ex. chpl_forall_error() would drop
  EurekaNotified and EurekaChecked errors.

Note: the demo test leaks an instance of the EurekaImpl class.
The PR follows the lead of test/memory/ferguson/test1.chpl
to ensure that nightly testing passes.
I believe this leak is due to the same cause as the one from #19479:
`test/errhandling/parallel/forall-calls-throwing-fn2.chpl`
