### PR TITLE
Accidentally introduced in my previous patch.

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -110,7 +110,7 @@ def check_llvm_packages(llvm_config):
     if os.path.isdir(llvm_lib_dir):
         if sys.platform == "darwin":
           clang_cpp_lib = os.path.join(llvm_lib_dir, 'libclang-cpp.dylib')
-        elif platform == "win32":
+        elif sys.platform == "win32":
           clang_cpp_lib = os.path.join(llvm_lib_dir, 'libclang-cpp.dll')
         else:
           clang_cpp_lib = os.path.join(llvm_lib_dir, 'libclang-cpp.so')


### PR DESCRIPTION
In python should have used `sys.platform` instead of just `platform` in a code path that only runs on non-mac systems.

---
Signed-off-by: Andy Stone <stonea@users.noreply.github.com>