### PR TITLE
Fix scope resolution of `super` at the end of a chain of dots.

### DIFF
--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1010,9 +1010,13 @@ doResolveImportStmt(Context* context, const Import* imp,
     // on it matching just one thing).
     // But, we don't do that for 'import M.f.{a,b,c}'
     if (auto dot = expr->toDot()) {
-      if (clause->limitationKind() != VisibilityClause::BRACES) {
-        expr = dot->receiver();
-        dotName = dot->field();
+      // super and this are special keywords, they should not be resolved
+      // via the dot-name mechanism here.
+      if (dot->field() != USTR("super") && dot->field() != USTR("this")) {
+        if (clause->limitationKind() != VisibilityClause::BRACES) {
+          expr = dot->receiver();
+          dotName = dot->field();
+        }
       }
     }
 

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -178,6 +178,11 @@ void gatherDeclsWithin(const uast::AstNode* ast,
     child->traverse(visitor);
   }
 
+  // For modules, also include the module's name itself.
+  if (auto mod = ast->toModule()) {
+    gather(visitor.declared, mod->name(), mod, uast::Decl::PUBLIC);
+  }
+
   declared.swap(visitor.declared);
   containsUseImport = visitor.containsUseImport;
   containsFunctionDecls = visitor.containsFunctionDecls;


### PR DESCRIPTION
This avoid performing the special logic for resolving overloaded functions when special keywords are being looked up.