### PR TITLE
Fix "the the" typos

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3506,7 +3506,7 @@ const clang::CodeGen::ABIArgInfo*
 getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg)
 {
 
-  // Don't try to use the the calling convention code for variadic args.
+  // Don't try to use the calling convention code for variadic args.
   if ((unsigned) curCArg >= CGI->arg_size() && CGI->isVariadic())
     return NULL;
 

--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -928,7 +928,7 @@ static Expr* findLastExprInStatement(Expr* e, VarSymbol* v) {
     }
   }
 
-  // Check if the early deinit point is the same as the the
+  // Check if the early deinit point is the same as the
   // usual (end of block) deinit point. If it is, treat the variable
   // as end-of-block to simplify matters.
   GotoStmt* gotoStmt = toGotoStmt(stmt);

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -2793,7 +2793,7 @@ static void insertInitConversion(Symbol* to, Symbol* toType, Symbol* from,
   }
 }
 
-// Adds conversions for cases where the the lhs and rhs types of
+// Adds conversions for cases where the lhs and rhs types of
 // PRIM_MOVE/PRIM_ASSIGN do not match. The conversions might be implemented
 // with a cast or init=.
 //

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -375,7 +375,7 @@ non-nilable classes are not currently supported.
    ``nil``. The next statement assigned to it an instance of the class
    ``C``. The declaration of variable ``c2`` shows that these steps can
    be combined. The type of ``c2`` is also ``borrowed C?``, determined
-   implicitly from the the initialization expression. Finally, an object
+   implicitly from the initialization expression. Finally, an object
    of type ``owned D`` is created and assigned to ``c``.
 
 .. _Class_nil_value:

--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -227,7 +227,7 @@ subtype of a type ``T2`` if:
 
  * ``T2`` is a generic type (:ref:`Generic_Types`) and ``T1`` is an
    instantiation that type
- * ``T1`` is a class type that inherits from the the class ``T2``
+ * ``T1`` is a class type that inherits from the class ``T2``
    (:ref:`Inheritance`)
  * ``T1`` is a non-nilable class type (e.g. ``borrowed C``) and ``T2`` is
    the nilable version of the same class type (e.g. ``borrowed C?``)

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -374,7 +374,7 @@ The *these* Method
 
 An iterator method declared with the name ``these`` allows the receiver
 to be “iterated over” similarly to how a domain or array supports
-iteration. When a value supporting a ``these`` method is used as the the
+iteration. When a value supporting a ``these`` method is used as the
 ``iteratable-expression`` of a loop, the loop proceeds in a manner
 controlled by the ``these`` iterator.
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -12,7 +12,7 @@ this programming-languages sense, rather than in the mathematical sense.
 A function has zero or more *formal arguments*, or simply *formals*.
 Upon a function call each formal is associated with the corresponding
 *actual argument*, or simply *actual*. Actual arguments are provided as
-part of the call expression, or at the the *call site*. Direct and
+part of the call expression, or at the *call site*. Direct and
 indirect recursion is supported.
 
 A function can be a *procedure*, which completes and returns to the call

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -444,7 +444,7 @@ The do-while loop is executed as follows:
    statement following the loop.
 
 #. If the expression evaluates to ``true``, control continues to step 1
-   and the the statement is executed again.
+   and the statement is executed again.
 
 In this second form of the loop, note that the statement is executed
 unconditionally the first time.

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -409,7 +409,7 @@ module ChapelArray {
   // increment/decrement the reference count based on the
   // number of indices in the outer domain instead; this could
   // cause the domain to be deallocated prematurely in the
-  // case the the outer domain was empty.  For example:
+  // case the outer domain was empty.  For example:
   //
   //   var D = {1..0};   // start empty; we'll resize later
   //   var A: [D] [1..2] real;

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1813,7 +1813,7 @@ proc solve(A: [?Adom] ?eltType, b: [?bdom] eltType) {
 
    Returns a tuple of ``(x, residues, rank, s)``, where:
 
-    - ``x`` is the the least-squares solution with shape of ``b``
+    - ``x`` is the least-squares solution with shape of ``b``
 
     - ``residues`` is:
 

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -1175,7 +1175,7 @@ module GMP {
 
   /* Return the number of limbs allocated in an __mpz_struct */
   private extern proc chpl_gmp_mpz_struct_nalloc(from: __mpz_struct) : mp_size_t;
-  /* Return the the number of limbs used with the sign of the mpz number
+  /* Return the number of limbs used with the sign of the mpz number
      for an __mpz_struct */
   private extern proc chpl_gmp_mpz_struct_sign_size(from: __mpz_struct) : mp_size_t;
   /* Set the sign and number of fields used in an mpz

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1321,7 +1321,7 @@ iter string.split(pattern: regex(string), maxsplit: int = 0)
 
 
 /*
-   Split the the receiving string by occurrences of the passed regular
+   Split the receiving string by occurrences of the passed regular
    expression by calling :proc:`regex.split`.
 
    :arg sep: the regular expression to use to split
@@ -1347,7 +1347,7 @@ iter bytes.split(pattern: regex(bytes), maxsplit: int = 0)
 
 
 /*
-   Split the the receiving bytes by occurrences of the passed regular
+   Split the receiving bytes by occurrences of the passed regular
    expression by calling :proc:`regex.split`.
 
    :arg sep: the regular expression to use to split

--- a/runtime/include/qio/bswap.h
+++ b/runtime/include/qio/bswap.h
@@ -96,7 +96,7 @@
 // have htobe## htole## be##toh and le##toh. We do that by
 // checking for one of them. We assume that if one of that
 // width exists, the rest do. If we don't have bswap_## already,
-// we will define it so that we can define the the htobe...
+// we will define it so that we can define the htobe...
 // functions based on the machine's byte order.
 //
 // These default implementations are copied from glibc bits/byteswap.h

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -667,7 +667,7 @@ static chpl_taskID_t get_next_task_id(void) {
 
 
 //
-// Get the the thread private data pointer for my thread.
+// Get the thread private data pointer for my thread.
 //
 static inline
 thread_private_data_t* get_thread_private_data(void) {

--- a/test/gpu/native/studies/shoc/sort.chpl
+++ b/test/gpu/native/studies/shoc/sort.chpl
@@ -64,7 +64,7 @@ proc runSort(){
         }
         numScanElts = numBlocks;
     } while (numScanElts > 1);
-    // Print the the above vars to see if they match the expected values
+    // Print the above vars to see if they match the expected values
 
     scanBlockSums[level] = new list(uint(32)); // Size of this last list is just 1
 

--- a/test/library/draft/arrow/Arrow.chpl
+++ b/test/library/draft/arrow/Arrow.chpl
@@ -224,7 +224,7 @@
       // Adding the column to the list
       fields = g_list_append(fields, col);
 
-      // Moving on the the next pair of arguments
+      // Moving on to the next pair of arguments
     }
 
     // Gotta build this schema now

--- a/test/reductions/partial/utilities.chpl
+++ b/test/reductions/partial/utilities.chpl
@@ -45,7 +45,7 @@ proc partRedCheckAndCreateResultDimensions(dist, resDimSpec, srcArr, srcDims)
         else if specD.boundedType == BoundedRangeType.boundedNone then
           resDims(dim) = srcDims(dim);
         else
-          compilerError("the range in the the dimension " + dim + " of the shape of the partial reduction is neither fully bounded nor fully unbounded");
+          compilerError("the range in the dimension " + dim + " of the shape of the partial reduction is neither fully bounded nor fully unbounded");
       }
       else {
         compilerError("the dimension " + dim + " of the shape of the partial reduction is neither a range nor an individual index");

--- a/test/release/examples/primers/arrays.chpl
+++ b/test/release/examples/primers/arrays.chpl
@@ -28,7 +28,7 @@ var A: [1..n] real;
 writeln("Initially, A is: ", A);
 
 //
-// Arrays can also be declared using the the array literal syntax.
+// Arrays can also be declared using the array literal syntax.
 // Array literals are specified by enclosing a comma separated list of
 // expressions in square brackets.  The domain of the array will be
 // 0-based, and the type of the array's elements will be that of the

--- a/test/release/examples/primers/specialMethods.chpl
+++ b/test/release/examples/primers/specialMethods.chpl
@@ -67,7 +67,7 @@ record R {
 */
 
 // The ``this`` method gives the record the ability to be accessed like an
-// array.  Here we use the the argument as an index to choose a tuple element.
+// array.  Here we use the argument as an index to choose a tuple element.
 proc R.this(n: int) ref {
   if !vals.indices.contains(n) then
     halt("index out of bounds accessing R");

--- a/test/studies/shootout/meteor/kbrady/meteor-implicit-domain.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-implicit-domain.chpl
@@ -296,7 +296,7 @@ module meteor {
 
   /* To thin the number of pieces, I calculate if any of them trap any empty
    * cells at the edges.  There are only a handful of exceptions where the
-   * the board can be solved with the trapped cells.  For example:  piece 8 can
+   * board can be solved with the trapped cells.  For example:  piece 8 can
    * trap 5 cells in the corner, but piece 3 can fit in those cells, or piece 0
    * can split the board in half where both halves are viable.
    */

--- a/test/studies/shootout/meteor/kbrady/meteor.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor.chpl
@@ -296,7 +296,7 @@ module meteor {
 
   /* To thin the number of pieces, I calculate if any of them trap any empty
    * cells at the edges.  There are only a handful of exceptions where the
-   * the board can be solved with the trapped cells.  For example:  piece 8 can
+   * board can be solved with the trapped cells.  For example:  piece 8 can
    * trap 5 cells in the corner, but piece 3 can fit in those cells, or piece 0
    * can split the board in half where both halves are viable.
    */

--- a/test/types/records/ferguson/expiring-value-alias.chpl
+++ b/test/types/records/ferguson/expiring-value-alias.chpl
@@ -299,7 +299,7 @@ proc test6()
   // now local_dom "aliases" globalR
   test6_part2(makeAlias(globalR.c)); // does argument passing create a copy?
   // 2019-03 - Chapel and C++ do not make a copy here
-  // (note that the the default argument passing in Chapel corresponds
+  // (note that the default argument passing in Chapel corresponds
   // to 'const ref' in C++).
 }
 


### PR DESCRIPTION
Fix "the the" typos in

compiler: clangUtil.cpp, addAutoDestroyCalls.cpp, resolveFunction.cpp
spec: classes.rst, conversions.rst, methods.rst, procedures.rst, statements.rst
modules: ChapelArray, LinearAlgebra, GMP, Regex, 
runtime: bswap.h, tasks-fifo.c
primers: arrays, specialMethods
tests: shoc sort, partial reductions utilities.chpl, kbrady meteor shootouts,
         expiring-values-alias.chpl