### PR TITLE
Update versions of three python packages we rely on now

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements1.txt
+++ b/third-party/chpl-venv/chpldoc-requirements1.txt
@@ -1,2 +1,2 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
-MarkupSafe==2.0.1
+MarkupSafe==2.1.1

--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -1,5 +1,5 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
-Jinja2==3.0.3
+Jinja2==3.1.2
 Pygments==2.12.0
 Sphinx==4.5.0
 docutils==0.16.0

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.0
-filelock==3.4.1
+filelock==3.7.1
 argcomplete==2.0.0
 setuptools==54.0.0


### PR DESCRIPTION
Our testing system is now no longer relying on the deprecated Python 3.6,
enabling us to use newer versions of these packages which drop support
for that version of Python.

This PR updates:
- filelock from 3.4.1 to 3.7.1
- MarkupSafe from 2.0.1 to 2.1.1
- Jinja2 from 3.0.3 to 3.1.2

It does not update:
- setuptools, due to encountering a bug when processing the skipif for
test/studies/dedup/dedup_externblock.chpl
- docutils because sphinx-rtd-theme has not been updated to be compatible
with it
- Sphinx because later versions require a more up-to-date version of breathe
- breathe because later versions generate warnings that we treat as error, a
known issue.
- PyYAML, argcomplete, Pygments and Babel because they were up to date
in July.

Spot checked some files in the generated documentation and ran a full
paratest with futures.