### PR TITLE
Address a gcc 12 warning

### DIFF
--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -89,7 +89,7 @@ static int aParsedString(FILE* argFile, char* setConfigBuffer,
   const char* moduleName;
   char* varName;
 
-  if (!equalsSign || !(equalsSign + 1)) {
+  if (!equalsSign) {
     return 0;
   }
 


### PR DESCRIPTION
gcc 12 is smart enough to realize that the second part of the
conditional that I'm  modifying in this PR will be true only iff
the first part is, and warns about it (breaking a CHPL_DEVELOPER
build).  So simplify the conditional by removing the second part.
This code has been around for a looong time!
