### PR TITLE
Add prototype support for using ASan with qthreads

### DIFF
--- a/make/compiler/Makefile.sanitizers
+++ b/make/compiler/Makefile.sanitizers
@@ -25,8 +25,10 @@
 
 ifneq ($(CHPL_MAKE_SANITIZE), none)
   # Configuration checks
-  ifneq ($(CHPL_MAKE_TASKS), fifo)
-    $(error CHPL_TASKS=fifo is required for sanitizers)
+  ifeq ($(CHPL_MAKE_TASKS), qthreads)
+    ifeq (,$(CHPL_QTHREAD_SANITIZER_SUPPORT))
+      $(error CHPL_TASKS=fifo is required for sanitizers)
+    endif
   endif
   ifneq ($(CHPL_MAKE_TARGET_MEM), cstdlib)
     $(error CHPL_MEM=cstdlib is required for sanitizers)

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -139,6 +139,13 @@ ifneq (, $(findstring pgi,$(CHPL_MAKE_TARGET_COMPILER)))
 CHPL_QTHREAD_CFG_OPTIONS += --disable-internal-spinlock
 endif
 
+# Address sanitizer doesn't work with asm context switching so try
+# makecontext/swapcontext (which may have false-positives, but doesn't
+# immediately fail)
+ifneq (,$(CHPL_QTHREAD_SANITIZER_SUPPORT))
+  CHPL_QTHREAD_CFG_OPTIONS += --disable-fastcontext
+endif
+
 ifeq ($(CHPL_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif


### PR DESCRIPTION
Qthreads inline assembly for task switching throws off ASan, so
previously we only supported using fifo. This adds experimental support
for using qthreads with `CHPL_QTHREAD_SANITIZER_SUPPORT`, which really
just disables asm context switching in favor of makecontext/swapcontext.
Asan can still get tripped up by these and some implementations will
warn with:

```
==18623==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
```

but this seems to work at least for hellos so I wanted to add prototype
support. This is to help debug a memory corruption issue we're seeing in
Cray/chapel-private#3417