### PR TITLE
Fix scope resolution of except lists in dyno

### DIFF
--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -857,14 +857,11 @@ findUseImportTarget(Context* context,
   return nullptr;
 }
 
-
 static void
 doResolveUseStmt(Context* context, const Use* use,
                  const Scope* scope,
                  ResolvedVisibilityScope* r) {
-  bool isPrivate = true;
-  if (use->visibility() == Decl::PUBLIC)
-    isPrivate = false;
+  bool isPrivate = (use->visibility() != Decl::PUBLIC);
 
   for (auto clause : use->visibilityClauses()) {
     // Figure out what was use'd
@@ -887,17 +884,18 @@ doResolveUseStmt(Context* context, const Use* use,
     const Scope* foundScope = findUseImportTarget(context, scope, r,
                                                   expr, VIS_USE, oldName);
     if (foundScope != nullptr) {
-      // First, add VisibilitySymbols entry for the symbol itself
-      if (newName.isEmpty()) {
-        r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
-                               isPrivate, convertOneName(oldName));
-      } else {
+      // First, add VisibilitySymbols entry for the symbol itself,
+      // iff the use is renamed or non-public
+      if (!newName.isEmpty()) {
         r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
                                isPrivate, convertOneRename(oldName, newName));
+      } else if (isPrivate) {
+        r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
+                               isPrivate, convertOneName(oldName));
       }
 
       // Then, add the entries for anything imported
-      VisibilitySymbols::Kind kind = VisibilitySymbols::ALL_CONTENTS;
+      VisibilitySymbols::Kind kind;
       switch (clause->limitationKind()) {
         case VisibilityClause::EXCEPT:
           kind = VisibilitySymbols::CONTENTS_EXCEPT;
@@ -936,9 +934,7 @@ static void
 doResolveImportStmt(Context* context, const Import* imp,
                     const Scope* scope,
                     ResolvedVisibilityScope* r) {
-  bool isPrivate = true;
-  if (imp->visibility() == Decl::PUBLIC)
-    isPrivate = false;
+  bool isPrivate = (imp->visibility() != Decl::PUBLIC);
 
   for (auto clause : imp->visibilityClauses()) {
     // Figure out what was imported
@@ -974,7 +970,7 @@ doResolveImportStmt(Context* context, const Import* imp,
     const Scope* foundScope = findUseImportTarget(context, scope, r,
                                                   expr, VIS_IMPORT, oldName);
     if (foundScope != nullptr) {
-      VisibilitySymbols::Kind kind = VisibilitySymbols::ONLY_CONTENTS;
+      VisibilitySymbols::Kind kind;
 
       if (!dotName.isEmpty()) {
         // e.g. 'import M.f' - dotName is f and foundScope is for M

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -352,7 +352,9 @@ static bool doLookupInImports(Context* context,
       bool named = is.lookupName(name, from);
       if (named && is.kind() == VisibilitySymbols::CONTENTS_EXCEPT) {
         // mentioned in an except clause, so don't return it
-      } else if (named || is.kind() == VisibilitySymbols::ALL_CONTENTS) {
+      } else if (named
+          || is.kind() == VisibilitySymbols::ALL_CONTENTS
+          || is.kind() == VisibilitySymbols::CONTENTS_EXCEPT) {
         // find it in the contents
         const Scope* symScope = is.scope();
         LookupConfig newConfig = LOOKUP_DECLS |

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -884,8 +884,9 @@ doResolveUseStmt(Context* context, const Use* use,
     const Scope* foundScope = findUseImportTarget(context, scope, r,
                                                   expr, VIS_USE, oldName);
     if (foundScope != nullptr) {
-      // First, add VisibilitySymbols entry for the symbol itself,
-      // iff the use is renamed or non-public
+      // First, add VisibilitySymbols entry for the symbol itself.
+      // Per the spec, we only have visibility of the symbol itself if the
+      // use is renamed (with 'as') or non-public.
       if (!newName.isEmpty()) {
         r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
                                isPrivate, convertOneRename(oldName, newName));

--- a/compiler/dyno/test/resolution/testScopeResolve.cpp
+++ b/compiler/dyno/test/resolution/testScopeResolve.cpp
@@ -382,6 +382,51 @@ static void test8() {
   assert(reB.toId().isEmpty());
 }
 
+// test use with except-lists
+static void test9() {
+  printf("test9\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module A {
+        var x : int;
+        var y : int;
+        var z : int = 4;
+      }
+      module B {
+        public use A except y, z;
+
+        var a : int = x;
+        var b : int = y;
+        var c : int = A.x;
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* y = findVariable(vec, "y");
+  assert(y);
+  const Variable* z = findVariable(vec, "z");
+  assert(z);
+  const Variable* a = findVariable(vec, "a");
+  assert(a);
+  const Variable* b = findVariable(vec, "b");
+  assert(b);
+  const Variable* c = findVariable(vec, "c");
+  assert(c);
+
+  const ResolvedExpression& reA = scopeResolveIt(context, a->initExpression());
+  assert(reA.toId() == x->id());
+  const ResolvedExpression& reB = scopeResolveIt(context, b->initExpression());
+  assert(reB.toId().isEmpty());
+  const ResolvedExpression& reC = scopeResolveIt(context, c->initExpression());
+  assert(reC.toId().isEmpty());
+}
 
 int main() {
   test1();
@@ -392,6 +437,7 @@ int main() {
   test6();
   test7();
   test8();
+  test9();
 
   return 0;
 }

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -489,6 +489,8 @@ void ResolveScope::extendMethodTracking(FnSymbol* newFn) {
             if (UnresolvedSymExpr* typeName =
                 toUnresolvedSymExpr(cType->baseExpr)) {
               mMethodsOnTypeName.insert(typeName->unresolved);
+            } else if (SymExpr* typeName = toSymExpr(cType->baseExpr)) {
+              mMethodsOnTypeName.insert(typeName->symbol()->name);
             }
           }
         } else {


### PR DESCRIPTION
Fixes bugs with scope resolution of use/imports with `except` lists in Dyno:
- Search for symbols *not* named in an `except` list
- Don't bring in the module name itself from a `public use` (see https://github.com/chapel-lang/chapel/pull/19306).
- In production scope-resolver, fix gathering types with method calls defined on them in the searched scope.

Resolves https://github.com/Cray/chapel-private/issues/3814.

Testing:
- [x] checking against tests listed in https://github.com/Cray/chapel-private/issues/3814 (see individual check-offs on that list)
- [x] primers with --dyno 
- [x] paratest