### PR TITLE
Use narrow arrays for blockdist scan

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1799,14 +1799,14 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
       // set up some references to our LocBlockArr descriptor, our
       // local array, local domain, and local result elements
       const thisArr = if _privatization then chpl_getPrivatizedCopy(this.type, cachedPID) else this;
-      ref myLocArrDesc = thisArr.locArr[locid];
-      ref myLocArr = myLocArrDesc.myElems;
+      ref myLocArr = if allowDuplicateTargetLocales then thisArr.locArr[locid].myElems
+                                                        else thisArr.myLocArr!.myElems;
       const ref myLocDom = myLocArr.domain;
 
       // Compute the local pre-scan on our local array
       const (numTasks, rngs, state, tot) =
-        if sameStaticDist && sameDynamicDist then
-          myLocArr._value.chpl__preScan(myop, res._value.locArr[locid].myElems, myLocDom[dom])
+        if !allowDuplicateTargetLocales && sameStaticDist && sameDynamicDist then
+          myLocArr._value.chpl__preScan(myop, res._value.myLocArr!.myElems, myLocDom[dom])
         else
           myLocArr._value.chpl__preScan(myop, res, myLocDom[dom]);
 
@@ -1867,8 +1867,8 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
 
       // have our local array compute its post scan with the globally
       // accurate state vector
-      if sameStaticDist && sameDynamicDist then
-        myLocArr._value.chpl__postScan(op, res._value.locArr[locid].myElems, numTasks, rngs, state);
+      if !allowDuplicateTargetLocales && sameStaticDist && sameDynamicDist then
+        myLocArr._value.chpl__postScan(op, res._value.myLocArr!.myElems, numTasks, rngs, state);
       else
         myLocArr._value.chpl__postScan(op, res, numTasks, rngs, state);
 


### PR DESCRIPTION
Now that duplicate targetLocales are no longer allowed for block arrays,
we know that the local array pointer `myLocArr` is safe to use. Using it
instead of `locArr[locid]` allows us to do scan operations on narrow
pointers, which reduces any wide pointer overhead.

On a 128-core Rome CPU running with just 2 cores this takes a 16G Block
scan from 4.9s to 2.9s, bringing it on par with DR. This has no real
impact when using all 128 cores since we're bandwidth bound. I expect
this to improve performance on systems with fewer cores and in cases
where not all cores are used (e.g. serial scan in a parallel region)