### PR TITLE
Add std::hash for CompilerFlags::Name

### DIFF
--- a/compiler/dyno/include/chpl/framework/CompilerFlags.h
+++ b/compiler/dyno/include/chpl/framework/CompilerFlags.h
@@ -91,4 +91,13 @@ public:
 
 } // end namespace chpl
 
+namespace std {
+  template<> struct hash<chpl::CompilerFlags::Name> {
+    inline size_t operator()(const chpl::CompilerFlags::Name& k) const{
+      return (size_t) k;
+    }
+  };
+} // end namespace std
+
+
 #endif


### PR DESCRIPTION
Add std::hash for CompilerFlags::Name to avoid an error with GCC 5.4
