### PR TITLE
Fix failing test fallout from #19788

### DIFF
--- a/test/execflags/thomasvandoren/exceedMemInts.chpl
+++ b/test/execflags/thomasvandoren/exceedMemInts.chpl
@@ -1,3 +1,4 @@
+use MemTracking;
 writeln(max(uint(64)));
 writeln("memMax = ", MemTracking.memMax);
 writeln("memThreshold = ", MemTracking.memThreshold);


### PR DESCRIPTION
This test is only run on linux32, so escaped my testing and refers to
an internal module, which is no longer available by default.  Here,
I'm using an explicit `use` to bring the module's name into scope,
though this will also break if/when we implement the proposal in
#19793.
