### PR TITLE
Fix an unused variable warning/error from clang in a test

### DIFF
--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -32,8 +32,6 @@
 
 #include "./ErrorGuard.h"
 
-static const bool ERRORS_EXPECTED=true;
-
 // resolves the last function, or module if testModule=true
 // checks that the copy elision points match the string IDs provided
 static void testCopyElision(const char* test,


### PR DESCRIPTION
Follow-up to PR #20989. This PR fixes a warning/error from clang for a new dyno C++ test.

Trivial and not reviewed.