### PR TITLE
Prediff some comm layer related memory allocations in a test

### DIFF
--- a/test/gpu/native/diags.prediff
+++ b/test/gpu/native/diags.prediff
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 sed -e 's/0x.*/0xPREDIFFED/' \
+    -e '/allocate [[:digit:]]\+B of comm layer/d' \
     -e 's/allocate [[:digit:]]\+B of/allocate xxB of/' \
     -e 's/free [[:digit:]]\+B of/free xxB of/' \
     -e '/^.*tasking layer unspecified data.*$/d' $2 > $2.tmp


### PR DESCRIPTION
With the new gasnet+gpu testing config, we get some more verbose
mem output from the comm layer for this test. This PR prediffs
those lines out.