### PR TITLE
Another fix for CMake definition generation for the 32bit linux tests 

### DIFF
--- a/test/interop/C/cmakelists/targetToChpl/CMakeLists.txt
+++ b/test/interop/C/cmakelists/targetToChpl/CMakeLists.txt
@@ -6,3 +6,5 @@ add_executable(cmakeTest cmakeTest.c)
 include(lib/FooLibrary.cmake)
 target_include_directories(cmakeTest PUBLIC ${FooLibrary_INCLUDE_DIRS})
 target_link_libraries(cmakeTest PUBLIC ${FooLibrary_LINK_LIBS})
+
+list(GET CHPL_COMPILER 0 CMAKE_C_COMPILER)

--- a/test/interop/C/cmakelists/targetToChpl/Makefile
+++ b/test/interop/C/cmakelists/targetToChpl/Makefile
@@ -1,5 +1,5 @@
 test:
-	cd build && cmake .. -DCMAKE_C_COMPILER=clang && make
+	cd build && cmake .. && make
 	build/cmakeTest
 
 clean:

--- a/test/interop/C/cmakelists/targetToLibToChpl/CMakeLists.txt
+++ b/test/interop/C/cmakelists/targetToLibToChpl/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(cmakeTest)
 cmake_minimum_required(VERSION 3.18)
 
+include(lib/FooLibrary.cmake)
+list(GET CHPL_COMPILER 0 CMAKE_C_COMPILER)
 add_subdirectory(src/clib)
 add_subdirectory(src/exec)
+

--- a/test/interop/C/cmakelists/targetToLibToChpl/Makefile
+++ b/test/interop/C/cmakelists/targetToLibToChpl/Makefile
@@ -1,5 +1,5 @@
 test:
-	cd build && cmake -DCMAKE_C_COMPILER=clang .. && make
+	cd build && cmake .. && make
 	build/src/exec/cmakeTest
 
 clean:


### PR DESCRIPTION
Previously I had required the tests to use clang, which the 32bit testing machine does not have. Now, I extract the compiler executable path from the CHPL_COMPILER variable and use that instead. Tested to work on my machine, chapcs11, and mnlchapvm04, which is the system that the test was failing for.