### PR TITLE
Produce compile time error if we generate a "launch kernel" call inside a kernel

### DIFF
--- a/test/gpu/native/limitations/iterateOverMultidimDomain.chpl
+++ b/test/gpu/native/limitations/iterateOverMultidimDomain.chpl
@@ -1,0 +1,6 @@
+on here.gpus[0] {
+  var A: [1..10, 1..10] real;
+  forall (i,j) in {1..10, 1..10} do
+    A(i,j) = i + j;
+  writeln(A);
+}

--- a/test/gpu/native/limitations/iterateOverMultidimDomain.good
+++ b/test/gpu/native/limitations/iterateOverMultidimDomain.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+iterateOverMultidimDomain.chpl:3: error: GPU support does not currently allow nested kernel launches. Do you have
+nested forall/foreach loops or looping over a multidimensional domain?


### PR DESCRIPTION
Currently (with GPU support) we don't support having loops over multi-dimensional domains like the following:

```chpl
on here.gpus[0] {
  var A: [1..10, 1..10] real;
  forall (i,j) in {1..10, 1..10} do
    A(i,j) = i + j;
  writeln(A);
}
```

Part of this PR is the "quick fix" mentioned here: https://github.com/Cray/chapel-private/issues/3481 which gets us "further along" to supporting these kind of loops but we run into other issues. Specifically, we'll produce a kernel launch inside a kernel and we don't know how to handle that.

As a convenience in this PR I detect when this situation occurs and produce a compile time error.

One concern is due to the nature of GPU support we will try and generate kernels for all eligible loops even if they won't actually launch on a GPU at runtime.

Maybe this should be a runtime error or warning instead?  All of our GPU tests pass and in the absence of this PR you'd still hit a compile time error (just one with an even worse error message: `foo.chpl:2: internal error: assertion error [codegen/cg-expr.cpp:2787]`

@e-kayrakli what do you think?