### PR TITLE
Allow CHPL_LOCALE_MODEL=gpu and CHPL_COMM=gasnet; also refactor GpuTransforms (without refactoring change)

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2626,27 +2626,27 @@ static void codegenPartTwo() {
     codegen_library_makefile();
   }
 
-    // Vectors to store different symbol names to be used while generating header
-    std::set<const char*> cnames;
-    std::vector<TypeSymbol*> types;
-    std::vector<FnSymbol*> functions;
-    std::vector<VarSymbol*> globals;
+  // Vectors to store different symbol names to be used while generating header
+  std::set<const char*> cnames;
+  std::vector<TypeSymbol*> types;
+  std::vector<FnSymbol*> functions;
+  std::vector<VarSymbol*> globals;
 
-    // This dumps the generated sources into the build directory.
-    info->cfile = hdrfile.fptr;
-    codegen_header(cnames, types, functions, globals);
+  // This dumps the generated sources into the build directory.
+  info->cfile = hdrfile.fptr;
+  codegen_header(cnames, types, functions, globals);
 
-    // Prepare the LLVM IR dumper for code generation
-    // This needs to happen after protectNameFromC which happens
-    // currently in codegen_header.
-    preparePrintLlvmIrForCodegen();
+  // Prepare the LLVM IR dumper for code generation
+  // This needs to happen after protectNameFromC which happens
+  // currently in codegen_header.
+  preparePrintLlvmIrForCodegen();
 
-    info->cfile = defnfile.fptr;
-    codegen_defn(cnames, types, functions, globals);
-    info->cfile = mainfile.fptr;
-    if ( gCodegenGPU == false ) {
-      codegen_config();
-    }
+  info->cfile = defnfile.fptr;
+  codegen_defn(cnames, types, functions, globals);
+  info->cfile = mainfile.fptr;
+  if ( gCodegenGPU == false ) {
+    codegen_config();
+  }
 
   // Don't need to do most of the rest of the function for LLVM;
   // just codegen the modules.
@@ -2721,7 +2721,7 @@ void codegen() {
 
     if (pid == 0) {
       // child process
-    gCodegenGPU = true;
+      gCodegenGPU = true;
       codegenPartTwo();
       makeBinary();
       clean_exit(0);
@@ -2740,7 +2740,7 @@ void codegen() {
     }
   }
 
-      codegenPartTwo();
+  codegenPartTwo();
 }
 
 void makeBinary(void) {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1965,7 +1965,7 @@ static void codegen_header(std::set<const char*> & cnames,
   //
   if( hdrfile ) {
     fprintf(hdrfile, "\nextern void* const chpl_private_broadcast_table[];\n");
-  } else {
+  } else if(!gCodegenGPU) {
 #ifdef HAVE_LLVM
     llvm::Type *private_broadcastTableEntryType =
       llvm::IntegerType::getInt8PtrTy(info->module->getContext());
@@ -2626,27 +2626,27 @@ static void codegenPartTwo() {
     codegen_library_makefile();
   }
 
-  // Vectors to store different symbol names to be used while generating header
-  std::set<const char*> cnames;
-  std::vector<TypeSymbol*> types;
-  std::vector<FnSymbol*> functions;
-  std::vector<VarSymbol*> globals;
+    // Vectors to store different symbol names to be used while generating header
+    std::set<const char*> cnames;
+    std::vector<TypeSymbol*> types;
+    std::vector<FnSymbol*> functions;
+    std::vector<VarSymbol*> globals;
 
-  // This dumps the generated sources into the build directory.
-  info->cfile = hdrfile.fptr;
-  codegen_header(cnames, types, functions, globals);
+    // This dumps the generated sources into the build directory.
+    info->cfile = hdrfile.fptr;
+    codegen_header(cnames, types, functions, globals);
 
-  // Prepare the LLVM IR dumper for code generation
-  // This needs to happen after protectNameFromC which happens
-  // currently in codegen_header.
-  preparePrintLlvmIrForCodegen();
+    // Prepare the LLVM IR dumper for code generation
+    // This needs to happen after protectNameFromC which happens
+    // currently in codegen_header.
+    preparePrintLlvmIrForCodegen();
 
-  info->cfile = defnfile.fptr;
-  codegen_defn(cnames, types, functions, globals);
-  info->cfile = mainfile.fptr;
-  if ( gCodegenGPU == false ) {
-    codegen_config();
-  }
+    info->cfile = defnfile.fptr;
+    codegen_defn(cnames, types, functions, globals);
+    info->cfile = mainfile.fptr;
+    if ( gCodegenGPU == false ) {
+      codegen_config();
+    }
 
   // Don't need to do most of the rest of the function for LLVM;
   // just codegen the modules.
@@ -2717,30 +2717,48 @@ void codegen() {
     // name uses the PID).
     ensureTmpDirExists();
 
-    pid_t pid = fork();
+    //pid_t pid = fork();
 
-    if (pid == 0) {
+    //if (pid == 0) {
       // child process
-      gCodegenGPU = true;
+
+    gCodegenGPU = true;
       codegenPartTwo();
       makeBinary();
-      clean_exit(0);
-    } else {
+      //clean_exit(0);
+    //} else {
       // parent process
-      INT_ASSERT(!gCodegenGPU);
-      int status = 0;
-      while (wait(&status) != pid) {
+    gCodegenGPU = false;
+    //INT_ASSERT(!gCodegenGPU);
+      //int status = 0;
+      //while (wait(&status) != pid) {
         // wait for child process
-      }
+      //}
       // If there was an error in GPU code generation then the .fatbin file (containing
       // the generated GPU code) was not created and we won't be able to continue.
-      if(status != 0) {
-        clean_exit(status);
-      }
+      //if(status != 0) {
+        //clean_exit(status);
+      //}
+    //}
+
+    // Types cache their code generated result we need to re codegen them into the new
+    // llvm context between our first invocation of clang (where we generate the GPU
+    // code) and the second (where we generate everything else).
+    forv_Vec(TypeSymbol, ts, gTypeSymbols) {
+      ts->llvmType = nullptr;
+      ts->llvmTbaaTypeDescriptor = nullptr;
+      ts->llvmTbaaAccessTag = nullptr;
+      ts->llvmConstTbaaAccessTag = nullptr;
+      ts->llvmTbaaAggTypeDescriptor = nullptr;
+      ts->llvmTbaaAggAccessTag = nullptr;
+      ts->llvmConstTbaaAggAccessTag = nullptr;
+      ts->llvmTbaaStructCopyNode = nullptr;
+      ts->llvmConstTbaaStructCopyNode = nullptr;
+      ts->llvmDIType = nullptr;
     }
   }
 
-  codegenPartTwo();
+      codegenPartTwo();
 }
 
 void makeBinary(void) {

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -206,7 +206,7 @@ bool OutlineInfo::buildStubOutlinedFunction(CForLoop* loop) {
 
   // Pattern match loop boundaries to determine lower
   // and upper bounds. If we fail to match exit early.
-  if(!extractIndicesAndLowerBounds(loop) || 
+  if(!extractIndicesAndLowerBounds(loop) ||
      !extractUpperBound(loop))
   {
     return false;

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -45,6 +45,16 @@ extern int classifyPrimitive(CallExpr *call, bool inLocal);
 extern bool inLocalBlock(CallExpr *call);
 
 struct OutlineInfo {
+  // Given a CForLoop that we want to outline into a function for a GPU kernel
+  // extract the loopIndices, lowerBounds, and upperBound and populate it with
+  // boilerplate computation to calculate what index the kernel should operate
+  // on given its thread ID. After buildStubOutlinedFunction is finished its up
+  // to the caller to populate its body with the body of the loop and to call
+  // the outlined function. It's possible that we fail to build the function if
+  // the loop boundaries don't represent a range if this is the case we return
+  // false and the caller should stop trying to outline.
+  bool buildStubOutlinedFunction(CForLoop* loop);
+
   CForLoop* loop = NULL;
 
   std::vector<Symbol*> loopIndices;
@@ -56,14 +66,17 @@ struct OutlineInfo {
   std::vector<Symbol*> kernelActuals;
 
   SymbolMap copyMap;
+
+  private:
+  bool extractIndicesAndLowerBounds(CForLoop* loop);
+  bool extractUpperBound(CForLoop* loop);
+  void generateIndexComputation();
 };
 
 static VarSymbol* generateAssignmentToPrimitive(FnSymbol* fn,
                                                 const char *varName,
                                                 PrimitiveTag prim,
                                                 Type *primReturnType);
-
-static void generateIndexComputation(OutlineInfo& info);
 
 static void generateEarlyReturn(OutlineInfo& info);
 
@@ -77,6 +90,7 @@ static bool shouldOutlineLoopHelp(BlockStmt* blk,
 static SymExpr* hasOuterVarAccesses(FnSymbol* fn);
 static void markGPUSuitableLoops();
 
+static Symbol* addKernelArgument(OutlineInfo& info, Symbol* symInLoop);
 
 static bool isDefinedInTheLoop(Symbol* sym, CForLoop* loop) {
   LoopStmt* curLoop = LoopStmt::findEnclosingLoop(sym->defPoint);
@@ -129,7 +143,7 @@ static bool isIndexVariable(OutlineInfo& info, Symbol* sym) {
   return std::find(indices.begin(), indices.end(), sym) != indices.end();
 }
 
-static void extractUpperBound(CForLoop* loop, OutlineInfo& info) {
+bool OutlineInfo::extractUpperBound(CForLoop* loop) {
   if(BlockStmt* bs = toBlockStmt(loop->testBlockGet())) {
     for_exprs_postorder (expr, bs) {
       if(CallExpr *call = toCallExpr(expr)) {
@@ -137,9 +151,9 @@ static void extractUpperBound(CForLoop* loop, OutlineInfo& info) {
           if(SymExpr *symExpr = toSymExpr(call->get(2))) {
 
             SymExpr* lhsSymExpr = toSymExpr(call->get(1));
-            INT_ASSERT(lhsSymExpr && lhsSymExpr->symbol() == info.loopIndices[0]);
+            INT_ASSERT(lhsSymExpr && lhsSymExpr->symbol() == this->loopIndices[0]);
 
-            info.upperBound = symExpr->symbol();
+            this->upperBound = symExpr->symbol();
 
             break;
           }
@@ -148,14 +162,10 @@ static void extractUpperBound(CForLoop* loop, OutlineInfo& info) {
     }
   }
 
-  if (info.upperBound == NULL) {
-    INT_FATAL("Unexpected upper bound for loop identified for extraction as "
-              "GPU kernel");
-  }
+  return this->upperBound != NULL;
 }
 
-static void extractIndicesAndLowerBounds(CForLoop* loop,
-                                         OutlineInfo& info) {
+bool OutlineInfo::extractIndicesAndLowerBounds(CForLoop* loop) {
   if(BlockStmt* bs = toBlockStmt(loop->initBlockGet())) {
     for_alist (expr, bs->body) {
       if(CallExpr *call = toCallExpr(expr)) {
@@ -168,18 +178,19 @@ static void extractIndicesAndLowerBounds(CForLoop* loop,
           INT_ASSERT(idxSymExpr);
           INT_ASSERT(boundSymExpr);
 
-          info.loopIndices.push_back(idxSymExpr->symbol());
-          info.lowerBounds.push_back(boundSymExpr->symbol());
+          this->loopIndices.push_back(idxSymExpr->symbol());
+          this->lowerBounds.push_back(boundSymExpr->symbol());
         }
       }
     }
 
-    INT_ASSERT(bs->body.length == (int)info.loopIndices.size());
-    INT_ASSERT(bs->body.length == (int)info.lowerBounds.size());
+    INT_ASSERT(bs->body.length == (int)this->loopIndices.size());
+    INT_ASSERT(bs->body.length == (int)this->lowerBounds.size());
+  } else {
+    return false;
   }
-  else {
-    INT_FATAL("Unexpected initBlock in CForLoop");
-  }
+
+  return true;
 }
 
 static VarSymbol* insertNewVarAndDef(BlockStmt* insertionPoint, const char* name,
@@ -190,21 +201,29 @@ static VarSymbol* insertNewVarAndDef(BlockStmt* insertionPoint, const char* name
   return var;
 }
 
-static OutlineInfo collectOutlineInfo(CForLoop* loop) {
-  OutlineInfo info;
-  info.loop = loop;
-  extractIndicesAndLowerBounds(loop, info);
-  extractUpperBound(loop, info);
+bool OutlineInfo::buildStubOutlinedFunction(CForLoop* loop) {
+  this->loop = loop;
 
-  info.fn = new FnSymbol("chpl_gpu_kernel");
-  info.fn->addFlag(FLAG_RESOLVED);
-  info.fn->addFlag(FLAG_ALWAYS_RESOLVE);
-  info.fn->addFlag(FLAG_GPU_CODEGEN);
+  // Pattern match loop boundaries to determine lower
+  // and upper bounds. If we fail to match exit early.
+  if(!extractIndicesAndLowerBounds(loop) || 
+     !extractUpperBound(loop))
+  {
+    return false;
+  }
 
-  generateIndexComputation(info);
-  generateEarlyReturn(info);
+  fn = new FnSymbol("chpl_gpu_kernel");
 
-  return info;
+  fn->body->blockInfoSet(new CallExpr(PRIM_BLOCK_LOCAL));
+
+  fn->addFlag(FLAG_RESOLVED);
+  fn->addFlag(FLAG_ALWAYS_RESOLVE);
+  fn->addFlag(FLAG_GPU_CODEGEN);
+
+  generateIndexComputation();
+  generateEarlyReturn(*this);
+
+  return true;
 }
 
 /**
@@ -283,16 +302,13 @@ static Symbol* addLocalVariable(OutlineInfo& info, Symbol* symInLoop) {
  *
  *  Also adds the loopIndex->index to the copyMap
  **/
-static void generateIndexComputation(OutlineInfo& info) {
-
-  FnSymbol* fn = info.fn;
-
-  std::vector<Symbol*>::size_type numIndices = info.loopIndices.size();
-  INT_ASSERT(info.lowerBounds.size() == numIndices);
+void OutlineInfo::generateIndexComputation() {
+  std::vector<Symbol*>::size_type numIndices = loopIndices.size();
+  INT_ASSERT(lowerBounds.size() == numIndices);
 
   for (std::vector<Symbol*>::size_type i=0 ; i<numIndices ; i++) {
-    Symbol* loopIndex  = info.loopIndices[i];
-    Symbol* lowerBound = info.lowerBounds[i];
+    Symbol* loopIndex  = loopIndices[i];
+    Symbol* lowerBound = lowerBounds[i];
 
     VarSymbol *varBlockIdxX = generateAssignmentToPrimitive(fn, "blockIdxX",
       PRIM_GPU_BLOCKIDX_X, dtInt[INT_SIZE_32]);
@@ -313,18 +329,18 @@ static void generateIndexComputation(OutlineInfo& info) {
                                                                   varThreadIdxX));
     fn->insertAtTail(c2);
 
-    Symbol* startOffset = addKernelArgument(info, lowerBound);
+    Symbol* startOffset = addKernelArgument(*this, lowerBound);
     VarSymbol* index = insertNewVarAndDef(fn->body, "chpl_simt_index",
                                           dtInt[INT_SIZE_32]);
     fn->insertAtTail(new CallExpr(PRIM_MOVE, index, new CallExpr(PRIM_ADD,
                                                                  tempVar1,
                                                                  startOffset)));
 
-    info.kernelIndices.push_back(index);
-    info.copyMap.put(loopIndex, index);
+    kernelIndices.push_back(index);
+    copyMap.put(loopIndex, index);
   }
 
-  INT_ASSERT(info.kernelIndices.size() == info.loopIndices.size());
+  INT_ASSERT(kernelIndices.size() == loopIndices.size());
 }
 
 /*
@@ -424,10 +440,13 @@ static void outlineGPUKernels() {
         if (shouldOutlineLoop(loop, allowFnCallsFromGPU)) {
           SET_LINENO(loop);
 
-          OutlineInfo info = collectOutlineInfo(loop);
+          // We may fail to build stub function if loop boundaries don't
+          // pattern match the way we expect, if that happens give up on
+          // outlining and continue to the next loop.
+          OutlineInfo info;
+          if(!info.buildStubOutlinedFunction(loop)) { continue; }
 
           FnSymbol* outlinedFunction = info.fn;
-
           fn->defPoint->insertBefore(new DefExpr(outlinedFunction));
 
           // if (chpl_task_getRequestedSubloc() >= 0) {
@@ -449,9 +468,7 @@ static void outlineGPUKernels() {
           elseBlock->insertAtHead(loop->remove());
 
           std::set<Symbol*> handledSymbols;
-
           for_alist(node, loop->body) {
-
             bool copyNode = true;
             std::vector<SymExpr*> symExprsInBody;
             collectSymExprs(node, symExprsInBody);

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -233,6 +233,12 @@ module LocaleModelHelpSetup {
   proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string,
       numSublocales: int, type GPULocale){
 
+    // Cylic distribution uses this variable to determine how many
+    // data-parallel tasks to have per locale. If this gets set to 0 then we
+    // end up not processing things in the first locale.
+    extern proc chpl_task_getMaxPar(): uint(32);
+    dst.maxTaskPar = chpl_task_getMaxPar();
+
     var childSpace = {0..#numSublocales};
 
     const origSubloc = chpl_task_getRequestedSubloc();

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -233,9 +233,9 @@ module LocaleModelHelpSetup {
   proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string,
       numSublocales: int, type GPULocale){
 
-    // Cylic distribution uses this variable to determine how many
-    // data-parallel tasks to have per locale. If this gets set to 0 then we
-    // end up not processing things in the first locale.
+    // Cylic (and likely other) distributions uses this variable to determine
+    // how many data-parallel tasks to have per locale. If this gets set to 0
+    // then we end up not processing things in the first locale.
     extern proc chpl_task_getMaxPar(): uint(32);
     dst.maxTaskPar = chpl_task_getMaxPar();
 

--- a/test/gpu/native/distArray/SKIPIF
+++ b/test/gpu/native/distArray/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_COMM==gasnet

--- a/test/gpu/native/environment/gasnet.chpl
+++ b/test/gpu/native/environment/gasnet.chpl
@@ -1,2 +1,3 @@
 // We don't actually have a program to compile. Just want to ensure that
-// if CHPL_LOCALE_MODEL == gpu and CHPL_COMM != none we error out.
+// if CHPL_LOCALE_MODEL == gpu and CHPL_COMM == gasnet is a valid
+// combination.

--- a/test/gpu/native/environment/gasnet.good
+++ b/test/gpu/native/environment/gasnet.good
@@ -1,2 +1,0 @@
-Error: The prototype GPU support does not work when CHPL_COMM is not set to
-"none".

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -113,9 +113,9 @@ CHPL_QTHREAD_CFG_OPTIONS += --enable-static --disable-shared
 
 # determine which scheduler to use. Use nemesis for flat and distrib for
 # non-flat.  Override with a user provided option if they requested one
-SCHEDULER = nemesis
-ifneq ($(CHPL_MAKE_LOCALE_MODEL),flat)
 SCHEDULER = distrib
+ifneq ($(CHPL_MAKE_LOCALE_MODEL),numa)
+SCHEDULER = nemesis
 endif
 ifneq (, $(CHPL_QTHREAD_SCHEDULER))
 SCHEDULER = $(CHPL_QTHREAD_SCHEDULER)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -111,12 +111,11 @@ endif
 
 CHPL_QTHREAD_CFG_OPTIONS += --enable-static --disable-shared
 
-# determine which scheduler to use. Use nemesis for numa and distrib for any
-# other model (e.g. flat and gpu).  Override with a user provided option if
-# they requested one
-SCHEDULER = distrib
-ifneq ($(CHPL_MAKE_LOCALE_MODEL),numa)
+# determine which scheduler to use based on locale model.  Override with a user
+# provided option if they requested one
 SCHEDULER = nemesis
+ifeq ($(CHPL_MAKE_LOCALE_MODEL),numa)
+  SCHEDULER = distrib
 endif
 ifneq (, $(CHPL_QTHREAD_SCHEDULER))
 SCHEDULER = $(CHPL_QTHREAD_SCHEDULER)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -112,9 +112,13 @@ endif
 CHPL_QTHREAD_CFG_OPTIONS += --enable-static --disable-shared
 
 # determine which scheduler to use based on locale model.  Override with a user
-# provided option if they requested one
+# provided option if they requested one.
 SCHEDULER = nemesis
 ifeq ($(CHPL_MAKE_LOCALE_MODEL),numa)
+  # The distrib scheduler is numa aware (you can say things like "run this new
+  # task on numa domain X" or "which numa domain is this task running on?");
+  # however its performance is generally worse than nemesis so we don't use it
+  # by default.
   SCHEDULER = distrib
 endif
 ifneq (, $(CHPL_QTHREAD_SCHEDULER))

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -111,8 +111,9 @@ endif
 
 CHPL_QTHREAD_CFG_OPTIONS += --enable-static --disable-shared
 
-# determine which scheduler to use. Use nemesis for flat and distrib for
-# non-flat.  Override with a user provided option if they requested one
+# determine which scheduler to use. Use nemesis for numa and distrib for any
+# other model (e.g. flat and gpu).  Override with a user provided option if
+# they requested one
 SCHEDULER = distrib
 ifneq ($(CHPL_MAKE_LOCALE_MODEL),numa)
 SCHEDULER = nemesis

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -24,6 +24,4 @@ def get_cuda_path():
         return ""
 
 def validate(chplLocaleModel, chplComm):
-    if chplLocaleModel == 'gpu' and chplComm != "none":
-        error("The prototype GPU support does not work when CHPL_COMM is not set to\n\"none\".");
-
+    pass

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -24,4 +24,7 @@ def get_cuda_path():
         return ""
 
 def validate(chplLocaleModel, chplComm):
-    pass
+    validModels = ["none", "gasnet"]
+    if chplLocaleModel == 'gpu' and chplComm not in ["none", "gasnet"]:
+      error("The prototype GPU support does not work when CHPL_COMM is not set to one of:\n\t%s." %
+         ", ".join(validModels))


### PR DESCRIPTION
This PR is essentially a clone of: https://github.com/chapel-lang/chapel/pull/19802 but without the refactoring change.

I want to separate out the refactoring change part of that into a separate PR for better reviewability / software archeology.

I'll repeat relevant information from the previous PR; this change:

Allows compilation with CHPL_LOCALE_MODEL=gpu and CHPL_COMM=gasnet.

This PR isn't intended to enable communication from/to the GPU across nodes but (the hope atleast) is that you'll be able to do the normal node-to-node communication you're used to.

I'm leaving it as remaining work to add a test (we'll need to decide if we want a "gasnet on Osprey for GPU tests" suite or not). **edit:** Yes we'll want this, I'll add it this sprint after this PR gets merged in.

I did however try maually running the following program on Osprey:

```chpl
use CyclicDist;
const Dom = {0..<numLocales} dmapped Cyclic(startIdx=0);
var A : [Dom] int;

coforall loc in Locales do on loc {
  on here.gpus[0] {
    var B : [0..10] int;
    foreach i in 0..10 {
      B[i] = here.id * 100 + i;
    }
    A[here.id] = B[0];
  }
}

writeln(A);
```

And it will work as I expect with the following output:

```
> foo -nl 4
0 100 200 300
```

A few other oddities to point out:
- In the qthread Makefile I changed the scheduler for the GPU locale model (or really any non-numa locale model) to use distrib. In absence of this change I'll get the following warning: `warning: Disabling --cache-remote because tasks can migrate threads (quiet with CHPL_RT_CACHE_QUIET=true)` Prior to this PR the Makefile would set the scheduler to `nemesis` for any non flat locale model but I have a feeling that was really only meant to only apply to the numa locale model. @ronawho, would you mind taking a quick look at this and letting me know if you think this is a safe change to make (I think you're the right person to ping?)?
- We previously weren't setting maxTaskPar for the CPU locale when using the GPU locale model, this was causing a crash and I think it was just an oversight.
- With these changes made for some reason I would encounter a CForLoop that was determined eligible for GPU code generation but who's bound was something of the form `lhs != rhs`. This would trigger an assertion because we're assuming the bounds of the loop is of the form `lhs < rhs`. I've now made it so if this doesn't pattern match we bail on doing the outlining of the function (to turn it into a GPU kernel).

**Some new info**:

Compared to the previous PR I've also updated some of the tests. I'm not able to get the distributed array examples and one of the stream configurations (with `--fast`) to compile under this configuration (with `CHPL_COMM=gasnet`) so I've added `.skipifs` for these test points for now. I'm leaving it as future work to figure out why (I talked with Engin about this earlier).
