### PR TITLE
Futurize chpldoc test for private classes, adjust another for intents

### DIFF
--- a/test/chpldoc/intents.doc.chpl
+++ b/test/chpldoc/intents.doc.chpl
@@ -65,7 +65,7 @@ module Inner {
   }
 
   /* This function has both an argument intent and a return intent */
-  proc thirteen (inout val) param {
+  proc thirteen (inout val) ref {
 
   }
 
@@ -140,7 +140,7 @@ proc twelve (val: int) param {
 }
 
 /* This function has both an argument intent and a return intent */
-proc thirteen (inout val) param {
+proc thirteen (inout val) ref {
 
 }
 

--- a/test/chpldoc/intents.doc.good
+++ b/test/chpldoc/intents.doc.good
@@ -78,7 +78,7 @@ or
 
    This function has both an argument and a return intent 
 
-.. function:: proc thirteen(inout val) param
+.. function:: proc thirteen(inout val) ref
 
    This function has both an argument intent and a return intent 
 
@@ -157,7 +157,7 @@ or
 
    This function has both an argument and a return intent 
 
-.. function:: proc thirteen(inout val) param
+.. function:: proc thirteen(inout val) ref
 
    This function has both an argument intent and a return intent 
 

--- a/test/chpldoc/nodoc/privateClasses.doc.bad
+++ b/test/chpldoc/nodoc/privateClasses.doc.bad
@@ -1,0 +1,5 @@
+privateClasses.doc.chpl:1: error: Can't apply private to types yet
+privateClasses.doc.chpl:7: error: Can't apply private to types yet
+privateClasses.doc.chpl:15: error: Can't apply private to the fields or methods of a class or record yet
+privateClasses.doc.chpl:18: error: Can't apply private to the fields or methods of a class or record yet
+cat: docs/source/modules/privateClasses.doc.rst: No such file or directory

--- a/test/chpldoc/nodoc/privateClasses.doc.future
+++ b/test/chpldoc/nodoc/privateClasses.doc.future
@@ -1,0 +1,3 @@
+#6067
+
+No support for private classes, fields, or methods yet.


### PR DESCRIPTION
Futurize chpldoc test for private classes, adjust another for intents

Adjust two chpldoc tests that started failing after post-parse checks
were introduced to dyno (see #19916).

Futurize a test for private classes, since that functionality is not
supported yet. Adjust a test for intents to return by `ref` instead
of `param` intent.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>