### PR TITLE
Mark `locale.numPUs` as unstable

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -265,6 +265,7 @@ module ChapelLocale {
     running programs within Cray batch jobs that have been set up
     with limited processor resources.
   */
+  @unstable "'locale.numPUs' is unstable"
   inline proc locale.numPUs(logical: bool = false, accessible: bool = true): int {
     return this._value.numPUs(logical, accessible);
   }

--- a/test/unstable/locale-numPUs.chpl
+++ b/test/unstable/locale-numPUs.chpl
@@ -1,0 +1,1 @@
+const npu = here.numPUs();

--- a/test/unstable/locale-numPUs.good
+++ b/test/unstable/locale-numPUs.good
@@ -1,0 +1,1 @@
+locale-numPUs.chpl:1: warning: 'locale.numPUs' is unstable


### PR DESCRIPTION
In the discussion here: https://github.com/chapel-lang/chapel/issues/20445, and a recent re-reveiew, we decided to mark `locale.numPUs` as unstable.

This PR:
* Adds the unstable flag to the method
* Adds an instability test

- [x] Paratest passing