### PR TITLE
Clean up C code generation of chained if-then-else statements

### DIFF
--- a/compiler/codegen/cg-stmt.cpp
+++ b/compiler/codegen/cg-stmt.cpp
@@ -237,7 +237,22 @@ CondStmt::codegen() {
 
     if (elseStmt) {
       info->cStatements.push_back(" else ");
-      elseStmt->codegen();
+
+      // If the first statement is the only statement and itself a
+      // conditional, just dive in and codegen it to avoid a potential
+      // cascade of curly brackets, striving instead for:
+      //
+      // ...
+      // } else if (...) {
+      // } else if (...) {
+      // ...
+      //
+      Expr* firstStmt = elseStmt->body.head;
+      if (elseStmt->length() == 1 && isCondStmt(firstStmt)) {
+        firstStmt->codegen();
+      } else {
+        elseStmt->codegen();
+      }
     }
 
   } else {


### PR DESCRIPTION
This does a spot-check in C code generation for chained if-then-else
blocks so that rather than generating:

```c
if (...) {
} else {
  if (...) {
  } else {
    if (...) {
    } else {
    }
  }
}
```

we generate:

```c
if (...) {
} else if (...) {
} else if (...) {
} else {
}
```

Essentially, it checks to see whether there's only one statement in
the else block and whether that one statement is itself a conditional.
If so, it codegens it directly; otherwise it does the normal thing.

Due to the compiler's insertion of temps, cases that _seem_ like they
should generate clean chained conditionals don't always, such as
test/parsing/bigifthenelse.chpl.  Perhaps there's more we could do to
denormalize to address such cases, but in the meantime, this seems
like a step forward.

Resolves https://github.com/Cray/chapel-private/issues/3519
