### PR TITLE
dyno: Improve finding of modules under --dyno

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -841,41 +841,6 @@ ModuleSymbol* buildModule(const char* name,
   return mod;
 }
 
-BlockStmt* buildIncludeModule(const char* name,
-                              bool priv,
-                              bool prototype) {
-  astlocT loc(chplLineno, yyfilename);
-  ModuleSymbol* mod = parseIncludedSubmodule(name);
-  INT_ASSERT(mod != NULL);
-
-  // check visibility specifiers
-  //
-  //  include public/default   +  declaration public/default -> OK, public
-  //  include public/default   +  declaration private        -> error
-  //  include private          +  declaration public/default -> OK, private
-  //  include private          +  declaration private        -> OK, private
-  //
-  if (priv && !mod->hasFlag(FLAG_PRIVATE)) {
-    // make the module private (override public)
-    mod->addFlag(FLAG_PRIVATE);
-  } else if (mod->hasFlag(FLAG_PRIVATE) && !priv) {
-    USR_FATAL_CONT(loc,
-          "cannot make a private module public through an include statement");
-    USR_PRINT(mod, "module declared private here");
-  }
-
-  if (prototype) {
-    USR_FATAL_CONT(loc, "cannot apply prototype to module in include statement");
-    USR_PRINT(mod, "put prototype keyword at module declaration here");
-  }
-
-  if (fWarnUnstable && mod->modTag == MOD_USER) {
-    USR_WARN(loc, "module include statements are not yet stable and may change");
-  }
-
-  return buildChapelStmt(new DefExpr(mod));
-}
-
 CallExpr* buildPrimitiveExpr(CallExpr* exprs) {
   INT_ASSERT(exprs->isPrimitive(PRIM_ACTUALS_LIST));
   if (exprs->argList.length == 0)

--- a/compiler/include/build.h
+++ b/compiler/include/build.h
@@ -109,9 +109,6 @@ ModuleSymbol* buildModule(const char* name,
                           const char* filename,
                           bool        priv,
                           bool        prototype);
-BlockStmt* buildIncludeModule(const char* name,
-                              bool priv,
-                              bool prototype);
 
 CallExpr* buildPrimitiveExpr(CallExpr* exprs);
 

--- a/compiler/include/parser.h
+++ b/compiler/include/parser.h
@@ -56,11 +56,6 @@ void               addFlagModulePath(const char* newpath);
 void               addModuleToParseList(const char* name,
                                         VisibilityStmt* newUse);
 
-// The new parser does not rely on yyfilename to set locations, so passing
-// in the submodule path allows for overriding that behavior.
-ModuleSymbol*      parseIncludedSubmodule(const char* name,
-                                          const char* path=yyfilename);
-
 void noteParsedIncludedModule(ModuleSymbol* mod, const char* path);
 
 #endif

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -1036,60 +1036,6 @@ static void addModuleToDoneList(ModuleSymbol* module) {
 ************************************** | *************************************/
 
 
-ModuleSymbol* parseIncludedSubmodule(const char* name, const char* path) {
-  // save parser global variables to restore after parsing the submodule
-  BlockStmt*  s_yyblock = yyblock;
-  const char* s_yyfilename = yyfilename;
-  int         s_yystartlineno = yystartlineno;
-  ModTag      s_currentModuleType = currentModuleType;
-  const char* s_currentModuleName = currentModuleName;
-  int         s_chplLineno = chplLineno;
-  bool        s_chplParseString = chplParseString;
-  const char* s_chplParseStringMsg = chplParseStringMsg;
-
-  std::string curPath = path;
-
-  // compute the path of the file to include
-  size_t lastDot = curPath.rfind(".");
-  INT_ASSERT(lastDot < curPath.size());
-  std::string noDot = curPath.substr(0, lastDot);
-  std::string includeFile = noDot + "/" + name + ".chpl";
-
-  const char* modNameFromFile = filenameToModulename(curPath.c_str());
-  if (0 != strcmp(modNameFromFile, currentModuleName)) {
-    UnresolvedSymExpr* dummy = new UnresolvedSymExpr("module");
-    USR_FATAL(dummy, "Cannot include modules from a module whose name doesn't match its filename");
-  }
-
-  ModuleSymbol* ret = nullptr;
-  const bool namedOnCommandLine = false;
-
-  ret = parseFile(astr(includeFile), currentModuleType,
-                  namedOnCommandLine);
-  INT_ASSERT(ret);
-
-  ret->addFlag(FLAG_INCLUDED_MODULE);
-
-  // restore parser global variables
-  yyblock = s_yyblock;
-  yyfilename = s_yyfilename;
-  yystartlineno = s_yystartlineno;
-  currentModuleType = s_currentModuleType;
-  currentModuleName = s_currentModuleName;
-  chplLineno = s_chplLineno;
-  chplParseString = s_chplParseString;
-  chplParseStringMsg = s_chplParseStringMsg;
-
-  return ret;
-}
-
-/************************************* | **************************************
-*                                                                             *
-*                                                                             *
-*                                                                             *
-************************************** | *************************************/
-
-
 static const char* stdModNameToPath(const char* modName,
                                     bool*       isStandard) {
   const char* usrPath = searchThePath(modName, false, sUsrModPath);

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -405,6 +405,16 @@ static void parseCommandLineFiles() {
   while ((inputFileName = nthFilename(fileNum++))) {
     if (isChplSource(inputFileName))
     {
+      auto path = chpl::UniqueString::get(gContext, inputFileName);
+      chpl::UniqueString emptySymbolPath;
+      chpl::parsing::parseFileToBuilderResult(gContext, path, emptySymbolPath);
+    }
+  }
+
+  fileNum = 0;
+  while ((inputFileName = nthFilename(fileNum++))) {
+    if (isChplSource(inputFileName))
+    {
       parseChplSourceFile(inputFileName);
     }
   }


### PR DESCRIPTION
This PR addresses two issues with ``--dyno`` testing that resulted in failures to find a ``use``'d module.

The first error occurred with files listed on the command line. If an earlier file referenced a module in a later file, the compiler was unable to find this under ``--dyno``. The cause of this failure was dyno attempting to parse and run convert-uast (thereby resolving ``use`` statements under ``--dyno``) one file at a time. The solution is to parse all of the files listed on the command line before running convert-uast.

The second error was that ``--dyno`` was unable to handle ``require`` statements. This PR addresses this issue by resolving ``require`` statements during the scope-resolution stage in which we also resolve ``use`` and ``import`` statements.

Testing:
- [x] local
- [x] --dyno (222 failures)