### PR TITLE
Address GCC 12 warnings

### DIFF
--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -2163,10 +2163,9 @@ void Resolver::resolveNewForRecord(const uast::New* node,
 
   if (node->management() != New::DEFAULT_MANAGEMENT) {
     auto managementStr = New::managementToString(node->management());
-    auto recordNameStr = recordType->name().c_str();
     context->error(node, "Cannot use new %s with record %s",
                          managementStr,
-                         recordNameStr);
+                         recordType->name().c_str());
   } else {
     auto qt = QualifiedType(QualifiedType::VAR, recordType);
     re.setType(qt);

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -806,9 +806,9 @@ static void maybePrintErrorHeader(chpl::ID id) {
 
     auto& declLoc = chpl::parsing::locateId(gContext, declId);
     auto line = declLoc.firstLine();
-    auto path = declLoc.path().c_str();
+    auto path = declLoc.path();
 
-    fprintf(stderr, "%s:%d: In %s:\n", path, line, declLabelStr);
+    fprintf(stderr, "%s:%d: In %s:\n", path.c_str(), line, declLabelStr);
 
     // Set so that we don't print out the same header over and over.
     idForLastContainingDecl = declId;
@@ -823,11 +823,11 @@ static void dynoDisplayError(chpl::Context* context,
 
   // For now have syntax errors just do their own thing (mimic old parser).
   if (err.kind() == chpl::ErrorMessage::SYNTAX) {
-    const char* path = loc.path().c_str();
+    UniqueString path = loc.path();
     const int line = loc.line();
     const int tagUsrFatalCont = 3;
-    setupError("parser", path, line, tagUsrFatalCont);
-    fprintf(stderr, "%s:%d: %s", path, line, "syntax error");
+    setupError("parser", path.c_str(), line, tagUsrFatalCont);
+    fprintf(stderr, "%s:%d: %s", path.c_str(), line, "syntax error");
     if (strlen(msg) > 0) {
       fprintf(stderr, ": %s\n", msg);
     } else {

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -287,6 +287,16 @@ ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 12; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-error=missing-template-keyword
 endif
 
+#
+# Avoid errors like '&expression' will never be NULL
+# because they occur in LLVM headers.
+# We would like to know when this occurs, though, so don't turn off
+# the warning; just don't let it abort the build.
+#
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 12; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-error=address
+endif
+
 
 #
 # Avoid false positive warnings about use-after free with realloc

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -268,6 +268,27 @@ WARN_CXXFLAGS += -Wno-error=init-list-lifetime
 endif
 
 #
+# Avoid errors about uninitialized memory because they occur in LLVM headers
+# (should be fixed in LLVM 15 though).
+# We would like to know when this occurs, though, so don't turn off
+# the warning; just don't let it abort the build.
+#
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 12; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-error=uninitialized
+endif
+
+#
+# Avoid errors about dependent template name because they occur in LLVM headers
+# (should be fixed in LLVM 15 though).
+# We would like to know when this occurs, though, so don't turn off
+# the warning; just don't let it abort the build.
+#
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 12; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-error=missing-template-keyword
+endif
+
+
+#
 # Avoid false positive warnings about use-after free with realloc
 # that occur in GCC 12.
 #


### PR DESCRIPTION
Some of our nightly testing configurations started using GCC 12.1. That led to several build failures due to new warnings in GCC 12.

For the warnings-as-errors in LLVM headers, update Makefile.gnu to pass `-Wno-error` flags for these, so that they continue to be warnings, but will not break the build. Two of these problems in the LLVM source code should be fixed for LLVM 15. (See [8e066b86a73205cdaf758a9dd4d761406d39bff1](https://github.com/llvm/llvm-project/commit/8e066b86a73205cdaf758a9dd4d761406d39bff1) and [1d9086bf054c2e734940620d02d4451156b424e6](https://github.com/llvm/llvm-project/commit/1d9086bf054c2e734940620d02d4451156b424e6) ). It's unclear to me if third problem related to `-Wno-error=address` and `DeclObjC.h` will remain in LLVM 15.

There were a few warnings about dangling pointers to unnamed temporaries as well which represented real potential problems and this PR fixes those.

Reviewed by @dlongnecke-cray - thanks!

- [x] compiler builds on an XC with GCC 12.1 with CHPL_LLVM=none
- [x] compiler builds on an XC with GCC 12.1 with CHPL_LLVM=system
- [x] full local testing