### PR TITLE
Automatically rebuild the compiler when the LLVM version changes

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -171,6 +171,11 @@ def get_llvm_config():
     return llvm_config
 
 @memoize
+def get_llvm_version():
+    (llvm_version, _) = check_llvm_config(get_llvm_config())
+    return llvm_version
+
+@memoize
 def validate_llvm_config():
     llvm_val = get()
     llvm_config = get_llvm_config()
@@ -813,6 +818,9 @@ def _main():
     parser.add_option('--llvm-config', dest='action',
                       action='store_const',
                       const='llvmconfig', default='')
+    parser.add_option('--llvm-vesion', dest='action',
+                      action='store_const',
+                      const='llvmversion', default='')
     parser.add_option('--supported-versions', dest='action',
                       action='store_const',
                       const='llvmversions', default='')
@@ -831,6 +839,9 @@ def _main():
     elif options.action == 'llvmconfig':
         sys.stdout.write("{0}\n".format(llvm_config))
         validate_llvm_config()
+    elif options.action == 'llvmversion':
+        llvm_version = get_llvm_version()
+        sys.stdout.write("{0}\n".format(llvm_version))
     elif options.action == 'llvmversions':
         sys.stdout.write("{0}\n".format(llvm_versions))
     elif options.action == 'sdkroot':

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -113,6 +113,7 @@ CHPL_ENVS = [
     ChapelEnv('  CHPL_RE2_IS_OVERRIDDEN', INTERNAL),
     ChapelEnv('CHPL_LLVM', COMPILER | DEFAULT, 'llvm'),
     ChapelEnv('  CHPL_LLVM_CONFIG', COMPILER | NOPATH),
+    ChapelEnv('  CHPL_LLVM_VERSION', COMPILER),
     ChapelEnv('  CHPL_LLVM_CLANG_C', INTERNAL),
     ChapelEnv('  CHPL_LLVM_CLANG_CXX', INTERNAL),
     ChapelEnv('CHPL_AUX_FILESYS', RUNTIME | DEFAULT, 'fs'),
@@ -200,6 +201,7 @@ def compute_all_values():
     ENV_VALS['  CHPL_RE2_IS_OVERRIDDEN'] = chpl_re2.is_overridden()
     ENV_VALS['CHPL_LLVM'] = chpl_llvm.get()
     ENV_VALS['  CHPL_LLVM_CONFIG'] = chpl_llvm.get_llvm_config()
+    ENV_VALS['  CHPL_LLVM_VERSION'] = chpl_llvm.get_llvm_version()
     llvm_clang_c = chpl_llvm.get_llvm_clang('c')
     llvm_clang_cxx = chpl_llvm.get_llvm_clang('c++')
     ENV_VALS['  CHPL_LLVM_CLANG_C'] = " ".join(llvm_clang_c)
@@ -313,6 +315,8 @@ def filter_tidy(chpl_env):
     elif chpl_env.name == '  CHPL_NETWORK_ATOMICS':
         return comm != 'none'
     elif chpl_env.name == '  CHPL_LLVM_CONFIG':
+        return llvm != 'none'
+    elif chpl_env.name == '  CHPL_LLVM_VERSION':
         return llvm != 'none'
     elif chpl_env.name == '  CHPL_CUDA_PATH':
         return locale_model == 'gpu'


### PR DESCRIPTION
When the LLVM version changes a rebuild of the compiler is required. Update
build scripts to do the rebuild.

Tested that a rebuild happens when switching from system 14 -> system 13 ->
system 12 -> bundled -> none -> system 14.

This is the change suggested in https://github.com/Cray/chapel-private/issues/3196.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>