### PR TITLE
Add debug flags for topo and tasks layers

### DIFF
--- a/runtime/src/tasks/qthreads/Makefile
+++ b/runtime/src/tasks/qthreads/Makefile
@@ -19,6 +19,14 @@
 RUNTIME_ROOT = ../../..
 RUNTIME_SUBDIR = src/tasks/$(CHPL_MAKE_TASKS)
 
+ifdef CHPL_TASKS_DEBUG
+RUNTIME_DEFS += -DDEBUG
+endif
+
+ifdef DEBUG_NODEID
+RUNTIME_DEFS += -DDEBUG_NODEID
+endif
+
 ifndef CHPL_MAKE_HOME
 export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
 endif

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -66,6 +66,24 @@
 #include <unistd.h>
 #include <math.h>
 
+#ifdef DEBUG
+// note: format arg 'f' must be a string constant
+#ifdef DEBUG_NODEID
+#define _DBG_P(f, ...)                                                  \
+        do {                                                            \
+          printf("%d:%s:%d: " f "\n", chpl_nodeID, __FILE__, __LINE__,  \
+                                      ## __VA_ARGS__);                  \
+        } while (0)
+#else
+#define _DBG_P(f, ...)                                                  \
+        do {                                                            \
+          printf("%s:%d: " f "\n", __FILE__, __LINE__, ## __VA_ARGS__); \
+        } while (0)
+#endif
+#else
+#define _DBG_P(f, ...)
+#endif
+
 #define ALIGN_DN(i, size)  ((i) & ~((size) - 1))
 #define ALIGN_UP(i, size)  ALIGN_DN((i) + (size) - 1, size)
 

--- a/runtime/src/topo/hwloc/Makefile
+++ b/runtime/src/topo/hwloc/Makefile
@@ -19,6 +19,14 @@
 RUNTIME_ROOT = ../../..
 RUNTIME_SUBDIR = src/topo/hwloc
 
+ifdef CHPL_TOPO_DEBUG
+RUNTIME_DEFS += -DDEBUG
+endif
+
+ifdef DEBUG_NODEID
+RUNTIME_DEFS += -DDEBUG_NODEID
+endif
+
 ifndef CHPL_MAKE_HOME
 export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
 endif

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -29,6 +29,7 @@
 #include "chplcgfns.h"
 #include "chplsys.h"
 #include "chpl-topo.h"
+#include "chpl-comm.h"
 #include "chpltypes.h"
 #include "error.h"
 
@@ -44,10 +45,18 @@
 
 #ifdef DEBUG
 // note: format arg 'f' must be a string constant
+#ifdef DEBUG_NODEID
+#define _DBG_P(f, ...)                                                  \
+        do {                                                            \
+          printf("%d:%s:%d: " f "\n", chpl_nodeID, __FILE__, __LINE__,  \
+                                      ## __VA_ARGS__);                  \
+        } while (0)
+#else
 #define _DBG_P(f, ...)                                                  \
         do {                                                            \
           printf("%s:%d: " f "\n", __FILE__, __LINE__, ## __VA_ARGS__); \
         } while (0)
+#endif
 #else
 #define _DBG_P(f, ...)
 #endif


### PR DESCRIPTION
Add `CHPL_TOPO_DEBUG` and `CHPL_TASKS_DEBUG` that turn on debug messages for the `topo` and `tasks` runtime layers, respectively. In addition, `DEBUG_NODEID` controls whether or not the node ID is printed as a prefix to the debug messages.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>