### PR TITLE
fix(dyno-resolver): updates for resolving logical and, or binary ops

### DIFF
--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -1423,7 +1423,7 @@ bool Resolver::enter(const Call* call) {
         // go ahead and evaluate the RHS
         op->actual(1)->traverse(*this);
         // look at the RHS type.
-        const QualifiedType& rhs = byPostorder.byAst(op->actual(0)).type();
+        const QualifiedType& rhs = byPostorder.byAst(op->actual(1)).type();
         if (lhs.isParamTrue() && rhs.isParamTrue()) {
           // if LHS and RHS are both param true, return param true.
           result = lhs;
@@ -1450,7 +1450,7 @@ bool Resolver::enter(const Call* call) {
         // go ahead and evaluate the RHS
         op->actual(1)->traverse(*this);
         // look at the RHS type.
-        const QualifiedType& rhs = byPostorder.byAst(op->actual(0)).type();
+        const QualifiedType& rhs = byPostorder.byAst(op->actual(1)).type();
         if (lhs.isParamFalse() && rhs.isParamFalse()) {
           // if LHS and RHS are both param false, return param false.
           result = lhs;

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -1432,10 +1432,17 @@ bool Resolver::enter(const Call* call) {
           result = QualifiedType(QualifiedType::CONST_VAR,
                                  UnknownType::get(context));
         } else {
-          // TODO: check that LHS and RHS are both bool
-          // otherwise just return a Bool value
-          result = QualifiedType(QualifiedType::CONST_VAR,
-                                 BoolType::get(context, 0));
+          assert(rhs.type()->isBoolType() && lhs.type()->isBoolType());
+          if (rhs.isParam() && lhs.isParam()) {
+            // preserve param-ness
+            result = QualifiedType(QualifiedType::PARAM,
+                                   BoolType::get(context, 0),
+                                   BoolParam::get(context, 0));
+          } else {
+            // otherwise just return a Bool value
+            result = QualifiedType(QualifiedType::CONST_VAR,
+                                   BoolType::get(context, 0));
+          }
         }
       }
     } else if (op->op() == USTR("||")) {
@@ -1459,10 +1466,17 @@ bool Resolver::enter(const Call* call) {
           result = QualifiedType(QualifiedType::CONST_VAR,
                                  UnknownType::get(context));
         } else {
-          // TODO: check that LHS and RHS are both bool
-          // otherwise just return a Bool value
-          result = QualifiedType(QualifiedType::CONST_VAR,
-                                 BoolType::get(context, 0));
+          assert(rhs.type()->isBoolType() && lhs.type()->isBoolType());
+          if (rhs.isParam() && lhs.isParam()) {
+            // preserve param-ness
+            result = QualifiedType(QualifiedType::PARAM,
+                                   BoolType::get(context, 0),
+                                   BoolParam::get(context, 1));
+          } else {
+            // otherwise just return a Bool value
+            result = QualifiedType(QualifiedType::CONST_VAR,
+                                   BoolType::get(context, 0));
+          }
         }
       }
     } else {

--- a/compiler/dyno/test/resolution/testParamFolding.cpp
+++ b/compiler/dyno/test/resolution/testParamFolding.cpp
@@ -125,12 +125,40 @@ static void test4() {
   assert(qt.type() == BoolType::get(context, 0));
 }
 
+static void test5() {
+  Context ctx;
+  Context* context = &ctx;
+
+  // configure context to fail test if there are any errors
+  context->setErrorHandler(reportError);
+
+  // both args are params, should make a param init expr
+  QualifiedType qt = parseTypeOfXInit(context,
+                                      "var x = true && false;");
+  assert(qt.isParamFalse());
+}
+
+static void test6() {
+  Context ctx;
+  Context* context = &ctx;
+
+  // configure context to fail test if there are any errors
+  context->setErrorHandler(reportError);
+
+  // both args are params, should make a param init expr
+  QualifiedType qt = parseTypeOfXInit(context,
+                                      "var x = false || true;");
+  assert(qt.isParamTrue());
+}
+
+
 int main() {
   test1();
   test2();
   test3();
   test4();
+  test5();
+  test6();
 
   return 0;
 }
-


### PR DESCRIPTION
This PR fixes a small bug where we were using the wrong index
value to evaluate the `Type` of the RHS of a binary `OpCall`.
It also updates the param folding of binary params that are
used in logical "and" `&&`, and "or" `||` statements. 

With this update, param folding will work properly in 
the following cases:
```chapel
var x: bool = true && false;
var y: bool = false || true;

```
Where previously the paramness of the initialization
expressions for `x` and `y` would have been lost.

TESTING: 

- [x] `make test-dyno` passes all
- [x] paratest

reviewed by @mppf - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>