### PR TITLE
Fix regex.matches() and channel.matches() for empty strings

### DIFF
--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -958,17 +958,12 @@ record regex {
     const localRegex = if home != here then regexCopy._regex else _regex;
     param nMatches = 1 + numCaptures;
     var matches: c_array(qio_regex_string_piece_t, nMatches);
-    var pos:byteIndex;
-    var endPos:byteIndex;
-    var textLength:int;
-    var localText = text.localize();
-
-    pos = 0;
-    textLength = localText.numBytes;
-    endPos = pos + textLength;
-
+    const localText = text.localize();
+    const textLength = localText.numBytes;
+    const endPos = textLength;
     var nFound = 0;
-    var cur = pos;
+    var cur = 0;
+
     while nFound < maxMatches && cur <= endPos {
       var got = qio_regex_match(localRegex, localText.c_str(), textLength,
                                 cur:int, endPos:int, QIO_REGEX_ANCHOR_UNANCHORED,

--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -293,19 +293,21 @@ qio_bool qio_regex_match(qio_regex_t* regex, const char* text, int64_t text_len,
   ret = re->Match(textp, startpos, endpos, ranchor, spPtr, nsubmatch);
   // Now set submatch based on StringPieces
   for( int64_t i = 0; i < nsubmatch; i++ ) {
-    if( !ret || spPtr[i].data() == NULL ) {
+    if( !ret ) {
       submatch[i].offset = -1;
       submatch[i].len = 0;
     } else {
       intptr_t diff = 0;
+      int64_t  length = 0;
       if( spPtr[i].empty() ) {
         diff = startpos;
       } else {
         diff = qio_ptr_diff((void*) spPtr[i].data(), (void*) textp.data());
         assert( diff >= startpos && diff <= endpos );
+        length = spPtr[i].length();
       }
       submatch[i].offset = diff;
-      submatch[i].len = spPtr[i].length();
+      submatch[i].len = length;
     }
   }
 

--- a/test/regex/empty-channel-matches.chpl
+++ b/test/regex/empty-channel-matches.chpl
@@ -1,0 +1,66 @@
+// A test of patterns that match an empty string.
+// First, test them on an empty channel, then on a channel with "xx".
+
+use Regex, IO;
+
+var f = openmem();
+
+proc testEmpty(re:string) {
+  var fr = f.reader();
+  writeln("[", re, "]  ", fr.matches(compile(re), 0, 6), " ", fr.offset());
+}
+
+// each of the following matches exactly once at offset 0, given an empty file
+testEmpty("");
+testEmpty("^");
+testEmpty("$");
+testEmpty("^$");
+testEmpty(".*");
+
+writeln();
+
+{ var w = f.writer(); w.write("xy"); }
+
+proc testXY(re:string) {
+  var fr1 = f.reader();
+  for mm in fr1.matches(compile(re), 0, 6) {
+    var ss: string;
+    fr1.extractMatch(mm(0), ss);
+    writeln("[", re, "]  ", mm, " <", ss, "> ", fr1.offset());
+  }
+  writeln("[", re, "]  done ", fr1.offset());
+}
+
+testXY("");    // matches once before each char and once after the last char
+//testXY("^"); // matches once at start of channel-->empty-channel-todo.future
+testXY("$");   // matches once after the last char
+testXY("^$");  // no match, given that the file is not empty; final offset??
+testXY(".*");  // matches once everything at start and once like "$"
+
+// check these non-empty patterns as well
+testXY(".");
+testXY("x");
+testXY("y");
+
+writeln();
+
+proc testSearch(re:string) {
+  var fr = f.reader();
+  writeln("[", re, "]   ", fr.search(compile(re)), " ", fr.offset());
+}
+
+testSearch("");
+testSearch("^");
+testSearch("$");
+testSearch("^$"); // what should be the offset after the search call here?
+testSearch(".*");
+testSearch(".");
+testSearch("x");
+testSearch("y");
+
+writeln();
+var frx = f.reader();
+const rex = "^$";
+// how should the offset progress here? see also testSearch("^$") above
+writeln("[", rex, "]   ", frx.search(compile(rex)), " ", frx.offset());
+writeln("[", rex, "]   ", frx.search(compile(rex)), " ", frx.offset());

--- a/test/regex/empty-channel-matches.good
+++ b/test/regex/empty-channel-matches.good
@@ -1,0 +1,38 @@
+$CHPL_HOME/modules/standard/IO.chpl:8388: In method 'search':
+$CHPL_HOME/modules/standard/IO.chpl:8391: warning: `channel.search(re:regex(?), ref error:errorCode)` is deprecated
+  empty-channel-matches.chpl:49: called as (fileReader(dynamic,true)).search(re: regex(string))
+[]  ((matched = true, byteOffset = 0, numBytes = 0),) 0
+[^]  ((matched = true, byteOffset = 0, numBytes = 0),) 0
+[$]  ((matched = true, byteOffset = 0, numBytes = 0),) 0
+[^$]  ((matched = true, byteOffset = 0, numBytes = 0),) 0
+[.*]  ((matched = true, byteOffset = 0, numBytes = 0),) 0
+
+[]  ((matched = true, byteOffset = 0, numBytes = 0),) <> 1
+[]  ((matched = true, byteOffset = 1, numBytes = 0),) <> 2
+[]  ((matched = true, byteOffset = 2, numBytes = 0),) <> 2
+[]  done 2
+[$]  ((matched = true, byteOffset = 2, numBytes = 0),) <> 2
+[$]  done 2
+[^$]  done 1
+[.*]  ((matched = true, byteOffset = 0, numBytes = 2),) <xy> 2
+[.*]  ((matched = true, byteOffset = 2, numBytes = 0),) <> 2
+[.*]  done 2
+[.]  ((matched = true, byteOffset = 0, numBytes = 1),) <x> 1
+[.]  ((matched = true, byteOffset = 1, numBytes = 1),) <y> 2
+[.]  done 2
+[x]  ((matched = true, byteOffset = 0, numBytes = 1),) <x> 1
+[x]  done 2
+[y]  ((matched = true, byteOffset = 1, numBytes = 1),) <y> 2
+[y]  done 2
+
+[]   (matched = true, byteOffset = 0, numBytes = 0) 0
+[^]   (matched = true, byteOffset = 0, numBytes = 0) 0
+[$]   (matched = true, byteOffset = 2, numBytes = 0) 2
+[^$]   (matched = false, byteOffset = -1, numBytes = 0) 1
+[.*]   (matched = true, byteOffset = 0, numBytes = 2) 0
+[.]   (matched = true, byteOffset = 0, numBytes = 1) 0
+[x]   (matched = true, byteOffset = 0, numBytes = 1) 0
+[y]   (matched = true, byteOffset = 1, numBytes = 1) 1
+
+[^$]   (matched = false, byteOffset = -1, numBytes = 0) 1
+[^$]   (matched = false, byteOffset = -1, numBytes = 0) 2

--- a/test/regex/empty-string-matches.chpl
+++ b/test/regex/empty-string-matches.chpl
@@ -1,0 +1,12 @@
+// Verify that `matches` produces at most one match
+// when `text` is an empty string.
+
+use Regex;
+
+var str = "";
+
+writeln(compile("").matches(str));
+writeln(compile("^").matches(str));
+writeln(compile("$").matches(str));
+writeln(compile("^$").matches(str));
+writeln(compile(".*").matches(str));

--- a/test/regex/empty-string-matches.good
+++ b/test/regex/empty-string-matches.good
@@ -1,0 +1,5 @@
+((matched = true, byteOffset = 0, numBytes = 0),)
+((matched = true, byteOffset = 0, numBytes = 0),)
+((matched = true, byteOffset = 0, numBytes = 0),)
+((matched = true, byteOffset = 0, numBytes = 0),)
+((matched = true, byteOffset = 0, numBytes = 0),)

--- a/test/regex/ferguson/readfinf.chpl
+++ b/test/regex/ferguson/readfinf.chpl
@@ -1,0 +1,34 @@
+// Do not change this line: it is used for .good. //
+// Verify that readf-ing an empty string does not advance the channel.
+
+use Regex, IO;
+
+var ch = openreader("readfinf.chpl");
+
+for i in 1..4 {
+  const ok = ch.readf("%//");
+  writeln(ok, " ", ch.offset());
+}
+
+writeln();
+
+for i in 1..4 {
+  var str = "hi";
+  const ok = ch.readf("%/()/", str);
+  writeln(ok, " <", str, "> ", ch.offset());
+}
+
+writeln();
+
+for i in 1..4 {
+  var str = "hi";
+  const ok = ch.readf("%/(.)/", str);
+  writeln(ok, "<", str, ">", ch.offset());
+}
+
+writeln();
+
+for i in 1..4 {
+  const ok = ch.readf("");
+  writeln(ok, " ", ch.offset());
+}

--- a/test/regex/ferguson/readfinf.good
+++ b/test/regex/ferguson/readfinf.good
@@ -1,0 +1,19 @@
+true 0
+true 0
+true 0
+true 0
+
+true <> 0
+true <> 0
+true <> 0
+true <> 0
+
+true</>1
+true</>2
+true< >3
+true<D>4
+
+true 4
+true 4
+true 4
+true 4

--- a/test/regex/regex-and-channel-todos.bad
+++ b/test/regex/regex-and-channel-todos.bad
@@ -1,0 +1,6 @@
+[^]  ((matched = true, byteOffset = 0, numBytes = 0),) <> 1
+[^]  ((matched = true, byteOffset = 1, numBytes = 0),) <> 2
+[^]  ((matched = true, byteOffset = 2, numBytes = 0),) <> 2
+[^]  done 2
+
+((matched = true, byteOffset = 0, numBytes = 0),) ((matched = true, byteOffset = 1, numBytes = 0),) ((matched = true, byteOffset = 2, numBytes = 0),)

--- a/test/regex/regex-and-channel-todos.chpl
+++ b/test/regex/regex-and-channel-todos.chpl
@@ -1,0 +1,28 @@
+// Tests for #20864
+
+use Regex, IO;
+
+var f = openmem();
+{ var w = f.writer(); w.write("xy"); }
+
+proc testXY(re:string) {
+  var fr = f.reader();
+  for mm in fr.matches(compile(re), 0, 6) {
+    var ss: string;
+    fr.extractMatch(mm(0), ss);
+    writeln("[", re, "]  ", mm, " <", ss, "> ", fr.offset());
+  }
+  writeln("[", re, "]  done ", fr.offset());
+}
+
+
+// This should matches once at the beginning of the channel.
+// What should be the ending position in the channel?
+// When this is fixed, merge it into empty-channel-matches.chpl
+testXY("^"); 
+
+writeln();
+
+// This should match once at the end of the string, with byteOffset = 2.
+// When this is fixed, merge it into empty-string-matches.chpl
+writeln(compile("$").matches("xy"));

--- a/test/regex/regex-and-channel-todos.future
+++ b/test/regex/regex-and-channel-todos.future
@@ -1,0 +1,2 @@
+Regex/channel bugs
+#20864

--- a/test/regex/regex-and-channel-todos.good
+++ b/test/regex/regex-and-channel-todos.good
@@ -1,0 +1,4 @@
+[^]  ((matched = true, byteOffset = 0, numBytes = 0),) <> 0
+[^]  done 2
+
+((matched = true, byteOffset = 2, numBytes = 0),)


### PR DESCRIPTION
Resolves #20441

When given a regexp that matches an empty string, the iterators
`regex.matches()` supplied with an empty string and
`channel.matches()` supplied with an empty channel
now yield exactly one match.

When given such a regexp and a non-empty channel, `channel.matches()`
now mimics the behavior of `regex.matches()` on a non-empty string.

### Implementation notes

The key changes are:

* record a valid match even when `spPtr[i].data() == NULL`
  in qio_regex_match()
* restore `oldPosition` in proc _channel._extractMatch()
* execute `qio_channel_advance(1 byte)` when the matched string is empty
  in iter _channel.matches()
* minor cleanups "while there"

For the last point, we decided to insert this additional advance
into the iterator rather than into qio_regex_match() -- because
this advancement is needed when iterating. Cf. if we are just getting
an empty-string match on a channel, it should not get advanced.

Another place where this latter point comes to play is when calling
`readf` whose format string matches an empty string. In this case
the channel should not get advanced and subsequent such calls
will match at the same offset in the channel.
I added a test illustrating this.

Next steps: see #20864
