### PR TITLE
Improve error when cmake is missing

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -79,7 +79,7 @@ llvm-config: FORCE
 	@if ./cmake-ok.sh $(CMAKE); then \
 	  echo ; \
 	else \
-	  echo Error: LLVM requires cmake 3 to build; \
+	  echo Error: Chapel requires cmake 3 to build; \
 	  exit 1; \
 	fi
 	
@@ -117,7 +117,7 @@ llvm-config-support-only: FORCE
 	@if ./cmake-ok.sh $(CMAKE); then \
 	  echo ; \
 	else \
-	  echo Error: LLVM requires cmake 3 to build; \
+	  echo Error: Chapel requires cmake 3 to build; \
 	  exit 1; \
 	fi
 	


### PR DESCRIPTION
Adjust the error to indicate Chapel requires cmake, not just LLVM.

Reviewed by @daviditen - thanks!