### PR TITLE
dyno: fix function resolution for dependent formals

### DIFF
--- a/compiler/dyno/test/common.cpp
+++ b/compiler/dyno/test/common.cpp
@@ -22,10 +22,9 @@
 
 using namespace parsing;
 
-const Module* parseModule(Context* context, const char* src) {
+const Module* parseModule(Context* context, std::string src) {
   auto path = UniqueString::get(context, "input.chpl");
-  std::string contents = src;
-  setFileText(context, path, contents);
+  setFileText(context, path, std::move(src));
 
   const ModuleVec& vec = parseToplevel(context, path);
   assert(vec.size() == 1);
@@ -33,13 +32,9 @@ const Module* parseModule(Context* context, const char* src) {
   return vec[0];
 }
 
-const Module* parseModule(Context* context, std::string& str) {
-  return parseModule(context, str.c_str());
-}
-
 QualifiedType
-resolveTypeOfXInit(Context* context, const char* program, bool requireTypeKnown) {
-  auto m = parseModule(context, program);
+resolveTypeOfXInit(Context* context, std::string program, bool requireTypeKnown) {
+  auto m = parseModule(context, std::move(program));
   assert(m->numStmts() > 0);
   const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
   assert(x);
@@ -56,8 +51,8 @@ resolveTypeOfXInit(Context* context, const char* program, bool requireTypeKnown)
 }
 
 QualifiedType
-resolveQualifiedTypeOfX(Context* context, const char* program) {
-  auto m = parseModule(context, program);
+resolveQualifiedTypeOfX(Context* context, std::string program) {
+  auto m = parseModule(context, std::move(program));
   assert(m->numStmts() > 0);
   const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
   assert(x);
@@ -72,8 +67,8 @@ resolveQualifiedTypeOfX(Context* context, const char* program) {
 }
 
 const Type*
-resolveTypeOfX(Context* context, const char* program) {
-  auto m = parseModule(context, program);
+resolveTypeOfX(Context* context, std::string program) {
+  auto m = parseModule(context, std::move(program));
   assert(m->numStmts() > 0);
   const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
   assert(x);

--- a/compiler/dyno/test/common.h
+++ b/compiler/dyno/test/common.h
@@ -28,20 +28,19 @@ using namespace types;
 using namespace uast;
 
 // Get the top-level module resulting from parsing the given string.
-const Module* parseModule(Context* context, const char* src);
-const Module* parseModule(Context* context, std::string& str);
+const Module* parseModule(Context* context, std::string src);
 
 // assumes the last statement is a variable declaration for x
 // with an initialization expression.
 // Returns the type of the initializer expression.
 QualifiedType
-resolveTypeOfXInit(Context* context, const char* program, bool requireTypeKnown = true);
+resolveTypeOfXInit(Context* context, std::string program, bool requireTypeKnown = true);
 
 QualifiedType
-resolveQualifiedTypeOfX(Context* context, const char* program);
+resolveQualifiedTypeOfX(Context* context, std::string program);
 
 const Type*
-resolveTypeOfX(Context* context, const char* program);
+resolveTypeOfX(Context* context, std::string program);
 
 // always check assertions in this test
 #ifdef NDEBUG


### PR DESCRIPTION
This PR ensures that Dyno rejects more calls to functions in which types of
later formals depend on the types / values of earlier ones. The canonical
example of the issue present on main is the following:

```Chapel
proc f(param a: bool, param b: if a then string else int) {}
f(true, "hello"); // passes
f(false, 0) // passes
f(true, 0) // also passes, but shouldn't!
```

The issue is that Dyno first computes an initial function signature without
knowing the types of the actuals, which in the case of `f` above is:

```Chapel
proc f(param a: bool, param b: UnknownType) {}
```

We allow formals of `UnknownType` to accept any actuals, so this initial
signature allows for all of the three calls in the example above. We eventually
compute an instantiated function signature, which does have `b: string` or
`b: int` depending on `a`, but we never check the actuals again!

This PR starts to address this issue. In particular, it modifies
`instantiateSignature` to incrementally re-resolve its formals. This means
that substitutions introduced by preceding formal-actual matches are
incorporated. In the `f` example above, `f(true, ...)` will incorporate the
fact that `a` has been instantiated with `= true`, and so the type of `b` will
be determined to be `string`. Thus, the third call above will be rejected.

Note that there is a complicated interaction with type queries in this
situation, which this PR is __not__ aiming to address. This is discussed
in https://github.com/Cray/chapel-private/issues/3774. In particular, the
following examples do not work:

```Chapel
proc g(a: int(?w), b: int(__primitive("*", 2, w))) { return b; }
proc h(a: someRecord(?w), b: someRecord(w)) { return b; }
```

Reviewed by @benharsh - thanks!

TESTING
- [x] Paratest (rebased onto main, since there were some failures at the time
   I branched).