### PR TITLE
dyno query tracing updates

### DIFF
--- a/compiler/dyno/include/chpl/queries/Context.h
+++ b/compiler/dyno/include/chpl/queries/Context.h
@@ -105,6 +105,10 @@ class Context {
   bool breakSet = false;
   size_t breakOnHash = 0;
   int numQueriesRunThisRevision_ = 0;
+  // tracks the nesting of queries, displayed during query tracing
+  int queryTraceDepth = 0;
+  // list of query names to ignore when tracing
+  std::vector<std::string> queryTraceIgnoreQueries = {"idToTagQuery", "idToParentId"};
 
   owned<std::ostream> queryTimingTraceOutput = nullptr;
 

--- a/compiler/dyno/include/chpl/queries/Context.h
+++ b/compiler/dyno/include/chpl/queries/Context.h
@@ -103,15 +103,20 @@ class Context {
   bool enableDebugTrace = false;
   bool enableQueryTiming = false;
   bool enableQueryTimingTrace = false;
+  bool currentTerminalSupportsColor_ = terminalSupportsColor(getenv("TERM"));
   bool breakSet = false;
   size_t breakOnHash = 0;
   int numQueriesRunThisRevision_ = 0;
   // tracks the nesting of queries, displayed during query tracing
   int queryTraceDepth = 0;
+
   // list of query names to ignore when tracing
-  const std::vector<std::string> queryTraceIgnoreQueries = {"idToTagQuery", "idToParentId"};
+  const std::vector<std::string>
+  queryTraceIgnoreQueries = {"idToTagQuery", "idToParentId"};
+
   // list of colors to use for open/close braces depending on query depth
-  const std::vector<TermColorName> queryDepthColor  = {blue, bright_yellow, magenta};
+  const std::vector<TermColorName>
+  queryDepthColor  = {BLUE, BRIGHT_YELLOW, MAGENTA};
 
   owned<std::ostream> queryTimingTraceOutput = nullptr;
 
@@ -124,8 +129,8 @@ class Context {
   }
 
   void setTerminalColor(TermColorName colorName, std::ostream& os) {
-    if (terminalSupportsColor(getenv("TERM"))) {
-      os << getTerminalColor(colorName);
+    if (currentTerminalSupportsColor_) {
+      os << getColorFormat(colorName);
     }
   }
 

--- a/compiler/dyno/include/chpl/queries/query-impl.h
+++ b/compiler/dyno/include/chpl/queries/query-impl.h
@@ -139,8 +139,8 @@ void Context::queryBeginTrace(const char* traceQueryName,
                 << clearTerminalColor() << traceQueryName << " (";
       queryArgsPrint(tupleOfArg);
       std::cout << ") ";
-      setTerminalColor(cyan, std::cout);
-      std::cout <<"QUERY+ARGS HASH: 0x"
+      setTerminalColor(CYAN, std::cout);
+      std::cout <<"hash: 0x"
                 << std::hex << queryAndArgsHash
                 << clearTerminalColor() << std::endl;
     }
@@ -345,11 +345,11 @@ Context::queryEnd(
               << "   " << traceQueryName
               << " ";
     if (ret->lastChanged == this->currentRevisionNumber) {
-      setTerminalColor(yellow, std::cout);
+      setTerminalColor(YELLOW, std::cout);
       std::cout << "UPDATED";
     } else {
-      setTerminalColor(green, std::cout);
-      std::cout << "NO CHANGE";
+      setTerminalColor(GREEN, std::cout);
+      std::cout << "unchanged";
     }
     setQueryDepthColor(queryTraceDepth, std::cout);
     std::cout << " } "

--- a/compiler/dyno/include/chpl/queries/query-impl.h
+++ b/compiler/dyno/include/chpl/queries/query-impl.h
@@ -132,12 +132,17 @@ void Context::queryBeginTrace(const char* traceQueryName,
     size_t queryAndArgsHash = hash_combine(hash(traceQueryName), hash(args));
     if (enableDebugTrace) {
       queryTraceDepth++;
-      printf("%i QUERY BEGIN     %s (", queryTraceDepth, traceQueryName);
+      // QUERY BEGIN
+      setQueryDepthColor(queryTraceDepth, std::cout);
+      std::cout << queryTraceDepth
+                << " { "
+                << clearTerminalColor() << traceQueryName;
       queryArgsPrint(tupleOfArg);
-      printf(") ");
-      std::cout << "QUERY + ARGS HASH: 0x"
+      std::cout << ") ";
+      setTerminalColor(cyan, std::cout);
+      std::cout <<"QUERY+ARGS HASH: 0x"
                 << std::hex << queryAndArgsHash
-                << " {" << std::endl;
+                << clearTerminalColor() << std::endl;
     }
     if (breakSet && queryAndArgsHash == breakOnHash) {
       debuggerBreakHere();
@@ -333,10 +338,23 @@ Context::queryEnd(
       && std::find(queryTraceIgnoreQueries.begin(),
                    queryTraceIgnoreQueries.end(),
                    traceQueryName) == queryTraceIgnoreQueries.end()) {
-    bool changed = ret->lastChanged == this->currentRevisionNumber;
-    printf("%i QUERY END       %s (", queryTraceDepth, traceQueryName);
-    queryArgsPrint(tupleOfArgs);
-    printf(") %s }\n", changed?"UPDATED":"NO CHANGE");
+    // QUERY END
+    setQueryDepthColor(queryTraceDepth, std::cout);
+    std::cout << queryTraceDepth
+              << clearTerminalColor()
+              << "   " << traceQueryName
+              << " ";
+    if (ret->lastChanged == this->currentRevisionNumber) {
+      setTerminalColor(yellow, std::cout);
+      std::cout << "UPDATED";
+    } else {
+      setTerminalColor(green, std::cout);
+      std::cout << "NO CHANGE";
+    }
+    setQueryDepthColor(queryTraceDepth, std::cout);
+    std::cout << " } "
+              << clearTerminalColor()
+              << std::endl;
     queryTraceDepth--;
     assert(r->lastChecked == this->currentRevisionNumber);
     //for (auto dep : r->dependencies) {

--- a/compiler/dyno/include/chpl/queries/query-impl.h
+++ b/compiler/dyno/include/chpl/queries/query-impl.h
@@ -136,7 +136,7 @@ void Context::queryBeginTrace(const char* traceQueryName,
       setQueryDepthColor(queryTraceDepth, std::cout);
       std::cout << queryTraceDepth
                 << " { "
-                << clearTerminalColor() << traceQueryName;
+                << clearTerminalColor() << traceQueryName << " (";
       queryArgsPrint(tupleOfArg);
       std::cout << ") ";
       setTerminalColor(cyan, std::cout);

--- a/compiler/dyno/include/chpl/resolution/resolution-types.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-types.h
@@ -75,6 +75,7 @@ class UntypedFnSignature {
 
     void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
       name.stringify(ss, stringKind);
+      ss << " ";
       if (decl != nullptr) {
         decl->stringify(ss, stringKind);
         ss << " ";

--- a/compiler/dyno/include/chpl/uast/Function.h
+++ b/compiler/dyno/include/chpl/uast/Function.h
@@ -397,7 +397,22 @@ template<> struct stringify<uast::Function::ReturnIntent> {
   void operator()(std::ostream& streamOut,
                   StringifyKind stringKind,
                   const uast::Function::ReturnIntent& stringMe) const {
-    streamOut << "uast:Function::ReturnIntent is not stringified";
+    std::string intent;
+    switch ((uast::IntentList) stringMe)  {
+    case uast::IntentList::CONST_INTENT: intent = "const"; break;
+    case uast::IntentList::VAR: intent = "var"; break;
+    case uast::IntentList::CONST_VAR: intent = "const var"; break;
+    case uast::IntentList::CONST_REF: intent = "const ref"; break;
+    case uast::IntentList::REF: intent = "ref"; break;
+    case uast::IntentList::IN: intent = "in"; break;
+    case uast::IntentList::CONST_IN: intent = "const in"; break;
+    case uast::IntentList::OUT: intent = "out"; break;
+    case uast::IntentList::INOUT: intent = "inout"; break;
+    case uast::IntentList::PARAM: intent = "param"; break;
+    case uast::IntentList::TYPE: intent = "type"; break;
+    default: intent = "uast:Function::ReturnIntent not recognized";
+    }
+    streamOut << intent;
   }
 };
 
@@ -405,7 +420,15 @@ template<> struct stringify<uast::Function::Kind> {
   void operator()(std::ostream& streamOut,
                   StringifyKind stringKind,
                   const uast::Function::Kind& stringMe) const {
-    streamOut << "uast:Function::Kind is not stringified";
+  std::string kind;
+  switch (stringMe) {
+    case uast::Function::Kind::PROC: kind = "proc"; break;
+    case uast::Function::Kind::ITER:  kind = "iter"; break;
+    case uast::Function::Kind::OPERATOR:  kind = "operator"; break;
+    case uast::Function::Kind::LAMBDA:  kind = "lambda"; break;
+    default: kind = "uast::Function::Kind not recognized";
+  }
+    streamOut << kind;
   }
 };
 /// \endcond DO_NOT_DOCUMENT

--- a/compiler/dyno/include/chpl/util/terminal.h
+++ b/compiler/dyno/include/chpl/util/terminal.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_UTIL_TERMINAL_H
+#define CHPL_UTIL_TERMINAL_H
+
+#include <string>
+
+namespace chpl {
+
+enum TermColorName {
+    clear,
+    black,
+    red,
+    green,
+    yellow,
+    blue,
+    magenta,
+    cyan,
+    white,
+    bright_black,
+    bright_red,
+    bright_green,
+    bright_yellow,
+    bright_blue,
+    bright_magenta,
+    bright_cyan,
+    bright_white
+};
+
+std::string getTerminalColor(TermColorName colorName);
+
+bool terminalSupportsColor(const char* term);
+
+std::string clearTerminalColor();
+
+} // end namespace chpl
+
+#endif

--- a/compiler/dyno/include/chpl/util/terminal.h
+++ b/compiler/dyno/include/chpl/util/terminal.h
@@ -26,26 +26,26 @@
 namespace chpl {
 
 enum TermColorName {
-    clear,
-    black,
-    red,
-    green,
-    yellow,
-    blue,
-    magenta,
-    cyan,
-    white,
-    bright_black,
-    bright_red,
-    bright_green,
-    bright_yellow,
-    bright_blue,
-    bright_magenta,
-    bright_cyan,
-    bright_white
+    CLEAR,
+    BLACK,
+    RED,
+    GREEN,
+    YELLOW,
+    BLUE,
+    MAGENTA,
+    CYAN,
+    WHITE,
+    BRIGHT_BLACK,
+    BRIGHT_RED,
+    BRIGHT_GREEN,
+    BRIGHT_YELLOW,
+    BRIGHT_BLUE,
+    BRIGHT_MAGENTA,
+    BRIGHT_CYAN,
+    BRIGHT_WHITE
 };
 
-std::string getTerminalColor(TermColorName colorName);
+std::string getColorFormat(TermColorName colorName);
 
 bool terminalSupportsColor(const char* term);
 

--- a/compiler/dyno/lib/queries/Context.cpp
+++ b/compiler/dyno/lib/queries/Context.cpp
@@ -433,7 +433,7 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
                        /* forSetter */ true);
 
   if (enableDebugTrace) {
-    printf("SETTING FILE PATH FOR MODULE %s -> %s\n",
+    printf("%i SETTING FILE PATH FOR MODULE %s -> %s\n", queryTraceDepth,
            moduleIdSymbolPath.c_str(), path.c_str());
   }
   #ifndef NDEBUG
@@ -455,7 +455,7 @@ void Context::advanceToNextRevision(bool prepareToGC) {
     gcCounter++;
   }
   if (enableDebugTrace) {
-    printf("CURRENT REVISION NUMBER IS NOW %i %s\n",
+    printf("%i CURRENT REVISION NUMBER IS NOW %i %s\n", queryTraceDepth,
            (int) this->currentRevisionNumber,
            prepareToGC?"PREPARING GC":"");
   }
@@ -475,7 +475,7 @@ void Context::collectGarbage() {
   assert(queryStack.size() == 0);
 
   if (enableDebugTrace) {
-    printf("COLLECTING GARBAGE\n");
+    printf("%i COLLECTING GARBAGE\n", queryTraceDepth);
   }
 
   // clear out the saved old results
@@ -506,12 +506,12 @@ void Context::collectGarbage() {
       if (buf[1] || buf[0] == gcMark) {
         newTable.insert(e);
         if (enableDebugTrace) {
-          printf("COPYING OVER UNIQUESTRING %s\n", key);
+          printf("%i COPYING OVER UNIQUESTRING %s\n", queryTraceDepth, key);
         }
       } else {
         toFree.push_back(allocation);
         if (enableDebugTrace) {
-          printf("WILL FREE UNIQUESTRING %s\n", key);
+          printf("%i WILL FREE UNIQUESTRING %s\n", queryTraceDepth, key);
         }
       }
     }
@@ -522,7 +522,7 @@ void Context::collectGarbage() {
 
     if (enableDebugTrace) {
       size_t nUniqueStringsAfter = uniqueStringsTable.size();
-      printf("COLLECTED %i UniqueStrings\n",
+      printf("%i COLLECTED %i UniqueStrings\n", queryTraceDepth,
              (int)(nUniqueStringsBefore-nUniqueStringsAfter));
     }
   }
@@ -640,14 +640,16 @@ void Context::recomputeIfNeeded(const QueryMapResultBase* resultEntry) {
     resultEntry->recompute(this);
     assert(resultEntry->lastChecked == this->currentRevisionNumber);
     if (enableDebugTrace) {
-      printf("DONE RECOMPUTING IF NEEDED -- RECOMPUTED FOR %s\n",
+      printf("%i DONE RECOMPUTING IF NEEDED -- RECOMPUTED FOR %s\n",
+             queryTraceDepth,
              resultEntry->parentQueryMap->queryName);
     }
     return;
   } else {
     updateForReuse(resultEntry);
     if (enableDebugTrace) {
-      printf("DONE RECOMPUTING IF NEEDED -- REUSED FOR %s\n",
+      printf("%i DONE RECOMPUTING IF NEEDED -- REUSED FOR %s\n",
+             queryTraceDepth,
              resultEntry->parentQueryMap->queryName);
     }
   }

--- a/compiler/dyno/lib/resolution/resolution-types.cpp
+++ b/compiler/dyno/lib/resolution/resolution-types.cpp
@@ -439,9 +439,6 @@ void CallInfo::stringify(std::ostream& ss,
     actual.stringify(ss, stringKind);
   }
   ss << ")";
-  if (stringKind != StringifyKind::CHPL_SYNTAX) {
-    ss << "\n";
-  }
 }
 
 void PoiInfo::accumulate(const PoiInfo& addPoiInfo) {

--- a/compiler/dyno/lib/uast/AstNode.cpp
+++ b/compiler/dyno/lib/uast/AstNode.cpp
@@ -272,7 +272,8 @@ static void dumpMaxIdLen(const AstNode* ast, int& maxIdLen) {
 static void dumpHelper(std::ostream& ss,
                        const AstNode* ast,
                        int maxIdLen,
-                       int depth) {
+                       int depth,
+                       StringifyKind stringKind) {
   std::string idStr = getIdStr(ast);
   ss << std::setw(maxIdLen) << idStr;
 
@@ -303,10 +304,11 @@ static void dumpHelper(std::ostream& ss,
 
   //printf("(containing %i) ", ast->id().numContainedChildren());
   //printf("%p", ast);
-  ss << "\n";
+  if (stringKind == StringifyKind::DEBUG_DETAIL)
+    ss << "\n";
 
   for (const AstNode* child : ast->children()) {
-    dumpHelper(ss, child, maxIdLen, depth+1);
+    dumpHelper(ss, child, maxIdLen, depth+1, stringKind);
   }
 }
 
@@ -315,12 +317,11 @@ void AstNode::stringify(std::ostream& ss,
 
   if (stringKind == StringifyKind::CHPL_SYNTAX) {
     printChapelSyntax(ss, this);
-  }
-  else {
+  } else {
     int maxIdLen = 0;
     int leadingSpaces = 0;
     dumpMaxIdLen(this, maxIdLen);
-    dumpHelper(ss, this, maxIdLen, leadingSpaces);
+    dumpHelper(ss, this, maxIdLen, leadingSpaces, stringKind);
   }
 }
 

--- a/compiler/dyno/lib/util/CMakeLists.txt
+++ b/compiler/dyno/lib/util/CMakeLists.txt
@@ -30,4 +30,5 @@ target_sources(libdyno-obj
                filesystem.cpp
                filesystem_help.h
                string-escapes.cpp
+               terminal.cpp
               )

--- a/compiler/dyno/lib/util/Makefile.include
+++ b/compiler/dyno/lib/util/Makefile.include
@@ -26,6 +26,7 @@ DYNO_UTIL_SRCS =      \
   break.cpp \
   filesystem.cpp \
   string-escapes.cpp \
+  terminal.cpp \
 
 
 SRCS = $(DYNO_UTIL_SRCS) my_aligned_alloc.c my_strerror_r.c

--- a/compiler/dyno/lib/util/terminal.cpp
+++ b/compiler/dyno/lib/util/terminal.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "chpl/util/terminal.h"
+#include <cstring>
+#include <map>
+
+
+namespace chpl {
+
+std::string getFgColorCode(TermColorName colorName);
+
+std::map<TermColorName, std::string> termColorMap = {
+    {clear, "0"},
+    {black,"30"},
+    {red,"31"},
+    {green, "32"},
+    {yellow, "33"},
+    {blue,"34"},
+    {magenta,"35"},
+    {cyan, "36"},
+    {white, "37"},
+    {bright_black, "90"},
+    {bright_red, "91"},
+    {bright_green, "92"},
+    {bright_yellow, "93"},
+    {bright_blue, "94"},
+    {bright_magenta, "95"},
+    {bright_cyan, "96"},
+    {bright_white, "97"}
+};
+
+std::string getTerminalColor(TermColorName colorName) {
+  std::string ret = "\033[";
+  ret += getFgColorCode(colorName);
+  ret += "m";
+  return ret.c_str();
+}
+
+std::string clearTerminalColor() {
+  std::string ret = getTerminalColor(clear);
+  return ret;
+}
+
+std::string getFgColorCode(TermColorName colorName) {
+  return termColorMap[colorName];
+}
+
+// This approach and these terminals are taken from googletest; see
+// https://github.com/google/googletest/blob/master/googletest/src/gtest.cc#L3216
+bool terminalSupportsColor(const char* term) {
+  bool isColorTerm = false;
+  const char* colorTerms[] = {"xterm",
+                              "xterm-color",
+                              "xterm-256color",
+                              "screen",
+                              "screen-256color",
+                              "tmux",
+                              "tmux-256color",
+                              "rxvt-unicode",
+                              "rxvt-unicode-256color",
+                              "linux",
+                              "cygwin",
+                              NULL};
+  if (term == NULL) term = "";
+  for (int i = 0; colorTerms[i] != NULL; i++) {
+    if (0 == strcmp(term, colorTerms[i])) {
+      isColorTerm = true;
+      break;
+    }
+  }
+  return isColorTerm;
+}
+
+
+} //end namespace chpl

--- a/compiler/dyno/lib/util/terminal.cpp
+++ b/compiler/dyno/lib/util/terminal.cpp
@@ -22,33 +22,33 @@
 #include "chpl/util/terminal.h"
 #include <cstring>
 #include <map>
-
+#include <unistd.h>
 
 namespace chpl {
 
 std::string getFgColorCode(TermColorName colorName);
 
 std::map<TermColorName, std::string> termColorMap = {
-    {clear, "0"},
-    {black,"30"},
-    {red,"31"},
-    {green, "32"},
-    {yellow, "33"},
-    {blue,"34"},
-    {magenta,"35"},
-    {cyan, "36"},
-    {white, "37"},
-    {bright_black, "90"},
-    {bright_red, "91"},
-    {bright_green, "92"},
-    {bright_yellow, "93"},
-    {bright_blue, "94"},
-    {bright_magenta, "95"},
-    {bright_cyan, "96"},
-    {bright_white, "97"}
+    {CLEAR,          "0"},
+    {BLACK,          "30"},
+    {RED,            "31"},
+    {GREEN,          "32"},
+    {YELLOW,         "33"},
+    {BLUE,           "34"},
+    {MAGENTA,        "35"},
+    {CYAN,           "36"},
+    {WHITE,          "37"},
+    {BRIGHT_BLACK,   "90"},
+    {BRIGHT_RED,     "91"},
+    {BRIGHT_GREEN,   "92"},
+    {BRIGHT_YELLOW,  "93"},
+    {BRIGHT_BLUE,    "94"},
+    {BRIGHT_MAGENTA, "95"},
+    {BRIGHT_CYAN,    "96"},
+    {BRIGHT_WHITE, "97"}
 };
 
-std::string getTerminalColor(TermColorName colorName) {
+std::string getColorFormat(TermColorName colorName) {
   std::string ret = "\033[";
   ret += getFgColorCode(colorName);
   ret += "m";
@@ -56,7 +56,7 @@ std::string getTerminalColor(TermColorName colorName) {
 }
 
 std::string clearTerminalColor() {
-  std::string ret = getTerminalColor(clear);
+  std::string ret = getColorFormat(CLEAR);
   return ret;
 }
 
@@ -87,6 +87,13 @@ bool terminalSupportsColor(const char* term) {
       break;
     }
   }
+
+  // Check if either output is to a tty.
+  if (isatty(fileno(stderr)) == 0 ||
+      isatty(fileno(stdout)) == 0) {
+    isColorTerm = false;
+  }
+
   return isColorTerm;
 }
 

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -485,8 +485,15 @@ static void ApplyValue(const ArgumentState*       state,
         break;
       }
       case 'U':
+      {
         *((size_t*) location) = str2uint64(value);
         break;
+      }
+      case 'X':
+      {
+        *((size_t*) location) = hexStr2uint64(value);
+        break;
+      }
     }
   }
 
@@ -706,6 +713,10 @@ static void process_arg(const ArgumentState*       state,
 
         case 'U':
           *((size_t*) desc->location) = std::stoull(arg);
+          break;
+
+        case 'X':
+          *((size_t*) desc->location) = std::stoull(arg, nullptr, 16);
           break;
 
         default:

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -967,6 +967,7 @@ Flag types:
   U = unsigned long
   N = --no-... flag, --no version sets to false
   n = --no-... flag, --no version sets to true
+  X = hexadecimal (converted to unsigned long)
 
 Record components:
  {"long option" (or "" for separators), 'short option', "description of option argument(s), if any", "option description", "option type", &affectedVariable, "environment variable name", setter_function},
@@ -1217,7 +1218,7 @@ static ArgumentDescription arg_desc[] = {
 
  {"dyno", ' ', NULL, "Enable [disable] using dyno compiler library", "N", &fDynoCompilerLibrary, "CHPL_DYNO_COMPILER_LIBRARY", NULL},
  {"dyno-debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using dyno compiler library", "N", &fDynoDebugTrace, "CHPL_DYNO_DEBUG_TRACE", NULL},
- {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "U", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
+ {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "X", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
 
 
  DRIVER_ARG_PRINT_CHPL_HOME,

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -974,12 +974,6 @@ static void setupErrorFormatEscapes() {
       // Check the TERM variable.
       const char* term = getenv("TERM");
       isColorTerm = chpl::terminalSupportsColor(term);
-
-      // Check if errors will be output to a tty. If not,
-      // the format codes will just store "" and have no effect.
-      if (isatty(fileno(stderr)) == 0) {
-        isColorTerm = false;
-      }
     }
 
     if (isColorTerm) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -24,6 +24,7 @@
 #include "baseAST.h"
 #include "chpl.h"
 #include "chpl/queries/Context.h"
+#include "chpl/util/terminal.h"
 #include "codegen.h"
 #include "driver.h"
 #include "expr.h"
@@ -970,27 +971,9 @@ static void setupErrorFormatEscapes() {
     // Other settings of these variables are for testing the formatting itself.
     bool isColorTerm = fUseColorTerminal;
     if (fDetectColorTerminal) {
-      // Check the TERM variable. This approach and these
-      // terminals are taken from googletest; see
-      // https://github.com/google/googletest/blob/master/googletest/src/gtest.cc#L3216
+      // Check the TERM variable.
       const char* term = getenv("TERM");
-      const char* colorTerms[] = {"xterm",
-                                  "xterm-color",
-                                  "xterm-256color",
-                                  "screen",
-                                  "screen-256color",
-                                  "tmux",
-                                  "tmux-256color",
-                                  "rxvt-unicode",
-                                  "rxvt-unicode-256color",
-                                  "linux",
-                                  "cygwin",
-                                  NULL};
-      if (term == NULL) term = "";
-      for (int i = 0; colorTerms[i] != NULL; i++) {
-        if (0 == strcmp(term, colorTerms[i]))
-          isColorTerm = true;
-      }
+      isColorTerm = chpl::terminalSupportsColor(term);
 
       // Check if errors will be output to a tty. If not,
       // the format codes will just store "" and have no effect.


### PR DESCRIPTION
This PR updates the dyno query tracing features to include a query depth 
indicator for nested queries, makes small fixes for formatting of `FormalDetail`
and `CallInfo`, implements `stringify` for `Function::Kind` and 
`Function::ReturnIntent`, adds a list of query names to ignore when tracing, 
and changes the `dyno-break-on-hash` flag to accept hex and similarly changes 
query + args hash to output in hex.

The query depth indicator is just a number that indicates the depth of the 
nested query, starting at 1. Here is an incomplete sample output:
```
1 { parse (/home/arezaii/git/chapel/test/types/bool/bradc/numBitsBytesDefault.chpl) QUERY+ARGS HASH: 0x726a5a85ae347e15
2 { parseFile (/home/arezaii/git/chapel/test/types/bool/bradc/numBitsBytesDefault.chpl) QUERY+ARGS HASH: 0xdcfafbaf0532de96
3 { fileTextQuery ("/home/arezaii/git/chapel/test/types/bool/bradc/numBitsBytesDefault.chpl") QUERY+ARGS HASH: 0x1c66113d41ff21ee
3   fileTextQuery UPDATED } 
3 { getStringParam (numBits = ) QUERY+ARGS HASH: 0x1e7fbff86d3c6d6
3   getStringParam UPDATED } 
3 { getStringParam (numBytes = ) QUERY+ARGS HASH: 0xc63edbd3f02bedf7
3   getStringParam UPDATED } 
3 { getStringParam (-------------) QUERY+ARGS HASH: 0x76bd6dc96f2108ba
3   getStringParam UPDATED } 
2 SETTING FILE PATH FOR MODULE numBitsBytesDefault -> /home/arezaii/git/chapel/test/types/bool/bradc/numBitsBytesDefault.chpl
2   parseFile UPDATED } 
1   parse UPDATED } 
```

Also note that the `QUERY+ARGS HASH` has been moved to the same line as
`QUERY BEGIN` and the output of the hash is now written in hex instead of
decimal. 

The list of queries we will ignore is stored in Context.h and initially 
includes only `idToTagQuery` and `idToParentId`. 

The implementation of `stringify` for `Function::Kind` and 
`Function::ReturnIntent` is nearly identical to that in the `kindToString` 
functions in `chpl-syntax-printer`. Ideally these would be centralized in a 
function that can be called from either place.

We also stopped printing the memory address of the `QueryMapResult` after 
`UPDATED` or `NO CHANGE`. In the future we may want to have a way to write some
details of the `QueryMapResult` and have a toggle to control if it prints or not.

Added some support for colorizing the output if your terminal supports it.
Here is a sample of what it might look like:
![colorized-trace-output](https://user-images.githubusercontent.com/2806014/173663621-80dde31e-a076-4186-87e3-d1738c74346e.PNG)

TESTING:

- [x] make `test-dyno`
- [x] paratest

reviewed by @dlongnecke-cray and @mppf - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>