### PR TITLE
fix(C-interop): fix cmake interop failure in some cases

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -378,15 +378,17 @@ void codegen_library_cmakelists() {
   printCMakeListsIncludes(cmakelists, name);
   printCMakeListsLibraries(cmakelists, name);
 
-  std::string compiler = getCompilelineOption("compiler");
+  // get the various options and convert any $(FOO) to ${FOO} at the same time.
+  // needed because cmake doesn't understand $(FOO)
+  std::string compiler = makeToCMake(getCompilelineOption("compiler"));
   removeTrailingNewlines(compiler);
   fprintf(cmakelists.fptr, "set(CHPL_COMPILER %s)\n", compiler.c_str());
 
-  std::string linker = getCompilelineOption("linker");
+  std::string linker = makeToCMake(getCompilelineOption("linker"));
   removeTrailingNewlines(linker);
   fprintf(cmakelists.fptr, "set(CHPL_LINKER %s)\n", linker.c_str());
 
-  std::string linkerShared = getCompilelineOption("linkershared");
+  std::string linkerShared = makeToCMake(getCompilelineOption("linkershared"));
   removeTrailingNewlines(linkerShared);
   fprintf(cmakelists.fptr, "set(CHPL_LINKERSHARED %s)\n", linkerShared.c_str());
 


### PR DESCRIPTION
This PR adds translation of make to cmake style variables 
to the `.cmake` files written by our cmake library interop
code generation. 

* Previously, if getCompilelineOption returned a path that included 
  an env var, it was formatted as `make` would expect, e.g., `$(FOO)`.
  `cmake` doesn't read that correctly and expects `${FOO}`, so in 
  some environments the interop would fail to build a valid 
  `MyLibraryName.cmake` file. This change adds a call to 
  `makeToCMake` when writing the `.cmake` file lines for 
  `CHPL_COMPILER`, `CHPL_LINKER` and `CHPL_LINKERSHARED`

TESTING:

- [x] paratest

reviewed by @mppf - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>