### PR TITLE
Rename 'SystemError.fromSyserr()'

### DIFF
--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -878,7 +878,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     var retErrCode: c_int;
     retErrCode = RAND_bytes(c_ptrTo(buff): c_ptr(c_uchar), buffLen: c_int);
     if (!retErrCode) {
-      throw SystemError.fromSyserr(retErrCode);
+      throw createSystemError(retErrCode);
     }
     return buff;
   }

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -171,12 +171,12 @@ module Curl {
     use CurlQioIntegration;
 
     if ch.home != here {
-      throw SystemError.fromSyserr(EINVAL, "getCurlHandle only functions with local channels");
+      throw createSystemError(EINVAL, "getCurlHandle only functions with local channels");
     }
 
     var plugin = ch.channelPlugin():CurlChannel?;
     if plugin == nil then
-      throw SystemError.fromSyserr(EINVAL, "getCurlHandle called on a non-curl channel");
+      throw createSystemError(EINVAL, "getCurlHandle called on a non-curl channel");
 
     var curl = plugin!.curl;
     return curl;
@@ -198,13 +198,13 @@ module Curl {
     var err:CURLcode = CURLE_OK;
 
     if (arg.type == slist) && (arg.home != ch.home) {
-      throw SystemError.fromSyserr(EINVAL, "in channel.setopt(): slist, and curl handle do not reside on the same locale");
+      throw createSystemError(EINVAL, "in channel.setopt(): slist, and curl handle do not reside on the same locale");
     }
 
     on ch.home {
       var plugin = ch.channelPlugin():CurlChannel?;
       if plugin == nil then
-        throw SystemError.fromSyserr(EINVAL, "in channel.setopt(): not a curl channel");
+        throw createSystemError(EINVAL, "in channel.setopt(): not a curl channel");
 
       var curl = plugin!.curl;
       err = setopt(curl, opt, arg);

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -193,7 +193,7 @@ module HDFS {
     if fs.hfs == c_nil {
       var err = qio_mkerror_errno();
       delete fs;
-      throw SystemError.fromSyserr(err, "in hdfsConnect");
+      throw createSystemError(err, "in hdfsConnect");
     }
     return new hdfs(fs);
   }
@@ -337,7 +337,7 @@ module HDFS {
         writeln("after hdfsOpenFile");
 
       if hfile == c_nil {
-        throw SystemError.fromSyserr(qio_mkerror_errno(), "in hdfsOpenFile");
+        throw createSystemError(qio_mkerror_errno(), "in hdfsOpenFile");
       }
 
       // Create an HDFSFile and return the QIO file containing it

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -1065,7 +1065,7 @@ module ZMQ {
       var errmsg_fmt = "Error in Socket.%s(%s): %s\n";
       var errmsg_str = errmsg_fmt.format(err_fn, string:string, errmsg_zmq);
 
-      throw SystemError.fromSyserr(socket_errno:syserr, errmsg_str);
+      throw createSystemError(socket_errno:syserr, errmsg_str);
     }
   } // record Socket
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -698,9 +698,9 @@ proc stringStyleWithLengthInternal(lengthBytes:int) throws {
     when 4 do x = iostringstyle.len4b_data;
     when 8 do x = iostringstyle.len8b_data;
     otherwise
-      throw SystemError.fromSyserr(EINVAL,
-                                   "Invalid string length prefix " +
-                                   lengthBytes:string);
+      throw createSystemError(EINVAL,
+                              "Invalid string length prefix " +
+                              lengthBytes:string);
   }
   return x;
 }
@@ -1549,9 +1549,9 @@ operator file.=(ref ret:file, x:file) {
 pragma "no doc"
 proc file.checkAssumingLocal() throws {
   if is_c_nil(_file_internal) then
-    throw SystemError.fromSyserr(EBADF, "Operation attempted on an invalid file");
+    throw createSystemError(EBADF, "Operation attempted on an invalid file");
   if !qio_file_isopen(_file_internal) then
-    throw SystemError.fromSyserr(EBADF, "Operation attempted on closed file");
+    throw createSystemError(EBADF, "Operation attempted on closed file");
 }
 
 /* Throw an error if `this` is not a valid representation of an OS file.
@@ -1632,7 +1632,7 @@ proc file._style:iostyleInternal throws {
  */
 proc file.close() throws {
   if is_c_nil(_file_internal) then
-    throw SystemError.fromSyserr(EBADF, "Operation attempted on an invalid file");
+    throw createSystemError(EBADF, "Operation attempted on an invalid file");
 
   var err:syserr = ENOERR;
   on this.home {
@@ -2402,7 +2402,7 @@ inline proc channel.lock() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
-    throw SystemError.fromSyserr(EINVAL, "Operation attempted on an invalid channel");
+    throw createSystemError(EINVAL, "Operation attempted on an invalid channel");
 
   if locking {
     on this.home {
@@ -2519,7 +2519,7 @@ proc channel.mark() throws where this.locking == false {
   const err = qio_channel_mark(false, _channel_internal);
 
   if err then
-    throw SystemError.fromSyserr(err);
+    throw createSystemError(err);
 
   return offset;
 }
@@ -2574,7 +2574,7 @@ proc channel.seek(start:int(64), end:int(64) = max(int(64))) throws {
   const err = qio_channel_seek(_channel_internal, start, end);
 
   if err then
-    throw SystemError.fromSyserr(err);
+    throw createSystemError(err);
 }
 
 
@@ -2613,7 +2613,7 @@ proc channel._mark() throws {
   const err = qio_channel_mark(false, _channel_internal);
 
   if err then
-    throw SystemError.fromSyserr(err);
+    throw createSystemError(err);
 
   return offset;
 }
@@ -4552,7 +4552,7 @@ proc channel.writeBinary(arg:numeric, param endian:ioendian = ioendian.native) t
     }
   }
   if (e != ENOERR) {
-    throw SystemError.fromSyserr(e);
+    throw createSystemError(e);
   }
 }
 
@@ -4607,7 +4607,7 @@ proc channel.readBinary(ref arg:numeric, param endian:ioendian = ioendian.native
   if (e == EEOF) {
     return false;
   } else if (e != ENOERR) {
-    throw SystemError.fromSyserr(e);
+    throw createSystemError(e);
   }
   return true;
 }
@@ -4901,7 +4901,7 @@ proc channel.close() throws {
   var err:syserr = ENOERR;
 
   if is_c_nil(_channel_internal) then
-    throw SystemError.fromSyserr(EINVAL, "cannot close invalid channel");
+    throw createSystemError(EINVAL, "cannot close invalid channel");
 
   on this.home {
     err = qio_channel_close(locking, _channel_internal);

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1002,46 +1002,9 @@ module OS {
     */
     pragma "insert line file info"
     pragma "always propagate line file info"
+    deprecated "'SystemError.fromSyserr' is deprecated. Please use 'createSystemError' instead."
     proc type fromSyserr(err: syserr, details: string = "") {
-      if err == EAGAIN || err == EALREADY || err == EWOULDBLOCK || err == EINPROGRESS {
-        return new owned BlockingIOError(details, err);
-      } else if err == ECHILD {
-        return new owned ChildProcessError(details, err);
-      } else if err == EPIPE || err == ESHUTDOWN {
-        return new owned BrokenPipeError(details, err);
-      } else if err == ECONNABORTED {
-        return new owned ConnectionAbortedError(details, err);
-      } else if err == ECONNREFUSED {
-        return new owned ConnectionRefusedError(details, err);
-      } else if err == ECONNRESET {
-        return new owned ConnectionResetError(details, err);
-      } else if err == EEXIST {
-        return new owned FileExistsError(details, err);
-      } else if err == ENOENT {
-        return new owned FileNotFoundError(details, err);
-      } else if err == EINTR {
-        return new owned InterruptedError(details, err);
-      } else if err == EISDIR {
-        return new owned IsADirectoryError(details, err);
-      } else if err == ENOTDIR {
-        return new owned NotADirectoryError(details, err);
-      } else if err == EACCES || err == EPERM {
-        return new owned PermissionError(details, err);
-      } else if err == ESRCH {
-        return new owned ProcessLookupError(details, err);
-      } else if err == ETIMEDOUT {
-        return new owned TimeoutError(details, err);
-      } else if err == EEOF {
-        return new owned EOFError(details, err);
-      } else if err == ESHORT {
-        return new owned UnexpectedEOFError(details, err);
-      } else if err == EFORMAT {
-        return new owned BadFormatError(details, err);
-      } else if err == EIO {
-        return new owned IOError(err, details);
-      }
-
-      return new owned SystemError(err, details);
+      return createSystemError(err, details);
     }
 
     /*
@@ -1053,10 +1016,76 @@ module OS {
     */
     pragma "insert line file info"
     pragma "always propagate line file info"
+    deprecated "'SystemError.fromSyserr' is deprecated. Please use 'createSystemError' instead."
     proc type fromSyserr(err: int, details: string = "") {
-      return fromSyserr(err:syserr, details);
+      return createSystemError(err:syserr, details);
     }
   }
+
+  /*
+    Return the matching :class:`SystemError` subtype for a given ``syserr``,
+    with an optional string containing extra details.
+
+    :arg err: the syserr to generate from
+    :arg details: extra information to include with the error
+  */
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc createSystemError(err: syserr, details: string = "") {
+    if err == EAGAIN || err == EALREADY || err == EWOULDBLOCK || err == EINPROGRESS {
+      return new owned BlockingIOError(details, err);
+    } else if err == ECHILD {
+      return new owned ChildProcessError(details, err);
+    } else if err == EPIPE || err == ESHUTDOWN {
+      return new owned BrokenPipeError(details, err);
+    } else if err == ECONNABORTED {
+      return new owned ConnectionAbortedError(details, err);
+    } else if err == ECONNREFUSED {
+      return new owned ConnectionRefusedError(details, err);
+    } else if err == ECONNRESET {
+      return new owned ConnectionResetError(details, err);
+    } else if err == EEXIST {
+      return new owned FileExistsError(details, err);
+    } else if err == ENOENT {
+      return new owned FileNotFoundError(details, err);
+    } else if err == EINTR {
+      return new owned InterruptedError(details, err);
+    } else if err == EISDIR {
+      return new owned IsADirectoryError(details, err);
+    } else if err == ENOTDIR {
+      return new owned NotADirectoryError(details, err);
+    } else if err == EACCES || err == EPERM {
+      return new owned PermissionError(details, err);
+    } else if err == ESRCH {
+      return new owned ProcessLookupError(details, err);
+    } else if err == ETIMEDOUT {
+      return new owned TimeoutError(details, err);
+    } else if err == EEOF {
+      return new owned EOFError(details, err);
+    } else if err == ESHORT {
+      return new owned UnexpectedEOFError(details, err);
+    } else if err == EFORMAT {
+      return new owned BadFormatError(details, err);
+    } else if err == EIO {
+      return new owned IOError(err, details);
+    }
+
+    return new owned SystemError(err, details);
+  }
+
+  /*
+    Return the matching :class:`SystemError` subtype for a given error number,
+    with an optional string containing extra details.
+
+    :arg err: the number to generate from
+    :arg details: extra information to include with the error
+  */
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc createSystemError(err: int, details: string = "") {
+    return createSystemError(err:syserr, details);  
+  }
+
 
   /*
      :class:`BlockingIOError` is the subclass of :class:`SystemError`
@@ -1298,7 +1327,7 @@ module OS {
       const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
       var   details    = msg + " with path " + quotedpath +
                          " offset " + offset:string;
-      throw SystemError.fromSyserr(error, details);
+      throw createSystemError(error, details);
     }
   }
 
@@ -1310,7 +1339,7 @@ module OS {
     if error {
       const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
       var   details    = msg + " with path " + quotedpath;
-      throw SystemError.fromSyserr(error, details);
+      throw createSystemError(error, details);
     }
   }
 
@@ -1319,7 +1348,7 @@ module OS {
   pragma "always propagate line file info"
   proc ioerror(error:syserr, msg:string) throws
   {
-    if error then throw SystemError.fromSyserr(error, msg);
+    if error then throw createSystemError(error, msg);
   }
 
   /* Create and throw an :class:`IOError` and include a formatted message
@@ -1339,7 +1368,7 @@ module OS {
     const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
     const details    = errstr + " " + msg + " with path " + quotedpath +
                        " offset " + offset:string;
-    throw SystemError.fromSyserr(EIO:syserr, details);
+    throw createSystemError(EIO:syserr, details);
   }
 
   /* Convert a syserr code to a human-readable string describing the error.

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1083,7 +1083,7 @@ module OS {
   pragma "insert line file info"
   pragma "always propagate line file info"
   proc createSystemError(err: int, details: string = "") {
-    return createSystemError(err:syserr, details);  
+    return createSystemError(err:syserr, details);
   }
 
 

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -271,7 +271,7 @@ module Subprocess {
     proc stdin throws {
       try _throw_on_launch_error();
       if stdin_pipe == false {
-        throw SystemError.fromSyserr(
+        throw createSystemError(
             EINVAL, "subprocess was not configured with a stdin pipe");
       }
       return stdin_channel;
@@ -287,7 +287,7 @@ module Subprocess {
     proc stdout throws {
       try _throw_on_launch_error();
       if stdout_pipe == false {
-        throw SystemError.fromSyserr(
+        throw createSystemError(
             EINVAL, "subprocess was not configured with a stdout pipe");
       }
       return stdout_channel;
@@ -303,7 +303,7 @@ module Subprocess {
     proc stderr throws {
       try _throw_on_launch_error();
       if stderr_pipe == false {
-        throw SystemError.fromSyserr(
+        throw createSystemError(
             EINVAL, "subprocess was not configured with a stderr pipe");
       }
       return stderr_channel;
@@ -509,7 +509,7 @@ module Subprocess {
           if sys_getenv(c"PE_PRODUCT_LIST", env_c_str)==1 {
             env_str = createStringWithNewBuffer(env_c_str);
             if env_str.count("HUGETLB") > 0 then
-              throw SystemError.fromSyserr(
+              throw createSystemError(
                   EINVAL,
                   "spawn with more than 1 locale for CHPL_COMM=ugni with hugepages currently requires stdin, stdout, stderr=pipeStyle.forward");
           }

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -523,7 +523,7 @@ module Sys {
 
       var err_out = sys_host_sys_sockaddr_t(this, buffer, NI_MAXHOST, length);
       if err_out != 0 {
-        throw SystemError.fromSyserr(err_out);
+        throw createSystemError(err_out);
       }
 
       return createStringWithOwnedBuffer(buffer, length, NI_MAXHOST);
@@ -544,7 +544,7 @@ module Sys {
 
       var err_out = sys_port_sys_sockaddr_t(this, port);
       if err_out != 0 {
-        throw SystemError.fromSyserr(err_out);
+        throw createSystemError(err_out);
       }
 
       return port;

--- a/test/deprecated/fromSyserrTest.chpl
+++ b/test/deprecated/fromSyserrTest.chpl
@@ -1,0 +1,3 @@
+use OS;
+
+var err = SystemError.fromSyserr(1);

--- a/test/deprecated/fromSyserrTest.good
+++ b/test/deprecated/fromSyserrTest.good
@@ -1,0 +1,1 @@
+fromSyserrTest.chpl:3: warning: 'SystemError.fromSyserr' is deprecated. Please use 'createSystemError' instead.

--- a/test/errhandling/ferguson/issue-18103.chpl
+++ b/test/errhandling/ferguson/issue-18103.chpl
@@ -1,5 +1,5 @@
 use OS;
 
-var e = SystemError.fromSyserr(-1);
+var e = createSystemError(-1);
 
 writeln(e);


### PR DESCRIPTION
Deprecate 'SystemError.fromSyserr()' type methods in favor of standalone
procedures named 'createSystemError()'. Update modules and one test to use
the new name. Add a deprecated test for 'SystemError.fromSyserr()'.