### PR TITLE
break(Version): stop printing "version " when casting sourceVersion

### DIFF
--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -147,10 +147,10 @@ module Version {
   pragma "no doc"
   operator :(x: sourceVersion(?), type t: string) param {
     if (x.commit == "") then
-      return ("version " + x.major:string + "." + x.minor:string + "." +
+      return (x.major:string + "." + x.minor:string + "." +
               x.update:string);
     else
-      return ("version " + x.major:string + "." + x.minor:string + "." +
+      return (x.major:string + "." + x.minor:string + "." +
               x.update:string + " (" + x.commit + ")");
   }
 

--- a/test/library/standard/Version/compareChplVersion.good
+++ b/test/library/standard/Version/compareChplVersion.good
@@ -1,6 +1,6 @@
 Comparing versions:
-version 2.1.0
-version 2.1.0
+2.1.0
+2.1.0
 ------------------
 == : true
 != : false
@@ -10,8 +10,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0 (aaa)
-version 2.1.0 (aaa)
+2.1.0 (aaa)
+2.1.0 (aaa)
 ------------------
 == : true
 != : false
@@ -21,8 +21,8 @@ version 2.1.0 (aaa)
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 2.1.0 (aaa)
+2.1.0
+2.1.0 (aaa)
 ------------------
 == : false
 != : true
@@ -30,8 +30,8 @@ version 2.1.0 (aaa)
 <= : false
 
 Comparing versions:
-version 2.1.0 (aaa)
-version 2.1.0
+2.1.0 (aaa)
+2.1.0
 ------------------
 == : false
 != : true
@@ -39,8 +39,8 @@ version 2.1.0
 >= : false
 
 Comparing versions:
-version 2.1.0
-version 2.1.1
+2.1.0
+2.1.1
 ------------------
 == : false
 != : true
@@ -50,30 +50,8 @@ version 2.1.1
 >= : false
 
 Comparing versions:
-version 2.1.1
-version 2.1.0
-------------------
-== : false
-!= : true
-<  : false
-<= : false
->  : true
->= : true
-
-Comparing versions:
-version 2.1.0
-version 2.2.0
-------------------
-== : false
-!= : true
-<  : true
-<= : true
->  : false
->= : false
-
-Comparing versions:
-version 2.2.0
-version 2.1.0
+2.1.1
+2.1.0
 ------------------
 == : false
 != : true
@@ -83,8 +61,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 2.2.1
+2.1.0
+2.2.0
 ------------------
 == : false
 != : true
@@ -94,8 +72,8 @@ version 2.2.1
 >= : false
 
 Comparing versions:
-version 2.2.1
-version 2.1.0
+2.2.0
+2.1.0
 ------------------
 == : false
 != : true
@@ -105,8 +83,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 3.1.0
+2.1.0
+2.2.1
 ------------------
 == : false
 != : true
@@ -116,8 +94,8 @@ version 3.1.0
 >= : false
 
 Comparing versions:
-version 3.1.0
-version 2.1.0
+2.2.1
+2.1.0
 ------------------
 == : false
 != : true
@@ -127,8 +105,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 3.1.1
+2.1.0
+3.1.0
 ------------------
 == : false
 != : true
@@ -138,8 +116,8 @@ version 3.1.1
 >= : false
 
 Comparing versions:
-version 3.1.1
-version 2.1.0
+3.1.0
+2.1.0
 ------------------
 == : false
 != : true
@@ -149,8 +127,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 2.1.1 (bbb)
+2.1.0
+3.1.1
 ------------------
 == : false
 != : true
@@ -160,8 +138,8 @@ version 2.1.1 (bbb)
 >= : false
 
 Comparing versions:
-version 2.1.1 (bbb)
-version 2.1.0
+3.1.1
+2.1.0
 ------------------
 == : false
 != : true
@@ -171,8 +149,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 2.2.0 (ccc)
+2.1.0
+2.1.1 (bbb)
 ------------------
 == : false
 != : true
@@ -182,8 +160,8 @@ version 2.2.0 (ccc)
 >= : false
 
 Comparing versions:
-version 2.2.0 (ccc)
-version 2.1.0
+2.1.1 (bbb)
+2.1.0
 ------------------
 == : false
 != : true
@@ -193,8 +171,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 2.2.1 (ddd)
+2.1.0
+2.2.0 (ccc)
 ------------------
 == : false
 != : true
@@ -204,8 +182,8 @@ version 2.2.1 (ddd)
 >= : false
 
 Comparing versions:
-version 2.2.1 (ddd)
-version 2.1.0
+2.2.0 (ccc)
+2.1.0
 ------------------
 == : false
 != : true
@@ -215,8 +193,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 3.1.0 (eee)
+2.1.0
+2.2.1 (ddd)
 ------------------
 == : false
 != : true
@@ -226,8 +204,8 @@ version 3.1.0 (eee)
 >= : false
 
 Comparing versions:
-version 3.1.0 (eee)
-version 2.1.0
+2.2.1 (ddd)
+2.1.0
 ------------------
 == : false
 != : true
@@ -237,8 +215,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.0
-version 3.1.1 (fff)
+2.1.0
+3.1.0 (eee)
 ------------------
 == : false
 != : true
@@ -248,8 +226,8 @@ version 3.1.1 (fff)
 >= : false
 
 Comparing versions:
-version 3.1.1 (fff)
-version 2.1.0
+3.1.0 (eee)
+2.1.0
 ------------------
 == : false
 != : true
@@ -259,8 +237,8 @@ version 2.1.0
 >= : true
 
 Comparing versions:
-version 2.1.1
-version 2.2.0
+2.1.0
+3.1.1 (fff)
 ------------------
 == : false
 != : true
@@ -270,8 +248,8 @@ version 2.2.0
 >= : false
 
 Comparing versions:
-version 2.2.0
-version 2.1.1
+3.1.1 (fff)
+2.1.0
 ------------------
 == : false
 != : true
@@ -281,8 +259,8 @@ version 2.1.1
 >= : true
 
 Comparing versions:
-version 2.1.1
-version 2.2.1
+2.1.1
+2.2.0
 ------------------
 == : false
 != : true
@@ -292,8 +270,8 @@ version 2.2.1
 >= : false
 
 Comparing versions:
-version 2.2.1
-version 2.1.1
+2.2.0
+2.1.1
 ------------------
 == : false
 != : true
@@ -303,8 +281,8 @@ version 2.1.1
 >= : true
 
 Comparing versions:
-version 2.1.1
-version 3.1.0
+2.1.1
+2.2.1
 ------------------
 == : false
 != : true
@@ -314,8 +292,8 @@ version 3.1.0
 >= : false
 
 Comparing versions:
-version 3.1.0
-version 2.1.1
+2.2.1
+2.1.1
 ------------------
 == : false
 != : true
@@ -325,8 +303,8 @@ version 2.1.1
 >= : true
 
 Comparing versions:
-version 2.1.1
-version 3.1.1
+2.1.1
+3.1.0
 ------------------
 == : false
 != : true
@@ -336,8 +314,8 @@ version 3.1.1
 >= : false
 
 Comparing versions:
-version 3.1.1
-version 2.1.1
+3.1.0
+2.1.1
 ------------------
 == : false
 != : true
@@ -347,8 +325,8 @@ version 2.1.1
 >= : true
 
 Comparing versions:
-version 2.1.1
-version 2.2.0 (ccc)
+2.1.1
+3.1.1
 ------------------
 == : false
 != : true
@@ -358,8 +336,8 @@ version 2.2.0 (ccc)
 >= : false
 
 Comparing versions:
-version 2.2.0 (ccc)
-version 2.1.1
+3.1.1
+2.1.1
 ------------------
 == : false
 != : true
@@ -369,8 +347,8 @@ version 2.1.1
 >= : true
 
 Comparing versions:
-version 2.1.1
-version 2.2.1 (ddd)
+2.1.1
+2.2.0 (ccc)
 ------------------
 == : false
 != : true
@@ -380,8 +358,8 @@ version 2.2.1 (ddd)
 >= : false
 
 Comparing versions:
-version 2.2.1 (ddd)
-version 2.1.1
+2.2.0 (ccc)
+2.1.1
 ------------------
 == : false
 != : true
@@ -391,8 +369,8 @@ version 2.1.1
 >= : true
 
 Comparing versions:
-version 2.1.1
-version 3.1.0 (eee)
+2.1.1
+2.2.1 (ddd)
 ------------------
 == : false
 != : true
@@ -402,8 +380,8 @@ version 3.1.0 (eee)
 >= : false
 
 Comparing versions:
-version 3.1.0 (eee)
-version 2.1.1
+2.2.1 (ddd)
+2.1.1
 ------------------
 == : false
 != : true
@@ -413,8 +391,8 @@ version 2.1.1
 >= : true
 
 Comparing versions:
-version 2.1.1
-version 3.1.1 (fff)
+2.1.1
+3.1.0 (eee)
 ------------------
 == : false
 != : true
@@ -424,8 +402,8 @@ version 3.1.1 (fff)
 >= : false
 
 Comparing versions:
-version 3.1.1 (fff)
-version 2.1.1
+3.1.0 (eee)
+2.1.1
 ------------------
 == : false
 != : true
@@ -435,8 +413,8 @@ version 2.1.1
 >= : true
 
 Comparing versions:
-version 2.2.0
-version 2.2.1
+2.1.1
+3.1.1 (fff)
 ------------------
 == : false
 != : true
@@ -446,8 +424,8 @@ version 2.2.1
 >= : false
 
 Comparing versions:
-version 2.2.1
-version 2.2.0
+3.1.1 (fff)
+2.1.1
 ------------------
 == : false
 != : true
@@ -457,8 +435,8 @@ version 2.2.0
 >= : true
 
 Comparing versions:
-version 2.2.0
-version 3.1.0
+2.2.0
+2.2.1
 ------------------
 == : false
 != : true
@@ -468,8 +446,8 @@ version 3.1.0
 >= : false
 
 Comparing versions:
-version 3.1.0
-version 2.2.0
+2.2.1
+2.2.0
 ------------------
 == : false
 != : true
@@ -479,8 +457,8 @@ version 2.2.0
 >= : true
 
 Comparing versions:
-version 2.2.0
-version 3.1.1
+2.2.0
+3.1.0
 ------------------
 == : false
 != : true
@@ -490,8 +468,8 @@ version 3.1.1
 >= : false
 
 Comparing versions:
-version 3.1.1
-version 2.2.0
+3.1.0
+2.2.0
 ------------------
 == : false
 != : true
@@ -501,8 +479,8 @@ version 2.2.0
 >= : true
 
 Comparing versions:
-version 2.2.0
-version 2.2.1 (ddd)
+2.2.0
+3.1.1
 ------------------
 == : false
 != : true
@@ -512,8 +490,8 @@ version 2.2.1 (ddd)
 >= : false
 
 Comparing versions:
-version 2.2.1 (ddd)
-version 2.2.0
+3.1.1
+2.2.0
 ------------------
 == : false
 != : true
@@ -523,8 +501,8 @@ version 2.2.0
 >= : true
 
 Comparing versions:
-version 2.2.0
-version 3.1.0 (eee)
+2.2.0
+2.2.1 (ddd)
 ------------------
 == : false
 != : true
@@ -534,8 +512,8 @@ version 3.1.0 (eee)
 >= : false
 
 Comparing versions:
-version 3.1.0 (eee)
-version 2.2.0
+2.2.1 (ddd)
+2.2.0
 ------------------
 == : false
 != : true
@@ -545,8 +523,8 @@ version 2.2.0
 >= : true
 
 Comparing versions:
-version 2.2.0
-version 3.1.1 (fff)
+2.2.0
+3.1.0 (eee)
 ------------------
 == : false
 != : true
@@ -556,8 +534,8 @@ version 3.1.1 (fff)
 >= : false
 
 Comparing versions:
-version 3.1.1 (fff)
-version 2.2.0
+3.1.0 (eee)
+2.2.0
 ------------------
 == : false
 != : true
@@ -567,8 +545,8 @@ version 2.2.0
 >= : true
 
 Comparing versions:
-version 2.2.1
-version 3.1.0
+2.2.0
+3.1.1 (fff)
 ------------------
 == : false
 != : true
@@ -578,8 +556,8 @@ version 3.1.0
 >= : false
 
 Comparing versions:
-version 3.1.0
-version 2.2.1
+3.1.1 (fff)
+2.2.0
 ------------------
 == : false
 != : true
@@ -589,8 +567,8 @@ version 2.2.1
 >= : true
 
 Comparing versions:
-version 2.2.1
-version 3.1.1
+2.2.1
+3.1.0
 ------------------
 == : false
 != : true
@@ -600,8 +578,8 @@ version 3.1.1
 >= : false
 
 Comparing versions:
-version 3.1.1
-version 2.2.1
+3.1.0
+2.2.1
 ------------------
 == : false
 != : true
@@ -611,8 +589,8 @@ version 2.2.1
 >= : true
 
 Comparing versions:
-version 2.2.1
-version 3.1.0 (eee)
+2.2.1
+3.1.1
 ------------------
 == : false
 != : true
@@ -622,8 +600,8 @@ version 3.1.0 (eee)
 >= : false
 
 Comparing versions:
-version 3.1.0 (eee)
-version 2.2.1
+3.1.1
+2.2.1
 ------------------
 == : false
 != : true
@@ -633,8 +611,8 @@ version 2.2.1
 >= : true
 
 Comparing versions:
-version 2.2.1
-version 3.1.1 (fff)
+2.2.1
+3.1.0 (eee)
 ------------------
 == : false
 != : true
@@ -644,8 +622,8 @@ version 3.1.1 (fff)
 >= : false
 
 Comparing versions:
-version 3.1.1 (fff)
-version 2.2.1
+3.1.0 (eee)
+2.2.1
 ------------------
 == : false
 != : true
@@ -655,8 +633,8 @@ version 2.2.1
 >= : true
 
 Comparing versions:
-version 3.1.0
-version 3.1.1
+2.2.1
+3.1.1 (fff)
 ------------------
 == : false
 != : true
@@ -666,8 +644,8 @@ version 3.1.1
 >= : false
 
 Comparing versions:
-version 3.1.1
-version 3.1.0
+3.1.1 (fff)
+2.2.1
 ------------------
 == : false
 != : true
@@ -677,8 +655,8 @@ version 3.1.0
 >= : true
 
 Comparing versions:
-version 3.1.0
-version 3.1.1 (fff)
+3.1.0
+3.1.1
 ------------------
 == : false
 != : true
@@ -688,8 +666,30 @@ version 3.1.1 (fff)
 >= : false
 
 Comparing versions:
-version 3.1.1 (fff)
-version 3.1.0
+3.1.1
+3.1.0
+------------------
+== : false
+!= : true
+<  : false
+<= : false
+>  : true
+>= : true
+
+Comparing versions:
+3.1.0
+3.1.1 (fff)
+------------------
+== : false
+!= : true
+<  : true
+<= : true
+>  : false
+>= : false
+
+Comparing versions:
+3.1.1 (fff)
+3.1.0
 ------------------
 == : false
 != : true

--- a/test/library/standard/Version/compareChplVersionErrors.good
+++ b/test/library/standard/Version/compareChplVersionErrors.good
@@ -13,8 +13,8 @@ compareChplVersionErrors.chpl:35: error: can't compare versions that only differ
   compareChplVersionErrors.chpl:22: called as compareVersions(v1: sourceVersion(2,1,0,\"bbb\"), v2: sourceVersion(2,1,0,\"aaa\")) from function 'compareBothVersions'
   compareChplVersionErrors.chpl:9: called as compareBothVersions(v1: sourceVersion(2,1,0,\"aaa\"), v2: sourceVersion(2,1,0,\"bbb\"))
 Comparing versions:
-version 2.1.0
-version 2.1.0 (aaa)
+2.1.0
+2.1.0 (aaa)
 ------------------
 == : false
 != : true
@@ -24,8 +24,8 @@ version 2.1.0 (aaa)
 >= : true
 
 Comparing versions:
-version 2.1.0 (aaa)
-version 2.1.0
+2.1.0 (aaa)
+2.1.0
 ------------------
 == : false
 != : true
@@ -35,8 +35,8 @@ version 2.1.0
 >= : false
 
 Comparing versions:
-version 2.1.0 (aaa)
-version 2.1.0 (bbb)
+2.1.0 (aaa)
+2.1.0 (bbb)
 ------------------
 == : false
 != : true
@@ -46,8 +46,8 @@ version 2.1.0 (bbb)
 >= : false
 
 Comparing versions:
-version 2.1.0 (bbb)
-version 2.1.0 (aaa)
+2.1.0 (bbb)
+2.1.0 (aaa)
 ------------------
 == : false
 != : true
@@ -57,8 +57,8 @@ version 2.1.0 (aaa)
 >= : false
 
 Comparing versions:
-version 2.0.0 (aaa)
-version 2.1.0 (aaa)
+2.0.0 (aaa)
+2.1.0 (aaa)
 ------------------
 == : false
 != : true
@@ -68,8 +68,8 @@ version 2.1.0 (aaa)
 >= : false
 
 Comparing versions:
-version 2.1.0 (aaa)
-version 2.0.0 (aaa)
+2.1.0 (aaa)
+2.0.0 (aaa)
 ------------------
 == : false
 != : true
@@ -79,8 +79,8 @@ version 2.0.0 (aaa)
 >= : true
 
 Comparing versions:
-version 2.0.0 (aaa)
-version 2.1.0 (bbb)
+2.0.0 (aaa)
+2.1.0 (bbb)
 ------------------
 == : false
 != : true
@@ -90,8 +90,8 @@ version 2.1.0 (bbb)
 >= : false
 
 Comparing versions:
-version 2.1.0 (bbb)
-version 2.0.0 (aaa)
+2.1.0 (bbb)
+2.0.0 (aaa)
 ------------------
 == : false
 != : true

--- a/test/library/standard/Version/testChplVersion.chpl
+++ b/test/library/standard/Version/testChplVersion.chpl
@@ -4,7 +4,7 @@ proc writeit(param x) {
   writeln(x," : ", x.type:string);
 }
 
-writeln(chplVersion);
+writeln("version " + chplVersion:string);
 writeit(chplVersion.major);
 writeit(chplVersion.minor);
 writeit(chplVersion.update);

--- a/test/library/standard/Version/versionCastIsParam.chpl
+++ b/test/library/standard/Version/versionCastIsParam.chpl
@@ -1,7 +1,7 @@
 use Version;
 
 var v = createVersion(1,23,0);
-param test = (v:string == "version 1.23.0");
+param test = ("version " + v:string == "version 1.23.0");
 
 var v2 = createVersion(1,23,0,"vass");
 compilerWarning(v2:string);

--- a/test/library/standard/Version/versionCastIsParam.good
+++ b/test/library/standard/Version/versionCastIsParam.good
@@ -1,2 +1,2 @@
-versionCastIsParam.chpl:7: warning: version 1.23.0 (vass)
+versionCastIsParam.chpl:7: warning: 1.23.0 (vass)
 versionCastIsParam.chpl:13: error: Yay!


### PR DESCRIPTION
This PR changes the behavior when casting a `sourceVersion` to
string. After this PR, we will no longer append `version ` to
the `major.minor.update (commit)` format.

Marked as potentially breaking if you were previously relying
on `version ` being in the result of a cast from a `sourceVersion`,
including `chplVersion`.


* change the behavior when casting a `sourceVersion` to string to
  no longer prepend the word "version " to the resulting string.
  This change was discussed in
  https://github.com/chapel-lang/chapel/issues/19928

* update tests to no longer expect "version " in most cases

TESTING: 

- [x] `paratest` 


Signed-off-by: arezaii <ahmad.rezaii@hpe.com>