### PR TITLE
Allow CHPL_LOCALE_MODEL=gpu and CHPL_COMM=gasnet; also refactor GpuTransforms

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2626,27 +2626,27 @@ static void codegenPartTwo() {
     codegen_library_makefile();
   }
 
-    // Vectors to store different symbol names to be used while generating header
-    std::set<const char*> cnames;
-    std::vector<TypeSymbol*> types;
-    std::vector<FnSymbol*> functions;
-    std::vector<VarSymbol*> globals;
+  // Vectors to store different symbol names to be used while generating header
+  std::set<const char*> cnames;
+  std::vector<TypeSymbol*> types;
+  std::vector<FnSymbol*> functions;
+  std::vector<VarSymbol*> globals;
 
-    // This dumps the generated sources into the build directory.
-    info->cfile = hdrfile.fptr;
-    codegen_header(cnames, types, functions, globals);
+  // This dumps the generated sources into the build directory.
+  info->cfile = hdrfile.fptr;
+  codegen_header(cnames, types, functions, globals);
 
-    // Prepare the LLVM IR dumper for code generation
-    // This needs to happen after protectNameFromC which happens
-    // currently in codegen_header.
-    preparePrintLlvmIrForCodegen();
+  // Prepare the LLVM IR dumper for code generation
+  // This needs to happen after protectNameFromC which happens
+  // currently in codegen_header.
+  preparePrintLlvmIrForCodegen();
 
-    info->cfile = defnfile.fptr;
-    codegen_defn(cnames, types, functions, globals);
-    info->cfile = mainfile.fptr;
-    if ( gCodegenGPU == false ) {
-      codegen_config();
-    }
+  info->cfile = defnfile.fptr;
+  codegen_defn(cnames, types, functions, globals);
+  info->cfile = mainfile.fptr;
+  if ( gCodegenGPU == false ) {
+    codegen_config();
+  }
 
   // Don't need to do most of the rest of the function for LLVM;
   // just codegen the modules.
@@ -2717,48 +2717,30 @@ void codegen() {
     // name uses the PID).
     ensureTmpDirExists();
 
-    //pid_t pid = fork();
+    pid_t pid = fork();
 
-    //if (pid == 0) {
+    if (pid == 0) {
       // child process
-
-    gCodegenGPU = true;
+      gCodegenGPU = true;
       codegenPartTwo();
       makeBinary();
-      //clean_exit(0);
-    //} else {
+      clean_exit(0);
+    } else {
       // parent process
-    gCodegenGPU = false;
-    //INT_ASSERT(!gCodegenGPU);
-      //int status = 0;
-      //while (wait(&status) != pid) {
+      INT_ASSERT(!gCodegenGPU);
+      int status = 0;
+      while (wait(&status) != pid) {
         // wait for child process
-      //}
+      }
       // If there was an error in GPU code generation then the .fatbin file (containing
       // the generated GPU code) was not created and we won't be able to continue.
-      //if(status != 0) {
-        //clean_exit(status);
-      //}
-    //}
-
-    // Types cache their code generated result we need to re codegen them into the new
-    // llvm context between our first invocation of clang (where we generate the GPU
-    // code) and the second (where we generate everything else).
-    forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-      ts->llvmType = nullptr;
-      ts->llvmTbaaTypeDescriptor = nullptr;
-      ts->llvmTbaaAccessTag = nullptr;
-      ts->llvmConstTbaaAccessTag = nullptr;
-      ts->llvmTbaaAggTypeDescriptor = nullptr;
-      ts->llvmTbaaAggAccessTag = nullptr;
-      ts->llvmConstTbaaAggAccessTag = nullptr;
-      ts->llvmTbaaStructCopyNode = nullptr;
-      ts->llvmConstTbaaStructCopyNode = nullptr;
-      ts->llvmDIType = nullptr;
+      if(status != 0) {
+        clean_exit(status);
+      }
     }
   }
 
-      codegenPartTwo();
+  codegenPartTwo();
 }
 
 void makeBinary(void) {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1965,7 +1965,7 @@ static void codegen_header(std::set<const char*> & cnames,
   //
   if( hdrfile ) {
     fprintf(hdrfile, "\nextern void* const chpl_private_broadcast_table[];\n");
-  } else {
+  } else if(!gCodegenGPU) {
 #ifdef HAVE_LLVM
     llvm::Type *private_broadcastTableEntryType =
       llvm::IntegerType::getInt8PtrTy(info->module->getContext());
@@ -2626,27 +2626,27 @@ static void codegenPartTwo() {
     codegen_library_makefile();
   }
 
-  // Vectors to store different symbol names to be used while generating header
-  std::set<const char*> cnames;
-  std::vector<TypeSymbol*> types;
-  std::vector<FnSymbol*> functions;
-  std::vector<VarSymbol*> globals;
+    // Vectors to store different symbol names to be used while generating header
+    std::set<const char*> cnames;
+    std::vector<TypeSymbol*> types;
+    std::vector<FnSymbol*> functions;
+    std::vector<VarSymbol*> globals;
 
-  // This dumps the generated sources into the build directory.
-  info->cfile = hdrfile.fptr;
-  codegen_header(cnames, types, functions, globals);
+    // This dumps the generated sources into the build directory.
+    info->cfile = hdrfile.fptr;
+    codegen_header(cnames, types, functions, globals);
 
-  // Prepare the LLVM IR dumper for code generation
-  // This needs to happen after protectNameFromC which happens
-  // currently in codegen_header.
-  preparePrintLlvmIrForCodegen();
+    // Prepare the LLVM IR dumper for code generation
+    // This needs to happen after protectNameFromC which happens
+    // currently in codegen_header.
+    preparePrintLlvmIrForCodegen();
 
-  info->cfile = defnfile.fptr;
-  codegen_defn(cnames, types, functions, globals);
-  info->cfile = mainfile.fptr;
-  if ( gCodegenGPU == false ) {
-    codegen_config();
-  }
+    info->cfile = defnfile.fptr;
+    codegen_defn(cnames, types, functions, globals);
+    info->cfile = mainfile.fptr;
+    if ( gCodegenGPU == false ) {
+      codegen_config();
+    }
 
   // Don't need to do most of the rest of the function for LLVM;
   // just codegen the modules.
@@ -2717,30 +2717,48 @@ void codegen() {
     // name uses the PID).
     ensureTmpDirExists();
 
-    pid_t pid = fork();
+    //pid_t pid = fork();
 
-    if (pid == 0) {
+    //if (pid == 0) {
       // child process
-      gCodegenGPU = true;
+
+    gCodegenGPU = true;
       codegenPartTwo();
       makeBinary();
-      clean_exit(0);
-    } else {
+      //clean_exit(0);
+    //} else {
       // parent process
-      INT_ASSERT(!gCodegenGPU);
-      int status = 0;
-      while (wait(&status) != pid) {
+    gCodegenGPU = false;
+    //INT_ASSERT(!gCodegenGPU);
+      //int status = 0;
+      //while (wait(&status) != pid) {
         // wait for child process
-      }
+      //}
       // If there was an error in GPU code generation then the .fatbin file (containing
       // the generated GPU code) was not created and we won't be able to continue.
-      if(status != 0) {
-        clean_exit(status);
-      }
+      //if(status != 0) {
+        //clean_exit(status);
+      //}
+    //}
+
+    // Types cache their code generated result we need to re codegen them into the new
+    // llvm context between our first invocation of clang (where we generate the GPU
+    // code) and the second (where we generate everything else).
+    forv_Vec(TypeSymbol, ts, gTypeSymbols) {
+      ts->llvmType = nullptr;
+      ts->llvmTbaaTypeDescriptor = nullptr;
+      ts->llvmTbaaAccessTag = nullptr;
+      ts->llvmConstTbaaAccessTag = nullptr;
+      ts->llvmTbaaAggTypeDescriptor = nullptr;
+      ts->llvmTbaaAggAccessTag = nullptr;
+      ts->llvmConstTbaaAggAccessTag = nullptr;
+      ts->llvmTbaaStructCopyNode = nullptr;
+      ts->llvmConstTbaaStructCopyNode = nullptr;
+      ts->llvmDIType = nullptr;
     }
   }
 
-  codegenPartTwo();
+      codegenPartTwo();
 }
 
 void makeBinary(void) {

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -44,54 +44,53 @@ int indentGPUChecksLevel = 0;
 extern int classifyPrimitive(CallExpr *call, bool inLocal);
 extern bool inLocalBlock(CallExpr *call);
 
-struct OutlineInfo {
-  // Given a CForLoop that we want to outline into a function for a GPU kernel
-  // extract the loopIndices, lowerBounds, and upperBound and populate it with
-  // boilerplate computation to calculate what index the kernel should operate
-  // on given its thread ID. After buildStubOutlinedFunction is finished its up
-  // to the caller to populate its body with the body of the loop and to call
-  // the outlined function. It's possible that we fail to build the function if
-  // the loop boundaries don't represent a range if this is the case we return
-  // false and the caller should stop trying to outline.
-  bool buildStubOutlinedFunction(CForLoop* loop);
+// --------------------------------------------------------------------------------------------------------------------
+// Utilities
+// --------------------------------------------------------------------------------------------------------------------
 
-  CForLoop* loop = NULL;
+// If any SymExpr is referring to a variable defined outside the
+// function return the SymExpr. Otherwise return nullptr
+static SymExpr* hasOuterVarAccesses(FnSymbol* fn) {
+  std::vector<SymExpr*> ses;
+  collectSymExprs(fn, ses);
+  for_vector(SymExpr, se, ses) {
+    if (VarSymbol* var = toVarSymbol(se->symbol())) {
+      if (var->defPoint->parentSymbol != fn) {
+        if (!var->isParameter() && var != gVoid) {
+          return se;
+        }
+      }
+    }
+  }
+  return nullptr;
+}
 
-  std::vector<Symbol*> loopIndices;
-  std::vector<Symbol*> lowerBounds;
-  Symbol* upperBound = NULL;
+static void errorForOuterVarAccesses(FnSymbol* fn) {
+  if (SymExpr* se = hasOuterVarAccesses(fn)) {
+    VarSymbol* var = toVarSymbol(se->symbol());
+    INT_ASSERT(var);
+    USR_FATAL(se, "variable '%s' must be defined in the function it"
+                  " is used in for GPU usage", var->name);
+  }
+}
 
-  FnSymbol* fn;
-  std::vector<Symbol*> kernelIndices;
-  std::vector<Symbol*> kernelActuals;
+static VarSymbol* insertNewVarAndDef(BlockStmt* insertionPoint, const char* name,
+                                     Type* type) {
+  VarSymbol *var = new VarSymbol(name, type);
+  var->defPoint = new DefExpr(var);
+  insertionPoint->insertAtTail(var->defPoint);
+  return var;
+}
 
-  SymbolMap copyMap;
+static VarSymbol* generateAssignmentToPrimitive(
+    FnSymbol* fn, const char *varName, PrimitiveTag prim, Type *primReturnType) {
 
-  private:
-  bool extractIndicesAndLowerBounds(CForLoop* loop);
-  bool extractUpperBound(CForLoop* loop);
-  void generateIndexComputation();
-};
+  VarSymbol *var = insertNewVarAndDef(fn->body, varName, primReturnType);
+  CallExpr *c1 = new CallExpr(PRIM_MOVE, var, new CallExpr(prim));
+  fn->insertAtTail(c1);
 
-static VarSymbol* generateAssignmentToPrimitive(FnSymbol* fn,
-                                                const char *varName,
-                                                PrimitiveTag prim,
-                                                Type *primReturnType);
-
-static void generateEarlyReturn(OutlineInfo& info);
-
-static bool shouldOutlineLoop(BlockStmt* blk, bool allowFnCalls);
-
-static bool shouldOutlineLoopHelp(BlockStmt* blk,
-                                  std::set<FnSymbol*>& okFns,
-                                  std::set<FnSymbol*> visitedFns,
-                                  bool allowFnCalls);
-
-static SymExpr* hasOuterVarAccesses(FnSymbol* fn);
-static void markGPUSuitableLoops();
-
-static Symbol* addKernelArgument(OutlineInfo& info, Symbol* symInLoop);
-
+  return var;
+}
 static bool isDefinedInTheLoop(Symbol* sym, CForLoop* loop) {
   LoopStmt* curLoop = LoopStmt::findEnclosingLoop(sym->defPoint);
 
@@ -123,489 +122,78 @@ static bool isDegenerateOuterRef(Symbol* sym, CForLoop* loop) {
   }
 
   for_SymbolUses(use, sym) {
-    if (LoopStmt::findEnclosingLoop(use) != loop) {
-      return false;
+      if (LoopStmt::findEnclosingLoop(use) != loop) {
+        return false;
+      }
     }
-  }
 
   for_SymbolDefs(def, sym) {
-    if (LoopStmt::findEnclosingLoop(def) != loop) {
-      return false;
+      if (LoopStmt::findEnclosingLoop(def) != loop) {
+        return false;
+      }
     }
-  }
 
   return true;
 }
 
-static bool isIndexVariable(OutlineInfo& info, Symbol* sym) {
-  std::vector<Symbol*>& indices = info.loopIndices;
+// --------------------------------------------------------------------------------------------------------------------
+// GpuizableLoop
+// --------------------------------------------------------------------------------------------------------------------
 
-  return std::find(indices.begin(), indices.end(), sym) != indices.end();
-}
+// Used to evaluate if a loop is eligible to be outlined into a GPU kernel and extracts information about
+// the loop's bounds and indices.
+class GpuizableLoop {
+  CForLoop* loop_ = nullptr;
+  bool isEligible_ = false;
+  Symbol* upperBound_ = nullptr;
+  std::vector<Symbol*> loopIndices_;
+  std::vector<Symbol*> lowerBounds_;
 
-bool OutlineInfo::extractUpperBound(CForLoop* loop) {
-  if(BlockStmt* bs = toBlockStmt(loop->testBlockGet())) {
-    for_exprs_postorder (expr, bs) {
-      if(CallExpr *call = toCallExpr(expr)) {
-        if(call->isPrimitive(PRIM_LESSOREQUAL)) {
-          if(SymExpr *symExpr = toSymExpr(call->get(2))) {
+public:
+  GpuizableLoop(BlockStmt* blk, bool allowFnCalls);
 
-            SymExpr* lhsSymExpr = toSymExpr(call->get(1));
-            INT_ASSERT(lhsSymExpr && lhsSymExpr->symbol() == this->loopIndices[0]);
-
-            this->upperBound = symExpr->symbol();
-
-            break;
-          }
-        }
-      }
-    }
+  CForLoop* loop() const { return loop_; }
+  bool isEligible() const { return isEligible_; }
+  Symbol* upperBound() const { return upperBound_; }
+  const std::vector<Symbol*>& loopIndices() const { return loopIndices_; }
+  const std::vector<Symbol*>& lowerBounds() const { return lowerBounds_; }
+  bool isIndexVariable(Symbol* sym) const {
+    return std::find(loopIndices_.begin(), loopIndices_.end(), sym) != loopIndices_.end();
   }
 
-  return this->upperBound != NULL;
+private:
+  bool evaluateLoop(BlockStmt *blk, bool allowFnCalls);
+  bool shouldOutlineLoopHelp(BlockStmt *blk, std::set<FnSymbol *> &okFns, std::set<FnSymbol *> visitedFns,
+                             bool allowFnCalls);
+  bool attemptToExtractLoopInformation();
+  bool extractIndicesAndLowerBounds();
+  bool extractUpperBound();
+};
+
+GpuizableLoop::GpuizableLoop(BlockStmt *blk, bool allowFnCalls) {
+  this->loop_ = toCForLoop(blk);
+  this->isEligible_ = evaluateLoop(blk, allowFnCalls);
 }
 
-bool OutlineInfo::extractIndicesAndLowerBounds(CForLoop* loop) {
-  if(BlockStmt* bs = toBlockStmt(loop->initBlockGet())) {
-    for_alist (expr, bs->body) {
-      if(CallExpr *call = toCallExpr(expr)) {
-        if(call->isPrimitive(PRIM_ASSIGN) ||
-           call->isPrimitive(PRIM_MOVE)) {
-
-          SymExpr *idxSymExpr = toSymExpr(call->get(1));
-          SymExpr *boundSymExpr = toSymExpr(call->get(2));
-
-          INT_ASSERT(idxSymExpr);
-          INT_ASSERT(boundSymExpr);
-
-          this->loopIndices.push_back(idxSymExpr->symbol());
-          this->lowerBounds.push_back(boundSymExpr->symbol());
-        }
-      }
-    }
-
-    INT_ASSERT(bs->body.length == (int)this->loopIndices.size());
-    INT_ASSERT(bs->body.length == (int)this->lowerBounds.size());
-  } else {
-    return false;
-  }
-
-  return true;
-}
-
-static VarSymbol* insertNewVarAndDef(BlockStmt* insertionPoint, const char* name,
-                                     Type* type) {
-  VarSymbol *var = new VarSymbol(name, type);
-  var->defPoint = new DefExpr(var);
-  insertionPoint->insertAtTail(var->defPoint);
-  return var;
-}
-
-bool OutlineInfo::buildStubOutlinedFunction(CForLoop* loop) {
-  this->loop = loop;
-
-  // Pattern match loop boundaries to determine lower
-  // and upper bounds. If we fail to match exit early.
-  if(!extractIndicesAndLowerBounds(loop) || 
-     !extractUpperBound(loop))
-  {
-    return false;
-  }
-
-  fn = new FnSymbol("chpl_gpu_kernel");
-
-  fn->body->blockInfoSet(new CallExpr(PRIM_BLOCK_LOCAL));
-
-  fn->addFlag(FLAG_RESOLVED);
-  fn->addFlag(FLAG_ALWAYS_RESOLVE);
-  fn->addFlag(FLAG_GPU_CODEGEN);
-
-  generateIndexComputation();
-  generateEarlyReturn(*this);
-
-  return true;
-}
-
-/**
- * Given a CForLoop with lower bound lb and upper bound ub
- * (See extractUpperBound\extractIndicesAndLowerBound to
- * see what we pattern match and extract), generate the
- * following AST and insert it into gpuLaunchBlock:
- *
- *   chpl_block_delta = ub - lb
- *   chpl_gpu_num_threads = chpl_block_delta + 1
- */
-static VarSymbol* generateNumThreads(BlockStmt* gpuLaunchBlock,
-                                     OutlineInfo& info) {
-
-  VarSymbol *varBoundDelta = insertNewVarAndDef(gpuLaunchBlock,
-                                                "chpl_block_delta",
-                                                dtInt[INT_SIZE_DEFAULT]);
-  VarSymbol *numThreads = insertNewVarAndDef(gpuLaunchBlock,
-                                             "chpl_num_gpu_threads",
-                                             dtInt[INT_SIZE_DEFAULT]);
-
-  CallExpr *c1 = new CallExpr(PRIM_ASSIGN, varBoundDelta,
-                              new CallExpr(PRIM_SUBTRACT,
-                                           info.upperBound,
-                                           info.lowerBounds[0]));
-  gpuLaunchBlock->insertAtTail(c1);
-
-  CallExpr *c2 = new CallExpr(PRIM_ASSIGN, numThreads,
-                              new CallExpr(PRIM_ADD, varBoundDelta,
-                                           new_IntSymbol(1)));
-  gpuLaunchBlock->insertAtTail(c2);
-
-  return numThreads;
-}
-
-static VarSymbol* generateAssignmentToPrimitive(
-  FnSymbol* fn, const char *varName, PrimitiveTag prim, Type *primReturnType) {
-
-  VarSymbol *var = insertNewVarAndDef(fn->body, varName, primReturnType);
-  CallExpr *c1 = new CallExpr(PRIM_MOVE, var, new CallExpr(prim));
-  fn->insertAtTail(c1);
-  return var;
-}
-
-static Symbol* addKernelArgument(OutlineInfo& info, Symbol* symInLoop) {
-  Type* symType = symInLoop->typeInfo();
-  ArgSymbol* newFormal = new ArgSymbol(INTENT_IN, symInLoop->name, symType);
-  info.fn->insertFormalAtTail(newFormal);
-
-  info.kernelActuals.push_back(symInLoop);
-  info.copyMap.put(symInLoop, newFormal);
-
-  return newFormal;
-}
-
-static Symbol* addLocalVariable(OutlineInfo& info, Symbol* symInLoop) {
-  VarSymbol* newSym = toVarSymbol(symInLoop->copy());
-
-  INT_ASSERT(newSym);
-
-  info.fn->insertAtHead(new DefExpr(newSym));
-  info.copyMap.put(symInLoop, newSym);
-
-  return newSym;
-}
-
-/**
- *  For each loopIndex, generates and inserts the following AST into fn:
- *
- *  blockIdxX  = __primitive('gpu blockIdx x')
- *  blockDimX  = __primitive('gpu blockDim x')
- *  threadIdxX = __primitive('gpu threadIdx x')
- *  t0 = varBlockIdxX * varBlockDimX
- *  t1 = t0 + threadIdxX
- *  index = t1 + lowerBound
- *
- *  Also adds the loopIndex->index to the copyMap
- **/
-void OutlineInfo::generateIndexComputation() {
-  std::vector<Symbol*>::size_type numIndices = loopIndices.size();
-  INT_ASSERT(lowerBounds.size() == numIndices);
-
-  for (std::vector<Symbol*>::size_type i=0 ; i<numIndices ; i++) {
-    Symbol* loopIndex  = loopIndices[i];
-    Symbol* lowerBound = lowerBounds[i];
-
-    VarSymbol *varBlockIdxX = generateAssignmentToPrimitive(fn, "blockIdxX",
-      PRIM_GPU_BLOCKIDX_X, dtInt[INT_SIZE_32]);
-    VarSymbol *varBlockDimX = generateAssignmentToPrimitive(fn, "blockDimX",
-      PRIM_GPU_BLOCKDIM_X, dtInt[INT_SIZE_32]);
-    VarSymbol *varThreadIdxX = generateAssignmentToPrimitive(fn, "threadIdxX",
-      PRIM_GPU_THREADIDX_X, dtInt[INT_SIZE_32]);
-
-    VarSymbol *tempVar = insertNewVarAndDef(fn->body, "t0", dtInt[INT_SIZE_32]);
-    CallExpr *c1 = new CallExpr(PRIM_MOVE, tempVar, new CallExpr(PRIM_MULT,
-                                                                 varBlockIdxX,
-                                                                 varBlockDimX));
-    fn->insertAtTail(c1);
-
-    VarSymbol *tempVar1 = insertNewVarAndDef(fn->body, "t1", dtInt[INT_SIZE_32]);
-    CallExpr *c2 = new CallExpr(PRIM_MOVE, tempVar1, new CallExpr(PRIM_ADD,
-                                                                  tempVar,
-                                                                  varThreadIdxX));
-    fn->insertAtTail(c2);
-
-    Symbol* startOffset = addKernelArgument(*this, lowerBound);
-    VarSymbol* index = insertNewVarAndDef(fn->body, "chpl_simt_index",
-                                          dtInt[INT_SIZE_32]);
-    fn->insertAtTail(new CallExpr(PRIM_MOVE, index, new CallExpr(PRIM_ADD,
-                                                                 tempVar1,
-                                                                 startOffset)));
-
-    kernelIndices.push_back(index);
-    copyMap.put(loopIndex, index);
-  }
-
-  INT_ASSERT(kernelIndices.size() == loopIndices.size());
-}
-
-/*
- * Adds the following AST to a GPU kernel
- *
- * def chpl_is_oob;
- * chpl_is_oob = `calculated thread idx` > upperBound
- * if (chpl_is_oob) {
- *   return;
- * }
- *
- */
-static void generateEarlyReturn(OutlineInfo& info) {
-  Symbol* localUpperBound = addKernelArgument(info, info.upperBound);
-
-  VarSymbol* isOOB = new VarSymbol("chpl_is_oob", dtBool);
-  info.fn->insertAtTail(new DefExpr(isOOB));
-
-  CallExpr* comparison = new CallExpr(PRIM_GREATER,
-                                      info.kernelIndices[0],
-                                      localUpperBound);
-  info.fn->insertAtTail(new CallExpr(PRIM_MOVE, isOOB, comparison));
-
-  BlockStmt* thenBlock = new BlockStmt();
-  thenBlock->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
-  info.fn->insertAtTail(new CondStmt(new SymExpr(isOOB), thenBlock));
-}
-
-static  CallExpr* generateGPUCall(OutlineInfo& info, VarSymbol* numThreads) {
-  CallExpr* call = new CallExpr(PRIM_GPU_KERNEL_LAUNCH_FLAT);
-
-  call->insertAtTail(info.fn);
-
-  call->insertAtTail(numThreads);  // total number of GPU threads
-
-  int blockSize = fGPUBlockSize != 0 ? fGPUBlockSize:512;
-  call->insertAtTail(new_IntSymbol(blockSize));
-
-
-  for_vector (Symbol, actual, info.kernelActuals) {
-    call->insertAtTail(new SymExpr(actual));
-  }
-
-  return call;
-}
-
-// If any SymExpr is referring to a variable defined outside the
-// function return the SymExpr. Otherwise return nullptr
-static SymExpr* hasOuterVarAccesses(FnSymbol* fn) {
-  std::vector<SymExpr*> ses;
-  collectSymExprs(fn, ses);
-  for_vector(SymExpr, se, ses) {
-    if (VarSymbol* var = toVarSymbol(se->symbol())) {
-      if (var->defPoint->parentSymbol != fn) {
-        if (!var->isParameter() && var != gVoid) {
-          return se;
-        }
-      }
-    }
-  }
-  return nullptr;
-}
-
-static void errorForOuterVarAccesses(FnSymbol* fn) {
-  if (SymExpr* se = hasOuterVarAccesses(fn)) {
-    VarSymbol* var = toVarSymbol(se->symbol());
-    INT_ASSERT(var);
-    USR_FATAL(se, "variable '%s' must be defined in the function it"
-              " is used in for GPU usage", var->name);
-  }
-}
-
-static void markGPUSubCalls(FnSymbol* fn) {
-  if (!fn->hasFlag(FLAG_GPU_AND_CPU_CODEGEN)) {
-    fn->addFlag(FLAG_GPU_AND_CPU_CODEGEN);
-    fn->addFlag(FLAG_GPU_CODEGEN);
-  }
-
-  errorForOuterVarAccesses(fn);
-
-  std::vector<CallExpr*> calls;
-  collectCallExprs(fn, calls);
-  for_vector(CallExpr, call, calls) {
-    if (FnSymbol* fn = call->resolvedFunction()) {
-      markGPUSubCalls(fn);
-    }
-  }
-}
-
-static void outlineGPUKernels() {
-  forv_Vec(FnSymbol*, fn, gFnSymbols) {
-    std::vector<BaseAST*> asts;
-    collect_asts(fn, asts);
-
-    for_vector(BaseAST, ast, asts) {
-      if (CForLoop* loop = toCForLoop(ast)) {
-        if (shouldOutlineLoop(loop, allowFnCallsFromGPU)) {
-          SET_LINENO(loop);
-
-          // We may fail to build stub function if loop boundaries don't
-          // pattern match the way we expect, if that happens give up on
-          // outlining and continue to the next loop.
-          OutlineInfo info;
-          if(!info.buildStubOutlinedFunction(loop)) { continue; }
-
-          FnSymbol* outlinedFunction = info.fn;
-          fn->defPoint->insertBefore(new DefExpr(outlinedFunction));
-
-          // if (chpl_task_getRequestedSubloc() >= 0) {
-          //   call the generated GPU kernel
-          // } else {
-          //   run the existing loop on the CPU
-          // }
-          Expr* condExpr =
-            new CallExpr(PRIM_GREATEROREQUAL,
-                         new CallExpr(PRIM_GET_REQUESTED_SUBLOC),
-                         new_IntSymbol(0));
-          BlockStmt* thenBlock = new BlockStmt();
-          BlockStmt* elseBlock = new BlockStmt();
-          CondStmt* loopCloneCond = new CondStmt(condExpr, thenBlock, elseBlock);
-          BlockStmt* gpuLaunchBlock = new BlockStmt();
-
-          loop->insertBefore(loopCloneCond);
-          thenBlock->insertAtHead(gpuLaunchBlock);
-          elseBlock->insertAtHead(loop->remove());
-
-          std::set<Symbol*> handledSymbols;
-          for_alist(node, loop->body) {
-            bool copyNode = true;
-            std::vector<SymExpr*> symExprsInBody;
-            collectSymExprs(node, symExprsInBody);
-
-            if (DefExpr* def = toDefExpr(node)) {
-              copyNode = false; // we'll do it here to adjust our symbol map
-
-              DefExpr* newDef = def->copy();
-              info.copyMap.put(def->sym, newDef->sym);
-
-              outlinedFunction->insertAtTail(newDef);
-            }
-            else {
-              for_vector(SymExpr, symExpr, symExprsInBody) {
-                Symbol* sym = symExpr->symbol();
-
-                if (handledSymbols.count(sym) == 1) {
-                  continue;
-                }
-                handledSymbols.insert(sym);
-
-                if (isDefinedInTheLoop(sym, loop)) {
-                  // looks like this symbol was declared within the loop body,
-                  // so do nothing. TODO: I am hoping that we don't need to
-                  // check the type of the variable here, and we'll know that it
-                  // is a valid variable to declare on the gpu via the loop body
-                  // analysis
-                }
-                else if (isDegenerateOuterRef(sym, loop)) {
-                  addLocalVariable(info, sym);
-                }
-                else if (sym->isImmediate()) {
-                  // nothing to do
-                }
-                else if (isTypeSymbol(sym)) {
-                  // nothing to do
-                }
-                else if (isIndexVariable(info, sym)) {
-                  // These are handled already, nothing to do
-                }
-                else {
-                  if (CallExpr* parent = toCallExpr(symExpr->parentExpr)) {
-                    if (parent->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
-                        parent->isPrimitive(PRIM_GET_MEMBER) ||
-                        parent->isPrimitive(PRIM_SET_MEMBER) ||
-                        parent->isPrimitive(PRIM_GET_SVEC_MEMBER_VALUE) ||
-                        parent->isPrimitive(PRIM_GET_SVEC_MEMBER) ||
-                        parent->isPrimitive(PRIM_SET_SVEC_MEMBER)) {
-                      if (symExpr == parent->get(2)) {  // this is a field
-                        // do nothing
-                      }
-                      else if (symExpr == parent->get(1)) {
-                        addKernelArgument(info, sym);
-                      }
-                      else {
-                        INT_FATAL("Malformed PRIM_GET_MEMBER_*");
-                      }
-                    }
-                    else if (parent->isPrimitive()) {
-                      addKernelArgument(info, sym);
-                    }
-                    else if (FnSymbol* calledFn = parent->resolvedFunction()) {
-                      if (!toFnSymbol(sym)) {
-                        addKernelArgument(info, sym);
-                      }
-
-                      if (!calledFn->hasFlag(FLAG_GPU_AND_CPU_CODEGEN)) {
-                         markGPUSubCalls(calledFn);
-                      }
-                    }
-                    else {
-                      INT_FATAL("Unexpected call expression");
-                    }
-                  }
-                }
-              }
-            }
-
-            if (copyNode) {
-              outlinedFunction->insertAtTail(node->copy());
-            }
-          }
-
-          update_symbols(outlinedFunction->body, &info.copyMap);
-          normalize(outlinedFunction);
-
-          // normalization above adds PRIM_END_OF_STATEMENTs. It is probably too
-          // wide of a brush. We can:
-          //  (a) generate the AST we are generating from scratch inside some
-          //      block, normalize that block, weed out these primitives inside
-          //      that block only, flatten and remove
-          //  (b) generate the new AST in the normalized form and never call
-          //      normalize
-          //  (c) keep things as is until this becomes an issue
-          std::vector<CallExpr*> callsInBody;
-          collectCallExprs(outlinedFunction, callsInBody);
-          for_vector (CallExpr, call, callsInBody) {
-            if (call->isPrimitive(PRIM_END_OF_STATEMENT)) {
-              call->remove();
-            }
-          }
-
-          VarSymbol *numThreads = generateNumThreads(gpuLaunchBlock, info);
-          CallExpr* gpuCall = generateGPUCall(info, numThreads);
-          gpuLaunchBlock->insertAtTail(gpuCall);
-          gpuLaunchBlock->flattenAndRemove();
-
-          // just repeat the dead code elimination steps for the new function
-          cleanupLoopBlocks(outlinedFunction);
-          deadVariableElimination(outlinedFunction);
-          cleanupLoopBlocks(outlinedFunction);
-          deadExpressionElimination(outlinedFunction);
-        }
-      }
-    }
-  }
-}
-
-static bool shouldOutlineLoop(BlockStmt* blk, bool allowFnCalls) {
+bool GpuizableLoop::evaluateLoop(BlockStmt *blk, bool allowFnCalls) {
   if (!blk->inTree())
     return false;
 
-  if (CForLoop* cfl = toCForLoop(blk))
-    if (!cfl->isOrderIndependent())
-      return false;
+  CForLoop* cfl = toCForLoop(blk);
+  if (cfl && !cfl->isOrderIndependent())
+    return false;
 
   std::set<FnSymbol*> okFns;
   std::set<FnSymbol*> visitedFns;
 
-  return shouldOutlineLoopHelp(blk, okFns, visitedFns, allowFnCalls);
+  return shouldOutlineLoopHelp(blk, okFns, visitedFns, allowFnCalls) &&
+         attemptToExtractLoopInformation();
 }
 
-static bool shouldOutlineLoopHelp(BlockStmt* blk,
-                                  std::set<FnSymbol*>& okFns,
-                                  std::set<FnSymbol*> visitedFns,
-                                  bool allowFnCalls) {
-
+bool GpuizableLoop::shouldOutlineLoopHelp(BlockStmt* blk,
+                                          std::set<FnSymbol*>& okFns,
+                                          std::set<FnSymbol*> visitedFns,
+                                          bool allowFnCalls) {
   if (debugPrintGPUChecks) {
     FnSymbol* fn = blk->getFunction();
     printf("%*s%s:%d: %s[%d]\n", indentGPUChecksLevel, "",
@@ -657,29 +245,480 @@ static bool shouldOutlineLoopHelp(BlockStmt* blk,
   return true;
 }
 
-static void markGPUSuitableLoops() {
+bool GpuizableLoop::attemptToExtractLoopInformation() {
+  // Pattern match loop boundaries to determine lower
+  // and upper bounds. If we fail to match exit early.
+  return extractIndicesAndLowerBounds() && extractUpperBound();
+}
+
+bool GpuizableLoop::extractIndicesAndLowerBounds() {
+  if(BlockStmt* bs = toBlockStmt(loop_->initBlockGet())) {
+    for_alist (expr, bs->body) {
+      if(CallExpr *call = toCallExpr(expr)) {
+        if(call->isPrimitive(PRIM_ASSIGN) ||
+           call->isPrimitive(PRIM_MOVE)) {
+
+          SymExpr *idxSymExpr = toSymExpr(call->get(1));
+          SymExpr *boundSymExpr = toSymExpr(call->get(2));
+
+          INT_ASSERT(idxSymExpr);
+          INT_ASSERT(boundSymExpr);
+
+          this->loopIndices_.push_back(idxSymExpr->symbol());
+          this->lowerBounds_.push_back(boundSymExpr->symbol());
+        }
+      }
+    }
+
+    INT_ASSERT(bs->body.length == (int)this->loopIndices_.size());
+    INT_ASSERT(bs->body.length == (int)this->lowerBounds_.size());
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+bool GpuizableLoop::extractUpperBound() {
+  if(BlockStmt* bs = toBlockStmt(loop_->testBlockGet())) {
+    for_exprs_postorder (expr, bs) {
+      if(CallExpr *call = toCallExpr(expr)) {
+        if(call->isPrimitive(PRIM_LESSOREQUAL)) {
+          if(SymExpr *symExpr = toSymExpr(call->get(2))) {
+
+            SymExpr* lhsSymExpr = toSymExpr(call->get(1));
+            INT_ASSERT(lhsSymExpr && lhsSymExpr->symbol() == loopIndices_[0]);
+
+            upperBound_ = symExpr->symbol();
+
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  return upperBound_ != nullptr;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// GpuKernel
+// --------------------------------------------------------------------------------------------------------------------
+
+// Given a GpuizableLoop that was determined to be "eligible" we generate an outlined function
+// for GPU code generation that:
+//    - Contains computation to determine what index of the loop is being processed based
+//      on GPU block and thread ID
+//    - Contains a copy of loop's body
+//    - Passes in any variables that are declared outside of the loop as parameters to this new function.
+class GpuKernel {
+  const GpuizableLoop &gpuLoop;
+  FnSymbol* fn_;
+  std::vector<Symbol*> kernelIndices_;
+  std::vector<Symbol*> kernelActuals_;
+  SymbolMap copyMap_;
+
+  public:
+  GpuKernel(const GpuizableLoop &gpuLoop, DefExpr* insertionPoint);
+  FnSymbol* fn() const { return fn_; }
+  const std::vector<Symbol*>& kernelActuals() { return kernelActuals_; }
+
+  private:
+  void buildStubOutlinedFunction(DefExpr* insertionPoint);
+  void populateBody(CForLoop *loop, FnSymbol *outlinedFunction);
+  void normalizeOutlinedFunction();
+  void finalize();
+
+  void generateIndexComputation();
+  void generateEarlyReturn();
+  void markGPUSubCalls(FnSymbol* fn);
+  Symbol* addKernelArgument(Symbol* symInLoop);
+  Symbol* addLocalVariable(Symbol* symInLoop);
+};
+
+GpuKernel::GpuKernel(const GpuizableLoop &gpuLoop, DefExpr* insertionPoint)
+  : gpuLoop(gpuLoop)
+{
+  buildStubOutlinedFunction(insertionPoint);
+  populateBody(gpuLoop.loop(), fn_);
+  normalizeOutlinedFunction();
+  finalize();
+}
+
+void GpuKernel::buildStubOutlinedFunction(DefExpr* insertionPoint) {
+  fn_ = new FnSymbol("chpl_gpu_kernel");
+
+  fn_->body->blockInfoSet(new CallExpr(PRIM_BLOCK_LOCAL));
+
+  fn_->addFlag(FLAG_RESOLVED);
+  fn_->addFlag(FLAG_ALWAYS_RESOLVE);
+  fn_->addFlag(FLAG_GPU_CODEGEN);
+
+  generateIndexComputation();
+  generateEarlyReturn();
+
+  insertionPoint->insertBefore(new DefExpr(fn_));
+}
+
+Symbol* GpuKernel::addKernelArgument(Symbol* symInLoop) {
+  Type* symType = symInLoop->typeInfo();
+  ArgSymbol* newFormal = new ArgSymbol(INTENT_IN, symInLoop->name, symType);
+  fn_->insertFormalAtTail(newFormal);
+
+  kernelActuals_.push_back(symInLoop);
+  copyMap_.put(symInLoop, newFormal);
+
+  return newFormal;
+}
+
+Symbol* GpuKernel::addLocalVariable(Symbol* symInLoop) {
+  VarSymbol* newSym = toVarSymbol(symInLoop->copy());
+
+  INT_ASSERT(newSym);
+
+  fn()->insertAtHead(new DefExpr(newSym));
+  copyMap_.put(symInLoop, newSym);
+
+  return newSym;
+}
+
+/**
+ *  For each loopIndex, generates and inserts the following AST into fn:
+ *
+ *  blockIdxX  = __primitive('gpu blockIdx x')
+ *  blockDimX  = __primitive('gpu blockDim x')
+ *  threadIdxX = __primitive('gpu threadIdx x')
+ *  t0 = varBlockIdxX * varBlockDimX
+ *  t1 = t0 + threadIdxX
+ *  index = t1 + lowerBound
+ *
+ *  Also adds the loopIndex->index to the copyMap_
+ **/
+void GpuKernel::generateIndexComputation() {
+  std::vector<Symbol*>::size_type numIndices = gpuLoop.loopIndices().size();
+  INT_ASSERT(gpuLoop.lowerBounds().size() == numIndices);
+
+  for (std::vector<Symbol*>::size_type i=0 ; i<numIndices ; i++) {
+    Symbol* loopIndex  = gpuLoop.loopIndices()[i];
+    Symbol* lowerBound = gpuLoop.lowerBounds()[i];
+
+    VarSymbol *varBlockIdxX = generateAssignmentToPrimitive(fn_, "blockIdxX",
+      PRIM_GPU_BLOCKIDX_X, dtInt[INT_SIZE_32]);
+    VarSymbol *varBlockDimX = generateAssignmentToPrimitive(fn_, "blockDimX",
+      PRIM_GPU_BLOCKDIM_X, dtInt[INT_SIZE_32]);
+    VarSymbol *varThreadIdxX = generateAssignmentToPrimitive(fn_, "threadIdxX",
+      PRIM_GPU_THREADIDX_X, dtInt[INT_SIZE_32]);
+
+    VarSymbol *tempVar = insertNewVarAndDef(fn_->body, "t0", dtInt[INT_SIZE_32]);
+    CallExpr *c1 = new CallExpr(PRIM_MOVE, tempVar, new CallExpr(PRIM_MULT,
+                                                                 varBlockIdxX,
+                                                                 varBlockDimX));
+    fn_->insertAtTail(c1);
+
+    VarSymbol *tempVar1 = insertNewVarAndDef(fn_->body, "t1", dtInt[INT_SIZE_32]);
+    CallExpr *c2 = new CallExpr(PRIM_MOVE, tempVar1, new CallExpr(PRIM_ADD,
+                                                                  tempVar,
+                                                                  varThreadIdxX));
+    fn_->insertAtTail(c2);
+
+    Symbol* startOffset = addKernelArgument(lowerBound);
+    VarSymbol* index = insertNewVarAndDef(fn_->body, "chpl_simt_index",
+                                          dtInt[INT_SIZE_32]);
+    fn_->insertAtTail(new CallExpr(PRIM_MOVE, index, new CallExpr(PRIM_ADD,
+                                                                 tempVar1,
+                                                                 startOffset)));
+
+    kernelIndices_.push_back(index);
+    copyMap_.put(loopIndex, index);
+  }
+
+  INT_ASSERT(kernelIndices_.size() == gpuLoop.loopIndices().size());
+}
+
+/*
+ * Adds the following AST to a GPU kernel
+ *
+ * def chpl_is_oob;
+ * chpl_is_oob = `calculated thread idx` > upperBound
+ * if (chpl_is_oob) {
+ *   return;
+ * }
+ *
+ */
+void GpuKernel::generateEarlyReturn() {
+  Symbol* localUpperBound = addKernelArgument(gpuLoop.upperBound());
+
+  VarSymbol* isOOB = new VarSymbol("chpl_is_oob", dtBool);
+  fn_->insertAtTail(new DefExpr(isOOB));
+
+  CallExpr* comparison = new CallExpr(PRIM_GREATER,
+                                      kernelIndices_[0],
+                                      localUpperBound);
+  fn_->insertAtTail(new CallExpr(PRIM_MOVE, isOOB, comparison));
+
+  BlockStmt* thenBlock = new BlockStmt();
+  thenBlock->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
+  fn_->insertAtTail(new CondStmt(new SymExpr(isOOB), thenBlock));
+}
+
+void GpuKernel::populateBody(CForLoop *loop, FnSymbol *outlinedFunction) {
+  std::set<Symbol*> handledSymbols;
+  for_alist(node, loop->body) {
+    bool copyNode = true;
+    std::vector<SymExpr*> symExprsInBody;
+    collectSymExprs(node, symExprsInBody);
+
+    if (DefExpr* def = toDefExpr(node)) {
+      copyNode = false; // we'll do it here to adjust our symbol map
+
+      DefExpr* newDef = def->copy();
+      this->copyMap_.put(def->sym, newDef->sym);
+
+      outlinedFunction->insertAtTail(newDef);
+    }
+    else {
+      for_vector(SymExpr, symExpr, symExprsInBody) {
+        Symbol* sym = symExpr->symbol();
+
+        if (handledSymbols.count(sym) == 1) {
+          continue;
+        }
+        handledSymbols.insert(sym);
+
+        if (isDefinedInTheLoop(sym, loop)) {
+          // looks like this symbol was declared within the loop body,
+          // so do nothing. TODO: I am hoping that we don't need to
+          // check the type of the variable here, and we'll know that it
+          // is a valid variable to declare on the gpu via the loop body
+          // analysis
+        }
+        else if (isDegenerateOuterRef(sym, loop)) {
+          addLocalVariable(sym);
+        }
+        else if (sym->isImmediate()) {
+          // nothing to do
+        }
+        else if (isTypeSymbol(sym)) {
+          // nothing to do
+        }
+        else if (gpuLoop.isIndexVariable(sym)) {
+          // These are handled already, nothing to do
+        }
+        else {
+          if (CallExpr* parent = toCallExpr(symExpr->parentExpr)) {
+            if (parent->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
+                parent->isPrimitive(PRIM_GET_MEMBER) ||
+                parent->isPrimitive(PRIM_SET_MEMBER) ||
+                parent->isPrimitive(PRIM_GET_SVEC_MEMBER_VALUE) ||
+                parent->isPrimitive(PRIM_GET_SVEC_MEMBER) ||
+                parent->isPrimitive(PRIM_SET_SVEC_MEMBER)) {
+              if (symExpr == parent->get(2)) {  // this is a field
+                // do nothing
+              }
+              else if (symExpr == parent->get(1)) {
+                addKernelArgument(sym);
+              }
+              else {
+                INT_FATAL("Malformed PRIM_GET_MEMBER_*");
+              }
+            }
+            else if (parent->isPrimitive()) {
+              addKernelArgument(sym);
+            }
+            else if (FnSymbol* calledFn = parent->resolvedFunction()) {
+              if (!toFnSymbol(sym)) {
+                addKernelArgument(sym);
+              }
+
+              if (!calledFn->hasFlag(FLAG_GPU_AND_CPU_CODEGEN)) {
+                 markGPUSubCalls(calledFn);
+              }
+            }
+            else {
+              INT_FATAL("Unexpected call expression");
+            }
+          }
+        }
+      }
+    }
+
+    if (copyNode) {
+      outlinedFunction->insertAtTail(node->copy());
+    }
+  }
+
+  update_symbols(outlinedFunction->body, &copyMap_);
+}
+
+void GpuKernel::normalizeOutlinedFunction() {
+  normalize(fn_);
+
+  // normalization above adds PRIM_END_OF_STATEMENTs. It is probably too
+  // wide of a brush. We can:
+  //  (a) generate the AST we are generating from scratch inside some
+  //      block, normalize that block, weed out these primitives inside
+  //      that block only, flatten and remove
+  //  (b) generate the new AST in the normalized form and never call
+  //      normalize
+  //  (c) keep things as is until this becomes an issue
+  std::vector<CallExpr*> callsInBody;
+  collectCallExprs(fn_, callsInBody);
+  for_vector (CallExpr, call, callsInBody) {
+    if (call->isPrimitive(PRIM_END_OF_STATEMENT)) {
+      call->remove();
+    }
+  }
+}
+
+void GpuKernel::finalize() {
+  // just repeat the dead code elimination steps for the new function
+  cleanupLoopBlocks(this->fn_);
+  deadVariableElimination(this->fn_);
+  cleanupLoopBlocks(this->fn_);
+  deadExpressionElimination(this->fn_);
+}
+
+void GpuKernel::markGPUSubCalls(FnSymbol* fn) {
+  if (!fn->hasFlag(FLAG_GPU_AND_CPU_CODEGEN)) {
+    fn->addFlag(FLAG_GPU_AND_CPU_CODEGEN);
+    fn->addFlag(FLAG_GPU_CODEGEN);
+  }
+
+  errorForOuterVarAccesses(fn);
+
+  std::vector<CallExpr*> calls;
+  collectCallExprs(fn, calls);
+  for_vector(CallExpr, call, calls) {
+    if (FnSymbol* fn = call->resolvedFunction()) {
+      markGPUSubCalls(fn);
+    }
+  }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// GPU Transforms
+// --------------------------------------------------------------------------------------------------------------------
+/**
+ * Given a CForLoop with lower bound lb and upper bound ub
+ * (See extractUpperBound\extractIndicesAndLowerBound to
+ * see what we pattern match and extract), generate the
+ * following AST and insert it into gpuLaunchBlock:
+ *
+ *   chpl_block_delta = ub - lb
+ *   chpl_gpu_num_threads = chpl_block_delta + 1
+ */
+static VarSymbol* generateNumThreads(BlockStmt* gpuLaunchBlock,
+                                     const GpuizableLoop& gpuLoop) {
+
+  VarSymbol *varBoundDelta = insertNewVarAndDef(gpuLaunchBlock,
+                                                "chpl_block_delta",
+                                                dtInt[INT_SIZE_DEFAULT]);
+  VarSymbol *numThreads = insertNewVarAndDef(gpuLaunchBlock,
+                                             "chpl_num_gpu_threads",
+                                             dtInt[INT_SIZE_DEFAULT]);
+
+  CallExpr *c1 = new CallExpr(PRIM_ASSIGN, varBoundDelta,
+                              new CallExpr(PRIM_SUBTRACT,
+                                           gpuLoop.upperBound(),
+                                           gpuLoop.lowerBounds()[0]));
+  gpuLaunchBlock->insertAtTail(c1);
+
+  CallExpr *c2 = new CallExpr(PRIM_ASSIGN, numThreads,
+                              new CallExpr(PRIM_ADD, varBoundDelta,
+                                           new_IntSymbol(1)));
+  gpuLaunchBlock->insertAtTail(c2);
+
+  return numThreads;
+}
+
+static CallExpr* generateGPUCall(GpuKernel& info, VarSymbol* numThreads) {
+  CallExpr* call = new CallExpr(PRIM_GPU_KERNEL_LAUNCH_FLAT);
+
+  call->insertAtTail(info.fn());
+
+  call->insertAtTail(numThreads);  // total number of GPU threads
+
+  int blockSize = fGPUBlockSize != 0 ? fGPUBlockSize:512;
+  call->insertAtTail(new_IntSymbol(blockSize));
+
+  for_vector (Symbol, actual, info.kernelActuals()) {
+    call->insertAtTail(new SymExpr(actual));
+  }
+
+  return call;
+}
+
+static void generateGpuAndNonGpuPaths(const GpuizableLoop &gpuLoop,
+                                      GpuKernel &kernel) {
+  // if (chpl_task_getRequestedSubloc() >= 0) {
+  //   code to determine number of threads to launch kernel with
+  //   call the generated GPU kernel
+  // } else {
+  //   run the existing loop on the CPU
+  // }
+  Expr* condExpr =
+      new CallExpr(PRIM_GREATEROREQUAL,
+                   new CallExpr(PRIM_GET_REQUESTED_SUBLOC),
+                   new_IntSymbol(0));
+  BlockStmt* thenBlock = new BlockStmt();
+  BlockStmt* elseBlock = new BlockStmt();
+  CondStmt* loopCloneCond = new CondStmt(condExpr, thenBlock, elseBlock);
+  BlockStmt* gpuLaunchBlock = new BlockStmt();
+
+  gpuLoop.loop()->insertBefore(loopCloneCond);
+  thenBlock->insertAtHead(gpuLaunchBlock);
+  elseBlock->insertAtHead(gpuLoop.loop()->remove());
+
+  VarSymbol *numThreads = generateNumThreads(gpuLaunchBlock, gpuLoop);
+  CallExpr* gpuCall = generateGPUCall(kernel, numThreads);
+  gpuLaunchBlock->insertAtTail(gpuCall);
+  gpuLaunchBlock->flattenAndRemove();
+}
+
+static void outlineEligibleLoop(FnSymbol *fn, const GpuizableLoop &gpuLoop) {
+  SET_LINENO(gpuLoop.loop());
+
+  // Construction of the GpuKernel will create the outlined function
+  GpuKernel kernel(gpuLoop, fn->defPoint);
+  generateGpuAndNonGpuPaths(gpuLoop, kernel);
+}
+
+static void outlineGPUKernels() {
+  forv_Vec(FnSymbol*, fn, gFnSymbols) {
+    std::vector<BaseAST*> asts;
+    collect_asts(fn, asts);
+
+    for_vector(BaseAST, ast, asts) {
+      if (CForLoop* loop = toCForLoop(ast)) {
+        GpuizableLoop gpuLoop(loop, allowFnCallsFromGPU);
+        if (gpuLoop.isEligible()) {
+          outlineEligibleLoop(fn, gpuLoop);
+        }
+      }
+    }
+  }
+}
+
+static void logGpuizableLoops() {
   forv_Vec(BlockStmt, block, gBlockStmts) {
     if (ForLoop* forLoop = toForLoop(block)) {
-      if (forLoop->isOrderIndependent()) {
-        if (shouldOutlineLoop(forLoop, allowFnCallsFromGPU)) {
+      if (forLoop->isOrderIndependent())
+        if (GpuizableLoop(forLoop, allowFnCallsFromGPU).isEligible())
           if (debugPrintGPUChecks)
             printf("Found viable forLoop %s:%d[%d]\n",
                    forLoop->fname(), forLoop->linenum(), forLoop->id);
-        }
-      }
     } else if (CForLoop* forLoop = toCForLoop(block)) {
-      if (shouldOutlineLoop(forLoop, allowFnCallsFromGPU)) {
+      if (GpuizableLoop(forLoop, allowFnCallsFromGPU).isEligible())
         if (debugPrintGPUChecks)
           printf("Found viable CForLoop %s:%d[%d]\n",
                  forLoop->fname(), forLoop->linenum(), forLoop->id);
-      }
     }
   }
 }
 
 void gpuTransforms() {
   if (debugPrintGPUChecks) {
-    markGPUSuitableLoops();
+    logGpuizableLoops();
   }
 
   // For now, we are doing GPU outlining here. In the future, it should probably

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -45,6 +45,16 @@ extern int classifyPrimitive(CallExpr *call, bool inLocal);
 extern bool inLocalBlock(CallExpr *call);
 
 struct OutlineInfo {
+  // Given a CForLoop that we want to outline into a function for a GPU kernel
+  // extract the loopIndices, lowerBounds, and upperBound and populate it with
+  // boilerplate computation to calculate what index the kernel should operate
+  // on given its thread ID. After buildStubOutlinedFunction is finished its up
+  // to the caller to populate its body with the body of the loop and to call
+  // the outlined function. It's possible that we fail to build the function if
+  // the loop boundaries don't represent a range if this is the case we return
+  // false and the caller should stop trying to outline.
+  bool buildStubOutlinedFunction(CForLoop* loop);
+
   CForLoop* loop = NULL;
 
   std::vector<Symbol*> loopIndices;
@@ -56,14 +66,17 @@ struct OutlineInfo {
   std::vector<Symbol*> kernelActuals;
 
   SymbolMap copyMap;
+
+  private:
+  bool extractIndicesAndLowerBounds(CForLoop* loop);
+  bool extractUpperBound(CForLoop* loop);
+  void generateIndexComputation();
 };
 
 static VarSymbol* generateAssignmentToPrimitive(FnSymbol* fn,
                                                 const char *varName,
                                                 PrimitiveTag prim,
                                                 Type *primReturnType);
-
-static void generateIndexComputation(OutlineInfo& info);
 
 static void generateEarlyReturn(OutlineInfo& info);
 
@@ -77,6 +90,7 @@ static bool shouldOutlineLoopHelp(BlockStmt* blk,
 static SymExpr* hasOuterVarAccesses(FnSymbol* fn);
 static void markGPUSuitableLoops();
 
+static Symbol* addKernelArgument(OutlineInfo& info, Symbol* symInLoop);
 
 static bool isDefinedInTheLoop(Symbol* sym, CForLoop* loop) {
   LoopStmt* curLoop = LoopStmt::findEnclosingLoop(sym->defPoint);
@@ -129,7 +143,7 @@ static bool isIndexVariable(OutlineInfo& info, Symbol* sym) {
   return std::find(indices.begin(), indices.end(), sym) != indices.end();
 }
 
-static void extractUpperBound(CForLoop* loop, OutlineInfo& info) {
+bool OutlineInfo::extractUpperBound(CForLoop* loop) {
   if(BlockStmt* bs = toBlockStmt(loop->testBlockGet())) {
     for_exprs_postorder (expr, bs) {
       if(CallExpr *call = toCallExpr(expr)) {
@@ -137,9 +151,9 @@ static void extractUpperBound(CForLoop* loop, OutlineInfo& info) {
           if(SymExpr *symExpr = toSymExpr(call->get(2))) {
 
             SymExpr* lhsSymExpr = toSymExpr(call->get(1));
-            INT_ASSERT(lhsSymExpr && lhsSymExpr->symbol() == info.loopIndices[0]);
+            INT_ASSERT(lhsSymExpr && lhsSymExpr->symbol() == this->loopIndices[0]);
 
-            info.upperBound = symExpr->symbol();
+            this->upperBound = symExpr->symbol();
 
             break;
           }
@@ -148,14 +162,10 @@ static void extractUpperBound(CForLoop* loop, OutlineInfo& info) {
     }
   }
 
-  if (info.upperBound == NULL) {
-    INT_FATAL("Unexpected upper bound for loop identified for extraction as "
-              "GPU kernel");
-  }
+  return this->upperBound != NULL;
 }
 
-static void extractIndicesAndLowerBounds(CForLoop* loop,
-                                         OutlineInfo& info) {
+bool OutlineInfo::extractIndicesAndLowerBounds(CForLoop* loop) {
   if(BlockStmt* bs = toBlockStmt(loop->initBlockGet())) {
     for_alist (expr, bs->body) {
       if(CallExpr *call = toCallExpr(expr)) {
@@ -168,18 +178,19 @@ static void extractIndicesAndLowerBounds(CForLoop* loop,
           INT_ASSERT(idxSymExpr);
           INT_ASSERT(boundSymExpr);
 
-          info.loopIndices.push_back(idxSymExpr->symbol());
-          info.lowerBounds.push_back(boundSymExpr->symbol());
+          this->loopIndices.push_back(idxSymExpr->symbol());
+          this->lowerBounds.push_back(boundSymExpr->symbol());
         }
       }
     }
 
-    INT_ASSERT(bs->body.length == (int)info.loopIndices.size());
-    INT_ASSERT(bs->body.length == (int)info.lowerBounds.size());
+    INT_ASSERT(bs->body.length == (int)this->loopIndices.size());
+    INT_ASSERT(bs->body.length == (int)this->lowerBounds.size());
+  } else {
+    return false;
   }
-  else {
-    INT_FATAL("Unexpected initBlock in CForLoop");
-  }
+
+  return true;
 }
 
 static VarSymbol* insertNewVarAndDef(BlockStmt* insertionPoint, const char* name,
@@ -190,21 +201,29 @@ static VarSymbol* insertNewVarAndDef(BlockStmt* insertionPoint, const char* name
   return var;
 }
 
-static OutlineInfo collectOutlineInfo(CForLoop* loop) {
-  OutlineInfo info;
-  info.loop = loop;
-  extractIndicesAndLowerBounds(loop, info);
-  extractUpperBound(loop, info);
+bool OutlineInfo::buildStubOutlinedFunction(CForLoop* loop) {
+  this->loop = loop;
 
-  info.fn = new FnSymbol("chpl_gpu_kernel");
-  info.fn->addFlag(FLAG_RESOLVED);
-  info.fn->addFlag(FLAG_ALWAYS_RESOLVE);
-  info.fn->addFlag(FLAG_GPU_CODEGEN);
+  // Pattern match loop boundaries to determine lower
+  // and upper bounds. If we fail to match exit early.
+  if(!extractIndicesAndLowerBounds(loop) || 
+     !extractUpperBound(loop))
+  {
+    return false;
+  }
 
-  generateIndexComputation(info);
-  generateEarlyReturn(info);
+  fn = new FnSymbol("chpl_gpu_kernel");
 
-  return info;
+  fn->body->blockInfoSet(new CallExpr(PRIM_BLOCK_LOCAL));
+
+  fn->addFlag(FLAG_RESOLVED);
+  fn->addFlag(FLAG_ALWAYS_RESOLVE);
+  fn->addFlag(FLAG_GPU_CODEGEN);
+
+  generateIndexComputation();
+  generateEarlyReturn(*this);
+
+  return true;
 }
 
 /**
@@ -283,16 +302,13 @@ static Symbol* addLocalVariable(OutlineInfo& info, Symbol* symInLoop) {
  *
  *  Also adds the loopIndex->index to the copyMap
  **/
-static void generateIndexComputation(OutlineInfo& info) {
-
-  FnSymbol* fn = info.fn;
-
-  std::vector<Symbol*>::size_type numIndices = info.loopIndices.size();
-  INT_ASSERT(info.lowerBounds.size() == numIndices);
+void OutlineInfo::generateIndexComputation() {
+  std::vector<Symbol*>::size_type numIndices = loopIndices.size();
+  INT_ASSERT(lowerBounds.size() == numIndices);
 
   for (std::vector<Symbol*>::size_type i=0 ; i<numIndices ; i++) {
-    Symbol* loopIndex  = info.loopIndices[i];
-    Symbol* lowerBound = info.lowerBounds[i];
+    Symbol* loopIndex  = loopIndices[i];
+    Symbol* lowerBound = lowerBounds[i];
 
     VarSymbol *varBlockIdxX = generateAssignmentToPrimitive(fn, "blockIdxX",
       PRIM_GPU_BLOCKIDX_X, dtInt[INT_SIZE_32]);
@@ -313,18 +329,18 @@ static void generateIndexComputation(OutlineInfo& info) {
                                                                   varThreadIdxX));
     fn->insertAtTail(c2);
 
-    Symbol* startOffset = addKernelArgument(info, lowerBound);
+    Symbol* startOffset = addKernelArgument(*this, lowerBound);
     VarSymbol* index = insertNewVarAndDef(fn->body, "chpl_simt_index",
                                           dtInt[INT_SIZE_32]);
     fn->insertAtTail(new CallExpr(PRIM_MOVE, index, new CallExpr(PRIM_ADD,
                                                                  tempVar1,
                                                                  startOffset)));
 
-    info.kernelIndices.push_back(index);
-    info.copyMap.put(loopIndex, index);
+    kernelIndices.push_back(index);
+    copyMap.put(loopIndex, index);
   }
 
-  INT_ASSERT(info.kernelIndices.size() == info.loopIndices.size());
+  INT_ASSERT(kernelIndices.size() == loopIndices.size());
 }
 
 /*
@@ -424,10 +440,13 @@ static void outlineGPUKernels() {
         if (shouldOutlineLoop(loop, allowFnCallsFromGPU)) {
           SET_LINENO(loop);
 
-          OutlineInfo info = collectOutlineInfo(loop);
+          // We may fail to build stub function if loop boundaries don't
+          // pattern match the way we expect, if that happens give up on
+          // outlining and continue to the next loop.
+          OutlineInfo info;
+          if(!info.buildStubOutlinedFunction(loop)) { continue; }
 
           FnSymbol* outlinedFunction = info.fn;
-
           fn->defPoint->insertBefore(new DefExpr(outlinedFunction));
 
           // if (chpl_task_getRequestedSubloc() >= 0) {
@@ -449,9 +468,7 @@ static void outlineGPUKernels() {
           elseBlock->insertAtHead(loop->remove());
 
           std::set<Symbol*> handledSymbols;
-
           for_alist(node, loop->body) {
-
             bool copyNode = true;
             std::vector<SymExpr*> symExprsInBody;
             collectSymExprs(node, symExprsInBody);

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -234,6 +234,12 @@ module LocaleModelHelpSetup {
   proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string,
       numSublocales: int, type GPULocale){
 
+    // Cylic distribution uses this variable to determine how many
+    // data-parallel tasks to have per locale. If this gets set to 0 then we
+    // end up not processing things in the first locale.
+    extern proc chpl_task_getMaxPar(): uint(32);
+    dst.maxTaskPar = chpl_task_getMaxPar();
+
     var childSpace = {0..#numSublocales};
 
     const origSubloc = chpl_task_getRequestedSubloc();

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -113,9 +113,9 @@ CHPL_QTHREAD_CFG_OPTIONS += --enable-static --disable-shared
 
 # determine which scheduler to use. Use nemesis for flat and distrib for
 # non-flat.  Override with a user provided option if they requested one
-SCHEDULER = nemesis
-ifneq ($(CHPL_MAKE_LOCALE_MODEL),flat)
 SCHEDULER = distrib
+ifneq ($(CHPL_MAKE_LOCALE_MODEL),numa)
+SCHEDULER = nemesis
 endif
 ifneq (, $(CHPL_QTHREAD_SCHEDULER))
 SCHEDULER = $(CHPL_QTHREAD_SCHEDULER)

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -24,6 +24,4 @@ def get_cuda_path():
         return ""
 
 def validate(chplLocaleModel, chplComm):
-    if chplLocaleModel == 'gpu' and chplComm != "none":
-        error("The prototype GPU support does not work when CHPL_COMM is not set to\n\"none\".");
-
+    pass


### PR DESCRIPTION
There are two main changes in the PR:
  - allow compilation with CHPL_LOCALE_MODEL=gpu and CHPL_COMM=gasnet.
  - refactoring the GpuTransforms file

This PR isn't intended to enable communication from/to the GPU across nodes but (the hope atleast) is that you'll be able to do the normal node-to-node communication you're used to.

I'm leaving it as remaining work to add a test (we'll need to decide if we want a "gasnet on Osprey for GPU tests" suite or not).

I did however try maually running  the following program on Osprey:

```chpl
use CyclicDist;
const Dom = {0..<numLocales} dmapped Cyclic(startIdx=0);
var A : [Dom] int;

coforall loc in Locales do on loc {
  on here.gpus[0] {
    var B : [0..10] int;
    foreach i in 0..10 {
      B[i] = here.id * 100 + i;
    }
    A[here.id] = B[0];
  }
}

writeln(A);
```

And it will work as I expect with the following output:

```
> foo -nl 4
0 100 200 300
```

A few other oddities to point out:
- In the qthread Makefile I changed the scehduler for the GPU locale model (or really any non-numa locale model) to use distrib. In absence of this change I'll get the following warning: `warning: Disabling --cache-remote because tasks can migrate threads (quiet with CHPL_RT_CACHE_QUIET=true)`
- We previously weren't setting maxTaskPar for the CPU locale when using the GPU locale model, this was causing a crash and I think it was just an oversight.
- With these changes made for some reason I would encounter a CForLoop that was determined eligible for GPU code generation but who's bound was something of the form `lhs != rhs`. This would trigger an assertion because we're assuming the bounds of the loop is of the form `lhs < rhs`. I've now made it so if this doesn't pattern match we bail on doing the outlining of the function (to turn it into a GPU kernel).

In terms of refactoring:
- I've moved various functions into two classes:
  - GpuizableLoop: Which is concerned with determining if a loop is eligible for GPU code generation and extracting the bounds of the loop
  - GpuKernel: Which is responsible for generating the kernel function itself and populating it (copying the body of the loop into it)

There are other a bunch of free functions at the bottom the process the callsite.