### PR TITLE
Fix an issue in log parsing where the special chars are evaluated in the merge log/

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -28,7 +28,7 @@ jobs:
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
-              echo "LOG= $(echo '${{github.event.pull_request.body}}' | sed 's/\`//g'| sed 's/\\n/<br>/g' | sed 's/\\r/ /g' ) " >> $GITHUB_ENV
+              echo "LOG= $(echo '${{github.event.pull_request.body}}' | sed 's/\\n/<br>/g' | sed 's/\\r/ /g' ) " >> $GITHUB_ENV
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -28,7 +28,7 @@ jobs:
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
-              echo "LOG= $(echo '${{github.event.pull_request.body}}'' | sed 's/\`//g'| sed 's/\\n/<br>/g' | sed 's/\\r/ /g' ) " >> $GITHUB_ENV
+              echo "LOG= $(echo '${{github.event.pull_request.body}}' | sed 's/\`//g'| sed 's/\\n/<br>/g' | sed 's/\\r/ /g' ) " >> $GITHUB_ENV
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -28,6 +28,7 @@ jobs:
               echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
+              echo "LOG= $(echo '${{github.event.pull_request.body}}'' | sed 's/\`//g'| sed 's/\\n/<br>/g' | sed 's/\\r/ /g' ) " >> $GITHUB_ENV
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.
@@ -67,7 +68,7 @@ jobs:
               Link: ${{github.event.pull_request._links.html.href}} <br>             
               Log Message: <br><br>
                            ${{env.MESSAGE}} <br> 
-                          ${{github.event.pull_request.body}} <br>
+                          ${{env.LOG}} <br>
               Compare: ${{env.COMPARE_URL}} <br> 
               Diff: ${{github.event.pull_request.diff_url}} <br>
               Modified Files: <br>


### PR DESCRIPTION
Special chars like @#, etc in the git description were evaluated.

Replacing  "double quotes"  around the git env with 'single quotes'.


Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>