### PR TITLE
C/Chapel Syntax Mixup in Interop Docs

### DIFF
--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -70,7 +70,7 @@ example, one can define a Chapel file ``foo.chpl`` like this:
    }
 
    // As will this one
-   export proc baz(int x) {
+   export proc baz(x: int) {
      // Does something different
      ...
    }


### PR DESCRIPTION
The Chapel function was declared with C-syntax parameters. I switched it to the correct syntax.
Signed-off-by: Brandon Neth <brandon.neth@hpe.com>