### PR TITLE
Fix problems after LLVM configuration PRs

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -61,7 +61,7 @@ $(CHPL_ENV_HEADER): $(CHPL_MAKE_HOME)/util/printchplenv $(CHPL_MAKE_HOME)/util/c
 	# save output of printchplenv into #defines but munge away
 	# characters that can't be in #defines
 	@$(CHPL_MAKE_HOME)/util/printchplenv --runtime --no-tidy --anonymize --simple | \
-	  sed 's/^[ \t]*//;s/[ \t]*$$//' | \
+	  sed 's/^ *//;s/ *$$//' | \
 	  sed 's/[^0-9A-Za-z]/_/g' | \
 	  awk '{ print "#define " toupper($$1) }' >> $(CHPL_ENV_HEADER)
 	@echo "#endif /* _CHPL_ENV_GEN_H_ */" >> $(CHPL_ENV_HEADER)

--- a/test/runtime/sungeun/chpl-env-gen.precomp
+++ b/test/runtime/sungeun/chpl-env-gen.precomp
@@ -27,7 +27,7 @@ with open(genfile, 'w') as f:
         key_val = re.sub(r'[^0-9A-Za-z]', '_', key_val)
         key_val = key_val.upper()
         f.write('#ifndef %s\n'%(key_val))
-        f.write('#error "%s undefined or does not match runtime definition"\n'%(val))
+        f.write('#error "%s=%s undefined or does not match runtime definition"\n'%(key, val))
         f.write('#endif\n')
 
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -104,6 +104,8 @@ def check_llvm_config(llvm_config):
 # Ensure that relevant LLVM-related header files and libraries have been
 # installed. If these are missing it usually indicates the user failed to
 # install some necessary package.
+#
+# Returns a tuple like (isOk, errorMessage)
 def check_llvm_packages(llvm_config):
     llvm_header = ''
     llvm_include_ok = False
@@ -388,13 +390,17 @@ def get_llvm_clang(lang):
 def has_compatible_installed_llvm():
     llvm_config = find_system_llvm_config()
 
-    if llvm_config:
-        clang_c_command = get_system_llvm_clang('c')
-        clang_cxx_command = get_system_llvm_clang('c++')
 
-        if (os.path.exists(clang_c_command) and
-            os.path.exists(clang_cxx_command)):
-            return True
+    if llvm_config:
+        (ok, errMsg) = check_llvm_packages(llvm_config)
+
+        if ok:
+            clang_c_command = get_system_llvm_clang('c')
+            clang_cxx_command = get_system_llvm_clang('c++')
+
+            if (os.path.exists(clang_c_command) and
+                os.path.exists(clang_cxx_command)):
+                return True
 
     # otherwise, something went wrong, so return False
     return False
@@ -415,6 +421,7 @@ def get():
                 llvm_val = 'bundled'
             elif has_compatible_installed_llvm():
                 llvm_val = 'system'
+            # otherwise, the default remains 'unset' -- ask user
 
         else:
             # This platform doesn't work with the LLVM backend

--- a/util/cron/common-quickstart.bash
+++ b/util/cron/common-quickstart.bash
@@ -9,3 +9,10 @@ source ${CHPL_HOME}/util/quickstart/setchplenv.bash
 # Skip $CHPL_HOME/test/regex/elliot/I-fail-without-re2
 export CHPL_TEST_REGEX=none
 export CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET=yes
+
+# Always use the C backend in quikcstart test configurations.
+# quickstart/setchplenv.bash will activate CHPL_LLVM=system if a
+# compatible system LLVM is available. However, this testing configuration
+# should always use CHPL_LLVM=none because that is a likely possibility
+# for quickstart compiles & we test CHPL_LLVM=system in other configs.
+export CHPL_LLVM=none


### PR DESCRIPTION
Follow-up to PRs #20396 and #20385 to address issues raised by nightly testing.

* build failures in cron-xc-wb-host-prgenv-cray-failure and xc-wb.prgenv-cray configurations: don't default to CHPL_LLVM_SUPPORT=system if all the LLVM dependencies are not installed. These configurations have just `llvm-config` but not the required headers.
* networking-packages failure with curl tests: update `common-quickstart.bash` to set `CHPL_LLVM=none`. The quickstart setup script can provide `CHPL_LLVM=none` or `CHPL_LLVM=system` but since we test `CHPL_LLVM=system` in most configurations, in the quickstart testing configuration, we want to test `CHPL_LLVM=none`. At the moment, the curl tests do not all work with the LLVM backend.
* darwin-m1 or other Mac OS testing failure with chpl-env-gen: fixed a sed portability issue between linux and Mac OS X.

Reviewed by @arezaii - thanks!

- [x] On Ubuntu, if llvm-14 is installed but not llvm-14-dev
  * default is CHPL_LLVM=unset and CHPL_LLVM_SUPPORT=bundled
  * setting CHPL_LLVM=system produces an error from printchplenv about a missing header
- [x] On Ubuntu, if we have the needed LLVM dependencies
  * default is CHPL_LLVM=system and CHPL_LLVM_SUPPORT=system
- [x] `make` functions on XC with PrgEnv-cray and GCC as the host compiler
- [x] `make` functions on XC with PrgEnv-cray and cray-prgenv-cray as the host compiler
- [x] full local testing