### PR TITLE
Make binders the default qthreads topology module.

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -27,7 +27,7 @@ endif
 ifneq ($(CHPL_MAKE_HWLOC),none)
   # Have Qthreads get its hwloc topology from the Chapel runtime,
   # unless directed not to.
-  TOPOLOGY=hwloc
+  TOPOLOGY=binders
   ifeq (, $(call isTrue, $(CHPL_QTHREAD_DONT_GET_TOPO_FROM_RT)))
     CFLAGS_NEEDS_RT_INCLUDES = y
     CHPL_QTHREAD_CFG_OPTIONS += --with-hwloc-get-topology-function="chpl_topo_getHwlocTopology()"


### PR DESCRIPTION
This allows the runtime to control the binding of `qthread` shepherds to cores/PUs, which will facilitate future runtime improvements such as dedicated cores for active message handler threads, and running one locale per socket on multi-socket machines such as the EX.

This change should not affect performance. The runtime will pack threads to cores in the same fashion as the `hwloc` topology module.

Closes https://github.com/Cray/chapel-private/issues/3845.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>