### PR TITLE
Enable dyno resolver to just scope resolve

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -49,6 +49,7 @@ Symbol *gNil = NULL;
 Symbol *gUnknown = NULL;
 Symbol *gMethodToken = NULL;
 Symbol *gDummyRef = NULL;
+Symbol *gFixupRequiredToken = NULL;
 Symbol *gTypeDefaultToken = NULL;
 Symbol *gLeaderTag = NULL, *gFollowerTag = NULL, *gStandaloneTag = NULL;
 Symbol *gModuleToken = NULL;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -944,6 +944,7 @@ void initPrimitiveTypes() {
   dtDummyRef = createInternalType ("_DummyRef", "_DummyRef");
   CREATE_DEFAULT_SYMBOL(dtDummyRef, gDummyRef, "_dummyRef");
   CREATE_DEFAULT_SYMBOL(dtVoid, gDummyWitness, "_dummyWitness");
+  CREATE_DEFAULT_SYMBOL(dtVoid, gFixupRequiredToken, "_fixupRequired");
 
   dtTypeDefaultToken = createInternalType("_TypeDefaultT", "_TypeDefaultT");
   CREATE_DEFAULT_SYMBOL(dtTypeDefaultToken, gTypeDefaultToken, "_typeDefaultT");

--- a/compiler/dyno/CMakeLists.txt
+++ b/compiler/dyno/CMakeLists.txt
@@ -103,6 +103,7 @@ add_custom_target(tests)
 function(comp_unit_test target)
   add_executable(${target} "${target}.cpp")
   set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL)
+  set_target_properties(${target}  PROPERTIES LINK_DEPENDS_NO_SHARED true)
   target_link_libraries(${target} libdyno)
   target_include_directories(${target} PUBLIC
                              ${CHPL_MAIN_INCLUDE_DIR}

--- a/compiler/dyno/include/chpl/resolution/resolution-queries.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-queries.h
@@ -40,6 +40,13 @@ const ResolutionResultByPostorderID& resolveModuleStmt(Context* context, ID id);
 const ResolutionResultByPostorderID& resolveModule(Context* context, ID id);
 
 /**
+  Resolve the contents of a Module but don't resolve any paren-ful function
+  calls or establish types.
+ */
+const ResolutionResultByPostorderID& scopeResolveModule(Context* context,
+                                                        ID id);
+
+/**
   Compute the type for a NamedDecl with a particular id.
  */
 const types::QualifiedType& typeForModuleLevelSymbol(Context* context, ID id);
@@ -196,11 +203,18 @@ const ResolvedFunction* resolveFunction(Context* context,
                                         const TypedFnSignature* sig,
                                         const PoiScope* poiScope);
 
-
 /**
-  Resolves a concrete function using the above queries.
+  Helper to resolves a concrete function using the above queries.
+  Will return `nullptr` if the function is generic or has a `where false`.
   */
 const ResolvedFunction* resolveConcreteFunction(Context* context, ID id);
+
+/**
+  Compute a ResolvedFunction given a TypedFnSignature, but don't
+  do full resolution of types or paren-ful calls in the body.
+ */
+const ResolvedFunction* scopeResolveConcreteFunction(Context* context,
+                                                     ID id);
 
 /**
   Returns the ResolvedFunction called by a particular

--- a/compiler/dyno/include/chpl/resolution/resolution-types.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-types.h
@@ -1126,7 +1126,7 @@ class ResolvedFunction {
                    ResolutionResultByPostorderID resolutionById,
                    PoiInfo poiInfo)
       : signature_(signature), returnIntent_(returnIntent),
-        resolutionById_(resolutionById), poiInfo_(poiInfo) {}
+        resolutionById_(std::move(resolutionById)), poiInfo_(poiInfo) {}
 
   /** The type signature */
   const TypedFnSignature* signature() const { return signature_; }

--- a/compiler/dyno/include/chpl/resolution/scope-queries.h
+++ b/compiler/dyno/include/chpl/resolution/scope-queries.h
@@ -47,38 +47,59 @@ namespace resolution {
    */
   const std::vector<ID>& findUseImportStmts(Context* context,
                                             const Scope* scope);
+ /**
+    Find what a name might refer to.
 
-  /**
-    Given an AstNode and a Scope, return the things
-    that AstNode might refer to.
+    'scope' is the context in which the name occurs (e.g. as an Identifier)
+
+    'receiverScope' is the scope of a type containing the name, in the case
+    of method calls, field accesses, and resolving a name within a method.
+    It is a Scope representing the record/class/union itself for the
+    receiver. If provided, the receiverScope will be consulted before
+    'scope' and its parents.
 
     The config argument is a group of or-ed together bit flags
     that adjusts the behavior of the lookup:
 
-    * If LOOKUP_DECLS is set, looks for symbols declared in this Scope.
+    * If LOOKUP_DECLS is set, looks for symbols declared in 'scope'
+      and 'receiverScope'.
     * If LOOKUP_IMPORT_AND_USE is set, looks for symbols from use/import
-      statements in this Scope.
+      statements in this 'scope' and 'receiverScope'.
     * If LOOKUP_PARENTS is set, looks for symbols from parent scopes (but not
       parent modules of a module) including looking for declarations and
       handling imports, and including finding declarations in the root module.
     * If LOOKUP_TOPLEVEL is set, checks for a toplevel module with this name.
     * If LOOKUP_INNERMOST is true, limits search to the innermost scope with a
       match.
-
    */
-  std::vector<BorrowedIdsWithName> lookupInScope(Context* context,
-                                                 const Scope* scope,
-                                                 const uast::AstNode* expr,
-                                                 LookupConfig config);
+  std::vector<BorrowedIdsWithName>
+  lookupNameInScope(Context* context,
+                    const Scope* scope,
+                    const Scope* receiverScope,
+                    UniqueString name,
+                    LookupConfig config);
 
   /**
-    Same as lookupInScope above but uses a name instead of an
-    AstNode.
+    Same as lookupInScope above but uses an AstNode instead of a name.
+    Note that this only really handles DotExprs for qualified
+    access to modules (and not so much method calls).
    */
-  std::vector<BorrowedIdsWithName> lookupNameInScope(Context* context,
-                                                     const Scope* scope,
-                                                     UniqueString name,
-                                                     LookupConfig config);
+  std::vector<BorrowedIdsWithName>
+  lookupInScope(Context* context,
+                const Scope* scope,
+                const uast::AstNode* expr,
+                LookupConfig config);
+
+  /**
+    Same as lookupNameInScope but includes a set tracking visited scopes.
+   */
+  std::vector<BorrowedIdsWithName>
+  lookupNameInScopeWithSet(Context* context,
+                           const Scope* scope,
+                           const Scope* receiverScope,
+                           UniqueString name,
+                           LookupConfig config,
+                           std::unordered_set<const Scope*>& visited);
 
   /**
     Same as lookupInScope but includes a set tracking visited scopes.
@@ -89,16 +110,6 @@ namespace resolution {
                        const uast::AstNode* expr,
                        LookupConfig config,
                        std::unordered_set<const Scope*>& visited);
-
-  /**
-    Same as lookupNameInScope but includes a set tracking visited scopes.
-   */
-  std::vector<BorrowedIdsWithName>
-  lookupNameInScopeWithSet(Context* context,
-                           const Scope* scope,
-                           UniqueString name,
-                           LookupConfig config,
-                           std::unordered_set<const Scope*>& visited);
 
   /**
     Returns true if all of checkScope is visible from fromScope

--- a/compiler/dyno/include/chpl/resolution/scope-types.h
+++ b/compiler/dyno/include/chpl/resolution/scope-types.h
@@ -90,6 +90,12 @@ class OwnedIdsWithName {
       }
     }
   }
+
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /**
@@ -171,9 +177,7 @@ class BorrowedIdsWithName {
     return ret;
   }
 
-  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
-    ID().stringify(ss, stringKind);
-  }
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
   /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -50,6 +50,7 @@ struct Resolver {
   const uast::Call* inLeafCall = nullptr;
   bool receiverScopeComputed = false;
   const Scope* savedReceiverScope = nullptr;
+  const types::CompositeType* savedReceiverType = nullptr;
 
   // results of the resolution process
 
@@ -168,6 +169,10 @@ struct Resolver {
      and return nullptr if it is not applicable.
    */
   const Scope* methodReceiverScope();
+  /* Compute the receiver scope (when resolving a method)
+     and return nullptr if it is not applicable.
+   */
+  const types::CompositeType* methodReceiverType();
 
   /* When resolving a generic record or a generic function,
      there might be generic types that we don't know yet.

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -42,8 +42,9 @@ struct Resolver {
   std::vector<const uast::Decl*> declStack;
   std::vector<const Scope*> scopeStack;
   bool signatureOnly = false;
-  const uast::Block* fnBody = nullptr;
   bool fieldOrFormalsComputed = false;
+  bool scopeResolveOnly = false;
+  const uast::Block* fnBody = nullptr;
   std::set<ID> fieldOrFormals;
   std::set<ID> instantiatedFieldOrFormals;
   const uast::Call* inLeafCall = nullptr;
@@ -83,6 +84,12 @@ struct Resolver {
                      const uast::AstNode* modStmt,
                      ResolutionResultByPostorderID& byPostorder);
 
+  // set up Resolver to scope resolve a Module
+  static Resolver
+  moduleStmtScopeResolver(Context* context, const uast::Module* mod,
+                          const uast::AstNode* modStmt,
+                          ResolutionResultByPostorderID& byPostorder);
+
   // set up Resolver to resolve a potentially generic Function signature
   static Resolver
   initialSignatureResolver(Context* context, const uast::Function* fn,
@@ -104,6 +111,11 @@ struct Resolver {
                    const PoiScope* poiScope,
                    const TypedFnSignature* typedFnSignature,
                    ResolutionResultByPostorderID& byPostorder);
+
+  // set up Resolver to scope resolve a Function
+  static Resolver
+  functionScopeResolver(Context* context, const uast::Function* fn,
+                        ResolutionResultByPostorderID& byPostorder);
 
   // set up Resolver to initially resolve field declaration types
   static Resolver

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -153,6 +153,9 @@ struct Resolver {
                       const PoiScope* poiScope,
                       ResolutionResultByPostorderID& byPostorder);
 
+  // get the formal types from a Resolver than computed them
+  std::vector<types::QualifiedType> getFormalTypes(const uast::Function* fn);
+
   /* Returns ErroneousType and emits the error message msg
      relevant to location for 'ast'.
    */

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -48,6 +48,8 @@ struct Resolver {
   std::set<ID> fieldOrFormals;
   std::set<ID> instantiatedFieldOrFormals;
   const uast::Call* inLeafCall = nullptr;
+  bool receiverScopeComputed = false;
+  const Scope* savedReceiverScope = nullptr;
 
   // results of the resolution process
 
@@ -153,13 +155,19 @@ struct Resolver {
                       const PoiScope* poiScope,
                       ResolutionResultByPostorderID& byPostorder);
 
-  // get the formal types from a Resolver than computed them
+  /* Get the formal types from a Resolver that computed them
+   */
   std::vector<types::QualifiedType> getFormalTypes(const uast::Function* fn);
 
   /* Returns ErroneousType and emits the error message msg
      relevant to location for 'ast'.
    */
   types::QualifiedType typeErr(const uast::AstNode* ast, const char* msg);
+
+  /* Compute the receiver scope (when resolving a method)
+     and return nullptr if it is not applicable.
+   */
+  const Scope* methodReceiverScope();
 
   /* When resolving a generic record or a generic function,
      there might be generic types that we don't know yet.

--- a/compiler/dyno/lib/resolution/default-functions.cpp
+++ b/compiler/dyno/lib/resolution/default-functions.cpp
@@ -65,8 +65,8 @@ areOverloadsPresentInDefiningScope(Context* context, const Type* type,
   const LookupConfig config = LOOKUP_DECLS | LOOKUP_PARENTS;
 
   auto vec = lookupNameInScope(context, scopeForReceiverType,
-                               name,
-                               config);
+                               /* receiver scope */ nullptr,
+                               name, config);
 
   // nothing found
   if (vec.size() == 0) return false;

--- a/compiler/dyno/lib/resolution/disambiguation.cpp
+++ b/compiler/dyno/lib/resolution/disambiguation.cpp
@@ -714,7 +714,9 @@ computeIsMoreVisible(Context* context,
        curScope != nullptr;
        curScope = curScope->parentScope()) {
 
-    auto decls = lookupNameInScope(context, curScope, callName, onlyDecls);
+    auto decls = lookupNameInScope(context, curScope,
+                                   /* receiver scope */ nullptr,
+                                   callName, onlyDecls);
     auto declVis = checkVisibilityInVec(context, decls, fn1Id, fn2Id);
     if (declVis != MoreVisibleResult::FOUND_NEITHER) {
       return declVis;
@@ -726,7 +728,9 @@ computeIsMoreVisible(Context* context,
       // use M putting M in a nearer scope than something called M
       // within the used module.
       // see issue #19219
-      auto more = lookupNameInScope(context, curScope, callName, importAndUse);
+      auto more = lookupNameInScope(context, curScope,
+                                    /* receiver scope */ nullptr,
+                                    callName, importAndUse);
       auto importUseVis = checkVisibilityInVec(context, more, fn1Id, fn2Id);
       if (importUseVis != MoreVisibleResult::FOUND_NEITHER) {
         return importUseVis;

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -117,6 +117,7 @@ const ResolutionResultByPostorderID& resolveModule(Context* context, ID id) {
         if (child->isComment() ||
             child->isTypeDecl() ||
             child->isFunction() ||
+            child->isModule() ||
             child->isUse() ||
             child->isImport()) {
           // ignore this statement since it is not relevant to
@@ -159,6 +160,7 @@ scopeResolveModule(Context* context, ID id) {
         if (child->isComment() ||
             child->isTypeDecl() ||
             child->isFunction() ||
+            child->isModule() ||
             child->isUse() ||
             child->isImport()) {
           // ignore this statement since it is not relevant to

--- a/compiler/dyno/lib/resolution/scope-types.cpp
+++ b/compiler/dyno/lib/resolution/scope-types.cpp
@@ -27,6 +27,26 @@ namespace chpl {
 namespace resolution {
 
 
+void OwnedIdsWithName::stringify(std::ostream& ss,
+                                 chpl::StringifyKind stringKind) const {
+  if (auto ptr = moreIds_.get()) {
+    for (const auto& elt : *ptr) {
+      elt.stringify(ss, stringKind);
+    }
+  } else {
+    if (!id_.isEmpty()) {
+      id_.stringify(ss, stringKind);
+    }
+  }
+}
+
+void BorrowedIdsWithName::stringify(std::ostream& ss,
+                                    chpl::StringifyKind stringKind) const {
+  for (const auto& elt : *this) {
+    elt.stringify(ss, stringKind);
+  }
+}
+
 Scope::Scope(const uast::AstNode* ast, const Scope* parentScope,
              bool autoUsesModules) {
   parentScope_ = parentScope;
@@ -46,6 +66,7 @@ void Scope::addBuiltin(UniqueString name) {
   declared_.emplace(name, ID());
 }
 
+IMPLEMENT_DUMP(OwnedIdsWithName);
 IMPLEMENT_DUMP(BorrowedIdsWithName);
 IMPLEMENT_DUMP(Scope);
 IMPLEMENT_DUMP(PoiScope);

--- a/compiler/dyno/test/resolution/testInteractive.cpp
+++ b/compiler/dyno/test/resolution/testInteractive.cpp
@@ -61,7 +61,8 @@ static void printId(const AstNode* ast) {
 
 static const ResolvedExpression*
 resolvedExpressionForAst(Context* context, const AstNode* ast,
-                         const ResolvedFunction* inFn) {
+                         const ResolvedFunction* inFn,
+                         bool scopeResolveOnly) {
   if (!(ast->isLoop() || ast->isBlock())) {
     // compute the parent module or function
     int postorder = ast->id().postOrderId();
@@ -70,18 +71,28 @@ resolvedExpressionForAst(Context* context, const AstNode* ast,
       auto parentAst = idToAst(context, parentId);
       if (parentAst != nullptr) {
         if (parentAst->isModule()) {
-          const auto& byId = resolveModule(context, parentAst->id());
-          return &byId.byAst(ast);
+          if (scopeResolveOnly) {
+            const auto& byId = scopeResolveModule(context, parentAst->id());
+            return &byId.byAst(ast);
+          } else {
+            const auto& byId = resolveModule(context, parentAst->id());
+            return &byId.byAst(ast);
+          }
         } else if (auto parentFn = parentAst->toFunction()) {
           auto untyped = UntypedFnSignature::get(context, parentFn);
           // use inFn if it matches
           if (inFn && inFn->signature()->untyped() == untyped) {
             return &inFn->resolutionById().byAst(ast);
           } else {
-            auto typed = typedSignatureInitial(context, untyped);
-            if (!typed->needsInstantiation()) {
-              auto rFn = resolveFunction(context, typed, nullptr);
+            if (scopeResolveOnly) {
+              auto rFn = scopeResolveConcreteFunction(context, parentFn->id());
               return &rFn->resolutionById().byAst(ast);
+            } else {
+              auto typed = typedSignatureInitial(context, untyped);
+              if (!typed->needsInstantiation()) {
+                auto rFn = resolveFunction(context, typed, nullptr);
+                return &rFn->resolutionById().byAst(ast);
+              }
             }
           }
         }
@@ -96,10 +107,11 @@ static void
 computeAndPrintStuff(Context* context,
                      const AstNode* ast,
                      const ResolvedFunction* inFn,
-                     std::set<const ResolvedFunction*>& calledFns) {
+                     std::set<const ResolvedFunction*>& calledFns,
+                     bool scopeResolveOnly) {
 
   for (const AstNode* child : ast->children()) {
-    computeAndPrintStuff(context, child, inFn, calledFns);
+    computeAndPrintStuff(context, child, inFn, calledFns, scopeResolveOnly);
   }
 
   /*
@@ -140,7 +152,8 @@ computeAndPrintStuff(Context* context,
   }*/
 
   int beforeCount = context->numQueriesRunThisRevision();
-  const ResolvedExpression* r = resolvedExpressionForAst(context, ast, inFn);
+  const ResolvedExpression* r =
+    resolvedExpressionForAst(context, ast, inFn, scopeResolveOnly);
   int afterCount = context->numQueriesRunThisRevision();
   if (r != nullptr) {
     for (const TypedFnSignature* sig : r->mostSpecific()) {
@@ -189,10 +202,12 @@ computeAndPrintStuff(Context* context,
 }
 
 static void usage(int argc, char** argv) {
-  printf("Usage: %s [--std] [--search path --search otherPath ...] "
-         "file.chpl otherFile.chpl ...\n"
+  printf("Usage: %s [args] file.chpl otherFile.chpl ...\n"
          "  --std enables the standard library\n"
-         "  --searchPath adjusts the search path\n", argv[0]);
+         "  --scope only performs scope resolution\n"
+         "  --trace enables query tracing\n"
+         "  --searchPath <path> adds to the module search path\n",
+         argv[0]);
 }
 
 static void setupSearchPaths(Context* ctx, bool enableStdLib,
@@ -224,6 +239,7 @@ int main(int argc, char** argv) {
   Context context;
   Context* ctx = &context;
   bool trace = false;
+  bool scopeResolveOnly = false;
   const char* chpl_home = nullptr;
   std::vector<std::string> cmdLinePaths;
   std::vector<std::string> files;
@@ -240,6 +256,8 @@ int main(int argc, char** argv) {
       i++;
     } else if (0 == strcmp(argv[i], "--trace")) {
       trace = true;
+    } else if (0 == strcmp(argv[i], "--scope")) {
+      scopeResolveOnly = true;
     } else {
       files.push_back(argv[i]);
     }
@@ -280,7 +298,7 @@ int main(int argc, char** argv) {
         mod->stringify(std::cout, chpl::StringifyKind::DEBUG_DETAIL);
         printf("\n");
 
-        computeAndPrintStuff(ctx, mod, nullptr, calledFns);
+        computeAndPrintStuff(ctx, mod, nullptr, calledFns, scopeResolveOnly);
         printf("\n");
       }
     }
@@ -312,7 +330,8 @@ int main(int argc, char** argv) {
             printf("Instantiation is ");
             sig->stringify(std::cout, chpl::StringifyKind::CHPL_SYNTAX);
             printf("\n");
-            computeAndPrintStuff(ctx, ast, calledFn, calledFns);
+            computeAndPrintStuff(ctx, ast, calledFn, calledFns,
+                                 scopeResolveOnly);
             printf("\n");
           }
         }

--- a/compiler/include/convert-uast.h
+++ b/compiler/include/convert-uast.h
@@ -37,4 +37,10 @@ convertToplevelModule(chpl::Context* context,
                       const chpl::uast::Comment* comment,
                       const chpl::uast::BuilderResult& builderResult);
 
+// apply fixups to fix SymExprs to refer to Symbols that
+// might have been created in a different order.
+// TODO: in the future, this should be a method on Converter,
+// and there should be 1 Converter to convert a module and its dependencies.
+void postConvertApplyFixups(chpl::Context* context);
+
 #endif

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -891,6 +891,8 @@ extern Symbol *gDummyWitness;
 // Pass this to a return-by-ref formal when the result is not needed.
 // Used when inlining iterators for ForallStmts.
 extern Symbol *gDummyRef;
+// used in convert-uast to mark a SymExpr needing future adjustment
+extern Symbol *gFixupRequiredToken;
 extern VarSymbol *gTrue;
 extern VarSymbol *gFalse;
 extern VarSymbol *gBoundsChecking;

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -134,6 +134,8 @@ void parse() {
 
   finishCountingTokens();
 
+  postConvertApplyFixups(gContext);
+
   parsed = true;
 }
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -146,13 +146,13 @@ struct Converter {
 
   static bool shouldScopeResolve(UniqueString symbolPath) {
     // TODO: check for dead modules and don't resolve those
-    if (symbolPath == "Random")
+    /*if (symbolPath == "Random")
       return false; // use super.RandomSupport; not working yet
     if (symbolPath == "DefaultRectangular")
       return false; // duplicate decorators error
+    return true;*/
 
-    return true;
-//    return false;
+    return false;
   }
   static bool shouldScopeResolve(ID symbolId) {
     return shouldScopeResolve(symbolId.symbolPath());


### PR DESCRIPTION
This PR is part of the effort of moving more and more of the production compiler to the dyno framework. Now that the parser has been replaced, the next step is to migrate over scope resolution. The dyno scope resolver is already written and is relatively complete.

This PR enables the dyno scope resolver to be run during convert-uast. In my own experiments I was able to get Hello World to compile in this mode.

Details:
 * Changes the strategy in convert-uast for handling CallExprs/SymExprs that need to refer to Symbols that haven't been converted yet. The previous strategy was to convert these before they are used. The new strategy is to always convert in whatever order the converter was operating in - but to create SymExprs pointing to gFixupRequiredToken and note these in a list of fixups. Then, when the parse phase is complete and everything is converted, these lists of fixups are processed to remove all of the references to gFixupRequiredToken. The advantage of this new strategy is that it doesn't impact the traversal order (which can be challenging to manage) and it doesn't impact the allocation order (so AST nodes can be placed better in memory). For now, this uses global variables to handle the fixups, but these should eventually be moved to Converter fields once we are able to get the dyno framework to drive the parsing process and we can have a single Converter.
 * Adds scopeResolveModule and scopeResolveConcreteFunction to dyno and adjusts the Resolver to keep track of if it is only asked to scope resolve.
 * Adds more helpers to ResolutionResultByPostorderID that can return nullptr if the ID is not present
 * Adjusts scope queries to consider the receiver scope in order to enable scope resolving fields in methods
 * migrates getFormalTypes to the Resolver class
 * adds dump/stringify support for OwnedIdsWithName
 * adjusts cmake to be OK not relinking the dyno tests if the .so changes (to improve `make dyno-test` compile times)

- [ ] can we add a dyno C++ test of scope resolving a field?
- [ ] full local testing