### PR TITLE
Make compiler updates required for LLVM-14

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2668,7 +2668,7 @@ GenRet codegenCallExprInner(GenRet function,
             func->getAttributes().hasAttributeAtIndex(llArgs.size()+1,
                                                       llvm::Attribute::ByVal);
 #else
-	  bool funcHasAttribute =
+          bool funcHasAttribute =
             func->getAttributes().hasAttribute(llArgs.size()+1,
                                                llvm::Attribute::ByVal);
 #endif

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -338,9 +338,8 @@ static llvm::Value* createInBoundsGEP(llvm::Value* ptr,
       // consider calling extendToPointerSize at the call site
     }
   }
-
 #if HAVE_LLVM_VER >= 130
-  return info->irBuilder->CreateInBoundsGEP(llvm::cast<llvm::PointerType>(ptr->getType()->getScalarType())->getElementType(), ptr, idxList);
+  return info->irBuilder->CreateInBoundsGEP(llvm::cast<llvm::PointerType>(ptr->getType()->getScalarType())->getPointerElementType(), ptr, idxList);
 #else
   return info->irBuilder->CreateInBoundsGEP(ptr, idxList);
 #endif
@@ -422,7 +421,7 @@ GenRet codegenWideAddr(GenRet locale, GenRet raddr, Type* wideType = NULL)
 #ifdef HAVE_LLVM
       llvm::Type* ty = nullptr;
 #if HAVE_LLVM_VER >= 130
-      ty = llvm::cast<llvm::PointerType>(ret.val->getType()->getScalarType())->getElementType();
+      ty = llvm::cast<llvm::PointerType>(ret.val->getType()->getScalarType())->getPointerElementType();
 #endif
       llvm::Value* adr = info->irBuilder->CreateStructGEP(
           ty, ret.val, WIDE_GEP_ADDR);
@@ -453,7 +452,11 @@ GenRet codegenWideAddr(GenRet locale, GenRet raddr, Type* wideType = NULL)
     llvm::Function* fn = getMakeFn(info->module, &info->globalToWideInfo,
                                    addrType);
     INT_ASSERT(fn);
+#if HAVE_LLVM_VER >= 130
+    llvm::Type* eltType = addrType->getPointerElementType();
+#else
     llvm::Type* eltType = addrType->getElementType();
+#endif
     llvm::Type* locAddrType = llvm::PointerType::getUnqual(eltType);
     // Null pointers require us to possibly cast to the pointer type
     // we are supposed to have since null has type void*.
@@ -571,10 +574,13 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
     if( ptr.isLVPtr ) valType = ptr.chplType;
     else valType = ptr.chplType->getValType();
   }
-
+#if HAVE_LLVM_VER >= 130
+  llvm::Type* ptrValType = llvm::cast<llvm::PointerType>(
+                                      ptr.val->getType())->getPointerElementType();
+#else
   llvm::Type* ptrValType = llvm::cast<llvm::PointerType>(
                                       ptr.val->getType())->getElementType();
-
+#endif
   // implicit cast in C, needs to be made explicit in LLVM
   // e.g. T3 = alloca i8;
   //      T3 = (T == T2);   // not actual LLVM syntax
@@ -876,7 +882,7 @@ static GenRet codegenWideThingField(GenRet ws, WideThingField field)
         llvm::Type* ty = nullptr;
 #if HAVE_LLVM_VER >= 130
         ty = llvm::cast<llvm::PointerType>(
-          ws.val->getType()->getScalarType())->getElementType();
+          ws.val->getType()->getScalarType())->getPointerElementType();
 #endif
         ret.val = info->irBuilder->CreateConstInBoundsGEP2_32(
                                             ty, ws.val, 0, field);
@@ -1160,7 +1166,7 @@ GenRet doCodegenFieldPtr(
       bool unused;
       llvm::Type* eltTy = nullptr;
 #if HAVE_LLVM_VER >= 130
-      eltTy = llvm::cast<llvm::PointerType>(baseValue->getType()->getScalarType())->getElementType();
+      eltTy = llvm::cast<llvm::PointerType>(baseValue->getType()->getScalarType())->getPointerElementType();
 #endif
       ret.val = info->irBuilder->CreateStructGEP(
           eltTy, baseValue, cBaseType->getMemberGEP("_u", unused));
@@ -1181,28 +1187,33 @@ GenRet doCodegenFieldPtr(
         llvm::Type* baseTy = nullptr;
         llvm::Type* retTy = nullptr;
 #if HAVE_LLVM_VER >= 130
-        baseTy = llvm::cast<llvm::PointerType>(baseValue->getType()->getScalarType())->getElementType();
+        baseTy = llvm::cast<llvm::PointerType>(baseValue->getType()->getScalarType())->getPointerElementType();
 #endif
         ret.val = info->irBuilder->CreateStructGEP(baseTy, baseValue, fieldno);
 #if HAVE_LLVM_VER >= 130
-        retTy = llvm::cast<llvm::PointerType>(ret.val->getType()->getScalarType())->getElementType();
+        retTy = llvm::cast<llvm::PointerType>(ret.val->getType()->getScalarType())->getPointerElementType();
 #endif
         ret.val = info->irBuilder->CreateStructGEP(retTy, ret.val, 0);
         ret.isLVPtr = GEN_VAL;
       } else {
+        llvm::Type* ty = nullptr;
 #if HAVE_LLVM_VER >= 130
-        llvm::Type* ty = llvm::cast<llvm::PointerType>(baseValue->getType()->getScalarType())->getElementType();
-        ret.val = info->irBuilder->CreateStructGEP(ty, baseValue, fieldno);
-#else
-        ret.val = info->irBuilder->CreateStructGEP(NULL, baseValue, fieldno);
+        ty = llvm::cast<llvm::PointerType>(baseValue->getType()->getScalarType())->getPointerElementType();
 #endif
+        ret.val = info->irBuilder->CreateStructGEP(ty, baseValue, fieldno);
+
         if ((isClass(ct) || isRecord(ct)) &&
           cBaseType->symbol->llvmTbaaAggTypeDescriptor &&
           ret.chplType->symbol->llvmTbaaTypeDescriptor != info->tbaaRootNode) {
-
+#if HAVE_LLVM_VER >= 130
           llvm::StructType *structType = llvm::cast<llvm::StructType>
             (llvm::cast<llvm::PointerType>
-             (baseValue->getType())->getElementType());
+             (baseValue->getType())->getPointerElementType());
+#else
+          llvm::StructType *structType = llvm::cast<llvm::StructType>
+            (llvm::cast<llvm::PointerType>
+             (baseValue->getType())->getPointerElementType());
+#endif
           ret.surroundingStruct = cBaseType;
           ret.fieldOffset = info->module->getDataLayout().
             getStructLayout(structType)->getElementOffset(fieldno);
@@ -2587,7 +2598,7 @@ GenRet codegenCallExprInner(GenRet function,
                 for (unsigned i = 0; i < nElts; i++) {
                   // load to produce the next LLVM argument
 #if HAVE_LLVM_VER >= 130
-                  llvm::Type* ty = llvm::cast<llvm::PointerType>(ptr->getType()->getScalarType())->getElementType();
+                  llvm::Type* ty = llvm::cast<llvm::PointerType>(ptr->getType()->getScalarType())->getPointerElementType();
                   llvm::Value* eltPtr =
                     irBuilder->CreateStructGEP(ty, ptr, i);
                   llvm::Value* loaded =
@@ -2651,12 +2662,19 @@ GenRet codegenCallExprInner(GenRet function,
         }
       } else {
 
-        if (llArgs.size() < fnType->getNumParams() &&
-            func &&
+        if (llArgs.size() < fnType->getNumParams() && func) {
+#if HAVE_LLVM_VER >= 140
+          bool funcHasAttribute =
+            func->getAttributes().hasAttributeAtIndex(llArgs.size()+1,
+                                                      llvm::Attribute::ByVal);
+#else
+	  bool funcHasAttribute =
             func->getAttributes().hasAttribute(llArgs.size()+1,
-                                               llvm::Attribute::ByVal))
-          INT_FATAL("byval without ABI info not implemented");
-
+                                               llvm::Attribute::ByVal);
+#endif
+          if (funcHasAttribute)
+            INT_FATAL("byval without ABI info not implemented");
+        }
         llvm::Value* val = NULL;
 
         if (llArgs.size() < fnType->getNumParams()) {

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1851,7 +1851,7 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
           b.addAttribute(llvm::Attribute::InReg);
 #if HAVE_LLVM_VER >= 140
         attrs = attrs.addAttributesAtIndex(ctx,
-			                   llvm::AttributeList::ReturnIndex, b);
+                                           llvm::AttributeList::ReturnIndex, b);
 #else
         attrs = attrs.addAttributes(ctx, llvm::AttributeList::ReturnIndex, b);
 #endif
@@ -1875,7 +1875,7 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
           b.addAttribute(llvm::Attribute::InReg);
 #if HAVE_LLVM_VER >= 140
         attrs = attrs.addAttributesAtIndex(ctx,
-			                   llvm::AttributeList::ReturnIndex, b);
+                                           llvm::AttributeList::ReturnIndex, b);
 #else
         attrs = attrs.addAttributes(ctx, llvm::AttributeList::ReturnIndex, b);
 #endif

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1801,7 +1801,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
     if (fn->hasFlag(FLAG_LLVM_RETURN_NOALIAS)) {
       // Add NoAlias on return for allocator-like functions
       if (returnTy->isPointerTy()) {
+#if HAVE_LLVM_VER >= 140
         llvm::AttrBuilder b(ctx);
+#else
+        llvm::AttrBuilder b;
+#endif
         b.addAttribute(llvm::Attribute::NoAlias);
 #if HAVE_LLVM_VER >= 140
         attrs = attrs.addAttributesAtIndex(ctx,
@@ -1838,7 +1842,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
 
       case clang::CodeGen::ABIArgInfo::Kind::Direct:
       {
+#if HAVE_LLVM_VER >= 140
         llvm::AttrBuilder b(ctx);
+#else
+        llvm::AttrBuilder b;
+#endif
         if (returnInfo.getInReg())
           b.addAttribute(llvm::Attribute::InReg);
 #if HAVE_LLVM_VER >= 140
@@ -1853,8 +1861,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
       case clang::CodeGen::ABIArgInfo::Kind::Extend:
       {
         bool isSigned = returnInfo.isSignExt();
-
+#if HAVE_LLVM_VER >= 140
         llvm::AttrBuilder b(ctx);
+#else
+        llvm::AttrBuilder b;
+#endif
         if (isSigned)
           b.addAttribute(llvm::Attribute::SExt);
         else
@@ -1904,7 +1915,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
       argNames.push_back("indirect_return");
 
       // Adjust attributes for sret argument
+#if HAVE_LLVM_VER >= 140
       llvm::AttrBuilder b(ctx);
+#else
+      llvm::AttrBuilder b;
+#endif
 #if HAVE_LLVM_VER >= 130
       b.addStructRetAttr(llvm::PointerType::get(chapelReturnTy, stackSpace));
 #else
@@ -1927,7 +1942,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
       argNames.push_back("inalloca_arg");
 
       // Adjust attributes for inalloca argument
+#if HAVE_LLVM_VER >= 140
       llvm::AttrBuilder b(ctx);
+#else
+      llvm::AttrBuilder b;
+#endif
       b.addAttribute(llvm::Attribute::InAlloca);
 #if HAVE_LLVM_VER >= 140
       attrs = attrs.addAttributesAtIndex(ctx, argTys.size(), b);
@@ -1961,7 +1980,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
 
         // Adjust attributes for padding argument
         if (argInfo->getPaddingInReg()) {
+#if HAVE_LLVM_VER >= 140
           llvm::AttrBuilder b(ctx);
+#else
+          llvm::AttrBuilder b;
+#endif
           b.addAttribute(llvm::Attribute::InReg);
 #if HAVE_LLVM_VER >= 140
           attrs = attrs.addAttributesAtIndex(ctx, argTys.size(), b);
@@ -1991,7 +2014,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
           argNames.push_back(astr(formal->cname, ".indirect"));
 
           // Adjust attributes for indirect argument
+#if HAVE_LLVM_VER >= 140
           llvm::AttrBuilder b(ctx);
+#else
+          llvm::AttrBuilder b;
+#endif
           if (argInfo->getInReg()) {
             b.addAttribute(llvm::Attribute::InReg);
           }
@@ -2027,7 +2054,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
               argTys.push_back(sTy->getElementType(i));
               argNames.push_back(astr(formal->cname, ".", istr(i)));
               // Adjust attributes
+#if HAVE_LLVM_VER >= 140
               llvm::AttrBuilder b(ctx);
+#else
+              llvm::AttrBuilder b;
+#endif
               if (argInfo->isExtend()) {
                 if (argInfo->isSignExt()) b.addAttribute(llvm::Attribute::SExt);
                 else                      b.addAttribute(llvm::Attribute::ZExt);
@@ -2049,7 +2080,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
               name = astr(name, ".coerce");
             argNames.push_back(name);
             // Adjust attributes
+#if HAVE_LLVM_VER >= 140
             llvm::AttrBuilder b(ctx);
+#else
+            llvm::AttrBuilder b;
+#endif
             if (formal->isRef() && argTy == toTy) {
               b.addAttribute(llvm::Attribute::NonNull);
               llvm::Type* valType = formal->getValType()->codegen().type;
@@ -2097,7 +2132,11 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
       argTys.push_back(argTy);
       argNames.push_back(formal->cname);
       if(formal->isRef()) {
+#if HAVE_LLVM_VER >= 140
         llvm::AttrBuilder b(ctx);
+#else
+        llvm::AttrBuilder b;
+#endif
         b.addAttribute(llvm::Attribute::NonNull);
         llvm::Type* valType = formal->getValType()->codegen().type;
         int64_t sz = getTypeSizeInBytes(layout, valType);

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -260,9 +260,13 @@ static void genGlobalRawString(const char *cname, std::string &value, size_t len
                       cname, llvm::IntegerType::getInt8PtrTy(info->module->getContext())));
       auto globalStringIr = info->irBuilder->CreateGlobalString(value);
       llvm::Type* ty = nullptr;
+#if HAVE_LLVM_VER >= 140
+      ty = globalStringIr->getValueType();
+#else
 #if HAVE_LLVM_VER >= 130
       ty = llvm::cast<llvm::PointerType>(
         globalStringIr->getType()->getScalarType())->getElementType();
+#endif
 #endif
       auto correctlyTypedValue = info->irBuilder->CreateConstInBoundsGEP2_32(
         ty, globalStringIr, 0, 0);

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -671,8 +671,13 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
     // Determine alignment
     unsigned Alignment = Range.Alignment;
     if (Alignment == 0) {
+#if HAVE_LLVM_VER >= 130
+      Type *EltType =
+        cast<PointerType>(StartPtr->getType())->getPointerElementType();
+#else
       Type *EltType =
         cast<PointerType>(StartPtr->getType())->getElementType();
+#endif
       Alignment = DL->getABITypeAlignment(EltType);
     }
 

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -300,7 +300,11 @@ namespace {
       }
       FunctionType* ft = NULL;
       if( PointerType* pt = dyn_cast<PointerType>(t) ) {
+#if HAVE_LLVM_VER >= 130
+        t = pt->getPointerElementType();
+#else
         t = pt->getElementType();
+#endif
       }
       ft = cast<FunctionType>(t);
       assert(ft);
@@ -1503,13 +1507,22 @@ namespace {
 
         if (update_return) {
           // if it's no longer a pointer, remove pointer-based attributes
+#if HAVE_LLVM_VER >= 140
+          NF->removeRetAttrs(AttributeFuncs::typeIncompatible(RetTy));
+#else
           NF->removeAttributes(AttributeList::ReturnIndex,
                                AttributeFuncs::typeIncompatible(RetTy));
+#endif
         }
         if (update_parameters) {
           for (size_t i = 0; i < Params.size(); i++ ) {
+#if HAVE_LLVM_VER >= 140
+            NF->removeParamAttrs(i+1,
+                                 AttributeFuncs::typeIncompatible(Params[i]));
+#else
             NF->removeAttributes(i+1,
                                  AttributeFuncs::typeIncompatible(Params[i]));
+#endif
           }
         }
 

--- a/test/execflags/bradc/gdbddash/declint.skipif
+++ b/test/execflags/bradc/gdbddash/declint.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM!=none

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -15,7 +15,7 @@ def llvm_versions():
     # Which major release - only need one number for that with current
     # llvm (since LLVM 4.0).
     # These will be tried in order.
-    return ('13','12','11',)
+    return ('14','13','12','11',)
 
 @memoize
 def get_uniq_cfg_path_for(llvm_val):


### PR DESCRIPTION
Update the compiler to work with LLVM-14 while continuing to work with other
already supported versions (11-13).

LLVM is moving toward opaque pointers, so PointerType::getElementType() is
deprecated. For now, switch to PointerType::getPointerElementType().
Eventually we'll need to switch to getting the type somewhere other than
from the pointer. https://llvm.org/docs/OpaquePointers.html

In a few spots functions named "removeAttribute" or similar became
"removeAttributeAtIndex".

llvm::AttrBuilder now takes a required context argument in its constructor. Add
"#if ..." to only use that argument for version 14 and above.

A few header files were renamed or relocated.

Some codegen and target option flags were removed.

Updated util/chplenv/chpl_llvm.py to allow LLVM version 14.

Added a .skipif to skip execflags/bradc/gdbdash/declint.chpl with LLVM due
to a DWARF error in gdb.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>
