### PR TITLE
Add futures to track desire to include operator keyword in chpldoc output

### DIFF
--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.bad
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.bad
@@ -1,0 +1,111 @@
+.. default-domain:: chpl
+
+.. module:: operatorPrimaryMethods.doc
+
+operatorPrimaryMethods.doc
+==========================
+**Usage**
+
+.. code-block:: chapel
+
+   use operatorPrimaryMethods.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import operatorPrimaryMethods.doc;
+
+.. class:: Foo
+
+   .. attribute:: var x: int
+
+   .. method:: proc type +(a: Foo, b: Foo)
+
+   .. method:: proc type chpl_align(r: range(?i), count: Foo)
+
+   .. method:: proc type chpl_by(r: range(?i), count: Foo)
+
+   .. method:: proc type :(rhs: Foo, type t: Bar)
+
+   .. method:: proc type #(r: range(?i), count: Foo)
+
+   .. method:: proc type /=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: proc type /(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type ==(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type **=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: proc type **(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type >(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type >=(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type !=(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type <~>(const ref ch: channel, const x: Foo) const ref throws
+
+   .. method:: proc type <(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type <=(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type -=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: proc type %(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type %=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: proc type *(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type -(arg: Foo)
+
+   .. method:: proc type +=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: proc type +(arg: Foo)
+
+   .. method:: proc type <<(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type <<=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: proc type >>(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type >>=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: proc type -(lhs: Foo, rhs: Foo)
+
+   .. method:: proc type <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+
+   .. method:: proc type *=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: proc type ~(arg: Foo)
+
+.. class:: Foo2
+
+   .. attribute:: var x: bool
+
+   .. method:: proc type &(lhs: Foo2, rhs: Foo2)
+
+   .. method:: proc type &=(ref lhs: Foo2, rhs: Foo2)
+
+   .. method:: proc type !(arg: Foo2)
+
+   .. method:: proc type |(lhs: Foo2, rhs: Foo2)
+
+   .. method:: proc type |=(ref lhs: Foo2, rhs: Foo2)
+
+   .. method:: proc type ^(lhs: Foo2, rhs: Foo2)
+
+   .. method:: proc type ^=(ref lhs: Foo2, rhs: Foo2)
+
+.. record:: Bar
+
+   .. attribute:: var y: int
+
+   .. method:: proc init=(other: Bar)
+
+   .. method:: proc type =(ref lhs: Bar, rhs: Bar)
+

--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.catfiles
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/operatorPrimaryMethods.doc.rst

--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.chpl
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.chpl
@@ -1,0 +1,218 @@
+use IO;
+
+class Foo {
+  var x: int;
+
+  operator +(a: Foo, b: Foo) {
+    writeln("In DefinesOp.+");
+    return new Foo(a.x + b.x);
+  }
+
+  operator align(r: range(?i), count: Foo) {
+    writeln("In DefinesOp.align");
+    return r align count.x;
+  }
+
+  operator by(r: range(?i), count: Foo) {
+    writeln("In DefinesOp.by");
+    return r by count.x;
+  }
+
+  operator :(rhs: Foo, type t: Bar) {
+    writeln("In DefinesOp.:");
+    return new Bar(rhs.x);
+  }
+
+  operator #(r:range(?i), count: Foo) {
+    writeln("In DefinesOp.#");
+    return r # count.x;
+  }
+
+  operator /=(ref lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp./=");
+    lhs.x /= rhs.x;
+  }
+
+  operator /(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp./");
+    return new Foo(lhs.x / rhs.x);
+  }
+
+  operator ==(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.==");
+    return(lhs.x == rhs.x);
+  }
+
+  operator **=(ref lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.**=");
+    lhs.x **= rhs.x;
+  }
+
+  operator **(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.**");
+    return new Foo(lhs.x ** rhs.x);
+  }
+
+  operator >(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.>");
+    return(lhs.x > rhs.x);
+  }
+
+  operator >=(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.>=");
+    return(lhs.x >= rhs.x);
+  }
+
+  operator !=(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.!=");
+    return(lhs.x != rhs.x);
+  }
+
+  operator <~>(const ref ch: channel, const x: Foo) const ref throws
+    where ch.writing {
+
+    writeln("In DefinesOp.<~>");
+    try ch.readwrite(x.x);
+    return ch;
+  }
+
+  operator <(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.<");
+    return(lhs.x < rhs.x);
+  }
+
+  operator <=(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.<=");
+    return(lhs.x <= rhs.x);
+  }
+
+  operator -=(ref lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.-=");
+    lhs.x -= rhs.x;
+  }
+
+  operator %(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.%");
+    return new Foo(lhs.x % rhs.x);
+  }
+
+  operator %=(ref lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.%=");
+    lhs.x %= rhs.x;
+  }
+
+  operator *(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.*");
+    return new Foo(lhs.x * rhs.x);
+  }
+
+  operator -(arg: Foo) {
+    writeln("In DefinesOp.-");
+    return new Foo(-arg.x);
+  }
+
+  operator +=(ref lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.+=");
+    lhs.x += rhs.x;
+  }
+
+  operator +(arg: Foo) {
+    writeln("In DefinesOp.+");
+    return new Foo(+arg.x);
+  }
+
+  operator <<(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.<<");
+    return new Foo(lhs.x << rhs.x);
+  }
+
+  operator <<=(ref lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.<<=");
+    lhs.x <<= rhs.x;
+  }
+
+  operator >>(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.>>");
+    return new Foo(lhs.x >> rhs.x);
+  }
+
+  operator >>=(ref lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.>>=");
+    lhs.x >>= rhs.x;
+  }
+
+  operator -(lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.-");
+    return new Foo(lhs.x - rhs.x);
+  }
+
+  operator <=>(ref lhs: owned Foo?, ref rhs: owned Foo?) {
+    writeln("In DefinesOp.<=>");
+    var tmp = lhs;
+    lhs = rhs;
+    rhs = tmp;
+  }
+
+  operator *=(ref lhs: Foo, rhs: Foo) {
+    writeln("In DefinesOp.*=");
+    lhs.x *= rhs.x;
+  }
+
+  operator ~(arg: Foo) {
+    writeln("In DefinesOp.~");
+    return new Foo(~arg.x);
+  }
+}
+
+class Foo2 {
+  var x: bool;
+
+  operator &(lhs: Foo2, rhs: Foo2) {
+    writeln("In DefinesOp.&");
+    return new Foo2(lhs.x & rhs.x);
+  }
+
+  operator &=(ref lhs: Foo2, rhs: Foo2) {
+    writeln("In DefinesOp.&=");
+    lhs.x &= rhs.x;
+  }
+
+  operator !(arg: Foo2) {
+    writeln("In DefinesOp.!");
+    return new Foo2(!arg.x);
+  }
+
+  operator |(lhs: Foo2, rhs: Foo2) {
+    writeln("In DefinesOp.|");
+    return new Foo2(lhs.x | rhs.x);
+  }
+
+  operator |=(ref lhs: Foo2, rhs: Foo2) {
+    writeln("In DefinesOp.|=");
+    lhs.x |= rhs.x;
+  }
+
+  operator ^(lhs: Foo2, rhs: Foo2) {
+    writeln("In DefinesOp.^");
+    return new Foo2(lhs.x ^ rhs.x);
+  }
+
+  operator ^=(ref lhs: Foo2, rhs: Foo2) {
+    writeln("In DefinesOp.^=");
+    lhs.x ^= rhs.x;
+  }
+}
+
+record Bar {
+  var y: int;
+
+  proc init=(other: Bar) {
+    writeln("In init=");
+    this.y = other.y;
+  }
+
+  operator =(ref lhs: Bar, rhs: Bar) {
+    writeln("In DefinesOp.=");
+    lhs.y = rhs.y;
+  }
+}

--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.future
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.future
@@ -1,0 +1,2 @@
+Feature request: support operator keyword in chpldoc output
+private #1643

--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.good
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.good
@@ -1,0 +1,111 @@
+.. default-domain:: chpl
+
+.. module:: operatorPrimaryMethods.doc
+
+operatorPrimaryMethods.doc
+==========================
+**Usage**
+
+.. code-block:: chapel
+
+   use operatorPrimaryMethods.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import operatorPrimaryMethods.doc;
+
+.. class:: Foo
+
+   .. attribute:: var x: int
+
+   .. method:: operator +(a: Foo, b: Foo)
+
+   .. method:: operator chpl_align(r: range(?i), count: Foo)
+
+   .. method:: operator chpl_by(r: range(?i), count: Foo)
+
+   .. method:: operator :(rhs: Foo, type t: Bar)
+
+   .. method:: operator #(r: range(?i), count: Foo)
+
+   .. method:: operator /=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: operator /(lhs: Foo, rhs: Foo)
+
+   .. method:: operator ==(lhs: Foo, rhs: Foo)
+
+   .. method:: operator **=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: operator **(lhs: Foo, rhs: Foo)
+
+   .. method:: operator >(lhs: Foo, rhs: Foo)
+
+   .. method:: operator >=(lhs: Foo, rhs: Foo)
+
+   .. method:: operator !=(lhs: Foo, rhs: Foo)
+
+   .. method:: operator <~>(const ref ch: channel, const x: Foo) const ref throws
+
+   .. method:: operator <(lhs: Foo, rhs: Foo)
+
+   .. method:: operator <=(lhs: Foo, rhs: Foo)
+
+   .. method:: operator -=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: operator %(lhs: Foo, rhs: Foo)
+
+   .. method:: operator %=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: operator *(lhs: Foo, rhs: Foo)
+
+   .. method:: operator -(arg: Foo)
+
+   .. method:: operator +=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: operator +(arg: Foo)
+
+   .. method:: operator <<(lhs: Foo, rhs: Foo)
+
+   .. method:: operator <<=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: operator >>(lhs: Foo, rhs: Foo)
+
+   .. method:: operator >>=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: operator -(lhs: Foo, rhs: Foo)
+
+   .. method:: operator <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+
+   .. method:: operator *=(ref lhs: Foo, rhs: Foo)
+
+   .. method:: operator ~(arg: Foo)
+
+.. class:: Foo2
+
+   .. attribute:: var x: bool
+
+   .. method:: operator &(lhs: Foo2, rhs: Foo2)
+
+   .. method:: operator &=(ref lhs: Foo2, rhs: Foo2)
+
+   .. method:: operator !(arg: Foo2)
+
+   .. method:: operator |(lhs: Foo2, rhs: Foo2)
+
+   .. method:: operator |=(ref lhs: Foo2, rhs: Foo2)
+
+   .. method:: operator ^(lhs: Foo2, rhs: Foo2)
+
+   .. method:: operator ^=(ref lhs: Foo2, rhs: Foo2)
+
+.. record:: Bar
+
+   .. attribute:: var y: int
+
+   .. method:: proc init=(other: Bar)
+
+   .. method:: operator =(ref lhs: Bar, rhs: Bar)
+

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.bad
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.bad
@@ -1,0 +1,111 @@
+.. default-domain:: chpl
+
+.. module:: operatorSecondaryMethods.doc
+
+operatorSecondaryMethods.doc
+============================
+**Usage**
+
+.. code-block:: chapel
+
+   use operatorSecondaryMethods.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import operatorSecondaryMethods.doc;
+
+.. class:: Foo
+
+   .. attribute:: var x: int
+
+.. class:: Foo2
+
+   .. attribute:: var x: bool
+
+.. method:: proc type Foo.+(a: Foo, b: Foo)
+
+.. method:: proc type Foo.chpl_align(r: range(?i), count: Foo)
+
+.. method:: proc type Foo2.&(lhs: Foo2, rhs: Foo2)
+
+.. method:: proc type Foo2.&=(ref lhs: Foo2, rhs: Foo2)
+
+.. method:: proc type Foo.chpl_by(r: range(?i), count: Foo)
+
+.. method:: proc type Foo.:(rhs: Foo, type t: Bar)
+
+.. method:: proc type Foo.#(r: range(?i), count: Foo)
+
+.. method:: proc type Foo./=(ref lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo./(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.==(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.**=(ref lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.**(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.>(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.>=(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.!=(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.<~>(const ref ch: channel, const x: Foo) const ref throws
+
+.. method:: proc type Foo.<(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.<=(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.-=(ref lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.%(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.%=(ref lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.*(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.-(arg: Foo)
+
+.. method:: proc type Foo2.!(arg: Foo2)
+
+.. method:: proc type Foo2.|(lhs: Foo2, rhs: Foo2)
+
+.. method:: proc type Foo2.|=(ref lhs: Foo2, rhs: Foo2)
+
+.. method:: proc type Foo.+=(ref lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.+(arg: Foo)
+
+.. method:: proc type Foo.<<(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.<<=(ref lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.>>(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.>>=(ref lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.-(lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.<=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+
+.. method:: proc type Foo.*=(ref lhs: Foo, rhs: Foo)
+
+.. method:: proc type Foo.~(arg: Foo)
+
+.. method:: proc type Foo2.^(lhs: Foo2, rhs: Foo2)
+
+.. method:: proc type Foo2.^=(ref lhs: Foo2, rhs: Foo2)
+
+.. record:: Bar
+
+   .. attribute:: var y: int
+
+.. method:: proc Bar.init=(other: Bar)
+
+.. method:: proc type Bar.=(ref lhs: Bar, rhs: Bar)
+

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.catfiles
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/operatorSecondaryMethods.doc.rst

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.chpl
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.chpl
@@ -1,0 +1,218 @@
+class Foo {
+  var x: int;
+}
+
+class Foo2 {
+  var x: bool;
+}
+
+operator Foo.+(a: Foo, b: Foo) {
+  writeln("In DefinesOp.+");
+  return new Foo(a.x + b.x);
+}
+
+operator Foo.align(r: range(?i), count: Foo) {
+  writeln("In DefinesOp.align");
+  return r align count.x;
+}
+
+operator Foo2.&(lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.&");
+  return new Foo2(lhs.x & rhs.x);
+}
+
+operator Foo2.&=(ref lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.&=");
+  lhs.x &= rhs.x;
+}
+
+operator Foo.by(r: range(?i), count: Foo) {
+  writeln("In DefinesOp.by");
+  return r by count.x;
+}
+
+operator Foo.:(rhs: Foo, type t: Bar) {
+  writeln("In DefinesOp.:");
+  return new Bar(rhs.x);
+}
+
+operator Foo.#(r:range(?i), count: Foo) {
+  writeln("In DefinesOp.#");
+  return r # count.x;
+}
+
+operator Foo./=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp./=");
+  lhs.x /= rhs.x;
+}
+
+operator Foo./(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp./");
+  return new Foo(lhs.x / rhs.x);
+}
+
+operator Foo.==(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.==");
+  return(lhs.x == rhs.x);
+}
+
+operator Foo.**=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.**=");
+  lhs.x **= rhs.x;
+}
+
+operator Foo.**(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.**");
+  return new Foo(lhs.x ** rhs.x);
+}
+
+operator Foo.>(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.>");
+  return(lhs.x > rhs.x);
+}
+
+operator Foo.>=(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.>=");
+  return(lhs.x >= rhs.x);
+}
+
+operator Foo.!=(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.!=");
+  return(lhs.x != rhs.x);
+}
+
+use IO;
+
+operator Foo.<~>(const ref ch: channel, const x: Foo) const ref throws
+  where ch.writing {
+
+  writeln("In DefinesOp.<~>");
+  try ch.readwrite(x.x);
+  return ch;
+}
+
+operator Foo.<(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.<");
+  return(lhs.x < rhs.x);
+}
+
+operator Foo.<=(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.<=");
+  return(lhs.x <= rhs.x);
+}
+
+operator Foo.-=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.-=");
+  lhs.x -= rhs.x;
+}
+
+operator Foo.%(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.%");
+  return new Foo(lhs.x % rhs.x);
+}
+
+operator Foo.%=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.%=");
+  lhs.x %= rhs.x;
+}
+
+operator Foo.*(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.*");
+  return new Foo(lhs.x * rhs.x);
+}
+
+operator Foo.-(arg: Foo) {
+  writeln("In DefinesOp.-");
+  return new Foo(-arg.x);
+}
+
+operator Foo2.!(arg: Foo2) {
+  writeln("In DefinesOp.!");
+  return new Foo2(!arg.x);
+}
+
+operator Foo2.|(lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.|");
+  return new Foo2(lhs.x | rhs.x);
+}
+
+operator Foo2.|=(ref lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.|=");
+  lhs.x |= rhs.x;
+}
+
+operator Foo.+=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.+=");
+  lhs.x += rhs.x;
+}
+
+operator Foo.+(arg: Foo) {
+  writeln("In DefinesOp.+");
+  return new Foo(+arg.x);
+}
+
+operator Foo.<<(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.<<");
+  return new Foo(lhs.x << rhs.x);
+}
+
+operator Foo.<<=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.<<=");
+  lhs.x <<= rhs.x;
+}
+
+operator Foo.>>(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.>>");
+  return new Foo(lhs.x >> rhs.x);
+}
+
+operator Foo.>>=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.>>=");
+  lhs.x >>= rhs.x;
+}
+
+operator Foo.-(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.-");
+  return new Foo(lhs.x - rhs.x);
+}
+
+operator Foo.<=>(ref lhs: owned Foo?, ref rhs: owned Foo?) {
+  writeln("In DefinesOp.<=>");
+  var tmp = lhs;
+  lhs = rhs;
+  rhs = tmp;
+}
+
+operator Foo.*=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.*=");
+  lhs.x *= rhs.x;
+}
+
+operator Foo.~(arg: Foo) {
+  writeln("In DefinesOp.~");
+  return new Foo(~arg.x);
+}
+
+operator Foo2.^(lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.^");
+  return new Foo2(lhs.x ^ rhs.x);
+}
+
+operator Foo2.^=(ref lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.^=");
+  lhs.x ^= rhs.x;
+}
+
+record Bar {
+  var y: int;
+}
+
+proc Bar.init=(other: Bar) {
+  writeln("In init=");
+  this.y = other.y;
+}
+
+operator Bar.=(ref lhs: Bar, rhs: Bar) {
+  writeln("In DefinesOp.=");
+  lhs.y = rhs.y;
+}

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.future
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.future
@@ -1,0 +1,2 @@
+Feature request: support operator keyword in chpldoc output
+private #1643

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.good
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.good
@@ -1,0 +1,111 @@
+.. default-domain:: chpl
+
+.. module:: operatorSecondaryMethods.doc
+
+operatorSecondaryMethods.doc
+============================
+**Usage**
+
+.. code-block:: chapel
+
+   use operatorSecondaryMethods.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import operatorSecondaryMethods.doc;
+
+.. class:: Foo
+
+   .. attribute:: var x: int
+
+.. class:: Foo2
+
+   .. attribute:: var x: bool
+
+.. method:: operator Foo.+(a: Foo, b: Foo)
+
+.. method:: operator Foo.chpl_align(r: range(?i), count: Foo)
+
+.. method:: operator Foo2.&(lhs: Foo2, rhs: Foo2)
+
+.. method:: operator Foo2.&=(ref lhs: Foo2, rhs: Foo2)
+
+.. method:: operator Foo.chpl_by(r: range(?i), count: Foo)
+
+.. method:: operator Foo.:(rhs: Foo, type t: Bar)
+
+.. method:: operator Foo.#(r: range(?i), count: Foo)
+
+.. method:: operator Foo./=(ref lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo./(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.==(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.**=(ref lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.**(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.>(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.>=(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.!=(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.<~>(const ref ch: channel, const x: Foo) const ref throws
+
+.. method:: operator Foo.<(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.<=(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.-=(ref lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.%(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.%=(ref lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.*(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.-(arg: Foo)
+
+.. method:: operator Foo2.!(arg: Foo2)
+
+.. method:: operator Foo2.|(lhs: Foo2, rhs: Foo2)
+
+.. method:: operator Foo2.|=(ref lhs: Foo2, rhs: Foo2)
+
+.. method:: operator Foo.+=(ref lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.+(arg: Foo)
+
+.. method:: operator Foo.<<(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.<<=(ref lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.>>(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.>>=(ref lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.-(lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.<=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+
+.. method:: operator Foo.*=(ref lhs: Foo, rhs: Foo)
+
+.. method:: operator Foo.~(arg: Foo)
+
+.. method:: operator Foo2.^(lhs: Foo2, rhs: Foo2)
+
+.. method:: operator Foo2.^=(ref lhs: Foo2, rhs: Foo2)
+
+.. record:: Bar
+
+   .. attribute:: var y: int
+
+.. method:: proc Bar.init=(other: Bar)
+
+.. method:: operator Bar.=(ref lhs: Bar, rhs: Bar)
+

--- a/test/chpldoc/functions/operators.doc.bad
+++ b/test/chpldoc/functions/operators.doc.bad
@@ -1,0 +1,111 @@
+.. default-domain:: chpl
+
+.. module:: operators.doc
+
+operators.doc
+=============
+**Usage**
+
+.. code-block:: chapel
+
+   use operators.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import operators.doc;
+
+.. class:: Foo
+
+   .. attribute:: var x: int
+
+.. class:: Foo2
+
+   .. attribute:: var x: bool
+
+.. function:: proc +(a: Foo, b: Foo)
+
+.. function:: proc chpl_align(r: range(?i), count: Foo)
+
+.. function:: proc &(lhs: Foo2, rhs: Foo2)
+
+.. function:: proc &=(ref lhs: Foo2, rhs: Foo2)
+
+.. function:: proc chpl_by(r: range(?i), count: Foo)
+
+.. function:: proc :(rhs: Foo, type t: Bar)
+
+.. function:: proc #(r: range(?i), count: Foo)
+
+.. function:: proc /=(ref lhs: Foo, rhs: Foo)
+
+.. function:: proc /(lhs: Foo, rhs: Foo)
+
+.. function:: proc ==(lhs: Foo, rhs: Foo)
+
+.. function:: proc **=(ref lhs: Foo, rhs: Foo)
+
+.. function:: proc **(lhs: Foo, rhs: Foo)
+
+.. function:: proc >(lhs: Foo, rhs: Foo)
+
+.. function:: proc >=(lhs: Foo, rhs: Foo)
+
+.. function:: proc !=(lhs: Foo, rhs: Foo)
+
+.. function:: proc <~>(const ref ch: channel, const x: Foo) const ref throws
+
+.. function:: proc <(lhs: Foo, rhs: Foo)
+
+.. function:: proc <=(lhs: Foo, rhs: Foo)
+
+.. function:: proc -=(ref lhs: Foo, rhs: Foo)
+
+.. function:: proc %(lhs: Foo, rhs: Foo)
+
+.. function:: proc %=(ref lhs: Foo, rhs: Foo)
+
+.. function:: proc *(lhs: Foo, rhs: Foo)
+
+.. function:: proc -(arg: Foo)
+
+.. function:: proc !(arg: Foo2)
+
+.. function:: proc |(lhs: Foo2, rhs: Foo2)
+
+.. function:: proc |=(ref lhs: Foo2, rhs: Foo2)
+
+.. function:: proc +=(ref lhs: Foo, rhs: Foo)
+
+.. function:: proc +(arg: Foo)
+
+.. function:: proc <<(lhs: Foo, rhs: Foo)
+
+.. function:: proc <<=(ref lhs: Foo, rhs: Foo)
+
+.. function:: proc >>(lhs: Foo, rhs: Foo)
+
+.. function:: proc >>=(ref lhs: Foo, rhs: Foo)
+
+.. function:: proc -(lhs: Foo, rhs: Foo)
+
+.. function:: proc <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+
+.. function:: proc *=(ref lhs: Foo, rhs: Foo)
+
+.. function:: proc ~(arg: Foo)
+
+.. function:: proc ^(lhs: Foo2, rhs: Foo2)
+
+.. function:: proc ^=(ref lhs: Foo2, rhs: Foo2)
+
+.. record:: Bar
+
+   .. attribute:: var y: int
+
+.. method:: proc Bar.init=(other: Bar)
+
+.. function:: proc =(ref lhs: Bar, rhs: Bar)
+

--- a/test/chpldoc/functions/operators.doc.catfiles
+++ b/test/chpldoc/functions/operators.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/operators.doc.rst

--- a/test/chpldoc/functions/operators.doc.chpl
+++ b/test/chpldoc/functions/operators.doc.chpl
@@ -1,0 +1,218 @@
+class Foo {
+  var x: int;
+}
+
+class Foo2 {
+  var x: bool;
+}
+
+operator +(a: Foo, b: Foo) {
+  writeln("In DefinesOp.+");
+  return new Foo(a.x + b.x);
+}
+
+operator align(r: range(?i), count: Foo) {
+  writeln("In DefinesOp.align");
+  return r align count.x;
+}
+
+operator &(lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.&");
+  return new Foo2(lhs.x & rhs.x);
+}
+
+operator &=(ref lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.&=");
+  lhs.x &= rhs.x;
+}
+
+operator by(r: range(?i), count: Foo) {
+  writeln("In DefinesOp.by");
+  return r by count.x;
+}
+
+operator :(rhs: Foo, type t: Bar) {
+  writeln("In DefinesOp.:");
+  return new Bar(rhs.x);
+}
+
+operator #(r:range(?i), count: Foo) {
+  writeln("In DefinesOp.#");
+  return r # count.x;
+}
+
+operator /=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp./=");
+  lhs.x /= rhs.x;
+}
+
+operator /(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp./");
+  return new Foo(lhs.x / rhs.x);
+}
+
+operator ==(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.==");
+  return(lhs.x == rhs.x);
+}
+
+operator **=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.**=");
+  lhs.x **= rhs.x;
+}
+
+operator **(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.**");
+  return new Foo(lhs.x ** rhs.x);
+}
+
+operator >(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.>");
+  return(lhs.x > rhs.x);
+}
+
+operator >=(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.>=");
+  return(lhs.x >= rhs.x);
+}
+
+operator !=(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.!=");
+  return(lhs.x != rhs.x);
+}
+
+use IO;
+
+operator <~>(const ref ch: channel, const x: Foo) const ref throws
+  where ch.writing {
+
+  writeln("In DefinesOp.<~>");
+  try ch.readwrite(x.x);
+  return ch;
+}
+
+operator <(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.<");
+  return(lhs.x < rhs.x);
+}
+
+operator <=(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.<=");
+  return(lhs.x <= rhs.x);
+}
+
+operator -=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.-=");
+  lhs.x -= rhs.x;
+}
+
+operator %(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.%");
+  return new Foo(lhs.x % rhs.x);
+}
+
+operator %=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.%=");
+  lhs.x %= rhs.x;
+}
+
+operator *(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.*");
+  return new Foo(lhs.x * rhs.x);
+}
+
+operator -(arg: Foo) {
+  writeln("In DefinesOp.-");
+  return new Foo(-arg.x);
+}
+
+operator !(arg: Foo2) {
+  writeln("In DefinesOp.!");
+  return new Foo2(!arg.x);
+}
+
+operator |(lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.|");
+  return new Foo2(lhs.x | rhs.x);
+}
+
+operator |=(ref lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.|=");
+  lhs.x |= rhs.x;
+}
+
+operator +=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.+=");
+  lhs.x += rhs.x;
+}
+
+operator +(arg: Foo) {
+  writeln("In DefinesOp.+");
+  return new Foo(+arg.x);
+}
+
+operator <<(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.<<");
+  return new Foo(lhs.x << rhs.x);
+}
+
+operator <<=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.<<=");
+  lhs.x <<= rhs.x;
+}
+
+operator >>(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.>>");
+  return new Foo(lhs.x >> rhs.x);
+}
+
+operator >>=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.>>=");
+  lhs.x >>= rhs.x;
+}
+
+operator -(lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.-");
+  return new Foo(lhs.x - rhs.x);
+}
+
+operator <=>(ref lhs: owned Foo?, ref rhs: owned Foo?) {
+  writeln("In DefinesOp.<=>");
+  var tmp = lhs;
+  lhs = rhs;
+  rhs = tmp;
+}
+
+operator *=(ref lhs: Foo, rhs: Foo) {
+  writeln("In DefinesOp.*=");
+  lhs.x *= rhs.x;
+}
+
+operator ~(arg: Foo) {
+  writeln("In DefinesOp.~");
+  return new Foo(~arg.x);
+}
+
+operator ^(lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.^");
+  return new Foo2(lhs.x ^ rhs.x);
+}
+
+operator ^=(ref lhs: Foo2, rhs: Foo2) {
+  writeln("In DefinesOp.^=");
+  lhs.x ^= rhs.x;
+}
+
+record Bar {
+  var y: int;
+}
+
+proc Bar.init=(other: Bar) {
+  writeln("In init=");
+  this.y = other.y;
+}
+
+operator =(ref lhs: Bar, rhs: Bar) {
+  writeln("In DefinesOp.=");
+  lhs.y = rhs.y;
+}

--- a/test/chpldoc/functions/operators.doc.future
+++ b/test/chpldoc/functions/operators.doc.future
@@ -1,0 +1,2 @@
+Feature request: support operator keyword in chpldoc output
+private #1643

--- a/test/chpldoc/functions/operators.doc.good
+++ b/test/chpldoc/functions/operators.doc.good
@@ -1,0 +1,111 @@
+.. default-domain:: chpl
+
+.. module:: operators.doc
+
+operators.doc
+=============
+**Usage**
+
+.. code-block:: chapel
+
+   use operators.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import operators.doc;
+
+.. class:: Foo
+
+   .. attribute:: var x: int
+
+.. class:: Foo2
+
+   .. attribute:: var x: bool
+
+.. function:: operator +(a: Foo, b: Foo)
+
+.. function:: operator chpl_align(r: range(?i), count: Foo)
+
+.. function:: operator &(lhs: Foo2, rhs: Foo2)
+
+.. function:: operator &=(ref lhs: Foo2, rhs: Foo2)
+
+.. function:: operator chpl_by(r: range(?i), count: Foo)
+
+.. function:: operator :(rhs: Foo, type t: Bar)
+
+.. function:: operator #(r: range(?i), count: Foo)
+
+.. function:: operator /=(ref lhs: Foo, rhs: Foo)
+
+.. function:: operator /(lhs: Foo, rhs: Foo)
+
+.. function:: operator ==(lhs: Foo, rhs: Foo)
+
+.. function:: operator **=(ref lhs: Foo, rhs: Foo)
+
+.. function:: operator **(lhs: Foo, rhs: Foo)
+
+.. function:: operator >(lhs: Foo, rhs: Foo)
+
+.. function:: operator >=(lhs: Foo, rhs: Foo)
+
+.. function:: operator !=(lhs: Foo, rhs: Foo)
+
+.. function:: operator <~>(const ref ch: channel, const x: Foo) const ref throws
+
+.. function:: operator <(lhs: Foo, rhs: Foo)
+
+.. function:: operator <=(lhs: Foo, rhs: Foo)
+
+.. function:: operator -=(ref lhs: Foo, rhs: Foo)
+
+.. function:: operator %(lhs: Foo, rhs: Foo)
+
+.. function:: operator %=(ref lhs: Foo, rhs: Foo)
+
+.. function:: operator *(lhs: Foo, rhs: Foo)
+
+.. function:: operator -(arg: Foo)
+
+.. function:: operator !(arg: Foo2)
+
+.. function:: operator |(lhs: Foo2, rhs: Foo2)
+
+.. function:: operator |=(ref lhs: Foo2, rhs: Foo2)
+
+.. function:: operator +=(ref lhs: Foo, rhs: Foo)
+
+.. function:: operator +(arg: Foo)
+
+.. function:: operator <<(lhs: Foo, rhs: Foo)
+
+.. function:: operator <<=(ref lhs: Foo, rhs: Foo)
+
+.. function:: operator >>(lhs: Foo, rhs: Foo)
+
+.. function:: operator >>=(ref lhs: Foo, rhs: Foo)
+
+.. function:: operator -(lhs: Foo, rhs: Foo)
+
+.. function:: operator <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+
+.. function:: operator *=(ref lhs: Foo, rhs: Foo)
+
+.. function:: operator ~(arg: Foo)
+
+.. function:: operator ^(lhs: Foo2, rhs: Foo2)
+
+.. function:: operator ^=(ref lhs: Foo2, rhs: Foo2)
+
+.. record:: Bar
+
+   .. attribute:: var y: int
+
+.. method:: proc Bar.init=(other: Bar)
+
+.. function:: operator =(ref lhs: Bar, rhs: Bar)
+


### PR DESCRIPTION
Covers standalone, primary, and secondary operator methods

Passed a fresh checkout of the tests