### PR TITLE
Switch the host to jemalloc for non-quickstart builds

### DIFF
--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -10,7 +10,8 @@ def get(flag='host'):
     arch_val = chpl_arch.get(flag)
     platform_val = chpl_platform.get(flag)
     cygwin = platform_val.startswith('cygwin')
-    mac_arm = platform_val == 'darwin' and arch_val == 'arm64'
+    mac = platform_val == 'darwin'
+    mac_arm = mac and arch_val == 'arm64'
     chpl_host_mem = overrides.get('CHPL_HOST_MEM')
     chpl_target_mem = overrides.get('CHPL_TARGET_MEM')
     chpl_mem = overrides.get('CHPL_MEM')
@@ -28,12 +29,12 @@ def get(flag='host'):
         else:
             mem_val = 'jemalloc'
     elif flag == 'host':
-        if cygwin:
+        if cygwin or mac:
             mem_val = 'cstdlib'
         elif chpl_host_mem:
             mem_val = chpl_host_mem
         else:
-            mem_val = 'cstdlib'
+            mem_val = 'jemalloc'
     else:
         error("Invalid flag: '{0}'".format(flag), ValueError)
     return mem_val

--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -58,6 +58,9 @@ export CHPL_TASKS=fifo
 echo "Setting CHPL_MEM to cstdlib"
 export CHPL_MEM=cstdlib
 
+echo "Setting CHPL_HOST_MEM to cstdlib"
+export CHPL_HOST_MEM=cstdlib
+
 echo "Setting CHPL_GMP to none"
 export CHPL_GMP=none
 

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -47,6 +47,9 @@ setenv CHPL_TASKS fifo
 echo "Setting CHPL_MEM to cstdlib"
 setenv CHPL_MEM cstdlib
 
+echo "Setting CHPL_HOST_MEM to cstdlib"
+setenv CHPL_HOST_MEM cstdlib
+
 echo "Setting CHPL_GMP to none"
 setenv CHPL_GMP none
 

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -51,6 +51,9 @@ set -x CHPL_TASKS fifo
 echo "Setting CHPL_MEM to cstdlib"
 set -x CHPL_MEM cstdlib
 
+echo "Setting CHPL_HOST_MEM to cstdlib"
+set -x CHPL_HOST_MEM cstdlib
+
 echo "Setting CHPL_GMP to none"
 set -x CHPL_GMP none
 

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -63,6 +63,12 @@ export CHPL_MEM
 echo "                           ...cstdlib"
 echo " "
 
+echo "Setting CHPL_HOST_MEM to..."
+CHPL_HOST_MEM=cstdlib
+export CHPL_HOST_MEM
+echo "                           ...cstdlib"
+echo " "
+
 echo "Setting CHPL_GMP to..."
 CHPL_GMP=none
 export CHPL_GMP


### PR DESCRIPTION
This switches the `CHPL_HOST_MEM` variable to `jemalloc` on systems that are
not Cygwin or Mac (Mac requires a system-level installation of jemalloc, which
we are not currently detecting).

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>