### PR TITLE
Fix failing GPU tests.

### DIFF
--- a/test/gpu/native/diags.good
+++ b/test/gpu/native/diags.good
@@ -6,7 +6,7 @@ Start
 0 (cpu): diags.chpl:10: allocate 48B of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (cpu): diags.chpl:10: free at 0xPREDIFFED
 0 (cpu): diags.chpl:12: allocate 168B of [domain(1,int(64),false)] locale at 0xPREDIFFED
-0 (cpu): diags.chpl:12: allocate 16B of array elements at 0xPREDIFFED
+0 (cpu): diags.chpl:12: allocate 128B of array elements at 0xPREDIFFED
 0 (cpu): diags.chpl:12: allocate 48B of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (cpu): diags.chpl:12: free at 0xPREDIFFED
 0 (gpu 0): diags.chpl:13: allocate 168B of [domain(1,int(64),false)] int(64) at 0xPREDIFFED

--- a/test/gpu/native/kernelFnCalls/fnWithForall.chpl
+++ b/test/gpu/native/kernelFnCalls/fnWithForall.chpl
@@ -16,7 +16,7 @@ proc foo(n) {
 
 
 startVerboseGPU();
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [0..#n] real;
 
   foreach i in 0..#n {  // This is not a kernel, `foo` is too complicated

--- a/test/gpu/native/multiGPU/multiGPU.good
+++ b/test/gpu/native/multiGPU/multiGPU.good
@@ -1,7 +1,32 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-warning: Unknown CUDA version. cuda.h: CUDA_VERSION=11060. Assuming the latest supported version 10.1
-ptxas warning : Unresolved extern variable 'chpl_nodeID' in whole program compilation, ignoring extern qualifier
-warning: Unknown CUDA version. cuda.h: CUDA_VERSION=11060. Assuming the latest supported version 10.1
+Array: 1 1 1 1 1 1 1 1 1 1 
+Array: 2 2 2 2 2 2 2 2 2 2 
+Array: 3 3 3 3 3 3 3 3 3 3 
+Array: 32 32 32 32 32 32 32 32 32 32 
+Array: 1 1 1 1 1 1 1 1 1 1 
+Array: 2 2 2 2 2 2 2 2 2 2 
+Array: 3 3 3 3 3 3 3 3 3 3 
+Array: 32 32 32 32 32 32 32 32 32 32 
+Array: 1 1 1 1 1 1 1 1 1 1 
+Array: 2 2 2 2 2 2 2 2 2 2 
+Array: 3 3 3 3 3 3 3 3 3 3 
+Array: 32 32 32 32 32 32 32 32 32 32 
+Array: 1 1 1 1 1 1 1 1 1 1 
+Array: 2 2 2 2 2 2 2 2 2 2 
+Array: 3 3 3 3 3 3 3 3 3 3 
+Array: 32 32 32 32 32 32 32 32 32 32 
+Array: 1 1 1 1 1 1 1 1 1 1 
+Array: 2 2 2 2 2 2 2 2 2 2 
+Array: 3 3 3 3 3 3 3 3 3 3 
+Array: 32 32 32 32 32 32 32 32 32 32 
+Array: 1 1 1 1 1 1 1 1 1 1 
+Array: 2 2 2 2 2 2 2 2 2 2 
+Array: 3 3 3 3 3 3 3 3 3 3 
+Array: 32 32 32 32 32 32 32 32 32 32 
+Array: 1 1 1 1 1 1 1 1 1 1 
+Array: 2 2 2 2 2 2 2 2 2 2 
+Array: 3 3 3 3 3 3 3 3 3 3 
+Array: 32 32 32 32 32 32 32 32 32 32 
 Array: 1 1 1 1 1 1 1 1 1 1 
 Array: 2 2 2 2 2 2 2 2 2 2 
 Array: 3 3 3 3 3 3 3 3 3 3 

--- a/test/gpu/native/multiGPU/worksharing.good
+++ b/test/gpu/native/multiGPU/worksharing.good
@@ -1,5 +1,2 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-warning: Unknown CUDA version. cuda.h: CUDA_VERSION=11060. Assuming the latest supported version 10.1
-ptxas warning : Unresolved extern variable 'chpl_nodeID' in whole program compilation, ignoring extern qualifier
-warning: Unknown CUDA version. cuda.h: CUDA_VERSION=11060. Assuming the latest supported version 10.1
 21 21 21 21 21 21 21 21 21 21

--- a/test/gpu/native/multiGPU/worksharingBasic.good
+++ b/test/gpu/native/multiGPU/worksharingBasic.good
@@ -1,5 +1,2 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-warning: Unknown CUDA version. cuda.h: CUDA_VERSION=11060. Assuming the latest supported version 10.1
-ptxas warning : Unresolved extern variable 'chpl_nodeID' in whole program compilation, ignoring extern qualifier
-warning: Unknown CUDA version. cuda.h: CUDA_VERSION=11060. Assuming the latest supported version 10.1
 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1


### PR DESCRIPTION
There are a few changes:

**Add PREDIFF symbolic link to multiGpu dir**

The outermost PREDIFF script is written generically enough to handle this.  Anyway I've updated the good files to not explicitly do this and am updated the multi/ directory to follow the precedent of having a symbolically linked PREDIFF to the more generic script.

**Update multiGPU .good file to recognize multiple printouts of arrays**

I'm not sure why this has changed (maybe due to changes in the locale model?).
But it seems like the new output is correct (we're supposed to reprint the arrays for each GPU, right?).  @e-kayrakli Could you please double check this?


**Update fnWithForall to use new locale model**
Instead of doing `getChild(1)` do `gpus[0]`. 

**Update memory allocation in diags**

See this diff, from:

`< 0 (cpu): diags.chpl:12: allocate 16B of array elements at 0xPREDIFFED`

to:

`> 0 (cpu): diags.chpl:12: allocate 128B of array elements at 0xPREDIFFED`

I'm guessing this reflects an internal change in the array module and we should just update the .good file but I want a second opinion. Can you comment @e-kayrakli?