### PR TITLE
fix(install): copy chpldoc during make install

### DIFF
--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -349,7 +349,7 @@ fi
 # create symlink for chpldoc-legacy
 if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc" ]
 then
-  # create a symbolic link for chpldoc-legacy
+  # Choose destination depending on installation mode {prefix, home}
   if [ ! -z "$PREFIX" ]
   then
     (cd "$PREFIX/bin" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -241,7 +241,7 @@ if [ ! -z "$PREFIX" ]
 then
   myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$PREFIX/bin"
 else
-  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$DEST_DIR/$tmp_bin_dir"
+  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"
 fi
 
 # copy runtime lib
@@ -363,7 +363,7 @@ if [ ! -z "$PREFIX" ]
 then
   myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$PREFIX/bin"
 else
-  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$DEST_DIR/$tmp_bin_dir"
+  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"
 fi
 
 # copy chplconfig

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -241,8 +241,7 @@ if [ ! -z "$PREFIX" ]
 then
   myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$PREFIX/bin"
 else
-  tmp_bin_dir="bin/$CHPL_BIN_SUBDIR"
-  myinstallfile "$tmp_bin_dir"/chpl "$DEST_DIR/$tmp_bin_dir"
+  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$DEST_DIR/$tmp_bin_dir"
 fi
 
 # copy runtime lib
@@ -348,7 +347,7 @@ then
 fi
 
 # create symlink for chpldoc-legacy
-if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc-legacy" ]
+if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc" ]
 then
   # create a symbolic link for chpldoc-legacy
   if [ ! -z "$PREFIX" ]
@@ -364,8 +363,7 @@ if [ ! -z "$PREFIX" ]
 then
   myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$PREFIX/bin"
 else
-  tmp_bin_dir="bin/$CHPL_BIN_SUBDIR"
-  myinstallfile "$tmp_bin_dir"/chpldoc "$DEST_DIR/$tmp_bin_dir"
+  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$DEST_DIR/$tmp_bin_dir"
 fi
 
 # copy chplconfig

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -347,15 +347,25 @@ then
   fi
 fi
 
-if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc" ]
+# create symlink for chpldoc-legacy
+if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc-legacy" ]
 then
-  # create a symbolic link for chpldoc
+  # create a symbolic link for chpldoc-legacy
   if [ ! -z "$PREFIX" ]
   then
-    (cd "$PREFIX/bin" && rm -f chpldoc && ln -s chpl chpldoc)
+    (cd "$PREFIX/bin" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)
   else
-    (cd "$DEST_DIR/bin/$CHPL_BIN_SUBDIR" && rm -f chpldoc && ln -s chpl chpldoc)
+    (cd "$DEST_DIR/bin/$CHPL_BIN_SUBDIR" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)
   fi
+fi
+
+# copy chpldoc
+if [ ! -z "$PREFIX" ]
+then
+  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$PREFIX/bin"
+else
+  tmp_bin_dir="bin/$CHPL_BIN_SUBDIR"
+  myinstallfile "$tmp_bin_dir"/chpldoc "$DEST_DIR/$tmp_bin_dir"
 fi
 
 # copy chplconfig


### PR DESCRIPTION
This PR addresses an issue where `make install` doesn't copy
the new `chpldoc` and continues the process of creating
a symlink called `chpldoc` that points to `chpl`. The update 
changes the symlink name to `chpldoc-legacy` and also copies
the `chpldoc` binary to the same location as `chpl`.
                                                                                                                 
TESTING:

- [x] `make install` copies binaries for `chpl`, `chpldoc`, `chpldoc-legacy`, and `mason` (if built)

reviewed by @riftEmber - thanks!