### PR TITLE
Link LLVM and clang dynamically on Mac OS X

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -876,7 +876,7 @@ def get_host_link_args():
         # that by using static linking.
         llvm_version = get_llvm_version()
         host_platform = chpl_platform.get('host')
-        if host_platform == 'darwin' and int(llvm_version) <= 11:
+        if host_platform == 'darwin' and llvm_version == '11':
             llvm_dynamic = False
 
         # Also, change to static, if llvm-config indicates static linking

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -870,15 +870,17 @@ def get_host_link_args():
                 # and -Wl,-syslibroot seems to have no effect
                 system.append("-L" + os.path.join(sdkroot, "usr", "lib"))
 
-        # Decide whether to try to link statically or dynamically.
-        # Future work: consider using 'llvm-config --shared-mode'
-        # to make this choice.
+
+        # For LLVM version 11 and older, there was a problem where
+        # 'llvm-config' did not work properly on Mac OS X, so work around
+        # that by using static linking.
+        llvm_version = get_llvm_version()
         host_platform = chpl_platform.get('host')
-        if host_platform == 'darwin':
+        if host_platform == 'darwin' and int(llvm_version) <= 11:
             llvm_dynamic = False
 
+        # Also, change to static, if llvm-config indicates static linking
         shared_mode = run_command([llvm_config, '--shared-mode'])
-
         if shared_mode.strip() == 'static':
             llvm_dynamic = False
 


### PR DESCRIPTION
This PR adjusts the chplenv scripts so that `chpl` builds on Mac OS X with system LLVM will link LLVM and Clang dynamically. That makes Mac OS X less of an exception in this regard.

We were originally statically linking on Mac OS X with system LLVM due to problems with upstream LLVM and Homebrew in building a dynamic library that works with `llvm-config` (in particular, there were errors about a versioned file, like `libLLVM-11.dylib`, missing). See [this LLVM bug report](https://github.com/llvm/llvm-project/issues/39599). However this should be fixed in Homebrew llvm@12 and newer.

Note that we are currently still statically linking for CHPL_LLVM=bundled.

Future Work:
 * I observed a problem CHPL_LLVM=none and llvm@11 on Monterey, but this problem exists also on 'main', and this PR does not make it worse.

Reviewed by @ronawho - thanks!

### Testing CHPL_LLVM=system `make check` with OS or Homebrew LLVM versions

* note: Homebrew docs say "10.15 or higher is recommended while 10.11-10.14 are supported on a best-effort basis". So, I only tested 10.15 and newer here.

#### Mac OS X 10.15 "Catalina"
- [x] llvm@11
 
#### Mac OS X 11 "Big Sur"
- [x] llvm@11
- [x] llvm@12
- [x] llvm@13
- [x] llvm (14)

#### Mac OS X 12 "Monterey"
- [x] llvm@11
- [x] llvm@12
- [x] llvm@13
- [x] llvm (14)