### PR TITLE
Fix clang 14 warning

### DIFF
--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -670,7 +670,7 @@ const ResolvedFields& fieldsForTypeDeclQuery(Context* context,
     for (auto child: ad->children()) {
       // Ignore everything other than VarLikeDecl, MultiDecl, TupleDecl
       if (child->isVarLikeDecl() ||
-          child->isMultiDecl() |
+          child->isMultiDecl() ||
           child->isTupleDecl()) {
         const ResolvedFields& resolvedFields =
           resolveFieldDecl(context, ct, child->id(), useGenericFormalDefaults);


### PR DESCRIPTION
This PR fixes a compilation warning-as-error from clang 14 from code added in PR #19765.

Trivial and not reviewed.