### PR TITLE
Undo third-party link change

### DIFF
--- a/third-party/qthread/qthread-src/test/benchmarks/generic/time_thread_ring.c
+++ b/third-party/qthread/qthread-src/test/benchmarks/generic/time_thread_ring.c
@@ -7,7 +7,7 @@
 
 
 // native qthreads version of thread-ring, based on Chapel's release version
-//   https://github.com/chapel-lang/chapel/blob/main/test/release/examples/benchmarks/shootout/threadring.chpl
+//   https://github.com/chapel-lang/chapel/blob/master/test/release/examples/benchmarks/shootout/threadring.chpl
 
 //static int n = 1000, ntasks = 503;
 static int n = 50000000, ntasks = 503;


### PR DESCRIPTION
In PR #19707, a broken link in the third-party qthreads code was
modified, but since that link is in the third-party directory,
we shouldn't be modifying it in our repo. This PR reverts it back
to the original state.