### PR TITLE
dyno: Improve scope resolution of internal/standard modules

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -3027,8 +3027,15 @@ Type* AggregateType::getDecoratedClass(ClassTypeDecoratorEnum d) {
       tsDec->addFlag(FLAG_GENERIC);
     // The generated code should just use the canonical class name
     tsDec->cname = at->symbol->cname;
-    DefExpr* defDec = new DefExpr(tsDec);
-    symbol->defPoint->insertAfter(defDec);
+
+    // 'symbol' might not be in the tree if we're running with --dyno and
+    // scope-resolving an AggregateType that contains a reference to itself
+    // (e.g. a linked-list with a 'next' node). The 'convert-uast' pass is
+    // meant to manually insert these defPoints later.
+    if (!fDynoCompilerLibrary || isAlive(symbol->defPoint)) {
+      DefExpr* defDec = new DefExpr(tsDec);
+      symbol->defPoint->insertAfter(defDec);
+    }
   }
 
   return at->decoratedClasses[packedDecorator];

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -212,6 +212,8 @@ static void gatherType(Symbol* sym, Type* t, const char* name) {
     WellKnownAggregateType& wkt = sWellKnownAggregateTypes[i];
 
     if (name == wkt.name) {
+      if (isDecoratedClassType(t)) continue;
+
       if (*wkt.type_ != NULL)
         multipleDefinedTypeError(sym, name);
       INT_ASSERT(t != NULL);

--- a/compiler/dyno/include/chpl/resolution/resolution-queries.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-queries.h
@@ -215,6 +215,13 @@ const ResolvedFunction* resolveConcreteFunction(Context* context, ID id);
  */
 const ResolvedFunction* scopeResolveFunction(Context* context, ID id);
 
+/*
+ * Scope-resolve an AggregateDecl's fields, along with their type expressions
+ * and initialization expressions.
+ */
+const ResolutionResultByPostorderID& scopeResolveAggregate(Context* context,
+                                                          ID id);
+
 /**
   Returns the ResolvedFunction called by a particular
   ResolvedExpression, if there was exactly one candidate.

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -355,13 +355,27 @@ types::QualifiedType Resolver::typeErr(const uast::AstNode* ast,
   return t;
 }
 
-const Scope* Resolver::methodReceiverScope() {
+const Scope* Resolver::methodReceiverScope(bool recompute) {
+  if (recompute) {
+    receiverScopeComputed = false;
+  }
+
   if (receiverScopeComputed) {
     return savedReceiverScope;
   }
 
   if (typedSignature && typedSignature->untyped()->isMethod()) {
-    if (auto receiverType = typedSignature->formalType(0).type()) {
+    if (scopeResolveOnly) {
+      auto* untyped = typedSignature->untyped();
+      auto thisFormal = untyped->formalDecl(0)->toFormal();
+      auto type = thisFormal->typeExpression();
+      if (auto ident = type->toIdentifier()) {
+        auto re = byPostorder.byAst(ident);
+        if (re.toId().isEmpty() == false) {
+          savedReceiverScope = scopeForId(context, re.toId());
+        }
+      }
+    } else if (auto receiverType = typedSignature->formalType(0).type()) {
       if (auto compType = receiverType->getCompositeType()) {
         savedReceiverScope = scopeForId(context, compType->id());
         savedReceiverType = compType;

--- a/compiler/dyno/lib/resolution/Resolver.cpp
+++ b/compiler/dyno/lib/resolution/Resolver.cpp
@@ -239,6 +239,19 @@ Resolver::createForScopeResolvingFunction(Context* context,
   return ret;
 }
 
+Resolver
+Resolver::createForScopeResolvingField(Context* context,
+                                 const uast::AggregateDecl* ad,
+                                 const AstNode* fieldStmt,
+                                 ResolutionResultByPostorderID& byPostorder) {
+  auto ret = Resolver(context, ad, byPostorder, nullptr);
+  ret.scopeResolveOnly = true;
+  ret.curStmt = fieldStmt;
+  ret.byPostorder.setupForSymbol(ad);
+
+  return ret;
+}
+
 
 // set up Resolver to initially resolve field declaration types
 Resolver

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -121,6 +121,11 @@ struct Resolver {
   createForScopeResolvingFunction(Context* context, const uast::Function* fn,
                                   ResolutionResultByPostorderID& byPostorder);
 
+  static Resolver createForScopeResolvingField(Context* context,
+                                         const uast::AggregateDecl* ad,
+                                         const uast::AstNode* fieldStmt,
+                                         ResolutionResultByPostorderID& byPostorder);
+
   // set up Resolver to initially resolve field declaration types
   static Resolver
   createForInitialFieldStmt(Context* context,

--- a/compiler/dyno/lib/resolution/Resolver.h
+++ b/compiler/dyno/lib/resolution/Resolver.h
@@ -179,7 +179,7 @@ struct Resolver {
   /* Compute the receiver scope (when resolving a method)
      and return nullptr if it is not applicable.
    */
-  const Scope* methodReceiverScope();
+  const Scope* methodReceiverScope(bool recompute = false);
   /* Compute the receiver scope (when resolving a method)
      and return nullptr if it is not applicable.
    */

--- a/compiler/dyno/lib/resolution/resolution-queries.cpp
+++ b/compiler/dyno/lib/resolution/resolution-queries.cpp
@@ -1706,6 +1706,28 @@ const ResolvedFunction* scopeResolveFunction(Context* context,
   return result.get();
 }
 
+const ResolutionResultByPostorderID& scopeResolveAggregate(Context* context,
+                                                           ID id) {
+  QUERY_BEGIN(scopeResolveAggregate, context, id);
+
+  const AggregateDecl* ad = parsing::idToAst(context, id)->toAggregateDecl();
+  ResolutionResultByPostorderID result;
+
+  if (ad) {
+    // TODO: Use some kind of "ad->fields()" iterator
+    for (auto child : ad->children()) {
+      if (child->isVarLikeDecl() ||
+          child->isMultiDecl() ||
+          child->isTupleDecl()) {
+        auto res = Resolver::createForScopeResolvingField(context, ad, child, result);
+        child->traverse(res);
+      }
+    }
+  }
+
+  return QUERY_END(result);
+}
+
 
 const ResolvedFunction* resolveOnlyCandidate(Context* context,
                                              const ResolvedExpression& r) {

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -299,6 +299,7 @@ const Scope* scopeForId(Context* context, ID id) {
 
 static bool doLookupInScope(Context* context,
                             const Scope* scope,
+                            const Scope* receiverScope,
                             const ResolvedVisibilityScope* resolving,
                             UniqueString name,
                             LookupConfig config,
@@ -354,7 +355,7 @@ static bool doLookupInImports(Context* context,
         }
 
         // find it in that scope
-        bool found = doLookupInScope(context, symScope, resolving,
+        bool found = doLookupInScope(context, symScope, nullptr, resolving,
                                      from, newConfig,
                                      checkedScopes, result);
         if (found && onlyInnermost)
@@ -379,7 +380,7 @@ static bool doLookupInImports(Context* context,
       }
 
       // find it in that scope
-      bool found = doLookupInScope(context, autoModScope, resolving,
+      bool found = doLookupInScope(context, autoModScope, nullptr, resolving,
                                    name, newConfig,
                                    checkedScopes, result);
       if (found && onlyInnermost)
@@ -405,6 +406,7 @@ static bool doLookupInToplevelModules(Context* context,
 // appends to result
 static bool doLookupInScope(Context* context,
                             const Scope* scope,
+                            const Scope* receiverScope,
                             const ResolvedVisibilityScope* resolving,
                             UniqueString name,
                             LookupConfig config,
@@ -439,6 +441,7 @@ static bool doLookupInScope(Context* context,
     if (onlyInnermost && got) return true;
   }
 
+  // Look at use/import statements in the current scope
   if (checkUseImport) {
     bool got = false;
     got = doLookupInImports(context, scope, resolving,
@@ -456,15 +459,41 @@ static bool doLookupInScope(Context* context,
       newConfig |= LOOKUP_INNERMOST;
     }
 
+    // Search parent scopes, if any, until a module is encountered
     const Scope* cur = nullptr;
+    bool reachedModule = false;
     for (cur = scope->parentScope(); cur != nullptr; cur = cur->parentScope()) {
-      bool got = doLookupInScope(context, cur, resolving, name, newConfig,
-                                 checkedScopes, result);
-      if (onlyInnermost && got) return true;
-
-      // stop if we reach a Module scope
-      if (asttags::isModule(cur->tag()))
+      if (asttags::isModule(cur->tag())) {
+        reachedModule = true;
         break;
+      }
+
+      bool got = doLookupInScope(context, cur, receiverScope, resolving, name,
+                                 newConfig, checkedScopes, result);
+      if (onlyInnermost && got) return true;
+    }
+
+    if (reachedModule) {
+      // Assumption: If a module is encountered, and if there is a receiver
+      // scope, then we were scope-resolving inside of a method call.  In this
+      // case we should perform a lookup in the receiver scope before looking
+      // in the module scope. For example:
+      // module M {
+      //   type T = int;
+      //   record R { type T; }
+      //   proc R.foo() : T { } // should resolve 'T' to 'R.T', not 'M.T'
+      // }
+      if (receiverScope != nullptr) {
+        bool got = doLookupInScope(context, receiverScope, nullptr,
+                                   resolving, name, newConfig, checkedScopes,
+                                   result);
+        if (onlyInnermost && got) return true;
+      }
+
+      // ... then check the containing module scope
+      bool got = doLookupInScope(context, cur, receiverScope, resolving, name,
+                                 newConfig, checkedScopes, result);
+      if (onlyInnermost && got) return true;
     }
 
     // check also in the root scope if this isn't already the root scope
@@ -474,8 +503,8 @@ static bool doLookupInScope(Context* context,
         rootScope = cur;
     }
     if (rootScope != nullptr) {
-      bool got = doLookupInScope(context, rootScope, resolving, name, newConfig,
-                                 checkedScopes, result);
+      bool got = doLookupInScope(context, rootScope, nullptr, resolving, name,
+                                 newConfig, checkedScopes, result);
       if (onlyInnermost && got) return true;
     }
   }
@@ -537,7 +566,7 @@ static bool lookupInScopeViz(Context* context,
     config |= LOOKUP_DECLS;
   }
 
-  bool got = doLookupInScope(context, scope, resolving,
+  bool got = doLookupInScope(context, scope, nullptr, resolving,
                              name, config,
                              checkedScopes, result);
 
@@ -564,14 +593,8 @@ lookupNameInScopeWithSet(Context* context,
                          ScopeSet& visited) {
   std::vector<BorrowedIdsWithName> vec;
 
-  if (receiverScope) {
-    doLookupInScope(context, receiverScope,
-                    /* resolving scope */ nullptr,
-                    name, config, visited, vec);
-  }
-
   if (scope) {
-    doLookupInScope(context, scope,
+    doLookupInScope(context, scope, receiverScope,
                     /* resolving scope */ nullptr,
                     name, config, visited, vec);
   }
@@ -647,7 +670,7 @@ static void errorIfNameNotInScope(Context* context,
   LookupConfig config = LOOKUP_INNERMOST |
                         LOOKUP_DECLS |
                         LOOKUP_IMPORT_AND_USE;
-  bool got = doLookupInScope(context, scope, resolving,
+  bool got = doLookupInScope(context, scope, nullptr, resolving,
                              name, config,
                              checkedScopes, result);
 
@@ -1144,8 +1167,7 @@ const InnermostMatch& findInnermostDecl(Context* context,
                         LOOKUP_INNERMOST;
 
   std::vector<BorrowedIdsWithName> vec =
-    lookupNameInScope(context, scope,
-                      /* receiver scope */ nullptr,
+    lookupNameInScope(context, scope, nullptr,
                       name, config);
 
   if (vec.size() > 0) {

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -342,10 +342,7 @@ static bool doLookupInImports(Context* context,
     for (const VisibilitySymbols& is: r->visibilityClauses()) {
       UniqueString from = name;
       bool named = is.lookupName(name, from);
-      if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {
-        result.push_back(BorrowedIdsWithName(is.scope()->id()));
-        return true;
-      } else if (named && is.kind() == VisibilitySymbols::CONTENTS_EXCEPT) {
+      if (named && is.kind() == VisibilitySymbols::CONTENTS_EXCEPT) {
         // mentioned in an except clause, so don't return it
       } else if (named || is.kind() == VisibilitySymbols::ALL_CONTENTS) {
         // find it in the contents
@@ -362,6 +359,11 @@ static bool doLookupInImports(Context* context,
                                      checkedScopes, result);
         if (found && onlyInnermost)
           return true;
+      }
+
+      if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {
+        result.push_back(BorrowedIdsWithName(is.scope()->id()));
+        return true;
       }
     }
   }

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -283,6 +283,8 @@ extern std::string llvmFlags;
 extern bool fPrintAdditionalErrors;
 
 extern bool fDynoCompilerLibrary;
+extern bool fDynoScopeProduction;
+extern bool fDynoScopeBundled;
 extern bool fDynoDebugTrace;
 
 extern size_t fDynoBreakOnHash;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -307,6 +307,8 @@ static
 bool fPrintChplSettings = false;
 
 bool fDynoCompilerLibrary = false;
+bool fDynoScopeProduction = true;
+bool fDynoScopeBundled = false;
 bool fDynoDebugTrace = false;
 size_t fDynoBreakOnHash = 0;
 
@@ -1224,6 +1226,8 @@ static ArgumentDescription arg_desc[] = {
  {"warn-special", ' ', NULL, "Enable [disable] special warnings", "n", &fNoWarnSpecial, "CHPL_WARN_SPECIAL", setWarnSpecial},
 
  {"dyno", ' ', NULL, "Enable [disable] using dyno compiler library", "N", &fDynoCompilerLibrary, "CHPL_DYNO_COMPILER_LIBRARY", NULL},
+ {"dyno-scope-production", ' ', NULL, "Enable [disable] using both dyno and production scope resolution", "N", &fDynoScopeProduction, "CHPL_DYNO_SCOPE_PRODUCTION", NULL},
+ {"dyno-scope-bundled", ' ', NULL, "Enable [disable] using dyno to scope resolve bundled modules", "N", &fDynoScopeBundled, "CHPL_DYNO_SCOPE_BUNDLED", NULL},
  {"dyno-debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using dyno compiler library", "N", &fDynoDebugTrace, "CHPL_DYNO_DEBUG_TRACE", NULL},
  {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "X", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
 

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -1138,7 +1138,14 @@ static const char* searchThePath(const char*      modName,
   const char* retval   = NULL;
 
   forv_Vec(const char*, dirName, searchPath) {
-    const char* path = astr(dirName, "/", fileName);
+    std::string dirStr = dirName;
+
+    // Remove slashes at the end of the directory path
+    while (dirStr.size() > 1 && dirStr.back() == '/') {
+      dirStr.pop_back();
+    }
+
+    const char* path = astr(dirStr.c_str(), "/", fileName);
 
     if (FILE* file = openfile(path, "r", false)) {
       closefile(file);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1125,12 +1125,14 @@ struct Converter {
     INT_ASSERT(node->numVisibilityClauses() > 0);
 
     inImportOrUse = true;
+    BlockStmt* ret = nullptr;
     if (node->numVisibilityClauses() == 1) {
-      return convertUsePossibleLimitations(node);
+      ret = convertUsePossibleLimitations(node);
     } else {
-      return convertUseNoLimitations(node);
+      ret = convertUseNoLimitations(node);
     }
     inImportOrUse = false;
+    return ret;
   }
 
   Expr* visit(const uast::VisibilityClause* node) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4250,6 +4250,19 @@ void postConvertApplyFixups(chpl::Context* context) {
     }
   }
 
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (fn->_this == nullptr) continue; // not a method
+
+    if (fn->_this->type == dtUnknown) {
+      Expr* expr = toArgSymbol(fn->_this)->typeExpr->body.only();
+      if (SymExpr* receiver = toSymExpr(expr)) {
+        if (auto dct = toDecoratedClassType(receiver->symbol()->type)) {
+          receiver->replace(new SymExpr(dct->getCanonicalClass()->symbol));
+        }
+      }
+    }
+  }
+
   // Ensure no SymExpr referring to TemporaryConversionSymbol is still in tree
   if (fVerify) {
     forv_Vec(SymExpr, se, gSymExprs) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1377,6 +1377,9 @@ struct Converter {
         auto initExpr = toExpr(convertAST(ifVar->initExpression()));
         bool isConst = ifVar->kind() == uast::Variable::CONST;
         cond = buildIfVar(varNameStr, initExpr, isConst);
+
+        DefExpr* def = toDefExpr(toCallExpr(cond)->get(1));
+        noteConvertedSym(node->condition(), def->sym);
       } else {
         cond = toExpr(convertAST(node->condition()));
       }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3385,7 +3385,9 @@ struct Converter {
   Expr* convertAggregateDecl(const uast::AggregateDecl* node) {
 
     const resolution::ResolutionResultByPostorderID* resolved = nullptr;
-    // TODO: set resolved
+    if (shouldScopeResolve(node)) {
+      resolved = &resolution::scopeResolveAggregate(context, node->id());
+    }
     pushToSymStack(node, resolved);
 
     auto comment = consumeLatestComment();

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -63,8 +63,6 @@ using namespace chpl;
 
 namespace {
 
-const bool tryToScopeResolveEverything = false;
-
 struct ConvertedSymbolsMap {
   ID inSymbolId;
   ConvertedSymbolsMap* parentMap = nullptr;
@@ -200,9 +198,12 @@ struct Converter {
   }
 
   bool shouldScopeResolve(ID symbolId) {
-    if (tryToScopeResolveEverything) return true;
-    return canScopeResolve &&
-           !chpl::parsing::idIsInBundledModule(context, symbolId);
+    if (canScopeResolve) {
+      return fDynoScopeBundled ||
+             !chpl::parsing::idIsInBundledModule(context, symbolId);
+    }
+
+    return false;
   }
   bool shouldScopeResolve(const uast::AstNode* node) {
     return shouldScopeResolve(node->id());

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4243,6 +4243,7 @@ void postConvertApplyFixups(chpl::Context* context) {
   forv_Vec(TypeSymbol, ts, gTypeSymbols) {
     if (auto dct = toDecoratedClassType(ts->type)) {
       if (isAlive(ts) == false) {
+        SET_LINENO(ts);
         auto at = dct->getCanonicalClass();
         DefExpr* defDec = new DefExpr(ts);
         at->symbol->defPoint->insertAfter(defDec);
@@ -4257,6 +4258,7 @@ void postConvertApplyFixups(chpl::Context* context) {
       Expr* expr = toArgSymbol(fn->_this)->typeExpr->body.only();
       if (SymExpr* receiver = toSymExpr(expr)) {
         if (auto dct = toDecoratedClassType(receiver->symbol()->type)) {
+          SET_LINENO(receiver);
           receiver->replace(new SymExpr(dct->getCanonicalClass()->symbol));
         }
       }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3965,11 +3965,19 @@ void Converter::pushToSymStack(
      const resolution::ResolutionResultByPostorderID* resolved) {
   ConvertedSymbolsMap* parentMap = nullptr;
   if (symStack.size() > 0) {
-    // Find the current top-level module from symStack and consider it the
-    // parent.
-    // We could track things in a more granular way but we might need to
-    // access something like A.B.C.D (where A, B, C are modules) later.
-    parentMap = symStack.front().convertedSyms.get();
+    auto backMap = symStack.back().convertedSyms.get();
+    auto backAst = parsing::idToAst(context, backMap->inSymbolId);
+    if (backAst->toFunction()) {
+      // If we're inside a nested function, then we should use the parent
+      // function's ConvertedSymbolsMap as the parentMap.
+      parentMap = backMap;
+    } else {
+      // Find the current top-level module from symStack and consider it the
+      // parent.
+      // We could track things in a more granular way but we might need to
+      // access something like A.B.C.D (where A, B, C are modules) later.
+      parentMap = symStack.front().convertedSyms.get();
+    }
   } else {
     parentMap = &gConvertedSyms;
   }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4064,7 +4064,7 @@ Symbol* ConvertedSymbolsMap::findConvertedSym(ID id, bool trace) {
       // e.g. 'C' in 'typeFn(C)' refers to anymanaged C rather than borrowed C
       if (TypeSymbol* ts = toTypeSymbol(ret)) {
         if (AggregateType* at = toAggregateType(ts->type)) {
-          if (at->isClass()) {
+          if (at->isClass() && isClassLikeOrManaged(at)) {
             Type* useType =
               at->getDecoratedClass(ClassTypeDecorator::GENERIC_NONNIL);
             ret = useType->symbol;

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -3104,7 +3104,9 @@ void scopeResolve() {
 
   resolveGotoLabels();
 
-  resolveUnresolvedSymExprs();
+  if (!fDynoCompilerLibrary || fDynoScopeProduction) {
+    resolveUnresolvedSymExprs();
+  }
 
   resolveEnumeratedTypes();
 

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -60,6 +60,8 @@ _chpl ()
 --dyno \
 --dyno-break-on-hash \
 --dyno-debug-trace \
+--dyno-scope-bundled \
+--dyno-scope-production \
 --early-deinit \
 --explain-call \
 --explain-call-id \
@@ -171,6 +173,8 @@ _chpl ()
 --no-dynamic-auto-local-access \
 --no-dyno \
 --no-dyno-debug-trace \
+--no-dyno-scope-bundled \
+--no-dyno-scope-production \
 --no-early-deinit \
 --no-explain-verbose \
 --no-fast-followers \


### PR DESCRIPTION
This PR includes a variety of fixes to improve the status of scope-resolution with --dyno. In particular, two new developer flags are added:
- "--[no-]dyno-scope-bundled" : enables/disables dyno scope resolution for internal, standard, and package modules
- "--[no-]dyno-scope-production" : enables/disables parts of the production compiler's scopeResolve pass

These flags can be used to more easily debug and develop convert-uast and dyno's scope-queries.

This PR adds a new scope-query: "scopeResolveAggregate". This query currently focuses on scope-resolving the fields of an aggregate type by recognizing them as declarations.

This PR includes a commit that improves scope resolution for secondary methods by improving the calculation of the receiver scope when ``scopeResolveOnly`` is ``true``, and the way it is used in scope-queries. In particular, ``doLookupInScope`` will now check the receiver scope before the module scope when exhausting its search of a method.

Other changes and fixes:

The ``AggregateType::getDecoratedClass`` method has been updated to account for the unconventional situation in convert-uast where we attempt to create a decorated class symbol before the original AggregateType's symbol has been inserted into the tree. Instead of inserting the ``DefExpr`` in ``getDecoratedClass``, it is inserted later during ``postConvertApplyFixups``.

``Converter::pushToSymStack`` is updated to use a Function's ConvertedSymbolsMap as the parentMap when the current symbol is inside that Function. This change helps to support scope-resolution of nested functions.

Minor changes:
- fixed scope-resolution of simple if-variables
- ``postConvertApplyFixups`` will now replace decorated receiver types with undecorated types
- fixed an issue in dyno where we failed to correctly scope resolve to a class that shared the same name as its parent module

Testing:
- [x] full local (without --dyno)
- [x] gasnet
- [x] --dyno (394 failures)