### PR TITLE
Use stdbool in the runtime GPU layer

### DIFF
--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -21,6 +21,8 @@
 #ifndef _CHPL_GPU_H_
 #define _CHPL_GPU_H_
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -33,6 +33,7 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <assert.h>
+#include <stdbool.h>
 
 static void CHPL_GPU_DEBUG(const char *str, ...) {
   if (verbosity >= 2) {


### PR DESCRIPTION
We use `bool` in the GPU layer, but we don't include `stdbool.h`. It looks like
we were getting by, because `CHPL_MEM=jemalloc` brings it in. If you have
`CHPL_MEM=cstdlib`, we aren't able to build the runtime.

Test:
- [x] can build with quickstart + `CHPL_LLVM!=none CHPL_LOCALE_MODEL=gpu`
- [x] local gpu/native with `CHPL_MEM=cstdlib`
