### PR TITLE
Add cray-cs-gpu-native-gasnet configuration

### DIFF
--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -12,4 +12,3 @@ export CHPL_LOCALE_MODEL=gpu
 export CHPL_TEST_GPU=true
 export CHPL_LAUNCHER_PARTITION=stormP100
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"
-

--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -1,0 +1,6 @@
+module load cudatoolkit
+export CHPL_LLVM=system
+export CHPL_LOCALE_MODEL=gpu
+export CHPL_TEST_GPU=true
+export CHPL_LAUNCHER_PARTITION=stormP100
+export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"

--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -1,6 +1,15 @@
+# Use LLVM-13 to work around https://github.com/chapel-lang/chapel/issues/19740
+source /cray/css/users/chapelu/setup_system_llvm.bash 13
+# Lie to prevent common.bash adding a newer llvm
+export OFFICIAL_SYSTEM_LLVM=true
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-cray-cs.bash
+
 module load cudatoolkit
 export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_TEST_GPU=true
 export CHPL_LAUNCHER_PARTITION=stormP100
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"
+

--- a/util/cron/test-cray-cs-gpu-native-gasnet.bash
+++ b/util/cron/test-cray-cs-gpu-native-gasnet.bash
@@ -3,9 +3,7 @@
 # GPU native testing on a Cray CS (using gasnet for CHPL_COMM)
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native-gasnet"
-
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-cray-cs-gpu-native-gasnet.bash
+++ b/util/cron/test-cray-cs-gpu-native-gasnet.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# GPU native testing on a Cray CS (using gasnet for CHPL_COMM)
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-cray-cs.bash
+source $CWD/common-native-gpu.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native-gasnet"
+
+$CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-cray-cs-gpu-native.bash
+++ b/util/cron/test-cray-cs-gpu-native.bash
@@ -2,16 +2,9 @@
 #
 # GPU native testing on a Cray CS (using none for CHPL_COMM)
 
-# Use LLVM-13 to work around https://github.com/chapel-lang/chapel/issues/19740
-source /cray/css/users/chapelu/setup_system_llvm.bash 13
-# Lie to prevent common.bash adding a newer llvm
-export OFFICIAL_SYSTEM_LLVM=true
-
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
-
 export CHPL_COMM=none
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native"
 
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native-gasnet"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-cray-cs-gpu-native.bash
+++ b/util/cron/test-cray-cs-gpu-native.bash
@@ -6,5 +6,5 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 export CHPL_COMM=none
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native-gasnet"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-cray-cs-gpu-native.bash
+++ b/util/cron/test-cray-cs-gpu-native.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# GPU itiventerop testing on a Cray CS
+# GPU native testing on a Cray CS (using none for CHPL_COMM)
 
 # Use LLVM-13 to work around https://github.com/chapel-lang/chapel/issues/19740
 source /cray/css/users/chapelu/setup_system_llvm.bash 13
@@ -9,16 +9,9 @@ export OFFICIAL_SYSTEM_LLVM=true
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
-
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native"
+source $CWD/common-native-gpu.bash
 
 export CHPL_COMM=none
-
-module load cudatoolkit
-export CHPL_LLVM=system
-export CHPL_LOCALE_MODEL=gpu
-export CHPL_TEST_GPU=true
-export CHPL_LAUNCHER_PARTITION=stormP100
-export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-cs-gpu-native"
 
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
I would like to have nightly tests runs everything under `gpu/native` with `CHPL_COMM=gasnet`. This PR adds `util/cron/test-cray-cs-gpu-native-gasnet.bash` to run a job with this configuration.