### PR TITLE
Use a block for try/catch try body

### DIFF
--- a/frontend/include/chpl/uast/Try.h
+++ b/frontend/include/chpl/uast/Try.h
@@ -77,6 +77,7 @@ class Try final : public AstNode {
   bool contentsMatchInner(const AstNode* other) const override {
     const Try* rhs = other->toTry();
     return this->numHandlers_ == rhs->numHandlers_ &&
+      this->containsBlock_ == rhs->containsBlock_ &&
       this->isExpressionLevel_ == rhs->isExpressionLevel_ &&
       this->isTryBang_ == rhs->isTryBang_;
   }

--- a/frontend/include/chpl/uast/Try.h
+++ b/frontend/include/chpl/uast/Try.h
@@ -54,24 +54,29 @@ namespace uast {
  */
 class Try final : public AstNode {
  private:
-  Try(AstList children, int numBodyStmts, int numHandlers,
+  Try(AstList children,
+      int numHandlers,
+      bool containsBlock,
       bool isExpressionLevel,
       bool isTryBang)
         : AstNode(asttags::Try, std::move(children)),
-          numBodyStmts_(numBodyStmts),
           numHandlers_(numHandlers),
+          containsBlock_(containsBlock),
           isExpressionLevel_(isExpressionLevel),
           isTryBang_(isTryBang) {
     if (isExpressionLevel_) {
-      assert(numBodyStmts == 1);
+      assert(numHandlers == 0);
+    }
+    if (containsBlock) {
+      assert(child(bodyChildNum_)->isBlock());
+    } else {
       assert(numHandlers == 0);
     }
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Try* rhs = other->toTry();
-    return this->numBodyStmts_ == rhs->numBodyStmts_ &&
-      this->numHandlers_ == rhs->numHandlers_ &&
+    return this->numHandlers_ == rhs->numHandlers_ &&
       this->isExpressionLevel_ == rhs->isExpressionLevel_ &&
       this->isTryBang_ == rhs->isTryBang_;
   }
@@ -79,11 +84,14 @@ class Try final : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
-  // If this exists, its position is always the same.
+  // body position is always the same
   static const int8_t bodyChildNum_ = 0;
+  // try expressions always contain a body expression
+  // try statements always contain a body block
+  static const int8_t numBodyStmts_ = 1;
 
-  int numBodyStmts_;
   int numHandlers_;
+  bool containsBlock_;
   bool isExpressionLevel_;
   bool isTryBang_;
 
@@ -93,12 +101,12 @@ class Try final : public AstNode {
   /**
     Create and return a try statement.
   */
-  static owned<Try> build(Builder* builder, Location loc, AstList stmts,
+  static owned<Try> build(Builder* builder, Location loc, owned<Block> body,
                           AstList catches,
                           bool isTryBang);
 
   /**
-    Create and return a try expression.
+    Create and return a try expression or decorated statement.
   */
   static owned<Try> build(Builder* builder, Location loc,
                           owned<AstNode> expr,
@@ -106,30 +114,55 @@ class Try final : public AstNode {
                           bool isExpressionLevel);
 
   /**
+    Return the contained block for a try statement.
+    For an expression-level try, returns nullptr.
+   */
+  const Block* body() const {
+    if (containsBlock_) {
+      assert(numBodyStmts_ == 1);
+      return (Block*) child(bodyChildNum_);
+    } else {
+      return nullptr;
+    }
+  }
+
+  /**
     Iterate over the statements contained in this try.
   */
   AstListIteratorPair<AstNode> stmts() const {
-    auto begin = numBodyStmts_ ? children_.begin() + bodyChildNum_
-                               : children_.end();
-    auto end = begin + numBodyStmts_;
-    return AstListIteratorPair<AstNode>(begin, end);
+    if (const Block* stmtBody = body()) {
+      return stmtBody->stmts();
+    } else {
+      auto begin = numBodyStmts_ ? children_.begin() + bodyChildNum_
+                                 : children_.end();
+      auto end = begin + numBodyStmts_;
+      return AstListIteratorPair<AstNode>(begin, end);
+    }
   }
 
   /**
     Return the number of statements contained in this try.
   */
   int numStmts() const {
-    return numBodyStmts_;
+    if (const Block* stmtBody = body()) {
+      return stmtBody->numStmts();
+    } else {
+      return numBodyStmts_;
+    }
   }
 
   /**
     Get the i'th statement in the body of this try.
   */
   const AstNode* stmt(int i) const {
-    assert(i >= bodyChildNum_ && i < numBodyStmts_);
-    auto ret = child(bodyChildNum_ + i);
-    assert(ret);
-    return ret;
+    if (const Block* stmtBody = body()) {
+      return stmtBody->stmt(i);
+    } else {
+      assert(i >= bodyChildNum_ && i < numBodyStmts_);
+      auto ret = child(bodyChildNum_ + i);
+      assert(ret);
+      return ret;
+    }
   }
 
   /**

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -2439,11 +2439,11 @@ ParserContext::buildTryCatchStmt(YYLTYPE location, CommentsAndStmt block,
   auto comments = gatherCommentsFromList(commentList, location);
   clearComments(commentList);
 
-  auto stmts = consumeAndFlattenTopLevelBlocks(makeList(block));
+  assert(block.stmt != nullptr && block.stmt->isBlock());
+  Block* bodyBlock = block.stmt->toBlock();
   auto catches = consumeList(handlers);
-
   auto node = Try::build(builder, convertLocation(location),
-                         std::move(stmts),
+                         toOwned(bodyBlock),
                          std::move(catches),
                          isTryBang);
 

--- a/frontend/lib/uast/Try.cpp
+++ b/frontend/lib/uast/Try.cpp
@@ -25,24 +25,25 @@ namespace chpl {
 namespace uast {
 
 
-owned<Try> Try::build(Builder* builder, Location loc, AstList stmts,
+owned<Try> Try::build(Builder* builder, Location loc,
+                      owned<Block> body,
                       AstList catches,
                       bool isTryBang) {
   AstList lst;
-  int numBodyStmts = stmts.size();
   int numHandlers = catches.size();
+  bool containsBlock = true;
   bool isExpressionLevel = false;
 
-  for (auto& ast : stmts) {
-    lst.push_back(std::move(ast));
-  }
+  lst.push_back(std::move(body));
 
   for (auto& ast : catches) {
     assert(ast->isCatch());
     lst.push_back(std::move(ast));
   }
 
-  Try* ret = new Try(std::move(lst), numBodyStmts, numHandlers,
+  Try* ret = new Try(std::move(lst),
+                     numHandlers,
+                     containsBlock,
                      isExpressionLevel,
                      isTryBang);
   builder->noteLocation(ret, loc);
@@ -54,12 +55,14 @@ owned<Try> Try::build(Builder* builder, Location loc,
                       bool isTryBang,
                       bool isExpressionLevel) {
   AstList lst;
-  int numBodyStmts = 1;
   int numHandlers = 0;
+  bool containsBlock = false;
 
   lst.push_back(std::move(expr));
 
-  Try* ret = new Try(std::move(lst), numBodyStmts, numHandlers,
+  Try* ret = new Try(std::move(lst),
+                     numHandlers,
+                     containsBlock,
                      isExpressionLevel,
                      isTryBang);
   builder->noteLocation(ret, loc);

--- a/frontend/test/parsing/testParseTryCatchThrow.cpp
+++ b/frontend/test/parsing/testParseTryCatchThrow.cpp
@@ -215,6 +215,33 @@ static void test2(Parser* parser) {
   }
 }
 
+static void test3(Parser* parser) {
+  auto parseResult = parser->parseString("test3.chpl",
+      R""""(
+        module M {
+          try {
+            var x;
+            x;
+          } catch {
+            x;
+          }
+        }
+      )"""");
+  assert(!parseResult.numErrors());
+  auto mod = parseResult.singleModule();
+  assert(mod);
+  assert(mod->numStmts() == 1);
+  assert(mod->stmt(0)->isTry());
+  const Try* t = mod->stmt(0)->toTry();
+  assert(t->body() != nullptr);
+  assert(t->body() == t->child(0));
+  assert(t->body()->numStmts() == 2);
+  assert(t->numStmts() == 2);
+  assert(t->stmt(0)->isVariable());
+  assert(t->stmt(1)->isIdentifier());
+  assert(t->numHandlers() == 1);
+}
+
 int main() {
   Context context;
   Context* ctx = &context;
@@ -225,6 +252,7 @@ int main() {
   test0(p);
   test1(p);
   test2(p);
+  test3(p);
 
   return 0;
 }


### PR DESCRIPTION
To resolve problems when scope-resolving:

``` chapel
  module M {
    proc main() {
      try {
        var x: int;
      } catch {
        x; // do not want this to resolve to x above
      }
    }
  }
```

This PR adjusts `Try` so that it always contains a Block or a single other expression for the body. It adds `Try::body()` to access this Block and wires the `stmt(i)` function to go in to it to preserve the old behavior.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local testing