### PR TITLE
fix(gitignore): add wildcard match for cmake-build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ tags
 *.vagrant
 .vscode/
 .idea/
-cmake-build-debug/
+cmake-build-*/
 .cache/
 
 # Top level ignores.


### PR DESCRIPTION
This PR just adds a wildcard match to for `cmake-build-`dirs to the
top level `gitignore`

Motivated by me adding new profiles to my `cmake` builds in `CLion`

(review bypassed due to nature of change)

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>