### PR TITLE
Emit an error for potential remote access in GPU kernels, fix a test

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4870,7 +4870,8 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   args.push_back(new_IntSymbol(call->astloc.lineno()));
   args.push_back(new_IntSymbol(gFilenameLookupCache[call->astloc.filename()]));
 
-  // We will emit the gpu code into a global variable named chpl_gpuBinary. Pass // this variable to the launch call.
+  // We will emit the gpu code into a global variable named chpl_gpuBinary. Pass
+  // this variable to the launch call.
   #ifdef HAVE_LLVM  // Needed to suppress warning; should always be true in code path for GPU codegen
     GenInfo* info = gGenInfo;
     args.push_back(info->lvt->getValue("chpl_gpuBinary"));

--- a/test/gpu/native/globalVar.chpl
+++ b/test/gpu/native/globalVar.chpl
@@ -1,0 +1,7 @@
+var x = 10;
+
+on here.gpus[0] {
+  var A: [0..0] int;
+  foreach a in A do a = x;
+  writeln(A);
+}

--- a/test/gpu/native/globalVar.good
+++ b/test/gpu/native/globalVar.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+globalVar.chpl:5: error: Accessing potentially-remote variables from GPU kernels is not supported yet
+globalVar.chpl:1: error: Offending variable was declared here

--- a/test/gpu/native/math.chpl
+++ b/test/gpu/native/math.chpl
@@ -1,55 +1,56 @@
 use Math;
 use GPUDiagnostics;
 
-config var i8: int(8) = 10;
-config var i16: int(16) = 10;
-config var i32: int(32) = 10;
-config var i64: int(64) = 10;
-config var u8: uint(8) = 10;
-config var u16: uint(16) = 10;
-config var u32: uint(32) = 10;
-config var u64: uint(64) = 10;
-
-config var im32: imag(32) = 10i;
-config var im64: imag(64) = 10i;
-
 config const verbose = false;
 
-/* TODO
-config var c64: complex(64) = 10+10i;
-config var c128: complex(128) = 10+10i;
-*/
+proc main() {
 
-config var r32: real(32) = 0.1;
-config var r64: real(64) = 0.1;
+  var i8: int(8) = 10;
+  var i16: int(16) = 10;
+  var i32: int(32) = 10;
+  var i64: int(64) = 10;
+  var u8: uint(8) = 10;
+  var u16: uint(16) = 10;
+  var u32: uint(32) = 10;
+  var u64: uint(64) = 10;
 
-config var r32b: real(32) = 10.0;
-config var r64b: real(64) = 10.0;
+  var im32: imag(32) = 10i;
+  var im64: imag(64) = 10i;
 
+  /* TODO
+  var c64: complex(64) = 10+10i;
+  var c128: complex(128) = 10+10i;
+  */
 
-on here.gpus[0] {
-  var R: [0..1] real;
-  var I: [0..1] imag;
-  var B: [0..1] bool;
+  var r32: real(32) = 0.1;
+  var r64: real(64) = 0.1;
 
-  const r = 0..0;
+  var r32b: real(32) = 10.0;
+  var r64b: real(64) = 10.0;
 
-  proc check(A, s) {
-    if getGPUDiagnostics()[0].kernel_launch !=1 then
-      writeln(s + " didn't result in kernel launch");
-    else if verbose then
-      writeln(s + " resulted in kernel launch");
+  on here.gpus[0] {
+    var R: [0..1] real;
+    var I: [0..1] imag;
+    var B: [0..1] bool;
 
-    const isCorrect = if A.eltType == bool then A[0]==A[1] else isclose(A[0],A[1]);
-    if !isCorrect then
-      writeln(s + " computed wrong result. ("+A[0]:string+", "+A[1]:string+")");
-    else if verbose then
-      writeln(s + " computed right result. ("+A[0]:string+", "+A[1]:string+")");
+    const r = 0..0;
 
-    resetGPUDiagnostics();
-  }
+    proc check(A, s) {
+      if getGPUDiagnostics()[0].kernel_launch !=1 then
+        writeln(s + " didn't result in kernel launch");
+      else if verbose then
+        writeln(s + " resulted in kernel launch");
 
-  startGPUDiagnostics();
+      const isCorrect = if A.eltType == bool then A[0]==A[1] else isclose(A[0],A[1]);
+      if !isCorrect then
+        writeln(s + " computed wrong result. ("+A[0]:string+", "+A[1]:string+")");
+      else if verbose then
+        writeln(s + " computed right result. ("+A[0]:string+", "+A[1]:string+")");
+
+      resetGPUDiagnostics();
+    }
+
+    startGPUDiagnostics();
 
 // foreach loops should result in a kernel launch that sets the 0th index of the array, the
 // following statement is outside the foreach, so wll execute on the host. We check whether they
@@ -289,5 +290,6 @@ foreach i in r do  R[0] =  y1(r64);   R[1] =  y1(r64);  check(R,"y1(r64)");
 foreach i in r do  R[0] =  yn(2,r32);   R[1] =  yn(2,r32);  check(R,"yn(2,r32)");
 foreach i in r do  R[0] =  yn(2,r64);   R[1] =  yn(2,r64);  check(R,"yn(2,r64)");
 
-  stopGPUDiagnostics();
+    stopGPUDiagnostics();
+  }
 }

--- a/test/gpu/native/math.chpl
+++ b/test/gpu/native/math.chpl
@@ -13,6 +13,8 @@ config var u64: uint(64) = 10;
 config var im32: imag(32) = 10i;
 config var im64: imag(64) = 10i;
 
+config const verbose = false;
+
 /* TODO
 config var c64: complex(64) = 10+10i;
 config var c128: complex(128) = 10+10i;
@@ -33,12 +35,16 @@ on here.gpus[0] {
   const r = 0..0;
 
   proc check(A, s) {
-    assert(getGPUDiagnostics()[0].kernel_launch == 1,
-           s + " didn't result in kernel launch");
+    if getGPUDiagnostics()[0].kernel_launch !=1 then
+      writeln(s + " didn't result in kernel launch");
+    else if verbose then
+      writeln(s + " resulted in kernel launch");
 
-    var isCorrect = if A.eltType == bool then A[0]==A[1] else isclose(A[0],A[1]);
-    assert(isCorrect,
-           s + " computed wrong result. ("+A[0]:string+", "+A[1]:string+")");
+    const isCorrect = if A.eltType == bool then A[0]==A[1] else isclose(A[0],A[1]);
+    if !isCorrect then
+      writeln(s + " computed wrong result. ("+A[0]:string+", "+A[1]:string+")");
+    else if verbose then
+      writeln(s + " computed right result. ("+A[0]:string+", "+A[1]:string+")");
 
     resetGPUDiagnostics();
   }


### PR DESCRIPTION
We've got failures on a recent GPU test because of access to `config var`s in
GASNet configs. This is because they were outer scalars in module scope. We turn
those into wide references. And in the test we were trying to pass the wide
reference to the kernel's narrow argument. Which, to my surprise, was compiling
fine. However, within the kernel we were getting junk values.

This PR adds an error message to catch such cases and fixes the problematic
case.


Test:
- [ ] gasnet in gpu/native