### PR TITLE
Move FCF test using extern block into separate file that is SKIPIF'd

### DIFF
--- a/test/functions/fcf/ExternBlock.chpl
+++ b/test/functions/fcf/ExternBlock.chpl
@@ -1,0 +1,27 @@
+/***
+*/
+module ExternBlock {
+  proc test5() {
+    extern {
+      #include <assert.h>
+      void foo(int64_t (*)(int64_t, int64_t));
+      void foo(int64_t (*fn)(int64_t, int64_t)) {
+        int n = fn(4, 4);
+        assert(n == 8);
+      }
+    }
+
+    extern proc foo(fn: proc(int, int): int): void;
+
+    // Call 'foo' with our proc literal.
+    foo(proc(x: int, y: int) {
+      return x + y;
+    });
+
+    // Call again but with a variable.
+    var fn = proc(x: int, y: int) { return x + y; };
+    foo(fn);
+  }
+  test5();
+}
+

--- a/test/functions/fcf/ExternBlock.skipif
+++ b/test/functions/fcf/ExternBlock.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM == none

--- a/test/functions/fcf/Motivators.chpl
+++ b/test/functions/fcf/Motivators.chpl
@@ -43,29 +43,6 @@ module Motivators {
   }
   test4();
 
-  proc test5() {
-    extern {
-      #include <assert.h>
-      void foo(int64_t (*)(int64_t, int64_t));
-      void foo(int64_t (*fn)(int64_t, int64_t)) {
-        int n = fn(4, 4);
-        assert(n == 8);
-      }
-    }
-
-    extern proc foo(fn: proc(int, int): int): void;
-
-    // Call 'foo' with our proc literal.
-    foo(proc(x: int, y: int) {
-      return x + y;
-    });
-
-    // Call again but with a variable.
-    var fn = proc(x: int, y: int) { return x + y; };
-    foo(fn);
-  }
-  test5();
-
   /*
   proc test() {
     type F = proc(int, int): int;


### PR DESCRIPTION
Move FCF test using extern block into separate file that is SKIPIF'd

Usual issue of extern blocks being unsupported without LLVM.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>