### PR TITLE
dyno: Fix a --dyno issue with nested classes

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2914,7 +2914,14 @@ AggregateType::checkSameNameFields() {
   // that no field with the same name is defined in a parent class.
   // But, ignore the compiler-added 'super' field.
   for_fields(field, this) {
-    if (!field->hasFlag(FLAG_SUPER_CLASS)) {
+    // Compiler currently inserts DefExprs for DecoratedClassTypes adjacent to
+    // the DefExpr of the original AggregateType. For nested types, the
+    // DefExprs for DecoratedClassTypes might mistakenly be recognized as
+    // fields.
+    bool isDecoratedTypeDef = isTypeSymbol(field) &&
+                              isDecoratedClassType(field->type);
+    if (!field->hasFlag(FLAG_SUPER_CLASS) &&
+        !isDecoratedTypeDef) {
       auto pair = allFields.emplace(field->name, field);
       bool inserted = pair.second;
       if (!inserted) {


### PR DESCRIPTION
This PR updates the production compiler to not consider a placeholder DecoratedClassType DefExpr to be a field when checking for fields with the same name. This is now possible with ``--dyno`` which will create those DefExprs before scopeResolve. The production compiler previously did not create those DefExprs by the time we checked for fields with the same name.

Testing:
- [x] full local