### PR TITLE
Fix sporadic failures in nestedOn and remote-array-write-access

### DIFF
--- a/test/optimizations/remoteValueForwarding/gmp/nestedOn.prediff
+++ b/test/optimizations/remoteValueForwarding/gmp/nestedOn.prediff
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+
+outfile = sys.argv[2]
+
+with open (outfile, 'r') as f:
+    lines = f.readlines()
+
+with open (outfile, 'w') as f:
+    for line in lines:
+        if 'error: references to remote data cannot be passed to external routines' in line:
+            f.write(line)

--- a/test/performance/ferguson/CommUtil.chpl
+++ b/test/performance/ferguson/CommUtil.chpl
@@ -79,7 +79,8 @@ proc totalOns(D:[LocaleSpace] commDiagnostics) : int {
 // Checks anything with a passed maximum != max(int) is below the maximum.
 // Prints out counts if the passed maximum == max(int) (or is not passed).
 // Prints out all counts if called with no arguments.
-proc report(maxGets=max(int), maxPuts=max(int), maxOns=max(int)) {
+proc report(maxGets=max(int), maxPuts=max(int), maxOns=max(int),
+            maxGetsToAdjust = maxGets) {
   var counts = getCommDiagnostics();
 
   if printAllCounts || printCounts then
@@ -100,7 +101,7 @@ proc report(maxGets=max(int), maxPuts=max(int), maxOns=max(int)) {
     writeln("GETs: ", gets);
   if gets > maxGets then
     writeln("ERROR -- TOO MANY GETs, ", gets, " EXCEEDS MAX OF ", maxGets);
-  if checkMaxAttained && maxGets!=max(int) && gets < maxGets then
+  if checkMaxAttained && maxGets!=max(int) && gets < maxGetsToAdjust then
     fixGets = true;
 
   if (printCounts && maxPuts==max(int)) || printAllCounts  then

--- a/test/performance/ferguson/remote-array-write-access.chpl
+++ b/test/performance/ferguson/remote-array-write-access.chpl
@@ -17,4 +17,15 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=1, maxOns=1);
+report(maxGets=maxGets(), maxOns=1, maxGetsToAdjust=1);
+
+proc maxGets() {
+  use ChplConfig;
+
+  // accept higher comm counts on m1 mac for now
+  // see https://github.com/Cray/chapel-private/issues/3728
+  if CHPL_TARGET_PLATFORM == "darwin" && CHPL_TARGET_ARCH == "arm64"
+  then return 2;
+  
+  return 1;
+}


### PR DESCRIPTION
This PR fixes sporadic failures in these two tests, as suggested by @ronawho.

### test/performance/ferguson/remote-array-write-access.chpl

This should fix the sporadic failure in `performance/ferguson/remote-array-write-access.chpl` when compiled with `--cache-remote` enabled.

The failure mode, most recently observed in our `gasnet.darwin-m1` configuration, is:
```
ERROR -- TOO MANY GETs, 2 EXCEEDS MAX OF 1
```

When Locale 1 issues a cache-get of A._instance, which is a wide pointer, it is typically done with a single get_nb. However, sometimes the _instance field is split across two cache pages, so one cache-get results in two get_nb communications. This PR allows this test to accept either 1 or 2 get_nb.

We limit this adjustment to this configuration; everywhere else it will continue requiring 1 get_nb. This way we will be alerted to extra comms in other configurations if/when they arise in the future.

### test/optimizations/remoteValueForwarding/gmp/nestedOn.chpl

This test has nested on-stmts and the inner one halts. We sporadically get warnings like: `GASNET WARNING(Node 0): int AMUDP_DrainNetwork(ep_t) returning an error code: AM_ERR_RESOURCE` for this test.

Just add a prediff to filter out any extra messages and only look for our expected error.

Once the .future is resolved, we will be getting mismatches on both .bad and .good. At this point the prediff needs to be removed.

This is analogous to https://github.com/chapel-lang/chapel/pull/12937 and https://github.com/chapel-lang/chapel/pull/14837, which added these prediffs:

    test/multilocale/bradc/needMultiLocales/writeThisUsingOn.prediff
    test/multilocale/local/diten/test_local2.prediff