### PR TITLE
Fix anonymousRangeIter test after disambiguation PR

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2067,8 +2067,7 @@ operator :(r: range(?), type t: range(?)) {
   iter chpl_direct_strided_range_iter(param low: integral,
                                       param high: integral,
                                       param stride: integral) {
-    const r = low..high by stride;
-    for i in r do yield i;
+    for i in chpl_direct_param_stride_range_iter(low, high, stride) do yield i;
   }
 
   iter chpl_direct_strided_range_iter(low: int(?w), high: int(w), param stride : integral) {

--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -29,12 +29,12 @@ _ic__F#_high_chpl# = INT#(#);
 for (i_chpl# = INT#(#); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {
 
 # for i in 2..#4 do write(i); writeln();
-_ic__F#_high_chpl# = tmp_x#_chpl;
-for (i_chpl# = tmp_x#_chpl; ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {
+_ic__F#_high_chpl# = tmp_chpl#;
+for (i_chpl# = INT#(#); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {
 
 # for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();
 _ic__F#_i_chpl = INT#(#);
 for (_ic__F#_i_chpl = INT#(#),_ic__F#_i_chpl# = INT#(#); (tmp_chpl# = (_ic__F#_i_chpl <= INT#(#)),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT#(#),_ic__F#_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(-#),_ic__F#_i_chpl# = tmp_chpl#) {
 
 # var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
-for (_ic__F#_i_chpl# = INT#(#),_ic__F#_i_chpl = tmp_chpl#; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(#),_ic__F#_i_chpl# = tmp_chpl#,tmp_chpl# = _ic__F#_this_chpl,tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += (&tmp_chpl#)->_stride,_ic__F#_i_chpl = tmp_chpl#) {
+for (_ic__F#_i_chpl# = INT#(#),_ic__F#_i_chpl# = tmp_chpl#; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(#),_ic__F#_i_chpl# = tmp_chpl#,tmp_chpl# = _ic__F#_this_chpl,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += (&tmp_chpl#)->_stride,_ic__F#_i_chpl# = tmp_chpl#) {


### PR DESCRIPTION
Follow-up to PR #20528.

This PR fixes a test failure for test/types/range/elliot/anonymousRangeIter.chpl.

- [x] full local quickstart CHPL_LLVM=none testing
- [x] full local testing

Reviewed by @benharsh - thanks!