### PR TITLE
Fix tests seemingly missed in #19940

### DIFF
--- a/test/visibility/only/operatorsAlone.chpl
+++ b/test/visibility/only/operatorsAlone.chpl
@@ -88,7 +88,7 @@ module DefinesOp {
     where ch.writing {
 
     writeln("In DefinesOp.<~>");
-    try ch.readwrite(x.x);
+    try ch.write(x.x);
     return ch;
   }
 

--- a/test/visibility/only/operatorsFirst.chpl
+++ b/test/visibility/only/operatorsFirst.chpl
@@ -88,7 +88,7 @@ module DefinesOp {
     where ch.writing {
 
     writeln("In DefinesOp.<~>");
-    try ch.readwrite(x.x);
+    try ch.write(x.x);
     return ch;
   }
 

--- a/test/visibility/only/operatorsLast.chpl
+++ b/test/visibility/only/operatorsLast.chpl
@@ -88,7 +88,7 @@ module DefinesOp {
     where ch.writing {
 
     writeln("In DefinesOp.<~>");
-    try ch.readwrite(x.x);
+    try ch.write(x.x);
     return ch;
   }
 


### PR DESCRIPTION
While running a sanity check paratest tonight, I found that these
three tests failed due to deprecation warnings about
channel.readwrite().  I suspect that these were just overlooked.
