### PR TITLE
Demonstrator for testing within a singularity container

### DIFF
--- a/util/devel/test/singularity/README-distro-timelines.txt
+++ b/util/devel/test/singularity/README-distro-timelines.txt
@@ -1,0 +1,1 @@
+../vagrant/README-distro-timelines.txt

--- a/util/devel/test/singularity/README.md
+++ b/util/devel/test/singularity/README.md
@@ -1,0 +1,12 @@
+Notes
+
+%post commands run as root
+%runscript commands run as regular user
+
+singularity build --fakeroot singularity.sif singularity.def
+
+singularity run singularity.sif
+
+singularity shell singularity.sif
+
+By default environment included in run commands

--- a/util/devel/test/singularity/current/ubuntu-xenial64/singularity.def
+++ b/util/devel/test/singularity/current/ubuntu-xenial64/singularity.def
@@ -1,0 +1,11 @@
+BootStrap: library
+From: ubuntu:16.04
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/apt-get-deps.sh
+
+%runscript
+    ../../provision-scripts/run.sh

--- a/util/devel/test/singularity/provision-scripts
+++ b/util/devel/test/singularity/provision-scripts
@@ -1,0 +1,1 @@
+../vagrant/provision-scripts/

--- a/util/devel/test/vagrant/provision-scripts/run.sh
+++ b/util/devel/test/vagrant/provision-scripts/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# script for singularity image 'run' command
+
+if [ -d chapel ]
+then
+  echo chapel directory already exists - updating
+  git checkout main
+  git pull
+else
+  echo cloning chapel
+  git clone https://github.com/chapel-lang/chapel
+fi
+
+cd chapel
+source util/quickstart/setchplenv.bash
+make -j4
+make check


### PR DESCRIPTION
We have lots of scripting for testing on many different platforms with vagrant and VMs in util/devel/test/vagrant. One thing we have been considering is using Docker or Singularity instead.

To that end I developed a demonstrator that ports the ubuntu-xenial64 config over to a singularity container (it leaves the vagrant version untouched). This consists of a `singularity.def` file as well as some commands to run and notes in README.md.

Some things I learned along the way:
 * Docker and Singularity both seem to want to run as root but at least with Singularity it seems to work OK to run with fakeroot. For our testing purposes I think we probably cannot assume that we can run as root.
 * Docker and Singularity can only really run linux binaries - so something like testing FreeBSD will still need to be done in a VM
 * I found singularity relatively pleasant to work with (although this is entirely subjective). I think its design aligns well with what we would want out if it in a testing scenario. But, I did not do the equivalent experiment with Docker (and we certainly could).