### PR TITLE
Fix llvm build failure in gpu runtime

### DIFF
--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -46,7 +46,7 @@ static inline bool chpl_gpu_running_on_gpu_locale(void) {
 }
 
 void chpl_gpu_init(void);
-void chpl_gpu_on_std_modules_finished_initializing();
+void chpl_gpu_on_std_modules_finished_initializing(void);
 
 void chpl_gpu_launch_kernel(int ln, int32_t fn,
                             const char* fatbinData, const char* name,

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -32,9 +32,12 @@ def get_cuda_path():
 def get_gpu_mem_strategy():
     memtype = os.environ.get("CHPL_GPU_MEM_STRATEGY")
     if memtype:
-        # TODO check if meaningful
+        valid_options = ["array_on_device", "unified_memory"]
+        if memtype not in valid_options:
+            error("CHPL_GPU_MEM_STRATEGY must be set to one of: %s" %
+                 ", ".join(valid_options));
         return memtype
-    return "array_on_device"
+    return "unified_memory"
 
 
 def get_cuda_libdevice_path():


### PR DESCRIPTION
Also while I'm at it add some checks for valid options to CHPL_GPU_MEM_STRATEGY and ensure we use unified memory by default