### PR TITLE
Add a doc comment for OS.errorCode

### DIFF
--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -957,8 +957,8 @@ module OS {
   } // end POSIX
 
 /* A type storing an error code or an error message.
-   A :type:`errorCode` can be compared using == or != to a
-   :type:`CTypes.c_int` or to another :type:`errorCode`. A :type:`errorCode`
+   An :type:`errorCode` can be compared using == or != to a
+   :type:`CTypes.c_int` or to another :type:`errorCode`. An :type:`errorCode`
    can be cast to or from a :type:`CTypes.c_int`. It can be assigned the
    value of a :type:`CTypes.c_int` or another :type:`errorCode`. In addition,
    :type:`errorCode` can be checked directly in an if statement like so:
@@ -969,7 +969,7 @@ module OS {
      if err then do writeln("err contains an error, ie err != ENOERR");
      if !err then do writeln("err does not contain an error; err == ENOERR");
 
-   When a :type:`errorCode` formal has default intent, the actual is copied to
+   When an :type:`errorCode` formal has default intent, the actual is copied to
    the formal upon a function call and the formal cannot be assigned within
    the function.
 

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -956,6 +956,25 @@ module OS {
 
   } // end POSIX
 
+/* A type storing an error code or an error message.
+   A :type:`errorCode` can be compared using == or != to a
+   :type:`CTypes.c_int` or to another :type:`errorCode`. A :type:`errorCode`
+   can be cast to or from a :type:`CTypes.c_int`. It can be assigned the
+   value of a :type:`CTypes.c_int` or another :type:`errorCode`. In addition,
+   :type:`errorCode` can be checked directly in an if statement like so:
+
+   .. code-block:: chapel
+
+     var err: errorCode;
+     if err then do writeln("err contains an error, ie err != ENOERR");
+     if !err then do writeln("err does not contain an error; err == ENOERR");
+
+   When a :type:`errorCode` formal has default intent, the actual is copied to
+   the formal upon a function call and the formal cannot be assigned within
+   the function.
+
+   The default value of the :type:`errorCode` type is undefined.
+*/
   extern "syserr" type errorCode; // opaque so we can manually override ==,!=,etc
 
   // error numbers

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -966,12 +966,10 @@ module OS {
    .. code-block:: chapel
 
      var err: errorCode;
-     if err then do writeln("err contains an error, ie err != ENOERR");
-     if !err then do writeln("err does not contain an error; err == ENOERR");
+     if err then writeln("err contains an error, ie err != ENOERR");
+     else writeln("err does not contain an error; err == ENOERR");
 
-   When an :type:`errorCode` formal has default intent, the actual is copied to
-   the formal upon a function call and the formal cannot be assigned within
-   the function.
+   The default intent for a formal of type :type:`errorCode` is `const in`.
 
    The default value of the :type:`errorCode` type is undefined.
 */


### PR DESCRIPTION
Add a doc comment for OS.errorCode derived from the comment for
SysBasic.syserr.

Signed-off-by: David Iten <daviditen@users.noreply.github.com>