### PR TITLE
Revert " Parse the commit log. Replace line feeds with <br>"

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -28,8 +28,7 @@ jobs:
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
-              echo ${{github.event.pull_request.body}} >> msg.txt
-              echo echo "LOG=$(cat msg.txt | sed  's/\\n/<br>/g') " >> $GITHUB_ENV
+  
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.
@@ -68,7 +67,8 @@ jobs:
               Author: ${{ env.AUTHOR}} <br>
               Link: ${{github.event.pull_request._links.html.href}} <br>             
               Log Message: <br><br>
-                           ${{env.LOG}} <br>
+                           ${{env.MESSAGE}} <br> 
+                           ${{github.event.pull_request.body}} <br>
               Compare: ${{env.COMPARE_URL}} <br> 
               Diff: ${{github.event.pull_request.diff_url}} <br>
               Modified Files: <br>


### PR DESCRIPTION
Reverts chapel-lang/chapel#21030.

Reverting the patch because the email parsing is failing in production runs.
The same changes passed on a git workflow run from a forked repository.
