### PR TITLE
fix(install): add CONFIGURED_PREFIX back how it was

### DIFF
--- a/compiler/main/configured_prefix.h
+++ b/compiler/main/configured_prefix.h
@@ -21,10 +21,8 @@
 #ifndef _configured_prefix_H_
 #define _configured_prefix_H_
 
-// TODO: THIS IS A TEMPORARY WORKAROUND for CMake SHould just get this
-// from CMAKE_INSTALL_PREFIX
-static const char* CONFIGURED_PREFIX = "";
-// #include "CONFIGURED_PREFIX"
-//;
+static const char* CONFIGURED_PREFIX =
+#include "CONFIGURED_PREFIX"
+;
 
 #endif


### PR DESCRIPTION
This PR fixes a `chpl` installation issue caused by removing the CONFIGURED_PREFIX
while developing a CMake build solution. The change should not have been checked
in originally.

TESTING:

- [x] can `./configure` and then `make install` to a specified directory

Reviewed by @mppf - thanks!