### PR TITLE
Migrate `tuple` docs from "builtins" section to "language-spec" page

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -120,7 +120,7 @@ exclude_patterns = ['Makefile',
                     'builtins/ChapelLocale.rst',
                     'builtins/ChapelRange.rst',
                     'builtins/ChapelTuple',
-                    'builtins/String.rst',
+                    'builtins/String.rst'
                    ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -119,7 +119,8 @@ exclude_patterns = ['Makefile',
                     'builtins/ChapelDomain.rst',
                     'builtins/ChapelLocale.rst',
                     'builtins/ChapelRange.rst',
-                    'builtins/String.rst'
+                    'builtins/ChapelTuple',
+                    'builtins/String.rst',
                    ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -119,7 +119,7 @@ exclude_patterns = ['Makefile',
                     'builtins/ChapelDomain.rst',
                     'builtins/ChapelLocale.rst',
                     'builtins/ChapelRange.rst',
-                    'builtins/ChapelTuple',
+                    'builtins/ChapelTuple.rst',
                     'builtins/String.rst'
                    ]
 

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -1212,4 +1212,5 @@ Predefined Functions and Methods on Tuples
    Returns true if ``t`` is a tuple of types; otherwise false.
 
 
+
 .. include:: /builtins/ChapelTuple.rst

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -1212,15 +1212,4 @@ Predefined Functions and Methods on Tuples
    Returns true if ``t`` is a tuple of types; otherwise false.
 
 
-
-.. function:: proc max(type t) where isTupleType(t)
-
-   Returns a tuple of type ``t`` with each component set to the maximum
-   value that can be stored in its position.
-
-
-
-.. function:: proc min(type t) where isTupleType(t)
-
-   Returns a tuple of type ``t`` with each component set to the minimum
-   value that can be stored in its position.
+.. include:: /builtins/ChapelTuple.rst

--- a/doc/rst/meta/builtins/index.rst
+++ b/doc/rst/meta/builtins/index.rst
@@ -15,7 +15,6 @@ amenable to being documented using **chpldoc**:
    OwnedObject
    SharedObject
    ChapelSyncvar
-   ChapelTuple
 
 
 Index

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -19,23 +19,6 @@
  */
 
 /*
-Tuples are a predefined structured type in Chapel. They are specified
-in the Tuples chapter of the Chapel Language Specification.
-This page lists the predefined functions on tuples.
-They are always available to all Chapel programs.
-
-The following methods are defined on the Tuple type:
-
-.. function:: proc tuple.size param
-
-   Returns the number of components of the tuple.
-
-.. function:: proc tuple.indices
-
-   Returns the range of indices that are legal for indexing into the
-   tuple: ``0..<this.size``.
-
-
 */
 module ChapelTuple {
   use ChapelStandard, DSIUtil;

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -130,7 +130,7 @@ function removeUsage() {
 
 ## ChapelTuple ##
 
-file=ChapelTuple.rst
+file="./ChapelTuple.rst"
 removePrefixFunctions $file
 removePattern "param size" $file
 removePattern "record:: _tuple" $file

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -134,7 +134,7 @@ file=ChapelTuple.rst
 removePrefixFunctions $file
 removePattern "param size" $file
 removePattern "record:: _tuple" $file
-fixTitle "Tuples" $file
+removeTitle $file
 removeUsage $file
 
 ## End ChapelTuple ##


### PR DESCRIPTION
Implementing the `chapelTuple` portion of this parent issue: https://github.com/chapel-lang/chapel/issues/18027