### PR TITLE
Skip `--static` test if libpthread.a isn't found

### DIFF
--- a/test/compflags/link/sungeun/static_dynamic.skipif
+++ b/test/compflags/link/sungeun/static_dynamic.skipif
@@ -35,6 +35,11 @@ elif $CHPL_HOME/util/printchplenv --make --all --internal \
   # a compopts-by-compopts basis, but we can't do that yet.
   #
   echo True
+elif [ ! -f "/usr/lib64/libpthread.a" ] ; then
+  # Many modern OS's don't ship static system libraries we depend on. We always
+  # link libpthread (and libm) so use that as a proxy for systems lacking
+  # static systems libs.
+  echo True
 else
   echo False
 fi


### PR DESCRIPTION
Currently, the `--static` compiler flags maps to a backend flag like `-static`, which tries to create a fully static executable. This is support by fewer and fewer distributions anymore since they don't ship static versions of libraries we need like pthreads. We could probably stand to revisit what `--static` means or whether we want to continue to have the flag, but for now I just want to prevent the test from failing on systems that lack static versions of libraries we need.

Part of Cray/chapel-private#4011