### PR TITLE
Update tests that require gdb to check for the executable

### DIFF
--- a/test/compflags/bradc/gdbddash/declint-lldb.skipif
+++ b/test/compflags/bradc/gdbddash/declint-lldb.skipif
@@ -1,1 +1,6 @@
-CHPL_HOST_PLATFORM!=darwin
+#!/usr/bin/env python3
+
+import shutil
+
+missing_lldb = shutil.which("lldb") is None
+print(missing_lldb)

--- a/test/compflags/bradc/gdbddash/declint.skipif
+++ b/test/compflags/bradc/gdbddash/declint.skipif
@@ -1,1 +1,6 @@
-CHPL_HOST_PLATFORM==darwin
+#!/usr/bin/env python3
+
+import shutil
+
+missing_gdb = shutil.which("gdb") is None
+print(missing_gdb)

--- a/test/execflags/bradc/gdbddash/SKIPIF
+++ b/test/execflags/bradc/gdbddash/SKIPIF
@@ -1,4 +1,10 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+
 # GASNet can run gdb but can't send a stdin file to each window
-# Darwin now only supports lldb
-CHPL_COMM == gasnet
-CHPL_TARGET_PLATFORM==darwin
+gasnet = os.getenv('CHPL_COMM') == 'gasnet'
+missing_gdb = shutil.which("gdb") is None
+
+print(gasnet or missing_gdb)

--- a/test/execflags/lldbddash/SKIPIF
+++ b/test/execflags/lldbddash/SKIPIF
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
-if which lldb >/dev/null 2>/dev/null; then
-  echo False
-else
-  echo True
-fi
+import shutil
+
+missing_lldb = shutil.which("lldb") is None
+print(missing_lldb)


### PR DESCRIPTION
Instead of hard coding what platforms have gdb/lldb, just check for the executables directly. This should make the tests more portable in general and avoids running the gdb tests on systems without gdb.

Part of Cray/chapel-private#4011