### PR TITLE
Fix "git" formatting in mason docs

### DIFF
--- a/doc/rst/mason-packages/guide/gitdependencies.rst
+++ b/doc/rst/mason-packages/guide/gitdependencies.rst
@@ -2,8 +2,8 @@
 
 .. _mason-git-dependencies:
 
-Specifying Dependencies from `git` Repositories
-===============================================
+Specifying Dependencies from ``git`` Repositories
+=================================================
 To depend on a library located in a git repository, a git key pointing to the repository URL is all that is required:
 
 .. code-block:: text


### PR DESCRIPTION
Brad pointed out that I should be using double backticks, rather than single in the title for the git docs that were recently added, so this PR makes that change (thanks for pointing this out Brad).