### PR TITLE
Suppress mason-external (spack) failures with newer python

### DIFF
--- a/test/mason/mason-external/libtomlc99/mason-external.suppressif
+++ b/test/mason/mason-external/libtomlc99/mason-external.suppressif
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 
-"""
-Mason's version of spack doesn't work on m1 currently:
-https://github.com/Cray/chapel-private/issues/3518
-"""
 
 from os import environ
+import sys
 
-print(environ['CHPL_TARGET_PLATFORM'] == 'darwin' and
-      environ['CHPL_TARGET_ARCH'] == 'arm64')
+# Mason's version of spack doesn't work on m1 currently:
+# https://github.com/Cray/chapel-private/issues/3518
+arm_mac = (environ['CHPL_TARGET_PLATFORM'] == 'darwin' and
+           environ['CHPL_TARGET_ARCH'] == 'arm64')
+# Mason's version of spack doesn't work with python >= 3.9
+# https://github.com/chapel-lang/chapel/issues/19517
+bad_python = sys.version_info.minor > 8
+
+print(arm_mac or bad_python)

--- a/test/mason/mason-external/masonExternalRanges/mason-external-range.suppressif
+++ b/test/mason/mason-external/masonExternalRanges/mason-external-range.suppressif
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 
-"""
-Mason's version of spack doesn't work on m1 currently:
-https://github.com/Cray/chapel-private/issues/3518
-"""
 
 from os import environ
+import sys
 
-print(environ['CHPL_TARGET_PLATFORM'] == 'darwin' and
-      environ['CHPL_TARGET_ARCH'] == 'arm64')
+# Mason's version of spack doesn't work on m1 currently:
+# https://github.com/Cray/chapel-private/issues/3518
+arm_mac = (environ['CHPL_TARGET_PLATFORM'] == 'darwin' and
+           environ['CHPL_TARGET_ARCH'] == 'arm64')
+# Mason's version of spack doesn't work with python >= 3.9
+# https://github.com/chapel-lang/chapel/issues/19517
+bad_python = sys.version_info.minor > 8
+
+print(arm_mac or bad_python)


### PR DESCRIPTION
The spack version we currently use for mason external only supports up
to python 3.8 and fails for anything newer. Suppress these failures
until we can upgrade spack versions.

https://github.com/chapel-lang/chapel/issues/19517 captures python version info
https://github.com/Cray/chapel-private/issues/3518 captures desire to upgrade spack