### PR TITLE
vim spaces to 4 in ftplugin/chpl.vim

### DIFF
--- a/highlight/vim/ftplugin/chpl.vim
+++ b/highlight/vim/ftplugin/chpl.vim
@@ -10,7 +10,7 @@ setlocal formatlistpat=^\\s*\\(\\d\\+[\\]:.)}\\t\ ]\\\|[*-][\\t\ ]\\)\\s*
 " If you prefer spaces to tabs, uncomment the following:
 "  (To get a real tab with these settings, do CTRL-V TAB)
 setlocal expandtab       " replace indents with spaces
-setlocal shiftwidth=2    " set how many spaces per indent
+setlocal shiftwidth=4    " set how many spaces per indent
 setlocal smarttab        " use spaces as indents at the beginning of lines
 
 


### PR DESCRIPTION
I am not sure if this is an appropriate change. I am not sure what standard practice is (2 or 4 spaces) or what it should be. I know I fought this for 20 minutes trying to figure out what was overriding my .vimrc. Maybe this is a me thing. Please feel free to reject the request if it is deemed silly or unnecessary.

Signed-off-by: kwaters4 <kwaters@mtu.edu>