### PR TITLE
Adjust .bad file for parsing future, make sure dyno parser displays all syntax errors

### DIFF
--- a/compiler/dyno/lib/parsing/parser-yyerror.h
+++ b/compiler/dyno/lib/parsing/parser-yyerror.h
@@ -52,8 +52,11 @@ void yychpl_error(YYLTYPE*       loc,
   switch (errorKind) {
     case EMPTY_ERROR_MESSAGE:
     case SYNTAX_ERROR:
-    case UNKNOWN:
       // Do not print "syntax error" - the error message kind implies that.
+      break;
+    case UNKNOWN:
+      // There is still a message of some sort to print.
+      baseMsg = errorMessage;
       break;
     case MEMORY_EXHAUSTED:
       baseMsg = "memory exhausted while parsing";

--- a/test/domains/sungeun/rect/at_operator.bad
+++ b/test/domains/sungeun/rect/at_operator.bad
@@ -1,4 +1,4 @@
-at_operator.chpl:6: syntax error: Invalid token
+at_operator.chpl:6: syntax error: Invalid token: near '@'
 at_operator.chpl:6: syntax error: near 'n'
-at_operator.chpl:8: syntax error: Invalid token
+at_operator.chpl:8: syntax error: Invalid token: near '@'
 at_operator.chpl:8: syntax error: near 'n'


### PR DESCRIPTION
Adjust .bad file for future, make dyno parser display all syntax errors

Adjust the `yyerror` hook for the dyno parser to print error messages
that it does not recognize (previously we were omitting the
messages on accident).

Adjust the .bad file for a parsing future accordingly.

Reviewed by @e-kayrakli, @mppf. Thanks!

TESTING

- [x] `ALL` on `linux64`, `standard`, `-futures`

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>