### PR TITLE
Skip some large memory tests when we might be sharing nodes

### DIFF
--- a/test/runtime/configMatters/mem/fragmentation/SKIPIF
+++ b/test/runtime/configMatters/mem/fragmentation/SKIPIF
@@ -1,2 +1,7 @@
 # skip cstdlib allocator since fragmentation handling will be system specific
 CHPL_MEM == cstdlib
+
+# most tests use a lot of memory, so skip for configs that might share nodes
+CHPL_LAUNCHER == none
+CHPL_LAUNCHER == smp
+CHPL_LAUNCHER == amudprun


### PR DESCRIPTION
Skip some fragmentation tests that use up to 1/2 of memory when we might be sharing nodes (basically when we're not using a launcher or using a launcher that can locally oversubscribe.)

Closes https://github.com/Cray/chapel-private/issues/3842