### PR TITLE
no-doc operators in ChapelDomain

### DIFF
--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -338,6 +338,7 @@ module ChapelDomain {
     return dom[(...ranges)];
   }
 
+  pragma "no doc"
   operator #(dom: domain, counts: integral) {
     errorIfNotRectangular(dom, "#", " and arrays");
     if dom.rank != 1 then compilerError(
@@ -346,6 +347,7 @@ module ChapelDomain {
     return chpl_countDomHelp(dom, (counts,));
   }
 
+  pragma "no doc"
   operator #(dom: domain, counts: _tuple) {
     errorIfNotRectangular(dom, "#", " and arrays");
     if (counts.size != dom.rank) then compilerError(
@@ -354,11 +356,13 @@ module ChapelDomain {
   }
 
   pragma "last resort"
+  pragma "no doc"
   operator #(dom: domain, counts) {
     compilerError("cannot apply '#' to '", dom.type:string,
                   "' using count(s) of type ", counts.type:string);
   }
 
+  pragma "no doc"
   operator +(d: domain, i: index(d)) {
     if d.isRectangular() then
       compilerError("Cannot add indices to a rectangular domain");
@@ -366,6 +370,7 @@ module ChapelDomain {
       compilerError("Cannot add indices to this domain type");
   }
 
+  pragma "no doc"
   operator +(i, d: domain) where isSubtype(i.type, index(d)) && !d.isIrregular() {
     if d.isRectangular() then
       compilerError("Cannot add indices to a rectangular domain");
@@ -373,16 +378,19 @@ module ChapelDomain {
       compilerError("Cannot add indices to this domain type");
   }
 
+  pragma "no doc"
   operator +(in d: domain, i: index(d)) where d.isIrregular() {
     d.add(i);
     return d;
   }
 
+  pragma "no doc"
   operator +(i, in d: domain) where isSubtype(i.type,index(d)) && d.isIrregular() {
     d.add(i);
     return d;
   }
 
+  pragma "no doc"
   operator +(in d1: domain, d2: domain) where
                                     d1.type == d2.type &&
                                     d1.isIrregular() &&
@@ -392,6 +400,7 @@ module ChapelDomain {
     return d1;
   }
 
+  pragma "no doc"
   operator +(d1: domain, d2: domain) {
     if (d1.isRectangular() || d2.isRectangular()) then
       compilerError("Cannot add indices to a rectangular domain");
@@ -399,9 +408,12 @@ module ChapelDomain {
       compilerError("Cannot add indices to this domain type");
   }
 
+  pragma "no doc"
   inline operator +=(ref D: domain, idx) { D.add(idx); }
+  pragma "no doc"
   inline operator +=(ref D: domain, param idx) { D.add(idx); }
 
+  pragma "no doc"
   operator -(d: domain, i: index(d)) {
     if d.isRectangular() then
       compilerError("Cannot remove indices from a rectangular domain");
@@ -409,11 +421,13 @@ module ChapelDomain {
       compilerError("Cannot remove indices from this domain type");
   }
 
+  pragma "no doc"
   operator -(in d: domain, i: index(d)) where d.isIrregular() {
     d.remove(i);
     return d;
   }
 
+  pragma "no doc"
   operator -(in d1: domain, d2: domain) where
                                     d1.type == d2.type &&
                                     d1.isSparse() {
@@ -422,6 +436,7 @@ module ChapelDomain {
     return d1;
   }
 
+  pragma "no doc"
   operator -(d1: domain, d2: domain) {
     if (d1.isRectangular() || d2.isRectangular()) then
       compilerError("Cannot remove indices from a rectangular domain");
@@ -429,9 +444,12 @@ module ChapelDomain {
       compilerError("Cannot remove indices from this domain type");
   }
 
+  pragma "no doc"
   inline operator -=(ref D: domain, idx) { D.remove(idx); }
+  pragma "no doc"
   inline operator -=(ref D: domain, param idx) { D.remove(idx); }
 
+  pragma "no doc"
   inline operator ==(d1: domain, d2: domain) where d1.isRectangular() &&
                                                    d2.isRectangular() {
     if d1._value.rank != d2._value.rank {
@@ -445,11 +463,13 @@ module ChapelDomain {
     }
   }
 
+  pragma "no doc"
   inline operator !=(d1: domain, d2: domain) where d1.isRectangular() &&
                                                    d2.isRectangular() {
     return !(d1 == d2);
   }
 
+  pragma "no doc"
   inline operator ==(d1: domain, d2: domain) where d1.isAssociative() &&
                                                    d2.isAssociative() {
     if d1._value == d2._value then return true;
@@ -460,11 +480,13 @@ module ChapelDomain {
     return true;
   }
 
+  pragma "no doc"
   inline operator !=(d1: domain, d2: domain) where d1.isAssociative() &&
                                                    d2.isAssociative() {
     return !(d1 == d2);
   }
 
+  pragma "no doc"
   inline operator ==(d1: domain, d2: domain) where d1.isSparse() &&
                                                    d2.isSparse() {
     if d1._value == d2._value then return true;
@@ -476,6 +498,7 @@ module ChapelDomain {
     return true;
   }
 
+  pragma "no doc"
   inline operator !=(d1: domain, d2: domain) where d1.isSparse() &&
                                                    d2.isSparse() {
     return !(d1 == d2);
@@ -498,10 +521,12 @@ module ChapelDomain {
                   d2.type:string, "' is not currently supported");
   }
 
+  pragma "no doc"
   inline operator ==(d1: domain, d2: domain) {
     cmpError(d1, d2);
   }
 
+  pragma "no doc"
   inline operator !=(d1: domain, d2: domain) {
     cmpError(d1, d2);
   }
@@ -512,6 +537,7 @@ module ChapelDomain {
            (d1.isAssociative() && d2.isAssociative()) ||
            (d1.isSparse()      && d2.isSparse()     );
 
+  pragma "no doc"
   operator -(a :domain, b :domain) where (a.type == b.type) &&
     a.isAssociative() {
     var newDom : a.type;
@@ -526,6 +552,7 @@ module ChapelDomain {
      they exist. If an element in the RHS is not present in the LHS, no error
      occurs.
   */
+  pragma "no doc"
   operator -=(ref a :domain, b :domain) where (a.type == b.type) &&
     a.isAssociative() {
     for e in b do
@@ -533,25 +560,30 @@ module ChapelDomain {
         a.remove(e);
   }
 
+  pragma "no doc"
   operator |(a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     return a + b;
   }
 
+  pragma "no doc"
   deprecated "'|' on rectangular domains is deprecated"
   operator |(a :domain, b: domain) where a.isRectangular() && b.isRectangular()
     return forall (aa, bb) in zip(a, b) do aa|bb;
 
+  pragma "no doc"
   operator |=(ref a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     for e in b do
       a.add(e);
   }
 
+  pragma "no doc"
   operator |=(a :domain, b: domain) where a.isRectangular() {
     compilerError("cannot invoke '|=' on a rectangular domain");
   }
 
+  pragma "no doc"
   operator +=(ref a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     a |= b;
@@ -562,6 +594,7 @@ module ChapelDomain {
      they exist. If an element in the RHS is not present in the LHS, no error
      occurs.
   */
+  pragma "no doc"
   operator &(a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     var newDom : a.type;
@@ -572,10 +605,12 @@ module ChapelDomain {
     return newDom;
   }
 
+  pragma "no doc"
   deprecated "'&' on rectangular domains is deprecated"
   operator &(a :domain, b: domain) where a.isRectangular() && b.isRectangular()
     return forall (aa, bb) in zip(a, b) do aa&bb;
 
+  pragma "no doc"
   operator &=(ref a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     var removeSet: domain(a.idxType);
@@ -586,10 +621,12 @@ module ChapelDomain {
       a.remove(e);
   }
 
+  pragma "no doc"
   operator &=(a :domain, b: domain) where a.isRectangular() {
     compilerError("cannot invoke '&=' on a rectangular domain");
   }
 
+  pragma "no doc"
   operator ^(a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     var newDom : a.type;
@@ -604,6 +641,7 @@ module ChapelDomain {
     return newDom;
   }
 
+  pragma "no doc"
   deprecated "'^' on rectangular domains is deprecated"
   operator ^(a :domain, b: domain) where a.isRectangular() && b.isRectangular()
     return forall (aa, bb) in zip(a, b) do aa^bb;
@@ -613,6 +651,7 @@ module ChapelDomain {
      they exist. If an element in the RHS is not present in the LHS, it is
      added to the LHS.
   */
+  pragma "no doc"
   operator ^=(ref a :domain, b: domain) where (a.type == b.type) &&
     a.isAssociative() {
     for e in b do
@@ -622,6 +661,7 @@ module ChapelDomain {
         a.add(e);
   }
 
+  pragma "no doc"
   operator ^=(a :domain, b: domain) where a.isRectangular() {
     compilerError("cannot invoke '^=' on a rectangular domain");
   }
@@ -629,6 +669,7 @@ module ChapelDomain {
   //
   // BaseSparseDom operator overloads
   //
+  pragma "no doc"
   operator +=(ref sd: domain, inds: [] index(sd)) where sd.isSparse() {
     if inds.sizeAs(int) == 0 then return;
 
@@ -637,6 +678,7 @@ module ChapelDomain {
 
 
   // TODO: Currently not optimized
+  pragma "no doc"
   operator +=(ref sd: domain, d: domain)
   where sd.isSparse() && d.rank==sd.rank && sd.idxType==d.idxType {
     if d.sizeAs(int) == 0 then return;
@@ -655,11 +697,13 @@ module ChapelDomain {
   }
 
   // TODO: Implement bulkRemove
+  pragma "no doc"
   operator -=(ref sd: domain, inds: [] index(sd)) where sd.isSparse() {
     for ind in inds do
       sd -= ind;
   }
 
+  pragma "no doc"
   operator -=(ref sd: domain, d: domain)
   where sd.isSparse() && d.rank==sd.rank && sd.idxType==d.idxType {
     for ind in d do
@@ -669,6 +713,7 @@ module ChapelDomain {
   //
   // Assignment of domains
   //
+  pragma "no doc"
   operator =(ref a: domain, b: domain) {
     if a.rank != b.rank then
       compilerError("rank mismatch in domain assignment");
@@ -713,6 +758,7 @@ module ChapelDomain {
     return isRangeTuple(t) && d.rank == t.size && strideSafe(d, t);
   }
 
+  pragma "no doc"
   operator =(ref a: domain, b: _tuple) {
     if chpl__isLegalRectTupDomAssign(a, b) {
       a = {(...b)};
@@ -724,10 +770,12 @@ module ChapelDomain {
     }
   }
 
+  pragma "no doc"
   operator =(ref d: domain, r: range(?)) {
     d = {r};
   }
 
+  pragma "no doc"
   operator =(ref a: domain, b) {  // b is iteratable
     if a.isRectangular() then
       compilerError("Illegal assignment to a rectangular domain");
@@ -738,6 +786,7 @@ module ChapelDomain {
   }
 
   // This is the definition of the 'by' operator for domains.
+  pragma "no doc"
   operator by(a: domain, b) {
     errorIfNotRectangular(a, "by");
     var r: a.rank*range(a._value.idxType,
@@ -752,6 +801,7 @@ module ChapelDomain {
   // This is the definition of the 'align' operator for domains.
   // It produces a new domain with the specified alignment.
   // See also: 'align' operator on ranges.
+  pragma "no doc"
   operator align(a: domain, b) {
     errorIfNotRectangular(a, "align");
     var r: a.rank*range(a._value.idxType,


### PR DESCRIPTION
This PR no-docs the operators in ChapelDomain that were exposed by the new chpldoc implementation. Some of these are already documented in the ``domains.rst`` spec file, and others have yet to be stabilized for 2.0.

Testing:
- [x] make docs
- [x] comparison against chpl-legacy