### PR TITLE
Keep "called" modules alive for the sake of generating errors for them

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1442,7 +1442,7 @@ static void resolveModuleCall(CallExpr* call) {
           currModule->moduleUseAdd(calledModule);
           storeReferencedMod(calledModule, call);
         }
-        
+
 #ifdef HAVE_LLVM
         // Failing that, try looking in an extern block.
         if (sym == NULL && mod->extern_info != nullptr) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1436,6 +1436,13 @@ static void resolveModuleCall(CallExpr* call) {
           sym = t->symbol;
         }
 
+        // If sym itself is a module, note that it is used
+        // (relevant for getting an error for the case in issue 19932).
+        if (ModuleSymbol* calledModule = toModuleSymbol(sym)) {
+          currModule->moduleUseAdd(calledModule);
+          storeReferencedMod(calledModule, call);
+        }
+        
 #ifdef HAVE_LLVM
         // Failing that, try looking in an extern block.
         if (sym == NULL && mod->extern_info != nullptr) {

--- a/test/modules/errors/callModLikeProc.chpl
+++ b/test/modules/errors/callModLikeProc.chpl
@@ -1,0 +1,11 @@
+module A {
+  module B {
+  }
+}
+
+module Main {
+  proc main() {
+    use A;
+    A.B();
+  }
+}

--- a/test/modules/errors/callModLikeProc.good
+++ b/test/modules/errors/callModLikeProc.good
@@ -1,0 +1,2 @@
+callModLikeProc.chpl:7: In function 'main':
+callModLikeProc.chpl:9: error: modules (like 'B' here) cannot be called like procedures

--- a/test/modules/errors/callModLikeProc2.chpl
+++ b/test/modules/errors/callModLikeProc2.chpl
@@ -1,0 +1,11 @@
+module A {
+  module B {
+  }
+}
+
+module Main {
+  proc main() {
+    use A;
+    A.B;
+  }
+}

--- a/test/modules/errors/callModLikeProc2.good
+++ b/test/modules/errors/callModLikeProc2.good
@@ -1,0 +1,2 @@
+callModLikeProc2.chpl:7: In function 'main':
+callModLikeProc2.chpl:9: error: modules (like 'B' here) cannot be called like procedures


### PR DESCRIPTION
[developed by @mppf; reviewed and tested by me]

Prior to this PR, a module that was "called" but otherwise dead was
dead-code eliminated, causing the compiler error that we'd generate
further along in compilation to refer to dead code.  This PR keeps
such called modules alive for the sake of generating a legal error.
It seems that we could also generate the error here, but this
approach has the benefit of emitting all instances of this error
in a single place.

Beyond putting Michael's suggested code change into a PR, I captured
the tests that were filed to highlight this issue from #19932.

Resolves #19932.