### PR TITLE
Update a test to avoid a deprecation message for TZInfo

### DIFF
--- a/test/library/standard/DateTime/unstableTimezones.chpl
+++ b/test/library/standard/DateTime/unstableTimezones.chpl
@@ -1,6 +1,6 @@
 use Time;
 
-class zone: TZInfo {
+class zone: Timezone {
   /* The offset from UTC this class represents */
   proc utcoffset(dt: datetime): timedelta {
     return new timedelta();

--- a/test/library/standard/DateTime/unstableTimezones.good
+++ b/test/library/standard/DateTime/unstableTimezones.good
@@ -1,2 +1,1 @@
-unstableTimezones.chpl:3: warning: 'TZInfo' is deprecated, please use 'Timezone' instead
 unstableTimezones.chpl:27: warning: tzinfo is unstable; its type may change in the future


### PR DESCRIPTION
Update a test to use Timezone instead of TZInfo.