### PR TITLE
Improve portability to Alpine linux

### DIFF
--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -36,3 +36,6 @@ as follows:
 
 * Pulled in an upstream fix for errno with syscalls.
   https://github.com/Qthreads/qthreads/pull/89
+
+* Pulled in an upstream fix for build errors on Alpine linux
+  https://github.com/Qthreads/qthreads/pull/105

--- a/third-party/qthread/qthread-src/include/qt_blocking_structs.h
+++ b/third-party/qthread/qthread-src/include/qt_blocking_structs.h
@@ -2,6 +2,7 @@
 #define QT_BLOCKING_STRUCTS_H
 
 #include <stdlib.h>            /* for malloc() and free() */
+#include <sys/types.h>
 
 #include "qt_mpool.h"
 #include "qt_shepherd_innards.h"

--- a/third-party/qthread/qthread-src/include/qt_debug.h
+++ b/third-party/qthread/qthread-src/include/qt_debug.h
@@ -2,7 +2,10 @@
 #define QTHREAD_DEBUG_H
 
 #include <stdlib.h> /* for malloc() and friends */
+#include <sys/types.h>
+
 #include "qt_alloc.h"
+
 #ifndef EXTERNAL_ALLOCATOR
 #ifdef QTHREAD_MEMORY_SCRIBBLING
 #include <string.h> /* for memset(), per C90 */

--- a/third-party/qthread/qthread-src/src/hashmap.c
+++ b/third-party/qthread/qthread-src/src/hashmap.c
@@ -4,6 +4,7 @@
 
 /* System Headers */
 #include <stdlib.h>
+#include <sys/types.h>
 
 /* Qthread Headers */
 #include <qthread/hash.h>

--- a/third-party/qthread/qthread-src/src/patterns/wavefront.c
+++ b/third-party/qthread/qthread-src/src/patterns/wavefront.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>                    /* for malloc */
+#include <sys/types.h>
 
 #include <qthread/qthread.h>
 #include <qthread/qdqueue.h>

--- a/third-party/qthread/qthread-src/src/qloop.c
+++ b/third-party/qthread/qthread-src/src/qloop.c
@@ -4,6 +4,7 @@
 
 /* System Headers */
 #include <stdlib.h>
+#include <sys/types.h>
 
 /* Installed Headers */
 #include <qthread/qthread.h>

--- a/third-party/qthread/qthread-src/src/shepherds.c
+++ b/third-party/qthread/qthread-src/src/shepherds.c
@@ -7,6 +7,7 @@
 
 /* System Headers */
 #include <stdlib.h> /* for random(), according to P2001 */
+#include <sys/types.h>
 
 /* Internal Headers */
 #include "qt_visibility.h"

--- a/third-party/qthread/qthread-src/src/syscalls/pread.c
+++ b/third-party/qthread/qthread-src/src/syscalls/pread.c
@@ -3,6 +3,8 @@
 #endif
 
 /* System Headers */
+#include <sys/types.h>
+
 #include <qthread/qthread-int.h> /* for uint64_t */
 
 #ifdef HAVE_SYS_SYSCALL_H

--- a/third-party/qthread/qthread-src/src/syscalls/pwrite.c
+++ b/third-party/qthread/qthread-src/src/syscalls/pwrite.c
@@ -3,6 +3,8 @@
 #endif
 
 /* System Headers */
+#include <sys/types.h>
+
 #include <qthread/qthread-int.h> /* for uint64_t */
 
 #ifdef HAVE_SYS_SYSCALL_H

--- a/third-party/qthread/qthread-src/src/syscalls/read.c
+++ b/third-party/qthread/qthread-src/src/syscalls/read.c
@@ -3,6 +3,8 @@
 #endif
 
 /* System Headers */
+#include <sys/types.h>
+
 #include <qthread/qthread-int.h> /* for uint64_t */
 
 #ifdef HAVE_SYS_SYSCALL_H

--- a/third-party/qthread/qthread-src/src/syscalls/write.c
+++ b/third-party/qthread/qthread-src/src/syscalls/write.c
@@ -3,6 +3,8 @@
 #endif
 
 /* System Headers */
+#include <sys/types.h>
+
 #include <qthread/qthread-int.h> /* for uint64_t */
 
 #ifdef HAVE_SYS_SYSCALL_H

--- a/third-party/qthread/qthread-src/src/threadqueues/lifo_threadqueues.c
+++ b/third-party/qthread/qthread-src/src/threadqueues/lifo_threadqueues.c
@@ -5,6 +5,7 @@
 /* System Headers */
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 /* Internal Headers */
 #include "qthread_innards.h"           /* for qlib */

--- a/third-party/qthread/qthread-src/src/threadqueues/mutexfifo_threadqueues.c
+++ b/third-party/qthread/qthread-src/src/threadqueues/mutexfifo_threadqueues.c
@@ -6,6 +6,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 /* API Headers */
 #include "qthread/qthread.h"

--- a/third-party/qthread/qthread-src/src/threadqueues/nemesis_threadqueues.c
+++ b/third-party/qthread/qthread-src/src/threadqueues/nemesis_threadqueues.c
@@ -4,7 +4,7 @@
 
 /* System Headers */
 #include <pthread.h>
-
+#include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/third-party/qthread/qthread-src/src/threadqueues/nottingham_threadqueues.c
+++ b/third-party/qthread/qthread-src/src/threadqueues/nottingham_threadqueues.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <emmintrin.h>
 #include <stdio.h>
+#include <sys/types.h>
 
 /* Internal Headers */
 #include "qthread/qthread.h"

--- a/third-party/qthread/qthread-src/src/threadqueues/sherwood_threadqueues.c
+++ b/third-party/qthread/qthread-src/src/threadqueues/sherwood_threadqueues.c
@@ -6,6 +6,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 /* Public Headers */
 #include "qthread/qthread.h"


### PR DESCRIPTION
This PR takes two steps to improve portability to Alpine Linux:
 * Brings in the changes from https://github.com/Qthreads/qthreads/pull/105 into the bundled qthreads
 * Adjusts chplenv scripts to, as a backup strategy, look for clang dependencies in /usr/include, /usr/lib, and /usr/bin since that is where Alpine installs them. This code includes a check that the version number matches the llvm-config version.

Resolves #19404.

Reviewed by @ronawho - thanks!

- [x] default configuration on Alpine Linux builds and `make check` succeeds
- [x] `make` and `make check` succeed in default configuration on Mac OS X + Homebrew
- [x] full local testing