### PR TITLE
Deprecate array.find

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -876,7 +876,8 @@ proc SparseBlockDom.dsiLocalSubdomain(loc: locale) {
     unimplementedFeatureHalt("the Sparse Block distribution",
                              "remote subdomain queries");
 
-  const (found, targetIdx) = dist.targetLocales.find(here);
+  const (found, targetIdx) = maxloc reduce
+    zip(dist.targetLocales == here, dist.targetLocales.domain);
   return locDoms[targetIdx]!.mySparseBlock;
 }
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1736,13 +1736,14 @@ module ChapelArray {
        instance of ``val`` in the array, or if ``val`` is not found, a
        tuple containing ``false`` and an unspecified value is returned.
      */
-    /*proc find(val: this.eltType): (bool, index(this.domain)) {
+     deprecated "find is deprecated"
+     proc find(val: this.eltType): (bool, index(this.domain)) {
       for i in this.domain {
         if this[i] == val then return (true, i);
       }
       var arbInd: index(this.domain);
       return (false, arbInd);
-    }*/
+    }
 
     /* Return the number of times ``val`` occurs in the array. */
     proc count(val: this.eltType): int {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1736,13 +1736,13 @@ module ChapelArray {
        instance of ``val`` in the array, or if ``val`` is not found, a
        tuple containing ``false`` and an unspecified value is returned.
      */
-    proc find(val: this.eltType): (bool, index(this.domain)) {
+    /*proc find(val: this.eltType): (bool, index(this.domain)) {
       for i in this.domain {
         if this[i] == val then return (true, i);
       }
       var arbInd: index(this.domain);
       return (false, arbInd);
-    }
+    }*/
 
     /* Return the number of times ``val`` occurs in the array. */
     proc count(val: this.eltType): int {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1736,7 +1736,7 @@ module ChapelArray {
        instance of ``val`` in the array, or if ``val`` is not found, a
        tuple containing ``false`` and an unspecified value is returned.
      */
-     deprecated "find is deprecated"
+     deprecated "find is deprecated, use a reduction like 'maxloc reduce zip(A == val, A.domain)' instead"
      proc find(val: this.eltType): (bool, index(this.domain)) {
       for i in this.domain {
         if this[i] == val then return (true, i);

--- a/test/arrays/diten/arrayFind.chpl
+++ b/test/arrays/diten/arrayFind.chpl
@@ -1,6 +1,6 @@
 var A: [1..10] int = [i in 1..10] i;
 
 for i in 0..11 by -1 {
-  var (found, idx) = A.find(i);
-  writeln((found, i, idx, if found then A[idx] else -1));
+  var (found, idx) = maxloc reduce zip(A == i, A.domain);
+  writeln((found, i, if found then idx else 0, if found then A[idx] else -1));
 }

--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -78,7 +78,6 @@ proc testArrayAPI1D(lbl, X: [], sliceDom, reindexDom) {
   writeln("is empty: ", X.isEmpty());
   writeln("head: ", X.head());
   writeln("tail: ", X.tail());
-  writeln("find last: ", X.find(X[X.domain.alignedHigh]));
   writeln("count last: ", X.count(X[X.domain.alignedHigh]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));
@@ -204,7 +203,6 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
   writeln("is empty: ", X.isEmpty());
   writeln("head: ", X.head());
   writeln("tail: ", X.tail());
-  writeln("find last: ", X.find(X[X.domain.alignedHigh]));
   writeln("count last: ", X.count(X[X.domain.alignedHigh]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:229: error: only sparse arrays have an IRV
+./arrayAPItest.chpl:106: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:227: error: only sparse arrays have an IRV
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-reverse.good
+++ b/test/arrays/userAPI/arrayOps2D-reverse.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:225: error: reverse() is only supported on dense 1D arrays
+./arrayAPItest.chpl:106: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:223: error: reverse() is only supported on dense 1D arrays
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-sorted.good
+++ b/test/arrays/userAPI/arrayOps2D-sorted.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:234: error: sort() is currently only supported for 1D rectangular arrays
+./arrayAPItest.chpl:106: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:232: error: sort() is currently only supported for 1D rectangular arrays
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D.good
+++ b/test/arrays/userAPI/arrayOps2D.good
@@ -78,7 +78,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (4, 4))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/assocArray.good
+++ b/test/arrays/userAPI/assocArray.good
@@ -44,7 +44,6 @@ local subdomains:
 {eight, five, four, half, nine, one, pointone, seven, six, ten, three, two, zero}
 
 is empty: false
-find last: (true, half)
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/assocArrayAPItest.chpl
+++ b/test/arrays/userAPI/assocArrayAPItest.chpl
@@ -113,7 +113,6 @@ proc testAssocArrayAPI(X: []) {
 
   // Test collection interface
   writeln("is empty: ", X.isEmpty());
-  writeln("find last: ", X.find(X[high]));
   writeln("count last: ", X.count(X[high]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));

--- a/test/arrays/userAPI/assocDistributedHashed.comm-none.good
+++ b/test/arrays/userAPI/assocDistributedHashed.comm-none.good
@@ -43,7 +43,6 @@ local subdomains:
 {eight, five, four, half, nine, one, pointone, seven, six, ten, three, two, zero}
 
 is empty: false
-find last: (true, half)
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/assocDistributedHashed.good
+++ b/test/arrays/userAPI/assocDistributedHashed.good
@@ -43,7 +43,6 @@ local subdomains:
 {half, one, pointone, zero}
 
 is empty: false
-find last: (true, half)
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/blockOps2D.comm-none.good
+++ b/test/arrays/userAPI/blockOps2D.comm-none.good
@@ -132,7 +132,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 100.8
-find last: (true, (10, 10))
 count last: 1
 equals same: true
 equals diff: false
@@ -354,7 +353,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 49.8
-find last: (true, (8, 8))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/blockOps2D.good
+++ b/test/arrays/userAPI/blockOps2D.good
@@ -133,7 +133,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 100.8
-find last: (true, (10, 10))
 count last: 1
 equals same: true
 equals diff: false
@@ -356,7 +355,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 49.8
-find last: (true, (8, 8))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/blockOpsRankChange.comm-none.good
+++ b/test/arrays/userAPI/blockOpsRankChange.comm-none.good
@@ -105,7 +105,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 49.8
-find last: (true, (7, 7))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/blockOpsRankChange.good
+++ b/test/arrays/userAPI/blockOpsRankChange.good
@@ -109,7 +109,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 49.8
-find last: (true, (7, 7))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/blockOpsReindex.comm-none.good
+++ b/test/arrays/userAPI/blockOpsReindex.comm-none.good
@@ -132,7 +132,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 100.8
-find last: (true, (9, 19))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/blockOpsReindex.good
+++ b/test/arrays/userAPI/blockOpsReindex.good
@@ -133,7 +133,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 100.8
-find last: (true, (9, 19))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/callExternArrTest.good
+++ b/test/arrays/userAPI/callExternArrTest.good
@@ -42,7 +42,6 @@ local subdomains:
 is empty: false
 head: 1.6
 tail: 5.6
-find last: (true, 4)
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/enumArray.good
+++ b/test/arrays/userAPI/enumArray.good
@@ -87,7 +87,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 25.8
-find last: (true, (blue, violet))
 count last: 1
 equals same: true
 equals diff: false
@@ -203,7 +202,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (violet, violet))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/rankChangeOps3to2D.good
+++ b/test/arrays/userAPI/rankChangeOps3to2D.good
@@ -78,7 +78,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (4, 4))
 count last: 1
 equals same: true
 equals diff: false
@@ -185,7 +184,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (4, 4))
 count last: 1
 equals same: true
 equals diff: false
@@ -292,7 +290,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (4, 4))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/reindexOps2D.good
+++ b/test/arrays/userAPI/reindexOps2D.good
@@ -78,7 +78,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (3, 8))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/sliceOps2D.good
+++ b/test/arrays/userAPI/sliceOps2D.good
@@ -78,7 +78,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (4, 4))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/arrays/userAPI/unsignedOps.good
+++ b/test/arrays/userAPI/unsignedOps.good
@@ -78,7 +78,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (4, 4))
 count last: 1
 equals same: true
 equals diff: false
@@ -185,7 +184,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (4, 4))
 count last: 1
 equals same: true
 equals diff: false
@@ -292,7 +290,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (3, 8))
 count last: 1
 equals same: true
 equals diff: false
@@ -399,7 +396,6 @@ local subdomains:
 is empty: false
 head: 1.8
 tail: 16.8
-find last: (true, (4, 4))
 count last: 1
 equals same: true
 equals diff: false

--- a/test/sparse/CS/multiplication/performance.chpl
+++ b/test/sparse/CS/multiplication/performance.chpl
@@ -60,7 +60,7 @@ proc populate(ref A, ref ADom, sparsity: real, seed: int) where A.isSparse() {
   for idx in indices {
     // Ensure no duplicates
     var newIdx = idx;
-    while indices.find(newIdx)(1) {
+    while (maxloc reduce zip(indices == newIdx, indices.domain))(1) {
       newIdx = (randomIndices.getNext(ADom.dim(0).low, ADom.dim(0).high), randomIndices.getNext(ADom.dim(1).low, ADom.dim(1).high));
     }
     idx = newIdx;
@@ -82,7 +82,7 @@ proc populate(ref A: [?ADom], sparsity: real, seed: int) where !A.isSparse() {
   for idx in indices {
     // Ensure no duplicates
     var newIdx = idx;
-    while indices.find(newIdx)(1) {
+    while (maxloc reduce zip(indices == newIdx, indices.domain))(1) {
       newIdx = (randomIndices.getNext(ADom.dim(0).low, ADom.dim(0).high), randomIndices.getNext(ADom.dim(1).low, ADom.dim(1).high));
     }
     idx = newIdx;


### PR DESCRIPTION
This is a followup item for the Array module review.

In the interest of keeping the interface to array streamlined we decided to remove a small handful of procedures.

One of these is find(), which is specific to 1D arrays and can be written as a reduction without too much difficulty; specifically like this: `maxloc reduce zip(A == needle, A.domain)`

This is a part of four similar PRs: 
* https://github.com/chapel-lang/chapel/pull/20025
* https://github.com/chapel-lang/chapel/pull/20062
* https://github.com/chapel-lang/chapel/pull/20077
* https://github.com/chapel-lang/chapel/pull/20078