### PR TITLE
Remove a compiler nondeterminism from PR #19561

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -87,13 +87,12 @@ static bool isDeadVariable(Symbol* var) {
 }
 
 void deadVariableElimination(FnSymbol* fn) {
-  llvm::SmallPtrSet<Symbol*, 32> symSet;
+  std::set<Symbol*> symSet;
   collectSymbolSet(fn, symSet);
 
   // Use 'symSet' and 'todo' together for a unique queue of symbols to process
   std::queue<Symbol*> todo;
-  // for_set(Symbol, sym, symSet) {
-  for(Symbol* sym : symSet) {
+  for_set(Symbol, sym, symSet) {
     todo.push(sym);
   }
 


### PR DESCRIPTION
PR #19561 changed dead code elimination in a way that introduces
nondeterminism. It changed a set to a SmallPtrSet but that set is
traversed and added to a work queue. The result is, with the SmallPtrSet,
the order of elements in the work queue depends on what addresses the
allocator got, which can vary run-to-run with ASLR.

We noticed this issue because there were nightly failures with these
tests in gasnet-asan testing:

 distributions/bharshbarg/stencil/rankChange.chpl
 distributions/robust/arithmetic/collapsing/test_domain_rank_change1.chpl
 distributions/robust/arithmetic/collapsing/test_domain_rank_change_OOB.chpl

This PR reverts just the change in PR #19561 to dead code elimination to
remove that nondeterminism.

- [x] resolves failures with the above tests in a gasnet-asan configuration
- [ ] full local testing