### PR TITLE
Add overlooked generation of deprecation warnings for qualified access

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1445,6 +1445,10 @@ static void resolveModuleCall(CallExpr* call) {
 
         if (sym != NULL) {
           if (sym->isVisible(call) == true) {
+            if (sym->hasFlag(FLAG_DEPRECATED)) {
+              sym->generateDeprecationWarning(call);
+            }
+
             if (FnSymbol* fn = toFnSymbol(sym)) {
               if (fn->_this == NULL && fn->hasFlag(FLAG_NO_PARENS) == true) {
                 call->replace(new CallExpr(fn));

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1445,7 +1445,9 @@ static void resolveModuleCall(CallExpr* call) {
 
         if (sym != NULL) {
           if (sym->isVisible(call) == true) {
-            if (sym->hasFlag(FLAG_DEPRECATED)) {
+            if (sym->hasFlag(FLAG_DEPRECATED) && !isFnSymbol(sym)) {
+              // Function symbols will generate a warning during function
+              // resolution, no need to warn here.
               sym->generateDeprecationWarning(call);
             }
 

--- a/test/deprecated-keyword/qualifiedAccess.bad
+++ b/test/deprecated-keyword/qualifiedAccess.bad
@@ -1,4 +1,0 @@
-qualifiedAccess.chpl:7: In function 'main':
-qualifiedAccess.chpl:9: warning: m1.asdf
-1
-1

--- a/test/deprecated-keyword/qualifiedAccess.chpl
+++ b/test/deprecated-keyword/qualifiedAccess.chpl
@@ -1,11 +1,18 @@
 module m1 {
   deprecated "m1.asdf"
   var asdf = 1;
+
+  deprecated "m1.foo"
+  proc foo() {
+    writeln("In foo");
+  }
 }
 module m2 {
   use m1; // same issue if 'import m1'
   proc main {
     writeln(m1.asdf);
     writeln(asdf);
+    m1.foo();
+    foo();
   }
 }

--- a/test/deprecated-keyword/qualifiedAccess.future
+++ b/test/deprecated-keyword/qualifiedAccess.future
@@ -1,2 +1,0 @@
-bug: qualified access suppresses deprecation warning
-#19813

--- a/test/deprecated-keyword/qualifiedAccess.good
+++ b/test/deprecated-keyword/qualifiedAccess.good
@@ -1,5 +1,9 @@
-qualifiedAccess.chpl:7: In function 'main':
-qualifiedAccess.chpl:8: warning: m1.asdf
-qualifiedAccess.chpl:9: warning: m1.asdf
+qualifiedAccess.chpl:12: In function 'main':
+qualifiedAccess.chpl:13: warning: m1.asdf
+qualifiedAccess.chpl:14: warning: m1.asdf
+qualifiedAccess.chpl:15: warning: m1.foo
+qualifiedAccess.chpl:16: warning: m1.foo
 1
 1
+In foo
+In foo


### PR DESCRIPTION
I had accidentally missed checking if a symbol accessed in a qualified manner
was deprecated.  Fix that oversight

Resolves #19813 

Removes the .bad and .future file for the test exercising this bug and extends it
to cover functions (which a naive implementation would cause multiple warnings
to be generated for).

Passed a full paratest with futures.  Double checked build with arkouda but didn't
see anything that looked like it would have been triggered by my change.