### PR TITLE
feat(chpldoc): swap dyno-chpldoc in place of chpldoc 

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -166,7 +166,11 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 
 $(CHPLDOC): $(CHPL)
 	rm -f $(CHPLDOC)
-	ln -s $(notdir $(CHPL)) $(CHPLDOC)
+	rm -f $(CHPLDOC)-legacy
+	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
+	@cd ../compiler/dyno && $(MAKE) -f Makefile.help dyno-chpldoc
+
+
 
 chpldoc: $(CHPLDOC)
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -164,7 +164,9 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 	$(TAGS_COMMAND)
 	$(EBROWSE_COMMAND)
 
-$(CHPLDOC): $(CHPL) dyno-chpldoc
+$(CHPLDOC): $(CHPL) dyno-chpldoc $(CHPLDOC)-legacy
+
+$(CHPLDOC)-legacy:
 	rm -f $(CHPLDOC)-legacy
 	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -164,13 +164,15 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 	$(TAGS_COMMAND)
 	$(EBROWSE_COMMAND)
 
-$(CHPLDOC): $(CHPL)
-	rm -f $(CHPLDOC)
+$(CHPLDOC): $(CHPL) dyno-chpldoc
 	rm -f $(CHPLDOC)-legacy
 	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
+
+# setup a phony rule to detect when dyno-chpldoc needs to be rebuilt
+.PHONY: dyno-chpldoc
+dyno-chpldoc:
+	rm -f $(CHPLDOC)
 	@cd ../compiler/dyno && $(MAKE) -f Makefile.help dyno-chpldoc
-
-
 
 chpldoc: $(CHPLDOC)
 

--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -78,6 +78,7 @@ dyno-parser: $(LIBCOMPILER_BUILD_DIR) FORCE
 
 dyno-chpldoc: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc && $(CMAKE) --build . --target chpldoc
+	mv $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc/chpldoc $(CHPL_BIN_DIR)/chpldoc
 
 dyno-linters: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/util && $(CMAKE) --build .

--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -78,7 +78,7 @@ dyno-parser: $(LIBCOMPILER_BUILD_DIR) FORCE
 
 dyno-chpldoc: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc && $(CMAKE) --build . --target chpldoc
-	mv $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc/chpldoc $(CHPL_BIN_DIR)/chpldoc
+	cp -f $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc/chpldoc $(CHPL_BIN_DIR)/chpldoc
 
 dyno-linters: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/util && $(CMAKE) --build .

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -84,6 +84,15 @@ std::error_code currentWorkingDir(std::string& path_out);
 std::error_code makeDir(std::string dirpath, bool makeParents=false);
 
 
+/*
+  Try to get the path of the executable. We rely on llvm implementation,
+  which states it _may_ return an empty path if it fails.
+  https://llvm.org/doxygen/namespacellvm_1_1sys_1_1fs.html#a057a733b2dfa2f0531ceb335cf3b1d03
+*/
+std::string getExecutablePath(const char* 	argv0, void* 	MainExecAddr);
+
+
+
 } // end namespace chpl
 
 

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -89,7 +89,7 @@ std::error_code makeDir(std::string dirpath, bool makeParents=false);
   which states it _may_ return an empty path if it fails.
   https://llvm.org/doxygen/namespacellvm_1_1sys_1_1fs.html#a057a733b2dfa2f0531ceb335cf3b1d03
 */
-std::string getExecutablePath(const char* 	argv0, void* 	MainExecAddr);
+std::string getExecutablePath(const char* argv0, void* MainExecAddr);
 
 
 

--- a/compiler/dyno/lib/util/filesystem.cpp
+++ b/compiler/dyno/lib/util/filesystem.cpp
@@ -217,5 +217,10 @@ std::error_code makeDir(std::string dirpath, bool makeParents) {
   }
 }
 
+std::string getExecutablePath(const char* argv0, void* MainExecAddr) {
+  using namespace llvm::sys::fs;
+  return getMainExecutable(argv0, MainExecAddr);
+}
+
 
 } // namespace chpl

--- a/compiler/dyno/tools/chpldoc/CMakeLists.txt
+++ b/compiler/dyno/tools/chpldoc/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 add_executable(chpldoc "chpldoc.cpp")
 set_property(TARGET chpldoc PROPERTY CXX_STANDARD 14)
-target_sources(chpldoc PRIVATE arg.h arg.cpp arg-helpers.h arg-helpers.cpp)
+target_sources(chpldoc PRIVATE arg.h arg.cpp arg-helpers.h arg-helpers.cpp version_num.h)
 target_link_libraries(chpldoc libdyno)
 target_include_directories(chpldoc PUBLIC
                            ${CHPL_MAIN_INCLUDE_DIR}

--- a/compiler/dyno/tools/chpldoc/arg-helpers.cpp
+++ b/compiler/dyno/tools/chpldoc/arg-helpers.cpp
@@ -70,10 +70,9 @@ uint64_t hexStr2uint64(const char* str, bool userSupplied,
 
 // Find the path to the running program
 // (or return NULL if we couldn't figure it out).
-// The return value must be freed by the caller.
-std::string findProgramPath(const char* argv0)
+std::string findProgramPath(const char* argv0, void* mainAddr)
 {
-  return chpl::getExecutablePath(argv0, nullptr);
+  return chpl::getExecutablePath(argv0, mainAddr);
 }
 
 

--- a/compiler/dyno/tools/chpldoc/arg-helpers.cpp
+++ b/compiler/dyno/tools/chpldoc/arg-helpers.cpp
@@ -51,11 +51,8 @@ uint64_t hexStr2uint64(const char* str, bool userSupplied,
   }
 
   if (strlen(str+startPos) > 16) {
-
-      //astlocT astloc(line, filename);
     std::cerr << "error: Integer literal overflow: '" + std::string(str) +
                   "' is too big for type 'uint64'" << std::endl;
-
     clean_exit(1);
   }
 

--- a/compiler/dyno/tools/chpldoc/arg-helpers.h
+++ b/compiler/dyno/tools/chpldoc/arg-helpers.h
@@ -38,7 +38,7 @@ typedef __uint64_t uint64_t;
 
 bool startsWith(const char* str, const char* prefix);
 void clean_exit(int status);
-std::string findProgramPath(const char* argv0);
+std::string findProgramPath(const char* argv0, void* mainAddr);
 
 extern bool developer;
 

--- a/compiler/dyno/tools/chpldoc/arg-helpers.h
+++ b/compiler/dyno/tools/chpldoc/arg-helpers.h
@@ -38,7 +38,7 @@ typedef __uint64_t uint64_t;
 
 bool startsWith(const char* str, const char* prefix);
 void clean_exit(int status);
-char* findProgramPath(const char *argv0);
+std::string findProgramPath(const char* argv0);
 
 extern bool developer;
 

--- a/compiler/dyno/tools/chpldoc/arg.cpp
+++ b/compiler/dyno/tools/chpldoc/arg.cpp
@@ -311,7 +311,7 @@ static void word_wrap_print(const char* text, int startCol, int endCol)
 *                                                                             *
 ************************************** | *************************************/
 
-void init_args(ArgumentState* state, const char* argv0) {
+void init_args(ArgumentState* state, const char* argv0, void* mainAddr) {
   char* name = strdup(argv0);
 
   if (char* firstSlash = strrchr(name, '/')) {
@@ -319,7 +319,7 @@ void init_args(ArgumentState* state, const char* argv0) {
   }
 
   state->program_name = name;
-  state->program_loc  = findProgramPath(argv0).c_str();
+  state->program_loc  = strdup(findProgramPath(argv0, mainAddr).c_str());
 }
 
 

--- a/compiler/dyno/tools/chpldoc/arg.cpp
+++ b/compiler/dyno/tools/chpldoc/arg.cpp
@@ -319,7 +319,7 @@ void init_args(ArgumentState* state, const char* argv0) {
   }
 
   state->program_name = name;
-  state->program_loc  = findProgramPath(argv0);
+  state->program_loc  = findProgramPath(argv0).c_str();
 }
 
 

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1402,7 +1402,12 @@ struct RstResultBuilder {
       auto err = ErrorMessage(ErrorMessage::Kind::WARNING, loc, errMsg);
       context_->report(err);
     }
-    if (commentShown && ((textOnly_ && !node->isModule()) || !textOnly_)) os_ << "\n";
+    // TODO: The presence of these node exceptions means we're probably missing
+    //  something from the old implementation
+    if (commentShown &&
+       ((textOnly_ && !node->isModule() && !node->isVariable()) || !textOnly_)) {
+      os_ << "\n";
+    }
     return commentShown;
   }
 
@@ -1491,6 +1496,7 @@ struct RstResultBuilder {
 
   owned<RstResult> visit(const Class* c) {
     if (isNoDoc(c) || c->visibility() == chpl::uast::Decl::PRIVATE) return {};
+    if (textOnly_) os_ << "Class: ";
     show("class", c);
     visitChildren(c);
     return getResult(true);

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -206,7 +206,7 @@ static std::string get_version() {
   return ret;
 }
 
-static void printStuff(const char* argv0) {
+static void printStuff(const char* argv0, void* mainAddr) {
   bool shouldExit       = false;
   bool printedSomething = false;
 
@@ -242,7 +242,7 @@ static void printStuff(const char* argv0) {
   }
 
   if( fPrintChplHome ) {
-    std::string guess = findProgramPath(argv0);
+    std::string guess = findProgramPath(argv0, mainAddr);
     printf("%s\t%s\n", CHPL_HOME.c_str(), guess.c_str());
     printedSomething = true;
   }
@@ -2004,9 +2004,9 @@ struct Args {
   std::string chplHome;
 };
 
-static Args parseArgs(int argc, char **argv) {
+static Args parseArgs(int argc, char **argv, void* mainAddr) {
   Args ret;
-  init_args(&sArgState, argv[0]);
+  init_args(&sArgState, argv[0], mainAddr);
   init_arg_desc(&sArgState, docs_arg_desc);
   process_args(&sArgState, argc, argv);
   ret.author = std::string(fDocsAuthor);
@@ -2086,11 +2086,11 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir,
 int main(int argc, char** argv) {
   // initial value of CHPL_HOME may be overridden by cmdline arg
   CHPL_HOME = getenv("CHPL_HOME");
-  Args args = parseArgs(argc, argv);
+  Args args = parseArgs(argc, argv, (void*)main);
 
   // check if user asked for legacy chpldoc
   if (fLegacyChpldoc) {
-    std::string pathToExe = getExecutablePath(argv[0], nullptr);
+    std::string pathToExe = getExecutablePath(argv[0], (void*)main);
     std::string cmd = pathToExe + "-legacy ";
     for (int i = 1; i < argc; i++) {
       std::string arg = std::string(argv[i]);
@@ -2190,7 +2190,7 @@ int main(int argc, char** argv) {
                          {}, //cmdLinePaths
                          args.files);
   GatherModulesVisitor gather(ctx);
-  printStuff(argv[0]);
+  printStuff(argv[0], (void*)main);
   // evaluate all the files and gather the modules
   for (auto cpath : args.files) {
     UniqueString path = UniqueString::get(ctx, cpath);

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -252,15 +252,15 @@ static void printStuff(const char* argv0) {
     printedSomething = true;
   }
   if( fPrintChplHome ) {
-    char* guess = findProgramPath(argv0);
+    std::string guess = findProgramPath(argv0);
 
-    printf("%s\t%s\n", CHPL_HOME.c_str(), guess);
+    printf("%s\t%s\n", CHPL_HOME.c_str(), guess.c_str());
     // TODO: Do we care about this for dyno-chpldoc?
     // const char* prefix = get_configured_prefix();
     // if (prefix != NULL && prefix[0] != '\0' )
     //   printf("# configured prefix  %s\n", prefix);
 
-    free(guess);
+//    free(guess);
 
     printedSomething = true;
   }

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -406,6 +406,7 @@ static UniqueString getNodeName(AstNode* node) {
     return node->toIdentifier()->name();
   } else {
     assert(false && "no name defined for node");
+    return UniqueString();
   }
 }
 

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -791,9 +791,7 @@ struct RstSignatureVisitor {
   }
 
   /*
-    helper for printing unary op calls, special handling for nilable operator
-    to conditionally prepend nilable in replacement of the ? operator when the
-    actual is not a function call
+    helper for printing unary op calls
   */
   void printUnaryOp(const OpCall* node) {
     assert(node->numActuals() == 1);
@@ -805,11 +803,7 @@ struct RstSignatureVisitor {
       isPostFixBang = true;
       unaryOp = USTR("!");
     } else if (node->op() == USTR("?")) {
-      if (node->actual(0)->isFnCall()) {
-        isNilable = true;
-      } else {
-        os_ << "nilable ";
-      }
+      isNilable = true;
     } else {
       os_ << unaryOp;
     }
@@ -818,6 +812,7 @@ struct RstSignatureVisitor {
       os_ << unaryOp;
     }
   }
+
 
   /*
     Helper for printing operands of binary and unary op calls

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -42,6 +42,7 @@
 
 #include "arg.h"
 #include "arg-helpers.h"
+#include "version_num.h"
 
 #include "chpl/parsing/Parser.h"
 #include "chpl/parsing/parsing-queries.h"
@@ -94,11 +95,6 @@ std::string outputDir_;
 bool textOnly_ = false;
 std::string CHPL_HOME;
 bool processUsedModules_ = false;
-
-// TODO: Whether or not to support this flag is an open discussion. Currently,
-//       it is not supported, so the flag is always true.
-//       (thomasvandoren, 2015-03-08)
-bool fDocsIncludeExterns = true;
 bool fDocsProcessUsedModules = false;
 
 static
@@ -128,18 +124,6 @@ void setHome(const ArgumentDescription* desc, const char* arg) {
 
 #define DRIVER_ARG_COPYRIGHT \
   {"copyright", ' ', NULL, "Show copyright", "F", &fPrintCopyright, NULL, NULL}
-
-// TODO: Does dyno-chpldoc need to support these flags too?
-// #define DRIVER_ARG_BREAKFLAGS_COMMON \
-//   {"break-on-id", ' ', NULL, "Break when AST id is created", "I", &breakOnID, "CHPL_BREAK_ON_ID", NULL}, \
-//   {"break-on-remove-id", ' ', NULL, "Break when AST id is removed from the tree", "I", &breakOnRemoveID, "CHPL_BREAK_ON_REMOVE_ID", NULL}
-
-// #define DRIVER_ARG_DEBUGGERS                                            \
-//   {"gdb", ' ', NULL, "Run compiler in gdb", "F", &fRungdb, NULL, NULL}, \
-//   {"lldb", ' ', NULL, "Run compiler in lldb", "F", &fRunlldb, NULL, NULL}
-
-// #define DRIVER_ARG_DEVELOPER \
-//   {"devel", ' ', NULL, "Compile as a developer [user]", "N", &developer, "CHPL_DEVELOPER", driverSetDevelSettings}
 
 #define DRIVER_ARG_HELP \
   {"help", 'h', NULL, "Help (show this list)", "F", &fPrintHelp, NULL, NULL}
@@ -175,13 +159,6 @@ static ArgumentState sArgState = {
 
 ArgumentDescription docs_arg_desc[] = {
  {"", ' ', NULL, "Documentation Options", NULL, NULL, NULL, NULL},
-
- // TODO: This option is disabled for now (since source based ordering was
- //       introduced). The code to support it is still around, and the plan is
- //       to bring it back someday soon. (thomasvandoren, 2015-03-11)
- //
- // {"alphabetical", ' ', NULL, "Alphabetizes the documentation", "N", &fDocsAlphabetize, NULL, NULL},
-
  {"output-dir", 'o', "<dirname>", "Sets the documentation directory to <dirname>", "S256", fDocsFolder, NULL, NULL},
  {"author", ' ', "<author>", "Documentation author string.", "S256", fDocsAuthor, "CHPLDOC_AUTHOR", NULL},
  {"comment-style", ' ', "<indicator>", "Only includes comments that start with <indicator>", "S256", fDocsCommentLabel, NULL, docsArgSetCommentLabel},
@@ -192,12 +169,7 @@ ArgumentDescription docs_arg_desc[] = {
  {"project-version", ' ', "<projectversion>", "Sets the documentation version to <projectversion>", "S256", fDocsProjectVersion, "CHPLDOC_PROJECT_VERSION", NULL},
 
  {"legacy", ' ', NULL, "Use the legacy version of chpldoc", "F", &fLegacyChpldoc, NULL, NULL},
- // TODO: Whether or not to support this flag is an open discussion. Currently,
- //       it is not supported, so the flag is always true.
- //       (thomasvandoren, 2015-03-08)
- //{"externs", ' ', NULL, "Include externs", "n", &fDocsIncludeExterns, NULL, NULL},
  {"print-commands", ' ', NULL, "[Don't] print system commands", "N", &printSystemCommands, "CHPL_PRINT_COMMANDS", NULL},
-
  {"", ' ', NULL, "Information Options", NULL, NULL, NULL, NULL},
  DRIVER_ARG_HELP,
  DRIVER_ARG_HELP_ENV,
@@ -205,29 +177,46 @@ ArgumentDescription docs_arg_desc[] = {
  DRIVER_ARG_VERSION,
  DRIVER_ARG_COPYRIGHT,
  DRIVER_ARG_LICENSE,
-
  {"", ' ', NULL, "Developer Flags", NULL, NULL, NULL, NULL},
- // TODO: do we need these flags for dyno-chpldoc?
-//  DRIVER_ARG_DEVELOPER,
-//  DRIVER_ARG_BREAKFLAGS_COMMON,
-//  DRIVER_ARG_DEBUGGERS,
  DRIVER_ARG_HOME,
  DRIVER_ARG_PRINT_CHPL_HOME,
-
  DRIVER_ARG_LAST
 };
+
+static std::string get_version() {
+  std::string ret;
+  ret = std::to_string(MAJOR_VERSION) + "." +
+        std::to_string(MINOR_VERSION) + "." +
+        std::to_string(UPDATE_VERSION);
+  if (!officialRelease) {
+    ret += " pre-release (" + std::string(BUILD_VERSION) + ")";
+  } else {
+    // It's is an official release.
+    // Try to decide whether or not to include the BUILD_VERSION
+    // based on its string length. A short git sha is 10 characters.
+    if (strlen(BUILD_VERSION) > 2 && !developer) {
+      // assume it is a sha, so don't include it
+    } else if (strcmp(BUILD_VERSION, "0") == 0) {
+      // no need to append a .0
+    } else {
+      // include the BUILD_VERSION contents to add e.g. a .1
+      ret += "." + std::string(BUILD_VERSION);
+    }
+  }
+  return ret;
+}
 
 static void printStuff(const char* argv0) {
   bool shouldExit       = false;
   bool printedSomething = false;
 
   if (fPrintVersion) {
-    // TODO: find equivalents for compileVersion, LLVM_VERSION_STRING
-    // fprintf(stdout, "%s version %s\n", sArgState.program_name, compileVersion);
+    std::string version = get_version();
+    fprintf(stdout, "%s version %s\n", sArgState.program_name, version.c_str());
 
-// #ifdef HAVE_LLVM
-//     fprintf(stdout, "  built with LLVM version %s\n", LLVM_VERSION_STRING);
-// #endif
+    #ifdef HAVE_LLVM
+        fprintf(stdout, "  built with LLVM version %s\n", LLVM_VERSION_STRING);
+    #endif
 
     fPrintCopyright  = true;
     printedSomething = true;
@@ -251,46 +240,12 @@ static void printStuff(const char* argv0) {
 
     printedSomething = true;
   }
+
   if( fPrintChplHome ) {
     std::string guess = findProgramPath(argv0);
-
     printf("%s\t%s\n", CHPL_HOME.c_str(), guess.c_str());
-    // TODO: Do we care about this for dyno-chpldoc?
-    // const char* prefix = get_configured_prefix();
-    // if (prefix != NULL && prefix[0] != '\0' )
-    //   printf("# configured prefix  %s\n", prefix);
-
-//    free(guess);
-
     printedSomething = true;
   }
-
-  // TODO: Do we care about this for dyno-chpldoc?
-  // if( fPrintChplSettings ) {
-  //   char buf[1025] = "";
-  //   printf("CHPL_HOME: %s\n", CHPL_HOME.c_str());
-  //   printf("CHPL_RUNTIME_LIB: %s\n", CHPL_RUNTIME_LIB);
-  //   printf("CHPL_RUNTIME_INCL: %s\n", CHPL_RUNTIME_INCL);
-  //   printf("CHPL_THIRD_PARTY: %s\n", CHPL_THIRD_PARTY);
-  //   printf("\n");
-  //   const char* internalFlag = "";
-  //   if (developer)
-  //     internalFlag = "--internal";
-  //   int wanted_to_write = snprintf(buf, sizeof(buf),
-  //                                  "%s/util/printchplenv --all %s",
-  //                                  CHPL_HOME.c_str(), internalFlag);
-  //   if (wanted_to_write < 0) {
-  //     USR_FATAL("character encoding error in CHPL_HOME path name");
-  //   } else if ((size_t)wanted_to_write >= sizeof(buf)) {
-  //     USR_FATAL("CHPL_HOME path name is too long");
-  //   }
-  //   int status = mysystem(buf, "running printchplenv", false);
-  //   if (compilerSetChplLLVM) {
-  //     printf("---\n");
-  //     printf("* Note: CHPL_LLVM was set by 'chpl' since it was built without LLVM support.\n");
-  //   }
-  //   clean_exit(status);
-  // }
 
   if (fPrintHelp || (!printedSomething && sArgState.nfile_arguments < 1)) {
     if (printedSomething) printf("\n");
@@ -309,7 +264,6 @@ static void printStuff(const char* argv0) {
     clean_exit(0);
   }
 }
-
 
 
 
@@ -2135,6 +2089,8 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir,
 
 
 int main(int argc, char** argv) {
+  // initial value of CHPL_HOME may be overridden by cmdline arg
+  CHPL_HOME = getenv("CHPL_HOME");
   Args args = parseArgs(argc, argv);
 
   // check if user asked for legacy chpldoc
@@ -2169,13 +2125,6 @@ int main(int argc, char** argv) {
   commentStyle_ = args.commentStyle;
   processUsedModules_ = args.processUsedModules;
 
-  // update CHPL_HOME if we got one from the command-line args, or use the
-  // environment variable.
-  if (!args.chplHome.empty()) {
-    CHPL_HOME = args.chplHome;
-  } else {
-    CHPL_HOME = getenv("CHPL_HOME");
-  }
 
   Context context(CHPL_HOME);
   Context *ctx = &context;

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1379,7 +1379,25 @@ struct RstResultBuilder {
     }
 
     showDeprecationMessage(node, indentComment);
+    // TODO: how do deprecation and unstable messages interplay?
+    showUnstableWarning(node, indentComment);
     return commentShown;
+  }
+
+  void showUnstableWarning(const Decl* node, bool indentComment=true) {
+    if (auto attrs = node->attributes()) {
+      if (attrs->isUnstable()) {
+        int commentShift = 0;
+          if (indentComment) {
+            indentStream(os_, indentDepth_ * indentPerDepth);
+            commentShift = 1;
+          }
+          os_ << ".. warning::\n\n";
+          indentStream(os_, (indentDepth_ + commentShift) * indentPerDepth);
+        os_ << strip(attrs->unstableMessage().c_str());
+        os_ << "\n\n";
+      }
+    }
   }
 
   void showDeprecationMessage(const Decl* node, bool indentComment=true) {
@@ -1585,6 +1603,8 @@ struct RstResultBuilder {
     if (textOnly_) indentDepth_ --;
     showComment(m, textOnly_);
     showDeprecationMessage(m, false);
+    // TODO: Are we not printing these for modules?
+    // showUnstableWarning(m, false);
     if (textOnly_) indentDepth_ ++;
 
     visitChildren(m);

--- a/compiler/dyno/tools/chpldoc/version_num.h
+++ b/compiler/dyno/tools/chpldoc/version_num.h
@@ -1,0 +1,1 @@
+../../../main/version_num.h

--- a/compiler/include/arg.h
+++ b/compiler/include/arg.h
@@ -82,7 +82,7 @@ void usage(const ArgumentState* arg_state,
            bool                 printEnvHelp,
            bool                 printCurrentSettings);
 
-void init_args(ArgumentState* state, const char* argv0);
+void init_args(ArgumentState* state, const char* argv0, void* mainAddr);
 
 void init_arg_desc(ArgumentState* state, ArgumentDescription* arg_desc);
 

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -312,7 +312,7 @@ static void word_wrap_print(const char* text, int startCol, int endCol)
 *                                                                             *
 ************************************** | *************************************/
 
-void init_args(ArgumentState* state, const char* argv0) {
+void init_args(ArgumentState* state, const char* argv0, void* mainAddr) {
   char* name = strdup(argv0);
 
   if (char* firstSlash = strrchr(name, '/')) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1780,7 +1780,7 @@ int main(int argc, char* argv[]) {
 
     tracker.StartPhase("init");
 
-    init_args(&sArgState, argv[0]);
+    init_args(&sArgState, argv[0], (void*)main);
 
     fDocs   = (strncmp(sArgState.program_name, "chpldoc", 7)  == 0) ? true : false;
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1782,7 +1782,7 @@ int main(int argc, char* argv[]) {
 
     init_args(&sArgState, argv[0]);
 
-    fDocs   = (strcmp(sArgState.program_name, "chpldoc")  == 0) ? true : false;
+    fDocs   = (strncmp(sArgState.program_name, "chpldoc", 7)  == 0) ? true : false;
 
     // Initialize the arguments for argument state. If chpldoc, use the docs
     // specific arguments. Otherwise, use the regular arguments.

--- a/man/chpldoc.rst
+++ b/man/chpldoc.rst
@@ -64,6 +64,10 @@ reStructuredText as an intermediate format.
     Sets the documentation version to *projectversion*
     (documentation version defaults to '0.0.1' if unspecified).
 
+**\--legacy**
+
+    Use the legacy version of chpldoc
+
 **\--[no-]print-commands**
 
     Prints the system commands that **chpldoc** executes in order to create

--- a/test/chpldoc/functions/functionArgDefaultOneTuple.doc.good
+++ b/test/chpldoc/functions/functionArgDefaultOneTuple.doc.good
@@ -17,6 +17,12 @@ or
 
    import functionArgDefaultOneTuple.doc;
 
+.. data:: var x: int
+
+.. data:: var y: x.type
+
+.. data:: var z: y.type
+
 .. function:: proc tuple1Default(arg = (x,))
 
 .. function:: proc tuple2Default(arg = (x, y))

--- a/test/chpldoc/functions/functionArgDefaults.doc.good
+++ b/test/chpldoc/functions/functionArgDefaults.doc.good
@@ -27,7 +27,7 @@ or
 
    .. attribute:: var aField: int
 
-.. data:: var c: unmanaged nilable C
+.. data:: var c: unmanaged C?
 
 .. function:: proc noArgs()
 

--- a/test/chpldoc/functions/functionArgDefaults.doc.good
+++ b/test/chpldoc/functions/functionArgDefaults.doc.good
@@ -17,6 +17,12 @@ or
 
    import functionArgDefaults.doc;
 
+.. data:: var x: int
+
+.. data:: var y: x.type
+
+.. data:: var z: y.type
+
 .. class:: C
 
    .. attribute:: var aField: int

--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.bad
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.bad
@@ -77,7 +77,7 @@ or
 
    .. method:: proc type -(lhs: Foo, rhs: Foo)
 
-   .. method:: proc type <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+   .. method:: proc type <=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
    .. method:: proc type *=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.good
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.good
@@ -77,7 +77,7 @@ or
 
    .. method:: operator -(lhs: Foo, rhs: Foo)
 
-   .. method:: operator <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+   .. method:: operator <=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
    .. method:: operator *=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.bad
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.bad
@@ -91,7 +91,7 @@ or
 
 .. method:: proc type Foo.-(lhs: Foo, rhs: Foo)
 
-.. method:: proc type Foo.<=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+.. method:: proc type Foo.<=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
 .. method:: proc type Foo.*=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.good
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.good
@@ -91,7 +91,7 @@ or
 
 .. method:: operator Foo.-(lhs: Foo, rhs: Foo)
 
-.. method:: operator Foo.<=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+.. method:: operator Foo.<=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
 .. method:: operator Foo.*=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operators.doc.bad
+++ b/test/chpldoc/functions/operators.doc.bad
@@ -91,7 +91,7 @@ or
 
 .. function:: proc -(lhs: Foo, rhs: Foo)
 
-.. function:: proc <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+.. function:: proc <=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
 .. function:: proc *=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operators.doc.good
+++ b/test/chpldoc/functions/operators.doc.good
@@ -91,7 +91,7 @@ or
 
 .. function:: operator -(lhs: Foo, rhs: Foo)
 
-.. function:: operator <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+.. function:: operator <=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
 .. function:: operator *=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/globals/nilableFields.doc.catfiles
+++ b/test/chpldoc/globals/nilableFields.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/nilableFields.doc.rst

--- a/test/chpldoc/globals/nilableFields.doc.chpl
+++ b/test/chpldoc/globals/nilableFields.doc.chpl
@@ -1,0 +1,6 @@
+
+
+  record r {
+    var atomicVar : if hasABASupport then _ddata(_ABAInternal(objType?)) else atomic uint(64);
+    var _impl : unmanaged DistributedBagImpl(eltType)?;
+  }

--- a/test/chpldoc/globals/nilableFields.doc.good
+++ b/test/chpldoc/globals/nilableFields.doc.good
@@ -1,0 +1,25 @@
+.. default-domain:: chpl
+
+.. module:: nilableFields.doc
+
+nilableFields.doc
+=================
+**Usage**
+
+.. code-block:: chapel
+
+   use nilableFields.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import nilableFields.doc;
+
+.. record:: r
+
+   .. attribute:: var atomicVar: if hasABASupport then _ddata(_ABAInternal(objType?)) else atomic uint(64)
+
+   .. attribute:: var _impl: unmanaged DistributedBagImpl(eltType)?
+

--- a/test/chpldoc/globals/variableDefaultValues.doc.good
+++ b/test/chpldoc/globals/variableDefaultValues.doc.good
@@ -17,6 +17,12 @@ or
 
    import variableDefaultValues;
 
+.. data:: var x: int
+
+.. data:: var y: x.type
+
+.. data:: var z: y.type
+
 .. class:: C
 
    .. attribute:: var aField: int

--- a/test/chpldoc/globals/variableDefaultValues.doc.good
+++ b/test/chpldoc/globals/variableDefaultValues.doc.good
@@ -27,7 +27,7 @@ or
 
    .. attribute:: var aField: int
 
-.. data:: var c: unmanaged nilable C
+.. data:: var c: unmanaged C?
 
 .. data:: var literalDefault = 42
 
@@ -43,7 +43,7 @@ or
 
 .. data:: var notNilDefault = c!
 
-.. data:: var isNilDefault: nilable C = nil
+.. data:: var isNilDefault: C? = nil
 
 .. data:: var plusDefault = x + y
 

--- a/test/chpldoc/globals/variablePrecedence.doc.good
+++ b/test/chpldoc/globals/variablePrecedence.doc.good
@@ -17,6 +17,18 @@ or
 
    import variablePrecedence;
 
+.. data:: var a: int
+
+.. data:: var b: a.type
+
+.. data:: var c: b.type
+
+.. data:: var d: c.type
+
+.. data:: var e: d.type
+
+.. data:: var f: e.type
+
 .. data:: var pp = a + b + c
 
 .. data:: var Pp = a + b + c

--- a/test/chpldoc/types/fields/fieldDefaultValues.doc.good
+++ b/test/chpldoc/types/fields/fieldDefaultValues.doc.good
@@ -17,6 +17,12 @@ or
 
    import fieldDefaultValues;
 
+.. data:: var x: int
+
+.. data:: var y: x.type
+
+.. data:: var z: y.type
+
 .. class:: C
 
    .. attribute:: var aField: int

--- a/test/chpldoc/types/fields/fieldDefaultValues.doc.good
+++ b/test/chpldoc/types/fields/fieldDefaultValues.doc.good
@@ -27,7 +27,7 @@ or
 
    .. attribute:: var aField: int
 
-.. data:: var c: nilable C
+.. data:: var c: C?
 
 .. record:: R0
 
@@ -65,7 +65,7 @@ or
 
    .. attribute:: var notNilDefault = c!
 
-   .. attribute:: var isNilDefault: nilable C = nil
+   .. attribute:: var isNilDefault: C? = nil
 
    .. attribute:: var plusDefault = x + y
 

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
@@ -29,5 +29,6 @@ record D {
   var bounded1DDomainBy = {1..10 by 2};
   var bounded1DDomainByAlign = {1..10 by 2 align 1};
 
-
+  var lSrcVals: [myLocaleSpace] [0..#bufferSize] elemType;
+  var openHighBound: [myLocaleSpace] [0..<bufferSize] elemType;
 }

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.good
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.good
@@ -63,3 +63,7 @@ or
 
    .. attribute:: var bounded1DDomainByAlign = {1..10 by 2 align 1}
 
+   .. attribute:: var lSrcVals: [myLocaleSpace] [0..#bufferSize] elemType
+
+   .. attribute:: var openHighBound: [myLocaleSpace] [0..<bufferSize] elemType
+

--- a/test/compflags/thomasvandoren/chpldoc.doc.good
+++ b/test/compflags/thomasvandoren/chpldoc.doc.good
@@ -15,6 +15,7 @@ Documentation Options:
       --project-version <projectversion>
                                       Sets the documentation version to
                                       <projectversion>
+      --legacy                        Use the legacy version of chpldoc
       --[no-]print-commands           [Don't] print system commands
 
 Information Options:

--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 sphinx-rtd-theme==1.0.0
-sphinxcontrib-chapeldomain==0.0.22
+sphinxcontrib-chapeldomain==0.0.23
 breathe==4.31.0


### PR DESCRIPTION
This PR makes `dyno-chpldoc` the default docs generation tool and renames
existing `chpldoc` to `chpldoc-legacy`. Previous functionality can be accessed
by passing the `--legacy` flag to `chpldoc` or by running `chpldoc-legacy` 
rather than `chpldoc`

To get `chpldoc` replaced, while maintaining the ability for a user in the 
field to access the previous binary, a new symlink `chpldoc-legacy` is created
from the `Makefile` target for `chpldoc`. This target is also set to depend on
the `dyno-chpldoc` target so that it will rebuild after the source files are
changed.

Caveat: If a user tries to use a flag that's no longer supported with 
the `--legacy` flag, it will fail because `dyno-chpldoc` doesn't recognize
the unsupported flag. The work-around is to use `chpldoc-legacy` instead 
of `chpldoc --legacy`. 

List of dropped flags:
* debugger flags: `--lldb`, `--gdb` Rationale: we may add support back in 
  later, but this requires non-trivial amount of work to support. 
  Recommend `lldb chpldoc` or `gdb chpldoc` as work-arounds in the interim. 
* break flags: `--break-on-id`, `--break-on-remove-id` Rationale: the uAST we 
  create isn't converted to AST, so there are no IDs to break on like before.
* developer flag: `--devel` Rationale: this appeared to have no actual effect 
  on the docs build.
 

This change required updates to many `.good` files for three reasons:

1. previous version of chpldoc did not properly handle all multi-decls, leaving
   some out of the docs.
2. previous version of chpldoc printed range high bound `1..<10` replacing the
   `<` operator with the signature of the internal `chpl__` function call.
3. previous version of chpldoc printed word `nilable` in front of identifiers 
   when a postfix `?` should have been placed instead.


The `sphinxcontrib-chapeldomain` version is bumped from `0.0.22` to `0.0.23`
to force the version that supports the `op` role for links in the docs.

Adds use of `LLVM`'s `getMainExecutable` to lookup path of running executable.


TESTING:

- [x] `paratest`
- [x] `test/chpldoc`
      `[Summary: #Successes = 163 | #Failures = 0 | #Futures = 0]`   
- [x] `test/chpldoc` with `--legacy` flag 
      `[Summary: #Successes = 156 | #Failures = 7 | #Futures = 0]`
      
<details>

<summary>expected failures based on new tests/updated `.good` files</summary>

```
< .. data:: var x: int
< .. data:: var y: x.type
< .. data:: var z: y.type
[Error matching compiler output for chpldoc/functions/functionArgDefaultOneTuple.doc]

< .. data:: var x: int
< .. data:: var y: x.type
< .. data:: var z: y.type
< .. data:: var c: unmanaged C?
---
> .. data:: var c: unmanaged nilable C
[Error matching compiler output for chpldoc/functions/functionArgDefaults.doc]

<    .. attribute:: var atomicVar: if hasABASupport then _ddata(_ABAInternal(objType?)) else atomic uint(64)
---
>    .. attribute:: var atomicVar: if hasABASupport then _ddata(_ABAInternal(nilable objType)) else atomic uint(64)
<    .. attribute:: var _impl: unmanaged DistributedBagImpl(eltType)?
---
>    .. attribute:: var _impl: unmanaged nilable DistributedBagImpl(eltType)
[Error matching compiler output for chpldoc/globals/nilableFields.doc]

< .. data:: var x: int
< .. data:: var y: x.type
< .. data:: var z: y.type
< .. data:: var c: unmanaged C?
---
> .. data:: var c: unmanaged nilable C
< .. data:: var isNilDefault: C? = nil
---
> .. data:: var isNilDefault: nilable C = nil
[Error matching compiler output for chpldoc/globals/variableDefaultValues.doc]

< .. data:: var a: int
< .. data:: var b: a.type
< .. data:: var c: b.type
< .. data:: var d: c.type
< .. data:: var e: d.type
< .. data:: var f: e.type
[Error matching compiler output for chpldoc/globals/variablePrecedence.doc]

< .. data:: var x: int
< .. data:: var y: x.type
< .. data:: var z: y.type
< .. data:: var c: C?
---
> .. data:: var c: nilable C
<    .. attribute:: var isNilDefault: C? = nil
---
>    .. attribute:: var isNilDefault: nilable C = nil
[Error matching compiler output for chpldoc/types/fields/fieldDefaultValues.doc]

<    .. attribute:: var openHighBound: [myLocaleSpace] [0..<bufferSize] elemType
---
>    .. attribute:: var openHighBound: [myLocaleSpace] [0..chpl__nudgeHighBound(bufferSize)] elemType
[Error matching compiler output for chpldoc/types/fields/rangesAndDomains.doc]

``` 

</details>
  
- [x] built and compared Chapel docs using old and new `chpldoc` tool
      diffs listed:

<details>

<summary>
file diffs for Chapel's documentation listed below
</summary>

<details>
  <summary>ChapelSyncvar.rst includes operators that were not showing in old chpldocs</summary>

```
.. function:: operator = (ref lhs: sync(?t), rhs: t)
.. function:: operator :(from, type t: sync)
.. function:: operator :(from: sync, type toType: sync)
.. warning::
Casting sync variables is deprecated
.. function:: operator +=(ref lhs: sync(?t), rhs: t)
.. function:: operator -=(ref lhs: sync(?t), rhs: t)
.. function:: operator *=(ref lhs: sync(?t), rhs: t)
.. function:: operator /=(ref lhs: sync(?t), rhs: t)
.. function:: operator %=(ref lhs: sync(?t), rhs: t)
.. function:: operator **=(ref lhs: sync(?t), rhs: t)
.. function:: operator &=(ref lhs: sync(?t), rhs: t)
.. function:: operator |=(ref lhs: sync(?t), rhs: t)
.. function:: operator ^=(ref lhs: sync(?t), rhs: t)
.. function:: operator >>=(ref lhs: sync(?t), rhs: t)
.. function:: operator <<=(ref lhs: sync(?t), rhs: t)
.. function:: operator <=>(lhs: sync, ref rhs)
.. function:: operator <=>(ref lhs, rhs: sync)
.. function:: operator <=>(lhs: sync, rhs: sync)

.. function:: operator = (ref lhs: single(?t), rhs: t)
.. function:: operator :(from, type t: single)
.. function:: operator :(from: single, type toType: single)
.. warning::
Casting single variables is deprecated
```

</details>


<details>
  <summary>ChapelTuple.rst includes operators that were not showing in old chpldocs</summary>

```
.. function:: operator *(param p: int, type t) type
.. function:: operator *(type t, param p: int)
.. function:: operator *(p: integral, type t) type
.. function:: operator = (ref x: _tuple, y: _tuple)
.. function:: operator :(x: (?, ?), type t: complex(64))
.. function:: operator :(x: (?, ?), type t: complex(128))
.. function:: operator :(x: _tuple, type t: _tuple)
.. function:: operator +(a: _tuple)
.. function:: operator -(a: _tuple)
.. function:: operator ~(a: _tuple)
.. function:: operator !(a: _tuple)

.. function:: operator +(a: _tuple, b: _tuple)
.. function:: operator +(a: _tuple, b: _tuple)
.. function:: operator -(a: _tuple, b: _tuple)
.. function:: operator -(a: _tuple, b: _tuple)
.. function:: operator *(a: _tuple, b: _tuple)
.. function:: operator *(a: _tuple, b: _tuple)
.. function:: operator /(a: _tuple, b: _tuple)
.. function:: operator /(a: _tuple, b: _tuple)
.. function:: operator %(a: _tuple, b: _tuple)
.. function:: operator %(a: _tuple, b: _tuple)
.. function:: operator **(a: _tuple, b: _tuple)
.. function:: operator **(a: _tuple, b: _tuple)
.. function:: operator &(a: _tuple, b: _tuple)
.. function:: operator &(a: _tuple, b: _tuple)
.. function:: operator |(a: _tuple, b: _tuple)
.. function:: operator |(a: _tuple, b: _tuple)
.. function:: operator ^(a: _tuple, b: _tuple)
.. function:: operator ^(a: _tuple, b: _tuple)
.. function:: operator <<(a: _tuple, b: _tuple)
.. function:: operator <<(a: _tuple, b: _tuple)
.. function:: operator >>(a: _tuple, b: _tuple)
.. function:: operator >>(a: _tuple, b: _tuple)
.. function:: operator >(a: _tuple, b: _tuple)
.. function:: operator >=(a: _tuple, b: _tuple)
.. function:: operator <(a: _tuple, b: _tuple)
.. function:: operator <=(a: _tuple, b: _tuple)
.. function:: operator ==(a: _tuple, b: _tuple)
.. function:: operator !=(a: _tuple, b: _tuple)
.. function:: operator +(x: _tuple, y: x(0).type)
.. function:: operator +(x: ?t, y: _tuple)
.. function:: operator -(x: _tuple, y: x(0).type)
.. function:: operator -(x: ?t, y: _tuple)
.. function:: operator *(x: _tuple, y: x(0).type)
.. function:: operator *(x: ?t, y: _tuple)
.. function:: operator /(x: _tuple, y: x(0).type)
.. function:: operator /(x: ?t, y: _tuple)
.. function:: operator %(x: _tuple, y: x(0).type)
.. function:: operator %(x: ?t, y: _tuple)
.. function:: operator **(x: _tuple, y: x(0).type)
.. function:: operator **(x: ?t, y: _tuple)
.. function:: operator &(x: _tuple, y: x(0).type)
.. function:: operator &(x: ?t, y: _tuple)
.. function:: operator |(x: _tuple, y: x(0).type)
.. function:: operator |(x: ?t, y: _tuple)
.. function:: operator ^(x: _tuple, y: x(0).type)
.. function:: operator ^(x: ?t, y: _tuple)
.. function:: operator <<(x: _tuple, y: x(0).type)
.. function:: operator <<(x: ?t, y: _tuple)
.. function:: operator >>(x: _tuple, y: x(0).type)
.. function:: operator >>(x: ?t, y: _tuple)
```
</details>

<details>
  <summary>AtomicOjbects.rst change from nilable objType to objType?</summary>

```
.. attribute:: var atomicVar: if hasABASupport then _ddata(_ABAInternal(nilable objType)) else atomic uint(64)
.. attribute:: var atomicVar: if hasABASupport then _ddata(_ABAInternal(objType?)) else atomic uint(64)
```
</details>

<details>
<summary>DistributedBag.rst change from nilabe thing to thing?</summary>

```
.. attribute:: var _impl: unmanaged nilable DistributedBagImpl(eltType)
.. attribute:: var _impl: unmanaged DistributedBagImpl(eltType)?
```

</details>

<details>
<summary>DistributedDequeu.rst change from nilable thing to thing?</summary>

```
.. attribute:: var _impl: unmanaged nilable DistributedDequeImpl(eltType)
.. attribute:: var _impl: unmanaged DistributedDequeImpl(eltType)?
```

</details>

<details>
<summary>LockFreeQueue.rst change from nilable thing to thing?</summary>

```
.. attribute:: var next: AtomicObject(unmanaged nilable Node(eltType), hasGlobalSupport = true, hasABASupport = false)
.. attribute:: var next: AtomicObject(unmanaged Node(eltType)?, hasGlobalSupport = true, hasABASupport = false)
```

</details>

<details>
<summary>LockFreeStack.rst change from nilable thing to thing?</summary>

```
.. attribute:: var next: unmanaged nilable Node(eltType)
.. attribute:: var next: unmanaged Node(eltType)?

.. attribute:: var _top: AtomicObject(unmanaged nilable Node(objType), hasGlobalSupport = true, hasABASupport = false)
.. attribute:: var _top: AtomicObject(unmanaged Node(objType)?, hasGlobalSupport = true, hasABASupport = false)
```

</details>

<details>
<summary>TomlParser.rst change from nilable thing to thing?</summary>

```
.. method:: proc set(tbl: string, A: [?D] shared nilable Toml)
.. method:: proc set(tbl: string, A: [?D] shared Toml?)

.. method:: proc set(tbl: string, arr: [?dom] shared nilable Toml)
.. method:: proc set(tbl: string, arr: [?dom] shared Toml?)
```

</details>

<details>
<summary>C_HDF5.rst change from hex printing as int to hex literal</summary>

```
.. data:: param H5F_ACC_RDONLY = 0: c_uint
.. data:: param H5F_ACC_RDONLY = 0x0000: c_uint

.. data:: param H5F_ACC_RDWR = 1: c_uint
.. data:: param H5F_ACC_RDWR = 0x0001: c_uint

.. data:: param H5F_ACC_TRUNC = 2: c_uint
.. data:: param H5F_ACC_TRUNC = 0x0002: c_uint

.. data:: param H5F_ACC_EXCL = 4: c_uint
.. data:: param H5F_ACC_EXCL = 0x0004: c_uint

.. data:: param H5F_ACC_CREAT = 16: c_uint
.. data:: param H5F_ACC_CREAT = 0x0010: c_uint

.. data:: param H5F_ACC_SWMR_WRITE = 32: c_uint
.. data:: param H5F_ACC_SWMR_WRITE = 0x0020: c_uint

.. data:: param H5F_ACC_SWMR_READ = 64: c_uint
.. data:: param H5F_ACC_SWMR_READ = 0x0040: c_uint

.. data:: param H5F_ACC_DEFAULT = 65535: c_uint
.. data:: param H5F_ACC_DEFAULT = 0xffff: c_uint


.. data:: param H5F_OBJ_FILE = 1: c_uint
.. data:: param H5F_OBJ_FILE = 0x0001: c_uint

.. data:: param H5F_OBJ_DATASET = 2: c_uint
.. data:: param H5F_OBJ_DATASET = 0x0002: c_uint

.. data:: param H5F_OBJ_GROUP = 4: c_uint
.. data:: param H5F_OBJ_GROUP = 0x0004: c_uint

.. data:: param H5F_OBJ_DATATYPE = 8: c_uint
.. data:: param H5F_OBJ_DATATYPE = 0x0008: c_uint

.. data:: param H5F_OBJ_ATTR = 16: c_uint
.. data:: param H5F_OBJ_ATTR = 0x0010: c_uint

.. data:: param H5F_OBJ_LOCAL = 32: c_uint
.. data:: param H5F_OBJ_LOCAL = 0x0020: c_uint

.. data:: param H5P_CRT_ORDER_TRACKED = 1: c_int
.. data:: param H5P_CRT_ORDER_TRACKED = 0x0001: c_int

.. data:: param H5P_CRT_ORDER_INDEXED = 2: c_int
.. data:: param H5P_CRT_ORDER_INDEXED = 0x0002: c_int
```

</details>

<details>
<summary>IO.rst hex literals rather than int representation</summary>

```
.. enum:: enum iostringstyle { len1b_data = -1, len2b_data = -2, len4b_data = -4, len8b_data = -8, lenVb_data = -10, data_toeof = -65280, data_null = -256 }
.. enum:: enum iostringstyle { len1b_data = -1, len2b_data = -2, len4b_data = -4, len8b_data = -8, lenVb_data = -10, data_toeof = -0xff00, data_null = -0x0100 }
```

</details>

<details>
<summary>AutoMath.rst many more significant digits vs. chpldoc</summary>

```
.. data:: param e = 2.71828
.. data:: param e = 2.7182818284590452354

.. data:: param log2_e = 1.4427
.. data:: param log2_e = 1.4426950408889634074

.. data:: param log10_e = 0.434294
.. data:: param log10_e = 0.43429448190325182765

.. data:: param ln_2 = 0.693147
.. data:: param ln_2 = 0.69314718055994530942

.. data:: param ln_10 = 2.30259
.. data:: param ln_10 = 2.30258509299404568402

.. data:: param pi = 3.14159
.. data:: param pi = 3.14159265358979323846

.. data:: param half_pi = 1.5708
.. data:: param half_pi = 1.57079632679489661923

.. data:: param quarter_pi = 0.785398
.. data:: param quarter_pi = 0.78539816339744830962

.. data:: param recipr_pi = 0.31831
.. data:: param recipr_pi = 0.31830988618379067154

.. data:: param twice_recipr_pi = 0.63662
.. data:: param twice_recipr_pi = 0.63661977236758134308

.. data:: param twice_recipr_sqrt_pi = 1.12838
.. data:: param twice_recipr_sqrt_pi = 1.12837916709551257390

.. data:: param sqrt_2 = 1.41421
.. data:: param sqrt_2 = 1.41421356237309504880

.. data:: param recipr_sqrt_2 = 0.707107
.. data:: param recipr_sqrt_2 = 0.70710678118654752440
```

</details>

<details>

<summary>FileSystem.rst octal literal prints instead of int representation</summary>

```
.. function:: proc mkdir(name: string, mode: int = 511, parents: bool = false) throws
.. function:: proc mkdir(name: string, mode: int = 0o777, parents: bool = false) throws
```

</details>

<details>
<summary>Socket.rst - additional space after op symbol</summary>

```
.. method:: operator =(in other: ipAddr)
.. method:: operator = (in other: ipAddr)
```

</details>

<details>
<summary>Random.rst spaces around ==</summary>

``` 
.. type:: type RandomStream = if defaultRNG==RNG.PCG then PCGRandomStream else NPBRandomStream
.. type:: type RandomStream = if defaultRNG == RNG.PCG then PCGRandomStream else NPBRandomStream
```

</details>

<details>
<summary>NPBRandom.rst new consts from multi-decl visible now</summary>

```
.. data:: const r23 = 0.5**23
.. data:: const t23 = 2.0**23
.. data:: const r46 = 0.5**46
.. data:: const t46 = 2.0**46
.. data:: const arand = 1220703125.0
```

</details>

<details>
<summary>Memory/Diagnostics.rst adds Memory. to example use/import in docs</summary>

```
use Diagnostics;
use Memory.Diagnostics;

import Diagnostics;
import Memory.Diagnostics;
```

</details>

<details>
<summary>Memory/Initialization.rst adds Memory. to example use/import in docs</summary>

```
use Initialization;
use Memory.Initialization;

import Initialization;
import Memory.Initialization;
```
</details>


</details>


- [x] built and compared Arkouda docs using old and new `chpldoc` tool
      diffs listed:

<details>

<summary>
file diffs for Arkouda's documentation listed below
</summary>

Filenames with diffs and explanation of the diff is followed by `chpldoc` output and then `dyno-chpldoc` output on the line below.

#### CommAggregation.rst - combination of improvements (not printing internal names, quoting string literals)
```
.. attribute:: const myLocaleSpace = 0..chpl__nudgeHighBound(numLocales)
.. attribute:: const myLocaleSpace = 0..<numLocales

.. data:: param defaultBuffSize = if CHPL_COMM == ugni then 4096 else 8192
.. data:: param defaultBuffSize = if CHPL_COMM == "ugni" then 4096 else 8192
```

#### Logging.rst - stop printing internal method name, probably an improvement.
```
.. attribute:: var warnLevels = new set(LogLevel, chpl__buildArrayExpr(LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG))
.. attribute:: var warnLevels = new set(LogLevel, [LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG])

.. attribute:: var criticalLevels = new set(LogLevel, chpl__buildArrayExpr(LogLevel.CRITICAL, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG))
.. attribute:: var criticalLevels = new set(LogLevel, [LogLevel.CRITICAL, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG])

.. attribute:: var errorLevels = new set(LogLevel, chpl__buildArrayExpr(LogLevel.ERROR, LogLevel.CRITICAL, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG))
.. attribute:: var errorLevels = new set(LogLevel, [LogLevel.ERROR, LogLevel.CRITICAL, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG])

.. attribute:: var infoLevels = new set(LogLevel, chpl__buildArrayExpr(LogLevel.INFO, LogLevel.DEBUG))
.. attribute:: var infoLevels = new set(LogLevel, [LogLevel.INFO, LogLevel.DEBUG])
```

#### MetricsMsg.rst - these are string literals in code, probably an improvement
```
.. data:: var metricScope = ServerConfig.getEnv(name = METRIC_SCOPE, default = MetricScope.REQUEST)
.. data:: var metricScope = ServerConfig.getEnv(name = "METRIC_SCOPE", default = "MetricScope.REQUEST")
```

#### MultiTypeSymbolTable.rst - these are string literals in code, probably an improvement.
```
.. attribute:: var serverid = id_ + generateToken(8) + _
.. attribute:: var serverid = "id_" + generateToken(8) + "_"
```

#### SegStringSort.rst - internal method name no longer printed - probably an improvement
```
.. method:: proc keyPart(chpl__tuple_arg_temp1: (string, int), in i: int)
.. method:: proc keyPart((a0, _): (string, int), in i: int)
```

#### SegmentedString.rst - Expected change now that operator prints as intended
```
.. function:: proc ==(lss: SegString, rss: SegString) throws
.. function:: operator ==(lss: SegString, rss: SegString) throws
```

#### ServerConfig.rst - This is a string literal in code, probably an improvement
```
.. data:: const QCQ = Q + : + Q
.. data:: const QCQ = Q + ":" + Q
```

#### SipHash.rst - extra space printing before : (innocuous)
```
.. data:: const defaultSipHashKey: [0..#16] uint(8) = for i in 0.. # 16 do i: uint(8)
.. data:: const defaultSipHashKey: [0..#16] uint(8) = for i in 0.. # 16 do i : uint(8)
```



</details>

Reviewed by @mppf - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>