### PR TITLE
Suppress mason-external (spack) failures on m1 mac

### DIFF
--- a/test/mason/mason-external/libtomlc99/mason-external.suppressif
+++ b/test/mason/mason-external/libtomlc99/mason-external.suppressif
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+"""
+Mason's version of spack doesn't work on m1 currently:
+https://github.com/Cray/chapel-private/issues/3518
+"""
+
+from os import environ
+
+print(environ['CHPL_TARGET_PLATFORM'] == 'darwin' and
+      environ['CHPL_TARGET_ARCH'] == 'arm64')

--- a/test/mason/mason-external/masonExternalRanges/mason-external-range.suppressif
+++ b/test/mason/mason-external/masonExternalRanges/mason-external-range.suppressif
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+"""
+Mason's version of spack doesn't work on m1 currently:
+https://github.com/Cray/chapel-private/issues/3518
+"""
+
+from os import environ
+
+print(environ['CHPL_TARGET_PLATFORM'] == 'darwin' and
+      environ['CHPL_TARGET_ARCH'] == 'arm64')


### PR DESCRIPTION
Suppress these mason-external tests until we're able to upgrade spack
versions in Cray/chapel-private#3518