### PR TITLE
Improve our gasnet support for the ofi conduit

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -731,10 +731,10 @@ static chpl_bool pollingRequired;
 static atomic_spinlock_t pollingLock;
 
 static inline void am_poll_try(void) {
-  // Serialize polling for IBV, UCX, and Aries. Concurrent polling causes
+  // Serialize polling for IBV, UCX, Aries, and OFI. Concurrent polling causes
   // contention in these configurations. For other configurations that are
   // AM-based (udp/amudp, mpi/ammpi) serializing can hurt performance.
-#if defined(GASNET_CONDUIT_IBV) || defined(GASNET_CONDUIT_UCX) || defined(GASNET_CONDUIT_ARIES)
+#if defined(GASNET_CONDUIT_IBV) || defined(GASNET_CONDUIT_UCX) || defined(GASNET_CONDUIT_ARIES) || defined(GASNET_CONDUIT_OFI)
   if (atomic_try_lock_spinlock_t(&pollingLock)) {
     (void) gasnet_AMPoll();
     atomic_unlock_spinlock_t(&pollingLock);
@@ -842,7 +842,7 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   // For configurations that register a fixed heap at startup use a gasnet hook
   // to allow us to fault and interleave in the memory in parallel for faster
   // startup and better NUMA affinity.
-#if defined(GASNET_CONDUIT_IBV) || defined(GASNET_CONDUIT_UCX) || defined(GASNET_CONDUIT_ARIES)
+#if defined(GASNET_CONDUIT_IBV) || defined(GASNET_CONDUIT_UCX) || defined(GASNET_CONDUIT_ARIES) || defined(GASNET_CONDUIT_OFI)
 #if defined(GASNET_SEGMENT_FAST)
   gasnet_client_attach_hook = &chpl_comm_regMemHeapTouch;
 #endif

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 
-import chpl_comm, chpl_comm_substrate, overrides
+import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
 from utils import memoize
 
 
@@ -12,7 +12,10 @@ def get():
         segment_val = overrides.get('CHPL_GASNET_SEGMENT')
         if not segment_val:
             substrate_val = chpl_comm_substrate.get()
+            platform_val = chpl_platform.get('target')
             if substrate_val in ('aries', 'smp', 'ucx'):
+                segment_val = 'fast'
+            elif substrate_val == 'ofi' and platform_val == 'hpe-cray-ex':
                 segment_val = 'fast'
             elif substrate_val == 'ibv':
                 segment_val = 'large'

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -15,6 +15,8 @@ def get():
         if comm_val == 'gasnet':
             if platform_val == 'cray-xc':
                 substrate_val = 'aries'
+            elif platform_val == 'hpe-cray-ex':
+                substrate_val = 'ofi'
             elif platform_val in ('cray-cs', 'hpe-apollo'):
                 substrate_val = 'ibv'
             elif platform_val == 'pwr6':


### PR DESCRIPTION
GASNet-EX 2022.3.0 significantly improved the ofi conduit in order to
support Slingshot 10/11 networks and restored support for Omni-Path
networks. Now that ofi support is back, improve our usage of it.

For the chplenv, change the default conduit to be ofi when gasnet is
used on hpe-cray-ex systems and ensure segment fast is used in those
cases. Note that we don't always default to segment fast since that
isn't helpful on omni-path systems.

In the gasnet shim, serialize active-message polling for ofi (this is
similar to #14912 and #17419) and parallelize the heap fault-in for ofi
segment fast (similar to #17405). This results in significant performance
improvements for gasnet-ofi. For instance, parallelizing the heap
fault-in takes 16 node indexgather on SS-11 from 620 MB/s/node to 730
MB/s/node and serializing polling takes it up to 3875 MB/s/node. On an
omnipath system we see serialization takes us from 415 MB/s/node to 490
MB/s/node.

There are a few places where we expect gasnet-ofi might be our default.
This is definitely true for omni-path systems, where ofi with the psm2
provider is recommended. Note that our native `CHPL_COMM=ofi` layer does
not work with psm2 and we don't expect to put in the effort to get it
working (beyond the comm layer, we would also need spawning and
out-of-band support that I don't think is worth adding currently.) On
Slingshot-10 systems it's still up in the air if gasnet-ofi, gasnet-ucx,
or our native ofi comm layer will be best in the long term. Currently,
our native ofi layer is not working there, but this is a bug we need to
address. And lastly it's possible to use gasnet-ofi on Slingshot-11
systems, but we expect our native ofi comm layer to be the preferred
option since that's what we've mostly been developing it for. This is
much like using our native ugni layer on Aries systems instead of
gasnet-aries because it gives us more control on flagship HPE/Cray
systems.

In order to evaluate the current state of gasnet-ofi and what we might
recommend to users I gathered performance figures on a few systems for 5
benchmarks that expose different patterns/idioms we care about:
 - Stream (no communication, numa affinity sensitive)
 - PRK-stencil (little comm, numa affinity sensitive)
 - ISx (concurrent bulk comm, numa affinity sensitive)
 - Indexgather (concurrent bulk/aggregated comm)
 - RA (concurrent fine-grained comm -- RDMA (rmo) and AM (on) variants)

```
chpl --fast test/release/examples/benchmarks/hpcc/stream.chpl
chpl --fast test/studies/prk/Stencil/optimized/stencil-opt.chpl -sorder="sqrt(16e9*numLocales / 8):int"
chpl --fast test/studies/isx/isx-hand-optimized.chpl -smode=scaling.weakISO
chpl --fast test/studies/bale/indexgather/ig.chpl -sN=10000000 -sprintStats -smode=Mode.aggregated
chpl --fast test/release/examples/benchmarks/hpcc/ra.chpl -sverify=false -suseOn=false -sN_U="2**(n-12)" -o ra-rmo
chpl --fast test/release/examples/benchmarks/hpcc/ra.chpl -sverify=false -suseOn=true -sN_U="2**(n-12)" -o ra-on

./stream -nl 16
./stencil-opt -nl 16
./isx-hand-optimized -nl 16
./ig -nl 16
./ra-rmo -nl 16
./ra-on -nl 16
```

Omni-path:
----------

16-nodes of an OPA cluster with 32 cores and 192 GB of ram per node:

| Config    | Stream    | PRK-Stencil  | ISx   | Indexgather   | RA-rmo       | RA-on        |
| --------- | --------: | -----------: | ----: | ------------: | -----------: | -----------: |
| Gasnet-1  | 2120 GB/s | 940 GFlops/s | 13.1s | 400 MB/s/node | 0.00082 GUPS | 0.00059 GUPS |
| 2021.9.0  | 2120 GB/s | 940 GFlops/s | 14.6s | 290 MB/s/node | 0.00045 GUPS | 0.00059 GUPS |
| 2022.3.0  | 2120 GB/s | 940 GFlops/s | 13.3s | 415 MB/s/node | 0.00086 GUPS | 0.00058 GUPS |
| ser-poll  | 2120 GB/s | 945 GFlops/s | 12.3s | 495 MB/s/node | 0.00086 GUPS | 0.00174 GUPS |

Previously, omni-path users had to revert to gasnet-1 and the initial
ofi support added in 2021.9.0 hurt performance. What we see now is that
2022.3.0 restores performance to gasnet-1 levels and serializing the
poller further improves performance. This makes me comfortable telling
users to stop falling back to gasnet-1 and just use the current support
for omni-path.

Slingshot-10:
-------------

16-nodes of a SS-10 system with 128 cores and 512 GB of ram per node:

| Config     | Stream    | PRK-Stencil   | ISx   | Indexgather    | RA-rmo      | RA-on       |
| ---------- | --------: | ------------: | ----: | -------------: | ----------: | ----------: |
| gasnet-ofi | 2335 GB/s | 1435 GFlops/s | 31.7s | 1830 MB/s/node | 0.0033 GUPS | 0.0030 GUPS |
| gasnet-ucx | 2355 GB/s | 1420 GFlops/s | 16.4s | 2290 MB/s/node | 0.0021 GUPS | 0.0015 GUPS |

Generally speaking, gasnet-ucx seems to perform the best on SS-10. I
should also note that our native `CHPL_COMM=ofi` layer does not appear
to be working correctly on SS-10 so I don't have that to compare to,
though we'll want to get that working in the near term. Also note that
serializing polling was important for performance for ofi on SS-10.

Slingshot-11:
-------------

16-nodes of a SS-11 system with 128 cores and 512 GB of ram per node:

| Config     | Stream    | PRK-Stencil   | ISx   | Indexgather    | RA-rmo     | RA-on      |
| ---------- | --------: | ------------: | ----: | -------------: | ---------: | ---------: |
| gasnet-ofi | 2460 GB/s | 1470 MFlops/s | 15.2s | 3875 MB/s/node | 0.003 GUPS | 0.004 GUPS |
| comm=ofi   | 2565 GB/s | 1540 MFlops/s |  7.3s | 5030 MB/s/node | 0.132 GUPS | 0.018 GUPS

Our native `CHPL_COMM=ofi` layer generally outperforms gasnet-ofi. This
is especially true for concurrent fine-grained operations like RA where
injection is serialized under gasnet currently. Note that much like ugni
on XC, we expect our ofi comm layer to be the native/default layer on
SS-11, but the comparison is still interesting and I expect we can
improve gasnet-ofi SS-11 performance with some tuning.

Summary:
--------

Overall, GASNet-EX 2022.3.0 significantly improved ofi performance, and
bringing in optimizations we applied to other conduits further improved
performance. I recommend gasnet-ex for omni-path in the short and long
term, gasnet-ucx for ss-10 in the short term and TBD for the long term,
and our native ofi layer for ss-11. The other potential targets for ofi
in the future are AWS EFA and Cornelis Omni-Path, but these will require
more exploration.