### PR TITLE
Rename a few factory functions in dyno

### DIFF
--- a/compiler/dyno/include/chpl/parsing/Parser.h
+++ b/compiler/dyno/include/chpl/parsing/Parser.h
@@ -53,9 +53,6 @@ class Parser final {
   static Parser createForIncludedModule(Context* context,
                                         UniqueString parentSymbolPath);
 
-  /* returns an owned topLevelModuleParser */
-  static owned<Parser> build(Context* context);
-
   ~Parser() = default;
 
   /**

--- a/compiler/dyno/include/chpl/parsing/Parser.h
+++ b/compiler/dyno/include/chpl/parsing/Parser.h
@@ -44,14 +44,14 @@ class Parser final {
 
  public:
   /** Construct a parser for parsing a top-level module */
-  static Parser topLevelModuleParser(Context* context);
+  static Parser createForTopLevelModule(Context* context);
 
   /** Construct a parser for parsing an included module.
       'parentSymbolPath' is the symbol path component of the ID
       of the module containing the 'module include' statement.
    */
-  static Parser includedModuleParser(Context* context,
-                                     UniqueString parentSymbolPath);
+  static Parser createForIncludedModule(Context* context,
+                                        UniqueString parentSymbolPath);
 
   /* returns an owned topLevelModuleParser */
   static owned<Parser> build(Context* context);

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -84,18 +84,18 @@ class Builder final {
 
  public:
   /** Construct a Builder for parsing a top-level module */
-  static owned<Builder> topLevelModuleBuilder(Context* context,
-                                              const char* filepath);
+  static owned<Builder> createForTopLevelModule(Context* context,
+                                                const char* filepath);
 
   /** Construct a Builder for parsing an included module.
       'parentSymbolPath' is the symbol path component of the ID
       of the module containing the 'module include' statement.
    */
-  static owned<Builder> includedModuleBuilder(Context* context,
-                                              const char* filepath,
-                                              UniqueString parentSymbolPath);
+  static owned<Builder> createForIncludedModule(Context* context,
+                                                const char* filepath,
+                                                UniqueString parentSymbolPath);
 
-  /** returns an owned topLevelModuleBuilder */
+  /** returns a the result of createForTopLevelModule */
   static owned<Builder> build(Context* context, const char* filepath);
 
   Context* context() const { return context_; }

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -95,9 +95,6 @@ class Builder final {
                                                 const char* filepath,
                                                 UniqueString parentSymbolPath);
 
-  /** returns a the result of createForTopLevelModule */
-  static owned<Builder> build(Context* context, const char* filepath);
-
   Context* context() const { return context_; }
 
   /**

--- a/compiler/dyno/lib/parsing/Parser.cpp
+++ b/compiler/dyno/lib/parsing/Parser.cpp
@@ -54,11 +54,6 @@ Parser Parser::createForIncludedModule(Context* context,
   return Parser(context, parentSymbolPath);
 }
 
-owned<Parser> Parser::build(Context* context) {
-  UniqueString emptySymbolPath;
-  return toOwned(new Parser(context, emptySymbolPath));
-}
-
 static void updateParseResult(ParserContext* parserContext) {
 
   Builder* builder = parserContext->builder;

--- a/compiler/dyno/lib/parsing/Parser.cpp
+++ b/compiler/dyno/lib/parsing/Parser.cpp
@@ -86,10 +86,10 @@ static void updateParseResult(ParserContext* parserContext) {
 BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
   owned<Builder> builder;
   if (parentSymbolPath_.isEmpty()) {
-    builder = Builder::topLevelModuleBuilder(this->context(), path);
+    builder = Builder::createForTopLevelModule(this->context(), path);
   } else {
-    builder = Builder::includedModuleBuilder(this->context(), path,
-                                             parentSymbolPath_);
+    builder = Builder::createForIncludedModule(this->context(), path,
+                                               parentSymbolPath_);
   }
   ErrorMessage fileError;
 
@@ -180,10 +180,10 @@ BuilderResult Parser::parseString(const char* path, const char* str,
                                   ParserStats* parseStats) {
   owned<Builder> builder;
   if (parentSymbolPath_.isEmpty()) {
-    builder = Builder::topLevelModuleBuilder(this->context(), path);
+    builder = Builder::createForTopLevelModule(this->context(), path);
   } else {
-    builder = Builder::includedModuleBuilder(this->context(), path,
-                                             parentSymbolPath_);
+    builder = Builder::createForIncludedModule(this->context(), path,
+                                               parentSymbolPath_);
   }
 
   // Set the (global) parser debug state

--- a/compiler/dyno/lib/parsing/Parser.cpp
+++ b/compiler/dyno/lib/parsing/Parser.cpp
@@ -44,13 +44,13 @@ Parser::Parser(Context* context, UniqueString parentSymbolPath)
   : context_(context), parentSymbolPath_(parentSymbolPath) {
 }
 
-Parser Parser::topLevelModuleParser(Context* context) {
+Parser Parser::createForTopLevelModule(Context* context) {
   UniqueString emptySymbolPath;
   return Parser(context, emptySymbolPath);
 }
 
-Parser Parser::includedModuleParser(Context* context,
-                                    UniqueString parentSymbolPath) {
+Parser Parser::createForIncludedModule(Context* context,
+                                       UniqueString parentSymbolPath) {
   return Parser(context, parentSymbolPath);
 }
 

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -151,10 +151,10 @@ void countTokens(Context* context, UniqueString path, ParserStats* parseStats) {
   BuilderResult result(path);
   if (error.isEmpty()) {
     // if there was no error reading the file, proceed to parse
-    auto parser = Parser::build(context);
+    auto parser = Parser::createForTopLevelModule(context);
     const char* pathc = path.c_str();
     const char* textc = text.c_str();
-    parser->parseString(pathc, textc, parseStats);
+    parser.parseString(pathc, textc, parseStats);
   }
 }
 

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -88,9 +88,9 @@ bool hasFileText(Context* context, const std::string& path) {
 static Parser helpMakeParser(Context* context,
                              UniqueString parentSymbolPath) {
   if (parentSymbolPath.isEmpty()) {
-    return Parser::topLevelModuleParser(context);
+    return Parser::createForTopLevelModule(context);
   } else {
-    return Parser::includedModuleParser(context, parentSymbolPath);
+    return Parser::createForIncludedModule(context, parentSymbolPath);
   }
 }
 

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -102,9 +102,9 @@ struct GatherFieldsOrFormals {
 };
 
 Resolver
-Resolver::moduleStmtResolver(Context* context, const Module* mod,
-                             const AstNode* modStmt,
-                             ResolutionResultByPostorderID& byId) {
+Resolver::createForModuleStmt(Context* context, const Module* mod,
+                              const AstNode* modStmt,
+                              ResolutionResultByPostorderID& byId) {
   auto ret = Resolver(context, mod, byId, nullptr);
   ret.curStmt = modStmt;
   ret.byPostorder.setupForSymbol(mod);
@@ -112,9 +112,10 @@ Resolver::moduleStmtResolver(Context* context, const Module* mod,
 }
 
 Resolver
-Resolver::moduleStmtScopeResolver(Context* context, const Module* mod,
-                                  const AstNode* modStmt,
-                                  ResolutionResultByPostorderID& byId) {
+Resolver::createForScopeResolvingModuleStmt(
+                              Context* context, const Module* mod,
+                              const AstNode* modStmt,
+                              ResolutionResultByPostorderID& byId) {
   auto ret = Resolver(context, mod, byId, nullptr);
   ret.curStmt = modStmt;
   ret.byPostorder.setupForSymbol(mod);
@@ -123,8 +124,8 @@ Resolver::moduleStmtScopeResolver(Context* context, const Module* mod,
 }
 
 Resolver
-Resolver::initialSignatureResolver(Context* context, const Function* fn,
-                                   ResolutionResultByPostorderID& byId)
+Resolver::createForInitialSignature(Context* context, const Function* fn,
+                                    ResolutionResultByPostorderID& byId)
 {
   auto ret = Resolver(context, fn, byId, nullptr);
   ret.signatureOnly = true;
@@ -134,11 +135,11 @@ Resolver::initialSignatureResolver(Context* context, const Function* fn,
 }
 
 Resolver
-Resolver::instantiatedSignatureResolver(Context* context,
-                                        const Function* fn,
-                                        const SubstitutionsMap& substitutions,
-                                        const PoiScope* poiScope,
-                                        ResolutionResultByPostorderID& byId) {
+Resolver::createForInstantiatedSignature(Context* context,
+                                         const Function* fn,
+                                         const SubstitutionsMap& substitutions,
+                                         const PoiScope* poiScope,
+                                         ResolutionResultByPostorderID& byId) {
   auto ret = Resolver(context, fn, byId, poiScope);
   ret.substitutions = &substitutions;
   ret.signatureOnly = true;
@@ -148,11 +149,11 @@ Resolver::instantiatedSignatureResolver(Context* context,
 }
 
 Resolver
-Resolver::functionResolver(Context* context,
-                           const Function* fn,
-                           const PoiScope* poiScope,
-                           const TypedFnSignature* typedFnSignature,
-                           ResolutionResultByPostorderID& byId) {
+Resolver::createForFunction(Context* context,
+                            const Function* fn,
+                            const PoiScope* poiScope,
+                            const TypedFnSignature* typedFnSignature,
+                            ResolutionResultByPostorderID& byId) {
   auto ret = Resolver(context, fn, byId, poiScope);
   ret.typedSignature = typedFnSignature;
   ret.signatureOnly = false;
@@ -184,9 +185,9 @@ Resolver::functionResolver(Context* context,
 }
 
 Resolver
-Resolver::functionScopeResolver(Context* context,
-                                const Function* fn,
-                                ResolutionResultByPostorderID& byId) {
+Resolver::createForScopeResolvingFunction(Context* context,
+                                          const Function* fn,
+                                          ResolutionResultByPostorderID& byId) {
   auto ret = Resolver(context, fn, byId, nullptr);
   ret.typedSignature = nullptr; // re-set below
   ret.signatureOnly = true; // re-set below
@@ -237,12 +238,12 @@ Resolver::functionScopeResolver(Context* context,
 
 // set up Resolver to initially resolve field declaration types
 Resolver
-Resolver::initialFieldStmtResolver(Context* context,
-                                   const AggregateDecl* decl,
-                                   const AstNode* fieldStmt,
-                                   const CompositeType* compositeType,
-                                   ResolutionResultByPostorderID& byId,
-                                   bool useGenericFormalDefaults) {
+Resolver::createForInitialFieldStmt(Context* context,
+                                    const AggregateDecl* decl,
+                                    const AstNode* fieldStmt,
+                                    const CompositeType* compositeType,
+                                    ResolutionResultByPostorderID& byId,
+                                    bool useGenericFormalDefaults) {
   auto ret = Resolver(context, decl, byId, nullptr);
   ret.curStmt = fieldStmt;
   ret.inCompositeType = compositeType;
@@ -253,13 +254,13 @@ Resolver::initialFieldStmtResolver(Context* context,
 
 // set up Resolver to resolve instantiated field declaration types
 Resolver
-Resolver::instantiatedFieldStmtResolver(Context* context,
-                                        const AggregateDecl* decl,
-                                        const AstNode* fieldStmt,
-                                        const CompositeType* compositeType,
-                                        const PoiScope* poiScope,
-                                        ResolutionResultByPostorderID& byId,
-                                        bool useGenericFormalDefaults) {
+Resolver::createForInstantiatedFieldStmt(Context* context,
+                                         const AggregateDecl* decl,
+                                         const AstNode* fieldStmt,
+                                         const CompositeType* compositeType,
+                                         const PoiScope* poiScope,
+                                         ResolutionResultByPostorderID& byId,
+                                         bool useGenericFormalDefaults) {
   auto ret = Resolver(context, decl, byId, poiScope);
   ret.curStmt = fieldStmt;
   ret.inCompositeType = compositeType;
@@ -272,7 +273,7 @@ Resolver::instantiatedFieldStmtResolver(Context* context,
 // set up Resolver to resolve instantiated field declaration types
 // without knowing the CompositeType
 Resolver
-Resolver::instantiatedSignatureFieldsResolver(Context* context,
+Resolver::createForInstantiatedSignatureFields(Context* context,
                                      const AggregateDecl* decl,
                                      const SubstitutionsMap& substitutions,
                                      const PoiScope* poiScope,
@@ -287,11 +288,11 @@ Resolver::instantiatedSignatureFieldsResolver(Context* context,
 
 // set up Resolver to resolve a parent class type expression
 Resolver
-Resolver::parentClassResolver(Context* context,
-                              const AggregateDecl* decl,
-                              const SubstitutionsMap& substitutions,
-                              const PoiScope* poiScope,
-                              ResolutionResultByPostorderID& byId) {
+Resolver::createForParentClass(Context* context,
+                               const AggregateDecl* decl,
+                               const SubstitutionsMap& substitutions,
+                               const PoiScope* poiScope,
+                               ResolutionResultByPostorderID& byId) {
   auto ret = Resolver(context, decl, byId, poiScope);
   ret.substitutions = &substitutions;
   ret.useGenericFormalDefaults = true;

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -83,33 +83,34 @@ struct Resolver {
 
   // set up Resolver to resolve a Module
   static Resolver
-  moduleStmtResolver(Context* context, const uast::Module* mod,
-                     const uast::AstNode* modStmt,
-                     ResolutionResultByPostorderID& byPostorder);
+  createForModuleStmt(Context* context, const uast::Module* mod,
+                      const uast::AstNode* modStmt,
+                      ResolutionResultByPostorderID& byPostorder);
 
   // set up Resolver to scope resolve a Module
   static Resolver
-  moduleStmtScopeResolver(Context* context, const uast::Module* mod,
-                          const uast::AstNode* modStmt,
-                          ResolutionResultByPostorderID& byPostorder);
+  createForScopeResolvingModuleStmt(
+                      Context* context, const uast::Module* mod,
+                      const uast::AstNode* modStmt,
+                      ResolutionResultByPostorderID& byPostorder);
 
   // set up Resolver to resolve a potentially generic Function signature
   static Resolver
-  initialSignatureResolver(Context* context, const uast::Function* fn,
-                           ResolutionResultByPostorderID& byPostorder);
+  createForInitialSignature(Context* context, const uast::Function* fn,
+                            ResolutionResultByPostorderID& byPostorder);
 
   // set up Resolver to resolve an instantiation of a Function signature
   static Resolver
-  instantiatedSignatureResolver(Context* context,
-                                const uast::Function* fn,
-                                const SubstitutionsMap& substitutions,
-                                const PoiScope* poiScope,
-                                ResolutionResultByPostorderID& byPostorder);
+  createForInstantiatedSignature(Context* context,
+                                 const uast::Function* fn,
+                                 const SubstitutionsMap& substitutions,
+                                 const PoiScope* poiScope,
+                                 ResolutionResultByPostorderID& byPostorder);
 
   // set up Resolver to resolve a Function body/return type after
   // instantiation (if any instantiation was needed)
   static Resolver
-  functionResolver(Context* context,
+  createForFunction(Context* context,
                    const uast::Function* fn,
                    const PoiScope* poiScope,
                    const TypedFnSignature* typedFnSignature,
@@ -117,44 +118,44 @@ struct Resolver {
 
   // set up Resolver to scope resolve a Function
   static Resolver
-  functionScopeResolver(Context* context, const uast::Function* fn,
-                        ResolutionResultByPostorderID& byPostorder);
+  createForScopeResolvingFunction(Context* context, const uast::Function* fn,
+                                  ResolutionResultByPostorderID& byPostorder);
 
   // set up Resolver to initially resolve field declaration types
   static Resolver
-  initialFieldStmtResolver(Context* context,
-                           const uast::AggregateDecl* decl,
-                           const uast::AstNode* fieldStmt,
-                           const types::CompositeType* compositeType,
-                           ResolutionResultByPostorderID& byPostorder,
-                           bool useGenericFormalDefaults);
+  createForInitialFieldStmt(Context* context,
+                            const uast::AggregateDecl* decl,
+                            const uast::AstNode* fieldStmt,
+                            const types::CompositeType* compositeType,
+                            ResolutionResultByPostorderID& byPostorder,
+                            bool useGenericFormalDefaults);
 
   // set up Resolver to resolve instantiated field declaration types
   static Resolver
-  instantiatedFieldStmtResolver(Context* context,
-                                const uast::AggregateDecl* decl,
-                                const uast::AstNode* fieldStmt,
-                                const types::CompositeType* compositeType,
-                                const PoiScope* poiScope,
-                                ResolutionResultByPostorderID& byPostorder,
-                                bool useGenericFormalDefaults);
+  createForInstantiatedFieldStmt(Context* context,
+                                 const uast::AggregateDecl* decl,
+                                 const uast::AstNode* fieldStmt,
+                                 const types::CompositeType* compositeType,
+                                 const PoiScope* poiScope,
+                                 ResolutionResultByPostorderID& byPostorder,
+                                 bool useGenericFormalDefaults);
 
   // set up Resolver to resolve instantiated field declaration types
   // without knowing the CompositeType
   static Resolver
-  instantiatedSignatureFieldsResolver(Context* context,
-                                      const uast::AggregateDecl* decl,
-                                      const SubstitutionsMap& substitutions,
-                                      const PoiScope* poiScope,
-                                      ResolutionResultByPostorderID& byId);
+  createForInstantiatedSignatureFields(Context* context,
+                                       const uast::AggregateDecl* decl,
+                                       const SubstitutionsMap& substitutions,
+                                       const PoiScope* poiScope,
+                                       ResolutionResultByPostorderID& byId);
 
   // set up Resolver to resolve a parent class type expression
   static Resolver
-  parentClassResolver(Context* context,
-                      const uast::AggregateDecl* decl,
-                      const SubstitutionsMap& substitutions,
-                      const PoiScope* poiScope,
-                      ResolutionResultByPostorderID& byPostorder);
+  createForParentClass(Context* context,
+                       const uast::AggregateDecl* decl,
+                       const SubstitutionsMap& substitutions,
+                       const PoiScope* poiScope,
+                       ResolutionResultByPostorderID& byPostorder);
 
   /* Get the formal types from a Resolver that computed them
    */

--- a/compiler/dyno/lib/uast/Builder.cpp
+++ b/compiler/dyno/lib/uast/Builder.cpp
@@ -82,24 +82,24 @@ std::string Builder::filenameToModulename(const char* filename) {
   }
 }
 
-owned<Builder> Builder::topLevelModuleBuilder(Context* context,
-                                              const char* filepath) {
+owned<Builder> Builder::createForTopLevelModule(Context* context,
+                                                const char* filepath) {
   auto uniqueFilename = UniqueString::get(context, filepath);
   UniqueString startingSymbolPath;
   auto b = new Builder(context, uniqueFilename, startingSymbolPath);
   return toOwned(b);
 }
 
-owned<Builder> Builder::includedModuleBuilder(Context* context,
-                                              const char* filepath,
-                                              UniqueString parentSymbolPath) {
+owned<Builder> Builder::createForIncludedModule(Context* context,
+                                                const char* filepath,
+                                                UniqueString parentSymbolPath) {
   auto uniqueFilename = UniqueString::get(context, filepath);
   auto b = new Builder(context, uniqueFilename, parentSymbolPath);
   return toOwned(b);
 }
 
 owned<Builder> Builder::build(Context* context, const char* filepath) {
-  return Builder::topLevelModuleBuilder(context, filepath);
+  return Builder::createForTopLevelModule(context, filepath);
 }
 
 void Builder::addToplevelExpression(owned<AstNode> e) {

--- a/compiler/dyno/lib/uast/Builder.cpp
+++ b/compiler/dyno/lib/uast/Builder.cpp
@@ -98,10 +98,6 @@ owned<Builder> Builder::createForIncludedModule(Context* context,
   return toOwned(b);
 }
 
-owned<Builder> Builder::build(Context* context, const char* filepath) {
-  return Builder::createForTopLevelModule(context, filepath);
-}
-
 void Builder::addToplevelExpression(owned<AstNode> e) {
   this->topLevelExpressions_.push_back(std::move(e));
 }

--- a/compiler/dyno/lib/uast/Builder.cpp
+++ b/compiler/dyno/lib/uast/Builder.cpp
@@ -515,12 +515,11 @@ owned <AstNode> Builder::parseDummyNodeForInitExpr(Variable* var, std::string va
     inputText += (!value.empty()) ? value : "true";
     inputText += ";";
   }
-  auto parser = parsing::Parser::build(context());
-  parsing::Parser *p = parser.get();
+  auto parser = parsing::Parser::createForTopLevelModule(context());
   std::string path = "Command-line arg (";
   path += var->name().str();
   path += ")";
-  auto parseResult = p->parseString(path.c_str(), inputText.c_str());
+  auto parseResult = parser.parseString(path.c_str(), inputText.c_str());
   // Propagate any parse errors from the dummy node to builder errors
   if (parseResult.numErrors() > 0) {
    for (ErrorMessage error : parseResult.errors()) {

--- a/compiler/dyno/test/parsing/testParse.cpp
+++ b/compiler/dyno/test/parsing/testParse.cpp
@@ -704,8 +704,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseAggregate.cpp
+++ b/compiler/dyno/test/parsing/testParseAggregate.cpp
@@ -555,8 +555,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseArrayDomainRange.cpp
+++ b/compiler/dyno/test/parsing/testParseArrayDomainRange.cpp
@@ -158,8 +158,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   testRange(p, "testRange0.chpl", "..", true, true);
   testRange(p, "testRange1.chpl", "..", true, false);

--- a/compiler/dyno/test/parsing/testParseAttributes.cpp
+++ b/compiler/dyno/test/parsing/testParseAttributes.cpp
@@ -483,8 +483,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseBegin.cpp
+++ b/compiler/dyno/test/parsing/testParseBegin.cpp
@@ -139,8 +139,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseBracketLoop.cpp
+++ b/compiler/dyno/test/parsing/testParseBracketLoop.cpp
@@ -254,8 +254,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseCobegin.cpp
+++ b/compiler/dyno/test/parsing/testParseCobegin.cpp
@@ -117,8 +117,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseCoforall.cpp
+++ b/compiler/dyno/test/parsing/testParseCoforall.cpp
@@ -214,8 +214,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseComments.cpp
+++ b/compiler/dyno/test/parsing/testParseComments.cpp
@@ -53,8 +53,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
 

--- a/compiler/dyno/test/parsing/testParseConditional.cpp
+++ b/compiler/dyno/test/parsing/testParseConditional.cpp
@@ -314,8 +314,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseDefer.cpp
+++ b/compiler/dyno/test/parsing/testParseDefer.cpp
@@ -115,8 +115,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseDelete.cpp
+++ b/compiler/dyno/test/parsing/testParseDelete.cpp
@@ -60,8 +60,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
 

--- a/compiler/dyno/test/parsing/testParseDoWhile.cpp
+++ b/compiler/dyno/test/parsing/testParseDoWhile.cpp
@@ -148,8 +148,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseEmptyStmt.cpp
+++ b/compiler/dyno/test/parsing/testParseEmptyStmt.cpp
@@ -171,8 +171,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseEnums.cpp
+++ b/compiler/dyno/test/parsing/testParseEnums.cpp
@@ -293,8 +293,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test1(p);
   test2(p);

--- a/compiler/dyno/test/parsing/testParseFor.cpp
+++ b/compiler/dyno/test/parsing/testParseFor.cpp
@@ -178,8 +178,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseForall.cpp
+++ b/compiler/dyno/test/parsing/testParseForall.cpp
@@ -251,8 +251,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseForeach.cpp
+++ b/compiler/dyno/test/parsing/testParseForeach.cpp
@@ -245,8 +245,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseForwardingDecl.cpp
+++ b/compiler/dyno/test/parsing/testParseForwardingDecl.cpp
@@ -388,8 +388,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseFunctions.cpp
+++ b/compiler/dyno/test/parsing/testParseFunctions.cpp
@@ -425,8 +425,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test1(p);
   test1a(p);

--- a/compiler/dyno/test/parsing/testParseImport.cpp
+++ b/compiler/dyno/test/parsing/testParseImport.cpp
@@ -277,8 +277,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseInclude.cpp
+++ b/compiler/dyno/test/parsing/testParseInclude.cpp
@@ -98,8 +98,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
 

--- a/compiler/dyno/test/parsing/testParseInterface.cpp
+++ b/compiler/dyno/test/parsing/testParseInterface.cpp
@@ -64,8 +64,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   return 0;

--- a/compiler/dyno/test/parsing/testParseLabelContinueBreak.cpp
+++ b/compiler/dyno/test/parsing/testParseLabelContinueBreak.cpp
@@ -123,8 +123,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseLocal.cpp
+++ b/compiler/dyno/test/parsing/testParseLocal.cpp
@@ -177,8 +177,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseModules.cpp
+++ b/compiler/dyno/test/parsing/testParseModules.cpp
@@ -306,8 +306,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test0a(p);

--- a/compiler/dyno/test/parsing/testParseMultiVar.cpp
+++ b/compiler/dyno/test/parsing/testParseMultiVar.cpp
@@ -452,8 +452,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test1(p);
   test1a(p);

--- a/compiler/dyno/test/parsing/testParseNew.cpp
+++ b/compiler/dyno/test/parsing/testParseNew.cpp
@@ -181,12 +181,13 @@ static void test5(Parser* parser) {
   assert(newExpr->management() == New::UNMANAGED);
   assert(newExpr->typeExpression()->isIdentifier());
 }
+
 int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseNumericLiterals.cpp
+++ b/compiler/dyno/test/parsing/testParseNumericLiterals.cpp
@@ -135,8 +135,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   testIntLiteral(p, "testAb.chpl", "0b0", 0);
   testIntLiteral(p, "testAB.chpl", "0b0", 0);

--- a/compiler/dyno/test/parsing/testParseOn.cpp
+++ b/compiler/dyno/test/parsing/testParseOn.cpp
@@ -109,8 +109,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseReturn.cpp
+++ b/compiler/dyno/test/parsing/testParseReturn.cpp
@@ -100,8 +100,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseSelect.cpp
+++ b/compiler/dyno/test/parsing/testParseSelect.cpp
@@ -186,8 +186,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseSerial.cpp
+++ b/compiler/dyno/test/parsing/testParseSerial.cpp
@@ -176,8 +176,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseStringBytesLiterals.cpp
+++ b/compiler/dyno/test/parsing/testParseStringBytesLiterals.cpp
@@ -167,8 +167,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   testSingleLiteral(p, "test0.chpl", "hi", std::string("hi"));
   testTripleLiteral(p, "test2.chpl", "hi", std::string("hi"));

--- a/compiler/dyno/test/parsing/testParseSync.cpp
+++ b/compiler/dyno/test/parsing/testParseSync.cpp
@@ -177,8 +177,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseTryCatchThrow.cpp
+++ b/compiler/dyno/test/parsing/testParseTryCatchThrow.cpp
@@ -228,8 +228,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseTupleVar.cpp
+++ b/compiler/dyno/test/parsing/testParseTupleVar.cpp
@@ -279,8 +279,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test1(p);
   test2(p);

--- a/compiler/dyno/test/parsing/testParseUse.cpp
+++ b/compiler/dyno/test/parsing/testParseUse.cpp
@@ -311,8 +311,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseVariables.cpp
+++ b/compiler/dyno/test/parsing/testParseVariables.cpp
@@ -397,8 +397,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test1(p);
   test2(p);

--- a/compiler/dyno/test/parsing/testParseWhile.cpp
+++ b/compiler/dyno/test/parsing/testParseWhile.cpp
@@ -142,8 +142,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/parsing/testParseYield.cpp
+++ b/compiler/dyno/test/parsing/testParseYield.cpp
@@ -110,8 +110,8 @@ int main() {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test0(p);
   test1(p);

--- a/compiler/dyno/test/uast/testBuildIDs.cpp
+++ b/compiler/dyno/test/uast/testBuildIDs.cpp
@@ -147,7 +147,7 @@ static  void test2() {
   Context context;
   Context* ctx = &context;
 
-  auto builder = Builder::build(ctx, "path/to/test.chpl");
+  auto builder = Builder::createForTopLevelModule(ctx, "path/to/test.chpl");
   Builder* b   = builder.get();
   Location dummyLoc(UniqueString::get(ctx, "path/to/test.chpl"));
 
@@ -253,7 +253,7 @@ static void test3() {
   Context context;
   Context* ctx = &context;
 
-  auto builder = Builder::build(ctx, "path/to/test.chpl");
+  auto builder = Builder::createForTopLevelModule(ctx, "path/to/test.chpl");
   Builder* b   = builder.get();
   Location dummyLoc(UniqueString::get(ctx, "path/to/test.chpl"));
 
@@ -317,7 +317,7 @@ static void test4() {
   Context context;
   Context* ctx = &context;
 
-  auto builder = Builder::build(ctx, "path/to/test.chpl");
+  auto builder = Builder::createForTopLevelModule(ctx, "path/to/test.chpl");
   Builder* b   = builder.get();
   Location dummyLoc(UniqueString::get(ctx, "path/to/test.chpl"));
 
@@ -441,7 +441,7 @@ static void test5() {
   Context* ctx = &context;
 
   const char* path = "path/to/file-name.sub.chpl";
-  auto builder = Builder::build(ctx, path);
+  auto builder = Builder::createForTopLevelModule(ctx, path);
   Builder* b   = builder.get();
   Location dummyLoc(UniqueString::get(ctx, path));
 

--- a/compiler/dyno/test/uast/testStringify.cpp
+++ b/compiler/dyno/test/uast/testStringify.cpp
@@ -517,8 +517,8 @@ int main(int argc, char** argv) {
   Context context;
   Context* ctx = &context;
 
-  auto parser = Parser::build(ctx);
-  Parser* p = parser.get();
+  auto parser = Parser::createForTopLevelModule(ctx);
+  Parser* p = &parser;
 
   test1(p);
   test2(p);

--- a/compiler/dyno/test/uast/testVisit.cpp
+++ b/compiler/dyno/test/uast/testVisit.cpp
@@ -32,7 +32,7 @@ using namespace chpl;
 using namespace uast;
 
 static BuilderResult makeAST(Context* ctx, const uast::Module*& modOut) {
-  auto builder = Builder::build(ctx, "path/to/test.chpl");
+  auto builder = Builder::createForTopLevelModule(ctx, "path/to/test.chpl");
   Builder* b   = builder.get();
   Location dummyLoc(UniqueString::get(ctx, "path/to/test.chpl"));
 


### PR DESCRIPTION
Based on discussion among those of us working with dyno, we would like to use `createFor` at the beginning of factory functions that need a special name; e.g. `Resolver::createForFunction`. This PR makes that change and also removes a few `build` functions that have a better name now.

Reviewed by @DanilaFe and @arezaii - thanks!

- [x] full local testing
