### PR TITLE
Revert "fix(chpldoc): add explicit initializer for RstResultBuilder"

### DIFF
--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1318,9 +1318,6 @@ struct RstResultBuilder {
   static const int commentIndent = 3;
   int indentDepth_ = 1;
 
-  RstResultBuilder(Context* context) : context_(context),
-                                       os_(std::stringstream()) {}
-
   bool showComment(const Comment* comment, std::string& errMsg, bool indent=true) {
     if (!comment || comment->str().substr(0, 2) == "//") {
       os_ << '\n';


### PR DESCRIPTION
Reverts chapel-lang/chapel#20580 based on failing smoke-tests