### PR TITLE
Bump the container used for CI testing to ubuntu 22.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
   make_check:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:dev
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -37,7 +37,7 @@ jobs:
   make_doc:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:dev
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -62,7 +62,7 @@ jobs:
   make_mason:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:dev
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -83,7 +83,7 @@ jobs:
   check_compiler_dyno_tests:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:dev
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -102,7 +102,7 @@ jobs:
   check_annotations_rt_calls:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:dev
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,9 +27,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
     - name: make check
       run: |
         ./util/buildRelease/smokeTest chpl
@@ -43,9 +40,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
     - name: make frontend-docs
       run: |
         make frontend-docs
@@ -68,12 +62,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
     - name: make mason
       # Use a quickstart config to keep it from running to long
       # While there, run a make check in that config for more coverage
@@ -89,9 +77,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
     - name: make test-dyno-with-asserts
       run: |
         make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
@@ -110,9 +95,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 100000
-    - name: Set ownership
+    - name: Check git version 
       run: |
-        chown -R $(id -u):$(id -g) $PWD   
+        git --version
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -46,11 +46,11 @@ jobs:
         with:
           file: ${{ env.DOCKERFILE }}
           # example: ghcr.io/chapel-lang/chapel-github-ci:latest
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:dev
       - name: Push Docker Image if on main
-        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+        if: github.repository_owner == 'chapel-lang'
         uses: docker/build-push-action@v3
         with:
           file: ${{ env.DOCKERFILE }}
           push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:dev

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -36,20 +36,20 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker Image
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@v3
         with:
           file: ${{ env.DOCKERFILE }}
           # example: ghcr.io/chapel-lang/chapel-github-ci:latest
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
       - name: Push Docker Image if on main
         if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@v3
         with:
           file: ${{ env.DOCKERFILE }}
           push: true

--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -2,26 +2,26 @@
 # tzdata is necessary for util/test/check_annotations.py to function properly (get the right dates)
 # locales is necessary for util/buildRelease/smokeTest docs
 
-# We use 22.04 to get llvm-13
-FROM ubuntu:22.04
+# We use 22.10 to get llvm-14
+FROM ubuntu:22.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     bash \
-    clang-13 \
+    clang-14 \
     cmake \
     cscope \
     doxygen \
     g++ \
     gcc \
     git \
-    libclang-13-dev \
-    libclang-cpp13-dev \
+    libclang-14-dev \
+    libclang-cpp14-dev \
     libedit-dev \
-    llvm-13 \
-    llvm-13-dev \
-    llvm-13-tools \
+    llvm-14 \
+    llvm-14-dev \
+    llvm-14-tools \
     locales \
     m4 \
     make \


### PR DESCRIPTION
This enables us to upgrade CI to clang/llvm 14 and bumps the git version to 2.37.2, which may help with Cray/chapel-private 3993