### PR TITLE
Add future for tuple initializer internal error (#15718)

### DIFF
--- a/test/types/tuple/errors/tuple-init.bad
+++ b/test/types/tuple/errors/tuple-init.bad
@@ -1,0 +1,8 @@
+$CHPL_HOME/modules/internal/ChapelBase.chpl:1347: internal error: UTI-MIS-0939 chpl version 1.27.0 pre-release (b832268935)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/types/tuple/errors/tuple-init.chpl
+++ b/test/types/tuple/errors/tuple-init.chpl
@@ -1,0 +1,3 @@
+proc (2*int).init(x: int) {
+  this = (3*x,4*x);
+}

--- a/test/types/tuple/errors/tuple-init.future
+++ b/test/types/tuple/errors/tuple-init.future
@@ -1,0 +1,2 @@
+bug: Internal error from declaring a secondary initializer on a tuple type
+#15718

--- a/test/types/tuple/errors/tuple-init.good
+++ b/test/types/tuple/errors/tuple-init.good
@@ -1,0 +1,1 @@
+tuple-init.chpl:1: error: cannot define initializer for tuple type


### PR DESCRIPTION
The error message in the .good file is just what I came up with.

Having the issue/future request successful compilation (raised as an option in the issue) would depend on a design discussion that I'm not proposing here.