### PR TITLE
Fix typos

### DIFF
--- a/compiler/dyno/include/chpl/resolution/scope-types.h
+++ b/compiler/dyno/include/chpl/resolution/scope-types.h
@@ -330,7 +330,7 @@ class VisibilitySymbols {
     ALL_CONTENTS,
     /** only the contents of the scope named in names */
     ONLY_CONTENTS,
-    /** contexnts of the scope except the contents named in names
+    /** contents of the scope except the contents named in names
         (no renaming) */
     CONTENTS_EXCEPT,
   };

--- a/compiler/dyno/lib/types/EnumType.cpp
+++ b/compiler/dyno/lib/types/EnumType.cpp
@@ -41,4 +41,4 @@ void EnumType::stringify(std::ostream& ss, StringifyKind stringKind) const {
 }
 
 } // end namespace types
-} // end namesapce chpl
+} // end namespace chpl

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1759,7 +1759,7 @@ int main(int argc, char** argv) {
 
     // TODO: Change which query we use to parse files as suggested by @mppf
     // parseFileContainingIdToBuilderResult(Context* context, ID id);
-    // and then work with the module ID to find the preceeding comment.
+    // and then work with the module ID to find the preceding comment.
     const BuilderResult& builderResult = parseFileToBuilderResult(ctx,
                                                                   path,
                                                                   emptyParent);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -687,7 +687,7 @@ public:
 
 /* This type exists to be used temporarily during convert-uast.
    By using this type, convert-uast code can robustly handle
-   AST copies from an AST node refering to something not yet converted.
+   AST copies from an AST node referring to something not yet converted.
    */
 class TemporaryConversionSymbol final : public Symbol {
 public:

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3882,7 +3882,7 @@ void Converter::noteAllContainedFixups(BaseAST* ast, int depth) {
   // this to be quadratic in time.
   //
   // Gather the fixups that need to be done.
-  // This is a separate traversal so that the build functios
+  // This is a separate traversal so that the build functions
   // can copy the AST freely.
 
   if (depth > 0) {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3247,7 +3247,7 @@ module ChapelArray {
   pragma "no copy returns owned"
   pragma "ignore transfer errors"
   // This function has foralls that have PRIM_ASSIGN in them. They are typically
-  // subject to normalization and as part of gpuization we create temproraries
+  // subject to normalization and as part of gpuization we create temporaries
   // for those primitive calls. But those temporaries don't get resolved. I
   // imagine we'll need to have this function work on GPUs, or be callable from
   // GPUs. So, we'll need to fix that.

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -556,7 +556,7 @@ module ChapelRange {
   }
 
 
-  /* Returns true if this range's high bound is *not* :math:`infty`,
+  /* Returns true if this range's high bound is *not* :math:`\infty`,
      and false otherwise */
   proc range.hasHighBound() param
     return boundedType == BoundedRangeType.bounded ||

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -3470,7 +3470,7 @@ module BigInteger {
 
   /*
    An `InversionError` is thrown if a :proc:`bigint.invert()` is attempted with
-   invalid arguments that result in a non-existant inverse. Specifically,
+   invalid arguments that result in a non-existent inverse. Specifically,
    if the arguments cause a divide by zero, this error notifies the caller
    that the internal value of the :record:`bigint` was left in an undefined state.
    */

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4108,7 +4108,7 @@ proc channel.readline(ref arg: ?t): bool throws where t==string || t==bytes {
 // Does not validate that the string has valid encoding -- the call
 // site should do that.
 // Assumes we are already on the locale with the channel and that
-// it is alrady locked.
+// it is already locked.
 private proc readStringBytesData(ref s /*: string or bytes*/,
                                  _channel_internal:qio_channel_ptr_t,
                                  nBytes: int,
@@ -4254,7 +4254,7 @@ proc channel.readLine(ref b: bytes,
     var err: syserr = ENOERR;
     var foundNewline = false;
     while !foundNewline {
-      // read a sigle byte
+      // read a single byte
       got = qio_channel_read_byte(false, this._channel_internal);
       if got == -EEOF {
         // encountered EOF

--- a/test/release/examples/primers/ranges.chpl
+++ b/test/release/examples/primers/ranges.chpl
@@ -350,7 +350,7 @@ writeln();
 // * ``stridable``: A ``bool`` indicating whether or not the range can have a stride other than 1 (defaults to ``false``)
 //
 // Like other variables, range types can be inferred by the compiler
-// from the initializing expression for simpicity, as in the previous
+// from the initializing expression for simplicity, as in the previous
 // examples.  However, they can also be specified if desired.  Here
 // are some examples that are equivalent to ones we've seen before:
 //


### PR DESCRIPTION
Fix typos in
scope-types.h, EnumType.cpp, chpldoc.cpp, symbol.h, convert-uast.cpp,
ChapelArray.chpl, ChapelRange.chpl, BigInteger, IO.chpl, ranges primer.