### PR TITLE
Update IO operator documentation

### DIFF
--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -267,6 +267,10 @@ the right-hand-side; or reading from the left-hand-side and storing the
 result in the variable on the right-hand-side. This operator can be
 chained with other I/O operator calls.
 
+.. warning::
+
+   The I/O operator is deprecated.
+
 The I/O operator can be overloaded for different types using operator
 overloading (:ref:`Function_Overloading`). 
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3857,6 +3857,14 @@ proc channel.writeIt(const x) throws {
      on the type of channel. This operator returns a const reference to the
      same channel so that multiple operator calls can be chained together.
 
+     .. warning:: The <~> operator on channels is deprecated. The intended
+       alternative is to use methods like :proc:`channel.read` and
+       :proc:`channel.write` instead.
+
+       Methods that provide both reading and writing functionality will soon be
+       deprecated. The chaining functionality supported by this operator is not
+       provided by other methods.
+
      :returns: ch
      :throws SystemError: When an IO error has occurred.
    */
@@ -3890,6 +3898,14 @@ proc channel.writeIt(const x) throws {
 
      works without requiring an explicit temporary value to store
      the ioLiteral.
+
+     .. warning:: The <~> operator on channels is deprecated. The intended
+       alternative is to use methods like :proc:`channel.readLiteral` and
+       :proc:`channel.writeLiteral` instead.
+
+       Methods that provide both reading and writing functionality will soon be
+       deprecated. The chaining functionality supported by this operator is not
+       provided by other methods.
    */
   deprecated "the <~> operator is deprecated"
   inline operator channel.<~>(const ref r: channel,
@@ -3909,6 +3925,14 @@ proc channel.writeIt(const x) throws {
 
      works without requiring an explicit temporary value to store
      the ioNewline.
+
+     .. warning:: The <~> operator on channels is deprecated. The intended
+       alternative is to use methods like :proc:`channel.readNewline` and
+       :proc:`channel.writeNewline` instead.
+
+       Methods that provide both reading and writing functionality will soon be
+       deprecated. The chaining functionality supported by this operator is not
+       provided by other methods.
    */
   deprecated "the <~> operator is deprecated"
   inline operator channel.<~>(const ref r: channel,

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -287,7 +287,7 @@ if there was an error. See:
 In addition, there is a convenient synonym for :proc:`channel.write` and
 :proc:`channel.read`: the `<~> operator`
 
-.. note:: the <~> operator is deprecated
+.. warning:: the <~> operator is deprecated
 
 Sometimes it's important to flush the buffer in a channel - to do that, use the
 :proc:`channel.flush()` method. Flushing the buffer will make all writes available

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3861,9 +3861,8 @@ proc channel.writeIt(const x) throws {
        alternative is to use methods like :proc:`channel.read` and
        :proc:`channel.write` instead.
 
-       Methods that provide both reading and writing functionality will soon be
-       deprecated. The chaining functionality supported by this operator is not
-       provided by other methods.
+       The chaining functionality supported by this operator is not provided by
+       other methods.
 
      :returns: ch
      :throws SystemError: When an IO error has occurred.
@@ -3903,9 +3902,8 @@ proc channel.writeIt(const x) throws {
        alternative is to use methods like :proc:`channel.readLiteral` and
        :proc:`channel.writeLiteral` instead.
 
-       Methods that provide both reading and writing functionality will soon be
-       deprecated. The chaining functionality supported by this operator is not
-       provided by other methods.
+       The chaining functionality supported by this operator is not provided by
+       other methods.
    */
   deprecated "the <~> operator is deprecated"
   inline operator channel.<~>(const ref r: channel,
@@ -3930,9 +3928,8 @@ proc channel.writeIt(const x) throws {
        alternative is to use methods like :proc:`channel.readNewline` and
        :proc:`channel.writeNewline` instead.
 
-       Methods that provide both reading and writing functionality will soon be
-       deprecated. The chaining functionality supported by this operator is not
-       provided by other methods.
+       The chaining functionality supported by this operator is not provided by
+       other methods.
    */
   deprecated "the <~> operator is deprecated"
   inline operator channel.<~>(const ref r: channel,


### PR DESCRIPTION
This PR updates the IO operator documentation in the modules to point to alternative methods on channels. This PR also updates the spec to warn that the IO operator is now deprecated.

Testing:
- [x] make docs