### PR TITLE
dyno: avoid resolution failures during calls to external functions.

### DIFF
--- a/compiler/dyno/lib/resolution/resolution-types.cpp
+++ b/compiler/dyno/lib/resolution/resolution-types.cpp
@@ -174,11 +174,11 @@ void ResolutionResultByPostorderID::setupForSymbol(const AstNode* ast) {
   symbolId = ast->id();
 }
 void ResolutionResultByPostorderID::setupForSignature(const Function* func) {
-  int bodyPostorder = 0;
-  if (func && func->body())
-    bodyPostorder = func->body()->id().postOrderId();
-  assert(0 <= bodyPostorder);
-  vec.resize(bodyPostorder);
+  int maxPostorderId = 0;
+  if (func && func->numChildren() > 0)
+    maxPostorderId = func->child(func->numChildren() - 1)->id().postOrderId();
+  assert(0 <= maxPostorderId);
+  vec.resize(maxPostorderId + 1);
 
   symbolId = func->id();
 }


### PR DESCRIPTION
When a resolver is being set up for processing a function signature,
the space allocaed for the `ResolutionResultByPostorderId` is only
nonzero if the function has a body. When considering a call to an
extern function (which doesn't have a body) the `byPostorderId` mapping
is empty, and thus retrieving the resolved expression for any parameter
results in an assertion failure or an error otherwise (presumably).

Instead of using the `body()` of the function as the "largest known
node" when computing a postorder ID, this PR changes the code to look at
the last child. This change is not needed for `setupForParamLoop`, since
a loop will always have a body.

Reviewed by @benharsh - thanks!

Testing:
- [x] paratest

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>