### PR TITLE
Fix bug causing all elements in Locale.gpus to refer to the same sublocale

### DIFF
--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -243,7 +243,7 @@ module LocaleModelHelpSetup {
       dst.childLocales[i] = new unmanaged GPULocale(i:chpl_sublocID_t, dst);
       dst.childLocales[i].maxTaskPar = 1;
 
-      dst.gpuSublocales = new locale(dst.childLocales[i]);
+      dst.gpuSublocales[i] = new locale(dst.childLocales[i]);
     }
     chpl_task_setSubloc(origSubloc);
   }

--- a/test/gpu/native/multiGPU/PREDIFF
+++ b/test/gpu/native/multiGPU/PREDIFF
@@ -9,7 +9,7 @@ num_gpus=$((num_gpus-1))
 num_launches=$(cat $1.numlaunches)
 
 rm -f $1.good
-for i in $(seq 1 $num_gpus);
+for i in $(seq 0 $num_gpus);
 do
   echo "$num_launches Kernel launcher called. (subloc $i)" >> $1.good
 done

--- a/test/gpu/native/multiGPU/worksharing.chpl
+++ b/test/gpu/native/multiGPU/worksharing.chpl
@@ -28,8 +28,8 @@ for i in 1..numIters {
     A = B + alpha * C;
   }
   else {
-    const numPUs = here.gpus.size; 
-    const numGPUs = numPUs-1;
+    const numGPUs = here.gpus.size;
+    const numPUs = numGPUs+1;
     const chunkDiv = numGPUs+cpuToGpuRatio;
     var chunkSize = (n/chunkDiv):int;
     var cpuSize = (chunkSize*cpuToGpuRatio):int;
@@ -40,8 +40,8 @@ for i in 1..numIters {
     cobegin {
       A[cpuRange] = B[cpuRange] + alpha * C[cpuRange];
 
-      coforall sublocID in 0..#numGPUs do on here.gpu[sublocID] {
-        const myChunk = cpuSize+(sublocID-1)*gpuChunkSize..#gpuChunkSize;
+      coforall sublocID in 0..#numGPUs do on here.gpus[sublocID] {
+        const myChunk = cpuSize+sublocID*gpuChunkSize..#gpuChunkSize;
         if debug then writeln(sublocID, ": ", myChunk);
 
         var Aloc: [myChunk] int;

--- a/test/gpu/native/multiGPU/worksharingBasic.chpl
+++ b/test/gpu/native/multiGPU/worksharingBasic.chpl
@@ -14,8 +14,8 @@ assert((n/2)%numGPUs == 0);
 cobegin {
   A[0..#cpuSize] += 1;
   
-  coforall subloc in 0..<numGPUs do on here.gpu[subloc] {
-    const myShare = cpuSize+gpuSize*(subloc-1)..#gpuSize;
+  coforall subloc in 0..<numGPUs do on here.gpus[subloc] {
+    const myShare = cpuSize+gpuSize*subloc..#gpuSize;
     
     var AonThisGPU = A[myShare];
     AonThisGPU += 1;


### PR DESCRIPTION
This is to fix this failure: https://chapel.discourse.group/t/cron-cray-cs-gpu-native/12358

I was accidentally promoting the assignment rather than assigning to individual elements.

I also had to update multiGpu tests to refer to first gpu as having sublocId 0.

I also had a type in the worksharing tests (called locale.gpu rather than locale.gpus) and fix an off by 1 error.

---
Signed-off-by: Andy Stone <stonea@users.noreply.github.com>