### PR TITLE
More minor test fixes: writeln and path deprecations

### DIFF
--- a/test/functions/vass/declaredGenericReturnTuple.bad
+++ b/test/functions/vass/declaredGenericReturnTuple.bad
@@ -6,9 +6,9 @@ $CHPL_HOME/modules/standard/ChapelIO.chpl:624: note: '<temporary>' has generic t
 $CHPL_HOME/modules/standard/ChapelIO.chpl:624: note: cannot find initialization point to split-init this variable
 $CHPL_HOME/modules/standard/ChapelIO.chpl:624: note: '<temporary>' is used here before it is initialized
   $CHPL_HOME/modules/standard/ChapelIO.chpl:579: called as 1*VectorListElement._readWriteHelper(f: fileWriter(dynamic,false)) from method 'writeThis'
-  $CHPL_HOME/modules/standard/IO.chpl:3901: called as 1*VectorListElement.writeThis(f: fileWriter(dynamic,false)) from function '_write_one_internal'
-  $CHPL_HOME/modules/standard/IO.chpl:3711: called as _write_one_internal(_channel_internal: qio_channel_ptr_t, param kind = 0: iokind, x: 1*VectorListElement, loc: locale) from method '_writeOne'
-  $CHPL_HOME/modules/standard/IO.chpl:5266: called as (fileWriter(dynamic,true))._writeOne(param kind = 0: iokind, x: 1*VectorListElement, loc: locale) from method 'write'
-  $CHPL_HOME/modules/standard/IO.chpl:5321: called as (fileWriter(dynamic,true)).write(args(0): 1*VectorListElement, args(1): ioNewline) from method 'writeln'
-  $CHPL_HOME/modules/standard/ChapelIO.chpl:719: called as (fileWriter(dynamic,true)).writeln(args(0): 1*VectorListElement) from function 'writeln'
+  $CHPL_HOME/modules/standard/IO.chpl:3917: called as 1*VectorListElement.writeThis(f: fileWriter(dynamic,false)) from function '_write_one_internal'
+  $CHPL_HOME/modules/standard/IO.chpl:3727: called as _write_one_internal(_channel_internal: qio_channel_ptr_t, param kind = 0: iokind, x: 1*VectorListElement, loc: locale) from method '_writeOne'
+  $CHPL_HOME/modules/standard/IO.chpl:5320: called as (fileWriter(dynamic,true))._writeOne(param kind = 0: iokind, x: 1*VectorListElement, loc: locale) from method '_write'
+  $CHPL_HOME/modules/standard/IO.chpl:5407: called as (fileWriter(dynamic,true))._write(args(0): 1*VectorListElement, args(1): ioNewline) from method '_writeln'
+  $CHPL_HOME/modules/standard/ChapelIO.chpl:719: called as (fileWriter(dynamic,true))._writeln(args(0): 1*VectorListElement) from function 'writeln'
   declaredGenericReturnTuple.chpl:12: called as writeln(args(0): 1*VectorListElement)

--- a/test/library/standard/IO/filePath/basic.prediff
+++ b/test/library/standard/IO/filePath/basic.prediff
@@ -9,4 +9,9 @@ tmptmp=`mktemp "tmp.XXXXXX"`
 regex="s~$CHPL_HOME~{CHPL_HOME}~g"
 sed -e "$regex" $tmpfile > $tmptmp
 
+# also use realpath to work with absolute paths
+realhome=`realpath $CHPL_HOME`
+regex="s~$realhome~{CHPL_HOME}~g"
+sed -e "$regex" $tmpfile > $tmptmp
+
 mv $tmptmp $tmpfile


### PR DESCRIPTION
Fixes a couple of test failures caused by: https://github.com/chapel-lang/chapel/pull/20769 and https://github.com/chapel-lang/chapel/pull/20508

`test/deprecated/IO/filepath.prediff` was updated to also check for the absolute `$CHPL_HOME` path in the output. This file is used by several tests.

`functions/vass/declaredGenericReturnTuple.bad` was updated to correctly reference `ch._write` instead of `ch.write`.