### PR TITLE
Fix ugni MR extent check when remote cache is on

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -575,7 +575,7 @@ static mem_region_table_t** mem_regions_all_my_entry_map;
 static chpl_bool can_register_memory = false;
 
 static chpl_bool do_mr_extent_checks;
-static int cache_pagesize;
+static size_t cache_max_readahead_size;
 
 //
 // The high bit of the 'len' member of a mem_region_t in the table
@@ -1903,7 +1903,7 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
 
   do_mr_extent_checks = chpl_env_rt_get_bool("COMM_UGNI_DO_MR_EXTENT_CHECKS",
                                              true);
-  cache_pagesize = chpl_cache_pagesize();
+  cache_max_readahead_size = chpl_getSysPageSize();
 
   //
   // We have to create the local memory region table before the first
@@ -2776,7 +2776,7 @@ mem_region_t* mreg_for_local_addr(void* addr, size_t size)
   }
   if (do_mr_extent_checks && mr != NULL) {
     size_t mrLen = chpl_cache_enabled()
-                   ? ALIGN_UP(mrtl_len(mr->len), cache_pagesize)
+                   ? ALIGN_UP(mrtl_len(mr->len), cache_max_readahead_size)
                    : mrtl_len(mr->len);
     if ((uint64_t) addr + size > mr->addr + mrLen) {
       CHPL_INTERNAL_ERROR("local xfer size extends beyond MR!");
@@ -2813,7 +2813,7 @@ mem_region_t* mreg_for_remote_addr(void* addr, size_t size, c_nodeid_t locale)
   }
   if (do_mr_extent_checks && mr != NULL) {
     size_t mrLen = chpl_cache_enabled()
-                   ? ALIGN_UP(mrtl_len(mr->len), cache_pagesize)
+                   ? ALIGN_UP(mrtl_len(mr->len), cache_max_readahead_size)
                    : mrtl_len(mr->len);
     if ((uint64_t) addr + size > mr->addr + mrLen) {
       CHPL_INTERNAL_ERROR("remote xfer size extends beyond MR!");


### PR DESCRIPTION
In #19516 we updated the ugni MR extent check to consider that the cache can read to the end of a CACHEPAGE (1K), but it turns out the cache can read to the end of a system page (usually 4K). Adjust the extent check to allow the larger system page size check here.

We've seen the MR extent check failures in nightly recently. I haven't been able to come up with a reliable reproducer yet, but I'm confident about this change just from code inspection. I believe we should be able to come up with a reproducer, but I want to get this into the release and I'm timing out coming up with the test case now.

Resolves Cray/chapel-private#3341