### PR TITLE
Warn for misleading 'new' pattern

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3447,7 +3447,7 @@ void resolveNormalCallAdjustAssign(CallExpr* call) {
       }
 
       // warn for misleading new in assign statement
-      warnIfMisleadingNew(call, targetType, srcType);
+      warnIfMisleadingNew(call, targetType->getValType(), srcType);
     }
   }
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3339,9 +3339,10 @@ static Type* resolveTypeSpecifier(CallInfo& info) {
 static void warnIfMisleadingNew(CallExpr* call, Type* lhs, Type* rhs) {
   // return 'true' for:
   //  * lhs type is borrowed
-  //  * rhs type is owned/shared
+  //  * rhs type is owned/shared/unmanaged
   //  * rhs represents a 'new' expression
-  if (isBorrowedClass(lhs) && isManagedPtrType(rhs)) {
+  if (isBorrowedClass(lhs) &&
+      (isUnmanagedClass(rhs) || isManagedPtrType(rhs))) {
 
     // check for rhs being a 'new' expression using pattern matching
     Symbol* dst = nullptr;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3344,11 +3344,15 @@ static void warnIfMisleadingNew(CallExpr* call, Type* lhs, Type* rhs) {
   if (isBorrowedClass(lhs) && isManagedPtrType(rhs)) {
 
     // check for rhs being a 'new' expression using pattern matching
+    Symbol* dst = nullptr;
     Symbol* src = nullptr;
     bool foundNew = false;
     if (call->numActuals() >= 2) {
       if (call->isPrimitive(PRIM_INIT_VAR) ||
           call->isPrimitive(PRIM_INIT_VAR_SPLIT_INIT)) {
+        if (SymExpr* se = toSymExpr(call->get(1))) {
+          dst = se->symbol();
+        }
         if (SymExpr* se = toSymExpr(call->get(2))) {
           src = se->symbol();
         }
@@ -3358,12 +3362,16 @@ static void warnIfMisleadingNew(CallExpr* call, Type* lhs, Type* rhs) {
           i += 2; // pass method token and (type) this arg
         }
         if (i+1 <= call->numActuals()) {
+          if (SymExpr* se = toSymExpr(call->get(i))) {
+            dst = se->symbol();
+          }
           if (SymExpr* se = toSymExpr(call->get(i+1))) {
             src = se->symbol();
           }
         }
       }
     }
+
     // rely on FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW which
     // is introduced for temporaries storing the result of a 'new' expression
     if (src &&
@@ -3372,8 +3380,18 @@ static void warnIfMisleadingNew(CallExpr* call, Type* lhs, Type* rhs) {
       foundNew = true;
     }
 
-    if (foundNew) {
-      USR_WARN(userCall(call), "misleading new");
+    if (foundNew && dst && !dst->hasFlag(FLAG_TEMP)) {
+      USR_WARN(userCall(call),
+               "here, '%s' is set to the result of borrowing from a 'new'",
+               dst->name);
+      USR_PRINT(userCall(call),
+                "if you meant to save the result of new, change "
+                "the type of '%s' to not be 'borrowed'",
+                dst->name);
+      USR_PRINT(userCall(call),
+                "if you meant to refer to another variable storing the 'new', "
+                "use an explicit variable, e.g. "
+                "'var myOwned = new C(); var myBorrowed = myOwned.borrow();'");
     }
   }
 }

--- a/test/classes/delete-free/borrowed/coercions-to-init-borrowed.chpl
+++ b/test/classes/delete-free/borrowed/coercions-to-init-borrowed.chpl
@@ -3,7 +3,8 @@ class MyClass {
   var y:int;
 }
 
-var x: borrowed = new owned MyClass(1,2);
+var myOwned = new owned MyClass(1,2);
+var x: borrowed = myOwned;
 writeln(x.type:string);
 writeln(x);
 

--- a/test/classes/delete-free/coercions-generic.chpl
+++ b/test/classes/delete-free/coercions-generic.chpl
@@ -9,7 +9,8 @@ proc test1() {
 }
 
 proc test2() {
-  var instance:borrowed MyClass(int) = new owned MyClass(1);
+  var myOwned = new owned MyClass(1);
+  var instance:borrowed MyClass(int) = myOwned;
 }
 
 proc acceptMyClass(c:borrowed MyClass) {

--- a/test/classes/delete-free/coercions-shared.chpl
+++ b/test/classes/delete-free/coercions-shared.chpl
@@ -12,7 +12,8 @@ proc test1() {
 }
 
 proc test2() {
-  var instance:borrowed MyClass = new shared MyClass(1);
+  var myShared = new shared MyClass(1);
+  var instance:borrowed MyClass = myShared;
 }
 
 proc acceptMyClass(c:borrowed MyClass) {

--- a/test/classes/delete-free/lifetimes/record-borrows.chpl
+++ b/test/classes/delete-free/lifetimes/record-borrows.chpl
@@ -44,9 +44,9 @@ var globalRMyClass:RMyClass;
 {
   var ri = new Rint(1);
   var sub = new unmanaged SubClass(1, ri);
-  globalMyClass = new unmanaged MyClass(sub);
+  var myUnmanaged = new unmanaged MyClass(sub);
+  globalMyClass = myUnmanaged;
 }
-
 proc refIdentity(ref x) ref {
   return x;
 }

--- a/test/classes/delete-free/lifetimes/stecil-setup.chpl
+++ b/test/classes/delete-free/lifetimes/stecil-setup.chpl
@@ -14,10 +14,12 @@ config const branch = true;
 
 proc MyStencilDom.setup() {
   ref elem = A[1];
-  if branch then
-    elem = new unmanaged MyLocDom(1);
-  else
+  if branch {
+    var myUnmanaged = new unmanaged MyLocDom(1);
+    elem = myUnmanaged;
+  } else {
     elem!.x += 1;
+  }
 }
 
 proc test() {

--- a/test/classes/delete-free/tests-from-design-overview/new-myclass.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/new-myclass.chpl
@@ -11,8 +11,10 @@ class MyClass {
 
 proc test1() {
   var a = new MyClass(1);
-  var b: borrowed MyClass = new MyClass(2); 
-  var c: borrowed MyClass = new owned MyClass(3); 
+  var myClass2 = new MyClass(2);
+  var b: borrowed MyClass = myClass2;
+  var myClass3 = new MyClass(3);
+  var c: borrowed MyClass = myClass3;
   var d = (new owned MyClass(4)): borrowed MyClass; 
   var e = (new owned MyClass(5)): borrowed MyClass; 
   var f = (new owned MyClass(6)).borrow();

--- a/test/classes/errors/warn-misleading-new-unmanaged.chpl
+++ b/test/classes/errors/warn-misleading-new-unmanaged.chpl
@@ -1,0 +1,116 @@
+class C { }
+
+proc test1() {
+  var myUnmanaged = new unmanaged C();
+
+  // not expecting a warning in this case b/c
+  // the RHS isn't a 'new' expression
+  var noError: borrowed C = myUnmanaged;
+
+  delete myUnmanaged;
+}
+test1();
+proc test1n() {
+  var myUnmanaged = new unmanaged C();
+
+  // not expecting a warning in this case b/c
+  // the RHS isn't a 'new' expression
+  var noError: borrowed C? = myUnmanaged;
+
+  delete myUnmanaged;
+}
+test1n();
+proc test1nn() {
+  var myUnmanaged = new unmanaged C?();
+
+  // not expecting a warning in this case b/c
+  // the RHS isn't a 'new' expression
+  var noError: borrowed C? = myUnmanaged;
+
+  delete myUnmanaged;
+}
+test1nn();
+
+proc test2() {
+  // warn
+  var x: borrowed C = new unmanaged C();
+
+  delete (x: unmanaged);
+}
+test2();
+proc test2n() {
+  // warn
+  var x: borrowed C? = new unmanaged C();
+
+  delete (x: unmanaged);
+}
+test2n();
+proc test2nn() {
+  // warn
+  var x: borrowed C? = new unmanaged C?();
+
+  delete (x: unmanaged);
+}
+test2nn();
+
+proc test3() {
+  // warn
+  var x: borrowed C;
+  x = new unmanaged C();
+
+  delete (x: unmanaged);
+}
+test3();
+proc test3n() {
+  // warn
+  var x: borrowed C?;
+  x = new unmanaged C();
+
+  delete (x: unmanaged);
+}
+test3n();
+proc test3nn() {
+  // warn
+  var x: borrowed C?;
+  x = new unmanaged C?();
+
+  delete (x: unmanaged);
+}
+test3nn();
+
+proc test4() {
+  var myUnmanaged = new unmanaged C();
+  var myBorrowed = myUnmanaged.borrow();
+
+  var x: borrowed C = myBorrowed;
+  // warn
+  x = new unmanaged C();
+
+  delete (x: unmanaged);
+  delete myUnmanaged;
+}
+test4();
+proc test4n() {
+  var myUnmanaged = new unmanaged C();
+  var myBorrowed = myUnmanaged.borrow();
+
+  var x: borrowed C? = myBorrowed;
+  // warn
+  x = new unmanaged C();
+  
+  delete (x: unmanaged);
+  delete myUnmanaged;
+}
+test4n();
+proc test4nn() {
+  var myUnmanaged = new unmanaged C();
+  var myBorrowed = myUnmanaged.borrow();
+
+  var x: borrowed C? = myBorrowed;
+  // warn
+  x = new unmanaged C?();
+  
+  delete (x: unmanaged);
+  delete myUnmanaged;
+}
+test4nn();

--- a/test/classes/errors/warn-misleading-new-unmanaged.good
+++ b/test/classes/errors/warn-misleading-new-unmanaged.good
@@ -1,0 +1,36 @@
+warn-misleading-new-unmanaged.chpl:34: In function 'test2':
+warn-misleading-new-unmanaged.chpl:36: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:36: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:36: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new-unmanaged.chpl:41: In function 'test2n':
+warn-misleading-new-unmanaged.chpl:43: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:43: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:43: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new-unmanaged.chpl:48: In function 'test2nn':
+warn-misleading-new-unmanaged.chpl:50: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:50: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:50: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new-unmanaged.chpl:56: In function 'test3':
+warn-misleading-new-unmanaged.chpl:59: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:59: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:59: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new-unmanaged.chpl:64: In function 'test3n':
+warn-misleading-new-unmanaged.chpl:67: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:67: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:67: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new-unmanaged.chpl:72: In function 'test3nn':
+warn-misleading-new-unmanaged.chpl:75: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:75: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:75: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new-unmanaged.chpl:81: In function 'test4':
+warn-misleading-new-unmanaged.chpl:87: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:87: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:87: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new-unmanaged.chpl:93: In function 'test4n':
+warn-misleading-new-unmanaged.chpl:99: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:99: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:99: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new-unmanaged.chpl:105: In function 'test4nn':
+warn-misleading-new-unmanaged.chpl:111: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new-unmanaged.chpl:111: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new-unmanaged.chpl:111: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'

--- a/test/classes/errors/warn-misleading-new.chpl
+++ b/test/classes/errors/warn-misleading-new.chpl
@@ -119,7 +119,7 @@ proc test4nn() {
   var z: borrowed C? = myBorrowed;
   // warn
   x = new owned C?();
-  x = new shared C?();
-  x = new C?();
+  y = new shared C?();
+  z = new C?();
 }
 test4nn();

--- a/test/classes/errors/warn-misleading-new.chpl
+++ b/test/classes/errors/warn-misleading-new.chpl
@@ -1,0 +1,125 @@
+class C { }
+
+proc test1() {
+  var myOwned = new owned C();
+  var myShared = new shared C();
+
+  // not expecting a warning in this case b/c
+  // the RHS isn't a 'new' expression
+  var noError: borrowed C = myOwned;
+  var noErrorS: borrowed C = myShared;
+}
+test1();
+proc test1n() {
+  var myOwned = new owned C();
+  var myShared = new shared C();
+
+  // not expecting a warning in this case b/c
+  // the RHS isn't a 'new' expression
+  var noError: borrowed C? = myOwned;
+  var noErrorS: borrowed C? = myShared;
+}
+test1n();
+proc test1nn() {
+  var myOwned = new owned C?();
+  var myShared = new shared C?();
+
+  // not expecting a warning in this case b/c
+  // the RHS isn't a 'new' expression
+  var noError: borrowed C? = myOwned;
+  var noErrorS: borrowed C? = myShared;
+}
+test1nn();
+
+proc test2() {
+  // warn
+  var x: borrowed C = new owned C();
+  var y: borrowed C = new shared C();
+  var z: borrowed C = new C();
+}
+test2();
+proc test2n() {
+  // warn
+  var x: borrowed C? = new owned C();
+  var y: borrowed C? = new shared C();
+  var z: borrowed C? = new C();
+}
+test2n();
+proc test2nn() {
+  // warn
+  var x: borrowed C? = new owned C?();
+  var y: borrowed C? = new shared C?();
+  var z: borrowed C? = new C?();
+}
+test2nn();
+
+proc test3() {
+  // warn
+  var x: borrowed C;
+  var y: borrowed C;
+  var z: borrowed C;
+  x = new owned C();
+  y = new shared C();
+  z = new C();
+}
+test3();
+proc test3n() {
+  // warn
+  var x: borrowed C?;
+  var y: borrowed C?;
+  var z: borrowed C?;
+  x = new owned C();
+  y = new shared C();
+  z = new C();
+}
+test3n();
+proc test3nn() {
+  // warn
+  var x: borrowed C?;
+  var y: borrowed C?;
+  var z: borrowed C?;
+  x = new owned C?();
+  y = new shared C?();
+  z = new C?();
+}
+test3nn();
+
+proc test4() {
+  var myOwned = new owned C();
+  var myBorrowed = myOwned.borrow();
+
+  var x: borrowed C = myBorrowed;
+  var y: borrowed C = myBorrowed;
+  var z: borrowed C = myBorrowed;
+  // warn
+  x = new owned C();
+  y = new shared C();
+  z = new C();
+}
+test4();
+proc test4n() {
+  var myOwned = new owned C();
+  var myBorrowed = myOwned.borrow();
+
+  var x: borrowed C? = myBorrowed;
+  var y: borrowed C? = myBorrowed;
+  var z: borrowed C? = myBorrowed;
+  // warn
+  x = new owned C();
+  y = new shared C();
+  z = new C();
+}
+test4n();
+proc test4nn() {
+  var myOwned = new owned C();
+  var myBorrowed = myOwned.borrow();
+
+  var x: borrowed C? = myBorrowed;
+  var y: borrowed C? = myBorrowed;
+  var z: borrowed C? = myBorrowed;
+  // warn
+  x = new owned C?();
+  x = new shared C?();
+  x = new C?();
+}
+test4nn();

--- a/test/classes/errors/warn-misleading-new.good
+++ b/test/classes/errors/warn-misleading-new.good
@@ -1,39 +1,93 @@
 warn-misleading-new.chpl:34: In function 'test2':
-warn-misleading-new.chpl:36: warning: misleading new
-warn-misleading-new.chpl:37: warning: misleading new
-warn-misleading-new.chpl:38: warning: misleading new
+warn-misleading-new.chpl:36: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:36: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:36: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:37: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:37: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:37: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:38: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:38: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:38: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:41: In function 'test2n':
-warn-misleading-new.chpl:43: warning: misleading new
-warn-misleading-new.chpl:44: warning: misleading new
-warn-misleading-new.chpl:45: warning: misleading new
+warn-misleading-new.chpl:43: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:43: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:43: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:44: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:44: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:44: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:45: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:45: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:45: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:48: In function 'test2nn':
-warn-misleading-new.chpl:50: warning: misleading new
-warn-misleading-new.chpl:51: warning: misleading new
-warn-misleading-new.chpl:52: warning: misleading new
+warn-misleading-new.chpl:50: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:50: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:50: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:51: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:51: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:51: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:52: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:52: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:52: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:56: In function 'test3':
-warn-misleading-new.chpl:61: warning: misleading new
-warn-misleading-new.chpl:62: warning: misleading new
-warn-misleading-new.chpl:63: warning: misleading new
+warn-misleading-new.chpl:61: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:61: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:61: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:62: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:62: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:62: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:63: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:63: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:63: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:66: In function 'test3n':
-warn-misleading-new.chpl:71: warning: misleading new
-warn-misleading-new.chpl:72: warning: misleading new
-warn-misleading-new.chpl:73: warning: misleading new
+warn-misleading-new.chpl:71: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:71: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:71: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:72: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:72: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:72: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:73: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:73: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:73: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:76: In function 'test3nn':
-warn-misleading-new.chpl:81: warning: misleading new
-warn-misleading-new.chpl:82: warning: misleading new
-warn-misleading-new.chpl:83: warning: misleading new
+warn-misleading-new.chpl:81: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:81: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:81: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:82: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:82: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:82: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:83: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:83: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:83: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:87: In function 'test4':
-warn-misleading-new.chpl:95: warning: misleading new
-warn-misleading-new.chpl:96: warning: misleading new
-warn-misleading-new.chpl:97: warning: misleading new
+warn-misleading-new.chpl:95: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:95: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:95: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:96: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:96: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:96: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:97: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:97: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:97: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:100: In function 'test4n':
-warn-misleading-new.chpl:108: warning: misleading new
-warn-misleading-new.chpl:109: warning: misleading new
-warn-misleading-new.chpl:110: warning: misleading new
+warn-misleading-new.chpl:108: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:108: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:108: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:109: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:109: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:109: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:110: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:110: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:110: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:113: In function 'test4nn':
-warn-misleading-new.chpl:121: warning: misleading new
-warn-misleading-new.chpl:122: warning: misleading new
-warn-misleading-new.chpl:123: warning: misleading new
+warn-misleading-new.chpl:121: warning: here, 'x' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:121: note: if you meant to save the result of new, change the type of 'x' to not be 'borrowed'
+warn-misleading-new.chpl:121: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:122: warning: here, 'y' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:122: note: if you meant to save the result of new, change the type of 'y' to not be 'borrowed'
+warn-misleading-new.chpl:122: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+warn-misleading-new.chpl:123: warning: here, 'z' is set to the result of borrowing from a 'new'
+warn-misleading-new.chpl:123: note: if you meant to save the result of new, change the type of 'z' to not be 'borrowed'
+warn-misleading-new.chpl:123: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 warn-misleading-new.chpl:87: In function 'test4':
 warn-misleading-new.chpl:95: error: Scoped variable x would outlive the value it is set to
 warn-misleading-new.chpl:96: error: Scoped variable y would outlive the value it is set to
@@ -44,5 +98,5 @@ warn-misleading-new.chpl:109: error: Scoped variable y would outlive the value i
 warn-misleading-new.chpl:110: error: Scoped variable z would outlive the value it is set to
 warn-misleading-new.chpl:113: In function 'test4nn':
 warn-misleading-new.chpl:121: error: Scoped variable x would outlive the value it is set to
-warn-misleading-new.chpl:122: error: Scoped variable x would outlive the value it is set to
-warn-misleading-new.chpl:123: error: Scoped variable x would outlive the value it is set to
+warn-misleading-new.chpl:122: error: Scoped variable y would outlive the value it is set to
+warn-misleading-new.chpl:123: error: Scoped variable z would outlive the value it is set to

--- a/test/classes/errors/warn-misleading-new.good
+++ b/test/classes/errors/warn-misleading-new.good
@@ -1,0 +1,48 @@
+warn-misleading-new.chpl:34: In function 'test2':
+warn-misleading-new.chpl:36: warning: misleading new
+warn-misleading-new.chpl:37: warning: misleading new
+warn-misleading-new.chpl:38: warning: misleading new
+warn-misleading-new.chpl:41: In function 'test2n':
+warn-misleading-new.chpl:43: warning: misleading new
+warn-misleading-new.chpl:44: warning: misleading new
+warn-misleading-new.chpl:45: warning: misleading new
+warn-misleading-new.chpl:48: In function 'test2nn':
+warn-misleading-new.chpl:50: warning: misleading new
+warn-misleading-new.chpl:51: warning: misleading new
+warn-misleading-new.chpl:52: warning: misleading new
+warn-misleading-new.chpl:56: In function 'test3':
+warn-misleading-new.chpl:61: warning: misleading new
+warn-misleading-new.chpl:62: warning: misleading new
+warn-misleading-new.chpl:63: warning: misleading new
+warn-misleading-new.chpl:66: In function 'test3n':
+warn-misleading-new.chpl:71: warning: misleading new
+warn-misleading-new.chpl:72: warning: misleading new
+warn-misleading-new.chpl:73: warning: misleading new
+warn-misleading-new.chpl:76: In function 'test3nn':
+warn-misleading-new.chpl:81: warning: misleading new
+warn-misleading-new.chpl:82: warning: misleading new
+warn-misleading-new.chpl:83: warning: misleading new
+warn-misleading-new.chpl:87: In function 'test4':
+warn-misleading-new.chpl:95: warning: misleading new
+warn-misleading-new.chpl:96: warning: misleading new
+warn-misleading-new.chpl:97: warning: misleading new
+warn-misleading-new.chpl:100: In function 'test4n':
+warn-misleading-new.chpl:108: warning: misleading new
+warn-misleading-new.chpl:109: warning: misleading new
+warn-misleading-new.chpl:110: warning: misleading new
+warn-misleading-new.chpl:113: In function 'test4nn':
+warn-misleading-new.chpl:121: warning: misleading new
+warn-misleading-new.chpl:122: warning: misleading new
+warn-misleading-new.chpl:123: warning: misleading new
+warn-misleading-new.chpl:87: In function 'test4':
+warn-misleading-new.chpl:95: error: Scoped variable x would outlive the value it is set to
+warn-misleading-new.chpl:96: error: Scoped variable y would outlive the value it is set to
+warn-misleading-new.chpl:97: error: Scoped variable z would outlive the value it is set to
+warn-misleading-new.chpl:100: In function 'test4n':
+warn-misleading-new.chpl:108: error: Scoped variable x would outlive the value it is set to
+warn-misleading-new.chpl:109: error: Scoped variable y would outlive the value it is set to
+warn-misleading-new.chpl:110: error: Scoped variable z would outlive the value it is set to
+warn-misleading-new.chpl:113: In function 'test4nn':
+warn-misleading-new.chpl:121: error: Scoped variable x would outlive the value it is set to
+warn-misleading-new.chpl:122: error: Scoped variable x would outlive the value it is set to
+warn-misleading-new.chpl:123: error: Scoped variable x would outlive the value it is set to

--- a/test/classes/ferguson/generic-field/generic-field-unmanaged-borrowed.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-unmanaged-borrowed.chpl
@@ -44,8 +44,10 @@ proc test1b() {
   var b = new unmanaged ClassB(2);
   var c = new unmanaged ClassB(3);
   var x = new owned GenericClassUnmanaged(a);
-  var y:borrowed GenericClassUnmanaged = new owned GenericClassUnmanaged(b);
-  var z:borrowed GenericClassUnmanaged(unmanaged ClassB) = new owned GenericClassUnmanaged(c);
+  var myOwnedY = new owned GenericClassUnmanaged(b);
+  var y:borrowed GenericClassUnmanaged = myOwnedY;
+  var myOwnedZ = new owned GenericClassUnmanaged(c);
+  var z:borrowed GenericClassUnmanaged(unmanaged ClassB) = myOwnedZ;
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);
@@ -81,8 +83,10 @@ proc test2b() {
   var b = (new owned ClassB(2)).borrow();
   var c = (new owned ClassB(3)).borrow();
   var x = new borrowed GenericClassBorrowed(a);
-  var y:borrowed GenericClassBorrowed = new owned GenericClassBorrowed(b);
-  var z:borrowed GenericClassBorrowed(borrowed ClassB) = new owned GenericClassBorrowed(c);
+  var myOwnedY = new owned GenericClassBorrowed(b);
+  var y:borrowed GenericClassBorrowed = myOwnedY;
+  var myOwnedZ = new owned GenericClassBorrowed(c);
+  var z:borrowed GenericClassBorrowed(borrowed ClassB) = myOwnedZ;
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);

--- a/test/classes/initializers/generics/phase1/hasLoopGood.chpl
+++ b/test/classes/initializers/generics/phase1/hasLoopGood.chpl
@@ -20,6 +20,7 @@ class InLoop {
 proc main() {
   var arr = [3, -5, 2, 7, 1, 2, 5, 8, 3, 0];
 
-  var c: borrowed InLoop(int) = new shared InLoop(arr);
+  var myShared = new shared InLoop(arr);
+  var c: borrowed InLoop(int) = myShared;
   writeln(c);
 }

--- a/test/classes/lydia/staticMethodInheritance-whenField.chpl
+++ b/test/classes/lydia/staticMethodInheritance-whenField.chpl
@@ -12,8 +12,10 @@ record Wrapper {
   var x;
 }
 
-var p:borrowed = new Parent();
-var c:borrowed = new Child();
+var ownedP = new Parent();
+var p:borrowed = ownedP;
+var ownedC = new Child();
+var c:borrowed = ownedC;
 var w1 = new Wrapper(p);
 var w2 = new Wrapper(c);
 

--- a/test/classes/vass/ref-like-intents/inout-subclass.good
+++ b/test/classes/vass/ref-like-intents/inout-subclass.good
@@ -1,1 +1,6 @@
+inout-subclass.chpl:6: In function 'procInoutC':
+inout-subclass.chpl:7: warning: here, 'arg' is set to the result of borrowing from a 'new'
+inout-subclass.chpl:7: note: if you meant to save the result of new, change the type of 'arg' to not be 'borrowed'
+inout-subclass.chpl:7: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
+  inout-subclass.chpl:13: called as procInoutC(arg: borrowed C?)
 inout-subclass.chpl:14: error: Cannot assign to borrowed D? from borrowed C?

--- a/test/classes/vass/ref-like-intents/ref-subclass.good
+++ b/test/classes/vass/ref-like-intents/ref-subclass.good
@@ -1,3 +1,7 @@
+ref-subclass.chpl:6: In function 'procRefC':
+ref-subclass.chpl:7: warning: here, 'arg' is set to the result of borrowing from a 'new'
+ref-subclass.chpl:7: note: if you meant to save the result of new, change the type of 'arg' to not be 'borrowed'
+ref-subclass.chpl:7: note: if you meant to refer to another variable storing the 'new', use an explicit variable, e.g. 'var myOwned = new C(); var myBorrowed = myOwned.borrow();'
 ref-subclass.chpl:14: error: unresolved call 'procRefC(borrowed D?)'
 ref-subclass.chpl:6: note: this candidate did not match: procRefC(ref arg: borrowed C?)
 ref-subclass.chpl:14: note: because actual argument #1 with type 'borrowed D?'

--- a/test/classes/waynew/dyndis2.chpl
+++ b/test/classes/waynew/dyndis2.chpl
@@ -38,8 +38,9 @@ class contain {
 
   proc xxx() {
     var something: borrowed somedata(int)?;
+    var myOwned = new owned somedata( int, 10);
 
-    something = new owned somedata( int, 10);
+    something = myOwned;
 
     for e in objs do
        e.jam( 99, something!);

--- a/test/modules/diten/mutualuse2.chpl
+++ b/test/modules/diten/mutualuse2.chpl
@@ -23,8 +23,8 @@ module M1 {
   class C {
     var field: int;
   }
-
-  var a:borrowed C = new C(1);
+  var myOwnedC = new C(1);
+  var a:borrowed C = myOwnedC;
 }
 
 module M2 {

--- a/test/trivial/jturner/iter_overload_simple.chpl
+++ b/test/trivial/jturner/iter_overload_simple.chpl
@@ -18,7 +18,8 @@ class Child : Parent {
   }
 }
 
-var c:borrowed Parent = new owned Child();
+var myOwnedChild = new owned Child();
+var c:borrowed Parent = myOwnedChild;
 
 for m in c.foo(10) {
   writeln(m);

--- a/test/visibility/private/uses/accessSecondary.chpl
+++ b/test/visibility/private/uses/accessSecondary.chpl
@@ -3,5 +3,6 @@ use TypeDefiner; // same
 
 // Verifies that you cannot make use of secondary methods obtained via
 // another module's private use.
-var foo: borrowed Foo = new Foo(5);
+var myOwnedFoo = new Foo(5);
+var foo: borrowed Foo = myOwnedFoo;
 foo.other();

--- a/test/visibility/private/uses/accessSecondary.good
+++ b/test/visibility/private/uses/accessSecondary.good
@@ -1,2 +1,2 @@
-accessSecondary.chpl:7: error: unresolved call 'Foo.other()'
-accessSecondary.chpl:7: note: because no functions named other found in scope
+accessSecondary.chpl:8: error: unresolved call 'Foo.other()'
+accessSecondary.chpl:8: note: because no functions named other found in scope

--- a/test/visibility/private/uses/pointOfInstantiation/methodOnType2.chpl
+++ b/test/visibility/private/uses/pointOfInstantiation/methodOnType2.chpl
@@ -9,7 +9,8 @@ module M1 {
   }
 
   proc main() {
-    var c: borrowed C = new C(3);
+    var myOwnedC = new C(3);
+    var c: borrowed C = myOwnedC;
     baz(c);
   }
 }
@@ -31,7 +32,8 @@ module M2 {
   // if baz is not generic and is called from M2.main (and there is nothing to
   // instantiate bar before it), this should error.
   proc baz(c1: borrowed C) {
-    var c2: borrowed C = new C(3);
+    var myOwnedC = new C(3);
+    var c2: borrowed C = myOwnedC;
 
     bar(c1);
     bar(c2);

--- a/test/visibility/private/uses/pointOfInstantiation/methodOnType2.good
+++ b/test/visibility/private/uses/pointOfInstantiation/methodOnType2.good
@@ -1,4 +1,4 @@
-methodOnType2.chpl:26: In function 'bar':
-methodOnType2.chpl:28: error: unresolved call 'C.goo()'
-methodOnType2.chpl:28: note: because no functions named goo found in scope
-  methodOnType2.chpl:36: called as bar(c: borrowed C)
+methodOnType2.chpl:27: In function 'bar':
+methodOnType2.chpl:29: error: unresolved call 'C.goo()'
+methodOnType2.chpl:29: note: because no functions named goo found in scope
+  methodOnType2.chpl:38: called as bar(c: borrowed C)


### PR DESCRIPTION
For
 * https://github.com/Cray/chapel-private/issues/3674
 * https://github.com/Cray/chapel-private/issues/3680

This PR adds a warning for patterns like

``` chapel
var x: borrowed C = new C(); // warn
x = new shared C(); // warn
```

including in variable initialization, split init, and assignment cases.

What happens in these patterns in that the result of the `new` expression is stored into a temporary variable and then that is borrowed from. That is because we have implicit conversions from owned/shared to borrowed. It is unlikely that this pattern is useful (specifically when the RHS is a `new` expression) and so this PR adds a warning for that case.

Reviewed by @daviditen - thanks!

- [x] full local testing