### PR TITLE
Specify CPU binding via QT_CPUBIND

### DIFF
--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -50,9 +50,13 @@ void* chpl_topo_getHwlocTopology(void);
 int chpl_topo_getNumCPUsPhysical(chpl_bool /*accessible_only*/);
 int chpl_topo_getNumCPUsLogical(chpl_bool /*accessible_only*/);
 
-// Which CPUs (cores/PUs) are accessible?
-
-int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int size);
+//
+// Fills the "cpus" array with up to "count" physical OS indices of the
+// accessible cores or PUs. If "physical" is true, then "cpus" contains
+// core indices, otherwise it contains PU indices. Returns the number
+// of indices in the "cpus" array.
+//
+int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count);
 
 //
 // how many NUMA domains are there?

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -50,6 +50,10 @@ void* chpl_topo_getHwlocTopology(void);
 int chpl_topo_getNumCPUsPhysical(chpl_bool /*accessible_only*/);
 int chpl_topo_getNumCPUsLogical(chpl_bool /*accessible_only*/);
 
+// Which CPUs (cores/PUs) are accessible?
+
+int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int size);
+
 //
 // how many NUMA domains are there?
 //

--- a/runtime/src/tasks/qthreads/Makefile
+++ b/runtime/src/tasks/qthreads/Makefile
@@ -33,6 +33,14 @@ include Makefile.share
 
 TARGETS = $(TASKS_OBJS)
 
+# define a macro containing the qthreads topology module
+
+ifeq (, $(CHPL_QTHREAD_TOPOLOGY))
+RUNTIME_DEFS += -DCHPL_QTHREAD_TOPOLOGY=hwloc	# default
+else
+RUNTIME_DEFS += -DCHPL_QTHREAD_TOPOLOGY=$(CHPL_QTHREAD_TOPOLOGY)
+endif
+
 include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
 
 FORCE:

--- a/runtime/src/tasks/qthreads/Makefile
+++ b/runtime/src/tasks/qthreads/Makefile
@@ -33,14 +33,6 @@ include Makefile.share
 
 TARGETS = $(TASKS_OBJS)
 
-# define a macro containing the qthreads topology module
-
-ifeq (, $(CHPL_QTHREAD_TOPOLOGY))
-RUNTIME_DEFS += -DCHPL_QTHREAD_TOPOLOGY=hwloc	# default
-else
-RUNTIME_DEFS += -DCHPL_QTHREAD_TOPOLOGY=$(CHPL_QTHREAD_TOPOLOGY)
-endif
-
 include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
 
 FORCE:

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -689,7 +689,7 @@ void chpl_task_init(void)
         int *cpus = NULL;
         int numCpus;
         chpl_bool physical;
-        char *unit = getenv("QT_WORKER_UNIT");
+        char *unit = chpl_qt_getenv_str("WORKER_UNIT");
         if ((unit != NULL) && !strcmp(unit, "pu")) {
             physical = false;
             numCpus = chpl_topo_getNumCPUsLogical(true);

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -340,6 +340,8 @@ int getCPUs(hwloc_cpuset_t cpuset, int *cpus, int size) {
 // of indices in the "cpus" array.
 //
 int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count) {
+  // Initializes CPU information.
+  CHK_ERR(pthread_once(&numCPUs_ctrl, getNumCPUs) == 0);
   return getCPUs(physical ? physAccSet : logAccSet, cpus, count);
 }
 

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -68,7 +68,6 @@ static int numNumaDomains;
 static hwloc_cpuset_t physAccSet = NULL;
 static hwloc_cpuset_t logAccSet = NULL;
 
-
 static hwloc_obj_t getNumaObj(c_sublocid_t);
 static void alignAddrSize(void*, size_t, chpl_bool,
                           size_t*, unsigned char**, size_t*);
@@ -282,13 +281,13 @@ void getNumCPUs(void) {
   for (hwloc_obj_t pu = NEXT_PU(NULL); pu != NULL; pu = NEXT_PU(pu)) {
     hwloc_obj_t core;
     CHK_ERR_ERRNO((core = hwloc_get_ancestor_obj_by_type(topology,
-                                                       HWLOC_OBJ_CORE,
-                                                       pu))
+                                                         HWLOC_OBJ_CORE,
+                                                         pu))
                   != NULL);
     // Only use the first PU per core.
     hwloc_obj_t first = hwloc_get_obj_inside_cpuset_by_type(topology,
-                                                     core->cpuset,
-                                                     HWLOC_OBJ_PU, 0);
+                                                            core->cpuset,
+                                                            HWLOC_OBJ_PU, 0);
     hwloc_bitmap_or(physAccSet, physAccSet, first->cpuset);
   }
 
@@ -317,7 +316,10 @@ void getNumCPUs(void) {
   CHK_ERR(numCPUsLogAll > 0);
 }
 
-// Fills the cpus array with the physical indices of the CPUs in the cpuset.
+//
+// Fills the "cpus" array with the hwloc "cpuset" (a bitmap whose bits are
+// set according to CPU physical OS indexes).
+//
 static
 int getCPUs(hwloc_cpuset_t cpuset, int *cpus, int size) {
   int count = 0;
@@ -331,6 +333,12 @@ int getCPUs(hwloc_cpuset_t cpuset, int *cpus, int size) {
 }
 
 
+//
+// Fills the "cpus" array with up to "count" physical OS indices of the
+// accessible cores or PUs. If "physical" is true, then "cpus" contains
+// core indices, otherwise it contains PU indices. Returns the number
+// of indices in the "cpus" array.
+//
 int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count) {
   return getCPUs(physical ? physAccSet : logAccSet, cpus, count);
 }

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -52,6 +52,10 @@ int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
 }
 
 
+int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count) {
+  return 0;
+}
+
 int chpl_topo_getNumNumaDomains(void) {
   return 1;
 }

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -48,6 +48,14 @@ ifneq (, $(TOPOLOGY))
 CHPL_QTHREAD_CFG_OPTIONS += --with-topology=$(TOPOLOGY)
 endif
 
+# Used to create qthread-chapel.h
+USE_TOPOLOGY_HWLOC = 0
+USE_TOPOLOGY_BINDERS = 0
+ifeq ($(TOPOLOGY),hwloc)
+  USE_TOPOLOGY_HWLOC=1
+else ifeq ($(TOPOLOGY),binders)
+  USE_TOPOLOGY_BINDERS=1
+endif
 
 # Have qthreads use Chapel's allocator, unless directed not to
 ifeq (, $(call isTrue, $(CHPL_QTHREAD_NO_CHPL_ALLOC)))
@@ -235,6 +243,12 @@ qthread-chapel-h: FORCE
 	echo "#define CHPL_QTHREAD_HAVE_GUARD_PAGES" \
 	     $(HAVE_GUARD_PAGES) \
 	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
+	echo "#define CHPL_QTHREAD_TOPOLOGY_BINDERS" \
+       $(USE_TOPOLOGY_BINDERS) \
+       >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
+	echo "#define CHPL_QTHREAD_TOPOLOGY_HWLOC" \
+       $(USE_TOPOLOGY_HWLOC) \
+       >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 
 qthread: qthread-config qthread-build qthread-chapel-h
 

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -49,12 +49,10 @@ CHPL_QTHREAD_CFG_OPTIONS += --with-topology=$(TOPOLOGY)
 endif
 
 # Used to create qthread-chapel.h
-USE_TOPOLOGY_HWLOC = 0
-USE_TOPOLOGY_BINDERS = 0
-ifeq ($(TOPOLOGY),hwloc)
-  USE_TOPOLOGY_HWLOC=1
-else ifeq ($(TOPOLOGY),binders)
+ifeq ($(TOPOLOGY),binders)
   USE_TOPOLOGY_BINDERS=1
+else
+  USE_TOPOLOGY_BINDERS=0
 endif
 
 # Have qthreads use Chapel's allocator, unless directed not to
@@ -244,11 +242,8 @@ qthread-chapel-h: FORCE
 	     $(HAVE_GUARD_PAGES) \
 	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 	echo "#define CHPL_QTHREAD_TOPOLOGY_BINDERS" \
-       $(USE_TOPOLOGY_BINDERS) \
-       >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
-	echo "#define CHPL_QTHREAD_TOPOLOGY_HWLOC" \
-       $(USE_TOPOLOGY_HWLOC) \
-       >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
+	     $(USE_TOPOLOGY_BINDERS) \
+	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 
 qthread: qthread-config qthread-build qthread-chapel-h
 


### PR DESCRIPTION
When using the `qthreads` `binders` topology module, specify the CPU bindings using the `QT_CPUBIND` environment variable. This removes all binding policy decisions from `binders`, as its default policies have problems such as incorrectly computing the number of workers per shepherd, always binding shepherds to PUs, and exiting when PUs are inaccessible. Setting `QT_CPUBIND` allows us to implement our own binding policies and avoid these problems with the default `binders` policies.

Passes all single- and multi-locale tests with the following exceptions:
- test/runtime/configMatters/comm/task-overload -- known problem on ss11
- test/studies/bale/indexgather/ig-variants -- output order is different, also fails on `main` with `hwloc` topology on ss11

No significant impact on the performance of the core benchmarks described  in https://github.com/Cray/chapel-private/issues/3593 running on an EX.

Closes https://github.com/cray/chapel-private/issues/3844.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>