### PR TITLE
Ensure suppressif is consulted

### DIFF
--- a/test/errhandling/ferguson/it-throws-inline.good
+++ b/test/errhandling/ferguson/it-throws-inline.good
@@ -1,0 +1,1 @@
+it-throws-inline.2.good

--- a/test/errhandling/ferguson/loopexprs-caught.good
+++ b/test/errhandling/ferguson/loopexprs-caught.good
@@ -1,0 +1,1 @@
+loopexprs-caught.11.good


### PR DESCRIPTION
The .suppressif files added in #20767 for it-throws-inline.chpl and loopexprs-caught.chpl were not consulted when these tests failed in baseline testing. This is probably because they lacked "straight" .good files.

This PR adds such .good files. Even though their contents should not matter, I made them symlinks to those existing .good files that contain the expected output when executing without any execopts.

Testing: tested the entire directory with and without '--baseline'.

This idea is due to @bradcray.
Not reviewed.
