### PR TITLE
Tidy up dyno C++ tests

### DIFF
--- a/frontend/CMakeLists.txt
+++ b/frontend/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 # message(DEBUG "CHPL_LLVM_LINK_ARGS: ${CHPL_LLVM_LINK_ARGS}")
 
 # Don't pass through jemalloc for the time being.
-string(REPLACE "-ljemalloc" "" CHPL_LLVM_LINK_ARGS ${CHPL_LLVM_LINK_ARGS})
+string(REPLACE "-ljemalloc" "" CHPL_LLVM_LINK_ARGS "${CHPL_LLVM_LINK_ARGS}")
 
 
 set(CHPL_MAIN_SRC_DIR     ${CMAKE_CURRENT_SOURCE_DIR})

--- a/frontend/test/CMakeLists.txt
+++ b/frontend/test/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # define target for the common code for all dyno tests
-add_library(tests-common OBJECT common.cpp)
+add_library(tests-common OBJECT test-parsing.cpp test-resolution.cpp)
 target_link_libraries(tests-common libdyno)
 
 add_custom_target(tests)

--- a/frontend/test/framework/testDependencies.cpp
+++ b/frontend/test/framework/testDependencies.cpp
@@ -17,15 +17,11 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/framework/Context.h"
 #include "chpl/framework/query-impl.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <cstdlib>
 
 using namespace chpl;

--- a/frontend/test/framework/testIds.cpp
+++ b/frontend/test/framework/testIds.cpp
@@ -17,16 +17,12 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/framework/Context.h"
 #include "chpl/framework/ID.h"
 #include "chpl/framework/UniqueString.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <cstdlib>
 
 using namespace chpl;

--- a/frontend/test/framework/testRecursionFails.cpp
+++ b/frontend/test/framework/testRecursionFails.cpp
@@ -17,15 +17,11 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/framework/Context.h"
 #include "chpl/framework/query-impl.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <cstdlib>
 
 using namespace chpl;

--- a/frontend/test/framework/testUniqueString.cpp
+++ b/frontend/test/framework/testUniqueString.cpp
@@ -17,21 +17,17 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/framework/Context.h"
 #include "chpl/framework/UniqueString.h"
 #include "chpl/framework/global-strings.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 
 #include <chrono>
 #include <fstream>
 #include <sstream>
 #include <string>
 #include <iostream>
-#include <cassert>
 
 using namespace chpl;
 

--- a/frontend/test/parsing/testParse.cpp
+++ b/frontend/test/parsing/testParse.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -31,17 +33,6 @@
 #include "chpl/uast/OpCall.h"
 #include "chpl/uast/PrimCall.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl", "");

--- a/frontend/test/parsing/testParseAggregate.cpp
+++ b/frontend/test/parsing/testParseAggregate.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/Class.h"
@@ -28,17 +30,6 @@
 #include "chpl/uast/StringLiteral.h"
 #include "chpl/uast/Union.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static BuilderResult parseAggregate(Parser* parser,
                                     const AggregateDecl*& agg,

--- a/frontend/test/parsing/testParseArrayDomainRange.cpp
+++ b/frontend/test/parsing/testParseArrayDomainRange.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/uast/Array.h"
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/Block.h"
@@ -30,17 +32,6 @@
 #include "chpl/uast/Variable.h"
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void testRange(Parser* parser, const char* testName,
                       const char* intervalStr,

--- a/frontend/test/parsing/testParseAttributes.cpp
+++ b/frontend/test/parsing/testParseAttributes.cpp
@@ -17,20 +17,11 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/all-uast.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static bool areAttributesEqual(const Decl* lhs, const Decl* rhs) {
   auto lhsAttr = lhs->attributes();

--- a/frontend/test/parsing/testParseBegin.cpp
+++ b/frontend/test/parsing/testParseBegin.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -26,17 +28,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/TaskVar.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseBracketLoop.cpp
+++ b/frontend/test/parsing/testParseBracketLoop.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -29,17 +31,7 @@
 #include "chpl/uast/WithClause.h"
 #include "chpl/uast/Zip.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseChecks.cpp
+++ b/frontend/test/parsing/testParseChecks.cpp
@@ -17,23 +17,15 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/framework/compiler-configuration.h"
 #include "chpl/framework/CompilerFlags.h"
 #include "chpl/framework/Context.h"
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/uast/all-uast.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static std::string
 buildErrorStr(const char* file, int line, const char* msg) {

--- a/frontend/test/parsing/testParseCobegin.cpp
+++ b/frontend/test/parsing/testParseCobegin.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -26,17 +28,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/TaskVar.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseCoforall.cpp
+++ b/frontend/test/parsing/testParseCoforall.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -28,17 +30,7 @@
 #include "chpl/uast/WithClause.h"
 #include "chpl/uast/Zip.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseComments.cpp
+++ b/frontend/test/parsing/testParseComments.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/Block.h"
 #include "chpl/uast/Comment.h"
@@ -25,17 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseConditional.cpp
+++ b/frontend/test/parsing/testParseConditional.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -32,17 +34,7 @@
 #include "chpl/uast/WithClause.h"
 #include "chpl/uast/Zip.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseDefer.cpp
+++ b/frontend/test/parsing/testParseDefer.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -25,17 +27,6 @@
 #include "chpl/uast/Defer.h"
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseDelete.cpp
+++ b/frontend/test/parsing/testParseDelete.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -24,17 +26,6 @@
 #include "chpl/uast/Delete.h"
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseDoWhile.cpp
+++ b/frontend/test/parsing/testParseDoWhile.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -27,17 +29,7 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseEmptyStmt.cpp
+++ b/frontend/test/parsing/testParseEmptyStmt.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/Identifier.h"
@@ -26,17 +28,6 @@
 #include "chpl/uast/While.h"
 #include "chpl/uast/BoolLiteral.h"
 #include "chpl/uast/Cobegin.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseEnums.cpp
+++ b/frontend/test/parsing/testParseEnums.cpp
@@ -17,23 +17,14 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/Enum.h"
 #include "chpl/uast/EnumElement.h"
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test1(Parser* parser) {
   auto parseResult = parser->parseString("test1.chpl",

--- a/frontend/test/parsing/testParseFor.cpp
+++ b/frontend/test/parsing/testParseFor.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -25,17 +27,7 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseForall.cpp
+++ b/frontend/test/parsing/testParseForall.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -28,17 +30,7 @@
 #include "chpl/uast/WithClause.h"
 #include "chpl/uast/Zip.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseForeach.cpp
+++ b/frontend/test/parsing/testParseForeach.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -28,17 +30,7 @@
 #include "chpl/uast/WithClause.h"
 #include "chpl/uast/Zip.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseForwardingDecl.cpp
+++ b/frontend/test/parsing/testParseForwardingDecl.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/Begin.h"
@@ -28,18 +30,6 @@
 #include "chpl/uast/ForwardingDecl.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/VisibilityClause.h"
-
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
 

--- a/frontend/test/parsing/testParseFunctions.cpp
+++ b/frontend/test/parsing/testParseFunctions.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -27,17 +29,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/OpCall.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test1(Parser* parser) {
   auto parseResult = parser->parseString("test1.chpl",

--- a/frontend/test/parsing/testParseImport.cpp
+++ b/frontend/test/parsing/testParseImport.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/As.h"
@@ -30,17 +32,7 @@
 #include "chpl/uast/VisibilityClause.h"
 #include "chpl/uast/Variable.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseInclude.cpp
+++ b/frontend/test/parsing/testParseInclude.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -26,17 +28,6 @@
 #include "chpl/uast/Include.h"
 #include "chpl/uast/Local.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseInterface.cpp
+++ b/frontend/test/parsing/testParseInterface.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/Comment.h"
@@ -24,18 +26,6 @@
 #include "chpl/uast/Implements.h"
 #include "chpl/uast/Module.h"
 #include "chpl/framework/Context.h"
-
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseLabelContinueBreak.cpp
+++ b/frontend/test/parsing/testParseLabelContinueBreak.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -30,17 +32,7 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/While.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseLocal.cpp
+++ b/frontend/test/parsing/testParseLocal.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -25,17 +27,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Local.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseModuleInclude.cpp
+++ b/frontend/test/parsing/testParseModuleInclude.cpp
@@ -20,8 +20,6 @@
 #include "test-parsing.h"
 
 #include "chpl/parsing/parsing-queries.h"
-//#include "chpl/resolution/resolution-queries.h"
-//#include "chpl/resolution/scope-queries.h"
 #include "chpl/uast/Include.h"
 #include "chpl/uast/Module.h"
 

--- a/frontend/test/parsing/testParseModuleInclude.cpp
+++ b/frontend/test/parsing/testParseModuleInclude.cpp
@@ -17,23 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/parsing-queries.h"
-#include "chpl/resolution/resolution-queries.h"
-#include "chpl/resolution/scope-queries.h"
+//#include "chpl/resolution/resolution-queries.h"
+//#include "chpl/resolution/scope-queries.h"
 #include "chpl/uast/Include.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace uast;
 
 static void test1() {
   printf("test1\n");

--- a/frontend/test/parsing/testParseModules.cpp
+++ b/frontend/test/parsing/testParseModules.cpp
@@ -17,21 +17,12 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseMultiVar.cpp
+++ b/frontend/test/parsing/testParseMultiVar.cpp
@@ -17,22 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/MultiDecl.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test1(Parser* parser) {
   auto parseResult = parser->parseString("test1.chpl", "var x, y;");

--- a/frontend/test/parsing/testParseNew.cpp
+++ b/frontend/test/parsing/testParseNew.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -28,17 +30,7 @@
 #include "chpl/uast/OpCall.h"
 #include "chpl/uast/Variable.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseNumericLiterals.cpp
+++ b/frontend/test/parsing/testParseNumericLiterals.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/ImagLiteral.h"
@@ -25,17 +27,6 @@
 #include "chpl/uast/RealLiteral.h"
 #include "chpl/uast/UintLiteral.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void testIntLiteral(Parser* parser,
                            const char* testname,

--- a/frontend/test/parsing/testParseOn.cpp
+++ b/frontend/test/parsing/testParseOn.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -25,17 +27,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/On.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseReturn.cpp
+++ b/frontend/test/parsing/testParseReturn.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -25,17 +27,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Return.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseSelect.cpp
+++ b/frontend/test/parsing/testParseSelect.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/framework/ErrorBase.h"
@@ -27,17 +29,7 @@
 #include "chpl/uast/Select.h"
 #include "chpl/uast/When.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseSerial.cpp
+++ b/frontend/test/parsing/testParseSerial.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -24,17 +26,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Serial.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseStringBytesLiterals.cpp
+++ b/frontend/test/parsing/testParseStringBytesLiterals.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/BytesLiteral.h"
@@ -24,17 +26,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/StringLiteral.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static uast::BuilderResult parseExprAsVarInit(Parser* parser,
                                               const std::string& testname,

--- a/frontend/test/parsing/testParseSync.cpp
+++ b/frontend/test/parsing/testParseSync.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/Begin.h"
@@ -26,18 +28,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Sync.h"
 #include "chpl/framework/Context.h"
-
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseTryCatchThrow.cpp
+++ b/frontend/test/parsing/testParseTryCatchThrow.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -27,17 +29,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Throw.h"
 #include "chpl/uast/Try.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseTupleVar.cpp
+++ b/frontend/test/parsing/testParseTupleVar.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/Identifier.h"
@@ -24,17 +26,6 @@
 #include "chpl/uast/MultiDecl.h"
 #include "chpl/uast/TupleDecl.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test1(Parser* parser) {
   auto parseResult = parser->parseString("test1.chpl", "var (x, y);");

--- a/frontend/test/parsing/testParseUse.cpp
+++ b/frontend/test/parsing/testParseUse.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/As.h"
@@ -30,17 +32,7 @@
 #include "chpl/uast/Variable.h"
 #include "chpl/uast/VisibilityClause.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseVariables.cpp
+++ b/frontend/test/parsing/testParseVariables.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -32,17 +34,6 @@
 #include "chpl/uast/PrimCall.h"
 #include "chpl/uast/StringLiteral.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test1(Parser* parser) {
   auto parseResult = parser->parseString("test1.chpl",

--- a/frontend/test/parsing/testParseWhile.cpp
+++ b/frontend/test/parsing/testParseWhile.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -25,17 +27,7 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/While.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <iostream>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParseYield.cpp
+++ b/frontend/test/parsing/testParseYield.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"
@@ -26,17 +28,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Yield.h"
 #include "chpl/uast/Try.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0(Parser* parser) {
   auto parseResult = parser->parseString("test0.chpl",

--- a/frontend/test/parsing/testParsingQueries.cpp
+++ b/frontend/test/parsing/testParsingQueries.cpp
@@ -17,22 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-parsing.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/uast/Comment.h"
 #include "chpl/uast/Function.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace uast;
-using namespace parsing;
 
 static void test0() {
   printf("test0\n");

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -17,20 +17,10 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/resolution/can-pass.h"
 #include "chpl/types/all-types.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static bool passesAsIs(CanPassResult r) {
   return r.passes() &&

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/types/BasicClassType.h"
@@ -29,19 +31,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static void test1() {
   printf("test1\n");

--- a/frontend/test/resolution/testDisambiguation.cpp
+++ b/frontend/test/resolution/testDisambiguation.cpp
@@ -17,23 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/uast/all-uast.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <string>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 struct GatherStuff {
   std::vector<const Function*> fns;

--- a/frontend/test/resolution/testEnums.cpp
+++ b/frontend/test/resolution/testEnums.cpp
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -24,9 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-#include <cassert>
 
 static void test1() {
   Context ctx;

--- a/frontend/test/resolution/testExprIf.cpp
+++ b/frontend/test/resolution/testExprIf.cpp
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -24,9 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-#include <cassert>
 
 static void test1() {
   Context ctx;

--- a/frontend/test/resolution/testFieldAccess.cpp
+++ b/frontend/test/resolution/testFieldAccess.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -25,20 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static void test1() {
   printf("test1\n");

--- a/frontend/test/resolution/testFindDecl.cpp
+++ b/frontend/test/resolution/testFindDecl.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/uast/AggregateDecl.h"
@@ -25,17 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace uast;
 
 // testing a simple variable declaration and subsequent identifier
 static void test1() {

--- a/frontend/test/resolution/testFunctionCalls.cpp
+++ b/frontend/test/resolution/testFunctionCalls.cpp
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -24,14 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 
 static void test1() {
   // make sure that function return type computation does not throw

--- a/frontend/test/resolution/testGenericDefaults.cpp
+++ b/frontend/test/resolution/testGenericDefaults.cpp
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -24,9 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-#include <cassert>
 
 static void test1() {
   Context ctx;

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/framework/query-impl.h"
 #include "chpl/resolution/resolution-queries.h"
@@ -24,18 +26,6 @@
 #include "chpl/uast/Call.h"
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace uast;
 
 static UniqueString nameForAst(const AstNode* ast) {
   UniqueString empty;

--- a/frontend/test/resolution/testLocation.cpp
+++ b/frontend/test/resolution/testLocation.cpp
@@ -17,24 +17,14 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/framework/ErrorWriter.h"
 #include "chpl/types/all-types.h"
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/uast/Comment.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace uast;
 
 static const Module* oneModule(const ModuleVec& vec) {
   assert(vec.size() == 1);

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
 #include "ResolvedVisitor.h"
 
 #include "chpl/parsing/parsing-queries.h"
@@ -29,22 +30,8 @@
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
 #include "chpl/uast/While.h"
-#include "common.h"
 
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <map>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static auto myiter = std::string(R""""(
 iter myiter() {

--- a/frontend/test/resolution/testMultiDecl.cpp
+++ b/frontend/test/resolution/testMultiDecl.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -25,20 +27,6 @@
 #include "chpl/uast/MultiDecl.h"
 #include "chpl/uast/TupleDecl.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static void test1() {
   printf("test1\n");

--- a/frontend/test/resolution/testOperatorOverloads.cpp
+++ b/frontend/test/resolution/testOperatorOverloads.cpp
@@ -17,14 +17,7 @@
  * limitations under the License.
  */
 
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
+#include "test-resolution.h"
 
 // basic definition tests with cast operator
 static void test1() {

--- a/frontend/test/resolution/testParamFolding.cpp
+++ b/frontend/test/resolution/testParamFolding.cpp
@@ -17,25 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 // error handler that causes the test to fail if it runs
 static void reportError(Context* context, const ErrorBase* err) {

--- a/frontend/test/resolution/testParamIf.cpp
+++ b/frontend/test/resolution/testParamIf.cpp
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -24,9 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-#include <cassert>
 
 static void test1() {
   Context ctx;

--- a/frontend/test/resolution/testParams.cpp
+++ b/frontend/test/resolution/testParams.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/types/ComplexType.h"
@@ -24,19 +26,6 @@
 #include "chpl/types/Param.h"
 #include "chpl/types/RealType.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace uast;
-using namespace types;
 
 static QualifiedType getTypeForFirstStmt(Context* context,
                                          const std::string& program) {

--- a/frontend/test/resolution/testPoi.cpp
+++ b/frontend/test/resolution/testPoi.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -25,18 +27,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace uast;
 
 // test showing point-of-instantiation behavior
 // This test has a function 'helper' that is only available

--- a/frontend/test/resolution/testProcThis.cpp
+++ b/frontend/test/resolution/testProcThis.cpp
@@ -17,26 +17,14 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/framework/ErrorWriter.h"
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 // error handler that causes the test to fail if it runs
 static void reportError(Context* context, const ErrorBase* err) {

--- a/frontend/test/resolution/testRanges.cpp
+++ b/frontend/test/resolution/testRanges.cpp
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -24,13 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-#include <cassert>
-
-using namespace chpl::parsing;
-using namespace chpl::resolution;
-using namespace chpl::types;
 
 static QualifiedType getRangeIndexType(Context* context, const RecordType* r, const std::string& ensureBoundedType) {
   assert(r->name() == "range");

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -27,19 +29,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 // test resolving a very simple module
 static void test1() {

--- a/frontend/test/resolution/testResolveMethodCalls.cpp
+++ b/frontend/test/resolution/testResolveMethodCalls.cpp
@@ -17,25 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 // test resolving a very simple module
 // Test resolving a simple primary and secondary method call on a record.

--- a/frontend/test/resolution/testResolveNew.cpp
+++ b/frontend/test/resolution/testResolveNew.cpp
@@ -17,24 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static void test1() {
   Context ctx;

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -16,6 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -25,9 +28,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-#include <cassert>
 
 struct ReturnVariant {
   std::string intent;

--- a/frontend/test/resolution/testScopeResolve.cpp
+++ b/frontend/test/resolution/testScopeResolve.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -26,44 +28,7 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace uast;
-
 // helper functions
-/*
-static const Module* findModule(const AstNode* ast, const char* name) {
-  if (auto v = ast->toModule()) {
-    if (v->name() == name) {
-      return v;
-    }
-  }
-
-  for (auto child : ast->children()) {
-    auto got = findModule(child, name);
-    if (got) return got;
-  }
-
-  return nullptr;
-}
-
-static const Module* findModule(const ModuleVec& vec, const char* name) {
-  for (auto mod : vec) {
-    auto got = findModule(mod, name);
-    if (got) return got;
-  }
-
-  return nullptr;
-}
-*/
 
 static const Variable* findVariable(const AstNode* ast, const char* name) {
   if (auto v = ast->toVariable()) {

--- a/frontend/test/resolution/testTaskIntents.cpp
+++ b/frontend/test/resolution/testTaskIntents.cpp
@@ -17,9 +17,7 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <sstream>
-
+#include "test-resolution.h"
 #include "ResolvedVisitor.h"
 
 #include "chpl/framework/ErrorWriter.h"
@@ -35,20 +33,9 @@
 #include "chpl/uast/Variable.h"
 #include "chpl/uast/While.h"
 
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
+#include <algorithm>
+#include <sstream>
 #include <map>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static bool debug = false;
 static bool verbose = false;

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -26,21 +28,6 @@
 #include "chpl/uast/Record.h"
 #include "chpl/uast/TupleDecl.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
-
 
 // assumes the last statement is a variable declaration for x.
 // returns the type of that.

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -25,20 +27,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static void test1() {
   printf("test1\n");

--- a/frontend/test/resolution/testTypeOperators.cpp
+++ b/frontend/test/resolution/testTypeOperators.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/types/ComplexType.h"
@@ -24,14 +26,6 @@
 #include "chpl/types/Param.h"
 #include "chpl/types/RealType.h"
 #include "chpl/uast/Module.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 
 static void test1() {
   Context ctx;

--- a/frontend/test/resolution/testTypeQueries.cpp
+++ b/frontend/test/resolution/testTypeQueries.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -26,20 +28,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
-#include "common.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static void test1() {
   printf("test1\n");

--- a/frontend/test/resolution/testVarArgs.cpp
+++ b/frontend/test/resolution/testVarArgs.cpp
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <sstream>
+#include "test-resolution.h"
 
 #include "ResolvedVisitor.h"
 
@@ -35,20 +34,9 @@
 #include "chpl/uast/Variable.h"
 #include "chpl/uast/While.h"
 
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
+#include <algorithm>
+#include <sstream>
 #include <map>
-
-using namespace chpl;
-using namespace parsing;
-using namespace resolution;
-using namespace types;
-using namespace uast;
 
 static bool debug = false;
 static bool verbose = false;

--- a/frontend/test/test-common.h
+++ b/frontend/test/test-common.h
@@ -17,30 +17,14 @@
  * limitations under the License.
  */
 
-#include "test-resolution.h"
+#ifndef TEST_COMMON_H
+#define TEST_COMMON_H
 
-#include "chpl/parsing/parsing-queries.h"
-#include "chpl/resolution/resolution-queries.h"
-#include "chpl/resolution/scope-queries.h"
-#include "chpl/types/all-types.h"
-#include "chpl/uast/Identifier.h"
-#include "chpl/uast/Module.h"
-#include "chpl/uast/Record.h"
-#include "chpl/uast/Variable.h"
+// always check assertions in the tests
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 
-static void test1() {
-  Context ctx;
-  auto context = &ctx;
-  auto qt = resolveQualifiedTypeOfX(context,
-                             R""""(
-                               var x: bool = true;
-                             )"""");
-  qt.dump();
-  assert(qt.kind() == QualifiedType::VAR);
-  assert(qt.type()->isBoolType());
-}
+#include <cassert>
 
-int main() {
-    test1();
-    return 0;
-}
+#endif

--- a/frontend/test/test-parsing.cpp
+++ b/frontend/test/test-parsing.cpp
@@ -17,30 +17,16 @@
  * limitations under the License.
  */
 
-#include "test-resolution.h"
+#include "test-parsing.h"
 
 #include "chpl/parsing/parsing-queries.h"
-#include "chpl/resolution/resolution-queries.h"
-#include "chpl/resolution/scope-queries.h"
-#include "chpl/types/all-types.h"
-#include "chpl/uast/Identifier.h"
-#include "chpl/uast/Module.h"
-#include "chpl/uast/Record.h"
-#include "chpl/uast/Variable.h"
 
-static void test1() {
-  Context ctx;
-  auto context = &ctx;
-  auto qt = resolveQualifiedTypeOfX(context,
-                             R""""(
-                               var x: bool = true;
-                             )"""");
-  qt.dump();
-  assert(qt.kind() == QualifiedType::VAR);
-  assert(qt.type()->isBoolType());
-}
+const Module* parseModule(Context* context, std::string src) {
+  auto path = UniqueString::get(context, "input.chpl");
+  setFileText(context, path, std::move(src));
 
-int main() {
-    test1();
-    return 0;
+  const ModuleVec& vec = parseToplevel(context, path);
+  assert(vec.size() == 1);
+
+  return vec[0];
 }

--- a/frontend/test/test-parsing.h
+++ b/frontend/test/test-parsing.h
@@ -17,30 +17,30 @@
  * limitations under the License.
  */
 
-#include "test-resolution.h"
+#ifndef TEST_PARSING_H
+#define TEST_PARSING_H
 
-#include "chpl/parsing/parsing-queries.h"
-#include "chpl/resolution/resolution-queries.h"
-#include "chpl/resolution/scope-queries.h"
-#include "chpl/types/all-types.h"
-#include "chpl/uast/Identifier.h"
-#include "chpl/uast/Module.h"
-#include "chpl/uast/Record.h"
-#include "chpl/uast/Variable.h"
+#include "test-common.h"
 
-static void test1() {
-  Context ctx;
-  auto context = &ctx;
-  auto qt = resolveQualifiedTypeOfX(context,
-                             R""""(
-                               var x: bool = true;
-                             )"""");
-  qt.dump();
-  assert(qt.kind() == QualifiedType::VAR);
-  assert(qt.type()->isBoolType());
+#include <string>
+
+// forward declare classes and namespaces
+namespace chpl {
+  class Context;
+  namespace uast {
+    class Module;
+  }
+  namespace parsing {
+  }
+  namespace uast {
+  }
 }
 
-int main() {
-    test1();
-    return 0;
-}
+using namespace chpl;
+using namespace parsing;
+using namespace uast;
+
+// Get the top-level module resulting from parsing the given string.
+const Module* parseModule(Context* context, std::string src);
+
+#endif

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -16,21 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "common.h"
-#include "chpl/parsing/parsing-queries.h"
+
+#include "test-resolution.h"
+
 #include "chpl/resolution/resolution-queries.h"
-
-using namespace parsing;
-
-const Module* parseModule(Context* context, std::string src) {
-  auto path = UniqueString::get(context, "input.chpl");
-  setFileText(context, path, std::move(src));
-
-  const ModuleVec& vec = parseToplevel(context, path);
-  assert(vec.size() == 1);
-
-  return vec[0];
-}
+#include "chpl/uast/Module.h"
 
 QualifiedType
 resolveTypeOfXInit(Context* context, std::string program, bool requireTypeKnown) {

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -16,33 +16,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "chpl/types/all-types.h"
-#include "chpl/uast/Identifier.h"
-#include "chpl/uast/Module.h"
-#include "chpl/uast/Record.h"
-#include "chpl/uast/Variable.h"
 
-using namespace chpl;
+#ifndef TEST_RESOLUTION_H
+#define TEST_RESOLUTION_H
+
+#include "test-parsing.h"
+
+#include "chpl/types/QualifiedType.h"
+
+// forward declare classes and namespaces
+namespace chpl {
+  namespace resolution {
+  }
+  namespace types {
+  }
+}
+
 using namespace resolution;
 using namespace types;
-using namespace uast;
-
-// Get the top-level module resulting from parsing the given string.
-const Module* parseModule(Context* context, std::string src);
 
 // assumes the last statement is a variable declaration for x
 // with an initialization expression.
 // Returns the type of the initializer expression.
-QualifiedType
-resolveTypeOfXInit(Context* context, std::string program, bool requireTypeKnown = true);
+QualifiedType resolveTypeOfXInit(Context* context,
+                                 std::string program,
+                                 bool requireTypeKnown = true);
 
-QualifiedType
-resolveQualifiedTypeOfX(Context* context, std::string program);
+QualifiedType resolveQualifiedTypeOfX(Context* context, std::string program);
 
-const Type*
-resolveTypeOfX(Context* context, std::string program);
+const Type* resolveTypeOfX(Context* context, std::string program);
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
 #endif

--- a/frontend/test/uast/testBuildIDs.cpp
+++ b/frontend/test/uast/testBuildIDs.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/framework/Context.h"
 #include "chpl/framework/ErrorMessage.h"
 #include "chpl/framework/Location.h"
@@ -26,11 +28,6 @@
 #include "chpl/uast/Builder.h"
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 
 using namespace chpl;
 using namespace uast;

--- a/frontend/test/uast/testConsistentEnums.cpp
+++ b/frontend/test/uast/testConsistentEnums.cpp
@@ -17,15 +17,12 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/uast/Variable.h"
 #include "chpl/uast/Formal.h"
 #include "chpl/uast/Function.h"
 #include "chpl/uast/TaskVar.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 
 using namespace chpl;
 using namespace uast;

--- a/frontend/test/uast/testStringify.cpp
+++ b/frontend/test/uast/testStringify.cpp
@@ -17,9 +17,8 @@
  * limitations under the License.
  */
 
-#include <climits>
-#include <map>
-#include <vector>
+#include "test-common.h"
+
 #include "chpl/framework/Context.h"
 #include "chpl/framework/ErrorBase.h"
 #include "chpl/framework/UniqueString.h"
@@ -27,11 +26,9 @@
 #include "chpl/parsing/Parser.h"
 #include "chpl/uast/chpl-syntax-printer.h"
 
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
+#include <climits>
+#include <map>
+#include <vector>
 
 using namespace chpl;
 using namespace uast;

--- a/frontend/test/uast/testVisit.cpp
+++ b/frontend/test/uast/testVisit.cpp
@@ -17,16 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/framework/Context.h"
 #include "chpl/framework/ErrorMessage.h"
 #include "chpl/framework/Location.h"
 #include "chpl/framework/UniqueString.h"
 #include "chpl/uast/all-uast.h"
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 
 using namespace chpl;
 using namespace uast;

--- a/frontend/test/util/testIteratorAdapters.cpp
+++ b/frontend/test/util/testIteratorAdapters.cpp
@@ -17,18 +17,13 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/util/iteration.h"
 
-#include <cassert>
 #include <cstddef>
-
 #include <vector>
 #include <unordered_set>
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 
 using namespace chpl;
 

--- a/frontend/test/util/testLLVMsupport.cpp
+++ b/frontend/test/util/testLLVMsupport.cpp
@@ -17,15 +17,9 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "llvm/Support/FileSystem.h"
-
-#include <cassert>
-
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 
 // Filesystem create/delete works from LLVM support library.
 static void test1() {

--- a/frontend/test/util/testQueryTimingAndTrace.cpp
+++ b/frontend/test/util/testQueryTimingAndTrace.cpp
@@ -17,15 +17,11 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include <cassert>
 #include <cstdlib>
 
 using namespace chpl;

--- a/frontend/test/util/testQuoteStrings.cpp
+++ b/frontend/test/util/testQuoteStrings.cpp
@@ -17,14 +17,9 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/util/string-escapes.h"
-
-#include <cassert>
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 
 using namespace chpl;
 

--- a/frontend/test/util/testSubprocess.cpp
+++ b/frontend/test/util/testSubprocess.cpp
@@ -17,14 +17,9 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
+
 #include "chpl/util/subprocess.h"
-
-#include <cassert>
-
-// always check assertions in this test
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 
 using namespace chpl;
 


### PR DESCRIPTION
This PR was motivated by my observation that these C++ tests were building with a mix of assertions enabled and disabled. That's due to the way that some headers were included before `#undef NDEBUG`. But, we want these C++ tests to always run with assertions on.

This PR improves the situation by adding `test-common.h` which does the `#undef NDEBUG` and arranges for this to always be the first thing included (possibly by another header) from one of these tests. It splits the helper functions & `using` declarations into `test-parsing.h` and `test-resolution.h` and corresponding .cpp files. `test-parsing.h` and `test-resolution.h` start by including `test-common.h` so assertions will be enabled as long as a test starts with one of these 3 headers.

This PR also fixes an issue with `cmake` when `CHPL_LLVM_LINK_ARGS` is blank.

Reviewed by @DanilaFe - thanks!