### PR TITLE
fix(mason-test): suppress hint when --show used

### DIFF
--- a/test/mason/masonTestSome/CLEANFILES
+++ b/test/mason/masonTestSome/CLEANFILES
@@ -1,0 +1,2 @@
+target
+Mason.lock

--- a/test/mason/masonTestSome/mason-test-noShow.chpl
+++ b/test/mason/masonTestSome/mason-test-noShow.chpl
@@ -1,0 +1,7 @@
+use MasonTest;
+
+proc main() {
+
+  const args = ["test", "test/compilererror.chpl"];
+  masonTest(args);
+}

--- a/test/mason/masonTestSome/mason-test-noShow.good
+++ b/test/mason/masonTestSome/mason-test-noShow.good
@@ -1,0 +1,12 @@
+Skipping registry update since no dependency found in manifest file.
+
+======================================================================
+ERROR test/compilererror.chpl: compilererror
+----------------------------------------------------------------------
+test/compilererror.chpl failed to compile
+Try running 'mason test --show' for more details
+----------------------------------------------------------------------
+Ran 1 test in n seconds
+
+FAILED (errors = 1 )
+compilation failed for test/compilererror.chpl

--- a/test/mason/masonTestSome/mason-test-noShow.prediff
+++ b/test/mason/masonTestSome/mason-test-noShow.prediff
@@ -1,0 +1,1 @@
+mason-test-some.prediff

--- a/test/mason/masonTestSome/mason-test-show.chpl
+++ b/test/mason/masonTestSome/mason-test-show.chpl
@@ -1,0 +1,7 @@
+use MasonTest;
+
+proc main() {
+
+  const args = ["test", "--show", "test/compilererror.chpl"];
+  masonTest(args);
+}

--- a/test/mason/masonTestSome/mason-test-show.good
+++ b/test/mason/masonTestSome/mason-test-show.good
@@ -1,0 +1,12 @@
+Skipping registry update since no dependency found in manifest file.
+test/mason/masonTestSome/test/compilererror.chpl:1: syntax error: near 'test'
+
+======================================================================
+ERROR test/compilererror.chpl: compilererror
+----------------------------------------------------------------------
+test/compilererror.chpl failed to compile
+----------------------------------------------------------------------
+Ran 1 test in n seconds
+
+FAILED (errors = 1 )
+compilation failed for test/compilererror.chpl

--- a/test/mason/masonTestSome/mason-test-show.prediff
+++ b/test/mason/masonTestSome/mason-test-show.prediff
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import sys, re, shutil, os
+CHPL_HOME = os.getenv("CHPL_HOME")
+test_name = sys.argv[1]
+out_file  = sys.argv[2]
+tmp_file  = out_file + ".prediff.tmp"
+with open(tmp_file, 'w') as tf:
+  with open(out_file) as outf:
+      for line in outf:
+        line = re.sub(r'[0-9]+([.][0-9]+)? seconds', 'n seconds', line)
+        line = line.replace(CHPL_HOME,"",1).lstrip('/')
+        tf.write(line)
+
+shutil.move(tmp_file, out_file)

--- a/test/mason/masonTestSome/test/compilererror.chpl
+++ b/test/mason/masonTestSome/test/compilererror.chpl
@@ -1,0 +1,1 @@
+../../mason-test/test/compileerror.chpl

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -279,8 +279,9 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
 
         if compilation != 0 {
           stderr.writeln("compilation failed for " + test);
-          const errMsg = test + " failed to compile\n" +
-                         "Try running 'mason test --show' for more details";
+          var errMsg = test + " failed to compile";
+          if !show then
+            errMsg += "\nTry running 'mason test --show' for more details";
           result.addError(testName, test,  errMsg);
         }
         else {


### PR DESCRIPTION
This PR makes a small fix to the output of `mason test` when
any test fails to compile. In the case that the user entered
`mason test --show`, we will no longer add the hint to try
running with the `--show` flag. 

Also added are two tests to lock in the behavior of providing
the hint or not.

TESTING:
- [x] paratest

reviewed by @bmcdonald3 - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>