### PR TITLE
Make improvements to commonType and if expressions

### DIFF
--- a/compiler/dyno/include/chpl/resolution/can-pass.h
+++ b/compiler/dyno/include/chpl/resolution/can-pass.h
@@ -176,6 +176,13 @@ CanPassResult canPass(Context* context,
 }
 
 /**
+  An optional additional constraint on the kind of a type. Used in
+  commonType to serve the case of functions that enforce param, type,
+  or const returs.
+ */
+using KindRequirement = llvm::Optional<chpl::types::QualifiedType::Kind>;
+
+/**
   Given a (non-empty) list of types (e.g., the types of various return statements
   in a function), determine the type, if any, that can be used to represent
   all of them. Returns an llvm::Optional that contains the qualified type
@@ -190,8 +197,7 @@ CanPassResult canPass(Context* context,
 llvm::Optional<chpl::types::QualifiedType>
 commonType(Context* context,
            const std::vector<chpl::types::QualifiedType>& types,
-           bool useRequiredKind,
-           chpl::types::QualifiedType::Kind requiredKind);
+           KindRequirement requiredKind = KindRequirement());
 // QualifiedType fully qualified here to prevent "reference target not found"
 // in Doxygen.
 

--- a/compiler/dyno/include/chpl/resolution/can-pass.h
+++ b/compiler/dyno/include/chpl/resolution/can-pass.h
@@ -176,17 +176,20 @@ CanPassResult canPass(Context* context,
 /**
   Given a (non-empty) list of types (e.g., the types of various return statements
   in a function), determine the type, if any, that can be used to represent
-  all of them. If such a type cannot be found, returns an empty QualifiedType.
+  all of them. Returns a boolean representing whether or not a common
+  type was found; if it was, the outType reference is set to said type.
 
   If useRequiredKind=true is specified, the requiredKind argument is treated
   as a strict constraint on the kinds of the given types. For instance,
   specifying requiredKind=PARAM and giving non-param types will
-  result in an empty QualifiedType, even if the types can otherwise by unified.
+  result in failure to find a common type, even if the types can otherwise
+  by unified.
  */
-chpl::types::QualifiedType commonType(Context* context,
-                                const std::vector<chpl::types::QualifiedType>& types,
-                                bool useRequiredKind,
-                                chpl::types::QualifiedType::Kind requiredKind);
+bool commonType(Context* context,
+                const std::vector<chpl::types::QualifiedType>& types,
+                bool useRequiredKind,
+                chpl::types::QualifiedType::Kind requiredKind,
+                chpl::types::QualifiedType& outType);
 // QualifiedType fully qualified here to prevent "reference target not found"
 // in Doxygen.
 

--- a/compiler/dyno/include/chpl/resolution/can-pass.h
+++ b/compiler/dyno/include/chpl/resolution/can-pass.h
@@ -23,6 +23,8 @@
 #include "chpl/resolution/resolution-types.h"
 #include "chpl/types/ClassTypeDecorator.h"
 
+#include "llvm/Support/Error.h"
+
 namespace chpl {
 namespace uast {
   class AstNode;
@@ -176,8 +178,8 @@ CanPassResult canPass(Context* context,
 /**
   Given a (non-empty) list of types (e.g., the types of various return statements
   in a function), determine the type, if any, that can be used to represent
-  all of them. Returns a boolean representing whether or not a common
-  type was found; if it was, the outType reference is set to said type.
+  all of them. Returns an llvm::Optional that contains the qualified type
+  if one is found, or is empty otherwise.
 
   If useRequiredKind=true is specified, the requiredKind argument is treated
   as a strict constraint on the kinds of the given types. For instance,
@@ -185,11 +187,11 @@ CanPassResult canPass(Context* context,
   result in failure to find a common type, even if the types can otherwise
   by unified.
  */
-bool commonType(Context* context,
-                const std::vector<chpl::types::QualifiedType>& types,
-                bool useRequiredKind,
-                chpl::types::QualifiedType::Kind requiredKind,
-                chpl::types::QualifiedType& outType);
+llvm::Optional<chpl::types::QualifiedType>
+commonType(Context* context,
+           const std::vector<chpl::types::QualifiedType>& types,
+           bool useRequiredKind,
+           chpl::types::QualifiedType::Kind requiredKind);
 // QualifiedType fully qualified here to prevent "reference target not found"
 // in Doxygen.
 

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -1426,16 +1426,14 @@ bool Resolver::enter(const uast::Conditional* cond) {
     }
     // with useRequiredKind = false, the QualifiedType::Kind argument
     // is ignored. Just pick a dummy value.
-    auto ifType = QualifiedType();
-    bool foundCommon = commonType(context, returnTypes,
+    auto ifType = commonType(context, returnTypes,
                                   /* useRequiredKind */ false,
-                                  QualifiedType::UNKNOWN,
-                                  ifType);
-    if (!foundCommon && !condType.isGenericOrUnknown()) {
+                                  QualifiedType::UNKNOWN);
+    if (!ifType && !condType.isGenericOrUnknown()) {
       // do not error if the condition type is unknown
       r.setType(typeErr(cond, "unable to reconcile branches of if-expression"));
-    } else {
-      r.setType(ifType);
+    } else if (ifType) {
+      r.setType(ifType.getValue());
     }
   }
   return false;

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -1426,10 +1426,13 @@ bool Resolver::enter(const uast::Conditional* cond) {
     }
     // with useRequiredKind = false, the QualifiedType::Kind argument
     // is ignored. Just pick a dummy value.
-    auto ifType = commonType(context, returnTypes,
-                             /* useRequiredKind */ false,
-                             QualifiedType::UNKNOWN);
-    if (ifType.isUnknown()) {
+    auto ifType = QualifiedType();
+    bool foundCommon = commonType(context, returnTypes,
+                                  /* useRequiredKind */ false,
+                                  QualifiedType::UNKNOWN,
+                                  ifType);
+    if (!foundCommon && !condType.isGenericOrUnknown()) {
+      // do not error if the condition type is unknown
       r.setType(typeErr(cond, "unable to reconcile branches of if-expression"));
     } else {
       r.setType(ifType);

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -1426,9 +1426,7 @@ bool Resolver::enter(const uast::Conditional* cond) {
     }
     // with useRequiredKind = false, the QualifiedType::Kind argument
     // is ignored. Just pick a dummy value.
-    auto ifType = commonType(context, returnTypes,
-                                  /* useRequiredKind */ false,
-                                  QualifiedType::UNKNOWN);
+    auto ifType = commonType(context, returnTypes);
     if (!ifType && !condType.isGenericOrUnknown()) {
       // do not error if the condition type is unknown
       r.setType(typeErr(cond, "unable to reconcile branches of if-expression"));

--- a/compiler/dyno/lib/resolution/can-pass.cpp
+++ b/compiler/dyno/lib/resolution/can-pass.cpp
@@ -1116,8 +1116,7 @@ findByPassing(Context* context,
 llvm::Optional<QualifiedType>
 commonType(Context* context,
            const std::vector<QualifiedType>& types,
-           bool useRequiredKind,
-           QualifiedType::Kind requiredKind) {
+           KindRequirement requiredKind) {
   assert(types.size() > 0);
 
   // figure out the kind
@@ -1133,10 +1132,10 @@ commonType(Context* context,
     properties.combineWith(typeProperties);
   }
 
-  if (useRequiredKind) {
+  if (requiredKind) {
     // The caller enforces a particular kind on us. Make sure that the
     // computed properties line up with the kind.
-    auto requiredProperties = KindProperties::fromKind(requiredKind);
+    auto requiredProperties = KindProperties::fromKind(requiredKind.getValue());
     requiredProperties.strictCombineWith(properties);
     properties = requiredProperties;
   }
@@ -1166,7 +1165,8 @@ commonType(Context* context,
     return commonType;
   }
 
-  bool paramRequired = useRequiredKind && requiredKind == QualifiedType::PARAM;
+  bool paramRequired = requiredKind &&
+    requiredKind.getValue() == QualifiedType::PARAM;
   if (bestKind == QualifiedType::PARAM && !paramRequired) {
     // We couldn't unify the types as params, but maybe if we downgrade
     // them to values, it'll work.

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -1731,8 +1731,7 @@ struct ReturnTypeInferrer {
       return QualifiedType(QualifiedType::CONST_VAR, VoidType::get(context));
     } else {
       auto retType = commonType(context, returnedTypes,
-                                   /* useRequiredKind */ true,
-                                   (QualifiedType::Kind) returnIntent);
+                                (QualifiedType::Kind) returnIntent);
       if (!retType) {
         // Couldn't find common type, so return type is incorrect.
         context->error(astForErr, "could not determine return type for function");

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -1730,17 +1730,15 @@ struct ReturnTypeInferrer {
     if (returnedTypes.size() == 0) {
       return QualifiedType(QualifiedType::CONST_VAR, VoidType::get(context));
     } else {
-      auto retType = QualifiedType();
-      bool foundCommon = commonType(context, returnedTypes,
-                                    /* useRequiredKind */ true,
-                                    (QualifiedType::Kind) returnIntent,
-                                    retType);
-      if (!foundCommon) {
+      auto retType = commonType(context, returnedTypes,
+                                   /* useRequiredKind */ true,
+                                   (QualifiedType::Kind) returnIntent);
+      if (!retType) {
         // Couldn't find common type, so return type is incorrect.
         context->error(astForErr, "could not determine return type for function");
-        retType = QualifiedType(retType.kind(), ErroneousType::get(context));
+        retType = QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
       }
-      return retType;
+      return retType.getValue();
     }
   }
 

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -1730,10 +1730,12 @@ struct ReturnTypeInferrer {
     if (returnedTypes.size() == 0) {
       return QualifiedType(QualifiedType::CONST_VAR, VoidType::get(context));
     } else {
-      auto retType = commonType(context, returnedTypes,
-                                /* useRequiredKind */ true,
-                                (QualifiedType::Kind) returnIntent);
-      if (retType.isUnknown()) {
+      auto retType = QualifiedType();
+      bool foundCommon = commonType(context, returnedTypes,
+                                    /* useRequiredKind */ true,
+                                    (QualifiedType::Kind) returnIntent,
+                                    retType);
+      if (!foundCommon) {
         // Couldn't find common type, so return type is incorrect.
         context->error(astForErr, "could not determine return type for function");
         retType = QualifiedType(retType.kind(), ErroneousType::get(context));

--- a/compiler/dyno/test/resolution/testReturnTypes.cpp
+++ b/compiler/dyno/test/resolution/testReturnTypes.cpp
@@ -110,9 +110,11 @@ void testProgram(const std::vector<ReturnVariant>& variants, F func,
   // declarations we want to include in the commonType test, so ignore them.
   size_t offset = hasReference(variants) ? 2 : 0;
   auto types = extractDefinedTypes(context, program.c_str(), offset);
-  auto commonTypeResult = chpl::resolution::commonType(context, types,
-                                                       kind != QualifiedType::UNKNOWN,
-                                                       kind);
+  KindRequirement requiredKind;
+  if (kind != QualifiedType::UNKNOWN) {
+    requiredKind = kind;
+  }
+  auto commonTypeResult = chpl::resolution::commonType(context, types, requiredKind);
   auto qt = commonTypeResult.getValueOr(QualifiedType());
   std::cout << "return type:" << std::endl;
   qt.dump();

--- a/compiler/dyno/test/resolution/testReturnTypes.cpp
+++ b/compiler/dyno/test/resolution/testReturnTypes.cpp
@@ -110,14 +110,14 @@ void testProgram(const std::vector<ReturnVariant>& variants, F func,
   // declarations we want to include in the commonType test, so ignore them.
   size_t offset = hasReference(variants) ? 2 : 0;
   auto types = extractDefinedTypes(context, program.c_str(), offset);
-  auto qt = QualifiedType();
-  bool foundCommon = chpl::resolution::commonType(context, types,
-                                                  kind != QualifiedType::UNKNOWN,
-                                                  kind, qt);
+  auto commonTypeResult = chpl::resolution::commonType(context, types,
+                                                       kind != QualifiedType::UNKNOWN,
+                                                       kind);
+  auto qt = commonTypeResult.getValueOr(QualifiedType());
   std::cout << "return type:" << std::endl;
   qt.dump();
   std::cout << std::endl;
-  func(foundCommon, qt);
+  func(commonTypeResult.hasValue(), qt);
 }
 
 static void test1() {


### PR DESCRIPTION
This PR makes several small improvements to the `commonType` function
and the if-expression resolution code.

* `commonType` now returns an llvm::Optional representing whether or not
  a common type was successfully found. This helps distinguish the
  case when an `UnknownType` was determined to be the common type
  (not an error) from the case when no common type could be found
  (an error).
* `commonType` now also accepts `useRequiredKind` and `requiredKind`
  via another llvm::Optional.
* `commonType` now properly handles the types vector containing an
  UnknownType. Previously, the intent computation code would
  replace the `UNKNOWN` intent with whatever was computed (such as
  `CONST_VAR`), which would create a non-`UNKNOWN` type with
  a missing `Type*`. This is not semantically correct.
* If-expressions no longer error when two branches could not be
  unified and the condition type is unknown. Semantically,
  not knowing the condition means not knowing which branch
  is taken, and thus which type should be returned. This
  fixes some cases in initial typed function signature matching.
  If-expressions still error if the condition is known and the
  branches are not compatible.

Reviewed by @mppf - thank you!

TESTING
- [x] Paratest works, as does CI.

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>