### PR TITLE
Add a small note about the Qthreads requirement for GPU support

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -45,6 +45,8 @@ where your installation of CUDA exists. If the build system fails to do this,
 or you would like to use a different CUDA installation, you can set
 ``CHPL_CUDA_PATH`` environment variable to the CUDA installation root.
 
+``CHPL_TASKS=qthreads`` is required for GPU support.
+
 We also suggest setting ``CHPL_RT_NUM_THREADS_PER_LOCALE=1`` (this is necessary
 if using CUDA 10).
 


### PR DESCRIPTION
`fifo` tasking layer doesn't support our GPU implementation today. This PR adds a sentence for `qthreads` requirement to the GPU technote.