### PR TITLE
Add a test about the semantic behavior when submodule and top level share a name

### DIFF
--- a/test/visibility/import/submoduleCloser.bad
+++ b/test/visibility/import/submoduleCloser.bad
@@ -1,0 +1,2 @@
+submoduleCloser.chpl:11: In function 'main':
+submoduleCloser.chpl:15: error: Symbol 'do_my_impl' undeclared in module 'Details'

--- a/test/visibility/import/submoduleCloser.chpl
+++ b/test/visibility/import/submoduleCloser.chpl
@@ -1,0 +1,23 @@
+module ExternalLib1 {
+  module Details {}
+}
+
+// My library's implementation details.
+module Details {
+  proc do_my_impl() { writeln("whatev"); }
+}
+
+module SomeOtherFile {
+  proc main() {
+    {
+      use ExternalLib1;
+      import Details;       // Should this find the public module?
+      Details.do_my_impl(); // currently: compile-error
+    }
+    {
+      import ExternalLib1;
+      import Details;       // Resolves fine
+      Details.do_my_impl();
+    }
+  }
+}

--- a/test/visibility/import/submoduleCloser.future
+++ b/test/visibility/import/submoduleCloser.future
@@ -1,0 +1,2 @@
+semantic: should top level modules be equally visible for imports as submodules?
+#19782

--- a/test/visibility/import/submoduleCloser.good
+++ b/test/visibility/import/submoduleCloser.good
@@ -1,0 +1,2 @@
+whatev
+whatev


### PR DESCRIPTION
This future questions whether import should conflict or choose the module made
available by the use statement in the same scope (the latter being the behavior
today).

Michael brought this up during my demo on Monday

Checking a fresh checkout