### PR TITLE
Update tests that reflect --help output to include new config var

### DIFF
--- a/test/execflags/bradc/configHelp.bad
+++ b/test/execflags/bradc/configHelp.bad
@@ -1,4 +1,4 @@
   -h, --help            : print this message
 CONFIG VARS:
-                 numLocales: int(64)
-                       help: bool
+                       numLocales: int(64)
+                             help: bool

--- a/test/execflags/configs/privateconfigs-help-set.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help-set.comm-none.good
@@ -6,53 +6,54 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-       printModuleInitOrder: bool
-      dataParTasksPerLocale: int(64)
-  dataParIgnoreRunningTasks: bool
-      dataParMinGranularity: int(64)
-                   memTrack: bool
-                   memStats: bool
-             memLeaksByType: bool
-                   memLeaks: bool
-                     memMax: uint(64)
-               memThreshold: uint(64)
-                     memLog: string
-                memLeaksLog: string
-             memLeaksByDesc: string
-                 numLocales: int(64)
+             printModuleInitOrder: bool
+            dataParTasksPerLocale: int(64)
+        dataParIgnoreRunningTasks: bool
+            dataParMinGranularity: int(64)
+                         memTrack: bool
+                         memStats: bool
+                   memLeaksByType: bool
+                         memLeaks: bool
+                           memMax: uint(64)
+                     memThreshold: uint(64)
+                           memLog: string
+                      memLeaksLog: string
+                   memLeaksByDesc: string
+  defaultHashTableResizeThreshold: real(64)
+                       numLocales: int(64)
 
 M1 config vars:
-                        aaa: int(64)
-                        bbb: int(64) (private)
-                        ccc: int(64) (private)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64)
-                        ggg: int(64) (private)
+                              aaa: int(64)
+                              bbb: int(64) (private)
+                              ccc: int(64) (private)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64)
+                              ggg: int(64) (private)
 
 M2 config vars:
-                        aaa: int(64) (private, configured to 0)
-                        bbb: int(64) (configured to 0)
-                        ccc: int(64) (private)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64) (private)
-                        ggg: int(64)
+                              aaa: int(64) (private, configured to 0)
+                              bbb: int(64) (configured to 0)
+                              ccc: int(64) (private)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64) (private)
+                              ggg: int(64)
 
 M3 config vars:
-                        aaa: int(64) (private, configured to 0)
-                        bbb: int(64) (private)
-                        ccc: int(64)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64)
-                        ggg: int(64) (private)
+                              aaa: int(64) (private, configured to 0)
+                              bbb: int(64) (private)
+                              ccc: int(64)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64)
+                              ggg: int(64) (private)
 
 M4 config vars:
-                        aaa: int(64) (private)
-                        bbb: int(64) (private)
-                        ccc: int(64) (private)
-                        ddd: int(64) (configured to 0)
-                        eee: int(64) (private)
-                        fff: int(64) (private)
-                        ggg: int(64)
+                              aaa: int(64) (private)
+                              bbb: int(64) (private)
+                              ccc: int(64) (private)
+                              ddd: int(64) (configured to 0)
+                              eee: int(64) (private)
+                              fff: int(64) (private)
+                              ggg: int(64)

--- a/test/execflags/configs/privateconfigs-help-set.good
+++ b/test/execflags/configs/privateconfigs-help-set.good
@@ -6,53 +6,54 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-       printModuleInitOrder: bool
-      dataParTasksPerLocale: int(64)
-  dataParIgnoreRunningTasks: bool
-      dataParMinGranularity: int(64)
-                   memTrack: bool
-                   memStats: bool
-             memLeaksByType: bool
-                   memLeaks: bool
-                     memMax: uint(64)
-               memThreshold: uint(64)
-                     memLog: string
-                memLeaksLog: string
-             memLeaksByDesc: string
-                 numLocales: int(64) (configured to 1)
+             printModuleInitOrder: bool
+            dataParTasksPerLocale: int(64)
+        dataParIgnoreRunningTasks: bool
+            dataParMinGranularity: int(64)
+                         memTrack: bool
+                         memStats: bool
+                   memLeaksByType: bool
+                         memLeaks: bool
+                           memMax: uint(64)
+                     memThreshold: uint(64)
+                           memLog: string
+                      memLeaksLog: string
+                   memLeaksByDesc: string
+  defaultHashTableResizeThreshold: real(64)
+                       numLocales: int(64) (configured to 1)
 
 M1 config vars:
-                        aaa: int(64)
-                        bbb: int(64) (private)
-                        ccc: int(64) (private)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64)
-                        ggg: int(64) (private)
+                              aaa: int(64)
+                              bbb: int(64) (private)
+                              ccc: int(64) (private)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64)
+                              ggg: int(64) (private)
 
 M2 config vars:
-                        aaa: int(64) (private, configured to 0)
-                        bbb: int(64) (configured to 0)
-                        ccc: int(64) (private)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64) (private)
-                        ggg: int(64)
+                              aaa: int(64) (private, configured to 0)
+                              bbb: int(64) (configured to 0)
+                              ccc: int(64) (private)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64) (private)
+                              ggg: int(64)
 
 M3 config vars:
-                        aaa: int(64) (private, configured to 0)
-                        bbb: int(64) (private)
-                        ccc: int(64)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64)
-                        ggg: int(64) (private)
+                              aaa: int(64) (private, configured to 0)
+                              bbb: int(64) (private)
+                              ccc: int(64)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64)
+                              ggg: int(64) (private)
 
 M4 config vars:
-                        aaa: int(64) (private)
-                        bbb: int(64) (private)
-                        ccc: int(64) (private)
-                        ddd: int(64) (configured to 0)
-                        eee: int(64) (private)
-                        fff: int(64) (private)
-                        ggg: int(64)
+                              aaa: int(64) (private)
+                              bbb: int(64) (private)
+                              ccc: int(64) (private)
+                              ddd: int(64) (configured to 0)
+                              eee: int(64) (private)
+                              fff: int(64) (private)
+                              ggg: int(64)

--- a/test/execflags/configs/privateconfigs-help.good
+++ b/test/execflags/configs/privateconfigs-help.good
@@ -6,53 +6,54 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-       printModuleInitOrder: bool
-      dataParTasksPerLocale: int(64)
-  dataParIgnoreRunningTasks: bool
-      dataParMinGranularity: int(64)
-                   memTrack: bool
-                   memStats: bool
-             memLeaksByType: bool
-                   memLeaks: bool
-                     memMax: uint(64)
-               memThreshold: uint(64)
-                     memLog: string
-                memLeaksLog: string
-             memLeaksByDesc: string
-                 numLocales: int(64) (configured to 1)
+             printModuleInitOrder: bool
+            dataParTasksPerLocale: int(64)
+        dataParIgnoreRunningTasks: bool
+            dataParMinGranularity: int(64)
+                         memTrack: bool
+                         memStats: bool
+                   memLeaksByType: bool
+                         memLeaks: bool
+                           memMax: uint(64)
+                     memThreshold: uint(64)
+                           memLog: string
+                      memLeaksLog: string
+                   memLeaksByDesc: string
+  defaultHashTableResizeThreshold: real(64)
+                       numLocales: int(64) (configured to 1)
 
 M1 config vars:
-                        aaa: int(64)
-                        bbb: int(64) (private)
-                        ccc: int(64) (private)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64)
-                        ggg: int(64) (private)
+                              aaa: int(64)
+                              bbb: int(64) (private)
+                              ccc: int(64) (private)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64)
+                              ggg: int(64) (private)
 
 M2 config vars:
-                        aaa: int(64) (private)
-                        bbb: int(64)
-                        ccc: int(64) (private)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64) (private)
-                        ggg: int(64)
+                              aaa: int(64) (private)
+                              bbb: int(64)
+                              ccc: int(64) (private)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64) (private)
+                              ggg: int(64)
 
 M3 config vars:
-                        aaa: int(64) (private)
-                        bbb: int(64) (private)
-                        ccc: int(64)
-                        ddd: int(64) (private)
-                        eee: int(64) (private)
-                        fff: int(64)
-                        ggg: int(64) (private)
+                              aaa: int(64) (private)
+                              bbb: int(64) (private)
+                              ccc: int(64)
+                              ddd: int(64) (private)
+                              eee: int(64) (private)
+                              fff: int(64)
+                              ggg: int(64) (private)
 
 M4 config vars:
-                        aaa: int(64) (private)
-                        bbb: int(64) (private)
-                        ccc: int(64) (private)
-                        ddd: int(64)
-                        eee: int(64) (private)
-                        fff: int(64) (private)
-                        ggg: int(64)
+                              aaa: int(64) (private)
+                              bbb: int(64) (private)
+                              ccc: int(64) (private)
+                              ddd: int(64)
+                              eee: int(64) (private)
+                              fff: int(64) (private)
+                              ggg: int(64)

--- a/test/execflags/ferguson/help2.good
+++ b/test/execflags/ferguson/help2.good
@@ -18,17 +18,18 @@ CONFIG VAR FLAGS:
 
 CONFIG VARS:
 ============
-       printModuleInitOrder: bool
-      dataParTasksPerLocale: int(64)
-  dataParIgnoreRunningTasks: bool
-      dataParMinGranularity: int(64)
-                   memTrack: bool
-                   memStats: bool
-             memLeaksByType: bool
-                   memLeaks: bool
-                     memMax: uint(64)
-               memThreshold: uint(64)
-                     memLog: string
-                memLeaksLog: string
-             memLeaksByDesc: string
-                 numLocales: int(64)
+             printModuleInitOrder: bool
+            dataParTasksPerLocale: int(64)
+        dataParIgnoreRunningTasks: bool
+            dataParMinGranularity: int(64)
+                         memTrack: bool
+                         memStats: bool
+                   memLeaksByType: bool
+                         memLeaks: bool
+                           memMax: uint(64)
+                     memThreshold: uint(64)
+                           memLog: string
+                      memLeaksLog: string
+                   memLeaksByDesc: string
+  defaultHashTableResizeThreshold: real(64)
+                       numLocales: int(64)

--- a/test/execflags/shannon/configs/help/basehelp.txt
+++ b/test/execflags/shannon/configs/help/basehelp.txt
@@ -7,18 +7,19 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-       printModuleInitOrder: bool
-      dataParTasksPerLocale: int(64)
-  dataParIgnoreRunningTasks: bool
-      dataParMinGranularity: int(64)
-                   memTrack: bool
-                   memStats: bool
-             memLeaksByType: bool
-                   memLeaks: bool
-                     memMax: uint(64)
-               memThreshold: uint(64)
-                     memLog: string
-                memLeaksLog: string
-             memLeaksByDesc: string
-                 numLocales: int(64)
+            printModuleInitOrder: bool
+           dataParTasksPerLocale: int(64)
+       dataParIgnoreRunningTasks: bool
+           dataParMinGranularity: int(64)
+                        memTrack: bool
+                        memStats: bool
+                  memLeaksByType: bool
+                        memLeaks: bool
+                          memMax: uint(64)
+                    memThreshold: uint(64)
+                          memLog: string
+                     memLeaksLog: string
+                  memLeaksByDesc: string
+ defaultHashTableResizeThreshold: real(64) 
+                      numLocales: int(64)
 

--- a/test/execflags/shannon/help.good
+++ b/test/execflags/shannon/help.good
@@ -5,17 +5,18 @@ CONFIG VAR FLAGS:
 
 CONFIG VARS:
 ============
-       printModuleInitOrder: bool
-      dataParTasksPerLocale: int(64)
-  dataParIgnoreRunningTasks: bool
-      dataParMinGranularity: int(64)
-                   memTrack: bool
-                   memStats: bool
-             memLeaksByType: bool
-                   memLeaks: bool
-                     memMax: uint(64)
-               memThreshold: uint(64)
-                     memLog: string
-                memLeaksLog: string
-             memLeaksByDesc: string
-                 numLocales: int(64)
+             printModuleInitOrder: bool
+            dataParTasksPerLocale: int(64)
+        dataParIgnoreRunningTasks: bool
+            dataParMinGranularity: int(64)
+                         memTrack: bool
+                         memStats: bool
+                   memLeaksByType: bool
+                         memLeaks: bool
+                           memMax: uint(64)
+                     memThreshold: uint(64)
+                           memLog: string
+                      memLeaksLog: string
+                   memLeaksByDesc: string
+  defaultHashTableResizeThreshold: real(64)
+                       numLocales: int(64)


### PR DESCRIPTION
This is a follow-up to #19732 to update tests that reflect the help output
to indicate the new variable.  An idea I've been kicking around lately is
to not print internal hash configs (by some definition) by default with
--help to keep the help message simpler and reduce maintenance burdens,
but for now... update and go.