### PR TITLE
dyno: automatically use ChapelStandard

### DIFF
--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -115,13 +115,66 @@ const ModuleVec& parse(Context* context, UniqueString path);
 /**
   Return the current module search path.
  */
-const std::vector<std::string>& moduleSearchPath(Context* context);
+const std::vector<UniqueString>& moduleSearchPath(Context* context);
 
 /**
   Sets the current module search path.
  */
 void setModuleSearchPath(Context* context,
-                         std::vector<std::string> searchPath);
+                         std::vector<UniqueString> searchPath);
+
+/**
+  Return the current internal module path, i.e. CHPL_HOME/modules/internal/
+ */
+UniqueString internalModulePath(Context* context);
+
+/**
+  Set the current internal modules directory, i.e. CHPL_HOME/modules/internal/
+  This should be formed in a consistent manner with setModuleSearchPath,
+  so that this is a prefix for some module search paths.
+ */
+void setInternalModulePath(Context* context, UniqueString path);
+
+
+/**
+  Return the current standard module path, i.e. CHPL_HOME/modules/
+ */
+UniqueString bundledModulePath(Context* context);
+
+/**
+  Set the current bundled modules directory, i.e. CHPL_HOME/modules/
+  This should be formed in a consistent manner with setModuleSearchPath,
+  so that this is a prefix for some module search paths.
+ */
+void setBundledModulePath(Context* context, UniqueString path);
+
+/**
+  Helper to call setModuleSearchPath, setInternalModulePath, standardModulePath.
+  This function accepts the path to CHPL_HOME, and any additional
+  module path components (from environment variable and command line).
+
+  chpl_module_path corresponds to the CHPL_MODULE_PATH env var
+ */
+void setupModuleSearchPaths(Context* context,
+                            const std::string& chpl_home,
+                            bool minimalModules,
+                            const std::string& chpl_locale_model,
+                            bool enableTaskTracking,
+                            const std::string& chpl_tasks,
+                            const std::string& chpl_comm,
+                            const std::string& chpl_sys_modules_subdir,
+                            const std::string& chpl_module_path,
+                            const std::vector<std::string>& cmdLinePaths);
+
+/**
+ Returns true if the ID corresponds to something in an internal module.
+ */
+bool idIsInInternalModule(Context* context, ID id);
+
+/**
+ Returns true if the ID corresponds to something in a bundled module.
+ */
+bool idIsInBundledModule(Context* context, ID id);
 
 /**
  This query parses a toplevel module by name. Returns nullptr

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -153,17 +153,23 @@ void setBundledModulePath(Context* context, UniqueString path);
   This function accepts the path to CHPL_HOME, and any additional
   module path components (from environment variable and command line).
 
-  chpl_module_path corresponds to the CHPL_MODULE_PATH env var
+  Most of these arguments have corresponding env / printchplenv settings:
+    chplHome             -- CHPL_HOME
+    chplLocaleModel      -- CHPL_LOCALE_MODEL
+    chplTasks            -- CHPL_TASKS
+    chplComm             -- CHPL_COMM
+    chplSysModulesSubdir -- CHPL_SYS_MODULES_SUBDIR
+    chplModulePath       -- CHPL_MODULE_PATH
  */
 void setupModuleSearchPaths(Context* context,
-                            const std::string& chpl_home,
+                            const std::string& chplHome,
                             bool minimalModules,
-                            const std::string& chpl_locale_model,
+                            const std::string& chplLocaleModel,
                             bool enableTaskTracking,
-                            const std::string& chpl_tasks,
-                            const std::string& chpl_comm,
-                            const std::string& chpl_sys_modules_subdir,
-                            const std::string& chpl_module_path,
+                            const std::string& chplTasks,
+                            const std::string& chplComm,
+                            const std::string& chplSysModulesSubdir,
+                            const std::string& chplModulePath,
                             const std::vector<std::string>& cmdLinePaths);
 
 /**

--- a/compiler/dyno/include/chpl/queries/Context-detail.h
+++ b/compiler/dyno/include/chpl/queries/Context-detail.h
@@ -260,7 +260,6 @@ class QueryMapResult final : public QueryMapResultBase {
  public:
   std::tuple<ArgTs...> tupleOfArgs;
   mutable ResultType result;
-  mutable ResultType partialResult;
 
   // This constructor creates an entry with
   //  * lastChecked and lastChanged = -1

--- a/compiler/dyno/include/chpl/queries/Context.h
+++ b/compiler/dyno/include/chpl/queries/Context.h
@@ -522,6 +522,17 @@ class Context {
        const ResultType& (*queryFunction)(Context* context, ArgTs...),
        const std::tuple<ArgTs...>& tupleOfArgs);
 
+  /**
+    Returns 'true' if the query in question is currently running.
+    This can be useful for avoiding recursion in certain cases.
+   */
+  template<typename ResultType,
+           typename... ArgTs>
+  bool
+  isQueryRunning(
+       const ResultType& (*queryFunction)(Context* context, ArgTs...),
+       const std::tuple<ArgTs...>& tupleOfArgs);
+
 
   // the following functions are called by the macros defined in QueryImpl.h
   // and should not be called directly

--- a/compiler/dyno/include/chpl/resolution/scope-types.h
+++ b/compiler/dyno/include/chpl/resolution/scope-types.h
@@ -205,6 +205,7 @@ class Scope {
   uast::asttags::AstTag tag_ = uast::asttags::AST_TAG_UNKNOWN;
   bool containsUseImport_ = false;
   bool containsFunctionDecls_ = false;
+  bool autoUsesModules_ = false;
   ID id_;
   UniqueString name_;
   DeclMap declared_;
@@ -216,7 +217,8 @@ class Scope {
 
   /** Construct a Scope for a particular AST node
       and with a particular parent. */
-  Scope(const uast::AstNode* ast, const Scope* parentScope);
+  Scope(const uast::AstNode* ast, const Scope* parentScope,
+        bool autoUsesModules);
 
   /** Add a builtin type with the provided name. This needs to
       be called to populate the root scope with builtins. */
@@ -232,8 +234,17 @@ class Scope {
       represents. An empty ID indicates that this Scope is the root scope. */
   const ID& id() const { return id_; }
 
-  /** Returns 'true' if this Scope directly contains use or import statements */
-  bool containsUseImport() const { return containsUseImport_; }
+  /** Returns 'true' if this Scope directly contains use or import statements
+      including the automatic 'use' for the standard library. */
+  bool containsUseImport() const {
+    return containsUseImport_ || autoUsesModules_;
+  }
+
+  /** Returns 'true' if the Scope includes the automatic 'use' for
+      the standard library. */
+  bool autoUsesModules() const {
+    return autoUsesModules_;
+  }
 
   /** Returns 'true' if this Scope directly contains any Functions */
   bool containsFunctionDecls() const { return containsFunctionDecls_; }
@@ -258,6 +269,7 @@ class Scope {
            tag_ == other.tag_ &&
            containsUseImport_ == other.containsUseImport_ &&
            containsFunctionDecls_ == other.containsFunctionDecls_ &&
+           autoUsesModules_ == other.autoUsesModules_ &&
            id_ == other.id_ &&
            declared_ == other.declared_ &&
            name_ == other.name_;

--- a/compiler/dyno/include/chpl/uast/AstNode.h
+++ b/compiler/dyno/include/chpl/uast/AstNode.h
@@ -141,6 +141,12 @@ class AstNode {
     return this->id_.contains(other->id_);
   }
 
+  /**
+    Returns 'true' if the passed type of AST node can contain statements,
+    transitively.
+   */
+  static bool mayContainStatements(AstTag tag);
+
   bool shallowMatch(const AstNode* other) const;
   bool completeMatch(const AstNode* other) const;
 

--- a/compiler/dyno/include/chpl/uast/prim-ops-list.h
+++ b/compiler/dyno/include/chpl/uast/prim-ops-list.h
@@ -31,11 +31,11 @@
 //  PRIMITIVE_G -- needs to be code generated
 //                 and there will be a CallExpr::codegenPRIM_BLA method for it
 
-// individual primitives are not documented in this file
-// but rather in AST/primitive.cpp
-
 // behavior for individual primitives are not documented in this file
 // but rather in AST/primitive.cpp
+
+// and the primitive value itself has a PRIM_ prefix e.g.
+// PRIMITIVE_G(NOOP, "noop") is talking about an enum value PRIM_NOOP.
 
 PRIMITIVE_G(UNKNOWN, "")
 

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -221,21 +221,21 @@ void setBundledModulePath(Context* context, UniqueString path) {
 }
 
 void setupModuleSearchPaths(Context* context,
-                            const std::string& chpl_home,
+                            const std::string& chplHome,
                             bool minimalModules,
-                            const std::string& chpl_locale_model,
+                            const std::string& chplLocaleModel,
                             bool enableTaskTracking,
-                            const std::string& chpl_tasks,
-                            const std::string& chpl_comm,
-                            const std::string& chpl_sys_modules_subdir,
-                            const std::string& chpl_module_path,
+                            const std::string& chplTasks,
+                            const std::string& chplComm,
+                            const std::string& chplSysModulesSubdir,
+                            const std::string& chplModulePath,
                             const std::vector<std::string>& cmdLinePaths) {
 
   std::string modRoot;
   if (!minimalModules) {
-    modRoot = chpl_home + "/modules";
+    modRoot = chplHome + "/modules";
   } else {
-    modRoot = chpl_home + "/modules/minimal";
+    modRoot = chplHome + "/modules/minimal";
   }
 
   std::string internal = modRoot + "/internal";
@@ -245,18 +245,18 @@ void setupModuleSearchPaths(Context* context,
 
   std::vector<std::string> searchPath;
 
-  searchPath.push_back(modRoot + "/internal/localeModels/" + chpl_locale_model);
+  searchPath.push_back(modRoot + "/internal/localeModels/" + chplLocaleModel);
 
   const char* tt = enableTaskTracking ? "on" : "off";
   searchPath.push_back(modRoot + "/internal/tasktable/" + tt);
 
-  searchPath.push_back(modRoot + "/internal/tasks/" + chpl_tasks);
+  searchPath.push_back(modRoot + "/internal/tasks/" + chplTasks);
 
-  searchPath.push_back(modRoot + "/internal/comm/" + chpl_comm);
+  searchPath.push_back(modRoot + "/internal/comm/" + chplComm);
 
   searchPath.push_back(modRoot + "/internal");
 
-  searchPath.push_back(modRoot + "/standard/gen/" + chpl_sys_modules_subdir);
+  searchPath.push_back(modRoot + "/standard/gen/" + chplSysModulesSubdir);
 
   searchPath.push_back(modRoot + "/standard");
   searchPath.push_back(modRoot + "/packages");
@@ -265,9 +265,9 @@ void setupModuleSearchPaths(Context* context,
   searchPath.push_back(modRoot + "/dists/dims");
 
   // Add paths from the CHPL_MODULE_PATH environment variable
-  if (!chpl_module_path.empty()) {
+  if (!chplModulePath.empty()) {
 
-    auto ss = std::stringstream(chpl_module_path);
+    auto ss = std::stringstream(chplModulePath);
     std::string path;
 
     while (std::getline(ss, path, ':')) {

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -925,11 +925,6 @@ const owned<ResolvedVisibilityScope>& resolveVisibilityStmtsQuery(
   const AstNode* ast = parsing::idToAst(context, scope->id());
   assert(ast != nullptr);
   if (ast != nullptr) {
-
-    printf("### BEGIN EVALUATING ");
-    scope->dump();
-    printf("\n");
-
     result = toOwned(new ResolvedVisibilityScope(scope));
     auto r = result.get();
     // Visit child nodes to find use/import statements therein
@@ -938,10 +933,6 @@ const owned<ResolvedVisibilityScope>& resolveVisibilityStmtsQuery(
         doResolveVisibilityStmt(context, child, r);
       }
     }
-
-    printf("### DONE EVALUATING ");
-    scope->dump();
-    printf("\n");
   }
 
   return QUERY_END(result);
@@ -956,9 +947,6 @@ resolveVisibilityStmts(Context* context, const Scope* scope) {
 
   if (context->isQueryRunning(resolveVisibilityStmtsQuery,
                               std::make_tuple(scope))) {
-    printf("### WAS RUNNING ");
-    scope->dump();
-    printf("\n");
     // ignore use/imports if we are currently resolving uses/imports
     // for this scope
     return nullptr;

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -303,7 +303,7 @@ static bool doLookupInImports(Context* context,
   if (resolving && resolving->scope() == scope) {
     r = resolving;
   } else {
-    resolveVisibilityStmts(context, scope);
+    r = resolveVisibilityStmts(context, scope);
   }
 
   if (r != nullptr) {

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -258,7 +258,7 @@ const Scope* scopeForId(Context* context, ID id) {
 
 static bool doLookupInScope(Context* context,
                             const Scope* scope,
-                            const VisibilityPath* path,
+                            const ResolvedVisibilityScope* resolving,
                             UniqueString name,
                             LookupConfig config,
                             std::unordered_set<const Scope*>& checkedScopes,
@@ -266,7 +266,7 @@ static bool doLookupInScope(Context* context,
 
 static bool doLookupExprInScope(Context* context,
                                 const Scope* scope,
-                                const VisibilityPath* path,
+                                const ResolvedVisibilityScope* resolving,
                                 const AstNode* expr,
                                 LookupConfig config,
                                 std::unordered_set<const Scope*>& checkedScopes,
@@ -274,9 +274,8 @@ static bool doLookupExprInScope(Context* context,
                                 UniqueString& name,
                                 const Scope*& resultScope);
 
-static const std::vector<VisibilitySymbols>&
-resolveVisibilityStmt(Context* context, ID useImportId,
-                      VisibilityPath path);
+static const ResolvedVisibilityScope*
+resolveVisibilityStmts(Context* context, const Scope* scope);
 
 // Returns the scope for the automatically included standard module
 static const Scope* const& scopeForAutoModule(Context* context) {
@@ -294,35 +293,22 @@ static const Scope* const& scopeForAutoModule(Context* context) {
 
 static bool doLookupInImports(Context* context,
                               const Scope* scope,
-                              const VisibilityPath& path,
+                              const ResolvedVisibilityScope* resolving,
                               UniqueString name,
                               bool onlyInnermost,
                               std::unordered_set<const Scope*>& checkedScopes,
                               std::vector<BorrowedIdsWithName>& result) {
-  if (!scope->containsUseImport()) {
-    // stop early if this scope has no use/import statements
-    return false;
+  // Get the resolved visibility statements, if available
+  const ResolvedVisibilityScope* r = nullptr;
+  if (resolving && resolving->scope() == scope) {
+    r = resolving;
+  } else {
+    resolveVisibilityStmts(context, scope);
   }
 
-  // Gather the list of IDs of use/import statements in this scope
-  const std::vector<ID>& vizIds = findUseImportStmts(context, scope);
-
-  // Check each use/import statement for the appropriate symbol
-  for (const ID& id : vizIds) {
-    // check only the use/import statements before any named in path
-    bool stop = false;
-    for (const auto& pathId: path) {
-      if (pathId == id)
-        stop = true;
-    }
-    if (stop) {
-      break;
-    }
-
-    const auto& vizSyms = resolveVisibilityStmt(context, id, path);
-
+  if (r != nullptr) {
     // check to see if it's mentioned in names/renames
-    for (const VisibilitySymbols& is: vizSyms) {
+    for (const VisibilitySymbols& is: r->visibilityClauses()) {
       UniqueString from = name;
       bool named = is.lookupName(name, from);
       if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {
@@ -344,7 +330,8 @@ static bool doLookupInImports(Context* context,
         }
 
         // find it in that scope
-        bool found = doLookupInScope(context, symScope, &path, from, newConfig,
+        bool found = doLookupInScope(context, symScope, resolving,
+                                     from, newConfig,
                                      checkedScopes, result);
         if (found && onlyInnermost)
           return true;
@@ -363,7 +350,7 @@ static bool doLookupInImports(Context* context,
       }
 
       // find it in that scope
-      bool found = doLookupInScope(context, autoModScope, &path,
+      bool found = doLookupInScope(context, autoModScope, resolving,
                                    name, newConfig,
                                    checkedScopes, result);
       if (found && onlyInnermost)
@@ -388,7 +375,7 @@ static bool doLookupInToplevelModules(Context* context,
 
 static bool doLookupInScope(Context* context,
                             const Scope* scope,
-                            const VisibilityPath* path,
+                            const ResolvedVisibilityScope* resolving,
                             UniqueString name,
                             LookupConfig config,
                             std::unordered_set<const Scope*>& checkedScopes,
@@ -425,16 +412,9 @@ static bool doLookupInScope(Context* context,
 
   if (checkUseImport) {
     bool got = false;
-    if (path != nullptr) {
-      got = doLookupInImports(context, scope, *path,
-                              name, onlyInnermost,
-                              checkedScopes, result);
-    } else {
-      VisibilityPath emptyPath;
-      got = doLookupInImports(context, scope, emptyPath,
-                        name, onlyInnermost,
-                        checkedScopes, result);
-    }
+    got = doLookupInImports(context, scope, resolving,
+                            name, onlyInnermost,
+                            checkedScopes, result);
     if (onlyInnermost && got) return true;
   }
 
@@ -449,7 +429,7 @@ static bool doLookupInScope(Context* context,
 
     const Scope* cur = nullptr;
     for (cur = scope->parentScope(); cur != nullptr; cur = cur->parentScope()) {
-      bool got = doLookupInScope(context, cur, path, name, newConfig,
+      bool got = doLookupInScope(context, cur, resolving, name, newConfig,
                                  checkedScopes, result);
       if (onlyInnermost && got) return true;
 
@@ -465,7 +445,7 @@ static bool doLookupInScope(Context* context,
         rootScope = cur;
     }
     if (rootScope != nullptr) {
-      bool got = doLookupInScope(context, rootScope, path, name, newConfig,
+      bool got = doLookupInScope(context, rootScope, resolving, name, newConfig,
                                  checkedScopes, result);
       if (onlyInnermost && got) return true;
     }
@@ -479,13 +459,12 @@ static bool doLookupInScope(Context* context,
   return result.size() > startSize;
 }
 
-// 'path' is only != nullptr when we are resolving
-// what module/enum is use/imported. In that event it is used to
-// handle recursive module uses by checking only previous use/import
-// statements.
+// 'resolving' is only != nullptr when we are resolving
+// what module/enum is use/imported. In that event it is a pointer
+// to the result currently being constructed.
 static bool doLookupExprInScope(Context* context,
                                 const Scope* scope,
-                                const VisibilityPath* path,
+                                const ResolvedVisibilityScope* resolving,
                                 const AstNode* expr,
                                 LookupConfig config,
                                 std::unordered_set<const Scope*>& checkedScopes,
@@ -498,7 +477,7 @@ static bool doLookupExprInScope(Context* context,
     name = n;
     resultScope = scope;
 
-    return doLookupInScope(context, scope, path, n, config,
+    return doLookupInScope(context, scope, resolving, n, config,
                            checkedScopes, result);
 
   } else if (auto dot = expr->toDot()) {
@@ -513,7 +492,7 @@ static bool doLookupExprInScope(Context* context,
     LookupConfig rcvConfig = config | LOOKUP_INNERMOST;
 
     // lookup the receiver, recursively
-    bool ok = doLookupExprInScope(context, scope, path,
+    bool ok = doLookupExprInScope(context, scope, resolving,
                                   rcv, rcvConfig, checkedScopes,
                                   rcvResult, rcvName, ignoredScope);
 
@@ -541,7 +520,7 @@ static bool doLookupExprInScope(Context* context,
     // look in rcvScope's declarations for fieldName
     // using a new set of checked scopes
     std::unordered_set<const Scope*> freshCheckedScopes;
-    return doLookupInScope(context, rcvScope, path,
+    return doLookupInScope(context, rcvScope, resolving,
                            fieldName, fieldConfig,
                            freshCheckedScopes, result);
   } else {
@@ -565,7 +544,7 @@ enum VisibilityStmtKind {
 //     (which is only different from 'scope' for a Dot expression)
 static bool lookupInScopeViz(Context* context,
                              const Scope* scope,
-                             const VisibilityPath& path,
+                             const ResolvedVisibilityScope* resolving,
                              const AstNode* expr,
                              VisibilityStmtKind inUseEtc,
                              std::vector<BorrowedIdsWithName>& result,
@@ -593,7 +572,7 @@ static bool lookupInScopeViz(Context* context,
     config |= LOOKUP_TOPLEVEL;
   }
 
-  bool got = doLookupExprInScope(context, scope, &path,
+  bool got = doLookupExprInScope(context, scope, resolving,
                                  expr, config,
                                  checkedScopes, result,
                                  nameOfResult, resultScope);
@@ -663,8 +642,6 @@ bool doIsWholeScopeVisibleFromScope(Context* context,
     return false;
   }
 
-  VisibilityPath emptyPath;
-
   // go through parent scopes checking for a match
   for (const Scope* cur = fromScope; cur != nullptr; cur = cur->parentScope()) {
     if (checkScope == cur) {
@@ -672,15 +649,11 @@ bool doIsWholeScopeVisibleFromScope(Context* context,
     }
 
     if (cur->containsUseImport()) {
-      // Gather the list of IDs of use/import statements in this scope
-      const std::vector<ID>& vizIds = findUseImportStmts(context, cur);
+      const ResolvedVisibilityScope* r = resolveVisibilityStmts(context, cur);
 
-      for (const ID& id : vizIds) {
-        // Resolve the use/import statement
-        const auto& vizSyms = resolveVisibilityStmt(context, id, emptyPath);
-
+      if (r != nullptr) {
         // check for scope containment
-        for (const VisibilitySymbols& is: vizSyms) {
+        for (const VisibilitySymbols& is: r->visibilityClauses()) {
           if (is.kind() == VisibilitySymbols::ALL_CONTENTS) {
             // find it in the contents
             const Scope* usedScope = scopeForId(context, is.symbolId());
@@ -711,26 +684,6 @@ bool isWholeScopeVisibleFromScope(Context* context,
                                         checkScope,
                                         fromScope,
                                         checked);
-}
-
-const std::vector<ID>& findUseImportStmts(Context* context,
-                                          const Scope* scope) {
-  QUERY_BEGIN(findUseImportStmts, context, scope);
-
-  std::vector<ID> result;
-  const AstNode* ast = parsing::idToAst(context, scope->id());
-  assert(ast != nullptr);
-  if (ast != nullptr) {
-    // Visit child nodes to e.g. look inside a Module
-    // rather than collecting it as a NamedDecl
-    for (const AstNode* child : ast->children()) {
-      if (child->isUse() || child->isImport()) {
-        result.push_back(child->id());
-      }
-    }
-  }
-
-  return QUERY_END(result);
 }
 
 static std::vector<std::pair<UniqueString,UniqueString>>
@@ -778,11 +731,10 @@ convertLimitations(Context* context, const VisibilityClause* clause) {
   return ret;
 }
 
-static std::vector<VisibilitySymbols>
+static void
 doResolveUseStmt(Context* context, const Use* use,
-                 const Scope* scope, const VisibilityPath& path) {
-  std::vector<VisibilitySymbols> result;
-
+                 const Scope* scope,
+                 ResolvedVisibilityScope* r) {
   bool isPrivate = true;
   if (use->visibility() == Decl::PUBLIC)
     isPrivate = false;
@@ -808,7 +760,7 @@ doResolveUseStmt(Context* context, const Use* use,
     std::vector<BorrowedIdsWithName> vec;
     UniqueString n;
     const Scope* resultScope = nullptr;
-    bool got = lookupInScopeViz(context, scope, path, expr, VIS_USE,
+    bool got = lookupInScopeViz(context, scope, r, expr, VIS_USE,
                                 vec, n, resultScope);
     if (got == false || vec.size() == 0) {
       context->error(expr, "could not find target of 'use'");
@@ -822,11 +774,11 @@ doResolveUseStmt(Context* context, const Use* use,
 
     // First, add VisibilitySymbols entry for the symbol itself
     if (newName.isEmpty()) {
-      result.emplace_back(id, VisibilitySymbols::SYMBOL_ONLY,
-                          isPrivate, convertOneName(n));
+      r->addVisibilityClause(id, VisibilitySymbols::SYMBOL_ONLY,
+                             isPrivate, convertOneName(n));
     } else {
-      result.emplace_back(id, VisibilitySymbols::SYMBOL_ONLY,
-                          isPrivate, convertOneRename(n, newName));
+      r->addVisibilityClause(id, VisibilitySymbols::SYMBOL_ONLY,
+                             isPrivate, convertOneRename(n, newName));
     }
 
     // Then, add the entries for anything imported
@@ -846,18 +798,15 @@ doResolveUseStmt(Context* context, const Use* use,
         break;
     }
     // constructs a VisibilitySymbols entry
-    result.emplace_back(id, kind, isPrivate,
-                        convertLimitations(context, clause));
+    r->addVisibilityClause(id, kind, isPrivate,
+                           convertLimitations(context, clause));
   }
-
-  return result;
 }
 
-static std::vector<VisibilitySymbols>
+static void
 doResolveImportStmt(Context* context, const Import* imp,
-                    const Scope* scope, const VisibilityPath& path) {
-  std::vector<VisibilitySymbols> result;
-
+                    const Scope* scope,
+                    ResolvedVisibilityScope* r) {
   bool isPrivate = true;
   if (imp->visibility() == Decl::PUBLIC)
     isPrivate = false;
@@ -883,7 +832,7 @@ doResolveImportStmt(Context* context, const Import* imp,
     std::vector<BorrowedIdsWithName> vec;
     UniqueString n;
     const Scope* resultScope = nullptr;
-    bool got = lookupInScopeViz(context, scope, path, expr, VIS_IMPORT,
+    bool got = lookupInScopeViz(context, scope, r, expr, VIS_IMPORT,
                                 vec, n, resultScope);
     if (got == false || vec.size() == 0) {
       context->error(expr, "could not find target of 'import'");
@@ -921,75 +870,105 @@ doResolveImportStmt(Context* context, const Import* imp,
           kind = VisibilitySymbols::SYMBOL_ONLY;
           if (newName.isEmpty()) {
             // Add a VisibilitySymbols entry for the imported thing
-            result.emplace_back(id, kind, isPrivate, convertOneName(n));
+            r->addVisibilityClause(id, kind, isPrivate, convertOneName(n));
           } else {
-            result.emplace_back(id, kind, isPrivate,
-                                convertOneRename(n, newName));
+            r->addVisibilityClause(id, kind, isPrivate,
+                                   convertOneRename(n, newName));
           }
         } else if (expr->isDot()) {
           kind = VisibilitySymbols::ONLY_CONTENTS;
           // Add a VisibilitySymbols entry
-          result.emplace_back(id, kind, isPrivate, convertOneName(n));
+          r->addVisibilityClause(id, kind, isPrivate, convertOneName(n));
         }
         break;
       case VisibilityClause::BRACES:
         kind = VisibilitySymbols::ONLY_CONTENTS;
         // Add a VisibilitySymbols entry for the imported things
-        result.emplace_back(id, kind, isPrivate,
-                            convertLimitations(context, clause));
+        r->addVisibilityClause(id, kind, isPrivate,
+                               convertLimitations(context, clause));
         break;
     }
   }
-
-  return result;
 }
 
-static std::vector<VisibilitySymbols>
+static void
 doResolveVisibilityStmt(Context* context,
                         const AstNode* ast,
-                        const VisibilityPath& path) {
+                        ResolvedVisibilityScope* r) {
   if (ast != nullptr) {
     if (ast->isUse() || ast->isImport()) {
-      // construct a new path that includes the current use/import
-      VisibilityPath newPath = path;
-      newPath.push_back(ast->id());
-
       // figure out the scope of the use/import
       const Scope* scope = scopeForIdQuery(context, ast->id());
 
       if (const Use* use = ast->toUse()) {
-        return doResolveUseStmt(context, use, scope, newPath);
+        doResolveUseStmt(context, use, scope, r);
+        return;
       } else if (const Import* imp = ast->toImport()) {
-        return doResolveImportStmt(context, imp, scope, newPath);
+        doResolveImportStmt(context, imp, scope, r);
+        return;
       }
     }
   }
 
   // this code should never run
   assert(false && "should not be reached");
-  std::vector<VisibilitySymbols> empty;
-  return empty;
 }
 
-/**
-  Given an ID of a Use/Import statement, resolves it to figure out
-  which module/enum is used/imported. This is a separate query for
-  each Use/Import statement in order to support modules that use/import
-  each other.
+static
+const owned<ResolvedVisibilityScope>& resolveVisibilityStmtsQuery(
+                                                      Context* context,
+                                                      const Scope* scope)
+{
+  QUERY_BEGIN(resolveVisibilityStmtsQuery, context, scope);
 
-  The 'path' argument indicates the use/import statements that are
-  currently being resolved in each scope in order to handle recusion.
- */
-const std::vector<VisibilitySymbols>&
-resolveVisibilityStmt(Context* context, ID useImportId,
-                      VisibilityPath path) {
-  QUERY_BEGIN(resolveVisibilityStmt, context, useImportId, path);
+  owned<ResolvedVisibilityScope> result;
+  const AstNode* ast = parsing::idToAst(context, scope->id());
+  assert(ast != nullptr);
+  if (ast != nullptr) {
 
-  const AstNode* ast = parsing::idToAst(context, useImportId);
-  auto result = doResolveVisibilityStmt(context, ast, path);
+    printf("### BEGIN EVALUATING ");
+    scope->dump();
+    printf("\n");
+
+    result = toOwned(new ResolvedVisibilityScope(scope));
+    auto r = result.get();
+    // Visit child nodes to find use/import statements therein
+    for (const AstNode* child : ast->children()) {
+      if (child->isUse() || child->isImport()) {
+        doResolveVisibilityStmt(context, child, r);
+      }
+    }
+
+    printf("### DONE EVALUATING ");
+    scope->dump();
+    printf("\n");
+  }
 
   return QUERY_END(result);
 }
+
+static const ResolvedVisibilityScope*
+resolveVisibilityStmts(Context* context, const Scope* scope) {
+  if (!scope->containsUseImport()) {
+    // stop early if this scope has no use/import statements
+    return nullptr;
+  }
+
+  if (context->isQueryRunning(resolveVisibilityStmtsQuery,
+                              std::make_tuple(scope))) {
+    printf("### WAS RUNNING ");
+    scope->dump();
+    printf("\n");
+    // ignore use/imports if we are currently resolving uses/imports
+    // for this scope
+    return nullptr;
+  }
+
+  const owned<ResolvedVisibilityScope>& r =
+    resolveVisibilityStmtsQuery(context, scope);
+  return r.get();
+}
+
 
 static
 const owned<PoiScope>& constructPoiScopeQuery(Context* context,

--- a/compiler/dyno/lib/resolution/scope-types.cpp
+++ b/compiler/dyno/lib/resolution/scope-types.cpp
@@ -27,9 +27,11 @@ namespace chpl {
 namespace resolution {
 
 
-Scope::Scope(const uast::AstNode* ast, const Scope* parentScope) {
+Scope::Scope(const uast::AstNode* ast, const Scope* parentScope,
+             bool autoUsesModules) {
   parentScope_ = parentScope;
   tag_ = ast->tag();
+  autoUsesModules_ = autoUsesModules;
   id_ = ast->id();
   if (auto decl = ast->toNamedDecl()) {
     name_ = decl->name();

--- a/compiler/dyno/lib/uast/AstNode.cpp
+++ b/compiler/dyno/lib/uast/AstNode.cpp
@@ -35,6 +35,127 @@ namespace uast {
 AstNode::~AstNode() {
 }
 
+bool AstNode::mayContainStatements(AstTag tag) {
+  switch (tag) {
+    // cannot contain Chapel statements
+    case asttags::As:
+    case asttags::Array:
+    case asttags::Attributes:
+    case asttags::Break:
+    case asttags::Comment:
+    case asttags::Continue:
+    case asttags::Delete:
+    case asttags::Domain:
+    case asttags::Dot:
+    case asttags::EmptyStmt:
+    case asttags::ErroneousExpression:
+    case asttags::ExternBlock:
+    case asttags::Identifier:
+    case asttags::Import:
+    case asttags::Include:
+    case asttags::Let:
+    case asttags::New:
+    case asttags::Range:
+    case asttags::Require:
+    case asttags::Return:
+    case asttags::Throw:
+    case asttags::TypeQuery:
+    case asttags::Use:
+    case asttags::VisibilityClause:
+    case asttags::WithClause:
+    case asttags::Yield:
+    case asttags::START_Literal:
+    case asttags::BoolLiteral:
+    case asttags::ImagLiteral:
+    case asttags::IntLiteral:
+    case asttags::RealLiteral:
+    case asttags::UintLiteral:
+    case asttags::START_StringLikeLiteral:
+    case asttags::BytesLiteral:
+    case asttags::CStringLiteral:
+    case asttags::StringLiteral:
+    case asttags::END_StringLikeLiteral:
+    case asttags::END_Literal:
+    case asttags::START_Call:
+    case asttags::FnCall:
+    case asttags::OpCall:
+    case asttags::PrimCall:
+    case asttags::Reduce:
+    case asttags::Scan:
+    case asttags::Tuple:
+    case asttags::Zip:
+    case asttags::END_Call:
+    case asttags::MultiDecl:
+    case asttags::TupleDecl:
+    case asttags::ForwardingDecl:
+    case asttags::EnumElement:
+    case asttags::START_VarLikeDecl:
+    case asttags::Formal:
+    case asttags::TaskVar:
+    case asttags::VarArgFormal:
+    case asttags::Variable:
+    case asttags::END_VarLikeDecl:
+    case asttags::Enum:
+      return false;
+
+    // can contain statements
+    case asttags::Catch:
+    case asttags::Cobegin:
+    case asttags::Conditional:
+    case asttags::Implements:
+    case asttags::Label: // contains a loop
+    case asttags::Select:
+    case asttags::Sync:
+    case asttags::Try:
+    case asttags::START_SimpleBlockLike:
+    case asttags::Begin:
+    case asttags::Block:
+    case asttags::Defer:
+    case asttags::Local:
+    case asttags::Manage:
+    case asttags::On:
+    case asttags::Serial:
+    case asttags::When:
+    case asttags::END_SimpleBlockLike:
+    case asttags::START_Loop:
+    case asttags::DoWhile:
+    case asttags::While:
+    case asttags::START_IndexableLoop:
+    case asttags::BracketLoop:
+    case asttags::Coforall:
+    case asttags::For:
+    case asttags::Forall:
+    case asttags::Foreach:
+    case asttags::END_IndexableLoop:
+    case asttags::END_Loop:
+    case asttags::START_Decl:
+    case asttags::START_NamedDecl:
+    case asttags::START_TypeDecl:
+    case asttags::Function:
+    case asttags::Interface:
+    case asttags::Module:
+    case asttags::START_AggregateDecl:
+    case asttags::Class:
+    case asttags::Record:
+    case asttags::Union:
+    case asttags::END_AggregateDecl:
+    case asttags::END_Decl:
+    case asttags::END_NamedDecl:
+    case asttags::END_TypeDecl:
+      return true;
+
+    // implementation details
+    case asttags::NUM_AST_TAGS:
+    case asttags::AST_TAG_UNKNOWN:
+      return true;
+
+    // no default to get compiler warning if any are added
+  }
+
+  assert(false && "should not be reachable");
+  return true;
+}
+
 bool AstNode::shallowMatch(const AstNode* other) const {
   const AstNode* lhs = this;
   const AstNode* rhs = other;

--- a/compiler/dyno/test/parsing/testParsingQueries.cpp
+++ b/compiler/dyno/test/parsing/testParsingQueries.cpp
@@ -622,9 +622,9 @@ static void test9() {
   Context ctx;
   Context* context = &ctx;
 
-  std::vector<std::string> searchPath;
-  searchPath.push_back("/test/path/library");
-  searchPath.push_back("/test/path/program/");
+  std::vector<UniqueString> searchPath;
+  searchPath.push_back(UniqueString::get(context, "/test/path/library"));
+  searchPath.push_back(UniqueString::get(context, "/test/path/program/"));
 
   setModuleSearchPath(context, searchPath);
 

--- a/compiler/dyno/test/resolution/testInteractive.cpp
+++ b/compiler/dyno/test/resolution/testInteractive.cpp
@@ -226,14 +226,13 @@ int main(int argc, char** argv) {
   bool trace = false;
   const char* chpl_home = nullptr;
   std::vector<std::string> cmdLinePaths;
+  std::vector<std::string> files;
   bool enableStdLib = false;
-  int firstfile = 1;
   for (int i = 1; i < argc; i++) {
     if (0 == strcmp(argv[i], "--std")) {
       enableStdLib = true;
-      i++;
     } else if (0 == strcmp(argv[i], "--search")) {
-      if (i+1 == argc || firstfile != 1) {
+      if (i+1 >= argc) {
         usage(argc, argv);
         return 1;
       }
@@ -241,10 +240,8 @@ int main(int argc, char** argv) {
       i++;
     } else if (0 == strcmp(argv[i], "--trace")) {
       trace = true;
-      i++;
     } else {
-      firstfile = i;
-      break;
+      files.push_back(argv[i]);
     }
   }
 
@@ -258,7 +255,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  if (firstfile == argc) {
+  if (files.size() == 0) {
     usage(argc, argv);
     return 0; // need this to return 0 for testing to be happy
   }
@@ -275,8 +272,8 @@ int main(int argc, char** argv) {
 
     std::set<const ResolvedFunction*> calledFns;
 
-    for (int i = firstfile; i < argc; i++) {
-      auto filepath = UniqueString::get(ctx, argv[i]);
+    for (auto p: files) {
+      auto filepath = UniqueString::get(ctx, p);
 
       const ModuleVec& mods = parse(ctx, filepath);
       for (const auto mod : mods) {

--- a/compiler/dyno/test/resolution/testScopeResolve.cpp
+++ b/compiler/dyno/test/resolution/testScopeResolve.cpp
@@ -726,9 +726,9 @@ static void test15() {
   Context ctx;
   Context* context = &ctx;
 
-  std::vector<std::string> searchPath;
-  searchPath.push_back("/test/path/library");
-  searchPath.push_back("/test/path/program/");
+  std::vector<UniqueString> searchPath;
+  searchPath.push_back(UniqueString::get(context, "/test/path/library"));
+  searchPath.push_back(UniqueString::get(context, "/test/path/program/"));
 
   setModuleSearchPath(context, searchPath);
 

--- a/compiler/dyno/test/resolution/testScopeResolve.cpp
+++ b/compiler/dyno/test/resolution/testScopeResolve.cpp
@@ -761,8 +761,6 @@ static void test15() {
   assert(match.id() == lMod->stmt(0)->id());
 }
 
-// test a mutually recursive module case
-// where the mutual recursion is relevant for resolving use/import
 static void test16() {
   printf("test16\n");
   Context ctx;
@@ -773,36 +771,24 @@ static void test16() {
       module M {
         use N;
         use NN;
-        use OO;
         x;
-        z;
       }
 
       module N {
         module NN {
           var x: int;
         }
-        public use O;
-      }
-
-      module O {
-        use M;
-        module OO {
-          var z: int;
-        }
       }
    )"""";
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parse(context, path);
-  assert(vec.size() == 3);
+  assert(vec.size() == 2);
   const Module* m = vec[0]->toModule();
   assert(m);
-  assert(m->numStmts() == 5);
-  const Identifier* xIdent = m->stmt(3)->toIdentifier();
+  assert(m->numStmts() == 3);
+  const Identifier* xIdent = m->stmt(2)->toIdentifier();
   assert(xIdent);
-  const Identifier* zIdent = m->stmt(4)->toIdentifier();
-  assert(zIdent);
   const Module* n = vec[1]->toModule();
   assert(n);
   assert(n->numStmts() == 2);
@@ -810,13 +796,6 @@ static void test16() {
   assert(nn);
   const Variable* x = nn->stmt(0)->toVariable();
   assert(x);
-  const Module* o = vec[2]->toModule();
-  assert(o);
-  assert(o->numStmts() == 2);
-  const Module* oo = o->stmt(1)->toModule();
-  assert(oo);
-  const Variable* z = oo->stmt(0)->toVariable();
-  assert(z);
 
   const Scope* scopeForIdent = scopeForId(context, xIdent->id());
   assert(scopeForIdent);

--- a/compiler/dyno/test/resolution/testScopeResolve.cpp
+++ b/compiler/dyno/test/resolution/testScopeResolve.cpp
@@ -171,8 +171,8 @@ static void test4() {
   assert(scopeForIdent);
 
   const auto& match = findInnermostDecl(context, scopeForIdent, xIdent->name());
-  assert(match.id() == x->id());
   assert(match.found() == InnermostMatch::ONE);
+  assert(match.id() == x->id());
 }
 
 // testing a simple recursive use statement
@@ -791,9 +791,10 @@ static void test16() {
   assert(xIdent);
   const Module* n = vec[1]->toModule();
   assert(n);
-  assert(n->numStmts() == 2);
+  assert(n->numStmts() == 1);
   const Module* nn = n->stmt(0)->toModule();
   assert(nn);
+  assert(nn->numStmts() == 1);
   const Variable* x = nn->stmt(0)->toVariable();
   assert(x);
 
@@ -803,11 +804,6 @@ static void test16() {
   const auto& m1 = findInnermostDecl(context, scopeForIdent, xIdent->name());
   assert(m1.id() == x->id());
   assert(m1.found() == InnermostMatch::ONE);
-
-  assert(scopeForIdent == scopeForId(context, zIdent->id()));
-  const auto& m2 = findInnermostDecl(context, scopeForIdent, zIdent->name());
-  assert(m2.id() == z->id());
-  assert(m2.found() == InnermostMatch::ONE);
 }
 
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -312,6 +312,8 @@ std::vector<std::pair<std::string, std::string>> gDynoParams;
 
 static bool compilerSetChplLLVM = false;
 
+static std::vector<std::string> cmdLineModPaths;
+
 /* Note -- LLVM provides a way to get the path to the executable...
 // This function isn't referenced outside its translation unit, but it
 // can't use the "static" keyword because its address is used for
@@ -718,6 +720,9 @@ static void readConfig(const ArgumentDescription* desc, const char* arg_unused) 
 
 static void addModulePath(const ArgumentDescription* desc, const char* newpath) {
   addFlagModulePath(newpath);
+
+  // also add the path to a vector to support dyno
+  cmdLineModPaths.push_back(std::string(newpath));
 }
 
 static void noteCppLinesSet(const ArgumentDescription* desc, const char* unused) {
@@ -1816,6 +1821,22 @@ int main(int argc, char* argv[]) {
       chpl::parsing::setConfigSettings(gContext, gDynoParams);
       // this should not be used after this point!
       gDynoParams.clear();
+
+      // set up the module paths
+      std::string chpl_module_path;
+      if (const char* envvarpath  = getenv("CHPL_MODULE_PATH")) {
+        chpl_module_path = envvarpath;
+      }
+      chpl::parsing::setupModuleSearchPaths(gContext,
+                                            CHPL_HOME,
+                                            fMinimalModules,
+                                            CHPL_LOCALE_MODEL,
+                                            fEnableTaskTracking,
+                                            CHPL_TASKS,
+                                            CHPL_COMM,
+                                            CHPL_SYS_MODULES_SUBDIR,
+                                            chpl_module_path,
+                                            cmdLineModPaths);
     }
     postprocess_args();
 


### PR DESCRIPTION
The main goal of this PR is to adjust dyno to support standard and internal modules.

* Removes `partialResult` from QueryMapResult. It has been unused since #19765 and I had just forgotten to remove it there.
* Adds support for setting the bundled (`modules/`) and internal module (`modules/internal`) search paths and the ability to query if an ID is in a bundled or internal module. Adjusted some of these module search path functions to return UniqueString rather than `std::string` since comparing them is useful. Added a helper function `setupModuleSearchPaths` that does the right setup calls with the configuration as arguments.
* Adjusts the dyno use/import resolver to automatically use ChapelStandard in modules that aren't internal modules. To support that, Scope now includes a bool `autoUsesModules` which indicates if ChapelStandard should be used.
* Once I did that, I noticed performance problems with the approach in #19741 (which can be O(n*n) in terms of use/import statements). So, this PR changes it to once again create a ResolvedVisibilityScope with a query and to ignore use/import statements in any module that has its use/import statements currently being resolved (by checking to see if `resolveVisibilityStmtsQuery` is already running). This situation (as well as some related issues) are discussed in issue #19770.
* To support the above, added `Contex::isQueryRunning` to check to see if a query is currently running, in order to avoid recursion. We will see if this introduces other issues with incremental compilation but I haven't yet found a case where it causes problems when used simply to avoid recursion.
* This PR also adds a helper, `AstNode::mayContainStatements`. I thought I would need this for some of the use/import statement processing but it didn't end up being necessary. However it seems like a useful property to have available so I have kept it in the PR.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local testing