### PR TITLE
dyno: handle converting void return types

### DIFF
--- a/compiler/dyno/include/chpl/queries/all-global-strings.h
+++ b/compiler/dyno/include/chpl/queries/all-global-strings.h
@@ -59,6 +59,7 @@ X(these_         , "these")
 X(type           , "type")
 X(uint_          , "uint")
 X(unmanaged      , "unmanaged")
+X(void_          , "void")
 
 X(equals         , "=")
 X(question       , "?")

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -342,6 +342,8 @@ struct Converter {
       return new UnresolvedSymExpr("chpl_by");
     } else if (name == USTR("_")) {
       return new UnresolvedSymExpr("chpl__tuple_blank");
+    } else if (name == USTR("void")) {
+      return new SymExpr(dtVoid->symbol);
     }
 
     return nullptr;


### PR DESCRIPTION
This PR adds converting of explicit `void` types in to
the corresponding `dtVoid` when using the `dyno` parser.

This is to address some test failures we saw when using
`--baseline` to compile Chapel programs. 

The tests in question are:
```
extern/diten/externVoidFnWithArrayNoUse
users/ibertolacc/void_extern_proc_array
```

TESTING:

- [x] failed tests now pass with `--baseline`
- [x] paratest with `--baseline`
- [x] paratest

reviewed by @dlongnecke-cray - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>