### PR TITLE
Fix to ensure we support `writeln` when `CHPL_GPU_MEM_STRATEGY=array_on_device`

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2586,7 +2586,7 @@ static void codegenPartTwo() {
     // processes. In one process gCodegenGPU is true and we generate a .fatbin file,
     // in the other gCodegenGpu is false and we'll consume the fatbin file
     // and embed its contents into the generated code.
-    if (localeUsesGPU() && !gCodegenGPU) {
+    if (usingGpuLocaleModel() && !gCodegenGPU) {
       embedGpuCode();
     }
 
@@ -2714,7 +2714,7 @@ void codegen() {
 
   codegenPartOne();
 
-  if (localeUsesGPU()) {
+  if (usingGpuLocaleModel()) {
     // We use the temp dir to output a fatbin file and read it between the forked and main process.
     // We need to generate the name for the temp directory before we do the fork (since this
     // name uses the PID).

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -89,7 +89,7 @@ class BaseAST;
 bool        forceWidePtrsForLocal();
 bool        requireWideReferences();
 bool        requireOutlinedOn();
-bool        localeUsesGPU();
+bool        usingGpuLocaleModel();
 
 const char* cleanFilename(const BaseAST* ast);
 const char* cleanFilename(const char*    name);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1649,7 +1649,7 @@ void setupClang(GenInfo* info, std::string mainFile)
   DiagnosticsEngine* Diags = NULL;
   Diags = new DiagnosticsEngine(
       clangInfo->DiagID, &*clangInfo->diagOptions, clangInfo->DiagClient);
-  if (localeUsesGPU()) {
+  if (usingGpuLocaleModel()) {
     Diags->setSeverityForGroup(diag::Flavor::WarningOrError,
                                "unknown-cuda-version",
                                diag::Severity::Ignored);
@@ -1670,7 +1670,7 @@ void setupClang(GenInfo* info, std::string mainFile)
 
   clang::driver::Command* job = NULL;
 
-  if (localeUsesGPU() == false) {
+  if (usingGpuLocaleModel() == false) {
     // Not a CPU+GPU compilation, so just use first job.
     job = &*C->getJobs().begin();
   } else {
@@ -2541,7 +2541,7 @@ void runClang(const char* just_parse_filename) {
   }
 
   // tell clang to use CUDA support
-  if (localeUsesGPU()) {
+  if (usingGpuLocaleModel()) {
     // Need to pass this flag so atomics header will compile
     clangOtherArgs.push_back("--std=c++11");
     // Need to select CUDA mode in embedded clang to
@@ -2559,7 +2559,7 @@ void runClang(const char* just_parse_filename) {
   clangOtherArgs.push_back("sys_basic.h");
 
   if (!parseOnly) {
-    if (localeUsesGPU()) {
+    if (usingGpuLocaleModel()) {
       //create a header file to include header files from the command line
       std::string genHeaderFilename;
       genHeaderFilename = genIntermediateFilename("command-line-includes.h");

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1437,7 +1437,7 @@ static void setChapelEnvs() {
   CHPL_TARGET_BUNDLED_LINK_ARGS = envMap["CHPL_TARGET_BUNDLED_LINK_ARGS"];
   CHPL_TARGET_SYSTEM_LINK_ARGS = envMap["CHPL_TARGET_SYSTEM_LINK_ARGS"];
 
-  if (localeUsesGPU()) {
+  if (usingGpuLocaleModel()) {
     CHPL_CUDA_LIBDEVICE_PATH = envMap["CHPL_CUDA_LIBDEVICE_PATH"];
   }
 
@@ -1540,7 +1540,7 @@ static void setPrintCppLineno() {
 }
 
 static void setGPUFlags() {
-  bool isGpuCodegen = localeUsesGPU();
+  bool isGpuCodegen = usingGpuLocaleModel();
 
   if(isGpuCodegen) {
     if (!fNoChecks) {

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -814,7 +814,7 @@ void gpuTransforms() {
 
   // For now, we are doing GPU outlining here. In the future, it should
   // probably be its own pass.
-  if (localeUsesGPU()) {
+  if (usingGpuLocaleModel()) {
     if (fReportGpuTransformTime) gpuTransformTimer.start();
 
     outlineGPUKernels();

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -80,7 +80,20 @@ void setupError(const char* subdir, const char* filename, int lineno, int tag) {
   exit_eventually  |= tag == 3;
 }
 
+// Return true if the current locale model needs GPU code generation
+bool usingGpuLocaleModel() {
+  return 0 == strcmp(CHPL_LOCALE_MODEL, "gpu");
+}
+
 bool forceWidePtrsForLocal() {
+  // For the gpu (for now) we don't want wide pointers inside kernel
+  // functions (which we consider a locale block) but we still want
+  // to force wide pointers outside of the so we have `forceWidePtrs`
+  // return true but don't want it to kick in for local blocks
+  if(usingGpuLocaleModel()) {
+    return false;
+  }
+
   return fLocal && forceWidePtrs();
 }
 
@@ -96,11 +109,6 @@ bool requireWideReferences() {
 //
 bool requireOutlinedOn() {
   return requireWideReferences();
-}
-
-// Return true if the current locale model needs GPU code generation
-bool localeUsesGPU() {
-  return 0 == strcmp(CHPL_LOCALE_MODEL, "gpu");
 }
 
 const char* cleanFilename(const char* name) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -87,8 +87,8 @@ bool usingGpuLocaleModel() {
 
 bool forceWidePtrsForLocal() {
   // For the gpu (for now) we don't want wide pointers inside kernel
-  // functions (which we consider a locale block) but we still want
-  // to force wide pointers outside of the so we have `forceWidePtrs`
+  // functions (which we consider a local block) but we still want
+  // to force wide pointers outside of there so we have `forceWidePtrs`
   // return true but don't want it to kick in for local blocks
   if(usingGpuLocaleModel()) {
     return false;

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -263,6 +263,7 @@ void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
 }
 
 void* chpl_gpu_impl_memmove(void* dst, const void* src, size_t n) {
+  #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
   bool dst_on_host = chpl_gpu_impl_is_host_ptr(dst);
   bool src_on_host = chpl_gpu_impl_is_host_ptr(src);
 
@@ -282,6 +283,12 @@ void* chpl_gpu_impl_memmove(void* dst, const void* src, size_t n) {
     assert(dst_on_host && src_on_host);
     return memmove(dst, src, n);
   }
+  #else
+
+  // for unified memory strategy we don't want to generate calls to copy
+  // data from the device to host (since it can just be acessed directly)
+  return memmove(dst, src, n);
+  #endif
 }
 
 void chpl_gpu_impl_copy_device_to_host(void* dst, const void* src, size_t n) {

--- a/test/gpu/native/page-locked-mem/jacobi.chpl
+++ b/test/gpu/native/page-locked-mem/jacobi.chpl
@@ -36,16 +36,8 @@ proc jacobi(loc) {
       forall i in 1..n { B[i] = 0.33333 * (A[i-1] + A[i] + A[i+1]); }
       forall i in 1..n { A[i] = 0.33333 * (B[i-1] + B[i] + B[i+1]); }
     }
-    // Can't do this either
-    //writeln(A);
-
-    printHelp(A);
+    
+    writeln(A);
   }
 }
 
-proc printHelp(A) {
-  on Locales[0] {
-    var ALocal = A;
-    writeln(ALocal);
-  }
-}


### PR DESCRIPTION
For the GPU locale model we don't want wide pointers inside kernel functions (which we consider a local block) but we still want to force wide pointers outside of it.

Implementing this just involved special casing the GPU locale model in `forceWidePtrsForLocal()` in `util/misc.cpp`.

This will ensure that when using the `array_on_device` strategy with a program like the following `A` will be a wide pointer so that we perform the `get` that's necessary to copy the data for A from the GPU to the host for the `write`:

```chpl
on here.gpus[0] {
  var A : [0..10] int;
  writeln(A);  // Previously this would crash when
               // GPU_MEM_STRATEGY=array_on_device
}
```

Long term we'll want to update insert wide references pass to be cognizant of the GPU locale model but that's going to be a bit of a project.

In an unrelated refactoring change I renamed `localeUsesGPU` to `usingGpuLocaleModel`.

@benharsh Could you do a quick review of my changes to `misc.cpp` (specializing `forceWidePtrsForLocal` for GPU locale model).

@daviditen Could you do a review of the other changes?

Thanks!