### PR TITLE
Fix for not finding c_pointer_return call from GPU

### DIFF
--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -59,6 +59,7 @@ __device__ static inline chpl_localeID_t chpl_gen_getLocaleID(void)
   return localeID;
 }
 
+__device__ static inline void* c_pointer_return(void* x) { return x; }
 
 __device__ static inline chpl_localeID_t chpl_rt_buildLocaleID(c_nodeid_t node,  c_sublocid_t subloc) {
   chpl_localeID_t loc = { node, subloc };


### PR DESCRIPTION
When a routine called from the GPU invoked the `c_pointer_return` function defined in https://github.com/chapel-lang/chapel/blob/main/runtime/include/chpltypes.h#L77 we run into the following issue.

```bash
$CHPL_HOME/modules/internal/ChapelStandard.chpl:24: error: Could not find C function for c_pointer_return;  perhaps it is missing or is a macro?
```

Fix was to create a device version of this function as suggested by @e-kayrakli 