### PR TITLE
Enable opt-in support for qthreads on arm based macs

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -146,6 +146,14 @@ ifneq (,$(CHPL_QTHREAD_SANITIZER_SUPPORT))
   CHPL_QTHREAD_CFG_OPTIONS += --disable-fastcontext
 endif
 
+# No fastcontext on m1, fallback to ucontext (with _XOPEN_SOURCE to allow it)
+ifeq ($(CHPL_MAKE_TARGET_PLATFORM),darwin)
+  ifeq ($(CHPL_MAKE_TARGET_ARCH),arm64)
+    CHPL_QTHREAD_CFG_OPTIONS += --disable-fastcontext
+    CFLAGS += -D_XOPEN_SOURCE
+  endif
+endif
+
 ifeq ($(CHPL_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif


### PR DESCRIPTION
qthreads 1.17 added initial support for arm based macs. This uses the
system ucontext instead of fast asm context switching, but it at least
enables support.

We're seeing much slower task creation compared to fifo (and ucontext on
x86 macs) so we're not changing the default tasking layer, but this at
least enables the ability to use qthreads to experiment more.

For the record, here's the timings I see for creating a task per core
10K times:

```sh
 chpl --fast test/parallel/taskCompare/elliot/empty-chpl-taskspawn.chpl -staskingMode=coforallT
./empty-chpl-taskspawn --numTrials=10_000 --printTimings
```

| config             | time   |
| ------------------ | -----: |
| x86 qt asm context |  0.02s |
| x86 qt ucontext    |  0.15s |
| x86 fifo           |  0.17s |
|  m1 qt ucontext    | 11.83s |
|  m1 fifo           |  0.27s |

Part of Cray/chapel-private#3374