### PR TITLE
Fix for failing GPU Perf tests

### DIFF
--- a/test/gpu/native/studies/shoc/result.chpl
+++ b/test/gpu/native/studies/shoc/result.chpl
@@ -127,7 +127,7 @@ module ResultDB {
                     median = (resultSorted[(resultSorted.size)/2] +
                                 resultSorted[(resultSorted.size-2)/2]) / 2 ;
                 }
-                writeln(testName, " ",atts,": ", blockSize, attsSuffix," Median: ", median, " ", units);
+                writeln(testName, " ",atts," ", blockSize, attsSuffix," Median: ", median, " ", units);
             }
         }
     }


### PR DESCRIPTION
Simple colon was breaking tests.

Both `start_test` and `start_test --perflabel gpu-` for `test/gpu/native/studies/shoc` are now passing on Osprey so I think this should fix that issue.