### PR TITLE
Removed extra space in job name argument

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -799,7 +799,7 @@ void chpl_launcher_get_job_name(char *baseName, char *jobName, int jobLen) {
     prefix = "CHPL-";
   }
   if (name == NULL) {
-    snprintf(jobName, jobLen, "%s%.10s ", prefix, baseName);
+    snprintf(jobName, jobLen, "%s%.10s", prefix, baseName);
   } else {
     strncpy(jobName, name, jobLen);
     jobName[jobLen-1] = '\0';


### PR DESCRIPTION
Removed an extra space in the job name argument to the launcher.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>