### PR TITLE
Fix `CHPL_COMM_USE_(G|LL)DB` on mac

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -264,7 +264,7 @@ chpl_run_cmdstr(const char *commandStr, char *outbuf, int outbuflen) {
 // Find the named executable in the PATH, if it's there.
 //
 char *chpl_find_executable(const char *prog_name) {
-  const char *cmd_fmt = "/usr/bin/which --skip-alias --skip-functions %s";
+  const char *cmd_fmt = "which %s";
   const int cmd_len
             = strlen(cmd_fmt)     // 'which' command, as printf() format
               - 2                 //   length of "%s" specifier


### PR DESCRIPTION
In 8aca2b3b575 we added a `find_executable` helper, which changed a
`which` call to `/usr/bin/which --skip-alias --skip-functions`. These
options ended up not being portable to the `which` command on mac, which
meant features like `CHPL_COMM_USE_LLDB` couldn't find executables they
needed and weren't working as a result. To fix this just go back to
using a plain `which`. The motivation for using the skip options was:

> In case the user has an alias or shell function with different
> behavior. I think we want to be using "classic which" rather than
> anything derivative.

But I don't think this gave us trouble in the past.

Part of Cray/chapel-private#3374