### PR TITLE
Deprecate IO.unlink function

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4961,6 +4961,7 @@ proc readln(type t ...?numTypes) throws {
 
    :throws SystemError: Thrown if the file is not successfully deleted.
  */
+deprecated "unlink is deprecated. Please use FileSystem.remove instead"
 proc unlink(path:string) throws {
   extern proc sys_unlink(path:c_string): c_int;
   var err = sys_unlink(path.localize().c_str());

--- a/test/deprecated/IO/unlink.chpl
+++ b/test/deprecated/IO/unlink.chpl
@@ -1,0 +1,14 @@
+
+use IO;
+
+proc main() {
+  const fname = "tempfile.txt";
+  var f = open(fname, iomode.cw);
+  {
+    var w = f.writer();
+    w.write("hello");
+  }
+  f.close();
+
+  unlink(fname);
+}

--- a/test/deprecated/IO/unlink.good
+++ b/test/deprecated/IO/unlink.good
@@ -1,0 +1,2 @@
+unlink.chpl:4: In function 'main':
+unlink.chpl:13: warning: unlink is deprecated. Please use FileSystem.remove instead

--- a/test/io/ferguson/bits-errors.chpl
+++ b/test/io/ferguson/bits-errors.chpl
@@ -1,6 +1,6 @@
 // tests convenience signatures for bit-I/O routines
 // these help avoid casting
-
+use FileSystem;
 use IO;
 
 config const test=1;
@@ -59,5 +59,5 @@ if test == 4 {
     assert(tmp == 0b011);
 }
 
-unlink(testfile);
+FileSystem.remove(testfile);
 

--- a/test/io/ferguson/bits-signed.chpl
+++ b/test/io/ferguson/bits-signed.chpl
@@ -1,6 +1,7 @@
 // tests convenience signatures for bit-I/O routines
 // these help avoid casting
 
+use FileSystem;
 use IO;
 
 config const test=1;
@@ -103,5 +104,5 @@ if test == 4 { // uint(8)s
   }
 }
 
-unlink(testfile);
+FileSystem.remove(testfile);
 

--- a/test/io/ferguson/easybits.chpl
+++ b/test/io/ferguson/easybits.chpl
@@ -1,4 +1,5 @@
 
+use FileSystem;
 use IO;
 
 config const testfile="test.bin";
@@ -22,5 +23,5 @@ var f = open(testfile, iomode.cwr);
     assert(tmp == 0b011);
 }
 
-unlink(testfile);
+FileSystem.remove(testfile);
 

--- a/test/io/ferguson/inteof.chpl
+++ b/test/io/ferguson/inteof.chpl
@@ -1,3 +1,4 @@
+use FileSystem;
 use IO;
 import SysBasic.EEOF;
 
@@ -121,5 +122,5 @@ for i in 0..sizes.size-1
   }
 }
 
-unlink(filename);
+FileSystem.remove(filename);
 

--- a/test/io/ferguson/zerosatend.chpl
+++ b/test/io/ferguson/zerosatend.chpl
@@ -1,4 +1,5 @@
 
+use FileSystem;
 use IO;
 
 config var testfile = "test.dat";
@@ -45,5 +46,5 @@ var n = sz / 8;
   assert( j == 0 );
 }
 
-unlink(testfile);
+FileSystem.remove(testfile);
 

--- a/test/library/standard/Spawn/spawn-checkmutate.chpl
+++ b/test/library/standard/Spawn/spawn-checkmutate.chpl
@@ -1,3 +1,4 @@
+use FileSystem;
 use Subprocess;
 
 {
@@ -12,5 +13,5 @@ use Subprocess;
   assert(runit.exitCode == 0);
 }
 
-unlink("mutate-args");
+FileSystem.remove("mutate-args");
 

--- a/test/library/standard/Spawn/spawn-checkret.chpl
+++ b/test/library/standard/Spawn/spawn-checkret.chpl
@@ -1,3 +1,4 @@
+use FileSystem;
 use Subprocess;
 
 {
@@ -12,5 +13,5 @@ use Subprocess;
   assert(runit.exitCode == 10);
 }
 
-unlink("return-10");
+FileSystem.remove("return-10");
 

--- a/test/library/standard/Spawn/spawn-popen-input-output-error-long.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-error-long.chpl
@@ -1,3 +1,4 @@
+use FileSystem;
 use Subprocess;
 
 {
@@ -40,4 +41,4 @@ sub.close();
 
 writeln("OK");
 
-unlink("stdout-stderr");
+FileSystem.remove("stdout-stderr");

--- a/test/library/standard/Spawn/spawn-popen-input-output-error.chpl
+++ b/test/library/standard/Spawn/spawn-popen-input-output-error.chpl
@@ -1,3 +1,4 @@
+use FileSystem;
 use Subprocess;
 
 {
@@ -28,4 +29,4 @@ assert(sub.exitCode == 0);
 
 sub.close();
 
-unlink("stdout-stderr");
+FileSystem.remove("stdout-stderr");

--- a/test/library/standard/Spawn/spawn-print-args-env.chpl
+++ b/test/library/standard/Spawn/spawn-print-args-env.chpl
@@ -1,3 +1,4 @@
+use FileSystem;
 use Subprocess;
 
 {
@@ -20,5 +21,5 @@ if printEnv {
 }
 
 
-unlink("print-args-env");
+FileSystem.remove("print-args-env");
 

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -152,9 +152,9 @@ if example == 0 || example == 2 {
   }
 
 // Now close the file, even though they are reference-counted like channels.
-// We can also remove the test file.
+// We can also remove the test file with :proc:`FileSystem.remove`.
   f.close();
-  FileSystem.remove(testfile);
+  remove(testfile);
 }
 
 // Here is the slightly more complicated but faster version, using some hints.
@@ -211,7 +211,7 @@ if example == 0 || example == 3 {
     f.close();
   }
 
-  FileSystem.remove(testfile);
+  remove(testfile);
 }
 
 /*
@@ -258,7 +258,7 @@ if example == 0 || example == 4 {
   }
 
   f.close();
-  FileSystem.remove(testfile);
+  remove(testfile);
 }
 
 /*
@@ -278,10 +278,10 @@ if example == 0 || example == 5 {
 
   try! {
     // Who knows, maybe 1st removal succeeds.
-    FileSystem.remove(testfile);
+    remove(testfile);
 
     // File does not exist by now, for sure.
-    FileSystem.remove(testfile);
+    remove(testfile);
 
     assert(false); // never reached
   } catch e: SystemError {

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -10,6 +10,7 @@ config const example = 0;
 config const testfile = "test.bin";
 config const epsilon = 10e-13;
 
+use FileSystem;
 use IO;
 
 /*
@@ -153,7 +154,7 @@ if example == 0 || example == 2 {
 // Now close the file, even though they are reference-counted like channels.
 // We can also remove the test file.
   f.close();
-  unlink(testfile);
+  FileSystem.remove(testfile);
 }
 
 // Here is the slightly more complicated but faster version, using some hints.
@@ -210,7 +211,7 @@ if example == 0 || example == 3 {
     f.close();
   }
 
-  unlink(testfile);
+  FileSystem.remove(testfile);
 }
 
 /*
@@ -257,7 +258,7 @@ if example == 0 || example == 4 {
   }
 
   f.close();
-  unlink(testfile);
+  FileSystem.remove(testfile);
 }
 
 /*
@@ -276,11 +277,11 @@ if example == 0 || example == 5 {
   writeln("Running Example 5");
 
   try! {
-    // Who knows, maybe 1st unlink succeeds.
-    unlink(testfile);
+    // Who knows, maybe 1st removal succeeds.
+    FileSystem.remove(testfile);
 
     // File does not exist by now, for sure.
-    unlink(testfile);
+    FileSystem.remove(testfile);
 
     assert(false); // never reached
   } catch e: SystemError {


### PR DESCRIPTION
This PR deprecates the "unlink" function in the IO module, and recommends using ``FileSystem.remove`` instead. Tests that use the unlink method have been updated to use ``FileSystem.remove``, including the ``fileIO`` primer.

Testing:
- [x] full local