### PR TITLE
Don't include -pthread in link args

### DIFF
--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -58,25 +58,43 @@ def handle_la(la_path):
                             args.append(tok)
     return args
 
+def filter_libs_skip_arg(arg):
+    if arg == '-pthread':
+        # ignore this flag since it causes problems
+        # if ld is used as the linker (vs clang/gcc/etc),
+        # and since Chapel programs always build with pthreads anyway
+        return True
+
+    return False
+
 # Given bundled_libs and system_libs lists, filters some
 # usual suspects into system_libs and
 # returns (bundled_args, system_args)
 def filter_libs(bundled_libs, system_libs):
     bundled_ret = [ ]
     system_ret = [ ]
+
     for arg in bundled_libs:
-        # put some of the usual suspects into the system args
-        if (arg == '-ldl' or
-            arg == '-lm' or
-            arg == '-lnuma' or
-            arg == '-lpthread' or
-            arg == '-pthread'):
+        if filter_libs_skip_arg(arg):
+            # ignore any args we need to skip
+            pass
+        elif (arg == '-ldl' or
+              arg == '-lm' or
+              arg == '-lnuma' or
+              arg == '-lpthread'):
+            # put some of the usual suspects into the system args
             system_ret.append(arg)
         else:
+            # otherwise include the flag in bundled
             bundled_ret.append(arg)
 
-    # append the system libs
-    system_ret.extend(system_libs)
+    for arg in system_libs:
+        if filter_libs_skip_arg(arg):
+            # ignore any args we need to skip
+            pass
+        else:
+            # otherwise include the flag in system
+            system_ret.append(arg)
 
     return (bundled_ret, system_ret)
 


### PR DESCRIPTION
PR #19913 started parsing the re2.pc pkg-config file.
One flag currently included in the link options there is `-pthread`.
However this flag messes up linking with `ld` which occurs in multilocale
Python interop. So, this commit adjusts `filter_libs` (which
is called from `pkgconfig_get_bundled_link_args`) to filter
out `-pthread`.

- [x] `interop/python/multilocale/` passes with CHPL_COMM=gasnet and CHPL_LIB_PIC=pic
- [x] `make check` works on Ubuntu 22.04
- [ ] `make check` works on Mac OS X
- [ ] full local testing