### PR TITLE
dyno: Adjust assertion for AggregateDecl

### DIFF
--- a/compiler/dyno/include/chpl/uast/AggregateDecl.h
+++ b/compiler/dyno/include/chpl/uast/AggregateDecl.h
@@ -111,12 +111,12 @@ class AggregateDecl : public TypeDecl {
   /**
    Return a way to iterate over the contained Decls (ignoring Comments)
    */
-  AstListNoCommentsIteratorPair<Decl> decls() const {
+  AstListNoCommentsIteratorPair<AstNode> decls() const {
     if (elementsChildNum_ < 0)
-      return AstListNoCommentsIteratorPair<Decl>(
+      return AstListNoCommentsIteratorPair<AstNode>(
                 children_.end(), children_.end());
 
-    return AstListNoCommentsIteratorPair<Decl>(
+    return AstListNoCommentsIteratorPair<AstNode>(
               children_.begin() + elementsChildNum_,
               children_.begin() + elementsChildNum_ + numElements_);
   }

--- a/compiler/dyno/include/chpl/uast/AggregateDecl.h
+++ b/compiler/dyno/include/chpl/uast/AggregateDecl.h
@@ -111,12 +111,12 @@ class AggregateDecl : public TypeDecl {
   /**
    Return a way to iterate over the contained Decls (ignoring Comments)
    */
-  AstListNoCommentsIteratorPair<AstNode> decls() const {
+  AstListNoCommentsIteratorPair<Decl> decls() const {
     if (elementsChildNum_ < 0)
-      return AstListNoCommentsIteratorPair<AstNode>(
+      return AstListNoCommentsIteratorPair<Decl>(
                 children_.end(), children_.end());
 
-    return AstListNoCommentsIteratorPair<AstNode>(
+    return AstListNoCommentsIteratorPair<Decl>(
               children_.begin() + elementsChildNum_,
               children_.begin() + elementsChildNum_ + numElements_);
   }

--- a/compiler/dyno/lib/uast/AggregateDecl.cpp
+++ b/compiler/dyno/lib/uast/AggregateDecl.cpp
@@ -27,13 +27,15 @@ namespace uast {
 
 bool AggregateDecl::validAggregateChildren(AstListIteratorPair<AstNode> it) {
   for (auto elt: it) {
-    if (elt->isComment() || elt->isErroneousExpression()) {
+    if (elt->isComment() || elt->isErroneousExpression() ||
+        elt->isEmptyStmt()) {
       // OK
     } else if (elt->isDecl()) {
       if (elt->isVariable() || elt->isFunction() || elt->isTupleDecl() ||
           elt->isMultiDecl() ||
           elt->isAggregateDecl() ||
-          elt->isForwardingDecl()) {
+          elt->isForwardingDecl() ||
+          elt->isTypeDecl()) {
         // OK
       } else {
         return false;


### PR DESCRIPTION
dyno: Adjust assertion for AggregateDecl (#19886)

Adjust an assertion which checks body elements in AggregateDecl
so that it accepts TypeDecl and EmptyStmt, which are both
valid children (e.g., `enum` and `;` respectively).

Reviewed by @benharsh. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>