### PR TITLE
Handle tuple primitives correctly in the GPU outliner

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -486,7 +486,11 @@ static void outlineGPUKernels() {
                 else {
                   if (CallExpr* parent = toCallExpr(symExpr->parentExpr)) {
                     if (parent->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
-                        parent->isPrimitive(PRIM_GET_MEMBER)) {
+                        parent->isPrimitive(PRIM_GET_MEMBER) ||
+                        parent->isPrimitive(PRIM_SET_MEMBER) ||
+                        parent->isPrimitive(PRIM_GET_SVEC_MEMBER_VALUE) ||
+                        parent->isPrimitive(PRIM_GET_SVEC_MEMBER) ||
+                        parent->isPrimitive(PRIM_SET_SVEC_MEMBER)) {
                       if (symExpr == parent->get(2)) {  // this is a field
                         // do nothing
                       }

--- a/test/gpu/native/tuple.chpl
+++ b/test/gpu/native/tuple.chpl
@@ -1,0 +1,38 @@
+config param tupSize = 5;
+config const n = 10;
+
+on here.getChild(1) {
+  var A: [1..n] int;
+
+  foreach a in A {
+    var x: tupSize*int;
+    for param i in 0..<x.size {
+      x[i] = i;
+    }
+
+    var sum = 0;
+    for i in 0..<x.size {
+      sum += x[i];
+    }
+
+    a = sum;
+
+  }
+
+  writeln(A);
+}
+
+on here.getChild(1) {
+  var A: [1..n] int;
+
+  foreach a in A {
+    var (x,y) = (1,2);
+    var t = (3,4,5);
+
+    a = x+y+t[0]+t[1]+t[2];
+  }
+
+  writeln(A);
+}
+
+

--- a/test/gpu/native/tuple.good
+++ b/test/gpu/native/tuple.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+10 10 10 10 10 10 10 10 10 10
+15 15 15 15 15 15 15 15 15 15


### PR DESCRIPTION
This PR allows tuples to be used in GPU kernels.

This is done by handling `SVEC` primitives in the outliner similarly to the other member primitives.

Test:
- [x] gpu/native