### PR TITLE
fix bugs in PR #20875

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1033,7 +1033,7 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
     }
   }
 
-  // 
+  //
   // Reserve cores for the AM handlers. This has to be done early before
   // calling other routines that use information about the cores, such as
   // pinning the heap.

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -671,7 +671,7 @@ chpl_topo_reserveCPUPhysical(void) {
   int id = -1;
   CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
   if (okToReserveCPU) {
-    if (topoSupport->cpubind->set_thread_cpubind && (numCPUsPhysAcc > 1)) {
+    if (topoSupport->cpubind->set_thisthread_cpubind && (numCPUsPhysAcc > 1)) {
 
 #ifdef DEBUG
       char buf[1024];

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -689,9 +689,7 @@ chpl_topo_reserveCPUPhysical(void) {
 
         // Find the core's object in the topology so we can reserve its PUs.
         hwloc_obj_t pu, core;
-        CHK_ERR_ERRNO(pu = hwloc_get_obj_inside_cpuset_by_type(topology,
-                                                        physAccSet,
-                                                        HWLOC_OBJ_PU, id));
+        CHK_ERR_ERRNO(pu = hwloc_get_pu_obj_by_os_index(topology, id));
         CHK_ERR_ERRNO(core = hwloc_get_ancestor_obj_by_type(topology,
                                                             HWLOC_OBJ_CORE,
                                                             pu));


### PR DESCRIPTION
Fix two problems with PR #20875:

-  The `hwloc` topology support flag `set_thisthread_cpubind` is the correct flag for checking whether or not the platform supports binding the current thread to a PU.
- Finding a PU within the topology should be done via  `hwloc_get_pu_obj_by_os_index`. The code was erroneously using the OS index as a logical index.