### PR TITLE
dyno: Remove unused method to convert string literals

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -167,15 +167,6 @@ struct Converter {
     return FLAG_UNKNOWN;
   }
 
-  const char* astrFromStringLiteral(const uast::AstNode* node) {
-    if (auto strLit = node->toStringLiteral()) {
-      const char* ret = astr(strLit->str());
-      return ret;
-    }
-
-    return nullptr;
-  }
-
   static bool isBlockComment(const uast::Comment* node) {
     const auto& str = node->str();
     if (str.size() < 4) return false;


### PR DESCRIPTION
dyno: Remove unused method to convert string literals (#19951)

Intel compilers are complaining about an unused method in the
converter, so remove it.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>