### PR TITLE
Quiet doxygen output from docs build

### DIFF
--- a/compiler/dyno/Makefile.help
+++ b/compiler/dyno/Makefile.help
@@ -95,7 +95,7 @@ dyno: $(LIBCOMPILER_BUILD_DIR) FORCE
 	  cd $(LIBCOMPILER_BUILD_DIR) && $(CMAKE) --build .  --target libdyno ; \
 	fi
 
-COPY_IF_DIFFERENT = $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/config/update-if-different --copy
+COPY_IF_DIFFERENT = $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/config/update-if-different --quiet --copy
 
 dyno-docs: $(LIBCOMPILER_BUILD_DIR) FORCE
 	@echo "Making the compiler library docs..."

--- a/compiler/dyno/doc/CMakeLists.txt
+++ b/compiler/dyno/doc/CMakeLists.txt
@@ -22,13 +22,19 @@ if(DOXYGEN_FOUND)
   # doxygen config-file settings can be set here by prefixing with DOXYGEN_
   set(DOXYGEN_GENERATE_XML YES)
   set(DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doxygen")
+  set(DOXYGEN_INCLUDE_PATH ${CHPL_MAIN_INCLUDE_DIR})
+
   # the following exclude avoids errors in the sphinx build
-  set(DOXYGEN_EXCLUDE "${CHPL_MAIN_INCLUDE_DIR}/chpl/AST/uast-classes-list.h")
+  #set(DOXYGEN_EXCLUDE "${CHPL_MAIN_INCLUDE_DIR}/chpl/AST/uast-classes-list.h";
+  #   )
+
   # these aliases allow \rst and \endrst in docs comments
   set(DOXYGEN_ALIASES
      "rst=\\verbatim embed:rst"
      "endrst=\\endverbatim")
   set(DOXYGEN_EXTRACT_PRIVATE NO)
+  set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)
+  set(DOXYGEN_QUIET YES)
 
   # Enable the below line to request inherited members appear
   # as if they are not inherited.

--- a/compiler/dyno/doc/CMakeLists.txt
+++ b/compiler/dyno/doc/CMakeLists.txt
@@ -24,10 +24,6 @@ if(DOXYGEN_FOUND)
   set(DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doxygen")
   set(DOXYGEN_INCLUDE_PATH ${CHPL_MAIN_INCLUDE_DIR})
 
-  # the following exclude avoids errors in the sphinx build
-  #set(DOXYGEN_EXCLUDE "${CHPL_MAIN_INCLUDE_DIR}/chpl/AST/uast-classes-list.h";
-  #   )
-
   # these aliases allow \rst and \endrst in docs comments
   set(DOXYGEN_ALIASES
      "rst=\\verbatim embed:rst"
@@ -42,9 +38,6 @@ if(DOXYGEN_FOUND)
 
   # when Doxygen runs, define DOXYGEN in the preprocessor
   set(DOXYGEN_PREDEFINED "DOXYGEN")
-  # exclude combine functions that the docs system has trouble with
-  #set(DOXYGEN_EXCLUDE_SYMBOLS "chpl::combine")
-
 
   file(GLOB_RECURSE headers "${CHPL_MAIN_INCLUDE_DIR}/*.h")
   if (CMAKE_VERSION VERSION_LESS 3.16)

--- a/compiler/dyno/doc/CMakeLists.txt
+++ b/compiler/dyno/doc/CMakeLists.txt
@@ -43,8 +43,17 @@ if(DOXYGEN_FOUND)
   # when Doxygen runs, define DOXYGEN in the preprocessor
   set(DOXYGEN_PREDEFINED "DOXYGEN")
   # exclude combine functions that the docs system has trouble with
-  set(DOXYGEN_EXCLUDE_SYMBOLS "chpl::combine")
-  doxygen_add_docs(api-docs ${CHPL_MAIN_INCLUDE_DIR})
+  #set(DOXYGEN_EXCLUDE_SYMBOLS "chpl::combine")
+
+
+  file(GLOB_RECURSE headers "${CHPL_MAIN_INCLUDE_DIR}/*.h")
+  if (CMAKE_VERSION VERSION_LESS 3.16)
+    # don't use USE_STAMP_FILE since it wasn't added until 3.16
+    doxygen_add_docs(api-docs ${headers})
+  else()
+    # use USE_STAMP_FILE to prevent rebuild if headers didn't change
+    doxygen_add_docs(api-docs ${headers} USE_STAMP_FILE)
+  endif()
 
 else(DOXYGEN_FOUND)
   add_custom_target(api-docs

--- a/util/config/update-if-different
+++ b/util/config/update-if-different
@@ -6,6 +6,8 @@ import os
 import shutil
 import sys
 
+quiet = False
+
 def main():
     parser = optparse.OptionParser(
         usage = 'usage: %prog dst src',
@@ -19,10 +21,14 @@ def main():
                       help=("given src dst - copy src to dst. "
                             "Only updates files that differ."
                             "Multiple src args are OK if dst is a directory."))
-
+    parser.add_option("--quiet", action="store_true", dest="quiet",
+                      help=("Do not print out when copying a file."))
 
     (options, args) = parser.parse_args()
 
+
+    if options.quiet:
+        quiet = True
 
     if options.update:
         if len(args) != 2:
@@ -47,7 +53,8 @@ def main():
 
 def update(dst, src):
     if not os.path.exists(dst) or not filecmp.cmp(src, dst):
-        sys.stdout.write("Updating {0} from {1}\n".format(dst, src))
+        if not quiet:
+            sys.stdout.write("Updating {0} from {1}\n".format(dst, src))
         shutil.copyfile(src, dst)
 
     os.remove(src)
@@ -75,12 +82,14 @@ def copy(src, dst):
             dst = os.path.join(dst, sub)
         # do the copy
         if not os.path.exists(dst) or not filecmp.cmp(src, dst):
-            sys.stdout.write("Copying {0} to {1}\n".format(src, dst))
+            if not quiet:
+                sys.stdout.write("Copying {0} to {1}\n".format(src, dst))
             shutil.copyfile(src, dst)
     else:
         # handle directories
         if not os.path.exists(dst):
-            sys.stdout.write("Copying dir {0} to {1}\n".format(src, dst))
+            if not quiet:
+                sys.stdout.write("Copying dir {0} to {1}\n".format(src, dst))
             shutil.copytree(src, dst)
         else:
             srclist = sorted(os.listdir(src))
@@ -91,10 +100,12 @@ def copy(src, dst):
                 if not sub in srcset:
                     rm = os.path.join(dst, sub)
                     if os.path.isdir(rm):
-                        sys.stdout.write("Removing dir {0} not present in {1}\n".format(rm, src))
+                        if not quiet:
+                            sys.stdout.write("Removing dir {0} not present in {1}\n".format(rm, src))
                         shutil.rmtree(rm)
                     else:
-                        sys.stdout.write("Removing {0} not present in {1}\n".format(rm, src))
+                        if not quiet:
+                            sys.stdout.write("Removing {0} not present in {1}\n".format(rm, src))
                         os.remove(rm)
             # recursively copy anything from src
             for sub in srclist:

--- a/util/config/update-if-different
+++ b/util/config/update-if-different
@@ -9,6 +9,8 @@ import sys
 quiet = False
 
 def main():
+    global quiet
+
     parser = optparse.OptionParser(
         usage = 'usage: %prog dst src',
         description = 'Updates dst with src. If they differ, copies dst to src. '


### PR DESCRIPTION
This PR is intended to improve the experience of doing a docs build.

* Quiets the doxygen and related "Copying..." output so that we don't get screens and screens of it
* Adjusts the doxygen rule to rebuild only if the relevant headers have changed in CMake 3.16 and newer. (Note that, since only 3.13 is required, with 3.13, we will just re-run doxygen every time).

Reviewed by @arezaii - thanks!

- [x] docs build works OK on my system with cmake 3.24
- [x] check docs build on debian-buster which includes cmake 3.13 (they do build, but with doxygen warnings, so the cmake logic added here is OK)
- [x] full local testing