### PR TITLE
Add skipif for test that relies on iterator inlining

### DIFF
--- a/test/errhandling/iterators/try-in-yield.skipif
+++ b/test/errhandling/iterators/try-in-yield.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline


### PR DESCRIPTION
... because iterator inlining is disabled with `--baseline`.

Test is skipped correctly with this skipif.