### PR TITLE
Fix test_mpi to use `0..<worldSize`

### DIFF
--- a/test/users/npadmana/mpi/test_mpi.chpl
+++ b/test/users/npadmana/mpi/test_mpi.chpl
@@ -162,7 +162,7 @@ proc test_scatter() {
     MPI_Type_commit(rowtype);
 
     if worldRank==0 {
-      for irank in 0.. #worldSize {
+      for irank in 0..<worldSize {
         if irank == 0 {
           recbuf = arr[0,..];
         } else {
@@ -187,7 +187,7 @@ proc test_scatter() {
     MPI_Type_commit(coltype);
 
     if worldRank==0 {
-      for irank in 0.. #worldSize {
+      for irank in 0..<worldSize {
         if irank == 0 {
           recbuf = arr[..,0];
         } else {
@@ -216,7 +216,7 @@ proc test_scatter() {
     MPI_Type_commit(indextype);
 
     if worldRank==0 {
-      for irank in 0.. #worldSize {
+      for irank in 0..<worldSize {
         if irank == 0 {
           recbuf[0.. #2] = arr2[5.. #2];
           recbuf[2.. #2] = arr2[12.. #2];
@@ -287,7 +287,7 @@ proc test_structure() {
 proc test_allgather() {
   var worldRank = commRank(),
       worldSize = commSize();
-  var ranks : [0.. #worldSize]c_int;
+  var ranks : [0..<worldSize]c_int;
 
   MPI_Allgather(worldRank, 1, MPI_INT, ranks[0], 1, MPI_INT, MPI_COMM_WORLD);
   writeln("ALLGATHER : Rank ", worldRank, " : ", ranks);


### PR DESCRIPTION
This is a follow-up to PR #20528 and it is about this test

```
test/users/npadmana/mpi/test_mpi.chpl
```

This test had several loops of the form

``` chapel
for irank in 0.. #worldSize { }
```

where `worldSize` has type `c_int`. After changes in PR #20528, these loops now have an iteration variable of type `int` aka `int(64)` which is intentional since the count isn't supposed to impact the range type. But that caused problems in this test since the body of the loop expected `irank` to have type `c_int`.

This PR fixes these loops to use the pattern `0..<worldSize` which will infer the range index type as `c_int`.

Test change only - not reviewed.