### PR TITLE
dyno: update error messages for missing/bad submodule names

### DIFF
--- a/compiler/include/astlocs.h
+++ b/compiler/include/astlocs.h
@@ -43,7 +43,7 @@ public:
   astlocT(int linenoArg, const char* filenameArg)
     : filename_(filenameArg), lineno_(linenoArg), id_()
   {
-    if (filenameArg != nullptr)
+    if (filenameArg != nullptr && strlen(filenameArg) > 0)
       assert(astr(filename_) == filename_);
   }
 

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -1173,8 +1173,10 @@ ModuleSymbol* parseIncludedSubmodule(const char* name, const char* path) {
   std::string includeFile = noDot + "/" + name + ".chpl";
 
   const char* modNameFromFile = filenameToModulename(curPath.c_str());
-  if (0 != strcmp(modNameFromFile, currentModuleName))
-    USR_FATAL("Cannot include modules from a module whose name doesn't match its filename");
+  if (0 != strcmp(modNameFromFile, currentModuleName)) {
+    UnresolvedSymExpr* dummy = new UnresolvedSymExpr("module");
+    USR_FATAL(dummy, "Cannot include modules from a module whose name doesn't match its filename");
+  }
 
   ModuleSymbol* ret = nullptr;
   const bool namedOnCommandLine = false;

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -514,7 +514,20 @@ struct Converter {
     auto& loc = chpl::parsing::locateAst(gContext, node);
     INT_ASSERT(!loc.isEmpty());
     auto path = astr(loc.path().c_str());
+    std::string curPath = path;
 
+    // check for module name mismatch as in old parser.cpp
+    // compute the path of the file to include
+    size_t lastDot = curPath.rfind(".");
+    INT_ASSERT(lastDot < curPath.size());
+    std::string noDot = curPath.substr(0, lastDot);
+    std::string includeFile = noDot + "/" + name + ".chpl";
+    if (0 != strcmp(name, currentModuleName)) {
+      // create this dummy node to hold the location information
+      // and avoid "This source location is a guess" messages
+      UnresolvedSymExpr* dummy = new UnresolvedSymExpr("module");
+      USR_FATAL(dummy,"Cannot include modules from a module whose name doesn't match its filename");
+    }
     ModuleSymbol* mod = parseIncludedSubmodule(name, path);
     INT_ASSERT(mod);
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -514,20 +514,6 @@ struct Converter {
     auto& loc = chpl::parsing::locateAst(gContext, node);
     INT_ASSERT(!loc.isEmpty());
     auto path = astr(loc.path().c_str());
-    std::string curPath = path;
-
-    // check for module name mismatch as in old parser.cpp
-    // compute the path of the file to include
-    size_t lastDot = curPath.rfind(".");
-    INT_ASSERT(lastDot < curPath.size());
-    std::string noDot = curPath.substr(0, lastDot);
-    std::string includeFile = noDot + "/" + name + ".chpl";
-    if (0 != strcmp(name, currentModuleName)) {
-      // create this dummy node to hold the location information
-      // and avoid "This source location is a guess" messages
-      UnresolvedSymExpr* dummy = new UnresolvedSymExpr("module");
-      USR_FATAL(dummy,"Cannot include modules from a module whose name doesn't match its filename");
-    }
     ModuleSymbol* mod = parseIncludedSubmodule(name, path);
     INT_ASSERT(mod);
 
@@ -2348,7 +2334,7 @@ struct Converter {
 
     // Push the current module name before descending into children.
     this->modNameStack.push_back(name);
-
+    currentModuleName = this->modNameStack.back();
     auto body = createBlockWithStmts(node->stmts(), style);
 
     // Pop the module name after converting children.

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -607,7 +607,10 @@ static bool printErrorHeader(BaseAST* ast, astlocT astloc) {
       // save the error location for printsSameLocationAsLastError
       last_error_loc = astlocT(linenum, filename);
     }
-    print_error("%s:%d: ", filename, linenum);
+    if (linenum > -1 && strlen(filename) > 0 )
+      print_error("%s:%d: ", filename, linenum);
+    else if (strlen(filename) > 0)
+      print_error("%s: ", filename);
   }
 
   if (err_print) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -607,7 +607,7 @@ static bool printErrorHeader(BaseAST* ast, astlocT astloc) {
       // save the error location for printsSameLocationAsLastError
       last_error_loc = astlocT(linenum, filename);
     }
-    if (linenum > -1 && strlen(filename) > 0 )
+    if (linenum > -1 && strlen(filename) > 0)
       print_error("%s:%d: ", filename, linenum);
     else if (strlen(filename) > 0)
       print_error("%s: ", filename);

--- a/test/visibility/submodule-in-file/errors/WrongModule1.good
+++ b/test/visibility/submodule-in-file/errors/WrongModule1.good
@@ -1,1 +1,1 @@
-error: Cannot include modules from a module whose name doesn't match its filename
+WrongModule1.chpl:2: error: Cannot include modules from a module whose name doesn't match its filename

--- a/test/visibility/submodule-in-file/errors/WrongModule2Wrong.good
+++ b/test/visibility/submodule-in-file/errors/WrongModule2Wrong.good
@@ -1,1 +1,1 @@
-error: Cannot include modules from a module whose name doesn't match its filename
+WrongModule2Wrong.chpl:2: error: Cannot include modules from a module whose name doesn't match its filename


### PR DESCRIPTION
This PR addresses some error messages when an invalid `include`
statement is encountered. We will now print the line number
and filename when trying to parse an include module from a file whose name
name doesn't match its filename. 
The error message printing was also updated to account for empty
filenames and line number equal to -1, such that we won't attempt
to print these values.

TESTING:

- [x] paratest
- [x] partest with `--dyno` (31 vs 33 failures on main)

reviewed by @dlongnecke-cray - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>