### PR TITLE
Only enable LLVM asserts for CHPL_LLVM_DEVELOPER instead of CHPL_DEVELOPER

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -15,7 +15,7 @@ endif
 # activate LLVM asserts if it's from `make ASSERTS=1`
 # or if CHPL_DEVELOPER is set
 CHPL_LLVM_ASSERTS := 0
-ifdef CHPL_DEVELOPER
+ifdef CHPL_LLVM_DEVELOPER
   CHPL_LLVM_ASSERTS := 1
 endif
 


### PR DESCRIPTION
These are expensive checks and aren't ABI compatible with LLVM without
assertions. Key them off of CHPL_LLVM_DEVELOPER instead of CHPL_DEVELOPER
so people will have to opt in more concretely.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>