### PR TITLE
Add gpu test using associative domain.

### DIFF
--- a/test/gpu/native/useAssociativeDomain.chpl
+++ b/test/gpu/native/useAssociativeDomain.chpl
@@ -1,0 +1,21 @@
+// Test for #20053
+
+use GPUDiagnostics;
+
+startGPUDiagnostics();
+
+var Days : domain(int) = {0, 10, 20};
+on here.getChild(1) {
+  var A : [Days] real;
+
+  // NOTE: Currently this does not generate a kernel launch
+  foreach d in A.domain {
+    A[d] = 10.0;
+  }
+
+  writeln(A);
+}
+
+stopGPUDiagnostics();
+writeln("GPU diagnostics:");
+writeln(getGPUDiagnostics());

--- a/test/gpu/native/useAssociativeDomain.good
+++ b/test/gpu/native/useAssociativeDomain.good
@@ -1,0 +1,4 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+10.0 10.0 10.0
+GPU diagnostics:
+(kernel_launch = 0)


### PR DESCRIPTION
We don't expect a kernel launch but previously this would generate an error:
Unresolved extern function '_ZL16c_pointer_returnPv.

With this PR: https://github.com/chapel-lang/chapel/pull/20053 we no longer
have this problem.