### PR TITLE
Make `library/standard/IO/filePath/basic.prediff` more portable

### DIFF
--- a/test/library/standard/IO/filePath/basic.prediff
+++ b/test/library/standard/IO/filePath/basic.prediff
@@ -9,9 +9,11 @@ tmptmp=`mktemp "tmp.XXXXXX"`
 regex="s~$CHPL_HOME~{CHPL_HOME}~g"
 sed -e "$regex" $tmpfile > $tmptmp
 
-# also use realpath to work with absolute paths
-realhome=`realpath $CHPL_HOME`
-regex="s~$realhome~{CHPL_HOME}~g"
-sed -e "$regex" $tmpfile > $tmptmp
+# also use realpath to work with absolute paths (if possible)
+if [ -x "$(command -v realpath)" ]; then
+    realhome=`realpath $CHPL_HOME`
+    regex="s~$realhome~{CHPL_HOME}~g"
+    sed -e "$regex" $tmpfile > $tmptmp
+fi
 
 mv $tmptmp $tmpfile

--- a/test/library/standard/IO/filePath/basic.prediff
+++ b/test/library/standard/IO/filePath/basic.prediff
@@ -9,7 +9,9 @@ tmptmp=`mktemp "tmp.XXXXXX"`
 regex="s~$CHPL_HOME~{CHPL_HOME}~g"
 sed -e "$regex" $tmpfile > $tmptmp
 
-# also use realpath to work with absolute paths (if possible)
+# also use realpath to work with absolute paths
+#  the 'realpath' command isn't avilible on Mac OS by default, so this step is skipped on Mac
+#  if absolute $CHPL_HOME paths become necessary on Mac, this script could be replaced by a Python script
 if [ -x "$(command -v realpath)" ]; then
     realhome=`realpath $CHPL_HOME`
     regex="s~$realhome~{CHPL_HOME}~g"


### PR DESCRIPTION
`library/standard/IO/filePath/basic.prediff` was causing some tests to fail on Mac systems because the `realpath` command isn't available in older versions of bash.

This PR updates the prediff script to skip a secondary absolute path check when `realpath` isn't available.

The relevant tests are now passing on Mac and Linux.
