### PR TITLE
Convert segfaulting futures to valgrind-only tests

### DIFF
--- a/test/parallel/taskPar/taskIntents/inCopyPassedToRef2.bad
+++ b/test/parallel/taskPar/taskIntents/inCopyPassedToRef2.bad
@@ -1,1 +1,0 @@
-timedexec: target program died with signal 11, without coredump

--- a/test/parallel/taskPar/taskIntents/inCopyPassedToRef2.skipif
+++ b/test/parallel/taskPar/taskIntents/inCopyPassedToRef2.skipif
@@ -1,1 +1,2 @@
-CHPL_COMM != none
+# only test with valgrind to ensure failure consistently
+CHPL_TEST_VGRND_EXE != on

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.bad
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.bad
@@ -1,1 +1,0 @@
-timedexec: target program died with signal 11, without coredump

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.skipif
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.skipif
@@ -1,1 +1,2 @@
-CHPL_COMM != none
+# only test with valgrind to ensure failure consistently
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
I'm not sure what I was thinking, believing that a segfaulting future
would be portable across testing configurations.  I guess the
spot-checks I did combined with the first night's results being mostly
clean made me overconfident, combined with not spending much time
on this, and not having filed many such futures lately.

This PR converts these tests to valgrind-only tests, which will make
them much more dependable (though with the downside that if they
start behaving better and I got the .goods wrong, we're less likely to
notice).
