### PR TITLE
Improvements to `locale.runningTasks` docs

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -281,24 +281,16 @@ module ChapelLocale {
   /*
     Get the number of tasks running on this locale.
 
+    This method is intended to guide task creation during a parallel
+    section. If the number of running tasks is greater than or equal
+    to the locale's maximum task parallelism (queried via maxTaskPar),
+    then creating more tasks is unlikely to decrease walltime.
+
     :returns: the number of tasks that have begun executing, but have not yet finished
     :rtype: `int`
 
     Note that this number can exceed the number of non-idle threads
-    because there are cases in which a thread is working on more than
-    one task. As one example, in fifo tasking, when a parent task
-    creates child tasks to execute the iterations of a coforall
-    construct, the thread the parent is running on may temporarily
-    suspend executing the parent task in order to help with the child
-    tasks, until the construct completes. When this occurs the count
-    of running tasks can include both the parent task and a child,
-    although strictly speaking only the child is executing
-    instructions.
-
-    As another example, any tasking implementation in which threads
-    can switch from running one task to running another, such as
-    qthreads, can have more tasks running than threads on which to run
-    them.
+    because there are cases in which a thread is working on more than one task.
   */
   pragma "fn synchronization free"
   proc locale.runningTasks(): int {

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -283,14 +283,11 @@ module ChapelLocale {
 
     This method is intended to guide task creation during a parallel
     section. If the number of running tasks is greater than or equal
-    to the locale's maximum task parallelism (queried via maxTaskPar),
+    to the locale's maximum task parallelism (queried via :proc:`locale.maxTaskPar`),
     then creating more tasks is unlikely to decrease walltime.
 
     :returns: the number of tasks that have begun executing, but have not yet finished
     :rtype: `int`
-
-    Note that this number can exceed the number of non-idle threads
-    because there are cases in which a thread is working on more than one task.
   */
   pragma "fn synchronization free"
   proc locale.runningTasks(): int {


### PR DESCRIPTION
Implementing the changes to `runningTasks`' documentation discussed here: https://github.com/chapel-lang/chapel/issues/20219

The general goal is to explain the purpose of the method without locking it into a particular definition of "currently-running", as the implementation may be slightly changed/improved in the future. 


