### PR TITLE
Update Python 3.6 job to not use start_test or chpldoc any more

### DIFF
--- a/util/cron/test-linux64-python36.bash
+++ b/util/cron/test-linux64-python36.bash
@@ -10,4 +10,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python36"
 
 set_python_version "3.6"
 
-$CWD/nightly -cron -hellos ${nightly_args}
+$CWD/nightly -cron -pythonDep ${nightly_args}


### PR DESCRIPTION
Now that those tools are relying on python packages that have dropped support
for 3.6, this configuration is no longer expected to work with them.  So have
it behave like the Python 3.5 job

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>