### PR TITLE
Retire a param string indexing future

### DIFF
--- a/test/parsing/stringLiteralIndex/paramIndexingIsParam.bad
+++ b/test/parsing/stringLiteralIndex/paramIndexingIsParam.bad
@@ -1,2 +1,0 @@
-paramIndexingIsParam.chpl:17: warning: In execution-time string foo()
-paramIndexingIsParam.chpl:18: warning: In execution-time int bar()

--- a/test/parsing/stringLiteralIndex/paramIndexingIsParam.future
+++ b/test/parsing/stringLiteralIndex/paramIndexingIsParam.future
@@ -1,2 +1,0 @@
-feature request: Indexing a param string/bytes with a param int should return a param
-#16895


### PR DESCRIPTION
I missed this one before merging https://github.com/chapel-lang/chapel/pull/19702.

The retired future passes as a test.