### PR TITLE
Adjust new prefetchCounters test

### DIFF
--- a/test/runtime/configMatters/comm/cache-remote/prefetchCounters.chpl
+++ b/test/runtime/configMatters/comm/cache-remote/prefetchCounters.chpl
@@ -21,6 +21,7 @@ inline proc prefetch(ref x, len:int) {
 
 // Helper function we use in this test to invalidate pages we prefetched
 // into the remote cache
+pragma "insert line file info"
 extern proc chpl_cache_invalidate(node:c_int, raddr:c_void_ptr,
                                   size: c_size_t);
 

--- a/test/runtime/configMatters/comm/cache-remote/prefetchCounters.skipif
+++ b/test/runtime/configMatters/comm/cache-remote/prefetchCounters.skipif
@@ -1,0 +1,5 @@
+# This test relies on the comm layer actually prefetching
+# and reporting the prefetch. With CHPL_GASNET_SEGMENT=fast
+# or with ugni it does not seem to do so.
+CHPL_COMM!=gasnet
+CHPL_GASNET_SEGMENT!=everything


### PR DESCRIPTION
Follow-up to PR #19969.

We were seeing failures in this test with `CHPL_COMM=ugni` and with `CHPL_COMM=gasnet` with `CHPL_GASNET_SEGMENT=fast` in an oversubscribed setting, so skip the test there for now. At the present time, `CHPL_COMM=ugni` doesn't do nonblocking GETs at all, so it is not surprising that the counts would behave differently there. It is not completely clear to me what the issue with `CHPL_GASNET_SEGMENT=fast` is, but this PR will cause that configuration to be skipped so it does not create failures in nightly testing.

We saw failures compiling this test with the C backend due to missing arguments to `chpl_cache_invalidate` and so this PR uses a pragma to add those arguments.

Test change only - not reviewed.