### PR TITLE
Update a test for renamings in the FileSystem module

### DIFF
--- a/test/library/standard/FileSystem/nonUTF8/basic.chpl
+++ b/test/library/standard/FileSystem/nonUTF8/basic.chpl
@@ -50,16 +50,16 @@ writeln("isLink works: ", isLink(filename1) == false);
 writeln("isMount works: ", isMount(filename1) == false);
 writeln("exists works: ", exists(filename1) == true);
 
-const gid = getGID(filename1);
-const uid = getUID(filename1);
+const gid = getGid(filename1);
+const uid = getUid(filename1);
 const mode = getMode(filename1);
 const size = getFileSize(filename1);
 writeln();
 
 writeln("Creating a copy");
 copy(filename1, filename2);
-writeln("getGID works: ", getGID(filename2) == gid);
-writeln("getUID works: ", getUID(filename2) == uid);
+writeln("getGid works: ", getGid(filename2) == gid);
+writeln("getUid works: ", getUid(filename2) == uid);
 writeln("getMode works: ", getMode(filename2) == mode);
 writeln("getFileSize works: ", getFileSize(filename2) == size);
 writeln();
@@ -107,7 +107,7 @@ writeln();
 writeln("listing the dir contents");
 // the order seems to change from system to system
 var l: list(string);
-for f in listdir(dirname1) {
+for f in listDir(dirname1) {
   l.append(f);
 }
 for f in sorted(l.toArray()) {

--- a/test/library/standard/FileSystem/nonUTF8/basic.good
+++ b/test/library/standard/FileSystem/nonUTF8/basic.good
@@ -14,8 +14,8 @@ isMount works: true
 exists works: true
 
 Creating a copy
-getGID works: true
-getUID works: true
+getGid works: true
+getUid works: true
 getMode works: true
 getFileSize works: true
 


### PR DESCRIPTION
Fix some function names that were deprecated yesterday. This test didn't run in my paratest because the SKIPIF for this directory gave "True" in the filesystem where my testing ran, but "False" in /tmp where nightly runs.