### PR TITLE
Adjust common-c-backend to not set CHPL_LLVM

### DIFF
--- a/util/cron/common-c-backend.bash
+++ b/util/cron/common-c-backend.bash
@@ -4,5 +4,10 @@
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-export CHPL_LLVM=none
+# Do not set CHPL_LLVM=none here for all c-backend testing.
+# Generally speaking, we would like for tests of the C backend
+# to build with LLVM so that we can test extern blocks with C
+# code generation.
+# Specific configs will set CHPL_LLVM=none (e.g. quickstart testing).
+
 export CHPL_TARGET_COMPILER=gnu


### PR DESCRIPTION
This PR removes `CHPL_LLVM=none` from `common-c-backend.bash`.

The reason to do that is to allow testing the C backend with a compiler built with extern block support.

By not setting `CHPL_LLVM` at all in `common-c-backend.bash`, we leave it to whatever script is calling it to set `CHPL_LLVM` as needed; or for the default to be used. In practice, I am expecting that a system LLVM will be detected in the configurations using `common-c-backend.bash` and that the quickstart configuration will continue to check `CHPL_LLVM=none`.

Resolves #5214.

Reviewed by @ronawho - thanks!