### PR TITLE
Update make install to include chpldoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,10 @@ compile-util-python: FORCE
 	  echo "Compiling Python scripts in util/" ; \
 	  $(CHPL_MAKE_PYTHON) -m compileall util/config -q ; \
 	  $(CHPL_MAKE_PYTHON) -m compileall util/chplenv -q ; \
+	  if [ -d third-party/chpl-venv/install/chpldeps ] ; then \
+	    echo "Compiling Python scripts in chpl-venv/" ; \
+	    $(CHPL_MAKE_PYTHON) -m compileall third-party/chpl-venv/install/chpldeps/ -q ; \
+	  fi ; \
 	else \
 	  echo "Not compiling Python scripts - missing compileall" ; \
 	fi

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -239,8 +239,6 @@ myinstallfileto () {
 # copy chpl
 if [ ! -z "$PREFIX" ]
 then
-  # TODO -- handle chpldoc
-  #   these are symbol links to chpl
   myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$PREFIX/bin"
 else
   tmp_bin_dir="bin/$CHPL_BIN_SUBDIR"
@@ -305,7 +303,7 @@ cd ..
 
 for dir in $THIRD_PARTY_DIRS
 do
-  #echo "Considering 3p dir $dir"
+  # copy Makefiles (which are used by the C backend)
   for f in third-party/"$dir"/Makefile*
   do
     if [ -f "$f" ]
@@ -313,9 +311,18 @@ do
       myinstallfile "$f"  "$DEST_THIRD_PARTY"/"$dir"
     fi
   done
+
+  # copy any installed libraries
   if [ -d third-party/"$dir"/install ]
   then
     myinstalldir "third-party/$dir/install" "$DEST_THIRD_PARTY/$dir/install/"
+  fi
+
+  # chpl-venv also needs to copy chpldoc-sphinx-project
+  # but this never contains executables so should go in DEST_CHPL_HOME
+  if [ -d third-party/"$dir"/chpldoc-sphinx-project ]
+  then
+    myinstalldir "third-party/$dir/chpldoc-sphinx-project" "$DEST_CHPL_HOME/third-party/$dir/chpldoc-sphinx-project/"
   fi
 done
 
@@ -337,6 +344,17 @@ then
   else
     myinstallfile "$MASON" "$DEST_CHPL_HOME/tools/mason"
     ln -s "$DEST_CHPL_HOME/tools/mason/mason" "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"/mason
+  fi
+fi
+
+if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc" ]
+then
+  # create a symbolic link for chpldoc
+  if [ ! -z "$PREFIX" ]
+  then
+    (cd "$PREFIX/bin" && rm -f chpldoc && ln -s chpl chpldoc)
+  else
+    (cd "$DEST_DIR/bin/$CHPL_BIN_SUBDIR" && rm -f chpldoc && ln -s chpl chpldoc)
   fi
 fi
 

--- a/util/buildRelease/test_install.bash
+++ b/util/buildRelease/test_install.bash
@@ -15,6 +15,7 @@ export CHPL_LLVM=bundled
 mytmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
 myprefix="$mytmpdir/prefix"
 myhome="$mytmpdir/chplhome"
+mydocstmp="$mytmpdir/docstest"
 
 mkdir -p "$myprefix"
 mkdir -p "$myhome"
@@ -24,7 +25,7 @@ EXITSTATUS=0
 if [ $EXITSTATUS -eq 0 ]
 then
   # First, check installation to bin lib etc
-  ./configure --prefix="$myprefix" && make && make mason && make install
+  ./configure --prefix="$myprefix" && make && make mason && make chpldoc && make install
 
   # Remove bin and lib to eliminate possible confusion
   rm -Rf bin lib
@@ -55,16 +56,47 @@ then
       EXITSTATUS=$TEST_STATUS
     fi
   fi
+
+  # Check that bin/chpldoc was created
+  if [ ! -f "$myprefix/bin/chpldoc" ]
+  then
+    echo "--prefix install: $myprefix/bin/chpldoc was not installed!" 1<&2
+    EXITSTATUS=1
+  else
+    # Try running chpldoc on a test program
+    (
+      export PATH=$myprefix/bin:$PATH
+      rm -Rf "$mydocstmp"
+      mkdir -p "$mydocstmp"
+      cd "$mydocstmp"
+      chpldoc $CHPL_CHECK_HOME/examples/primers/chpldoc.doc.chpl
+      exit $?
+    )
+    TEST_STATUS=$?
+    if [ $TEST_STATUS -ne 0 ]
+    then
+      echo "--prefix install: running chpldoc failed" 1>&2
+      EXITSTATUS=$TEST_STATUS
+    fi
+  fi
+
 fi
 
 if [ $EXITSTATUS -eq 0 ]
 then
   # Next, check installation to a chpl-home
-  ./configure --chpl-home="$myhome" && make && make install
+  ./configure --chpl-home="$myhome" && make && make mason && make chpldoc && make install
   binsubdir=`./util/chplenv/chpl_bin_subdir.py`
 
   # Remove bin and lib to eliminate possible confusion
   rm -Rf bin lib
+
+# Check that bin/mason was created
+  if [ ! -f "$myhome/bin/$binsubdir/mason" ]
+  then
+      echo "--chpl-home install: $myhome/bin/$binsubdir/mason was not installed!" 1<&2
+      EXITSTATUS=1
+  fi
 
   # Check that chpl-home/bin/subdir/chpl was created
   if [ ! -f "$myhome/bin/$binsubdir/chpl" ]
@@ -85,10 +117,33 @@ then
       EXITSTATUS=$TEST_STATUS
     fi
   fi
+
+  # Check that bin/chpldoc was created
+  if [ ! -f "$myhome/bin/$binsubdir/chpldoc" ]
+  then
+    echo "--chpl-home install: $myhome/bin/$binsubdir/chpldoc was not installed!" 1<&2
+    EXITSTATUS=1
+  else
+    # Try running chpldoc on a test program
+    (
+      export PATH=$myhome/bin/$binsubdir:$PATH
+      rm -Rf "$mydocstmp"
+      mkdir -p "$mydocstmp"
+      cd "$mydocstmp"
+      chpldoc $CHPL_CHECK_HOME/examples/primers/chpldoc.doc.chpl
+      exit $?
+    )
+    TEST_STATUS=$?
+    if [ $TEST_STATUS -ne 0 ]
+    then
+      echo "--prefix install: running chpldoc failed" 1>&2
+      EXITSTATUS=$TEST_STATUS
+    fi
+  fi
+
 fi
 
-rm -Rf $myprefix
-rm -Rf $myhome
+rm -Rf $mytmpdir
 
 if [ $EXITSTATUS -eq 0 ]
 then


### PR DESCRIPTION
For #19992. Related to #19911.

* pre-compile Python code in chpl-venv since it will be installed
* adds chpldoc to installation (as a symbolic link for chpl like usual)
* the chpl-venv install directory was already being installed but chpldoc needs one more directory so add that
* update util/buildRelease/test_install.bash to test chpldoc install and also update it to check --chpl-home install includes mason

Reviewed by @lydia-duncan - thanks!

- [x] verified `chpldoc` suceeds for a simple project after configuring with `--prefix` and installing
- [x] verified `chpldoc` suceeds for a simple project after configuring with `--chpl-home` and installing
- [x] util/buildRelease/test_install.bash succeeds