### PR TITLE
Skip these newly added segfaulting futures on multi-locale runs

### DIFF
--- a/test/parallel/taskPar/taskIntents/inCopyPassedToRef2.future
+++ b/test/parallel/taskPar/taskIntents/inCopyPassedToRef2.future
@@ -1,3 +1,6 @@
 bug: seg fault when passing 'in' task intent to 'ref' formal
 
-This code segfaults, but shouldn't.
+#19739
+
+Note that the .skipif for this test should be removed when
+this future is retired.

--- a/test/parallel/taskPar/taskIntents/inCopyPassedToRef2.skipif
+++ b/test/parallel/taskPar/taskIntents/inCopyPassedToRef2.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.future
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.future
@@ -1,3 +1,6 @@
 bug: seg fault when passing 'in' task intent to 'ref' formal
 
-This code segfaults, but shouldn't.
+#19739
+
+Note that the .skipif for this test should be removed when
+this future is retired.

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.skipif
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none


### PR DESCRIPTION
This adds skipifs for the segfaulting futures that I added in
#19739 for multi-locale executions because the output
differs from my .bad files.  Once they are working for
single-locale runs, there's no reason to believe they won't for
multi-locale as well, and the skipifs can be removed.
