### PR TITLE
GPU test fixes

### DIFF
--- a/test/gpu/native/dataPingPong.good
+++ b/test/gpu/native/dataPingPong.good
@@ -1,6 +1,10 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 operator =(a:[],b:[]): in chpl__bulkTransferArray
 operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(1), Blo=(0), len=12, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
 In DefaultRectangular._simpleTransfer(): Alo=(1), Blo=(1), len=10, elemSize=8
 operator =(a:[],b:[]): successfully completed bulk transfer
 operator =(a:[],b:[]): in chpl__bulkTransferArray

--- a/test/gpu/native/diags.good
+++ b/test/gpu/native/diags.good
@@ -5,17 +5,11 @@ Start
 0 (cpu): diags.chpl:10: allocate xxB of array elements at 0xPREDIFFED
 0 (cpu): diags.chpl:10: allocate xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (cpu): diags.chpl:10: free xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
-0 (cpu): diags.chpl:12: allocate xxB of [domain(1,int(64),false)] locale at 0xPREDIFFED
-0 (cpu): diags.chpl:12: allocate xxB of array elements at 0xPREDIFFED
-0 (cpu): diags.chpl:12: allocate xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free xxB of _EndCount(AtomicT(int(64)),int(64)) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:13: allocate xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:13: allocate xxB of array elements at 0xPREDIFFED
 0 (gpu 0): diags.chpl:14: kernel launch (block size: 512x1x1)
 0 (gpu 0): diags.chpl:18: free xxB of array elements at 0xPREDIFFED
 0 (gpu 0): diags.chpl:18: free xxB of [domain(1,int(64),false)] int(64) at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free xxB of array elements at 0xPREDIFFED
-0 (cpu): diags.chpl:12: free xxB of [domain(1,int(64),false)] locale at 0xPREDIFFED
 2 2 2 2 2 2 2 2 2 2
 End
 GPU diagnostics:


### PR DESCRIPTION
Due to fallout from https://github.com/chapel-lang/chapel/pull/20399.

This changed how the array of gpus gets returned from the locale
(returned as const ref rather than by value) so that impacts what memory
transfers occur. A couple tests were locking down the old behavior