### PR TITLE
Remove check disallowing CHPL_LOCALE_MODEL=`gpu` to be used with `CHPL_COMM=ugni` and `CHPL_COMM=ofi`

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -24,7 +24,5 @@ def get_cuda_path():
         return ""
 
 def validate(chplLocaleModel, chplComm):
-    validModels = ["none", "gasnet"]
-    if chplLocaleModel == 'gpu' and chplComm not in validModels:
-      error("The prototype GPU support does not work when CHPL_COMM is not set to one of:\n\t%s." %
-         ", ".join(validModels))
+    pass
+

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -25,4 +25,3 @@ def get_cuda_path():
 
 def validate(chplLocaleModel, chplComm):
     pass
-


### PR DESCRIPTION
I've manually verified that `CHPL_COMM=ugni` works fine (by running all the test under `gpu/native/`) on a Cray XC system and that `CHPL_COMM=ofi` works on a Cray CS system.
