### PR TITLE
Change `configure` to create prefix directories

### DIFF
--- a/configure
+++ b/configure
@@ -89,6 +89,12 @@ mynormalizepath () {
       ;;
   esac
 
+  if [ ! -d $P ]
+  then
+    echo "Prefix directory does not exist, creating directory."
+    mkdir $P
+  fi
+
   # Normalize $P more - normalize path
   P=`(unset CDPATH && cd "$P" && pwd)`
 

--- a/configure
+++ b/configure
@@ -92,7 +92,7 @@ mynormalizepath () {
   if [ ! -d $P ]
   then
     echo "Prefix directory does not exist, creating directory."
-    mkdir $P
+    mkdir -p $P
   fi
 
   # Normalize $P more - normalize path

--- a/test/compflags/ferguson/home/sub_test
+++ b/test/compflags/ferguson/home/sub_test
@@ -116,11 +116,16 @@ sub check {
   #print "RUNNING $exe --print-chpl-home\n";
   $got = `$exe --print-chpl-home 2>&1`;
   #print "GOT IS $got\n";
-
-
+ 
   my @lines = split('\n', $got);
-  my ($gothome, $gotexe) = split('\t', $lines[-1]);
-
+  my $prefix_line = "configured prefix";
+  my ($gothome, $gotexe) = ("", "") ;
+  #If we configured with a prefix, the --print-chpl-home output includes an extra line. 
+  if (index($lines[-1] , $prefix_line) != -1) { #configured with prefix
+    ($gothome, $gotexe) = split('\t', $lines[-2]);
+  } else { #not configured with prefix
+    ($gothome, $gotexe) = split('\t', $lines[-1]);
+  }
   #print "[Success compiling --print-chpl-home]\n";
   if ($expecthome ne "") {
     if( realpath($gothome) eq realpath($expecthome) ) {


### PR DESCRIPTION
Changes `./configure` to create the prefix directory if it doesn't exit. Also changes --print-chpl-home tests so they account for builds that use a prefix directory.

Completes #19762 