### PR TITLE
Support for one locale per socket.

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -588,8 +588,7 @@ void* chpl_get_global_serialize_table(int64_t idx);
 void chpl_signal_shutdown(void);
 void chpl_wait_for_shutdown(void);
 
-// Sets the number of locales on the local node and determines if the node is
-// oversubscribed.
+// Sets the number of locales on the local node.
 void chpl_set_num_locales_on_node(int32_t count);
 
 // Returns the number of locales on the local node.
@@ -601,9 +600,6 @@ void chpl_set_local_rank(int32_t rank);
 // Returns our local rank on the node, -1 if chpl_set_local_rank has
 // not been called.
 int32_t chpl_get_local_rank(void);
-
-// Returns true if node is oversubscribed, false otherwise.
-chpl_bool chpl_get_oversubscribed(void);
 
 #ifdef __cplusplus
 }

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -194,8 +194,15 @@ int32_t chpl_comm_getMaxThreads(void);
 void chpl_comm_init(int *argc_p, char ***argv_p);
 
 //
-// Allow the communication layer to do any secondary initialization it needs
-// to, after the memory layer is initialized.
+// Allow the communication layer to do any additional initialization
+// after the topology layer has been fully initialized but before the
+// memory layer is initialized.
+//
+void chpl_comm_pre_mem_init(void);
+
+//
+// Allow the communication layer to do any additional initialization
+// after the memory layer is initialized.
 //
 void chpl_comm_post_mem_init(void);
 
@@ -586,11 +593,16 @@ void chpl_wait_for_shutdown(void);
 void chpl_set_num_locales_on_node(int32_t count);
 
 // Returns the number of locales on the local node.
-
 int32_t chpl_get_num_locales_on_node(void);
 
-// Returns true if node is oversubscribed, false otherwise.
+// Sets our local rank on the node.
+void chpl_set_local_rank(int32_t rank);
 
+// Returns our local rank on the node, -1 if chpl_set_local_rank has
+// not been called.
+int32_t chpl_get_local_rank(void);
+
+// Returns true if node is oversubscribed, false otherwise.
 chpl_bool chpl_get_oversubscribed(void);
 
 #ifdef __cplusplus

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -146,6 +146,11 @@ void chpl_topo_touchMemFromSubloc(void*, size_t, chpl_bool, c_sublocid_t);
 //
 c_sublocid_t chpl_topo_getMemLocality(void*);
 
+//
+// Returns True if the node is oversubscribed (locales are sharing
+// cores).
+chpl_bool chpl_topo_isOversubscribed(void);
+
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -37,6 +37,7 @@ extern "C" {
 // initialize the topology support
 //
 void chpl_topo_init(void);
+void chpl_topo_post_comm_init(void);
 void chpl_topo_exit(void);
 
 //

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -38,6 +38,7 @@ extern "C" {
 //
 void chpl_topo_init(void);
 void chpl_topo_post_comm_init(void);
+void chpl_topo_post_args_init(void);
 void chpl_topo_exit(void);
 
 //

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -46,6 +46,7 @@ int32_t          chpl_nodeID = -1;
 int32_t          chpl_numNodes = -1;
 static int32_t   numLocalesOnNode = -1;
 static chpl_bool oversubscribed = false;
+static int32_t   localRank = -1;
 
 
 //
@@ -262,6 +263,17 @@ int32_t chpl_get_num_locales_on_node(void) {
       chpl_internal_error("chpl_set_num_locales_on_node has not been called");
   }
   return numLocalesOnNode;
+}
+
+// Sets the rank (ordering) of the calling locale on the local node.
+void chpl_set_local_rank(int32_t rank) {
+  localRank = rank;
+}
+
+// Returns the rank (ordering) of the calling locale on the local node.
+// Returns -1 if chpl_set_local_rank has not been called.
+int32_t chpl_get_local_rank(void) {
+  return localRank;
 }
 
 chpl_bool chpl_get_oversubscribed(void) {

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -45,7 +45,6 @@
 int32_t          chpl_nodeID = -1;
 int32_t          chpl_numNodes = -1;
 static int32_t   numLocalesOnNode = -1;
-static chpl_bool oversubscribed = false;
 static int32_t   localRank = -1;
 
 
@@ -245,17 +244,11 @@ void chpl_wait_for_shutdown(void) {
   pthread_mutex_unlock(&shutdown_mutex);
 }
 
-// Sets numLocalesOnNode and determines if node is oversubscribed based
-// on the number of locales and the CHPL_RT_OVERSUBSCRIBED environment
-// variable.
-
 void chpl_set_num_locales_on_node(int32_t count) {
   if (count <= 0) {
     chpl_internal_error_v("count (%d) must be > 0", count);
   }
   numLocalesOnNode = count;
-  oversubscribed = chpl_env_rt_get_bool("OVERSUBSCRIBED",
-                                        numLocalesOnNode > 1);
 }
 
 int32_t chpl_get_num_locales_on_node(void) {
@@ -276,9 +269,3 @@ int32_t chpl_get_local_rank(void) {
   return localRank;
 }
 
-chpl_bool chpl_get_oversubscribed(void) {
-  if (numLocalesOnNode < 1) {
-      chpl_internal_error("chpl_set_num_locales_on_node has not been called");
-  }
-  return oversubscribed;
-}

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -243,6 +243,8 @@ void chpl_rt_init(int argc, char* argv[]) {
   parseArgs(false, parse_normally, &argc, argv);
   recordExecutionCommand(argc, argv);
 
+  chpl_topo_post_args_init();
+  
   //
   // If the user specified a number of locales, have the comm layer
   // verify that it is reasonable.

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -228,6 +228,8 @@ void chpl_rt_init(int argc, char* argv[]) {
   chpl_error_init();  // This does local-only initialization
   chpl_topo_init();
   chpl_comm_init(&argc, &argv);
+  chpl_topo_post_comm_init();
+  chpl_comm_pre_mem_init();
   chpl_mem_init();
   chpl_comm_post_mem_init();
 

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -244,7 +244,7 @@ void chpl_rt_init(int argc, char* argv[]) {
   recordExecutionCommand(argc, argv);
 
   chpl_topo_post_args_init();
-  
+
   //
   // If the user specified a number of locales, have the comm layer
   // verify that it is reasonable.

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -935,6 +935,8 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   chpl_set_num_locales_on_node(1);
 }
 
+void chpl_comm_pre_mem_init(void) { }
+
 void chpl_comm_post_mem_init(void) {
   chpl_comm_init_prv_bcast_tab();
 }

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -113,6 +113,8 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   chpl_set_num_locales_on_node(1);
 }
 
+void chpl_comm_pre_mem_init(void) { }
+
 void chpl_comm_post_mem_init(void) { }
 
 int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status) {

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -273,7 +273,15 @@ void chpl_comm_ofi_oob_fini(void);
 void chpl_comm_ofi_oob_barrier(void);
 void chpl_comm_ofi_oob_allgather(const void*, void*, size_t);
 void chpl_comm_ofi_oob_bcast(void*, size_t);
-int  chpl_comm_ofi_oob_locales_on_node(void);
+
+/*
+Returns the number of locales on the local node. If localRank is not
+NULL it will contain the rank of the locale on the local node starting
+at 0. This may be used to distinguish between locales on the same
+node. If the rank functionality isn't implemented then *localRank is
+set to -1.
+*/
+int  chpl_comm_ofi_oob_locales_on_node(int *localRank);
 
 
 //

--- a/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
@@ -98,7 +98,7 @@ void chpl_comm_ofi_oob_bcast(void* buf, size_t size) {
   MPI_CHK(MPI_Bcast(buf, size, MPI_BYTE, 0, MPI_COMM_WORLD));
 }
 
-int chpl_comm_ofi_oob_locales_on_node(void) {
+int chpl_comm_ofi_oob_locales_on_node(int *rank) {
   //
   // The MPI_Comm_split_type() call splits the specified input communicator
   // (MPI_COMM_WORLD) into one or more output communicators which, because of the
@@ -117,6 +117,9 @@ int chpl_comm_ofi_oob_locales_on_node(void) {
   int nodeSize;
   MPI_CHK(MPI_Comm_size(nodeComm, &nodeSize));
   MPI_CHK(MPI_Comm_free(&nodeComm));
-  DBG_PRINTF(DBG_OOB, "OOB locales on node: %d", nodeSize);
+  DBG_PRINTF(DBG_OOB, "MPI OOB locales on node: %d", nodeSize);
+  if (rank != NULL) {
+    *rank = -1;  // not implemented
+  }
   return nodeSize;
 }

--- a/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
@@ -297,10 +297,6 @@ typedef struct locale_info_t {
   int       nodeID;   // locale's ID
 } locale_info_t;
 
-static int compareRanks(const void *a, const void *b) {
-  return *((int *) a) - *((int *) b);
-}
-
 int chpl_comm_ofi_oob_locales_on_node(int *rank) {
   int count = 0;
   if (PMI_Get_numpes_on_smp && PMI_Get_pes_on_smp) {
@@ -310,14 +306,10 @@ int chpl_comm_ofi_oob_locales_on_node(int *rank) {
       int *ranks;
       CHK_SYS_CALLOC(ranks, count);
       PMI_CHK(PMI_Get_pes_on_smp(ranks, count));
-      // Ranks aren't guaranteed to be returned in order, so sort them
-      // so all locales see them in the same order.
-      qsort(ranks, count, sizeof(int), compareRanks);
-      *rank = -1;
+      *rank = 0;
       for (int i = 0; i < count; i++) {
-        if (ranks[i] == chpl_nodeID) {
-          *rank = i;
-          break;
+        if (ranks[i] < chpl_nodeID) {
+          *rank++;
         }
       }
       sys_free(ranks);

--- a/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
@@ -304,14 +304,15 @@ int chpl_comm_ofi_oob_locales_on_node(int *rank) {
     PMI_CHK(PMI_Get_numpes_on_smp(&count));
     if (rank) {
       int *ranks;
+      int myrank = 0;
       CHK_SYS_CALLOC(ranks, count);
       PMI_CHK(PMI_Get_pes_on_smp(ranks, count));
-      *rank = 0;
       for (int i = 0; i < count; i++) {
         if (ranks[i] < chpl_nodeID) {
-          *rank++;
+          myrank++;
         }
       }
+      *rank = myrank;
       sys_free(ranks);
     }
     DBG_PRINTF(DBG_OOB, "got rank info from PMI");

--- a/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
@@ -291,53 +291,64 @@ void decode_kvs(char* raw, const char* enc, size_t size) {
   }
 }
 
-int chpl_comm_ofi_oob_locales_on_node(void) {
+typedef struct locale_info_t {
+  uint64_t  hash;     // hash of the locale's hostname
+  int       nodeID;   // locale's ID
+} locale_info_t;
+
+int chpl_comm_ofi_oob_locales_on_node(int *rank) {
   int count = 0;
-  if (PMI_Get_clique_size != NULL) {
-    PMI_CHK(PMI_Get_clique_size(&count));
-    DBG_PRINTF(DBG_OOB, "PMI_Get_clique_size returned %d", count);
-  } else {
-    // do an allgather of hostname hashes to determine the locales on the same node as us
-    // assumes each hostname has a unique hash
+  // do an allgather of hostname hashes to determine the locales on the same node as us
+  // assumes each hostname has a unique hash
 
-    char hostname[HOST_NAME_MAX+1];
-    int rc = gethostname(hostname, sizeof(hostname));
-    CHK_TRUE(rc == 0);
+  char hostname[HOST_NAME_MAX+1];
+  int rc = gethostname(hostname, sizeof(hostname));
+  CHK_TRUE(rc == 0);
 
-    uint64_t hash = 0;
-    for (int i = 0; i < sizeof(hostname); i++) {
-      char c = hostname[i];
-      if (c == '\0') {
-        break;
-      }
-      // The hash code is borrowed from gasnet including the comment.
-      // See third-party/gasnet/gasnet-src/license.txt.
-
-      /* The "c = ..." squeezes ASCII down to 6 bits, while encoding
-       * all chars valid in hostnames and IP addresses (IPV4 and IPV6).
-       * A unique value is assigned to each of the digits, the lower
-       * case letters, '-', '.' and ':'.  The upper case letters map
-       * to the same values as the corresponding lower-case.
-       */
-      c = ((c & 0x40) >> 1) | (c & 0x1f);
-      hash = ((hash << 6) | ((hash >> 58) & 0x3F)) ^ c;
+  uint64_t hash = 0;
+  for (int i = 0; i < sizeof(hostname); i++) {
+    char c = hostname[i];
+    if (c == '\0') {
+      break;
     }
+    // The hash code is borrowed from gasnet including the comment.
+    // See third-party/gasnet/gasnet-src/license.txt.
 
-    // get the hashes for all locales
-
-    uint64_t *hashes = NULL;
-    CHK_SYS_CALLOC(hashes, chpl_numNodes);
-    chpl_comm_ofi_oob_allgather(&hash, hashes, sizeof(*hashes));
-
-    // count the number of hashes that match ours
-
-    for (int i = 0; i < chpl_numNodes; i++) {
-      if (hashes[i] == hash) {
-        count++;
-      }
-    }
-    CHK_SYS_FREE(hashes);
+    /* The "c = ..." squeezes ASCII down to 6 bits, while encoding
+     * all chars valid in hostnames and IP addresses (IPV4 and IPV6).
+     * A unique value is assigned to each of the digits, the lower
+     * case letters, '-', '.' and ':'.  The upper case letters map
+     * to the same values as the corresponding lower-case.
+     */
+    c = ((c & 0x40) >> 1) | (c & 0x1f);
+    hash = ((hash << 6) | ((hash >> 58) & 0x3F)) ^ c;
   }
-  DBG_PRINTF(DBG_OOB, "OOB locales on node: %d", count);
+
+  // get the hashes for all locales
+
+  locale_info_t info;
+  info.hash = hash;
+  DBG_PRINTF(DBG_OOB, "PMI2 OOB chpl_nodeID %d", chpl_nodeID);
+  info.nodeID = chpl_nodeID;
+  locale_info_t *infos = NULL;
+  CHK_SYS_CALLOC(infos, chpl_numNodes);
+  chpl_comm_ofi_oob_allgather(&info, infos, sizeof(*infos));
+
+  // count the number of hashes that match ours
+
+  for (int i = 0; i < chpl_numNodes; i++) {
+    if (infos[i].hash == hash) {
+      if ((rank != NULL) && (infos[i].nodeID == chpl_nodeID)) {
+        // record our rank among the locales on the same node
+        *rank = count;
+      }
+      count++;
+    }
+  }
+  CHK_SYS_FREE(infos);
+  DBG_PRINTF(DBG_OOB, "PMI2 OOB locales on node: %d", count);
+  if (rank != NULL) {
+    DBG_PRINTF(DBG_OOB, "PMI2 OOB local rank: %d", *rank);
+  }
   return count;
 }

--- a/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
@@ -102,7 +102,10 @@ void chpl_comm_ofi_oob_bcast(void* buf, size_t len) {
   }
 }
 
-int chpl_comm_ofi_oob_locales_on_node(void) {
+int chpl_comm_ofi_oob_locales_on_node(int *rank) {
   // assume the answer is 1
+  if (rank != NULL) {
+    *rank = -1; // not implemented
+  }
   return 1;
 }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -997,8 +997,12 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   time_init();
   chpl_comm_ofi_oob_init();
   DBG_INIT();
-  int32_t count = chpl_comm_ofi_oob_locales_on_node();
+  int32_t rank;
+  int32_t count = chpl_comm_ofi_oob_locales_on_node(&rank);
   chpl_set_num_locales_on_node(count);
+  if (rank != -1) {
+    chpl_set_local_rank(rank);
+  }
   //
   // Gather run-invariant environment info as early as possible.
   //
@@ -1039,14 +1043,17 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
     }
   }
 
+  pthread_that_inited = pthread_self();
+}
+
+void chpl_comm_pre_mem_init(void) {
   //
-  // Reserve cores for the AM handlers. This has to be done early before
-  // calling other routines that use information about the cores, such as
-  // pinning the heap.
+  // Reserve cores for the AM handlers. This is done here because it has
+  // to happen after chpl_topo_post_comm_init has been called, but before
+  // other functions access information about the cores, such as pinning the
+  // heap.
   //
   init_ofiReserveCores();
-
-  pthread_that_inited = pthread_self();
 }
 
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1930,6 +1930,8 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
 }
 
 
+void chpl_comm_pre_mem_init(void) { }
+
 void chpl_comm_post_mem_init(void)
 {
   chpl_comm_init_prv_bcast_tab();

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -288,7 +288,6 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     fprintf(slurmFile, "#SBATCH --nodes=%d\n", numNodes);
     fprintf(slurmFile, "#SBATCH --ntasks=%d\n", numLocales);
-    fprintf(slurmFile, "#SBATCH --ntasks-per-node=%d\n", localesPerNode);
     int localesOnNode = (numLocales < localesPerNode) ?
                         numLocales : localesPerNode;
     int cpusPerTask = getCoresPerLocale(localesOnNode);
@@ -416,8 +415,6 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     len += snprintf(iCom+len, sizeof(iCom)-len, "--nodes=%d ",numNodes);
     len += snprintf(iCom+len, sizeof(iCom)-len, "--ntasks=%d ", numLocales);
-    len += snprintf(iCom+len, sizeof(iCom)-len, "--ntasks-per-node=%d ",
-                    localesPerNode);
     int localesOnNode = (numLocales < localesPerNode) ?
                         numLocales : localesPerNode;
     int cpusPerTask = getCoresPerLocale(localesOnNode);

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -38,6 +38,8 @@
 #define CHPL_PARTITION_FLAG "--partition"
 #define CHPL_EXCLUDE_FLAG "--exclude"
 
+#define CHPL_LPN_VAR "CHPL_RT_LOCALES_PER_NODE"
+
 static char* debug = NULL;
 static char* walltime = NULL;
 static int generate_sbatch_script = 0;
@@ -47,8 +49,6 @@ static char* exclude = NULL;
 
 char slurmFilename[FILENAME_MAX];
 
-/* copies of binary to run per node */
-#define procsPerNode 1
 
 typedef enum {
   slurmpro,
@@ -99,8 +99,9 @@ static int nomultithread(int batch) {
 }
 
 // Get the number of locales from the environment variable or if that is not
-// set just use sinfo to get the number of cpus.
-static int getCoresPerLocale(int nomultithread) {
+// set just use sinfo to get the number of cpus and divide by the number
+// of locales per node.
+static int getCoresPerLocale(int nomultithread, int32_t localesPerNode) {
   int numCores = -1;
   int threadsPerCore = -1;
   const int buflen = 1024;
@@ -147,7 +148,7 @@ static int getCoresPerLocale(int nomultithread) {
   if (nomultithread)
     numCores /= threadsPerCore;
 
-  return numCores;
+  return numCores / localesPerNode;
 }
 #define MAX_COM_LEN (FILENAME_MAX + 128)
 // create the command that will actually launch the program and
@@ -165,11 +166,13 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   char* errorfn = getenv("CHPL_LAUNCHER_SLURM_ERROR_FILENAME");
   char* nodeAccessEnv = getenv("CHPL_LAUNCHER_NODE_ACCESS");
   char* memEnv = getenv("CHPL_LAUNCHER_MEM");
+  char* lpnEnv = getenv(CHPL_LPN_VAR);
   const char* nodeAccessStr = NULL;
   const char* memStr = NULL;
   char* basenamePtr = strrchr(argv[0], '/');
   pid_t mypid;
   char  jobName[128];
+  int localesPerNode = 1;
 
   // For programs with large amounts of output, a lot of time can be
   // spent syncing the stdout buffer to the output file. This can cause
@@ -240,6 +243,21 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     memStr = memEnv;
   }
 
+  localesPerNode = 1;
+  if (lpnEnv != NULL) {
+    localesPerNode = atoi(lpnEnv);
+    if (localesPerNode <= 0) {
+      char msg[100];
+      snprintf(msg, sizeof(msg), "%s must be > 0.", CHPL_LPN_VAR);
+      chpl_warning(msg, 0, 0);
+      localesPerNode = 1;
+    }
+  }
+
+  if (localesPerNode > numLocales) {
+    localesPerNode = numLocales;
+  }
+
   if (basenamePtr == NULL) {
     basenamePtr = argv[0];
   } else {
@@ -278,13 +296,21 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // suppress informational messages, will still display errors
     fprintf(slurmFile, "#SBATCH --quiet\n");
 
-    // request the number of locales, with 1 task per node, and number of cores
-    // cpus-per-task. We probably don't need --nodes and --ntasks specified
-    // since 1 task-per-node with n --tasks implies -n nodes
-    fprintf(slurmFile, "#SBATCH --nodes=%d\n", numLocales);
+    int32_t numNodes = (numLocales + localesPerNode - 1) / localesPerNode;
+
+    fprintf(slurmFile, "#SBATCH --nodes=%d\n", numNodes);
     fprintf(slurmFile, "#SBATCH --ntasks=%d\n", numLocales);
-    fprintf(slurmFile, "#SBATCH --ntasks-per-node=%d\n", procsPerNode);
-    fprintf(slurmFile, "#SBATCH --cpus-per-task=%d\n", getCoresPerLocale(nomultithread(true)));
+    fprintf(slurmFile, "#SBATCH --ntasks-per-node=%d\n", localesPerNode);
+    if (localesPerNode == 1) {
+
+      // Don't specify cpus-per-task if oversubscribed otherwise cores
+      // won't be used due to rounding.
+      fprintf(slurmFile, "#SBATCH --cpus-per-task=%d\n",
+              getCoresPerLocale(nomultithread(true), localesPerNode));
+    }
+    if (localesPerNode > 1) {
+      fprintf(slurmFile, "#SBATCH --cpu-bind=none\n");
+    }
 
     // request specified node access
     if (nodeAccessStr != NULL)
@@ -401,11 +427,18 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // request the number of locales, with 1 task per node, and number of cores
     // cpus-per-task. We probably don't need --nodes and --ntasks specified
     // since 1 task-per-node with n --tasks implies -n nodes
-    len += snprintf(iCom+len, sizeof(iCom)-len, "--nodes=%d ",numLocales);
+    int32_t numNodes = (numLocales + localesPerNode - 1) / localesPerNode;
+
+    len += snprintf(iCom+len, sizeof(iCom)-len, "--nodes=%d ",numNodes);
     len += snprintf(iCom+len, sizeof(iCom)-len, "--ntasks=%d ", numLocales);
-    len += snprintf(iCom+len, sizeof(iCom)-len, "--ntasks-per-node=%d ", procsPerNode);
+    len += snprintf(iCom+len, sizeof(iCom)-len, "--ntasks-per-node=%d ",
+                    localesPerNode);
     len += snprintf(iCom+len, sizeof(iCom)-len, "--cpus-per-task=%d ",
-                    getCoresPerLocale(nomultithread(false)));
+                    getCoresPerLocale(nomultithread(false), localesPerNode));
+
+    if (localesPerNode > 1) {
+      len += sprintf(iCom+len, "--cpu-bind=none ");
+    }
 
     // request specified node access
     if (nodeAccessStr != NULL)
@@ -516,8 +549,8 @@ int chpl_launch(int argc, char* argv[], int32_t numLocales) {
   }
   // otherwise generate the batch file or srun command and execute it
   else {
-    retcode = chpl_launch_using_system(chpl_launch_create_command(argc, argv,
-          numLocales), argv[0]);
+    char *cmd = chpl_launch_create_command(argc, argv, numLocales);
+    retcode = chpl_launch_using_system(cmd, argv[0]);
 
     chpl_launch_cleanup();
   }

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -28,6 +28,7 @@
 #include "chpllaunch.h"
 #include "chpl-env.h"
 #include "chpl-mem.h"
+#include "chplcgfns.h"
 #include "chpltypes.h"
 #include "error.h"
 
@@ -296,6 +297,12 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       fprintf(slurmFile, "#SBATCH --cpu-bind=none\n");
     }
 
+    // On the EX create a VNI even if we only launch on one node. Otherwise
+    // we won't be able to create an authorization key.
+    if (!strcmp(CHPL_TARGET_PLATFORM, "hpe-cray-ex")) {
+      fprintf(slurmFile, "#SBATCH --network=single_node_vni\n");
+    }
+
     // request specified node access
     if (nodeAccessStr != NULL)
       fprintf(slurmFile, "#SBATCH --%s\n", nodeAccessStr);
@@ -408,9 +415,8 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // suppress informational messages, will still display errors
     len += snprintf(iCom+len, sizeof(iCom)-len, "--quiet ");
 
-    // request the number of locales, with 1 task per node, and number of cores
-    // cpus-per-task. We probably don't need --nodes and --ntasks specified
-    // since 1 task-per-node with n --tasks implies -n nodes
+    // request the number of locales and number of cores
+    // cpus-per-task.
     int32_t numNodes = (numLocales + localesPerNode - 1) / localesPerNode;
 
     len += snprintf(iCom+len, sizeof(iCom)-len, "--nodes=%d ",numNodes);
@@ -422,9 +428,15 @@ static char* chpl_launch_create_command(int argc, char* argv[],
                     cpusPerTask);
 
     if (localesPerNode > 1) {
-      len += sprintf(iCom+len, "--cpu-bind=none ");
+      len += snprintf(iCom+len, sizeof(iCom)-len, "--cpu-bind=none ");
     }
 
+    // On the EX create a VNI even if we only launch on one node. Otherwise
+    // we won't be able to create an authorization key.
+    if (!strcmp(CHPL_TARGET_PLATFORM, "hpe-cray-ex")) {
+      len += snprintf(iCom+len, sizeof(iCom)-len,
+                      "--network=single_node_vni ");
+    }
     // request specified node access
     if (nodeAccessStr != NULL)
       len += snprintf(iCom+len, sizeof(iCom)-len, "--%s ", nodeAccessStr);

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -741,7 +741,7 @@ void chpl_task_init(void)
     setupSpinWaiting();
     setupAffinity();
 
-    if (verbosity >= 2) { 
+    if (verbosity >= 2) {
         chpl_qt_setenv("INFO", "1", 0);
         if (chpl_nodeID == 0) {
             printf("oversubscribed = %s\n", chpl_topo_isOversubscribed() ? "True" : "False");

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -683,6 +683,7 @@ static void setupAffinity(void) {
     int numCpus;
     chpl_bool physical;
     char *unit = chpl_qt_getenv_str("WORKER_UNIT");
+    _DBG_P("QT_WORKER_UNIT: %s", unit);
     if ((unit != NULL) && !strcmp(unit, "pu")) {
         physical = false;
         numCpus = chpl_topo_getNumCPUsLogical(true);
@@ -714,6 +715,7 @@ static void setupAffinity(void) {
           buf[offset-1] = '\0';
       }
       // tell binders which PUs to use
+      _DBG_P("QT_CPUBIND: %s (%d)", buf, numCpus);
       chpl_qt_setenv("CPUBIND", buf, 1);
       chpl_free(buf);
     }
@@ -821,6 +823,7 @@ static void *comm_task_wrapper(void *arg)
                      "binding comm task to CPU %d failed", rarg->cpu);
             chpl_warning(msg, 0, 0);
         }
+        _DBG_P("comm task bound to CPU %d", rarg->cpu);
     }
     (*(chpl_fn_p)(rarg->fn))(rarg->arg);
     return 0;

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -445,6 +445,7 @@ static int32_t chpl_qt_getenv_num_workers(void) {
 static void setupAvailableParallelism(int32_t maxThreads) {
     int32_t   numThreadsPerLocale;
     int32_t   qtEnvThreads;
+    chpl_bool noMultithread;
     int32_t   hwpar;
     char      newenv_workers[QT_ENV_S] = { 0 };
 
@@ -454,6 +455,7 @@ static void setupAvailableParallelism(int32_t maxThreads) {
     // vars, we override the default.
     numThreadsPerLocale = chpl_task_getenvNumThreadsPerLocale();
     qtEnvThreads = chpl_qt_getenv_num_workers();
+    noMultithread = chpl_env_rt_get_bool("NO_MULTITHREAD", false);
     hwpar = 0;
 
     // User set chapel level env var (CHPL_RT_NUM_THREADS_PER_LOCALE)
@@ -463,7 +465,11 @@ static void setupAvailableParallelism(int32_t maxThreads) {
 
         hwpar = numThreadsPerLocale;
 
-        numPUsPerLocale = chpl_topo_getNumCPUsLogical(true);
+        if (noMultithread) {
+            numPUsPerLocale = chpl_topo_getNumCPUsPhysical(true);
+        } else {
+            numPUsPerLocale = chpl_topo_getNumCPUsLogical(true);
+        }
         if (0 < numPUsPerLocale && numPUsPerLocale < hwpar) {
             char msg[256];
             snprintf(msg, sizeof(msg),

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -664,7 +664,7 @@ static void setupWorkStealing(void) {
 
 static void setupSpinWaiting(void) {
   const char *crayPlatform = "cray-x";
-  if (chpl_get_oversubscribed()) {
+  if (chpl_topo_isOversubscribed()) {
     chpl_qt_setenv("SPINCOUNT", "300", 0);
   } else if (strncmp(crayPlatform, CHPL_TARGET_PLATFORM, strlen(crayPlatform)) == 0) {
     chpl_qt_setenv("SPINCOUNT", "3000000", 0);
@@ -672,7 +672,7 @@ static void setupSpinWaiting(void) {
 }
 
 static void setupAffinity(void) {
-  if (chpl_get_oversubscribed()) {
+  if (chpl_topo_isOversubscribed()) {
     chpl_qt_setenv("AFFINITY", "no", 0);
   }
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -741,7 +741,12 @@ void chpl_task_init(void)
     setupSpinWaiting();
     setupAffinity();
 
-    if (verbosity >= 2) { chpl_qt_setenv("INFO", "1", 0); }
+    if (verbosity >= 2) { 
+        chpl_qt_setenv("INFO", "1", 0);
+        if (chpl_nodeID == 0) {
+            printf("oversubscribed = %s\n", chpl_topo_isOversubscribed() ? "True" : "False");
+        }
+    }
 
     // Initialize qthreads
     pthread_create(&initer, NULL, initializer, NULL);

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -63,7 +63,6 @@ static chpl_bool debug = true;
 static chpl_bool debug = false;
 #endif
 
-static chpl_bool initialized = false;
 static chpl_bool haveTopology = false;
 
 static hwloc_topology_t topology;

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -74,16 +74,18 @@ static int numaLevel;
 static int numNumaDomains;
 
 // A note on core and PU numbering. As per the hwloc documentation, a cpuset
-// contains OS indices of PUs, which are guaranteed to be unique across the
-// machine. In order to use a cpuset to represent a collection of cores and
-// not break this invariant, we represent a core in a cpuset with the smallest
-// OS index of its PUs. For example, the physAccSet contains the OS indices of
-// the smallest PU for each accessible core.
+// contains OS indices of PUs. In order to use a cpuset to represent a
+// collection of cores and not break this invariant, we represent a core in a
+// cpuset with the smallest OS index of its PUs. For example, the physAccSet
+// contains the OS indices of the smallest PU for each accessible core.
 
 // Accessible cores and PUs.
 static hwloc_cpuset_t physAccSet = NULL;
 static hwloc_cpuset_t physReservedSet = NULL;
 static hwloc_cpuset_t logAccSet = NULL;
+
+// Our root within the overall topology.
+static hwloc_obj_t root = NULL;
 
 static hwloc_obj_t getNumaObj(c_sublocid_t);
 static void alignAddrSize(void*, size_t, chpl_bool,
@@ -176,6 +178,14 @@ void chpl_topo_init(void) {
   topoDepth = hwloc_topology_get_depth(topology);
 
   //
+  // By default our root is the root of the topology.
+  //
+
+  root = hwloc_get_root_obj(topology);
+
+  // XXX do we need NUMA stuff?
+
+  //
   // How many NUMA domains do we have?
   //
   {
@@ -192,26 +202,6 @@ void chpl_topo_init(void) {
         numaLevel = level;
       }
     }
-  }
-
-  //
-  // Find the NUMA nodes, that is, the objects at numaLevel that also
-  // have CPUs.  This is as opposed to things like Xeon Phi HBM, which
-  // is memory-only, no CPUs.  Allow for overriding this through the
-  // environment.
-  //
-  if (strcmp(CHPL_LOCALE_MODEL, "flat") != 0) {
-    //
-    // The number of NUMA domains only matters for locale models other
-    // than 'flat'.
-    //
-    numNumaDomains = (int) chpl_env_rt_get_uint("NUM_NUMA_DOMAINS", 0);
-  }
-
-  if (numNumaDomains == 0) {
-    const hwloc_cpuset_t cpusetAll = hwloc_get_root_obj(topology)->cpuset;
-    numNumaDomains =
-      hwloc_get_nbobjs_inside_cpuset_by_depth(topology, cpusetAll, numaLevel);
   }
 }
 
@@ -244,31 +234,30 @@ void* chpl_topo_getHwlocTopology(void) {
 //
 // How many CPUs (cores or PUs) are there?
 //
-static pthread_once_t numCPUs_ctrl = PTHREAD_ONCE_INIT;
-static void getCPUInfo(void);
 static int numCPUsPhysAcc = -1;
 static int numCPUsPhysAll = -1;
 static int numCPUsLogAcc  = -1;
 static int numCPUsLogAll  = -1;
 
 int chpl_topo_getNumCPUsPhysical(chpl_bool accessible_only) {
-  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
-  okToReserveCPU = true;
+  okToReserveCPU = false;
   return (accessible_only) ? numCPUsPhysAcc : numCPUsPhysAll;
 }
 
 
 int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
-  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
   okToReserveCPU = false;
   return (accessible_only) ? numCPUsLogAcc : numCPUsLogAll;
 }
 
+
+
 //
-// Gets information about CPUs (cores and PUs) from the topology.
+// Initializes information about CPUs (cores and PUs) and and NICs from the
+// toplogy.
 //
-static
-void getCPUInfo(void) {
+
+void chpl_topo_post_comm_init(void) {
   //
   // accessible cores and PUs
   //
@@ -281,26 +270,74 @@ void getCPUInfo(void) {
   // get that by counting the parent cores of the accessible PUs.
   //
 
+  // accessible PUs
+
   //
   // We could seemingly use hwloc_topology_get_allowed_cpuset() to get
   // the set of accessible PUs here.  But that seems not to reflect the
   // schedaffinity settings, so use hwloc_get_proc_cpubind() instead.
   //
-  if (hwloc_get_proc_cpubind(topology, getpid(), logAccSet, 0) != 0) {
-#ifdef __APPLE__
-    const int errRecoverable = (errno == ENOSYS); // no cpubind on macOS
-#else
-    const int errRecoverable = 0;
-#endif
-    if (errRecoverable) {
-      hwloc_bitmap_fill(logAccSet);
-    } else {
-      REPORT_ERR_ERRNO(hwloc_get_proc_cpubind(topology, getpid(), logAccSet, 0)
-                       == 0);
-    }
+  if (topoSupport->cpubind->get_proc_cpubind) {
+    int rc = hwloc_get_proc_cpubind(topology, getpid(), logAccSet, 0);
+    CHK_ERR_ERRNO(rc == 0);
+  } else {
+    // assume all PUs are accessible
+    hwloc_bitmap_fill(logAccSet);
   }
   hwloc_bitmap_and(logAccSet, logAccSet,
                    hwloc_topology_get_online_cpuset(topology));
+  numCPUsLogAcc = hwloc_bitmap_weight(logAccSet);
+  CHK_ERR(numCPUsLogAcc > 0);
+
+  //
+  // all PUs
+  //
+  numCPUsLogAll = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+  CHK_ERR(numCPUsLogAll > 0);
+  //
+  // If some PUs are inaccesssible to us then assume we've been restricted to
+  // certain PUs at a higher level such as by the launcher. If so, use all
+  // accessible PUs. Otherwise, if we can access all PUs but we are sharing
+  // the machine with other locales then the number of locales must equal the
+  // number of sockets and we get our own socket.
+  //
+
+  int numLocalesOnNode = chpl_get_num_locales_on_node();
+  int rank = chpl_get_local_rank();
+  if ((numCPUsLogAcc == numCPUsLogAll) && (numLocalesOnNode > 1) &&
+      (rank != -1)) {
+    int numSockets = hwloc_get_nbobjs_inside_cpuset_by_type(topology,
+                          root->cpuset, HWLOC_OBJ_PACKAGE);
+    if (numSockets != numLocalesOnNode) {
+      char msg[100];
+      snprintf(msg, sizeof(msg), "The number of locales on the node does not "
+               "equal the number of sockets (%d != %d).", numLocalesOnNode,
+               numSockets);
+      chpl_error(msg, 0, 0);
+    }
+
+    // Each locale gets its own socket.
+
+    hwloc_obj_t socket = hwloc_get_obj_inside_cpuset_by_type(topology,
+                              root->cpuset, HWLOC_OBJ_PACKAGE, rank);
+    CHK_ERR(socket != NULL);
+
+    _DBG_P("using socket %d", socket->logical_index);
+
+    // Limit the accessible PUs to those in our socket.
+
+    hwloc_bitmap_and(logAccSet, logAccSet, socket->cpuset);
+    numCPUsLogAcc = hwloc_bitmap_weight(logAccSet);
+    CHK_ERR(numCPUsLogAcc > 0);
+#ifdef DEBUG
+    char buf[1024];
+    hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
+    _DBG_P("numCPUsLogAcc: %d logAccSet: %s", numCPUsLogAcc, buf);
+#endif
+    root = socket;
+  }
+
+// accessible cores
 
 #define NEXT_PU(pu)                                                \
   hwloc_get_next_obj_inside_cpuset_by_type(topology, logAccSet,    \
@@ -330,17 +367,37 @@ void getCPUInfo(void) {
   CHK_ERR(numCPUsPhysAll > 0);
 
   //
-  // accessible PUs
+  // Find the NUMA nodes, that is, the objects at numaLevel that also
+  // have CPUs.  This is as opposed to things like Xeon Phi HBM, which
+  // is memory-only, no CPUs.  Allow for overriding this through the
+  // environment.
   //
-  numCPUsLogAcc = hwloc_bitmap_weight(logAccSet);
-  CHK_ERR(numCPUsLogAcc > 0);
+  if (strcmp(CHPL_LOCALE_MODEL, "flat") != 0) {
+    //
+    // The number of NUMA domains only matters for locale models other
+    // than 'flat'.
+    //
+    numNumaDomains = (int) chpl_env_rt_get_uint("NUM_NUMA_DOMAINS", 0);
+  }
 
-  //
-  // all PUs
-  //
-  numCPUsLogAll = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-  CHK_ERR(numCPUsLogAll > 0);
+  if (numNumaDomains == 0) {
+    numNumaDomains =
+      hwloc_get_nbobjs_inside_cpuset_by_depth(topology, root->cpuset,
+                                              numaLevel);
+    _DBG_P("numNumaDomains %d", numNumaDomains);
+  }
+#ifdef DEBUG
+  char buf[1024];
+  _DBG_P("%d numCPUsLogAll: %d", getpid(), numCPUsLogAll);
+  hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
+  _DBG_P("%d numCPUsLogAcc: %d logAccSet: %s", getpid(), numCPUsLogAcc, buf);
+
+  _DBG_P("%d numCPUsPhysAll: %d", getpid(), numCPUsPhysAll);
+  hwloc_bitmap_list_snprintf(buf, sizeof(buf), physAccSet);
+  _DBG_P("%d numCPUsPhysAcc: %d physAccSet: %s", getpid(), numCPUsPhysAcc, buf);
+#endif
 }
+
 
 //
 // Fills the "cpus" array with the hwloc "cpuset" (a bitmap whose bits are
@@ -368,7 +425,6 @@ int getCPUs(hwloc_cpuset_t cpuset, int *cpus, int size) {
 //
 int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count) {
   // Initializes CPU information.
-  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
   okToReserveCPU = false;
   return getCPUs(physical ? physAccSet : logAccSet, cpus, count);
 }
@@ -397,9 +453,17 @@ void chpl_topo_setThreadLocality(c_sublocid_t subloc) {
   hwloc_cpuset_from_nodeset(topology, cpuset,
                             getNumaObj(subloc)->allowed_nodeset);
 
+  // Only use accessible CPUs.
+
+  hwloc_bitmap_and(cpuset, cpuset, logAccSet);
+
   flags = HWLOC_CPUBIND_THREAD | HWLOC_CPUBIND_STRICT;
   CHK_ERR_ERRNO(hwloc_set_cpubind(topology, cpuset, flags) == 0);
-
+#ifdef DEBUG
+  char buf[1024];
+  hwloc_bitmap_list_snprintf(buf, sizeof(buf), cpuset);
+  _DBG_P("chpl_topo_setThreadLocality(%d): %s", (int) subloc, buf);
+#endif
   hwloc_bitmap_free(cpuset);
 }
 
@@ -549,9 +613,7 @@ static inline
 hwloc_obj_t getNumaObj(c_sublocid_t subloc) {
   // could easily imagine this being a bit slow, but it's okay for now
   return
-    hwloc_get_obj_inside_cpuset_by_depth(topology,
-                                         hwloc_get_root_obj(topology)->cpuset,
-                                         numaLevel,
+    hwloc_get_obj_inside_cpuset_by_depth(topology, root->cpuset, numaLevel,
                                          subloc);
 }
 
@@ -596,9 +658,7 @@ void chpl_topo_interleaveMemLocality(void* p, size_t size) {
   }
 
   hwloc_bitmap_t set;
-  hwloc_obj_t obj;
-  obj = hwloc_get_root_obj(topology);
-  set = hwloc_bitmap_dup(obj->cpuset);
+  set = hwloc_bitmap_dup(root->cpuset);
 
   flags = 0;
   CHK_ERR_ERRNO(hwloc_set_area_membind(topology, p, size, set, HWLOC_MEMBIND_INTERLEAVE, flags) == 0);
@@ -678,9 +738,12 @@ c_sublocid_t chpl_topo_getMemLocality(void* p) {
 int
 chpl_topo_reserveCPUPhysical(void) {
   int id = -1;
-  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
+  _DBG_P("topoSupport->cpubind->set_thisthread_cpubind: %d",
+         topoSupport->cpubind->set_thisthread_cpubind);
+  _DBG_P("numCPUsPhysAcc: %d", numCPUsPhysAcc);
   if (okToReserveCPU) {
-    if (topoSupport->cpubind->set_thisthread_cpubind && (numCPUsPhysAcc > 1)) {
+    if ((topoSupport->cpubind->set_thisthread_cpubind) &&
+        (numCPUsPhysAcc > 1)) {
 
 #ifdef DEBUG
       char buf[1024];
@@ -742,8 +805,8 @@ chpl_topo_reserveCPUPhysical(void) {
 //
 int chpl_topo_bindCPU(int id) {
   int status = 1;
-  CHK_ERR(pthread_once(&numCPUs_ctrl, getCPUInfo) == 0);
-  if (hwloc_bitmap_isset(physReservedSet, id)) {
+  if (hwloc_bitmap_isset(physReservedSet, id) &&
+      (topoSupport->cpubind->set_thisthread_cpubind)) {
     int flags = HWLOC_CPUBIND_THREAD | HWLOC_CPUBIND_STRICT;
     hwloc_cpuset_t cpuset;
     CHK_ERR_ERRNO((cpuset = hwloc_bitmap_alloc()) != NULL);

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -351,10 +351,10 @@ void chpl_topo_post_comm_init(void) {
     }
 
     // We get our own socket if all cores are accessible, we know our local
-    // rank, and the number of locales on the node equals the number of
-    // sockets. It is an error if the number of locales on the node is greater
-    // than the number of sockets and CHPL_RT_LOCALES_PER_NODE is set,
-    // otherwise we are oversubscribed.
+    // rank, and the number of locales on the node is less than or equal to
+    // the number of sockets. It is an error if the number of locales on the
+    // node is greater than the number of sockets and CHPL_RT_LOCALES_PER_NODE
+    // is set, otherwise we are oversubscribed.
 
     // TODO: The oversubscription determination is incorrect. A node is only
     // oversubscribed if locales are sharing cores. Need to figure out how
@@ -392,8 +392,8 @@ void chpl_topo_post_comm_init(void) {
         }
       } else if (expectedLocalesOnNode > 0) {
         char msg[100];
-        snprintf(msg, sizeof(msg), "The number of locales on the node does "
-                 "not equal the number of sockets (%d != %d).",
+        snprintf(msg, sizeof(msg), "The number of locales on the node is "
+                 "greater than the number of sockets (%d > %d).",
                  numLocalesOnNode, numSockets);
         chpl_error(msg, 0, 0);
       }

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -206,6 +206,7 @@ void chpl_topo_init(void) {
       }
     }
   }
+  oversubscribed = chpl_env_rt_get_bool("OVERSUBSCRIBED", false);
 }
 
 
@@ -297,55 +298,52 @@ void chpl_topo_post_comm_init(void) {
   //
   numCPUsLogAll = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
   CHK_ERR(numCPUsLogAll > 0);
-  //
-  // If some PUs are inaccesssible to us then assume we've been restricted to
-  // certain PUs at a higher level such as by the launcher. If so, use all
-  // accessible PUs. Otherwise, if we can access all PUs but we are sharing
-  // the machine with other locales then the number of locales must equal the
-  // number of sockets and we get our own socket.
-  //
+
+  // If there is more than one locale on the node then we are oversubscribed
+  // if there isn't one locale per socket. If CHPL_RT_LOCALES_PER_NODE is
+  // set then it's an error if there isn't one locale per socket.
 
   int numLocalesOnNode = chpl_get_num_locales_on_node();
   int rank = chpl_get_local_rank();
-  if ((numCPUsLogAcc == numCPUsLogAll) && (numLocalesOnNode > 1) &&
-      (rank != -1)) {
+  if (numLocalesOnNode > 1) {
     int numSockets = hwloc_get_nbobjs_inside_cpuset_by_type(topology,
-                          root->cpuset, HWLOC_OBJ_PACKAGE);
-    if (numSockets != numLocalesOnNode) {
-
-      // If CHPL_RT_LOCALES_PER_NODE is set then the number of locales
-      // must equal the number of sockets.
+                        root->cpuset, HWLOC_OBJ_PACKAGE);
+    if (numLocalesOnNode != numSockets) {
+      oversubscribed = true;
       if (chpl_env_rt_get("LOCALES_PER_NODE", NULL) != NULL) {
         char msg[100];
         snprintf(msg, sizeof(msg), "The number of locales on the node does "
                  "not equal the number of sockets (%d != %d).",
                  numLocalesOnNode, numSockets);
         chpl_error(msg, 0, 0);
-      } else {
-        // We are oversubscribed.
-        oversubscribed = true;
+      }
+
+    // If we have access to all PUs and we know our rank, then only use the
+    // PUs in our socket. Otherwise, we'll use all of the PUs accessible
+    // to us.
+
+    } else if (numCPUsLogAcc == numCPUsLogAll) {
+      if (rank != -1) {
+        hwloc_obj_t socket = hwloc_get_obj_inside_cpuset_by_type(topology,
+                                  root->cpuset, HWLOC_OBJ_PACKAGE, rank);
+        CHK_ERR(socket != NULL);
+
+        _DBG_P("using socket %d", socket->logical_index);
+
+        // Limit the accessible PUs to those in our socket.
+
+        hwloc_bitmap_and(logAccSet, logAccSet, socket->cpuset);
+        numCPUsLogAcc = hwloc_bitmap_weight(logAccSet);
+        CHK_ERR(numCPUsLogAcc > 0);
+#ifdef DEBUG
+        char buf[1024];
+        hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
+        _DBG_P("numCPUsLogAcc: %d logAccSet: %s", numCPUsLogAcc, buf);
+#endif
+        root = socket;
       }
     } else {
-
-      // Each locale gets its own socket.
-
-      hwloc_obj_t socket = hwloc_get_obj_inside_cpuset_by_type(topology,
-                                root->cpuset, HWLOC_OBJ_PACKAGE, rank);
-      CHK_ERR(socket != NULL);
-
-      _DBG_P("using socket %d", socket->logical_index);
-
-      // Limit the accessible PUs to those in our socket.
-
-      hwloc_bitmap_and(logAccSet, logAccSet, socket->cpuset);
-      numCPUsLogAcc = hwloc_bitmap_weight(logAccSet);
-      CHK_ERR(numCPUsLogAcc > 0);
-#ifdef DEBUG
-      char buf[1024];
-      hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
-      _DBG_P("numCPUsLogAcc: %d logAccSet: %s", numCPUsLogAcc, buf);
-#endif
-      root = socket;
+      oversubscribed = true;
     }
   }
 

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -34,6 +34,9 @@
 void chpl_topo_init(void) { }
 
 
+void chpl_topo_post_comm_init(void) { }
+
+
 void chpl_topo_exit(void) { }
 
 

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -36,6 +36,7 @@ void chpl_topo_init(void) { }
 
 void chpl_topo_post_comm_init(void) { }
 
+void chpl_topo_post_args_init(void) { }
 
 void chpl_topo_exit(void) { }
 

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -100,3 +100,7 @@ void chpl_topo_touchMemFromSubloc(void* p, size_t size, chpl_bool onlyInside,
 c_sublocid_t chpl_topo_getMemLocality(void* p) {
   return c_sublocid_any;
 }
+
+chpl_bool chpl_topo_isOversubscribed(void) {
+  return false;
+}

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
@@ -8,7 +8,7 @@ fi
 
 echo "EVARS=vals" \
      "srun --job-name=CHPL-testVFlag --quiet" \
-     "--nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N" \
+     "--nodes=1 --ntasks=1 --cpus-per-task=N --cpu-bind=none" \
      "--exclusive${CHPL_LAUNCHER_MEM:+ --mem=M}" \
      "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P}${CHPL_LAUNCHER_EXCLUDE:+ --exclude=E} " \
      "./testVFlag_real -v -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVFlag.prediff
@@ -49,10 +49,15 @@ case $target in
 esac
 
 # With Qthreads, -v results in some lines of QTHREADS info we don't need.
+# We also don't need oversubscription status.
 case $tasks in
-  qthreads) grep -v '^QTHREADS' $2 > $2.tmp &&
+  qthreads) grep -v -e '^QTHREADS' -e '^oversubscribed' $2 > $2.tmp &&
             mv $2.tmp $2;;
 esac
+
+# Remove info related to running one locale per socket
+
+grep -v '^0: using socket' $2 > $2.tmp && mv $2.tmp $2
 
 # If we use the amudprun launcher, there's a path on the front of it.
 # If we use the aprun launcher, the depth (-d) value may vary, and also

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
@@ -8,7 +8,7 @@ fi
 
 echo "EVARS=vals" \
      "srun --job-name=CHPL-testVerbos --quiet" \
-     "--nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N" \
+     "--nodes=1 --ntasks=1 --cpus-per-task=N --cpu-bind=none" \
      "--exclusive${CHPL_LAUNCHER_MEM:+ --mem=M}" \
      "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P}${CHPL_LAUNCHER_EXCLUDE:+ --exclude=E} " \
      "./testVerboseFlag_real --verbose -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
@@ -49,10 +49,15 @@ case $target in
 esac
 
 # With Qthreads, -v results in some lines of QTHREADS info we don't need.
+# We also don't need oversubscription status.
 case $tasks in
-  qthreads) grep -v '^QTHREADS' $2 > $2.tmp &&
+  qthreads) grep -v -e '^QTHREADS' -e '^oversubscribed' $2 > $2.tmp &&
             mv $2.tmp $2;;
 esac
+
+# Remove info related to running one locale per socket
+
+grep -v '^0: using socket' $2 > $2.tmp && mv $2.tmp $2
 
 # If we use the amudprun launcher, there's a path on the front of it.
 # If we use the aprun launcher, the depth (-d) value may vary, and also

--- a/test/runtime/jhh/lps_test.chpl
+++ b/test/runtime/jhh/lps_test.chpl
@@ -1,0 +1,2 @@
+// Simple hello world
+writeln("Hello, world!");    // print 'Hello, world!' to the console

--- a/test/runtime/jhh/lps_test.py
+++ b/test/runtime/jhh/lps_test.py
@@ -32,7 +32,7 @@ class LocalePerSocket(unittest.TestCase):
         checkConfig()
         proc = run(["sinfo", "--format=%X %Y %Z", "--noheader",
                    "--exact"])
-        (cls.sockets, cls.cores, cls.threads) =
+        (cls.sockets, cls.cores, cls.threads) = \
             [int(i) for i in proc.stdout.split()]
 
         # We need the qthread output
@@ -64,7 +64,6 @@ class LocalePerSocket(unittest.TestCase):
                   cpuBind, output):
         self.assertIn('--nodes=%d' % nodes, output)
         self.assertIn('--ntasks=%d' % tasks, output)
-        self.assertIn('--ntasks-per-node=%d' % tasksPerNode, output)
         self.assertIn('--cpus-per-task=%d' % cpusPerTask, output)
         if (cpuBind != None):
             self.assertIn('--cpu-bind=%s' % cpuBind, output)

--- a/test/runtime/jhh/lps_test.py
+++ b/test/runtime/jhh/lps_test.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
-import unittest 
+"""
+Locale-per-socket tests. Usage: ./lps_test.py. The -v flag prints
+verbose output, the -f flag will cause testing to stop when the
+first test fails.
+"""
+
+import unittest
 import subprocess
 import os
 import sys
@@ -55,7 +61,7 @@ class LocalePerSocket(unittest.TestCase):
 
         # Should not be set by default
         if 'CHPL_RT_LOCALES_PER_NODE' in os.environ:
-            del os.environ['CHPL_RT_LOCALES_PER_NODE'] 
+            del os.environ['CHPL_RT_LOCALES_PER_NODE']
 
         # Compile the test program
         if verbose:
@@ -100,15 +106,17 @@ class LocalePerSocket(unittest.TestCase):
                 if "FI_MR_ALLOCATED" in line:
                     return True
                 else:
-                    return False
-        return None # should not get here
+                    break
+        return False
 
     def test_00_base(self):
-        global cls 
+        global cls
         proc = run("./lps_test -nl 2 -v")
-        self.checkArgs(2, 2, 1, self.sockets * self.cores * self.threads, None, proc.stdout)
+        self.checkArgs(2, 2, 1, self.sockets * self.cores * self.threads,
+                       None, proc.stdout)
         self.assertIn('oversubscribed = False', proc.stdout)
-        self.assertIn('Using %d Shepherds' % (self.sockets * self.cores), proc.stdout)
+        self.assertIn('Using %d Shepherds' % (self.sockets * self.cores),
+                      proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getCores("all"),
                       proc.stdout)
 
@@ -120,9 +128,11 @@ class LocalePerSocket(unittest.TestCase):
         env = os.environ.copy()
         env['CHPL_RT_OVERSUBSCRIBED'] = 'true'
         proc = run("./lps_test -nl 2 -v", env=env)
-        self.checkArgs(2, 2, 1, self.sockets * self.cores * self.threads, None, proc.stdout)
+        self.checkArgs(2, 2, 1, self.sockets * self.cores * self.threads,
+                       None, proc.stdout)
         self.assertIn('oversubscribed = True', proc.stdout)
-        self.assertIn('Using %s Shepherds' % (self.sockets * self.cores), proc.stdout)
+        self.assertIn('Using %s Shepherds' % (self.sockets * self.cores),
+                      proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getCores("all"), proc.stdout)
 
     def test_02_two_lpn(self):
@@ -153,7 +163,8 @@ class LocalePerSocket(unittest.TestCase):
         env = os.environ.copy()
         env['CHPL_RT_LOCALES_PER_NODE'] = '2'
         proc = run(['./lps_test', '-nl', '1', '-v'], env=env)
-        self.checkArgs(1, 1, 2, self.sockets * self.cores * self.threads, 'none', proc.stdout)
+        self.checkArgs(1, 1, 2, self.sockets * self.cores * self.threads,
+                       'none', proc.stdout)
         self.assertIn('using socket 0', proc.stdout)
         self.assertIn('Using %s Shepherds' % self.cores, proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getCores(0), proc.stdout)
@@ -192,12 +203,14 @@ class LocalePerSocket(unittest.TestCase):
         # One worker per PU.
         env = os.environ.copy()
         env['CHPL_RT_LOCALES_PER_NODE'] = '2'
-        env['CHPL_RT_NUM_THREADS_PER_LOCALE'] = '%s' % (self.sockets * self.cores)
+        env['CHPL_RT_NUM_THREADS_PER_LOCALE'] = \
+            '%s' % (self.sockets * self.cores)
         proc = run("./lps_test -nl 2 -v", env=env)
         self.checkArgs(1, 2, 2, self.sockets * self.cores, 'none', proc.stdout)
         self.assertIn('using socket 0', proc.stdout)
         self.assertIn('using socket 1', proc.stdout)
-        self.assertIn('Using %s Shepherds' % (self.sockets * self.cores), proc.stdout)
+        self.assertIn('Using %s Shepherds' % (self.sockets * self.cores),
+                      proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getThreads(0), proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getThreads(1), proc.stdout)
 
@@ -213,7 +226,8 @@ class LocalePerSocket(unittest.TestCase):
         self.checkArgs(1, 2, 2, self.sockets * self.cores, 'none', proc.stdout)
         self.assertIn('using socket 0', proc.stdout)
         self.assertIn('using socket 1', proc.stdout)
-        self.assertIn('Using %s Shepherds' % (self.sockets * self.cores), proc.stdout)
+        self.assertIn('Using %s Shepherds' % (self.sockets * self.cores),
+                      proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getThreads(0), proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getThreads(1), proc.stdout)
 
@@ -241,7 +255,8 @@ class LocalePerSocket(unittest.TestCase):
         self.checkArgs(1, 2, 2, self.sockets * self.cores, 'none', proc.stdout)
         self.assertIn('using socket 0', proc.stdout)
         self.assertIn('using socket 1', proc.stdout)
-        self.assertIn('Using %d Shepherds' % (self.sockets * self.cores - 2), proc.stdout)
+        self.assertIn('Using %d Shepherds' % (self.sockets * self.cores - 2),
+                      proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getThreads(0,1),
                       proc.stdout)
         self.assertIn("QT_CPUBIND = " + self.getThreads(1,1),

--- a/test/runtime/jhh/lps_test.py
+++ b/test/runtime/jhh/lps_test.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+
+import unittest 
+import subprocess
+import os
+import sys
+
+def run(cmd, env=None):
+    if type(cmd) is str:
+        cmd = cmd.split()
+    if env is None:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              check=True)
+    else:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              check=True, env=env)
+    return proc
+
+def checkConfig():
+    # These tests only run on comm=ofi and slurm-srun
+    proc = run("printchplenv --simple")
+    for line in proc.stdout.splitlines():
+        (key, value) = line.split('=')
+        if key == 'CHPL_COMM' and value != 'ofi':
+            raise unittest.SkipTest("CHPL_COMM != ofi")
+        if key == 'CHPL_LAUNCHER' and value != 'slurm-srun':
+            raise unittest.SkipTest("CHPL_LAUNCHER != slurm-srun")
+
+class LocalePerSocket(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        checkConfig()
+        proc = run(["sinfo", "--format=%X %Y %Z", "--noheader",
+                   "--exact"])
+        (cls.sockets, cls.cores, cls.threads) =
+            [int(i) for i in proc.stdout.split()]
+
+        # We need the qthread output
+        os.environ['QTHREAD_INFO'] = '2'
+
+        # Compile the test program
+        run('chpl hello.chpl')
+
+    def setUp(self):
+        pass
+
+    def getCores(self, socket, reserved = 0):
+        if socket == "all":
+            return ':'.join([self.getCores(i)
+                            for i in range(0,self.sockets)])
+        else:
+            return ':'.join([str(i + (socket * self.cores))
+                            for i in range(0,self.cores-reserved)])
+
+    def getThreads(self, socket, reserved = 0):
+        if socket == "all":
+            return ':'.join([self.getCores(i, reserved)
+                        for i in range(0,self.sockets * self.threads)])
+        return ':'.join([self.getCores(socket + i * self.sockets,
+                        reserved) for i in range(0, self.threads)])
+
+    # Check standard srun arguments
+    def checkArgs(self, nodes, tasks, tasksPerNode, cpusPerTask,
+                  cpuBind, output):
+        self.assertIn('--nodes=%d' % nodes, output)
+        self.assertIn('--ntasks=%d' % tasks, output)
+        self.assertIn('--ntasks-per-node=%d' % tasksPerNode, output)
+        self.assertIn('--cpus-per-task=%d' % cpusPerTask, output)
+        if (cpuBind != None):
+            self.assertIn('--cpu-bind=%s' % cpuBind, output)
+        else:
+            self.assertNotIn('--cpu-bind', output)
+
+    def test_00_base(self):
+        proc = run("./hello -nl 2 -v")
+        self.checkArgs(2, 2, 1, 256, None, proc.stdout)
+        self.assertIn('oversubscribed = False', proc.stdout)
+        self.assertIn('Using 128 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores("all"),
+                      proc.stdout)
+
+    def test_01_oversubscribed_env(self):
+        # Being oversubscribed should have no effect on the number
+        # of shepherds.
+        env = os.environ.copy()
+        env['CHPL_RT_OVERSUBSCRIBED'] = 'true'
+        proc = run("./hello -nl 2 -v", env=env)
+        self.checkArgs(2, 2, 1, 256, None, proc.stdout)
+        self.assertIn('oversubscribed = True', proc.stdout)
+        self.assertIn('Using 128 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores("all"), proc.stdout)
+
+    def test_02_two_lpn(self):
+        # One locale per socket. Each locale only uses the cores in
+        # its socket.
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        proc = run("./hello -nl 2 -v", env=env)
+        self.checkArgs(1, 2, 2, 128, 'none', proc.stdout)
+        self.assertIn('using socket 0', proc.stdout)
+        self.assertIn('using socket 1', proc.stdout)
+        self.assertIn('Using 64 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(0), proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(1), proc.stdout)
+
+    def test_03_four_lpn(self):
+        # Four locales per node is an error if CHPL_RT_LOCALES_PER_NODE
+        # is set.
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '4'
+        proc = run(['./hello', '-nl', '4', '-v'], env=env)
+        self.assertIn('error: The number of locales on the node does '
+                      'not equal the number of sockets (4 != 2).',
+                      proc.stderr)
+
+    def test_04_one_locale(self):
+        # One locale uses only the cores in its socket.
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        proc = run(['./hello', '-nl', '1', '-v'], env=env)
+        self.checkArgs(1, 1, 2, 256, 'none', proc.stdout)
+        self.assertIn('using socket 0', proc.stdout)
+        self.assertIn('Using 64 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(0), proc.stdout)
+
+    def test_05_two_lpn_oversubscribed(self):
+        # CHPL_RT_OVERSUBSCRIBED should have no effect when there is
+        # one locale per socket
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        env['CHPL_RT_OVERSUBSCRIBED'] = 'true'
+        proc = run("./hello -nl 2 -v", env=env)
+        self.checkArgs(1, 2, 2, 128, 'none', proc.stdout)
+        self.assertIn('using socket 0', proc.stdout)
+        self.assertIn('using socket 1', proc.stdout)
+        self.assertIn('oversubscribed = True', proc.stdout)
+        self.assertIn('Using 64 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(0), proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(1), proc.stdout)
+
+    def test_06_no_ht(self):
+        # SLURM_HINT=nomultithread should have no effect.
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        env['SLURM_HINT'] = 'nomultithread'
+        proc = run("./hello -nl 2 -v", env=env)
+        self.checkArgs(1, 2, 2, 128, 'none', proc.stdout)
+        self.assertIn('using socket 0', proc.stdout)
+        self.assertIn('using socket 1', proc.stdout)
+        self.assertIn('Using 64 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(0), proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(1), proc.stdout)
+
+    def test_07_ht_shepherds(self):
+        # One worker per PU.
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        env['CHPL_RT_NUM_THREADS_PER_LOCALE'] = '128'
+        proc = run("./hello -nl 2 -v", env=env)
+        self.checkArgs(1, 2, 2, 128, 'none', proc.stdout)
+        self.assertIn('using socket 0', proc.stdout)
+        self.assertIn('using socket 1', proc.stdout)
+        self.assertIn('Using 128 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getThreads(0), proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getThreads(1), proc.stdout)
+
+    def test_08_no_ht_ht_shepherds(self):
+        # SLURM_HINT=nomultithread should have no effect when
+        # CHPL_RT_NUM_THREADS_PER_LOCALE indicates to use
+        # hyperthreading.
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        env['CHPL_RT_NUM_THREADS_PER_LOCALE'] = '128'
+        env['SLURM_HINT'] = 'nomultithread'
+        proc = run("./hello -nl 2 -v", env=env)
+        self.checkArgs(1, 2, 2, 128, 'none', proc.stdout)
+        self.assertIn('using socket 0', proc.stdout)
+        self.assertIn('using socket 1', proc.stdout)
+        self.assertIn('Using 128 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getThreads(0), proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getThreads(1), proc.stdout)
+
+    def test_09_reserved(self):
+        # One core is reserved for the AM handler thread
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        env['CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES'] = 'true'
+        proc = run("./hello -nl 2 -v", env=env)
+        self.checkArgs(1, 2, 2, 128, 'none', proc.stdout)
+        self.assertIn('using socket 0', proc.stdout)
+        self.assertIn('using socket 1', proc.stdout)
+        self.assertIn('Using 63 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(0,1), proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getCores(1,1), proc.stdout)
+
+    def test_10_ht_reserved(self):
+        # One core is reserved for the AM handler thread when using
+        # hyperthreading.
+        env = os.environ.copy()
+        env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        env['CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES'] = 'true'
+        env['CHPL_RT_NUM_THREADS_PER_LOCALE'] = '128'
+        proc = run("./hello -nl 2 -v", env=env)
+        self.checkArgs(1, 2, 2, 128, 'none', proc.stdout)
+        self.assertIn('using socket 0', proc.stdout)
+        self.assertIn('using socket 1', proc.stdout)
+        self.assertIn('Using 126 Shepherds', proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getThreads(0,1),
+                      proc.stdout)
+        self.assertIn("QT_CPUBIND = " + self.getThreads(1,1),
+                      proc.stdout)
+
+    @unittest.skip("should not be considered oversubscribed")
+    def test_11_oversubscribed_no_env(self):
+        # Detect and allow oversubscription w/out CHPL_RT_OVERSUBSCRIBED
+        # and CHPL_RT_LOCALES_PER_NODE set.
+        env = os.environ.copy()
+        env['PMI_MAX_KVS_ENTRIES'] = '20'
+        env['PMI_NO_PREINITIALIZE'] = 'y'
+        proc = run(['srun', '-l', '--quiet', '--nodes=1', '--ntasks=3',
+                    '--ntasks-per-node=3', '--cpus-per-task=16',
+                    '--exclusive', '--kill-on-bad-exit',
+                    './hello_real', '-nl', '3', '-v'], env=env)
+        self.assertIn('oversubscribed = True', proc.stdout)
+        self.assertIn('Using 8 Shepherds', proc.stdout)
+
+def main(argv):
+    failfast = False
+    if "-f" in argv:
+        failfast = True
+        del argv["-f"]
+    unittest.main(argv=argv, failfast=failfast)
+
+if __name__ == '__main__':
+    main(sys.argv)
+

--- a/test/runtime/jhh/lps_test.py
+++ b/test/runtime/jhh/lps_test.py
@@ -38,6 +38,10 @@ class LocalePerSocket(unittest.TestCase):
         # We need the qthread output
         os.environ['QTHREAD_INFO'] = '2'
 
+        # Should not be set by default
+        if 'CHPL_RT_LOCALES_PER_NODE' in os.environ:
+            del os.environ['CHPL_RT_LOCALES_PER_NODE'] 
+
         # Compile the test program
         run('chpl hello.chpl')
 

--- a/util/test/prediff-for-slurm
+++ b/util/test/prediff-for-slurm
@@ -11,6 +11,8 @@ msgs = (
 """,
 """srun: error: .+: task [0-9]+: (Killed|Terminated)
 """,
+"""srun: error: .+: tasks [0-9]+-[0-9]+: (Killed|Terminated)
+""",
 """srun: .*(Force Terminated|Terminating) (job step |StepId=)[0-9.]+
 """,
 """srun: Job step aborted: Waiting up to [0-9]+ seconds for job step .*


### PR DESCRIPTION
Adds the ability to run multiple locales per node as determined by the CHPL_RT_LOCALES_PER_NODE environment variable. The default is to run one locale per node. If the number of locales per node is less than or equal to the number of sockets, then each locale uses only the cores associated with its socket. 

This functionality is only supported for the following configuration:

CHPL_COMM = ofi
CHPL_LAUNCHER = slurm-srun
CHPL_COMM_OFI_OOB = pmi2
CHPL_TASKS = qthreads
CHPL_QTHREAD_TOPOLOGY = binders
CHPL_HWLOC = bundled
