### PR TITLE
Add last resort to generic chpl__coerceMove

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3198,7 +3198,6 @@ module ChapelArray {
     return lhs;
   }
 
-  // TODO: can we remove this last resort?
   pragma "find user line"
   pragma "coerce fn"
   pragma "last resort"
@@ -3220,6 +3219,7 @@ module ChapelArray {
   }
   pragma "find user line"
   pragma "coerce fn"
+  pragma "last resort"
   proc chpl__coerceMove(type dstType:_array, in rhs, definedConst: bool) {
     // assumes rhs is iterable (e.g. list)
 

--- a/test/classes/ferguson/check-init-array-classes-nil.chpl
+++ b/test/classes/ferguson/check-init-array-classes-nil.chpl
@@ -1,0 +1,9 @@
+// initializing with nil
+var y: [1..10] unmanaged C? = nil;
+
+// assigning from nil
+var z: [1..10] unmanaged C?;
+z;
+z = nil;
+
+class C { }


### PR DESCRIPTION
Follow-up to PR #20755.

This PR adds `pragma "last resort"` to the generic `chpl__coerceMove` to get this code pattern working:

    var x:[1..10] unmanaged C? = nil

The `pragma "last resort"` was already present on the corresponding `chpl__coerceCopy`.

This resolves a problem building `prep` from CHAMPS.

This PR also adds a small test showing the pattern that was failing to compile.

Reviewed by @DanilaFe - thanks!

- [x] full local testing