### PR TITLE
Convert an internal error to a slightly vague user error for #20050

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -585,6 +585,9 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
   // e.g. T3 = alloca i8;
   //      T3 = (T == T2);   // not actual LLVM syntax
   // in LLVM, boolean type is i1
+  if (val.val == NULL) {
+    USR_FATAL("Using an idiom that is not yet well-supported\n(possibly instantiating a type field with an array or domain type?)\n(see https://github.com/chapel-lang/chapel/issues/20050)");
+  }
   if (val.val->getType() != ptrValType){
     llvm::Value* v = convertValueToType(val.val, ptrValType, !val.isUnsigned);
     INT_ASSERT(v);

--- a/test/types/records/generic/errorOnRuntimeTypeField.chpl
+++ b/test/types/records/generic/errorOnRuntimeTypeField.chpl
@@ -1,0 +1,21 @@
+    record MultiDual {
+        type t;
+        type d;
+        var prim : t;
+        var dual : d;
+    }
+
+    proc gradient(x : [?D] ?t) {
+        type d = MultiDual(t, [D] t);
+        var x0 : [D] d;
+        forall i in D {
+            var eps : [D] t = 0.0;
+            eps[i] = 1.0;
+            x0[i] = new d(x[i], eps); // this is line 15
+        }
+        return x0;
+    }
+
+    var x = [1.0, 2.0, 3.0];
+    var a = gradient(x);
+    writeln(a);

--- a/test/types/records/generic/errorOnRuntimeTypeField.good
+++ b/test/types/records/generic/errorOnRuntimeTypeField.good
@@ -1,0 +1,4 @@
+errorOnRuntimeTypeField.chpl:14: error: Using an idiom that is not yet well-supported
+(possibly instantiating a type field with an array or domain type?)
+(see https://github.com/chapel-lang/chapel/issues/20050)
+Note: This source location is a guess.


### PR DESCRIPTION
In investigating #20050, I found that the cause of the internal
error was a NULL dereference, so inserted a check for NULL and
a guess as to the cause of the problem.  This isn't completely
satisfying, but may be more satisfying than an internal error.
