### PR TITLE
Deprecate `channel.readwrite`

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -72,19 +72,8 @@ argument.
 Because it is often more convenient to use an operator for I/O, instead of
 writing
 
-.. code-block:: chapel
-
-  f.readwrite(x);
-  f.readwrite(y);
-
-one can write
-
-.. code-block:: chapel
-
-  f <~> x <~> y;
-
-Note that the types :type:`IO.ioLiteral` and :type:`IO.ioNewline` from the :mod:`IO` module
-may be useful when using the ``<~>`` operator. :type:`IO.ioLiteral` represents some string
+ote that the types :type:`IO.ioLiteral` and :type:`IO.ioNewline` may be useful
+when using the ``<~>`` operator. :type:`IO.ioLiteral` represents some string
 that must be read or written as-is (e.g. ``","`` when working with a tuple),
 and :type:`IO.ioNewline` will emit a newline when writing but skip to and
 consume a newline when reading. Note that these types are not included by default.

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -242,7 +242,7 @@ module ChapelIO {
           if isIoField(x, i) {
             if !isBinary {
               var comma = new ioLiteral(", ");
-              if !first then writer.write(comma);
+              if !first then writer.writeIt(comma);
 
               var eq:ioLiteral = ioFieldNameEqLiteral(writer, t, i);
               writer.writeIt(eq);
@@ -531,7 +531,6 @@ module ChapelIO {
             then new ioLiteral(":", true)
             else new ioLiteral("=", true);
 
-          // TODO: Why not a `read` call here?
           try readIt(eq);
 
           // We read the 'name = ', so now read the value!

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -245,10 +245,10 @@ module ChapelIO {
               if !first then writer.write(comma);
 
               var eq:ioLiteral = ioFieldNameEqLiteral(writer, t, i);
-              writer.write(eq);
+              writer.writeIt(eq);
             }
 
-            writer.write(__primitive("field by num", x, i));
+            writer.writeIt(__primitive("field by num", x, i));
 
             first = false;
           }
@@ -264,9 +264,9 @@ module ChapelIO {
               write(id);
             } else {
               var eq:ioLiteral = ioFieldNameEqLiteral(writer, t, i);
-              writer.write(eq);
+              writer.writeIt(eq);
             }
-            writer.write(__primitive("field by num", x, i));
+            writer.writeIt(__primitive("field by num", x, i));
           }
         }
       }
@@ -299,7 +299,7 @@ module ChapelIO {
             start = new ioLiteral("(");
           }
         }
-        writer.write(start);
+        writer.writeIt(start);
       }
 
       var first = true;
@@ -320,7 +320,7 @@ module ChapelIO {
             end = new ioLiteral(")");
           }
         }
-        writer.write(end);
+        writer.writeIt(end);
       }
     }
 
@@ -339,7 +339,7 @@ module ChapelIO {
 
           // Try reading a comma. If we don't, break out of the loop.
           try {
-            reader.read(comma);
+            reader.readIt(comma);
             needsComma = false;
           } catch err: BadFormatError {
             break;
@@ -389,7 +389,7 @@ module ChapelIO {
         // Binary is simple, just read all fields in order.
         for param i in 1..numFields do
           if isIoField(x, i) then
-            try reader.read(__primitive("field by num", x, i));
+            try reader.readIt(__primitive("field by num", x, i));
       } else if numFields > 0 {
 
         // This tuple helps us not read the same field twice.
@@ -410,7 +410,7 @@ module ChapelIO {
           if needsComma then
             try {
               var comma = new ioLiteral(",", true);
-              reader.read(comma);
+              reader.readIt(comma);
               needsComma = false;
             } catch err: BadFormatError {
               // Break out of the loop if we didn't read a comma.
@@ -441,7 +441,7 @@ module ChapelIO {
             var fieldName = ioFieldNameLiteral(reader, t, i);
 
             try {
-              reader.read(fieldName);
+              reader.readIt(fieldName);
             } catch err: SystemError {
               // Try reading again with a different union element.
               if err.err == EFORMAT || err.err == EEOF then continue;
@@ -455,9 +455,9 @@ module ChapelIO {
               then new ioLiteral(":", true)
               else new ioLiteral("=", true);
 
-            try reader.read(equalSign);
+            try reader.readIt(equalSign);
 
-            try reader.read(__primitive("field by num", x, i));
+            try reader.readIt(__primitive("field by num", x, i));
             readField[i-1] = true;
             numRead += 1;
           }
@@ -501,10 +501,10 @@ module ChapelIO {
         var id = __primitive("get_union_id", x);
 
         // Read the ID.
-        try reader.read(id);
+        try reader.readIt(id);
         for param i in 1..numFields do
           if isIoField(x, i) && i == id then
-            try reader.read(__primitive("field by num", x, i));
+            try reader.readIt(__primitive("field by num", x, i));
       } else {
 
         // Read the field name = part until we get one that worked.
@@ -517,7 +517,7 @@ module ChapelIO {
           var fieldName = ioFieldNameLiteral(reader, t, i);
 
           try {
-            reader.read(fieldName);
+            reader.readIt(fieldName);
           } catch err: SystemError {
 
             // Try reading again with a different union element.
@@ -535,7 +535,7 @@ module ChapelIO {
           try readIt(eq);
 
           // We read the 'name = ', so now read the value!
-          try reader.read(__primitive("field by num", x, i));
+          try reader.readIt(__primitive("field by num", x, i));
         }
 
         if !hasFoundAtLeastOneField then
@@ -557,7 +557,7 @@ module ChapelIO {
           then new ioLiteral("new " + t:string + "(")
           else new ioLiteral("{");
 
-        try reader.read(start);
+        try reader.readIt(start);
       }
 
       var needsComma = false;
@@ -573,7 +573,7 @@ module ChapelIO {
           then new ioLiteral(")")
           else new ioLiteral("}");
 
-        try reader.read(end);
+        try reader.readIt(end);
       }
     }
 
@@ -593,7 +593,7 @@ module ChapelIO {
             start = new ioLiteral("(");
         }
 
-        try reader.read(start);
+        try reader.readIt(start);
       }
 
       var needsComma = false;
@@ -606,7 +606,7 @@ module ChapelIO {
           then new ioLiteral("}")
           else new ioLiteral(")");
 
-        try reader.read(end);
+        try reader.readIt(end);
       }
     }
 

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -253,13 +253,13 @@ module ChapelIO {
           if isIoField(x, i) {
             if !isBinary {
               var comma = new ioLiteral(", ");
-              if !first then writer.readwrite(comma);
+              if !first then writer.write(comma);
 
               var eq:ioLiteral = ioFieldNameEqLiteral(writer, t, i);
-              writer.readwrite(eq);
+              writer.write(eq);
             }
 
-            writer.readwrite(__primitive("field by num", x, i));
+            writer.write(__primitive("field by num", x, i));
 
             first = false;
           }
@@ -275,9 +275,9 @@ module ChapelIO {
               write(id);
             } else {
               var eq:ioLiteral = ioFieldNameEqLiteral(writer, t, i);
-              writer.readwrite(eq);
+              writer.write(eq);
             }
-            writer.readwrite(__primitive("field by num", x, i));
+            writer.write(__primitive("field by num", x, i));
           }
         }
       }
@@ -310,7 +310,7 @@ module ChapelIO {
             start = new ioLiteral("(");
           }
         }
-        writer.readwrite(start);
+        writer.write(start);
       }
 
       var first = true;
@@ -331,7 +331,7 @@ module ChapelIO {
             end = new ioLiteral(")");
           }
         }
-        writer.readwrite(end);
+        writer.write(end);
       }
     }
 
@@ -350,7 +350,7 @@ module ChapelIO {
 
           // Try reading a comma. If we don't, break out of the loop.
           try {
-            reader.readwrite(comma);
+            reader.read(comma);
             needsComma = false;
           } catch err: BadFormatError {
             break;
@@ -400,7 +400,7 @@ module ChapelIO {
         // Binary is simple, just read all fields in order.
         for param i in 1..numFields do
           if isIoField(x, i) then
-            try reader.readwrite(__primitive("field by num", x, i));
+            try reader.read(__primitive("field by num", x, i));
       } else if numFields > 0 {
 
         // This tuple helps us not read the same field twice.
@@ -421,7 +421,7 @@ module ChapelIO {
           if needsComma then
             try {
               var comma = new ioLiteral(",", true);
-              reader.readwrite(comma);
+              reader.read(comma);
               needsComma = false;
             } catch err: BadFormatError {
               // Break out of the loop if we didn't read a comma.
@@ -452,7 +452,7 @@ module ChapelIO {
             var fieldName = ioFieldNameLiteral(reader, t, i);
 
             try {
-              reader.readwrite(fieldName);
+              reader.read(fieldName);
             } catch err: SystemError {
               // Try reading again with a different union element.
               if err.err == EFORMAT || err.err == EEOF then continue;
@@ -466,9 +466,9 @@ module ChapelIO {
               then new ioLiteral(":", true)
               else new ioLiteral("=", true);
 
-            try reader.readwrite(equalSign);
+            try reader.read(equalSign);
 
-            try reader.readwrite(__primitive("field by num", x, i));
+            try reader.read(__primitive("field by num", x, i));
             readField[i-1] = true;
             numRead += 1;
           }
@@ -512,10 +512,10 @@ module ChapelIO {
         var id = __primitive("get_union_id", x);
 
         // Read the ID.
-        try reader.readwrite(id);
+        try reader.read(id);
         for param i in 1..numFields do
           if isIoField(x, i) && i == id then
-            try reader.readwrite(__primitive("field by num", x, i));
+            try reader.read(__primitive("field by num", x, i));
       } else {
 
         // Read the field name = part until we get one that worked.
@@ -528,7 +528,7 @@ module ChapelIO {
           var fieldName = ioFieldNameLiteral(reader, t, i);
 
           try {
-            reader.readwrite(fieldName);
+            reader.read(fieldName);
           } catch err: SystemError {
 
             // Try reading again with a different union element.
@@ -542,11 +542,11 @@ module ChapelIO {
             then new ioLiteral(":", true)
             else new ioLiteral("=", true);
 
-          // TODO: Why not a `readwrite` call here?
+          // TODO: Why not a `read` call here?
           try readIt(eq);
 
           // We read the 'name = ', so now read the value!
-          try reader.readwrite(__primitive("field by num", x, i));
+          try reader.read(__primitive("field by num", x, i));
         }
 
         if !hasFoundAtLeastOneField then
@@ -568,7 +568,7 @@ module ChapelIO {
           then new ioLiteral("new " + t:string + "(")
           else new ioLiteral("{");
 
-        try reader.readwrite(start);
+        try reader.read(start);
       }
 
       var needsComma = false;
@@ -584,7 +584,7 @@ module ChapelIO {
           then new ioLiteral(")")
           else new ioLiteral("}");
 
-        try reader.readwrite(end);
+        try reader.read(end);
       }
     }
 
@@ -604,7 +604,7 @@ module ChapelIO {
             start = new ioLiteral("(");
         }
 
-        try reader.readwrite(start);
+        try reader.read(start);
       }
 
       var needsComma = false;
@@ -617,7 +617,7 @@ module ChapelIO {
           then new ioLiteral("}")
           else new ioLiteral(")");
 
-        try reader.readwrite(end);
+        try reader.read(end);
       }
     }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3610,7 +3610,10 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   proc channel.readWriteLiteral(lit:string, ignoreWhiteSpace=true) throws
   {
     var iolit = new ioLiteral(lit:string, ignoreWhiteSpace);
-    this.readwrite(iolit);
+    if this.writing then
+      this.write(iolit);
+    else
+      this.read(iolit);
   }
 
   /* Explicit call for reading or writing a newline as an
@@ -3620,7 +3623,10 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   inline proc channel.readWriteNewline() throws
   {
     var ionl = new ioNewline();
-    this.readwrite(ionl);
+    if this.writing then
+      this.write(ionl);
+    else
+      this.read(ionl);
   }
 
   /* Returns `true` if this channel is configured for binary I/O.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3549,7 +3549,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
    */
   inline operator channel.<~>(const ref ch: channel, const x) const ref throws
   where ch.writing {
-    try ch.write(x);
+    try ch.writeIt(x);
     return ch;
   }
 
@@ -3557,7 +3557,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   pragma "no doc"
   inline operator channel.<~>(const ref ch: channel, ref x) const ref throws
   where !ch.writing {
-    try ch.read(x);
+    try ch.readIt(x);
     return ch;
   }
 
@@ -3610,9 +3610,9 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   {
     var iolit = new ioLiteral(lit:string, ignoreWhiteSpace);
     if this.writing then
-      this.write(iolit);
+      this.writeIt(iolit);
     else
-      this.read(iolit);
+      this.readIt(iolit);
   }
 
   /* Explicit call for reading or writing a newline as an
@@ -3622,9 +3622,9 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   {
     var ionl = new ioNewline();
     if this.writing then
-      this.write(ionl);
+      this.writeIt(ionl);
     else
-      this.read(ionl);
+      this.readIt(ionl);
   }
 
   /* Returns `true` if this channel is configured for binary I/O.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3549,7 +3549,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
    */
   inline operator channel.<~>(const ref ch: channel, const x) const ref throws
   where ch.writing {
-    try ch.readwrite(x);
+    try ch.write(x);
     return ch;
   }
 
@@ -3557,7 +3557,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   pragma "no doc"
   inline operator channel.<~>(const ref ch: channel, ref x) const ref throws
   where !ch.writing {
-    try ch.readwrite(x);
+    try ch.read(x);
     return ch;
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3605,7 +3605,6 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   /* Explicit call for reading or writing a literal as an
      alternative to using :type:`IO.ioLiteral`.
    */
-  deprecated "channel.readWriteLiteral is deprecated"
   inline
   proc channel.readWriteLiteral(lit:string, ignoreWhiteSpace=true) throws
   {
@@ -3619,7 +3618,6 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   /* Explicit call for reading or writing a newline as an
      alternative to using :type:`IO.ioNewline`.
    */
-  deprecated "channel.readWriteNewLine is deprecated"
   inline proc channel.readWriteNewline() throws
   {
     var ionl = new ioNewline();

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3525,11 +3525,13 @@ proc channel.writeIt(const x) throws {
 
    :throws SystemError: When an IO error has occurred.
  */
+deprecated "channel.readwrite is deprecated"
 inline proc channel.readwrite(const x) throws where this.writing {
   try this.writeIt(x);
 }
 // documented in the writing version.
 pragma "no doc"
+deprecated "channel.readwrite is deprecated"
 inline proc channel.readwrite(ref x) throws where !this.writing {
   try this.readIt(x);
 }
@@ -3603,6 +3605,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   /* Explicit call for reading or writing a literal as an
      alternative to using :type:`IO.ioLiteral`.
    */
+  deprecated "channel.readWriteLiteral is deprecated"
   inline
   proc channel.readWriteLiteral(lit:string, ignoreWhiteSpace=true) throws
   {
@@ -3613,6 +3616,7 @@ inline proc channel.readwrite(ref x) throws where !this.writing {
   /* Explicit call for reading or writing a newline as an
      alternative to using :type:`IO.ioNewline`.
    */
+  deprecated "channel.readWriteNewLine is deprecated"
   inline proc channel.readWriteNewline() throws
   {
     var ionl = new ioNewline();

--- a/test/deprecated/IO/readwrite.chpl
+++ b/test/deprecated/IO/readwrite.chpl
@@ -1,0 +1,7 @@
+use IO;
+
+var f = opentmp();
+
+var ch = f.writer();
+
+ch.readwrite("foo");

--- a/test/deprecated/IO/readwrite.good
+++ b/test/deprecated/IO/readwrite.good
@@ -1,0 +1,1 @@
+readwrite.chpl:7: warning: channel.readwrite is deprecated

--- a/test/functions/operatorOverloads/operatorMethods/allOps/ioOperator.chpl
+++ b/test/functions/operatorOverloads/operatorMethods/allOps/ioOperator.chpl
@@ -7,7 +7,7 @@ record Foo {
 operator Foo.<~>(const ref ch: channel, const x: Foo) const ref throws
   where ch.writing {
 
-  try ch.readwrite(x.x);
+  try ch.write(x.x);
   return ch;
 }
 proc main() {

--- a/test/io/ferguson/readThis/read-write-locale-arg.chpl
+++ b/test/io/ferguson/readThis/read-write-locale-arg.chpl
@@ -23,7 +23,10 @@ class C {
   proc readWriteThis(rw) throws {
     var loc = rw.readWriteThisFromLocale();
     writeln("in C.readWriteThis loc= ", loc.id);
-    rw.readwrite(x);
+    if rw.writing then
+      rw.write(x);
+    else
+      rw.read(x);
   }
 }
 

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsAlone.chpl
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsAlone.chpl
@@ -88,7 +88,7 @@ module DefinesOp {
     where ch.writing {
 
     writeln("In DefinesOp.<~>");
-    try ch.readwrite(x.x);
+    try ch.write(x.x);
     return ch;
   }
 

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsFirst.chpl
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsFirst.chpl
@@ -88,7 +88,7 @@ module DefinesOp {
     where ch.writing {
 
     writeln("In DefinesOp.<~>");
-    try ch.readwrite(x.x);
+    try ch.write(x.x);
     return ch;
   }
 

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsLast.chpl
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsLast.chpl
@@ -88,7 +88,7 @@ module DefinesOp {
     where ch.writing {
 
     writeln("In DefinesOp.<~>");
-    try ch.readwrite(x.x);
+    try ch.write(x.x);
     return ch;
   }
 

--- a/test/visibility/import/enablesUnqualified/operatorsAlone.chpl
+++ b/test/visibility/import/enablesUnqualified/operatorsAlone.chpl
@@ -88,7 +88,7 @@ module DefinesOp {
     where ch.writing {
 
     writeln("In DefinesOp.<~>");
-    try ch.readwrite(x.x);
+    try ch.write(x.x);
     return ch;
   }
 


### PR DESCRIPTION
This PR deprecates `channel.readwrite`.

Resolves https://github.com/chapel-lang/chapel/issues/19500

Calls to `readwrite` are replaced with `readIt`/`writeIt` in the IO modules. They are replaced with `read`/`write` in tests.

Test:

- [x] standard