### PR TITLE
Ignore LLVM identifiers when generating Chapel library docs

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -41,6 +41,7 @@ extensions = [
 
 breathe_default_project = "dyno"
 
+nitpick_ignore_regex = [('cpp:identifier', r'llvm(:.*)?')]
 nitpick_ignore = []
 for line in open('../util/nitpick_ignore'):
     if line.strip() == "" or line.startswith("#"):


### PR DESCRIPTION
As things stand, we get warnings about unknown identifiers from LLVM,
which get escalated to errors in CI. For example, a PR using `llvm::SmallSet`
issued the following warnings when building documentation:

```
cpp:identifier reference target not found: llvm
cpp:identifier reference target not found: llvm::SmallPtrSet<const Scope*, 5>
```

These are LLVM symbols, specifically ones from the support library. As
Dyno (and possibly other parts of the code) are starting to rely on 
LLVM's support library, Doxygen will keep running into these. We can
either let Doxygen also generate documentation for LLVM, or we
can silence the LLVM-specific warnings. The latter seems more
appropriate, since it's _Chapel_ documentation we're interested in.

Reviewed by @lydia-duncan - thanks!

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>