### PR TITLE
fix(mason-test): use relative path for internal mason tests

### DIFF
--- a/test/mason/masonTestSome/Mason.toml
+++ b/test/mason/masonTestSome/Mason.toml
@@ -3,4 +3,6 @@ name = "masonTestSome"
 version = "0.1.0"
 chplVersion = "1.20.0"
 
+tests = ["compilererror.chpl"]
+
 [dependencies]

--- a/test/mason/masonTestSome/mason-test-show.chpl
+++ b/test/mason/masonTestSome/mason-test-show.chpl
@@ -2,6 +2,6 @@ use MasonTest;
 
 proc main() {
 
-  const args = ["test", "--show", "test/compilererror.chpl"];
+  const args = ["test", "--show"];
   masonTest(args);
 }

--- a/test/mason/masonTestSome/mason-test-show.good
+++ b/test/mason/masonTestSome/mason-test-show.good
@@ -1,12 +1,12 @@
 Skipping registry update since no dependency found in manifest file.
-test/mason/masonTestSome/test/compilererror.chpl:1: syntax error: near 'test'
+test/compilererror.chpl:1: syntax error: near 'test'
 
 ======================================================================
-ERROR test/compilererror.chpl: compilererror
+ERROR compilererror.chpl: compilererror
 ----------------------------------------------------------------------
-test/compilererror.chpl failed to compile
+compilererror.chpl failed to compile
 ----------------------------------------------------------------------
 Ran 1 test in n seconds
 
 FAILED (errors = 1 )
-compilation failed for test/compilererror.chpl
+compilation failed for compilererror.chpl

--- a/test/mason/masonTestSome/mason-test-show.prediff
+++ b/test/mason/masonTestSome/mason-test-show.prediff
@@ -8,7 +8,6 @@ with open(tmp_file, 'w') as tf:
   with open(out_file) as outf:
       for line in outf:
         line = re.sub(r'[0-9]+([.][0-9]+)? seconds', 'n seconds', line)
-        #line = line.replace(CHPL_HOME,"",1).lstrip('/')
         tf.write(line)
 
 shutil.move(tmp_file, out_file)

--- a/test/mason/masonTestSome/mason-test-show.prediff
+++ b/test/mason/masonTestSome/mason-test-show.prediff
@@ -8,7 +8,7 @@ with open(tmp_file, 'w') as tf:
   with open(out_file) as outf:
       for line in outf:
         line = re.sub(r'[0-9]+([.][0-9]+)? seconds', 'n seconds', line)
-        line = line.replace(CHPL_HOME,"",1).lstrip('/')
+        #line = line.replace(CHPL_HOME,"",1).lstrip('/')
         tf.write(line)
 
 shutil.move(tmp_file, out_file)

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -260,7 +260,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
           testPath = "".join(cwd,"/",test);
         }
         else {
-          testPath = "".join(projectHome, '/test/', test);
+          testPath = "".join('test/', test);
         }
         const testName = basename(stripExt(test, ".chpl"));
 


### PR DESCRIPTION
This PR changes the way `mason test` constructs paths for
test files that are defined in the `tests` key of the `mason.toml` file.
The change is to use a relative path rather than an absolute path if
the test is known to the mason package by being defined in the
`tests` key of the `mason.toml` file.

This addresses an issue where the path reported by a failed 
internal `mason test` was absolute, when the expected output would be
relative for internal tests.


TESTING:

- [x] paratest

Reviewed by @bmcdonald3 - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>