### PR TITLE
Have nightly gpu tests use system rather than bundled LLVM

### DIFF
--- a/util/cron/test-cray-cs-gpu-native.bash
+++ b/util/cron/test-cray-cs-gpu-native.bash
@@ -10,7 +10,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native"
 export CHPL_COMM=none
 
 module load cudatoolkit
-export CHPL_LLVM=bundled
+export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_TEST_GPU=true
 export CHPL_LAUNCHER_PARTITION=stormP100


### PR DESCRIPTION
This is because we're getting tons of errors when using the bundled LLVM 14 (see https://chapel.discourse.group/t/cron-cray-cs-gpu-native/12575/2).  I don't believe we would get these issues when using LLVM 13 (the system LLVM).

This is a temporary "fix" just so we can get meaningful test results for other work while we investigate the source of these issues.

Edit: Elliot informed me (on Slack) that we were using the bundled LLVM for this testing configuration as we added it before we had system LLVM's, so we may want to make this a permanent change.