### PR TITLE
Fix installation of mason

### DIFF
--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -325,14 +325,17 @@ myinstallfile third-party/llvm/filter-llvm-config.awk "$DEST_THIRD_PARTY"/llvm
 # copy utf8-decoder header
 myinstallfile third-party/utf8-decoder/utf8-decoder.h "$DEST_THIRD_PARTY"/utf8-decoder/
 
+
+MASON="bin/$CHPL_BIN_SUBDIR"/mason
+
 # copy mason
-if [ -f tools/mason/mason ]
+if [ -f "$MASON" ]
 then
   if [ ! -z "$PREFIX" ]
   then
-    myinstallfile tools/mason/mason "$PREFIX/bin"
+    myinstallfile "$MASON" "$PREFIX/bin"
   else
-    myinstallfile tools/mason/mason "$DEST_CHPL_HOME/tools/mason"
+    myinstallfile "$MASON" "$DEST_CHPL_HOME/tools/mason"
     ln -s "$DEST_CHPL_HOME/tools/mason/mason" "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"/mason
   fi
 fi

--- a/util/buildRelease/test_install.bash
+++ b/util/buildRelease/test_install.bash
@@ -24,10 +24,17 @@ EXITSTATUS=0
 if [ $EXITSTATUS -eq 0 ]
 then
   # First, check installation to bin lib etc
-  ./configure --prefix="$myprefix" && make && make install
+  ./configure --prefix="$myprefix" && make && make mason && make install
 
   # Remove bin and lib to eliminate possible confusion
   rm -Rf bin lib
+
+  # Check that bin/mason was created
+  if [ ! -f "$myprefix/bin/mason" ]
+  then
+      echo "--prefix install: $myprefix/bin/mason was not installed!" 1<&2
+      EXITSTATUS=1
+  fi
 
   # Check that bin/chpl was created
   if [ ! -f "$myprefix/bin/chpl" ]


### PR DESCRIPTION
Historically, mason was built into `tools/mason`, so that's where
our 'make install' command would try to install it from.  However,
in #16154, it was changed to build directly into `bin/[whatever]/`
causing `make install` to stop finding and copying it (except for
those of us who still had an ancient version of `tools/mason/mason`
lying around).

Here, I'm updating the make install script (`install.sh`) to copy
it from the correct location, and also adding a 'make mason' step
to our test of the installation logic, followed by a check to see
that it got put where expected to try and prevent this from happening
again in the future.

Resolves #19910.