### PR TITLE
Adding skipif for regex deprecation test

### DIFF
--- a/test/deprecated/regexTertiary.skipif
+++ b/test/deprecated/regexTertiary.skipif
@@ -1,0 +1,1 @@
+CHPL_RE2==none


### PR DESCRIPTION
Adding skipif for regex deprecation test (fix for #19622)