### PR TITLE
Change owner to root for smokeTest lint

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,9 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
+    - name: Set ownership
+      run: |
+        chown -R $(id -u):$(id -g) $PWD 
     - name: make check
       run: |
         ./util/buildRelease/smokeTest chpl
@@ -40,6 +43,9 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
+    - name: Set ownership
+      run: |
+        chown -R $(id -u):$(id -g) $PWD 
     - name: make frontend-docs
       run: |
         make frontend-docs
@@ -62,6 +68,12 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
+    - name: Set ownership
+      run: |
+        chown -R $(id -u):$(id -g) $PWD 
+    - name: Set ownership
+      run: |
+        chown -R $(id -u):$(id -g) $PWD 
     - name: make mason
       # Use a quickstart config to keep it from running to long
       # While there, run a make check in that config for more coverage
@@ -77,6 +89,9 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
+    - name: Set ownership
+      run: |
+        chown -R $(id -u):$(id -g) $PWD 
     - name: make test-dyno-with-asserts
       run: |
         make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
-      options: --user root
+      options: --user sudo
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
-      options: --user sudo
+      options: --user root
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -96,6 +96,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 100000
+    - name: Set ownership
+        run: |
+          # this is to fix "detected dubious ownership in repository"
+          chown -R $(id -u):$(id -g) $PWD   
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -97,9 +97,8 @@ jobs:
       with:
         fetch-depth: 100000
     - name: Set ownership
-        run: |
-          # this is to fix "detected dubious ownership in repository"
-          chown -R $(id -u):$(id -g) $PWD   
+      run: |
+        chown -R $(id -u):$(id -g) $PWD   
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls
@@ -109,4 +108,5 @@ jobs:
         CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
     - name: smokeTest lint
       run: |
+        chown -R $(id -u):$(id -g) $PWD  
         ./util/buildRelease/smokeTest lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,6 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      options: --user root
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
-      options: --user root
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -108,5 +107,4 @@ jobs:
         CHPL_LLVM=none CHPL_HOME=$PWD ./util/test/run-in-test-venv.bash ./util/test/check_annotations.py
     - name: smokeTest lint
       run: |
-        chown -R $(id -u):$(id -g) $PWD  
         ./util/buildRelease/smokeTest lint


### PR DESCRIPTION
Fix for issue: https://github.com/Cray/chapel-private/issues/3993
Problem:
CI workflow failing in SmokeTest Lint with
fatal: detected dubious ownership in repository at '/__w/chapel/chapel'
To add an exception for this directory, call:
	git config --global --add safe.directory /__w/chapel/chapel
	
Root-cause and fix:
The test script is trying to access a file structure that is not not accessible to the github.actor so the fix is to chown of the $PWD after the gitfiles are checked out.
