### PR TITLE
dyno: factor VarScopeVisitor out of split init implementation

### DIFF
--- a/frontend/include/chpl/resolution/split-init.h
+++ b/frontend/include/chpl/resolution/split-init.h
@@ -37,29 +37,6 @@ computeSplitInits(Context* context,
                   const uast::AstNode* symbol,
                   const ResolutionResultByPostorderID& byPostorder);
 
-/**
-  Compute a vector indicating which actuals are passed to an 'out'
-  formal in all return intent overloads. For each actual 'i',
-  actualIsOut[i] will be set to 0 or 1; where 1 means all best
-  candidates used an 'out' formal for that actual.
-
-  actualFormalTypes will be set so that for actual 'i',
-  if it is passed to an 'out' formal, actualFormalTypes[i] will be
-  set to the type of the 'out' formal. If these do not match among
-  several return intent overloads, this function will issue an error
-  in the current query.
-
-  This is not a query. It may raise errors within the currently
-  running query.
- */
-void
-computeOutFormals(Context* context,
-                  const MostSpecificCandidates& candidates,
-                  const CallInfo& ci,
-                  const std::vector<const uast::AstNode*>& actualAsts,
-                  std::vector<int8_t>& actualIsOut,
-                  std::vector<types::QualifiedType>& actualFormalTypes);
-
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/resolution/CMakeLists.txt
+++ b/frontend/lib/resolution/CMakeLists.txt
@@ -32,5 +32,6 @@ target_sources(libdyno-obj
                scope-queries.cpp
                scope-types.cpp
                split-init.cpp
+               VarScopeVisitor.cpp
 
               )

--- a/frontend/lib/resolution/Makefile.include
+++ b/frontend/lib/resolution/Makefile.include
@@ -35,6 +35,7 @@ FRONTEND_RESOLUTION_SRCS =                          \
            scope-queries.cpp                        \
            scope-types.cpp                          \
            split-init.cpp                           \
+           VarScopeVisitor.cpp                      \
 
 
 SRCS = $(FRONTEND_RESOLUTION_SRCS)

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -27,11 +27,11 @@
 #include "chpl/resolution/intents.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
-#include "chpl/resolution/split-init.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
 
 #include "InitResolver.h"
+#include "VarScopeVisitor.h"
 
 #include <cstdio>
 #include <set>
@@ -1125,9 +1125,9 @@ Resolver::adjustTypesForOutFormals(const CallInfo& ci,
                                    const MostSpecificCandidates& fns) {
 
   std::vector<QualifiedType> actualFormalTypes;
-  std::vector<int8_t> actualIdxToOut;
-  computeOutFormals(context, fns, ci, asts,
-                    actualIdxToOut, actualFormalTypes);
+  std::vector<IntentList> actualIntents;
+  computeActualFormalIntents(context, fns, ci, asts,
+                             actualIntents, actualFormalTypes);
 
   int actualIdx = 0;
   for (auto actual : ci.actuals()) {
@@ -1139,7 +1139,7 @@ Resolver::adjustTypesForOutFormals(const CallInfo& ci,
     if (actualAst != nullptr && byPostorder.hasAst(actualAst)) {
       id = byPostorder.byAst(actualAst).toId();
     }
-    if (actualIdxToOut[actualIdx] && !id.isEmpty()) {
+    if (actualIntents[actualIdx] == IntentList::OUT && !id.isEmpty()) {
       QualifiedType formalType = actualFormalTypes[actualIdx];
       adjustTypesForSplitInit(id, formalType, actualAst, actualAst);
     }

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -210,8 +210,7 @@ bool VarScopeVisitor::enter(const FnCall* callAst, RV& rv) {
           const QualifiedType& formalQt = fn->formalType(i);
           auto kind = formalQt.kind();
           if (kind == QualifiedType::OUT ||
-              kind == QualifiedType::IN ||
-              kind == QualifiedType::CONST_IN ||
+              kind == QualifiedType::IN || kind == QualifiedType::CONST_IN ||
               kind == QualifiedType::INOUT) {
             anyInOutInout = true;
             break;
@@ -251,15 +250,16 @@ bool VarScopeVisitor::enter(const FnCall* callAst, RV& rv) {
           (void) actual; // avoid compilation error about unused variable
 
           const AstNode* actualAst = actualAsts[actualIdx];
+          IntentList kind = actualFormalIntents[actualIdx];
 
           // handle an actual that is passed to an 'out'/'in'/'inout' formal
-          if (actualFormalIntents[actualIdx] == IntentList::OUT) {
+          if (kind == IntentList::OUT) {
             handleOutFormal(callAst, actualAst,
                             actualFormalTypes[actualIdx], rv);
-          } else if (actualFormalIntents[actualIdx] == IntentList::IN) {
+          } else if (kind == IntentList::IN || kind == IntentList::CONST_IN) {
             handleInFormal(callAst, actualAst,
                            actualFormalTypes[actualIdx], rv);
-          } else if (actualFormalIntents[actualIdx] == IntentList::INOUT) {
+          } else if (kind == IntentList::INOUT) {
             handleInoutFormal(callAst, actualAst,
                               actualFormalTypes[actualIdx], rv);
           } else {

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VarScopeVisitor.h"
+
+#include "chpl/resolution/ResolvedVisitor.h"
+#include "chpl/resolution/resolution-types.h"
+#include "chpl/resolution/scope-queries.h"
+#include "chpl/uast/all-uast.h"
+
+#include "Resolver.h"
+
+namespace chpl {
+namespace resolution {
+
+
+using namespace uast;
+using namespace types;
+
+
+bool VarFrame::addToDeclaredVars(ID varId) {
+  auto pair = declaredVars.insert(std::move(varId));
+  return pair.second;
+}
+bool VarFrame::addToInitedVars(ID varId) {
+  auto pair = initedVars.insert(std::move(varId));
+  return pair.second;
+}
+
+void
+VarScopeVisitor::process(const uast::AstNode* symbol,
+                         const ResolutionResultByPostorderID& byPostorder) {
+  ResolvedVisitor<VarScopeVisitor> rv(context,
+                                      symbol,
+                                      *this,
+                                      byPostorder);
+
+  // Traverse formals and then the body. This is done here rather
+  // than in enter(Function) because nested functions will have
+  // 'process' called on them separately.
+  if (auto fn = symbol->toFunction()) {
+    // traverse formals and then traverse the body
+    if (auto body = fn->body()) {
+      // make a pretend scope for the formals
+      enterScope(body);
+
+      // traverse the formals
+      for (auto formal : fn->formals()) {
+        formal->traverse(rv);
+      }
+
+      // traverse the real body
+      body->traverse(rv);
+
+      exitScope(body);
+    }
+  } else {
+    symbol->traverse(rv);
+  }
+}
+
+ID VarScopeVisitor::refersToId(const AstNode* ast, RV& rv) {
+  ID toId;
+  if (ast != nullptr && rv.hasAst(ast)) {
+    toId = rv.byAst(ast).toId();
+  }
+  return toId;
+}
+
+void VarScopeVisitor::handleMentions(const AstNode* ast, RV& rv) {
+  // This could be its own ResolvedVisitor if it needs to handle
+  // more complex forms. For now, this simple implementation should suffice
+  // for expressions used as actuals etc.
+  if (auto ident = ast->toIdentifier()) {
+    ID toId = refersToId(ident, rv);
+    if (!toId.isEmpty()) {
+      handleMention(ident, toId, rv);
+    }
+  } else {
+    for (auto child : ast->children()) {
+      handleMentions(child, rv);
+    }
+  }
+}
+
+void VarScopeVisitor::enterScope(const AstNode* ast) {
+  if (createsScope(ast->tag())) {
+    scopeStack.push_back(toOwned(new VarFrame(ast)));
+  }
+  if (auto c = ast->toConditional()) {
+    // note thenBlock / elseBlock
+    VarFrame* condFrame = scopeStack.back().get();
+    condFrame->subBlocks.push_back(ControlFlowSubBlock(c->thenBlock()));
+    condFrame->subBlocks.push_back(ControlFlowSubBlock(c->elseBlock()));
+  } else if (auto t = ast->toTry()) {
+    // note each of the catch handlers (aka catch clauses)
+    VarFrame* tryFrame = scopeStack.back().get();
+    for (auto clause : t->handlers()) {
+      tryFrame->subBlocks.push_back(ControlFlowSubBlock(clause));
+    }
+  }
+}
+void VarScopeVisitor::exitScope(const AstNode* ast) {
+  if (createsScope(ast->tag())) {
+    assert(!scopeStack.empty());
+    size_t n = scopeStack.size();
+    owned<VarFrame>& curFrame = scopeStack[n-1];
+    assert(curFrame->scopeAst == ast);
+    VarFrame* parentFrame = nullptr; // Conditional or Try
+    bool savedSubBlock = false;
+    if (n >= 2) {
+      // Are we in the situation of just finishing a Block
+      // that is within a Conditional? or a Catch clause?
+      // If so, save the frame in the subBlocks, to
+      // be handled when processing condFrame.
+      parentFrame = scopeStack[n-2].get();
+      for (auto & subBlock : parentFrame->subBlocks) {
+        if (subBlock.block == ast) {
+          subBlock.frame.swap(curFrame);
+          savedSubBlock = true;
+        }
+      }
+    }
+    if (savedSubBlock) {
+      // frame will be processed with parent block
+      assert(parentFrame->scopeAst->isConditional() ||
+             parentFrame->scopeAst->isTry());
+    } else if (auto cond = ast->toConditional()) {
+      handleConditional(cond);
+    } else if (auto t = ast->toTry()) {
+      handleTry(t);
+    } else {
+      handleScope(ast);
+    }
+    scopeStack.pop_back();
+  }
+}
+
+
+bool VarScopeVisitor::enter(const VarLikeDecl* ast, RV& rv) {
+  enterScope(ast);
+
+  return true;
+}
+void VarScopeVisitor::exit(const VarLikeDecl* ast, RV& rv) {
+  assert(!scopeStack.empty());
+  if (!scopeStack.empty()) {
+    handleDeclaration(ast, rv);
+  }
+
+  exitScope(ast);
+}
+
+
+bool VarScopeVisitor::enter(const OpCall* ast, RV& rv) {
+
+  if (ast->op() == USTR("=")) {
+    // What is the RHS and LHS of the '=' call?
+    auto lhsAst = ast->actual(0);
+    auto rhsAst = ast->actual(1);
+
+    // visit the RHS first
+    rhsAst->traverse(rv);
+
+    // now consider the LHS
+    ID toId = rv.byAst(lhsAst).toId();
+
+    if (!toId.isEmpty()) {
+      handleVarAssign(ast, toId, rv);
+    } else {
+      // visit the LHS to check for mentions
+      lhsAst->traverse(rv);
+    }
+  }
+
+  return false;
+}
+
+void VarScopeVisitor::exit(const OpCall* ast, RV& rv) {
+}
+
+
+bool VarScopeVisitor::enter(const FnCall* callAst, RV& rv) {
+
+  if (rv.hasAst(callAst)) {
+    // Does any return-intent-overload use 'in', 'out', or 'inout'?
+    // This filter is intended as an optimization.
+    const MostSpecificCandidates& candidates = rv.byAst(callAst).mostSpecific();
+    bool anyInOutInout = false;
+    for (const TypedFnSignature* fn : candidates) {
+      if (fn != nullptr) {
+        int n = fn->numFormals();
+        for (int i = 0; i < n; i++) {
+          const QualifiedType& formalQt = fn->formalType(i);
+          auto kind = formalQt.kind();
+          if (kind == QualifiedType::OUT ||
+              kind == QualifiedType::IN ||
+              kind == QualifiedType::CONST_IN ||
+              kind == QualifiedType::INOUT) {
+            anyInOutInout = true;
+            break;
+          }
+        }
+        if (anyInOutInout) {
+          break;
+        }
+      }
+    }
+
+    if (!anyInOutInout) {
+      // visit the actuals to gather mentions
+      for (auto actualAst : callAst->actuals()) {
+        actualAst->traverse(rv);
+      }
+    } else {
+      // Use FormalActualMap to figure out which variable ID
+      // is passed to a formal with out/in/inout intent.
+      // Issue an error if it does not match among return intent overloads.
+      auto calledExprAst = callAst->calledExpression();
+      if (rv.hasAst(calledExprAst)) {
+        std::vector<const AstNode*> actualAsts;
+        auto ci = CallInfo::create(context, callAst, rv.byPostorder(),
+                                   /* raiseErrors */ false,
+                                   &actualAsts);
+
+        // compute a vector indicating which actuals are passed to
+        // an 'out' formal in all return intent overloads
+        std::vector<QualifiedType> actualFormalTypes;
+        std::vector<IntentList> actualFormalIntents;
+        computeActualFormalIntents(context, candidates, ci, actualAsts,
+                                   actualFormalIntents, actualFormalTypes);
+
+        int actualIdx = 0;
+        for (auto actual : ci.actuals()) {
+          (void) actual; // avoid compilation error about unused variable
+
+          const AstNode* actualAst = actualAsts[actualIdx];
+
+          // handle an actual that is passed to an 'out'/'in'/'inout' formal
+          if (actualFormalIntents[actualIdx] == IntentList::OUT) {
+            handleOutFormal(callAst, actualAst,
+                            actualFormalTypes[actualIdx], rv);
+          } else if (actualFormalIntents[actualIdx] == IntentList::IN) {
+            handleInFormal(callAst, actualAst,
+                           actualFormalTypes[actualIdx], rv);
+          } else if (actualFormalIntents[actualIdx] == IntentList::INOUT) {
+            handleInoutFormal(callAst, actualAst,
+                              actualFormalTypes[actualIdx], rv);
+          } else {
+            // otherwise, visit the actuals to gather mentions
+            actualAst->traverse(rv);
+          }
+
+          actualIdx++;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+void VarScopeVisitor::exit(const FnCall* ast, RV& rv) {
+}
+
+
+bool VarScopeVisitor::enter(const Return* ast, RV& rv) {
+  return true;
+}
+void VarScopeVisitor::exit(const Return* ast, RV& rv) {
+  if (!scopeStack.empty()) {
+    VarFrame* frame = scopeStack.back().get();
+    frame->returns = true;
+  }
+}
+
+
+bool VarScopeVisitor::enter(const Throw* ast, RV& rv) {
+  return true;
+}
+void VarScopeVisitor::exit(const Throw* ast, RV& rv) {
+  if (!scopeStack.empty()) {
+    VarFrame* frame = scopeStack.back().get();
+    frame->throws = true;
+  }
+}
+
+
+bool VarScopeVisitor::enter(const Identifier* ast, RV& rv) {
+  return true;
+}
+void VarScopeVisitor::exit(const Identifier* ast, RV& rv) {
+  if (!scopeStack.empty()) {
+    ID toId;
+    if (rv.hasAst(ast)) {
+      toId = rv.byAst(ast).toId();
+    }
+    if (!toId.isEmpty()) {
+      handleMention(ast, toId, rv);
+    }
+  }
+}
+
+bool VarScopeVisitor::enter(const AstNode* ast, RV& rv) {
+  enterScope(ast);
+
+  return true;
+}
+void VarScopeVisitor::exit(const AstNode* ast, RV& rv) {
+  exitScope(ast);
+}
+
+
+static IntentList normalizeFormalIntent(IntentList intent) {
+  switch (intent) {
+    case IntentList::OUT:
+      return IntentList::OUT;
+
+    case IntentList::IN:
+    case IntentList::CONST_IN:
+      return IntentList::IN;
+
+    case IntentList::INOUT:
+      return IntentList::INOUT;
+
+    default:
+      return IntentList::UNKNOWN;
+  }
+}
+
+void
+computeActualFormalIntents(Context* context,
+                           const MostSpecificCandidates& candidates,
+                           const CallInfo& ci,
+                           const std::vector<const AstNode*>& actualAsts,
+                           std::vector<IntentList>& actualFormalIntents,
+                           std::vector<QualifiedType>& actualFormalTypes) {
+
+  int nActuals = ci.numActuals();
+  actualFormalIntents.clear();
+  actualFormalIntents.resize(nActuals);
+  actualFormalTypes.clear();
+  actualFormalTypes.resize(nActuals);
+
+  int nFns = candidates.numBest();
+  if (nFns == 0) {
+    // return early if there are no actual candidates
+    return;
+  }
+
+  bool firstCandidate = true;
+  for (const TypedFnSignature* fn : candidates) {
+    if (fn != nullptr) {
+      auto formalActualMap = FormalActualMap(fn, ci);
+      for (int actualIdx = 0; actualIdx < nActuals; actualIdx++) {
+        const FormalActual* fa = formalActualMap.byActualIdx(actualIdx);
+        auto intent  = normalizeFormalIntent(fa->formalType().kind());
+        QualifiedType& aft = actualFormalTypes[actualIdx];
+
+        if (firstCandidate) {
+          actualFormalIntents[actualIdx] = intent;
+          if (intent != IntentList::UNKNOWN) {
+            aft = fa->formalType();
+          }
+        } else {
+          // check that the intent and types match
+          if (actualFormalIntents[actualIdx] != intent) {
+            // TODO: fix this error once return intent overloading implemented.
+            context->error(actualAsts[actualIdx],
+                  "return intent overloading but intent does not match");
+            actualFormalIntents[actualIdx] = IntentList::UNKNOWN;
+          } else if (intent != IntentList::UNKNOWN && aft != fa->formalType()) {
+            // TODO: fix this error once return intent overloading implemented.
+            context->error(actualAsts[actualIdx],
+                "using return intent overloads but the return "
+                "intent overloads do not have matching formal types");
+          }
+        }
+      }
+      firstCandidate = false;
+    }
+  }
+}
+
+
+
+} // end namespace resolution
+} // end namespace chpl

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -75,6 +75,42 @@ VarScopeVisitor::process(const uast::AstNode* symbol,
   }
 }
 
+VarFrame* VarScopeVisitor::currentThenFrame() {
+  VarFrame* frame = currentFrame();
+  assert(frame->scopeAst->isConditional());
+  assert(frame->subBlocks.size() == 1 || frame->subBlocks.size() == 2);
+  VarFrame* ret = frame->subBlocks[0].frame.get();
+  assert(ret);
+  return ret;
+}
+VarFrame* VarScopeVisitor::currentElseFrame() {
+  VarFrame* frame = currentFrame();
+  assert(frame->scopeAst->isConditional());
+  assert(frame->subBlocks.size() == 1 || frame->subBlocks.size() == 2);
+  if (frame->subBlocks.size() == 1) {
+    // there was no 'else' clause
+    return nullptr;
+  } else {
+    return frame->subBlocks[1].frame.get();
+  }
+}
+
+int VarScopeVisitor::currentNumCatchFrames() {
+  VarFrame* frame = currentFrame();
+  assert(frame->scopeAst->isTry());
+  int ret = frame->subBlocks.size();
+  assert(frame->scopeAst->toTry()->numHandlers() == ret);
+  return ret;
+}
+VarFrame* VarScopeVisitor::currentCatchFrame(int i) {
+  VarFrame* frame = currentFrame();
+  assert(frame->scopeAst->isTry());
+  assert(0 <= i && (size_t) i < frame->subBlocks.size());
+  VarFrame* ret = frame->subBlocks[i].frame.get();
+  assert(ret);
+  return ret;
+}
+
 ID VarScopeVisitor::refersToId(const AstNode* ast, RV& rv) {
   ID toId;
   if (ast != nullptr && rv.hasAst(ast)) {

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VAR_SCOPE_VISITOR_H
+#define VAR_SCOPE_VISITOR_H
+
+#include "chpl/framework/ID.h"
+#include "chpl/resolution/ResolvedVisitor.h"
+
+namespace chpl {
+namespace uast {
+  class AstNode;
+  class Conditional;
+  class FnCall;
+  class Identifier;
+  class OpCall;
+  class Return;
+  class Throw;
+  class Try;
+}
+namespace types {
+  class QualifiedType;
+}
+
+namespace resolution {
+
+struct VarFrame;
+struct ControlFlowSubBlock;
+
+/** Helper visitor for traversals that work with variable
+    init and deinit. This class is intended to factor out code
+    common between 3 analysis:
+     * split init
+     * copy elision
+     * computing where copies and deinits occur
+
+    Since it is only used internally for these cases,
+    the interface covers whatever these analyses need. */
+class VarScopeVisitor {
+ protected:
+  using RV = ResolvedVisitor<VarScopeVisitor>;
+
+  // ----- inputs to the process
+  Context* context = nullptr;
+
+
+  // ----- internal variables
+  std::vector<owned<VarFrame>> scopeStack;
+
+
+  // ----- methods to be implemented by specific analysis subclass
+
+  /** Called for a variable declaration */
+  virtual void handleDeclaration(const uast::VarLikeDecl* ast, RV& rv) = 0;
+  /** Called for an Identifier not used in one of the below cases */
+  virtual void handleMention(const uast::Identifier* ast, ID varId, RV& rv) = 0;
+  /** Called for Identifier = <expr> assignment pattern */
+  virtual void handleVarAssign(const uast::OpCall* ast, ID varId, RV& rv) = 0;
+  /** Called for an actual passed to an 'out' formal */
+  virtual void handleOutFormal(const uast::FnCall* ast,
+                               const uast::AstNode* actual,
+                               const types::QualifiedType& formalType, RV& rv) = 0;
+  /** Called for an actual passed to an 'in' formal */
+  virtual void handleInFormal(const uast::FnCall* ast,
+                              const uast::AstNode* actual,
+                              const types::QualifiedType& formalType,
+                              RV& rv) = 0;
+  /** Called for an actual passed to an 'out' formal */
+  virtual void handleInoutFormal(const uast::FnCall* ast,
+                                 const uast::AstNode* actual,
+                                 const types::QualifiedType& formalType,
+                                 RV& rv) = 0;
+ 
+  /** Called to process a Conditional after handling its contents --
+      should update currentFrame() which is the frame for the Conditional.
+      The then/else frames are sitting in currentFrame().subBlocks. */
+  virtual void handleConditional(const uast::Conditional* cond) = 0;
+  /** Called to process a Try after handling its contents --
+      should update currentFrame() which is the frame for the Try.
+      The catch clause frames are sitting in currentFrame().subBlocks. */
+  virtual void handleTry(const uast::Try* t) = 0;
+  /** Called to process any other Scope after handling its contents --
+      should update scopeStack.back() which is the frame for the Try.
+      Not called for Conditional or Try. */
+  virtual void handleScope(const uast::AstNode* ast) = 0;
+
+
+  // ----- methods for use by specific analysis subclasses
+
+  VarScopeVisitor(Context* context) : context(context), scopeStack() { }
+
+ public:
+  void process(const uast::AstNode* symbol,
+               const ResolutionResultByPostorderID& byPostorder);
+
+ protected:
+
+  /** Return the current frame. This should always be safe to call
+      from one of the handle* methods. */
+  VarFrame* currentFrame() {
+    assert(!scopeStack.empty());
+    return scopeStack.back().get();
+  }
+
+  /** If ast is an Identifier that refers to a VarLikeDecl, return the
+      Id of the VarLikeDecl. Otherwise, return an empty ID. */
+  ID refersToId(const AstNode* ast, RV& rv);
+
+  /** Call handleMention for any Identifiers contained in this ast node.
+      Only appropriate for expressions (not for Loops) */
+  void handleMentions(const AstNode* ast, RV& rv);
+
+ public:
+  // ----- visitor implementation
+  void enterScope(const uast::AstNode* ast);
+  void exitScope(const uast::AstNode* ast);
+
+  bool enter(const VarLikeDecl* ast, RV& rv);
+  void exit(const VarLikeDecl* ast, RV& rv);
+
+  bool enter(const OpCall* ast, RV& rv);
+  void exit(const OpCall* ast, RV& rv);
+
+  bool enter(const FnCall* ast, RV& rv);
+  void exit(const FnCall* ast, RV& rv);
+
+  bool enter(const Return* ast, RV& rv);
+  void exit(const Return* ast, RV& rv);
+
+  bool enter(const Throw* ast, RV& rv);
+  void exit(const Throw* ast, RV& rv);
+
+  bool enter(const Identifier* ast, RV& rv);
+  void exit(const Identifier* ast, RV& rv);
+
+  bool enter(const uast::AstNode* node, RV& rv);
+  void exit(const uast::AstNode* node, RV& rv);
+};
+
+/** Collects information about a Conditional's then/else blocks
+    or a Try's Catch blocks. */
+struct ControlFlowSubBlock {
+  const AstNode* block = nullptr; // then block / else block / catch block
+  owned<VarFrame> frame;
+  ControlFlowSubBlock(const AstNode* block) : block(block) { }
+};
+
+/** Collects information about a variable declaration frame / scope.
+    Note that some of the fields here will only be used by a single subclass.
+    Keeping them declared here keeps things simple. */
+struct VarFrame {
+  // ----- variables used by VarScopeVisitor
+  const AstNode* scopeAst = nullptr; // for debugging
+
+  // Which variables are declared in this scope?
+  // For split init, only variables without init expressions.
+  std::set<ID> declaredVars;
+
+  // Which variables are initialized in this scope?
+  // This includes both locally declared and outer variables.
+  std::set<ID> initedVars;
+
+  // has the block already encountered a return?
+  bool returns = false;
+
+  // has the block already encountered a throw?
+  bool throws = false;
+
+  // When processing a conditional or catch blocks,
+  // instead of popping the SplitInitFrame for the then/else/catch blocks,
+  // store them here, for use in handleExitScope(Conditional or Try).
+  std::vector<ControlFlowSubBlock> subBlocks;
+
+
+  // ----- variables declared here for use in particular subclasses
+
+  // for split init:
+
+  // which variables are declared here in a way that allows split init?
+  std::set<ID> eligibleVars;
+  // same as initedVars but preserves order & saves types
+  std::vector<std::pair<ID, types::QualifiedType>> initedVarsVec;
+  // Which variables are mentioned in this scope before
+  // being initialized, throwing or returning?
+  std::set<ID> mentionedVars;
+
+  VarFrame(const AstNode* scopeAst) : scopeAst(scopeAst) { }
+
+  // returns 'true' if it was inserted
+  bool addToDeclaredVars(ID varId);
+  // returns 'true' if it was inserted
+  bool addToInitedVars(ID varId);
+};
+
+/**
+  Compute a vector indicating which actuals are passed to an 'out'/'in'/'inout'
+  formal in all return intent overloads. For each actual 'i',
+  actualFormalIntent[i] will be set to one of the following:
+   * uast::IntentList::OUT if it is passed to an 'out' formal
+   * uast::IntentList::IN if it is passed to an 'in' or 'const in' formal
+   * uast::IntentList::INOUT if it is passed to an 'inout' formal
+   * uast::IntentList::UNKNOWN otherwise
+
+  actualFormalTypes will be set so that for actual 'i', if it is passed
+  to an 'out'/'in'/'inout' formal, actualFormalTypes[i] will be set to the
+  type of the 'out'/'in'/'inout' formal.
+
+  If either of the above computed values do not match among
+  the return intent overloads, this function will issue an error
+  in the current query.
+ */
+void
+computeActualFormalIntents(Context* context,
+                           const MostSpecificCandidates& candidates,
+                           const CallInfo& ci,
+                           const std::vector<const AstNode*>& actualAsts,
+                           std::vector<uast::IntentList>& actualFrmlIntents,
+                           std::vector<types::QualifiedType>& actualFrmlTypes);
+
+} // end namespace resolution
+} // end namespace chpl
+
+#endif

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -118,6 +118,20 @@ class VarScopeVisitor {
     return scopeStack.back().get();
   }
 
+  /** Assuming that the current frame refers to a Conditional,
+      returns the frame for the 'then' block. */
+  VarFrame* currentThenFrame();
+  /** Assuming that the current frame refers to a Conditional,
+      returns the frame for the 'else' block, or 'nullptr' if there was none. */
+  VarFrame* currentElseFrame();
+
+  /** Assuming that the current frame refers to a Try,
+      returns the number of frames saved for Catch clauses.  */
+  int currentNumCatchFrames();
+  /** Assuming that the current frame refers to a Try,
+      returns the i'th saved Catch frame. */
+  VarFrame* currentCatchFrame(int i);
+
   /** If ast is an Identifier that refers to a VarLikeDecl, return the
       Id of the VarLikeDecl. Otherwise, return an empty ID. */
   ID refersToId(const AstNode* ast, RV& rv);


### PR DESCRIPTION
Follow-up to PR #20843.

As I am looking at implementing the copy elision analysis in dyno, I'm realizing that many of the details are the same as for split init. So, in this PR, I've factored out these details into VarScopeVisitor.h / VarScopeVisitor.cpp (which are private within the library). This visitor can have subclasses for split init / copy elision / etc. It should just be updated to handle whatever these similar cases need.

This is primarily a refactor. The only behavior change that I've added intentionally is that the replacement for `computeOutFormals`, which is `computeActualFormalIntents`, is now more picky about making sure that the return intent overloads have the same types and intents.

Reviewed by @DanilaFe - thanks!