### PR TITLE
fix(release): copy CMakeLists.txt files to tarball

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -248,7 +248,7 @@ foreach $dir (@code_dirs) {
         chomp $fullpath;
         $file = $fullpath;
         $file =~ s/(\S+\/)+//g;
-        if ($file =~ /(\.(h|cpp|c|ypp|lex)$)|Makefile|README|BUILD_VERSION/) {
+        if ($file =~ /(\.(h|cpp|c|ypp|lex)$)|Makefile|README|BUILD_VERSION|CMakeLists\.txt/) {
             # print "$fullpath\n";
             push @tarfiles, "$reldir/$fullpath";
         }


### PR DESCRIPTION
This PR sets `CMakeLists.txt` files to be explicitly copied into release tarballs
by modifying the `gen_release` script.

I suspect we have been getting away without copying the `CMakeLists.txt` files
into the release tarball because we have been maintaining two build systems for
all the new `dyno` stuff. Now that `dyno-chpldoc` has replaced `chpldoc`, we rely
on `cmake` to build it.


TESTING:

- [x] Local testing using `util/cron/test_release`

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>