### PR TITLE
Fix test failures caused by PR #20140 (removing array functions)

### DIFF
--- a/test/library/packages/LinearAlgebra/performance/MatrixUtils.chpl
+++ b/test/library/packages/LinearAlgebra/performance/MatrixUtils.chpl
@@ -21,7 +21,7 @@ proc populate(ref A, ref ADom, nnz: int, seed: int) where isCSArr(A) {
   for idx in indices {
     // Ensure no duplicates
     var newIdx = idx;
-    while indices.find(newIdx)(1) {
+    while (maxloc reduce zip(indices == newIdx, indices.domain))(0) {
       newIdx = (randomIndices.getNext(ADom.dim(0).low, ADom.dim(0).high),
                 randomIndices.getNext(ADom.dim(1).low, ADom.dim(1).high));
     }

--- a/test/sparse/CS/multiplication/performance.chpl
+++ b/test/sparse/CS/multiplication/performance.chpl
@@ -60,7 +60,7 @@ proc populate(ref A, ref ADom, sparsity: real, seed: int) where A.isSparse() {
   for idx in indices {
     // Ensure no duplicates
     var newIdx = idx;
-    while (maxloc reduce zip(indices == newIdx, indices.domain))(1) {
+    while (maxloc reduce zip(indices == newIdx, indices.domain))(0) {
       newIdx = (randomIndices.getNext(ADom.dim(0).low, ADom.dim(0).high), randomIndices.getNext(ADom.dim(1).low, ADom.dim(1).high));
     }
     idx = newIdx;
@@ -82,7 +82,7 @@ proc populate(ref A: [?ADom], sparsity: real, seed: int) where !A.isSparse() {
   for idx in indices {
     // Ensure no duplicates
     var newIdx = idx;
-    while (maxloc reduce zip(indices == newIdx, indices.domain))(1) {
+    while (maxloc reduce zip(indices == newIdx, indices.domain))(0) {
       newIdx = (randomIndices.getNext(ADom.dim(0).low, ADom.dim(0).high), randomIndices.getNext(ADom.dim(1).low, ADom.dim(1).high));
     }
     idx = newIdx;


### PR DESCRIPTION
This aims to fix the failures noted here:

https://chapel.discourse.group/t/cron-xc-none-gnu-slurm/13768

and here:

https://chapel.discourse.group/t/cron-perf-chapcs/13774

`Array.find` returns a tuple: (didFind, idx) where didFind is a bool and idx is the first index of the array containing the element.  The doc says `idx` is unspecified if not found but we had some tests that relied on this returning 0.

With the reduction approach it looks like it will return the first index in the domain if it doesn't find the desired element.

Either way looking at the first element of the `(didFind, idx)` tuple is the right thing to do.