### PR TITLE
fix(dyno): change CMake keyword to PUBLIC for libdyno

### DIFF
--- a/compiler/dyno/lib/CMakeLists.txt
+++ b/compiler/dyno/lib/CMakeLists.txt
@@ -49,4 +49,4 @@ add_library(libdyno SHARED $<TARGET_OBJECTS:libdyno-obj>)
 target_include_directories(libdyno PUBLIC
                            ${CHPL_MAIN_INCLUDE_DIR}
                            ${CHPL_INCLUDE_DIR})
-target_link_libraries(libdyno INTERFACE ${DYNO_LLVM_LINK_ARGS})
+target_link_libraries(libdyno PUBLIC ${DYNO_LLVM_LINK_ARGS})


### PR DESCRIPTION
This PR adjusts the `CMake` keyword used when linking `LLVM` to `libdyno`
from `INTERFACE` to `PUBLIC`

The `CMake` docs suggest that `INTERFACE` might be failing here because it 
doesn't link the target, `libdyno` in this case, it only extends the 
link interface.

* BenH. reported builds on mac began failing after PR20280.
  While this only appears broken on macs, changing the
  keyword from `INTERFACE` to `PUBLIC` fixes the link failure.
  failure mode was `ld: symbol(s) not found for architecture ...`

TESTING:

- [x] `libdyno` builds on linux
- [x] `libdyno` builds on mac

reviewed by @dlongnecke-cray and @DanilaFe - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>