### PR TITLE
Fixups to spec split init details

### DIFF
--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -123,7 +123,7 @@ described in :ref:`Variable_Declarations_in_a_Tuple`.
 .. _Split_Initialization:
 
 Split Initialization
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 Split initialization is a feature that allows an initialization
 expression for a variable to be in a statement after the variable
@@ -242,10 +242,10 @@ Split initialization does not apply:
    block which has ``catch`` clauses that mention the variable
    or which has ``catch`` clauses that do not always throw or return.
 
-In the case that the variable is declared without a ``type-part`` and
-where multiple applicable assignment statements are identified, all of
-the assignment statements need to contain an initialization expression of
-the same type.
+In the case that the variable is declared with no ``type-part`` or with a
+generic declared type, and where multiple applicable assignment
+statements are identified, all of the assignment statements need to
+contain an initialization expression of the same type.
 
 Any variables declared in a particular scope that are initialized with
 split init in both the ``then`` and ``else`` branches of a conditional
@@ -255,7 +255,7 @@ branches.
 .. _Default_Values_For_Types:
 
 Default Initialization
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 If a variable declaration has no initialization expression, a variable
 is initialized to the default value of its type. The default values are
@@ -285,7 +285,7 @@ atomic      base default value
 .. _Local_Type_Inference:
 
 Local Type Inference
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 If the type is omitted from a variable declaration, the type of the
 variable is defined to be the type of the initialization expression.
@@ -308,7 +308,7 @@ the type of ``v`` is the base type of ``e``.
 .. _Multiple_Variable_Declarations:
 
 Multiple Variable Declarations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 All variables defined in the same ``identifier-list`` are defined such
 that they have the same type and value, and so that the type and
@@ -673,7 +673,8 @@ Variable Lifetimes
 ------------------
 
 A variable only exists during its lifetime. The lifetime of a variable
-begins when the variable is initialized.
+begins when the variable is initialized (whether at the declaration or
+at a later point with :ref:`Split_Initialization`).
 
 A variable's lifetime ends:
 


### PR DESCRIPTION
Fixes some issues with the spec section on split init that I noticed while looking at it while developing PR #20843.

 * promotes the Split Initialization section and subsequent sections up a level in the outline so that they appear on the left
 * adds a link from the Variable Lifetimes section back to Split Initialization
 * clarifies one of the split init rules which was not clear about type inference for variables with a generic declared type

Reviewed by @benharsh - thanks!