### PR TITLE
 Add the Log message back in the email body.

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -27,7 +27,6 @@ jobs:
               echo "LINK=$(jq -r '.[0].html_url' commits.json)" >> $GITHUB_ENV
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
-              echo "LOG=$(echo '${{github.event.pull_request.body}} | sed  's/\\n/<br>/g' ')" >> $GITHUB_ENV
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
               echo "SUBJECT= $(echo '[Chapel Merge] ${{github.event.pull_request.title}} #${{github.event.number}}' )" >> $GITHUB_ENV
       - name: checkout
@@ -68,8 +67,7 @@ jobs:
               Author: ${{ env.AUTHOR}} <br>
               Link: ${{github.event.pull_request._links.html.href}} <br>             
               Log Message: <br><br>
-                           ${{env.MESSAGE}} <br>  
-                           ${{env.LOG}} <br>
+                           ${{env.MESSAGE}} <br> 
                            ${{github.event.pull_request.body}} <br>
               Compare: ${{env.COMPARE_URL}} <br> 
               Diff: ${{github.event.pull_request.diff_url}} <br>

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -70,6 +70,7 @@ jobs:
               Log Message: <br><br>
                            ${{env.MESSAGE}} <br>  
                            ${{env.LOG}} <br>
+                           ${{github.event.pull_request.body}} <br>
               Compare: ${{env.COMPARE_URL}} <br> 
               Diff: ${{github.event.pull_request.diff_url}} <br>
               Modified Files: <br>


### PR DESCRIPTION
To address one of the comments in the issue https://github.com/Cray/chapel-private/issues/3995 to preserve the newline a change was merged, but the email client does not honor the <br> tags added.

Putting back the log in the email body while we figure out how to send multi line git actions ENV to an email body.