### PR TITLE
Continued modifications for Arkouda + GPU nightly test

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -132,6 +132,13 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
     fi
     test_end
   fi
+else
+  # If we've gotten here then the build succeeded I need to create a "fake"
+  # test for Jenkins even though in this mode all I really care about is the
+  # build.
+  test_start "build"
+  log_success "build output"
+  test_end
 fi
 
 subtest_end

--- a/util/cron/test-cray-xc-gpu-arkouda.bash
+++ b/util/cron/test-cray-xc-gpu-arkouda.bash
@@ -4,6 +4,8 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
+source $CWD/common.bash
+
 # Setup for GPU:
 source /cray/css/users/chapelu/setup_system_llvm.bash $LLVM_VERSION
 module load cudatoolkit
@@ -16,10 +18,14 @@ export CHPL_TEST_GPU=true
 export CHPL_LAUNCHER_CONSTRAINT=BW18
 export CHPL_LAUNCHER="slurm-srun"
 
-# For some reason needed to not fail when building Arkouda with
-# CHPL_LOCALE_MODEL=gpu:
-module unload cce
+# setup for XC perf (ugni, gnu, 28-core broadwell)
+module unload $(module -t list 2>&1 | grep PrgEnv-)
 module load PrgEnv-gnu
+module unload $(module -t list 2>&1 | grep craype-hugepages)
+module load craype-hugepages16M
+module unload perftools-base
+module unload atp
+module load craype-x86-cascadelake
 
 # setup arkouda
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-xc-gpu-arkouda"


### PR DESCRIPTION
These are some continued modifications to ensure we have the right set of modules loaded and have sub_test register the test a success if we've built successfully and are in a mode where we're skipping other checks (which we do for the GPU build since we're skipping some modules).

This time I've qualified these changes in Jenkins by first configuring the job to run off of my Chapel repos. I got a passing run, so I'm now merging these changes in with this PR and will change the Jenkins config to run off of the nightly synced repos.