### PR TITLE
Skip ISX tests for GASNet + MPI

### DIFF
--- a/test/release/examples/benchmarks/isx/SKIPIF
+++ b/test/release/examples/benchmarks/isx/SKIPIF
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import os
+
+retval = (os.environ['CHPL_COMM']=="gasnet") & (os.environ['CHPL_COMM_SUBSTRATE']=="mpi")
+
+print(retval)
+
+

--- a/test/release/examples/benchmarks/isx/SKIPIF
+++ b/test/release/examples/benchmarks/isx/SKIPIF
@@ -2,8 +2,12 @@
 
 import os
 
-retval = (os.environ['CHPL_COMM']=="gasnet") & (os.environ['CHPL_COMM_SUBSTRATE']=="mpi")
+# Skip this test for gasnet+mpi performance testing. As of 06/01/22 it
+# takes ~5-6 minutes to complete which is not terrible, but is more
+# time than we want to spend on it and bumping up against our timeout.
 
-print(retval)
+print(os.getenv('CHPL_TEST_PERF') == 'on' and
+      os.getenv('CHPL_COMM') == 'gasnet' and
+      os.getenv('CHPL_COMM_SUBSTRATE') == 'mpi')
 
 

--- a/test/studies/isx/SKIPIF
+++ b/test/studies/isx/SKIPIF
@@ -2,8 +2,10 @@
 
 import os
 
-retval = (os.environ['CHPL_COMM']=="gasnet") & (os.environ['CHPL_COMM_SUBSTRATE']=="mpi")
+# Skip this test for gasnet+mpi performance testing. As of 06/01/22 it
+# takes ~5-6 minutes to complete which is not terrible, but is more
+# time than we want to spend on it and bumping up against our timeout.
 
-print(retval)
-
-
+print(os.getenv('CHPL_TEST_PERF') == 'on' and
+      os.getenv('CHPL_COMM') == 'gasnet' and
+      os.getenv('CHPL_COMM_SUBSTRATE') == 'mpi')

--- a/test/studies/isx/SKIPIF
+++ b/test/studies/isx/SKIPIF
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import os
+
+retval = (os.environ['CHPL_COMM']=="gasnet") & (os.environ['CHPL_COMM_SUBSTRATE']=="mpi")
+
+print(retval)
+
+


### PR DESCRIPTION
We're finding that the execution times for ISx are higher than we care to
spend on them in the GASNet/mpi configuration, resulting in us running
right up against the timeout in certain performance configurations.  This
PR adds SKIPIF files to the ISx directories when doing performance runs
using GASNet/mpi.
