### PR TITLE
Do not initialize fabric domain when there is only one locale

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1045,7 +1045,9 @@ void chpl_comm_post_mem_init(void) {
     causes fi_domain to be called before the worker threads are
     created, avoiding the issue.
   */
-  init_ofiFabricDomain();
+  if (chpl_numNodes > 1) {
+    init_ofiFabricDomain();
+  }
 }
 
 


### PR DESCRIPTION
The libfabric comm layer is only partially initialized when there is only one locale to avoid unnecessary overheads. In this situation we should not initialize the fabric domain because doing so depends on other parts of the libfabric layer that have not been initialized.

Passes all multi-locale tests on an EX except for the following failures which appear to be unrelated.
```
[Error matching program output for library/packages/Collection/CollectionCounter (compopts: 2)]
[Error: Timed out executing program library/packages/Collection/CollectionNQueens (compopts: 1)]
[Error matching program output for parallel/forall/task-private-vars/count-tpvs]
```



Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>