### PR TITLE
Fix `time_t` and `suseconds_t` ambiguity errors on 32 bit systems

### DIFF
--- a/modules/packages/MatrixMarket.chpl
+++ b/modules/packages/MatrixMarket.chpl
@@ -202,8 +202,8 @@ class MMReader {
    var finfo:MMInfo;
 
    proc init(const fname:string) {
-      fd = open(fname, iomode.r, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
-      fin = fd.reader(start=0, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
+      fd = open(fname, iomode.r, hints=ioHints.sequential|ioHints.prefetch);
+      fin = fd.reader(start=0, hints=ioHints.sequential|ioHints.prefetch);
    }
 
    proc read_header() {
@@ -223,7 +223,7 @@ class MMReader {
        // didn't find a percentage, rewind channel by length of read string...
        if percentfound.find("%") == -1 {
          fin.close();
-         fin = fd.reader(start=offset, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
+         fin = fd.reader(start=offset, hints=ioHints.sequential|ioHints.prefetch);
          pctflag = true;
        }
      }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1918,23 +1918,17 @@ The system file descriptor will be closed when the Chapel file is closed.
 
 :throws SystemError: Thrown if the file descriptor could not be retrieved.
 */
-proc openfd(fd: fd_t, hints=ioHints.empty):file throws {
-  return openfdHelper(fd, hints._internal);
+proc openfd(fd: fd_t, hints = ioHints.empty):file throws {
+  return openfdHelper(fd, hints);
 }
 
-pragma "no doc"
-// to address the use of "QIO_HINT_OWNED" in the Subprocess module
-proc openfd(fd: fd_t, hints: c_int):file throws {
-  return openfdHelper(fd, hints._internal);
-}
-
-private proc openfdHelper(fd: fd_t, hints: c_int,
+private proc openfdHelper(fd: fd_t, hints = ioHints.empty,
                           style:iostyleInternal = defaultIOStyleInternal()):file throws {
   var local_style = style;
   var ret:file;
   ret.home = here;
   extern proc chpl_cnullfile():_file;
-  var err = qio_file_init(ret._file_internal, chpl_cnullfile(), fd, hints, local_style, 0);
+  var err = qio_file_init(ret._file_internal, chpl_cnullfile(), fd, hints._internal, local_style, 0);
 
   // On return, either ret._file_internal.ref_cnt == 1, or ret._file_internal is NULL.
   // err should be nonzero in the latter case.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1436,35 +1436,74 @@ extern type fdflag_t = c_int;
 // extern type iohints = c_int;
 
 // https://man7.org/linux/man-pages/man2/posix_fadvise.2.html
-private const IOHINT_NONE: int = 0x0;
-private const IOHINT_SEQUENTIAL: int = 0x1;
-private const IOHINT_RANDOM: int = 0x2;
-private const IOHINT_PREFETCH: int = 0x4;
-private const IOHINT_MMAP: int = 0x8;
+private const IOHINT_NONE: int = 0x00;
+private const IOHINT_SEQUENTIAL: int = 0x10;
+private const IOHINT_RANDOM: int = 0x20;
+private const IOHINT_PREFETCH: int = 0x40;
+private const IOHINT_MMAP: int = 0x80;
 
+/* A value of the :type:`iohints` type defines a set of hints about the I/O that
+  the file or channel will perform.  These hints may be used by the
+  implementation to select optimized versions of the I/O operations.
+
+  Most hints have POSIX equivalents either associated with posix_fadvise() or
+  posix_madvise().
+*/
 record ioHints {
   pragma "no doc"
   var _internal : int;
 
+  /* Defines an empty set, which provides no hints.
+  Corresponds to 'POSIX_*_NORMAL'.
+  */
   proc type none { return new ioHints(IOHINT_NONE); }
+
+ /* Suggests that the file will be accessed sequentially
+  Corresponds to 'POSIX_*_SEQUENTIAL'
+  */
   proc type sequential { return new ioHints(IOHINT_SEQUENTIAL); }
+
+  /* Suggests that the file will be accessed randomly.
+  Corresponds to 'POSIX_*_RANDOM'.
+  */
   proc type random { return new ioHints(IOHINT_RANDOM); }
+
+  /* Suggests that the runtime/OS should immediately begin prefetching the file contents.
+  Corresponds to 'POSIX_*_WILLNEED'.
+  */
   proc type prefetch { return new ioHints(IOHINT_PREFETCH); }
+
+  /* Suggests that mmap should be used to access the file contents
+  */
   proc type mmap { return new ioHints(IOHINT_MMAP); }
+
+  pragma "no doc"
+  proc to_qio_hint_t(): qio_hint_t {
+    // temporary (need to look into runtime implementation)
+    return this._internal;
+  }
 }
 
+/* Compute the bitwise-or (union) of two ioHints
+*/
 operator ioHints.|(lhs: ioHints, rhs: ioHints) {
   return new ioHints(lhs._internal | rhs._internal);
 }
 
+/* Compute the bitwise-and (intersection) of two ioHints
+*/
 operator ioHints.&(lhs: ioHints, rhs: ioHints) {
   return new ioHints(lhs._internal & rhs._internal);
 }
 
+/* Compare two ioHints for equality
+*/
 operator ioHints.==(lhs: ioHints, rhs: ioHints) {
   return lhs._internal == rhs._internal;
 }
 
+/* Compare two ioHints for inequality
+*/
 operator ioHints.!=(lhs: ioHints, rhs: ioHints) {
   return !(lhs == rhs)
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1401,42 +1401,89 @@ extern type fdflag_t = c_int;
 //  QIO_HINT_NOREUSE
 /*
 
-A value of the :type:`iohints` type defines a set of hints about the I/O that
-the file or channel will perform.  These hints may be used by the
-implementation to select optimized versions of the I/O operations.
+// A value of the :type:`iohints` type defines a set of hints about the I/O that
+// the file or channel will perform.  These hints may be used by the
+// implementation to select optimized versions of the I/O operations.
 
-The :type:`iohints` type is implementation-defined.
-The following :type:`iohints` constants are provided:
+// The :type:`iohints` type is implementation-defined.
+// The following :type:`iohints` constants are provided:
 
-  * :const:`IOHINT_NONE` defines an empty set, which provides no hints.
-  * :const:`IOHINT_RANDOM` suggests to expect random access.
-  * :const:`IOHINT_SEQUENTIAL` suggests to expect sequential access.
-  * :const:`IOHINT_CACHED` suggests that the file data is or should be
-    cached in memory, possibly all at once.
-  * :const:`IOHINT_PARALLEL` suggests to expect many channels
-    working with this file in parallel.
+//   * :const:`IOHINT_NONE` defines an empty set, which provides no hints.
+//   * :const:`IOHINT_RANDOM` suggests to expect random access.
+//   * :const:`IOHINT_SEQUENTIAL` suggests to expect sequential access.
+//   * :const:`IOHINT_CACHED` suggests that the file data is or should be
+//     cached in memory, possibly all at once.
+//   * :const:`IOHINT_PARALLEL` suggests to expect many channels
+//     working with this file in parallel.
 
 
-Other hints might be added in the future.
+// Other hints might be added in the future.
 
-The following binary operators are defined on :type:`iohints`:
+// The following binary operators are defined on :type:`iohints`:
 
-* ``|`` for set union
-* ``&`` for set intersection
-* ``==`` for set equality
-* ``!=`` for set inequality
+// * ``|`` for set union
+// * ``&`` for set intersection
+// * ``==`` for set equality
+// * ``!=`` for set inequality
 
-When an :type:`iohints` formal argument has default intent, the
-actual is copied as ``const in`` to the formal upon a function
-call, and the formal cannot be assigned within the function.
+// When an :type:`iohints` formal argument has default intent, the
+// actual is copied as ``const in`` to the formal upon a function
+// call, and the formal cannot be assigned within the function.
 
-The default value of the :type:`iohints` type is undefined.
+// The default value of the :type:`iohints` type is undefined.
 
-*/
-extern type iohints = c_int;
+// */
+// extern type iohints = c_int;
+
+// https://man7.org/linux/man-pages/man2/posix_fadvise.2.html
+private const IOHINT_NONE: c_int = 0;
+private const IOHINT_SEQUENTIAL: c_int = 0;
+private const IOHINT_RANDOM: c_int = 0;
+private const IOHINT_PREFETCH: c_int = 0;
+private const IOHINT_MMAP: c_int = 0;
+
+record ioHints {
+  pragma "no doc"
+  var _internal : c_int;
+
+  proc type none {
+    return new ioHints(IOHINT_NONE);
+  }
+
+  proc type sequential {
+    return new ioHints(IOHINT_SEQUENTIAL);
+  }
+
+  proc type random {
+    return new ioHints(IOHINT_RANDOM);
+  }
+
+  proc type prefetch {
+    return new ioHints(IOHINT_PREFETCH);
+  }
+
+  proc type mmap {
+    return new ioHints(IOHINT_MMAP);
+  }
+}
+
+operator ioHints.|(lhs: ioHints, rhs: ioHints) {
+  return new ioHints(lhs._internal | rhs._internal);
+}
+
+operator ioHints.&(lhs: ioHints, rhs: ioHints) {
+  return new ioHints(lhs._internal & rhs._internal);
+}
+
+operator ioHints.==(lhs: ioHints, rhs: ioHints) {
+  return lhs._internal == rhs._internal;
+}
+
+operator ioHints.!=(lhs: ioHints, rhs: ioHints) {
+  return !(lhs == rhs)
+}
 
 /*
-
 The :record:`file` type is implementation-defined.  A value of the
 :record:`file` type refers to the state that is used by the implementation to
 identify and interact with the OS file.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1436,35 +1436,21 @@ extern type fdflag_t = c_int;
 // extern type iohints = c_int;
 
 // https://man7.org/linux/man-pages/man2/posix_fadvise.2.html
-private const IOHINT_NONE: c_int = 0;
-private const IOHINT_SEQUENTIAL: c_int = 0;
-private const IOHINT_RANDOM: c_int = 0;
-private const IOHINT_PREFETCH: c_int = 0;
-private const IOHINT_MMAP: c_int = 0;
+private const IOHINT_NONE: int = 0x0;
+private const IOHINT_SEQUENTIAL: int = 0x1;
+private const IOHINT_RANDOM: int = 0x2;
+private const IOHINT_PREFETCH: int = 0x4;
+private const IOHINT_MMAP: int = 0x8;
 
 record ioHints {
   pragma "no doc"
-  var _internal : c_int;
+  var _internal : int;
 
-  proc type none {
-    return new ioHints(IOHINT_NONE);
-  }
-
-  proc type sequential {
-    return new ioHints(IOHINT_SEQUENTIAL);
-  }
-
-  proc type random {
-    return new ioHints(IOHINT_RANDOM);
-  }
-
-  proc type prefetch {
-    return new ioHints(IOHINT_PREFETCH);
-  }
-
-  proc type mmap {
-    return new ioHints(IOHINT_MMAP);
-  }
+  proc type none { return new ioHints(IOHINT_NONE); }
+  proc type sequential { return new ioHints(IOHINT_SEQUENTIAL); }
+  proc type random { return new ioHints(IOHINT_RANDOM); }
+  proc type prefetch { return new ioHints(IOHINT_PREFETCH); }
+  proc type mmap { return new ioHints(IOHINT_MMAP); }
 }
 
 operator ioHints.|(lhs: ioHints, rhs: ioHints) {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1493,6 +1493,9 @@ record ioHints {
   /* Suggests that 'mmap' should be used to access the file contents
   */
   proc type mmap { return new ioHints(IOHINTS_MMAP); }
+
+  pragma "no doc"
+  proc type direct(constant: c_int) { return new ioHints(constant); }
 }
 
 /* Compute the union of two sets of ioHints
@@ -1922,7 +1925,7 @@ proc openfd(fd: fd_t, hints=ioHints.empty):file throws {
 pragma "no doc"
 // to address the use of "QIO_HINT_OWNED" in the Subprocess module
 proc openfd(fd: fd_t, hints: c_int):file throws {
-  return openfdHelper(fd, hints);
+  return openfdHelper(fd, hints._internal);
 }
 
 private proc openfdHelper(fd: fd_t, hints: c_int,
@@ -2034,7 +2037,7 @@ private proc opentmpHelper(hints=ioHints.empty,
   ret.home = here;
 
   // On return ret._file_internal.ref_cnt == 1.
-  var err = qio_file_open_tmp(ret._file_internal, hints, local_style);
+  var err = qio_file_open_tmp(ret._file_internal, hints._internal, local_style);
   if err then try ioerror(err, "in opentmp");
   return ret;
 }

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -171,9 +171,9 @@ module OS {
     pragma "no doc"
     inline operator :(x:suseconds_t, type t:c_int)
       return __primitive("cast", t, x);
-    pragma "no doc"
-    inline operator :(x:c_int, type t:suseconds_t)
-      return __primitive("cast", t, x);
+    // pragma "no doc"
+    // inline operator :(x:c_int, type t:suseconds_t)
+    //   return __primitive("cast", t, x);
     pragma "no doc"
     inline operator :(x:c_long, type t:suseconds_t)
       return __primitive("cast", t, x);
@@ -189,9 +189,9 @@ module OS {
     pragma "no doc"
     inline operator :(x:time_t, type t:c_int)
       return __primitive("cast", t, x);
-    pragma "no doc"
-    inline operator :(x:c_int, type t:time_t)
-      return __primitive("cast", t, x);
+    // pragma "no doc"
+    // inline operator :(x:c_int, type t:time_t)
+    //   return __primitive("cast", t, x);
     pragma "no doc"
     inline operator :(x:c_long, type t:time_t)
       return __primitive("cast", t, x);

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -171,9 +171,6 @@ module OS {
     pragma "no doc"
     inline operator :(x:suseconds_t, type t:c_int)
       return __primitive("cast", t, x);
-    // pragma "no doc"
-    // inline operator :(x:c_int, type t:suseconds_t)
-    //   return __primitive("cast", t, x);
     pragma "no doc"
     inline operator :(x:c_long, type t:suseconds_t)
       return __primitive("cast", t, x);
@@ -189,9 +186,6 @@ module OS {
     pragma "no doc"
     inline operator :(x:time_t, type t:c_int)
       return __primitive("cast", t, x);
-    // pragma "no doc"
-    // inline operator :(x:c_int, type t:time_t)
-    //   return __primitive("cast", t, x);
     pragma "no doc"
     inline operator :(x:c_long, type t:time_t)
       return __primitive("cast", t, x);

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -584,7 +584,7 @@ module Subprocess {
       // goes out of scope, but the channel will still keep
       // the file alive by referring to it.
       try {
-        var stdin_file = openfd(stdin_fd, hints=QIO_HINT_OWNED);
+        var stdin_file = openfd(stdin_fd, hints=ioHints.direct(QIO_HINT_OWNED));
         ret.stdin_channel = stdin_file.writer();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -609,7 +609,7 @@ module Subprocess {
     if stdout_pipe {
       ret.stdout_pipe = true;
       try {
-        var stdout_file = openfd(stdout_fd, hints=QIO_HINT_OWNED);
+        var stdout_file = openfd(stdout_fd, hints=ioHints.direct(QIO_HINT_OWNED));
         ret.stdout_channel = stdout_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -623,7 +623,7 @@ module Subprocess {
     if stderr_pipe {
       ret.stderr_pipe = true;
       try {
-        ret.stderr_file = openfd(stderr_fd, hints=QIO_HINT_OWNED);
+        ret.stderr_file = openfd(stderr_fd, hints=ioHints.direct(QIO_HINT_OWNED));
         ret.stderr_channel = ret.stderr_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -606,6 +606,7 @@ module Sys {
     :returns: 1 if ``name`` is defined and 0 if not
     :rtype: `c_int`
    */
+   pragma "last resort"
   deprecated "'Sys.sys_getenv' is deprecated; please use 'OS.sys_getenv' instead"
   extern proc sys_getenv(name:c_string, ref string_out:c_string):c_int;
 

--- a/test/functions/iterators/tzakian/open_inside_file_iter.chpl
+++ b/test/functions/iterators/tzakian/open_inside_file_iter.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-iter file.split(hints:iohints = IOHINT_NONE) {
+iter file.split(hints = ioHints.empty) {
   open(this.path, iomode.r, hints);
   yield 1;
 }

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -11,7 +11,7 @@ const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
 proc main(args: [] string) {
   const stdin = openfd(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints=QIO_HINT_PARALLEL),
+                             hints=ioHints.direct(QIO_HINT_PARALLEL)),
         len = stdin.size;
   var data: [0..#len] uint(8);
 
@@ -54,7 +54,7 @@ proc main(args: [] string) {
 
   // write the data out to stdout once all tasks have completed
   const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/release/examples/benchmarks/shootout/revcomp.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp.chpl
@@ -40,8 +40,8 @@ proc main(args: [] string) {
       process(data, start, idx-2);
   }
 
-  const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+  const stdoutBin = openfd(1).writer(iokind.native, locking=false,
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -192,7 +192,7 @@ if example == 0 || example == 3 {
 // we can optimize better (using ``mmap``, if you like details).
   {
     var f = open(testfile, iomode.r,
-                 hints=IOHINT_RANDOM|IOHINT_CACHED|IOHINT_PARALLEL);
+                hints=ioHints.random | ioHints.prefetch | ioHints.direct(QIO_HINT_PARALLEL));
 
     // This is a forall loop to do I/O in parallel!
     forall i in 0..#num by -1 {

--- a/test/studies/lammps/shemmy/m-lammps.chpl
+++ b/test/studies/lammps/shemmy/m-lammps.chpl
@@ -228,8 +228,8 @@ proc updateNeighbors()
 proc loadParticles(filename:string, p:[?D], v:[D])
 {
     use IO;
-    var rawFile=open(filename, iomode.r, IOHINT_SEQUENTIAL);
-    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), IOHINT_SEQUENTIAL);
+    var rawFile=open(filename, iomode.r, ioHints.sequential);
+    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), ioHints.sequential);
 
     for i in D
     {

--- a/test/studies/lammps/shemmy/s-lammps.chpl
+++ b/test/studies/lammps/shemmy/s-lammps.chpl
@@ -146,8 +146,8 @@ proc updateNeighbors()
 proc loadParticles(filename:string, p:[?D], v:[D])
 {
     use IO;
-    var rawFile=open(filename, iomode.r, IOHINT_SEQUENTIAL);
-    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), IOHINT_SEQUENTIAL);
+    var rawFile=open(filename, iomode.r, ioHints.sequential);
+    var fileIn=rawFile.reader(iokind.dynamic,true,0,max(int(64)), ioHints.sequential);
 
     for i in D
     {

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
@@ -54,7 +54,7 @@ proc main(args: [] string) {
 
   // Open a binary writer to stdout
   var binout = openfd(1).writer(iokind.native, locking=false, 
-                                hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   binout.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
@@ -136,8 +136,8 @@ proc main(args: [] string) {
     }
   }
 
-  const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+  const stdoutBin = openfd(1).writer(iokind.native, locking=false,
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   //
   // This conversion wastes memory, but correct output requires array stdout
   // specifically at the moment.

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
@@ -129,7 +129,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   //
   // Necessary for now because list `readWriteThis` includes formatting chars,
   // while arrays do not.

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -13,7 +13,7 @@ config const readSize = 16 * 1024;
 proc main(args: [] string) {
   const stdin = openfd(0);
   var input = stdin.reader(iokind.native, locking=false,
-                           hints=QIO_HINT_PARALLEL);
+                           hints=ioHints.direct(QIO_HINT_PARALLEL));
   var len = stdin.size;
   var data : [0..#len] uint(8);
   
@@ -61,7 +61,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                     hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -20,9 +20,9 @@ param eol = '\n'.toByte(),  // end-of-line, as an integer
 
 proc main(args: [] string) {
   var stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints=QIO_CH_ALWAYS_UNBUFFERED),
+                                   hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints=QIO_CH_ALWAYS_UNBUFFERED),
+                                   hints=ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
       bufLen = 8 * 1024,
       bufDom = {0..<bufLen},
       buf: [bufDom] uint(8),

--- a/test/studies/shootout/submitted/revcomp2.chpl
+++ b/test/studies/shootout/submitted/revcomp2.chpl
@@ -17,14 +17,14 @@ config const readSize = 16384;  // the chunk size to read at a time
 
 // a channel and coordination variable for writing data to stdout
 var stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                 hints=QIO_CH_ALWAYS_UNBUFFERED),
+                                 hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
     seqToWrite: atomic int = 1;
 
 
 proc main(args: [] string) {
   const stdin = openfd(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints = QIO_CH_ALWAYS_UNBUFFERED);
+                             hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
 
   var curSeq = new Seq?(id=1);
 

--- a/test/studies/shootout/submitted/revcomp3.chpl
+++ b/test/studies/shootout/submitted/revcomp3.chpl
@@ -13,9 +13,9 @@ const table = createTable();    // create the table of code complements
 proc main(args: [] string) {
   use IO;
   const stdinBin = openfd(0).reader(iokind.native, locking=false,
-                                 hints = QIO_CH_ALWAYS_UNBUFFERED),
+                                 hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED)),
         stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                  hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                  hints = ioHints.direct(QIO_CH_ALWAYS_UNBUFFERED));
 
   // read in the data using an incrementally growing buffer
   var bufLen = 8 * 1024,

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -342,7 +342,7 @@ proc graphNumVertices(G) return G.vertices.size;
 proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
   const f = open(prefix+suffix,
                  if forWriting then iomode.cw else iomode.r,
-                 IOHINT_SEQUENTIAL);
+                 ioHints.sequential);
   const chan = if forWriting
     then f.writer(iokind.big, false)
     else f.reader(iokind.big, false);

--- a/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
@@ -499,7 +499,7 @@ proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
 proc createGraphFile(prefix:string, suffix:string, param forWriting:bool) {
   return open(prefix+suffix,
               if forWriting then iomode.cw else iomode.r,
-              IOHINT_SEQUENTIAL);
+              ioHints.sequential);
 }
 
 proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {


### PR DESCRIPTION
`OS.Posix.time_t` and `OS.POSIX.suseconds_t` had casts to `c_int` *and* `c_long.` The cast to `c_int` functionality was unused and was causing ambiguity errors on 32 bit systems (where `c_long` is also 32 bit).

The casts to `c_int` were removed. 