### PR TITLE
Bring block dist scan performance on par with local DR arrays

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1774,6 +1774,9 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
 
   const cachedPID = pid;
 
+  param sameStaticDist = dsiStaticFastFollowCheck(res._value.type);
+  const sameDynamicDist = sameStaticDist && dsiDynamicFastFollowCheck(res);
+
   // Fire up tasks per participating locale
   coforall locid in targetLocs.domain {
     on targetLocs[locid] {
@@ -1787,7 +1790,12 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
       const ref myLocDom = myLocArr.domain;
 
       // Compute the local pre-scan on our local array
-      const (numTasks, rngs, state, tot) = myLocArr._value.chpl__preScan(myop, res, myLocDom[dom]);
+      const (numTasks, rngs, state, tot) =
+        if sameStaticDist && sameDynamicDist then
+          myLocArr._value.chpl__preScan(myop, res._value.locArr[locid].myElems, myLocDom[dom])
+        else
+          myLocArr._value.chpl__preScan(myop, res, myLocDom[dom]);
+
       if debugBlockScan then
         writeln(locid, ": ", (numTasks, rngs, state, tot));
 
@@ -1845,7 +1853,11 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
 
       // have our local array compute its post scan with the globally
       // accurate state vector
-      myLocArr._value.chpl__postScan(op, res, numTasks, rngs, state);
+      if sameStaticDist && sameDynamicDist then
+        myLocArr._value.chpl__postScan(op, res._value.locArr[locid].myElems, numTasks, rngs, state);
+      else
+        myLocArr._value.chpl__postScan(op, res, numTasks, rngs, state);
+
       if debugBlockScan then
         writeln(locid, ": ", myLocArr);
 


### PR DESCRIPTION
Optimize block dist scans by passing in local views of the result array
to preScan/postScan. This means the indexing in these methods will be on
default rectangular arrays instead of block and DR indexing is cheaper.
Note that this is only legal when the array being scanned and the result
array have the same distribution so reuse the fast-follower checks to
ensure that's the case for this optimization to trigger.

This brings the performance of block scans on par with DR. On a 128-core
rome node I see a 128GB scan go from 2.35s to 2.25, which matches the
performance of DR.

We're operating on wide DR arrays for block, but that doesn't seem to
impact performance at least when using all cores since we're bandwidth
bound. When using fewer cores there is still a difference however.

Part of Cray/chapel-private#3505