### PR TITLE
Update Potpourri.rst for changes to the util/devel/grep scripts

### DIFF
--- a/doc/rst/developer/bestPractices/Potpourri.rst
+++ b/doc/rst/developer/bestPractices/Potpourri.rst
@@ -38,10 +38,9 @@ In ``$CHPL_HOME/util/devel/`` - grep these files:
 
 * grepchpl    - all of the above
 
-* grepgoods   - .good files in the test subtree
-
 * grepstdchdrs - grep C files to look for std C header ``#includes``
 
-* greptests    - Chapel sources in the test subtree
-
-* greptestoutputs - .good files from the test subtree
+* greptests   - grep files in the test subtree.  Takes argument with ``-t`` to
+  specify the file type to search through (e.g. ``-t tests`` to search ``.chpl``
+  files, ``-t outputs`` to search ``.good`` and ``.bad`` files, etc), defaulting
+  to ``tests``.


### PR DESCRIPTION
`grepgoods` and `greptestoutputs` have been merged into `greptests` and
`greptests` has been expanded to include more options.  This change removes the
old entries and expands the entry for `greptests`.

Passed `make docs`