### PR TITLE
Require doxygen version 1.8.17 for C++ docs

### DIFF
--- a/compiler/dyno/doc/CMakeLists.txt
+++ b/compiler/dyno/doc/CMakeLists.txt
@@ -15,8 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Support for documentation of AST header
-find_package(Doxygen)
+# Support for generating API documentation from C++ headers
+
+# Require Doxygen version 1.8.17 or newer
+#  * observed problems with 1.8.13 and 1.8.14
+#  * 1.8.17 is used in Ubuntu 20.04 LTS and seems to work
+find_package(Doxygen 1.8.17)
 
 if(DOXYGEN_FOUND)
   # doxygen config-file settings can be set here by prefixing with DOXYGEN_

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -50,7 +50,7 @@ In addition, several optional components have additional requirements:
     or the equivalent package; ``python3`` and ``pip3`` commands; and the
     ``venv`` Python package.
 
-  * ``doxygen`` is required to build the complete documentation
+  * ``doxygen`` 1.8.17 or newer is required to build the complete documentation
 
   * ``m4`` is required for building the bundled GMP
 


### PR DESCRIPTION
Require Doxygen version 1.8.17 or newer to do build the compiler library API docs. Note that, currently, `make docs` will succeed even if `doxygen` is not found. The idea is that `doxygen` is an optional dependency.

Follow-up to PR #20712.

Why 1.8.17?
 * observed problems with 1.8.13 and 1.8.14
 * 1.8.17 is used in Ubuntu 20.04 Focal Fossa LTS and seems to work

Reviewed by @arezaii - thanks!

- [x] docs build succeeds on Debian 10 Buster with doxygen 1.8.13 installed (automatically skipping compiler API docs) where it previously failed
- [x] docs build succeeds on another system with doxygen 1.8.14 installed (automatically skipping compiler API docs)
- [x] docs build succeeds on Mac OS X with Homebrew doxygen 1.9.5 (including compiler API docs)
- [x] docs build succeeds on a linux system with doxygen 1.8.20 (including compiler API docs)