### PR TITLE
dyno: fix std::hash failures under older C++ stdlibs

### DIFF
--- a/frontend/include/chpl/uast/Decl.h
+++ b/frontend/include/chpl/uast/Decl.h
@@ -157,4 +157,15 @@ class Decl : public AstNode {
 } // end namespace uast
 } // end namespace chpl
 
+namespace std {
+
+template<> struct hash<chpl::uast::Decl::Visibility>
+{
+  size_t operator()(const chpl::uast::Decl::Visibility& key) const {
+    return (size_t) key;
+  }
+};
+
+} // end namespace std
+
 #endif

--- a/frontend/include/chpl/uast/IntentList.h
+++ b/frontend/include/chpl/uast/IntentList.h
@@ -100,4 +100,15 @@ enum struct IntentList {
 } // end namespace uast
 } // end namespace chpl
 
+namespace std {
+
+template<> struct hash<chpl::uast::IntentList>
+{
+  size_t operator()(const chpl::uast::IntentList& key) const {
+    return (size_t) key;
+  }
+};
+
+} // end namespace std
+
 #endif

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -83,7 +83,7 @@ void Scope::addBuiltin(UniqueString name) {
   // Just refer to empty ID since builtin type declarations don't
   // actually exist in the AST.
   // The resolver knows that the empty ID means a builtin thing.
-  declared_.insert({ name, OwnedIdsWithName(ID(), uast::Decl::PUBLIC) });
+  declared_.emplace(name, OwnedIdsWithName(ID(), uast::Decl::PUBLIC));
 }
 
 const Scope* Scope::moduleScope() const {


### PR DESCRIPTION
On newer compilers, `std::hash` is automatically defined for enum types; on
older ones, it's not. This PR explicitly specializes `std::hash` for enums used
in error messages to make sure we compile under older versions of the stdlib.

This is pretty trivial, as long as it compiles on CI and somewhere with clang,
it's probably safe to merge.

Testing:
- [x] Compiled with `clang` locally, where it didn't before
- [x] GitHub CI checks

Reviewed by @mppf - thanks! 