### PR TITLE
fixed some missing ch.write->ch._write's in mason source

### DIFF
--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -351,7 +351,7 @@ proc printAvailableExamples() {
     writeln("--------------------------");
   }
   catch e: MasonError {
-    stderr.writeln(e.message());
+    stderr._writeln(e.message());
     exit(1);
   }
 }

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -517,7 +517,7 @@ proc testFile(file, ref result, show: bool) throws {
   const compilation = runWithStatus(compCommand, !show);
 
   if compilation != 0 {
-    stderr.writeln("compilation failed for " + fileName);
+    stderr._writeln("compilation failed for " + fileName);
     const errMsg = fileName +" failed to compile";
     result.addError(executable, fileName,  errMsg);
   }


### PR DESCRIPTION
After https://github.com/chapel-lang/chapel/pull/20508, `mason build` was throwing a couple of deprecation warnings. This PR removes them.

