### PR TITLE
Do not gpuize call to atomic_init_bool

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -287,6 +287,10 @@ bool GpuizableLoop::callsInBodyAreGpuizableHelp(BlockStmt* blk,
 
       FnSymbol* fn = call->resolvedFunction();
 
+      if (fn->hasFlag(FLAG_NO_GPU_CODEGEN)) {
+        return false;
+      }
+
       if (hasOuterVarAccesses(fn))
         return false;
 

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -226,6 +226,7 @@ module Atomics {
     proc init_helper(value:bool) {
       pragma "fn synchronization free"
       pragma "local fn" pragma "fast-on safe extern function"
+      pragma "no gpu codegen"
       extern externFunc("init", bool, explicit=false)
         proc atomic_init(ref obj:externT(bool), value:bool): void;
 
@@ -417,6 +418,7 @@ module Atomics {
     proc init_helper(value:T) {
       pragma "fn synchronization free"
       pragma "local fn" pragma "fast-on safe extern function"
+      pragma "no gpu codegen"
       extern externFunc("init", T, explicit=false)
         proc atomic_init(ref obj:externT(T), value:T): void;
 


### PR DESCRIPTION
This should resolve this failure: https://chapel.discourse.group/t/cron-cray-cs-gpu-native/14597

Basically with https://github.com/chapel-lang/chapel/pull/20342 (Exempt field access from outside data check) we end up trying to gpuize more module code and some of that code ends up calling an extern (atomic_init_bool) that we don't have a device version of.

Long term we might want to cerate a proper device version of the function but in the short term I think it makes sense to just say we don't care to gpuize anything that calls out to that function.

To do this I've applied atomic_init_bool to where we declare the extern in the module code and broadened the definition of the "no gpu codegen" pragma to mean "don't gpuize anything that calls this function" in addition to "don't gpuize any loops in this function"