### PR TITLE
Fix re2 c++ tests

### DIFF
--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -352,6 +352,9 @@ int qio_regex_channel_read_byte(qio_channel_s* ch)
   return ret;
 }
 
+// cur: what the search process believes to be the current offset
+// min: what the search process believes to be the minimum offset
+//      that we cannot discard
 void qio_regex_channel_discard(qio_channel_s* ch, int64_t cur, int64_t min)
 {
   int64_t buf;
@@ -367,7 +370,7 @@ void qio_regex_channel_discard(qio_channel_s* ch, int64_t cur, int64_t min)
   if( min < buf ) min = buf;
 
   // advance to target.
-  //printf("DISCARD CALLED: advance to %i\n", (int) target);
+  //printf("DISCARD CALLED: advance to %i\n", (int) min);
   qio_channel_advance_unlocked(ch, min - buf);
   //printf("DISCARD CALLED: mark\n");
   qio_channel_mark(false, ch);

--- a/test/regex/ferguson/ctests/regex_channel_test.cc
+++ b/test/regex/ferguson/ctests/regex_channel_test.cc
@@ -253,7 +253,7 @@ void check_channel(qio_hint_t file_hints, qio_hint_t ch_hints, char unbounded_ch
   }
 
   // Create a "write to file" channel.
-  err = qio_channel_create(&writing, f, ch_hints, 0, 1, start, ch_end, NULL);
+  err = qio_channel_create(&writing, f, ch_hints, 0, 1, start, ch_end, NULL, 0);
   assert(!err);
   // Write stuff to the file.
   err = qio_channel_write_amt(threadsafe,writing,test->data,strlen(test->data));
@@ -290,7 +290,7 @@ void check_channel(qio_hint_t file_hints, qio_hint_t ch_hints, char unbounded_ch
 
   // Read the data.
   //err = qio_channel_init_file(&reading, type, f, ch_hints, 1, 0, start, end);
-  err = qio_channel_create(&reading, f, ch_hints, 1, 0, test_start, ch_end, NULL);
+  err = qio_channel_create(&reading, f, ch_hints, 1, 0, test_start, ch_end, NULL, 0);
   assert(!err);
 
   // Read stuff from the file.

--- a/test/regex/ferguson/ctests/sub_test
+++ b/test/regex/ferguson/ctests/sub_test
@@ -24,6 +24,10 @@ RE2INCLS=-I$RE2_INSTALL_DIR/include
 RE2LIB="-L$RE2_INSTALL_DIR/lib -Wl,-rpath,$RE2_INSTALL_DIR/lib -lre2"
 
 RE=`$CHPL_HOME/util/chplenv/chpl_re2.py`
+if [ $? -ne 0 ]
+then
+    exit 1
+fi
 if [ "$RE" = "bundled" ]
 then
   echo "[Working on $DIR with RE2]"
@@ -32,12 +36,12 @@ else
   exit
 fi
 
-echo $DEFS | grep atomics/intrinsics
+echo $DEFS | grep atomics/cstdlib
 if [ $? -eq 0 ]
 then
-  echo "[Working on $DIR with atomics/intrinsics]"
+  echo "[Working on $DIR with atomics/cstdlib]"
 else
-  echo "[Skipping directory $DIR without atomics/intrinsics]"
+  echo "[Skipping directory $DIR without atomics/cstdlib]"
   exit
 fi
 
@@ -59,7 +63,7 @@ else
 fi
 
 DEPS="$OPTS --std=gnu++11 -Wall -DCHPL_RT_UNIT_TEST $DEFS $RE2INCLS"
-LDEPS="$RSRC/qio.c $RSRC/sys.c $RSRC/sys_xsi_strerror_r.c $RSRC/qbuffer.c $RSRC/qio_error.c $RSRC/deque.c $RSRC/regex/re2/re2-interface.cc $RE2LIB -lpthread"
+LDEPS="$RSRC/qio.c $RSRC/sys.c $RSRC/sys_xsi_strerror_r.c $RSRC/qbuffer.c $RSRC/qio_error.c $RSRC/deque.c $RSRC/regex/bundled/re2-interface.cc $RE2LIB -lpthread"
 
 T1="$CXX $DEPS -g regex_test.cc -o regex_test $LDEPS"
 T2="$CXX $DEPS -g regex_channel_test.cc -o regex_channel_test $LDEPS"

--- a/test/regex/ferguson/ctests/sub_test
+++ b/test/regex/ferguson/ctests/sub_test
@@ -23,8 +23,8 @@ RE2_INSTALL_DIR=$($CHPL_HOME/util/config/compileline --libraries | \
 RE2INCLS=-I$RE2_INSTALL_DIR/include
 RE2LIB="-L$RE2_INSTALL_DIR/lib -Wl,-rpath,$RE2_INSTALL_DIR/lib -lre2"
 
-RE=`$CHPL_HOME/util/chplenv/chpl_regex.py`
-if [ "$RE" = "re2" ]
+RE=`$CHPL_HOME/util/chplenv/chpl_re2.py`
+if [ "$RE" = "bundled" ]
 then
   echo "[Working on $DIR with RE2]"
 else

--- a/test/regex/ferguson/ctests/sub_test
+++ b/test/regex/ferguson/ctests/sub_test
@@ -14,7 +14,6 @@ then
 fi
 
 DIR=regex/ferguson/ctests
-CC=gcc
 CXX=g++
 DEFS=`$CHPL_HOME/util/config/compileline --includes-and-defines`
 RSRC="$CHPL_HOME/runtime/src/qio"
@@ -45,23 +44,23 @@ else
   exit
 fi
 
-# If we had an easy way to get the names of the C/C++ compilers
-# we could support non-gnu
 COMP=`$CHPL_HOME/util/chplenv/chpl_compiler.py --target`
-PLAT=`$CHPL_HOME/util/chplenv/chpl_platform.py --target`
+CXX=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_TARGET_CXX | cut -d = -f 2`
 if [ "$COMP" = "gnu" ]
 then
-  echo C tests will run using gnu compiler
+  echo C tests will run using gnu compiler $CXX
 elif [ "$COMP" = "clang" ]
 then
-  echo C tests will run using clang compiler
-  CC=clang
-  CXX=clang++
+  echo C tests will run using clang compiler $CXX
+elif [ "$COMP" = "llvm" ]
+then
+  echo C tests will run using clang compiler $CXX
 else
-  echo "[Skipping directory $DIR without gcc or clang]"
+  echo "[Skipping directory $DIR with unknown compiler]"
   exit
 fi
 
+# compute the g++ etc command
 DEPS="$OPTS --std=gnu++11 -Wall -DCHPL_RT_UNIT_TEST $DEFS $RE2INCLS"
 LDEPS="$RSRC/qio.c $RSRC/sys.c $RSRC/sys_xsi_strerror_r.c $RSRC/qbuffer.c $RSRC/qio_error.c $RSRC/deque.c $RSRC/regex/bundled/re2-interface.cc $RE2LIB -lpthread"
 

--- a/third-party/re2/re2-src/re2/file_strings.cc
+++ b/third-party/re2/re2-src/re2/file_strings.cc
@@ -195,7 +195,8 @@ FileSearchPtr FilePiece::prefix_accel(Prog* prog, ReadingFileSearchPtr s, ssize_
   int c = prog->first_byte();
 
   FileSearchPtr begin = s;
-  for( ssize_t i = 0; i < len; s++,i++ ) {
+  FileSearchPtr end = begin + len;
+  for( ; s < end; s++) {
     if( ( (*s) & 0xff ) == c ) return s;
     if( this->can_discard(s - begin) ) {
       this->discard(false, s, s, s);


### PR DESCRIPTION
Closes #20723

This PR fixes `test/regex/ferguson/ctests` so that it is no longer accidentally skipped and fixes a bug in the RE2 patches while doing so.

The bug was that the loop in `prefix_accel` would run forever because it did not use the `FileSearchPtr` comparison to find the end.

- [ ] full local testing