### PR TITLE
Exempt field access from outside data check

### DIFF
--- a/test/gpu/native/callBuildTupleFunc.chpl
+++ b/test/gpu/native/callBuildTupleFunc.chpl
@@ -1,0 +1,16 @@
+use GPUDiagnostics;
+
+on here.gpus[0] {
+  startGPUDiagnostics();
+  var A : [0..0] (int,int);
+  forall i in 0..0 {
+    A[0] = createTuple();
+  }
+  stopGPUDiagnostics();
+  writeln(getGPUDiagnostics());
+  writeln("A = ", A);
+
+  proc createTuple() {
+    return (123,456);
+  }
+}

--- a/test/gpu/native/callBuildTupleFunc.good
+++ b/test/gpu/native/callBuildTupleFunc.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+(kernel_launch = 1)
+A = (123, 456)


### PR DESCRIPTION
A loop is not considered "gpuizable" if it calls a function where that function accesses an "outside" variable.  This check previously considered any field access to be outside. This commit fixes that.

This should fix: https://github.com/chapel-lang/chapel/issues/20293
