### PR TITLE
Adjust allGenericFieldsHaveDefaults to ignore fields w/ type expr

### DIFF
--- a/compiler/dyno/include/chpl/resolution/resolution-types.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-types.h
@@ -1310,18 +1310,22 @@ class FormalActualMap {
 class ResolvedFields {
   struct FieldDetail {
     UniqueString name;
+    bool hasTypeExpression = false;
     bool hasDefaultValue = false;
     ID declId;
     types::QualifiedType type;
 
     FieldDetail(UniqueString name,
+                bool hasTypeExpression,
                 bool hasDefaultValue,
                 ID declId,
                 types::QualifiedType type)
-      : name(name), hasDefaultValue(hasDefaultValue), declId(declId), type(type) {
+      : name(name), hasTypeExpression(hasTypeExpression),
+        hasDefaultValue(hasDefaultValue), declId(declId), type(type) {
     }
     bool operator==(const FieldDetail& other) const {
       return name == other.name &&
+             hasTypeExpression == other.hasTypeExpression &&
              hasDefaultValue == other.hasDefaultValue &&
              declId == other.declId &&
              type == other.type;
@@ -1330,7 +1334,7 @@ class ResolvedFields {
       return !(*this == other);
     }
     size_t hash() const {
-      return chpl::hash(name, hasDefaultValue, declId, type);
+      return chpl::hash(name, hasTypeExpression, hasDefaultValue, declId, type);
     }
 
     void mark(Context* context) const {
@@ -1363,10 +1367,11 @@ class ResolvedFields {
   }
 
   void addField(UniqueString name,
+                bool hasTypeExpression,
                 bool hasDefaultValue,
                 ID declId,
                 types::QualifiedType type) {
-    fields_.push_back(FieldDetail(name, hasDefaultValue, declId, type));
+    fields_.push_back(FieldDetail(name, hasTypeExpression, hasDefaultValue, declId, type));
   }
 
   void finalizeFields(Context* context);
@@ -1388,6 +1393,10 @@ class ResolvedFields {
   UniqueString fieldName(int i) const {
     assert(0 <= i && (size_t) i < fields_.size());
     return fields_[i].name;
+  }
+  bool fieldHasTypeExpression(int i) const {
+    assert(0 <= i && (size_t) i < fields_.size());
+    return fields_[i].hasTypeExpression;
   }
   bool fieldHasDefaultValue(int i) const {
     assert(0 <= i && (size_t) i < fields_.size());

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -567,9 +567,10 @@ static void helpSetFieldTypes(const AstNode* ast,
                               ResolvedFields& fields) {
 
   if (auto var = ast->toVarLikeDecl()) {
+    bool hasTypeExpression = var->typeExpression() != nullptr;
     bool hasDefaultValue = initedInParent || var->initExpression() != nullptr;
     const ResolvedExpression& e = r.byAst(var);
-    fields.addField(var->name(), hasDefaultValue, var->id(), e.type());
+    fields.addField(var->name(), hasTypeExpression, hasDefaultValue, var->id(), e.type());
   } else if (auto mult = ast->toMultiDecl()) {
     for (auto decl : mult->decls()) {
       helpSetFieldTypes(decl, r, initedInParent, fields);
@@ -708,6 +709,7 @@ const ResolvedFields& fieldsForTypeDeclQuery(Context* context,
         int n = resolvedFields.numFields();
         for (int i = 0; i < n; i++) {
           result.addField(resolvedFields.fieldName(i),
+                          resolvedFields.fieldHasTypeExpression(i),
                           resolvedFields.fieldHasDefaultValue(i),
                           resolvedFields.fieldDeclId(i),
                           resolvedFields.fieldType(i));

--- a/compiler/dyno/lib/resolution/resolution-types.cpp
+++ b/compiler/dyno/lib/resolution/resolution-types.cpp
@@ -339,7 +339,10 @@ void ResolvedFields::finalizeFields(Context* context) {
   // look at the fields and compute the summary information
   for (auto field : fields_) {
     auto g = getTypeGenericityIgnoring(context, field.type, ignore);
-    if (g != Type::CONCRETE) {
+    if (g != Type::CONCRETE && !field.hasTypeExpression) {
+      // XXX: as a temporary workaround to the insufficient
+      // genericity computation, skip types marked as generic
+      // that have a type expression.
       if (!field.hasDefaultValue) {
         allGenHaveDefault = false;
       }


### PR DESCRIPTION
This is a temporary workaround to get ranges resolving in dyno.
The current mechanism for resolving a type with defaults does
not provide any defaults if any generic field lacks a default
value. However, fields with function calls that reference generic fields
in their type expressions are marked as having an unknown type, and
thus possibly generic, preventing the enclosing type from
being resolved with defaults.

While the resolver cannot properly determine the types of
such fields, we will try simply ignoring unknown-typed
fields without generic values if they have a type expression.

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>