### PR TITLE
Make subtype comparison operators unstable

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2820,7 +2820,10 @@ static bool resolveTypeComparisonCall(CallExpr* call) {
             // Put the call back in to aid traversal
             se->getStmtExpr()->insertBefore(call);
           } else {
-            USR_WARN(call, "type comparsion operators are deprecated use isSubtype/isProperSubtype instead");
+            if (fWarnUnstable) {
+              USR_WARN(call, "type comparsion operators are unstable; "
+                "consider using isSubtype/isProperSubtype as a stable alternative");
+            }
 
             rhs->remove();
             lhs->remove();

--- a/test/deprecated/typeQueryFuncs.chpl
+++ b/test/deprecated/typeQueryFuncs.chpl
@@ -32,30 +32,6 @@ runQueries("associative array", assocArr);
 runQueries("sparse domain", sparseDom);
 runQueries("sparse array", sparseArr);
 
-// Type subtype relations (operators now deprecated in favor of named
-// functions)
-
-writeln("Compare 1.type op int");
-writeln("op <= returns ", 1.type <= int);
-writeln("op <  returns ", 1.type <  int);
-writeln("op >= returns ", 1.type >= int);
-writeln("op >  returns ", 1.type >  int);
-
-class BaseClass {}
-class DerivedClass : BaseClass {}
-
-writeln("Compare BaseClass op DerivedClass");
-writeln("op <= returns ", BaseClass <= DerivedClass);
-writeln("op <  returns ", BaseClass <  DerivedClass);
-writeln("op >= returns ", BaseClass >= DerivedClass);
-writeln("op >  returns ", BaseClass >  DerivedClass);
-
-writeln("Compare DerivedClass.type op BaseClass.type");
-writeln("op <= returns ", BaseClass <= DerivedClass);
-writeln("op <  returns ", BaseClass <  DerivedClass);
-writeln("op >= returns ", BaseClass >= DerivedClass);
-writeln("op >  returns ", BaseClass >  DerivedClass);
-
 // isFloat* functions are being deprecatd
 // (in favor of doing isReal(x) || isImag(x) instead)
 

--- a/test/deprecated/typeQueryFuncs.good
+++ b/test/deprecated/typeQueryFuncs.good
@@ -34,22 +34,10 @@ typeQueryFuncs.chpl:11: warning: isIrregularArr is deprecated - please use isIrr
 typeQueryFuncs.chpl:12: warning: isAssociativeArr is deprecated - please use isAssociative method on array
 typeQueryFuncs.chpl:13: warning: isSparseArr is deprecated - please use isSparse method on array
   typeQueryFuncs.chpl:33: called as runQueries(description: string, A: [DefaultSparseDom(2,int(64),domain(2,int(64),false))] int(64))
-typeQueryFuncs.chpl:39: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:40: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:41: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:42: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:48: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:49: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:50: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:51: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:54: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:55: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:56: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:57: warning: type comparsion operators are deprecated use isSubtype/isProperSubtype instead
-typeQueryFuncs.chpl:62: warning: isFloat is deprecated use `isReal(e) || isImag(e)` instead
-typeQueryFuncs.chpl:63: warning: isFloat is deprecated use `isReal(t) || isImag(t)` instead
-typeQueryFuncs.chpl:64: warning: isFloatType is deprecated use `isRealType(t) || isImagType(t)` instead
-typeQueryFuncs.chpl:65: warning: isFloatValue is deprecated use `isRealValue(e) || isImagValue(e)` instead
+typeQueryFuncs.chpl:38: warning: isFloat is deprecated use `isReal(e) || isImag(e)` instead
+typeQueryFuncs.chpl:39: warning: isFloat is deprecated use `isReal(t) || isImag(t)` instead
+typeQueryFuncs.chpl:40: warning: isFloatType is deprecated use `isRealType(t) || isImagType(t)` instead
+typeQueryFuncs.chpl:41: warning: isFloatValue is deprecated use `isRealValue(e) || isImagValue(e)` instead
 Given a rectangular domain: 
   isRectangularDom() = true
   isIrregularDom()   = false
@@ -80,21 +68,6 @@ Given a sparse array:
   isIrregularArr()   = true
   isAssociativeArr() = false
   isSparseArr()      = true
-Compare 1.type op int
-op <= returns true
-op <  returns false
-op >= returns true
-op >  returns false
-Compare BaseClass op DerivedClass
-op <= returns false
-op <  returns false
-op >= returns true
-op >  returns true
-Compare DerivedClass.type op BaseClass.type
-op <= returns false
-op <  returns false
-op >= returns true
-op >  returns true
 isFloat(1.2) returns true
 isFloat(real) returns true
 isFloatType(real) returns true

--- a/test/unstable/typeQueryFuncs.chpl
+++ b/test/unstable/typeQueryFuncs.chpl
@@ -1,0 +1,24 @@
+// Type subtype relations (operators now deprecated in favor of named
+// functions)
+
+writeln("Compare 1.type op int");
+writeln("op <= returns ", 1.type <= int);
+writeln("op <  returns ", 1.type <  int);
+writeln("op >= returns ", 1.type >= int);
+writeln("op >  returns ", 1.type >  int);
+
+class BaseClass {}
+class DerivedClass : BaseClass {}
+
+writeln("Compare BaseClass op DerivedClass");
+writeln("op <= returns ", BaseClass <= DerivedClass);
+writeln("op <  returns ", BaseClass <  DerivedClass);
+writeln("op >= returns ", BaseClass >= DerivedClass);
+writeln("op >  returns ", BaseClass >  DerivedClass);
+
+writeln("Compare DerivedClass.type op BaseClass.type");
+writeln("op <= returns ", BaseClass <= DerivedClass);
+writeln("op <  returns ", BaseClass <  DerivedClass);
+writeln("op >= returns ", BaseClass >= DerivedClass);
+writeln("op >  returns ", BaseClass >  DerivedClass);
+

--- a/test/unstable/typeQueryFuncs.chpl
+++ b/test/unstable/typeQueryFuncs.chpl
@@ -1,5 +1,5 @@
-// Type subtype relations (operators now deprecated in favor of named
-// functions)
+// Type subtype relations (operators now marked unstable, will likely be
+// deprecated in favor of named functions)
 
 writeln("Compare 1.type op int");
 writeln("op <= returns ", 1.type <= int);

--- a/test/unstable/typeQueryFuncs.good
+++ b/test/unstable/typeQueryFuncs.good
@@ -1,0 +1,27 @@
+typeQueryFuncs.chpl:5: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:6: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:7: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:8: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:14: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:15: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:16: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:17: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:20: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:21: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:22: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:23: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+Compare 1.type op int
+op <= returns true
+op <  returns false
+op >= returns true
+op >  returns false
+Compare BaseClass op DerivedClass
+op <= returns false
+op <  returns false
+op >= returns true
+op >  returns true
+Compare DerivedClass.type op BaseClass.type
+op <= returns false
+op <  returns false
+op >= returns true
+op >  returns true


### PR DESCRIPTION
After merging this PR: https://github.com/chapel-lang/chapel/pull/20466 (which deprecates subtype comparison operators; e.g. `someDerivedType < subBaseType`), we realized there's a user code that will encounter this deprecation warning over a hundred times.

Proceeding with this as deprecated might, ultimately, be the right thing to do, but we'd like to gather user feedback (in part to make sure we're not deprecating a favorite feature).

This PR changes these operators from being deprecated to being marked unstable. This will also give other users the chance to to measure the impact of this by opting into the warnings (by using `--mark-unstable`) rather than having them displayed with each compilation.