### PR TITLE
marked the Array.equals() method as unstable. resolves #19140

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1886,7 +1886,7 @@ module ChapelArray {
      equal to the corresponding element in ``that``. Otherwise
      return false. */
   proc _array.equals(that: _array): bool {
-    if chpl_warnUnstable then compilerWarning("the Array.equals() method is unstable");
+    if chpl_warnUnstable then compilerWarning("the 'Array.equals()' method is unstable");
 
     //
     // quick path for identical arrays

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1886,6 +1886,8 @@ module ChapelArray {
      equal to the corresponding element in ``that``. Otherwise
      return false. */
   proc _array.equals(that: _array): bool {
+    if chpl_warnUnstable then compilerWarning("the Array.equals() method is unstable");
+
     //
     // quick path for identical arrays
     //

--- a/test/unstable/arrayEquals.chpl
+++ b/test/unstable/arrayEquals.chpl
@@ -1,0 +1,4 @@
+var a1 = [1, 2, 3, 4];
+var a2 = [5, 6, 7, 8];
+
+writeln(a1.equals(a2));

--- a/test/unstable/arrayEquals.good
+++ b/test/unstable/arrayEquals.good
@@ -1,0 +1,2 @@
+arrayEquals.chpl:4: warning: the 'Array.equals()' method is unstable
+false


### PR DESCRIPTION
Mark the Array.equals() method as unstable per #19140

Signed-off-by: Jeremiah Corrado <jeremiah.corrado@hpe.com>