### PR TITLE
dyno: resolve param for loops

### DIFF
--- a/compiler/dyno/include/chpl/resolution/resolution-types.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-types.h
@@ -26,10 +26,10 @@
 #include "chpl/types/QualifiedType.h"
 #include "chpl/types/Type.h"
 #include "chpl/uast/AstNode.h"
+#include "chpl/uast/For.h"
 #include "chpl/uast/Function.h"
 #include "chpl/util/bitmap.h"
 #include "chpl/util/memory.h"
-#include "chpl/uast/all-uast.h"
 
 #include <unordered_map>
 #include <utility>
@@ -1431,13 +1431,14 @@ class ResolvedFields {
 };
 
 class ResolvedParamLoop {
-  private:
-    const uast::For* loop_;
-    std::vector<ResolutionResultByPostorderID> loopBodies_;
-
   public:
     using LoopBodies = std::vector<ResolutionResultByPostorderID>;
 
+  private:
+    const uast::For* loop_;
+    LoopBodies loopBodies_;
+
+  public:
     ResolvedParamLoop(const uast::For* loop) : loop_(loop) { }
 
     const uast::For* loop() const {

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -2073,7 +2073,7 @@ bool Resolver::enter(const For* loop) {
 
         cur.exitScope(loop);
 
-        loopResults.push_back(cur.byPostorder);
+        loopResults.push_back(std::move(cur.byPostorder));
       }
 
       auto paramLoop = new ResolvedParamLoop(loop);

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -299,6 +299,19 @@ Resolver::parentClassResolver(Context* context,
   return ret;
 }
 
+// set up Resolver to resolve a param loop
+Resolver
+Resolver::paramLoopResolver(Resolver& parent,
+                            const For* loop,
+                            ResolutionResultByPostorderID& bodyResults) {
+  auto ret = Resolver(parent.context, loop, bodyResults, parent.poiScope);
+  ret.parentResolver = &parent;
+  ret.declStack = parent.declStack;
+  ret.byPostorder.setupForParamLoop(loop, parent.byPostorder);
+
+  return ret;
+}
+
 std::vector<types::QualifiedType>
 Resolver::getFormalTypes(const Function* fn) {
   std::vector<types::QualifiedType> formalTypes;
@@ -1108,6 +1121,20 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
   //
   // when resolving a module statement, the resolution result only
   // contains things within that statement.
+  if (parentResolver != nullptr) {
+    const Scope* idScope = scopeForId(context, id);
+    bool local = false;
+    for (auto sc : scopeStack) {
+      if (sc == idScope) {
+        local = true;
+      }
+    }
+
+    if (!local) {
+      return parentResolver->typeForId(id, localGenericToUnknown);
+    }
+  }
+
   bool useLocalResult = (id.symbolPath() == symbol->id().symbolPath() &&
                          id.postOrderId() >= 0);
   bool error = false;
@@ -2012,67 +2039,111 @@ void Resolver::exit(const uast::New* node) {
 }
 
 bool Resolver::enter(const For* loop) {
-  enterScope(loop);
 
   const AstNode* iterand = loop->iterand();
   iterand->traverse(*this);
-
   ResolvedExpression& iterandRE = byPostorder.byAst(iterand);
 
-  auto& MSC = iterandRE.mostSpecific();
-  bool isIter = MSC.isEmpty() == false &&
-                MSC.numBest() == 1 &&
-                MSC.only()->untyped()->kind() == uast::Function::Kind::ITER;
+  if (loop->isParam()) {
+    if (iterand->isRange() == false) {
+      context->error(loop, "param loops may only iterate over range literals");
+    } else {
+      // TODO: ranges with strides, '#', and '<'
+      const Range* rng = iterand->toRange();
+      ResolvedExpression& lowRE = byPostorder.byAst(rng->lowerBound());
+      ResolvedExpression& hiRE = byPostorder.byAst(rng->upperBound());
+      auto low = lowRE.type().param()->toIntParam();
+      auto hi = hiRE.type().param()->toIntParam();
 
-  bool wasResolved = iterandRE.type().isUnknown() == false &&
-                     iterandRE.type().isErroneousType() == false;
+      if (low == nullptr || hi == nullptr) {
+        context->error(loop, "param loops may only iterate over range literals with integer bounds");
+      }
 
-  QualifiedType idxType;
+      std::vector<ResolutionResultByPostorderID> loopResults;
+      for (int64_t i = low->value(); i <= hi->value(); i++) {
+        ResolutionResultByPostorderID bodyResults;
+        auto cur = Resolver::paramLoopResolver(*this, loop, bodyResults);
 
-  if (isIter) {
-    idxType = iterandRE.type();
-  } else if (wasResolved) {
-    //
-    // Resolve "iterand.these()"
-    //
-    std::vector<CallInfoActual> actuals;
-    actuals.push_back(CallInfoActual(iterandRE.type(), USTR("this")));
-    auto ci = CallInfo (/* name */ USTR("these"),
-                        /* calledType */ iterandRE.type(),
-                        /* isMethod */ true,
-                        /* hasQuestionArg */ false,
-                        /* isParenless */ false,
-                        actuals);
-    auto inScope = scopeStack.back();
-    auto c = resolveGeneratedCall(context, iterand, ci, inScope, poiScope);
+        cur.enterScope(loop);
 
-    if (c.mostSpecific().only() != nullptr) {
-      idxType = c.exprType();
-      handleResolvedAssociatedCall(iterandRE, loop, ci, c);
+        ResolvedExpression& idx = cur.byPostorder.byAst(loop->index());
+        QualifiedType qt = QualifiedType(QualifiedType::PARAM, lowRE.type().type(), IntParam::get(context, i));
+        idx.setType(qt);
+        loop->body()->traverse(cur);
+
+        cur.exitScope(loop);
+
+        loopResults.push_back(cur.byPostorder);
+      }
+
+      auto paramLoop = new ResolvedParamLoop(loop);
+      paramLoop->setLoopBodies(loopResults);
+      auto& resolvedLoopExpr = byPostorder.byAst(loop);
+      resolvedLoopExpr.setParamLoop(paramLoop);
+    }
+
+    return false;
+  } else {
+    enterScope(loop);
+
+    auto& MSC = iterandRE.mostSpecific();
+    bool isIter = MSC.isEmpty() == false &&
+                  MSC.numBest() == 1 &&
+                  MSC.only()->untyped()->kind() == uast::Function::Kind::ITER;
+
+    bool wasResolved = iterandRE.type().isUnknown() == false &&
+                       iterandRE.type().isErroneousType() == false;
+
+    QualifiedType idxType;
+
+    if (isIter) {
+      idxType = iterandRE.type();
+    } else if (wasResolved) {
+      //
+      // Resolve "iterand.these()"
+      //
+      std::vector<CallInfoActual> actuals;
+      actuals.push_back(CallInfoActual(iterandRE.type(), USTR("this")));
+      auto ci = CallInfo (/* name */ USTR("these"),
+                          /* calledType */ iterandRE.type(),
+                          /* isMethod */ true,
+                          /* hasQuestionArg */ false,
+                          /* isParenless */ false,
+                          actuals);
+      auto inScope = scopeStack.back();
+      auto c = resolveGeneratedCall(context, iterand, ci, inScope, poiScope);
+
+      if (c.mostSpecific().only() != nullptr) {
+        idxType = c.exprType();
+        handleResolvedAssociatedCall(iterandRE, loop, ci, c);
+      } else {
+        idxType = QualifiedType(QualifiedType::UNKNOWN,
+                                ErroneousType::get(context));
+        std::ostringstream oss;
+        iterandRE.type().type()->stringify(oss, chpl::StringifyKind::CHPL_SYNTAX);
+        context->error(loop, "unable to iterate over values of type %s", oss.str().c_str());
+      }
     } else {
       idxType = QualifiedType(QualifiedType::UNKNOWN,
                               ErroneousType::get(context));
-      std::ostringstream oss;
-      iterandRE.type().type()->stringify(oss, chpl::StringifyKind::CHPL_SYNTAX);
-      context->error(loop, "unable to iterate over values of type %s", oss.str().c_str());
     }
-  } else {
-    idxType = QualifiedType(QualifiedType::UNKNOWN,
-                            ErroneousType::get(context));
-  }
 
-  if (const Decl* idx = loop->index()) {
-    ResolvedExpression& re = byPostorder.byAst(idx);
-    re.setType(idxType);
-  }
+    if (const Decl* idx = loop->index()) {
+      ResolvedExpression& re = byPostorder.byAst(idx);
+      re.setType(idxType);
+    }
 
-  loop->body()->traverse(*this);
+    loop->body()->traverse(*this);
+  }
 
   return false;
 }
 
 void Resolver::exit(const For* loop) {
-  exitScope(loop);
+  // Param loops handle scope differently
+  if (loop->isParam() == false) {
+    exitScope(loop);
+  }
 }
 
 bool Resolver::enter(const AstNode* ast) {

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -51,6 +51,7 @@ struct Resolver {
   bool receiverScopeComputed = false;
   const Scope* savedReceiverScope = nullptr;
   const types::CompositeType* savedReceiverType = nullptr;
+  Resolver* parentResolver = nullptr;
 
   // results of the resolution process
 
@@ -155,6 +156,11 @@ struct Resolver {
                       const SubstitutionsMap& substitutions,
                       const PoiScope* poiScope,
                       ResolutionResultByPostorderID& byPostorder);
+
+  // set up Resolver to resolve a param for loop body
+  static Resolver paramLoopResolver(Resolver& parent,
+                                    const uast::For* loop,
+                                    ResolutionResultByPostorderID& bodyResults);
 
   /* Get the formal types from a Resolver that computed them
    */

--- a/compiler/dyno/lib/resolution/resolution-types.cpp
+++ b/compiler/dyno/lib/resolution/resolution-types.cpp
@@ -28,6 +28,7 @@
 #include "chpl/uast/FnCall.h"
 #include "chpl/uast/Formal.h"
 #include "chpl/uast/Identifier.h"
+#include "chpl/uast/For.h"
 
 namespace chpl {
 namespace resolution {
@@ -180,6 +181,15 @@ void ResolutionResultByPostorderID::setupForSignature(const Function* func) {
   vec.resize(bodyPostorder);
 
   symbolId = func->id();
+}
+void ResolutionResultByPostorderID::setupForParamLoop(const For* loop, ResolutionResultByPostorderID& parent) {
+  int bodyPostorder = 0;
+  if (loop && loop->body())
+    bodyPostorder = loop->body()->id().postOrderId();
+  assert(0 <= bodyPostorder);
+  vec.resize(bodyPostorder);
+
+  this->symbolId = parent.symbolId;
 }
 void ResolutionResultByPostorderID::setupForFunction(const Function* func) {
   setupForSymbol(func);

--- a/compiler/dyno/test/resolution/ResolvedVisitor.h
+++ b/compiler/dyno/test/resolution/ResolvedVisitor.h
@@ -21,6 +21,7 @@
 #define CHPL_RESOLUTION_RESOLVED_VISITOR_H
 
 #include "chpl/resolution/resolution-types.h"
+#include "chpl/uast/all-uast.h"
 
 namespace chpl {
 namespace resolution {

--- a/compiler/dyno/test/resolution/ResolvedVisitor.h
+++ b/compiler/dyno/test/resolution/ResolvedVisitor.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_RESOLUTION_RESOLVED_VISITOR_H
+#define CHPL_RESOLUTION_RESOLVED_VISITOR_H
+
+#include "chpl/resolution/resolution-types.h"
+
+namespace chpl {
+namespace resolution {
+
+using namespace uast;
+
+template <typename UV>
+struct ResolvedVisitor {
+  Context* context = nullptr;
+  const uast::AstNode* symbol = nullptr;
+  UV& userVisitor;
+
+  // the resolution results for the contained AstNodes
+  const ResolutionResultByPostorderID& byPostorder;
+
+public:
+  ResolvedVisitor(Context* context,
+           const uast::AstNode* symbol,
+           UV& userVisitor,
+           const ResolutionResultByPostorderID& byPostorder)
+    : context(context),
+      symbol(symbol),
+      userVisitor(userVisitor),
+      byPostorder(byPostorder) {
+  }
+
+  // TODO: Some factory functions that user visitors can call
+  //static ResolvedVisitor
+  //resolvedModuleVisitor(Context* context,
+  //                      UV& userVisitor,
+  //                      const uast::Module* mod);
+
+  //static ResolvedVisitor
+  //resolvedConcreteFunctionVisitor(Context* context,
+  //                                UV& userVisitor,
+  //                                const uast::Function* fn);
+
+  //static ResolvedVisitor
+  //resolvedFunctionVisitor(Context* context,
+  //                        UV& userVisitor,
+  //                        const ResolvedFunction* fn);
+
+
+  //// TODO: use with 'fieldsForTypeDecl'
+  //static ResolvedVisitor
+  //resolvedTypeDeclVisitor(Context* context,
+  //                        UV& userVisitor,
+  //                        uast::TypeDecl* type);
+
+  // TODO
+  // Should we have some kind of iterator for a param For Loop that yields
+  // ResolvedVisitor objects?
+
+  /*
+   * Visiting a param for-loop has special behavior. The user's visitor
+   * will be invoked with the current resolution results. These results will
+   * contain valid information for the iterand, and the means to access the
+   * per-iteration resolution results in case the ResolvedVisitor's default
+   * behavior is insufficient.
+   *
+   * If the user's visitor returns true, then the ResolvedVisitor will invoke
+   * the user's visitor once on the iterand, and will then invoke the user's
+   * visitor on the loop index and loop body for each iteration of the param
+   * for-loop.
+   */
+  bool enter(const uast::For* loop) {
+    if (loop->isParam()) {
+      // Enter the param for-loop with the current resolution results, so that
+      // the user-defined visitor can choose to do something custom if it
+      // wants.
+      bool goInto = userVisitor.enter(loop, *this);
+
+      if (goInto) {
+        const ResolvedExpression& rr = byPostorder.byAst(loop);
+        const ResolvedParamLoop* resolvedLoop = rr.paramLoop();
+
+        const AstNode* iterand = loop->iterand();
+        iterand->traverse(*this);
+
+        // TODO: Should there be some kind of function the UserVisitor can
+        // implement to observe a new iteration of the loop body?
+        for (auto loopBody : resolvedLoop->loopBodies()) {
+          ResolvedVisitor<UV> loopVis(context, loop, userVisitor, loopBody);
+
+          for (const AstNode* child : loop->children()) {
+            // Written to visit "all but the iterand" in case we add more
+            // fields/children to the For class later.
+            if (child != iterand) {
+              child->traverse(loopVis);
+            }
+          }
+        }
+      }
+
+      return false;
+    } else {
+      return userVisitor.enter(loop, *this);
+    }
+  }
+
+  void exit(const uast::For* loop) {
+    userVisitor.exit(loop, *this);
+  }
+
+  // if none of the above is called, fall back on this one
+  bool enter(const uast::AstNode* ast) {
+    switch (ast->tag()) {
+      #define CASE_LEAF(NAME) \
+        case asttags::NAME: \
+        { \
+          const NAME* casted = (const NAME*) ast; \
+          userVisitor.enter(casted, *this); \
+          assert(ast->numChildren() == 0); \
+          userVisitor.exit(casted, *this); \
+          break; \
+        }
+
+      #define CASE_NODE(NAME) \
+        case asttags::NAME: \
+        { \
+          const NAME* casted = (const NAME*) ast; \
+          bool goInToIt = userVisitor.enter(casted, *this); \
+          if (goInToIt) { \
+            for (const AstNode* child : ast->children()) { \
+              child->traverse(*this); \
+            } \
+          } \
+          userVisitor.exit(casted, *this); \
+          break; \
+        }
+
+      #define CASE_OTHER(NAME) \
+        case asttags::NAME: \
+        { \
+          assert(false && "this code should never be run"); \
+          break; \
+        }
+
+      #define AST_NODE(NAME) CASE_NODE(NAME)
+      #define AST_LEAF(NAME) CASE_LEAF(NAME)
+      #define AST_BEGIN_SUBCLASSES(NAME) CASE_OTHER(START_##NAME)
+      #define AST_END_SUBCLASSES(NAME) CASE_OTHER(END_##NAME)
+
+      // Apply the above macros to uast-classes-list.h
+      // to fill in the cases
+      #include "chpl/uast/uast-classes-list.h"
+      // and also for NUM_AST_TAGS
+      CASE_OTHER(NUM_AST_TAGS)
+      CASE_OTHER(AST_TAG_UNKNOWN)
+
+      // clear the macros
+      #undef AST_NODE
+      #undef AST_LEAF
+      #undef AST_BEGIN_SUBCLASSES
+      #undef AST_END_SUBCLASSES
+      #undef CASE_LEAF
+      #undef CASE_NODE
+      #undef CASE_OTHER
+    }
+
+    return false;
+  }
+  void exit(const uast::AstNode* ast) { };
+};
+
+
+} // end namespace resolution
+
+
+} // end namespace chpl
+
+#endif


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/3393

This PR implements resolution of param for-loops, the results of which will be stored in the new type ``ResolvedParamLoop``.

We resolve param loops by creating a new Resolver for each iteration, and
storing the collected ResolutionResultByPostorderIDs in a
ResolvedParamLoop result. Each iteration stores a different param
resolution result for the AST representing the index variable.

These temporary Resolvers don't inherit their parent's scopeStacks or
their ResolutionResultByPostorderID values directly. Instead, a
'parentResolver' reference is stored in the Resolver type and used by
'typeForId' to determine whether a parent resolver 'owns' the resolution
results for the desired scope.

The ResolvedParamLoop is finally stored in the ResolvedExpression for
the For loop.

-----

This PR introduces a first draft of a ResolvedVisitor type, which is meant
to handle iterating over the AST and make resolution results available to
the client type.

Clients of this type will implement their own visitors, e.g.
MyVisitor, which will implement enter/exit methods that accept two
arguments:
- An AST node
- A reference to a ResolvedVisitor<MyVisitor>

The ResolvedVisitor stores a ResolutionResultByPostorderID that will
contain the relevant results for the corresponding AST.

The ResolvedVisitor will handle param for loops by first invoking the
client 'enter' method to determine whether it should recurse. If so, it
will traverse once over the iterand, and then will traverse for each
iteration of the loop body with the corresponding results from the
ResolvedParamLoop.

Remaining work:
- handle strided ranges
- handle ranges with '#' or '<' operators

Testing:
- [x] test-dyno