### PR TITLE
Update some links to refer to renamed main branch

### DIFF
--- a/test/release/examples/primers/interopWithC.chpl
+++ b/test/release/examples/primers/interopWithC.chpl
@@ -161,10 +161,10 @@ module interopWithC {
    An example of compiling a C program with a generated Chapel library using
   the generated Makefile can be found under the `interopWithC` target in the
   `Makefile
-  <https://github.com/chapel-lang/chapel/blob/master/test/release/examples/primers/Makefile>`_
+  <https://github.com/chapel-lang/chapel/blob/main/test/release/examples/primers/Makefile>`_
   for the primers directory, to build this source file.  An example of using the
   generated Makefile can be seen in `Makefile.cClient
-  <https://github.com/chapel-lang/chapel/blob/master/test/release/examples/primers/Makefile.cClient>`_.
+  <https://github.com/chapel-lang/chapel/blob/main/test/release/examples/primers/Makefile.cClient>`_.
   To build the C client, first run `make interopWithC` then run `make -f
   Makefile.cClient`.
 */ 

--- a/third-party/qthread/qthread-src/test/benchmarks/generic/time_thread_ring.c
+++ b/third-party/qthread/qthread-src/test/benchmarks/generic/time_thread_ring.c
@@ -7,7 +7,7 @@
 
 
 // native qthreads version of thread-ring, based on Chapel's release version
-//   https://github.com/chapel-lang/chapel/blob/master/test/release/examples/benchmarks/shootout/threadring.chpl
+//   https://github.com/chapel-lang/chapel/blob/main/test/release/examples/benchmarks/shootout/threadring.chpl
 
 //static int n = 1000, ntasks = 503;
 static int n = 50000000, ntasks = 503;


### PR DESCRIPTION
There were some links that were referring to outdated branch names in Chapel, so this updates them to refer to `main` instead, which is the new name.