### PR TITLE
Hide stderr for Mason's `runCommand`

### DIFF
--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -101,13 +101,17 @@ proc runCommand(cmd, quiet=false) : string throws {
   try {
 
     var splitCmd = cmd.split();
-    var process = spawn(splitCmd, stdout=pipeStyle.pipe);
+    var process = spawn(splitCmd, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
 
-    for line in process.stdout.lines() {
+    var line:string;
+    while process.stdout.readLine(line) {
       ret += line;
       if !quiet {
         write(line);
       }
+    }
+    if !quiet {
+      while process.stderr.readLine(line) do write(line);
     }
     process.wait();
   }


### PR DESCRIPTION
There are some mason tests that are currently sensitive to stderr, so in this PR we are piping the stderr and then not displaying when quiet=true for the `runCommand` procedure, which should make the tests no longer fail from git warnings.