### PR TITLE
Fix order of 'GPU' in TOC in Doc for Standard Modules.

### DIFF
--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -88,8 +88,8 @@ Parallelism/Distributed Computing
    Barriers <standard/Barriers>
    Communication <standard/Communication>
    DynamicIters <standard/DynamicIters>
-   VectorizingIterator <standard/VectorizingIterator>
    GPU <standard/GPU>
+   VectorizingIterator <standard/VectorizingIterator>
 
 System/Interoperability
 -----------------------


### PR DESCRIPTION
Things are supposed to be alphabetized under each category.