### PR TITLE
dyno: scope-resolve catch statements

### DIFF
--- a/compiler/AST/CatchStmt.cpp
+++ b/compiler/AST/CatchStmt.cpp
@@ -265,6 +265,7 @@ void CatchStmt::cleanup()
     // We 'remove()' the Def to insert it in the newBody with an init-expr.
     errorDef = toDefExpr(oldBody->body.head->remove());
     error = toVarSymbol(errorDef->sym);
+    INT_ASSERT(error->name == _name);
   } else {
     error = new VarSymbol(name);
     errorDef = new DefExpr(error);

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -182,7 +182,8 @@ bool createsScope(asttags::AstTag tag) {
          || asttags::isCobegin(tag)
          || asttags::isConditional(tag)
          || asttags::isSelect(tag)
-         || asttags::isTry(tag);
+         || asttags::isTry(tag)
+         || asttags::isCatch(tag);
 }
 
 static const Scope* const& scopeForIdQuery(Context* context, ID id);

--- a/compiler/include/CatchStmt.h
+++ b/compiler/include/CatchStmt.h
@@ -74,6 +74,7 @@ public:
   Expr*               getNextExpr(Expr* expr) override;
   void                verify() override;
 
+  void                createErrSym();
   void                cleanup();
 
   GenRet              codegen() override;
@@ -83,6 +84,7 @@ public:
   const char* _name;
   Expr*       _type;
   BlockStmt*  _body;
+  bool  _createdErr;
 
 private:
   CatchStmt();

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1229,6 +1229,12 @@ struct Converter {
       ret = CatchStmt::build(body);
     }
 
+    if (canScopeResolve && errorVar != nullptr) {
+      ret->createErrSym();
+      DefExpr* def = toDefExpr(body->body.head);
+      noteConvertedSym(errorVar, def->sym);
+    }
+
     INT_ASSERT(ret != nullptr);
 
     return ret;


### PR DESCRIPTION
This PR updates dyno and the ``convert-uast`` pass to scope-resolve catch-statements.

The change to dyno is minimal and simply requires identifying Catch nodes as creating a new scope.

The change to support scope-resolution in ``convert-uast`` is slightly more complex. ``CatchStmt::build`` does not create a Symbol that ``convert-uast`` can use to map from dyno's representation to the production compiler's representation. Prior to this PR, the necessary Symbol was created during ``CatchStmt::cleanup``. This PR creates a new method, ``CatchStmt::createErrSym``, that will create the necessary Symbol (only the first time the method is called). ``CatchStmt::cleanup`` will invoke this method at the start to create the symbol if it's not already created. ``convert-uast`` can call this method right after ``CatchStmt::build`` to retrieve the symbol and use it for scope-resolution.

Testing:
- [x] full local
- [x] full gasnet