### PR TITLE
Fix a comment that wants to be helpful but is misleading

### DIFF
--- a/test/gpu/native/kernelFnCalls/fnWithForall.chpl
+++ b/test/gpu/native/kernelFnCalls/fnWithForall.chpl
@@ -20,12 +20,12 @@ on here.gpus[0] {
   var A: [0..#n] real;
 
   foreach i in 0..#n {  // This is not a kernel, `foo` is too complicated
-    A[i] = foo(i);
+    A[i] = foo(i);      // This will cause n kernel launches from `foo`
   }
 
   writeln(A);
 
-  var x = foo(n); // This should cause n+1 kernel launches
+  var x = foo(n); // This should cause 1 more launch
   writeln(x);
 }
 


### PR DESCRIPTION
I added comments to a complicated kernel launch test while switching to
GPUDiagnostics-based testing. I thought I understood what's happening, but I was
wrong. I spent some time understanding what's going on, but couldn't because of
the comments. Thanks @daviditen for the explanation.
