### PR TITLE
print command if execvp fails in chpl_launch_using_exec

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -455,7 +455,7 @@ int chpl_launch_using_exec(const char* command, char * const argv1[], const char
   execvp(command, argv1);
   {
     char msg[256];
-    sprintf(msg, "execvp() failed: %s", strerror(errno));
+    sprintf(msg, "execvp() failed for command %s: %s", command, strerror(errno));
     chpl_internal_error(msg);
   }
   return -1;


### PR DESCRIPTION
If the Chapel launcher fails due to an error in execvp(), it may be helpful to know what command it was trying to run.

Signed-off-by: Josh Milthorpe <josh.milthorpe@gmail.com>