### PR TITLE
Remove workarounds for issue #15756

### DIFF
--- a/test/functions/deitz/nested/test_nested_with_begin.chpl
+++ b/test/functions/deitz/nested/test_nested_with_begin.chpl
@@ -1,6 +1,4 @@
 var s: sync bool;
-proc ensureDefaultInit(arg) { }
-ensureDefaultInit(s); // make sure s is default-initialized empty
 
 proc foo() {
   var i: int = 2;

--- a/test/parallel/begin/waynew/simple2.chpl
+++ b/test/parallel/begin/waynew/simple2.chpl
@@ -1,6 +1,4 @@
 var go: sync bool;
-proc ensureDefaultInit(arg) { }
-ensureDefaultInit(go); // make sure go is default-initialized
 
 var a: sync int;
 

--- a/test/parallel/taskPool/figueroa/TooManyThreads.chpl
+++ b/test/parallel/taskPool/figueroa/TooManyThreads.chpl
@@ -25,8 +25,6 @@ var total: int,
     count: int = numThreads,
      done: sync bool,
     ready: sync bool;
-ensureDefaultInit(ready);
-proc ensureDefaultInit(arg) { }
 
 proc foo (x) {
 


### PR DESCRIPTION
Resolves #15756.

Issue #15756 listed 3 tests that had workarounds for an issue with split-init combined with sync variables. However the workarounds are no longer needed now that we have deprecated assignment to sync variables since the `s.writeEF` calls do not activate split-init.

A sync variable can be split-initialized today without any deprecation warning e.g. `var s: sync int; ...; s = true;`. However:
 * if an assignment is desired, it would need to be `writeEF` or else be a deprecation
 * if the code in the `...` uses the sync variable, it should be an error reported by the compiler (for module-level code or code within a function)

We still have issue #15769 for the more general question of how one should write a variable that isn't default initialized.

Reviewed by @ronawho - thanks!