### PR TITLE
Improve param-inf test an param real to string casts

### DIFF
--- a/compiler/dyno/lib/immediates/num.cpp
+++ b/compiler/dyno/lib/immediates/num.cpp
@@ -51,12 +51,12 @@ snprint_float_val(char* buf, size_t max, double val, bool hex) {
       return nc;
     }
   } else if (std::isinf(val)) {
-    if (std::signbit(val)) strncpy(buf, "-INFINITY", max);
-    else                   strncpy(buf, "INFINITY", max);
+    if (std::signbit(val)) strncpy(buf, "-inf", max);
+    else                   strncpy(buf, "inf", max);
     return strlen(buf);
   } else {
-    if (std::signbit(val)) strncpy(buf, "-NAN", max);
-    else                   strncpy(buf, "NAN", max);
+    if (std::signbit(val)) strncpy(buf, "-nan", max);
+    else                   strncpy(buf, "nan", max);
     return strlen(buf);
   }
 }

--- a/test/param/ferguson/param-inf.chpl
+++ b/test/param/ferguson/param-inf.chpl
@@ -14,22 +14,38 @@ param negnanzeros = -nanzeros;
 param naninf = inf / inf;
 param negnaninf = -naninf;
 
-proc printit(name:string, arg:real(64), str:string, nosign=false) {
+proc printit(name:string, arg:real(64), str:string) {
   extern proc copysign(x:real(64), y:real(64)):real(64);
   var one = 1.0;
   var pos_neg_one = copysign(one, arg);
   var neg = pos_neg_one < 0.0;
   writef("% 8s % 14s %10r % 12s", arg.type:string, name, arg, str);
-  if nosign || !neg then
+  if !neg then
     writeln();
   else
     writeln(" negative");
 }
 proc printit(name:string, param arg:real(64), nosign=false) {
   param str = arg:string;
-  printit(name, arg, str, nosign);
+  param flip_arg = -arg;
+  param flip_str = flip_arg:string;
+
+  extern proc copysign(x:real(64), y:real(64)):real(64);
+  if nosign {
+    var pos_neg_one = copysign(one, arg);
+    if pos_neg_one < 0.0 {
+      // arg is negative, so output flip_arg and flip_str
+      printit(name, flip_arg, flip_str);
+    } else {
+      printit(name, arg, str);
+    }
+  } else {
+    printit(name, arg, str);
+  }
 }
 
+writef("% 8s % 14s % 10s % 12s\n",
+       "type", "test", "param_val", "param_to_string");
 printit("zero", zero);
 printit("nzero", nzero);
 printit("one", one);

--- a/test/param/ferguson/param-inf.good
+++ b/test/param/ferguson/param-inf.good
@@ -1,18 +1,19 @@
+    type           test  param_val param_to_string
 real(64)           zero          0          0.0
 real(64)          nzero         -0         -0.0 negative
 real(64)            one          1          1.0
 real(64)           huge     1e+300       1e+300
 real(64)           tiny     1e-300       1e-300
-real(64)           inf0        inf     INFINITY
-real(64)            inf        inf     INFINITY
-real(64)         neginf       -inf    -INFINITY negative
-real(64)        neginf0       -inf    -INFINITY negative
-real(64)       neginf0n       -inf    -INFINITY negative
-real(64)       nanzeros        nan         -NAN
-real(64)    negnanzeros        nan          NAN
-real(64)         naninf        nan         -NAN
-real(64)      negnaninf        nan          NAN
-real(64)            NAN        nan          NAN
-real(64)           -NAN        nan         -NAN negative
-real(64)       INFINITY        inf     INFINITY
-real(64)      -INFINITY       -inf    -INFINITY negative
+real(64)           inf0        inf          inf
+real(64)            inf        inf          inf
+real(64)         neginf       -inf         -inf negative
+real(64)        neginf0       -inf         -inf negative
+real(64)       neginf0n       -inf         -inf negative
+real(64)       nanzeros        nan          nan
+real(64)    negnanzeros        nan          nan
+real(64)         naninf        nan          nan
+real(64)      negnaninf        nan          nan
+real(64)            NAN        nan          nan
+real(64)           -NAN        nan         -nan negative
+real(64)       INFINITY        inf          inf
+real(64)      -INFINITY       -inf         -inf negative


### PR DESCRIPTION
Adjust param-inf to avoid outputing negative nans and also adjusted param real : string cast to use inf / nan instead of INFINITY / NAN to better match regular output of these values.

We were observing failures for param-inf on an arm system due to differences in whether or not the NANs were negative. But, a NAN being positive or negative is not guaranteed by C/C++ (the param-evaluation is happening in C++ code within the compiler) and Chapel isn't trying to do anything special for the sign of NANs.

Resolves https://github.com/Cray/chapel-private/issues/3520

Reviewed by @ronawho - thanks!

- [x] full local testing