### PR TITLE
Add .suppressif for test passing FCF to extern

### DIFF
--- a/test/functions/fcf/ExternBlock.suppressif
+++ b/test/functions/fcf/ExternBlock.suppressif
@@ -1,0 +1,1 @@
+EXECOPTS <= --memLeaks


### PR DESCRIPTION
Add .suppressif for test passing FCF to extern

The test currently leaks and is not trivial to fix.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>