### PR TITLE
Require `--memTrack` to enable memory hooks

### DIFF
--- a/runtime/include/chpl-mem-hook.h
+++ b/runtime/include/chpl-mem-hook.h
@@ -37,24 +37,11 @@
 extern "C" {
 #endif
 
-// CHPL_MEMHOOKS_ACTIVE=1 will enable the memory hooks;
-// CHPL_MEMHOOKS_ACTIVE will be set to 1 if CHPL_DEBUG is defined;
-// or if CHPL_OPTIMIZE is not defined.
-// If CHPL_OPTIMIZE is defined and CHPL_DEBUG is not defined,
-// we set CHPL_MEMHOOKS_ACTIVE to chpl_memTrack, so that memory tracking
-// can still be activated at run-time.
+// Generally, memory hooks are enabled with chpl_memTrack (e.g. --memTrack).
+// However, -DCHPL_MEMHOOKS_ACTIVE=1 will enable them at compile-time, and
+// -DCHPL_MEMHOOKS_ACTIVE=0 will disable them at compile-time.
 #ifndef CHPL_MEMHOOKS_ACTIVE
-
-#ifdef CHPL_DEBUG
-#define CHPL_MEMHOOKS_ACTIVE 1
-#else
-#ifdef CHPL_OPTIMIZE
 #define CHPL_MEMHOOKS_ACTIVE chpl_memTrack
-#else
-#define CHPL_MEMHOOKS_ACTIVE 1
-#endif
-#endif
-
 #endif
 
 // Returns the starting number for memory descriptors for use by Chapel code.

--- a/test/memory/gbt/test-memLog.execopts
+++ b/test/memory/gbt/test-memLog.execopts
@@ -1,1 +1,1 @@
---memLog=test-memLog.memLog
+--memLog=test-memLog.memLog --memTrack

--- a/test/regex/allocationCounts.execopts
+++ b/test/regex/allocationCounts.execopts
@@ -1,0 +1,1 @@
+--memTrack

--- a/test/regex/allocationCounts.prediff
+++ b/test/regex/allocationCounts.prediff
@@ -3,6 +3,7 @@ testname=$1
 outfile=$2
 sed -E \
     -e '/of tasking layer unspecified/d' \
+    -e '/ of comm layer/d' \
     -e 's/free [[:digit:]]+.+at/free at/' \
     -e 's/[^ ]+.chpl:[[:digit:]]+/<file>.chpl:line/' \
     -e 's/at 0x[a-fA-F0-9]+/at <address>/' \

--- a/test/regex/allocationCounts.skipif
+++ b/test/regex/allocationCounts.skipif
@@ -1,2 +1,1 @@
 COMPOPTS <= --baseline
-COMPOPTS <= --fast


### PR DESCRIPTION
Previously, runtime memory hooks (sanity checks and memory tracking)
were enabled if `CHPL_DEBUG` was set or if `CHPL_OPTIMIZE` wasn't set.
This led to pretty confusing behavior, because our third-party, runtime,
and generated code could all get different values of these settings,
which resulted in inconsistent tracking for the final executable.

Simplify things here to only enable memory hooks if memory tracking is
enabled regardless of optimization or debug levels. This should make the
behavior for an executable consistent across all components and should
speed up allocations coming from qthreads, which got tracked since we
don't set `CHPL_OPTIMIZE` when calling our memory layer from qthreads.

This code originated from 9c50debb80, where the flags were more about
memory debugging instead of just tracking so it made more sense to
enable extra checks if debug was enabled. It was then changed in
c1484c3974. I believe the behavior is more confusing than helpful now
and it's been a very long time since our memory hook checks caught any
correctness issues so I don't think there's value in enabling them just
because debug is on.

Resolves Cray/chapel-private#3388