### PR TITLE
Set python version and display what we use and where it lives for CS testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -48,6 +48,11 @@ if [ -f "$SETUP_PYTHON" ]; then
   source $SETUP_PYTHON
 fi
 
+echo "Location of Python3"
+which python3
+echo "Python3 version"
+python3 --version
+
 # test against Chapel release (checking our current test/cron directories)
 function test_release() {
   export CHPL_TEST_PERF_DESCRIPTION=release

--- a/util/cron/common-perf-cray-cs-hdr.bash
+++ b/util/cron/common-perf-cray-cs-hdr.bash
@@ -5,6 +5,21 @@
 export CHPL_LAUNCHER_PARTITION=clx24
 export CHPL_TARGET_CPU=none
 
+COMMON_DIR=/cray/css/users/chapelu
+if [ ! -d "$COMMON_DIR" ]; then
+  COMMON_DIR=/cy/users/chapelu
+fi
+
+SETUP_PYTHON=$COMMON_DIR/setup_python_nightly.bash
+if [ -f "$SETUP_PYTHON" ]; then
+  source $SETUP_PYTHON
+fi
+
+echo "Location of Python3"
+which python3
+echo "Python3 version"
+python3 --version
+
 # the lengths we go to, to avoid line wrap ...
 pcca=(-performance-configs gn-ibv-large:v,gn-ibv-fast:v,gn-mpi,ofi \
       -performance \


### PR DESCRIPTION
- Our CS hdr jobs were using the default version of Python 3 but that will no
longer be helpful.  Set them to use a nightly version, determined by the .bash
file they will call
- Update both them and the arkouda jobs so that they print which version of Python
3 is being used and where it lives.  This will help know how to update them in
the future.

Double checked that the changes work okay when sourced locally