### PR TITLE
Add two tests of fcfs as fields

### DIFF
--- a/test/functions/firstClassFns/saveInField-nothing.bad
+++ b/test/functions/firstClassFns/saveInField-nothing.bad
@@ -1,0 +1,9 @@
+saveInField-nothing.chpl:10: In initializer:
+saveInField-nothing.chpl:11: error: could not find a copy initializer ('init=') for type 'shared chpl__fcf_type_int64_t_chpl_bool' from type 'nothing'
+$CHPL_HOME/modules/internal/SharedObject.chpl:255: note: this candidate did not match: _shared.init=(pragma"nil from arg"in take: owned)
+saveInField-nothing.chpl:11: note: because actual argument #1 with type 'nothing'
+$CHPL_HOME/modules/internal/SharedObject.chpl:255: note: is passed to formal 'in take: owned'
+saveInField-nothing.chpl:11: note: other candidates are:
+$CHPL_HOME/modules/internal/SharedObject.chpl:281: note:   _shared.init=(pragma"nil from arg"const ref src: _shared)
+$CHPL_HOME/modules/internal/SharedObject.chpl:303: note:   _shared.init=(src: borrowed)
+note: and 2 other candidates, use --print-all-candidates to see them

--- a/test/functions/firstClassFns/saveInField-nothing.chpl
+++ b/test/functions/firstClassFns/saveInField-nothing.chpl
@@ -1,0 +1,39 @@
+record Foo {
+  var funcStored = false;
+  var funcField: func(int, bool) = none;
+
+  proc init(x: func(int, bool)) {
+    funcStored = true;
+    funcField = x;
+  }
+
+  proc init() {
+    this.complete();
+  }
+
+  proc callTheField(arg: int) {
+    if (funcStored) {
+      if (funcField(arg)) {
+        writeln("fcf with arg ", arg, " successful");
+      } else {
+        writeln("fcf with arg ", arg, " unsuccessful");
+      }
+    } else {
+      writeln("no fcf stored");
+    }
+  }
+}
+
+proc bar(x: int): bool {
+  if (x * 3 > 15) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+var f1 = new Foo(bar);
+f1.callTheField(2);
+f1.callTheField(6);
+var f2 = new Foo();
+f2.callTheField(17);

--- a/test/functions/firstClassFns/saveInField-nothing.future
+++ b/test/functions/firstClassFns/saveInField-nothing.future
@@ -1,0 +1,2 @@
+bug: Can't use none with first class function fields
+#20175

--- a/test/functions/firstClassFns/saveInField-nothing.good
+++ b/test/functions/firstClassFns/saveInField-nothing.good
@@ -1,0 +1,3 @@
+fcf with arg 2 unsuccessful
+fcf with arg 6 successful
+no fcf stored

--- a/test/functions/firstClassFns/saveInField.chpl
+++ b/test/functions/firstClassFns/saveInField.chpl
@@ -1,0 +1,23 @@
+record Foo {
+  var funcField: func(int, bool);
+
+  proc callTheField(arg: int) {
+    if (funcField(arg)) {
+      writeln("fcf with arg ", arg, " successful");
+    } else {
+      writeln("fcf with arg ", arg, " unsuccessful");
+    }
+  }
+}
+
+proc bar(x: int): bool {
+  if (x * 3 > 15) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+var f = new Foo(bar);
+f.callTheField(2);
+f.callTheField(6);

--- a/test/functions/firstClassFns/saveInField.good
+++ b/test/functions/firstClassFns/saveInField.good
@@ -1,0 +1,2 @@
+fcf with arg 2 unsuccessful
+fcf with arg 6 successful


### PR DESCRIPTION
One just checks saving a fcf in a field and calling it in a method.  The other
is the case I encountered when trying to implement distributed maps, where I
was attempting to use a `nothing` type in the case where I was relying on a
default hasher, which triggered a resolution failure.

A fresh checkout of the tests behaved as expected