### PR TITLE
Fix typos

### DIFF
--- a/compiler/dyno/lib/parsing/parser-yylloc-default.h
+++ b/compiler/dyno/lib/parsing/parser-yylloc-default.h
@@ -65,7 +65,7 @@
   the uAST node. So line numbers are off quite often.
 
   What's been done to fix this is: for zero application reductions, set
-  the location of the entire reduction to be the location of the currrent
+  the location of the entire reduction to be the location of the current
   lookahead token. In essence, optimistically look 1 forward instead of
   1 back (assume that we will consume some non-zero amount of input in a
   future reduction).

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -200,7 +200,7 @@ Resolver::instantiatedFieldStmtResolver(Context* context,
 }
 
 // set up Resolver to resolve instantiated field declaration types
-// without knowning the CompositeType
+// without knowing the CompositeType
 Resolver
 Resolver::instantiatedSignatureFieldsResolver(Context* context,
                                      const AggregateDecl* decl,

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -125,7 +125,7 @@ struct Resolver {
                                 bool useGenericFormalDefaults);
 
   // set up Resolver to resolve instantiated field declaration types
-  // without knowning the CompositeType
+  // without knowing the CompositeType
   static Resolver
   instantiatedSignatureFieldsResolver(Context* context,
                                       const uast::AggregateDecl* decl,

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -2354,7 +2354,7 @@ considerCompilerGeneratedCandidates(Context* context,
   auto tfs = getCompilerGeneratedMethod(context, receiverType, ci.name());
   assert(tfs);
 
-  // check if the inital signature matches
+  // check if the initial signature matches
   auto faMap = FormalActualMap(tfs->untyped(), ci);
   if (!isInitialTypedSignatureApplicable(context, tfs, faMap, ci)) {
     return false;

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -331,7 +331,7 @@ The ``use`` and ``import`` statements themselves are processed in order,
 so it is not possible to ``use`` a module that is only made available by
 a later ``use``.
 
-The other mentiones of a name made visible by a ``use`` or ``import``
+The other mentions of a name made visible by a ``use`` or ``import``
 statement can be at any position relative to the ``use`` or ``import``.
 
 Private ``use`` statements -- for example ``use M`` or ``private use M``

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -449,7 +449,7 @@ leads to undefined behavior.
 
 In order for it to be possible to iterate over a range with a last
 index, it needs to be possible to add the stride to the range's last
-index without overflowng the index type. In other words, the last index
+index without overflowing the index type. In other words, the last index
 plus the stride must be between the index type's minimum and maximum
 value (inclusive). If this property is not met, the program will have
 undefined behavior.

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -106,7 +106,7 @@ You should see something like this:
     writeln("New library: HelloPackage");
   }
 
-This program will run as-is, but we aren't using our ``HelloWorld`` dependecy
+This program will run as-is, but we aren't using our ``HelloWorld`` dependency
 just yet. In order to use the package, we need to add a ``use HelloWorld`` to
 bring in the dependency. This gives us access to the whole module namespace
 of the ``HelloWorld`` package, and we can call all of the available functions.

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -233,7 +233,7 @@ module LocaleModelHelpSetup {
   proc helpSetupLocaleGPU(dst: borrowed LocaleModel, out local_name:string,
       numSublocales: int, type GPULocale){
 
-    // Cylic (and likely other) distributions uses this variable to determine
+    // Cyclic (and likely other) distributions uses this variable to determine
     // how many data-parallel tasks to have per locale. If this gets set to 0
     // then we end up not processing things in the first locale.
     extern proc chpl_task_getMaxPar(): uint(32);

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -128,7 +128,7 @@ module Errors {
   }
 
   /*
-   A `CodepointSplittintError` is thrown if an attempt to slice a string with
+   A `CodepointSplittingError` is thrown if an attempt to slice a string with
    byteIndex-based ranges where the range boundaries does not align with
    codepoint boundaries.
    */

--- a/modules/standard/GPUDiagnostics.chpl
+++ b/modules/standard/GPUDiagnostics.chpl
@@ -104,7 +104,7 @@ module GPUDiagnostics
    */
   proc resetGPUDiagnostics() {
     for loc in Locales do on loc do
-      resetgpuDiagnosticsHere();
+      resetGPUDiagnosticsHere();
   }
 
   /*

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -1031,7 +1031,7 @@ module Subprocess {
   deprecated "'Subprocess.SIGTRAP' is deprecated. Use 'Sys.SIGTRAP' instead."
   extern const SIGTRAP: c_int;
   pragma "no doc"
-  deprecated "'Subprocess.SIGSTP' is deprecated. Use 'Sys.SIGSTP' instead."
+  deprecated "'Subprocess.SIGTSTP' is deprecated. Use 'Sys.SIGTSTP' instead."
   extern const SIGTSTP: c_int;
   pragma "no doc"
   deprecated "'Subprocess.SIGTTIN' is deprecated. Use 'Sys.SIGTTIN' instead."

--- a/test/deprecated/subprocessPosixSignals.good
+++ b/test/deprecated/subprocessPosixSignals.good
@@ -14,7 +14,7 @@ subprocessPosixSignals.chpl:17: warning: 'Subprocess.SIGSEGV' is deprecated. Use
 subprocessPosixSignals.chpl:18: warning: 'Subprocess.SIGSTOP' is deprecated. Use 'Sys.SIGSTOP' instead.
 subprocessPosixSignals.chpl:19: warning: 'Subprocess.SIGTERM' is deprecated. Use 'Sys.SIGTERM' instead.
 subprocessPosixSignals.chpl:20: warning: 'Subprocess.SIGTRAP' is deprecated. Use 'Sys.SIGTRAP' instead.
-subprocessPosixSignals.chpl:21: warning: 'Subprocess.SIGSTP' is deprecated. Use 'Sys.SIGSTP' instead.
+subprocessPosixSignals.chpl:21: warning: 'Subprocess.SIGTSTP' is deprecated. Use 'Sys.SIGTSTP' instead.
 subprocessPosixSignals.chpl:22: warning: 'Subprocess.SIGTTIN' is deprecated. Use 'Sys.SIGTTIN' instead.
 subprocessPosixSignals.chpl:23: warning: 'Subprocess.SIGTTOU' is deprecated. Use 'Sys.SIGTTOU' instead.
 subprocessPosixSignals.chpl:24: warning: 'Subprocess.SIGURG' is deprecated. Use 'Sys.SIGURG' instead.


### PR DESCRIPTION
Fix typos in

parser-yylloc-default.h, Resolver.{h,cpp}, resolution-queries.cpp,
modules.rst, ranges,rst, mason.rst,
Errors.chpl, GPUDiagnostics.chpl, LocaleModelHelpSetup.chpl
Subprocess.chpl (and .good file)
