### PR TITLE
Correct Protobuff tests following WritersReturnBool removal

### DIFF
--- a/test/functions/vass/declaredGenericReturnTuple.bad
+++ b/test/functions/vass/declaredGenericReturnTuple.bad
@@ -1,14 +1,14 @@
 declaredGenericReturnTuple.chpl:11: In function 'p2':
 declaredGenericReturnTuple.chpl:11: error: cannot initialize return value of type '1*VectorListElement' from a '1*VectorListElement(int(64))'
-$CHPL_HOME/modules/standard/ChapelIO.chpl:584: In method '_readWriteHelper':
-$CHPL_HOME/modules/standard/ChapelIO.chpl:624: error: cannot default-initialize a variable with generic type
-$CHPL_HOME/modules/standard/ChapelIO.chpl:624: note: '<temporary>' has generic type 'VectorListElement'
-$CHPL_HOME/modules/standard/ChapelIO.chpl:624: note: cannot find initialization point to split-init this variable
-$CHPL_HOME/modules/standard/ChapelIO.chpl:624: note: '<temporary>' is used here before it is initialized
-  $CHPL_HOME/modules/standard/ChapelIO.chpl:579: called as 1*VectorListElement._readWriteHelper(f: fileWriter(dynamic,false)) from method 'writeThis'
-  $CHPL_HOME/modules/standard/IO.chpl:3917: called as 1*VectorListElement.writeThis(f: fileWriter(dynamic,false)) from function '_write_one_internal'
-  $CHPL_HOME/modules/standard/IO.chpl:3727: called as _write_one_internal(_channel_internal: qio_channel_ptr_t, param kind = 0: iokind, x: 1*VectorListElement, loc: locale) from method '_writeOne'
-  $CHPL_HOME/modules/standard/IO.chpl:5320: called as (fileWriter(dynamic,true))._writeOne(param kind = 0: iokind, x: 1*VectorListElement, loc: locale) from method '_write'
-  $CHPL_HOME/modules/standard/IO.chpl:5407: called as (fileWriter(dynamic,true))._write(args(0): 1*VectorListElement, args(1): ioNewline) from method '_writeln'
-  $CHPL_HOME/modules/standard/ChapelIO.chpl:719: called as (fileWriter(dynamic,true))._writeln(args(0): 1*VectorListElement) from function 'writeln'
+$CHPL_HOME/modules/standard/ChapelIO.chpl:583: In method '_readWriteHelper':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:623: error: cannot default-initialize a variable with generic type
+$CHPL_HOME/modules/standard/ChapelIO.chpl:623: note: '<temporary>' has generic type 'VectorListElement'
+$CHPL_HOME/modules/standard/ChapelIO.chpl:623: note: cannot find initialization point to split-init this variable
+$CHPL_HOME/modules/standard/ChapelIO.chpl:623: note: '<temporary>' is used here before it is initialized
+  $CHPL_HOME/modules/standard/ChapelIO.chpl:578: called as 1*VectorListElement._readWriteHelper(f: fileWriter(dynamic,false)) from method 'writeThis'
+  $CHPL_HOME/modules/standard/IO.chpl:3919: called as 1*VectorListElement.writeThis(f: fileWriter(dynamic,false)) from function '_write_one_internal'
+  $CHPL_HOME/modules/standard/IO.chpl:3729: called as _write_one_internal(_channel_internal: qio_channel_ptr_t, param kind = 0: iokind, x: 1*VectorListElement, loc: locale) from method '_writeOne'
+  $CHPL_HOME/modules/standard/IO.chpl:5420: called as (fileWriter(dynamic,true))._writeOne(param kind = 0: iokind, x: 1*VectorListElement, loc: locale) from method 'write'
+  $CHPL_HOME/modules/standard/IO.chpl:5471: called as (fileWriter(dynamic,true)).write(args(0): 1*VectorListElement, args(1): ioNewline) from method 'writeln'
+  $CHPL_HOME/modules/standard/ChapelIO.chpl:718: called as (fileWriter(dynamic,true)).writeln(args(0): 1*VectorListElement) from function 'writeln'
   declaredGenericReturnTuple.chpl:12: called as writeln(args(0): 1*VectorListElement)

--- a/test/library/packages/ProtobufProtocolSupport/endToEndRunnerUtils.chpl
+++ b/test/library/packages/ProtobufProtocolSupport/endToEndRunnerUtils.chpl
@@ -17,11 +17,11 @@ proc endToEndTest(package: string) {
   shell2.wait();
 
   if debug then writeln("Writing and reading from Chapel");
-  shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl -sWritersReturnBool=false");
+  shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl");
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./write -nl 1");
   shell2.wait();
-  shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl -sWritersReturnBool=false");
+  shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl");
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=pipeStyle.pipe);
   while shell2.stdout.readLine(line1) {
@@ -30,7 +30,7 @@ proc endToEndTest(package: string) {
   shell2.wait(); 
 
   if debug then writeln("Writing from Chapel and reading from Python");
-  shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl -sWritersReturnBool=false");
+  shell2 = spawnshell("chpl -o "+packageDir+"/write "+packageDir+"/write.chpl");
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./write -nl 1");
   shell2.wait();
@@ -43,7 +43,7 @@ proc endToEndTest(package: string) {
   if debug then writeln("Writing from Python and reading from Chapel");
   shell2 = spawnshell("python3 "+packageDir+"/write.py");
   shell2.wait();
-  shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl -sWritersReturnBool=false");
+  shell2 = spawnshell("chpl -o "+packageDir+"/read "+packageDir+"/read.chpl");
   shell2.wait();
   shell2 = spawnshell(packageDir+"/./read -nl 1", stdout=pipeStyle.pipe);
   while shell2.stdout.readLine(line1) {


### PR DESCRIPTION
#20960, caused the following test failures:
```
[Error matching program output for library/packages/ProtobufProtocolSupport/anyRunner]
[Error matching program output for library/packages/ProtobufProtocolSupport/enumsRunner]
[Error matching program output for library/packages/ProtobufProtocolSupport/mapsRunner]
[Error matching program output for library/packages/ProtobufProtocolSupport/messagefieldRunner]
[Error matching program output for library/packages/ProtobufProtocolSupport/oneofsRunner]
[Error matching program output for library/packages/ProtobufProtocolSupport/repeatedfieldRunner]
[Error matching program output for library/packages/ProtobufProtocolSupport/typesRunner]
```
Due to the use of the `-sWritersReturnBool=false` flag in some internal calls to the chapel compiler.

This PR removes the uses of the flag from those tests.

Also fixes `[Error matching .bad file for functions/vass/declaredGenericReturnTuple]`. The prediff script to obfuscate line #'s was not being invoked on `comp.out` for some reason, so I just update the line #s in the `.bad` file.