### PR TITLE
Have nightly GPU+Arkouda tests filter out HDF5Msg_LEGACY

### DIFF
--- a/util/cron/test-cray-xc-gpu-arkouda.bash
+++ b/util/cron/test-cray-xc-gpu-arkouda.bash
@@ -34,7 +34,7 @@ source $CWD/common-arkouda.bash
 
 # List of Arkouda server modules we exempt from testing (that goal is to
 # eventually have this be an empty list).
-export CHPL_TEST_ARKOUDA_DISABLE_MODULES=In1dMsg:HDF5Msg
+export CHPL_TEST_ARKOUDA_DISABLE_MODULES=In1dMsg:HDF5Msg:HDF5Msg_LEGACY
 export CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD="true"
 
 module list


### PR DESCRIPTION
This is a new Arkouda module (based on the HDF5 module which we also filter out for these tests).