### PR TITLE
fix(mason-example): properly set the build flag when running examples

### DIFF
--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -154,7 +154,7 @@ private proc masonBuildRun(args: [?d] string) {
     var release = releaseFlag.valueAsBool();
     var force = forceFlag.valueAsBool();
     var exec = false;
-    var buildExample = false;
+    var buildExample = buildFlag.valueAsBool();
     var skipUpdate = MASON_OFFLINE;
     var execopts: list(string);
     var exampleProgram='';


### PR DESCRIPTION
This PR fixes a bug where running `mason run --example <example_name> --build`
would not rebuild the example prior to running. 

* the flag to tell an example to build was defaulted to false and
  never updated with the result of command-line parsing. This caused
  `mason run --example <name> --build` to fail to build. 
  Reported by user during CHIUW 2022 coding day.

TESTING:
- [x] paratest
- [x] `mason run --example <example_name> --build` builds before run

reviewed by @bmcdonald3 - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>