### PR TITLE
Update future to reflect correction from Brad and Michael and add another test

### DIFF
--- a/test/functions/firstClassFns/saveInField-nothing.future
+++ b/test/functions/firstClassFns/saveInField-nothing.future
@@ -1,2 +1,2 @@
-bug: Can't use none with first class function fields
+error message: better message when trying to assign 'none' to field with a type
 #20175

--- a/test/functions/firstClassFns/saveInField-nothing.good
+++ b/test/functions/firstClassFns/saveInField-nothing.good
@@ -1,3 +1,2 @@
-fcf with arg 2 unsuccessful
-fcf with arg 6 successful
-no fcf stored
+saveInField-nothing.chpl:3: error: cannot assign 'none' to a field of type 'shared chpl__fcf_type_int64_t_chpl_bool'
+saveInField-nothing.chpl:3: note: try removing the type declaration

--- a/test/functions/firstClassFns/saveInField-properNothing.chpl
+++ b/test/functions/firstClassFns/saveInField-properNothing.chpl
@@ -1,0 +1,40 @@
+record Foo {
+  type funcType;
+  var funcField: funcType;
+
+  proc init(x: func(int, bool)) {
+    funcType = func(int, bool);
+    funcField = x;
+  }
+
+  proc init() {
+    funcType = nothing;
+    funcField = none;
+  }
+
+  proc callTheField(arg: int) {
+    if (funcType != nothing) {
+      if (funcField(arg)) {
+        writeln("fcf with arg ", arg, " successful");
+      } else {
+        writeln("fcf with arg ", arg, " unsuccessful");
+      }
+    } else {
+      writeln("no fcf stored");
+    }
+  }
+}
+
+proc bar(x: int): bool {
+  if (x * 3 > 15) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+var f1 = new Foo(bar);
+f1.callTheField(2);
+f1.callTheField(6);
+var f2 = new Foo();
+f2.callTheField(17);

--- a/test/functions/firstClassFns/saveInField-properNothing.good
+++ b/test/functions/firstClassFns/saveInField-properNothing.good
@@ -1,0 +1,3 @@
+fcf with arg 2 unsuccessful
+fcf with arg 6 successful
+no fcf stored


### PR DESCRIPTION
The other test is what I should have written (and works as intended).  The old
future has now been updated to be an "error message" future, since it should not
work but it should generate a better message to the user.  I updated the .good
file with a potential error message, but we may not generate that exact one when
the issue is resolved

A fresh checkout of both tests behaved as expected