### PR TITLE
Ignore the -Wunused-result flag from GASNet

### DIFF
--- a/util/chplenv/chpl_gasnet.py
+++ b/util/chplenv/chpl_gasnet.py
@@ -54,7 +54,11 @@ def filter_compile_args(args):
     # certain flags from the gasnet .pc file
     more_filtered = [ ]
     for arg in ret:
-        if arg.startswith('-O') or arg == '-Winline' or arg == '-g':
+        skip_flag = (
+            arg.startswith('-O') or arg == '-Winline' or
+            arg == '-g' or arg == '-Wunused-result'
+        )
+        if skip_flag:
             pass # leave out this flag
         else:
             more_filtered.append(arg)


### PR DESCRIPTION
This flag is not supported by the Intel compiler (icc),
and causes warnings when building programs. With this
PR merged, builds using ICC and GASNet should return
back to normal.

It's not at all clear to me what changed between the last
successful build with ICC/GASNet and the failing builds.
Some facts that I have gathered (@mppf points out
that one of these is likely false, otherwise we wouldn't
be in this situation).
1. The commit that passed the last successful build is
    now failing it on the same machine, with the same
    error (`-Wunused-result` is not recognized)
2. The module versions of the Intel compilers have
     not changed between the working and failing builds,
     nor have the versions of any other modules, at
    least as reported in the Jenkins build logs.

Moreover, here's a quick primer on how
`-Wunused-result` slips into _our_ code (into our
`chpl` invocation!!)

1. `printchplenv` (or a similar script using the same
    underlying Python code) loads additional compile
    flags for target programs. This is influenced by
    various other libraries used for runtime (GASNet
    included)
2. For `GASNet` specifically, the flags are loaded
    from `pkg-config` files generated during the
    build. These files reside _in our source tree_,
    and are _freshly generated each time_. 
3. The `GASNet` `pkg-config`file sure does
    specify `-Wunused-result`, so there's that.
4. Most interestingly, the `./configure` script that
    runs (and presumably informs the `pkg-config`
    file) correctly detects the Intel compiler, correctly
    runs it to determine that _some_ flags are not
    supported by the compiler (complete with the
    error message issued by the compiler, which is
    very similar to the one in Jenkins for `Wunused-result`),
    but then __reports that `Wunused-result` is supported__.
    Why this happens is beyond me.

This PR in particular acts on step (2), where the Python
script is simply told to ignore `Wunused-result` when
it finds it in the `pkg-config` file. A smarter and more
informed solution would determine

a) why `Wunused-result` is incorrectly detected in `icc`
b) what changed between the builds on July 25 and July 30

However, having spent a few hours, I don't think
further investigation is worth it at the time.

Testing:
- [x] `make && make check` now passes on Horizon in the intel configuration
- [x] Builds locally in gcc configuration 

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>