### PR TITLE
Adjust debug support in doiOptimizedSwap

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1625,6 +1625,7 @@ proc BlockArr.doiOptimizedSwap(other: this.type)
 // type, stridability, or rank mismatch in the other argument). When
 // debugOptimizedSwap is off, this overload will be ignored due to its where
 // clause.
+pragma "last resort"
 proc BlockArr.doiOptimizedSwap(other) where debugOptimizedSwap {
   writeln("BlockArr doing unoptimized swap. Type mismatch");
   return false;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2292,6 +2292,7 @@ module DefaultRectangular {
   // due to a type, stridability, or rank mismatch in the other argument). When
   // debugOptimizedSwap is off, this overload will be ignored due to its where
   // clause.
+  pragma "last resort"
   proc DefaultRectangularArr.doiOptimizedSwap(other) where debugOptimizedSwap {
     writeln("DefaultRectangularArr doing unoptimized swap. Type mismatch");
     return false;


### PR DESCRIPTION
Fixes a test failure after PR #20755 with

    optimizations/arraySwap/edgeCases

Adjusts doiOptimizedSwap `where debugOptimizedSwap` to use `pragma "last resort"`. Otherwise, this generic function will be preferred to the other overload.