### PR TITLE
Improve LLVM config errors

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -135,9 +135,6 @@ def find_system_llvm_config():
     if homebrew_prefix:
         paths.append(homebrew_prefix + "/opt/llvm/bin/llvm-config")
 
-    by_version = defaultdict(list)
-    errs = []
-
     feasible_commands = []
     feasible_versions = []
     feasible_errors = []


### PR DESCRIPTION
Fixes #19797, but more generally provides better error clarity when LLVM found but it has issues (like missing Clang, etc.).

The changes are small, but this is not the most elegant fix (that would require a more substantial rewrite in my opinion).

Happy to get feedback and make changes, thanks.