### PR TITLE
Note overflow behavior in spec, remove out of date stuff

### DIFF
--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -447,11 +447,12 @@ sequence. If the range is empty, no iterations are executed.
 Overflow of the index variable while iterating over an unbounded range
 leads to undefined behavior.
 
-In order for it to be possible to iterate over a range, it needs to be
-possible to add the stride to the range's last index without overflowng
-the index type. In other words, the last index plus the stride must be
-between the index type's minimum and maximum value (inclusive). If this
-property is not met, the program will have undefined behavior.
+In order for it to be possible to iterate over a range with an upper
+bound, it needs to be possible to add the stride to the range's last
+index without overflowng the index type. In other words, the last index
+plus the stride must be between the index type's minimum and maximum
+value (inclusive). If this property is not met, the program will have
+undefined behavior.
 
    *Implementation Notes*.
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -440,16 +440,24 @@ Iterating over Ranges
 ~~~~~~~~~~~~~~~~~~~~~
 
 A range can be used as an iterator expression in a loop. This is legal
-only if the range is iterable. In this case the loop iterates over the
-members of the range’s represented sequence, in the order defined by the
+only if the range is iterable. In this case, the loop iterates over the
+members of the range’s represented sequence in the order defined by the
 sequence. If the range is empty, no iterations are executed.
+
+Overflow of the index variable while iterating over an unbounded range
+leads to undefined behavior.
+
+In order for it to be possible to iterate over a range, it needs to be
+possible to add the stride to the range's last index without overflowng
+the index type. In other words, the last index plus the stride must be
+between the index type's minimum and maximum value (inclusive). If this
+property is not met, the program will have undefined behavior.
 
    *Implementation Notes*.
 
-   An attempt to iterate over a range causes an error if adding stride
-   to the range’s last index overflows its index type, i.e. if the sum
-   is greater than the index type’s maximum value, or smaller than its
-   minimum value.
+   When bounds checking is enabled, the case in the above paragraph is
+   checked at runtime and the program will halt if the range iteration is
+   invalid.
 
 .. _Iterating_over_Unbounded_Ranges_in_Zippered_Iterations:
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -447,8 +447,8 @@ sequence. If the range is empty, no iterations are executed.
 Overflow of the index variable while iterating over an unbounded range
 leads to undefined behavior.
 
-In order for it to be possible to iterate over a range with an upper
-bound, it needs to be possible to add the stride to the range's last
+In order for it to be possible to iterate over a range with a last
+index, it needs to be possible to add the stride to the range's last
 index without overflowng the index type. In other words, the last index
 plus the stride must be between the index type's minimum and maximum
 value (inclusive). If this property is not met, the program will have

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -178,11 +178,11 @@ Integer literals such as `3` have type ``int``. However, such literals
 can implicitly convert to other numeric types that can losslessly store
 the value. See :ref:`Implicit_Compile_Time_Constant_Conversions`.
 
-It is possible for overflow to occur with binary operators on signed and
-unsigned integers. The result of overflow for each of these is different.
+It is possible for overflow to occur with binary operators on integers.
 For signed integers, overflow leads to undefined behavior. For unsigned
-integers, overflow leads to the wrapping according to two's complement
+integers, overflow leads to wrapping according to two's complement
 arithmetic.
+
 
 .. _Real_Types:
 

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -156,8 +156,8 @@ Signed and Unsigned Integral Types
 
 The integral types can be parameterized by the number of bits used to
 represent them. Valid bit-sizes are 8, 16, 32, and 64. The default
-signed integral type, ``int``, and the default unsigned integral type,
-``uint`` correspond to ``int(64)`` and ``uint(64)`` respectively.
+signed integral type, ``int``, is a synonym for ``int(64)``; and the
+default unsigned integral type, ``uint``, is a synonym for ``uint(64)``.
 
 The integral types and their ranges are given in the following table:
 
@@ -174,11 +174,15 @@ int(64), int   -9223372036854775808 9223372036854775807
 uint(64), uint 0                    18446744073709551615
 ============== ==================== ====================
 
-The unary and binary operators that are pre-defined over the integral
-types operate with 32- and 64-bit precision. Using these operators on
-integral types represented with fewer bits results in an implicit
-conversion to the corresponding 32-bit types according to the rules
-defined in :ref:`Implicit_Conversions`.
+Integer literals such as `3` have type ``int``. However, such literals
+can implicitly convert to other numeric types that can losslessly store
+the value. See :ref:`Implicit_Compile_Time_Constant_Conversions`.
+
+It is possible for overflow to occur with binary operators on signed and
+unsigned integers. The result of overflow for each of these is different.
+For signed integers, overflow leads to undefined behavior. For unsigned
+integers, overflow leads to the wrapping according to two's complement
+arithmetic.
 
 .. _Real_Types:
 


### PR DESCRIPTION
This PR updates the discussion of integral types to:
 * make the definition of `int` and `uint` easier for me to follow
 * remove section about myInt8 + myInt8 ending up as an `int(32)` which is no longer accurate
 * added a note about literals and a link
 * added a paragraph about signed and unsigned overflow

For #6160

Reviewed by @vasslitvinov - thanks!
