### PR TITLE
Recommend `c_array` instead of tuples for C array interoperability.

### DIFF
--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -244,8 +244,9 @@ If an optional ``external-name`` is supplied, it provides the name of
 the symbol(s) in C, where the given Chapel identifier(s) are used to
 refer to them within Chapel code.
 
-Fixed-size C array types can be described within Chapel using its
-homogeneous tuple type. For example, the C typedef 
+Fixed-size C array types can be described within Chapel using the
+``c_array`` type defined by the standard ``CTypes`` module.
+For example, the C typedef 
 
 .. code-block:: chapel
 
@@ -255,7 +256,7 @@ can be described in Chapel using
 
 .. code-block:: chapel
 
-   extern type vec = 3*real(64);
+   extern type vec = c_array(c_double, 3);
 
 .. _Referring_to_External_C_Structs:
 


### PR DESCRIPTION
The `c_array()` type is an explicitly intended and better match for
fixed-size C arrays than a homogeneous tuple is.  Update the interop doc
to say so.
