### PR TITLE
Add TOML checking of mason git dependencies and revision locking

### DIFF
--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -245,14 +245,10 @@ proc genSourceList(lockFile: borrowed Toml) {
       if name == "root" || name == "system" || name == "external" then continue;
       else {
         var toml = lockFile[name]!;
-        // TODO: What do we want to do with version for git deps?
         var version = toml["version"]!.s;
 
-        if toml.pathExists("source") {
-          var source = toml["source"]!.s;
-          sourceList.append((source, name, version));
-        } else if toml.pathExists("url") {
-          var url = toml["url"]!.s;
+        if toml.pathExists("rev") {
+          var url = toml["source"]!.s;
           var revision = toml["rev"]!.s;
 
           var branch: string;
@@ -263,6 +259,9 @@ proc genSourceList(lockFile: borrowed Toml) {
             branch = "HEAD";
           }
           gitList.append((url, name, branch, revision));
+        } else if toml.pathExists("source") {
+          var source = toml["source"]!.s;
+          sourceList.append((source, name, version));
         }
       }
     }
@@ -285,7 +284,7 @@ proc getSrcCode(sourceListArg: list(3*string), show) {
   var baseDir = MASON_HOME +'/src/';
   forall (srcURL, name, version) in sourceList {
     // version of -1 specifies a git dep
-    if version != -1 {
+    if version != "-1" {
       const nameVers = name + "-" + version;
       const destination = baseDir + nameVers;
       if !depExists(nameVers) {

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -201,11 +201,14 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string, show: bool,
     if sourceList.size > 0 then command += " --main-module " + project;
 
     for (_, name, version) in sourceList {
-      var depSrc = ' ' + depPath + name + "-" + version + '/src/' + name + ".chpl";
-      command += depSrc;
+      // version of -1 specifies a git dep
+      if version != "-1" {
+        var depSrc = ' ' + depPath + name + "-" + version + '/src/' + name + ".chpl";
+        command += depSrc;
+      }
     }
 
-    for (_, name, branch) in gitList {
+    for (_, name, branch, _) in gitList {
       var gitDepSrc = ' ' + gitDepPath + name + "-" + branch + '/src/' + name + ".chpl";
       command += gitDepSrc;
     }
@@ -236,7 +239,7 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string, show: bool,
    url and the name for local mason dependency pool */
 proc genSourceList(lockFile: borrowed Toml) {
   var sourceList: list((string, string, string));
-  var gitList: list((string, string, string));
+  var gitList: list((string, string, string, string));
   for (name, package) in lockFile.A.items() {
     if package!.tag == fieldtag.fieldToml {
       if name == "root" || name == "system" || name == "external" then continue;
@@ -250,15 +253,16 @@ proc genSourceList(lockFile: borrowed Toml) {
           sourceList.append((source, name, version));
         } else if toml.pathExists("url") {
           var url = toml["url"]!.s;
+          var revision = toml["rev"]!.s;
 
           var branch: string;
           // use branch if specified, else default to master
           if toml["branch"] != nil {
             branch = toml["branch"]!.s;
           } else {
-            branch = "master";
+            branch = "HEAD";
           }
-          gitList.append((url, name, branch));
+          gitList.append((url, name, branch, revision));
         }
       }
     }
@@ -266,18 +270,6 @@ proc genSourceList(lockFile: borrowed Toml) {
   return (sourceList, gitList);
 }
 
-
-/* Checks to see if dependency has already been
-   downloaded previously */
-proc depExists(dependency: string, repo='/src/') {
-  var repos = MASON_HOME + repo;
-  var exists = false;
-  for dir in listdir(repos) {
-    if dir == dependency then
-      exists = true;
-  }
-  return exists;
-}
 
 /* Clones the git repository of each dependency into
    the src code dependency pool */
@@ -292,23 +284,26 @@ proc getSrcCode(sourceListArg: list(3*string), show) {
 
   var baseDir = MASON_HOME +'/src/';
   forall (srcURL, name, version) in sourceList {
-    const nameVers = name + "-" + version;
-    const destination = baseDir + nameVers;
-    if !depExists(nameVers) {
-      writeln("Downloading dependency: " + nameVers);
-      var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
-      var checkout = "git checkout -q v" + version;
-      if show {
-        getDependency = "git clone -n " + srcURL + ' ' + destination + '/';
-        checkout = "git checkout v" + version;
+    // version of -1 specifies a git dep
+    if version != -1 {
+      const nameVers = name + "-" + version;
+      const destination = baseDir + nameVers;
+      if !depExists(nameVers) {
+        writeln("Downloading dependency: " + nameVers);
+        var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
+        var checkout = "git checkout -q v" + version;
+        if show {
+          getDependency = "git clone -n " + srcURL + ' ' + destination + '/';
+          checkout = "git checkout v" + version;
+        }
+        runCommand(getDependency);
+        gitC(destination, checkout);
       }
-      runCommand(getDependency);
-      gitC(destination, checkout);
     }
   }
 }
 
-proc getGitCode(gitListArg: list(3*string), show) {
+proc getGitCode(gitListArg: list(4*string), show) {
   if !isDir(MASON_HOME + '/git/') {
     mkdir(MASON_HOME + '/git/', parents=true);
   }
@@ -321,30 +316,27 @@ proc getGitCode(gitListArg: list(3*string), show) {
   var gitList = gitListArg.toArray();
 
   var baseDir = MASON_HOME +'/git/';
-  forall (srcURL, name, branch) in gitList {
+  forall (srcURL, name, branch, revision) in gitList {
     const nameVers = name + "-" + branch;
     const destination = baseDir + nameVers;
     if !depExists(nameVers, '/git/') {
       writeln("Downloading dependency: " + nameVers);
       var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
-      var checkout = "git checkout -q " + branch;
+      var checkout = "git checkout -q " + revision;
       if show {
         getDependency = "git clone -n " + srcURL + ' ' + destination + '/';
-        checkout = "git checkout " + branch;
+        checkout = "git checkout " + revision;
       }
       runCommand(getDependency);
       gitC(destination, checkout);
     } else {
-      writeln("Pulling latest changes for " + nameVers + "...");
+      writeln("Checking out specified revision for " + nameVers + "...");
 
-      var checkoutBranch = "git checkout -q " + branch;
-      var pullLatest = "git pull -q origin " + branch;
+      var checkoutBranch = "git checkout -q " + revision;
       if show {
-        checkoutBranch = "git checkout " + branch;
-        pullLatest = "git pull origin " + branch;
+        checkoutBranch = "git checkout " + revision;
       }
       gitC(destination, checkoutBranch);
-      gitC(destination, pullLatest);
     }
   }
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -252,7 +252,7 @@ proc genSourceList(lockFile: borrowed Toml) {
           var revision = toml["rev"]!.s;
 
           var branch: string;
-          // use branch if specified, else default to master
+          // use branch if specified, else default to HEAD
           if toml["branch"] != nil {
             branch = toml["branch"]!.s;
           } else {

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -88,7 +88,6 @@ private proc getBuildInfo(projectHome: string) {
   const tomlFile = parseToml(toml);
 
   // Get project source code and dependencies
-  // TODO: Add some use of the gitDeps
   const (sourceList, gitList) = genSourceList(lockFile);
 
   //

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -78,7 +78,7 @@ proc masonModules(args: [] string) throws {
     modules += depM;
   }
 
-  for (_, name, branch) in gitList {
+  for (_, name, branch, _) in gitList {
     var gitDepSrc = ' ' + gitDepPath + name + "-" + branch + '/src/' + name + ".chpl";
     modules += gitDepSrc;
   }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -327,7 +327,7 @@ private proc createDepTree(root: Toml) {
     // add dependencies found in TOML files of git deps
     for m in gitManifests do
       manifests.append(m);
-    
+
     depTree = createDepTrees(depTree, manifests, "root");
     depTree = addGitDeps(depTree, gitDeps);
   }
@@ -574,11 +574,11 @@ private proc pullGitDeps(gitDeps, show=false) {
   if !isDir(MASON_HOME + '/git/') {
     mkdir(MASON_HOME + '/git/', parents=true);
   }
-  
+
   var gitDepsWithRevision: list((string, string, string, string));
 
   var gitDepMap: map(string, (string, string, string));
-  
+
   // form map of name -> url, branch, revision
   for val in gitDeps {
     if val[1] == "git" then
@@ -588,13 +588,13 @@ private proc pullGitDeps(gitDeps, show=false) {
     else if val[1] == "rev" then
       gitDepMap[val[0]][2] = val[2]!.s;
   }
-  
+
   // Pull git repositories so that we can have access to the
   // current revision and TOML file to get dependencies
   var baseDir = MASON_HOME +'/git/';
   for val in gitDepMap {
     var (srcURL, origBranch, revision) = gitDepMap[val];
-    
+
     // Default to head if branch isn't specified
     var branch = if origBranch == "" then "HEAD" else origBranch;
     const nameVers = val + "-" + branch;
@@ -612,10 +612,10 @@ private proc pullGitDeps(gitDeps, show=false) {
           getDependency = "git clone " + srcURL + ' ' + destination + '/';
           checkout = "git checkout " + toCheckout;
         }
-      
+
         gitC(destination, checkout);
       }
-      
+
       // get the revision to store in lock if not specified
       if revision == "" {
         var revParse = "git rev-parse HEAD";
@@ -628,27 +628,27 @@ private proc pullGitDeps(gitDeps, show=false) {
         var pullDependency = "git fetch -q --all";
         if show then pullDependency = "git fetch --all";
         gitC(destination, pullDependency);
-        
+
         writeln("Checking out specified revision for " + nameVers + "...");
         // Use the revision to checkout, if specified
         var checkout = "git checkout -q " + revision;
         if show then checkout = "git checkout " + revision;
-      
+
         gitC(destination, checkout);
       } else if branch != "HEAD" {
         writeln("Fetching latest changes for: " + nameVers + "...");
         var pullDependency = "git fetch -q --all";
         if show then pullDependency = "git fetch --all";
         gitC(destination, pullDependency);
-        
+
         writeln("Checking out specified revision for " + nameVers + "...");
 
         var checkout = "git checkout -q " + branch;
         if show then checkout = "git checkout " + branch;
-      
+
         gitC(destination, checkout);
       }
-      
+
       // get the revision to store in lock if not specified
       if revision == "" {
         var revParse = "git rev-parse HEAD";

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -316,8 +316,18 @@ private proc createDepTree(root: Toml) {
 
   if root.pathExists("dependencies") {
     var deps = getDependencies(root);
-    var gitDeps = getGitDeps(root);
+
+    // gitDeps is a list of (name, url, branch, revision)
+    // git repositories that don't have a revision specified
+    // in the TOML will always be updated to the latest revision
+    var gitDeps = pullGitDeps(getGitDeps(root));
     var manifests = getManifests(deps);
+    var gitManifests = getGitManifests(gitDeps);
+
+    // add dependencies found in TOML files of git deps
+    for m in gitManifests do
+      manifests.append(m);
+    
     depTree = createDepTrees(depTree, manifests, "root");
     depTree = addGitDeps(depTree, gitDeps);
   }
@@ -404,6 +414,7 @@ private proc createDepTrees(depTree: Toml, ref deps: list(shared Toml), name: st
 }
 
 private proc addGitDeps(depTree: Toml, ref gitDeps) {
+  //val url branch revision
   for key in gitDeps {
     if !depTree.pathExists(key[0]) {
       var dt: domain(string);
@@ -411,16 +422,16 @@ private proc addGitDeps(depTree: Toml, ref gitDeps) {
       depTree.set(key[0], depTbl);
       depTree[key[0]]!.set("name", key[0]);
     }
-    if key[1] == "git" then
-      depTree[key[0]]!.set("url", key[2]!);
-    else
-      depTree[key[0]]!.set("branch", key[2]!);
+    depTree[key[0]]!.set("url", key[1]);
+    if key[2] != "HEAD" then
+      depTree[key[0]]!.set("branch", key[2]);
+    depTree[key[0]]!.set("rev", key[3]);
 
     // TODO: Fix version and chplversion
     //       these should really be coming from the toml
     //       file in the git repo manifest that isn't yet
     //       downloaded
-    depTree[key[0]]!.set("version", "0");
+    depTree[key[0]]!.set("version", "-1");
     depTree[key[0]]!.set("chplVersion", "1.27.0");
   }
   return depTree;
@@ -512,6 +523,31 @@ private proc retrieveDep(name: string, version: string) {
   exit(1);
 }
 
+/* Returns the Mason.toml for each dep listed as a Toml */
+private proc getGitManifests(deps: list((string, string, string, string))) {
+  var manifests: list(shared Toml);
+  for dep in deps {
+    var toAdd = retrieveGitDep(dep(0), dep(2));
+    manifests.append(toAdd);
+  }
+  return manifests;
+}
+
+/* Responsible for parsing the Mason.toml that have been
+   already pulled down from git dependencies */
+private proc retrieveGitDep(name: string, branch: string) {
+  var baseDir = MASON_HOME +'/git/';
+  const tomlPath = baseDir + "/"+name+"-"+branch+"/Mason.toml";
+  if isFile(tomlPath) {
+    var tomlFile = open(tomlPath, iomode.r);
+    var depToml = parseToml(tomlFile);
+    return depToml;
+  }
+
+  stderr.writeln("No toml file found in git dependency for " + name +'-'+ branch);
+  exit(1);
+}
+
 /* Checks if a dependency has deps; if so, the
    dependencies are returned as a (string, Toml) */
 private proc getDependencies(tomlTbl: Toml) {
@@ -531,10 +567,101 @@ private proc getGitDeps(tomlTbl: Toml) {
   var gitDeps: list((string, string, shared Toml?));
   for k in tomlTbl["dependencies"]!.A {
     for (a, d) in allFields(tomlTbl["dependencies"]![k]!) {
-      // name, branch, toml that it is set to
+      // name, type of field (url, branch, etc.), toml that it is set to
       gitDeps.append((k, a, d));
     }
   }
   return gitDeps;
+}
+
+private proc pullGitDeps(gitDeps, show=false) {
+  if !isDir(MASON_HOME + '/git/') {
+    mkdir(MASON_HOME + '/git/', parents=true);
+  }
+  
+  var gitDepsWithRevision: list((string, string, string, string));
+
+  var gitDepMap: map(string, (string, string, string));
+  
+  // form map of name -> url, branch, revision
+  // TODO: need to allow user to specify revision
+  for val in gitDeps {
+    if val[1] == "git" then
+      gitDepMap[val[0]][0] = val[2]!.s;
+    else if val[1] == "branch" then
+      gitDepMap[val[0]][1] = val[2]!.s;
+    else if val[1] == "rev" then
+      gitDepMap[val[0]][2] = val[2]!.s;
+  }
+  
+  // Pull git repositories so that we can have access to the
+  // current revision and TOML file to get dependencies
+  var baseDir = MASON_HOME +'/git/';
+  for val in gitDepMap {
+    var (srcURL, origBranch, revision) = gitDepMap[val];
+    
+    // Default to head if branch isn't specified
+    var branch = if origBranch == "" then "HEAD" else origBranch;
+    const nameVers = val + "-" + branch;
+    const destination = baseDir + nameVers;
+    if !depExists(nameVers, '/git/') {
+      writeln("Downloading dependency: " + nameVers);
+      var getDependency = "git clone -q "+ srcURL + ' ' + destination +'/';
+      runCommand(getDependency);
+
+      if (branch != "HEAD") || (revision != "") {
+        // Use the revision to checkout, if specified
+        var toCheckout = if revision != "" then revision else branch;
+        var checkout = "git checkout -q " + toCheckout;
+        if show {
+          getDependency = "git clone " + srcURL + ' ' + destination + '/';
+          checkout = "git checkout " + toCheckout;
+        }
+      
+        gitC(destination, checkout);
+      }
+      
+      // get the revision to store in lock if not specified
+      if revision == "" {
+        var revParse = "git rev-parse HEAD";
+        revision = gitC(destination, revParse, true).strip();
+      }
+      gitDepsWithRevision.append((val, srcURL, branch, revision));
+    } else {
+      if revision != "" {
+        writeln("Pulling latest changes for : " + nameVers + "...");
+        var pullDependency = "git pull -q origin " + branch;
+        if show then pullDependency = "git pull origin " + branch;
+        gitC(destination, pullDependency);
+        
+        writeln("Checking out specified revision for " + nameVers + "...");
+        // Use the revision to checkout, if specified
+        var checkout = "git checkout -q " + revision;
+        if show then checkout = "git checkout " + revision;
+      
+        gitC(destination, checkout);
+      } else if branch != "HEAD" {
+        writeln("Pulling latest changes for " + nameVers + "...");
+        var pullDependency = "git pull -q origin " + branch;
+        if show then pullDependency = "git pull origin " + branch;
+        gitC(destination, pullDependency);
+        
+        writeln("Checking out specified revision for " + nameVers + "...");
+
+        var checkout = "git checkout -q " + branch;
+        if show then checkout = "git checkout " + branch;
+      
+        gitC(destination, checkout);
+      }
+      
+      // get the revision to store in lock if not specified
+      if revision == "" {
+        var revParse = "git rev-parse HEAD";
+        revision = gitC(destination, revParse, true).strip();
+      }
+      gitDepsWithRevision.append((val, srcURL, branch, revision));
+    }
+  }
+  return gitDepsWithRevision;
 }
 

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -422,17 +422,13 @@ private proc addGitDeps(depTree: Toml, ref gitDeps) {
       depTree.set(key[0], depTbl);
       depTree[key[0]]!.set("name", key[0]);
     }
-    depTree[key[0]]!.set("url", key[1]);
+    depTree[key[0]]!.set("source", key[1]);
     if key[2] != "HEAD" then
       depTree[key[0]]!.set("branch", key[2]);
     depTree[key[0]]!.set("rev", key[3]);
 
-    // TODO: Fix version and chplversion
-    //       these should really be coming from the toml
-    //       file in the git repo manifest that isn't yet
-    //       downloaded
+    // version of -1 is a special
     depTree[key[0]]!.set("version", "-1");
-    depTree[key[0]]!.set("chplVersion", "1.27.0");
   }
   return depTree;
 }
@@ -584,7 +580,6 @@ private proc pullGitDeps(gitDeps, show=false) {
   var gitDepMap: map(string, (string, string, string));
   
   // form map of name -> url, branch, revision
-  // TODO: need to allow user to specify revision
   for val in gitDeps {
     if val[1] == "git" then
       gitDepMap[val[0]][0] = val[2]!.s;
@@ -629,9 +624,9 @@ private proc pullGitDeps(gitDeps, show=false) {
       gitDepsWithRevision.append((val, srcURL, branch, revision));
     } else {
       if revision != "" {
-        writeln("Pulling latest changes for : " + nameVers + "...");
-        var pullDependency = "git pull -q origin " + branch;
-        if show then pullDependency = "git pull origin " + branch;
+        writeln("Fetching latest changes for: " + nameVers + "...");
+        var pullDependency = "git fetch -q --all";
+        if show then pullDependency = "git fetch --all";
         gitC(destination, pullDependency);
         
         writeln("Checking out specified revision for " + nameVers + "...");
@@ -641,9 +636,9 @@ private proc pullGitDeps(gitDeps, show=false) {
       
         gitC(destination, checkout);
       } else if branch != "HEAD" {
-        writeln("Pulling latest changes for " + nameVers + "...");
-        var pullDependency = "git pull -q origin " + branch;
-        if show then pullDependency = "git pull origin " + branch;
+        writeln("Fetching latest changes for: " + nameVers + "...");
+        var pullDependency = "git fetch -q --all";
+        if show then pullDependency = "git fetch --all";
         gitC(destination, pullDependency);
         
         writeln("Checking out specified revision for " + nameVers + "...");

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -522,11 +522,13 @@ proc depExists(dependency: string, repo='/src/') {
 }
 
 
-proc getProjectType(): string {
+proc getProjectType(): string throws {
   const cwd = here.cwd();
   const projectHome = getProjectHome(cwd);
   const toParse = open(projectHome + "/Mason.toml", iomode.r);
   const tomlFile = parseToml(toParse);
+  if !tomlFile.pathExists("brick.type") then
+    throw new owned MasonError('Type not found in TOML file; please add a type="application" key');
   return tomlFile["brick"]!["type"]!.s;
 }
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -482,7 +482,7 @@ proc isIdentifier(name:string) {
 
 
 proc getMasonDependencies(sourceList: list(3*string),
-                          gitList: list(3*string),
+                          gitList: list(4*string),
                           progName: string) {
 
   // Declare example to run as the main module
@@ -501,12 +501,24 @@ proc getMasonDependencies(sourceList: list(3*string),
     const gitDepPath = MASON_HOME + '/git/';
 
     // Add git dependencies
-    for (_, name, branch) in gitList {
+    for (_, name, branch, _) in gitList {
       var gitDepSrc = ' ' + gitDepPath + name + "-" + branch + '/src/' + name + ".chpl";
       masonCompopts += gitDepSrc;
     }
   }
   return masonCompopts;
+}
+
+/* Checks to see if dependency has already been
+   downloaded previously */
+proc depExists(dependency: string, repo='/src/') {
+  var repos = MASON_HOME + repo;
+  var exists = false;
+  for dir in listdir(repos) {
+    if dir == dependency then
+      exists = true;
+  }
+  return exists;
 }
 
 


### PR DESCRIPTION
Previously, support was added to mason for using git repositories 
outside of a mason registry as dependencies, but the TOML files of 
those dependencies were not checked and their revisions were not 
locked in. This meant that if the git repo specified as a dependency 
used another required mason package, it would not be pulled into the 
new build and wouldn't compile.

This PR adds support for checking the TOML file and adding the
dependencies to the lock file of the package using the git repo, so
all dependencies should be resolved.

Additionally, the specific git revision is now always locked in
to ensure build reproducibility. Upon building with a git dep
specified, a directory will be created a and the repo pulled down at
`$MASON_HOME/git/<dep-name>-<branch>`. Then, while generating the
lock file, the TOML file in the git dependency will be checked and
the dependencies pulled into the lock file. Finally, the git revision
is retrieved from the repo and stored in the lock file to ensure
that the build will be reproducible.

The git revision will then only be updated when running the
`mason update` command without having a `rev` field in the TOML file.
If a `rev` field is specified, the revision will never be updated.
This means that running `mason build` will never update the revision,
but will instead checkout the revision specified in `Mason.lock`
everytime.
