### PR TITLE
Improve environments scripts for better CUDA path handling

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -41,7 +41,7 @@ def get_cuda_libdevice_path():
         libdevices = glob.glob(chpl_cuda_path+"/nvvm/libdevice/libdevice*.bc")
         if len(libdevices) == 0:
             error("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
-                  "set such that CHPL_CUDA_PATH/bin/nvcc exists.")
+                  "set such that CHPL_CUDA_PATH/nvmm/libdevice/libdevice*.bc exists.")
         else:
             return libdevices[0]
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -13,33 +13,39 @@ def get():
 
 @memoize
 def get_cuda_path():
-    chpl_cuda_path = os.environ.get("CHPL_CUDA_PATH")
-    if chpl_cuda_path:
-        return chpl_cuda_path
+    if chpl_locale_model.get() == 'gpu':
+        chpl_cuda_path = os.environ.get("CHPL_CUDA_PATH")
+        if chpl_cuda_path:
+            return chpl_cuda_path
 
-    exists, returncode, my_stdout, my_stderr = utils.try_run_command(["which",
-                                                                      "nvcc"])
+        exists, returncode, my_stdout, my_stderr = utils.try_run_command(["which",
+                                                                          "nvcc"])
 
-    if exists and returncode == 0:
-        chpl_cuda_path = "/".join(os.path.realpath(my_stdout).strip().split("/")[:-2])
-        return chpl_cuda_path
-    else:
-        return ""
+        if exists and returncode == 0:
+            chpl_cuda_path = "/".join(os.path.realpath(my_stdout).strip().split("/")[:-2])
+            return chpl_cuda_path
+        else:
+            error("Can't find cuda")
+
+    return ""
 
 def get_cuda_libdevice_path():
-    # TODO this only makes sense when we are generating for nvidia
-    chpl_cuda_path = get_cuda_path()
+    if chpl_locale_model.get() == 'gpu':
+        # TODO this only makes sense when we are generating for nvidia
+        chpl_cuda_path = get_cuda_path()
 
-    # there can be multiple libdevices for multiple compute architectures. Not
-    # sure how realistic that is, nor I see multiple instances in the systems I
-    # have access to. They are always named `libdevice.10.bc`, but I just want
-    # to be sure here.
-    libdevices = glob.glob(chpl_cuda_path+"/nvvm/libdevice/libdevice*.bc")
-    if len(libdevices) == 0:
-        error("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
-              "set such that CHPL_CUDA_PATH/bin/nvcc exists.")
-    else:
-        return libdevices[0]
+        # there can be multiple libdevices for multiple compute architectures. Not
+        # sure how realistic that is, nor I see multiple instances in the systems I
+        # have access to. They are always named `libdevice.10.bc`, but I just want
+        # to be sure here.
+        libdevices = glob.glob(chpl_cuda_path+"/nvvm/libdevice/libdevice*.bc")
+        if len(libdevices) == 0:
+            error("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
+                  "set such that CHPL_CUDA_PATH/bin/nvcc exists.")
+        else:
+            return libdevices[0]
+
+    return ""
 
 
 def get_runtime():

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -36,7 +36,8 @@ def get_cuda_libdevice_path():
     # to be sure here.
     libdevices = glob.glob(chpl_cuda_path+"/nvvm/libdevice/libdevice*.bc")
     if len(libdevices) == 0:
-        return ""
+        error("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
+              "set such that CHPL_CUDA_PATH/bin/nvcc exists.")
     else:
         return libdevices[0]
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -21,7 +21,7 @@ def get_cuda_path():
                                                                       "nvcc"])
 
     if exists and returncode == 0:
-        chpl_cuda_path = "/".join(my_stdout.strip().split("/")[:-2])
+        chpl_cuda_path = "/".join(os.path.realpath(my_stdout).strip().split("/")[:-2])
         return chpl_cuda_path
     else:
         return ""


### PR DESCRIPTION
@hokiegeek2 reported some issues with compiling applications with the GPU locale
model, even though build was successful.

The issue was that `which nvcc` was returning non-normal path resulting in us
looking for libdevice in all the wrong places. We should be able to do better
when that happens. This PR:

- normalizes the path returned by `which nvcc`
- errors if we cannot find libdevice in the path we want at `printchplenv`
  (today, we just get an `""` which we try to open and link at makeBinary time
  resulting in a segfault)
- now that we have a stricter checking, GPU environment scripts try to do
  something only with the `gpu` locale model

Test:
- [x] gpu/native
- [x] spot-checks on various systems with gpu and flat locale
