### PR TITLE
set primary context flags before creating context; print CUDA error string in chpl_gpu_cuda_check

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -78,8 +78,8 @@ void chpl_gpu_init() {
     CUcontext context;
 
     CUDA_CALL(cuDeviceGet(&device, i));
-    CUDA_CALL(cuDevicePrimaryCtxRetain(&context, device));
     CUDA_CALL(cuDevicePrimaryCtxSetFlags(device, CU_CTX_SCHED_BLOCKING_SYNC));
+    CUDA_CALL(cuDevicePrimaryCtxRetain(&context, device));
 
     chpl_gpu_primary_ctx[i] = context;
   }

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -45,12 +45,12 @@ static void CHPL_GPU_LOG(const char *str, ...) {
 
 static void chpl_gpu_cuda_check(int err, const char* file, int line) {
   if(err != CUDA_SUCCESS) {
-    const int msg_len = 80;
+    const int msg_len = 256;
     char msg[msg_len];
 
     snprintf(msg, msg_len,
-             "%s:%d: Error calling CUDA function. (Code: %d)",
-             file, line, err);
+             "%s:%d: Error calling CUDA function: %s (Code: %d)",
+             file, line, cudaGetErrorString(err), err);
 
     chpl_internal_error(msg);
   }


### PR DESCRIPTION
These changes are intended as small improvements to Chapel's (preliminary) Nvidia GPU support.

The first change prints the CUDA error string (in addition to the error code) when an error is detected in
chpl_gpu_cuda_check.
The second change reorders the setup calls in chpl_gpu_init to set the primary context flags before creating the context.
Without this change, some versions of CUDA throw CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE (Code: 708) on the call to
cuDevicePrimaryCtxSetFlags().

Signed-off-by: Josh Milthorpe <josh.milthorpe@gmail.com>