### PR TITLE
Fixed signed/unsigned comparison when computing number of bytes to read

### DIFF
--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -413,8 +413,9 @@ qioerr qio_channel_read_string(const int threadsafe, const int byteorder, const 
 
       int64_t offset = qio_channel_offset_unlocked(ch);
       err = qio_file_length(ch->file, &file_len);
-      num = file_len - offset;
-      if (num < 0) {
+      if (file_len > offset) {
+        num = file_len - offset;
+      } else {
         num = 0;
       }
       if (err) {


### PR DESCRIPTION
When computing the number of bytes remaining to be read in the file the current file offset was subtracted from the current file length. The length may be less than the offset because the file size may change.  Previously, the difference was assigned to an unsigned integer that was compared against zero, leading to a conditional that was always false.  Now the comparison is done prior to the assignment.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>