### PR TITLE
Update gen compilers from 10.0.3 to 14.0.0 for chapel 1.28.0 release

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -267,7 +267,7 @@ else
     fi
 
     gen_version_gcc=9.3.0
-    gen_version_cce=10.0.3
+    gen_version_cce=14.0.0
 
     target_cpu_module=craype-arm-thunderx2
 

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -312,7 +312,7 @@ else
 
     gen_version_gcc=8.1.0
     gen_version_intel=2022.0.1
-    gen_version_cce=10.0.3
+    gen_version_cce=14.0.0
 
     target_cpu_module=craype-sandybridge
 


### PR DESCRIPTION
Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>

As part of the release process for chapel 1.28.0 updated the build_config files with the latest CEE version(14.0.0)