### PR TITLE
Fix problem with dyno builds on Mac OS X with LLVM

### DIFF
--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -45,8 +45,14 @@ else
 CLANG_CMAKE_DIR := $(LLVM_CMAKE_DIR)/..
 endif
 
-$(info CHPL_MAKE_LLVM_CONFIG $(CHPL_MAKE_LLVM_CONFIG))
-$(info CLANG_CMAKE_DIR $(CLANG_CMAKE_DIR))
+# Figure out the sdkroot set by chplenv scripts to get cmake
+# to use something consistent
+CHPL_SDKROOT := $(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_llvm.py --sdkroot)
+ifeq ($(CHPL_SDKROOT),)
+SDKROOT_ARG :=
+else
+SDKROOT_ARG := -DCMAKE_OSX_SYSROOT=$(CHPL_SDKROOT)
+endif
 
 $(LIBCOMPILER_BUILD_DIR):
 	@echo "Configuring the compiler library..."
@@ -54,6 +60,7 @@ $(LIBCOMPILER_BUILD_DIR):
 	cd $(LIBCOMPILER_BUILD_DIR) && \
 	  $(CMAKE) $(CHPL_MAKE_HOME)/compiler/dyno \
 	    $(LIB_CMAKE_ARG) \
+	    $(SDKROOT_ARG) \
 	    -DCMAKE_C_COMPILER='$(CC)' \
 	    -DCMAKE_C_FLAGS='$(WARN_CFLAGS)' \
 	    -DCMAKE_CXX_COMPILER='$(CXX)' \

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -783,6 +783,24 @@ def get_host_link_args():
 
     return (bundled, system)
 
+# Return the isysroot argument provided by get_clang_basic_args, if any
+def get_clang_args_sdkroot():
+    args = get_clang_basic_args()
+    bundled, system = get_host_compile_args()
+    args += bundled
+    args += system
+
+    return_next_arg = False
+    for arg in args:
+        if return_next_arg:
+            return arg
+
+        if arg == "-isysroot":
+            return_next_arg = True
+
+    return ''
+
+
 def _main():
     llvm_val = get()
     llvm_config = get_llvm_config()
@@ -798,6 +816,10 @@ def _main():
     parser.add_option('--supported-versions', dest='action',
                       action='store_const',
                       const='llvmversions', default='')
+    parser.add_option('--sdkroot', dest='action',
+                      action='store_const',
+                      const='sdkroot', default='')
+
 
     (options, args) = parser.parse_args()
 
@@ -811,6 +833,8 @@ def _main():
         validate_llvm_config()
     elif options.action == 'llvmversions':
         sys.stdout.write("{0}\n".format(llvm_versions))
+    elif options.action == 'sdkroot':
+        sys.stdout.write("{0}\n".format(get_clang_args_sdkroot()))
     else:
         sys.stdout.write("{0}\n".format(llvm_val))
 


### PR DESCRIPTION
We were observing problems with 'make test-dyno' when CHPL_LLVM=system
on Mac OS X with Homebrew cmake and llvm.

The cmake build tries to gather the command line arguments
from chplenv but sometimes these include -isysroot, but cmake wants to
have its own variable to set that. This PR just adjusts the Makefiles to
configure cmake's sdkroot to match whatever -isysroot our chplenv scripts
have figured out. That way, if cmake adds a flag for it in addition, it
is OK, because everything is consistent.

Reviewed by @benharsh - thanks!