### PR TITLE
Reduce noise associated with `WritersReturnBool` deprecation flag

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8654,17 +8654,20 @@ static Type* moveDetermineRhsTypeErrorIfInvalid(CallExpr* call) {
           // this deprecation-specific error message should be removed
           // when the bool-returning-writers deprecation is finalized
           if (
-            // writer methods on channels
-            (rhsFn->isMethod() == 1 &&
-            (
-                std::strcmp("write", rhsName) == 0 ||
-                std::strcmp("writeln", rhsName) == 0 ||
-                std::strcmp("writebits", rhsName) == 0 ||
-                std::strcmp("writeBytes", rhsName) == 0 ||
-                std::strcmp("writef", rhsName) == 0
-            )) ||
-            // or, top-level writef
-            std::strcmp("writef", rhsName) == 0
+            rhsFn->getModule()->modTag != MOD_USER && (
+              // writer methods on channels
+              (rhsFn->isMethod() == 1 &&
+                (
+                    std::strcmp("write", rhsName) == 0 ||
+                    std::strcmp("writeln", rhsName) == 0 ||
+                    std::strcmp("writebits", rhsName) == 0 ||
+                    std::strcmp("writeBytes", rhsName) == 0 ||
+                    std::strcmp("writef", rhsName) == 0
+                )
+              ) ||
+              // or, top-level writef
+              std::strcmp("writef", rhsName) == 0
+            )
           ) {
             // emit the write* specific error message:
             USR_FATAL(userCall(call),

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8651,10 +8651,35 @@ static Type* moveDetermineRhsTypeErrorIfInvalid(CallExpr* call) {
           if (rhsFn->hasFlag(FLAG_PROMOTION_WRAPPER))
             rhsName = unwrapFnName(rhsFn);
 
-          USR_FATAL(userCall(call),
+          // this deprecation-specific error message should be removed
+          // when the bool-returning-writers deprecation is finalized
+          if (
+            // writer methods on channels
+            (rhsFn->isMethod() == 1 &&
+            (
+                std::strcmp("write", rhsName) == 0 ||
+                std::strcmp("writeln", rhsName) == 0 ||
+                std::strcmp("writebits", rhsName) == 0 ||
+                std::strcmp("writeBytes", rhsName) == 0 ||
+                std::strcmp("writef", rhsName) == 0
+            )) ||
+            // or, top-level writef
+            std::strcmp("writef", rhsName) == 0
+          ) {
+            // emit the write* specific error message:
+            USR_FATAL(userCall(call),
+                    "illegal use of boolean return value from '%s'. "
+                    "Note: this functionality is deprecated; recompile "
+                    "with -sWritersReturnBool=true to continue using the "
+                    "deprecated behavior.",
+                    rhsName);
+          } else {
+            // otherwise, emit the normal error message:
+            USR_FATAL(userCall(call),
                     "illegal use of function that does not "
                     "return a value: '%s'",
                     rhsName);
+          }
         }
       }
     }

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -739,7 +739,7 @@ module ChapelIO {
     try! { stdout._writef(fmt); }
   }
 
-  deprecated "The returning variant of ``writef`` is deprecated; use the new variant by compiling with :param:`IO.WritersReturnBool` = false"
+  deprecated "The returning variant of ``writef`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
   proc writef(fmt:?t, const args ...?k):bool
       where (isStringType(t) || isBytesType(t)) && IO.WritersReturnBool == true
   {
@@ -750,7 +750,7 @@ module ChapelIO {
   }
   // documented in string version
   pragma "no doc"
-  deprecated "The returning variant of ``writef`` is deprecated; use the new variant by compiling with :param:`IO.WritersReturnBool` = false"
+  deprecated "The returning variant of ``writef`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
   proc writef(fmt:?t):bool
       where (isStringType(t) || isBytesType(t)) && IO.WritersReturnBool == true
   {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2053,27 +2053,28 @@ proc openmemHelper(style:iostyleInternal = defaultIOStyleInternal()):file throws
 
 /*
   A parameter to select between the new and deprecated overloads of the
-  :record:`channel` type's `writer` methods.
+  :record:`fileWriter` type's `writer` methods.
 
-  These include: :proc:`channel.write`, :proc:`channel.writeln`, :proc:`channel.writebits`,
-  :proc:`channel.writeBytes`, and :proc:`FormattedIO.channel.writef`
+  These include: :proc:`channel.write`, :proc:`channel.writeln`,
+  :proc:`channel.writebits`, :proc:`channel.writeBytes`, and
+  :proc:`FormattedIO.channel.writef`
 
   This parameter also toggles the new and deprecated variants of the top-level
-  :proc:`ChapelIO.writef` method.
+  :proc:`~ChapelIO.writef` method.
 
-  - When `WritersReturnBool=true` the deprecated variants of the writer methods are called
+  - When `WritersReturnBool=true` the deprecated variants of the writer methodsare called
   - When `WritersReturnBool=false` the new variants of the writer methods are called
 
   .. note::
-    The only difference between the new and deprecated versions of these methods is the
-    return type. The deprecated overloads return a `bool` which is always ``true``, while
-    the new overloads do not return anything.
+    The only difference between the new and deprecated versions of these methods
+    is the return type. The deprecated overloads return a `bool` which is always
+    ``true``, while the new overloads do not return anything.
 
-    Leaving this param with its default value of ``true``, will allow you to rely on the
-    return value for the time being; however, the returning methods will be removed in
-    a future release.
+    Compiling with this param set to ``true`` will allow you to rely on the
+    return value for the time being; however, the returning methods will be
+    removed in a future release.
 */
-config param WritersReturnBool=true;
+config param WritersReturnBool=false;
 
 pragma "ignore noinit"
 pragma "no doc"
@@ -4325,7 +4326,7 @@ proc _channel.writeIt(const x) throws {
     return ret;
   }
 
-  deprecated "The returning variant of ``writeBytes`` is deprecated; use the new variant by compiling with :param:`WritersReturnBool` = false"
+  deprecated "The returning variant of ``writeBytes`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
   proc _channel.writeBytes(x, len:c_ssize_t):bool throws where WritersReturnBool == true {
     try this._writeBytes(x, len);
     return true;
@@ -5050,7 +5051,7 @@ proc _channel.readbits(ref v:integral, nbits:integral):bool throws {
   return ret;
 }
 
-deprecated "The returning variant of ``writebits`` is deprecated; use the new variant by compiling with :param:`WritersReturnBool` = false"
+deprecated "The returning variant of ``writebits`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
 proc _channel.writebits(v:integral, nbits:integral):bool throws where WritersReturnBool == true {
   if castChecking {
     // Error if writing more bits than fit into v
@@ -5309,7 +5310,7 @@ proc _channel.read(type t ...?numTypes) throws where numTypes > 1 {
   return tupleVal;
 }
 
-deprecated "The returning variant of ``channel.write`` is deprecated; use the new variant by compiling with :param:`WritersReturnBool` = false"
+deprecated "The returning variant of ``channel.write`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
 inline proc _channel.write(const args ...?k):bool throws where WritersReturnBool == true {
   try this._write((...args));
   return true;
@@ -5385,7 +5386,7 @@ proc _channel.writeHelper(const args ...?k, style:iostyleInternal):bool throws {
 
 // documented in varargs version
 pragma "no doc"
-deprecated "The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with :param:`WritersReturnBool` = false"
+deprecated "The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
 proc _channel.writeln():bool throws where WritersReturnBool == true {
   try this._writeln();
   return true;
@@ -5400,7 +5401,7 @@ proc _channel._writeln() throws {
   try this._write(new ioNewline());
 }
 
-deprecated "The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with :param:`WritersReturnBool` = false"
+deprecated "The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
 proc _channel.writeln(const args ...?k):bool throws where WritersReturnBool == true {
   try this._writeln((...args));
   return true;
@@ -7543,7 +7544,7 @@ proc _channel._writefOne(fmtStr, ref arg, i: int,
   }
 }
 
-deprecated "The returning variant of ``channel.writef`` is deprecated; use the new variant by compiling with :param:`IO.WritersReturnBool` = false"
+deprecated "The returning variant of ``channel.writef`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
 proc _channel.writef(fmtStr: ?t, const args ...?k): bool throws
     where (isStringType(t) || isBytesType(t)) && IO.WritersReturnBool == true
 {
@@ -7630,7 +7631,7 @@ proc _channel._writef(fmtStr: ?t, const args ...?k) throws
 }
 
 // documented in varargs version
-deprecated "The returning variant of ``channel.writef`` is deprecated; use the new variant by compiling with :param:`IO.WritersReturnBool` = false"
+deprecated "The returning variant of ``channel.writef`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`"
 proc _channel.writef(fmtStr:?t): bool throws
     where (isStringType(t) || isBytesType(t)) && IO.WritersReturnBool == true
 {

--- a/test/deprecated/IO/writersReturnBool.md
+++ b/test/deprecated/IO/writersReturnBool.md
@@ -22,9 +22,13 @@ All Modules (and tools/mason/*)
 
 Switch `ch._write`, `ch._writeln`, `ch._writef`, and `ch._writeBytes` calls back to `ch.write`, `ch.writeln`, `ch.writef` and `ch.writeBytes`
 
+Compiler
+---
+
+Remove specialized 'illegal use of boolean return value from...' error message from functionResolution.cpp (in 'moveDetermineRhsTypeErrorIfInvalid()')
 
 Tests
 ---
 
-1. In `start_test.py` : `set_up_environment()`, remove ` + " -s WritersReturnBool=false"` from lines 693, 695 (at the time this was written)
-2. Update `test/library/standard/Spawn/cat-stdout-stderr` to use `ch.write` instead of `ch._write`
+1. Update `test/library/standard/Spawn/cat-stdout-stderr` to use `ch.write` instead of `ch._write`
+2. Delete deprecation tests

--- a/test/deprecated/IO/writersReturningBool.good
+++ b/test/deprecated/IO/writersReturningBool.good
@@ -1,12 +1,12 @@
-writersReturningBool.chpl:7: warning: The returning variant of ``channel.write`` is deprecated; use the new variant by compiling with WritersReturnBool = false
-writersReturningBool.chpl:8: warning: The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with WritersReturnBool = false
-writersReturningBool.chpl:10: warning: The returning variant of ``writebits`` is deprecated; use the new variant by compiling with WritersReturnBool = false
-writersReturningBool.chpl:11: warning: The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with WritersReturnBool = false
-writersReturningBool.chpl:13: warning: The returning variant of ``writeBytes`` is deprecated; use the new variant by compiling with WritersReturnBool = false
-writersReturningBool.chpl:14: warning: The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with WritersReturnBool = false
-writersReturningBool.chpl:16: warning: The returning variant of ``channel.writef`` is deprecated; use the new variant by compiling with IO.WritersReturnBool = false
-writersReturningBool.chpl:17: warning: The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with WritersReturnBool = false
-writersReturningBool.chpl:19: warning: The returning variant of ``writef`` is deprecated; use the new variant by compiling with IO.WritersReturnBool = false
+writersReturningBool.chpl:7: warning: The returning variant of ``channel.write`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
+writersReturningBool.chpl:8: warning: The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
+writersReturningBool.chpl:10: warning: The returning variant of ``writebits`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
+writersReturningBool.chpl:11: warning: The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
+writersReturningBool.chpl:13: warning: The returning variant of ``writeBytes`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
+writersReturningBool.chpl:14: warning: The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
+writersReturningBool.chpl:16: warning: The returning variant of ``channel.writef`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
+writersReturningBool.chpl:17: warning: The returning variant of ``channel.writeln`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
+writersReturningBool.chpl:19: warning: The returning variant of ``writef`` is deprecated; use the new variant by compiling with `-sWritersReturnBool=false`
 5
 ab
 a

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/normalErrorMessage.chpl
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/normalErrorMessage.chpl
@@ -1,0 +1,9 @@
+// test that normal instances of "illegal use of function that does not return a value"
+//  still print the non-specialized error message
+
+proc returnsVoid(a: [] int) {
+    a[0] += 1;
+}
+
+if returnsVoid([1, 2, 3]) then
+    writeln("this won't print...");

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/normalErrorMessage.good
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/normalErrorMessage.good
@@ -1,0 +1,1 @@
+normalErrorMessage.chpl:8: error: illegal use of function that does not return a value: 'returnsVoid'

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/userDefinedWritelnMethod.chpl
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/userDefinedWritelnMethod.chpl
@@ -1,0 +1,14 @@
+// test that user-defined writer methods emit the non-specialized error message
+
+class myclass {
+    var x: real;
+
+    proc writeln() {
+        writef("%.5\n", this.x);
+    }
+}
+
+var c = new myclass(5);
+if c.writeln() {
+    // do something
+}

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/userDefinedWritelnMethod.good
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/userDefinedWritelnMethod.good
@@ -1,0 +1,1 @@
+userDefinedWritelnMethod.chpl:12: error: illegal use of function that does not return a value: 'writeln'

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbTopWritef.chpl
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbTopWritef.chpl
@@ -1,0 +1,5 @@
+use IO;
+
+if writef("yep") {
+    writeln("nope");
+}

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbTopWritef.good
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbTopWritef.good
@@ -1,0 +1,1 @@
+wrbTopWritef.chpl:3: error: illegal use of boolean return value from 'writef'. Note: this functionality is deprecated; recompile with -sWritersReturnBool=true to continue using the deprecated behavior.

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWrite.chpl
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWrite.chpl
@@ -1,0 +1,6 @@
+use IO;
+
+var fw = opentmp().writer();
+if fw.write("yep") {
+    writeln("nope");
+}

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWrite.good
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWrite.good
@@ -1,0 +1,1 @@
+wrbWrite.chpl:4: error: illegal use of boolean return value from 'write'. Note: this functionality is deprecated; recompile with -sWritersReturnBool=true to continue using the deprecated behavior.

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWriteBytes.chpl
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWriteBytes.chpl
@@ -1,0 +1,6 @@
+use IO;
+
+var fw = opentmp().writer();
+if fw.writeBytes(63, 2) {
+    writeln("nope");
+}

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWriteBytes.good
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWriteBytes.good
@@ -1,0 +1,1 @@
+wrbWriteBytes.chpl:4: error: illegal use of boolean return value from 'writeBytes'. Note: this functionality is deprecated; recompile with -sWritersReturnBool=true to continue using the deprecated behavior.

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWritebits.chpl
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWritebits.chpl
@@ -1,0 +1,6 @@
+use IO;
+
+var fw = opentmp().writer();
+if fw.writebits(7, 3) {
+    writeln("nope");
+}

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWritebits.good
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWritebits.good
@@ -1,0 +1,1 @@
+wrbWritebits.chpl:4: error: illegal use of boolean return value from 'writebits'. Note: this functionality is deprecated; recompile with -sWritersReturnBool=true to continue using the deprecated behavior.

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWritef.chpl
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWritef.chpl
@@ -1,0 +1,6 @@
+use IO;
+
+var fw = opentmp().writer();
+if fw.writef("%.5", 3.1415) {
+    writeln("nope");
+}

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWritef.good
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWritef.good
@@ -1,0 +1,1 @@
+wrbWritef.chpl:4: error: illegal use of boolean return value from 'writef'. Note: this functionality is deprecated; recompile with -sWritersReturnBool=true to continue using the deprecated behavior.

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWriteln.chpl
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWriteln.chpl
@@ -1,0 +1,6 @@
+use IO;
+
+var fw = opentmp().writer();
+if fw.writeln("yep") {
+    writeln("nope");
+}

--- a/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWriteln.good
+++ b/test/deprecated/IO/writersReturningBoolFlagUnset/wrbWriteln.good
@@ -1,0 +1,1 @@
+wrbWriteln.chpl:4: error: illegal use of boolean return value from 'writeln'. Note: this functionality is deprecated; recompile with -sWritersReturnBool=true to continue using the deprecated behavior.

--- a/test/regex/empty-channel-matches.good
+++ b/test/regex/empty-channel-matches.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/IO.chpl:8388: In method 'search':
-$CHPL_HOME/modules/standard/IO.chpl:8391: warning: `channel.search(re:regex(?), ref error:errorCode)` is deprecated
+$CHPL_HOME/modules/standard/IO.chpl:8389: In method 'search':
+$CHPL_HOME/modules/standard/IO.chpl:8392: warning: `channel.search(re:regex(?), ref error:errorCode)` is deprecated
   empty-channel-matches.chpl:49: called as (fileReader(dynamic,true)).search(re: regex(string))
 []  ((matched = true, byteOffset = 0, numBytes = 0),) 0
 [^]  ((matched = true, byteOffset = 0, numBytes = 0),) 0

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -690,9 +690,9 @@ def set_up_environment():
     # compopts (note that we have to strip out our preprocessing)
     if args.compopts:
         args.compopts = [strip_preprocessing(x) for x in args.compopts]
-        args.compopts = "--cc-warnings " + " ".join(args.compopts) + " -s WritersReturnBool=false"
+        args.compopts = "--cc-warnings " + " ".join(args.compopts)
     else:
-        args.compopts = "--cc-warnings" + " -s WritersReturnBool=false"
+        args.compopts = "--cc-warnings"
 
     # execopts (note that we have to strip out our preprocessing)
     if args.execopts:


### PR DESCRIPTION
PR: https://github.com/chapel-lang/chapel/pull/20508 introduced a new config-param (`WritersReturnBool`) that allowed users to toggle between implementations of channel writer methods that do/don't return a boolean value.

It defaulted to `true`, maintaining the deprecated behavior (i.e. keep the boolean return value, and emit a warning whenever one of the relevant methods is used). This created too much noise for larger programs, and was unlikely to be helpful given that this return value is rarely used in practice.

This PR does two things to alleviate that noise:
- Switches the default value of `WritersReturnBool` to false.
- Causes the compiler to emit a specialized warning when a users code tries to use the return value from one of the affected methods: `illegal use of boolean return value from 'writef'. Note: this functionality is deprecated; recompile with -sWritersReturnBool=true to continue using the deprecated behavior.`

(it also reformats the normal deprecation warnings to be slightly more helpful)

- [x] paratest passing