### PR TITLE
Pass extern records by pointer under LLVM

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -966,9 +966,15 @@ bool argMustUseCPtr(Type* type) {
       type->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS))
     return false;
 
+#ifdef HAVE_LLVM
+  // Pass extern records by pointer due to LLVM bug (see #19218)
+  bool recordNotRangeNotExtern = isRecord(type) &&
+                                 !type->symbol->hasFlag(FLAG_RANGE);
+#else
   bool recordNotRangeNotExtern = isRecord(type) &&
                                  !type->symbol->hasFlag(FLAG_RANGE) &&
                                  !type->symbol->hasFlag(FLAG_EXTERN);
+#endif
 
   return recordNotRangeNotExtern ||
          isUnion(type);

--- a/test/release/examples/primers/fileIO.suppressif
+++ b/test/release/examples/primers/fileIO.suppressif
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-
-import os
-
-platform = os.getenv('CHPL_TARGET_PLATFORM')
-arch = os.getenv('CHPL_TARGET_ARCH')
-comp = os.getenv('CHPL_TARGET_COMPILER')
-
-print(platform == 'darwin' and arch == 'arm64' and comp == 'llvm')

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -54,11 +54,8 @@ def compatible_platform_for_llvm():
     target_platform = chpl_platform.get('target')
 
     is32bit = target_platform == "linux32" or target_arch == "i368"
-    mac_arm = target_platform == 'darwin' and target_arch == 'arm64'
 
-    if is32bit or mac_arm:
-        return False
-    return True
+    return not is32bit
 
 # returns a string of the supported llvm versions suitable for error msgs
 def llvm_versions_string():


### PR DESCRIPTION
This PR resolves #19218 , which encountered an error believed to have been caused by LLVM on arm systems.

Testing:
- [ ] full local (LLVM)
- [ ] gasnet (LLVM)
- [ ] full local (gcc)

TODO:
- Should we enable this for the clang backend as well? I need to collect some proof that an ABI issue exists in that instance.
- Should we only do this on ARM for now?
- Open issue on LLVM repo with my reproducer