### PR TITLE
Add device versions of math macros

### DIFF
--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -69,6 +69,36 @@ __device__ static inline c_nodeid_t get_chpl_nodeID(void) {
   return 0;
 }
 
+__device__ static inline float chpl_macro_INFINITY(void) { return INFINITY; }
+__device__ static inline float chpl_macro_NAN(void) { return NAN; }
+
+__device__ static inline int chpl_macro_double_isinf(double x) { return isinf(x); }
+__device__ static inline int chpl_macro_float_isinf(float x) { return isinf(x); }
+__device__ static inline int chpl_macro_double_isfinite(double x) { return isfinite(x); }
+__device__ static inline int chpl_macro_float_isfinite(float x) { return isfinite(x); }
+__device__ static inline int chpl_macro_double_isnan(double x) { return isnan(x); }
+__device__ static inline int chpl_macro_float_isnan(float x) { return isnan(x); }
+__device__ static inline int chpl_macro_double_signbit(double x) { return signbit(x); }
+__device__ static inline int chpl_macro_float_signbit(float x) { return signbit(x); }
+
+#ifdef __linux__
+__device__ static inline float chpl_float_j0(float x) { return j0f(x); }
+__device__ static inline float chpl_float_j1(float x) { return j1f(x); }
+__device__ static inline float chpl_float_jn(int n, float x) { return jnf(n, x); }
+__device__ static inline float chpl_float_y0(float x) { return y0f(x); }
+__device__ static inline float chpl_float_y1(float x) { return y1f(x); }
+__device__ static inline float chpl_float_yn(int n, float x) { return ynf(n, x); }
+#else
+__device__ static inline float chpl_float_j0(float x) { return (float)j0(x); }
+__device__ static inline float chpl_float_j1(float x) { return (float)j1(x); }
+__device__ static inline float chpl_float_jn(int n, float x) { return (float)jn(n, x); }
+__device__ static inline float chpl_float_y0(float x) { return (float)y0(x); }
+__device__ static inline float chpl_float_y1(float x) { return (float)y1(x); }
+__device__ static inline float chpl_float_yn(int n, float x) { return (float)yn(n, x); }
+#endif
+
+
+
 #endif // HAS_GPU_LOCALE
 
 #endif // _CHPL_GPU_GEN_INCLUDES_H


### PR DESCRIPTION
This is a draft PR that outlines how we can support some math functions for which we have `static inline` functions in runtime headers.