### PR TITLE
Parse the email body and replace newline with <br>

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -27,7 +27,7 @@ jobs:
               echo "LINK=$(jq -r '.[0].html_url' commits.json)" >> $GITHUB_ENV
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
-              echo "LOG=$(echo '[Merge pull request] # ${{github.event.number}} from ${{github.event.pull_request.head.label}}' )" >> $GITHUB_ENV
+              echo "LOG=$(echo '${{github.event.pull_request.body}}' | sed  's/\\n/<br>/g')" >> $GITHUB_ENV
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
               echo "SUBJECT= $(echo '[Chapel Merge] ${{github.event.pull_request.title}} #${{github.event.number}}' )" >> $GITHUB_ENV
       - name: checkout
@@ -69,7 +69,7 @@ jobs:
               Link: ${{github.event.pull_request._links.html.href}} <br>             
               Log Message: <br><br>
                            ${{env.MESSAGE}} <br>  
-                           ${{github.event.pull_request.body}} <br><br>
+                           ${{env.LOG}} <br>
               Compare: ${{env.COMPARE_URL}} <br> 
               Diff: ${{github.event.pull_request.diff_url}} <br>
               Modified Files: <br>


### PR DESCRIPTION
Part 2 to address https://github.com/Cray/chapel-private/issues/3995

- [x]  In the merge message quoted in the mail, newlines/paragraphs seem to be lost.I think it’s important to preserve these linefeeds in the mail for readability.