### PR TITLE
Add noMmap hint to ioHintSet

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1460,7 +1460,7 @@ record ioHintSet {
   */
   proc type mmap { return new ioHintSet(IOHINTS_MMAP); }
 
-  /* Suggests that 'mmap' should not be used to acces the file contents.
+  /* Suggests that 'mmap' should not be used to access the file contents.
   Instead, pread/pwrite are used.
   */
   proc type noMmap { return new ioHintSet(IOHINTS_NOMMAP); }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1410,6 +1410,7 @@ private const IOHINTS_SEQUENTIAL:  c_int = QIO_HINT_SEQUENTIAL;
 private const IOHINTS_RANDOM:      c_int = QIO_HINT_RANDOM;
 private const IOHINTS_PREFETCH:    c_int = QIO_HINT_CACHED;
 private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
+private const IOHINTS_NOMMAP:      c_int = QIO_METHOD_PREADPWRITE;
 
 /* A value of the :record:`ioHintSet` type defines a set of hints about
   the I/O that the file or channel will perform.  These hints may be used
@@ -1459,8 +1460,13 @@ record ioHintSet {
   */
   proc type mmap { return new ioHintSet(IOHINTS_MMAP); }
 
+  /* Suggests that 'mmap' should not be used to acces the file contents.
+  Instead, pread/pwrite are used.
+  */
+  proc type noMmap { return new ioHintSet(IOHINTS_NOMMAP); }
+
   pragma "no doc"
-  proc type direct(constant: c_int) { return new ioHintSet(constant); }
+  proc type fromFlag(flag: c_int) { return new ioHintSet(flag); }
 }
 
 /* Compute the union of two ioHintSets

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -582,7 +582,7 @@ module Subprocess {
       // goes out of scope, but the channel will still keep
       // the file alive by referring to it.
       try {
-        var stdin_file = openfd(stdin_fd, hints=ioHintSet.direct(QIO_HINT_OWNED));
+        var stdin_file = openfd(stdin_fd, hints=ioHintSet.fromFlag(QIO_HINT_OWNED));
         ret.stdin_channel = stdin_file.writer();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -607,7 +607,7 @@ module Subprocess {
     if stdout_pipe {
       ret.stdout_pipe = true;
       try {
-        var stdout_file = openfd(stdout_fd, hints=ioHintSet.direct(QIO_HINT_OWNED));
+        var stdout_file = openfd(stdout_fd, hints=ioHintSet.fromFlag(QIO_HINT_OWNED));
         ret.stdout_channel = stdout_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -621,7 +621,7 @@ module Subprocess {
     if stderr_pipe {
       ret.stderr_pipe = true;
       try {
-        ret.stderr_file = openfd(stderr_fd, hints=ioHintSet.direct(QIO_HINT_OWNED));
+        ret.stderr_file = openfd(stderr_fd, hints=ioHintSet.fromFlag(QIO_HINT_OWNED));
         ret.stderr_channel = ret.stderr_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;

--- a/test/io/tzakian/recordReader/test.chpl
+++ b/test/io/tzakian/recordReader/test.chpl
@@ -5,7 +5,7 @@ use RecordParser, IO;
 config const no_mmap=false;
 var hints=ioHintSet.empty;
 if no_mmap {
-  hints = ioHintSet.direct(QIO_METHOD_PREADPWRITE);
+  hints = ioHintSet.noMmap;
 }
 
 var f = open("input1.txt", iomode.rw);

--- a/test/library/standard/IO/ioHintSetOperations.chpl
+++ b/test/library/standard/IO/ioHintSetOperations.chpl
@@ -7,6 +7,7 @@ const seq = ioHintSet.sequential;
 const rand = ioHintSet.random;
 const pref = ioHintSet.prefetch;
 const mmap = ioHintSet.mmap;
+const nommap = ioHintSet.nommap;
 
 // equality and inequality
 writeln(seq != rand);
@@ -17,8 +18,8 @@ writeln(seq | rand != empty);
 // union and intersection
 writeln(pref | rand == rand | pref);
 writeln(pref & rand == rand & pref);
-writeln(ioHintSet.direct(pref._internal | mmap._internal) == pref | mmap);
-writeln(ioHintSet.direct(seq._internal & rand._internal) == seq & rand);
+writeln(ioHintSet.fromFlag(pref._internal | mmap._internal) == pref | mmap);
+writeln(ioHintSet.fromFlag(seq._internal & rand._internal) == seq & rand);
 
 // internal bits are unique
 var s = new set(int(32));
@@ -27,4 +28,5 @@ s.add(seq._internal);
 s.add(rand._internal);
 s.add(pref._internal);
 s.add(mmap._internal);
+s.add(nommap._internal);
 writeln(s.size);

--- a/test/library/standard/IO/ioHintSetOperations.chpl
+++ b/test/library/standard/IO/ioHintSetOperations.chpl
@@ -7,7 +7,7 @@ const seq = ioHintSet.sequential;
 const rand = ioHintSet.random;
 const pref = ioHintSet.prefetch;
 const mmap = ioHintSet.mmap;
-const nommap = ioHintSet.nommap;
+const nommap = ioHintSet.noMmap;
 
 // equality and inequality
 writeln(seq != rand);

--- a/test/library/standard/IO/ioHintSetOperations.good
+++ b/test/library/standard/IO/ioHintSetOperations.good
@@ -6,4 +6,4 @@ true
 true
 true
 true
-5
+6

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -11,7 +11,7 @@ const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
 proc main(args: [] string) {
   const stdin = openfd(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints=ioHintSet.fromFlag(QIO_HINT_PARALLEL)),
+                             hints=ioHintSet.mmap),
         len = stdin.size;
   var data: [0..#len] uint(8);
 

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -11,7 +11,7 @@ const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
 proc main(args: [] string) {
   const stdin = openfd(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints=ioHintSet.direct(QIO_HINT_PARALLEL)),
+                             hints=ioHintSet.fromFlag(QIO_HINT_PARALLEL)),
         len = stdin.size;
   var data: [0..#len] uint(8);
 
@@ -54,7 +54,7 @@ proc main(args: [] string) {
 
   // write the data out to stdout once all tasks have completed
   const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/release/examples/benchmarks/shootout/revcomp.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp.chpl
@@ -41,7 +41,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl
@@ -54,7 +54,7 @@ proc main(args: [] string) {
 
   // Open a binary writer to stdout
   var binout = openfd(1).writer(iokind.native, locking=false, 
-                                hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                hints=ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
   binout.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
@@ -137,7 +137,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
   //
   // This conversion wastes memory, but correct output requires array stdout
   // specifically at the moment.

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
@@ -129,7 +129,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
   //
   // Necessary for now because list `readWriteThis` includes formatting chars,
   // while arrays do not.

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -13,7 +13,7 @@ config const readSize = 16 * 1024;
 proc main(args: [] string) {
   const stdin = openfd(0);
   var input = stdin.reader(iokind.native, locking=false,
-                           hints=ioHintSet.fromFlag(QIO_HINT_PARALLEL));
+                           hints=ioHintSet.mmap);
   var len = stdin.size;
   var data : [0..#len] uint(8);
   

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -13,7 +13,7 @@ config const readSize = 16 * 1024;
 proc main(args: [] string) {
   const stdin = openfd(0);
   var input = stdin.reader(iokind.native, locking=false,
-                           hints=ioHintSet.direct(QIO_HINT_PARALLEL));
+                           hints=ioHintSet.fromFlag(QIO_HINT_PARALLEL));
   var len = stdin.size;
   var data : [0..#len] uint(8);
   
@@ -61,7 +61,7 @@ proc main(args: [] string) {
   }
 
   const stdoutBin = openfd(1).writer(iokind.native, locking=false, 
-                                     hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                     hints=ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
   stdoutBin.write(data);
 }
 

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.chpl
@@ -8,9 +8,9 @@
 use IO;
 
 const stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                   hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED)),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                   hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
 
 config var readSize = 16384, // how much to read at a time
            n = 0;            // a dummy variable to support the CLBG framework

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.verify.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.verify.chpl
@@ -8,9 +8,9 @@
 use IO;
 
 const stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                   hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED)),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                   hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
 
 config var readSize = 16384, // how much to read at a time
            n = 0;            // a dummy variable to support the CLBG framework

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-ref.chpl
@@ -8,9 +8,9 @@
 use IO;
 
 const stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints = QIO_CH_ALWAYS_UNBUFFERED),
+                                   hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED)),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints=QIO_CH_ALWAYS_UNBUFFERED);
+                                   hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
 
 config var readSize = 16384, // how much to read at a time
            n = 0;            // a dummy variable to support the CLBG framework

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug.chpl
@@ -9,9 +9,9 @@
 proc main(args: [] string) {
   use IO;
   const stdinBin = openfd(0).reader(iokind.native, locking=false,
-                                    hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                    hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED)),
         stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                    hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                    hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
 
   // read in the data using an incrementally growing buffer
   var bufLen = 8 * 1024,

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-tpv.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-tpv.chpl
@@ -8,9 +8,9 @@
 use IO;
 
 const stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                   hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED)),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                   hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
 
 config var readSize = 16384, // how much to read at a time
            n = 0;            // a dummy variable to support the CLBG framework

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -20,9 +20,9 @@ param eol = '\n'.toByte(),  // end-of-line, as an integer
 
 proc main(args: [] string) {
   var stdinBin  = openfd(0).reader(iokind.native, locking=false,
-                                   hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                   hints=ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED)),
       stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                   hints=ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                   hints=ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED)),
       bufLen = 8 * 1024,
       bufDom = {0..<bufLen},
       buf: [bufDom] uint(8),

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-dowhile-bug.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-dowhile-bug.chpl
@@ -12,9 +12,9 @@ const table = createTable();    // create the table of code complements
 proc main(args: [] string) {
   use IO;
   const stdinBin = openfd(0).reader(iokind.native, locking=false,
-                                hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED)),
+                                hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED)),
         stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                hints = ioHintSet.direct(QIO_CH_ALWAYS_UNBUFFERED));
+                                hints = ioHintSet.fromFlag(QIO_CH_ALWAYS_UNBUFFERED));
 
   var bufLen = 8 * 1024,
       bufDom = {0..<bufLen},


### PR DESCRIPTION
Per the discussion in this issue: https://github.com/chapel-lang/chapel/issues/20346:

- `QIO_METHOD_PREADPWRITE` was added to the `ioHintSet` type as a new hint called `noMmap`
- The hidden `ioHintSet.direct` method was renamed to `ioHintSet.fromFlag()` as its name conflicted with the "direct" iohint that may be added at some point in the future.
- Switched uses of `ioHintSet.direct(QIO_HINT_PARALLEL)` to `ioHintSet.mmap`

Tests and library code were updated to reflect the above changes. 

- [x] paratest passing



 