### PR TITLE
dyno: update errors for bad import/use statements

### DIFF
--- a/compiler/dyno/lib/parsing/ParserContext.h
+++ b/compiler/dyno/lib/parsing/ParserContext.h
@@ -499,12 +499,12 @@ struct ParserContext {
                        owned<AstNode> rename);
 
   AstNode*
-  buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol);
+  buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol, bool isImport);
 
   AstNode*
   buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol,
                         VisibilityClause::LimitationKind limitationKind,
-                        AstList limitations);
+                        AstList limitations, bool isImport);
 
   CommentsAndStmt
   buildImportStmt(YYLTYPE locEverything, Decl::Visibility visibility,

--- a/compiler/dyno/lib/parsing/ParserContextImpl.h
+++ b/compiler/dyno/lib/parsing/ParserContextImpl.h
@@ -1570,11 +1570,16 @@ AstNode* ParserContext::buildNumericLiteral(YYLTYPE location,
 AstNode* ParserContext::
 buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol,
                       VisibilityClause::LimitationKind limitationKind,
-                      AstList limitations) {
+                      AstList limitations, bool isImport) {
   if (!symbol->isAs() && !symbol->isIdentifier() && !symbol->isDot()) {
-    // auto msg = "Expected symbol in visibility clause";
-    // TODO: This error message isn't always correct here, might be an import statement that starts this builder
-    auto msg = "'use' statements must refer to module or enum symbols (e.g., 'use <module>[.<submodule>]*;')";
+    std::string msg;
+    if (isImport) {
+      msg = "'import' statement paths must start with at least one module "
+            "symbol (e.g., 'import <module>[.<submodule>]*;')";
+    } else {
+      msg = "'use' statements must refer to module or enum symbols (e.g., "
+            "'use <module>[.<submodule>]*;')";
+    }
     return raiseError(location, msg);
   }
 
@@ -1582,10 +1587,15 @@ buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol,
     if (expr->isAs() || expr->isIdentifier() || expr->isDot() ||
         expr->isComment()) {
       continue;
-    } else {
+    } else if (limitationKind==VisibilityClause::LimitationKind::EXCEPT ||
+               limitationKind==VisibilityClause::LimitationKind::ONLY) {
       std::string msg = "incorrect expression in '";
       msg += kindToString(limitationKind);
       msg += "' list, identifier expected";
+      return raiseError(location, msg);
+    } else if (limitationKind == VisibilityClause::LimitationKind::BRACES) {
+      std::string msg = "incorrect expression in 'import' for unqualified "
+                        "access, identifier expected";
       return raiseError(location, msg);
     }
   }
@@ -1599,10 +1609,10 @@ buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol,
 }
 
 AstNode* ParserContext::
-buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol) {
+buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol, bool isImport) {
   return buildVisibilityClause(location, std::move(symbol),
                                VisibilityClause::NONE,
-                               AstList());
+                               AstList(), isImport);
 }
 
 
@@ -1628,7 +1638,7 @@ buildForwardingDecl(YYLTYPE location, owned<Attributes> attributes,
 
   auto visClause = buildVisibilityClause(location, std::move(expr),
                                          limitationKind,
-                                         std::move(limitationsList));
+                                         std::move(limitationsList), false);
 
   auto node = ForwardingDecl::build(builder, convertLocation(location),
                                     std::move(attributes),
@@ -1665,12 +1675,12 @@ AstNode* ParserContext::buildAsExpr(YYLTYPE locName, YYLTYPE locRename,
                                     owned<AstNode> name,
                                     owned<AstNode> rename) {
   if (!rename->isIdentifier()) {
-    const char* msg = "Rename in as expression must be identifier";
+    const char* msg = "Rename in 'as' expression must be identifier";
     return raiseError(locRename, msg);
   }
 
   if (!name->isDot() && !name->isIdentifier()) {
-    const char* msg = "Symbol in as expression must be dot or identifier";
+    const char* msg = "Symbol in 'as' expression must be dot or identifier";
     return raiseError(locName, msg);
   }
 
@@ -1747,7 +1757,7 @@ buildSingleUseStmt(YYLTYPE locEverything, YYLTYPE locVisibilityClause,
   auto visClause = buildVisibilityClause(locVisibilityClause,
                                          std::move(name),
                                          limitationKind,
-                                         consumeList(limitationExprs));
+                                         consumeList(limitationExprs), false);
 
   if (visClause->isErroneousExpression()) {
     auto convLoc = convertLocation(locVisibilityClause);

--- a/compiler/dyno/lib/parsing/bison-chpl-lib.cpp
+++ b/compiler/dyno/lib/parsing/bison-chpl-lib.cpp
@@ -7120,7 +7120,7 @@ yyreduce:
   case 72: /* use_renames_ls: expr  */
 #line 1029 "chpl.ypp"
   {
-    auto node = context->buildVisibilityClause((yyloc), toOwned((yyvsp[0].expr)));
+    auto node = context->buildVisibilityClause((yyloc), toOwned((yyvsp[0].expr)), false);
     (yyval.exprList) = context->makeList(node);
   }
 #line 7127 "bison-chpl-lib.cpp"
@@ -7130,7 +7130,7 @@ yyreduce:
 #line 1034 "chpl.ypp"
   {
     auto as = context->buildAsExpr((yylsp[-2]), (yylsp[0]), toOwned((yyvsp[-2].expr)), toOwned((yyvsp[0].expr)));
-    auto node = context->buildVisibilityClause((yyloc), toOwned(as));
+    auto node = context->buildVisibilityClause((yyloc), toOwned(as), false);
     (yyval.exprList) = context->makeList(node);
   }
 #line 7137 "bison-chpl-lib.cpp"
@@ -7141,7 +7141,7 @@ yyreduce:
   {
     auto ident = toOwned(context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)));
     auto as = context->buildAsExpr((yylsp[-2]), (yylsp[0]), toOwned((yyvsp[-2].expr)), std::move(ident));
-    auto node = context->buildVisibilityClause((yyloc), toOwned(as));
+    auto node = context->buildVisibilityClause((yyloc), toOwned(as), false);
     (yyval.exprList) = context->makeList(node);
   }
 #line 7148 "bison-chpl-lib.cpp"
@@ -7150,7 +7150,7 @@ yyreduce:
   case 75: /* use_renames_ls: use_renames_ls TCOMMA expr  */
 #line 1047 "chpl.ypp"
   {
-    auto node = context->buildVisibilityClause((yylsp[0]), toOwned((yyvsp[0].expr)));
+    auto node = context->buildVisibilityClause((yylsp[0]), toOwned((yyvsp[0].expr)), false);
     (yyval.exprList) = context->appendList((yyvsp[-2].exprList), node);
   }
 #line 7157 "bison-chpl-lib.cpp"
@@ -7161,7 +7161,7 @@ yyreduce:
   {
     auto as = context->buildAsExpr((yylsp[-2]), (yylsp[0]), toOwned((yyvsp[-2].expr)), toOwned((yyvsp[0].expr)));
     auto locVisClause = context->makeSpannedLocation((yylsp[-2]), (yylsp[0]));
-    auto node = context->buildVisibilityClause(locVisClause, toOwned(as));
+    auto node = context->buildVisibilityClause(locVisClause, toOwned(as), false);
     (yyval.exprList) = context->appendList((yyvsp[-4].exprList), node);
   }
 #line 7168 "bison-chpl-lib.cpp"
@@ -7173,7 +7173,7 @@ yyreduce:
     auto ident = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr));
     auto as = context->buildAsExpr((yylsp[-2]), (yylsp[0]), toOwned((yyvsp[-2].expr)), toOwned(ident));
     auto locVisClause = context->makeSpannedLocation((yylsp[-2]), (yylsp[0]));
-    auto node = context->buildVisibilityClause(locVisClause, toOwned(as));
+    auto node = context->buildVisibilityClause(locVisClause, toOwned(as), false);
     (yyval.exprList) = context->appendList((yyvsp[-4].exprList), node);
   }
 #line 7180 "bison-chpl-lib.cpp"
@@ -7282,7 +7282,7 @@ yyreduce:
   case 88: /* import_expr: expr  */
 #line 1137 "chpl.ypp"
   {
-    (yyval.expr) = context->buildVisibilityClause((yyloc), toOwned((yyvsp[0].expr)));
+    (yyval.expr) = context->buildVisibilityClause((yyloc), toOwned((yyvsp[0].expr)), true);
   }
 #line 7288 "bison-chpl-lib.cpp"
     break;
@@ -7291,7 +7291,7 @@ yyreduce:
 #line 1141 "chpl.ypp"
   {
     auto dot = Dot::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-2].expr)), (yyvsp[0].uniqueStr)).release();
-    (yyval.expr) = context->buildVisibilityClause((yyloc), toOwned(dot));
+    (yyval.expr) = context->buildVisibilityClause((yyloc), toOwned(dot), true);
   }
 #line 7297 "bison-chpl-lib.cpp"
     break;
@@ -7301,7 +7301,7 @@ yyreduce:
   {
     auto ident = toOwned(context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)));
     auto as = context->buildAsExpr((yylsp[-2]), (yylsp[0]), toOwned((yyvsp[-2].expr)), std::move(ident));
-    (yyval.expr) = context->buildVisibilityClause((yyloc), toOwned(as));
+    (yyval.expr) = context->buildVisibilityClause((yyloc), toOwned(as), true);
   }
 #line 7307 "bison-chpl-lib.cpp"
     break;
@@ -7311,7 +7311,7 @@ yyreduce:
   {
     (yyval.expr) = context->buildVisibilityClause((yyloc), toOwned((yyvsp[-4].expr)),
                                         VisibilityClause::BRACES,
-                                        context->consumeList((yyvsp[-1].exprList)));
+                                        context->consumeList((yyvsp[-1].exprList)), true);
   }
 #line 7317 "bison-chpl-lib.cpp"
     break;

--- a/compiler/dyno/lib/parsing/chpl.ypp
+++ b/compiler/dyno/lib/parsing/chpl.ypp
@@ -1027,32 +1027,32 @@ renames_ls:
 use_renames_ls:
   expr
   {
-    auto node = context->buildVisibilityClause(@$, toOwned($1));
+    auto node = context->buildVisibilityClause(@$, toOwned($1), false);
     $$ = context->makeList(node);
   }
 | expr TAS expr
   {
     auto as = context->buildAsExpr(@1, @3, toOwned($1), toOwned($3));
-    auto node = context->buildVisibilityClause(@$, toOwned(as));
+    auto node = context->buildVisibilityClause(@$, toOwned(as), false);
     $$ = context->makeList(node);
   }
 | expr TAS TUNDERSCORE
   {
     auto ident = toOwned(context->buildIdent(@3, $3));
     auto as = context->buildAsExpr(@1, @3, toOwned($1), std::move(ident));
-    auto node = context->buildVisibilityClause(@$, toOwned(as));
+    auto node = context->buildVisibilityClause(@$, toOwned(as), false);
     $$ = context->makeList(node);
   }
 | use_renames_ls TCOMMA expr
   {
-    auto node = context->buildVisibilityClause(@3, toOwned($3));
+    auto node = context->buildVisibilityClause(@3, toOwned($3), false);
     $$ = context->appendList($1, node);
   }
 | use_renames_ls TCOMMA expr TAS expr
   {
     auto as = context->buildAsExpr(@3, @5, toOwned($3), toOwned($5));
     auto locVisClause = context->makeSpannedLocation(@3, @5);
-    auto node = context->buildVisibilityClause(locVisClause, toOwned(as));
+    auto node = context->buildVisibilityClause(locVisClause, toOwned(as), false);
     $$ = context->appendList($1, node);
   }
 | use_renames_ls TCOMMA expr TAS TUNDERSCORE
@@ -1060,7 +1060,7 @@ use_renames_ls:
     auto ident = context->buildIdent(@5, $5);
     auto as = context->buildAsExpr(@3, @5, toOwned($3), toOwned(ident));
     auto locVisClause = context->makeSpannedLocation(@3, @5);
-    auto node = context->buildVisibilityClause(locVisClause, toOwned(as));
+    auto node = context->buildVisibilityClause(locVisClause, toOwned(as), false);
     $$ = context->appendList($1, node);
   }
 ;
@@ -1135,24 +1135,24 @@ import_stmt:
 import_expr:
   expr
   {
-    $$ = context->buildVisibilityClause(@$, toOwned($1));
+    $$ = context->buildVisibilityClause(@$, toOwned($1), true);
   }
 | expr TDOT all_op_name
   {
     auto dot = Dot::build(BUILDER, LOC(@$), toOwned($1), $3).release();
-    $$ = context->buildVisibilityClause(@$, toOwned(dot));
+    $$ = context->buildVisibilityClause(@$, toOwned(dot), true);
   }
 | expr TAS ident_use
   {
     auto ident = toOwned(context->buildIdent(@3, $3));
     auto as = context->buildAsExpr(@1, @3, toOwned($1), std::move(ident));
-    $$ = context->buildVisibilityClause(@$, toOwned(as));
+    $$ = context->buildVisibilityClause(@$, toOwned(as), true);
   }
 | expr TDOT TLCBR renames_ls TRCBR
   {
     $$ = context->buildVisibilityClause(@$, toOwned($1),
                                         VisibilityClause::BRACES,
-                                        context->consumeList($4));
+                                        context->consumeList($4), true);
   }
 ;
 


### PR DESCRIPTION
This PR updates the handling of `import` and `use` statements
in the dyno parser to emit error messages that align with the
production compiler. 

Previously, when building a `VisibilityClause` in dyno we did
not necessarily know if we were building the clause for a `use`
or an `import` statement, and therefore we could not emit the 
correct error message when the clause was invalid. This change
adds a formal boolean to indicate if the clause is an `import`
and updates some of the error messages emitted when an invalid
syntax is recognized.

TESTING:

- [x] paratest
- [x] paratest with `--dyno`(110 failures vs. 114 on main)

reviewed by @dlongnecke-cray - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>