### PR TITLE
Check conflicting imported symbol names in Dyno scope-resolver

### DIFF
--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -366,8 +366,10 @@ static bool doLookupInImports(Context* context,
         }
 
         // find it in that scope
-        found |= doLookupInScope(context, symScope, nullptr, resolving, from,
-                                 newConfig, checkedScopes, result);
+        if (doLookupInScope(context, symScope, nullptr, resolving, from,
+                            newConfig, checkedScopes, result)) {
+          found = true;
+        }
       }
 
       if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -342,6 +342,7 @@ static bool doLookupInImports(Context* context,
 
   if (r != nullptr) {
     // check to see if it's mentioned in names/renames
+    bool found = false;
     for (const VisibilitySymbols& is: r->visibilityClauses()) {
       // if we should not continue transitively through private use/includes,
       // and this is private, skip it
@@ -365,17 +366,18 @@ static bool doLookupInImports(Context* context,
         }
 
         // find it in that scope
-        bool found = doLookupInScope(context, symScope, nullptr, resolving,
-                                     from, newConfig,
-                                     checkedScopes, result);
-        if (found && onlyInnermost)
-          return true;
+        found |= doLookupInScope(context, symScope, nullptr, resolving, from,
+                                 newConfig, checkedScopes, result);
       }
 
       if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {
         result.push_back(BorrowedIdsWithName(is.scope()->id()));
-        return true;
+        found = true;
       }
+    }
+
+    if (found && onlyInnermost) {
+      return true;
     }
   }
 

--- a/compiler/dyno/lib/resolution/scope-queries.cpp
+++ b/compiler/dyno/lib/resolution/scope-queries.cpp
@@ -366,10 +366,8 @@ static bool doLookupInImports(Context* context,
         }
 
         // find it in that scope
-        if (doLookupInScope(context, symScope, nullptr, resolving, from,
-                            newConfig, checkedScopes, result)) {
-          found = true;
-        }
+        found |= doLookupInScope(context, symScope, nullptr, resolving, from,
+                                 newConfig, checkedScopes, result);
       }
 
       if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {

--- a/compiler/dyno/test/resolution/testScopeResolve.cpp
+++ b/compiler/dyno/test/resolution/testScopeResolve.cpp
@@ -428,6 +428,38 @@ static void test9() {
   assert(reC.toId().isEmpty());
 }
 
+// test name conflicts can occur with uses
+static void test10() {
+  printf("test10\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module A {
+        var x = 2;
+      }
+      module B {
+        var x = 4;
+      }
+      module Z {
+        use A, B;
+        var a = x;
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* a = findVariable(vec, "a");
+  assert(a);
+
+  const ResolvedExpression& reA = scopeResolveIt(context, a->initExpression());
+  assert(reA.toId().isEmpty());
+}
+
 int main() {
   test1();
   test2();
@@ -438,6 +470,7 @@ int main() {
   test7();
   test8();
   test9();
+  test10();
 
   return 0;
 }


### PR DESCRIPTION
Updates the Dyno scope-resolver to search for a name in all use/imports, not just the first one that matches, so that name conflicts between imported symbols can be detected.

Resolves https://github.com/Cray/chapel-private/issues/3903.

Testing:
- [x] checking against tests listed in https://github.com/Cray/chapel-private/issues/3903
- [x] primers with --dyno 
- [x] paratest