### PR TITLE
Improve readLine

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3885,7 +3885,7 @@ proc channel.readline(arg: [] uint(8), out numRead : int, start = arg.domain.low
   stored in the array).
 
   :arg arg: A 1D DefaultRectangular non-strided array storing int(8) or uint(8) which must have at least 1 element.
-  :arg maxSize: The maximum number of bytes to return.
+  :arg maxSize: The maximum number of bytes to store into the ``arg`` array.
   :arg stripNewline: Whether to strip the trailing ``\n`` from the line.
   :returns: Returns `0` if EOF is reached and no data is read. Otherwise, returns the number of array elements that were set by this call.
 
@@ -4034,7 +4034,7 @@ private proc readStringBytesData(ref s /*: string or bytes*/,
   Read a line into a Chapel string. Reads until a ``\n`` is reached.
 
   :arg arg: a string to receive the line
-  :arg maxSize: The maximum number of codepoints to return. The default of -1 means to read an unlimited number of codepoints.
+  :arg maxSize: The maximum number of codepoints to store into ``s``. The default of -1 means to read an unlimited number of codepoints.
   :arg stripNewline: Whether to strip the trailing ``\n`` from the line.
   :returns: `true` if a line was read without error, `false` upon EOF
 
@@ -4119,7 +4119,7 @@ proc channel.readLine(ref s: string,
   Read a line into Chapel bytes. Reads until a ``\n`` is reached.
 
   :arg arg: bytes to receive the line
-  :arg maxSize: The maximum number of bytes to return. The default of -1 means to read an unlimited number of bytes.
+  :arg maxSize: The maximum number of bytes to store into ``b``. The default of -1 means to read an unlimited number of bytes.
   :arg stripNewline: Whether to strip the trailing ``\n`` from the line.
   :returns: `true` if a line was read without error, `false` upon EOF
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4010,9 +4010,9 @@ private proc readStringBytesData(ref s /*: string or bytes*/,
 
   // TODO: if the channel is working with non-UTF-8 data
   // (which is a feature not yet implemented at all)
-  // this would need to call a read than can do character set conversion.
+  // this would need to call a read than can do character set conversion
+  // in the event that s.type == string.
 
-  var amtRead: c_ssize_t = 0;
   var err = qio_channel_read_amt(false, _channel_internal, s.buff, nBytes);
   if !err {
     s.buffLen = nBytes;
@@ -4096,6 +4096,8 @@ proc channel.readLine(ref s: string,
     }
 
     // now read the data into the string
+    // readStringBytesData will advance the channel by exactly `nBytes`.
+    // This may consume or leave the newline based on the logic above.
     err = readStringBytesData(s, this._channel_internal, nBytes, nCodepoints);
     if foundNewline && stripNewline && !err {
       // pass the newline in the input
@@ -4177,7 +4179,10 @@ proc channel.readLine(ref b: bytes,
     }
 
     // now read the data into the bytes
-    err = readStringBytesData(b, this._channel_internal, nBytes, nCodepoints=0);
+    // readStringBytesData will advance the channel by exactly `nBytes`.
+    // This may consume or leave the newline based on the logic above.
+    err = readStringBytesData(b, this._channel_internal, nBytes,
+                              nCodepoints=-1);
     if foundNewline && stripNewline && !err {
       // pass the newline in the input
       got = qio_channel_read_byte(false, this._channel_internal);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -385,7 +385,6 @@ IO Functions and Types
 
  */
 module IO {
-
 /* "channel" I/O contributed by Michael Ferguson
 
    Future Work:
@@ -3886,7 +3885,7 @@ proc channel.readline(arg: [] uint(8), out numRead : int, start = arg.domain.low
   stored in the array).
 
   :arg arg: A 1D DefaultRectangular non-strided array storing int(8) or uint(8) which must have at least 1 element.
-  :arg maxSize: The maximum amount of bytes to read.
+  :arg maxSize: The maximum number of bytes to return.
   :arg stripNewline: Whether to strip the trailing ``\n`` from the line.
   :returns: Returns `0` if EOF is reached and no data is read. Otherwise, returns the number of array elements that were set by this call.
 
@@ -3907,18 +3906,34 @@ proc channel.readLine(ref arg: [] ?t, maxSize=arg.size, stripNewline=false): int
     var got: int;
     var i = arg.domain.lowBound;
     const maxIdx = arg.domain.lowBound + maxSize - 1;
-    while got != newLineChar {
+    var foundNewline = false;
+    while !foundNewline {
       got = qio_channel_read_byte(false, this._channel_internal);
-      if got < 0 then break;
-      if( i > maxIdx ) {
-        // The line is longer than was specified so we throw an error
+      if got == -EEOF {
+        // encountered EOF
+        break;
+      } else if got < 0 {
+        // encountered an error so throw
         this._revert();
-        try this._ch_ioerror(EFORMAT:syserr, "line longer than maxSize in channel.readLine(arg : [] uint(8))");
+        var err:syserr = -got;
+        try this._ch_ioerror(EFORMAT:syserr, "in channel.readLine(arg : [] uint(8))");
       }
-      if got == newLineChar && stripNewline then break;
-      arg[i] = got:uint(8);
-      i += 1;
-      if got == newLineChar then break;
+      if got == newLineChar {
+        foundNewline = true;
+      }
+      if i > maxIdx {
+        if foundNewline && stripNewline {
+          // don't worry about it since we wouldn't return the newline
+        } else {
+          // The line is longer than was specified so we throw an error
+          this._revert();
+          try this._ch_ioerror(EFORMAT:syserr, "line longer than maxSize in channel.readLine(arg : [] uint(8))");
+        }
+      }
+      if !(foundNewline && stripNewline) {
+        arg[i] = got:uint(8);
+        i += 1;
+      }
     }
     numRead = i - arg.domain.lowBound;
     if i == arg.domain.lowBound && got < 0 then err = (-got):syserr;
@@ -3977,125 +3992,209 @@ proc channel.readline(ref arg: ?t): bool throws where t==string || t==bytes {
   return true;
 }
 
+// Helper function to replace the contents of a string or bytes
+// by reading up to a fixed number of bytes / codepoints.
+// Returns an error code, and ESHORT if less than that number of
+// bytes was read.
+// Does not validate that the string has valid encoding -- the call
+// site should do that.
+// Assumes we are already on the locale with the channel and that
+// it is alrady locked.
+private proc readStringBytesData(ref s /*: string or bytes*/,
+                                 _channel_internal:qio_channel_ptr_t,
+                                 nBytes: int,
+                                 nCodepoints: int): syserr {
+  import BytesStringCommon;
+
+  BytesStringCommon.resizeBuffer(s, nBytes);
+
+  // TODO: if the channel is working with non-UTF-8 data
+  // (which is a feature not yet implemented at all)
+  // this would need to call a read than can do character set conversion.
+
+  var amtRead: c_ssize_t = 0;
+  var err = qio_channel_read_amt(false, _channel_internal, s.buff, nBytes);
+  if !err {
+    s.buffLen = nBytes;
+    if s.type == string {
+      s.cachedNumCodepoints = nCodepoints;
+      s.hasEscapes = false;
+    }
+  } else {
+    s.buffLen = 0;
+    if s.type == string {
+      s.cachedNumCodepoints = 0;
+      s.hasEscapes = false;
+    }
+  }
+  return err;
+}
+
 /*
   Read a line into a Chapel string. Reads until a ``\n`` is reached.
 
   :arg arg: a string to receive the line
-  :arg maxSize: The maximum number of codepoints to read. The default of -1 means to read an unlimited number of codepoints.
+  :arg maxSize: The maximum number of codepoints to return. The default of -1 means to read an unlimited number of codepoints.
   :arg stripNewline: Whether to strip the trailing ``\n`` from the line.
   :returns: `true` if a line was read without error, `false` upon EOF
 
   :throws SystemError: Thrown if data could not be read from the channel.
   :throws IOError: Thrown if the line is longer than `maxSize`. It leaves the input marker at the beginning of the offending line.
 */
-proc channel.readLine(ref s: string, maxSize=-1, stripNewline=false): bool throws{
+proc channel.readLine(ref s: string,
+                      maxSize=-1,
+                      stripNewline=false): bool throws {
   if writing then compilerError("read on write-only channel");
   const origLocale = this.getLocaleOfIoRequest();
+  var ret: bool = false;
 
-  try {
-    on this.home {
-      try this.lock(); defer { this.unlock(); }
-      param newLineChar = 0x0A; // ascii newline.
-      if(maxSize != -1){
-        this._mark();
-        var lineSize = 0;
-        var got : int;
-        while got!=newLineChar {
-          got = qio_channel_read_byte(false, this._channel_internal);
-          if(got < 0) then break;
-          lineSize+=1;
-          if(lineSize > maxSize){
-            // The line is longer than was specified so we throw an error
-            this._revert();
-            try this._ch_ioerror(EFORMAT:syserr, "line longer than maxSize in channel.readLine(ref s: string)");
-          }
-        }
+  on this.home {
+    try this.lock(); defer { this.unlock(); }
+    param newLineChar = 0x0A; // ascii newline.
+    var maxCodepoints = if maxSize < 0 then max(int) else maxSize;
+    var nCodepoints: int = 0; // num codepoints, including newline
+    var chr : int(32);
+    var err: syserr = ENOERR;
+    var foundNewline = false;
+    // use the channel's buffering to compute how many bytes/codepoints
+    // we are reading
+    this._mark();
+    while !foundNewline {
+      // read a single codepoint
+      err = qio_channel_read_char(false, this._channel_internal, chr);
+      if err == EEOF {
+        // encountered EOF
+        break;
+      } else if err {
+        // encountered an error so throw
         this._revert();
+        try this._ch_ioerror(err, "in channel.readLine(ref s: string)");
       }
-      var saveStyle: iostyleInternal = this._styleInternal();
-      defer {
-        this._set_styleInternal(saveStyle);
+      nCodepoints += 1;
+      if chr == newLineChar {
+        foundNewline = true;
       }
-      var myStyle = saveStyle.text();
-      myStyle.string_format = QIO_STRING_FORMAT_TOEND;
-      myStyle.string_end = newLineChar;
-      if(maxSize >= 0){
-        try myStyle.max_width_characters = maxSize.safeCast(uint(32)); // Probably should change maxSize's type to be safe to cast
+      if nCodepoints > maxCodepoints {
+        if stripNewline && foundNewline {
+          // don't worry about it since we wouldn't return the newline
+        } else {
+          // The line is longer than was specified so we throw an error
+          this._revert();
+          try this._ch_ioerror(EFORMAT:syserr,
+               "line longer than maxSize in channel.readLine(ref s: string)");
+        }
       }
-      this._set_styleInternal(myStyle);
-      try _readOne(iokind.dynamic, s, origLocale);
     }
-  } catch err: SystemError {
-    if err.err != EEOF then throw err;
-    return false;
-  }
-  // TODO find a more memory efficient way to do this
-  // Maybe have a QIO_STRING_FORMAT_TOEND_DROPEND which drops the last char
-  if(stripNewline){
-    s = s.strip(chars="\n", leading = false);
+    var endOffset = this._offset();
+    this._revert();
+    var nBytes:int = endOffset - this._offset();
+    // now, nCodepoints and nBytes include the newline
+    if foundNewline && stripNewline {
+      // but we don't want to read the newline if stripNewline=true.
+      nBytes -= 1;
+      nCodepoints -= 1;
+    }
+
+    // now read the data into the string
+    err = readStringBytesData(s, this._channel_internal, nBytes, nCodepoints);
+    if foundNewline && stripNewline && !err {
+      // pass the newline in the input
+      err = qio_channel_read_char(false, this._channel_internal, chr);
+    }
+
+    if err != ENOERR && err != EEOF {
+      try this._ch_ioerror(err, "in channel.readLine(ref s: string)");
+    }
+
+    // return 'true' if we read anything
+    ret = foundNewline || nBytes > 0;
   }
 
-  return true;
+  return ret;
 }
 
 /*
   Read a line into Chapel bytes. Reads until a ``\n`` is reached.
 
   :arg arg: bytes to receive the line
-  :arg maxSize: The maximum number of bytes to read. The default of -1 means to read an unlimited number of bytes.
+  :arg maxSize: The maximum number of bytes to return. The default of -1 means to read an unlimited number of bytes.
   :arg stripNewline: Whether to strip the trailing ``\n`` from the line.
   :returns: `true` if a line was read without error, `false` upon EOF
 
   :throws SystemError: Thrown if data could not be read from the channel.
   :throws IOError: Thrown if the line is longer than `maxSize`. It leaves the input marker at the beginning of the offending line.
 */
-proc channel.readLine(ref b: bytes, maxSize=-1, stripNewline=false): bool throws{
+proc channel.readLine(ref b: bytes,
+                      maxSize=-1,
+                      stripNewline=false): bool throws {
   if writing then compilerError("read on write-only channel");
   const origLocale = this.getLocaleOfIoRequest();
+  var ret: bool = false;
 
-  try {
-    on this.home {
-      try this.lock(); defer { this.unlock(); }
-      param newLineChar = 0x0A; // ascii newline.
-      if(maxSize != -1) {
-        this._mark();
-        var lineSize = 0;
-        var got : int;
-        while got!=newLineChar {
-          got = qio_channel_read_byte(false, this._channel_internal);
-          if(got < 0) then break;
-          lineSize+=1;
-          if(lineSize > maxSize){
-                    // The line is longer than was specified so we throw an error
-          this._revert();
-          try this._ch_ioerror(EFORMAT:syserr, "line longer than maxSize in channel.readLine(ref b: bytes)");
-          }
-        }
+  on this.home {
+    try this.lock(); defer { this.unlock(); }
+    param newLineChar = 0x0A; // ascii newline.
+    var maxBytes = if maxSize < 0 then max(int) else maxSize;
+    var nBytes: int = 0;
+    // use the channel's buffering to compute how many bytes we are reading
+    this._mark();
+    var got : int;
+    var err: syserr = ENOERR;
+    var foundNewline = false;
+    while !foundNewline {
+      // read a sigle byte
+      got = qio_channel_read_byte(false, this._channel_internal);
+      if got == -EEOF {
+        // encountered EOF
+        break;
+      } else if got < 0 {
+        // encountered an error so throw
         this._revert();
+        err = -got;
+        try this._ch_ioerror(err, "in channel.readLine(ref b: bytes)");
+        break;
       }
-      var saveStyle: iostyleInternal = this._styleInternal();
-      defer {
-        this._set_styleInternal(saveStyle);
+      nBytes += 1;
+      if got == newLineChar {
+        foundNewline = true;
       }
-      var myStyle = saveStyle.text();
-      myStyle.string_format = QIO_STRING_FORMAT_TOEND;
-      myStyle.string_end = newLineChar;
-      if(maxSize >= 0){
-        try myStyle.max_width_bytes = maxSize.safeCast(uint(32)); // Probably should change maxSize's type to be safe to cast
+      if nBytes > maxBytes {
+        if foundNewline && stripNewline {
+          // don't worry about it since we wouldn't return the newline
+        } else {
+          // The line is longer than was specified so we throw an error
+          this._revert();
+          try this._ch_ioerror(EFORMAT:syserr,
+                   "line longer than maxSize in channel.readLine(ref b: bytes)");
+        }
       }
-      this._set_styleInternal(myStyle);
-      try _readOne(iokind.dynamic, b, origLocale);
     }
-  } catch err: SystemError {
-    if err.err != EEOF then throw err;
-    return false;
+    this._revert();
+    // now, nBytes includes the newline
+    if foundNewline && stripNewline {
+      // but we don't want to read the newline if stripNewline=true.
+      nBytes -= 1;
+    }
+
+    // now read the data into the bytes
+    err = readStringBytesData(b, this._channel_internal, nBytes, nCodepoints=0);
+    if foundNewline && stripNewline && !err {
+      // pass the newline in the input
+      got = qio_channel_read_byte(false, this._channel_internal);
+      if got < 0 {
+        err = -got;
+      }
+    }
+
+    if err != ENOERR && err != EEOF {
+      try this._ch_ioerror(err, "in channel.readLine(ref s: string)");
+    }
+
+    // return 'true' if we read anything
+    ret = foundNewline || nBytes > 0;
   }
-  // TODO find a more memory efficient way to do this
-  // Maybe have a QIO_STRING_FORMAT_TOEND_DROPEND which drops the last char
-  if(stripNewline){
-    b = b.strip(chars=b"\n", leading = false);
-  }
-  return true;
+
+  return ret;
 }
 
 /*

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3885,7 +3885,7 @@ proc channel.readline(arg: [] uint(8), out numRead : int, start = arg.domain.low
   stored in the array).
 
   :arg arg: A 1D DefaultRectangular non-strided array storing int(8) or uint(8) which must have at least 1 element.
-  :arg maxSize: The maximum number of bytes to store into the ``arg`` array.
+  :arg maxSize: The maximum number of bytes to store into the ``arg`` array. Defaults to the size of the array.
   :arg stripNewline: Whether to strip the trailing ``\n`` from the line.
   :returns: Returns `0` if EOF is reached and no data is read. Otherwise, returns the number of array elements that were set by this call.
 

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -879,6 +879,7 @@ int32_t qio_channel_read_byte(const int threadsafe, qio_channel_t* restrict ch)
     uint8_t tmp;
     err = _qio_slow_read(ch, &tmp, 1, &amt_read);
     if( err == 0 && amt_read != 1 ) err = QIO_ESHORT;
+
     if( err == 0 ) ret = tmp;
     else {
       _qio_channel_set_error_unlocked(ch, err);

--- a/test/io/readLine/readLineArrayBoundary.chpl
+++ b/test/io/readLine/readLineArrayBoundary.chpl
@@ -1,0 +1,226 @@
+use IO;
+
+var evenementArr:[0..8] uint(8) = ["e".toByte(),
+                                   "v".toByte(),
+                                   "e".toByte(),
+                                   "n".toByte(),
+                                   "e".toByte(),
+                                   "m".toByte(),
+                                   "e".toByte(),
+                                   "n".toByte(),
+                                   "t".toByte()];
+
+proc isEvenement(arr) {
+  for i in 0..8 {
+    if arr[i] != evenementArr[i] {
+      return false;
+    }
+  }
+  return true;
+}
+proc isEvenementNewline(arr) {
+  for i in 0..8 {
+    if arr[i] != evenementArr[i] {
+      return false;
+    }
+  }
+  if arr[9] != "\n".toByte() {
+    return false;
+  }
+
+  return true;
+}
+
+
+proc test1() {
+  // test a variety of reads when near the end of file and no newline exists 
+  writeln("test1");
+  var f = openmem();
+  f.writer().write("evenement");
+
+  var s:[0..100] uint(8);
+
+  writeln("test1 part 1a");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=true);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test1 part 1b");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test1 part 2a");
+  try! {
+    var r = f.reader();
+    // OK because there was no newline
+    s = 255;
+    var got = r.readLine(s, maxSize=9, stripNewline=true);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+  }
+  writeln("test1 part 2b");
+  try! {
+    var r = f.reader();
+    // OK because there was no newline
+    s = 255;
+    var got = r.readLine(s, maxSize=9, stripNewline=false);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+  }
+
+  writeln("test1 part 3a");
+  try! {
+    var r = f.reader();
+    // OK
+    s = 255;
+    var got = r.readLine(s, maxSize=10, stripNewline=true);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+  }
+  writeln("test1 part 3b");
+  try! {
+    var r = f.reader();
+    // OK
+    s = 255;
+    var got = r.readLine(s, maxSize=10, stripNewline=false);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+  }
+
+  writeln("test1 part 4a");
+  try! {
+    var r = f.reader();
+    // OK
+    s = 255;
+    var got = r.readLine(s, maxSize=11, stripNewline=true);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+  }
+  writeln("test1 part 4b");
+  try! {
+    var r = f.reader();
+    // OK
+    s = 255;
+    var got = r.readLine(s, maxSize=11, stripNewline=false);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+
+    // check EOF handling
+    s = 255;
+    got = r.readLine(s);
+    assert(got==0);
+    assert(s[0] == 255);
+  }
+}
+test1();
+
+proc test2() {
+  // test a variety of reads when near the end of file and newline exists 
+  writeln("test2");
+  var f = openmem();
+  f.writer().write("evenement\n");
+
+  var s:[0..100] uint(8);
+
+  writeln("test2 part 1a");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=true);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 1b");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 2a");
+  try! {
+    var r = f.reader();
+    // OK because the newline was stripped
+    s = 255;
+    var got = r.readLine(s, maxSize=9, stripNewline=true);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+  }
+  writeln("test2 part 2b");
+  try! {
+    var r = f.reader();
+    // should fail because data + newline is 10 bytes
+    r.readLine(s, maxSize=9, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 3a");
+  try! {
+    var r = f.reader();
+    // OK
+    s = 255;
+    var got = r.readLine(s, maxSize=10, stripNewline=true);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+  }
+  writeln("test2 part 3b");
+  try! {
+    var r = f.reader();
+    // OK
+    s = 255;
+    var got = r.readLine(s, maxSize=10, stripNewline=false);
+    assert(got==10);
+    assert(isEvenementNewline(s));
+    assert(s[10] == 255);
+  }
+
+  writeln("test2 part 4a");
+  try! {
+    var r = f.reader();
+    // OK
+    s = 255;
+    var got = r.readLine(s, maxSize=11, stripNewline=true);
+    assert(got==9);
+    assert(isEvenement(s));
+    assert(s[9] == 255);
+  }
+  writeln("test2 part 4b");
+  try! {
+    var r = f.reader();
+    // OK
+    s = 255;
+    var got = r.readLine(s, maxSize=11, stripNewline=false);
+    assert(got==10);
+    assert(isEvenementNewline(s));
+    assert(s[10] == 255);
+
+    // check EOF handling
+    s = 255;
+    got = r.readLine(s);
+    assert(got==0);
+    assert(s[0] == 255);
+  }
+}
+test2();

--- a/test/io/readLine/readLineArrayBoundary.good
+++ b/test/io/readLine/readLineArrayBoundary.good
@@ -1,0 +1,23 @@
+test1
+test1 part 1a
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(arg : [] uint(8)) with path "unknown" offset 0)
+test1 part 1b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(arg : [] uint(8)) with path "unknown" offset 0)
+test1 part 2a
+test1 part 2b
+test1 part 3a
+test1 part 3b
+test1 part 4a
+test1 part 4b
+test2
+test2 part 1a
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(arg : [] uint(8)) with path "unknown" offset 0)
+test2 part 1b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(arg : [] uint(8)) with path "unknown" offset 0)
+test2 part 2a
+test2 part 2b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(arg : [] uint(8)) with path "unknown" offset 0)
+test2 part 3a
+test2 part 3b
+test2 part 4a
+test2 part 4b

--- a/test/io/readLine/readLineBytesBoundary.chpl
+++ b/test/io/readLine/readLineBytesBoundary.chpl
@@ -1,0 +1,168 @@
+use IO;
+
+proc test1() {
+  // test a variety of reads when near the end of file and no newline exists 
+  writeln("test1");
+  var f = openmem();
+  f.writer().write("evenement");
+
+  var s:bytes = b"foo";
+
+  writeln("test1 part 1a");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=true);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test1 part 1b");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test1 part 2a");
+  try! {
+    var r = f.reader();
+    // OK because there was no newline
+    var got = r.readLine(s, maxSize=9, stripNewline=true);
+    assert(got);
+    assert(s == b"evenement");
+  }
+  writeln("test1 part 2b");
+  try! {
+    var r = f.reader();
+    // OK because there was no newline
+    var got = r.readLine(s, maxSize=9, stripNewline=false);
+    assert(got);
+    assert(s == b"evenement");
+  }
+
+  writeln("test1 part 3a");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=10, stripNewline=true);
+    assert(got);
+    assert(s == b"evenement");
+  }
+  writeln("test1 part 3b");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=10, stripNewline=false);
+    assert(got);
+    assert(s == b"evenement");
+  }
+
+  writeln("test1 part 4a");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=11, stripNewline=true);
+    assert(got);
+    assert(s == b"evenement");
+  }
+  writeln("test1 part 4b");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=11, stripNewline=false);
+    assert(got);
+    assert(s == b"evenement");
+
+    // check EOF handling
+    got = r.readLine(s);
+    assert(got == false);
+  }
+}
+test1();
+
+proc test2() {
+  // test a variety of reads when near the end of file and newline exists 
+  writeln("test2");
+  var f = openmem();
+  f.writer().write("evenement\n");
+
+  var s: bytes = b"foo";
+
+  writeln("test2 part 1a");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=true);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 1b");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 2a");
+  try! {
+    var r = f.reader();
+    // OK because the newline was stripped
+    var got = r.readLine(s, maxSize=9, stripNewline=true);
+    assert(got);
+    assert(s == b"evenement");
+  }
+  writeln("test2 part 2b");
+  try! {
+    var r = f.reader();
+    // should fail because data + newline is 10 bytes
+    r.readLine(s, maxSize=9, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 3a");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=10, stripNewline=true);
+    assert(got);
+    assert(s == b"evenement");
+  }
+  writeln("test2 part 3b");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=10, stripNewline=false);
+    assert(got);
+    assert(s == b"evenement\n");
+  }
+
+  writeln("test2 part 4a");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=11, stripNewline=true);
+    assert(got);
+    assert(s == b"evenement");
+  }
+  writeln("test2 part 4b");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=11, stripNewline=false);
+    assert(got);
+    assert(s == b"evenement\n");
+
+    // check EOF handling
+    got = r.readLine(s);
+    assert(got == false);
+  }
+}
+test2();

--- a/test/io/readLine/readLineBytesBoundary.good
+++ b/test/io/readLine/readLineBytesBoundary.good
@@ -1,0 +1,23 @@
+test1
+test1 part 1a
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref b: bytes) with path "unknown" offset 0)
+test1 part 1b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref b: bytes) with path "unknown" offset 0)
+test1 part 2a
+test1 part 2b
+test1 part 3a
+test1 part 3b
+test1 part 4a
+test1 part 4b
+test2
+test2 part 1a
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref b: bytes) with path "unknown" offset 0)
+test2 part 1b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref b: bytes) with path "unknown" offset 0)
+test2 part 2a
+test2 part 2b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref b: bytes) with path "unknown" offset 0)
+test2 part 3a
+test2 part 3b
+test2 part 4a
+test2 part 4b

--- a/test/io/readLine/readLineStringBoundary.chpl
+++ b/test/io/readLine/readLineStringBoundary.chpl
@@ -1,0 +1,167 @@
+use IO;
+
+proc test1() {
+  // test a variety of reads when near the end of file and no newline exists 
+  writeln("test1");
+  var f = openmem();
+  f.writer().write("événement");
+
+  var s: string = "foo";
+
+  writeln("test1 part 1a");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=true);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test1 part 1b");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test1 part 2a");
+  try! {
+    var r = f.reader();
+    // OK because there was no newline
+    var got = r.readLine(s, maxSize=9, stripNewline=true);
+    assert(got);
+    assert(s == "événement");
+  }
+  writeln("test1 part 2b");
+  try! {
+    var r = f.reader();
+    // OK because there was no newline
+    var got = r.readLine(s, maxSize=9, stripNewline=false);
+    assert(got);
+    assert(s == "événement");
+  }
+
+
+  writeln("test1 part 3a");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=10, stripNewline=true);
+    assert(got);
+    assert(s == "événement");
+  }
+  writeln("test1 part 3b");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=10, stripNewline=false);
+    assert(got);
+    assert(s == "événement");
+  }
+
+  writeln("test1 part 4a");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=11, stripNewline=true);
+    assert(got);
+    assert(s == "événement");
+  }
+  writeln("test1 part 4b");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=11, stripNewline=false);
+    assert(got);
+    assert(s == "événement");
+    // check EOF
+    got = r.readLine(s);
+    assert(!got);
+  }
+}
+test1();
+
+proc test2() {
+  // test a variety of reads when near the end of file and newline exists 
+  writeln("test2");
+  var f = openmem();
+  f.writer().write("événement\n");
+
+  var s: string = "foo";
+
+  writeln("test2 part 1a");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=true);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 1b");
+  try {
+    var r = f.reader();
+    r.readLine(s, maxSize=1, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 2a");
+  try! {
+    var r = f.reader();
+    // OK because the newline was stripped
+    var got = r.readLine(s, maxSize=9, stripNewline=true);
+    assert(got);
+    assert(s == "événement");
+  }
+  writeln("test2 part 2b");
+  try! {
+    var r = f.reader();
+    // should fail because data + newline is 10 codepoints
+    r.readLine(s, maxSize=9, stripNewline=false);
+    writeln("should not be reached!");
+  } catch e {
+    writeln("caught expected error: ", e);
+  }
+
+  writeln("test2 part 3a");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=10, stripNewline=true);
+    assert(got);
+    assert(s == "événement");
+  }
+  writeln("test2 part 3b");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=10, stripNewline=false);
+    assert(got);
+    assert(s == "événement\n");
+  }
+
+  writeln("test2 part 4a");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=11, stripNewline=true);
+    assert(got);
+    assert(s == "événement");
+  }
+  writeln("test2 part 4b");
+  try! {
+    var r = f.reader();
+    // OK
+    var got = r.readLine(s, maxSize=11, stripNewline=false);
+    assert(got);
+    assert(s == "événement\n");
+    // check EOF
+    got = r.readLine(s);
+    assert(!got);
+  }
+}
+test2();

--- a/test/io/readLine/readLineStringBoundary.good
+++ b/test/io/readLine/readLineStringBoundary.good
@@ -1,0 +1,23 @@
+test1
+test1 part 1a
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref s: string) with path "unknown" offset 0)
+test1 part 1b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref s: string) with path "unknown" offset 0)
+test1 part 2a
+test1 part 2b
+test1 part 3a
+test1 part 3b
+test1 part 4a
+test1 part 4b
+test2
+test2 part 1a
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref s: string) with path "unknown" offset 0)
+test2 part 1b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref s: string) with path "unknown" offset 0)
+test2 part 2a
+test2 part 2b
+caught expected error: BadFormatError: bad format (line longer than maxSize in channel.readLine(ref s: string) with path "unknown" offset 0)
+test2 part 3a
+test2 part 3b
+test2 part 4a
+test2 part 4b


### PR DESCRIPTION
Follow-up to #19937

* improve size checking
* figure out line size in channel buffer
* better optimize to avoid copying the contents of the line

Reviewed by @e-kayrakli and @ShreyasKhandekar - thanks!

- [x] full local testing