### PR TITLE
Copy FLAG_C_MEMORY_ORDER_TYPE in convertTypesToExtern

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2616,6 +2616,7 @@ BlockStmt* convertTypesToExtern(BlockStmt* blk, const char* cname) {
 
           // TODO: Loop/copy all flags here instead of two?
           if (theVs->hasFlag(FLAG_PRIVATE)) ts->addFlag(FLAG_PRIVATE);
+          if (theVs->hasFlag(FLAG_C_MEMORY_ORDER_TYPE)) ts->addFlag(FLAG_C_MEMORY_ORDER_TYPE);
           if (theVs->hasFlag(FLAG_NO_DOC)) ts->addFlag(FLAG_NO_DOC);
           if (theVs->hasFlag(FLAG_DEPRECATED)) {
             ts->addFlag(FLAG_DEPRECATED);


### PR DESCRIPTION
To fix a problem after PR #19816 with forall unordered optimization e.g. for

     test/release/examples/benchmarks/hpcc/ra-atomics.chpl

- [x] primers pass with gasnet
- [x] full local testing
- [x] fixes problems with ra-atomics.chpl on a Cray CS
- [x] fixes problems in Cray XC aarch testing

Reviewed by @arezaii - thanks!