### PR TITLE
Refer to `brew --cellar` when talking about the Homebrew cellar.

### DIFF
--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -28,11 +28,11 @@ following commands::
 These commands install the latest release of Chapel.  When using a
 Homebrew installation of Chapel, the ``CHPL_HOME`` directory is here::
 
-    $HOMEBREW_CELLAR/chapel/<chapel-version>/libexec/
+    `brew --cellar`/chapel/<chapel-version>/libexec/
 
 Compile and run a test program::
 
-    chpl $HOMEBREW_CELLAR/chapel/<chapel-version>/libexec/examples/hello.chpl
+    chpl `brew --cellar`/chapel/<chapel-version>/libexec/examples/hello.chpl
     ./hello
 
 If you're new to Chapel, refer to the `What's Next?

--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -28,11 +28,11 @@ following commands::
 These commands install the latest release of Chapel.  When using a
 Homebrew installation of Chapel, the ``CHPL_HOME`` directory is here::
 
-    /usr/local/Cellar/chapel/<chapel-version>/libexec/
+    $HOMEBREW_CELLAR/chapel/<chapel-version>/libexec/
 
 Compile and run a test program::
 
-    chpl /usr/local/Cellar/chapel/<chapel-version>/libexec/hello.chpl
+    chpl $HOMEBREW_CELLAR/chapel/<chapel-version>/libexec/hello.chpl
     ./hello
 
 If you're new to Chapel, refer to the `What's Next?

--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -32,7 +32,7 @@ Homebrew installation of Chapel, the ``CHPL_HOME`` directory is here::
 
 Compile and run a test program::
 
-    chpl $HOMEBREW_CELLAR/chapel/<chapel-version>/libexec/hello.chpl
+    chpl $HOMEBREW_CELLAR/chapel/<chapel-version>/libexec/examples/hello.chpl
     ./hello
 
 If you're new to Chapel, refer to the `What's Next?


### PR DESCRIPTION
The cellar isn't in the same place on all systems. By using the
`brew --cellar` command instead of hardcoding a path,
we can be more sure that the instructions and documentation
works on our users' machines.