### PR TITLE
Update .good to keep unstableTimezones test working

### DIFF
--- a/test/library/standard/DateTime/unstableTimezones.good
+++ b/test/library/standard/DateTime/unstableTimezones.good
@@ -1,1 +1,2 @@
+unstableTimezones.chpl:3: warning: 'TZInfo' is deprecated, please use 'Timezone' instead
 unstableTimezones.chpl:27: warning: tzinfo is unstable; its type may change in the future


### PR DESCRIPTION
Testing a branch close to `main`, I saw failures here, and
then saw them on main as well.  Updating the .good to
avoid a failure per configuration that tests this tonight.
