### PR TITLE
Use HOST_MEM=cstdlib when running address sanitizer.

### DIFF
--- a/doc/rst/developer/bestPractices/Sanitizers.rst
+++ b/doc/rst/developer/bestPractices/Sanitizers.rst
@@ -20,6 +20,7 @@ To use AddressSanitizer with Chapel (compiler and executables):
 .. code-block:: bash
 
      export CHPL_MEM=cstdlib
+     export CHPL_HOST_MEM=cstdlib
      export CHPL_TASKS=fifo
      export CHPL_LLVM=none
      export CHPL_SANITIZE=address

--- a/util/cron/common-asan.bash
+++ b/util/cron/common-asan.bash
@@ -5,6 +5,7 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 export CHPL_MEM=cstdlib
+export CHPL_HOST_MEM=cstdlib
 export CHPL_TASKS=fifo
 export CHPL_LLVM=none
 export CHPL_SANITIZE=address


### PR DESCRIPTION
This fixes the address sanitizer tests, which have until now assumed that
`HOST_MEM` will default to `cstdlib` (which is the only option that works when
sanitizing). However, a recent change makes `jemalloc` default, which the tests
do not override, leading to failures. This PR should fix those failures.

Reviewed by @ronawho - thanks!