### PR TITLE
Fix channel.read*(type) to throw EOF errors

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4539,12 +4539,6 @@ proc channel.readlnHelper(ref args ...?k,
 /*
    Read a value of passed type.
 
-   .. note::
-
-     It is difficult to handle errors or to handle reaching the end of
-     the file with this function. If such cases are important please use
-     the :proc:`channel.read` returning the values read into arguments instead.
-
    For example, the following line of code reads a value of type `int`
    from :var:`stdin` and uses it to initialize a variable ``x``:
 
@@ -4566,12 +4560,6 @@ proc channel.read(type t) throws {
 
 /*
    Read a value of passed type followed by a newline.
-
-   .. note::
-
-     It is difficult to handle errors or to handle reaching the end of
-     the file with this function. If such cases are important please use
-     the :proc:`channel.readln` returning the values read into arguments instead.
 
    :arg t: the type to read
    :returns: the value read

--- a/test/io/bharshbarg/readTypeEOF.chpl
+++ b/test/io/bharshbarg/readTypeEOF.chpl
@@ -1,0 +1,42 @@
+
+use IO;
+
+// This test exists to ensure that the ``channel.read*`` methods that accept
+// arguments will throw an EOF error.
+
+proc main() {
+  var f = openmem();
+  var r = f.reader();
+
+  try {
+    var x = r.read(int);
+    writeln(x);
+    writeln("ERROR: expected EOF");
+  } catch e : Error {
+    writeln(e.message());
+  }
+
+  try {
+    var x = r.readln(int);
+    writeln(x);
+    writeln("ERROR: expected EOF");
+  } catch e : Error {
+    writeln(e.message());
+  }
+
+  try {
+    var (x, y, z) = r.read(int, real, bool);
+    writeln(x, " :: ", y, " :: ", z);
+    writeln("ERROR: expected EOF");
+  } catch e : Error {
+    writeln(e.message());
+  }
+
+  try {
+    var (x, y, z) = r.readln(int, real, bool);
+    writeln(x, " :: ", y, " :: ", z);
+    writeln("ERROR: expected EOF");
+  } catch e : Error {
+    writeln(e.message());
+  }
+}

--- a/test/io/bharshbarg/readTypeEOF.good
+++ b/test/io/bharshbarg/readTypeEOF.good
@@ -1,0 +1,4 @@
+end of file (while reading int(64) with path "unknown" offset 0)
+end of file (while reading int(64) with path "unknown" offset 0)
+end of file (while reading int(64) with path "unknown" offset 0)
+end of file (while reading int(64) with path "unknown" offset 0)


### PR DESCRIPTION
This PR updates various ``channel.read*`` methods that accept a type to throw EOF errors rather than silently dropping them. A helper method ``channel._readInner`` is introduced to implement this change, which is essentially a version of ``channel.read(ref args...)`` that throws EOF errors rather than returning a bool. The ``channel.read*(`` methods that accept type arguments are updated to invoke this helper method directly, so that any errors are propagated upwards.

This PR also removes a couple of old comments about EOF errors being difficult to handle. These comments predated error handling and were likely written to emphasize that there was in fact no reliable way to handle such errors for these type-argument methods. With the advent of error handling such errors *could* have been handled, but the implementations of these methods were not updated, and so the old comment was inadvertently still accurate.

This PR adds a test to lock in this expected behavior.

Resolves #20030

Testing:
- [ ] full local
- [ ] full gasnet