### PR TITLE
Fix a typo in the IO documentation

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1810,7 +1810,7 @@ proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE, style:iostyle):file throws {
 
 /*
 
-Create a Chapel file that works with a system file descriptor  Note that once
+Create a Chapel file that works with a system file descriptor.  Note that once
 the file is open, you will need to use a :proc:`file.reader` or
 :proc:`file.writer` to create a channel to actually perform I/O operations
 


### PR DESCRIPTION
The touched line was missing a period between sentences.  Noticed while
reviewing the open* functions.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>