### PR TITLE
feat(dyno-chpldoc): integrate calls to sphinx to build HTML docs

### DIFF
--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -78,8 +78,9 @@ std::string getCwd();
 std::error_code currentWorkingDir(std::string& path_out);
 
 /**
- * makes the directory and all intermediate directories in dirpath
- * if they don't exist. Directory permissions are set to llvm::all-all.
+ * makes the directory in dirpath. Will fail if a directory in the path doesn't
+ * already exist.
+ * Directory permissions are set to llvm::all-all.
  * which should be equivalent to  S_IRWXU | S_IRWXG | S_IRWXO
  *
  * dirpath - the path of the directory to create

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -67,14 +67,25 @@ std::error_code deleteDir(std::string dirname);
 
 /*
  * Returns the current working directory. Does not report failures. Use
- * sys_getcwd() if you need error reports.
+ * currentWorkingDir() if you need error reports.
  */
 std::string getCwd();
 
-// This also exists in runtime/src/qio/sys.c
-// returns 0 on success.
-int sys_getcwd(std::string& path_out);
+/*
+ * Gets the current working directory
+ * (uses LLVM sys::fs::current_path internally).
+ */
+std::error_code currentWorkingDir(std::string& path_out);
 
+/**
+ * makes the directory and all intermediate directories in dirpath
+ * if they don't exist. Directory permissions are set to llvm::all-all.
+ * which should be equivalent to  S_IRWXU | S_IRWXG | S_IRWXO
+ *
+ * dirpath - the path of the directory to create
+ * returns - std::error_code
+ */
+std::error_code makeDir(std::string dirpath);
 
 } // end namespace chpl
 

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -65,6 +65,16 @@ std::error_code makeTempDir(std::string dirPrefix, std::string& tmpDirPathOut);
  */
 std::error_code deleteDir(std::string dirname);
 
+/*
+ * Returns the current working directory. Does not report failures. Use
+ * sys_getcwd() if you need error reports.
+ */
+std::string getCwd();
+
+// This also exists in runtime/src/qio/sys.c
+// returns 0 on success.
+int sys_getcwd(std::string& path_out);
+
 
 } // end namespace chpl
 

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -66,12 +66,6 @@ std::error_code makeTempDir(std::string dirPrefix, std::string& tmpDirPathOut);
 std::error_code deleteDir(std::string dirname);
 
 /*
- * Returns the current working directory. Does not report failures. Use
- * currentWorkingDir() if you need error reports.
- */
-std::string getCwd();
-
-/*
  * Gets the current working directory
  * (uses LLVM sys::fs::current_path internally).
  */

--- a/compiler/dyno/lib/util/filesystem.cpp
+++ b/compiler/dyno/lib/util/filesystem.cpp
@@ -208,19 +208,6 @@ std::error_code currentWorkingDir(std::string& path_out) {
   }
 }
 
-/*
- * Returns the current working directory. Does not report failures. Use
- * currentWorkingDir() if you need error reports.
- */
-std::string getCwd() {
-  std::string ret;
-  if (auto err = currentWorkingDir(ret)) {
-    return "";
-  } else {
-    return ret;
-  }
-}
-
 std::error_code makeDir(std::string dirpath) {
   using namespace llvm::sys::fs;
   if (auto err = create_directory(dirpath, true, perms::all_all)) {

--- a/compiler/dyno/lib/util/filesystem.cpp
+++ b/compiler/dyno/lib/util/filesystem.cpp
@@ -223,7 +223,7 @@ std::string getCwd() {
 
 std::error_code makeDir(std::string dirpath) {
   using namespace llvm::sys::fs;
-  if (auto err = create_directories(dirpath, true, perms::all_all)) {
+  if (auto err = create_directory(dirpath, true, perms::all_all)) {
     return err;
   } else {
     return std::error_code();

--- a/compiler/dyno/lib/util/filesystem.cpp
+++ b/compiler/dyno/lib/util/filesystem.cpp
@@ -194,4 +194,65 @@ std::error_code ensureDirExists(std::string dirname) {
   return llvm::sys::fs::create_directories(dirname);
 }
 
+// This also exists in runtime/src/qio/sys.c
+// returns 0 on success.
+int sys_getcwd(std::string& path_out)
+{
+  int sz = 128;
+  char* buf;
+
+  buf = (char*) malloc(sz);
+  if( !buf ) return ENOMEM;
+
+  while( 1 ) {
+    if ( getcwd(buf, sz) != NULL ) {
+      break;
+
+    } else if ( errno == ERANGE ) {
+      // keep looping but with bigger buffer.
+      sz *= 2;
+
+      /*
+       * Realloc may return NULL, in which case we will need to free the memory
+       * initially pointed to by buf.  This is why we store the result of the
+       * call in newP instead of directly into buf.  If a non-NULL value is
+       * returned we update the buf pointer.
+       */
+      void* newP = realloc(buf, sz);
+
+      if (newP != NULL) {
+        buf = static_cast<char*>(newP);
+
+      } else {
+        free(buf);
+        return ENOMEM;
+      }
+
+    } else {
+      // Other error, stop.
+      free(buf);
+      return errno;
+    }
+  }
+
+  path_out = std::string(buf);
+  return 0;
+}
+
+/*
+ * Returns the current working directory. Does not report failures. Use
+ * sys_getcwd() if you need error reports.
+ */
+std::string getCwd() {
+  std::string ret;
+  int rc;
+
+  rc = sys_getcwd(ret);
+  if (rc == 0)
+    return ret;
+  else
+    return "";
+}
+
+
 } // namespace chpl

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1725,6 +1725,7 @@ int main(int argc, char** argv) {
       std::cerr << "error: Failed to create directory: "
                 << docsOutputDir << " due to: "
                 << err.message() << std::endl;
+      return 1;
    }
 
   // The location of intermediate rst files.

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1662,18 +1662,6 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir,
   printf("HTML files are at: %s\n", outputDir.c_str());
 }
 
-/* Create the directory (non-recursively). If an error occurs, exit and report
- * error.
- */
-static void makeDir(const char* dirpath) {
-  static const int dirPerms = S_IRWXU | S_IRWXG | S_IRWXO;
-  int result = mkdir(dirpath, dirPerms);
-  if (result != 0 && errno != 0 && errno != EEXIST) {
-    // USR_FATAL("Failed to create directory: %s due to: %s",
-    //           dirpath, strerror(errno));
-  }
-}
-
 
 int main(int argc, char** argv) {
   Context context;
@@ -1722,8 +1710,17 @@ int main(int argc, char** argv) {
   }
 
   // Make the intermediate dir and output dir.
-   makeDir(docsSphinxDir.c_str());
-   makeDir(docsOutputDir.c_str());
+   if (auto err = makeDir(docsSphinxDir)) {
+      std::cerr << "error: Failed to create directory: "
+                << docsSphinxDir << " due to: "
+                << err.message() << std::endl;
+      return 1;
+   }
+   if (auto err = makeDir(docsOutputDir)) {
+      std::cerr << "error: Failed to create directory: "
+                << docsOutputDir << " due to: "
+                << err.message() << std::endl;
+   }
 
   // The location of intermediate rst files.
   std::string docsRstDir;

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -198,65 +198,7 @@ static int myshell(std::string command,
 
   return status;
 }
-// This also exists in runtime/src/qio/sys.c
-// returns 0 on success.
-static int sys_getcwd(char** path_out)
-{
-  int sz = 128;
-  char* buf;
 
-  buf = (char*) malloc(sz);
-  if( !buf ) return ENOMEM;
-
-  while( 1 ) {
-    if ( getcwd(buf, sz) != NULL ) {
-      break;
-
-    } else if ( errno == ERANGE ) {
-      // keep looping but with bigger buffer.
-      sz *= 2;
-
-      /*
-       * Realloc may return NULL, in which case we will need to free the memory
-       * initially pointed to by buf.  This is why we store the result of the
-       * call in newP instead of directly into buf.  If a non-NULL value is
-       * returned we update the buf pointer.
-       */
-      void* newP = realloc(buf, sz);
-
-      if (newP != NULL) {
-        buf = static_cast<char*>(newP);
-
-      } else {
-        free(buf);
-        return ENOMEM;
-      }
-
-    } else {
-      // Other error, stop.
-      free(buf);
-      return errno;
-    }
-  }
-
-  *path_out = buf;
-  return 0;
-}
-
-/*
- * Returns the current working directory. Does not report failures. Use
- * sys_getcwd() if you need error reports.
- */
-static std::string getCwd() {
-  char* ret = nullptr;;
-  int rc;
-
-  rc = sys_getcwd(&ret);
-  if (rc == 0)
-    return std::string(ret);
-  else
-    return "";
-}
 
 static
 std::string getChplDepsApp() {
@@ -1765,7 +1707,7 @@ int main(int argc, char** argv) {
   if (args.outputDir.length() > 0) {
     docsOutputDir = args.outputDir;
   } else {
-    docsOutputDir = std::string(getCwd()) + "/docs";
+    docsOutputDir = getCwd() + "/docs";
   }
 
   // Root of the sphinx project and generated rst files. If

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -152,6 +152,7 @@ std::string runCommand(std::string& command) {
   FILE* pipe = popen(command.c_str(), "r");
   if (!pipe) {
     // USR_FATAL("running %s", command.c_str());
+    std::cerr << "error: running " << command << std::endl;
   }
 
   // Read output of command into result via buffer
@@ -163,6 +164,8 @@ std::string runCommand(std::string& command) {
 
   if (pclose(pipe)) {
     // USR_FATAL("'%s' did not run successfully", command.c_str());
+    std::cerr << "error: '" << command << "' did not run successfully"
+              << std::endl;
   }
 
   return result;
@@ -191,9 +194,11 @@ static int myshell(std::string command,
 
   if (status == -1) {
     // USR_FATAL("system() fork failed: %s", strerror(errno));
-
+    std::cerr << "error: system() fork failed: " << strerror(errno)
+              << std::endl;
   } else if (status != 0 && ignoreStatus == false) {
     // USR_FATAL("%s", description);
+    std::cerr << "error: " << description << std::endl;
   }
 
   return status;

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -142,6 +142,20 @@ static UniqueString getNodeName(AstNode* node) {
   }
 }
 
+/*
+ * Returns the current working directory. Does not report failures. Use
+ * currentWorkingDir() if you need error reports.
+ */
+static
+std::string getCwd() {
+  std::string ret;
+  if (auto err = currentWorkingDir(ret)) {
+    return "";
+  } else {
+    return ret;
+  }
+}
+
 static
 std::string runCommand(std::string& command) {
   // Run arbitrary command and return result
@@ -1055,8 +1069,7 @@ struct RstResultBuilder {
     return commentShown;
   }
 
-  template<typename T>
-  void showDeprecationMessage(const T* node, bool indentComment=true) {
+  void showDeprecationMessage(const Decl* node, bool indentComment=true) {
     if (auto attrs = node->attributes()) {
       if (attrs->isDeprecated() && !textOnly_) {
         auto comment = previousComment(context_, node->id());

--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -42,6 +42,8 @@
 #include "stringutil.h"
 #include "tmpdirname.h"
 
+#include "chpl/util/filesystem.h"
+
 #include "global-ast-vecs.h"
 
 static int compareNames(const void* v1, const void* v2) {
@@ -257,11 +259,10 @@ void createDocsFileFolders(std::string filename) {
  * error.
  */
 static void makeDir(const char* dirpath) {
-  static const int dirPerms = S_IRWXU | S_IRWXG | S_IRWXO;
-  int result = mkdir(dirpath, dirPerms);
-  if (result != 0 && errno != 0 && errno != EEXIST) {
+  std::string path = std::string(dirpath);
+  if (auto err = chpl::makeDir(path)) {
     USR_FATAL("Failed to create directory: %s due to: %s",
-              dirpath, strerror(errno));
+              dirpath, err.message().c_str());
   }
 }
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -1023,7 +1023,7 @@ char* dirHasFile(const char *dir, const char *file)
 
 /*
  * Returns the current working directory. Does not report failures. Use
- * sys_getcwd() if you need error reports.
+ * chpl::currentWorkingDir if you need error reports.
  */
 const char* getCwd() {
   return astr(chpl::getCwd());
@@ -1068,10 +1068,10 @@ char* findProgramPath(const char *argv0)
   // Is argv0 a relative path?
   if( strchr(argv0, '/') != NULL ) {
     std::string cwd;
-    if( 0 == chpl::sys_getcwd(cwd) ) {
-      real = dirHasFile(astr(cwd), argv0);
-    } else {
+    if(auto err = chpl::currentWorkingDir(cwd)) {
       real = NULL;
+    } else {
+      real = dirHasFile(astr(cwd), argv0);
     }
     return real;
   }

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -1026,7 +1026,12 @@ char* dirHasFile(const char *dir, const char *file)
  * chpl::currentWorkingDir if you need error reports.
  */
 const char* getCwd() {
-  return astr(chpl::getCwd());
+  std::string cwd;
+  if (auto err = chpl::currentWorkingDir(cwd)) {
+    return "";
+  } else {
+    return astr(cwd);
+  }
 }
 
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -1020,65 +1020,13 @@ char* dirHasFile(const char *dir, const char *file)
   return real;
 }
 
-// This also exists in runtime/src/qio/sys.c
-// returns 0 on success.
-static int sys_getcwd(char** path_out)
-{
-  int sz = 128;
-  char* buf;
-
-  buf = (char*) malloc(sz);
-  if( !buf ) return ENOMEM;
-
-  while( 1 ) {
-    if ( getcwd(buf, sz) != NULL ) {
-      break;
-
-    } else if ( errno == ERANGE ) {
-      // keep looping but with bigger buffer.
-      sz *= 2;
-
-      /*
-       * Realloc may return NULL, in which case we will need to free the memory
-       * initially pointed to by buf.  This is why we store the result of the
-       * call in newP instead of directly into buf.  If a non-NULL value is
-       * returned we update the buf pointer.
-       */
-      void* newP = realloc(buf, sz);
-
-      if (newP != NULL) {
-        buf = static_cast<char*>(newP);
-
-      } else {
-        free(buf);
-        return ENOMEM;
-      }
-
-    } else {
-      // Other error, stop.
-      free(buf);
-      return errno;
-    }
-  }
-
-  *path_out = buf;
-  return 0;
-}
-
 
 /*
  * Returns the current working directory. Does not report failures. Use
  * sys_getcwd() if you need error reports.
  */
 const char* getCwd() {
-  char* ret = nullptr;;
-  int rc;
-
-  rc = sys_getcwd(&ret);
-  if (rc == 0)
-    return ret;
-  else
-    return "";
+  return astr(chpl::getCwd());
 }
 
 
@@ -1119,13 +1067,12 @@ char* findProgramPath(const char *argv0)
 
   // Is argv0 a relative path?
   if( strchr(argv0, '/') != NULL ) {
-    char* cwd = NULL;
-    if( 0 == sys_getcwd(&cwd) ) {
-      real = dirHasFile(cwd, argv0);
+    std::string cwd;
+    if( 0 == chpl::sys_getcwd(cwd) ) {
+      real = dirHasFile(astr(cwd), argv0);
     } else {
       real = NULL;
     }
-    free(cwd);
     return real;
   }
 


### PR DESCRIPTION
This PR begins adding support for building HTML docs using the python
package `sphinx` from within `dyno-chpldoc`.

Prior to this work, there were ~23 tests that were failing due to faults 
with `dyno-chpldoc`. This PR fixes 16 of those failures, leaving 7 test 
failures to be fixed in future work.

Much of the supporting functions from `chpldoc` were copied over 
to `dyno-chpldoc` as opposed to adding them to the `dyno` library. 
Future work will refactor these static functions.

TESTING:

- [x] paratest
- [x] use `dyno-chpldoc` for `test/chpldoc` tests (7 fails vs. 23 prior)

Reviewed by @dlongnecke-cray - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>