### PR TITLE
Update more tests for 'findfiles' deprecation

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3533,7 +3533,7 @@ module HDF5 {
     use FileSystem, List;
 
     var filenames: list(string);
-    for f in findfiles(dirName) {
+    for f in findFiles(dirName) {
       if f.startsWith(dirName + '/' + filenameStart:string) &&
          f.endsWith(".h5") {
         filenames.append(f);

--- a/test/functions/iterators/thomasvandoren/ParallelOnly.chpl
+++ b/test/functions/iterators/thomasvandoren/ParallelOnly.chpl
@@ -3,7 +3,7 @@ use FileSystem;
 iter myIter(param tag: iterKind)
   where tag == iterKind.standalone
 {
-  forall f in findfiles() {
+  forall f in findFiles() {
     if f == "./ParallelOnly.chpl" {
       yield f;
     }

--- a/test/library/packages/Curl/check-http.chpl
+++ b/test/library/packages/Curl/check-http.chpl
@@ -18,8 +18,8 @@ module CheckHttp {
 
     writeln("checking served files match");
 
-    /* for f in findfiles() but for #18218 */
-    var files = findfiles();
+    /* for f in findFiles() but for #18218 */
+    var files = findFiles();
     for f in files {
       if f.endsWith(".txt") ||
         f.endsWith(".htm") || f.endsWith(".html") ||

--- a/test/library/packages/Curl/download-http-upload-ftp.chpl
+++ b/test/library/packages/Curl/download-http-upload-ftp.chpl
@@ -9,7 +9,7 @@ config const outUrl = "ftp://127.0.0.1/upload/";
 proc runtest() {
   writeln("uploading some files to FTP");
 
-  for f in findfiles() {
+  for f in findFiles() {
     if f.endsWith(".txt") || f.endsWith(".htm") || f.endsWith(".html") {
 
       if verbose then

--- a/test/library/packages/Curl/upload-ftp.chpl
+++ b/test/library/packages/Curl/upload-ftp.chpl
@@ -19,7 +19,7 @@ proc runtest() {
 
   writeln("uploading some files to FTP");
 
-  for f in findfiles() {
+  for f in findFiles() {
     if f.endsWith(".txt") || f.endsWith(".htm") || f.endsWith(".html") {
 
       if verbose then

--- a/test/studies/dedup/dedup-externblock.chpl
+++ b/test/studies/dedup/dedup-externblock.chpl
@@ -30,7 +30,7 @@ proc main(args:[] string)
     if isFile(arg) then
       paths.append(arg);
     else if isDir(arg) then
-      for path in findfiles(arg, recursive=true) do
+      for path in findFiles(arg, recursive=true) do
         paths.append(path);
   }
 


### PR DESCRIPTION
These tests don't run in a standard linux64 paratest so I missed them in the first PR that deprecated 'findfiles'. Nightly testing caught them, so update them now.