### PR TITLE
dyno: adjust scope resolve to avoid recursive queries

### DIFF
--- a/compiler/dyno/include/chpl/resolution/scope-queries.h
+++ b/compiler/dyno/include/chpl/resolution/scope-queries.h
@@ -43,13 +43,10 @@ namespace resolution {
   const Scope* scopeForModule(Context* context, ID moduleId);
 
   /**
-    Given a Scope, compute the ResolvedVisibilityScope
-    by processing the use/import statements in order.
-
-    If the scope didn't have use/imports, returns nullptr.
+    Gather the IDs of Use/Import statements within a scope.
    */
-  const ResolvedVisibilityScope* resolveVisibilityStmts(Context* context,
-                                                        const Scope* scope);
+  const std::vector<ID>& findUseImportStmts(Context* context,
+                                            const Scope* scope);
 
   /**
     Given an AstNode and a Scope, return the things

--- a/compiler/dyno/include/chpl/resolution/scope-types.h
+++ b/compiler/dyno/include/chpl/resolution/scope-types.h
@@ -391,61 +391,6 @@ class VisibilitySymbols {
   }
 };
 
-/**
- Stores the result of in-order resolution of use/import
- statements.
-*/
-// This would not be separate from resolving variables
-// if the language design was that symbols available due to use/import
-// are only available after that statement (and in that case this analysis
-// could fold into the logic about variable declarations).
-#if 0
-class ResolvedVisibilityScope {
- private:
-  const Scope* scope_;
-  std::vector<VisibilitySymbols> visibilityClauses_;
-
- public:
-  using VisibilitySymbolsIterable = Iterable<std::vector<VisibilitySymbols>>;
-
-  ResolvedVisibilityScope(const Scope* scope)
-    : scope_(scope)
-  { }
-
-  /** Return the scope */
-  const Scope *scope() const { return scope_; }
-
-  /** Return an iterator over the visibility clauses */
-  VisibilitySymbolsIterable visibilityClauses() const {
-    return VisibilitySymbolsIterable(visibilityClauses_);
-  }
-
-  /** Add a visibility clause */
-  void addVisibilityClause(const VisibilitySymbols &clause) {
-    // TODO are we missing the whole point of emplace_back here (see callsites)
-    visibilityClauses_.push_back(clause);
-  }
-
-  bool operator==(const ResolvedVisibilityScope& other) const {
-    return scope_ == other.scope_ &&
-           visibilityClauses_ == other.visibilityClauses_;
-  }
-  bool operator!=(const ResolvedVisibilityScope& other) const {
-    return !(*this == other);
-  }
-  static bool update(owned<ResolvedVisibilityScope>& keep,
-                     owned<ResolvedVisibilityScope>& addin) {
-    return defaultUpdateOwned(keep, addin);
-  }
-  void mark(Context* context) const {
-    context->markPointer(scope_);
-    for (auto sym : visibilityClauses_) {
-      sym.mark(context);
-    }
-  }
-};
-#endif
-
 enum {
   LOOKUP_DECLS = 1,
   LOOKUP_IMPORT_AND_USE = 2,

--- a/compiler/dyno/include/chpl/resolution/scope-types.h
+++ b/compiler/dyno/include/chpl/resolution/scope-types.h
@@ -294,6 +294,12 @@ class Scope {
 };
 
 /**
+  A path of which use/import statements are currently being resolved
+  (in order to support recursive use/import)
+ */
+using VisibilityPath = std::vector<ID>;
+
+/**
  This class supports both `use` and `import`.
  It stores a normalized form of the symbols made available
  by a use/import clause.
@@ -371,6 +377,11 @@ class VisibilitySymbols {
     std::swap(isPrivate_, other.isPrivate_);
   }
 
+  static bool update(VisibilitySymbols& keep,
+                     VisibilitySymbols& addin) {
+    return defaultUpdate(keep, addin);
+  }
+
   void mark(Context* context) const {
     symbolId_.mark(context);
     for (auto p : names_) {
@@ -388,6 +399,7 @@ class VisibilitySymbols {
 // if the language design was that symbols available due to use/import
 // are only available after that statement (and in that case this analysis
 // could fold into the logic about variable declarations).
+#if 0
 class ResolvedVisibilityScope {
  private:
   const Scope* scope_;
@@ -432,6 +444,7 @@ class ResolvedVisibilityScope {
     }
   }
 };
+#endif
 
 enum {
   LOOKUP_DECLS = 1,


### PR DESCRIPTION
For https://github.com/Cray/chapel-private/issues/3290

Recursive queries as implemented today present some challenge for the
query system and we have some problems with incremental compilation when
they are used. In particular when the incremental framework recomputes a
query (to check a dependency) it does not currently handle the
possibility of a recursive query. At the same time, the current approach
can have partial results and these are mutated partway though - so there
might be a case where the partial result used by some other query is
different in one case or another (for example, if some, but not all, of
the dependent queries could be reused, the partial data might or might
not appoear visible at all).

There are currently 3 locations that use recursive queries today:
 * scope resolution of what module is use/imported
 * resolving the module-level statements in a module (not including procs)
 * resolving the fields of recursive types

This commit changes the first case to no longer use a recursive query.
Instead, changes approach to having a query to resolve an individual
use/import statement. That query takes in a "path" of which use/import
statements are currently being resolved, so that the resolution of the
use/import statements can consider only the symbols available up to that
point.

Reviewed by @dlongnecke-cray - thanks!