### PR TITLE
Fix regex ctests to work in asan configurations

### DIFF
--- a/test/regex/ferguson/ctests/sub_test
+++ b/test/regex/ferguson/ctests/sub_test
@@ -46,6 +46,7 @@ fi
 
 COMP=`$CHPL_HOME/util/chplenv/chpl_compiler.py --target`
 CXX=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_TARGET_CXX | cut -d = -f 2-`
+ASAN=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_SANITIZE_EXE | cut -d = -f 2-`
 if [ "$COMP" = "gnu" ]
 then
   echo C tests will run using gnu compiler $CXX
@@ -58,6 +59,11 @@ then
 else
   echo "[Skipping directory $DIR with unknown compiler]"
   exit
+fi
+
+if [ "$ASAN" = "address" ]
+then
+  CXX="$CXX -fsanitize=address"
 fi
 
 # compute the g++ etc command


### PR DESCRIPTION
Follow-up to PR #20738 to address testing failures in asan configurations.

Test change only -- not reviewed.