### PR TITLE
Fix testing error in BogusDestructors.chpl

### DIFF
--- a/test/classes/figueroa/BogusDestructors.chpl
+++ b/test/classes/figueroa/BogusDestructors.chpl
@@ -1,3 +1,5 @@
+
+
 class C {
   proc deinit () {writeln("inside ~C");}
 }


### PR DESCRIPTION
This test started to fail after #20722 because the line numbers in its error message changed. This PR restores the line numbers to allow this test to pass again.

Trivial, not reviewed.