### PR TITLE
Fix typo in AddressSanitizer docs

### DIFF
--- a/doc/rst/developer/bestPractices/Sanitizers.rst
+++ b/doc/rst/developer/bestPractices/Sanitizers.rst
@@ -24,7 +24,6 @@ To use AddressSanitizer with Chapel (compiler and executables):
      export CHPL_LLVM=none
      export CHPL_SANITIZE=address
      export ASAN_OPTIONS="use_sigaltstack=0,detect_leaks=0"
-     export ASAN_OPTIONS=detect_leaks=0
 
      cd $CHPL_HOME
      make

--- a/make/compiler/Makefile.sanitizers
+++ b/make/compiler/Makefile.sanitizers
@@ -31,8 +31,10 @@ ifneq ($(CHPL_MAKE_SANITIZE), none)
   ifneq ($(CHPL_MAKE_TARGET_MEM), cstdlib)
     $(error CHPL_MEM=cstdlib is required for sanitizers)
   endif
-  ifneq ($(CHPL_MAKE_HOST_MEM), cstdlib)
-    $(error CHPL_HOST_MEM=cstdlib is required for sanitizers)
+  ifeq ($(strip $(CHPL_MAKE_HOST_TARGET)),--host)
+    ifneq ($(CHPL_MAKE_HOST_MEM), cstdlib)
+      $(error CHPL_HOST_MEM=cstdlib is required for sanitizers)
+    endif
   endif
 
   # enable sanitizers


### PR DESCRIPTION
Remove old `ASAN_OPTIONS` setting (mistake from #19545)

While here, loosen an error about needing `CHPL_HOST_MEM=cstdlib` for
asan testing. This is needed for `CHPL_SANITIZE`, but not when only
setting `CHPL_SANITIZE_EXE=address`