### PR TITLE
Improve internal errors w.r.t. mentions of line numbers

### DIFF
--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -950,7 +950,7 @@ size_t globalCopyPropagation(FnSymbol* fn) {
         // Two available pairs at the start of a basic block should not have
         // the same LHS, because one should kill the other.
         // Also, this makes arbitrary the choice of which one survives.
-        INT_ASSERT(available.find(ap.first) == available.end());
+        INT_ASSERT(fn, available.find(ap.first) == available.end());
         available.insert(ap);
         ravailable[ap.second].push_back(ap.first);
       }

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -789,7 +789,7 @@ static void cleanupNothingVarsAndFields() {
       case PRIM_ASSIGN:
         if (isNothingType(call->get(2)->typeInfo()) ||
             call->get(2)->typeInfo() == dtNothing->refType) {
-          INT_ASSERT(call->get(1)->typeInfo() == call->get(2)->typeInfo());
+          INT_ASSERT(call, call->get(1)->typeInfo() == call->get(2)->typeInfo());
           // Remove moves where the rhs has type nothing. If the rhs is a
           // call to something other than a few primitives, still make
           // that call, just don't move the result into anything.

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -528,6 +528,11 @@ static bool interestingModuleInit(FnSymbol* fn) {
   return strcmp(modulename, basename) != 0;
 }
 
+// return values:
+//   -1 = no filename:line# was printed;
+//    0 = they were printed and were not the result of a guess
+//    1 = they were printed but were the result of a guess
+//
 static int printErrorHeader(BaseAST* ast, astlocT astloc) {
 
   if (Expr* expr = toExpr(ast)) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -672,9 +672,9 @@ static void printErrorFooter(int guess) {
     print_error("\n\n"
       "Internal errors indicate a bug in the Chapel compiler (\"It's us, not you\"),\n"
       "and we're sorry for the hassle.  We would appreciate your reporting this bug --\n"
-      "please see %s for instructions.%s\n", help_url,
+      "please see %s for instructions.%s\n\n", help_url,
       (guess == -1) ? "" : "  In the meantime,\n"
-      "the filename + line number above may be useful in working around the issue.\n");
+      "the filename + line number above may be useful in working around the issue.");
 
     //
     // and exit if it's fatal (isn't it always?)

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -674,7 +674,7 @@ static void printErrorFooter(int guess) {
       "and we're sorry for the hassle.  We would appreciate your reporting this bug --\n"
       "please see %s for instructions.%s\n", help_url,
       (guess == -1) ? "" : "  In the meantime,\n"
-      "the filename + line number above may be useful in working around the issue.\n\n");
+      "the filename + line number above may be useful in working around the issue.\n");
 
     //
     // and exit if it's fatal (isn't it always?)

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -528,7 +528,7 @@ static bool interestingModuleInit(FnSymbol* fn) {
   return strcmp(modulename, basename) != 0;
 }
 
-static bool printErrorHeader(BaseAST* ast, astlocT astloc) {
+static int printErrorHeader(BaseAST* ast, astlocT astloc) {
 
   if (Expr* expr = toExpr(ast)) {
     Expr* use = findLocationIgnoringInternalInlining(expr);
@@ -609,9 +609,10 @@ static bool printErrorHeader(BaseAST* ast, astlocT astloc) {
     }
   }
 
-  bool guess = filename && !have_ast_line;
+  int guess = -1;  // -1=no filename:line# printed; 0=not guessed; 1=guessed
 
   if (filename) {
+    guess = !have_ast_line;
     if (err_fatal && err_user) {
       // save the error location for printsSameLocationAsLastError
       last_error_loc = astlocT(linenum, filename);
@@ -647,7 +648,7 @@ static bool printErrorHeader(BaseAST* ast, astlocT astloc) {
 }
 
 
-static void printErrorFooter(bool guess) {
+static void printErrorFooter(int guess) {
   //
   // For developers, indicate the compiler source location where an
   // internal error was generated.
@@ -660,7 +661,7 @@ static void printErrorFooter(bool guess) {
   // AST was not passed to the INT_FATAL() macro and we relied on the
   // global SET_LINENO() information instead), indicate that.
   //
-  if (guess) {
+  if (guess == 1) {
     print_error("\nNote: This source location is a guess.");
   }
 
@@ -671,9 +672,9 @@ static void printErrorFooter(bool guess) {
     print_error("\n\n"
       "Internal errors indicate a bug in the Chapel compiler (\"It's us, not you\"),\n"
       "and we're sorry for the hassle.  We would appreciate your reporting this bug --\n"
-      "please see %s for instructions.  In the meantime,\n"
-      "the filename + line number above may be useful in working around the issue.\n\n",
-      help_url);
+      "please see %s for instructions.%s\n", help_url,
+      (guess == -1) ? "" : "  In the meantime,\n"
+      "the filename + line number above may be useful in working around the issue.\n\n");
 
     //
     // and exit if it's fatal (isn't it always?)
@@ -854,9 +855,7 @@ static void vhandleError(const BaseAST* ast,
     // now the rest of this function will report the additional error
   }
 
-  bool guess = false;
-
-  guess = printErrorHeader(const_cast<BaseAST*>(ast), astloc);
+  int guess = printErrorHeader(const_cast<BaseAST*>(ast), astloc);
 
   //
   // Only print out the arguments if this is a user error or we're

--- a/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
@@ -4,6 +4,5 @@ internal error: COD-CG--BOL-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
+please see https://chapel-lang.org/bugs.html for instructions.
 

--- a/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.bad
@@ -4,6 +4,5 @@ internal error: COD-CG--BOL-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
+please see https://chapel-lang.org/bugs.html for instructions.
 

--- a/test/functions/iterators/bradc/captureEmpty.bad
+++ b/test/functions/iterators/bradc/captureEmpty.bad
@@ -1,4 +1,4 @@
-internal error: RES-CLE-UPS-nnnn chpl version mmmm
+captureEmpty.chpl:5: internal error: RES-CLE-UPS-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug --

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug.bad
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug.bad
@@ -1,4 +1,4 @@
-internal error: OPT-COP-ION-0949 chpl version 1.27.0 pre-release (d3784d28a2)
+revcomp-blc-copyPropBug.chpl:51: internal error: OPT-COP-ION-0949 chpl version 1.27.0 pre-release (d3784d28a2)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug --

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-dowhile-bug.bad
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-dowhile-bug.bad
@@ -1,4 +1,4 @@
-internal error: OPT-COP-ION-0904 chpl version 1.23.0 pre-release (dc8c98a9ae)
+revcomp-dowhile-bug.chpl:58: internal error: OPT-COP-ION-0904 chpl version 1.23.0 pre-release (dc8c98a9ae)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug --


### PR DESCRIPTION
Based on a recent user comment, it was noted that our standard
internal error message refers to a line number, but that not all
internal errors generate line numbers.  This improves that message
to only print that part of the message in the event that a line
number was actually printed out.

While here, I also added AST nodes to some assertion errors to
add line numbers for them; however, many more potential cases
for improvement like this remain.

TODO:
- [x] either update .bad files for cases that do this today
- [x] or else update their internal errors to include a line number