### PR TITLE
dyno: implement copy elision

### DIFF
--- a/frontend/include/chpl/resolution/copy-elision.h
+++ b/frontend/include/chpl/resolution/copy-elision.h
@@ -34,7 +34,8 @@ namespace resolution {
 std::set<ID>
 computeElidedCopies(Context* context,
                     const uast::AstNode* symbol,
-                    const ResolutionResultByPostorderID& byPostorder);
+                    const ResolutionResultByPostorderID& byPostorder,
+                    const std::set<ID>& allSplitInitedVars);
 
 
 } // end namespace resolution

--- a/frontend/include/chpl/resolution/copy-elision.h
+++ b/frontend/include/chpl/resolution/copy-elision.h
@@ -29,8 +29,21 @@ namespace chpl {
 namespace resolution {
 
 
-/* Computes the set of IDs of init-exprs that are 'move's rather
-   than '=' or 'copy-init' now. */
+/* Computes the set of IDs of initialization points
+   that can be 'move's rather than '=' or 'copy-init'.
+     * If the elided initialization point is a variable initialization expr,
+       the ID of the initialized variable is stored in the set.
+     * If the elided initialization point is an '=' call,
+       the ID of the OpCall is stored in the set.
+     * If the elided initialization point is an actual passed by 'in' intent,
+       the ID of the actual is stored in the set.
+   Does not consider copy elision that only work with temporary
+   variables (e.g. acceptsWithIn(returnsByValue())).
+
+   This is not a query. It may raise errors within the currently running query.
+
+   allSplitInitedVars can be computed by computeSplitInits.
+ */
 std::set<ID>
 computeElidedCopies(Context* context,
                     const uast::AstNode* symbol,

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -558,6 +558,7 @@ void Context::collectGarbage() {
 }
 
 void Context::report(const ErrorBase* error) {
+  gdbShouldBreakHere();
   if (queryStack.size() > 0) {
     queryStack.back()->errors.push_back(std::move(error));
     reportError(this, queryStack.back()->errors.back());

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -162,6 +162,15 @@ bool VarScopeVisitor::handleSplitInitOut(const FnCall* ast,
   return inserted;
 }
 
+bool VarScopeVisitor::handleDeclarationInit(const VarLikeDecl* ast, RV& rv) {
+  VarFrame* frame = currentFrame();
+  bool inserted = false;
+  if (ast->initExpression() != nullptr) {
+    inserted = frame->addToInitedVars(ast->id());
+  }
+  return inserted;
+}
+
 void VarScopeVisitor::enterScope(const AstNode* ast) {
   if (createsScope(ast->tag())) {
     scopeStack.push_back(toOwned(new VarFrame(ast)));

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -119,7 +119,7 @@ ID VarScopeVisitor::refersToId(const AstNode* ast, RV& rv) {
   return toId;
 }
 
-void VarScopeVisitor::handleMentions(const AstNode* ast, RV& rv) {
+void VarScopeVisitor::processMentions(const AstNode* ast, RV& rv) {
   // This could be its own ResolvedVisitor if it needs to handle
   // more complex forms. For now, this simple implementation should suffice
   // for expressions used as actuals etc.
@@ -130,15 +130,15 @@ void VarScopeVisitor::handleMentions(const AstNode* ast, RV& rv) {
     }
   } else {
     for (auto child : ast->children()) {
-      handleMentions(child, rv);
+      processMentions(child, rv);
     }
   }
 }
 
 bool
-VarScopeVisitor::handleSplitInitAssign(const OpCall* ast,
-                                       const std::set<ID>& allSplitInitedVars,
-                                       RV& rv) {
+VarScopeVisitor::processSplitInitAssign(const OpCall* ast,
+                                        const std::set<ID>& allSplitInitedVars,
+                                        RV& rv) {
   bool inserted = false;
   VarFrame* frame = currentFrame();
   auto lhsAst = ast->actual(0);
@@ -149,10 +149,11 @@ VarScopeVisitor::handleSplitInitAssign(const OpCall* ast,
   return inserted;
 }
 
-bool VarScopeVisitor::handleSplitInitOut(const FnCall* ast,
-                                         const AstNode* actual,
-                                         const std::set<ID>& allSplitInitedVars,
-                                         RV& rv) {
+bool
+VarScopeVisitor::processSplitInitOut(const FnCall* ast,
+                                     const AstNode* actual,
+                                     const std::set<ID>& allSplitInitedVars,
+                                     RV& rv) {
   bool inserted = false;
   VarFrame* frame = currentFrame();
   ID actualVarId = refersToId(actual, rv);
@@ -162,7 +163,7 @@ bool VarScopeVisitor::handleSplitInitOut(const FnCall* ast,
   return inserted;
 }
 
-bool VarScopeVisitor::handleDeclarationInit(const VarLikeDecl* ast, RV& rv) {
+bool VarScopeVisitor::processDeclarationInit(const VarLikeDecl* ast, RV& rv) {
   VarFrame* frame = currentFrame();
   bool inserted = false;
   if (ast->initExpression() != nullptr) {

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -45,11 +45,11 @@ bool VarFrame::addToInitedVars(ID varId) {
 
 void
 VarScopeVisitor::process(const uast::AstNode* symbol,
-                         const ResolutionResultByPostorderID& byPostorder) {
-  ResolvedVisitor<VarScopeVisitor> rv(context,
-                                      symbol,
-                                      *this,
-                                      byPostorder);
+                         ResolutionResultByPostorderID& byPostorder) {
+  MutatingResolvedVisitor<VarScopeVisitor> rv(context,
+                                              symbol,
+                                              *this,
+                                              byPostorder);
 
   // Traverse formals and then the body. This is done here rather
   // than in enter(Function) because nested functions will have
@@ -135,6 +135,33 @@ void VarScopeVisitor::handleMentions(const AstNode* ast, RV& rv) {
   }
 }
 
+bool
+VarScopeVisitor::handleSplitInitAssign(const OpCall* ast,
+                                       const std::set<ID>& allSplitInitedVars,
+                                       RV& rv) {
+  bool inserted = false;
+  VarFrame* frame = currentFrame();
+  auto lhsAst = ast->actual(0);
+  ID lhsVarId = refersToId(lhsAst, rv);
+  if (!lhsVarId.isEmpty() && allSplitInitedVars.count(lhsVarId) > 0) {
+    inserted = frame->addToInitedVars(lhsVarId);
+  }
+  return inserted;
+}
+
+bool VarScopeVisitor::handleSplitInitOut(const FnCall* ast,
+                                         const AstNode* actual,
+                                         const std::set<ID>& allSplitInitedVars,
+                                         RV& rv) {
+  bool inserted = false;
+  VarFrame* frame = currentFrame();
+  ID actualVarId = refersToId(actual, rv);
+  if (!actualVarId.isEmpty() && allSplitInitedVars.count(actualVarId) > 0) {
+    inserted = frame->addToInitedVars(actualVarId);
+  }
+  return inserted;
+}
+
 void VarScopeVisitor::enterScope(const AstNode* ast) {
   if (createsScope(ast->tag())) {
     scopeStack.push_back(toOwned(new VarFrame(ast)));
@@ -179,10 +206,49 @@ void VarScopeVisitor::exitScope(const AstNode* ast) {
              parentFrame->scopeAst->isTry());
     } else if (auto cond = ast->toConditional()) {
       handleConditional(cond);
+      if (parentFrame != nullptr) {
+        // if both branches return or throw, update the parent frame.
+        VarFrame* thenFrame = currentThenFrame();
+        VarFrame* elseFrame = currentElseFrame();
+        if (thenFrame && elseFrame &&
+            thenFrame->returnsOrThrows && elseFrame->returnsOrThrows) {
+          parentFrame->returnsOrThrows = true;
+        }
+      }
     } else if (auto t = ast->toTry()) {
       handleTry(t);
+      // if the try returns/throws
+      // and any catch clauses also return/throws, update the parent frame
+      if (parentFrame != nullptr) {
+        VarFrame* tryFrame = currentFrame();
+        if (tryFrame->returnsOrThrows) {
+          int nCatchFrames = currentNumCatchFrames();
+          bool allCatchReturnThrow = true;
+          for (int i = 0; i < nCatchFrames; i++) {
+            VarFrame* catchFrame = currentCatchFrame(i);
+            if (!catchFrame->returnsOrThrows) {
+              allCatchReturnThrow = false;
+              break;
+            }
+          }
+          if (allCatchReturnThrow) {
+            parentFrame->returnsOrThrows = true;
+          }
+        }
+      }
     } else {
       handleScope(ast);
+      // update the parent frame with the returns/throws status
+      if (parentFrame != nullptr) {
+        if (!ast->isLoop()) {
+          // don't propagate return/throw out of a loop,
+          // because it could be loop { break; return; } e.g.
+          VarFrame* frame = currentFrame();
+          if (frame->returnsOrThrows) {
+            parentFrame->returnsOrThrows = true;
+          }
+        }
+      }
     }
     scopeStack.pop_back();
   }
@@ -207,22 +273,13 @@ void VarScopeVisitor::exit(const VarLikeDecl* ast, RV& rv) {
 bool VarScopeVisitor::enter(const OpCall* ast, RV& rv) {
 
   if (ast->op() == USTR("=")) {
-    // What is the RHS and LHS of the '=' call?
-    auto lhsAst = ast->actual(0);
+    // What is the RHS of the '=' call?
     auto rhsAst = ast->actual(1);
 
     // visit the RHS first
     rhsAst->traverse(rv);
 
-    // now consider the LHS
-    ID toId = rv.byAst(lhsAst).toId();
-
-    if (!toId.isEmpty()) {
-      handleVarAssign(ast, toId, rv);
-    } else {
-      // visit the LHS to check for mentions
-      lhsAst->traverse(rv);
-    }
+    handleAssign(ast, rv);
   }
 
   return false;
@@ -322,7 +379,8 @@ bool VarScopeVisitor::enter(const Return* ast, RV& rv) {
 void VarScopeVisitor::exit(const Return* ast, RV& rv) {
   if (!scopeStack.empty()) {
     VarFrame* frame = scopeStack.back().get();
-    frame->returns = true;
+    frame->returnsOrThrows = true;
+    handleReturnOrThrow(ast, rv);
   }
 }
 
@@ -333,7 +391,8 @@ bool VarScopeVisitor::enter(const Throw* ast, RV& rv) {
 void VarScopeVisitor::exit(const Throw* ast, RV& rv) {
   if (!scopeStack.empty()) {
     VarFrame* frame = scopeStack.back().get();
-    frame->throws = true;
+    frame->returnsOrThrows = true;
+    handleReturnOrThrow(ast, rv);
   }
 }
 

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -166,6 +166,9 @@ class VarScopeVisitor {
                           const std::set<ID>& allSplitInitedVars,
                           RV& rv);
 
+  /** Handle updating initedVars for a declaration with an initExpression. */
+  bool handleDeclarationInit(const VarLikeDecl* ast, RV& rv);
+
  public:
   // ----- visitor implementation
   void enterScope(const uast::AstNode* ast);

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -151,23 +151,23 @@ class VarScopeVisitor {
 
   /** Call handleMention for any Identifiers contained in this ast node.
       Only appropriate for expressions (not for Loops) */
-  void handleMentions(const AstNode* ast, RV& rv);
+  void processMentions(const AstNode* ast, RV& rv);
 
-  /** Handle updating initedVars if an assignment represents a split-init.
+  /** Update initedVars if an assignment represents a split-init.
       Returns true if it was a split init. */
-  bool handleSplitInitAssign(const OpCall* ast,
-                             const std::set<ID>& allSplitInitedVars,
-                             RV& rv);
+  bool processSplitInitAssign(const OpCall* ast,
+                              const std::set<ID>& allSplitInitedVars,
+                              RV& rv);
 
-  /** Handle updating initedVars if a call with at 'out' formal
+  /** Update initedVars if a call with at 'out' formal
       represents a split-init. Returns true if it was a split init. */
-  bool handleSplitInitOut(const FnCall* ast,
-                          const AstNode* actual,
-                          const std::set<ID>& allSplitInitedVars,
-                          RV& rv);
+  bool processSplitInitOut(const FnCall* ast,
+                           const AstNode* actual,
+                           const std::set<ID>& allSplitInitedVars,
+                           RV& rv);
 
-  /** Handle updating initedVars for a declaration with an initExpression. */
-  bool handleDeclarationInit(const VarLikeDecl* ast, RV& rv);
+  /** Update initedVars for a declaration with an initExpression. */
+  bool processDeclarationInit(const VarLikeDecl* ast, RV& rv);
 
  public:
   // ----- visitor implementation

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -54,7 +54,7 @@ struct ControlFlowSubBlock;
     the interface covers whatever these analyses need. */
 class VarScopeVisitor {
  protected:
-  using RV = ResolvedVisitor<VarScopeVisitor>;
+  using RV = MutatingResolvedVisitor<VarScopeVisitor>;
 
   // ----- inputs to the process
   Context* context = nullptr;
@@ -70,8 +70,8 @@ class VarScopeVisitor {
   virtual void handleDeclaration(const uast::VarLikeDecl* ast, RV& rv) = 0;
   /** Called for an Identifier not used in one of the below cases */
   virtual void handleMention(const uast::Identifier* ast, ID varId, RV& rv) = 0;
-  /** Called for Identifier = <expr> assignment pattern */
-  virtual void handleVarAssign(const uast::OpCall* ast, ID varId, RV& rv) = 0;
+  /** Called for <expr> = <expr> assignment pattern */
+  virtual void handleAssign(const uast::OpCall* ast, RV& rv) = 0;
   /** Called for an actual passed to an 'out' formal */
   virtual void handleOutFormal(const uast::FnCall* ast,
                                const uast::AstNode* actual,
@@ -86,7 +86,10 @@ class VarScopeVisitor {
                                  const uast::AstNode* actual,
                                  const types::QualifiedType& formalType,
                                  RV& rv) = 0;
- 
+
+  /** Called for an unconditional return or throw */
+  virtual void handleReturnOrThrow(const uast::AstNode* ast, RV& rv) = 0;
+
   /** Called to process a Conditional after handling its contents --
       should update currentFrame() which is the frame for the Conditional.
       The then/else frames are sitting in currentFrame().subBlocks. */
@@ -107,7 +110,7 @@ class VarScopeVisitor {
 
  public:
   void process(const uast::AstNode* symbol,
-               const ResolutionResultByPostorderID& byPostorder);
+               ResolutionResultByPostorderID& byPostorder);
 
  protected:
 
@@ -116,6 +119,16 @@ class VarScopeVisitor {
   VarFrame* currentFrame() {
     assert(!scopeStack.empty());
     return scopeStack.back().get();
+  }
+
+  /** Return the parent frame or nullptr if there is none. */
+  VarFrame* currentParentFrame() {
+    VarFrame* parent = nullptr;
+    size_t n = scopeStack.size();
+    if (n >= 2) {
+      parent = scopeStack[n-2].get();
+    }
+    return parent;
   }
 
   /** Assuming that the current frame refers to a Conditional,
@@ -139,6 +152,19 @@ class VarScopeVisitor {
   /** Call handleMention for any Identifiers contained in this ast node.
       Only appropriate for expressions (not for Loops) */
   void handleMentions(const AstNode* ast, RV& rv);
+
+  /** Handle updating initedVars if an assignment represents a split-init.
+      Returns true if it was a split init. */
+  bool handleSplitInitAssign(const OpCall* ast,
+                             const std::set<ID>& allSplitInitedVars,
+                             RV& rv);
+
+  /** Handle updating initedVars if a call with at 'out' formal
+      represents a split-init. Returns true if it was a split init. */
+  bool handleSplitInitOut(const FnCall* ast,
+                          const AstNode* actual,
+                          const std::set<ID>& allSplitInitedVars,
+                          RV& rv);
 
  public:
   // ----- visitor implementation
@@ -175,6 +201,12 @@ struct ControlFlowSubBlock {
   ControlFlowSubBlock(const AstNode* block) : block(block) { }
 };
 
+/** Per-variable state used by the copy elision implementation */
+struct CopyElisionState {
+  bool lastIsCopy = false; // is the last mention (so far) a copy?
+  std::set<ID> points; // uAST IDs of the potentially elided copies?
+};
+
 /** Collects information about a variable declaration frame / scope.
     Note that some of the fields here will only be used by a single subclass.
     Keeping them declared here keeps things simple. */
@@ -190,11 +222,8 @@ struct VarFrame {
   // This includes both locally declared and outer variables.
   std::set<ID> initedVars;
 
-  // has the block already encountered a return?
-  bool returns = false;
-
-  // has the block already encountered a throw?
-  bool throws = false;
+  // has the block already encountered a return or a throw?
+  bool returnsOrThrows = false;
 
   // When processing a conditional or catch blocks,
   // instead of popping the SplitInitFrame for the then/else/catch blocks,
@@ -204,15 +233,35 @@ struct VarFrame {
 
   // ----- variables declared here for use in particular subclasses
 
-  // for split init:
-
+  // for split init and copy elision:
   // which variables are declared here in a way that allows split init?
   std::set<ID> eligibleVars;
+
+  // for split init:
   // same as initedVars but preserves order & saves types
   std::vector<std::pair<ID, types::QualifiedType>> initedVarsVec;
   // Which variables are mentioned in this scope before
   // being initialized, throwing or returning?
   std::set<ID> mentionedVars;
+
+  // for copy elision:
+  // Is the last mention of the variable a copy?
+  // What are the copy points?
+  std::map<ID,CopyElisionState> copyElisionState;
+
+  // for call init deinit:
+  // localsAndDefers contains both VarSymbol and DeferStmt in
+  // order to create a single stack for cleanup operations to be executed.
+  // In particular, the ordering between defer blocks and locals matters,
+  // in addition to the ordering within each group.
+  std::vector<const AstNode*> localsAndDefers;
+
+  // Which outer variables have been initialized in this scope?
+  // This vector lists them in initialization order.
+  std::vector<ID> initedOuterVars;
+
+  // Which variables have been deinitialized early in this scope?
+  std::set<ID> deinitedVars;
 
   VarFrame(const AstNode* scopeAst) : scopeAst(scopeAst) { }
 

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -117,7 +117,7 @@ void CallInitDeinit::printActions(const std::vector<Action>& actions) {
 }*/
 
 void CallInitDeinit::handleDeclaration(const VarLikeDecl* ast, RV& rv) {
-  // TODO
+  handleDeclarationInit(ast, rv);
 }
 void CallInitDeinit::handleMention(const Identifier* ast, ID varId, RV& rv) {
   // TODO

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -117,7 +117,7 @@ void CallInitDeinit::printActions(const std::vector<Action>& actions) {
 }*/
 
 void CallInitDeinit::handleDeclaration(const VarLikeDecl* ast, RV& rv) {
-  handleDeclarationInit(ast, rv);
+  processDeclarationInit(ast, rv);
 }
 void CallInitDeinit::handleMention(const Identifier* ast, ID varId, RV& rv) {
   // TODO
@@ -137,7 +137,7 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
   bool resolveInitAssign = false;
 
   // update initedVars if it is initializing a variable
-  bool splitInited = handleSplitInitAssign(ast, splitInitedVars, rv);
+  bool splitInited = processSplitInitAssign(ast, splitInitedVars, rv);
 
   if (lhsType.isType() || lhsType.isParam()) {
     // these are basically 'move' initialization
@@ -206,7 +206,7 @@ void CallInitDeinit::handleOutFormal(const FnCall* ast,
                                      const QualifiedType& formalType,
                                      RV& rv) {
   // update initedVars if it is initializing a variable
-  handleSplitInitOut(ast, actual, splitInitedVars, rv);
+  processSplitInitOut(ast, actual, splitInitedVars, rv);
 }
 void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
                                       const QualifiedType& formalType,

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -19,12 +19,12 @@
 
 #include "chpl/resolution/copy-elision.h"
 
-#include "Resolver.h"
-
 #include "chpl/resolution/ResolvedVisitor.h"
 #include "chpl/resolution/resolution-types.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/uast/all-uast.h"
+
+#include "VarScopeVisitor.h"
 
 namespace chpl {
 namespace resolution {
@@ -33,171 +33,422 @@ namespace resolution {
 using namespace uast;
 using namespace types;
 
-struct FindElidedCopies {
-  using RV = ResolvedVisitor<FindElidedCopies>;
-
-  // inputs to the process
-  Context* context = nullptr;
+struct FindElidedCopies : VarScopeVisitor {
+  // inputs
+  const std::set<ID>& allSplitInitedVars;
 
   // result of the process
-  std::set<ID> elidedCopyFromIds;
+  std::set<ID> allElidedCopyFromIds;
 
-  // internal variables
+  // methods
+  FindElidedCopies(Context* context, const std::set<ID>& allSplitInitedVars)
+    : VarScopeVisitor(context), allSplitInitedVars(allSplitInitedVars) { }
 
-  // main entry point to this code
-  static void process(Resolver& resolver, std::set<ID>& elidedCopyFromIds);
+  static bool copyElisionAllowedForTypes(const QualifiedType& lhsType,
+                                         const QualifiedType& rhsType);
+  static bool lastMentionIsCopy(VarFrame* frame, ID varId);
+  static void gatherLastMentionIsCopyVars(VarFrame* frame, std::set<ID>& vars);
+  static void addDeclaration(VarFrame* frame, const VarLikeDecl* ast);
+  static void addCopyInit(VarFrame* frame, ID fromVarId, ID point);
+  static void addMention(VarFrame* frame, ID varId);
 
-  FindElidedCopies(Context* context);
+  // save the copy-elided variables in frame to allElidedCopyFromIds
+  void saveElidedCopies(VarFrame* frame);
+  // save the copy-elided local variables in frame to allElidedCopyFromIds
+  void saveLocalVarElidedCopies(VarFrame* frame);
 
-  void handleMention(ID dstId);
-  void handleInitOrAssign(ID dstId);
-  void enterScope(const uast::AstNode* ast);
-  void exitScope(const uast::AstNode* ast);
+  bool isEligibleVarInAnyFrame(ID varId);
 
-  bool enter(const VarLikeDecl* ast, RV& rv);
-  void exit(const VarLikeDecl* ast, RV& rv);
+  // overrides
+  void handleDeclaration(const VarLikeDecl* ast, RV& rv) override;
+  void handleMention(const Identifier* ast, ID varId, RV& rv) override;
+  void handleAssign(const OpCall* ast, RV& rv) override;
+  void handleOutFormal(const FnCall* ast, const AstNode* actual,
+                       const QualifiedType& formalType,
+                       RV& rv) override;
+  void handleInFormal(const FnCall* ast, const AstNode* actual,
+                      const QualifiedType& formalType,
+                      RV& rv) override;
+  void handleInoutFormal(const FnCall* ast, const AstNode* actual,
+                         const QualifiedType& formalType,
+                         RV& rv) override;
 
-  bool enter(const OpCall* ast, RV& rv);
-  void exit(const OpCall* ast, RV& rv);
-
-  bool enter(const FnCall* ast, RV& rv);
-  void exit(const FnCall* ast, RV& rv);
-
-  bool enter(const Identifier* ast, RV& rv);
-  void exit(const Identifier* ast, RV& rv);
-
-  bool enter(const uast::AstNode* node, RV& rv);
-  void exit(const uast::AstNode* node, RV& rv);
+  void handleReturnOrThrow(const uast::AstNode* ast, RV& rv) override;
+  void handleConditional(const Conditional* cond) override;
+  void handleTry(const Try* t) override;
+  void handleScope(const AstNode* ast) override;
 };
 
-FindElidedCopies::FindElidedCopies(Context* context)
-  : context(context)
-{
+static bool kindAllowsCopyElision(IntentList kind) {
+  return (kind == IntentList::VAR ||
+          kind == IntentList::CONST_VAR ||
+          kind == IntentList::IN ||
+          kind == IntentList::CONST_IN ||
+          kind == IntentList::OUT ||
+          kind == IntentList::INOUT);
 }
 
-void FindElidedCopies::handleMention(ID dstId) {
-  // TODO
-}
-
-void FindElidedCopies::handleInitOrAssign(ID dstId) {
-  // TODO
-}
-
-void FindElidedCopies::enterScope(const AstNode* ast) {
-  // TODO
-}
-
-void FindElidedCopies::exitScope(const AstNode* ast) {
-  // TODO
-}
-
-bool FindElidedCopies::enter(const VarLikeDecl* ast, RV& rv) {
-
-  enterScope(ast);
-
-  return true;
-}
-void FindElidedCopies::exit(const VarLikeDecl* ast, RV& rv) {
-  // TODO -- consider init= becoming a move
-
-  exitScope(ast);
-}
-
-bool FindElidedCopies::enter(const OpCall* ast, RV& rv) {
-
-  if (ast->op() == USTR("=")) {
-    // What is the RHS and LHS of the '=' call?
-    auto lhsAst = ast->actual(0);
-    auto rhsAst = ast->actual(1);
-
-    // visit the RHS first
-    rhsAst->traverse(rv);
-
-    // now consider the LHS
-    ID toId;
-    if (rv.hasAst(lhsAst)) {
-      toId = rv.byAst(lhsAst).toId();
-    }
-
-    if (!toId.isEmpty()) {
-      handleInitOrAssign(toId);
-    } else {
-      // visit the LHS to check for mentions
-      lhsAst->traverse(rv);
+bool
+FindElidedCopies::copyElisionAllowedForTypes(const QualifiedType& lhsType,
+                                             const QualifiedType& rhsType) {
+  if (kindAllowsCopyElision(lhsType.kind()) &&
+      kindAllowsCopyElision(rhsType.kind())) {
+    if (lhsType.type() == rhsType.type()) {
+      return true;
     }
   }
 
   return false;
 }
 
-void FindElidedCopies::exit(const OpCall* ast, RV& rv) {
+bool FindElidedCopies::lastMentionIsCopy(VarFrame* frame, ID varId) {
+  auto it = frame->copyElisionState.find(varId);
+  if (it != frame->copyElisionState.end()) {
+    const CopyElisionState& state = it->second;
+    return state.lastIsCopy;
+  }
+
+  return false;
+}
+void FindElidedCopies::gatherLastMentionIsCopyVars(VarFrame* frame,
+                                                   std::set<ID>& vars) {
+  for (auto pair : frame->copyElisionState) {
+    if (pair.second.lastIsCopy) {
+      vars.insert(pair.first);
+    }
+  }
 }
 
-bool FindElidedCopies::enter(const FnCall* callAst, RV& rv) {
+void FindElidedCopies::addDeclaration(VarFrame* frame, const VarLikeDecl* ast) {
+  bool inserted = frame->addToDeclaredVars(ast->id());
+  if (inserted) {
+    auto kind = ast->storageKind();
+    if (kindAllowsCopyElision(kind)) {
+      frame->eligibleVars.insert(ast->id());
+    }
+  }
+}
 
-  // TODO: consider 'in' and 'out' formals
+// caller should guarantee types are OK and fromVarId is eligible
+// in this frame or a parent frame.
+void FindElidedCopies::addCopyInit(VarFrame* frame, ID fromVarId, ID point) {
+  // get the map entry, default-initializing it if there was none
+  CopyElisionState& state = frame->copyElisionState[fromVarId];
+  state.lastIsCopy = true;
+  state.points.clear();
+  state.points.insert(point);
+}
+void FindElidedCopies::addMention(VarFrame* frame, ID varId) {
+  auto it = frame->copyElisionState.find(varId);
+  if (it != frame->copyElisionState.end()) {
+    CopyElisionState& state = it->second;
+    state.lastIsCopy = false;
+    state.points.clear();
+  }
+}
+
+void FindElidedCopies::saveElidedCopies(VarFrame* frame) {
+  for (auto pair : frame->copyElisionState) {
+    const CopyElisionState& state = pair.second;
+    if (state.lastIsCopy) {
+      allElidedCopyFromIds.insert(state.points.begin(), state.points.end());
+    }
+  }
+}
+
+void FindElidedCopies::saveLocalVarElidedCopies(VarFrame* frame) {
+  for (auto id : frame->eligibleVars) {
+    assert(frame->declaredVars.count(id) > 0);
+    if (lastMentionIsCopy(frame, id)) {
+      const CopyElisionState& state = frame->copyElisionState[id];
+      allElidedCopyFromIds.insert(state.points.begin(), state.points.end());
+    }
+  }
+}
+
+bool FindElidedCopies::isEligibleVarInAnyFrame(ID varId) {
+  if (scopeStack.empty()) return false;
+
+  for (ssize_t i = scopeStack.size() - 1; i >= 0; i--) {
+    VarFrame* frame = scopeStack[i].get();
+    if (frame->eligibleVars.count(varId) > 0) {
+      return true;
+    }
+  }
 
   return false;
 }
 
-void FindElidedCopies::exit(const FnCall* ast, RV& rv) {
+void FindElidedCopies::handleDeclaration(const VarLikeDecl* ast, RV& rv) {
+  addDeclaration(currentFrame(), ast);
+}
+void FindElidedCopies::handleMention(const Identifier* ast, ID varId, RV& rv) {
+  VarFrame* frame = currentFrame();
+  addMention(frame, varId);
+}
+void FindElidedCopies::handleAssign(const OpCall* ast, RV& rv) {
+  auto lhsAst = ast->actual(0);
+  auto rhsAst = ast->actual(1);
+  bool splitInit = handleSplitInitAssign(ast, allSplitInitedVars, rv);
+  if (splitInit) {
+    VarFrame* frame = currentFrame();
+
+    // if it was inserted in the current frame, it was a split init,
+    // so the RHS here could be a copy & might be elided
+    ID lhsVarId = refersToId(lhsAst, rv);
+    ID rhsVarId = refersToId(rhsAst, rv);
+    if (!rhsVarId.isEmpty() && isEligibleVarInAnyFrame(rhsVarId)) {
+      // check that the types are the same
+      if (rv.hasId(lhsVarId) && rv.hasId(rhsVarId)) {
+        QualifiedType lhsType = rv.byId(lhsVarId).type();
+        QualifiedType rhsType = rv.byId(rhsVarId).type();
+        if (copyElisionAllowedForTypes(lhsType, rhsType)) {
+          addCopyInit(frame, rhsVarId, ast->id());
+        }
+      }
+    }
+  } else {
+    handleMentions(lhsAst, rv);
+  }
+}
+void FindElidedCopies::handleOutFormal(const FnCall* ast,
+                                       const AstNode* actual,
+                                       const QualifiedType& formalType,
+                                       RV& rv) {
+  // 'out' can't be the RHS for an elided copy
+  handleMentions(actual, rv);
+
+  // updated initedVars for split init
+  handleSplitInitOut(ast, actual, allSplitInitedVars, rv);
+}
+void FindElidedCopies::handleInFormal(const FnCall* ast, const AstNode* actual,
+                                      const QualifiedType& formalType,
+                                      RV& rv) {
+  // 'in' formal can be copied from another variable, and that
+  // copy might need to be elided
+  VarFrame* frame = currentFrame();
+  ID actualToId = refersToId(actual, rv);
+  if (!actualToId.isEmpty() && isEligibleVarInAnyFrame(actualToId)) {
+    // check that the types are the same
+    if (rv.hasId(actualToId)) {
+      QualifiedType actualType = rv.byId(actualToId).type();
+      if (copyElisionAllowedForTypes(formalType, actualType)) {
+        addCopyInit(frame, actualToId, ast->id());
+      }
+    }
+  }
+}
+void FindElidedCopies::handleInoutFormal(const FnCall* ast,
+                                         const AstNode* actual,
+                                         const QualifiedType& formalType,
+                                         RV& rv) {
+  // 'inout' can't be the RHS for an elided copy
+  handleMentions(actual, rv);
 }
 
-
-bool FindElidedCopies::enter(const Identifier* ast, RV& rv) {
-  return true;
-}
-void FindElidedCopies::exit(const Identifier* ast, RV& rv) {
-  // TODO: handle mentions
+void FindElidedCopies::handleReturnOrThrow(const uast::AstNode* ast, RV& rv) {
+  VarFrame* frame = currentFrame();
+  saveElidedCopies(frame);
 }
 
+void FindElidedCopies::handleConditional(const Conditional* cond) {
+  VarFrame* frame = currentFrame();
+  VarFrame* thenFrame = currentThenFrame();
+  VarFrame* elseFrame = currentElseFrame();
 
-bool FindElidedCopies::enter(const AstNode* ast, RV& rv) {
-  enterScope(ast);
+  bool thenReturnsThrows = thenFrame->returnsOrThrows;
+  bool elseReturnsThrows = false;
+  if (elseFrame != nullptr) {
+    elseReturnsThrows = elseFrame->returnsOrThrows;
+  }
 
-  return true;
+  // don't copy elide
+  //  * when the copy statement is in one branch of a conditional but not in
+  //    the other
+  //  * when the other branch does not always return or throw.
+
+  if (thenReturnsThrows && elseReturnsThrows) {
+    // if both blocks return, their copy elisions have already been saved
+  } else if (elseFrame == nullptr && thenReturnsThrows) {
+    // then returns, no else block, so then copy elisions
+    // have already been saved and nothing else to do
+  } else if (elseFrame == nullptr && !thenReturnsThrows) {
+    // then does not return, no else block.
+    // allow copy elision only for local variables
+    // outer variables aren't eligible because they wouldn't
+    // aways be copy elided.
+    saveLocalVarElidedCopies(thenFrame);
+  } else if (!thenReturnsThrows && !elseReturnsThrows) {
+    // Both then and else blocks exist.
+    // Neither if nor else block returns. Promote elision points from
+    // each block into the parent copy elision map. If a variable is
+    // declared in a higher scope and is not copied in both blocks, then
+    // we cannot promote it. The elision points for local variables from
+    // each block can be promoted freely.
+
+    // First, save local variables from each block.
+    saveLocalVarElidedCopies(thenFrame);
+    saveLocalVarElidedCopies(elseFrame);
+
+    // promote only vars that can be copy elided in both branches
+    for (auto thenPair : thenFrame->copyElisionState) {
+      const CopyElisionState& thenState = thenPair.second;
+      if (thenState.lastIsCopy) {
+        ID id = thenPair.first;
+        if (lastMentionIsCopy(elseFrame, id)) {
+          const CopyElisionState& elseState = elseFrame->copyElisionState[id];
+          if (elseState.lastIsCopy) {
+            CopyElisionState& s = frame->copyElisionState[id];
+            s.lastIsCopy = true;
+            s.points.insert(thenState.points.begin(), thenState.points.end());
+            s.points.insert(elseState.points.begin(), elseState.points.end());
+          }
+        }
+      }
+    }
+  } else {
+    // Both then and else exist, but one block returned and the
+    // other did not. Promote all elision points for the block that
+    // didn't return into the parent map.
+    // (those from the block that returned have already been saved)
+    VarFrame* branch = thenReturnsThrows ? elseFrame : thenFrame;
+
+    // First, save local variables from the block
+    saveLocalVarElidedCopies(branch);
+
+    // promote other vars in the branch not returning
+    for (auto pair : branch->copyElisionState) {
+      const CopyElisionState& branchState = pair.second;
+      if (branchState.lastIsCopy) {
+        ID id = pair.first;
+        // only consider variables that aren't local to the branch
+        if (branch->eligibleVars.count(id) == 0) {
+          CopyElisionState& s = frame->copyElisionState[id];
+          s.lastIsCopy = true;
+          s.points.insert(branchState.points.begin(), branchState.points.end());
+        }
+      }
+    }
+  }
+
+  // propagate inited variables from the then/else scopes
+  frame->initedVars.insert(thenFrame->initedVars.begin(),
+                           thenFrame->initedVars.end());
+  if (elseFrame) {
+    frame->initedVars.insert(elseFrame->initedVars.begin(),
+                             elseFrame->initedVars.end());
+  }
+
+  // now that the current frame is updated, propagate to the parent
+  handleScope(cond);
 }
-void FindElidedCopies::exit(const AstNode* ast, RV& rv) {
-  exitScope(ast);
+
+void FindElidedCopies::handleTry(const Try* t) {
+
+  VarFrame* tryFrame = currentFrame();
+
+  int nCatchFrames = currentNumCatchFrames();
+  // if there are no catch clauses, treat it like any other scope
+  if (nCatchFrames == 0) {
+    // will handle variables local to the try
+    handleScope(t);
+    return;
+  }
+
+  // otherwise, consider the catch clauses
+
+  // don't copy elide:
+  // when the copy statement is in a try or try! which
+  //  * has catch clauses that mention the variable
+  //  * has catch clauses that do not always throw or return
+
+  // don't copy elide if any catch clauses mention the variable
+  // don't copy elide if any catch clause doesn't throw/return
+  std::map<ID,CopyElisionState> updatedState;
+  std::set<ID> catchMentions;
+  bool allThrowOrReturn = true;
+
+  for (int i = 0; i < nCatchFrames; i++) {
+    VarFrame* catchFrame = currentCatchFrame(i);
+    if (!catchFrame->returnsOrThrows) {
+      allThrowOrReturn = false;
+    }
+    for (auto pair : catchFrame->copyElisionState) {
+      catchMentions.insert(pair.first);
+    }
+  }
+
+  if (allThrowOrReturn) {
+    for (auto pair : tryFrame->copyElisionState) {
+      const CopyElisionState& tryState = pair.second;
+      if (tryState.lastIsCopy) {
+        ID id = pair.first;
+        // do any catch clauses mention the variable,
+        // including in a way we thought could be copy elided?
+        if (catchMentions.count(id) == 0) {
+          CopyElisionState& s = updatedState[id];
+          s.lastIsCopy = true;
+          s.points.insert(tryState.points.begin(), tryState.points.end());
+        }
+      }
+    }
+  }
+
+  tryFrame->copyElisionState.swap(updatedState);
+
+  handleScope(t);
+}
+
+static bool allowsCopyElision(const AstNode* ast) {
+  return ast->isBlock() ||
+         ast->isConditional() ||
+         ast->isLocal() ||
+         ast->isSerial() ||
+         ast->isTry();
+}
+
+void FindElidedCopies::handleScope(const AstNode* ast) {
+  VarFrame* frame = currentFrame();
+  VarFrame* parent = currentParentFrame();
+
+  // handle any local variables
+  saveLocalVarElidedCopies(frame);
+
+  if (parent != nullptr) {
+    // propagate any non-local variables
+    if (allowsCopyElision(ast) && parent != nullptr) {
+      for (auto pair : frame->copyElisionState) {
+        ID id = pair.first;
+        const CopyElisionState& state = pair.second;
+        if (state.lastIsCopy && frame->eligibleVars.count(id) == 0) {
+          CopyElisionState& parentState = parent->copyElisionState[id];
+          parentState.lastIsCopy = true;
+          parentState.points.insert(state.points.begin(), state.points.end());
+        }
+      }
+    }
+
+    // propagate inited vars
+    parent->initedVars.insert(frame->initedVars.begin(),
+                              frame->initedVars.end());
+  }
 }
 
 std::set<ID>
 computeElidedCopies(Context* context,
                     const uast::AstNode* symbol,
-                    const ResolutionResultByPostorderID& byPostorder) {
+                    const ResolutionResultByPostorderID& byPostorder,
+                    const std::set<ID>& allSplitInitedVars) {
   std::set<ID> elidedCopyFromIds;
-  FindElidedCopies uv(context);
+  FindElidedCopies uv(context, allSplitInitedVars);
 
-  ResolvedVisitor<FindElidedCopies> rv(context,
-                                       symbol,
-                                       uv,
-                                       byPostorder);
-
-  // Traverse formals and then the body. This is done here rather
-  // than in enter(Function) because nested functions will have
-  // computeElidedCopies called on them separately.
-  if (auto fn = symbol->toFunction()) {
-    // traverse formals and then traverse the body
-    if (auto body = fn->body()) {
-      // make a pretend scope for the formals
-      uv.enterScope(body);
-
-      // traverse the formals
-      for (auto formal : fn->formals()) {
-        formal->traverse(rv);
-      }
-
-      // traverse the real body
-      body->traverse(rv);
-
-      uv.exitScope(body);
-    }
-  } else {
-    symbol->traverse(rv);
-  }
+  uv.process(symbol,
+             // cast here allows VarScopeVisitor to be simple
+             // by always using the mutating visitor
+             const_cast<ResolutionResultByPostorderID&>(byPostorder));
 
   // swap the result into place
-  elidedCopyFromIds.swap(uv.elidedCopyFromIds);
+  elidedCopyFromIds.swap(uv.allElidedCopyFromIds);
 
   return elidedCopyFromIds;
 }

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -181,7 +181,7 @@ bool FindElidedCopies::isEligibleVarInAnyFrame(ID varId) {
 
 void FindElidedCopies::handleDeclaration(const VarLikeDecl* ast, RV& rv) {
   addDeclaration(currentFrame(), ast);
-  handleDeclarationInit(ast, rv);
+  processDeclarationInit(ast, rv);
 
   if (auto initExpr = ast->initExpression()) {
     VarFrame* frame = currentFrame();
@@ -206,7 +206,7 @@ void FindElidedCopies::handleMention(const Identifier* ast, ID varId, RV& rv) {
 void FindElidedCopies::handleAssign(const OpCall* ast, RV& rv) {
   auto lhsAst = ast->actual(0);
   auto rhsAst = ast->actual(1);
-  bool splitInit = handleSplitInitAssign(ast, allSplitInitedVars, rv);
+  bool splitInit = processSplitInitAssign(ast, allSplitInitedVars, rv);
   if (splitInit) {
     VarFrame* frame = currentFrame();
 
@@ -225,7 +225,7 @@ void FindElidedCopies::handleAssign(const OpCall* ast, RV& rv) {
       }
     }
   } else {
-    handleMentions(lhsAst, rv);
+    processMentions(lhsAst, rv);
   }
 }
 void FindElidedCopies::handleOutFormal(const FnCall* ast,
@@ -233,10 +233,10 @@ void FindElidedCopies::handleOutFormal(const FnCall* ast,
                                        const QualifiedType& formalType,
                                        RV& rv) {
   // 'out' can't be the RHS for an elided copy
-  handleMentions(actual, rv);
+  processMentions(actual, rv);
 
   // updated initedVars for split init
-  handleSplitInitOut(ast, actual, allSplitInitedVars, rv);
+  processSplitInitOut(ast, actual, allSplitInitedVars, rv);
 }
 void FindElidedCopies::handleInFormal(const FnCall* ast, const AstNode* actual,
                                       const QualifiedType& formalType,
@@ -259,7 +259,7 @@ void FindElidedCopies::handleInFormal(const FnCall* ast, const AstNode* actual,
   if (elide) {
     addCopyInit(frame, actualToId, actual->id());
   } else {
-    handleMentions(actual, rv);
+    processMentions(actual, rv);
   }
 }
 void FindElidedCopies::handleInoutFormal(const FnCall* ast,
@@ -267,7 +267,7 @@ void FindElidedCopies::handleInoutFormal(const FnCall* ast,
                                          const QualifiedType& formalType,
                                          RV& rv) {
   // 'inout' can't be the RHS for an elided copy
-  handleMentions(actual, rv);
+  processMentions(actual, rv);
 }
 
 void FindElidedCopies::handleReturnOrThrow(const uast::AstNode* ast, RV& rv) {

--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -187,20 +187,20 @@ void FindSplitInits::handleOutFormal(const FnCall* ast, const AstNode* actual,
     handleInitOrAssign(toId, formalType, rv);
   } else {
     // gather any mentions used in the actual
-    handleMentions(actual, rv);
+    processMentions(actual, rv);
   }
 }
 
 void FindSplitInits::handleInFormal(const FnCall* ast, const AstNode* actual,
                                     const QualifiedType& formalType,
                                     RV& rv) {
-  handleMentions(actual, rv);
+  processMentions(actual, rv);
 }
 
 void FindSplitInits::handleInoutFormal(const FnCall* ast, const AstNode* actual,
                                        const QualifiedType& formalType,
                                        RV& rv) {
-  handleMentions(actual, rv);
+  processMentions(actual, rv);
 }
 
 void FindSplitInits::handleReturnOrThrow(const uast::AstNode* ast, RV& rv) {

--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -24,7 +24,6 @@
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/uast/all-uast.h"
 
-#include "Resolver.h"
 #include "VarScopeVisitor.h"
 
 namespace chpl {
@@ -52,7 +51,7 @@ struct FindSplitInits : VarScopeVisitor {
   // overrides
   void handleDeclaration(const VarLikeDecl* ast, RV& rv) override;
   void handleMention(const Identifier* ast, ID varId, RV& rv) override;
-  void handleVarAssign(const OpCall* ast, ID varId, RV& rv) override;
+  void handleAssign(const OpCall* ast, RV& rv) override;
   void handleOutFormal(const FnCall* ast, const AstNode* actual,
                        const QualifiedType& formalType,
                        RV& rv) override;
@@ -62,6 +61,8 @@ struct FindSplitInits : VarScopeVisitor {
   void handleInoutFormal(const FnCall* ast, const AstNode* actual,
                          const QualifiedType& formalType,
                          RV& rv) override;
+
+  void handleReturnOrThrow(const uast::AstNode* ast, RV& rv) override;
   void handleConditional(const Conditional* cond) override;
   void handleTry(const Try* t) override;
   void handleScope(const AstNode* ast) override;
@@ -81,7 +82,7 @@ SplitInitVarStatus FindSplitInits::findVarStatus(ID varId) {
 
   for (ssize_t i = scopeStack.size() - 1; i >= 0; i--) {
     VarFrame* frame = scopeStack[i].get();
-    if (frame->returns || frame->throws) {
+    if (frame->returnsOrThrows) {
       status.foundReturnsThrows = true;
     }
     if (frame->initedVars.count(varId) > 0) {
@@ -164,12 +165,19 @@ void FindSplitInits::handleMention(const Identifier* ast, ID varId, RV& rv) {
   }
 }
 
-void FindSplitInits::handleVarAssign(const OpCall* ast, ID varId, RV& rv) {
-  // get the type for the rhs
+void FindSplitInits::handleAssign(const OpCall* ast, RV& rv) {
+  auto lhsAst = ast->actual(0);
   auto rhsAst = ast->actual(1);
-  QualifiedType rhsType = rv.byAst(rhsAst).type();
 
-  handleInitOrAssign(varId, rhsType, rv);
+  ID lhsVarId = refersToId(lhsAst, rv);
+  if (!lhsVarId.isEmpty()) {
+    // get the type for the rhs
+    QualifiedType rhsType = rv.byAst(rhsAst).type();
+    handleInitOrAssign(lhsVarId, rhsType, rv);
+  } else {
+    // visit the LHS to check for mentions
+    lhsAst->traverse(rv);
+  }
 }
 
 void FindSplitInits::handleOutFormal(const FnCall* ast, const AstNode* actual,
@@ -193,6 +201,10 @@ void FindSplitInits::handleInoutFormal(const FnCall* ast, const AstNode* actual,
                                        const QualifiedType& formalType,
                                        RV& rv) {
   handleMentions(actual, rv);
+}
+
+void FindSplitInits::handleReturnOrThrow(const uast::AstNode* ast, RV& rv) {
+  // no action needed
 }
 
 // updates the back frame with the combined result from
@@ -224,16 +236,10 @@ void FindSplitInits::handleConditional(const Conditional* cond) {
     }
   }
 
-  bool thenReturns = thenFrame->returns;
-  bool thenThrows = thenFrame->throws;
-  bool thenReturnsThrows = thenReturns || thenThrows;
-  bool elseReturns = false;
-  bool elseThrows = false;
+  bool thenReturnsThrows = thenFrame->returnsOrThrows;
   bool elseReturnsThrows = false;
   if (elseFrame != nullptr) {
-    elseReturns = elseFrame->returns;
-    elseThrows = elseFrame->throws;
-    elseReturnsThrows = elseReturns || elseThrows;
+    elseReturnsThrows = elseFrame->returnsOrThrows;
   }
 
   std::set<ID> locSplitInitedVars;
@@ -389,7 +395,7 @@ void FindSplitInits::handleTry(const Try* t) {
   bool allThrowOrReturn = true;
   for (int i = 0; i < nCatchFrames; i++) {
     VarFrame* catchFrame = currentCatchFrame(i);
-    if (!catchFrame->returns && !catchFrame->throws) {
+    if (!catchFrame->returnsOrThrows) {
       allThrowOrReturn = false;
     }
   }
@@ -467,12 +473,8 @@ static bool allowsSplitInit(const AstNode* ast) {
 }
 
 void FindSplitInits::handleScope(const AstNode* ast) {
-  size_t n = scopeStack.size();
   VarFrame* frame = currentFrame();
-  VarFrame* parent = nullptr;
-  if (n >= 2) {
-    parent = scopeStack[n-2].get();
-  }
+  VarFrame* parent = currentParentFrame();
 
   if (allowsSplitInit(ast)) {
     // a scope that allows split init (e.g. a regular { } block)
@@ -497,9 +499,6 @@ void FindSplitInits::handleScope(const AstNode* ast) {
           parent->mentionedVars.insert(id);
         }
       }
-      // propagate return/throw-ness
-      parent->returns |= frame->returns;
-      parent->throws |= frame->throws;
     }
   } else {
     // some kind of scope that does not allow split init
@@ -528,7 +527,10 @@ computeSplitInits(Context* context,
   std::set<ID> splitInitedVars;
   FindSplitInits uv(context);
 
-  uv.process(symbol, byPostorder);
+  uv.process(symbol,
+             // cast here allows VarScopeVisitor to be simple
+             // by always using the mutating visitor
+             const_cast<ResolutionResultByPostorderID&>(byPostorder));
 
   splitInitedVars.swap(uv.allSplitInitedVars);
   return splitInitedVars;

--- a/frontend/test/resolution/CMakeLists.txt
+++ b/frontend/test/resolution/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 comp_unit_test(testCanPass)
 comp_unit_test(testClasses)
+comp_unit_test(testCopyElision)
 comp_unit_test(testDisambiguation)
 comp_unit_test(testEnums)
 comp_unit_test(testErrorGuard)

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -1,0 +1,596 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test-resolution.h"
+
+#include "chpl/parsing/parsing-queries.h"
+#include "chpl/resolution/copy-elision.h"
+#include "chpl/resolution/resolution-queries.h"
+#include "chpl/resolution/scope-queries.h"
+#include "chpl/resolution/split-init.h"
+#include "chpl/uast/Call.h"
+#include "chpl/uast/Comment.h"
+#include "chpl/uast/Identifier.h"
+#include "chpl/uast/Module.h"
+#include "chpl/uast/Variable.h"
+
+#include "./ErrorGuard.h"
+
+static const bool ERRORS_EXPECTED=true;
+
+// resolves the last function, or module if testModule=true
+// checks that the copy elision points match the string IDs provided
+static void testCopyElision(const char* test,
+                            const char* program,
+                            std::vector<const char*> expectedPoints,
+                            bool testModule=false,
+                            bool expectErrors=false) {
+  printf("%s\n", test);
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string testname = test;
+  testname += ".chpl";
+  auto path = UniqueString::get(context, testname);
+  std::string contents = program;
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+  assert(vec.size() == 1);
+  const Module* M = vec[0]->toModule();
+  assert(M);
+  assert(M->numStmts() >= 1);
+
+  const Function* func = M->stmt(M->numStmts()-1)->toFunction();
+
+  std::set<ID> splitIds;
+  std::set<ID> elisionPoints;
+
+  if (testModule == false) {
+    assert(func);
+    printf("Resolving function %s\n", func->name().c_str());
+    const ResolvedFunction* r = resolveConcreteFunction(context, func->id());
+    assert(r);
+
+    splitIds = computeSplitInits(context, func, r->resolutionById());
+
+    elisionPoints = computeElidedCopies(context, func,
+                                        r->resolutionById(),
+                                        splitIds);
+  } else {
+    printf("Resolving module\n");
+    // check the module init function
+    const ResolutionResultByPostorderID& rr = resolveModule(context, M->id());
+
+    splitIds = computeSplitInits(context, M, rr);
+
+    elisionPoints = computeElidedCopies(context, M,
+                                        rr,
+                                        splitIds);
+  }
+
+  std::set<std::string> pointNames;
+  for (auto id : elisionPoints) {
+    pointNames.insert(id.str());
+  }
+
+  std::set<std::string> expectNames;
+  for (auto cstr : expectedPoints) {
+    expectNames.insert(std::string(cstr));
+  }
+
+  // check that each thing in expectNames is in splitNames
+  for (auto expectName : expectNames) {
+    if (pointNames.count(expectName) == 0) {
+      printf("%s: missing expected point for '%s'\n",
+             test, expectName.c_str());
+    }
+  }
+
+  // check that each thing in splitNames is in expectNames
+  for (auto pointName : pointNames) {
+    if (expectNames.count(pointName) == 0) {
+      printf("%s: found unexpected point for '%s'\n", test, pointName.c_str());
+    }
+  }
+
+  assert(expectNames == pointNames);
+
+  size_t errCount = guard.realizeErrors();
+  if (expectErrors) {
+    assert(errCount > 0);
+  } else {
+    assert(errCount == 0);
+  }
+}
+
+static void test1() {
+  testCopyElision("test1",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int = 0;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test2() {
+  testCopyElision("test2",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x;
+          x = 1;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test3() {
+  testCopyElision("test3",
+    R""""(
+      module M {
+        proc test() {
+          var x:int;
+          var y = x;
+        }
+      }
+    )"""",
+    {"M.test@3"});
+}
+
+
+static void test4() {
+  testCopyElision("test4",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          var y = x;
+          x;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test5() {
+  testCopyElision("test5",
+    R""""(
+      module M {
+        proc test(cond: bool) {
+          var x:int;
+          if cond {
+            var y = x;
+            return;
+          }
+          x;
+        }
+      }
+    )"""",
+    {"M.test@6"});
+}
+
+static void test6() {
+  testCopyElision("test6",
+    R""""(
+      module M {
+        proc test(cond: bool) {
+          var x:int;
+          var y;
+          if cond {
+            y = x;
+          } else {
+            y = x;
+          }
+        }
+      }
+    )"""",
+    {"M.test@8", "M.test@12"});
+}
+
+static void test7() {
+  testCopyElision("test7",
+    R""""(
+      module M {
+        proc test() {
+          var i: int;
+          ref r = i;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test8() {
+  testCopyElision("test8",
+    R""""(
+      module M {
+        proc test() {
+          var i: int;
+          ref r = i;
+          ref rr = r;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test9() {
+  testCopyElision("test9",
+    R""""(
+      module M {
+        proc fIn(arg: int) { }
+        proc test() {
+          var x:int;
+          fIn(x);
+        }
+      }
+    )"""",
+    {"M.test@3"});
+}
+
+static void test10() {
+  testCopyElision("test10",
+    R""""(
+      module M {
+        proc fIn(arg: int) { }
+        proc test() {
+          var x:int;
+          fIn(x);
+          x;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test11() {
+  testCopyElision("test11",
+    R""""(
+      module M {
+        proc test() {
+          var x:int;
+          var y;
+          y = x;
+        }
+      }
+    )"""",
+    {"M.test@5"});
+}
+
+static void test12() {
+  testCopyElision("test12",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          var y;
+          y = x;
+          y = x;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test13() {
+  testCopyElision("test13",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test(cond: bool) {
+          var x:int;
+          if cond {
+            var y = x;
+          }
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test14() {
+  testCopyElision("test14",
+    R""""(
+      module M {
+        proc test(cond: bool) {
+          var x:int;
+          var y;
+          if cond {
+            return;
+          } else {
+            y = x;
+          }
+        }
+      }
+    )"""",
+    {"M.test@10"});
+}
+
+static void test15() {
+  testCopyElision("test15",
+    R""""(
+      module M {
+        proc test(cond: bool) {
+          var x:int;
+          var y;
+          if cond {
+            y = x;
+          } else {
+            return;
+          }
+        }
+      }
+    )"""",
+    {"M.test@8"});
+}
+
+static void test16() {
+  testCopyElision("test16",
+    R""""(
+      module M {
+        proc test() {
+          var x:int;
+          try {
+            var y = x;
+          }
+        }
+      }
+    )"""",
+    {"M.test@3"});
+}
+
+static void test17() {
+  testCopyElision("test17",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          var y;
+          try {
+            y = x;
+          } catch {
+          }
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test18() {
+  testCopyElision("test18",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          var y;
+          try {
+            y = x;
+          } catch {
+            y;
+          }
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test19() {
+  testCopyElision("test19",
+    R""""(
+      module M {
+        proc test() {
+          var x:int;
+          var y;
+          try {
+            y = x;
+          } catch {
+            return;
+          }
+        }
+      }
+    )"""",
+    {"M.test@5"});
+}
+
+static void test20() {
+  testCopyElision("test20",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          var y;
+          try {
+            y = x;
+          } catch {
+            y = x;
+          }
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test21() {
+  testCopyElision("test21",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          var y;
+          try {
+          } catch {
+            y = x;
+          }
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test22() {
+  testCopyElision("test22",
+    R""""(
+      module M {
+        proc test() {
+          try {
+          } catch {
+            var x:int;
+            var y = x;
+          }
+        }
+      }
+    )"""",
+    {"M.test@4"});
+}
+
+static void test23() {
+  testCopyElision("test23",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+        record R {
+          var field: int;
+        }
+        proc R.test() {
+          var x = field;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test24() {
+  // module scope variables aren't subject to copy elision
+  testCopyElision("test24",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+        var x: int;
+        var y = x;
+      }
+    )"""",
+    {},
+    /* resolveModule */ true);
+}
+
+static void test25() {
+  // module scope variables aren't subject to copy elision
+  testCopyElision("test25",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+        var x: int;
+        proc test() {
+          var y = x;
+        }
+      }
+    )"""",
+    {});
+}
+
+
+int main() {
+  test1();
+  test2();
+  test3();
+  test4();
+  test5();
+  test6();
+  test7();
+  test8();
+  test9();
+  test10();
+  test11();
+  test12();
+  test13();
+  test14();
+  test15();
+  test16();
+  test17();
+  test18();
+  test19();
+  test20();
+  test21();
+  test22();
+  test23();
+  test24();
+  test25();
+
+  return 0;
+}

--- a/frontend/test/resolution/testSplitInit.cpp
+++ b/frontend/test/resolution/testSplitInit.cpp
@@ -19,11 +19,10 @@
 
 #include "test-resolution.h"
 
-#include "chpl/resolution/split-init.h"
-
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
+#include "chpl/resolution/split-init.h"
 #include "chpl/uast/Call.h"
 #include "chpl/uast/Comment.h"
 #include "chpl/uast/Identifier.h"

--- a/frontend/test/resolution/testSplitInit.cpp
+++ b/frontend/test/resolution/testSplitInit.cpp
@@ -975,6 +975,208 @@ static void test37() {
     {});
 }
 
+static void test38() {
+  testSplitInit("test38",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          if x {
+            x = 11;
+          } else {
+            x = 11;
+          }
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test39() {
+  testSplitInit("test39",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          var y = x;
+          x = 11;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test40() {
+  testSplitInit("test40",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test(cond: bool) {
+          var x:int;
+          if cond {
+            x;
+          }
+          x = 11;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test41() {
+  testSplitInit("test41",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          {
+            x;
+          }
+          x = 11;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test42() {
+  testSplitInit("test42",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          try {
+            x;
+          }
+          x = 11;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test43() {
+  testSplitInit("test43",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          var x:int;
+          try {
+          } catch {
+            x;
+          }
+          x = 11;
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test44() {
+  testSplitInit("test44",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test(cond: bool) {
+          var x:int;
+          if cond {
+            x = 12;
+          } else {
+            if cond {
+              return;
+            } else {
+              return;
+            }
+          }
+        }
+      }
+    )"""",
+    {"x"});
+}
+
+static void test45() {
+  testSplitInit("test45",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test(cond: bool) {
+          var x:int;
+          if cond {
+            x = 12;
+          } else {
+            while true {
+              return;
+            }
+          }
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test46() {
+  testSplitInit("test46",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test(cond: bool) {
+          var x:int;
+          if cond {
+            x = 12;
+          } else {
+            try {
+              return;
+            } catch e {
+              return;
+            }
+          }
+        }
+      }
+    )"""",
+    {"x"});
+}
+
 
 int main() {
   test1();
@@ -1016,6 +1218,15 @@ int main() {
   //test35(); TODO
   //test36(); TODO
   test37();
+  test38();
+  test39();
+  test40();
+  test41();
+  test42();
+  test43();
+  test44();
+  test45();
+  test46();
 
   return 0;
 }


### PR DESCRIPTION
Continuing #20843 and #20963.

This PR implements copy elision analysis in dyno and adds a test of the same. It also improves the split init testing and the call-init-deinit logic.

Changes that need a bit more description:
* It migrates copy-elision.cpp and call-init-deinit.cpp to use the new VarScopeVisitor. To enable call-init-deinit.cpp to update resolution results, changed the VarScopeVisitor to a MutatingResolvedVisitor. But, split init and copy elision analysis don't mutate, so they cost away the const-ness to keep things simple.
* adds a call to `gdbShouldBreakHere()` to `Context::report` since it is often useful to stop compilation on an error when debugging.
* merges VarFrame returns and throws fields and updates VarScopeVisitor to update this information.

The call-init-deinit implementation is mostly skeletal and I plan to add detail to it in a future PR.

Reviewed by @DanilaFe - thanks!