### PR TITLE
Adjust two GPU tests to be more portable

### DIFF
--- a/test/gpu/native/diags.good
+++ b/test/gpu/native/diags.good
@@ -1,16 +1,16 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 Start
-0 (cpu): diags.chpl:10: allocate 88B of domain(1,int(64),false) at 0xPREDIFFED
-0 (cpu): diags.chpl:10: allocate 168B of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
-0 (cpu): diags.chpl:10: allocate 80B of array elements at 0xPREDIFFED
-0 (cpu): diags.chpl:10: allocate 48B of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
+0 (cpu): diags.chpl:10: allocate xxB of domain(1,int(64),false) at 0xPREDIFFED
+0 (cpu): diags.chpl:10: allocate xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
+0 (cpu): diags.chpl:10: allocate xxB of array elements at 0xPREDIFFED
+0 (cpu): diags.chpl:10: allocate xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (cpu): diags.chpl:10: free at 0xPREDIFFED
-0 (cpu): diags.chpl:12: allocate 168B of [domain(1,int(64),false)] locale at 0xPREDIFFED
-0 (cpu): diags.chpl:12: allocate 128B of array elements at 0xPREDIFFED
-0 (cpu): diags.chpl:12: allocate 48B of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
+0 (cpu): diags.chpl:12: allocate xxB of [domain(1,int(64),false)] locale at 0xPREDIFFED
+0 (cpu): diags.chpl:12: allocate xxB of array elements at 0xPREDIFFED
+0 (cpu): diags.chpl:12: allocate xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (cpu): diags.chpl:12: free at 0xPREDIFFED
-0 (gpu 0): diags.chpl:13: allocate 168B of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
-0 (gpu 0): diags.chpl:13: allocate 80B of array elements at 0xPREDIFFED
+0 (gpu 0): diags.chpl:13: allocate xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
+0 (gpu 0): diags.chpl:13: allocate xxB of array elements at 0xPREDIFFED
 0 (gpu 0): diags.chpl:14: kernel launch
 0 (gpu 0): diags.chpl:18: free at 0xPREDIFFED
 0 (gpu 0): diags.chpl:18: free at 0xPREDIFFED

--- a/test/gpu/native/diags.prediff
+++ b/test/gpu/native/diags.prediff
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 sed -e 's/0x.*/0xPREDIFFED/' \
+    -e 's/allocate [[:digit:]]\+B of/allocate xxB of/' \
     -e '/^.*tasking layer unspecified data.*$/d' $2 > $2.tmp
 mv $2.tmp $2

--- a/test/gpu/native/distArray/blockOutsideOnWorkaround.chpl
+++ b/test/gpu/native/distArray/blockOutsideOnWorkaround.chpl
@@ -17,4 +17,4 @@ forall i in dom do
 stopGPUDiagnostics();
 
 writeln(arr);
-writeln(getGPUDiagnostics());
+assert(here.maxTaskPar == getGPUDiagnostics().kernel_launch);

--- a/test/gpu/native/distArray/blockOutsideOnWorkaround.good
+++ b/test/gpu/native/distArray/blockOutsideOnWorkaround.good
@@ -1,3 +1,2 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 1 1 1 1 1 1 1 1 1 1
-(kernel_launch = 1)


### PR DESCRIPTION
This PR adjusts two tests to be more portable w.r.t. amount of memory allocated
and parallelism. These seem to differ between personal workstations and the
nightly testing system.
