### PR TITLE
Default to cstdlib mem for arm based macs

### DIFF
--- a/test/stress/deitz/test_10k_local_coforall_with_remote_update.skipif
+++ b/test/stress/deitz/test_10k_local_coforall_with_remote_update.skipif
@@ -1,2 +1,4 @@
 # This test assumes we're running on multiple locales
 CHPL_COMM == none
+# fifo can lead to too many concurrent threads for gasnet
+CHPL_TASKS == fifo

--- a/test/stress/deitz/test_10k_remote_coforall.skipif
+++ b/test/stress/deitz/test_10k_remote_coforall.skipif
@@ -1,2 +1,4 @@
 # This test assumes we're running on multiple locales
 CHPL_COMM == none
+# fifo can lead to too many concurrent threads for gasnet
+CHPL_TASKS == fifo

--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -2,19 +2,21 @@
 import optparse
 import sys
 
-import chpl_platform, overrides
+import chpl_arch, chpl_platform, overrides
 from utils import error, memoize, warning
 
 @memoize
 def get(flag='host'):
+    arch_val = chpl_arch.get(flag)
     platform_val = chpl_platform.get(flag)
     cygwin = platform_val.startswith('cygwin')
+    mac_arm = platform_val == 'darwin' and arch_val == 'arm64'
     chpl_host_mem = overrides.get('CHPL_HOST_MEM')
     chpl_target_mem = overrides.get('CHPL_TARGET_MEM')
     chpl_mem = overrides.get('CHPL_MEM')
 
     if flag == 'target':
-        if cygwin:
+        if cygwin or mac_arm:
             mem_val = 'cstdlib'
         elif chpl_target_mem:
             mem_val = chpl_target_mem

--- a/util/cron/test-gasnet.darwin-m1.bash
+++ b/util/cron/test-gasnet.darwin-m1.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Test gasnet (segment everything) against multilocale tests
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-gasnet.bash
+source $CWD/common-darwin.bash
+source $CWD/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin-m1"
+
+# Quiet warnings from defaulting to fifo
+export CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET=yes
+
+$CWD/nightly -cron -multilocale $(get_nightly_paratest_args)


### PR DESCRIPTION
Something about jemalloc seems to be causing issues for multi-locale
testing as reported in #17825. I don't know the root cause yet, but
change the default while we look into it.

With cstdlib, all multilocale tests except 2 that create a lot of
communicating threads pass. gasnet only allows so many threads to
communicate concurrently (256 by default) and these tests can result in
10,000 threads. We haven't seen the tests fail previously, but they do
on m1 macs now. I'm not sure if time-slicing on m1 is different or
something is slower or faster but somehow more concurrent threads are
calling into gasnet.

Now that all tests are passing, add full multilocale m1 testing

Part of https://github.com/chapel-lang/chapel/issues/17825
Part of https://github.com/Cray/chapel-private/issues/3374