### PR TITLE
Fix outdated test with new flag

### DIFF
--- a/test/mason/chplVersion/mason-chpl-version-build.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-build.chpl
@@ -34,5 +34,5 @@ proc main() {
 
   var compopts: list(string);
   compopts.append("");
-  buildProgram(false, false, false, compopts, "Mason.toml", "Mason.lock");
+  buildProgram(false, false, false, false, compopts, "Mason.toml", "Mason.lock");
 }


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/20550, the `skipUpdate` flag was added to `masonBuild` and this test slipped past getting updated. This PR updates that test to account for the new flag.