### PR TITLE
Improve openssl skipifs and adjust Crypto package module

### DIFF
--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -136,8 +136,29 @@ module Crypto {
         halt("Enter a string with length greater than 0 in order to create a buffer");
       }
       this.buffDomain = {0..<this._len};
-      for i in this.buffDomain do {
-        this.buff[i] = s.byte(i);
+      for (elt, b) in zip(this.buff, s.bytes()) {
+        elt = b;
+      }
+    }
+    /* The `CryptoBuffer` class initializer that initializes the buffer
+       when a `bytes` is supplied to it.
+
+       :arg s: `bytes` input for buffer conversion.
+       :type s: `bytes`
+
+       :return: An object of class `CryptoBuffer`.
+       :rtype: `CryptoBuffer`
+
+    */
+    proc init(s: bytes) {
+      this.complete();
+      this._len = s.numBytes;
+      if (this._len == 0) {
+        halt("Enter a string with length greater than 0 in order to create a buffer");
+      }
+      this.buffDomain = {0..<this._len};
+      for (elt, b) in zip(this.buff, s.bytes()) {
+        elt = b;
       }
     }
 
@@ -774,7 +795,13 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
 
      - ``ofb`` or `Output Feedback`
 
+     .. note:
+
+       This cipher is removed in OpenSSL 3 and therefore deprecated here as
+       well. The deprecated Blowfish support here does not function with OpenSSL
+       3.
   */
+  deprecated "Blowfish is deprecated, please use another algorithm"
   class Blowfish {
     pragma "no doc"
     var cipher: CONST_EVP_CIPHER_PTR;

--- a/test/library/packages/Crypto.skipif
+++ b/test/library/packages/Crypto.skipif
@@ -2,8 +2,6 @@
 
 import os
 import subprocess
-from pkg_resources import parse_version
-
 
 platform = os.getenv('CHPL_TARGET_PLATFORM')
 

--- a/test/library/packages/Crypto.skipif
+++ b/test/library/packages/Crypto.skipif
@@ -12,14 +12,8 @@ Ok = False
 if platform != 'linux64':
     Ok = False  # not linux
 else:
-    sub = subprocess.run(['pkg-config', '--modversion', 'libcrypto'],
-                         capture_output=True)
+    sub = subprocess.run(['pkg-config', '--exists', 'libcrypto >= 1.1'])
     if sub.returncode == 0:
-        v = sub.stdout
-        v = v.strip()
-        v = str(v, encoding='utf-8', errors='surrogateescape')
-        if v == "1.1.1k" or parse_version(v) >= parse_version('1.1'):
-            # OK, version is compatible.
-            Ok = True
+        Ok = True
 
 print(not Ok)

--- a/test/library/packages/Crypto.skipif
+++ b/test/library/packages/Crypto.skipif
@@ -16,10 +16,9 @@ else:
                          capture_output=True)
     if sub.returncode == 0:
         v = sub.stdout
-        v = v.rstrip()
+        v = v.strip()
         v = str(v, encoding='utf-8', errors='surrogateescape')
-
-        if parse_version(v) >= parse_version('1.1'):
+        if v == "1.1.1k" or parse_version(v) >= parse_version('1.1'):
             # OK, version is compatible.
             Ok = True
 

--- a/test/library/packages/Crypto/blowfish.skipif
+++ b/test/library/packages/Crypto/blowfish.skipif
@@ -15,10 +15,10 @@ else:
                          capture_output=True)
     if sub.returncode == 0:
         v = sub.stdout
-        v = v.rstrip()
+        v = v.strip()
         v = str(v, encoding='utf-8', errors='surrogateescape')
 
-        if parse_version(v) < parse_version('3.0'):
+        if v == "1.1.1k" or parse_version(v) < parse_version('3.0'):
             # blowfish was moved to legacy in OpenSSL 3 and doesn't work
             # in the crypto module
             Ok = True

--- a/test/library/packages/Crypto/blowfish.skipif
+++ b/test/library/packages/Crypto/blowfish.skipif
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-from pkg_resources import parse_version
 
 platform = os.getenv('CHPL_TARGET_PLATFORM')
 

--- a/test/library/packages/Crypto/blowfish.skipif
+++ b/test/library/packages/Crypto/blowfish.skipif
@@ -4,7 +4,6 @@ import os
 import subprocess
 from pkg_resources import parse_version
 
-
 platform = os.getenv('CHPL_TARGET_PLATFORM')
 
 Ok = False
@@ -19,8 +18,9 @@ else:
         v = v.rstrip()
         v = str(v, encoding='utf-8', errors='surrogateescape')
 
-        if parse_version(v) >= parse_version('1.1'):
-            # OK, version is compatible.
+        if parse_version(v) < parse_version('3.0'):
+            # blowfish was moved to legacy in OpenSSL 3 and doesn't work
+            # in the crypto module
             Ok = True
 
 print(not Ok)

--- a/test/library/packages/Crypto/blowfish.skipif
+++ b/test/library/packages/Crypto/blowfish.skipif
@@ -11,16 +11,10 @@ Ok = False
 if platform != 'linux64':
     Ok = False  # not linux
 else:
-    sub = subprocess.run(['pkg-config', '--modversion', 'libcrypto'],
-                         capture_output=True)
+    # blowfish was moved to legacy in OpenSSL 3 and doesn't work
+    # in the crypto module
+    sub = subprocess.run(['pkg-config', '--exists', 'libcrypto < 3.0'])
     if sub.returncode == 0:
-        v = sub.stdout
-        v = v.strip()
-        v = str(v, encoding='utf-8', errors='surrogateescape')
-
-        if v == "1.1.1k" or parse_version(v) < parse_version('3.0'):
-            # blowfish was moved to legacy in OpenSSL 3 and doesn't work
-            # in the crypto module
-            Ok = True
+        Ok = True
 
 print(not Ok)

--- a/test/library/packages/Crypto/blowfish/bfTest1.good
+++ b/test/library/packages/Crypto/blowfish/bfTest1.good
@@ -1,3 +1,5 @@
+bfTest1.chpl:1: In function 'main':
+bfTest1.chpl:4: warning: Blowfish is deprecated, please use another algorithm
 MSG: 68 65 6c 6c 6f 20 77 6f 72 6c 64
 CT: 64 16 02 e7 e5 fd 4c b4 8b 46 bb e2 69 16 55 2b
 PT: 68 65 6c 6c 6f 20 77 6f 72 6c 64

--- a/test/library/packages/Crypto/blowfish/bfTest2.good
+++ b/test/library/packages/Crypto/blowfish/bfTest2.good
@@ -1,3 +1,5 @@
+bfTest2.chpl:3: In function 'main':
+bfTest2.chpl:6: warning: Blowfish is deprecated, please use another algorithm
 Generated Key: c1 75 99 d8 24 84 cd a5 3f 23 a1 9a ba 6c 05 0f
 Generated IV: 69 76 31 32 33 34 35 36
 Original Message: 74 65 73 74 20 73 74 72 69 6e 67

--- a/test/studies/dedup/dedup-extern.skipif
+++ b/test/studies/dedup/dedup-extern.skipif
@@ -11,15 +11,8 @@ Ok = False
 if platform != 'linux64':
     Ok = False  # not linux
 else:
-    sub = subprocess.run(['pkg-config', '--modversion', 'libcrypto'],
-                         capture_output=True)
+    sub = subprocess.run(['pkg-config', '--exists', 'libcrypto >= 1.1'])
     if sub.returncode == 0:
-        v = sub.stdout
-        v = v.strip()
-        v = str(v, encoding='utf-8', errors='surrogateescape')
-
-        if v == "1.1.1k" or parse_version(v) >= parse_version('1.1'):
-            # OK, version is compatible.
-            Ok = True
+        Ok = True
 
 print(not Ok)

--- a/test/studies/dedup/dedup-extern.skipif
+++ b/test/studies/dedup/dedup-extern.skipif
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-from pkg_resources import parse_version
 
 platform = os.getenv('CHPL_TARGET_PLATFORM')
 

--- a/test/studies/dedup/dedup-extern.skipif
+++ b/test/studies/dedup/dedup-extern.skipif
@@ -15,10 +15,10 @@ else:
                          capture_output=True)
     if sub.returncode == 0:
         v = sub.stdout
-        v = v.rstrip()
+        v = v.strip()
         v = str(v, encoding='utf-8', errors='surrogateescape')
 
-        if parse_version(v) >= parse_version('1.1'):
+        if v == "1.1.1k" or parse_version(v) >= parse_version('1.1'):
             # OK, version is compatible.
             Ok = True
 

--- a/test/studies/dedup/dedup-extern.skipif
+++ b/test/studies/dedup/dedup-extern.skipif
@@ -1,1 +1,25 @@
-CHPL_TARGET_PLATFORM != linux64
+#!/usr/bin/env python3
+
+import os
+import subprocess
+from pkg_resources import parse_version
+
+platform = os.getenv('CHPL_TARGET_PLATFORM')
+
+Ok = False
+
+if platform != 'linux64':
+    Ok = False  # not linux
+else:
+    sub = subprocess.run(['pkg-config', '--modversion', 'libcrypto'],
+                         capture_output=True)
+    if sub.returncode == 0:
+        v = sub.stdout
+        v = v.rstrip()
+        v = str(v, encoding='utf-8', errors='surrogateescape')
+
+        if parse_version(v) >= parse_version('1.1'):
+            # OK, version is compatible.
+            Ok = True
+
+print(not Ok)

--- a/test/studies/dedup/dedup-externblock.skipif
+++ b/test/studies/dedup/dedup-externblock.skipif
@@ -2,8 +2,6 @@
 
 import os
 import subprocess
-from pkg_resources import parse_version
-
 
 llvm = os.getenv('CHPL_LLVM')
 platform = os.getenv('CHPL_TARGET_PLATFORM')

--- a/test/studies/dedup/dedup-externblock.skipif
+++ b/test/studies/dedup/dedup-externblock.skipif
@@ -13,11 +13,15 @@ Ok = False
 if llvm == 'none' or platform != 'linux64':
     Ok = False  # not linux / no llvm
 else:
-    output = subprocess.check_output(['openssl', 'version']).rstrip()
-    output = str(output, encoding='utf-8', errors='surrogateescape')
-    output = output.replace("OpenSSL", "")
-    output = output.strip()
-    if parse_version(output) >= parse_version('1.1'):
-        Ok = True
+    sub = subprocess.run(['pkg-config', '--modversion', 'libcrypto'],
+                         capture_output=True)
+    if sub.returncode == 0:
+        v = sub.stdout
+        v = v.rstrip()
+        v = str(v, encoding='utf-8', errors='surrogateescape')
+
+        if parse_version(v) >= parse_version('1.1'):
+            # OK, version is compatible.
+            Ok = True
 
 print(not Ok)

--- a/test/studies/dedup/dedup-externblock.skipif
+++ b/test/studies/dedup/dedup-externblock.skipif
@@ -17,10 +17,10 @@ else:
                          capture_output=True)
     if sub.returncode == 0:
         v = sub.stdout
-        v = v.rstrip()
+        v = v.strip()
         v = str(v, encoding='utf-8', errors='surrogateescape')
 
-        if parse_version(v) >= parse_version('1.1'):
+        if v == "1.1.1k" or parse_version(v) >= parse_version('1.1'):
             # OK, version is compatible.
             Ok = True
 

--- a/test/studies/dedup/dedup-externblock.skipif
+++ b/test/studies/dedup/dedup-externblock.skipif
@@ -13,15 +13,8 @@ Ok = False
 if llvm == 'none' or platform != 'linux64':
     Ok = False  # not linux / no llvm
 else:
-    sub = subprocess.run(['pkg-config', '--modversion', 'libcrypto'],
-                         capture_output=True)
+    sub = subprocess.run(['pkg-config', '--exists', 'libcrypto >= 1.1'])
     if sub.returncode == 0:
-        v = sub.stdout
-        v = v.strip()
-        v = str(v, encoding='utf-8', errors='surrogateescape')
-
-        if v == "1.1.1k" or parse_version(v) >= parse_version('1.1'):
-            # OK, version is compatible.
-            Ok = True
+        Ok = True
 
 print(not Ok)


### PR DESCRIPTION
* Improves skipifs for tests using openssl to skip if libcrypto isn't installed and to work with openssl version 1.1.1k
* Adjusts CryptoBuffer.init(string) to work correctly with Unicode and added a bytes version
* Deprecated Blowfish support in Crypto because
  * it does not work as written in OpenSSL 3
  * Blowfish is considered legacy in OpenSSL 3

`start_test test/studies/dedup/dedup-extern.chpl  test/studies/dedup/dedup-externblock.chpl  test/library/packages/Crypto --respect-skipifs` passes:

- [x] with no libcrypto installed, everything is skipped
- [x] with OpenSSL 3, skipping the Blowfish tests
- [x] with OpenSSL 1.1.k

Reviewed by @ronawho - thanks!