### PR TITLE
Revert "Drop M1 mac testing to just hellos"

### DIFF
--- a/util/cron/test-darwin-m1.bash
+++ b/util/cron/test-darwin-m1.bash
@@ -8,4 +8,4 @@ source $CWD/common-darwin.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
 
-$CWD/nightly -cron -hellos
+$CWD/nightly -cron -examples


### PR DESCRIPTION
This reverts commit 4da134b349. We may have improved the disconnect
issues, so bump the amount of testing we do again to check.

For Cray/chapel-private#3310