### PR TITLE
Add gpuClock() function to GPU module

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -37,6 +37,19 @@ module GPU
   pragma "codegen for CPU and GPU"
   extern proc chpl_gpu_write(const str : c_string) : void;
 
+  pragma "no doc"
+  pragma "codegen for CPU and GPU"
+  extern proc chpl_gpu_clock() : uint;
+
+  pragma "no doc"
+  pragma "codegen for CPU and GPU"
+  extern proc chpl_gpu_printTimeDelta(
+    msg : c_string, start : uint, stop : uint) : void;
+
+  pragma "no doc"
+  pragma "codegen for CPU and GPU"
+  extern proc chpl_gpu_device_clock_rate(devNum : int(32)) : uint;
+
   /*
      This function is intended to be called from within a GPU kernel and is
      useful for debugging purposes.
@@ -90,5 +103,32 @@ module GPU
   pragma "always propagate line file info"
   inline proc assertOnGpu() {
     __primitive("chpl_assert_on_gpu");
+  }
+
+  /*
+    Returns value of a per-multiprocessor counter that increments every clock cycle
+  */
+  pragma "no doc"
+  proc gpuClock() : uint {
+    return chpl_gpu_clock();
+  }
+
+  /*
+    Prints 'msg' followed by the difference between 'stop' and 'stop'. Meant to
+    print the time ellapsed between subsequent calls to 'gpuClock()'.
+    To convert to seconds divide by 'gpuClocksPerSec()'
+  */
+  pragma "no doc"
+  proc gpuPrintTimeDelta(msg : c_string, start : uint, stop : uint) : void {
+    chpl_gpu_printTimeDelta(msg, start, stop);
+  }
+
+  /*
+    Returns the number of clock cycles per second of a GPU multiprocessor.
+    Currently we don't support calling this function from within a kernel.
+   */
+  pragma "no doc"
+  proc gpuClocksPerSec(devNum : int) {
+    return chpl_gpu_device_clock_rate(devNum : int(32));
   }
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -114,7 +114,7 @@ module GPU
   }
 
   /*
-    Prints 'msg' followed by the difference between 'stop' and 'stop'. Meant to
+    Prints 'msg' followed by the difference between 'stop' and 'start'. Meant to
     print the time ellapsed between subsequent calls to 'gpuClock()'.
     To convert to seconds divide by 'gpuClocksPerSec()'
   */

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -80,6 +80,8 @@ void chpl_gpu_copy_host_to_device(void* dst, const void* src, size_t n);
 bool chpl_gpu_is_device_ptr(const void* ptr);
 bool chpl_gpu_is_host_ptr(const void* ptr);
 
+unsigned int chpl_gpu_device_clock_rate(int32_t devNum);
+
 // TODO do we really need to expose this?
 size_t chpl_gpu_get_alloc_size(void* ptr);
 #endif // HAS_GPU_LOCALE

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -103,8 +103,6 @@ __host__ static inline unsigned int chpl_gpu_clock(void) {
 __device__ __host__ static inline void chpl_gpu_printTimeDelta(
   const char *msg, unsigned int start, unsigned int end)
 {
-  // For some reason the %Lf specifier doesn't work in CUDA
-  // so I downcast to double.
   printf("%s%u\n", msg, end - start);
 }
 

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -93,6 +93,21 @@ __host__ static inline void chpl_assert_on_gpu(int32_t lineno, int32_t filenameI
   chpl_error("assertOnGpu() failed", lineno, filenameIdx);
 }
 
+__device__ static inline unsigned int chpl_gpu_clock(void) {
+  return (unsigned int)clock();
+}
+__host__ static inline unsigned int chpl_gpu_clock(void) {
+  return 0;
+}
+
+__device__ __host__ static inline void chpl_gpu_printTimeDelta(
+  const char *msg, unsigned int start, unsigned int end)
+{
+  // For some reason the %Lf specifier doesn't work in CUDA
+  // so I downcast to double.
+  printf("%s%u\n", msg, end - start);
+}
+
 #endif // HAS_GPU_LOCALE
 
 #endif // _CHPL_GPU_GEN_INCLUDES_H

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -37,6 +37,7 @@
 #include <stdbool.h>
 
 static CUcontext *chpl_gpu_primary_ctx;
+static int *deviceClockRates;
 
 static bool chpl_gpu_has_context() {
   CUcontext cuda_context = NULL;
@@ -91,6 +92,7 @@ void chpl_gpu_impl_init() {
   CUDA_CALL(cuDeviceGetCount(&num_devices));
 
   chpl_gpu_primary_ctx = chpl_malloc(sizeof(CUcontext)*num_devices);
+  deviceClockRates = chpl_malloc(sizeof(int)*num_devices);
 
   int i;
   for (i=0 ; i<num_devices ; i++) {
@@ -100,6 +102,7 @@ void chpl_gpu_impl_init() {
     CUDA_CALL(cuDeviceGet(&device, i));
     CUDA_CALL(cuDevicePrimaryCtxSetFlags(device, CU_CTX_SCHED_BLOCKING_SYNC));
     CUDA_CALL(cuDevicePrimaryCtxRetain(&context, device));
+    cuDeviceGetAttribute(&deviceClockRates[i], CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device);
 
     chpl_gpu_primary_ctx[i] = context;
   }
@@ -382,6 +385,8 @@ size_t chpl_gpu_impl_get_alloc_size(void* ptr) {
   return chpl_gpu_common_get_alloc_size(ptr);
 }
 
+unsigned int chpl_gpu_device_clock_rate(int32_t devNum) {
+  return (unsigned int)deviceClockRates[devNum];
+}
 
 #endif // HAS_GPU_LOCALE
-

--- a/test/gpu/native/measureGpuCycles.chpl
+++ b/test/gpu/native/measureGpuCycles.chpl
@@ -1,0 +1,36 @@
+use GPU;
+
+config param howManyResults = 3;
+config param showTimingResults = false;
+
+on here.gpus[0] {
+  var A : [0..1024] int;
+  var clockDiff : [0..<howManyResults] uint;
+
+  foreach i in 0..0 {
+    var dblFactor = 1;
+    var start, stop : uint;
+    for j in 0..<howManyResults {
+      start = gpuClock();
+      for k in 0..1024 * dblFactor {
+        A[k % 1024] = A[k % 1024] + j * k;
+      }
+      stop = gpuClock();
+      clockDiff[j] = stop - start;
+      dblFactor *= 10;
+    }
+  }
+
+  var isMonotonicallyIncreasing = true;
+  for i in 0..<howManyResults {
+    if showTimingResults then
+      writeln("Diff is: ",
+        (clockDiff[i] : real) / (gpuClocksPerSec(0) : real));
+    if i > 0 && clockDiff[i] < clockDiff[i-1] then
+      isMonotonicallyIncreasing = false;
+  }
+
+  // Used as a crude correctness check. If this isn't true then we're likely
+  // doing something wrong.
+  writeln("Largers loops always took longer: ", isMonotonicallyIncreasing);
+}

--- a/test/gpu/native/measureGpuCycles.good
+++ b/test/gpu/native/measureGpuCycles.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+Largers loops always took longer: true


### PR DESCRIPTION
This function can be used to measure performance from within a GPU kernel.  The function returns the number of clock cycles on a SM that have occurred since kernel launch.

The PR also adds `gpuClocksPerSec` and `gpuPrintTimeDelta`. The clocks per second function can currently only be called by the host and the print delta function exists so that (in the absence of getting `writeln` to work) we can output this data from the kernel.

Due to these usability issues I have these functions no doc'd for the time being.