### PR TITLE
Remove Knights-Landing memory interface from `locale`

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -145,22 +145,6 @@ module ChapelLocale {
       return this._value.chpl_name();
     }
 
-    inline proc defaultMemory() {
-      return this._value.defaultMemory();
-    }
-
-    inline proc largeMemory() {
-      return this._value.largeMemory();
-    }
-
-    inline proc lowLatencyMemory() {
-      return this._value.lowLatencyMemory();
-    }
-
-    inline proc highBandwidthMemory() {
-      return this._value.highBandwidthMemory();
-    }
-
     inline proc getChildCount() {
       return this._value.getChildCount();
     }

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -411,30 +411,6 @@ module ChapelLocale {
       return "";
     }
 
-    //
-    // Support for different types of memory:
-    // large, low latency, and high bandwidth
-    //
-    pragma "no doc"
-    proc defaultMemory() : locale {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
-    pragma "no doc"
-    proc largeMemory() : locale {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
-    pragma "no doc"
-    proc lowLatencyMemory() : locale {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
-    pragma "no doc"
-    proc highBandwidthMemory() : locale {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
     pragma "no doc"
     proc getChildCount() : int {
       HaltWrappers.pureVirtualMethodHalt();

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -100,28 +100,6 @@ module LocaleModel {
     }
     override proc chpl_name() return local_name;
 
-    //
-    // Support for different types of memory:
-    // large, low latency, and high bandwidth
-    //
-    // The flat memory model assumes only one memory.
-    //
-    override proc defaultMemory() : locale {
-      return new locale(this);
-    }
-
-    override proc largeMemory() : locale {
-      return new locale(this);
-    }
-
-    override proc lowLatencyMemory() : locale {
-      return new locale(this);
-    }
-
-    override proc highBandwidthMemory() : locale {
-      return new locale(this);
-    }
-
     proc getChildSpace() return chpl_emptyLocaleSpace;
 
     override proc getChildCount() return 0;

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -172,29 +172,6 @@ module LocaleModel {
     }
     override proc chpl_name() return local_name;
 
-    //
-    // Support for different types of memory:
-    // large, low latency, and high bandwidth
-    //
-    // The numa memory model currently assumes only one memory.
-    //
-    // ENGIN: Are these ever used?
-    override proc defaultMemory() : locale {
-      return new locale(this);
-    }
-
-    override proc largeMemory() : locale {
-      return new locale(this);
-    }
-
-    override proc lowLatencyMemory() : locale {
-      return new locale(this);
-    }
-
-    override proc highBandwidthMemory() : locale {
-      return new locale(this);
-    }
-
     proc getChildSpace() return childSpace;
 
     override proc getChildCount() return numSublocales;

--- a/test/types/locale/promotedCalls.chpl
+++ b/test/types/locale/promotedCalls.chpl
@@ -9,8 +9,4 @@ writeln(Locales.name);
 writeln(Locales.chpl_id());
 writeln(Locales.chpl_localeid());
 writeln(Locales.chpl_name());
-writeln(Locales.defaultMemory());
-writeln(Locales.largeMemory());
-writeln(Locales.lowLatencyMemory());
-writeln(Locales.highBandwidthMemory());
 writeln(Locales.getChildCount());


### PR DESCRIPTION
This PR removes the Knights-Landing memory interface from the `locale` type.

The following methods were unused and undocumented:
- defaultMemory()
- largeMemory()
- lowLatencyMemory()
- highBandwidthMemory()

They have been removed from chapelLocale and the individual locale model implementations.