### PR TITLE
Added missing const keywords.

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -792,8 +792,8 @@ const char* chpl_get_real_binary_name(void) {
 }
 
 void chpl_launcher_get_job_name(char *baseName, char *jobName, int jobLen) {
-  char* prefix = getenv("CHPL_LAUNCHER_JOB_PREFIX");
-  char* name = getenv("CHPL_LAUNCHER_JOB_NAME");
+  const char* prefix = getenv("CHPL_LAUNCHER_JOB_PREFIX");
+  const char* name = getenv("CHPL_LAUNCHER_JOB_NAME");
 
   if (prefix == NULL) {
     prefix = "CHPL-";


### PR DESCRIPTION
PR #19600 was missing a couple of `const` keywords that prevented it from compiling with `llvm`.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>