### PR TITLE
Fix some issues with the GPU support to enable simple Arkouda builds

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -760,6 +760,11 @@ CallExpr* FnSymbol::singleInvocation() const {
     if (se == parent->baseExpr) {
       retval = parent;
     }
+    else if (parent->isPrimitive(PRIM_GPU_KERNEL_LAUNCH_FLAT)) {
+      if (se == parent->get(1)) {
+        retval = parent;
+      }
+    }
   }
 
   // The use is not as the callee, ex. as a FCF.

--- a/compiler/dyno/include/chpl/uast/PragmaList.h
+++ b/compiler/dyno/include/chpl/uast/PragmaList.h
@@ -400,6 +400,8 @@ PRAGMA(NO_RENAME, npr, "no rename", ncm)
 PRAGMA(NO_RVF, npr, "do not RVF", ncm)
 PRAGMA(NO_WIDE_CLASS, ypr, "no wide class", ncm)
 
+PRAGMA(NO_GPU_CODEGEN, ypr, "no gpu codegen", ncm)
+
 // See ORDER_INDEPENDENT_YIELDING_LOOPS below
 PRAGMA(NOT_ORDER_INDEPENDENT_YIELDING_LOOPS, ypr, "not order independent yielding loops", "yielding loops in iterator itself are not order independent")
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2565,12 +2565,6 @@ void runClang(const char* just_parse_filename) {
       genHeaderFilename = genIntermediateFilename("command-line-includes.h");
       FILE* fp =  openfile(genHeaderFilename.c_str(), "w");
 
-      //const char* ifdefStrBegin = "#ifdef __cplusplus\n"
-                                  //"extern \"C\" {\n"
-                                  //"#endif";
-
-      //fprintf(fp, "%s\n", ifdefStrBegin);
-
       int filenum = 0;
       while (const char* inputFilename = nthFilename(filenum++)) {
         if (isCHeader(inputFilename)) {
@@ -2578,10 +2572,6 @@ void runClang(const char* just_parse_filename) {
         }
       }
 
-      //const char* ifdefStrEnd = "#ifdef __cplusplus\n"
-                                //"}\n"
-                                //"#endif";
-      //fprintf(fp, "%s", ifdefStrEnd);
       closefile(fp);
       clangOtherArgs.push_back("-include");
       clangOtherArgs.push_back(genHeaderFilename);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2565,11 +2565,11 @@ void runClang(const char* just_parse_filename) {
       genHeaderFilename = genIntermediateFilename("command-line-includes.h");
       FILE* fp =  openfile(genHeaderFilename.c_str(), "w");
 
-      const char* ifdefStrBegin = "#ifdef __cplusplus\n"
-                                  "extern \"C\" {\n"
-                                  "#endif";
+      //const char* ifdefStrBegin = "#ifdef __cplusplus\n"
+                                  //"extern \"C\" {\n"
+                                  //"#endif";
 
-      fprintf(fp, "%s\n", ifdefStrBegin);
+      //fprintf(fp, "%s\n", ifdefStrBegin);
 
       int filenum = 0;
       while (const char* inputFilename = nthFilename(filenum++)) {
@@ -2578,10 +2578,10 @@ void runClang(const char* just_parse_filename) {
         }
       }
 
-      const char* ifdefStrEnd = "#ifdef __cplusplus\n"
-                                "}\n"
-                                "#endif";
-      fprintf(fp, "%s", ifdefStrEnd);
+      //const char* ifdefStrEnd = "#ifdef __cplusplus\n"
+                                //"}\n"
+                                //"#endif";
+      //fprintf(fp, "%s", ifdefStrEnd);
       closefile(fp);
       clangOtherArgs.push_back("-include");
       clangOtherArgs.push_back(genHeaderFilename);

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -213,7 +213,6 @@ bool GpuizableLoop::shouldOutlineLoopHelp(BlockStmt* blk,
            fn->fname(), fn->linenum(), fn->name, fn->id);
   }
 
-  // TODO this should walk up the call chain recursively
   FnSymbol *cur = blk->getFunction();
   while (cur) {
     if (cur->hasFlag(FLAG_NO_GPU_CODEGEN)) {

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -37,9 +37,9 @@
 
 #include "global-ast-vecs.h"
 
-bool debugPrintGPUChecks = false;
-bool allowFnCallsFromGPU = true;
-int indentGPUChecksLevel = 0;
+static bool debugPrintGPUChecks = false;
+static bool allowFnCallsFromGPU = true;
+static int indentGPUChecksLevel = 0;
 
 extern int classifyPrimitive(CallExpr *call, bool inLocal);
 extern bool inLocalBlock(CallExpr *call);
@@ -136,99 +136,9 @@ static bool isDegenerateOuterRef(Symbol* sym, CForLoop* loop) {
   return true;
 }
 
-// ----------------------------------------------------------------------------
-// GpuizableLoop
-// ----------------------------------------------------------------------------
-
-// Used to evaluate if a loop is eligible to be outlined into a GPU kernel and
-// extracts information about the loop's bounds and indices.
-class GpuizableLoop {
-  CForLoop* loop_ = nullptr;
-  bool isEligible_ = false;
-  Symbol* upperBound_ = nullptr;
-  std::vector<Symbol*> loopIndices_;
-  std::vector<Symbol*> lowerBounds_;
-
-public:
-  GpuizableLoop(BlockStmt* blk, bool allowFnCalls);
-
-  CForLoop* loop() const { return loop_; }
-  bool isEligible() const { return isEligible_; }
-  Symbol* upperBound() const { return upperBound_; }
-  const std::vector<Symbol*>& loopIndices() const { return loopIndices_; }
-  const std::vector<Symbol*>& lowerBounds() const { return lowerBounds_; }
-  bool isIndexVariable(Symbol* sym) const {
-    return std::find(loopIndices_.begin(), loopIndices_.end(), sym) !=
-      loopIndices_.end();
-  }
-
-private:
-  bool evaluateLoop(BlockStmt *blk, bool allowFnCalls);
-  bool functionDisablesOutlining(BlockStmt* blk);
-  bool shouldOutlineLoopHelp(BlockStmt *blk, std::set<FnSymbol *> &okFns,
-    std::set<FnSymbol *> visitedFns, bool allowFnCalls);
-  bool attemptToExtractLoopInformation();
-  bool extractIndicesAndLowerBounds();
-  bool extractUpperBound();
-};
-
-GpuizableLoop::GpuizableLoop(BlockStmt *blk, bool allowFnCalls) {
-  this->loop_ = toCForLoop(blk);
-  this->isEligible_ = evaluateLoop(blk, allowFnCalls);
-}
-
-bool GpuizableLoop::evaluateLoop(BlockStmt *blk, bool allowFnCalls) {
-  if (!blk->inTree())
-    return false;
-
-  CForLoop* cfl = toCForLoop(blk);
-  if (cfl && !cfl->isOrderIndependent())
-    return false;
-
-  std::set<FnSymbol*> okFns;
-  std::set<FnSymbol*> visitedFns;
-
-  bool looksEligible =
-    !functionDisablesOutlining(blk) &&
-    shouldOutlineLoopHelp(blk, okFns, visitedFns, allowFnCalls) &&
-    attemptToExtractLoopInformation();
-
-  // We currently don't support launching kernels from kernels. So if
-  // the loop is within a function already marked for use on the GPU
-  // error out.
-  if(cfl->getFunction()->hasFlag(FLAG_GPU_CODEGEN)) {
-    USR_FATAL(cfl,
-      "GPU support does not currently allow nested kernel launches. Do you have\n"
-      "nested forall/foreach loops or looping over a multidimensional domain?");
-  }
-
-  return looksEligible;
-}
-
-bool GpuizableLoop::functionDisablesOutlining(BlockStmt* blk) {
-  FnSymbol *cur = blk->getFunction();
-  while (cur) {
-    if (cur->hasFlag(FLAG_NO_GPU_CODEGEN)) {
-      return true;
-    }
-
-    // this is obviously a weak implementation. But the purpose is to track the
-    // call chain from things like `coforall_fn`, `wrapcoforall_fn` etc, which
-    // are always single invocation
-    if (CallExpr *singleCall = cur->singleInvocation()) {
-      cur = singleCall->getFunction();
-    }
-    else {
-      break;
-    }
-  }
-  return false;
-}
-
-bool GpuizableLoop::shouldOutlineLoopHelp(BlockStmt* blk,
-                                          std::set<FnSymbol*>& okFns,
-                                          std::set<FnSymbol*> visitedFns,
-                                          bool allowFnCalls) {
+static bool callsInBodyAreGpuizableHelp(BlockStmt* blk,
+                                        std::set<FnSymbol*>& okFns,
+                                        std::set<FnSymbol*> visitedFns) {
   FnSymbol* fn = blk->getFunction();
   if (debugPrintGPUChecks) {
     printf("%*s%s:%d: %s[%d]\n", indentGPUChecksLevel, "",
@@ -257,7 +167,7 @@ bool GpuizableLoop::shouldOutlineLoopHelp(BlockStmt* blk,
         return false;
       }
     } else if (call->isResolved()) {
-      if (!allowFnCalls)
+      if (!allowFnCallsFromGPU)
         return false;
 
       FnSymbol* fn = call->resolvedFunction();
@@ -267,8 +177,7 @@ bool GpuizableLoop::shouldOutlineLoopHelp(BlockStmt* blk,
 
       indentGPUChecksLevel += 2;
       if (okFns.count(fn) != 0 ||
-          shouldOutlineLoopHelp(fn->body, okFns,
-                                visitedFns, allowFnCalls)) {
+          callsInBodyAreGpuizableHelp(fn->body, okFns, visitedFns)) {
         indentGPUChecksLevel -= 2;
         okFns.insert(fn);
       } else {
@@ -278,6 +187,102 @@ bool GpuizableLoop::shouldOutlineLoopHelp(BlockStmt* blk,
     }
   }
   return true;
+}
+
+
+
+// ----------------------------------------------------------------------------
+// GpuizableLoop
+// ----------------------------------------------------------------------------
+
+// Used to evaluate if a loop is eligible to be outlined into a GPU kernel and
+// extracts information about the loop's bounds and indices.
+class GpuizableLoop {
+  CForLoop* loop_ = nullptr;
+  FnSymbol* parentFn_ = nullptr;
+  bool isEligible_ = false;
+  Symbol* upperBound_ = nullptr;
+  std::vector<Symbol*> loopIndices_;
+  std::vector<Symbol*> lowerBounds_;
+
+public:
+  GpuizableLoop(BlockStmt* blk);
+
+  CForLoop* loop() const { return loop_; }
+  bool isEligible() const { return isEligible_; }
+  Symbol* upperBound() const { return upperBound_; }
+  const std::vector<Symbol*>& loopIndices() const { return loopIndices_; }
+  const std::vector<Symbol*>& lowerBounds() const { return lowerBounds_; }
+  bool isIndexVariable(Symbol* sym) const {
+    return std::find(loopIndices_.begin(), loopIndices_.end(), sym) !=
+      loopIndices_.end();
+  }
+
+private:
+  bool evaluateLoop();
+  bool parentFnAllowsGpuization();
+  bool callsInBodyAreGpuizable();
+  bool attemptToExtractLoopInformation();
+  bool extractIndicesAndLowerBounds();
+  bool extractUpperBound();
+};
+
+GpuizableLoop::GpuizableLoop(BlockStmt *blk) {
+  INT_ASSERT(blk->getFunction());
+
+  this->loop_ = toCForLoop(blk);
+  this->parentFn_ = toFnSymbol(blk->getFunction());
+  this->isEligible_ = evaluateLoop();
+}
+
+bool GpuizableLoop::evaluateLoop() {
+  CForLoop *cfl = this->loop_;
+  INT_ASSERT(cfl);
+
+  if (!cfl->inTree())
+    return false;
+
+  if (!cfl->isOrderIndependent())
+    return false;
+
+  // We currently don't support launching kernels from kernels. So if
+  // the loop is within a function already marked for use on the GPU
+  // error out.
+  if(this->parentFn_->hasFlag(FLAG_GPU_CODEGEN)) {
+    USR_FATAL(cfl,
+      "GPU support does not currently allow nested kernel launches. Do you have\n"
+      "nested forall/foreach loops or looping over a multidimensional domain?");
+  }
+
+  return parentFnAllowsGpuization() &&
+         callsInBodyAreGpuizable() &&
+         attemptToExtractLoopInformation();
+}
+
+bool GpuizableLoop::parentFnAllowsGpuization() {
+  FnSymbol *cur = this->parentFn_;
+  while (cur) {
+    if (cur->hasFlag(FLAG_NO_GPU_CODEGEN)) {
+      return false;
+    }
+
+    // this is obviously a weak implementation. But the purpose is to track the
+    // call chain from things like `coforall_fn`, `wrapcoforall_fn` etc, which
+    // are always single invocation
+    if (CallExpr *singleCall = cur->singleInvocation()) {
+      cur = singleCall->getFunction();
+    }
+    else {
+      break;
+    }
+  }
+  return true;
+}
+
+bool GpuizableLoop::callsInBodyAreGpuizable() {
+  std::set<FnSymbol*> okFns;
+  std::set<FnSymbol*> visitedFns;
+  return callsInBodyAreGpuizableHelp(this->loop_, okFns, visitedFns);
 }
 
 bool GpuizableLoop::attemptToExtractLoopInformation() {
@@ -742,7 +747,7 @@ static void outlineGPUKernels() {
 
     for_vector(BaseAST, ast, asts) {
       if (CForLoop* loop = toCForLoop(ast)) {
-        GpuizableLoop gpuLoop(loop, allowFnCallsFromGPU);
+        GpuizableLoop gpuLoop(loop);
         if (gpuLoop.isEligible()) {
           outlineEligibleLoop(fn, gpuLoop);
         }
@@ -755,12 +760,12 @@ static void logGpuizableLoops() {
   forv_Vec(BlockStmt, block, gBlockStmts) {
     if (ForLoop* forLoop = toForLoop(block)) {
       if (forLoop->isOrderIndependent())
-        if (GpuizableLoop(forLoop, allowFnCallsFromGPU).isEligible())
+        if (GpuizableLoop(forLoop).isEligible())
           if (debugPrintGPUChecks)
             printf("Found viable forLoop %s:%d[%d]\n",
                    forLoop->fname(), forLoop->linenum(), forLoop->id);
     } else if (CForLoop* forLoop = toCForLoop(block)) {
-      if (GpuizableLoop(forLoop, allowFnCallsFromGPU).isEligible())
+      if (GpuizableLoop(forLoop).isEligible())
         if (debugPrintGPUChecks)
           printf("Found viable CForLoop %s:%d[%d]\n",
                  forLoop->fname(), forLoop->linenum(), forLoop->id);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3246,6 +3246,12 @@ module ChapelArray {
 
   pragma "no copy returns owned"
   pragma "ignore transfer errors"
+  // This function has foralls that have PRIM_ASSIGN in them. They are typically
+  // subject to normalization and as part of gpuization we create temproraries
+  // for those primitive calls. But those temporaries don't get resolved. I
+  // imagine we'll need to have this function work on GPUs, or be callable from
+  // GPUs. So, we'll need to fix that.
+  pragma "no gpu codegen"
   proc chpl__initCopy_shapeHelp(shape: domain, ir: _iteratorRecord)
   {
     pragma "unsafe" pragma "no copy"

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3288,8 +3288,11 @@ module MSBRadixSort {
                  settings=new MSBRadixSortSettings());
   }
 
-  // startbit counts from 0 and is a multiple of RADIX_BITS
+  // forall with intents used in tuple expansion causes compilation errors,
+  // for now, explicitly thwart kernel generation here, as detecting intents is
+  // not easy that late in compilation
   pragma "no gpu codegen"
+  // startbit counts from 0 and is a multiple of RADIX_BITS
   proc msbRadixSort(A:[], start_n:A.idxType, end_n:A.idxType, criterion,
                     startbit:int, endbit:int,
                     settings /* MSBRadixSortSettings */)

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3289,6 +3289,7 @@ module MSBRadixSort {
   }
 
   // startbit counts from 0 and is a multiple of RADIX_BITS
+  pragma "no gpu codegen"
   proc msbRadixSort(A:[], start_n:A.idxType, end_n:A.idxType, criterion,
                     startbit:int, endbit:int,
                     settings /* MSBRadixSortSettings */)

--- a/runtime/include/chpl-bitops.h
+++ b/runtime/include/chpl-bitops.h
@@ -46,7 +46,7 @@ extern "C" {
 // the same assembly as the builtin under clang
 // Returns: number of bits set in the provided integer
 
-static inline uint32_t chpl_bitops_popcount_32(unsigned int x) {
+MAYBE_GPU static inline uint32_t chpl_bitops_popcount_32(unsigned int x) {
 #if !defined(CHPL_BITOPS_C) && (RT_COMP_CC & (~RT_COMP_PGI))
   // - Assumes 'int's are 32bit
   // - gcc4.3's doesn't have support for popcnt and the like
@@ -61,7 +61,7 @@ static inline uint32_t chpl_bitops_popcount_32(unsigned int x) {
 #endif
 }
 
-static inline uint64_t chpl_bitops_popcount_64(unsigned long long x) {
+MAYBE_GPU static inline uint64_t chpl_bitops_popcount_64(unsigned long long x) {
 #if !defined(CHPL_BITOPS_C) && (RT_COMP_CC & (~RT_COMP_PGI))
   // Assumes 'long long's are 64bit
   return __builtin_popcountll(x);
@@ -83,7 +83,7 @@ static inline uint64_t chpl_bitops_popcount_64(unsigned long long x) {
 
 // TODO: find a better bit hack to do this? the popcount at the end makes it
 //       roughly twice as slow as the others
-static inline uint32_t chpl_bitops_clz_32(unsigned int x) {
+MAYBE_GPU static inline uint32_t chpl_bitops_clz_32(unsigned int x) {
 #if !defined(CHPL_BITOPS_C) && (RT_COMP_CC & (~RT_COMP_PGI))
   // - Assumes 'int's are 32bit
   // - __builtin_clz(0) is undefined, return 32 when 0, these conditionals
@@ -106,7 +106,7 @@ static inline uint32_t chpl_bitops_clz_32(unsigned int x) {
 #endif
 }
 
-static inline uint64_t chpl_bitops_clz_64(unsigned long long x) {
+MAYBE_GPU static inline uint64_t chpl_bitops_clz_64(unsigned long long x) {
 #if !defined(CHPL_BITOPS_C) && (RT_COMP_CC & (~RT_COMP_PGI))
   // - Assumes 'long long's are 64bit
   // - Same as above, __builtin_clzll(0) is undefined, return 64 when 0
@@ -134,7 +134,7 @@ static inline uint64_t chpl_bitops_clz_64(unsigned long long x) {
 // Lookup table for the C implementation
 extern const uint8_t chpl_bitops_debruijn32[32];
 
-static inline uint32_t chpl_bitops_ctz_32(unsigned int x) {
+MAYBE_GPU static inline uint32_t chpl_bitops_ctz_32(unsigned int x) {
 #if !defined(CHPL_BITOPS_C) && (RT_COMP_CC & (~RT_COMP_PGI))
   // - Assumes 'int's are 32bit
   // - __builtin_ctz(0) is undefined, return 0 when 0
@@ -153,7 +153,7 @@ static inline uint32_t chpl_bitops_ctz_32(unsigned int x) {
 // Lookup table for the C implementation
 extern const uint8_t chpl_bitops_debruijn64[64];
 
-static inline uint64_t chpl_bitops_ctz_64(unsigned long long x) {
+MAYBE_GPU static inline uint64_t chpl_bitops_ctz_64(unsigned long long x) {
 #if !defined(CHPL_BITOPS_C) && (RT_COMP_CC & (~RT_COMP_PGI))
   // Assumes 'long long's are 64bit
   // __builtin_ctzll(0) is undefined, return 0 when 0
@@ -172,7 +172,7 @@ static inline uint64_t chpl_bitops_ctz_64(unsigned long long x) {
 // Returns: 0 if an even number of bits are set
 //          1 if an odd number of bits are set
 
-static inline uint32_t chpl_bitops_parity_32(unsigned int x) {
+MAYBE_GPU static inline uint32_t chpl_bitops_parity_32(unsigned int x) {
 #if !defined(CHPL_BITOPS_C) && (RT_COMP_CC & (~RT_COMP_PGI))
   // This will expand to (confirmed w/ GCC):
   // When`popcnt` is supported:    Otherwise:
@@ -194,7 +194,7 @@ static inline uint32_t chpl_bitops_parity_32(unsigned int x) {
 #endif
 }
 
-static inline uint64_t chpl_bitops_parity_64(unsigned long long x) {
+MAYBE_GPU static inline uint64_t chpl_bitops_parity_64(unsigned long long x) {
 #if !defined(CHPL_BITOPS_C) && (RT_COMP_CC & (~RT_COMP_PGI))
   return __builtin_parityll(x);
 #else
@@ -215,7 +215,7 @@ static inline uint64_t chpl_bitops_parity_64(unsigned long long x) {
 
 #define UI(size) uint##size##_t
 #define CHPL_BITOPS_ROTL(size) \
-static inline UI(size) chpl_bitops_rotl_##size(UI(size) x, UI(size) n) { \
+MAYBE_GPU static inline UI(size) chpl_bitops_rotl_##size(UI(size) x, UI(size) n) { \
   assert(n < size);                                                      \
   return (x << n) | (x >> (-n & (size - 1)));                            \
 }
@@ -237,7 +237,7 @@ CHPL_BITOPS_ROTL(64)
 // Returns: x rotated left by n
 
 #define CHPL_BITOPS_ROTR(size) \
-static inline UI(size) chpl_bitops_rotr_##size(UI(size) x, UI(size) n) { \
+MAYBE_GPU static inline UI(size) chpl_bitops_rotr_##size(UI(size) x, UI(size) n) { \
   assert(n < size);                                                      \
   return (x >> n) | (x << (-n & (size - 1)));                            \
 }

--- a/runtime/include/chplcast.h
+++ b/runtime/include/chplcast.h
@@ -58,19 +58,15 @@ _real32 c_string_to_real32_precise(c_string str, int* invalid, char* invalidCh);
 _real64 c_string_to_real64_precise(c_string str, int* invalid, char* invalidCh);
 _imag32 c_string_to_imag32_precise(c_string str, int* invalid, char* invalidCh);
 _imag64 c_string_to_imag64_precise(c_string str, int* invalid, char* invalidCh);
-#ifndef __cplusplus
 _complex64 c_string_to_complex64_precise(c_string str, int* invalid, char* invalidCh);
 _complex128 c_string_to_complex128_precise(c_string str, int* invalid, char* invalidCh);
-#endif
 
 _real32 c_string_to_real32(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _real64 c_string_to_real64(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _imag32 c_string_to_imag32(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _imag64 c_string_to_imag64(c_string str, chpl_bool* err, int lineno, int32_t filename);
-#ifndef __cplusplus
 _complex64 c_string_to_complex64(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _complex128 c_string_to_complex128(c_string str, chpl_bool* err, int lineno, int32_t filename);
-#endif
 
 
 /* every other primitive type to string */

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -35,6 +35,7 @@
 typedef float _Complex        _complex64;
 typedef double _Complex       _complex128;
 
+// clang doesn't support _Complex_I but it does support __builtin_complex
 #ifndef _Complex_I
 #define _Complex_I __builtin_complex(0.0,1.0)
 #endif

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -31,14 +31,12 @@
 #include <string.h>
 #include <sys/time.h> // for struct timeval
 
-#ifndef __cplusplus
 #include <complex.h>
-typedef float complex        _complex64;
-typedef double complex       _complex128;
-#else
-#include <complex>
-typedef std::complex<float>  _complex64;
-typedef std::complex<double> _complex128;
+typedef float _Complex        _complex64;
+typedef double _Complex       _complex128;
+
+#ifndef _Complex_I
+#define _Complex_I __builtin_complex(0.0,1.0)
 #endif
 
 #ifdef __cplusplus
@@ -244,18 +242,10 @@ typedef struct chpl_main_argument_s {
 } chpl_main_argument;
 
 static inline _complex128 _chpl_complex128(_real64 re, _real64 im) {
-#ifndef __cplusplus
   return re + im*_Complex_I;
-#else
-  return std::complex<double>(re, im);
-#endif
 }
 static inline _complex64 _chpl_complex64(_real32 re, _real32 im) {
-#ifndef __cplusplus
   return re + im*_Complex_I;
-#else
-  return std::complex<float>(re, im);
-#endif
 }
 
 static inline _real64* complex128GetRealRef(_complex128* cplx) {

--- a/test/gpu/interop/stream/streamWrapper.h
+++ b/test/gpu/interop/stream/streamWrapper.h
@@ -1,1 +1,9 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void vector_add(float *a, float *b, float *c, float alpha, int n);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/gpu/native/bitops.chpl
+++ b/test/gpu/native/bitops.chpl
@@ -1,0 +1,43 @@
+use GPUDiagnostics;
+use BitOps;
+
+config const verbose = false;
+
+proc main() {
+
+  const arg = 15;
+
+  on here.gpus[0] {
+
+    var R: [0..1] int;
+    const r = 0..0;
+
+    proc check(A, s) {
+      if getGPUDiagnostics()[0].kernel_launch !=1 then
+        writeln(s + " didn't result in kernel launch");
+      else if verbose then
+        writeln(s + " resulted in kernel launch");
+
+      const isCorrect = if A.eltType == bool then A[0]==A[1] else isclose(A[0],A[1]);
+      if !isCorrect then
+        writeln(s + " computed wrong result. ("+A[0]:string+", "+A[1]:string+")");
+      else if verbose then
+        writeln(s + " computed right result. ("+A[0]:string+", "+A[1]:string+")");
+
+      resetGPUDiagnostics();
+    }
+
+    startGPUDiagnostics();
+
+    foreach i in r do R[0] = clz(arg); R[1] = clz(arg); check(R, "clz");
+    foreach i in r do R[0] = ctz(arg); R[1] = ctz(arg); check(R, "ctz");
+
+    foreach i in r do R[0] = popcount(arg); R[1] = popcount(arg); check(R, "popcount");
+    foreach i in r do R[0] = parity(arg); R[1] = parity(arg); check(R, "parity");
+
+    foreach i in r do R[0] = rotl(arg,2); R[1] = rotl(arg,2); check(R, "rotl");
+    foreach i in r do R[0] = rotr(arg,2); R[1] = rotr(arg,2); check(R, "rotr");
+
+    stopGPUDiagnostics();
+  }
+}

--- a/test/gpu/native/bitops.good
+++ b/test/gpu/native/bitops.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly

--- a/test/gpu/native/noGPUPragma.chpl
+++ b/test/gpu/native/noGPUPragma.chpl
@@ -1,0 +1,41 @@
+use GPUDiagnostics;
+
+config param useForall = false;
+
+proc yepGPU(A) {
+  if useForall then
+    forall a in A do a += 1;
+  else
+    foreach a in A do a += 1;
+}
+
+// NOTE: the pragma is implemented with mostly coforall wrappers in mind, which
+// have single invocation. So, if you rewrite this test with the function bodies
+// placed in a single function `foo`, and call `foo` from `yepGPU` and
+// `nopeGPU`, the pragma will not function properly. (And that's OK for now)
+// Another way to put it is that, this pragma only applies to order-independent
+// loops within this function's body.
+pragma "no gpu codegen"
+proc nopeGPU(A) {
+  if useForall then
+    forall a in A do a += 1;
+  else
+    foreach a in A do a += 1;
+}
+
+on here.gpus[0] {
+  var A: [1..10] int;
+
+  startGPUDiagnostics();
+  yepGPU(A);
+  stopGPUDiagnostics();
+  assert(getGPUDiagnostics()[0].kernel_launch == 1);
+  writeln(A);
+
+  resetGPUDiagnostics();
+  startGPUDiagnostics();
+  nopeGPU(A);
+  stopGPUDiagnostics();
+  assert(getGPUDiagnostics()[0].kernel_launch == 0);
+  writeln(A);
+}

--- a/test/gpu/native/noGPUPragma.compopts
+++ b/test/gpu/native/noGPUPragma.compopts
@@ -1,0 +1,1 @@
+-suseForall=true

--- a/test/gpu/native/noGPUPragma.good
+++ b/test/gpu/native/noGPUPragma.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+1 1 1 1 1 1 1 1 1 1
+2 2 2 2 2 2 2 2 2 2


### PR DESCRIPTION
This branch makes bunch of small-ish changes in an attempt to get Arkouda to
compile with the GPU locale model. I can separate this into multiple PRs, but I
want to test it some more as a whole. Fixes with this PR:

- Resolves https://github.com/chapel-lang/chapel/issues/19754
  - Stops adding `extern "C"` in the C headers included at the command line.
    This was proposed by @milthorhpe.
  - Fixes an interop test broken by this.
- To be able to do that makes runtime's generated code interface for complex
  numbers C-based even if we're compiling with C++. (A prior PR that made some
  improvements in that direction is
  https://github.com/chapel-lang/chapel/pull/16847)
- This enables defining `c_string_to_complex*` functions to be included in the
  generated executable, because their return types are no longer
  `std::complex<>` which you can't link with C linkage.
- Adds a `no gpu codegen` pragma to thwart gpuization within some internal
  functions. Currently this only applies to:
  - `chpl__initCopy_shapeHelp`: Has PRIM_ASSIGN that gets normalized after
    gpuization, but not resolved. We probably need this function, and the lack
    might be preventing us from using loop expressions to initialize arrays on
    gpus.
- Fixes `.name` implementation of the `GPULocale` type.
  - Adds a relevant test.
- Adds support for `BitOps` module.
  - Adds a relevant test.
- While there, cleans up `gpuTransforms.cpp` a bit.

Test:

- [x] gpu/native
- [x] gpu/interop
- [x] `make check` + spot checks in `types/complex` with `intel` as the host+target compiler
- [x] `make check` + spot checks in `types/complex` with `cray` as the host+target compiler 