### PR TITLE
Update prereqs to require GCC 7.1 or Clang 5.0

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -21,12 +21,18 @@ for using Chapel:
 
   * You have access to ``gmake`` or a GNU-compatible version of ``make``.
 
-  * You have access to standard C and C++14 compilers. The C++14 support
-    is required for building the compiler itself. In particular, GCC 7.1
-    or Clang 5.0 (or higher) not only have C++14 support, but are also
-    suitable for building third-party components such as LLVM and its support
-    library. Note that C11 support, while not required, will enable
-    faster atomic operations.
+  * You have access to standard C and C++ compilers.
+
+    * Building the Chapel compiler and bundled components requires
+      C++14 and one of the following:
+
+      * GCC 7.1 or newer
+
+      * Clang 5.0 or newer
+
+      * Apple Clang 9.3 or newer
+
+    * C11 support, while not required, will enable faster atomic operations.
 
   * CMake is available and ``cmake`` runs version 3.13.4 or later.
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -22,9 +22,11 @@ for using Chapel:
   * You have access to ``gmake`` or a GNU-compatible version of ``make``.
 
   * You have access to standard C and C++14 compilers. The C++14 support
-    is required for building the compiler itself. For GCC specifically,
-    GCC 5 or newer is required for C++14 support. Note that C11 support,
-    while not required, will enable faster atomic operations.
+    is required for building the compiler itself. In particular, GCC 7.1
+    or Clang 5.0 (or higher) not only have C++14 support, but are also
+    suitable for building third-party components such as LLVM and its support
+    library. Note that C11 support, while not required, will enable
+    faster atomic operations.
 
   * CMake is available and ``cmake`` runs version 3.13.4 or later.
 


### PR DESCRIPTION
These versions are required by LLVM, and have full C++17
support. At some point in the future, we would like to
be able to use C++17 as well. See also the following
issue for a more in-depth discussion.

https://github.com/chapel-lang/chapel/issues/20232

Reviewed by @mppf - thanks!

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>