### PR TITLE
Arkouda gpu testing

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2564,6 +2564,13 @@ void runClang(const char* just_parse_filename) {
       std::string genHeaderFilename;
       genHeaderFilename = genIntermediateFilename("command-line-includes.h");
       FILE* fp =  openfile(genHeaderFilename.c_str(), "w");
+      if(usingGpuLocaleModel()) {
+        // In some version of the CUDA headers they end up redefining
+        // __noinline__, which is used as an attribute in gcc. This was
+        // causing us to fail to compile Arkouda and so we undef it
+        // here as a workaround
+        fprintf(fp, "#undef __noinline__\n");
+      }
 
       int filenum = 0;
       while (const char* inputFilename = nthFilename(filenum++)) {

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -6,7 +6,6 @@
 ARKOUDA_URL=${ARKOUDA_URL:-https://github.com/Bears-R-Us/arkouda.git}
 ARKOUDA_BRANCH=${ARKOUDA_BRANCH:-master}
 
-export CHPL_TEST_ARKOUDA_DISABLE_MODULES=${CHPL_TEST_ARKOUDA_DISABLE_MODULES:- }
 export CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD=${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD:-"false"}
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
@@ -47,7 +46,7 @@ if [ -n "${CHPL_TEST_ARKOUDA_DISABLE_MODULES}" ] ; then
   IFS=":"
   for mod in $CHPL_TEST_ARKOUDA_DISABLE_MODULES; do
     cmd="s/^\s*$mod/#$mod/g"
-    sed -i $cmd ServerModules.cfg
+    sed -i'' -e $cmd ServerModules.cfg
   done
   unset IFS
 fi

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -6,7 +6,7 @@
 ARKOUDA_URL=${ARKOUDA_URL:-https://github.com/Bears-R-Us/arkouda.git}
 ARKOUDA_BRANCH=${ARKOUDA_BRANCH:-master}
 
-export CHPL_TEST_ARKOUDA_DISABLE_MODELS=${CHPL_TEST_ARKOUDA_DISABLE_MODELS:- }
+export CHPL_TEST_ARKOUDA_DISABLE_MODULES=${CHPL_TEST_ARKOUDA_DISABLE_MODULES:- }
 export CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD=${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD:-"false"}
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
@@ -41,11 +41,11 @@ else
   export "PATH=${ARKOUDA_HOME}/dep/hdf5-install/bin:$PATH"
 fi
 
-# CHPL_TEST_ARKOUDA_DISABLE_MODELS is a colon separated list of modules to
+# CHPL_TEST_ARKOUDA_DISABLE_MODULES is a colon separated list of modules to
 # disable.  Disable these modules by commenting them out in ServerModules.cfg
-if [ ! -z "${CHPL_TEST_ARKOUDA_DISABLE_MODELS+x}" ] ; then
+if [ ! -z "${CHPL_TEST_ARKOUDA_DISABLE_MODULES+x}" ] ; then
   IFS=":"
-  for mod in $CHPL_TEST_ARKOUDA_DISABLE_MODELS; do
+  for mod in $CHPL_TEST_ARKOUDA_DISABLE_MODULES; do
     cmd="s/^\s*$mod/#$mod/g"
     sed -i $cmd ServerModules.cfg
   done

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -6,6 +6,9 @@
 ARKOUDA_URL=${ARKOUDA_URL:-https://github.com/Bears-R-Us/arkouda.git}
 ARKOUDA_BRANCH=${ARKOUDA_BRANCH:-master}
 
+export CHPL_TEST_ARKOUDA_DISABLE_MODELS=${CHPL_TEST_ARKOUDA_DISABLE_MODELS:- }
+export CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD=${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD:-"false"}
+
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/functions.bash
 
@@ -38,6 +41,17 @@ else
   export "PATH=${ARKOUDA_HOME}/dep/hdf5-install/bin:$PATH"
 fi
 
+# CHPL_TEST_ARKOUDA_DISABLE_MODELS is a colon separated list of modules to
+# disable.  Disable these modules by commenting them out in ServerModules.cfg
+if [ ! -z "${CHPL_TEST_ARKOUDA_DISABLE_MODELS+x}" ] ; then
+  IFS=":"
+  for mod in $CHPL_TEST_ARKOUDA_DISABLE_MODELS; do
+    cmd="s/^\s*$mod/#$mod/g"
+    sed -i $cmd ServerModules.cfg
+  done
+  unset IFS
+fi
+
 # Compile Arkouda
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
   PERF_SUB_DIR="$CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION"
@@ -60,63 +74,65 @@ else
   fi
 fi
 
-# Install Arkouda and python dependencies to a python-deps subdir
-export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
-# If Arkouda deps use any of our test deps, try to use the versions we want
-AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
-if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user ; then
-  log_fatal_error "installing arkouda"
-fi
-
-# Check installation
-test_start "make check"
-if make check ; then
-  log_success "make check output"
-else
-  log_fatal_error "running make check"
-fi
-test_end
-
-# Run Python unit tests
-test_start "make test-python"
-if make test-python ; then
-  log_success "make test-python output"
-else
-  log_error "running make test-python"
-fi
-test_end
-
-# Run benchmarks
-if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-  benchmark_opts="--gen-graphs --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
-
-  benchmark_opts="${benchmark_opts} --annotations $CHPL_HOME/test/ANNOTATIONS.yaml"
-  if [[ -n $CHPL_TEST_PERF_DESCRIPTION ]]; then
-    benchmark_opts="${benchmark_opts} --description $CHPL_TEST_PERF_DESCRIPTION"
-  fi
-  if [[ -n $CHPL_TEST_PERF_CONFIG_NAME ]]; then
-    benchmark_opts="${benchmark_opts} --platform $CHPL_TEST_PERF_CONFIG_NAME"
-  fi
-  if [[ -n $CHPL_TEST_NUM_TRIALS ]]; then
-    benchmark_opts="${benchmark_opts} --numtrials $CHPL_TEST_NUM_TRIALS"
-  fi
-  if [[ -n $CHPL_TEST_PERF_START_DATE ]]; then
-    benchmark_opts="${benchmark_opts} --start-date $CHPL_TEST_PERF_START_DATE"
-  fi
-  if [[ -n $CHPL_TEST_PERF_CONFIGS ]]; then
-    benchmark_opts="${benchmark_opts} --configs $CHPL_TEST_PERF_CONFIGS"
-  fi
-  if [[ -n $CHPL_TEST_ARKOUDA_BENCHMARKS ]]; then
-    benchmark_opts="${benchmark_opts} $CHPL_TEST_ARKOUDA_BENCHMARKS"
+if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
+  # Install Arkouda and python dependencies to a python-deps subdir
+  export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
+  # If Arkouda deps use any of our test deps, try to use the versions we want
+  AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
+  if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user ; then
+    log_fatal_error "installing arkouda"
   fi
 
-  test_start "benchmarks"
-  if ./benchmarks/run_benchmarks.py ${benchmark_opts} ; then
-    log_success "benchmark output"
+  # Check installation
+  test_start "make check"
+  if make check ; then
+    log_success "make check output"
   else
-    log_error "running benchmarks"
+    log_fatal_error "running make check"
   fi
   test_end
+
+  # Run Python unit tests
+  test_start "make test-python"
+  if make test-python ; then
+    log_success "make test-python output"
+  else
+    log_error "running make test-python"
+  fi
+  test_end
+
+  # Run benchmarks
+  if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
+    benchmark_opts="--gen-graphs --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
+
+    benchmark_opts="${benchmark_opts} --annotations $CHPL_HOME/test/ANNOTATIONS.yaml"
+    if [[ -n $CHPL_TEST_PERF_DESCRIPTION ]]; then
+      benchmark_opts="${benchmark_opts} --description $CHPL_TEST_PERF_DESCRIPTION"
+    fi
+    if [[ -n $CHPL_TEST_PERF_CONFIG_NAME ]]; then
+      benchmark_opts="${benchmark_opts} --platform $CHPL_TEST_PERF_CONFIG_NAME"
+    fi
+    if [[ -n $CHPL_TEST_NUM_TRIALS ]]; then
+      benchmark_opts="${benchmark_opts} --numtrials $CHPL_TEST_NUM_TRIALS"
+    fi
+    if [[ -n $CHPL_TEST_PERF_START_DATE ]]; then
+      benchmark_opts="${benchmark_opts} --start-date $CHPL_TEST_PERF_START_DATE"
+    fi
+    if [[ -n $CHPL_TEST_PERF_CONFIGS ]]; then
+      benchmark_opts="${benchmark_opts} --configs $CHPL_TEST_PERF_CONFIGS"
+    fi
+    if [[ -n $CHPL_TEST_ARKOUDA_BENCHMARKS ]]; then
+      benchmark_opts="${benchmark_opts} $CHPL_TEST_ARKOUDA_BENCHMARKS"
+    fi
+
+    test_start "benchmarks"
+    if ./benchmarks/run_benchmarks.py ${benchmark_opts} ; then
+      log_success "benchmark output"
+    else
+      log_error "running benchmarks"
+    fi
+    test_end
+  fi
 fi
 
 subtest_end

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -43,7 +43,7 @@ fi
 
 # CHPL_TEST_ARKOUDA_DISABLE_MODULES is a colon separated list of modules to
 # disable.  Disable these modules by commenting them out in ServerModules.cfg
-if [ ! -z "${CHPL_TEST_ARKOUDA_DISABLE_MODULES+x}" ] ; then
+if [ -n "${CHPL_TEST_ARKOUDA_DISABLE_MODULES}" ] ; then
   IFS=":"
   for mod in $CHPL_TEST_ARKOUDA_DISABLE_MODULES; do
     cmd="s/^\s*$mod/#$mod/g"

--- a/util/cron/test-cray-xc-gpu-arkouda.bash
+++ b/util/cron/test-cray-xc-gpu-arkouda.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Run arkouda testing on a cray-cs with HDR IB
+# Build Arkouda on a cray-xc with GPU locale model
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-native-gpu.bash
@@ -11,7 +11,6 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-xc-gpu-arkouda"
 # setup arkouda
 export CHPL_TEST_ARKOUDA_PERF=false
 source $CWD/common-arkouda.bash
-export ARKOUDA_NUMLOCALES=16
 
 # List of Arkouda server modules we exempt from testing (that goal is to
 # eventually have this be an empty list).

--- a/util/cron/test-cray-xc-gpu-arkouda.bash
+++ b/util/cron/test-cray-xc-gpu-arkouda.bash
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Run arkouda testing on a cray-cs with HDR IB
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-native-gpu.bash
+export CHPL_COMM=none
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-xc-gpu-arkouda"
+
+# setup arkouda
+export CHPL_TEST_ARKOUDA_PERF=false
+source $CWD/common-arkouda.bash
+export ARKOUDA_NUMLOCALES=16
+
+# List of Arkouda server modules we exempt from testing (that goal is to
+# eventually have this be an empty list).
+export CHPL_TEST_ARKOUDA_DISABLE_MODELS=ArraySetopsMsg:KExtremeMsg:ArgSortMsg:SegmentedMsg:DataFrameIndexingMsg:UniqueMsg:In1dMsg:SortMsg:ReductionMsg:EfuncMsg:HDF5Msg:EncodingMsg
+export CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD="true"
+
+module list
+
+# setup for CS perf (gasnet-large, gnu, 128-core Rome)
+source $CWD/common-cray-cs.bash
+export CHPL_LAUNCHER_PARTITION=rome64Share
+export CHPL_TARGET_CPU=none
+
+module list
+
+export GASNET_PHYSMEM_MAX="9/10"
+nightly_args="${nightly_args} -no-buildcheck"
+
+test_nightly
+sync_graphs

--- a/util/cron/test-cray-xc-gpu-arkouda.bash
+++ b/util/cron/test-cray-xc-gpu-arkouda.bash
@@ -15,20 +15,10 @@ export ARKOUDA_NUMLOCALES=16
 
 # List of Arkouda server modules we exempt from testing (that goal is to
 # eventually have this be an empty list).
-export CHPL_TEST_ARKOUDA_DISABLE_MODELS=ArraySetopsMsg:KExtremeMsg:ArgSortMsg:SegmentedMsg:DataFrameIndexingMsg:UniqueMsg:In1dMsg:SortMsg:ReductionMsg:EfuncMsg:HDF5Msg:EncodingMsg
+export CHPL_TEST_ARKOUDA_DISABLE_MODULES=ArraySetopsMsg:KExtremeMsg:ArgSortMsg:SegmentedMsg:DataFrameIndexingMsg:UniqueMsg:In1dMsg:SortMsg:ReductionMsg:EfuncMsg:HDF5Msg:EncodingMsg
 export CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD="true"
 
 module list
-
-# setup for CS perf (gasnet-large, gnu, 128-core Rome)
-source $CWD/common-cray-cs.bash
-export CHPL_LAUNCHER_PARTITION=rome64Share
-export CHPL_TARGET_CPU=none
-
-module list
-
-export GASNET_PHYSMEM_MAX="9/10"
 nightly_args="${nightly_args} -no-buildcheck"
 
 test_nightly
-sync_graphs


### PR DESCRIPTION
This PR is meant to set up nightly testing for building Arkouda with `CHPL_LOCALE_MODEL=gpu`.

Why do this?

* Despite the fact that Arkouda (currently) isn't using the GPU sublocale we still attempt to gpuize eligible loops, Arkouda in an important application with many such loops, and we've already found bugs by trying to compile it in this mode.
* We have users that are attempting to use Chapel GPU support with Arkouda and they're running into issues. As we resolve issues on our end we want to lock down that they don't later "regress".

Note that this nightly test will filter out modules we currently know will not build under this mode (our intent is to remove modules from this list over time). The test will build Arkouda but doesn't perform any correctness test from there (mostly because some of these would fail due to a lack of having all modules compiled).

---

As far as what specific changes are in this PR:

* I have the compiler add `#undef __noinline__` to `command-line-includes.h`
  * For whatever reason the CUDA headers on the XC we're running this on end up redefining `__noinline__`, which is used by an Arkouda header elsewhere and this causes ussues.

Changes made to the `sub_test` file in `studies/arkouda` include:

* Using the enviornment variable $CHPL_TEST_ARKOUDA_DISABLE_MODULES to selectively comment out modules in ServerModules.cfg
* If the environment variable $CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD is set to anything other than false than we will not do For whatever reason the diff renders a little funny but the main thing is that from line 63 on (in the original file) is basically just embedding the existing content into a block like this:

```bash
if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
...
fi
```

I introduce a file `test-cray-xc-gpu-arkouda.bash`, which should be the main nightly "test" I want to run. I will have to make corresponding changes in our `ci-config` repository to get this integrated into our testing infrastructure.

---

Pinging the following people for possible comments/review:

@bmcdonald3: Since this touches on Arkouda: you may want to take a quick look at `sub_test` to make sure I haven't introduced anything that would accidentally break normal Arkouda testing (I don't believe I have but always good to have a second pair of eyes). Or let me know if there's a better way to filter out these modules for this test.

@bhavanijayakumaran and @ronawho: I may have to ask for help from one (or both) of you with how to get things set up on the Jenkins side of things. There's a specific machine I intend to have these run on (which is not the same machine we're running other GPU testing on). I've also mostly speculated on what I think `test-cray-xc-gpu-arkouda.bash` should contain (based off of what I see in other `arkouda` test scripts). I'm not sure there's any easy way for me to test this ahead of time beyond just trying it out in Jenkins and hoping for the best.