### PR TITLE
Add check to see if libclang-cpp-dev package is installed and ensure missing package errors get to user

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -69,12 +69,10 @@ def check_llvm_config(llvm_config):
 
     got_version = 0
     version_ok = False
-    llvm_header = ''
-    llvm_include_ok = False
-    clang_header = ''
-    clang_include_ok = False
+
     exists, returncode, my_stdout, my_stderr = try_run_command([llvm_config,
                                                                 '--version'])
+    s = ''
     if exists and returncode == 0:
         version_string = my_stdout.strip()
         got_version = version_string.split('.')[0]
@@ -82,6 +80,23 @@ def check_llvm_config(llvm_config):
     else:
         s = "could not run llvm-config at {0}".format(llvm_config)
         return (0, s)
+
+    if not version_ok:
+        s = ("LLVM version {0} is not one of the supported versions: {1}"
+             .format(got_version, llvm_versions_string()))
+
+    return (got_version, s)
+
+# Ensure that relevant LLVM-related header files and libraries have been
+# installed. If these are missing it usually indicates the user failed to
+# install some necessary package.
+def check_llvm_packages(llvm_config):
+    llvm_header = ''
+    llvm_include_ok = False
+    clang_header = ''
+    clang_include_ok = False
+    clang_cpp_lib = ''
+    clang_cpp_lib_ok = False
 
     include_dir = run_command([llvm_config, '--includedir']).strip()
     if os.path.isdir(include_dir):
@@ -91,22 +106,23 @@ def check_llvm_config(llvm_config):
         clang_header = os.path.join(include_dir, 'clang', 'Basic', 'Version.h')
         clang_include_ok = os.path.exists(clang_header)
 
-    s = ''
-    if not version_ok:
-        s = ("LLVM version {0} is not one of the supported versions: {1}"
-             .format(got_version, llvm_versions_string()))
-        return (got_version, s)
+    llvm_lib_dir = run_command([llvm_config, '--libdir']).strip()
+    if os.path.isdir(llvm_lib_dir):
+        clang_cpp_lib = os.path.join(llvm_lib_dir, 'libclang-cpp.so')
+        clang_cpp_lib_ok = os.path.exists(clang_cpp_lib)
 
+    s = ''
     if not llvm_include_ok:
         s = "Could not find the LLVM header {0}".format(llvm_header)
         s += "\nPerhaps you need to install clang and llvm dev packages"
-        return (got_version, s)
     elif not clang_include_ok:
         s = "Could not find the clang header {0}".format(clang_header)
         s += "\nPerhaps you need to install clang and llvm dev packages"
-        return (got_version, s)
+    elif not clang_cpp_lib_ok:
+        s = "Could not find the clang library {0}".format(clang_cpp_lib)
+        s += "\nPerhaps you need to install the libclang-cpp-dev package"
 
-    return (got_version, '')
+    return (s == '', s)
 
 
 @memoize
@@ -189,18 +205,20 @@ def validate_llvm_config():
                   .format(llvm_config, config_error))
 
     if llvm_val == 'system':
-        bindir = get_system_llvm_config_bindir()
-        if not (bindir and os.path.isdir(bindir)):
-            error("llvm-config command {0} provides missing bin dir {1}"
-                  .format(llvm_config, bindir))
-        clang_c = get_llvm_clang('c')[0]
-        clang_cxx = get_llvm_clang('c++')[0]
-        if not os.path.exists(clang_c):
-            error("Missing clang command at {0}".format(clang_c))
-        if not os.path.exists(clang_cxx):
-            error("Missing clang++ command at {0}".format(clang_cxx))
+      bindir = get_system_llvm_config_bindir()
+      if not (bindir and os.path.isdir(bindir)):
+          error("llvm-config command {0} provides missing bin dir {1}"
+                .format(llvm_config, bindir))
+      clang_c = get_llvm_clang('c')[0]
+      clang_cxx = get_llvm_clang('c++')[0]
+      if not os.path.exists(clang_c):
+          error("Missing clang command at {0}".format(clang_c))
+      if not os.path.exists(clang_cxx):
+          error("Missing clang++ command at {0}".format(clang_cxx))
 
-
+      (noPackageErrors, package_err) = check_llvm_packages(llvm_config)
+      if not noPackageErrors:
+        error(package_err)
 
 @memoize
 def get_system_llvm_config_bindir():


### PR DESCRIPTION
I'm trying to install llvm 13 on my desktop to use it as the "system" LLVM when `CHPL_LLVM=system`.  Anyway, I must have forgotten to install a package because when I build Chapel I get this error: 

```
/usr/bin/ld: cannot find -lclang-cpp
```

I figured out the missing package was: `libclang-cpp-dev` (after apt-getting it things work fine).

It's a better user experience if we can get `printchplenv` to guide the user towards installing the necessary packages. I see in `chplenv/chpl_llvm.py` (in the `check_llvm_config` function) we have some checking that looks for things like missing include files (due to missing packages) and produces some nice error messages. Unfortunately, these error messages never reach the user, rather you'll get this more confusing error:

`Exception: CHPL_LLVM=system but could not find an installed LLVM with one of the supported versions: 14, 13, 12, 11`

You can reproduce this by running `sudo apt remove libclang-dev` and running `printchplenv`. I think this is due to a bug where we produce the error message (and add it to some error log) but never actually report it to the user.

In this PR I fix this so we separate out the check for the presence of `llvm_config` from the other checks about include files (and now libs) and ensure that we run these checks when we're using the system LLVM.

I also add in the check for missing `-lclang_cpp`, you'll now get this message if it can't find it:

`Perhaps you need to install the libclang-cpp-dev package`

**One concern I have about this PR**: is that my new check explicitly looks for `libclang-cpp.so`. I'm not sure what adds `-lclang_cpp` to our build but anytime we hardcode something there's always a risk the name change underneath us. I don't know of any more generic way of doing this, however.

--

In terms of validation: I don't think we really have any tests for this so I hand validated it, here's a detailed log showing what I did:

<details>
On my desktop without clang preinstalled:

Showing that I don't have LLVM installed:

```
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ apt list --installed | grep "llvm"

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ apt list --installed | grep "clang"

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

Showing things are fine if we use the bundled LLVM:

```
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ export CHPL_LLVM="bundled"
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ printchplenv
machine info: Linux gpudesktop 5.14.0-1036-oem #40-Ubuntu SMP Mon May 9 09:15:08 UTC 2022 x86_64
CHPL_HOME: /home/stonea/chapel *
script location: /home/stonea/chapel/util/chplenv
CHPL_TARGET_PLATFORM: linux64
CHPL_TARGET_COMPILER: llvm *
CHPL_TARGET_ARCH: x86_64
CHPL_TARGET_CPU: native
CHPL_LOCALE_MODEL: gpu *
CHPL_COMM: none *
CHPL_TASKS: qthreads
CHPL_LAUNCHER: none
CHPL_TIMERS: generic
CHPL_UNWIND: none
CHPL_MEM: jemalloc
CHPL_ATOMICS: cstdlib
CHPL_GMP: none
CHPL_HWLOC: bundled
CHPL_RE2: bundled
CHPL_LLVM: bundled *
CHPL_AUX_FILESYS: none
```

Showing we error if I try and use a non-existent system LLVM:

```
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ export CHPL_LLVM=system
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ printchplenv
Traceback (most recent call last):
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 495, in <module>
    main()
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 484, in main
    compute_all_values()
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 217, in compute_all_values
    chpl_llvm.validate_llvm_config()
  File "/home/stonea/chapel/util/chplenv/utils.py", line 43, in memoize_wrapper
    cache[args] = func(*args)
  File "/home/stonea/chapel/util/chplenv/chpl_llvm.py", line 196, in validate_llvm_config
    error("CHPL_LLVM=system but could not find an installed LLVM"
  File "/home/stonea/chapel/util/chplenv/utils.py", line 27, in error
    raise exception(msg)
Exception: CHPL_LLVM=system but could not find an installed LLVM with one of the supported versions: 14, 13, 12, 11
```

Installing LLVM-13 but not clang I get a nice error message saying its missing:

```
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ sudo apt install llvm-13
...

Traceback (most recent call last):
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 495, in <module>
    main()
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 484, in main
    compute_all_values()
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 217, in compute_all_values
    chpl_llvm.validate_llvm_config()
  File "/home/stonea/chapel/util/chplenv/utils.py", line 43, in memoize_wrapper
    cache[args] = func(*args)
  File "/home/stonea/chapel/util/chplenv/chpl_llvm.py", line 215, in validate_llvm_config
    error("Missing clang command at {0}".format(clang_c))
  File "/home/stonea/chapel/util/chplenv/utils.py", line 27, in error
    raise exception(msg)
Exception: Missing clang command at /usr/lib/llvm-13/bin/clang
```

So if I install clang but not the dev package it gives a nice error message:

```
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ sudo apt install clang-13

stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ printchplenv
Traceback (most recent call last):
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 495, in <module>
    main()
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 484, in main
    compute_all_values()
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 217, in compute_all_values
    chpl_llvm.validate_llvm_config()
  File "/home/stonea/chapel/util/chplenv/utils.py", line 43, in memoize_wrapper
    cache[args] = func(*args)
  File "/home/stonea/chapel/util/chplenv/chpl_llvm.py", line 221, in validate_llvm_config
    error(package_err)
  File "/home/stonea/chapel/util/chplenv/utils.py", line 27, in error
    raise exception(msg)
Exception: Could not find the clang header /usr/lib/llvm-13/include/clang/Basic/Version.h
Perhaps you need to install clang and llvm dev packages
```

Installing libclang-dev package but not clang++ we now get a new error message:

```
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ sudo apt install libclang-13-dev

stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ printchplenv
Traceback (most recent call last):
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 495, in <module>
    main()
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 484, in main
    compute_all_values()
  File "/home/stonea/chapel/util/chplenv/printchplenv.py", line 217, in compute_all_values
    chpl_llvm.validate_llvm_config()
  File "/home/stonea/chapel/util/chplenv/utils.py", line 43, in memoize_wrapper
    cache[args] = func(*args)
  File "/home/stonea/chapel/util/chplenv/chpl_llvm.py", line 221, in validate_llvm_config
    error(package_err)
  File "/home/stonea/chapel/util/chplenv/utils.py", line 27, in error
    raise exception(msg)
Exception: Could not find the clang library /usr/lib/llvm-13/lib/libclang-cpp.so
Perhaps you need to install the libclang-cpp-dev package
```

If I compile Chapel at this point I now get a linker error:

```
/usr/bin/ld: cannot find -lclang-cpp
```

So if I install it everything is fine (woohoo!):

```
stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ sudo apt-get install libclang-cpp13-dev

stonea@gpudesktop [CHAP 1][DEV] ~/chapel
$ printchplenv
machine info: Linux gpudesktop 5.14.0-1036-oem #40-Ubuntu SMP Mon May 9 09:15:08 UTC 2022 x86_64
CHPL_HOME: /home/stonea/chapel *
script location: /home/stonea/chapel/util/chplenv
CHPL_TARGET_PLATFORM: linux64
CHPL_TARGET_COMPILER: llvm *
CHPL_TARGET_ARCH: x86_64
CHPL_TARGET_CPU: native
CHPL_LOCALE_MODEL: gpu *
CHPL_COMM: none *
CHPL_TASKS: qthreads
CHPL_LAUNCHER: none
CHPL_TIMERS: generic
CHPL_UNWIND: none
CHPL_MEM: jemalloc
CHPL_ATOMICS: cstdlib
CHPL_GMP: none
CHPL_HWLOC: bundled
CHPL_RE2: bundled
CHPL_LLVM: system *
CHPL_AUX_FILESYS: none
```
</details>
