### PR TITLE
Throw -Wno-misleading-indentation on GCC 5.x.x and up

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -193,6 +193,10 @@ ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -lt 5; echo "$$?"),1)
 SQUASH_WARN_GEN_CFLAGS += -Wno-incompatible-pointer-types
 endif
 
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -ge 5; echo "$$?"),0)
+SQUASH_WARN_GEN_CFLAGS += -Wno-misleading-indentation
+endif
+
 #
 # Don't warn/error for tautological compares (ex. x == x)
 #


### PR DESCRIPTION
Throw -Wno-misleading-indentation on GCC 5.x.x and up (#20163)

When using the C backend and GCC, throw `-Wno-misleading-indentation` to
suppress backend errors that were introduced after #20106.

Tested `gcc 5.4.x` as well.

Reviewed by @bradcray. Thanks!

TESTING

- [x] `ALL` on `linux64`, `COMM=gasnet`, `TARGET_COMPILER=gnu`, `nightly GCC`
Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>