### PR TITLE
Change error about 'new borrowed' into a deprecation warning

### DIFF
--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -334,7 +334,7 @@ void resolveNewInitializer(CallExpr* newExpr, Type* manager) {
     manager = dtUnmanaged;
 
   if (manager == dtBorrowed) {
-    USR_FATAL(newExpr, "creating a 'new borrowed' type is a not allowed");
+    USR_WARN(newExpr, "creating a 'new borrowed' type is deprecated");
   }
 
   INT_ASSERT(newExpr->isPrimitive(PRIM_NEW));

--- a/test/arrays/types-fixed-array/testBorrowed.chpl
+++ b/test/arrays/types-fixed-array/testBorrowed.chpl
@@ -1,9 +1,0 @@
-import ArrayTest;
-
-class T {
-  var value = 0;
-}
-
-type t = borrowed T;
-
-ArrayTest.testArray(t);

--- a/test/arrays/types-fixed-array/testBorrowed.good
+++ b/test/arrays/types-fixed-array/testBorrowed.good
@@ -1,3 +1,0 @@
-./ArrayTest.chpl:1: In function 'testArray':
-./ArrayTest.chpl:5: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:9: called as testArray(type t = borrowed T)

--- a/test/arrays/types-fixed-array/testNilableBorrowed.chpl
+++ b/test/arrays/types-fixed-array/testNilableBorrowed.chpl
@@ -1,8 +1,0 @@
-import ArrayTest;
-class T {
-  var value = 0;
-}
-
-type t = borrowed T?;
-
-ArrayTest.testArray(t);

--- a/test/arrays/types-fixed-array/testNilableBorrowed.good
+++ b/test/arrays/types-fixed-array/testNilableBorrowed.good
@@ -1,3 +1,0 @@
-./ArrayTest.chpl:1: In function 'testArray':
-./ArrayTest.chpl:5: error: creating a 'new borrowed' type is a not allowed
-  testNilableBorrowed.chpl:8: called as testArray(type t = borrowed T?)

--- a/test/arrays/types-resized-array/testBorrowed.chpl
+++ b/test/arrays/types-resized-array/testBorrowed.chpl
@@ -1,9 +1,0 @@
-import ArrayTest;
-
-class T {
-  var value = 0;
-}
-
-type t = borrowed T;
-
-ArrayTest.testArray(t);

--- a/test/arrays/types-resized-array/testBorrowed.good
+++ b/test/arrays/types-resized-array/testBorrowed.good
@@ -1,3 +1,0 @@
-./ArrayTest.chpl:1: In function 'testArray':
-./ArrayTest.chpl:5: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:9: called as testArray(type t = borrowed T)

--- a/test/arrays/types-resized-array/testNilableBorrowed.chpl
+++ b/test/arrays/types-resized-array/testNilableBorrowed.chpl
@@ -1,8 +1,0 @@
-import ArrayTest;
-class T {
-  var value = 0;
-}
-
-type t = borrowed T?;
-
-ArrayTest.testArray(t);

--- a/test/arrays/types-resized-array/testNilableBorrowed.good
+++ b/test/arrays/types-resized-array/testNilableBorrowed.good
@@ -1,3 +1,0 @@
-./ArrayTest.chpl:1: In function 'testArray':
-./ArrayTest.chpl:5: error: creating a 'new borrowed' type is a not allowed
-  testNilableBorrowed.chpl:8: called as testArray(type t = borrowed T?)

--- a/test/associative/types/testBorrowed.chpl
+++ b/test/associative/types/testBorrowed.chpl
@@ -1,9 +1,0 @@
-import AssocTest;
-
-class T {
-  var value = 0;
-}
-
-type t = borrowed T;
-
-AssocTest.testAssoc(t);

--- a/test/associative/types/testBorrowed.good
+++ b/test/associative/types/testBorrowed.good
@@ -1,3 +1,0 @@
-./AssocTest.chpl:1: In function 'testAssoc':
-./AssocTest.chpl:10: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:9: called as testAssoc(type t = borrowed T)

--- a/test/classes/delete-free/borrowed/makeNewBorrowed.chpl
+++ b/test/classes/delete-free/borrowed/makeNewBorrowed.chpl
@@ -1,3 +1,0 @@
-class C { }
-
-var bC = new borrowed C();

--- a/test/classes/delete-free/borrowed/makeNewBorrowed.good
+++ b/test/classes/delete-free/borrowed/makeNewBorrowed.good
@@ -1,1 +1,0 @@
-makeNewBorrowed.chpl:3: error: creating a 'new borrowed' type is a not allowed

--- a/test/classes/delete-free/errors-managed-new-record.good
+++ b/test/classes/delete-free/errors-managed-new-record.good
@@ -2,4 +2,4 @@ errors-managed-new-record.chpl:4: error: Cannot use new owned with record R
 errors-managed-new-record.chpl:5: error: Cannot use new shared with record R
 errors-managed-new-record.chpl:7: error: Cannot use new unmanaged with record R
 errors-managed-new-record.chpl:8: error: Cannot use new borrowed with record R
-errors-managed-new-record.chpl:8: error: creating a 'new borrowed' type is a not allowed
+errors-managed-new-record.chpl:8: warning: creating a 'new borrowed' type is deprecated

--- a/test/classes/ferguson/class-double-modifier.chpl
+++ b/test/classes/ferguson/class-double-modifier.chpl
@@ -62,5 +62,4 @@ writeln("Section 4");
 doit4(unmanaged A(int));
 doit4(owned A(int));
 doit4(shared A(int));
-doit4(borrowed A(int));
 doit4(A(int));

--- a/test/classes/ferguson/class-double-modifier.good
+++ b/test/classes/ferguson/class-double-modifier.good
@@ -34,6 +34,3 @@ class-double-modifier.chpl:24: error: duplicate decorators - shared shared A(int
 class-double-modifier.chpl:23: In function 'doit3':
 class-double-modifier.chpl:24: error: duplicate decorators - shared borrowed A(int(64))
   class-double-modifier.chpl:58: called as doit3(type C = borrowed A(int(64)))
-class-double-modifier.chpl:30: In function 'doit4':
-class-double-modifier.chpl:32: error: creating a 'new borrowed' type is a not allowed
-  class-double-modifier.chpl:65: called as doit4(type C = borrowed A(int(64)))

--- a/test/classes/generic/with-runtime-fields-errors.chpl
+++ b/test/classes/generic/with-runtime-fields-errors.chpl
@@ -18,8 +18,8 @@ module w {
     else if opt == 4 then owned CC?
     else if opt == 5 then shared CC
     else if opt == 6 then shared CC?
-    else if opt == 7 then borrowed CC
-    else if opt == 8 then borrowed CC?
+    //else if opt == 7 then borrowed CC
+    //else if opt == 8 then borrowed CC?
     else if opt == 9 then unmanaged CC
     else                  unmanaged CC?
     ;

--- a/test/classes/generic/with-runtime-fields-errors.compopts
+++ b/test/classes/generic/with-runtime-fields-errors.compopts
@@ -4,7 +4,5 @@
 -s opt=4     # with-runtime-fields-errors.error.owned.good
 -s opt=5     # with-runtime-fields-errors.done.good
 -s opt=6     # with-runtime-fields-errors.error.shared.good
--s opt=7     # with-runtime-fields-errors.error.borrowed.good
--s opt=8     # with-runtime-fields-errors.error.borrowed.good
 -s opt=9     # with-runtime-fields-errors.done.good
 -s opt=10    # with-runtime-fields-errors.error.unmanaged.good

--- a/test/classes/generic/with-runtime-fields-errors.error.borrowed.good
+++ b/test/classes/generic/with-runtime-fields-errors.error.borrowed.good
@@ -1,2 +1,0 @@
-with-runtime-fields-errors.chpl:2: In module 'w':
-with-runtime-fields-errors.chpl:27: error: creating a 'new borrowed' type is a not allowed

--- a/test/deprecated/newBorrowed.chpl
+++ b/test/deprecated/newBorrowed.chpl
@@ -1,0 +1,3 @@
+class C {}
+
+var c = new borrowed C();

--- a/test/deprecated/newBorrowed.good
+++ b/test/deprecated/newBorrowed.good
@@ -1,0 +1,1 @@
+newBorrowed.chpl:3: warning: creating a 'new borrowed' type is deprecated

--- a/test/library/packages/SortedMap/types/testBorrowed.chpl
+++ b/test/library/packages/SortedMap/types/testBorrowed.chpl
@@ -1,9 +1,0 @@
-import MapTest;
-
-class T {
-  var value = 0;
-}
-
-type t = borrowed T;
-
-MapTest.testMap(t);

--- a/test/library/packages/SortedMap/types/testBorrowed.good
+++ b/test/library/packages/SortedMap/types/testBorrowed.good
@@ -1,3 +1,0 @@
-./MapTest.chpl:4: In function 'testMap':
-./MapTest.chpl:9: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:9: called as testMap(type t = borrowed T)

--- a/test/library/packages/SortedSet/general/types/testBorrowed.chpl
+++ b/test/library/packages/SortedSet/general/types/testBorrowed.chpl
@@ -1,6 +1,0 @@
-import OsetTypeTest;
-use OsetTest;
-
-type t = borrowed testClass;
-
-OsetTypeTest.testSet(t);

--- a/test/library/packages/SortedSet/general/types/testBorrowed.good
+++ b/test/library/packages/SortedSet/general/types/testBorrowed.good
@@ -1,3 +1,0 @@
-./OsetTypeTest.chpl:21: In function 'testSet':
-./OsetTypeTest.chpl:24: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:6: called as testSet(type t = borrowed testClass)

--- a/test/library/standard/Heap/type/testBorrowed.chpl
+++ b/test/library/standard/Heap/type/testBorrowed.chpl
@@ -1,5 +1,0 @@
-import HeapTest;
-
-type t = borrowed HeapTest.T;
-
-HeapTest.testHeap(t);

--- a/test/library/standard/Heap/type/testBorrowed.good
+++ b/test/library/standard/Heap/type/testBorrowed.good
@@ -1,3 +1,0 @@
-./HeapTest.chpl:36: In function 'testHeap':
-./HeapTest.chpl:39: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:5: called as testHeap(type t = borrowed T)

--- a/test/library/standard/List/types/testBorrowed.chpl
+++ b/test/library/standard/List/types/testBorrowed.chpl
@@ -1,9 +1,0 @@
-import ListTest;
-
-class T {
-  var value = 0;
-}
-
-type t = borrowed T;
-
-ListTest.testList(t);

--- a/test/library/standard/List/types/testBorrowed.good
+++ b/test/library/standard/List/types/testBorrowed.good
@@ -1,3 +1,0 @@
-./ListTest.chpl:14: In function 'testList':
-./ListTest.chpl:17: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:9: called as testList(type t = borrowed T)

--- a/test/library/standard/Map/types/testBorrowed.chpl
+++ b/test/library/standard/Map/types/testBorrowed.chpl
@@ -1,9 +1,0 @@
-import MapTest;
-
-class T {
-  var value = 0;
-}
-
-type t = borrowed T;
-
-MapTest.testMap(t);

--- a/test/library/standard/Map/types/testBorrowed.good
+++ b/test/library/standard/Map/types/testBorrowed.good
@@ -1,3 +1,0 @@
-./MapTest.chpl:3: In function 'testMap':
-./MapTest.chpl:8: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:9: called as testMap(type t = borrowed T)

--- a/test/library/standard/Set/types/testBorrowed.chpl
+++ b/test/library/standard/Set/types/testBorrowed.chpl
@@ -1,9 +1,0 @@
-import SetTest;
-
-class T {
-  var value = 0;
-}
-
-type t = borrowed T;
-
-SetTest.testSet(t);

--- a/test/library/standard/Set/types/testBorrowed.good
+++ b/test/library/standard/Set/types/testBorrowed.good
@@ -1,3 +1,0 @@
-./SetTest.chpl:19: In function 'testSet':
-./SetTest.chpl:22: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:9: called as testSet(type t = borrowed T)

--- a/test/types/tuple/types/testBorrowed.chpl
+++ b/test/types/tuple/types/testBorrowed.chpl
@@ -1,9 +1,0 @@
-import TupleTest;
-
-class T {
-  var value = 0;
-}
-
-type t = borrowed T;
-
-TupleTest.test(t);

--- a/test/types/tuple/types/testBorrowed.good
+++ b/test/types/tuple/types/testBorrowed.good
@@ -1,3 +1,0 @@
-./TupleTest.chpl:6: In function 'test':
-./TupleTest.chpl:7: error: creating a 'new borrowed' type is a not allowed
-  testBorrowed.chpl:9: called as test(type t = borrowed T)

--- a/test/types/tuple/types/testNilableBorrowed.chpl
+++ b/test/types/tuple/types/testNilableBorrowed.chpl
@@ -1,8 +1,0 @@
-import TupleTest;
-class T {
-  var value = 0;
-}
-
-type t = borrowed T?;
-
-TupleTest.test(t);

--- a/test/types/tuple/types/testNilableBorrowed.good
+++ b/test/types/tuple/types/testNilableBorrowed.good
@@ -1,3 +1,0 @@
-./TupleTest.chpl:6: In function 'test':
-./TupleTest.chpl:7: error: creating a 'new borrowed' type is a not allowed
-  testNilableBorrowed.chpl:8: called as test(type t = borrowed T?)


### PR DESCRIPTION
Change the error about 'new borrowed C' into a deprecation warning and add
a deprecation test for it.

Remove tests that just test 'new borrowed C()', remove 'new borrowed C()'
from other wider tests.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>