### PR TITLE
Skipif a test that relies on extern block support

### DIFF
--- a/test/extern/ExternBlockClangError.skipif
+++ b/test/extern/ExternBlockClangError.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM == none


### PR DESCRIPTION
Skipif a test that relies on extern block support

This recently added test relies on extern block support, which
requires that CHPL_LLVM != none. Add a skipif.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>