### PR TITLE
Account for ref+out intents with virtual methods

### DIFF
--- a/test/functions/vass/override-def-use.chpl
+++ b/test/functions/vass/override-def-use.chpl
@@ -1,0 +1,44 @@
+// Issue #21073
+
+config const flag = false;
+
+class parent {
+  proc plusone(ref n: int): void
+  {
+    n = n + 1;
+  }
+  proc plusthree(ref n: int): void
+  {
+    n = n + 3;
+  }
+}
+
+class child : parent {
+  override proc plusone(ref n: int): void
+  {
+    n = n + 2;
+  }
+  override proc plusthree(ref n: int): void
+  {
+    n = n + 4;
+  }
+}
+
+proc main(): int
+{
+  var c: parent = if flag then new parent() else new child();
+  var v: [1..5] int = 1;
+
+  c.plusone(v[3]);
+  writeln("first try:  ", v);
+
+  ref k: int = v[3];
+  c.plusone(k);
+  writeln("second try: ", v);
+
+  var c3: parent = if !flag then new parent() else new child();
+  c3.plusthree(v[3]);
+  writeln("third try:  ", v);
+
+  return 0;
+}

--- a/test/functions/vass/override-def-use.good
+++ b/test/functions/vass/override-def-use.good
@@ -1,0 +1,3 @@
+first try:  1 1 3 1 1
+second try: 1 1 5 1 1
+third try:  1 1 8 1 1


### PR DESCRIPTION
Resolves #21073

This fixes a bug where an actual argument was always considered a "use" upon a call to a virtually-dispatched method even when the corresponding formal had a ref or [in]out intent.

The bug was observed when such an actual argument was an array indexing expression, which involved return intent overloading. Because of the bug, the return-value overload was chosen instead of the return-ref one.

Next steps: check if this bug can occur upon calls to ftable-ed functions.

Testing: standard paratest; gasnet paratest over multilocale tests.