### PR TITLE
Ignore line numbers in .good files with ChapelIO warnings

### DIFF
--- a/test/optimizations/bulkcomm/asenjo/ptransDR/v1/PREDIFF
+++ b/test/optimizations/bulkcomm/asenjo/ptransDR/v1/PREDIFF
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/optimizations/bulkcomm/asenjo/ptransDR/v1/ptrans.good
+++ b/test/optimizations/bulkcomm/asenjo/ptransDR/v1/ptrans.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:768: In function 'write':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:769: warning: write with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'write':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: write with a style argument is deprecated
   ./util.chpl:46: called as write(args(0): real(64), args(1): iostyleInternal) from function 'showrealrow'
   ./util.chpl:41: called as showrealrow(ARR: [domain(2,int(64),false)] real(64), i: int(64))
 

--- a/test/optimizations/bulkcomm/asenjo/ptransDR/v2/PREDIFF
+++ b/test/optimizations/bulkcomm/asenjo/ptransDR/v2/PREDIFF
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/optimizations/bulkcomm/asenjo/ptransDR/v2/ptrans.good
+++ b/test/optimizations/bulkcomm/asenjo/ptransDR/v2/ptrans.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:768: In function 'write':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:769: warning: write with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'write':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: write with a style argument is deprecated
   ./util.chpl:46: called as write(args(0): real(64), args(1): iostyleInternal) from function 'showrealrow'
   ./util.chpl:41: called as showrealrow(ARR: [domain(2,int(64),false)] real(64), i: int(64))
 

--- a/test/optimizations/bulkcomm/asenjo/stencilDR/v1/PREDIFF
+++ b/test/optimizations/bulkcomm/asenjo/stencilDR/v1/PREDIFF
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/optimizations/bulkcomm/asenjo/stencilDR/v1/stencil.good
+++ b/test/optimizations/bulkcomm/asenjo/stencilDR/v1/stencil.good
@@ -1,8 +1,8 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: writeln with a style argument is deprecated
   ./util.chpl:70: called as writeln(args(0): [domain(2,int(64),false)] real(64), args(1): iostyleInternal)
-$CHPL_HOME/modules/standard/ChapelIO.chpl:768: In function 'write':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:769: warning: write with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'write':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: write with a style argument is deprecated
   ./util.chpl:92: called as write(args(0): real(64), args(1): iostyleInternal) from function 'showrealrow'
   ./util.chpl:87: called as showrealrow(ARR: [domain(2,int(64),false)] real(64), i: int(64))
 

--- a/test/studies/shootout/spectral-norm/lydia/PREDIFF
+++ b/test/studies/shootout/spectral-norm/lydia/PREDIFF
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: writeln with a style argument is deprecated
   spectral-norm-barrier.chpl:86: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-double-time.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-double-time.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: writeln with a style argument is deprecated
   spectral-norm-double-time.chpl:71: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-no-reduct.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-no-reduct.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: writeln with a style argument is deprecated
   spectral-norm-no-reduct.chpl:77: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-specify-step.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-specify-step.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: writeln with a style argument is deprecated
   spectral-norm-specify-step.chpl:91: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm.good
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: writeln with a style argument is deprecated
   spectral-norm.chpl:59: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/sidelnik/PREDIFF
+++ b/test/studies/shootout/spectral-norm/sidelnik/PREDIFF
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.good
+++ b/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: writeln with a style argument is deprecated
   spectralnorm.chpl:73: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116

--- a/test/studies/shootout/spectral-norm/sidelnik/spectralnorm_2.good
+++ b/test/studies/shootout/spectral-norm/sidelnik/spectralnorm_2.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/standard/ChapelIO.chpl:772: In function 'writeln':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:773: warning: writeln with a style argument is deprecated
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: In function 'writeln':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: warning: writeln with a style argument is deprecated
   spectralnorm_2.chpl:61: called as writeln(args(0): real(64), args(1): iostyleInternal)
 1.274224116


### PR DESCRIPTION
These tests are very sensitive to line number changes in ChapelIO, which has been seeing an uptick in activity as we deprecate things. This PR adds some PREDIFFs to help avoid the tedium of merge conflicts on these files going forward.

Testing:
- [x] macos M1
- [x] linux64
- [x] gasnet