### PR TITLE
Fix compare link in the email body. Build the compare url from the gi…

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -29,6 +29,7 @@ jobs:
               echo "AUTHOR=$(jq -r '.[0].commit.author.name' commits.json)" >> $GITHUB_ENV   
               echo "LINK=$(jq -r '.[0].html_url' commits.json)" >> $GITHUB_ENV
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
+              echo "COMPARE_URL= $( echo '$github.event.repository.compare_url' | awk -v repbase='${{github.event.pull_request.base.sha}}' -v rephead='${{github.event.pull_request.merge_commit_sha}}' '{gsub("{base}", repbase ) gsub("{head}",rephead ) } {print}' )" >> $GITHUB_ENV          
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.
@@ -73,7 +74,7 @@ jobs:
               Modified Files: <br>
                 M . ${{steps.changed-files.outputs.all_changed_and_modified_files}} <br>
                 D . ${{steps.changed-files.outputs.deleted_files}} <br>
-              Compare: ${{github.event.repository.compare_url}} <br>   
+              Compare: ${{env.COMPARE_URL}} <br>   
               </p>
               </body>
               </html>

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -29,7 +29,7 @@ jobs:
               echo "AUTHOR=$(jq -r '.[0].commit.author.name' commits.json)" >> $GITHUB_ENV   
               echo "LINK=$(jq -r '.[0].html_url' commits.json)" >> $GITHUB_ENV
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
-              echo "COMPARE_URL= $( echo '$github.event.repository.compare_url' | awk -v repbase='${{github.event.pull_request.base.sha}}' -v rephead='${{github.event.pull_request.merge_commit_sha}}' '{gsub("{base}", repbase ) gsub("{head}",rephead ) } {print}' )" >> $GITHUB_ENV          
+              echo "COMPARE_URL= $( echo '${{github.event.repository.compare_url}}' | awk -v repbase='${{github.event.pull_request.base.sha}}' -v rephead='${{github.event.pull_request.merge_commit_sha}}' '{gsub("{base}", repbase ) gsub("{head}",rephead ) } {print}' )" >> $GITHUB_ENV          
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.


### PR DESCRIPTION
…t event pull request target

Compare_url on the pull_request handle does not resolve to base_sha and commit sha.
https://api.github.com/repos/chapel-lang/chapel/compare/{base}...{head}

This PR will substitute base and head with appropriate SHAs(base_sha, merge_sha)