### PR TITLE
Update gpu tests to avoid using locale.getChild().

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -437,7 +437,7 @@ module ChapelLocale {
     }
 
     // Return array of gpu sublocale
-    proc gpus {
+    proc gpus const ref {
       return gpusImpl();
     }
 

--- a/test/gpu/native/dataPingPong.chpl
+++ b/test/gpu/native/dataPingPong.chpl
@@ -24,7 +24,7 @@ var copyIn = 0.0,
 startGPUDiagnostics();
 totalTimer.start();
 if useGPU {
-  on here.getChild(1) {
+  on here.gpus[0] {
     detailTimer.start();
     var B = A;
     detailTimer.stop();

--- a/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/gpuAddNums/gpuAddNums_primitive.chpl
@@ -48,7 +48,7 @@ proc main() {
 var output: real(64);
 
 
-on here.getChild(1) {
+on here.gpus[0] {
 
   var dummy = [1,2,3]; // to ensure that the CUDA context is attached to the
                        // thread

--- a/test/gpu/native/innerBlock.chpl
+++ b/test/gpu/native/innerBlock.chpl
@@ -1,7 +1,7 @@
 use GPUDiagnostics;
 
 startGPUDiagnostics();
-on here.getChild(1) {
+on here.gpus[0] {
   var A = [1,2,3,4,5];
   var outerVar = 10;
 
@@ -14,7 +14,7 @@ on here.getChild(1) {
   writeArr(A);
 }
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A = [1,2,3,4,5];
   var outerVar = 10;
 
@@ -29,7 +29,7 @@ on here.getChild(1) {
   writeArr(A);
 }
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A = [1,2,3,4,5];
   var outerVar = 10;
 
@@ -44,7 +44,7 @@ on here.getChild(1) {
   writeArr(A);
 }
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A = [1,2,3,4,5];
   var outerVar = 10;
 

--- a/test/gpu/native/kernelFnCalls/callFnAccessModVar.chpl
+++ b/test/gpu/native/kernelFnCalls/callFnAccessModVar.chpl
@@ -9,7 +9,7 @@ proc foo(i) {
 }
 
 startGPUDiagnostics();
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [0..#n] real;
   forall i in 0..#n {
     A[i] = foo(i);

--- a/test/gpu/native/kernelFnCalls/callFnFromFn.chpl
+++ b/test/gpu/native/kernelFnCalls/callFnFromFn.chpl
@@ -10,7 +10,7 @@ proc bar(i) {
 }
 
 startGPUDiagnostics();
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [0..#n] int;
 
   forall i in 0..#n {

--- a/test/gpu/native/kernelFnCalls/callHalts.chpl
+++ b/test/gpu/native/kernelFnCalls/callHalts.chpl
@@ -5,7 +5,7 @@ proc foo(i) {
     halt("i is too big!");
 }
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [0..#n] real;
   forall i in 0..#n {
     foo(i);

--- a/test/gpu/native/kernelFnCalls/callRecursiveFn.chpl
+++ b/test/gpu/native/kernelFnCalls/callRecursiveFn.chpl
@@ -7,7 +7,7 @@ proc foo(i): int {
   return 0;
 }
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [0..#n] int;
   forall i in 0..#n {
     A[i] = foo(i);

--- a/test/gpu/native/kernelFnCalls/callTrivialFn.chpl
+++ b/test/gpu/native/kernelFnCalls/callTrivialFn.chpl
@@ -5,7 +5,7 @@ proc foo(a, b, i) {
 }
 
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A, B: [0..#n] real;
   startGPUDiagnostics();
   forall i in 0..#n {

--- a/test/gpu/native/multiGPU/multiGPU.chpl
+++ b/test/gpu/native/multiGPU/multiGPU.chpl
@@ -23,7 +23,7 @@ stopGPUDiagnostics();
 
 const nLaunch = getGPUDiagnostics().kernel_launch;
 
-assert(nLaunch == here.getChildCount()*4);
+assert(nLaunch == here.gpus.size*4);
 
 proc assertElemVal(X, val) {
   if writeArrays {

--- a/test/gpu/native/multiGPU/worksharing.chpl
+++ b/test/gpu/native/multiGPU/worksharing.chpl
@@ -62,7 +62,7 @@ for i in 1..numIters {
 stopGPUDiagnostics();
 const nLaunch = getGPUDiagnostics().kernel_launch;
 
-assert(nLaunch == here.getChildCount()*numIters);
+assert(nLaunch == here.gpus.size*numIters);
 
 writeln(A);
 

--- a/test/gpu/native/multiGPU/worksharingBasic.chpl
+++ b/test/gpu/native/multiGPU/worksharingBasic.chpl
@@ -31,5 +31,5 @@ writeln(A);
 
 const nLaunch = getGPUDiagnostics().kernel_launch;
 
-assert(nLaunch == here.getChildCount());
+assert(nLaunch == here.gpus.size);
 assert((+ reduce A) == n);

--- a/test/gpu/native/promotion2.chpl
+++ b/test/gpu/native/promotion2.chpl
@@ -2,7 +2,7 @@ config const n = 10;
 
 config const alpha = 10;
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [1..n] int;
   var B: [1..n] int;
   var C: [1..n] int;

--- a/test/gpu/native/threadBlockAndGridPrimitives.chpl
+++ b/test/gpu/native/threadBlockAndGridPrimitives.chpl
@@ -114,7 +114,7 @@ proc runExample(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ) {
 }
 
 proc main() {
-  on here.getChild(1) {
+  on here.gpus[0] {
     var dummy = [1,2,3]; // to ensure that the CUDA context is attached to the
                          // thread
 

--- a/test/gpu/native/tuple.chpl
+++ b/test/gpu/native/tuple.chpl
@@ -1,7 +1,7 @@
 config param tupSize = 5;
 config const n = 10;
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [1..n] int;
 
   foreach a in A {
@@ -22,7 +22,7 @@ on here.getChild(1) {
   writeln(A);
 }
 
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [1..n] int;
 
   foreach a in A {

--- a/test/gpu/native/useAssociativeDomain.chpl
+++ b/test/gpu/native/useAssociativeDomain.chpl
@@ -5,7 +5,7 @@ use GPUDiagnostics;
 startGPUDiagnostics();
 
 var Days : domain(int) = {0, 10, 20};
-on here.getChild(1) {
+on here.gpus[0] {
   var A : [Days] real;
 
   // NOTE: Currently this does not generate a kernel launch

--- a/test/gpu/native/varInInnerBlock.chpl
+++ b/test/gpu/native/varInInnerBlock.chpl
@@ -1,5 +1,5 @@
 config const n = 10;
-on here.getChild(1) {
+on here.gpus[0] {
   var A: [1..n] int;
 
   foreach a in A {


### PR DESCRIPTION
With the GPU locale model we no longer intend end users to use `locale.getChild()` to access gpu sublocales; instead, they should use `locale.gpus`.

This was changed as of https://github.com/chapel-lang/chapel/pull/19673 but for whatever reason there are a bunch of tests using the old style.  This PR brings these tests up-to-date.

While updating these tests a failure in `dataPingPong.chpl` (which compares against a log of expected memory copies) alerted me that I was inadvertently copying the gpus array whenever we call the parenless `gpus` proc.  This PR also fixes that.