### PR TITLE
Update expected output for chpldoc operator futures at Paul's suggestion

### DIFF
--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.good
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.good
@@ -23,9 +23,9 @@ or
 
    .. method:: operator +(a: Foo, b: Foo)
 
-   .. method:: operator chpl_align(r: range(?i), count: Foo)
+   .. method:: operator align(r: range(?i), count: Foo)
 
-   .. method:: operator chpl_by(r: range(?i), count: Foo)
+   .. method:: operator by(r: range(?i), count: Foo)
 
    .. method:: operator :(rhs: Foo, type t: Bar)
 

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.good
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.good
@@ -27,13 +27,13 @@ or
 
 .. method:: operator Foo.+(a: Foo, b: Foo)
 
-.. method:: operator Foo.chpl_align(r: range(?i), count: Foo)
+.. method:: operator Foo.align(r: range(?i), count: Foo)
 
 .. method:: operator Foo2.&(lhs: Foo2, rhs: Foo2)
 
 .. method:: operator Foo2.&=(ref lhs: Foo2, rhs: Foo2)
 
-.. method:: operator Foo.chpl_by(r: range(?i), count: Foo)
+.. method:: operator Foo.by(r: range(?i), count: Foo)
 
 .. method:: operator Foo.:(rhs: Foo, type t: Bar)
 

--- a/test/chpldoc/functions/operators.doc.good
+++ b/test/chpldoc/functions/operators.doc.good
@@ -27,13 +27,13 @@ or
 
 .. function:: operator +(a: Foo, b: Foo)
 
-.. function:: operator chpl_align(r: range(?i), count: Foo)
+.. function:: operator align(r: range(?i), count: Foo)
 
 .. function:: operator &(lhs: Foo2, rhs: Foo2)
 
 .. function:: operator &=(ref lhs: Foo2, rhs: Foo2)
 
-.. function:: operator chpl_by(r: range(?i), count: Foo)
+.. function:: operator by(r: range(?i), count: Foo)
 
 .. function:: operator :(rhs: Foo, type t: Bar)
 


### PR DESCRIPTION
The by and align operators can be defined with a `chpl_` prefix, but they
probably shouldn't display in the docs with one.

Passed a fresh checkout of the tests