### PR TITLE
Deprecate SystemError.fromSyserr in favor of a standalone fromSyserr function

### DIFF
--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -878,7 +878,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     var retErrCode: c_int;
     retErrCode = RAND_bytes(c_ptrTo(buff): c_ptr(c_uchar), buffLen: c_int);
     if (!retErrCode) {
-      throw fromSyserr(retErrCode);
+      throw SystemErrorFrom(retErrCode);
     }
     return buff;
   }

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -878,7 +878,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     var retErrCode: c_int;
     retErrCode = RAND_bytes(c_ptrTo(buff): c_ptr(c_uchar), buffLen: c_int);
     if (!retErrCode) {
-      throw SystemError.fromSyserr(retErrCode);
+      throw fromSyserr(retErrCode);
     }
     return buff;
   }

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -172,12 +172,12 @@ module Curl {
     use CurlQioIntegration;
 
     if ch.home != here {
-      throw fromSyserr(EINVAL, "getCurlHandle only functions with local channels");
+      throw SystemErrorFrom(EINVAL, "getCurlHandle only functions with local channels");
     }
 
     var plugin = ch.channelPlugin():CurlChannel?;
     if plugin == nil then
-      throw fromSyserr(EINVAL, "getCurlHandle called on a non-curl channel");
+      throw SystemErrorFrom(EINVAL, "getCurlHandle called on a non-curl channel");
 
     var curl = plugin!.curl;
     return curl;
@@ -199,13 +199,13 @@ module Curl {
     var err:CURLcode = CURLE_OK;
 
     if (arg.type == slist) && (arg.home != ch.home) {
-      throw fromSyserr(EINVAL, "in channel.setopt(): slist, and curl handle do not reside on the same locale");
+      throw SystemErrorFrom(EINVAL, "in channel.setopt(): slist, and curl handle do not reside on the same locale");
     }
 
     on ch.home {
       var plugin = ch.channelPlugin():CurlChannel?;
       if plugin == nil then
-        throw fromSyserr(EINVAL, "in channel.setopt(): not a curl channel");
+        throw SystemErrorFrom(EINVAL, "in channel.setopt(): not a curl channel");
 
       var curl = plugin!.curl;
       err = setopt(curl, opt, arg);

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -172,12 +172,12 @@ module Curl {
     use CurlQioIntegration;
 
     if ch.home != here {
-      throw SystemError.fromSyserr(EINVAL, "getCurlHandle only functions with local channels");
+      throw fromSyserr(EINVAL, "getCurlHandle only functions with local channels");
     }
 
     var plugin = ch.channelPlugin():CurlChannel?;
     if plugin == nil then
-      throw SystemError.fromSyserr(EINVAL, "getCurlHandle called on a non-curl channel");
+      throw fromSyserr(EINVAL, "getCurlHandle called on a non-curl channel");
 
     var curl = plugin!.curl;
     return curl;
@@ -199,13 +199,13 @@ module Curl {
     var err:CURLcode = CURLE_OK;
 
     if (arg.type == slist) && (arg.home != ch.home) {
-      throw SystemError.fromSyserr(EINVAL, "in channel.setopt(): slist, and curl handle do not reside on the same locale");
+      throw fromSyserr(EINVAL, "in channel.setopt(): slist, and curl handle do not reside on the same locale");
     }
 
     on ch.home {
       var plugin = ch.channelPlugin():CurlChannel?;
       if plugin == nil then
-        throw SystemError.fromSyserr(EINVAL, "in channel.setopt(): not a curl channel");
+        throw fromSyserr(EINVAL, "in channel.setopt(): not a curl channel");
 
       var curl = plugin!.curl;
       err = setopt(curl, opt, arg);

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -193,7 +193,7 @@ module HDFS {
     if fs.hfs == c_nil {
       var err = qio_mkerror_errno();
       delete fs;
-      throw SystemError.fromSyserr(err, "in hdfsConnect");
+      throw fromSyserr(err, "in hdfsConnect");
     }
     return new hdfs(fs);
   }
@@ -337,7 +337,7 @@ module HDFS {
         writeln("after hdfsOpenFile");
 
       if hfile == c_nil {
-        throw SystemError.fromSyserr(qio_mkerror_errno(), "in hdfsOpenFile");
+        throw fromSyserr(qio_mkerror_errno(), "in hdfsOpenFile");
       }
 
       // Create an HDFSFile and return the QIO file containing it

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -193,7 +193,7 @@ module HDFS {
     if fs.hfs == c_nil {
       var err = qio_mkerror_errno();
       delete fs;
-      throw fromSyserr(err, "in hdfsConnect");
+      throw SystemErrorFrom(err, "in hdfsConnect");
     }
     return new hdfs(fs);
   }
@@ -337,7 +337,7 @@ module HDFS {
         writeln("after hdfsOpenFile");
 
       if hfile == c_nil {
-        throw fromSyserr(qio_mkerror_errno(), "in hdfsOpenFile");
+        throw SystemErrorFrom(qio_mkerror_errno(), "in hdfsOpenFile");
       }
 
       // Create an HDFSFile and return the QIO file containing it

--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -422,7 +422,7 @@ proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws 
   err_out = sys_accept(socketFd, client_addr, fdOut);
   // if error is not about blocking, throw error
   if err_out != 0 && err_out != EAGAIN && err_out != EWOULDBLOCK {
-    throw SystemError.fromSyserr(err_out, "accept() failed");
+    throw fromSyserr(err_out, "accept() failed");
   }
   // successfully return file
   if err_out == 0 {
@@ -450,7 +450,7 @@ proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws 
     t.stop();
     // if error was timeout throw error
     if retval & EV_TIMEOUT != 0 {
-      throw SystemError.fromSyserr(ETIMEDOUT, "accept() timed out");
+      throw fromSyserr(ETIMEDOUT, "accept() timed out");
     }
     var elapsedTime = t.elapsed(TimeUnits.microseconds):c_long;
     // try accept again
@@ -458,7 +458,7 @@ proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws 
     if err_out != 0 {
       // error was not about blocking wait so throw it
       if err_out != EAGAIN && err_out != EWOULDBLOCK {
-        throw SystemError.fromSyserr(err_out, "accept() failed");
+        throw fromSyserr(err_out, "accept() failed");
       }
       // no indefinitely blocking wait
       if timeout.tv_sec != -1 {
@@ -470,7 +470,7 @@ proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws 
           timeout.tv_sec = remainingSeconds;
           timeout.tv_usec = remainingMicroSeconds;
         }
-        throw SystemError.fromSyserr(ETIMEDOUT, "accept() timed out");
+        throw fromSyserr(ETIMEDOUT, "accept() timed out");
       }
     }
   }
@@ -487,7 +487,7 @@ proc tcpListener.accept(timeout: real): tcpConn throws {
 proc ref tcpListener.close() throws {
   var err_out = sys_close(this.socketFd);
   if err_out != 0 {
-    throw SystemError.fromSyserr(err_out, "Failed to close tcpListener");
+    throw fromSyserr(err_out, "Failed to close tcpListener");
   }
   this.socketFd = -1;
 }
@@ -580,7 +580,7 @@ proc listen(in address: ipAddr, reuseAddr: bool = true,
   bind(socketFd, address, reuseAddr);
   var err_out = sys_listen(socketFd, backlog:c_int);
   if err_out != 0 {
-    throw SystemError.fromSyserr(err_out, "Failed to listen on socket");
+    throw fromSyserr(err_out, "Failed to listen on socket");
   }
   const listener = new tcpListener(socketFd);
   return listener;
@@ -613,7 +613,7 @@ proc connect(const ref address: ipAddr, in timeout = new timeval(-1,0)): tcpConn
   var err_out = sys_connect(socketFd, address._addressStorage);
   if err_out != 0 && err_out != EINPROGRESS {
     sys_close(socketFd);
-    throw SystemError.fromSyserr(err_out,"connect() failed");
+    throw fromSyserr(err_out,"connect() failed");
   }
   if err_out == 0 {
     setBlocking(socketFd, true);
@@ -632,12 +632,12 @@ proc connect(const ref address: ipAddr, in timeout = new timeval(-1,0)): tcpConn
   }
   var retval = localSync$.readFE();
   if retval & EV_TIMEOUT != 0 {
-    throw SystemError.fromSyserr(ETIMEDOUT, "connect() timed out");
+    throw fromSyserr(ETIMEDOUT, "connect() timed out");
   }
   err_out = sys_connect(socketFd, address._addressStorage);
   if err_out != 0 {
     sys_close(socketFd);
-    throw SystemError.fromSyserr(err_out,"connect() failed");
+    throw fromSyserr(err_out,"connect() failed");
   }
   setBlocking(socketFd, true);
   return openfd(socketFd):tcpConn;
@@ -771,7 +771,7 @@ proc udpSocket.addr throws {
 proc udpSocket.close throws {
   var err_out = sys_close(this.socketFd);
   if err_out != 0 {
-    throw SystemError.fromSyserr(err_out, "Failed to close udpSocket");
+    throw fromSyserr(err_out, "Failed to close udpSocket");
   }
 }
 
@@ -810,7 +810,7 @@ proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
   }
   if err_out != 0 && err_out != EAGAIN && err_out != EWOULDBLOCK {
     c_free(buffer);
-    throw SystemError.fromSyserr(err_out,"recv failed");
+    throw fromSyserr(err_out,"recv failed");
   }
   var localSync$: sync c_short;
   var internalEvent = event_new(event_loop_base, this.socketFd, EV_READ | EV_TIMEOUT, c_ptrTo(syncRWTCallback), c_ptrTo(localSync$):c_void_ptr);
@@ -830,14 +830,14 @@ proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
     t.stop();
     if retval & EV_TIMEOUT != 0 {
       c_free(buffer);
-      throw SystemError.fromSyserr(ETIMEDOUT, "recv timed out");
+      throw fromSyserr(ETIMEDOUT, "recv timed out");
     }
     var elapsedTime = t.elapsed(TimeUnits.microseconds):c_long;
     err_out = sys_recvfrom(this.socketFd, buffer, bufferLen:c_size_t, 0, addressStorage, length);
     if err_out != 0 {
       if err_out != EAGAIN && err_out != EWOULDBLOCK {
         c_free(buffer);
-        throw SystemError.fromSyserr(err_out,"recv failed");
+        throw fromSyserr(err_out,"recv failed");
       }
       if timeout.tv_sec == -1 {
         var totalTimeout = timeout.tv_sec*1000000 + timeout.tv_usec;
@@ -848,7 +848,7 @@ proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
           timeout.tv_usec = remainingMicroSeconds;
         }
         c_free(buffer);
-        throw SystemError.fromSyserr(ETIMEDOUT, "recv timed out");
+        throw fromSyserr(ETIMEDOUT, "recv timed out");
       }
     }
   }
@@ -921,7 +921,7 @@ proc udpSocket.send(data: bytes, in address: ipAddr,
     return length;
   }
   if err_out != 0 && err_out != EAGAIN && err_out != EWOULDBLOCK {
-    throw SystemError.fromSyserr(err_out, "send failed");
+    throw fromSyserr(err_out, "send failed");
   }
   var localSync$: sync c_short;
   var internalEvent = event_new(event_loop_base, this.socketFd, EV_WRITE | EV_TIMEOUT, c_ptrTo(syncRWTCallback), c_ptrTo(localSync$):c_void_ptr);
@@ -933,18 +933,18 @@ proc udpSocket.send(data: bytes, in address: ipAddr,
     t.start();
     err_out = event_add(internalEvent, if timeout.tv_sec == -1 then nil else c_ptrTo(timeout));
     if err_out != 0 {
-      throw SystemError.fromSyserr(err_out, "send failed");
+      throw fromSyserr(err_out, "send failed");
     }
     var retval = localSync$.readFE();
     t.stop();
     if retval & EV_TIMEOUT != 0 {
-      throw SystemError.fromSyserr(ETIMEDOUT, "send timed out");
+      throw fromSyserr(ETIMEDOUT, "send timed out");
     }
     var elapsedTime = t.elapsed(TimeUnits.microseconds):c_long;
     err_out = sys_sendto(this.socketFd, data.c_str():c_void_ptr, data.size:c_long, 0, address._addressStorage, length);
     if err_out != 0 {
       if err_out != EAGAIN && err_out != EWOULDBLOCK {
-        throw SystemError.fromSyserr(err_out, "send failed");
+        throw fromSyserr(err_out, "send failed");
       }
       if timeout.tv_sec == -1 {
         var totalTimeout = timeout.tv_sec*1000000 + timeout.tv_usec;
@@ -954,7 +954,7 @@ proc udpSocket.send(data: bytes, in address: ipAddr,
           timeout.tv_sec = remainingSeconds;
           timeout.tv_usec = remainingMicroSeconds;
         }
-        throw SystemError.fromSyserr(ETIMEDOUT, "send timed out");
+        throw fromSyserr(ETIMEDOUT, "send timed out");
       }
     }
   }
@@ -986,7 +986,7 @@ proc setSockOpt(socketFd: fd_t, level: c_int, optname: c_int, ref value: c_int) 
   var ptroptval = c_ptrTo(value);
   var err_out = sys_setsockopt(socketFd, level, optname, ptroptval:c_void_ptr, optlen);
   if err_out != 0 {
-    throw SystemError.fromSyserr(err_out, "Failed to set socket option");
+    throw fromSyserr(err_out, "Failed to set socket option");
   }
 }
 
@@ -1022,7 +1022,7 @@ proc setSockOpt(socketFd:fd_t, level: c_int, optname: c_int, ref value: bytes) t
   var ptroptval = value.c_str();
   var err_out = sys_setsockopt(socketFd, level, optname, ptroptval, optlen);
   if err_out != 0 {
-    throw SystemError.fromSyserr(err_out, "Failed to set socket option");
+    throw fromSyserr(err_out, "Failed to set socket option");
   }
 }
 
@@ -1054,7 +1054,7 @@ pragma "no doc"
 proc setSockOpt(socketFd:fd_t, level: c_int, optname: c_int, value:nothing, optlen:socklen_t) throws {
   var err_out = sys_setsockopt(socketFd, level, optname, nil, optlen);
   if err_out != 0 {
-    throw SystemError.fromSyserr(err_out, "Failed to set socket option");
+    throw fromSyserr(err_out, "Failed to set socket option");
   }
 }
 
@@ -1088,7 +1088,7 @@ proc getSockOpt(socketFd:fd_t, level: c_int, optname: c_int) throws {
   var optlen = sizeof(optval):socklen_t;
   var err_out = sys_getsockopt(socketFd, level, optname, ptroptval:c_void_ptr, optlen);
   if err_out != 0 {
-    throw SystemError.fromSyserr(err_out, "Failed to get socket option");
+    throw fromSyserr(err_out, "Failed to get socket option");
   }
   return optval;
 }
@@ -1126,7 +1126,7 @@ proc getSockOpt(socketFd:fd_t, level: c_int, optname: c_int, buflen: uint(16)) t
     var err_out = sys_getsockopt(socketFd, level, optname, buffer:c_void_ptr, len);
     if err_out != 0 {
       c_free(buffer);
-      throw SystemError.fromSyserr(err_out, "Failed to get socket option");
+      throw fromSyserr(err_out, "Failed to get socket option");
     }
     return createBytesWithOwnedBuffer(buffer, len, buflen);
   }
@@ -1159,7 +1159,7 @@ proc getPeerName(socketFD: fd_t) throws {
   var addressStorage = new sys_sockaddr_t();
   var err = sys_getpeername(socketFD, addressStorage);
   if err != 0 {
-    throw SystemError.fromSyserr(err, "Failed to get remote address");
+    throw fromSyserr(err, "Failed to get remote address");
   }
   return new ipAddr(addressStorage);
 }
@@ -1186,7 +1186,7 @@ proc getSockName(socketFD: fd_t) throws {
   var addressStorage = new sys_sockaddr_t();
   var err = sys_getsockname(socketFD, addressStorage);
   if err != 0 {
-    throw SystemError.fromSyserr(err, "Failed to get local address");
+    throw fromSyserr(err, "Failed to get local address");
   }
   return new ipAddr(addressStorage);
 }
@@ -1213,7 +1213,7 @@ proc socket(family:IPFamily = IPFamily.IPv4, sockType:c_int = SOCK_STREAM, proto
   var socketFd: c_int;
   var err = sys_socket(family:c_int, sockType, protocol:c_int, socketFd);
   if err != 0 {
-    throw SystemError.fromSyserr(err, "Failed to create socket");
+    throw fromSyserr(err, "Failed to create socket");
   }
   return socketFd;
 }
@@ -1223,7 +1223,7 @@ proc setBlocking(socketFd: fd_t, blocking: bool) throws {
   var flags:c_int;
   var err = sys_fcntl(socketFd, F_GETFL, flags);
   if err != 0 {
-    throw SystemError.fromSyserr(err, "Failed to get socket flags");
+    throw fromSyserr(err, "Failed to get socket flags");
   }
   if blocking {
     flags &= ~OS.POSIX.O_NONBLOCK;
@@ -1233,7 +1233,7 @@ proc setBlocking(socketFd: fd_t, blocking: bool) throws {
   }
   err = sys_fcntl_long(socketFd, F_SETFL, flags, flags);
   if err != 0 {
-    throw SystemError.fromSyserr(err, "Failed to make socket non blocking");
+    throw fromSyserr(err, "Failed to make socket non blocking");
   }
 }
 
@@ -1243,7 +1243,7 @@ proc bind(socketFd:fd_t, ref address: ipAddr, reuseAddr = true) throws {
   setSockOpt(socketFd, SOL_SOCKET, SO_REUSEADDR, enable);
   var err = sys_bind(socketFd, address._addressStorage);
   if err != 0 {
-    throw SystemError.fromSyserr(err, "Failed to bind Socket");
+    throw fromSyserr(err, "Failed to bind Socket");
   }
 }
 

--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -422,7 +422,7 @@ proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws 
   err_out = sys_accept(socketFd, client_addr, fdOut);
   // if error is not about blocking, throw error
   if err_out != 0 && err_out != EAGAIN && err_out != EWOULDBLOCK {
-    throw fromSyserr(err_out, "accept() failed");
+    throw SystemErrorFrom(err_out, "accept() failed");
   }
   // successfully return file
   if err_out == 0 {
@@ -450,7 +450,7 @@ proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws 
     t.stop();
     // if error was timeout throw error
     if retval & EV_TIMEOUT != 0 {
-      throw fromSyserr(ETIMEDOUT, "accept() timed out");
+      throw SystemErrorFrom(ETIMEDOUT, "accept() timed out");
     }
     var elapsedTime = t.elapsed(TimeUnits.microseconds):c_long;
     // try accept again
@@ -458,7 +458,7 @@ proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws 
     if err_out != 0 {
       // error was not about blocking wait so throw it
       if err_out != EAGAIN && err_out != EWOULDBLOCK {
-        throw fromSyserr(err_out, "accept() failed");
+        throw SystemErrorFrom(err_out, "accept() failed");
       }
       // no indefinitely blocking wait
       if timeout.tv_sec != -1 {
@@ -470,7 +470,7 @@ proc tcpListener.accept(in timeout: timeval = new timeval(-1,0)):tcpConn throws 
           timeout.tv_sec = remainingSeconds;
           timeout.tv_usec = remainingMicroSeconds;
         }
-        throw fromSyserr(ETIMEDOUT, "accept() timed out");
+        throw SystemErrorFrom(ETIMEDOUT, "accept() timed out");
       }
     }
   }
@@ -487,7 +487,7 @@ proc tcpListener.accept(timeout: real): tcpConn throws {
 proc ref tcpListener.close() throws {
   var err_out = sys_close(this.socketFd);
   if err_out != 0 {
-    throw fromSyserr(err_out, "Failed to close tcpListener");
+    throw SystemErrorFrom(err_out, "Failed to close tcpListener");
   }
   this.socketFd = -1;
 }
@@ -580,7 +580,7 @@ proc listen(in address: ipAddr, reuseAddr: bool = true,
   bind(socketFd, address, reuseAddr);
   var err_out = sys_listen(socketFd, backlog:c_int);
   if err_out != 0 {
-    throw fromSyserr(err_out, "Failed to listen on socket");
+    throw SystemErrorFrom(err_out, "Failed to listen on socket");
   }
   const listener = new tcpListener(socketFd);
   return listener;
@@ -613,7 +613,7 @@ proc connect(const ref address: ipAddr, in timeout = new timeval(-1,0)): tcpConn
   var err_out = sys_connect(socketFd, address._addressStorage);
   if err_out != 0 && err_out != EINPROGRESS {
     sys_close(socketFd);
-    throw fromSyserr(err_out,"connect() failed");
+    throw SystemErrorFrom(err_out,"connect() failed");
   }
   if err_out == 0 {
     setBlocking(socketFd, true);
@@ -632,12 +632,12 @@ proc connect(const ref address: ipAddr, in timeout = new timeval(-1,0)): tcpConn
   }
   var retval = localSync$.readFE();
   if retval & EV_TIMEOUT != 0 {
-    throw fromSyserr(ETIMEDOUT, "connect() timed out");
+    throw SystemErrorFrom(ETIMEDOUT, "connect() timed out");
   }
   err_out = sys_connect(socketFd, address._addressStorage);
   if err_out != 0 {
     sys_close(socketFd);
-    throw fromSyserr(err_out,"connect() failed");
+    throw SystemErrorFrom(err_out,"connect() failed");
   }
   setBlocking(socketFd, true);
   return openfd(socketFd):tcpConn;
@@ -771,7 +771,7 @@ proc udpSocket.addr throws {
 proc udpSocket.close throws {
   var err_out = sys_close(this.socketFd);
   if err_out != 0 {
-    throw fromSyserr(err_out, "Failed to close udpSocket");
+    throw SystemErrorFrom(err_out, "Failed to close udpSocket");
   }
 }
 
@@ -810,7 +810,7 @@ proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
   }
   if err_out != 0 && err_out != EAGAIN && err_out != EWOULDBLOCK {
     c_free(buffer);
-    throw fromSyserr(err_out,"recv failed");
+    throw SystemErrorFrom(err_out,"recv failed");
   }
   var localSync$: sync c_short;
   var internalEvent = event_new(event_loop_base, this.socketFd, EV_READ | EV_TIMEOUT, c_ptrTo(syncRWTCallback), c_ptrTo(localSync$):c_void_ptr);
@@ -830,14 +830,14 @@ proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
     t.stop();
     if retval & EV_TIMEOUT != 0 {
       c_free(buffer);
-      throw fromSyserr(ETIMEDOUT, "recv timed out");
+      throw SystemErrorFrom(ETIMEDOUT, "recv timed out");
     }
     var elapsedTime = t.elapsed(TimeUnits.microseconds):c_long;
     err_out = sys_recvfrom(this.socketFd, buffer, bufferLen:c_size_t, 0, addressStorage, length);
     if err_out != 0 {
       if err_out != EAGAIN && err_out != EWOULDBLOCK {
         c_free(buffer);
-        throw fromSyserr(err_out,"recv failed");
+        throw SystemErrorFrom(err_out,"recv failed");
       }
       if timeout.tv_sec == -1 {
         var totalTimeout = timeout.tv_sec*1000000 + timeout.tv_usec;
@@ -848,7 +848,7 @@ proc udpSocket.recvfrom(bufferLen: int, in timeout = new timeval(-1,0),
           timeout.tv_usec = remainingMicroSeconds;
         }
         c_free(buffer);
-        throw fromSyserr(ETIMEDOUT, "recv timed out");
+        throw SystemErrorFrom(ETIMEDOUT, "recv timed out");
       }
     }
   }
@@ -921,7 +921,7 @@ proc udpSocket.send(data: bytes, in address: ipAddr,
     return length;
   }
   if err_out != 0 && err_out != EAGAIN && err_out != EWOULDBLOCK {
-    throw fromSyserr(err_out, "send failed");
+    throw SystemErrorFrom(err_out, "send failed");
   }
   var localSync$: sync c_short;
   var internalEvent = event_new(event_loop_base, this.socketFd, EV_WRITE | EV_TIMEOUT, c_ptrTo(syncRWTCallback), c_ptrTo(localSync$):c_void_ptr);
@@ -933,18 +933,18 @@ proc udpSocket.send(data: bytes, in address: ipAddr,
     t.start();
     err_out = event_add(internalEvent, if timeout.tv_sec == -1 then nil else c_ptrTo(timeout));
     if err_out != 0 {
-      throw fromSyserr(err_out, "send failed");
+      throw SystemErrorFrom(err_out, "send failed");
     }
     var retval = localSync$.readFE();
     t.stop();
     if retval & EV_TIMEOUT != 0 {
-      throw fromSyserr(ETIMEDOUT, "send timed out");
+      throw SystemErrorFrom(ETIMEDOUT, "send timed out");
     }
     var elapsedTime = t.elapsed(TimeUnits.microseconds):c_long;
     err_out = sys_sendto(this.socketFd, data.c_str():c_void_ptr, data.size:c_long, 0, address._addressStorage, length);
     if err_out != 0 {
       if err_out != EAGAIN && err_out != EWOULDBLOCK {
-        throw fromSyserr(err_out, "send failed");
+        throw SystemErrorFrom(err_out, "send failed");
       }
       if timeout.tv_sec == -1 {
         var totalTimeout = timeout.tv_sec*1000000 + timeout.tv_usec;
@@ -954,7 +954,7 @@ proc udpSocket.send(data: bytes, in address: ipAddr,
           timeout.tv_sec = remainingSeconds;
           timeout.tv_usec = remainingMicroSeconds;
         }
-        throw fromSyserr(ETIMEDOUT, "send timed out");
+        throw SystemErrorFrom(ETIMEDOUT, "send timed out");
       }
     }
   }
@@ -986,7 +986,7 @@ proc setSockOpt(socketFd: fd_t, level: c_int, optname: c_int, ref value: c_int) 
   var ptroptval = c_ptrTo(value);
   var err_out = sys_setsockopt(socketFd, level, optname, ptroptval:c_void_ptr, optlen);
   if err_out != 0 {
-    throw fromSyserr(err_out, "Failed to set socket option");
+    throw SystemErrorFrom(err_out, "Failed to set socket option");
   }
 }
 
@@ -1022,7 +1022,7 @@ proc setSockOpt(socketFd:fd_t, level: c_int, optname: c_int, ref value: bytes) t
   var ptroptval = value.c_str();
   var err_out = sys_setsockopt(socketFd, level, optname, ptroptval, optlen);
   if err_out != 0 {
-    throw fromSyserr(err_out, "Failed to set socket option");
+    throw SystemErrorFrom(err_out, "Failed to set socket option");
   }
 }
 
@@ -1054,7 +1054,7 @@ pragma "no doc"
 proc setSockOpt(socketFd:fd_t, level: c_int, optname: c_int, value:nothing, optlen:socklen_t) throws {
   var err_out = sys_setsockopt(socketFd, level, optname, nil, optlen);
   if err_out != 0 {
-    throw fromSyserr(err_out, "Failed to set socket option");
+    throw SystemErrorFrom(err_out, "Failed to set socket option");
   }
 }
 
@@ -1088,7 +1088,7 @@ proc getSockOpt(socketFd:fd_t, level: c_int, optname: c_int) throws {
   var optlen = sizeof(optval):socklen_t;
   var err_out = sys_getsockopt(socketFd, level, optname, ptroptval:c_void_ptr, optlen);
   if err_out != 0 {
-    throw fromSyserr(err_out, "Failed to get socket option");
+    throw SystemErrorFrom(err_out, "Failed to get socket option");
   }
   return optval;
 }
@@ -1126,7 +1126,7 @@ proc getSockOpt(socketFd:fd_t, level: c_int, optname: c_int, buflen: uint(16)) t
     var err_out = sys_getsockopt(socketFd, level, optname, buffer:c_void_ptr, len);
     if err_out != 0 {
       c_free(buffer);
-      throw fromSyserr(err_out, "Failed to get socket option");
+      throw SystemErrorFrom(err_out, "Failed to get socket option");
     }
     return createBytesWithOwnedBuffer(buffer, len, buflen);
   }
@@ -1159,7 +1159,7 @@ proc getPeerName(socketFD: fd_t) throws {
   var addressStorage = new sys_sockaddr_t();
   var err = sys_getpeername(socketFD, addressStorage);
   if err != 0 {
-    throw fromSyserr(err, "Failed to get remote address");
+    throw SystemErrorFrom(err, "Failed to get remote address");
   }
   return new ipAddr(addressStorage);
 }
@@ -1186,7 +1186,7 @@ proc getSockName(socketFD: fd_t) throws {
   var addressStorage = new sys_sockaddr_t();
   var err = sys_getsockname(socketFD, addressStorage);
   if err != 0 {
-    throw fromSyserr(err, "Failed to get local address");
+    throw SystemErrorFrom(err, "Failed to get local address");
   }
   return new ipAddr(addressStorage);
 }
@@ -1213,7 +1213,7 @@ proc socket(family:IPFamily = IPFamily.IPv4, sockType:c_int = SOCK_STREAM, proto
   var socketFd: c_int;
   var err = sys_socket(family:c_int, sockType, protocol:c_int, socketFd);
   if err != 0 {
-    throw fromSyserr(err, "Failed to create socket");
+    throw SystemErrorFrom(err, "Failed to create socket");
   }
   return socketFd;
 }
@@ -1223,7 +1223,7 @@ proc setBlocking(socketFd: fd_t, blocking: bool) throws {
   var flags:c_int;
   var err = sys_fcntl(socketFd, F_GETFL, flags);
   if err != 0 {
-    throw fromSyserr(err, "Failed to get socket flags");
+    throw SystemErrorFrom(err, "Failed to get socket flags");
   }
   if blocking {
     flags &= ~OS.POSIX.O_NONBLOCK;
@@ -1233,7 +1233,7 @@ proc setBlocking(socketFd: fd_t, blocking: bool) throws {
   }
   err = sys_fcntl_long(socketFd, F_SETFL, flags, flags);
   if err != 0 {
-    throw fromSyserr(err, "Failed to make socket non blocking");
+    throw SystemErrorFrom(err, "Failed to make socket non blocking");
   }
 }
 
@@ -1243,7 +1243,7 @@ proc bind(socketFd:fd_t, ref address: ipAddr, reuseAddr = true) throws {
   setSockOpt(socketFd, SOL_SOCKET, SO_REUSEADDR, enable);
   var err = sys_bind(socketFd, address._addressStorage);
   if err != 0 {
-    throw fromSyserr(err, "Failed to bind Socket");
+    throw SystemErrorFrom(err, "Failed to bind Socket");
   }
 }
 

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -1065,7 +1065,7 @@ module ZMQ {
       var errmsg_fmt = "Error in Socket.%s(%s): %s\n";
       var errmsg_str = errmsg_fmt.format(err_fn, string:string, errmsg_zmq);
 
-      throw SystemError.fromSyserr(socket_errno:syserr, errmsg_str);
+      throw fromSyserr(socket_errno:syserr, errmsg_str);
     }
   } // record Socket
 

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -1065,7 +1065,7 @@ module ZMQ {
       var errmsg_fmt = "Error in Socket.%s(%s): %s\n";
       var errmsg_str = errmsg_fmt.format(err_fn, string:string, errmsg_zmq);
 
-      throw fromSyserr(socket_errno:syserr, errmsg_str);
+      throw SystemErrorFrom(socket_errno:syserr, errmsg_str);
     }
   } // record Socket
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -701,9 +701,9 @@ proc stringStyleWithLengthInternal(lengthBytes:int) throws {
     when 4 do x = iostringstyle.len4b_data;
     when 8 do x = iostringstyle.len8b_data;
     otherwise
-      throw fromSyserr(EINVAL,
-                       "Invalid string length prefix " +
-                       lengthBytes:string);
+      throw SystemErrorFrom(EINVAL,
+                            "Invalid string length prefix " +
+                            lengthBytes:string);
   }
   return x;
 }
@@ -1497,9 +1497,9 @@ operator file.=(ref ret:file, x:file) {
 pragma "no doc"
 proc file.checkAssumingLocal() throws {
   if is_c_nil(_file_internal) then
-    throw fromSyserr(EBADF, "Operation attempted on an invalid file");
+    throw SystemErrorFrom(EBADF, "Operation attempted on an invalid file");
   if !qio_file_isopen(_file_internal) then
-    throw fromSyserr(EBADF, "Operation attempted on closed file");
+    throw SystemErrorFrom(EBADF, "Operation attempted on closed file");
 }
 
 /* Throw an error if `this` is not a valid representation of an OS file.
@@ -1580,7 +1580,7 @@ proc file._style:iostyleInternal throws {
  */
 proc file.close() throws {
   if is_c_nil(_file_internal) then
-    throw fromSyserr(EBADF, "Operation attempted on an invalid file");
+    throw SystemErrorFrom(EBADF, "Operation attempted on an invalid file");
 
   var err:syserr = ENOERR;
   on this.home {
@@ -2320,7 +2320,7 @@ inline proc channel.lock() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
-    throw fromSyserr(EINVAL, "Operation attempted on an invalid channel");
+    throw SystemErrorFrom(EINVAL, "Operation attempted on an invalid channel");
 
   if locking {
     on this.home {
@@ -2437,7 +2437,7 @@ proc channel.mark() throws where this.locking == false {
   const err = qio_channel_mark(false, _channel_internal);
 
   if err then
-    throw fromSyserr(err);
+    throw SystemErrorFrom(err);
 
   return offset;
 }
@@ -2492,7 +2492,7 @@ proc channel.seek(start:int(64), end:int(64) = max(int(64))) throws {
   const err = qio_channel_seek(_channel_internal, start, end);
 
   if err then
-    throw fromSyserr(err);
+    throw SystemErrorFrom(err);
 }
 
 
@@ -2531,7 +2531,7 @@ proc channel._mark() throws {
   const err = qio_channel_mark(false, _channel_internal);
 
   if err then
-    throw fromSyserr(err);
+    throw SystemErrorFrom(err);
 
   return offset;
 }
@@ -4407,7 +4407,7 @@ proc channel.writeBinary(arg:numeric, param endian:ioendian = ioendian.native) t
     }
   }
   if (e != ENOERR) {
-    throw fromSyserr(e);
+    throw SystemErrorFrom(e);
   }
 }
 
@@ -4462,7 +4462,7 @@ proc channel.readBinary(ref arg:numeric, param endian:ioendian = ioendian.native
   if (e == EEOF) {
     return false;
   } else if (e != ENOERR) {
-    throw fromSyserr(e);
+    throw SystemErrorFrom(e);
   }
   return true;
 }
@@ -4756,7 +4756,7 @@ proc channel.close() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
-    throw fromSyserr(EINVAL, "cannot close invalid channel");
+    throw SystemErrorFrom(EINVAL, "cannot close invalid channel");
 
   on this.home {
     err = qio_channel_close(locking, _channel_internal);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -701,9 +701,9 @@ proc stringStyleWithLengthInternal(lengthBytes:int) throws {
     when 4 do x = iostringstyle.len4b_data;
     when 8 do x = iostringstyle.len8b_data;
     otherwise
-      throw SystemError.fromSyserr(EINVAL,
-                                   "Invalid string length prefix " +
-                                   lengthBytes:string);
+      throw fromSyserr(EINVAL,
+                       "Invalid string length prefix " +
+                       lengthBytes:string);
   }
   return x;
 }
@@ -1497,9 +1497,9 @@ operator file.=(ref ret:file, x:file) {
 pragma "no doc"
 proc file.checkAssumingLocal() throws {
   if is_c_nil(_file_internal) then
-    throw SystemError.fromSyserr(EBADF, "Operation attempted on an invalid file");
+    throw fromSyserr(EBADF, "Operation attempted on an invalid file");
   if !qio_file_isopen(_file_internal) then
-    throw SystemError.fromSyserr(EBADF, "Operation attempted on closed file");
+    throw fromSyserr(EBADF, "Operation attempted on closed file");
 }
 
 /* Throw an error if `this` is not a valid representation of an OS file.
@@ -1580,7 +1580,7 @@ proc file._style:iostyleInternal throws {
  */
 proc file.close() throws {
   if is_c_nil(_file_internal) then
-    throw SystemError.fromSyserr(EBADF, "Operation attempted on an invalid file");
+    throw fromSyserr(EBADF, "Operation attempted on an invalid file");
 
   var err:syserr = ENOERR;
   on this.home {
@@ -2320,7 +2320,7 @@ inline proc channel.lock() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
-    throw SystemError.fromSyserr(EINVAL, "Operation attempted on an invalid channel");
+    throw fromSyserr(EINVAL, "Operation attempted on an invalid channel");
 
   if locking {
     on this.home {
@@ -2437,7 +2437,7 @@ proc channel.mark() throws where this.locking == false {
   const err = qio_channel_mark(false, _channel_internal);
 
   if err then
-    throw SystemError.fromSyserr(err);
+    throw fromSyserr(err);
 
   return offset;
 }
@@ -2492,7 +2492,7 @@ proc channel.seek(start:int(64), end:int(64) = max(int(64))) throws {
   const err = qio_channel_seek(_channel_internal, start, end);
 
   if err then
-    throw SystemError.fromSyserr(err);
+    throw fromSyserr(err);
 }
 
 
@@ -2531,7 +2531,7 @@ proc channel._mark() throws {
   const err = qio_channel_mark(false, _channel_internal);
 
   if err then
-    throw SystemError.fromSyserr(err);
+    throw fromSyserr(err);
 
   return offset;
 }
@@ -4407,7 +4407,7 @@ proc channel.writeBinary(arg:numeric, param endian:ioendian = ioendian.native) t
     }
   }
   if (e != ENOERR) {
-    throw SystemError.fromSyserr(e);
+    throw fromSyserr(e);
   }
 }
 
@@ -4462,7 +4462,7 @@ proc channel.readBinary(ref arg:numeric, param endian:ioendian = ioendian.native
   if (e == EEOF) {
     return false;
   } else if (e != ENOERR) {
-    throw SystemError.fromSyserr(e);
+    throw fromSyserr(e);
   }
   return true;
 }
@@ -4756,7 +4756,7 @@ proc channel.close() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
-    throw SystemError.fromSyserr(EINVAL, "cannot close invalid channel");
+    throw fromSyserr(EINVAL, "cannot close invalid channel");
 
   on this.home {
     err = qio_channel_close(locking, _channel_internal);

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -271,7 +271,7 @@ module Subprocess {
     proc stdin throws {
       try _throw_on_launch_error();
       if stdin_pipe == false {
-        throw SystemError.fromSyserr(
+        throw fromSyserr(
             EINVAL, "subprocess was not configured with a stdin pipe");
       }
       return stdin_channel;
@@ -287,7 +287,7 @@ module Subprocess {
     proc stdout throws {
       try _throw_on_launch_error();
       if stdout_pipe == false {
-        throw SystemError.fromSyserr(
+        throw fromSyserr(
             EINVAL, "subprocess was not configured with a stdout pipe");
       }
       return stdout_channel;
@@ -303,7 +303,7 @@ module Subprocess {
     proc stderr throws {
       try _throw_on_launch_error();
       if stderr_pipe == false {
-        throw SystemError.fromSyserr(
+        throw fromSyserr(
             EINVAL, "subprocess was not configured with a stderr pipe");
       }
       return stderr_channel;
@@ -509,7 +509,7 @@ module Subprocess {
           if sys_getenv(c"PE_PRODUCT_LIST", env_c_str)==1 {
             env_str = createStringWithNewBuffer(env_c_str);
             if env_str.count("HUGETLB") > 0 then
-              throw SystemError.fromSyserr(
+              throw fromSyserr(
                   EINVAL,
                   "spawn with more than 1 locale for CHPL_COMM=ugni with hugepages currently requires stdin, stdout, stderr=pipeStyle.forward");
           }

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -271,7 +271,7 @@ module Subprocess {
     proc stdin throws {
       try _throw_on_launch_error();
       if stdin_pipe == false {
-        throw fromSyserr(
+        throw SystemErrorFrom(
             EINVAL, "subprocess was not configured with a stdin pipe");
       }
       return stdin_channel;
@@ -287,7 +287,7 @@ module Subprocess {
     proc stdout throws {
       try _throw_on_launch_error();
       if stdout_pipe == false {
-        throw fromSyserr(
+        throw SystemErrorFrom(
             EINVAL, "subprocess was not configured with a stdout pipe");
       }
       return stdout_channel;
@@ -303,7 +303,7 @@ module Subprocess {
     proc stderr throws {
       try _throw_on_launch_error();
       if stderr_pipe == false {
-        throw fromSyserr(
+        throw SystemErrorFrom(
             EINVAL, "subprocess was not configured with a stderr pipe");
       }
       return stderr_channel;
@@ -509,7 +509,7 @@ module Subprocess {
           if sys_getenv(c"PE_PRODUCT_LIST", env_c_str)==1 {
             env_str = createStringWithNewBuffer(env_c_str);
             if env_str.count("HUGETLB") > 0 then
-              throw fromSyserr(
+              throw SystemErrorFrom(
                   EINVAL,
                   "spawn with more than 1 locale for CHPL_COMM=ugni with hugepages currently requires stdin, stdout, stderr=pipeStyle.forward");
           }

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -412,7 +412,7 @@ module Sys {
 
       var err_out = sys_host_sys_sockaddr_t(this, buffer, NI_MAXHOST, length);
       if err_out != 0 {
-        throw SystemError.fromSyserr(err_out);
+        throw fromSyserr(err_out);
       }
 
       return createStringWithOwnedBuffer(buffer, length, NI_MAXHOST);
@@ -433,7 +433,7 @@ module Sys {
 
       var err_out = sys_port_sys_sockaddr_t(this, port);
       if err_out != 0 {
-        throw SystemError.fromSyserr(err_out);
+        throw fromSyserr(err_out);
       }
 
       return port;

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -412,7 +412,7 @@ module Sys {
 
       var err_out = sys_host_sys_sockaddr_t(this, buffer, NI_MAXHOST, length);
       if err_out != 0 {
-        throw fromSyserr(err_out);
+        throw SystemErrorFrom(err_out);
       }
 
       return createStringWithOwnedBuffer(buffer, length, NI_MAXHOST);
@@ -433,7 +433,7 @@ module Sys {
 
       var err_out = sys_port_sys_sockaddr_t(this, port);
       if err_out != 0 {
-        throw fromSyserr(err_out);
+        throw SystemErrorFrom(err_out);
       }
 
       return port;

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -364,7 +364,7 @@ private proc quote_string(s:string, len:c_ssize_t) {
 /* Helper to allow calling the standalone fromSyserr function from the
    deprecated type method SystemError.fromSyserr until it is removed */
 private proc fromSyserrHelper(err: syserr, details: string = "") {
-  return fromSyserr(err, details);  
+  return fromSyserr(err, details);
 }
 /*
   Return the matching :class:`SystemError` subtype for a given ``syserr``,

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -81,46 +81,9 @@ class SystemError : Error {
   */
   pragma "insert line file info"
   pragma "always propagate line file info"
+  deprecated "'SystemError.fromSyserr' is deprecated. Please use 'fromSyserr' instead"
   proc type fromSyserr(err: syserr, details: string = "") {
-    if err == EAGAIN || err == EALREADY || err == EWOULDBLOCK || err == EINPROGRESS {
-      return new owned BlockingIOError(details, err);
-    } else if err == ECHILD {
-      return new owned ChildProcessError(details, err);
-    } else if err == EPIPE || err == ESHUTDOWN {
-      return new owned BrokenPipeError(details, err);
-    } else if err == ECONNABORTED {
-      return new owned ConnectionAbortedError(details, err);
-    } else if err == ECONNREFUSED {
-      return new owned ConnectionRefusedError(details, err);
-    } else if err == ECONNRESET {
-      return new owned ConnectionResetError(details, err);
-    } else if err == EEXIST {
-      return new owned FileExistsError(details, err);
-    } else if err == ENOENT {
-      return new owned FileNotFoundError(details, err);
-    } else if err == EINTR {
-      return new owned InterruptedError(details, err);
-    } else if err == EISDIR {
-      return new owned IsADirectoryError(details, err);
-    } else if err == ENOTDIR {
-      return new owned NotADirectoryError(details, err);
-    } else if err == EACCES || err == EPERM {
-      return new owned PermissionError(details, err);
-    } else if err == ESRCH {
-      return new owned ProcessLookupError(details, err);
-    } else if err == ETIMEDOUT {
-      return new owned TimeoutError(details, err);
-    } else if err == EEOF {
-      return new owned EOFError(details, err);
-    } else if err == ESHORT {
-      return new owned UnexpectedEOFError(details, err);
-    } else if err == EFORMAT {
-      return new owned BadFormatError(details, err);
-    } else if err == EIO {
-      return new owned IOError(err, details);
-    }
-
-    return new owned SystemError(err, details);
+    return fromSyserrHelper(err, details);
   }
 
   /*
@@ -132,10 +95,12 @@ class SystemError : Error {
   */
   pragma "insert line file info"
   pragma "always propagate line file info"
+  deprecated "SystemError.fromSyserr' is deprecated. Please use 'fromSyserr' instead"
   proc type fromSyserr(err: int, details: string = "") {
-    return fromSyserr(err:syserr, details);
+    return fromSyserrHelper(err:syserr, details);
   }
 }
+
 
 /*
 
@@ -396,6 +361,75 @@ private proc quote_string(s:string, len:c_ssize_t) {
   }
 }
 
+/* Helper to allow calling the standalone fromSyserr function from the
+   deprecated type method SystemError.fromSyserr until it is removed */
+private proc fromSyserrHelper(err: syserr, details: string = "") {
+  return fromSyserr(err, details);  
+}
+/*
+  Return the matching :class:`SystemError` subtype for a given ``syserr``,
+  with an optional string containing extra details.
+
+  :arg err: the syserr to generate from
+  :arg details: extra information to include with the error
+*/
+pragma "insert line file info"
+pragma "always propagate line file info"
+proc fromSyserr(err: syserr, details: string = "") {
+  if err == EAGAIN || err == EALREADY || err == EWOULDBLOCK || err == EINPROGRESS {
+    return new owned BlockingIOError(details, err);
+  } else if err == ECHILD {
+    return new owned ChildProcessError(details, err);
+  } else if err == EPIPE || err == ESHUTDOWN {
+    return new owned BrokenPipeError(details, err);
+  } else if err == ECONNABORTED {
+    return new owned ConnectionAbortedError(details, err);
+  } else if err == ECONNREFUSED {
+    return new owned ConnectionRefusedError(details, err);
+  } else if err == ECONNRESET {
+    return new owned ConnectionResetError(details, err);
+  } else if err == EEXIST {
+    return new owned FileExistsError(details, err);
+  } else if err == ENOENT {
+    return new owned FileNotFoundError(details, err);
+  } else if err == EINTR {
+    return new owned InterruptedError(details, err);
+  } else if err == EISDIR {
+    return new owned IsADirectoryError(details, err);
+  } else if err == ENOTDIR {
+    return new owned NotADirectoryError(details, err);
+  } else if err == EACCES || err == EPERM {
+    return new owned PermissionError(details, err);
+  } else if err == ESRCH {
+    return new owned ProcessLookupError(details, err);
+  } else if err == ETIMEDOUT {
+    return new owned TimeoutError(details, err);
+  } else if err == EEOF {
+    return new owned EOFError(details, err);
+  } else if err == ESHORT {
+    return new owned UnexpectedEOFError(details, err);
+  } else if err == EFORMAT {
+    return new owned BadFormatError(details, err);
+  } else if err == EIO {
+    return new owned IOError(err, details);
+  }
+
+  return new owned SystemError(err, details);
+}
+
+/*
+  Return the matching :class:`SystemError` subtype for a given error number,
+  with an optional string containing extra details.
+
+  :arg err: the number to generate from
+  :arg details: extra information to include with the error
+*/
+pragma "insert line file info"
+pragma "always propagate line file info"
+proc fromSyserr(err: int, details: string = "") {
+  return fromSyserr(err:syserr, details);
+}
+
 /* Create and throw a :class:`SystemError` if an error occurred, formatting a
    useful message based on the provided arguments. Do nothing if the error
    argument does not indicate an error occurred.
@@ -416,7 +450,7 @@ proc ioerror(error:syserr, msg:string, path:string, offset:int(64)) throws
     const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
     var   details    = msg + " with path " + quotedpath +
                        " offset " + offset:string;
-    throw SystemError.fromSyserr(error, details);
+    throw fromSyserr(error, details);
   }
 }
 
@@ -428,7 +462,7 @@ proc ioerror(error:syserr, msg:string, path:string) throws
   if error {
     const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
     var   details    = msg + " with path " + quotedpath;
-    throw SystemError.fromSyserr(error, details);
+    throw fromSyserr(error, details);
   }
 }
 
@@ -437,7 +471,7 @@ pragma "insert line file info"
 pragma "always propagate line file info"
 proc ioerror(error:syserr, msg:string) throws
 {
-  if error then throw SystemError.fromSyserr(error, msg);
+  if error then throw fromSyserr(error, msg);
 }
 
 /* Create and throw an :class:`IOError` and include a formatted message based on
@@ -457,7 +491,7 @@ proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
   const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
   const details    = errstr + " " + msg + " with path " + quotedpath +
                      " offset " + offset:string;
-  throw SystemError.fromSyserr(EIO:syserr, details);
+  throw fromSyserr(EIO:syserr, details);
 }
 
 /* Convert a syserr code to a human-readable string describing the error.

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -81,7 +81,7 @@ class SystemError : Error {
   */
   pragma "insert line file info"
   pragma "always propagate line file info"
-  deprecated "'SystemError.fromSyserr' is deprecated. Please use 'fromSyserr' instead"
+  deprecated "'SystemError.fromSyserr' is deprecated. Please use 'SystemErrorFrom' instead"
   proc type fromSyserr(err: syserr, details: string = "") {
     return fromSyserrHelper(err, details);
   }
@@ -95,7 +95,7 @@ class SystemError : Error {
   */
   pragma "insert line file info"
   pragma "always propagate line file info"
-  deprecated "SystemError.fromSyserr' is deprecated. Please use 'fromSyserr' instead"
+  deprecated "SystemError.fromSyserr' is deprecated. Please use 'SystemErrorFrom' instead"
   proc type fromSyserr(err: int, details: string = "") {
     return fromSyserrHelper(err:syserr, details);
   }
@@ -361,10 +361,10 @@ private proc quote_string(s:string, len:c_ssize_t) {
   }
 }
 
-/* Helper to allow calling the standalone fromSyserr function from the
+/* Helper to allow calling the standalone SystemErrorFrom function from the
    deprecated type method SystemError.fromSyserr until it is removed */
 private proc fromSyserrHelper(err: syserr, details: string = "") {
-  return fromSyserr(err, details);
+  return SystemErrorFrom(err, details);
 }
 /*
   Return the matching :class:`SystemError` subtype for a given ``syserr``,
@@ -375,7 +375,7 @@ private proc fromSyserrHelper(err: syserr, details: string = "") {
 */
 pragma "insert line file info"
 pragma "always propagate line file info"
-proc fromSyserr(err: syserr, details: string = "") {
+proc SystemErrorFrom(err: syserr, details: string = "") {
   if err == EAGAIN || err == EALREADY || err == EWOULDBLOCK || err == EINPROGRESS {
     return new owned BlockingIOError(details, err);
   } else if err == ECHILD {
@@ -426,8 +426,8 @@ proc fromSyserr(err: syserr, details: string = "") {
 */
 pragma "insert line file info"
 pragma "always propagate line file info"
-proc fromSyserr(err: int, details: string = "") {
-  return fromSyserr(err:syserr, details);
+proc SystemErrorFrom(err: int, details: string = "") {
+  return SystemErrorFrom(err:syserr, details);
 }
 
 /* Create and throw a :class:`SystemError` if an error occurred, formatting a
@@ -450,7 +450,7 @@ proc ioerror(error:syserr, msg:string, path:string, offset:int(64)) throws
     const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
     var   details    = msg + " with path " + quotedpath +
                        " offset " + offset:string;
-    throw fromSyserr(error, details);
+    throw SystemErrorFrom(error, details);
   }
 }
 
@@ -462,7 +462,7 @@ proc ioerror(error:syserr, msg:string, path:string) throws
   if error {
     const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
     var   details    = msg + " with path " + quotedpath;
-    throw fromSyserr(error, details);
+    throw SystemErrorFrom(error, details);
   }
 }
 
@@ -471,7 +471,7 @@ pragma "insert line file info"
 pragma "always propagate line file info"
 proc ioerror(error:syserr, msg:string) throws
 {
-  if error then throw fromSyserr(error, msg);
+  if error then throw SystemErrorFrom(error, msg);
 }
 
 /* Create and throw an :class:`IOError` and include a formatted message based on
@@ -491,7 +491,7 @@ proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
   const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
   const details    = errstr + " " + msg + " with path " + quotedpath +
                      " offset " + offset:string;
-  throw fromSyserr(EIO:syserr, details);
+  throw SystemErrorFrom(EIO:syserr, details);
 }
 
 /* Convert a syserr code to a human-readable string describing the error.

--- a/test/deprecated/fromSyserrTypeMethod.chpl
+++ b/test/deprecated/fromSyserrTypeMethod.chpl
@@ -1,0 +1,5 @@
+use SysError;
+import SysBasic.syserr;
+
+SystemError.fromSyserr(1);
+SystemError.fromSyserr(1:syserr);

--- a/test/deprecated/fromSyserrTypeMethod.good
+++ b/test/deprecated/fromSyserrTypeMethod.good
@@ -1,0 +1,2 @@
+fromSyserrTypeMethod.chpl:4: warning: SystemError.fromSyserr' is deprecated. Please use 'fromSyserr' instead
+fromSyserrTypeMethod.chpl:5: warning: 'SystemError.fromSyserr' is deprecated. Please use 'fromSyserr' instead

--- a/test/deprecated/fromSyserrTypeMethod.good
+++ b/test/deprecated/fromSyserrTypeMethod.good
@@ -1,2 +1,2 @@
-fromSyserrTypeMethod.chpl:4: warning: SystemError.fromSyserr' is deprecated. Please use 'fromSyserr' instead
-fromSyserrTypeMethod.chpl:5: warning: 'SystemError.fromSyserr' is deprecated. Please use 'fromSyserr' instead
+fromSyserrTypeMethod.chpl:4: warning: SystemError.fromSyserr' is deprecated. Please use 'SystemErrorFrom' instead
+fromSyserrTypeMethod.chpl:5: warning: 'SystemError.fromSyserr' is deprecated. Please use 'SystemErrorFrom' instead

--- a/test/errhandling/ferguson/issue-18103.chpl
+++ b/test/errhandling/ferguson/issue-18103.chpl
@@ -1,5 +1,5 @@
 use SysError;
 
-var e = fromSyserr(-1);
+var e = SystemErrorFrom(-1);
 
 writeln(e);

--- a/test/errhandling/ferguson/issue-18103.chpl
+++ b/test/errhandling/ferguson/issue-18103.chpl
@@ -1,5 +1,5 @@
 use SysError;
 
-var e = SystemError.fromSyserr(-1);
+var e = fromSyserr(-1);
 
 writeln(e);


### PR DESCRIPTION
Add deprecation messages for SystemError.fromSyserr and add a stand alone
version.

Update modules and a test to not use the deprecated version.

Add a test/deprecated test.

Closes
https://github.com/Cray/chapel-private/issues/3398

Signed-off-by: David Iten <daviditen@users.noreply.github.com>