### PR TITLE
 Parse the commit log. Replace line feeds with <br>

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -28,7 +28,8 @@ jobs:
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
-  
+              echo ${{github.event.pull_request.body}} >> msg.txt
+              echo echo "LOG=$(cat msg.txt | sed  's/\\n/<br>/g') " >> $GITHUB_ENV
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.
@@ -67,8 +68,7 @@ jobs:
               Author: ${{ env.AUTHOR}} <br>
               Link: ${{github.event.pull_request._links.html.href}} <br>             
               Log Message: <br><br>
-                           ${{env.MESSAGE}} <br> 
-                           ${{github.event.pull_request.body}} <br>
+                           ${{env.LOG}} <br>
               Compare: ${{env.COMPARE_URL}} <br> 
               Diff: ${{github.event.pull_request.diff_url}} <br>
               Modified Files: <br>


### PR DESCRIPTION
Email body was not honoring linefeeds.
Parse the merge log replace line feeds with '<br>' .

- [x]  To address a comment in the issue https://github.com/Cray/chapel-private/issues/3995.

In the merge message quoted in the mail, newlines/paragraphs seem to be lost. For example, compare the OP in this PR https://github.com/chapel-lang/chapel/pull/20891 with its merge mail message here: [https://chapel.discourse.group/t/chapel-merge-20891-make-zippered-for-loops-more-like-pa[…]-zippered-loops-by-having-the-first-expression-lead/17148](https://chapel.discourse.group/t/chapel-merge-20891-make-zippered-for-loops-more-like-parallel-zippered-loops-by-having-the-first-expression-lead/17148) I think it’s important to preserve these linefeeds in the mail for readability.