### PR TITLE
Revcomp cleanup

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -29,14 +29,11 @@ proc main(args: [] string) {
       buf: [bufDom] uint(8),
       end = 0;
 
-  do {
-    const more = stdinBin.read(buf[end..]);
-    if more {
-      end = bufLen;
-      bufLen += min(1024**2, bufLen);
-      bufDom = {0..<bufLen};
-    }
-  } while more;
+  while stdinBin.read(buf[end..]) {
+    end = bufLen;
+    bufLen += min(1024**2, bufLen);
+    bufDom = {0..<bufLen};
+  }
   end = stdinBin.offset()-1;
 
   // process the buffer a sequence at a time, working from the end

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -46,17 +46,17 @@ proc main(args: [] string) {
     var lo = hi;
     while buf[lo] != '>'.toByte() do
       lo -= 1;
-    const nexthi = lo - 1;
 
     // skip past header line
+    var seqlo = lo;
     do {
-      lo += 1;
-    } while buf[lo-1] != eol;
+      seqlo += 1;
+    } while buf[seqlo-1] != eol;
 
     // reverse and complement the sequence
-    revcomp(buf, lo, hi);
+    revcomp(buf, seqlo, hi);
 
-    hi = nexthi;
+    hi = lo - 1;
   }
 
   // write out the transformed buffer

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -2,109 +2,83 @@
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Brad Chamberlain
-   based on the C gcc #6 version by Jeremy Zerfas
+   based on the Chapel #3 version with some inspiration taken from the
+   C gcc #6 version by Jeremy Zerfas
 */
 
 use IO;
 
-const stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints = QIO_CH_ALWAYS_UNBUFFERED),
+param eol = '\n'.toByte(),  // end-of-line, as an integer
+      cols = 61,            // # of characters per full row (including '\n')
+
+      // A 'bytes' value that stores the complement of each base at its index
+      cmpl = b"          \n                                                  "
+           + b"    TVGH  CD  M KN   YSAABW R       TVGH  CD  M KN   YSAABW R";
+             //    ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑       ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑
+             //    ABCDEFGHIJKLMNOPQRSTUVWXYZ      abcdefghijklmnopqrstuvwxyz
+
+const stdinBin = openfd(0).reader(iokind.native, locking=false,
+                                  hints = QIO_CH_ALWAYS_UNBUFFERED),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
                                    hints=QIO_CH_ALWAYS_UNBUFFERED);
 
-config var readSize = 16384, // how much to read at a time
-           n = 0;            // a dummy variable to support the CLBG framework
-
-var seqToPrint: atomic int = 0;
-
-proc main() {
+proc main(args: [] string) {
   // read in the data using an incrementally growing buffer
-  var bufSize = readSize,
-      bufDom = {0..<bufSize},
+  var bufLen = 8 * 1024,
+      bufDom = {0..<bufLen},
       buf: [bufDom] uint(8),
-      seqStart, nextSeqID, totRead, end = 0;
+      end = 0;
 
   do {
-    const start = end,
-          more = stdinBin.read(buf[start..#readSize]);
+    const more = stdinBin.read(buf[end..]);
     if more {
-      totRead += readSize;
-    } else {
-      readSize = stdinBin.offset() - totRead + 1;
-    }
-
-    do {
-      if end != 0 && buf[end] == '>'.toByte() {
-        // TODO: This latch is heavy-handed... we really want:
-        //   begin with (var seq = buf[seqStart..<end])
-        //     revcomp(stdoutBin, seq);
-        // or maybe even just:
-        //   begin revcomp(stoutBin, seq); ???
-        //
-        // Unfortunate: Have to make a double copy of seq (to avoid
-        // sharing a domain with buf and possibly getting resized
-        // within our begin when it does.  TPVs would help with
-        // this.
-        const seq = buf[seqStart..<end];
-        begin with (in seq)
-          revcomp(nextSeqID, seq);
-        nextSeqID += 1;
-        seqStart = end;
-      }
-      end += 1;
-    } while end < start+readSize;
-
-    if more {
-      // if we processed one or more sequences, shift leftovers down
-      if seqStart != 0 {
-        // TODO: Cool to have a cool array shift that was parallel?
-        for (s,d) in zip(seqStart..<start+readSize, 0..) do
-          buf[d] = buf[s];
-        end -= seqStart;
-        seqStart = 0;
-      }
-
-      // resize if necessary
-      if end + readSize > bufSize {
-        bufSize *= 2;
-        bufDom = {0..<bufSize};
-      }
+      end = bufLen;
+      bufLen += min(1024**2, bufLen);
+      bufDom = {0..<bufLen};
     }
   } while more;
-  revcomp(nextSeqID, buf[seqStart..<end-1]);
+  end = stdinBin.offset()-1;
+
+  // process the buffer a sequence at a time, working from the end
+  var hi = end;
+  while (hi >= 0) {
+    // search for the '>' that marks the start of a sequence
+    var lo = hi;
+    while buf[lo] != '>'.toByte() do
+      lo -= 1;
+    const nexthi = lo - 1;
+
+    // skip past header line
+    do {
+      lo += 1;
+    } while buf[lo-1] != eol;
+
+    // reverse and complement the sequence
+    revcomp(buf, lo, hi);
+
+    hi = nexthi;
+  }
+
+  // write out the transformed buffer
+  stdoutBin.write(buf[..end]);
 }
 
-proc revcomp(seqID, seq:[?D]) {
-  param eol  = '\n'.toByte(),      // end-of-line, as an integer
-        cmp = b"                                                             "
-            + b"    TVGH  CD  M KN   YSAABW R       TVGH  CD  M KN   YSAABW R";
-              //    ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑       ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑
-              //    ABCDEFGHIJKLMNOPQRSTUVWXYZ      abcdefghijklmnopqrstuvwxyz
 
-  var lo = D.low,
-      hi = D.high+1;
+proc revcomp(buf, lo, hi) {
+  // shift all of the linefeeds into the right places
+  const len = hi - lo + 1,
+        off = (len - 1) % cols,
+        shift = cols - off - 1;
 
-  if lo < hi {
-    // skip past header line
-    while seq[lo] != eol {
-      lo += 1;
+  if off {
+    forall m in lo+off..<hi by cols {
+      for i in m..#shift by -1 do
+        buf[i+1] = buf[i];
+      buf[m] = eol;
     }
-
-    while lo < hi {
-      do {
-        lo += 1;
-      } while seq[lo] == eol;
-
-      do {
-        hi -= 1;
-      } while seq[hi] == eol;
-
-      if lo < hi {
-        (seq[lo], seq[hi]) = (cmp(seq[hi]), cmp(seq[lo]));
-      }
-    }
-    seqToPrint.waitFor(seqID);
-    stdoutBin.write(seq);
-    seqToPrint.add(1);
   }
+
+  // walk from both ends of the sequence, complementing and swapping
+  forall (i,j) in zip(lo..#(len/2), ..<hi by -1) do
+    (buf[i], buf[j]) = (cmpl[buf[j]], cmpl[buf[i]]);
 }

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -17,8 +17,8 @@ param eol = '\n'.toByte(),  // end-of-line, as an integer
              //    ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑       ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑
              //    ABCDEFGHIJKLMNOPQRSTUVWXYZ      abcdefghijklmnopqrstuvwxyz
 
-const stdinBin = openfd(0).reader(iokind.native, locking=false,
-                                  hints = QIO_CH_ALWAYS_UNBUFFERED),
+const stdinBin  = openfd(0).reader(iokind.native, locking=false,
+                                   hints=QIO_CH_ALWAYS_UNBUFFERED),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
                                    hints=QIO_CH_ALWAYS_UNBUFFERED);
 
@@ -49,12 +49,12 @@ proc main(args: [] string) {
 
     // skip past header line
     var seqlo = lo;
-    do {
+    while buf[seqlo] != eol {
       seqlo += 1;
-    } while buf[seqlo-1] != eol;
+    }
 
     // reverse and complement the sequence
-    revcomp(buf, seqlo, hi);
+    revcomp(buf, seqlo+1, hi);
 
     hi = lo - 1;
   }

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -17,18 +17,18 @@ param eol = '\n'.toByte(),  // end-of-line, as an integer
              //    ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑       ↑↑↑↑  ↑↑  ↑ ↑↑   ↑↑↑↑↑↑ ↑
              //    ABCDEFGHIJKLMNOPQRSTUVWXYZ      abcdefghijklmnopqrstuvwxyz
 
-const stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints=QIO_CH_ALWAYS_UNBUFFERED),
-      stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints=QIO_CH_ALWAYS_UNBUFFERED);
 
 proc main(args: [] string) {
-  // read in the data using an incrementally growing buffer
-  var bufLen = 8 * 1024,
+  var stdinBin  = openfd(0).reader(iokind.native, locking=false,
+                                   hints=QIO_CH_ALWAYS_UNBUFFERED),
+      stdoutBin = openfd(1).writer(iokind.native, locking=false,
+                                   hints=QIO_CH_ALWAYS_UNBUFFERED),
+      bufLen = 8 * 1024,
       bufDom = {0..<bufLen},
       buf: [bufDom] uint(8),
       end = 0;
 
+  // read in the data using an incrementally growing buffer
   while stdinBin.read(buf[end..]) {
     end = bufLen;
     bufLen += min(1024**2, bufLen);


### PR DESCRIPTION
In discussing a bug workaround in the revcomp variation added in #19597
with Engin today, I found myself questioning why I hadn't gotten more
creative, for example by hoisting the logic that skips past the header line
outside of the revcomp procedure itself.  I think that the answer is simply
"because I was trying to minimize the diff with revcomp3", which isn't really
a good answer.  So this version takes a more dramatic restructuring to avoid
the lame bug workaround.  In doing so, I also found other logic that could
be cleaned up, such as the while loop that reads in the data (duh).  This
brings the code size down to 595 gz bytes which is a new record for us.
