### PR TITLE
Fix performance of list benchmark by making these helpers inlined

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -785,7 +785,7 @@ module AutoMath {
   // To prevent this auto-included module from using a non-auto-included module
   // (Math)
   pragma "no doc"
-  proc chpl_log1p(x: real(64)): real(64) {
+  inline proc chpl_log1p(x: real(64)): real(64) {
     pragma "fn synchronization free"
     extern proc log1p(x: real(64)): real(64);
     return log1p(x);
@@ -869,7 +869,7 @@ module AutoMath {
   }
 
   pragma "no doc"
-  proc chpl_logBasePow2(val: int(?w), baseLog2) {
+  inline proc chpl_logBasePow2(val: int(?w), baseLog2) {
     if (val < 1) {
       halt("Can't take the log() of a non-positive integer");
     }
@@ -877,7 +877,7 @@ module AutoMath {
   }
 
   pragma "no doc"
-  proc chpl_logBasePow2(val: uint(?w), baseLog2) {
+  inline proc chpl_logBasePow2(val: uint(?w), baseLog2) {
     return _logBasePow2Help(val, baseLog2);
   }
 


### PR DESCRIPTION
Accidentally thwarted some optimizations by not making the helpers inlined as
well.

Fix developed by Elliot

Resolves Cray/chapel-private#3419

Saw improvements for InsertFront, Append, and PopFront with
`CHPL_TARGET_CPU=native`.  Passed a full paratest with futures
