### PR TITLE
Fix a bug with FCF codes running under `--verify`

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -135,10 +135,10 @@ void Symbol::verify() {
   }
   verifyInTree(type, "Symbol::type");
 
-  if (name != astr(name))
+  if (name && name != astr(name))
     INT_FATAL("name is not an astr");
 
-  if (cname != astr(cname))
+  if (cname && cname != astr(cname))
     INT_FATAL("cname is not an astr");
 
   if (symExprsHead) {


### PR DESCRIPTION
Fix a bug with FCF codes running under `--verify`

The `Symbol::verify()` method was not considering the possibility
that `name` or `cname` could be `nullptr`. This is possible when
a formal or function is anonymous (in e.g., a function type).

Reviewed by @behharsh. Thanks!

TESTING

- [x] `release/examples` w/ `--verify`

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>