### PR TITLE
For SHOC correctness tests only do one pass

### DIFF
--- a/test/gpu/native/studies/shoc/EXECOPTS
+++ b/test/gpu/native/studies/shoc/EXECOPTS
@@ -1,1 +1,1 @@
---output=false --passes=5
+--output=false --passes=1

--- a/test/gpu/native/studies/shoc/sort.good
+++ b/test/gpu/native/studies/shoc/sort.good
@@ -1,7 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 Test Passed
-Test Passed
-Test Passed
-Test Passed
-Test Passed
-(kernel_launch = 249)
+(kernel_launch = 57)

--- a/test/gpu/native/studies/shoc/triad.good
+++ b/test/gpu/native/studies/shoc/triad.good
@@ -1,1 +1,1 @@
-(kernel_launch = 2561)
+(kernel_launch = 517)

--- a/test/gpu/native/studies/shoc/triadalt1.good
+++ b/test/gpu/native/studies/shoc/triadalt1.good
@@ -1,1 +1,1 @@
-(kernel_launch = 2615)
+(kernel_launch = 523)

--- a/test/gpu/native/studies/shoc/triadalt2.good
+++ b/test/gpu/native/studies/shoc/triadalt2.good
@@ -1,1 +1,1 @@
-(kernel_launch = 2635)
+(kernel_launch = 527)

--- a/test/gpu/native/studies/shoc/triadchpl.good
+++ b/test/gpu/native/studies/shoc/triadchpl.good
@@ -1,1 +1,1 @@
-(kernel_launch = 13)
+(kernel_launch = 5)


### PR DESCRIPTION
We're getting timeouts on some of our implementations of the SHOC benchmarks when our nightly `cray-cs-gpu-native-gasnet` job runs.

Looking at our performance graphs I'm thinking this is fallout from this PR:

https://github.com/chapel-lang/chapel/pull/20460

We should investigate the cause of the performance change but I don't think it's worth having our correctness tests continue to fail in the meantime.

Currently we're running "5 passes" of each benchmark regardless of whether we're doing so for checking correctness or measuring performance. I don't think it's necessary to run it 5 times for correctness so this PR changes it to only run 1 time under this configuration.

Ultimately, we might want to move away from having separate correctness and performance jobs for these tests (it's wasting resources) and there is a way to check correctness for performance tests here:

https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/TestSystem.rst#validating-performance-test-output
