### PR TITLE
dyno: use LLVM data structures to improve performance

### DIFF
--- a/compiler/dyno/include/chpl/framework/Context.h
+++ b/compiler/dyno/include/chpl/framework/Context.h
@@ -37,6 +37,8 @@
 #include <utility>
 #include <vector>
 
+#include "llvm/ADT/DenseMap.h"
+
 namespace chpl {
 
 namespace uast {
@@ -86,7 +88,7 @@ class Context {
   // Maps to an 'owned' heap-allocated thing to manage having subclasses
   // without slicing.
   // It assumes that the query name is already unique.
-  std::unordered_map<const void*, owned<querydetail::QueryMapBase>> queryDB;
+  llvm::DenseMap<const void*, owned<querydetail::QueryMapBase>> queryDB;
 
   // Since IDs include module names but not file paths, use this
   // map to go from module name to file path.

--- a/compiler/dyno/include/chpl/framework/all-global-strings.h
+++ b/compiler/dyno/include/chpl/framework/all-global-strings.h
@@ -26,6 +26,8 @@
 /* X(identifier, chapel string name) */
 /* the identifier must be a legal C++ identifier */
 
+X(tombstone      , "<tombstone>")
+X(empty          , "<empty>")
 X(align          , "align")
 X(atomic         , "atomic")
 X(bool_          , "bool")

--- a/compiler/dyno/include/chpl/framework/query-impl.h
+++ b/compiler/dyno/include/chpl/framework/query-impl.h
@@ -171,15 +171,13 @@ Context::getMap(const ResultType& (*queryFunc)(Context* context, ArgTs...),
 
   // Otherwise, create the QueryMap entry for this query
   // and add it to the map
-  auto iter =
-    this->queryDB.emplace_hint(
-      search,
-      std::make_pair(queryFuncV,
+  auto res =
+    this->queryDB.try_emplace(queryFuncV,
                      toOwned(new QueryMap<ResultType, ArgTs...>(traceQueryName,
                                                                 isInputQuery,
-                                                                queryFunc))));
+                                                                queryFunc)));
   // and return a pointer to the newly inserted map
-  QueryMapBase* newBase = iter->second.get();
+  QueryMapBase* newBase = res.first->second.get();
   return (QueryMap<ResultType, ArgTs...>*)newBase;
 }
 

--- a/compiler/dyno/include/chpl/resolution/scope-queries.h
+++ b/compiler/dyno/include/chpl/resolution/scope-queries.h
@@ -21,10 +21,12 @@
 #define CHPL_RESOLUTION_SCOPE_QUERIES_H
 
 #include "chpl/resolution/scope-types.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 namespace chpl {
 namespace resolution {
 
+  using ScopeSet = llvm::SmallPtrSet<const Scope*, 5>;
 
   /**
     Returns true if this AST type can create a scope.
@@ -83,7 +85,7 @@ namespace resolution {
                            const Scope* receiverScope,
                            UniqueString name,
                            LookupConfig config,
-                           std::unordered_set<const Scope*>& visited);
+                           ScopeSet& visited);
 
   /**
     Returns true if all of checkScope is visible from fromScope

--- a/compiler/dyno/include/chpl/uast/Builder.h
+++ b/compiler/dyno/include/chpl/uast/Builder.h
@@ -64,10 +64,10 @@ class Builder final {
   std::unordered_map<const AstNode*, Location> notedLocations_;
 
   // the following maps are computed during assignIDs
-  std::unordered_map<ID, Location> idToLocation_;
+  llvm::DenseMap<ID, Location> idToLocation_;
   std::vector<Location> commentToLocation_;
-  std::unordered_map<ID, const AstNode*> idToAst_;
-  std::unordered_map<ID, ID> idToParent_;
+  llvm::DenseMap<ID, const AstNode*> idToAst_;
+  llvm::DenseMap<ID, ID> idToParent_;
 
   Builder(Context* context, UniqueString filepath,
           UniqueString startingSymbolPath)

--- a/compiler/dyno/include/chpl/uast/BuilderResult.h
+++ b/compiler/dyno/include/chpl/uast/BuilderResult.h
@@ -27,10 +27,34 @@
 #include "chpl/uast/AstNode.h"
 #include "chpl/util/iteration.h"
 #include "chpl/framework/stringify-functions.h"
+#include "chpl/framework/global-strings.h"
 
 #include <vector>
 #include <unordered_map>
 #include <utility>
+
+#include "llvm/ADT/DenseMap.h"
+
+namespace llvm {
+  template<> struct DenseMapInfo<chpl::ID> {
+    static bool isEqual(const chpl::ID& lhs, const chpl::ID& rhs) {
+      return lhs == rhs;
+    }
+
+    static size_t getHashValue(const chpl::ID& id) {
+      return chpl::hash(id);
+    }
+
+    static const chpl::ID getEmptyKey() {
+      return chpl::ID(USTR("<empty>"), -1, 0);
+    }
+
+    static const chpl::ID getTombstoneKey() {
+      return chpl::ID(USTR("<tombstone>"), -1, 0);
+    }
+  };
+}
+
 
 namespace chpl {
 
@@ -61,13 +85,13 @@ class BuilderResult final {
   std::vector<ErrorMessage> errors_;
 
   // Given an ID, what is the AstNode?
-  std::unordered_map<ID, const AstNode*> idToAst_;
+  llvm::DenseMap<ID, const AstNode*> idToAst_;
 
   // Given an ID, what is the parent ID?
-  std::unordered_map<ID, ID> idToParentId_;
+  llvm::DenseMap<ID, ID> idToParentId_;
 
   // Goes from ID to Location, applies to all AST nodes except Comment
-  std::unordered_map<ID, Location> idToLocation_;
+  llvm::DenseMap<ID, Location> idToLocation_;
 
   // Goes from Comment ID to Location, applies to all AST nodes except Comment
   std::vector<Location> commentIdToLocation_;

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -2232,7 +2232,7 @@ static std::vector<BorrowedIdsWithName>
 lookupCalledExpr(Context* context,
                  const Scope* scope,
                  const CallInfo& ci,
-                 std::unordered_set<const Scope*>& visited) {
+                 ScopeSet& visited) {
   const LookupConfig config = LOOKUP_DECLS |
                               LOOKUP_IMPORT_AND_USE |
                               LOOKUP_PARENTS;
@@ -2644,7 +2644,7 @@ resolveFnCallFilterAndFindMostSpecific(Context* context,
   // search for candidates at each POI until we have found a candidate
   CandidatesVec candidates;
   size_t firstPoiCandidate = 0;
-  std::unordered_set<const Scope*> visited;
+  ScopeSet visited;
 
   // inject compiler-generated candidates in a manner similar to below
   considerCompilerGeneratedCandidates(context, ci, inScope, inPoiScope,

--- a/compiler/dyno/lib/uast/BuilderResult.cpp
+++ b/compiler/dyno/lib/uast/BuilderResult.cpp
@@ -47,8 +47,8 @@ static
 void computeIdMaps(
     const AstNode* ast,
     const AstNode* parentAst,
-    std::unordered_map<ID, const AstNode*>& idToAst,
-    std::unordered_map<ID, ID>& idToParentId) {
+    llvm::DenseMap<ID, const AstNode*>& idToAst,
+    llvm::DenseMap<ID, ID>& idToParentId) {
 
   for (const AstNode* child : ast->children()) {
     computeIdMaps(child, ast, idToAst, idToParentId);
@@ -91,8 +91,8 @@ bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {
   changed |= updateAstList(keep.topLevelExpressions_,
                            addin.topLevelExpressions_);
 
-  std::unordered_map<ID, const AstNode*> newIdToAst;
-  std::unordered_map<ID, ID> newIdToParent;
+  llvm::DenseMap<ID, const AstNode*> newIdToAst;
+  llvm::DenseMap<ID, ID> newIdToParent;
 
   // recompute locationsVec by traversing the AST and using the maps
   for (const auto& ast : keep.topLevelExpressions_) {


### PR DESCRIPTION
I individually tested each performance change in
https://github.com/Cray/chapel-private/issues/3702; check it out if interested.
On my local machine, though, the three changes (one per commit) brought
Dyno average execution time[^1] from 20 runs from 463ms to 382ms,
a net improvement of roughly 17%.

The changes consisted of:
1. Using `SmallPtrSet` for the set of visited scopes when looking up
   names in scopes.
2. Using `DenseMap` for the `queryDB` in `Context`
3. Using `DenseMap` for the uAST builder when mapping node IDs
    to various other things.

In order to be able to use `llvm::DenseMap` with ID keys, we needed
to provide a template specialization for the `DenseMapInfo` struct. This
struct specifies how IDs should be hashed and compared for equality. It also
requires that we provide two dummy values (one for "empty", and one for
"tombstone"). Both of these values are added as identifiers in angle brackets,
which I believe is impossible to somehow collide with from actual Chapel code.
A `DenseMap` with key type `K` automatically uses `DenseMapInfo<K>`.

Reviewed by @mppf - thanks!

TESTING:
- [x] Performance testing in issue above
- [x] Performance testing on local machine (17% improvement, modulo [^1])
- [x] Paratest  

[^1]: It's important to re-iterate that I run performance tests by letting
the Dyno scope-resolver proceed as long as it can before it
gets stuck (which it does). Thus, although a net boost to performance,
these times are not representative of the magnitude of the changes
once the Dyno scope resolver runs end-to-end without hitting errors. On my
machine, the production compiler (no Dyno scope resolver) takes roughly 1.8
seconds to complete; using this, one could estimate that the changes are
closer to a 4% improvement. 