### PR TITLE
Add fn exempt instantiation limit pragma and apply it to isArrayValue

### DIFF
--- a/compiler/dyno/include/chpl/uast/PragmaList.h
+++ b/compiler/dyno/include/chpl/uast/PragmaList.h
@@ -598,6 +598,8 @@ PRAGMA(OPT_INFO_NO_BLOCKING, npr, "forall not blocking", "forall does not have b
 
 PRAGMA(DESERIALIZATION_BLOCK_MARKER, npr, "marks deserialization options", "then block is var else block is ref serialization")
 
+PRAGMA(EXEMPT_INSTANTIATION_LIMIT, ypr, "fn exempt instantiation limit", "compiler will not limit the number of instantiations of this function")
+
 #undef ypr
 #undef npr
 #undef ncm

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -189,7 +189,8 @@ static bool trackInstantiationsForFn(FnSymbol* fn) {
           // result in infinitely recursive instantiations; to
           // reproduce this, comment out that part of the test and try
           // test/functions/resolution/instantiateMax/instMaxOKifNonrecursive.chpl).
-          !fn->hasFlag(FLAG_COMPILER_GENERATED));
+          !fn->hasFlag(FLAG_COMPILER_GENERATED) &&
+          !fn->hasFlag(FLAG_EXEMPT_INSTANTIATION_LIMIT));
 }
 
 //

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -383,8 +383,10 @@ proc isDomainValue(e: domain) param  return true;
 proc isDomainValue(e)         param  return false;
 
 pragma "no doc"
+pragma "fn exempt instantiation limit"
 proc isArrayValue(e: []) param  return true;
 /* Return true if ``e`` is an array. Otherwise return false. */
+pragma "fn exempt instantiation limit"
 proc isArrayValue(e)     param  return false;
 
 pragma "no doc"


### PR DESCRIPTION
This is to address the test failures we see here:

https://chapel.discourse.group/t/cron-perf-cray-cs-hdr-arkouda/12773/13

In this PR https://github.com/chapel-lang/chapel/pull/19856 I moved a function (`isArrayValue`) from an internal module to a standard module.

To prevent inifite recursions we limit the number of times a generic function can be instantiated and present an error message if it exceeds this limit.  We exempt functions in internal (but not standard) modules from this limit.

It appears that `isArrayValue` is legitamatly instantiated an enormous number of times so in order to keep these tests running in this PR I introduce a pragma that lets us flag functions to be exempt from this check and exempt the `isArrayValue` function.

It may be worth spending more time to investigate why this function is being instantiated so many times and there may be better ways of determining which functions should be exempt from this check.  In the meantime I think it's worth merging this PR.

I've manually verified that this PR resolves the build failure in Arkouda.  I haven't run it through paratests but I can't imagine it could cause any failures.
