### PR TITLE
Fixing Chapel and C syntax mix-up in interop docs

### DIFF
--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -70,7 +70,7 @@ example, one can define a Chapel file ``foo.chpl`` like this:
    }
 
    // As will this one
-   export proc baz(int x) {
+   export proc baz(x: int) {
      // Does something different
      ...
    }


### PR DESCRIPTION
The parameters of a chapel function were written with C syntax.