### PR TITLE
chpldoc: swap dyno-chpldoc in place of chpldoc

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -164,9 +164,17 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 	$(TAGS_COMMAND)
 	$(EBROWSE_COMMAND)
 
-$(CHPLDOC): $(CHPL)
+$(CHPLDOC): $(CHPL) dyno-chpldoc $(CHPLDOC)-legacy
+
+$(CHPLDOC)-legacy:
+	rm -f $(CHPLDOC)-legacy
+	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
+
+# setup a phony rule to detect when dyno-chpldoc needs to be rebuilt
+.PHONY: dyno-chpldoc
+dyno-chpldoc:
 	rm -f $(CHPLDOC)
-	ln -s $(notdir $(CHPL)) $(CHPLDOC)
+	@cd ../compiler/dyno && $(MAKE) -f Makefile.help dyno-chpldoc
 
 chpldoc: $(CHPLDOC)
 

--- a/compiler/dyno/CMakeLists.txt
+++ b/compiler/dyno/CMakeLists.txt
@@ -103,8 +103,10 @@ add_subdirectory(tools)
 # Utils like C++ linters for this codebase
 add_subdirectory(util)
 
-# Support for C++ compiler unit tests
-# Needs to happen in this file for ctest to work in this dir
-enable_testing()
-
-add_subdirectory(test)
+# Check if the directory is there, because in release tarballs, it shouldn't be
+if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test")
+  # Support for C++ compiler unit tests
+  # Needs to happen in this file for ctest to work in this dir
+  enable_testing()
+  add_subdirectory(test)
+endif()

--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -78,6 +78,7 @@ dyno-parser: $(LIBCOMPILER_BUILD_DIR) FORCE
 
 dyno-chpldoc: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc && $(CMAKE) --build . --target chpldoc
+	cp -f $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc/chpldoc $(CHPL_BIN_DIR)/chpldoc
 
 dyno-linters: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/util && $(CMAKE) --build .

--- a/compiler/dyno/include/chpl/util/filesystem.h
+++ b/compiler/dyno/include/chpl/util/filesystem.h
@@ -84,6 +84,15 @@ std::error_code currentWorkingDir(std::string& path_out);
 std::error_code makeDir(std::string dirpath, bool makeParents=false);
 
 
+/*
+  Try to get the path of the executable. We rely on llvm implementation,
+  which states it _may_ return an empty path if it fails.
+  https://llvm.org/doxygen/namespacellvm_1_1sys_1_1fs.html#a057a733b2dfa2f0531ceb335cf3b1d03
+*/
+std::string getExecutablePath(const char* argv0, void* MainExecAddr);
+
+
+
 } // end namespace chpl
 
 

--- a/compiler/dyno/lib/util/filesystem.cpp
+++ b/compiler/dyno/lib/util/filesystem.cpp
@@ -217,5 +217,10 @@ std::error_code makeDir(std::string dirpath, bool makeParents) {
   }
 }
 
+std::string getExecutablePath(const char* argv0, void* MainExecAddr) {
+  using namespace llvm::sys::fs;
+  return getMainExecutable(argv0, MainExecAddr);
+}
+
 
 } // namespace chpl

--- a/compiler/dyno/tools/chpldoc/CMakeLists.txt
+++ b/compiler/dyno/tools/chpldoc/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 add_executable(chpldoc "chpldoc.cpp")
 set_property(TARGET chpldoc PROPERTY CXX_STANDARD 14)
-target_sources(chpldoc PRIVATE arg.h arg.cpp arg-helpers.h arg-helpers.cpp)
+target_sources(chpldoc PRIVATE arg.h arg.cpp arg-helpers.h arg-helpers.cpp version_num.h)
 target_link_libraries(chpldoc libdyno)
 target_include_directories(chpldoc PUBLIC
                            ${CHPL_MAIN_INCLUDE_DIR}

--- a/compiler/dyno/tools/chpldoc/arg-helpers.cpp
+++ b/compiler/dyno/tools/chpldoc/arg-helpers.cpp
@@ -51,11 +51,8 @@ uint64_t hexStr2uint64(const char* str, bool userSupplied,
   }
 
   if (strlen(str+startPos) > 16) {
-
-      //astlocT astloc(line, filename);
     std::cerr << "error: Integer literal overflow: '" + std::string(str) +
                   "' is too big for type 'uint64'" << std::endl;
-
     clean_exit(1);
   }
 
@@ -68,130 +65,14 @@ uint64_t hexStr2uint64(const char* str, bool userSupplied,
   return val;
 }
 
-// // would just use realpath, but it is not supported on all platforms.
-static
-char* chplRealPath(const char* path)
-{
-  // We would really rather use
-  // char* got = realpath(path, NULL);
-  // but that doesn't work on some Mac OS X versions.
-  char* buf = (char*) malloc(1024);
-  char* got = realpath(path, buf);
-  char* ret = NULL;
-  if( got ) ret = strdup(got);
-  free(buf);
-  return ret;
-}
 
-
-// Returns a "real path" to the file in the directory,
-// or NULL if the file did not exist.
-// The return value must be freed by the caller.
-// We try to use realpath but might give up.
-static
-char* dirHasFile(const char *dir, const char *file)
-{
-  struct stat stats;
-  int len = strlen(dir) + strlen(file) + 2;
-  char* tmp = (char*) malloc(len);
-  char* real;
-
-  if( ! tmp ) {
-    std::cerr << "error: no memory" << std::endl;
-    clean_exit(1);
-  }
-
-  snprintf(tmp, len, "%s/%s", dir, file);
-  real = chplRealPath(tmp);
-  if( real == NULL ) {
-    // realpath not working on this system,
-    // just use tmp.
-    real = tmp;
-  } else {
-    free(tmp);
-  }
-
-  if( stat(real, &stats) != 0) {
-    free(real);
-    real = NULL;
-  }
-
-  return real;
-}
 
 
 // Find the path to the running program
 // (or return NULL if we couldn't figure it out).
-// The return value must be freed by the caller.
-char* findProgramPath(const char *argv0)
+std::string findProgramPath(const char* argv0, void* mainAddr)
 {
-  char* real = NULL;
-  char* path;
-
-  /* Note - there are lots of friendly
-   * but platform-specific ways to do this:
-    #ifdef __linux__
-      int ret;
-      ret = readlink("/proc/self/exe", dst, max_dst - 1);
-      // return an error if there was an error.
-      if( ret < 0 ) return -1;
-      // append the NULL byte
-      if( ret < max_dst ) dst[ret] = '\0';
-      return 0;
-    #else
-    #ifdef __APPLE__
-      uint32_t sz = max_dst - 1;
-      return _NSGetExecutablePath(dst, &sz);
-    #else
-      // getexe path not available.
-      return -1;
-    #endif
-  */
-
-
-  // Is argv0 an absolute path?
-  if( argv0[0] == '/' ) {
-    real = dirHasFile("/", argv0);
-    return real;
-  }
-
-  // Is argv0 a relative path?
-  if( strchr(argv0, '/') != NULL ) {
-    std::string cwd;
-    if(auto err = chpl::currentWorkingDir(cwd)) {
-      real = NULL;
-    } else {
-      real = dirHasFile(cwd.c_str(), argv0);
-    }
-    return real;
-  }
-
-  // Is argv0 just in $PATH?
-  path = getenv("PATH");
-  if( path == NULL ) return NULL;
-
-  path = strdup(path);
-  if( path == NULL ) return NULL;
-
-  // Go through PATH changing ':' into '\0'
-  char* start;
-  char* end;
-  char* path_end = path + strlen(path);
-
-  start = path;
-  while( start != NULL && start < path_end ) {
-    end = strchr(start, ':');
-    if( end == NULL ) end = path_end;
-    else end[0] = '\0'; // replace ':' with '\0'
-
-    real = dirHasFile(start, argv0);
-    if( real ) break;
-
-    start = end + 1;
-  }
-
-  free(path);
-  return real;
+  return chpl::getExecutablePath(argv0, mainAddr);
 }
 
 

--- a/compiler/dyno/tools/chpldoc/arg-helpers.h
+++ b/compiler/dyno/tools/chpldoc/arg-helpers.h
@@ -38,7 +38,7 @@ typedef __uint64_t uint64_t;
 
 bool startsWith(const char* str, const char* prefix);
 void clean_exit(int status);
-char* findProgramPath(const char *argv0);
+std::string findProgramPath(const char* argv0, void* mainAddr);
 
 extern bool developer;
 

--- a/compiler/dyno/tools/chpldoc/arg.cpp
+++ b/compiler/dyno/tools/chpldoc/arg.cpp
@@ -311,7 +311,7 @@ static void word_wrap_print(const char* text, int startCol, int endCol)
 *                                                                             *
 ************************************** | *************************************/
 
-void init_args(ArgumentState* state, const char* argv0) {
+void init_args(ArgumentState* state, const char* argv0, void* mainAddr) {
   char* name = strdup(argv0);
 
   if (char* firstSlash = strrchr(name, '/')) {
@@ -319,7 +319,7 @@ void init_args(ArgumentState* state, const char* argv0) {
   }
 
   state->program_name = name;
-  state->program_loc  = findProgramPath(argv0);
+  state->program_loc  = strdup(findProgramPath(argv0, mainAddr).c_str());
 }
 
 

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1318,6 +1318,9 @@ struct RstResultBuilder {
   static const int commentIndent = 3;
   int indentDepth_ = 1;
 
+  RstResultBuilder(Context* context) : context_(context),
+                                       os_(std::stringstream()) {}
+
   bool showComment(const Comment* comment, std::string& errMsg, bool indent=true) {
     if (!comment || comment->str().substr(0, 2) == "//") {
       os_ << '\n';

--- a/compiler/dyno/tools/chpldoc/version_num.h
+++ b/compiler/dyno/tools/chpldoc/version_num.h
@@ -1,0 +1,1 @@
+../../../main/version_num.h

--- a/compiler/include/arg.h
+++ b/compiler/include/arg.h
@@ -82,7 +82,7 @@ void usage(const ArgumentState* arg_state,
            bool                 printEnvHelp,
            bool                 printCurrentSettings);
 
-void init_args(ArgumentState* state, const char* argv0);
+void init_args(ArgumentState* state, const char* argv0, void* mainAddr);
 
 void init_arg_desc(ArgumentState* state, ArgumentDescription* arg_desc);
 

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -312,7 +312,7 @@ static void word_wrap_print(const char* text, int startCol, int endCol)
 *                                                                             *
 ************************************** | *************************************/
 
-void init_args(ArgumentState* state, const char* argv0) {
+void init_args(ArgumentState* state, const char* argv0, void* mainAddr) {
   char* name = strdup(argv0);
 
   if (char* firstSlash = strrchr(name, '/')) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1780,9 +1780,9 @@ int main(int argc, char* argv[]) {
 
     tracker.StartPhase("init");
 
-    init_args(&sArgState, argv[0]);
+    init_args(&sArgState, argv[0], (void*)main);
 
-    fDocs   = (strcmp(sArgState.program_name, "chpldoc")  == 0) ? true : false;
+    fDocs   = (strncmp(sArgState.program_name, "chpldoc", 7)  == 0) ? true : false;
 
     // Initialize the arguments for argument state. If chpldoc, use the docs
     // specific arguments. Otherwise, use the regular arguments.

--- a/man/chpldoc.rst
+++ b/man/chpldoc.rst
@@ -64,6 +64,10 @@ reStructuredText as an intermediate format.
     Sets the documentation version to *projectversion*
     (documentation version defaults to '0.0.1' if unspecified).
 
+**\--legacy**
+
+    Use the legacy version of chpldoc
+
 **\--[no-]print-commands**
 
     Prints the system commands that **chpldoc** executes in order to create

--- a/test/chpldoc/functions/functionArgDefaultOneTuple.doc.good
+++ b/test/chpldoc/functions/functionArgDefaultOneTuple.doc.good
@@ -17,6 +17,12 @@ or
 
    import functionArgDefaultOneTuple.doc;
 
+.. data:: var x: int
+
+.. data:: var y: x.type
+
+.. data:: var z: y.type
+
 .. function:: proc tuple1Default(arg = (x,))
 
 .. function:: proc tuple2Default(arg = (x, y))

--- a/test/chpldoc/functions/functionArgDefaults.doc.good
+++ b/test/chpldoc/functions/functionArgDefaults.doc.good
@@ -17,11 +17,17 @@ or
 
    import functionArgDefaults.doc;
 
+.. data:: var x: int
+
+.. data:: var y: x.type
+
+.. data:: var z: y.type
+
 .. class:: C
 
    .. attribute:: var aField: int
 
-.. data:: var c: unmanaged nilable C
+.. data:: var c: unmanaged C?
 
 .. function:: proc noArgs()
 

--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.bad
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.bad
@@ -77,7 +77,7 @@ or
 
    .. method:: proc type -(lhs: Foo, rhs: Foo)
 
-   .. method:: proc type <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+   .. method:: proc type <=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
    .. method:: proc type *=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operatorPrimaryMethods.doc.good
+++ b/test/chpldoc/functions/operatorPrimaryMethods.doc.good
@@ -77,7 +77,7 @@ or
 
    .. method:: operator -(lhs: Foo, rhs: Foo)
 
-   .. method:: operator <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+   .. method:: operator <=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
    .. method:: operator *=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.bad
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.bad
@@ -91,7 +91,7 @@ or
 
 .. method:: proc type Foo.-(lhs: Foo, rhs: Foo)
 
-.. method:: proc type Foo.<=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+.. method:: proc type Foo.<=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
 .. method:: proc type Foo.*=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operatorSecondaryMethods.doc.good
+++ b/test/chpldoc/functions/operatorSecondaryMethods.doc.good
@@ -91,7 +91,7 @@ or
 
 .. method:: operator Foo.-(lhs: Foo, rhs: Foo)
 
-.. method:: operator Foo.<=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+.. method:: operator Foo.<=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
 .. method:: operator Foo.*=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operators.doc.bad
+++ b/test/chpldoc/functions/operators.doc.bad
@@ -91,7 +91,7 @@ or
 
 .. function:: proc -(lhs: Foo, rhs: Foo)
 
-.. function:: proc <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+.. function:: proc <=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
 .. function:: proc *=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/functions/operators.doc.good
+++ b/test/chpldoc/functions/operators.doc.good
@@ -91,7 +91,7 @@ or
 
 .. function:: operator -(lhs: Foo, rhs: Foo)
 
-.. function:: operator <=>(ref lhs: owned nilable Foo, ref rhs: owned nilable Foo)
+.. function:: operator <=>(ref lhs: owned Foo?, ref rhs: owned Foo?)
 
 .. function:: operator *=(ref lhs: Foo, rhs: Foo)
 

--- a/test/chpldoc/globals/nilableFields.doc.catfiles
+++ b/test/chpldoc/globals/nilableFields.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/nilableFields.doc.rst

--- a/test/chpldoc/globals/nilableFields.doc.chpl
+++ b/test/chpldoc/globals/nilableFields.doc.chpl
@@ -1,0 +1,6 @@
+
+
+  record r {
+    var atomicVar : if hasABASupport then _ddata(_ABAInternal(objType?)) else atomic uint(64);
+    var _impl : unmanaged DistributedBagImpl(eltType)?;
+  }

--- a/test/chpldoc/globals/nilableFields.doc.good
+++ b/test/chpldoc/globals/nilableFields.doc.good
@@ -1,0 +1,25 @@
+.. default-domain:: chpl
+
+.. module:: nilableFields.doc
+
+nilableFields.doc
+=================
+**Usage**
+
+.. code-block:: chapel
+
+   use nilableFields.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import nilableFields.doc;
+
+.. record:: r
+
+   .. attribute:: var atomicVar: if hasABASupport then _ddata(_ABAInternal(objType?)) else atomic uint(64)
+
+   .. attribute:: var _impl: unmanaged DistributedBagImpl(eltType)?
+

--- a/test/chpldoc/globals/variableDefaultValues.doc.good
+++ b/test/chpldoc/globals/variableDefaultValues.doc.good
@@ -17,11 +17,17 @@ or
 
    import variableDefaultValues;
 
+.. data:: var x: int
+
+.. data:: var y: x.type
+
+.. data:: var z: y.type
+
 .. class:: C
 
    .. attribute:: var aField: int
 
-.. data:: var c: unmanaged nilable C
+.. data:: var c: unmanaged C?
 
 .. data:: var literalDefault = 42
 
@@ -37,7 +43,7 @@ or
 
 .. data:: var notNilDefault = c!
 
-.. data:: var isNilDefault: nilable C = nil
+.. data:: var isNilDefault: C? = nil
 
 .. data:: var plusDefault = x + y
 

--- a/test/chpldoc/globals/variablePrecedence.doc.good
+++ b/test/chpldoc/globals/variablePrecedence.doc.good
@@ -17,6 +17,18 @@ or
 
    import variablePrecedence;
 
+.. data:: var a: int
+
+.. data:: var b: a.type
+
+.. data:: var c: b.type
+
+.. data:: var d: c.type
+
+.. data:: var e: d.type
+
+.. data:: var f: e.type
+
 .. data:: var pp = a + b + c
 
 .. data:: var Pp = a + b + c

--- a/test/chpldoc/types/fields/fieldDefaultValues.doc.good
+++ b/test/chpldoc/types/fields/fieldDefaultValues.doc.good
@@ -17,11 +17,17 @@ or
 
    import fieldDefaultValues;
 
+.. data:: var x: int
+
+.. data:: var y: x.type
+
+.. data:: var z: y.type
+
 .. class:: C
 
    .. attribute:: var aField: int
 
-.. data:: var c: nilable C
+.. data:: var c: C?
 
 .. record:: R0
 
@@ -59,7 +65,7 @@ or
 
    .. attribute:: var notNilDefault = c!
 
-   .. attribute:: var isNilDefault: nilable C = nil
+   .. attribute:: var isNilDefault: C? = nil
 
    .. attribute:: var plusDefault = x + y
 

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
@@ -29,5 +29,6 @@ record D {
   var bounded1DDomainBy = {1..10 by 2};
   var bounded1DDomainByAlign = {1..10 by 2 align 1};
 
-
+  var lSrcVals: [myLocaleSpace] [0..#bufferSize] elemType;
+  var openHighBound: [myLocaleSpace] [0..<bufferSize] elemType;
 }

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.good
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.good
@@ -63,3 +63,7 @@ or
 
    .. attribute:: var bounded1DDomainByAlign = {1..10 by 2 align 1}
 
+   .. attribute:: var lSrcVals: [myLocaleSpace] [0..#bufferSize] elemType
+
+   .. attribute:: var openHighBound: [myLocaleSpace] [0..<bufferSize] elemType
+

--- a/test/compflags/thomasvandoren/chpldoc.doc.good
+++ b/test/compflags/thomasvandoren/chpldoc.doc.good
@@ -15,6 +15,7 @@ Documentation Options:
       --project-version <projectversion>
                                       Sets the documentation version to
                                       <projectversion>
+      --legacy                        Use the legacy version of chpldoc
       --[no-]print-commands           [Don't] print system commands
 
 Information Options:

--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 sphinx-rtd-theme==1.0.0
-sphinxcontrib-chapeldomain==0.0.22
+sphinxcontrib-chapeldomain==0.0.23
 breathe==4.31.0

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -248,7 +248,7 @@ foreach $dir (@code_dirs) {
         chomp $fullpath;
         $file = $fullpath;
         $file =~ s/(\S+\/)+//g;
-        if ($file =~ /(\.(h|cpp|c|ypp|lex)$)|Makefile|README|BUILD_VERSION/) {
+        if ($file =~ /(\.(h|cpp|c|ypp|lex)$)|Makefile|README|BUILD_VERSION|CMakeLists\.txt/) {
             # print "$fullpath\n";
             push @tarfiles, "$reldir/$fullpath";
         }

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -254,7 +254,7 @@ foreach $dir (@code_dirs) {
         chomp $fullpath;
         $file = $fullpath;
         $file =~ s/(\S+\/)+//g;
-        if ($file =~ /(\.(h|cpp|c|ypp|lex)$)|Makefile|README|BUILD_VERSION|CMakeLists\.txt/) {
+        if ($file =~ /(\.(h|cpp|c|ypp|lex|cmake)$)|Makefile|README|BUILD_VERSION|CMakeLists\.txt/) {
             # print "$fullpath\n";
             push @tarfiles, "$reldir/$fullpath";
         }

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -137,6 +137,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
        "compiler/dyno/tools/chpldoc/LICENSE",
        "compiler/dyno/tools/chpldoc/BUILD_VERSION",
        "compiler/dyno/tools/chpldoc/COPYRIGHT",
+       "compiler/dyno/include/chpl/config/config.h.cmake",
 );
 
 
@@ -254,7 +255,7 @@ foreach $dir (@code_dirs) {
         chomp $fullpath;
         $file = $fullpath;
         $file =~ s/(\S+\/)+//g;
-        if ($file =~ /(\.(h|cpp|c|ypp|lex|cmake)$)|Makefile|README|BUILD_VERSION|CMakeLists\.txt/) {
+        if ($file =~ /(\.(h|cpp|c|ypp|lex)$)|Makefile|README|BUILD_VERSION|CMakeLists\.txt/) {
             # print "$fullpath\n";
             push @tarfiles, "$reldir/$fullpath";
         }

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -134,6 +134,9 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
        "util/setchplenv.sh",
        "util/start_test",
        "util/chpltags",
+       "compiler/dyno/tools/chpldoc/LICENSE",
+       "compiler/dyno/tools/chpldoc/BUILD_VERSION",
+       "compiler/dyno/tools/chpldoc/COPYRIGHT",
 );
 
 
@@ -219,6 +222,9 @@ SystemOrDie("cd util && cp start_test ../examples/");
 print "[gen_release] Removing runtime directories that are not ready for release...\n";
 SystemOrDie("cd runtime/src/launch && rm -r dummy");
 SystemOrDie("cd runtime/src/launch && rm -r mpirun");
+
+print "[gen_release] Removing dyno test directory which is not intended for release...\n";
+SystemOrDie("cd compiler/dyno && rm -r test");
 
 print "[gen_release] Removing third-party directories that are not intended for release...\n";
 SystemOrDie("cd third-party && rm *.devel*");


### PR DESCRIPTION
This PR swaps `dyno-chpldoc` in place of `chpldoc`, and renames `chpldoc` 
to `chpldoc-legacy`.

It contains reverts of three previous reverts that went in late last night 
in an attempt to salvage nightly testing in the face of smoke-test failures. 

It also implements the fixes for some bugs that were only discovered through
smoke-tests.

Bug list/fix:

- adds a constructor to the `RstResultBuilder` struct to avoid compiler 
  warning about explicit instantiation. 
- copy `.cmake` and `CMakeLists.txt` files into the release tarball
- copy `LICENSE`, `BUILD_VERSION`, and `COPYRIGHT` files for `dyno-chpldoc` 
  into release tarball
- delete `compiler/dyno/test` directory from release tarball
- conditionally setup `dyno` testing based on presence of `test` subdirectory

TESTING:

- [x] `paratest`
- [x] local testing of `util/buildRelease/gen_release`
- [x] local extract of release tarball artifact, able to 
      build `chpl`, `chpldoc`, `mason`
- [x] local test of `test/chpldoc`


Reviewed by @mppf with commentary from @bradcray - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>
