### PR TITLE
Don't include sha in version if officialRelease

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -34,8 +34,18 @@ get_version(char *v) {
   v += sprintf(v, "%d.%d.%d", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (!officialRelease) {
     sprintf(v, " pre-release (%s)", BUILD_VERSION);
-  } else if (developer || strcmp(BUILD_VERSION, "0") != 0) {
-    sprintf(v, ".%s", BUILD_VERSION);
+  } else {
+    // It's is an official release.
+    // Try to decide whether or not to include the BUILD_VERSION
+    // based on its string length. A short git sha is 10 characters.
+    if (strlen(BUILD_VERSION) > 2) {
+      // assume it is a sha, so don't include it
+    } else if (strcmp(BUILD_VERSION, "0") == 0) {
+      // no need to append a .0
+    } else {
+      // include the BUILD_VERSION contents to add e.g. a .1
+      sprintf(v, ".%s", BUILD_VERSION);
+    }
   }
 }
 

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -38,7 +38,7 @@ get_version(char *v) {
     // It's is an official release.
     // Try to decide whether or not to include the BUILD_VERSION
     // based on its string length. A short git sha is 10 characters.
-    if (strlen(BUILD_VERSION) > 2) {
+    if (strlen(BUILD_VERSION) > 2 && !developer) {
       // assume it is a sha, so don't include it
     } else if (strcmp(BUILD_VERSION, "0") == 0) {
       // no need to append a .0


### PR DESCRIPTION
Testing:
 * It prints out `1.27.0 pre-release (edda1bb5eb)`, without other changes, regardless of `--devel`
 * If I disable the `BUILD_VERSION_FILE` rule in `compiler/Makefile` and set `officialRelease = true` in `compiler/main/version_num.h`, and then store `"1"` in `compiler/main/BUILD_VERSION`; `chpl --version` prints out `1.27.0.1`, regardless of `--devel` or not.
 * If I do the same as the above but store the `"0"` as the `BUILD_VERSION` then `chpl --version` prints out `1.27.0`,  regardless of `--devel` or not.
 * If I let `compiler/Makefile` update `BUILD_VERSION_FILE` and have set `officialRelease = true` in `compiler/main/version_num.h`, it prints out ` 1.27.0` without `--devel` and ` 1.27.0.edda1bb5eb` with `--devel`.
 * passed full local testing
 
Future Work:
 * split `BUILD_VERSION` into two files, e.g. `BUILD_VERSION` and `SHA_VERSION`; that way `BUILD_VERSION` can always be set by a person but `SHA_VERSION` can always be computed by the Makefiles.

Reviewed by @ronawho and discussed with @bradcray - thanks!