### PR TITLE
Update mason documentation and recommend submodules

### DIFF
--- a/doc/rst/mason-packages/guide/buildingandrunning.rst
+++ b/doc/rst/mason-packages/guide/buildingandrunning.rst
@@ -1,5 +1,7 @@
 :title: Mason Guide: *Building and Running*
 
+.. _building-and-running:
+        
 Building and Running
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -8,7 +10,8 @@ When invoked, ``mason build [ options ]`` will do the following:
     - Run update to make sure any manual manifest edits are reflected in the dependency code.
     - Build ``MyPackage.chpl`` in the ``src/`` directory.
     - All packages are compiled into binaries and placed into ``target/``
-    - All options not recognized by ``mason`` will be forwarded to the chapel compiler(``chpl``)
+    - To forward options to the Chapel compiler(``chpl``), seperate them with a double dash
+       - e.g., mason build --force -- --savec tmpdir
 
 ``mason run [ options ]`` will, in turn:
 
@@ -35,7 +38,7 @@ For example, after ``mason run --build [ options ]``, the package directory appe
 As you can see, new files have been added to the package, the first of which
 is the ``Mason.lock``. You can think of this file as a snapshot of a single
 run of the program. This file "locks" in the settings in which the program
-ran upon invocation of ``mason run``. This file can be generated manually
+was built upon invocation of ``mason build``. This file can be generated manually
 with the ``mason update`` command. ``mason update`` will read the ``Mason.toml``,
 resolve dependencies, and generate the ``Mason.lock`` based on it's contents.
 
@@ -47,6 +50,10 @@ being produced, the ``--release`` flag can be thrown as follows:
 
 .. code-block:: sh
 
+   mason build --release --force
+   
+   OR
+   
    mason run --build --release --force
 
 The ``--release`` option adds the ``--fast`` argument to the compilation step.

--- a/doc/rst/mason-packages/guide/buildinglargerpackages.rst
+++ b/doc/rst/mason-packages/guide/buildinglargerpackages.rst
@@ -9,7 +9,7 @@ shares the name with the package directory and the name field in the ``Mason.tom
 While not recommended with mason libraries that are going to be added to the mason registry,
 passing a ``-M`` as outlined below can make building your mason application easier, but,
 for mason libraries, submodules should be used to avoid conflicting namespaces for users
-of your library (see `readme-module_include`_).
+of your library (see :ref:`readme-module_include`).
 
 For packages that span multiple sub-directories within ``src``, sub-directories must be passed
 to Mason with the ``-M  <src/subdirectory>`` flag which is forwarded to the chapel compiler. For example, lets say

--- a/doc/rst/mason-packages/guide/buildinglargerpackages.rst
+++ b/doc/rst/mason-packages/guide/buildinglargerpackages.rst
@@ -6,6 +6,10 @@ Building Larger Packages
 For packages that span multiple files, the main module is designated by the module that
 shares the name with the package directory and the name field in the ``Mason.toml``.
 
+While not recommended with mason libraries that are going to be added to the mason registry,
+passing a ``-M`` as outlined below can make building your mason application easier, but,
+for mason libraries, submodules should be used to avoid conflicting namespaces for users
+of your library (see `readme-module_include`_).
 
 For packages that span multiple sub-directories within ``src``, sub-directories must be passed
 to Mason with the ``-M  <src/subdirectory>`` flag which is forwarded to the chapel compiler. For example, lets say

--- a/doc/rst/mason-packages/guide/chapeldependencies.rst
+++ b/doc/rst/mason-packages/guide/chapeldependencies.rst
@@ -27,3 +27,5 @@ To add a Chapel dependency without editing the ``Mason.toml`` manually, use the 
 command as follows::
 
   mason add MatrixMarket@0.1.0
+
+For example usage of a mason package, see :ref:`using-a-package`.

--- a/doc/rst/mason-packages/guide/chapeldependencies.rst
+++ b/doc/rst/mason-packages/guide/chapeldependencies.rst
@@ -28,4 +28,4 @@ command as follows::
 
   mason add MatrixMarket@0.1.0
 
-For example usage of a mason package, see :ref:`using-a-package`.
+For example usage of a Mason package, see :ref:`using-a-package`.

--- a/doc/rst/mason-packages/guide/examples.rst
+++ b/doc/rst/mason-packages/guide/examples.rst
@@ -1,5 +1,7 @@
 :title: Mason Guide: *Examples*
 
+.. _mason-examples:
+        
 Creating and Running Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/rst/mason-packages/guide/externaldependencies.rst
+++ b/doc/rst/mason-packages/guide/externaldependencies.rst
@@ -81,13 +81,9 @@ Using Spack Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mason users can interface with ``Spack``, a package manager geared towards high performance
-computing. Through this integration, Mason users now have
-access to a large ecosystem of `packages <https://spack.readthedocs.io/en/latest/package_list.html#package-list>`_.
-Non-destructive installs, custom version and configurations, and simple package installation
-and uninstallation are a few of the features Mason gains through this integration.
+computing, through the ``mason external`` command. For a list of available ``Spack`` packages,
+see: `packages <https://spack.readthedocs.io/en/latest/package_list.html#package-list>`_.
 
-Mason users can access Spack through the ``mason external`` command. Spack provides Mason users with the ability
-to install and use any package in the `Spack registry <https://spack.readthedocs.io/en/latest/package_list.html#package-list>`_.
 This interface is analogous to the previous example except when a package is missing, user's can download that package
 through the Spack integration. The following is a workflow of finding, installing, and adding a Spack dependency to a Mason Package.
 

--- a/doc/rst/mason-packages/guide/gitdependencies.rst
+++ b/doc/rst/mason-packages/guide/gitdependencies.rst
@@ -25,9 +25,9 @@ To specify a different branch, the ``branch`` key can be used:
     [dependencies]
     HelloWorld = { git = "https://github.com/bmcdonald3/HelloWorld", branch = "test-branch" }
 
-When you have only a ``branch`` specified and not a ``rev``, your first run of ``mason build`` will lock in the revision in the ``Mason.lock`` file and will continue to use that revision until the ``mason update`` command is executed. The ``mason update`` command will fetch the latest changes and then update the revision used to the current tip of the specified ``branch``.
+When a ``branch`` tag is specified, your first run of ``mason build`` will lock in the revision in the ``Mason.lock`` file and will continue to use that revision until the ``mason update`` command is executed. The ``mason update`` command will fetch the latest changes and then update the revision used to the current tip of the specified ``branch``.
 
-If you would like to lock in a specific revision that should not be updated, a specific revision can be specified for your git dependency with the ``rev`` tag:
+If you would like to lock in a specific revision that should not be updated, a specific revision can be specified for your git dependency by explicitly specifying a ``rev`` tag, and this revision will never be modified by any mason command:
 
 .. code-block:: text
 

--- a/doc/rst/mason-packages/guide/gitdependencies.rst
+++ b/doc/rst/mason-packages/guide/gitdependencies.rst
@@ -36,3 +36,13 @@ If you would like to lock in a specific revision that should not be updated, a s
     HelloWorld = { git = "https://github.com/bmcdonald3/HelloWorld", rev = "43d462682851dd2fed6edf123e8fb699db124183" }
                 
 Now, when running ``mason build`` or ``mason update``, the latest changes will be fetched from the repository, but the commit specified by ``rev`` will always be checked out and never changed by mason.
+
+The examples above have used the inline subtable syntax to format the git dependency. Git dependencies can also be specified with subtable syntax and mason commands that modify the ``Mason.toml`` file may reformat dependencies to be of this format:
+
+.. code-block:: text
+
+
+    [dependencies.HelloWorld]
+    git = "https://github.com/bmcdonald3/HelloWorld"
+
+

--- a/doc/rst/mason-packages/guide/gitdependencies.rst
+++ b/doc/rst/mason-packages/guide/gitdependencies.rst
@@ -1,5 +1,7 @@
 :title: Mason Guide: *Git Dependencies*
 
+.. _mason-git-dependencies:
+
 Specifying Dependencies from `git` Repositories
 ===============================================
 To depend on a library located in a git repository, a git key pointing to the repository URL is all that is required:
@@ -13,7 +15,9 @@ To depend on a library located in a git repository, a git key pointing to the re
 
 The repository that is specified must be a mason package itself, but it does not need to be contained in a mason registry.
 
-Without specifying the branch to be used, a default branch of `master` will be assumed and if there is no master branch, the dependency will not work. To specify a different branch, the `branch` key can be used:
+Without specifying the branch to be used, mason will default to a usage of the project ``HEAD``. After the first run of ``mason build``, the revision will be locked in and continuously reused until a ``mason update`` command is run. Then, the latest changes will be fetched and the revision will be updated in the ``Mason.lock`` file and used until the next run of ``mason update``. Executing the ``mason build`` command will not update the revision in ``Mason.lock``.
+
+To specify a different branch, the ``branch`` key can be used:
 
 .. code-block:: text
 
@@ -21,9 +25,14 @@ Without specifying the branch to be used, a default branch of `master` will be a
     [dependencies]
     HelloWorld = { git = "https://github.com/bmcdonald3/HelloWorld", branch = "test-branch" }
 
+When you have only a ``branch`` specified and not a ``rev``, your first run of ``mason build`` will lock in the revision in the ``Mason.lock`` file and will continue to use that revision until the ``mason update`` command is executed. The ``mason update`` command will fetch the latest changes and then update the revision used to the current tip of the specified ``branch``.
 
-Now, when running `mason build` or `mason update`, the latest changes from the repository will be pulled.
+If you would like to lock in a specific revision that should not be updated, a specific revision can be specified for your git dependency with the ``rev`` tag:
 
-.. note::
-   
-   Currently, the manifest file from git repository dependencies are not checked, so any essential information there will need to be manually copied into the `Mason.toml` from the repository using the dependency. This is currently a work in progress and will hopefully be fixed in the near future. Additionally, locking in the revision at the time of specification and allowing specific revisions to be specified are also works in progress.
+.. code-block:: text
+
+
+    [dependencies]
+    HelloWorld = { git = "https://github.com/bmcdonald3/HelloWorld", rev = "43d462682851dd2fed6edf123e8fb699db124183" }
+                
+Now, when running ``mason build`` or ``mason update``, the latest changes will be fetched from the repository, but the commit specified by ``rev`` will always be checked out and never changed by mason.

--- a/doc/rst/mason-packages/guide/namespacing.rst
+++ b/doc/rst/mason-packages/guide/namespacing.rst
@@ -6,3 +6,10 @@ Namespacing
 All mason packages will exist in a single common namespace with a first-come, first-served policy.
 It is easier to go to separate namespaces than to roll them back, so this position affords
 flexibility.
+
+It is expected that all accessible symbols should be made available with an include of the single
+module at ``src/package-name.chpl``. To facilitate the use of multiple Chapel modules in a single
+Chapel module, it is suggested to use Chapel submodules (see `readme-module_include`_).
+
+Expecting users to use ``-M`` of a mason package is not recommended as this can cause conflicting
+namespaces that would otherwise be avoided by the mason registry requirements.

--- a/doc/rst/mason-packages/guide/namespacing.rst
+++ b/doc/rst/mason-packages/guide/namespacing.rst
@@ -9,7 +9,7 @@ flexibility.
 
 It is expected that all accessible symbols should be made available with an include of the single
 module at ``src/package-name.chpl``. To facilitate the use of multiple Chapel modules in a single
-Chapel module, it is suggested to use Chapel submodules (see `readme-module_include`_).
+Chapel module, it is suggested to use Chapel submodules (see :ref:`readme-module_include`).
 
 Expecting users to use ``-M`` of a mason package is not recommended as this can cause conflicting
 namespaces that would otherwise be avoided by the mason registry requirements.

--- a/doc/rst/mason-packages/guide/testing.rst
+++ b/doc/rst/mason-packages/guide/testing.rst
@@ -1,5 +1,7 @@
 :title: Mason Guide: *Testing*
 
+.. _testing-with-mason:
+        
 Testing your Package
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/rst/mason-packages/index.rst
+++ b/doc/rst/mason-packages/index.rst
@@ -40,6 +40,7 @@ packages in your own code.
 
    start/installation
    start/helloworld
+   start/whymason
 
 
 .. _index-mason-guide:

--- a/doc/rst/mason-packages/start/helloworld.rst
+++ b/doc/rst/mason-packages/start/helloworld.rst
@@ -1,5 +1,7 @@
 :title: Mason Guide: *Hello World*
 
+.. _using-a-package:
+        
 Using a Mason Package
 =====================
 
@@ -19,9 +21,9 @@ while keeping our directory structure nice and clean.
 
   .. code-block:: sh
 
-    mkdir HelloPackage
+
+    mason new HelloPackage
     cd HelloPackage
-    mason init
 
 At this point, mason will start prompting you for some basic information about
 your package. Since this package is just for getting started, all that you need

--- a/doc/rst/mason-packages/start/helloworld.rst
+++ b/doc/rst/mason-packages/start/helloworld.rst
@@ -46,7 +46,7 @@ package. Let's signal to mason that we would like to install that package:
 
   .. code-block:: sh
 
-    mason add HelloWorld@1.0.0
+    mason add HelloWorld@0.1.0
 
 This will add the ``HelloWorld`` package to our ``Mason.toml`` file as a
 dependency (you can open the ``Mason.toml`` file to see the change).

--- a/doc/rst/mason-packages/start/whymason.rst
+++ b/doc/rst/mason-packages/start/whymason.rst
@@ -4,7 +4,7 @@ Why would I want to use mason?
 ==============================
 
 So, you want to write some Chapel code and find yourself asking if it would
-make sense to use or if it would just end up adding needless overhead to your
+make sense to use mason or if it would just end up adding needless overhead to your
 project in the long run. Here's an answer for you: Yes! You should use mason!
 
 Using mason brings with it a number of valuable features that are not available
@@ -12,13 +12,13 @@ to users of the old-fashioned ``chpl`` command. Some of these are:
 
 * access to libraries contributed by the Chapel community (see :ref:`using-a-package`)
   
-* portable, easy build commands (see :ref:`building-and-running`)
+* portable, simple build commands (see :ref:`building-and-running`)
   
-* an existing testing framework to help test your code (see :ref:`testing-with-mason`)
+* a built-in testing framework to help test your code (see :ref:`testing-with-mason`)
   
 * make your code easily shareable on GitHub (see :ref:`mason-git-dependencies`)
   
-* contribute your own libraries to the existing mason registry (see :ref:`submit-a-package`)
+* contribute your own libraries and help the Chapel community grow (see :ref:`submit-a-package`)
   
 
 So, you see, a better question would be "Why not use mason?" instead of "Why use mason?"
@@ -48,57 +48,62 @@ themselves.
 
 When you create a mason application with ``mason new <package-name>`` or
 ``mason new <package-name> --app``, the default module created will have a ``main()`` function
-already in place. This is what drives your application and where the execution will happen from.
-This ``main()`` function is unique to the mason application mason applications are the only type
-of mason packages that can be ran via ``mason run``.
+already in place. This is what drives your application and where the execution will start.
+This ``main()`` function is unique to the mason application package type and makes it the only
+type of mason package that can be ran via ``mason run``.
 
 When compiling Chapel code, there can only be one ``main()`` function (or you will need to use the
-``--main-module`` flag to specify which one to run). What this means for mason applications is that
-that they are not designed to be imported into other code and have functions included in the
-application be run by other applications. Because of this, mason applications published to the mason
-registry can be downloaded, built, and run by running the ``mason install <application-name>`` command
-(which is currently a work in progress), but they cannot be added as a dependency with the
-``mason add <library-name@version>`` command. If you would like to create a library with functions
-to be exposed to other users, the mason library is what you are looking for.
+``--main-module`` flag to specify which one to run). This means that mason application package
+types are not meant to be used as dependencies for other mason packages and cannot be added as a
+dependency with the ``mason add <library-name@version>`` command. Rather, mason applications published
+to the mason registry can be downloaded, built, and run using the mason install <application-name>
+command (which is currently a work in progress). If you would like to create a library with functions
+to be exposed to other users, the mason library is what you are looking for (see :ref:`mason-libraries`).
 
 Some examples of when you would want to use a mason application as opposed to one of the other
 types are a benchmark that you would like others to be able to compile and execute in a reproducible
 way, an application that simulates the weather, or just about anywhere you have a cool program that
 you would like to share.
 
+.. _mason-libraries:
 
 Mason Libraries
 ~~~~~~~~~~~~~~~
 A mason library is meant to be a module that contains functions that are to be made accessible
 to other users. Mason libraries do not have a ``main()`` function and cannot be run with the
-``mason run`` command, but can be run through examples.
+``mason run`` command, but Mason library code can be executed through examples
+(see :ref:`mason-examples`).
 
-When you create a mason library with ``mason new <package-name> --lib``, the default module
-created will not have a ``main()`` function and will just be an empty module. In this module
-functions can be defined that other users can use.
+To start writing your own mason library, use the ``mason new <package-name> --lib`` command and
+mason will create an empty default module. Inside the empty module you can define the
+functions your library will provide to its users.
 
-Some examples of when you would want to use a mason library as opposed to one of the other
-types include adding a linear algebra library that could be useful to other users or for just
-about any set of functions that other users of Chapel may find useful.
+Some examples of when you would want to create a mason library as opposed to an application are:
+
+* You want to provide a linear algebra library for other Chapel programs
+
+* You have multiple Chapel projects that depend on a common set of functionality you wish to centralize
+  
+* You found some functionality missing from Chapel, and think others could benefit from your solution
 
 
 Mason Lightweight Projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-A mason lightweight project is nothing than a mason manifest file that can track dependencies
-of mason packages that your project is using without being forced into the confines of a
-mason project structure, like you would be with a mason library or mason application. This
-means that you cannot use most of the mason commands, such as ``mason build`` or ``mason run``,
-but you can use mason libraries and get the compilation flags for using those libraries
-through the ``mason modules`` command.
+A mason lightweight project is simply a mason manifest file that tracks which mason packages your
+Chapel code depends on. This gives all Chapel users the ability to use mason libraries
+as dependencies, without forcing your project to use the folder structure defined for mason packages.
 
-When you create a lightweight mason project with ``mason new --light``, all that is created
-is a ``Mason.toml`` file in the current directory. Dependencies can then be added to that
-file as you would with any other mason project, using the ``mason add <package-name@ver>``
-command or specifying a git dependency.
+Lightweight packages cannot use most mason commands, such as ``mason build`` or ``mason run``, but a special
+``mason modules`` command allows you to get the ``chpl`` compiler flags necessary to include the list of
+dependencies in your Chapel project.
 
-Once dependencies are added to the ``Mason.toml`` that you would like to use, running a
-``mason modules`` command will print out the flags that should be added to your ``chpl``
-compilation step to use those libraries in your project.
+When you run the ``mason new --light`` command to create a lightweight package, mason creates a basic
+``Mason.toml`` file in the current directory. You can add dependencies to that file by using the
+``mason add <package-name@ver>`` command or specifying a git dependency (see :ref:`mason-git-dependencies`),
+the same as you would for other mason package types.
+
+After adding your project's dependencies to the ``Mason.toml`` file, use the ``mason modules`` command to
+print out the flags that should be added to your build system's chpl compilation step.
 
 The main reason you would use a lightweight mason project as opposed to one of the other
 types of mason project types would be in the case that you already have a project that is

--- a/doc/rst/mason-packages/start/whymason.rst
+++ b/doc/rst/mason-packages/start/whymason.rst
@@ -1,0 +1,108 @@
+:title: Mason Guide: *Why mason?*
+        
+Why would I want to use mason?
+==============================
+
+So, you want to write some Chapel code and find yourself asking if it would
+make sense to use or if it would just end up adding needless overhead to your
+project in the long run. Here's an answer for you: Yes! You should use mason!
+
+Using mason brings with it a number of valuable features that are not available
+to users of the old-fashioned ``chpl`` command. Some of these are:
+
+* access to libraries contributed by the Chapel community (see :ref:`using-a-package`)
+  
+* portable, easy build commands (see :ref:`building-and-running`)
+  
+* an existing testing framework to help test your code (see :ref:`testing-with-mason`)
+  
+* make your code easily shareable on GitHub (see :ref:`mason-git-dependencies`)
+  
+* contribute your own libraries to the existing mason registry (see :ref:`submit-a-package`)
+  
+
+So, you see, a better question would be "Why not use mason?" instead of "Why use mason?"
+
+The Three Modes of Mason
+========================
+
+Now, having answered the "why" of mason, let's get into the "how".
+
+There are three distinct types of mason packages:
+
+#. mason applications
+#. mason libraries
+#. mason lightweight projects
+
+Each of these types of mason packages serve different purposes and, to use mason effectively,
+it helps to know what each type has been designed for.
+
+
+Mason Applications
+~~~~~~~~~~~~~~~~~~
+A mason application, which is the default type of mason package, is meant to be a self-contained,
+executable, full application. What this means is that a mason application will have a main
+module and expect to be built and run as a standalone application, as opposed to being only a
+library that contains functions that are valuable to users, but you wouldn't want to run by
+themselves.
+
+When you create a mason application with ``mason new <package-name>`` or
+``mason new <package-name> --app``, the default module created will have a ``main()`` function
+already in place. This is what drives your application and where the execution will happen from.
+This ``main()`` function is unique to the mason application mason applications are the only type
+of mason packages that can be ran via ``mason run``.
+
+When compiling Chapel code, there can only be one ``main()`` function (or you will need to use the
+``--main-module`` flag to specify which one to run). What this means for mason applications is that
+that they are not designed to be imported into other code and have functions included in the
+application be run by other applications. Because of this, mason applications published to the mason
+registry can be downloaded, built, and run by running the ``mason install <application-name>`` command
+(which is currently a work in progress), but they cannot be added as a dependency with the
+``mason add <library-name@version>`` command. If you would like to create a library with functions
+to be exposed to other users, the mason library is what you are looking for.
+
+Some examples of when you would want to use a mason application as opposed to one of the other
+types are a benchmark that you would like others to be able to compile and execute in a reproducible
+way, an application that simulates the weather, or just about anywhere you have a cool program that
+you would like to share.
+
+
+Mason Libraries
+~~~~~~~~~~~~~~~
+A mason library is meant to be a module that contains functions that are to be made accessible
+to other users. Mason libraries do not have a ``main()`` function and cannot be run with the
+``mason run`` command, but can be run through examples.
+
+When you create a mason library with ``mason new <package-name> --lib``, the default module
+created will not have a ``main()`` function and will just be an empty module. In this module
+functions can be defined that other users can use.
+
+Some examples of when you would want to use a mason library as opposed to one of the other
+types include adding a linear algebra library that could be useful to other users or for just
+about any set of functions that other users of Chapel may find useful.
+
+
+Mason Lightweight Projects
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+A mason lightweight project is nothing than a mason manifest file that can track dependencies
+of mason packages that your project is using without being forced into the confines of a
+mason project structure, like you would be with a mason library or mason application. This
+means that you cannot use most of the mason commands, such as ``mason build`` or ``mason run``,
+but you can use mason libraries and get the compilation flags for using those libraries
+through the ``mason modules`` command.
+
+When you create a lightweight mason project with ``mason new --light``, all that is created
+is a ``Mason.toml`` file in the current directory. Dependencies can then be added to that
+file as you would with any other mason project, using the ``mason add <package-name@ver>``
+command or specifying a git dependency.
+
+Once dependencies are added to the ``Mason.toml`` that you would like to use, running a
+``mason modules`` command will print out the flags that should be added to your ``chpl``
+compilation step to use those libraries in your project.
+
+The main reason you would use a lightweight mason project as opposed to one of the other
+types of mason project types would be in the case that you already have a project that is
+built out and has its own well-defined build process that uses something like a ``Makefile``
+to handle building, so you just want to use some mason packages without having to corral
+your directory structure to fit the requirements of a mason application.
+


### PR DESCRIPTION
This PR updates the mason documentation, adding sections explaining
why there is value in using mason and explaining the three different
types of mason packages.

Also, many general improvements have been made, including suggesting
submodules and discouraging use of the `-M` flag in mason packages.
Git dependency documentation is updated alongside many other small
rewords and improvements.