### PR TITLE
Remove deprecated fromSyserr type methods

### DIFF
--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1068,34 +1068,6 @@ module OS {
 
       return err_msg;
     }
-
-    /*
-      Return the matching :class:`SystemError` subtype for a given
-      ``errorCode``, with an optional string containing extra details.
-
-      :arg err: the errorCode to generate from
-      :arg details: extra information to include with the error
-    */
-    pragma "insert line file info"
-    pragma "always propagate line file info"
-    deprecated "'SystemError.fromSyserr' is deprecated. Please use 'createSystemError' instead."
-    proc type fromSyserr(err: errorCode, details: string = "") {
-      return createSystemError(err, details);
-    }
-
-    /*
-      Return the matching :class:`SystemError` subtype for a given error number,
-      with an optional string containing extra details.
-
-      :arg err: the number to generate from
-      :arg details: extra information to include with the error
-    */
-    pragma "insert line file info"
-    pragma "always propagate line file info"
-    deprecated "'SystemError.fromSyserr' is deprecated. Please use 'createSystemError' instead."
-    proc type fromSyserr(err: int, details: string = "") {
-      return createSystemError(err:errorCode, details);
-    }
   }
 
   /*

--- a/test/deprecated/fromSyserrTest.chpl
+++ b/test/deprecated/fromSyserrTest.chpl
@@ -1,3 +1,0 @@
-use OS;
-
-var err = SystemError.fromSyserr(1);

--- a/test/deprecated/fromSyserrTest.good
+++ b/test/deprecated/fromSyserrTest.good
@@ -1,1 +1,0 @@
-fromSyserrTest.chpl:3: warning: 'SystemError.fromSyserr' is deprecated. Please use 'createSystemError' instead.


### PR DESCRIPTION
Remove the fromSyserr methods now that they've been deprecated in a release.