### PR TITLE
Email Enhancements based on the feedback. Part 1.

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -29,7 +29,7 @@ jobs:
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
               echo "LOG=$(echo '[Merge pull request] # ${{github.event.number}} from ${{github.event.pull_request.head.label}}' )" >> $GITHUB_ENV
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
-              echo "SUBJECT= $(echo '[Chapel Merge] ${{github.event.number}}  ${{github.event.pull_request.title}}' )" >> $GITHUB_ENV
+              echo "SUBJECT= $(echo '[Chapel Merge] ${{github.event.pull_request.title}} #${{github.event.number}}' )" >> $GITHUB_ENV
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.
@@ -57,7 +57,7 @@ jobs:
            # Required recipients' addresses:
            to: chapel+commits@discoursemail.com
            # Required sender full name (address can be skipped):
-           from: chapel-lang 
+           from:  ${{env.AUTHOR}}
            html_body: |
               <!DOCTYPE html>
               <html>
@@ -66,16 +66,16 @@ jobs:
               Branch: ${{github.ref}} <br>
               Revision: ${{ github.event.pull_request.merge_commit_sha }}  <br>
               Author: ${{ env.AUTHOR}} <br>
-              Link: ${{env.LOG}} &nbsp;&nbsp;${{github.event.pull_request._links.html.href}} <br>             
+              Link: ${{github.event.pull_request._links.html.href}} <br>             
               Log Message: <br><br>
-                           ${{env.LOG}} <br>
                            ${{env.MESSAGE}} <br>  
                            ${{github.event.pull_request.body}} <br><br>
               Compare: ${{env.COMPARE_URL}} <br> 
               Diff: ${{github.event.pull_request.diff_url}} <br>
-              FilesChanged: ${{env.FILES_CHANGED}} <br><br>
               Modified Files: <br>
-                   ${{steps.changed-files.outputs.all_changed_and_modified_files}} <br><br>
+                   ${{steps.changed-files.outputs.modified_files}} <br><br>
+              Added Files: <br>
+                   ${{steps.changed-files.outputs.added_files}} <br><br>    
               Removed Files: <br>     
                    ${{steps.changed-files.outputs.deleted_files}} <br>
              


### PR DESCRIPTION
Address some of the formatting changes for this issue #3995

- [x] I’d prefer to remove the PR # from the subject line since it pushes the important / human-readable content (the title of the PR) to the right, and potentially off the screen for narrow displays. The PR # seems strictly less important to me since it’s just an arbitrary number. If someone has requested for it to be in the subject, my preference would be to move it to the end (and prefix it with a # to match the GitHub formatting). But for me, I’d just drop it and rely on the PR # and link being in the message of the body, which seems good enough.
       Moved the PR to the end and prefixed with #.

- [x] Speaking of the link in the body, it seems like it’s being prefixed by things like ‘[Merge Pull Request]‘, the PR #, and the branch name, where I’d prefer to just see Link: https://github.com/chapel-lang/chapel/pull/20962 (say). I’m not opposed to the other stuff being somewhere in the message as well, but if they are, I think they deserve their own lines and headers rather than being smooshed into this one (e.g., branch: serial-leader-zip-leads. That said, personally, I don’t think I’d need to refer to the branch name within the body of the mail, and can get the PR # from the link itself, so would probably just drop them.
      Removed extra details and left just the html link to the PR.

- [x] The log message also starts with the prefix ‘[Merge pull request] # 20891 from bradcray:serial-zip-leader-leads’, similar to the ‘Link:’ field as mentioned above. It feels out of place here, as with the Link field. Maybe there’s some helper that’s injecting this text as a prefix for both of these things?

Removed extra details from the log message.

- [x] The 'files changed' list seems somehow wrong or like overkill… On Github, https://github.com/chapel-lang/chapel/pull/20891 shows 27 files changed in its tab, but the mail shows many, many, many more than that. My guess would be that GitHub filters out files changed only by merges of other branches, but that the email script does not? 

Removed files changed link.

- [x] It might be nice to split added and modified apart, that will make it faster to figure out “is this test that broke new”
- [x] we stopped having the sender be "person via Chapel Programming Language" and instead it is "chapel-lang via Chapel Programming Language".