### PR TITLE
Add support for displaying resulting assembly

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -145,12 +145,14 @@ bool shouldLlvmPrintIrFn(FnSymbol* fn) {
   return shouldLlvmPrintIrName(fn->name) || shouldLlvmPrintIrCName(fn->cname);
 }
 
-std::vector<const char*> gatherPrintLlvmIrCNames() {
-  std::vector<const char*> ret;
+std::vector<std::string> gatherPrintLlvmIrCNames() {
+  std::vector<std::string> ret;
   for (auto elt : llvmPrintIrCNames) {
-    ret.push_back(elt);
+    ret.push_back(std::string(elt));
   }
 
+  // sort the symbols by value to have deterministic ordering
+  std::sort(ret.begin(), ret.end());
   return ret;
 }
 

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -94,6 +94,7 @@ const char* llvmStageName[llvmStageNum::LAST] = {
   "none", //llvmStageNum::NONE
   "basic", //llvmStageNum::BASIC
   "full", //llvmStageNum::FULL
+  "asm", //llvmStageNum::ASM
   "every", //llvmStageNum::EVERY
   "early-as-possible",
   "module-optimizer-early",
@@ -142,6 +143,15 @@ bool shouldLlvmPrintIrCName(const char* name) {
 
 bool shouldLlvmPrintIrFn(FnSymbol* fn) {
   return shouldLlvmPrintIrName(fn->name) || shouldLlvmPrintIrCName(fn->cname);
+}
+
+std::vector<const char*> gatherPrintLlvmIrCNames() {
+  std::vector<const char*> ret;
+  for (auto elt : llvmPrintIrCNames) {
+    ret.push_back(elt);
+  }
+
+  return ret;
 }
 
 #ifdef HAVE_LLVM

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -99,7 +99,7 @@ const char* createDebuggerFile(const char* debugger, int argc, char* argv[]);
 
 std::string getChplDepsApp();
 bool compilingWithPrgEnv();
-std::string runCommand(std::string& command);
+std::string runCommand(const std::string& command);
 
 const char* filenameToModulename(const char* filename);
 

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -112,6 +112,7 @@ void expandInstallationPaths(std::string& arg);
 void expandInstallationPaths(std::vector<std::string>& args);
 
 bool isDirectory(const char* path);
+bool pathExists(const char* path);
 
 char*       chplRealPath(const char* path);
 char*       dirHasFile(const char* dir, const char* file);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -953,6 +953,7 @@ typedef enum {
        NONE,
        BASIC,
        FULL,
+       ASM,
        EVERY, // after every optimization if possible
        // These options allow instrumenting the pass pipeline
        // and match ExtensionPointTy in PassManagerBuilder
@@ -982,6 +983,7 @@ void addCNameToPrintLlvmIr(const char* name);
 bool shouldLlvmPrintIrName(const char* name);
 bool shouldLlvmPrintIrCName(const char* name);
 bool shouldLlvmPrintIrFn(FnSymbol* fn);
+std::vector<const char*> gatherPrintLlvmIrCNames();
 
 #ifdef HAVE_LLVM
 void printLlvmIr(const char* name, llvm::Function *func, llvmStageNum_t numStage);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -983,7 +983,7 @@ void addCNameToPrintLlvmIr(const char* name);
 bool shouldLlvmPrintIrName(const char* name);
 bool shouldLlvmPrintIrCName(const char* name);
 bool shouldLlvmPrintIrFn(FnSymbol* fn);
-std::vector<const char*> gatherPrintLlvmIrCNames();
+std::vector<std::string> gatherPrintLlvmIrCNames();
 
 #ifdef HAVE_LLVM
 void printLlvmIr(const char* name, llvm::Function *func, llvmStageNum_t numStage);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4305,6 +4305,7 @@ void makeBinaryLLVM(void) {
         std::vector<const char*> names = gatherPrintLlvmIrCNames();
         for (auto name : names) {
           printf("\n\n# Dissasembling symbol %s\n\n", name);
+          fflush(stdout);
           std::vector<std::string> cmd;
           cmd.push_back("objdump");
           std::string arg = "--disassemble=";

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3805,6 +3805,7 @@ bool getIrDumpExtensionPoint(llvmStageNum_t s,
     case llvmStageNum::BASIC:
     case llvmStageNum::FULL:
     case llvmStageNum::EVERY:
+    case llvmStageNum::ASM:
     case llvmStageNum::LAST:
       return false;
   }
@@ -4294,6 +4295,29 @@ void makeBinaryLLVM(void) {
 
       }
       outputOfile.close();
+
+      if (llvmPrintIrStageNum == llvmStageNum::ASM ||
+          llvmPrintIrStageNum == llvmStageNum::EVERY) {
+        if (myshell("which objdump > /dev/null 2>&1", "Check to see if fatbinary command can be found", true)) {
+          USR_FATAL("Command 'objdump' not found");
+        }
+
+        std::vector<const char*> names = gatherPrintLlvmIrCNames();
+        for (auto name : names) {
+          printf("\n\n# Dissasembling symbol %s\n\n", name);
+          std::vector<std::string> cmd;
+          cmd.push_back("objdump");
+          std::string arg = "--disassemble=";
+          arg += name;
+          cmd.push_back(arg);
+          cmd.push_back(moduleFilename);
+
+          mysystem(cmd, "dissassemble a symbol",
+                   /* ignoreStatus */ true,
+                   /* quiet */ false);
+        }
+      }
+
 
     } else {
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4527,7 +4527,12 @@ static void handlePrintAsm(std::string dotOFile) {
   if (llvmPrintIrStageNum == llvmStageNum::ASM ||
       llvmPrintIrStageNum == llvmStageNum::EVERY) {
 
-    // find the directory containing clang
+    // Find llvm-objdump as a sibling to clang
+    // note that if we have /path/to/clang-14, this logic
+    // will loop for /path/to/llvm-objdump-14.
+    //
+    // If such suffixes do not turn out to matter in practice, it would
+    // be nice to update this code to use sys::path::parent_path().
     std::vector<std::string> split;
     std::string llvmObjDump = "llvm-objdump";
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4298,7 +4298,7 @@ void makeBinaryLLVM(void) {
 
       if (llvmPrintIrStageNum == llvmStageNum::ASM ||
           llvmPrintIrStageNum == llvmStageNum::EVERY) {
-        if (myshell("which objdump > /dev/null 2>&1", "Check to see if fatbinary command can be found", true)) {
+        if (myshell("which objdump > /dev/null 2>&1", "Check to see if objdump command can be found", true)) {
           USR_FATAL("Command 'objdump' not found");
         }
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -958,6 +958,15 @@ bool isDirectory(const char* path)
   return false;
 }
 
+bool pathExists(const char* path)
+{
+  struct stat stats;
+  if (stat(path, &stats) == 0)
+    return true;
+
+  return false;
+}
+
 // would just use realpath, but it is not supported on all platforms.
 char* chplRealPath(const char* path)
 {

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -501,7 +501,7 @@ bool compilingWithPrgEnv() {
   return 0 != strcmp(CHPL_TARGET_COMPILER_PRGENV, "none");
 }
 
-std::string runCommand(std::string& command) {
+std::string runCommand(const std::string& command) {
   auto commandOutput = chpl::getCommandOutput(command);
   if (auto err = commandOutput.getError()) {
     USR_FATAL("failed to run '%s', error: %s",

--- a/test/compflags/ferguson/print-asm.chpl
+++ b/test/compflags/ferguson/print-asm.chpl
@@ -1,0 +1,19 @@
+config const n = 10_000;
+proc foo() {
+  var result = 0.0;
+  for i in 1..n {
+    result += sqrt(i*i);
+  }
+  return result;
+}
+
+proc bar() {
+  var total = 0.0;
+  for i in 1..10 {
+    total += foo();
+  }
+  return total;
+}
+
+writeln(foo());
+writeln(bar());

--- a/test/compflags/ferguson/print-asm.compopts
+++ b/test/compflags/ferguson/print-asm.compopts
@@ -1,0 +1,1 @@
+--llvm-print-ir foo,bar --llvm-print-ir-stage asm

--- a/test/compflags/ferguson/print-asm.good
+++ b/test/compflags/ferguson/print-asm.good
@@ -1,0 +1,4 @@
+# Dissasembling symbol foo_chpl
+ADDR <foo_chpl>:
+# Dissasembling symbol bar_chpl
+ADDR <bar_chpl>:

--- a/test/compflags/ferguson/print-asm.good
+++ b/test/compflags/ferguson/print-asm.good
@@ -1,4 +1,4 @@
-# Dissasembling symbol foo_chpl
-ADDR <foo_chpl>:
 # Dissasembling symbol bar_chpl
 ADDR <bar_chpl>:
+# Dissasembling symbol foo_chpl
+ADDR <foo_chpl>:

--- a/test/compflags/ferguson/print-asm.prediff
+++ b/test/compflags/ferguson/print-asm.prediff
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TEST=$1
+LOG=$2
+# PREDIFF: Script to execute before diff'ing output (arguments: <test
+#    executable>, <log>, <compiler executable>)
+
+cat $LOG | grep -e 'Dissasembling\|<foo_chpl>:\|<bar_chpl>:' | sed 's/^[0-9a-fA-F][0-9a-fA-F]*/ADDR/' > $LOG.tmp
+mv $LOG.tmp $LOG

--- a/test/compflags/ferguson/print-asm.prediff
+++ b/test/compflags/ferguson/print-asm.prediff
@@ -5,5 +5,8 @@ LOG=$2
 # PREDIFF: Script to execute before diff'ing output (arguments: <test
 #    executable>, <log>, <compiler executable>)
 
-cat $LOG | grep -e 'Dissasembling\|<foo_chpl>:\|<bar_chpl>:' | sed 's/^[0-9a-fA-F][0-9a-fA-F]*/ADDR/' > $LOG.tmp
+# Include only Dissasembling output and the symbol label
+# Hide addresses
+# Remove leading _ from symbol if it is present
+cat $LOG | grep -e 'Dissasembling\|foo_chpl>:\|bar_chpl>:' | sed 's/^[0-9a-fA-F][0-9a-fA-F]*/ADDR/' | sed 's/<_/</' > $LOG.tmp
 mv $LOG.tmp $LOG

--- a/test/compflags/ferguson/print-asm.skipif
+++ b/test/compflags/ferguson/print-asm.skipif
@@ -1,0 +1,2 @@
+# Asm printing currently only works with LLVM backend
+CHPL_TARGET_COMPILER != llvm


### PR DESCRIPTION
Resolves #15043

This adds 'asm' as a stage for 'llvm-print-ir' so that it can be displayed with, for example:

```
chpl bb.chpl --fast  --llvm-print-ir foo,bar --llvm-print-ir-stage asm
```

At present, this functionality only works with the LLVM backend.

This functionality works by running an `llvm-objdump` command, e.g. `llvm-objdump --disassemble-symbols=foo_chpl tmp/chpl__module.o`. It will fail if `llvm-objdump` is not installed along with the `clang` we are working with.

Reviewed by @ronawho - thanks!

- [x] full local testing

New test passes:

- [x] on a SLES 11 system
- [x] on a Mac OS X system with homebrew LLVM
- [x] on an Ubuntu 22.10 with system LLVM
- [x] on an Ubuntu 22.10 with bundled LLVM