### PR TITLE
accidentally allow gpuization on failing upper-bounds check

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -412,6 +412,7 @@ bool GpuizableLoop::extractUpperBound() {
 
   if(upperBound_ == nullptr) {
     reportNotGpuizable(loop_, "upper bound does not match expected pattern for GPU execution");
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
This is a bug introduced by an earlier PR: https://github.com/chapel-lang/chapel/pull/20593, which was causing the following test to fail with a sefault: `gpu/native/multiLocale/cyclicDist`.

Basically I added a better error message in a case where we fail to gpuize but I accidentally removed the `return false` statement that indicates we should fail to gpuize.

The fix for this is easy but what's more concerning is this shows we only have test coverage for this particular failure mode in our gasnet/multilocale test configuration. The (expected) fail-to-gpuize occurs when we have a CForLoop who's upper bound doesn't match the expected pattern.  I'll add another issue about trying to beef up test coverage for this (and related cases) but I'll do it outside this PR.