### PR TITLE
locale module documentation improvements

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -202,8 +202,8 @@ module ChapelLocale {
   /*
     Get the unique integer identifier for this locale.
 
-  :returns: index of this locale in the range ``0..numLocales-1``
-  :rtype: int
+    :returns: index of this locale in the range ``0..numLocales-1``
+    :rtype: int
 
   */
   inline proc locale.id: int {
@@ -212,17 +212,18 @@ module ChapelLocale {
 
   /*
     Get the maximum task concurrency that one can expect to
-    achieve on this locale.  The value is an estimate by the
-    runtime tasking layer.  Typically it is the number of physical
-    processor cores available to the program.  Creating more tasks
-    than this will probably increase walltime rather than decrease
-    it.
+    achieve on this locale.
 
     :returns: the maximum number of tasks that can run in parallel
       on this locale
     :rtype: int
+
+    Note that the value is an estimate by the runtime tasking layer.
+    Typically it is the number of physical processor cores available
+    to the program.  Creating more tasks than this will probably increase
+    walltime rather than decrease it.
   */
-  inline proc locale.maxTaskPar : int { return this._value.maxTaskPar; }
+  inline proc locale.maxTaskPar: int { return this._value.maxTaskPar; }
 
   // the following are normally taken care of by `forwarding`. However, they
   // don't work if they are called in a promoted expression. See 15148
@@ -295,7 +296,7 @@ module ChapelLocale {
     them.
   */
   pragma "fn synchronization free"
-  proc locale.runningTasks() : int {
+  proc locale.runningTasks(): int {
     return this.runningTaskCnt();
   }
 

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -220,8 +220,8 @@ module ChapelLocale {
 
     Note that the value is an estimate by the runtime tasking layer.
     Typically it is the number of physical processor cores available
-    to the program.  Creating more tasks than this will probably increase
-    walltime rather than decrease it.
+    to the program.  Executing a data-parallel construct with more
+    tasks this that is unlikely to improve performance.
   */
   inline proc locale.maxTaskPar: int { return this._value.maxTaskPar; }
 

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -232,7 +232,7 @@ module ChapelLocale {
 
     A *processing unit* or *PU* is an instance of the processor
     architecture, basically the thing that executes instructions.
-    :proc:`locale.numPus` tells how many of these are present on this
+    :proc:`locale.numPUs` tells how many of these are present on this
     locale.  It can count either physical PUs (commonly known as
     *cores*) or hardware threads such as hyperthreads and the like.
     It can also either take into account any OS limits on which PUs
@@ -259,8 +259,8 @@ module ChapelLocale {
     running programs within Cray batch jobs that have been set up
     with limited processor resources.
   */
-  inline proc locale.numPus(logical: bool = false, accessible: bool = true) {
-    return this._value.numPus(logical, accessible);
+  inline proc locale.numPUs(logical: bool = false, accessible: bool = true): int {
+    return this._value.numPUs(logical, accessible);
   }
 
   /*
@@ -336,7 +336,7 @@ module ChapelLocale {
     pragma "no doc" var nPUsPhysAll: int;    // HW cores, all
 
     inline
-    proc numPus(logical: bool = false, accessible: bool = true)
+    proc numPUs(logical: bool = false, accessible: bool = true)
       return if logical
              then if accessible then nPUsLogAcc else nPUsLogAll
              else if accessible then nPUsPhysAcc else nPUsPhysAll;

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -232,7 +232,7 @@ module ChapelLocale {
 
     A *processing unit* or *PU* is an instance of the processor
     architecture, basically the thing that executes instructions.
-    :proc:`locale.numPUs` tells how many of these are present on this
+    :proc:`locale.numPus` tells how many of these are present on this
     locale.  It can count either physical PUs (commonly known as
     *cores*) or hardware threads such as hyperthreads and the like.
     It can also either take into account any OS limits on which PUs
@@ -259,8 +259,8 @@ module ChapelLocale {
     running programs within Cray batch jobs that have been set up
     with limited processor resources.
   */
-  inline proc locale.numPUs(logical: bool = false, accessible: bool = true) {
-    return this._value.numPUs(logical, accessible);
+  inline proc locale.numPus(logical: bool = false, accessible: bool = true) {
+    return this._value.numPus(logical, accessible);
   }
 
   /*
@@ -336,7 +336,7 @@ module ChapelLocale {
     pragma "no doc" var nPUsPhysAll: int;    // HW cores, all
 
     inline
-    proc numPUs(logical: bool = false, accessible: bool = true)
+    proc numPus(logical: bool = false, accessible: bool = true)
       return if logical
              then if accessible then nPUsLogAcc else nPUsLogAll
              else if accessible then nPUsPhysAcc else nPUsPhysAll;

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -211,19 +211,25 @@ module ChapelLocale {
   }
 
   /*
-    This is the maximum task concurrency that one can expect to
+    Get the maximum task concurrency that one can expect to
     achieve on this locale.  The value is an estimate by the
     runtime tasking layer.  Typically it is the number of physical
     processor cores available to the program.  Creating more tasks
     than this will probably increase walltime rather than decrease
     it.
+
+    :returns: the maximum number of tasks that can run in parallel
+      on this locale
+    :rtype: int
   */
-  inline proc locale.maxTaskPar { return this._value.maxTaskPar; }
+  inline proc locale.maxTaskPar : int { return this._value.maxTaskPar; }
 
   // the following are normally taken care of by `forwarding`. However, they
   // don't work if they are called in a promoted expression. See 15148
 
   /*
+    Get the number of processing units available on this locale.
+
     A *processing unit* or *PU* is an instance of the processor
     architecture, basically the thing that executes instructions.
     :proc:`locale.numPUs` tells how many of these are present on this
@@ -243,8 +249,8 @@ module ChapelLocale {
     :returns: number of PUs
     :rtype: `int`
 
-    There are several things that can cause the OS to limit the
-    processor resources available to a Chapel program.  On plain
+    Note that there are several things that can cause the OS to limit
+    the processor resources available to a Chapel program.  On plain
     Linux systems using the ``taskset(1)`` command will do it.  On
     Cray systems the ``CHPL_LAUNCHER_CORES_PER_LOCALE`` environment
     variable may do it, indirectly via the system job launcher.
@@ -267,6 +273,8 @@ module ChapelLocale {
   inline proc locale.callStackSize { return this._value.callStackSize; }
 
   /*
+    Get the number of tasks running on this locale.
+
     :returns: the number of tasks that have begun executing, but have not yet finished
     :rtype: `int`
 
@@ -287,7 +295,7 @@ module ChapelLocale {
     them.
   */
   pragma "fn synchronization free"
-  proc locale.runningTasks() {
+  proc locale.runningTasks() : int {
     return this.runningTaskCnt();
   }
 


### PR DESCRIPTION
Made some small improvements to the locale docs:
- Added return types to public methods that did not already have them: `maxTaskPar`, `numPUs`, `runningTasks()`. 
- Made minor changes to the layout of method descriptions to make them more uniform. I.e. the first line should be a terse description of what the method does, then additional details in the next paragraph if necessary, then the return/argument types, and more advanced notes should be at the end. 

Note: `numPUs` needs to be changed to `numPus`; however, I am waiting on the discussion in this issue https://github.com/chapel-lang/chapel/issues/20445 to finish before moving forward.