### PR TITLE
Fix testReleaseHelp to check only Chapel version

### DIFF
--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -84,7 +84,7 @@ set patch=`cat compiler/main/version_num.h | grep UPDATE_VERSION | cut -f3 -d' '
 set expected_version_string="$major.$minor.$patch"
 
 # Test chpl --version for expected string version.
-set version_string = `chpl --version | grep 'version' | cut -d' ' -f 3`
+set version_string = `chpl --version | grep 'chpl version' | cut -d' ' -f 3`
 set versionstatus = $status
 if ($versionstatus != 0) then
     echo "ERROR: execution of chpl --version failed"


### PR DESCRIPTION
Follow-up to PR #20396 to fix a test failure.

Test code was picking up the LLVM version as well
since now with LLVM support the output looks like this e.g.:

    chpl version 1.28.0 pre-release (e4f5b05948)
      built with LLVM version 14.0.0

Fix that by adjusting a `grep` call used in buildReleaseHelp.

Reviewed by @daviditen - thanks!

- [x] `util/buildRelease/testRelease -debug` works