### PR TITLE
Add the explicit include to runtime's bitops header

### DIFF
--- a/runtime/include/chpl-bitops.h
+++ b/runtime/include/chpl-bitops.h
@@ -34,6 +34,7 @@
 #include <limits.h>
 
 #include "chpl-comp-detect-macros.h"
+#include "sys_basic.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This was an obvious missing piece from https://github.com/chapel-lang/chapel/pull/20239.

Test:
- [x] standard