### PR TITLE
Deprecate IO.unicodeSupported

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6026,6 +6026,7 @@ proc readln(type t ...?numTypes) throws {
 /*
    :returns: `true` if this version of the Chapel runtime supports UTF-8 output.
  */
+deprecated "unicodeSupported is deprecated"
 proc unicodeSupported():bool {
   return true;
 }

--- a/test/deprecated/IO/unicodeSupported.chpl
+++ b/test/deprecated/IO/unicodeSupported.chpl
@@ -1,0 +1,3 @@
+use IO only unicodeSupported;
+
+writeln(unicodeSupported());

--- a/test/deprecated/IO/unicodeSupported.good
+++ b/test/deprecated/IO/unicodeSupported.good
@@ -1,0 +1,3 @@
+unicodeSupported.chpl:1: warning: unicodeSupported is deprecated
+unicodeSupported.chpl:3: warning: unicodeSupported is deprecated
+true

--- a/test/io/ferguson/writefstring.chpl
+++ b/test/io/ferguson/writefstring.chpl
@@ -4,10 +4,8 @@ config type t = string;
 writef("%s\n":t, "boo");
 writef("%2.1s|\n":t, "boo");
 writef("%-2.1s|\n":t, "boo");
-if unicodeSupported() {
-  writef("%2.2s|%-4.4s|\n":t, "boo", "boo");
-  writef("%2.2s|%4.4s|\n":t, "Ａ", "ＡＡ");
-}
+writef("%2.2s|%-4.4s|\n":t, "boo", "boo");
+writef("%2.2s|%4.4s|\n":t, "Ａ", "ＡＡ");
 
 writef(" 123456789ABCD\n":t);
 writef("1%2.1s\n":t, "123456789");

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -235,12 +235,7 @@ if example == 0 || example == 4 {
   w.writeln(" is ");
   w.writeln(" a test ");
 
-// We only write the UTF-8 characters if unicode is supported,
-// and that depends on the current unix locale environment
-// (e.g. setting the environment variable ``LC_ALL=C`` will disable unicode support).
-// Note that since UTF-8 strings are C strings, this should work even in a C locale.
-// We don't do it all the time for testing sanity reasons.
-  if unicodeSupported() then w.writeln(" of UTF-8 Euro Sign: €");
+  w.writeln(" of UTF-8 Euro Sign: €");
 
   // flush buffers, close the channel.
   w.close();

--- a/test/unicode/write_read_euro.chpl
+++ b/test/unicode/write_read_euro.chpl
@@ -1,24 +1,19 @@
 use IO;
 
-if unicodeSupported() {
-  var f = openTempFile();
+var f = openTempFile();
 
-  var euro = new ioChar(0x20ac); // euro sign "?";
-  var got = new ioChar(0);
+var euro = new ioChar(0x20ac); // euro sign "?";
+var got = new ioChar(0);
 
-  writeln("Writing ", euro);
-  var writer = f.writer();
-  writer.write(euro);
-  writer.close();
+writeln("Writing ", euro);
+var writer = f.writer();
+writer.write(euro);
+writer.close();
 
-  var reader = f.reader();
-  reader.read(got);
-  reader.close();
+var reader = f.reader();
+reader.read(got);
+reader.close();
 
-  writeln("Read  ", got);
+writeln("Read  ", got);
 
-  assert( got == euro );
-
-} else {
-  writeln("Test omitted because unicode is not supported (set e.g. LC_CTYPE=\"en_US.UTF-8\")");
-}
+assert( got == euro );


### PR DESCRIPTION
Deprecate `IO.unicodeSupported`, which always returns `true`.

Resolves https://github.com/chapel-lang/chapel/issues/20275.

Testing:
- [x] paratest