### PR TITLE
fix(build): remove chpldoc LICENSE file from release script

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -135,7 +135,6 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
        "util/setchplenv.sh",
        "util/start_test",
        "util/chpltags",
-       "tools/chpldoc/LICENSE",
        "tools/chpldoc/COPYRIGHT",
        "frontend/include/chpl/config/config.h.cmake",
 );


### PR DESCRIPTION
This PR removes the recently removed `LICENSE` file from the `gen_release`
script's list of files to explicitly copy. The `LICENSE` file for `chpldoc` 
was removed in #20835, which led to failures in the release smoke tests.

TESTING: 

- [x] can run `gen_release` again

reviewed by @mppf

