### PR TITLE
Fix read-write-locale-arg test to emit expected output

### DIFF
--- a/test/io/ferguson/readThis/read-write-locale-arg.chpl
+++ b/test/io/ferguson/readThis/read-write-locale-arg.chpl
@@ -31,7 +31,7 @@ class C {
 
   proc readWriteHelper(rw) throws {
     var loc = rw.readWriteThisFromLocale();
-    writeln("in C.readWriteThis loc= ", loc.id);
+    writeln("in C.readWriteHelper loc= ", loc.id);
     if rw.writing then
       rw.write(x);
     else


### PR DESCRIPTION
I made an error in rebasing #19983 and took the wrong set of changes.

Trivial, not reviewed.