### PR TITLE
dyno: Fix bug that caused syntax errors to disappear

### DIFF
--- a/compiler/dyno/include/chpl/queries/ErrorMessage.h
+++ b/compiler/dyno/include/chpl/queries/ErrorMessage.h
@@ -45,6 +45,7 @@ class ErrorMessage final {
   };
 
  private:
+  bool isDefaultConstructed_;
   Kind kind_;
   Location location_;
   std::string message_;
@@ -76,7 +77,22 @@ class ErrorMessage final {
 
   void addDetail(ErrorMessage err);
 
+  /**
+    Returns true is this error message has no message and no details. Even
+    if the error is empty, it may still be meaningful in the case of e.g.,
+    a syntax error (where the location offers useful info).
+  */
   bool isEmpty() const { return message_.empty() && details_.empty(); }
+
+  /**
+    Returns true if this error message was default constructed, in
+    which case its contents are not meaningful.
+  */
+  bool isDefaultConstructed() const { return isDefaultConstructed_; }
+
+  /**
+    Return the location in the source code where this error occurred.
+  */
   Location location() const { return location_; }
 
   UniqueString path() const { return location_.path(); }

--- a/compiler/dyno/include/chpl/queries/ErrorMessage.h
+++ b/compiler/dyno/include/chpl/queries/ErrorMessage.h
@@ -109,7 +109,8 @@ class ErrorMessage final {
   Kind kind() const { return kind_; }
 
   inline bool operator==(const ErrorMessage& other) const {
-    return kind_ == other.kind_ &&
+    return isDefaultConstructed_ == other.isDefaultConstructed_ &&
+           kind_ == other.kind_ &&
            location_ == other.location_ &&
            message_ == other.message_ &&
            details_ == other.details_ &&

--- a/compiler/dyno/lib/parsing/parser-yyerror.h
+++ b/compiler/dyno/lib/parsing/parser-yyerror.h
@@ -26,14 +26,23 @@ void yychpl_error(YYLTYPE*       loc,
                   ParserContext* context,
                   const char*    errorMessage) {
   std::string msg;
-  const char* tokenText = yychpl_get_text(context->scanner);
-  if (strlen(tokenText) > 0) {
-    msg += "near '";
-    msg += tokenText;
-    msg += "'";
+  bool isEmptyOrDefaultError = !strcmp("syntax error", errorMessage) ||
+                               !strlen(errorMessage);
+
+  // If Bison reported a generic "syntax error", leave message empty.
+  if (isEmptyOrDefaultError) {
+    const char* tokenText = yychpl_get_text(context->scanner);
+
+    // But append info about nearest token.
+    if (strlen(tokenText) > 0) {
+      msg += "near '";
+      msg += tokenText;
+      msg += "'";
+    }
+
+  // TODO: Also print nearest token?
   } else {
-    // Not very helpful, but default parser errors aren't...
-    assert(msg.size() == 0);
+    msg = errorMessage;
   }
 
   auto err = ParserError(*loc, msg, ErrorMessage::SYNTAX);

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -99,7 +99,7 @@ const uast::BuilderResult& parseFile(Context* context, UniqueString path) {
     result.swap(tmpResult);
     // raise any errors encountered
     for (const ErrorMessage& e : result.errors()) {
-      if (!e.isEmpty()) {
+      if (!e.isDefaultConstructed()) {
         // report the error and save it for this query
         context->report(e);
       }

--- a/compiler/dyno/lib/queries/ErrorMessage.cpp
+++ b/compiler/dyno/lib/queries/ErrorMessage.cpp
@@ -48,16 +48,22 @@ static std::string vprint_to_string(const char* format, va_list vl) {
 }
 
 ErrorMessage::ErrorMessage()
-  : kind_(ERROR), location_(), message_() {
+  : isDefaultConstructed_(true), kind_(ERROR), location_(), message_() {
 }
+
 ErrorMessage::ErrorMessage(ID id, Location location, std::string message,
                            Kind kind)
-  : kind_(kind), location_(location), message_(message), id_(id) {
+  : isDefaultConstructed_(false), kind_(kind), location_(location),
+    message_(message),
+    id_(id) {
   gdbShouldBreakHere();
 }
+
 ErrorMessage::ErrorMessage(ID id, Location location, const char* message,
                            Kind kind)
-  : kind_(kind), location_(location), message_(message), id_(id) {
+  : isDefaultConstructed_(false), kind_(kind), location_(location),
+    message_(message),
+    id_(id) {
   gdbShouldBreakHere();
 }
 

--- a/compiler/dyno/lib/queries/ErrorMessage.cpp
+++ b/compiler/dyno/lib/queries/ErrorMessage.cpp
@@ -90,6 +90,7 @@ void ErrorMessage::addDetail(ErrorMessage err) {
 }
 
 void ErrorMessage::swap(ErrorMessage& other) {
+  std::swap(isDefaultConstructed_, other.isDefaultConstructed_);
   std::swap(id_, other.id_);
   std::swap(kind_, other.kind_);
   location_.swap(other.location_);

--- a/test/domains/sungeun/rect/at_operator.bad
+++ b/test/domains/sungeun/rect/at_operator.bad
@@ -1,4 +1,4 @@
-at_operator.chpl:6: syntax error: near '@'
+at_operator.chpl:6: syntax error: Invalid token
 at_operator.chpl:6: syntax error: near 'n'
-at_operator.chpl:8: syntax error: near '@'
+at_operator.chpl:8: syntax error: Invalid token
 at_operator.chpl:8: syntax error: near 'n'

--- a/test/parsing/BlockMissingClosingBrace.chpl
+++ b/test/parsing/BlockMissingClosingBrace.chpl
@@ -1,0 +1,3 @@
+writeln("Who are you, really?");
+{
+  writeln("I am just a figment of your imagination.");

--- a/test/parsing/BlockMissingClosingBrace.good
+++ b/test/parsing/BlockMissingClosingBrace.good
@@ -1,0 +1,1 @@
+BlockMissingClosingBrace.chpl:3: syntax error

--- a/test/users/rohanbadlani/bugs/bug1.bad
+++ b/test/users/rohanbadlani/bugs/bug1.bad
@@ -1,0 +1,1 @@
+bug1.chpl:8: syntax error


### PR DESCRIPTION
dyno: Fix bug that caused syntax errors to disappear (#19923)

Fix a bug which caused syntax errors not to propagate out of the
builder and into the compiler context. This caused programs
with syntax errors such as missing a closing brace to silently
compile.

Resolves #19922.

TESTING

- [x] `ALL` on `linux64`, `standard`

Reviewed by @mppf. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>