### PR TITLE
Add forall-iterator-throws-at-end.skipif

### DIFF
--- a/test/errhandling/parallel/forall-iterator-throws-at-end.skipif
+++ b/test/errhandling/parallel/forall-iterator-throws-at-end.skipif
@@ -1,0 +1,6 @@
+# throwing from non-inlined iterators not yet supported
+#
+# baseline makes the iterators not inlined; this code
+# pattern isn't supported yet.
+
+COMPOPTS <= --baseline


### PR DESCRIPTION
`forall-iterator-throws-at-end.chpl` behaves the same way as `forall-iterator-throws-follower.chpl` -- both tests cause the error: "throwing non-inlined iterators are not yet supported".

The latter test is skipif-ed in --baseline testing. This PR adds an identical skipif to the former. This skipif should have been there from the beginning.

Suggested by @bradcray