### PR TITLE
Fix llvmIntrinsicAttributes test

### DIFF
--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.precomp
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.precomp
@@ -14,5 +14,20 @@ $TARGET_CC -S -emit-llvm llvmIntrinsicAttributes.cu --cuda-gpu-arch=sm_60 -L/glo
 # the attributes on that declaration.
 
 CLANG_IR_DUMP_FILE="llvmIntrinsicAttributes-cuda-nvptx64-nvidia-cuda-sm_60.ll"
-grep "declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #2" $CLANG_IR_DUMP_FILE > llvmIntrinsicAttributes.good
-grep "attributes #2" $CLANG_IR_DUMP_FILE >> llvmIntrinsicAttributes.good
+GOOD_FILE="llvmIntrinsicAttributes.good"
+
+regex="declare i32 @llvm.nvvm.read.ptx.sreg.tid.x\(\) #([[:digit:]]*)"
+if [[ $(cat $CLANG_IR_DUMP_FILE) =~ $regex ]]
+then
+  id=${BASH_REMATCH[1]}
+  regex2="attributes #$id = \{([^\}]*)\}"
+  if [[ $(cat $CLANG_IR_DUMP_FILE) =~ $regex2 ]]
+  then
+    attributes=${BASH_REMATCH[1]}
+    echo $attributes > $GOOD_FILE
+  else
+    echo "(from .precomp script) Did not find expected attributes for @llvm.nvvm.read.ptx.sreg.tid.x()" #> $GOOD_FILE
+  fi
+else
+  echo "(from .precomp script) Did not find expected declaration: @llvm.nvvm.read.ptx.sreg.tid.x()" #> $GOOD_FILE
+fi

--- a/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.prediff
+++ b/test/gpu/native/llvmIntrinsicAttributes/llvmIntrinsicAttributes.prediff
@@ -1,6 +1,18 @@
 #!/bin/bash
 
-LINE1=`grep "declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() #2" $2`
-LINE2=`grep "attributes #2" $2`
-echo $LINE1 > $2
-echo $LINE2 >> $2
+regex="declare i32 @llvm.nvvm.read.ptx.sreg.tid.x\(\) #([[:digit:]]*)"
+if [[ $(cat $2) =~ $regex ]]
+then
+  id=${BASH_REMATCH[1]}
+
+  regex2="attributes #$id = \{([^\}]*)\}"
+  if [[ $(cat $2) =~ $regex2 ]]
+  then
+    attributes=${BASH_REMATCH[1]}
+    echo $attributes > $2
+  else
+    echo "Did not find expected attributes for @llvm.nvvm.read.ptx.sreg.tid.x()" #> $GOOD_FILE
+  fi
+else
+  echo "Did not find expected declaration: @llvm.nvvm.read.ptx.sreg.tid.x()" #> $2
+fi


### PR DESCRIPTION
This PR fixes a gpu test that fails on Horizon but not Osprey:

The llvmintrinsicAttributes test compares IR generated by clang against IR we generate in our codegen pass for a declaration to an intrinsic (`llvm.nvvm.read.ptx.sreg.tid.x`).  More specifically it ensures that the attributes that are on the declaration of that intrinsic match (between what we generate and what clang generates).

The idea is if something diverges in clang as far as how it generates this declaration we want to be alerted to it. See the README in the test directory for more info.

Anyway, the previous way this test worked was pretty fragile: it assumed the set of attributes we cared about were tied to a specific tag.  For whatever reason this tag would differ on Osprey compared to other machines (like Horizon or our personal desktops). This PR generalizes it to extract the correct ID for the tag and use that.