### PR TITLE
Introduce unstable read/match/write methods for literals and newlines

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3923,6 +3923,23 @@ proc channel.writeIt(const x) throws {
     this.readIt(iolit);
   }
 
+  /*
+    Advances the position of a channel by reading the exact text of the given
+    string ``literal`` from the channel.
+
+    If the string is not matched exactly, then the channel's position is
+    unchanged. In such cases a :class:`OS.BadFormatError` will be thrown, unless the end of
+    the channel is encountered in which case an :class:`OS.EofError` will be thrown. By
+    default this method will ignore leading whitespace when attempting to read
+    a literal.
+
+    :arg literal: the string to be matched.
+    :arg ignoreWhitespace: determines whether leading whitespace is ignored.
+
+    :throws BadFormatError: Thrown if literal could not be matched.
+    :throws EofError: Thrown if end of channel is encountered.
+
+  */
   @unstable "channel.readLiteral is unstable and subject to change."
   inline
   proc channel.readLiteral(literal:string,
@@ -3930,6 +3947,23 @@ proc channel.writeIt(const x) throws {
     _readLiteralCommon(literal, ignoreWhitespace, isMatch=false);
   }
 
+  /*
+    Advances the position of a channel by reading the exact bytes of the given
+    ``literal`` from the channel.
+
+    If the bytes are not matched exactly, then the channel's position is
+    unchanged. In such cases a :class:`OS.BadFormatError` will be thrown, unless the end of
+    the channel is encountered in which case an :class:`OS.EofError` will be thrown. By
+    default this method will ignore leading whitespace when attempting to read
+    a literal.
+
+    :arg literal: the bytes to be matched.
+    :arg ignoreWhitespace: determines whether leading whitespace is ignored.
+
+    :throws BadFormatError: Thrown if literal could not be matched.
+    :throws EofError: Thrown if end of channel is encountered.
+
+  */
   @unstable "channel.readLiteral is unstable and subject to change."
   inline
   proc channel.readLiteral(literal:bytes,
@@ -3968,6 +4002,19 @@ proc channel.writeIt(const x) throws {
   }
 
   // TODO: How does this differ from readln() ?
+  /*
+    Advances the position of the channel by reading a newline.
+
+    If a newline is not matched exactly, then the channel's position is
+    unchanged. In such cases a :class:`OS.BadFormatError` will be thrown, unless the end of
+    the channel is encountered in which case an :class:`OS.EofError` will be thrown. By
+    default this method will ignore leading whitespace when attempting to read
+    a newline.
+
+    :throws BadFormatError: Thrown if a newline could not be matched.
+    :throws EofError: Thrown if end of channel is encountered.
+
+  */
   @unstable "channel.readNewline is unstable and subject to change."
   inline
   proc channel.readNewline() : void throws {
@@ -3988,6 +4035,24 @@ proc channel.writeIt(const x) throws {
     return true;
   }
 
+  /*
+    Advances the position of a channel by reading the exact text of the given
+    string ``literal`` from the channel.
+
+    If the string is not matched exactly, then the channel's position is
+    unchanged and this method will return ``false``. In other words, this
+    channel will return ``false`` in the cases where :proc:`channel.readLiteral`
+    would throw a :class:`OS.BadFormatError` or an :class:`OS.EofError`.
+
+    By default this method will ignore leading whitespace when attempting to
+    read a literal.
+
+    :arg literal: the string to be matched.
+    :arg ignoreWhitespace: determines whether leading whitespace is ignored.
+
+    :returns: ``true`` if the read succeeded, and ``false`` on end of file or if
+      the literal could not be matched.
+  */
   @unstable "channel.matchLiteral is unstable and subject to change."
   inline
   proc channel.matchLiteral(literal:string,
@@ -3995,6 +4060,24 @@ proc channel.writeIt(const x) throws {
     return _matchLiteralCommon(literal, ignoreWhitespace);
   }
 
+  /*
+    Advances the position of a channel by reading the exact bytes of the given
+    ``literal`` from the channel.
+
+    If the bytes are not matched exactly, then the channel's position is
+    unchanged and this method will return ``false``. In other words, this
+    channel will return ``false`` in the cases where :proc:`channel.readLiteral`
+    would throw a :class:`OS.BadFormatError` or an :class:`OS.EofError`.
+
+    By default this method will ignore leading whitespace when attempting to
+    read a literal.
+
+    :arg literal: the bytes to be matched.
+    :arg ignoreWhitespace: determines whether leading whitespace is ignored.
+
+    :returns: ``true`` if the read succeeded, and ``false`` on end of file or if
+      the literal could not be matched.
+  */
   @unstable "channel.matchLiteral is unstable and subject to change."
   inline
   proc channel.matchLiteral(literal:bytes,
@@ -4002,6 +4085,20 @@ proc channel.writeIt(const x) throws {
     return _matchLiteralCommon(literal, ignoreWhitespace);
   }
 
+  /*
+    Advances the position of the channel by reading a newline.
+
+    If a newline is not matched exactly, then the channel's position is
+    unchanged and this method will return ``false``. In other words, this
+    channel will return ``false`` in the cases where :proc:`channel.readNewline`
+    would throw a :class:`OS.BadFormatError` or an :class:`OS.EofError`.
+
+    By default this method will ignore leading whitespace when attempting to
+    read a newline.
+
+    :returns: ``true`` if the read succeeded, and ``false`` on end of file or if
+      the newline could not be matched.
+  */
   @unstable "channel.matchNewline is unstable and subject to change."
   inline
   proc channel.matchNewline() : bool throws {
@@ -4040,12 +4137,20 @@ proc channel.writeIt(const x) throws {
     this.writeIt(iolit);
   }
 
+  /*
+    Writes a string to the channel, ignoring any formatting configured for
+    this channel.
+  */
   @unstable "channel.writeLiteral is unstable and subject to change."
   inline
   proc channel.writeLiteral(literal:string) : void throws {
     _writeLiteralCommon(literal);
   }
 
+  /*
+    Writes bytes to the channel, ignoring any formatting configured for this
+    channel.
+  */
   @unstable "channel.writeLiteral is unstable and subject to change."
   inline
   proc channel.writeLiteral(literal:bytes) : void throws {
@@ -4053,6 +4158,10 @@ proc channel.writeIt(const x) throws {
   }
 
   // TODO: How does this differ from writeln() ?
+  /*
+    Writes a newline to the channel, ignoring any formatting configured for
+    this channel.
+  */
   @unstable "channel.writeNewline is unstable and subject to change."
   inline
   proc channel.writeNewline() : void throws {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3546,6 +3546,12 @@ proc channel._readOne(param kind: iokind, ref x:?t,
   }
 }
 
+private proc escapedNonUTF8ErrorMessage() : string {
+  const ret = "Strings with escaped non-UTF8 bytes cannot be used with I/O. " +
+        "Try using string.encode(encodePolicy.unescape) first.\n";
+  return ret;
+}
+
 //
 // The channel must be locked and running on this.home.
 //
@@ -3557,8 +3563,8 @@ proc channel._writeOne(param kind: iokind, const x:?t, loc:locale) throws {
   if err != ENOERR {
     var msg = _constructIoErrorMsg(kind, x);
     if err == EILSEQ {
-      msg = "Strings with escaped non-UTF8 bytes cannot be used with I/O. " +
-            "Try using string.encode(encodePolicy.unescape) first." + msg;
+      // TODO: Is this error tested?
+      msg = escapedNonUTF8ErrorMessage() + msg;
     }
     try _ch_ioerror(err, msg);
   }
@@ -3854,31 +3860,209 @@ proc channel.writeIt(const x) throws {
   }
 
   pragma "no doc"
+  inline proc channel._checkLiteralError(x:?t, err:errorCode,
+                                         action:string,
+                                         isLiteral:bool) : void throws {
+    // Error message construction is handled here so that messages are
+    // consistent across the cross product of:
+    //   {read,write,match} x {literal,newline} x {string, bytes}
+    //
+    // Note that newlines do not involve strings or bytes
+
+    if err != ENOERR {
+      var msg: string = "while " + action + " ";
+
+      if isLiteral {
+        if t == string then
+          msg += "string literal \"" + x + "\"";
+        else
+          msg += "bytes literal";
+      } else {
+        msg += "newline";
+      }
+
+      if err == EILSEQ {
+        // TODO: Is this error tested?
+        msg = escapedNonUTF8ErrorMessage() + "Error: " + msg;
+      }
+
+      try _ch_ioerror(err, msg);
+    }
+  }
+
+  pragma "no doc"
+  inline proc channel._readLiteralCommon(x:?t, ignore:bool,
+                                         param isMatch:bool) throws {
+    if t != string && t != bytes then
+      compilerError("expecting string or bytes");
+
+    if writing {
+      param name = if isMatch then "matchLiteral" else "readLiteral";
+      param depth = if isMatch then 3 else 2;
+      compilerError(name + " on write-only channel", depth);
+    }
+
+    on this.home {
+      try! this.lock(); defer { this.unlock(); }
+      const cstr = x.localize().c_str();
+      const err = qio_channel_scan_literal(false, _channel_internal,
+                                           cstr, x.numBytes:c_ssize_t,
+                                           ignore);
+
+      const action = if isMatch then "matching" else "reading";
+      try _checkLiteralError(x, err, action, isLiteral=true);
+    }
+  }
+
+  // non-unstable version we can use internally
+  pragma "no doc"
   inline
-  proc channel._readLiteral(lit:string, ignoreWhitespace=true) throws {
-    var iolit = new ioLiteral(lit, ignoreWhitespace);
+  proc channel._readLiteral(literal:string,
+                            ignoreWhitespace=true) : void throws {
+    var iolit = new ioLiteral(literal, ignoreWhitespace);
     this.readIt(iolit);
   }
 
-  pragma "no doc"
+  @unstable "channel.readLiteral is unstable and subject to change."
   inline
-  proc channel._writeLiteral(lit:string) throws {
-    var iolit = new ioLiteral(lit);
-    this.writeIt(iolit);
+  proc channel.readLiteral(literal:string,
+                           ignoreWhitespace=true) : void throws {
+    _readLiteralCommon(literal, ignoreWhitespace, isMatch=false);
   }
 
+  @unstable "channel.readLiteral is unstable and subject to change."
+  inline
+  proc channel.readLiteral(literal:bytes,
+                           ignoreWhitespace=true) : void throws {
+    _readLiteralCommon(literal, ignoreWhitespace, isMatch=false);
+  }
+
+  // TODO: Don't we need an option to ignore whitespace or not?
+  // Note: We don't want to allow skipping over non-whitespace.
+  //
+  // Note: We can add an 'ignoreWhitespace' optional argument that defaults
+  // to 'true' without changing behavior in existing programs.
   pragma "no doc"
   inline
-  proc channel._readNewline() throws {
+  proc channel._readNewlineCommon(param isMatch:bool) throws {
+    if writing {
+      param name = if isMatch then "matchNewline" else "readNewline";
+      compilerError(name + " on write-only channel", 2);
+    }
+
+    on this.home {
+      try! this.lock(); defer { this.unlock(); }
+      const err = qio_channel_skip_past_newline(false, _channel_internal,
+                                                /*skipWhitespaceOnly=*/ true);
+
+      const action = if isMatch then "matching" else "reading";
+      try _checkLiteralError("", err, action, isLiteral=false);
+    }
+  }
+
+  // non-unstable version we can use internally
+  pragma "no doc"
+  inline proc channel._readNewline() : void throws {
     var ionl = new ioNewline(true);
     this.readIt(ionl);
   }
 
+  // TODO: How does this differ from readln() ?
+  @unstable "channel.readNewline is unstable and subject to change."
+  inline
+  proc channel.readNewline() : void throws {
+    _readNewlineCommon(isMatch=false);
+  }
+
   pragma "no doc"
   inline
-  proc channel._writeNewline() throws {
-    var ionl = new ioNewline(true);
-    this.writeIt(ionl);
+  proc channel._matchLiteralCommon(literal, ignore : bool) : bool throws {
+    try {
+      _readLiteralCommon(literal, ignore, isMatch=true);
+    } catch e : BadFormatError {
+      return false;
+    } catch e : EofError {
+      return false;
+    }
+
+    return true;
+  }
+
+  @unstable "channel.matchLiteral is unstable and subject to change."
+  inline
+  proc channel.matchLiteral(literal:string,
+                            ignoreWhitespace=true) : bool throws {
+    return _matchLiteralCommon(literal, ignoreWhitespace);
+  }
+
+  @unstable "channel.matchLiteral is unstable and subject to change."
+  inline
+  proc channel.matchLiteral(literal:bytes,
+                            ignoreWhitespace=true) : bool throws {
+    return _matchLiteralCommon(literal, ignoreWhitespace);
+  }
+
+  @unstable "channel.matchNewline is unstable and subject to change."
+  inline
+  proc channel.matchNewline() : bool throws {
+    try {
+      _readNewlineCommon(isMatch=true);
+    } catch e : BadFormatError {
+      return false;
+    } catch e : EofError {
+      return false;
+    }
+
+    return true;
+  }
+
+  pragma "no doc"
+  inline
+  proc channel._writeLiteralCommon(x:?t) : void throws {
+    if t != string && t != bytes then
+      compilerError("expecting string or bytes");
+
+    if !writing then compilerError("writeLiteral on read-only channel", 2);
+
+    on this.home {
+      try! this.lock(); defer { this.unlock(); }
+      const cstr = x.localize().c_str();
+      const err = qio_channel_print_literal(false, _channel_internal, cstr,
+                                            x.numBytes:c_ssize_t);
+      try _checkLiteralError(x, err, "writing", isLiteral=true);
+    }
+  }
+
+  pragma "no doc"
+  inline
+  proc channel._writeLiteral(literal:string) : void throws {
+    var iolit = new ioLiteral(literal);
+    this.writeIt(iolit);
+  }
+
+  @unstable "channel.writeLiteral is unstable and subject to change."
+  inline
+  proc channel.writeLiteral(literal:string) : void throws {
+    _writeLiteralCommon(literal);
+  }
+
+  @unstable "channel.writeLiteral is unstable and subject to change."
+  inline
+  proc channel.writeLiteral(literal:bytes) : void throws {
+    _writeLiteralCommon(literal);
+  }
+
+  // TODO: How does this differ from writeln() ?
+  @unstable "channel.writeNewline is unstable and subject to change."
+  inline
+  proc channel.writeNewline() : void throws {
+    if !writing then compilerError("writeNewline on read-only channel");
+
+    on this.home {
+      try! this.lock(); defer { this.unlock(); }
+      const err = qio_channel_write_newline(false, _channel_internal);
+      try _checkLiteralError("", err, "writing", isLiteral=false);
+    }
   }
 
   /* Explicit call for reading or writing a newline as an

--- a/test/io/ferguson/readThis/readclass.chpl
+++ b/test/io/ferguson/readThis/readclass.chpl
@@ -17,13 +17,13 @@ class subthing : mything {
 
   override proc readThis(r) throws {
     x = r.read(int);
-    r._readLiteral(",");
+    r.readLiteral(",");
     y = r.read(int);
   }
 
   override proc writeThis(w) throws {
     w.write(x);
-    w._writeLiteral(",");
+    w.writeLiteral(",");
     w.write(y);
   }
 }

--- a/test/io/ferguson/readThis/readclass2.chpl
+++ b/test/io/ferguson/readThis/readclass2.chpl
@@ -6,13 +6,13 @@ class mything {
 
   proc readThis(r) throws {
     x = r.read(int);
-    r._readLiteral(" ");
+    r.readLiteral(" ");
     y = r.read(int);
   }
 
   proc writeThis(w) throws {
     w.write(x);
-    w._writeLiteral(" ");
+    w.writeLiteral(" ");
     w.write(y);
   }
 }

--- a/test/io/ferguson/readThis/readclass3.chpl
+++ b/test/io/ferguson/readThis/readclass3.chpl
@@ -6,13 +6,13 @@ class mything {
 
   proc readThis(r) throws {
     x = r.read(int);
-    r._readLiteral(" ");
+    r.readLiteral(" ");
     y = r.read(int);
   }
 
   proc writeThis(w) throws {
     w.write(x);
-    w._writeLiteral(" ");
+    w.writeLiteral(" ");
     w.write(y);
   }
 

--- a/test/io/ferguson/recordeof.chpl
+++ b/test/io/ferguson/recordeof.chpl
@@ -21,7 +21,7 @@ proc MyRecord.writeThis(f) throws {
 
 proc MyRecord.readWriteHelper(f) throws {
   if f.writing then f.write(i); else i = f.read(int);
-  if f.writing then f._writeLiteral("\n"); else f._readLiteral("\n");
+  if f.writing then f.writeNewline(); else f.readNewline();
 }
 
 {

--- a/test/io/literals/match-literal.chpl
+++ b/test/io/literals/match-literal.chpl
@@ -1,0 +1,185 @@
+
+use IO;
+use OS;
+
+//
+// Test cases:
+// - successfully read a literal
+// - fail to read a literal
+//   - due to format error
+//   - due to EOF
+// - read a literal on a json channel
+// - ignoreWhitespace
+// - speculative read
+// - matchNewline
+//
+// for both bytes and string types
+//
+
+config param useStrings = true;
+
+var fiveSquare = if useStrings then "[5]" else b"[5]";
+var LBR = if useStrings then "[" else b"[";
+var RBR = if useStrings then "]" else b"]";
+
+proc testBasic() throws {
+  var f = openmem();
+  {
+    var w = f.writer();
+    w.write(fiveSquare);
+  }
+  var r = f.reader();
+  r.matchLiteral(LBR);
+  writeln(r.read(int));
+  r.matchLiteral(RBR);
+  assert(r.atEOF());
+}
+
+proc testFailure() {
+  var f = openmem();
+  {
+    var w = f.writer();
+    w.write(fiveSquare);
+  }
+
+  var r = f.reader();
+  {
+    param paren = if useStrings then "(" else b"(";
+    const res = r.matchLiteral(paren);
+    assert(res == false);
+    assert(r.offset() == 0);
+  }
+
+  assert(r.matchLiteral(fiveSquare));
+  {
+    param foo = if useStrings then "foo" else b"foo";
+    const res = r.matchLiteral(foo);
+    assert(res == false);
+    assert(r.atEOF());
+  }
+}
+
+proc testJSON() {
+  var f = openmem();
+  param quote = if useStrings then '"' else b"\"";
+  {
+    var w = f.writer();
+    w.write(quote);
+    w.write(fiveSquare);
+    w.write(quote);
+  }
+
+  var r = f.reader(locking=false);
+  var st = r._styleInternal();
+  st.string_format = iostringformat.json:uint(8);
+  r._set_styleInternal(st);
+
+  try {
+    var x = "[";
+    r.mark();
+    r.read(x);
+    const off = r.offset();
+    assert(r.atEOF());
+    r.revert();
+    if off != 1 then throw new BadFormatError("msg");
+  } catch e:BadFormatError {
+    writeln("caught expected format error with JSON");
+  } catch {
+    assert(false);
+  }
+
+  assert(r.matchLiteral(quote + LBR));
+  writeln(r.read(int));
+  assert(r.matchLiteral(RBR + quote));
+  assert(r.atEOF());
+}
+
+proc testWhitespace() {
+  var f = openmem();
+  {
+    var w = f.writer();
+    const str = "   [5   ]";
+    const spaced = if useStrings then str else str.encode();
+    w.write(spaced);
+  }
+
+  var r = f.reader(locking=false);
+  r.mark();
+  assert(r.matchLiteral(LBR));
+  writeln(r.read(int));
+  assert(r.matchLiteral(RBR));
+  assert(r.atEOF());
+  r.revert();
+
+  assert(!r.matchLiteral(LBR, ignoreWhitespace=false));
+}
+
+proc testSpeculative() {
+  param comma = if useStrings then "," else b",";
+  var f = openmem();
+  {
+    var w = f.writer();
+    w.write(LBR);
+    for i in 1..9 do w.write(i, comma);
+    w.write(10);
+    w.write(RBR);
+  }
+
+  // Use 'readLiteral' here as an example of mixed usage
+  var A : [1..10] bool;
+  var r = f.reader();
+  r.readLiteral(LBR);
+  do {
+    const i = r.read(int);
+    A[i] = true;
+  } while r.matchLiteral(",");
+
+  r.readLiteral(RBR);
+  assert(r.atEOF());
+  assert(&& reduce A);
+}
+
+proc testNewline() {
+  var f = openmem();
+  const numSpaces = 5;
+  const start = "start";
+  {
+    var w = f.writer();
+    w.write(start);
+    // by default matchNewline should read past contiguous whitespace
+    w.write(" " * numSpaces);
+    for 1..10 do w.writeln();
+    w.write("end");
+  }
+  {
+    // try to read a newline with 'start' in the way
+    var r = f.reader();
+    assert(!r.matchNewline());
+  }
+  {
+    var r = f.reader();
+    assert(r.matchLiteral(start));
+    assert(r.matchNewline());
+    assert(r.offset() == start.size + numSpaces + 1);
+  }
+  {
+    var r = f.reader();
+    assert(r.matchLiteral(start));
+    while r.matchNewline() {};
+    var x = r.read(string);
+    assert(x == "end");
+    assert(r.atEOF());
+    assert(!r.matchNewline());
+  }
+}
+
+proc main() {
+  testBasic();
+  testFailure();
+  testJSON();
+  testWhitespace();
+  testSpeculative();
+  testNewline();
+
+  writeln("SUCCESS");
+}

--- a/test/io/literals/match-literal.compopts
+++ b/test/io/literals/match-literal.compopts
@@ -1,0 +1,2 @@
+-suseStrings=true
+-suseStrings=false

--- a/test/io/literals/match-literal.good
+++ b/test/io/literals/match-literal.good
@@ -1,0 +1,5 @@
+5
+caught expected format error with JSON
+5
+5
+SUCCESS

--- a/test/io/literals/mismatch-read-write.chpl
+++ b/test/io/literals/mismatch-read-write.chpl
@@ -1,0 +1,36 @@
+
+use IO;
+
+//
+// Testing errors like 'write on read-only channel'
+//
+
+enum action {
+  read,
+  match,
+  write,
+}
+
+config param useStrings = true;
+config param useLiteral = true;
+config param useAction = action.read;
+
+proc main() {
+  var f = openmem();
+  param lit = if useStrings then "x" else b"x";
+  var ch = if useAction == action.write then f.reader() else f.writer();
+
+  if useLiteral {
+    select useAction {
+      when action.read do ch.readLiteral(lit);
+      when action.match do ch.matchLiteral(lit);
+      when action.write do ch.writeLiteral(lit);
+    }
+  } else {
+    select useAction {
+      when action.read do ch.readNewline();
+      when action.match do ch.matchNewline();
+      when action.write do ch.writeNewline();
+    }
+  }
+}

--- a/test/io/literals/mismatch-read-write.cleanfiles
+++ b/test/io/literals/mismatch-read-write.cleanfiles
@@ -1,0 +1,1 @@
+mismatch-read-write.good

--- a/test/io/literals/mismatch-read-write.compopts
+++ b/test/io/literals/mismatch-read-write.compopts
@@ -1,0 +1,11 @@
+-suseStrings=true -suseLiteral=true -suseAction=action.read
+-suseStrings=true -suseLiteral=true -suseAction=action.match
+-suseStrings=true -suseLiteral=true -suseAction=action.write
+
+-suseStrings=false -suseLiteral=true -suseAction=action.read
+-suseStrings=false -suseLiteral=true -suseAction=action.match
+-suseStrings=false -suseLiteral=true -suseAction=action.write
+
+-suseStrings=true -suseLiteral=false -suseAction=action.read
+-suseStrings=true -suseLiteral=false -suseAction=action.match
+-suseStrings=true -suseLiteral=false -suseAction=action.write

--- a/test/io/literals/mismatch-read-write.prediff
+++ b/test/io/literals/mismatch-read-write.prediff
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import sys, os, re;
+
+testname=sys.argv[1]
+compopts=sys.argv[4]
+
+useLiteral = re.search(r"useLiteral\=(\w+)", compopts).group(1)
+useAction = re.search(r"useAction\=action\.(\w+)", compopts).group(1)
+
+suffix = "Literal" if useLiteral == "true" else "Newline"
+methodName = useAction + suffix
+kind = "read" if useAction == "write" else "write"
+
+lineno = -1
+with open(testname + ".chpl") as source:
+    for n, line in enumerate(source, 1):
+        if methodName in line:
+            lineno = n
+            break
+
+template = ""
+with open(testname + ".template.good") as tf:
+    template = tf.read()
+
+template = template.replace("LINENO", str(lineno))
+template = template.replace("METHOD", methodName)
+template = template.replace("READWRITE", kind)
+
+with open(testname + ".good", "w") as f:
+    f.write(template)

--- a/test/io/literals/mismatch-read-write.template.good
+++ b/test/io/literals/mismatch-read-write.template.good
@@ -1,0 +1,2 @@
+mismatch-read-write.chpl:18: In function 'main':
+mismatch-read-write.chpl:LINENO: error: METHOD on READWRITE-only channel

--- a/test/io/literals/read-literal.chpl
+++ b/test/io/literals/read-literal.chpl
@@ -1,0 +1,226 @@
+
+use IO;
+use OS;
+
+//
+// Test cases:
+// - successfully read a literal
+// - fail to read a literal
+//   - due to format error
+//   - due to EOF
+// - read a literal on a json channel
+// - ignoreWhitespace
+// - speculative read
+// - readNewline
+//
+// for both bytes and string types
+//
+
+config param useStrings = true;
+
+var fiveSquare = if useStrings then "[5]" else b"[5]";
+var LBR = if useStrings then "[" else b"[";
+var RBR = if useStrings then "]" else b"]";
+
+proc testBasic() throws {
+  var f = openmem();
+  {
+    var w = f.writer();
+    w.write(fiveSquare);
+  }
+  var r = f.reader();
+  r.readLiteral(LBR);
+  writeln(r.read(int));
+  r.readLiteral(RBR);
+  assert(r.atEOF());
+}
+
+proc testFailure() {
+  var f = openmem();
+  {
+    var w = f.writer();
+    w.write(fiveSquare);
+  }
+
+  var r = f.reader();
+  try {
+    param paren = if useStrings then "(" else b"(";
+    r.readLiteral(paren); // trying to read the wrong opening symbol
+    assert(false);
+  } catch e:BadFormatError {
+    writeln("caught expected format error");
+    assert(r.offset() == 0);
+  } catch {
+    assert(false);
+  }
+
+  r.readLiteral(fiveSquare);
+  try {
+    param foo = if useStrings then "foo" else b"foo";
+    r.readLiteral(foo);
+  } catch e:EofError {
+    writeln("caught expected EOF error");
+    assert(r.atEOF());
+  } catch {
+    assert(false);
+  }
+}
+
+proc testJSON() {
+  var f = openmem();
+  param quote = if useStrings then '"' else b"\"";
+  {
+    var w = f.writer();
+    w.write(quote);
+    w.write(fiveSquare);
+    w.write(quote);
+  }
+
+  var r = f.reader(locking=false);
+  var st = r._styleInternal();
+  st.string_format = iostringformat.json:uint(8);
+  r._set_styleInternal(st);
+
+  try {
+    var x = "[";
+    r.mark();
+    r.read(x);
+    const off = r.offset();
+    assert(r.atEOF());
+    r.revert();
+    if off != 1 then throw new BadFormatError("msg");
+  } catch e:BadFormatError {
+    writeln("caught expected format error with JSON");
+  } catch {
+    assert(false);
+  }
+
+  r.readLiteral(quote + LBR);
+  writeln(r.read(int));
+  r.readLiteral(RBR + quote);
+  assert(r.atEOF());
+}
+
+proc testWhitespace() {
+  var f = openmem();
+  {
+    var w = f.writer();
+    const str = "   [5   ]";
+    const spaced = if useStrings then str else str.encode();
+    w.write(spaced);
+  }
+
+  var r = f.reader(locking=false);
+  r.mark();
+  r.readLiteral(LBR);
+  writeln(r.read(int));
+  r.readLiteral(RBR);
+  assert(r.atEOF());
+  r.revert();
+
+  try {
+    r.readLiteral(LBR, ignoreWhitespace=false);
+  } catch e:BadFormatError {
+    writeln("caught expected format error with whitespace");
+  } catch {
+    assert(false);
+  }
+}
+
+proc testSpeculative() {
+  param comma = if useStrings then "," else b",";
+  var f = openmem();
+  {
+    var w = f.writer();
+    w.write(LBR);
+    for i in 1..9 do w.write(i, comma);
+    w.write(10);
+    w.write(RBR);
+  }
+
+  var A : [1..10] bool;
+  var r = f.reader();
+  r.readLiteral(LBR);
+  while true {
+    const i = r.read(int);
+    A[i] = true;
+
+    try {
+      r.readLiteral(comma);
+    } catch e:BadFormatError {
+      writeln("caught comma");
+      break;
+    } catch {
+      assert(false);
+    }
+  }
+  r.readLiteral(RBR);
+  assert(r.atEOF());
+  assert(&& reduce A);
+}
+
+proc testNewline() {
+  var f = openmem();
+  const numSpaces = 5;
+  const start = "start";
+  {
+    var w = f.writer();
+    w.write(start);
+    // by default readnewline should read past contiguous whitespace
+    w.write(" " * numSpaces);
+    for 1..10 do w.writeln();
+    w.write("end");
+  }
+  {
+    // try to read a newline with 'start' in the way
+    var r = f.reader();
+    try {
+      r.readNewline();
+    } catch e:BadFormatError {
+      writeln("caught newline trying to read non-whitespace");
+    } catch {
+      assert(false);
+    }
+  }
+  {
+    var r = f.reader();
+    r.readLiteral(start);
+    r.readNewline();
+    assert(r.offset() == start.size + numSpaces + 1);
+  }
+  {
+    var r = f.reader();
+    r.readLiteral(start);
+    while true {
+      try {
+        r.readNewline();
+      } catch e:BadFormatError {
+        writeln("caught expected format error");
+        break;
+      } catch {
+        assert(false);
+      }
+    }
+    var x = r.read(string);
+    assert(x == "end");
+    assert(r.atEOF());
+    try {
+      r.readNewline();
+    } catch e:EofError {
+      writeln("caught expected eof error");
+    } catch {
+      assert(false);
+    }
+  }
+}
+
+proc main() {
+  testBasic();
+  testFailure();
+  testJSON();
+  testWhitespace();
+  testSpeculative();
+  testNewline();
+
+  writeln("SUCCESS");
+}

--- a/test/io/literals/read-literal.compopts
+++ b/test/io/literals/read-literal.compopts
@@ -1,0 +1,2 @@
+-suseStrings=true
+-suseStrings=false

--- a/test/io/literals/read-literal.good
+++ b/test/io/literals/read-literal.good
@@ -1,0 +1,12 @@
+5
+caught expected format error
+caught expected EOF error
+caught expected format error with JSON
+5
+5
+caught expected format error with whitespace
+caught comma
+caught newline trying to read non-whitespace
+caught expected format error
+caught expected eof error
+SUCCESS

--- a/test/io/literals/utf8-literal-error.chpl
+++ b/test/io/literals/utf8-literal-error.chpl
@@ -1,0 +1,38 @@
+
+use IO;
+
+//
+// Make sure we print something a bit more useful for invalid bytes
+//
+// The SystemError text differs between mac and linux:
+// mac: Illegal byte sequence
+// linux: Invalid or incomplete multibyte or wide character
+//
+
+proc main() {
+  var b = b"\x80\x81";
+  var f = openmem();
+  {
+    var w = f.writer();
+    w.write("hello");
+  }
+  var r = f.reader();
+
+  try {
+    r.readLiteral(b);
+    assert(false);
+  } catch e : SystemError {
+    assert(e.message().count("non-UTF8 bytes") > 0);
+  } catch {
+    assert(false);
+  }
+
+  try {
+    r.matchLiteral(b);
+    assert(false);
+  } catch e : SystemError {
+    assert(e.message().count("non-UTF8 bytes") > 0);
+  } catch {
+    assert(false);
+  }
+}

--- a/test/io/recordio.chpl
+++ b/test/io/recordio.chpl
@@ -98,7 +98,7 @@ proc MyRecord.writeThis(f) throws {
 
 proc MyRecord.readWriteHelper(f) throws {
   proc rwLiteral(lit:string) {
-    if f.writing then f._writeLiteral(lit); else f._readLiteral(lit);
+    if f.writing then f.writeLiteral(lit); else f.readLiteral(lit);
   }
 
   if f.writing then f.write(i); else i = f.read(int);

--- a/test/unstable/readMatchLiteral.chpl
+++ b/test/unstable/readMatchLiteral.chpl
@@ -1,0 +1,24 @@
+
+use IO;
+
+proc main() {
+  var f = openmem();
+  {
+    var w = f.writer();
+    for 1..2 {
+      w.writeLiteral("$");
+      w.writeLiteral("$");
+      w.writeNewline();
+    }
+  }
+
+  var r = f.reader();
+
+  r.readLiteral("$");
+  r.readLiteral(b"$");
+  r.readNewline();
+
+  assert(r.matchLiteral("$"));
+  assert(r.matchLiteral(b"$"));
+  assert(r.matchNewline());
+}

--- a/test/unstable/readMatchLiteral.good
+++ b/test/unstable/readMatchLiteral.good
@@ -1,0 +1,10 @@
+readMatchLiteral.chpl:4: In function 'main':
+readMatchLiteral.chpl:9: warning: channel.writeLiteral is unstable and subject to change.
+readMatchLiteral.chpl:10: warning: channel.writeLiteral is unstable and subject to change.
+readMatchLiteral.chpl:11: warning: channel.writeNewline is unstable and subject to change.
+readMatchLiteral.chpl:17: warning: channel.readLiteral is unstable and subject to change.
+readMatchLiteral.chpl:18: warning: channel.readLiteral is unstable and subject to change.
+readMatchLiteral.chpl:19: warning: channel.readNewline is unstable and subject to change.
+readMatchLiteral.chpl:21: warning: channel.matchLiteral is unstable and subject to change.
+readMatchLiteral.chpl:22: warning: channel.matchLiteral is unstable and subject to change.
+readMatchLiteral.chpl:23: warning: channel.matchNewline is unstable and subject to change.


### PR DESCRIPTION
This PR introduces new methods on channels to support reading and writing of literal strings, bytes, and newlines. The new methods, as discussed in #19487:
```chpl
proc channel.readLiteral(literal:string, ignoreWhitespace=true) : void throws
proc channel.readLiteral(literal:bytes, ignoreWhitespace=true) : void throws
proc channel.readNewline() : void throws

// returns 'false' if literal could not be matched, or on EOF
proc channel.matchLiteral(literal:string, ignoreWhitespace=true) : bool throws
proc channel.matchLiteral(literal:bytes, ignoreWhitespace=true) : bool throws
proc channel.matchNewline() : bool throws

proc channel.writeLiteral(literal:string) : void throws
proc channel.writeLiteral(literal:bytes) : void throws
proc channel.writeNewline() : void throws
```

These methods will be marked as unstable for the time being until we can conclude a couple of questions:
- What if a literal contains leading whitespace, and ``ignoreWhitespace`` is ``true`` (for read/match methods)?
- Should the read/match newline methods contain an ``ignoreWhitespace=true`` argument?

Testing:
- [x] full local
- [x] full gasnet