### PR TITLE
Suppress unbounded enum/bool tests for --baseline; add future showing bug

### DIFF
--- a/test/functions/iterators/bugs/no-inline-method-iter.bad
+++ b/test/functions/iterators/bugs/no-inline-method-iter.bad
@@ -1,6 +1,11 @@
 Calling standalone foo()
 0
 1
+Calling range.baz()
+0
+1
+2
+This is not working...
 Calling range.bar()
 0
 1
@@ -16,3 +21,6 @@ false
 true
 true
 This is not working...
+Calling range.foo() on a bounded range
+0
+1

--- a/test/functions/iterators/bugs/no-inline-method-iter.bad
+++ b/test/functions/iterators/bugs/no-inline-method-iter.bad
@@ -1,0 +1,18 @@
+Calling standalone foo()
+0
+1
+Calling range.bar()
+0
+1
+2
+This is not working...
+Calling range.foo()
+0
+1
+2
+This is not working...
+Calling range.iterator()
+false
+true
+true
+This is not working...

--- a/test/functions/iterators/bugs/no-inline-method-iter.chpl
+++ b/test/functions/iterators/bugs/no-inline-method-iter.chpl
@@ -1,16 +1,39 @@
+// This works
 iter foo() {
   var i: int;
   const start = 0;
   const end = 1;
   const stride = 1;
-  while __primitive("C for loop",
-                    __primitive( "=", i, start),
-                    __primitive("<=", i, end),
-                    __primitive("+=", i, stride)) {
+  while i <= end {
     yield i;
+    i += stride;
   }
 }
 
+// Once it's a method, it doesn't
+iter range.bar() {
+  var i: int;
+  const start = 0;
+  const end = 1;
+  const stride = 1;
+  i = start;
+  while i <= end {
+    yield i;
+    i += stride;
+  }
+}
+
+// Even a for-loop based method doesn't
+iter range.baz() {
+  var i: int;
+  const start = 0;
+  const end = 1;
+  const stride = 1;
+  for i in start..end by stride do
+    yield i;
+}
+
+// This is similar to the unbounded range iterator for bools/enums
 iter range.foo() {
   var i: int;
   const start = 0;
@@ -24,21 +47,18 @@ iter range.foo() {
   }
 }
 
-iter range.bar() {
-  var i: int;
-  const start = 0;
-  const end = 1;
-  const stride = 1;
-  i = start;
-  while i <= end {
-    yield i;
-    i += stride;
-  }
-}
-
 writeln("Calling standalone foo()");
 for i in foo() {
   writeln(i);
+}
+
+writeln("Calling range.baz()");
+for i in (false..).baz() {
+  writeln(i);
+  if i > 1 {
+    writeln("This is not working...");
+    break;
+  }
 }
 
 writeln("Calling range.bar()");
@@ -70,3 +90,7 @@ for i in (false..) {
   }
 }
 
+writeln("Calling range.foo() on a bounded range");
+for i in (false..true).foo() {
+  writeln(i);
+}

--- a/test/functions/iterators/bugs/no-inline-method-iter.chpl
+++ b/test/functions/iterators/bugs/no-inline-method-iter.chpl
@@ -1,0 +1,72 @@
+iter foo() {
+  var i: int;
+  const start = 0;
+  const end = 1;
+  const stride = 1;
+  while __primitive("C for loop",
+                    __primitive( "=", i, start),
+                    __primitive("<=", i, end),
+                    __primitive("+=", i, stride)) {
+    yield i;
+  }
+}
+
+iter range.foo() {
+  var i: int;
+  const start = 0;
+  const end = 1;
+  const stride = 1;
+  while __primitive("C for loop",
+                    __primitive( "=", i, start),
+                    __primitive("<=", i, end),
+                    __primitive("+=", i, stride)) {
+    yield i;
+  }
+}
+
+iter range.bar() {
+  var i: int;
+  const start = 0;
+  const end = 1;
+  const stride = 1;
+  i = start;
+  while i <= end {
+    yield i;
+    i += stride;
+  }
+}
+
+writeln("Calling standalone foo()");
+for i in foo() {
+  writeln(i);
+}
+
+writeln("Calling range.bar()");
+for i in (false..).bar() {
+  writeln(i);
+  if i > 1 {
+    writeln("This is not working...");
+    break;
+  }
+}
+
+writeln("Calling range.foo()");
+for i in (false..).foo() {
+  writeln(i);
+  if i > 1 {
+    writeln("This is not working...");
+    break;
+  }
+}
+
+var count = 0;
+writeln("Calling range.iterator()");
+for i in (false..) {
+  count += 1;
+  writeln(i);
+  if count > 2 {
+    writeln("This is not working...");
+    break;
+  }
+}
+

--- a/test/functions/iterators/bugs/no-inline-method-iter.compopts
+++ b/test/functions/iterators/bugs/no-inline-method-iter.compopts
@@ -1,0 +1,1 @@
+--no-inline-iterators

--- a/test/functions/iterators/bugs/no-inline-method-iter.future
+++ b/test/functions/iterators/bugs/no-inline-method-iter.future
@@ -1,0 +1,4 @@
+bug: infinite loops for method iterators with --no-inline-iterators
+
+When using the --no-inline-iterators flag, some method-based iterators
+go into infinite loops for reasons that are not obvious to me.

--- a/test/functions/iterators/bugs/no-inline-method-iter.good
+++ b/test/functions/iterators/bugs/no-inline-method-iter.good
@@ -1,6 +1,9 @@
 Calling standalone foo()
 0
 1
+Calling range.baz()
+0
+1
 Calling range.bar()
 0
 1
@@ -10,3 +13,6 @@ Calling range.foo()
 Calling range.iterator()
 false
 true
+Calling range.foo() on a bounded range
+0
+1

--- a/test/functions/iterators/bugs/no-inline-method-iter.good
+++ b/test/functions/iterators/bugs/no-inline-method-iter.good
@@ -1,0 +1,12 @@
+Calling standalone foo()
+0
+1
+Calling range.bar()
+0
+1
+Calling range.foo()
+0
+1
+Calling range.iterator()
+false
+true

--- a/test/types/range/unbounded/unboundedBoolEnum.chpl
+++ b/test/types/range/unbounded/unboundedBoolEnum.chpl
@@ -1,33 +1,23 @@
 enum color { red, green, blue };
 
-for i in false.. do
-  writeln(i);
-writeln();
+proc testRange(r) {
+  var count = 0;
+  for i in r {
+    writeln(i);
+    count += 1;
+    if count > 5 {
+      writeln("This isn't working");
+      break;
+    }
+  }
+  writeln();
+}
 
-for i in false.. by 2 do
-  writeln(i);
-writeln();
-
-for i in color.red.. do
-  writeln(i);
-writeln();
-
-for i in color.red.. by 2 do
-  writeln(i);
-writeln();
-
-for i in ..true by -1 do
-  writeln(i);
-writeln();
-
-for i in ..true by -2 do
-  writeln(i);
-writeln();
-
-for i in ..color.blue by -1 do
-  writeln(i);
-writeln();
-
-for i in ..color.blue by -2 do
-  writeln(i);
-writeln();
+testRange(false..);
+testRange(false.. by 2);
+testRange(color.red..);
+testRange(color.red.. by 2);
+testRange(..true by -1);
+testRange(..true by -2);
+testRange(..color.blue by -1);
+testRange(..color.blue by -2);

--- a/test/types/range/unbounded/unboundedBoolEnum.suppressif
+++ b/test/types/range/unbounded/unboundedBoolEnum.suppressif
@@ -1,0 +1,2 @@
+COMPOPTS <= --baseline
+COMPOPTS <= --no-inline-iterators

--- a/test/types/range/unbounded/unboundedEnumIntVals.chpl
+++ b/test/types/range/unbounded/unboundedEnumIntVals.chpl
@@ -1,26 +1,22 @@
 enum numbers { mn = min(int), one = 1, two = 2, three = 3, mx = max(int)}
 use numbers;
 
-for i in mn.. do
-  writeln(i);
-writeln();
+proc testRange(r) {
+  var count = 0;
+  for i in r {
+    writeln(i);
+    count += 1;
+    if count > 5 {
+      writeln("This isn't working");
+      break;
+    }
+  }
+  writeln();
+}
 
-for i in mn.. by 2 do
-  writeln(i);
-writeln();
-
-for i in one.. by 2 do
-  writeln(i);
-writeln();
-
-for i in ..mx by -1 do
-  writeln(i);
-writeln();
-
-for i in ..mx by -2 do
-  writeln(i);
-writeln();
-
-for i in ..three by -2 do
-  writeln(i);
-writeln();
+testRange(mn..);
+testRange(mn.. by 2);
+testRange(one.. by 2);
+testRange(..mx by -1);
+testRange(..mx by -2);
+testRange(..three by -2);

--- a/test/types/range/unbounded/unboundedEnumIntVals.suppressif
+++ b/test/types/range/unbounded/unboundedEnumIntVals.suppressif
@@ -1,0 +1,2 @@
+COMPOPTS <= --baseline
+COMPOPTS <= --no-inline-iterators


### PR DESCRIPTION
When #19991 was merged, we started seeing failures for the new tests
with --baseline testing where the loops would go into an infinite
loop.  This was no worse than the behavior prior to #19991 (also an
infinite loop), and turns out to be a pre-existing condition (at least
as far back as 1.25.0) that seems to plague iterator methods of a
certain kind when compiled with `--no-inline-iterators`.  In this PR,
I've illustrated this with `no-inline-method-iter.chpl` which shows
some iterators that work by default but not with --no-inline-iterators.
Interestingly, being a method seems to be part of what causes the
problematic behavior.

For this reason, I've added a '.suppressif' to the tests that were
causing infinite loops in testing to silence them when compiled with
--baseline or --no-inline-iterators for the time being, and also
refactored the tests a bit to detect the infinite loop early rather than
waiting for a timeout and generating too much data.