### PR TITLE
dyno: Make tweaks to import lookup to improve scope resolution

### DIFF
--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -324,14 +324,41 @@ class VisibilitySymbols {
  public:
   /** The kind of import symbol */
   enum Kind {
-    /** the scope itself only (one name in names) */
+    /**
+      the scope itself only, e.g.:
+
+          import Bar as Baz;
+
+      The names field will contain one pair, denoting the renaming
+      of the module itself.
+
+     */
     SYMBOL_ONLY,
-    /** all the contents of the scope (and names is empty) */
+    /**
+      all the contents of the scope, e.g.:
+
+          import Foo;
+
+      The names field will be empty.
+
+     */
     ALL_CONTENTS,
-    /** only the contents of the scope named in names */
+    /**
+      only the contents of the scope named in names, e.g.:
+
+          import Foo.{a as x,b};
+
+      The names field will contain the imported names.
+     */
     ONLY_CONTENTS,
-    /** contents of the scope except the contents named in names
-        (no renaming) */
+    /**
+      contents of the scope except listed names, e.g.:
+
+          use Foo except {a, b};
+
+      The names field will contain the excluded names. There is no renaming
+      in this case.
+     */
     CONTENTS_EXCEPT,
   };
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1807,6 +1807,10 @@ bool Resolver::enter(const Range* range) {
   return true;
 }
 void Resolver::exit(const Range* range) {
+  if (scopeResolveOnly) {
+    return;
+  }
+
   // For the time being, we're resolving ranges by manually finding the record
   // and instantiating it appropriately. However, long-term, range literals
   // should be equivalent to a call to chpl_build_bounded_range. The resolver

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -365,9 +365,16 @@ static bool doLookupInImports(Context* context,
           newConfig |= LOOKUP_INNERMOST;
         }
 
-        // find it in that scope
-        found |= doLookupInScope(context, symScope, nullptr, resolving, from,
-                                 newConfig, checkedScopes, result);
+        // If the whole module is being renamed, still search for the original
+        // name within the module. Otherwise, search for the name that our
+        // target was renamed from.
+        UniqueString nameToLookUp = from;
+        if (is.kind() == VisibilitySymbols::SYMBOL_ONLY) {
+          nameToLookUp = name;
+        }
+
+        found |= doLookupInScope(context, symScope, nullptr, resolving,
+                                 nameToLookUp, newConfig, checkedScopes, result);
       }
 
       if (named && is.kind() == VisibilitySymbols::SYMBOL_ONLY) {


### PR DESCRIPTION
In particular, make sure that modules-used-as-variables is now an error like in
the regular `scopeResolver.cpp` pass. This PR also fixes some issues that
surface after this change (e.g., problems with converting tuple assignment with
`_` in it). The most prominent of these issues is that renaming a module to
something on import breaks looking up variables within the module.

Testing:
- [x] full local
- [x] `--dyno` (244 failures)

Reviewed by @benharsh - thanks! 