### PR TITLE
Fixes to tests broken by channel.readAll implementation

### DIFF
--- a/test/library/standard/IO/readAll/readBytesArrayLeaveExcessAlone.compopts
+++ b/test/library/standard/IO/readAll/readBytesArrayLeaveExcessAlone.compopts
@@ -1,0 +1,1 @@
+-suseNewOpenReaderRegionBounds=true

--- a/test/regex/empty-channel-matches.good
+++ b/test/regex/empty-channel-matches.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/IO.chpl:8388: In method 'search':
-$CHPL_HOME/modules/standard/IO.chpl:8391: warning: `channel.search(re:regex(?), ref error:errorCode)` is deprecated
+$CHPL_HOME/modules/standard/IO.chpl:8529: In method 'search':
+$CHPL_HOME/modules/standard/IO.chpl:8532: warning: `channel.search(re:regex(?), ref error:errorCode)` is deprecated
   empty-channel-matches.chpl:49: called as (fileReader(dynamic,true)).search(re: regex(string))
 []  ((matched = true, byteOffset = 0, numBytes = 0),) 0
 [^]  ((matched = true, byteOffset = 0, numBytes = 0),) 0


### PR DESCRIPTION
[#20761](https://github.com/chapel-lang/chapel/pull/20761) caused a couple of test failures when it was merged with main.

This PR fixes failures on:
- `library/standard/IO/readAll/readBytesArrayInsufficientCapacity`
- `regex/empty-channel-matches`
