### PR TITLE
Fix some --verify errors with --no-local

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -2079,18 +2079,8 @@ static void fixAST() {
 
         if (Type* wide = wideClassMap.get(act->typeInfo())) {
           insertWideTemp(QualifiedType(QUAL_VAL, wide), act);
-        }
-        else if (Type* wide = wideRefMap.get(act->typeInfo())) {
-          insertWideTemp(QualifiedType(QUAL_WIDE_REF, wide), act);
         } else if (act->isRef()) {
-          Type* ty = act->typeInfo();
-          if (!ty->symbol->hasFlag(FLAG_REF))
-            ty = ty->refType;
-
-          Type* wide = wideRefMap.get(ty);
-          INT_ASSERT(wide);
-
-          insertWideTemp(QualifiedType(QUAL_WIDE_REF, wide), act);
+          insertWideTemp(QualifiedType(QUAL_WIDE_REF, act->typeInfo()), act);
         } else if (argMustUseCPtr(act->symbol()->type)) {
           // passing a non-ref thing, e.g. a record, to an arg expecting to be
           // given something by ref. This arg actually has the 'ref' kind,


### PR DESCRIPTION
The following tests were failing with ``--no-local --verify`` with an error complaining about the existence of ``_wide__ref`` types:
- deprecated/URL/depReaderWriter
- library/packages/canCompileNoLink/Curltest
- library/packages/canCompileNoLink/HDFStest

The solution is to not use the _ref type when creating wide temp for virtual method call.

Testing:
- [x] full local
- [x] full gasnet