### PR TITLE
test: fix .bad file for one test

### DIFF
--- a/test/classes/vass/no-instance-for-arg-type.bad
+++ b/test/classes/vass/no-instance-for-arg-type.bad
@@ -1,4 +1,4 @@
 no-instance-for-arg-type.chpl:5: error: unresolved call 'proc1(nil)'
-no-instance-for-arg-type.chpl:4: note: this candidate did not match: proc1(arg: ?Monkey1)
+no-instance-for-arg-type.chpl:4: note: this candidate did not match: proc1(arg: Monkey1?)
 no-instance-for-arg-type.chpl:5: note: because actual argument #1 with type 'nil'
 no-instance-for-arg-type.chpl:4: note: is passed to formal 'arg: Monkey1?'


### PR DESCRIPTION
This PR fixes a test's `.bad` file that was modified during the
parser replacement and not updated after a fix was implemented.

The test in question is `test/classes/vass/no-instance-for-arg-type`

TESTING:

- [x] failing test now passes

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>