### PR TITLE
Adjust .bad files for RTT futures

### DIFF
--- a/test/arrays/deitz/part3/test_record_of_array_type.bad
+++ b/test/arrays/deitz/part3/test_record_of_array_type.bad
@@ -1,3 +1,3 @@
-(x = 0.0 0.0 0.0)
+1.0 2.0 3.0
 Thread
 Conditional jump or move depends on uninitialised value(s)

--- a/test/arrays/deitz/part3/test_record_of_domain_type.bad
+++ b/test/arrays/deitz/part3/test_record_of_domain_type.bad
@@ -1,3 +1,3 @@
-(x = {1..0})
+{1..3}
 Thread
 Conditional jump or move depends on uninitialised value(s)


### PR DESCRIPTION
Adjust the .bad files for two futures related to runtime types.
Trivial and not reviewed.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>