### PR TITLE
dyno: More fixes for tests running under COMM=gasnet

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -297,7 +297,7 @@ struct Converter {
       Expr* e = convertAST(stmt);
       if (!e) continue;
       if (ret) INT_FATAL("implicit block with multiple statements");
-      ret = buildChapelStmt(e);
+      ret = isBlockStmt(e) ? toBlockStmt(e) : buildChapelStmt(e);
     }
 
     return ret;


### PR DESCRIPTION
dyno: More fixes for tests running under COMM=gasnet (#19771)

A bunch of fixes which get more tests to pass with `--dyno` while
running with `COMM=gasnet`.

The most notable fix here is that we stop attaching qualified types
to variable-like things early. Attaching early doesn't affect any
tests when running under `COMM=none`. However, doing so when
running with wide pointers leads to strange runtime bugs that are
extremely difficult to debug.

My guess is that setting early affects some optimizations or shallow
copies that occur during resolution or in `insertWideReferences()`.
I don't know for sure, though.

Future work should find this bug so that we can resume attaching
qualified types early.

[Summary: #Successes = 13573 | #Failures = 36 | #Futures = 0]

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>

Reviewed by @arezaii. Thanks!