### PR TITLE
fixing unresolved insufficientCapacity test 

### DIFF
--- a/test/library/standard/IO/readAll/readBytesArrayInsufficientCapacity.compopts
+++ b/test/library/standard/IO/readAll/readBytesArrayInsufficientCapacity.compopts
@@ -1,0 +1,1 @@
+-suseNewOpenReaderRegionBounds=true

--- a/test/library/standard/IO/readAll/readBytesArrayInsufficientCapacity.good
+++ b/test/library/standard/IO/readAll/readBytesArrayInsufficientCapacity.good
@@ -1,6 +1,6 @@
 InsufficientCapacityError: Channel's contents exceeded capacity of array argument (100 bytes) in 'readAll'
 true
 --Jabberwocky--
-InsufficientCapacityError: Channel's contents (1032 bytes) exceeded capacity of array argument (100 bytes) in 'readAll'
+InsufficientCapacityError: Channel's contents (1033 bytes) exceeded capacity of array argument (100 bytes) in 'readAll'
 true
 --Jabberwocky--


### PR DESCRIPTION
Fixing unresolved test failure for `test/library/standard/IO/readAll/readBytesArrayInsufficientCapacity` with compopts file for region bounds.
