### PR TITLE
Fix tiny mistake in PR #19857

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -25,6 +25,6 @@ def get_cuda_path():
 
 def validate(chplLocaleModel, chplComm):
     validModels = ["none", "gasnet"]
-    if chplLocaleModel == 'gpu' and chplComm not in ["none", "gasnet"]:
+    if chplLocaleModel == 'gpu' and chplComm not in validModels:
       error("The prototype GPU support does not work when CHPL_COMM is not set to one of:\n\t%s." %
          ", ".join(validModels))


### PR DESCRIPTION
This is a tiny/quick fox for PR #19857.

In chpl_gpu.py I have an array of valid values for CHPL_COMM when
CHPL_LOCALE_MODEL_GPU. I accidentally manually "constant folded" this
value in a place where I should have just used the variable.