### PR TITLE
dyno: add filenames' directories to module search paths

### DIFF
--- a/compiler/dyno/include/chpl/parsing/parsing-queries.h
+++ b/compiler/dyno/include/chpl/parsing/parsing-queries.h
@@ -205,7 +205,8 @@ void setupModuleSearchPaths(Context* context,
                             const std::string& chplComm,
                             const std::string& chplSysModulesSubdir,
                             const std::string& chplModulePath,
-                            const std::vector<std::string>& cmdLinePaths);
+                            const std::vector<std::string>& cmdLinePaths,
+                            const std::vector<std::string>& inputFilenames);
 
 /**
  Returns true if the ID corresponds to something in an internal module.

--- a/compiler/dyno/lib/parsing/parsing-queries.cpp
+++ b/compiler/dyno/lib/parsing/parsing-queries.cpp
@@ -262,6 +262,23 @@ void setBundledModulePath(Context* context, UniqueString path) {
   QUERY_STORE_INPUT_RESULT(bundledModulePathQuery, context, path);
 }
 
+static void addFilePathModules(std::vector<std::string>& searchPath,
+                               const std::vector<std::string>& inputFilenames) {
+  for (auto& fname : inputFilenames) {
+    auto idx = fname.find_last_of('/');
+    if (idx == std::string::npos) {
+      // local file
+      searchPath.push_back(".");
+    } else if (idx == 0) {
+      // root path: /foo.chpl
+      searchPath.push_back("/");
+    } else {
+      auto path = fname.substr(0, idx);
+      searchPath.push_back(path);
+    }
+  }
+}
+
 void setupModuleSearchPaths(Context* context,
                             const std::string& chplHome,
                             bool minimalModules,
@@ -271,7 +288,8 @@ void setupModuleSearchPaths(Context* context,
                             const std::string& chplComm,
                             const std::string& chplSysModulesSubdir,
                             const std::string& chplModulePath,
-                            const std::vector<std::string>& cmdLinePaths) {
+                            const std::vector<std::string>& cmdLinePaths,
+                            const std::vector<std::string>& inputFilenames) {
 
   std::string modRoot;
   if (!minimalModules) {
@@ -321,6 +339,8 @@ void setupModuleSearchPaths(Context* context,
   for (const auto& p : cmdLinePaths) {
     searchPath.push_back(p);
   }
+
+  addFilePathModules(searchPath, inputFilenames);
 
   // Convert them all to UniqueStrings.
   std::vector<UniqueString> uSearchPath;

--- a/compiler/dyno/test/resolution/testInteractive.cpp
+++ b/compiler/dyno/test/resolution/testInteractive.cpp
@@ -225,7 +225,8 @@ static void usage(int argc, char** argv) {
 
 static void setupSearchPaths(Context* ctx, bool enableStdLib,
                              const char* chpl_home,
-                             const std::vector<std::string>& cmdLinePaths) {
+                             const std::vector<std::string>& cmdLinePaths,
+                             const std::vector<std::string>& files) {
   if (enableStdLib) {
     setupModuleSearchPaths(ctx,
                            chpl_home,
@@ -236,7 +237,8 @@ static void setupSearchPaths(Context* ctx, bool enableStdLib,
                            "none",
                            "linux64-x86_64-gnu",
                            "",
-                           cmdLinePaths);
+                           cmdLinePaths,
+                           files);
   } else {
     std::vector<UniqueString> uPaths;
     for (auto p: cmdLinePaths) {
@@ -299,7 +301,7 @@ int main(int argc, char** argv) {
     typeForBuiltin(ctx, UniqueString::get(ctx, "int"));
     ctx->setDebugTraceFlag(trace);
 
-    setupSearchPaths(ctx, enableStdLib, chpl_home, cmdLinePaths);
+    setupSearchPaths(ctx, enableStdLib, chpl_home, cmdLinePaths, files);
 
     std::set<const ResolvedFunction*> calledFns;
 

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -87,6 +87,7 @@ bool isCSource(const char* filename);
 bool isObjFile(const char* filename);
 void addSourceFiles(int numFilenames, const char* filename[]);
 void addSourceFile(const char* filename, const char* modFilename);
+void assertSourceFilesFound();
 const char* nthFilename(int i);
 void addLibPath(const char* filename);
 void addLibFile(const char* filename);

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -80,6 +80,7 @@ void      closefile(FILE*     thefile);
 
 FILE* openInputFile(const char* filename);
 void closeInputFile(FILE* infile);
+std::vector<std::string> getChplFilenames();
 bool isChplSource(const char* filename);
 bool isCHeader(const char* filename);
 bool isCSource(const char* filename);

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1885,6 +1885,8 @@ int main(int argc, char* argv[]) {
   if (fRunlldb)
     runCompilerInLLDB(argc, argv);
 
+  assertSourceFilesFound();
+
   runPasses(tracker, fDocs);
 
   tracker.StartPhase("driverCleanup");

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1838,6 +1838,8 @@ int main(int argc, char* argv[]) {
       chpl_module_path = envvarpath;
     }
 
+    addSourceFiles(sArgState.nfile_arguments, sArgState.file_argument);
+
     chpl::parsing::setupModuleSearchPaths(gContext,
                                           CHPL_HOME,
                                           fMinimalModules,
@@ -1847,7 +1849,8 @@ int main(int argc, char* argv[]) {
                                           CHPL_COMM,
                                           CHPL_SYS_MODULES_SUBDIR,
                                           chpl_module_path,
-                                          cmdLineModPaths);
+                                          cmdLineModPaths,
+                                          getChplFilenames());
 
     postprocess_args();
 
@@ -1881,8 +1884,6 @@ int main(int argc, char* argv[]) {
 
   if (fRunlldb)
     runCompilerInLLDB(argc, argv);
-
-  addSourceFiles(sArgState.nfile_arguments, sArgState.file_argument);
 
   runPasses(tracker, fDocs);
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -307,6 +307,17 @@ void closeInputFile(FILE* infile) {
 
 static const char** inputFilenames = NULL;
 
+std::vector<std::string> getChplFilenames() {
+  std::vector<std::string> ret;
+  int i = 0;
+  while (auto fname = nthFilename(i++)) {
+    if (isChplSource(fname)) {
+      ret.push_back(std::string(fname));
+    }
+  }
+  return ret;
+}
+
 
 static bool checkSuffix(const char* filename, const char* suffix) {
   const char* dot = strrchr(filename, '.');

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -396,7 +396,9 @@ void addSourceFiles(int numNewFilenames, const char* filename[]) {
     }
   }
   inputFilenames[cursor] = NULL;
+}
 
+void assertSourceFilesFound() {
   if (!foundChplSource)
     USR_FATAL("Command line contains no .chpl source files");
 }


### PR DESCRIPTION
This PR allows ``chpl::parsing::setupModuleSearchPaths`` to accept a list of ".chpl" file names that will be used to add more module search paths depending on the location of the provided files. For example, "chpl foo.chpl" would add the current directory to the module search paths.

This PR adds ``getChplFilenames`` to ``files.h``, which returns a vector of ".chpl" file names.

This PR also separates the error message "Command line contains no .chpl source files" from the addition of source files. This change supports calling ``addSourceFiles`` earlier than ``printStuff``, which supports things like ``chpl --version`` in which no source files are expected.

Testing:
- [x] full local
- [x] full gasnet