### PR TITLE
Add bug from Gitter related to large if-then-else statements

### DIFF
--- a/test/parsing/bigifthenelse.chpl
+++ b/test/parsing/bigifthenelse.chpl
@@ -1,0 +1,127 @@
+config var name = "";
+
+if (name == "a") {
+  writeln(name);
+} else if (name == "b") {
+  writeln(name);
+} else if (name == "c") {
+  writeln(name);
+} else if (name == "d") {
+  writeln(name);
+} else if (name == "e") {
+  writeln(name);
+} else if (name == "f") {
+  writeln(name);
+} else if (name == "g") {
+  writeln(name);
+} else if (name == "h") {
+  writeln(name);
+} else if (name == "i") {
+  writeln(name);
+} else if (name == "j") {
+  writeln(name);
+} else if (name == "k") {
+  writeln(name);
+} else if (name == "l") {
+  writeln(name);
+} else if (name == "m") {
+  writeln(name);
+} else if (name == "n") {
+  writeln(name);
+} else if (name == "o") {
+  writeln(name);
+} else if (name == "p") {
+  writeln(name);
+} else if (name == "q") {
+  writeln(name);
+} else if (name == "r") {
+  writeln(name);
+} else if (name == "s") {
+  writeln(name);
+} else if (name == "t") {
+  writeln(name);
+} else if (name == "u") {
+  writeln(name);
+} else if (name == "v") {
+  writeln(name);
+} else if (name == "w") {
+  writeln(name);
+} else if (name == "x") {
+  writeln(name);
+} else if (name == "y") {
+  writeln(name);
+} else if (name == "z") {
+  writeln(name);
+} else if (name == "A") {
+  writeln(name);
+} else if (name == "B") {
+  writeln(name);
+} else if (name == "C") {
+  writeln(name);
+} else if (name == "D") {
+  writeln(name);
+} else if (name == "E") {
+  writeln(name);
+} else if (name == "F") {
+  writeln(name);
+} else if (name == "G") {
+  writeln(name);
+} else if (name == "H") {
+  writeln(name);
+} else if (name == "I") {
+  writeln(name);
+} else if (name == "J") {
+  writeln(name);
+} else if (name == "K") {
+  writeln(name);
+} else if (name == "L") {
+  writeln(name);
+} else if (name == "M") {
+  writeln(name);
+} else if (name == "N") {
+  writeln(name);
+} else if (name == "O") {
+  writeln(name);
+} else if (name == "P") {
+  writeln(name);
+} else if (name == "Q") {
+  writeln(name);
+} else if (name == "R") {
+  writeln(name);
+} else if (name == "S") {
+  writeln(name);
+} else if (name == "T") {
+  writeln(name);
+} else if (name == "U") {
+  writeln(name);
+} else if (name == "V") {
+  writeln(name);
+} else if (name == "W") {
+  writeln(name);
+} else if (name == "X") {
+  writeln(name);
+} else if (name == "Y") {
+  writeln(name);
+} else if (name == "Z") {
+  writeln(name);
+} else if (name == "1") {
+  writeln(name);
+} else if (name == "2") {
+  writeln(name);
+} else if (name == "3") {
+  writeln(name);
+} else if (name == "4") {
+  writeln(name);
+} else if (name == "5") {
+  writeln(name);
+} else if (name == "6") {
+  writeln(name);
+} else if (name == "7") {
+  writeln(name);
+} else if (name == "8") {
+  writeln(name);
+} else if (name == "9") {
+  writeln(name);
+} else if (name == "0") {
+  writeln(name);
+}

--- a/test/parsing/bigifthenelse.future
+++ b/test/parsing/bigifthenelse.future
@@ -1,0 +1,10 @@
+bug: parser can't handle large if-then-else statements
+
+As pointed out by a user on Gitter, when Chapel code contains large
+if-then-else statements, the parser goes off the rails.  This is true
+of both the old and new parser, though the way in which they go off
+the rails differs (and, I'd expect, may depend on what system you're
+running on, how much memory you have, etc.)
+
+As a workaround, a similarly large select statement can be used (when
+the pattern is as regular as this, anyway).


### PR DESCRIPTION
As noted in the .future, large if-then-else statements like this seem
to cause our parser (dyno or traditional) to go off the rails in
surprising ways.  Using a select statement instead seems to work fine.
