### PR TITLE
Fix dangling reference bug.

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2916,9 +2916,9 @@ struct Converter {
       if (varLikeDecl == nullptr) continue;
       if (varLikeDecl->storageKind() != types::QualifiedType::TYPE) continue;
 
-      auto assocTypeName = varLikeDecl->name().c_str();
+      auto assocTypeName = varLikeDecl->name();
       noteConvertedSym(varLikeDecl,
-                       isymAssociatedTypes.at(assocTypeName)->symbol);
+                       isymAssociatedTypes.at(assocTypeName.c_str())->symbol);
     }
 
     auto ret = buildChapelStmt(isym);


### PR DESCRIPTION
Sometimes, a `UniqueString` struct contains the `c_str()` it represents (small
string optimization), which means it needs to stay in scope for the `c_str()`
to remain valid. This temporary goes out of scope right away, so the `c_str()`
may be invalid.

Testing:
- [x] ASAN failures before this are fixed after this.
- [x] full local testing

Reviewed by @dlongnecke-cray - thanks!

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>
