### PR TITLE
Fix (C++) errors introduced by the "better (Chapel) error messages" PR

### DIFF
--- a/compiler/dyno/lib/framework/ErrorWriter.cpp
+++ b/compiler/dyno/lib/framework/ErrorWriter.cpp
@@ -93,7 +93,8 @@ static TermColorName kindColor(ErrorBase::Kind kind) {
 }
 
 static void writeFile(std::ostream& oss, const Location& loc) {
-  auto path = loc.path().c_str();
+  auto pathUstr = loc.path();
+  auto path = pathUstr.c_str();
   int lineno = loc.line();
   bool validPath = (path != nullptr && path[0] != '\0');
 

--- a/test/chpldoc/nodoc/privateClasses.doc.bad
+++ b/test/chpldoc/nodoc/privateClasses.doc.bad
@@ -1,5 +1,5 @@
-privateClasses.doc.chpl:1: error: Can't apply private to types yet
-privateClasses.doc.chpl:7: error: Can't apply private to types yet
-privateClasses.doc.chpl:15: error: Can't apply private to the fields or methods of a class or record yet
-privateClasses.doc.chpl:18: error: Can't apply private to the fields or methods of a class or record yet
+error in privateClasses.doc.chpl:1: Can't apply private to types yet
+error in privateClasses.doc.chpl:7: Can't apply private to types yet
+error in privateClasses.doc.chpl:15: Can't apply private to the fields or methods of a class or record yet
+error in privateClasses.doc.chpl:18: Can't apply private to the fields or methods of a class or record yet
 cat: docs/source/modules/privateClasses.doc.rst: No such file or directory

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.bad
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.bad
@@ -1,4 +1,4 @@
-privateTypeAlias.doc.chpl:2: error: Can't apply private to types yet
-privateTypeAlias.doc.chpl:5: error: Can't apply private to types yet
-privateTypeAlias.doc.chpl:8: error: Can't apply private to types yet
+error in privateTypeAlias.doc.chpl:2: Can't apply private to types yet
+error in privateTypeAlias.doc.chpl:5: Can't apply private to types yet
+error in privateTypeAlias.doc.chpl:8: Can't apply private to types yet
 cat: docs/source/modules/privateTypeAlias.doc.rst: No such file or directory


### PR DESCRIPTION
Attempts to compile with `-Wall -Werror` brought out issues that hadn't been
caught by my local testing or GitHub CI. In particular, `loc.path()` goes out of
scope right after the line on which its `c_str()` is retrieved, creating a dangling
pointer issue. To fix this, it's necessary to keep the `path()` in scope until the
last use of the c-string.

This PR also updates chpldoc futures to also have the new error message format.

Reviewed by @mppf and @dlongnecke-cray - thanks!

Testing:
- PR checks