### PR TITLE
Use pkg-config for zmq package tests

### DIFF
--- a/test/library/packages/ZMQ.skipif
+++ b/test/library/packages/ZMQ.skipif
@@ -1,26 +1,13 @@
 #!/usr/bin/env python3
 
-"""
- The ZMQ package requires the zmq library.
+import subprocess
+from contextlib import suppress
 
- Installation of the ZMQ library is detected with the find_library function,
- which looks for the appropriate dynamic library (e.g. libzmq.so).
- Note that if the dynamic library is found, this test assumes that the
- header and static library are available. Can be overridden with
- `CHPL_TEST_NO_ZMQ=True`
+Ok = False
 
- Skip CHPL_COMM != none until #9425 is resolved.
-"""
+with suppress(Exception):
+    sub = subprocess.run(['pkg-config', '--exists', 'libzmq'], stderr=subprocess.DEVNULL)
+    if sub.returncode == 0:
+        Ok = True
 
-from ctypes.util import find_library
-import os
-
-# Is ZMQ available?
-zmq_found = find_library('zmq') is not None
-user_no_zmq = os.getenv('CHPL_TEST_NO_ZMQ') is not None
-
-# OK contains the conditions that must be met to run the test
-OK = zmq_found and not user_no_zmq
-
-# Skip if not OK
-print(not OK)
+print(not Ok)

--- a/test/library/packages/ZMQ/COMPOPTS
+++ b/test/library/packages/ZMQ/COMPOPTS
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo `pkg-config --libs --cflags libzmq`

--- a/test/library/packages/ZMQ/getLastEndpointMain.preexec
+++ b/test/library/packages/ZMQ/getLastEndpointMain.preexec
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$3 getLastEndpointHelper.chpl
+$3 `pkg-config --libs --cflags libzmq` getLastEndpointHelper.chpl

--- a/test/library/packages/ZMQ/interop-py/COMPOPTS
+++ b/test/library/packages/ZMQ/interop-py/COMPOPTS
@@ -1,0 +1,1 @@
+../COMPOPTS

--- a/test/library/packages/ZMQ/multilocale/COMPOPTS
+++ b/test/library/packages/ZMQ/multilocale/COMPOPTS
@@ -1,0 +1,1 @@
+../COMPOPTS

--- a/test/library/packages/ZMQ/version.prediff
+++ b/test/library/packages/ZMQ/version.prediff
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cc -std=c99 -o version-c version.c -lzmq && ./version-c > version.good 
+cc -std=c99 -o version-c version.c `pkg-config --libs --cflags libzmq` && ./version-c > version.good


### PR DESCRIPTION
Previously, the ZMQ package tests required a system install of libzmq to work. Our skipif would look for a libzmq library and if it was found assume that a zmq.h header would be found too. However, this isn't always the case and we have systems that have the libzmq library but not the headers, which caused the tests to run and then fail. To improve this, use pkg-config to check if zmq is installed and to get appropriate compilation cflags/libs.

We've run into the zmq library only issue before and added a workaround in #20191 that let us manually skip the tests, but this makes that check automatic, at least for the package tests. We'll want to do something similar for the multi-locale interop tests at some point too, but I think that will require updating the compiler or makefile makefile support for mli to use pkg-config to get cflags/libs.)

Tested `start_test --respect-skipifs test/library/packages/ZMQ/` on
 - [x] machine with system libzmq.so and zmq.h (passed)
 - [x] machine with spack installed zmq (passed)
 - [x] machine with brew installed zmq (passed)
 - [x] machine with only libzmq.so and not zmq.h (skipped)

Motivated by Cray/chapel-private#4011