### PR TITLE
Fix up dyno scope resolution for  constrained generics

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2891,6 +2891,7 @@ struct Converter {
 
     auto isym = InterfaceSymbol::buildDef(name, formals, body);
     auto ret = buildChapelStmt(isym);
+    noteConvertedSym(node, isym->sym);
 
     return ret;
   }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2873,20 +2873,15 @@ struct Converter {
     auto style = uast::BlockStyle::EXPLICIT;
     BlockStmt* body = createBlockWithStmts(node->stmts(), style);
 
-    if (node->isFormalListPresent()) {
-      for (auto formal : node->formals()) {
-        if (auto ident = formal->toIdentifier()) {
-          const char* name = astr(ident->name());
-          auto formal = InterfaceSymbol::buildFormal(name, INTENT_TYPE);
-          formals->insertAtTail(formal);
-        } else {
-          INT_FATAL("Expected identifier for interface formal");
-        }
+    for (auto formal : node->formals()) {
+      if (auto ident = formal->toIdentifier()) {
+        const char* name = astr(ident->name());
+        auto formal = InterfaceSymbol::buildFormal(name, INTENT_TYPE);
+        formals->insertAtTail(formal);
+        noteConvertedSym(ident, formal->sym);
+      } else {
+        INT_FATAL("Expected identifier for interface formal");
       }
-    } else {
-      INT_ASSERT(node->numFormals() == 0);
-      DefExpr* formal = InterfaceSymbol::buildFormal("Self", INTENT_TYPE);
-      formals->insertAtTail(formal);
     }
 
     auto isym = InterfaceSymbol::buildDef(name, formals, body);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2873,14 +2873,14 @@ struct Converter {
     auto style = uast::BlockStyle::EXPLICIT;
     BlockStmt* body = createBlockWithStmts(node->stmts(), style);
 
-    for (auto formal : node->formals()) {
-      if (auto ident = formal->toIdentifier()) {
-        const char* name = astr(ident->name());
-        auto formal = InterfaceSymbol::buildFormal(name, INTENT_TYPE);
-        formals->insertAtTail(formal);
-        noteConvertedSym(ident, formal->sym);
+    for (auto ast : node->formals()) {
+      if (auto formal = ast->toFormal()) {
+        const char* name = astr(formal->name());
+        auto ifcFormal = InterfaceSymbol::buildFormal(name, INTENT_TYPE);
+        formals->insertAtTail(ifcFormal);
+        noteConvertedSym(formal, ifcFormal->sym);
       } else {
-        INT_FATAL("Expected identifier for interface formal");
+        INT_FATAL("Interface formal is not represented by a formal AST node!");
       }
     }
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -174,48 +174,36 @@ static void handleReceiverFormals() {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
 
     if (fn->_this == NULL) continue; // not a method
+    SET_LINENO(fn->_this);
 
     if (fn->_this->type == dtUnknown) {
       Expr* stmt = toArgSymbol(fn->_this)->typeExpr->body.only();
 
-      if (UnresolvedSymExpr* sym = toUnresolvedSymExpr(stmt)) {
-        SET_LINENO(fn->_this);
-
-        Symbol* rsym = lookup(sym->unresolved, sym);
-        if (TypeSymbol* ts = toTypeSymbol(rsym)) {
-          sym->replace(new SymExpr(ts));
-
-          fn->_this->type = ts->type;
-          fn->_this->type->methods.add(fn);
-
-          AggregateType::setCreationStyle(ts, fn);
-
-        } else if (InterfaceSymbol* isym = toInterfaceSymbol(rsym)) {
-          // Convert fn(this: IFC, ...) to
-          //   fn(this: ?t_IFC, ...) where t_IFC implements IFC
-          TypeSymbol* ctSym = desugarInterfaceAsType(fn,
-                                toArgSymbol(fn->_this), sym, isym);
-          sym->replace(new SymExpr(ctSym));
-          fn->_this->type = ctSym->type;
-          recordIfcThis(isym, fn, ctSym);
-        }
-
-      } else if (SymExpr* sym = toSymExpr(stmt)) {
-        if (InterfaceSymbol* isym = toInterfaceSymbol(sym->symbol())) {
-          // Convert fn(this: IFC, ...) to
-          //   fn(this: ?t_IFC, ...) where t_IFC implements IFC
-          TypeSymbol* ctSym = desugarInterfaceAsType(fn,
-                                toArgSymbol(fn->_this), sym, isym);
-          fn->_this->type = ctSym->type;
-          recordIfcThis(isym, fn, ctSym);
-        } else {
-          fn->_this->type = sym->symbol()->type;
-          fn->_this->type->methods.add(fn);
-
-          AggregateType::setCreationStyle(sym->symbol()->type->symbol, fn);
-        }
+      UnresolvedSymExpr* unresolvedSymExpr = toUnresolvedSymExpr(stmt);
+      Symbol* symbol = nullptr;
+      if (unresolvedSymExpr) {
+        symbol = lookup(unresolvedSymExpr->unresolved, unresolvedSymExpr);
+      } else if (SymExpr* symExpr = toSymExpr(stmt)) {
+        symbol = symExpr->symbol();
       }
 
+      if (TypeSymbol* ts = toTypeSymbol(symbol)) {
+        if (unresolvedSymExpr) unresolvedSymExpr->replace(new SymExpr(ts));
+
+        fn->_this->type = ts->type;
+        fn->_this->type->methods.add(fn);
+
+        AggregateType::setCreationStyle(ts, fn);
+
+      } else if (InterfaceSymbol* isym = toInterfaceSymbol(symbol)) {
+        // Convert fn(this: IFC, ...) to
+        //   fn(this: ?t_IFC, ...) where t_IFC implements IFC
+        TypeSymbol* ctSym = desugarInterfaceAsType(fn,
+                              toArgSymbol(fn->_this), stmt, isym);
+        if (unresolvedSymExpr) unresolvedSymExpr->replace(new SymExpr(ctSym));
+        fn->_this->type = ctSym->type;
+        recordIfcThis(isym, fn, ctSym);
+      }
     } else {
       AggregateType::setCreationStyle(fn->_this->type->symbol, fn);
     }

--- a/frontend/include/chpl/uast/Interface.h
+++ b/frontend/include/chpl/uast/Interface.h
@@ -51,7 +51,7 @@ class Interface final : public NamedDecl {
   int numInterfaceFormals_;
   int bodyChildNum_;
   int numBodyStmts_;
-  bool isFormalListPresent_;
+  bool isFormalListExplicit_;
 
   Interface(AstList children, int attributesChildNum,
             Visibility visibility,
@@ -60,7 +60,7 @@ class Interface final : public NamedDecl {
             int numInterfaceFormals,
             int bodyChildNum,
             int numBodyStmts,
-            bool isFormalListPresent)
+            bool isFormalListExplicit)
       : NamedDecl(asttags::Interface, std::move(children),
                   attributesChildNum,
                   visibility,
@@ -71,7 +71,7 @@ class Interface final : public NamedDecl {
         numInterfaceFormals_(numInterfaceFormals),
         bodyChildNum_(bodyChildNum),
         numBodyStmts_(numBodyStmts),
-        isFormalListPresent_(isFormalListPresent) {
+        isFormalListExplicit_(isFormalListExplicit) {
     // TODO: Some assertions here...
   }
 
@@ -83,7 +83,7 @@ class Interface final : public NamedDecl {
       lhs->numInterfaceFormals_ == rhs->numInterfaceFormals_ &&
       lhs->bodyChildNum_ == rhs->bodyChildNum_ &&
       lhs->numBodyStmts_ == rhs->numBodyStmts_ &&
-      lhs->isFormalListPresent_ == rhs->isFormalListPresent_;
+      lhs->isFormalListExplicit_ == rhs->isFormalListExplicit_;
   }
 
   void markUniqueStringsInner(Context* context) const override {
@@ -109,8 +109,8 @@ class Interface final : public NamedDecl {
 
     The formal list '(T)' is present, so this method returns 'true'.
   */
-  bool isFormalListPresent() const {
-    return isFormalListPresent_;
+  bool isFormalListExplicit() const {
+    return isFormalListExplicit_;
   }
 
   /**
@@ -180,7 +180,7 @@ class Interface final : public NamedDecl {
                                 owned<Attributes> attributes,
                                 Decl::Visibility visibility,
                                 UniqueString name,
-                                bool isFormalListPresent,
+                                bool isFormalListExplicit,
                                 AstList formals,
                                 AstList body);
 };

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -2554,7 +2554,14 @@ CommentsAndStmt ParserContext::buildInterfaceStmt(YYLTYPE location,
                     locBody,
                     body);
 
-  AstList formalList = formals ? consumeList(formals) : AstList();
+  AstList formalList;
+  if (formals != nullptr) {
+    formalList = consumeList(formals);
+  } else {
+    auto selfStr = PODUniqueString::get(context(), "Self");
+    formalList.push_back(toOwned(buildInterfaceFormal(location, selfStr)));
+  }
+
   AstList bodyStmts = bodyExprLst
       ? consumeAndFlattenTopLevelBlocks(bodyExprLst)
       : AstList();

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -2537,7 +2537,10 @@ ParserContext::buildSelectStmt(YYLTYPE location, owned<AstNode> expr,
 
 AstNode* ParserContext::buildInterfaceFormal(YYLTYPE location,
                                              PODUniqueString name) {
-  return buildIdent(location, name);
+  return buildFormal(location, Formal::Intent::TYPE, name,
+                    /* typeExpr */ nullptr,
+                    /* initExpr */ nullptr,
+                    /* consumeAttributes */ false);
 }
 
 CommentsAndStmt ParserContext::buildInterfaceStmt(YYLTYPE location,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -162,6 +162,7 @@ scopeResolveModule(Context* context, ID id) {
             child->isTypeDecl() ||
             child->isFunction() ||
             child->isModule() ||
+            child->isInterface() ||
             child->isUse() ||
             child->isImport()) {
           // ignore this statement since it is not relevant to

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -141,6 +141,7 @@ bool Builder::astTagIndicatesNewIdScope(asttags::AstTag tag) {
   return asttags::isNamedDecl(tag) &&
         (asttags::isFunction(tag) ||
          asttags::isModule(tag) ||
+         asttags::isInterface(tag) ||
          asttags::isTypeDecl(tag));
 }
 

--- a/frontend/test/parsing/testParseInterface.cpp
+++ b/frontend/test/parsing/testParseInterface.cpp
@@ -43,7 +43,7 @@ static void test0(Parser* parser) {
   assert(mod->stmt(2)->isComment());
   auto intf = mod->stmt(1)->toInterface();
   assert(intf);
-  assert(intf->isFormalListPresent());
+  assert(intf->isFormalListExplicit());
   assert(intf->numFormals() == 3);
   assert(intf->numStmts() == 1);
   assert(intf->stmt(0)->isFunction());


### PR DESCRIPTION
This PR addresses some of the `--dyno` failures related to scope resolution. In
particular:

- __`scopeResolve.cpp` didn't know what to do with resolved interfaces.__. This
  issue came up when interface names were used for defining secondary methods,
  like `proc MyInterface.foo`. Whereas the old compiler leaves `MyInterface`
  unresolved, Dyno already determines that `MyInterface` is an
  `InterfaceSymbol`. The code in `scopeResolve` assumed that the only time a
  receiver is defined is when it was a record, causing issues. This PR modifies
  code in `scopeResolve.cpp` to properly handle the receiver being a `SymExpr`
  pointing to an interface.
- __Interface formals weren't considered declarations.__. This was because the
  interface formals were represented by `Identifier`s, and thus skipped when
  gathering variables. This meant that a variable defined outside of an
  interface that shadows the interface's `Self` type would be found instead of
  the type itself.  This PR addresses this in two ways:
    1. Converting the AST nodes representing interface formals from
       `Identifier`s to `Formal`s.
    2. Always inserting the (sometimes implicit) `Self` formal into the Dyno
       AST, so that it's picked up during declaration gathering.
- __`InterfaceSymbol` conversion wasn't noted__. A simple mental typo, fixed by
  adding `noteConvertedSymbol`.
- __`InterfaceSymbol::buildDef` led to broken scope resolution__. When the
  statements inside the `InterfaceSymbol` are scope-resolved, associated types
  are left as variable declarations. However, `buildDef` mangles the AST,
  replacing the variables with new `TypeSymbols`. This broke `SymExpr` nodes
  that referred to the variables that were removed from the tree. This PR fixes
  this by leaving references to associated types as `TemporaryConversionSymbol`s,
  and re-running `noteConvertedSymbol` after the mangling has been completed.

TESTING
- [x] full local
- [x] with `--dyno` (148 failures, down from 157 on main)