### PR TITLE
Fix node.js warning in workflow CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: make check
       run: |
         ./util/buildRelease/smokeTest chpl
@@ -39,7 +39,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: make frontend-docs
       run: |
         make frontend-docs
@@ -61,7 +61,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: make mason
       # Use a quickstart config to keep it from running to long
       # While there, run a make check in that config for more coverage
@@ -76,7 +76,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: make test-dyno-with-asserts
       run: |
         make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
@@ -92,7 +92,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100000
     - name: find bad runtime calls

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -34,7 +34,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1.14.1
         with:


### PR DESCRIPTION
To fix the issue reported in the slack thread 
https://cray.slack.com/archives/CGSFYJN86/p1665761869247239

Upgrading checkout options from v2 to v3. 
Version v3 supports latest version node.js 16. 
v2 supports node.js version 12 which will be deprecated soon.

Issue is tracked with https://github.com/Cray/chapel-private/issues/3934