### PR TITLE
Add additional multilocale GPU tests

### DIFF
--- a/test/gpu/native/multiLocale/copyToLocaleThenToGpu.chpl
+++ b/test/gpu/native/multiLocale/copyToLocaleThenToGpu.chpl
@@ -1,0 +1,41 @@
+//Data created on Locales[0], chunks copied to locales and then to GPUs
+use GPUDiagnostics;
+
+config const n = 128;
+config const alpha = 5;
+
+var A, B, C: [0..<n] int;
+B = 1;
+C = 2;
+
+startGPUDiagnostics();
+coforall (l,lid) in zip(Locales, LocaleSpace) do on l {
+  const perLocSize = n/numLocales;
+  const locStart = lid*perLocSize;
+  const locChunk = locStart..#perLocSize;
+
+  var Al: [locChunk] int;
+  var Bl = B[locChunk], Cl = C[locChunk];
+
+  const numGPUs = here.gpus.size;
+  coforall (g,gid) in zip(here.gpus, here.gpus.domain) do on g {
+    const perGPUSize = perLocSize/numGPUs;
+    const gpuStart = locStart+gid*perGPUSize;
+    const gpuChunk = gpuStart..#perGPUSize;
+
+    var Ag: [gpuChunk] int;
+    var Bg = Bl[gpuChunk], Cg = Cl[gpuChunk];
+
+    Ag = Bg + alpha * Cg;
+    Al[gpuChunk] = Ag;
+  }
+
+  A[locChunk] = Al;
+}
+stopGPUDiagnostics();
+
+// validation
+param nLaunch=1;
+for l in Locales {
+  assert(getGPUDiagnostics()[l.id].kernel_launch == nLaunch*l.gpus.size);
+}

--- a/test/gpu/native/multiLocale/copyToLocaleThenToGpu.good
+++ b/test/gpu/native/multiLocale/copyToLocaleThenToGpu.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly

--- a/test/gpu/native/multiLocale/directCopyToGpu.chpl
+++ b/test/gpu/native/multiLocale/directCopyToGpu.chpl
@@ -1,0 +1,42 @@
+//Direct copy to GPUs
+
+use CommDiagnostics;
+use GPUDiagnostics;
+
+config const n = 128;
+config const alpha = 5;
+
+var A, B, C: [0..<n] int;
+B = 1;
+C = 2;
+
+startGPUDiagnostics();
+coforall (l,lid) in zip(Locales, LocaleSpace) do on l {
+  const perLocSize = n/numLocales;
+  const locStart = lid*perLocSize;
+  const locChunk = locStart..#perLocSize;
+
+  const numGPUs = here.gpus.size; // initially I used `here.gpus.size` inside
+                                  // the `on` below. But `here` on a gpu
+                                  // sublocale is the sublocale. Should it be?
+                                  // Probably. But maybe we need a way to query
+                                  // number of siblings from a sublocale
+  coforall (g,gid) in zip(here.gpus, here.gpus.domain) do on g {
+    const perGPUSize = perLocSize/numGPUs;
+    const gpuStart = locStart+gid*perGPUSize;
+    const gpuChunk = gpuStart..#perGPUSize;
+
+    var Ag: [gpuChunk] int;
+    var Bg = B[gpuChunk], Cg = C[gpuChunk];
+
+    Ag = Bg + alpha * Cg;
+
+    A[gpuChunk] = Ag;
+  }
+}
+stopGPUDiagnostics();
+
+// validation
+param nLaunch=1;
+for l in Locales do
+  assert(getGPUDiagnostics()[l.id].kernel_launch == nLaunch*l.gpus.size);

--- a/test/gpu/native/multiLocale/directCopyToGpu.good
+++ b/test/gpu/native/multiLocale/directCopyToGpu.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly

--- a/test/gpu/native/multiLocale/promotedOpOnAllGpusAndLocales.chpl
+++ b/test/gpu/native/multiLocale/promotedOpOnAllGpusAndLocales.chpl
@@ -1,0 +1,22 @@
+// Everything is initiated on the GPU(s)
+use GPUDiagnostics;
+
+config const n = 10;
+config const alpha = 5;
+
+startGPUDiagnostics();
+coforall l in Locales do on l {
+  coforall g in here.gpus do on g {
+    var A, B, C: [1..n] int;
+
+    B = 1;
+    C = 2;
+    A = B + alpha  * C;
+  }
+}
+stopGPUDiagnostics();
+
+// validation
+param nLaunch=3;
+for l in Locales do
+  assert(getGPUDiagnostics()[l.id].kernel_launch == nLaunch*l.gpus.size);

--- a/test/gpu/native/multiLocale/promotedOpOnAllGpusAndLocales.good
+++ b/test/gpu/native/multiLocale/promotedOpOnAllGpusAndLocales.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly


### PR DESCRIPTION
Engin created these multilocale\multiGPU tests that perform different sorts of communication.

`promotedOpOnAllGpusAndLocales`: Stream like computation occurs on all gpus and locales locally without any remote puts\gets.
`copyToLocaleThenToGpu`: Copy relevant portions of input data from Locale[0] to Locale[n] and then back
`directCopyToGpu`: Copy relevant portions of input data from Locale[0] directly to gpu sublocales across all locales.

I want to make sure we get these in our nightly tests.