### PR TITLE
Further fix for nightly Arkouda + GPU testing (filter out HDF5MultiDim)

### DIFF
--- a/util/cron/test-cray-xc-gpu-arkouda.bash
+++ b/util/cron/test-cray-xc-gpu-arkouda.bash
@@ -34,7 +34,7 @@ source $CWD/common-arkouda.bash
 
 # List of Arkouda server modules we exempt from testing (that goal is to
 # eventually have this be an empty list).
-export CHPL_TEST_ARKOUDA_DISABLE_MODULES=In1dMsg:HDF5Msg:HDF5Msg_LEGACY
+export CHPL_TEST_ARKOUDA_DISABLE_MODULES=In1dMsg:HDF5Msg:HDF5Msg_LEGACY:HDF5MultiDim
 export CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD="true"
 
 module list


### PR DESCRIPTION
My previous PR didn't fully fix it: https://github.com/chapel-lang/chapel/pull/20959

It looks like HDF5MultiDim is temporarily including HDF5 (which we need to filter out) so we also need to filter out HDF5MultiDim in the mean time:

https://github.com/Bears-R-Us/arkouda/blob/fc187718709a059f8e2a5353a7a1e3db15a22132/src/HDF5MultiDim.chpl#L6

I've tested things manually this time (and it resolves it). Apologies for the noise.