### PR TITLE
Fixed tests failing due to shifted line numbers in chapelio

### DIFF
--- a/test/optimizations/bulkcomm/asenjo/ptransDR/v1/ptrans.good
+++ b/test/optimizations/bulkcomm/asenjo/ptransDR/v1/ptrans.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:770: In function 'write':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:771: warning: write with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:768: In function 'write':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:769: warning: write with a style argument is deprecated
   ./util.chpl:46: called as write(args(0): real(64), args(1): iostyleInternal) from function 'showrealrow'
   ./util.chpl:41: called as showrealrow(ARR: [domain(2,int(64),false)] real(64), i: int(64))
 

--- a/test/optimizations/bulkcomm/asenjo/ptransDR/v2/ptrans.good
+++ b/test/optimizations/bulkcomm/asenjo/ptransDR/v2/ptrans.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:770: In function 'write':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:771: warning: write with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:768: In function 'write':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:769: warning: write with a style argument is deprecated
   ./util.chpl:46: called as write(args(0): real(64), args(1): iostyleInternal) from function 'showrealrow'
   ./util.chpl:41: called as showrealrow(ARR: [domain(2,int(64),false)] real(64), i: int(64))
 

--- a/test/optimizations/bulkcomm/asenjo/stencilDR/v1/stencil.good
+++ b/test/optimizations/bulkcomm/asenjo/stencilDR/v1/stencil.good
@@ -1,8 +1,8 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:774: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:775: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
   ./util.chpl:70: called as writeln(args(0): [domain(2,int(64),false)] real(64), args(1): iostyleInternal)
-$CHPL_HOME/modules/standard/ChapelIO.chpl:770: In function 'write':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:771: warning: write with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:768: In function 'write':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:769: warning: write with a style argument is deprecated
   ./util.chpl:92: called as write(args(0): real(64), args(1): iostyleInternal) from function 'showrealrow'
   ./util.chpl:87: called as showrealrow(ARR: [domain(2,int(64),false)] real(64), i: int(64))
 

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:774: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:775: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
   spectral-norm-barrier.chpl:86: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-double-time.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-double-time.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:774: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:775: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
   spectral-norm-double-time.chpl:71: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-no-reduct.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-no-reduct.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:774: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:775: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
   spectral-norm-no-reduct.chpl:77: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-specify-step.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-specify-step.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:774: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:775: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
   spectral-norm-specify-step.chpl:91: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:774: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:775: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
   spectral-norm.chpl:59: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.good
+++ b/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:774: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:775: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
   spectralnorm.chpl:73: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/sidelnik/spectralnorm_2.good
+++ b/test/studies/shootout/spectral-norm/sidelnik/spectralnorm_2.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:774: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:775: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
   spectralnorm_2.chpl:61: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116


### PR DESCRIPTION
The following tests failed after #19974: 
```
[Error matching program output for optimizations/bulkcomm/asenjo/ptransDR/v1/ptrans]
[Error matching program output for optimizations/bulkcomm/asenjo/ptransDR/v2/ptrans]
[Error matching program output for optimizations/bulkcomm/asenjo/stencilDR/v1/stencil]
[Error matching program output for studies/shootout/spectral-norm/lydia/spectral-norm-barrier]
[Error matching program output for studies/shootout/spectral-norm/lydia/spectral-norm-double-time]
[Error matching program output for studies/shootout/spectral-norm/lydia/spectral-norm-no-reduct]
[Error matching program output for studies/shootout/spectral-norm/lydia/spectral-norm-specify-step]
[Error matching program output for studies/shootout/spectral-norm/lydia/spectral-norm]
[Error matching program output for studies/shootout/spectral-norm/sidelnik/spectralnorm]
[Error matching program output for studies/shootout/spectral-norm/sidelnik/spectralnorm_2]
```
Due to a shift in line numbers that were embedded in the test's `.good` files. 

Those line numbers have been updated accordingly. 

Signed-off-by: Jeremiah Corrado <jeremiah.corrado@hpe.com>