### PR TITLE
Add output of python3 version information to common.bash instead

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -32,6 +32,9 @@ fi
 log_info "gcc version: $(which gcc)"
 gcc --version
 
+log_info "python3 version: $(which python3)"
+python3 --version
+
 SCRIPT_NAME=$0
 start_time=$(date '+%s')
 log_info "Starting ${SCRIPT_NAME} on $(hostname -s)"


### PR DESCRIPTION
At Elliot's suggestion

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>