### PR TITLE
Deprecate 'arrayIndicesAlwaysLocal'

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -42,12 +42,6 @@ module ChapelArray {
   pragma "no doc"
   param nullPid = -1;
 
-  // This permits a user to opt into upcoming behavior to always have
-  // .indices return local indices for an array
-  pragma "no doc"
-  deprecated "'arrayIndicesAlwaysLocal' is deprecated and no longer has an effect"
-  config param arrayIndicesAlwaysLocal = true;
-
   pragma "no doc"
   config param debugBulkTransfer = false;
   pragma "no doc"

--- a/test/deprecated/arrayIndicesAlwaysLocal.chpl
+++ b/test/deprecated/arrayIndicesAlwaysLocal.chpl
@@ -1,2 +1,0 @@
-var A: [1..10] real;
-writeln(A.indices);

--- a/test/deprecated/arrayIndicesAlwaysLocal.compopts
+++ b/test/deprecated/arrayIndicesAlwaysLocal.compopts
@@ -1,1 +1,0 @@
--sarrayIndicesAlwaysLocal=false

--- a/test/deprecated/arrayIndicesAlwaysLocal.good
+++ b/test/deprecated/arrayIndicesAlwaysLocal.good
@@ -1,3 +1,0 @@
-warning: 'arrayIndicesAlwaysLocal' is deprecated and no longer has an effect
-note: 'arrayIndicesAlwaysLocal' was set via a compiler flag
-{1..10}


### PR DESCRIPTION
Remove this outdated/deprecated mechanism for changing the
behavior of `array.indices` which was used to transition from
old behavior to new.  Removing it to clean up.
