### PR TITLE
dyno: More progress on scope resolution, fix bugs in resolver

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -3009,6 +3009,8 @@ Type* AggregateType::getDecoratedClass(ClassTypeDecoratorEnum d) {
     tsDec->copyFlags(at->symbol);
     tsDec->deprecationMsg = at->symbol->deprecationMsg;
     tsDec->addFlag(FLAG_NO_OBJECT);
+    // this flag avoids scope resolve considering it duplicative
+    tsDec->addFlag(FLAG_TEMP);
     // Propagate generic-ness to the decorated type
     if (at->isGeneric() || at->symbol->hasFlag(FLAG_GENERIC))
       tsDec->addFlag(FLAG_GENERIC);

--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -246,6 +246,11 @@ uast::AstTag idToTag(Context* context, ID id);
 bool idIsParenlessFunction(Context* context, ID id);
 
 /**
+ Returns true if the ID is a field in a record/class/union.
+ */
+bool idIsField(Context* context, ID id);
+
+/**
  Returns the parent ID given an ID
  */
 const ID& idToParentId(Context* context, ID id);

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -598,6 +598,27 @@ bool idIsParenlessFunction(Context* context, ID id) {
   return idIsParenlessFunctionQuery(context, id);
 }
 
+static const bool& idIsFieldQuery(Context* context, ID id) {
+  QUERY_BEGIN(idIsFieldQuery, context, id);
+
+  bool result = false;
+  AstTag tag = idToTag(context, id);
+  if (asttags::isVariable(tag)) {
+    const AstNode* ast = astForIDQuery(context, id);
+    if (ast != nullptr) {
+      if (auto var = ast->toVariable()) {
+        result = var->isField();
+      }
+    }
+  }
+
+  return QUERY_END(result);
+}
+
+bool idIsField(Context* context, ID id) {
+  return idIsFieldQuery(context, id);
+}
+
 const ID& idToParentId(Context* context, ID id) {
   QUERY_BEGIN(idToParentId, context, id);
 

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -602,15 +602,9 @@ static const bool& idIsFieldQuery(Context* context, ID id) {
   QUERY_BEGIN(idIsFieldQuery, context, id);
 
   bool result = false;
-  AstTag tag = idToTag(context, id);
-  if (asttags::isVariable(tag)) {
-    const AstNode* ast = astForIDQuery(context, id);
-    if (ast != nullptr) {
-      if (auto var = ast->toVariable()) {
-        result = var->isField();
-      }
-    }
-  }
+  if (auto ast = astForIDQuery(context, id))
+    if (auto var = ast->toVariable())
+      result = var->isField();
 
   return QUERY_END(result);
 }

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -1782,22 +1782,23 @@ CallInfo Resolver::prepareCallInfoNormalCall(const Call* call) {
   }
 
   // Get the type of the called expression.
-  if (auto calledExpr = call->calledExpression()) {
-    ResolvedExpression& r = byPostorder.byAst(calledExpr);
-    calledType = r.type();
+  if (isMethodCall == false) {
+    if (auto calledExpr = call->calledExpression()) {
+      ResolvedExpression& r = byPostorder.byAst(calledExpr);
+      calledType = r.type();
 
-    if (isMethodCall == false &&
-        calledType.kind() != QualifiedType::UNKNOWN &&
-        calledType.kind() != QualifiedType::TYPE &&
-        calledType.kind() != QualifiedType::FUNCTION) {
-      // If e.g. x is a value (and not a function)
-      // then x(0) translates to x.this(0)
-      name = USTR("this");
-      // add the 'this' argument as well
-      isMethodCall = true;
-      actuals.push_back(CallInfoActual(calledType, USTR("this")));
-      // and reset calledType
-      calledType = QualifiedType(QualifiedType::FUNCTION, nullptr);
+      if (calledType.kind() != QualifiedType::UNKNOWN &&
+          calledType.kind() != QualifiedType::TYPE &&
+          calledType.kind() != QualifiedType::FUNCTION) {
+        // If e.g. x is a value (and not a function)
+        // then x(0) translates to x.this(0)
+        name = USTR("this");
+        // add the 'this' argument as well
+        isMethodCall = true;
+        actuals.push_back(CallInfoActual(calledType, USTR("this")));
+        // and reset calledType
+        calledType = QualifiedType(QualifiedType::FUNCTION, nullptr);
+      }
     }
   }
 
@@ -1879,6 +1880,13 @@ bool Resolver::enter(const Dot* dot) {
 }
 void Resolver::exit(const Dot* dot) {
   ResolvedExpression& receiver = byPostorder.byAst(dot->receiver());
+
+  bool resolvingCalledDot = (inLeafCall &&
+                             dot == inLeafCall->calledExpression());
+  if (resolvingCalledDot) {
+    // we will handle it when resolving the FnCall
+    return;
+  }
 
   if (dot->field() == USTR("type")) {
     const Type* receiverType;

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -1951,10 +1951,8 @@ doIsCandidateApplicableInitial(Context* context,
     return typeConstructorInitial(context, t);
   }
 
-  if (isFormal(tag)) {
-    // not a candidate
-    return nullptr;
-  }
+  // not a candidate
+  if (ci.isMethodCall() && isFormal(tag)) return nullptr;
 
   if (isVariable(tag)) {
     if (ci.isParenless() && ci.isMethodCall() && ci.numActuals() == 1) {

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -552,9 +552,11 @@ lookupNameInScopeWithSet(Context* context,
                     name, config, visited, vec);
   }
 
-  doLookupInScope(context, scope,
-                  /* resolving scope */ nullptr,
-                  name, config, visited, vec);
+  if (scope) {
+    doLookupInScope(context, scope,
+                    /* resolving scope */ nullptr,
+                    name, config, visited, vec);
+  }
 
   return vec;
 }

--- a/compiler/dyno/test/resolution/CMakeLists.txt
+++ b/compiler/dyno/test/resolution/CMakeLists.txt
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 comp_unit_test(testCanPass)
+comp_unit_test(testClasses)
 comp_unit_test(testDisambiguation)
 comp_unit_test(testEnums)
 comp_unit_test(testFieldAccess)

--- a/compiler/dyno/test/resolution/testClasses.cpp
+++ b/compiler/dyno/test/resolution/testClasses.cpp
@@ -92,7 +92,7 @@ static void test1() {
                                     ClassTypeDecorator::GENERIC_NONNIL));
 
   assert(methodT->formalName(0) == "this");
-  assert(methodT->formalType(0).kind() == QualifiedType::DEFAULT_INTENT);
+  assert(methodT->formalType(0).kind() == QualifiedType::CONST_IN);
   assert(methodT->formalType(0).type() == borrowedNonNil);
 
   assert(functionT->formalName(0) == "arg");

--- a/compiler/dyno/test/resolution/testClasses.cpp
+++ b/compiler/dyno/test/resolution/testClasses.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/parsing/parsing-queries.h"
+#include "chpl/resolution/resolution-queries.h"
+#include "chpl/types/BasicClassType.h"
+#include "chpl/types/ClassType.h"
+#include "chpl/types/IntType.h"
+#include "chpl/types/QualifiedType.h"
+#include "chpl/uast/Class.h"
+#include "chpl/uast/Comment.h"
+#include "chpl/uast/FnCall.h"
+#include "chpl/uast/Identifier.h"
+#include "chpl/uast/Module.h"
+#include "chpl/uast/Variable.h"
+
+// always check assertions in this test
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+
+using namespace chpl;
+using namespace parsing;
+using namespace resolution;
+using namespace types;
+using namespace uast;
+
+static void test1() {
+  printf("test1\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "test1.chpl");
+  std::string contents = R""""(
+                           module M {
+                             class C { }
+
+                             proc C.method() { }
+
+                             proc function(arg: C) { }
+                          }
+                        )"""";
+
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+  assert(vec.size() == 1);
+  const Module* m = vec[0]->toModule();
+  assert(m);
+  assert(m->numStmts() == 3);
+  auto c = m->stmt(0)->toClass();
+  assert(c);
+  auto method = m->stmt(1)->toFunction();
+  assert(method);
+  auto function = m->stmt(2)->toFunction();
+  assert(function);
+
+  auto methodU = UntypedFnSignature::get(context, method);
+  auto functionU = UntypedFnSignature::get(context, function);
+
+  auto methodT = typedSignatureInitial(context, methodU);
+  auto functionT = typedSignatureInitial(context, functionU);
+
+  auto it = initialTypeForTypeDecl(context, c->id());
+  assert(it);
+  auto bct = it->getCompositeType()->toBasicClassType();
+  assert(bct);
+
+  auto borrowedNonNil = ClassType::get(context, bct, nullptr,
+                                       ClassTypeDecorator(
+                                         ClassTypeDecorator::BORROWED_NONNIL));
+  auto anyNonNil = ClassType::get(context, bct, nullptr,
+                                  ClassTypeDecorator(
+                                    ClassTypeDecorator::GENERIC_NONNIL));
+
+  assert(methodT->formalName(0) == "this");
+  assert(methodT->formalType(0).kind() == QualifiedType::DEFAULT_INTENT);
+  assert(methodT->formalType(0).type() == borrowedNonNil);
+
+  assert(functionT->formalName(0) == "arg");
+  assert(functionT->formalType(0).kind() == QualifiedType::DEFAULT_INTENT);
+  assert(functionT->formalType(0).type() == anyNonNil);
+}
+
+int main() {
+  test1();
+
+  return 0;
+}

--- a/compiler/dyno/test/resolution/testResolveMethodCalls.cpp
+++ b/compiler/dyno/test/resolution/testResolveMethodCalls.cpp
@@ -22,6 +22,7 @@
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
+#include "common.h"
 
 // always check assertions in this test
 #ifdef NDEBUG
@@ -189,10 +190,34 @@ static void test2() {
   context->collectGarbage();
 }
 
+// test case to lock in correct behavior w.r.t. T being both a
+// field and a formal.
+static void test3() {
+  Context ctx;
+  Context* context = &ctx;
+
+  const char* contents = R""""(
+                              module M {
+                                record R {
+                                  type T;
+                                  proc foo(T: int) type {
+                                    return this.T;
+                                  }
+                                }
+                                var z: R(real);
+                                var arg: int;
+                                var x: z.foo(arg);
+                              }
+                         )"""";
+
+  auto qt = resolveQualifiedTypeOfX(context, contents);
+  assert(qt.type()->isRealType()); // and not real
+}
 
 int main() {
   test1();
   test2();
+  test3();
 
   return 0;
 }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -198,23 +198,21 @@ struct Converter {
     return ret;
   }
 
-  static bool shouldScopeResolve(UniqueString symbolPath) {
-    return fDynoCompilerLibrary;
+  bool shouldScopeResolve(ID symbolId) {
+    return canScopeResolve &&
+           !chpl::parsing::idIsInBundledModule(context, symbolId);
   }
-  static bool shouldScopeResolve(ID symbolId) {
-    return shouldScopeResolve(symbolId.symbolPath());
-  }
-  static bool shouldScopeResolve(const uast::AstNode* node) {
+  bool shouldScopeResolve(const uast::AstNode* node) {
     return shouldScopeResolve(node->id());
   }
 
-  static bool shouldResolve(UniqueString symbolPath) {
+  bool shouldResolve(UniqueString symbolPath) {
     return false;
   }
-  static bool shouldResolve(ID symbolId) {
+  bool shouldResolve(ID symbolId) {
     return shouldResolve(symbolId.symbolPath());
   }
-  static bool shouldResolve(const uast::AstNode* node) {
+  bool shouldResolve(const uast::AstNode* node) {
     return shouldResolve(node->id());
   }
 
@@ -494,6 +492,40 @@ struct Converter {
         if (rr != nullptr) {
           auto id = rr->toId();
           if (!id.isEmpty()) {
+            // figure out if it is field access
+            bool isFieldAccess = false;
+            const uast::Formal* parentMethodThis = nullptr;
+            if (parsing::idIsField(context, id)) {
+              // are we in a method? if so, what is the 'this' formal?
+              for (auto it = symStack.rbegin(); it != symStack.rend(); ++it) {
+                if (it->ast != nullptr) {
+                  if (auto inFn = it->ast->toFunction()) {
+                    if (inFn->isMethod()) {
+                      parentMethodThis = inFn->thisFormal();
+                      isFieldAccess = true;
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+
+            // handle field access when only scope resolving
+            if (!shouldResolve(node) && isFieldAccess) {
+              // if we are just scope resolving, convert field
+              // access to this.field using a string literal to
+              // match production scope resolve
+              Symbol* thisSym = findConvertedSym(parentMethodThis->id());
+              INT_ASSERT(thisSym != nullptr);
+              auto ast = parsing::idToAst(context, id);
+              INT_ASSERT(ast && ast->isVariable());
+              auto var = ast->toVariable();
+              auto str = new_CStringSymbol(var->name().c_str());
+              CallExpr* ret = new CallExpr(".", thisSym, str);
+              return ret;
+            }
+
+            // handle other Identifiers
             Symbol* sym = findConvertedSym(id);
             if (sym == nullptr) {
               // we will fix it later
@@ -506,8 +538,13 @@ struct Converter {
               // it's a parenless function call so add a CallExpr
               ret = new CallExpr(se);
             }
+            if (isFieldAccess) {
+              INT_FATAL("resolving field access call not yet implemented");
+              // TODO: convert it to a call to the field accessor
+              // using the resolved TypedFnSignature from rr
+            }
 
-            // fixup, if any, will noted in noteAllContainedFixups
+            // fixup, if any, will be noted in noteAllContainedFixups
 
             return ret;
           }
@@ -3975,6 +4012,17 @@ Symbol* ConvertedSymbolsMap::findConvertedSym(ID id, bool trace) {
         printf("Found sym %s %s in %s\n",
                ret->name, id.str().c_str(), inSymbolId.str().c_str());
       }
+      // convert references to classes as anymanaged
+      // e.g. 'C' in 'typeFn(C)' refers to anymanaged C rather than borrowed C
+      if (TypeSymbol* ts = toTypeSymbol(ret)) {
+        if (AggregateType* at = toAggregateType(ts->type)) {
+          if (at->isClass()) {
+            Type* useType =
+              at->getDecoratedClass(ClassTypeDecorator::GENERIC_NONNIL);
+            ret = useType->symbol;
+          }
+        }
+      }
       return ret;
     }
   }
@@ -4100,7 +4148,7 @@ convertToplevelModule(chpl::Context* context,
   Converter c(context, modTag, builderResult);
 
   c.canScopeResolve = fDynoCompilerLibrary;
-  c.trace = fDynoCompilerLibrary; // TODO: remove once things are working
+  c.trace = fDynoDebugTrace;
 
   // Maybe prepare a toplevel comment to attach to the module.
   if (comment) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -63,6 +63,7 @@ using namespace chpl;
 
 namespace {
 
+const bool tryToScopeResolveEverything = false;
 
 struct ConvertedSymbolsMap {
   ID inSymbolId;
@@ -199,6 +200,7 @@ struct Converter {
   }
 
   bool shouldScopeResolve(ID symbolId) {
+    if (tryToScopeResolveEverything) return true;
     return canScopeResolve &&
            !chpl::parsing::idIsInBundledModule(context, symbolId);
   }


### PR DESCRIPTION
dyno: More progress on scope resolution, fix bugs in resolver (#20281)

This PR continues the effort of PR #20228 to migrate scope resolution
to the dyno framework and fixes a few bugs in the dyno resolver.

[PR and message written by @mppf]

This PR:

  - marks TypeSymbols for decorated class types with FLAG_TEMP so that
    if they are created before the production scope resolve runs, the
    scope resolver will not report an error about symbols with the
    same name
  - adds `parsing::idIsField` to support the conversion
  - in the dyno type resolver, adjusts the types of formals for class
    methods like `proc C.foo` to be borrowed (vs any-management)
  - adjusts `prepareCallInfoNormalCall` to avoid unnecessary work if
    `isMethodCall == true`
  - fixes a bug when resolving method calls
  - fixes a bug when resolving a field access like `this.T` in the
    presence of a formal named `T`
  - improves the dump/stringify output for class types
  - adjusts convert-uast to only scope resolve user-level code if
    `--dyno` is provided (vs all internal modules)
  - adjusts convert-uast to convert scope resolved field access to
    the format the production compiler expects
  - adjusts convert-uast to adjust the types of formals for class
    methods like `proc C.foo` to be borrowed (vs any-management)
  - turns off tracing in the converter by default

TESTING

  - [x] `ALL` on `linux64`, `standard`

Reviewed by @dlongnecke-cray, @DanilaFe. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>