### PR TITLE
Enable hardcoded PATH in Dockerfile

### DIFF
--- a/util/dockerfiles/Dockerfile
+++ b/util/dockerfiles/Dockerfile
@@ -55,9 +55,6 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 RUN git config --global user.email "noreply@example.com" && \
     git config --global user.name  "Chapel user"
 
-
-COPY entrypoint.sh .
-RUN chmod a+x /entrypoint.sh
-
-# setting path based on the underlying architecture
-ENTRYPOINT ["/entrypoint.sh"]
+# Hack to get access to Chapel binaries
+RUN cp $CHPL_HOME/bin/*/* $CHPL_HOME/bin/
+ENV PATH="${PATH}:${CHPL_HOME}/bin:${CHPL_HOME}/util"

--- a/util/dockerfiles/Dockerfile
+++ b/util/dockerfiles/Dockerfile
@@ -56,5 +56,5 @@ RUN git config --global user.email "noreply@example.com" && \
     git config --global user.name  "Chapel user"
 
 # Hack to get access to Chapel binaries
-RUN cp $CHPL_HOME/bin/*/* $CHPL_HOME/bin/
+RUN cd $CHPL_HOME/bin && ln -s */* .
 ENV PATH="${PATH}:${CHPL_HOME}/bin:${CHPL_HOME}/util"

--- a/util/dockerfiles/entrypoint.sh
+++ b/util/dockerfiles/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-export CHPL_BIN_SUBDIR=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py --host`
-export PATH=$PATH:$CHPL_HOME/bin/$CHPL_BIN_SUBDIR:$CHPL_HOME/util
-exec "$@"


### PR DESCRIPTION
This allows us to get around issues with CI builds that overwrite the `ENTRYPOINT`, breaking our current method of dynamically setting `PATH` based on script output.