### PR TITLE
Investigating the implications of removing automatic string casting from ChapelIO

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -802,19 +802,19 @@ module ChapelIO {
     return stringify((...args));
   }
 
-  //
-  // Catch all
-  //
-  // Convert 'x' to a string just the way it would be written out.
-  //
-  // This is marked as last resort so it doesn't take precedence over
-  // generated casts for types like enums
-  //
-  // This version only applies to non-primitive types
-  // (primitive types should support :string directly)
-  pragma "no doc"
-  pragma "last resort"
-  operator :(x, type t:string) where !isPrimitiveType(x.type) {
-    return stringify(x);
-  }
+  // //
+  // // Catch all
+  // //
+  // // Convert 'x' to a string just the way it would be written out.
+  // //
+  // // This is marked as last resort so it doesn't take precedence over
+  // // generated casts for types like enums
+  // //
+  // // This version only applies to non-primitive types
+  // // (primitive types should support :string directly)
+  // pragma "no doc"
+  // pragma "last resort"
+  // operator :(x, type t:string) where !isPrimitiveType(x.type) {
+  //   return stringify(x);
+  // }
 }


### PR DESCRIPTION
Removed:
```chapel
operator :(x, type t:string) where !isPrimitiveType(x.type) {}
```
from ChapelIO to investigate the feasibility of deprecating this feature and requiring users to directly implement an `operator :(arg: mytype, type t:string)` on their type (per: #19893)

Signed-off-by: Jeremiah Corrado <jeremiah.corrado@hpe.com>