### PR TITLE
Add 3 distinct mason modes and `mason modules` command

### DIFF
--- a/test/library/packages/UnitTest/Launcher_Test.chpl
+++ b/test/library/packages/UnitTest/Launcher_Test.chpl
@@ -3,5 +3,5 @@ use MasonTest;
 
 proc main(args: [] string) {
   var masonArgs = ["mason", "--recursive", args[1]];
-  masonTest(masonArgs);
+  masonTest(masonArgs, checkProj=false);
 }

--- a/test/mason/build/noDeps.chpl
+++ b/test/mason/build/noDeps.chpl
@@ -7,5 +7,5 @@ proc main() {
   const package = '_noDeps';
   here.chdir(package);
   const args = ["build"];
-  masonBuild(args);
+  masonBuild(args, checkProj=false);
 }

--- a/test/mason/chplVersion/mason-chpl-version-new.good
+++ b/test/mason/chplVersion/mason-chpl-version-new.good
@@ -1,9 +1,10 @@
-Created new library project: newTest
+Created new application project: newTest
 [brick]
 name="newTest"
 version="0.1.0"
 chplVersion="CHPL_CUR_FULL"
 license="None"
+type="application"
 
 [dependencies]
 

--- a/test/mason/init/masonInteractive.good
+++ b/test/mason/init/masonInteractive.good
@@ -10,9 +10,10 @@ name="project"
 version="1.2.3"
 chplVersion="1.21.0"
 license="MIT"
+type="application"
 
 [dependencies]
 
 
 
-Is this okay ? (Y/N): Created new library project: project
+Is this okay ? (Y/N): Created new application project: project

--- a/test/mason/mason-example-with-opts/mason-example.chpl
+++ b/test/mason/mason-example-with-opts/mason-example.chpl
@@ -4,11 +4,11 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonBuild(["build", "--example", "--force"]);
+  masonBuild(["build", "--example", "--force"], checkProj=false);
 
   // run each example
   // over 3 arguments runs all examples
   var runArgs = ["run", "--example", "--force"];
-  masonRun(runArgs);
+  masonRun(runArgs, checkProj=false);
 
 }

--- a/test/mason/mason-example/mason-example.chpl
+++ b/test/mason/mason-example/mason-example.chpl
@@ -4,10 +4,10 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonBuild(["build", "--example", "--force"]);
+  masonBuild(["build", "--example", "--force"], checkProj=false);
 
   // run each example
   // over 3 arguments runs all examples
-  masonRun(["run", "--example", "--force", "--no-update"]);
+  masonRun(["run", "--example", "--force", "--no-update"], checkProj=false);
 
 }

--- a/test/mason/mason-help-tests/masonHelpTests.good
+++ b/test/mason/mason-help-tests/masonHelpTests.good
@@ -59,11 +59,52 @@ Manually edit the Mason.toml if multiple versions of the same package are listed
 Package names and versions are not validated upon adding
 ********************************************************************************
 $ mason build -h
+Compile a local package and all of its dependencies
+
+Usage:
+    mason build [options]
+
+Options:
+    -h, --help                   Display this message
+        --show                   Increase verbosity
+        --release                Compile to target/release with optimizations (--fast)
+        --force                  Force Mason to build the project
+        --example <example>      Build an example from the example/ directory
+        --[no-]update            [Do not] update the mason registry before building
+        --dependent-modules      Print the include paths to the dependent modules to be integrated into build step
+
+When --example is thrown without an example, all examples will be built
+When no options are provided, the following will take place:
+   - Build from mason project if Mason.lock present
+
+Compilation flags and arguments can be included after mason arguments.
+To ensure compilation flags and mason arguments to not conflict, separate them with a
+double dash(`--`). For example
+   e.g. mason build --force -- --savec tmpdir
 ********************************************************************************
-Failed to run cmd: 'mason build -h'
 $ mason run -h
+Run the compiled project and output to standard output
+
+Usage:
+   mason run [options]
+
+Options:
+    -h, --help                   Display this message
+        --build                  Compile before running binary
+        --show                   Increase verbosity
+        --example <example>      Run an example
+
+When --example is thrown without an example, all available examples will be listed
+
+When no options are provided, the following will take place:
+   - Execute binary from mason project if target/ is present
+   - If no target directory, build and run is Mason.toml is present
+
+Runtime arguments can be included after mason arguments.
+To ensure that runtime arguments and mason arguments do not conflict, separate them
+with a double dash(`--`). For example
+   e.g. mason run --build -- --runtimeArg=true
 ********************************************************************************
-Failed to run cmd: 'mason run -h'
 $ mason search -h
 Search the registry for a package
 
@@ -155,8 +196,26 @@ Options:
 
 ********************************************************************************
 $ mason test -h
+mason test works inside and outside of mason packages.
+Inside a mason package: run test files found in test/
+Outside of a mason package: run test files found in the provided path (defaults to '.').
+
+Usage:
+    mason test [options] <path>
+
+Options:
+    -h, --help                  Display this message
+        --show                  Direct output of tests to stdout
+        --no-run                Compile tests without running them
+        --keep-binary           Doesn't delete the binaries after running
+        --recursive             Descend recursively into subdirectories of given directories
+        --parallel              Run tests in parallel(sequential by default)
+        --[no]-update           [Do not] update the mason-registry when testing
+        --setComm               Set the CHPL_COMM value for running the tests,  e.g. none, gasnet, ugni
+
+Test configuration is up to the user
+Tests pass if they exit with status code 0
 ********************************************************************************
-Failed to run cmd: 'mason test -h'
 $ mason external -h
 Use, install and search for external packages to build Mason packages with
 

--- a/test/mason/mason-help-tests/masonHelpTests.good
+++ b/test/mason/mason-help-tests/masonHelpTests.good
@@ -7,6 +7,9 @@ Options:
     -h, --help                   Display this message
         --show                   Increase verbosity
         --no-vcs                 Do not initialize a git repository
+        --app                    Create a Mason "application" (package with main function)
+        --lib                    Create a Mason "library" (package without main function)
+        --light                  Create a Mason "lightweight" project (place a TOML file in current directory)
     --name <legalName>           Specify package name different from directory name
 ********************************************************************************
 $ mason init -h
@@ -56,51 +59,11 @@ Manually edit the Mason.toml if multiple versions of the same package are listed
 Package names and versions are not validated upon adding
 ********************************************************************************
 $ mason build -h
-Compile a local package and all of its dependencies
-
-Usage:
-    mason build [options]
-
-Options:
-    -h, --help                   Display this message
-        --show                   Increase verbosity
-        --release                Compile to target/release with optimizations (--fast)
-        --force                  Force Mason to build the project
-        --example <example>      Build an example from the example/ directory
-        --[no-]update            [Do not] update the mason registry before building
-
-When --example is thrown without an example, all examples will be built
-When no options are provided, the following will take place:
-   - Build from mason project if Mason.lock present
-
-Compilation flags and arguments can be included after mason arguments.
-To ensure compilation flags and mason arguments to not conflict, separate them with a
-double dash(`--`). For example
-   e.g. mason build --force -- --savec tmpdir
 ********************************************************************************
+Failed to run cmd: 'mason build -h'
 $ mason run -h
-Run the compiled project and output to standard output
-
-Usage:
-   mason run [options]
-
-Options:
-    -h, --help                   Display this message
-        --build                  Compile before running binary
-        --show                   Increase verbosity
-        --example <example>      Run an example
-
-When --example is thrown without an example, all available examples will be listed
-
-When no options are provided, the following will take place:
-   - Execute binary from mason project if target/ is present
-   - If no target directory, build and run is Mason.toml is present
-
-Runtime arguments can be included after mason arguments.
-To ensure that runtime arguments and mason arguments do not conflict, separate them
-with a double dash(`--`). For example
-   e.g. mason run --build -- --runtimeArg=true
 ********************************************************************************
+Failed to run cmd: 'mason run -h'
 $ mason search -h
 Search the registry for a package
 
@@ -192,26 +155,8 @@ Options:
 
 ********************************************************************************
 $ mason test -h
-mason test works inside and outside of mason packages.
-Inside a mason package: run test files found in test/
-Outside of a mason package: run test files found in the provided path (defaults to '.').
-
-Usage:
-    mason test [options] <path>
-
-Options:
-    -h, --help                  Display this message
-        --show                  Direct output of tests to stdout
-        --no-run                Compile tests without running them
-        --keep-binary           Doesn't delete the binaries after running
-        --recursive             Descend recursively into subdirectories of given directories
-        --parallel              Run tests in parallel(sequential by default)
-        --[no]-update           [Do not] update the mason-registry when testing
-        --setComm               Set the CHPL_COMM value for running the tests,  e.g. none, gasnet, ugni
-
-Test configuration is up to the user
-Tests pass if they exit with status code 0
 ********************************************************************************
+Failed to run cmd: 'mason test -h'
 $ mason external -h
 Use, install and search for external packages to build Mason packages with
 

--- a/test/mason/mason-test/mason-test.chpl
+++ b/test/mason/mason-test/mason-test.chpl
@@ -2,5 +2,5 @@ use MasonTest;
 
 proc main() {
   const args = ["test"];
-  masonTest(args);
+  masonTest(args, checkProj=false);
 }

--- a/test/mason/masonInit/masonInitModifyToml.good
+++ b/test/mason/masonInit/masonInitModifyToml.good
@@ -1,3 +1,3 @@
-Created new library project: testSrc
+Created new application project: testSrc
 Library project has already been initialized.
 Mason.toml has been successfully created

--- a/test/mason/masonInit/masonInitTest2.good
+++ b/test/mason/masonInit/masonInitTest2.good
@@ -1,3 +1,3 @@
-Created new library project: testSrc
+Created new application project: testSrc
 Initialized new library project in testSrc: testSrc
 src has been successfully created

--- a/test/mason/masonInit/masonInitTest3.good
+++ b/test/mason/masonInit/masonInitTest3.good
@@ -1,3 +1,3 @@
-Created new library project: testSrc
+Created new application project: testSrc
 Initialized new library project in testSrc: testSrc
 .git has been successfully created

--- a/test/mason/masonInit/masonInitTest4.good
+++ b/test/mason/masonInit/masonInitTest4.good
@@ -1,2 +1,2 @@
-Created new library project: testSrc
+Created new application project: testSrc
 Library project has already been initialized.

--- a/test/mason/masonNewModule.good
+++ b/test/mason/masonNewModule.good
@@ -1,2 +1,2 @@
-Created new library project: project-testSrc
+Created new application project: project-testSrc
 Project.chpl has been successfully created

--- a/test/mason/masonNewTest.chpl
+++ b/test/mason/masonNewTest.chpl
@@ -2,7 +2,7 @@ use FileSystem;
 use MasonNew;
 
 proc main() {
-  const args = ['new', 'Test'];
+  var args = ['new', 'Test'];
   masonNew(args);
 
   // Confirm structure
@@ -12,6 +12,46 @@ proc main() {
       writeln('File structure: correct');
       rmTree('Test');
     }
+  }
+  else {
+    writeln('File structure: incorrect');
+  }
+
+  var args2 = ['new', 'Test', '--app'];
+  masonNew(args2);
+
+  // Confirm structure
+  if isDir(pwd + '/Test/src') {
+    if isFile(pwd + '/Test/src/Test.chpl') {
+      writeln('File structure: correct');
+      rmTree('Test');
+    }
+  }
+  else {
+    writeln('File structure: incorrect');
+  }
+
+  var args3 = ['new', 'Test', '--lib'];
+  masonNew(args3);
+
+  // Confirm structure
+  if isDir(pwd + '/Test/src') {
+    if isFile(pwd + '/Test/src/Test.chpl') {
+      writeln('File structure: correct');
+      rmTree('Test');
+    }
+  }
+  else {
+    writeln('File structure: incorrect');
+  }
+
+  var args4 = ['new', 'Test', '--light'];
+  masonNew(args4);
+
+  // Confirm structure
+  if isFile(pwd + '/Mason.toml') {
+    writeln('File structure: correct');
+    remove('Mason.toml');
   }
   else {
     writeln('File structure: incorrect');

--- a/test/mason/masonNewTest.good
+++ b/test/mason/masonNewTest.good
@@ -1,2 +1,8 @@
+Created new application project: Test
+File structure: correct
+Created new application project: Test
+File structure: correct
 Created new library project: Test
+File structure: correct
+Created new light project: /Users/ben.mcdonald/chapel/test/mason
 File structure: correct

--- a/test/mason/masonNewTest.good
+++ b/test/mason/masonNewTest.good
@@ -4,5 +4,5 @@ Created new application project: Test
 File structure: correct
 Created new library project: Test
 File structure: correct
-Created new light project: /Users/ben.mcdonald/chapel/test/mason
+Created new light project in current directory
 File structure: correct

--- a/test/mason/masonTestSome/mason-test-noShow.chpl
+++ b/test/mason/masonTestSome/mason-test-noShow.chpl
@@ -3,5 +3,5 @@ use MasonTest;
 proc main() {
 
   const args = ["test", "test/compilererror.chpl"];
-  masonTest(args);
+  masonTest(args, checkProj=false);
 }

--- a/test/mason/masonTestSome/mason-test-show.chpl
+++ b/test/mason/masonTestSome/mason-test-show.chpl
@@ -3,5 +3,5 @@ use MasonTest;
 proc main() {
 
   const args = ["test", "--show"];
-  masonTest(args);
+  masonTest(args, checkProj=false);
 }

--- a/test/mason/masonTestSome/mason-test-some.chpl
+++ b/test/mason/masonTestSome/mason-test-some.chpl
@@ -3,5 +3,5 @@ use MasonTest;
 
 proc main() {
   const args = ["test" , "test/test1.chpl", "test/testDir"];
-  masonTest(args);
+  masonTest(args, checkProj=false);
 }

--- a/test/mason/masonTestSubString/mason-test-sub-string.chpl
+++ b/test/mason/masonTestSubString/mason-test-sub-string.chpl
@@ -2,5 +2,5 @@ use MasonTest;
 
 proc main() {
   const args = ["test" , "1", "3", "--no-update"];
-  masonTest(args);
+  masonTest(args, checkProj=false);
 }

--- a/test/mason/new/masonInteractive.good
+++ b/test/mason/new/masonInteractive.good
@@ -10,9 +10,10 @@ name="project"
 version="1.2.3"
 chplVersion="1.21.0"
 license="MIT"
+type="application"
 
 [dependencies]
 
 
 
-Is this okay ? (Y/N): Created new library project: project
+Is this okay ? (Y/N): Created new application project: project

--- a/test/mason/publish/badDry.good
+++ b/test/mason/publish/badDry.good
@@ -1,2 +1,2 @@
-Created new library project: publishCheck
+Created new application project: publishCheck
 ../bad-registry is not a valid path to a local mason-registry.

--- a/test/mason/publish/badRegTest.good
+++ b/test/mason/publish/badRegTest.good
@@ -1,2 +1,2 @@
-Created new library project: publishCheck
+Created new application project: publishCheck
 ../bad-regsitry is not a valid path to a local mason-registry.

--- a/test/mason/publish/publish.good
+++ b/test/mason/publish/publish.good
@@ -1,2 +1,2 @@
-Created new library project: publishCheck
+Created new application project: publishCheck
 Unable to publish your package to the registry, make sure your package is a git repository.

--- a/test/mason/publish/publishGitCheck.good
+++ b/test/mason/publish/publishGitCheck.good
@@ -1,2 +1,2 @@
-Created new library project: publishCheck
+Created new application project: publishCheck
 Passed! Should return empty string as no repo was initialized

--- a/test/mason/run/mason-run.chpl
+++ b/test/mason/run/mason-run.chpl
@@ -2,5 +2,5 @@ use MasonRun;
 
 proc main() {
   const args: [0..2] string = ["run", "--build", "--force"];
-  masonRun(args);
+  masonRun(args, checkProj=false);
 }

--- a/test/mason/subdir-commands/mason-run.chpl
+++ b/test/mason/subdir-commands/mason-run.chpl
@@ -2,5 +2,5 @@ use MasonRun;
 
 proc main() {
   const args: [0..2] string = ["run", "--build", "--force"];
-  masonRun(args);
+  masonRun(args, checkProj=false);
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -35,10 +35,6 @@ use TOML;
 
 proc masonBuild(args: [] string) throws {
 
-  const projectType = getProjectType();
-  if projectType == "light" then
-      throw new owned MasonError("Mason light projects do not currently support 'mason build'");
-
   var parser = new argumentParser(helpHandler=new MasonBuildHelpHandler());
 
   var showFlag = parser.addFlag(name="show", defaultValue=false);
@@ -54,6 +50,10 @@ proc masonBuild(args: [] string) throws {
   if passArgs.hasValue() && exampleOpts._present {
     throw new owned MasonError("Examples do not support `--` syntax");
   }
+
+  const projectType = getProjectType();
+  if projectType == "light" then
+    throw new owned MasonError("Mason light projects do not currently support 'mason build'");
 
   var show = showFlag.valueAsBool();
   var release = releaseFlag.valueAsBool();

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -35,6 +35,10 @@ use TOML;
 
 proc masonBuild(args: [] string) throws {
 
+  const projectType = getProjectType();
+  if projectType == "light" then
+      throw new owned MasonError("Mason light projects do not currently support 'mason build'");
+
   var parser = new argumentParser(helpHandler=new MasonBuildHelpHandler());
 
   var showFlag = parser.addFlag(name="show", defaultValue=false);

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -33,7 +33,7 @@ use MasonExample;
 use Subprocess;
 use TOML;
 
-proc masonBuild(args: [] string) throws {
+proc masonBuild(args: [] string, checkProj=true) throws {
 
   var parser = new argumentParser(helpHandler=new MasonBuildHelpHandler());
 
@@ -51,9 +51,11 @@ proc masonBuild(args: [] string) throws {
     throw new owned MasonError("Examples do not support `--` syntax");
   }
 
-  const projectType = getProjectType();
-  if projectType == "light" then
-    throw new owned MasonError("Mason light projects do not currently support 'mason build'");
+  if checkProj {
+    const projectType = getProjectType();
+    if projectType == "light" then
+      throw new owned MasonError("Mason light projects do not currently support 'mason build'");
+  }
 
   var show = showFlag.valueAsBool();
   var release = releaseFlag.valueAsBool();
@@ -81,7 +83,7 @@ proc masonBuild(args: [] string) throws {
     if force then compopts.append("--force");
     // add expected arguments for masonExample
     compopts.insert(0,["example", "--example"]);
-    masonExample(compopts.toArray());
+    masonExample(compopts.toArray(), checkProj=checkProj);
   }
   else {
     if passArgs.hasValue() {

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -34,7 +34,11 @@ use TOML;
 
 
 /* Runs the .chpl files found within the /example directory */
-proc masonExample(args: [] string) {
+proc masonExample(args: [] string) throws {
+
+  const projectType = getProjectType();
+  if projectType == "light" then
+      throw new owned MasonError("Mason light projects do not currently support 'mason example'");
 
   var parser = new argumentParser();
 

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -36,10 +36,6 @@ use TOML;
 /* Runs the .chpl files found within the /example directory */
 proc masonExample(args: [] string) throws {
 
-  const projectType = getProjectType();
-  if projectType == "light" then
-      throw new owned MasonError("Mason light projects do not currently support 'mason example'");
-
   var parser = new argumentParser();
 
   var runFlag = parser.addFlag(name="run",
@@ -54,6 +50,10 @@ proc masonExample(args: [] string) throws {
   var forceFlag = parser.addFlag(name="force", defaultValue=false);
   var updateFlag = parser.addFlag(name="update", flagInversion=true);
   var exampleOpts = parser.addOption(name="example", numArgs=0..);
+
+  const projectType = getProjectType();
+  if projectType == "light" then
+    throw new owned MasonError("Mason light projects do not currently support 'mason example'");
 
   try! {
     parser.parseArgs(args);

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -34,7 +34,7 @@ use TOML;
 
 
 /* Runs the .chpl files found within the /example directory */
-proc masonExample(args: [] string) throws {
+proc masonExample(args: [] string, checkProj=true) throws {
 
   var parser = new argumentParser();
 
@@ -51,9 +51,11 @@ proc masonExample(args: [] string) throws {
   var updateFlag = parser.addFlag(name="update", flagInversion=true);
   var exampleOpts = parser.addOption(name="example", numArgs=0..);
 
-  const projectType = getProjectType();
-  if projectType == "light" then
-    throw new owned MasonError("Mason light projects do not currently support 'mason example'");
+  if checkProj {
+    const projectType = getProjectType();
+    if projectType == "light" then
+      throw new owned MasonError("Mason light projects do not currently support 'mason example'");
+  }
 
   try! {
     parser.parseArgs(args);

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -164,6 +164,11 @@ class MasonDocHelpHandler : HelpHandler {
   }
 }
 
+class MasonLightHelpHandler : HelpHandler {
+  override proc printHelp() {
+    masonLightHelp();
+  }
+}
 
 proc masonHelp() {
   writeln("Chapel's package manager");
@@ -192,6 +197,7 @@ proc masonHelp() {
   writeln('    test        Compile and run tests found in /test');
   writeln('    external    Integrate external dependencies into mason packages');
   writeln('    publish     Publish package to mason-registry');
+  writeln('    light       Interact with a lightweight mason project');
 }
 
 proc masonRunHelp() {
@@ -231,6 +237,7 @@ proc masonBuildHelp() {
   writeln('        --force                  Force Mason to build the project');
   writeln('        --example <example>      Build an example from the example/ directory');
   writeln('        --[no-]update            [Do not] update the mason registry before building');
+  writeln('        --dependent-modules      Print the include paths to the dependent modules to be integrated into build step');
   writeln();
   writeln('When --example is thrown without an example, all examples will be built');
   writeln('When no options are provided, the following will take place:');
@@ -251,7 +258,9 @@ proc masonNewHelp() {
   writeln('    -h, --help                   Display this message');
   writeln('        --show                   Increase verbosity');
   writeln('        --no-vcs                 Do not initialize a git repository');
+  writeln('        --light                  Create a "lightweight" Mason package in current directory');
   writeln('    --name <legalName>           Specify package name different from directory name');
+  
 }
 
 proc masonInitHelp(){
@@ -595,5 +604,18 @@ proc masonDocHelp() {
   writeln("Will generate documentation when ran inside a mason package.");
   writeln("Requires that chpldoc is set up in order to work.");
   writeln("For instructions on setting up chpldoc, please view its documentation.");
+  writeln();
+}
+
+proc masonLightHelp() {
+  writeln("Interact with a lightweight mason project");
+  writeln();
+  writeln('Usage:');
+  writeln('    mason light [options]');
+  writeln();
+  writeln('Options:');
+  writeln("    -h, --help                  Display this message");
+  writeln("        --new                   Create a new mason lightweight project in the current directory");
+  writeln("        --dependent-modules     Print the include paths to the dependent modules to be integrated into build step");
   writeln();
 }

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -164,9 +164,9 @@ class MasonDocHelpHandler : HelpHandler {
   }
 }
 
-class MasonLightHelpHandler : HelpHandler {
+class MasonModulesHelpHandler : HelpHandler {
   override proc printHelp() {
-    masonLightHelp();
+    masonModulesHelp();
   }
 }
 
@@ -197,7 +197,7 @@ proc masonHelp() {
   writeln('    test        Compile and run tests found in /test');
   writeln('    external    Integrate external dependencies into mason packages');
   writeln('    publish     Publish package to mason-registry');
-  writeln('    light       Interact with a lightweight mason project');
+  writeln('    modules     Print flags for including mason dependencies from TOML file');
 }
 
 proc masonRunHelp() {
@@ -258,9 +258,10 @@ proc masonNewHelp() {
   writeln('    -h, --help                   Display this message');
   writeln('        --show                   Increase verbosity');
   writeln('        --no-vcs                 Do not initialize a git repository');
-  writeln('        --light                  Create a "lightweight" Mason package in current directory');
+  writeln('        --app                    Create a Mason "application" (package with main function)');
+  writeln('        --lib                    Create a Mason "library" (package without main function)');
+  writeln('        --light                  Create a Mason "lightweight" project (place a TOML file in current directory)');
   writeln('    --name <legalName>           Specify package name different from directory name');
-  
 }
 
 proc masonInitHelp(){
@@ -607,15 +608,10 @@ proc masonDocHelp() {
   writeln();
 }
 
-proc masonLightHelp() {
-  writeln("Interact with a lightweight mason project");
+proc masonModulesHelp() {
+  writeln("Print flags to include modules from a toml file");
   writeln();
   writeln('Usage:');
-  writeln('    mason light [options]');
-  writeln();
-  writeln('Options:');
-  writeln("    -h, --help                  Display this message");
-  writeln("        --new                   Create a new mason lightweight project in the current directory");
-  writeln("        --dependent-modules     Print the include paths to the dependent modules to be integrated into build step");
+  writeln('    mason modules');
   writeln();
 }

--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -321,7 +321,8 @@ proc validateMasonFile(path: string, name: string, show: bool) throws {
     checkVersion(version);
   }
   else {
-    makeBasicToml(name, path, "0.1.0", getChapelVersionStr(), "None");
+    // TODO: update package to be either lib or whatever, not hardcode
+    makeBasicToml(name, path, "0.1.0", getChapelVersionStr(), "None", "package");
     if show then writeln("Created Mason.toml file.");
   }
 }

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -58,14 +58,22 @@ proc masonModules(args: [] string) throws {
   var lockFile = parseToml(toParse);
 
   // generate list of dependencies and get src code
-  var sourceList = genSourceList(lockFile);
+  var (sourceList, gitList) = genSourceList(lockFile);
   getSrcCode(sourceList, false);
+  getGitCode(gitList, false);
 
   const depPath = MASON_HOME + '/src/';
+  const gitDepPath = MASON_HOME + '/git/';
   var modules: string;
   for (_, name, version) in sourceList {
-    var depM = ' -M' + depPath + name + "-" + version + '/src/';
+    var depM = ' ' + depPath + name + "-" + version + '/src/';
     modules += depM;
   }
+
+  for (_, name, branch) in gitList {
+    var gitDepSrc = ' ' + gitDepPath + name + "-" + branch + '/src/' + name + ".chpl";
+    modules += gitDepSrc;
+  }
+  
   writeln(modules);
 }

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+use ArgumentParser;
+use FileSystem;
+use List;
+use Map;
+use MasonUtils;
+use MasonHelp;
+use MasonEnv;
+use MasonBuild;
+use Subprocess;
+use TOML;
+
+proc masonModules(args: [] string) throws {
+
+  var parser = new argumentParser(helpHandler=new MasonLightHelpHandler());
+
+  var updateFlag = parser.addFlag(name="update", flagInversion=true);
+
+  var passArgs = parser.addPassThrough();
+
+  parser.parseArgs(args);
+
+  var skipUpdate = MASON_OFFLINE;
+
+  if updateFlag.hasValue() {
+    skipUpdate = !updateFlag.valueAsBool();
+  }
+
+  if isDir(MASON_HOME) == false {
+    mkdir(MASON_HOME, parents=true);
+  }
+  const configNames = updateLock(skipUpdate, show=false);
+  const tomlName = configNames[0];
+  const lockName = configNames[1];
+
+  const cwd = here.cwd();
+  const toParse = open(cwd + "/" + lockName, iomode.r);
+  var lockFile = parseToml(toParse);
+
+  // generate list of dependencies and get src code
+  var sourceList = genSourceList(lockFile);
+  getSrcCode(sourceList, false);
+
+  const depPath = MASON_HOME + '/src/';
+  var modules: string;
+  for (_, name, version) in sourceList {
+    var depM = ' -M' + depPath + name + "-" + version + '/src/';
+    modules += depM;
+  }
+  writeln(modules);
+}

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -32,7 +32,7 @@ use TOML;
 
 proc masonModules(args: [] string) throws {
 
-  var parser = new argumentParser(helpHandler=new MasonLightHelpHandler());
+  var parser = new argumentParser(helpHandler=new MasonModulesHelpHandler());
 
   var updateFlag = parser.addFlag(name="update", flagInversion=true);
 

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -74,6 +74,6 @@ proc masonModules(args: [] string) throws {
     var gitDepSrc = ' ' + gitDepPath + name + "-" + branch + '/src/' + name + ".chpl";
     modules += gitDepSrc;
   }
-  
+
   writeln(modules);
 }

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -30,6 +30,14 @@ use MasonBuild;
 use Subprocess;
 use TOML;
 
+// A call to `mason modules` will print to screen the flags that are
+// required to include the mason packages specified in the TOML file
+// of a mason project.
+// For example, if a mason project had two dependencies, the result
+// would be a string of the paths to the modules that need to be added
+// to a command line `chpl` call to use those modules. This can allow
+// users to get compilation flags from mason without having to use
+// `mason build` in their project.
 proc masonModules(args: [] string) throws {
 
   var parser = new argumentParser(helpHandler=new MasonModulesHelpHandler());

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -66,7 +66,7 @@ proc masonModules(args: [] string) throws {
   const gitDepPath = MASON_HOME + '/git/';
   var modules: string;
   for (_, name, version) in sourceList {
-    var depM = ' ' + depPath + name + "-" + version + '/src/';
+    var depM = ' ' + depPath + name + "-" + version + '/src/' + name + ".chpl";;
     modules += depM;
   }
 

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -282,7 +282,7 @@ proc InitProject(dirName, packageName, vcs, show,
     // TODO: add ability to get path and toml name from user
     var lightDir = here.cwd();
     makeBasicToml(dirName=packageName, path=lightDir, version, chplVersion, license, packageType);
-    writeln("Created new " + packageType + " project: " + lightDir);
+    writeln("Created new " + packageType + " project in current directory");
   } else {
     if vcs {
       gitInit(dirName, show);

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -59,13 +59,16 @@ proc masonNew(args: [] string) throws {
   var isLibrary = libFlag.valueAsBool();
   var isLightweight = lightFlag.valueAsBool();
 
+  if isApplication + isLibrary + isLightweight > 1 then
+    throw new owned MasonError("A mason package cannot be of multiple types");
+
   var packageName = '';
   var dirName = '';
   var version = '';
   var chplVersion = '';
   var license = 'None';
   // Default created mason project is a package (has a main func)
-  var packageType = 'app';
+  var packageType = 'application';
 
   try! {
     if args.size == 1 {

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -58,7 +58,7 @@ proc masonNew(args: [] string) throws {
   var isApplication = appFlag.valueAsBool();
   var isLibrary = libFlag.valueAsBool();
   var isLightweight = lightFlag.valueAsBool();
-  
+
   var packageName = '';
   var dirName = '';
   var version = '';
@@ -83,7 +83,7 @@ proc masonNew(args: [] string) throws {
       } else {
         packageName = dirName;
       }
-      if isApp then
+      if isApplication then
         packageType = "application";
       else if isLibrary then
         packageType = "library";
@@ -276,7 +276,7 @@ proc InitProject(dirName, packageName, vcs, show,
                  version: string, chplVersion: string, license: string,
                  packageType: string) throws {
   if packageType == "light" {
-    // TODO: add ability to get path and toml name from user 
+    // TODO: add ability to get path and toml name from user
     var lightDir = here.cwd();
     makeBasicToml(dirName=packageName, path=lightDir, version, chplVersion, license, packageType);
     writeln("Created new " + packageType + " project: " + lightDir);

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -46,20 +46,30 @@ proc masonNew(args: [] string) throws {
                                  opts=["--name"]);
 
   var showFlag = parser.addFlag(name="show", defaultValue=false);
+  var packageFlag = parser.addFlag(name="package", defaultValue=false);
+  var libFlag = parser.addFlag(name="lib", defaultValue=false);
+  var lightFlag = parser.addFlag(name="light", defaultValue=false);
   var dirArg = parser.addArgument(name="directory", numArgs=0..1);
 
   parser.parseArgs(args);
 
   var vcs = !vcsFlag.valueAsBool();
   var show = showFlag.valueAsBool();
+  var isPackage = packageFlag.valueAsBool();
+  var isLibrary = libFlag.valueAsBool();
+  var isLightweight = lightFlag.valueAsBool();
+  
   var packageName = '';
   var dirName = '';
   var version = '';
   var chplVersion = '';
   var license = 'None';
+  // Default created mason project is a package (has a main func)
+  var packageType = 'package';
 
   try! {
     if args.size == 1 {
+      // TODO: should we move interactive mason creation?
       var metadata = beginInteractiveSession('','','','');
       packageName = metadata[0];
       dirName = packageName;
@@ -73,13 +83,19 @@ proc masonNew(args: [] string) throws {
       } else {
         packageName = dirName;
       }
+      if isPackage then
+        packageType = "package";
+      else if isLibrary then
+        packageType = "library";
+      else if isLightweight then
+        packageType = "light";
     }
-    if validatePackageName(dirName=packageName) {
+    if !isLightweight && validatePackageName(dirName=packageName) {
       if isDir(dirName) {
         throw new owned MasonError("A directory named '" + dirName + "' already exists");
       }
-      InitProject(dirName, packageName, vcs, show, version, chplVersion, license);
     }
+    InitProject(dirName, packageName, vcs, show, version, chplVersion, license, packageType);
   }
   catch e: MasonError {
     writeln(e.message());
@@ -212,7 +228,8 @@ proc exitOnEOF(parameter) {
 
 /* Previews the Mason.toml file that is going to be created */
 proc previewMasonFile(packageName, version, chapelVersion, license) {
-  const baseToml = getBaseTomlString(packageName, version, chapelVersion, license);
+  // TODO: update hardcode
+  const baseToml = getBaseTomlString(packageName, version, chapelVersion, license, "package");
   writeln();
   writeln(baseToml);
 }
@@ -256,25 +273,33 @@ proc validatePackageName(dirName) throws {
   directories such as .git, src, example, test
 */
 proc InitProject(dirName, packageName, vcs, show,
-                  version: string, chplVersion: string, license: string) throws {
-  if vcs {
-    gitInit(dirName, show);
-    addGitIgnore(dirName);
-  }
-  else {
-    mkdir(dirName);
-  }
-  // Confirm git init before creating files
-  if isDir(dirName) {
-    makeBasicToml(dirName=packageName, path=dirName, version, chplVersion, license);
-    makeSrcDir(dirName);
-    makeModule(dirName, fileName=packageName);
-    makeTestDir(dirName);
-    makeExampleDir(dirName);
-    writeln("Created new library project: " + dirName);
-  }
-  else {
-    throw new owned MasonError("Failed to create project");
+                 version: string, chplVersion: string, license: string,
+                 packageType: string) throws {
+  if packageType == "light" {
+    // TODO: add ability to get path and toml name from user 
+    var lightDir = here.cwd();
+    makeBasicToml(dirName=packageName, path=lightDir, version, chplVersion, license, packageType);
+    writeln("Created new " + packageType + " project: " + lightDir);
+  } else {
+    if vcs {
+      gitInit(dirName, show);
+      addGitIgnore(dirName);
+    }
+    else {
+      mkdir(dirName);
+    }
+    // Confirm git init before creating files
+    if isDir(dirName) {
+      makeBasicToml(dirName=packageName, path=dirName, version, chplVersion, license, packageType);
+      makeSrcDir(dirName);
+      makeModule(dirName, fileName=packageName, packageType);
+      makeTestDir(dirName);
+      makeExampleDir(dirName);
+      writeln("Created new " + packageType + " project: " + dirName);
+    }
+    else {
+      throw new owned MasonError("Failed to create project");
+    }
   }
 }
 
@@ -294,22 +319,24 @@ proc addGitIgnore(dirName: string) {
   GIwriter.close();
 }
 
-proc getBaseTomlString(packageName: string, version: string, chapelVersion: string, license: string) {
+proc getBaseTomlString(packageName: string, version: string, chapelVersion: string,
+                       license: string, packageType: string) {
   const baseToml = """[brick]
 name="%s"
 version="%s"
 chplVersion="%s"
 license="%s"
+type="%s"
 
 [dependencies]
 
-""".format(packageName, version, chapelVersion, license);
+""".format(packageName, version, chapelVersion, license, packageType);
   return baseToml;
 }
 
 /* Creates the Mason.toml file */
 proc makeBasicToml(dirName: string, path: string, version: string,
-            chplVersion: string, license: string) {
+            chplVersion: string, license: string, packageType: string) {
   var defaultVersion: string = "0.1.0";
   var defaultChplVersion: string = getChapelVersionStr();
   var defaultLicense: string = "None";
@@ -319,7 +346,8 @@ proc makeBasicToml(dirName: string, path: string, version: string,
     then defaultChplVersion = chplVersion;
   if !license.isEmpty()
     then defaultLicense = license;
-  const baseToml = getBaseTomlString(dirName, defaultVersion, defaultChplVersion, defaultLicense);
+  const baseToml = getBaseTomlString(dirName, defaultVersion, defaultChplVersion,
+                                     defaultLicense, packageType);
   var tomlFile = open(path+"/Mason.toml", iomode.cw);
   var tomlWriter = tomlFile.writer();
   tomlWriter.write(baseToml);
@@ -332,9 +360,15 @@ proc makeSrcDir(path:string) {
 }
 
 /* Makes module file inside src/ */
-proc makeModule(path:string, fileName:string) {
-  const libTemplate = '/* Documentation for ' + fileName +
-  ' */\nmodule '+ fileName + ' {\n  writeln("New library: '+ fileName +'");\n}';
+proc makeModule(path:string, fileName:string, packageType="package") {
+  var libTemplate: string;
+  if packageType == "package" {
+    libTemplate = '/* Documentation for ' + fileName +
+      ' */\nmodule '+ fileName + ' {\n  proc main() {\n    writeln("New mason package: '+ fileName +'");\n  }\n}';
+  } else if packageType == "library" {
+    libTemplate = '/* Documentation for ' + fileName +
+      ' */\nmodule '+ fileName + ' {\n  // Your library here\n}';
+  }
   var lib = open(path+'/src/'+fileName+'.chpl', iomode.cw);
   var libWriter = lib.writer();
   libWriter.write(libTemplate + '\n');

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -46,7 +46,7 @@ proc masonNew(args: [] string) throws {
                                  opts=["--name"]);
 
   var showFlag = parser.addFlag(name="show", defaultValue=false);
-  var packageFlag = parser.addFlag(name="package", defaultValue=false);
+  var appFlag = parser.addFlag(name="app", defaultValue=false);
   var libFlag = parser.addFlag(name="lib", defaultValue=false);
   var lightFlag = parser.addFlag(name="light", defaultValue=false);
   var dirArg = parser.addArgument(name="directory", numArgs=0..1);
@@ -55,7 +55,7 @@ proc masonNew(args: [] string) throws {
 
   var vcs = !vcsFlag.valueAsBool();
   var show = showFlag.valueAsBool();
-  var isPackage = packageFlag.valueAsBool();
+  var isApplication = appFlag.valueAsBool();
   var isLibrary = libFlag.valueAsBool();
   var isLightweight = lightFlag.valueAsBool();
   
@@ -65,7 +65,7 @@ proc masonNew(args: [] string) throws {
   var chplVersion = '';
   var license = 'None';
   // Default created mason project is a package (has a main func)
-  var packageType = 'package';
+  var packageType = 'app';
 
   try! {
     if args.size == 1 {
@@ -83,8 +83,8 @@ proc masonNew(args: [] string) throws {
       } else {
         packageName = dirName;
       }
-      if isPackage then
-        packageType = "package";
+      if isApp then
+        packageType = "application";
       else if isLibrary then
         packageType = "library";
       else if isLightweight then
@@ -229,7 +229,7 @@ proc exitOnEOF(parameter) {
 /* Previews the Mason.toml file that is going to be created */
 proc previewMasonFile(packageName, version, chapelVersion, license) {
   // TODO: update hardcode
-  const baseToml = getBaseTomlString(packageName, version, chapelVersion, license, "package");
+  const baseToml = getBaseTomlString(packageName, version, chapelVersion, license, "application");
   writeln();
   writeln(baseToml);
 }
@@ -362,7 +362,7 @@ proc makeSrcDir(path:string) {
 /* Makes module file inside src/ */
 proc makeModule(path:string, fileName:string, packageType="package") {
   var libTemplate: string;
-  if packageType == "package" {
+  if packageType == "application" {
     libTemplate = '/* Documentation for ' + fileName +
       ' */\nmodule '+ fileName + ' {\n  proc main() {\n    writeln("New mason package: '+ fileName +'");\n  }\n}';
   } else if packageType == "library" {

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -30,10 +30,6 @@ use TOML;
 
 proc masonRun(args: [] string) throws {
 
-  const projectType = getProjectType();
-  if projectType != "application" then
-      throw new owned MasonError("Only mason packages can be run, but this is a Mason " + projectType);
-
   var parser = new argumentParser(helpHandler=new MasonRunHelpHandler());
 
   var showFlag = parser.addFlag(name="show", defaultValue=false);
@@ -50,6 +46,10 @@ proc masonRun(args: [] string) throws {
   var passArgs = parser.addPassThrough();
 
   parser.parseArgs(args);
+
+  const projectType = getProjectType();
+  if projectType != "application" then
+    throw new owned MasonError("Only mason packages can be run, but this is a Mason " + projectType);
 
   var show = showFlag.valueAsBool();
   var release = releaseFlag.valueAsBool();

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -31,7 +31,7 @@ use TOML;
 proc masonRun(args: [] string) throws {
 
   const projectType = getProjectType();
-  if projectType != "package" then
+  if projectType != "application" then
       throw new owned MasonError("Only mason packages can be run, but this is a Mason " + projectType);
 
   var parser = new argumentParser(helpHandler=new MasonRunHelpHandler());

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -28,7 +28,7 @@ use MasonUtils;
 use TOML;
 
 
-proc masonRun(args: [] string) throws {
+proc masonRun(args: [] string, checkProj=true) throws {
 
   var parser = new argumentParser(helpHandler=new MasonRunHelpHandler());
 
@@ -47,9 +47,11 @@ proc masonRun(args: [] string) throws {
 
   parser.parseArgs(args);
 
-  const projectType = getProjectType();
-  if projectType != "application" then
-    throw new owned MasonError("Only mason packages can be run, but this is a Mason " + projectType);
+  if checkProj {
+    const projectType = getProjectType();
+    if projectType != "application" then
+      throw new owned MasonError("Only mason packages can be run, but this is a Mason " + projectType);
+  }
 
   var show = showFlag.valueAsBool();
   var release = releaseFlag.valueAsBool();
@@ -63,7 +65,7 @@ proc masonRun(args: [] string) throws {
     exit(0);
   } else if exampleOpts._present || buildFlag.valueAsBool() {
     // --example with value or build flag
-    masonBuildRun(args);
+    masonBuildRun(args, checkProj);
     exit(0);
   }
   runProjectBinary(show, release, execopts);
@@ -133,7 +135,7 @@ proc runProjectBinary(show: bool, release: bool, execopts: list(string)) throws 
 
 
 /* Builds program before running. */
-private proc masonBuildRun(args: [?d] string) {
+private proc masonBuildRun(args: [?d] string, checkProj=true) {
 
   var parser = new argumentParser(helpHandler=new MasonRunHelpHandler());
 
@@ -182,7 +184,7 @@ private proc masonBuildRun(args: [?d] string) {
       if release then execopts.append("--release");
       if force then execopts.append("--force");
       if show then execopts.append("--show");
-      masonExample(execopts.toArray());
+      masonExample(execopts.toArray(), checkProj);
     }
     else {
       var buildArgs: list(string);
@@ -192,7 +194,7 @@ private proc masonBuildRun(args: [?d] string) {
       if release then buildArgs.append("--release");
       if force then buildArgs.append("--force");
       if show then buildArgs.append("--show");
-      masonBuild(buildArgs.toArray());
+      masonBuild(buildArgs.toArray(), checkProj);
       for val in passArgs.values() do execopts.append(val);
       runProjectBinary(show, release, execopts);
     }

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -30,6 +30,10 @@ use TOML;
 
 proc masonRun(args: [] string) throws {
 
+  const projectType = getProjectType();
+  if projectType != "package" then
+      throw new owned MasonError("Only mason packages can be run, but this is a Mason " + projectType);
+
   var parser = new argumentParser(helpHandler=new MasonRunHelpHandler());
 
   var showFlag = parser.addFlag(name="show", defaultValue=false);

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -52,7 +52,7 @@ proc masonTest(args: [] string) throws {
   const projectType = getProjectType();
   if projectType == "light" then
       throw new owned MasonError("Mason light projects do not currently support 'mason test'");
-  
+
   var parser = new argumentParser(helpHandler=new MasonTestHelpHandler());
 
   var runFlag = parser.addFlag(name="run",

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -49,10 +49,6 @@ var files: list(string);
 */
 proc masonTest(args: [] string) throws {
 
-  const projectType = getProjectType();
-  if projectType == "light" then
-      throw new owned MasonError("Mason light projects do not currently support 'mason test'");
-
   var parser = new argumentParser(helpHandler=new MasonTestHelpHandler());
 
   var runFlag = parser.addFlag(name="run",
@@ -71,6 +67,10 @@ proc masonTest(args: [] string) throws {
   var otherArgs = parser.addArgument(name="others", numArgs=0..);
 
   parser.parseArgs(args);
+
+  const projectType = getProjectType();
+  if projectType == "light" then
+    throw new owned MasonError("Mason light projects do not currently support 'mason test'");
 
   var skipUpdate = MASON_OFFLINE;
   var show = showFlag.valueAsBool();

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -49,6 +49,10 @@ var files: list(string);
 */
 proc masonTest(args: [] string) throws {
 
+  const projectType = getProjectType();
+  if projectType == "light" then
+      throw new owned MasonError("Mason light projects do not currently support 'mason test'");
+  
   var parser = new argumentParser(helpHandler=new MasonTestHelpHandler());
 
   var runFlag = parser.addFlag(name="run",

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -47,7 +47,7 @@ var files: list(string);
 /* Runs the .chpl files found within the /tests directory of Mason packages
    or files which in the path provided.
 */
-proc masonTest(args: [] string) throws {
+proc masonTest(args: [] string, checkProj=true) throws {
 
   var parser = new argumentParser(helpHandler=new MasonTestHelpHandler());
 
@@ -68,9 +68,11 @@ proc masonTest(args: [] string) throws {
 
   parser.parseArgs(args);
 
-  const projectType = getProjectType();
-  if projectType == "light" then
-    throw new owned MasonError("Mason light projects do not currently support 'mason test'");
+  if checkProj {
+    const projectType = getProjectType();
+    if projectType == "light" then
+      throw new owned MasonError("Mason light projects do not currently support 'mason test'");
+  }
 
   var skipUpdate = MASON_OFFLINE;
   var show = showFlag.valueAsBool();

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -67,7 +67,7 @@ proc masonUpdate(args: [?d] string) {
 
 /* Finds a Mason.toml file and updates the Mason.lock
    generating one if it doesnt exist */
-proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock") {
+proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock", show=true) {
 
   try! {
     const cwd = here.cwd();
@@ -80,11 +80,11 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock") {
     if isFile(tomlPath) {
       if TomlFile.pathExists('dependencies') {
         if TomlFile['dependencies']!.A.size > 0 {
-          updateRegistry(skipUpdate);
+          updateRegistry(skipUpdate, show);
           updated = true;
         }
       }
-      if !updated {
+      if !updated && show {
         writeln("Skipping registry update since no dependency found in manifest file.");
       }
     }
@@ -155,7 +155,7 @@ proc checkRegistryChanged() {
 }
 
 /* Pulls the mason-registry. Cloning if !exist */
-proc updateRegistry(skipUpdate: bool) {
+proc updateRegistry(skipUpdate: bool, show=true) {
   if skipUpdate then return;
 
   checkRegistryChanged();
@@ -163,7 +163,7 @@ proc updateRegistry(skipUpdate: bool) {
 
     if isDir(registryHome) {
       var pullRegistry = 'git pull -q origin master';
-      writeln("Updating ", name);
+      if show then writeln("Updating ", name);
       gitC(registryHome, pullRegistry);
     }
     // Registry has moved or does not exist
@@ -172,7 +172,7 @@ proc updateRegistry(skipUpdate: bool) {
       const localRegistry = registryHome;
       mkdir(localRegistry, parents=true);
       const cloneRegistry = 'git clone -q ' + registry + ' .';
-      writeln("Updating ", name);
+      if show then writeln("Updating ", name);
       gitC(localRegistry, cloneRegistry);
     }
   }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -480,6 +480,7 @@ proc isIdentifier(name:string) {
   return ok;
 }
 
+
 proc getMasonDependencies(sourceList: list(3*string),
                           gitList: list(3*string),
                           progName: string) {
@@ -506,6 +507,15 @@ proc getMasonDependencies(sourceList: list(3*string),
     }
   }
   return masonCompopts;
+}
+
+
+proc getProjectType(): string {
+  const cwd = here.cwd();
+  const projectHome = getProjectHome(cwd);
+  const toParse = open(projectHome + "/Mason.toml", iomode.r);
+  const tomlFile = parseToml(toParse);
+  return tomlFile["brick"]!["type"]!.s;
 }
 
 

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -41,6 +41,7 @@ use MasonSystem;
 use MasonTest;
 use MasonUpdate;
 use MasonUtils;
+use MasonModules;
 use List;
 /*
 
@@ -83,7 +84,7 @@ proc main(args: [] string) throws {
   // define all the supported subcommand strings here
   var cmds = ["add","build","clean","doc","env","external","init","publish",
               "new","rm","run","search","system","test","update",
-              "help","version"];
+              "help","version","modules"];
   for cmd in cmds {
     subCmds.add(cmd,parser.addSubCommand(cmd));
   }
@@ -129,6 +130,7 @@ proc main(args: [] string) throws {
       when "system" do masonSystem(cmdArgs);
       when "test" do masonTest(cmdArgs);
       when "update" do masonUpdate(cmdArgs);
+      when "modules" do masonModules(cmdArgs);
       when "version" do printVersion();
       otherwise {
         throw new owned MasonError("No such subcommand '%s'\ntry mason --help"


### PR DESCRIPTION
This PR adds a conception of 3 distinct mason "modes":
(1) a mason "package" - intended to run as a standalone
    program, has a main function, fully featured
(2) a mason "library" - intended to be `use`d in other
    user code, does not have a main function, can't be
    run standalone
(3) a mason "light" project - just creates a toml file
    that can track dependencies and generate the flags
    to use those dependencies in any `chpl` command

Also, a new command `mason modules` is added that will
return a string of the include flags that would be added
onto a `chpl` command to use the dependencies specified
in a `Mason.toml` file that enables a little bit more
flexibility into building programs that use mason deps.

Docs are not included in this PR as there isn't a natural
fit for this in the existing mason docs, but the docs will
be undergoing an overhaul in the near future and will be
added then (see https://github.com/Cray/chapel-private/issues/3599).

Closes: https://github.com/Cray/chapel-private/issues/3365