### PR TITLE
Add a mechanism to disable comm diags for a specific task

### DIFF
--- a/modules/internal/ChapelTaskData.chpl
+++ b/modules/internal/ChapelTaskData.chpl
@@ -28,10 +28,12 @@ module ChapelTaskData {
   // up to 16 bytes of wide pointer for _remoteEndCountType
   // 1 byte for serial_state
   // 1 byte for nextCoStmtSerial
+  // 1 byte for commDiagsTemporarilyDisabled
   private const chpl_offset_endCount = 0:c_size_t;
   private const chpl_offset_serial = sizeof_endcount_ptr();
   private const chpl_offset_nextCoStmtSerial = chpl_offset_serial+1;
-  private const chpl_offset_end = chpl_offset_nextCoStmtSerial+1;
+  private const chpl_offset_commDiagsTemporarilyDisabled = chpl_offset_nextCoStmtSerial+1;
+  private const chpl_offset_end = chpl_offset_commDiagsTemporarilyDisabled+1;
 
   // What is the size of a wide _EndCount pointer?
   private
@@ -89,7 +91,6 @@ module ChapelTaskData {
     c_memcpy(c_ptrTo(prv[i]), c_ptrTo(v), c_sizeof(uint(8)));
   }
   proc chpl_task_data_getSerial(tls:c_ptr(chpl_task_infoChapel_t)) : bool {
-    var ret:bool = false;
     var prv = tls:c_ptr(c_uchar);
     var i = chpl_offset_serial;
     var v:uint(8) = 0;
@@ -113,9 +114,29 @@ module ChapelTaskData {
   }
 
   proc chpl_task_data_getNextCoStmtSerial(tls:c_ptr(chpl_task_infoChapel_t)) : bool {
-    var ret:bool = false;
     var prv = tls:c_ptr(c_uchar);
     var i = chpl_offset_nextCoStmtSerial;
+    var v:uint(8) = 0;
+    c_memcpy(c_ptrTo(v), c_ptrTo(prv[i]), c_sizeof(uint(8)));
+    if boundsChecking then
+      assert(v == 0 || v == 1);
+    return v == 1;
+  }
+
+  proc chpl_task_data_setCommDiagsTemporarilyDisabled(tls:c_ptr(chpl_task_infoChapel_t), disabled: bool) : bool {
+    var ret = chpl_task_data_getCommDiagsTemporarilyDisabled(tls);
+    var prv = tls:c_ptr(c_uchar);
+    var i = chpl_offset_commDiagsTemporarilyDisabled;
+    var v:uint(8) = 0;
+    if disabled then
+      v = 1;
+    c_memcpy(c_ptrTo(prv[i]), c_ptrTo(v), c_sizeof(uint(8)));
+    return ret;
+  }
+
+  proc chpl_task_data_getCommDiagsTemporarilyDisabled(tls:c_ptr(chpl_task_infoChapel_t)) : bool {
+    var prv = tls:c_ptr(c_uchar);
+    var i = chpl_offset_commDiagsTemporarilyDisabled;
     var v:uint(8) = 0;
     c_memcpy(c_ptrTo(v), c_ptrTo(prv[i]), c_sizeof(uint(8)));
     if boundsChecking then
@@ -140,6 +161,14 @@ module ChapelTaskData {
   }
   export proc chpl_task_getSerial() : bool {
     return chpl_task_data_getSerial(chpl_task_getInfoChapel());
+  }
+
+  export proc chpl_task_setCommDiagsTemporarilyDisabled(disabled: bool) : bool {
+    return chpl_task_data_setCommDiagsTemporarilyDisabled(chpl_task_getInfoChapel(), disabled);
+  }
+
+  export proc chpl_task_getCommDiagsTemporarilyDisabled() : bool {
+    return chpl_task_data_getCommDiagsTemporarilyDisabled(chpl_task_getInfoChapel());
   }
 
 

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -40,7 +40,6 @@ int chpl_verbose_comm_stacktrace = 0;
 int chpl_comm_diagnostics = 0;
 int chpl_comm_diags_print_unstable = 0;
 
-atomic_int_least16_t chpl_comm_diags_disable_flag;
 chpl_atomic_commDiagnostics chpl_comm_diags_counters;
 
 static pthread_once_t bcastPrintUnstable_once = PTHREAD_ONCE_INIT;
@@ -48,9 +47,9 @@ static pthread_once_t bcastPrintUnstable_once = PTHREAD_ONCE_INIT;
 
 static
 void broadcast_print_unstable(void) {
-  chpl_comm_diags_disable();
+  chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
   chpl_comm_bcast_rt_private(chpl_comm_diags_print_unstable);
-  chpl_comm_diags_enable();
+  (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
 
@@ -62,18 +61,18 @@ void chpl_comm_startVerbose(chpl_bool stacktrace, chpl_bool print_unstable) {
   }
 
   chpl_verbose_comm = 1;
-  chpl_comm_diags_disable();
+  chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
   chpl_comm_bcast_rt_private(chpl_verbose_comm);
   chpl_comm_bcast_rt_private(chpl_verbose_comm_stacktrace);
-  chpl_comm_diags_enable();
+  (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
 
 void chpl_comm_stopVerbose(void) {
   chpl_verbose_comm = 0;
-  chpl_comm_diags_disable();
+  chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
   chpl_comm_bcast_rt_private(chpl_verbose_comm);
-  chpl_comm_diags_enable();
+  (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
 
@@ -100,9 +99,9 @@ void chpl_comm_startDiagnostics(chpl_bool print_unstable) {
   chpl_rmem_consist_release(0, 0);
 
   chpl_comm_diagnostics = 1;
-  chpl_comm_diags_disable();
+  chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
   chpl_comm_bcast_rt_private(chpl_comm_diagnostics);
-  chpl_comm_diags_enable();
+  (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
 
@@ -111,9 +110,9 @@ void chpl_comm_stopDiagnostics(void) {
   chpl_rmem_consist_release(0, 0);
 
   chpl_comm_diagnostics = 0;
-  chpl_comm_diags_disable();
+  chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
   chpl_comm_bcast_rt_private(chpl_comm_diagnostics);
-  chpl_comm_diags_enable();
+  (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
 

--- a/runtime/src/chpl-gpu-diags.c
+++ b/runtime/src/chpl-gpu-diags.c
@@ -49,9 +49,7 @@ static pthread_once_t bcastPrintUnstable_once = PTHREAD_ONCE_INIT;
 
 static
 void broadcast_print_unstable(void) {
-  chpl_comm_diags_disable();
   chpl_comm_bcast_rt_private(chpl_gpu_diags_print_unstable);
-  chpl_comm_diags_enable();
 }
 
 
@@ -63,18 +61,14 @@ void chpl_gpu_startVerbose(chpl_bool stacktrace, chpl_bool print_unstable) {
   }
 
   chpl_verbose_gpu = 1;
-  chpl_comm_diags_disable();
   chpl_comm_bcast_rt_private(chpl_verbose_gpu);
   chpl_comm_bcast_rt_private(chpl_verbose_gpu_stacktrace);
-  chpl_comm_diags_enable();
 }
 
 
 void chpl_gpu_stopVerbose(void) {
   chpl_verbose_gpu = 0;
-  chpl_comm_diags_disable();
   chpl_comm_bcast_rt_private(chpl_verbose_gpu);
-  chpl_comm_diags_enable();
 }
 
 
@@ -101,9 +95,7 @@ void chpl_gpu_startDiagnostics(chpl_bool print_unstable) {
   chpl_rmem_consist_release(0, 0);
 
   chpl_gpu_diagnostics = 1;
-  chpl_comm_diags_disable();
   chpl_comm_bcast_rt_private(chpl_gpu_diagnostics);
-  chpl_comm_diags_enable();
 }
 
 
@@ -112,9 +104,7 @@ void chpl_gpu_stopDiagnostics(void) {
   chpl_rmem_consist_release(0, 0);
 
   chpl_gpu_diagnostics = 0;
-  chpl_comm_diags_disable();
   chpl_comm_bcast_rt_private(chpl_gpu_diagnostics);
-  chpl_comm_diags_enable();
 }
 
 


### PR DESCRIPTION
Previously, comm diagnostics could only be disabled at a locale granularity, but there are some cases where we just want to disable comm for a specific function call for the current task. This adds a mechanism that uses task-locale-storage to temporarily disable comms for the current task and replaces the previous locale-wide disabling code.

This is motivated by some upcoming work to not track communication from end counts, but was useful for replacing an existing mechanism so I wanted to split it into a separate PR.

Note that I removed the comm diags disabling from chapel-gpu-diags since that isn't broadcasting code to enable/disable diags so I don't think it's required and we don't disable for similar broadcasting in memory diagnostics code. If we decide we should disable when broadcasting everywhere we could do that directly in `chpl_comm_bcast_rt_private`.

In the future it may also be interesting to consider enabling comm diags for a specific task only as there have been times I just want to track only some comm from a locale. I didn't do that here in part because I wasn't ready to do the API design, but also because that would require getting TLS for every comm diag call and that has a non-zero cost.