### PR TITLE
Minor test fixes: writeln and path deprecations

### DIFF
--- a/test/library/packages/ProtobufProtocolSupport/endToEndRunnerUtils.chpl
+++ b/test/library/packages/ProtobufProtocolSupport/endToEndRunnerUtils.chpl
@@ -17,11 +17,11 @@ proc endToEndTest(package: string) {
   shell2.wait();
 
   if debug then writeln("Writing and reading from Chapel");
-  shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl");
+  shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl -sWritersReturnBool=false");
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./write -nl 1");
   shell2.wait();
-  shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl");
+  shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl -sWritersReturnBool=false");
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=pipeStyle.pipe);
   while shell2.stdout.readLine(line1) {
@@ -30,7 +30,7 @@ proc endToEndTest(package: string) {
   shell2.wait(); 
 
   if debug then writeln("Writing from Chapel and reading from Python");
-  shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl");
+  shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl -sWritersReturnBool=false");
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./write -nl 1");
   shell2.wait();
@@ -43,7 +43,7 @@ proc endToEndTest(package: string) {
   if debug then writeln("Writing from Python and reading from Chapel");
   shell2 = spawnshell("python3 "+packageDir+"/write.py");
   shell2.wait();
-  shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl");
+  shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl -sWritersReturnBool=false");
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=pipeStyle.pipe);
   while shell2.stdout.readLine(line1) {

--- a/test/library/standard/IO/nonUTF8/basic.chpl
+++ b/test/library/standard/IO/nonUTF8/basic.chpl
@@ -1,4 +1,5 @@
 use IO;
+use ChplConfig;
 
 config param useNonUTF8 = true;
 
@@ -14,6 +15,5 @@ const filename1 = s("junkfile1");
 
 var f = open(filename1, iomode.cw);
 var p = f.path;
-writeln("file.path works: ", p == filename1);
+writeln("file.path works: ", p == CHPL_HOME + "/test/library/standard/IO/nonUTF8/" + filename1);
 f.close();
-

--- a/test/library/standard/IO/nonUTF8/basic.compopts
+++ b/test/library/standard/IO/nonUTF8/basic.compopts
@@ -1,0 +1,1 @@
+-sfilePathAbsolute=true


### PR DESCRIPTION
Fixes some test failures caused by: https://github.com/chapel-lang/chapel/pull/20508 and https://github.com/chapel-lang/chapel/pull/20769.

- `library/packages/ProtobufProtocolSupport` tests called the chapel compiler on some other files, and needed the `writersReturnBool=false` flag included in those compilation calls. 
- `library/standard/IO/nonUTF8/` was missing the `filePathAbsolute=true` flag.