### PR TITLE
fixed BigInt.Fits_* deprecation test

### DIFF
--- a/test/deprecated/BigInteger/deprecateFitsMethods.good
+++ b/test/deprecated/BigInteger/deprecateFitsMethods.good
@@ -1,7 +1,7 @@
-deprecateFitsMethods.chpl:4: warning: `fits_ulong_p` is deprecated -  please use `bigint.fitsInto(uint(64))` or `bigint.fitsInto(c_ulong)`` instead
-deprecateFitsMethods.chpl:4: warning: `fits_slong_p` is deprecated -  please use `bigint.fitsInto(int(64))` or `bigint.fitsInto(c_long)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_uint_p` is deprecated -  please use `bigint.fitsInto(uint(32))` or `bigint.fitsInto(c_uint)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_sint_p` is deprecated -  please use `bigint.fitsInto(int(32))` or `bigint.fitsInto(c_int)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_ushort_p` is deprecated -  please use `bigint.fitsInto(uint(16))` or `bigint.fitsInto(c_ushort)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_sshort_p` is deprecated -  please use `bigint.fitsInto(int(16))` or `bigint.fitsInto(c_short)` instead
+deprecateFitsMethods.chpl:4: warning: `fits_ulong_p` is deprecated -  please use `bigint.fitsInto(c_ulong)` instead
+deprecateFitsMethods.chpl:4: warning: `fits_slong_p` is deprecated -  please use `bigint.fitsInto(c_long)` instead
+deprecateFitsMethods.chpl:4: warning: `fits_uint_p` is deprecated -  please use `bigint.fitsInto(c_uint)` instead
+deprecateFitsMethods.chpl:4: warning: `fits_sint_p` is deprecated -  please use `bigint.fitsInto(c_int)` instead
+deprecateFitsMethods.chpl:4: warning: `fits_ushort_p` is deprecated -  please use `bigint.fitsInto(c_ushort)` instead
+deprecateFitsMethods.chpl:4: warning: `fits_sshort_p` is deprecated -  please use `bigint.fitsInto(c_short)` instead
 1


### PR DESCRIPTION
The deprecation test for the old BigInt.Fits_* methods showed outdated deprecation messages. These have been updated in the `.good` file.

`test/deprecated/BigInteger/deprecateFitsMethods` test should no longer be failing. 