### PR TITLE
Clean up most of the test failures from last night

### DIFF
--- a/test/associative/types/testBorrowed.bad
+++ b/test/associative/types/testBorrowed.bad
@@ -1,3 +1,0 @@
-./AssocTest.chpl:1: In function 'testAssoc':
-./AssocTest.chpl:8: error: Cannot default initialize associative array because element type borrowed T is a non-nilable class
-  testBorrowed.chpl:9: called as testAssoc(type t = borrowed T)

--- a/test/associative/types/testBorrowed.future
+++ b/test/associative/types/testBorrowed.future
@@ -1,1 +1,0 @@
-borrowed type not supported

--- a/test/associative/types/testBorrowed.good
+++ b/test/associative/types/testBorrowed.good
@@ -1,0 +1,3 @@
+./AssocTest.chpl:1: In function 'testAssoc':
+./AssocTest.chpl:10: error: creating a 'new borrowed' type is a not allowed
+  testBorrowed.chpl:9: called as testAssoc(type t = borrowed T)

--- a/test/classes/delete-free/borrowed/borrowed-if-expr.chpl
+++ b/test/classes/delete-free/borrowed/borrowed-if-expr.chpl
@@ -6,7 +6,7 @@ config const c = true;
 
 proc main() {
  
-  var x = if c then (new owned MyClass(1) else new borrowed MyClass(2)).borrow();
+  var x = if c then (new owned MyClass(1)).borrow() else (new owned MyClass(2)).borrow();
 
   writeln(x);
 }

--- a/test/classes/diten/subclassMethodCall.chpl
+++ b/test/classes/diten/subclassMethodCall.chpl
@@ -27,6 +27,6 @@ class Sub2: Base {
 
 proc main {
   var s1: borrowed Base?;
-  s1 = (new owned Sub1(); s1!.method(new C1(int))).borrow();
-  s1 = (new owned Sub2(); s1!.method(new C2())).borrow();
+  s1 = (new owned Sub1()).borrow(); s1!.method(new C1(int));
+  s1 = (new owned Sub2()).borrow(); s1!.method(new C2());
 }

--- a/test/io/vass/writeThis-on.chpl
+++ b/test/io/vass/writeThis-on.chpl
@@ -5,7 +5,7 @@ class C {
   override proc writeThis(f) throws { f.write("here=", here.id, " home=", home); }
 }
 
-for l in Locales do on l do { const c = (new owned C(); writeln(c)).borrow(); }
+for l in Locales do on l do { const c = (new owned C()).borrow(); writeln(c); }
 writeln();
 
 

--- a/test/library/packages/ZMQ/not-serializable.chpl
+++ b/test/library/packages/ZMQ/not-serializable.chpl
@@ -12,7 +12,7 @@ class Foo {
   var d: borrowed Bar;
 }
 
-var foo = (new owned Foo(42, 13.0, "hello", new borrowed Bar(29, "goodbye"))).borrow();
+var foo = (new owned Foo(42, 13.0, "hello", (new owned Bar(29, "goodbye")).borrow())).borrow();
 
 var context = new ZMQ.Context();
 var socket = context.socket(ZMQ.PUSH);

--- a/test/library/packages/ZMQ/weather.chpl
+++ b/test/library/packages/ZMQ/weather.chpl
@@ -61,7 +61,7 @@ proc Launcher(exec: string) {
 }
 
 proc Master(exec: string) {
-  var rand = (new owned RandomStream(real,13); rand.getNext()).borrow();
+  var rand = (new owned RandomStream(real,13)).borrow(); rand.getNext();
   var ctxt: Context;
   var sock = ctxt.socket(ZMQ.PUB);
   sock.bind("tcp://*:5556");

--- a/test/modules/figueroa/DuplicateConfigVars/DuplicateConfigVars.chpl
+++ b/test/modules/figueroa/DuplicateConfigVars/DuplicateConfigVars.chpl
@@ -7,7 +7,7 @@ proc main () {
     halt ("arraySize must be even!");
   // Each point consists of two coordinates.
   const numberOfPoints = arraySize/2;
-  var r = new borrowed Random (),
+  var r = (new owned Random ()).borrow(),
       rArray: [1..arraySize] real;
   ref x = rArray[1..numberOfPoints],
       y = rArray[numberOfPoints+1 ..];

--- a/test/param/ifExprCopyInitBug.chpl
+++ b/test/param/ifExprCopyInitBug.chpl
@@ -9,11 +9,11 @@ proc test(type T) {
 
 type T1 = owned C;
 type T2 = owned C?;
-type T3 = borrowed C?;
+//type T3 = borrowed C?;
 
 proc main() {
   test(T1);
   test(T2);
-  test(T3);
+  //test(T3);
   return;
 }


### PR DESCRIPTION
Most of these ran only with CHPL_COMM!=none or were .futures so I didn't
catch them in my initial pass.

Correct some incorrect automatic translations and avoid doing
'new borrowed C()' in a few places.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>