### PR TITLE
Address regressions due to zip() changes last night

### DIFF
--- a/test/deprecated/zipUnbounded.skipif
+++ b/test/deprecated/zipUnbounded.skipif
@@ -1,0 +1,2 @@
+COMPOPTS <= --fast
+COMPOPTS <= --no-checks

--- a/test/types/range/unbounded/test_indefinite1.skipif
+++ b/test/types/range/unbounded/test_indefinite1.skipif
@@ -1,0 +1,2 @@
+COMPOPTS <= --fast
+COMPOPTS <= --no-checks

--- a/test/types/range/unbounded/zipMismatch-case3-fast.good
+++ b/test/types/range/unbounded/zipMismatch-case3-fast.good
@@ -1,0 +1,9 @@
+zipMismatch.chpl:4: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
+zipMismatch.chpl:8: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
+zipMismatch.chpl:12: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
+(250, 1)
+(251, 2)
+(252, 3)
+(253, 4)
+(254, 5)
+zipMismatch.chpl:12: error: halt reached - Loop over unbounded range surpassed representable values

--- a/test/types/range/unbounded/zipMismatch.execopts
+++ b/test/types/range/unbounded/zipMismatch.execopts
@@ -3,8 +3,11 @@
 import os
 
 print('--case 1')
-if '--baseline' in os.getenv('COMPOPTS'):
+if '--baseline' in os.getenv('COMPOPTS') or '--fast' in os.getenv('COMPOPTS'):
    print('--case 2  # zipMismatch-case2-baseline.good')
 else:
    print('--case 2  # zipMismatch-case2.good')
-print('--case 3  # zipMismatch-case3.good')
+if '--fast' in os.getenv('COMPOPTS'):
+   print('--case 3  # zipMismatch-case3-fast.good')
+else:
+   print('--case 3  # zipMismatch-case3.good')

--- a/test/users/npadmana/mpi/test_mpi.chpl
+++ b/test/users/npadmana/mpi/test_mpi.chpl
@@ -263,7 +263,7 @@ proc test_structure() {
 
   var a : [0.. #10] Particle;
   if worldRank==0 {
-    for (i1, p1) in zip(0.. , a) {
+    for (p1, i1) in zip(a, 0..) {
       p1.x = i1;
       p1.y = -i1;
       p1.z = i1;


### PR DESCRIPTION
A few configurations that I did not test turned up some new failures,
addressed here:
* tests that zip unbounded ranges with bounded work differently
  when compiled with `--fast`/`--no-checks` than by default
  because we don't do the end-of-range check for the bounded
  range, so end up spinning until timeout.  Added .skipif files to
  zipUnbounded.chpl and test_indefinite.chpl for this reason
* similarly for zipMismatch.chpl, but since this test already had
  a complex .execopts script to show the behavior in various
  settings, it was more amenable to updating to show the change
  in behavior for `--fast` test configurations
* test_mpi.chpl had a zip that was led by an unbounded range
  which I missed since it's skipped in most configurations.
