### PR TITLE
Optimize distributed rectangular domain creation

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -433,9 +433,12 @@ module ChapelArray {
                          definedConst: bool) {
     if definedConst {
       if dom.isRectangular() {
-        const distDom: domain(dom.rank,
+        const distDom = new _domain(d.newRectangularDom(
+                              dom.rank,
                               dom._value.idxType,
-                              dom._value.stridable) dmapped d = dom;
+                              dom._value.stridable,
+                              dom.dims(),
+                              definedConst));
         return distDom;
       } else {
         const distDom: domain(dom._value.idxType) dmapped d = dom;
@@ -444,7 +447,13 @@ module ChapelArray {
     }
     else {
       if dom.isRectangular() {
-        var distDom: domain(dom.rank, dom._value.idxType, dom._value.stridable) dmapped d = dom;
+        var distDom = new _domain(d.newRectangularDom(
+                              dom.rank,
+                              dom._value.idxType,
+                              dom._value.stridable,
+                              dom.dims(),
+                              definedConst));
+
         return distDom;
       } else {
         var distDom: domain(dom._value.idxType) dmapped d = dom;


### PR DESCRIPTION
When creating distributed rectangular domains, directly create the final distributed domain instead of creating an empty domain and assigning the local domain into it. This eliminates a distributed domain assignment and re-privatization, which gets rid of 3 coforall+ons resulting in some domain creation speedups.

Here's the performance results for creating a block distributed domain on 16 nodes of a CS and XC:

```
./distCreate --size=arraySize.tiny --dist=distType.block -nl 16
```

16-node-cs-hdr

| config | domInit  |
| ------ | -------: |
| before | 0.00464s |
| after  | 0.00288s |

16-node-xc:

| config | domInit  |
| ------ | -------: |
| before | 0.00055s |
| after  | 0.00027s |

Part of #20197