### PR TITLE
Revert "Update .bad files for two mismatch-errors futures"

### DIFF
--- a/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
@@ -1,2 +1,9 @@
-void llvm::CallInst::init(llvm::FunctionType*, llvm::Value*, llvm::ArrayRef<llvm::Value*>, llvm::ArrayRef<llvm::OperandBundleDefT<llvm::Value*> >, const llvm::Twine&): Assertion `(Args.size() == FTy->getNumParams() || (FTy->isVarArg() && Args.size() > FTy->getNumParams())) && "Calling a function with bad signature!"' failed.
-timedexec: target program died with signal 6, without coredump
+Incorrect number of arguments passed to called function!
+  %4 = call i32 @returnIntFromIntArg() #0
+internal error: COD-CG--BOL-nnnn chpl version mmmm
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.prediff
+++ b/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.prediff
@@ -1,1 +1,0 @@
-mismatch-riv-iv.prediff

--- a/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.bad
@@ -1,2 +1,9 @@
-void llvm::CallInst::init(llvm::FunctionType*, llvm::Value*, llvm::ArrayRef<llvm::Value*>, llvm::ArrayRef<llvm::OperandBundleDefT<llvm::Value*> >, const llvm::Twine&): Assertion `(Args.size() == FTy->getNumParams() || (FTy->isVarArg() && Args.size() > FTy->getNumParams())) && "Calling a function with bad signature!"' failed.
-timedexec: target program died with signal 6, without coredump
+Incorrect number of arguments passed to called function!
+  %2 = call i32 @returnIntFromIntArg() #0
+internal error: COD-CG--BOL-nnnn chpl version mmmm
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.prediff
+++ b/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.prediff
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-sed -e 's/chpl: [^ ]* //' $2 > $2.tmp
-mv $2.tmp $2


### PR DESCRIPTION
This reverts commit 327f3049a8454b701a169cb20074c79972cc6284. The tests
are back to matching the old .bad files.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>