### PR TITLE
dyno: don't convert _ in As statements

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -642,13 +642,9 @@ struct Converter {
     astlocMarker markAstLoc(node->id());
 
     Expr* one = toExpr(convertAST(node->symbol()));
-    Expr* two = nullptr;
-    // if this rename is to '_', don't convert it to chpl__tuple_blank!
-    if (node->rename()->toIdentifier()->name()==USTR("_"))
-      two = new UnresolvedSymExpr("_");
-    else
-      two = toExpr(convertAST(node->rename()));
-    assert(two);
+    auto renameIdent = node->rename()->toIdentifier();
+    assert(renameIdent);
+    Expr* two = new UnresolvedSymExpr(renameIdent->name().c_str());
     return std::pair<Expr*, Expr*>(one, two);
   }
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -642,7 +642,13 @@ struct Converter {
     astlocMarker markAstLoc(node->id());
 
     Expr* one = toExpr(convertAST(node->symbol()));
-    Expr* two = toExpr(convertAST(node->rename()));
+    Expr* two = nullptr;
+    // if this rename is to '_', don't convert it to chpl__tuple_blank!
+    if (node->rename()->toIdentifier()->name()==USTR("_"))
+      two = new UnresolvedSymExpr("_");
+    else
+      two = toExpr(convertAST(node->rename()));
+    assert(two);
     return std::pair<Expr*, Expr*>(one, two);
   }
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -638,7 +638,7 @@ struct Converter {
     return ret;
   }
 
-  std::pair<Expr*, Expr*> convertAs(const uast::As* node) {
+  std::pair<Expr*, Expr*> convertAsForRename(const uast::As* node) {
     astlocMarker markAstLoc(node->id());
 
     Expr* one = toExpr(convertAST(node->symbol()));
@@ -660,7 +660,7 @@ struct Converter {
 
     if (auto as = node->toAs()) {
       ret->tag = PotentialRename::DOUBLE;
-      ret->renamed = new std::pair<Expr*, Expr*>(convertAs(as));
+      ret->renamed = new std::pair<Expr*, Expr*>(convertAsForRename(as));
     } else {
       ret->tag = PotentialRename::SINGLE;
       ret->elem = toExpr(convertAST(node));
@@ -693,7 +693,7 @@ struct Converter {
     }
 
     if (auto as = vc->symbol()->toAs()) {
-      auto exprs = convertAs(as);
+      auto exprs = convertAsForRename(as);
       mod = exprs.first;
       rename = exprs.second;
     } else {


### PR DESCRIPTION
This PR fixes a bug caused by eagerly converting the rename part of an `As`
node. Previously we were erroneously converting a rename to `_` the same 
as `chpl__tuple_blank`, which is not correct in the case of an `As` statement. 

TESTING:

- [x] paratest
- [x] paratest with `--dyno` (26 failures)

reviewed by @dlongnecke-cray - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>