### PR TITLE
Converted Existing Unstable Messages to Use @unstable

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -860,9 +860,7 @@ module Bytes {
         ``bytes.dedent`` is not considered stable and is subject to change in
         future Chapel releases.
   */
-  proc bytes.dedent(columns=0, ignoreFirst=true): bytes {
-    if chpl_warnUnstable then
-      compilerWarning("bytes.dedent is subject to change in the future.");
+  @unstable "bytes.dedent is subject to change in the future." proc bytes.dedent(columns=0, ignoreFirst=true): bytes {
     return doDedent(this, columns, ignoreFirst);
   }
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1883,9 +1883,7 @@ module ChapelArray {
      as argument ``that`` and all elements of this array are
      equal to the corresponding element in ``that``. Otherwise
      return false. */
-  proc _array.equals(that: _array): bool {
-    if chpl_warnUnstable then compilerWarning("the 'Array.equals()' method is unstable");
-
+  @unstable "the 'Array.equals()' method is unstable" proc _array.equals(that: _array): bool {
     //
     // quick path for identical arrays
     //

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1456,19 +1456,14 @@ module ChapelBase {
   inline operator :(x:chpl_anyreal, type t:chpl_anyreal)
     return __primitive("cast", t, x);
 
-  inline operator :(x:enum, type t:chpl_anybool) throws {
-    if chpl_warnUnstable {
-      compilerWarning("enum-to-bool casts are likely to be deprecated in the future");
-    }    return x: int: bool;
+  @unstable "enum-to-bool casts are likely to be deprecated in the future" inline operator :(x:enum, type t:chpl_anybool) throws {
+    return x: int: bool;
   }
   // operator :(x: enum, type t:integral)
   // is generated for each enum in buildDefaultFunctions
   inline operator :(x: enum, type t:enum) where x.type == t
     return x;
-  inline operator :(x: enum, type t:chpl_anyreal) throws {
-    if chpl_warnUnstable {
-      compilerWarning("enum-to-float casts are likely to be deprecated in the future");
-    }
+  @unstable "enum-to-float casts are likely to be deprecated in the future" inline operator :(x: enum, type t:chpl_anyreal) throws {
     return x: int: real;
   }
 

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1793,12 +1793,9 @@ module ChapelDomain {
     }
 
     pragma "no doc"
-    proc ref bulkAdd(inds: [] _value.idxType, dataSorted=false,
+    @unstable "bulkAdd() is subject to change in the future." proc ref bulkAdd(inds: [] _value.idxType, dataSorted=false,
         isUnique=false, preserveInds=true, addOn=nilLocale)
         where this.isSparse() && _value.rank==1 {
-      if chpl_warnUnstable then compilerWarning(
-        "bulkAdd() is subject to change in the future.");
-
       if inds.isEmpty() then return 0;
 
       return _value.dsiBulkAdd(inds, dataSorted, isUnique, preserveInds, addOn);
@@ -1837,10 +1834,7 @@ module ChapelDomain {
      :arg size: Size of the buffer in number of indices.
      :type size: int
     */
-    inline proc makeIndexBuffer(size: int) {
-      if chpl_warnUnstable then compilerWarning(
-        "makeIndexBuffer() is subject to change in the future.");
-
+    @unstable "makeIndexBuffer() is subject to change in the future." inline proc makeIndexBuffer(size: int) {
       return _value.dsiMakeIndexBuffer(size);
     }
 
@@ -1895,9 +1889,6 @@ module ChapelDomain {
     proc ref bulkAdd(inds: [] _value.rank*_value.idxType,
         dataSorted=false, isUnique=false, preserveInds=true, addOn=nilLocale)
         where this.isSparse() && _value.rank>1 {
-      if chpl_warnUnstable then compilerWarning(
-        "bulkAdd() is subject to change in the future.");
-
       if inds.isEmpty() then return 0;
 
       return _value.dsiBulkAdd(inds, dataSorted, isUnique, preserveInds, addOn);

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1916,9 +1916,7 @@ module String {
         ``string.dedent`` is not considered stable and is subject to change in
         future Chapel releases.
   */
-  proc string.dedent(columns=0, ignoreFirst=true) : string {
-    if chpl_warnUnstable then
-      compilerWarning("string.dedent is subject to change in the future.");
+  @unstable "string.dedent is subject to change in the future." proc string.dedent(columns=0, ignoreFirst=true) : string {
     return doDedent(this, columns, ignoreFirst);
   }
 

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -27,13 +27,9 @@
 // backward compatible with the architecture implicitly provided by
 // releases 1.6 and preceding.
 //
-module LocaleModel {
-
-  if chpl_warnUnstable {
-    compilerWarning("GPU support is a prototype in this version of Chapel.",
-                    " As such, the interface is unstable and expected to",
-                    " change in the forthcoming releases.");
-  }
+@unstable "GPU support is a prototype in this version of Chapel. 
+          As such, the interface is unstable and expected to change 
+          in the forthcoming releases." module LocaleModel {
 
   public use LocaleModelHelpGPU;
 

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -241,7 +241,7 @@
 
  */
 
-module ArgumentParser {
+@unstable "ArgumentParser is unstable." module ArgumentParser {
   use List;
   use Map;
   use IO;
@@ -255,9 +255,6 @@ module ArgumentParser {
   // TODO: Implement Help message and formatting
   // TODO: Move logic splitting '=' into '_match'
   // TODO: Add public github issue when available
-
-  if chpl_warnUnstable then
-    compilerWarning("ArgumentParser is unstable.");
 
   pragma "no doc"
   enum argKind { positional, subcommand, option, flag, passthrough };

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -581,7 +581,7 @@ module DateTime {
     pragma "no doc"
     var chpl_hour, chpl_minute, chpl_second, chpl_microsecond: int;
     pragma "no doc"
-    var chpl_tzinfo: shared TZInfo?;
+    @unstable "tzinfo is unstable; its type may change in the future" var chpl_tzinfo: shared TZInfo?;
 
     /* The hour represented by this `time` value */
     proc hour {
@@ -631,9 +631,6 @@ module DateTime {
    */
   proc time.init(hour=0, minute=0, second=0, microsecond=0,
                  in tzinfo: shared TZInfo?) {
-    if chpl_warnUnstable {
-      compilerWarning("tzinfo is unstable; its type may change in the future");
-    }
     if hour < 0 || hour >= 24 then
       HaltWrappers.initHalt("hour out of range");
     if minute < 0 || minute >= 60 then
@@ -695,9 +692,6 @@ module DateTime {
    */
   proc time.replace(hour=-1, minute=-1, second=-1, microsecond=-1,
                     in tzinfo) {
-    if chpl_warnUnstable {
-      compilerWarning("tzinfo is unstable; its type may change in the future");
-    }
     const newhour = if hour != -1 then hour else this.hour;
     const newminute = if minute != -1 then minute else this.minute;
     const newsecond = if second != -1 then second else this.second;
@@ -1044,9 +1038,6 @@ module DateTime {
   proc datetime.init(year, month, day,
                      hour=0, minute=0, second=0, microsecond=0,
                      in tzinfo) {
-    if chpl_warnUnstable {
-      compilerWarning("tzinfo is unstable; its type may change in the future");
-    }
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond, tzinfo);
   }
@@ -1093,9 +1084,6 @@ module DateTime {
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=timeSinceEpoch(1));
     } else {
-      if chpl_warnUnstable  {
-        compilerWarning("tzinfo is unstable; its type may change in the future");
-      }
       const timeSinceEpoch = getTimeOfDay();
       const td = new timedelta(seconds=timeSinceEpoch(0),
                                microseconds=timeSinceEpoch(1));
@@ -1149,9 +1137,6 @@ module DateTime {
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=t(1));
     } else {
-      if chpl_warnUnstable {
-        compilerWarning("tzinfo is unstable; its type may change in the future");
-      }
       var dt = datetime.utcFromTimestamp(timestamp);
       return (dt + tz!.utcOffset(dt)).replace(tzinfo=tz);
     }
@@ -1239,9 +1224,6 @@ module DateTime {
 
   /* Return the date and time converted into the timezone in the argument */
   proc datetime.astimezone(in tz: shared TZInfo) {
-    if chpl_warnUnstable {
-      compilerWarning("tzinfo is unstable; its type may change in the future");
-    }
     if tzinfo == tz {
       return this;
     }

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -573,7 +573,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     pragma "no doc"
     var chpl_hour, chpl_minute, chpl_second, chpl_microsecond: int;
     pragma "no doc"
-    var chpl_tzinfo: shared TZInfo?;
+    @unstable "tzinfo is unstable; its type may change in the future" : shared TZInfo?;
 
     /* The hour represented by this `time` value */
     proc hour {
@@ -623,9 +623,6 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
    */
   proc time.init(hour=0, minute=0, second=0, microsecond=0,
                  in tzinfo: shared TZInfo?) {
-    if chpl_warnUnstable {
-      compilerWarning("tzinfo is unstable; its type may change in the future");
-    }
     if hour < 0 || hour >= 24 then
       HaltWrappers.initHalt("hour out of range");
     if minute < 0 || minute >= 60 then
@@ -687,9 +684,6 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
    */
   proc time.replace(hour=-1, minute=-1, second=-1, microsecond=-1,
                     in tzinfo) {
-    if chpl_warnUnstable {
-      compilerWarning("tzinfo is unstable; its type may change in the future");
-    }
     const newhour = if hour != -1 then hour else this.hour;
     const newminute = if minute != -1 then minute else this.minute;
     const newsecond = if second != -1 then second else this.second;
@@ -1024,9 +1018,6 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   proc datetime.init(year, month, day,
                      hour=0, minute=0, second=0, microsecond=0,
                      in tzinfo) {
-    if chpl_warnUnstable {
-      compilerWarning("tzinfo is unstable; its type may change in the future");
-    }
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond, tzinfo);
   }
@@ -1067,9 +1058,6 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=timeSinceEpoch(1));
     } else {
-      if chpl_warnUnstable {
-        compilerWarning("tzinfo is unstable; its type may change in the future");
-      }
       const timeSinceEpoch = getTimeOfDay();
       const td = new timedelta(seconds=timeSinceEpoch(0),
                                microseconds=timeSinceEpoch(1));
@@ -1103,9 +1091,6 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=t(1));
     } else {
-      if chpl_warnUnstable {
-        compilerWarning("tzinfo is unstable; its type may change in the future");
-      }
       var dt = datetime.utcFromTimestamp(timestamp);
       return (dt + tz!.utcOffset(dt)).replace(tzinfo=tz);
     }
@@ -1170,9 +1155,6 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Return the date and time converted into the timezone in the argument */
   proc datetime.astimezone(in tz: shared TZInfo) {
-    if chpl_warnUnstable {
-      compilerWarning("tzinfo is unstable; its type may change in the future");
-    }
     if tzinfo == tz {
       return this;
     }


### PR DESCRIPTION
This PR updated modules with the old method of marking symbols as unstable (chpl_warnUnstable) with the new keyword (@unstable).

Signed-off-by: Nikki Rad <nikki.rad@hpe.com>