### PR TITLE
Generate device versions of some functions in runtime

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1307,11 +1307,14 @@ class CCodeGenConsumer final : public ASTConsumer {
     ASTContext* savedCtx;
 
     bool shouldHandleDecl(Decl* d) {
-      if (localeUsesGPU()) {
-        return gCodegenGPU == d->hasAttr<CUDADeviceAttr>();
+      if (gCodegenGPU) {
+        //this decl must have __device__
+        return d->hasAttr<CUDADeviceAttr>();
       }
       else {
-        return true;
+        // this decl either doesn't have __device__, or if it has, it also has a
+        // __host__
+        return !d->hasAttr<CUDADeviceAttr>() || d->hasAttr<CUDAHostAttr>();
       }
     }
 

--- a/runtime/include/chplmath.h
+++ b/runtime/include/chplmath.h
@@ -33,32 +33,32 @@ static inline float chpl_macro_NAN(void) {
   return NAN;
 }
 
-static inline int chpl_macro_double_isinf(double x) { return isinf(x); }
-static inline int chpl_macro_float_isinf(float x) { return isinf(x); }
-static inline int chpl_macro_double_isfinite(double x) { return isfinite(x); }
-static inline int chpl_macro_float_isfinite(float x) { return isfinite(x); }
-static inline int chpl_macro_double_isnan(double x) { return isnan(x); }
-static inline int chpl_macro_float_isnan(float x) { return isnan(x); }
-static inline int chpl_macro_double_signbit(double x) { return signbit(x); }
-static inline int chpl_macro_float_signbit(float x) { return signbit(x); }
+MAYBE_GPU static inline int chpl_macro_double_isinf(double x) { return isinf(x); }
+MAYBE_GPU static inline int chpl_macro_float_isinf(float x) { return isinf(x); }
+MAYBE_GPU static inline int chpl_macro_double_isfinite(double x) { return isfinite(x); }
+MAYBE_GPU static inline int chpl_macro_float_isfinite(float x) { return isfinite(x); }
+MAYBE_GPU static inline int chpl_macro_double_isnan(double x) { return isnan(x); }
+MAYBE_GPU static inline int chpl_macro_float_isnan(float x) { return isnan(x); }
+MAYBE_GPU static inline int chpl_macro_double_signbit(double x) { return signbit(x); }
+MAYBE_GPU static inline int chpl_macro_float_signbit(float x) { return signbit(x); }
 
 // 32-bit Bessel functions aren't available on all platforms. For cases where
 // we know they're available use them since they should be faster, but in other
 // cases default to using the 64-bit versions and casting.
 #ifdef __linux__
-static inline float chpl_float_j0(float x) { return j0f(x); }
-static inline float chpl_float_j1(float x) { return j1f(x); }
-static inline float chpl_float_jn(int n, float x) { return jnf(n, x); }
-static inline float chpl_float_y0(float x) { return y0f(x); }
-static inline float chpl_float_y1(float x) { return y1f(x); }
-static inline float chpl_float_yn(int n, float x) { return ynf(n, x); }
+MAYBE_GPU static inline float chpl_float_j0(float x) { return j0f(x); }
+MAYBE_GPU static inline float chpl_float_j1(float x) { return j1f(x); }
+MAYBE_GPU static inline float chpl_float_jn(int n, float x) { return jnf(n, x); }
+MAYBE_GPU static inline float chpl_float_y0(float x) { return y0f(x); }
+MAYBE_GPU static inline float chpl_float_y1(float x) { return y1f(x); }
+MAYBE_GPU static inline float chpl_float_yn(int n, float x) { return ynf(n, x); }
 #else
-static inline float chpl_float_j0(float x) { return (float)j0(x); }
-static inline float chpl_float_j1(float x) { return (float)j1(x); }
-static inline float chpl_float_jn(int n, float x) { return (float)jn(n, x); }
-static inline float chpl_float_y0(float x) { return (float)y0(x); }
-static inline float chpl_float_y1(float x) { return (float)y1(x); }
-static inline float chpl_float_yn(int n, float x) { return (float)yn(n, x); }
+MAYBE_GPU static inline float chpl_float_j0(float x) { return (float)j0(x); }
+MAYBE_GPU static inline float chpl_float_j1(float x) { return (float)j1(x); }
+MAYBE_GPU static inline float chpl_float_jn(int n, float x) { return (float)jn(n, x); }
+MAYBE_GPU static inline float chpl_float_y0(float x) { return (float)y0(x); }
+MAYBE_GPU static inline float chpl_float_y1(float x) { return (float)y1(x); }
+MAYBE_GPU static inline float chpl_float_yn(int n, float x) { return (float)yn(n, x); }
 #endif
 
 #ifdef DEFINE_32_BIT_MATH_FNS

--- a/runtime/include/sys_basic.h
+++ b/runtime/include/sys_basic.h
@@ -113,5 +113,11 @@
 #endif
 #endif
 
+#if defined(HAS_GPU_LOCALE) && defined(CHPL_GEN_CODE)
+#define MAYBE_GPU __host__ __device__
+#else
+#define MAYBE_GPU
+#endif
+
 
 #endif

--- a/test/gpu/native/math.chpl
+++ b/test/gpu/native/math.chpl
@@ -151,10 +151,14 @@ foreach i in r do R[0] = gcd(i16,i16); R[1] = gcd(i16,i16); check(R,"gcd(i16,i16
 foreach i in r do R[0] = gcd(i32,i32); R[1] = gcd(i32,i32); check(R,"gcd(i32,i32)");
 foreach i in r do R[0] = gcd(i64,i64); R[1] = gcd(i64,i64); check(R,"gcd(i64,i64)");
 
-/* TODO: these use macro wrappers. There are others, too.
 foreach i in r do  B[0] =  isfinite(r32);   B[1] =  isfinite(r32);  check(B,"isfinite(r32)");
 foreach i in r do  B[0] =  isfinite(r64);   B[1] =  isfinite(r64);  check(B,"isfinite(r64)");
-*/
+
+foreach i in r do  B[0] =  isinf(r32);   B[1] =  isinf(r32);  check(B,"isinf(r32)");
+foreach i in r do  B[0] =  isinf(r64);   B[1] =  isinf(r64);  check(B,"isinf(r64)");
+
+foreach i in r do  B[0] =  isnan(r32);   B[1] =  isnan(r32);  check(B,"isnan(r32)");
+foreach i in r do  B[0] =  isnan(r64);   B[1] =  isnan(r64);  check(B,"isnan(r64)");
 
 foreach i in r do  R[0] = ldexp(r32,i32);   R[1] =  ldexp(r32,i32);  check(R,"ldexp(r32,i32)");
 foreach i in r do  R[0] = ldexp(r64,i32);   R[1] =  ldexp(r64,i32);  check(R,"ldexp(r64,i32)");
@@ -191,7 +195,6 @@ foreach i in r do  R[0] = log2(u32);   R[1] = log2(u32);  check(R,"log2(u32)");
 foreach i in r do  R[0] = log2(u64);   R[1] = log2(u64);  check(R,"log2(u64)");
 */
 
-/* TODO macro wrapper support
 foreach i in r do  R[0] = max(i8 ,i8 );   R[1] = max(i8 ,i8 );  check(R,"max(i8 ,i8 )");
 foreach i in r do  R[0] = max(i16,i16);   R[1] = max(i16,i16);  check(R,"max(i16,i16)");
 foreach i in r do  R[0] = max(i32,i32);   R[1] = max(i32,i32);  check(R,"max(i32,i32)");
@@ -212,7 +215,6 @@ foreach i in r do  R[0] = min(u32,u32);   R[1] = min(u32,u32);  check(R,"min(u32
 foreach i in r do  R[0] = min(u64,u64);   R[1] = min(u64,u64);  check(R,"min(u64,u64)");
 foreach i in r do  R[0] = min(r32,r32);   R[1] = min(r32,r32);  check(R,"min(r32,r32)");
 foreach i in r do  R[0] = min(r64,r64);   R[1] = min(r64,r64);  check(R,"min(r64,r64)");
-*/
 
 foreach i in r do  R[0] = mod(i8 ,i8 );   R[1] = mod(i8 ,i8 );  check(R,"mod(i8 ,i8 )");
 foreach i in r do  R[0] = mod(i16,i16);   R[1] = mod(i16,i16);  check(R,"mod(i16,i16)");
@@ -245,6 +247,9 @@ foreach i in r do  R[0] = sgn(u64);   R[1] = sgn(u64);  check(R,"sgn(u64)");
 foreach i in r do  R[0] = sgn(r32);   R[1] = sgn(r32);  check(R,"sgn(r32)");
 foreach i in r do  R[0] = sgn(r64);   R[1] = sgn(r64);  check(R,"sgn(r64)");
 
+foreach i in r do  B[0] =  signbit(r32);   B[1] =  signbit(r32);  check(B,"signbit(r32)");
+foreach i in r do  B[0] =  signbit(r64);   B[1] =  signbit(r64);  check(B,"signbit(r64)");
+
 foreach i in r do  R[0] =  sin(r32);   R[1] =  sin(r32);  check(R,"sin(r32)");
 foreach i in r do  R[0] =  sin(r64);   R[1] =  sin(r64);  check(R,"sin(r64)");
 foreach i in r do  R[0] =  sinh(r32);   R[1] =  sinh(r32);  check(R,"sinh(r32)");
@@ -264,7 +269,6 @@ foreach i in r do  R[0] =  tgamma(r64);   R[1] =  tgamma(r64);  check(R,"tgamma(
 foreach i in r do  R[0] =  trunc(r32);   R[1] =  trunc(r32);  check(R,"trunc(r32)");
 foreach i in r do  R[0] =  trunc(r64);   R[1] =  trunc(r64);  check(R,"trunc(r64)");
 
-/* TODO macro wrapper support
 foreach i in r do  R[0] =  j0(r32);   R[1] =  j0(r32);  check(R,"j0(r32)");
 foreach i in r do  R[0] =  j0(r64);   R[1] =  j0(r64);  check(R,"j0(r64)");
 foreach i in r do  R[0] =  j1(r32);   R[1] =  j1(r32);  check(R,"j1(r32)");
@@ -278,7 +282,6 @@ foreach i in r do  R[0] =  y1(r32);   R[1] =  y1(r32);  check(R,"y1(r32)");
 foreach i in r do  R[0] =  y1(r64);   R[1] =  y1(r64);  check(R,"y1(r64)");
 foreach i in r do  R[0] =  yn(2,r32);   R[1] =  yn(2,r32);  check(R,"yn(2,r32)");
 foreach i in r do  R[0] =  yn(2,r64);   R[1] =  yn(2,r64);  check(R,"yn(2,r64)");
-*/
 
   stopGPUDiagnostics();
 }


### PR DESCRIPTION
This PR adds a `MAYBE_GPU` specifier, and uses it in some
`static inline` functions in a header that's only included
by the generated code.

Supersedes https://github.com/chapel-lang/chapel/pull/20055

Test:
- [x] gpu/native