### PR TITLE
Add a future for the deprecated message failing to trigger on qualified access

### DIFF
--- a/test/deprecated-keyword/qualifiedAccess.bad
+++ b/test/deprecated-keyword/qualifiedAccess.bad
@@ -1,0 +1,4 @@
+qualifiedAccess.chpl:7: In function 'main':
+qualifiedAccess.chpl:9: warning: m1.asdf
+1
+1

--- a/test/deprecated-keyword/qualifiedAccess.chpl
+++ b/test/deprecated-keyword/qualifiedAccess.chpl
@@ -1,0 +1,11 @@
+module m1 {
+  deprecated "m1.asdf"
+  var asdf = 1;
+}
+module m2 {
+  use m1; // same issue if 'import m1'
+  proc main {
+    writeln(m1.asdf);
+    writeln(asdf);
+  }
+}

--- a/test/deprecated-keyword/qualifiedAccess.future
+++ b/test/deprecated-keyword/qualifiedAccess.future
@@ -1,0 +1,2 @@
+bug: qualified access suppresses deprecation warning
+#19813

--- a/test/deprecated-keyword/qualifiedAccess.good
+++ b/test/deprecated-keyword/qualifiedAccess.good
@@ -1,0 +1,5 @@
+qualifiedAccess.chpl:7: In function 'main':
+qualifiedAccess.chpl:8: warning: m1.asdf
+qualifiedAccess.chpl:9: warning: m1.asdf
+1
+1


### PR DESCRIPTION
This is probably something that should get fixed soon
