### PR TITLE
assertOnGpu do compiletime assert if not gpuizable

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -166,6 +166,7 @@ class GpuizableLoop {
   Symbol* upperBound_ = nullptr;
   std::vector<Symbol*> loopIndices_;
   std::vector<Symbol*> lowerBounds_;
+  bool shouldErrorIfNotGpuizable_;
 
 public:
   GpuizableLoop(BlockStmt* blk);
@@ -181,12 +182,15 @@ public:
   }
 
 private:
+  bool determineIfShouldErrorIfNotGpuizable();
   bool evaluateLoop();
+  bool isAlreadyInGpuKernel();
   bool parentFnAllowsGpuization();
   bool callsInBodyAreGpuizable();
   bool attemptToExtractLoopInformation();
   bool extractIndicesAndLowerBounds();
   bool extractUpperBound();
+  void reportNotGpuizable(const BaseAST* ast, const char *msg);
 
   bool callsInBodyAreGpuizableHelp(BlockStmt* blk,
                                    std::set<FnSymbol*>& okFns,
@@ -198,7 +202,45 @@ GpuizableLoop::GpuizableLoop(BlockStmt *blk) {
 
   this->loop_ = toCForLoop(blk);
   this->parentFn_ = toFnSymbol(blk->getFunction());
+  this->shouldErrorIfNotGpuizable_ = determineIfShouldErrorIfNotGpuizable();
   this->isEligible_ = evaluateLoop();
+
+  // Ideally we should error out earlier than this with a more specific
+  // error message but here's a final fallback error.
+  // There's one use case we want to exempt, which is failure to
+  // gpuize a nested loop. In this case if there was a failure to gpuize
+  // the outer loop we already would have errored.
+  if(this->shouldErrorIfNotGpuizable_ &&
+    !this->isEligible_ &&
+    !isAlreadyInGpuKernel())
+  {
+    USR_FATAL(blk, "Loop containing assertOnGpu() is not gpuizable");
+  }
+}
+
+bool GpuizableLoop::determineIfShouldErrorIfNotGpuizable() {
+  CForLoop *cfl = this->loop_;
+  INT_ASSERT(cfl);
+
+  // The gpuizable check will kick in if `assertOnGpu()` appears in the
+  // body of the loop absent of any control flow.
+  // It's necessary to do this instead of just checking the first
+  // statement as by the time we get to gpuTransforms code may have
+  // been added to the start of the loop (for example to
+  // assign to the loop iteration variable if we're iterating
+  // over values rather than indices)
+  for_alist(expr, cfl->body) {
+    CallExpr *call = toCallExpr(expr);
+    if (call && call->isPrimitive(PRIM_ASSERT_ON_GPU)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool GpuizableLoop::isAlreadyInGpuKernel() {
+  return this->parentFn_->hasFlag(FLAG_GPU_CODEGEN);
 }
 
 bool GpuizableLoop::evaluateLoop() {
@@ -214,7 +256,7 @@ bool GpuizableLoop::evaluateLoop() {
   // We currently don't support launching kernels from kernels. So if
   // the loop is within a function already marked for use on the GPU,
   // don't GPUize.
-  if(this->parentFn_->hasFlag(FLAG_GPU_CODEGEN)) {
+  if(isAlreadyInGpuKernel()) {
     return false;
   }
 
@@ -227,6 +269,7 @@ bool GpuizableLoop::parentFnAllowsGpuization() {
   FnSymbol *cur = this->parentFn_;
   while (cur) {
     if (cur->hasFlag(FLAG_NO_GPU_CODEGEN)) {
+      reportNotGpuizable(cur, "parent function does not allow gpuization");
       return false;
     }
 
@@ -262,6 +305,7 @@ bool GpuizableLoop::callsInBodyAreGpuizableHelp(BlockStmt* blk,
     if (blk->getFunction()->hasFlag(FLAG_FUNCTION_TERMINATES_PROGRAM)) {
       return true; // allow `halt` to be potentially called recursively
     } else {
+      reportNotGpuizable(fn, "function is recursive");
       return false;
     }
   }
@@ -277,20 +321,24 @@ bool GpuizableLoop::callsInBodyAreGpuizableHelp(BlockStmt* blk,
       bool inLocal = inLocalBlock(call);
       int is = classifyPrimitive(call, inLocal);
       if ((is != FAST_AND_LOCAL)) {
+        reportNotGpuizable(call, "primitive is not fast and local");
         return false;
       }
     } else if (call->isResolved()) {
       if (!allowFnCallsFromGPU)
         return false;
 
-      FnSymbol* fn = call->resolvedFunction();
+      FnSymbol *fn = call->resolvedFunction();
 
       if (fn->hasFlag(FLAG_NO_GPU_CODEGEN)) {
+        reportNotGpuizable(fn, "function is marked not gpuizable");
         return false;
       }
 
-      if (hasOuterVarAccesses(fn))
+      if (hasOuterVarAccesses(fn)) {
+        reportNotGpuizable(call, "call has outer var access");
         return false;
+      }
 
       indentGPUChecksLevel += 2;
       if (okFns.count(fn) != 0 ||
@@ -336,6 +384,7 @@ bool GpuizableLoop::extractIndicesAndLowerBounds() {
     INT_ASSERT(bs->body.length == (int)this->loopIndices_.size());
     INT_ASSERT(bs->body.length == (int)this->lowerBounds_.size());
   } else {
+    reportNotGpuizable(loop_, "loop indices not eligible for gpuization");
     return false;
   }
 
@@ -361,7 +410,20 @@ bool GpuizableLoop::extractUpperBound() {
     }
   }
 
-  return upperBound_ != nullptr;
+  if(upperBound_ == nullptr) {
+    reportNotGpuizable(loop_, "upper bound is not eligible for gpuization");
+  }
+  return true;
+}
+
+void GpuizableLoop::reportNotGpuizable(const BaseAST* ast, const char *msg) {
+  if(this->shouldErrorIfNotGpuizable_) {
+    std::string fullMsg = "Loop containing assertOnGpu() is not Gpuizable "
+                          "because " + std::string(msg);
+    USR_FATAL_CONT(loop_, "Loop containing assertOnGpu() is not Gpuizable");
+    USR_PRINT(ast, "%s", msg);
+    USR_STOP();
+  }
 }
 
 // ----------------------------------------------------------------------------

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -269,7 +269,7 @@ bool GpuizableLoop::parentFnAllowsGpuization() {
   FnSymbol *cur = this->parentFn_;
   while (cur) {
     if (cur->hasFlag(FLAG_NO_GPU_CODEGEN)) {
-      reportNotGpuizable(cur, "parent function does not allow gpuization");
+      reportNotGpuizable(cur, "parent function disallows execution on a GPU");
       return false;
     }
 
@@ -331,7 +331,7 @@ bool GpuizableLoop::callsInBodyAreGpuizableHelp(BlockStmt* blk,
       FnSymbol *fn = call->resolvedFunction();
 
       if (fn->hasFlag(FLAG_NO_GPU_CODEGEN)) {
-        reportNotGpuizable(fn, "function is marked not gpuizable");
+        reportNotGpuizable(fn, "function is marked as not eligible for GPU execution");
         return false;
       }
 
@@ -384,7 +384,7 @@ bool GpuizableLoop::extractIndicesAndLowerBounds() {
     INT_ASSERT(bs->body.length == (int)this->loopIndices_.size());
     INT_ASSERT(bs->body.length == (int)this->lowerBounds_.size());
   } else {
-    reportNotGpuizable(loop_, "loop indices not eligible for gpuization");
+    reportNotGpuizable(loop_, "loop indices do not match expected pattern for GPU execution");
     return false;
   }
 
@@ -411,16 +411,14 @@ bool GpuizableLoop::extractUpperBound() {
   }
 
   if(upperBound_ == nullptr) {
-    reportNotGpuizable(loop_, "upper bound is not eligible for gpuization");
+    reportNotGpuizable(loop_, "upper bound does not match expected pattern for GPU execution");
   }
   return true;
 }
 
 void GpuizableLoop::reportNotGpuizable(const BaseAST* ast, const char *msg) {
   if(this->shouldErrorIfNotGpuizable_) {
-    std::string fullMsg = "Loop containing assertOnGpu() is not Gpuizable "
-                          "because " + std::string(msg);
-    USR_FATAL_CONT(loop_, "Loop containing assertOnGpu() is not Gpuizable");
+    USR_FATAL_CONT(loop_, "Loop containing assertOnGpu() is not eligible for execution on a GPU");
     USR_PRINT(ast, "%s", msg);
     USR_STOP();
   }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -81,7 +81,7 @@ module GPU
   */
   pragma "insert line file info"
   pragma "always propagate line file info"
-  proc assertOnGpu() {
+  inline proc assertOnGpu() {
     __primitive("chpl_assert_on_gpu");
   }
 }

--- a/test/gpu/native/assertOnFailToGpuize.1.good
+++ b/test/gpu/native/assertOnFailToGpuize.1.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+assertOnFailToGpuize.chpl:23: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:6: note: function is recursive

--- a/test/gpu/native/assertOnFailToGpuize.1.good
+++ b/test/gpu/native/assertOnFailToGpuize.1.good
@@ -1,3 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-assertOnFailToGpuize.chpl:23: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:23: error: Loop containing assertOnGpu() is not eligible for execution on a GPU
 assertOnFailToGpuize.chpl:6: note: function is recursive

--- a/test/gpu/native/assertOnFailToGpuize.2.good
+++ b/test/gpu/native/assertOnFailToGpuize.2.good
@@ -1,3 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-assertOnFailToGpuize.chpl:30: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:30: error: Loop containing assertOnGpu() is not eligible for execution on a GPU
 assertOnFailToGpuize.chpl:7: note: function is recursive

--- a/test/gpu/native/assertOnFailToGpuize.2.good
+++ b/test/gpu/native/assertOnFailToGpuize.2.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+assertOnFailToGpuize.chpl:30: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:7: note: function is recursive

--- a/test/gpu/native/assertOnFailToGpuize.3.good
+++ b/test/gpu/native/assertOnFailToGpuize.3.good
@@ -1,4 +1,4 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 assertOnFailToGpuize.chpl:12: In function 'funcMarkedNotGpuizableThatTriesToGpuize':
-assertOnFailToGpuize.chpl:13: error: Loop containing assertOnGpu() is not Gpuizable
-assertOnFailToGpuize.chpl:12: note: parent function does not allow gpuization
+assertOnFailToGpuize.chpl:13: error: Loop containing assertOnGpu() is not eligible for execution on a GPU
+assertOnFailToGpuize.chpl:12: note: parent function disallows execution on a GPU

--- a/test/gpu/native/assertOnFailToGpuize.3.good
+++ b/test/gpu/native/assertOnFailToGpuize.3.good
@@ -1,0 +1,4 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+assertOnFailToGpuize.chpl:12: In function 'funcMarkedNotGpuizableThatTriesToGpuize':
+assertOnFailToGpuize.chpl:13: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:12: note: parent function does not allow gpuization

--- a/test/gpu/native/assertOnFailToGpuize.4.good
+++ b/test/gpu/native/assertOnFailToGpuize.4.good
@@ -1,3 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-assertOnFailToGpuize.chpl:41: error: Loop containing assertOnGpu() is not Gpuizable
-assertOnFailToGpuize.chpl:19: note: function is marked not gpuizable
+assertOnFailToGpuize.chpl:41: error: Loop containing assertOnGpu() is not eligible for execution on a GPU
+assertOnFailToGpuize.chpl:19: note: function is marked are not eligible for GPU execution

--- a/test/gpu/native/assertOnFailToGpuize.4.good
+++ b/test/gpu/native/assertOnFailToGpuize.4.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+assertOnFailToGpuize.chpl:41: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:19: note: function is marked not gpuizable

--- a/test/gpu/native/assertOnFailToGpuize.5.good
+++ b/test/gpu/native/assertOnFailToGpuize.5.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+assertOnFailToGpuize.chpl:48: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:50: note: call has outer var access

--- a/test/gpu/native/assertOnFailToGpuize.5.good
+++ b/test/gpu/native/assertOnFailToGpuize.5.good
@@ -1,3 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-assertOnFailToGpuize.chpl:48: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:48: error: Loop containing assertOnGpu() is not eligible for execution on a GPU
 assertOnFailToGpuize.chpl:50: note: call has outer var access

--- a/test/gpu/native/assertOnFailToGpuize.6.good
+++ b/test/gpu/native/assertOnFailToGpuize.6.good
@@ -1,3 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-assertOnFailToGpuize.chpl:57: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:57: error: Loop containing assertOnGpu() is not eligible for execution on a GPU
 assertOnFailToGpuize.chpl:6: note: function is recursive

--- a/test/gpu/native/assertOnFailToGpuize.6.good
+++ b/test/gpu/native/assertOnFailToGpuize.6.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+assertOnFailToGpuize.chpl:57: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:6: note: function is recursive

--- a/test/gpu/native/assertOnFailToGpuize.7.good
+++ b/test/gpu/native/assertOnFailToGpuize.7.good
@@ -1,3 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-assertOnFailToGpuize.chpl:66: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:66: error: Loop containing assertOnGpu() is not eligible for execution on a GPU
 assertOnFailToGpuize.chpl:6: note: function is recursive

--- a/test/gpu/native/assertOnFailToGpuize.7.good
+++ b/test/gpu/native/assertOnFailToGpuize.7.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+assertOnFailToGpuize.chpl:66: error: Loop containing assertOnGpu() is not Gpuizable
+assertOnFailToGpuize.chpl:6: note: function is recursive

--- a/test/gpu/native/assertOnFailToGpuize.8.good
+++ b/test/gpu/native/assertOnFailToGpuize.8.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly

--- a/test/gpu/native/assertOnFailToGpuize.chpl
+++ b/test/gpu/native/assertOnFailToGpuize.chpl
@@ -1,0 +1,82 @@
+use GPU;
+
+config param failureMode = 8;
+var globalVar = 0;
+
+proc directlyRecursiveFunc() { directlyRecursiveFunc(); }
+proc indirectlyRecursiveFunc() { indirectlyRecursiveFunc2(); }
+proc indirectlyRecursiveFunc2() { indirectlyRecursiveFunc(); }
+proc usesOutsideVar() { return globalVar; }
+
+pragma "no gpu codegen"
+proc funcMarkedNotGpuizableThatTriesToGpuize() {
+  foreach i in 0..10 {
+    assertOnGpu();
+  }
+}
+
+pragma "no gpu codegen"
+proc funcMarkedNotGpuizable() { }
+
+on here.gpus[0] {
+  if failureMode == 1 {
+    foreach i in 0..10 {
+      assertOnGpu();
+      directlyRecursiveFunc();
+    }
+  }
+
+  if failureMode == 2 {
+    foreach i in 0..10 {
+      assertOnGpu();
+      indirectlyRecursiveFunc();
+    }
+  }
+
+  if failureMode == 3 {
+    funcMarkedNotGpuizableThatTriesToGpuize();
+  }
+
+  if failureMode == 4 {
+    foreach i in 0..10 {
+      assertOnGpu();
+      funcMarkedNotGpuizable();
+    }
+  }
+
+  if failureMode == 5 {
+    foreach i in 0..10 {
+      assertOnGpu();
+      usesOutsideVar();
+    }
+  }
+
+  // I want to ensure this works
+  // with forall loops as well:
+  if failureMode == 6 {
+    forall i in 0..10 {
+      assertOnGpu();
+      directlyRecursiveFunc();
+    }
+  }
+
+  // And loops of a multidimensional array:
+  if failureMode == 7 {
+    var A: [1..10, 1..10] int;
+    foreach a in A {
+      assertOnGpu();
+      directlyRecursiveFunc();
+    }
+  }
+
+  // Also ensure that assertOnGpu does not fail
+  // for the following (use failureMode >= 8
+  // to run these tests):
+  foreach i in 0..10 { assertOnGpu(); }
+  forall i in 0..10 { assertOnGpu(); }
+  var A: [1..10, 1..10] int;
+  foreach a in A { assertOnGpu(); }
+  foreach idx in {0..10, 0..10} { assertOnGpu(); }
+  forall a in A { assertOnGpu(); }
+  forall idx in {0..10, 0..10} { assertOnGpu(); }
+}

--- a/test/gpu/native/assertOnFailToGpuize.compopts
+++ b/test/gpu/native/assertOnFailToGpuize.compopts
@@ -1,0 +1,8 @@
+-sfailureMode=1 # assertOnFailToGpuize.1.good
+-sfailureMode=2 # assertOnFailToGpuize.2.good
+-sfailureMode=3 # assertOnFailToGpuize.3.good
+-sfailureMode=4 # assertOnFailToGpuize.4.good
+-sfailureMode=5 # assertOnFailToGpuize.5.good
+-sfailureMode=6 # assertOnFailToGpuize.6.good
+-sfailureMode=7 # assertOnFailToGpuize.7.good
+-sfailureMode=8 # assertOnFailToGpuize.8.good

--- a/test/gpu/native/gpuWritelnAndAssertOnGpu.chpl
+++ b/test/gpu/native/gpuWritelnAndAssertOnGpu.chpl
@@ -21,13 +21,12 @@ on here.gpus[0] {
   // should have been flushed to the terminal..
 
   writeln("Before next loop");
-
-  foreach i in 0..10 {
-    assertOnGpu();
-    writeln("As of today this will throw us off the GPU");
-  }
-
-  writeln("!!! This message should not be displayed unless there's a bug in");
-  writeln("    assertOnGpu or we fixed things so that writeln can be Gpuized. If that's");
-  writeln("    fixed then cool we can get rid of gpuWriteln and this test!");
 }
+
+// Should produce runtime error
+foreach i in 0..10 {
+  assertOnGpu();
+}
+
+writeln("!!! This message should not be displayed unless there's a bug in");
+writeln("    assertOnGpu.");

--- a/test/gpu/native/gpuWritelnAndAssertOnGpu.good
+++ b/test/gpu/native/gpuWritelnAndAssertOnGpu.good
@@ -5,4 +5,4 @@ hello from the GPU again!
 hello from function called by GPU!
 hello again from  function called by GPU!
 Before next loop
-gpuWritelnAndAssertOnGpu.chpl:26: error: assertOnGpu() failed
+gpuWritelnAndAssertOnGpu.chpl:28: error: assertOnGpu() failed


### PR DESCRIPTION
This change will cause `assertOnGpu` to produce a compile time error in any loop that contains it if that loop fails to GPUize.  This also lets us give some better error messages to explain why a loop failed to GPUize (for example: because it had a call to a recursive function or because it accesses a global variable).

Some additional details:

* I inline the assertOnGpu() procedure so by the time we get gpuTransforms I can just check for the presence of the primitive we use for this.
* From an optimal performance standpoint it's probably not great that I'm introducing an extra pass over the loop body to look for the presence of this primitive. We end up doing a later pass over the loop body anyway so in theory I could try and restructure things to do the check there. In practice I wouldn't expect it makes a big perf difference though.
* For cases where we have nested loops we won't trigger the compile time assertion if the inner loop fails to gpuize -- if the outer loop gpuizes you'll still be on the GPU, there just won't be a nested kernel launch.