### PR TITLE
Move prototype of setHome from driver.h to commonFlags.h

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -92,7 +92,6 @@ extern bool fReportOptimizeForallUnordered;
 extern bool report_inlining;
 
 // Chapel Envs
-void setHome(const ArgumentDescription* desc, const char* arg);
 bool useDefaultEnv(std::string key);
 
 extern std::map<std::string, const char*> envMap;

--- a/compiler/main/commonFlags.h
+++ b/compiler/main/commonFlags.h
@@ -38,6 +38,7 @@ extern bool fRunlldb;
 // Shared setter functions.
 void driverSetHelpTrue(const ArgumentDescription* desc, const char* unused);
 void driverSetDevelSettings(const ArgumentDescription* desc, const char* arg_unused);
+void setHome(const ArgumentDescription* desc, const char* arg);
 
 #define DRIVER_ARG_COPYRIGHT \
   {"copyright", ' ', NULL, "Show copyright", "F", &fPrintCopyright, NULL, NULL}


### PR DESCRIPTION
In reviewing #19753, Lydia pointed out that commonFlags.h now referred
to 'setHome' yet didn't #include driver.h, which is where that routine
is prototyped.  This wasn't an issue because each file that #includes
commonFlags.h also #includes driver.h, but it's obviously a bit
sketchy (and didn't get addressed in that PR because I was hoping to
fix the broken build last night).

Here, I'm moving the prototype of setHome to commonFlags.h to fix
this issue, in the section of other prototypes that are used to
set things in the common flags section.
