### PR TITLE
Update 3rd party packages relied upon by start_test and chpldoc

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -1,6 +1,6 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 Jinja2==3.0.1
-Pygments==2.9.0
+Pygments==2.12.0
 Sphinx==4.3.2
 docutils==0.16.0
 babel==2.9.1

--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -1,6 +1,6 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 Jinja2==3.0.1
 Pygments==2.12.0
-Sphinx==4.3.2
+Sphinx==4.5.0
 docutils==0.16.0
 babel==2.10.3

--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -3,4 +3,4 @@ Jinja2==3.0.1
 Pygments==2.12.0
 Sphinx==4.3.2
 docutils==0.16.0
-babel==2.9.1
+babel==2.10.3

--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -1,5 +1,5 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
-Jinja2==3.0.1
+Jinja2==3.0.3
 Pygments==2.12.0
 Sphinx==4.5.0
 docutils==0.16.0

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.0
-filelock==3.0.12
+filelock==3.4.1
 argcomplete==2.0.0
 setuptools==54.0.0

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==5.4.1
+PyYAML==6.0.0
 filelock==3.0.12
 argcomplete==1.12.3
 setuptools==54.0.0

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.0
 filelock==3.0.12
-argcomplete==1.12.3
+argcomplete==2.0.0
 setuptools==54.0.0


### PR DESCRIPTION
Updates:
- PyYAML from 5.4.1 to 6.0.0
- argcomplete from 1.12.3 to 2.0.0
- Pygments from 2.9.0 to 2.12.0
- Babel from 2.9.1 to 2.10.3
- Sphinx from 4.3.2 to 4.5.0
- filelock from 3.0.12 to 3.4.1
- Jinja2 from 3.0.1 to 3.0.3

Does not update the following packages further because they
require Python 3.7 or greater:
- filelock (to 3.7.1)
- setuptools (could potentially update to 59.6.0 but the last time we did that, we had problems with arkouda)
- MarkupSafe (to 2.1.1)
- Jinja2 (to 3.1.2)

Can't update docutils because sphinx-rtd-theme won't use it yet (and also this version of
Sphinx isn't compatible with it).

Can't update Sphinx further even though other versions are available because these
versions require a more up to date version of breathe.

Can't update breathe, later versions generate a bunch of warnings about not being able
to find labels and this is a known issue on their repository:
[issue 726](https://github.com/michaeljones/breathe/issues/726)

Packages that did not need updates:
- sphinx-rtd-theme

Resolves Cray/chapel-private#3607

Passed a full paratest with futures (and ensured that the same number of tests were run
as before the change).  Spot checked some specific files that a diff between the docs builds
pointed out to ensure nothing looked broken.  Checked:
- the spec section on lexical structure
- the generated code developer doc
- the dyno Queries page
- the C interoperability primer
- the tuples primer