### PR TITLE
Skip dash-llvm test when using C backend

### DIFF
--- a/test/deprecated/dash-llvm.skipif
+++ b/test/deprecated/dash-llvm.skipif
@@ -1,1 +1,2 @@
 CHPL_LLVM==none
+CHPL_TARGET_COMPILER==gnu


### PR DESCRIPTION
Otherwise we can get an error about runtime not
being built for this configuration.

Follow-up to PR #19693.

Test change only - not reviewed.