### PR TITLE
Mark array sorted, reverse, find, and count @unstable

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1590,7 +1590,7 @@ module ChapelArray {
     }
 
     /* Yield the array elements in sorted order. */
-    deprecated "'Array.sorted' is deprecated, use 'Sort.sorted' instead"
+    @unstable "'Array.sorted' is unstable"
     iter sorted(comparator:?t = chpl_defaultComparator()) {
       if Reflection.canResolveMethod(_value, "dsiSorted", comparator) {
         for i in _value.dsiSorted(comparator) {
@@ -1722,7 +1722,7 @@ module ChapelArray {
     }
 
     /* Reverse the order of the values in the array. */
-    deprecated "'Array.reverse' is deprecated"
+    @unstable "'Array.reverse' is unstable"
     proc reverse() {
       if (!chpl__isDense1DArray()) then
         compilerError("reverse() is only supported on dense 1D arrays");
@@ -1738,7 +1738,7 @@ module ChapelArray {
        instance of ``val`` in the array, or if ``val`` is not found, a
        tuple containing ``false`` and an unspecified value is returned.
      */
-     deprecated "'Array.find' is deprecated, use a reduction like 'maxloc reduce zip(A == val, A.domain)' instead"
+     @unstable "'Array.find' is unstable"
      proc find(val: this.eltType): (bool, index(this.domain)) {
       for i in this.domain {
         if this[i] == val then return (true, i);
@@ -1748,7 +1748,7 @@ module ChapelArray {
     }
 
     /* Return the number of times ``val`` occurs in the array. */
-    deprecated "'Array.count' is deprecated use a reduction like '+ reduce (A == val)' instead"
+    @unstable "'Array.count' is unstable"
     proc count(val: this.eltType): int {
       return + reduce (this == val);
     }

--- a/test/deprecated/deprecatedArrayFunctions.chpl
+++ b/test/deprecated/deprecatedArrayFunctions.chpl
@@ -1,6 +1,0 @@
-var A = [1, 2, 1, 3, 1, 4, 1, 5];
-writeln("Count of 1's in A = ", A.count(1));
-writeln("A sorted is = ", A.sorted());
-writeln("Finding 3 in A = ", A.find(3));
-A.reverse();
-writeln("Reversing A: ", A);

--- a/test/deprecated/deprecatedArrayFunctions.good
+++ b/test/deprecated/deprecatedArrayFunctions.good
@@ -1,8 +1,0 @@
-deprecatedArrayFunctions.chpl:2: warning: 'Array.count' is deprecated use a reduction like '+ reduce (A == val)' instead
-deprecatedArrayFunctions.chpl:3: warning: 'Array.sorted' is deprecated, use 'Sort.sorted' instead
-deprecatedArrayFunctions.chpl:4: warning: 'Array.find' is deprecated, use a reduction like 'maxloc reduce zip(A == val, A.domain)' instead
-deprecatedArrayFunctions.chpl:5: warning: 'Array.reverse' is deprecated
-Count of 1's in A = 4
-A sorted is = 1 1 1 1 2 3 4 5
-Finding 3 in A = (true, 3)
-Reversing A: 5 1 4 1 3 1 2 1

--- a/test/unstable/arrayFuncs.chpl
+++ b/test/unstable/arrayFuncs.chpl
@@ -1,5 +1,5 @@
-// We were considering deprecating these but have since pulled back the the
-// change and marked them unstable (going forward we might decide to continue
+// We were considering deprecating these but have since pulled back the change
+// and marked them unstable (going forward we might decide to continue
 // deprecating these or moving them to another module or keeping them on the
 // array)
 

--- a/test/unstable/arrayFuncs.chpl
+++ b/test/unstable/arrayFuncs.chpl
@@ -1,0 +1,11 @@
+// We were considering deprecating these but have since pulled back the the
+// change and marked them unstable (going forward we might decide to continue
+// deprecating these or moving them to another module or keeping them on the
+// array)
+
+var A = [1, 2, 1, 3, 1, 4, 1, 5];
+writeln("Count of 1's in A = ", A.count(1));
+writeln("A sorted is = ", A.sorted());
+writeln("Finding 3 in A = ", A.find(3));
+A.reverse();
+writeln("Reversing A: ", A);

--- a/test/unstable/arrayFuncs.good
+++ b/test/unstable/arrayFuncs.good
@@ -1,0 +1,8 @@
+arrayFuncs.chpl:7: warning: 'Array.count' is unstable
+arrayFuncs.chpl:8: warning: 'Array.sorted' is unstable
+arrayFuncs.chpl:9: warning: 'Array.find' is unstable
+arrayFuncs.chpl:10: warning: 'Array.reverse' is unstable
+Count of 1's in A = 4
+A sorted is = 1 1 1 1 2 3 4 5
+Finding 3 in A = (true, 3)
+Reversing A: 5 1 4 1 3 1 2 1


### PR DESCRIPTION
Earlier I jumped the gun on making these deprecated in this PR: https://github.com/chapel-lang/chapel/pull/20140

The backing issue for that is here: https://github.com/chapel-lang/chapel/issues/18089

Given that we don't have consensus on what to do with these functions and we're approaching code freeze marking them "unstable" for now seems like the sensible thing to do. This isn't to imply things will be left as `@unstable`: we need to make a decision for Chapel 2.0 but I think it can wait until next release.

Arguably since these are no longer deprecated I should also pull back the test changes I made in the original PR (https://github.com/chapel-lang/chapel/pull/20140) but I think it's unlikely anything that these would have regressed and the "unstable" test I'm adding provides a little bit of test coverage (famous last words).

If the lack of test coverage makes you uncomfortable let me know and I can revert those test change as well.

@bradcray and @lydia-duncan would one (or both) of you mind doing a quick review of this PR?