### PR TITLE
Deprecate and rename FileSystem functions to use camelCase

### DIFF
--- a/test/deprecated/filesystem-functions.chpl
+++ b/test/deprecated/filesystem-functions.chpl
@@ -1,0 +1,10 @@
+use FileSystem;
+
+for dir in walkdirs() { }
+
+forall dir in walkdirs() { }
+
+for filename in listdir() { }
+
+getUID("no-such-file");
+getGID("no-such-file");

--- a/test/deprecated/filesystem-functions.good
+++ b/test/deprecated/filesystem-functions.good
@@ -1,0 +1,8 @@
+filesystem-functions.chpl:3: warning: walkdirs is deprecated; please use walkDirs instead
+filesystem-functions.chpl:5: warning: walkdirs is deprecated; please use walkDirs instead
+filesystem-functions.chpl:7: warning: listdir is deprecated, please use listDir instead
+filesystem-functions.chpl:9: warning: getUID is deprecated, please use getUid instead
+filesystem-functions.chpl:10: warning: getGID is deprecated, please use getGid instead
+uncaught FileNotFoundError: No such file or directory (in getUid)
+  filesystem-functions.chpl:9: thrown here
+  filesystem-functions.chpl:9: uncaught here

--- a/test/functions/iterators/recursive/recursive-iter-findfilesfailure.chpl
+++ b/test/functions/iterators/recursive/recursive-iter-findfilesfailure.chpl
@@ -18,10 +18,10 @@ iter myfindfiles(startdir: string = ".", recursive: bool = false,
                hidden: bool = false): string {
   if (recursive) then
     foreach subdir in mywalkdirs(startdir, hidden=hidden) do
-      foreach file in listdir(subdir, hidden=hidden, dirs=false, files=true, listlinks=true) do
+      foreach file in listDir(subdir, hidden=hidden, dirs=false, files=true, listlinks=true) do
         yield subdir+"/"+file;
   else
-    foreach file in listdir(startdir, hidden=hidden, dirs=false, files=true, listlinks=false) do
+    foreach file in listDir(startdir, hidden=hidden, dirs=false, files=true, listlinks=false) do
       yield startdir+"/"+file;
 }
 
@@ -34,7 +34,7 @@ iter mywalkdirs(path: string = ".", topdown: bool = true, depth: int = max(int),
     yield path;
 
   if (depth) {
-    var subdirs = listdir(path, hidden=hidden, files=false, listlinks=followlinks);
+    var subdirs = listDir(path, hidden=hidden, files=false, listlinks=followlinks);
     if (sort) {
       use Sort /* only sort */;
       sort(subdirs);

--- a/test/library/standard/FileSystem/filerator/bradc/testboth.chpl
+++ b/test/library/standard/FileSystem/filerator/bradc/testboth.chpl
@@ -1,6 +1,6 @@
 use FileSystem;
 
-for dir in walkdirs("subdir", sort=true) {
+for dir in walkDirs("subdir", sort=true) {
   writeln("dir ", dir, " contains:");
   for file in glob(dir+"/*") do
     writeln("  ", file);

--- a/test/library/standard/FileSystem/filerator/bradc/walk-par.chpl
+++ b/test/library/standard/FileSystem/filerator/bradc/walk-par.chpl
@@ -9,5 +9,5 @@ config const followlinks = true;
 config const sort = true;
 config const defaults = false;
 
-forall filename in walkdirs(startdir, topdown, depth, dotfiles, followlinks, sort=sort) do
+forall filename in walkDirs(startdir, topdown, depth, dotfiles, followlinks, sort=sort) do
   writeln(filename);

--- a/test/library/standard/FileSystem/filerator/bradc/walk.chpl
+++ b/test/library/standard/FileSystem/filerator/bradc/walk.chpl
@@ -10,8 +10,8 @@ config const sort = true;
 config const defaults = false;
 
 if defaults then
-  for filename in walkdirs(sort=sort) do
+  for filename in walkDirs(sort=sort) do
     writeln(filename);
 else
-  for filename in walkdirs(startdir, topdown, depth, dotfiles, followlinks, sort=sort) do
+  for filename in walkDirs(startdir, topdown, depth, dotfiles, followlinks, sort=sort) do
     writeln(filename);

--- a/test/library/standard/FileSystem/filerator/listdir-errors.chpl
+++ b/test/library/standard/FileSystem/filerator/listdir-errors.chpl
@@ -4,7 +4,7 @@
 
 use FileSystem;
 
-for file in listdir("no/such/dir/ever") do
+for file in listDir("no/such/dir/ever") do
   writeln(file);
-for file in listdir("listdir-errors.chpl") do
+for file in listDir("listdir-errors.chpl") do
   writeln(file);

--- a/test/library/standard/FileSystem/filerator/listdir-errors.good
+++ b/test/library/standard/FileSystem/filerator/listdir-errors.good
@@ -1,2 +1,2 @@
-error in listdir(): no/such/dir/ever: No such file or directory
-error in listdir(): listdir-errors.chpl: Not a directory
+error in listDir(): no/such/dir/ever: No such file or directory
+error in listDir(): listdir-errors.chpl: Not a directory

--- a/test/library/standard/FileSystem/lydia/getIDs/getting.chpl
+++ b/test/library/standard/FileSystem/lydia/getIDs/getting.chpl
@@ -1,4 +1,4 @@
 use FileSystem;
 
-writeln(getUID("getting.chpl"));
-writeln(getGID("getting.chpl"));
+writeln(getUid("getting.chpl"));
+writeln(getGid("getting.chpl"));

--- a/test/library/standard/FileSystem/lydia/moveDir/moveEmpty.chpl
+++ b/test/library/standard/FileSystem/lydia/moveDir/moveEmpty.chpl
@@ -7,7 +7,7 @@ var destName = "destFolder";
 if (!exists(srcName)) {
   mkdir(srcName);
 } else {
-  var srcChildren = listdir(realPath(srcName));
+  var srcChildren = listDir(realPath(srcName));
   if (srcChildren.size > 0) {
     writeln("Removing tree at ", srcName, ", does not fulfill test conditions");
     rmTree(srcName);
@@ -24,5 +24,5 @@ writeln(destName, " exists: ", exists(destName));
 moveDir(srcName, destName);
 writeln(srcName, " exists: ", exists(srcName));
 writeln(destName, " exists: ", exists(destName));
-var destChildren = listdir(realPath(destName));
+var destChildren = listDir(realPath(destName));
 writeln(destName, " is empty: ", (destChildren.size == 0));

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -678,7 +678,7 @@ private proc checkLicense(projectHome: string) throws {
     const url = 'https://github.com/spdx/license-list.git ';
     const command = 'git clone -q ' + branch + depth + url + dest;
     if !isDir(dest) then runCommand(command);
-    var licenseList = listdir(MASON_HOME + "/spdx");
+    var licenseList = listDir(MASON_HOME + "/spdx");
     for licenses in licenseList {
       const licenseName: string = licenses.strip('.txt', trailing=true);
       if licenseName == defaultLicense || defaultLicense == 'None' {
@@ -769,7 +769,7 @@ private proc ensureMasonProject(cwd : string, tomlName="Mason.toml") : string {
 /* Checks to make sure the package only has one main module
  */
 private proc moduleCheck(projectHome : string) throws {
-  const subModules = listdir(projectHome + '/src');
+  const subModules = listDir(projectHome + '/src');
   if subModules.size > 1 then return false;
   else return true;
 }
@@ -777,7 +777,7 @@ private proc moduleCheck(projectHome : string) throws {
 /* Checks package for examples */
 proc exampleCheck(projectHome: string) {
   if isDir(projectHome + '/example') {
-    const examples = listdir(projectHome + '/example');
+    const examples = listDir(projectHome + '/example');
     return examples.size > 0;
   } else return false;
 }
@@ -785,7 +785,7 @@ proc exampleCheck(projectHome: string) {
 /* Checks package for tests */
 proc testCheck(projectHome: string) {
   if isDir(projectHome + '/test') {
-    const tests = listdir(projectHome + '/test');
+    const tests = listDir(projectHome + '/test');
     return tests.size > 0;
   } else return false;
 }

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -80,7 +80,7 @@ proc masonSearch(ref args: list(string)) {
   for registry in MASON_CACHED_REGISTRY {
     const searchDir = registry + "/Bricks/";
 
-    for dir in listdir(searchDir, files=false, dirs=true) {
+    for dir in listDir(searchDir, files=false, dirs=true) {
       const name = dir.replace("/", "");
       if pattern.search(name) {
         if isHidden(name) {

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -70,7 +70,7 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
 
   const actualTest = joinPath(projectHome,'test');
   if isDir(actualTest) {
-    for dir in walkdirs(actualTest) {
+    for dir in walkDirs(actualTest) {
       const internalDir = target+dir.replace(projectHome,"");
       if !isDir(internalDir) {
         mkdir(internalDir);
@@ -439,7 +439,7 @@ proc projectModified(projectHome, projectName, binLocation) : bool {
 
   if isFile(binaryPath) {
     const binModTime = getLastModified(binaryPath);
-    for file in listdir(joinPath(projectHome, "src")) {
+    for file in listDir(joinPath(projectHome, "src")) {
       var srcPath = joinPath(projectHome, "src", file);
       if getLastModified(srcPath) > binModTime {
         return true;
@@ -515,7 +515,7 @@ proc getMasonDependencies(sourceList: list(3*string),
 proc depExists(dependency: string, repo='/src/') {
   var repos = MASON_HOME + repo;
   var exists = false;
-  for dir in listdir(repos) {
+  for dir in listDir(repos) {
     if dir == dependency then
       exists = true;
   }
@@ -547,7 +547,7 @@ proc getDepToml(depName: string, depVersion: string) throws {
   for registry in MASON_CACHED_REGISTRY {
     const searchDir = registry + "/Bricks/";
 
-    for dir in listdir(searchDir, files=false, dirs=true) {
+    for dir in listDir(searchDir, files=false, dirs=true) {
       const name = dir.replace("/", "");
       if pattern.search(name) {
         const ver = findLatest(searchDir + dir);
@@ -582,7 +582,7 @@ proc findLatest(packageDir: string): VersionInfo {
   var ret = new VersionInfo(0, 0, 0);
   const suffix = ".toml";
   const packageName = basename(packageDir);
-  for manifest in listdir(packageDir, files=true, dirs=false) {
+  for manifest in listDir(packageDir, files=true, dirs=false) {
     // Check that it is a valid TOML file
     if !manifest.endsWith(suffix) {
       var warningStr = "File without '.toml' extension encountered - skipping ";


### PR DESCRIPTION
Deprecate walkdirs, listdir, getUID and getGID in favor of walkDirs,
listDir, getUid, and getGid. Add a deprecation test.

Update Mason and tests to use the new names to avoid
deprecation warnings.