### PR TITLE
dyno: Use llvm::SmallPtrSet instead of std::set for scope lookup

### DIFF
--- a/compiler/dyno/include/chpl/resolution/scope-queries.h
+++ b/compiler/dyno/include/chpl/resolution/scope-queries.h
@@ -21,10 +21,12 @@
 #define CHPL_RESOLUTION_SCOPE_QUERIES_H
 
 #include "chpl/resolution/scope-types.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 namespace chpl {
 namespace resolution {
 
+  using ScopeSet = llvm::SmallPtrSet<const Scope*, 5>;
 
   /**
     Returns true if this AST type can create a scope.
@@ -88,7 +90,7 @@ namespace resolution {
                            const Scope* receiverScope,
                            UniqueString name,
                            LookupConfig config,
-                           std::unordered_set<const Scope*>& visited);
+                           ScopeSet& visited);
 
   /**
     Returns true if all of checkScope is visible from fromScope

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -2084,7 +2084,7 @@ static std::vector<BorrowedIdsWithName>
 lookupCalledExpr(Context* context,
                  const Scope* scope,
                  const CallInfo& ci,
-                 std::unordered_set<const Scope*>& visited) {
+                 ScopeSet& visited) {
   const LookupConfig config = LOOKUP_DECLS |
                               LOOKUP_IMPORT_AND_USE |
                               LOOKUP_PARENTS;
@@ -2496,7 +2496,7 @@ resolveFnCallFilterAndFindMostSpecific(Context* context,
   // search for candidates at each POI until we have found a candidate
   CandidatesVec candidates;
   size_t firstPoiCandidate = 0;
-  std::unordered_set<const Scope*> visited;
+  ScopeSet visited;
 
   // inject compiler-generated candidates in a manner similar to below
   considerCompilerGeneratedCandidates(context, ci, inScope, inPoiScope,

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -27,6 +27,8 @@
 
 #include "scope-help.h"
 
+#include "llvm/ADT/SmallPtrSet.h"
+
 #include <cstdio>
 #include <set>
 #include <string>
@@ -286,7 +288,7 @@ static bool doLookupInScope(Context* context,
                             const ResolvedVisibilityScope* resolving,
                             UniqueString name,
                             LookupConfig config,
-                            std::unordered_set<const Scope*>& checkedScopes,
+                            ScopeSet& checkedScopes,
                             std::vector<BorrowedIdsWithName>& result);
 
 static const ResolvedVisibilityScope*
@@ -311,7 +313,7 @@ static bool doLookupInImports(Context* context,
                               const ResolvedVisibilityScope* resolving,
                               UniqueString name,
                               bool onlyInnermost,
-                              std::unordered_set<const Scope*>& checkedScopes,
+                              ScopeSet& checkedScopes,
                               std::vector<BorrowedIdsWithName>& result) {
   // Get the resolved visibility statements, if available
   const ResolvedVisibilityScope* r = nullptr;
@@ -390,7 +392,7 @@ static bool doLookupInScope(Context* context,
                             const ResolvedVisibilityScope* resolving,
                             UniqueString name,
                             LookupConfig config,
-                            std::unordered_set<const Scope*>& checkedScopes,
+                            ScopeSet& checkedScopes,
                             std::vector<BorrowedIdsWithName>& result) {
 
   bool checkDecls = (config & LOOKUP_DECLS) != 0;
@@ -486,7 +488,7 @@ static bool lookupInScopeViz(Context* context,
                              VisibilityStmtKind useOrImport,
                              bool isFirstPart,
                              std::vector<BorrowedIdsWithName>& result) {
-  std::unordered_set<const Scope*> checkedScopes;
+  ScopeSet checkedScopes;
 
   LookupConfig config = LOOKUP_INNERMOST;
 
@@ -531,7 +533,7 @@ std::vector<BorrowedIdsWithName> lookupNameInScope(Context* context,
                                                    const Scope* receiverScope,
                                                    UniqueString name,
                                                    LookupConfig config) {
-  std::unordered_set<const Scope*> checkedScopes;
+  ScopeSet checkedScopes;
 
   return lookupNameInScopeWithSet(context, scope, receiverScope, name,
                                   config, checkedScopes);
@@ -543,7 +545,7 @@ lookupNameInScopeWithSet(Context* context,
                          const Scope* receiverScope,
                          UniqueString name,
                          LookupConfig config,
-                         std::unordered_set<const Scope*>& visited) {
+                         ScopeSet& visited) {
   std::vector<BorrowedIdsWithName> vec;
 
   if (receiverScope) {
@@ -565,7 +567,7 @@ static
 bool doIsWholeScopeVisibleFromScope(Context* context,
                                    const Scope* checkScope,
                                    const Scope* fromScope,
-                                   std::unordered_set<const Scope*>& checked) {
+                                   ScopeSet& checked) {
 
   auto pair = checked.insert(fromScope);
   if (pair.second == false) {
@@ -610,7 +612,7 @@ bool isWholeScopeVisibleFromScope(Context* context,
                                   const Scope* checkScope,
                                   const Scope* fromScope) {
 
-  std::unordered_set<const Scope*> checked;
+  ScopeSet checked;
 
   return doIsWholeScopeVisibleFromScope(context,
                                         checkScope,
@@ -624,7 +626,7 @@ static void errorIfNameNotInScope(Context* context,
                                   UniqueString name,
                                   ID idForErr,
                                   VisibilityStmtKind useOrImport) {
-  std::unordered_set<const Scope*> checkedScopes;
+  ScopeSet checkedScopes;
   std::vector<BorrowedIdsWithName> result;
   LookupConfig config = LOOKUP_INNERMOST |
                         LOOKUP_DECLS |

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -41,6 +41,7 @@ extensions = [
 
 breathe_default_project = "dyno"
 
+nitpick_ignore_regex = [('cpp:identifier', r'llvm(:.*)?')]
 nitpick_ignore = []
 for line in open('../util/nitpick_ignore'):
     if line.strip() == "" or line.startswith("#"):


### PR DESCRIPTION
LLVM's SmallPtrSet is exactly what it says on the can: a set
optimzied for having few elements, which are pointers. Replacing
the more general `std::set` with LLVM's version seems to have a
positive impact on performance.

I've done some performance testing locally, and here are the
results in a release build chapel, while trying to scope resolve
_everything_ (including the internal modules, so not _just_
using `--dyno`).

```
Benchmark 1: chapel-perf-old/bin/darwin-arm64/chpl perftest.chpl -o helpme --dyno
  Time (mean ± σ):     426.5 ms ±   2.2 ms    [User: 368.4 ms, System: 44.1 ms]
  Range (min … max):   422.6 ms … 430.4 ms    10 runs
 
Benchmark 2: chapel-perf-new/bin/darwin-arm64/chpl perftest.chpl -o helpme --dyno
  Time (mean ± σ):     374.3 ms ±   1.7 ms    [User: 316.1 ms, System: 44.8 ms]
  Range (min … max):   371.9 ms … 377.1 ms    10 runs
 
Summary
  '/chapel-perf-new/bin/darwin-arm64/chpl perftest.chpl -o helpme --dyno' ran
    1.14 ± 0.01 times faster than 'chapel-perf-old/bin/darwin-arm64/chpl perftest.chpl -o helpme --dyno'
```

So we're looking at roughly a 15% boost. This is only a local test, and until I can get a clearer picture of performance in general, I'm leaving this as a WIP PR.

__Important caveat to the performance measurements__: All other issues aside, note that Dyno scope resolving cannot handle all internal modules; the two executions that are timed are not representative of a full compiler execution, because the dyno scope resolver fails at some point in the execution.