### PR TITLE
Add comm=none skipif for scanTargetLocsBlock

### DIFF
--- a/test/scan/scanTargetLocsBlock.skipif
+++ b/test/scan/scanTargetLocsBlock.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM==none


### PR DESCRIPTION
This test assumes at least 2 locales. I thought I added this in #20093,
but apparently forget to commit it.