### PR TITLE
Reduce conservatism in GPU technote

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -21,9 +21,10 @@ Overview
 To deploy code to a GPU, put the relevant code in an ``on`` statement targeting
 a GPU sublocale (i.e. ``here.gpus[0]``).
 
-Any arrays that are declared in the body of this ``on`` statement will be
+Any arrays that are declared by tasks executing on a GPU sublocale will be
 allocated into unified memory and will be accessible on the GPU. Chapel will
-generate CUDA kernels for all eligible loops in the ``on`` block. Loops are
+launch CUDA kernels for all eligible loops (instead of running the loop on the
+CPU) that are encountered by tasks executing on a GPU sublocale. Loops are
 eligible when:
 
 * They are order-independent (e.g., `forall` or `foreach`).


### PR DESCRIPTION
Following a discussion, I wanted to check how we describe what we run on the GPU
and what we run on the CPU. I think the language we have there is a little bit
too static-sounding. The real behavior is more dynamic and much less strict than
the technote suggests.

This PR adjusts the language to make it sound closer to what actually happens.
