### PR TITLE
Followup for PR 20965

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,9 +27,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
     - name: make check
       run: |
         ./util/buildRelease/smokeTest chpl
@@ -42,10 +39,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
+    - uses: actions/checkout@v3 
     - name: make frontend-docs
       run: |
         make frontend-docs
@@ -68,12 +62,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
     - name: make mason
       # Use a quickstart config to keep it from running to long
       # While there, run a make check in that config for more coverage
@@ -89,9 +77,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set ownership
-      run: |
-        chown -R $(id -u):$(id -g) $PWD 
     - name: make test-dyno-with-asserts
       run: |
         make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`


### PR DESCRIPTION
Removed  chown added in this PR https://github.com/chapel-lang/chapel/pull/20965 for all the steps except for check_annotations_rt_calls.

Chown is only needed for this job because CheckTabs inside check_annotations_rt_calls is running a script(https://github.com/chapel-lang/chapel/blob/main/util/devel/lookForTabs ) that runs git commands which were failing for "Dubious owner".

Other jobs does not require this fix.

