### PR TITLE
Fix arrays of sortedSets

### DIFF
--- a/modules/packages/SortedSet.chpl
+++ b/modules/packages/SortedSet.chpl
@@ -50,9 +50,28 @@ module SortedSet {
     /* If `true`, this sortedSet will perform parallel safe operations. */
     param parSafe = false;
 
+    type comparatorType = defaultComparator.type;
+
     /* The underlying implementation */
     pragma "no doc"
-    var instance: treap(eltType, parSafe, ?);
+    var instance: treap(eltType, parSafe, comparatorType);
+
+    /*
+      Initializes an empty sortedSet containing elements of the given type.
+
+      :arg eltType: The type of the elements of this sortedSet.
+      :arg parSafe: If `true`, this sortedSet will use parallel safe operations.
+      :arg comparatorType: The comparator type
+    */
+    proc init(type eltType, param parSafe = false,
+              type comparatorType = defaultComparator.type) {
+      this.eltType = eltType;
+      this.parSafe = parSafe;
+      this.comparatorType = comparatorType;
+
+      var comparator: comparatorType;
+      this.instance = new treap(eltType, parSafe, comparator);
+    }
 
     /*
       Initializes an empty sortedSet containing elements of the given type.
@@ -61,10 +80,10 @@ module SortedSet {
       :arg parSafe: If `true`, this sortedSet will use parallel safe operations.
       :arg comparator: The comparator used to compare elements.
     */
-    proc init(type eltType, param parSafe = false,
-              comparator: record = defaultComparator) {
+    proc init(type eltType, param parSafe = false, comparator: record) {
       this.eltType = eltType;
       this.parSafe = parSafe;
+      this.comparatorType = comparator.type;
 
       this.instance = new treap(eltType, parSafe, comparator);
     }
@@ -84,6 +103,7 @@ module SortedSet {
     where canResolveMethod(iterable, "these") lifetime this < iterable {
       this.eltType = eltType;
       this.parSafe = parSafe;
+      this.comparatorType = comparator.type;
 
       this.instance = new treap(eltType, iterable, parSafe, comparator);
     }
@@ -98,6 +118,7 @@ module SortedSet {
     proc init=(const ref other: sortedSet(?t)) lifetime this < other {
       this.eltType = t;
       this.parSafe = other.parSafe;
+      this.comparatorType = other.comparatorType;
       this.instance = new treap(this.eltType, this.parSafe,
                                             other.instance.comparator);
 


### PR DESCRIPTION
This PR fixes a relatively long-standing SortedSet issue.

Implemented by @mppf, thanks!

Resolves https://github.com/chapel-lang/chapel/issues/19872

1. The story started with the user bug report https://github.com/chapel-lang/chapel/issues/18656.
2. It was observed that the compiler wasn't able to handle partial generic fields properly, resulting in type mismatches. That specific problem was spun-off to its own issue https://github.com/chapel-lang/chapel/issues/18664.
  a. We now know that the issue is fixed in the dyno resolver. Current plan is to not invest time in the production compiler: https://github.com/chapel-lang/chapel/issues/18664#issuecomment-1171618053
3. Until that issue was resolved, we created a patch for the SortedSet module to workaround the issue: https://github.com/chapel-lang/chapel/pull/18661
4. But that fix resulted in https://github.com/chapel-lang/chapel/issues/19872, which is an issue for CHAMPS.

This solution involves having a `comparatorType` field and using it as a field explicitly instead of `?`. What eluded me in my attempt at doing so was that the changes also required a new initializer.

Test:
- [x] library/packages/SortedSet