### PR TITLE
Fix bulk transfer tests

### DIFF
--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -100,7 +100,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   /* The maximum year allowed in `date` objects */
   param MAXYEAR = 9999;
 
-  private const DAYS_IN_MONTH: [1..12] int = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  private const DAYS_IN_MONTH: [1..12] int = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31);
   private const DAYS_BEFORE_MONTH = init_days_before_month();
 
   /* The Unix Epoch date and time */

--- a/test/optimizations/sungeun/bulk_transfer/assign.good
+++ b/test/optimizations/sungeun/bulk_transfer/assign.good
@@ -1,9 +1,5 @@
 operator =(a:[],b:[]): in chpl__bulkTransferArray
 operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
-In DefaultRectangular._simpleTransfer(): Alo=(1), Blo=(0), len=12, elemSize=8
-operator =(a:[],b:[]): successfully completed bulk transfer
-operator =(a:[],b:[]): in chpl__bulkTransferArray
-operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
 In DefaultRectangular._simpleTransfer(): Alo=(1, 1, 1), Blo=(1, 1, 1), len=315, elemSize=8
 operator =(a:[],b:[]): successfully completed bulk transfer
 operator =(a:[],b:[]): in chpl__bulkTransferArray


### PR DESCRIPTION
Initialize a private array constant with a tuple instead of array

Now that DateTime is combined into Time a test that does 'use Time'
and tracking bulk transfers is seeing an extra array transfer. This is from
initializing a private const array from DateTime with an array literal.
Replace the literal with a tuple literal instead to avoid the extra transfer
message.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>