### PR TITLE
dyno: avoid recursive queries in module resolution

### DIFF
--- a/compiler/dyno/include/chpl/queries/ID.h
+++ b/compiler/dyno/include/chpl/queries/ID.h
@@ -83,7 +83,7 @@ class ID final {
     the postorder traversal numbering, the ids contained appear before the node.
 
     The node with postorder traversal ID
-      postOrderId(Node) - numChildIds()
+      postOrderId() - numChildIds()
     is the first node contained within this node.
 
     E.g. in this notional AST:

--- a/compiler/dyno/include/chpl/resolution/resolution-queries.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-queries.h
@@ -30,6 +30,11 @@ namespace resolution {
 ////// resolution basics
 
 /**
+  Resolve a module-level statement or variable declaration.
+ */
+const ResolutionResultByPostorderID& resolveModuleStmt(Context* context, ID id);
+
+/**
   Resolve the contents of a Module
  */
 const ResolutionResultByPostorderID& resolveModule(Context* context, ID id);

--- a/compiler/dyno/lib/queries/Context.cpp
+++ b/compiler/dyno/lib/queries/Context.cpp
@@ -632,10 +632,10 @@ void Context::error(const resolution::TypedFnSignature* inFn,
 
 void Context::recomputeIfNeeded(const QueryMapResultBase* resultEntry) {
 
-  if (enableDebugTrace) {
-    printf("RECOMPUTING IF NEEDED FOR %p %s\n", resultEntry,
-           resultEntry->parentQueryMap->queryName);
-  }
+  //if (enableDebugTrace) {
+  //  printf("RECOMPUTING IF NEEDED FOR %p %s\n", resultEntry,
+  //         resultEntry->parentQueryMap->queryName);
+  //}
 
   if (this->currentRevisionNumber == resultEntry->lastChecked) {
     // No need to check the dependencies again.

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -31,10 +31,11 @@ struct Resolver {
   // inputs to the resolution process
   Context* context = nullptr;
   const uast::AstNode* symbol = nullptr;
-  const PoiScope* poiScope = nullptr;
+  const uast::AstNode* modStmt = nullptr;
   const SubstitutionsMap* substitutions = nullptr;
   bool useGenericFormalDefaults = false;
   const TypedFnSignature* typedSignature = nullptr;
+  const PoiScope* poiScope = nullptr;
 
   // internal variables
   std::vector<const uast::Decl*> declStack;
@@ -66,7 +67,8 @@ struct Resolver {
            const uast::AstNode* symbol,
            ResolutionResultByPostorderID& byPostorder,
            const PoiScope* poiScope)
-    : context(context), symbol(symbol), poiScope(poiScope),
+    : context(context), symbol(symbol),
+      poiScope(poiScope),
       byPostorder(byPostorder), poiInfo(makePoiInfo(poiScope)) {
 
     enterScope(symbol);
@@ -75,8 +77,9 @@ struct Resolver {
 
   // set up Resolver to resolve a Module
   static Resolver
-  moduleResolver(Context* context, const uast::Module* mod,
-                 ResolutionResultByPostorderID& byPostorder);
+  moduleStmtResolver(Context* context, const uast::Module* mod,
+                     const uast::AstNode* modStmt,
+                     ResolutionResultByPostorderID& byPostorder);
 
   // set up Resolver to resolve a potentially generic Function signature
   static Resolver

--- a/compiler/dyno/lib/uast/AstNode.cpp
+++ b/compiler/dyno/lib/uast/AstNode.cpp
@@ -156,6 +156,9 @@ static void dumpHelper(std::ostream& ss,
   ss << std::setw(maxIdLen) << idStr;
 
 
+  if (depth == 0) {
+    ss << " ";
+  }
   for (int i = 0; i < depth; i++) {
     ss << "  ";
   }

--- a/compiler/dyno/test/resolution/testInteractive.cpp
+++ b/compiler/dyno/test/resolution/testInteractive.cpp
@@ -198,6 +198,7 @@ int main(int argc, char** argv) {
   bool gc = false;
   Context context;
   Context* ctx = &context;
+  bool trace = false;
 
   std::vector<std::string> searchPath;
   int firstfile = 1;
@@ -210,7 +211,7 @@ int main(int argc, char** argv) {
       searchPath.push_back(argv[i+1]);
       i++;
     } else if (0 == strcmp(argv[i], "--trace")) {
-      ctx->setDebugTraceFlag(true);
+      trace = true;
     } else {
       firstfile = i;
       break;
@@ -223,6 +224,11 @@ int main(int argc, char** argv) {
     usage(argc, argv);
     return 0; // need this to return 0 for testing to be happy
   }
+
+  // Run this query first to make the other output more understandable
+  ctx->setDebugTraceFlag(false);
+  typeForBuiltin(ctx, UniqueString::get(ctx, "int"));
+  ctx->setDebugTraceFlag(trace);
 
   while (true) {
     ctx->advanceToNextRevision(gc);


### PR DESCRIPTION
For https://github.com/Cray/chapel-private/issues/3290

Continuing #19741 which includes some justification for the direction here.

This PR updates the module resolution process to have a query that resolves each module init statement individually rather than using a partial result for resolving the whole module. This fixes a crash with a simple pattern in incremental compilation that is added as a test.