### PR TITLE
dyno: Fix some memory leaks detected by ASAN

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -965,8 +965,8 @@ struct Converter {
   }
 
   BlockStmt* visit(const uast::Break* node) {
-    const char* name = node->target() ? node->target()->name().c_str()
-                                      : nullptr;
+    const char* name = nullptr;
+    if (auto target = node->target()) name = astr(target->name().c_str());
     return buildGotoStmt(GOTO_BREAK, name);
   }
 
@@ -1117,8 +1117,8 @@ struct Converter {
   }
 
   BlockStmt* visit(const uast::Continue* node) {
-    const char* name =
-        node->target() ? astr(node->target()->name().c_str()) : nullptr;
+    const char* name = nullptr;
+    if (auto target = node->target()) name = astr(target->name().c_str());
     return buildGotoStmt(GOTO_CONTINUE, name);
   }
 
@@ -2485,7 +2485,7 @@ struct Converter {
   DefExpr* visit(const uast::Module* node) {
     auto comment = consumeLatestComment();
     const char* name = astr(node->name().c_str());
-    const char* path = context->filePathForId(node->id()).c_str();
+    const char* path = astr(context->filePathForId(node->id()).c_str());
 
     // TODO (dlongnecke): For now, the tag is overridden by the caller.
     // See 'uASTAttemptToParseMod'. Eventually, it would be great if dyno

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -799,7 +799,8 @@ void handleError(astlocT astloc, const char *fmt, ...) {
 }
 
 void handleError(chpl::Location loc, const char *fmt, ...) {
-  astlocT astloc(loc.firstLine(), loc.path().c_str());
+  const char* astrPath = astr(loc.path().c_str());
+  astlocT astloc(loc.firstLine(), astrPath);
 
   va_list args;
 


### PR DESCRIPTION
dyno: Fix some memory leaks detected by ASAN (#19852)

Fix some memory leaks detected by ASAN as a result of doing the
parser swap. Sometimes a chpl::UniqueString may store an inlined
string on the stack. These are temporary, so call `astr` on them
to make sure we don't have a memory error.

Reviewed by @benharsh. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>