### PR TITLE
Limit I/O size between channel buffer and underlying file

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1110,7 +1110,7 @@ private extern proc qio_file_get_plugin(f:qio_file_ptr_t):c_void_ptr;
 private extern proc qio_channel_get_plugin(ch:qio_channel_ptr_t):c_void_ptr;
 private extern proc qio_file_length(f:qio_file_ptr_t, ref len:int(64)):syserr;
 
-private extern proc qio_channel_create(ref ch:qio_channel_ptr_t, file:qio_file_ptr_t, hints:c_int, readable:c_int, writeable:c_int, start:int(64), end:int(64), const ref style:iostyleInternal):syserr;
+private extern proc qio_channel_create(ref ch:qio_channel_ptr_t, file:qio_file_ptr_t, hints:c_int, readable:c_int, writeable:c_int, start:int(64), end:int(64), const ref style:iostyleInternal, bufIoMax:int(64)):syserr;
 
 private extern proc qio_channel_path_offset(threadsafe:c_int, ch:qio_channel_ptr_t, ref path:c_string, ref offset:int(64)):syserr;
 
@@ -2139,7 +2139,7 @@ proc channel.init(param writing:bool, param kind:iokind, param locking:bool, f:f
       local_style.binary = true;
       local_style.byteorder = kind:uint(8);
     }
-    error = qio_channel_create(this._channel_internal, f._file_internal, hints, !writing, writing, start, end, local_style);
+    error = qio_channel_create(this._channel_internal, f._file_internal, hints, !writing, writing, start, end, local_style, 64*1024);
     // On return this._channel_internal.ref_cnt == 1.
     // Failure to check the error return code may result in a double-deletion error.
   }
@@ -4320,10 +4320,12 @@ private proc readBytesOrString(ch: channel, ref out_var: ?t,  len: int(64))
     }
 
     if t == string {
-      out_var = createStringWithOwnedBuffer(tx, length=lenread);
+      var tmp = createStringWithOwnedBuffer(tx, length=lenread);
+      out_var <=> tmp;
     }
     else {
-      out_var = createBytesWithOwnedBuffer(tx, length=lenread);
+      var tmp = createBytesWithOwnedBuffer(tx, length=lenread);
+      out_var <=> tmp;
     }
   }
 

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -316,6 +316,10 @@ char qbuffer_iter_same_part(qbuffer_iter_t a, qbuffer_iter_t b) {
   return deque_it_equals(a.iter, b.iter);
 }
 
+/* is the iterator at the end of a part?
+ */
+int qbuffer_iter_at_part_end(qbuffer_t* buf, qbuffer_iter_t* iter);
+
 /* Moves to the beginning of the next part
  */
 void qbuffer_iter_next_part(qbuffer_t* buf, qbuffer_iter_t* iter);
@@ -471,7 +475,7 @@ qioerr qbuffer_memset(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end, 
 #define qio_malloc(size) chpl_mem_alloc(size, CHPL_RT_MD_IO_BUFFER, __LINE__, 0)
 #define qio_calloc(nmemb, size) chpl_mem_allocManyZero(nmemb, size, CHPL_RT_MD_IO_BUFFER, __LINE__, 0)
 #define qio_realloc(ptr, size) chpl_mem_realloc(ptr, size, CHPL_RT_MD_IO_BUFFER, __LINE__, 0)
-#define qio_memalign(boundary, size)  chpl_memalign(boundary, size)
+#define qio_memalign(boundary, size)  chpl_mem_memalign(boundary, size, CHPL_RT_MD_IO_BUFFER, __LINE__, 0)
 #define qio_free(ptr) chpl_mem_free(ptr, __LINE__, 0)
 #define qio_memcpy(dest, src, num) chpl_memcpy(dest, src, num)
 

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -719,6 +719,7 @@ typedef struct qio_channel_s {
   int64_t mark_space[MARK_INITIAL_STACK_SZ];
 
   qio_style_t style;
+  int64_t bufIoMax; // maximum single I/O to/from buffer
 } qio_channel_t;
 
 
@@ -771,12 +772,11 @@ void* qio_channel_get_plugin(qio_channel_t* ch) {
 }
 
 qioerr _qio_channel_init_buffered(qio_channel_t* ch, qio_file_t* file, qio_hint_t hints, int readable, int writeable, int64_t start, int64_t end, qio_style_t* style);
-qioerr _qio_channel_init_file(qio_channel_t* ch, qio_file_t* file, qio_hint_t hints, int readable, int writeable, int64_t start, int64_t end, qio_style_t* style);
+qioerr _qio_channel_init_file(qio_channel_t* ch, qio_file_t* file, qio_hint_t hints, int readable, int writeable, int64_t start, int64_t end, qio_style_t* style, int64_t bufIoMax);
 
 
 // maybe want to use INT64_MAX for end if it's not to be restricted.
-qioerr qio_channel_create(qio_channel_t** ch_out, qio_file_t* file, qio_hint_t hints, int readable, int writeable, int64_t start, int64_t end, qio_style_t* style);
-
+qioerr qio_channel_create(qio_channel_t** ch_out, qio_file_t* file, qio_hint_t hints, int readable, int writeable, int64_t start, int64_t end, qio_style_t* style, int64_t bufIoMax);
 
 qioerr qio_relative_path(const char** path_out, const char* cwd, const char* path);
 qioerr qio_shortest_path(qio_file_t* file, const char** path_out, const char* path_in);

--- a/runtime/src/qio/qbuffer.c
+++ b/runtime/src/qio/qbuffer.c
@@ -644,6 +644,17 @@ qbuffer_iter_t qbuffer_end(qbuffer_t* buf)
   return ret;
 }
 
+int qbuffer_iter_at_part_end(qbuffer_t* buf, qbuffer_iter_t* iter)
+{
+  deque_iterator_t d_end = deque_end( & buf->deque );
+
+  if (deque_it_equals(iter->iter, d_end) ) {
+    return true;
+  }
+  qbuffer_part_t* qbp = (qbuffer_part_t*) deque_it_get_cur_ptr(sizeof(qbuffer_part_t), iter->iter);
+  return iter->offset == qbp->end_offset;
+}
+
 void qbuffer_iter_next_part(qbuffer_t* buf, qbuffer_iter_t* iter)
 {
   deque_iterator_t d_end = deque_end( & buf->deque );

--- a/test/io/ferguson/ctests/qio_bits_test.test.c
+++ b/test/io/ferguson/ctests/qio_bits_test.test.c
@@ -37,7 +37,7 @@ void check_bits(int offset, int padding)
   err = qio_file_open_tmp(&f, 0, NULL);
   assert(!err);
 
-  err = qio_channel_create(&writing, f, 0, 0, 1, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&writing, f, 0, 0, 1, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   for( i = 0; i < offset; i++ ) {
@@ -73,7 +73,7 @@ void check_bits(int offset, int padding)
   qio_channel_release(writing);
 
   // Read the data a byte at a time.
-  err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   for( i = 0; i < offset; i++ ) {
@@ -103,7 +103,7 @@ void check_bits(int offset, int padding)
   qio_channel_release(reading);
 
   // Read the data with the binary reader.
-  err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   for( i = 0; i < offset; i++ ) {
@@ -130,17 +130,17 @@ void check_bits(int offset, int padding)
     err = qio_channel_read_amt(true, reading, &got, 1);
     assert(!err);
     assert( got == 0xff );
-  
+ 
     b = 0;
     err = qio_channel_read_bits(true, reading, &b, 3);
     assert(!err);
     assert( b == 2 );
- 
+
     got = 0;
     err = qio_channel_read_amt(true, reading, &got, 1);
     assert(!err);
     assert( got == 0xff );
- 
+
     b = 0;
     err = qio_channel_read_bits(true, reading, &b, 3);
     assert(!err);
@@ -223,7 +223,7 @@ void check_write_read_pat(int width, int num, int pat, qio_chtype_t type, qio_hi
     }
   }
 
-  err = qio_channel_create(&writing, f, ch_hints, 0, 1, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&writing, f, ch_hints, 0, 1, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   for( int i = 0; i < num; i++ ) {
@@ -250,7 +250,7 @@ void check_write_read_pat(int width, int num, int pat, qio_chtype_t type, qio_hi
     err = qio_file_open_access(&f, filename, "r", file_hints, NULL);
     assert(!err);
   }
-  // Rewind the file 
+  // Rewind the file
   if( !memory ) {
     off_t off;
 
@@ -260,7 +260,7 @@ void check_write_read_pat(int width, int num, int pat, qio_chtype_t type, qio_hi
 
 
 
-  err = qio_channel_create(&reading, f, ch_hints, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, ch_hints, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   for( int i = 0; i < num; i++ ) {
@@ -351,7 +351,7 @@ int main(int argc, char** argv)
     uint64_t got;
     uint64_t expect;
     qioerr err;
-    
+   
 
     //qbytes_iobuf_size = 256;
 
@@ -360,7 +360,7 @@ int main(int argc, char** argv)
     //err = qio_file_open_access(&f, "test.bin", "w+", 0, NULL);
     //assert(!err);
 
-    err = qio_channel_create(&writing, f, 0, 0, 1, 0, INT64_MAX, NULL);
+    err = qio_channel_create(&writing, f, 0, 0, 1, 0, INT64_MAX, NULL, 0);
     assert(!err);
 
     for( i = 0; i < n; i++ ) {
@@ -372,7 +372,7 @@ int main(int argc, char** argv)
     qio_channel_release(writing);
 
     if( argc > 2 ) {
-      err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL);
+      err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL, 0);
       assert(!err);
 
       for( i = 0; i < n; i++ ) {

--- a/test/io/ferguson/ctests/qio_formatted_test.test.c
+++ b/test/io/ferguson/ctests/qio_formatted_test.test.c
@@ -11,7 +11,7 @@ void test_endian(void)
   // We write (hex) 00 0102 03040506 0708091011121314
   // as big endian and little endian, and then we check
   // that the data is what we expected.
-  
+ 
   qioerr err;
   qio_file_t* f;
   qio_channel_t* writing;
@@ -46,7 +46,7 @@ void test_endian(void)
     }
 
     // Create a "write to file" channel.
-    err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL);
+    err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL, 0);
     assert(!err);
 
     err = qio_channel_write_uint8(true, writing, n0);
@@ -67,7 +67,7 @@ void test_endian(void)
     writing = NULL;
 
     // Create a "read from file" channel.
-    err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+    err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
     assert(!err);
 
     err = qio_channel_read_amt(true, reading, got, len);
@@ -125,7 +125,7 @@ void test_readwriteint(void)
         memset(got, 0, sizeof(got));
 
         // Create a "write to file" channel.
-        err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL);
+        err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL, 0);
         assert(!err);
 
         err = qio_channel_write_int(true, b_order, writing, data, len, sz < 0);
@@ -135,7 +135,7 @@ void test_readwriteint(void)
         writing = NULL;
 
         // Create a "read from file" channel.
-        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
         assert(!err);
 
 
@@ -320,7 +320,7 @@ void test_printscan_int(void)
       memset(got, 0, sizeof(got));
 
       // Create a "write to file" channel.
-      err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, style);
+      err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, style, 0);
       assert(!err);
 
       err = qio_channel_print_int(true, writing, &num, 8, true);
@@ -334,7 +334,7 @@ void test_printscan_int(void)
       writing = NULL;
 
       // Create a "read from file" channel.
-      err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+      err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
       assert(!err);
 
       err = qio_channel_read(true, reading, got, sizeof(got), &amt_read);
@@ -350,7 +350,7 @@ void test_printscan_int(void)
 
       // Try scanning our number.
       // Create a "read from file" channel.
-      err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, style);
+      err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, style, 0);
       assert(!err);
 
       got_num = 0;
@@ -624,7 +624,7 @@ void test_printscan_float(void)
       memset(got, 0, sizeof(got));
 
       // Create a "write to file" channel.
-      err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, style);
+      err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, style, 0);
       assert(!err);
 
       err = qio_channel_print_float(true, writing, &num, 8);
@@ -638,7 +638,7 @@ void test_printscan_float(void)
       writing = NULL;
 
       // Create a "read from file" channel.
-      err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, style);
+      err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, style, 0);
       assert(!err);
 
       err = qio_channel_read(true, reading, got, sizeof(got), &amt_read);
@@ -659,7 +659,7 @@ void test_printscan_float(void)
       // Try scanning our number.
       // Create a "read from file" channel.
       {
-        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
         assert(!err);
 
         got_num = 0;
@@ -704,20 +704,20 @@ void test_verybasic()
 	qio_file_t *f = NULL;
 	qio_channel_t *writing = NULL;
 	qio_channel_t *reading = NULL;
-	qioerr err; 
+	qioerr err;
 	char buf[4] = {0};
-	
+
 	//open the tmp file, create a write channel, write our data, and release the channel
   	err = qio_file_open_tmp(&f, 0, NULL);
         assert(!err);
-      	err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL);
+      	err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL, 0);
         assert(!err);
       	err = qio_channel_write_amt(true, writing, "\xDE\xAD\xBE\xEF", 4);
         assert(!err);
         qio_channel_release(writing);
 
 	//open a read channel to the tmp file, and read back the data.
-    	err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+    	err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
         assert(!err);
       	err = qio_channel_read_amt(true, reading, buf, 4);
         assert(!err);
@@ -758,10 +758,10 @@ void string_escape_tests()
 	style.binary=0;
 	style.string_start = '"';
 	style.string_end = '"';
-	
+
 	err = qio_file_open_tmp(&f, 0, NULL);
         assert(!err);
-        
+       
         for( i = 0; inputs[i][0]; i++ ) {
           const char* input = inputs[i][0];
           ssize_t input_len = strlen(input);
@@ -770,24 +770,24 @@ void string_escape_tests()
             ssize_t expect_len = strlen(expect);
             style.string_format = j;
 
-            err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style);
+            err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style, 0);
             assert(!err);
-            err = qio_channel_print_string(true, writing, input, input_len);	
+            err = qio_channel_print_string(true, writing, input, input_len);
             assert(!err);
             qio_channel_release(writing);
 
-            err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, &style);
+            err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, &style, 0);
             assert(!err);
             err = qio_channel_read_amt(true, reading, buf, expect_len);
             assert(!err);
-     
+    
             qio_channel_release(reading);
 
             //printf("Got %s expect %s\n", buf, expect);
             assert( memcmp(buf, expect, expect_len) == 0 );
 
             // Check that we can read it in again.
-            err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, &style);
+            err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, &style, 0);
             assert(!err);
 
             {
@@ -802,7 +802,7 @@ void string_escape_tests()
 
               qio_free((void*) got);
             }
-     
+    
             qio_channel_release(reading);
           }
         }
@@ -835,7 +835,7 @@ void write_65k_test()
         style.byteorder = QIO_BIG;
         style.str_style = -2;
 
-        err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style);
+        err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style, 0);
         assert(!err);
 
 	p = (char *)qio_calloc(1, buflen);
@@ -847,7 +847,7 @@ void write_65k_test()
         qio_channel_release(writing);
         assert(!err);
 
-        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
         assert(!err);
 
 	while(1){
@@ -872,7 +872,7 @@ void write_65k_test()
 }
 
 /**
- *   
+ *  
  **/
 void max_width_test()
 {
@@ -892,7 +892,7 @@ void max_width_test()
         style.max_width_columns = 5;
 
 
-        err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style);
+        err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style, 0);
         assert(!err);
 
         err = qio_channel_print_string(true, writing, "helloworld", 10);
@@ -900,7 +900,7 @@ void max_width_test()
         qio_channel_release(writing);
         assert(!err);
 
-        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
         assert(!err);
         err = qio_channel_scan_string(true, reading, &out, &out_len, -1);
         assert(!err);
@@ -920,7 +920,7 @@ void max_width_test()
 
 /**
  * Tests the min_width option.
- * by writing 10 byte helloworld string but specifying 
+ * by writing 10 byte helloworld string but specifying
  * min_width = 11 so the read should return 11 bytes where
  * the 11th byte would be a space character.
  */
@@ -941,7 +941,7 @@ void min_width_test()
 	style.string_format = 1;
 	style.min_width_columns = 11;
 
-        err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style);
+        err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style, 0);
         assert(!err);
 
 
@@ -949,7 +949,7 @@ void min_width_test()
         assert(!err);
         qio_channel_release(writing);
 
-        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+        err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
         assert(!err);
         err = qio_channel_scan_string(true, reading, &out, &out_len, -1);
         assert(!err);
@@ -970,7 +970,7 @@ void min_width_test()
  * Test basic ascii functionality
  */
 void basicstring_test()
-{ 
+{
  	const char *out = NULL;
         int64_t out_len = 0;
         qioerr err;
@@ -982,11 +982,11 @@ void basicstring_test()
 	#define NUM_STR_STYLES 12
         qio_style_t styles[NUM_STR_STYLES];
 
-	string_test_t strings[] = { 	
+	string_test_t strings[] = { 
 				    { "", 0 },
 				    { "a", 1 },
 				    { "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 255},
-				  }; 
+				  };
         int NUM_STRINGS = sizeof(strings)/sizeof(string_test_t);
 
         if( verbose ) printf("Testing basic string writing/reading\n");
@@ -1034,12 +1034,12 @@ void basicstring_test()
                         // make style 8 always use the string length!
                         if( x == 8 ) style->str_style = string->length;
 
-        		err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, style);
+        		err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, style, 0);
 			assert(!err);
 
                         //printf("Writing string '%s' with style %i\n", string->string, x);
 
-                        if( style->binary ) 
+                        if( style->binary )
                           err = qio_channel_write_string(true, style->byteorder, style->str_style, writing, string->string, string->length);
                         else
                           err = qio_channel_print_string(true, writing, string->string, string->length);
@@ -1047,11 +1047,11 @@ void basicstring_test()
 			assert(!err);
         		qio_channel_release(writing);
 
-			err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, style);
+			err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, style, 0);
 			assert(!err);
 
                         //printf("Reading string '%s' with style %i\n", string->string, x);
-                        if( style->binary ) 
+                        if( style->binary )
                           err = qio_channel_read_string(true, style->byteorder, style->str_style, reading, &out, &out_len, -1);
                         else
                           err = qio_channel_scan_string(true, reading, &out, &out_len, -1);
@@ -1073,7 +1073,7 @@ void basicstring_test()
 
         qio_file_release(f);
         f = NULL;
-       
+      
         if( verbose ) printf("PASS: basic string test\n");
 #undef NUM_STR_STYLES
 #define NUM_STRINGS 1
@@ -1085,9 +1085,9 @@ void test_readwritestring()
 	//basicstring_test(); in main.
 	write_65k_test();   //write 65k then read it back.
 
-	//min_width_test();  //test min_width              
+	//min_width_test();  //test min_width             
 	//max_width_test();  //test max_width
-	
+
         string_escape_tests();
 }
 
@@ -1101,7 +1101,7 @@ void test_scanmatch()
   err = qio_file_open_tmp(&f, 0, NULL);
   assert(!err);
 
-  err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_write_char(true, writing, ' ');
@@ -1120,7 +1120,7 @@ void test_scanmatch()
 
   qio_channel_release(writing);
 
-  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_scan_literal(true, reading, "test", 4, 1);
@@ -1132,20 +1132,20 @@ void test_scanmatch()
 
   qio_channel_release(reading);
 
-  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
   err = qio_channel_scan_literal(true, reading, " match", 5, 1);
   assert(err == 0);
 
   qio_channel_release(reading);
- 
+
   qio_file_release(f);
   f = NULL;
 
   err = qio_file_open_tmp(&f, 0, NULL);
   assert(!err);
 
-  err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_write_char(true, writing, 'a');
@@ -1157,7 +1157,7 @@ void test_scanmatch()
 
   qio_channel_release(writing);
 
-  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_scan_literal(true, reading, "ab", 2, 1);
@@ -1173,7 +1173,7 @@ void test_scanmatch()
 
   qio_channel_release(reading);
 
-  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_scan_literal(true, reading, "ab", 2, 1);
@@ -1210,7 +1210,7 @@ void do_test_utf8(int wchar, char* utf8)
   err = qio_file_open_tmp(&f, 0, NULL);
   assert(!err);
 
-  err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_write_char(true, writing, wchar);
@@ -1218,7 +1218,7 @@ void do_test_utf8(int wchar, char* utf8)
 
   qio_channel_release(writing);
 
-  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   for( i = 0; i < len; i++ ) {
@@ -1230,7 +1230,7 @@ void do_test_utf8(int wchar, char* utf8)
 
   qio_channel_release(reading);
 
-  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_read_char(true, reading, &got_wchar);
@@ -1239,7 +1239,7 @@ void do_test_utf8(int wchar, char* utf8)
   assert(got_wchar == wchar);
 
   qio_channel_release(reading);
- 
+
   qio_file_release(f);
   f = NULL;
 
@@ -1424,7 +1424,7 @@ void test_quoted_string_maxlength(void)
   style.binary=0;
   style.string_start = '"';
   style.string_end = '"';
-  
+ 
   err = qio_file_open_tmp(&f, 0, NULL);
   assert(!err);
 
@@ -1443,7 +1443,7 @@ void test_quoted_string_maxlength(void)
       ti.max_columns = style.max_width_columns;
       ti.max_chars = SSIZE_MAX;
       ti.max_bytes = SSIZE_MAX;
-      
+     
       // check that qio_quote_string gives correct string when
       // used in a no-quote mode
       if( i != 6 ) {
@@ -1469,13 +1469,13 @@ void test_quoted_string_maxlength(void)
 
       // Now, check that the quoting works correctly when writing.
 
-      err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style);
+      err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, &style, 0);
       assert(!err);
-      err = qio_channel_print_string(true, writing, input, input_len);	
+      err = qio_channel_print_string(true, writing, input, input_len);
       assert(!err);
       qio_channel_release(writing);
 
-      err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, &style);
+      err = qio_channel_create(&reading, f, QIO_CH_BUFFERED, 1, 0, 0, INT64_MAX, &style, 0);
       assert(!err);
       err = qio_channel_read_amt(true, reading, buf, expect_len);
       assert(!err);
@@ -1504,7 +1504,7 @@ int main(int argc, char** argv)
   }
 
   for( int i = 0; sizes[i] != 0; i++ ) {
-    char* codeset = nl_langinfo(CODESET); 
+    char* codeset = nl_langinfo(CODESET);
     qbytes_iobuf_size = sizes[i];
 
     if( 0 == strcmp(codeset, "UTF-8") ) {

--- a/test/io/ferguson/ctests/qio_mark_test.test.c
+++ b/test/io/ferguson/ctests/qio_mark_test.test.c
@@ -13,7 +13,7 @@ void check_mark_easy(void)
   err = qio_file_open_tmp(&f, 0, NULL);
   assert(!err);
 
-  err = qio_channel_create(&writing, f, 0, 0, 1, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&writing, f, 0, 0, 1, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_offset(true, writing, &offset);
@@ -57,7 +57,7 @@ void check_mark_easy(void)
   qio_channel_release(writing);
 
   // Read the data a byte at a time.
-  err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   assert('a' == qio_channel_read_byte(true, reading));
@@ -84,7 +84,7 @@ void check_mark(char* writepattern, char* readpattern)
   err = qio_file_open_tmp(&f, 0, NULL);
   assert(!err);
 
-  err = qio_channel_create(&writing, f, 0, 0, 1, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&writing, f, 0, 0, 1, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_offset(true, writing, &offset);
@@ -114,7 +114,7 @@ void check_mark(char* writepattern, char* readpattern)
   qio_channel_release(writing);
 
   // Read the data a byte at a time.
-  err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL);
+  err = qio_channel_create(&reading, f, 0, 1, 0, 0, INT64_MAX, NULL, 0);
   assert(!err);
 
   for( i = 0; readpattern[i]; i++ ) {

--- a/test/io/ferguson/ctests/qio_memfile_test.test.c
+++ b/test/io/ferguson/ctests/qio_memfile_test.test.c
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
   err = qio_file_length(f, &len);
   assert(!err);
 
-  err = qio_channel_create(&ch, f, 0, 1, 1, len, INT64_MAX, NULL);
+  err = qio_channel_create(&ch, f, 0, 1, 1, len, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_write_amt(1, ch, testone, strlen(testone));
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
   err = qio_file_length(f, &len);
   assert(!err);
 
-  err = qio_channel_create(&ch, f, 0, 1, 1, len, INT64_MAX, NULL);
+  err = qio_channel_create(&ch, f, 0, 1, 1, len, INT64_MAX, NULL, 0);
   assert(!err);
 
   err = qio_channel_write_amt(1, ch, testtwo, strlen(testtwo));

--- a/test/io/ferguson/ctests/qio_test.test.c
+++ b/test/io/ferguson/ctests/qio_test.test.c
@@ -127,7 +127,7 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
   }
 
   // Create a "write to file" channel.
-  err = qio_channel_create(&writing, f, ch_hints, 0, 1, start, ch_end, NULL);
+  err = qio_channel_create(&writing, f, ch_hints, 0, 1, start, ch_end, NULL, 0);
   assert(!err);
 
   // Write stuff to the file.
@@ -225,7 +225,7 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
 
   // Read the data.
   //err = qio_channel_init_file(&reading, type, f, ch_hints, 1, 0, start, end);
-  err = qio_channel_create(&reading, f, ch_hints, 1, 0, start, ch_end, NULL);
+  err = qio_channel_create(&reading, f, ch_hints, 1, 0, start, ch_end, NULL, 0);
   assert(!err);
 
   // Read stuff from the file.


### PR DESCRIPTION
Perform I/O between a channel buffer and the underlying file in fixed-size I/Os, rather than one large I/O. Previously, if the application did a large read from a channel the data would be read from the file into the buffer in a single large read, then copied from the buffer into the application, requiring twice as much memory as the size of the read. A similar behavior happened with writes.

With these changes even if the application does a large read the data are read into the buffer and copied to the application in fixed-size I/Os. The amount of memory is reduced to the size of the read plus the size of the I/O. Writes are similar.

Changing this behavior required several changes and fixes to the channel implementation. First, the channels are no longer marked when reading or writing unstructered data such as strings and bytes. Marking a channel causes all subsequent reads or writes to be buffered until the channel is reverted or committed, requiring memory equal to the subsequent reads or writes independent of the size of the I/Os to the underlying file. There is little point in marking the channel anyway as reverting a write is impossible and reverting a read of unstructured data isn't very useful.

Second, there was an off-by-one error in the buffer implementation necessitating qbuffer_iter_at_part_end.

Third, qio_memalign did not call chpl_mem_memalign so that memory allocated in this way could not be tracked.

Fourth, the result of readBytesOrString was created through a copy, so that in the case of a large read the memory requirements were three times the size of the read. Using the swap operator avoids this copy.

Resolves https://github.com/chapel-lang/chapel/issues/18913 and closes Cray/chapel-private#3349.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>