### PR TITLE
dyno: make params without values be considered unknown

### DIFF
--- a/compiler/dyno/include/chpl/types/QualifiedType.h
+++ b/compiler/dyno/include/chpl/types/QualifiedType.h
@@ -166,7 +166,7 @@ class QualifiedType final {
    */
   bool isParamFalse() const;
 
-  /** Returns 'true' if storing a tuple record type whose
+  /** Returns 'true' if storing a tuple type whose
       constituent types are all known params.
   */
   bool isParamKnownTuple() const;

--- a/compiler/dyno/include/chpl/types/QualifiedType.h
+++ b/compiler/dyno/include/chpl/types/QualifiedType.h
@@ -134,6 +134,11 @@ class QualifiedType final {
   }
 
   bool isUnknown() const {
+    return isUnknownKindOrType() ||
+      (kind_ == PARAM && !hasParamPtr() && !isParamKnownTuple());
+  }
+
+  bool isUnknownKindOrType() const {
     return kind_ == UNKNOWN || !hasTypePtr() || type_->isUnknownType();
   }
 
@@ -160,6 +165,11 @@ class QualifiedType final {
       'false' otherwise
    */
   bool isParamFalse() const;
+
+  /** Returns 'true' if storing a tuple record type whose
+      constituent types are all known params.
+  */
+  bool isParamKnownTuple() const;
 
   /**
     Returns true if the value cannot be modified directly (but might

--- a/compiler/dyno/include/chpl/types/TupleType.h
+++ b/compiler/dyno/include/chpl/types/TupleType.h
@@ -34,8 +34,10 @@ class TupleType final : public CompositeType {
   bool isStarTuple_ = false; // i.e. all elements have the same type
   bool isVarArgTuple_ = false;
   bool isKnownSize_ = true;
+  bool isParamKnown_ = false;
 
   void computeIsStarTuple();
+  void computeIsParamKnown();
 
   TupleType(ID id, UniqueString name,
             const TupleType* instantiatedFrom,
@@ -55,6 +57,7 @@ class TupleType final : public CompositeType {
       }
     }
     computeIsStarTuple();
+    computeIsParamKnown();
   }
 
 
@@ -112,6 +115,10 @@ class TupleType final : public CompositeType {
   /** Return true if this is a *star tuple* - that is, all of the
       element types are the same. */
   bool isStarTuple() const { return isStarTuple_; }
+
+  /** Return true if this tuple's elements are all non-generic
+      params, e.g., (param b: bool = true, param i: int = 0). */
+  bool isParamKnown() const { return isParamKnown_; }
 
   bool isVarArgTuple() const { return isVarArgTuple_; }
 

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -1427,7 +1427,7 @@ bool Resolver::enter(const uast::Conditional* cond) {
     // with useRequiredKind = false, the QualifiedType::Kind argument
     // is ignored. Just pick a dummy value.
     auto ifType = commonType(context, returnTypes);
-    if (!ifType && !condType.isGenericOrUnknown()) {
+    if (!ifType && !condType.isUnknown()) {
       // do not error if the condition type is unknown
       r.setType(typeErr(cond, "unable to reconcile branches of if-expression"));
     } else if (ifType) {

--- a/compiler/dyno/lib/resolution/can-pass.cpp
+++ b/compiler/dyno/lib/resolution/can-pass.cpp
@@ -899,7 +899,7 @@ CanPassResult CanPassResult::canPass(Context* context,
     return fail(); // actual type not established
   }
 
-  if (formalQT.isUnknown()) {
+  if (formalQT.isUnknownKindOrType()) {
     return fail(); // unknown formal type, can't resolve
   }
 

--- a/compiler/dyno/lib/types/QualifiedType.cpp
+++ b/compiler/dyno/lib/types/QualifiedType.cpp
@@ -22,6 +22,7 @@
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/types/Param.h"
 #include "chpl/types/Type.h"
+#include "chpl/types/TupleType.h"
 
 namespace chpl {
 namespace types {
@@ -47,6 +48,22 @@ bool QualifiedType::isParamFalse() const {
     }
   }
 
+  return false;
+}
+
+bool QualifiedType::isParamKnownTuple() const {
+  if (kind_ == Kind::PARAM && type_ != nullptr) {
+    if (auto tt = type_->toTupleType()) {
+      // Check if all type actuals are known params
+      for (int i = 0; i < tt->numElements(); i++) {
+        const auto& elemType = tt->elementType(i);
+        if (!elemType.isParam() || elemType.isUnknown()) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
   return false;
 }
 

--- a/compiler/dyno/lib/types/QualifiedType.cpp
+++ b/compiler/dyno/lib/types/QualifiedType.cpp
@@ -54,14 +54,7 @@ bool QualifiedType::isParamFalse() const {
 bool QualifiedType::isParamKnownTuple() const {
   if (kind_ == Kind::PARAM && type_ != nullptr) {
     if (auto tt = type_->toTupleType()) {
-      // Check if all type actuals are known params
-      for (int i = 0; i < tt->numElements(); i++) {
-        const auto& elemType = tt->elementType(i);
-        if (!elemType.isParam() || elemType.isUnknown()) {
-          return false;
-        }
-      }
-      return true;
+      return tt->isParamKnown();
     }
   }
   return false;

--- a/compiler/dyno/lib/types/TupleType.cpp
+++ b/compiler/dyno/lib/types/TupleType.cpp
@@ -144,10 +144,9 @@ const TupleType*
 TupleType::getVarArgTuple(Context* context,
                           QualifiedType paramSize,
                           QualifiedType varArgEltType) {
-  assert(!varArgEltType.isUnknown());
+  assert(!varArgEltType.isUnknownKindOrType());
 
-  if (!paramSize.isUnknown() &&
-      paramSize.param() != nullptr) {
+  if (!paramSize.isUnknown()) {
     // Fixed size, we can at least create a star tuple of AnyType
     int64_t numElements = paramSize.param()->toIntParam()->value();
     std::vector<QualifiedType> eltTypes(numElements, varArgEltType);

--- a/compiler/dyno/lib/types/TupleType.cpp
+++ b/compiler/dyno/lib/types/TupleType.cpp
@@ -54,6 +54,22 @@ void TupleType::computeIsStarTuple() {
   }
 }
 
+void TupleType::computeIsParamKnown() {
+  if (isKnownSize_ == false) {
+    isParamKnown_ = false;
+  } else {
+    isParamKnown_ = true;
+    int n = numElements();
+    for (int i = 0; i < n; i++) {
+      const auto& eltT = elementType(i);
+      if (!eltT.isParam() || eltT.isUnknown()) {
+        isParamKnown_ = false;
+        break;
+      }
+    }
+  }
+}
+
 const owned<TupleType>&
 TupleType::getTupleType(Context* context, ID id, UniqueString name,
                         const TupleType* instantiatedFrom,

--- a/compiler/dyno/test/resolution/testExprIf.cpp
+++ b/compiler/dyno/test/resolution/testExprIf.cpp
@@ -89,11 +89,24 @@ static void test5() {
   assert(qt.type() && qt.type()->isRecordType());
 }
 
+static void test6() {
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                         param b : bool;
+                         var x = if b then 1 else "hello";
+                         )"""", false);
+  qt.dump();
+  assert(qt.kind() == QualifiedType::UNKNOWN);
+}
+
 int main() {
   test1();
   test2();
   test3();
   test4();
   test5();
+  test6();
   return 0;
 }


### PR DESCRIPTION
This is needed for the resolution of if-expressions with `param`
conditions. An if-expression depending on a `param bool` without a value
should be considered unknown (as is the case for an if-expression
depending on any other unknown value).

This commit also implements special-case behavior for `param _tuple`
types, which have their tuple elements' values encoded in the
`QualifiedType`s of the `TupleType`, but not stored into a `Param*`.

There is discussion in https://github.com/chapel-lang/chapel/issues/20487 
about how to properly represent param tuples. It is likely that in the
event that we add param tuples to Dyno, we will settle on a representation
that includes a special `Param` that contains tuple values. This would
preclude the need for special-case handling in isUnknown. In the meantime,
though, we don't have Param tuples (and they're not in the production compiler),
so this workaround seems appropriate. 

Reviewed by @benharsh  - thanks!

TESTING:
- [x] Paratest. some failures on this branch are fixed on main, but nothing
   otherwise.

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>