### PR TITLE
Update CHAMPS testing for the new version

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -60,7 +60,7 @@ function test_compile() {
   local kind=$@
 
   test_start "make $kind"
-  make release MOD=$kind 2> $kind.comp.out.tmp
+  make release MOD=$kind NPROC=0 2> $kind.comp.out.tmp
   local status=$?
   cat $kind.comp.out.tmp
 

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -52,7 +52,7 @@ test_compile potentialPrep
 test_compile geo
 test_compile thermo
 test_compile postLink
-# test_compile post   # this one requires the sortedSet patch (#19872)
+test_compile post
 test_compile stochasticIcing
 test_compile octree
 test_compile eigenSolvePost


### PR DESCRIPTION
This PR makes two updates for CHAMPS nightly testing:
- CHAMPS now uses `-j` by default. This hurts execution performance. For nightly
  performance tracking purposes, we should avoid parallel compilation. With this
  PR, we pass `NPROCS=0` to CHAMPS' make to disable parallel building.
- With https://github.com/chapel-lang/chapel/pull/20158 in, we can test `post`
  executable now. That's the last executable that we weren't testing. Now we
  build all CHAMPS executables every night.