### PR TITLE
Avoid a false positive warning from GCC 12

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -267,6 +267,13 @@ ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 9; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-error=init-list-lifetime
 endif
 
+#
+# Avoid false positive warnings about use-after free with realloc
+# that occur in GCC 12.
+#
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 12; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-use-after-free
+endif
 
 #
 # 2016/03/28: Help to protect the Chapel compiler from a partially


### PR DESCRIPTION
We see a warning in GCC 12 along these lines:

```
ErrorMessage.cpp: In function 'std::string chpl::vprint_to_string(const char*, __va_list_tag*)':
ErrorMessage.cpp:53:11: error: pointer 'buf' may be used after 'void* realloc(void*, size_t)' [-Werror=use-after-free]
   53 |       free(buf);
      |       ~~~~^~~~~
ErrorMessage.cpp:50:35: note: call to 'void* realloc(void*, size_t)' here
   50 |     char* newbuf = (char*) realloc(buf, size);
      |                            ~~~~~~~^~~~~~~~~~~
```

See also this GCC bug report:  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104069

Thanks to @PHHargrove for reporting the bug and suggesting a solution.

Reviewed by @ronawho - thanks!

- [x] compiler builds cleanly and `make check` passes with GCC 12
- [x] compiler builds cleanly and `make check` passes with GCC 11
- [x] compiler builds cleanly and `make check` passes with clang 13 on Mac OS X
- [x] full local testing