### PR TITLE
Fix a null dereference in a dyno stringify function

### DIFF
--- a/compiler/dyno/include/chpl/resolution/resolution-types.h
+++ b/compiler/dyno/include/chpl/resolution/resolution-types.h
@@ -556,7 +556,9 @@ class PoiInfo {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
     ss << "PoiInfo: ";
-    poiScope()->stringify(ss, stringKind);
+    if (poiScope()) {
+      poiScope()->stringify(ss, stringKind);
+    }
   }
 
   /// \cond DO_NOT_DOCUMENT


### PR DESCRIPTION
Fixes a minor problem in a stringify function to fix a core dump I noticed when doing some tracing.

Reviewed by @riftEmber - thanks!

- [x] full local testing