### PR TITLE
Stop using list.extend in protobuf support

### DIFF
--- a/tools/protoc-gen-chpl/message.cpp
+++ b/tools/protoc-gen-chpl/message.cpp
@@ -182,7 +182,7 @@ namespace chapel {
               "  $field_name$ = $proto_field_type$Consume(binCh, $type_name$);\n");
           } else {
             printer->Print(vars[i],
-              "  $field_name$.extend($proto_field_type$RepeatedConsume(binCh, $type_name$));\n");
+              "  $field_name$.append($proto_field_type$RepeatedConsume(binCh, $type_name$));\n");
           }
         } else if(vars[i]["proto_field_type"] == "enum") {
           if(vars[i]["is_repeated"] == "0") {
@@ -198,7 +198,7 @@ namespace chapel {
               "  $field_name$ = $proto_field_type$Consume(binCh);\n");
           } else {
             printer->Print(vars[i],
-              "  $field_name$.extend($proto_field_type$RepeatedConsume(binCh));\n");
+              "  $field_name$.append($proto_field_type$RepeatedConsume(binCh));\n");
           }
         }
 


### PR DESCRIPTION
I deprecated `list.extend` in
https://github.com/chapel-lang/chapel/pull/19828. I missed
its uses in protobuf support. This PR fixes that.

I confirmed that the failing test passes with this patch.