### PR TITLE
Add issue tracker test and jenkins job

### DIFF
--- a/test/studies/issuetracker/functions.bash
+++ b/test/studies/issuetracker/functions.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Helper functions for logging and marking test start/stop. Formats output in
+# the way the testing infrastructure expects.
+
+function subtest_start() {
+  subtest_start_time=$(date +%s)
+  echo "[Starting subtest - $(date)]"
+}
+
+function subtest_end() {
+  local subtest_end_time=$(date +%s)
+  local elapsed=$(( $subtest_end_time - $subtest_start_time ))
+  echo "[Finished subtest \"studies/champs\" - $elapsed seconds"
+}

--- a/test/studies/issuetracker/sub_test
+++ b/test/studies/issuetracker/sub_test
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Custom sub_test to run issue tracker.
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/functions.bash
+
+subtest_start
+
+cp -r /users/stonea/public_html/ghTracker/graphData/html $CHPL_TEST_PERF_DIR
+
+subtest_end

--- a/util/cron/common-issuetracker.bash
+++ b/util/cron/common-issuetracker.bash
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Configure environment for issue tracker
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+
+COMMON_DIR=/cray/css/users/chapelu
+if [ ! -d "$COMMON_DIR" ]; then
+  COMMON_DIR=/cy/users/chapelu
+fi
+
+# Perf configuration
+source $CWD/common-perf.bash
+ISSUETRACKER_PERF_DIR=${ISSUETRACKER_PERF_DIR:-$COMMON_DIR/NightlyPerformance/issuetracker}
+export CHPL_TEST_PERF_DIR=$ISSUETRACKER_PERF_DIR/$CHPL_TEST_PERF_CONFIG_NAME
+export CHPL_TEST_NUM_TRIALS=3
+export CHPL_TEST_PERF_START_DATE=10/15/21
+
+# Run issue tracker performance testing
+export CHPL_NIGHTLY_TEST_DIRS=studies/issuetracker/
+export CHPL_TEST_ISSUETRACKER=true
+export CHPL_TEST_ISSUETRACKER_PERF=true
+
+# test against Chapel nightly
+function test_nightly() {
+  export CHPL_TEST_PERF_DESCRIPTION=nightly
+  export CHPL_TEST_PERF_CONFIGS="release:v,nightly"
+  $CWD/nightly -cron ${nightly_args}
+}
+
+function sync_graphs() {
+  $CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/html/ issuetracker/$CHPL_TEST_PERF_CONFIG_NAME
+}

--- a/util/cron/test-perf.chapcs.issuetracker.bash
+++ b/util/cron/test-perf.chapcs.issuetracker.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Run issue tracker on chapcs
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.issuetracker"
+source $CWD/common-issuetracker.bash
+
+test_nightly
+sync_graphs


### PR DESCRIPTION
I have a nightly cron job I use to gather a count of how many Github issues we have under various queries. Using Chapel's `genGraph` tool I use this data to generate graphs that show how these counts have changed over time.

I'd like to get a nightly Jenkins job that manages all this for me and publishes the graphs similar to how we do for our nightly performance tests.

As a first step I want to set up the Jenkins job and just have it copy the generated webpage of graphs from my account. Once this is in place I can then go about trying to update the scripts so they don't rely on my account and then I can try and get everything to be handled by the testing system.

@ronawho -- would you mind taking a look?  I get paranoid about anything dealing with our testing infrastructure and want to make sure I'm not risking anything blow up on us with my call to `syncPerfGraphs`.  Do you know of an easy way to test these scripts (beyond just submitting it and running the corresponding Jenkins job?) Thanks!