### PR TITLE
Pin gcc version 11.2.0 for Arkouda XC testing

### DIFF
--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -16,6 +16,8 @@ module list
 # setup for XC perf (ugni, gnu, 28-core broadwell)
 module unload $(module -t list 2>&1 | grep PrgEnv-)
 module load PrgEnv-gnu
+# pin gcc 11.2.0 due to warnings with 12.1.0
+module swap gcc gcc/11.2.0
 module unload $(module -t list 2>&1 | grep craype-hugepages)
 module load craype-hugepages16M
 module unload perftools-base


### PR DESCRIPTION
After our XC nightly testing updated to gcc 12.1.0, we were
seeing some warnings causing build failures regarding some
templates (`error: expected 'template' keyword before dependent
template name`). Reverting to 11.2.0 removes these errors,
but we would like to not need to pin the version, so this
change should be removed on our nightly runs when the problem
is resolved.