### PR TITLE
GPU Kernel Conditional Statement Bug Fix

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -605,6 +605,13 @@ void GpuKernel::populateBody(CForLoop *loop, FnSymbol *outlinedFunction) {
             else {
               INT_FATAL("Unexpected call expression");
             }
+          } else if (CondStmt* cond = toCondStmt(symExpr->parentExpr)) {
+            // Parent is a conditional statement.
+            if (symExpr == cond->condExpr) {
+              addKernelArgument(sym);
+            }
+          } else {
+            INT_FATAL("Unexpected symbol expression");
           }
         }
       }

--- a/test/gpu/native/innerBlock.chpl
+++ b/test/gpu/native/innerBlock.chpl
@@ -60,6 +60,22 @@ on here.getChild(1) {
   writeArr(A);
 
 }
+
+// Create test for arg bug
+on here.gpus[0] {
+  var A = [1,2,3,4,5];
+  var outerVar = true;
+
+    forall a in A {
+      if outerVar then
+        a += 1;
+      else
+        a -= 1;
+    }
+
+  writeArr(A);
+}
+
 stopGPUDiagnostics();
 
 writeln(getGPUDiagnostics());

--- a/test/gpu/native/innerBlock.chpl
+++ b/test/gpu/native/innerBlock.chpl
@@ -61,17 +61,16 @@ on here.getChild(1) {
 
 }
 
-// Create test for arg bug
 on here.gpus[0] {
   var A = [1,2,3,4,5];
   var outerVar = true;
 
-    forall a in A {
-      if outerVar then
-        a += 1;
-      else
-        a -= 1;
-    }
+  forall a in A {
+    if outerVar then
+      a += 1;
+    else
+      a -= 1;
+  }
 
   writeArr(A);
 }

--- a/test/gpu/native/innerBlock.good
+++ b/test/gpu/native/innerBlock.good
@@ -3,4 +3,5 @@ Array: 151 152 153 154 155
 Array: 151 152 153 154 155 
 Array: 151 152 153 154 155 
 Array: -29 -28 -27 -26 -25 
-(kernel_launch = 4)
+Array: 2 3 4 5 6 
+(kernel_launch = 5)


### PR DESCRIPTION
Fixing a bug in the compiler where if a GPUizable loop has a conditional statement whose expression comes from outside the loop, we do not add it as a argument to the code generated for the kernel.

Added conditions in `gpuTransforms.cpp` so that it adds that expression as a kernel argument.

Also added a catch-all `else` block that causes an error if there happen to be any other such cases where we forget to add a compiler argument.

Added a test which fails on main but passes with this fix.

- [X] Local test
- [ ] Paratests 