### PR TITLE
`locale` documentation improvements

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -184,59 +184,50 @@ module ChapelLocale {
   /*
     Get the hostname of this locale.
 
+    Returns the hostname acquired from the system call ``uname -n``.
+    Sub-locales have the same hostname as their parent.
+
     :returns: the hostname of the compute node associated with the locale
     :rtype: string
 
-  .. list-table::
-    :widths: 15 18 18
-    :header-rows: 1
-
-    * -
-      - locale ( `here` )
-      - sub-locale ( `here.gpus[0]` )
-    * - normal
-      - prod-1234
-      - prod-1234-GPU0
-    * - oversubscribed
-      - prod-1234
-      - prod-1234-GPU0
-
   */
-  inline proc locale.hostname {
+  inline proc locale.hostname: string {
     return this._value.hostname;
   }
 
   /*
-    Get the name of this locale.  In practice, this is often the
-    same as the hostname, though in some cases (like when using
-    local launchers), it may be modified.
+    Get the name of this locale.
 
-    :returns: locale name
-    :rtype: string
+    In general, this method returns the same string as :proc:`hostname`;
+    however, it will differ when called on a sub-locale (such as a GPU),
+    or when the program is being run in an oversubscribed manner.
+
+    The following table summarizes the various behaviors (where {hostname} is
+    the string returned by `here.hostname`, and {id} is the unique locale ID):
 
   .. list-table::
-    :widths: 15 18 18
+    :widths: 18 22 22
     :header-rows: 1
 
     * -
-      - locale ( `here` )
-      - sub-locale ( `here.gpus[0]` )
-    * - normal
-      - prod-1234
-      - prod-1234
-    * - oversubscribed
-      - prod-1234
-      - prod-1234
+      - locale ( `here.name` )
+      - sub-locale ( `here.gpus[0].name` )
+    * - normal allocation
+      - {hostname}
+      - {hostname}-GPU0
+    * - oversubscribed allocation
+      - {hostname}-{id}
+      - {hostname}-{id}-GPU0
+
+  :returns: the unique name of this locale
+  :rtype: string
   */
-  inline proc locale.name {
+  inline proc locale.name: string {
     return this._value.name;
   }
 
   /*
     Get the unique integer identifier for this locale.
-
-    :returns: locale number, in the range ``0..numLocales-1``
-    :rtype: int
 
     When called on a sub-locale, this method still returns the ID of the
     parent locale. So, for example, the following program prints true:
@@ -245,8 +236,11 @@ module ChapelLocale {
 
     writeln(here.id == here.gpus[0].id);
 
+  :returns: locale number, in the range ``0..numLocales-1``
+  :rtype: int
+
   */
-  inline proc locale.id {
+  inline proc locale.id: int {
     return this._value.id;
   }
 

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -209,14 +209,14 @@ module ChapelLocale {
       - `here.name`
     * - normal execution
       - {hostname}
-    * - general oversubscribed execution
-      - {hostname}
-    * - oversubscribed execution with gasnet(*)
+    * - oversubscribed execution with gasnet\*
       - {hostname}-{id}
+    * - other oversubscribed execution
+      - {hostname}
 
   .. note::
 
-    (*)This behavior occurs when launching in an oversubscribed manner
+    \*This behavior occurs when launching in an oversubscribed manner
     with `CHPL_COMM=gasnet` and one of the following configurations:
 
     - `CHPL_COMM_SUBSTRATE=udp` & `GASNET_SPAWNFN=L`

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -197,27 +197,11 @@ module ChapelLocale {
     In general, this method returns the same string as :proc:`locale.hostname`;
     however, it can differ when the program is executed in an oversubscribed manner.
 
-    The following table summarizes the various behaviors of this method (where
-    {hostname} is the string returned by `here.hostname`, and {id} is the locale's
-    unique integer ID):
-
-  .. list-table::
-    :widths: 25 25
-    :header-rows: 1
-
-    * - Configuration
-      - `here.name`
-    * - normal execution
-      - {hostname}
-    * - oversubscribed execution with gasnet\*
-      - {hostname}-{id}
-    * - other oversubscribed execution
-      - {hostname}
-
   .. note::
 
-    \*This behavior occurs when launching in an oversubscribed manner
-    with `CHPL_COMM=gasnet` and one of the following configurations:
+    The locale's `id` (from :proc:`locale.id`) will be appended to the `hostname`
+    when launching in an oversubscribed manner with `CHPL_COMM=gasnet` and one of
+    the following configurations:
 
     - `CHPL_COMM_SUBSTRATE=udp` & `GASNET_SPAWNFN=L`
     - `CHPL_COMM_SUBSTRATE=smp`

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -189,7 +189,6 @@ module ChapelLocale {
 
     :returns: the hostname of the compute node associated with the locale
     :rtype: string
-
   */
   inline proc locale.hostname: string {
     return this._value.hostname;
@@ -211,27 +210,25 @@ module ChapelLocale {
     :header-rows: 1
 
     * - Configuration
-      - locale ( `here.name` )
-      - sub-locale ( `here.gpus[0].name` )
+      - locale (`here.name`)
+      - sub-locale (`here.gpus[0].name`)
     * - normal execution
       - {hostname}
       - {hostname}-GPU0
     * - oversubscribed execution
       - {hostname}
       - {hostname}-GPU0
-    * - oversubscribed execution (gasnet*)
+    * - oversubscribed execution with gasnet `(*)`
       - {hostname}-{id}
       - {hostname}-{id}-GPU0
 
   .. note::
 
-    When launching in an oversubscribed manner with `CHPL_COMM=gasnet`
-    and one of the following configurations:
+    `(*)`: This behavior occurs when launching in an oversubscribed manner
+    with `CHPL_COMM=gasnet` and one of the following configurations:
 
     - `CHPL_COMM_SUBSTRATE=udp` & `GASNET_SPAWNFN=L`
     - `CHPL_COMM_SUBSTRATE=smp`
-
-    the locale's integer ID will also be included in it's name.
 
     More information about these environment variables can be found here: :ref:`readme-multilocale`
 

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -186,6 +186,21 @@ module ChapelLocale {
 
     :returns: the hostname of the compute node associated with the locale
     :rtype: string
+
+  .. list-table::
+    :widths: 15 18 18
+    :header-rows: 1
+
+    * -
+      - locale ( `here` )
+      - sub-locale ( `here.gpus[0]` )
+    * - normal
+      - prod-1234
+      - prod-1234-GPU0
+    * - oversubscribed
+      - prod-1234
+      - prod-1234-GPU0
+
   */
   inline proc locale.hostname {
     return this._value.hostname;
@@ -198,6 +213,20 @@ module ChapelLocale {
 
     :returns: locale name
     :rtype: string
+
+  .. list-table::
+    :widths: 15 18 18
+    :header-rows: 1
+
+    * -
+      - locale ( `here` )
+      - sub-locale ( `here.gpus[0]` )
+    * - normal
+      - prod-1234
+      - prod-1234
+    * - oversubscribed
+      - prod-1234
+      - prod-1234
   */
   inline proc locale.name {
     return this._value.name;
@@ -208,6 +237,14 @@ module ChapelLocale {
 
     :returns: locale number, in the range ``0..numLocales-1``
     :rtype: int
+
+    When called on a sub-locale, this method still returns the ID of the
+    parent locale. So, for example, the following program prints true:
+
+  .. code-block:: chapel
+
+    writeln(here.id == here.gpus[0].id);
+
   */
   inline proc locale.id {
     return this._value.id;

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -182,10 +182,7 @@ module ChapelLocale {
   // Locale methods we want to have show up in chpldoc start here:
 
   /*
-    Get the hostname of the hardware associated with this locale.
-
-    The behavior of this method does not differ for calls made from
-    sub-locales (Unlike :proc:`locale.name`).
+    Get the hostname of this locale.
 
     :returns: the hostname of the compute node associated with the locale
     :rtype: string
@@ -198,33 +195,28 @@ module ChapelLocale {
     Get the name of this locale.
 
     In general, this method returns the same string as :proc:`locale.hostname`;
-    however, it can differ when called on a sub-locale (such as a GPU),
-    or when the program is executed in an oversubscribed manner.
+    however, it can differ when the program is executed in an oversubscribed manner.
 
     The following table summarizes the various behaviors of this method (where
     {hostname} is the string returned by `here.hostname`, and {id} is the locale's
     unique integer ID):
 
   .. list-table::
-    :widths: 25 22 22
+    :widths: 25 25
     :header-rows: 1
 
     * - Configuration
-      - locale (`here.name`)
-      - sub-locale (`here.gpus[0].name`)
+      - `here.name`
     * - normal execution
       - {hostname}
-      - {hostname}-GPU0
-    * - oversubscribed execution
+    * - general oversubscribed execution
       - {hostname}
-      - {hostname}-GPU0
-    * - oversubscribed execution with gasnet `(*)`
+    * - oversubscribed execution with gasnet(*)
       - {hostname}-{id}
-      - {hostname}-{id}-GPU0
 
   .. note::
 
-    `(*)`: This behavior occurs when launching in an oversubscribed manner
+    (*)This behavior occurs when launching in an oversubscribed manner
     with `CHPL_COMM=gasnet` and one of the following configurations:
 
     - `CHPL_COMM_SUBSTRATE=udp` & `GASNET_SPAWNFN=L`
@@ -242,15 +234,7 @@ module ChapelLocale {
   /*
     Get the unique integer identifier for this locale.
 
-    When called on a sub-locale, this method returns the ID of the
-    parent locale, not the sub-locale. So, for example, the following
-    program prints true:
-
-  .. code-block:: chapel
-
-    writeln(here.id == here.gpus[0].id);
-
-  :returns: locale number, in the range ``0..numLocales-1``
+  :returns: index of this locale in the range ``0..numLocales-1``
   :rtype: int
 
   */


### PR DESCRIPTION
Updates to the documentation for `locale.name`, `locale.hostname`, and `locale.id` to clarify their behaviors for sub-locales and oversubscribed execution.

Explicit return type annotations were also added to these methods. 
