### PR TITLE
Enable tags for dyno headers

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -56,10 +56,12 @@ SUBDIRS = \
 #
 include $(COMPILER_ROOT)/make/Makefile.compiler.head
 
+ALL_HEADERS= */*.h dyno/include/chpl/*/*.h
+
 # Generate tags command, dependent on if Make variable, TAGS == 1
 ifeq ($(TAGS), 1)
-TAGS_COMMAND=-@(which $(CHPL_TAGS_UTIL) > /dev/null 2>&1 && echo "Updating TAGS..." && $(CHPL_TAGS_UTIL) $(CHPL_TAGS_FLAGS) $(ALL_SRCS) */*.h) || echo "$(CHPL_TAGS_UTIL) not available"
-EBROWSE_COMMAND=-@(which ebrowse > /dev/null 2>&1 && echo "Updating BROWSE..." && ebrowse $(ALL_SRCS) */*.h) || echo "ebrowse not available"
+TAGS_COMMAND=-@(which $(CHPL_TAGS_UTIL) > /dev/null 2>&1 && echo "Updating TAGS..." && $(CHPL_TAGS_UTIL) $(CHPL_TAGS_FLAGS) $(ALL_SRCS) $(ALL_HEADERS)) || echo "$(CHPL_TAGS_UTIL) not available"
+EBROWSE_COMMAND=-@(which ebrowse > /dev/null 2>&1 && echo "Updating BROWSE..." && ebrowse $(ALL_SRCS) $(ALL_HEADERS)) || echo "ebrowse not available"
 endif
 
 #

--- a/compiler/dyno/lib/framework/Makefile.include
+++ b/compiler/dyno/lib/framework/Makefile.include
@@ -18,7 +18,7 @@
 
 DYNO_FRAMEWORK_OBJDIR = $(COMPILER_BUILD)/dyno/lib/framework
 
-ALL_SRCS += dyno/lib/framework/*.cpp
+ALL_SRCS += dyno/lib/framework/*.h dyno/lib/framework/*.cpp
 
 DYNO_FRAMEWORK_SRCS =                               \
            compiler-configuration.cpp               \

--- a/compiler/dyno/lib/immediates/Makefile.include
+++ b/compiler/dyno/lib/immediates/Makefile.include
@@ -18,7 +18,7 @@
 
 DYNO_IMMEDIATES_OBJDIR = $(COMPILER_BUILD)/dyno/lib/immediates
 
-ALL_SRCS += dyno/lib/immediates/*.cpp
+ALL_SRCS += dyno/lib/immediates/*.h dyno/lib/immediates/*.cpp
 
 DYNO_IMMEDIATES_SRCS =                              \
            ifa_vars.cpp                             \

--- a/compiler/dyno/lib/parsing/Makefile.include
+++ b/compiler/dyno/lib/parsing/Makefile.include
@@ -18,7 +18,7 @@
 
 DYNO_PARSING_OBJDIR = $(COMPILER_BUILD)/dyno/lib/parsing
 
-ALL_SRCS += dyno/lib/parsing/*.cpp
+ALL_SRCS += dyno/lib/parsing/*.h dyno/lib/parsing/*.cpp
 
 DYNO_PARSING_SRCS =                                 \
            bison-chpl-lib.cpp                       \

--- a/compiler/dyno/lib/resolution/Makefile.include
+++ b/compiler/dyno/lib/resolution/Makefile.include
@@ -18,7 +18,7 @@
 
 DYNO_RESOLUTION_OBJDIR = $(COMPILER_BUILD)/dyno/lib/resolution
 
-ALL_SRCS += dyno/lib/resolution/*.cpp
+ALL_SRCS += dyno/lib/resolution/*.h dyno/lib/resolution/*.cpp
 
 DYNO_RESOLUTION_SRCS =                              \
            Resolver.cpp                             \

--- a/compiler/dyno/lib/types/Makefile.include
+++ b/compiler/dyno/lib/types/Makefile.include
@@ -18,7 +18,7 @@
 
 DYNO_TYPES_OBJDIR = $(COMPILER_BUILD)/dyno/lib/types
 
-ALL_SRCS += dyno/lib/types/*.cpp
+ALL_SRCS += dyno/lib/types/*.h dyno/lib/types/*.cpp
 
 DYNO_TYPES_SRCS =                                 \
   AnyType.cpp \

--- a/compiler/dyno/lib/uast/Makefile.include
+++ b/compiler/dyno/lib/uast/Makefile.include
@@ -18,7 +18,7 @@
 
 DYNO_UAST_OBJDIR = $(COMPILER_BUILD)/dyno/lib/uast
 
-ALL_SRCS += dyno/lib/uast/*.cpp
+ALL_SRCS += dyno/lib/uast/*.h dyno/lib/uast/*.cpp
 
 DYNO_UAST_SRCS =                                 \
   AggregateDecl.cpp \

--- a/compiler/dyno/lib/util/Makefile.include
+++ b/compiler/dyno/lib/util/Makefile.include
@@ -18,7 +18,7 @@
 
 DYNO_UTIL_OBJDIR = $(COMPILER_BUILD)/dyno/lib/util
 
-ALL_SRCS += dyno/lib/util/*.cpp
+ALL_SRCS += dyno/lib/util/*.h dyno/lib/util/*.cpp
 
 
 DYNO_UTIL_SRCS =      \

--- a/compiler/main/Makefile.include
+++ b/compiler/main/Makefile.include
@@ -18,6 +18,6 @@
 
 MAIN_OBJDIR = $(COMPILER_BUILD)/main
 
-ALL_SRCS += main/*.h main/*.cpp
+ALL_SRCS += main/*.cpp
 
 include $(COMPILER_ROOT)/main/Makefile.share


### PR DESCRIPTION
Resolves #20379.

Adjusts the tags file generation to include the dyno headers.

Reviewed by @bradcray - thanks!