### PR TITLE
Another attempt at fixing GPU test failures

### DIFF
--- a/test/gpu/native/diags.execopts
+++ b/test/gpu/native/diags.execopts
@@ -1,0 +1,1 @@
+--memTrack

--- a/test/gpu/native/diags.good
+++ b/test/gpu/native/diags.good
@@ -4,18 +4,18 @@ Start
 0 (cpu): diags.chpl:10: allocate xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
 0 (cpu): diags.chpl:10: allocate xxB of array elements at 0xPREDIFFED
 0 (cpu): diags.chpl:10: allocate xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
-0 (cpu): diags.chpl:10: free at 0xPREDIFFED
+0 (cpu): diags.chpl:10: free 48B of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (cpu): diags.chpl:12: allocate xxB of [domain(1,int(64),false)] locale at 0xPREDIFFED
 0 (cpu): diags.chpl:12: allocate xxB of array elements at 0xPREDIFFED
 0 (cpu): diags.chpl:12: allocate xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free at 0xPREDIFFED
+0 (cpu): diags.chpl:12: free 48B of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:13: allocate xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:13: allocate xxB of array elements at 0xPREDIFFED
 0 (gpu 0): diags.chpl:14: kernel launch
-0 (gpu 0): diags.chpl:18: free at 0xPREDIFFED
-0 (gpu 0): diags.chpl:18: free at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free at 0xPREDIFFED
+0 (gpu 0): diags.chpl:18: free 80B of array elements at 0xPREDIFFED
+0 (gpu 0): diags.chpl:18: free 168B of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
+0 (cpu): diags.chpl:12: free 16B of array elements at 0xPREDIFFED
+0 (cpu): diags.chpl:12: free 168B of [domain(1,int(64),false)] locale at 0xPREDIFFED
 2 2 2 2 2 2 2 2 2 2
 End
 GPU diagnostics:

--- a/test/gpu/native/diags.good
+++ b/test/gpu/native/diags.good
@@ -4,18 +4,18 @@ Start
 0 (cpu): diags.chpl:10: allocate xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
 0 (cpu): diags.chpl:10: allocate xxB of array elements at 0xPREDIFFED
 0 (cpu): diags.chpl:10: allocate xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
-0 (cpu): diags.chpl:10: free 48B of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
+0 (cpu): diags.chpl:10: free xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (cpu): diags.chpl:12: allocate xxB of [domain(1,int(64),false)] locale at 0xPREDIFFED
 0 (cpu): diags.chpl:12: allocate xxB of array elements at 0xPREDIFFED
 0 (cpu): diags.chpl:12: allocate xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free 48B of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
+0 (cpu): diags.chpl:12: free xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:13: allocate xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:13: allocate xxB of array elements at 0xPREDIFFED
 0 (gpu 0): diags.chpl:14: kernel launch
-0 (gpu 0): diags.chpl:18: free 80B of array elements at 0xPREDIFFED
-0 (gpu 0): diags.chpl:18: free 168B of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free 16B of array elements at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free 168B of [domain(1,int(64),false)] locale at 0xPREDIFFED
+0 (gpu 0): diags.chpl:18: free xxB of array elements at 0xPREDIFFED
+0 (gpu 0): diags.chpl:18: free xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
+0 (cpu): diags.chpl:12: free xxB of array elements at 0xPREDIFFED
+0 (cpu): diags.chpl:12: free xxB of [domain(1,int(64),false)] locale at 0xPREDIFFED
 2 2 2 2 2 2 2 2 2 2
 End
 GPU diagnostics:

--- a/test/gpu/native/diags.prediff
+++ b/test/gpu/native/diags.prediff
@@ -2,5 +2,6 @@
 
 sed -e 's/0x.*/0xPREDIFFED/' \
     -e 's/allocate [[:digit:]]\+B of/allocate xxB of/' \
+    -e 's/free [[:digit:]]\+B of/free xxB of/' \
     -e '/^.*tasking layer unspecified data.*$/d' $2 > $2.tmp
 mv $2.tmp $2

--- a/test/gpu/native/distArray/blockOutsideOnWorkaround.chpl
+++ b/test/gpu/native/distArray/blockOutsideOnWorkaround.chpl
@@ -1,7 +1,7 @@
 use BlockDist;
 use GPUDiagnostics;
 
-config const n = 10;
+config const n = here.maxTaskPar*2;
 
 startGPUDiagnostics();
 
@@ -16,5 +16,7 @@ forall i in dom do
 
 stopGPUDiagnostics();
 
-writeln(arr);
+var sum = 0;
+for a in arr do sum += a;
+assert(sum == n);
 assert(here.maxTaskPar == getGPUDiagnostics().kernel_launch);

--- a/test/gpu/native/distArray/blockOutsideOnWorkaround.good
+++ b/test/gpu/native/distArray/blockOutsideOnWorkaround.good
@@ -1,2 +1,1 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-1 1 1 1 1 1 1 1 1 1


### PR DESCRIPTION
The `diags` test was failing due to the confusing nature of verbose memory
output. This PR adds `--memTrack` to the execopts of that tests to work around
that. We want to fix this confusing behavior soon. See
https://github.com/Cray/chapel-private/issues/3388.

The `test/gpu/native/distArray/blockOutsideOnWorkaround.chpl` test had too small
data, causing paralellism to be less than the number of cores on the nightly
testing machine. This is a trivial issue with a trivial fix.

Both tests pass on my workstation and the testing system.
