### PR TITLE
dyno: add token counting and code size stats

### DIFF
--- a/compiler/dyno/include/chpl/parsing/Parser.h
+++ b/compiler/dyno/include/chpl/parsing/Parser.h
@@ -25,6 +25,7 @@
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/Builder.h"
 #include "chpl/util/memory.h"
+#include "chpl/parsing/parser-stats.h"
 
 #include <vector>
 
@@ -33,36 +34,38 @@ namespace parsing {
 
 /**
   A class for parsing
- */
+*/
 class Parser final {
- private:
-   // TODO: stuff to do with module search paths
-   // and then connect parsed modules to a query
+  private:
+  // TODO: stuff to do with module search paths
+  // and then connect parsed modules to a query
 
-   // TODO: compile-time configuration variable settings
-   // need to be stored in here.
+  // TODO: compile-time configuration variable settings
+  // need to be stored in here.
 
-   Context* context_;
-   Parser(Context* context);
+  Context* context_;
+  Parser(Context* context);
 
- public:
-   static owned<Parser> build(Context* context);
-   ~Parser() = default;
+  public:
+    static owned<Parser> build(Context* context);
+    ~Parser() = default;
 
-   /**
-     Return the AST Context used by this Parser.
+    /**
+      Return the AST Context used by this Parser.
     */
-   Context* context() { return context_; }
+    Context* context() { return context_; }
 
-   /**
+    /**
      Parse a file at a particular path.
     */
-   uast::BuilderResult parseFile(const char* path);
-   /**
+    uast::BuilderResult parseFile(const char* path,
+                                  ParserStats* parseStats=nullptr);
+    /**
      Parse source code in a string.
      'path' is only used for certain errors.
     */
-   uast::BuilderResult parseString(const char* path, const char* str);
+    uast::BuilderResult parseString(const char* path, const char* str,
+                                    ParserStats* parseStats=nullptr);
 };
 
 } // end namespace parsing

--- a/compiler/dyno/include/chpl/parsing/parser-stats.h
+++ b/compiler/dyno/include/chpl/parsing/parser-stats.h
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_PARSING_PARSER_STATS_H
+#define CHPL_PARSING_PARSER_STATS_H
+
+namespace chpl {
+
+namespace parsing {
+
+  struct ParserStats {
+    bool countTokens;
+    bool printTokens;
+    static const int HIST_SIZE = 4096;
+    int lineTokens;
+    int fileTokens;
+    int totTokens;
+    int blankLines;
+    int commentLines;
+    int codeLines;
+    int fileTokenHist[HIST_SIZE];
+    int totTokenHist[HIST_SIZE];
+    int maxTokensPerLineInFile;
+    int maxTokensPerLineTot;
+
+    int firstLineInFile;
+    int lineBlank;
+    int lineComment;
+    std::string line;
+
+
+    // TODO: Move all the function definitions to the .cpp file
+    void clearHist(int h[]) {
+      int i;
+      for (i = 0; i < HIST_SIZE; i++) {
+        h[i] = 0;
+      }
+    }
+
+    void clearLine() {
+      if (firstLineInFile) {
+        firstLineInFile = 0;
+      } else {
+        if (lineTokens < HIST_SIZE) {
+          fileTokenHist[lineTokens]++;
+          totTokenHist[lineTokens]++;
+        }
+      }
+      if (lineTokens > maxTokensPerLineInFile)
+        maxTokensPerLineInFile = lineTokens;
+      if (lineTokens > maxTokensPerLineTot)
+        maxTokensPerLineTot = lineTokens;
+      lineTokens = 0;
+      lineBlank = true;
+      lineComment = true;
+      if (printTokens) {
+        line.clear();
+      }
+    }
+
+    void clearFile() {
+      fileTokens = 0;
+      blankLines = 0;
+      commentLines = 0;
+      codeLines = 0;
+      clearHist(fileTokenHist);
+      maxTokensPerLineInFile = 0;
+      firstLineInFile = 1;
+    }
+
+    void clearGlob() {
+      totTokens = 0;
+      clearHist(totTokenHist);
+      maxTokensPerLineTot = 0;
+    }
+
+    void printSeparator() {
+      fflush(stdout);
+      fprintf(stderr,
+              "=============================================================\n");
+    }
+
+    void printFileSummary() {
+      if (printTokens) {
+        int j;
+
+        fflush(stdout);
+        fprintf(stderr, "TOKENS = %d\n", fileTokens);
+        fprintf(stderr, "LINES  = %d code, %d comment, %d blank\n", codeLines,
+                commentLines, blankLines);
+        fprintf(stderr, "MAX TOKENS/LINE = %d\n"
+                        "AVG TOKENS/CODE LINE = %.2f\n",
+                maxTokensPerLineInFile, (double) fileTokens / codeLines);
+        fprintf(stderr, "HISTOGRAM:\n");
+        for (j = 0; j <= maxTokensPerLineInFile; j++) {
+          fprintf(stderr, "%3d: %3d\n", j, fileTokenHist[j]);
+        }
+      }
+    }
+
+    void initTokenCount() {
+      if (printTokens && !countTokens) { // printTokens => countTokens
+        countTokens = true;
+      }
+      if (countTokens) {
+        clearGlob();
+      }
+    }
+
+    bool tokenCountingOn = false;
+
+    void startCountingFileTokens(const char* filename) {
+      bool firstCall = true;
+
+      if (firstCall) {
+        firstCall = false;
+        initTokenCount();
+      }
+
+      tokenCountingOn = true;
+
+      if (countTokens) {
+        clearFile();
+        clearLine();
+        if (printTokens) {
+          fprintf(stderr, "%s\n", filename);
+          printSeparator();
+        }
+      }
+    }
+
+    void stopCountingFileTokens() {
+      tokenCountingOn = false;
+
+      if (printTokens) {
+        if (!line.empty()) {
+          // TODO: Can we reproduce or replace this call to processNewline?
+          //   processNewline(scanner);
+          countNewline();
+        }
+
+        printSeparator();
+        printFileSummary();
+        printSeparator();
+        fprintf(stderr, "\n");
+      }
+    }
+
+    void finishCountingTokens() {
+      if (countTokens) {
+        if (printTokens) {
+          fflush(stdout);
+          fprintf(stderr, "GRAND TOTAL = ");
+        }
+        fprintf(stderr, "%d\n", totTokens);
+      }
+    }
+
+    void countToken(const char* toktext1,
+                    const char* toktext2 = NULL,
+                    const char* toktext3 = NULL) {
+      if (tokenCountingOn && countTokens) {
+        if (printTokens) {
+          line.push_back(' ');
+          line.append(toktext1);
+          if (toktext2 != NULL)
+            line.append(toktext2);
+          if (toktext3 != NULL)
+            line.append(toktext3);
+        }
+        lineTokens++;
+        fileTokens++;
+        totTokens++;
+        lineBlank = false;
+        lineComment = false;
+      }
+    }
+
+    void countNewline() {
+      if (tokenCountingOn && countTokens) {
+        if (lineBlank) {
+          blankLines++;
+        } else if (lineComment) {
+          commentLines++;
+        } else {
+          codeLines++;
+        }
+        if (printTokens) {
+          if (lineTokens) {
+            printf("%3d | ", lineTokens);
+          } else if (lineBlank) {
+            printf("*B* | ");
+          } else if (lineComment) {
+            printf("*C* | ");
+          } else {
+            printf("    | ");
+          }
+          printf("%s\n", line.c_str());
+        }
+      }
+      clearLine();
+    }
+
+    void countCommentLine() {
+      if (tokenCountingOn && countTokens) {
+        lineBlank = false;
+      }
+    }
+
+    void countSingleLineComment(const char* comment) {
+      if (printTokens) {
+        if (!comment) {
+          comment = "";
+        }
+        line.append(" ");
+        line.append(comment);
+      }
+    }
+
+    void countMultiLineComment(const char* comment) {
+      if (printTokens) {
+        // add space to tabify
+        line.append(" ");
+        if (!comment || strcmp(comment, "") == 0) {
+          line.append("/* ");
+          line.append(" */");
+        } else {
+          line.append(comment);
+        }
+      }
+    }
+
+    ParserStats(bool printTokens) {
+      this->printTokens = printTokens;
+      this->countTokens = true;
+      this->blankLines = 0;
+      this->lineTokens = 0;
+      this->fileTokens = 0;
+      this->totTokens = 0;
+      this->blankLines = 0;
+      this->commentLines = 0;
+      this->codeLines = 0;
+      this->maxTokensPerLineInFile = 0;
+      this->maxTokensPerLineTot = 0;
+
+      this->firstLineInFile = 0;
+      this->lineBlank = 0;
+      this->lineComment = 0;
+    }
+
+    ParserStats() {
+      ParserStats(false);
+    }
+  };
+
+} // end namespace parsing
+
+} // end namespace chpl
+
+#endif

--- a/compiler/dyno/include/chpl/parsing/parser-stats.h
+++ b/compiler/dyno/include/chpl/parsing/parser-stats.h
@@ -24,250 +24,62 @@ namespace chpl {
 
 namespace parsing {
 
-  struct ParserStats {
-    bool countTokens;
-    bool printTokens;
-    static const int HIST_SIZE = 4096;
-    int lineTokens;
-    int fileTokens;
-    int totTokens;
-    int blankLines;
-    int commentLines;
-    int codeLines;
-    int fileTokenHist[HIST_SIZE];
-    int totTokenHist[HIST_SIZE];
-    int maxTokensPerLineInFile;
-    int maxTokensPerLineTot;
+struct ParserStats {
+  bool countTokens;
+  bool printTokens;
+  static const int HIST_SIZE = 4096;
+  int lineTokens;
+  int fileTokens;
+  int totTokens;
+  int blankLines;
+  int commentLines;
+  int codeLines;
+  int fileTokenHist[HIST_SIZE];
+  int totTokenHist[HIST_SIZE];
+  int maxTokensPerLineInFile;
+  int maxTokensPerLineTot;
 
-    int firstLineInFile;
-    int lineBlank;
-    int lineComment;
-    std::string line;
+  int firstLineInFile;
+  int lineBlank;
+  int lineComment;
+  std::string line;
 
+  bool tokenCountingOn = false;
 
-    // TODO: Move all the function definitions to the .cpp file
-    void clearHist(int h[]) {
-      int i;
-      for (i = 0; i < HIST_SIZE; i++) {
-        h[i] = 0;
-      }
-    }
+  void clearHist(int h[]);
 
-    void clearLine() {
-      if (firstLineInFile) {
-        firstLineInFile = 0;
-      } else {
-        if (lineTokens < HIST_SIZE) {
-          fileTokenHist[lineTokens]++;
-          totTokenHist[lineTokens]++;
-        }
-      }
-      if (lineTokens > maxTokensPerLineInFile)
-        maxTokensPerLineInFile = lineTokens;
-      if (lineTokens > maxTokensPerLineTot)
-        maxTokensPerLineTot = lineTokens;
-      lineTokens = 0;
-      lineBlank = true;
-      lineComment = true;
-      if (printTokens) {
-        line.clear();
-      }
-    }
+  void clearLine();
 
-    void clearFile() {
-      fileTokens = 0;
-      blankLines = 0;
-      commentLines = 0;
-      codeLines = 0;
-      clearHist(fileTokenHist);
-      maxTokensPerLineInFile = 0;
-      firstLineInFile = 1;
-    }
+  void clearFile();
 
-    void clearGlob() {
-      totTokens = 0;
-      clearHist(totTokenHist);
-      maxTokensPerLineTot = 0;
-    }
+  void clearGlob();
 
-    void printSeparator() {
-      fflush(stdout);
-      fprintf(stderr,
-              "=============================================================\n");
-    }
+  void printSeparator();
 
-    void printFileSummary() {
-      if (printTokens) {
-        int j;
+  void printFileSummary();
 
-        fflush(stdout);
-        fprintf(stderr, "TOKENS = %d\n", fileTokens);
-        fprintf(stderr, "LINES  = %d code, %d comment, %d blank\n", codeLines,
-                commentLines, blankLines);
-        fprintf(stderr, "MAX TOKENS/LINE = %d\n"
-                        "AVG TOKENS/CODE LINE = %.2f\n",
-                maxTokensPerLineInFile, (double) fileTokens / codeLines);
-        fprintf(stderr, "HISTOGRAM:\n");
-        for (j = 0; j <= maxTokensPerLineInFile; j++) {
-          fprintf(stderr, "%3d: %3d\n", j, fileTokenHist[j]);
-        }
-      }
-    }
+  void initTokenCount();
 
-    void initTokenCount() {
-      if (printTokens && !countTokens) { // printTokens => countTokens
-        countTokens = true;
-      }
-      if (countTokens) {
-        clearGlob();
-      }
-    }
+  void startCountingFileTokens(const char* filename);
+  void stopCountingFileTokens();
 
-    bool tokenCountingOn = false;
+  void finishCountingTokens();
 
-    void startCountingFileTokens(const char* filename) {
-      bool firstCall = true;
+  void countToken(const char* toktext1,
+                  const char* toktext2 = NULL,
+                  const char* toktext3 = NULL);
 
-      if (firstCall) {
-        firstCall = false;
-        initTokenCount();
-      }
+  void countNewline();
 
-      tokenCountingOn = true;
+  void countCommentLine();
 
-      if (countTokens) {
-        clearFile();
-        clearLine();
-        if (printTokens) {
-          fprintf(stderr, "%s\n", filename);
-          printSeparator();
-        }
-      }
-    }
+  void countSingleLineComment(const char* comment);
 
-    void stopCountingFileTokens() {
-      tokenCountingOn = false;
+  void countMultiLineComment(const char* comment);
 
-      if (printTokens) {
-        if (!line.empty()) {
-          // TODO: Can we reproduce or replace this call to processNewline?
-          //   processNewline(scanner);
-          countNewline();
-        }
-
-        printSeparator();
-        printFileSummary();
-        printSeparator();
-        fprintf(stderr, "\n");
-      }
-    }
-
-    void finishCountingTokens() {
-      if (countTokens) {
-        if (printTokens) {
-          fflush(stdout);
-          fprintf(stderr, "GRAND TOTAL = ");
-        }
-        fprintf(stderr, "%d\n", totTokens);
-      }
-    }
-
-    void countToken(const char* toktext1,
-                    const char* toktext2 = NULL,
-                    const char* toktext3 = NULL) {
-      if (tokenCountingOn && countTokens) {
-        if (printTokens) {
-          line.push_back(' ');
-          line.append(toktext1);
-          if (toktext2 != NULL)
-            line.append(toktext2);
-          if (toktext3 != NULL)
-            line.append(toktext3);
-        }
-        lineTokens++;
-        fileTokens++;
-        totTokens++;
-        lineBlank = false;
-        lineComment = false;
-      }
-    }
-
-    void countNewline() {
-      if (tokenCountingOn && countTokens) {
-        if (lineBlank) {
-          blankLines++;
-        } else if (lineComment) {
-          commentLines++;
-        } else {
-          codeLines++;
-        }
-        if (printTokens) {
-          if (lineTokens) {
-            printf("%3d | ", lineTokens);
-          } else if (lineBlank) {
-            printf("*B* | ");
-          } else if (lineComment) {
-            printf("*C* | ");
-          } else {
-            printf("    | ");
-          }
-          printf("%s\n", line.c_str());
-        }
-      }
-      clearLine();
-    }
-
-    void countCommentLine() {
-      if (tokenCountingOn && countTokens) {
-        lineBlank = false;
-      }
-    }
-
-    void countSingleLineComment(const char* comment) {
-      if (printTokens) {
-        if (!comment) {
-          comment = "";
-        }
-        line.append(" ");
-        line.append(comment);
-      }
-    }
-
-    void countMultiLineComment(const char* comment) {
-      if (printTokens) {
-        // add space to tabify
-        line.append(" ");
-        if (!comment || strcmp(comment, "") == 0) {
-          line.append("/* ");
-          line.append(" */");
-        } else {
-          line.append(comment);
-        }
-      }
-    }
-
-    ParserStats(bool printTokens) {
-      this->printTokens = printTokens;
-      this->countTokens = true;
-      this->blankLines = 0;
-      this->lineTokens = 0;
-      this->fileTokens = 0;
-      this->totTokens = 0;
-      this->blankLines = 0;
-      this->commentLines = 0;
-      this->codeLines = 0;
-      this->maxTokensPerLineInFile = 0;
-      this->maxTokensPerLineTot = 0;
-
-      this->firstLineInFile = 0;
-      this->lineBlank = 0;
-      this->lineComment = 0;
-    }
-
-    ParserStats() {
-      ParserStats(false);
-    }
-  };
+  ParserStats();
+  ParserStats(bool printTokens);
+};
 
 } // end namespace parsing
 

--- a/compiler/dyno/include/chpl/parsing/parser-stats.h
+++ b/compiler/dyno/include/chpl/parsing/parser-stats.h
@@ -19,7 +19,7 @@
 
 #ifndef CHPL_PARSING_PARSER_STATS_H
 #define CHPL_PARSING_PARSER_STATS_H
-
+/// \cond DO_NOT_DOCUMENT
 namespace chpl {
 
 namespace parsing {
@@ -84,5 +84,6 @@ struct ParserStats {
 } // end namespace parsing
 
 } // end namespace chpl
+/// \endcond
 
 #endif

--- a/compiler/dyno/include/chpl/parsing/parser-stats.h
+++ b/compiler/dyno/include/chpl/parsing/parser-stats.h
@@ -19,12 +19,18 @@
 
 #ifndef CHPL_PARSING_PARSER_STATS_H
 #define CHPL_PARSING_PARSER_STATS_H
-/// \cond DO_NOT_DOCUMENT
+
 namespace chpl {
 
 namespace parsing {
 
+/*
+  A place to collect code stats and generate a report of the number of lines
+  which are code, comments, and blank lines.
+*/
 struct ParserStats {
+
+ /// \cond DO_NOT_DOCUMENT
   bool countTokens;
   bool printTokens;
   static const int HIST_SIZE = 4096;
@@ -76,7 +82,7 @@ struct ParserStats {
   void countSingleLineComment(const char* comment);
 
   void countMultiLineComment(const char* comment);
-
+/// \endcond
   ParserStats();
   ParserStats(bool printTokens);
 };
@@ -84,6 +90,6 @@ struct ParserStats {
 } // end namespace parsing
 
 } // end namespace chpl
-/// \endcond
+
 
 #endif

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -82,9 +82,13 @@ bool hasFileText(Context* context, const std::string& path);
  */
 const uast::BuilderResult& parseFile(Context* context, UniqueString path);
 
-// Counts the tokens when parsing
-// TODO: Expose this in a more reasonable manner
+
+/**
+  A function for counting the tokens when parsing
+*/
 void countTokens(Context* context, UniqueString path, ParserStats* parseStats);
+// TODO: Expose this in a more reasonable manner
+
 
 // These functions can't return the Location for a Comment
 // because Comments don't have IDs. If Locations for Comments are needed,

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -28,6 +28,7 @@
 #include "chpl/uast/BuilderResult.h"
 #include "chpl/uast/Function.h"
 #include "chpl/uast/Module.h"
+#include "chpl/parsing/parser-stats.h"
 
 #include <vector>
 
@@ -81,6 +82,9 @@ bool hasFileText(Context* context, const std::string& path);
  */
 const uast::BuilderResult& parseFile(Context* context, UniqueString path);
 
+// Counts the tokens when parsing
+// TODO: Expose this in a more reasonable manner
+void countTokens(Context* context, UniqueString path, ParserStats* parseStats);
 
 // These functions can't return the Location for a Comment
 // because Comments don't have IDs. If Locations for Comments are needed,

--- a/compiler/dyno/lib/parsing/CMakeLists.txt
+++ b/compiler/dyno/lib/parsing/CMakeLists.txt
@@ -42,7 +42,7 @@ target_sources(libdyno-obj
                lexer-help.h
                parser-dependencies.h
                parser-help.h
-
+               parser-stats.cpp
                # these are implementing the public interface
                Parser.cpp
                parsing-queries.cpp

--- a/compiler/dyno/lib/parsing/Makefile.include
+++ b/compiler/dyno/lib/parsing/Makefile.include
@@ -25,6 +25,7 @@ DYNO_PARSING_SRCS =                                 \
            flex-chpl-lib.cpp                        \
            parsing-queries.cpp                      \
            Parser.cpp                               \
+           parser-stats.cpp                         \
 
 
 SRCS = $(DYNO_PARSING_SRCS)

--- a/compiler/dyno/lib/parsing/Parser.cpp
+++ b/compiler/dyno/lib/parsing/Parser.cpp
@@ -78,7 +78,7 @@ static void updateParseResult(ParserContext* parserContext) {
 }
 
 
-BuilderResult Parser::parseFile(const char* path) {
+BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
   auto builder = Builder::build(this->context(), path);
   ErrorMessage fileError;
 
@@ -101,7 +101,7 @@ BuilderResult Parser::parseFile(const char* path) {
   yychpl_pstate* parser = yychpl_pstate_new();
   int           parserStatus = YYPUSH_MORE;
   YYLTYPE       my_yylloc;
-  ParserContext parserContext(path, builder.get());
+  ParserContext parserContext(path, builder.get(), parseStats);
 
   my_yylloc.first_line             = 1;
   my_yylloc.first_column           = 1;
@@ -165,7 +165,8 @@ BuilderResult Parser::parseFile(const char* path) {
 }
 
 
-BuilderResult Parser::parseString(const char* path, const char* str) {
+BuilderResult Parser::parseString(const char* path, const char* str,
+                                  ParserStats* parseStats) {
   auto builder = Builder::build(this->context(), path);
 
   // Set the (global) parser debug state
@@ -180,7 +181,7 @@ BuilderResult Parser::parseString(const char* path, const char* str) {
   // State for the parser
   yychpl_pstate* parser = yychpl_pstate_new();
   int           parserStatus = YYPUSH_MORE;
-  ParserContext parserContext(path, builder.get());
+  ParserContext parserContext(path, builder.get(), parseStats);
 
   yychpl_lex_init_extra(&parserContext, &parserContext.scanner);
 

--- a/compiler/dyno/lib/parsing/ParserContext.h
+++ b/compiler/dyno/lib/parsing/ParserContext.h
@@ -63,6 +63,7 @@ struct ParserContext {
   yyscan_t scanner;
   UniqueString filename;
   Builder* builder;
+  parsing::ParserStats* parseStats;
 
   ParserExprList* topLevelStatements;
   std::vector<ParserError> errors;
@@ -104,7 +105,8 @@ struct ParserContext {
 
   ParserExprList* parenlessMarker;
 
-  ParserContext(const char* filename, Builder* builder)
+  ParserContext(const char* filename, Builder* builder,
+                parsing::ParserStats* parseStats)
   {
     auto uniqueFilename = UniqueString::get(builder->context(), filename);
 
@@ -127,6 +129,7 @@ struct ParserContext {
     this->declStartLocation       = emptyLoc;
     this->atEOF                   = false;
     this->parenlessMarker         = new ParserExprList();
+    this->parseStats              = parseStats;
   }
   ~ParserContext() {
     delete this->parenlessMarker;

--- a/compiler/dyno/lib/parsing/flex-chpl-lib.cpp
+++ b/compiler/dyno/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 1 "flex-chpl-lib.cpp"
+#line 2 "flex-chpl-lib.cpp"
 
-#line 3 "flex-chpl-lib.cpp"
+#line 4 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1084,10 +1084,10 @@ static void processInvalidToken(yyscan_t scanner);
 static bool yy_has_state(yyscan_t scanner);
 }
 
-#line 1087 "flex-chpl-lib.cpp"
+#line 1088 "flex-chpl-lib.cpp"
 /* hex float literals, have decimal exponents indicating the power of 2 */
 
-#line 1090 "flex-chpl-lib.cpp"
+#line 1091 "flex-chpl-lib.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -1377,7 +1377,7 @@ YY_DECL
 #line 113 "chpl.lex"
 
 
-#line 1380 "flex-chpl-lib.cpp"
+#line 1381 "flex-chpl-lib.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2382,7 +2382,7 @@ YY_RULE_SETUP
 #line 329 "chpl.lex"
 ECHO;
 	YY_BREAK
-#line 2385 "flex-chpl-lib.cpp"
+#line 2386 "flex-chpl-lib.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();

--- a/compiler/dyno/lib/parsing/flex-chpl-lib.h
+++ b/compiler/dyno/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 5 "flex-chpl-lib.h"
+#line 6 "flex-chpl-lib.h"
 
-#line 7 "flex-chpl-lib.h"
+#line 8 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -730,6 +730,6 @@ extern int yylex \
 #line 329 "chpl.lex"
 
 
-#line 733 "flex-chpl-lib.h"
+#line 734 "flex-chpl-lib.h"
 #undef yychpl_IN_HEADER
 #endif /* yychpl_HEADER_H */

--- a/compiler/dyno/lib/parsing/lexer-help.h
+++ b/compiler/dyno/lib/parsing/lexer-help.h
@@ -290,7 +290,6 @@ static std::string eatStringLiteral(yyscan_t scanner,
 
       // account for newlines after \ at the end
       if (c == '\n') {
-        processNewline(scanner);
         nLines++;
         nCols = 0;
       }
@@ -406,7 +405,6 @@ static std::string eatTripleStringLiteral(yyscan_t scanner,
     }
 
     if (c == '\n') {
-      processNewline(scanner);
       nLines++;
       nCols = 0;
     } else {
@@ -563,7 +561,6 @@ static SizedStr eatExternCode(yyscan_t scanner) {
     s += c;
 
     if (c == '\n') {
-      processNewline(scanner);
       nCols = 0;
       nLines++;
     }

--- a/compiler/dyno/lib/parsing/parser-dependencies.h
+++ b/compiler/dyno/lib/parsing/parser-dependencies.h
@@ -25,7 +25,7 @@
 #include "chpl/queries/ErrorMessage.h"
 #include "chpl/queries/Location.h"
 #include "chpl/queries/UniqueString.h"
-
+#include "chpl/parsing/Parser.h"
 #include "chpl/uast/all-uast.h"
 
 #include <cstdint>

--- a/compiler/dyno/lib/parsing/parser-stats.cpp
+++ b/compiler/dyno/lib/parsing/parser-stats.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include "chpl/parsing/parser-stats.h"
 
-/// \cond DO_NOT_DOCUMENT
+
 namespace chpl {
 
 
@@ -252,4 +252,3 @@ ParserStats::ParserStats() {
 
 
 } // end namespace chpl
-/// \endcond

--- a/compiler/dyno/lib/parsing/parser-stats.cpp
+++ b/compiler/dyno/lib/parsing/parser-stats.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+#include <cstdio>
+#include <string>
+#include "chpl/parsing/parser-stats.h"
+
+
+namespace chpl {
+
+
+namespace parsing {
+
+void ParserStats::clearHist(int h[]) {
+  int i;
+  for (i = 0; i < HIST_SIZE; i++) {
+    h[i] = 0;
+  }
+}
+
+void ParserStats::clearLine() {
+  if (firstLineInFile) {
+    firstLineInFile = 0;
+  } else {
+    if (lineTokens < HIST_SIZE) {
+      fileTokenHist[lineTokens]++;
+      totTokenHist[lineTokens]++;
+    }
+  }
+  if (lineTokens > maxTokensPerLineInFile)
+    maxTokensPerLineInFile = lineTokens;
+  if (lineTokens > maxTokensPerLineTot)
+    maxTokensPerLineTot = lineTokens;
+  lineTokens = 0;
+  lineBlank = true;
+  lineComment = true;
+  if (printTokens) {
+    line.clear();
+  }
+}
+
+void ParserStats::clearFile() {
+  fileTokens = 0;
+  blankLines = 0;
+  commentLines = 0;
+  codeLines = 0;
+  clearHist(fileTokenHist);
+  maxTokensPerLineInFile = 0;
+  firstLineInFile = 1;
+}
+
+void ParserStats::clearGlob() {
+  totTokens = 0;
+  clearHist(totTokenHist);
+  maxTokensPerLineTot = 0;
+}
+
+void ParserStats::printSeparator() {
+  fflush(stdout);
+  fprintf(stderr,
+          "=============================================================\n");
+}
+
+void ParserStats::printFileSummary() {
+  if (printTokens) {
+    int j;
+
+    fflush(stdout);
+    fprintf(stderr, "TOKENS = %d\n", fileTokens);
+    fprintf(stderr, "LINES  = %d code, %d comment, %d blank\n", codeLines,
+            commentLines, blankLines);
+    fprintf(stderr, "MAX TOKENS/LINE = %d\n"
+                    "AVG TOKENS/CODE LINE = %.2f\n",
+            maxTokensPerLineInFile, (double) fileTokens / codeLines);
+    fprintf(stderr, "HISTOGRAM:\n");
+    for (j = 0; j <= maxTokensPerLineInFile; j++) {
+      fprintf(stderr, "%3d: %3d\n", j, fileTokenHist[j]);
+    }
+  }
+}
+
+void ParserStats::initTokenCount() {
+  if (printTokens && !countTokens) { // printTokens => countTokens
+    countTokens = true;
+  }
+  if (countTokens) {
+    clearGlob();
+  }
+}
+
+void ParserStats::startCountingFileTokens(const char* filename) {
+  bool firstCall = true;
+
+  if (firstCall) {
+    firstCall = false;
+    initTokenCount();
+  }
+
+  tokenCountingOn = true;
+
+  if (countTokens) {
+    clearFile();
+    clearLine();
+    if (printTokens) {
+      fprintf(stderr, "%s\n", filename);
+      printSeparator();
+    }
+  }
+}
+
+void ParserStats::stopCountingFileTokens() {
+  tokenCountingOn = false;
+
+  if (printTokens) {
+    if (!line.empty()) {
+      // TODO: Can we reproduce or replace this call to processNewline?
+      // processNewline(scanner);
+      countNewline();
+    }
+
+    printSeparator();
+    printFileSummary();
+    printSeparator();
+    fprintf(stderr, "\n");
+  }
+}
+
+void ParserStats::finishCountingTokens() {
+  if (countTokens) {
+    if (printTokens) {
+      fflush(stdout);
+      fprintf(stderr, "GRAND TOTAL = ");
+    }
+    fprintf(stderr, "%d\n", totTokens);
+  }
+}
+
+void ParserStats::countToken(const char* toktext1,
+                             const char* toktext2,
+                             const char* toktext3) {
+  if (tokenCountingOn && countTokens) {
+    if (printTokens) {
+      line.push_back(' ');
+      line.append(toktext1);
+      if (toktext2 != NULL)
+        line.append(toktext2);
+      if (toktext3 != NULL)
+        line.append(toktext3);
+    }
+    lineTokens++;
+    fileTokens++;
+    totTokens++;
+    lineBlank = false;
+    lineComment = false;
+  }
+}
+
+void ParserStats::countNewline() {
+  if (tokenCountingOn && countTokens) {
+    if (lineBlank) {
+      blankLines++;
+    } else if (lineComment) {
+      commentLines++;
+    } else {
+      codeLines++;
+    }
+    if (printTokens) {
+      if (lineTokens) {
+        printf("%3d | ", lineTokens);
+      } else if (lineBlank) {
+        printf("*B* | ");
+      } else if (lineComment) {
+        printf("*C* | ");
+      } else {
+        printf("    | ");
+      }
+      printf("%s\n", line.c_str());
+    }
+  }
+  clearLine();
+}
+
+void ParserStats::countCommentLine() {
+  if (tokenCountingOn && countTokens) {
+    lineBlank = false;
+  }
+}
+
+void ParserStats::countSingleLineComment(const char* comment) {
+  if (printTokens) {
+    if (!comment) {
+      comment = "";
+    }
+    line.append(" ");
+    line.append(comment);
+  }
+}
+
+void ParserStats::countMultiLineComment(const char* comment) {
+  if (printTokens) {
+    // add space to tabify
+    line.append(" ");
+    if (!comment || strcmp(comment, "") == 0) {
+      line.append("/* ");
+      line.append(" */");
+    } else {
+      line.append(comment);
+    }
+  }
+}
+
+ParserStats::ParserStats(bool printTokens) {
+  this->printTokens = printTokens;
+  this->countTokens = true;
+  this->blankLines = 0;
+  this->lineTokens = 0;
+  this->fileTokens = 0;
+  this->totTokens = 0;
+  this->blankLines = 0;
+  this->commentLines = 0;
+  this->codeLines = 0;
+  this->maxTokensPerLineInFile = 0;
+  this->maxTokensPerLineTot = 0;
+
+  this->firstLineInFile = 0;
+  this->lineBlank = 0;
+  this->lineComment = 0;
+}
+
+ParserStats::ParserStats() {
+  ParserStats(false);
+}
+
+} // end namespace parsing
+
+
+} // end namespace chpl

--- a/compiler/dyno/lib/parsing/parser-stats.cpp
+++ b/compiler/dyno/lib/parsing/parser-stats.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include "chpl/parsing/parser-stats.h"
 
-
+/// \cond DO_NOT_DOCUMENT
 namespace chpl {
 
 
@@ -252,3 +252,4 @@ ParserStats::ParserStats() {
 
 
 } // end namespace chpl
+/// \endcond

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -114,6 +114,20 @@ const uast::BuilderResult& parseFile(Context* context, UniqueString path) {
   return QUERY_END(result);
 }
 
+void countTokens(Context* context, UniqueString path, ParserStats* parseStats) {
+  const FileContents& contents = fileText(context, path);
+  const std::string& text = contents.text();
+  const ErrorMessage& error = contents.error();
+  BuilderResult result(path);
+  if (error.isEmpty()) {
+    // if there was no error reading the file, proceed to parse
+    auto parser = Parser::build(context);
+    const char* pathc = path.c_str();
+    const char* textc = text.c_str();
+    parser->parseString(pathc, textc, parseStats);
+  }
+}
+
 const Location& locateId(Context* context, ID id) {
   QUERY_BEGIN(locateId, context, id);
 


### PR DESCRIPTION
This PR adds token counting and code size stats when using the `dyno` parser. 

The production parser has the ability to count and print tokens
for files named on the command line. There are two tests that were
failing because this functionality was not available in `dyno`.

To avoid relying on global state, this implementation introduces
a struct that contains all of the counting functions and variables.

The reproduction in `dyno` is not 100% faithful to the original 
implementation w.r.t multi-line comments, mostly due to differences
in how the `dyno` parser handles comments. For example, `dyno` parses
and retains comment indicators `//`, `/*`, and `*/` where the old
parser discards them.

TESTING:

- [x] paratest
- [x] paratest with `--dyno` (34 failures)

reviewed by @mppf - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>