### PR TITLE
Fix an overlooked case where we failed to update 'master' to 'main'

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,7 +12,7 @@ endif
 # release's verion number
 #
 WEB_DOC_DIR=
-WEB_DOC_VERSION=master
+WEB_DOC_VERSION=main
 
 # Makefile.sphinx interfaces with sphinx build commands
 include Makefile.sphinx


### PR DESCRIPTION
The effect of this was that when clicking on the link to view the rst for
a file, you'd be taken to a URL that relied on the `master/` path to
documentation.