### PR TITLE
fix(chpldoc): add explicit initializer for RstResultBuilder

### DIFF
--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1318,6 +1318,11 @@ struct RstResultBuilder {
   static const int commentIndent = 3;
   int indentDepth_ = 1;
 
+  RstResultBuilder(Context* context) {
+    context_ = context;
+    os_ = std::stringstream();
+  }
+
   bool showComment(const Comment* comment, std::string& errMsg, bool indent=true) {
     if (!comment || comment->str().substr(0, 2) == "//") {
       os_ << '\n';

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1318,10 +1318,8 @@ struct RstResultBuilder {
   static const int commentIndent = 3;
   int indentDepth_ = 1;
 
-  RstResultBuilder(Context* context) {
-    context_ = context;
-    os_ = std::stringstream();
-  }
+  RstResultBuilder(Context* context) : context_(context),
+                                       os_(std::stringstream()) {}
 
   bool showComment(const Comment* comment, std::string& errMsg, bool indent=true) {
     if (!comment || comment->str().substr(0, 2) == "//") {


### PR DESCRIPTION
This PR adds an initializer to the `RstResultBuilder` struct in the new
`chpldoc`. Previously the code relied on implicit instantiation, but some 
compilers complain about this and so it breaks our smoke-tests.

TESTING:

- [x] `test/chpldoc`

Reviewed by @dlongnecke-cray - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>