### PR TITLE
Ignore unreachable code during resolution

### DIFF
--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -860,7 +860,7 @@ inline proc _remoteAccessData.getDataIndex(
   // modified from DefaultRectangularArr
   var sum = origin;
   if stridable {
-    halt("RADOpt not supported for strided cyclic arrays.");
+    compilerError("RADOpt not supported for strided cyclic arrays.");
   } else {
     for param i in 0..rank-1 do {
       sum += (((ind(i) - off(i)):int * blk(i))-startIdx(i):int)/dimLen(i);
@@ -879,7 +879,7 @@ proc CyclicArr.dsiAccess(i:rank*idxType) ref {
       if myLocArrNN.locDom.contains(i) then
         return myLocArrNN.this(i);
   }
-  if doRADOpt && !stridable {
+  if !stridable && doRADOpt {
     if const myLocArr = this.myLocArr {
       var rlocIdx = dom.dist.targetLocsIdx(i);
       if !disableCyclicLazyRAD {

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1178,8 +1178,7 @@ module Random {
         var dom: domain(1,stridable=true);
 
         if !isBoundedRange(x) {
-          throw new owned IllegalArgumentError('input range must be bounded');
-          dom = {1..2}; // this is a workaround for issue #15691
+          compilerError('input range must be bounded');
         } else {
           dom = {x};
         }

--- a/test/errhandling/codePathCoverage/ifOrThrow2.bad
+++ b/test/errhandling/codePathCoverage/ifOrThrow2.bad
@@ -1,4 +1,1 @@
-ifOrThrow2.chpl:5: In function 'testit':
-ifOrThrow2.chpl:13: error: 'dom' is used before it is initialized
-ifOrThrow2.chpl:6: note: 'dom' declared here
-  ifOrThrow2.chpl:16: called as testit(r: range(int(64),boundedLow,false))
+ifOrThrow2.chpl:16: error: illegal use of function that does not return a value: 'testit'

--- a/test/errhandling/codePathCoverage/ifOrThrow2.future
+++ b/test/errhandling/codePathCoverage/ifOrThrow2.future
@@ -6,3 +6,8 @@ along one branch and not the other, we sometimes get an incorrect
 use-before-def error.  If `return testit2(dom);` is changed to `return
 dom;` things work; as does adding a dummy assignment to the throwing
 branch of the conditional.
+
+Update: given that the return statement is dead, it is no longer
+considered by resolution. So `testit()` looks to the compiler like
+a function without any return statements. This gives it the `void`
+return type. The .bad file is updated to this behavior.

--- a/test/errhandling/parallel/forall-iterator-throws-at-end.chpl
+++ b/test/errhandling/parallel/forall-iterator-throws-at-end.chpl
@@ -1,0 +1,45 @@
+use ExampleErrors;
+
+config const n = 10;
+config const t = 2;
+// This is a mod of forall-iterator-throws-follower
+// with nothing in the follower after 'throw'.
+iter myiter(nn: int, nt: int) throws {
+  for i in 0..#nt {
+    for j in i*nn..#nn {
+      yield j;
+    }
+  }
+}
+
+// coforall loop in leader should NOT get vector pragma
+iter myiter(nn: int, nt: int, param tag: iterKind) throws where tag == iterKind.leader {
+  coforall i in 0..#nt {
+    yield i*nn..#nn;
+  }
+}
+
+// for loop in follower with yield should get vector pragma
+iter myiter(nn:int, nt: int, followThis, param tag: iterKind) throws where tag == iterKind.follower {
+  throw new owned StringError("Test error");
+}
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in myiter(n,t) {
+      writeln(i);
+    }
+    writeln("after forall block");
+  } catch errors: TaskErrors {
+    for e in errors { 
+      if e != nil {
+        writeln("Caught group error e ", e!.message());
+      }
+    }
+  } catch e {
+    writeln("Caught other error ", e.message());
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-iterator-throws-at-end.good
+++ b/test/errhandling/parallel/forall-iterator-throws-at-end.good
@@ -1,0 +1,3 @@
+before forall block
+Caught group error e Test error
+Caught group error e Test error

--- a/test/functions/resolution/ignore-unreachable.chpl
+++ b/test/functions/resolution/ignore-unreachable.chpl
@@ -1,0 +1,70 @@
+// https://github.com/chapel-lang/chapel/issues/20481#issuecomment-1224354640
+
+use Reflection;
+
+record Foo {
+    type t = int(32);
+    var s = "hi";
+}
+
+var foo = new Foo();
+
+for param i in 0..<numFields(foo.type) {
+    if isType(getField(foo,i)) {
+        continue;
+    }
+    writeln(getField(foo, i));
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+proc p() type {
+  if true then
+    return int;
+
+  return string;
+}
+
+compilerWarning(p():string);
+
+proc p(param flag) {
+  if flag then
+    return 3.5;
+
+  return "bye";
+}
+
+writeln(p(true));
+writeln(p(false));
+
+/////////////////////////////////////////////////////////////////////////////
+
+proc t1(arg:int) {
+  writeln("in t1");
+  if arg > 1 {
+    return 55;
+    writeln("after return 55");
+    compilerError("after return 55");
+  } else {
+    return 77;
+    writeln("after return 77");
+    compilerError("after return 77");
+  }
+  writeln("after if arg > 1");
+  compilerError("after if arg > 1");
+}
+
+proc t2() throws {
+  writeln("in t2");
+  throw new Error();
+  writeln("after throw");
+  compilerError("after throw");
+}
+
+proc main {
+  writeln(t1(1), t1(2));
+  try { t2(); } catch { }
+  halt("in main");
+  writeln("after halt");
+  compilerError("after halt");
+}

--- a/test/functions/resolution/ignore-unreachable.good
+++ b/test/functions/resolution/ignore-unreachable.good
@@ -1,0 +1,9 @@
+ignore-unreachable.chpl:28: warning: int(64)
+hi
+3.5
+bye
+in t1
+in t1
+7755
+in t2
+ignore-unreachable.chpl:67: error: halt reached - in main

--- a/test/library/standard/Random/RandomStreamInterface/choiceTestErrors.chpl
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestErrors.chpl
@@ -101,13 +101,15 @@ proc main() throws {
   } catch e: IllegalArgumentError {
     if debug then writeln(e.message());
   }
-  
+
+/* now generates a compile-time error:  
   try {
     var c = stream.choice(1..);
     writeln('Error: unbounded range did not throw error');
   } catch e: IllegalArgumentError {
     if debug then writeln(e.message());
   }
+*/
 
   try {
     var c = stream.choice({1..2}, size=0);

--- a/test/library/standard/Random/RandomStreamInterface/choiceTestLowbounded.chpl
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestLowbounded.chpl
@@ -1,0 +1,14 @@
+use Random;
+
+config const debug = false;
+
+/* Confirm a number of cases that should throw errors */
+proc main() throws {
+
+  var success = true;
+
+  var stream = createRandomStream(real);
+
+  var c = stream.choice(1..);
+  writeln('Error: unbounded range did not throw error');
+}

--- a/test/library/standard/Random/RandomStreamInterface/choiceTestLowbounded.good
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestLowbounded.good
@@ -1,0 +1,2 @@
+choiceTestLowbounded.chpl:6: In function 'main':
+choiceTestLowbounded.chpl:12: error: input range must be bounded

--- a/test/statements/conditionals/param/nonparam-and-false.bad
+++ b/test/statements/conditionals/param/nonparam-and-false.bad
@@ -1,0 +1,3 @@
+nonparam-and-false.chpl:9: In function 'CyclicArr_dsiAccess':
+nonparam-and-false.chpl:10: warning: in doRADOpt
+nonparam-and-false.chpl:15: error: got !stridable

--- a/test/statements/conditionals/param/nonparam-and-false.chpl
+++ b/test/statements/conditionals/param/nonparam-and-false.chpl
@@ -1,0 +1,16 @@
+
+proc doRADOpt {
+  compilerWarning("in doRADOpt");
+  return true;
+}
+
+param stridable = true;
+
+proc CyclicArr_dsiAccess() {
+  if doRADOpt && !stridable {
+    compilerError("got !stridable");
+  }
+}
+
+CyclicArr_dsiAccess();
+compilerError("success");

--- a/test/statements/conditionals/param/nonparam-and-false.future
+++ b/test/statements/conditionals/param/nonparam-and-false.future
@@ -1,0 +1,2 @@
+feature request: fold `(non-param) && false`
+#20496

--- a/test/statements/conditionals/param/nonparam-and-false.good
+++ b/test/statements/conditionals/param/nonparam-and-false.good
@@ -1,0 +1,3 @@
+nonparam-and-false.chpl:9: In function 'CyclicArr_dsiAccess':
+nonparam-and-false.chpl:10: warning: in doRADOpt
+nonparam-and-false.chpl:16: error: success

--- a/test/types/records/intents/out-intent.good
+++ b/test/types/records/intents/out-intent.good
@@ -171,6 +171,8 @@ init 1 1
 (x = 1, ptr = {xx = 1})
 deinit 1 1
 test24
+init (default)
+deinit 0 0
 Error: 
 test25
 Error: 

--- a/test/users/weili/typefnbug.future
+++ b/test/users/weili/typefnbug.future
@@ -1,9 +1,0 @@
-bug: failure to unify return types for type function (?)
-
-I'm not quite sure what's going wrong in this test, but my
-best guess would be that the logic we use to unify inferred
-return types might be trying to be applied to type functions
-as well.  That's just a wild guess, though.
-
-Also of interest, the small rewrite captured in typefnbug-works.chpl
-(adding an else clause) causes this to work.


### PR DESCRIPTION
Resolves or affects #14683 #15691 #18597 #20481

When a code block has a statement that interrupts the control flow, such as:

* `return`
* `throw`
* call to a function that terminates the program, like `halt()`
* an `if` whose both branches have this interruption property

then the remainder of the code block is discarded as unreachable.

### Semantic impact

The following function is now inferred to return `void` because its return statement is discarded:
```chpl
proc testit() {
  if true {
    halt();
  }
  return 5;
}
```

There are several places in our code base where we use code like the above, in several shapes and forms, to lead the compiler to infer the desired return type. This PR adjusts those cases that came up in testing. Ex. adjusted .bad for: `test/errhandling/codePathCoverage/ifOrThrow2.chpl`

The following function used to return a nilable, now returns a non-nilable class C:
```chpl
proc makeC() {
  if true then
    return new C();

  return new C()?;
}
```

### Semantic exception

If a `throw` or a `halt` is followed by a `return`, then the remainder of the block is handled normally.

Rationale: this exception supports the following code pattern. Test: `test/sparse/CS/multiplication/correctness.chpl`

```chpl
    // in parent class BaseSparseDomImpl
    proc bulkAdd_help(....){
      halt("Helper function called on the BaseSparseDomImpl");

      return -1;
    }

    // in child class DefaultSparseDom
    override proc bulkAdd_help(....){
      ....
      return actualAddCnt;  // return normally
    }
```

The following would happen if we did not have this exception.

* The parent's bulkAdd_help() does not contain any return statements for the compiler to consider, since "return -1" is discarded as unreachable. A function without return statements is inferred to return `void`.

* This by itself is fine. The impact is merely that I cannot pass its result elsewhere, like `writeln(bulkAdd_help(...));` is now an error.

* The child's bulkAdd_help() is inferred to return `int` as usual.

* There are cases where a variable whose static type is the parent (BaseSparseDomImpl) always contains a reference to a child (such as DefaultSparseDom). So the code author expects `v.bulkAdd_help(...)` to produce an integer. However the compiler goes to bulkAdd_help() on the static type of `v`, concludes that the call produces no value, and generates an error "cannot use void".

### Implementation exceptions

* Non-executable declarations are retained, such as declarations of types and functions. Only the declarations of variables are removed.
* Code inside task constructs is not considered. Otherwise we can lose some magic code that handles endCounts.

### Other

The change in lowerIterators fixes a compiler assertion failure when a follower iterator contains a `throw` as the last statement in its body, see `test/errhandling/parallel/forall-iterator-throws-at-end.chpl` . This change makes it equivalent to its sibling test `forall-iterator-throws-follower.chpl` .

While there: add a future test for #20496: `test/statements/conditionals/param/nonparam-and-false.chpl`.

### Next steps

* [ ] Reflect this semantics in documentation.
* [ ] Remove the Semantic Exception (see above), providing an alternative way to specify the return type of a function that never returns.

For example, have the compiler accept the following function and `int` as its return type -- because according to the analysis in this PR it does not return normally and `int` is the specified return type:

```chpl
proc bulkAdd_help(): int {
  halt("Helper function called on the BaseSparseDomImpl");
}
```
