### PR TITLE
Fix gasnet related gpu test failures

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2260,7 +2260,9 @@ void FnSymbol::codegenPrototype() {
   if (hasFlag(FLAG_EXTERN) && !hasFlag(FLAG_GENERATE_SIGNATURE)) return;
   if (hasFlag(FLAG_NO_CODEGEN))   return;
   if (gCodegenGPU == true) {
-    if (hasFlag(FLAG_GPU_CODEGEN) == false) return;
+    if (hasFlag(FLAG_GPU_AND_CPU_CODEGEN) == false &&
+       hasFlag(FLAG_GPU_CODEGEN) == false)
+      return;
   }
 
   if( id == breakOnCodegenID ||

--- a/compiler/dyno/include/chpl/uast/PragmaList.h
+++ b/compiler/dyno/include/chpl/uast/PragmaList.h
@@ -261,7 +261,7 @@ PRAGMA(GET_MODULE_NAME, ypr, "get module name", "replace calls to this function 
 PRAGMA(GLOBAL_TYPE_SYMBOL, ypr, "global type symbol", "is accessible through a global type variable")
 PRAGMA(GLOBAL_VAR_BUILTIN, ypr, "global var builtin", "is accessible through a global symbol variable")
 PRAGMA(GPU_CODEGEN, ypr, "codegen for GPU", "generate GPU code and set function calling convention to kernel launch")
-PRAGMA(GPU_AND_CPU_CODEGEN, npr, "", "generate both GPU and CPU code")
+PRAGMA(GPU_AND_CPU_CODEGEN, ypr, "codegen for CPU and GPU", "generate both GPU and CPU code")
 PRAGMA(HAS_POSTINIT, ypr, "has postinit", "type that has a postinit method")
 PRAGMA(HAS_RUNTIME_TYPE, ypr, "has runtime type", "type that has an associated runtime type")
 

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -78,6 +78,7 @@ module LocaleModelHelpRuntime {
 
   pragma "insert line file info"
   pragma "always resolve function"
+  pragma "codegen for CPU and GPU"
   proc chpl_nodeFromLocaleID(in loc: chpl_localeID_t)
     return chpl_rt_nodeFromLocaleID(loc);
 

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -70,6 +70,22 @@ __device__ static inline c_nodeid_t get_chpl_nodeID(void) {
   return 0;
 }
 
+__device__ static inline c_nodeid_t chpl_rt_nodeFromLocaleID(chpl_localeID_t loc) {
+  return loc.node;
+}
+
+__device__ static inline void chpl_gen_comm_get(void *addr, c_nodeid_t node,
+  void* raddr, size_t size, int32_t commID, int ln, int32_t fn)
+{
+  // TODO
+}
+
+__device__ static inline void chpl_gen_comm_put(void* addr, c_nodeid_t node,
+  void* raddr, size_t size, int32_t commID, int ln, int32_t fn)
+{
+  // TODO
+}
+
 #endif // HAS_GPU_LOCALE
 
 #endif // _CHPL_GPU_GEN_INCLUDES_H


### PR DESCRIPTION
Similar to the issues https://github.com/chapel-lang/chapel/pull/20356 it looks like  #20342 made it so we gpuize more loops in our module code.  In this case we were getting failures for our gasnet tests ().

It looks like some loop (or loops) that we now gpuize gets access to wide pointers and thus we were get complaints about not having GPUized versions of certain other functions.

To fix I:
* Made `GPU_AND_CPU_CODEGEN` a user visible pragma
* Apply this pragma to `chpl_nodeFromLocaleID`
* Add `__device__` functions for a handful of functions that these call (with the implementation left as a TODO)