### PR TITLE
Deprecate Array.reverse()

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1721,6 +1721,7 @@ module ChapelArray {
     }
 
     /* Reverse the order of the values in the array. */
+    deprecated "reverse is deprecated"
     proc reverse() {
       if (!chpl__isDense1DArray()) then
         compilerError("reverse() is only supported on dense 1D arrays");

--- a/test/arrays/diten/arrayReverse.chpl
+++ b/test/arrays/diten/arrayReverse.chpl
@@ -2,17 +2,27 @@ var A: [1..10] int = [i in 1..10] i;
 
 writeln(A);
 writeln("reversing even sized array");
-A.reverse();
+reverse(A);
 writeln(A);
 
 var B: [1..9] int = [i in 1..9] i;
 writeln(B);
 writeln("reversing odd sized array");
-B.reverse();
+reverse(B);
 writeln(B);
 
 var C: [11..20] int = [i in 11..20] i;
 writeln(C);
 writeln("reversing array with higher domain");
-C.reverse();
+reverse(C);
 writeln(C);
+
+/* Reverse the order of the values in the array. */
+proc reverse(ref A) {
+  const lo = A.domain.low,
+        mid = A.domain.sizeAs(A.idxType) / 2,
+        hi = A.domain.high;
+  for i in 0..#mid {
+    A[lo + i] <=> A[hi - i];
+  }
+}

--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -90,9 +90,6 @@ proc testArrayAPI1D(lbl, X: [], sliceDom, reindexDom) {
   for (i,x) in zip(reindexDom, X.reindex(reindexDom)) do
     writeln("reindexed X[", i, "] = ", x);
   writeln();
-  // Test vector ops
-  if testError == 10 then
-    X.reverse();
   // Test sparse-specific things
   if testError == 12 then
     writeln("IRV is: ", X.IRV);
@@ -220,10 +217,6 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
     writeln("reindexed X[", i, "] = ", x);
   writeln();
 
-  // Test vector ops
-  if testError == 10 then
-    X.reverse();
-  
   // Test sparse-specific things
   if testError == 12 then
     writeln("IRV is: ", X.IRV);

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:229: error: only sparse arrays have an IRV
+./arrayAPItest.chpl:104: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:222: error: only sparse arrays have an IRV
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-reverse.good
+++ b/test/arrays/userAPI/arrayOps2D-reverse.good
@@ -1,3 +1,0 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:225: error: reverse() is only supported on dense 1D arrays
-  arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-sorted.good
+++ b/test/arrays/userAPI/arrayOps2D-sorted.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:234: error: sort() is currently only supported for 1D rectangular arrays
+./arrayAPItest.chpl:104: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:227: error: sort() is currently only supported for 1D rectangular arrays
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D.compopts
+++ b/test/arrays/userAPI/arrayOps2D.compopts
@@ -1,5 +1,4 @@
                # arrayOps2D.good
--stestError=10 # arrayOps2D-reverse.good
 -stestError=12 # arrayOps2D-IRV.good
 -stestError=13 # arrayOps2D-sorted.good
 

--- a/test/constrained-generics/basic/set2/resolve-implements-types.chpl
+++ b/test/constrained-generics/basic/set2/resolve-implements-types.chpl
@@ -4,13 +4,12 @@ of an 'implements' statement needs to be resolved.
 */
 
 interface MyArray {
-  proc Self.reverse();
+  proc Self.isEmpty() : bool;
   proc writeln(arg: Self);
 }
 
 proc cgFun(arg: MyArray) {
-  arg.reverse();
-  writeln(arg);
+  writeln("is empty? ", arg.isEmpty());
 }
 
 var AR = [1, 2, 5];

--- a/test/constrained-generics/basic/set2/resolve-implements-types.good
+++ b/test/constrained-generics/basic/set2/resolve-implements-types.good
@@ -1,1 +1,1 @@
-5 2 1
+is empty? false

--- a/test/deprecated/arrayReverse.chpl
+++ b/test/deprecated/arrayReverse.chpl
@@ -1,0 +1,4 @@
+var A: [1..10] int = [i in 1..10] i;
+writeln(A);
+A.reverse();
+writeln(A);

--- a/test/deprecated/arrayReverse.good
+++ b/test/deprecated/arrayReverse.good
@@ -1,0 +1,3 @@
+arrayReverse.chpl:3: warning: reverse is deprecated
+1 2 3 4 5 6 7 8 9 10
+10 9 8 7 6 5 4 3 2 1


### PR DESCRIPTION
This is a followup item for the Array module review.

In the interest of keeping the interface to array streamlined we decided to remove a small handful of procedures.

One of these is `reverse()`, which is specific to 1D arrays and can be written with a forall loop without too much difficulty.

This is a part of four similar PRs: 
* https://github.com/chapel-lang/chapel/pull/20025
* https://github.com/chapel-lang/chapel/pull/20062
* https://github.com/chapel-lang/chapel/pull/20077
* https://github.com/chapel-lang/chapel/pull/20078