### PR TITLE
Fix entry point script

### DIFF
--- a/util/dockerfiles/entrypoint.sh
+++ b/util/dockerfiles/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export CHPL_BIN_SUBDIR=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`
 export PATH=$PATH:$CHPL_HOME/bin/$CHPL_BIN_SUBDIR:$CHPL_HOME/util
-exec "/bin/bash"
+exec "$@"


### PR DESCRIPTION
Saw issue running the commands directly on the container
docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp 41b3b9a9f461 chpl -o hello hello.chplSigned-off-by: bhavanijayakumaran 
Fixed it by replacing /bin/bash with $@



<82669529+bhavanijayakumaran@users.noreply.github.com>