### PR TITLE
Upgrade our arkouda python version

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -42,8 +42,8 @@ fi
 # enable arrow/parquet support
 export ARKOUDA_SERVER_PARQUET_SUPPORT=true
 
-# Arkouda requires Python >= 3.7
-SETUP_PYTHON=$COMMON_DIR/setup_python37.bash
+# Arkouda requires a newer python
+SETUP_PYTHON=$COMMON_DIR/setup_python_arkouda.bash
 if [ -f "$SETUP_PYTHON" ]; then
   source $SETUP_PYTHON
 fi


### PR DESCRIPTION
Switch from python 3.7 to 3.9 since Arkouda now requires at least 3.8
(Bears-R-Us/arkouda#1487). Note that I wanted to use a newer version do
limit when we have to do the next upgrade, but I didn't go with 3.10
since spack is still defaulting to 3.9.

Also note that I added a `setup_python_arkouda` wrapper so that we don't
have to change our testing and dev scripts the next time we have to
upgrade.