### PR TITLE
Fix how we get ZMQ flags from pkg-config

### DIFF
--- a/test/library/packages/ZMQ/COMPOPTS
+++ b/test/library/packages/ZMQ/COMPOPTS
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
-echo `pkg-config --libs --cflags libzmq`
+ccflags=$(pkg-config --cflags libzmq)
+ldflags=$(pkg-config --libs libzmq)
+
+echo "${ccflags:+--ccflags '$ccflags'} ${ldflags:+--ldflags '$ldflags'}"

--- a/test/library/packages/ZMQ/getLastEndpointMain.preexec
+++ b/test/library/packages/ZMQ/getLastEndpointMain.preexec
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-$3 `pkg-config --libs --cflags libzmq` getLastEndpointHelper.chpl
+ccflags=$(pkg-config --cflags libzmq)
+ldflags=$(pkg-config --libs libzmq)
+
+$3 ${ccflags:+--ccflags "$ccflags"} ${ldflags:+--ldflags "$ldflags"} getLastEndpointHelper.chpl


### PR DESCRIPTION
In #21026, we started getting ZMQ include/lib paths from pkg-config, but they were being passed directly to the chpl compiler. This was under the assumption that we'd only get `-I`/`-L`/`-l` args, which our compiler supports, but there can also be some variants that we don't support (like `-isystem`). Fix that here by passing pkg-config flags to `--ccflags`/`--ldflags` instead.