### PR TITLE
fix(chpldoc): address failed smoketest on mac-overflow

### DIFF
--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1867,7 +1867,7 @@ commentMap(Context* context, ID id) {
                                                        id);
 
   CommentVisitor cv{result};
-  for (const auto& ast : builderResult->topLevelExpressions()) {
+  for (const chpl::uast::AstNode* ast : builderResult->topLevelExpressions()) {
     ast->traverse(cv);
   }
 
@@ -2253,7 +2253,7 @@ int main(int argc, char** argv) {
       }
     }
     // gather all the top level and used/imported/included module IDs
-    for (const auto& ast : builderResult.topLevelExpressions()) {
+    for (const chpl::uast::AstNode* ast : builderResult.topLevelExpressions()) {
       ast->traverse(gather);
     }
   }

--- a/compiler/dyno/tools/chpldoc/chpldoc.cpp
+++ b/compiler/dyno/tools/chpldoc/chpldoc.cpp
@@ -1868,6 +1868,11 @@ commentMap(Context* context, ID id) {
 
   CommentVisitor cv{result};
   for (const chpl::uast::AstNode* ast : builderResult->topLevelExpressions()) {
+    /* note the use of the above pattern rather than `const auto& ast:`
+    was motivated by a compiler error from chapelmac during smoketests
+    that complained about the pattern and suggested this replacement,
+    which it seems satisfied with.
+    */
     ast->traverse(cv);
   }
 
@@ -2254,6 +2259,11 @@ int main(int argc, char** argv) {
     }
     // gather all the top level and used/imported/included module IDs
     for (const chpl::uast::AstNode* ast : builderResult.topLevelExpressions()) {
+      /* note the use of the above pattern rather than `const auto& ast:`
+          was motivated by a compiler error from chapelmac during smoketests
+          that complained about the pattern and suggested this replacement,
+          which it seems satisfied with.
+      */
       ast->traverse(gather);
     }
   }


### PR DESCRIPTION
This PR fixes an error reported by `chapelmac` smoketests.

The compiler did not like
`const auto& ast : builderResult->topLevelExpressions())`
and complained about the iterator being copied on every loop. 
It suggested replacing the statement with 
`const chpl::uast::AstNode* ast : builderResult->topLevelExpressions())`
which is the change that I implemented. 

TESTING: 
- [x] `test/chpldocs` all pass
- [x] fixes failure mode on `chapelmac` machine

reviewed by @benharsh - thank you!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>