### PR TITLE
Update the Github CI container build action

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -4,9 +4,8 @@ env:
   REGISTRY: ghcr.io
   # NOTE: IMAGE_NAME must be lowercase
   IMAGE_NAME: chapel-github-ci
-
   # NOTE: if this filename changes, also update in the on.paths section below
-  DOCKERFILE: util/dockerfiles/github-ci/Dockerfile
+  DOCKERFILE: util/packaging/docker/github-ci/Dockerfile
 
 on:
   push:
@@ -15,8 +14,14 @@ on:
     paths:
       # unfortunately we can't use ${{env.DOCKERFILE}} here
       # see https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-      - util/dockerfiles/github-ci/Dockerfile
-
+      - util/packaging/docker/github-ci/Dockerfile
+      # also trigger on changes to this workflow file itself
+      - .github/workflows/build-CI-container.yml
+  pull_request:
+    paths:
+      # same as for pushes above
+      - util/packaging/docker/github-ci/Dockerfile
+      - .github/workflows/build-CI-container.yml
   # Adds a "manual run" option in the GH UI
   workflow_dispatch:
 
@@ -36,10 +41,16 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and Push Docker Image
+      - name: Build Docker Image
+        uses: docker/build-push-action@v2.9.0
+        with:
+          file: ${{ env.DOCKERFILE }}
+          # example: ghcr.io/chapel-lang/chapel-github-ci:latest
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+      - name: Push Docker Image if on main
+        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
         uses: docker/build-push-action@v2.9.0
         with:
           file: ${{ env.DOCKERFILE }}
           push: true
-          # example: ghcr.io/chapel-lang/chapel-github-ci:latest
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
Updates the CI container build action

- updated Dockerfile path for https://github.com/chapel-lang/chapel/pull/20705
- now builds on PRs as well
  - pushing image to registry still only triggers on push to main
- build now triggers from workflow file changes as well