### PR TITLE
Use f(void) for no-argument functions in C

### DIFF
--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -69,7 +69,7 @@ void chpl_comm_startVerbose(chpl_bool stacktrace, chpl_bool print_unstable) {
 }
 
 
-void chpl_comm_stopVerbose() {
+void chpl_comm_stopVerbose(void) {
   chpl_verbose_comm = 0;
   chpl_comm_diags_disable();
   chpl_comm_bcast_rt_private(chpl_verbose_comm);
@@ -84,7 +84,7 @@ void chpl_comm_startVerboseHere(chpl_bool stacktrace, chpl_bool print_unstable) 
 }
 
 
-void chpl_comm_stopVerboseHere() {
+void chpl_comm_stopVerboseHere(void) {
   chpl_verbose_comm = 0;
 }
 
@@ -106,7 +106,7 @@ void chpl_comm_startDiagnostics(chpl_bool print_unstable) {
 }
 
 
-void chpl_comm_stopDiagnostics() {
+void chpl_comm_stopDiagnostics(void) {
   // Make sure that there are no pending communication operations.
   chpl_rmem_consist_release(0, 0);
 
@@ -127,7 +127,7 @@ void chpl_comm_startDiagnosticsHere(chpl_bool print_unstable) {
 }
 
 
-void chpl_comm_stopDiagnosticsHere() {
+void chpl_comm_stopDiagnosticsHere(void) {
   // Make sure that there are no pending communication operations.
   chpl_rmem_consist_release(0, 0);
 
@@ -135,7 +135,7 @@ void chpl_comm_stopDiagnosticsHere() {
 }
 
 
-void chpl_comm_resetDiagnosticsHere() {
+void chpl_comm_resetDiagnosticsHere(void) {
   chpl_comm_diags_reset();
 }
 

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -155,7 +155,7 @@ void set_maxHeapSize(void)
   }
 }
 
-ssize_t chpl_comm_getenvMaxHeapSize()
+ssize_t chpl_comm_getenvMaxHeapSize(void)
 {
   if (pthread_once(&maxHeapSize_once, set_maxHeapSize) != 0) {
     chpl_internal_error("pthread_once(&maxHeapSize_once) failed");

--- a/runtime/src/chpl-gpu-diags.c
+++ b/runtime/src/chpl-gpu-diags.c
@@ -70,7 +70,7 @@ void chpl_gpu_startVerbose(chpl_bool stacktrace, chpl_bool print_unstable) {
 }
 
 
-void chpl_gpu_stopVerbose() {
+void chpl_gpu_stopVerbose(void) {
   chpl_verbose_gpu = 0;
   chpl_comm_diags_disable();
   chpl_comm_bcast_rt_private(chpl_verbose_gpu);
@@ -85,7 +85,7 @@ void chpl_gpu_startVerboseHere(chpl_bool stacktrace, chpl_bool print_unstable) {
 }
 
 
-void chpl_gpu_stopVerboseHere() {
+void chpl_gpu_stopVerboseHere(void) {
   chpl_verbose_gpu = 0;
 }
 
@@ -107,7 +107,7 @@ void chpl_gpu_startDiagnostics(chpl_bool print_unstable) {
 }
 
 
-void chpl_gpu_stopDiagnostics() {
+void chpl_gpu_stopDiagnostics(void) {
   // Make sure that there are no pending GPU operations.
   chpl_rmem_consist_release(0, 0);
 
@@ -128,7 +128,7 @@ void chpl_gpu_startDiagnosticsHere(chpl_bool print_unstable) {
 }
 
 
-void chpl_gpu_stopDiagnosticsHere() {
+void chpl_gpu_stopDiagnosticsHere(void) {
   // Make sure that there are no pending GPU operations.
   chpl_rmem_consist_release(0, 0);
 
@@ -136,7 +136,7 @@ void chpl_gpu_stopDiagnosticsHere() {
 }
 
 
-void chpl_gpu_resetDiagnosticsHere() {
+void chpl_gpu_resetDiagnosticsHere(void) {
   chpl_gpu_diags_reset();
 }
 

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -630,7 +630,7 @@ printMemAllocs(chpl_mem_descInt_t description, int64_t threshold,
 }
 
 
-void chpl_reportMemInfo() {
+void chpl_reportMemInfo(void) {
   if (memStats) {
     fprintf(memLogFile, "\n");
     chpl_printMemAllocStats(0, 0);
@@ -771,20 +771,20 @@ void chpl_track_realloc_post(void* moreMemAlloc,
   }
 }
 
-void chpl_startVerboseMem() {
+void chpl_startVerboseMem(void) {
   chpl_verbose_mem = 1;
   chpl_comm_bcast_rt_private(chpl_verbose_mem);
 }
 
-void chpl_stopVerboseMem() {
+void chpl_stopVerboseMem(void) {
   chpl_verbose_mem = 0;
   chpl_comm_bcast_rt_private(chpl_verbose_mem);
 }
 
-void chpl_startVerboseMemHere() {
+void chpl_startVerboseMemHere(void) {
   chpl_verbose_mem = 1;
 }
 
-void chpl_stopVerboseMemHere() {
+void chpl_stopVerboseMemHere(void) {
   chpl_verbose_mem = 0;
 }


### PR DESCRIPTION
To be more correct & to resolve some warnings from the CCE compiler.

Continues PR #20714.

- [x] `make WARNINGS=1` works in the CCE configuration that was failing
- [x] full local testing

Reviewed by @riftEmber - thanks!