### PR TITLE
Replace iohints constants with an ioHints Record type

### DIFF
--- a/modules/packages/MatrixMarket.chpl
+++ b/modules/packages/MatrixMarket.chpl
@@ -202,8 +202,8 @@ class MMReader {
    var finfo:MMInfo;
 
    proc init(const fname:string) {
-      fd = open(fname, iomode.r, hints=ioHints.sequential|ioHints.prefetch);
-      fin = fd.reader(start=0, hints=ioHints.sequential|ioHints.prefetch);
+      fd = open(fname, iomode.r, hints=ioHintSet.sequential|ioHintSet.prefetch);
+      fin = fd.reader(start=0, hints=ioHintSet.sequential|ioHintSet.prefetch);
    }
 
    proc read_header() {
@@ -223,7 +223,7 @@ class MMReader {
        // didn't find a percentage, rewind channel by length of read string...
        if percentfound.find("%") == -1 {
          fin.close();
-         fin = fd.reader(start=offset, hints=ioHints.sequential|ioHints.prefetch);
+         fin = fd.reader(start=offset, hints=ioHintSet.sequential|ioHintSet.prefetch);
          pctflag = true;
        }
      }

--- a/modules/packages/MatrixMarket.chpl
+++ b/modules/packages/MatrixMarket.chpl
@@ -202,8 +202,8 @@ class MMReader {
    var finfo:MMInfo;
 
    proc init(const fname:string) {
-      fd = open(fname, iomode.r, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
-      fin = fd.reader(start=0, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
+      fd = open(fname, iomode.r, hints=ioHints.sequential|ioHints.prefetch);
+      fin = fd.reader(start=0, hints=ioHints.sequential|ioHints.prefetch);
    }
 
    proc read_header() {
@@ -223,7 +223,7 @@ class MMReader {
        // didn't find a percentage, rewind channel by length of read string...
        if percentfound.find("%") == -1 {
          fin.close();
-         fin = fd.reader(start=offset, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
+         fin = fd.reader(start=offset, hints=ioHints.sequential|ioHints.prefetch);
          pctflag = true;
        }
      }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1918,23 +1918,17 @@ The system file descriptor will be closed when the Chapel file is closed.
 
 :throws SystemError: Thrown if the file descriptor could not be retrieved.
 */
-proc openfd(fd: fd_t, hints=ioHints.empty):file throws {
-  return openfdHelper(fd, hints._internal);
+proc openfd(fd: fd_t, hints = ioHints.empty):file throws {
+  return openfdHelper(fd, hints);
 }
 
-pragma "no doc"
-// to address the use of "QIO_HINT_OWNED" in the Subprocess module
-proc openfd(fd: fd_t, hints: c_int):file throws {
-  return openfdHelper(fd, hints._internal);
-}
-
-private proc openfdHelper(fd: fd_t, hints: c_int,
+private proc openfdHelper(fd: fd_t, hints = ioHints.empty,
                           style:iostyleInternal = defaultIOStyleInternal()):file throws {
   var local_style = style;
   var ret:file;
   ret.home = here;
   extern proc chpl_cnullfile():_file;
-  var err = qio_file_init(ret._file_internal, chpl_cnullfile(), fd, hints, local_style, 0);
+  var err = qio_file_init(ret._file_internal, chpl_cnullfile(), fd, hints._internal, local_style, 0);
 
   // On return, either ret._file_internal.ref_cnt == 1, or ret._file_internal is NULL.
   // err should be nonzero in the latter case.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1406,40 +1406,6 @@ extern type fdflag_t = c_int;
 //  QIO_HINT_NOREUSE
 /*
 
-// A value of the :type:`iohints` type defines a set of hints about the I/O that
-// the file or channel will perform.  These hints may be used by the
-// implementation to select optimized versions of the I/O operations.
-
-// The :type:`iohints` type is implementation-defined.
-// The following :type:`iohints` constants are provided:
-
-//   * :const:`IOHINT_NONE` defines an empty set, which provides no hints.
-//   * :const:`IOHINT_RANDOM` suggests to expect random access.
-//   * :const:`IOHINT_SEQUENTIAL` suggests to expect sequential access.
-//   * :const:`IOHINT_CACHED` suggests that the file data is or should be
-//     cached in memory, possibly all at once.
-//   * :const:`IOHINT_PARALLEL` suggests to expect many channels
-//     working with this file in parallel.
-
-
-// Other hints might be added in the future.
-
-// The following binary operators are defined on :type:`iohints`:
-
-// * ``|`` for set union
-// * ``&`` for set intersection
-// * ``==`` for set equality
-// * ``!=`` for set inequality
-
-// When an :type:`iohints` formal argument has default intent, the
-// actual is copied as ``const in`` to the formal upon a function
-// call, and the formal cannot be assigned within the function.
-
-// The default value of the :type:`iohints` type is undefined.
-
-// */
-// extern type iohints = c_int;
-
 private const IOHINTS_NONE:        c_int = 0;
 private const IOHINTS_SEQUENTIAL:  c_int = QIO_HINT_SEQUENTIAL;
 private const IOHINTS_RANDOM:      c_int = QIO_HINT_RANDOM;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1436,35 +1436,74 @@ extern type fdflag_t = c_int;
 // extern type iohints = c_int;
 
 // https://man7.org/linux/man-pages/man2/posix_fadvise.2.html
-private const IOHINT_NONE: int = 0x0;
-private const IOHINT_SEQUENTIAL: int = 0x1;
-private const IOHINT_RANDOM: int = 0x2;
-private const IOHINT_PREFETCH: int = 0x4;
-private const IOHINT_MMAP: int = 0x8;
+private const IOHINT_NONE: int = 0x00;
+private const IOHINT_SEQUENTIAL: int = 0x10;
+private const IOHINT_RANDOM: int = 0x20;
+private const IOHINT_PREFETCH: int = 0x40;
+private const IOHINT_MMAP: int = 0x80;
 
+/* A value of the :type:`iohints` type defines a set of hints about the I/O that
+  the file or channel will perform.  These hints may be used by the
+  implementation to select optimized versions of the I/O operations.
+
+  Most hints have POSIX equivalents either associated with posix_fadvise() or
+  posix_madvise().
+*/
 record ioHints {
   pragma "no doc"
   var _internal : int;
 
+  /* Defines an empty set, which provides no hints.
+  Corresponds to 'POSIX_*_NORMAL'.
+  */
   proc type none { return new ioHints(IOHINT_NONE); }
+
+ /* Suggests that the file will be accessed sequentially
+  Corresponds to 'POSIX_*_SEQUENTIAL'
+  */
   proc type sequential { return new ioHints(IOHINT_SEQUENTIAL); }
+
+  /* Suggests that the file will be accessed randomly.
+  Corresponds to 'POSIX_*_RANDOM'.
+  */
   proc type random { return new ioHints(IOHINT_RANDOM); }
+
+  /* Suggests that the runtime/OS should immediately begin prefetching the file contents.
+  Corresponds to 'POSIX_*_WILLNEED'.
+  */
   proc type prefetch { return new ioHints(IOHINT_PREFETCH); }
+
+  /* Suggests that mmap should be used to access the file contents
+  */
   proc type mmap { return new ioHints(IOHINT_MMAP); }
+
+  pragma "no doc"
+  proc to_qio_hint_t(): qio_hint_t {
+    // temporary (need to look into runtime implementation)
+    return this._internal;
+  }
 }
 
+/* Compute the bitwise-or (union) of two ioHints
+*/
 operator ioHints.|(lhs: ioHints, rhs: ioHints) {
   return new ioHints(lhs._internal | rhs._internal);
 }
 
+/* Compute the bitwise-and (intersection) of two ioHints
+*/
 operator ioHints.&(lhs: ioHints, rhs: ioHints) {
   return new ioHints(lhs._internal & rhs._internal);
 }
 
+/* Compare two ioHints for equality
+*/
 operator ioHints.==(lhs: ioHints, rhs: ioHints) {
   return lhs._internal == rhs._internal;
 }
 
+/* Compare two ioHints for inequality
+*/
 operator ioHints.!=(lhs: ioHints, rhs: ioHints) {
   return !(lhs == rhs)
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1401,42 +1401,89 @@ extern type fdflag_t = c_int;
 //  QIO_HINT_NOREUSE
 /*
 
-A value of the :type:`iohints` type defines a set of hints about the I/O that
-the file or channel will perform.  These hints may be used by the
-implementation to select optimized versions of the I/O operations.
+// A value of the :type:`iohints` type defines a set of hints about the I/O that
+// the file or channel will perform.  These hints may be used by the
+// implementation to select optimized versions of the I/O operations.
 
-The :type:`iohints` type is implementation-defined.
-The following :type:`iohints` constants are provided:
+// The :type:`iohints` type is implementation-defined.
+// The following :type:`iohints` constants are provided:
 
-  * :const:`IOHINT_NONE` defines an empty set, which provides no hints.
-  * :const:`IOHINT_RANDOM` suggests to expect random access.
-  * :const:`IOHINT_SEQUENTIAL` suggests to expect sequential access.
-  * :const:`IOHINT_CACHED` suggests that the file data is or should be
-    cached in memory, possibly all at once.
-  * :const:`IOHINT_PARALLEL` suggests to expect many channels
-    working with this file in parallel.
+//   * :const:`IOHINT_NONE` defines an empty set, which provides no hints.
+//   * :const:`IOHINT_RANDOM` suggests to expect random access.
+//   * :const:`IOHINT_SEQUENTIAL` suggests to expect sequential access.
+//   * :const:`IOHINT_CACHED` suggests that the file data is or should be
+//     cached in memory, possibly all at once.
+//   * :const:`IOHINT_PARALLEL` suggests to expect many channels
+//     working with this file in parallel.
 
 
-Other hints might be added in the future.
+// Other hints might be added in the future.
 
-The following binary operators are defined on :type:`iohints`:
+// The following binary operators are defined on :type:`iohints`:
 
-* ``|`` for set union
-* ``&`` for set intersection
-* ``==`` for set equality
-* ``!=`` for set inequality
+// * ``|`` for set union
+// * ``&`` for set intersection
+// * ``==`` for set equality
+// * ``!=`` for set inequality
 
-When an :type:`iohints` formal argument has default intent, the
-actual is copied as ``const in`` to the formal upon a function
-call, and the formal cannot be assigned within the function.
+// When an :type:`iohints` formal argument has default intent, the
+// actual is copied as ``const in`` to the formal upon a function
+// call, and the formal cannot be assigned within the function.
 
-The default value of the :type:`iohints` type is undefined.
+// The default value of the :type:`iohints` type is undefined.
 
-*/
-extern type iohints = c_int;
+// */
+// extern type iohints = c_int;
+
+// https://man7.org/linux/man-pages/man2/posix_fadvise.2.html
+private const IOHINT_NONE: c_int = 0;
+private const IOHINT_SEQUENTIAL: c_int = 0;
+private const IOHINT_RANDOM: c_int = 0;
+private const IOHINT_PREFETCH: c_int = 0;
+private const IOHINT_MMAP: c_int = 0;
+
+record ioHints {
+  pragma "no doc"
+  var _internal : c_int;
+
+  proc type none {
+    return new ioHints(IOHINT_NONE);
+  }
+
+  proc type sequential {
+    return new ioHints(IOHINT_SEQUENTIAL);
+  }
+
+  proc type random {
+    return new ioHints(IOHINT_RANDOM);
+  }
+
+  proc type prefetch {
+    return new ioHints(IOHINT_PREFETCH);
+  }
+
+  proc type mmap {
+    return new ioHints(IOHINT_MMAP);
+  }
+}
+
+operator ioHints.|(lhs: ioHints, rhs: ioHints) {
+  return new ioHints(lhs._internal | rhs._internal);
+}
+
+operator ioHints.&(lhs: ioHints, rhs: ioHints) {
+  return new ioHints(lhs._internal & rhs._internal);
+}
+
+operator ioHints.==(lhs: ioHints, rhs: ioHints) {
+  return lhs._internal == rhs._internal;
+}
+
+operator ioHints.!=(lhs: ioHints, rhs: ioHints) {
+  return !(lhs == rhs)
+}
 
 /*
-
 The :record:`file` type is implementation-defined.  A value of the
 :record:`file` type refers to the state that is used by the implementation to
 identify and interact with the OS file.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1404,7 +1404,6 @@ extern type fdflag_t = c_int;
 //  QIO_HINT_BANDWIDTH,
 //  QIO_HINT_CACHED,
 //  QIO_HINT_NOREUSE
-/*
 
 private const IOHINTS_NONE:        c_int = 0;
 private const IOHINTS_SEQUENTIAL:  c_int = QIO_HINT_SEQUENTIAL;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1414,7 +1414,7 @@ private const IOHINTS_RANDOM:      c_int = QIO_HINT_RANDOM;
 private const IOHINTS_PREFETCH:    c_int = QIO_HINT_CACHED;
 private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
 
-/* A value of the :record:`ioHintSet` type defines a set of hints about /
+/* A value of the :record:`ioHintSet` type defines a set of hints about
   the I/O that the file or channel will perform.  These hints may be used
   by the implementation to select optimized versions of the I/O operations.
 
@@ -1425,7 +1425,7 @@ private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
 
     use IO;
 
-    // define a set of hints using a union
+    // define a set of hints using a union operation
     var hints = ioHintSet::sequential | ioHintSet::prefetch;
 
     // open a file using the hints
@@ -1753,13 +1753,6 @@ proc _modestring(mode:iomode) {
 }
 
 deprecated "open with a style argument is deprecated"
-proc open(path:string, mode:iomode, hints=ioHintSet.empty,
-          style:iostyle): file throws {
-  return openHelper(path, mode, hints, style:iostyleInternal);
-}
-
-pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead."
 proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE,
           style:iostyle): file throws {
   return openHelper(path, mode, new ioHintSet(hints), style:iostyleInternal);
@@ -1788,7 +1781,7 @@ proc open(path:string, mode:iomode, hints=ioHintSet.empty): file throws {
 pragma "last resort"
 deprecated "The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead."
 proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE): file throws {
-  return openHelper(path, mode, new ioHintSet(hints));
+  return open(path, mode, new ioHintSet(hints));
 }
 
 private proc openHelper(path:string, mode:iomode, hints=ioHintSet.empty,
@@ -1869,12 +1862,6 @@ proc openplugin(pluginFile: QioPluginFile, mode:iomode,
 }
 
 deprecated "openfd with a style argument is deprecated"
-proc openfd(fd: fd_t, hints=ioHintSet.empty, style:iostyle):file throws {
-  return openfdHelper(fd, hints, style: iostyleInternal);
-}
-
-pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead."
 proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE, style:iostyle):file throws {
   return openfdHelper(fd, new ioHintSet(hints), style: iostyleInternal);
 }
@@ -1912,7 +1899,7 @@ proc openfd(fd: fd_t, hints = ioHintSet.empty):file throws {
 pragma "last resort"
 deprecated "The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead."
 proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE):file throws {
-  return openfdHelper(fd, new ioHintSet(hints));
+  return openfd(fd, new ioHintSet(hints));
 }
 
 private proc openfdHelper(fd: fd_t, hints = ioHintSet.empty,
@@ -1937,12 +1924,6 @@ private proc openfdHelper(fd: fd_t, hints = ioHintSet.empty,
 }
 
 deprecated "openfp with a style argument is deprecated"
-proc openfp(fp: _file, hints=ioHintSet.empty, style:iostyle):file throws {
-  return openfpHelper(fp, hints, style: iostyleInternal);
-}
-
-pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead."
 proc openfp(fp: _file, hints:iohints=IOHINT_NONE, style:iostyle):file throws {
   return openfpHelper(fp, new ioHintSet(hints), style: iostyleInternal);
 }
@@ -1974,7 +1955,7 @@ proc openfp(fp: _file, hints=ioHintSet.empty):file throws {
 pragma "last resort"
 deprecated "The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead."
 proc openfp(fp: _file, hints:iohints=IOHINT_NONE):file throws {
-  return openfpHelper(fp, new ioHintSet(hints));
+  return openfp(fp, new ioHintSet(hints));
 }
 
 private proc openfpHelper(fp: _file, hints=ioHintSet.empty,
@@ -1999,12 +1980,6 @@ private proc openfpHelper(fp: _file, hints=ioHintSet.empty,
 }
 
 deprecated "opentmp with a style argument is deprecated"
-proc opentmp(hints=ioHintSet.empty, style:iostyle):file throws {
-  return opentmpHelper(hints, style: iostyleInternal);
-}
-
-pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead."
 proc opentmp(hints:iohints=IOHINT_NONE, style:iostyle):file throws {
   return opentmpHelper(new ioHintSet(hints), style: iostyleInternal);
 }
@@ -2039,7 +2014,7 @@ proc opentmp(hints=ioHintSet.empty):file throws {
 pragma "last resort"
 deprecated "The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead."
 proc opentmp(hints:iohints=IOHINT_NONE):file throws {
-  return opentmpHelper(new ioHintSet(hints));
+  return opentmp(new ioHintSet(hints));
 }
 
 private proc opentmpHelper(hints=ioHintSet.empty,
@@ -2760,28 +2735,16 @@ deprecated "openreader with a style argument is deprecated"
 proc openreader(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
-                hints = ioHintSet.empty,
-                style:iostyle)
-    : channel(false, kind, locking) throws {
-  return openreaderHelper(path, kind, locking, start, end, hints,
-                          style: iostyleInternal);
-}
-// We can simply call channel.close() on these, since the underlying file will
-// be closed once we no longer have any references to it (which in this case,
-// since we only will have one reference, will be right after we close this
-// channel presumably).
-
-pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead."
-proc openreader(path:string,
-                param kind=iokind.dynamic, param locking=true,
-                start:int(64) = 0, end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE,
                 style:iostyle)
     : channel(false, kind, locking) throws {
   return openreaderHelper(path, kind, locking, start, end, new ioHintSet(hints),
                           style: iostyleInternal);
 }
+// We can simply call channel.close() on these, since the underlying file will
+// be closed once we no longer have any references to it (which in this case,
+// since we only will have one reference, will be right after we close this
+// channel presumably).
 
 /*
 
@@ -2825,7 +2788,7 @@ proc openreader(path:string,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE)
     : channel(false, kind, locking) throws {
-  return openreaderHelper(path, kind, locking, start, end, new ioHintSet(hints));
+  return openreader(path, kind, locking, start, end, new ioHintSet(hints));
 }
 
 private proc openreaderHelper(path:string,
@@ -2840,18 +2803,6 @@ private proc openreaderHelper(path:string,
 }
 
 deprecated "openwriter with a style argument is deprecated"
-proc openwriter(path:string,
-                param kind=iokind.dynamic, param locking=true,
-                start:int(64) = 0, end:int(64) = max(int(64)),
-                hints=ioHintSet.empty,
-                style:iostyle)
-    : channel(true, kind, locking) throws {
-  return openwriterHelper(path, kind, locking, start, end, hints,
-                    style: iostyleInternal);
-}
-
-pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openwriter' that takes an 'ioHintSet' instead."
 proc openwriter(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
@@ -2904,7 +2855,7 @@ proc openwriter(path:string,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE)
     : channel(true, kind, locking) throws {
-  return openwriterHelper(path, kind, locking, start, end, new ioHintSet(hints));
+  return openwriter(path, kind, locking, start, end, new ioHintSet(hints));
 }
 
 private proc openwriterHelper(path:string,
@@ -2921,10 +2872,10 @@ private proc openwriterHelper(path:string,
 deprecated "reader with a style argument is deprecated"
 proc file.reader(param kind=iokind.dynamic, param locking=true,
                  start:int(64) = 0, end:int(64) = max(int(64)),
-                 hints = ioHintSet.empty,
+                 hints:iohints=IOHINT_NONE,
                  style:iostyle): channel(false, kind, locking)
                  throws {
-  return this.readerHelper(kind, locking, start, end, hints, style: iostyleInternal);
+  return this.readerHelper(kind, locking, start, end, new ioHintSet(hints), style: iostyleInternal);
 }
 
 /*
@@ -2972,7 +2923,7 @@ pragma "last resort"
 deprecated "The 'iohints' type is deprecated; please use a variant of 'file.reader' that takes an 'ioHintSet' instead."
 proc file.reader(param kind=iokind.dynamic, param locking=true, start:int(64) = 0,
                  end:int(64) = max(int(64)), hints:iohints=IOHINT_NONE): channel(false, kind, locking) throws {
-  return this.readerHelper(kind, locking, start, end, new ioHintSet(hints));
+  return this.reader(kind, locking, start, end, new ioHintSet(hints));
 }
 
 pragma "no doc"
@@ -2995,15 +2946,6 @@ proc file.readerHelper(param kind=iokind.dynamic, param locking=true,
 }
 
 deprecated "lines with a local_style argument is deprecated"
-proc file.lines(param locking:bool = true, start:int(64) = 0,
-                end:int(64) = max(int(64)), hints = ioHintSet.empty,
-                in local_style:iostyle) throws {
-  return this.linesHelper(locking, start, end, hints,
-                          local_style: iostyleInternal);
-}
-
-pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'file.lines' that takes an 'ioHintSet' instead."
 proc file.lines(param locking:bool = true, start:int(64) = 0,
                 end:int(64) = max(int(64)), hints:iohints=IOHINT_NONE,
                 in local_style:iostyle) throws {
@@ -3028,7 +2970,7 @@ deprecated "The 'iohints' type is deprecated; please use a variant of 'file.line
 proc file.lines(param locking:bool = true, start:int(64) = 0,
                 end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE) throws {
-  return this.linesHelper(locking, start, end, new ioHintSet(hints));
+  return this.lines(locking, start, end, new ioHintSet(hints));
 }
 
 pragma "no doc"
@@ -3052,15 +2994,6 @@ proc file.linesHelper(param locking:bool = true, start:int(64) = 0,
 }
 
 deprecated "writer with a style argument is deprecated"
-proc file.writer(param kind=iokind.dynamic, param locking=true,
-                 start:int(64) = 0, end:int(64) = max(int(64)),
-                 hints = ioHintSet.empty, style:iostyle):
-                 channel(true,kind,locking) throws {
-  return this.writerHelper(kind, locking, start, end, hints, style: iostyleInternal);
-}
-
-pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'file.writer' that takes an 'ioHintSet' instead."
 proc file.writer(param kind=iokind.dynamic, param locking=true,
                  start:int(64) = 0, end:int(64) = max(int(64)),
                  hints:iohints=IOHINT_NONE, style:iostyle):
@@ -3122,7 +3055,7 @@ proc file.writer(param kind=iokind.dynamic, param locking=true,
                  start:int(64) = 0, end:int(64) = max(int(64)),
                  hints:iohints=IOHINT_NONE):
                  channel(true,kind,locking) throws {
-  return this.writerHelper(kind, locking, start, end, new ioHintSet(hints));
+  return this.writer(kind, locking, start, end, new ioHintSet(hints));
 }
 
 pragma "no doc"

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1436,35 +1436,21 @@ extern type fdflag_t = c_int;
 // extern type iohints = c_int;
 
 // https://man7.org/linux/man-pages/man2/posix_fadvise.2.html
-private const IOHINT_NONE: c_int = 0;
-private const IOHINT_SEQUENTIAL: c_int = 0;
-private const IOHINT_RANDOM: c_int = 0;
-private const IOHINT_PREFETCH: c_int = 0;
-private const IOHINT_MMAP: c_int = 0;
+private const IOHINT_NONE: int = 0x0;
+private const IOHINT_SEQUENTIAL: int = 0x1;
+private const IOHINT_RANDOM: int = 0x2;
+private const IOHINT_PREFETCH: int = 0x4;
+private const IOHINT_MMAP: int = 0x8;
 
 record ioHints {
   pragma "no doc"
-  var _internal : c_int;
+  var _internal : int;
 
-  proc type none {
-    return new ioHints(IOHINT_NONE);
-  }
-
-  proc type sequential {
-    return new ioHints(IOHINT_SEQUENTIAL);
-  }
-
-  proc type random {
-    return new ioHints(IOHINT_RANDOM);
-  }
-
-  proc type prefetch {
-    return new ioHints(IOHINT_PREFETCH);
-  }
-
-  proc type mmap {
-    return new ioHints(IOHINT_MMAP);
-  }
+  proc type none { return new ioHints(IOHINT_NONE); }
+  proc type sequential { return new ioHints(IOHINT_SEQUENTIAL); }
+  proc type random { return new ioHints(IOHINT_RANDOM); }
+  proc type prefetch { return new ioHints(IOHINT_PREFETCH); }
+  proc type mmap { return new ioHints(IOHINT_MMAP); }
 }
 
 operator ioHints.|(lhs: ioHints, rhs: ioHints) {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1493,6 +1493,9 @@ record ioHints {
   /* Suggests that 'mmap' should be used to access the file contents
   */
   proc type mmap { return new ioHints(IOHINTS_MMAP); }
+
+  pragma "no doc"
+  proc type direct(constant: c_int) { return new ioHints(constant); }
 }
 
 /* Compute the union of two sets of ioHints
@@ -1922,7 +1925,7 @@ proc openfd(fd: fd_t, hints=ioHints.empty):file throws {
 pragma "no doc"
 // to address the use of "QIO_HINT_OWNED" in the Subprocess module
 proc openfd(fd: fd_t, hints: c_int):file throws {
-  return openfdHelper(fd, hints);
+  return openfdHelper(fd, hints._internal);
 }
 
 private proc openfdHelper(fd: fd_t, hints: c_int,
@@ -2034,7 +2037,7 @@ private proc opentmpHelper(hints=ioHints.empty,
   ret.home = here;
 
   // On return ret._file_internal.ref_cnt == 1.
-  var err = qio_file_open_tmp(ret._file_internal, hints, local_style);
+  var err = qio_file_open_tmp(ret._file_internal, hints._internal, local_style);
   if err then try ioerror(err, "in opentmp");
   return ret;
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1405,6 +1405,9 @@ extern type fdflag_t = c_int;
 //  QIO_HINT_CACHED,
 //  QIO_HINT_NOREUSE
 
+deprecated "the 'iohints' type is deprecated; please use the 'ioHints' record type instead."
+extern type iohints = c_int;
+
 private const IOHINTS_NONE:        c_int = 0;
 private const IOHINTS_SEQUENTIAL:  c_int = QIO_HINT_SEQUENTIAL;
 private const IOHINTS_RANDOM:      c_int = QIO_HINT_RANDOM;
@@ -1415,7 +1418,7 @@ private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
   the file or channel will perform.  These hints may be used by the
   implementation to select optimized versions of the I/O operations.
 
-  Most hints have POSIX equivalents either associated with posix_fadvise() or
+  Most hints have POSIX equivalents associated with posix_fadvise() and
   posix_madvise().
 
   .. code-block:: chapel
@@ -1428,7 +1431,7 @@ private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
     // open a file using the hints
     var f: file;
     try! {
-      f = open("path/to/my/file.txt", iomode.r, iohints=hints);
+      f = open("path/to/my/file.txt", iomode.r, hints=hints);
     }
 */
 record ioHints {
@@ -1755,6 +1758,13 @@ proc open(path:string, mode:iomode, hints=ioHints.empty,
   return openHelper(path, mode, hints, style:iostyleInternal);
 }
 
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHints' record instead."
+proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE,
+          style:iostyle): file throws {
+  return openHelper(path, mode, new ioHints(hints), style:iostyleInternal);
+}
+
 /*
 
 Open a file on a filesystem. Note that once the
@@ -1773,6 +1783,12 @@ to create a channel to actually perform I/O operations
 */
 proc open(path:string, mode:iomode, hints=ioHints.empty): file throws {
   return openHelper(path, mode, hints);
+}
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHints' record instead."
+proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE): file throws {
+  return openHelper(path, mode, new ioHints(hints));
 }
 
 private proc openHelper(path:string, mode:iomode, hints=ioHints.empty,
@@ -1857,6 +1873,12 @@ proc openfd(fd: fd_t, hints=ioHints.empty, style:iostyle):file throws {
   return openfdHelper(fd, hints, style: iostyleInternal);
 }
 
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHints' record instead."
+proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE, style:iostyle):file throws {
+  return openfdHelper(fd, new ioHints(hints), style: iostyleInternal);
+}
+
 /*
 
 Create a Chapel file that works with a system file descriptor.  Note that once
@@ -1887,6 +1909,12 @@ proc openfd(fd: fd_t, hints = ioHints.empty):file throws {
   return openfdHelper(fd, hints);
 }
 
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHints' record instead."
+proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE):file throws {
+  return openfdHelper(fd, new ioHints(hints));
+}
+
 private proc openfdHelper(fd: fd_t, hints = ioHints.empty,
                           style:iostyleInternal = defaultIOStyleInternal()):file throws {
   var local_style = style;
@@ -1912,6 +1940,13 @@ deprecated "openfp with a style argument is deprecated"
 proc openfp(fp: _file, hints=ioHints.empty, style:iostyle):file throws {
   return openfpHelper(fp, hints, style: iostyleInternal);
 }
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHints' record instead."
+proc openfp(fp: _file, hints:iohints=IOHINT_NONE, style:iostyle):file throws {
+  return openfpHelper(fp, new ioHints(hints), style: iostyleInternal);
+}
+
 /*
 
 Create a Chapel file that works with an open C file (ie a ``FILE*``).  Note
@@ -1934,6 +1969,12 @@ that once the file is open, you will need to use a :proc:`file.reader` or
  */
 proc openfp(fp: _file, hints=ioHints.empty):file throws {
   return openfpHelper(fp, hints);
+}
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHints' record instead."
+proc openfp(fp: _file, hints:iohints=IOHINT_NONE):file throws {
+  return openfpHelper(fp, new ioHints(hints));
 }
 
 private proc openfpHelper(fp: _file, hints=ioHints.empty,
@@ -1962,6 +2003,12 @@ proc opentmp(hints=ioHints.empty, style:iostyle):file throws {
   return opentmpHelper(hints, style: iostyleInternal);
 }
 
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHints' record instead."
+proc opentmp(hints:iohints=IOHINT_NONE, style:iostyle):file throws {
+  return opentmpHelper(new ioHints(hints), style: iostyleInternal);
+}
+
 /*
 
 Open a temporary file. Note that once the file is open, you will need to use a
@@ -1987,6 +2034,12 @@ that is, a new file is created that supports both writing and reading.
 */
 proc opentmp(hints=ioHints.empty):file throws {
   return opentmpHelper(hints);
+}
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHints' record instead."
+proc opentmp(hints:iohints=IOHINT_NONE):file throws {
+  return opentmpHelper(new ioHints(hints));
 }
 
 private proc opentmpHelper(hints=ioHints.empty,
@@ -2717,6 +2770,19 @@ proc openreader(path:string,
 // be closed once we no longer have any references to it (which in this case,
 // since we only will have one reference, will be right after we close this
 // channel presumably).
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHints' record instead."
+proc openreader(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                start:int(64) = 0, end:int(64) = max(int(64)),
+                hints:iohints=IOHINT_NONE,
+                style:iostyle)
+    : channel(false, kind, locking) throws {
+  return openreaderHelper(path, kind, locking, start, end, new ioHints(hints),
+                          style: iostyleInternal);
+}
+
 /*
 
 Open a file at a particular path and return a reading channel for it.
@@ -2752,6 +2818,16 @@ proc openreader(path:string,
   return openreaderHelper(path, kind, locking, start, end, hints);
 }
 
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHints' record instead."
+proc openreader(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                start:int(64) = 0, end:int(64) = max(int(64)),
+                hints:iohints=IOHINT_NONE)
+    : channel(false, kind, locking) throws {
+  return openreaderHelper(path, kind, locking, start, end, new ioHints(hints));
+}
+
 private proc openreaderHelper(path:string,
                               param kind=iokind.dynamic, param locking=true,
                               start:int(64) = 0, end:int(64) = max(int(64)),
@@ -2773,6 +2849,19 @@ proc openwriter(path:string,
   return openwriterHelper(path, kind, locking, start, end, hints,
                     style: iostyleInternal);
 }
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openwriter' that takes an 'ioHints' record instead."
+proc openwriter(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                start:int(64) = 0, end:int(64) = max(int(64)),
+                hints:iohints=IOHINT_NONE,
+                style:iostyle)
+    : channel(true, kind, locking) throws {
+  return openwriterHelper(path, kind, locking, start, end, new ioHints(hints),
+                    style: iostyleInternal);
+}
+
 /*
 
 Open a file at a particular path and return a writing channel for it.
@@ -2806,6 +2895,16 @@ proc openwriter(path:string,
                 hints = ioHints.empty)
     : channel(true, kind, locking) throws {
   return openwriterHelper(path, kind, locking, start, end, hints);
+}
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openwriter' that takes an 'ioHints' record instead."
+proc openwriter(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                start:int(64) = 0, end:int(64) = max(int(64)),
+                hints:iohints=IOHINT_NONE)
+    : channel(true, kind, locking) throws {
+  return openwriterHelper(path, kind, locking, start, end, new ioHints(hints));
 }
 
 private proc openwriterHelper(path:string,
@@ -2869,6 +2968,13 @@ proc file.reader(param kind=iokind.dynamic, param locking=true, start:int(64) = 
   return this.readerHelper(kind, locking, start, end, hints);
 }
 
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.reader' that takes an 'ioHints' record instead."
+proc file.reader(param kind=iokind.dynamic, param locking=true, start:int(64) = 0,
+                 end:int(64) = max(int(64)), hints:iohints=IOHINT_NONE): channel(false, kind, locking) throws {
+  return this.readerHelper(kind, locking, start, end, new ioHints(hints));
+}
+
 pragma "no doc"
 proc file.readerHelper(param kind=iokind.dynamic, param locking=true,
                        start:int(64) = 0, end:int(64) = max(int(64)),
@@ -2895,6 +3001,16 @@ proc file.lines(param locking:bool = true, start:int(64) = 0,
   return this.linesHelper(locking, start, end, hints,
                           local_style: iostyleInternal);
 }
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.lines' that takes an 'ioHints' record instead."
+proc file.lines(param locking:bool = true, start:int(64) = 0,
+                end:int(64) = max(int(64)), hints:iohints=IOHINT_NONE,
+                in local_style:iostyle) throws {
+  return this.linesHelper(locking, start, end, new ioHints(hints),
+                          local_style: iostyleInternal);
+}
+
 /* Iterate over all of the lines in a file.
 
    :returns: an object which yields strings read from the file
@@ -2905,6 +3021,14 @@ proc file.lines(param locking:bool = true, start:int(64) = 0,
                 end:int(64) = max(int(64)),
                 hints = ioHints.empty) throws {
   return this.linesHelper(locking, start, end, hints);
+}
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.lines' that takes an 'ioHints' record instead."
+proc file.lines(param locking:bool = true, start:int(64) = 0,
+                end:int(64) = max(int(64)),
+                hints:iohints=IOHINT_NONE) throws {
+  return this.linesHelper(locking, start, end, new ioHints(hints));
 }
 
 pragma "no doc"
@@ -2933,6 +3057,15 @@ proc file.writer(param kind=iokind.dynamic, param locking=true,
                  hints = ioHints.empty, style:iostyle):
                  channel(true,kind,locking) throws {
   return this.writerHelper(kind, locking, start, end, hints, style: iostyleInternal);
+}
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.writer' that takes an 'ioHints' record instead."
+proc file.writer(param kind=iokind.dynamic, param locking=true,
+                 start:int(64) = 0, end:int(64) = max(int(64)),
+                 hints:iohints=IOHINT_NONE, style:iostyle):
+                 channel(true,kind,locking) throws {
+  return this.writerHelper(kind, locking, start, end, new ioHints(hints), style: iostyleInternal);
 }
 
 /*
@@ -2981,6 +3114,15 @@ proc file.writer(param kind=iokind.dynamic, param locking=true,
                  hints = ioHints.empty):
                  channel(true,kind,locking) throws {
   return this.writerHelper(kind, locking, start, end, hints);
+}
+
+pragma "last resort"
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.writer' that takes an 'ioHints' record instead."
+proc file.writer(param kind=iokind.dynamic, param locking=true,
+                 start:int(64) = 0, end:int(64) = max(int(64)),
+                 hints:iohints=IOHINT_NONE):
+                 channel(true,kind,locking) throws {
+  return this.writerHelper(kind, locking, start, end, new ioHints(hints));
 }
 
 pragma "no doc"

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -759,24 +759,24 @@ extern const QIO_HINT_OWNED:c_int;
     to hint. Expect to use NONE most of the time.
     The other hints can be bitwise-ORed in.
  */
-deprecated "'IOHINT_NONE' is deprecated; please use 'ioHints.empty' instead"
+deprecated "'IOHINT_NONE' is deprecated; please use 'ioHintSet.empty' instead"
 const IOHINT_NONE = 0:c_int;
 
 /* IOHINT_RANDOM means we expect random access to a file */
-deprecated "'IOHINT_RANDOM' is deprecated; please use 'ioHints.random' instead"
+deprecated "'IOHINT_RANDOM' is deprecated; please use 'ioHintSet.random' instead"
 const IOHINT_RANDOM = QIO_HINT_RANDOM;
 
 /*  IOHINT_SEQUENTIAL means expect sequential access. On
     Linux, this should double the readahead.
  */
-deprecated "'IOHINT_SEQUENTIAL' is deprecated; please use 'ioHints.sequential' instead"
+deprecated "'IOHINT_SEQUENTIAL' is deprecated; please use 'ioHintSet.sequential' instead"
 const IOHINT_SEQUENTIAL = QIO_HINT_SEQUENTIAL;
 
 /*  IOHINT_CACHED means we expect the entire file
     to be cached and/or we pull it in all at
     once. May request readahead on the entire file.
  */
-deprecated "'IOHINT_CACHED' is deprecated; please use 'ioHints.prefetch' instead"
+deprecated "'IOHINT_CACHED' is deprecated; please use 'ioHintSet.prefetch' instead"
 const IOHINT_CACHED = QIO_HINT_CACHED;
 
 /*  IOHINT_PARALLEL means that we expect to have many
@@ -1405,7 +1405,7 @@ extern type fdflag_t = c_int;
 //  QIO_HINT_CACHED,
 //  QIO_HINT_NOREUSE
 
-deprecated "the 'iohints' type is deprecated; please use the 'ioHints' record type instead."
+deprecated "the 'iohints' type is deprecated; please use the 'ioHintSet' type instead."
 extern type iohints = c_int;
 
 private const IOHINTS_NONE:        c_int = 0;
@@ -1414,9 +1414,9 @@ private const IOHINTS_RANDOM:      c_int = QIO_HINT_RANDOM;
 private const IOHINTS_PREFETCH:    c_int = QIO_HINT_CACHED;
 private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
 
-/* A value of the :record:`ioHints` type defines a set of hints about the I/O that
-  the file or channel will perform.  These hints may be used by the
-  implementation to select optimized versions of the I/O operations.
+/* A value of the :record:`ioHintSet` type defines a set of hints about /
+  the I/O that the file or channel will perform.  These hints may be used
+  by the implementation to select optimized versions of the I/O operations.
 
   Most hints have POSIX equivalents associated with posix_fadvise() and
   posix_madvise().
@@ -1426,7 +1426,7 @@ private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
     use IO;
 
     // define a set of hints using a union
-    var hints = ioHints::sequential | ioHints::prefetch;
+    var hints = ioHintSet::sequential | ioHintSet::prefetch;
 
     // open a file using the hints
     var f: file;
@@ -1434,59 +1434,59 @@ private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
       f = open("path/to/my/file.txt", iomode.r, hints=hints);
     }
 */
-record ioHints {
+record ioHintSet {
   pragma "no doc"
   var _internal : c_int;
 
   /* Defines an empty set, which provides no hints.
   Corresponds to 'POSIX_*_NORMAL'.
   */
-  proc type empty { return new ioHints(IOHINTS_NONE); }
+  proc type empty { return new ioHintSet(IOHINTS_NONE); }
 
  /* Suggests that the file will be accessed sequentially.
   Corresponds to 'POSIX_*_SEQUENTIAL'
   */
-  proc type sequential { return new ioHints(IOHINTS_SEQUENTIAL); }
+  proc type sequential { return new ioHintSet(IOHINTS_SEQUENTIAL); }
 
   /* Suggests that the file will be accessed randomly.
   Corresponds to 'POSIX_*_RANDOM'.
   */
-  proc type random { return new ioHints(IOHINTS_RANDOM); }
+  proc type random { return new ioHintSet(IOHINTS_RANDOM); }
 
   /* Suggests that the runtime/OS should immediately begin prefetching the file contents.
   Corresponds to 'POSIX_*_WILLNEED'.
   */
-  proc type prefetch { return new ioHints(IOHINTS_PREFETCH); }
+  proc type prefetch { return new ioHintSet(IOHINTS_PREFETCH); }
 
   /* Suggests that 'mmap' should be used to access the file contents
   */
-  proc type mmap { return new ioHints(IOHINTS_MMAP); }
+  proc type mmap { return new ioHintSet(IOHINTS_MMAP); }
 
   pragma "no doc"
-  proc type direct(constant: c_int) { return new ioHints(constant); }
+  proc type direct(constant: c_int) { return new ioHintSet(constant); }
 }
 
-/* Compute the union of two sets of ioHints
+/* Compute the union of two ioHintSets
 */
-operator ioHints.|(lhs: ioHints, rhs: ioHints) {
-  return new ioHints(lhs._internal | rhs._internal);
+operator ioHintSet.|(lhs: ioHintSet, rhs: ioHintSet) {
+  return new ioHintSet(lhs._internal | rhs._internal);
 }
 
-/* Compute the intersection of two sets of ioHints
+/* Compute the intersection of two ioHintSets
 */
-operator ioHints.&(lhs: ioHints, rhs: ioHints) {
-  return new ioHints(lhs._internal & rhs._internal);
+operator ioHintSet.&(lhs: ioHintSet, rhs: ioHintSet) {
+  return new ioHintSet(lhs._internal & rhs._internal);
 }
 
-/* Compare two sets of ioHints for equality
+/* Compare two ioHintSets for equality
 */
-operator ioHints.==(lhs: ioHints, rhs: ioHints) {
+operator ioHintSet.==(lhs: ioHintSet, rhs: ioHintSet) {
   return lhs._internal == rhs._internal;
 }
 
-/* Compare two sets of ioHints for inequality
+/* Compare two ioHintSets for inequality
 */
-operator ioHints.!=(lhs: ioHints, rhs: ioHints) {
+operator ioHintSet.!=(lhs: ioHintSet, rhs: ioHintSet) {
   return !(lhs == rhs);
 }
 
@@ -1753,16 +1753,16 @@ proc _modestring(mode:iomode) {
 }
 
 deprecated "open with a style argument is deprecated"
-proc open(path:string, mode:iomode, hints=ioHints.empty,
+proc open(path:string, mode:iomode, hints=ioHintSet.empty,
           style:iostyle): file throws {
   return openHelper(path, mode, hints, style:iostyleInternal);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead."
 proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE,
           style:iostyle): file throws {
-  return openHelper(path, mode, new ioHints(hints), style:iostyleInternal);
+  return openHelper(path, mode, new ioHintSet(hints), style:iostyleInternal);
 }
 
 /*
@@ -1776,22 +1776,22 @@ to create a channel to actually perform I/O operations
              whether or not to create the file if it doesn't exist.
              See :type:`iomode`.
 :arg hints: optional argument to specify any hints to the I/O system about
-            this file. See :record:`ioHints`.
+            this file. See :record:`ioHintSet`.
 :returns: an open file to the requested resource.
 
 :throws SystemError: Thrown if the file could not be opened.
 */
-proc open(path:string, mode:iomode, hints=ioHints.empty): file throws {
+proc open(path:string, mode:iomode, hints=ioHintSet.empty): file throws {
   return openHelper(path, mode, hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead."
 proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE): file throws {
-  return openHelper(path, mode, new ioHints(hints));
+  return openHelper(path, mode, new ioHintSet(hints));
 }
 
-private proc openHelper(path:string, mode:iomode, hints=ioHints.empty,
+private proc openHelper(path:string, mode:iomode, hints=ioHintSet.empty,
                         style:iostyleInternal = defaultIOStyleInternal()): file throws {
 
   var local_style = style;
@@ -1869,14 +1869,14 @@ proc openplugin(pluginFile: QioPluginFile, mode:iomode,
 }
 
 deprecated "openfd with a style argument is deprecated"
-proc openfd(fd: fd_t, hints=ioHints.empty, style:iostyle):file throws {
+proc openfd(fd: fd_t, hints=ioHintSet.empty, style:iostyle):file throws {
   return openfdHelper(fd, hints, style: iostyleInternal);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead."
 proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE, style:iostyle):file throws {
-  return openfdHelper(fd, new ioHints(hints), style: iostyleInternal);
+  return openfdHelper(fd, new ioHintSet(hints), style: iostyleInternal);
 }
 
 /*
@@ -1900,22 +1900,22 @@ The system file descriptor will be closed when the Chapel file is closed.
 
 :arg fd: a system file descriptor.
 :arg hints: optional argument to specify any hints to the I/O system about
-            this file. See :record:`ioHints`.
+            this file. See :record:`ioHintSet`.
 :returns: an open :record:`file` using the specified file descriptor.
 
 :throws SystemError: Thrown if the file descriptor could not be retrieved.
 */
-proc openfd(fd: fd_t, hints = ioHints.empty):file throws {
+proc openfd(fd: fd_t, hints = ioHintSet.empty):file throws {
   return openfdHelper(fd, hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead."
 proc openfd(fd: fd_t, hints:iohints=IOHINT_NONE):file throws {
-  return openfdHelper(fd, new ioHints(hints));
+  return openfdHelper(fd, new ioHintSet(hints));
 }
 
-private proc openfdHelper(fd: fd_t, hints = ioHints.empty,
+private proc openfdHelper(fd: fd_t, hints = ioHintSet.empty,
                           style:iostyleInternal = defaultIOStyleInternal()):file throws {
   var local_style = style;
   var ret:file;
@@ -1937,14 +1937,14 @@ private proc openfdHelper(fd: fd_t, hints = ioHints.empty,
 }
 
 deprecated "openfp with a style argument is deprecated"
-proc openfp(fp: _file, hints=ioHints.empty, style:iostyle):file throws {
+proc openfp(fp: _file, hints=ioHintSet.empty, style:iostyle):file throws {
   return openfpHelper(fp, hints, style: iostyleInternal);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead."
 proc openfp(fp: _file, hints:iohints=IOHINT_NONE, style:iostyle):file throws {
-  return openfpHelper(fp, new ioHints(hints), style: iostyleInternal);
+  return openfpHelper(fp, new ioHintSet(hints), style: iostyleInternal);
 }
 
 /*
@@ -1962,22 +1962,22 @@ that once the file is open, you will need to use a :proc:`file.reader` or
 
 :arg fp: a C ``FILE*`` to work with
 :arg hints: optional argument to specify any hints to the I/O system about
-            this file. See :record:`ioHints`.
+            this file. See :record:`ioHintSet`.
 :returns: an open :record:`file` that uses the underlying FILE* argument.
 
 :throws SystemError: Thrown if the C file could not be retrieved.
  */
-proc openfp(fp: _file, hints=ioHints.empty):file throws {
+proc openfp(fp: _file, hints=ioHintSet.empty):file throws {
   return openfpHelper(fp, hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead."
 proc openfp(fp: _file, hints:iohints=IOHINT_NONE):file throws {
-  return openfpHelper(fp, new ioHints(hints));
+  return openfpHelper(fp, new ioHintSet(hints));
 }
 
-private proc openfpHelper(fp: _file, hints=ioHints.empty,
+private proc openfpHelper(fp: _file, hints=ioHintSet.empty,
                           style:iostyleInternal = defaultIOStyleInternal()):file throws {
   var local_style = style;
   var ret:file;
@@ -1999,14 +1999,14 @@ private proc openfpHelper(fp: _file, hints=ioHints.empty,
 }
 
 deprecated "opentmp with a style argument is deprecated"
-proc opentmp(hints=ioHints.empty, style:iostyle):file throws {
+proc opentmp(hints=ioHintSet.empty, style:iostyle):file throws {
   return opentmpHelper(hints, style: iostyleInternal);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead."
 proc opentmp(hints:iohints=IOHINT_NONE, style:iostyle):file throws {
-  return opentmpHelper(new ioHints(hints), style: iostyleInternal);
+  return opentmpHelper(new ioHintSet(hints), style: iostyleInternal);
 }
 
 /*
@@ -2027,22 +2027,22 @@ that is, a new file is created that supports both writing and reading.
   that is, a new file is created that supports both writing and reading.
 
 :arg hints: optional argument to specify any hints to the I/O system about
-            this file. See :record:`ioHints`.
+            this file. See :record:`ioHintSet`.
 :returns: an open temporary file.
 
 :throws SystemError: Thrown if the temporary file could not be opened.
 */
-proc opentmp(hints=ioHints.empty):file throws {
+proc opentmp(hints=ioHintSet.empty):file throws {
   return opentmpHelper(hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead."
 proc opentmp(hints:iohints=IOHINT_NONE):file throws {
-  return opentmpHelper(new ioHints(hints));
+  return opentmpHelper(new ioHintSet(hints));
 }
 
-private proc opentmpHelper(hints=ioHints.empty,
+private proc opentmpHelper(hints=ioHintSet.empty,
                            style:iostyleInternal = defaultIOStyleInternal()):file throws {
   var local_style = style;
   var ret:file;
@@ -2234,7 +2234,7 @@ proc channel.init(param writing:bool, param kind:iokind, param locking:bool,
 }
 
 pragma "no doc"
-proc channel.init(param writing:bool, param kind:iokind, param locking:bool, f:file, out error:syserr, hints: ioHints, start:int(64), end:int(64), in local_style:iostyleInternal) {
+proc channel.init(param writing:bool, param kind:iokind, param locking:bool, f:file, out error:syserr, hints: ioHintSet, start:int(64), end:int(64), in local_style:iostyleInternal) {
   this.init(writing, kind, locking);
   on f.home {
     this.home = f.home;
@@ -2760,7 +2760,7 @@ deprecated "openreader with a style argument is deprecated"
 proc openreader(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
-                hints = ioHints.empty,
+                hints = ioHintSet.empty,
                 style:iostyle)
     : channel(false, kind, locking) throws {
   return openreaderHelper(path, kind, locking, start, end, hints,
@@ -2772,14 +2772,14 @@ proc openreader(path:string,
 // channel presumably).
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead."
 proc openreader(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE,
                 style:iostyle)
     : channel(false, kind, locking) throws {
-  return openreaderHelper(path, kind, locking, start, end, new ioHints(hints),
+  return openreaderHelper(path, kind, locking, start, end, new ioHintSet(hints),
                           style: iostyleInternal);
 }
 
@@ -2805,7 +2805,7 @@ This function is equivalent to calling :proc:`open` and then
           channel should no longer be allowed to read. Defaults
           to a ``max(int(64))`` - meaning no end point.
 :arg hints: optional argument to specify any hints to the I/O system about
-            this file. See :record:`ioHints`.
+            this file. See :record:`ioHintSet`.
 :returns: an open reading channel to the requested resource.
 
 :throws SystemError: Thrown if a reading channel could not be returned.
@@ -2813,25 +2813,25 @@ This function is equivalent to calling :proc:`open` and then
 proc openreader(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
-                hints=ioHints.empty)
+                hints=ioHintSet.empty)
     : channel(false, kind, locking) throws {
   return openreaderHelper(path, kind, locking, start, end, hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead."
 proc openreader(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE)
     : channel(false, kind, locking) throws {
-  return openreaderHelper(path, kind, locking, start, end, new ioHints(hints));
+  return openreaderHelper(path, kind, locking, start, end, new ioHintSet(hints));
 }
 
 private proc openreaderHelper(path:string,
                               param kind=iokind.dynamic, param locking=true,
                               start:int(64) = 0, end:int(64) = max(int(64)),
-                              hints=ioHints.empty,
+                              hints=ioHintSet.empty,
                               style:iostyleInternal = defaultIOStyleInternal())
   : channel(false, kind, locking) throws {
 
@@ -2843,7 +2843,7 @@ deprecated "openwriter with a style argument is deprecated"
 proc openwriter(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
-                hints=ioHints.empty,
+                hints=ioHintSet.empty,
                 style:iostyle)
     : channel(true, kind, locking) throws {
   return openwriterHelper(path, kind, locking, start, end, hints,
@@ -2851,14 +2851,14 @@ proc openwriter(path:string,
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openwriter' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openwriter' that takes an 'ioHintSet' instead."
 proc openwriter(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE,
                 style:iostyle)
     : channel(true, kind, locking) throws {
-  return openwriterHelper(path, kind, locking, start, end, new ioHints(hints),
+  return openwriterHelper(path, kind, locking, start, end, new ioHintSet(hints),
                     style: iostyleInternal);
 }
 
@@ -2884,7 +2884,7 @@ This function is equivalent to calling :proc:`open` with ``iomode.cwr`` and then
           channel should no longer be allowed to write. Defaults
           to a ``max(int(64))`` - meaning no end point.
 :arg hints: optional argument to specify any hints to the I/O system about
-            this file. See :record:`ioHints`.
+            this file. See :record:`ioHintSet`.
 :returns: an open writing channel to the requested resource.
 
 :throws SystemError: Thrown if a writing channel could not be returned.
@@ -2892,25 +2892,25 @@ This function is equivalent to calling :proc:`open` with ``iomode.cwr`` and then
 proc openwriter(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
-                hints = ioHints.empty)
+                hints = ioHintSet.empty)
     : channel(true, kind, locking) throws {
   return openwriterHelper(path, kind, locking, start, end, hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'openwriter' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'openwriter' that takes an 'ioHintSet' instead."
 proc openwriter(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE)
     : channel(true, kind, locking) throws {
-  return openwriterHelper(path, kind, locking, start, end, new ioHints(hints));
+  return openwriterHelper(path, kind, locking, start, end, new ioHintSet(hints));
 }
 
 private proc openwriterHelper(path:string,
                               param kind=iokind.dynamic, param locking=true,
                               start:int(64) = 0, end:int(64) = max(int(64)),
-                              hints = ioHints.empty,
+                              hints = ioHintSet.empty,
                               style:iostyleInternal = defaultIOStyleInternal())
   : channel(true, kind, locking) throws {
 
@@ -2921,7 +2921,7 @@ private proc openwriterHelper(path:string,
 deprecated "reader with a style argument is deprecated"
 proc file.reader(param kind=iokind.dynamic, param locking=true,
                  start:int(64) = 0, end:int(64) = max(int(64)),
-                 hints = ioHints.empty,
+                 hints = ioHintSet.empty,
                  style:iostyle): channel(false, kind, locking)
                  throws {
   return this.readerHelper(kind, locking, start, end, hints, style: iostyleInternal);
@@ -2957,28 +2957,28 @@ proc file.reader(param kind=iokind.dynamic, param locking=true,
              channel should no longer be allowed to read. Defaults
              to a ``max(int(64))`` - meaning no end point.
    :arg hints: provide hints about the I/O that this channel will perform. See
-               :record:`ioHints`. The default value of `ioHints.empty`
+               :record:`ioHintSet`. The default value of `ioHintSet.empty`
                will cause the channel to use the hints provided when the
                file was opened.
 
    :throws SystemError: Thrown if a file reader channel could not be returned.
  */
 proc file.reader(param kind=iokind.dynamic, param locking=true, start:int(64) = 0,
-                 end:int(64) = max(int(64)), hints = ioHints.empty): channel(false, kind, locking) throws {
+                 end:int(64) = max(int(64)), hints = ioHintSet.empty): channel(false, kind, locking) throws {
   return this.readerHelper(kind, locking, start, end, hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'file.reader' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.reader' that takes an 'ioHintSet' instead."
 proc file.reader(param kind=iokind.dynamic, param locking=true, start:int(64) = 0,
                  end:int(64) = max(int(64)), hints:iohints=IOHINT_NONE): channel(false, kind, locking) throws {
-  return this.readerHelper(kind, locking, start, end, new ioHints(hints));
+  return this.readerHelper(kind, locking, start, end, new ioHintSet(hints));
 }
 
 pragma "no doc"
 proc file.readerHelper(param kind=iokind.dynamic, param locking=true,
                        start:int(64) = 0, end:int(64) = max(int(64)),
-                       hints = ioHints.empty,
+                       hints = ioHintSet.empty,
                        style:iostyleInternal = this._style): channel(false, kind, locking) throws {
   // It is the responsibility of the caller to release the returned channel
   // if the error code is nonzero.
@@ -2996,18 +2996,18 @@ proc file.readerHelper(param kind=iokind.dynamic, param locking=true,
 
 deprecated "lines with a local_style argument is deprecated"
 proc file.lines(param locking:bool = true, start:int(64) = 0,
-                end:int(64) = max(int(64)), hints = ioHints.empty,
+                end:int(64) = max(int(64)), hints = ioHintSet.empty,
                 in local_style:iostyle) throws {
   return this.linesHelper(locking, start, end, hints,
                           local_style: iostyleInternal);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'file.lines' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.lines' that takes an 'ioHintSet' instead."
 proc file.lines(param locking:bool = true, start:int(64) = 0,
                 end:int(64) = max(int(64)), hints:iohints=IOHINT_NONE,
                 in local_style:iostyle) throws {
-  return this.linesHelper(locking, start, end, new ioHints(hints),
+  return this.linesHelper(locking, start, end, new ioHintSet(hints),
                           local_style: iostyleInternal);
 }
 
@@ -3019,21 +3019,21 @@ proc file.lines(param locking:bool = true, start:int(64) = 0,
  */
 proc file.lines(param locking:bool = true, start:int(64) = 0,
                 end:int(64) = max(int(64)),
-                hints = ioHints.empty) throws {
+                hints = ioHintSet.empty) throws {
   return this.linesHelper(locking, start, end, hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'file.lines' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.lines' that takes an 'ioHintSet' instead."
 proc file.lines(param locking:bool = true, start:int(64) = 0,
                 end:int(64) = max(int(64)),
                 hints:iohints=IOHINT_NONE) throws {
-  return this.linesHelper(locking, start, end, new ioHints(hints));
+  return this.linesHelper(locking, start, end, new ioHintSet(hints));
 }
 
 pragma "no doc"
 proc file.linesHelper(param locking:bool = true, start:int(64) = 0,
-                      end:int(64) = max(int(64)), hints = ioHints.empty,
+                      end:int(64) = max(int(64)), hints = ioHintSet.empty,
                       in local_style:iostyleInternal = this._style) throws {
   local_style.string_format = QIO_STRING_FORMAT_TOEND;
   local_style.string_end = 0x0a; // '\n'
@@ -3054,18 +3054,18 @@ proc file.linesHelper(param locking:bool = true, start:int(64) = 0,
 deprecated "writer with a style argument is deprecated"
 proc file.writer(param kind=iokind.dynamic, param locking=true,
                  start:int(64) = 0, end:int(64) = max(int(64)),
-                 hints = ioHints.empty, style:iostyle):
+                 hints = ioHintSet.empty, style:iostyle):
                  channel(true,kind,locking) throws {
   return this.writerHelper(kind, locking, start, end, hints, style: iostyleInternal);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'file.writer' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.writer' that takes an 'ioHintSet' instead."
 proc file.writer(param kind=iokind.dynamic, param locking=true,
                  start:int(64) = 0, end:int(64) = max(int(64)),
                  hints:iohints=IOHINT_NONE, style:iostyle):
                  channel(true,kind,locking) throws {
-  return this.writerHelper(kind, locking, start, end, new ioHints(hints), style: iostyleInternal);
+  return this.writerHelper(kind, locking, start, end, new ioHintSet(hints), style: iostyleInternal);
 }
 
 /*
@@ -3103,7 +3103,7 @@ proc file.writer(param kind=iokind.dynamic, param locking=true,
              channel should no longer be allowed to write. Defaults
              to a ``max(int(64))`` - meaning no end point.
    :arg hints: provide hints about the I/O that this channel will perform. See
-               :record:`ioHints`. The default value of `ioHints.empty`
+               :record:`ioHintSet`. The default value of `ioHintSet.empty`
                will cause the channel to use the hints provided when the
                file was opened.
 
@@ -3111,24 +3111,24 @@ proc file.writer(param kind=iokind.dynamic, param locking=true,
  */
 proc file.writer(param kind=iokind.dynamic, param locking=true,
                  start:int(64) = 0, end:int(64) = max(int(64)),
-                 hints = ioHints.empty):
+                 hints = ioHintSet.empty):
                  channel(true,kind,locking) throws {
   return this.writerHelper(kind, locking, start, end, hints);
 }
 
 pragma "last resort"
-deprecated "The 'iohints' type is deprecated; please use a variant of 'file.writer' that takes an 'ioHints' record instead."
+deprecated "The 'iohints' type is deprecated; please use a variant of 'file.writer' that takes an 'ioHintSet' instead."
 proc file.writer(param kind=iokind.dynamic, param locking=true,
                  start:int(64) = 0, end:int(64) = max(int(64)),
                  hints:iohints=IOHINT_NONE):
                  channel(true,kind,locking) throws {
-  return this.writerHelper(kind, locking, start, end, new ioHints(hints));
+  return this.writerHelper(kind, locking, start, end, new ioHintSet(hints));
 }
 
 pragma "no doc"
 proc file.writerHelper(param kind=iokind.dynamic, param locking=true,
                        start:int(64) = 0, end:int(64) = max(int(64)),
-                       hints = ioHints.empty, style:iostyleInternal = this._style):
+                       hints = ioHintSet.empty, style:iostyleInternal = this._style):
   channel(true,kind,locking) throws {
   // It is the responsibility of the caller to retain and release the returned
   // channel.

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -584,7 +584,7 @@ module Subprocess {
       // goes out of scope, but the channel will still keep
       // the file alive by referring to it.
       try {
-        var stdin_file = openfd(stdin_fd, hints=QIO_HINT_OWNED);
+        var stdin_file = openfd(stdin_fd, hints=ioHints.direct(QIO_HINT_OWNED));
         ret.stdin_channel = stdin_file.writer();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -609,7 +609,7 @@ module Subprocess {
     if stdout_pipe {
       ret.stdout_pipe = true;
       try {
-        var stdout_file = openfd(stdout_fd, hints=QIO_HINT_OWNED);
+        var stdout_file = openfd(stdout_fd, hints=ioHints.direct(QIO_HINT_OWNED));
         ret.stdout_channel = stdout_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -623,7 +623,7 @@ module Subprocess {
     if stderr_pipe {
       ret.stderr_pipe = true;
       try {
-        ret.stderr_file = openfd(stderr_fd, hints=QIO_HINT_OWNED);
+        ret.stderr_file = openfd(stderr_fd, hints=ioHints.direct(QIO_HINT_OWNED));
         ret.stderr_channel = ret.stderr_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -584,7 +584,7 @@ module Subprocess {
       // goes out of scope, but the channel will still keep
       // the file alive by referring to it.
       try {
-        var stdin_file = openfd(stdin_fd, hints=ioHints.direct(QIO_HINT_OWNED));
+        var stdin_file = openfd(stdin_fd, hints=ioHintSet.direct(QIO_HINT_OWNED));
         ret.stdin_channel = stdin_file.writer();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -609,7 +609,7 @@ module Subprocess {
     if stdout_pipe {
       ret.stdout_pipe = true;
       try {
-        var stdout_file = openfd(stdout_fd, hints=ioHints.direct(QIO_HINT_OWNED));
+        var stdout_file = openfd(stdout_fd, hints=ioHintSet.direct(QIO_HINT_OWNED));
         ret.stdout_channel = stdout_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -623,7 +623,7 @@ module Subprocess {
     if stderr_pipe {
       ret.stderr_pipe = true;
       try {
-        ret.stderr_file = openfd(stderr_fd, hints=ioHints.direct(QIO_HINT_OWNED));
+        ret.stderr_file = openfd(stderr_fd, hints=ioHintSet.direct(QIO_HINT_OWNED));
         ret.stderr_channel = ret.stderr_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -606,6 +606,7 @@ module Sys {
     :returns: 1 if ``name`` is defined and 0 if not
     :rtype: `c_int`
    */
+   pragma "last resort"
   deprecated "'Sys.sys_getenv' is deprecated; please use 'OS.sys_getenv' instead"
   extern proc sys_getenv(name:c_string, ref string_out:c_string):c_int;
 

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -606,7 +606,6 @@ module Sys {
     :returns: 1 if ``name`` is defined and 0 if not
     :rtype: `c_int`
    */
-   pragma "last resort"
   deprecated "'Sys.sys_getenv' is deprecated; please use 'OS.sys_getenv' instead"
   extern proc sys_getenv(name:c_string, ref string_out:c_string):c_int;
 

--- a/test/deprecated/IO/iohints.chpl
+++ b/test/deprecated/IO/iohints.chpl
@@ -8,20 +8,10 @@ h = IOHINT_CACHED;
 h = IOHINT_PARALLEL;
 h = IOHINT_NONE;
 
-const ds = defaultIOStyle();
 var f, c;
 
-f = open("./iohints.chpl", iomode.r, hints = h, ds); f.close();
 f = open("./iohints.chpl", iomode.r, hints = h); f.close();
-
-openfd(0, hints = h, ds);
 openfd(0, hints = h);
-
-openfp(chpl_cstdout(), hints = h, ds);
 openfp(chpl_cstdout(), hints = h);
-
-opentmp(hints = h, ds);
 opentmp(hints = h);
-
-c = openreader("./iohints.chpl", hints = h, style=ds); f.close();
 c = openreader("./iohints.chpl", hints = h); f.close();

--- a/test/deprecated/IO/iohints.chpl
+++ b/test/deprecated/IO/iohints.chpl
@@ -1,0 +1,27 @@
+use IO;
+use CTypes;
+
+var h : iohints;
+h = IOHINT_RANDOM;
+h = IOHINT_SEQUENTIAL;
+h = IOHINT_CACHED;
+h = IOHINT_PARALLEL;
+h = IOHINT_NONE;
+
+const ds = defaultIOStyle();
+var f, c;
+
+f = open("./iohints.chpl", iomode.r, hints = h, ds); f.close();
+f = open("./iohints.chpl", iomode.r, hints = h); f.close();
+
+openfd(0, hints = h, ds);
+openfd(0, hints = h);
+
+openfp(chpl_cstdout(), hints = h, ds);
+openfp(chpl_cstdout(), hints = h);
+
+opentmp(hints = h, ds);
+opentmp(hints = h);
+
+c = openreader("./iohints.chpl", hints = h, style=ds); f.close();
+c = openreader("./iohints.chpl", hints = h); f.close();

--- a/test/deprecated/IO/iohints.chpl
+++ b/test/deprecated/IO/iohints.chpl
@@ -8,10 +8,19 @@ h = IOHINT_CACHED;
 h = IOHINT_PARALLEL;
 h = IOHINT_NONE;
 
-var f, c;
+var f, cr, cw;
 
-f = open("./iohints.chpl", iomode.r, hints = h); f.close();
+f = open("./iohints.chpl", iomode.r, hints = h);
+f.reader(hints = h);
+f.close();
+
+f = open("./iohints.chpl", iomode.rw, hints = h);
+f.writer(hints = h);
+f.close();
+
 openfd(0, hints = h);
 openfp(chpl_cstdout(), hints = h);
 opentmp(hints = h);
-c = openreader("./iohints.chpl", hints = h); f.close();
+
+cr = openreader("./iohints.chpl", hints = h); cr.close();
+cw = openwriter("./blah.txt", hints = h); cw.close();

--- a/test/deprecated/IO/iohints.good
+++ b/test/deprecated/IO/iohints.good
@@ -4,14 +4,8 @@ iohints.chpl:6: warning: 'IOHINT_SEQUENTIAL' is deprecated; please use 'ioHintSe
 iohints.chpl:7: warning: 'IOHINT_CACHED' is deprecated; please use 'ioHintSet.prefetch' instead
 iohints.chpl:8: warning: 'IOHINT_PARALLEL' is deprecated
 iohints.chpl:9: warning: 'IOHINT_NONE' is deprecated; please use 'ioHintSet.empty' instead
-iohints.chpl:11: warning: defaultIOStyle is deprecated due to returning a deprecated type
-iohints.chpl:14: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead.
-iohints.chpl:15: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead.
-iohints.chpl:17: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead.
-iohints.chpl:18: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead.
-iohints.chpl:20: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead.
-iohints.chpl:21: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead.
-iohints.chpl:23: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead.
-iohints.chpl:24: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead.
-iohints.chpl:26: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead.
-iohints.chpl:27: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead.
+iohints.chpl:13: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead.
+iohints.chpl:14: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead.
+iohints.chpl:15: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead.
+iohints.chpl:16: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead.
+iohints.chpl:17: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead.

--- a/test/deprecated/IO/iohints.good
+++ b/test/deprecated/IO/iohints.good
@@ -1,0 +1,17 @@
+iohints.chpl:4: warning: the 'iohints' type is deprecated; please use the 'ioHints' record type instead.
+iohints.chpl:5: warning: 'IOHINT_RANDOM' is deprecated; please use 'ioHints.random' instead
+iohints.chpl:6: warning: 'IOHINT_SEQUENTIAL' is deprecated; please use 'ioHints.sequential' instead
+iohints.chpl:7: warning: 'IOHINT_CACHED' is deprecated; please use 'ioHints.prefetch' instead
+iohints.chpl:8: warning: 'IOHINT_PARALLEL' is deprecated
+iohints.chpl:9: warning: 'IOHINT_NONE' is deprecated; please use 'ioHints.empty' instead
+iohints.chpl:11: warning: defaultIOStyle is deprecated due to returning a deprecated type
+iohints.chpl:14: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHints' record instead.
+iohints.chpl:15: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHints' record instead.
+iohints.chpl:17: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHints' record instead.
+iohints.chpl:18: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHints' record instead.
+iohints.chpl:20: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHints' record instead.
+iohints.chpl:21: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHints' record instead.
+iohints.chpl:23: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHints' record instead.
+iohints.chpl:24: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHints' record instead.
+iohints.chpl:26: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHints' record instead.
+iohints.chpl:27: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHints' record instead.

--- a/test/deprecated/IO/iohints.good
+++ b/test/deprecated/IO/iohints.good
@@ -5,7 +5,11 @@ iohints.chpl:7: warning: 'IOHINT_CACHED' is deprecated; please use 'ioHintSet.pr
 iohints.chpl:8: warning: 'IOHINT_PARALLEL' is deprecated
 iohints.chpl:9: warning: 'IOHINT_NONE' is deprecated; please use 'ioHintSet.empty' instead
 iohints.chpl:13: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead.
-iohints.chpl:14: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead.
-iohints.chpl:15: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead.
-iohints.chpl:16: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead.
-iohints.chpl:17: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead.
+iohints.chpl:14: warning: The 'iohints' type is deprecated; please use a variant of 'file.reader' that takes an 'ioHintSet' instead.
+iohints.chpl:17: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead.
+iohints.chpl:18: warning: The 'iohints' type is deprecated; please use a variant of 'file.writer' that takes an 'ioHintSet' instead.
+iohints.chpl:21: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead.
+iohints.chpl:22: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead.
+iohints.chpl:23: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead.
+iohints.chpl:25: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead.
+iohints.chpl:26: warning: The 'iohints' type is deprecated; please use a variant of 'openwriter' that takes an 'ioHintSet' instead.

--- a/test/deprecated/IO/iohints.good
+++ b/test/deprecated/IO/iohints.good
@@ -1,17 +1,17 @@
-iohints.chpl:4: warning: the 'iohints' type is deprecated; please use the 'ioHints' record type instead.
-iohints.chpl:5: warning: 'IOHINT_RANDOM' is deprecated; please use 'ioHints.random' instead
-iohints.chpl:6: warning: 'IOHINT_SEQUENTIAL' is deprecated; please use 'ioHints.sequential' instead
-iohints.chpl:7: warning: 'IOHINT_CACHED' is deprecated; please use 'ioHints.prefetch' instead
+iohints.chpl:4: warning: the 'iohints' type is deprecated; please use the 'ioHintSet' type instead.
+iohints.chpl:5: warning: 'IOHINT_RANDOM' is deprecated; please use 'ioHintSet.random' instead
+iohints.chpl:6: warning: 'IOHINT_SEQUENTIAL' is deprecated; please use 'ioHintSet.sequential' instead
+iohints.chpl:7: warning: 'IOHINT_CACHED' is deprecated; please use 'ioHintSet.prefetch' instead
 iohints.chpl:8: warning: 'IOHINT_PARALLEL' is deprecated
-iohints.chpl:9: warning: 'IOHINT_NONE' is deprecated; please use 'ioHints.empty' instead
+iohints.chpl:9: warning: 'IOHINT_NONE' is deprecated; please use 'ioHintSet.empty' instead
 iohints.chpl:11: warning: defaultIOStyle is deprecated due to returning a deprecated type
-iohints.chpl:14: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHints' record instead.
-iohints.chpl:15: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHints' record instead.
-iohints.chpl:17: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHints' record instead.
-iohints.chpl:18: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHints' record instead.
-iohints.chpl:20: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHints' record instead.
-iohints.chpl:21: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHints' record instead.
-iohints.chpl:23: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHints' record instead.
-iohints.chpl:24: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHints' record instead.
-iohints.chpl:26: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHints' record instead.
-iohints.chpl:27: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHints' record instead.
+iohints.chpl:14: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead.
+iohints.chpl:15: warning: The 'iohints' type is deprecated; please use a variant of 'open' that takes an 'ioHintSet' instead.
+iohints.chpl:17: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead.
+iohints.chpl:18: warning: The 'iohints' type is deprecated; please use a variant of 'openfd' that takes an 'ioHintSet' instead.
+iohints.chpl:20: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead.
+iohints.chpl:21: warning: The 'iohints' type is deprecated; please use a variant of 'openfp' that takes an 'ioHintSet' instead.
+iohints.chpl:23: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead.
+iohints.chpl:24: warning: The 'iohints' type is deprecated; please use a variant of 'opentmp' that takes an 'ioHintSet' instead.
+iohints.chpl:26: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead.
+iohints.chpl:27: warning: The 'iohints' type is deprecated; please use a variant of 'openreader' that takes an 'ioHintSet' instead.

--- a/test/functions/iterators/tzakian/open_inside_file_iter.chpl
+++ b/test/functions/iterators/tzakian/open_inside_file_iter.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-iter file.split(hints = ioHints.empty) {
+iter file.split(hints = ioHintSet.empty) {
   open(this.path, iomode.r, hints);
   yield 1;
 }

--- a/test/functions/iterators/tzakian/open_inside_file_iter.chpl
+++ b/test/functions/iterators/tzakian/open_inside_file_iter.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-iter file.split(hints:iohints = IOHINT_NONE) {
+iter file.split(hints = ioHints.empty) {
   open(this.path, iomode.r, hints);
   yield 1;
 }

--- a/test/io/tzakian/recordReader/test.chpl
+++ b/test/io/tzakian/recordReader/test.chpl
@@ -3,7 +3,7 @@ use RecordParser, IO;
 // Allow test to run with mmap or without since this test has exposed
 // QIO errors in the past for one of these configurations.
 config const no_mmap=false;
-var hints=IOHINT_NONE;
+var hints=ioHints.empty;
 if no_mmap {
   hints = QIO_METHOD_PREADPWRITE;
 }

--- a/test/io/tzakian/recordReader/test.chpl
+++ b/test/io/tzakian/recordReader/test.chpl
@@ -5,7 +5,7 @@ use RecordParser, IO;
 config const no_mmap=false;
 var hints=ioHints.empty;
 if no_mmap {
-  hints = QIO_METHOD_PREADPWRITE;
+  hints = ioHints.direct(QIO_METHOD_PREADPWRITE);
 }
 
 var f = open("input1.txt", iomode.rw);

--- a/test/io/tzakian/recordReader/test.chpl
+++ b/test/io/tzakian/recordReader/test.chpl
@@ -3,9 +3,9 @@ use RecordParser, IO;
 // Allow test to run with mmap or without since this test has exposed
 // QIO errors in the past for one of these configurations.
 config const no_mmap=false;
-var hints=ioHints.empty;
+var hints=ioHintSet.empty;
 if no_mmap {
-  hints = ioHints.direct(QIO_METHOD_PREADPWRITE);
+  hints = ioHintSet.direct(QIO_METHOD_PREADPWRITE);
 }
 
 var f = open("input1.txt", iomode.rw);

--- a/test/library/standard/IO/ioHintSetOperations.chpl
+++ b/test/library/standard/IO/ioHintSetOperations.chpl
@@ -8,11 +8,17 @@ const rand = ioHintSet.random;
 const pref = ioHintSet.prefetch;
 const mmap = ioHintSet.mmap;
 
-// set operations work
-writeln(empty == seq & rand & pref & mmap);
-writeln(seq | rand != pref | mmap);
-writeln(seq != seq | rand);
-writeln(pref & pref | rand == pref | rand);
+// equality and inequality
+writeln(seq != rand);
+writeln(seq == seq);
+writeln(seq & rand == empty);
+writeln(seq | rand != empty);
+
+// union and intersection
+writeln(pref | rand == rand | pref);
+writeln(pref & rand == rand & pref);
+writeln(ioHintSet.direct(pref._internal | mmap._internal) == pref | mmap);
+writeln(ioHintSet.direct(seq._internal & rand._internal) == seq & rand);
 
 // internal bits are unique
 var s = new set(int(32));

--- a/test/library/standard/IO/ioHintSetOperations.chpl
+++ b/test/library/standard/IO/ioHintSetOperations.chpl
@@ -1,0 +1,24 @@
+use IO;
+use Set;
+
+// constructors work
+const empty = ioHintSet.empty;
+const seq = ioHintSet.sequential;
+const rand = ioHintSet.random;
+const pref = ioHintSet.prefetch;
+const mmap = ioHintSet.mmap;
+
+// set operations work
+writeln(empty == seq & rand & pref & mmap);
+writeln(seq | rand != pref | mmap);
+writeln(seq != seq | rand);
+writeln(pref & pref | rand == pref | rand);
+
+// internal bits are unique
+var s = new set(int(32));
+s.add(empty._internal);
+s.add(seq._internal);
+s.add(rand._internal);
+s.add(pref._internal);
+s.add(mmap._internal);
+writeln(s.size);

--- a/test/library/standard/IO/ioHintSetOperations.good
+++ b/test/library/standard/IO/ioHintSetOperations.good
@@ -2,4 +2,8 @@ true
 true
 true
 true
+true
+true
+true
+true
 5

--- a/test/library/standard/IO/ioHintSetOperations.good
+++ b/test/library/standard/IO/ioHintSetOperations.good
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+5

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -11,7 +11,7 @@ const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
 proc main(args: [] string) {
   const stdin = openfd(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints=QIO_HINT_PARALLEL),
+                             hints=ioHints.direct(QIO_HINT_PARALLEL)),
         len = stdin.size;
   var data: [0..#len] uint(8);
 
@@ -54,7 +54,7 @@ proc main(args: [] string) {
 
   // write the data out to stdout once all tasks have completed
   const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -11,7 +11,7 @@ const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
 proc main(args: [] string) {
   const stdin = openfd(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints=ioHints.direct(QIO_HINT_PARALLEL)),
+                             hints=ioHintSet.direct(QIO_HINT_PARALLEL)),
         len = stdin.size;
   var data: [0..#len] uint(8);
 
@@ -54,7 +54,7 @@ proc main(args: [] string) {
 
   // write the data out to stdout once all tasks have completed
   const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/release/examples/benchmarks/shootout/revcomp.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp.chpl
@@ -40,8 +40,8 @@ proc main(args: [] string) {
       process(data, start, idx-2);
   }
 
-  const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+  const stdoutBin = openfd(1).writer(iokind.native, locking=false,
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/release/examples/benchmarks/shootout/revcomp.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp.chpl
@@ -41,7 +41,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -192,7 +192,7 @@ if example == 0 || example == 3 {
 // we can optimize better (using ``mmap``, if you like details).
   {
     var f = open(testfile, iomode.r,
-                hints=ioHintSet.random | ioHintSet.prefetch | ioHintSet.direct(QIO_HINT_PARALLEL));
+                hints=ioHintSet.random | ioHintSet.prefetch);
 
     // This is a forall loop to do I/O in parallel!
     forall i in 0..#num by -1 {

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -192,7 +192,7 @@ if example == 0 || example == 3 {
 // we can optimize better (using ``mmap``, if you like details).
   {
     var f = open(testfile, iomode.r,
-                 hints=IOHINT_RANDOM|IOHINT_CACHED|IOHINT_PARALLEL);
+                hints=ioHints.random | ioHints.prefetch | ioHints.direct(QIO_HINT_PARALLEL));
 
     // This is a forall loop to do I/O in parallel!
     forall i in 0..#num by -1 {

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -192,7 +192,7 @@ if example == 0 || example == 3 {
 // we can optimize better (using ``mmap``, if you like details).
   {
     var f = open(testfile, iomode.r,
-                hints=ioHints.random | ioHints.prefetch | ioHints.direct(QIO_HINT_PARALLEL));
+                hints=ioHintSet.random | ioHintSet.prefetch | ioHintSet.direct(QIO_HINT_PARALLEL));
 
     // This is a forall loop to do I/O in parallel!
     forall i in 0..#num by -1 {

--- a/test/studies/lammps/shemmy/m-lammps.chpl
+++ b/test/studies/lammps/shemmy/m-lammps.chpl
@@ -228,8 +228,8 @@ proc updateNeighbors()
 proc loadParticles(filename:string, p:[?D], v:[D])
 {
     use IO;
-    var rawFile=open(filename, iomode.r, IOHINT_SEQUENTIAL);
-    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), IOHINT_SEQUENTIAL);
+    var rawFile=open(filename, iomode.r, ioHints.sequential);
+    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), ioHints.sequential);
 
     for i in D
     {

--- a/test/studies/lammps/shemmy/m-lammps.chpl
+++ b/test/studies/lammps/shemmy/m-lammps.chpl
@@ -228,8 +228,8 @@ proc updateNeighbors()
 proc loadParticles(filename:string, p:[?D], v:[D])
 {
     use IO;
-    var rawFile=open(filename, iomode.r, ioHints.sequential);
-    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), ioHints.sequential);
+    var rawFile=open(filename, iomode.r, ioHintSet.sequential);
+    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), ioHintSet.sequential);
 
     for i in D
     {

--- a/test/studies/lammps/shemmy/s-lammps.chpl
+++ b/test/studies/lammps/shemmy/s-lammps.chpl
@@ -146,8 +146,8 @@ proc updateNeighbors()
 proc loadParticles(filename:string, p:[?D], v:[D])
 {
     use IO;
-    var rawFile=open(filename, iomode.r, IOHINT_SEQUENTIAL);
-    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), IOHINT_SEQUENTIAL);
+    var rawFile=open(filename, iomode.r, ioHints.sequential);
+    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), ioHints.sequential);
 
     for i in D
     {

--- a/test/studies/lammps/shemmy/s-lammps.chpl
+++ b/test/studies/lammps/shemmy/s-lammps.chpl
@@ -146,8 +146,8 @@ proc updateNeighbors()
 proc loadParticles(filename:string, p:[?D], v:[D])
 {
     use IO;
-    var rawFile=open(filename, iomode.r, ioHints.sequential);
-    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), ioHints.sequential);
+    var rawFile=open(filename, iomode.r, ioHintSet.sequential);
+    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), ioHintSet.sequential);
 
     for i in D
     {

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
@@ -54,7 +54,7 @@ proc main(args: [] string) {
 
   // Open a binary writer to stdout
   var binout = openfd(1).writer(iokind.native, locking=false, 
-                                hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   binout.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
@@ -54,7 +54,7 @@ proc main(args: [] string) {
 
   // Open a binary writer to stdout
   var binout = openfd(1).writer(iokind.native, locking=false, 
-                                hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
   binout.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
@@ -136,8 +136,8 @@ proc main(args: [] string) {
     }
   }
 
-  const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+  const stdoutBin = openfd(1).writer(iokind.native, locking=false,
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   //
   // This conversion wastes memory, but correct output requires array stdout
   // specifically at the moment.

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
@@ -137,7 +137,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
   //
   // This conversion wastes memory, but correct output requires array stdout
   // specifically at the moment.

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
@@ -129,7 +129,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
   //
   // Necessary for now because list `readWriteThis` includes formatting chars,
   // while arrays do not.

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
@@ -129,7 +129,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   //
   // Necessary for now because list `readWriteThis` includes formatting chars,
   // while arrays do not.

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -13,7 +13,7 @@ config const readSize = 16 * 1024;
 proc main(args: [] string) {
   const stdin = openfd(0);
   var input = stdin.reader(iokind.native, locking=false,
-                           hints=QIO_HINT_PARALLEL);
+                           hints=ioHints.direct(QIO_HINT_PARALLEL));
   var len = stdin.size;
   var data : [0..#len] uint(8);
   
@@ -61,7 +61,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -13,7 +13,7 @@ config const readSize = 16 * 1024;
 proc main(args: [] string) {
   const stdin = openfd(0);
   var input = stdin.reader(iokind.native, locking=false,
-                           hints=ioHints.direct(QIO_HINT_PARALLEL));
+                           hints=ioHintSet.direct(QIO_HINT_PARALLEL));
   var len = stdin.size;
   var data : [0..#len] uint(8);
   
@@ -61,7 +61,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -20,9 +20,9 @@ param eol = '\n'.toByte(),  // end-of-line, as an integer
 
 proc main(args: [] string) {
   var stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                   hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                   hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
       bufLen = 8 * 1024,
       bufDom = {0..<bufLen},
       buf: [bufDom] uint(8),

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -20,9 +20,9 @@ param eol = '\n'.toByte(),  // end-of-line, as an integer
 
 proc main(args: [] string) {
   var stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints=QIO_CH_ALWAYS_UNBUFFERED),
+                                   hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints=QIO_CH_ALWAYS_UNBUFFERED),
+                                   hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
       bufLen = 8 * 1024,
       bufDom = {0..<bufLen},
       buf: [bufDom] uint(8),

--- a/test/studies/shootout/submitted/revcomp2.chpl
+++ b/test/studies/shootout/submitted/revcomp2.chpl
@@ -17,14 +17,14 @@ config const readSize = 16384;  // the chunk size to read at a time
 
 // a channel and coordination variable for writing data to stdout
 var stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                 hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                 hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
     seqToWrite: atomic int = 1;
 
 
 proc main(args: [] string) {
   const stdin = openfd(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                             hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
 
   var curSeq = new Seq?(id=1);
 

--- a/test/studies/shootout/submitted/revcomp2.chpl
+++ b/test/studies/shootout/submitted/revcomp2.chpl
@@ -17,14 +17,14 @@ config const readSize = 16384;  // the chunk size to read at a time
 
 // a channel and coordination variable for writing data to stdout
 var stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                 hints=QIO_CH_ALWAYS_UNBUFFERED),
+                                 hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
     seqToWrite: atomic int = 1;
 
 
 proc main(args: [] string) {
   const stdin = openfd(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints = QIO_CH_ALWAYS_UNBUFFERED);
+                             hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
 
   var curSeq = new Seq?(id=1);
 

--- a/test/studies/shootout/submitted/revcomp3.chpl
+++ b/test/studies/shootout/submitted/revcomp3.chpl
@@ -13,9 +13,9 @@ const table = createTable();    // create the table of code complements
 proc main(args: [] string) {
   use IO;
   const stdinBin = openfd(0).reader(iokind.native, locking=false,
-                                 hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                 hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
         stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                  hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                  hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
 
   // read in the data using an incrementally growing buffer
   var bufLen = 8 * 1024,

--- a/test/studies/shootout/submitted/revcomp3.chpl
+++ b/test/studies/shootout/submitted/revcomp3.chpl
@@ -13,9 +13,9 @@ const table = createTable();    // create the table of code complements
 proc main(args: [] string) {
   use IO;
   const stdinBin = openfd(0).reader(iokind.native, locking=false,
-                                 hints = QIO_CH_ALWAYS_UNBUFFERED),
+                                 hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
         stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                  hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                  hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
 
   // read in the data using an incrementally growing buffer
   var bufLen = 8 * 1024,

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -342,7 +342,7 @@ proc graphNumVertices(G) return G.vertices.size;
 proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
   const f = open(prefix+suffix,
                  if forWriting then iomode.cw else iomode.r,
-                 ioHints.sequential);
+                 ioHintSet.sequential);
   const chan = if forWriting
     then f.writer(iokind.big, false)
     else f.reader(iokind.big, false);

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -342,7 +342,7 @@ proc graphNumVertices(G) return G.vertices.size;
 proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
   const f = open(prefix+suffix,
                  if forWriting then iomode.cw else iomode.r,
-                 IOHINT_SEQUENTIAL);
+                 ioHints.sequential);
   const chan = if forWriting
     then f.writer(iokind.big, false)
     else f.reader(iokind.big, false);

--- a/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
@@ -499,7 +499,7 @@ proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
 proc createGraphFile(prefix:string, suffix:string, param forWriting:bool) {
   return open(prefix+suffix,
               if forWriting then iomode.cw else iomode.r,
-              ioHints.sequential);
+              ioHintSet.sequential);
 }
 
 proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {

--- a/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
@@ -499,7 +499,7 @@ proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
 proc createGraphFile(prefix:string, suffix:string, param forWriting:bool) {
   return open(prefix+suffix,
               if forWriting then iomode.cw else iomode.r,
-              IOHINT_SEQUENTIAL);
+              ioHints.sequential);
 }
 
 proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {


### PR DESCRIPTION
This PR implements the changes proposed here: https://github.com/chapel-lang/chapel/issues/20141

The old `iohints` constants are replaced with a new `ioHints` record type.

Still to do:
- [x] Ensure all tests are passing. 
- [x] Ensure that the `mmap` variant of ioHints is implemented correctly