### PR TITLE
Set defaultGpuArrayInitMethod automatically

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -820,7 +820,9 @@ module ChapelBase {
   //
   enum ArrayInit {heuristicInit, noInit, serialInit, parallelInit, gpuInit};
   config param chpl_defaultArrayInitMethod = ArrayInit.heuristicInit;
-  config param chpl_defaultGpuArrayInitMethod = chpl_defaultArrayInitMethod;
+  config param chpl_defaultGpuArrayInitMethod =
+    if CHPL_GPU_MEM_STRATEGY == "array_on_device" then
+      ArrayInit.gpuInit else chpl_defaultArrayInitMethod;
 
   config param chpl_arrayInitMethodRuntimeSelectable = false;
   private var chpl_arrayInitMethod = chpl_defaultArrayInitMethod;

--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -147,4 +147,8 @@ module ChplConfig {
   /* See :ref:`readme-chplenv.CHPL_LLVM` for more information. */
   param CHPL_LLVM:string;
   CHPL_LLVM = __primitive("get compiler variable", "CHPL_LLVM");
+
+  pragma "no doc"
+  param CHPL_GPU_MEM_STRATEGY:string;
+  CHPL_GPU_MEM_STRATEGY = __primitive("get compiler variable", "CHPL_GPU_MEM_STRATEGY");
 }

--- a/test/gpu/native/page-locked-mem/COMPOPTS
+++ b/test/gpu/native/page-locked-mem/COMPOPTS
@@ -1,1 +1,0 @@
--schpl_defaultGpuArrayInitMethod=ArrayInit.gpuInit


### PR DESCRIPTION
Based on value of CHPL_GPU_MEM_STRATEGY (previously if using the array_on_device strategy you would need to explicitly pass -schpl_defaultGpuArrayInitMethod=ArrayInit.gpuInit to chpl).

This PR changes this so that CHPL_GPU_MEM_STRATEGY is accessible from the `ChplConfig` module. We can then later look at this value to determine what `chpl_defaultGpuArrayInitMethod` should be set to by default.

I no doc'd this inclusion of CHPL_GPU_MEM_STRATEGY in the `ChplConfig` module as I think we might move away from having this set by environment variable sometime in the future so I'd rather users not have access to it in the meantime.
