### PR TITLE
Factor common code from dyno resolution tests

### DIFF
--- a/compiler/dyno/CMakeLists.txt
+++ b/compiler/dyno/CMakeLists.txt
@@ -97,20 +97,4 @@ add_subdirectory(util)
 # Needs to happen in this file for ctest to work in this dir
 enable_testing()
 
-add_custom_target(tests)
-
-# define a function to simplify adding tests
-function(comp_unit_test target)
-  add_executable(${target} "${target}.cpp")
-  set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL)
-  set_target_properties(${target}  PROPERTIES LINK_DEPENDS_NO_SHARED true)
-  target_link_libraries(${target} libdyno)
-  target_include_directories(${target} PUBLIC
-                             ${CHPL_MAIN_INCLUDE_DIR}
-                             ${CHPL_INCLUDE_DIR})
-  add_dependencies(${target} libdyno)
-  add_test(NAME ${target} COMMAND ${target})
-  add_dependencies(tests ${target})
-endfunction(comp_unit_test)
-
 add_subdirectory(test)

--- a/compiler/dyno/test/CMakeLists.txt
+++ b/compiler/dyno/test/CMakeLists.txt
@@ -15,6 +15,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# define target for the common code for all dyno tests
+add_library(tests-common OBJECT common.cpp)
+target_link_libraries(tests-common libdyno)
+
+add_custom_target(tests)
+set(CHPL_TEST_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+# define a function to simplify adding tests
+function(comp_unit_test target)
+  add_executable(${target} "${target}.cpp")
+  set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL)
+  set_target_properties(${target}  PROPERTIES LINK_DEPENDS_NO_SHARED true)
+  target_link_libraries(${target} libdyno tests-common)
+  target_include_directories(${target} PUBLIC
+                             ${CHPL_MAIN_INCLUDE_DIR}
+                             ${CHPL_INCLUDE_DIR}
+                             ${CHPL_TEST_INCLUDE_DIR})
+  add_dependencies(${target} libdyno)
+  add_test(NAME ${target} COMMAND ${target})
+  add_dependencies(tests ${target})
+endfunction(comp_unit_test)
+
 add_subdirectory(parsing)
 add_subdirectory(queries)
 add_subdirectory(resolution)

--- a/compiler/dyno/test/common.cpp
+++ b/compiler/dyno/test/common.cpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "common.h"
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"

--- a/compiler/dyno/test/common.cpp
+++ b/compiler/dyno/test/common.cpp
@@ -39,4 +39,39 @@ parseTypeOfXInit(Context* context, const char* program, bool requireTypeKnown) {
   return qt;
 }
 
+QualifiedType
+parseQualifiedTypeOfX(Context* context, const char* program) {
+  auto m = parseModule(context, program);
+  assert(m->numStmts() > 0);
+  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
+  assert(x);
+  assert(x->name() == "x");
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+  auto qt = rr.byAst(x).type();
+  assert(qt.type());
+
+  return qt;
+}
+
+const Type*
+parseTypeOfX(Context* context, const char* program) {
+  auto m = parseModule(context, program);
+  assert(m->numStmts() > 0);
+  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
+  assert(x);
+  assert(x->name() == "x");
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+  auto qt = rr.byAst(x).type();
+  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.type());
+
+  const Type* t = qt.type();
+  return t;
+}
+
+
 }

--- a/compiler/dyno/test/common.cpp
+++ b/compiler/dyno/test/common.cpp
@@ -22,8 +22,6 @@
 
 using namespace parsing;
 
-namespace impl {
-
 const Module* parseModule(Context* context, const char* src) {
   auto path = UniqueString::get(context, "input.chpl");
   std::string contents = src;
@@ -89,7 +87,4 @@ parseTypeOfX(Context* context, const char* program) {
 
   const Type* t = qt.type();
   return t;
-}
-
-
 }

--- a/compiler/dyno/test/common.cpp
+++ b/compiler/dyno/test/common.cpp
@@ -1,0 +1,42 @@
+#include "common.h"
+#include "chpl/parsing/parsing-queries.h"
+#include "chpl/resolution/resolution-queries.h"
+
+using namespace parsing;
+
+namespace impl {
+
+const Module* parseModule(Context* context, const char* src) {
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = src;
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+  assert(vec.size() == 1);
+
+  return vec[0];
+}
+
+const Module* parseModule(Context* context, std::string& str) {
+  return parseModule(context, str.c_str());
+}
+
+QualifiedType
+parseTypeOfXInit(Context* context, const char* program, bool requireTypeKnown) {
+  auto m = parseModule(context, program);
+  assert(m->numStmts() > 0);
+  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
+  assert(x);
+  assert(x->name() == "x");
+  auto initExpr = x->initExpression();
+  assert(initExpr);
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+  auto qt = rr.byAst(initExpr).type();
+  if (requireTypeKnown) assert(qt.type());
+
+  return qt;
+}
+
+}

--- a/compiler/dyno/test/common.cpp
+++ b/compiler/dyno/test/common.cpp
@@ -38,7 +38,7 @@ const Module* parseModule(Context* context, std::string& str) {
 }
 
 QualifiedType
-parseTypeOfXInit(Context* context, const char* program, bool requireTypeKnown) {
+resolveTypeOfXInit(Context* context, const char* program, bool requireTypeKnown) {
   auto m = parseModule(context, program);
   assert(m->numStmts() > 0);
   const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
@@ -56,7 +56,7 @@ parseTypeOfXInit(Context* context, const char* program, bool requireTypeKnown) {
 }
 
 QualifiedType
-parseQualifiedTypeOfX(Context* context, const char* program) {
+resolveQualifiedTypeOfX(Context* context, const char* program) {
   auto m = parseModule(context, program);
   assert(m->numStmts() > 0);
   const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
@@ -72,7 +72,7 @@ parseQualifiedTypeOfX(Context* context, const char* program) {
 }
 
 const Type*
-parseTypeOfX(Context* context, const char* program) {
+resolveTypeOfX(Context* context, const char* program) {
   auto m = parseModule(context, program);
   assert(m->numStmts() > 0);
   const Variable* x = m->stmt(m->numStmts()-1)->toVariable();

--- a/compiler/dyno/test/common.h
+++ b/compiler/dyno/test/common.h
@@ -35,13 +35,13 @@ const Module* parseModule(Context* context, std::string& str);
 // with an initialization expression.
 // Returns the type of the initializer expression.
 QualifiedType
-parseTypeOfXInit(Context* context, const char* program, bool requireTypeKnown = true);
+resolveTypeOfXInit(Context* context, const char* program, bool requireTypeKnown = true);
 
 QualifiedType
-parseQualifiedTypeOfX(Context* context, const char* program);
+resolveQualifiedTypeOfX(Context* context, const char* program);
 
 const Type*
-parseTypeOfX(Context* context, const char* program);
+resolveTypeOfX(Context* context, const char* program);
 
 // always check assertions in this test
 #ifdef NDEBUG

--- a/compiler/dyno/test/common.h
+++ b/compiler/dyno/test/common.h
@@ -39,6 +39,12 @@ const Module* parseModule(Context* context, std::string& str);
 QualifiedType
 parseTypeOfXInit(Context* context, const char* program, bool requireTypeKnown = true);
 
+QualifiedType
+parseQualifiedTypeOfX(Context* context, const char* program);
+
+const Type*
+parseTypeOfX(Context* context, const char* program);
+
 } // end namespace impl
 
 using namespace impl;

--- a/compiler/dyno/test/common.h
+++ b/compiler/dyno/test/common.h
@@ -22,8 +22,6 @@
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
 
-namespace impl {
-
 using namespace chpl;
 using namespace resolution;
 using namespace types;
@@ -44,10 +42,6 @@ parseQualifiedTypeOfX(Context* context, const char* program);
 
 const Type*
 parseTypeOfX(Context* context, const char* program);
-
-} // end namespace impl
-
-using namespace impl;
 
 // always check assertions in this test
 #ifdef NDEBUG

--- a/compiler/dyno/test/common.h
+++ b/compiler/dyno/test/common.h
@@ -16,51 +16,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#include "chpl/parsing/parsing-queries.h"
-#include "chpl/resolution/resolution-queries.h"
-#include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
+
+namespace impl {
+
+using namespace chpl;
+using namespace resolution;
+using namespace types;
+using namespace uast;
+
+// Get the top-level module resulting from parsing the given string.
+const Module* parseModule(Context* context, const char* src);
+const Module* parseModule(Context* context, std::string& str);
+
+// assumes the last statement is a variable declaration for x
+// with an initialization expression.
+// Returns the type of the initializer expression.
+QualifiedType
+parseTypeOfXInit(Context* context, const char* program, bool requireTypeKnown = true);
+
+} // end namespace impl
+
+using namespace impl;
 
 // always check assertions in this test
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
-
-static void test1() {
-  printf("test1\n");
-  Context ctx;
-  Context* context = &ctx;
-
-  auto qt = parseTypeOfXInit(context,
-                             R""""(
-                               record R {
-                                 var field: int;
-                               }
-                               var rec: R;
-                               var x = rec.field;
-                             )"""");
-
-  assert(qt.kind() == QualifiedType::REF);
-  assert(qt.type() == IntType::get(context, 0));
-}
-
-
-int main() {
-  test1();
-
-  return 0;
-}

--- a/compiler/dyno/test/resolution/testEnums.cpp
+++ b/compiler/dyno/test/resolution/testEnums.cpp
@@ -34,7 +34,7 @@
 static void test1() {
   Context ctx;
   auto context = &ctx;
-  QualifiedType qt =  parseTypeOfXInit(context,
+  QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          enum color {
                            red, green, blue
@@ -58,7 +58,7 @@ static void test1() {
 static void test2() {
   Context ctx;
   auto context = &ctx;
-  QualifiedType qt =  parseTypeOfXInit(context,
+  QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          enum color {
                            red, red, blue
@@ -73,7 +73,7 @@ static void test2() {
 static void test3() {
   Context ctx;
   auto context = &ctx;
-  QualifiedType qt =  parseTypeOfXInit(context,
+  QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          enum color {
                            green, blue

--- a/compiler/dyno/test/resolution/testEnums.cpp
+++ b/compiler/dyno/test/resolution/testEnums.cpp
@@ -24,52 +24,13 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
+#include "common.h"
 
 #include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
-
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
 
 // assumes the last statement is a variable declaration for x
 // with an initialization expression.
 // Returns the type of the initializer expression.
-static QualifiedType
-parseTypeOfXInit(Context* context, const char* program) {
-  auto m = parseModule(context, program);
-  assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
-  assert(x);
-  assert(x->name() == "x");
-  auto initExpr = x->initExpression();
-  assert(initExpr);
-
-  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
-
-  auto qt = rr.byAst(initExpr).type();
-  // assert(qt.type());
-
-  return qt;
-}
-
 static void test1() {
   Context ctx;
   auto context = &ctx;

--- a/compiler/dyno/test/resolution/testFieldAccess.cpp
+++ b/compiler/dyno/test/resolution/testFieldAccess.cpp
@@ -45,7 +45,7 @@ static void test1() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                              R""""(
                                record R {
                                  var field: int;

--- a/compiler/dyno/test/resolution/testLoopIndexVars.cpp
+++ b/compiler/dyno/test/resolution/testLoopIndexVars.cpp
@@ -29,6 +29,7 @@
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
 #include "chpl/uast/While.h"
+#include "common.h"
 
 
 // always check assertions in this test
@@ -64,21 +65,6 @@ static auto recIter = std::string(R""""(
 std::vector<ErrorMessage> errors;
 static void collectErrors(Context* context, const ErrorMessage& err) {
   errors.push_back(err);
-}
-
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
-
-static const Module* parseModule(Context* context, std::string& str) {
-  return parseModule(context, str.c_str());
 }
 
 struct ParamCollector {

--- a/compiler/dyno/test/resolution/testMultiDecl.cpp
+++ b/compiler/dyno/test/resolution/testMultiDecl.cpp
@@ -25,6 +25,7 @@
 #include "chpl/uast/MultiDecl.h"
 #include "chpl/uast/TupleDecl.h"
 #include "chpl/uast/Variable.h"
+#include "common.h"
 
 // always check assertions in this test
 #ifdef NDEBUG
@@ -38,17 +39,6 @@ using namespace parsing;
 using namespace resolution;
 using namespace types;
 using namespace uast;
-
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
 
 static void test1() {
   printf("test1\n");

--- a/compiler/dyno/test/resolution/testParamFolding.cpp
+++ b/compiler/dyno/test/resolution/testParamFolding.cpp
@@ -22,6 +22,7 @@
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
+#include "common.h"
 
 // always check assertions in this test
 #ifdef NDEBUG
@@ -42,37 +43,9 @@ static void reportError(Context* context, const ErrorMessage& err) {
   assert(false && "fatal error");
 }
 
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
-
 // assumes the last statement is a variable declaration for x
 // with an initialization expression.
 // Returns the type of the initializer expression.
-static QualifiedType
-parseTypeOfXInit(Context* context, const char* program) {
-  auto m = parseModule(context, program);
-  assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
-  assert(x);
-  assert(x->name() == "x");
-  auto initExpr = x->initExpression();
-  assert(initExpr);
-
-  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
-
-  auto qt = rr.byAst(initExpr).type();
-  assert(qt.type());
-
-  return qt;
-}
 
 static void test1() {
   Context ctx;

--- a/compiler/dyno/test/resolution/testParamFolding.cpp
+++ b/compiler/dyno/test/resolution/testParamFolding.cpp
@@ -54,7 +54,7 @@ static void test1() {
   // configure context to fail test if there are any errors
   context->setErrorHandler(reportError);
 
-  QualifiedType qt = parseTypeOfXInit(context, "var x = true || f();");
+  QualifiedType qt = resolveTypeOfXInit(context, "var x = true || f();");
   assert(qt.isParamTrue());
 }
 
@@ -65,7 +65,7 @@ static void test2() {
   // configure context to fail test if there are any errors
   context->setErrorHandler(reportError);
 
-  QualifiedType qt = parseTypeOfXInit(context, "var x = false && f();");
+  QualifiedType qt = resolveTypeOfXInit(context, "var x = false && f();");
   assert(qt.isParamFalse());
 }
 
@@ -78,7 +78,7 @@ static void test3() {
   // configure context to fail test if there are any errors
   context->setErrorHandler(reportError);
 
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                                       "var a: bool; var x = a || true;");
   assert(!qt.isParam() && !qt.hasParamPtr());
   assert(qt.type() == BoolType::get(context, 0));
@@ -92,7 +92,7 @@ static void test4() {
   context->setErrorHandler(reportError);
 
   // 2nd argument param should not be folded
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                                       "var a: bool; var x = a && false;");
   assert(!qt.isParam() && !qt.hasParamPtr());
   assert(qt.type() == BoolType::get(context, 0));
@@ -106,7 +106,7 @@ static void test5() {
   context->setErrorHandler(reportError);
 
   // both args are params, should make a param init expr
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                                       "var x = true && false;");
   assert(qt.isParamFalse());
 }
@@ -119,7 +119,7 @@ static void test6() {
   context->setErrorHandler(reportError);
 
   // both args are params, should make a param init expr
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                                       "var x = false || true;");
   assert(qt.isParamTrue());
 }
@@ -132,7 +132,7 @@ static void test7() {
   context->setErrorHandler(reportError);
 
   // both args are the (or) identity params, should make param false.
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                                       "var x = false || false;");
   assert(qt.isParamFalse());
 }
@@ -145,7 +145,7 @@ static void test8() {
   context->setErrorHandler(reportError);
 
   // both args are the (and) identity params, should make param true.
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                                       "var x = true && true;");
   assert(qt.isParamTrue());
 }
@@ -158,7 +158,7 @@ static void test9() {
   context->setErrorHandler(reportError);
 
   // the type of y is unknown, so the whole type is unknown.
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                                       "var x = true && y;");
   assert(qt.isUnknown());
 }
@@ -171,7 +171,7 @@ static void test10() {
   context->setErrorHandler(reportError);
 
   // the type of y is unknown, so the whole type is unknown.
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                                       "var x = false || y;");
   assert(qt.isUnknown());
 }

--- a/compiler/dyno/test/resolution/testProcThis.cpp
+++ b/compiler/dyno/test/resolution/testProcThis.cpp
@@ -50,7 +50,7 @@ static void test1() {
   // configure context to fail test if there are any errors
   context->setErrorHandler(reportError);
 
-  QualifiedType qt = parseTypeOfXInit(context,
+  QualifiedType qt = resolveTypeOfXInit(context,
                 R""""(
                   module M {
                     record R { }

--- a/compiler/dyno/test/resolution/testProcThis.cpp
+++ b/compiler/dyno/test/resolution/testProcThis.cpp
@@ -22,6 +22,7 @@
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
+#include "common.h"
 
 // always check assertions in this test
 #ifdef NDEBUG
@@ -40,38 +41,6 @@ using namespace uast;
 static void reportError(Context* context, const ErrorMessage& err) {
   printf("error encountered - %s\n", err.message().c_str());
   assert(false && "fatal error");
-}
-
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
-
-// assumes the last statement is a variable declaration for x
-// with an initialization expression.
-// Returns the type of the initializer expression.
-static QualifiedType
-parseTypeOfXInit(Context* context, const char* program) {
-  auto m = parseModule(context, program);
-  assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
-  assert(x);
-  assert(x->name() == "x");
-  auto initExpr = x->initExpression();
-  assert(initExpr);
-
-  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
-
-  auto qt = rr.byAst(initExpr).type();
-  assert(qt.type());
-
-  return qt;
 }
 
 static void test1() {

--- a/compiler/dyno/test/resolution/testTuples.cpp
+++ b/compiler/dyno/test/resolution/testTuples.cpp
@@ -44,22 +44,6 @@ using namespace uast;
 
 // assumes the last statement is a variable declaration for x.
 // returns the type of that.
-static QualifiedType
-parseTypeOfX(Context* context, const char* program) {
-  auto m = parseModule(context, program);
-  assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
-  assert(x);
-  assert(x->name() == "x");
-
-  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
-
-  auto qt = rr.byAst(x).type();
-  assert(qt.type());
-
-  return qt;
-}
-
 static void test1() {
   printf("test1\n");
   Context ctx;
@@ -170,7 +154,7 @@ static void test5() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfX(context,
+  auto qt = parseQualifiedTypeOfX(context,
                 R""""(
                   record R { }
                   var r: R;
@@ -466,7 +450,7 @@ static void test16() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfX(context,
+  auto qt = parseQualifiedTypeOfX(context,
                 R""""(
                   proc helper(a: int, b: real) { return b; }
                   var tup = (1, 2.0);

--- a/compiler/dyno/test/resolution/testTuples.cpp
+++ b/compiler/dyno/test/resolution/testTuples.cpp
@@ -49,7 +49,7 @@ static void test1() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   var x = (1, 2);
                 )"""");
@@ -75,7 +75,7 @@ static void test2() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   type x = (int, real);
                 )"""");
@@ -97,7 +97,7 @@ static void test3() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { }
                   var r: R;
@@ -128,7 +128,7 @@ static void test4() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { }
                   type x = (R, R);
@@ -154,7 +154,7 @@ static void test5() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseQualifiedTypeOfX(context,
+  auto qt = resolveQualifiedTypeOfX(context,
                 R""""(
                   record R { }
                   var r: R;
@@ -181,7 +181,7 @@ static void test6() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { }
                   proc f() {
@@ -205,7 +205,7 @@ static void test7() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { }
                   var r: R;
@@ -230,7 +230,7 @@ static void test8() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { }
                   proc f() : (R, R) {
@@ -322,7 +322,7 @@ static void test11() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   proc f(in arg: (real, real)) { return arg; }
                   var x = f( (1,2) );
@@ -344,7 +344,7 @@ static void test12() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { }
                   proc f(in arg: (R, R)) { return arg; }
@@ -374,7 +374,7 @@ static void test13() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { param p; }
                   proc f(in arg: (R, R)) { return arg; }
@@ -406,7 +406,7 @@ static void test14() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   proc f(x: int, (y, z): (real, int)) { return (x, y, z); }
                   var x = f( 1, (2.0, 3) );
@@ -428,7 +428,7 @@ static void test15() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseTypeOfXInit(context,
+  auto qt = resolveTypeOfXInit(context,
                 R""""(
                   var tup = (1, 2);
                   var x = ( (... tup), 3.0);
@@ -450,7 +450,7 @@ static void test16() {
   Context ctx;
   Context* context = &ctx;
 
-  auto qt = parseQualifiedTypeOfX(context,
+  auto qt = resolveQualifiedTypeOfX(context,
                 R""""(
                   proc helper(a: int, b: real) { return b; }
                   var tup = (1, 2.0);

--- a/compiler/dyno/test/resolution/testTuples.cpp
+++ b/compiler/dyno/test/resolution/testTuples.cpp
@@ -26,6 +26,7 @@
 #include "chpl/uast/Record.h"
 #include "chpl/uast/TupleDecl.h"
 #include "chpl/uast/Variable.h"
+#include "common.h"
 
 // always check assertions in this test
 #ifdef NDEBUG
@@ -39,38 +40,6 @@ using namespace parsing;
 using namespace resolution;
 using namespace types;
 using namespace uast;
-
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
-
-// assumes the last statement is a variable declaration for x
-// with an initialization expression.
-// Returns the type of the initializer expression.
-static QualifiedType
-parseTypeOfXInit(Context* context, const char* program) {
-  auto m = parseModule(context, program);
-  assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
-  assert(x);
-  assert(x->name() == "x");
-  auto initExpr = x->initExpression();
-  assert(initExpr);
-
-  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
-
-  auto qt = rr.byAst(initExpr).type();
-  assert(qt.type());
-
-  return qt;
-}
 
 
 // assumes the last statement is a variable declaration for x.

--- a/compiler/dyno/test/resolution/testTypeAndInit.cpp
+++ b/compiler/dyno/test/resolution/testTypeAndInit.cpp
@@ -25,6 +25,7 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
+#include "common.h"
 
 // always check assertions in this test
 #ifdef NDEBUG
@@ -38,17 +39,6 @@ using namespace parsing;
 using namespace resolution;
 using namespace types;
 using namespace uast;
-
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
 
 // assumes the last statement is a variable declaration for x
 // with an initialization expression.

--- a/compiler/dyno/test/resolution/testTypeAndInit.cpp
+++ b/compiler/dyno/test/resolution/testTypeAndInit.cpp
@@ -40,29 +40,10 @@ using namespace resolution;
 using namespace types;
 using namespace uast;
 
-// assumes the last statement is a variable declaration for x
-// with an initialization expression.
-// Returns the type of the initializer expression.
-static QualifiedType
-parseTypeOfX(Context* context, const char* program) {
-  auto m = parseModule(context, program);
-  assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
-  assert(x);
-  assert(x->name() == "x");
-
-  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
-
-  auto qt = rr.byAst(x).type();
-  assert(qt.type());
-
-  return qt;
-}
-
 void test1() {
   Context ctx;
   auto context = &ctx;
-  auto qt = parseTypeOfX(context,
+  auto qt = parseQualifiedTypeOfX(context,
                              R""""(
                                var x: bool = true;
                              )"""");

--- a/compiler/dyno/test/resolution/testTypeAndInit.cpp
+++ b/compiler/dyno/test/resolution/testTypeAndInit.cpp
@@ -43,7 +43,7 @@ using namespace uast;
 void test1() {
   Context ctx;
   auto context = &ctx;
-  auto qt = parseQualifiedTypeOfX(context,
+  auto qt = resolveQualifiedTypeOfX(context,
                              R""""(
                                var x: bool = true;
                              )"""");

--- a/compiler/dyno/test/resolution/testTypeConstruction.cpp
+++ b/compiler/dyno/test/resolution/testTypeConstruction.cpp
@@ -25,6 +25,7 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
+#include "common.h"
 
 // always check assertions in this test
 #ifdef NDEBUG
@@ -38,17 +39,6 @@ using namespace parsing;
 using namespace resolution;
 using namespace types;
 using namespace uast;
-
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
 
 static void test1() {
   printf("test1\n");

--- a/compiler/dyno/test/resolution/testTypeConstruction.cpp
+++ b/compiler/dyno/test/resolution/testTypeConstruction.cpp
@@ -197,7 +197,7 @@ static void test3() {
 // assumes the last statement is a variable declaration for x.
 // returns the type of that.
 static std::pair<const Type*, const ResolvedFields*>
-parseTypeOfX(Context* context, const char* program) {
+parseTypeAndFieldsOfX(Context* context, const char* program) {
   auto m = parseModule(context, program);
   assert(m->numStmts() > 0);
   const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
@@ -229,7 +229,7 @@ static void test4a() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { var field: int; }\n"
                                  "var x: R;\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -248,7 +248,7 @@ static void test4b() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { var field; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { var field; }\n"
                                  "var x: R(int);\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -267,7 +267,7 @@ static void test5() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { type t; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { type t; }\n"
                                  "var x: R(int);\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -298,7 +298,7 @@ static void test6() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { param p; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { param p; }\n"
                                  "var x: R(1);\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -318,7 +318,7 @@ static void test7() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { type t = int; }\n"
                                  "var x: R(real);\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -337,7 +337,7 @@ static void test8() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { type t = int; }\n"
                                  "var x: R;\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -356,7 +356,7 @@ static void test9() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { param p = 1; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { param p = 1; }\n"
                                  "var x: R(2);\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -376,7 +376,7 @@ static void test10() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { param p = 1; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { param p = 1; }\n"
                                  "var x: R;\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -396,7 +396,7 @@ static void test11() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { type t = int; }\n"
                                  "var x: R();\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -415,7 +415,7 @@ static void test12() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { type t = int; }\n"
                                  "var x: R(?);\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -434,7 +434,7 @@ static void test13() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { param p = 1; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { param p = 1; }\n"
                                  "var x: R();\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -453,7 +453,7 @@ static void test14() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "record R { param p = 1; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "record R { param p = 1; }\n"
                                  "var x: R(?);\n");
   auto rt = p.first->toRecordType();
   assert(rt);
@@ -473,7 +473,7 @@ static void test15() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: C;\n");
 
   auto ct = p.first->toClassType();
@@ -498,7 +498,7 @@ static void test16() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: C?;\n");
 
   auto ct = p.first->toClassType();
@@ -524,7 +524,7 @@ static void test17() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: borrowed C;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -548,7 +548,7 @@ static void test18() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: borrowed C?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -572,7 +572,7 @@ static void test19() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: unmanaged C;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -596,7 +596,7 @@ static void test20() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: unmanaged C?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -620,7 +620,7 @@ static void test21() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: owned C;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -644,7 +644,7 @@ static void test22() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: owned C?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -668,7 +668,7 @@ static void test23() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: shared C;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -692,7 +692,7 @@ static void test23q() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field: int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: shared C?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -716,7 +716,7 @@ static void test24() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field; }\n"
                                  "var x: C(int);\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -740,7 +740,7 @@ static void test25() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field; }\n"
                                  "var x: C(int)?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -764,7 +764,7 @@ static void test26() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { var field; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { var field; }\n"
                                  "var x: borrowed C(int)?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -788,7 +788,7 @@ static void test27() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { type t; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { type t; }\n"
                                  "var x: owned C(int)?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -812,7 +812,7 @@ static void test28() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: C;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -836,7 +836,7 @@ static void test29() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: C();\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -860,7 +860,7 @@ static void test30() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: borrowed C?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -884,7 +884,7 @@ static void test31() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: borrowed C()?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -908,7 +908,7 @@ static void test32() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: shared C(real)?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -932,7 +932,7 @@ static void test33() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: C(real)?;\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -956,7 +956,7 @@ static void test34() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context, "class C { type t = int; }\n"
+  auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: unmanaged C(real);\n");
   auto ct = p.first->toClassType();
   assert(ct);
@@ -1030,7 +1030,7 @@ static void test35() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context,
+  auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                           record R {
                             var a = 1;
@@ -1079,7 +1079,7 @@ static void test36() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context,
+  auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                           class ClassA {
                             var field: object;
@@ -1112,7 +1112,7 @@ static void test37() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context,
+  auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                           class ClassA {
                             var x: int;
@@ -1148,7 +1148,7 @@ static void test38() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context,
+  auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                           class Parent {
                             var parentField:int;
@@ -1196,7 +1196,7 @@ static void test39() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context,
+  auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                           class C {
                             var next: owned C;
@@ -1226,7 +1226,7 @@ static void test40() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context,
+  auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                           proc useType(type t) {
                             var ret: t;
@@ -1250,7 +1250,7 @@ static void test41() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context,
+  auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                           proc useType(type t) {
                             var ret: t;
@@ -1282,7 +1282,7 @@ static void test42() {
   Context ctx;
   Context* context = &ctx;
 
-  auto p = parseTypeOfX(context,
+  auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                           proc useType(type t) {
                             var ret: t(1);

--- a/compiler/dyno/test/resolution/testTypeQueries.cpp
+++ b/compiler/dyno/test/resolution/testTypeQueries.cpp
@@ -46,7 +46,7 @@ static void test1() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t1 = parseTypeOfX(context,
+  auto t1 = resolveTypeOfX(context,
                 R""""(
                   proc f(arg: ?) { return arg; }
                   var x = f(1);
@@ -54,7 +54,7 @@ static void test1() {
 
   assert(t1 && t1->isIntType());
 
-  auto t2 = parseTypeOfX(context,
+  auto t2 = resolveTypeOfX(context,
                 R""""(
                   proc f(arg: ?) { var ret: arg.type; return ret; }
                   var x = f(1);
@@ -62,7 +62,7 @@ static void test1() {
 
   assert(t2 && t2->isIntType());
 
-  auto t3 = parseTypeOfX(context,
+  auto t3 = resolveTypeOfX(context,
                 R""""(
                   proc f(arg: ?t) { var ret: arg.type; return ret; }
                   var x = f(1);
@@ -70,7 +70,7 @@ static void test1() {
 
   assert(t3 && t3->isIntType());
 
-  auto t4 = parseTypeOfX(context,
+  auto t4 = resolveTypeOfX(context,
                 R""""(
                   proc f(arg: ?t) { var ret: t; return ret; }
                   var x = f(1);
@@ -84,7 +84,7 @@ static void test2() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   record R { type tt; }
                   proc f(arg: ?) { return arg; }
@@ -105,7 +105,7 @@ static void test3() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   record R { type tt; }
                   proc f(arg: R(?)) { return arg; }
@@ -126,7 +126,7 @@ static void test4() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   record R { type tt; }
                   proc f(arg: R(?t)) { return arg; }
@@ -147,7 +147,7 @@ static void test5() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   record R { type tt; }
                   proc f(arg: R(?t)) { var ret: t; return ret; }
@@ -163,7 +163,7 @@ static void test6() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   record RR { type ttt; }
                   record R { type tt; }
@@ -180,7 +180,7 @@ static void test7() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   proc f(arg: int(?)) { return arg; }
                   var a: int(8);
@@ -197,7 +197,7 @@ static void test8() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   proc f(arg: int(?w)) { return arg; }
                   var a: int(8);
@@ -214,7 +214,7 @@ static void test9() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   proc f(arg: int(?w)) {
                     var y: uint(w);
@@ -293,7 +293,7 @@ static void test11() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t = parseTypeOfX(context,
+  auto t = resolveTypeOfX(context,
                 R""""(
                   proc g(a: int(?w), b: int(__primitive("*", 2, w))) {
                     return b;

--- a/compiler/dyno/test/resolution/testTypeQueries.cpp
+++ b/compiler/dyno/test/resolution/testTypeQueries.cpp
@@ -26,6 +26,7 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
+#include "common.h"
 
 // always check assertions in this test
 #ifdef NDEBUG
@@ -39,17 +40,6 @@ using namespace parsing;
 using namespace resolution;
 using namespace types;
 using namespace uast;
-
-static const Module* parseModule(Context* context, const char* src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
 
 // assumes the last statement is a variable declaration for x.
 // returns the type of that.

--- a/compiler/dyno/test/resolution/testTypeQueries.cpp
+++ b/compiler/dyno/test/resolution/testTypeQueries.cpp
@@ -41,26 +41,6 @@ using namespace resolution;
 using namespace types;
 using namespace uast;
 
-// assumes the last statement is a variable declaration for x.
-// returns the type of that.
-static const Type*
-parseTypeOfX(Context* context, const char* program) {
-  auto m = parseModule(context, program);
-  assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
-  assert(x);
-  assert(x->name() == "x");
-
-  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
-
-  auto qt = rr.byAst(x).type();
-  assert(qt.kind() == QualifiedType::VAR);
-  assert(qt.type());
-
-  const Type* t = qt.type();
-  return t;
-}
-
 static void test1() {
   printf("test1\n");
   Context ctx;


### PR DESCRIPTION
A lot of the dyno resolution tests use the same common functions, such as `parseModule`. However, each test file includes its own copy of these functions, which leads to a lot of duplication, and introduces the possibility of these functions going out of sync. If possible, we'd like to avoid this.

This PR introduces a new library target / object file that contains common functions intended to be shared among all dyno tests. This new library is linked with all tests, and thus allows them to share common code. Here's a summary of the changes:

1. The CMake function `comp_unit_test` is pushed into `dyno/tests/CMakeLists.txt` from `dyno/CMakeLists.txt`. It seemed cleaner to introduce the new "common test code" library in `dyno/tests`, and then refer to it in the same place from inside `comp_unit_test`. The existing `tests` target is also pushed to the subdirectory.
2. The `parseModule`, `parseTypeOfX` and `parseTypeOfXInit` functions are moved into new `common.{h, cpp}` files. The `parseTypeOfX` function is different across some tests (which seems to me like a good reason to have a "canonical" place for these things); the two versions are renamed to `parseTypeOfX` (version returning `Type*`) and `parseQualifiedTypeOfX` (version returning `QualifiedType`). 