### PR TITLE
Ensure exit-on-error logic also applies to Dyno errors

### DIFF
--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -69,7 +69,7 @@
 
 #define USR_PRINT      setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 5), handleError
 
-#define USR_STOP       exitAndPrintIfFatalErrorsEncountered
+#define USR_STOP       exitIfFatalErrorsEncountered
 
 // INT_ASSERT is intended to become no-op in production builds of compiler
 #define SELECT_ASSERT(_1, _2, NAME, ...) NAME
@@ -112,7 +112,6 @@ void        handleError(const BaseAST* ast, const char* fmt, ...)__attribute__ (
 void        handleError(astlocT astloc, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
 void        handleError(chpl::Location, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
 
-void        exitAndPrintIfFatalErrorsEncountered();
 void        exitIfFatalErrorsEncountered();
 
 void        considerExitingEndOfPass();

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -28,6 +28,7 @@
 
 #include "astlocs.h"
 #include "chpl/util/break.h"
+#include "chpl/framework/ErrorBase.h"
 
 #ifdef HAVE_LLVM
 #define exit(x) clean_exit(x)
@@ -68,7 +69,7 @@
 
 #define USR_PRINT      setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 5), handleError
 
-#define USR_STOP       exitIfFatalErrorsEncountered
+#define USR_STOP       exitAndPrintIfFatalErrorsEncountered
 
 // INT_ASSERT is intended to become no-op in production builds of compiler
 #define SELECT_ASSERT(_1, _2, NAME, ...) NAME
@@ -104,12 +105,14 @@ const char* cleanFilename(const char*    name);
 //  5 = USR_PRINT
 //
 void        setupError(const char* subdir, const char* filename, int lineno, int tag);
+void        setupDynoError(chpl::ErrorBase::Kind errKind);
 
 void        handleError(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 void        handleError(const BaseAST* ast, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
 void        handleError(astlocT astloc, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
 void        handleError(chpl::Location, const char* fmt, ...)__attribute__ ((format (printf, 2, 3)));
 
+void        exitAndPrintIfFatalErrorsEncountered();
 void        exitIfFatalErrorsEncountered();
 
 void        considerExitingEndOfPass();

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -81,7 +81,7 @@ void check_checkParsed()
 {
   // checkIsIterator() will crash if there were certain USR_FATAL_CONT()
   // e.g. functions/vass/proc-iter/error-yield-in-proc-*
-  exitAndPrintIfFatalErrorsEncountered();
+  exitIfFatalErrorsEncountered();
   checkIsIterator();
 }
 

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -81,7 +81,7 @@ void check_checkParsed()
 {
   // checkIsIterator() will crash if there were certain USR_FATAL_CONT()
   // e.g. functions/vass/proc-iter/error-yield-in-proc-*
-  exitIfFatalErrorsEncountered();
+  exitAndPrintIfFatalErrorsEncountered();
   checkIsIterator();
 }
 

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -891,7 +891,6 @@ static bool dynoRealizeErrors(void) {
       // Use production compiler's exit-on-error functionality for errors
       // reported via new Dyno mechanism
       setupDynoError(err->kind());
-      exitIfFatalErrorsEncountered();
     } else {
       // Try to maintain compatibility with the old reporting mechanism
       dynoDisplayError(gContext, err->toErrorMessage(gContext));

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -888,6 +888,10 @@ static bool dynoRealizeErrors(void) {
     if (!issuedErrors.insert(err).second) continue;
     if (fDetailedErrors) {
       chpl::Context::defaultReportError(gContext, err);
+      // Use production compiler's exit-on-error functionality for errors
+      // reported via new Dyno mechanism
+      setupDynoError(err->kind());
+      exitIfFatalErrorsEncountered();
     } else {
       // Try to maintain compatibility with the old reporting mechanism
       dynoDisplayError(gContext, err->toErrorMessage(gContext));

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -871,7 +871,7 @@ static void vhandleError(const BaseAST* ast,
     if (fPrintAdditionalErrors == false) {
       print_error("note: An additional error is hidden. "
                   "Use --print-additional-errors to see it.\n");
-      exitAndPrintIfFatalErrorsEncountered();
+      exitIfFatalErrorsEncountered();
       return;
     }
     print_error("note: Additional error follows\n");
@@ -910,12 +910,10 @@ static void vhandleError(const BaseAST* ast,
   }
 }
 
-void exitAndPrintIfFatalErrorsEncountered() {
-  printCallstackForLastError();
-  exitIfFatalErrorsEncountered();
-}
 
 void exitIfFatalErrorsEncountered() {
+  printCallstackForLastError();
+
   if (exit_eventually) {
     if (ignore_errors_for_pass) {
       exit_end_of_pass = true;


### PR DESCRIPTION
This PR fixes a bug (explained below) encountered in the course of testing https://github.com/chapel-lang/chapel/pull/20942 for https://github.com/Cray/chapel-private/issues/3949.

I noticed that compiling `test/arrays/bradc/noelemtype.chpl` resulted in a segfault only when the `--detailed-errors` flag was used. This segfault occurred because we attempted to proceed to the resolution pass after a fatal error was encountered in parsing.

@DanilaFe and I investigated and determined the cause: when [this error-reporting code](https://github.com/chapel-lang/chapel/blob/edac77ce53ec4ef2f534c674f1bdb97fc7bc30e8/compiler/parser/parser.cpp#L890) is selected due to the presence of `--detailed-errors`, it sidesteps the production compiler's exit-on-error functionality which would otherwise be invoked [here](https://github.com/chapel-lang/chapel/blob/edac77ce53ec4ef2f534c674f1bdb97fc7bc30e8/compiler/parser/parser.cpp#L893) and ultimately trigger a clean exit after the parsing pass. The solution was to also trigger the production compiler's exit-on-error functionality when reporting a detailed error through the Dyno mechanism.

Testing:
- [x] originally segfaulting compilation succeeds
- [x] paratest