### PR TITLE
Make 'use's transitively private by default in dyno

### DIFF
--- a/compiler/dyno/include/chpl/resolution/scope-types.h
+++ b/compiler/dyno/include/chpl/resolution/scope-types.h
@@ -466,6 +466,7 @@ enum {
   LOOKUP_PARENTS = 4,
   LOOKUP_TOPLEVEL = 8,
   LOOKUP_INNERMOST = 16,
+  LOOKUP_SKIP_PRIVATE_VIS = 32,
 };
 
 using LookupConfig = unsigned int;

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -376,12 +376,11 @@ static bool doLookupInImports(Context* context,
     }
   }
 
-  if (scope->autoUsesModules()) {
+  if (scope->autoUsesModules() && !skipPrivateVisibilities) {
     const Scope* autoModScope = scopeForAutoModule(context);
     if (autoModScope) {
       LookupConfig newConfig = LOOKUP_DECLS |
-                               LOOKUP_IMPORT_AND_USE |
-                               LOOKUP_SKIP_PRIVATE_VIS;
+                               LOOKUP_IMPORT_AND_USE;
 
       if (onlyInnermost) {
         newConfig |= LOOKUP_INNERMOST;

--- a/compiler/dyno/test/resolution/testScopeResolve.cpp
+++ b/compiler/dyno/test/resolution/testScopeResolve.cpp
@@ -332,6 +332,11 @@ static void test7() {
 }
 
 // test transitive visibility through public/non-public uses
+// TODO: Test that private auto-uses (ChapelStandard) are subject to the
+// correct transitive visibility rules. Currently this is not very well
+// possible because we cannot change which module is auto-used to one that
+// would be conducive to testing -- see private issue #3830 which would
+// change this.
 static void test8() {
   printf("test8\n");
   Context ctx;


### PR DESCRIPTION
Fix a bug where Dyno scope resolution would continue searches transitively through non-public `use`s and `import`s.

This contains a TODO for automatic testing that private auto-`use`s, such as for `ChapelStandard`, are subject to the correct transitive visibility rules as well. This has been tested manually but is currently not feasible to automatically test; https://github.com/Cray/chapel-private/issues/3830 might change that.

Resolves https://github.com/cray/chapel-private/issues/3805.