### PR TITLE
Bring in upstream gasnet patch for checking if LD requires MPI

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -10,6 +10,19 @@ convenience and was obtained from
 Any Chapel issues that seem to be related to GASNet should be directed
 to the Chapel team at https://chapel-lang.org/bugs.html.
 
+Chapel modifications to GASNet
+==============================
+The modifications that we have made to the official GASNet release are
+as follows:
+
+* Pulled in an upstream patch for getting gasnet prefix out of .pc file
+   - https://bitbucket.org/berkeleylab/gasnet/commits/8f5f8a1ab
+* Pulled in an upstream patch to check if LD requires MPI using .pc file
+   - https://bitbucket.org/berkeleylab/gasnet/commits/a657aa1ef
+   - https://bitbucket.org/berkeleylab/gasnet/commits/12335d0fe
+   - https://bitbucket.org/berkeleylab/gasnet/commits/a57d84def
+* Pulled in an upstream fix for `--disable-full-path-expansion`
+   - https://bitbucket.org/berkeleylab/gasnet/commits/8f3eb926b
 
 Upgrading GASNet versions
 =========================

--- a/third-party/gasnet/gasnet-src/aries-conduit/Makefile.in
+++ b/third-party/gasnet/gasnet-src/aries-conduit/Makefile.in
@@ -838,9 +838,9 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@USE_ARIES_CONDUIT_FALSE@uninstall-local:
 @USE_ARIES_CONDUIT_FALSE@install-data-local:
 @USE_ARIES_CONDUIT_FALSE@clean-local:
+@USE_ARIES_CONDUIT_FALSE@uninstall-local:
 clean: clean-recursive
 
 clean-am: clean-generic clean-libLIBRARIES clean-local mostlyclean-am

--- a/third-party/gasnet/gasnet-src/configure.in
+++ b/third-party/gasnet/gasnet-src/configure.in
@@ -3352,7 +3352,7 @@ if test "$enabled_mpi" = yes || test "$enabled_mpi_compat" = yes; then
     mpi_reason="was disabled"
   else
     GASNET_GETFULLPATH(MPI_CC)
-    if expr "x$MPI_CC" : 'x/' >/dev/null; then
+    if command -v $MPI_CC > /dev/null 2>&1; then
       # figure out a reasonable fallback MPI_CFLAGS for this arch/OS and C99 support
       # this is complicated by the fact that $MPI_CC may be a different compiler than $CC
       GASNET_PUSHVAR(CC,"$MPI_CC")

--- a/third-party/gasnet/gasnet-src/ibv-conduit/Makefile.in
+++ b/third-party/gasnet/gasnet-src/ibv-conduit/Makefile.in
@@ -869,8 +869,8 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@USE_IBV_CONDUIT_FALSE@uninstall-local:
 @USE_IBV_CONDUIT_FALSE@install-data-local:
+@USE_IBV_CONDUIT_FALSE@uninstall-local:
 @USE_IBV_CONDUIT_FALSE@clean-local:
 clean: clean-recursive
 

--- a/third-party/gasnet/gasnet-src/mpi-conduit/Makefile.in
+++ b/third-party/gasnet/gasnet-src/mpi-conduit/Makefile.in
@@ -830,8 +830,8 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@USE_MPI_CONDUIT_FALSE@uninstall-local:
 @USE_MPI_CONDUIT_FALSE@install-data-local:
+@USE_MPI_CONDUIT_FALSE@uninstall-local:
 @USE_MPI_CONDUIT_FALSE@clean-local:
 clean: clean-recursive
 

--- a/third-party/gasnet/gasnet-src/ofi-conduit/Makefile.in
+++ b/third-party/gasnet/gasnet-src/ofi-conduit/Makefile.in
@@ -856,8 +856,8 @@ maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
 @USE_OFI_CONDUIT_FALSE@uninstall-local:
-@USE_OFI_CONDUIT_FALSE@install-data-local:
 @USE_OFI_CONDUIT_FALSE@clean-local:
+@USE_OFI_CONDUIT_FALSE@install-data-local:
 clean: clean-recursive
 
 clean-am: clean-generic clean-libLIBRARIES clean-local mostlyclean-am

--- a/third-party/gasnet/gasnet-src/other/Makefile-conduit.mak.in
+++ b/third-party/gasnet/gasnet-src/other/Makefile-conduit.mak.in
@@ -353,7 +353,7 @@ do-pkgconfig-conduit: force
 	@VARS="GASNET_CC GASNET_OPT_CFLAGS GASNET_MISC_CFLAGS \
                GASNET_MISC_CPPFLAGS GASNET_DEFINES GASNET_INCLUDES \
                GASNET_CXX GASNET_OPT_CXXFLAGS GASNET_MISC_CXXFLAGS GASNET_MISC_CXXCPPFLAGS \
-               GASNET_LD GASNET_LDFLAGS GASNET_LIBS" ; \
+               GASNET_LD GASNET_LDFLAGS GASNET_LIBS GASNET_PREFIX" ; \
          $(MAKE) --no-print-directory -f $(top_srcdir)/other/Makefile-echovar.mak VARS="$$VARS" echovars \
 	           >> $(pkgconfig_file)
 	@unset GASNET_DESC; \

--- a/third-party/gasnet/gasnet-src/other/Makefile-conduit.mak.in
+++ b/third-party/gasnet/gasnet-src/other/Makefile-conduit.mak.in
@@ -354,7 +354,7 @@ do-pkgconfig-conduit: force
                GASNET_MISC_CPPFLAGS GASNET_DEFINES GASNET_INCLUDES \
                GASNET_CXX GASNET_OPT_CXXFLAGS GASNET_MISC_CXXFLAGS GASNET_MISC_CXXCPPFLAGS \
                GASNET_LD GASNET_LDFLAGS GASNET_LIBS GASNET_PREFIX" ; \
-         $(MAKE) --no-print-directory -f $(top_srcdir)/other/Makefile-echovar.mak VARS="$$VARS" echovars \
+         $(MAKE) --no-print-directory -f $(top_srcdir)/other/Makefile-echovar.mak VARS="$$VARS" echovars-preserve-unset \
 	           >> $(pkgconfig_file)
 	@unset GASNET_DESC; \
 	if test -d $(top_srcdir)/.git ; then \

--- a/third-party/gasnet/gasnet-src/other/Makefile-conduit.mak.in
+++ b/third-party/gasnet/gasnet-src/other/Makefile-conduit.mak.in
@@ -353,7 +353,10 @@ do-pkgconfig-conduit: force
 	@VARS="GASNET_CC GASNET_OPT_CFLAGS GASNET_MISC_CFLAGS \
                GASNET_MISC_CPPFLAGS GASNET_DEFINES GASNET_INCLUDES \
                GASNET_CXX GASNET_OPT_CXXFLAGS GASNET_MISC_CXXFLAGS GASNET_MISC_CXXCPPFLAGS \
-               GASNET_LD GASNET_LDFLAGS GASNET_LIBS GASNET_PREFIX" ; \
+               GASNET_LD GASNET_LDFLAGS GASNET_LIBS \
+	       GASNET_LD_REQUIRES_CXX GASNET_LD_REQUIRES_MPI \
+	       GASNET_SPAWNER_DEFAULT GASNET_SPAWNER_PMI GASNET_SPAWNER_MPI GASNET_SPAWNER_SSH \
+	       GASNET_PREFIX" ; \
          $(MAKE) --no-print-directory -f $(top_srcdir)/other/Makefile-echovar.mak VARS="$$VARS" echovars-preserve-unset \
 	           >> $(pkgconfig_file)
 	@unset GASNET_DESC; \

--- a/third-party/gasnet/gasnet-src/other/Makefile-echovar.mak
+++ b/third-party/gasnet/gasnet-src/other/Makefile-echovar.mak
@@ -1,15 +1,37 @@
 include $(FRAGMENT)
 
+.EXPORT_ALL_VARIABLES:
+
+# echovar:
+#  output a VAR=VAL string for provided $(VAR)
+#  if the variable is unset, the result is an empty VAL
+
 echovar:
 	@echo $(VAR)=$($(VAR))
 
-#export $(VARS)
-.EXPORT_ALL_VARIABLES:
-
+# Iterative form accepts variable names in $(VARS)
 echovars:
 	@for var in $(VARS) ; do  \
 	   eval echo $$var=\$$$$var ; \
 	 done
 
-.PHONY: echovar echovars
+# echovar-preserve-unset:
+#  output a VAR=VAL string for provided $(VAR)
+#  if the variable is unset, the result is no output
+
+echovar-preserve-unset:
+	@if ! test -z $${$(VAR)+set} ; then \
+	    echo $(VAR)=$($(VAR)) ; \
+	 fi 
+
+# Iterative form accepts variable names in $(VARS)
+echovars-preserve-unset:
+	@for var in $(VARS) ; do  \
+	   if ! eval test -z \$${$${var}+set} ; then \
+	     eval echo $$var=\$$$$var ; \
+	   fi ; \
+	 done
+
+
+.PHONY: echovar echovars echovar-preserve-unset echovars-preserve-unset
 

--- a/third-party/gasnet/gasnet-src/other/Makefile-libgasnet.mak.in
+++ b/third-party/gasnet/gasnet-src/other/Makefile-libgasnet.mak.in
@@ -235,7 +235,8 @@ do-pkgconfig-tools: force
 	@echo '# See the GASNet README for instructions on using these variables' >> $(pkgconfig_file)
 	@VARS="GASNETTOOLS_CC GASNETTOOLS_CPPFLAGS GASNETTOOLS_CFLAGS \
                GASNETTOOLS_CXX GASNETTOOLS_CXXFLAGS \
-               GASNETTOOLS_LD GASNETTOOLS_LDFLAGS GASNETTOOLS_LIBS" ; \
+               GASNETTOOLS_LD GASNETTOOLS_LDFLAGS GASNETTOOLS_LIBS \
+	       GASNET_PREFIX" ; \
            $(MAKE) --no-print-directory -f $(top_srcdir)/other/Makefile-echovar.mak VARS="$$VARS" echovars \
 	           >> $(pkgconfig_file)
 	@unset GASNET_DESC; \

--- a/third-party/gasnet/gasnet-src/other/Makefile-libgasnet.mak.in
+++ b/third-party/gasnet/gasnet-src/other/Makefile-libgasnet.mak.in
@@ -237,7 +237,7 @@ do-pkgconfig-tools: force
                GASNETTOOLS_CXX GASNETTOOLS_CXXFLAGS \
                GASNETTOOLS_LD GASNETTOOLS_LDFLAGS GASNETTOOLS_LIBS \
 	       GASNET_PREFIX" ; \
-           $(MAKE) --no-print-directory -f $(top_srcdir)/other/Makefile-echovar.mak VARS="$$VARS" echovars \
+           $(MAKE) --no-print-directory -f $(top_srcdir)/other/Makefile-echovar.mak VARS="$$VARS" echovars-preserve-unset \
 	           >> $(pkgconfig_file)
 	@unset GASNET_DESC; \
 	if test -d $(top_srcdir)/.git ; then \

--- a/third-party/gasnet/gasnet-src/smp-conduit/Makefile.in
+++ b/third-party/gasnet/gasnet-src/smp-conduit/Makefile.in
@@ -831,8 +831,8 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@USE_SMP_CONDUIT_FALSE@uninstall-local:
 @USE_SMP_CONDUIT_FALSE@install-data-local:
+@USE_SMP_CONDUIT_FALSE@uninstall-local:
 @USE_SMP_CONDUIT_FALSE@clean-local:
 clean: clean-recursive
 

--- a/third-party/gasnet/gasnet-src/ucx-conduit/Makefile.in
+++ b/third-party/gasnet/gasnet-src/ucx-conduit/Makefile.in
@@ -851,9 +851,9 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@USE_UCX_CONDUIT_FALSE@uninstall-local:
 @USE_UCX_CONDUIT_FALSE@install-data-local:
 @USE_UCX_CONDUIT_FALSE@clean-local:
+@USE_UCX_CONDUIT_FALSE@uninstall-local:
 clean: clean-recursive
 
 clean-am: clean-generic clean-libLIBRARIES clean-local mostlyclean-am

--- a/third-party/gasnet/gasnet-src/udp-conduit/Makefile.in
+++ b/third-party/gasnet/gasnet-src/udp-conduit/Makefile.in
@@ -837,9 +837,9 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@USE_UDP_CONDUIT_FALSE@uninstall-local:
 @USE_UDP_CONDUIT_FALSE@install-data-local:
 @USE_UDP_CONDUIT_FALSE@clean-local:
+@USE_UDP_CONDUIT_FALSE@uninstall-local:
 clean: clean-recursive
 
 clean-am: clean-generic clean-libLIBRARIES clean-local mostlyclean-am


### PR DESCRIPTION
Bring in https://bitbucket.org/berkeleylab/gasnet/pull-requests/554 and
some related work to enable getting `GASNET_LD_REQUIRES_MPI` out of
gasnet's pkg-config file. This is a follow up to #20385, which has
additional motivation for the change.
