### PR TITLE
Fix initialized spelling in mason

### DIFF
--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -103,7 +103,7 @@ proc masonInit(args: [] string) throws {
           if isFile('./src/' + moduleName) then rename('src/' + moduleName, 'src/' + newPackageName + '.chpl');
         }
         var isInitialized = validateInit('.', newPackageName, true, show, true);
-        writeln("Initialised new library project: " + newPackageName);
+        writeln("Initialized new library project: " + newPackageName);
       }
     }
     else {


### PR DESCRIPTION
This PR fixes a typo in the `mason init` command, which was printing out "Inititialised" instead of "Initialized".