### PR TITLE
Use the complex initializer that's supported by clang 11

### DIFF
--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -35,9 +35,9 @@
 typedef float _Complex        _complex64;
 typedef double _Complex       _complex128;
 
-// clang doesn't support _Complex_I but it does support __builtin_complex
+// clang doesn't have _Complex_I but it supports initializer lists for complex
 #ifndef _Complex_I
-#define _Complex_I __builtin_complex(0.0,1.0)
+static const _complex64 _Complex_I = {0.0f, 1.0f};
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
clang-11 doesn't support `__builtin_complex`, but it supports complex initializer lists. This PR uses those to create `_Complex_I` if it is not defined.
