### PR TITLE
`string` and `bytes` documentation improvements

### DIFF
--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -1015,7 +1015,7 @@ the existing value in ``A`` when indices overlap.
 
 .. _Predefined_Functions_and_Methods_on_Arrays:
 
-Predefined Functions and Methods on Arrays
-------------------------------------------
+Predefined Routines on Arrays
+-----------------------------
 
 .. include:: ../../builtins/ChapelArray.rst

--- a/doc/rst/language/spec/bytes.rst
+++ b/doc/rst/language/spec/bytes.rst
@@ -86,8 +86,8 @@ on :ref:`Error Handling <Chapter-Error_Handling>`.
 
 .. _Bytes_Methods:
 
-Predefined Methods on Bytes
----------------------------
+Predefined Routines on Bytes
+----------------------------
 
 The *bytes* type:
 

--- a/doc/rst/language/spec/bytes.rst
+++ b/doc/rst/language/spec/bytes.rst
@@ -7,9 +7,9 @@
 Bytes
 =====
 
-The ``bytes`` type is similar to a string but allows arbitrary
-data to be stored in it. Methods on ``bytes`` that interpret the data as
-characters assume that the bytes are ASCII characters.
+The ``bytes`` type is similar to the :type:`~String.string` type but allows
+arbitrary data to be stored in it. Methods on ``bytes`` that interpret the
+data as characters assume that the bytes are ASCII characters.
 
 .. _Bytes_Instantiation:
 
@@ -17,15 +17,15 @@ Bytes Instantiation and Casting
 -------------------------------
 
 A ``bytes`` instance can be created using the literals similar to strings,
-prepended by a `b` character:
+prepended by a ``b`` character:
 
 .. code-block:: chapel
 
    var b = b"my bytes";
 
-``bytes`` can also be crated using a specific buffer (i.e. data in another
-*bytes*, a `c_string` or a C pointer) you can use the factory functions shown
-below, such as :proc:`~Bytes.createBytesWithNewBuffer`.
+The factory functions shown below, such as :proc:`~Bytes.createBytesWithNewBuffer`,
+allow you to create a ``bytes`` using a specific buffer (i.e. data in another
+``bytes``, a ``c_string`` or a :class:`~CTypes.c_ptr`).
 
 .. _Bytes_and_String:
 
@@ -50,9 +50,9 @@ and needs to be decoded to be converted to a *string*.
 
   var s2 = b.decode(); // you need to decode a bytes to convert it to a string
 
-See the documentation for the :proc:`~Bytes.bytes.decode` method for details.
+See the :proc:`~Bytes.bytes.decode` method below for details.
 
-Similarly, a ``bytes`` can be initialized using a string:
+Similarly, a ``bytes`` can be initialized using a ``string``:
 
 .. code-block:: chapel
 
@@ -86,8 +86,8 @@ on :ref:`Error Handling <Chapter-Error_Handling>`.
 
 .. _Bytes_Methods:
 
-Bytes Methods
--------------
+Predefined Methods on Bytes
+---------------------------
 
 The *bytes* type:
 

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -924,11 +924,10 @@ set manipulations.  The supported set operators are:
   =======  ====================
 
 
-Predefined Methods on Domains
------------------------------
+Predefined Routines on Domains
+------------------------------
 
 .. include:: ../../builtins/ChapelDomain.rst
 
 .. [3]
    This is also known as row-major ordering.
-

--- a/doc/rst/language/spec/index.rst
+++ b/doc/rst/language/spec/index.rst
@@ -45,8 +45,8 @@ Composite Types
    :maxdepth: 1
 
    tuples
-   bytes
    strings
+   bytes
    classes
    records
    unions

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -961,8 +961,8 @@ numbers.
 
 .. _Predefined_Range_Functions:
 
-Predefined Routines on Ranges
------------------------------
+Predefined Methods on Ranges
+----------------------------
 
 .. _Range_Type_Accessors:
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -961,8 +961,8 @@ numbers.
 
 .. _Predefined_Range_Functions:
 
-Predefined Methods on Ranges
-----------------------------
+Predefined Routines on Ranges
+-----------------------------
 
 .. _Range_Type_Accessors:
 

--- a/doc/rst/language/spec/strings.rst
+++ b/doc/rst/language/spec/strings.rst
@@ -17,7 +17,7 @@ Methods Available in Standard Modules
 
 Besides the functions below, some other modules provide routines that are
 useful for working with strings. The :mod:`IO` module provides
-``IO.string.format`` which creates a string that is the result of
+:proc:`~FormattedIO.string.format` which creates a string that is the result of
 formatting. It also includes functions for reading and writing strings.
 The :mod:`Regex` module also provides some routines for searching
 within strings.
@@ -172,8 +172,8 @@ codepoint of the argument:
 
 .. _String_Methods:
 
-String Methods
---------------
+Predefined Methods on Strings
+-----------------------------
 
 The *string* type:
 

--- a/doc/rst/language/spec/strings.rst
+++ b/doc/rst/language/spec/strings.rst
@@ -172,8 +172,8 @@ codepoint of the argument:
 
 .. _String_Methods:
 
-Predefined Methods on Strings
------------------------------
+Predefined Routines on Strings
+------------------------------
 
 The *string* type:
 

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -1181,8 +1181,8 @@ in the two operand tuples. Otherwise, a compile-time error will result.
 
 .. _Predefined_Functions_and_Methods_on_Tuples:
 
-Predefined Functions and Methods on Tuples
-------------------------------------------
+Predefined Routines on Tuples
+-----------------------------
 
 .. function:: proc tuple.size param
 


### PR DESCRIPTION
This PR makes a few minor improvements to the `string` and `bytes` documentation pages:

* Swapped order of `string` and `bytes` lang-spec pages. (Because of the wording, the string page is sort of a prerequisite for the bytes page).
* Included some missing links to other pages
* Improved wording/grammar in a couple of places
* Made headings more consistent across composite-types pages

