### PR TITLE
test: fix text case on warning message

### DIFF
--- a/test/chpldoc/compflags/comment/badClose.doc.good
+++ b/test/chpldoc/compflags/comment/badClose.doc.good
@@ -1,4 +1,4 @@
-Warning:1: chpldoc comment not closed, ignoring comment: This comment is not closed properly
+warning:1: chpldoc comment not closed, ignoring comment: This comment is not closed properly
 .. default-domain:: chpl
 
 .. module:: badClose.doc


### PR DESCRIPTION
This PR fixes a test failure introduced in chapel-lang/chapel/pull/19711
caused by a case change in an explicit warning message. We simply 
change the `.good` file to match the new expected character case.

TESTING:
- [x] Failing test passes
- [x] Failing test passes with `--dyno`

*review not required for trivial change to `.good` file

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>