### PR TITLE
Use f(void) for no-argument functions in C in tests

### DIFF
--- a/test/arrays/diten/time_iterate.c
+++ b/test/arrays/diten/time_iterate.c
@@ -27,7 +27,7 @@ static void assign(int *A, int n) {
 static const int size = 100000000;
 static const int ntrials = 100;
 
-void c_trial() {
+void c_trial(void) {
   int* A;
   int i;
   double starttime, endtime;

--- a/test/arrays/lydia/time_access.c
+++ b/test/arrays/lydia/time_access.c
@@ -47,7 +47,7 @@ static int touch(int **A, int n) {
 static const int size = 1000;
 static const int ntrials = 100;
 
-void c_trial() {
+void c_trial(void) {
   int** A;
   int i;
   double starttime, endtime;

--- a/test/statements/lydia/forVersusWhilePerf.c
+++ b/test/statements/lydia/forVersusWhilePerf.c
@@ -19,7 +19,7 @@ static double now_time(void) {
 int64_t numIters = 1000000;
 int64_t ntrials = 10000;
 
-int64_t for_loop()
+int64_t for_loop(void)
 {
   int64_t result = 0;
   int64_t i, j;
@@ -35,7 +35,7 @@ int64_t for_loop()
   return result;
 }
 
-int64_t while_loop()
+int64_t while_loop(void)
 {
   int64_t result2 = 0;
   int64_t i = 0, j;
@@ -54,7 +54,7 @@ int64_t while_loop()
   return result2;
 }
 
-int64_t c_trial() {
+int64_t c_trial(void) {
   double starttimeFor, endtimeFor;
   double starttimeWhile, endtimeWhile;
   starttimeFor = now_time();


### PR DESCRIPTION
To be more correct & to resolve some warnings from the CCE compiler.

Continuing PR #20739

Test change only -- not reviewed.

- [x] affected tests pass in the CCE configuration that was failing