### PR TITLE
Quick patch to mac specific bug introduced in previous PR

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -108,7 +108,12 @@ def check_llvm_packages(llvm_config):
 
     llvm_lib_dir = run_command([llvm_config, '--libdir']).strip()
     if os.path.isdir(llvm_lib_dir):
-        clang_cpp_lib = os.path.join(llvm_lib_dir, 'libclang-cpp.so')
+        if sys.platform == "darwin":
+          clang_cpp_lib = os.path.join(llvm_lib_dir, 'libclang-cpp.dylib')
+        elif platform == "win32":
+          clang_cpp_lib = os.path.join(llvm_lib_dir, 'libclang-cpp.dll')
+        else:
+          clang_cpp_lib = os.path.join(llvm_lib_dir, 'libclang-cpp.so')
         clang_cpp_lib_ok = os.path.exists(clang_cpp_lib)
 
     s = ''


### PR DESCRIPTION
This PR: https://github.com/chapel-lang/chapel/pull/19851 was Linux specific
(it searches for a dynamic lib and assumes the extension is .so). I generalized
it to also work on mac and windows systems.  This is still not ideal (maybe
there's another file extension I'm forgetting about?). But it's better.

---
Signed-off-by: Andy Stone <stonea@users.noreply.github.com>