### PR TITLE
Update futures with new error message casing.

### DIFF
--- a/test/chpldoc/nodoc/privateClasses.doc.bad
+++ b/test/chpldoc/nodoc/privateClasses.doc.bad
@@ -1,5 +1,5 @@
-error in privateClasses.doc.chpl:1: Can't apply private to types yet
-error in privateClasses.doc.chpl:7: Can't apply private to types yet
-error in privateClasses.doc.chpl:15: Can't apply private to the fields or methods of a class or record yet
-error in privateClasses.doc.chpl:18: Can't apply private to the fields or methods of a class or record yet
+error in privateClasses.doc.chpl:1: can't apply private to types yet
+error in privateClasses.doc.chpl:7: can't apply private to types yet
+error in privateClasses.doc.chpl:15: can't apply private to the fields or methods of a class or record yet
+error in privateClasses.doc.chpl:18: can't apply private to the fields or methods of a class or record yet
 cat: docs/source/modules/privateClasses.doc.rst: No such file or directory

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.bad
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.bad
@@ -1,4 +1,4 @@
-error in privateTypeAlias.doc.chpl:2: Can't apply private to types yet
-error in privateTypeAlias.doc.chpl:5: Can't apply private to types yet
-error in privateTypeAlias.doc.chpl:8: Can't apply private to types yet
+error in privateTypeAlias.doc.chpl:2: can't apply private to types yet
+error in privateTypeAlias.doc.chpl:5: can't apply private to types yet
+error in privateTypeAlias.doc.chpl:8: can't apply private to types yet
 cat: docs/source/modules/privateTypeAlias.doc.rst: No such file or directory

--- a/test/classes/generic/domainQueryField-feature.bad
+++ b/test/classes/generic/domainQueryField-feature.bad
@@ -1,1 +1,1 @@
-domainQueryField-feature.chpl:2: error: Domain query expressions may currently only be used in formal argument types
+domainQueryField-feature.chpl:2: error: domain query expressions may currently only be used in formal argument types

--- a/test/interop/python/defaultValues_global.bad
+++ b/test/interop/python/defaultValues_global.bad
@@ -1,1 +1,1 @@
-defaultValues_global.chpl:1: error: Export variables are not yet supported
+defaultValues_global.chpl:1: error: export variables are not yet supported

--- a/test/interop/python/multilocale/defaultValues_global.bad
+++ b/test/interop/python/multilocale/defaultValues_global.bad
@@ -1,1 +1,1 @@
-defaultValues_global.chpl:1: error: Export variables are not yet supported
+defaultValues_global.chpl:1: error: export variables are not yet supported

--- a/test/visibility/private/classes/privateField.bad
+++ b/test/visibility/private/classes/privateField.bad
@@ -1,2 +1,2 @@
-privateField.chpl:2: error: Can't apply private to the fields or methods of a class or record yet
-privateField.chpl:4: error: Can't apply private to the fields or methods of a class or record yet
+privateField.chpl:2: error: can't apply private to the fields or methods of a class or record yet
+privateField.chpl:4: error: can't apply private to the fields or methods of a class or record yet

--- a/test/visibility/private/classes/privateSecondaryMethod.bad
+++ b/test/visibility/private/classes/privateSecondaryMethod.bad
@@ -1,1 +1,1 @@
-privateSecondaryMethod.chpl:8: error: Can't apply private to the fields or methods of a class or record yet
+privateSecondaryMethod.chpl:8: error: can't apply private to the fields or methods of a class or record yet

--- a/test/visibility/private/privateEnum.bad
+++ b/test/visibility/private/privateEnum.bad
@@ -1,1 +1,1 @@
-privateEnum.chpl:1: error: Can't apply private to types yet
+privateEnum.chpl:1: error: can't apply private to types yet

--- a/test/visibility/private/typeAlias.bad
+++ b/test/visibility/private/typeAlias.bad
@@ -1,1 +1,1 @@
-typeAlias.chpl:1: error: Can't apply private to types yet
+typeAlias.chpl:1: error: can't apply private to types yet


### PR DESCRIPTION
The Dyno-based error system does some tweaking of error message letter cases.
Specifically, it wants all brief error messages to be lowercase. I missed
updating some tests because they were futures and don't regularly run with a
paratest. This PR updates those futures. Thanks @dlongnecke-cray for pointing
these out to me.

Reviewed by @riftEmber - thanks!

Testing:
- [x] Tests pass locally