### PR TITLE
Remove (dyno-based) chpldoc sources from `chpl`'s tags/ebrowse output

### DIFF
--- a/compiler/dyno/tools/chpldoc/Makefile.include
+++ b/compiler/dyno/tools/chpldoc/Makefile.include
@@ -18,8 +18,6 @@
 
 DYNO_CHPLDOC_OBJDIR = $(COMPILER_BUILD)/dyno/tools/chpldoc
 
-ALL_SRCS += dyno/tools/chpldoc/*.h dyno/tools/chpldoc/*.cpp
-
 DYNO_CHPLDOC_SRCS =                              \
            arg-helpers.cpp \
            arg.cpp \


### PR DESCRIPTION
The ALL_SRCS Makefile variable is used to determine which sources
should have tags and/or ebrowse information generated for them.
Traditionally, the chpldoc sources and the `chpl` sources have been
one and the same, but with the recent dyno-based rewrite of chpldoc,
this is no longer the case.  For that reason, it doesn't really make sense
to include its sources in the tags/ebrowse output for `chpl` since it's a
distinct binary / code base.  As a result, this PR removes its sources from
the ALL_SRCS variables.  If/when we want tags/ebrowse information for
chpldoc itself, we can do that as a distinct tags/ebrowse artifact (captured
in https://github.com/Cray/chapel-private/issues/3808).

This PR addresses one part of https://github.com/Cray/chapel-private/issues/3784.
