### PR TITLE
Update GPU test locking down warn-unstable message

### DIFF
--- a/test/gpu/native/jacobi/flags-warn-unstable.good
+++ b/test/gpu/native/jacobi/flags-warn-unstable.good
@@ -1,5 +1,6 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-$CHPL_HOME/modules/internal/localeModels/gpu/LocaleModel.chpl:33: warning: GPU support is a prototype in this version of Chapel. As such, the interface is unstable and expected to change in the forthcoming releases.
+$CHPL_HOME/modules/internal/ChapelStandard.chpl:53: warning: GPU support is a prototype in this version of Chapel. As such, the interface is unstable and expected to change in the forthcoming releases.
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:29: warning: GPU support is a prototype in this version of Chapel. As such, the interface is unstable and expected to change in the forthcoming releases.
 on GPU:
 1.0 1.20906 2.19525 2.9034 3.5552 4.01125 4.21599 4.10448 3.62297 2.85669 1.60226 1.0
 on CPU:


### PR DESCRIPTION
We have a test that locks down that we produce a warning when using the GPU locale model and `--warn-unstable`. It looks like after this PR:

https://github.com/chapel-lang/chapel/pull/20486

We modified the filename/location of this message.

