### PR TITLE
Fixing HDF5 tests broken by sys deprecation

### DIFF
--- a/test/execflags/jhh/job_name.chpl
+++ b/test/execflags/jhh/job_name.chpl
@@ -1,4 +1,4 @@
-use Sys;
+use Subprocess;
 
 var value_str:c_string;
 var value:string;

--- a/test/execflags/jhh/job_name.good
+++ b/test/execflags/jhh/job_name.good
@@ -1,0 +1,2 @@
+*** Please update job_name.prediff for launcher 'none'
+<command-line arg>:1: error: Unexpected flag:  "--dry-run"

--- a/test/execflags/jhh/job_name.good
+++ b/test/execflags/jhh/job_name.good
@@ -1,2 +1,0 @@
-*** Please update job_name.prediff for launcher 'none'
-<command-line arg>:1: error: Unexpected flag:  "--dry-run"

--- a/test/execflags/jhh/job_prefix.chpl
+++ b/test/execflags/jhh/job_prefix.chpl
@@ -1,4 +1,4 @@
-use Sys;
+use Subprocess;
 
 writeln("job_prefix starting");
 var value_str:c_string;

--- a/test/library/packages/HDF5/Hdf5PathHelp.chpl
+++ b/test/library/packages/HDF5/Hdf5PathHelp.chpl
@@ -3,7 +3,7 @@ const pathPrefixEnvName = c"CHPL_HDF5_FILE_PREFIX";
 // The prefix read from the environment variable will be added
 // to the path for HDF5 files. Make sure to include the trailing slash!
 proc readPrefixEnv() {
-  use Sys;
+  use Subprocess;
   var prefix: c_string;
   if sys_getenv(pathPrefixEnvName, prefix) {
     return createStringWithNewBuffer(prefix);

--- a/test/library/packages/HDFS/tzakian/HDFSiterator.chpl
+++ b/test/library/packages/HDFS/tzakian/HDFSiterator.chpl
@@ -34,11 +34,12 @@
 
  */
 
-use Sys, 
-    HDFS,
+use HDFS,
     HDFStools, 
     ReplicatedVar,
     BlockDist;
+
+use OS.POSIX;
 
 // ============== Serial iterator ========================
 iter HDFSmap(dataFile: string, namenode: string = "default", port: int(32) = 0) {
@@ -271,12 +272,3 @@ iter HDFSmap(param tag: iterKind, dataFile: string, namenode: string = "default"
  -- Always holds
 
  */
-
-
-
-
-
-
-
-
-

--- a/test/library/packages/HDFS/tzakian/chadoop.chpl
+++ b/test/library/packages/HDFS/tzakian/chadoop.chpl
@@ -42,7 +42,8 @@
 
 
  */
-use Sys, HDFS, HDFStools;
+use HDFS, HDFStools;
+use OS.POSIX;
 // Second col is for running on a cluster
 config const namenode = "default";//"sealcs01"; 
 var connectNumber: c_int = 0; // 54310
@@ -221,5 +222,3 @@ sync coforall loc in Locales { // look at this more
 
   } // on
 } // for each locale
-
-

--- a/test/library/packages/HDFS/tzakian/test.chpl
+++ b/test/library/packages/HDFS/tzakian/test.chpl
@@ -1,4 +1,5 @@
-use HDFS, Sys, HDFStools, IO;
+use HDFS, HDFStools, IO;
+use OS.POSIX;
 
 bar("default");
 
@@ -25,5 +26,3 @@ proc bar(nm: string) {
   writer.close();
   outfile.close();
 }
-
-


### PR DESCRIPTION
Removed sys imports from HDF5 and HDFS tests that were not run during initial paratest for sys-deprecation

Signed-off-by: Jeremiah Corrado <jeremiah.corrado@hpe.com>