### PR TITLE
Improve a dyno assertion

### DIFF
--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -26,6 +26,8 @@
 #include "chpl/framework/ErrorWriter.h"
 #include "chpl/framework/ErrorBase.h"
 
+#include "llvm/Support/FileSystem.h"
+
 #include <chrono>
 #include <fstream>
 #include <iomanip>
@@ -435,10 +437,11 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
            moduleIdSymbolPath.c_str(), path.c_str());
   }
   #ifndef NDEBUG
+    // check that querying the file path gives the same file
     UniqueString gotPath;
     UniqueString gotParentSymbolPath;
     bool ok = filePathForId(moduleID, gotPath, gotParentSymbolPath);
-    assert(ok && path == gotPath);
+    assert(ok && llvm::sys::fs::equivalent(path.str(), gotPath.str()));
   #endif
 }
 

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -437,11 +437,28 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
            moduleIdSymbolPath.c_str(), path.c_str());
   }
   #ifndef NDEBUG
-    // check that querying the file path gives the same file
+    // check that querying the module ID works...
     UniqueString gotPath;
     UniqueString gotParentSymbolPath;
     bool ok = filePathForId(moduleID, gotPath, gotParentSymbolPath);
-    assert(ok && llvm::sys::fs::equivalent(path.str(), gotPath.str()));
+    assert(ok);
+
+    // ... and gives the same path
+
+    // Note: if this check causes problems in the future, it could
+    // be removed, or we could wire up setFileText used in tests
+    // to work with the LLVM VirtualFilesystem
+    llvm::SmallVector<char> realPath;
+    llvm::SmallVector<char> realGotPath;
+    std::error_code errPath;
+    std::error_code errGotPath;
+    errPath = llvm::sys::fs::real_path(path.str(), realPath);
+    errGotPath = llvm::sys::fs::real_path(gotPath.str(), realGotPath);
+    if (errPath || errGotPath) {
+      // ignore the check if there were errors
+    } else {
+      assert(realPath == realGotPath);
+    }
   #endif
 }
 


### PR DESCRIPTION
Use the LLVM Support library to check if it's the same file.

Addresses a failure with the test modules/implicit/parseTwice/main.

Reviewed by @arezaii - thanks!

- [x] full local testing
