### PR TITLE
Make a string start on the same line as the opening quote

### DIFF
--- a/test/library/packages/HDF5/readChunks1DPreprocess.chpl
+++ b/test/library/packages/HDF5/readChunks1DPreprocess.chpl
@@ -9,8 +9,7 @@ if pathPrefix != "" {
   copyFile(infileName, pathPrefix + infileName);
 }
 
-const script = """
-#!/usr/bin/env bash
+const script = """#!/usr/bin/env bash
 # Requires that stdin is a list of integers, one per line
 # Writes the result back to stdout, one per line
 


### PR DESCRIPTION
The string that defines a bash script in this test started with a newline
character because it was written as:

```
const script = """
<script contents>
""";
```

This recently stopped working on some test systems because there was a blank
line before the #! line in the script. Move the <script contents> to the same
line as the opening triple quote.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>