### PR TITLE
singularity portability testing updates

### DIFF
--- a/util/devel/test/singularity/README.md
+++ b/util/devel/test/singularity/README.md
@@ -28,7 +28,13 @@ singularity build --fakeroot singularity.sif singularity.def
 #To create an image for experimenting with where you can install
 # more packages etc, use this:
 #   sudo singularity build --sandbox singularity.sif singularity.def
+#
+#   # to explore as root
 #   sudo singularity shell --writable singularity.sif
+#
+#   # to explore not as root
+#   singularity shell --writable singularity.sif
+
 
 ## to run the runscript
 singularity run singularity.sif

--- a/util/devel/test/singularity/current/amazonlinux-2022/singularity.def
+++ b/util/devel/test/singularity/current/amazonlinux-2022/singularity.def
@@ -7,8 +7,8 @@ From: amazonlinux:2022
 
 %post
     /provision-scripts/dnf-deps.sh
-    # amazon linux 2022 defaulted to llvm 13 but clang 12 at some point
-    dnf -y install clang clang-devel llvm12-devel
+    # this installs clang 14 / llvm 14
+    dnf -y install clang clang-devel llvm-devel
 
 %runscript
     ../../provision-scripts/run.sh

--- a/util/devel/test/singularity/current/ubuntu-kinetic/singularity.def
+++ b/util/devel/test/singularity/current/ubuntu-kinetic/singularity.def
@@ -1,0 +1,13 @@
+BootStrap: docker
+From: ubuntu:kinetic
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/apt-get-deps.sh
+    # installs LLVM 14
+    /provision-scripts/apt-get-llvm.sh
+
+%runscript
+    ../../provision-scripts/run.sh


### PR DESCRIPTION
This PR makes some little updates to improve portability testing with singularity. None of these scripts are currently run in nightly testing.

* Adds some more notes to the README
* Fixes the amazonlinux-2022 configuration by removing a workaround
* Adds a singularity image for Ubuntu Kinetic

Reviewed by @bhavanijayakumaran - thanks!