### PR TITLE
Allow iterating over range counted by bool & test it

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2152,10 +2152,22 @@ operator :(r: range(?), type t: range(?)) {
   //
 
   iter chpl_direct_counted_range_iter(low: int(?w), count) {
+    if !isIntegral(count) && !isBool(count) {
+      compilerError("can't apply '#' to a range with idxType ",
+                    low.type:string, " using a count of type ",
+                    count.type:string);
+    }
+
     for i in chpl_direct_counted_range_iter_helper(low, count) do yield i;
   }
 
   iter chpl_direct_counted_range_iter(low: uint(?w), count) {
+    if !isIntegral(count) && !isBool(count) {
+      compilerError("can't apply '#' to a range with idxType ",
+                    low.type:string, " using a count of type ",
+                    count.type:string);
+    }
+
     for i in chpl_direct_counted_range_iter_helper(low, count) do yield i;
   }
 

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2151,11 +2151,11 @@ operator :(r: range(?), type t: range(?)) {
   // Direct range iterators for low bounded counted ranges (low..#count)
   //
 
-  iter chpl_direct_counted_range_iter(low: int(?w), count: integral) {
+  iter chpl_direct_counted_range_iter(low: int(?w), count) {
     for i in chpl_direct_counted_range_iter_helper(low, count) do yield i;
   }
 
-  iter chpl_direct_counted_range_iter(low: uint(?w), count: integral) {
+  iter chpl_direct_counted_range_iter(low: uint(?w), count) {
     for i in chpl_direct_counted_range_iter_helper(low, count) do yield i;
   }
 

--- a/test/types/range/nonIntTypes/countedByBool.chpl
+++ b/test/types/range/nonIntTypes/countedByBool.chpl
@@ -1,0 +1,25 @@
+proc main() {
+  var myBool: bool = true;
+
+  writeln("iterating over param range variable");
+  var r1 = 0.. # true;
+  for k in r1 {
+    writeln("k = ", k, " : ", k.type:string);
+  }
+
+  writeln("iterating over range variable");
+  var r2 = 0.. # myBool;
+  for k in r2 {
+    writeln("k = ", k, " : ", k.type:string);
+  }
+
+  writeln("iterating over param range literal");
+  for k in 0.. # true {
+    writeln("k = ", k, " : ", k.type:string);
+  }
+
+  writeln("iterating over range literal");
+  for k in 0.. # myBool {
+    writeln("k = ", k, " : ", k.type:string);
+  }
+}

--- a/test/types/range/nonIntTypes/countedByBool.good
+++ b/test/types/range/nonIntTypes/countedByBool.good
@@ -1,0 +1,8 @@
+iterating over param range variable
+k = 0 : int(64)
+iterating over range variable
+k = 0 : int(64)
+iterating over param range literal
+k = 0 : int(64)
+iterating over range literal
+k = 0 : int(64)


### PR DESCRIPTION
This is to fix a problem building Arkouda after PR #20595.

It is not so clear to me that it makes sense to have a `bool` count, but since `bool` can coerce to an integer type, it seems OK. Before PR #20528, the count arguments were matching the low bound type, but that PR changed them to `integral` to match other choices about counting. However, `count:integral` arguments cannot currently accept a `bool` (but issue #20011 requests that they could). Since the helper code will cast them appropriately, this PR just removes the type constraint.

- [x] test/types/range/elliot passes with CHPL_LLVM=none
- [x] Arkouda builds
- [x] full local testing

Reviewed by @benharsh and @bradcray - thanks!