### PR TITLE
Updating homebrew formulas

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,6 +1,7 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
+  head "https://github.com/chapel-lang/chapel.git", branch: "main"
   url "https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz"
   sha256 "558b1376fb7757a5e1f254c717953f598a3e89850c8edd1936b8d09c464f3e8b"
   license "Apache-2.0"
@@ -14,6 +15,7 @@ class Chapel < Formula
     sha256 x86_64_linux:   "c4ccfadfa28118b70d76a324310dc17be9f351011490c7c29eb6dca5eb7ab093"
   end
 
+  depends_on "cmake"
   depends_on "gmp"
   # `chapel` scripts use python on PATH (e.g. checking `command -v python3`),
   # so it needs to depend on the currently linked Homebrew Python version.

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,20 +1,17 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.26/chapel-1.26.0.tar.gz"
-  sha256 "ba396b581f0a17f8da3f365a3f8b079b8d2e229a393fbd1756966b0019931ece"
-#  url "<URL of Chapel tarball>"
-#  sha256 "<sha256 sum for the associated tarball>"
+  url "https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz"
+  sha256 "558b1376fb7757a5e1f254c717953f598a3e89850c8edd1936b8d09c464f3e8b"
   license "Apache-2.0"
-  revision 1
 
   bottle do
-    sha256 arm64_monterey: "64d6aec51c37987b02b097485e201e6d6bbbf750c4f4ec1f6a0c42a5ad3b00b5"
-    sha256 arm64_big_sur:  "2af1e2f47d881b45fceb8269c0e0072651f2c31636d18477a69ed40cfe183425"
-    sha256 monterey:       "071524c6a8974377d6331048878bc05213e292995985d7211855a54fe83fb8af"
-    sha256 big_sur:        "6357ed5ffe3478282d7260364c9cbbde0b9043c32d6f40057a4906ee2cc364ec"
-    sha256 catalina:       "9b6177315ed483d8bf5767d02d911d67aa9968219e21eaca8901a6f0b5c554e5"
-    sha256 x86_64_linux:   "2fd94cac965b48ddb70ab6c5d2104c79c9ae8b892f25131a33356ab012dcc5ef"
+    sha256 arm64_monterey: "2f3b638cc2c187ac2c11f0dc128eae825466ce6745b5ad358e2fee8b96ef0187"
+    sha256 arm64_big_sur:  "90f68a1e21e3ad61165bbcea1e79306cbf09e811f5b5dd0c91068dadb07e0aca"
+    sha256 monterey:       "f33951b329c819f7ff386b33a413b3cd331fb3a31c0823f10f435d0227c29cf2"
+    sha256 big_sur:        "aeaa92c2f32435c1c16c52f737261c66b2b44ce197ec3e6f6a479f1c029d702c"
+    sha256 catalina:       "11eebc6dbc8383482c689e8a1d74359d12a4781579a48bb29417ca25779c50c4"
+    sha256 x86_64_linux:   "c4ccfadfa28118b70d76a324310dc17be9f351011490c7c29eb6dca5eb7ab093"
   end
 
   depends_on "gmp"
@@ -26,8 +23,11 @@ class Chapel < Formula
 
   on_macos do
     depends_on "llvm" if MacOS.version > :catalina
+    # fatal error: cannot open file './sys_basic.h': No such file or directory
+    # Issue ref: https://github.com/Homebrew/homebrew-core/issues/96915
     depends_on "llvm@11" if MacOS.version <= :catalina
   end
+
   on_linux do
     depends_on "llvm"
   end

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -1,33 +1,50 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.26/chapel-1.26.0.tar.gz"
+  url "https://github.com/chapel-lang/chapel/releases/download/1.26.0/chapel-1.26.0.tar.gz"
   sha256 "ba396b581f0a17f8da3f365a3f8b079b8d2e229a393fbd1756966b0019931ece"
-#  url "<URL of Chapel tarball>"
-#  sha256 "<sha256 sum for the associated tarball>"
   license "Apache-2.0"
+  revision 2
 
   bottle do
-    sha256 arm64_monterey: "229f22e29b0cc7a904841636c924d0c94c00299f817ed294247957d43c128cf3"
-    sha256 arm64_big_sur:  "9f4a5b7644f18da492f75b4442bc7e22d0b59fa72d6952b15f14f15a2949f57b"
-    sha256 monterey:       "bd3d8c066ce51d66b44e0430fc12f01ce5b99701f337304bf609b185bdbdefec"
-    sha256 big_sur:        "20b698193b5f7efb99c0eee60126a3e47a420fe99a65ed83aba919fac1cfacac"
-    sha256 catalina:       "8eeb73c3884680831146792096af481b1f2c23902eed1ad798f3aa890d2a1e49"
-    sha256 x86_64_linux:   "f351e793925739313b0025b6e90287688da278ebe60191000b5a6e5e239b60ef"
+    sha256 arm64_monterey: "2f3b638cc2c187ac2c11f0dc128eae825466ce6745b5ad358e2fee8b96ef0187"
+    sha256 arm64_big_sur:  "90f68a1e21e3ad61165bbcea1e79306cbf09e811f5b5dd0c91068dadb07e0aca"
+    sha256 monterey:       "f33951b329c819f7ff386b33a413b3cd331fb3a31c0823f10f435d0227c29cf2"
+    sha256 big_sur:        "aeaa92c2f32435c1c16c52f737261c66b2b44ce197ec3e6f6a479f1c029d702c"
+    sha256 catalina:       "11eebc6dbc8383482c689e8a1d74359d12a4781579a48bb29417ca25779c50c4"
+    sha256 x86_64_linux:   "c4ccfadfa28118b70d76a324310dc17be9f351011490c7c29eb6dca5eb7ab093"
   end
 
   depends_on "gmp"
-  depends_on "python@3.10"
+  # `chapel` scripts use python on PATH (e.g. checking `command -v python3`),
+  # so it needs to depend on the currently linked Homebrew Python version.
+  # TODO: remove from versioned_dependencies_conflicts_allowlist when
+  # when Python dependency matches LLVM's Python for all OS versions.
+  depends_on "python@3.9"
+
   on_macos do
-    depends_on "llvm" if MacOS.version > :catalina
+    depends_on "llvm@13" if MacOS.version > :catalina
+    # fatal error: cannot open file './sys_basic.h': No such file or directory
+    # Issue ref: https://github.com/Homebrew/homebrew-core/issues/96915
     depends_on "llvm@11" if MacOS.version <= :catalina
   end
+
   on_linux do
-    depends_on "llvm"
+    depends_on "llvm@13"
   end
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"
+
+  # Work around Homebrew 11-arm64 CI issue, which outputs unwanted objc warnings like:
+  # objc[42134]: Class ... is implemented in both ... One of the two will be used. Which one is undefined.
+  # These end up incorrectly failing checkChplInstall test script when it checks for stdout/stderr.
+  # TODO: remove when Homebrew CI no longer outputs these warnings or 11-arm64 is no longer used.
+  patch :DATA
+
+  def llvm
+    deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }
+  end
 
   def install
     libexec.install Dir["*"]
@@ -41,24 +58,15 @@ class Chapel < Formula
     # Must be built from within CHPL_HOME to prevent build bugs.
     # https://github.com/Homebrew/legacy-homebrew/pull/35166
     cd libexec do
+      # don't try to set CHPL_LLVM_GCC_PREFIX since the llvm@13
+      # package should be configured to use a reasonable GCC
       (libexec/"chplconfig").write <<~EOS
         CHPL_RE2=bundled
         CHPL_GMP=system
+        CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
+        CHPL_LLVM_GCC_PREFIX=none
       EOS
 
-      if OS.mac?
-        if MacOS.version > :catalina
-          system "echo CHPL_LLVM_CONFIG=#{HOMEBREW_PREFIX}/opt/llvm@13/bin/llvm-config >> chplconfig"
-        else
-          system "echo CHPL_LLVM_CONFIG=#{HOMEBREW_PREFIX}/opt/llvm@11/bin/llvm-config >> chplconfig"
-        end
-      else
-        system "echo CHPL_LLVM_CONFIG=#{HOMEBREW_PREFIX}/opt/llvm@13/bin/llvm-config >> chplconfig"
-      end
-
-      # don't try to set CHPL_LLVM_GCC_PREFIX since the llvm@13
-      # package should be configured to use a reasonable GCC
-      system 'echo CHPL_LLVM_GCC_PREFIX="none" >> chplconfig'
       system "./util/printchplenv", "--all"
       with_env(CHPL_PIP_FROM_SOURCE: "1") do
         system "make", "test-venv"
@@ -74,6 +82,7 @@ class Chapel < Formula
       end
       system "make", "mason"
       system "make", "cleanall"
+
       rm_rf("third-party/llvm/llvm-src/")
       rm_rf("third-party/gasnet/gasnet-src")
       rm_rf("third-party/libfabric/libfabric-src")
@@ -110,3 +119,17 @@ class Chapel < Formula
     system bin/"chpl", "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
   end
 end
+
+__END__
+diff --git a/util/test/checkChplInstall b/util/test/checkChplInstall
+index 7d2eb78a88..a9ddf22054 100755
+--- a/util/test/checkChplInstall
++++ b/util/test/checkChplInstall
+@@ -189,6 +189,7 @@ fi
+ if [ -n "${TEST_COMP_OUT}" ]; then
+     # apply "prediff"-like filter to remove gmake "clock skew detected" warnings, if any
+     TEST_COMP_OUT=$( grep <<<"${TEST_COMP_OUT}" -v \
++        -e '^objc\(\[[0-9]*\]\)*: Class .* is implemented in both .* One of the two will be used\. Which one is undefined\. *$' \
+         -e '^g*make\(\[[0-9]*\]\)*: Warning: File .* has modification time .* in the future *$' \
+         -e '^g*make\(\[[0-9]*\]\)*: warning:  Clock skew detected\.  Your build may be incomplete\. *$' )
+ fi

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -1,10 +1,9 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.26.0/chapel-1.26.0.tar.gz"
-  sha256 "ba396b581f0a17f8da3f365a3f8b079b8d2e229a393fbd1756966b0019931ece"
+  url "https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz"
+  sha256 "558b1376fb7757a5e1f254c717953f598a3e89850c8edd1936b8d09c464f3e8b"
   license "Apache-2.0"
-  revision 2
 
   bottle do
     sha256 arm64_monterey: "2f3b638cc2c187ac2c11f0dc128eae825466ce6745b5ad358e2fee8b96ef0187"
@@ -23,14 +22,14 @@ class Chapel < Formula
   depends_on "python@3.9"
 
   on_macos do
-    depends_on "llvm@13" if MacOS.version > :catalina
+    depends_on "llvm" if MacOS.version > :catalina
     # fatal error: cannot open file './sys_basic.h': No such file or directory
     # Issue ref: https://github.com/Homebrew/homebrew-core/issues/96915
     depends_on "llvm@11" if MacOS.version <= :catalina
   end
 
   on_linux do
-    depends_on "llvm@13"
+    depends_on "llvm"
   end
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx

--- a/util/packaging/homebrew/readme.md
+++ b/util/packaging/homebrew/readme.md
@@ -41,18 +41,28 @@ docker cp chapel.rb <container name or container ID>:/home/linuxbrew/chapel.rb
 ```
 
 ## How to test formula changes
-To test local homebrew builds, the following items are needed: 
- - A Chapel tarball 
- - The sha256 for that tarball
+With the most recent release of Chapel, the formula has been updated to support 
+testing of the main trunk of the source tree.  This approach will clone the Chapel 
+repository locally and build from source.   The instructions for this approach
+are listed below: 
 
- The steps used to do this on a local system are as follows: 
+ - Rename `chapel-main.rb` to `chapel.rb`
+ - Run the following command: 
+   - `brew  install --HEAD chapel.rb` 
+ - Validate the build by running: 
+   - `chpl --version`
+   - Compile and run pidigits
+
+Alternatively, local testing can also be performed using a tarball, and the instructions
+for creating that artifact and building the homebrew package are listed below: 
+
  - Clone Chapel source 
  - Build the tarball via `./util/cron/create_tarball.bash`
  - Run `shasum -a 256 "url for the tarball"`
  - Verify the permissions on the tarball - it should be set to `644` if you are attempting to use a web location. 
  - Rename `chapel-main.rb` to `chapel.rb` 
  - Modify the `chapel.rb` file to include the tarball URL (this can be a network location or a local file) and sha256 value
- - Then the following commands can be run (https://github.com/Cray/chapel-private/issues/2866): 
+ - Then the following command can be run to build and install: 
    - `brew install --build-from-source chapel.rb`
  - Finally, the install can be validated by running: 
    - `chpl --version`


### PR DESCRIPTION
This commit updates both the currently released formula
(chapel-release.rb) for 1.26 which includes updates for the newly
released llvm14 and some other formula clean up and the formula for the
upcoming release (chapel-main.rb).

Signed-off-by: Tim Zinsky <tim.zinsky@hpe.com>