### PR TITLE
Fix trailing spaces in #20801

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8644,7 +8644,7 @@ iter _channel.matches(re:regex(?), param captures=0, maxmatches:int = max(int))
               if error == EEOF {
                 error = ENOERR;
                 go = false;
-              }  
+              }
             }
           }
         } else {


### PR DESCRIPTION
#20801 introduced trailing spaces, which we should not have.
This change removes them.
Trivial, not reviewed.