### PR TITLE
Deprecate array.count in favor of explicitly writing a reduction

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1745,9 +1745,9 @@ module ChapelArray {
     }
 
     /* Return the number of times ``val`` occurs in the array. */
-    proc count(val: this.eltType): int {
+    /*proc count(val: this.eltType): int {
       return + reduce (this == val);
-    }
+    }*/
 
    /* Return a tuple of integers describing the size of each dimension.
       For a sparse array, returns the shape of the parent domain.*/

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1745,7 +1745,7 @@ module ChapelArray {
     }
 
     /* Return the number of times ``val`` occurs in the array. */
-    deprecated "'count' is deprecated"
+    deprecated "'count' is deprecated use '+ reduce (A == val)' instead"
     proc count(val: this.eltType): int {
       return + reduce (this == val);
     }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1745,9 +1745,10 @@ module ChapelArray {
     }
 
     /* Return the number of times ``val`` occurs in the array. */
-    /*proc count(val: this.eltType): int {
+    deprecated "'count' is deprecated"
+    proc count(val: this.eltType): int {
       return + reduce (this == val);
-    }*/
+    }
 
    /* Return a tuple of integers describing the size of each dimension.
       For a sparse array, returns the shape of the parent domain.*/

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1745,7 +1745,7 @@ module ChapelArray {
     }
 
     /* Return the number of times ``val`` occurs in the array. */
-    deprecated "'count' is deprecated use '+ reduce (A == val)' instead"
+    deprecated "'count' is deprecated use a reduction like '+ reduce (A == val)' instead"
     proc count(val: this.eltType): int {
       return + reduce (this == val);
     }

--- a/test/arrays/diten/arrayCount.chpl
+++ b/test/arrays/diten/arrayCount.chpl
@@ -1,6 +1,6 @@
 var A: [1..10] int = [i in 1..10] i;
-writeln(A.count(3));
+writeln(+ reduce (A == 3));
 
 A[7..9] = 3;
-writeln(A.count(3));
-writeln(A.count(11));
+writeln(+ reduce (A == 3));
+writeln(+ reduce (A == 11));

--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -79,7 +79,6 @@ proc testArrayAPI1D(lbl, X: [], sliceDom, reindexDom) {
   writeln("head: ", X.head());
   writeln("tail: ", X.tail());
   writeln("find last: ", X.find(X[X.domain.alignedHigh]));
-  writeln("count last: ", X.count(X[X.domain.alignedHigh]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));
   var Z = X + 0.1;
@@ -205,7 +204,6 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
   writeln("head: ", X.head());
   writeln("tail: ", X.tail());
   writeln("find last: ", X.find(X[X.domain.alignedHigh]));
-  writeln("count last: ", X.count(X[X.domain.alignedHigh]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));
   var Z = X + 0.1;

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:229: error: only sparse arrays have an IRV
+./arrayAPItest.chpl:106: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:227: error: only sparse arrays have an IRV
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-reverse.good
+++ b/test/arrays/userAPI/arrayOps2D-reverse.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:225: error: reverse() is only supported on dense 1D arrays
+./arrayAPItest.chpl:106: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:223: error: reverse() is only supported on dense 1D arrays
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-sorted.good
+++ b/test/arrays/userAPI/arrayOps2D-sorted.good
@@ -1,3 +1,3 @@
-./arrayAPItest.chpl:107: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:234: error: sort() is currently only supported for 1D rectangular arrays
+./arrayAPItest.chpl:106: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:232: error: sort() is currently only supported for 1D rectangular arrays
   arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D.good
+++ b/test/arrays/userAPI/arrayOps2D.good
@@ -79,7 +79,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (4, 4))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/assocArray.good
+++ b/test/arrays/userAPI/assocArray.good
@@ -45,7 +45,6 @@ local subdomains:
 
 is empty: false
 find last: (true, half)
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/assocArrayAPItest.chpl
+++ b/test/arrays/userAPI/assocArrayAPItest.chpl
@@ -114,7 +114,6 @@ proc testAssocArrayAPI(X: []) {
   // Test collection interface
   writeln("is empty: ", X.isEmpty());
   writeln("find last: ", X.find(X[high]));
-  writeln("count last: ", X.count(X[high]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));
   var Z = X + 0.1;

--- a/test/arrays/userAPI/assocDistributedHashed.comm-none.good
+++ b/test/arrays/userAPI/assocDistributedHashed.comm-none.good
@@ -44,7 +44,6 @@ local subdomains:
 
 is empty: false
 find last: (true, half)
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOps2D.comm-none.good
+++ b/test/arrays/userAPI/blockOps2D.comm-none.good
@@ -133,7 +133,6 @@ is empty: false
 head: 1.8
 tail: 100.8
 find last: (true, (10, 10))
-count last: 1
 equals same: true
 equals diff: false
 
@@ -355,7 +354,6 @@ is empty: false
 head: 1.8
 tail: 49.8
 find last: (true, (8, 8))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOpsRankChange.comm-none.good
+++ b/test/arrays/userAPI/blockOpsRankChange.comm-none.good
@@ -106,7 +106,6 @@ is empty: false
 head: 1.8
 tail: 49.8
 find last: (true, (7, 7))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOpsReindex.comm-none.good
+++ b/test/arrays/userAPI/blockOpsReindex.comm-none.good
@@ -133,7 +133,6 @@ is empty: false
 head: 1.8
 tail: 100.8
 find last: (true, (9, 19))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/callExternArrTest.good
+++ b/test/arrays/userAPI/callExternArrTest.good
@@ -43,7 +43,6 @@ is empty: false
 head: 1.6
 tail: 5.6
 find last: (true, 4)
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/enumArray.good
+++ b/test/arrays/userAPI/enumArray.good
@@ -88,7 +88,6 @@ is empty: false
 head: 1.8
 tail: 25.8
 find last: (true, (blue, violet))
-count last: 1
 equals same: true
 equals diff: false
 
@@ -204,7 +203,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (violet, violet))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/rankChangeOps3to2D.good
+++ b/test/arrays/userAPI/rankChangeOps3to2D.good
@@ -79,7 +79,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (4, 4))
-count last: 1
 equals same: true
 equals diff: false
 
@@ -186,7 +185,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (4, 4))
-count last: 1
 equals same: true
 equals diff: false
 
@@ -293,7 +291,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (4, 4))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/reindexOps2D.good
+++ b/test/arrays/userAPI/reindexOps2D.good
@@ -79,7 +79,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (3, 8))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/sliceOps2D.good
+++ b/test/arrays/userAPI/sliceOps2D.good
@@ -79,7 +79,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (4, 4))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/unsignedOps.good
+++ b/test/arrays/userAPI/unsignedOps.good
@@ -79,7 +79,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (4, 4))
-count last: 1
 equals same: true
 equals diff: false
 
@@ -186,7 +185,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (4, 4))
-count last: 1
 equals same: true
 equals diff: false
 
@@ -293,7 +291,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (3, 8))
-count last: 1
 equals same: true
 equals diff: false
 
@@ -400,7 +397,6 @@ is empty: false
 head: 1.8
 tail: 16.8
 find last: (true, (4, 4))
-count last: 1
 equals same: true
 equals diff: false
 

--- a/test/deprecated/missingArrayFunctions.chpl
+++ b/test/deprecated/missingArrayFunctions.chpl
@@ -1,0 +1,6 @@
+var A = [1, 2, 1, 3, 1, 4, 1, 5];
+writeln("Count of 1's in A = ", A.count(1));
+writeln("A sorted is = ", A.sorted());
+writeln("Finding 3 in A = ", A.find(3));
+A.reverse();
+writeln("Reversing A: ", A);

--- a/test/deprecated/missingArrayFunctions.good
+++ b/test/deprecated/missingArrayFunctions.good
@@ -1,0 +1,5 @@
+missingArrayFunctions.chpl:2: warning: 'count' is deprecated use a reduction like '+ reduce (A == val)' instead
+Count of 1's in A = 4
+A sorted is = 1 1 1 1 2 3 4 5
+Finding 3 in A = (true, 3)
+Reversing A: 5 1 4 1 3 1 2 1

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -590,7 +590,7 @@ proc installSpkg(args: [?d] string) throws {
 
   if specArg.hasValue() {
     var specArr = specArg.values();
-    if MASON_OFFLINE && specArr.count("--update") == 0 {
+    if MASON_OFFLINE && ((+ reduce (specArr == "--update")) == 0) {
       writeln("Cannot install Spack packages when MASON_OFFLINE=true");
       return;
     }


### PR DESCRIPTION
This is a followup item for the Array module review.

In the interest of keeping the interface to array streamlined we decided to remove a small handful of procedures.

One of these is Array.count(), which counts the number of elements in the array equaling some specified value. This can easily be rewritten into a reduction of the form `+ reduce (A == val);`, which is in fact how it's implemented.

I've verified that this change passes paratests.

This is a part of four similar PRs: 
* https://github.com/chapel-lang/chapel/pull/20025
* https://github.com/chapel-lang/chapel/pull/20062
* https://github.com/chapel-lang/chapel/pull/20077
* https://github.com/chapel-lang/chapel/pull/20078