### PR TITLE
Fix problems with Socket module and adjust skipifs

### DIFF
--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -263,7 +263,7 @@ type tcpConn = file;
 proc tcpConn.socketFd throws {
   var tempfd:c_int;
   var err:errorCode = 0;
-  on this.home {
+  on this._home {
     var localtempfd = tempfd;
     err = qio_get_fd(this._file_internal, localtempfd);
     if err then try ioerror(err, "in tcpConn.socketFd");
@@ -279,7 +279,7 @@ proc tcpConn.socketFd throws {
 */
 proc tcpConn.addr throws {
   var address:ipAddr;
-  on this.home {
+  on this._home {
     address = getPeerName(this.socketFd);
   }
   return address;

--- a/test/library/packages/Socket.skipif
+++ b/test/library/packages/Socket.skipif
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-from pkg_resources import parse_version
 
 platform = os.getenv('CHPL_TARGET_PLATFORM')
 tasks = os.getenv('CHPL_TASKS')

--- a/test/library/packages/Socket.skipif
+++ b/test/library/packages/Socket.skipif
@@ -5,22 +5,18 @@ import subprocess
 from pkg_resources import parse_version
 
 platform = os.getenv('CHPL_TARGET_PLATFORM')
+tasks = os.getenv('CHPL_TASKS')
+comp = os.getenv('CHPL_TARGET_COMPILER')
 
-skip = False
+skip = True
 
 if platform != 'linux64':
-    skip = True
+    skip = True # only test on linux
+elif tasks == 'fifo' or comp == 'llvm':
+    skip = True # these configurations don't currently work
 else:
-    v = subprocess.check_output(['pkg-config', '--modversion', 'libevent'])
-    v = v.rstrip()
-    v = str(v, encoding='utf-8', errors='surrogateescape')
-
-    if parse_version(v.split('-')[0]) < parse_version('2.1'):
-        # skip, version not is compatible.
-        skip = True
-
-    if os.getenv('CHPL_TASKS') == 'fifo' or os.getenv('CHPL_TARGET_COMPILER') == 'llvm':
-        skip = True
-
+    sub = subprocess.run(['pkg-config', '--exists', 'libevent >= 2.1'])
+    if sub.returncode == 0:
+      skip = False # libevent exists and is new enough
 
 print(skip)

--- a/test/library/packages/Socket/ipv6/connect_timeout_ipv6.chpl
+++ b/test/library/packages/Socket/ipv6/connect_timeout_ipv6.chpl
@@ -1,5 +1,6 @@
 use UnitTest;
 use Socket;
+use OS.POSIX;
 
 proc test_success_ipv6(test: borrowed Test) throws {
   var port:uint(16) = 8822;
@@ -10,7 +11,7 @@ proc test_success_ipv6(test: borrowed Test) throws {
     begin {
       var conn = server.accept();
     }
-    var conn = connect(address, new timeval(2,0));
+    var conn = connect(address, new struct_timeval(2,0));
     test.assertEqual(conn.addr, address);
   }
 }
@@ -24,7 +25,7 @@ proc test_fail_backlog_ipv6(test: borrowed Test) throws {
   var failures = 0;
   coforall x in 1..20 with (+ reduce failures) do {
     try {
-      var conn = connect(address, new timeval(1, 0));
+      var conn = connect(address, new struct_timeval(1, 0));
     }
     catch e {
       failures += 1;

--- a/test/library/packages/Socket/ipv6/udpio_ipv6.chpl
+++ b/test/library/packages/Socket/ipv6/udpio_ipv6.chpl
@@ -1,5 +1,6 @@
 use UnitTest;
 use Socket;
+use OS.POSIX;
 
 proc test_send_recv(test: borrowed Test) throws {
   var host = "::1";
@@ -52,7 +53,7 @@ proc test_send_recv_timed(test: borrowed Test) throws {
       var sentBytes = sender.send(sent, address);
       test.assertEqual(sentBytes, sent.size);
     }
-    received = receiver.recv(sent.size, new timeval(2,0));
+    received = receiver.recv(sent.size, new struct_timeval(2,0));
     test.assertEqual(received, sent);
   }
 }
@@ -71,7 +72,7 @@ proc test_send_recv_from_timed(test: borrowed Test) throws {
       var sentBytes = sender.send(sent, receiverAddress);
       test.assertEqual(sentBytes, sent.size);
     }
-    var (received, receivedAddress) = receiver.recvfrom(sent.size, new timeval(2,0));
+    var (received, receivedAddress) = receiver.recvfrom(sent.size, new struct_timeval(2,0));
     test.assertEqual(received, sent);
     test.assertEqual(receivedAddress, sender.addr);
   }
@@ -93,7 +94,7 @@ proc test_recv_timeout(test: borrowed Test) throws {
   bind(receiver, receiverAddress);
   var sent = b"hello";
   try {
-    var received = receiver.recv(sent.size, new timeval(2,0));
+    var received = receiver.recv(sent.size, new struct_timeval(2,0));
     test.assertEqual(-1,0);
   } catch e:TimeoutError {
     test.assertEqual(e.message(), "Connection timed out (recv timed out)");
@@ -107,7 +108,7 @@ proc test_recv_from_timeout(test: borrowed Test) throws {
   bind(receiver, receiverAddress);
   var sent = b"hello";
   try {
-    var (received, receivedAddress) = receiver.recvfrom(sent.size, new timeval(2,0));
+    var (received, receivedAddress) = receiver.recvfrom(sent.size, new struct_timeval(2,0));
     test.assertEqual(-1,0);
   } catch e:TimeoutError {
     test.assertEqual(e.message(), "Connection timed out (recv timed out)");


### PR DESCRIPTION
Similar to PR #21013.

This PR:
 * Fixes some compilation failures from the Socket module and tests
 * Adjust the skipif to better handle libevent missing entirely

`CHPL_TARGET_PLATFORM=linux64 CHPL_TARGET_COMPILER=gnu start_test test/library/packages/Socket` works in several configurations:

- [x] all tests are skipped if libevent is not installed
- [x] tests run and pass with libevent 2.1.12
- [x] all tests are skipped with libevent 2.0.21

Reviewed by @ronawho - thanks!