### PR TITLE
Add mkdir -p for bin directory for dyno-chpldoc

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -164,19 +164,17 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 	$(TAGS_COMMAND)
 	$(EBROWSE_COMMAND)
 
-$(CHPLDOC): $(CHPL) dyno-chpldoc $(CHPLDOC)-legacy
-
-$(CHPLDOC)-legacy:
-	rm -f $(CHPLDOC)-legacy
-	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
-
-# setup a phony rule to detect when dyno-chpldoc needs to be rebuilt
-.PHONY: dyno-chpldoc
-dyno-chpldoc:
+$(CHPLDOC): $(CHPL_BIN_DIR)
 	rm -f $(CHPLDOC)
 	@cd ../compiler/dyno && $(MAKE) -f Makefile.help dyno-chpldoc
 
-chpldoc: $(CHPLDOC)
+$(CHPLDOC)-legacy: $(CHPL_BIN_DIR)
+	rm -f $(CHPLDOC)-legacy
+	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
+
+chpldoc: $(CHPL_BIN_DIR) $(CHPLDOC) $(CHPLDOC)-legacy
+
+dyno-chpldoc: chpldoc
 
 $(COMPILER_BUILD):
 	mkdir -p $@

--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -78,6 +78,7 @@ dyno-parser: $(LIBCOMPILER_BUILD_DIR) FORCE
 
 dyno-chpldoc: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc && $(CMAKE) --build . --target chpldoc
+	mkdir -p $(CHPL_BIN_DIR)
 	cp -f $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc/chpldoc $(CHPL_BIN_DIR)/chpldoc
 
 dyno-linters: $(LIBCOMPILER_BUILD_DIR) FORCE


### PR DESCRIPTION
I noticed a problem if I had done 'make clobber' and then do 'make dyno-chpldoc' there were errors due to the bin directory not existing yet.

This PR just adds some dependencies on Makefile rules that should add the directory and also a `mkdir -p` just before where it was failing.