### PR TITLE
Add error about foreach loops not supporting task intents

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1469,6 +1469,11 @@ struct Converter {
     // Does not appear possible right now, from reading the grammar.
     INT_ASSERT(!node->isExpressionLevel());
 
+    if (node->withClause()) {
+      USR_FATAL_CONT(node->withClause()->id(), "foreach loops do not yet "
+                                               "support task intents");
+    }
+
     // The pieces that we need for 'buildForallLoopExpr'.
     Expr* indices = convertLoopIndexDecl(node->index());
     Expr* iteratorExpr = toExpr(convertAST(node->iterand()));

--- a/test/performance/vectorization/vectorizeOnly/vectorizeOnlyWithIntents.bad
+++ b/test/performance/vectorization/vectorizeOnly/vectorizeOnlyWithIntents.bad
@@ -1,6 +1,3 @@
-vectorizeOnlyWithIntents.chpl:5: syntax error: near 'with'
-vectorizeOnlyWithIntents.chpl:8: syntax error: near '}'
-vectorizeOnlyWithIntents.chpl:11: syntax error: near 'with'
-vectorizeOnlyWithIntents.chpl:14: syntax error: near '}'
-vectorizeOnlyWithIntents.chpl:17: syntax error: near 'with'
-vectorizeOnlyWithIntents.chpl:20: syntax error: near '}'
+vectorizeOnlyWithIntents.chpl:5: error: foreach loops do not yet support task intents
+vectorizeOnlyWithIntents.chpl:11: error: foreach loops do not yet support task intents
+vectorizeOnlyWithIntents.chpl:17: error: foreach loops do not yet support task intents

--- a/test/statements/errors/foreachTaskIntents.chpl
+++ b/test/statements/errors/foreachTaskIntents.chpl
@@ -1,0 +1,22 @@
+// check that 'foreach' works with forall intents since forall intents are
+// currently implemented by using varargs
+
+var x = 0;
+foreach i in 1..10 with (ref x) {
+  x = i;
+  writeln((i, x));
+}
+writeln(x);
+
+foreach i in zip(1..10, 11..20) with (ref x) {
+  x = i(1);
+  writeln((i, x));
+}
+writeln(x);
+
+foreach i in zip(11..20, 21..30) with (ref x) {
+  x = i(1);
+  writeln((i, x));
+}
+writeln(x);
+

--- a/test/statements/errors/foreachTaskIntents.good
+++ b/test/statements/errors/foreachTaskIntents.good
@@ -1,0 +1,3 @@
+foreachTaskIntents.chpl:5: error: foreach loops do not yet support task intents
+foreachTaskIntents.chpl:11: error: foreach loops do not yet support task intents
+foreachTaskIntents.chpl:17: error: foreach loops do not yet support task intents


### PR DESCRIPTION
Add error about foreach loops not supporting task intents (#19887)

The dyno parser supports parsing foreach loops with task intents,
but the old AST is not yet capable of supporting them. Add a
compile-time error stating that task intents are not yet supported
(though we intend to, see #18500).

Reviewed by @mppf. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>