### PR TITLE
Ensure the declared type of a formal is, indeed, a type

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2371,6 +2371,7 @@ void AggregateType::fieldToArg(FnSymbol*              fn,
           arg->defaultExpr = new BlockStmt(defPoint->init->copy());
 
           // mimic normalize's hack_resolve_types
+          arg->typeExprFromDefaultExpr = true;
           arg->typeExpr = arg->defaultExpr->copy();
 
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -733,6 +733,7 @@ ArgSymbol::ArgSymbol(IntentTag iIntent, const char* iName,
   LcnSymbol(E_ArgSymbol, iName, iType),
   intent(iIntent),
   originalIntent(iIntent),
+  typeExprFromDefaultExpr(false),
   typeExpr(NULL),
   defaultExpr(NULL),
   variableExpr(NULL),
@@ -807,6 +808,7 @@ ArgSymbol::copyInner(SymbolMap* map) {
   ArgSymbol *ps = new ArgSymbol(intent, name, type, COPY_INT(typeExpr),
                                 COPY_INT(defaultExpr), COPY_INT(variableExpr));
   ps->copyFlags(this);
+  ps->typeExprFromDefaultExpr = typeExprFromDefaultExpr;
   ps->cname = cname;
   ps->instantiatedFrom = instantiatedFrom;
   ps->originalIntent = this->originalIntent;

--- a/compiler/include/AstToText.h
+++ b/compiler/include/AstToText.h
@@ -116,8 +116,6 @@ private:
   void                   appendFormalName(ArgSymbol* arg);
 
   void                   appendFormalType(ArgSymbol* arg);
-  bool                   typeExprCopiedFromDefaultExpr(ArgSymbol* arg) const;
-  bool                   exprTypeHackEqual(Expr* expr0, Expr* expr1)   const;
   bool                   handleNormalizedTypeOf(BlockStmt* bs);
 
   void                   appendFormalVariableExpr(ArgSymbol* arg);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -413,6 +413,7 @@ public:
 
   IntentTag       intent;
   IntentTag       originalIntent; // stores orig intent after resolve intents
+  bool            typeExprFromDefaultExpr;
   BlockStmt*      typeExpr;    // Type expr for arg type, or NULL.
   BlockStmt*      defaultExpr;
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -3289,8 +3289,8 @@ static void hack_resolve_types(ArgSymbol* arg) {
           se = toSymExpr(arg->defaultExpr->body.tail);
         if (!se || se->symbol() != gTypeDefaultToken) {
           SET_LINENO(arg->defaultExpr);
-          // MPF: this seems wrong since the result is a value not
-          // a type.
+          // white lie: `typeExpr` should be a type, not a value
+          arg->typeExprFromDefaultExpr = true;
           arg->typeExpr = arg->defaultExpr->copy();
           insert_help(arg->typeExpr, NULL, arg);
         }

--- a/test/functions/compilation-errors/value-for-arg-type.chpl
+++ b/test/functions/compilation-errors/value-for-arg-type.chpl
@@ -1,0 +1,13 @@
+
+var myVar: int;
+proc p1(arg: myVar) { }
+p1(5);
+
+proc p2(arg: 1+2) { }
+p2(6);
+
+proc p3(arg: Locales.size) { }
+p3(7);
+
+proc p4(arg: here.numPUs()) { }
+p4(8);

--- a/test/functions/compilation-errors/value-for-arg-type.good
+++ b/test/functions/compilation-errors/value-for-arg-type.good
@@ -1,0 +1,8 @@
+value-for-arg-type.chpl:3: In function 'p1':
+value-for-arg-type.chpl:3: error: The declared type of the formal arg is non-type 'myVar'
+value-for-arg-type.chpl:6: In function 'p2':
+value-for-arg-type.chpl:6: error: The declared type of the formal arg is non-type '3'
+value-for-arg-type.chpl:9: In function 'p3':
+value-for-arg-type.chpl:9: error: The declared type of the formal arg is given by non-type function 'size'
+value-for-arg-type.chpl:12: In function 'p4':
+value-for-arg-type.chpl:12: error: The declared type of the formal arg is given by non-type function 'numPUs'

--- a/test/functions/default-arguments/runtime-type-1.bad
+++ b/test/functions/default-arguments/runtime-type-1.bad
@@ -1,0 +1,6 @@
+in fn()
+in DA()
+in DA()
+runtime-type-1.chpl:22: error: halt reached - Domain mismatch passing array argument:
+  Formal domain is: {1..7}
+  Actual domain is: {1..6}

--- a/test/functions/default-arguments/runtime-type-1.chpl
+++ b/test/functions/default-arguments/runtime-type-1.chpl
@@ -1,0 +1,27 @@
+// Given a formal argument with a default value that is calculated
+// using by calling a function and has a runtime type,
+// here fn() returning an array,
+// in what cases should the function be invoked?
+
+proc fn(size) {
+  writeln("in fn()");
+  var A: [1..size] int;
+  return A;
+}
+
+proc DA(arg = fn(5)) {
+  writeln("in DA()");
+}
+
+DA();  // fn() is invoked just once
+
+var B: [1..6] int;
+
+DA(B); // fn() is not invoked; should it be?
+
+proc nonD(arg: [1..7] int) {
+  writeln("in nonD()");
+}
+nonD(B); // halt "Domain mismatch passing array argument"
+
+writeln("done");

--- a/test/functions/default-arguments/runtime-type-1.future
+++ b/test/functions/default-arguments/runtime-type-1.future
@@ -1,0 +1,18 @@
+design: the runtime type of a defaulted formal - should it matter?
+
+Given an argument with a default value that's an array,
+should the actual argument, when present, be bounds-checked against
+the domain of that default value?
+
+In other words, whereas the actual-argument array is bounds-checked
+when calling this function:
+
+    proc nonD(arg: [1..7] int) {}
+
+should the actual-argument array also be bounds-checked when calling:
+
+    proc DA(arg = fn()) {}
+    // where
+    proc fn() { var A: [1..7] int; return A; }
+
+Currently this latter check is not done.

--- a/test/functions/default-arguments/runtime-type-1.good
+++ b/test/functions/default-arguments/runtime-type-1.good
@@ -1,0 +1,5 @@
+in fn()
+in DA()
+runtime-type-1.chpl:12: error: halt reached - Domain mismatch passing array argument:
+  Formal domain is: {1..5}
+  Actual domain is: {1..6}

--- a/test/functions/default-arguments/runtime-type-2.bad
+++ b/test/functions/default-arguments/runtime-type-2.bad
@@ -1,0 +1,2 @@
+in nonD()
+done

--- a/test/functions/default-arguments/runtime-type-2.chpl
+++ b/test/functions/default-arguments/runtime-type-2.chpl
@@ -1,0 +1,19 @@
+// Given a formal argument whose type is via calling a function
+// returning an array value, should this array's bounds be checked
+// against the actual argument?
+
+proc fn(size) {
+  writeln("in fn()");
+  var A: [1..size] int;
+  return A;
+}
+
+proc nonD(arg: fn(7).type) {
+  writeln("in nonD()");
+}
+
+var B: [1..6] int;
+
+nonD(B); // should this halt with "Domain mismatch passing array argument" ?
+
+writeln("done");

--- a/test/functions/default-arguments/runtime-type-2.future
+++ b/test/functions/default-arguments/runtime-type-2.future
@@ -1,0 +1,18 @@
+design: the runtime type of a formal declared using `.type` - should it matter?
+
+Given a formal argument whose type is via calling a function
+returning an array value, should this array's bounds be checked
+against the actual argument?
+
+In other words, whereas the actual-argument array is bounds-checked
+when calling this function:
+
+    proc nonD_1(arg: [1..7] int) {}
+
+should the actual-argument array also be bounds-checked when calling:
+
+    proc nonD_2(arg: fn(7).type) {}
+    // where
+    proc fn() { var A: [1..7] int; return A; }
+
+Currently this latter check is not done.

--- a/test/functions/default-arguments/runtime-type-2.good
+++ b/test/functions/default-arguments/runtime-type-2.good
@@ -1,0 +1,3 @@
+runtime-type-2.chpl:11: error: halt reached - Domain mismatch passing array argument:
+  Formal domain is: {1..7}
+  Actual domain is: {1..6}


### PR DESCRIPTION
This extends the checking introduced in #20262 to all formals.

After [making a big deal out of it](https://github.com/chapel-lang/chapel/pull/20262#issuecomment-1190259631), I realized that maybe it is actually simple? Maybe indeed all we need is to add a field `bool typeExprFromDefaultExpr` to `ArgSymbol`?

Turned out that it was not so simple after all. On the upside, I was able to remove some heuristic code, replacing it with a (non-heuristic) check for `typeExprFromDefaultExpr`.

It took some work to handle the various ways a user may declare a formal's type, see `checkFormalType()`. I think that this code will still miss some cases ex. when the formal's type is declared using a value-producing primitive. The way it should be done is by flagging the cases where the `qualType()` of the formal's typeExpr is not a QUAL_TYPE. However, our qualType() does not have the QUAL_TYPE option, so we cannot do this at present. Luckily, Dyno gets it right with `QualifiedType::Kind::TYPE` .

While there, add two futures asking about the behavior in some cases where the formal's type is a runtime type, specifically an array. These futures support the cause of #19292, showing another example of where runtime types add complexity, albeit minor in this case, to both the implementation and the language definition.

Testing: standard and -multilocale-only paratests.