### PR TITLE
Convert more sections of callDestructors to use PassManager

### DIFF
--- a/compiler/include/pass-manager-passes.h
+++ b/compiler/include/pass-manager-passes.h
@@ -81,6 +81,36 @@ class AutoDestroyLoopExprTemps: public PassT<CallExpr*> {
   void process(CallExpr* call) override;
 };
 
+class InsertDestructorCalls: public PassT<CallExpr*> {
+  public:
+    bool shouldProcess(CallExpr* fn) override;
+    void process(CallExpr* fn) override;
+};
+
+class LowerAutoDestroyRuntimeType: public PassT<CallExpr*> {
+  public:
+    bool shouldProcess(CallExpr* fn) override;
+    void process(CallExpr* fn) override;
+};
+
+class InsertCopiesForYields: public PassT<CallExpr*> {
+  public:
+    bool shouldProcess(CallExpr* fn) override;
+    void process(CallExpr* fn) override;
+};
+
+class CallDestructorsCallCleanup: public PassT<CallExpr*> {
+  public:
+    bool shouldProcess(CallExpr* fn) override;
+    void process(CallExpr* fn) override;
+};
+
+class RemoveElidedOnBlocks: public PassT<BlockStmt*> {
+  public:
+    bool shouldProcess(BlockStmt* fn) override;
+    void process(BlockStmt* fn) override;
+};
+
 /**
   Adjust assignment of POD types to perform bitcopies.
 */

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1148,6 +1148,10 @@ static void lowerAutoDestroyRuntimeType(CallExpr* call) {
             }
 
             call->insertBefore(destroyCall);
+
+            if (destroyCall->isPrimitive(PRIM_AUTO_DESTROY_RUNTIME_TYPE)) {
+              lowerAutoDestroyRuntimeType(destroyCall);
+            }
           }
         }
       }
@@ -2087,7 +2091,7 @@ void InsertDestructorCalls::process(CallExpr* call) {
 }
 
 bool LowerAutoDestroyRuntimeType::shouldProcess(CallExpr* call) {
-  return call->isPrimitive(PRIM_AUTO_DESTROY_RUNTIME_TYPE);
+  return call->inTree() && call->isPrimitive(PRIM_AUTO_DESTROY_RUNTIME_TYPE);
 }
 
 void LowerAutoDestroyRuntimeType::process(CallExpr* call) {


### PR DESCRIPTION
These are some relatively straightforward changes to the callDestructors pass that convert sub-passes to use the PassManager.

Splitting off the ``LowerAutoDestroyRuntimeType`` section seems appropriate conceptually, but is somewhat wasteful. In ``CallDestructorsCallCleanup`` we simply overload the functionality when it might technically be more appropriate to split off the section that mutates ``PRIM_ASSIGN_ELIDED_COPY``, rather than removing it.

Testing:
- [x] full local
- [x] full gasnet