### PR TITLE
Try renaming err_t to qio_err_t to avoid conflicts with AMD math library

### DIFF
--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -416,7 +416,7 @@ record tcpListener {
 proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws {
   var client_addr:sys_sockaddr_t = new sys_sockaddr_t();
   var fdOut:fd_t;
-  var err_out:err_t = 0;
+  var err_out:qio_err_t = 0;
   // try accept
   err_out = sys_accept(socketFd, client_addr, fdOut);
   // if error is not about blocking, throw error
@@ -775,7 +775,7 @@ proc udpSocket.close throws {
 }
 
 pragma "no doc"
-private extern proc sys_recvfrom(sockfd:fd_t, buff:c_void_ptr, len:c_size_t, flags:c_int, ref src_addr_out:sys_sockaddr_t, ref num_recvd_out:c_ssize_t):err_t;
+private extern proc sys_recvfrom(sockfd:fd_t, buff:c_void_ptr, len:c_size_t, flags:c_int, ref src_addr_out:sys_sockaddr_t, ref num_recvd_out:c_ssize_t):qio_err_t;
 
 /*
   Reads upto `bufferLen` bytes from the socket, and
@@ -799,7 +799,7 @@ private extern proc sys_recvfrom(sockfd:fd_t, buff:c_void_ptr, len:c_size_t, fla
 */
 proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
                         flags:c_int = 0):(bytes, ipAddr) throws {
-  var err_out:err_t = 0;
+  var err_out:qio_err_t = 0;
   var buffer = c_calloc(c_uchar, bufferLen);
   var length:c_ssize_t;
   var addressStorage = new sys_sockaddr_t();
@@ -888,7 +888,7 @@ proc udpSocket.recv(bufferLen: int, timeout: real) throws {
 }
 
 pragma "no doc"
-private extern proc sys_sendto(sockfd:fd_t, buff:c_void_ptr, len:c_long, flags:c_int, const ref address:sys_sockaddr_t,  ref num_sent_out:c_ssize_t):err_t;
+private extern proc sys_sendto(sockfd:fd_t, buff:c_void_ptr, len:c_long, flags:c_int, const ref address:sys_sockaddr_t,  ref num_sent_out:c_ssize_t):qio_err_t;
 
 /*
   Send `data` over socket to the provided address and
@@ -913,7 +913,7 @@ private extern proc sys_sendto(sockfd:fd_t, buff:c_void_ptr, len:c_long, flags:c
 */
 proc udpSocket.send(data: bytes, in address: ipAddr,
                     in timeout = new timeval(-1,0)):c_ssize_t throws {
-  var err_out:err_t = 0;
+  var err_out:qio_err_t = 0;
   var length:c_ssize_t;
   err_out = sys_sendto(this.socketFd, data.c_str():c_void_ptr, data.size:c_long, 0, address._addressStorage, length);
   if err_out == 0 {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4598,7 +4598,7 @@ proc readln(type t ...?numTypes) throws {
    :throws SystemError: Thrown if the file is not successfully deleted.
  */
 proc unlink(path:string) throws {
-  extern proc sys_unlink(path:c_string):err_t;
+  extern proc sys_unlink(path:c_string):qio_err_t;
   var err = sys_unlink(path.localize().c_str());
   if err then try ioerror(err:syserr, "in unlink", path);
 }

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -27,7 +27,7 @@
 
    Each of the functions in this file provides the same functionality
    as the corresponding function without the ``sys_`` prefix, except that
-   the ``sys_`` versions all return an error code (of type :type:`~SysBasic.err_t`)
+   the ``sys_`` versions all return an error code (of type :type:`~SysBasic.qio_err_t`)
    and return any other values (such as how much was read) through an out
    argument.
 
@@ -441,9 +441,9 @@ module Sys {
   extern proc sys_set_sys_sockaddr_in6_t(ref addr: sys_sockaddr_t, host:sys_in6_addr_t, port:c_uint);
   extern proc sys_host_sys_sockaddr_t(const ref addr: sys_sockaddr_t, host: c_ptr(c_char), hostlen: socklen_t, ref length: c_int) : c_int;
   extern proc sys_port_sys_sockaddr_t(const ref addr: sys_sockaddr_t, ref port: c_uint) : c_int;
-  extern proc sys_strerror(error:err_t, ref string_out:c_string):err_t;
+  extern proc sys_strerror(error:qio_err_t, ref string_out:c_string):qio_err_t;
 
-  extern proc sys_readlink(path:c_string, ref string_out:c_string):err_t;
+  extern proc sys_readlink(path:c_string, ref string_out:c_string):qio_err_t;
 
   /*Check whether or not the environment variable ``name`` is defined.
     If ``name`` is defined then return 1 and update ``string_out``
@@ -462,27 +462,27 @@ module Sys {
   extern proc sys_getenv(name:c_string, ref string_out:c_string):c_int;
   /* The type corresponding to C's mode_t */
   extern type mode_t = uint(32);
-  extern proc sys_open(pathname:c_string, flags:c_int, mode:mode_t, ref fd_out:fd_t):err_t;
-  extern proc sys_close(fd:fd_t):err_t;
+  extern proc sys_open(pathname:c_string, flags:c_int, mode:mode_t, ref fd_out:fd_t):qio_err_t;
+  extern proc sys_close(fd:fd_t):qio_err_t;
 
   /* The type corresponding to C's off_t */
   extern type off_t = int(64);
 
-  extern proc sys_mmap(addr:c_void_ptr, length:c_size_t, prot:c_int, flags:c_int, fd:fd_t, offset:off_t, ref ret_out:c_void_ptr):err_t;
-  extern proc sys_munmap(addr:c_void_ptr, length:c_size_t):err_t;
+  extern proc sys_mmap(addr:c_void_ptr, length:c_size_t, prot:c_int, flags:c_int, fd:fd_t, offset:off_t, ref ret_out:c_void_ptr):qio_err_t;
+  extern proc sys_munmap(addr:c_void_ptr, length:c_size_t):qio_err_t;
 
   // readv, writev, preadv, pwritev -- can't (yet) pass array.
 
-  extern proc sys_fcntl(fd:fd_t, cmd:c_int, ref ret_out:c_int):err_t;
-  extern proc sys_fcntl_long(fd:fd_t, cmd:c_int, arg:c_long, ref ret_out:c_int):err_t;
-  extern proc sys_fcntl_ptr(fd:fd_t, cmd:c_int, arg:c_void_ptr, ref ret_out:c_int):err_t;
-  extern proc sys_dup(oldfd:fd_t, ref fd_out:fd_t):err_t;
-  extern proc sys_dup2(oldfd:fd_t, newfd:fd_t, ref fd_out:fd_t):err_t;
-  extern proc sys_pipe(ref read_fd_out:fd_t, ref write_fd_out:fd_t):err_t;
-  extern proc sys_accept(sockfd:fd_t, ref add_out:sys_sockaddr_t, ref fd_out:fd_t):err_t;
-  extern proc sys_bind(sockfd:fd_t, const ref addr:sys_sockaddr_t):err_t;
-  extern proc sys_connect(sockfd:fd_t, const ref addr:sys_sockaddr_t):err_t;
-  extern proc getaddrinfo(node:c_string, service:c_string, ref hints:sys_addrinfo_t, ref res_out:sys_addrinfo_ptr_t):err_t;
+  extern proc sys_fcntl(fd:fd_t, cmd:c_int, ref ret_out:c_int):qio_err_t;
+  extern proc sys_fcntl_long(fd:fd_t, cmd:c_int, arg:c_long, ref ret_out:c_int):qio_err_t;
+  extern proc sys_fcntl_ptr(fd:fd_t, cmd:c_int, arg:c_void_ptr, ref ret_out:c_int):qio_err_t;
+  extern proc sys_dup(oldfd:fd_t, ref fd_out:fd_t):qio_err_t;
+  extern proc sys_dup2(oldfd:fd_t, newfd:fd_t, ref fd_out:fd_t):qio_err_t;
+  extern proc sys_pipe(ref read_fd_out:fd_t, ref write_fd_out:fd_t):qio_err_t;
+  extern proc sys_accept(sockfd:fd_t, ref add_out:sys_sockaddr_t, ref fd_out:fd_t):qio_err_t;
+  extern proc sys_bind(sockfd:fd_t, const ref addr:sys_sockaddr_t):qio_err_t;
+  extern proc sys_connect(sockfd:fd_t, const ref addr:sys_sockaddr_t):qio_err_t;
+  extern proc getaddrinfo(node:c_string, service:c_string, ref hints:sys_addrinfo_t, ref res_out:sys_addrinfo_ptr_t):qio_err_t;
   extern proc sys_getaddrinfo_flags(res:sys_addrinfo_ptr_t):c_int;
   extern proc sys_getaddrinfo_family(res:sys_addrinfo_ptr_t):c_int;
   extern proc sys_getaddrinfo_socktype(res:sys_addrinfo_ptr_t):c_int;
@@ -492,19 +492,19 @@ module Sys {
   extern proc sys_getaddrinfo_next(res:sys_addrinfo_ptr_t):sys_addrinfo_ptr_t;
   extern proc sys_freeaddrinfo(res:sys_addrinfo_ptr_t);
 
-  extern proc sys_getnameinfo(ref addr:sys_sockaddr_t, ref host_out:c_string, ref serv_outc_:c_string, flags:c_int):err_t;
-  extern proc sys_getpeername(sockfd:fd_t, ref addr:sys_sockaddr_t):err_t;
-  extern proc sys_getsockname(sockfd:fd_t, ref addr:sys_sockaddr_t):err_t;
+  extern proc sys_getnameinfo(ref addr:sys_sockaddr_t, ref host_out:c_string, ref serv_outc_:c_string, flags:c_int):qio_err_t;
+  extern proc sys_getpeername(sockfd:fd_t, ref addr:sys_sockaddr_t):qio_err_t;
+  extern proc sys_getsockname(sockfd:fd_t, ref addr:sys_sockaddr_t):qio_err_t;
 
   // TODO -- these should be generic, assuming caller knows what they
   // are doing.
-  extern proc sys_getsockopt(sockfd:fd_t, level:c_int, optname:c_int, optval:c_void_ptr, ref optlen:socklen_t):err_t;
-  extern proc sys_setsockopt(sockfd:fd_t, level:c_int, optname:c_int, optval:c_void_ptr, optlen:socklen_t):err_t;
+  extern proc sys_getsockopt(sockfd:fd_t, level:c_int, optname:c_int, optval:c_void_ptr, ref optlen:socklen_t):qio_err_t;
+  extern proc sys_setsockopt(sockfd:fd_t, level:c_int, optname:c_int, optval:c_void_ptr, optlen:socklen_t):qio_err_t;
 
-  extern proc sys_listen(sockfd:fd_t, backlog:c_int):err_t;
-  extern proc sys_shutdown(sockfd:fd_t, how:c_int):err_t;
-  extern proc sys_socket(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out:fd_t):err_t;
-  extern proc sys_socketpair(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out_a:fd_t, ref sockfd_out_b:fd_t):err_t;
+  extern proc sys_listen(sockfd:fd_t, backlog:c_int):qio_err_t;
+  extern proc sys_shutdown(sockfd:fd_t, how:c_int):qio_err_t;
+  extern proc sys_socket(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out:fd_t):qio_err_t;
+  extern proc sys_socketpair(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out_a:fd_t, ref sockfd_out_b:fd_t):qio_err_t;
 
   extern type fd_set;
   extern type time_t = c_long;
@@ -513,7 +513,7 @@ module Sys {
      var tv_sec:time_t; // seconds
      var tv_usec:suseconds_t; // microseconds
   }
-  extern proc sys_select(nfds:c_int, readfds:c_ptr(fd_set), writefds:c_ptr(fd_set), exceptfds:c_ptr(fd_set), timeout:c_ptr(timeval), ref nset:c_int):err_t;
+  extern proc sys_select(nfds:c_int, readfds:c_ptr(fd_set), writefds:c_ptr(fd_set), exceptfds:c_ptr(fd_set), timeout:c_ptr(timeval), ref nset:c_int):qio_err_t;
   extern proc sys_fd_clr(fd:c_int, ref set:fd_set);
   extern proc sys_fd_isset(fd:c_int, ref set:fd_set):c_int;
   extern proc sys_fd_set(fd:c_int, ref set:fd_set);

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -20,14 +20,14 @@
 
 /* Types for low-level system error integration
 
-   This module defines the error types :type:`syserr` and :type:`err_t`.
+   This module defines the error types :type:`syserr` and :type:`qio_err_t`.
 
-   When should one use :type:`syserr` and when should one use :type:`err_t`?
-   :type:`err_t` is a system error code (a `c_int` by a nicer name to
+   When should one use :type:`syserr` and when should one use :type:`qio_err_t`?
+   :type:`qio_err_t` is a system error code (a `c_int` by a nicer name to
    indicate its purpose). :type:`syserr` is an enhanced error that might also
    include an error message. All user-facing Chapel library code, or user
    Chapel code, should generally use :type:`syserr`. When wrapping functions
-   or declaring them in C, use :type:`err_t` to indicate that a function is
+   or declaring them in C, use :type:`qio_err_t` to indicate that a function is
    returning an error code.
 
    A note about the error code documentation in this file. Error descriptions
@@ -83,9 +83,9 @@ use CTypes;
 
 
 /* A type storing an error code or an error message.
-   A syserr can be compared using == or != to an err_t (ie integer error code)
-   or to another syserr. A syserr can be cast to or from an err_t. It can be
-   assigned the value of an err_t or another syserr. In addition, syserr can be
+   A syserr can be compared using == or != to an qio_err_t (ie integer error code)
+   or to another syserr. A syserr can be cast to or from an qio_err_t. It can be
+   assigned the value of an qio_err_t or another syserr. In addition, syserr can be
    checked directly in an if statement like so:
 
    .. code-block:: chapel
@@ -105,10 +105,10 @@ use CTypes;
 extern type syserr; // = c_int, opaque so we can manually override ==,!=,etc
 
 /* An integral error code. This is really just a `c_int`, but code is
-   clearer if you use err_t to indicate arguments, variables, and return types
+   clearer if you use qio_err_t to indicate arguments, variables, and return types
    that are system error codes.
  */
-extern type err_t = c_int;
+extern type qio_err_t = c_int;
 
 /* A system file descriptor. This is really just a `c_int`, but code is
    clearer if you use fd_t to indicate arguments, variables, and return types
@@ -125,9 +125,9 @@ private extern proc qio_int_to_err(a:int(32)):syserr;
 private extern proc qio_err_iserr(a:syserr):c_int;
 
 /* The error code indicating that no error occurred (Chapel specific) */
-inline proc ENOERR return 0:err_t;
+inline proc ENOERR return 0:qio_err_t;
 
-// When err_t is no longer just int(32), will need to add cases for err_t too.
+// When qio_err_t is no longer just int(32), will need to add cases for qio_err_t too.
 pragma "no doc"
 inline operator syserr.==(a: syserr, b: syserr) {
   return (qio_err_eq(a,b) != 0:c_int);
@@ -175,31 +175,31 @@ pragma "no doc"
 inline operator syserr.=(ref ret:syserr, x:int(64))
 { __primitive("=", ret, qio_int_to_err(x:int(32))); }
 pragma "no doc"
-inline operator syserr.=(ref ret:err_t, x:syserr)
-{ __primitive("=", ret, qio_err_to_int(x):err_t); }
+inline operator syserr.=(ref ret:qio_err_t, x:syserr)
+{ __primitive("=", ret, qio_err_to_int(x):qio_err_t); }
 
 // end of file
-private extern proc chpl_macro_int_EEOF():err_t;
+private extern proc chpl_macro_int_EEOF():qio_err_t;
 
 /* An error code indicating the end of file has been reached (Chapel specific)
  */
-inline proc EEOF return chpl_macro_int_EEOF():err_t;
+inline proc EEOF return chpl_macro_int_EEOF():qio_err_t;
 
-private extern proc chpl_macro_int_ESHORT():err_t;
+private extern proc chpl_macro_int_ESHORT():qio_err_t;
 
 /* An error code indicating that the end of file or the end of the
    input was reached before the requested amount of data could be read.
    (Chapel specific)
   */
-inline proc ESHORT return chpl_macro_int_ESHORT():err_t;
+inline proc ESHORT return chpl_macro_int_ESHORT():qio_err_t;
 
-private extern proc chpl_macro_int_EFORMAT():err_t;
+private extern proc chpl_macro_int_EFORMAT():qio_err_t;
 
 /* An error code indicating a format error; for example when reading a quoted
    string literal, this would be returned if we never encountered the
    opening quote. (Chapel specific)
   */
-inline proc EFORMAT return chpl_macro_int_EFORMAT():err_t;
+inline proc EFORMAT return chpl_macro_int_EFORMAT():qio_err_t;
 
 // system error numbers
 
@@ -215,115 +215,115 @@ inline proc EFORMAT return chpl_macro_int_EFORMAT():err_t;
 /* Argument list too long. The number of bytes used for the argument and
   environment list of the new process exceeded the current limit. (POSIX.1)
  */
-extern const E2BIG:err_t;
+extern const E2BIG:qio_err_t;
 
 /* Permission denied. An attempt was made to access a file in a way forbidden
   by its file access permissions. (POSIX.1)
  */
-extern const EACCES:err_t;
+extern const EACCES:qio_err_t;
 
 /* Address already in use. Only one usage of each address is normally permitted.
    (POSIX.1)
  */
-extern const EADDRINUSE:err_t;
+extern const EADDRINUSE:qio_err_t;
 
 /* Can't assign requested address. Normally results from an attempt to create
    a socket with an address not on this machine. (POSIX.1)
  */
-extern const EADDRNOTAVAIL:err_t;
+extern const EADDRNOTAVAIL:qio_err_t;
 
 /* Address family not supported by protocol family. An address incompatible
    with the requested protocol was used. For example, you should not
    necessarily expect to be able to use NS addresses with ARPA Internet
    protocols. (POSIX.1)
 */
-extern const EAFNOSUPPORT:err_t;
+extern const EAFNOSUPPORT:qio_err_t;
 
 /* Resource temporarily unavailable. This is a temporary condition and later
    calls to the same routine may complete normally. (POSIX.1)
  */
-extern const EAGAIN:err_t;
+extern const EAGAIN:qio_err_t;
 
 /* Operation already in progress. An operation was attempted on a non-blocking
    object that already had an operation in progress. (POSIX.1)
  */
-extern const EALREADY:err_t;
+extern const EALREADY:qio_err_t;
 
 /* Invalid exchange (linux only) */
-extern const EBADE:err_t;
+extern const EBADE:qio_err_t;
 
 /* Bad file descriptor. A file descriptor argument was out of range, referred
    to no open file, or a read (write) request was made to a file that was only
    open for writing (reading). (POSIX.1)
   */
-extern const EBADF:err_t;
+extern const EBADF:qio_err_t;
 
 /* File descriptor in bad state (linux only) */
-extern const EBADFD:err_t;
+extern const EBADFD:qio_err_t;
 
 /* Bad message. A corrupted message was detected. (POSIX.1) */
-extern const EBADMSG:err_t;
+extern const EBADMSG:qio_err_t;
 
 /* Invalid request descriptor (linux only) */
-extern const EBADR:err_t;
+extern const EBADR:qio_err_t;
 
 /* Invalid request code (linux only) */
-extern const EBADRQC:err_t;
+extern const EBADRQC:qio_err_t;
 
 /* Invalid slot (linux only) */
-extern const EBADSLT:err_t;
+extern const EBADSLT:qio_err_t;
 
 /* Device or resource busy. An attempt to use a system resource which was in
    use at the time in a manner which would have conflicted with the request.
    (POSIX.1)
  */
-extern const EBUSY:err_t;
+extern const EBUSY:qio_err_t;
 
 /* Operation canceled. The scheduled operation was canceled. (POSIX.1) */
-extern const ECANCELED:err_t;
+extern const ECANCELED:qio_err_t;
 
 /* No child processes. A wait or waitpid system call was executed by a
    process that had no existing or unwaited-for child processes. (POSIX.1)
  */
-extern const ECHILD:err_t;
+extern const ECHILD:qio_err_t;
 
 /* Channel number out of range (linux only) */
-extern const ECHRNG:err_t;
+extern const ECHRNG:qio_err_t;
 
 /* Communication error on send (linux only) */
-extern const ECOMM:err_t;
+extern const ECOMM:qio_err_t;
 
 /* Software caused connection abort. A connection abort was caused internal
    to your host machine. (POSIX.1)
  */
-extern const ECONNABORTED:err_t;
+extern const ECONNABORTED:qio_err_t;
 
 /* Connection refused. No connection could be made because the target machine
    actively refused it. This usually results from trying to connect to a
    service that is inactive on the foreign host. (POSIX.1)
  */
-extern const ECONNREFUSED:err_t;
+extern const ECONNREFUSED:qio_err_t;
 
 /* Connection reset by peer. A connection was forcibly closed by a peer. This
    normally results from a loss of the connection on the remote socket due to a
    timeout or a reboot. (POSIX.1)
  */
-extern const ECONNRESET:err_t;
+extern const ECONNRESET:qio_err_t;
 
 /* Resource deadlock avoided. An attempt was made to lock a system resource
    that would have resulted in a deadlock situation. (POSIX.1)
  */
-extern const EDEADLK:err_t;
+extern const EDEADLK:qio_err_t;
 
 /* Destination address required. A required address was omitted from an
    operation on a socket. (POSIX.1)
  */
-extern const EDESTADDRREQ:err_t;
+extern const EDESTADDRREQ:qio_err_t;
 
 /* Numerical argument out of domain. A numerical input argument was outside
    the defined domain of the mathematical function. (POSIX.1, C99)
  */
-extern const EDOM:err_t;
+extern const EDOM:qio_err_t;
 
 /* Disc quota exceeded. A write system call to an ordinary file, the creation
    of a directory or symbolic link, or the creation of a directory entry failed
@@ -331,35 +331,35 @@ extern const EDOM:err_t;
    an inode for a newly created file failed because the user's quota of inodes
    was exhausted. (POSIX.1)
  */
-extern const EDQUOT:err_t;
+extern const EDQUOT:qio_err_t;
 
 /* File exists. An existing file was mentioned in an inappropriate context, for
    instance, as the new link name in a link system call. (POSIX.1)
  */
-extern const EEXIST:err_t;
+extern const EEXIST:qio_err_t;
 
 /* Bad address. The system detected an invalid address in attempting to
    use an argument of a call. (POSIX.1)
  */
-extern const EFAULT:err_t;
+extern const EFAULT:qio_err_t;
 
 /* File too large. The size of a file exceeded the maximum. (POSIX.1) */
-extern const EFBIG:err_t;
+extern const EFBIG:qio_err_t;
 
 /* Host is down. A socket operation failed because the destination host was
    down. (linux, FreeBSD)
  */
-extern const EHOSTDOWN:err_t;
+extern const EHOSTDOWN:qio_err_t;
 
 /* No route to host. A socket operation was attempted to an unreachable host.
    (POSIX.1)
  */
-extern const EHOSTUNREACH:err_t;
+extern const EHOSTUNREACH:qio_err_t;
 
 /* Identifier removed. An IPC identifier was removed while the current
    process was waiting on it. (POSIX.1)
  */
-extern const EIDRM:err_t;
+extern const EIDRM:qio_err_t;
 
 /*
    Illegal byte sequence. While decoding a multibyte character the function
@@ -369,177 +369,177 @@ extern const EIDRM:err_t;
    This error might be returned for example in the case of an illegal UTF-8
    byte sequence. (POSIX.1, C99)
  */
-extern const EILSEQ:err_t;
+extern const EILSEQ:qio_err_t;
 
 /* Operation now in progress. An operation that takes a long time to complete
    (such as a connect system call) was attempted on a non-blocking object.
    (POSIX.1)
   */
-extern const EINPROGRESS:err_t;
+extern const EINPROGRESS:qio_err_t;
 
 /* Interrupted system call. An asynchronous signal (such as SIGINT or SIGQUIT)
    was caught by the process during the execution of an interruptible function.
    If the signal handler performs a normal return, the interrupted system call
    will seem to have returned the error condition. (POSIX.1)
 */
-extern const EINTR:err_t;
+extern const EINTR:qio_err_t;
 
 /* Invalid argument. Some invalid argument was supplied. (For example,
    specifying an undefined signal to a signal system call or a kill system
    call). (POSIX.1)
 */
-extern const EINVAL:err_t;
+extern const EINVAL:qio_err_t;
 
 /* Input/output error. Some physical input or output error occurred. This
    error will not be reported until a subsequent operation on the same file
    descriptor and may be lost (over written) by any subsequent errors. (POSIX.1)
   */
-extern const EIO:err_t;
+extern const EIO:qio_err_t;
 
 /* Socket is already connected. A connect system call was made on an already
    connected socket; or, a sendto or sendmsg system call on a connected socket
    specified a destination when already connected. (POSIX.1)
 */
-extern const EISCONN:err_t;
+extern const EISCONN:qio_err_t;
 
 /* Is a directory. An attempt was made to open a directory with write mode
    specified. (POSIX.1)
  */
-extern const EISDIR:err_t;
+extern const EISDIR:qio_err_t;
 
 /* Is a named type file (linux only) */
-extern const EISNAM:err_t;
+extern const EISNAM:qio_err_t;
 
 /* Key has expired (linux only) */
-extern const EKEYEXPIRED:err_t;
+extern const EKEYEXPIRED:qio_err_t;
 
 /* Key was rejected by service (linux only) */
-extern const EKEYREJECTED:err_t;
+extern const EKEYREJECTED:qio_err_t;
 
 /* Key has been revoked (linux only) */
-extern const EKEYREVOKED:err_t;
+extern const EKEYREVOKED:qio_err_t;
 
 /* Level 2 halted (linux only) */
-extern const EL2HLT:err_t;
+extern const EL2HLT:qio_err_t;
 
 /* Level 2 not synchronized (linux only) */
-extern const EL2NSYNC:err_t;
+extern const EL2NSYNC:qio_err_t;
 
 /* Level 3 halted (linux only) */
-extern const EL3HLT:err_t;
+extern const EL3HLT:qio_err_t;
 
 /* Level 3 halted (linux only) */
-extern const EL3RST:err_t;
+extern const EL3RST:qio_err_t;
 
 /* Cannot access a needed shared library (linux only) */
-extern const ELIBACC:err_t;
+extern const ELIBACC:qio_err_t;
 
 /* Accessing a corrupted shared library (linux only) */
-extern const ELIBBAD:err_t;
+extern const ELIBBAD:qio_err_t;
 
 /* Attempting to link in too many shared libraries (linux only) */
-extern const ELIBMAX:err_t;
+extern const ELIBMAX:qio_err_t;
 
 /* lib section in a.out corrupted (linux only) */
-extern const ELIBSCN:err_t;
+extern const ELIBSCN:qio_err_t;
 
 /* Cannot exec a shared library directly (linux only) */
-extern const ELIBEXEC:err_t;
+extern const ELIBEXEC:qio_err_t;
 
 /* Too many levels of symbolic links. A path name lookup involved more than 32
    (MAXSYMLINKS) symbolic links. (POSIX.1)
   */
-extern const ELOOP:err_t;
+extern const ELOOP:qio_err_t;
 
 /* Wrong medium type (linux only) */
-extern const EMEDIUMTYPE:err_t;
+extern const EMEDIUMTYPE:qio_err_t;
 
 /* Too many open files. Maximum number of file descriptors allowable in the
    process has been reached and requests for an open cannot be satisfied until
    at least one has been closed. The getdtablesize system call will obtain the
    current limit. (POSIX.1)
 */
-extern const EMFILE:err_t;
+extern const EMFILE:qio_err_t;
 
 /* Too many links. Maximum allowable hard links to a single file has been
    exceeded. (POSIX.1)
   */
-extern const EMLINK:err_t;
+extern const EMLINK:qio_err_t;
 
 /* Message too long. A message sent on a socket was larger than the internal
    message buffer or some other network limit. (POSIX.1)
  */
-extern const EMSGSIZE:err_t;
+extern const EMSGSIZE:qio_err_t;
 
 /* Multihop attempted. (POSIX.1)
  */
-extern const EMULTIHOP:err_t;
+extern const EMULTIHOP:qio_err_t;
 
 /* File name too long. A component of a path name exceeded {NAME_MAX}
    characters, or an entire path name exceeded {PATH_MAX} characters. (POSIX.1)
  */
-extern const ENAMETOOLONG:err_t;
+extern const ENAMETOOLONG:qio_err_t;
 
 /* Network is down. A socket operation encountered a dead network. (POSIX.1) */
-extern const ENETDOWN:err_t;
+extern const ENETDOWN:qio_err_t;
 
 /* Network dropped connection on reset. The host you were connected to crashed
    and rebooted. (POSIX.1)
   */
-extern const ENETRESET:err_t;
+extern const ENETRESET:qio_err_t;
 
 /* Network is unreachable. A socket operation was attempted to an unreachable
    network. (POSIX.1)
  */
-extern const ENETUNREACH:err_t;
+extern const ENETUNREACH:qio_err_t;
 
 /* Too many open files in system. Maximum number of open files allowable on
    the system has been reached and requests for an open cannot be satisfied
    until at least one has been closed. (POSIX.1)
  */
-extern const ENFILE:err_t;
+extern const ENFILE:qio_err_t;
 
 /* No buffer space available. An operation on a socket or pipe was not
    performed because the system lacked sufficient buffer space or because a
    queue was full. (POSIX.1 XSI STREAMS option)
   */
-extern const ENOBUFS:err_t;
+extern const ENOBUFS:qio_err_t;
 
 /* No  message is available on the STREAM head read queue (POSIX.1)
  */
-extern const ENODATA:err_t;
+extern const ENODATA:qio_err_t;
 
 /* Operation not supported by device. An attempt was made to apply an
    inappropriate function to a device, for example, trying to read a write-only
    device such as a printer. (POSIX.1)
  */
-extern const ENODEV:err_t;
+extern const ENODEV:qio_err_t;
 
 /* No such file or directory. A component of a specified pathname did not
    exist, or the pathname was an empty string. (POSIX.1)
  */
-extern const ENOENT:err_t;
+extern const ENOENT:qio_err_t;
 
 /* Exec format error. A request was made to execute a file that, although it
    has the appropriate permissions, was not in the format required for an
    executable file. (POSIX.1)
  */
-extern const ENOEXEC:err_t;
+extern const ENOEXEC:qio_err_t;
 
 /* Required key not available (linux only) */
-extern const ENOKEY:err_t;
+extern const ENOKEY:qio_err_t;
 
 /* No locks available. A system-imposed limit on the number of simultaneous
   file locks was reached. (POSIX.1)
  */
-extern const ENOLCK:err_t;
+extern const ENOLCK:qio_err_t;
 
 /* Link has been severed. (POSIX.1)
  */
-extern const ENOLINK:err_t;
+extern const ENOLINK:qio_err_t;
 
 /* No medium found (linux only) */
-extern const ENOMEDIUM:err_t;
+extern const ENOMEDIUM:qio_err_t;
 
 /* Cannot allocate memory. The new process image required more memory than
    was allowed by the hardware or by system-imposed memory management
@@ -547,26 +547,26 @@ extern const ENOMEDIUM:err_t;
    core is not. Soft limits may be increased to their corresponding hard
    limits. (POSIX.1)
  */
-extern const ENOMEM:err_t;
+extern const ENOMEM:qio_err_t;
 
 /* No message of desired type. An IPC message queue does not contain a message
    of the desired type, or a message catalog does not contain the requested
    message. (POSIX.1)
  */
-extern const ENOMSG:err_t;
+extern const ENOMSG:qio_err_t;
 
 /* Machine is not on the network (linux only)
  */
-extern const ENONET:err_t;
+extern const ENONET:qio_err_t;
 
 /* Package not installed  (linux only)
  */
-extern const ENOPKG:err_t;
+extern const ENOPKG:qio_err_t;
 
 /* Protocol not available. A bad option or level was specified in a
    getsockopt or setsockopt system call. (POSIX.1)
   */
-extern const ENOPROTOOPT:err_t;
+extern const ENOPROTOOPT:qio_err_t;
 
 /* No space left on device. A write system call to an ordinary file, the
    creation of a directory or symbolic link, or the creation of a directory
@@ -574,205 +574,205 @@ extern const ENOPROTOOPT:err_t;
    or the allocation of an inode for a newly created file failed because no
    more inodes were available on the file system. (POSIX.1)
  */
-extern const ENOSPC:err_t;
+extern const ENOSPC:qio_err_t;
 
 /* No STREAM resources (POSIX.1 XSI STREAMS option) */
-extern const ENOSR:err_t;
+extern const ENOSR:qio_err_t;
 
 /* Not a STREAM (POSIX.1 XSI STREAMS option) */
-extern const ENOSTR:err_t;
+extern const ENOSTR:qio_err_t;
 
 /* Function not implemented. Attempted a system call that is not available on
    this system. (POSIX.1)
  */
-extern const ENOSYS:err_t;
+extern const ENOSYS:qio_err_t;
 
 /* Block device required.
    A block device operation was attempted on a non-block device or file.
    (linux, FreeBSD)
  */
-extern const ENOTBLK:err_t;
+extern const ENOTBLK:qio_err_t;
 
 /* Socket is not connected. An request to send or receive data was disallowed
    because the socket was not connected and (when sending on a datagram socket)
    no address was supplied. (POSIX.1)
  */
-extern const ENOTCONN:err_t;
+extern const ENOTCONN:qio_err_t;
 
 /* Not a directory. A component of the specified pathname existed, but it was
    not a directory, when a directory was expected. (POSIX.1)
  */
-extern const ENOTDIR:err_t;
+extern const ENOTDIR:qio_err_t;
 
 /* Directory not empty. A directory with entries other than '.' and '..' was
    supplied to a remove directory or rename call. (POSIX.1)
  */
-extern const ENOTEMPTY:err_t;
+extern const ENOTEMPTY:qio_err_t;
 
 // POSIX 2008 also defines ENOTRECOVERABLE but this
 // is in neither FreeBSD nor Linux documentation
 
 /* Socket operation on non-socket. (POSIX.1) */
-extern const ENOTSOCK:err_t;
+extern const ENOTSOCK:qio_err_t;
 
 /* Operation not supported. The attempted operation is not supported for the
    type of object referenced. Usually this occurs when a file descriptor
    refers to a file or socket that cannot support this operation, for example,
    trying to accept a connection on a datagram socket. (POSIX.1)
  */
-extern const ENOTSUP:err_t;
+extern const ENOTSUP:qio_err_t;
 
 /* Inappropriate ioctl for device. A control function (e.g. ioctl system
    call) was attempted for a file or special device for which the operation was
    inappropriate. (POSIX.1)
  */
-extern const ENOTTY:err_t;
+extern const ENOTTY:qio_err_t;
 
 /* Name not unique on network (linux only) */
-extern const ENOTUNIQ:err_t;
+extern const ENOTUNIQ:qio_err_t;
 
 /* Device not configured. Input or output on a special file referred to a
    device that did not exist, or made a request beyond the limits of the
    device. This error may also occur when, for example, a tape drive is
    not online or no disk pack is loaded on a drive. (POSIX.1)
  */
-extern const ENXIO:err_t;
+extern const ENXIO:qio_err_t;
 
 /* Operation not supported. The attempted operation is not supported for the
   type of object referenced. Usually this occurs when a file descriptor refers
   to a file or socket that cannot support this operation, for example, trying
   to accept a connection on a datagram socket. (POSIX.1)
   */
-extern const EOPNOTSUPP:err_t;
+extern const EOPNOTSUPP:qio_err_t;
 
 /* Value too large to be stored in data type. A numerical result of the
    function was too large to be stored in the caller provided space. (POSIX.1)
  */
-extern const EOVERFLOW:err_t;
+extern const EOVERFLOW:qio_err_t;
 
 /* Operation not permitted. An attempt was made to perform an operation
    limited to processes with appropriate privileges or to the owner of a file
    or other resources. (POSIX.1)
  */
-extern const EPERM:err_t;
+extern const EPERM:qio_err_t;
 
 /* Protocol family not supported. The protocol family has not been configured
    into the system or no implementation for it exists. (linux, FreeBSD)
  */
-extern const EPFNOSUPPORT:err_t;
+extern const EPFNOSUPPORT:qio_err_t;
 
 /* Broken pipe. A write on a pipe, socket or FIFO for which there is no
    process to read the data. (POSIX.1)
  */
-extern const EPIPE:err_t;
+extern const EPIPE:qio_err_t;
 
 /* Protocol error. A device or socket encountered an unrecoverable
    protocol error. (POSIX.1)
  */
-extern const EPROTO:err_t;
+extern const EPROTO:qio_err_t;
 
 /* Protocol not supported. The protocol has not been configured into the
    system or no implementation for it exists. (POSIX.1)
  */
-extern const EPROTONOSUPPORT:err_t;
+extern const EPROTONOSUPPORT:qio_err_t;
 
 /* Protocol wrong type for socket. A protocol was specified that does not sup-
    port the semantics of the socket type requested. For example, you cannot
    use the ARPA Internet UDP protocol with type SOCK_STREAM. (POSIX.1)
  */
-extern const EPROTOTYPE:err_t;
+extern const EPROTOTYPE:qio_err_t;
 
 /* Result too large. A numerical result of the function was too large to fit
    in the available space (perhaps exceeded precision). (POSIX.1, C99)
  */
-extern const ERANGE:err_t;
+extern const ERANGE:qio_err_t;
 
 /* Remote address changed (linux only) */
-extern const EREMCHG:err_t;
+extern const EREMCHG:qio_err_t;
 
 /* Object is remote (linux only) */
-extern const EREMOTE:err_t;
+extern const EREMOTE:qio_err_t;
 
 /* Remote I/O error (linux only) */
-extern const EREMOTEIO:err_t;
+extern const EREMOTEIO:qio_err_t;
 
 /* Interrupted system call should be restarted (linux only) */
-extern const ERESTART:err_t;
+extern const ERESTART:qio_err_t;
 
 /* Read-only file system. An attempt was made to modify a file or directory on
    a file system that was read-only at the time. (POSIX.1)
  */
-extern const EROFS:err_t;
+extern const EROFS:qio_err_t;
 
 /* Can't send after socket shutdown. A request to send data was disallowed
    because the socket had already been shut down with a previous shutdown system
    call.
  */
-extern const ESHUTDOWN:err_t;
+extern const ESHUTDOWN:qio_err_t;
 
 /* Illegal seek. An lseek system call was issued on a socket, pipe or FIFO.
    (POSIX.1)
  */
-extern const ESPIPE:err_t;
+extern const ESPIPE:qio_err_t;
 
 /* Socket type not supported. The support for the socket type has not been
    configured into the system or no implementation for it exists.
    (linux, FreeBSD)
  */
-extern const ESOCKTNOSUPPORT:err_t;
+extern const ESOCKTNOSUPPORT:qio_err_t;
 
 /* No such process. No process could be found corresponding to that specified
    by the given process ID. (POSIX.1)
  */
-extern const ESRCH:err_t;
+extern const ESRCH:qio_err_t;
 
 /* Stale NFS file handle. An attempt was made to access an open file (on an
    NFS file system) which is now unavailable as referenced by the file
    descriptor. This may indicate the file was deleted on the NFS server or
    some other catastrophic event occurred. (POSIX.1)
  */
-extern const ESTALE:err_t;
+extern const ESTALE:qio_err_t;
 
 /* Streams pipe error (linux only) */
-extern const ESTRPIPE:err_t;
+extern const ESTRPIPE:qio_err_t;
 
 /* Timer expired (POSIX.1 XSI STREAMS option)
  */
-extern const ETIME:err_t;
+extern const ETIME:qio_err_t;
 
 /* Operation timed out. A connect or send system call failed because the
    connected party did not properly respond after a period of time. (The
    timeout period is dependent on the communication protocol.) (POSIX.1)
  */
-extern const ETIMEDOUT:err_t;
+extern const ETIMEDOUT:qio_err_t;
 
 /* Text file busy. The new process was a pure procedure (shared text) file
    which was open for writing by another process, or while the pure procedure
    file was being executed an open system call requested write access. (POSIX.1)
  */
-extern const ETXTBSY:err_t;
+extern const ETXTBSY:qio_err_t;
 
 /* Structure needs cleaning (linux only) */
-extern const EUCLEAN:err_t;
+extern const EUCLEAN:qio_err_t;
 
 /* Protocol driver not attached (linux only) */
-extern const EUNATCH:err_t;
+extern const EUNATCH:qio_err_t;
 
 /* Too many users. The quota system ran out of table entries.
    (linux, FreeBSD)
  */
-extern const EUSERS:err_t;
+extern const EUSERS:qio_err_t;
 
 /* Operation would block (may be same value as EAGAIN) (POSIX.1)
  */
-extern const EWOULDBLOCK:err_t;
+extern const EWOULDBLOCK:qio_err_t;
 
 /* Cross-device link. A hard link to a file on another file system was
    attempted. (POSIX.1)
  */
-extern const EXDEV:err_t;
+extern const EXDEV:qio_err_t;
 
 /* Exchange full (linux only) */
-extern const EXFULL:err_t;
+extern const EXFULL:qio_err_t;
 
 }

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -58,7 +58,7 @@ class SystemError : Error {
      from the internal ``err`` and the ``details`` string.
   */
   override proc message() {
-    var strerror_err: err_t = ENOERR;
+    var strerror_err: qio_err_t = ENOERR;
     var errstr              = sys_strerror_syserr_str(err, strerror_err);
     var err_msg: string;
     try! {
@@ -368,7 +368,7 @@ class BadFormatError : IOError {
 }
 
 // here's what we need from Sys
-private extern proc sys_strerror_syserr_str(error:syserr, out err_in_strerror:err_t):c_string;
+private extern proc sys_strerror_syserr_str(error:syserr, out err_in_strerror:qio_err_t):c_string;
 
 /* This function takes in a string and returns it in double-quotes,
    with internal double-quotes escaped with backslash.
@@ -466,7 +466,7 @@ proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
  */
 proc errorToString(error:syserr):string
 {
-  var strerror_err:err_t = ENOERR;
+  var strerror_err:qio_err_t = ENOERR;
   const errstr = sys_strerror_syserr_str(error, strerror_err);
   try! {
     return createStringWithOwnedBuffer(errstr);

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -147,7 +147,7 @@ static inline void qio_unlock(qio_lock_t* x) { int rc = pthread_mutex_unlock(x);
 
 static inline qioerr qio_lock_init(qio_lock_t* x) {
   pthread_mutexattr_t attr;
-  err_t err, newerr;
+  qio_err_t err, newerr;
 
   err = pthread_mutexattr_init(&attr);
   if( err ) return qio_int_to_err(err);
@@ -859,7 +859,7 @@ int32_t qio_channel_read_byte(const int threadsafe, qio_channel_t* restrict ch)
 
   if( threadsafe ) {
     qioerr err;
-    err_t errcode;
+    qio_err_t errcode;
     err = qio_lock(&ch->lock);
     errcode = qio_err_to_int(err);
     if( errcode ) {
@@ -875,7 +875,7 @@ int32_t qio_channel_read_byte(const int threadsafe, qio_channel_t* restrict ch)
   } else {
     ssize_t amt_read;
     qioerr err;
-    err_t errcode;
+    qio_err_t errcode;
     uint8_t tmp;
     err = _qio_slow_read(ch, &tmp, 1, &amt_read);
     if( err == 0 && amt_read != 1 ) err = QIO_ESHORT;

--- a/runtime/include/qio/qio_error.h
+++ b/runtime/include/qio/qio_error.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-typedef int err_t;
+typedef int qio_err_t;
 
 struct qio_err_s {
   int code;

--- a/runtime/include/qio/sys.h
+++ b/runtime/include/qio/sys.h
@@ -146,98 +146,98 @@ int sys_port_sys_sockaddr_t(sys_sockaddr_t* addr, uint16_t* numericport);
 size_t sys_page_size(void);
 
 
-err_t sys_fseeko(FILE* stream, off_t offset, int whence);
-err_t sys_ftello(FILE* stream, off_t* offset_out);
-err_t sys_fopen(const char* path, const char* mode, FILE** file_out);
-err_t sys_fdopen(fd_t fd, const char* mode, FILE** file_out);
-err_t sys_fclose(FILE* stream);
+qio_err_t sys_fseeko(FILE* stream, off_t offset, int whence);
+qio_err_t sys_ftello(FILE* stream, off_t* offset_out);
+qio_err_t sys_fopen(const char* path, const char* mode, FILE** file_out);
+qio_err_t sys_fdopen(fd_t fd, const char* mode, FILE** file_out);
+qio_err_t sys_fclose(FILE* stream);
 // like sys_fread, but returns EEOF on eof.
-err_t sys_fread(void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_read);
-err_t sys_fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_written);
-err_t sys_fflush(FILE* stream);
-err_t sys_feof(FILE* stream, int *iseof);
-err_t sys_ferror(FILE* stream);
-err_t sys_posix_fadvise(fd_t fd, off_t offset, off_t len, int advice);
-err_t sys_posix_madvise(void* addr, size_t len, int advice);
+qio_err_t sys_fread(void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_read);
+qio_err_t sys_fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_written);
+qio_err_t sys_fflush(FILE* stream);
+qio_err_t sys_feof(FILE* stream, int *iseof);
+qio_err_t sys_ferror(FILE* stream);
+qio_err_t sys_posix_fadvise(fd_t fd, off_t offset, off_t len, int advice);
+qio_err_t sys_posix_madvise(void* addr, size_t len, int advice);
 
 // returns an allocated string in string_out, which must be freed.
-err_t sys_strerror(err_t error, const char** string_out);
+qio_err_t sys_strerror(qio_err_t error, const char** string_out);
 
-const char* sys_strerror_syserr_str(syserr error, err_t* err_in_strerror);
+const char* sys_strerror_syserr_str(syserr error, qio_err_t* err_in_strerror);
 
 // returns an allocated string in string_out, which must be freed.
-err_t sys_readlink(const char* path, const char** string_out);
+qio_err_t sys_readlink(const char* path, const char** string_out);
 int sys_getenv(const char* name, const char** string_out);
 
-err_t sys_open(const char* path, int flags, mode_t mode, fd_t* fd_out);
+qio_err_t sys_open(const char* path, int flags, mode_t mode, fd_t* fd_out);
 
 
-err_t sys_close(fd_t fd);
+qio_err_t sys_close(fd_t fd);
 
-err_t sys_lseek(fd_t fd, off_t offset, int whence, off_t* offset_out);
-err_t sys_stat(const char* path, sys_stat_t* buf);
-err_t sys_fstat(fd_t fd, struct stat* buf);
-err_t sys_lstat(const char* path, struct stat* buf);
-err_t sys_fstatfs(fd_t fd, sys_statfs_t* buf);
+qio_err_t sys_lseek(fd_t fd, off_t offset, int whence, off_t* offset_out);
+qio_err_t sys_stat(const char* path, sys_stat_t* buf);
+qio_err_t sys_fstat(fd_t fd, struct stat* buf);
+qio_err_t sys_lstat(const char* path, struct stat* buf);
+qio_err_t sys_fstatfs(fd_t fd, sys_statfs_t* buf);
 
-err_t sys_lustre_get_stripe_size(fd_t fd, int64_t* size_out);
+qio_err_t sys_lustre_get_stripe_size(fd_t fd, int64_t* size_out);
 
-err_t sys_mkstemp(char* template_, fd_t* fd_out);
+qio_err_t sys_mkstemp(char* template_, fd_t* fd_out);
 
-err_t sys_ftruncate(fd_t fd, off_t length);
+qio_err_t sys_ftruncate(fd_t fd, off_t length);
 
-err_t sys_sysconf(int name, long* val_out);
+qio_err_t sys_sysconf(int name, long* val_out);
 
-err_t sys_posix_fallocate(fd_t fd, off_t offset, off_t len);
+qio_err_t sys_posix_fallocate(fd_t fd, off_t offset, off_t len);
 
 int64_t sys_iov_total_bytes(const struct iovec* iov, int iovcnt);
-err_t sys_mmap(void* addr, size_t length, int prot, int flags, fd_t fd, off_t offset, void** ret);
+qio_err_t sys_mmap(void* addr, size_t length, int prot, int flags, fd_t fd, off_t offset, void** ret);
 
-err_t sys_munmap(void* addr, size_t length);
+qio_err_t sys_munmap(void* addr, size_t length);
 
-err_t sys_read(fd_t fd, void* buf, size_t count, ssize_t* num_read_out);
-err_t sys_write(fd_t fd, const void* buf, size_t count, ssize_t* num_written_out);
+qio_err_t sys_read(fd_t fd, void* buf, size_t count, ssize_t* num_read_out);
+qio_err_t sys_write(fd_t fd, const void* buf, size_t count, ssize_t* num_written_out);
 
-err_t sys_pread(fd_t fd, void* buf, size_t count, off_t offset, ssize_t* num_read_out);
-err_t sys_pwrite(fd_t fd, const void* buf, size_t count, off_t offset, ssize_t* num_written_out);
+qio_err_t sys_pread(fd_t fd, void* buf, size_t count, off_t offset, ssize_t* num_read_out);
+qio_err_t sys_pwrite(fd_t fd, const void* buf, size_t count, off_t offset, ssize_t* num_written_out);
 
-err_t sys_readv(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_read_out);
-err_t sys_writev(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_written_out);
+qio_err_t sys_readv(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_read_out);
+qio_err_t sys_writev(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_written_out);
 
-err_t sys_preadv(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_read_out);
-err_t sys_pwritev(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_written_out);
+qio_err_t sys_preadv(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_read_out);
+qio_err_t sys_pwritev(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_written_out);
 
-err_t sys_fsync(fd_t fd);
+qio_err_t sys_fsync(fd_t fd);
 
-err_t sys_fcntl(fd_t fd, int cmd, int* ret);
+qio_err_t sys_fcntl(fd_t fd, int cmd, int* ret);
 
-err_t sys_fcntl_long(fd_t fd, int cmd, long arg, int* ret);
-
-
-err_t sys_fcntl_ptr(fd_t fd, int cmd, void* arg, int* ret);
+qio_err_t sys_fcntl_long(fd_t fd, int cmd, long arg, int* ret);
 
 
-err_t sys_dup(fd_t oldfd, fd_t* fd_out);
+qio_err_t sys_fcntl_ptr(fd_t fd, int cmd, void* arg, int* ret);
 
 
-err_t sys_dup2(fd_t oldfd, fd_t newfd, fd_t* fd_out);
+qio_err_t sys_dup(fd_t oldfd, fd_t* fd_out);
 
 
-err_t sys_pipe(fd_t* read_fd_out, fd_t* write_fd_out);
+qio_err_t sys_dup2(fd_t oldfd, fd_t newfd, fd_t* fd_out);
 
 
-err_t sys_accept(fd_t sockfd, sys_sockaddr_t* addr_out, int* fd_out);
+qio_err_t sys_pipe(fd_t* read_fd_out, fd_t* write_fd_out);
 
 
-err_t sys_bind(fd_t sockfd, const sys_sockaddr_t* addr);
+qio_err_t sys_accept(fd_t sockfd, sys_sockaddr_t* addr_out, int* fd_out);
 
 
-err_t sys_connect(fd_t sockfd, const sys_sockaddr_t* addr);
+qio_err_t sys_bind(fd_t sockfd, const sys_sockaddr_t* addr);
+
+
+qio_err_t sys_connect(fd_t sockfd, const sys_sockaddr_t* addr);
 
 
 #ifdef HAS_GETADDRINFO
 /* See comment about this being commented out in sys.c -BLC */
-//err_t sys_getaddrinfo(const char* node, const char* service,
+//qio_err_t sys_getaddrinfo(const char* node, const char* service,
 //                     const struct addrinfo* hints, struct addrinfo ** res);
 
 
@@ -252,49 +252,49 @@ sys_addrinfo_ptr_t sys_getaddrinfo_next(sys_addrinfo_ptr_t a);
 void sys_freeaddrinfo(sys_addrinfo_ptr_t p);
 
 
-err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_out, int flags);
+qio_err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_out, int flags);
 #endif
 
-err_t sys_getpeername(fd_t sockfd, sys_sockaddr_t* addr);
+qio_err_t sys_getpeername(fd_t sockfd, sys_sockaddr_t* addr);
 
 
-err_t sys_getsockname(fd_t sockfd, sys_sockaddr_t* addr);
+qio_err_t sys_getsockname(fd_t sockfd, sys_sockaddr_t* addr);
 
 
-err_t sys_getsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_t* optlen);
+qio_err_t sys_getsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_t* optlen);
 
-err_t sys_listen(fd_t sockfd, int backlog);
-
-
-err_t sys_recv(fd_t sockfd, void* buf, size_t len, int flags, ssize_t* num_recvd_out);
+qio_err_t sys_listen(fd_t sockfd, int backlog);
 
 
-err_t sys_recvfrom(fd_t sockfd, void* buf, size_t len, int flags, sys_sockaddr_t* src_addr_out, ssize_t* num_recvd_out);
+qio_err_t sys_recv(fd_t sockfd, void* buf, size_t len, int flags, ssize_t* num_recvd_out);
 
 
-err_t sys_recvmsg(fd_t sockfd, struct msghdr *msg, int flags, ssize_t* num_recvd_out);
-
-err_t sys_send(fd_t sockfd, const void* buf, int64_t len, int flags, ssize_t* num_sent_out);
+qio_err_t sys_recvfrom(fd_t sockfd, void* buf, size_t len, int flags, sys_sockaddr_t* src_addr_out, ssize_t* num_recvd_out);
 
 
-err_t sys_sendto(fd_t sockfd, const void* buf, int64_t len, int flags, const sys_sockaddr_t* dest_addr, ssize_t* num_sent_out);
+qio_err_t sys_recvmsg(fd_t sockfd, struct msghdr *msg, int flags, ssize_t* num_recvd_out);
+
+qio_err_t sys_send(fd_t sockfd, const void* buf, int64_t len, int flags, ssize_t* num_sent_out);
 
 
-err_t sys_sendmsg(fd_t sockfd, const struct msghdr *msg, int flags, ssize_t* num_sent_out);
+qio_err_t sys_sendto(fd_t sockfd, const void* buf, int64_t len, int flags, const sys_sockaddr_t* dest_addr, ssize_t* num_sent_out);
 
 
-err_t sys_setsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_t optlen);
+qio_err_t sys_sendmsg(fd_t sockfd, const struct msghdr *msg, int flags, ssize_t* num_sent_out);
 
 
-err_t sys_shutdown(fd_t sockfd, int how);
+qio_err_t sys_setsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_t optlen);
 
 
-err_t sys_socket(int domain, int type, int protocol, fd_t* fd_out);
+qio_err_t sys_shutdown(fd_t sockfd, int how);
 
 
-err_t sys_socketpair(int domain, int type, int protocol, fd_t* fd_out_a, fd_t* fd_out_b);
+qio_err_t sys_socket(int domain, int type, int protocol, fd_t* fd_out);
 
-err_t sys_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout, int* nset);
+
+qio_err_t sys_socketpair(int domain, int type, int protocol, fd_t* fd_out_a, fd_t* fd_out_b);
+
+qio_err_t sys_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout, int* nset);
 
 static inline void sys_fd_clr(int fd, fd_set* set) {
   FD_CLR(fd, set);
@@ -310,10 +310,10 @@ static inline void sys_fd_zero(fd_set* set) {
 }
 
 
-err_t sys_unlink(const char* path);
+qio_err_t sys_unlink(const char* path);
 
 // Allocates a string to store the current directory which must be freed.
-err_t sys_getcwd(const char** path_out);
+qio_err_t sys_getcwd(const char** path_out);
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/runtime/src/qio/qbuffer.c
+++ b/runtime/src/qio/qbuffer.c
@@ -64,7 +64,7 @@ void qbytes_free_null(qbytes_t* b) {
 }
 
 void qbytes_free_munmap(qbytes_t* b) {
-  err_t err;
+  qio_err_t err;
 
   /* I don't believe this is required, but
    * I've heard here and there it might be for NFS...

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -3058,7 +3058,7 @@ qioerr _qio_unbuffered_read(qio_channel_t* ch, void* ptr, ssize_t len_in, ssize_
 qioerr _qio_channel_flush_qio_unlocked(qio_channel_t* ch)
 {
   qioerr err, saved_err;
-  err_t errcode;
+  qio_err_t errcode;
 
   err = 0;
 

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -361,7 +361,7 @@ qioerr qio_channel_read_string(const int threadsafe, const int byteorder, const 
   int found_term=0;
   ssize_t len=0;
   ssize_t amt = 0;
-  err_t errcode;
+  qio_err_t errcode;
 
   if( maxlen <= 0 ) maxlen = SSIZE_MAX - 1;
 

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -145,7 +145,7 @@ void sys_set_sys_sockaddr_in6_t(sys_sockaddr_t* addr, sys_in6_addr_t host, u_int
 }
 
 int sys_host_sys_sockaddr_t(sys_sockaddr_t* addr, char* host, socklen_t hostlen, int* length){
-  err_t err_out = 0;
+  qio_err_t err_out = 0;
 
   err_out = getnameinfo((struct sockaddr *)&addr->addr, addr->len, host, hostlen, NULL, 0, NI_NUMERICHOST);
 
@@ -154,7 +154,7 @@ int sys_host_sys_sockaddr_t(sys_sockaddr_t* addr, char* host, socklen_t hostlen,
 }
 
 int sys_port_sys_sockaddr_t(sys_sockaddr_t* addr, uint16_t* numericport){
-  err_t err_out = 0;
+  qio_err_t err_out = 0;
 
   char port[NI_MAXSERV];
   err_out = getnameinfo((struct sockaddr *)&addr->addr, addr->len, NULL, 0, port, sizeof(port), NI_NUMERICSERV);
@@ -169,7 +169,7 @@ int sys_port_sys_sockaddr_t(sys_sockaddr_t* addr, uint16_t* numericport){
 size_t sys_page_size(void)
 {
   static long pagesize = -1;
-  err_t err;
+  qio_err_t err;
 
   // Handle already computed page size.
   if( pagesize > 0 ) return pagesize;
@@ -193,10 +193,10 @@ size_t sys_page_size(void)
 
 
 #if 0
-err_t sys_fseeko(FILE* stream, off_t offset, int whence)
+qio_err_t sys_fseeko(FILE* stream, off_t offset, int whence)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = fseeko(stream, offset, whence);
   if( got == 0 ) {
@@ -208,10 +208,10 @@ err_t sys_fseeko(FILE* stream, off_t offset, int whence)
   return err_out;
 }
 
-err_t sys_ftello(FILE* stream, off_t* offset_out)
+qio_err_t sys_ftello(FILE* stream, off_t* offset_out)
 {
   off_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = ftello(stream);
   if( got != (off_t) -1 ) {
@@ -225,10 +225,10 @@ err_t sys_ftello(FILE* stream, off_t* offset_out)
   return err_out;
 }
 
-err_t sys_fopen(const char* path, const char* mode, FILE** file_out)
+qio_err_t sys_fopen(const char* path, const char* mode, FILE** file_out)
 {
   FILE* got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = fopen(path, mode);
   if( got ) {
@@ -242,10 +242,10 @@ err_t sys_fopen(const char* path, const char* mode, FILE** file_out)
   return err_out;
 }
 
-err_t sys_fdopen(fd_t fd, const char* mode, FILE** file_out)
+qio_err_t sys_fdopen(fd_t fd, const char* mode, FILE** file_out)
 {
   FILE* got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = fdopen(fd, mode);
   if( got ) {
@@ -259,10 +259,10 @@ err_t sys_fdopen(fd_t fd, const char* mode, FILE** file_out)
   return err_out;
 }
 
-err_t sys_fclose(FILE* fp)
+qio_err_t sys_fclose(FILE* fp)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   // might block with SO_LINGER
   STARTING_SLOW_SYSCALL;
@@ -277,10 +277,10 @@ err_t sys_fclose(FILE* fp)
   return err_out;
 }
 
-err_t sys_fread(void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_read)
+qio_err_t sys_fread(void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_read)
 {
   size_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   // might block.
   STARTING_SLOW_SYSCALL;
@@ -297,10 +297,10 @@ err_t sys_fread(void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_
   return err_out;
 }
 
-err_t sys_fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_written)
+qio_err_t sys_fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream, size_t* num_written)
 {
   size_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   // might block.
   STARTING_SLOW_SYSCALL;
@@ -317,10 +317,10 @@ err_t sys_fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream, size_
   return err_out;
 }
 
-err_t sys_fflush(FILE* stream)
+qio_err_t sys_fflush(FILE* stream)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   // might block.
   STARTING_SLOW_SYSCALL;
@@ -336,23 +336,23 @@ err_t sys_fflush(FILE* stream)
 }
 
 
-err_t sys_feof(FILE* stream, int *iseof)
+qio_err_t sys_feof(FILE* stream, int *iseof)
 {
   *iseof = feof(stream);
   return 0;
 }
 
-err_t sys_ferror(FILE* stream)
+qio_err_t sys_ferror(FILE* stream)
 {
   return ferror(stream);
 }
 
 #endif
 
-err_t sys_posix_fadvise(fd_t fd, off_t offset, off_t len, int advice)
+qio_err_t sys_posix_fadvise(fd_t fd, off_t offset, off_t len, int advice)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = 0;
 #if (_XOPEN_SOURCE >= 600 || _POSIX_C_SOURCE >= 200112L)
@@ -365,10 +365,10 @@ err_t sys_posix_fadvise(fd_t fd, off_t offset, off_t len, int advice)
   return err_out;
 }
 
-err_t sys_posix_madvise(void* addr, size_t len, int advice)
+qio_err_t sys_posix_madvise(void* addr, size_t len, int advice)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = 0;
 #ifdef POSIX_MADV_NORMAL
@@ -403,7 +403,7 @@ const char* extended_errors[] = {
 // allocates and returns an error string in *string_out
 // which must be freed.
 static
-err_t sys_strerror_internal(err_t error, char** string_out, size_t extra_space)
+qio_err_t sys_strerror_internal(qio_err_t error, char** string_out, size_t extra_space)
 {
   // normal errors are in normal places.
   // EAI_AGAIN... etc are at 10000 + num.
@@ -411,7 +411,7 @@ err_t sys_strerror_internal(err_t error, char** string_out, size_t extra_space)
   char* buf = NULL;
   char* newbuf;
   const char* errmsg;
-  err_t err_out;
+  qio_err_t err_out;
 
   err_out = 0;
 
@@ -470,15 +470,15 @@ err_t sys_strerror_internal(err_t error, char** string_out, size_t extra_space)
   return err_out;
 }
 
-err_t sys_strerror(err_t error, const char** string_out)
+qio_err_t sys_strerror(qio_err_t error, const char** string_out)
 {
   return sys_strerror_internal(error, (char**) string_out, 0);
 }
 
-const char* sys_strerror_syserr_str(qioerr error, err_t* err_in_strerror)
+const char* sys_strerror_syserr_str(qioerr error, qio_err_t* err_in_strerror)
 {
   char* ret = NULL;
-  err_t code = qio_err_to_int(error);
+  qio_err_t code = qio_err_to_int(error);
   const char* msg = qio_err_msg(error);
   size_t extra_space = 0;
   size_t start = 0;
@@ -501,13 +501,13 @@ const char* sys_strerror_syserr_str(qioerr error, err_t* err_in_strerror)
 }
 
 // returns an allocated string in string_out, which must be freed.
-err_t sys_readlink(const char* path, const char** string_out)
+qio_err_t sys_readlink(const char* path, const char** string_out)
 {
   ssize_t got;
   char* buf = NULL;
   char* newbuf;
   int buf_sz = 248;
-  err_t ret = EINVAL;
+  qio_err_t ret = EINVAL;
 
   while( 1 ) {
     newbuf = (char*) qio_realloc(buf, buf_sz);
@@ -554,10 +554,10 @@ int sys_getenv(const char* name, const char** string_out)
   }
 }
 
-err_t sys_open(const char* pathname, int flags, mode_t mode, fd_t* fd_out)
+qio_err_t sys_open(const char* pathname, int flags, mode_t mode, fd_t* fd_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = open(pathname, flags, mode);
   if( got != -1 ) {
@@ -571,10 +571,10 @@ err_t sys_open(const char* pathname, int flags, mode_t mode, fd_t* fd_out)
   return err_out;
 }
 
-err_t sys_close(fd_t fd)
+qio_err_t sys_close(fd_t fd)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   // might block with SO_LINGER
   STARTING_SLOW_SYSCALL;
@@ -589,10 +589,10 @@ err_t sys_close(fd_t fd)
   return err_out;
 }
 
-err_t sys_lseek(fd_t fd, off_t offset, int whence, off_t* offset_out)
+qio_err_t sys_lseek(fd_t fd, off_t offset, int whence, off_t* offset_out)
 {
   off_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = lseek(fd, offset, whence);
   if( got != (off_t) -1 ) {
@@ -639,10 +639,10 @@ void stat_to_sys_stat(const char* path, sys_stat_t* out_buf, struct stat* in_buf
 }
 
 
-err_t sys_stat(const char* path, sys_stat_t* out_buf)
+qio_err_t sys_stat(const char* path, sys_stat_t* out_buf)
 {
   off_t got;
-  err_t err_out;
+  qio_err_t err_out;
   struct stat in_buf;
 
   got = stat(path, &in_buf);
@@ -656,10 +656,10 @@ err_t sys_stat(const char* path, sys_stat_t* out_buf)
   return err_out;
 }
 
-err_t sys_fstat(fd_t fd, struct stat* buf)
+qio_err_t sys_fstat(fd_t fd, struct stat* buf)
 {
   off_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = fstat(fd, buf);
   if( got != -1 ) {
@@ -671,9 +671,9 @@ err_t sys_fstat(fd_t fd, struct stat* buf)
   return err_out;
 }
 
-err_t sys_lstat(const char* path, struct stat* buf)
+qio_err_t sys_lstat(const char* path, struct stat* buf)
 {  off_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = lstat(path, buf);
   if( got != -1 ) {
@@ -686,12 +686,12 @@ err_t sys_lstat(const char* path, struct stat* buf)
 }
 
 #ifdef SYS_HAS_LLAPI
-err_t sys_lustre_get_stripe_size(fd_t fd, int64_t* size_out)
+qio_err_t sys_lustre_get_stripe_size(fd_t fd, int64_t* size_out)
 {
   struct lov_user_md_v1 *lum;
   size_t lum_size = sizeof(*lum) + LOV_MAX_STRIPE_COUNT * sizeof(struct lov_user_ost_data_v1);
   int rc = 0;
-  err_t err = 0;
+  qio_err_t err = 0;
 
   lum = qio_calloc(lum_size, 1);
 
@@ -713,7 +713,7 @@ err_t sys_lustre_get_stripe_size(fd_t fd, int64_t* size_out)
   return err;
 }
 #else
-err_t sys_lustre_get_stripe_size(fd_t fd, int64_t* size_out)
+qio_err_t sys_lustre_get_stripe_size(fd_t fd, int64_t* size_out)
 {
   return ENOSYS;
 }
@@ -728,9 +728,9 @@ err_t sys_lustre_get_stripe_size(fd_t fd, int64_t* size_out)
 // given file system are set to 0 (and we handle this in safe_inode_cast).
 #define safe_inode_cast(t) (t < 0 ? 0 : (uint64_t)t)
 
-err_t sys_fstatfs(fd_t fd, sys_statfs_t* buf)
+qio_err_t sys_fstatfs(fd_t fd, sys_statfs_t* buf)
 {
-    err_t err_out;
+    qio_err_t err_out;
     int got;
 
 #if SYS_HAS_STATFS
@@ -783,10 +783,10 @@ err_t sys_fstatfs(fd_t fd, sys_statfs_t* buf)
     return err_out;
 }
 
-err_t sys_mkstemp(char* template_, fd_t* fd_out)
+qio_err_t sys_mkstemp(char* template_, fd_t* fd_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = mkstemp(template_);
   if( got != -1 ) {
@@ -800,10 +800,10 @@ err_t sys_mkstemp(char* template_, fd_t* fd_out)
   return err_out;
 }
 
-err_t sys_ftruncate(fd_t fd, off_t length)
+qio_err_t sys_ftruncate(fd_t fd, off_t length)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = ftruncate(fd, length);
   if( got == 0 ) {
@@ -815,10 +815,10 @@ err_t sys_ftruncate(fd_t fd, off_t length)
   return err_out;
 }
 
-err_t sys_sysconf(int name, long* val_out)
+qio_err_t sys_sysconf(int name, long* val_out)
 {
   long got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = sysconf(name);
   if( got != -1 ) {
@@ -832,9 +832,9 @@ err_t sys_sysconf(int name, long* val_out)
   return err_out;
 }
 
-err_t sys_posix_fallocate(fd_t fd, off_t offset, off_t len)
+qio_err_t sys_posix_fallocate(fd_t fd, off_t offset, off_t len)
 {
-  err_t err_out;
+  qio_err_t err_out;
   STARTING_SLOW_SYSCALL;
 #ifdef __linux__
   err_out = posix_fallocate(fd, offset, len);
@@ -845,10 +845,10 @@ err_t sys_posix_fallocate(fd_t fd, off_t offset, off_t len)
   return err_out;
 }
 
-err_t sys_mmap(void* addr, size_t length, int prot, int flags, fd_t fd, off_t offset, void** ret_out)
+qio_err_t sys_mmap(void* addr, size_t length, int prot, int flags, fd_t fd, off_t offset, void** ret_out)
 {
   void* got;
-  err_t err_out;
+  qio_err_t err_out;
   got = mmap(addr, length, prot, flags, fd, offset);
   if( got != MAP_FAILED ) {
     err_out = 0;
@@ -861,10 +861,10 @@ err_t sys_mmap(void* addr, size_t length, int prot, int flags, fd_t fd, off_t of
   return err_out;
 }
 
-err_t sys_munmap(void* addr, size_t length)
+qio_err_t sys_munmap(void* addr, size_t length)
 {
   int rc;
-  err_t err_out;
+  qio_err_t err_out;
   rc = munmap(addr, length);
   if( rc ) {
     err_out = errno;
@@ -876,10 +876,10 @@ err_t sys_munmap(void* addr, size_t length)
 }
 
 
-err_t sys_read(int fd, void* buf, size_t count, ssize_t* num_read_out)
+qio_err_t sys_read(int fd, void* buf, size_t count, ssize_t* num_read_out)
 {
   ssize_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   got = read(fd, buf, count);
@@ -896,10 +896,10 @@ err_t sys_read(int fd, void* buf, size_t count, ssize_t* num_read_out)
   return err_out;
 }
 
-err_t sys_write(int fd, const void* buf, size_t count, ssize_t* num_written_out)
+qio_err_t sys_write(int fd, const void* buf, size_t count, ssize_t* num_written_out)
 {
   ssize_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   got = write(fd, buf, count);
@@ -918,7 +918,7 @@ err_t sys_write(int fd, const void* buf, size_t count, ssize_t* num_written_out)
 
 #ifdef __CYGWIN__
 static
-err_t get_errcode_from_winerr(DWORD win_error)
+qio_err_t get_errcode_from_winerr(DWORD win_error)
 {
   uintptr_t res = cygwin_internal(CW_GET_ERRNO_FROM_WINERROR,
                                   win_error,
@@ -928,11 +928,11 @@ err_t get_errcode_from_winerr(DWORD win_error)
 #endif
 
 static inline
-err_t do_pread(int fd, void* buf, size_t count, off_t offset, ssize_t *num_read)
+qio_err_t do_pread(int fd, void* buf, size_t count, off_t offset, ssize_t *num_read)
 {
 #ifdef REPLACE_CYGWIN_PREADWRITE
   ssize_t got;
-  err_t error;
+  qio_err_t error;
   HANDLE handle = (HANDLE) _get_osfhandle(fd);
   DWORD win_to_read;
   DWORD win_num_read;
@@ -981,11 +981,11 @@ err_t do_pread(int fd, void* buf, size_t count, off_t offset, ssize_t *num_read)
 }
 
 static inline
-err_t do_pwrite(int fd, const void* buf, size_t count, off_t offset, ssize_t *num_written)
+qio_err_t do_pwrite(int fd, const void* buf, size_t count, off_t offset, ssize_t *num_written)
 {
 #ifdef REPLACE_CYGWIN_PREADWRITE
   ssize_t got;
-  err_t error;
+  qio_err_t error;
   HANDLE handle = (HANDLE) _get_osfhandle(fd);
   DWORD win_to_write;
   DWORD win_num_wrote;
@@ -1025,10 +1025,10 @@ err_t do_pwrite(int fd, const void* buf, size_t count, off_t offset, ssize_t *nu
 #endif
 }
 
-err_t sys_pread(int fd, void* buf, size_t count, off_t offset, ssize_t* num_read_out)
+qio_err_t sys_pread(int fd, void* buf, size_t count, off_t offset, ssize_t* num_read_out)
 {
   ssize_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   got = 0;
@@ -1045,10 +1045,10 @@ err_t sys_pread(int fd, void* buf, size_t count, off_t offset, ssize_t* num_read
   return err_out;
 }
 
-err_t sys_pwrite(int fd, const void* buf, size_t count, off_t offset, ssize_t* num_written_out)
+qio_err_t sys_pwrite(int fd, const void* buf, size_t count, off_t offset, ssize_t* num_written_out)
 {
   ssize_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   got = 0;
@@ -1073,11 +1073,11 @@ int64_t sys_iov_total_bytes(const struct iovec* iov, int iovcnt)
   return tot;
 }
 
-err_t sys_readv(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_read_out)
+qio_err_t sys_readv(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_read_out)
 {
   ssize_t got;
   ssize_t got_total;
-  err_t err_out;
+  qio_err_t err_out;
   int i;
   int niovs = IOV_MAX;
 
@@ -1111,11 +1111,11 @@ err_t sys_readv(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_read_
   return err_out;
 }
 
-err_t sys_writev(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_written_out)
+qio_err_t sys_writev(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_written_out)
 {
   ssize_t got;
   ssize_t got_total;
-  err_t err_out;
+  qio_err_t err_out;
   int i;
   int niovs = IOV_MAX;
 
@@ -1148,11 +1148,11 @@ err_t sys_writev(fd_t fd, const struct iovec* iov, int iovcnt, ssize_t* num_writ
 }
 
 #ifdef HAS_PREADV
-err_t sys_preadv(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_read_out)
+qio_err_t sys_preadv(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_read_out)
 {
   ssize_t got;
   ssize_t got_total;
-  err_t err_out;
+  qio_err_t err_out;
   int i;
   int niovs = IOV_MAX;
 
@@ -1191,11 +1191,11 @@ err_t sys_preadv(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_off
 
 #else
 
-err_t sys_preadv(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_read_out)
+qio_err_t sys_preadv(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_read_out)
 {
   ssize_t got;
   ssize_t got_total;
-  err_t err_out;
+  qio_err_t err_out;
   int i;
 
   STARTING_SLOW_SYSCALL;
@@ -1226,11 +1226,11 @@ err_t sys_preadv(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_off
 
 #endif
 #ifdef HAS_PWRITEV
-err_t sys_pwritev(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_written_out)
+qio_err_t sys_pwritev(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_written_out)
 {
   ssize_t got;
   ssize_t got_total;
-  err_t err_out;
+  qio_err_t err_out;
   int i;
   int niovs = IOV_MAX;
 
@@ -1264,11 +1264,11 @@ err_t sys_pwritev(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_of
 
 #else
 
-err_t sys_pwritev(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_written_out)
+qio_err_t sys_pwritev(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_offset, ssize_t* num_written_out)
 {
   ssize_t got;
   ssize_t got_total;
-  err_t err_out;
+  qio_err_t err_out;
   int i;
 
   STARTING_SLOW_SYSCALL;
@@ -1298,10 +1298,10 @@ err_t sys_pwritev(fd_t fd, const struct iovec* iov, int iovcnt, off_t seek_to_of
 
 #endif
 
-err_t sys_fsync(fd_t fd)
+qio_err_t sys_fsync(fd_t fd)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   got = fsync(fd);
@@ -1315,10 +1315,10 @@ err_t sys_fsync(fd_t fd)
   return err_out;
 }
 
-err_t sys_fcntl(fd_t fd, int cmd, int* ret_out)
+qio_err_t sys_fcntl(fd_t fd, int cmd, int* ret_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = fcntl(fd, cmd);
   if( got != -1 ) {
@@ -1332,10 +1332,10 @@ err_t sys_fcntl(fd_t fd, int cmd, int* ret_out)
   return err_out;
 }
 
-err_t sys_fcntl_long(fd_t fd, int cmd, long arg, int* ret_out)
+qio_err_t sys_fcntl_long(fd_t fd, int cmd, long arg, int* ret_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = fcntl(fd, cmd, arg);
   if( got != -1 ) {
@@ -1349,10 +1349,10 @@ err_t sys_fcntl_long(fd_t fd, int cmd, long arg, int* ret_out)
   return err_out;
 }
 
-err_t sys_fcntl_ptr(fd_t fd, int cmd, void* arg, int* ret_out)
+qio_err_t sys_fcntl_ptr(fd_t fd, int cmd, void* arg, int* ret_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = fcntl(fd, cmd, arg);
   if( got != -1 ) {
@@ -1366,10 +1366,10 @@ err_t sys_fcntl_ptr(fd_t fd, int cmd, void* arg, int* ret_out)
   return err_out;
 }
 
-err_t sys_dup(fd_t oldfd, fd_t* fd_out)
+qio_err_t sys_dup(fd_t oldfd, fd_t* fd_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = dup(oldfd);
   if( got != -1 ) {
@@ -1383,10 +1383,10 @@ err_t sys_dup(fd_t oldfd, fd_t* fd_out)
   return err_out;
 }
 
-err_t sys_dup2(int oldfd, int newfd, fd_t* fd_out)
+qio_err_t sys_dup2(int oldfd, int newfd, fd_t* fd_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = dup2(oldfd, newfd);
   if( got != -1 ) {
@@ -1400,10 +1400,10 @@ err_t sys_dup2(int oldfd, int newfd, fd_t* fd_out)
   return err_out;
 }
 
-err_t sys_pipe(fd_t* read_fd_out, fd_t* write_fd_out)
+qio_err_t sys_pipe(fd_t* read_fd_out, fd_t* write_fd_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
   fd_t fds[2];
 
   fds[0] = fds[1] = -1;
@@ -1427,10 +1427,10 @@ poll
 epoll
 */
 
-err_t sys_accept(fd_t sockfd, sys_sockaddr_t* addr_out, fd_t* fd_out)
+qio_err_t sys_accept(fd_t sockfd, sys_sockaddr_t* addr_out, fd_t* fd_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
   socklen_t addr_len = sizeof(sys_sockaddr_storage_t);
 
   STARTING_SLOW_SYSCALL;
@@ -1454,10 +1454,10 @@ err_t sys_accept(fd_t sockfd, sys_sockaddr_t* addr_out, fd_t* fd_out)
   return err_out;
 }
 
-err_t sys_bind(fd_t sockfd, const sys_sockaddr_t* addr)
+qio_err_t sys_bind(fd_t sockfd, const sys_sockaddr_t* addr)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   if( addr->len == 0 ) {
     return EINVAL;
@@ -1473,10 +1473,10 @@ err_t sys_bind(fd_t sockfd, const sys_sockaddr_t* addr)
   return err_out;
 }
 
-err_t sys_connect(fd_t sockfd, const sys_sockaddr_t* addr)
+qio_err_t sys_connect(fd_t sockfd, const sys_sockaddr_t* addr)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
 
@@ -1507,11 +1507,11 @@ err_t sys_connect(fd_t sockfd, const sys_sockaddr_t* addr)
 
    -BLC */
 
-//  err_t sys_getaddrinfo(const char* node, const char* service,
+//  qio_err_t sys_getaddrinfo(const char* node, const char* service,
 //                       const sys_addrinfo_t* hints, sys_addrinfo_t ** res_out)
 //  {
 //    int got;
-//    err_t err_out;
+//    qio_err_t err_out;
 //
 //    STARTING_SLOW_SYSCALL;
 //
@@ -1545,7 +1545,7 @@ void sys_freeaddrinfo(sys_addrinfo_ptr_t p)
   freeaddrinfo(p);
 }
 
-err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_out, int flags)
+qio_err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_out, int flags)
 {
   char* host_buf=0;
   char* new_host_buf;
@@ -1554,7 +1554,7 @@ err_t sys_getnameinfo(const sys_sockaddr_t* addr, char** host_out, char** serv_o
   int host_buf_sz;
   int serv_buf_sz;
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
 #ifdef NI_MAXHOST
   host_buf_sz = NI_MAXHOST;
@@ -1616,10 +1616,10 @@ error:
 
 #endif
 
-err_t sys_getpeername(fd_t sockfd, sys_sockaddr_t* addr)
+qio_err_t sys_getpeername(fd_t sockfd, sys_sockaddr_t* addr)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = getpeername(sockfd, (struct sockaddr*) & addr->addr, & addr->len);
   if( got != -1 ) {
@@ -1631,10 +1631,10 @@ err_t sys_getpeername(fd_t sockfd, sys_sockaddr_t* addr)
   return err_out;
 }
 
-err_t sys_getsockname(fd_t sockfd, sys_sockaddr_t* addr)
+qio_err_t sys_getsockname(fd_t sockfd, sys_sockaddr_t* addr)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = getsockname(sockfd, (struct sockaddr*) & addr->addr, & addr->len);
   if( got != -1 ) {
@@ -1647,10 +1647,10 @@ err_t sys_getsockname(fd_t sockfd, sys_sockaddr_t* addr)
 }
 
 
-err_t sys_getsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_t* optlen)
+qio_err_t sys_getsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_t* optlen)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = getsockopt(sockfd, level, optname, optval, optlen);
   if( got != -1 ) {
@@ -1662,10 +1662,10 @@ err_t sys_getsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_
   return err_out;
 }
 
-err_t sys_setsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_t optlen)
+qio_err_t sys_setsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_t optlen)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = setsockopt(sockfd, level, optname, optval, optlen);
   if( got != -1 ) {
@@ -1678,10 +1678,10 @@ err_t sys_setsockopt(fd_t sockfd, int level, int optname, void* optval, socklen_
 }
 
 
-err_t sys_listen(fd_t sockfd, int backlog)
+qio_err_t sys_listen(fd_t sockfd, int backlog)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = listen(sockfd, backlog);
   if( got != -1 ) {
@@ -1693,10 +1693,10 @@ err_t sys_listen(fd_t sockfd, int backlog)
   return err_out;
 }
 
-err_t sys_recv(fd_t sockfd, void* buf, size_t len, int flags, ssize_t* num_recvd_out)
+qio_err_t sys_recv(fd_t sockfd, void* buf, size_t len, int flags, ssize_t* num_recvd_out)
 {
   ssize_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   got = recv(sockfd, buf, len, flags);
@@ -1712,10 +1712,10 @@ err_t sys_recv(fd_t sockfd, void* buf, size_t len, int flags, ssize_t* num_recvd
   return err_out;
 }
 
-err_t sys_recvfrom(fd_t sockfd, void* buf, size_t len, int flags, sys_sockaddr_t* src_addr_out, ssize_t* num_recvd_out)
+qio_err_t sys_recvfrom(fd_t sockfd, void* buf, size_t len, int flags, sys_sockaddr_t* src_addr_out, ssize_t* num_recvd_out)
 {
   ssize_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   got = recvfrom(sockfd, buf, len, flags, (struct sockaddr*) &src_addr_out->addr, & src_addr_out->len);
@@ -1731,11 +1731,11 @@ err_t sys_recvfrom(fd_t sockfd, void* buf, size_t len, int flags, sys_sockaddr_t
   return err_out;
 }
 
-err_t sys_recvmsg(fd_t sockfd, struct msghdr *msg, int flags, ssize_t* num_recvd_out)
+qio_err_t sys_recvmsg(fd_t sockfd, struct msghdr *msg, int flags, ssize_t* num_recvd_out)
 
 {
   ssize_t got;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   got = recvmsg(sockfd, msg, flags);
@@ -1753,10 +1753,10 @@ err_t sys_recvmsg(fd_t sockfd, struct msghdr *msg, int flags, ssize_t* num_recvd
   return err_out;
 }
 
-err_t sys_send(fd_t sockfd, const void* buf, int64_t len, int flags, ssize_t* num_sent_out)
+qio_err_t sys_send(fd_t sockfd, const void* buf, int64_t len, int flags, ssize_t* num_sent_out)
 {
   ssize_t sent;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   sent = send(sockfd, buf, len, flags);
@@ -1772,10 +1772,10 @@ err_t sys_send(fd_t sockfd, const void* buf, int64_t len, int flags, ssize_t* nu
   return err_out;
 }
 
-err_t sys_sendto(fd_t sockfd, const void* buf, int64_t len, int flags, const sys_sockaddr_t* dest_addr, ssize_t* num_sent_out)
+qio_err_t sys_sendto(fd_t sockfd, const void* buf, int64_t len, int flags, const sys_sockaddr_t* dest_addr, ssize_t* num_sent_out)
 {
   ssize_t sent;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   sent = sendto(sockfd, buf, len, flags, (const struct sockaddr*) &dest_addr->addr, dest_addr->len);
@@ -1791,10 +1791,10 @@ err_t sys_sendto(fd_t sockfd, const void* buf, int64_t len, int flags, const sys
   return err_out;
 }
 
-err_t sys_sendmsg(fd_t sockfd, const struct msghdr *msg, int flags, ssize_t* num_sent_out)
+qio_err_t sys_sendmsg(fd_t sockfd, const struct msghdr *msg, int flags, ssize_t* num_sent_out)
 {
   ssize_t sent;
-  err_t err_out;
+  qio_err_t err_out;
 
   STARTING_SLOW_SYSCALL;
   sent = sendmsg(sockfd, msg, flags);
@@ -1811,10 +1811,10 @@ err_t sys_sendmsg(fd_t sockfd, const struct msghdr *msg, int flags, ssize_t* num
 }
 
 
-err_t sys_shutdown(fd_t sockfd, int how)
+qio_err_t sys_shutdown(fd_t sockfd, int how)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   // might block with SO_LINGER
   STARTING_SLOW_SYSCALL;
@@ -1830,10 +1830,10 @@ err_t sys_shutdown(fd_t sockfd, int how)
 }
 
 
-err_t sys_socket(int domain, int type, int protocol, fd_t* sockfd_out)
+qio_err_t sys_socket(int domain, int type, int protocol, fd_t* sockfd_out)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = socket(domain, type, protocol);
   if( got != -1 ) {
@@ -1848,10 +1848,10 @@ err_t sys_socket(int domain, int type, int protocol, fd_t* sockfd_out)
 
 }
 
-err_t sys_socketpair(int domain, int type, int protocol, fd_t* sockfd_out_a, fd_t* sockfd_out_b)
+qio_err_t sys_socketpair(int domain, int type, int protocol, fd_t* sockfd_out_a, fd_t* sockfd_out_b)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
   int sv[2];
 
   sv[0] = sv[1] = -1;
@@ -1871,9 +1871,9 @@ err_t sys_socketpair(int domain, int type, int protocol, fd_t* sockfd_out_a, fd_
 
 extern void chpl_task_yield(void);
 
-err_t sys_select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, struct timeval* timeout, int* nset) {
+qio_err_t sys_select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, struct timeval* timeout, int* nset) {
   int got_nset;
-  err_t err_out = 0;
+  qio_err_t err_out = 0;
 
   struct timeval first_timeout;
   struct timeval second_timeout = {0};
@@ -1932,10 +1932,10 @@ err_t sys_select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds,
   return err_out;
 }
 
-err_t sys_unlink(const char* path)
+qio_err_t sys_unlink(const char* path)
 {
   int got;
-  err_t err_out;
+  qio_err_t err_out;
 
   got = unlink(path);
   if( got == 0 ) err_out = 0;
@@ -1946,11 +1946,11 @@ err_t sys_unlink(const char* path)
 
 // This routine returns a malloc'd string through its path_out pointer.
 // The caller is responsible for freeing that memory.
-err_t sys_getcwd(const char** path_out)
+qio_err_t sys_getcwd(const char** path_out)
 {
   int   sz  = 128;
   char* buf = (char*) qio_malloc(sz);
-  err_t err = (buf == 0) ? ENOMEM : 0;
+  qio_err_t err = (buf == 0) ? ENOMEM : 0;
 
   // getcwd() returns 0 if the provided buffer is too small
   // If this happens, grow the buffer and try again


### PR DESCRIPTION
TODO: discussion on whether this approach is acceptable and write up this message.