### PR TITLE
Deprecate the SysBasic module

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -953,7 +953,7 @@ module ChapelBase {
 
   // dynamic data block class
   // (note that c_ptr(type) is similar, but local only,
-  //  and defined in SysBasic.chpl)
+  //  and defined in CTypes.chpl)
   pragma "data class"
   pragma "no object"
   pragma "no default functions"

--- a/modules/packages/Buffers.chpl
+++ b/modules/packages/Buffers.chpl
@@ -47,7 +47,6 @@
  */
 module Buffers {
   use OS.POSIX;
-  import SysBasic.{ENOERR};
   use OS;
   private use CTypes;
 
@@ -302,7 +301,7 @@ module Buffers {
   }
   pragma "no doc"
   proc buffer.init() /*throws*/ {
-    var error:errorCode = ENOERR;
+    var error:errorCode = 0;
     this.home = here;
     this.complete();
     error = qbuffer_create(this._buf_internal);
@@ -318,7 +317,7 @@ module Buffers {
       this._buf_internal = x._buf_internal;
       this.complete();
     } else {
-      var error: errorCode = ENOERR;
+      var error: errorCode = 0;
       this.init(error);
       if error then halt("Got an error when initializing a new buffer.");
       var start_offset:int(64);
@@ -329,7 +328,7 @@ module Buffers {
         end_offset = qbuffer_end_offset(x._buf_internal);
       }
 
-      var allocErr:errorCode = ENOERR;
+      var allocErr:errorCode = 0;
       var b = new byteBuffer(end_offset - start_offset, error=allocErr);
       if allocErr then
         try! ioerror(allocErr, "could not allocate bytes in buffer copy");
@@ -344,7 +343,7 @@ module Buffers {
       var there_uid = here.id;
 
       on x.home {
-        var err:errorCode = ENOERR;
+        var err:errorCode = 0;
         err = bulk_put_buffer(there_uid, ptr, len, x._buf_internal,
                               qbuffer_begin(x._buf_internal),
                               qbuffer_end(x._buf_internal));
@@ -364,7 +363,7 @@ module Buffers {
    */
   proc buffer.flatten(range:buffer_range) throws {
     var ret: byteBuffer  = new byteBuffer();
-    var err: errorCode = ENOERR;
+    var err: errorCode = 0;
 
     if this.home == here {
       err = qbuffer_flatten(this._buf_internal, range.start._bufit_internal, range.end._bufit_internal, ret._bytes_internal);
@@ -426,7 +425,7 @@ module Buffers {
       var there_uid = here.id;
 
       on x.home {
-        var err:errorCode = ENOERR;
+        var err:errorCode = 0;
         err = bulk_put_buffer(there_uid, ptr, len, x._buf_internal,
                               qbuffer_begin(x._buf_internal),
                               qbuffer_end(x._buf_internal));
@@ -467,7 +466,7 @@ module Buffers {
      :arg len_bytes: how many bytes to append to the buffer
   */
   proc buffer.append(b:byteBuffer, skip_bytes:int(64) = 0, len_bytes:int(64) = b.len) throws {
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     on this.home {
       err = qbuffer_append(this._buf_internal, b._bytes_internal, skip_bytes, len_bytes);
     }
@@ -485,7 +484,7 @@ module Buffers {
                 buffer to copy. Defaults to all of the buffer.
    */
   proc buffer.append(buf:buffer, part:buffer_range = buf.all()) throws {
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     on this.home {
       err = qbuffer_append_buffer(this._buf_internal, buf._buf_internal, part.start._bufit_internal, part.end._bufit_internal);
     }
@@ -504,7 +503,7 @@ module Buffers {
      :arg len_bytes: how many bytes to append to the buffer
   */
   proc buffer.prepend(b:byteBuffer, skip_bytes:int(64) = 0, len_bytes:int(64) = b.len) throws {
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     on this.home {
       err = qbuffer_prepend(this._buf_internal, b._bytes_internal, skip_bytes, len_bytes);
     }
@@ -598,7 +597,7 @@ module Buffers {
   */
   proc buffer.copyout(it:buffer_iterator, ref value: ?T):buffer_iterator throws where isNumericType(T) {
     var ret:buffer_iterator;
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     ret.home = this.home;
     on this.home {
       var end:buffer_iterator = it;
@@ -616,7 +615,7 @@ module Buffers {
   pragma "no doc"
   proc buffer.copyout(it:buffer_iterator, ref value: string):buffer_iterator throws {
     var ret:buffer_iterator;
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     ret.home = this.home;
     on this.home {
       var start = it;
@@ -658,7 +657,7 @@ module Buffers {
   proc buffer.copyin(it:buffer_iterator, value: ?T): buffer_iterator
                      throws where isNumericType(T) {
     var ret:buffer_iterator;
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     ret.home = this.home;
     on this.home {
       //writeln("iterator on way in");
@@ -682,7 +681,7 @@ module Buffers {
   pragma "no doc"
   proc buffer.copyin(it:buffer_iterator, value: string):buffer_iterator throws {
     var ret:buffer_iterator;
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     ret.home = this.home;
     on this.home {
       var start = it;

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -159,7 +159,6 @@ Curl Support Types and Functions
 module Curl {
   public use IO, CTypes;
   use OS.POSIX;
-  import SysBasic.{ENOERR};
   import OS.{errorCode};
 
   require "curl/curl.h";
@@ -326,7 +325,7 @@ module Curl {
      :arg str: a string argument to append
     */
   proc slist.append(str:string) throws {
-    var err: errorCode = ENOERR;
+    var err: errorCode = 0;
     on this.home {
       this.list = curl_slist_append(this.list, str.localize().c_str());
       if this.list == nil then
@@ -512,7 +511,6 @@ module Curl {
     use Curl;
     use CTypes;
     use OS.POSIX;
-    import SysBasic.{ENOERR};
     import OS.{errorCode};
 
     pragma "no doc"
@@ -542,12 +540,12 @@ module Curl {
         }
 
         length = this.length;
-        return ENOERR;
+        return 0;
       }
       override proc getpath(out path:c_string, out len:int(64)):errorCode {
         path = qio_strdup(this.url_c);
         len = url_c.size;
-        return ENOERR;
+        return 0;
       }
 
       override proc fsync():errorCode {
@@ -564,7 +562,7 @@ module Curl {
       override proc close():errorCode {
         c_free(url_c:c_void_ptr);
         url_c = nil;
-        return ENOERR;
+        return 0;
       }
     }
 
@@ -575,7 +573,7 @@ module Curl {
       var curlm: c_ptr(CURLM);  // Curl multi handle
       var running_handles: c_int;
       var have_channel_lock:bool;
-      var saved_error:errorCode = ENOERR;
+      var saved_error:errorCode = 0;
 
       override proc readAtLeast(amt:int(64)):errorCode {
         return read_atleast(this, amt);
@@ -588,7 +586,7 @@ module Curl {
         curl_multi_remove_handle(curlm, curl);
         curl_easy_cleanup(curl);
         curl_multi_cleanup(curlm);
-        return ENOERR;
+        return 0;
       }
     }
 
@@ -855,13 +853,13 @@ module Curl {
 
       //writeln("finished start_channel");
 
-      return ENOERR;
+      return 0;
     }
 
     private proc curl_write_received(contents: c_void_ptr, size:c_size_t, nmemb:c_size_t, userp: c_void_ptr):c_size_t {
       var realsize:c_size_t = size * nmemb;
       var cc = userp:unmanaged CurlChannel?;
-      var err:errorCode = ENOERR;
+      var err:errorCode = 0;
 
       // lock the channel if it's not already locked
       assert(cc!.have_channel_lock);
@@ -876,7 +874,7 @@ module Curl {
 
       // unlock the channel if we locked it
 
-      if err != ENOERR {
+      if err != 0 {
         cc!.saved_error = err;
         return 0;
       }
@@ -897,7 +895,7 @@ module Curl {
       var curl = cc.curl;
       var curlm = cc.curlm;
       var mcode: CURLMcode;
-      var serr:errorCode = ENOERR;
+      var serr:errorCode = 0;
       var fdread: fd_set;
       var fdwrite: fd_set;
       var fdexcept: fd_set;
@@ -975,7 +973,7 @@ module Curl {
           break;
 
         // stop if there was an error saving the data to the buffer
-        if cc.saved_error != ENOERR then
+        if cc.saved_error != 0 then
           return cc.saved_error;
       }
 
@@ -984,7 +982,7 @@ module Curl {
       if cc.running_handles == 0 && space < amt then
         return EEOF;
 
-      return ENOERR;
+      return 0;
     }
 
     // Send some data somewhere with curl
@@ -993,7 +991,7 @@ module Curl {
     private proc curl_read_buffered(contents: c_void_ptr, size:c_size_t, nmemb:c_size_t, userp: c_void_ptr):c_size_t {
       var realsize:c_size_t = size * nmemb;
       var cc = userp:unmanaged CurlChannel?;
-      var err:errorCode = ENOERR;
+      var err:errorCode = 0;
 
       // lock the channel if it's not already locked
       assert(cc!.have_channel_lock);
@@ -1010,7 +1008,7 @@ module Curl {
       // unlock the channel if we locked it
 
       // If there was an error from the channel, abort the connection
-      if err != ENOERR {
+      if err != 0 {
         cc!.saved_error = err;
         return CURL_READFUNC_ABORT;
       }
@@ -1039,7 +1037,7 @@ module Curl {
       var curlm = cc.curlm;
       var ccode: CURLcode;
       var mcode: CURLMcode;
-      var serr:errorCode = ENOERR;
+      var serr:errorCode = 0;
       var fdread: fd_set;
       var fdwrite: fd_set;
       var fdexcept: fd_set;
@@ -1117,7 +1115,7 @@ module Curl {
           break;
 
         // stop if there was an error saving the data to the buffer
-        if cc.saved_error != ENOERR then
+        if cc.saved_error != 0 then
           return cc.saved_error;
       }
 
@@ -1128,14 +1126,14 @@ module Curl {
         return EEOF;
       }
 
-      return ENOERR;
+      return 0;
     }
 
     proc openCurlFile(url:string,
                      mode:iomode = iomode.r,
                      style:iostyleInternal = defaultIOStyleInternal()) throws {
 
-      var err_out: errorCode = ENOERR;
+      var err_out: errorCode = 0;
       var rc = 0;
       var filelength: int(64);
 

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -127,7 +127,6 @@ module HDFS {
 
   use IO, OS.POSIX, OS;
   public use CTypes;
-  import SysBasic.{ENOERR};
 
   require "hdfs.h";
 
@@ -385,7 +384,7 @@ module HDFS {
 
       var hdfsch = new unmanaged HDFSChannel(this:unmanaged, qioChannelPtr);
       pluginChannel = hdfsch;
-      return ENOERR;
+      return 0;
     }
 
     override proc filelength(out length:int(64)):errorCode {
@@ -399,7 +398,7 @@ module HDFS {
       hdfsFreeFileInfo(fInfoPtr, 1);
       if verbose then
         writeln("HDFSFile.filelength length=", length);
-      return ENOERR;
+      return 0;
     }
     override proc getpath(out path:c_string, out len:int(64)):errorCode {
       if verbose then
@@ -408,7 +407,7 @@ module HDFS {
       len = this.path.size;
       if verbose then
         writeln("HDFSFile.getpath returning ", (path:string, len));
-      return ENOERR;
+      return 0;
     }
 
     override proc fsync():errorCode {
@@ -417,7 +416,7 @@ module HDFS {
       var rc = hdfsFlush(fs.hfs, hfile);
       if rc < 0 then
         return qio_mkerror_errno();
-      return ENOERR;
+      return 0;
     }
     override proc getChunk(out length:int(64)):errorCode {
       if verbose then
@@ -427,7 +426,7 @@ module HDFS {
         return EINVAL;
       length = fInfoPtr.deref().mBlockSize;
       hdfsFreeFileInfo(fInfoPtr, 1);
-      return ENOERR;
+      return 0;
     }
     override proc getLocalesForRegion(start:int(64), end:int(64), out
         localeNames:c_ptr(c_string), ref nLocales:int(64)):errorCode {
@@ -440,7 +439,7 @@ module HDFS {
       if verbose then
         writeln("hdfsCloseFile");
 
-      var err:errorCode = ENOERR;
+      var err:errorCode = 0;
       var rc = hdfsCloseFile(fs.hfs, hfile);
       if rc != 0 then
         err = qio_mkerror_errno();
@@ -449,7 +448,7 @@ module HDFS {
       if count == 0 {
         delete fs;
       }
-      return ENOERR;
+      return 0;
     }
   }
 
@@ -471,9 +470,9 @@ module HDFS {
         writeln("HDFSChannel.readAtLeast");
 
       if amt == 0 then
-        return ENOERR;
+        return 0;
 
-      var err:errorCode = ENOERR;
+      var err:errorCode = 0;
 
       var remaining = amt;
       while remaining > 0 {
@@ -507,13 +506,13 @@ module HDFS {
         remaining -= rc:int(64);
       }
 
-      return ENOERR;
+      return 0;
     }
     override proc write(amt:int(64)):errorCode {
       if verbose then
         writeln("HDFSChannel.write");
 
-      var err:errorCode = ENOERR;
+      var err:errorCode = 0;
       var remaining = amt;
       while remaining > 0 {
         var ptr:c_void_ptr = c_nil;
@@ -539,10 +538,10 @@ module HDFS {
         qio_channel_advance_write_behind_unlocked(qio_ch, rc);
         remaining -= rc:int(64);
       }
-      return ENOERR;
+      return 0;
     }
     override proc close():errorCode {
-      return ENOERR;
+      return 0;
     }
   }
 

--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -72,7 +72,6 @@ public use CTypes;
 use Time;
 use OS, OS.POSIX;
 use IO;
-import SysBasic.{ENOERR, fd_t};
 
 /*
   Available values for different Internet
@@ -263,7 +262,7 @@ type tcpConn = file;
 */
 proc tcpConn.socketFd throws {
   var tempfd:c_int;
-  var err:errorCode = ENOERR;
+  var err:errorCode = 0;
   on this.home {
     var localtempfd = tempfd;
     err = qio_get_fd(this._file_internal, localtempfd);
@@ -580,20 +579,20 @@ pragma "no doc" proc sys_addrinfo_ptr_t.addr:sys_sockaddr_t { return sys_getaddr
 pragma "no doc" proc sys_addrinfo_ptr_t.next:sys_addrinfo_ptr_t { return sys_getaddrinfo_next(this); }
 
 
-private extern proc sys_fcntl(fd:fd_t, cmd:c_int, ref ret_out:c_int):c_int;
-private extern proc sys_fcntl_long(fd:fd_t, cmd:c_int, arg:c_long, ref ret_out:c_int):c_int;
-private extern proc sys_accept(sockfd:fd_t, ref add_out:sys_sockaddr_t, ref fd_out:fd_t):c_int;
-private extern proc sys_bind(sockfd:fd_t, const ref addr:sys_sockaddr_t):c_int;
-private extern proc sys_connect(sockfd:fd_t, const ref addr:sys_sockaddr_t):c_int;
+private extern proc sys_fcntl(fd:c_int, cmd:c_int, ref ret_out:c_int):c_int;
+private extern proc sys_fcntl_long(fd:c_int, cmd:c_int, arg:c_long, ref ret_out:c_int):c_int;
+private extern proc sys_accept(sockfd:c_int, ref add_out:sys_sockaddr_t, ref fd_out:c_int):c_int;
+private extern proc sys_bind(sockfd:c_int, const ref addr:sys_sockaddr_t):c_int;
+private extern proc sys_connect(sockfd:c_int, const ref addr:sys_sockaddr_t):c_int;
 private extern proc getaddrinfo(node:c_string, service:c_string, ref hints:sys_addrinfo_t, ref res_out:sys_addrinfo_ptr_t):c_int;
 private extern proc sys_freeaddrinfo(res:sys_addrinfo_ptr_t);
-private extern proc sys_getpeername(sockfd:fd_t, ref addr:sys_sockaddr_t):c_int;
-private extern proc sys_getsockname(sockfd:fd_t, ref addr:sys_sockaddr_t):c_int;
-private extern proc sys_getsockopt(sockfd:fd_t, level:c_int, optname:c_int, optval:c_void_ptr, ref optlen:socklen_t):c_int;
-private extern proc sys_setsockopt(sockfd:fd_t, level:c_int, optname:c_int, optval:c_void_ptr, optlen:socklen_t):c_int;
-private extern proc sys_listen(sockfd:fd_t, backlog:c_int):c_int;
-private extern proc sys_socket(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out:fd_t):c_int;
-private extern proc sys_close(fd:fd_t):c_int;
+private extern proc sys_getpeername(sockfd:c_int, ref addr:sys_sockaddr_t):c_int;
+private extern proc sys_getsockname(sockfd:c_int, ref addr:sys_sockaddr_t):c_int;
+private extern proc sys_getsockopt(sockfd:c_int, level:c_int, optname:c_int, optval:c_void_ptr, ref optlen:socklen_t):c_int;
+private extern proc sys_setsockopt(sockfd:c_int, level:c_int, optname:c_int, optval:c_void_ptr, optlen:socklen_t):c_int;
+private extern proc sys_listen(sockfd:c_int, backlog:c_int):c_int;
+private extern proc sys_socket(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out:c_int):c_int;
+private extern proc sys_close(fd:c_int):c_int;
 private extern proc sys_getaddrinfo_addr(res:sys_addrinfo_ptr_t):sys_sockaddr_t;
 private extern proc sys_getaddrinfo_next(res:sys_addrinfo_ptr_t):sys_addrinfo_ptr_t;
 private extern proc sys_getaddrinfo_flags(res:sys_addrinfo_ptr_t):c_int;
@@ -651,7 +650,7 @@ record tcpListener {
 */
 proc tcpListener.accept(in timeout: struct_timeval = indefiniteTimeout):tcpConn throws {
   var client_addr:sys_sockaddr_t = new sys_sockaddr_t();
-  var fdOut:fd_t;
+  var fdOut:c_int;
   var err_out:c_int = 0;
   // try accept
   err_out = sys_accept(socketFd, client_addr, fdOut);
@@ -1019,7 +1018,7 @@ proc udpSocket.close throws {
 }
 
 pragma "no doc"
-private extern proc sys_recvfrom(sockfd:fd_t, buff:c_void_ptr, len:c_size_t, flags:c_int, ref src_addr_out:sys_sockaddr_t, ref num_recvd_out:c_ssize_t):c_int;
+private extern proc sys_recvfrom(sockfd:c_int, buff:c_void_ptr, len:c_size_t, flags:c_int, ref src_addr_out:sys_sockaddr_t, ref num_recvd_out:c_ssize_t):c_int;
 
 /*
   Reads upto `bufferLen` bytes from the socket, and
@@ -1136,7 +1135,7 @@ proc udpSocket.recv(bufferLen: int, timeout: real) throws {
 }
 
 pragma "no doc"
-private extern proc sys_sendto(sockfd:fd_t, buff:c_void_ptr, len:c_long, flags:c_int, const ref address:sys_sockaddr_t,  ref num_sent_out:c_ssize_t):c_int;
+private extern proc sys_sendto(sockfd:c_int, buff:c_void_ptr, len:c_long, flags:c_int, const ref address:sys_sockaddr_t,  ref num_sent_out:c_ssize_t):c_int;
 
 /*
   Send `data` over socket to the provided address and
@@ -1245,7 +1244,7 @@ extern const SO_SNDTIMEO:c_int;
 extern const SO_SECINFO:c_int;
 
 pragma "no doc"
-proc setSockOpt(socketFd: fd_t, level: c_int, optname: c_int, ref value: c_int) throws {
+proc setSockOpt(socketFd: c_int, level: c_int, optname: c_int, ref value: c_int) throws {
   var optlen = sizeof(value):socklen_t;
   var ptroptval = c_ptrTo(value);
   var err_out = sys_setsockopt(socketFd, level, optname, ptroptval:c_void_ptr, optlen);
@@ -1281,7 +1280,7 @@ proc setSockOpt(ref socket: ?t, level: c_int, optname: c_int, value: c_int)
 }
 
 pragma "no doc"
-proc setSockOpt(socketFd:fd_t, level: c_int, optname: c_int, ref value: bytes) throws {
+proc setSockOpt(socketFd:c_int, level: c_int, optname: c_int, ref value: bytes) throws {
   var optlen = value.size:socklen_t;
   var ptroptval = value.c_str();
   var err_out = sys_setsockopt(socketFd, level, optname, ptroptval, optlen);
@@ -1315,7 +1314,7 @@ proc setSockOpt(ref socket: ?t, level: c_int, optname: c_int, value: bytes)
 }
 
 pragma "no doc"
-proc setSockOpt(socketFd:fd_t, level: c_int, optname: c_int, value:nothing, optlen:socklen_t) throws {
+proc setSockOpt(socketFd:c_int, level: c_int, optname: c_int, value:nothing, optlen:socklen_t) throws {
   var err_out = sys_setsockopt(socketFd, level, optname, nil, optlen);
   if err_out != 0 {
     throw createSystemError(err_out, "Failed to set socket option");
@@ -1346,7 +1345,7 @@ proc setSockOpt(ref socket: ?t, level: c_int, optname: c_int, value: nothing, op
 }
 
 pragma "no doc"
-proc getSockOpt(socketFd:fd_t, level: c_int, optname: c_int) throws {
+proc getSockOpt(socketFd:c_int, level: c_int, optname: c_int) throws {
   var optval:c_int;
   var ptroptval = c_ptrTo(optval);
   var optlen = sizeof(optval):socklen_t;
@@ -1380,7 +1379,7 @@ proc getSockOpt(ref socket: ?t, level: c_int, optname: c_int): int(32)
 }
 
 pragma "no doc"
-proc getSockOpt(socketFd:fd_t, level: c_int, optname: c_int, buflen: uint(16)) throws {
+proc getSockOpt(socketFd:c_int, level: c_int, optname: c_int, buflen: uint(16)) throws {
   if buflen < 0 || buflen > 1024 {
     throw new Error("getSockOpt buflen out of range");
   }
@@ -1419,7 +1418,7 @@ proc getSockOpt(ref socket: ?t, level: c_int, optname: c_int, buflen: uint(16)):
 }
 
 pragma "no doc"
-proc getPeerName(socketFD: fd_t) throws {
+proc getPeerName(socketFD: c_int) throws {
   var addressStorage = new sys_sockaddr_t();
   var err = sys_getpeername(socketFD, addressStorage);
   if err != 0 {
@@ -1446,7 +1445,7 @@ proc getPeerName(ref socket: tcpConn): ipAddr throws {
 }
 
 pragma "no doc"
-proc getSockName(socketFD: fd_t) throws {
+proc getSockName(socketFD: c_int) throws {
   var addressStorage = new sys_sockaddr_t();
   var err = sys_getsockname(socketFD, addressStorage);
   if err != 0 {
@@ -1483,7 +1482,7 @@ proc socket(family:IPFamily = IPFamily.IPv4, sockType:c_int = SOCK_STREAM, proto
 }
 
 pragma "no doc"
-proc setBlocking(socketFd: fd_t, blocking: bool) throws {
+proc setBlocking(socketFd: c_int, blocking: bool) throws {
   var flags:c_int;
   var err = sys_fcntl(socketFd, F_GETFL, flags);
   if err != 0 {
@@ -1502,7 +1501,7 @@ proc setBlocking(socketFd: fd_t, blocking: bool) throws {
 }
 
 pragma "no doc"
-proc bind(socketFd:fd_t, ref address: ipAddr, reuseAddr = true) throws {
+proc bind(socketFd:c_int, ref address: ipAddr, reuseAddr = true) throws {
   var enable = (if reuseAddr then 1 else 0):c_int;
   setSockOpt(socketFd, SOL_SOCKET, SO_REUSEADDR, enable);
   var err = sys_bind(socketFd, address._addressStorage);
@@ -1538,24 +1537,24 @@ proc bind(ref socket: ?t, ref address: ipAddr, reuseAddr = true)
 }
 
 pragma "no doc"
-proc nagle(socketFd:fd_t, enable:bool) throws {
+proc nagle(socketFd:c_int, enable:bool) throws {
   var c_enable = (if enable then 0 else 1):c_int;
   setSockOpt(socketFd, IPPROTO_TCP, TCP_NODELAY, c_enable);
 }
 
 pragma "no doc"
-proc nagle(socketFd:fd_t):bool throws {
+proc nagle(socketFd:c_int):bool throws {
   return if getSockOpt(socketFd, IPPROTO_TCP, TCP_NODELAY) == 0 then true else false;
 }
 
 pragma "no doc"
-proc delayAck(socketFd:fd_t, enable:bool) throws {
+proc delayAck(socketFd:c_int, enable:bool) throws {
   var c_enable = (if enable then 0 else 1):c_int;
   setSockOpt(socketFd, IPPROTO_TCP, TCP_QUICKACK, c_enable);
 }
 
 pragma "no doc"
-proc delayAck(socketFd:fd_t):bool throws {
+proc delayAck(socketFd:c_int):bool throws {
   return if getSockOpt(socketFd, IPPROTO_TCP, TCP_QUICKACK) == 0 then true else false;
 }
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -151,7 +151,6 @@ module BigInteger {
   use GMP;
   use HaltWrappers;
   use CTypes;
-  use SysBasic only ENOERR;
   use IO only EFORMAT;
   use OS;
 
@@ -262,7 +261,7 @@ module BigInteger {
 
         error = EFORMAT;
       } else {
-        error = ENOERR;
+        error = 0;
       }
 
       this.localeId = chpl_nodeID;

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -137,7 +137,6 @@ pragma "module included by default"
 module ChapelIO {
   use ChapelBase; // for uint().
   use ChapelLocale;
-  import SysBasic.{ENOERR};
 
   // TODO -- this should probably be private
   pragma "no doc"

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -93,7 +93,6 @@
 module FileSystem {
 
   public use OS;
-  import SysBasic.{ENOERR};
   use Path;
   use HaltWrappers;
   use CTypes;
@@ -187,7 +186,7 @@ private inline proc unescape(str: string) {
 proc locale.chdir(name: string) throws {
   extern proc chpl_fs_chdir(name: c_string):errorCode;
 
-  var err: errorCode = ENOERR;
+  var err: errorCode = 0;
   on this {
     err = chpl_fs_chdir(unescape(name).c_str());
   }
@@ -432,7 +431,7 @@ proc copyMode(src: string, dest: string) throws {
 
 pragma "no doc"
 proc copyMode(out error: errorCode, src: string, dest: string) {
-  var err: errorCode = ENOERR;
+  var err: errorCode = 0;
   try {
     copyMode(src, dest);
   } catch e: SystemError {
@@ -531,7 +530,7 @@ proc locale.cwd(): string throws {
   extern proc chpl_fs_cwd(ref working_dir:c_string):errorCode;
 
   var ret:string;
-  var err: errorCode = ENOERR;
+  var err: errorCode = 0;
   on this {
     var tmp:c_string;
     // c_strings can't cross on statements.
@@ -542,7 +541,7 @@ proc locale.cwd(): string throws {
     // tmp was qio_malloc'd by chpl_fs_cwd
     chpl_free_c_string(tmp);
   }
-  if err != ENOERR then try ioerror(err, "in cwd");
+  if err != 0 then try ioerror(err, "in cwd");
   return ret;
 }
 

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -45,7 +45,6 @@ module OS {
   */
   module POSIX {
     public use CTypes;
-    import SysBasic.fd_t;
 
     //
     // sys/types.h
@@ -966,8 +965,8 @@ module OS {
    .. code-block:: chapel
 
      var err: errorCode;
-     if err then writeln("err contains an error, ie err != ENOERR");
-     else writeln("err does not contain an error; err == ENOERR");
+     if err then writeln("err contains an error, ie err != 0");
+     else writeln("err does not contain an error; err == 0");
 
    The default intent for a formal of type :type:`errorCode` is `const in`.
 
@@ -1035,7 +1034,6 @@ module OS {
 
   private use CTypes;
   private use POSIX;
-  import SysBasic.{ESHUTDOWN,ENOERR};
 
   /*
    Private local copies of IO.{EEOF,ESHORT,EFORMAT}, since if we import IO
@@ -1069,7 +1067,7 @@ module OS {
        from the internal ``err`` and the ``details`` string.
     */
     override proc message() {
-      var strerror_err: c_int = ENOERR;
+      var strerror_err: c_int = 0;
       var errstr              = sys_strerror_syserr_str(err, strerror_err);
       var err_msg: string;
       try! {
@@ -1181,7 +1179,7 @@ module OS {
 
   /*
      :class:`BrokenPipeError` is the subclass of :class:`ConnectionError`
-     corresponding to :const:`~POSIX.EPIPE` and :const:`SysBasic.ESHUTDOWN`.
+     corresponding to :const:`~POSIX.EPIPE`
   */
   class BrokenPipeError : ConnectionError {
     proc init(details: string = "", err: errorCode = EPIPE:errorCode) {
@@ -1457,7 +1455,7 @@ module OS {
    */
   proc errorToString(error:errorCode):string
   {
-    var strerror_err:c_int = ENOERR;
+    var strerror_err:c_int = 0;
     const errstr = sys_strerror_syserr_str(error, strerror_err);
     try! {
       return createStringWithOwnedBuffer(errstr);

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1095,7 +1095,7 @@ module OS {
       return new owned BlockingIoError(details, err);
     } else if err == ECHILD {
       return new owned ChildProcessError(details, err);
-    } else if err == EPIPE || err == ESHUTDOWN {
+    } else if err == EPIPE {
       return new owned BrokenPipeError(details, err);
     } else if err == ECONNABORTED {
       return new owned ConnectionAbortedError(details, err);

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -133,7 +133,6 @@ module Subprocess {
   use OS;
   use CTypes;
   use OS.POSIX;
-  import SysBasic.{ENOERR};
 
   private extern proc qio_openproc(argv:c_ptr(c_string),
                                    env:c_ptr(c_string),
@@ -569,7 +568,7 @@ module Subprocess {
       ret.spawn_error = err;
       return ret;
     }
-    ret.spawn_error = ENOERR;
+    ret.spawn_error = 0;
 
     // open the QIO files if a pipe was used.
 
@@ -726,7 +725,7 @@ module Subprocess {
   proc subprocess.poll() throws {
     try _throw_on_launch_error();
 
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     on home {
       // check if child process has terminated.
       var done:c_int = 0;
@@ -794,10 +793,10 @@ module Subprocess {
       return;
     }
 
-    var stdin_err:errorCode  = ENOERR;
-    var wait_err:errorCode   = ENOERR;
-    var stdout_err:errorCode = ENOERR;
-    var stderr_err:errorCode = ENOERR;
+    var stdin_err:errorCode  = 0;
+    var wait_err:errorCode   = 0;
+    var stdout_err:errorCode = 0;
+    var stderr_err:errorCode = 0;
 
     on home {
       // Close stdin.
@@ -909,7 +908,7 @@ module Subprocess {
       return;
     }
 
-    var err:errorCode = ENOERR;
+    var err:errorCode = 0;
     on home {
       if this.stdin_pipe {
         // send data to stdin
@@ -943,7 +942,7 @@ module Subprocess {
    */
   proc subprocess.close() throws {
     // TODO: see subprocess.wait() for more on this error handling approach
-    var err: errorCode = ENOERR;
+    var err: errorCode = 0;
 
     // Close stdin.
     if this.stdin_pipe {
@@ -1120,7 +1119,7 @@ module Subprocess {
   proc subprocess.sendPosixSignal(signal:int) throws {
     try _throw_on_launch_error();
 
-    var err: errorCode = ENOERR;
+    var err: errorCode = 0;
     on home {
       err = qio_send_signal(pid, signal:c_int);
     }

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -44,7 +44,6 @@
  */
 deprecated "The 'Sys' module has been deprecated; please find replacement symbols in the 'OS' and  'Socket' modules"
 module Sys {
-  import SysBasic.{qio_err_t, fd_t};
   private use CTypes;
   private use OS;
 
@@ -564,43 +563,43 @@ module Sys {
 
   // not used outside of Sys
   // --- deprecated with no replacement ---
-  extern proc sys_open(pathname:c_string, flags:c_int, mode:mode_t, ref fd_out:fd_t):qio_err_t;
+  extern proc sys_open(pathname:c_string, flags:c_int, mode:mode_t, ref fd_out:c_int):qio_err_t;
 
   // --- deprecated and moved to Socket as private ---
-  extern proc sys_close(fd:fd_t):qio_err_t;
+  extern proc sys_close(fd:c_int):qio_err_t;
 
   /* The type corresponding to C's off_t */
   // --- has replacement in OS.POSIX ---
   extern type off_t = int(64);
 
   // --- deprecated with no replacement ---
-  extern proc sys_mmap(addr:c_void_ptr, length:c_size_t, prot:c_int, flags:c_int, fd:fd_t, offset:off_t, ref ret_out:c_void_ptr):qio_err_t;
+  extern proc sys_mmap(addr:c_void_ptr, length:c_size_t, prot:c_int, flags:c_int, fd:c_int, offset:off_t, ref ret_out:c_void_ptr):qio_err_t;
   extern proc sys_munmap(addr:c_void_ptr, length:c_size_t):qio_err_t;
-  extern proc sys_fcntl_ptr(fd:fd_t, cmd:c_int, arg:c_void_ptr, ref ret_out:c_int):qio_err_t;
-  extern proc sys_dup(oldfd:fd_t, ref fd_out:fd_t):qio_err_t;
-  extern proc sys_dup2(oldfd:fd_t, newfd:fd_t, ref fd_out:fd_t):qio_err_t;
-  extern proc sys_pipe(ref read_fd_out:fd_t, ref write_fd_out:fd_t):qio_err_t;
+  extern proc sys_fcntl_ptr(fd:c_int, cmd:c_int, arg:c_void_ptr, ref ret_out:c_int):qio_err_t;
+  extern proc sys_dup(oldfd:c_int, ref fd_out:c_int):qio_err_t;
+  extern proc sys_dup2(oldfd:c_int, newfd:c_int, ref fd_out:fd_t):qio_err_t;
+  extern proc sys_pipe(ref read_fd_out:c_int, ref write_fd_out:c_int):qio_err_t;
   extern proc sys_getaddrinfo_protocol(res:sys_addrinfo_ptr_t):c_int;
   extern proc sys_getnameinfo(ref addr:sys_sockaddr_t, ref host_out:c_string, ref serv_outc_:c_string, flags:c_int):qio_err_t;
-  extern proc sys_socketpair(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out_a:fd_t, ref sockfd_out_b:fd_t):qio_err_t;
-  extern proc sys_shutdown(sockfd:fd_t, how:c_int):qio_err_t;
+  extern proc sys_socketpair(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out_a:c_int, ref sockfd_out_b:c_int):qio_err_t;
+  extern proc sys_shutdown(sockfd:c_int, how:c_int):qio_err_t;
 
   // --- deprecated and moved to Socket as private ---
-  extern proc sys_fcntl(fd:fd_t, cmd:c_int, ref ret_out:c_int):qio_err_t;
-  extern proc sys_fcntl_long(fd:fd_t, cmd:c_int, arg:c_long, ref ret_out:c_int):qio_err_t;
-  extern proc sys_accept(sockfd:fd_t, ref add_out:sys_sockaddr_t, ref fd_out:fd_t):qio_err_t;
-  extern proc sys_bind(sockfd:fd_t, const ref addr:sys_sockaddr_t):qio_err_t;
-  extern proc sys_connect(sockfd:fd_t, const ref addr:sys_sockaddr_t):qio_err_t;
+  extern proc sys_fcntl(fd:c_int, cmd:c_int, ref ret_out:c_int):qio_err_t;
+  extern proc sys_fcntl_long(fd:c_int, cmd:c_int, arg:c_long, ref ret_out:c_int):qio_err_t;
+  extern proc sys_accept(sockfd:c_int, ref add_out:sys_sockaddr_t, ref fd_out:c_int):qio_err_t;
+  extern proc sys_bind(sockfd:c_int, const ref addr:sys_sockaddr_t):qio_err_t;
+  extern proc sys_connect(sockfd:c_int, const ref addr:sys_sockaddr_t):qio_err_t;
   extern proc getaddrinfo(node:c_string, service:c_string, ref hints:sys_addrinfo_t, ref res_out:sys_addrinfo_ptr_t):qio_err_t;
   extern proc sys_freeaddrinfo(res:sys_addrinfo_ptr_t);
-  extern proc sys_getpeername(sockfd:fd_t, ref addr:sys_sockaddr_t):qio_err_t;
-  extern proc sys_getsockname(sockfd:fd_t, ref addr:sys_sockaddr_t):qio_err_t;
+  extern proc sys_getpeername(sockfd:c_int, ref addr:sys_sockaddr_t):qio_err_t;
+  extern proc sys_getsockname(sockfd:c_int, ref addr:sys_sockaddr_t):qio_err_t;
   // TODO -- these should be generic, assuming caller knows what they
   // are doing.
-  extern proc sys_getsockopt(sockfd:fd_t, level:c_int, optname:c_int, optval:c_void_ptr, ref optlen:socklen_t):qio_err_t;
-  extern proc sys_setsockopt(sockfd:fd_t, level:c_int, optname:c_int, optval:c_void_ptr, optlen:socklen_t):qio_err_t;
-  extern proc sys_listen(sockfd:fd_t, backlog:c_int):qio_err_t;
-  extern proc sys_socket(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out:fd_t):qio_err_t;
+  extern proc sys_getsockopt(sockfd:c_int, level:c_int, optname:c_int, optval:c_void_ptr, ref optlen:socklen_t):qio_err_t;
+  extern proc sys_setsockopt(sockfd:c_int, level:c_int, optname:c_int, optval:c_void_ptr, optlen:socklen_t):qio_err_t;
+  extern proc sys_listen(sockfd:c_int, backlog:c_int):qio_err_t;
+  extern proc sys_socket(_domain:c_int, _type:c_int, protocol:c_int, ref sockfd_out:c_int):qio_err_t;
   extern proc sys_getaddrinfo_addr(res:sys_addrinfo_ptr_t):sys_sockaddr_t;
   extern proc sys_getaddrinfo_next(res:sys_addrinfo_ptr_t):sys_addrinfo_ptr_t;
   extern proc sys_getaddrinfo_flags(res:sys_addrinfo_ptr_t):c_int;

--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -577,7 +577,7 @@ module Sys {
   extern proc sys_munmap(addr:c_void_ptr, length:c_size_t):qio_err_t;
   extern proc sys_fcntl_ptr(fd:c_int, cmd:c_int, arg:c_void_ptr, ref ret_out:c_int):qio_err_t;
   extern proc sys_dup(oldfd:c_int, ref fd_out:c_int):qio_err_t;
-  extern proc sys_dup2(oldfd:c_int, newfd:c_int, ref fd_out:fd_t):qio_err_t;
+  extern proc sys_dup2(oldfd:c_int, newfd:c_int, ref fd_out:c_int):qio_err_t;
   extern proc sys_pipe(ref read_fd_out:c_int, ref write_fd_out:c_int):qio_err_t;
   extern proc sys_getaddrinfo_protocol(res:sys_addrinfo_ptr_t):c_int;
   extern proc sys_getnameinfo(ref addr:sys_sockaddr_t, ref host_out:c_string, ref serv_outc_:c_string, flags:c_int):qio_err_t;

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -42,7 +42,7 @@ deprecated "'qio_err_t' has been deprecated; please use a 'CTypes.c_int' instead
 extern type qio_err_t = c_int;
 
 /* A system file descriptor. This is really just a `c_int`, but code is
-   clearer if you use c_int to indicate arguments, variables, and return types
+   clearer if you use fd_t to indicate arguments, variables, and return types
    that are system file descriptors.
  */
 extern type fd_t = c_int;

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -28,6 +28,7 @@
    authority on system error codes.
  */
 
+deprecated "The SysBasic module has been deprecated; most symbols have been moved to IO or OS as appropriate"
 module SysBasic {
 
 /* BASIC TYPES */
@@ -41,13 +42,13 @@ deprecated "'qio_err_t' has been deprecated; please use a 'CTypes.c_int' instead
 extern type qio_err_t = c_int;
 
 /* A system file descriptor. This is really just a `c_int`, but code is
-   clearer if you use fd_t to indicate arguments, variables, and return types
+   clearer if you use c_int to indicate arguments, variables, and return types
    that are system file descriptors.
  */
-extern type fd_t = c_int;
+extern type c_int = c_int;
 
 /* The error code indicating that no error occurred (Chapel specific) */
-inline proc ENOERR return 0:c_int;
+inline proc 0 return 0:c_int;
 
 // end of file
 private extern proc chpl_macro_int_EEOF():c_int;

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -45,10 +45,10 @@ extern type qio_err_t = c_int;
    clearer if you use c_int to indicate arguments, variables, and return types
    that are system file descriptors.
  */
-extern type c_int = c_int;
+extern type fd_t = c_int;
 
 /* The error code indicating that no error occurred (Chapel specific) */
-inline proc 0 return 0:c_int;
+inline proc ENOERR return 0:c_int;
 
 // end of file
 private extern proc chpl_macro_int_EEOF():c_int;

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -12,8 +12,6 @@ ByteBufferHelpers
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.ByteBufferHelpers
 NVStringFactory
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.BytesStringCommon.NVStringFactory
-SysBasic
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.BytesStringCommon.OS.POSIX.SysBasic
 POSIX
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.BytesStringCommon.OS.POSIX
 OS

--- a/test/deprecated/SysBasic/chapel_specific_errors.good
+++ b/test/deprecated/SysBasic/chapel_specific_errors.good
@@ -1,6 +1,7 @@
 chapel_specific_errors.chpl:1: warning: 'SysBasic.EEOF' has been deprecated; please use 'IO.EEOF' instead.
 chapel_specific_errors.chpl:1: warning: 'SysBasic.ESHORT' has been deprecated; please use 'IO.ESHORT' instead.
 chapel_specific_errors.chpl:1: warning: 'SysBasic.EFORMAT' has been deprecated; please use 'IO.EFORMAT' instead.
+chapel_specific_errors.chpl:1: warning: The SysBasic module has been deprecated; most symbols have been moved to IO or OS as appropriate
 chapel_specific_errors.chpl:4: warning: 'SysBasic.EEOF' has been deprecated; please use 'IO.EEOF' instead.
 chapel_specific_errors.chpl:5: warning: 'SysBasic.ESHORT' has been deprecated; please use 'IO.ESHORT' instead.
 chapel_specific_errors.chpl:6: warning: 'SysBasic.EFORMAT' has been deprecated; please use 'IO.EFORMAT' instead.

--- a/test/deprecated/SysBasic/qio_err_t.good
+++ b/test/deprecated/SysBasic/qio_err_t.good
@@ -1,1 +1,2 @@
+qio_err_t.chpl:1: warning: The SysBasic module has been deprecated; most symbols have been moved to IO or OS as appropriate
 qio_err_t.chpl:3: warning: 'qio_err_t' has been deprecated; please use a 'CTypes.c_int' instead.

--- a/test/io/sungeun/ioerror.chpl
+++ b/test/io/sungeun/ioerror.chpl
@@ -1,5 +1,5 @@
 // Test IO error function interfaces
-use IO, OS.POSIX; import SysBasic.{ENOERR};
+use IO, OS.POSIX;
 
 config const testError = 0;
 
@@ -10,10 +10,10 @@ select testError {
   when 3 do ioerror(errorToString(EACCES:errorCode),
                     "EACCES", "this/is/my/path", -1);
   when 4 {
-    writeln(errorToString(ENOERR:errorCode));
-    ioerror(ENOERR:errorCode, "This is a test");
-    ioerror(ENOERR:errorCode, "This is a test", "this/is/my/path");
-    ioerror(ENOERR:errorCode, "This is a test", "this/is/my/path", -1);
+    writeln(errorToString(0:errorCode));
+    ioerror(0:errorCode, "This is a test");
+    ioerror(0:errorCode, "This is a test", "this/is/my/path");
+    ioerror(0:errorCode, "This is a test", "this/is/my/path", -1);
   }
 }
 

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -39,7 +39,6 @@ end of module search dirs
   $CHPL_HOME/modules/packages/Search.chpl
   $CHPL_HOME/modules/packages/CopyAggregation.chpl
   $CHPL_HOME/modules/standard/Communication.chpl
-  $CHPL_HOME/modules/standard/SysBasic.chpl
   $CHPL_HOME/modules/standard/Regex.chpl
   $CHPL_HOME/modules/standard/List.chpl
   $CHPL_HOME/modules/standard/Random.chpl

--- a/test/users/ferguson/err_tmp.chpl
+++ b/test/users/ferguson/err_tmp.chpl
@@ -1,4 +1,3 @@
-use SysBasic;
 use CTypes;
 import OS.{errorCode};
 
@@ -10,14 +9,14 @@ proc doDebugWrite(x, y):c_int {
 }
 
 proc test(arg:string, out error:c_int):bool {
-  error = ENOERR;
+  error = 0;
   on Locales[0] {
     if ! error {
       error = doDebugWrite("test ", arg);
     }
   }
-  return error==ENOERR;
+  return error==0;
 }
 
-var e:c_int = ENOERR;
+var e:c_int = 0;
 test("hello", e);


### PR DESCRIPTION
Resolves #3943.

This deprecates the entire SysBasic module per module review discussion. See meta issue https://github.com/Cray/chapel-private/issues/3467.

Testing:
- [x] paratest