### PR TITLE
Sync 'submitted' shootouts directory with the CLBG website

### DIFF
--- a/test/studies/shootout/submitted/knucleotide3.chpl
+++ b/test/studies/shootout/submitted/knucleotide3.chpl
@@ -57,7 +57,7 @@ proc writeFreqs(data, param nclSize) {
   var arr = for (s,f) in freqs.items() do (f,s);
 
   // print the array, sorted by decreasing frequency
-  for (f, s) in sorted(arr, reverseComparator) do
+  for (f, s) in arr.sorted(reverseComparator) do
    writef("%s %.3dr\n", decode(s, nclSize),
            (100.0 * f) / (data.size - nclSize));
   writeln();

--- a/test/studies/shootout/submitted/knucleotide4.chpl
+++ b/test/studies/shootout/submitted/knucleotide4.chpl
@@ -56,7 +56,7 @@ proc writeFreqs(data, param nclSize) {
   var arr = for (s,f) in freqs.items() do (f,s.val);
 
   // print the array, sorted by decreasing frequency
-  for (f, s) in sorted(arr, reverseComparator) do
+  for (f, s) in arr.sorted(reverseComparator) do
    writef("%s %.3dr\n", decode(s, nclSize),
            (100.0 * f) / (data.size - nclSize));
   writeln();

--- a/test/studies/shootout/submitted/revcomp2.chpl
+++ b/test/studies/shootout/submitted/revcomp2.chpl
@@ -17,7 +17,7 @@ config const readSize = 16384;  // the chunk size to read at a time
 
 // a channel and coordination variable for writing data to stdout
 var stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                 hints = QIO_CH_ALWAYS_UNBUFFERED),
+                                 hints=QIO_CH_ALWAYS_UNBUFFERED),
     seqToWrite: atomic int = 1;
 
 

--- a/test/studies/shootout/submitted/revcomp3.chpl
+++ b/test/studies/shootout/submitted/revcomp3.chpl
@@ -13,9 +13,9 @@ const table = createTable();    // create the table of code complements
 proc main(args: [] string) {
   use IO;
   const stdinBin = openfd(0).reader(iokind.native, locking=false,
-                                hints = QIO_CH_ALWAYS_UNBUFFERED),
+                                 hints = QIO_CH_ALWAYS_UNBUFFERED),
         stdoutBin = openfd(1).writer(iokind.native, locking=false,
-                                  hints = QIO_CH_ALWAYS_UNBUFFERED);
+                                  hints=QIO_CH_ALWAYS_UNBUFFERED);
 
   // read in the data using an incrementally growing buffer
   var bufLen = 8 * 1024,


### PR DESCRIPTION
I think these got updated as part of various deprecation/unstable
efforts this past release cycle.  Reverting those changes to keep
the output of `./clbg-diff.py` clean.
