### PR TITLE
Ensure that secondary/tertiary methods are defined on types, not values

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -866,6 +866,15 @@ bool FnSymbol::hasGenericFormals(SymbolMap* map) const {
       }
 
       resolveBlockStmt(formal->typeExpr);
+      if (formal == _this) {
+        BaseAST* thisType = formal->typeExpr->body.tail;
+        if (SymExpr* se = toSymExpr(thisType)) {
+          Symbol* sym = se->symbol();
+          if (!toTypeSymbol(sym) && !sym->hasFlag(FLAG_TYPE_VARIABLE)) {
+            USR_FATAL(formal, "Method defined on non-type '%s'", sym->name);
+          }
+        }
+      }
       formal->type = formal->typeExpr->body.tail->getValType();
     }
 

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -866,12 +866,20 @@ bool FnSymbol::hasGenericFormals(SymbolMap* map) const {
       }
 
       resolveBlockStmt(formal->typeExpr);
+
+      // Check that the user did not define a method on a non-type, as
+      // in 'proc myVar.foo() { ... }'.  It would be nice to extend
+      // this check to all formals, but as Vass explains in
+      // https://github.com/chapel-lang/chapel/pull/20262#issuecomment-1190259631
+      // this is not as trivial as one would hope currently.  Ideally,
+      // 'dyno' will do a better job with this.
       if (formal == _this) {
         BaseAST* thisType = formal->typeExpr->body.tail;
         if (SymExpr* se = toSymExpr(thisType)) {
           Symbol* sym = se->symbol();
-          if (!toTypeSymbol(sym) && !sym->hasFlag(FLAG_TYPE_VARIABLE)) {
-            USR_FATAL(formal, "Method defined on non-type '%s'", sym->name);
+          if (!isTypeSymbol(sym) && !sym->hasFlag(FLAG_TYPE_VARIABLE)) {
+            USR_FATAL_CONT(formal, "Method defined on non-type '%s'",
+                           sym->name);
           }
         }
       }

--- a/test/types/records/bugs/methodOnValue.chpl
+++ b/test/types/records/bugs/methodOnValue.chpl
@@ -1,0 +1,17 @@
+record R {
+}
+
+var myR: R;
+
+// this is OK, since R is a type
+proc R.foo() {
+  writeln("In foo()");
+}
+
+// this shouldn't be OK, myR is a value
+proc myR.bar() {
+  writeln("In bar()");
+}
+
+myR.foo();
+myR.bar();

--- a/test/types/records/bugs/methodOnValue.good
+++ b/test/types/records/bugs/methodOnValue.good
@@ -1,0 +1,1 @@
+methodOnValue.chpl:12: error: Method defined on non-type 'myR'


### PR DESCRIPTION
In issue #20259, user @ghbrown pointed out that Chapel currently allows tertiary
methods to be defined on values rather than types (which has the same effect as
defining the method on the type itself, but isn't something I think we ever intended
to support).  This PR closes that loop by tightening up the resolution of the method
receiver to ensure that it's a type and to complain otherwise.

Though I think this is better than what was on `main`, it had a few aspects of it
that were a little disconcerting and worthy of additional looks / future work:

* First, it seems that we call `getValType()` on arbitrary formal type expressions without
  checking to see whether the thing we're calling it on is a type or not.  This makes me
  wonder where else in the compiler value expressions can be used where a type is
  expected without warning, and whether we have (or should have) a method that says
  "convert this expression which I think is a type into its corresponding value type and
  complain at me if it's not actually a type" (where getValType() currently also seems to
  support "get the value type of this arbitrary expression", which makes sense in that
  sort of context).
* Next, it seems as though probably this check could/should be applied to all formal
  expressions rather than just the `_this` formal as I'm doing here.  However, when I
  tried this, it complained about `true` not being a type in:

  ```chapel
    private proc externFunc(param s: string, type T, param explicit=true) param {
  ```
  which suggests to me that we may just abuse the `typeExpr` field of formals at some
  point in the compiler by changing `explicit = true` into `explicit: true = true` (rather
  than (`explicit: true.type = true`)?

In the discussion on this PR, Vass provides some more context for the status quo
and options for improving it, though I'm not pursuing those, and would suggest
we just build dyno to be better in this regard rather than trying to fix the legacy
logic.

Resolves #20259.