### PR TITLE
Removed cast from `c_int->time_t` and `c_int->suseconds_t` from `OS.POSIX` to fix ambiguity errors

### DIFF
--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -172,9 +172,6 @@ module OS {
     inline operator :(x:suseconds_t, type t:c_int)
       return __primitive("cast", t, x);
     pragma "no doc"
-    inline operator :(x:c_int, type t:suseconds_t)
-      return __primitive("cast", t, x);
-    pragma "no doc"
     inline operator :(x:c_long, type t:suseconds_t)
       return __primitive("cast", t, x);
     pragma "no doc"
@@ -188,9 +185,6 @@ module OS {
     extern type time_t;
     pragma "no doc"
     inline operator :(x:time_t, type t:c_int)
-      return __primitive("cast", t, x);
-    pragma "no doc"
-    inline operator :(x:c_int, type t:time_t)
       return __primitive("cast", t, x);
     pragma "no doc"
     inline operator :(x:c_long, type t:time_t)

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -169,13 +169,10 @@ module OS {
     */
     extern type suseconds_t;
     pragma "no doc"
-    inline operator :(x:suseconds_t, type t:c_int)
+    inline operator :(x:integral, type t:suseconds_t)
       return __primitive("cast", t, x);
     pragma "no doc"
-    inline operator :(x:c_long, type t:suseconds_t)
-      return __primitive("cast", t, x);
-    pragma "no doc"
-    inline operator :(x:suseconds_t, type t:int)
+    inline operator :(x:suseconds_t, type t:integral)
       return __primitive("cast", t, x);
 
     /*
@@ -184,13 +181,10 @@ module OS {
     */
     extern type time_t;
     pragma "no doc"
-    inline operator :(x:time_t, type t:c_int)
+    inline operator :(x:integral, type t:time_t)
       return __primitive("cast", t, x);
     pragma "no doc"
-    inline operator :(x:c_long, type t:time_t)
-      return __primitive("cast", t, x);
-    pragma "no doc"
-    inline operator :(x:time_t, type t:int)
+    inline operator :(x:time_t, type t:integral)
       return __primitive("cast", t, x);
 
     /*


### PR DESCRIPTION
`OS.POSIX.time_t` and `OS.POSIX.suseconds_t` had casts defined from `c_int` and `c_long`. The `c_int` cast was unneeded and was causing ambiguity errors on 32 bit system where `c_long` is also 32 bits. 

The casts from `c_int` were removed for these types.