### PR TITLE
Deprecate DateTime methods from issue #18846.

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -1071,9 +1071,9 @@ used to recursively hold tables and respective values
         when fieldReal do return val.re:string;
         when fieldString do return ('"' + val.s + '"');
         when fieldEmpty do return ""; // empty
-        when fieldDate do return val.ld.isoformat();
-        when fieldTime do return val.ti.isoformat();
-        when fieldDateTime do return val.dt.isoformat();
+        when fieldDate do return val.ld.isoFormat();
+        when fieldTime do return val.ti.isoFormat();
+        when fieldDateTime do return val.dt.isoFormat();
         otherwise {
           throw new owned TomlError("Error in printing " + val.s);
           return val.s;

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -304,10 +304,7 @@ module DateTime {
   /* The date that is `timestamp` seconds from the epoch */
   deprecated "'date.fromtimestamp()' is deprecated. Please use 'date.fromTimestamp()' instead"
   proc type date.fromtimestamp(timestamp) {
-    const sec = timestamp: int;
-    const us = ((timestamp-sec) * 1000000 + 0.5): int;
-    const td = new timedelta(seconds=sec, microseconds=us);
-    return unixEpoch.getdate() + td;
+    return fromTimestamp(timestamp);
   }
 
   /* The date that is `timestamp` seconds from the epoch */
@@ -321,10 +318,7 @@ module DateTime {
   /* The `date` that is `ord` days from 1-1-0001 */
   deprecated "'date.fromordinal()' is deprecated. Please use 'date.fromOrdinal()' instead"
   proc type date.fromordinal(ord) {
-    if ord < 0 || ord > 1+date.max.toOrdinal() then
-      halt("ordinal (", ord, ") out of range");
-    const (y,m,d) = ordToYmd(ord);
-    return new date(y,m,d);
+    return fromOrdinal(ord);
   }
 
 
@@ -368,7 +362,7 @@ module DateTime {
   /* Return the number of days since 1-1-0001 this `date` represents */
   deprecated "'date.toordinal()' is deprecated. Please use 'date.toOrdinal()' instead"
   proc date.toordinal() {
-    return ymdToOrd(year, month, day);
+    return toOrdinal();
   }
 
   /* Return the number of days since 1-1-0001 this `date` represents */
@@ -697,11 +691,7 @@ module DateTime {
   /* Return the offset from UTC */
   deprecated "'time.utcoffset()' is deprecated. Please use 'time.utcOffset()' instead"
   proc time.utcoffset() {
-    if tzinfo.borrow() == nil {
-      return new timedelta();
-    } else {
-      return tzinfo!.utcOffset(datetime.now());
-    }
+    return utcOffset();
   }
 
   /* Return the offset from UTC */
@@ -1040,17 +1030,7 @@ module DateTime {
   deprecated "'datetime.fromtimestamp()' is deprecated. Please use 'datetime.fromTimestamp()' instead"
   proc type datetime.fromtimestamp(timestamp: real,
                                    in tz: shared TZInfo? = nil) {
-    if tz.borrow() == nil {
-      var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);
-      const lt = getLocalTime(t);
-      return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
-                          day=lt.tm_mday,       hour=lt.tm_hour,
-                          minute=lt.tm_min,     second=lt.tm_sec,
-                          microsecond=t(1));
-    } else {
-      var dt = datetime.utcFromTimestamp(timestamp);
-      return (dt + tz!.utcOffset(dt)).replace(tzinfo=tz);
-    }
+    return fromTimestamp(timestamp, tz);
   }
 
   /* The `datetime` that is `timestamp` seconds from the epoch */
@@ -1073,7 +1053,7 @@ module DateTime {
   /* The `datetime` that is `timestamp` seconds from the epoch in UTC */
   deprecated "'datetime.utcfromtimestamp()' is deprecated. Please use 'datetime.utcFromTimestamp()' instead"
   proc type datetime.utcfromtimestamp(timestamp) {
-    return unixEpoch + new timedelta(seconds=timestamp: int, microseconds=((timestamp-timestamp: int)*1000000): int);
+    return utcFromTimestamp(timestamp);
   }
 
   /* The `datetime` that is `timestamp` seconds from the epoch in UTC */
@@ -1085,7 +1065,7 @@ module DateTime {
   /* The `datetime` that is `ordinal` days from 1-1-0001 */
   deprecated "'datetime.fromordinal()' is deprecated. Please use 'datetime.fromOrdinal()' instead"
   proc type datetime.fromordinal(ordinal) {
-    return datetime.combine(date.fromOrdinal(ordinal), new time());
+    return fromOrdinal(ordinal);
   }
 
   /* The `datetime` that is `ordinal` days from 1-1-0001 */
@@ -1161,11 +1141,7 @@ module DateTime {
   /* Return the offset from UTC */
   deprecated "'datetime.utcoffset()' is deprecated. Please use 'datetime.utcOffset()' instead"
   proc datetime.utcoffset() {
-    if tzinfo.borrow() == nil {
-      halt("utcoffset called on naive datetime");
-    } else {
-      return tzinfo!.utcoffset(this);
-    }
+    return utcOffset();
   }
 
   /* Return the offset from UTC */
@@ -1233,7 +1209,7 @@ module DateTime {
   /* Return the number of days since 1-1-0001 this `datetime` represents */
   deprecated "'datetime.toordinal()' is deprecated. Please use 'datetime.toOrdinal()' instead"
   proc datetime.toordinal() {
-    return getdate().toOrdinal();
+    return toOrdinal();
   }
 
   /* Return the number of days since 1-1-0001 this `datetime` represents */

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -302,6 +302,7 @@ module DateTime {
   }
 
   /* The date that is `timestamp` seconds from the epoch */
+  deprecated "'date.fromtimestamp()' is deprecated. Please use 'date.fromTimestamp()' instead"
   proc type date.fromtimestamp(timestamp) {
     const sec = timestamp: int;
     const us = ((timestamp-sec) * 1000000 + 0.5): int;
@@ -309,9 +310,27 @@ module DateTime {
     return unixEpoch.getdate() + td;
   }
 
+  /* The date that is `timestamp` seconds from the epoch */
+  proc type date.fromTimestamp(timestamp) {
+    const sec = timestamp: int;
+    const us = ((timestamp-sec) * 1000000 + 0.5): int;
+    const td = new timedelta(seconds=sec, microseconds=us);
+    return unixEpoch.getdate() + td;
+  }
+
   /* The `date` that is `ord` days from 1-1-0001 */
+  deprecated "'date.fromordinal()' is deprecated. Please use 'date.fromOrdinal()' instead"
   proc type date.fromordinal(ord) {
-    if ord < 0 || ord > 1+date.max.toordinal() then
+    if ord < 0 || ord > 1+date.max.toOrdinal() then
+      halt("ordinal (", ord, ") out of range");
+    const (y,m,d) = ordToYmd(ord);
+    return new date(y,m,d);
+  }
+
+
+  /* The `date` that is `ord` days from 1-1-0001 */
+  proc type date.fromOrdinal(ord) {
+    if ord < 0 || ord > 1+date.max.toOrdinal() then
       halt("ordinal (", ord, ") out of range");
     const (y,m,d) = ordToYmd(ord);
     return new date(y,m,d);
@@ -341,13 +360,19 @@ module DateTime {
     timeStruct.tm_mon = month: int(32);
     timeStruct.tm_year = year: int(32);
     timeStruct.tm_wday = weekday(): int(32);
-    timeStruct.tm_yday = (toordinal() - (new date(year, 1, 1)).toordinal() + 1): int(32);
+    timeStruct.tm_yday = (toOrdinal() - (new date(year, 1, 1)).toOrdinal() + 1): int(32);
     timeStruct.tm_isdst = (-1): int(32);
     return timeStruct;
   }
 
   /* Return the number of days since 1-1-0001 this `date` represents */
+  deprecated "'date.toordinal()' is deprecated. Please use 'date.toOrdinal()' instead"
   proc date.toordinal() {
+    return ymdToOrd(year, month, day);
+  }
+
+  /* Return the number of days since 1-1-0001 this `date` represents */
+  proc date.toOrdinal() {
     return ymdToOrd(year, month, day);
   }
 
@@ -356,19 +381,34 @@ module DateTime {
    */
   proc date.weekday() {
     // January 1 0001 is a Monday
-    return try! ((toordinal() + 6) % 7): DayOfWeek;
+    return try! ((toOrdinal() + 6) % 7): DayOfWeek;
   }
 
   /* Return the day of the week as an `ISODayOfWeek`.
      `Monday` == 1, `Sunday` == 7 */
+  deprecated "'date.isoweekday()' is deprecated. Please use 'date.isoWeekday() instead"
   proc date.isoweekday() {
+    return isoWeekday();
+  }
+
+  /* Return the day of the week as an `ISODayOfWeek`.
+     `Monday` == 1, `Sunday` == 7 */
+  proc date.isoWeekday() {
     return try! (weekday(): int + 1): ISODayOfWeek;
   }
 
   /* Return the ISO date as a tuple containing the ISO year, ISO week number,
      and ISO day of the week
    */
+  deprecated "'date.isocalendar()' is deprecated. Please use 'date.isoCalendar()' instead"
   proc date.isocalendar() {
+    return isoCalendar();
+  }
+
+  /* Return the ISO date as a tuple containing the ISO year, ISO week number,
+     and ISO day of the week
+   */
+  proc date.isoCalendar() {
     proc findThursday(d: date) {
       var wd = d.weekday();
       return d + new timedelta(days = (DayOfWeek.Thursday:int - wd:int));
@@ -391,11 +431,17 @@ module DateTime {
     const firstDay = findFirstDayOfYear(y);
     const delta = this - firstDay;
 
-    return (y, 1+delta.days/7, isoweekday(): int);
+    return (y, 1+delta.days/7, isoWeekday(): int);
   }
 
   /* Return the date as a `string` in ISO 8601 format: "YYYY-MM-DD" */
+  deprecated "'date.isoformat()' is deprecated. Please use 'date.isoFormat()' instead"
   proc date.isoformat() {
+    return isoFormat();
+  }
+
+  /* Return the date as a `string` in ISO 8601 format: "YYYY-MM-DD" */
+  proc date.isoFormat() {
     var yearstr = year: string;
     var monthstr = month: string;
     var daystr = day: string;
@@ -461,7 +507,7 @@ module DateTime {
 
     if f.writing {
       try! {
-        f.write(isoformat());
+        f.write(isoFormat());
       }
     } else {
       const binary = f.binary(),
@@ -482,7 +528,7 @@ module DateTime {
   /* Operators on date values */
   pragma "no doc"
   operator date.+(d: date, t: timedelta): date {
-    return date.fromordinal(d.toordinal() + t.days);
+    return date.fromOrdinal(d.toOrdinal() + t.days);
   }
 
   pragma "no doc"
@@ -492,32 +538,32 @@ module DateTime {
 
   pragma "no doc"
   operator date.-(d: date, t: timedelta): date {
-    return date.fromordinal(d.toordinal() - t.days);
+    return date.fromOrdinal(d.toOrdinal() - t.days);
   }
 
   pragma "no doc"
   operator date.-(d1: date, d2: date): timedelta {
-    return new timedelta(days=d1.toordinal() - d2.toordinal());
+    return new timedelta(days=d1.toOrdinal() - d2.toOrdinal());
   }
 
   pragma "no doc"
   operator date.<(d1: date, d2: date) {
-    return d1.toordinal() < d2.toordinal();
+    return d1.toOrdinal() < d2.toOrdinal();
   }
 
   pragma "no doc"
   operator date.<=(d1: date, d2: date) {
-    return d1.toordinal() <= d2.toordinal();
+    return d1.toOrdinal() <= d2.toOrdinal();
   }
 
   pragma "no doc"
   operator date.>(d1: date, d2: date) {
-    return d1.toordinal() > d2.toordinal();
+    return d1.toOrdinal() > d2.toOrdinal();
   }
 
   pragma "no doc"
   operator date.>=(d1: date, d2: date) {
-    return d1.toordinal() >= d2.toordinal();
+    return d1.toOrdinal() >= d2.toOrdinal();
   }
 
 
@@ -627,7 +673,7 @@ module DateTime {
     if microsecond != 0 {
       ret = ret + "." + makeNDigits(6, microsecond);
     }
-    var offset = utcoffset();
+    var offset = utcOffset();
     if tzinfo.borrow() != nil {
       var sign: string;
       if offset.days < 0 {
@@ -643,11 +689,21 @@ module DateTime {
   }
 
   /* Return the offset from UTC */
+  deprecated "'time.utcoffset()' is deprecated. Please use 'time.utcOffset()' instead"
   proc time.utcoffset() {
     if tzinfo.borrow() == nil {
       return new timedelta();
     } else {
-      return tzinfo!.utcoffset(datetime.now());
+      return tzinfo!.utcOffset(datetime.now());
+    }
+  }
+
+  /* Return the offset from UTC */
+  proc time.utcOffset() {
+    if tzinfo.borrow() == nil {
+      return new timedelta();
+    } else {
+      return tzinfo!.utcOffset(datetime.now());
     }
   }
 
@@ -686,7 +742,7 @@ module DateTime {
     timeStruct.tm_yday = 0;
 
     if tzinfo.borrow() != nil {
-      timeStruct.tm_gmtoff = abs(utcoffset()).seconds: c_long;
+      timeStruct.tm_gmtoff = abs(utcOffset()).seconds: c_long;
       timeStruct.tm_zone = __primitive("cast", tm_zoneType, tzname().c_str());
       timeStruct.tm_isdst = dst().seconds: int(32);
     } else {
@@ -775,8 +831,8 @@ module DateTime {
       const dt1 = datetime.combine(new date(1900, 1, 1), t1);
       const dt2 = datetime.combine(new date(1900, 1, 1), t2);
       return dt1 < dt2;
-      //return (t1.replace(tzinfo=nil) - t1.utcoffset()) <
-      //       (t2.replace(tzinfo=nil) - t2.utcoffset());
+      //return (t1.replace(tzinfo=nil) - t1.utcOffset()) <
+      //       (t2.replace(tzinfo=nil) - t2.utcOffset());
     }
   }
 
@@ -955,19 +1011,27 @@ module DateTime {
                                microseconds=timeSinceEpoch(1));
       const utcNow = unixEpoch + td;
 
-      return (utcNow + tz!.utcoffset(utcNow)).replace(tzinfo=tz);
+      return (utcNow + tz!.utcOffset(utcNow)).replace(tzinfo=tz);
     }
   }
 
   /* Return a `datetime` value representing the current time and date in UTC */
+  deprecated "'datetime.utcnow()' is deprecated. Please use 'datetime.utcNow()' instead"
   proc type datetime.utcnow() {
+    return utcNow();
+  }
+
+  /* Return a `datetime` value representing the current time and date in UTC */
+  proc type datetime.utcNow() {
     const timeSinceEpoch = getTimeOfDay();
     const td = new timedelta(seconds=timeSinceEpoch(0),
                              microseconds=timeSinceEpoch(1));
     return unixEpoch + td;
   }
 
+
   /* The `datetime` that is `timestamp` seconds from the epoch */
+  deprecated "'datetime.fromtimestamp()' is deprecated. Please use 'datetime.fromTimestamp()' instead"
   proc type datetime.fromtimestamp(timestamp: real,
                                    in tz: shared TZInfo? = nil) {
     if tz.borrow() == nil {
@@ -978,19 +1042,49 @@ module DateTime {
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=t(1));
     } else {
-      var dt = datetime.utcfromtimestamp(timestamp);
-      return (dt + tz!.utcoffset(dt)).replace(tzinfo=tz);
+      var dt = datetime.utcFromTimestamp(timestamp);
+      return (dt + tz!.utcOffset(dt)).replace(tzinfo=tz);
     }
   }
 
+  /* The `datetime` that is `timestamp` seconds from the epoch */
+  proc type datetime.fromTimestamp(timestamp: real,
+                                   in tz: shared TZInfo? = nil) {
+    if tz.borrow() == nil {
+      var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);
+      const lt = getLocalTime(t);
+      return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+                          day=lt.tm_mday,       hour=lt.tm_hour,
+                          minute=lt.tm_min,     second=lt.tm_sec,
+                          microsecond=t(1));
+    } else {
+      var dt = datetime.utcFromTimestamp(timestamp);
+      return (dt + tz!.utcOffset(dt)).replace(tzinfo=tz);
+    }
+  }
+
+
   /* The `datetime` that is `timestamp` seconds from the epoch in UTC */
+  deprecated "'datetime.utcfromtimestamp()' is deprecated. Please use 'datetime.utcFromTimestamp()' instead"
   proc type datetime.utcfromtimestamp(timestamp) {
     return unixEpoch + new timedelta(seconds=timestamp: int, microseconds=((timestamp-timestamp: int)*1000000): int);
   }
 
+  /* The `datetime` that is `timestamp` seconds from the epoch in UTC */
+  proc type datetime.utcFromTimestamp(timestamp) {
+    return unixEpoch + new timedelta(seconds=timestamp: int, microseconds=((timestamp-timestamp: int)*1000000): int);
+  }
+
+
   /* The `datetime` that is `ordinal` days from 1-1-0001 */
+  deprecated "'datetime.fromordinal()' is deprecated. Please use 'datetime.fromOrdinal()' instead"
   proc type datetime.fromordinal(ordinal) {
-    return datetime.combine(date.fromordinal(ordinal), new time());
+    return datetime.combine(date.fromOrdinal(ordinal), new time());
+  }
+
+  /* The `datetime` that is `ordinal` days from 1-1-0001 */
+  proc type datetime.fromOrdinal(ordinal) {
+    return datetime.combine(date.fromOrdinal(ordinal), new time());
   }
 
   /* Form a `datetime` value from a given `date` and `time` */
@@ -1054,11 +1148,12 @@ module DateTime {
     if tzinfo == tz {
       return this;
     }
-    const utc = (this - this.utcoffset()).replace(tzinfo=tz);
-    return tz.borrow().fromutc(utc);
+    const utc = (this - this.utcOffset()).replace(tzinfo=tz);
+    return tz.borrow().fromUtc(utc);
   }
 
   /* Return the offset from UTC */
+  deprecated "'datetime.utcoffset()' is deprecated. Please use 'datetime.utcOffset()' instead"
   proc datetime.utcoffset() {
     if tzinfo.borrow() == nil {
       halt("utcoffset called on naive datetime");
@@ -1067,6 +1162,14 @@ module DateTime {
     }
   }
 
+  /* Return the offset from UTC */
+  proc datetime.utcOffset() {
+    if tzinfo.borrow() == nil {
+      halt("utcOffset called on naive datetime");
+    } else {
+      return tzinfo!.utcOffset(this);
+    }
+  }
   /* Return the daylight saving time offset */
   proc datetime.dst() {
     if tzinfo.borrow() == nil then
@@ -1092,7 +1195,7 @@ module DateTime {
     timeStruct.tm_mon = month: int(32);
     timeStruct.tm_year = year: int(32);
     timeStruct.tm_wday = weekday(): int(32);
-    timeStruct.tm_yday = (toordinal() - (new date(year, 1, 1)).toordinal() + 1): int(32);
+    timeStruct.tm_yday = (toOrdinal() - (new date(year, 1, 1)).toOrdinal() + 1): int(32);
 
     if tzinfo.borrow() == nil {
       timeStruct.tm_isdst = -1;
@@ -1114,7 +1217,7 @@ module DateTime {
       ret.tm_isdst = 0;
       return ret;
     } else {
-      const utc = this.replace(tzinfo=nil) - utcoffset();
+      const utc = this.replace(tzinfo=nil) - utcOffset();
       var ret = utc.timetuple();
       ret.tm_isdst = 0;
       return ret;
@@ -1122,8 +1225,14 @@ module DateTime {
   }
 
   /* Return the number of days since 1-1-0001 this `datetime` represents */
+  deprecated "'datetime.toordinal()' is deprecated. Please use 'datetime.toOrdinal()' instead"
   proc datetime.toordinal() {
-    return getdate().toordinal();
+    return getdate().toOrdinal();
+  }
+
+  /* Return the number of days since 1-1-0001 this `datetime` represents */
+  proc datetime.toOrdinal() {
+    return getdate().toOrdinal();
   }
 
   /* Return the day of the week as a `DayOfWeek`.
@@ -1159,7 +1268,7 @@ module DateTime {
     var micro = if microsecond > 0 then "." + zeroPad(6, microsecond) else "";
     var offset: string;
     if tzinfo.borrow() != nil {
-      var utcoff = utcoffset();
+      var utcoff = utcOffset();
       var sign: string;
       if utcoff < new timedelta(0) {
         sign = '-';
@@ -1210,7 +1319,7 @@ module DateTime {
 
     if tzinfo.borrow() != nil {
       timeStruct.tm_isdst = tzinfo!.dst(this).seconds: int(32);
-      timeStruct.tm_gmtoff = tzinfo!.utcoffset(this).seconds: c_long;
+      timeStruct.tm_gmtoff = tzinfo!.utcOffset(this).seconds: c_long;
       timeStruct.tm_zone = nil;
     } else {
       timeStruct.tm_isdst = -1: int(32);
@@ -1326,7 +1435,7 @@ module DateTime {
     var adddays = td.days + newhour / 24;
     newhour %= 24;
 
-    return datetime.combine(date.fromordinal(dt.getdate().toordinal()+adddays),
+    return datetime.combine(date.fromOrdinal(dt.getdate().toOrdinal()+adddays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tzinfo=dt.tzinfo));
@@ -1367,7 +1476,7 @@ module DateTime {
       subDays += 1;
       newhour += 24;
     }
-    return datetime.combine(date.fromordinal(dt.getdate().toordinal()-subDays),
+    return datetime.combine(date.fromOrdinal(dt.getdate().toOrdinal()-subDays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tzinfo=dt.tzinfo));
@@ -1384,13 +1493,13 @@ module DateTime {
             newsec = dt1.second - dt2.second,
             newmin = dt1.minute - dt2.minute,
             newhour = dt1.hour - dt2.hour,
-            newday = dt1.toordinal() - dt2.toordinal();
+            newday = dt1.toOrdinal() - dt2.toOrdinal();
       return new timedelta(days=newday, hours=newhour, minutes=newmin,
                            seconds=newsec, microseconds=newmicro);
     } else {
       return dt1.replace(tzinfo=nil) -
                                 dt2.replace(tzinfo=nil) +
-                                dt2.utcoffset() - dt1.utcoffset();
+                                dt2.utcOffset() - dt1.utcOffset();
     }
   }
 
@@ -1419,8 +1528,8 @@ module DateTime {
                         t1.second == t2.second &&
                         t1.microsecond == t2.microsecond;
     } else {
-      return (dt1.replace(tzinfo=nil) - dt1.utcoffset()) ==
-             (dt2.replace(tzinfo=nil) - dt2.utcoffset());
+      return (dt1.replace(tzinfo=nil) - dt1.utcOffset()) ==
+             (dt2.replace(tzinfo=nil) - dt2.utcOffset());
     }
   }
 
@@ -1441,8 +1550,8 @@ module DateTime {
       else if date2 < date1 then return false;
       else return dt1.gettime() < dt2.gettime();
     } else {
-      return (dt1.replace(tzinfo=nil) - dt1.utcoffset()) <
-             (dt2.replace(tzinfo=nil) - dt2.utcoffset());
+      return (dt1.replace(tzinfo=nil) - dt1.utcOffset()) <
+             (dt2.replace(tzinfo=nil) - dt2.utcOffset());
     }
   }
 
@@ -1458,8 +1567,8 @@ module DateTime {
       else if date2 < date1 then return false;
       else return dt1.gettime() <= dt2.gettime();
     } else {
-      return (dt1.replace(tzinfo=nil) - dt1.utcoffset()) <=
-             (dt2.replace(tzinfo=nil) - dt2.utcoffset());
+      return (dt1.replace(tzinfo=nil) - dt1.utcOffset()) <=
+             (dt2.replace(tzinfo=nil) - dt2.utcOffset());
     }
   }
 
@@ -1475,8 +1584,8 @@ module DateTime {
       else if date2 > date1 then return false;
       else return dt1.gettime() > dt2.gettime();
     } else {
-      return (dt1.replace(tzinfo=nil) - dt1.utcoffset()) >
-             (dt2.replace(tzinfo=nil) - dt2.utcoffset());
+      return (dt1.replace(tzinfo=nil) - dt1.utcOffset()) >
+             (dt2.replace(tzinfo=nil) - dt2.utcOffset());
     }
   }
 
@@ -1492,8 +1601,8 @@ module DateTime {
       else if date2 > date1 then return false;
       else return dt1.gettime() >= dt2.gettime();
     } else {
-      return (dt1.replace(tzinfo=nil) - dt1.utcoffset()) >=
-             (dt2.replace(tzinfo=nil) - dt2.utcoffset());
+      return (dt1.replace(tzinfo=nil) - dt1.utcOffset()) >=
+             (dt2.replace(tzinfo=nil) - dt2.utcOffset());
     }
   }
 
@@ -1744,7 +1853,14 @@ module DateTime {
      derived from it. */
   class TZInfo {
     /* The offset from UTC this class represents */
+    deprecated "'TZInfo.utcoffset()' is deprecated. Please use 'TZInfo.utcOffset()' instead"
     proc utcoffset(dt: datetime): timedelta {
+      HaltWrappers.pureVirtualMethodHalt();
+      return new timedelta();
+    }
+
+    /* The offset from UTC this class represents */
+    proc utcOffset(dt: datetime): timedelta {
       HaltWrappers.pureVirtualMethodHalt();
       return new timedelta();
     }
@@ -1762,10 +1878,18 @@ module DateTime {
     }
 
     /* Convert a `time` in UTC to this time zone */
+    deprecated "'TZInfo.fromutc()' is deprecated. Please use 'TZInfo.fromUtc()' instead"
     proc fromutc(dt: datetime): datetime {
       HaltWrappers.pureVirtualMethodHalt();
       return new datetime(0,0,0);
     }
+
+    /* Convert a `time` in UTC to this time zone */
+    proc fromUtc(dt: datetime): datetime {
+      HaltWrappers.pureVirtualMethodHalt();
+      return new datetime(0,0,0);
+    }
+
   }
 
   // TODO: Add a timezone class implementation

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -657,7 +657,13 @@ module DateTime {
   }
 
   /* Return a `string` representing the `time` in ISO format */
+  deprecated "'time.isoformat()' is deprecated. Please use 'time.isoFormat()' instead"
   proc time.isoformat() {
+    return isoFormat();
+  }
+
+  /* Return a `string` representing the `time` in ISO format */
+  proc time.isoFormat() {
     proc makeNDigits(n, d) {
       var ret = d: string;
       while ret.size < n {
@@ -765,7 +771,7 @@ module DateTime {
     const colon = new ioLiteral(":");
     if f.writing {
       try! {
-        f.write(isoformat());
+        f.write(isoFormat());
       }
     } else {
       const binary = f.binary(),
@@ -1257,7 +1263,13 @@ module DateTime {
   }
 
   /* Return the `datetime` as a `string` in ISO format */
+  deprecated "'datetime.isoformat()' is deprecated. Please use 'datetime.isoFormat()' instead"
   proc datetime.isoformat(sep="T") {
+    return isoFormat(sep);
+  }
+
+  /* Return the `datetime` as a `string` in ISO format */
+  proc datetime.isoFormat(sep="T") {
     proc zeroPad(nDigits: int, i: int) {
       var numStr = i: string;
       for i in 1..nDigits-numStr.size {
@@ -1390,7 +1402,7 @@ module DateTime {
 
     if f.writing {
       try! {
-        f.write(isoformat());
+        f.write(isoFormat());
       }
     } else {
       const binary = f.binary(),

--- a/test/deprecated/renameDateTimeMethods.chpl
+++ b/test/deprecated/renameDateTimeMethods.chpl
@@ -1,0 +1,27 @@
+use DateTime;
+
+// deprecaed methods
+var d = new date(2022, 6, 6);
+
+writeln(d.isoweekday());
+writeln(d.isocalendar());
+writeln(d.isoformat());
+writeln(d.toordinal());
+
+var t = new time(12, 0,0);
+
+writeln(t.utcoffset());
+
+var dt = new datetime(2022, 6, 6, 12, 0, 0);
+writeln(dt.toordinal());
+
+// deprecated type methods
+writeln(date.fromordinal(9999));
+writeln(datetime.fromordinal(9999));
+
+var uNow = datetime.utcNow();
+writeln(date.fromtimestamp(9999.0));
+writeln(datetime.fromtimestamp(9999.0));
+
+var zone = new TZInfo();
+writeln(zone.fromutc(dt)); // Halts

--- a/test/deprecated/renameDateTimeMethods.good
+++ b/test/deprecated/renameDateTimeMethods.good
@@ -1,0 +1,22 @@
+renameDateTimeMethods.chpl:6: warning: 'date.isoweekday()' is deprecated. Please use 'date.isoWeekday() instead
+renameDateTimeMethods.chpl:7: warning: 'date.isocalendar()' is deprecated. Please use 'date.isoCalendar()' instead
+renameDateTimeMethods.chpl:8: warning: 'date.isoformat()' is deprecated. Please use 'date.isoFormat()' instead
+renameDateTimeMethods.chpl:9: warning: 'date.toordinal()' is deprecated. Please use 'date.toOrdinal()' instead
+renameDateTimeMethods.chpl:13: warning: 'time.utcoffset()' is deprecated. Please use 'time.utcOffset()' instead
+renameDateTimeMethods.chpl:16: warning: 'datetime.toordinal()' is deprecated. Please use 'datetime.toOrdinal()' instead
+renameDateTimeMethods.chpl:19: warning: 'date.fromordinal()' is deprecated. Please use 'date.fromOrdinal()' instead
+renameDateTimeMethods.chpl:20: warning: 'datetime.fromordinal()' is deprecated. Please use 'datetime.fromOrdinal()' instead
+renameDateTimeMethods.chpl:23: warning: 'date.fromtimestamp()' is deprecated. Please use 'date.fromTimestamp()' instead
+renameDateTimeMethods.chpl:24: warning: 'datetime.fromtimestamp()' is deprecated. Please use 'datetime.fromTimestamp()' instead
+renameDateTimeMethods.chpl:27: warning: 'TZInfo.fromutc()' is deprecated. Please use 'TZInfo.fromUtc()' instead
+Monday
+(2022, 23, 1)
+2022-06-06
+738312
+(chpl_days = 0, chpl_seconds = 0, chpl_microseconds = 0)
+738312
+0028-05-17
+0028-05-17T00:00:00
+1970-01-01
+1969-12-31T20:46:39
+renameDateTimeMethods.chpl:27: error: halt reached - pure virtual method called

--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -51,7 +51,7 @@ module CheckHttpSetOpt {
     curl_easy_getinfo(getCurlHandle(urlreader), CURLINFO_FILETIME,
 		      c_ptrTo(time));
 
-    writeln("Remote Time ", datetime.utcfromtimestamp(time));
+    writeln("Remote Time ", datetime.utcFromTimestamp(time));
 
     stderr.flush();
     stdout.flush();

--- a/test/library/standard/DateTime/testDate.chpl
+++ b/test/library/standard/DateTime/testDate.chpl
@@ -40,36 +40,36 @@ proc test_date_ordinal_conversions() {
                     (2,1,1,366),
                     (1945,11,12,710347)] {
     var d1 = new date(y, m, d);
-    assert(n == d1.toordinal());
-    var fromord = date.fromordinal(n);
+    assert(n == d1.toOrdinal());
+    var fromord = date.fromOrdinal(n);
     assert(d1 == fromord);
   }
 
   for year in MINYEAR..MAXYEAR by 7 {
     var d = new date(year, 1, 1);
-    var n = d.toordinal();
-    var d2 = date.fromordinal(n);
+    var n = d.toOrdinal();
+    var d2 = date.fromOrdinal(n);
     assert(d == d2);
 
     if year > 1 {
-      d = date.fromordinal(n-1);
+      d = date.fromOrdinal(n-1);
       d2 = new date(year-1, 12, 31);
       assert(d == d2);
-      assert(d2.toordinal() == n-1);
+      assert(d2.toOrdinal() == n-1);
     }
   }
 
   var dim = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
   for (year, isleap) in [(2000, true), (2002, false)] {
-    var n = (new date(year, 1, 1)).toordinal();
+    var n = (new date(year, 1, 1)).toOrdinal();
     for (month, maxday) in zip (1..12, dim) {
       var md = maxday;
       if month == 2 && isleap then
         md += 1;
       for day in 1..md {
         var d = new date(year, month, day);
-        assert(d.toordinal() == n);
-        assert(d == date.fromordinal(n));
+        assert(d.toOrdinal() == n);
+        assert(d == date.fromOrdinal(n));
         n += 1;
       }
     }
@@ -78,22 +78,22 @@ proc test_date_ordinal_conversions() {
 
 proc test_date_extreme_ordinals() {
   var a = date.min;
-  var aord = a.toordinal();
-  var b = date.fromordinal(aord);
+  var aord = a.toOrdinal();
+  var b = date.fromOrdinal(aord);
   assert(a == b);
 
   b = a + new timedelta(days=1);
-  assert(b.toordinal() == aord + 1);
-  assert(b == date.fromordinal(aord+1));
+  assert(b.toOrdinal() == aord + 1);
+  assert(b == date.fromOrdinal(aord+1));
 
   a = date.max;
-  aord = a.toordinal();
-  b = date.fromordinal(aord);
+  aord = a.toOrdinal();
+  b = date.fromOrdinal(aord);
   assert(a == b);
 
   b = a - new timedelta(days=1);
-  assert(b.toordinal() == aord - 1);
-  assert(b == date.fromordinal(aord - 1));
+  assert(b.toOrdinal() == aord - 1);
+  assert(b == date.fromOrdinal(aord - 1));
 }
 
 proc test_date_computations() {
@@ -133,7 +133,7 @@ proc test_date_fromtimestamp() {
   var delta = d1 - unixEpoch.getdate();
   var ts = delta.days * 60 * 60 * 24 + delta.seconds;
 
-  var d = date.fromtimestamp(ts);
+  var d = date.fromTimestamp(ts);
   assert(d.year == year);
   assert(d.month == month);
   assert(d.day == day);
@@ -145,7 +145,7 @@ proc test_date_today() {
     tday = date.today();
     var delta = tday - unixEpoch.getdate();
     var ts = delta.days * 60 * 60 * 24 + delta.seconds;
-    tdayAgain = date.fromtimestamp(ts);
+    tdayAgain = date.fromTimestamp(ts);
     if tday == tdayAgain then
       break;
   }
@@ -155,26 +155,26 @@ proc test_date_today() {
 proc test_date_weekday() {
   for i in 0..#7 {
     assert((new date(2002, 3, 4+i)).weekday(): int == i);
-    assert((new date(2002, 3, 4+i)).isoweekday(): int == i+1);
+    assert((new date(2002, 3, 4+i)).isoWeekday(): int == i+1);
     assert((new date(1956, 1, 2+i)).weekday(): int == i);
-    assert((new date(1956, 1, 2+i)).isoweekday(): int == i+1);
+    assert((new date(1956, 1, 2+i)).isoWeekday(): int == i+1);
   }
 }
 
 proc test_date_isocalendar() {
   for i in 0..#7 {
     var d = new date(2003, 12, 22+i);
-    assert(d.isocalendar() == (2003, 52, i+1));
+    assert(d.isoCalendar() == (2003, 52, i+1));
     d = new date(2003, 12, 29) + new timedelta(i);
-    assert(d.isocalendar() == (2004, 1, i+1));
+    assert(d.isoCalendar() == (2004, 1, i+1));
     d = new date(2004, 1, 5+i);
-    assert(d.isocalendar() == (2004, 2, i+1));
+    assert(d.isoCalendar() == (2004, 2, i+1));
     d = new date(2009, 12, 21+i);
-    assert(d.isocalendar() == (2009, 52, i+1));
+    assert(d.isoCalendar() == (2009, 52, i+1));
     d = new date(2009, 12, 28) + new timedelta(i);
-    assert(d.isocalendar() == (2009, 53, i+1));
+    assert(d.isoCalendar() == (2009, 53, i+1));
     d = new date(2010, 1, 4+i);
-    assert(d.isocalendar() == (2010, 1, i+1));
+    assert(d.isoCalendar() == (2010, 1, i+1));
   }
 }
 
@@ -194,9 +194,9 @@ proc test_date_iso_long_years() {
   for i in 0..#400 {
     var d = new date(2000+i, 12, 31);
     var d1 = new date(1600+i, 12, 31);
-    assert(d.isocalendar()(1) == d1.isocalendar()(1) &&
-           d.isocalendar()(2) == d1.isocalendar()(2));
-    if d.isocalendar()(1) == 53 then
+    assert(d.isoCalendar()(1) == d1.isoCalendar()(1) &&
+           d.isoCalendar()(2) == d1.isoCalendar()(2));
+    if d.isoCalendar()(1) == 53 then
       L.append(i);
   }
 
@@ -208,7 +208,7 @@ proc test_date_iso_long_years() {
 
 proc test_date_isoformat() {
   var t = new date(2, 3, 2);
-  assert(t.isoformat() == "0002-03-02");
+  assert(t.isoFormat() == "0002-03-02");
 }
 
 proc test_date_ctime() {

--- a/test/library/standard/DateTime/testDatetime.chpl
+++ b/test/library/standard/DateTime/testDatetime.chpl
@@ -26,16 +26,16 @@ proc test_basic_attributes_nonzero() {
 
 proc test_isoformat() {
   var t = new datetime(2, 3, 2, 4, 5, 1, 123);
-  assert(t.isoformat() == "0002-03-02T04:05:01.000123");
-  assert(t.isoformat('T') == "0002-03-02T04:05:01.000123");
-  assert(t.isoformat(' ') == "0002-03-02 04:05:01.000123");
+  assert(t.isoFormat() == "0002-03-02T04:05:01.000123");
+  assert(t.isoFormat('T') == "0002-03-02T04:05:01.000123");
+  assert(t.isoFormat(' ') == "0002-03-02 04:05:01.000123");
   // str is ISO format with the separator forced to a blank.
   //assert(str(t) == "0002-03-02 04:05:01.000123");
 
   t = new datetime(2, 3, 2);
-  assert(t.isoformat() == "0002-03-02T00:00:00");
-  assert(t.isoformat('T') == "0002-03-02T00:00:00");
-  assert(t.isoformat(' ') == "0002-03-02 00:00:00");
+  assert(t.isoFormat() == "0002-03-02T00:00:00");
+  assert(t.isoFormat('T') == "0002-03-02T00:00:00");
+  assert(t.isoFormat(' ') == "0002-03-02 00:00:00");
   // str is ISO format with the separator forced to a blank.
   //assert(str(t) == "0002-03-02 00:00:00");
 }
@@ -178,8 +178,8 @@ proc test_more_timetuple() {
   assert(tt.tm_min == t.minute);
   assert(tt.tm_sec == t.second);
   assert(tt.tm_wday == t.weekday(): int(32));
-  assert(tt.tm_yday == t.toordinal() -
-                       (new date(t.year, 1, 1)).toordinal() + 1);
+  assert(tt.tm_yday == t.toOrdinal() -
+                       (new date(t.year, 1, 1)).toOrdinal() + 1);
   assert(tt.tm_isdst == -1);
 }
 

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -15,7 +15,7 @@ class FixedOffset: TZInfo {
     this.dstoffset = new timedelta(minutes=dstoffset);
   }
 
-  override proc utcoffset(dt: datetime) {
+  override proc utcOffset(dt: datetime) {
     return offset;
   }
   override proc tzname(dt: datetime) {
@@ -24,8 +24,8 @@ class FixedOffset: TZInfo {
   override proc dst(dt: datetime) {
     return dstoffset;
   }
-  override proc fromutc(dt: datetime) {
-    var dtoff = dt.utcoffset();
+  override proc fromUtc(dt: datetime) {
+    var dtoff = dt.utcOffset();
     var dtdst = dt.dst();
     var delta = dtoff - dtdst;
     var dt2 = dt + delta;
@@ -102,9 +102,9 @@ proc test_zones() {
   assert(t1.tzinfo == est);
   assert(t2.tzinfo == utc);
   assert(t3.tzinfo == met);
-  assert(t1.utcoffset() == new timedelta(minutes=-300));
-  assert(t2.utcoffset() == new timedelta(minutes=0));
-  assert(t3.utcoffset() == new timedelta(minutes=60));
+  assert(t1.utcOffset() == new timedelta(minutes=-300));
+  assert(t2.utcOffset() == new timedelta(minutes=0));
+  assert(t3.utcOffset() == new timedelta(minutes=60));
   assert(t1.tzname() == "EST");
   assert(t2.tzname() == "UTC");
   assert(t3.tzname() == "MET");
@@ -173,7 +173,7 @@ proc test_tz_aware_arithmetic() {
   //            (nowaware base - nowawareplus base) +
   //            (nowawareplus offset - nowaware offset) =
   //            -delta + nowawareplus offset - nowaware offset
-  var expected = nowawareplus.utcoffset() - nowaware.utcoffset() - delta;
+  var expected = nowawareplus.utcOffset() - nowaware.utcOffset() - delta;
   assert(got == expected);
 
   // Try max possible difference.
@@ -194,7 +194,7 @@ proc test_tzinfo_now() {
   var another = datetime.now(off42);
   var again = datetime.now(tz=off42);
   assert(another.tzinfo == again.tzinfo);
-  assert(another.utcoffset() == new timedelta(minutes=42));
+  assert(another.utcOffset() == new timedelta(minutes=42));
 
   // We don't know which time zone we're in, and don't have a tzinfo
   // class to represent it, so seeing whether a tz argument actually
@@ -205,7 +205,7 @@ proc test_tzinfo_now() {
   for 0..2 {
     var now = datetime.now(weirdtz);
     assert(now.tzinfo == weirdtz);
-    var utcnow = datetime.utcnow().replace(tzinfo=utc);
+    var utcnow = datetime.utcNow().replace(tzinfo=utc);
     var now2 = utcnow.astimezone(weirdtz);
     if abs(now - now2) < new timedelta(seconds=30) {
       break;
@@ -234,17 +234,17 @@ proc test_tzinfo_fromtimestamp() {
 
   var ts = getTimeOfDay()(1);
   // Ensure it doesn't require tzinfo (i.e., that this doesn't blow up).
-  var base = datetime.fromtimestamp(ts);
+  var base = datetime.fromTimestamp(ts);
   // Try with and without naming the keyword.
   var off42 = new shared FixedOffset(42, "42");
-  var another = datetime.fromtimestamp(ts, off42);
-  var again = datetime.fromtimestamp(ts, tz=off42);
+  var another = datetime.fromTimestamp(ts, off42);
+  var again = datetime.fromTimestamp(ts, tz=off42);
   assert(another.tzinfo == again.tzinfo);
-  assert(another.utcoffset() == new timedelta(minutes=42));
+  assert(another.utcOffset() == new timedelta(minutes=42));
 
   // Try to make sure tz= actually does some conversion.
   var timestamp = 1000000000;
-  var utcdatetime = datetime.utcfromtimestamp(timestamp);
+  var utcdatetime = datetime.utcFromTimestamp(timestamp);
   // In POSIX (epoch 1970), that's 2001-09-09 01:46:40 UTC, give or take.
   // But on some flavor of Mac, it's nowhere near that.  So we can't have
   // any idea here what time that actually is, we can only test that
@@ -252,7 +252,7 @@ proc test_tzinfo_fromtimestamp() {
   var utcoffset = new timedelta(hours=-15, minutes=39); // arbitrary, but not zero
   var tz = new shared FixedOffset(utcoffset, "tz", new timedelta());
   var expected = utcdatetime + utcoffset;
-  var got = datetime.fromtimestamp(timestamp, tz);
+  var got = datetime.fromTimestamp(timestamp, tz);
   assert(expected == got.replace(tzinfo=nil));
 }
 
@@ -306,7 +306,7 @@ proc test_utctimetuple() {
       super.init(dofs);
       this.uofs = new timedelta(minutes=uofs);
     }
-    override proc utcoffset(dt) {
+    override proc utcOffset(dt) {
       return uofs;
     }
   }
@@ -323,7 +323,7 @@ proc test_utctimetuple() {
     assert(13 == t.tm_min);
     assert(d.second == t.tm_sec);
     assert(d.weekday():int == t.tm_wday);
-    assert(d.toordinal() - (new date(1, 1, 1)).toordinal() + 1 == t.tm_yday);
+    assert(d.toOrdinal() - (new date(1, 1, 1)).toOrdinal() + 1 == t.tm_yday);
     assert(0 == t.tm_isdst);
   }
 
@@ -367,10 +367,10 @@ proc test_tzinfo_isoformat() {
       var timestr = '04:05:59' + if us != 0 then '.987001' else '';
       var ofsstr = d.tzname();
       var tailstr = timestr + ofsstr;
-      var iso = d.isoformat();
+      var iso = d.isoFormat();
       assert(iso == datestr + 'T' + tailstr);
-      assert(iso == d.isoformat('T'));
-      assert(d.isoformat('k') == datestr + 'k' + tailstr);
+      assert(iso == d.isoFormat('T'));
+      assert(d.isoFormat('k') == datestr + 'k' + tailstr);
       //assert(str(d) == datestr + ' ' + tailstr);
     }
   }
@@ -448,9 +448,9 @@ proc test_more_astimezone() {
   // Replacing with different tzinfo does adjust.
   var got = dt.astimezone(fm5h);
   assert(got.tzinfo == fm5h);
-  assert(got.utcoffset() == new timedelta(hours=-5));
-  var expected = dt - dt.utcoffset();  // in effect, convert to UTC
-  expected += fm5h.utcoffset(dt);  // and from there to local time
+  assert(got.utcOffset() == new timedelta(hours=-5));
+  var expected = dt - dt.utcOffset();  // in effect, convert to UTC
+  expected += fm5h.utcOffset(dt);  // and from there to local time
   expected = expected.replace(tzinfo=fm5h); // and attach new tzinfo
   assert(got.getdate() == expected.getdate());
   assert(got.gettime() == expected.gettime());
@@ -463,7 +463,7 @@ proc test_aware_subtract() {
   // Ensure that utcoffset() is ignored when the operands have the
   // same tzinfo member.
   class OperandDependentOffset: TZInfo {
-    override proc utcoffset(dt: datetime) {
+    override proc utcOffset(dt: datetime) {
       if dt.minute < 10 {
         // d0 and d1 equal after adjustment
         return new timedelta(minutes=dt.minute);
@@ -524,7 +524,7 @@ proc test_mixed_compare() {
     proc init() {
       offset = new timedelta(minutes=22);
     }
-    override proc utcoffset(dt: datetime) {
+    override proc utcOffset(dt: datetime) {
       offset += new timedelta(minutes=1);
       return offset;
     }
@@ -533,8 +533,8 @@ proc test_mixed_compare() {
   var v = new shared Varies();
   t1 = t2.replace(tzinfo=v);
   t2 = t2.replace(tzinfo=v);
-  assert(t1.utcoffset() == new timedelta(minutes=23));
-  assert(t2.utcoffset() == new timedelta(minutes=24));
+  assert(t1.utcOffset() == new timedelta(minutes=23));
+  assert(t2.utcOffset() == new timedelta(minutes=24));
   assert(t1 == t2);
 
   // But if they're not identical, it isn't ignored.

--- a/test/library/standard/DateTime/testTime.chpl
+++ b/test/library/standard/DateTime/testTime.chpl
@@ -52,28 +52,28 @@ proc test_comparing() {
 
 proc test_isoformat() {
   var t = new time(4, 5, 1, 123);
-  assert(t.isoformat() == "04:05:01.000123");
+  assert(t.isoFormat() == "04:05:01.000123");
 
   t = new time();
-  assert(t.isoformat() == "00:00:00");
+  assert(t.isoFormat() == "00:00:00");
 
   t = new time(microsecond=1);
-  assert(t.isoformat() == "00:00:00.000001");
+  assert(t.isoFormat() == "00:00:00.000001");
 
   t = new time(microsecond=10);
-  assert(t.isoformat() == "00:00:00.000010");
+  assert(t.isoFormat() == "00:00:00.000010");
 
   t = new time(microsecond=100);
-  assert(t.isoformat() == "00:00:00.000100");
+  assert(t.isoFormat() == "00:00:00.000100");
 
   t = new time(microsecond=1000);
-  assert(t.isoformat() == "00:00:00.001000");
+  assert(t.isoFormat() == "00:00:00.001000");
 
   t = new time(microsecond=10000);
-  assert(t.isoformat() == "00:00:00.010000");
+  assert(t.isoFormat() == "00:00:00.010000");
 
   t = new time(microsecond=100000);
-  assert(t.isoformat() == "00:00:00.100000");
+  assert(t.isoFormat() == "00:00:00.100000");
 }
 
 proc test_strftime() {

--- a/test/library/standard/DateTime/testTimezone.chpl
+++ b/test/library/standard/DateTime/testTimezone.chpl
@@ -17,7 +17,7 @@ class FixedOffset: TZInfo {
     this.dstoffset = new timedelta(minutes=dstoffset);
   }
 
-  override proc utcoffset(dt) {
+  override proc utcOffset(dt) {
     return offset;
   }
   override proc tzname(dt) {
@@ -53,9 +53,9 @@ proc test_zones() {
   assert(t4.tzinfo.borrow() == nil);
   assert(t5.tzinfo == utc);
 
-  assert(t1.utcoffset() == new timedelta(minutes=-300));
-  assert(t2.utcoffset() == new timedelta(minutes=0));
-  assert(t3.utcoffset() == new timedelta(minutes=60));
+  assert(t1.utcOffset() == new timedelta(minutes=-300));
+  assert(t2.utcOffset() == new timedelta(minutes=0));
+  assert(t3.utcOffset() == new timedelta(minutes=60));
 
   assert(t1.tzname() == "EST");
   assert(t2.tzname() == "UTC");
@@ -77,11 +77,11 @@ proc test_zones() {
   assert(str(t5) == "00:00:00.000040+00:00");
 */
 
-  assert(t1.isoformat() == "07:47:00-05:00");
-  assert(t2.isoformat() == "12:47:00+00:00");
-  assert(t3.isoformat() == "13:47:00+01:00");
-  assert(t4.isoformat() == "00:00:00.000040");
-  assert(t5.isoformat() == "00:00:00.000040+00:00");
+  assert(t1.isoFormat() == "07:47:00-05:00");
+  assert(t2.isoFormat() == "12:47:00+00:00");
+  assert(t3.isoFormat() == "13:47:00+01:00");
+  assert(t4.isoFormat() == "00:00:00.000040");
+  assert(t5.isoFormat() == "00:00:00.000040+00:00");
 
   // %z conversion uses local timezone instead of the one in the tzinfo
   //assert(t1.strftime("%H:%M:%S %%Z=%Z %%z=%z") ==
@@ -157,7 +157,7 @@ proc test_mixed_compare() {
     proc init() {
       offset = new timedelta(minutes=22);
     }
-    override proc utcoffset(dt: datetime) {
+    override proc utcOffset(dt: datetime) {
       offset += new timedelta(minutes=1);
       return offset;
     }
@@ -172,8 +172,8 @@ proc test_mixed_compare() {
   var v = new shared Varies();
   t1 = t2.replace(tzinfo=v);
   t2 = t2.replace(tzinfo=v);
-  assert(t1.utcoffset() == new timedelta(minutes=23));
-  assert(t2.utcoffset() == new timedelta(minutes=24));
+  assert(t1.utcOffset() == new timedelta(minutes=23));
+  assert(t2.utcOffset() == new timedelta(minutes=24));
   assert(t1 == t2);
 
   // But if they're not identical, it isn't ignored.

--- a/test/library/standard/DateTime/testTimezoneConversions.chpl
+++ b/test/library/standard/DateTime/testTimezoneConversions.chpl
@@ -34,7 +34,7 @@ class USTimeZone: TZInfo {
       return stdname;
   }
 
-  override proc utcoffset(dt: datetime) {
+  override proc utcOffset(dt: datetime) {
     return stdoffset + dst(dt);
   }
 
@@ -63,8 +63,8 @@ class USTimeZone: TZInfo {
     }
   }
 
-  override proc fromutc(dt: datetime) {
-    var dtoff = dt.utcoffset();
+  override proc fromUtc(dt: datetime) {
+    var dtoff = dt.utcOffset();
     var dtdst = dt.dst();
     var delta = dtoff - dtdst;
     var dt2 = dt + delta;
@@ -84,7 +84,7 @@ class FixedOffset: TZInfo {
     this.dstoffset = new timedelta(minutes=dstoffset);
   }
 
-  override proc utcoffset(dt: datetime) {
+  override proc utcOffset(dt: datetime) {
     return offset;
   }
 
@@ -96,8 +96,8 @@ class FixedOffset: TZInfo {
     return dstoffset;
   }
 
-  override proc fromutc(dt: datetime) {
-    var dtoff = dt.utcoffset();
+  override proc fromUtc(dt: datetime) {
+    var dtoff = dt.utcOffset();
     var dtdst = dt.dst();
     var delta = dtoff - dtdst;
     var dt2 = dt + delta;
@@ -279,9 +279,9 @@ proc test_tricky() {
     for tz in (Eastern, Pacific) {
       var first_std_hour = dstoff - new timedelta(hours=2); // 23:MM
       // Convert that to UTC.
-      first_std_hour -= tz.borrow().utcoffset(new datetime(1,1,1));
+      first_std_hour -= tz.borrow().utcOffset(new datetime(1,1,1));
       // Adjust for possibly fake UTC.
-      var asutc = first_std_hour + utc.borrow().utcoffset(new datetime(1,1,1));
+      var asutc = first_std_hour + utc.borrow().utcOffset(new datetime(1,1,1));
       // First UTC hour to convert; this is 4:00 when utc=utc_real &
       // tz=Eastern.
       var asutcbase = asutc.replace(tzinfo=utc);
@@ -300,14 +300,14 @@ proc test_tricky() {
 }
 
 proc test_fromutc() {
-  var now = datetime.utcnow().replace(tzinfo=utc_real);
+  var now = datetime.utcNow().replace(tzinfo=utc_real);
   now = now.replace(tzinfo=Eastern);   // insert correct tzinfo
-  var enow = Eastern.fromutc(now);         // doesn't blow up
+  var enow = Eastern.fromUtc(now);         // doesn't blow up
   assert(enow.tzinfo == Eastern); // has right tzinfo member
 
   // Always converts UTC to standard time.
   class FauxUSTimeZone: USTimeZone {
-    override proc fromutc(dt: datetime) {
+    override proc fromUtc(dt: datetime) {
       return dt + stdoffset;
     }
 
@@ -331,11 +331,11 @@ proc test_fromutc() {
     if wall == 23 {
       expected -= new timedelta(days=1);
     }
-    var got = Eastern.fromutc(start);
+    var got = Eastern.fromUtc(start);
     assert(expected == got);
 
     expected = fstart + FEasternRef.stdoffset;
-    got = FEastern.fromutc(fstart);
+    got = FEastern.fromUtc(fstart);
     assert(expected == got);
 
     // Ensure astimezone() calls fromutc() too.
@@ -351,11 +351,11 @@ proc test_fromutc() {
   fstart = start.replace(tzinfo=FEastern);
   for wall in (0, 1, 1, 2, 3, 4) {
     var expected = start.replace(hour=wall, tzinfo=start.tzinfo);
-    var got = Eastern.fromutc(start);
+    var got = Eastern.fromUtc(start);
     assert(expected == got);
 
     expected = fstart + FEasternRef.stdoffset;
-    got = FEastern.fromutc(fstart);
+    got = FEastern.fromUtc(fstart);
     assert(expected == got);
 
     // Ensure astimezone() calls fromutc() too.


### PR DESCRIPTION
Deprecate and rename DateTime methods from issue https://github.com/chapel-lang/chapel/issues/18846. This has not yet
modified the classes or enums suggested in that issue.

Added a deprecated test to trigger the warnings for each of the deprecated
methods.

Fixed up any tests that were using the now-deprecated names.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>