### PR TITLE
Fix writeln'ing GPU locales, expand test to cover that

### DIFF
--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -223,7 +223,7 @@ module LocaleModel {
                                 sid);
     }
     override proc chpl_name() {
-      return "node"+ parent.chpl_id():string + "-GPU" + sid:string;
+      return "node"+ chpl_id():string + "-GPU" + sid:string;
     }
 
     proc init() {

--- a/test/gpu/native/localeName.chpl
+++ b/test/gpu/native/localeName.chpl
@@ -1,4 +1,5 @@
 writeln(here.name); // why empty?
+writeln(here.gpus[0]);
 on here.gpus[0] {
   writeln(here.name);
 }

--- a/test/gpu/native/localeName.good
+++ b/test/gpu/native/localeName.good
@@ -1,3 +1,4 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 
+LOCALE0.node0-GPU0
 node0-GPU0


### PR DESCRIPTION
My https://github.com/chapel-lang/chapel/pull/20249 fixed
`writeln(here.gpus[0].name)`, but broke `writeln(here.gpus[0])`. This PR fixes
that by using the proper internal helper.

Also adjusts a test added by #20249 to make sure we can print GPU locales.
