### PR TITLE
dyno: fix more scope resolution issues

### DIFF
--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -27,6 +27,7 @@ namespace chpl {
 namespace resolution {
 
   using ScopeSet = llvm::SmallPtrSet<const Scope*, 5>;
+  using NamedScopeSet = std::unordered_set<std::pair<UniqueString, const Scope*>>;
 
   /**
     Returns true if this AST type can create a scope.
@@ -85,7 +86,7 @@ namespace resolution {
                            const Scope* receiverScope,
                            UniqueString name,
                            LookupConfig config,
-                           ScopeSet& visited);
+                           NamedScopeSet& visited);
 
   /**
     Returns true if all of checkScope is visible from fromScope

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -22,16 +22,21 @@
 
 #include "chpl/types/Type.h"
 #include "chpl/uast/AstNode.h"
+#include "chpl/uast/Decl.h"
 #include "chpl/util/memory.h"
 #include "chpl/util/iteration.h"
 
 #include <unordered_map>
 #include <utility>
 
+#include "llvm/ADT/Optional.h"
+
 namespace chpl {
 namespace resolution {
 
 class BorrowedIdsWithName;
+
+using OwnedID = std::pair<ID, uast::Decl::Visibility>;
 
 /**
   Collects IDs with a particular name. These can be referred to
@@ -43,27 +48,27 @@ class OwnedIdsWithName {
  private:
   // If there is just one ID with this name, it is stored here,
   // and moreIds == nullptr.
-  ID id_;
+  OwnedID id_;
   // If there is more than one, all are stored in here,
   // and id redundantly stores the first one.
   // This field is 'owned' in order to allow reuse of pointers to it.
-  owned<std::vector<ID>> moreIds_;
+  owned<std::vector<OwnedID>> moreIds_;
 
  public:
   /** Construct an OwnedIdsWithName containing one ID. */
-  OwnedIdsWithName(ID id)
-    : id_(std::move(id)), moreIds_(nullptr)
+  OwnedIdsWithName(ID id, uast::Decl::Visibility vis)
+    : id_(std::make_pair(std::move(id), vis)), moreIds_(nullptr)
   { }
 
   /** Append an ID to an OwnedIdsWithName. */
-  void appendId(ID newId) {
+  void appendId(ID id, uast::Decl::Visibility vis) {
     if (moreIds_.get() == nullptr) {
       // create the vector and add the single existing id to it
-      moreIds_ = toOwned(new std::vector<ID>());
+      moreIds_ = toOwned(new std::vector<OwnedID>());
       moreIds_->push_back(id_);
     }
     // add the id passed
-    moreIds_->push_back(std::move(newId));
+    moreIds_->push_back(std::make_pair(std::move(id), vis));
   }
 
   bool operator==(const OwnedIdsWithName& other) const {
@@ -83,15 +88,17 @@ class OwnedIdsWithName {
     return !(*this == other);
   }
   void mark(Context* context) const {
-    id_.mark(context);
+    id_.first.mark(context);
     if (auto ptr = moreIds_.get()) {
       for (auto const& elt : *ptr) {
-        context->markOwnedPointer(&elt);
+        context->markOwnedPointer(&elt.first);
       }
     }
   }
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  llvm::Optional<BorrowedIdsWithName> borrow(bool skipPrivateVisibilities) const;
 
   /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
@@ -103,51 +110,28 @@ class OwnedIdsWithName {
   reference to a collection stored in OwnedIdsWithName.
  */
 class BorrowedIdsWithName {
- private:
-  // TODO: consider storing a variant of ID here
-  // with symbolPath, postOrderId, and tag
-  ID id_;
-  const std::vector<ID>* moreIds_ = nullptr;
- public:
-  /** Construct an empty BorrowedIdsWithName */
-  BorrowedIdsWithName() { }
-  /** Construct a BorrowedIdsWithName referring to one ID */
-  BorrowedIdsWithName(ID id) : id_(std::move(id)) { }
-  /** Construct a BorrowedIdsWithName referring to the same IDs
-      as the passed OwnedIdsWithName.
-      This BorrowedIdsWithName assumes that the OwnedIdsWithName
-      will continue to exist. */
-  BorrowedIdsWithName(const OwnedIdsWithName& o)
-    : id_(o.id_), moreIds_(o.moreIds_.get())
-  { }
+ // To allow us to use the private constructor
+ friend class OwnedIdsWithName;
 
-  /** Return the number of IDs stored here */
-  int numIds() const {
-    if (moreIds_ == nullptr) {
-      return 1;
-    }
-    return moreIds_->size();
+ private:
+  static inline bool isIDVisible(const OwnedID& id, bool skipPrivateVisibilities) {
+    return !skipPrivateVisibilities || id.second != uast::Decl::PRIVATE;
   }
 
-  /** Returns the i'th ID. id(0) is always available. */
-  const ID& id(int i) const {
-    if (i == 0) {
-      return id_;
-    }
-    assert(moreIds_ && 0 <= i && (size_t) i < moreIds_->size());
-    return (*moreIds_)[i];
+  bool isIDVisible(const OwnedID& id) const {
+    return isIDVisible(id, skipPrivateVisibilities);
   }
 
   /** Returns an iterator referring to the first element stored. */
-  const ID* begin() const {
+  const OwnedID* beginOwned() const {
     if (moreIds_ == nullptr) {
       return &id_;
     }
     return &(*moreIds_)[0];
   }
   /** Returns an iterator referring just past the last element stored. */
-  const ID* end() const {
-    const ID* last = nullptr;
+  const OwnedID* endOwned() const {
+    const OwnedID* last = nullptr;
     if (moreIds_ == nullptr) {
       last = &id_;
     } else {
@@ -156,9 +140,102 @@ class BorrowedIdsWithName {
     // return the element just past the last element
     return last+1;
   }
+ public:
+  /**
+    Iterator that skips invisible entries from the list of borrowed IDs.
+   */
+  class BorrowedIdsWithNameIter : public std::iterator<ID, std::forward_iterator_tag> {
+    // To allow use of isIDVisible
+    friend class BorrowedIdsWithName;
+   private:
+    /** The borrowed IDs over which we are iterating. */
+    const BorrowedIdsWithName* ids;
+    /** The ID this iterator is pointing too. */
+    const OwnedID* currentId;
+
+    BorrowedIdsWithNameIter(const BorrowedIdsWithName* ids, const OwnedID* currentId)
+      : ids(ids), currentId(currentId) {
+      fastForward();
+    }
+
+    /** Skip over symbols deemed invisible by the BorrowedIdsWithName. **/
+    void fastForward() {
+      while (currentId != ids->endOwned() && !ids->isIDVisible(*currentId)) {
+        currentId++;
+      }
+    }
+
+   public:
+    bool operator!=(const BorrowedIdsWithNameIter& other) const {
+      return ids != other.ids || currentId != other.currentId;
+    }
+    BorrowedIdsWithNameIter& operator++() {
+      currentId++;
+      fastForward();
+      return *this;
+    }
+    inline const ID& operator*() const { return currentId->first; }
+  };
+ private:
+  /**
+    Whether or not this list of IDs should include the private IDs
+    from the scope.
+   */
+  bool skipPrivateVisibilities;
+  /** How many IDs are visible in this list. */
+  int numIds_;
+  // TODO: consider storing a variant of ID here
+  // with symbolPath, postOrderId, and tag
+  OwnedID id_;
+  const std::vector<OwnedID>* moreIds_ = nullptr;
+
+  /** Construct a BorrowedIdsWithName referring to the same IDs
+      as the passed OwnedIdsWithName.
+      This BorrowedIdsWithName assumes that the OwnedIdsWithName
+      will continue to exist. */
+  BorrowedIdsWithName(OwnedID id, const std::vector<OwnedID>* moreIds,
+                      bool skipPrivateVisibilities)
+    : skipPrivateVisibilities(skipPrivateVisibilities), id_(id),
+      moreIds_(moreIds) {
+    if(moreIds_ == nullptr) {
+      numIds_ = 1;
+      return;
+    }
+
+    // Count all the visible IDs.
+    numIds_ = 0;
+    for (const auto& id : *moreIds_) {
+      if (isIDVisible(id)) numIds_ += 1;
+    }
+  }
+ public:
+  /** Construct a BorrowedIdsWithName referring to one ID */
+  BorrowedIdsWithName(ID id, uast::Decl::Visibility vis)
+    : skipPrivateVisibilities(true), numIds_(1),
+      id_(std::make_pair(std::move(id), vis)) { }
+
+  /** Return the number of IDs stored here */
+  int numIds() const {
+    return numIds_;
+  }
+
+  /** Returns the first ID in this list. */
+  const ID& firstId() const {
+    return id_.first;
+  }
+
+  BorrowedIdsWithNameIter begin() const {
+    return BorrowedIdsWithNameIter(this, beginOwned());
+  }
+
+  BorrowedIdsWithNameIter end() const {
+    return BorrowedIdsWithNameIter(this, endOwned());
+  }
 
   bool operator==(const BorrowedIdsWithName& other) const {
-    return id_ == other.id_ &&
+    return skipPrivateVisibilities == other.skipPrivateVisibilities &&
+           numIds_ == other.numIds_ &&
+           id_ == other.id_ &&
            moreIds_ == other.moreIds_;
   }
   bool operator!=(const BorrowedIdsWithName& other) const {
@@ -167,10 +244,13 @@ class BorrowedIdsWithName {
 
   size_t hash() const {
     size_t ret = 0;
+    ret = hash_combine(ret, chpl::hash(skipPrivateVisibilities));
+    ret = hash_combine(ret, chpl::hash(numIds_));
+    ret = hash_combine(ret, chpl::hash(moreIds_));
     if (moreIds_ == nullptr) {
       ret = hash_combine(ret, chpl::hash(id_));
     } else {
-      for (const ID& x : *moreIds_) {
+      for (const auto& x : *moreIds_) {
         ret = hash_combine(ret, chpl::hash(x));
       }
     }
@@ -265,11 +345,17 @@ class Scope {
       append the relevant BorrowedIdsToName the the vector.
       Returns true if something was appended. */
   bool lookupInScope(UniqueString name,
-                     std::vector<BorrowedIdsWithName>& result) const {
+                     std::vector<BorrowedIdsWithName>& result,
+                     bool skipPrivateVisibilities) const {
     auto search = declared_.find(name);
     if (search != declared_.end()) {
-      result.push_back(BorrowedIdsWithName(search->second));
-      return true;
+      // There might not be any IDs that are visible to us, so borrow returns
+      // an optional list.
+      auto borrowedIds = search->second.borrow(skipPrivateVisibilities);
+      if (borrowedIds.hasValue()) {
+        result.push_back(std::move(borrowedIds.getValue()));
+        return true;
+      }
     }
     return false;
   }

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -495,8 +495,8 @@ bool InitResolver::handleUseOfField(const AstNode* node) {
 ID InitResolver::solveNameConflictByIgnoringField(const NameVec& vec) {
   if (vec.size() != 2) return ID();
   if (vec[0].numIds() > 1 || vec[1].numIds() > 1) return ID();
-  auto one = vec[0].id(0);
-  auto two = vec[1].id(0);
+  auto one = vec[0].firstId();
+  auto two = vec[1].firstId();
   assert(one != two);
   if (!parsing::idIsField(ctx_, one) &&
       !parsing::idIsField(ctx_, two)) return ID();
@@ -511,7 +511,7 @@ bool InitResolver::handleResolvingFieldAccess(const Identifier* node) {
 
   // Handle and exit early if there were no ambiguities.
   if (vec.size() == 1 && vec[0].numIds() == 1) {
-    auto& id = vec[0].id(0);
+    auto& id = vec[0].firstId();
     if (parsing::idIsField(ctx_, id)) {
       auto state = fieldStateFromId(id);
       auto qt = state->qt;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1571,7 +1571,7 @@ bool Resolver::resolveIdentifier(const Identifier* ident,
     // call, we'll establish it later anyway.
   } else {
     // vec.size() == 1 and vec[0].numIds() <= 1
-    const ID& id = vec[0].id(0);
+    const ID& id = vec[0].firstId();
     QualifiedType type;
     if (id.isEmpty()) {
       // empty IDs from the scope resolution process are builtins
@@ -1722,7 +1722,7 @@ bool Resolver::enter(const NamedDecl* decl) {
 
     if (vec.size() > 0) {
       const BorrowedIdsWithName& m = vec[0];
-      if (m.id(0) == decl->id()) {
+      if (m.firstId() == decl->id()) {
         // Checks if the given ID refers to a declaration conflicting
         // with this one. Functions don't conflict.
         auto isConflictingId = [&](auto decl) {
@@ -2305,7 +2305,7 @@ QualifiedType Resolver::typeForEnumElement(const EnumType* enumType,
       CHPL_REPORT(context, MultipleEnumElems, nodeForErr, elementName, enumType, std::move(redefinedIds));
       return QualifiedType(QualifiedType::CONST_VAR, enumType);
     } else {
-      auto id = vec[0].id(0);
+      auto id = vec[0].firstId();
       auto newParam = EnumParam::get(context, id);
       outElemId = id;
       return QualifiedType(QualifiedType::PARAM, enumType, newParam);
@@ -2355,7 +2355,7 @@ void Resolver::exit(const Dot* dot) {
       // call, we'll establish it later anyway.
     } else {
       // vec.size() == 1 and vec[0].numIds() <= 1
-      const ID& id = vec[0].id(0);
+      const ID& id = vec[0].firstId();
       QualifiedType type;
       if (id.isEmpty()) {
         // empty IDs from the scope resolution process are builtins
@@ -2679,7 +2679,7 @@ static bool computeTaskIntentInfo(Resolver& resolver, const NamedDecl* intent,
   auto vec = lookupNameInScope(resolver.context, scope, receiverScope,
                                intent->name(), config);
   if (vec.size() == 1) {
-    resolvedId = vec[0].id(0);
+    resolvedId = vec[0].firstId();
     if (resolver.scopeResolveOnly == false) {
       if (resolvedId.isEmpty()) {
         type = typeForBuiltin(resolver.context, intent->name());

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2488,7 +2488,7 @@ static std::vector<BorrowedIdsWithName>
 lookupCalledExpr(Context* context,
                  const Scope* scope,
                  const CallInfo& ci,
-                 ScopeSet& visited) {
+                 NamedScopeSet& visited) {
   const LookupConfig config = LOOKUP_DECLS |
                               LOOKUP_IMPORT_AND_USE |
                               LOOKUP_PARENTS;
@@ -2929,7 +2929,7 @@ static std::vector<BorrowedIdsWithName>
 lookupCalledExprConsideringReceiver(Context* context,
                                     const Scope* inScope,
                                     const CallInfo& ci,
-                                    ScopeSet& visited) {
+                                    NamedScopeSet& visited) {
   const Scope* receiverScope = nullptr;
 
   // For method and operator calls, also consider the receiver scope.
@@ -2969,7 +2969,7 @@ resolveFnCallFilterAndFindMostSpecific(Context* context,
   // search for candidates at each POI until we have found a candidate
   CandidatesVec candidates;
   size_t firstPoiCandidate = 0;
-  ScopeSet visited;
+  NamedScopeSet visited;
 
   // inject compiler-generated candidates in a manner similar to below
   // (note that any added candidates are already fully instantiated)

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -55,7 +55,7 @@ static void gather(DeclMap& declared, UniqueString name, const AstNode* d,
   } else {
     // found an entry, so add to it
     OwnedIdsWithName& val = search->second;
-    val.appendId(d->id(), visibility);
+    val.appendIdAndVis(d->id(), visibility);
   }
 }
 

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -304,7 +304,7 @@ static bool doLookupInScope(Context* context,
                             const ResolvedVisibilityScope* resolving,
                             UniqueString name,
                             LookupConfig config,
-                            ScopeSet& checkedScopes,
+                            NamedScopeSet& checkedScopes,
                             std::vector<BorrowedIdsWithName>& result);
 
 static const ResolvedVisibilityScope*
@@ -330,7 +330,7 @@ static bool doLookupInImports(Context* context,
                               UniqueString name,
                               bool onlyInnermost,
                               bool skipPrivateVisibilities,
-                              ScopeSet& checkedScopes,
+                              NamedScopeSet& checkedScopes,
                               std::vector<BorrowedIdsWithName>& result) {
   // Get the resolved visibility statements, if available
   const ResolvedVisibilityScope* r = nullptr;
@@ -429,7 +429,7 @@ static bool doLookupInScope(Context* context,
                             const ResolvedVisibilityScope* resolving,
                             UniqueString name,
                             LookupConfig config,
-                            ScopeSet& checkedScopes,
+                            NamedScopeSet& checkedScopes,
                             std::vector<BorrowedIdsWithName>& result) {
 
   bool checkDecls = (config & LOOKUP_DECLS) != 0;
@@ -449,7 +449,7 @@ static bool doLookupInScope(Context* context,
   // two 'result' vector entries in that case...
   size_t startSize = result.size();
 
-  auto pair = checkedScopes.insert(scope);
+  auto pair = checkedScopes.insert(std::make_pair(name, scope));
   if (pair.second == false) {
     // scope has already been visited by this function,
     // so don't try it again.
@@ -556,7 +556,7 @@ static bool lookupInScopeViz(Context* context,
                              VisibilityStmtKind useOrImport,
                              bool isFirstPart,
                              std::vector<BorrowedIdsWithName>& result) {
-  ScopeSet checkedScopes;
+  NamedScopeSet checkedScopes;
 
   LookupConfig config = LOOKUP_INNERMOST;
 
@@ -601,7 +601,7 @@ std::vector<BorrowedIdsWithName> lookupNameInScope(Context* context,
                                                    const Scope* receiverScope,
                                                    UniqueString name,
                                                    LookupConfig config) {
-  ScopeSet checkedScopes;
+  NamedScopeSet checkedScopes;
 
   return lookupNameInScopeWithSet(context, scope, receiverScope, name,
                                   config, checkedScopes);
@@ -613,7 +613,7 @@ lookupNameInScopeWithSet(Context* context,
                          const Scope* receiverScope,
                          UniqueString name,
                          LookupConfig config,
-                         ScopeSet& visited) {
+                         NamedScopeSet& visited) {
   std::vector<BorrowedIdsWithName> vec;
 
   if (scope) {
@@ -688,7 +688,7 @@ static void errorIfNameNotInScope(Context* context,
                                   UniqueString name,
                                   ID idForErr,
                                   VisibilityStmtKind useOrImport) {
-  ScopeSet checkedScopes;
+  NamedScopeSet checkedScopes;
   std::vector<BorrowedIdsWithName> result;
   LookupConfig config = LOOKUP_INNERMOST |
                         LOOKUP_DECLS |

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -41,7 +41,7 @@ void OwnedIdsWithName::stringify(std::ostream& ss,
 }
 
 llvm::Optional<BorrowedIdsWithName> OwnedIdsWithName::borrow(bool skipPrivateVisibilities) const {
-  if (BorrowedIdsWithName::isIDVisible(id_, skipPrivateVisibilities)) {
+  if (BorrowedIdsWithName::isIdVisible(id_, skipPrivateVisibilities)) {
     return BorrowedIdsWithName(id_, moreIds_.get(), skipPrivateVisibilities);
   }
   // The first ID isn't visible; are others?
@@ -50,7 +50,7 @@ llvm::Optional<BorrowedIdsWithName> OwnedIdsWithName::borrow(bool skipPrivateVis
   }
 
   for (auto& id : *moreIds_) {
-    if (!BorrowedIdsWithName::isIDVisible(id, skipPrivateVisibilities)) continue;
+    if (!BorrowedIdsWithName::isIdVisible(id, skipPrivateVisibilities)) continue;
 
     // Found a visible ID!
     return BorrowedIdsWithName(id, moreIds_.get(), skipPrivateVisibilities);

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -31,13 +31,33 @@ void OwnedIdsWithName::stringify(std::ostream& ss,
                                  chpl::StringifyKind stringKind) const {
   if (auto ptr = moreIds_.get()) {
     for (const auto& elt : *ptr) {
-      elt.stringify(ss, stringKind);
+      elt.first.stringify(ss, stringKind);
     }
   } else {
-    if (!id_.isEmpty()) {
-      id_.stringify(ss, stringKind);
+    if (!id_.first.isEmpty()) {
+      id_.first.stringify(ss, stringKind);
     }
   }
+}
+
+llvm::Optional<BorrowedIdsWithName> OwnedIdsWithName::borrow(bool skipPrivateVisibilities) const {
+  if (BorrowedIdsWithName::isIDVisible(id_, skipPrivateVisibilities)) {
+    return BorrowedIdsWithName(id_, moreIds_.get(), skipPrivateVisibilities);
+  }
+  // The first ID isn't visible; are others?
+  if (moreIds_.get() == nullptr) {
+    return llvm::None;
+  }
+
+  for (auto& id : *moreIds_) {
+    if (!BorrowedIdsWithName::isIDVisible(id, skipPrivateVisibilities)) continue;
+
+    // Found a visible ID!
+    return BorrowedIdsWithName(id, moreIds_.get(), skipPrivateVisibilities);
+  }
+
+  // No ID was visible, so we can't borrow.
+  return llvm::None;
 }
 
 void BorrowedIdsWithName::stringify(std::ostream& ss,
@@ -63,7 +83,7 @@ void Scope::addBuiltin(UniqueString name) {
   // Just refer to empty ID since builtin type declarations don't
   // actually exist in the AST.
   // The resolver knows that the empty ID means a builtin thing.
-  declared_.emplace(name, ID());
+  declared_.insert({ name, OwnedIdsWithName(ID(), uast::Decl::PUBLIC) });
 }
 
 const Scope* Scope::moduleScope() const {


### PR DESCRIPTION
__This PR is best reviewed commit-by-commit.__

This tackled mostly one-off scope resolution issues:

- Functions (even parenless ones) have been made to not throw
   "multiple declaration" errors (they _can_ be overloaded via
   return intents, and they can shadow underlying fields of
   the same name)
- Module identifiers found via import search are deduplicated
  to prevent the same module, found multiple times, from being
  reported as a conflict.
- The "checked scope set" is augmented with the name that was
  used to check it. The same scope can be checked multiple times
  with different names, which would lead to different results.

However, one of the seemingly one-off issues contributed some 33 tests
to the "uncategorized" group, which I have now lifted into a
"private keyword for declarations" category. I'm including
the rationale for my implementation of this feature below; it's
also included in the commit that adds support.

# Implementing `private var x`

To preserve the ability to "borrow" an owned list of IDs in a scope
(which is efficient if the scope has a _lot_ of IDs with a particular
name, such as many overloads of a particular function), this commit
makes the BorrowedIds track whether or not private symbols are to be
reported. A new non-trivial iterator is also added for BorrowedIds,
which skips over entries in the scope when private symbols are being
excluded, and doesn't when private symbols are requested to be left in.
Thus, the iterator returned from a BorrowedIds will contain the correct
symbols without the need to create new (filtered) lists.

This commit also modifies the symbols stored in Owned and Borrowed lists
to include the symbols' visibilities, which is necessary to determine
whether or not they should be reported.

An alternative was to split the OwnedIds into multiple lists, but this would
mean either duplication (one list containing all IDs, and one list containing
IDs only visible publically) or losing order (public IDs, then private
IDs). This approach would also require a non-trivial iterator.

# Testing
- [x] full local
- [x] `--dyno` (162 failures) 
