### PR TITLE
Fix OOB error for string comparison in UnitTest assert

### DIFF
--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -395,7 +395,7 @@ module UnitTest {
         if len1 == len2 {
           if all(seq1 == seq2) then return;
         }
-        var shorterLength = if len1 < len2 then len1 else len2;
+        var shorterLength = min(len1, len2);
         tmpString = seq_type_name+"s differ: ";
         tmpString += "'"+stringify(seq1)+"' != '"+stringify(seq2)+"'" ;
         for i in 0..#shorterLength {

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -395,11 +395,12 @@ module UnitTest {
         if len1 == len2 {
           if all(seq1 == seq2) then return;
         }
+        var shorterLength = if len1 < len2 then len1 else len2;
         tmpString = seq_type_name+"s differ: ";
         tmpString += "'"+stringify(seq1)+"' != '"+stringify(seq2)+"'" ;
-        for (item1, item2, i) in zip(seq1, seq2, 0..) {
-          if item1 != item2 {
-            tmpString += "\nFirst differing element at index "+i:string +":\n'"+item1:string+"'\n'"+item2:string+"'\n";
+        for i in 0..#shorterLength {
+          if seq1[i] != seq2[i] {
+            tmpString += "\nFirst differing element at index "+i:string +":\n'"+seq1[i]:string+"'\n'"+seq2[i]:string+"'\n";
             break;
           }
         }

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -406,12 +406,12 @@ module UnitTest {
         if len1 > len2 {
           var size_diff = len1 - len2;
           tmpString += "\nFirst "+seq_type_name+" contains "+ size_diff:string +" additional elements.\n";
-          tmpString += "First extra element is at index "+(len2+1):string+"\n'"+seq1[len2+1]:string+"'\n";
+          tmpString += "First extra element is at index "+(len2):string+"\n'"+seq1[len2]:string+"'\n";
         }
         else if len1 < len2 {
           var size_diff = len2 - len1;
           tmpString += "\nSecond "+seq_type_name+" contains "+ size_diff:string +" additional elements.\n";
-          tmpString += "First extra element is at index "+(len1+1):string+"\n'"+seq2[len1+1]:string+"'\n";
+          tmpString += "First extra element is at index "+(len1):string+"\n'"+seq2[len1]:string+"'\n";
         }
       }
       throw new owned AssertionError(tmpString);

--- a/test/library/packages/UnitTest/AssertEqual/test_string_equality.chpl
+++ b/test/library/packages/UnitTest/AssertEqual/test_string_equality.chpl
@@ -1,0 +1,7 @@
+use UnitTest;
+
+proc first_longer(test: borrowed Test) throws {
+  test.assertEqual("Goodbye, Mars!", "Hello, World!");
+}
+
+UnitTest.main();

--- a/test/library/packages/UnitTest/AssertEqual/test_string_equality.chpl
+++ b/test/library/packages/UnitTest/AssertEqual/test_string_equality.chpl
@@ -4,4 +4,8 @@ proc first_longer(test: borrowed Test) throws {
   test.assertEqual("Goodbye, Mars!", "Hello, World!");
 }
 
+proc equality_diff_lengths(test: borrowed Test) throws {
+  test.assertEqual("aaaaa", "aa");
+}
+
 UnitTest.main();

--- a/test/library/packages/UnitTest/AssertEqual/test_string_equality.good
+++ b/test/library/packages/UnitTest/AssertEqual/test_string_equality.good
@@ -11,3 +11,12 @@ First extra element is at index 13
 '!'
 
 ----------------------------------------------------------------------
+equality_diff_lengths()
+Flavour: FAIL
+======================================================================
+AssertionError: Strings differ: 'aaaaa' != 'aa'
+First String contains 3 additional elements.
+First extra element is at index 2
+'a'
+
+----------------------------------------------------------------------

--- a/test/library/packages/UnitTest/AssertEqual/test_string_equality.good
+++ b/test/library/packages/UnitTest/AssertEqual/test_string_equality.good
@@ -1,0 +1,13 @@
+first_longer()
+Flavour: FAIL
+======================================================================
+AssertionError: Strings differ: 'Goodbye, Mars!' != 'Hello, World!'
+First differing element at index 0:
+'G'
+'H'
+
+First String contains 1 additional elements.
+First extra element is at index 13
+'!'
+
+----------------------------------------------------------------------


### PR DESCRIPTION
When checking string equality, the UnitTest code would compare the length of strings and, if they differed, would then index into the value at the length of the shorter string+1, which is 1 more than what we want when using 0-based indexing. This was causing an OOB access for strings that differed in length by 1.

Resolves: https://github.com/chapel-lang/chapel/issues/20781