### PR TITLE
Adjust the Python 3.5 job to behave more like the Python 2.7 job

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -69,6 +69,7 @@ $junit_xml = 0;
 $mason_build = 0;
 $protobuf_build = 0;
 $python2 = 0;
+$pythonDep = 0;
 
 while (@ARGV) {
     $flag = shift @ARGV;
@@ -141,6 +142,8 @@ while (@ARGV) {
         $buildcheck = 0;
     } elsif ($flag eq "-python2") {
         $python2 = 1;
+    } elsif ($flag eq "-pythonDep") {
+        $pythonDep = 1;
     } elsif ($flag eq "-parnodefile") {
         $parnodefile = shift @ARGV;
     } elsif ($flag eq "-no-local") {
@@ -227,6 +230,7 @@ if ($printusage == 1) {
     print "\t-performance-description <...> : run performance tests with additional description\n";
     print "\t-protobuf                      : build the protobuf Chapel plugin before running tests\n";
     print "\t-python2                       : don't use features that needs python 3\n";
+    print "\t-pythonDep                     : don't use features that need newer python\n";
     print "\t-releasePerformance            : \$releasePerformance=1 ?\n";
    #print "\t-retaintree                    : \$retaintree=1 ?\n";
     print "\t-startdate <date>              : run performance tests providing a common start date to all the graphs\n";
@@ -522,8 +526,9 @@ $makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt compi
 print "Making $make_vars_opt third-party-try-opt\n";
 mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt third-party-try-opt", "make chapel third-party-try-opt", 1, 1);
 
-# if we are using python2, we cannot build the test-venv and/or chpldoc
-if ($python2 == 0) {
+# if we are using python2 or a deprecated version of python3, we cannot build
+# the test-venv and/or chpldoc
+if ($python2 == 0 && $pythonDep == 0) {
   # Build chpldoc. Do not fail the build if it does not succeed. Do not send
   # mail either.
   print "Making $make_vars_opt chpldoc\n";
@@ -738,10 +743,10 @@ if ($runtests == 0) {
         print "CHPL_TEST_NOMAIL: No $mailcommand\n";
     }
 
-} elsif ($python2 == 1) {
+} elsif ($python2 == 1 || $pythonDep == 1) {
 
-  # test system depends on python3, so with python2 we cannot do much other than
-  # `make check`
+  # test system depends on recent versions of python3, so with python2 or
+  # earlier versions of python3 we cannot do much other than `make check`
   $ENV{'CHPL_HOME'} = $chplhomedir;
 
   $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && CHPL_CHECK_DEBUG=1 make check";

--- a/util/cron/test-linux64-python35.bash
+++ b/util/cron/test-linux64-python35.bash
@@ -10,4 +10,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python35"
 
 set_python_version "3.5"
 
-$CWD/nightly -cron -hellos ${nightly_args}
+$CWD/nightly -cron -pythonDep ${nightly_args}


### PR DESCRIPTION
Adds a flag to nightly that can be used with jobs to test versions of Python 3
that are no longer supported by chpldoc and start_test.  This is separate from
the python2 flag, since Python 2 can have additional constraints.  Use this flag
with the job tracking Python 3.5.

This should avoid the sporadic failures we've been seeing when the job happens
to run with the version of Python it is supposed to.  Other changes will be
necessary to avoid running places where Python 3.5 doesn't exist and to ensure
that the correct version of Python is used, but I think this should get in
independently of those.

Tested the Python 3.5 job using the `-debug` flag

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>