### PR TITLE
Add env var to force skip tests that use ZMQ

### DIFF
--- a/test/interop/C/multilocale.skipif
+++ b/test/interop/C/multilocale.skipif
@@ -5,21 +5,22 @@
  Installation of the ZMQ library is detected with the find_library function,
  which looks for the appropriate dynamic library (e.g. libzmq.so).
  Note that if the dynamic library is found, this test assumes that the
- header and static library are available.
+ header and static library are available. Can be overridden with
+ `CHPL_TEST_NO_ZMQ=True`
 """
 
-from __future__ import print_function
 from ctypes.util import find_library
 import os
 
 # Is ZMQ available?
 zmq_found = find_library('zmq') is not None
+user_no_zmq = os.getenv('CHPL_TEST_NO_ZMQ') is not None
 
 # Are we configured for multilocale?
 is_not_local = os.getenv('CHPL_COMM', 'none') != 'none'
 
 # OK contains the conditions that must be met to run the test
-OK = is_not_local and zmq_found
+OK = is_not_local and zmq_found and not user_no_zmq
 
 # Skip if not OK
 print(not OK)

--- a/test/interop/python/multilocale.skipif
+++ b/test/interop/python/multilocale.skipif
@@ -5,18 +5,19 @@
  Installation of the ZMQ library is detected with the find_library function,
  which looks for the appropriate dynamic library (e.g. libzmq.so).
  Note that if the dynamic library is found, this test assumes that the
- header and static library are available.
+ header and static library are available. Can be overridden with
+ `CHPL_TEST_NO_ZMQ=True`
 """
 
-from __future__ import print_function
 from ctypes.util import find_library
 import os
 
 # Is ZMQ available?
 zmq_found = find_library('zmq') is not None
+user_no_zmq = os.getenv('CHPL_TEST_NO_ZMQ') is not None
 
 # OK contains the conditions that must be met to run the test
-OK = zmq_found
+OK = zmq_found and not user_no_zmq
 
 # Skip if not OK
 print(not OK)

--- a/test/library/packages/ZMQ.skipif
+++ b/test/library/packages/ZMQ.skipif
@@ -6,20 +6,21 @@
  Installation of the ZMQ library is detected with the find_library function,
  which looks for the appropriate dynamic library (e.g. libzmq.so).
  Note that if the dynamic library is found, this test assumes that the
- header and static library are available.
+ header and static library are available. Can be overridden with
+ `CHPL_TEST_NO_ZMQ=True`
 
  Skip CHPL_COMM != none until #9425 is resolved.
 """
 
-from __future__ import print_function
 from ctypes.util import find_library
 import os
 
 # Is ZMQ available?
 zmq_found = find_library('zmq') is not None
+user_no_zmq = os.getenv('CHPL_TEST_NO_ZMQ') is not None
 
 # OK contains the conditions that must be met to run the test
-OK = zmq_found
+OK = zmq_found and not user_no_zmq
 
 # Skip if not OK
 print(not OK)


### PR DESCRIPTION
Our tests that use ZMQ assume that if a shared library can be found then
so can the headers and a static lib, but this isn't always the case.  On
many Cray systems just `libzmq.so` is available but nothing else.

Longer term, we probably want more of a configure-like check for zmq
functionality, but for now just add an option to tell the skipifs that
not all zmq functionality is available.