### PR TITLE
Deprecate both ItemReader and ItemWriter

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -425,9 +425,6 @@ module IO {
       NFS), we should open a local copy of that file and use that in the
       channel. (not sure how to avoid opening # channels copies of these files
       -- seems that we'd want some way to cache that...).
-    - Create leader/follower iterators for ItemReader/ItemWriter so that these
-      are as efficient as possible when working with fixed-size data types
-      (ie, they can open up channels that are not shared).
 */
 
 public use SysBasic;
@@ -2867,12 +2864,12 @@ proc file.linesHelper(param locking:bool = true, start:int(64) = 0,
   local_style.string_end = 0x0a; // '\n'
   param kind = iokind.dynamic;
 
-  var ret:ItemReader(string, kind, locking);
+  var ret:itemReaderInternal(string, kind, locking);
   var err:syserr = ENOERR;
   on this.home {
     try this.checkAssumingLocal();
     var ch = new channel(false, kind, locking, this, err, hints, start, end, local_style);
-    ret = new ItemReader(string, kind, locking, ch);
+    ret = new itemReaderInternal(string, kind, locking, ch);
   }
   if err then try ioerror(err, "in file.lines", this.tryGetPath());
 
@@ -3683,7 +3680,8 @@ iter channel.lines() {
   this._set_styleInternal(newline_style);
 
   // Iterate over lines
-  for line in this.itemReader(string, this.kind) {
+  var itemReader = new itemReaderInternal(string, kind, locking, this);
+  for line in itemReader {
     yield line;
   }
 
@@ -4485,8 +4483,11 @@ proc channel.readBytes(x, len:c_ssize_t) throws {
    of a single type. Also supports an iterator yielding
    the read values.
  */
+deprecated "ItemReader is deprecated"
+type ItemReader = itemReaderInternal;
+
 pragma "no doc"
-record ItemReader {
+record itemReaderInternal {
   /* What type do we read and yield? */
   type ItemType;
   /* the kind field for our channel */
@@ -4517,14 +4518,17 @@ record ItemReader {
 /* Create and return an :record:`ItemReader` that can yield read values of
    a single type.
  */
-pragma "no doc"
+deprecated "channel.itemReader is deprecated"
 proc channel.itemReader(type ItemType, param kind:iokind=iokind.dynamic) {
   if writing then compilerError(".itemReader on write-only channel");
-  return new ItemReader(ItemType, kind, locking, this);
+  return new itemReaderInternal(ItemType, kind, locking, this);
 }
 
+deprecated "ItemWriter is deprecated"
+type ItemWriter = itemWriterInternal;
+
 pragma "no doc"
-record ItemWriter {
+record itemWriterInternal {
   /* What type do we write? */
   type ItemType;
   /* the kind field for our channel */
@@ -4542,9 +4546,8 @@ record ItemWriter {
 /* Create and return an :record:`ItemWriter` that can write values of
    a single type.
  */
-pragma "no doc"
 deprecated
-"ItemWriter is deprecated"
+"channel.itemWriter is deprecated"
 proc channel.itemWriter(type ItemType, param kind:iokind=iokind.dynamic) {
   if !writing then compilerError(".itemWriter on read-only channel");
   return new ItemWriter(ItemType, kind, locking, this);

--- a/test/deprecated/IO/itemReader.chpl
+++ b/test/deprecated/IO/itemReader.chpl
@@ -1,0 +1,26 @@
+
+use IO;
+
+proc main() {
+  var f = openmem();
+  var w = f.writer();
+  for i in 1..10 do w.writeln(i);
+  w.close();
+
+  {
+    var ch = f.reader();
+    var ir = ch.itemReader(int);
+    for i in ir do writeln(i);
+  }
+  {
+    var ch = f.reader();
+    var ir = new ItemReader(int, ch.kind, ch.locking, ch);
+    for i in ir do writeln(i);
+  }
+  {
+    // Make sure we don't throw any warnings for this case, which used to use
+    // the deprecated method/type 
+    var ch = f.reader();
+    for i in ch.lines() do writeln(i.strip());
+  }
+}

--- a/test/deprecated/IO/itemReader.good
+++ b/test/deprecated/IO/itemReader.good
@@ -1,0 +1,33 @@
+itemReader.chpl:4: In function 'main':
+itemReader.chpl:17: warning: ItemReader is deprecated
+itemReader.chpl:12: warning: channel.itemReader is deprecated
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10

--- a/test/deprecated/IO/itemWriter.chpl
+++ b/test/deprecated/IO/itemWriter.chpl
@@ -4,3 +4,8 @@ var fwiw = stdout.itemWriter(int);
 fwiw.write(1);
 fwiw.write(2);
 fwiw.write(3);
+
+var iw = new ItemWriter(int, stdout.kind, stdout.locking, stdout);
+iw.write(4);
+iw.write(5);
+iw.write(6);

--- a/test/deprecated/IO/itemWriter.good
+++ b/test/deprecated/IO/itemWriter.good
@@ -1,2 +1,3 @@
-itemWriter.chpl:3: warning: ItemWriter is deprecated
-123
+itemWriter.chpl:8: warning: ItemWriter is deprecated
+itemWriter.chpl:3: warning: channel.itemWriter is deprecated
+123456

--- a/test/io/ferguson/io_test.good
+++ b/test/io/ferguson/io_test.good
@@ -380,3 +380,4 @@ io_test.chpl:17: warning: reader with a style argument is deprecated
   io_test.chpl:152: called as testio(x: ioBits)
 io_test.chpl:54: In function 'test_readlines':
 io_test.chpl:87: warning: reader with a style argument is deprecated
+io_test.chpl:88: warning: channel.itemReader is deprecated


### PR DESCRIPTION
After discussion on #19829 this merge will deprecate the ItemReader/Writer types and their methods without no-doc-ing anything.

Testing:
- [x] full local paratest
- [x] make docs