### PR TITLE
Cleaning up Tuple docs

### DIFF
--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -1201,7 +1201,7 @@ Predefined Functions and Methods on Tuples
 
 
 
-.. function:: proc isTuple(type: t) param
+.. function:: proc isTuple(type t) param
 
    Returns true if ``t`` is a tuple; otherwise false.
 

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -1068,7 +1068,26 @@ the results as a new tuple.
 
 The size of the result tuple is the same as the size of the argument
 tuple. The type of each result component is the result type of the
-operator when applied to the corresponding argument component.
+operator when applied to the corresponding argument component. For example:
+
+   *Example (unary-ops.chpl)*.
+
+   The following code:
+
+   .. code-block:: chapel
+
+      var x = -(-1, 5, -3.14, 99.9);
+
+   creates a 3-tuple, ``x``, with the value ``(1, -5, 3.14, -99.9)`` which has
+   the same type as the tuple-literal on the right side of the expression.
+
+   .. BLOCK-test-chapelpost
+
+      writeln(x);
+
+   .. BLOCK-test-chapeloutput
+
+      (1, -5, 3.14, -99.9)
 
 The type of every element of the operand tuple must have a well-defined
 operator matching the unary operator being applied. That is, if the
@@ -1099,20 +1118,19 @@ result.
 
    *Example (binary-ops.chpl)*.
 
-   The code 
+   The code:
 
    .. code-block:: chapel
 
       var x = (1, 1, "1") + (2, 2.0, "2");
 
    creates a 3-tuple of an int, a real and a string with the value
-   ``(3, 3.0, "12")``. 
+   ``(3, 3.0, "12")``.
 
    .. BLOCK-test-chapelpost
 
       writeln(x);
 
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -1141,7 +1159,7 @@ in the two operand tuples. Otherwise, a compile-time error will result.
 
    *Example (relational-ops.chpl)*.
 
-   The code 
+   The code:
 
    .. code-block:: chapel
 
@@ -1150,13 +1168,12 @@ in the two operand tuples. Otherwise, a compile-time error will result.
    creates a variable initialized to ``true``. After comparing the first
    components and determining they are equal, the next components are
    compared to determine that the first tuple is greater than the second
-   tuple. 
+   tuple.
 
    .. BLOCK-test-chapelpost
 
       writeln(x);
 
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -1184,7 +1201,7 @@ Predefined Functions and Methods on Tuples
 
 
 
-.. function:: proc isTuple(t: tuple) param
+.. function:: proc isTuple(type: t) param
 
    Returns true if ``t`` is a tuple; otherwise false.
 

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -24,62 +24,6 @@ in the Tuples chapter of the Chapel Language Specification.
 This page lists the predefined functions on tuples.
 They are always available to all Chapel programs.
 
-The tuple type supports a wide variety of operators, some of which can only
-be invoked on a single tuple (unary operators), while others can be invoked
-on pairs of compatible tuples or on a tuple and a non-tuple variable of
-compatible type (binary operators).
-
-The unary operators include the logical not: ``!``, the bitwise logical not:
-``~`` as well as the numerical operators: ``+`` and ``-``. In these cases,
-the operator is applied to each individual element of the tuple, producing a
-new tuple of the same type. For example:
-
-.. code-block:: chapel
-
-  var t = (-1, 5, -3.14, 99.9);
-  var tNegative = -t;
-
-  writeln(tNegative); // prints: (1, -5, 3.14, -99.9)
-  writeln(t.type == tNegative.type); // prints: true
-
-The binary operators include the logical comparison operators: ``==`` and
-``!=``, the ordering comparison operators: ``<``, ``>``, ``<=``, and ``>=``,
-the bitwise logical operators: ``&``, ``|``, ``~``, ``^``, ``<<``, ``>>``,
-and the mathematical operators: ``+``, ``-``, ``*``, ``/``, ``**``, and ``%``.
-
-.. note:
-  The logical comparison operators can be applied to tuples of different
-  types. In these cases, the tuples are simply considered to be non-equal;
-  however ordering-comparisons between tuples of different types are not
-  allowed.
-
-The bitwise and mathematical operators can be applied to tuples of the same
-length and compatible types. In these cases, the operator is applied to
-individual pairs of elements using the languages definition of that operator.
-For example:
-
-.. code-block:: chapel
-
-  var t1 = (1, 2.0);
-  var t2 = (3.0, 4);
-
-  writeln(t1 + t2); // prints: (4.0, 6.0)
-
-Bitwise and mathematical operations between a tuple and a variable of compatible
-type are also allowed. For example:
-
-.. code-block:: chapel
-
-  var t = (1, 2.0, 3.0i);
-
-  writeln(t + 1); // prints: (2, 3.0, 4.0i)
-
-
-In addition to the functions and operators, tuples also support a wide variety
-of special functionality such as: :ref:`Iteration <Iteration_over_Tuples>`,
-:ref:`Destructuring <Tuple_Destructuring>`, and
-:ref:`Expansion <Tuple_Expansion>`.
-
 The following methods are defined on the Tuple type:
 
 .. function:: proc tuple.size param

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -25,9 +25,9 @@ This page lists the predefined functions on tuples.
 They are always available to all Chapel programs.
 
 The tuple type supports a wide variety of operators, some of which can only
-be invoked on a single tuple (unary operators), while others that can be
-invoked on pairs of compatible tuples or on a tuple and a non-tuple variable
-of compatible type (binary operators).
+be invoked on a single tuple (unary operators), while others can be invoked
+on pairs of compatible tuples or on a tuple and a non-tuple variable of
+compatible type (binary operators).
 
 The unary operators include the logical not: ``!``, the bitwise logical not:
 ``~`` as well as the numerical operators: ``+`` and ``-``. In these cases,
@@ -49,8 +49,9 @@ and the mathematical operators: ``+``, ``-``, ``*``, ``/``, ``**``, and ``%``.
 
 .. note:
   The logical comparison operators can be applied to tuples of different
-  types. In these cases, the tuples are not equal; however ordering-comparisons
-  between tuples of different types are not allowed.
+  types. In these cases, the tuples are simply considered to be non-equal;
+  however ordering-comparisons between tuples of different types are not
+  allowed.
 
 The bitwise and mathematical operators can be applied to tuples of the same
 length and compatible types. In these cases, the operator is applied to
@@ -64,7 +65,7 @@ For example:
 
   writeln(t1 + t2); // prints: (4.0, 6.0)
 
-Bitwise or mathematical operations between a tuple and a variable of compatible
+Bitwise and mathematical operations between a tuple and a variable of compatible
 type are also allowed. For example:
 
 .. code-block:: chapel

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -19,16 +19,67 @@
  */
 
 /*
-Predefined Functions on Tuples.
-
 Tuples are a predefined structured type in Chapel. They are specified
 in the Tuples chapter of the Chapel Language Specification.
 This page lists the predefined functions on tuples.
 They are always available to all Chapel programs.
 
-Besides the functions defined here, the Chapel Language specification
-defines other operations available on tuples: indexing, iteration,
-assignment, and unary, binary, and relational operators.
+The tuple type supports a wide variety of operators, some of which can only
+be invoked on a single tuple (unary operators), while others that can be
+invoked on pairs of compatible tuples or on a tuple and a non-tuple variable
+of compatible type (binary operators).
+
+The unary operators include the logical not: ``!``, the bitwise logical not:
+``~`` as well as the numerical operators: ``+`` and ``-``. In these cases,
+the operator is applied to each individual element of the tuple, producing a
+new tuple of the same type. For example:
+
+.. code-block:: chapel
+
+  var t = (-1, 5, -3.14, 99.9);
+  var tNegative = -t;
+
+  writeln(tNegative); // prints: (1, -5, 3.14, -99.9)
+  writeln(t.type == tNegative.type); // prints: true
+
+The binary operators include the logical comparison operators: ``==`` and
+``!=``, the ordering comparison operators: ``<``, ``>``, ``<=``, and ``>=``,
+the bitwise logical operators: ``&``, ``|``, ``~``, ``^``, ``<<``, ``>>``,
+and the mathematical operators: ``+``, ``-``, ``*``, ``/``, ``**``, and ``%``.
+
+.. note:
+  The logical comparison operators can be applied to tuples of different
+  types. In these cases, the tuples are not equal; however ordering-comparisons
+  between tuples of different types are not allowed.
+
+The bitwise and mathematical operators can be applied to tuples of the same
+length and compatible types. In these cases, the operator is applied to
+individual pairs of elements using the languages definition of that operator.
+For example:
+
+.. code-block:: chapel
+
+  var t1 = (1, 2.0);
+  var t2 = (3.0, 4);
+
+  writeln(t1 + t2); // prints: (4.0, 6.0)
+
+Bitwise or mathematical operations between a tuple and a variable of compatible
+type are also allowed. For example:
+
+.. code-block:: chapel
+
+  var t = (1, 2.0, 3.0i);
+
+  writeln(t + 1); // prints: (2, 3.0, 4.0i)
+
+
+In addition to the functions and operators, tuples also support a wide variety
+of special functionality such as: :ref:`Iteration <Iteration_over_Tuples>`,
+:ref:`Destructuring <Tuple_Destructuring>`, and
+:ref:`Expansion <Tuple_Expansion>`.
+
+The following methods are defined on the Tuple type:
 
 .. function:: proc tuple.size param
 
@@ -94,6 +145,7 @@ module ChapelTuple {
   }
 
    // homogeneous tuple type
+  pragma "no doc"
   pragma "build tuple"
   pragma "build tuple type"
   pragma "star tuple"
@@ -129,12 +181,14 @@ module ChapelTuple {
     // body inserted during generic instantiation
   }
 
+  pragma "no doc"
   pragma "last resort"
   operator *(type t, param p: int) {
     compilerError("<type>*<param int> not supported.  If you're trying to specify a homogeneous tuple type, use <param int>*<type>.");
   }
 
   // last resort since if this resolves some other way, OK
+  pragma "no doc"
   pragma "last resort"
   operator *(p: integral, type t) type {
     compilerError("tuple size must be known at compile-time");
@@ -164,6 +218,7 @@ module ChapelTuple {
   //
   // tuple assignment
   //
+  pragma "no doc"
   pragma "compiler generated"
   pragma "last resort"
   inline operator =(ref x: _tuple,
@@ -295,12 +350,18 @@ module ChapelTuple {
   // Note: statically inlining the _chpl_complex runtime functions is necessary
   // for good performance
   //
+  /*
+  Cast from a generic two-tuple to a ``complex(64)``
+  */
   inline operator :(x: (?,?), type t: complex(64)) {
     pragma "fn synchronization free"
     extern proc _chpl_complex64(re:real(32),im:real(32)) : complex(64);
     return _chpl_complex64(x(0):real(32),x(1):real(32));
   }
 
+  /*
+  Cast from a generic two-tuple to a ``complex(128)``
+  */
   inline operator :(x: (?,?), type t: complex(128)) {
     pragma "fn synchronization free"
     extern proc _chpl_complex128(re:real(64),im:real(64)):complex(128);
@@ -310,6 +371,7 @@ module ChapelTuple {
   //
   // General tuple cast function
   //
+  pragma "no doc"
   pragma "tuple cast fn"
   pragma "unsafe"
   inline operator :(x: _tuple, type t:_tuple) {
@@ -329,6 +391,7 @@ module ChapelTuple {
   //
   // standard overloaded unary operators on tuples.
   //
+  pragma "no doc"
   inline operator +(a: _tuple) {
     var result: a.type;
     for param d in 0..a.size-1 do
@@ -336,6 +399,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator -(a: _tuple) {
     var result: a.type;
     for param d in 0..a.size-1 do
@@ -343,6 +407,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator ~(a: _tuple) {
     var result: a.type;
     for param d in 0..a.size-1 do
@@ -350,6 +415,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator !(a: _tuple) {
     var result: a.type;
     for param d in 0..a.size-1 do
@@ -389,6 +455,7 @@ module ChapelTuple {
   // standard overloaded binary operators on tuples.  Each pair starts
   // with a case optimized for homogeneous tuples (because the result
   // type is easy to express)...
+  pragma "no doc"
   inline operator +(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to + have different sizes");
@@ -403,6 +470,7 @@ module ChapelTuple {
   // ...followed by a more complicated/general case for heterogeneous
   // tuples because the result type is more complex to describe.
   //
+  pragma "no doc"
   inline operator +(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to + have different sizes");
@@ -412,7 +480,7 @@ module ChapelTuple {
       return (a(0)+b(0), (...chpl__tupleRest(a)+chpl__tupleRest(b)));
   }
 
-
+  pragma "no doc"
   inline operator -(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to - have different sizes");
@@ -424,6 +492,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator -(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to - have different sizes");
@@ -433,7 +502,7 @@ module ChapelTuple {
       return (a(0)-b(0), (...chpl__tupleRest(a)-chpl__tupleRest(b)));
   }
 
-
+  pragma "no doc"
   inline operator *(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to * have different sizes");
@@ -445,6 +514,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator *(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to * have different sizes");
@@ -454,6 +524,7 @@ module ChapelTuple {
       return (a(0)*b(0), (...chpl__tupleRest(a)*chpl__tupleRest(b)));
   }
 
+  pragma "no doc"
   inline operator /(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to / have different sizes");
@@ -465,6 +536,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator /(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to / have different sizes");
@@ -474,6 +546,7 @@ module ChapelTuple {
       return (a(0)/b(0), (...chpl__tupleRest(a)/chpl__tupleRest(b)));
   }
 
+  pragma "no doc"
   inline operator %(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to % have different sizes");
@@ -485,6 +558,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator %(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to % have different sizes");
@@ -494,6 +568,7 @@ module ChapelTuple {
       return (a(0)%b(0), (...chpl__tupleRest(a)%chpl__tupleRest(b)));
   }
 
+  pragma "no doc"
   inline operator **(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to ** have different sizes");
@@ -505,6 +580,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator **(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to ** have different sizes");
@@ -514,6 +590,7 @@ module ChapelTuple {
       return (a(0)**b(0), (...chpl__tupleRest(a)**chpl__tupleRest(b)));
   }
 
+  pragma "no doc"
   inline operator &(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to & have different sizes");
@@ -525,6 +602,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator &(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to & have different sizes");
@@ -534,6 +612,7 @@ module ChapelTuple {
       return (a(0)&b(0), (...chpl__tupleRest(a)&chpl__tupleRest(b)));
   }
 
+  pragma "no doc"
   inline operator |(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to | have different sizes");
@@ -545,6 +624,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator |(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to | have different sizes");
@@ -554,6 +634,7 @@ module ChapelTuple {
       return (a(0)|b(0), (...chpl__tupleRest(a)|chpl__tupleRest(b)));
   }
 
+  pragma "no doc"
   inline operator ^(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to ^ have different sizes");
@@ -565,6 +646,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator ^(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to ^ have different sizes");
@@ -574,6 +656,7 @@ module ChapelTuple {
       return (a(0)^b(0), (...chpl__tupleRest(a)^chpl__tupleRest(b)));
   }
 
+  pragma "no doc"
   inline operator <<(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to << have different sizes");
@@ -585,6 +668,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator <<(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to << have different sizes");
@@ -594,6 +678,7 @@ module ChapelTuple {
       return (a(0)<<b(0), (...chpl__tupleRest(a)<<chpl__tupleRest(b)));
   }
 
+  pragma "no doc"
   inline operator >>(a: _tuple, b: _tuple) where chpl_TwoHomogTuples(a,b) {
     if a.size != b.size then
       compilerError("tuple operands to >> have different sizes");
@@ -605,6 +690,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator >>(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to >> have different sizes");
@@ -617,6 +703,7 @@ module ChapelTuple {
   //
   // standard overloaded relational operators on tuples
   //
+  pragma "no doc"
   inline operator >(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to > have different sizes");
@@ -628,6 +715,7 @@ module ChapelTuple {
     return false;
   }
 
+  pragma "no doc"
   inline operator >=(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to >= have different sizes");
@@ -639,6 +727,7 @@ module ChapelTuple {
     return true;
   }
 
+  pragma "no doc"
   inline operator <(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to < have different sizes");
@@ -650,6 +739,7 @@ module ChapelTuple {
     return false;
   }
 
+  pragma "no doc"
   inline operator <=(a: _tuple, b: _tuple) {
     if a.size != b.size then
       compilerError("tuple operands to <= have different sizes");
@@ -661,6 +751,7 @@ module ChapelTuple {
     return true;
   }
 
+  pragma "no doc"
   inline operator ==(a: _tuple, b: _tuple) {
     if a.size != b.size {
       return false;
@@ -672,6 +763,7 @@ module ChapelTuple {
     return true;
   }
 
+  pragma "no doc"
   inline operator !=(a: _tuple, b: _tuple) {
     if a.size != b.size {
       return true;
@@ -687,6 +779,7 @@ module ChapelTuple {
   // standard overloaded binary operators on homog tuple / scalar
   // pairs.
   //
+  pragma "no doc"
   inline operator +(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -694,6 +787,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator +(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                             isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -702,6 +796,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator -(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -709,6 +804,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator -(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                             isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -717,6 +813,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator *(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -724,6 +821,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator *(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                             isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -732,6 +830,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator /(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -739,6 +838,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator /(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                             isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -747,6 +847,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator %(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -754,6 +855,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator %(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                             isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -762,6 +864,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator **(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -769,6 +872,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator **(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                              isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -777,6 +881,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator &(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -784,6 +889,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator &(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                             isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -792,6 +898,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator |(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -799,6 +906,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator |(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                             isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -807,6 +915,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc" 
   inline operator ^(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -814,6 +923,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator ^(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                             isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -822,6 +932,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator <<(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -829,6 +940,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator <<(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                              isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;
@@ -837,6 +949,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator >>(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do
@@ -844,6 +957,7 @@ module ChapelTuple {
     return result;
   }
 
+  pragma "no doc"
   inline operator >>(x: ?t, y: _tuple) where isHomogeneousTuple(y) &&
                                              isCoercible(t, (y(0).type)) {
     var result: y.size * y(0).type;

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -916,7 +916,7 @@ module ChapelTuple {
     return result;
   }
 
-  pragma "no doc" 
+  pragma "no doc"
   inline operator ^(x: _tuple, y: x(0).type) where isHomogeneousTuple(x) {
     var result: x.size * x(0).type;
     for param d in 0..x.size-1 do


### PR DESCRIPTION
Due to the recent changes to `chpldoc` that expose more operators to the public docs, this PR marks most of the Tuple type operators as `no doc`ed, and summarizes them above the type definition instead.
