### PR TITLE
feat(dyno): migrate some system and file funcs

### DIFF
--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -66,21 +66,6 @@ std::error_code makeTempDir(std::string dirPrefix, std::string& tmpDirPathOut);
 std::error_code deleteDir(std::string dirname);
 
 
-/**
- * make sure we have set up a temp directory for the use when generating C code.
- * if we don't, create one. May update intDirName to saveCDir, or create a new
- * temporary directory and update the path in tmpdirname and intDirName.
- *
- * saveCDir the path of the directory to save the generated C code, if set
- * intDirName ref to the current path to the intermediate directory
- * tmpdirname ref to the current temp directory name, if set
- * returns std::error_code
- */
-std::error_code ensureTmpDirExists(std::string& saveCDir,
-                                   std::string& intDirName,
-                                   std::string& tmpdirname);
-
-
 } // end namespace chpl
 
 #endif

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -42,7 +42,7 @@ bool fileExists(const char* path);
  * create the directory specified by argument dirname
  *
  * dirname the path of the directory to create
- * std::error_code
+ * returns std::error_code
  */
 std::error_code ensureDirExists(std::string dirname);
 
@@ -68,11 +68,12 @@ std::error_code deleteDir(std::string dirname);
 
 /**
  * make sure we have set up a temp directory for the use when generating C code.
- * if we don't, create one.
+ * if we don't, create one. May update intDirName to saveCDir, or create a new
+ * temporary directory and update the path in tmpdirname and intDirName.
  *
  * saveCDir the path of the directory to save the generated C code, if set
- * intDirName the path to the intermediate directory
- * tmpdirname the current temp directory name, if set
+ * intDirName ref to the current path to the intermediate directory
+ * tmpdirname ref to the current temp directory name, if set
  * returns std::error_code
  */
 std::error_code ensureTmpDirExists(std::string& saveCDir,

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -38,6 +38,19 @@ bool readfile(const char* path, std::string& strOut, ErrorMessage& errorOut);
  */
 bool fileExists(const char* path);
 
+std::error_code ensureDirExists(std::string dirname, std::string  explanation);
+
+
+std::error_code makeTempDir(std::string dirPrefix, std::string& tmpDirPathOut);
+
+std::string getTempDir();
+
+std::error_code deleteDir(std::string dirname);
+
+void ensureTmpDirExists(std::string& saveCDir, std::string& intDirName,
+                        std::string& tmpdirname);
+
+
 } // end namespace chpl
 
 #endif

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -38,17 +38,46 @@ bool readfile(const char* path, std::string& strOut, ErrorMessage& errorOut);
  */
 bool fileExists(const char* path);
 
-std::error_code ensureDirExists(std::string dirname, std::string  explanation);
+/**
+ * create the directory specified by argument dirname
+ *
+ * dirname the path of the directory to create
+ * std::error_code
+ */
+std::error_code ensureDirExists(std::string dirname);
 
 
+/**
+ * creates a directory in the temp location for the system
+ * with the pattern "dirPrefix-username.deleteme-XXXXXX/"
+ *
+ * dirPrefix a prefix to place in the directory name
+ * tmpDirPathOut reference to an empty string that will hold the path of the created directory
+ * returns std::error_code
+ */
 std::error_code makeTempDir(std::string dirPrefix, std::string& tmpDirPathOut);
 
-std::string getTempDir();
-
+/**
+ * forwards to llvm::sys::fs::remove_directories
+ *
+ * dirname the path of the directory to remove
+ * returns std::error_code
+ */
 std::error_code deleteDir(std::string dirname);
 
-void ensureTmpDirExists(std::string& saveCDir, std::string& intDirName,
-                        std::string& tmpdirname);
+
+/**
+ * make sure we have set up a temp directory for the use when generating C code.
+ * if we don't, create one.
+ *
+ * saveCDir the path of the directory to save the generated C code, if set
+ * intDirName the path to the intermediate directory
+ * tmpdirname the current temp directory name, if set
+ * returns std::error_code
+ */
+std::error_code ensureTmpDirExists(std::string& saveCDir,
+                                   std::string& intDirName,
+                                   std::string& tmpdirname);
 
 
 } // end namespace chpl

--- a/compiler/dyno/include/chpl/util/subprocess.h
+++ b/compiler/dyno/include/chpl/util/subprocess.h
@@ -27,13 +27,6 @@
 
 namespace chpl {
 
-// TODO: remove this completely, so only mysystem remains
-int myshell(std::string command,
-            std::string description,
-            bool        ignoreStatus = false,
-            bool        quiet = false,
-            bool        printSystemCommands = false);
-
 
 /**
  * Launch a subprocess

--- a/compiler/dyno/include/chpl/util/subprocess.h
+++ b/compiler/dyno/include/chpl/util/subprocess.h
@@ -27,13 +27,25 @@
 
 namespace chpl {
 
-
+// TODO: remove this completely, so only mysystem remains
 int myshell(std::string command,
             std::string description,
             bool        ignoreStatus = false,
             bool        quiet = false,
             bool        printSystemCommands = false);
 
+
+/**
+ * Launch a subprocess
+ *
+ * commandVec first element is the command to run, the rest are the arguments.
+ * description a string representation of the command to run
+ * childPidOut output parameter for the child's pid
+ * ignoreStatus if true, don't abort if the child exits with a non-zero
+ * quiet  if true, won't print systemCommands
+ * printSystemCommands if true, print the command to be run
+ * returns int as program exit status if fork successful, -1 otherwise
+ */
 int mysystem(const std::vector<std::string> commandVec,
              std::string description,
              pid_t&      childPidOut,

--- a/compiler/dyno/include/chpl/util/subprocess.h
+++ b/compiler/dyno/include/chpl/util/subprocess.h
@@ -39,7 +39,7 @@ namespace chpl {
  * printSystemCommands if true, print the command to be run
  * returns int as program exit status if fork successful, -1 otherwise
  */
-int mysystem(const std::vector<std::string> commandVec,
+int executeAndWait(const std::vector<std::string> commandVec,
              std::string description,
              pid_t&      childPidOut,
              bool        ignoreStatus = false,

--- a/compiler/dyno/include/chpl/util/subprocess.h
+++ b/compiler/dyno/include/chpl/util/subprocess.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_UTIL_SUBPROCESS_H
+#define CHPL_UTIL_SUBPROCESS_H
+
+#include <string>
+#include <vector>
+
+
+namespace chpl {
+
+
+int myshell(std::string command,
+            std::string description,
+            bool        ignoreStatus = false,
+            bool        quiet = false,
+            bool        printSystemCommands = false);
+
+int mysystem(const std::vector<std::string> commandVec,
+             std::string description,
+             pid_t&      childPidOut,
+             bool        ignoreStatus = false,
+             bool        quiet = false,
+             bool        printSystemCommands = false);
+
+#endif
+
+
+} // namespace chpl

--- a/compiler/dyno/lib/util/CMakeLists.txt
+++ b/compiler/dyno/lib/util/CMakeLists.txt
@@ -30,5 +30,6 @@ target_sources(libdyno-obj
                filesystem.cpp
                filesystem_help.h
                string-escapes.cpp
+               subprocess.cpp
                terminal.cpp
               )

--- a/compiler/dyno/lib/util/Makefile.include
+++ b/compiler/dyno/lib/util/Makefile.include
@@ -26,6 +26,7 @@ DYNO_UTIL_SRCS =      \
   break.cpp \
   filesystem.cpp \
   string-escapes.cpp \
+  subprocess.cpp \
   terminal.cpp \
 
 
@@ -35,4 +36,3 @@ DYNO_UTIL_OBJS = \
 	$(DYNO_UTIL_SRCS:%.cpp=$(DYNO_UTIL_OBJDIR)/%.$(OBJ_SUFFIX)) \
         $(DYNO_UTIL_OBJDIR)/my_aligned_alloc.o \
         $(DYNO_UTIL_OBJDIR)/my_strerror_r.o \
-

--- a/compiler/dyno/lib/util/filesystem.cpp
+++ b/compiler/dyno/lib/util/filesystem.cpp
@@ -24,14 +24,30 @@
 #include "chpl/framework/ErrorMessage.h"
 #include "chpl/framework/Location.h"
 
+#include "llvm/Support/FileSystem.h"
+
 #include <cerrno>
 
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <pwd.h>
 
 namespace chpl {
 
+
+static void removeSpacesBackslashesFromString(char* str)
+{
+ char* src = str;
+ char* dst = str;
+ while (*src != '\0')
+ {
+   *dst = *src++;
+   if (*dst != ' ' && *dst != '\\')
+       dst++;
+ }
+ *dst = '\0';
+}
 
 static std::string my_strerror(int errno_) {
   char errbuf[256];
@@ -115,4 +131,84 @@ bool fileExists(const char* path) {
 }
 
 
+/*
+ * Find the default tmp directory. Try getting the tmp dir from the ISO/IEC
+ * 9945 env var options first, then P_tmpdir, then "/tmp".
+ */
+std::string getTempDir() {
+  std::vector<std::string> possibleDirsInEnv = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};
+  for (unsigned int i = 0; i < possibleDirsInEnv.size(); i++) {
+    auto curDir = getenv(possibleDirsInEnv[i].c_str());
+    if (curDir != NULL) {
+      return curDir;
+    }
+  }
+#ifdef P_tmpdir
+  return P_tmpdir;
+#else
+  return "/tmp";
+#endif
 }
+
+std::error_code deleteDir(std::string dirname) {
+  // LLVM 5 added remove_directories
+  return llvm::sys::fs::remove_directories(dirname, false);
+}
+
+std::error_code makeTempDir(std::string dirPrefix, std::string& tmpDirPathOut) {
+  std::string tmpdirprefix = std::string(getTempDir()) + "/" + dirPrefix;
+  std::string tmpdirsuffix = ".deleteme-XXXXXX";
+
+  struct passwd* passwdinfo = getpwuid(geteuid());
+  const char* userid;
+  if (passwdinfo == NULL) {
+    userid = "anon";
+  } else {
+    userid = passwdinfo->pw_name;
+  }
+  char* myuserid = strdup(userid);
+  removeSpacesBackslashesFromString(myuserid);
+  std::string tmpDir = tmpdirprefix + std::string(myuserid) + tmpdirsuffix;
+  char* tmpDirMut = strdup(tmpDir.c_str());
+  // TODO: we could use llvm::sys::fs::createUniqueDirectory instead of mkdtemp
+  // see the comment in LLVM source
+  // https://llvm.org/doxygen/Path_8cpp_source.html#l00883
+  auto dirRes = std::string(mkdtemp(tmpDirMut));
+
+  // get the posix error code if mkdtemp failed.
+  int err = errno;
+
+  if (dirRes.empty()) {
+    std::error_code ret = make_error_code(static_cast<std::errc>(err));
+  return ret;
+  }
+
+  free(myuserid); myuserid = NULL;
+  free(tmpDirMut); tmpDirMut = NULL;
+
+  tmpDirPathOut = dirRes;
+  return std::error_code();
+}
+
+ void ensureTmpDirExists(std::string& saveCDir, std::string& intDirName,
+                         std::string& tmpdirname) {
+   if (saveCDir.empty()) {
+     if (tmpdirname.empty()) {
+       if (auto err = makeTempDir("chpl-", tmpdirname)) {
+         return;
+       }
+       intDirName = tmpdirname;
+     }
+   } else {
+     if (intDirName != saveCDir) {
+       intDirName = saveCDir;
+       ensureDirExists(saveCDir, "ensuring --savec directory exists");
+     }
+   }
+ }
+
+  std::error_code ensureDirExists(std::string dirname , std::string  explanation ) {
+    return llvm::sys::fs::create_directories(dirname);
+  }
+
+} // namespace chpl

--- a/compiler/dyno/lib/util/filesystem.cpp
+++ b/compiler/dyno/lib/util/filesystem.cpp
@@ -190,25 +190,6 @@ std::error_code makeTempDir(std::string dirPrefix, std::string& tmpDirPathOut) {
   return std::error_code();
 }
 
-std::error_code ensureTmpDirExists(std::string& saveCDir,
-                                   std::string& intDirName,
-                                   std::string& tmpdirname) {
-  if (saveCDir.empty()) {
-    if (tmpdirname.empty()) {
-      if (auto err = makeTempDir("chpl-", tmpdirname)) {
-        return err;
-      }
-      intDirName = tmpdirname;
-    }
-  } else {
-    if (intDirName != saveCDir) {
-      intDirName = saveCDir;
-      return ensureDirExists(saveCDir);
-    }
-  }
-  return std::error_code();
-}
-
 std::error_code ensureDirExists(std::string dirname) {
   return llvm::sys::fs::create_directories(dirname);
 }

--- a/compiler/dyno/lib/util/subprocess.cpp
+++ b/compiler/dyno/lib/util/subprocess.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/util/subprocess.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+
+namespace chpl {
+
+
+int myshell(std::string  command,
+            std::string description,
+            bool        ignoreStatus,
+            bool        quiet,
+            bool        printSystemCommands) {
+
+  int status = 0;
+
+  if (printSystemCommands && !quiet) {
+    printf("\n# %s\n", description.c_str());
+    printf("%s\n", command.c_str());
+    fflush(stdout);
+    fflush(stderr);
+  }
+
+  // Treat a '#' at the start of a line as a comment
+  if (command[0] == '#')
+    return 0;
+
+  status = system(command.c_str());
+
+  return status;
+}
+
+// TODO: body of this function should call llvm::sys::ExecuteAndWait instead
+// see: https://llvm.org/doxygen/namespacellvm_1_1sys.html#a67688ad4697f1d516a7c71e41d78c5ba
+int mysystem(const std::vector<std::string> commandVec,
+             std::string description,
+             pid_t&      childPidOut,
+             bool        ignoreStatus,
+             bool        quiet,
+             bool        printSystemCommands) {
+
+  // if an empty command passed, do nothing
+  if (commandVec.empty()) {
+    return 0;
+  }
+
+  // Join the elements of commandVec into a single space separated string
+  std::string commandStr = commandVec.front();
+  for (unsigned int i = 1; i < commandVec.size(); i++) {
+    commandStr += " " + commandVec.at(i);
+  }
+
+  int status = 0;
+  std::vector<const char*> execArgs;
+  for (unsigned int i = 0; i < commandVec.size(); ++i) {
+    execArgs.push_back(commandVec[i].c_str());
+  }
+  execArgs.push_back(NULL);
+  execArgs.shrink_to_fit();
+
+  if (printSystemCommands && !quiet) {
+    printf("\n# %s\n", description.c_str());
+    printf("%s\n", commandStr.c_str());
+    fflush(stdout);
+    fflush(stderr);
+  }
+
+  // Treat a '#' at the start of a line as a comment
+  if (commandStr.c_str()[0] == '#')
+    return 0;
+
+  childPidOut = fork();
+
+  if (childPidOut == 0) {
+    // in child process
+    execvp(execArgs[0], const_cast<char* const *> (execArgs.data()));
+  } else if (childPidOut > 0 ) {
+    // in parent process
+    waitpid(childPidOut, &status, 0);
+    // filter status down to key bits
+    status = WEXITSTATUS(status);
+  }
+  return status;
+}
+
+
+} // namespace chpl

--- a/compiler/dyno/lib/util/subprocess.cpp
+++ b/compiler/dyno/lib/util/subprocess.cpp
@@ -76,7 +76,7 @@ int mysystem(const std::vector<std::string> commandVec,
     commandStr += " " + commandVec.at(i);
   }
 
-  int status = 0;
+  int status = -1;
   std::vector<const char*> execArgs;
   for (unsigned int i = 0; i < commandVec.size(); ++i) {
     execArgs.push_back(commandVec[i].c_str());

--- a/compiler/dyno/lib/util/subprocess.cpp
+++ b/compiler/dyno/lib/util/subprocess.cpp
@@ -34,7 +34,7 @@ namespace chpl {
 
 // TODO: body of this function should call llvm::sys::ExecuteAndWait instead
 // see: https://llvm.org/doxygen/namespacellvm_1_1sys.html#a67688ad4697f1d516a7c71e41d78c5ba
-int mysystem(const std::vector<std::string> commandVec,
+int executeAndWait(const std::vector<std::string> commandVec,
              std::string description,
              pid_t&      childPidOut,
              bool        ignoreStatus,

--- a/compiler/dyno/lib/util/subprocess.cpp
+++ b/compiler/dyno/lib/util/subprocess.cpp
@@ -32,30 +32,6 @@
 namespace chpl {
 
 
-int myshell(std::string  command,
-            std::string description,
-            bool        ignoreStatus,
-            bool        quiet,
-            bool        printSystemCommands) {
-
-  int status = 0;
-
-  if (printSystemCommands && !quiet) {
-    printf("\n# %s\n", description.c_str());
-    printf("%s\n", command.c_str());
-    fflush(stdout);
-    fflush(stderr);
-  }
-
-  // Treat a '#' at the start of a line as a comment
-  if (command[0] == '#')
-    return 0;
-
-  status = system(command.c_str());
-
-  return status;
-}
-
 // TODO: body of this function should call llvm::sys::ExecuteAndWait instead
 // see: https://llvm.org/doxygen/namespacellvm_1_1sys.html#a67688ad4697f1d516a7c71e41d78c5ba
 int mysystem(const std::vector<std::string> commandVec,

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -124,15 +124,17 @@ const char* makeTempDir(const char* dirPrefix) {
 }
 
 void ensureTmpDirExists() {
- std::string cDir, intDir, tmpdir;
- cDir = std::string(saveCDir);
- if (intDirName != NULL) intDir = std::string(intDirName);
- if (tmpdirname != NULL) tmpdir = std::string(tmpdirname);
- if (auto err = chpl::ensureTmpDirExists(cDir, intDir, tmpdir)) {
-      USR_FATAL("creating temp directory failed: %s\n", err.message().c_str());
- }
- if (!intDir.empty()) intDirName = astr(intDir);
- if (!tmpdir.empty()) tmpdirname = astr(tmpdir);
+  if (saveCDir[0] == '\0') {
+    if (tmpdirname == NULL) {
+      tmpdirname = makeTempDir("chpl-");
+      intDirName = tmpdirname;
+    }
+  } else {
+    if (intDirName != saveCDir) {
+      intDirName = saveCDir;
+      ensureDirExists(saveCDir, "ensuring --savec directory exists");
+    }
+  }
 }
 
 void deleteDir(const char* dirname) {

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -107,12 +107,9 @@ void addIncInfo(const char* incDir) {
 }
 
 void ensureDirExists(const char* dirname, const char* explanation) {
-  // make std::strings from args and pass to chpl::ensureDirExists,
-  // check for errors, and report them
+  // forward to chpl::ensureDirExists(), check for errors, and report them
   std::string dirName = std::string(dirname);
-  std::string explanationString = std::string(explanation);
-  auto err = chpl::ensureDirExists(dirName, explanationString);
-  if (err) {
+  if (auto err = chpl::ensureDirExists(dirName)) {
     USR_FATAL("creating directory %s failed: %s\n", dirname,
                    err.message().c_str());
   }
@@ -120,20 +117,22 @@ void ensureDirExists(const char* dirname, const char* explanation) {
 
 const char* makeTempDir(const char* dirPrefix) {
  std::string tmpDirPath;
- if(auto err = chpl::makeTempDir(std::string(dirPrefix), tmpDirPath)) {
+ if (auto err = chpl::makeTempDir(std::string(dirPrefix), tmpDirPath)) {
   USR_FATAL(NULL, "%s", err.message().c_str());
  }
  return astr(tmpDirPath.c_str());
 }
 
 void ensureTmpDirExists() {
-  std::string cDir, intDir, tmpdir;
-  cDir = std::string(saveCDir);
-  if (intDirName != NULL) intDir = std::string(intDirName);
-  if (tmpdirname != NULL) tmpdir = std::string(tmpdir);
-  chpl::ensureTmpDirExists(cDir, intDir, tmpdir);
-  if (!intDir.empty()) intDirName = astr(intDir);
-  if (!tmpdir.empty()) tmpdirname = astr(tmpdir);
+ std::string cDir, intDir, tmpdir;
+ cDir = std::string(saveCDir);
+ if (intDirName != NULL) intDir = std::string(intDirName);
+ if (tmpdirname != NULL) tmpdir = std::string(tmpdirname);
+ if (auto err = chpl::ensureTmpDirExists(cDir, intDir, tmpdir)) {
+      USR_FATAL("creating temp directory failed: %s\n", err.message().c_str());
+ }
+ if (!intDir.empty()) intDirName = astr(intDir);
+ if (!tmpdir.empty()) tmpdirname = astr(tmpdir);
 }
 
 void deleteDir(const char* dirname) {

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -30,6 +30,8 @@
 
 #include "files.h"
 
+#include "chpl/util/filesystem.h"
+
 #include "beautify.h"
 #include "driver.h"
 #include "llvmVer.h"
@@ -40,10 +42,6 @@
 #include "stlUtil.h"
 #include "stringutil.h"
 #include "tmpdirname.h"
-
-#ifdef HAVE_LLVM
-#include "llvm/Support/FileSystem.h"
-#endif
 
 #include <pwd.h>
 #include <unistd.h>
@@ -56,6 +54,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+
 
 char executableFilename[FILENAME_MAX + 1] = "";
 char libmodeHeadername[FILENAME_MAX + 1]  = "";
@@ -108,130 +107,42 @@ void addIncInfo(const char* incDir) {
 }
 
 void ensureDirExists(const char* dirname, const char* explanation) {
-#ifdef HAVE_LLVM
-  std::error_code err = llvm::sys::fs::create_directories(dirname);
+  // make std::strings from args and pass to chpl::ensureDirExists,
+  // check for errors, and report them
+  std::string dirName = std::string(dirname);
+  std::string explanationString = std::string(explanation);
+  auto err = chpl::ensureDirExists(dirName, explanationString);
   if (err) {
-    USR_FATAL("creating directory %s failed: %s\n",
-              dirname,
-              err.message().c_str());
+    USR_FATAL("creating directory %s failed: %s\n", dirname,
+                   err.message().c_str());
   }
-#else
-  const char* mkdircommand = "mkdir -p ";
-  const char* command = astr(mkdircommand, dirname);
-
-  mysystem(command, explanation);
-#endif
 }
-
-
-static void removeSpacesBackslashesFromString(char* str)
-{
-  char* src = str;
-  char* dst = str;
-  while (*src != '\0')
-  {
-    *dst = *src++;
-    if (*dst != ' ' && *dst != '\\')
-        dst++;
-  }
-  *dst = '\0';
-}
-
-
-/*
- * Find the default tmp directory. Try getting the tmp dir from the ISO/IEC
- * 9945 env var options first, then P_tmpdir, then "/tmp".
- */
-static const char* getTempDir() {
-  const char* possibleDirsInEnv[] = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};
-  for (unsigned int i = 0; i < (sizeof(possibleDirsInEnv) / sizeof(char*)); i++) {
-    const char* curDir = getenv(possibleDirsInEnv[i]);
-    if (curDir != NULL) {
-      return curDir;
-    }
-  }
-#ifdef P_tmpdir
-  return P_tmpdir;
-#else
-  return "/tmp";
-#endif
-}
-
 
 const char* makeTempDir(const char* dirPrefix) {
-  const char* tmpdirprefix = astr(getTempDir(), "/", dirPrefix);
-  const char* tmpdirsuffix = ".deleteme-XXXXXX";
-
-  struct passwd* passwdinfo = getpwuid(geteuid());
-  const char* userid;
-  if (passwdinfo == NULL) {
-    userid = "anon";
-  } else {
-    userid = passwdinfo->pw_name;
-  }
-  char* myuserid = strdup(userid);
-  removeSpacesBackslashesFromString(myuserid);
-
-  const char* tmpDir = astr(tmpdirprefix, myuserid, tmpdirsuffix);
-  char* tmpDirMut = strdup(tmpDir);
-  char* dirRes = mkdtemp(tmpDirMut);
-
-  if (dirRes == NULL) {
-    USR_FATAL("unable to create temporary directory at %s\n", tmpDir);
-  }
-
-  free(myuserid); myuserid = NULL;
-
-  const char* ret = astr(dirRes);
-  free(tmpDirMut);
-
-  return ret;
+ std::string tmpDirPath;
+ if(auto err = chpl::makeTempDir(std::string(dirPrefix), tmpDirPath)) {
+  USR_FATAL(NULL, "%s", err.message().c_str());
+ }
+ return astr(tmpDirPath.c_str());
 }
 
 void ensureTmpDirExists() {
-  if (saveCDir[0] == '\0') {
-    if (tmpdirname == NULL) {
-      tmpdirname = makeTempDir("chpl-");
-      intDirName = tmpdirname;
-    }
-  } else {
-    if (intDirName != saveCDir) {
-      intDirName = saveCDir;
-      ensureDirExists(saveCDir, "ensuring --savec directory exists");
-    }
-  }
+  std::string cDir, intDir, tmpdir;
+  cDir = std::string(saveCDir);
+  if (intDirName != NULL) intDir = std::string(intDirName);
+  if (tmpdirname != NULL) tmpdir = std::string(tmpdir);
+  chpl::ensureTmpDirExists(cDir, intDir, tmpdir);
+  if (!intDir.empty()) intDirName = astr(intDir);
+  if (!tmpdir.empty()) tmpdirname = astr(tmpdir);
 }
 
-
-#if !defined(HAVE_LLVM)
-static
-void deleteDirSystem(const char* dirname) {
-  const char* cmd = astr("rm -rf ", dirname);
-  mysystem(cmd, astr("removing directory: ", dirname));
-}
-#endif
-
-#ifdef HAVE_LLVM
-static
-void deleteDirLLVM(const char* dirname) {
-  // LLVM 5 added remove_directories
-  std::error_code err = llvm::sys::fs::remove_directories(dirname, false);
+void deleteDir(const char* dirname) {
+  auto err = chpl::deleteDir(std::string(dirname));
   if (err) {
     USR_FATAL("removing directory %s failed: %s\n",
               dirname,
               err.message().c_str());
   }
-}
-#endif
-
-
-
-void deleteDir(const char* dirname) {
-#ifdef HAVE_LLVM
-  deleteDirLLVM(dirname);
-#else
-  deleteDirSystem(dirname);
-#endif
 }
 
 

--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -41,11 +41,24 @@ int myshell(const char* command,
              bool        ignoreStatus,
              bool        quiet) {
 
-  int status = chpl::myshell(std::string(command), std::string(description),
-                             ignoreStatus, quiet, printSystemCommands);
+  int status = 0;
+
+  if (printSystemCommands && !quiet) {
+    printf("\n# %s\n", description);
+    printf("%s\n", command);
+    fflush(stdout);
+    fflush(stderr);
+  }
+
+  // Treat a '#' at the start of a line as a comment
+  if (command[0] == '#')
+    return 0;
+
+  status = system(command);
 
   if (status == -1) {
     USR_FATAL("system() fork failed: %s", strerror(errno));
+
   } else if (status != 0 && ignoreStatus == false) {
     USR_FATAL("%s", description);
   }

--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -82,7 +82,7 @@ int mysystem(const std::vector<std::string> commandVec,
              bool        ignoreStatus,
              bool        quiet) {
   pid_t childPid = 0;
-  int status = chpl::mysystem(commandVec, std::string(description), childPid,
+  int status = chpl::executeAndWait(commandVec, std::string(description), childPid,
                               ignoreStatus, quiet, printSystemCommands);
   if (childPid == 0) {
     // if there was an error and we shouldn't ignore them, then exit

--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -20,6 +20,8 @@
 
 #include "mysystem.h"
 
+#include "chpl/util/subprocess.h"
+
 #include "misc.h"
 
 #include "stringutil.h"
@@ -39,24 +41,11 @@ int myshell(const char* command,
              bool        ignoreStatus,
              bool        quiet) {
 
-  int status = 0;
-
-  if (printSystemCommands && !quiet) {
-    printf("\n# %s\n", description);
-    printf("%s\n", command);
-    fflush(stdout);
-    fflush(stderr);
-  }
-
-  // Treat a '#' at the start of a line as a comment
-  if (command[0] == '#')
-    return 0;
-
-  status = system(command);
+  int status = chpl::myshell(std::string(command), std::string(description),
+                             ignoreStatus, quiet, printSystemCommands);
 
   if (status == -1) {
     USR_FATAL("system() fork failed: %s", strerror(errno));
-
   } else if (status != 0 && ignoreStatus == false) {
     USR_FATAL("%s", description);
   }
@@ -79,49 +68,11 @@ int mysystem(const std::vector<std::string> commandVec,
              const char* description,
              bool        ignoreStatus,
              bool        quiet) {
-
-  // if an empty command passed, do nothing
-  if (commandVec.empty()) {
-    return 0;
-  }
-
-  // Join the elements of commandVec into a single space separated string
-  std::string commandStr = commandVec.front();
-  for (unsigned int i = 1; i < commandVec.size(); i++) {
-    commandStr += " " + commandVec.at(i);
-  }
-
-  int status = 0;
-  std::vector<const char*> execArgs;
-  for (unsigned int i = 0; i < commandVec.size(); ++i)
-      execArgs.push_back(commandVec[i].c_str());
-  execArgs.push_back(NULL);
-  execArgs.shrink_to_fit();
-
-  if (printSystemCommands && !quiet) {
-    printf("\n# %s\n", description);
-    printf("%s\n", commandStr.c_str());
-    fflush(stdout);
-    fflush(stderr);
-  }
-
-  // Treat a '#' at the start of a line as a comment
-  if (commandStr.c_str()[0] == '#')
-    return 0;
-
-  pid_t childPid;
-
-  childPid = fork();
-
+  pid_t childPid = 0;
+  int status = chpl::mysystem(commandVec, std::string(description), childPid,
+                              ignoreStatus, quiet, printSystemCommands);
   if (childPid == 0) {
-    // in child process
-    execvp(execArgs[0], const_cast<char* const *> (execArgs.data()));
-  } else if (childPid > 0 ) {
-    // in parent process
-    waitpid(childPid, &status, 0);
-    // filter status down to key bits
-    status = WEXITSTATUS(status);
-    // generate an error if there was one and we weren't asked to ignore it
+    // if there was an error and we shouldn't ignore them, then exit
     if (status != 0 && !ignoreStatus) {
       USR_FATAL("%s", description);
     }


### PR DESCRIPTION
This PR migrates some file and system functionality
into dyno and the `chpl` namespace.

Some motivation for this is the need for `dyno-chpldoc`
to form and execute a shell command to invoke `sphinx`.

Overview of changes:

* move some functions associated with creating temporary directories
  to dyno

* rely on `LLVM` support library for deleting directories, where
  previously we conditionally built and used different supporting
  functions depending on `HAVE_LLVM`, now we assume we using the
  support library at least

* migrate `mysystem` functionality to dyno, preserving
  old call sites by changing original functions to wrappers around
  the new calls in dyno

TESTING:

- [x] paratest

Reviewed by @dlongnecke-cray and @mppf - thanks!

*Note: Old PR https://github.com/chapel-lang/chapel/pull/20264 is superseded by this work and will be closed.

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>