### PR TITLE
SKIPIF added for CMake library definitions

### DIFF
--- a/test/interop/C/cmakelists/SKIPIF
+++ b/test/interop/C/cmakelists/SKIPIF
@@ -1,0 +1,2 @@
+# Does not currently work with multilocale
+CHPL_COMM != none

--- a/test/interop/C/cmakelists/targetToChpl/SKIPIF
+++ b/test/interop/C/cmakelists/targetToChpl/SKIPIF
@@ -1,0 +1,2 @@
+# Does not currently work with multilocale
+CHPL_COMM != none

--- a/test/interop/C/cmakelists/targetToLibToChpl/SKIPIF
+++ b/test/interop/C/cmakelists/targetToLibToChpl/SKIPIF
@@ -1,0 +1,2 @@
+# Does not currently work with multilocale
+CHPL_COMM != none


### PR DESCRIPTION
Fixes a failure with the gasnet-everything configuration. These tests shouldn't be running because they don't support CHPL_COMM != NONE like the makefile support.