### PR TITLE
chpl-syntax: handle postfix nilable in formal type expressions

### DIFF
--- a/compiler/dyno/lib/uast/chpl-syntax-printer.cpp
+++ b/compiler/dyno/lib/uast/chpl-syntax-printer.cpp
@@ -257,7 +257,6 @@ struct ChplSyntaxVisitor {
       auto it = node->formals();
       interpose(it.begin() + numThisFormal, it.end(), ", ", "(", ")");
     }
-
   }
 
   /*
@@ -510,13 +509,7 @@ struct ChplSyntaxVisitor {
     printChapelSyntax(ss_, callee);
     if (isCalleeReservedWord(callee)) {
       ss_ << " ";
-      if (auto op = node->actual(0)->toOpCall()) {
-        assert(op->isUnaryOp() && op->op() == USTR("?"));
-        printChapelSyntax(ss_, op->actual(0));
-        ss_ << op->op();
-      } else {
-        printChapelSyntax(ss_, node->actual(0));
-      }
+      printChapelSyntax(ss_, node->actual(0));
     } else {
       if (node->callUsedSquareBrackets()) {
         ss_ << "[";
@@ -783,8 +776,11 @@ struct ChplSyntaxVisitor {
     // is different than !this && that
     if (node->isUnaryOp()) {
       bool isPostFixBang = false;
+      bool isNilable = false;
       if (node->op() == USTR("postfix!")) {
         isPostFixBang = true;
+      } else if (node->op() == USTR("?")) {
+        isNilable = true;
       } else {
         ss_ << node->op();
       }
@@ -792,6 +788,8 @@ struct ChplSyntaxVisitor {
       printChapelSyntax(ss_, node->actual(0));
       if (isPostFixBang) {
         ss_ << "!";
+      } else if (isNilable) {
+        ss_ << "?";
       }
     } else if (node->isBinaryOp()) {
       assert(node->numActuals() == 2);
@@ -976,11 +974,7 @@ struct ChplSyntaxVisitor {
 
     ss_ << " ...";
     if (const AstNode* ce = node->count()) {
-      if (const TypeQuery* tq = ce->toTypeQuery()) {
-        printChapelSyntax(ss_, tq);
-      } else {
-        printChapelSyntax(ss_, ce);
-      }
+      printChapelSyntax(ss_, ce);
     }
   }
 

--- a/compiler/dyno/test/uast/testStringify.cpp
+++ b/compiler/dyno/test/uast/testStringify.cpp
@@ -414,6 +414,9 @@ static void test3(Parser* parser) {
   TEST_USER_STRING("proc foo(x: borrowed C(t=?tt, r=?rr), y: borrowed C(tt, rr)) {}",
                    "foo(x: borrowed C(t = ?tt, r = ?rr), y: borrowed C(tt, rr))")
   TEST_USER_STRING("proc (int(32)).foo() {\n}", "(int(32)).foo()")
+  TEST_USER_STRING("proc proc1(arg: Monkey1?) { }", "proc1(arg: Monkey1?)" )
+  TEST_USER_STRING("proc proc1(arg: 2*Monkey1?) { }", "proc1(arg: 2*Monkey1?)")
+  TEST_USER_STRING("proc proc1(arg: owned 2*Monkey1?) { }", "proc1(arg: owned 2*Monkey1?)")
 }
 
 static void test4(Parser* parser) {


### PR DESCRIPTION
This PR updates and corrects how we print `?` whether we
are in a `TypeQuery` (prefix) or an `OpCall` (postfix).

This should fix the future for `test/classes/vass/no-instance-for-arg-type`
that started breaking after moving to the `dyno` parser.

Added some test cases to catch regressions.

TESTING:

- [x] paratest (0 failures)
- [x] paratest with `--no-dyno` (24 failures)

reviewed by @dlongnecke-cray - Thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>