### PR TITLE
dyno: insert dyno parsed filenames into gFilenameLookup

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -933,7 +933,7 @@ static ModuleSymbol* dynoParseFile(const char* fileName,
   // The 'parseFile' query gets us a builder result that we can inspect to
   // see if there were any parse errors.
   auto& builderResult = chpl::parsing::parseFile(gContext, path);
-
+  gFilenameLookup.push_back(path.c_str());
   // Any errors while building will have already been emitted by the global
   // error handling callback that was set above. So just stop.
   // TODO (dlongnecke): What if errors were emitted outside of / not noted


### PR DESCRIPTION
This PR addresses test failures that showed up after PR 
https://github.com/chapel-lang/chapel/pull/19816 when `CHPL_UNWIND` is set,
e.g., `test/runtime/stacktrace/fact-linenum.chpl`.

Now we will explicitly add parsed filenames to `gFilenameLookup`
when using the `dyno` parser.

TESTING:
- [x] paratest
- [x] fixed runtime/stacktrace/fact-linenum
- [x] fixed runtime/stacktrace/fact-stacktrace
- [x] fixed runtime/stacktrace/stacktrace

reviewed by @dlongnecke-cray - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>