### PR TITLE
Deprecated file.localesForRegion in I/O module

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5674,6 +5674,7 @@ proc file.getchunk(start:int(64) = 0, end:int(64) = max(int(64))):(int(64),int(6
    :returns: a set of locales that are best for working with this region
    :rtype: domain(locale)
  */
+ deprecated "file.localesForRegion is deprecated"
 proc file.localesForRegion(start:int(64), end:int(64)) {
 
   proc findloc(loc:string, locs:c_ptr(c_string), end:int) {

--- a/test/deprecated/IO/localesForRegion.chpl
+++ b/test/deprecated/IO/localesForRegion.chpl
@@ -1,0 +1,7 @@
+use IO;
+
+const f = open("test.txt", iomode.r);
+
+const locales = f.localesForRegion(0, 10);
+
+f.close();

--- a/test/deprecated/IO/localesForRegion.good
+++ b/test/deprecated/IO/localesForRegion.good
@@ -1,0 +1,10 @@
+localesForRegion.chpl:5: warning: file.localesForRegion is deprecated
+$CHPL_HOME/modules/standard/IO.chpl:5678: In method 'localesForRegion':
+$CHPL_HOME/modules/standard/IO.chpl:5682: error: unresolved call '==(string, c_string)'
+$CHPL_HOME/modules/internal/ChapelBase.chpl:95: note: this candidate did not match: ==(a: _nilType, b: _nilType)
+$CHPL_HOME/modules/standard/IO.chpl:5682: note: because actual argument #1 with type 'string'
+$CHPL_HOME/modules/internal/ChapelBase.chpl:95: note: is passed to formal 'a: nil'
+$CHPL_HOME/modules/standard/IO.chpl:5682: note: other candidates are:
+$CHPL_HOME/modules/internal/ChapelBase.chpl:96: note:   ==(a: bool, b: bool)
+$CHPL_HOME/modules/internal/ChapelBase.chpl:102: note:   ==(a: borrowed object?, b: borrowed object?)
+note: and 111 other candidates, use --print-all-candidates to see them


### PR DESCRIPTION
Signed-off-by: Vivian Wang <vwang0101@gmail.com>

For [issue #20274](https://github.com/chapel-lang/chapel/issues/20274)