### PR TITLE
Don't count the comms from end counts

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1302,7 +1302,9 @@ module ChapelBase {
   pragma "no remote memory fence"
   pragma "task spawn impl fn"
   proc _upEndCount(e: _EndCount, param countRunningTasks=true, numTasks) {
+    chpl_task_setSkipCommDiags(true);
     e.i.add(numTasks:int, memoryOrder.release);
+    chpl_task_setSkipCommDiags(false);
 
     if countRunningTasks {
       if numTasks > 1 {
@@ -1338,7 +1340,9 @@ module ChapelBase {
     chpl_save_task_error(e, err);
     chpl_comm_task_end();
     // inform anybody waiting that we're done
+    chpl_task_setSkipCommDiags(true);
     e.i.sub(1, memoryOrder.release);
+    chpl_task_setSkipCommDiags(false);
   }
 
   // This function is called once by the initiating task.  As above, no
@@ -1354,7 +1358,9 @@ module ChapelBase {
     here.runningTaskCntSub(1);
 
     // Wait for all tasks to finish
+    chpl_task_setSkipCommDiags(true);
     e.i.waitFor(0, memoryOrder.acquire);
+    chpl_task_setSkipCommDiags(false);
 
     if countRunningTasks {
       const taskDec = if isAtomic(e.taskCnt) then e.taskCnt.read() else e.taskCnt;
@@ -1376,7 +1382,9 @@ module ChapelBase {
   pragma "unchecked throws"
   proc _waitEndCount(e: _EndCount, param countRunningTasks=true, numTasks) throws {
     // Wait for all tasks to finish
+    chpl_task_setSkipCommDiags(true);
     e.i.waitFor(0, memoryOrder.acquire);
+    chpl_task_setSkipCommDiags(false);
 
     if countRunningTasks {
       if numTasks > 1 {

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -138,6 +138,8 @@ int chpl_comm_diags_is_enabled(void) {
   return (atomic_load_int_least16_t(&chpl_comm_diags_disable_flag) <= 0);
 }
 
+extern chpl_bool chpl_task_getSkipCommDiags(void);
+
 #define chpl_comm_diags_verbose_printf(is_unstable, format, ...)   \
   do {                                                             \
     if (chpl_verbose_comm                                          \
@@ -186,7 +188,8 @@ int chpl_comm_diags_is_enabled(void) {
 
 #define chpl_comm_diags_incr(_ctr)                                           \
   do {                                                                       \
-    if (chpl_comm_diagnostics && chpl_comm_diags_is_enabled()) {             \
+    if (chpl_comm_diagnostics && chpl_comm_diags_is_enabled() &&             \
+        !chpl_task_getSkipCommDiags()) {                                     \
       atomic_uint_least64_t* ctrAddr = &chpl_comm_diags_counters._ctr;       \
       (void) atomic_fetch_add_explicit_uint_least64_t(ctrAddr, 1,            \
                                                       memory_order_relaxed); \


### PR DESCRIPTION
EndCounts are used to track task completion. We effectively just use an
atomic int to count, and atomics are implemented differently depending
on `CHPL_NETWORK_ATOMICS`. This leads to different comm count output
(tracking fast-ons/ons vs. amos), which increases the cost of
maintaining comm count tests. We also already track the comm that's used
to initiate the remote tasks separately (as non-blocking ons) so it's
not like we're hiding that any comm is happening, we're just papering
over some of the implementation details. Here's the output before and
after for a no-op coforall+on:

```chpl
coforall loc in Locales do on loc {}
```

Processor atomics before:

| locale | execute_on_fast | execute_on_nb |
| -----: | --------------: | ------------: |
|      0 |               0 |             3 |
|      1 |               1 |             0 |
|      2 |               1 |             0 |
|      3 |               1 |             0 |

Network atomics before:

| locale |      amo | execute_on_nb |
| -----: | -------: | ------------: |
|      0 | unstable |             3 |
|      1 | unstable |             0 |
|      2 | unstable |             0 |
|      3 | unstable |             0 |

Network atomics before (`-scommDiagsPrintUnstable=true`):

| locale | amo | execute_on_nb |
| -----: | --: | ------------: |
|      0 |  61 |             3 |
|      1 |   1 |             0 |
|      2 |   1 |             0 |
|      3 |   1 |             0 |

All configs now:

| locale | execute_on_nb |
| -----: | ------------: |
|      0 |             3 |
|      1 |             0 |
|      2 |             0 |
|      3 |             0 |