### PR TITLE
Deprecate 'findfiles' in favor of 'findFiles'

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -85,7 +85,7 @@
    :iter:`glob`
    :iter:`listDir`
    :iter:`walkDirs`
-   :iter:`findfiles`
+   :iter:`findFiles`
 
    Constant and Function Definitions
    ---------------------------------
@@ -592,7 +592,20 @@ proc exists(name: string): bool throws {
 
    :yield:  The paths to any files found, relative to `startdir`, as strings
 */
+iter findFiles(startdir: string = ".", recursive: bool = false,
+               hidden: bool = false): string {
+  if (recursive) then
+    foreach subdir in walkDirs(startdir, hidden=hidden) do
+      foreach file in listDir(subdir, hidden=hidden, dirs=false, files=true, listlinks=true) do
+        yield subdir+"/"+file;
+  else
+    foreach file in listDir(startdir, hidden=hidden, dirs=false, files=true, listlinks=false) do
+      yield startdir+"/"+file;
+}
 
+// When this deprecated iterator is removed remember to remove the standalone
+// parallel version below as well.
+deprecated "'findfiles' is deprecated, please use 'findFiles' instead"
 iter findfiles(startdir: string = ".", recursive: bool = false,
                hidden: bool = false): string {
   if (recursive) then
@@ -605,6 +618,27 @@ iter findfiles(startdir: string = ".", recursive: bool = false,
 }
 
 pragma "no doc"
+iter findFiles(startdir: string = ".", recursive: bool = false,
+               hidden: bool = false, param tag: iterKind): string
+       where tag == iterKind.standalone {
+  if (recursive) then
+    // Why "with (ref hidden)"?  A: the compiler currently allows only
+    // [const] ref intents in forall loops over recursive parallel iterators
+    // such as walkDirs().
+    forall subdir in walkDirs(startdir, hidden=hidden) with (ref hidden) do
+      foreach file in listDir(subdir, hidden=hidden, dirs=false, files=true, listlinks=true) do
+        yield subdir+"/"+file;
+  else
+    foreach file in listDir(startdir, hidden=hidden, dirs=false, files=true, listlinks=false) do
+      yield startdir+"/"+file;
+}
+
+// Adding the deprecation warning here causes 3 deprecation warnings in
+// addition to the one that comes from the serial iterator for a forall loop
+// that calls this. (serial, leader, follower, standalone). Rely on just
+// the serial deprecation warning to reduce it to a single message.
+pragma "no doc"
+//deprecated "'findfiles' is deprecated, please use 'findFiles' instead"
 iter findfiles(startdir: string = ".", recursive: bool = false,
                hidden: bool = false, param tag: iterKind): string
        where tag == iterKind.standalone {

--- a/test/deprecated/fileSystemFindFiles.chpl
+++ b/test/deprecated/fileSystemFindFiles.chpl
@@ -1,0 +1,11 @@
+use FileSystem;
+
+proc foo(f: string) { }
+
+for f in findfiles() {
+  foo(f);
+}
+
+forall f in findfiles() {
+  foo(f);
+}

--- a/test/deprecated/fileSystemFindFiles.good
+++ b/test/deprecated/fileSystemFindFiles.good
@@ -1,0 +1,2 @@
+fileSystemFindFiles.chpl:5: warning: 'findfiles' is deprecated, please use 'findFiles' instead
+fileSystemFindFiles.chpl:9: warning: 'findfiles' is deprecated, please use 'findFiles' instead

--- a/test/exercises/duplicates/duplicates-alt-assoc-reduce.chpl
+++ b/test/exercises/duplicates/duplicates-alt-assoc-reduce.chpl
@@ -93,7 +93,7 @@ proc main(args: [] string) {
     if isFile(arg) {
       paths.keys += relativeRealPath(arg);
     } else if isDir(arg) {
-      for path in findfiles(arg, recursive=true) {
+      for path in findFiles(arg, recursive=true) {
         paths.keys += relativeRealPath(path);
       }
     } else {

--- a/test/exercises/duplicates/duplicates-alt-assoc.chpl
+++ b/test/exercises/duplicates/duplicates-alt-assoc.chpl
@@ -19,7 +19,7 @@ proc main(args: [] string) {
     if isFile(arg) {
       paths += relativeRealPath(arg);
     } else if isDir(arg) {
-      for path in findfiles(arg, recursive=true) {
+      for path in findFiles(arg, recursive=true) {
         paths += relativeRealPath(path);
       }
     } else {

--- a/test/exercises/duplicates/duplicates-bonus-b2-record.chpl
+++ b/test/exercises/duplicates/duplicates-bonus-b2-record.chpl
@@ -101,7 +101,7 @@ proc handleArguments(args: [] string, ref paths: domain(string)) {
         paths += relativeRealPath(arg);
       }
     } else if isDir(arg) {
-      for path in findfiles(arg, recursive=true) {
+      for path in findFiles(arg, recursive=true) {
         if filter == "" || path.endsWith(filter) {
           paths += relativeRealPath(path);
         }

--- a/test/exercises/duplicates/duplicates-bonus-b3-size.chpl
+++ b/test/exercises/duplicates/duplicates-bonus-b3-size.chpl
@@ -117,7 +117,7 @@ proc handleArguments(args: [] string, ref paths: domain(string)) {
         paths += relativeRealPath(arg);
       }
     } else if isDir(arg) {
-      for path in findfiles(arg, recursive=true) {
+      for path in findFiles(arg, recursive=true) {
         if filter == "" || path.endsWith(filter) {
           paths += relativeRealPath(path);
         }

--- a/test/exercises/duplicates/duplicates-step1-for.chpl
+++ b/test/exercises/duplicates/duplicates-step1-for.chpl
@@ -76,7 +76,7 @@ proc handleArguments(args: [] string, ref paths: domain(string)) {
         paths += relativeRealPath(arg);
       }
     } else if isDir(arg) {
-      for path in findfiles(arg, recursive=true) {
+      for path in findFiles(arg, recursive=true) {
         if filter == "" || path.endsWith(filter) {
           paths += relativeRealPath(path);
         }

--- a/test/exercises/duplicates/duplicates-step2-forall.chpl
+++ b/test/exercises/duplicates/duplicates-step2-forall.chpl
@@ -80,7 +80,7 @@ proc handleArguments(args: [] string, ref paths: domain(string)) {
         paths += relativeRealPath(arg);
       }
     } else if isDir(arg) {
-      for path in findfiles(arg, recursive=true) {
+      for path in findFiles(arg, recursive=true) {
         if filter == "" || path.endsWith(filter) {
           paths += relativeRealPath(path);
         }

--- a/test/exercises/duplicates/duplicates-step3-error.chpl
+++ b/test/exercises/duplicates/duplicates-step3-error.chpl
@@ -74,7 +74,7 @@ proc handleArguments(args: [] string, ref paths: domain(string)) {
         paths += relativeRealPath(arg);
       }
     } else if isDir(arg) {
-      for path in findfiles(arg, recursive=true) {
+      for path in findFiles(arg, recursive=true) {
         if filter == "" || path.endsWith(filter) {
           paths += relativeRealPath(path);
         }

--- a/test/exercises/duplicates/forStudents/duplicates.chpl
+++ b/test/exercises/duplicates/forStudents/duplicates.chpl
@@ -66,7 +66,7 @@ proc handleArguments(args: [] string, ref paths: domain(string)) {
         paths += relativeRealPath(arg);
       }
     } else if isDir(arg) {
-      for path in findfiles(arg, recursive=true) {
+      for path in findFiles(arg, recursive=true) {
         if filter == "" || path.endsWith(filter) {
           paths += relativeRealPath(path);
         }

--- a/test/library/standard/FileSystem/filerator/bradc/findfiles-par.chpl
+++ b/test/library/standard/FileSystem/filerator/bradc/findfiles-par.chpl
@@ -4,5 +4,5 @@ config const startdir = "subdir";
 config const recur = true;
 config const dotfiles = true;
 
-forall filename in findfiles(startdir, recur, dotfiles) do
+forall filename in findFiles(startdir, recur, dotfiles) do
   writeln(filename);

--- a/test/library/standard/FileSystem/filerator/bradc/findfiles.chpl
+++ b/test/library/standard/FileSystem/filerator/bradc/findfiles.chpl
@@ -6,8 +6,8 @@ config const dotfiles = false;
 config param sort = true;
 
 if sort then
-  for filename in sorted(findfiles(startdir, recur, dotfiles)) do
+  for filename in sorted(findFiles(startdir, recur, dotfiles)) do
     writeln(filename);
 else
-  for filename in findfiles(startdir, recur, dotfiles) do
+  for filename in findFiles(startdir, recur, dotfiles) do
     writeln(filename);

--- a/test/parallel/forall/vass/reciter/forall-reciter-alt.chpl
+++ b/test/parallel/forall/vass/reciter/forall-reciter-alt.chpl
@@ -1,7 +1,7 @@
 // This test is a slimmed-down version of the code in OP of #19301.
 // It is essentially the same as forall-reciter-todo.chpl
 // except:
-// * it uses findfiles() as the recursive iterator
+// * it uses findFiles() as the recursive iterator
 // * it is not a .future, so the error messages are in a .good file.
 
 use FileSystem;
@@ -10,6 +10,6 @@ config const inputDir = "InputFiles";
 config const debug = true;
 config const minCount = 1000;
 
-forall file in findfiles(inputDir) {
+forall file in findFiles(inputDir) {
   writeln((file, debug, minCount));
 }

--- a/test/parallel/forall/vass/reciter/outbound-ibb-goto.chpl
+++ b/test/parallel/forall/vass/reciter/outbound-ibb-goto.chpl
@@ -1,5 +1,5 @@
 // from #18218
-// also, the following test keeps a snapshot of findfiles() et al.
+// also, the following test keeps a snapshot of findFiles() et al.
 // that exhibited an undesired behavior:
 //   test/functions/iterators/recursive/recursive-iter-findfilesfailure.chpl
 
@@ -14,8 +14,8 @@ module CheckHttp {
   }
 
   proc main() throws {
-    for f in findfiles(".") do throwingFunction(f);
+    for f in findFiles(".") do throwingFunction(f);
     writeln("---");
-    forall f in findfiles(".") do throwingFunction(f);
+    forall f in findFiles(".") do throwingFunction(f);
   }
 }

--- a/test/patterns/cltools/grep/grep.chpl
+++ b/test/patterns/cltools/grep/grep.chpl
@@ -68,7 +68,7 @@ proc parallelGrep(tofind: string) throws {
 
   // Seaches current working directory ignoring anthing but UTF-8
   // encoded characters
-  var files = FileSystem.findfiles(Path.curDir);
+  var files = FileSystem.findFiles(Path.curDir);
   forall file in files {
     fileGrep(tofind, file);
   }

--- a/test/studies/dedup/dedup-distributed-ints.chpl
+++ b/test/studies/dedup/dedup-distributed-ints.chpl
@@ -20,7 +20,7 @@ proc main(args:[] string)
     if isFile(arg) then
       paths.append(arg);
     else if isDir(arg) then
-      for path in findfiles(arg, recursive=true) do
+      for path in findFiles(arg, recursive=true) do
         paths.append(path);
   }
 

--- a/test/studies/dedup/dedup-distributed-strings.chpl
+++ b/test/studies/dedup/dedup-distributed-strings.chpl
@@ -24,9 +24,9 @@ proc main(args:[] string)
     if isFile(arg) then
       paths.append(arg);
     else if isDir(arg) then
-      // use FileSystem.findfiles to easily enumerate files.
+      // use FileSystem.findFiles to easily enumerate files.
       // A parallel version is available.
-      for path in findfiles(arg, recursive=true) do
+      for path in findFiles(arg, recursive=true) do
         paths.append(path);
   }
 

--- a/test/studies/dedup/dedup-extern.chpl
+++ b/test/studies/dedup/dedup-extern.chpl
@@ -25,7 +25,7 @@ proc main(args:[] string)
     if isFile(arg) then
       paths.append(arg);
     else if isDir(arg) then
-      for path in findfiles(arg, recursive=true) do
+      for path in findFiles(arg, recursive=true) do
         paths.append(path);
   }
 

--- a/test/studies/dedup/dedup-local.chpl
+++ b/test/studies/dedup/dedup-local.chpl
@@ -16,7 +16,7 @@ proc main(args:[] string)
     if isFile(arg) then
       paths.append(arg);
     else if isDir(arg) then
-      for path in findfiles(arg, recursive=true) do
+      for path in findFiles(arg, recursive=true) do
         paths.append(path);
   }
 

--- a/test/studies/dedup/dedup-spawn-sort.chpl
+++ b/test/studies/dedup/dedup-spawn-sort.chpl
@@ -12,7 +12,7 @@ proc main(args:[] string)
     if isFile(arg) then
       paths.append(arg);
     else if isDir(arg) then
-      for path in findfiles(arg, recursive=true) do
+      for path in findFiles(arg, recursive=true) do
         paths.append(path);
   }
 

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -71,7 +71,7 @@ proc main(args:[] string) {
   for arg in files {
     if isDir(arg) {
       // Go through files in directories.
-      for f in findfiles(arg, true) {
+      for f in findFiles(arg, true) {
         todo.append(f);
       }
     } else {

--- a/test/studies/mstrout/wordCount.chpl
+++ b/test/studies/mstrout/wordCount.chpl
@@ -57,9 +57,9 @@ t.start();
 
 var filenamesList: list(string);
 
-// findfiles() returns an iterator so putting all file names in a list
+// findFiles() returns an iterator so putting all file names in a list
 // to enable creating an array of file names.
-for f in findfiles(inputDir) {
+for f in findFiles(inputDir) {
     filenamesList.append(f);
 }
 // Create an array blocked into pieces per locale.

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -308,7 +308,7 @@ private proc getExamples(toml: Toml, projectHome: string) {
     return exampleNames;
   }
   else if isDir(examplePath) {
-    var examples = findfiles(startdir=examplePath, recursive=true, hidden=false);
+    var examples = findFiles(startdir=examplePath, recursive=true, hidden=false);
     for example in examples {
       if example.endsWith(".chpl") {
         exampleNames.append(getExamplePath(example));

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -136,7 +136,7 @@ proc masonTest(args: [] string, checkProj=true) throws {
         subTestPath = cwd;
       }
 
-      var tests = findfiles(startdir=subTestPath, recursive=true, hidden=false);
+      var tests = findFiles(startdir=subTestPath, recursive=true, hidden=false);
       for test in tests{
         if test.endsWith(".chpl"){
           if(inProjectDir){
@@ -186,7 +186,7 @@ proc masonTest(args: [] string, checkProj=true) throws {
         var testNames: list(string);
 
         if isDir('.'){
-          var tests = findfiles(startdir='.', recursive=subdir);
+          var tests = findFiles(startdir='.', recursive=subdir);
           for test in tests {
             if test.endsWith(".chpl") {
               testNames.append(test);
@@ -248,7 +248,7 @@ private proc runTests(show: bool, run: bool, parallel: bool,
     else {
       try! {
         for dir in dirs {
-          for file in findfiles(startdir = dir, recursive = subdir) {
+          for file in findFiles(startdir = dir, recursive = subdir) {
             if file.endsWith(".chpl") {
               files.append(file);
             }
@@ -391,7 +391,7 @@ private proc getTests(lock: borrowed Toml, projectHome: string) {
     }
   }
   else if isDir(testPath) {
-    var tests = findfiles(startdir=testPath, recursive=true, hidden=false);
+    var tests = findFiles(startdir=testPath, recursive=true, hidden=false);
     for test in tests {
       if test.endsWith(".chpl") {
         testNames.append(getTestPath(test));
@@ -554,7 +554,7 @@ proc testFile(file, ref result, show: bool) throws {
 pragma "no doc"
 /*Docs: Todo*/
 proc testDirectory(dir, ref result, show: bool) throws {
-  for file in findfiles(startdir = dir, recursive = subdir) {
+  for file in findFiles(startdir = dir, recursive = subdir) {
     if file.endsWith(".chpl") {
       testFile(file, result, show);
     }


### PR DESCRIPTION
Deprecate the all lowercase version in favor of the camelCase version. Add
a deprecation test.

Did not add a deprecation warning to the standalone parallel version because
it causes multiple messages for a single forall loop. Instead rely on the
single warning for the serial version.