### PR TITLE
avoid quickstart CHPL_LLVM=system on incompatible platforms

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1007,7 +1007,7 @@ def _main():
     elif options.action == 'sdkroot':
         sys.stdout.write("{0}\n".format(get_clang_args_sdkroot()))
     elif options.action == 'quickstart':
-        if has_compatible_installed_llvm():
+        if has_compatible_installed_llvm() and compatible_platform_for_llvm():
             sys.stdout.write("system\n")
         else:
             sys.stdout.write("none\n")


### PR DESCRIPTION
This is a follow-up to PR #20396.

In doing some portability testing, I noticed that the `quickstart` configuration was not working on a 32-bit Debian 11 image. The problem was that the image has the right LLVM/clang packages installed, but Chapel does not support using LLVM on a 32-bit platform right now. The result was that `quickstart` set CHPL_LLVM=system but that led to errors later on from `printchplenv` / `make`.

This PR just adjusts the `chpl_llvm.py` code determining the quickstart setting for CHPL_LLVM to use `none` if the platform is not supported for Chapel+LLVM.

Reviewed by @bhavanijayakumaran and @daviditen - thanks!