### PR TITLE
Remove env invocation for setting LANG variables in launcher

### DIFF
--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -59,8 +59,6 @@ int chpl_launch_using_exec(const char* command, char * const argv1[],
 int chpl_launch_using_system(char* command, char* argv0);
 
 char* chpl_get_enviro_keys(char sep);
-int chpl_get_charset_env_nargs(void);
-int chpl_get_charset_env_args(char *argv[]);
 
 void chpl_compute_real_binary_name(const char* argv0);
 const char* chpl_get_real_binary_wrapper(void);

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -569,62 +569,6 @@ char* chpl_get_enviro_keys(char sep)
   return ret;
 }
 
-static const int charset_env_nargs = 4;
-
-int chpl_get_charset_env_nargs()
-{
-  return charset_env_nargs;
-}
-
-//
-// Populate the argv array and return the number of arguments added.
-// Return the number of arguments populated.
-//
-int chpl_get_charset_env_args(char *argv[])
-{
-  // If any of the relevant character set environment variables
-  // are set, replicate the state of all of them.  This needs to
-  // be done separately from the -E mechanism because Perl
-  // launchers modify the character set environment, losing our
-  // settings.
-  //
-  // Note that if we are setting these variables, and one or more
-  // of them is empty, we must set it with explicitly empty
-  // contents (e.g. LC_ALL= instead of -u LC_ALL) so that the
-  // Chapel launch mechanism will not overwrite it.
-  char *lang = getenv("LANG");
-  char *lc_all = getenv("LC_ALL");
-  char *lc_collate = getenv("LC_COLLATE");
-  if (!lang && !lc_all && !lc_collate)
-    return 0;
-
-  argv[0] = (char *)"env";
-  if (lang == NULL)
-    lang = (char *)"";
-  char *lang_buf = chpl_mem_allocMany(sizeof("LANG=") + strlen(lang),
-                        sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  strcpy(lang_buf, "LANG=");
-  strcat(lang_buf, lang);
-  argv[1] = lang_buf;
-  if (lc_all == NULL)
-    lc_all = (char *)"";
-  char *lc_all_buf = chpl_mem_allocMany(sizeof("LC_ALL=") + strlen(lc_all),
-                        sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  strcpy(lc_all_buf, "LC_ALL=");
-  strcat(lc_all_buf, lc_all);
-  argv[2] = lc_all_buf;
-  if (lc_collate == NULL)
-    lc_collate = (char *)"";
-  char *lc_collate_buf = chpl_mem_allocMany(
-                        sizeof("LC_COLLATE=") + strlen(lc_collate),
-                        sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  strcpy(lc_collate_buf, "LC_COLLATE=");
-  strcat(lc_collate_buf, lc_collate);
-  argv[3] = lc_collate_buf;
-
-  return charset_env_nargs;
-}
-
 
 static const
 argDescTuple_t universalArgs[]

--- a/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
+++ b/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
@@ -37,7 +37,7 @@ static char _nlbuf[16];
 static char** chpl_launch_create_argv(const char *launch_cmd,
                                       int argc, char* argv[],
                                       int32_t numLocales) {
-  const int maxlargc = 9 + chpl_get_charset_env_nargs();
+  const int maxlargc = 9;
   char *largv[maxlargc];
 
   snprintf(_nlbuf, sizeof(_nlbuf), "%d", numLocales);
@@ -52,7 +52,6 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
   largv[6] = (char *) "0";
   largv[7] = (char*) "-E";
   largv[8] = chpl_get_enviro_keys(',');
-  largc += chpl_get_charset_env_args(&largv[largc]);
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -48,7 +48,7 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   sprintf(cmd, "%s/%sgasnetrun_ibv", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
 
-  const int maxlargc = 15 + chpl_get_charset_env_nargs();
+  const int maxlargc = 15;
   char *largv[maxlargc];
 
   sprintf(_nlbuf, "%d", numLocales);
@@ -69,7 +69,6 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
   largv[12] = (char *)"0";
   largv[13] = (char*)"-E";
   largv[14] = chpl_get_enviro_keys(',');
-  largc += chpl_get_charset_env_args(&largv[largc]);
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }

--- a/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
+++ b/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
@@ -123,30 +123,6 @@ static void genNumLocalesOptions(FILE* pbsFile, qsubVersion qsub,
   }
 }
 
-static void propagate_charset_environment(FILE *f)
-{
-  // If any of the relevant character set environment variables
-  // are set, replicate the state of all of them.  This needs to
-  // be done separately from both the PBS -V mechanism and the
-  // launcher's -E mechanism because the launcher is written in
-  // Perl, which modifies the character set environment, losing
-  // our settings
-  //
-  // Note that if we are setting these variables, and one or more
-  // of them is empty, we must set it with explicitly empty
-  // contents (e.g. LC_ALL= instead of -u LC_ALL) so that the
-  // Chapel launch mechanism will not overwrite it.
-  char *lang = getenv("LANG");
-  char *lc_all = getenv("LC_ALL");
-  char *lc_collate = getenv("LC_COLLATE");
-  if (lang || lc_all || lc_collate) {
-    fprintf(f, " env");
-    fprintf(f, " LANG=%s", lang ? lang : "");
-    fprintf(f, " LC_ALL=%s", lc_all ? lc_all : "");
-    fprintf(f, " LC_COLLATE=%s", lc_collate ? lc_collate : "");
-  }
-}
-
 static char* chpl_launch_create_command(int argc, char* argv[],
                                         int32_t numLocales) {
   int i;
@@ -191,7 +167,6 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   fprintf(expectFile, "expect -re $prompt\n");
   fprintf(expectFile, "send \"%s/%s/gasnetrun_ibv -n %d -N %d",
           CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales, numLocales);
-  propagate_charset_environment(expectFile);
   fprintf(expectFile, " %s ", chpl_get_real_binary_name());
   for (i=1; i<argc; i++) {
     fprintf(expectFile, " '%s'", argv[i]);

--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -159,27 +159,6 @@ static int propagate_environment(char* buf)
   char *enviro_keys = chpl_get_enviro_keys(',');
   if (enviro_keys)
     len += sprintf(buf, " -E '%s'", enviro_keys);
-
-
-  // If any of the relevant character set environment variables
-  // are set, replicate the state of all of them.  This needs to
-  // be done separately from the -E mechanism because the launcher
-  // is written in Perl, which mangles the character set
-  // environment.
-  //
-  // Note that if we are setting these variables, and one or more
-  // of them is empty, we must set it with explicitly empty
-  // contents (e.g. LC_ALL= instead of -u LC_ALL) so that the
-  // Chapel launch mechanism will not overwrite it.
-  char *lang = getenv("LANG");
-  char *lc_all = getenv("LC_ALL");
-  char *lc_collate = getenv("LC_COLLATE");
-  if (lang || lc_all || lc_collate) {
-    len += sprintf(buf+len, " env");
-    len += sprintf(buf+len, " LANG=%s", lang ? lang : "");
-    len += sprintf(buf+len, " LC_ALL=%s", lc_all ? lc_all : "");
-    len += sprintf(buf+len, " LC_COLLATE=%s", lc_collate ? lc_collate : "");
-  }
   return len;
 }
 


### PR DESCRIPTION
Previously, Chapel would determine what character set to use
based off of `LANG`, `LC_COLLATE`, and `LC_ALL`. In #19381, 
this was changed so that we now always use UTF8 and no longer 
check those variables, meaning that they are no longer needed 
and can be removed.

Closes: https://github.com/chapel-lang/chapel/issues/20395