### PR TITLE
Fix minimal modules fallout from 20973

### DIFF
--- a/modules/minimal/internal/ChapelTaskData.chpl
+++ b/modules/minimal/internal/ChapelTaskData.chpl
@@ -18,14 +18,14 @@
  * limitations under the License.
  */
 
-// ChapelStandard.chpl
+// ChapelTaskData.chpl
 //
-pragma "export init"
-module ChapelStandard {
-  public use ChapelLocale;
-  public use ChapelTaskData;
-  public use ChapelTaskTable;
-  public use MemTracking;
-  public use ChapelUtil;
-  public use IO;
+module ChapelTaskData {
+  export proc chpl_task_setCommDiagsTemporarilyDisabled(disabled: bool) : bool {
+    return false;
+  }
+
+  export proc chpl_task_getCommDiagsTemporarilyDisabled() : bool {
+    return false;
+  }
 }

--- a/test/trivial/diten/printvisibleOptFalse.good
+++ b/test/trivial/diten/printvisibleOptFalse.good
@@ -5,6 +5,8 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/ChapelLocale.chpl:53: chpl_taskRunningCntInc
   modules/minimal/internal/ChapelLocale.chpl:58: chpl_taskRunningCntDec
   modules/minimal/internal/ChapelLocale.chpl:62: chpl_taskRunningCntReset
+  modules/minimal/internal/ChapelTaskData.chpl:24: chpl_task_setCommDiagsTemporarilyDisabled
+  modules/minimal/internal/ChapelTaskData.chpl:28: chpl_task_getCommDiagsTemporarilyDisabled
   modules/minimal/internal/ChapelTaskTable.chpl:26: chpldev_taskTable_init
   modules/minimal/internal/ChapelTaskTable.chpl:29: chpldev_taskTable_add
   modules/minimal/internal/ChapelTaskTable.chpl:36: chpldev_taskTable_remove


### PR DESCRIPTION
A new exported function that's used in the runtime was added in #20973, but I missed adding a dummy stub for minimal modules. Add that here.