### PR TITLE
Deprecate undesirable DateTime methods

### DIFF
--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -98,6 +98,14 @@ module DateTime {
       return c_string; // const char *
   }
 
+  /* Get the `time` since Unix Epoch in seconds
+  */
+  proc timeSinceEpoch(): timedelta {
+    var (seconds,microseconds):(real,real) = getTimeOfDay();
+    microseconds = microseconds/1000000.0;
+    return new timedelta(seconds + microseconds);
+  }
+
   pragma "no doc"
   extern "struct tm" record tm {
     var tm_sec:    c_int;         // seconds [0,61]
@@ -639,7 +647,7 @@ module DateTime {
     if tzinfo.borrow() == nil {
       return new timedelta();
     } else {
-      return tzinfo!.utcoffset(datetime.today());
+      return tzinfo!.utcoffset(datetime.now());
     }
   }
 
@@ -648,7 +656,7 @@ module DateTime {
     if tzinfo.borrow() == nil {
       return new timedelta();
     } else {
-      return tzinfo!.dst(datetime.today());
+      return tzinfo!.dst(datetime.now());
     }
   }
 
@@ -921,7 +929,13 @@ module DateTime {
     chpl_time = new time(hour, minute, second, microsecond, tzinfo);
   }
 
+  /* Initialize a new `datetime` value from the given `date` and `time` */
+  proc datetime.init(d: date, t: time) {
+    chpl_date = d;
+    chpl_time = t;
+  }
   /* Return a `datetime` value representing the current time and date */
+  deprecated "'datetime.today()' is deprecated, please use 'date.today()' or 'datetime.now()' instead"
   proc type datetime.today() {
     return this.now();
   }
@@ -1003,6 +1017,7 @@ module DateTime {
 
   /* Get the `time` since Unix Epoch in seconds
   */
+  deprecated "'datetime.timeSinceEpoch()' is deprecated. Please use 'timeSinceEpoch().totalSeconds()' instead."
   proc type datetime.timeSinceEpoch():real {
     var (seconds,microseconds):(real,real) = getTimeOfDay();
     microseconds = microseconds/1000000.0;
@@ -1380,6 +1395,7 @@ module DateTime {
   }
 
   pragma "no doc"
+  deprecated "'operator datetime.-(dt: datetime, d: date)' is deprecated. Please use 'dt - new datetime(d, new time())' instead."
   operator datetime.-(dt: datetime, d: date):timedelta {
     // convert date to datetime and use the default zero time
     var castDate = datetime.combine(d,new time());
@@ -1590,8 +1606,14 @@ module DateTime {
   /* Methods on timedelta values */
 
   /* Return the total number of seconds represented by this object */
-  proc timedelta.total_seconds(): real {
+  proc timedelta.totalSeconds(): real {
     return days*(24*60*60) + seconds + microseconds / 1000000.0;
+  }
+
+  /* Return the total number of seconds represented by this object */
+  deprecated "'timedelta.total_seconds()' is deprecated. Please use 'timedelta.totalSeconds()' instead."
+  proc timedelta.total_seconds(): real {
+    return totalSeconds();
   }
 
 

--- a/test/deprecated/datetimeMinusDate.chpl
+++ b/test/deprecated/datetimeMinusDate.chpl
@@ -1,0 +1,6 @@
+use DateTime;
+
+const dt = datetime.now(),
+      d  = date.today();
+
+const td = dt - d;

--- a/test/deprecated/datetimeMinusDate.chpl
+++ b/test/deprecated/datetimeMinusDate.chpl
@@ -1,6 +1,8 @@
 use DateTime;
 
-const dt = datetime.now(),
-      d  = date.today();
+const dt = new datetime(year=2000, month=1, day=1, second=1, microsecond=1),
+      d  = new date(year=1999, month=12, day=31);
 
 const td = dt - d;
+
+writeln(td);

--- a/test/deprecated/datetimeMinusDate.good
+++ b/test/deprecated/datetimeMinusDate.good
@@ -1,0 +1,1 @@
+datetimeMinusDate.chpl:6: warning: 'operator datetime.-(dt: datetime, d: date)' is deprecated. Please use 'dt - new datetime(d, new time())' instead.

--- a/test/deprecated/datetimeMinusDate.good
+++ b/test/deprecated/datetimeMinusDate.good
@@ -1,1 +1,2 @@
 datetimeMinusDate.chpl:6: warning: 'operator datetime.-(dt: datetime, d: date)' is deprecated. Please use 'dt - new datetime(d, new time())' instead.
+(chpl_days = 1, chpl_seconds = 1, chpl_microseconds = 1)

--- a/test/deprecated/datetimeTimeSinceEpoch.chpl
+++ b/test/deprecated/datetimeTimeSinceEpoch.chpl
@@ -1,0 +1,3 @@
+use DateTime;
+
+const tse = datetime.timeSinceEpoch();

--- a/test/deprecated/datetimeTimeSinceEpoch.good
+++ b/test/deprecated/datetimeTimeSinceEpoch.good
@@ -1,0 +1,1 @@
+datetimeTimeSinceEpoch.chpl:3: warning: 'datetime.timeSinceEpoch()' is deprecated. Please use 'timeSinceEpoch().totalSeconds()' instead.

--- a/test/deprecated/datetimeToday.chpl
+++ b/test/deprecated/datetimeToday.chpl
@@ -1,0 +1,3 @@
+use DateTime;
+
+var dt = datetime.today();

--- a/test/deprecated/datetimeToday.good
+++ b/test/deprecated/datetimeToday.good
@@ -1,0 +1,1 @@
+datetimeToday.chpl:3: warning: 'datetime.today()' is deprecated, please use 'date.today()' or 'datetime.now()' instead

--- a/test/deprecated/timedelta_total_seconds.chpl
+++ b/test/deprecated/timedelta_total_seconds.chpl
@@ -1,4 +1,6 @@
 use DateTime;
 
-const td = datetime.now() - unixEpoch;
+const td = new datetime(2022, 1, 1) - unixEpoch;
 const secs = td.total_seconds();
+
+writeln(secs);

--- a/test/deprecated/timedelta_total_seconds.chpl
+++ b/test/deprecated/timedelta_total_seconds.chpl
@@ -1,0 +1,4 @@
+use DateTime;
+
+const td = datetime.now() - unixEpoch;
+const secs = td.total_seconds();

--- a/test/deprecated/timedelta_total_seconds.good
+++ b/test/deprecated/timedelta_total_seconds.good
@@ -1,0 +1,1 @@
+timedelta_total_seconds.chpl:4: warning: 'timedelta.total_seconds()' is deprecated. Please use 'timedelta.totalSeconds()' instead.

--- a/test/deprecated/timedelta_total_seconds.good
+++ b/test/deprecated/timedelta_total_seconds.good
@@ -1,1 +1,2 @@
 timedelta_total_seconds.chpl:4: warning: 'timedelta.total_seconds()' is deprecated. Please use 'timedelta.totalSeconds()' instead.
+1.641e+09

--- a/test/library/standard/DateTime/datetimeInitWithDateAndTime.chpl
+++ b/test/library/standard/DateTime/datetimeInitWithDateAndTime.chpl
@@ -1,0 +1,8 @@
+use DateTime;
+
+const dt = datetime.now();
+const d = date.today();
+
+// used to support datetime - date where date was promoted
+// to datetime with time == 0. This is the equivalent of that.
+const td = dt - new datetime(d, new time());


### PR DESCRIPTION
We've decided to remove 'type datetime.today()', the "datetime - date" operator,
and 'type datetime.timeSinceEpoch():real'.

Equivalent replacements are: 'type datetime.now()', "datetime - new datetime(date, new time())", and
'timeSinceEpoch().totalSeconds(): timedelta' (a standalone function).

While there also deprecate/replace 'timedelta.total_seconds()'
with a camelCase version.

Added a new datetime initializer that takes a 'date' and 'time' argument. Added
a test of this initializer.

Added test/deprecated tests for everything that was deprecated.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>