### PR TITLE
Add void to chpl_program_about

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1204,7 +1204,7 @@ static void genConfigGlobalsAndAbout() {
 
   if (info->cfile) {
     fprintf(info->cfile, "\nvoid chpl_program_about(void);\n");
-    fprintf(info->cfile, "\nvoid chpl_program_about() {\n");
+    fprintf(info->cfile, "\nvoid chpl_program_about(void) {\n");
   } else {
 #ifdef HAVE_LLVM
     llvm::FunctionType* programAboutType;


### PR DESCRIPTION
CCE 15 started complaining about the lack of `void` here,
and @bmcdonald3 and @dlongnecke-cray put this fix
together, but didn't get a chance to test it before Ben headed
home for the weekend.  The change is sufficiently innocuous
and sufficiently likely to fix the warning that I think it's
worth merging to see (and to see whether there are others
hiding behind this one).