### PR TITLE
Changing graph legend for Triad

### DIFF
--- a/test/gpu/native/studies/shoc/bandwidth.graph
+++ b/test/gpu/native/studies/shoc/bandwidth.graph
@@ -2,4 +2,4 @@ perfkeys: TriadBdwth BlckSz:    64KB Median:, TriadBdwth BlckSz:    64KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat
 graphkeys: Transliteration, NoSliceLHS, NoSlice
 ylabel: Bandwidth (GB/s)
-graphtitle: Triad Bandwidth - 64KB
+graphtitle: SHOC Triad - Bandwidth - 64KB

--- a/test/gpu/native/studies/shoc/bandwidth.graph
+++ b/test/gpu/native/studies/shoc/bandwidth.graph
@@ -1,5 +1,5 @@
 perfkeys: TriadBdwth BlckSz:    64KB Median:, TriadBdwth BlckSz:    64KB Median:, TriadBdwth BlckSz:    64KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat
-graphkeys: Triad, TriadAlt1, TriadAlt2
+graphkeys: Transliteration, NoSliceLHS, NoSlice
 ylabel: Bandwidth (GB/s)
 graphtitle: Triad Bandwidth - 64KB

--- a/test/gpu/native/studies/shoc/bandwidth2.graph
+++ b/test/gpu/native/studies/shoc/bandwidth2.graph
@@ -2,4 +2,4 @@ perfkeys: TriadBdwth BlckSz: 16384KB Median:, TriadBdwth BlckSz: 16384KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat, triadchpl.dat
 graphkeys: Transliteration, NoSliceLHS, NoSlice, Idiomatic
 ylabel: Bandwidth (GB/s)
-graphtitle: Triad Bandwidth - 16384KB
+graphtitle: SHOC Triad - Bandwidth - 16384KB

--- a/test/gpu/native/studies/shoc/bandwidth2.graph
+++ b/test/gpu/native/studies/shoc/bandwidth2.graph
@@ -1,5 +1,5 @@
 perfkeys: TriadBdwth BlckSz: 16384KB Median:, TriadBdwth BlckSz: 16384KB Median:, TriadBdwth BlckSz: 16384KB Median:, TriadBdwth BlckSz: 16384KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat, triadchpl.dat
-graphkeys: Triad, TriadAlt1, TriadAlt2, TriachChpl
+graphkeys: Transliteration, NoSliceLHS, NoSlice, Idiomatic
 ylabel: Bandwidth (GB/s)
 graphtitle: Triad Bandwidth - 16384KB

--- a/test/gpu/native/studies/shoc/kernel.graph
+++ b/test/gpu/native/studies/shoc/kernel.graph
@@ -1,5 +1,5 @@
 perfkeys: Kernel Time BlckSz:    64KB Median:, Kernel Time BlckSz:    64KB Median:, Kernel Time BlckSz:    64KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat
-graphkeys: Triad, TriadAlt1, TriadAlt2
+graphkeys: Transliteration, NoSliceLHS, NoSlice
 ylabel: Time (s)
 graphtitle: Kernel Time - 64KB

--- a/test/gpu/native/studies/shoc/kernel.graph
+++ b/test/gpu/native/studies/shoc/kernel.graph
@@ -2,4 +2,4 @@ perfkeys: Kernel Time BlckSz:    64KB Median:, Kernel Time BlckSz:    64KB Media
 files: triad.dat, triadalt1.dat, triadalt2.dat
 graphkeys: Transliteration, NoSliceLHS, NoSlice
 ylabel: Time (s)
-graphtitle: Kernel Time - 64KB
+graphtitle: SHOC Triad - Kernel Time - 64KB

--- a/test/gpu/native/studies/shoc/kernel2.graph
+++ b/test/gpu/native/studies/shoc/kernel2.graph
@@ -1,5 +1,5 @@
 perfkeys: Triad Time BlckSz: 16384KB Median:, Triad Time BlckSz: 16384KB Median:, Triad Time BlckSz: 16384KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat
-graphkeys: Triad, TriadAlt1, TriadAlt2
+graphkeys: Transliteration, NoSliceLHS, NoSlice
 ylabel: Time (s)
 graphtitle: Kernel Time - 16384KB

--- a/test/gpu/native/studies/shoc/kernel2.graph
+++ b/test/gpu/native/studies/shoc/kernel2.graph
@@ -2,4 +2,4 @@ perfkeys: Triad Time BlckSz: 16384KB Median:, Triad Time BlckSz: 16384KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat
 graphkeys: Transliteration, NoSliceLHS, NoSlice
 ylabel: Time (s)
-graphtitle: Kernel Time - 16384KB
+graphtitle: SHOC Triad - Kernel Time - 16384KB

--- a/test/gpu/native/studies/shoc/triad.graph
+++ b/test/gpu/native/studies/shoc/triad.graph
@@ -2,4 +2,4 @@ perfkeys: Triad Time BlckSz:    64KB Median:, Triad Time BlckSz:    64KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat
 graphkeys: Transliteration, NoSliceLHS, NoSlice
 ylabel: Time (s)
-graphtitle: Triad Time - 64KB
+graphtitle: SHOC Triad - Time - 64KB

--- a/test/gpu/native/studies/shoc/triad.graph
+++ b/test/gpu/native/studies/shoc/triad.graph
@@ -1,5 +1,5 @@
 perfkeys: Triad Time BlckSz:    64KB Median:, Triad Time BlckSz:    64KB Median:, Triad Time BlckSz:    64KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat
-graphkeys: Triad, TriadAlt1, TriadAlt2
+graphkeys: Transliteration, NoSliceLHS, NoSlice
 ylabel: Time (s)
 graphtitle: Triad Time - 64KB

--- a/test/gpu/native/studies/shoc/triad2.graph
+++ b/test/gpu/native/studies/shoc/triad2.graph
@@ -1,5 +1,5 @@
 perfkeys: Triad Time BlckSz: 16384KB Median:, Triad Time BlckSz: 16384KB Median:, Triad Time BlckSz: 16384KB Median:, Triad Time BlckSz: 16384KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat, triadchpl.dat
-graphkeys: Triad, TriadAlt1, TriadAlt2, TriachChpl
+graphkeys: Transliteration, NoSliceLHS, NoSlice, Idiomatic
 ylabel: Time (s)
 graphtitle: Triad Time - 16384KB

--- a/test/gpu/native/studies/shoc/triad2.graph
+++ b/test/gpu/native/studies/shoc/triad2.graph
@@ -2,4 +2,4 @@ perfkeys: Triad Time BlckSz: 16384KB Median:, Triad Time BlckSz: 16384KB Median:
 files: triad.dat, triadalt1.dat, triadalt2.dat, triadchpl.dat
 graphkeys: Transliteration, NoSliceLHS, NoSlice, Idiomatic
 ylabel: Time (s)
-graphtitle: Triad Time - 16384KB
+graphtitle: SHOC Triad - Time - 16384KB


### PR DESCRIPTION
Changing the labels of the different Triad versions as follows:

- TriachChpl -> Idiomatic
- Triad -> Transliteration
- Alt1 -> NoSliceLHS
- Alt2 -> NoSlice


Generated graphs before and after making the change on Osprey and viewed the `html` locally. Everything seems to be fine. Hopefully the hosted graphs are also fine.
