### PR TITLE
Fix- Email workflow failure to parse LOG

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -27,7 +27,7 @@ jobs:
               echo "LINK=$(jq -r '.[0].html_url' commits.json)" >> $GITHUB_ENV
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
-              echo "LOG=$(echo '${{github.event.pull_request.body}}' | sed  's/\\n/<br>/g')" >> $GITHUB_ENV
+              echo "LOG=$(echo '${{github.event.pull_request.body}} | sed  's/\\n/<br>/g' ')" >> $GITHUB_ENV
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
               echo "SUBJECT= $(echo '[Chapel Merge] ${{github.event.pull_request.title}} #${{github.event.number}}' )" >> $GITHUB_ENV
       - name: checkout


### PR DESCRIPTION
 Add a single quote around the LOG env.

Issue: Unable to process file command 'env' successfully.
