### PR TITLE
Fix some import and module scope resolution issues

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -453,29 +453,6 @@ struct Converter {
             SymExpr* se = new SymExpr(sym);
             Expr* ret = se;
 
-
-            // TODO(Resolver): This logic should probably be handled from
-            //                 within Dyno.
-            if (!inImportOrUse && rr->type().kind() == types::QualifiedType::MODULE) {
-              const char* reason = "cannot be mentioned like variables";
-              auto parentId = parsing::idToParentId(context, node->id());
-              auto parentAst = parsing::idToAst(context, parentId);
-              if (auto callAst = parentAst->toCall()) {
-                if (callAst->calledExpression() == node) {
-                  reason = "cannot be called like procedures";
-                }
-              } else if (auto dotAst = parentAst->toDot()) {
-                if (dotAst->receiver() == node) {
-                  // Not an error to reference a module name in a dot expression.
-                  reason = nullptr;
-                }
-              }
-
-              if (reason != nullptr) {
-                USR_FATAL_CONT(se, "modules (like '%s' here) %s", node->name().c_str(), reason);
-              }
-            }
-
             if (parsing::idIsParenlessFunction(context, id)) {
               // it's a parenless function call so add a CallExpr
               ret = new CallExpr(se);

--- a/frontend/include/chpl/framework/error-classes-list.h
+++ b/frontend/include/chpl/framework/error-classes-list.h
@@ -96,6 +96,10 @@ ERROR_CLASS(IncompatibleTypeAndInit,
 ERROR_CLASS(InvalidNewTarget, const uast::New*, types::QualifiedType)
 ERROR_CLASS(MemManagementNonClass, const uast::New*, const types::Type*)
 ERROR_CLASS(MissingInclude, const uast::Include*, std::string)
+ERROR_CLASS(ModuleAsVariable,
+            const uast::AstNode*,
+            const uast::AstNode*,
+            const uast::Module*)
 ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const types::EnumType*, std::vector<ID>)
 ERROR_CLASS(MultipleQuestionArgs, const uast::FnCall*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(NonIterable, const uast::IndexableLoop*, const uast::AstNode*, types::QualifiedType)

--- a/frontend/include/chpl/framework/error-classes-list.h
+++ b/frontend/include/chpl/framework/error-classes-list.h
@@ -123,8 +123,11 @@ ERROR_CLASS(UseImportNotModule, const ID, const resolution::VisibilityStmtKind,
             std::string)
 ERROR_CLASS(UseImportUnknownMod, const ID, const resolution::VisibilityStmtKind,
             std::string)
-ERROR_CLASS(UseImportUnknownSym, const uast::VisibilityClause*,
-            const resolution::Scope*, const resolution::VisibilityStmtKind,
+ERROR_CLASS(UseImportUnknownSym,
+            const uast::VisibilityClause*,
+            const resolution::Scope*,
+            const resolution::VisibilityStmtKind,
+            bool,
             std::string)
 ERROR_CLASS(UseOfLaterVariable, const uast::AstNode*, ID)
 ERROR_CLASS(ValueUsedAsType, const uast::AstNode*, types::QualifiedType)

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -208,11 +208,34 @@ class BorrowedIdsWithName {
       if (isIdVisible(id)) numVisibleIds_ += 1;
     }
   }
+
+  /** Construct a BorrowedIdsWithName referring to one ID. Requires
+      that the ID is visible. */
+  BorrowedIdsWithName(IdAndVis id, bool arePrivateIdsIgnored = true)
+    : arePrivateIdsIgnored(arePrivateIdsIgnored),
+      numVisibleIds_(1), id_(std::move(id)) {
+    assert(isIdVisible(id_, arePrivateIdsIgnored));
+  }
  public:
-  /** Construct a BorrowedIdsWithName referring to one ID */
-  BorrowedIdsWithName(ID id, uast::Decl::Visibility vis)
-    : arePrivateIdsIgnored(true), numVisibleIds_(1),
-      id_(std::make_pair(std::move(id), vis)) { }
+
+  static llvm::Optional<BorrowedIdsWithName>
+  createWithSingleId(ID id, uast::Decl::Visibility vis,
+                     bool arePrivateIdsIgnored = true) {
+    auto idAndVis = std::make_pair(id, vis);
+    if (isIdVisible(idAndVis, arePrivateIdsIgnored)) {
+      return BorrowedIdsWithName(std::move(idAndVis), arePrivateIdsIgnored);
+    }
+    return llvm::None;
+  }
+
+  static BorrowedIdsWithName
+  createWithSinglePublicId(ID id, bool arePrivateIdsIgnored = true) {
+    auto maybeIds = createWithSingleId(std::move(id),
+                                       uast::Decl::Visibility::PUBLIC,
+                                       arePrivateIdsIgnored);
+    assert(maybeIds);
+    return maybeIds.getValue();
+  }
 
   /** Return the number of IDs stored here */
   int numIds() const {

--- a/frontend/lib/framework/error-classes-list.cpp
+++ b/frontend/lib/framework/error-classes-list.cpp
@@ -768,8 +768,22 @@ void ErrorUseImportUnknownSym::write(ErrorWriterBase& wr) const {
   auto symbolName = std::get<std::string>(info);
   auto searchedScope = std::get<const resolution::Scope*>(info);
   auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  wr.heading(kind_, type_, locationOnly(visibilityClause),
-             "cannot find symbol '", symbolName, "' for ", useOrImport, ".");
+  auto isRename = std::get<bool>(info);
+
+  auto limitationKind = visibilityClause->limitationKind();
+  if (isRename) {
+    wr.heading(kind_, type_, locationOnly(visibilityClause),
+               "Bad identifier in rename, no known '",
+               symbolName, "' in '", searchedScope->name(),"'");
+  } else if (limitationKind == uast::VisibilityClause::ONLY ||
+      limitationKind == uast::VisibilityClause::EXCEPT) {
+    wr.heading(kind_, type_, visibilityClause,
+               "Bad identifier in '", limitationKind, "' clause, no known '",
+               symbolName, "' defined in '", searchedScope->name(),"'");
+  } else {
+    wr.heading(kind_, type_, locationOnly(visibilityClause),
+               "cannot find symbol '", symbolName, "' for ", useOrImport, ".");
+  }
   wr.message("In the following '", useOrImport, "' statement:");
   wr.code(visibilityClause, { visibilityClause });
   // get class name of AstNode that generated scope (probably Module or Enum)

--- a/frontend/lib/framework/error-classes-list.cpp
+++ b/frontend/lib/framework/error-classes-list.cpp
@@ -772,16 +772,16 @@ void ErrorUseImportUnknownSym::write(ErrorWriterBase& wr) const {
 
   auto limitationKind = visibilityClause->limitationKind();
   if (isRename) {
-    wr.heading(kind_, type_, locationOnly(visibilityClause),
-               "Bad identifier in rename, no known '",
-               symbolName, "' in '", searchedScope->name(),"'");
+    wr.heading(kind_, type_, visibilityClause,
+               "bad identifier in rename, no known '",
+               symbolName, "' in '", searchedScope->name(),"'.");
   } else if (limitationKind == uast::VisibilityClause::ONLY ||
       limitationKind == uast::VisibilityClause::EXCEPT) {
     wr.heading(kind_, type_, visibilityClause,
-               "Bad identifier in '", limitationKind, "' clause, no known '",
-               symbolName, "' defined in '", searchedScope->name(),"'");
+               "bad identifier in '", limitationKind, "' clause, no known '",
+               symbolName, "' defined in '", searchedScope->name(),"'.");
   } else {
-    wr.heading(kind_, type_, locationOnly(visibilityClause),
+    wr.heading(kind_, type_, visibilityClause,
                "cannot find symbol '", symbolName, "' for ", useOrImport, ".");
   }
   wr.message("In the following '", useOrImport, "' statement:");

--- a/frontend/lib/framework/error-classes-list.cpp
+++ b/frontend/lib/framework/error-classes-list.cpp
@@ -792,16 +792,18 @@ void ErrorUseImportUnknownSym::write(ErrorWriterBase& wr) const {
   auto limitationKind = visibilityClause->limitationKind();
   if (isRename) {
     wr.heading(kind_, type_, visibilityClause,
-               "bad identifier in rename, no known '",
-               symbolName, "' in '", searchedScope->name(),"'.");
+               "cannot rename symbol '", symbolName, "' as it is not found in '",
+               searchedScope->name(),"'.");
   } else if (limitationKind == uast::VisibilityClause::ONLY ||
       limitationKind == uast::VisibilityClause::EXCEPT) {
     wr.heading(kind_, type_, visibilityClause,
-               "bad identifier in '", limitationKind, "' clause, no known '",
-               symbolName, "' defined in '", searchedScope->name(),"'.");
+               "cannot use '", limitationKind, "' clause with symbol '",
+               symbolName, "' as it is not defined in '",
+               searchedScope->name(),"'.");
   } else {
     wr.heading(kind_, type_, visibilityClause,
-               "cannot find symbol '", symbolName, "' for ", useOrImport, ".");
+               "cannot '", useOrImport, "' symbol '", symbolName, "' "
+               "as it is not defined in '", searchedScope->name(), "'.");
   }
   wr.message("In the following '", useOrImport, "' statement:");
   wr.code(visibilityClause, { visibilityClause });

--- a/frontend/lib/framework/error-classes-list.cpp
+++ b/frontend/lib/framework/error-classes-list.cpp
@@ -541,12 +541,31 @@ void ErrorMemManagementNonClass::write(ErrorWriterBase& wr) const {
   }
 }
 
+
 void ErrorMissingInclude::write(ErrorWriterBase& wr) const {
   auto moduleInclude = std::get<const uast::Include*>(info);
   auto& filePath = std::get<std::string>(info);
   wr.heading(kind_, type_, moduleInclude, "cannot find included submodule");
   wr.code(moduleInclude);
   wr.note(moduleInclude, "expected file at path '", filePath, "'");
+}
+
+void ErrorModuleAsVariable::write(ErrorWriterBase& wr) const {
+  auto node = std::get<0>(info);
+  auto parent = std::get<1>(info);
+  auto mod = std::get<const uast::Module*>(info);
+  const char* reason = "cannot be mentioned like variables";
+
+  if (parent) {
+    if (auto call = parent->toCall()) {
+      if (call->calledExpression() == node) {
+        reason = "cannot be called like procedures";
+      }
+    }
+  }
+  wr.heading(kind_, type_, node, "modules (like '", mod->name(), "' here) ",
+             reason, ".");
+  wr.code(parent, { node });
 }
 
 void ErrorMultipleEnumElems::write(ErrorWriterBase& wr) const {

--- a/frontend/lib/framework/error-classes-list.cpp
+++ b/frontend/lib/framework/error-classes-list.cpp
@@ -792,7 +792,7 @@ void ErrorUseImportUnknownSym::write(ErrorWriterBase& wr) const {
   auto limitationKind = visibilityClause->limitationKind();
   if (isRename) {
     wr.heading(kind_, type_, visibilityClause,
-               "cannot rename symbol '", symbolName, "' as it is not found in '",
+               "cannot rename symbol '", symbolName, "' as it is not defined in '",
                searchedScope->name(),"'.");
   } else if (limitationKind == uast::VisibilityClause::ONLY ||
       limitationKind == uast::VisibilityClause::EXCEPT) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1685,23 +1685,26 @@ Resolver::lookupIdentifier(const Identifier* ident,
 void Resolver::validateAndSetToId(ResolvedExpression& r,
                                   const AstNode* node,
                                   const ID& id) {
-  if (!id.isEmpty()) {
-    auto toAst = parsing::idToAst(context, id);
-    if (toAst != nullptr) {
-      if (auto mod = toAst->toModule()) {
-        auto parentId = parsing::idToParentId(context, node->id());
-        if (!parentId.isEmpty()) {
-          auto parentAst = parsing::idToAst(context, parentId);
-          if (!parentAst->isUse() && !parentAst->isImport() &&
-              !parentAst->isAs() && !parentAst->isVisibilityClause() &&
-              !parentAst->isDot()) {
-            CHPL_REPORT(context, ModuleAsVariable, node, parentAst, mod);
-          }
+  r.setToId(id);
+  if (id.isEmpty()) return;
+
+  // Validate the newly set to ID. It shouldn't refer to a module unless
+  // the node is an identifier in one of the places where module references
+  // are allowed (e.g. imports).
+  auto toAst = parsing::idToAst(context, id);
+  if (toAst != nullptr) {
+    if (auto mod = toAst->toModule()) {
+      auto parentId = parsing::idToParentId(context, node->id());
+      if (!parentId.isEmpty()) {
+        auto parentAst = parsing::idToAst(context, parentId);
+        if (!parentAst->isUse() && !parentAst->isImport() &&
+            !parentAst->isAs() && !parentAst->isVisibilityClause() &&
+            !parentAst->isDot()) {
+          CHPL_REPORT(context, ModuleAsVariable, node, parentAst, mod);
         }
       }
     }
   }
-  r.setToId(id);
 }
 
 bool Resolver::resolveIdentifier(const Identifier* ident,

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1682,6 +1682,28 @@ Resolver::lookupIdentifier(const Identifier* ident,
   return vec;
 }
 
+void Resolver::validateAndSetToId(ResolvedExpression& r,
+                                  const AstNode* node,
+                                  const ID& id) {
+  if (!id.isEmpty()) {
+    auto toAst = parsing::idToAst(context, id);
+    if (toAst != nullptr) {
+      if (auto mod = toAst->toModule()) {
+        auto parentId = parsing::idToParentId(context, node->id());
+        if (!parentId.isEmpty()) {
+          auto parentAst = parsing::idToAst(context, parentId);
+          if (!parentAst->isUse() && !parentAst->isImport() &&
+              !parentAst->isAs() && !parentAst->isVisibilityClause() &&
+              !parentAst->isDot()) {
+            CHPL_REPORT(context, ModuleAsVariable, node, parentAst, mod);
+          }
+        }
+      }
+    }
+  }
+  r.setToId(id);
+}
+
 bool Resolver::resolveIdentifier(const Identifier* ident,
                                  const Scope* receiverScope) {
   ResolvedExpression& result = byPostorder.byAst(ident);
@@ -1759,7 +1781,7 @@ bool Resolver::resolveIdentifier(const Identifier* ident,
       }
     }
 
-    result.setToId(id);
+    validateAndSetToId(result, ident, id);
     result.setType(type);
     // if there are multiple ids we should have gotten
     // a multiple definition error at the declarations.
@@ -2382,7 +2404,7 @@ void Resolver::exit(const Dot* dot) {
         // but for things with generic type, use unknown.
         type = typeForId(id, /*localGenericToUnknown*/ true);
       }
-      r.setToId(id);
+      validateAndSetToId(r, dot, id);
       r.setType(type);
     }
     return;
@@ -2400,7 +2422,7 @@ void Resolver::exit(const Dot* dot) {
     ID elemId = r.toId(); // store the original in case we don't get a new one
     auto qt = typeForEnumElement(enumType, dot->field(), dot, elemId);
     r.setType(std::move(qt));
-    r.setToId(std::move(elemId));
+    validateAndSetToId(r, dot, std::move(elemId));
 
     return;
   }
@@ -2719,7 +2741,7 @@ bool Resolver::enter(const ReduceIntent* reduce) {
   ResolvedExpression& result = byPostorder.byAst(reduce);
 
   if (computeTaskIntentInfo(*this, reduce, id, type)) {
-    result.setToId(id);
+    validateAndSetToId(result, reduce, id);
   } else if (!scopeResolveOnly) {
     context->error(reduce, "Unable to find declaration of \"%s\" for reduction", reduce->name().c_str());
   }
@@ -2744,7 +2766,7 @@ bool Resolver::enter(const TaskVar* taskVar) {
     if (computeTaskIntentInfo(*this, taskVar, id, type)) {
       QualifiedType taskVarType = QualifiedType(taskVar->storageKind(),
                                                 type.type());
-      result.setToId(id);
+      validateAndSetToId(result, taskVar, id);
 
       // TODO: Handle in-intents where type can change (e.g. array slices)
       result.setType(taskVarType);

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -328,6 +328,10 @@ struct Resolver {
   void resolveTupleDecl(const uast::TupleDecl* td,
                         const types::Type* useType);
 
+  void validateAndSetToId(ResolvedExpression& r,
+                          const uast::AstNode* exr,
+                          const ID& id);
+
   // e.g. new shared C(a, 0)
   // also resolves initializer call as a side effect
   bool resolveSpecialNewCall(const uast::Call* call);

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1010,9 +1010,13 @@ doResolveImportStmt(Context* context, const Import* imp,
     // on it matching just one thing).
     // But, we don't do that for 'import M.f.{a,b,c}'
     if (auto dot = expr->toDot()) {
-      if (clause->limitationKind() != VisibilityClause::BRACES) {
-        expr = dot->receiver();
-        dotName = dot->field();
+      // super and this are special keywords, they should not be resolved
+      // via the dot-name mechanism here.
+      if (dot->field() != USTR("super") && dot->field() != USTR("this")) {
+        if (clause->limitationKind() != VisibilityClause::BRACES) {
+          expr = dot->receiver();
+          dotName = dot->field();
+        }
       }
     }
 

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -892,6 +892,8 @@ findUseImportTarget(Context* context,
                                        expr,
                                        useOrImport);
       return ret;
+    } else if (dot->field() == USTR("this")) {
+      return innerScope->moduleScope();
     }
 
     if (innerScope != nullptr) {

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -949,8 +949,14 @@ doResolveUseStmt(Context* context, const Use* use,
       // Per the spec, we only have visibility of the symbol itself if the
       // use is renamed (with 'as') or non-public.
       if (!newName.isEmpty()) {
-        r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
-                               isPrivate, convertOneRename(oldName, newName));
+        if (newName == USTR("_")) {
+          // Do not introduce the name at all.
+          r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
+                                 isPrivate, emptyNames());
+        } else {
+          r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
+                                 isPrivate, convertOneRename(oldName, newName));
+        }
       } else if (isPrivate) {
         r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
                                isPrivate, convertOneName(oldName));
@@ -1080,6 +1086,9 @@ doResolveImportStmt(Context* context, const Import* imp,
               // e.g. 'import OtherModule'
               r->addVisibilityClause(foundScope, kind, isPrivate,
                                      convertOneName(oldName));
+            } if (newName == USTR("_")) {
+              // e.g. 'import OtherModule as _'
+              r->addVisibilityClause(foundScope, kind, isPrivate, emptyNames());
             } else {
               // e.g. 'import OtherModule as Foo'
               r->addVisibilityClause(foundScope, kind, isPrivate,

--- a/frontend/test/resolution/testScopeResolve.cpp
+++ b/frontend/test/resolution/testScopeResolve.cpp
@@ -570,6 +570,134 @@ static void test13() {
   assert(guard.realizeErrors());
 }
 
+// There's specal handling for the rightmost field access. Make sure this
+// special handling properly handles super.
+static void test14() {
+  printf("test14\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module A {
+        var x : int;
+        module B {
+          import this.super as C;
+          var y = C.x;
+        }
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* y = findVariable(vec, "y");
+  assert(y);
+
+  const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
+  assert(reY.toId() == x->id());
+}
+
+
+// Make sure that the dot-expression handling of "this" works in addition
+// to the idenifier-expression handling of "this". Technically this is
+// redundant, but our goal is to issue a warning, not fail to resolve in
+// this case.
+static void test15() {
+  printf("test15\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  // Note this.super.this instead of this.super in the previous test.
+  std::string contents = R""""(
+      module A {
+        var x : int;
+        module B {
+          import this.super.this as C;
+          var y = C.x;
+        }
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* y = findVariable(vec, "y");
+  assert(y);
+
+  const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
+  assert(reY.toId() == x->id());
+}
+
+// Ensures that a module declared private and then imported renamed is
+// not accessible externally (renaming doesn't change visibility).
+static void test16() {
+  printf("test16\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module A {
+        private module B {
+          var x = 1;
+        };
+        public use B as C;
+      }
+      module D {
+        use A;
+        var y = C.x;
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* y = findVariable(vec, "y");
+  assert(y);
+
+  const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
+  assert(reY.toId().isEmpty());
+}
+
+// Makes sure a user can't use a module as a variable (like var x = M).
+static void test17() {
+  printf("test17\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module TopLevel {
+        module A {}
+        var x = A;
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  // Trigger scope resolution
+  const ResolvedExpression& reX = scopeResolveIt(context, x->initExpression());
+  (void) reX;
+
+  assert(guard.errors().size() == 1);
+  auto& e = guard.errors()[0];
+  assert(e->message() == "modules (like 'A' here) cannot be "
+                         "mentioned like variables");
+  guard.realizeErrors();
+}
+
 int main() {
   test1();
   test2();
@@ -584,6 +712,10 @@ int main() {
   test11();
   test12();
   test13();
+  test14();
+  test15();
+  test16();
+  test17();
 
   return 0;
 }

--- a/frontend/test/resolution/testScopeResolve.cpp
+++ b/frontend/test/resolution/testScopeResolve.cpp
@@ -640,6 +640,7 @@ static void test16() {
   printf("test16\n");
   Context ctx;
   Context* context = &ctx;
+  ErrorGuard guard(context);
 
   auto path = UniqueString::get(context, "input.chpl");
   std::string contents = R""""(
@@ -651,6 +652,7 @@ static void test16() {
       }
       module D {
         use A;
+        import C;
         var y = C.x;
       }
    )"""";
@@ -665,6 +667,7 @@ static void test16() {
 
   const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
   assert(reY.toId().isEmpty());
+  assert(guard.realizeErrors() == 1);
 }
 
 // Makes sure a user can't use a module as a variable (like var x = M).


### PR DESCRIPTION
This fixes a few scope resolution issues.

* Dyno doesn't go the "usual" way for finding import targets when faced with a top-level dot-expression like `M.f`, because `f` may be overloaded. This is needed because the "usual" way doesn't cope with overloading. However, when the last identifier in a dot chain is `super` or `this`, there's no need to account for overloading, so this PR changes Dyno to use the "usual" algorithm for handling these (and thus makes it understand `super` and `this` in the rightmost position of a dot expression in imports/uses).
* With the addition of support for private fields, all modules discovered via renaming (`import M as X`) were marked as public. This is not correct, since a `private` module should not show up outside of its scope.
* The `Dot` operator was missing an implementation for `this`. Strictly speaking, that's redundant (`super.this` is the same as `super`) but I think we prefer to issue warnings rather than fail to find imports altogether.
* The modules-as-variables error was moved up into Dyno. I believe this fixed issues with error message wording / decoration. 

Adds "failures" due to improved error messages:
```
[Error matching compiler output for modules/errors/assign-param-from-module]
[Error matching compiler output for modules/errors/assign-var-from-imported-module]
[Error matching compiler output for modules/errors/assign-var-from-module]
[Error matching compiler output for modules/errors/call-imported-module]
[Error matching compiler output for modules/errors/call-module]
[Error matching compiler output for modules/errors/callModLikeProc2]
[Error matching compiler output for modules/errors/issue-14537]
```

Testing
- [x] Full local (0 failures)
- [x] Full local with `--dyno` (145 failures, up 3 from main -- but some new "errors" were introduced)

Reviewed by @dlongnecke-cray - thanks!

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>