### PR TITLE
Fix audit failures in homebrew formula

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,8 +1,8 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://chapel-lang.org/tmp/chapel-1.28.0.tar.gz"
-  sha256 "162db408d2ae6efcbaaf121eb0797e686b1caac2f16005af6ca69af15d210073"
+  url "https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz"
+  sha256 "558b1376fb7757a5e1f254c717953f598a3e89850c8edd1936b8d09c464f3e8b"
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,10 +1,9 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.27.0/chapel-1.27.0.tar.gz"
-  sha256 "558b1376fb7757a5e1f254c717953f598a3e89850c8edd1936b8d09c464f3e8b"
+  url "https://chapel-lang.org/tmp/chapel-1.28.0.tar.gz"
+  sha256 "162db408d2ae6efcbaaf121eb0797e686b1caac2f16005af6ca69af15d210073"
   license "Apache-2.0"
-  revision 2
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   bottle do
@@ -17,10 +16,10 @@ class Chapel < Formula
   end
 
   depends_on "gmp"
-  depends_on "python@3.10"
   # Chapel only supports  LLVM 14 and older. When LLVM15 releases,  our formula would need to change
-  # this line to llvm@14. 
+  # this line to llvm@14.
   depends_on "llvm"
+  depends_on "python@3.10"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"
@@ -38,8 +37,8 @@ class Chapel < Formula
   def install
     # Always detect Python used as dependency rather than needing aliased Python formula
     python = "python3.10"
-    # It should be noted that this will expand to: 'for cmd in python3.10 python3 python python2; do' 
-    # in our find-python.sh script.  
+    # It should be noted that this will expand to: 'for cmd in python3.10 python3 python python2; do'
+    # in our find-python.sh script.
     inreplace "util/config/find-python.sh", /^(for cmd in )(python3 )/, "\\1#{python} \\2"
 
     libexec.install Dir["*"]


### PR DESCRIPTION
Clean up white space issues and dependency order. These issues
were found in the homebrew CI process or brew audit <formula>
command.