### PR TITLE
Use Clang ABI Info to pass extern records by pointer on M1s

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2521,8 +2521,8 @@ GenRet codegenCallExprInner(GenRet function,
       const clang::CodeGen::ABIArgInfo* argInfo = NULL;
       if (CGI) {
         argInfo = getCGArgInfo(CGI, i);
-      } else if (useDarwinArmFix(formal)) {
-        argInfo = getSingleCGArgInfo(formal);
+      } else if (useDarwinArmFix(args[i].chplType)) {
+        argInfo = getSingleCGArgInfo(args[i].chplType);
       }
 
       if (argInfo) {

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2521,7 +2521,7 @@ GenRet codegenCallExprInner(GenRet function,
       const clang::CodeGen::ABIArgInfo* argInfo = NULL;
       if (CGI) {
         argInfo = getCGArgInfo(CGI, i);
-      } else if (useDarwinArmFix(args[i].chplType)) {
+      } else if (args[i].isLVPtr == GEN_VAL && useDarwinArmFix(args[i].chplType)) {
         argInfo = getSingleCGArgInfo(args[i].chplType);
       }
 

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2521,6 +2521,8 @@ GenRet codegenCallExprInner(GenRet function,
       const clang::CodeGen::ABIArgInfo* argInfo = NULL;
       if (CGI) {
         argInfo = getCGArgInfo(CGI, i);
+      } else if (useDarwinArmFix(formal)) {
+        argInfo = getSingleCGArgInfo(formal);
       }
 
       if (argInfo) {

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1961,8 +1961,8 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
     const clang::CodeGen::ABIArgInfo* argInfo = NULL;
     if (CGI) {
       argInfo = getCGArgInfo(CGI, clangArgNum);
-    } else if (useDarwinArmFix(formal)) {
-      argInfo = getSingleCGArgInfo(formal);
+    } else if (useDarwinArmFix(formal->type)) {
+      argInfo = getSingleCGArgInfo(formal->type);
     }
 
     if (formal->hasFlag(FLAG_NO_CODEGEN))
@@ -2594,8 +2594,8 @@ void FnSymbol::codegenDef() {
       const clang::CodeGen::ABIArgInfo* argInfo = NULL;
       if (CGI) {
         argInfo = getCGArgInfo(CGI, clangArgNum);
-      } else if (useDarwinArmFix(arg)) {
-        argInfo = getSingleCGArgInfo(arg);
+      } else if (useDarwinArmFix(arg->type)) {
+        argInfo = getSingleCGArgInfo(arg->type);
       }
 
       // We should have already skipped past the sret above.

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1961,6 +1961,8 @@ static llvm::FunctionType* codegenFunctionTypeLLVM(FnSymbol* fn,
     const clang::CodeGen::ABIArgInfo* argInfo = NULL;
     if (CGI) {
       argInfo = getCGArgInfo(CGI, clangArgNum);
+    } else if (useDarwinArmFix(formal)) {
+      argInfo = getSingleCGArgInfo(formal);
     }
 
     if (formal->hasFlag(FLAG_NO_CODEGEN))
@@ -2592,6 +2594,8 @@ void FnSymbol::codegenDef() {
       const clang::CodeGen::ABIArgInfo* argInfo = NULL;
       if (CGI) {
         argInfo = getCGArgInfo(CGI, clangArgNum);
+      } else if (useDarwinArmFix(arg)) {
+        argInfo = getSingleCGArgInfo(arg);
       }
 
       // We should have already skipped past the sret above.

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -100,9 +100,9 @@ const clang::CodeGen::ABIArgInfo*
 getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg);
 
 const clang::CodeGen::ABIArgInfo*
-getSingleCGArgInfo(ArgSymbol* formal);
+getSingleCGArgInfo(Type* type);
 
-bool useDarwinArmFix(ArgSymbol* formal);
+bool useDarwinArmFix(Type* type);
 
 void makeBinaryLLVM();
 void prepareCodegenLLVM();

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -99,6 +99,11 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfo(FnSymbol* fn);
 const clang::CodeGen::ABIArgInfo*
 getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg);
 
+const clang::CodeGen::ABIArgInfo*
+getSingleCGArgInfo(ArgSymbol* formal);
+
+bool useDarwinArmFix(ArgSymbol* formal);
+
 void makeBinaryLLVM();
 void prepareCodegenLLVM();
 void finishCodegenLLVM();

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3531,13 +3531,13 @@ getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg)
   return argInfo;
 }
 
-bool useDarwinArmFix(ArgSymbol* formal) {
+bool useDarwinArmFix(::Type* type) {
   static bool isDarwin = strcmp(CHPL_TARGET_PLATFORM, "darwin") == 0;
   static bool isArm = strcmp(CHPL_TARGET_ARCH, "arm64") == 0;
 
-  if (isDarwin && isArm &&
-      formal->type->symbol->hasFlag(FLAG_EXTERN) &&
-      isRecord(formal->type)) {
+  if (type != nullptr && isDarwin && isArm &&
+      type->symbol->hasFlag(FLAG_EXTERN) &&
+      isRecord(type)) {
     return true;
   }
 
@@ -3551,7 +3551,7 @@ bool useDarwinArmFix(ArgSymbol* formal) {
 // formal is the only argument.
 //
 const clang::CodeGen::ABIArgInfo*
-getSingleCGArgInfo(ArgSymbol* formal) {
+getSingleCGArgInfo(::Type* type) {
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
@@ -3563,7 +3563,7 @@ getSingleCGArgInfo(ArgSymbol* formal) {
   llvm::SmallVector<clang::CanQualType,4> argTypesC;
 
   // Convert formal to a Clang type.
-  clang::CanQualType argTyC = getClangFormalType(formal);
+  clang::CanQualType argTyC = getClangType(type, false);
   argTypesC.push_back(argTyC);
 
   auto extInfo = clang::FunctionType::ExtInfo();

--- a/test/release/examples/primers/fileIO.suppressif
+++ b/test/release/examples/primers/fileIO.suppressif
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-
-import os
-
-platform = os.getenv('CHPL_TARGET_PLATFORM')
-arch = os.getenv('CHPL_TARGET_ARCH')
-comp = os.getenv('CHPL_TARGET_COMPILER')
-
-print(platform == 'darwin' and arch == 'arm64' and comp == 'llvm')

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -66,11 +66,8 @@ def compatible_platform_for_llvm():
     target_platform = chpl_platform.get('target')
 
     is32bit = target_platform == "linux32" or target_arch == "i368"
-    mac_arm = target_platform == 'darwin' and target_arch == 'arm64'
 
-    if is32bit or mac_arm:
-        return False
-    return True
+    return not is32bit
 
 # returns a string of the supported llvm versions suitable for error msgs
 def llvm_versions_string():


### PR DESCRIPTION
Issue #19218 describes a problem where the fileIO primer fails to successfully run on M1 machines under LLVM. The problem appears to be that LLVM is generating incorrect assembly when passing sufficiently large structs by value (and when optimizations are turned off).

This PR works around the underlying issue by querying ABI information from Clang, and providing that information to the existing codegen logic that determines whether such actuals/formals should use a pointer.

This PR also restores ``CHPL_LLVM=system`` as a compatible option for M1 systems, and removes the suppressif on the fileIO primer.

Testing:
- [x] full local (linux64)
- [x] full gasnet (linux64)
- [x] full local (darwin-m1)
- [x] multilocale-only gasnet (darwin-m1)