### PR TITLE
Change TOML to use shared instead of unmanaged

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -85,7 +85,7 @@ Use the following code in chapel.
   a non-deterministic manner.
 
 */
-proc parseToml(input: file) : unmanaged Toml {
+proc parseToml(input: file) : shared Toml {
   var tomlStr: string;
   var tomlFile = input.reader();
   tomlFile.readstring(tomlStr);
@@ -95,17 +95,17 @@ proc parseToml(input: file) : unmanaged Toml {
 
 /* Receives a channel to a TOML file as a parameter and outputs a Toml object.
 */
-proc parseToml(input: channel) : unmanaged Toml {
+proc parseToml(input: channel) : shared Toml {
   var tomlStr: string;
   input.readstring(tomlStr);
   return parseToml(tomlStr);
 }
 
  /* Receives a string of TOML format as a parameter and outputs a Toml object */
-proc parseToml(input: string) : unmanaged Toml {
+proc parseToml(input: string) : shared Toml {
   var D: domain(string);
-  var table: [D] unmanaged Toml?;
-  var rootTable = new unmanaged Toml(table);
+  var table: [D] shared Toml?;
+  var rootTable = new shared Toml(table);
   const source = new unmanaged Source(input);
   const parser = new unmanaged Parser(source, rootTable);
   const tomlData = parser.parseLoop();
@@ -150,7 +150,7 @@ module TomlParser {
   class Parser {
 
     var source: Source;
-    var rootTable: unmanaged Toml;
+    var rootTable: shared Toml;
     var curTable: string;
 
     const doubleQuotes = '".*?"',
@@ -174,7 +174,7 @@ module TomlParser {
 
     var debugCounter = 1;
 
-    proc parseLoop() : unmanaged Toml throws {
+    proc parseLoop() : shared Toml throws {
       try! {
 
         if !source.isEmpty() {
@@ -216,7 +216,7 @@ module TomlParser {
       var toke = getToken(source);
       var tablename = brackets.sub('', toke);
       var tblD: domain(string);
-      var tbl: [tblD] unmanaged Toml?;
+      var tbl: [tblD] shared Toml?;
       if !rootTable.pathExists(tablename) {
         rootTable.set(tablename, tbl);
       }
@@ -228,7 +228,7 @@ module TomlParser {
       var tblname = getToken(source);
       skipNext(source);
       var tblD: domain(string);
-      var tbl: [tblD] unmanaged Toml?;
+      var tbl: [tblD] shared Toml?;
       var (tblPath, tblLeaf) = splitTblPath(tblname);
       if !rootTable.pathExists(tblPath) then makePath(tblPath);
       rootTable[tblPath]!.set(tblLeaf, tbl);
@@ -244,13 +244,13 @@ module TomlParser {
       for parent in path {
         if first {
           var tblD: domain(string);
-          var tbl: [tblD] unmanaged Toml?;
+          var tbl: [tblD] shared Toml?;
           rootTable.set(parent, tbl);
           first = false;
         }
         else {
           var tblD: domain(string);
-          var tbl: [tblD] unmanaged Toml?;
+          var tbl: [tblD] shared Toml?;
           var grandParent = '.'.join(path[..firstIn+i]);
           rootTable[grandParent]!.set(parent, tbl);
           i+=1;
@@ -261,7 +261,7 @@ module TomlParser {
     proc parseInlineTbl(key: string) {
       var tblname: string;
       var tblD: domain(string);
-      var tbl: [tblD] unmanaged Toml?;
+      var tbl: [tblD] shared Toml?;
       if curTable.isEmpty() {
         tblname = key;
         rootTable.set(key, tbl);
@@ -318,14 +318,14 @@ module TomlParser {
     }
 
     /* Creates and returns a Toml parsed from tokens into respective type */
-    proc parseValue(): unmanaged Toml throws {
+    proc parseValue(): shared Toml throws {
       var val: string;
       try! {
         val = top(source);
         // Array
         if val == '['  {
           skipNext(source);
-          var array: list(unmanaged Toml);
+          var array: list(shared Toml);
           while top(source) != ']' {
             if comma.match(top(source)) {
               skipNext(source);
@@ -339,7 +339,7 @@ module TomlParser {
             }
           }
           skipNext(source);
-          return new unmanaged Toml(array);
+          return new shared Toml(array);
         }
         // Strings (includes multi-line)
         else if Str.match(val) {
@@ -349,24 +349,24 @@ module TomlParser {
             while toStr.endsWith('"""') == false {
               toStr += " " + getToken(source);
             }
-            return new unmanaged Toml(toStr.strip('"""'));
+            return new shared Toml(toStr.strip('"""'));
           }
           else if val.startsWith("'''") {
             toStr += getToken(source).strip("'''", true, false);
             while toStr.endsWith("'''") == false {
               toStr += " " + getToken(source);
             }
-            return new unmanaged Toml(toStr.strip("'''"));
+            return new shared Toml(toStr.strip("'''"));
           }
           else {
             toStr = getToken(source).strip('"').strip("'");
-            return new unmanaged Toml(toStr);
+            return new shared Toml(toStr);
           }
         }
         // DateTime
         else if dt.match(val) {
           var date = datetime.strptime(getToken(source), "%Y-%m-%dT%H:%M:%SZ");
-          return new unmanaged Toml(date);
+          return new shared Toml(date);
         }
         // Date
         else if ld.match(val) {
@@ -374,7 +374,7 @@ module TomlParser {
           var d = new date(raw[0]: int,
                            raw[1]: int,
                            raw[2]: int);
-          return new unmanaged Toml(d);
+          return new shared Toml(d);
         }
         // Time
         else if ti.match(val) {
@@ -388,25 +388,25 @@ module TomlParser {
                        sec[0]: int,
                        sec[1]: int);
 
-          return new unmanaged Toml(t);
+          return new shared Toml(t);
         }
         // Real
         else if realNum.match(val) {
          var token = getToken(source);
          var toReal = token: real;
-         return new unmanaged Toml(toReal);
+         return new shared Toml(toReal);
         }
         // Int
         else if ints.match(val) {
           var token = getToken(source);
           var toInt = token: int;
-          return new unmanaged Toml(toInt);
+          return new shared Toml(toInt);
         }
         // Boolean
         else if val == "true" || val ==  "false" {
           var token = getToken(source);
           var toBool = token: bool;
-          return new unmanaged Toml(toBool);
+          return new shared Toml(toBool);
         }
         // Comments within arrays
         else if val == '#' {
@@ -423,7 +423,7 @@ module TomlParser {
         // Error
         else {
           throw new owned TomlError("Line "+ debugCounter:string +": Unexpected Token -> " + getToken(source));
-          return new unmanaged Toml(val);
+          return new shared Toml(val);
         }
       }
       catch e: IllegalArgumentError {
@@ -464,10 +464,10 @@ pragma "no doc"
  private use fieldtag;
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml, s: string) {
+ operator Toml.=(ref t: shared Toml, s: string) {
    compilerWarning("= overloads for Toml are deprecated");
    if t == nil {
-     t = new unmanaged Toml(s);
+     t = new shared Toml(s);
    } else {
      t.tag = fieldString;
      t.s = s;
@@ -475,10 +475,10 @@ pragma "no doc"
  }
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml, i: int) {
+ operator Toml.=(ref t: shared Toml, i: int) {
    compilerWarning("= overloads for Toml are deprecated");
    if t == nil {
-     t = new unmanaged Toml(i);
+     t = new shared Toml(i);
    } else {
      t.tag = fieldInt;
      t.i = i;
@@ -486,10 +486,10 @@ pragma "no doc"
  }
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml, b: bool) {
+ operator Toml.=(ref t: shared Toml, b: bool) {
    compilerWarning("= overloads for Toml are deprecated");
    if t == nil {
-     t = new unmanaged Toml(b);
+     t = new shared Toml(b);
    } else {
      t.tag = fieldBool;
      t.boo = b;
@@ -497,10 +497,10 @@ pragma "no doc"
  }
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml, r: real) {
+ operator Toml.=(ref t: shared Toml, r: real) {
    compilerWarning("= overloads for Toml are deprecated");
    if t == nil {
-     t = new unmanaged Toml(r);
+     t = new shared Toml(r);
    } else {
      t.tag = fieldReal;
      t.re = r;
@@ -508,10 +508,10 @@ pragma "no doc"
  }
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml, ld: date) {
+ operator Toml.=(ref t: shared Toml, ld: date) {
    compilerWarning("= overloads for Toml are deprecated");
    if t == nil {
-     t = new unmanaged Toml(ld);
+     t = new shared Toml(ld);
    } else {
      t.tag = fieldDate;
      t.ld = ld;
@@ -519,10 +519,10 @@ pragma "no doc"
  }
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml, ti: time) {
+ operator Toml.=(ref t: shared Toml, ti: time) {
    compilerWarning("= overloads for Toml are deprecated");
    if t == nil {
-     t = new unmanaged Toml(ti);
+     t = new shared Toml(ti);
    } else {
      t.tag = fieldTime;
      t.ti = ti;
@@ -530,10 +530,10 @@ pragma "no doc"
  }
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml, dt: datetime) {
+ operator Toml.=(ref t: shared Toml, dt: datetime) {
    compilerWarning("= overloads for Toml are deprecated");
    if t == nil {
-     t = new unmanaged Toml(dt);
+     t = new shared Toml(dt);
    } else {
      t.tag = fieldDateTime;
      t.dt = dt;
@@ -541,15 +541,15 @@ pragma "no doc"
  }
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml,
-                 A: [?D] unmanaged Toml) where D.isAssociative() {
+ operator Toml.=(ref t: shared Toml,
+                 A: [?D] shared Toml) where D.isAssociative() {
    compilerWarning("= overloads for Toml are deprecated");
    setupToml(t, A);
  }
  pragma "no doc"
- proc setupToml(ref t: unmanaged Toml, A: [?D] unmanaged Toml) where D.isAssociative() {
+ proc setupToml(ref t: shared Toml, A: [?D] shared Toml) where D.isAssociative() {
    if t == nil {
-     t = new unmanaged Toml(A);
+     t = new shared Toml(A);
    } else {
      t.tag = fieldToml;
      t.D = D;
@@ -558,9 +558,9 @@ pragma "no doc"
  }
 
  pragma "no doc"
- proc setupToml(ref t: unmanaged Toml, arr: [?dom] unmanaged Toml) where !dom.isAssociative(){
+ proc setupToml(ref t: shared Toml, arr: [?dom] shared Toml) where !dom.isAssociative(){
    if t == nil {
-     t = new unmanaged Toml(arr);
+     t = new shared Toml(arr);
    } else {
      t.tag = fieldArr;
      t.dom = dom;
@@ -570,7 +570,7 @@ pragma "no doc"
 
 
  pragma "no doc"
- operator Toml.=(ref t: unmanaged Toml, arr: [?dom] unmanaged Toml) where !dom.isAssociative(){
+ operator Toml.=(ref t: shared Toml, arr: [?dom] shared Toml) where !dom.isAssociative(){
    compilerWarning("= overloads for Toml are deprecated");
    setupToml(t, arr);
  }
@@ -591,8 +591,8 @@ used to recursively hold tables and respective values
       ti: time,
       dt: datetime,
       dom: domain(1),
-      arr: [dom] unmanaged Toml?,
-      A: map(string, unmanaged Toml?, false),
+      arr: [dom] shared Toml?,
+      A: map(string, shared Toml?, false),
       tag: fieldtag;
 
     // Empty
@@ -607,14 +607,14 @@ used to recursively hold tables and respective values
     }
 
     // Toml
-    proc init(A: [?D] unmanaged Toml) where D.isAssociative() {
+    proc init(A: [?D] shared Toml) where D.isAssociative() {
       this.complete();
       for i in D do this.A[i] = A[i];
       this.tag = fieldToml;
     }
 
     pragma "no doc"
-    proc init(A: [?D] unmanaged Toml?) where D.isAssociative() {
+    proc init(A: [?D] shared Toml?) where D.isAssociative() {
       this.complete();
       for i in D do this.A[i] = A[i];
       this.tag = fieldToml;
@@ -657,52 +657,52 @@ used to recursively hold tables and respective values
     }
 
     // Array
-    proc init(arr: [?dom] unmanaged Toml) where dom.isAssociative() == false  {
+    proc init(arr: [?dom] shared Toml) where dom.isAssociative() == false  {
       this.dom = dom;
       this.arr = arr;
       this.tag = fieldArr;
     }
 
     pragma "no doc"
-    proc init(arr: [?dom] unmanaged Toml?) where dom.isAssociative() == false  {
+    proc init(arr: [?dom] shared Toml?) where dom.isAssociative() == false  {
       this.dom = dom;
       this.arr = arr;
       this.tag = fieldArr;
     }
 
     // List
-    proc init(lst: list(unmanaged Toml)) {
+    proc init(lst: list(shared Toml)) {
       // Cheat by translating directly into an array for now.
       this.init(lst.toArray());
     }
 
     pragma "no doc"
-    proc init(lst: list(unmanaged Toml?)) {
+    proc init(lst: list(shared Toml?)) {
       // Cheat by translating directly into an array for now.
       this.init(lst.toArray());
     }
 
 
     // Clone
-    proc init(root: unmanaged Toml) {
+    proc init(root: Toml) {
       // INIT TODO: Can this be written in phase one?
       this.complete();
       this.boo = root.boo;
       this.i = root.i;
       this.re = root.re;
       this.dom = root.dom;
-      for idx in root.dom do this.arr[idx] = new unmanaged Toml(root.arr[idx]!)?;
+      for idx in root.dom do this.arr[idx] = new shared Toml(root.arr[idx]!)?;
       this.ld = root.ld;
       this.ti = root.ti;
       this.dt = root.dt;
       this.s = root.s;
-      for idx in root.A do this.A[idx] = new unmanaged Toml(root.A[idx]!)?;
+      for idx in root.A do this.A[idx] = new shared Toml(root.A[idx]!)?;
       this.tag = root.tag;
     }
 
 
     /* Returns the index of the table path given as a parameter */
-    proc this(tbl: string) ref : unmanaged Toml? throws {
+    proc this(tbl: string) ref : shared Toml? throws {
       const indx = tbl.split('.');
       var top = indx.domain.first;
 
@@ -753,12 +753,20 @@ used to recursively hold tables and respective values
       return false;
     }
 
-    proc set(tbl: string, toml: unmanaged Toml?) {
+    proc set(tbl: string, toml: shared Toml?) {
       ref t = this(tbl);
       if t == nil {
         t = toml;
       } else {
-        delete t;
+        t = toml;
+      }
+    }
+
+    proc set(tbl: string, toml: Toml) {
+      ref t = this(tbl);
+      if t == nil {
+        t = toml;
+      } else {
         t = toml;
       }
     }
@@ -766,7 +774,7 @@ used to recursively hold tables and respective values
     proc set(tbl: string, s: string) {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(s);
+        t = new shared Toml(s);
       } else {
         t!.tag = fieldString;
         t!.s = s;
@@ -775,7 +783,7 @@ used to recursively hold tables and respective values
     proc set(tbl: string, i: int) {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(i);
+        t = new shared Toml(i);
       } else {
         t!.tag = fieldInt;
         t!.i = i;
@@ -784,7 +792,7 @@ used to recursively hold tables and respective values
     proc set(tbl: string, b: bool) {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(b);
+        t = new shared Toml(b);
       } else {
         t!.tag = fieldBool;
         t!.boo = b;
@@ -793,7 +801,7 @@ used to recursively hold tables and respective values
     proc set(tbl: string, r: real) {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(r);
+        t = new shared Toml(r);
       } else {
         t!.tag = fieldReal;
         t!.re = r;
@@ -802,7 +810,7 @@ used to recursively hold tables and respective values
     proc set(tbl: string, ld: date) {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(ld);
+        t = new shared Toml(ld);
       } else {
         t!.tag = fieldDate;
         t!.ld = ld;
@@ -811,7 +819,7 @@ used to recursively hold tables and respective values
     proc set(tbl: string, ti: time) {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(ti);
+        t = new shared Toml(ti);
       } else {
         t!.tag = fieldTime;
         t!.ti = ti;
@@ -820,25 +828,25 @@ used to recursively hold tables and respective values
     proc set(tbl: string, dt: datetime) {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(dt);
+        t = new shared Toml(dt);
       } else {
         t!.tag = fieldDateTime;
         t!.dt = dt;
       }
     }
-    proc set(tbl: string, A: [?D] unmanaged Toml?) where D.isAssociative() {
+    proc set(tbl: string, A: [?D] shared Toml?) where D.isAssociative() {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(A);
+        t = new shared Toml(A);
       } else {
         t!.tag = fieldToml;
         for i in D do t!.A[i] = A[i];
       }
     }
-    proc set(tbl: string, arr: [?dom] unmanaged Toml?) where !dom.isAssociative() {
+    proc set(tbl: string, arr: [?dom] shared Toml?) where !dom.isAssociative() {
       ref t = this(tbl);
       if t == nil {
-        t = new unmanaged Toml(arr);
+        t = new shared Toml(arr);
       } else {
         t!.tag = fieldArr;
         t!.dom = dom;
@@ -855,7 +863,7 @@ used to recursively hold tables and respective values
     /* Write a Table to channel f in TOML format */
     proc writeTOML(f) {
       try! {
-        var flat = new map(string, unmanaged Toml?);
+        var flat = new map(string, shared Toml?);
         this.flatten(flat);       // Flattens containing Toml
         printValues(f, this);     // Prints key values in containing Toml
         printTables(flat, f);       // Prints tables in containing Toml
@@ -868,7 +876,7 @@ used to recursively hold tables and respective values
     /* Write a Table to channel f in JSON format */
     proc writeJSON(f) {
       try! {
-        var flat = new map(string, unmanaged Toml?);
+        var flat = new map(string, shared Toml?);
         this.flatten(flat);           // Flattens containing Toml
 
         var indent=0;
@@ -902,7 +910,7 @@ used to recursively hold tables and respective values
 
     pragma "no doc"
     /* Flatten tables into flat associative array for writing */
-    proc flatten(ref flat: map(string, unmanaged Toml?, false), rootKey = '') : flat.type {
+    proc flatten(ref flat: map(string, shared Toml?, false), rootKey = '') : flat.type {
       for (k, v) in this.A.items() {
         if v!.tag == fieldToml {
           var fullKey = k;
@@ -915,7 +923,7 @@ used to recursively hold tables and respective values
     }
 
     pragma "no doc"
-    proc printTables(ref flat: map(string, unmanaged Toml?, false), f:channel) {
+    proc printTables(ref flat: map(string, shared Toml?, false), f:channel) {
       if flat.contains('root') {
         f.writeln('[root]');
         printValues(f, flat['root']!);
@@ -1121,13 +1129,6 @@ used to recursively hold tables and respective values
           return "nil";
         }
       }
-    }
-
-
-    pragma "no doc"
-    proc deinit() {
-      for a in A.values() do delete a;
-      for a in arr do delete a;
     }
   }
 }

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -753,22 +753,9 @@ used to recursively hold tables and respective values
       return false;
     }
 
-    proc set(tbl: string, toml: shared Toml?) {
-      ref t = this(tbl);
-      if t == nil {
-        t = toml;
-      } else {
-        t = toml;
-      }
-    }
-
     proc set(tbl: string, toml: Toml) {
       ref t = this(tbl);
-      if t == nil {
-        t = toml;
-      } else {
-        t = toml;
-      }
+      t = toml;
     }
 
     proc set(tbl: string, s: string) {

--- a/test/library/packages/TOML/BurntSushi/Passing.chpl
+++ b/test/library/packages/TOML/BurntSushi/Passing.chpl
@@ -18,6 +18,5 @@ proc main() {
   tomlData.writeJSON(jsonChannel);
 
   jsonChannel.close();
-  delete tomlData;
   tomlChannel.close();
 }

--- a/test/library/packages/TOML/test/TomlTest.chpl
+++ b/test/library/packages/TOML/test/TomlTest.chpl
@@ -6,6 +6,5 @@ proc main() {
   var tomlChannel = openreader(f);
   var tomlData = parseToml(tomlChannel);
   writeln(tomlData);
-  delete tomlData;
   tomlChannel.close();
 }

--- a/test/library/packages/TOML/test/UTomlTest.chpl
+++ b/test/library/packages/TOML/test/UTomlTest.chpl
@@ -9,7 +9,7 @@ proc main() {
 
   // New Table
   var tblD: domain(string);
-  var tbl: [tblD] unmanaged Toml?;
+  var tbl: [tblD] shared Toml?;
 
   // Table indexed into and new table added
   tomlData["A.B"]!.set("C", tbl);
@@ -34,16 +34,14 @@ proc main() {
   // Test of the "copy constructor"
   // New Toml
   var tbl2D: domain(string);
-  var tbl2: [tbl2D] unmanaged Toml?;
-  var tomlData2 = new unmanaged Toml(tbl2);
+  var tbl2: [tbl2D] shared Toml?;
+  var tomlData2 = new shared Toml(tbl2);
 
   // copy Toml A.B in tomlData to Toml A in TomlData2
-  tomlData2["A"] = new unmanaged Toml(tomlData["A"]!);
+  tomlData2["A"] = new shared Toml(tomlData["A"]!);
   writeln(tomlData["A"]);
   writeln("Should be the same as");
   writeln(tomlData2["A"]);
 
-  delete tomlData2;
-  delete tomlData;
   tomlChannel.close();
 }

--- a/test/library/packages/TOML/test/checkParseLoop.chpl
+++ b/test/library/packages/TOML/test/checkParseLoop.chpl
@@ -3,12 +3,9 @@ use TOML.TomlParser;
 
 var tomlStr = "t = true\nf = false";
 var D: domain(string);
-var table: [D] unmanaged Toml?;
-var rootTable = new unmanaged Toml(table);
-const source = new unmanaged TOML.TomlReader.Source(tomlStr);
-const parser = new unmanaged Parser(source, rootTable);
+var table: [D] shared Toml?;
+var rootTable = new shared Toml(table);
+const source = new shared TOML.TomlReader.Source(tomlStr);
+const parser = new shared Parser(source, rootTable);
 const tomlData = parser.parseLoop();
 writeln(tomlData);
-delete parser;
-delete source;
-delete tomlData;

--- a/test/library/packages/TOML/test/commentTest.chpl
+++ b/test/library/packages/TOML/test/commentTest.chpl
@@ -12,7 +12,6 @@ proc main() {
     var TomlData = parseToml(str);
     var dob = TomlData["owner"]!["name"];
 
-    delete TomlData;
   } catch e: TomlError{
     writeln(e.message());
     exit(1);

--- a/test/library/packages/TOML/test/date.chpl
+++ b/test/library/packages/TOML/test/date.chpl
@@ -10,7 +10,5 @@ proc main() {
   var TomlData = parseToml(str);
   var dob = TomlData["owner"]!["dob"];
   writeln(dob!.toString());
-
-  delete TomlData;
 }
 

--- a/test/library/packages/TOML/test/fileTest.chpl
+++ b/test/library/packages/TOML/test/fileTest.chpl
@@ -6,6 +6,4 @@ proc main() {
   var TomlFile = open(f, iomode.r);
   var TomlData = parseToml(TomlFile);
   writeln(TomlData);
-
-  delete TomlData;
 }

--- a/test/library/packages/TOML/test/newline.chpl
+++ b/test/library/packages/TOML/test/newline.chpl
@@ -11,7 +11,5 @@ config const str: string = """[owner]
 proc main() {
   var TomlData = parseToml(str);
   writeln(TomlData);
-
-  delete TomlData;
 }
 

--- a/test/library/packages/TOML/test/stringTest.chpl
+++ b/test/library/packages/TOML/test/stringTest.chpl
@@ -7,7 +7,5 @@ key = 'value' ";
 proc main() {
   var TomlData = parseToml(str);
   writeln(TomlData);
-
-  delete TomlData;
 }
 

--- a/test/library/packages/TOML/test/testtime.chpl
+++ b/test/library/packages/TOML/test/testtime.chpl
@@ -23,7 +23,5 @@ proc main() {
   writeln(ts3!.toString());
   writeln(ts4!.toString());
   writeln(ts5!.toString());
-
-  delete TomlData;
 }
 

--- a/test/mason/masonUpdateTest.chpl
+++ b/test/mason/masonUpdateTest.chpl
@@ -33,5 +33,4 @@ proc main() {
   remove(lf);
   temp.close();
   lock.close();
-  delete lockFile;
 }

--- a/test/mason/pkgconfig-tests/pcTest.chpl
+++ b/test/mason/pkgconfig-tests/pcTest.chpl
@@ -29,5 +29,4 @@ proc test(goodLock: string, tf: string) {
   remove(lf);
   temp.close();
   lock.close();
-  delete lockFile;
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -108,7 +108,7 @@ proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: l
     const cwd = here.cwd();
     const projectHome = getProjectHome(cwd, tomlName);
     const toParse = open(projectHome + "/" + lockName, iomode.r);
-    var lockFile = owned.create(parseToml(toParse));
+    var lockFile = parseToml(toParse);
     const projectName = lockFile["root"]!["name"]!.s;
 
     // --fast

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -38,7 +38,7 @@ proc masonDoc(args: [] string) throws {
     const tomlPath = projectHome + "/" + tomlName;
 
     const toParse = open(projectHome + "/" + tomlName, iomode.r);
-    var tomlFile = owned.create(parseToml(toParse));
+    var tomlFile = parseToml(toParse);
 
     const projectName = tomlFile["brick"]!["name"]!.s;
     const projectFile = projectName + '.chpl';

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -78,8 +78,8 @@ private proc getBuildInfo(projectHome: string) {
   // parse lock and toml(examples dont make it to lock file)
   const lock = open(projectHome + "/Mason.lock", iomode.r);
   const toml = open(projectHome + "/Mason.toml", iomode.r);
-  const lockFile = owned.create(parseToml(lock));
-  const tomlFile = owned.create(parseToml(toml));
+  const lockFile = parseToml(lock);
+  const tomlFile = parseToml(toml);
 
   // Get project source code and dependencies
   const sourceList = genSourceList(lockFile);
@@ -351,7 +351,7 @@ proc printAvailableExamples() {
     const cwd = here.cwd();
     const projectHome = getProjectHome(cwd);
     const toParse = open(projectHome + "/Mason.toml", iomode.r);
-    const toml = owned.create(parseToml(toParse));
+    const toml = parseToml(toParse);
     const examples = getExamples(toml, projectHome);
     writeln("--- available examples ---");
     for example in examples {

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -412,10 +412,10 @@ private proc editCompilers() {
 
 /* Given a toml of external dependencies returns
    the dependencies in a toml in lock file format */
-proc getExternalPackages(exDeps: unmanaged Toml) /* [domain(string)] unmanaged Toml? */ {
+proc getExternalPackages(exDeps: Toml) /* [domain(string)] shared Toml? */ {
 
   var exDom: domain(string);
-  var exDepTree: [exDom] unmanaged Toml?;
+  var exDepTree: [exDom] shared Toml?;
 
   for (name, spc) in exDeps.A.items() {
     try! {
@@ -452,12 +452,12 @@ proc getExternalPackages(exDeps: unmanaged Toml) /* [domain(string)] unmanaged T
 
 
 /* Retrieves build information for MasonUpdate */
-proc getSpkgInfo(spec: string, ref dependencies: list(string)): unmanaged Toml throws {
+proc getSpkgInfo(spec: string, ref dependencies: list(string)): shared Toml throws {
 
-  var depList: list(unmanaged Toml);
+  var depList: list(shared Toml);
   var spkgDom: domain(string);
-  var spkgToml: [spkgDom] unmanaged Toml?;
-  var spkgInfo = new unmanaged Toml(spkgToml);
+  var spkgToml: [spkgDom] shared Toml?;
+  var spkgInfo = new shared Toml(spkgToml);
 
   try {
     const specFields = getSpecFields(spec);
@@ -489,7 +489,7 @@ proc getSpkgInfo(spec: string, ref dependencies: list(string)): unmanaged Toml t
         var name = depSpec[0];
 
         // put dep into current packages dep list
-        depList.append(new unmanaged Toml(name));
+        depList.append(new shared Toml(name));
 
         // get dependencies of dep
         var depsOfDep = getSpkgDependencies(dep);

--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -140,7 +140,7 @@ proc overwriteTomlFileValues(isMasonTomlPresent, newPackageName, newVersion,
     defaultChplVersion, defaultLicense) {
   const tomlPath = "./Mason.toml";
   const toParse = open(tomlPath, iomode.r);
-  const tomlFile = owned.create(parseToml(toParse));
+  const tomlFile = parseToml(toParse);
   if isMasonTomlPresent {
     if newPackageName != defaultPackageName then
       tomlFile["brick"]!.set("name", newPackageName);
@@ -164,7 +164,7 @@ proc readPartialSrc(){
 proc readPartialManifest() {
   var defaultPackageName, defaultVersion, defaultChplVersion, defaultLicense: string;
   const toParse = open("./Mason.toml", iomode.r);
-  const tomlFile = owned.create(parseToml(toParse));
+  const tomlFile = parseToml(toParse);
   if tomlFile.pathExists("brick.name") then
     defaultPackageName = tomlFile["brick"]!["name"]!.s;
   if tomlFile.pathExists("brick.version") then
@@ -271,7 +271,7 @@ proc validateMasonFile(path: string, name: string, show: bool) throws {
     var chplVersion = "";
     var license = "None";
     const toParse = open(path + "/Mason.toml", iomode.r);
-    const tomlFile = owned.create(parseToml(toParse));
+    const tomlFile = parseToml(toParse);
 
     if !tomlFile.pathExists("brick") {
       if tomlFile.pathExists("name") ||
@@ -329,10 +329,10 @@ proc validateMasonFile(path: string, name: string, show: bool) throws {
 /*
 adds a section that is absent in the Mason.toml file
 */
-proc addSection(sectionName: string, path: string, tomlFile: owned Toml, show: bool) {
+proc addSection(sectionName: string, path: string, tomlFile: Toml, show: bool) {
   var tdom: domain(string);
   var tomlPath = path + "/Mason.toml";
-  var deps: [tdom] unmanaged Toml?;
+  var deps: [tdom] shared Toml?;
   tomlFile.set(sectionName, deps);
   generateToml(tomlFile, tomlPath);
   if show then writeln("Added [" + sectionName + "] section to Mason.toml");
@@ -347,7 +347,7 @@ proc createModule(path: string, packageName: string, show: bool) throws {
   if validatePackageName(packageName) {
     if isFile(path + "/Mason.toml") {
       const toParse = open(path + "/Mason.toml", iomode.r);
-      const tomlFile = owned.create(parseToml(toParse));
+      const tomlFile = parseToml(toParse);
       if tomlFile.pathExists("brick.name") {
           throw new owned MasonError("Cannot use '--name' here" +
                                 " since brick name already exists.");
@@ -374,7 +374,7 @@ proc validatePackageNameChecks(path: string, name: string) {
   try {
     if isFile(path + "/Mason.toml") {
       const toParse = open(path + "/Mason.toml", iomode.r);
-      const tomlFile = owned.create(parseToml(toParse));
+      const tomlFile = parseToml(toParse);
       if tomlFile.pathExists("brick.name") {
         const nameTOML = tomlFile["brick"]!["name"]!.s;
         if validateNameInit(nameTOML) then actualName = nameTOML;

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -55,8 +55,7 @@ proc masonModify(args: [] string) throws {
 
   const result = modifyToml(add, depArg.value(), extFlag.valueAsBool(),
                             sysFlag.valueAsBool(), projectHome);
-  generateToml(result[0], result[1]);
-  delete result[0];
+  generateToml(result[0]!, result[1]);
 }
 
 proc modifyToml(add: bool, spec: string, external: bool, system: bool,
@@ -65,7 +64,7 @@ proc modifyToml(add: bool, spec: string, external: bool, system: bool,
   const tomlPath = '/'.join(projectHome, tf);
   const openFile = openreader(tomlPath);
   const toml = parseToml(openFile);
-  var newToml: unmanaged Toml?;
+  var newToml: shared Toml?;
 
   try! {
 
@@ -126,11 +125,11 @@ proc modifyToml(add: bool, spec: string, external: bool, system: bool,
     writeln(e.message());
     exit(1);
   }
-  return (newToml!, tomlPath);
+  return (newToml, tomlPath);
 }
 
 /* Add a mason dependency to Mason.toml */
-private proc masonAdd(toml: unmanaged Toml, toAdd: string, version: string) throws {
+private proc masonAdd(toml: shared Toml, toAdd: string, version: string) throws {
   if toml.pathExists("dependencies") {
     if toml.pathExists("dependencies." + toAdd) {
       throw new owned MasonError("A dependency by that name already exists in Mason.toml");
@@ -142,7 +141,7 @@ private proc masonAdd(toml: unmanaged Toml, toAdd: string, version: string) thro
   // Create dependency table if it doesnt exist
   else {
     var tdom: domain(string);
-    var deps: [tdom] unmanaged Toml?;
+    var deps: [tdom] shared Toml?;
     toml.set("dependencies", deps);
     toml["dependencies"]!.set(toAdd, version);
   }
@@ -150,12 +149,11 @@ private proc masonAdd(toml: unmanaged Toml, toAdd: string, version: string) thro
 }
 
 /* Remove a mason dependency from Mason.toml */
-private proc masonRemove(toml: unmanaged Toml, toRm: string) throws {
+private proc masonRemove(toml: shared Toml, toRm: string) throws {
   if toml.pathExists("dependencies") {
     if toml.pathExists("dependencies." + toRm) {
       var old = toml["dependencies"]![toRm]!;
       toml["dependencies"]!.A.remove(toRm);
-      delete old;
     }
     else {
       throw new owned MasonError("No dependency exists by that name");
@@ -168,7 +166,7 @@ private proc masonRemove(toml: unmanaged Toml, toRm: string) throws {
 }
 
 /* Add a system dependency to Mason.toml */
-private proc masonSystemAdd(toml: unmanaged Toml, toAdd: string, version: string) throws {
+private proc masonSystemAdd(toml: shared Toml, toAdd: string, version: string) throws {
 
   if toml.pathExists("system") {
     if toml.pathExists("system." + toAdd) {
@@ -180,7 +178,7 @@ private proc masonSystemAdd(toml: unmanaged Toml, toAdd: string, version: string
   }
   else {
     var pkgdom: domain(string);
-    var pkgdeps: [pkgdom] unmanaged Toml?;
+    var pkgdeps: [pkgdom] shared Toml?;
     toml.set("system", pkgdeps);
     toml["system"]!.set(toAdd, version);
   }
@@ -188,12 +186,11 @@ private proc masonSystemAdd(toml: unmanaged Toml, toAdd: string, version: string
 }
 
 /* Remove a system dependency from Mason.toml */
-private proc masonSystemRemove(toml: unmanaged Toml, toRm: string) throws {
+private proc masonSystemRemove(toml: shared Toml, toRm: string) throws {
   if toml.pathExists("system") {
     if toml.pathExists("system." + toRm) {
       var old = toml["system"]![toRm]!;
       toml["system"]!.A.remove(toRm);
-      delete old;
     }
     else {
       throw new owned MasonError("No system dependency exists by " + toRm);
@@ -206,7 +203,7 @@ private proc masonSystemRemove(toml: unmanaged Toml, toRm: string) throws {
 }
 
 /* Add an external dependency to Mason.toml */
-private proc masonExternalAdd(toml: unmanaged Toml, toAdd: string, spec: string) throws {
+private proc masonExternalAdd(toml: shared Toml, toAdd: string, spec: string) throws {
   if toml.pathExists("external") {
     if toml.pathExists("external." + toAdd) {
       throw new owned MasonError("An external dependency by that name already exists in Mason.toml");
@@ -217,7 +214,7 @@ private proc masonExternalAdd(toml: unmanaged Toml, toAdd: string, spec: string)
   }
   else {
     var exdom: domain(string);
-    var exdeps: [exdom] unmanaged Toml?;
+    var exdeps: [exdom] shared Toml?;
     toml.set("external", exdeps);
     toml["external"]!.set(toAdd, spec);
   }
@@ -225,12 +222,11 @@ private proc masonExternalAdd(toml: unmanaged Toml, toAdd: string, spec: string)
 }
 
 /* Remove an external dependency from Mason.toml */
-private proc masonExternalRemove(toml: unmanaged Toml, toRm: string) throws {
+private proc masonExternalRemove(toml: shared Toml, toRm: string) throws {
   if toml.pathExists("external") {
     if toml.pathExists("external." + toRm) {
       var old = toml["external"]![toRm]!;
       toml["external"]!.A.remove(toRm);
-      delete old;
     }
     else {
       throw new owned MasonError("No external dependency exists by that name");

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -402,7 +402,7 @@ proc branchMasonReg(username: string, name: string, safeDir: string, registryPat
 proc getPackageName() throws {
   try! {
     const toParse = open("Mason.toml", iomode.r);
-    var tomlFile = owned.create(parseToml(toParse));
+    var tomlFile = (parseToml(toParse));
     const name = tomlFile['brick']!['name']!.s;
     return name;
   }
@@ -418,7 +418,7 @@ proc getPackageName() throws {
 private proc addPackageToBricks(projectLocal: string, safeDir: string, name : string,registryPath : string, isLocal : bool) throws {
   try! {
     const toParse = open(projectLocal+ "/Mason.toml", iomode.r);
-    var tomlFile:owned class? = owned.create(parseToml(toParse));
+    var tomlFile = (parseToml(toParse));
     const versionNum = tomlFile!['brick']!['version']!.s;
     if !isLocal {
       if !exists(safeDir + '/mason-registry/Bricks/') {
@@ -428,7 +428,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
         mkdir(safeDir + "/mason-registry/Bricks/" + name);
       }
       if !exists(safeDir + '/mason-registry/Bricks/' + name + "/" + versionNum + ".toml") {
-        const baseToml = tomlFile:owned class;
+        const baseToml = tomlFile;
         var newToml = open(safeDir + "/mason-registry/Bricks/" + name + "/" + versionNum + ".toml", iomode.cw);
         var tomlWriter = newToml.writer();
         const url = gitUrl();
@@ -451,7 +451,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
         mkdir(safeDir + "/Bricks/" + name);
       }
       if !exists(safeDir + "/Bricks/" + name + "/" + versionNum + ".toml") {
-        const baseToml = tomlFile:owned class;
+        const baseToml = tomlFile;
         var newToml = open(safeDir + "/Bricks/" + name + "/" + versionNum + ".toml", iomode.cw);
         var tomlWriter = newToml.writer();
         baseToml["brick"]!.set("source", projectLocal);
@@ -667,7 +667,7 @@ private proc checkLicense(projectHome: string) throws {
   var defaultLicense = "None";
   if exists(joinPath(projectHome, "Mason.toml")) {
     const toParse = open(joinPath(projectHome, "Mason.toml"), iomode.r);
-    const tomlFile = owned.create(parseToml(toParse));
+    const tomlFile = (parseToml(toParse));
     if tomlFile.pathExists("brick.license") {
       defaultLicense = tomlFile["brick"]!["license"]!.s;
     }
@@ -811,7 +811,7 @@ proc gitTagVersionCheck(projectHome: string) throws {
   var tags = runCommand("git tag -l", true);
   var allTags = tags.split("\n");
   const toParse = open(projectHome + "/Mason.toml", iomode.r);
-  const tomlFile = owned.create(parseToml(toParse));
+  const tomlFile = (parseToml(toParse));
   var version = "v" + tomlFile["brick"]!["version"]!.s;
   for tag in allTags {
     if tag == version {
@@ -826,7 +826,7 @@ proc gitTagVersionCheck(projectHome: string) throws {
 proc namespaceCollisionCheck(projectHome: string) throws {
   var directoryName = basename(projectHome);
   const toParse = open(projectHome + "/Mason.toml", iomode.r);
-  const tomlFile = owned.create(parseToml(toParse));
+  const tomlFile = (parseToml(toParse));
   var packageName = tomlFile["brick"]!["name"]!.s;
   if packageName == directoryName then return true;
   else return false;
@@ -835,7 +835,7 @@ proc namespaceCollisionCheck(projectHome: string) throws {
 /* Mason toml file formatting */
 proc masonTomlFileCheck(projectHome: string) {
   const toParse = open(projectHome + "/Mason.toml", iomode.r);
-  const tomlFile = owned.create(parseToml(toParse));
+  const tomlFile = (parseToml(toParse));
   var missingFields : list(string);
   var name, chplVersion, version, source, author, license = false;
   if tomlFile.pathExists("brick.name") then name = true; else missingFields.append('name');

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -72,7 +72,7 @@ proc runProjectBinary(show: bool, release: bool, execopts: list(string)) throws 
     const cwd = here.cwd();
     const projectHome = getProjectHome(cwd);
     const toParse = open(projectHome + "/Mason.toml", iomode.r);
-    const tomlFile = owned.create(parseToml(toParse));
+    const tomlFile = parseToml(toParse);
     const project = tomlFile["brick"]!["name"]!.s;
 
     // Find the Binary and execute

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -216,7 +216,7 @@ proc getPackageScores(res: [] string) {
   if isFile(pathToReg) then cacheExists = true;
   if !cacheExists then touch(pathToReg);
   const parse = open(pathToReg, iomode.r);
-  const cacheFile = owned.create(parseToml(parse));
+  const cacheFile = parseToml(parse);
   var packageScores: map(string, int);
   var packageName: string;
   // defaultScore = (8/12 * 100) = 66
@@ -258,7 +258,7 @@ proc findLatest(packageDir: string): VersionInfo {
     const chplVersion = getChapelVersionInfo();
 
     const manifestReader = openreader(packageDir + '/' + manifest);
-    const manifestToml = owned.create(parseToml(manifestReader));
+    const manifestToml = parseToml(manifestReader);
     const brick = manifestToml['brick'];
     var (low, high) = parseChplVersion(brick);
     if chplVersion < low || chplVersion > high then continue;
@@ -274,7 +274,7 @@ proc findLatest(packageDir: string): VersionInfo {
 /* Print a TOML file. Expects full path. */
 proc showToml(tomlFile : string) {
   const openFile = openreader(tomlFile);
-  const toml = owned.create(parseToml(openFile));
+  const toml = parseToml(openFile);
   writeln(toml);
   openFile.close();
 }

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -207,8 +207,8 @@ proc pkgExists(pkgName: string) : bool {
 proc getPkgInfo(pkgName: string, version: string) throws {
 
   var pkgDom: domain(string);
-  var pkgToml: [pkgDom] unmanaged Toml?;
-  var pkgInfo = new unmanaged Toml(pkgToml);
+  var pkgToml: [pkgDom] shared Toml?;
+  var pkgInfo = new shared Toml(pkgToml);
 
   if pkgExists(pkgName) {
     // Pass "these" to join instead of converting the list to an array.
@@ -233,10 +233,10 @@ proc getPkgInfo(pkgName: string, version: string) throws {
 
 /* Given a toml of external dependencies returns
    the dependencies in a toml */
-proc getPCDeps(exDeps: unmanaged Toml) {
+proc getPCDeps(exDeps: Toml) {
 
   var exDom: domain(string);
-  var exDepTree: [exDom] unmanaged Toml?;
+  var exDepTree: [exDom] shared Toml?;
 
   for (name, vers) in exDeps.A.items() {
     try! {

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -208,7 +208,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
 
     // parse lockfile
     const toParse = open(projectHome + "/Mason.lock", iomode.r);
-    const lockFile = owned.create(parseToml(toParse));
+    const lockFile = parseToml(toParse);
 
     // Get project source code and dependencies
     const sourceList = genSourceList(lockFile);

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -483,7 +483,7 @@ proc isIdentifier(name:string) {
 
 /* Iterator to collect fields from a toml
    TODO custom fields returned */
-iter allFields(tomlTbl: unmanaged Toml) {
+iter allFields(tomlTbl: Toml) {
   for (k,v) in tomlTbl.A.items() {
     if v!.tag == fieldtag.fieldToml then
       continue;


### PR DESCRIPTION
TOML was previously using unmanaged for everything, which
was causing some problems when trying to parse more advanced
TOML files. This PR removes all instances of `unmanaged` from
`TOML.chpl` and Mason to alleviate some of the difficulty with
having to recursively manage memory.

- [x] paratest