### PR TITLE
Resolve c for loop primitive

### DIFF
--- a/compiler/dyno/lib/resolution/prims.cpp
+++ b/compiler/dyno/lib/resolution/prims.cpp
@@ -159,6 +159,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_GET_SERIAL:
     case PRIM_PTR_EQUAL:
     case PRIM_PTR_NOTEQUAL:
+    case PRIM_BLOCK_C_FOR_LOOP:
       type = QualifiedType(QualifiedType::CONST_VAR,
                            BoolType::get(context, 0));
       break;
@@ -316,7 +317,6 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_BLOCK_WHILEDO_LOOP:
     case PRIM_BLOCK_DOWHILE_LOOP:
     case PRIM_BLOCK_FOR_LOOP:
-    case PRIM_BLOCK_C_FOR_LOOP:
     case PRIM_BLOCK_BEGIN:
     case PRIM_BLOCK_COBEGIN:
     case PRIM_BLOCK_COFORALL:


### PR DESCRIPTION
Thanks to #19819 this is a fairly trivial change, which simply tells the compiler to resolve a 'C for loop' primitive as a ``bool``. Some later lowering pass will handle any necessary transformations. Also adds a new mini-test for this case.

Testing:
- [x] make test-dyno