### PR TITLE
Use llvm 13 for valgrind testing

### DIFF
--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -2,6 +2,11 @@
 #
 # Test valgrind-compatible configuration on full suite with valgrind on linux64.
 
+# Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
+# and pretend it's a system llvm to avoid common.bash adding a newer one
+source /cray/css/users/chapelu/setup_system_llvm.bash 13
+export OFFICIAL_SYSTEM_LLVM=true
+
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-valgrind.bash

--- a/util/cron/test-valgrindexe.bash
+++ b/util/cron/test-valgrindexe.bash
@@ -2,6 +2,11 @@
 #
 # Test valgrind-compatible configuration on full suite with valgrind on linux64.
 
+# Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
+# and pretend it's a system llvm to avoid common.bash adding a newer one
+source /cray/css/users/chapelu/setup_system_llvm.bash 13
+export OFFICIAL_SYSTEM_LLVM=true
+
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-valgrind.bash


### PR DESCRIPTION
clang/llvm 14 started generated dwarf5 debug info by default and that's
not compatible with the version of valgrind we use. Until we get a
chance to upgrade, pin to clang/llvm 13.

For more info see Cray/chapel-private#3373