### PR TITLE
Hide internal module names used by ChapelStandard

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -521,6 +521,7 @@ module BytesStringCommon {
   }
 
   proc getIndexType(type t) type {
+    import Bytes, String;
     if t==bytes then return Bytes.idxType;
     else if t==string then return String.byteIndex;
     else compilerError("This function should only be used by bytes or string");

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -25,7 +25,14 @@ module ChapelStandard {
   use startInitCommDiags;
   // Internal, but uses standard/CommDiagnostics
 
-  // Internal modules.
+  // The following list 'use's the internal modules whose contents
+  // should be available to every program (as well as some automatic
+  // standard modules that have moved around over time).  Note that
+  // these 'public use's make the contents of these modules available
+  // to 'use's of this module, but hide the name of the module itself
+  // (unless 'as xyz;' is also added).  Issue #19793 suggests taking
+  // this a step further and not permitting the user to refer to the
+  // names of internal modules at all.
   public use CString;
   public use Bytes;
   public use String;

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -26,46 +26,46 @@ module ChapelStandard {
   // Internal, but uses standard/CommDiagnostics
 
   // Internal modules.
-  public use CString as CString;
-  public use Bytes as Bytes;
-  public use String as String;
-  public use OwnedObject as OwnedObject;
-  public use SharedObject as SharedObject;
+  public use CString;
+  public use Bytes;
+  public use String;
+  public use OwnedObject;
+  public use SharedObject;
   public use ChapelEnv as ChapelEnv;
-  public use ChapelBase as ChapelBase;
-  public use Atomics as Atomics;
-  public use NetworkAtomics as NetworkAtomics;
-  public use NetworkAtomicTypes as NetworkAtomicTypes;
-  public use AtomicsCommon as AtomicsCommon;
-  public use ChapelIteratorSupport as ChapelIteratorSupport;
-  public use ChapelThreads as ChapelThreads;
-  public use ChapelTuple as ChapelTuple;
-  public use ChapelRange as ChapelRange;
-  public use ChapelReduce as ChapelReduce;
-  public use ChapelSyncvar as ChapelSyncvar;
-  public use ChapelTaskDataHelp as ChapelTaskDataHelp;
-  public use LocaleModel as _; // let LocaleModel refer to the class
-  public use ChapelLocale as ChapelLocale;
-  public use ChapelPrivatization as ChapelPrivatization;
-  public use DefaultRectangular as DefaultRectangular; // This might be able to go just after Atomics
-  public use LocalesArray as LocalesArray;
-  public use ChapelArray as ChapelArray;
-  public use ChapelDistribution as ChapelDistribution;
-  public use ChapelAutoLocalAccess as ChapelAutoLocalAccess;
+  public use ChapelBase;
+  public use Atomics;
+  public use NetworkAtomics;
+  public use NetworkAtomicTypes;
+  public use AtomicsCommon;
+  public use ChapelIteratorSupport;
+  public use ChapelThreads;
+  public use ChapelTuple;
+  public use ChapelRange;
+  public use ChapelReduce;
+  public use ChapelSyncvar;
+  public use ChapelTaskDataHelp;
+  public use LocaleModel;
+  public use ChapelLocale;
+  public use ChapelPrivatization;
+  public use DefaultRectangular;
+  public use LocalesArray;
+  public use ChapelArray;
+  public use ChapelDistribution;
+  public use ChapelAutoLocalAccess;
   public use ChapelIO as ChapelIO;
-  public use LocaleTree as LocaleTree;
-  public use ChapelHashing as ChapelHashing;
-  public use DefaultAssociative as DefaultAssociative;
-  public use DefaultSparse as DefaultSparse;
-  public use ChapelTaskID as ChapelTaskID;
-  public use ChapelTaskTable as ChapelTaskTable;
-  public use MemTracking as MemTracking;
-  public use ChapelUtil as ChapelUtil;
+  public use LocaleTree;
+  public use ChapelHashing;
+  public use DefaultAssociative;
+  public use DefaultSparse;
+  public use ChapelTaskID;
+  public use ChapelTaskTable;
+  public use MemTracking;
+  public use ChapelUtil;
   public use Errors as Errors;
-  public use ChapelTaskData as ChapelTaskData;
-  public use ChapelSerializedBroadcast as ChapelSerializedBroadcast;
-  public use ExportWrappers as ExportWrappers;
-  public use ChapelAutoAggregation as ChapelAutoAggregation;
+  public use ChapelTaskData;
+  public use ChapelSerializedBroadcast;
+  public use ExportWrappers;
+  public use ChapelAutoAggregation;
 
   // Standard modules.
   public use Types as Types;


### PR DESCRIPTION
This is a follow-up to #19306 which took pains to keep internal module symbols
visible to code by default via its use of `ChapelStandard`.  We don't generally
want to make these internal module names known/knowable to users, so this
PR hides them again and updates the one place I found that had been relying
on them being auto-available.