### PR TITLE
Replace explicit ends of the region in the fileIO primer with the count operator

### DIFF
--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -145,8 +145,7 @@ if example == 0 || example == 2 {
 // Note: This could be a forall loop to do I/O in parallel!
   for i in 0..#num by -1 {
     var start = 8*i;
-    var end = 8*i+8;
-    var r = f.reader(kind=ionative, region=start..end);
+    var r = f.reader(kind=ionative, region=start..#9);
     var tmp:uint(64);
     r.read(tmp);
     assert(tmp == i:uint(64));
@@ -200,11 +199,10 @@ if example == 0 || example == 3 {
     // This is a forall loop to do I/O in parallel!
     forall i in 0..#num by -1 {
       var start = 8*i;
-      var end = 8*i+8;
       // When we create the reader, supplying locking=false will do unlocked I/O.
       // That's fine as long as the channel is not shared between tasks;
       // here it's just used as a local variable, so we are O.K.
-      var r = f.reader(kind=ionative, locking=false, region=start..end);
+      var r = f.reader(kind=ionative, locking=false, region=start..#9);
       var tmp:uint(64);
       r.read(tmp);
       assert(tmp == i:uint(64));


### PR DESCRIPTION
Brad pointed out that since these were computed as a set number past the start point, the count operator would also accomplish the same thing and could be naturally used in the expression.  This impacted two places in the primer.

Will verify a fresh checkout