### PR TITLE
Compile all CHAMPS executables nightly

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -60,6 +60,7 @@ test_compile externalSolverPost
 test_compile meshDeformation
 test_compile continuation
 test_compile stability
+test_compile coloring
 
 # copy the input data to the filesystem we're running on
 

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -46,6 +46,20 @@ fi
 test_compile prep
 test_compile flow
 test_compile icing
+test_compile drop
+test_compile potential
+test_compile potentialPrep
+test_compile geo
+test_compile thermo
+test_compile postLink
+# test_compile post   # this one requires the sortedSet patch (#19872)
+test_compile stochasticIcing
+test_compile octree
+test_compile eigenSolvePost
+test_compile externalSolverPost
+test_compile meshDeformation
+test_compile continuation
+test_compile stability
 
 # copy the input data to the filesystem we're running on
 


### PR DESCRIPTION
This PR makes our nightly testing cover all CHAMPS
executables (except `post`, see #19872).

I made some updates to the patch repository to be able cover
all of them. Once we get successful runs, I'll expand the
plots, too.