### PR TITLE
Add a workaround for arch linux pic support

### DIFF
--- a/util/chplenv/chpl_lib_pic.py
+++ b/util/chplenv/chpl_lib_pic.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 import sys
-import platform
 
 import overrides
+import chpl_platform
 from utils import memoize
-
 
 @memoize
 def get():
@@ -12,14 +11,13 @@ def get():
     if not lib_pic_val:
         # Some platforms have 'gcc' and/or standard libraries
         # default to PIC. For those platforms, arrange for CHPL_LIB_PIC
-        # to defaurt to 'pic' instead of 'none' to avoid problems.
+        # to default to 'pic' instead of 'none' to avoid problems.
         #
         # Another option would be to check for --enable-default-pie in
         #   gcc -v -E
         # However, that would assume that 'gcc' is related to the link command,
         # which is not necessarily the case.
-        release = platform.uname()[2]
-        if 'arch' in release:
+        if chpl_platform.is_arch_linux():
             lib_pic_val = 'pic'
         else:
             lib_pic_val = 'none'

--- a/util/chplenv/chpl_lib_pic.py
+++ b/util/chplenv/chpl_lib_pic.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import platform
 
 import overrides
 from utils import memoize
@@ -9,7 +10,20 @@ from utils import memoize
 def get():
     lib_pic_val = overrides.get('CHPL_LIB_PIC')
     if not lib_pic_val:
-        lib_pic_val = 'none'
+        # Some platforms have 'gcc' and/or standard libraries
+        # default to PIC. For those platforms, arrange for CHPL_LIB_PIC
+        # to defaurt to 'pic' instead of 'none' to avoid problems.
+        #
+        # Another option would be to check for --enable-default-pie in
+        #   gcc -v -E
+        # However, that would assume that 'gcc' is related to the link command,
+        # which is not necessarily the case.
+        release = platform.uname()[2]
+        if 'arch' in release:
+            lib_pic_val = 'pic'
+        else:
+            lib_pic_val = 'none'
+
     return lib_pic_val
 
 

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -81,6 +81,11 @@ def get_mac_os_version():
     release, version, machine = platform.mac_ver()
     return release
 
+@memoize
+def is_arch_linux():
+    arch_file = "/etc/arch-release"
+    return os.path.exists(arch_file)
+
 # if running on a system with homebrew, return the homebrew prefix
 # if not, return None
 @memoize


### PR DESCRIPTION
This PR arranges for `CHPL_LIB_PIC` to default to `pic` instead of `none` on arch linux.

See also https://chapel.discourse.group/t/when-is-setting-chpl-lib-pic-necessary-for-working-build/12339 .

Reviewed by @lydia-duncan - thanks!

- [x] verified that `make; make check` in the default config works on Arch after this change
- [x] full local testing