### PR TITLE
Use the correct variable name in CHAMPS' make command

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -60,7 +60,7 @@ function test_compile() {
   local kind=$@
 
   test_start "make $kind"
-  make release MOD=$kind NPROC=0 2> $kind.comp.out.tmp
+  make release MOD=$kind NPROCS=0 2> $kind.comp.out.tmp
   local status=$?
   cat $kind.comp.out.tmp
 


### PR DESCRIPTION
This fixes the `make` command edited in https://github.com/chapel-lang/chapel/pull/20224.