### PR TITLE
Make a prediff more portable

### DIFF
--- a/test/library/standard/Communication/errors.prediff
+++ b/test/library/standard/Communication/errors.prediff
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed "s/\(errors\.chpl\):[[:digit:]]\+/\1:PREDIFFED_LINENO/" $2 > $2.prediffed
-sed "s/\(locale ID (\)[[:digit:]]\+/\1PREDIFFED_LOCALEID/" $2.prediffed > $2
+sed -r "s/errors\.chpl:[0-9]+/errors.chpl:PREDIFFED_LINENO/" $2 > $2.prediffed
+sed -r "s/locale ID \([0-9]+/locale ID (PREDIFFED_LOCALEID/" $2.prediffed > $2


### PR DESCRIPTION
This prediff was failing on darwin. Use `-r` and more general regex.