### PR TITLE
Trigger bounded coforall optimization for broadcast in BlockDist scan

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1847,7 +1847,7 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
         }
 
         // Mark that scan values are ready
-        coforall (ready, elem) in zip(valIter(outputReady), valIter(elemPerLoc)) do on ready {
+        coforall (_, ready, elem) in zip(targetLocs.domain, valIter(outputReady), valIter(elemPerLoc)) do on ready {
           ready!.writeEF(elem);
         }
 


### PR DESCRIPTION
Bounded coforalls (coforalls with a known trip count) have optimized end count tracking, so when possible we want to use them. While doing some other work I noticed that #20100 unintentionally switched away from a bounded cofororall, so fix that here by adding a bounded leader.

I don't have access to the larger machine I tested #20100 on anymore, but on 256 non-homogeneous nodes of an XC I see a trivial scan go from 0.0028s to 0.0019s with this change.