### PR TITLE
dyno: optionally resolve and convert types in converter

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1843,12 +1843,8 @@ FnSymbol* buildLambda(FnSymbol *fn) {
   return fn;
 }
 
-BlockStmt* buildExternExportFunctionDecl(Flag externOrExport, Expr* paramCNameExpr, BlockStmt* blockFnDef) {
-  DefExpr* def = toDefExpr(blockFnDef->body.tail);
-  INT_ASSERT(def);
-  FnSymbol* fn = toFnSymbol(def->sym);
-  INT_ASSERT(fn);
-
+void setupExternExportFunctionDecl(Flag externOrExport, Expr* paramCNameExpr,
+                                   FnSymbol* fn) {
   const char* cname = "";
   // Look for a string literal we can use
   if (paramCNameExpr != NULL) {
@@ -1888,6 +1884,15 @@ BlockStmt* buildExternExportFunctionDecl(Flag externOrExport, Expr* paramCNameEx
                                       paramCNameExpr, NULL);
     fn->insertFormalAtTail(argDef);
   }
+}
+
+BlockStmt* buildExternExportFunctionDecl(Flag externOrExport, Expr* paramCNameExpr, BlockStmt* blockFnDef) {
+  DefExpr* def = toDefExpr(blockFnDef->body.tail);
+  INT_ASSERT(def);
+  FnSymbol* fn = toFnSymbol(def->sym);
+  INT_ASSERT(fn);
+
+  setupExternExportFunctionDecl(externOrExport, paramCNameExpr, fn);
 
   return blockFnDef;
 }
@@ -1931,8 +1936,8 @@ buildFunctionSymbol(FnSymbol*   fn,
   return fn;
 }
 
-BlockStmt*
-buildFunctionDecl(FnSymbol*   fn,
+void
+setupFunctionDecl(FnSymbol*   fn,
                   RetTag      optRetTag,
                   Expr*       optRetType,
                   bool        optThrowsError,
@@ -1979,7 +1984,20 @@ buildFunctionDecl(FnSymbol*   fn,
   }
 
   fn->doc = docs;
+}
 
+BlockStmt*
+buildFunctionDecl(FnSymbol*   fn,
+                  RetTag      optRetTag,
+                  Expr*       optRetType,
+                  bool        optThrowsError,
+                  Expr*       optWhere,
+                  Expr*       optLifetimeConstraints,
+                  BlockStmt*  optFnBody,
+                  const char* docs)
+{
+  setupFunctionDecl(fn, optRetTag, optRetType, optThrowsError,
+                    optWhere, optLifetimeConstraints, optFnBody, docs);
   return buildChapelStmt(new DefExpr(fn));
 }
 

--- a/compiler/dyno/include/chpl/resolution/resolution-queries.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-queries.h
@@ -68,6 +68,7 @@ types::QualifiedType getInstantiationType(Context* context,
 
 /**
   Compute a TypedFnSignature from an UntypedFnSignature.
+  (An UntypedFnSignature can be computed with UntypedFnSignature::get()).
   The TypedFnSignature will represent generic and potentially unknown
   types if the function is generic.
  */

--- a/compiler/include/build.h
+++ b/compiler/include/build.h
@@ -167,12 +167,25 @@ DefExpr*  buildTupleArgDefExpr(IntentTag tag, BlockStmt* tuple, Expr* type, Expr
 FnSymbol* buildFunctionFormal(FnSymbol* fn, DefExpr* def);
 FnSymbol* buildLambda(FnSymbol* fn);
 
+void setupExternExportFunctionDecl(Flag externOrExport, Expr* paramCNameExpr,
+                                   FnSymbol* fn);
+
 BlockStmt* buildExternExportFunctionDecl(Flag externOrExport, Expr* paramCNameExpr, BlockStmt* blockFnDef);
 
 FnSymbol* buildFunctionSymbol(FnSymbol*   fn,
                               const char* name,
                               IntentTag   thisTag,
                               Expr*       receiver);
+
+void setupFunctionDecl(FnSymbol*   fn,
+                       RetTag      optRetTag,
+                       Expr*       optRetType,
+                       bool        optThrowsError,
+                       Expr*       optWhere,
+                       Expr*       optLifetimeConstraints,
+                       BlockStmt*  optFnBody,
+                       const char* docs);
+
 BlockStmt* buildFunctionDecl(FnSymbol*   fn,
                              RetTag      optRetTag,
                              Expr*       optRetType,

--- a/compiler/include/convert-uast.h
+++ b/compiler/include/convert-uast.h
@@ -28,8 +28,6 @@
 #include "chpl/uast/BuilderResult.h"
 #include "chpl/uast/Module.h"
 
-// TODO: allow conversion across multiple files
-
 ModuleSymbol*
 convertToplevelModule(chpl::Context* context,
                       const chpl::uast::Module* mod,

--- a/compiler/include/convert-uast.h
+++ b/compiler/include/convert-uast.h
@@ -28,6 +28,8 @@
 #include "chpl/uast/BuilderResult.h"
 #include "chpl/uast/Module.h"
 
+// TODO: once chpldoc is implemented as a separate tool on uAST,
+// remove the comment and builderResult arguments here.
 ModuleSymbol*
 convertToplevelModule(chpl::Context* context,
                       const chpl::uast::Module* mod,

--- a/compiler/include/convert-uast.h
+++ b/compiler/include/convert-uast.h
@@ -28,6 +28,8 @@
 #include "chpl/uast/BuilderResult.h"
 #include "chpl/uast/Module.h"
 
+// TODO: allow conversion across multiple files
+
 ModuleSymbol*
 convertToplevelModule(chpl::Context* context,
                       const chpl::uast::Module* mod,

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -77,6 +77,8 @@ struct Converter {
   chpl::Context* context = nullptr;
   bool inTupleDecl = false;
   ModTag topLevelModTag;
+  // TODO: remove latestComment and builderResult once
+  // chpldoc is implemented as a separate tool on uAST
   const char* latestComment = nullptr;
   const uast::BuilderResult& builderResult;
   std::vector<ModStackEntry> modStack;

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -148,7 +148,7 @@ struct Converter {
   const char* convertLinkageNameAstr(const uast::Decl* node) {
     if (auto linkageName = node->linkageName()) {
       INT_ASSERT(linkageName->isStringLiteral());
-      return astr(linkageName->toStringLiteral()->str().c_str());
+      return astr(linkageName->toStringLiteral()->str());
     }
 
     return nullptr;
@@ -168,7 +168,7 @@ struct Converter {
 
   const char* astrFromStringLiteral(const uast::AstNode* node) {
     if (auto strLit = node->toStringLiteral()) {
-      const char* ret = astr(strLit->str().c_str());
+      const char* ret = astr(strLit->str());
       return ret;
     }
 
@@ -289,7 +289,7 @@ struct Converter {
       return nullptr;
     }
 
-    auto ret = str.size() ? astr(str.c_str()) : nullptr;
+    auto ret = str.size() ? astr(str) : nullptr;
 
     return ret;
   }
@@ -335,7 +335,7 @@ struct Converter {
 
       auto msg = attr->deprecationMessage();
       if (!msg.isEmpty()) {
-        sym->deprecationMsg = astr(msg.c_str());
+        sym->deprecationMsg = astr(msg);
       }
     }
 
@@ -420,7 +420,7 @@ struct Converter {
   }
 
   Expr* visit(const uast::Implements* node) {
-    const char* name = astr(node->interfaceName().c_str());
+    const char* name = astr(node->interfaceName());
     CallExpr* act = new CallExpr(PRIM_ACTUALS_LIST);
     Expr* ret = nullptr;
 
@@ -570,7 +570,7 @@ struct Converter {
         INT_ASSERT(var);
         INT_ASSERT(!var->initExpression() && !var->typeExpression());
 
-        resourceName = astr(var->name().c_str());
+        resourceName = astr(var->name());
 
         // TODO: I'm not sure what the best way to get flags is here.
         if (var->kind() != uast::Variable::INDEX) {
@@ -684,7 +684,7 @@ struct Converter {
   }
 
   Expr* visit(const uast::ExternBlock* node) {
-    return buildExternBlockStmt(astr(node->code().c_str()));
+    return buildExternBlockStmt(astr(node->code()));
   }
 
   Expr* visit(const uast::Require* node) {
@@ -701,7 +701,7 @@ struct Converter {
   // Copy the body of 'buildIncludeModule' since it is heavily tied to the
   // old parser's implementation.
   Expr* visit(const uast::Include* node) {
-    const char* name = astr(node->name().c_str());
+    const char* name = astr(node->name());
     bool isPrivate = node->visibility() == uast::Decl::PRIVATE;
     bool isPrototype = node->isPrototype();
 
@@ -711,7 +711,7 @@ struct Converter {
 
     auto& loc = chpl::parsing::locateAst(gContext, node);
     INT_ASSERT(!loc.isEmpty());
-    auto path = astr(loc.path().c_str());
+    auto path = astr(loc.path());
     ModuleSymbol* mod = parseIncludedSubmodule(name, path);
     INT_ASSERT(mod);
 
@@ -756,7 +756,7 @@ struct Converter {
             Expr* mod = convertAST(as->symbol());
             auto ident = as->rename()->toIdentifier();
             INT_ASSERT(ident);
-            const char* rename = astr(ident->name().c_str());
+            const char* rename = astr(ident->name());
             conv = buildImportStmt(mod, rename);
 
           // Handles: 'import foo'
@@ -1024,13 +1024,13 @@ struct Converter {
 
   BlockStmt* visit(const uast::Break* node) {
     const char* name = nullptr;
-    if (auto target = node->target()) name = astr(target->name().c_str());
+    if (auto target = node->target()) name = astr(target->name());
     return buildGotoStmt(GOTO_BREAK, name);
   }
 
   CatchStmt* visit(const uast::Catch* node) {
     auto errorVar = node->error();
-    const char* name = errorVar ? astr(errorVar->name().c_str()) : nullptr;
+    const char* name = errorVar ? astr(errorVar->name()) : nullptr;
     Expr* type = errorVar ? convertExprOrNull(errorVar->typeExpression())
                           : nullptr;
     BlockStmt* body = toBlockStmt(convertAST(node->body()));
@@ -1156,7 +1156,7 @@ struct Converter {
         INT_ASSERT(ifVar->initExpression());
         // astr() varNameStr so it doesn't go out of scope when passed to
         // buildIfVar
-        auto varNameStr = astr(ifVar->name().c_str());
+        auto varNameStr = astr(ifVar->name());
         auto initExpr = toExpr(convertAST(ifVar->initExpression()));
         bool isConst = ifVar->kind() == uast::Variable::CONST;
         cond = buildIfVar(varNameStr, initExpr, isConst);
@@ -1176,12 +1176,12 @@ struct Converter {
 
   BlockStmt* visit(const uast::Continue* node) {
     const char* name = nullptr;
-    if (auto target = node->target()) name = astr(target->name().c_str());
+    if (auto target = node->target()) name = astr(target->name());
     return buildGotoStmt(GOTO_CONTINUE, name);
   }
 
   Expr* visit(const uast::Label* node) {
-    const char* name = astr(node->name().c_str());
+    const char* name = astr(node->name());
     Expr* stmt = toExpr(convertAST(node->loop()));
     INT_ASSERT(stmt);
     return buildLabelStmt(name, stmt);
@@ -1447,7 +1447,7 @@ struct Converter {
     } else if (node->isParam()) {
       INT_ASSERT(node->index() && node->index()->isVariable());
 
-      auto indexStr = astr(node->index()->toVariable()->name().c_str());
+      auto indexStr = astr(node->index()->toVariable()->name());
       body = createBlockWithStmts(node->stmts(), node->blockStyle());
       BlockStmt* block = toBlockStmt(body);
       INT_ASSERT(block);
@@ -1942,7 +1942,7 @@ struct Converter {
                                       const char* name=nullptr) {
     astlocMarker markAstLoc(node->id());
 
-    const char* opName = name ? name : astr(node->op().c_str());
+    const char* opName = name ? name : astr(node->op());
     int nActuals = node->numActuals();
     CallExpr* ret = new CallExpr(opName);
 
@@ -2363,7 +2363,7 @@ struct Converter {
     // and if so, we are not able to reconstruct them at this time
     std::stringstream ss;
     printFunctionSignature(ss, node);
-    fn->userString = astr(ss.str().c_str());
+    fn->userString = astr(ss.str());
 
     attachSymbolAttributes(node, fn);
     attachSymbolVisibility(node, fn);
@@ -2571,7 +2571,7 @@ struct Converter {
   }
 
   Expr* visit(const uast::Interface* node) {
-    const char* name = astr(node->name().c_str());
+    const char* name = astr(node->name());
     CallExpr* formals = new CallExpr(PRIM_ACTUALS_LIST);
     auto style = uast::BlockStyle::EXPLICIT;
     BlockStmt* body = createBlockWithStmts(node->stmts(), style);
@@ -2579,7 +2579,7 @@ struct Converter {
     if (node->isFormalListPresent()) {
       for (auto formal : node->formals()) {
         if (auto ident = formal->toIdentifier()) {
-          const char* name = astr(ident->name().c_str());
+          const char* name = astr(ident->name());
           auto formal = InterfaceSymbol::buildFormal(name, INTENT_TYPE);
           formals->insertAtTail(formal);
         } else {
@@ -2625,8 +2625,8 @@ struct Converter {
     // Add a SymStackEntry to the end of the symStack
     this->symStack.emplace_back(node, resolved);
 
-    const char* name = astr(node->name().c_str());
-    const char* path = astr(context->filePathForId(node->id()).c_str());
+    const char* name = astr(node->name());
+    const char* path = astr(context->filePathForId(node->id()));
 
     // TODO (dlongnecke): For now, the tag is overridden by the caller.
     // See 'uASTAttemptToParseMod'. Eventually, it would be great if dyno
@@ -3057,7 +3057,7 @@ struct Converter {
   DefExpr* convertEnumElement(const uast::EnumElement* node) {
     astlocMarker markAstLoc(node->id());
 
-    const char* name = astr(node->name().c_str());
+    const char* name = astr(node->name());
     Expr* initExpr = convertExprOrNull(node->initExpression());
     auto ret = new DefExpr(new EnumSymbol(name), initExpr);
     attachSymbolAttributes(node, ret->sym);
@@ -3109,7 +3109,7 @@ struct Converter {
 
   Expr* convertAggregateDecl(const uast::AggregateDecl* node) {
     auto comment = consumeLatestComment();
-    const char* name = astr(node->name().c_str());
+    const char* name = astr(node->name());
     const char* cname = name;
     Expr* inherit = nullptr;
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2321,7 +2321,7 @@ struct Converter {
       return toFnSymbol(it->second);
     }
 
-    // Decide if we want to resolve this module
+    // Decide if we want to resolve this function
     bool shouldResolveFunction = shouldResolve(node);
 
     const resolution::ResolutionResultByPostorderID* resolved = nullptr;

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2313,8 +2313,7 @@ struct Converter {
     return callExpr;
   }
 
-  FnSymbol* convertFunction(const uast::Function* node) {
-    auto comment = consumeLatestComment();
+  FnSymbol* convertFunction(const uast::Function* node, const char* comment) {
     auto it = alreadyConverted.find(node);
     if (it != alreadyConverted.end()) {
       // already converted it, so return that
@@ -2552,7 +2551,8 @@ struct Converter {
   }
 
   Expr* visit(const uast::Function* node) {
-    FnSymbol* fn = convertFunction(node);
+    auto comment = consumeLatestComment();
+    FnSymbol* fn = convertFunction(node, comment);
 
     // For lambdas, return a DefExpr instead of a BlockStmt
     // containing a DefExpr because this is the pattern expected

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2598,8 +2598,6 @@ struct Converter {
 
   DefExpr* visit(const uast::Module* node) {
     auto comment = consumeLatestComment();
-    const char* name = astr(node->name().c_str());
-    const char* path = astr(context->filePathForId(node->id()).c_str());
 
     auto it = alreadyConverted.find(node);
     if (it != alreadyConverted.end()) {
@@ -2611,7 +2609,6 @@ struct Converter {
     bool shouldResolveModule = shouldResolve(node);
 
     const resolution::ResolutionResultByPostorderID* resolved = nullptr;
-    const char* name = astr(node->name().c_str());
 
     if (shouldResolveModule) {
       // Resolve the module
@@ -2626,7 +2623,8 @@ struct Converter {
     // Add a SymStackEntry to the end of the symStack
     this->symStack.emplace_back(node, resolved);
 
-    const char* path = context->filePathForId(node->id()).c_str();
+    const char* name = astr(node->name().c_str());
+    const char* path = astr(context->filePathForId(node->id()).c_str());
 
     // TODO (dlongnecke): For now, the tag is overridden by the caller.
     // See 'uASTAttemptToParseMod'. Eventually, it would be great if dyno

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2933,9 +2933,23 @@ struct Converter {
         auto resolvedVar = r->byAst(node);
         types::QualifiedType qt = resolvedVar.type();
         if (!qt.isUnknown()) {
-
           // Set a type for the variable
           varSym->type = convertType(qt);
+
+          // Set the Qualifier
+          Qualifier q = QUAL_UNKNOWN;
+          if      (qt.kind() == types::QualifiedType::VAR) q = QUAL_VAL;
+          else if (qt.kind() == types::QualifiedType::CONST_VAR) q = QUAL_CONST_VAL;
+          else if (qt.kind() == types::QualifiedType::CONST_REF) q = QUAL_CONST_REF;
+          else if (qt.kind() == types::QualifiedType::REF) q = QUAL_REF;
+          else if (qt.kind() == types::QualifiedType::IN) q = QUAL_VAL;
+          else if (qt.kind() == types::QualifiedType::CONST_IN) q = QUAL_CONST_VAL;
+          else if (qt.kind() == types::QualifiedType::OUT) q = QUAL_VAL;
+          else if (qt.kind() == types::QualifiedType::INOUT) q = QUAL_VAL;
+          else if (qt.kind() == types::QualifiedType::PARAM) q = QUAL_PARAM;
+
+          if (q != QUAL_UNKNOWN)
+            varSym->qual = q;
 
           // Set the param value for the variable, if applicable
           if (varSym->hasFlag(FLAG_MAYBE_PARAM) ||

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -124,7 +124,8 @@ struct Converter {
 
   static bool shouldResolve(UniqueString symbolPath) {
     // TODO: check for dead modules and don't resolve those
-    return symbolPath == "M" || symbolPath.startsWith("M.");
+    //return symbolPath == "M" || symbolPath.startsWith("M.");
+    return false;
   }
   static bool shouldResolve(ID symbolId) {
     return shouldResolve(symbolId.symbolPath());


### PR DESCRIPTION
This PR enables the conversion process in convert-uast.cpp to:
 * resolve the module to compute types etc
 * convert types and params from the resolution result to the production AST
 * set the types and param values when the resolution result is known

The optional resolution process within convert-uast.cpp is controlled by `shouldResolve` which currently just returns `false`.

To do so, I refactored a couple of functions in build.cpp so that the functionality could be more easily reused when including types in the conversion process.

Reviewed by @arezaii - thanks!

- [x] full local testing