### PR TITLE
Factor out common code from `chpl2rst` to create `chpl2md`

### DIFF
--- a/doc/util/chpl2md.py
+++ b/doc/util/chpl2md.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+"""chpl2md converts a chapel program to an md file, where all comments are
+rendered md, and all code is wrapped in code blocks.
+
+Chapel files are converted as follows:
+
+* Line comments starting at the beginning of the line are converted to text
+* Block comments starting anywhere are converted to text
+* All other lines are wrapped as code-blocks
+
+example.chpl
+============
+
+/* This is
+     an example */
+proc foo() {
+    // this comment will be in the code block
+    var bar = 1; }
+// this comment will be text
+
+example.rst
+===========
+
+This is
+  an example
+
+```chapel
+proc foo() {
+    // this comment will be in the code block
+    var bar = 1; }
+```
+
+this comment will be text"""
+
+from __future__ import print_function
+
+import os
+import sys
+from itertools import product
+from litchapel import to_pieces, titlecomment
+
+import argparse
+
+def get_arguments():
+    """
+    Get arguments from command line
+    """
+    parser = argparse.ArgumentParser(
+        prog='chpl2md',
+        usage='%(prog)s  file.chpl [options] ',
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument('chapelfiles', nargs='+',
+                        help='Chapel files to convert to md')
+    parser.add_argument('--output', default='md', choices=['stdout', 'md'],
+                        help='destination of output')
+    parser.add_argument('--prefix', default='.',
+                        help='prefix path for output')
+    parser.add_argument('--codeblock', '-c', action='store_true', default=False,
+                        help='convert entire document into code block')
+    parser.add_argument('--verbose', '-v', action='store_true', default=False,
+                        help='verbosity')
+    return parser.parse_args()
+
+
+def print_good(output, good_options, chunk_index):
+    """Print the output from .good files"""
+
+    output.append('')
+    if len(good_options) == 1:
+        # Just one good option means no need to generate menu
+        (basename, _, _), = good_options
+        output.append('{{{{< goodChunk name="{0}" chunk="{1}">}}}}'
+                        .format(basename, chunk_index))
+    else:
+        output.append('{{{{< goodMenu name="list_{0}" >}}}}'.format(chunk_index))
+        for (basename, version, options) in good_options:
+            output.append('  {{{{< goodOption chunk="{0}" file="{1}" cnfg="{2}" txt="{3}" >}}}}'
+                          .format(chunk_index, basename, version, options))
+        output.append('{{< /goodMenu >}}')
+
+def gen_md(pieces, chapelfile):
+    output = []
+    good_options = list(goodfiles(chapelfile))
+
+    # Each line is md or code-block
+    for (kind, content) in pieces:
+        if kind == 'title':
+            output.append('---')
+            output.append('title: "{0}"'.format(content[0]))
+            output.append('draft: true')
+            output.append('---')
+        elif kind == 'prose':
+            output.extend(content)
+        elif kind == 'code':
+            output.append('```Chapel')
+            output.extend(content)
+            output.append('```')
+        elif kind == 'output':
+            print_good(output, good_options, content)
+        output.append('')
+    return '\n'.join(output)
+
+
+def iterate_lines(file):
+    """Yield every line from a compopts / execopts file. Doesn't
+    currently handle executable files."""
+
+    with open(file, 'r', encoding='utf-8') as handle:
+        yield from (l.strip('\n') for l in handle)
+
+def variant_iter(file):
+    """Create an iterator of an compopts / execopts file's lines if it
+    exists, and return None otherwise."""
+
+    if not os.path.isfile(file): return None
+    return iterate_lines(file)
+
+def get_combinations(iterables):
+    """Take iterables of compopts, execopts, etc and yield tuples of
+    (file_modifier, option_tuple) corresponding to each combination of these
+    options. File modifier is, e.g., "1-1" for 'first compile option, first
+    exec option'."""
+
+    if len(iterables) == 0:
+        yield (None, ())
+        return
+    for combination in product(*[enumerate(it, 1) for it in iterables]):
+        indices = []
+        opts = []
+        for (idx, opt) in combination:
+            indices.append(str(idx))
+            opts.append(opt)
+        yield ('-'.join(indices), tuple(opts))
+
+def goodfiles(chapelfile):
+    """Yield (file_name, options_string) for .good files corresponding to
+    each combination of compile and execution options."""
+
+    filedir, filename = os.path.split(chapelfile)
+    basename, _ = os.path.splitext(filename)
+    compoptsFile = os.path.join(filedir, ''.join([basename, '.compopts']))
+    execoptsFile = os.path.join(filedir, ''.join([basename, '.execopts']))
+
+    iters = []
+    compoptsIter = variant_iter(compoptsFile)
+    if compoptsIter is not None: iters.append(compoptsIter)
+    execoptsIer = variant_iter(execoptsFile)
+    if execoptsIer is not None: iters.append(execoptsIer)
+
+    for (name, opts) in get_combinations(iters):
+        yield (basename, name, ' '.join(opts))
+
+def getfname(chapelfile, output, prefix):
+    """Compute filename for output"""
+    if output == 'md':
+        filename = os.path.split(chapelfile)[1]
+        basename, _ = os.path.splitext(filename)
+        mdname = ''.join([basename, '.md'])
+        mdfile = os.path.join(prefix, mdname)
+        print("Writing to", mdfile, os.path.split(chapelfile))
+        return mdfile
+    elif output == 'stdout':
+        return None
+    else:
+        print('Error: output = {0} is invalid')
+        sys.exit(1)
+
+
+def write(mdoutput, output):
+    """Write to output"""
+    if output is None:
+        sys.stdout.write(mdoutput)
+        return
+
+    with open(output, 'w', encoding='utf-8') as handle:
+        handle.write(mdoutput)
+
+
+def main_args(**kwargs):
+    """Driver function - convert each file to md and write to output"""
+
+    # Parse keyword arguments
+    chapelfiles = kwargs['chapelfiles']
+    output = kwargs['output']
+    prefix = kwargs['prefix']
+    verbose = kwargs['verbose']
+
+    for chapelfile in chapelfiles:
+        islearnChapelInYMinutes = (os.path.basename(chapelfile)=='learnChapelInYMinutes.chpl')
+
+        with open(chapelfile, 'r', encoding='utf-8') as handle:
+            pieces = to_pieces(handle, islearnChapelInYMinutes)
+            mdoutput = gen_md(pieces, chapelfile)
+
+        fname = getfname(chapelfile, output, prefix)
+
+        if not os.path.exists(prefix) and output != 'stdout':
+            print('Creating directory: ', prefix)
+            os.makedirs(prefix)
+
+        if verbose:
+            print('writing output of {0} to {1}'.format(chapelfile, fname))
+
+        write(mdoutput, fname)
+
+def main():
+    # Parse arguments and cast them into a dictionary
+    arguments = vars(get_arguments())
+    main_args(**arguments)
+
+if __name__ == '__main__':
+    main()

--- a/doc/util/chpl2md.py
+++ b/doc/util/chpl2md.py
@@ -20,7 +20,7 @@ proc foo() {
     var bar = 1; }
 // this comment will be text
 
-example.rst
+example.md
 ===========
 
 This is
@@ -34,12 +34,10 @@ proc foo() {
 
 this comment will be text"""
 
-from __future__ import print_function
-
 import os
 import sys
 from itertools import product
-from litchapel import to_pieces, titlecomment
+from literate_chapel import to_pieces, title_comment
 
 import argparse
 
@@ -104,20 +102,13 @@ def gen_md(pieces, chapelfile):
         output.append('')
     return '\n'.join(output)
 
-
-def iterate_lines(file):
-    """Yield every line from a compopts / execopts file. Doesn't
-    currently handle executable files."""
-
-    with open(file, 'r', encoding='utf-8') as handle:
-        yield from (l.strip('\n') for l in handle)
-
-def variant_iter(file):
-    """Create an iterator of an compopts / execopts file's lines if it
+def variant_list(file):
+    """Create a list of an compopts / execopts file's lines if it
     exists, and return None otherwise."""
 
     if not os.path.isfile(file): return None
-    return iterate_lines(file)
+    with open(file, 'r', encoding='utf-8') as handle:
+        return [l.strip("\n") for l in handle]
 
 def get_combinations(iterables):
     """Take iterables of compopts, execopts, etc and yield tuples of
@@ -146,10 +137,10 @@ def goodfiles(chapelfile):
     execoptsFile = os.path.join(filedir, ''.join([basename, '.execopts']))
 
     iters = []
-    compoptsIter = variant_iter(compoptsFile)
-    if compoptsIter is not None: iters.append(compoptsIter)
-    execoptsIer = variant_iter(execoptsFile)
-    if execoptsIer is not None: iters.append(execoptsIer)
+    compoptsList = variant_list(compoptsFile)
+    if compoptsList is not None: iters.append(compoptsList)
+    execoptsList = variant_list(execoptsFile)
+    if execoptsList is not None: iters.append(execoptsList)
 
     for (name, opts) in get_combinations(iters):
         yield (basename, name, ' '.join(opts))

--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -38,6 +38,7 @@ from __future__ import print_function
 
 import os
 import sys
+from litchapel import to_pieces, titlecomment
 
 import argparse
 
@@ -93,11 +94,6 @@ def gen_link(link, chapelfile):
     return rstlink
 
 
-def titlecomment(line):
-    """Condition for a line to be a title comment"""
-    return line.startswith('//') and len(line.lstrip('//').strip()) > 0
-
-
 def gen_title(chapelfile):
     """Generate file title, based on if title comment exists"""
     with open(chapelfile, 'r', encoding='utf-8') as handle:
@@ -139,111 +135,22 @@ def gen_preamble(chapelfile, link=None):
 
     return '\n'.join(output)
 
-
-def gen_rst(handle):
-    """Convert contents of file handle to restructured text, using the rules
-    described in the module doc string (__doc__)"""
-
+def gen_rst(pieces, chapelfile):
     output = []
-    commentdepth = 0
-    state = ''
-    indentation = -1
-    islearnChapelInYMinutes = (os.path.basename(handle.name)=='learnChapelInYMinutes.chpl')
-    foundCommentExample = False
 
     # Each line is rst or code-block
-    for (i, line) in enumerate([l.strip('\n') for l in handle.readlines()]):
-
-        # Skip title comment if present
-        if i == 0:
-            if titlecomment(line):
-                continue
-
-        # Skip empty lines
-        if len(line.strip()) == 0:
+    for (kind, content) in pieces:
+        if kind == 'title': continue
+        elif kind == 'prose':
+            output.extend(content)
+        elif kind == 'code':
+            output.append('.. code-block:: chapel')
             output.append('')
+            output.extend('    ' + line for line in content)
+        elif kind == 'output':
+            # Don't support output
             continue
-
-        # Comment canaries - note: we don't support escaped comments: \/*
-        commentstarts = line.count('/*')
-        commentends = line.count('*/')
-        commentdepth += commentstarts - commentends
-
-        # State tracking
-        laststate = state
-        state = ''
-
-        # Identification of line
-        if commentdepth > 0 or commentends > 0:
-            state = 'blockcomment'
-        elif line.startswith('//'):
-            state = 'linecomment'
-        elif 'code' in laststate:
-            state = 'code'
-        else:
-            state = 'codeblock'
-
-        if 'comment' in state:
-
-            if 'comment' not in laststate:
-                output.append('')
-
-            rstline = line
-            if state == 'linecomment':
-                # Strip white space for line comments
-                rstline = rstline.replace('//', '  ', 1)
-                rstline = rstline.strip()
-            else:
-                # Preserve white space for block comments, for indent purposes
-                if commentstarts:
-                    rstline = rstline.replace('/*', '  ')
-                if commentends > 0:
-                    rstline = rstline.replace('*/', '  ')
-                # No need for trailing white space... ever
-                rstline = rstline.rstrip(' ')
-
-            # Handle indentation
-            if indentation == -1:
-                # Detect level of indentation (number of leading whitespaces)
-                baseline = len(rstline) - len(rstline.lstrip(' '))
-                if baseline > 0:
-                    # Set indentation for the proceeding block
-                    indentation = baseline
-                    # Set indentation for baseline to 0
-                    rstline = rstline.lstrip(' ')
-            else:
-                # Remove the amount of indent that was removed from baseline
-                if rstline.startswith(' '*indentation):
-                    rstline = rstline[indentation:]
-                else:
-                    rstline = rstline.lstrip(' ')
-            # Special case for multi line comment in learnChapelInYMinutes
-            if islearnChapelInYMinutes and 'multi-line comment' in rstline:
-                output.append(' '*indentation + '/*')
-                output.append(rstline)
-                output.append(' '*indentation + '*/')
-                if foundCommentExample:
-                    print("Error: Found more than one line containing \"multi-line comment\" in \
-                        learnChapelInYMinutes.chpl")
-                    sys.exit(1)
-                foundCommentExample = True
-            else:
-               output.append(rstline)
-        else:
-            # Reset indentation as we enter codeblock state
-            indentation = -1
-
-            # Write code block
-            if state == 'codeblock':
-                output.append('')
-                output.append('.. code-block:: chapel')
-                output.append('')
-            codeline = ''.join(['    ', line])
-            output.append(codeline)
-
-    if islearnChapelInYMinutes and not foundCommentExample:
-        print('Error: Failed to find special case of comment example in learnChapelInYMinutes.chpl')
-        sys.exit(1)
+        output.append('')
     return '\n'.join(output)
 
 
@@ -264,7 +171,6 @@ def gen_codeblock(handle):
         output.append('  ' + line)
 
     return '\n'.join(output)
-
 
 def getfname(chapelfile, output, prefix):
     """Compute filename for output"""
@@ -304,14 +210,15 @@ def main_args(**kwargs):
     verbose = kwargs['verbose']
 
     for chapelfile in chapelfiles:
-
+        islearnChapelInYMinutes = (os.path.basename(chapelfile)=='learnChapelInYMinutes.chpl')
         preamble = gen_preamble(chapelfile, link=link)
 
         with open(chapelfile, 'r', encoding='utf-8') as handle:
             if codeblock:
                 rstoutput = gen_codeblock(handle)
             else:
-                rstoutput = gen_rst(handle)
+                pieces = to_pieces(handle, islearnChapelInYMinutes)
+                rstoutput = gen_rst(pieces, chapelfile)
 
         rstoutput = '\n'.join([preamble, rstoutput])
 

--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -34,11 +34,9 @@ This is
 
 this comment will be text"""
 
-from __future__ import print_function
-
 import os
 import sys
-from litchapel import to_pieces, titlecomment
+from literate_chapel import to_pieces, title_comment
 
 import argparse
 
@@ -98,7 +96,7 @@ def gen_title(chapelfile):
     """Generate file title, based on if title comment exists"""
     with open(chapelfile, 'r', encoding='utf-8') as handle:
         line1 = handle.readline()
-        if titlecomment(line1):
+        if title_comment(line1):
             title = line1.lstrip('//').strip()
         else:
             filename = os.path.split(chapelfile)[1]
@@ -165,7 +163,7 @@ def gen_codeblock(handle):
 
     for (i, line) in enumerate([l.strip('\n') for l in handle.readlines()]):
         if i == 0:
-            if titlecomment(line):
+            if title_comment(line):
                 continue
 
         output.append('  ' + line)

--- a/doc/util/litchapel.py
+++ b/doc/util/litchapel.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+from __future__ import print_function
+
+import sys
+
+def titlecomment(line):
+    """Condition for a line to be a title comment"""
+    return line.startswith('//') and len(line.lstrip('//').strip()) > 0
+
+def to_pieces(handle, islearnChapelInYMinutes=False):
+    output = []
+    current_type = ''
+    current_content = []
+
+    def flush():
+        nonlocal current_content, current_type
+        if len(current_content) != 0 and any(s != '' for s in current_content):
+            while current_content[0] == '': current_content.pop(0)
+            while current_content[-1] == '': current_content.pop(-1)
+            output.append((current_type, current_content))
+            current_content = []
+
+
+    def switch_type(new_type):
+        nonlocal current_type
+        if current_type == new_type:
+            return
+        flush()
+        current_type = new_type
+
+    def push_line(line):
+        nonlocal current_content
+        current_content.append(line)
+
+    commentdepth = 0
+    state = ''
+    indentation = -1
+    chunk_index = 0
+    foundCommentExample = False
+
+    # Each line is rst or code-block
+    for (i, line) in enumerate([l.strip('\n') for l in handle.readlines()]):
+        # Skip title comment if present
+        if i == 0 and titlecomment(line):
+            switch_type('title')
+            push_line(line.lstrip('//').strip())
+            switch_type('prose')
+            continue
+
+        # Skip empty lines
+        if len(line.strip()) == 0:
+            push_line('')
+            continue
+
+        # Comment canaries - note: we don't support escaped comments: \/*
+        commentstarts = line.count('/*')
+        commentends = line.count('*/')
+        commentdepth += commentstarts - commentends
+
+        # State tracking
+        laststate = state
+        state = ''
+
+        # Identification of line
+        if commentdepth > 0 or commentends > 0:
+            state = 'blockcomment'
+        elif line.startswith('//'):
+            state = 'linecomment'
+        elif 'code' in laststate:
+            state = 'code'
+        else:
+            state = 'codeblock'
+
+        if 'comment' in state:
+            rstline = line
+            if state == 'linecomment':
+                # Strip white space for line comments
+                rstline = rstline.replace('//', '  ', 1)
+                rstline = rstline.strip()
+            else:
+                # Preserve white space for block comments, for indent purposes
+                if commentstarts:
+                    rstline = rstline.replace('/*', '  ')
+                if commentends > 0:
+                    rstline = rstline.replace('*/', '  ')
+                # No need for trailing white space... ever
+                rstline = rstline.rstrip(' ')
+
+            # Handle indentation
+            if indentation == -1:
+                # Detect level of indentation (number of leading whitespaces)
+                baseline = len(rstline) - len(rstline.lstrip(' '))
+                if baseline > 0:
+                    # Set indentation for the proceeding block
+                    indentation = baseline
+                    # Set indentation for baseline to 0
+                    rstline = rstline.lstrip(' ')
+            else:
+                # Remove the amount of indent that was removed from baseline
+                if rstline.startswith(' '*indentation):
+                    rstline = rstline[indentation:]
+                else:
+                    rstline = rstline.lstrip(' ')
+            # Special case for multi line comment in learnChapelInYMinutes
+            if islearnChapelInYMinutes and 'multi-line comment' in rstline:
+                push_line(' '*indentation + '/*')
+                push_line(rstline)
+                push_line(' '*indentation + '*/')
+                if foundCommentExample:
+                    print("Error: Found more than one line containing \"multi-line comment\" in \
+                        learnChapelInYMinutes.chpl")
+                    sys.exit(1)
+                foundCommentExample = True
+            else:
+               switch_type('prose')
+               push_line(rstline)
+        else:
+            # Reset indentation as we enter codeblock state
+            indentation = -1
+            switch_type('code')
+
+            if "__BREAK__" in line:
+                flush()
+                output.append(('output', chunk_index))
+                chunk_index += 1
+                continue
+
+            push_line(line)
+
+    flush()
+    if chunk_index != 0:
+        # We found __BREAK__; print the last chunk.
+        output.append(('output', chunk_index))
+
+    if islearnChapelInYMinutes and not foundCommentExample:
+        print('Error: Failed to find special case of comment example in learnChapelInYMinutes.chpl')
+        sys.exit(1)
+    return output

--- a/doc/util/literate_chapel.py
+++ b/doc/util/literate_chapel.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import sys
 
-def titlecomment(line):
+def title_comment(line):
     """Condition for a line to be a title comment"""
     return line.startswith('//') and len(line.lstrip('//').strip()) > 0
 
@@ -40,10 +40,10 @@ def to_pieces(handle, islearnChapelInYMinutes=False):
     chunk_index = 0
     foundCommentExample = False
 
-    # Each line is rst or code-block
+    # Each line is prose or code-block
     for (i, line) in enumerate([l.strip('\n') for l in handle.readlines()]):
         # Skip title comment if present
-        if i == 0 and titlecomment(line):
+        if i == 0 and title_comment(line):
             switch_type('title')
             push_line(line.lstrip('//').strip())
             switch_type('prose')
@@ -74,39 +74,39 @@ def to_pieces(handle, islearnChapelInYMinutes=False):
             state = 'codeblock'
 
         if 'comment' in state:
-            rstline = line
+            proseline = line
             if state == 'linecomment':
                 # Strip white space for line comments
-                rstline = rstline.replace('//', '  ', 1)
-                rstline = rstline.strip()
+                proseline = proseline.replace('//', '  ', 1)
+                proseline = proseline.strip()
             else:
                 # Preserve white space for block comments, for indent purposes
                 if commentstarts:
-                    rstline = rstline.replace('/*', '  ')
+                    proseline = proseline.replace('/*', '  ')
                 if commentends > 0:
-                    rstline = rstline.replace('*/', '  ')
+                    proseline = proseline.replace('*/', '  ')
                 # No need for trailing white space... ever
-                rstline = rstline.rstrip(' ')
+                proseline = proseline.rstrip(' ')
 
             # Handle indentation
             if indentation == -1:
                 # Detect level of indentation (number of leading whitespaces)
-                baseline = len(rstline) - len(rstline.lstrip(' '))
+                baseline = len(proseline) - len(proseline.lstrip(' '))
                 if baseline > 0:
                     # Set indentation for the proceeding block
                     indentation = baseline
                     # Set indentation for baseline to 0
-                    rstline = rstline.lstrip(' ')
+                    proseline = proseline.lstrip(' ')
             else:
                 # Remove the amount of indent that was removed from baseline
-                if rstline.startswith(' '*indentation):
-                    rstline = rstline[indentation:]
+                if proseline.startswith(' '*indentation):
+                    proseline = proseline[indentation:]
                 else:
-                    rstline = rstline.lstrip(' ')
+                    proseline = proseline.lstrip(' ')
             # Special case for multi line comment in learnChapelInYMinutes
-            if islearnChapelInYMinutes and 'multi-line comment' in rstline:
+            if islearnChapelInYMinutes and 'multi-line comment' in proseline:
                 push_line(' '*indentation + '/*')
-                push_line(rstline)
+                push_line(proseline)
                 push_line(' '*indentation + '*/')
                 if foundCommentExample:
                     print("Error: Found more than one line containing \"multi-line comment\" in \
@@ -115,7 +115,7 @@ def to_pieces(handle, islearnChapelInYMinutes=False):
                 foundCommentExample = True
             else:
                switch_type('prose')
-               push_line(rstline)
+               push_line(proseline)
         else:
             # Reset indentation as we enter codeblock state
             indentation = -1


### PR DESCRIPTION
We've previously discussed wanting to use roughly the same infrastructure for
handling the primers and possible blog posts. However, Hugo, the static site
generator we are interested in using, does not have first-class support for
Markdown (it calls out to `rst2html`). Furthermore, it seems like the team
either prefers Markdown for authoring content, or is neutral on `rst`/`md`. It
thus seems like the best course of action is to add support for converting code
written in the style of our primers (prose in comments, code in... code) to
Markdown in addition to reStructuredText.

The "read Chapel code, treating comments as prose and code as code blocks"
functionality is very similar between what we'd need to do for Markdown and
what we currently do for reStructuredText. Thus, this PR extracts this
functionality into a `litchapel.py` module, which exports a `to_pieces`
function that returns "pieces" of code that correspond to comments / code /
etc. Then, `chpl2rst` is made to use these pieces to generate `.rst` files,
and a new `chpl2md.py` script is added to do the same for Hugo-compatible
markdown.

In addition to this, the new scripts now recognize `__BREAK__` printouts as
introduced in @jeremiah-corrado's efforts to add code-then-output functionality
to Hugo. In the `.rst` case they are ignored (since our primers do not make
use of them), but on the Markdown end, they are converted into calls to
Jeremiah's `goodMenu`/`goodOption` shortcodes.

For instance, the following Chapel code:
```Chapel
// Finally, let's call the linspace proc with our numPoints argument,
// and print it out.
const ls = linspace(numPoints, 0.5, 2.5);

for (val, idx) in zip(ls, ls.domain) {
    writeln(idx, "\t", val);
}

writeln("__BREAK__");

// And now, just print some extra things to show that we get more "output"
// blocks later.
```

Is converted into the following markdown output (using indentation here instead
of backticks to avoid escaping woes)
```Markdown
Finally, let's call the linspace proc with our numPoints argument,
and print it out.


    const ls = linspace(numPoints, 0.5, 2.5);
    
    for (val, idx) in zip(ls, ls.domain) {
        writeln(idx, "\t", val);
    }

{{< goodMenu name="list_0" >}}
  {{< goodOption chunk="0" file="multiConfig" cnfg="1-1" txt="-s zeroIndexed=false --numPoints=5" >}}
  {{< goodOption chunk="0" file="multiConfig" cnfg="1-2" txt="-s zeroIndexed=false --numPoints=10" >}}
  {{< goodOption chunk="0" file="multiConfig" cnfg="2-1" txt="-s zeroIndexed=true --numPoints=5" >}}
  {{< goodOption chunk="0" file="multiConfig" cnfg="2-2" txt="-s zeroIndexed=true --numPoints=10" >}}
{{< /goodMenu >}}

And now, just print some extra things to show that we get more "output"
blocks later.
```

This changes the current RST output, largely by removing unnecessary newlines.
As far as my `diff`ing can tell, HTML output is unaffected. 

Reviewed by @riftEmber - thanks!

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>
