### PR TITLE
dyno: more fixes to convert-uast for scope resolution

### DIFF
--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -190,7 +190,8 @@ bool createsScope(asttags::AstTag tag) {
          || asttags::isConditional(tag)
          || asttags::isSelect(tag)
          || asttags::isTry(tag)
-         || asttags::isCatch(tag);
+         || asttags::isCatch(tag)
+         || asttags::isSync(tag);
 }
 
 static const Scope* const& scopeForIdQuery(Context* context, ID id);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1773,6 +1773,9 @@ struct Converter {
     bool zippered = node->iterand()->isZip();
     bool isForExpr = node->isExpressionLevel();
 
+    // convert these for now, despite the error, so that symbols are converted.
+    convertWithClause(node->withClause(), node);
+
     auto ret = ForLoop::buildForeachLoop(indices, iteratorExpr, body,
                                          zippered,
                                          isForExpr);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1504,6 +1504,8 @@ struct Converter {
       condExpr = buildIfVar(condVar->name().c_str(),
                             toExpr(convertAST(condVar->initExpression())),
                             condVar->kind() == chpl::uast::Variable::CONST);
+      DefExpr* def = toDefExpr(toCallExpr(condExpr)->get(1));
+      noteConvertedSym(node->condition(), def->sym);
     } else {
       condExpr = toExpr(convertAST(node->condition()));
     }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3979,9 +3979,15 @@ void Converter::pushToSymStack(
   if (symStack.size() > 0) {
     auto backMap = symStack.back().convertedSyms.get();
     auto backAst = parsing::idToAst(context, backMap->inSymbolId);
-    if (backAst->toFunction()) {
-      // If we're inside a nested function, then we should use the parent
-      // function's ConvertedSymbolsMap as the parentMap.
+
+    // If we're inside a nested function, then we should use the parent
+    // function's ConvertedSymbolsMap as the parentMap.
+    //
+    // If we're inside an aggregate, then we should use that aggregate's
+    // map as the parent so that we can find the right fields. This can
+    // happen for methods declared inside a class or record.
+    if (backAst->toFunction() ||
+        backAst->isAggregateDecl()) {
       parentMap = backMap;
     } else {
       // Find the current top-level module from symStack and consider it the


### PR DESCRIPTION
This PR includes several fixes for various ``--dyno`` failures:
- Update scope-queries to recognize that sync-statements create a scope
- Fix symbol conversion for task-variables that don't alias an existing variable
- Fix for while-vars
- Fix to avoid an internal error for with-clauses on foreach loops
- For methods declared inside aggregates, use the aggregate's scope resolution map as the parent map

Testing:
- [x] full local
- [x] --dyno (326 failures)