### PR TITLE
reinstate and deprecate createVersion

### DIFF
--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -128,6 +128,26 @@ module Version {
   chplVersion = new versionValue(chplMajor, chplMinor, chplUpdate, chplSHA);
 
   /*
+    A helper function that creates a new versionValue from its arguments.
+    :arg major: The major version number
+    :type major: `int`
+    :arg minor: The minor version number
+    :type minor: `int`
+    :arg update: The optional update version number (defaults to 0)
+    :type update: `int`
+    :arg commit: The optional commit ID (defaults to "")
+    :type commit: `string`
+    :returns: A new version value of type :type:`versionValue`.
+  */
+  deprecated "createVersion is deprecated, please use 'new versionValue()' instead."
+  proc createVersion(param major: int,
+                     param minor: int,
+                     param update: int = 0,
+                     param commit: string = ""): versionValue(?) {
+    return new versionValue(major, minor, update, commit);
+  }
+
+  /*
     This record represents a software version that is mostly equivalent to
     a semantic version, though not 100% true to the semver spec. The main
     deviation from the spec is that ``versionValue`` doesn't support pre-release

--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -23,9 +23,9 @@
 .. highlight:: chapel
 
 This module contains features that support reasoning about version numbers.
-The :type:`versionValue` supports compile-time reasoning about version numbers
+The :type:`versionValue` type supports compile-time reasoning about version numbers
 in general, and Chapel version numbers specifically, while the :type:`version`
-supports run-time reasoning about version numbers.
+type supports run-time reasoning about version numbers.
 
 In more detail, the module features:
 
@@ -128,7 +128,26 @@ module Version {
   chplVersion = new versionValue(chplMajor, chplMinor, chplUpdate, chplSHA);
 
   /*
-    A helper function that creates a new versionValue from its arguments.
+    This record represents a software version that is modeled after a semantic
+    version. It uses ``param`` values to represent its components in order to
+    support compile-time comparison of version numbers which in turn
+    permits code to specialize to specific versions of Chapel.  When
+    printed or converted to a string, it is represented as
+    ``major.minor.update (commit)``.
+    Note that ordered comparisons between two :type:`sourceVersion`
+    values that only differ in their ``commit`` values are not
+    supported due to the challenges involved in ordering commit
+    values.  However, when a value with an empty ``update`` value is
+    compared to one whose ``update`` is non-empty, the latter is
+    considered to be earlier than (less than) the former, due to the
+    interpretation that it represents a pre-release of the official
+    release.
+  */
+  deprecated "sourceVersion is deprecated, please use versionValue instead."
+  type sourceVersion = versionValue;
+
+  /*
+    A helper function that creates a new sourceVersion from its arguments.
     :arg major: The major version number
     :type major: `int`
     :arg minor: The minor version number
@@ -137,18 +156,19 @@ module Version {
     :type update: `int`
     :arg commit: The optional commit ID (defaults to "")
     :type commit: `string`
-    :returns: A new version value of type :type:`versionValue`.
+    :returns: A new version value of type :type:`sourceVersion`.
   */
   deprecated "createVersion is deprecated, please use 'new versionValue()' instead."
   proc createVersion(param major: int,
                      param minor: int,
                      param update: int = 0,
-                     param commit: string = ""): versionValue(?) {
-    return new versionValue(major, minor, update, commit);
+                     param commit: string = ""): sourceVersion(?) {
+    return new sourceVersion(major, minor, update, commit);
   }
 
+
   /*
-    This record represents a software version that is mostly equivalent to
+    This record represents a software version that is modeled after
     a semantic version, though not 100% true to the semver spec. The main
     deviation from the spec is that ``versionValue`` doesn't support pre-release
     identifiers and the version and optional build/commit value are separated
@@ -317,7 +337,6 @@ module Version {
     converted to a string, it is represented as ``major.minor.update (commit)``.
     Unlike :type:`versionValue`, a ``version`` can be created and modified at runtime.
   */
-
   record version {
     /*
       The major version number. For version ``2.0.1``, this would be ``2``.

--- a/test/library/standard/Version/compareVersionTypes.chpl
+++ b/test/library/standard/Version/compareVersionTypes.chpl
@@ -17,15 +17,17 @@ const v2_2_1_p = new versionValue(2,2,1,"ddd");
 const v3_1_0_p = new versionValue(3,1,0,"eee");
 const v3_1_1_p = new versionValue(3,1,1,"fff");
 
+// test for deprecated sourceVersion
+const v3_1_1_psv = new sourceVersion(3,1,1,"fff");
 
 var x = 2, y = 1, z = 3, q = 0;
 
 const v2_1_0_c = new version(x,y);
-const v2_1_1_c = new version(x,y,y);
+const v2_1_1_c = new version(2,1,1);
 const v2_2_0_c = new version(x,x,q);
 const v2_2_1_c = new version(x,x,y);
 const v3_1_0_c = new version(z,y);
-const v3_1_1_c = new version(z,y,y);
+const v3_1_1_c = new version(3,1,1);
 
 const v2_1_0_p_c = new version(x,y,q,"aaa");
 const v2_1_1_p_c = new version(x,y,y,"bbb");
@@ -119,6 +121,9 @@ compareBothVersions(v3_1_0, v3_1_1_c);
 compareBothVersions(v3_1_0_c, v3_1_1_p);
 compareBothVersions(v3_1_0, v3_1_1_p_c);
 
+compareBothVersions(v3_1_0, v3_1_1_psv);
+compareBothVersions(v3_1_1, v3_1_1_psv);
+compareBothVersions(v3_1_1_p, v3_1_1_psv);
 
 proc compareBothVersions(v1, v2) {
   compareVersions(v1,v2);

--- a/test/library/standard/Version/compareVersionTypes.good
+++ b/test/library/standard/Version/compareVersionTypes.good
@@ -1,3 +1,4 @@
+compareVersionTypes.chpl:21: warning: sourceVersion is deprecated, please use versionValue instead.
 Comparing versions:
 3.1.1
 3.1.1
@@ -1440,5 +1441,71 @@ Comparing versions:
 <  : false
 <= : false
 >  : true
+>= : true
+
+Comparing versions:
+3.1.0
+3.1.1 (fff)
+------------------
+== : false
+!= : true
+<  : true
+<= : true
+>  : false
+>= : false
+
+Comparing versions:
+3.1.1 (fff)
+3.1.0
+------------------
+== : false
+!= : true
+<  : false
+<= : false
+>  : true
+>= : true
+
+Comparing versions:
+3.1.1
+3.1.1 (fff)
+------------------
+== : false
+!= : true
+<  : false
+<= : false
+>  : true
+>= : true
+
+Comparing versions:
+3.1.1 (fff)
+3.1.1
+------------------
+== : false
+!= : true
+<  : true
+<= : true
+>  : false
+>= : false
+
+Comparing versions:
+3.1.1 (fff)
+3.1.1 (fff)
+------------------
+== : true
+!= : false
+<  : false
+<= : true
+>  : false
+>= : true
+
+Comparing versions:
+3.1.1 (fff)
+3.1.1 (fff)
+------------------
+== : true
+!= : false
+<  : false
+<= : true
+>  : false
 >= : true
 

--- a/test/library/standard/Version/versionCastIsParam.chpl
+++ b/test/library/standard/Version/versionCastIsParam.chpl
@@ -1,9 +1,9 @@
 use Version;
 
-var v = new versionValue(1,23,0);
+var v = createVersion(1,23,0);
 param test = ("version " + v:string == "version 1.23.0");
 
-var v2 = new versionValue(1,23,0,"vass");
+var v2 = createVersion(1,23,0,"vass");
 compilerWarning(v2:string);
 
 if test == false then

--- a/test/library/standard/Version/versionCastIsParam.good
+++ b/test/library/standard/Version/versionCastIsParam.good
@@ -1,2 +1,4 @@
+versionCastIsParam.chpl:3: warning: createVersion is deprecated, please use 'new versionValue()' instead.
+versionCastIsParam.chpl:6: warning: createVersion is deprecated, please use 'new versionValue()' instead.
 versionCastIsParam.chpl:7: warning: 1.23.0 (vass)
 versionCastIsParam.chpl:13: error: Yay!


### PR DESCRIPTION
This PR reinstates the `createVersion` function and creates a type alias
for `sourceVersion` and marks both as deprecated. 
Both of these items were dropped without deprecation in PR #19300 and this
PR corrects that mistake. 

TESTING:

- [x] paratest
- [x] Arkouda builds locally with these changes
- [x] manually review docs for `Version`

reviewed by @riftEmber - thanks!