### PR TITLE
update chapelio docs

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -83,17 +83,19 @@ one can write
 
   f <~> x <~> y;
 
-Note that the types :type:`IO.ioLiteral` and :type:`IO.ioNewline` may be useful
-when using the ``<~>`` operator. :type:`IO.ioLiteral` represents some string
+Note that the types :type:`IO.ioLiteral` and :type:`IO.ioNewline` from the :mod:`IO` module
+may be useful when using the ``<~>`` operator. :type:`IO.ioLiteral` represents some string
 that must be read or written as-is (e.g. ``","`` when working with a tuple),
 and :type:`IO.ioNewline` will emit a newline when writing but skip to and
-consume a newline when reading.
+consume a newline when reading. Note that these types are not included by default.
 
 
 This example defines a readWriteThis method and demonstrates how ``<~>`` will
 call the read or write routine, depending on the situation.
 
 .. code-block:: chapel
+
+  use IO;
 
   class IntPair {
     var x: int;
@@ -106,8 +108,6 @@ call the read or write routine, depending on the situation.
   write(ip);
   // prints out
   // 17,2
-
-  delete ip;
 
 This example defines a only a writeThis method - so that there will be a
 function resolution error if the class NoRead is read.
@@ -128,8 +128,6 @@ function resolution error if the class NoRead is read.
   // hello
 
   // Note that read(nr) will generate a compiler error.
-
-  delete nr;
 
 .. _default-readThis-writeThis:
 


### PR DESCRIPTION
From a discussion in gitter, the examples in the [ChapelIO](https://chapel-lang.org/docs/modules/standard/ChapelIO.html) page did not compile. The example

```chpl
class IntPair {
  var x: int;
  var y: int;
  proc readWriteThis(f) throws {
    f <~> x <~> new ioLiteral(",") <~> y <~> new ioNewline();
  }
}
var ip = new IntPair(17,2);
write(ip);
// prints out
// 17,2

delete ip;
```

failed to compile with error
```
sandbox.chpl:5: error: Attempt to 'new' a function or undefined symbol
sandbox.chpl:5: error: Attempt to 'new' a function or undefined symbol
```

because `ioLiteral` and `ioNewline` are not included by default. This was fixed by adding `use IO` at the beginning of the snippet and a note in the text about this (not sure whether this is the best improvement though)

Next, the snippet still didn't compile with error
```
sandbox.chpl:16: error: 'delete' is not allowed on an owned class type
```

which was fixed by removing the delete statement in that example and the one after.