### PR TITLE
Fix problem with make install for AUR package

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1279,8 +1279,12 @@ static void printStuff(const char* argv0) {
     printf("CHPL_RUNTIME_INCL: %s\n", CHPL_RUNTIME_INCL);
     printf("CHPL_THIRD_PARTY: %s\n", CHPL_THIRD_PARTY);
     printf("\n");
+    const char* internalFlag = "";
+    if (developer)
+      internalFlag = "--internal";
     int wanted_to_write = snprintf(buf, sizeof(buf),
-                                   "%s/util/printchplenv --all", CHPL_HOME);
+                                   "%s/util/printchplenv --all %s",
+                                   CHPL_HOME, internalFlag);
     if (wanted_to_write < 0) {
       USR_FATAL("character encoding error in CHPL_HOME path name");
     } else if ((size_t)wanted_to_write >= sizeof(buf)) {

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -15,7 +15,10 @@ do
     #e.g. -s|--short)
     --stage=*)
       STAGE="${arg#*=}"
-      STAGE_SET=1
+      if [ ! -z $STAGE ]
+      then
+        STAGE_SET=1
+      fi
       shift
       ;;
     *)

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -246,14 +246,24 @@ def get_bundled_link_args(pkg, ucp='', libs=[], add_L_opt=True):
     if add_L_opt:
         all_args.append('-L' + lib_dir)
         all_args.append('-Wl,-rpath,' + lib_dir)
+
+    # gather the args from the .la, or fallback on just -lpkg
     for lib_arg in libs:
         if lib_arg.endswith('.la'):
             la = os.path.join(lib_dir, lib_arg)
-            all_args.extend(handle_la(la))
+            if os.path.isfile(la):
+                all_args.extend(handle_la(la))
+            else:
+                # if we can't find 'libBLA.la' then add '-lBLA'.
+                # this happens for some package installations
+                x = lib_arg
+                if x.startswith('lib'):
+                    x = x[len('lib'):]
+                if x.endswith('.la'):
+                    x = x[:-len('.la')]
+                all_args.append('-l' + x)
         else:
             all_args.append(lib_arg)
-    if all_args == []:
-        all_args.append('-l' + pkg)
 
     bundled_args = [ ]
     system_args = [ ]


### PR DESCRIPTION
This PR makes 3 improvements motivated by the effort to create an Arch Linux AUR package:

 * adjusts `get_bundled_link_args` in `util/chplenv/third_party_utils.py` to fix a problem with falling back on a `-l` flag if the `.la` file for the library is missing since the AUR install process removes the `.la` files. This fallback logic originated in #15000 but was disrupted by later changes to that function.
 * adjusts `chpl --print-chpl-settings` to print out all internal settings if `--devel` is also passed (to make it easier to debug problems with chplenv scripts)
 * adjusts `install.sh` to only consider it a staged install if the stage directory is not the empty string (since the Makefile calling it always passes `--stage=${DESTDIR}`. As far as I know, this does not change the behavior of install.sh, but it fixes something that would probably be confusing if relied upon in more ways.

Reviewed by @ronawho - thanks!

- [x] full local testing