### PR TITLE
Stop automatically including the Bessel functions j0, j1, jn, y0, y1, and yn

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -1286,51 +1286,110 @@ module AutoMath {
     return ( (diff<=abs(rtol*y)) || (diff<=abs(rtol*x)) || (diff<=atol) );
   }
 
-  /* Returns the Bessel function of the first kind of order `0` of `x`. */
-  inline proc j0(x: real(32)): real(32) {
+  pragma "no doc"
+  inline proc chpl_j0(x: real(32)): real(32) {
     pragma "fn synchronization free"
     extern proc chpl_float_j0(x: real(32)): real(32);
     return chpl_float_j0(x);
   }
 
-  /* Returns the Bessel function of the first kind of order `0` of `x`. */
-  inline proc j0(x: real(64)): real(64) {
+  pragma "no doc"
+  inline proc chpl_j0(x: real(64)): real(64) {
     pragma "fn synchronization free"
     extern proc j0(x: real(64)): real(64);
     return j0(x);
   }
 
-  /* Returns the Bessel function of the first kind of order `1` of `x`. */
-  inline proc j1(x: real(32)): real(32) {
+  // When removing this deprecated function, be sure to remove chpl_j0 and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc j0(x: real(32)): real(32) {
+    return chpl_j0(x);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_j0 and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc j0(x: real(64)): real(64) {
+    return chpl_j0(x);
+  }
+
+  pragma "no doc"
+  inline proc chpl_j1(x: real(32)): real(32) {
     pragma "fn synchronization free"
     extern proc chpl_float_j1(x: real(32)): real(32);
     return chpl_float_j1(x);
   }
 
-  /* Returns the Bessel function of the first kind of order `1` of `x`. */
-  inline proc j1(x: real(64)): real(64) {
+  pragma "no doc"
+  inline proc chpl_j1(x: real(64)): real(64) {
     pragma "fn synchronization free"
     extern proc j1(x: real(64)): real(64);
     return j1(x);
   }
 
-  /* Returns the Bessel function of the first kind of order `n` of `x`. */
-  inline proc jn(n: int, x: real(32)): real(32) {
+  // When removing this deprecated function, be sure to remove chpl_j1 and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc j1(x: real(32)): real(32) {
+    return chpl_j1(x);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_j1 and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc j1(x: real(64)): real(64) {
+    return chpl_j1(x);
+  }
+
+  pragma "no doc"
+  inline proc chpl_jn(n: int, x: real(32)): real(32) {
     pragma "fn synchronization free"
     extern proc chpl_float_jn(n: c_int, x: real(32)): real(32);
     return chpl_float_jn(n.safeCast(c_int), x);
   }
 
-  /* Returns the Bessel function of the first kind of order `n` of `x`. */
-  inline proc jn(n: int, x: real(64)): real(64) {
+  pragma "no doc"
+  inline proc chpl_jn(n: int, x: real(64)): real(64) {
     pragma "fn synchronization free"
     extern proc jn(n: c_int, x: real(64)): real(64);
     return jn(n.safeCast(c_int), x);
   }
 
-  /* Returns the Bessel function of the second kind of order `0` of `x`, where
-     `x` must be greater than 0 */
-  inline proc y0(x: real(32)): real(32) {
+  // When removing this deprecated function, be sure to remove chpl_jn and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc jn(n: int, x: real(32)): real(32) {
+    return chpl_jn(n, x);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_jn and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc jn(n: int, x: real(64)): real(64) {
+    return chpl_jn(n, x);
+  }
+
+  pragma "no doc"
+  inline proc chpl_y0(x: real(32)): real(32) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for y0() must be non-negative");
 
@@ -1339,9 +1398,8 @@ module AutoMath {
     return chpl_float_y0(x);
   }
 
-  /* Returns the Bessel function of the second kind of order `0` of `x`,
-     where `x` must be greater than 0 */
-  inline proc y0(x: real(64)): real(64) {
+  pragma "no doc"
+  inline proc chpl_y0(x: real(64)): real(64) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for y0() must be non-negative");
 
@@ -1350,9 +1408,28 @@ module AutoMath {
     return y0(x);
   }
 
-  /* Returns the Bessel function of the second kind of order `1` of `x`,
-     where `x` must be greater than 0 */
-  inline proc y1(x: real(32)): real(32) {
+  // When removing this deprecated function, be sure to remove chpl_y0 and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc y0(x: real(32)): real(32) {
+    return chpl_y0(x);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_y0 and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc y0(x: real(64)): real(64) {
+    return chpl_y0(x);
+  }
+
+  pragma "no doc"
+  inline proc chpl_y1(x: real(32)): real(32) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for y1() must be non-negative");
 
@@ -1361,9 +1438,8 @@ module AutoMath {
     return chpl_float_y1(x);
   }
 
-  /* Returns the Bessel function of the second kind of order `1` of `x`,
-     where `x` must be greater than 0 */
-  inline proc y1(x: real(64)): real(64) {
+  pragma "no doc"
+  inline proc chpl_y1(x: real(64)): real(64) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for y1() must be non-negative");
 
@@ -1372,9 +1448,28 @@ module AutoMath {
     return y1(x);
   }
 
-  /* Returns the Bessel function of the second kind of order `n` of `x`,
-     where `x` must be greater than 0 */
-  inline proc yn(n: int, x: real(32)): real(32) {
+  // When removing this deprecated function, be sure to remove chpl_y1 and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc y1(x: real(32)): real(32) {
+    return chpl_y1(x);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_y1 and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc y1(x: real(64)): real(64) {
+    return chpl_y1(x);
+  }
+
+  pragma "no doc"
+  inline proc chpl_yn(n: int, x: real(32)): real(32) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for yn() must be non-negative");
 
@@ -1383,15 +1478,34 @@ module AutoMath {
     return chpl_float_yn(n.safeCast(c_int), x);
   }
 
-  /* Returns the Bessel function of the second kind of order `n` of `x`,
-     where `x` must be greater than 0 */
-  inline proc yn(n: int, x: real(64)): real(64) {
+  pragma "no doc"
+  inline proc chpl_yn(n: int, x: real(64)): real(64) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for yn() must be non-negative");
 
     pragma "fn synchronization free"
     extern proc yn(n: c_int, x: real(64)): real(64);
     return yn(n.safeCast(c_int), x);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_yn and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc yn(n: int, x: real(32)): real(32) {
+    return chpl_yn(n, x);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_yn and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module
+  pragma "no doc"
+  pragma "last resort"
+  deprecated "yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it"
+  inline proc yn(n: int, x: real(64)): real(64) {
+    return chpl_yn(n, x);
   }
 
   /* Returns true if the sign of `x` is negative, else returns false. It detects

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -83,4 +83,69 @@ module Math {
     return chpl_logBasePow2(val, baseLog2);
   }
 
+  /* Returns the Bessel function of the first kind of order `0` of `x`. */
+  inline proc j0(x: real(32)): real(32) {
+    return chpl_j0(x);
+  }
+
+  /* Returns the Bessel function of the first kind of order `0` of `x`. */
+  inline proc j0(x: real(64)): real(64) {
+    return chpl_j0(x);
+  }
+
+  /* Returns the Bessel function of the first kind of order `1` of `x`. */
+  inline proc j1(x: real(32)): real(32) {
+    return chpl_j1(x);
+  }
+
+  /* Returns the Bessel function of the first kind of order `1` of `x`. */
+  inline proc j1(x: real(64)): real(64) {
+    return chpl_j1(x);
+  }
+
+  /* Returns the Bessel function of the first kind of order `n` of `x`. */
+  inline proc jn(n: int, x: real(32)): real(32) {
+    return chpl_jn(n, x);
+  }
+
+  /* Returns the Bessel function of the first kind of order `n` of `x`. */
+  inline proc jn(n: int, x: real(64)): real(64) {
+    return chpl_jn(n, x);
+  }
+
+  /* Returns the Bessel function of the second kind of order `0` of `x`, where
+     `x` must be greater than 0 */
+  inline proc y0(x: real(32)): real(32) {
+    return chpl_y0(x);
+  }
+
+  /* Returns the Bessel function of the second kind of order `0` of `x`,
+     where `x` must be greater than 0 */
+  inline proc y0(x: real(64)): real(64) {
+    return chpl_y0(x);
+  }
+
+  /* Returns the Bessel function of the second kind of order `1` of `x`,
+     where `x` must be greater than 0 */
+  inline proc y1(x: real(32)): real(32) {
+    return chpl_y1(x);
+  }
+
+  /* Returns the Bessel function of the second kind of order `1` of `x`,
+     where `x` must be greater than 0 */
+  inline proc y1(x: real(64)): real(64) {
+    return chpl_y1(x);
+  }
+
+  /* Returns the Bessel function of the second kind of order `n` of `x`,
+     where `x` must be greater than 0 */
+  inline proc yn(n: int, x: real(32)): real(32) {
+    return chpl_yn(n, x);
+  }
+
+  /* Returns the Bessel function of the second kind of order `n` of `x`,
+     where `x` must be greater than 0 */
+  inline proc yn(n: int, x: real(64)): real(64) {
+    return chpl_yn(n, x);
+  }
 }

--- a/test/deprecated/Math/j0.chpl
+++ b/test/deprecated/Math/j0.chpl
@@ -1,0 +1,40 @@
+
+{
+  var a: real(64) = -100;
+  var b: real(64) = -0.05;
+  var c: real(64) = 0;
+  var d: real(64) = 0.05;
+  var e: real(64) = 100;
+
+  writeln("For 64-bit reals: ");
+  writeln("a = ", a);
+  writeln("j0(a) = ", j0(a));
+  writeln("b = ", b);
+  writeln("j0(b) = ", j0(b));
+  writeln("c = ", c);
+  writeln("j0(c) = ", j0(c));
+  writeln("d = ", d);
+  writeln("j0(d) = ", j0(d));
+  writeln("e = ", e);
+  writeln("j0(e) = ", j0(e));
+}
+
+{
+  writeln("For 32-bit reals: ");
+  var a: real(32) = (-100):real(32);
+  var b: real(32) = (-0.05):real(32);
+  var c: real(32) = (0):real(32);
+  var d: real(32) = (0.05):real(32);
+  var e: real(32) = (100):real(32);
+
+  writeln("a = ", a);
+  writeln("j0(a) = ", j0(a));
+  writeln("b = ", b);
+  writeln("j0(b) = ", j0(b));
+  writeln("c = ", c);
+  writeln("j0(c) = ", j0(c));
+  writeln("d = ", d);
+  writeln("j0(d) = ", j0(d));
+  writeln("e = ", e);
+  writeln("j0(e) = ", j0(e));
+}

--- a/test/deprecated/Math/j0.good
+++ b/test/deprecated/Math/j0.good
@@ -1,0 +1,32 @@
+j0.chpl:11: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:13: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:15: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:17: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:19: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:31: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:33: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:35: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:37: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j0.chpl:39: warning: j0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+For 64-bit reals: 
+a = -100.0
+j0(a) = 0.0199859
+b = -0.05
+j0(b) = 0.999375
+c = 0.0
+j0(c) = 1.0
+d = 0.05
+j0(d) = 0.999375
+e = 100.0
+j0(e) = 0.0199859
+For 32-bit reals: 
+a = -100.0
+j0(a) = 0.0199859
+b = -0.05
+j0(b) = 0.999375
+c = 0.0
+j0(c) = 1.0
+d = 0.05
+j0(d) = 0.999375
+e = 100.0
+j0(e) = 0.0199859

--- a/test/deprecated/Math/j1.chpl
+++ b/test/deprecated/Math/j1.chpl
@@ -1,0 +1,40 @@
+
+{
+  var a: real(64) = -100;
+  var b: real(64) = -0.05;
+  var c: real(64) = 0;
+  var d: real(64) = 0.05;
+  var e: real(64) = 100;
+
+  writeln("For 64-bit reals: ");
+  writeln("a = ", a);
+  writeln("j1(a) = ", j1(a));
+  writeln("b = ", b);
+  writeln("j1(b) = ", j1(b));
+  writeln("c = ", c);
+  writeln("j1(c) = ", j1(c));
+  writeln("d = ", d);
+  writeln("j1(d) = ", j1(d));
+  writeln("e = ", e);
+  writeln("j1(e) = ", j1(e));
+}
+
+{
+  writeln("For 32-bit reals: ");
+  var a: real(32) = (-100):real(32);
+  var b: real(32) = (-0.05):real(32);
+  var c: real(32) = (0):real(32);
+  var d: real(32) = (0.05):real(32);
+  var e: real(32) = (100):real(32);
+
+  writeln("a = ", a);
+  writeln("j1(a) = ", j1(a));
+  writeln("b = ", b);
+  writeln("j1(b) = ", j1(b));
+  writeln("c = ", c);
+  writeln("j1(c) = ", j1(c));
+  writeln("d = ", d);
+  writeln("j1(d) = ", j1(d));
+  writeln("e = ", e);
+  writeln("j1(e) = ", j1(e));
+}

--- a/test/deprecated/Math/j1.good
+++ b/test/deprecated/Math/j1.good
@@ -1,0 +1,32 @@
+j1.chpl:11: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:13: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:15: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:17: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:19: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:31: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:33: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:35: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:37: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+j1.chpl:39: warning: j1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+For 64-bit reals: 
+a = -100.0
+j1(a) = 0.0771454
+b = -0.05
+j1(b) = -0.0249922
+c = 0.0
+j1(c) = 0.0
+d = 0.05
+j1(d) = 0.0249922
+e = 100.0
+j1(e) = -0.0771454
+For 32-bit reals: 
+a = -100.0
+j1(a) = 0.0771454
+b = -0.05
+j1(b) = -0.0249922
+c = 0.0
+j1(c) = 0.0
+d = 0.05
+j1(d) = 0.0249922
+e = 100.0
+j1(e) = -0.0771454

--- a/test/deprecated/Math/jn.chpl
+++ b/test/deprecated/Math/jn.chpl
@@ -1,0 +1,39 @@
+
+{
+  var a: real(64) = -100, an: int = 5;
+  var b: real(64) = -0.05, bn: int = 4;
+  var c: real(64) = 0, cn: int = 7;
+  var d: real(64) = 0.05, dn: int = 2;
+  var e: real(64) = 100, en: int = 9;
+
+  writeln("For 64-bit reals: ");
+  writeln("a = ", a, " an = ", an);
+  writeln("jn(an, a) = ", jn(an, a));
+  writeln("b = ", b, " bn = ", bn);
+  writeln("jn(bn, b) = ", jn(bn, b));
+  writeln("c = ", c, " cn = ", cn);
+  writeln("jn(cn, c) = ", jn(cn, c));
+  writeln("d = ", d, " dn = ", dn);
+  writeln("jn(dn, d) = ", jn(dn, d));
+  writeln("e = ", e, " en = ", en);
+  writeln("jn(en, e) = ", jn(en, e));
+}
+
+{
+  var a: real(32) = (-100):real(32), an: int = 5;
+  var b: real(32) = (-0.05):real(32), bn: int = 4;
+  var c: real(32) = (0):real(32), cn: int = 7;
+  var d: real(32) = (0.05):real(32), dn: int = 2;
+  var e: real(32) = (100):real(32), en: int = 9;
+
+  writeln("a = ", a, " an = ", an);
+  writeln("jn(an, a) = ", jn(an, a));
+  writeln("b = ", b, " bn = ", bn);
+  writeln("jn(bn, b) = ", jn(bn, b));
+  writeln("c = ", c, " cn = ", cn);
+  writeln("jn(cn, c) = ", jn(cn, c));
+  writeln("d = ", d, " dn = ", dn);
+  writeln("jn(dn, d) = ", jn(dn, d));
+  writeln("e = ", e, " en = ", en);
+  writeln("jn(en, e) = ", jn(en, e));
+}

--- a/test/deprecated/Math/jn.good
+++ b/test/deprecated/Math/jn.good
@@ -1,0 +1,31 @@
+jn.chpl:11: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:13: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:15: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:17: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:19: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:30: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:32: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:34: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:36: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+jn.chpl:38: warning: jn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+For 64-bit reals: 
+a = -100.0 an = 5
+jn(an, a) = 0.0741957
+b = -0.05 bn = 4
+jn(bn, b) = 1.6274e-08
+c = 0.0 cn = 7
+jn(cn, c) = 0.0
+d = 0.05 dn = 2
+jn(dn, d) = 0.000312435
+e = 100.0 en = 9
+jn(en, e) = -0.0632368
+a = -100.0 an = 5
+jn(an, a) = 0.0741957
+b = -0.05 bn = 4
+jn(bn, b) = 1.6274e-08
+c = 0.0 cn = 7
+jn(cn, c) = 0.0
+d = 0.05 dn = 2
+jn(dn, d) = 0.000312435
+e = 100.0 en = 9
+jn(en, e) = -0.0632368

--- a/test/deprecated/Math/y0.chpl
+++ b/test/deprecated/Math/y0.chpl
@@ -1,0 +1,39 @@
+{
+  writeln("For 64-bit reals: ");
+  var a: real(64) = 10;
+  var b: real(64) = 31;
+  var c: real(64) = 110;
+  var d: real(64) = 0.05;
+  var e: real(64) = 100;
+
+  writeln("a = ", a);
+  writeln("y0(a) = ", y0(a));
+  writeln("b = ", b);
+  writeln("y0(b) = ", y0(b));
+  writeln("c = ", c);
+  writeln("y0(c) = ", y0(c));
+  writeln("d = ", d);
+  writeln("y0(d) = ", y0(d));
+  writeln("e = ", e);
+  writeln("y0(e) = ", y0(e));
+}
+
+{
+  writeln("For 32-bit reals: ");
+  var a: real(32) = 10;
+  var b: real(32) = 31;
+  var c: real(32) = 110;
+  var d: real(32) = 0.05;
+  var e: real(32) = 100;
+
+  writeln("a = ", a);
+  writeln("y0(a) = ", y0(a));
+  writeln("b = ", b);
+  writeln("y0(b) = ", y0(b));
+  writeln("c = ", c);
+  writeln("y0(c) = ", y0(c));
+  writeln("d = ", d);
+  writeln("y0(d) = ", y0(d));
+  writeln("e = ", e);
+  writeln("y0(e) = ", y0(e));
+}

--- a/test/deprecated/Math/y0.good
+++ b/test/deprecated/Math/y0.good
@@ -1,0 +1,32 @@
+y0.chpl:10: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:12: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:14: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:16: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:18: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:30: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:32: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:34: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:36: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y0.chpl:38: warning: y0 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+For 64-bit reals: 
+a = 10.0
+y0(a) = 0.0556712
+b = 31.0
+y0(b) = -0.133833
+c = 110.0
+y0(c) = 0.0514242
+d = 0.05
+y0(d) = -1.97931
+e = 100.0
+y0(e) = -0.0772443
+For 32-bit reals: 
+a = 10.0
+y0(a) = 0.0556712
+b = 31.0
+y0(b) = -0.133833
+c = 110.0
+y0(c) = 0.0514242
+d = 0.05
+y0(d) = -1.97931
+e = 100.0
+y0(e) = -0.0772443

--- a/test/deprecated/Math/y1.chpl
+++ b/test/deprecated/Math/y1.chpl
@@ -1,0 +1,39 @@
+{
+  writeln("For 64-bit reals: ");
+  var a: real(64) = 10;
+  var b: real(64) = 31;
+  var c: real(64) = 110;
+  var d: real(64) = 0.05;
+  var e: real(64) = 100;
+
+  writeln("a = ", a);
+  writeln("y1(a) = ", y1(a));
+  writeln("b = ", b);
+  writeln("y1(b) = ", y1(b));
+  writeln("c = ", c);
+  writeln("y1(c) = ", y1(c));
+  writeln("d = ", d);
+  writeln("y1(d) = ", y1(d));
+  writeln("e = ", e);
+  writeln("y1(e) = ", y1(e));
+}
+
+{
+  writeln("For 32-bit reals: ");
+  var a: real(32) = 10;
+  var b: real(32) = 31;
+  var c: real(32) = 110;
+  var d: real(32) = 0.05;
+  var e: real(32) = 100;
+
+  writeln("a = ", a);
+  writeln("y1(a) = ", y1(a));
+  writeln("b = ", b);
+  writeln("y1(b) = ", y1(b));
+  writeln("c = ", c);
+  writeln("y1(c) = ", y1(c));
+  writeln("d = ", d);
+  writeln("y1(d) = ", y1(d));
+  writeln("e = ", e);
+  writeln("y1(e) = ", y1(e));
+}

--- a/test/deprecated/Math/y1.good
+++ b/test/deprecated/Math/y1.good
@@ -1,0 +1,32 @@
+y1.chpl:10: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:12: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:14: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:16: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:18: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:30: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:32: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:34: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:36: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+y1.chpl:38: warning: y1 is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+For 64-bit reals: 
+a = 10.0
+y1(a) = 0.249015
+b = 31.0
+y1(b) = -0.0533728
+c = 110.0
+y1(c) = 0.0562963
+d = 0.05
+y1(d) = -12.7899
+e = 100.0
+y1(e) = -0.0203723
+For 32-bit reals: 
+a = 10.0
+y1(a) = 0.249015
+b = 31.0
+y1(b) = -0.0533728
+c = 110.0
+y1(c) = 0.0562963
+d = 0.05
+y1(d) = -12.7899
+e = 100.0
+y1(e) = -0.0203723

--- a/test/deprecated/Math/yn.chpl
+++ b/test/deprecated/Math/yn.chpl
@@ -1,0 +1,40 @@
+
+{
+  writeln("For 64-bit reals: ");
+  var a: real(64) = 10, an: int = 5;
+  var b: real(64) = 31, bn: int = 4;
+  var c: real(64) = 0, cn: int = 7;
+  var d: real(64) = 0.05, dn: int = 2;
+  var e: real(64) = 100, en: int = 9;
+
+  writeln("a = ", a, " an = ", an);
+  writeln("yn(an, a) = ", yn(an, a));
+  writeln("b = ", b, " bn = ", bn);
+  writeln("yn(bn, b) = ", yn(bn, b));
+  writeln("c = ", c, " cn = ", cn);
+  writeln("yn(cn, c) = ", yn(cn, c));
+  writeln("d = ", d, " dn = ", dn);
+  writeln("yn(dn, d) = ", yn(dn, d));
+  writeln("e = ", e, " en = ", en);
+  writeln("yn(en, e) = ", yn(en, e));
+}
+
+{
+  writeln("For 32-bit reals: ");
+  var a: real(32) = 10, an: int = 5;
+  var b: real(32) = 31, bn: int = 4;
+  var c: real(32) = 0, cn: int = 7;
+  var d: real(32) = 0.05, dn: int = 2;
+  var e: real(32) = 100, en: int = 9;
+
+  writeln("a = ", a, " an = ", an);
+  writeln("yn(an, a) = ", yn(an, a));
+  writeln("b = ", b, " bn = ", bn);
+  writeln("yn(bn, b) = ", yn(bn, b));
+  writeln("c = ", c, " cn = ", cn);
+  writeln("yn(cn, c) = ", yn(cn, c));
+  writeln("d = ", d, " dn = ", dn);
+  writeln("yn(dn, d) = ", yn(dn, d));
+  writeln("e = ", e, " en = ", en);
+  writeln("yn(en, e) = ", yn(en, e));
+}

--- a/test/deprecated/Math/yn.good
+++ b/test/deprecated/Math/yn.good
@@ -1,0 +1,32 @@
+yn.chpl:11: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:13: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:15: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:17: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:19: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:31: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:33: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:35: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:37: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+yn.chpl:39: warning: yn is no longer included by default, please 'use' or 'import' the 'Math' module to call it
+For 64-bit reals: 
+a = 10.0 an = 5
+yn(an, a) = 0.135403
+b = 31.0 bn = 4
+yn(bn, b) = -0.116803
+c = 0.0 cn = 7
+yn(cn, c) = -inf
+d = 0.05 dn = 2
+yn(dn, d) = -509.615
+e = 100.0 en = 9
+yn(en, e) = -0.04892
+For 32-bit reals: 
+a = 10.0 an = 5
+yn(an, a) = 0.135403
+b = 31.0 bn = 4
+yn(bn, b) = -0.116803
+c = 0.0 cn = 7
+yn(cn, c) = -inf
+d = 0.05 dn = 2
+yn(dn, d) = -509.615
+e = 100.0 en = 9
+yn(en, e) = -0.04892

--- a/test/library/standard/Math/j0.chpl
+++ b/test/library/standard/Math/j0.chpl
@@ -1,5 +1,6 @@
 
 {
+  use Math;
   var a: real(64) = -100;
   var b: real(64) = -0.05;
   var c: real(64) = 0;
@@ -20,6 +21,7 @@
 }
 
 {
+  use Math;
   writeln("For 32-bit reals: ");
   var a: real(32) = (-100):real(32);
   var b: real(32) = (-0.05):real(32);

--- a/test/library/standard/Math/j1.chpl
+++ b/test/library/standard/Math/j1.chpl
@@ -1,5 +1,6 @@
 
 {
+  use Math;
   var a: real(64) = -100;
   var b: real(64) = -0.05;
   var c: real(64) = 0;
@@ -20,6 +21,7 @@
 }
 
 {
+  use Math;
   writeln("For 32-bit reals: ");
   var a: real(32) = (-100):real(32);
   var b: real(32) = (-0.05):real(32);

--- a/test/library/standard/Math/jn.chpl
+++ b/test/library/standard/Math/jn.chpl
@@ -1,5 +1,6 @@
 
 {
+  use Math;
   var a: real(64) = -100, an: int = 5;
   var b: real(64) = -0.05, bn: int = 4;
   var c: real(64) = 0, cn: int = 7;
@@ -20,6 +21,7 @@
 }
 
 {
+  use Math;
   var a: real(32) = (-100):real(32), an: int = 5;
   var b: real(32) = (-0.05):real(32), bn: int = 4;
   var c: real(32) = (0):real(32), cn: int = 7;

--- a/test/library/standard/Math/y0.chpl
+++ b/test/library/standard/Math/y0.chpl
@@ -1,4 +1,5 @@
 {
+  use Math;
   writeln("For 64-bit reals: ");
   var a: real(64) = 10;
   var b: real(64) = 31;
@@ -19,6 +20,7 @@
 }
 
 {
+  use Math;
   writeln("For 32-bit reals: ");
   var a: real(32) = 10;
   var b: real(32) = 31;

--- a/test/library/standard/Math/y1.chpl
+++ b/test/library/standard/Math/y1.chpl
@@ -1,4 +1,5 @@
 {
+  use Math;
   writeln("For 64-bit reals: ");
   var a: real(64) = 10;
   var b: real(64) = 31;
@@ -19,6 +20,7 @@
 }
 
 {
+  use Math;
   writeln("For 32-bit reals: ");
   var a: real(32) = 10;
   var b: real(32) = 31;

--- a/test/library/standard/Math/yn.chpl
+++ b/test/library/standard/Math/yn.chpl
@@ -1,5 +1,6 @@
 
 {
+  use Math;
   writeln("For 64-bit reals: ");
   var a: real(64) = 10, an: int = 5;
   var b: real(64) = 31, bn: int = 4;
@@ -20,6 +21,7 @@
 }
 
 {
+  use Math;
   writeln("For 32-bit reals: ");
   var a: real(32) = 10, an: int = 5;
   var b: real(32) = 31, bn: int = 4;


### PR DESCRIPTION
Deprecate the automatically included versions in AutoMath, moving their contents
to versions with the `chpl_` prefix for now (so that AutoMath does not need to
insert uses or imports of Math to continue supporting the deprecated
functionality) and adding the appropriate declarations (back) to Math.

Adds a use of the Math module to the tests of these functions in
`test/library/standard/Math` and copies the version that will trigger the
deprecation warning into `test/deprecated/Math`

Passed a full paratest with futures