### PR TITLE
Fix internal error when calling a parenless method invocation

### DIFF
--- a/test/expressions/calls/CallInfinity.chpl
+++ b/test/expressions/calls/CallInfinity.chpl
@@ -1,0 +1,1 @@
+writeln(INFINITY());

--- a/test/expressions/calls/CallInfinity.good
+++ b/test/expressions/calls/CallInfinity.good
@@ -1,0 +1,1 @@
+CallInfinity.chpl:1: error: unresolved access of 'real(64)' by '()'

--- a/test/expressions/calls/CallParenlessWithParens.chpl
+++ b/test/expressions/calls/CallParenlessWithParens.chpl
@@ -1,7 +1,7 @@
-proc foo param { return 0; }
+proc bar { return 0; }
 
 proc test() {
-  param x = foo();
+  var x = bar();
   writeln(x);
 }
 test();

--- a/test/expressions/calls/CallParenlessWithParens.chpl
+++ b/test/expressions/calls/CallParenlessWithParens.chpl
@@ -1,0 +1,8 @@
+proc foo param { return 0; }
+
+proc test() {
+  param x = foo();
+  writeln(x);
+}
+test();
+

--- a/test/expressions/calls/CallParenlessWithParens.good
+++ b/test/expressions/calls/CallParenlessWithParens.good
@@ -1,0 +1,2 @@
+CallParenlessWithParens.chpl:3: In function 'test':
+CallParenlessWithParens.chpl:4: error: unresolved access of 'int(64)' by '()'

--- a/test/expressions/calls/CallParenlessWithParensParam.chpl
+++ b/test/expressions/calls/CallParenlessWithParensParam.chpl
@@ -1,0 +1,8 @@
+proc foo param { return 0; }
+
+proc test() {
+  param x = foo();
+  writeln(x);
+}
+test();
+

--- a/test/expressions/calls/CallParenlessWithParensParam.good
+++ b/test/expressions/calls/CallParenlessWithParensParam.good
@@ -1,0 +1,2 @@
+CallParenlessWithParensParam.chpl:3: In function 'test':
+CallParenlessWithParensParam.chpl:4: error: unresolved access of 'int(64)' by '()'


### PR DESCRIPTION
Fix internal error when calling a parenless method invocation

Resolves #19945.

Fix a bug which caused calling the result of a parenless method
invocation to result in an internal error:

```chapel
writeln(INFINITY());
```

This code now emits an error:

```
error: unresolved access of 'real(64)' by '()'
```

Which is consistent with the errors emitted when trying to call
a type that does not support that operation.

TESTING

- [x] `ALL` on `linux64`, `standard`

Reviewed by @mppf. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>