### PR TITLE
docs(Strings): fix menu link and heading for String methods

### DIFF
--- a/doc/rst/language/spec/strings.rst
+++ b/doc/rst/language/spec/strings.rst
@@ -170,10 +170,10 @@ codepoint of the argument:
      }
 
 
-.. String_Methods:
+.. _String_Methods:
 
 String Methods
-~~~~~~~~~~~~~~
+--------------
 
 The *string* type:
 

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -214,7 +214,7 @@ removeUsage $file
 ## String ##
 
 file="./String.rst"
-fixTitle "Strings" $file
+removeTitle $file
 removeUsage $file
 replace "chpl_bytes" "bytes" $file
 


### PR DESCRIPTION
This PR fixes a small heading issue with `Strings` that became apparent with
https://github.com/chapel-lang/chapel/pull/20625. 
The menu link for `String Methods` did not appear in the left side navigation
menu as it did for other `Composite Types`, like `Bytes` for example. 
The menu entry for `String Methods` will now appear under 
`Language Specification` -> `Composite Types` -> `Strings`, similar to `Bytes`. 

Changes include:

- add leading underscore `_` to `String_Methods`
- change heading level indicators for `String Methods` from `~` to `-`
- modify post-processing script to stop inserting `Strings` title

TESTING: 

- [x] diff compare Chapel docs before/after change
- [x] all `chpldoc` tests pass
- [x] visually inspect docs for `Strings` and `Bytes`

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>