### PR TITLE
Fix GPU support for LLVM 14, ignore CUDA version warnings

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1302,6 +1302,15 @@ class CCodeGenConsumer final : public ASTConsumer {
     bool parseOnly;
     ASTContext* savedCtx;
 
+    bool shouldHandleDecl(Decl* d) {
+      if (localeUsesGPU()) {
+        if (gCodegenGPU == d->hasAttr<CUDADeviceAttr>()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
   public:
     CCodeGenConsumer()
       : ASTConsumer(),
@@ -1355,9 +1364,13 @@ class CCodeGenConsumer final : public ASTConsumer {
           info->lvt->addGlobalCDecl(td);
         }
       } else if (FunctionDecl *fd = dyn_cast<FunctionDecl>(d)) {
-        info->lvt->addGlobalCDecl(fd);
+        if (shouldHandleDecl(d)) {
+          info->lvt->addGlobalCDecl(fd);
+        }
       } else if (VarDecl *vd = dyn_cast<VarDecl>(d)) {
-        info->lvt->addGlobalCDecl(vd);
+        if (shouldHandleDecl(d)) {
+          info->lvt->addGlobalCDecl(vd);
+        }
       } else if (RecordDecl *rd = dyn_cast<RecordDecl>(d)) {
         info->lvt->addGlobalCDecl(rd);
       } else if (UsingDecl* ud = dyn_cast<UsingDecl>(d)) {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1642,6 +1642,11 @@ void setupClang(GenInfo* info, std::string mainFile)
   DiagnosticsEngine* Diags = NULL;
   Diags = new DiagnosticsEngine(
       clangInfo->DiagID, &*clangInfo->diagOptions, clangInfo->DiagClient);
+  if (localeUsesGPU()) {
+    Diags->setSeverityForGroup(diag::Flavor::WarningOrError,
+                               "unknown-cuda-version",
+                               diag::Severity::Ignored);
+  }
   clangInfo->Diags = Diags;
   clangInfo->Clang = Clang;
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1304,11 +1304,11 @@ class CCodeGenConsumer final : public ASTConsumer {
 
     bool shouldHandleDecl(Decl* d) {
       if (localeUsesGPU()) {
-        if (gCodegenGPU == d->hasAttr<CUDADeviceAttr>()) {
-          return true;
-        }
+        return gCodegenGPU == d->hasAttr<CUDADeviceAttr>();
       }
-      return false;
+      else {
+        return true;
+      }
     }
 
   public:

--- a/test/gpu/native/PREDIFF
+++ b/test/gpu/native/PREDIFF
@@ -1,7 +1,4 @@
 #!/bin/sh
 
-awk '!/Unknown CUDA version/ {print};' $2 > $2.no_version_warn
-mv $2.no_version_warn $2
-
 awk '!/ptxas warning : Unresolved extern variable/ {print};' $2 > $2.no_extern_warn
 mv $2.no_extern_warn $2


### PR DESCRIPTION
This PR checks the `device` attribute while adding declarations to `lvt`.

Resolves https://github.com/chapel-lang/chapel/issues/19740

While working on this, I realized that with clang 14, the CUDA version warning
has changed. Instead of fixing our PREDIFF for a warning message that we wanted
to get rid of anyways, I bit the bullet and figured out the correct incantation
for making clang ignore it for us.

### Future Work
This PR doesn't take us all the way to what me and @mppf described starting
https://github.com/chapel-lang/chapel/issues/19740#issuecomment-1145480231. I
have a separate branch that makes lvt use a `llvm::SmallVector` to keep track of
multiple overloads. I haven't figured out how to match the correct version to a
`CallExpr`, yet. But before pursuing that further, I forked off this branch to
make sure we have LLVM 14 support as early as we can and start testing it.

### Test
- [x] gpu/native
