### PR TITLE
Revert "Merge pull request #20880 from arezaii/chpldoc-install-fix"

### DIFF
--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -241,7 +241,8 @@ if [ ! -z "$PREFIX" ]
 then
   myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$PREFIX/bin"
 else
-  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"
+  tmp_bin_dir="bin/$CHPL_BIN_SUBDIR"
+  myinstallfile "$tmp_bin_dir"/chpl "$DEST_DIR/$tmp_bin_dir"
 fi
 
 # copy runtime lib
@@ -346,24 +347,15 @@ then
   fi
 fi
 
-# create symlink for chpldoc-legacy
 if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc" ]
 then
-  # Choose destination depending on installation mode {prefix, home}
+  # create a symbolic link for chpldoc
   if [ ! -z "$PREFIX" ]
   then
-    (cd "$PREFIX/bin" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)
+    (cd "$PREFIX/bin" && rm -f chpldoc && ln -s chpl chpldoc)
   else
-    (cd "$DEST_DIR/bin/$CHPL_BIN_SUBDIR" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)
+    (cd "$DEST_DIR/bin/$CHPL_BIN_SUBDIR" && rm -f chpldoc && ln -s chpl chpldoc)
   fi
-fi
-
-# copy chpldoc
-if [ ! -z "$PREFIX" ]
-then
-  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$PREFIX/bin"
-else
-  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"
 fi
 
 # copy chplconfig


### PR DESCRIPTION
This reverts a fix for installing `chpldoc` that exposed a shortcoming in
`chpldoc` where it doesn't do a search for possible `CHPL_HOME` values if
`CHPL_HOME` is not detected in the environment or passed using the `--home` 
option.

Once the fixes have been made for `chpldoc`, we will un-revert this revert.

This reverts commit 85c7720ea56ea8762d4b4b4718c89214427ab2b2, reversing 
changes made to 86393aed5d972fa50e737c5807a2b9471fc8fffc.

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>