### PR TITLE
Remove delete statements from TOML futures

### DIFF
--- a/test/library/packages/TOML/BurntSushi/TomlTest.chpl
+++ b/test/library/packages/TOML/BurntSushi/TomlTest.chpl
@@ -18,6 +18,5 @@ proc main() {
   tomlData.writeJSON(jsonChannel);
 
   jsonChannel.close();
-  delete tomlData;
   tomlChannel.close();
 }

--- a/test/library/packages/TOML/specification/TomlTest.chpl
+++ b/test/library/packages/TOML/specification/TomlTest.chpl
@@ -13,6 +13,5 @@ proc main() {
   var tomlChannel = openreader(f);
   var tomlData = parseToml(tomlChannel);
   writeln(tomlData);
-  delete tomlData;
   tomlChannel.close();
 }

--- a/test/library/packages/TOML/test/arrayoftbl.chpl
+++ b/test/library/packages/TOML/test/arrayoftbl.chpl
@@ -7,6 +7,5 @@ proc main() {
   var tomlData = parseToml(tomlChannel);
   writeln(tomlData);
 
-  delete tomlData;
   tomlChannel.close();
 }

--- a/test/library/packages/TOML/test/quoteTable.chpl
+++ b/test/library/packages/TOML/test/quoteTable.chpl
@@ -18,7 +18,6 @@ proc main() {
   const score2 = TomlData['DataStructures."0.1.0"']!['score']!.s;
   const score3 = TomlData['GPUIterator."0.0.1"']!['score']!.s;
   writeln(TomlData);
-  delete TomlData;
 }
 
 


### PR DESCRIPTION
In #20213, TOML usage was changed from unmanaged to shared, so
deletions of TOML objects no longer compile. For updating
testing, futures had not been taken into account and were not
updated, but @dlongnecke-cray thankfully caught those before
testing ran (thank you David!)