### PR TITLE
Add a warning for inheriting from a deprecated class

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2715,6 +2715,10 @@ AggregateType* AggregateType::discoverParentAndCheck(Expr* storesName) {
     USR_FATAL(storesName, "Illegal super class");
   }
 
+  if (ts->hasFlag(FLAG_DEPRECATED)) {
+    ts->generateDeprecationWarning(storesName);
+  }
+
   AggregateType* pt = toAggregateType(ts->type);
 
   if (pt == NULL) {

--- a/test/deprecated-keyword/handleClassInheritence.chpl
+++ b/test/deprecated-keyword/handleClassInheritence.chpl
@@ -1,0 +1,10 @@
+deprecated "'Dep' is deprecated, please use 'Undep' instead"
+class Dep: Undep { }
+
+class Undep { }
+
+class UseDep: Dep { }
+
+proc main {
+  var d: owned UseDep?;
+}

--- a/test/deprecated-keyword/handleClassInheritence.good
+++ b/test/deprecated-keyword/handleClassInheritence.good
@@ -1,0 +1,1 @@
+handleClassInheritence.chpl:6: warning: 'Dep' is deprecated, please use 'Undep' instead


### PR DESCRIPTION
Inheriting from a deprecated class was not producing a deprecation warning.
Add a warning for this case and add a test that trips it.