### PR TITLE
Stop tying Clang flags for extern blocks to the --cc-warnings flag

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2386,11 +2386,16 @@ void runClang(const char* just_parse_filename) {
   static bool is_installed_fatal_error_handler = false;
 
   // These warnings are _required_ to make sure the code Clang generates
-  // will play well with our backend.
+  // when compiling the code in Chapel 'extern' blocks will play well
+  // with our backend.
   const char* clangRequiredWarningFlags[] = {
-    "-Wall", "-Werror", "-Wpointer-arith",
-    "-Wwrite-strings", "-Wno-strict-aliasing",
-    "-Wmissing-declarations", "-Wmissing-prototypes",
+    "-Wall",
+    "-Werror",
+    "-Wpointer-arith",
+    "-Wwrite-strings",
+    "-Wno-strict-aliasing",
+    "-Wmissing-declarations",
+    "-Wmissing-prototypes",
     "-Wstrict-prototypes",
     "-Wmissing-format-attribute",
     // clang can't tell which functions we use

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2385,14 +2385,18 @@ void runClang(const char* just_parse_filename) {
   bool parseOnly = (just_parse_filename != NULL);
   static bool is_installed_fatal_error_handler = false;
 
-  const char* clang_warn[] = {"-Wall", "-Werror", "-Wpointer-arith",
-                              "-Wwrite-strings", "-Wno-strict-aliasing",
-                              "-Wmissing-declarations", "-Wmissing-prototypes",
-                              "-Wstrict-prototypes",
-                              "-Wmissing-format-attribute",
-                              // clang can't tell which functions we use
-                              "-Wno-unused-function",
-                              NULL};
+  // These warnings are _required_ to make sure the code Clang generates
+  // will play well with our backend.
+  const char* clangRequiredWarningFlags[] = {
+    "-Wall", "-Werror", "-Wpointer-arith",
+    "-Wwrite-strings", "-Wno-strict-aliasing",
+    "-Wmissing-declarations", "-Wmissing-prototypes",
+    "-Wstrict-prototypes",
+    "-Wmissing-format-attribute",
+    // clang can't tell which functions we use
+    "-Wno-unused-function",
+    NULL};
+
   const char* clang_debug = "-g";
   const char* clang_opt = "-O3";
   const char* clang_fast_float = "-ffast-math";
@@ -2458,11 +2462,9 @@ void runClang(const char* just_parse_filename) {
   // add a -I for the generated code directory
   clangCCArgs.push_back(std::string("-I") + getIntermediateDirName());
 
-  // Add warnings flags
-  if (ccwarnings) {
-    for (int i = 0; clang_warn[i]; i++) {
-      clangCCArgs.push_back(clang_warn[i]);
-    }
+  // Always add warnings flags
+  for (int i = 0; clangRequiredWarningFlags[i]; i++) {
+    clangCCArgs.push_back(clangRequiredWarningFlags[i]);
   }
 
   // Add debug flags

--- a/test/extern/ExternBlockClangError.chpl
+++ b/test/extern/ExternBlockClangError.chpl
@@ -1,0 +1,21 @@
+extern {
+  extern void foo();
+  void bar() {
+    foo();
+  }
+}
+
+var globalArr : [1..1] real;
+
+export proc foo() {
+  writeln(here.id, " # before");
+  writeln(here.id, " # ", globalArr.size);
+  writeln(here.id, " # after");
+}
+
+proc main() {
+  coforall loc in Locales do on loc {
+      // this works: foo();                                                      
+      bar();
+  }
+}

--- a/test/extern/ExternBlockClangError.compopts
+++ b/test/extern/ExternBlockClangError.compopts
@@ -1,0 +1,1 @@
+--no-devel --no-cc-warnings

--- a/test/extern/ExternBlockClangError.good
+++ b/test/extern/ExternBlockClangError.good
@@ -1,0 +1,17 @@
+In file included from <built-in>:2:
+ExternBlockClangError.chpl:2:18: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
+  extern void foo();
+                 ^
+                  void
+ExternBlockClangError.chpl:3:8: error: no previous prototype for function 'bar' [-Werror,-Wmissing-prototypes]
+  void bar() {
+       ^
+ExternBlockClangError.chpl:3:3: note: declare 'static' if the function is not intended to be used outside of this translation unit
+  void bar() {
+  ^
+  static 
+ExternBlockClangError.chpl:3:11: error: this old-style function definition is not preceded by a prototype [-Werror,-Wstrict-prototypes]
+  void bar() {
+          ^
+3 errors generated.
+error: error running clang on extern block


### PR DESCRIPTION
Stop tying Clang flags for extern blocks to the --cc-warnings flag

There is a large list of `-W` warning flags we pass to our internal
Clang compiler when invoking it. These flags were not previously
required and were tied to the `--cc-warnings` flag, which meant that
it was possible for non-developer compiles to skip throwing the
flags.

This PR adjusts the invocation to always add the flags. They protect
against a large class of "warnings" (that really ought to be errors)
in C code that the Chapel backend does not know how to handle.

For further justification: the `--cc-warnings` flag is intended to
suppress warnings for _generated_ C code, however C code in extern
blocks is handwritten and is consumed only by the Chapel compiler.
Since `chpl` is the only consumer, it seems fine to require that
all code in extern blocks must compile using specific `-W` flags.
The documentation could be updated to list the flags if needed.

Reviewed by @vasslitvinov. Thanks!

TESTING

- [x] `linux64`, `standard`

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>