### PR TITLE
Change the email recipient to discourse commit email

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -53,7 +53,7 @@ jobs:
            # Required mail subject:
            subject: Chapel Merge  ${{github.event.pull_request.title}}  
            # Required recipients' addresses:
-           to: bhavani@hpe.com
+           to: chapel+commits@discoursemail.com
            # Required sender full name (address can be skipped):
            from: chapel-lang 
            html_body: |


### PR DESCRIPTION
 As part of the git issue to replace the email sent by heroku for PR Merge commits.
 Change the email recipient to discourse commit email.
https://github.com/Cray/chapel-private/issues/3799