### PR TITLE
Fix typos

### DIFF
--- a/compiler/dyno/include/chpl/framework/Context.h
+++ b/compiler/dyno/include/chpl/framework/Context.h
@@ -256,7 +256,7 @@ class Context {
   /**
     Create a new AST Context. Optionally, specify the value of the
     CHPL_HOME environment variable, which is used for determining
-    chapel environment varaibles.
+    chapel environment variables.
    */
   Context(std::string chplHome = "",
           std::unordered_map<std::string, std::string> chplEnvOverrides = {});

--- a/compiler/dyno/include/chpl/resolution/can-pass.h
+++ b/compiler/dyno/include/chpl/resolution/can-pass.h
@@ -178,7 +178,7 @@ CanPassResult canPass(Context* context,
 /**
   An optional additional constraint on the kind of a type. Used in
   commonType to serve the case of functions that enforce param, type,
-  or const returs.
+  or const returns.
  */
 using KindRequirement = llvm::Optional<chpl::types::QualifiedType::Kind>;
 

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -230,7 +230,7 @@ static void removeRandomPrimitive(CallExpr* call) {
               if (auto se = toSymExpr(actual)) {
                 auto ts = se->symbol()->type->symbol;
 
-                // Runtime types sould have been transformed into values.
+                // Runtime types should have been transformed into values.
                 if (ts && ts->hasFlag(FLAG_RUNTIME_TYPE_VALUE)) {
                   INT_ASSERT(se->symbol()->defPoint->inTree());
                   containsRuntimeType = true;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2926,7 +2926,7 @@ static bool resolveTypeComparisonCall(CallExpr* call) {
             se->getStmtExpr()->insertBefore(call);
           } else {
             if (fWarnUnstable) {
-              USR_WARN(call, "type comparsion operators are unstable; "
+              USR_WARN(call, "type comparison operators are unstable; "
                 "consider using isSubtype/isProperSubtype as a stable alternative");
             }
 
@@ -5789,7 +5789,7 @@ static void discardWorsePromoting(Vec<ResolutionCandidate*>&   candidates,
 //   proc f(uint(32), uint(32))
 //   proc f(int(64), int(64))
 //   f(myUint32, max(int));
-//  .... but it causes problems with prefering generic to non-generic.
+//  .... but it causes problems with preferring generic to non-generic.
 /*static void discardWorseConversionsToNotMentioned(
     Vec<ResolutionCandidate*>&   candidates,
     const DisambiguationContext& DC,

--- a/doc/rst/mason-packages/guide/buildingandrunning.rst
+++ b/doc/rst/mason-packages/guide/buildingandrunning.rst
@@ -10,7 +10,7 @@ When invoked, ``mason build [ options ]`` will do the following:
     - Run update to make sure any manual manifest edits are reflected in the dependency code.
     - Build ``MyPackage.chpl`` in the ``src/`` directory.
     - All packages are compiled into binaries and placed into ``target/``
-    - To forward options to the Chapel compiler(``chpl``), seperate them with a double dash
+    - To forward options to the Chapel compiler(``chpl``), separate them with a double dash
        - e.g., mason build --force -- --savec tmpdir
 
 ``mason run [ options ]`` will, in turn:

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -89,7 +89,7 @@ rebuild Chapel from source in a different configuration:
 * Open up a new shell to avoid inheriting the previous environment
   settings.
 
-* The Quickstart configuration attempts to detect if you have a compatable
+* The Quickstart configuration attempts to detect if you have a compatible
   system installation of LLVM and clang. If you do not, it will set
   ``CHPL_LLVM=none`` for simplicity and to save time.  This causes
   the Chapel compiler to use its C back-end, which is not the preferred

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1328,7 +1328,7 @@ module OS {
   }
 
   pragma "no doc"
-  deprecated "'EOFError is deprecated, please use 'EofError instedad"
+  deprecated "'EOFError is deprecated, please use 'EofError instead"
   class EOFError : IoError {}
 
   /*

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -1084,7 +1084,7 @@ proc isProperSubtype(type sub, type super) param {
 
 /* :returns: isProperSubtype(a,b) */
 pragma "docs only"
-deprecated "< operator is deprecated to compare types, use isPropersubtype instead"
+deprecated "< operator is deprecated to compare types, use isProperSubtype instead"
 operator <(type a, type b) param {
   return isProperSubtype(a,b);
 }

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -330,7 +330,7 @@ void chpl_std_module_init(void) {
     // We want to treat how we allocate arrays on GPUs differently
     // for standard modules so we start the runtime assuming we're doing
     // all initialization for the standard modules until this callback
-    // functiong gets called.  (see comments on the `impl` version of this
+    // function gets called.  (see comments on the `impl` version of this
     // function for more details on why).
     #ifdef HAS_GPU_LOCALE
     chpl_gpu_on_std_modules_finished_initializing();

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -115,7 +115,7 @@ void chpl_gpu_impl_on_std_modules_finished_initializing(void) {
   //
   // Basically during the setup of the locale model we need to be "on" a given
   // sublocale when we instantiate the object for it (the expectation is that
-  // the widepointer for a sublocale appears to be on that sublocale),
+  // the wide pointer for a sublocale appears to be on that sublocale),
   // but in practice we don't actually want the data for the GPU sublocale
   // object to be on the GPU).
   //
@@ -286,7 +286,7 @@ void* chpl_gpu_impl_memmove(void* dst, const void* src, size_t n) {
   #else
 
   // for unified memory strategy we don't want to generate calls to copy
-  // data from the device to host (since it can just be acessed directly)
+  // data from the device to host (since it can just be accessed directly)
   return memmove(dst, src, n);
   #endif
 }

--- a/test/deprecated/deprecated-errors.good
+++ b/test/deprecated/deprecated-errors.good
@@ -1,4 +1,4 @@
 deprecated-errors.chpl:3: warning: 'IOError' is deprecated, please use 'IoError' instead
 deprecated-errors.chpl:4: warning: 'BlockingIOError' is deprecated, please use 'BlockingIoError' instead
-deprecated-errors.chpl:5: warning: 'EOFError is deprecated, please use 'EofError instedad
+deprecated-errors.chpl:5: warning: 'EOFError is deprecated, please use 'EofError instead
 deprecated-errors.chpl:6: warning: 'UnexpectedEOFError' is deprecated, please use 'UnexpectedEofError' instead

--- a/test/unstable/typeQueryFuncs.good
+++ b/test/unstable/typeQueryFuncs.good
@@ -1,15 +1,15 @@
-typeQueryFuncs.chpl:5: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:6: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:7: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:8: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:14: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:15: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:16: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:17: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:20: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:21: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:22: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
-typeQueryFuncs.chpl:23: warning: type comparsion operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:5: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:6: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:7: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:8: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:14: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:15: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:16: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:17: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:20: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:21: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:22: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
+typeQueryFuncs.chpl:23: warning: type comparison operators are unstable; consider using isSubtype/isProperSubtype as a stable alternative
 Compare 1.type op int
 op <= returns true
 op <  returns false


### PR DESCRIPTION
Fix typos in

Context.h, can-pass.h, cleanups.cpp, functionResolution.cpp,
chpl-init.cpp, and gpu-cuda.c,
buildingandrunning.rst, QUICKSTART.rst,
OS.chpl, Types.chpl,
and two affected .good files.