### PR TITLE
Fix the generated tarball on Mac OS X

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -135,7 +135,6 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
        "util/start_test",
        "util/chpltags",
        "compiler/dyno/tools/chpldoc/LICENSE",
-       "compiler/dyno/tools/chpldoc/BUILD_VERSION",
        "compiler/dyno/tools/chpldoc/COPYRIGHT",
        "compiler/dyno/include/chpl/config/config.h.cmake",
 );


### PR DESCRIPTION
When building the tarball on linux and then untarring it on Mac OS X we were seeing an error like:

    chapel-1.28.0/compiler/dyno/tools/chpldoc/BUILD_VERSION: Skipping hardlink pointing to itself: chapel-1.28.0/compiler/dyno/tools/chpldoc/BUILD_VERSION

We did not see this error when untarring on linux.

It turns out that compiler/dyno/tools/chpldoc/BUILD_VERSION was a symbolic link that we listed twice in the tar command so it was included twice in the tar archive. It was included in the explicit files to include section and also automatically added by the loop below:

https://github.com/chapel-lang/chapel/blob/6d2141230691521dc27737d1f1aedc0d516a0977/util/buildRelease/gen_release#L252-L263

Changing the gen_release script to include that file only once in the archive solves the problem. This PR removes it from the explicit files since compiler/main/BUILD_VERSION was already being found by the loop.

From running gen_release on linux and using the resulting tarball:

Reviewed by @bhavanijayakumaran and @tzinsky - thanks!

- [x] untar, make, make check, make chpldoc works on linux
- [x] untar, make, make check, make chpldoc works on Mac OS X