### PR TITLE
Add the missing test for `resetGPUDiagnostics`, comment fixes

### DIFF
--- a/runtime/src/chpl-gpu-diags.c
+++ b/runtime/src/chpl-gpu-diags.c
@@ -97,7 +97,7 @@ void chpl_gpu_startDiagnostics(chpl_bool print_unstable) {
     chpl_internal_error("pthread_once(&bcastPrintUnstable_once) failed");
   }
 
-  // Make sure that there are no pending gpuunication operations.
+  // Make sure that there are no pending GPU operations.
   chpl_rmem_consist_release(0, 0);
 
   chpl_gpu_diagnostics = 1;
@@ -108,7 +108,7 @@ void chpl_gpu_startDiagnostics(chpl_bool print_unstable) {
 
 
 void chpl_gpu_stopDiagnostics() {
-  // Make sure that there are no pending gpuunication operations.
+  // Make sure that there are no pending GPU operations.
   chpl_rmem_consist_release(0, 0);
 
   chpl_gpu_diagnostics = 0;
@@ -121,7 +121,7 @@ void chpl_gpu_stopDiagnostics() {
 void chpl_gpu_startDiagnosticsHere(chpl_bool print_unstable) {
   chpl_gpu_diags_print_unstable = (print_unstable == true);
 
-  // Make sure that there are no pending gpuunication operations.
+  // Make sure that there are no pending GPU operations.
   chpl_rmem_consist_release(0, 0);
 
   chpl_gpu_diagnostics = 1;
@@ -129,7 +129,7 @@ void chpl_gpu_startDiagnosticsHere(chpl_bool print_unstable) {
 
 
 void chpl_gpu_stopDiagnosticsHere() {
-  // Make sure that there are no pending gpuunication operations.
+  // Make sure that there are no pending GPU operations.
   chpl_rmem_consist_release(0, 0);
 
   chpl_gpu_diagnostics = 0;

--- a/test/gpu/native/diags.chpl
+++ b/test/gpu/native/diags.chpl
@@ -27,3 +27,7 @@ writeln("End");
 
 writeln("GPU diagnostics:");
 writeln(getGPUDiagnostics());
+
+resetGPUDiagnostics();
+writeln("GPU diagnostics after reset:");
+writeln(getGPUDiagnostics());

--- a/test/gpu/native/diags.good
+++ b/test/gpu/native/diags.good
@@ -20,3 +20,5 @@ Start
 End
 GPU diagnostics:
 (kernel_launch = 1)
+GPU diagnostics after reset:
+(kernel_launch = 0)


### PR DESCRIPTION
This PR addresses issues pointed out be @cassella:
  https://github.com/chapel-lang/chapel/pull/19941#issuecomment-1147093973

- Expands a test to cover `resetGPUDiagnostics`
- Fixes comments in the runtime