### PR TITLE
chore: add deprecation warnings when casting string/bytes to regex

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1444,6 +1444,11 @@ module ChapelBase {
       // string to a type. Otherwise, we can't resolve chpl_debug_writeln in
       // `range.these`
       { var dummyRange = 1..0; for i in dummyRange {} }
+      // TODO: String comparison here is a workaround and would be better if
+      // we could use t == regex(string) - but this fails with an error that
+      // regex(type string) is not defined in this scope - adding use Regex;
+      // leads to a different error:
+      // "use of 'rootLocale' before encountering its definition, type unknown"
       if t:string == "regex(string)" || t:string == "regex(bytes)" then
         return compile(str);
       else

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1444,7 +1444,10 @@ module ChapelBase {
       // string to a type. Otherwise, we can't resolve chpl_debug_writeln in
       // `range.these`
       { var dummyRange = 1..0; for i in dummyRange {} }
-      return str:t;
+      if t:string == "regex(string)" || t:string == "regex(bytes)" then
+        return compile(str);
+      else
+        return str:t;
     }
   }
   // param s is used for error reporting

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1142,12 +1142,14 @@ inline operator :(x: regex(bytes), type t: bytes) {
 
 // Cast string to regex
 pragma "no doc"
+deprecated "Casting strings to regex is deprecated. Use regex.compile(string) instead."
 inline operator :(x: string, type t: regex(string)) throws {
   return compile(x);
 }
 
 // Cast bytes to regex
 pragma "no doc"
+deprecated "Casting bytes to regex is deprecated. Use regex.compile(bytes) instead."
 inline operator :(x: bytes, type t: regex(bytes)) throws {
   return compile(x);
 }

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1142,14 +1142,14 @@ inline operator :(x: regex(bytes), type t: bytes) {
 
 // Cast string to regex
 pragma "no doc"
-deprecated "Casting strings to regex is deprecated. Use regex.compile(string) instead."
+deprecated "Casting strings to regex is deprecated. Use compile(string) from the Regex module instead."
 inline operator :(x: string, type t: regex(string)) throws {
   return compile(x);
 }
 
 // Cast bytes to regex
 pragma "no doc"
-deprecated "Casting bytes to regex is deprecated. Use regex.compile(bytes) instead."
+deprecated "Casting bytes to regex is deprecated. Use compile(bytes) from the Regex module instead."
 inline operator :(x: bytes, type t: regex(bytes)) throws {
   return compile(x);
 }

--- a/test/deprecated/regexTertiary.good
+++ b/test/deprecated/regexTertiary.good
@@ -1,3 +1,5 @@
+regexTertiary.chpl:8: warning: Casting strings to regex is deprecated. Use regex.compile(string) instead.
+regexTertiary.chpl:9: warning: Casting bytes to regex is deprecated. Use regex.compile(bytes) instead.
 regexTertiary.chpl:11: warning: string.search is deprecated, use regex search instead
 regexTertiary.chpl:12: warning: bytes.search is deprecated, use regex search instead
 regexTertiary.chpl:14: warning: string.search is deprecated, use regex search instead

--- a/test/deprecated/regexTertiary.good
+++ b/test/deprecated/regexTertiary.good
@@ -1,5 +1,5 @@
-regexTertiary.chpl:8: warning: Casting strings to regex is deprecated. Use regex.compile(string) instead.
-regexTertiary.chpl:9: warning: Casting bytes to regex is deprecated. Use regex.compile(bytes) instead.
+regexTertiary.chpl:8: warning: Casting strings to regex is deprecated. Use compile(string) from the Regex module instead.
+regexTertiary.chpl:9: warning: Casting bytes to regex is deprecated. Use compile(bytes) from the Regex module instead.
 regexTertiary.chpl:11: warning: string.search is deprecated, use regex search instead
 regexTertiary.chpl:12: warning: bytes.search is deprecated, use regex search instead
 regexTertiary.chpl:14: warning: string.search is deprecated, use regex search instead

--- a/test/regex/bytes/cast.chpl
+++ b/test/regex/bytes/cast.chpl
@@ -13,3 +13,13 @@ writeln(b"contains regular expression".find(rb));
 
 writeln("doesn't contain regular expression".find(rs));
 writeln(b"doesn't contain regular expression".find(rb));
+
+
+var rcs = compile(s);
+var rcb = compile(b);
+
+writeln("contains regular expression".find(rcs));
+writeln(b"contains regular expression".find(rcb));
+
+writeln("doesn't contain regular expression".find(rcs));
+writeln(b"doesn't contain regular expression".find(rcb));

--- a/test/regex/bytes/cast.chpl
+++ b/test/regex/bytes/cast.chpl
@@ -5,16 +5,6 @@ use Regex;
 var s = "contains";
 var b = b"contains";
 
-var rs = s:regex(string);
-var rb = b:regex(bytes);
-
-writeln("contains regular expression".find(rs));
-writeln(b"contains regular expression".find(rb));
-
-writeln("doesn't contain regular expression".find(rs));
-writeln(b"doesn't contain regular expression".find(rb));
-
-
 var rcs = compile(s);
 var rcb = compile(b);
 

--- a/test/regex/bytes/cast.good
+++ b/test/regex/bytes/cast.good
@@ -1,3 +1,9 @@
+cast.chpl:8: warning: Casting strings to regex is deprecated. Use regex.compile(string) instead.
+cast.chpl:9: warning: Casting bytes to regex is deprecated. Use regex.compile(bytes) instead.
+0
+0
+-1
+-1
 0
 0
 -1

--- a/test/regex/bytes/cast.good
+++ b/test/regex/bytes/cast.good
@@ -1,9 +1,3 @@
-cast.chpl:8: warning: Casting strings to regex is deprecated. Use regex.compile(string) instead.
-cast.chpl:9: warning: Casting bytes to regex is deprecated. Use regex.compile(bytes) instead.
-0
-0
--1
--1
 0
 0
 -1


### PR DESCRIPTION
This PR marks casts from strings or bytes to regex as deprecated and 
suggests using `compile()` from `Regex` module as a replacement until 
throwing initializers are implemented and we can suggest `new regex()`.

Updates some test `.good` files to expect the deprecation message.

TESTING:

- [x] paratest

reviewd by @jeremiah-corrado - thanks!