### PR TITLE
Fix param narrowing conversion for INFINITY and NAN

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2253,6 +2253,12 @@ static bool fits_in_mantissa_exponent(int mantissa_width,
   } else
     INT_FATAL("unsupported number kind");
 
+  if (!std::isfinite(v)) {
+    // it must be infinity or nan
+    // assume these fit in any sized real
+    return true;
+  }
+
   double frac = 0.0;
   int exp = 0;
 

--- a/frontend/lib/immediates/num.cpp
+++ b/frontend/lib/immediates/num.cpp
@@ -28,7 +28,6 @@
 #include <cfloat>
 #include <cinttypes>
 #include <cmath>
-#include <cmath>
 #include <cstdio>
 #include <cstring>
 

--- a/test/param/ferguson/inf-nan-narrowing.chpl
+++ b/test/param/ferguson/inf-nan-narrowing.chpl
@@ -1,0 +1,49 @@
+proc checkOne(arg: real(32)) {
+  assert(!isnan(arg));
+  assert(!isinf(arg));
+  assert(signbit(arg) == false);
+  assert(arg == 1);
+}
+proc checkNan(arg: real(32)) {
+  assert(isnan(arg));
+}
+proc checkPosInf(arg: real(32)) {
+  assert(isinf(arg));
+  assert(signbit(arg) == false);
+}
+proc checkNegInf(arg: real(32)) {
+  assert(isinf(arg));
+  assert(signbit(arg) == true);
+}
+
+param zero = 0.0;
+param nzero = -0.0;
+param one = 1.0;
+param huge = 1.0e+300;
+param tiny = 1.0e-300;
+param inf = huge / tiny;
+param neginf = -huge / tiny;
+param inf0 = one / zero;
+param neginf0 = -1.0 / 0.0;
+param neginf0n = -(one / zero);
+param nanzeros = zero / zero;
+param negnanzeros = -nanzeros;
+param naninf = inf / inf;
+param negnaninf = -naninf;
+
+var x: real(32) = 1;
+
+checkOne(x*one);
+checkPosInf(x*inf);
+checkNegInf(x*neginf);
+checkPosInf(x*inf0);
+checkNegInf(x*neginf0);
+checkNegInf(x*neginf0n);
+checkNan(x*nanzeros);
+checkNan(x*negnanzeros);
+checkNan(x*naninf);
+checkNan(x*negnaninf);
+
+checkPosInf(x*INFINITY);
+checkNegInf(-(x*INFINITY));
+checkNegInf(x*(-INFINITY));


### PR DESCRIPTION
Resolves an issue brought up in https://github.com/chapel-lang/chapel/issues/18599#issuecomment-1306002949

This PR enables param narrowing conversion from a `real` `param` storing infinity or NaN to a smaller sized `real` type. Supporting such param narrowing conversion is reasonable because all `real` types of various sizes will support infinity and NaN values. So there is no loss of precision when converting to the smaller width.

This is arguably already implied by the spec language in https://chapel-lang.org/docs/language/spec/conversions.html#implicit-compile-time-constant-conversions :

> `param` `real(s)` that is exactly representable in the target type can implicitly convert to `real(t)` or to `complex(t)` regardless of the values of `s` and `t`.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing