### PR TITLE
Default to the c-backend for arm based macs

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -52,7 +52,13 @@ def is_included_llvm_built():
 def compatible_platform_for_llvm():
     target_arch = chpl_arch.get('target')
     target_platform = chpl_platform.get('target')
-    return (target_arch != "i368" and target_platform != "linux32")
+
+    is32bit = target_platform == "linux32" or target_arch == "i368"
+    mac_arm = target_platform == 'darwin' and target_arch == 'arm64'
+
+    if is32bit or mac_arm:
+        return False
+    return True
 
 # returns a string of the supported llvm versions suitable for error msgs
 def llvm_versions_string():

--- a/util/cron/test-darwin-m1.bash
+++ b/util/cron/test-darwin-m1.bash
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 #
-# Test examples for default configuration on M1 darwin
+# Test full suite for default configuration on M1 darwin
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-darwin.bash
+source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
 
-$CWD/nightly -cron -examples
+# Quiet warnings from defaulting to fifo
+export CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET=yes
+
+$CWD/nightly -cron $(get_nightly_paratest_args)


### PR DESCRIPTION
We're seeing some ABI issues or something with the llvm backend in
#19218. Until we resolve that issue (hopefully soon) just default to the
C backend.

Even though we expect #19218 to be fixed soon, I want to expand nightly
testing (done in this PR) to include the full test suite, and this
allows us to do so.

Part of Cray/chapel-private#3374
Related to #19218