### PR TITLE
Fix an off-by-one error in removeParamAttrs call

### DIFF
--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1517,7 +1517,7 @@ namespace {
         if (update_parameters) {
           for (size_t i = 0; i < Params.size(); i++ ) {
 #if HAVE_LLVM_VER >= 140
-            NF->removeParamAttrs(i+1,
+            NF->removeParamAttrs(i,
                                  AttributeFuncs::typeIncompatible(Params[i]));
 #else
             NF->removeAttributes(i+1,


### PR DESCRIPTION
The function that removeParamAttrs replaced in llvm 14 was 1-based but
removeParamAttrs is 0-based. Stop adding 1 in the call.

This error was causing multilocale tests involving --llvm-wide-opt to fail,
for example those in test/performance/ferguson.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>