### PR TITLE
Deprecate IO Operator

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -473,6 +473,13 @@ static void checkOperator(FnSymbol* fn) {
   } else {
     if (!isAstrOpName(fn->name)) {
       USR_FATAL_CONT(fn, "'%s' is not a legal operator name", fn->name);
+    } else if (astr("<~>") == astr(fn->name)) {
+      if (fn->hasFlag(FLAG_DEPRECATED) == false) {
+        const char* msg = astr("the <~> operator is deprecated");
+        USR_WARN(fn, "%s", msg);
+        fn->addFlag(FLAG_DEPRECATED);
+        fn->deprecationMsg = msg;
+      }
     }
   }
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -287,6 +287,8 @@ if there was an error. See:
 In addition, there is a convenient synonym for :proc:`channel.write` and
 :proc:`channel.read`: the `<~> operator`
 
+.. note:: the <~> operator is deprecated
+
 Sometimes it's important to flush the buffer in a channel - to do that, use the
 :proc:`channel.flush()` method. Flushing the buffer will make all writes available
 to other applications or other views of the file (e.g., it will call the OS call
@@ -3661,6 +3663,7 @@ proc channel.writeIt(const x) throws {
      :returns: ch
      :throws SystemError: When an IO error has occurred.
    */
+  deprecated "the <~> operator is deprecated"
   inline operator channel.<~>(const ref ch: channel, const x) const ref throws
   where ch.writing {
     try ch.writeIt(x);
@@ -3669,6 +3672,7 @@ proc channel.writeIt(const x) throws {
 
   // documented in the writing version.
   pragma "no doc"
+  deprecated "the <~> operator is deprecated"
   inline operator channel.<~>(const ref ch: channel, ref x) const ref throws
   where !ch.writing {
     try ch.readIt(x);
@@ -3690,6 +3694,7 @@ proc channel.writeIt(const x) throws {
      works without requiring an explicit temporary value to store
      the ioLiteral.
    */
+  deprecated "the <~> operator is deprecated"
   inline operator channel.<~>(const ref r: channel,
                               lit:ioLiteral) const ref throws
   where !r.writing {
@@ -3708,6 +3713,7 @@ proc channel.writeIt(const x) throws {
      works without requiring an explicit temporary value to store
      the ioNewline.
    */
+  deprecated "the <~> operator is deprecated"
   inline operator channel.<~>(const ref r: channel,
                               nl:ioNewline) const ref throws
   where !r.writing {

--- a/test/deprecated/IO/ioOperator.chpl
+++ b/test/deprecated/IO/ioOperator.chpl
@@ -1,0 +1,38 @@
+
+use IO;
+
+record R {
+  var x : int;
+}
+
+operator R.<~>(ref r : R, arg : int) ref {
+  r.x = arg;
+  return r;
+}
+
+proc main() {
+  var f = openmem();
+  {
+    var w = f.writer();
+    w <~> "hello";
+    w <~> new ioNewline();
+    w <~> new ioLiteral("-----\n");
+    w <~> "goodbye";
+  }
+  {
+    var r = f.reader();
+    var s : string;
+    r <~> s;
+    writeln(s);
+    r <~> new ioNewline();
+    r <~> new ioLiteral("-----\n");
+    r <~> s;
+    writeln(s);
+  }
+  {
+    var r = new R(0);
+    r <~> 5 <~> 10 <~> 42;
+    writeln(r);
+  }
+
+}

--- a/test/deprecated/IO/ioOperator.good
+++ b/test/deprecated/IO/ioOperator.good
@@ -1,0 +1,16 @@
+ioOperator.chpl:8: warning: the <~> operator is deprecated
+ioOperator.chpl:13: In function 'main':
+ioOperator.chpl:17: warning: the <~> operator is deprecated
+ioOperator.chpl:18: warning: the <~> operator is deprecated
+ioOperator.chpl:19: warning: the <~> operator is deprecated
+ioOperator.chpl:20: warning: the <~> operator is deprecated
+ioOperator.chpl:25: warning: the <~> operator is deprecated
+ioOperator.chpl:27: warning: the <~> operator is deprecated
+ioOperator.chpl:28: warning: the <~> operator is deprecated
+ioOperator.chpl:29: warning: the <~> operator is deprecated
+ioOperator.chpl:34: warning: the <~> operator is deprecated
+ioOperator.chpl:34: warning: the <~> operator is deprecated
+ioOperator.chpl:34: warning: the <~> operator is deprecated
+hello
+goodbye
+(x = 42)

--- a/test/functions/operatorOverloads/operatorMethods/allOps/ioOperator.good
+++ b/test/functions/operatorOverloads/operatorMethods/allOps/ioOperator.good
@@ -1,1 +1,5 @@
+ioOperator.chpl:7: warning: the <~> operator is deprecated
+ioOperator.chpl:13: In function 'main':
+ioOperator.chpl:15: warning: the <~> operator is deprecated
+ioOperator.chpl:15: warning: the <~> operator is deprecated
 3

--- a/test/visibility/except/operatorsExceptions/DefinesOp.chpl
+++ b/test/visibility/except/operatorsExceptions/DefinesOp.chpl
@@ -90,16 +90,6 @@ module ProvidesOps {
     return(lhs.x != rhs.x);
   }
 
-  use IO;
-
-  operator <~>(const ref ch: channel, const x: Foo) const ref throws
-    where ch.writing {
-
-    writeln("In ProvidesOps.<~>");
-    try ch.write(x.x);
-    return ch;
-  }
-
   operator <(lhs: Foo, rhs: Foo) {
     writeln("In ProvidesOps.<");
     return(lhs.x < rhs.x);

--- a/test/visibility/except/operatorsExceptions/exceptIO.chpl
+++ b/test/visibility/except/operatorsExceptions/exceptIO.chpl
@@ -1,5 +1,19 @@
+
+module DefinesOp {
+  use ProvidesTypes;
+  use IO;
+
+  operator <~>(const ref ch: channel, const x: Foo) const ref throws
+    where ch.writing {
+
+    writeln("In ProvidesOps.<~>");
+    try ch.write(x.x);
+    return ch;
+  }
+}
+
 use ProvidesTypes;
-use ProvidesOps except <~>;
+use DefinesOp except <~>;
 use IO only ioNewline, stdout;
 use IO only <~>;
 

--- a/test/visibility/except/operatorsExceptions/exceptIO.good
+++ b/test/visibility/except/operatorsExceptions/exceptIO.good
@@ -1,1 +1,8 @@
+exceptIO.chpl:15: warning: This file-scope code is outside of any explicit module declarations (e.g., module DefinesOp), so an implicit module named 'exceptIO' is being introduced to contain the file's contents.
+exceptIO.chpl:6: warning: the <~> operator is deprecated
+exceptIO.chpl:16: warning: the <~> operator is deprecated
+exceptIO.chpl:18: warning: the <~> operator is deprecated
+exceptIO.chpl:21: In function 'main':
+exceptIO.chpl:23: warning: the <~> operator is deprecated
+exceptIO.chpl:24: warning: the <~> operator is deprecated
 {x = 3}

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsAlone.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsAlone.good
@@ -1,4 +1,10 @@
 operatorsAlone.chpl:224: warning: This file-scope code is outside of any explicit module declarations (e.g., module DefinesOp), so an implicit module named 'operatorsAlone' is being introduced to contain the file's contents.
+operatorsAlone.chpl:87: warning: the <~> operator is deprecated
+operatorsAlone.chpl:224: In function 'main':
+operatorsAlone.chpl:357: warning: the <~> operator is deprecated
+operatorsAlone.chpl:358: warning: the <~> operator is deprecated
+operatorsAlone.chpl:361: warning: the <~> operator is deprecated
+operatorsAlone.chpl:362: warning: the <~> operator is deprecated
 In DefinesOp.+
 {x = 10}
 In DefinesOp.align

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsFirst.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsFirst.good
@@ -1,4 +1,10 @@
 operatorsFirst.chpl:224: warning: This file-scope code is outside of any explicit module declarations (e.g., module DefinesOp), so an implicit module named 'operatorsFirst' is being introduced to contain the file's contents.
+operatorsFirst.chpl:87: warning: the <~> operator is deprecated
+operatorsFirst.chpl:224: In function 'main':
+operatorsFirst.chpl:355: warning: the <~> operator is deprecated
+operatorsFirst.chpl:356: warning: the <~> operator is deprecated
+operatorsFirst.chpl:359: warning: the <~> operator is deprecated
+operatorsFirst.chpl:360: warning: the <~> operator is deprecated
 In DefinesOp.+
 {x = 10}
 In DefinesOp.align

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsLast.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/operatorsLast.good
@@ -1,4 +1,10 @@
 operatorsLast.chpl:224: warning: This file-scope code is outside of any explicit module declarations (e.g., module DefinesOp), so an implicit module named 'operatorsLast' is being introduced to contain the file's contents.
+operatorsLast.chpl:87: warning: the <~> operator is deprecated
+operatorsLast.chpl:224: In function 'main':
+operatorsLast.chpl:355: warning: the <~> operator is deprecated
+operatorsLast.chpl:356: warning: the <~> operator is deprecated
+operatorsLast.chpl:359: warning: the <~> operator is deprecated
+operatorsLast.chpl:360: warning: the <~> operator is deprecated
 In DefinesOp.+
 {x = 10}
 In DefinesOp.align

--- a/test/visibility/import/enablesUnqualified/operatorsAlone.good
+++ b/test/visibility/import/enablesUnqualified/operatorsAlone.good
@@ -1,4 +1,10 @@
 operatorsAlone.chpl:224: warning: This file-scope code is outside of any explicit module declarations (e.g., module DefinesOp), so an implicit module named 'operatorsAlone' is being introduced to contain the file's contents.
+operatorsAlone.chpl:87: warning: the <~> operator is deprecated
+operatorsAlone.chpl:224: In function 'main':
+operatorsAlone.chpl:357: warning: the <~> operator is deprecated
+operatorsAlone.chpl:358: warning: the <~> operator is deprecated
+operatorsAlone.chpl:361: warning: the <~> operator is deprecated
+operatorsAlone.chpl:362: warning: the <~> operator is deprecated
 In DefinesOp.+
 {x = 10}
 In DefinesOp.align

--- a/test/visibility/only/operatorsAlone.good
+++ b/test/visibility/only/operatorsAlone.good
@@ -1,4 +1,10 @@
 operatorsAlone.chpl:223: warning: This file-scope code is outside of any explicit module declarations (e.g., module DefinesOp), so an implicit module named 'operatorsAlone' is being introduced to contain the file's contents.
+operatorsAlone.chpl:87: warning: the <~> operator is deprecated
+operatorsAlone.chpl:223: In function 'main':
+operatorsAlone.chpl:356: warning: the <~> operator is deprecated
+operatorsAlone.chpl:357: warning: the <~> operator is deprecated
+operatorsAlone.chpl:360: warning: the <~> operator is deprecated
+operatorsAlone.chpl:361: warning: the <~> operator is deprecated
 In DefinesOp.+
 {x = 10}
 In DefinesOp.align

--- a/test/visibility/only/operatorsFirst.good
+++ b/test/visibility/only/operatorsFirst.good
@@ -1,4 +1,10 @@
 operatorsFirst.chpl:223: warning: This file-scope code is outside of any explicit module declarations (e.g., module DefinesOp), so an implicit module named 'operatorsFirst' is being introduced to contain the file's contents.
+operatorsFirst.chpl:87: warning: the <~> operator is deprecated
+operatorsFirst.chpl:223: In function 'main':
+operatorsFirst.chpl:354: warning: the <~> operator is deprecated
+operatorsFirst.chpl:355: warning: the <~> operator is deprecated
+operatorsFirst.chpl:358: warning: the <~> operator is deprecated
+operatorsFirst.chpl:359: warning: the <~> operator is deprecated
 In DefinesOp.+
 {x = 10}
 In DefinesOp.align

--- a/test/visibility/only/operatorsLast.good
+++ b/test/visibility/only/operatorsLast.good
@@ -1,4 +1,10 @@
 operatorsLast.chpl:223: warning: This file-scope code is outside of any explicit module declarations (e.g., module DefinesOp), so an implicit module named 'operatorsLast' is being introduced to contain the file's contents.
+operatorsLast.chpl:87: warning: the <~> operator is deprecated
+operatorsLast.chpl:223: In function 'main':
+operatorsLast.chpl:354: warning: the <~> operator is deprecated
+operatorsLast.chpl:355: warning: the <~> operator is deprecated
+operatorsLast.chpl:358: warning: the <~> operator is deprecated
+operatorsLast.chpl:359: warning: the <~> operator is deprecated
 In DefinesOp.+
 {x = 10}
 In DefinesOp.align


### PR DESCRIPTION
This PR deprecates the ``<~>`` operator in general as well as our usage of the operator in the IO module.

Testing:
- [x] full local
- [x] full gasnet