### PR TITLE
Fix typo in gpu test

### DIFF
--- a/test/gpu/native/assertOnFailToGpuize.4.good
+++ b/test/gpu/native/assertOnFailToGpuize.4.good
@@ -1,3 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 assertOnFailToGpuize.chpl:41: error: Loop containing assertOnGpu() is not eligible for execution on a GPU
-assertOnFailToGpuize.chpl:19: note: function is marked are not eligible for GPU execution
+assertOnFailToGpuize.chpl:19: note: function is marked as not eligible for GPU execution


### PR DESCRIPTION
This failed our nightly Jenkins GPU tests job (and good thing to since it's a typo). I'm in the habit of manually running the gpu tests before submitting so I'm unsure how I missed this one (possibly I made a last minute change, walked away, then forgot to redo it). Anyway apologies for the noise but I'm glad Jenkins caught it.