### PR TITLE
Remove extra mason toml spaces

### DIFF
--- a/test/mason/chplVersion/mason-chpl-version-new.good
+++ b/test/mason/chplVersion/mason-chpl-version-new.good
@@ -1,9 +1,9 @@
 Created new library project: newTest
 [brick]
-name = "newTest"
-version = "0.1.0"
-chplVersion = "CHPL_CUR_FULL"
-license = "None"
+name="newTest"
+version="0.1.0"
+chplVersion="CHPL_CUR_FULL"
+license="None"
 
 [dependencies]
 

--- a/test/mason/init/masonInteractive.good
+++ b/test/mason/init/masonInteractive.good
@@ -6,10 +6,10 @@ considered if no input is given.
 Press ^C to quit interactive mode.
 Package name: Package version (0.1.0): Chapel version (CHPL_CUR_FULL): License (None): 
 [brick]
-name = "project"
-version = "1.2.3"
-chplVersion = "1.21.0"
-license = "MIT"
+name="project"
+version="1.2.3"
+chplVersion="1.21.0"
+license="MIT"
 
 [dependencies]
 

--- a/test/mason/new/masonInteractive.good
+++ b/test/mason/new/masonInteractive.good
@@ -6,10 +6,10 @@ considered if no input is given.
 Press ^C to quit interactive mode.
 Package name: Package version (0.1.0): Chapel version (CHPL_CUR_FULL): License (None): 
 [brick]
-name = "project"
-version = "1.2.3"
-chplVersion = "1.21.0"
-license = "MIT"
+name="project"
+version="1.2.3"
+chplVersion="1.21.0"
+license="MIT"
 
 [dependencies]
 

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -296,10 +296,10 @@ proc addGitIgnore(dirName: string) {
 
 proc getBaseTomlString(packageName: string, version: string, chapelVersion: string, license: string) {
   const baseToml = """[brick]
-name = "%s"
-version = "%s"
-chplVersion = "%s"
-license = "%s"
+name="%s"
+version="%s"
+chplVersion="%s"
+license="%s"
 
 [dependencies]
 


### PR DESCRIPTION
The mason toml file that is generated with `mason new` and
`mason init` was creating lines such as `version = "0.1.0"` and
that would be interpreted by the CI testing as " 0.1.0" and this
was causing errors in the CI. This PR removes those extra spaces
and updates the tests affected.

Resolves https://github.com/Cray/chapel-private/issues/3309