### PR TITLE
Revert the countDeadModules test

### DIFF
--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 27 dead modules.
+Removed 26 dead modules.


### PR DESCRIPTION
I bumped up the number this test reports earlier in my work, but then, the
subsequent changes might have stopped the `Communication` module from being
used/eliminated. This PR reverts the count.

[Trivial, not reviewed]

Test passes with this PR.
