### PR TITLE
Remove more deprecated symbols related to SysError

### DIFF
--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1174,10 +1174,6 @@ module OS {
     }
   }
 
-  pragma "no doc"
-  deprecated "'BlockingIOError' is deprecated, please use 'BlockingIoError' instead"
-  class BlockingIOError: SystemError {}
-
   /*
      :class:`ChildProcessError` is the subclass of :class:`SystemError`
      corresponding to :const:`~POSIX.ECHILD`.
@@ -1330,10 +1326,6 @@ module OS {
     }
   }
 
-  pragma "no doc"
-  deprecated "'IOError' is deprecated, please use 'IoError' instead"
-  class IOError: SystemError {}
-
   /*
      :class:`EofError` is the subclass of :class:`IoError` corresponding to
      :const:`SysBasic.EEOF`.
@@ -1344,10 +1336,6 @@ module OS {
     }
   }
 
-  pragma "no doc"
-  deprecated "'EOFError is deprecated, please use 'EofError instead"
-  class EOFError : IoError {}
-
   /*
      :class:`UnexpectedEofError` is the subclass of :class:`IoError`
      corresponding to :const:`SysBasic.ESHORT`.
@@ -1357,10 +1345,6 @@ module OS {
       super.init(err, details);
     }
   }
-
-  pragma "no doc"
-  deprecated "'UnexpectedEOFError' is deprecated, please use 'UnexpectedEofError' instead"
-  class UnexpectedEOFError : IoError {}
 
   /*
      :class:`BadFormatError` is the subclass of :class:`IoError` corresponding

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -41,30 +41,6 @@ module SysBasic {
 /* BASIC TYPES */
 use CTypes;
 
-import OS.errorCode;
-
-/* A type storing an error code or an error message.
-   A syserr can be compared using == or != to an qio_err_t (ie integer error code)
-   or to another syserr. A syserr can be cast to or from an qio_err_t. It can be
-   assigned the value of an qio_err_t or another syserr. In addition, syserr can be
-   checked directly in an if statement like so:
-
-   .. code-block:: chapel
-
-     var err: syserr;
-     if err then do writeln("err contains an error, ie err != ENOERR");
-     if !err then do writeln("err does not contain an error; err == ENOERR");
-
-   When a :type:`syserr` formal has default intent, the actual is copied to the
-   formal upon a function call and the formal cannot be assigned within the
-   function.
-
-   The default value of the :type:`syserr` type is undefined.
-
- */
-deprecated "'SysBasic.syserr' has been deprecated; please use 'OS.errorCode' instead."
-extern type syserr; // = c_int, opaque so we can manually override ==,!=,etc
-
 /* An integral error code. This is really just a `c_int`, but code is
    clearer if you use qio_err_t to indicate arguments, variables, and return types
    that are system error codes.

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -20,15 +20,7 @@
 
 /* Types for low-level system error integration.
 
-   This module defines the error types :type:`syserr` and :type:`qio_err_t`.
-
-   When should one use :type:`syserr` and when should one use :type:`qio_err_t`?
-   :type:`qio_err_t` is a system error code (a `c_int` by a nicer name to
-   indicate its purpose). :type:`syserr` is an enhanced error that might also
-   include an error message. All user-facing Chapel library code, or user
-   Chapel code, should generally use :type:`syserr`. When wrapping functions
-   or declaring them in C, use :type:`qio_err_t` to indicate that a function is
-   returning an error code.
+   This module defines the some system error types.
 
    A note about the error code documentation in this file. Error descriptions
    for system errors are included here for convenience only. Other

--- a/test/deprecated/deprecated-errors.chpl
+++ b/test/deprecated/deprecated-errors.chpl
@@ -1,6 +1,0 @@
-use OS;
-
-var IOerr: unmanaged IOError?;
-var BlockingIOErr: unmanaged BlockingIOError?;
-var EOFErr: unmanaged EOFError?;
-var UnexpetedEOFErr: unmanaged UnexpectedEOFError?;

--- a/test/deprecated/deprecated-errors.good
+++ b/test/deprecated/deprecated-errors.good
@@ -1,4 +1,0 @@
-deprecated-errors.chpl:3: warning: 'IOError' is deprecated, please use 'IoError' instead
-deprecated-errors.chpl:4: warning: 'BlockingIOError' is deprecated, please use 'BlockingIoError' instead
-deprecated-errors.chpl:5: warning: 'EOFError is deprecated, please use 'EofError instead
-deprecated-errors.chpl:6: warning: 'UnexpectedEOFError' is deprecated, please use 'UnexpectedEofError' instead

--- a/test/deprecated/useSyserr.chpl
+++ b/test/deprecated/useSyserr.chpl
@@ -1,1 +1,0 @@
-import SysBasic.{syserr};

--- a/test/deprecated/useSyserr.good
+++ b/test/deprecated/useSyserr.good
@@ -1,1 +1,0 @@
-useSyserr.chpl:1: warning: 'SysBasic.syserr' has been deprecated; please use 'OS.errorCode' instead.


### PR DESCRIPTION
Remove classes with all uppercase acronyms. Remove the syserr type.

Remove deprecation tests for these symbols.