### PR TITLE
Add checking of the MASON_OFFLINE flag before attempting install

### DIFF
--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -273,7 +273,7 @@ proc genSourceList(lockFile: borrowed Toml) {
 
 /* Clones the git repository of each dependency into
    the src code dependency pool */
-proc getSrcCode(sourceListArg: list(3*string), skipUpdate, show) {
+proc getSrcCode(sourceListArg: list(3*string), skipUpdate, show) throws {
 
   //
   // TODO: Temporarily use `toArray` here because `list` does not yet

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -92,7 +92,7 @@ proc masonBuild(args: [] string, checkProj=true) throws {
     const configNames = updateLock(skipUpdate);
     const tomlName = configNames[0];
     const lockName = configNames[1];
-    buildProgram(release, show, force, compopts, tomlName, lockName);
+    buildProgram(release, show, force, skipUpdate, compopts, tomlName, lockName);
   }
 }
 
@@ -106,8 +106,9 @@ private proc checkChplVersion(lockFile : borrowed Toml) throws {
 }
 
 
-proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: list(string),
-                  tomlName="Mason.toml", lockName="Mason.lock") throws {
+proc buildProgram(release: bool, show: bool, force: bool, skipUpdate: bool,
+                  ref cmdLineCompopts: list(string), tomlName="Mason.toml",
+                  lockName="Mason.lock") throws {
 
   try! {
 
@@ -147,7 +148,7 @@ proc buildProgram(release: bool, show: bool, force: bool, ref cmdLineCompopts: l
         // support parallel iteration, which the `getSrcCode` method _must_
         // have for good performance.
         //
-        getSrcCode(sourceList, show);
+        getSrcCode(sourceList, skipUpdate, show);
 
         getGitCode(gitList, show);
 
@@ -272,7 +273,7 @@ proc genSourceList(lockFile: borrowed Toml) {
 
 /* Clones the git repository of each dependency into
    the src code dependency pool */
-proc getSrcCode(sourceListArg: list(3*string), show) {
+proc getSrcCode(sourceListArg: list(3*string), skipUpdate, show) {
 
   //
   // TODO: Temporarily use `toArray` here because `list` does not yet
@@ -288,6 +289,8 @@ proc getSrcCode(sourceListArg: list(3*string), show) {
       const nameVers = name + "-" + version;
       const destination = baseDir + nameVers;
       if !depExists(nameVers) {
+        if skipUpdate then
+          throw new owned MasonError("Dependency cannot be installed when MASON_OFFLINE is set.");
         writeln("Downloading dependency: " + nameVers);
         var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
         var checkout = "git checkout -q v" + version;

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -75,11 +75,11 @@ proc masonExample(args: [] string, checkProj=true) throws {
   }
   var examples = new list(exampleOpts.values());
   updateLock(skipUpdate);
-  runExamples(show, run, build, release, force, examples);
+  runExamples(show, run, build, release, skipUpdate, force, examples);
 }
 
 
-private proc getBuildInfo(projectHome: string) {
+private proc getBuildInfo(projectHome: string, skipUpdate: bool) {
 
   // parse lock and toml(examples dont make it to lock file)
   const lock = open(projectHome + "/Mason.lock", iomode.r);
@@ -95,7 +95,7 @@ private proc getBuildInfo(projectHome: string) {
   // support parallel iteration, which the `getSrcCode` method _must_
   // have for good performance.
   //
-  getSrcCode(sourceList, false);
+  getSrcCode(sourceList, skipUpdate, false);
   getGitCode(gitList, false);
   const project = lockFile["root"]!["name"]!.s;
   const projectPath = "".join(projectHome, "/src/", project, ".chpl");
@@ -185,7 +185,7 @@ private proc determineExamples(exampleNames: list(string),
 
 
 private proc runExamples(show: bool, run: bool, build: bool, release: bool,
-                         force: bool, examplesRequested: list(string)) throws {
+                         skipUpdate: bool, force: bool, examplesRequested: list(string)) throws {
 
   try! {
 
@@ -194,7 +194,7 @@ private proc runExamples(show: bool, run: bool, build: bool, release: bool,
 
     // Get buildInfo: dependencies, path to src code, compopts,
     // names of examples, example compopts
-    var buildInfo = getBuildInfo(projectHome);
+    var buildInfo = getBuildInfo(projectHome, skipUpdate);
     const sourceList = buildInfo[0];
     const gitList = buildInfo[1];
     const projectPath = buildInfo[2];

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -67,7 +67,7 @@ proc masonModules(args: [] string) throws {
 
   // generate list of dependencies and get src code
   var (sourceList, gitList) = genSourceList(lockFile);
-  getSrcCode(sourceList, false);
+  getSrcCode(sourceList, skipUpdate, false);
   getGitCode(gitList, false);
 
   const depPath = MASON_HOME + '/src/';

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -178,7 +178,7 @@ proc masonTest(args: [] string, checkProj=true) throws {
 
     updateLock(skipUpdate);
     compopts.append("".join("--comm=",comm));
-    runTests(show, run, parallel, compopts);
+    runTests(show, run, parallel, skipUpdate, compopts);
   }
   catch e: MasonError {
     try! {
@@ -207,7 +207,8 @@ proc masonTest(args: [] string, checkProj=true) throws {
   }
 }
 
-private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts: list(string)) throws {
+private proc runTests(show: bool, run: bool, parallel: bool,
+                      skipUpdate: bool, ref cmdLineCompopts: list(string)) throws {
 
   try! {
 
@@ -221,7 +222,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
     // Get project source code and dependencies
     const (sourceList, gitList) = genSourceList(lockFile);
 
-    getSrcCode(sourceList, show);
+    getSrcCode(sourceList, skipUpdate, show);
     getGitCode(gitList, show);
 
     const project = lockFile["root"]!["name"]!.s;


### PR DESCRIPTION
This PR adds a check to make sure that we aren't in offline
mode before attempting to install dependencies from GitHub. This
means that the dependency will either already have to be in the
registry and installed at `MASON_HOME` in order to be used in
`MASON_OFFLINE` mode. This seems to have been overlooked and
should have always been the case, since we don't want to try to
access the internet when we are offline.