### PR TITLE
Add the disable flag to disable warning. 

### DIFF
--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -129,7 +129,7 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 #  174 : warns about expressions that have no effect
 #  177 : warns about unused variable declarations
 
-WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599 -diag-warning 3924
+WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599,10441 -diag-warning 3924
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -70,7 +70,7 @@ CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 #  592 : squelch use-before-def problems -- we'll rely on valgrind to catch them
 
 COMP_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
-COMP_CXXFLAGS_NONCHPL = -wr111,193,1418,1419,2215,2259,170 -Wno-error
+COMP_CXXFLAGS_NONCHPL = -wr111,193,1418,1419,2215,2259,170,-wd10441 -Wno-error
 
 RUNTIME_CFLAGS = $(C_STD) $(CPPFLAGS) $(CFLAGS) -wr181,188
 RUNTIME_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
@@ -129,7 +129,7 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 #  174 : warns about expressions that have no effect
 #  177 : warns about unused variable declarations
 
-WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599,10441 -diag-warning 3924
+WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599,-wd10441 -diag-warning 3924
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -70,8 +70,8 @@ CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 #  592 : squelch use-before-def problems -- we'll rely on valgrind to catch them
 
 COMP_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
-COMP_CXXFLAGS_NONCHPL = -wr111,193,1418,1419,2215,2259,170,-wd10441 -Wno-error
-
+COMP_CXXFLAGS_NONCHPL = -wr111,193,1418,1419,2215,2259,170 -Wno-error
+COMP_CXXFLAGS_NONCHPL+= -diag-disable 10441 
 RUNTIME_CFLAGS = $(C_STD) $(CPPFLAGS) $(CFLAGS) -wr181,188
 RUNTIME_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
 GEN_CFLAGS = $(C_STD) -wr592
@@ -129,7 +129,8 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 #  174 : warns about expressions that have no effect
 #  177 : warns about unused variable declarations
 
-WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599,-wd10441 -diag-warning 3924
+WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599 -diag-warning 3924
+WARN_CXXFLAGS+= -diag-disable 10441
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177


### PR DESCRIPTION
Add a disable warning flag to disable Intel compiler compatibility warning message.

The warning is seen on this test run.

https://chapel-ci.us.cray.com/job/cray-module-performance-cray-xc-single-locale/CHPL_LAUNCHER=slurm-srun,COMMUNICATION=none,COMPILER=intel,LOCALE_MODEL=flat,label_exp=horizon/744/console

icc: remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023. The Intel(R) oneAPI DPC++/C++ Compiler (ICX) is the recommended compiler moving forward. Please transition to use this compiler. Use '-diag-disable=10441' to disable this message.