### PR TITLE
Change remaining sprintf calls to snprintf

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -297,7 +297,8 @@ void AstDump::visitSymExpr(SymExpr* node) {
     char         buff[bufSize + 1];
 
     snprint_imm(imm, bufSize, *var->immediate);
-    sprintf(buff, "%s%s", imm, is_imag_type(var->type) ? "i" : "");
+    snprintf(buff, sizeof(buff), "%s%s", imm,
+            is_imag_type(var->type) ? "i" : "");
 
     write(buff);
 

--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -1665,10 +1665,10 @@ static const char* symPrefixString(Symbol* sym) {
     Symbol* parent = sym->defPoint ? sym->defPoint->parentSymbol : NULL;
 
     if (isModuleSymbol(parent))
-      sprintf(symPrefixBuffer, "%s.",  parent->name);
+      snprintf(symPrefixBuffer, sizeof(symPrefixBuffer), "%s.", parent->name);
 
     else if (isTypeSymbol(parent))
-      sprintf(symPrefixBuffer, "%s::", parent->name);
+      snprintf(symPrefixBuffer, sizeof(symPrefixBuffer), "%s::", parent->name);
 
     else
       symPrefixBuffer[0] = '\0';
@@ -1687,7 +1687,7 @@ void AstDumpToNode::writeSymbol(Symbol* sym) const
 
   if (compact)
   {
-    sprintf(name, "%s%s", symPrefixString(sym), sym->name);
+    snprintf(name, sizeof(name), "%s%s", symPrefixString(sym), sym->name);
   }
   else if (mod != 0)
   {
@@ -1696,32 +1696,32 @@ void AstDumpToNode::writeSymbol(Symbol* sym) const
       ;
 
     else if (sym == 0)
-      sprintf(name, "??.NULL");
+      snprintf(name, sizeof(name), "??.NULL");
 
     else if (mod->name == 0 && sym->name == 0)
-      sprintf(name, "??.??");
+      snprintf(name, sizeof(name), "??.??");
 
     else if (mod->name != 0 && sym->name == 0)
-      sprintf(name, "%s.??", mod->name);
+      snprintf(name, sizeof(name), "%s.??", mod->name);
 
     else if (mod->name == 0 && sym->name != 0)
-      sprintf(name, "??.%s", sym->name);
+      snprintf(name, sizeof(name), "??.%s", sym->name);
 
     else
-      sprintf(name, "%s.%s", mod->name, sym->name);
+      snprintf(name, sizeof(name), "%s.%s", mod->name, sym->name);
 #else
 
-      sprintf(name, "%s", sym->name);
+      snprintf(name, sizeof(name), "%s", sym->name);
 
 #endif
   }
   else
   {
     if (sym->name == 0)
-      sprintf(name, "NULL.??");
+      snprintf(name, sizeof(name), "NULL.??");
 
     else
-      sprintf(name, "NULL.%s", sym->name);
+      snprintf(name, sizeof(name), "NULL.%s", sym->name);
   }
 
 
@@ -1875,9 +1875,9 @@ void AstDumpToNode::writeSymbol(Symbol* sym) const
       if (var->type == dtBool)
       {
         if (var->immediate->v_bool == 0)
-          sprintf(imm, "false");
+          snprintf(imm, bufSize, "false");
         else
-          sprintf(imm, "true");
+          snprintf(imm, bufSize, "true");
       }
       else
       {

--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -703,9 +703,9 @@ void AstToText::appendExpr(SymExpr* expr, bool printingType, bool quoteStrings)
       if (var->type == dtBool)
       {
         if (var->immediate->v_bool == 0)
-          sprintf(imm, "false");
+          snprintf(imm, bufSize, "false");
         else
-          sprintf(imm, "true");
+          snprintf(imm, bufSize, "true");
       }
 
       else if (var->immediate->const_kind == CONST_KIND_STRING)

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -1315,10 +1315,10 @@ static char* parentMsg(Expr* expr, int* cntInTreeP, int* cntNonTreeP) {
   static char result[128];
   if (expr->inTree()) {
     (*cntInTreeP)++;
-    sprintf(result, "psym %d", expr->parentSymbol->id);
+    snprintf(result, sizeof(result), "psym %d", expr->parentSymbol->id);
   } else {
     (*cntNonTreeP)++;
-    sprintf(result, "<not in tree>");
+    snprintf(result, sizeof(result), "<not in tree>");
   }
   return result;
 }

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -274,7 +274,7 @@ llvm::AllocaInst* createVarLLVM(llvm::Type* type, const char* name)
 llvm::AllocaInst* createVarLLVM(llvm::Type* type)
 {
   char name[32];
-  sprintf(name, "chpl_macro_tmp_%d", codegen_tmp++);
+  snprintf(name, sizeof(name), "chpl_macro_tmp_%d", codegen_tmp++);
   return createVarLLVM(type, name);
 }
 
@@ -1395,7 +1395,7 @@ GenRet createTempVar(const char* ctype)
   GenInfo* info = gGenInfo;
   GenRet ret;
   char name[32];
-  sprintf(name, "chpl_macro_tmp_%d", codegen_tmp++);
+  snprintf(name, sizeof(name), "chpl_macro_tmp_%d", codegen_tmp++);
 
   ret.isLVPtr = GEN_PTR;
   if( info->cfile ) {
@@ -2147,7 +2147,7 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
         ifTrueVal.val, ifFalseVal.val, ifTrueSigned, ifFalseSigned);
 
     char name[32];
-    sprintf(name, "chpl_macro_tmp_tv_%d", codegen_tmp++);
+    snprintf(name, sizeof(name), "chpl_macro_tmp_tv_%d", codegen_tmp++);
 
     llvm::Value* tmp = createVarLLVM(values.a->getType(), name);
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -99,7 +99,7 @@ void zlineToFileIfNeeded(BaseAST* ast, FILE* outfile) {
 static char idCommentBuffer[32];
 
 const char* idCommentTemp(BaseAST* ast) {
-  sprintf(idCommentBuffer, "/* %7d */ ", ast->id);
+  snprintf(idCommentBuffer, sizeof(idCommentBuffer), "/* %7d */ ", ast->id);
   return idCommentBuffer;
 }
 
@@ -2183,7 +2183,7 @@ static const char* generateFileName(ChainHashMap<char*, StringHashFns, int>& fil
 
   // create the lowercase filename
   char lowerFilename[FILENAME_MAX];
-  sprintf(lowerFilename, "%s", currentModuleName);
+  snprintf(lowerFilename, sizeof(lowerFilename), "%s", currentModuleName);
   for (unsigned int i=0; i<strlen(lowerFilename); i++) {
     lowerFilename[i] = tolower(lowerFilename[i]);
   }
@@ -2191,7 +2191,7 @@ static const char* generateFileName(ChainHashMap<char*, StringHashFns, int>& fil
   // create a filename by bumping a version number until we get a
   // filename we haven't seen before
   char filename[FILENAME_MAX];
-  sprintf(filename, "%s", lowerFilename);
+  snprintf(filename, sizeof(filename), "%s", lowerFilename);
   int version = 1;
   while (filenames.get(filename)) {
     version++;
@@ -2210,9 +2210,9 @@ static const char* generateFileName(ChainHashMap<char*, StringHashFns, int>& fil
   // case by default by going back to currentModule->name rather
   // than using the lowercase filename
   if (version == 1) {
-    sprintf(filename, "%s", currentModuleName);
+    snprintf(filename, sizeof(filename), "%s", currentModuleName);
   } else {
-    sprintf(filename, "%s%d", currentModuleName, version);
+    snprintf(filename, sizeof(filename), "%s%d", currentModuleName, version);
   }
 
   name = astr(filename);
@@ -2758,7 +2758,7 @@ void makeBinary(void) {
     const char* makeflags = printSystemCommands ? "-f " : "-s -f ";
     char parMakeFlags[32] = "";
     if (fParMake > 0) {
-      sprintf(parMakeFlags, "-j %d ", fParMake);
+      snprintf(parMakeFlags, sizeof(parMakeFlags), "-j %d ", fParMake);
     }
     const char* command = astr(astr(CHPL_MAKE, " "),
                                parMakeFlags, makeflags,

--- a/compiler/include/version.h
+++ b/compiler/include/version.h
@@ -23,8 +23,8 @@
 
 #include <string>
 
-void get_version(char * buf);
-void get_major_minor_version(char * buf);
+void get_version(char * buf, size_t bufsize);
+void get_major_minor_version(char * buf, size_t bufsize);
 const char* get_configured_prefix();
 
 int get_major_version();

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2132,7 +2132,7 @@ void finishCodegenLLVM() {
   // Now overwrite the value of llvm.ident to show Chapel
   char version[128];
   char chapel_string[256];
-  get_version(version);
+  get_version(version, sizeof(version));
   snprintf(chapel_string, 256, "Chapel version %s", version);
   info->module->getNamedMetadata("llvm.ident")->setOperand(0,
     llvm::MDNode::get(info->module->getContext(),

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -105,7 +105,7 @@ void debug_data::create_compile_unit(const char *file, const char *directory, bo
   this->optimized = is_optimized;
   char version[128];
   char chapel_string[256];
-  get_version(version);
+  get_version(version, sizeof(version));
   snprintf(chapel_string, 256, "Chapel version %s", version);
   strncpy(current_dir, directory,sizeof(current_dir)-1);
 

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -313,7 +313,7 @@ void Phase::ReportPass(unsigned long now) const
   {
     char text[32];
 
-    sprintf(text, "  [%9d]", lastNodeIDUsed());
+    snprintf(text, sizeof(text), "  [%9d]", lastNodeIDUsed());
 
     ReportText(text);
   }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -383,7 +383,7 @@ static void setupChplHome(const char* argv0) {
   char        majMinorVers[64];
 
   // Get major.minor version string (used below)
-  get_major_minor_version(majMinorVers);
+  get_major_minor_version(majMinorVers, sizeof(majMinorVers));
 
   // Get the executable path.
   guess = findProgramPath(argv0);
@@ -577,7 +577,7 @@ static void recordCodeGenStrings(int argc, char* argv[]) {
     if (arg)
       compileCommand = astr(compileCommand, arg, " ");
   }
-  get_version(compileVersion);
+  get_version(compileVersion, sizeof(compileVersion));
 }
 
 void setHome(const ArgumentDescription* desc, const char* arg) {

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -29,11 +29,12 @@
 // this include sets CONFIGURED_PREFIX
 #include "configured_prefix.h"
 
-void
-get_version(char *v, size_t bufsize) {
-  v += snprintf(v, (bufsize -= 16 * sizeof(char)), "%d.%d.%d", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
+void get_version(char* v, size_t bufsize) {
+  size_t len = 0;
+  len += snprintf(v + len, bufsize - len, "%d.%d.%d", MAJOR_VERSION,
+                  MINOR_VERSION, UPDATE_VERSION);
   if (!officialRelease) {
-    snprintf(v, (bufsize -= 32 * sizeof(char)), " pre-release (%s)", BUILD_VERSION);
+    len += snprintf(v + len, bufsize - len, " pre-release (%s)", BUILD_VERSION);
   } else {
     // It's is an official release.
     // Try to decide whether or not to include the BUILD_VERSION
@@ -44,7 +45,7 @@ get_version(char *v, size_t bufsize) {
       // no need to append a .0
     } else {
       // include the BUILD_VERSION contents to add e.g. a .1
-      snprintf(v, (bufsize -= 16 * sizeof(char)), ".%s", BUILD_VERSION);
+      len += snprintf(v + len, bufsize - len, ".%s", BUILD_VERSION);
     }
   }
 }

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -31,9 +31,9 @@
 
 void
 get_version(char *v) {
-  v += sprintf(v, "%d.%d.%d", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
+  v += snprintf(v, 16 * sizeof(char), "%d.%d.%d", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (!officialRelease) {
-    sprintf(v, " pre-release (%s)", BUILD_VERSION);
+    snprintf(v, 32 * sizeof(char), " pre-release (%s)", BUILD_VERSION);
   } else {
     // It's is an official release.
     // Try to decide whether or not to include the BUILD_VERSION
@@ -44,14 +44,14 @@ get_version(char *v) {
       // no need to append a .0
     } else {
       // include the BUILD_VERSION contents to add e.g. a .1
-      sprintf(v, ".%s", BUILD_VERSION);
+      snprintf(v, 16 * sizeof(char), ".%s", BUILD_VERSION);
     }
   }
 }
 
 void
 get_major_minor_version(char *v) {
-  sprintf(v, "%d.%d", MAJOR_VERSION, MINOR_VERSION);
+  snprintf(v, 12 * sizeof(char), "%d.%d", MAJOR_VERSION, MINOR_VERSION);
 }
 
 const char*

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -30,10 +30,10 @@
 #include "configured_prefix.h"
 
 void
-get_version(char *v) {
-  v += snprintf(v, 16 * sizeof(char), "%d.%d.%d", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
+get_version(char *v, size_t bufsize) {
+  v += snprintf(v, (bufsize -= 16 * sizeof(char)), "%d.%d.%d", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (!officialRelease) {
-    snprintf(v, 32 * sizeof(char), " pre-release (%s)", BUILD_VERSION);
+    snprintf(v, (bufsize -= 32 * sizeof(char)), " pre-release (%s)", BUILD_VERSION);
   } else {
     // It's is an official release.
     // Try to decide whether or not to include the BUILD_VERSION
@@ -44,14 +44,14 @@ get_version(char *v) {
       // no need to append a .0
     } else {
       // include the BUILD_VERSION contents to add e.g. a .1
-      snprintf(v, 16 * sizeof(char), ".%s", BUILD_VERSION);
+      snprintf(v, (bufsize -= 16 * sizeof(char)), ".%s", BUILD_VERSION);
     }
   }
 }
 
 void
-get_major_minor_version(char *v) {
-  snprintf(v, 12 * sizeof(char), "%d.%d", MAJOR_VERSION, MINOR_VERSION);
+get_major_minor_version(char *v, size_t bufsize) {
+  snprintf(v, bufsize, "%d.%d", MAJOR_VERSION, MINOR_VERSION);
 }
 
 const char*

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -308,7 +308,7 @@ std::string ResolveScope::name() const {
   } else if (BlockStmt*    block   = toBlockStmt(mAstRef))    {
     char buff[1024];
 
-    sprintf(buff, "BlockStmt %9d", block->id);
+    snprintf(buff, sizeof(buff), "BlockStmt %9d", block->id);
 
     retval = buff;
 

--- a/compiler/passes/addInitGuards.cpp
+++ b/compiler/passes/addInitGuards.cpp
@@ -178,7 +178,7 @@ void AddInitGuards::addPrintModInitOrder(FnSymbol* fn) {
   const char* s2 = astr(fn->getModule()->name);
   int myLen = strlen(s2);
   char lenStr[25];
-  sprintf(lenStr, "%d", myLen);
+  snprintf(lenStr, sizeof(lenStr), "%d", myLen);
   Expr *es1 = buildCStringLiteral(s1);
   Expr *es2 = buildCStringLiteral(s2);
   Expr *elen = buildIntLiteral(lenStr);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2408,8 +2408,8 @@ struct Converter {
 
     if ((nextId + 1) == 0) INT_FATAL("Overflow for lambda ID number");
 
-    // Use sprintf to prevent buffer overflow if there are too many lambdas.
-    int n = snprintf(buf, maxDigits, "chpl_lambda_%i", nextId++);
+    // Use snprintf to prevent buffer overflow if there are too many lambdas.
+    int n = snprintf(buf, (size_t)maxDigits, "chpl_lambda_%i", nextId++);
     if (n > (int) maxDigits) INT_FATAL("Too many lambdas.");
 
     auto ret = astr(buf);

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -73,7 +73,7 @@ explainInstantiation(FnSymbol* fn) {
   SymbolMapVector elts = sortedSymbolMapElts(fn->substitutions);
 
   char msg[1024] = "";
-  int len = sprintf(msg, "instantiated %s(", fn->name);
+  int len = snprintf(msg, sizeof(msg), "instantiated %s(", fn->name);
   bool first = true;
   for_formals(formal, fn) {
     for (auto elem: elts) {
@@ -83,28 +83,28 @@ explainInstantiation(FnSymbol* fn) {
         if (first)
           first = false;
         else
-          len += sprintf(msg+len, ", ");
+          len += snprintf(msg+len, sizeof(msg)-len, ", ");
         INT_ASSERT(arg);
         if (strcmp(fn->name, tupleInitName))
-          len += sprintf(msg+len, "%s = ", arg->name);
+          len += snprintf(msg+len, sizeof(msg)-len, "%s = ", arg->name);
         if (VarSymbol* vs = toVarSymbol(elem.value)) {
           if (vs->immediate && vs->immediate->const_kind == NUM_KIND_INT)
-            len += sprintf(msg+len, "%" PRId64, vs->immediate->int_value());
+            len += snprintf(msg+len, sizeof(msg)-len, "%" PRId64, vs->immediate->int_value());
           else if (vs->immediate && vs->immediate->const_kind == CONST_KIND_STRING)
-            len += sprintf(msg+len, "\"%s\"", vs->immediate->v_string.c_str());
+            len += snprintf(msg+len, sizeof(msg)-len, "\"%s\"", vs->immediate->v_string.c_str());
           else
-            len += sprintf(msg+len, "%s", vs->name);
+            len += snprintf(msg+len, sizeof(msg)-len, "%s", vs->name);
         }
         else if (Symbol* s = toSymbol(elem.value))
       // For a generic symbol, just print the name.
       // Additional clauses for specific symbol types should precede this one.
-          len += sprintf(msg+len, "%s", s->name);
+          len += snprintf(msg+len, sizeof(msg)-len, "%s", s->name);
         else
           INT_FATAL("unexpected case using --explain-instantiation");
       }
     }
   }
-  sprintf(msg+len, ")");
+  snprintf(msg+len, sizeof(msg)-len, ")");
   if (callStack.n) {
     USR_PRINT(callStack.v[callStack.n-1], "%s", msg);
   } else {

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -50,9 +50,9 @@ static const char* symstring(Symbol* sym) {
   if (!sym)
     return "<no symbol provided>";
   if (developer)
-    snprintf(nameBuff, nameBuffSize, "%s[%d]", sym->name, sym->id);
+    snprintf(nameBuff, (size_t)nameBuffSize, "%s[%d]", sym->name, sym->id);
   else
-    snprintf(nameBuff, nameBuffSize, "'%s'", sym->name);
+    snprintf(nameBuff, (size_t)nameBuffSize, "'%s'", sym->name);
   return nameBuff;
 }
 
@@ -61,9 +61,9 @@ static const char* idstring(const char* prefix, BaseAST* ast) {
   if (!ast)
     return "<no node provided>";
   if (developer)
-    snprintf(idBuff, idBuffSize, "%s [%d]", prefix, ast->id);
+    snprintf(idBuff, (size_t)idBuffSize, "%s [%d]", prefix, ast->id);
   else
-    sprintf(idBuff, "");
+    snprintf(idBuff, 1 * sizeof(char), "");
   return idBuff;
 }
 

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2374,7 +2374,7 @@ static Expr* preFoldNamed(CallExpr* call) {
         USR_FATAL(call, "type index expression '%" PRId64 "' out of bounds (0..%d)", index, at->fields.length-2);
       }
 
-      sprintf(field, "x%" PRId64, index);
+      snprintf(field, sizeof(field), "x%" PRId64, index);
 
       retval = new SymExpr(sym->type->getField(field)->type->symbol);
       call->replace(retval);
@@ -2712,20 +2712,20 @@ static Expr* resolveTupleIndexing(CallExpr* call, Symbol* baseVar) {
   bool error = false;
 
   if (get_int(call->get(3), &index)) {
-    sprintf(field, "x%" PRId64, index);
+    snprintf(field, sizeof(field), "x%" PRId64, index);
     if (index < 0 || index >= baseType->fields.length-1) {
       USR_FATAL_CONT(call, "tuple index %" PRId64 " is out of bounds", index);
       if (index < 0) zero_error = true;
       error = true;
     }
   } else if (get_uint(call->get(3), &uindex)) {
-    sprintf(field, "x%" PRIu64, uindex);
+    snprintf(field, sizeof(field), "x%" PRIu64, uindex);
     if (uindex >= (unsigned long)baseType->fields.length-1) {
       USR_FATAL_CONT(call, "tuple index %" PRIu64 " is out of bounds", uindex);
       error = true;
     }
   } else if (get_bool(call->get(3), &uindex)) {
-    sprintf(field, "x%" PRIu64, uindex);
+    snprintf(field, sizeof(field), "x%" PRIu64, uindex);
     if (uindex >= (unsigned long)baseType->fields.length-1) {
       USR_FATAL_CONT(call, "tuple index %" PRIu64 " is out of bounds", uindex);
       error = true;

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -246,7 +246,7 @@ static void print_user_internal_error() {
 
   error[idx++] = '-';
   // next 4 characters are the line number
-  snprintf(&error[idx], 4 * sizeof(char), "%04d", err_lineno);
+  snprintf(&error[idx], 5 * sizeof(char), "%04d", err_lineno);
 
   // now make the error string upper case
   for (int i = 0; i < (int)sizeof(error) && error[i]; i++) {
@@ -257,7 +257,7 @@ static void print_user_internal_error() {
 
   print_error("%s ", error);
 
-  get_version(version);
+  get_version(version, sizeof(version));
 
   print_error("chpl version %s", version);
 }

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -246,7 +246,7 @@ static void print_user_internal_error() {
 
   error[idx++] = '-';
   // next 4 characters are the line number
-  sprintf(&error[idx], "%04d", err_lineno);
+  snprintf(&error[idx], 4 * sizeof(char), "%04d", err_lineno);
 
   // now make the error string upper case
   for (int i = 0; i < (int)sizeof(error) && error[i]; i++) {

--- a/compiler/util/stringutil.cpp
+++ b/compiler/util/stringutil.cpp
@@ -63,7 +63,7 @@ const char* astr(UniqueString s)
 const char*
 istr(int i) {
   char s[64];
-  if (sprintf(s, "%d", i) > 63)
+  if (snprintf(s, sizeof(s), "%d", i) > 63)
     INT_FATAL("istr buffer overflow");
   return astr(s);
 }

--- a/test/compflags/link/deitz/dir/link2.c
+++ b/test/compflags/link/deitz/dir/link2.c
@@ -8,7 +8,8 @@ void foo(const char* s) {
 
 char* bar(int i) {
   char* s;
-  s = (char*)malloc(50*sizeof(char));
-  sprintf(s, "sprintf %d", i);
+  size_t slen = 50;
+  s = (char*)malloc(slen);
+  snprintf(s, slen, "sprintf %d", i);
   return s;
 }

--- a/test/compflags/link/deitz/link1.c
+++ b/test/compflags/link/deitz/link1.c
@@ -8,7 +8,8 @@ void foo(const char* s) {
 
 char* bar(int i) {
   char* s;
-  s = (char*)malloc(50*sizeof(char));
-  sprintf(s, "sprintf %d", i);
+  size_t slen = 50;
+  s = (char*)malloc(slen);
+  snprintf(s, slen, "sprintf %d", i);
   return s;
 }

--- a/test/library/standard/Memory/Diagnostics/countMemory/countMemory.makegood
+++ b/test/library/standard/Memory/Diagnostics/countMemory/countMemory.makegood
@@ -46,11 +46,11 @@ printf "    in gb: %s\n", $realMemInGBytes;
 sub print_chapel_real{
 	$retVal = 0;
 	if( ($_[0] >= 100000.0) and ($_[0] < 1000000.0) ){
-		$retVal = sprintf("%.5e", $_[0]);
+		$retVal = snprintf("%.5e", 32 * sizeof(char), $_[0]);
 		$retVal =~ s/0+e/e/; #for removing the zeroes
 	}
 	else {
-		$retVal = sprintf("%g", $_[0]);
+		$retVal = snprintf("%g", 32 * sizeof(char), $_[0]);
 	}
 
 	#

--- a/test/library/standard/Memory/Diagnostics/countMemory/countMemory.makegood
+++ b/test/library/standard/Memory/Diagnostics/countMemory/countMemory.makegood
@@ -46,11 +46,11 @@ printf "    in gb: %s\n", $realMemInGBytes;
 sub print_chapel_real{
 	$retVal = 0;
 	if( ($_[0] >= 100000.0) and ($_[0] < 1000000.0) ){
-		$retVal = snprintf("%.5e", 32 * sizeof(char), $_[0]);
+		$retVal = sprintf("%.5e", $_[0]);
 		$retVal =~ s/0+e/e/; #for removing the zeroes
 	}
 	else {
-		$retVal = snprintf("%g", 32 * sizeof(char), $_[0]);
+		$retVal = sprintf("%g", $_[0]);
 	}
 
 	#

--- a/test/studies/compOcean/compOcean.h
+++ b/test/studies/compOcean/compOcean.h
@@ -15,11 +15,12 @@ static int nc_inq_dimlen_WAR(int ncid, int dimid, void* dimlens) {
 char hexstr[19];
 
 static const char* float_to_hex(float x) {
-  sprintf(hexstr, "0x%8x", *(unsigned int*)&x);
+  snprintf(hexstr, sizeof(hexstr), "0x%8x", *(unsigned int*)&x);
   return hexstr;
 }
 
 static const char* double_to_hex(double x) {
-  sprintf(hexstr, "0x%.8x%.8x", ((unsigned int*)&x)[1], ((unsigned int*)&x)[0]);
+  snprintf(hexstr, sizeof(hexstr), "0x%.8x%.8x", ((unsigned int*)&x)[1],
+           ((unsigned int*)&x)[0]);
   return hexstr;
 }

--- a/test/studies/nqueens/nqueens-c++.cpp
+++ b/test/studies/nqueens/nqueens-c++.cpp
@@ -125,10 +125,10 @@ void Board::show() {
   }
   char notFilledMsg[64];
   if (lastfilled < boardSize) {
-    sprintf(notFilledMsg, " row(s) %d to %d are not filled\n",
+    snprintf(notFilledMsg, sizeof(notFilledMsg), " row(s) %d to %d are not filled\n",
             (lastfilled + 1), boardSize);
   } else {
-    sprintf(notFilledMsg, "");
+    snprintf(notFilledMsg, 1 * sizeof(char), "");
   }
   if (show1line) {
     for (int row = 1; row <= lastfilled; row++) {

--- a/test/studies/uts/brg_sha1.c
+++ b/test/studies/uts/brg_sha1.c
@@ -111,7 +111,7 @@ int rng_nextrand(RNG_state *mystate){
 
 /* condense state into string to display during debugging */
 char * rng_showstate(RNG_state *state, char *s){
-  snprintf(s,"%.2X%.2X...", 8 * sizeof(char), state[0],state[1]);
+  snprintf(s, 8 * sizeof(char), "%.2X%.2X...", state[0],state[1]);
   return s;
 }
 

--- a/test/studies/uts/brg_sha1.c
+++ b/test/studies/uts/brg_sha1.c
@@ -111,14 +111,14 @@ int rng_nextrand(RNG_state *mystate){
 
 /* condense state into string to display during debugging */
 char * rng_showstate(RNG_state *state, char *s){
-  sprintf(s,"%.2X%.2X...", state[0],state[1]);
+  snprintf(s,"%.2X%.2X...", 8 * sizeof(char), state[0],state[1]);
   return s;
 }
 
 /* describe random number generator type into string */
 int rng_showtype(char *strBuf, int ind) {
-  ind += sprintf(strBuf+ind, "SHA-1 (state size = %uB)",
-                 (unsigned) sizeof(struct state_t));
+  ind += snprintf(strBuf + ind, 25 * sizeof(char), "SHA-1 (state size = %uB)",
+                  (unsigned)sizeof(struct state_t));
   return ind;
 }
 


### PR DESCRIPTION
Change all remaining instances of `sprintf`->`snprintf` due to `sprintf` deprecation (and general unsafety). Instances in the runtime have already been changed by https://github.com/chapel-lang/chapel/pull/21021. Instances in third-party code are left untouched as we don't own them.

Resolves https://github.com/Cray/chapel-private/issues/3999.

Testing:
- [x] local compile in environment with `sprintf` deprecated
- [x] paratest