### PR TITLE
Updates for GASNet tests sensitive to #20891

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -2520,7 +2520,6 @@ expandForLoop(ForLoop* forLoop) {
       FnSymbol* iterFn = getTheIteratorFn(iterators.v[i]);
       if (iterFn->hasFlag(FLAG_YIELD_WITHIN_ON)) {
         USR_FATAL_CONT(forLoop, "'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)");
-        break;
       }
 
       // If we haven't yet generated a test to terminate the loop and

--- a/test/functions/iterators/multilocale/zipMultiLocSerIter.good
+++ b/test/functions/iterators/multilocale/zipMultiLocSerIter.good
@@ -1,2 +1,4 @@
 zipMultiLocSerIter.chpl:13: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)
+zipMultiLocSerIter.chpl:13: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)
+zipMultiLocSerIter.chpl:16: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)
 zipMultiLocSerIter.chpl:16: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)

--- a/test/functions/iterators/multilocale/zipMultiLocSerIter.no-local.good
+++ b/test/functions/iterators/multilocale/zipMultiLocSerIter.no-local.good
@@ -1,2 +1,4 @@
 zipMultiLocSerIter.chpl:13: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)
+zipMultiLocSerIter.chpl:13: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)
+zipMultiLocSerIter.chpl:16: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)
 zipMultiLocSerIter.chpl:16: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)

--- a/test/multilocale/deitz/needMultiLocales/raCommCheck.chpl
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheck.chpl
@@ -108,7 +108,7 @@ proc main() {
 
   var Diagnostics = getCommDiagnostics();
   writeln("Locale: (gets, puts, forks, fast forks, non-blocking forks)");
-  for (lid, diagnostics) in zip(1..,Diagnostics) do
+  for (diagnostics, lid) in zip(Diagnostics, 1..) do
     writeln(lid, ": ", diagnostics);
 
   const validAnswer = verifyResults();             // verify the updates


### PR DESCRIPTION
This fixes some failures in GASNet testing due to #20891.  The
first is that there are some CHPL_COMM!=none tests that used
a zip with an unbounded leader iterator which I'd missed due to
not doing GASNet testing.

The other two were cases where the code reorganization I did
in `lowerIterators.cpp` caused us to hit a point where we
tried to dereference the `testBlock`, which was NULL due to
having hit a `USR_FATAL_CONT()` and breaking out of the
loop that would have set it up.  Here, I removed the `break;`
to set it up as before.  This had the side effect of printing more
errors for one of our tests because it invoked two iterators with
a yield within an on.  If the zip() were to only contain a single
such iterator, just a single error would be printed.  Updated the
.good files to reflect the new behavior.