### PR TITLE
Fix exported-fn.chpl for C backend

### DIFF
--- a/test/optimizations/widepointers/exported-fn.h
+++ b/test/optimizations/widepointers/exported-fn.h
@@ -1,5 +1,5 @@
 
 extern void foo(void);
-static void bar() {
+static void bar(void) {
   foo();
 }


### PR DESCRIPTION
This fixes code introduced in #20861 where compiling `exported-fn.h` with gcc gave us:
```
error: function declaration isn~t a prototype [-Werror=strict-prototypes]
static void bar() {
            ^~~
```

Clang does not complain about this.

Testing: the affected test with C and LLVM backends under gasnet.