### PR TITLE
Fix these two tests after the Math module split

### DIFF
--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_assignment.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_assignment.chpl
@@ -8,10 +8,10 @@
 */
 
 //
-// Use standard modules for Bit operations, Random numbers, Timing, and
-// Block and Cyclic distributions
+// Use standard modules for less common Math, Bit operations, Random numbers,
+// Timing, and Block and Cyclic distributions
 //
-use BitOps, Random, Time, BlockDist, CyclicDist;
+use Math, BitOps, Random, Time, BlockDist, CyclicDist;
 
 //
 // Use shared user module for computing HPCC problem sizes

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_bulk.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_bulk.chpl
@@ -1,4 +1,4 @@
-use CTypes;
+use CTypes, Math;
 
 proc copyBtoC(A:[], B:[])
 {


### PR DESCRIPTION
Now that Math is not included by default and these tests rely on symbols in it,
they need an explicit use of the module to continue to function

Passed a fresh checkout