### PR TITLE
Updates and fixes to dyno-chpldoc

### DIFF
--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -607,12 +607,11 @@ struct RstSignatureVisitor {
       call->actual(0)->traverse(*this);
       if (needsParens) os_ << ")";
       needsParens = false;
-      if (call->op() == USTR("by")
-          || (call->op() != USTR("**") && call->op() != USTR(":")))
+      bool addSpace = wantSpaces(call->op().c_str(), true);
+      if (addSpace)
         os_ << " ";
       os_ << call->op();
-      if (call->op() == USTR("by")
-          || (call->op() != USTR("**") && call->op() != USTR(":")))
+      if (addSpace)
         os_ << " ";
       if (call->actual(1)->isOpCall()) {
         innerOp = call->actual(1)->toOpCall()->op().str();

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -564,24 +564,24 @@ struct RstSignatureVisitor {
 
   bool enter(const OpCall* call) {
     bool needsParens = false;
-    std::string outerOp, innerOp;
+    UniqueString outerOp, innerOp;
     if (call->isUnaryOp()) {
       assert(call->numActuals() == 1);
       bool isPostFixBang = false;
       bool isNilable = false;
-      outerOp = call->op().str();
+      outerOp = call->op();
       if (call->op() == USTR("postfix!")) {
         isPostFixBang = true;
-        outerOp = "!";
+        outerOp = USTR("!");
       } else if (call->op() == USTR("?")) {
         isNilable = true;
-        outerOp = "?";
+        outerOp = USTR("?");
       } else {
-        os_ << call->op().c_str();
+        os_ << call->op();
       }
       if (call->actual(0)->isOpCall()) {
-        innerOp = call->actual(0)->toOpCall()->op().str();
-        needsParens = needParens(outerOp.c_str(), innerOp.c_str(), true,
+        innerOp = call->actual(0)->toOpCall()->op();
+        needsParens = needParens(outerOp, innerOp, true,
                                  (isPostFixBang || isNilable),
                                  call->actual(0)->toOpCall()->isUnaryOp(),
                                  isPostfix(call->actual(0)->toOpCall()) , false);
@@ -596,10 +596,10 @@ struct RstSignatureVisitor {
       }
     } else if (call->isBinaryOp()) {
       assert(call->numActuals() == 2);
-      outerOp = call->op().str();
+      outerOp = call->op();
       if (call->actual(0)->isOpCall()) {
-        innerOp = call->actual(0)->toOpCall()->op().str();
-        needsParens = needParens(outerOp.c_str(), innerOp.c_str(), false, false,
+        innerOp = call->actual(0)->toOpCall()->op();
+        needsParens = needParens(outerOp, innerOp, false, false,
                                  call->actual(0)->toOpCall()->isUnaryOp(),
                                  isPostfix(call->actual(0)->toOpCall()), false);
       }
@@ -607,15 +607,15 @@ struct RstSignatureVisitor {
       call->actual(0)->traverse(*this);
       if (needsParens) os_ << ")";
       needsParens = false;
-      bool addSpace = wantSpaces(call->op().c_str(), true);
+      bool addSpace = wantSpaces(call->op(), true);
       if (addSpace)
         os_ << " ";
       os_ << call->op();
       if (addSpace)
         os_ << " ";
       if (call->actual(1)->isOpCall()) {
-        innerOp = call->actual(1)->toOpCall()->op().str();
-        needsParens = needParens(outerOp.c_str(), innerOp.c_str(), false,
+        innerOp = call->actual(1)->toOpCall()->op();
+        needsParens = needParens(outerOp, innerOp, false,
                                  false, call->actual(1)->toOpCall()->isUnaryOp(),
                                  isPostfix(call->actual(1)->toOpCall()) , true);
         // special case handling things like 3*(4*string)

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -169,6 +169,7 @@ static const char* kindToRstString(bool isMethod, Function::Kind kind) {
   case Function::Kind::PROC: return isMethod ? "method" : "function";
   case Function::Kind::ITER: return isMethod ? "itermethod" : "iter";
   case Function::Kind::OPERATOR: return "operator";
+  case Function::Kind::LAMBDA: return "lambda";
   }
   assert(false);
   return "";
@@ -189,6 +190,7 @@ static const char* kindToString(Function::Kind kind) {
   case Function::Kind::PROC: return "proc";
   case Function::Kind::ITER: return "iter";
   case Function::Kind::OPERATOR: return "operator";
+  case Function::Kind::LAMBDA: return "lambda";
   }
   assert(false);
   return "";

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -618,6 +618,12 @@ struct RstSignatureVisitor {
         needsParens = needParens(outerOp.c_str(), innerOp.c_str(), false,
                                  false, call->actual(1)->toOpCall()->isUnaryOp(),
                                  isPostfix(call->actual(1)->toOpCall()) , true);
+        // special case handling things like 3*(4*string)
+        if (!needsParens && innerOp == "*" &&
+            (call->actual(1)->toOpCall()->actual(1)->isTuple() ||
+             call->actual(1)->toOpCall()->actual(1)->isIdentifier())) {
+          needsParens = true;
+        }
       }
       if (needsParens) os_ << "(";
       call->actual(1)->traverse(*this);

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -351,7 +351,7 @@ struct RstSignatureVisitor {
 
   bool enter(const EnumElement* e) {
     os_ << e->name().c_str();
-    if (const Expression* ie = e->initExpression()) {
+    if (const AstNode* ie = e->initExpression()) {
       os_ <<  " = ";
       ie->traverse(*this);
     }
@@ -366,11 +366,11 @@ struct RstSignatureVisitor {
       os_ << kindToString(v->kind()) << " ";
     }
     os_ << v->name().c_str();
-    if (const Expression* te = v->typeExpression()) {
+    if (const AstNode* te = v->typeExpression()) {
       os_ << ": ";
       te->traverse(*this);
     }
-    if (const Expression* ie = v->initExpression()) {
+    if (const AstNode* ie = v->initExpression()) {
       os_ << " = ";
       ie->traverse(*this);
     }
@@ -382,11 +382,11 @@ struct RstSignatureVisitor {
       os_ << kindToString(f->intent()) << " ";
     }
     os_ << f->name().c_str();
-    if (const Expression* te = f->typeExpression()) {
+    if (const AstNode* te = f->typeExpression()) {
       os_ << ": ";
       te->traverse(*this);
     }
-    if (const Expression* ie = f->initExpression()) {
+    if (const AstNode* ie = f->initExpression()) {
       os_ << "=";
       ie->traverse(*this);
     }
@@ -415,7 +415,7 @@ struct RstSignatureVisitor {
     }
 
     // Return type
-    if (const Expression* e = f->returnType()) {
+    if (const AstNode* e = f->returnType()) {
       os_ << ": ";
       e->traverse(*this);
     }
@@ -443,7 +443,7 @@ struct RstSignatureVisitor {
   }
 
   bool enter(const Call* call) {
-    const Expression* callee = call->calledExpression();
+    const AstNode* callee = call->calledExpression();
     if (!callee) {
       printf("ERROR %s\n", asttags::tagToString(call->tag()));
       call->stringify(std::cerr, StringifyKind::DEBUG_DETAIL);


### PR DESCRIPTION
This PR captures work to get dyno-chpldoc to pass more of our
chpldoc test suite. We were previously passing about 15/150 tests
and this update brings us up to ~29 passing tests.

* Added new command-line arguments to match `chpldoc`

* Added `checkVersion` from `chpldoc` to validate a version
  number passed from the command line.

* Fixed printing of `MultiDecl` to match format needed
  by docs. Type and value information will print on the 
  first `var` and subsequent matching types and values
  will refer to the first `var.type` and value.
  Example:

  ```chapel
  var x, y, z: int;
  ```
  printed in docs like:
  ```
  .. data:: var x: int
  .. data:: var y: x.type
  .. data:: var z: y.type
  ```


* Print `iterfunction` instead of `iter` for docs

* Print `attribute` when a `var` is part of a `Class` or `Record`.

* Add custom printing for `TypeQuery`, `VarArgFormal`, and `Conditional`

* Update `Expression` to `AstNode` due to previous change to class name

* Print a comma as last character of 1-tuples

* Improve printing of `Function` signatures to include more information 
  as needed by docs

* Collapse most `kindToString` functions into a single function that
  handles all entries as `IntentList`

* Add `lambda` as a `Function::Kind`

* Add handling for `FnCall`, remove `Call`

* Improve handling for `OpCall` printing by evaluating prefix/postfix operators
  and operator precedence

* Add handling for `Class`

TESTING:

- [x] `dyno-chpldoc` passes ~29/150 `chpldoc` tests (vs. ~15)
- [x] paratest

reviewed by @mppf - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>