### PR TITLE
Change mason init to default to application

### DIFF
--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -322,7 +322,7 @@ proc validateMasonFile(path: string, name: string, show: bool) throws {
   }
   else {
     // TODO: update package to be either lib or whatever, not hardcode
-    makeBasicToml(name, path, "0.1.0", getChapelVersionStr(), "None", "package");
+    makeBasicToml(name, path, "0.1.0", getChapelVersionStr(), "None", "application");
     if show then writeln("Created Mason.toml file.");
   }
 }

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -363,7 +363,7 @@ proc makeSrcDir(path:string) {
 }
 
 /* Makes module file inside src/ */
-proc makeModule(path:string, fileName:string, packageType="package") {
+proc makeModule(path:string, fileName:string, packageType="application") {
   var libTemplate: string;
   if packageType == "application" {
     libTemplate = '/* Documentation for ' + fileName +

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -50,7 +50,7 @@ proc masonRun(args: [] string, checkProj=true) throws {
   if checkProj {
     const projectType = getProjectType();
     if projectType != "application" then
-      throw new owned MasonError("Only mason packages can be run, but this is a Mason " + projectType);
+      throw new owned MasonError("Only mason applications can be run, but this is a Mason " + projectType);
   }
 
   var show = showFlag.valueAsBool();


### PR DESCRIPTION
Mason init was incorrectly creating mason "packages", I had
apparently forgotten to update that name to application, so
this PR fixes that by changing the "package" references to
say application instead.