### PR TITLE
Pin XC x86 cce module build to an older mpich

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -356,6 +356,9 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
+
+        # pin to versions of mpich that work with gen_version_cce
+        load_module_version cray-mpich 7.7.19
     }
 
     function load_target_cpu() {


### PR DESCRIPTION
The default mpich is no longer compatible with our cce gen compiler, so
pin to an older one.