### PR TITLE
Disable Werror for unknown attribute warnings for icc

### DIFF
--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -129,7 +129,7 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 #  174 : warns about expressions that have no effect
 #  177 : warns about unused variable declarations
 
-WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599
+WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599 -diag-warning 3924
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177


### PR DESCRIPTION
Intel's compiler claims to recognize clang-specific
attributes but then doesn't, and warns about it. Builds
with `Werror` pick this up and break. This change
makes the specific attribute warning not an error, which
lets the builds finish.

In the specific case of failures we observed, the following
happened:

1. Compilation of the LLVM support library failed around
   `LLVM_NODISCARD` when using `icc` as the _host_
    compiler.
3. The `LLVM_NODISCARD` flag checks for the attribute
    `clang::warn_unused_result`, and if it's present,
    expands to `[[clang::warn_unused_result]]`.
4. `icc` reports that it has `clang::warn_unused_result`,
     but doesn't recognize the attribute when push comes
     to shove. This results in a warning.
5. The warning is escalated by `-Werror` into an error.

This PR overrides the `Werror` behavior to make the
attribute diagnostic message just a warning.

Reviewed my @mppf - thanks!

TESTING
- [x] compilation failed in repro environment prior to this
   commit as expected, but succeeded with new flag.