### PR TITLE
Ensure we time mem transfer in SHOC Triad

### DIFF
--- a/test/gpu/native/studies/shoc/triadchpl.chpl
+++ b/test/gpu/native/studies/shoc/triadchpl.chpl
@@ -30,8 +30,18 @@ proc main(){
             // The reference (CUDA) implementation of SHOC fills hos
             // with random values, in our implementation we fill with
             // known sample values so we can later verify the result.
-            // This difference shouldn't impact performance.
-            forall i in 0..#halfNumFloats {
+            // This difference in values shouldn't impact performance.
+            //
+            // Note: we're very explicit about making this a 'for'
+            // rather than a 'forall' loop so that this initialization
+            // computation occurs on the CPU rather than GPU. Why?:
+            // We want A, B, and C to start off on the CPU so that
+            // we measure the transfer cost (as we do in the CUDA
+            // version) for a fair comparison. If we made this a forall
+            // loop it would turn into a GPU kernel and (assuming
+            // we're using the unified_memory memory strategy) A, B,
+            //  and C will be left on the GPU before we start the timers.
+            for i in 0..#halfNumFloats {
                 A[i] = i:int(32)%16:int(32) + 0.12:real(32);
                 A[halfNumFloats+i] = A[i] ;
                 B[i] = A[i];


### PR DESCRIPTION
The timers in the CUDA version of SHOC triad include the time needed to transfer the A and B vectors to the GPU.

However, in our Chapeltastic version we were initializing these vectors on the GPU and avoided the memory transfer.  In order to make the comparison more fair I'm modifying our implementation of the benchmark to initialize these vectors on the CPU.

For more details see this comment: https://github.com/Cray/chapel-private/issues/3882#issuecomment-1297515792