### PR TITLE
Remove deprecated back and front array procs

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1703,11 +1703,6 @@ module ChapelArray {
       return this(this.domain.last);
     }
 
-    deprecated "Array back() method is deprecated; use :proc:`last` instead"
-    proc back() {
-      return this.last;
-    }
-
     /* Return the first element in the array. The array must be a
        rectangular 1-D array.
      */
@@ -1719,11 +1714,6 @@ module ChapelArray {
         halt("first called on an empty array");
 
       return this(this.domain.first);
-    }
-
-    deprecated "Array front() method is deprecated; use :proc:`first` instead"
-    proc front() {
-      return this.first;
     }
 
     /* Reverse the order of the values in the array. */

--- a/test/deprecated/arrays.chpl
+++ b/test/deprecated/arrays.chpl
@@ -1,5 +1,0 @@
-var A = [1,2,3,4];
-writeln(A.front());
-writeln(A.back());
-writeln(A.first);
-writeln(A.last);

--- a/test/deprecated/arrays.good
+++ b/test/deprecated/arrays.good
@@ -1,6 +1,0 @@
-arrays.chpl:2: warning: Array front() method is deprecated; use first instead
-arrays.chpl:3: warning: Array back() method is deprecated; use last instead
-1
-4
-1
-4


### PR DESCRIPTION
Specifically front() and back() (should use .first and .last instead).