### PR TITLE
Add comments to astlocT fields and reorder them

### DIFF
--- a/compiler/include/astlocs.h
+++ b/compiler/include/astlocs.h
@@ -35,20 +35,28 @@ class Expr;
 // (assumed to get copied upon assignment and parameter passing)
 class astlocT {
 private:
+  // Primarily, astlocT stores the location in the id_ field,
+  // which is computed for each AST element by the dyno parser.
+  chpl::ID            id_;        // id from compiler/dyno
+
+  // Secondarily, an astlocT can store a filename / line number
+  // directly for use in extern C blocks.
+  // Also, the filename and line number fields are used to
+  // cache the result of running the query to compute that
+  // information from the ID.
   mutable const char* filename_;  // filename of location
   mutable int         lineno_;    // line number of location
-  chpl::ID            id_;        // id from compiler/dyno
 
 public:
   astlocT(int linenoArg, const char* filenameArg)
-    : filename_(filenameArg), lineno_(linenoArg), id_()
+    : id_(), filename_(filenameArg), lineno_(linenoArg)
   {
     if (filenameArg != nullptr && strlen(filenameArg) > 0)
       assert(astr(filename_) == filename_);
   }
 
   astlocT(chpl::ID id)
-    : filename_(nullptr), lineno_(0), id_(std::move(id))
+    : id_(std::move(id)), filename_(nullptr), lineno_(0)
   { }
 
   int compare(const astlocT& other) const;


### PR DESCRIPTION
Added comments to clarify how these fields are used.
Reordered the fields to make the most used field first.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local testing