### PR TITLE
Build dyno-chpldoc with Makefiles only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ test-venv: third-party-test-venv
 
 chpldoc: compiler third-party-chpldoc-venv
 	cd compiler && $(MAKE) chpldoc
+	@cd modules && $(MAKE)
 	@test -r Makefile.devel && $(MAKE) man-chpldoc || echo ""
 
 always-build-test-venv: FORCE

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ clean: FORCE
 	cd modules && $(MAKE) clean
 	cd runtime && $(MAKE) clean
 	cd third-party && $(MAKE) clean
+	cd compiler/dyno/tools/chpldoc && $(MAKE) clean
 	if [ -e doc/Makefile ]; then cd doc && $(MAKE) clean; fi
 	rm -f util/chplenv/*.pyc
 
@@ -174,6 +175,7 @@ cleanall: FORCE
 	cd modules && $(MAKE) cleanall
 	cd runtime && $(MAKE) cleanall
 	cd third-party && $(MAKE) cleanall
+	cd compiler/dyno/tools/chpldoc && $(MAKE) cleanall
 	if [ -e doc/Makefile ]; then cd doc && $(MAKE) cleanall; fi
 	rm -f util/chplenv/*.pyc
 	rm -rf build
@@ -191,6 +193,7 @@ clobber: FORCE
 	cd tools/c2chapel && $(MAKE) clobber
 	cd tools/mason && $(MAKE) clobber
 	cd tools/protoc-gen-chpl && $(MAKE) clobber
+	cd compiler/dyno/tools/chpldoc && $(MAKE) clobber
 	if [ -e doc/Makefile ]; then cd doc && $(MAKE) clobber; fi
 	rm -rf bin
 	rm -rf lib

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -73,9 +73,6 @@ test-dyno: dyno FORCE
 dyno-parser: FORCE
 	@cd compiler/dyno && $(MAKE) -f Makefile.help dyno-parser
 
-dyno-chpldoc: FORCE
-	@cd compiler/dyno && $(MAKE) -f Makefile.help dyno-chpldoc
-
 run-dyno-linters: FORCE
 	@cd compiler/dyno && $(MAKE) -f Makefile.help run-dyno-linters
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -164,19 +164,17 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 	$(TAGS_COMMAND)
 	$(EBROWSE_COMMAND)
 
-$(CHPLDOC): $(CHPL) dyno-chpldoc $(CHPLDOC)-legacy
-
-$(CHPLDOC)-legacy:
-	rm -f $(CHPLDOC)-legacy
-	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
-
-# setup a phony rule to detect when dyno-chpldoc needs to be rebuilt
-.PHONY: dyno-chpldoc
-dyno-chpldoc:
+$(CHPLDOC): $(CHPL_BIN_DIR)
 	rm -f $(CHPLDOC)
 	@cd ../compiler/dyno && $(MAKE) -f Makefile.help dyno-chpldoc
 
-chpldoc: $(CHPLDOC)
+$(CHPLDOC)-legacy: $(CHPL_BIN_DIR)
+	rm -f $(CHPLDOC)-legacy
+	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
+
+chpldoc: $(CHPL_BIN_DIR) $(CHPLDOC) $(CHPLDOC)-legacy
+
+dyno-chpldoc: chpldoc
 
 $(COMPILER_BUILD):
 	mkdir -p $@

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -53,6 +53,13 @@ SUBDIRS = \
 
 
 CHPLDOC_SUBDIRS = \
+	dyno/lib/immediates \
+	dyno/lib/parsing \
+	dyno/lib/framework \
+	dyno/lib/resolution \
+	dyno/lib/types \
+	dyno/lib/uast \
+	dyno/lib/util \
 	dyno/tools/chpldoc \
 
 
@@ -185,7 +192,7 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 
 MAKEALLCHPLDOCSUBDIRS = $(CHPLDOC_SUBDIRS:%=%.makedir)
 
-$(CHPLDOC): $(CHPLDOC_OBJS) | $(MAKEALLCHPLDOCSUBDIRS) $(CHPL_BIN_DIR)
+$(CHPLDOC): $(MAKEALLCHPLDOCSUBDIRS) $(CHPLDOC_OBJS) | $(CHPL_BIN_DIR)
 	$(CXX) $(LDFLAGS) -o $@ $(CHPLDOC_OBJS) $(CHPL_MAKE_HOST_BUNDLED_LINK_ARGS) $(LIBS) $(LLVM_EXTRA_LIBS) $(CHPL_MAKE_HOST_SYSTEM_LINK_ARGS)
 
 $(CHPLDOC)-legacy: | $(CHPL_BIN_DIR)

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -50,7 +50,11 @@ SUBDIRS = \
 	passes \
 	resolution \
 	util \
+
+
+CHPLDOC_SUBDIRS = \
 	dyno/tools/chpldoc \
+
 
 #
 # include standard header for compiler
@@ -179,7 +183,9 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 	$(TAGS_COMMAND)
 	$(EBROWSE_COMMAND)
 
-$(CHPLDOC): $(CHPLDOC_OBJS) | $(CHPL_BIN_DIR)
+MAKEALLCHPLDOCSUBDIRS = $(CHPLDOC_SUBDIRS:%=%.makedir)
+
+$(CHPLDOC): $(CHPLDOC_OBJS) | $(MAKEALLCHPLDOCSUBDIRS) $(CHPL_BIN_DIR)
 	$(CXX) $(LDFLAGS) -o $@ $(CHPLDOC_OBJS) $(CHPL_MAKE_HOST_BUNDLED_LINK_ARGS) $(LIBS) $(LLVM_EXTRA_LIBS) $(CHPL_MAKE_HOST_SYSTEM_LINK_ARGS)
 
 $(CHPLDOC)-legacy: | $(CHPL_BIN_DIR)

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -50,6 +50,7 @@ SUBDIRS = \
 	passes \
 	resolution \
 	util \
+	dyno/tools/chpldoc \
 
 #
 # include standard header for compiler
@@ -93,6 +94,9 @@ include passes/Makefile.include
 include resolution/Makefile.include
 include util/Makefile.include
 
+# sources here are only used to build chpldoc
+include dyno/tools/chpldoc/Makefile.include
+
 SRCS =
 
 CHPL_OBJS = \
@@ -109,13 +113,24 @@ CHPL_OBJS = \
 	$(RESOLUTION_OBJS) \
 	$(SYMTAB_OBJS) \
 	$(UTIL_OBJS) \
+	$(DYNO_FRAMEWORK_OBJS) \
 	$(DYNO_IMMEDIATES_OBJS) \
 	$(DYNO_PARSING_OBJS) \
-	$(DYNO_FRAMEWORK_OBJS) \
 	$(DYNO_RESOLUTION_OBJS) \
 	$(DYNO_TYPES_OBJS) \
 	$(DYNO_UAST_OBJS) \
 	$(DYNO_UTIL_OBJS) \
+
+
+CHPLDOC_OBJS = \
+	$(DYNO_FRAMEWORK_OBJS) \
+	$(DYNO_IMMEDIATES_OBJS) \
+	$(DYNO_PARSING_OBJS) \
+	$(DYNO_RESOLUTION_OBJS) \
+	$(DYNO_TYPES_OBJS) \
+	$(DYNO_UAST_OBJS) \
+	$(DYNO_UTIL_OBJS) \
+        $(DYNO_CHPLDOC_OBJS) \
 
 
 EXECS = $(CHPL) $(CHPLDOC)
@@ -164,15 +179,14 @@ $(CHPL): $(CHPL_OBJS) $(CHPL_CONFIG_CHECK) | $(CHPL_BIN_DIR)
 	$(TAGS_COMMAND)
 	$(EBROWSE_COMMAND)
 
-$(CHPLDOC): $(CHPL_BIN_DIR)
-	rm -f $(CHPLDOC)
-	@cd ../compiler/dyno && $(MAKE) -f Makefile.help dyno-chpldoc
+$(CHPLDOC): $(CHPLDOC_OBJS) | $(CHPL_BIN_DIR)
+	$(CXX) $(LDFLAGS) -o $@ $(CHPLDOC_OBJS) $(CHPL_MAKE_HOST_BUNDLED_LINK_ARGS) $(LIBS) $(LLVM_EXTRA_LIBS) $(CHPL_MAKE_HOST_SYSTEM_LINK_ARGS)
 
-$(CHPLDOC)-legacy: $(CHPL_BIN_DIR)
+$(CHPLDOC)-legacy: | $(CHPL_BIN_DIR)
 	rm -f $(CHPLDOC)-legacy
 	ln -s $(notdir $(CHPL)) $(CHPLDOC)-legacy
 
-chpldoc: $(CHPL_BIN_DIR) $(CHPLDOC) $(CHPLDOC)-legacy
+chpldoc: $(CHPLDOC) $(CHPLDOC)-legacy
 
 dyno-chpldoc: chpldoc
 

--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -78,6 +78,7 @@ dyno-parser: $(LIBCOMPILER_BUILD_DIR) FORCE
 
 dyno-chpldoc: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc && $(CMAKE) --build . --target chpldoc
+	mkdir -p $(CHPL_BIN_DIR)
 	cp -f $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc/chpldoc $(CHPL_BIN_DIR)/chpldoc
 
 dyno-linters: $(LIBCOMPILER_BUILD_DIR) FORCE

--- a/compiler/dyno/tools/chpldoc/Makefile
+++ b/compiler/dyno/tools/chpldoc/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/../../../..
+endif
+
+COMPILER_ROOT = ../../..
+COMPILER_SUBDIR = dyno/tools/chpldoc
+
+#
+# standard header
+#
+include $(COMPILER_ROOT)/make/Makefile.compiler.head
+
+include Makefile.include
+
+TARGETS = $(DYNO_CHPLDOC_OBJS)
+
+include $(COMPILER_ROOT)/make/Makefile.compiler.subdirrules
+
+FORCE:
+
+#
+# standard footer
+#
+include $(COMPILER_ROOT)/make/Makefile.compiler.foot

--- a/compiler/dyno/tools/chpldoc/Makefile.include
+++ b/compiler/dyno/tools/chpldoc/Makefile.include
@@ -1,0 +1,32 @@
+# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DYNO_CHPLDOC_OBJDIR = $(COMPILER_BUILD)/dyno/tools/chpldoc
+
+ALL_SRCS += dyno/tools/chpldoc/*.h dyno/tools/chpldoc/*.cpp
+
+DYNO_CHPLDOC_SRCS =                              \
+           arg-helpers.cpp \
+           arg.cpp \
+           chpldoc.cpp \
+
+
+SRCS = $(DYNO_CHPLDOC_SRCS)
+
+DYNO_CHPLDOC_OBJS = \
+	$(DYNO_CHPLDOC_SRCS:%.cpp=$(DYNO_CHPLDOC_OBJDIR)/%.$(OBJ_SUFFIX))


### PR DESCRIPTION
This PR adjusts `chpldoc` (which is now the dyno-chpldoc) to build entirely with `make` instead of using `cmake`. This is a temporary measure for this release. In the future it would be good to use `cmake` for this and other tasks and that is possible now that `cmake` is a dependency. However, building `chpldoc` only with `make` will simplify the transition to dyno-chpldoc.

Reviewed by @arezaii - thanks!

- [x] full local testing
