### PR TITLE
Fix some tests for mac

### DIFF
--- a/test/execflags/gbt/dry_run.prediff
+++ b/test/execflags/gbt/dry_run.prediff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys, os, re
 from dry_run_helper import sysLauncherName

--- a/test/execflags/gbt/dry_run.skipif
+++ b/test/execflags/gbt/dry_run.skipif
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import os, dry_run_helper
 from dry_run_helper import sysLauncherName

--- a/test/library/standard/Prefetch/prefetch.prediff
+++ b/test/library/standard/Prefetch/prefetch.prediff
@@ -10,7 +10,7 @@ fi
 
 objdump -d "./$testname" > $disasm
 
-grep -A 20 -e "<_main>" -e "<main>" -e "^_*main:" $disasm | grep "prefetch" > /dev/null
+grep -A 20 -e "<_main>" -e "<main>" -e "_*main:" $disasm | grep "prefetch" > /dev/null
 if [ $? -eq 1 ]; then
   echo "Prefetch instruction not found" >> $outfile
 fi

--- a/test/parallel/taskPool/figueroa/TooManyThreads.skipif
+++ b/test/parallel/taskPool/figueroa/TooManyThreads.skipif
@@ -3,3 +3,5 @@ CHPL_TASKS != fifo
 CHPL_TEST_VGRND_EXE == on
 # Cygwin doesn't allow you to set the number of threads, so skip this test.
 CHPL_HOST_PLATFORM <= cygwin
+# Setting stack limit on darwin doesn't work
+CHPL_TARGET_PLATFORM <= darwin


### PR DESCRIPTION
Fix some minor test issues identified on mac:
 - python -> python3 since python isn't installed
 - fix a prefetch test to handle slightly different disassembly
 - skip test that adjusts thread stack size, which doesn't work on mac

Part of Cray/chapel-private#3374