### PR TITLE
Remove timeMapMinusEqual from GRAPHFILE

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2038,10 +2038,6 @@ time-write:
   01/06/21:
     - Remove lots of inlines in IO.chpl for non-trivial procedures (#16887)
 
-timeMapMinusEqual:
-  07/10/20:
-    - Optimize map -= operation (#16038)
-
 views-forall-iter:
   10/12/17:
     - Switch from these(tag) to foralls for some standalone iters (#7578)

--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -315,7 +315,6 @@ statements/lydia/ifVersusSelect.alternates.graph
 statements/lydia/moduleVersusFunctionBaseline.graph
 statements/lydia/moduleVersusFunctionDifAccess.graph
 statements/lydia/moduleVersusFunction.graph
-library/standard/Map/timeMapMinusEqual.graph
 library/standard/Map/moby-perf.graph
 # suite: - Chapel versus C Comparisons
 patterns/primality/prime.graph


### PR DESCRIPTION
Remove graph reference to removed test from https://github.com/chapel-lang/chapel/pull/19825.

This benchmark was removed because it was using set-like operators on a map, which are ambiguous in their functionality.