### PR TITLE
Skip sourcing common.bash in Github Actions builds

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -159,7 +159,9 @@ fi
 
 # Source common.bash, which sets up a bunch of environment variables that are
 # required for nightly testing.
-source $CHPL_HOME/util/cron/common.bash
+if [ "$GITHUB_ACTIONS" != "true" ]; then
+  source $CHPL_HOME/util/cron/common.bash
+fi
 
 # Disable GMP and re2 to speed up build.
 export CHPL_GMP=none

--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 
-# Configure locale (taken from util/dockerfiles/Dockerfile)
+# Configure locale (taken from primary Chapel Dockerfile)
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
     dpkg-reconfigure --frontend=noninteractive locales && \


### PR DESCRIPTION
Skip sourcing `common.bash` in Github Actions builds

This was causing the error `fatal: detected dubious ownership in repository at '/__w/chapel/chapel'`, revealed when the CI container was incidentally updated to use a more recent Git by https://github.com/chapel-lang/chapel/pull/20760.