### PR TITLE
Enable dedicated cores for active message handlers

### DIFF
--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -159,11 +159,13 @@ void chpl_task_exit(void);        // called by the main task
 // This task should be quite dedicated (e.g., get its own system
 // thread) in order to be responsive and not be held up by other
 // user-level tasks. returns 0 on success, nonzero on failure.
+// If cpu is >= 0 then the task is bound to the specified CPU if
+// the platform supports CPU binding.
 //
 // The caller of this function is responsible for ensuring that
 // *arg remains available to the task as long as it is needed.
 //
-int chpl_task_createCommTask(chpl_fn_p fn, void* arg);
+int chpl_task_createCommTask(chpl_fn_p fn, void* arg, int cpu);
 
 //
 // Have the tasking layer call the 'chpl_main' function pointer

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -58,6 +58,23 @@ int chpl_topo_getNumCPUsLogical(chpl_bool /*accessible_only*/);
 //
 int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count);
 
+// Reserves a physical CPU (core) and returns its hwloc OS index. The
+// core and its PUs will no longer be included in the results returned
+// by chpl_topo_getCPUs, chpl_topo_getNumCPUsPhysical, and
+// chpl_topo_getNumCPUsLogical.
+//
+// Returns -1 if the reservation failed.
+//
+int chpl_topo_reserveCPUPhysical(void);
+
+// Binds the current thread to the PU specified by the hwloc OS index.
+// The index must have previously been returned by
+// chpl_topo_reserveCPUPhysical.
+//
+// Returns 0 on success, 1 otherwise
+//
+int chpl_topo_bindCPU(int id);
+
 //
 // how many NUMA domains are there?
 //

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -58,10 +58,13 @@ int chpl_topo_getNumCPUsLogical(chpl_bool /*accessible_only*/);
 //
 int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count);
 
+//
 // Reserves a physical CPU (core) and returns its hwloc OS index. The
-// core and its PUs will no longer be included in the results returned
-// by chpl_topo_getCPUs, chpl_topo_getNumCPUsPhysical, and
-// chpl_topo_getNumCPUsLogical.
+// core and its PUs will not be returned by chpl_topo_getCPUs,
+// chpl_topo_getNumCPUsPhysical, and chpl_topo_getNumCPUsLogical. Must
+// be called before those functions. Will not reserve a core if CPU
+// binding is not supported on this platform or if there is only one
+// unreserved core.
 //
 // Returns -1 if the reservation failed.
 //

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -771,7 +771,7 @@ static void start_polling(void) {
   pollingRunning = 0;
   pollingQuit = 0;
 
-  if (chpl_task_createCommTask(polling, NULL)) {
+  if (chpl_task_createCommTask(polling, NULL, -1)) {
     chpl_internal_error("unable to start polling task for gasnet");
   }
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2105,7 +2105,7 @@ void chpl_comm_post_task_init(void)
   //
   // Start the polling task.
   //
-  if (chpl_task_createCommTask(polling_task, NULL) != 0)
+  if (chpl_task_createCommTask(polling_task, NULL, -1) != 0)
     CHPL_INTERNAL_ERROR("unable to start comm task for uGNI comm layer");
 
   //

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -410,7 +410,7 @@ void chpl_task_stdModulesInitialized(void) {
 }
 
 
-int chpl_task_createCommTask(chpl_fn_p fn, void* arg) {
+int chpl_task_createCommTask(chpl_fn_p fn, void* arg, int cpu) {
   comm_task_fn = fn;
   return chpl_thread_createCommThread(comm_task_wrapper, arg);
 }

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -788,11 +788,21 @@ static aligned_t chapel_wrapper(void *arg)
 typedef struct {
     chpl_fn_p fn;
     void *arg;
+    int cpu;
 } comm_task_wrapper_info_t;
 
 static void *comm_task_wrapper(void *arg)
 {
     comm_task_wrapper_info_t *rarg = arg;
+    if (rarg->cpu >= 0) {
+        int rc = chpl_topo_bindCPU(rarg->cpu);
+        if (rc) {
+            char msg[100];
+            snprintf(msg, sizeof(msg),
+                     "binding comm task to CPU %d failed", rarg->cpu);
+            chpl_warning(msg, 0, 0);
+        }
+    }
     (*(chpl_fn_p)(rarg->fn))(rarg->arg);
     return 0;
 }
@@ -826,7 +836,8 @@ void chpl_task_stdModulesInitialized(void)
 }
 
 int chpl_task_createCommTask(chpl_fn_p fn,
-                             void     *arg)
+                             void     *arg,
+                             int      cpu)
 {
     //
     // The wrapper info must be static because it won't be referred to
@@ -837,6 +848,7 @@ int chpl_task_createCommTask(chpl_fn_p fn,
     static comm_task_wrapper_info_t wrapper_info;
     wrapper_info.fn = fn;
     wrapper_info.arg = arg;
+    wrapper_info.cpu = cpu;
     return pthread_create(&chpl_qthread_comm_pthread,
                           NULL, comm_task_wrapper, &wrapper_info);
 }

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -64,8 +64,16 @@ static int topoDepth;
 static int numaLevel;
 static int numNumaDomains;
 
+// A note on core and PU numbering. As per the hwloc documentation, a cpuset
+// contains OS indices of PUs, which are guaranteed to be unique across the
+// machine. In order to use a cpuset to represent a collection of cores and
+// not break this invariant, we represent a core in a cpuset with the smallest
+// OS index of its PUs. For example, the physAccSet contains the OS indices of
+// the smallest PU for each accessible core.
+
 // Accessible cores and PUs.
 static hwloc_cpuset_t physAccSet = NULL;
+static hwloc_cpuset_t physReservedSet = NULL;
 static hwloc_cpuset_t logAccSet = NULL;
 
 static hwloc_obj_t getNumaObj(c_sublocid_t);
@@ -205,6 +213,10 @@ void chpl_topo_exit(void) {
     hwloc_bitmap_free(physAccSet);
     physAccSet = NULL;
   }
+  if (physReservedSet != NULL) {
+    hwloc_bitmap_free(physReservedSet);
+    physReservedSet = NULL;
+  }
   if (logAccSet != NULL) {
     hwloc_bitmap_free(logAccSet);
     logAccSet = NULL;
@@ -217,35 +229,37 @@ void* chpl_topo_getHwlocTopology(void) {
   return (haveTopology) ? topology : NULL;
 }
 
-
 //
 // How many CPUs (cores or PUs) are there?
 //
 static pthread_once_t numCPUs_ctrl = PTHREAD_ONCE_INIT;
-static void getNumCPUs(void);
+static void getCPUInfo(void);
 static int numCPUsPhysAcc = -1;
 static int numCPUsPhysAll = -1;
 static int numCPUsLogAcc  = -1;
 static int numCPUsLogAll  = -1;
 
 int chpl_topo_getNumCPUsPhysical(chpl_bool accessible_only) {
-  CHK_ERR(pthread_once(&numCPUs_ctrl, getNumCPUs) == 0);
+  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
   return (accessible_only) ? numCPUsPhysAcc : numCPUsPhysAll;
 }
 
 
 int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
-  CHK_ERR(pthread_once(&numCPUs_ctrl, getNumCPUs) == 0);
+  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
   return (accessible_only) ? numCPUsLogAcc : numCPUsLogAll;
 }
 
-
+//
+// Gets information about CPUs (cores and PUs) from the toplogy.
+//
 static
-void getNumCPUs(void) {
+void getCPUInfo(void) {
   //
   // accessible cores and PUs
   //
   CHK_ERR_ERRNO((physAccSet = hwloc_bitmap_alloc()) != NULL);
+  CHK_ERR_ERRNO((physReservedSet = hwloc_bitmap_alloc()) != NULL);
   CHK_ERR_ERRNO((logAccSet = hwloc_bitmap_alloc()) != NULL);
 
   //
@@ -274,21 +288,19 @@ void getNumCPUs(void) {
   hwloc_bitmap_and(logAccSet, logAccSet,
                    hwloc_topology_get_online_cpuset(topology));
 
-#define NEXT_PU(pu)                                                     \
-  hwloc_get_next_obj_inside_cpuset_by_type(topology, logAccSet,         \
+#define NEXT_PU(pu)                                                \
+  hwloc_get_next_obj_inside_cpuset_by_type(topology, logAccSet,    \
                                            HWLOC_OBJ_PU, pu)
 
   for (hwloc_obj_t pu = NEXT_PU(NULL); pu != NULL; pu = NEXT_PU(pu)) {
     hwloc_obj_t core;
-    CHK_ERR_ERRNO((core = hwloc_get_ancestor_obj_by_type(topology,
+    CHK_ERR_ERRNO(core = hwloc_get_ancestor_obj_by_type(topology,
                                                          HWLOC_OBJ_CORE,
-                                                         pu))
-                  != NULL);
-    // Only use the first PU per core.
-    hwloc_obj_t first = hwloc_get_obj_inside_cpuset_by_type(topology,
-                                                            core->cpuset,
-                                                            HWLOC_OBJ_PU, 0);
-    hwloc_bitmap_or(physAccSet, physAccSet, first->cpuset);
+                                                         pu));
+    // Use the smallest PU to represent the core.
+    int smallest = hwloc_bitmap_first(core->cpuset);
+    CHK_ERR(smallest != -1);
+    hwloc_bitmap_set(physAccSet, smallest);
   }
 
 #undef NEXT_PU
@@ -323,12 +335,13 @@ void getNumCPUs(void) {
 static
 int getCPUs(hwloc_cpuset_t cpuset, int *cpus, int size) {
   int count = 0;
-  for (int i = hwloc_bitmap_first(cpuset);
-        i <= hwloc_bitmap_last(cpuset) && (count < size); i++) {
-    if (hwloc_bitmap_isset(cpuset, i)) {
-      cpus[count++] = i;
+  int id;
+  hwloc_bitmap_foreach_begin(id, cpuset) {
+    if (count == size) {
+      break;
     }
-  }
+    cpus[count++] = id;
+  } hwloc_bitmap_foreach_end();
   return count;
 }
 
@@ -341,7 +354,7 @@ int getCPUs(hwloc_cpuset_t cpuset, int *cpus, int size) {
 //
 int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count) {
   // Initializes CPU information.
-  CHK_ERR(pthread_once(&numCPUs_ctrl, getNumCPUs) == 0);
+  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
   return getCPUs(physical ? physAccSet : logAccSet, cpus, count);
 }
 
@@ -355,7 +368,7 @@ void chpl_topo_setThreadLocality(c_sublocid_t subloc) {
   hwloc_cpuset_t cpuset;
   int flags;
 
-  _DBG_P("chpl_topo_setThreadLocality(%d)\n", (int) subloc);
+  _DBG_P("chpl_topo_setThreadLocality(%d)", (int) subloc);
 
   if (!haveTopology) {
     return;
@@ -413,7 +426,7 @@ void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
   unsigned char* pPgLo;
   size_t nPages;
 
-  _DBG_P("chpl_topo_setMemLocality(%p, %#zx, onlyIn=%s, %d)\n",
+  _DBG_P("chpl_topo_setMemLocality(%p, %#zx, onlyIn=%s, %d)",
          p, size, (onlyInside ? "T" : "F"), (int) subloc);
 
   if (!haveTopology) {
@@ -422,7 +435,7 @@ void chpl_topo_setMemLocality(void* p, size_t size, chpl_bool onlyInside,
 
   alignAddrSize(p, size, onlyInside, &pgSize, &pPgLo, &nPages);
 
-  _DBG_P("    localize %p, %#zx bytes (%#zx pages)\n",
+  _DBG_P("    localize %p, %#zx bytes (%#zx pages)",
          pPgLo, nPages * pgSize, nPages);
 
   if (nPages == 0)
@@ -442,7 +455,7 @@ void chpl_topo_setMemSubchunkLocality(void* p, size_t size,
   size_t pg;
   size_t pgNext;
 
-  _DBG_P("chpl_topo_setMemSubchunkLocality(%p, %#zx, onlyIn=%s)\n",
+  _DBG_P("chpl_topo_setMemSubchunkLocality(%p, %#zx, onlyIn=%s)",
          p, size, (onlyInside ? "T" : "F"));
 
   if (!haveTopology) {
@@ -451,7 +464,7 @@ void chpl_topo_setMemSubchunkLocality(void* p, size_t size,
 
   alignAddrSize(p, size, onlyInside, &pgSize, &pPgLo, &nPages);
 
-  _DBG_P("    localize %p, %#zx bytes (%#zx pages)\n",
+  _DBG_P("    localize %p, %#zx bytes (%#zx pages)",
          pPgLo, nPages * pgSize, nPages);
 
   if (nPages == 0)
@@ -479,7 +492,7 @@ void chpl_topo_touchMemFromSubloc(void* p, size_t size, chpl_bool onlyInside,
   hwloc_cpuset_t cpuset;
   int flags;
 
-  _DBG_P("chpl_topo_touchMemFromSubloc(%p, %#zx, onlyIn=%s, %d)\n",
+  _DBG_P("chpl_topo_touchMemFromSubloc(%p, %#zx, onlyIn=%s, %d)",
          p, size, (onlyInside ? "T" : "F"), (int) subloc);
 
   if (!haveTopology
@@ -490,7 +503,7 @@ void chpl_topo_touchMemFromSubloc(void* p, size_t size, chpl_bool onlyInside,
 
   alignAddrSize(p, size, onlyInside, &pgSize, &pPgLo, &nPages);
 
-  _DBG_P("    localize %p, %#zx bytes (%#zx pages)\n",
+  _DBG_P("    localize %p, %#zx bytes (%#zx pages)",
          pPgLo, nPages * pgSize, nPages);
 
   if (nPages == 0)
@@ -593,7 +606,7 @@ void chpl_topo_setMemLocalityByPages(unsigned char* p, size_t size,
       || !do_set_area_membind)
     return;
 
-  _DBG_P("hwloc_set_area_membind_nodeset(%p, %#zx, %d)\n", p, size,
+  _DBG_P("hwloc_set_area_membind_nodeset(%p, %#zx, %d)", p, size,
          (int) hwloc_bitmap_first(numaObj->allowed_nodeset));
 
   flags = HWLOC_MEMBIND_MIGRATE | HWLOC_MEMBIND_STRICT;
@@ -635,6 +648,93 @@ c_sublocid_t chpl_topo_getMemLocality(void* p) {
   hwloc_bitmap_free(nodeset);
 
   return node;
+}
+
+
+//
+// Reserves a physical CPU (core) and returns its hwloc OS index. The core and
+// its PUs will no longer be returned by chpl_topo_getCPUs,
+// chpl_topo_getNumCPUsPhysical, and chpl_topo_getNumCPUsLogical. Will not
+// reserve a core if CPU binding is not supported on this platform.
+//
+// Returns OS index of reserved physical CPU, -1 otherwise
+//
+int
+chpl_topo_reserveCPUPhysical(void) {
+  int id = -1;
+  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
+  if (topoSupport->cpubind->set_thread_cpubind) {
+
+#ifdef DEBUG
+    char buf[1024];
+    _DBG_P("chpl_topo_reserveCPUPhysical before");
+    hwloc_bitmap_list_snprintf(buf, sizeof(buf), physAccSet);
+    _DBG_P("physAccSet: %s", buf);
+    hwloc_bitmap_list_snprintf(buf, sizeof(buf), physReservedSet);
+    _DBG_P("physReservedSet: %s", buf);
+    hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
+    _DBG_P("logAccSet: %s", buf);
+#endif
+    // Reserve the highest-numbered core.
+    id = hwloc_bitmap_last(physAccSet);
+    if (id >= 0) {
+
+      // Find the core's object in the topology so we can reserve its PUs.
+      hwloc_obj_t pu, core;
+      CHK_ERR_ERRNO(pu = hwloc_get_obj_inside_cpuset_by_type(topology,
+                                                      physAccSet,
+                                                      HWLOC_OBJ_PU, id));
+      CHK_ERR_ERRNO(core = hwloc_get_ancestor_obj_by_type(topology,
+                                                          HWLOC_OBJ_CORE,
+                                                          pu));
+      // Reserve the core.
+      hwloc_bitmap_andnot(physAccSet, physAccSet, pu->cpuset);
+      numCPUsPhysAcc = hwloc_bitmap_weight(physAccSet);
+      hwloc_bitmap_or(physReservedSet, physReservedSet, pu->cpuset);
+      CHK_ERR(numCPUsPhysAcc > 0);
+
+      // Reserve the core's PUs.
+      hwloc_bitmap_andnot(logAccSet, logAccSet, core->cpuset);
+      numCPUsLogAcc = hwloc_bitmap_weight(logAccSet);
+      CHK_ERR(numCPUsLogAcc > 0);
+
+      _DBG_P("reserved core %d", id);
+    }
+  }
+#ifdef DEBUG
+  char buf[1024];
+  _DBG_P("chpl_topo_reserveCPUPhysical %d", id);
+  hwloc_bitmap_list_snprintf(buf, sizeof(buf), physAccSet);
+  _DBG_P("physAccSet: %s", buf);
+  hwloc_bitmap_list_snprintf(buf, sizeof(buf), physReservedSet);
+  _DBG_P("physReservedSet: %s", buf);
+  hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
+  _DBG_P("logAccSet: %s", buf);
+#endif
+  return id;
+}
+
+
+//
+// Binds the current thread to the specified CPU. The CPU must
+// have previously been reserved via chpl_topo_reserveCPUPhysical.
+//
+// Returns 0 on success, 1 otherwise
+//
+int chpl_topo_bindCPU(int id) {
+  int status = 1;
+  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
+  if (hwloc_bitmap_isset(physReservedSet, id)) {
+    int flags = HWLOC_CPUBIND_THREAD | HWLOC_CPUBIND_STRICT;
+    hwloc_cpuset_t cpuset;
+    CHK_ERR_ERRNO((cpuset = hwloc_bitmap_alloc()) != NULL);
+    hwloc_bitmap_set(cpuset, id);
+    CHK_ERR_ERRNO(hwloc_set_cpubind(topology, cpuset, flags) == 0);
+    hwloc_bitmap_free(cpuset);
+    status = 0;
+  }
+  _DBG_P("chpl_topo_bindCPUPhysical id: %d status: %d", id, status);
+  return status;
 }
 
 

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -56,6 +56,17 @@ int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count) {
   return 0;
 }
 
+
+int chpl_topo_reserveCPUPhysical(void) {
+  return -1;
+}
+
+
+int chpl_topo_bindCPU(int id) {
+  return 1;
+}
+
+
 int chpl_topo_getNumNumaDomains(void) {
   return 1;
 }


### PR DESCRIPTION
Add opt-in support for a dedicated core for the ofi active message handler.  This functionality is enabled when:

-  `CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES = true` (default: `false`)
- `CHPL_COMM = ofi`
- `CHPL_TASKS = qthreads`
- `CHPL_HWLOC != none`
- `CHPL_QTHREAD_TOPOLOGY = binders` (default: `binders`)
- The platform supports CPU binding
- The number of accessible cores > the number of active message handlers

When these conditions are met each active message handler thread is bound to its own exclusive core. The remaining cores run `qthread` shepherd threads.

This functionality is disabled by default. In the future we may change the default on some platforms and extend this functionality to other comm layers. 

While I was here, cleaned up how the bitmap is iterated through in `getCPUs` and removed extra newline characters in debug messages in `topo-hwloc.c`.

Closes https://github.com/cray/chapel-private/issues/3846.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>