### PR TITLE
Adjust a bunch of .future files impacted by changes to FCFs

### DIFF
--- a/test/extern/fnPtrs/improveErrorForFcfMismatch.bad
+++ b/test/extern/fnPtrs/improveErrorForFcfMismatch.bad
@@ -1,4 +1,4 @@
-improveErrorForFcfMismatch.chpl:13: error: unresolved call 'bar(shared chpl__fcf_type_void_void)'
+improveErrorForFcfMismatch.chpl:13: error: unresolved call 'bar(proc())'
 improveErrorForFcfMismatch.chpl:7: note: this candidate did not match: bar(f: c_fn_ptr)
-improveErrorForFcfMismatch.chpl:13: note: because actual argument #1 with type 'shared chpl__fcf_type_void_void'
+improveErrorForFcfMismatch.chpl:13: note: because actual argument #1 with type 'proc()'
 improveErrorForFcfMismatch.chpl:7: note: is passed to formal 'f: c_fn_ptr'

--- a/test/extern/fnPtrs/sugarFcfTypes.bad
+++ b/test/extern/fnPtrs/sugarFcfTypes.bad
@@ -1,4 +1,0 @@
-sugarFcfTypes.chpl:13: error: unresolved call 'bar(proc())'
-sugarFcfTypes.chpl:7: note: this candidate did not match: bar(f: c_fn_ptr)
-sugarFcfTypes.chpl:13: note: because actual argument #1 with type 'proc()'
-sugarFcfTypes.chpl:7: note: is passed to formal 'f: c_fn_ptr'

--- a/test/extern/fnPtrs/sugarFcfTypes.bad
+++ b/test/extern/fnPtrs/sugarFcfTypes.bad
@@ -1,4 +1,4 @@
-sugarFcfTypes.chpl:13: error: unresolved call 'bar(shared chpl__fcf_type_void_void)'
+sugarFcfTypes.chpl:13: error: unresolved call 'bar(proc())'
 sugarFcfTypes.chpl:7: note: this candidate did not match: bar(f: c_fn_ptr)
-sugarFcfTypes.chpl:13: note: because actual argument #1 with type 'shared chpl__fcf_type_void_void'
+sugarFcfTypes.chpl:13: note: because actual argument #1 with type 'proc()'
 sugarFcfTypes.chpl:7: note: is passed to formal 'f: c_fn_ptr'

--- a/test/extern/fnPtrs/sugarFcfTypes.future
+++ b/test/extern/fnPtrs/sugarFcfTypes.future
@@ -1,4 +1,0 @@
-error message: Need to sugar first-class function (fcf) types
-
-We shouldn't be printing out internal fcf type names when we
-generate errors involving first-class functions.

--- a/test/extern/fnPtrs/sugarFcfTypes.good
+++ b/test/extern/fnPtrs/sugarFcfTypes.good
@@ -1,2 +1,4 @@
-sugarFcfTypes.chpl:13: error: unresolved call 'bar(func())'
-sugarFcfTypes.chpl:7: note: candidates are: bar(f: c_fn_ptr)
+sugarFcfTypes.chpl:13: error: unresolved call 'bar(proc())'
+sugarFcfTypes.chpl:7: note: this candidate did not match: bar(f: c_fn_ptr)
+sugarFcfTypes.chpl:13: note: because actual argument #1 with type 'proc()'
+sugarFcfTypes.chpl:7: note: is passed to formal 'f: c_fn_ptr'

--- a/test/extern/fnPtrs/sugarFcfTypes2.bad
+++ b/test/extern/fnPtrs/sugarFcfTypes2.bad
@@ -1,4 +1,0 @@
-sugarFcfTypes2.chpl:13: error: unresolved call 'barIntInt(shared chpl__fcf_type_int64_t_int64_t)'
-sugarFcfTypes2.chpl:7: note: this candidate did not match: barIntInt(f: c_fn_ptr)
-sugarFcfTypes2.chpl:13: note: because actual argument #1 with type 'shared chpl__fcf_type_int64_t_int64_t'
-sugarFcfTypes2.chpl:7: note: is passed to formal 'f: c_fn_ptr'

--- a/test/extern/fnPtrs/sugarFcfTypes2.future
+++ b/test/extern/fnPtrs/sugarFcfTypes2.future
@@ -1,4 +1,4 @@
-error message: Need to sugar first-class function (fcf) types
-
-We shouldn't be printing out internal fcf type names when we
-generate errors involving first-class functions.
+sugarFcfTypes2.chpl:13: error: unresolved call 'barIntInt(proc(x: int): int)'
+sugarFcfTypes2.chpl:7: note: this candidate did not match: barIntInt(f: c_fn_ptr)
+sugarFcfTypes2.chpl:13: note: because actual argument #1 with type 'proc(x: int): int'
+sugarFcfTypes2.chpl:7: note: is passed to formal 'f: c_fn_ptr'

--- a/test/extern/fnPtrs/sugarFcfTypes2.future
+++ b/test/extern/fnPtrs/sugarFcfTypes2.future
@@ -1,4 +1,0 @@
-sugarFcfTypes2.chpl:13: error: unresolved call 'barIntInt(proc(x: int): int)'
-sugarFcfTypes2.chpl:7: note: this candidate did not match: barIntInt(f: c_fn_ptr)
-sugarFcfTypes2.chpl:13: note: because actual argument #1 with type 'proc(x: int): int'
-sugarFcfTypes2.chpl:7: note: is passed to formal 'f: c_fn_ptr'

--- a/test/extern/fnPtrs/sugarFcfTypes2.good
+++ b/test/extern/fnPtrs/sugarFcfTypes2.good
@@ -1,2 +1,4 @@
-sugarFcfTypes2.chpl:13: error: unresolved call 'barIntInt(func(int(64), int(64)))'
-sugarFcfTypes2.chpl:7: note: candidates are: barIntInt(f: c_fn_ptr)
+sugarFcfTypes2.chpl:13: error: unresolved call 'barIntInt(proc(x: int): int)'
+sugarFcfTypes2.chpl:7: note: this candidate did not match: barIntInt(f: c_fn_ptr)
+sugarFcfTypes2.chpl:13: note: because actual argument #1 with type 'proc(x: int): int'
+sugarFcfTypes2.chpl:7: note: is passed to formal 'f: c_fn_ptr'

--- a/test/extern/rename/renameViaParamExpr.bad
+++ b/test/extern/rename/renameViaParamExpr.bad
@@ -1,2 +1,5 @@
 renameViaParamExpr.chpl:9: syntax error: near 'record'
 renameViaParamExpr.chpl:12: syntax error: near '}'
+renameViaParamExpr.chpl:3: error: the linkage name for 'cVarType' must be a string literal
+renameViaParamExpr.chpl:11: error: the linkage name for 'cFieldType' must be a string literal
+renameViaParamExpr.chpl:16: error: the linkage name for 'myCInt' must be a string literal

--- a/test/extern/rename/renameViaParamExpr.compopts
+++ b/test/extern/rename/renameViaParamExpr.compopts
@@ -1,1 +1,0 @@
---ignore-errors-for-pass

--- a/test/functions/lambda/saveInField-nothing.bad
+++ b/test/functions/lambda/saveInField-nothing.bad
@@ -1,9 +1,9 @@
 saveInField-nothing.chpl:10: In initializer:
-saveInField-nothing.chpl:11: error: could not find a copy initializer ('init=') for type 'shared chpl__fcf_type_int64_t_chpl_bool' from type 'nothing'
-$CHPL_HOME/modules/internal/SharedObject.chpl:255: note: this candidate did not match: _shared.init=(pragma"nil from arg"in take: owned)
+saveInField-nothing.chpl:11: error: could not find a copy initializer ('init=') for type 'proc(int): bool' from type 'nothing'
+$CHPL_HOME/modules/internal/SharedObject.chpl:256: note: this candidate did not match: _shared.init=(pragma"nil from arg"in take: owned)
 saveInField-nothing.chpl:11: note: because actual argument #1 with type 'nothing'
-$CHPL_HOME/modules/internal/SharedObject.chpl:255: note: is passed to formal 'in take: owned'
+$CHPL_HOME/modules/internal/SharedObject.chpl:256: note: is passed to formal 'in take: owned'
 saveInField-nothing.chpl:11: note: other candidates are:
-$CHPL_HOME/modules/internal/SharedObject.chpl:281: note:   _shared.init=(pragma"nil from arg"const ref src: _shared)
-$CHPL_HOME/modules/internal/SharedObject.chpl:303: note:   _shared.init=(src: borrowed)
+$CHPL_HOME/modules/internal/SharedObject.chpl:282: note:   _shared.init=(pragma"nil from arg"const ref src: _shared)
+$CHPL_HOME/modules/internal/SharedObject.chpl:304: note:   _shared.init=(src: borrowed)
 note: and 2 other candidates, use --print-all-candidates to see them


### PR DESCRIPTION
Adjust a bunch of .future files impacted by changes to FCFs

Remove the .compopts for a parsing related future because it was
no longer needed. Promote two futures.

Reviewed by @DanilaFe. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>