### PR TITLE
Fix fallout from module order change

### DIFF
--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -6,8 +6,6 @@ Reflection
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.Reflection
 CTypes
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes
-ChapelTaskData
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChapelTaskData
 Communication
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.ByteBufferHelpers.Communication
 ByteBufferHelpers
@@ -30,6 +28,8 @@ String
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String
 ChplConfig
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig
+ChapelTaskData
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChapelTaskData
 ChapelBase
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase
 CommDiagnostics

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -24,9 +24,9 @@ end of module search dirs
   subdir4/subdir/bax.chpl
   ./bah.chpl
   $CHPL_HOME/modules/standard/CTypes.chpl
+  $CHPL_HOME/modules/standard/ChplConfig.chpl
   $CHPL_HOME/modules/standard/HaltWrappers.chpl
   $CHPL_HOME/modules/standard/Reflection.chpl
-  $CHPL_HOME/modules/standard/ChplConfig.chpl
   $CHPL_HOME/modules/standard/ChapelIO.chpl
   $CHPL_HOME/modules/standard/Types.chpl
   $CHPL_HOME/modules/standard/AutoMath.chpl

--- a/test/types/records/ferguson/default-compare-mixed-insn.1.good
+++ b/test/types/records/ferguson/default-compare-mixed-insn.1.good
@@ -1,3 +1,3 @@
 default-compare-mixed-insn.chpl:8: In function 'main':
 default-compare-mixed-insn.chpl:13: error: unresolved call '==(R(int(32)), R(int(64)))'
-$CHPL_HOME/modules/internal/ChapelBase.chpl:97: note: this candidate did not match: ==(a: _nilType, b: _nilType)
+$CHPL_HOME/modules/internal/ChapelBase.chpl:98: note: this candidate did not match: ==(a: _nilType, b: _nilType)

--- a/test/types/records/ferguson/default-compare-mixed-insn.2.good
+++ b/test/types/records/ferguson/default-compare-mixed-insn.2.good
@@ -1,3 +1,3 @@
 default-compare-mixed-insn.chpl:8: In function 'main':
 default-compare-mixed-insn.chpl:16: error: unresolved call '==(R(int(64)), R(int(32)))'
-$CHPL_HOME/modules/internal/ChapelBase.chpl:97: note: this candidate did not match: ==(a: _nilType, b: _nilType)
+$CHPL_HOME/modules/internal/ChapelBase.chpl:98: note: this candidate did not match: ==(a: _nilType, b: _nilType)

--- a/test/types/records/ferguson/default-compare-mixed-insn.5.good
+++ b/test/types/records/ferguson/default-compare-mixed-insn.5.good
@@ -1,3 +1,3 @@
 default-compare-mixed-insn.chpl:8: In function 'main':
 default-compare-mixed-insn.chpl:25: error: unresolved call '!=(R(int(32)), R(int(64)))'
-$CHPL_HOME/modules/internal/ChapelBase.chpl:114: note: this candidate did not match: !=(a: _nilType, b: _nilType)
+$CHPL_HOME/modules/internal/ChapelBase.chpl:115: note: this candidate did not match: !=(a: _nilType, b: _nilType)

--- a/test/types/records/ferguson/default-compare-mixed-insn.6.good
+++ b/test/types/records/ferguson/default-compare-mixed-insn.6.good
@@ -1,3 +1,3 @@
 default-compare-mixed-insn.chpl:8: In function 'main':
 default-compare-mixed-insn.chpl:28: error: unresolved call '!=(R(int(64)), R(int(32)))'
-$CHPL_HOME/modules/internal/ChapelBase.chpl:114: note: this candidate did not match: !=(a: _nilType, b: _nilType)
+$CHPL_HOME/modules/internal/ChapelBase.chpl:115: note: this candidate did not match: !=(a: _nilType, b: _nilType)

--- a/test/types/records/ferguson/default-compare-mixed-insn.good
+++ b/test/types/records/ferguson/default-compare-mixed-insn.good
@@ -1,3 +1,3 @@
 default-compare-mixed-insn.chpl:8: In function 'main':
-default-compare-mixed-insn.chpl:16: error: unresolved call '==(R(int(64)), R(int(32)))'
-$CHPL_HOME/modules/internal/ChapelBase.chpl:116: note: this candidate did not match: ==(a: bool, b: bool)
+default-compare-mixed-insn.chpl:25: error: unresolved call '!=(R(int(32)), R(int(64)))'
+$CHPL_HOME/modules/internal/ChapelBase.chpl:115: note: this candidate did not match: !=(a: _nilType, b: _nilType)


### PR DESCRIPTION
As mentioned here:

https://chapel.discourse.group/t/cron-fast/15126/2?u=stonea

This commit (https://github.com/chapel-lang/chapel/commit/7f91e7e33a2f9c7fe3b84ce6f217378cb21a4f15) added `use ChplConfig` to `ChapelBase.chpl` which caused some failures in some tests that locked down module load order and the line numbers for some errors.

In this PR I've updated the `.good` files for the relevant tests.