### PR TITLE
Fix test errors in minimal-modules and print-init-order tests

### DIFF
--- a/modules/minimal/internal/IO.chpl
+++ b/modules/minimal/internal/IO.chpl
@@ -20,7 +20,7 @@
 
 module IO {
 
-  extern type errorCode;
+  extern "syserr" type errorCode;
   extern type qio_channel_ptr_t;
   private extern proc qio_int_to_err(a:int(32)):errorCode;
   extern type c_void_ptr = chpl__c_void_ptr;

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -31,15 +31,15 @@ end of module search dirs
   $CHPL_HOME/modules/standard/Types.chpl
   $CHPL_HOME/modules/standard/AutoMath.chpl
   $CHPL_HOME/modules/standard/CommDiagnostics.chpl
-  $CHPL_HOME/modules/standard/SysBasic.chpl
+  $CHPL_HOME/modules/standard/OS.chpl
   $CHPL_HOME/modules/dists/DSIUtil.chpl
   $CHPL_HOME/modules/standard/IO.chpl
-  $CHPL_HOME/modules/standard/OS.chpl
   $CHPL_HOME/modules/packages/RangeChunk.chpl
   $CHPL_HOME/modules/packages/Sort.chpl
   $CHPL_HOME/modules/packages/Search.chpl
   $CHPL_HOME/modules/packages/CopyAggregation.chpl
   $CHPL_HOME/modules/standard/Communication.chpl
+  $CHPL_HOME/modules/standard/SysBasic.chpl
   $CHPL_HOME/modules/standard/Regex.chpl
   $CHPL_HOME/modules/standard/List.chpl
   $CHPL_HOME/modules/standard/Random.chpl

--- a/test/trivial/diten/printvisibleOptFalse.good
+++ b/test/trivial/diten/printvisibleOptFalse.good
@@ -19,7 +19,7 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/ChapelUtil.chpl:43: chpl_libraryModuleLevelCleanup
   modules/minimal/internal/ChapelUtil.chpl:46: chpl_addModule
   modules/minimal/internal/ChapelUtil.chpl:48: chpl_deinitModules
-  modules/minimal/internal/IO.chpl:23: syserr
+  modules/minimal/internal/IO.chpl:23: errorCode
   modules/minimal/internal/IO.chpl:24: qio_channel_ptr_t
   modules/minimal/internal/IO.chpl:26: c_void_ptr
   modules/minimal/internal/IO.chpl:28: chpl_qio_setup_plugin_channel


### PR DESCRIPTION
Update some tests for a slightly different module initialization order and
make the minimal-modules version of 'errorCode' point at the proper C name
for it. This fixes the errors we had in the linux64 and basic gasnet
configurations last night.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>