### PR TITLE
Start test cmd output

### DIFF
--- a/test/testsystem/failingCases/README
+++ b/test/testsystem/failingCases/README
@@ -1,0 +1,5 @@
+This directory contains a number of tests that are meant to demonstrate
+different failure modes that can be encountered when running `start_test`.
+
+To "reset" things use you can use the `cleanup` script (or just use normal git
+commands).

--- a/test/testsystem/failingCases/cleanUp
+++ b/test/testsystem/failingCases/cleanUp
@@ -1,0 +1,13 @@
+rm *.out.tmp
+rm compile_error_missing_good.good
+rm runtime_error_missing_good.good
+rm compile_error_missing_good_for_case.mode1.good
+rm compile_error_missing_good_for_case.mode2.good
+rm runtime_error_missing_good_for_case.mode1.good
+rm runtime_error_missing_good_for_case.mode2.good
+echo "BAD_OUTPUT" > compile_error_bad_good.good
+echo "BAD_OUTPUT" > runtime_error_bad_good.good
+echo "BAD_OUTPUT" > compile_error_bad_good_for_case.mode1.good
+echo "BAD_OUTPUT" > compile_error_bad_good_for_case.mode2.good
+echo "BAD_OUTPUT" > runtime_error_bad_good_for_case.mode1.good
+echo "BAD_OUTPUT" > runtime_error_bad_good_for_case.mode2.good

--- a/test/testsystem/failingCases/compile_error_bad_good.chpl
+++ b/test/testsystem/failingCases/compile_error_bad_good.chpl
@@ -1,0 +1,1 @@
+syntax_error

--- a/test/testsystem/failingCases/compile_error_bad_good.good
+++ b/test/testsystem/failingCases/compile_error_bad_good.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/compile_error_bad_good.mode1.good
+++ b/test/testsystem/failingCases/compile_error_bad_good.mode1.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/compile_error_bad_good.mode2.good
+++ b/test/testsystem/failingCases/compile_error_bad_good.mode2.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/compile_error_bad_good_for_case.chpl
+++ b/test/testsystem/failingCases/compile_error_bad_good_for_case.chpl
@@ -1,0 +1,1 @@
+syntax_error

--- a/test/testsystem/failingCases/compile_error_bad_good_for_case.compopts
+++ b/test/testsystem/failingCases/compile_error_bad_good_for_case.compopts
@@ -1,0 +1,2 @@
+-sSomeParam=1 # compile_error_bad_good_for_case.mode1.good
+-sSomeParam=2 # compile_error_bad_good_for_case.mode2.good

--- a/test/testsystem/failingCases/compile_error_bad_good_for_case.mode1.good
+++ b/test/testsystem/failingCases/compile_error_bad_good_for_case.mode1.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/compile_error_bad_good_for_case.mode2.good
+++ b/test/testsystem/failingCases/compile_error_bad_good_for_case.mode2.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/compile_error_missing_good.chpl
+++ b/test/testsystem/failingCases/compile_error_missing_good.chpl
@@ -1,0 +1,1 @@
+syntax_error

--- a/test/testsystem/failingCases/compile_error_missing_good_for_case.chpl
+++ b/test/testsystem/failingCases/compile_error_missing_good_for_case.chpl
@@ -1,0 +1,1 @@
+syntax_error

--- a/test/testsystem/failingCases/compile_error_missing_good_for_case.compopts
+++ b/test/testsystem/failingCases/compile_error_missing_good_for_case.compopts
@@ -1,0 +1,2 @@
+-sSomeParam=1 # compile_error_missing_good_for_case.mode1.good
+-sSomeParam=2 # compile_error_missing_good_for_case.mode2.good

--- a/test/testsystem/failingCases/runtime_error_bad_good.chpl
+++ b/test/testsystem/failingCases/runtime_error_bad_good.chpl
@@ -1,0 +1,1 @@
+writeln("Hello world");

--- a/test/testsystem/failingCases/runtime_error_bad_good.good
+++ b/test/testsystem/failingCases/runtime_error_bad_good.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/runtime_error_bad_good.mode1.good
+++ b/test/testsystem/failingCases/runtime_error_bad_good.mode1.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/runtime_error_bad_good.mode2.good
+++ b/test/testsystem/failingCases/runtime_error_bad_good.mode2.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/runtime_error_bad_good_for_case.chpl
+++ b/test/testsystem/failingCases/runtime_error_bad_good_for_case.chpl
@@ -1,0 +1,2 @@
+config const SomeParam = 1;
+writeln("Hello world");

--- a/test/testsystem/failingCases/runtime_error_bad_good_for_case.execopts
+++ b/test/testsystem/failingCases/runtime_error_bad_good_for_case.execopts
@@ -1,0 +1,2 @@
+-sSomeParam=1 # runtime_error_bad_good_for_case.mode1.good
+-sSomeParam=2 # runtime_error_bad_good_for_case.mode2.good

--- a/test/testsystem/failingCases/runtime_error_bad_good_for_case.mode1.good
+++ b/test/testsystem/failingCases/runtime_error_bad_good_for_case.mode1.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/runtime_error_bad_good_for_case.mode2.good
+++ b/test/testsystem/failingCases/runtime_error_bad_good_for_case.mode2.good
@@ -1,0 +1,1 @@
+BAD_OUTPUT

--- a/test/testsystem/failingCases/runtime_error_missing_good.chpl
+++ b/test/testsystem/failingCases/runtime_error_missing_good.chpl
@@ -1,0 +1,1 @@
+writeln("hello world");

--- a/test/testsystem/failingCases/runtime_error_missing_good_for_case.chpl
+++ b/test/testsystem/failingCases/runtime_error_missing_good_for_case.chpl
@@ -1,0 +1,2 @@
+config const SomeParam = 1;
+writeln("hello world");

--- a/test/testsystem/failingCases/runtime_error_missing_good_for_case.execopts
+++ b/test/testsystem/failingCases/runtime_error_missing_good_for_case.execopts
@@ -1,0 +1,2 @@
+-sSomeParam=1 # runtime_error_missing_good_for_case.mode1.good
+-sSomeParam=2 # runtime_error_missing_good_for_case.mode2.good

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -367,6 +367,8 @@ def summarize():
     passing_futures_marker = "{0}.*{1}".format(future_marker, success_marker)
     success_marker = "^" + success_marker
     skip_stdin_redirect_marker = r"^\[Skipping test with .stdin input"
+    re_good_cmd_marker = r"\[To re-good execute:"
+    re_good_cmd_matcher = re.compile(r"\[To re-good execute: (.*)]")
 
     # setup counts and blank strings to hold summaries
     global failures # for exit codes later
@@ -377,6 +379,7 @@ def summarize():
     passing_suppressions = 0
     passing_futures = 0
     skip_stdin_redirects = 0
+    regood_command_summary = ""
     failure_summary = ""
     suppression_summary = ""
     future_summary = ""
@@ -405,8 +408,14 @@ def summarize():
                 passing_futures += 1
             elif re.search(skip_stdin_redirect_marker, line, flags=re.M):
                 skip_stdin_redirects += 1
+            elif re.search(re_good_cmd_marker, line, flags=re.M):
+              result = re_good_cmd_matcher.search(line)
+              regood_command_summary += "%s\n" % result.group(1) if result else line
 
     # compile summary
+    if regood_command_summary != "":
+      summary += "[To regood failing tests execute the following commands]\n"
+      summary += regood_command_summary
     summary += failure_summary
     summary += suppression_summary
     summary += future_summary
@@ -610,6 +619,13 @@ def check_environment():
         if not os.path.isdir(util_dir):
             print("Error: Cannot find {0}.".format(util_dir))
             sys.exit(1)
+
+    if sys.stdout.isatty():
+      os.environ["CHPL_TEST_IS_A_TTY"]  = "true"
+
+    difftool = run_git_command(["config", "diff.tool"])
+    difftool = difftool or "diff"
+    os.environ["CHPL_TEST_DIFFTOOL"] = difftool
 
 def check_environment_with_args():
     # find test dir and check for access

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -65,7 +65,13 @@
 #                     not under $CHPL_HOME. Should not be set when test/ is
 #                     under $CHPL_HOME. When it is set and the path prefixes a
 #                     test in the logs, it will be removed (from the logs).
-#
+# CHPL_TEST_IS_A_TTY: Was start_tests run with stdout directed to a TTY (as
+#                     opposed to a file). Useful to determine if we should
+#                     avoid printing colorcodes to terminal.
+# CHPL_TEST_DIFFTOOL: Difftool suggested to user on "To diff execute"
+#                     messages. Note this is not what sub_test actually uses
+#                     to conduct the diff (rather it's meant to be the users
+#                     preferred editor to view the diff).
 #
 # DIRECTORY-WIDE FILES:  These settings are for the entire directory and
 #  in many cases can be overridden or augmented with test-specific settings.
@@ -707,6 +713,22 @@ def filter_errors(output_in, pre_exec_output, execgoodfile, execlog):
 
     return extra_msg
 
+COLOR_LIGHT_BLUE = '\033[94m'
+COLOR_GREEN = '\033[32m'
+COLOR_BOLD = '\033[1m'
+COLOR_RESET = '\033[0m'
+
+def writeCmdMessage(msg):
+  writeMessageInColor(msg, COLOR_LIGHT_BLUE)
+
+def writeNewTestMessage(msg):
+  writeMessageInColor(msg, COLOR_GREEN + COLOR_BOLD)
+
+def writeMessageInColor(msg, color):
+  if os.getenv('CHPL_TEST_IS_A_TTY'):
+    sys.stdout.write("%s%s%s" % (color, msg, COLOR_RESET))
+  else:
+    sys.stdout.write(msg);
 
 # Start of sub_test proper
 #
@@ -1204,7 +1226,7 @@ for testname in testsrc:
     compiler = original_compiler
 
     # print testname
-    sys.stdout.write('[test: %s/%s]\n'%(localdir,testname))
+    writeNewTestMessage('[test: %s/%s]\n'%(localdir,testname))
     test_filename = re.match(r'^(.*)\.(?:chpl|test\.c|test\.cpp|ml-test\.c|ml-test\.cpp)$', testname).group(1)
     execname = test_filename
     if uniquifyTests:
@@ -1820,6 +1842,7 @@ for testname in testsrc:
                     sys.stdout.write('[Error compilation failed for %s]\n'%(test_name))
                 else:
                     sys.stdout.write('[Error cannot locate compiler output comparison file %s/%s]\n'%(localdir, goodfile))
+                writeCmdMessage('[To re-good execute: mv %s %s]\n' % (complog, goodfile));
                 sys.stdout.write('[Compiler output was as follows:]\n')
                 sys.stdout.write(origoutput)
                 cleanup(execname)
@@ -1839,6 +1862,11 @@ for testname in testsrc:
                                  (localdir, test_filename))
             printTestVariation(compoptsnum, compoptslist);
             sys.stdout.write(']\n')
+
+            if result != 0:
+              writeCmdMessage('[To re-good execute: mv %s %s]\n' % (complog, goodfile));
+              writeCmdMessage('[To view diff execute: %s %s %s]\n' %
+                (os.getenv('CHPL_TEST_DIFFTOOL'), complog, goodfile));
 
             # If there was a prediff it may have hidden the compilation
             # failure, so print out the full log. Note that we don't check
@@ -2333,6 +2361,7 @@ for testname in testsrc:
 
                         if not os.path.isfile(execgoodfile) or not os.access(execgoodfile, os.R_OK):
                             sys.stdout.write('[Error cannot locate program output comparison file %s/%s]\n'%(localdir, execgoodfile))
+                            writeCmdMessage('[To re-good execute: mv %s %s]\n' % (execlog, execgoodfile));
                             sys.stdout.write('[Execution output was as follows:]\n')
                             p = py3_compat.Popen(['cat', execlog], stdout=subprocess.PIPE)
                             exec_output = p.communicate()[0]
@@ -2354,6 +2383,10 @@ for testname in testsrc:
                             printTestVariation(compoptsnum, compoptslist,
                                                execoptsnum, execoptslist);
                         sys.stdout.write(']\n')
+                        if result!=0:
+                          writeCmdMessage('[To re-good execute: mv %s %s]\n' % (execlog, execgoodfile))
+                          writeCmdMessage('[To view diff execute: %s %s %s]\n' %
+                            (os.getenv('CHPL_TEST_DIFFTOOL'), execlog, execgoodfile));
 
                         if (result != 0 and futuretest != ''):
                             badfile=test_filename+'.bad'


### PR DESCRIPTION
This updates `start_test` (and `sub_test`) to:

* Highlight each test that's being started in green
* Print commands to regood a failing test (either due to a mismatch or a missing file)
* Print a diff command (using users's GIT difftool) when a `good` file mismatch occurs
* Print list of regood commands in the summary
* Suppress colorcodes used by the above colored output when the script is not detected to be in a TTY (so you won't get ugly codes piped out to a file)

It also adds a bunch of failing tests to test it (with NOTEST) file.