### PR TITLE
dyno: copy some default and const intents from production compiler

### DIFF
--- a/compiler/dyno/lib/resolution/intents.cpp
+++ b/compiler/dyno/lib/resolution/intents.cpp
@@ -37,7 +37,10 @@ static QualifiedType::Kind constIntentForType(const Type* t) {
   if (t == nullptr || t->isUnknownType() || t->isErroneousType())
     return QualifiedType::UNKNOWN;
 
-  if (t->isPrimitiveType())
+  if (t->isPrimitiveType() || t->isEnumType() || t->isOpaqueType() ||
+      t->isTaskIdType() || t->isCFileType() || t->isNilType() ||
+      t->isCStringType() || t->isCVoidPtrType() || t->isCFnPtrType() ||
+      t->isNothingType() || t->isVoidType())
     return QualifiedType::CONST_IN;
 
   if (t->isStringType() || t->isBytesType() ||
@@ -65,7 +68,10 @@ static QualifiedType::Kind defaultIntentForType(const Type* t) {
   if (t == nullptr || t->isUnknownType() || t->isErroneousType())
     return QualifiedType::UNKNOWN;
 
-  if (t->isPrimitiveType() || t->isEnumType())
+  if (t->isPrimitiveType() || t->isEnumType() || t->isOpaqueType() ||
+      t->isTaskIdType() || t->isCFileType() || t->isNilType() ||
+      t->isCStringType() || t->isCVoidPtrType() || t->isCFnPtrType() ||
+      t->isNothingType() || t->isVoidType())
     return QualifiedType::CONST_IN;
 
   if (t->isStringType() || t->isBytesType() ||


### PR DESCRIPTION
The production compiler specifies default intents for a lot
of the built-in types. However, Dyno does not yet know how
to handle intents for these types. This results in assertion
errors whenever a function is called that uses any such built-in
types.

For the following test program:

    proc test(s: c_string) {}
    test("hello".c_str());

Currently, the compiler reports an assertion error:

    Assertion failed: (t->genericity() != Type::CONCRETE)

With this change, however, the call is correctly resolved.

Not all rules from the production compiler are copied in this PR; in particular, I'm not sure how to translate `FLAG_RANGE` (and other flags), as well as other production-compiler-specific things. However, this is an improvement over the current state.

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>