### PR TITLE
Update triadchpl.good file

### DIFF
--- a/test/gpu/native/studies/shoc/triadchpl.good
+++ b/test/gpu/native/studies/shoc/triadchpl.good
@@ -1,1 +1,1 @@
-(kernel_launch = 5)
+(kernel_launch = 4)


### PR DESCRIPTION
I should have done this in PR #20961. That PR modified the Chapelastic triad benchmark to not initialize the 'A' and 'B' vectors of the computation in a kernel. As such I should have update the .good file to expect one less kernel launch.