### PR TITLE
Fix prefetch test for ARM systems

### DIFF
--- a/test/library/standard/Prefetch/prefetch.prediff
+++ b/test/library/standard/Prefetch/prefetch.prediff
@@ -10,7 +10,7 @@ fi
 
 objdump -d "./$testname" > $disasm
 
-grep -A 20 -e "<_main>" -e "<main>" -e "_*main:" $disasm | grep "prefetch" > /dev/null
+grep -A 20 -e "<_main>" -e "<main>" -e "_*main:" $disasm | grep -e "prefetch" -e "prfum" > /dev/null
 if [ $? -eq 1 ]; then
   echo "Prefetch instruction not found" >> $outfile
 fi


### PR DESCRIPTION
In addition to looking for the `prefetch` instruction, look for `prfum`,
which is the name of the instruction for ARM.

See https://developer.arm.com/documentation/dui0802/b/PRFUM

Part of Cray/chapel-private#3374