### PR TITLE
Rename opentmp to openTempFile

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1980,7 +1980,7 @@ private proc openfpHelper(fp: c_FILE, hints=ioHintSet.empty,
 
 @unstable "openTempFile with a style argument is unstable"
 proc openTempFile(hints=ioHintSet.empty, style:iostyle):file throws {
-  return openTempFileHelper(hints, style: iostyleInternal);
+  return opentmpHelper(hints, style: iostyleInternal);
 }
 
 deprecated "opentmp is deprecated, please use :proc:`openTempFile` instead"

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2000,8 +2000,8 @@ deleted upon closing.
 
 Temporary files are opened with :type:`iomode` ``iomode.cwr``; that is, a new
 file is created that supports both writing and reading.  When possible, it may
-be opened such that it can never be reached via any pathname and in such a way
-that it will avoid symlink attacks, but this is system dependent.
+be opened using OS support for temporary files in order to make sure that a new
+file is created only for use by the current application.
 
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :record:`ioHintSet`.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -186,7 +186,9 @@ implementing read or write operations for that type (see
 Files
 -----
 
-There are several functions that open a file and return a :record:`file` including :proc:`open`, :proc:`opentmp`, :proc:`openmem`, :proc:`openfd`, and :proc:`openfp`.
+There are several functions that open a file and return a :record:`file`
+including :proc:`open`, :proc:`openTempFile`, :proc:`openmem`, :proc:`openfd`,
+and :proc:`openfp`.
 
 Once a file is open, it is necessary to create associated channel(s) - see
 :proc:`file.reader` and :proc:`file.writer` - to write to and/or read from the
@@ -1976,7 +1978,12 @@ private proc openfpHelper(fp: c_FILE, hints=ioHintSet.empty,
   return ret;
 }
 
-@unstable "opentmp with a style argument is unstable"
+@unstable "openTempFile with a style argument is unstable"
+proc openTempFile(hints=ioHintSet.empty, style:iostyle):file throws {
+  return openTempFileHelper(hints, style: iostyleInternal);
+}
+
+deprecated "opentmp is deprecated, please use :proc:`openTempFile` instead"
 proc opentmp(hints=ioHintSet.empty, style:iostyle):file throws {
   return opentmpHelper(hints, style: iostyleInternal);
 }
@@ -1991,12 +1998,10 @@ The temporary file will be created in an OS-dependent temporary directory,
 for example "/tmp" is the typical location. The temporary file will be
 deleted upon closing.
 
-Temporary files are always opened with :type:`iomode` ``iomode.cwr``;
-that is, a new file is created that supports both writing and reading.
-
-.. TODO:
-  Temporary files are always opened with :type:`iomode` ``iomode.cwrx``;
-  that is, a new file is created that supports both writing and reading.
+Temporary files are opened with :type:`iomode` ``iomode.cwr``; that is, a new
+file is created that supports both writing and reading.  When possible, it may
+be opened such that it can never be reached via any pathname and in such a way
+that it will avoid symlink attacks, but this is system dependent.
 
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :record:`ioHintSet`.
@@ -2004,6 +2009,11 @@ that is, a new file is created that supports both writing and reading.
 
 :throws SystemError: Thrown if the temporary file could not be opened.
 */
+proc openTempFile(hints=ioHintSet.empty):file throws {
+  return opentmpHelper(hints);
+}
+
+deprecated "opentmp is deprecated, please use :proc:`openTempFile` instead"
 proc opentmp(hints=ioHintSet.empty):file throws {
   return opentmpHelper(hints);
 }

--- a/test/deprecated/IO/iochannel.chpl
+++ b/test/deprecated/IO/iochannel.chpl
@@ -3,7 +3,7 @@ use IO;
 proc foo(arg: channel) { }
 
 proc main() {
-  var f = opentmp();
+  var f = openTempFile();
 
   var r: channel = f.reader();
   var w: channel = f.writer();

--- a/test/deprecated/IO/opentmp.chpl
+++ b/test/deprecated/IO/opentmp.chpl
@@ -1,0 +1,11 @@
+use IO;
+
+var f = opentmp();
+
+// not checking OS-specific implementations for now...
+try {
+    var p = f.path;
+    writeln("didn't throw");
+} catch {
+    writeln("threw!");
+}

--- a/test/deprecated/IO/opentmp.compopts
+++ b/test/deprecated/IO/opentmp.compopts
@@ -1,0 +1,1 @@
+-sfilePathAbsolute=true

--- a/test/deprecated/IO/opentmp.good
+++ b/test/deprecated/IO/opentmp.good
@@ -1,0 +1,2 @@
+opentmp.chpl:3: warning: opentmp is deprecated, please use openTempFile instead
+didn't throw

--- a/test/deprecated/IO/readline.chpl
+++ b/test/deprecated/IO/readline.chpl
@@ -4,7 +4,7 @@ config type dataType = string;
 proc test_readlines()
 {
 
-  var f = opentmp();
+  var f = openTempFile();
   {
     var ch = f.writer();
     ch.writeln("a b");

--- a/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWrite.chpl
+++ b/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWrite.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var fw = opentmp().writer();
+var fw = openTempFile().writer();
 if fw.write("yep") {
     writeln("nope");
 }

--- a/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWriteBytes.chpl
+++ b/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWriteBytes.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var fw = opentmp().writer();
+var fw = openTempFile().writer();
 if fw.writeBytes(63, 2) {
     writeln("nope");
 }

--- a/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWritebits.chpl
+++ b/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWritebits.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var fw = opentmp().writer();
+var fw = openTempFile().writer();
 if fw.writebits(7, 3) {
     writeln("nope");
 }

--- a/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWritef.chpl
+++ b/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWritef.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var fw = opentmp().writer();
+var fw = openTempFile().writer();
 if fw.writef("%.5", 3.1415) {
     writeln("nope");
 }

--- a/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWriteln.chpl
+++ b/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWriteln.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var fw = opentmp().writer();
+var fw = openTempFile().writer();
 if fw.writeln("yep") {
     writeln("nope");
 }

--- a/test/deprecated/recordiobug.chpl
+++ b/test/deprecated/recordiobug.chpl
@@ -5,7 +5,7 @@ record Point {
   var y: int;
 }
 
-var f = opentmp();
+var f = openTempFile();
 var w = f.writer();
 
 var p = new Point(1,3);

--- a/test/io/ferguson/assoc-array-chpl.chpl
+++ b/test/io/ferguson/assoc-array-chpl.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 proc main() {
-  var tmp = opentmp();
+  var tmp = openTempFile();
 
   var A = ["one"=>1, "two"=>2, "three"=>3];
   var B:[A.domain] int;

--- a/test/io/ferguson/channel-changing-type-error1.chpl
+++ b/test/io/ferguson/channel-changing-type-error1.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 proc main() {
-  var f = opentmp();
+  var f = openTempFile();
   var a = f.writer();
   var b:fileReader = a;
 }

--- a/test/io/ferguson/channel-changing-type-error2.chpl
+++ b/test/io/ferguson/channel-changing-type-error2.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 proc main() {
-  var f = opentmp();
+  var f = openTempFile();
   var a = f.reader();
   var b:fileWriter = a;
 }

--- a/test/io/ferguson/channel-changing-type-error3.chpl
+++ b/test/io/ferguson/channel-changing-type-error3.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 proc main() {
-  var f = opentmp();
+  var f = openTempFile();
   var a = f.writer();
   var b:fileReader(kind=iokind.dynamic,locking=true);
   b; // prevent split-init

--- a/test/io/ferguson/channel-changing-type-error4.chpl
+++ b/test/io/ferguson/channel-changing-type-error4.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 proc main() {
-  var f = opentmp();
+  var f = openTempFile();
   var a = f.reader();
   var b:fileWriter(kind=iokind.dynamic,locking=true);
   b; // prevent split-init

--- a/test/io/ferguson/io_test.chpl
+++ b/test/io/ferguson/io_test.chpl
@@ -6,7 +6,7 @@ config const noisy = false;
 proc testio(param typ:iokind, style:iostyleInternal, x)
 {
   if noisy then writeln("Testing ",typ:int(64)," ",x.type:string," ",style.binary:int(64)," ",style.byteorder:int(64)," ",style.str_style);
-  var f = opentmp();
+  var f = openTempFile();
   {
     var ch = f.writer(typ, style=style);
     if noisy then writeln("Writing ", x:string);
@@ -54,7 +54,7 @@ proc testio(x)
 proc test_readlines()
 {
 
-  var f = opentmp();
+  var f = openTempFile();
   {
     var ch = f.writer();
     ch.writeln("a b");

--- a/test/io/ferguson/json-enum.chpl
+++ b/test/io/ferguson/json-enum.chpl
@@ -7,7 +7,7 @@ record MyRecord {
   var b: MyEnum;
 }
 
-var f = opentmp();
+var f = openTempFile();
 
 {
   var writer = f.writer();

--- a/test/io/ferguson/json-linked-list.chpl
+++ b/test/io/ferguson/json-linked-list.chpl
@@ -12,7 +12,7 @@ use LinkedLists, IO;
   mylist.destroy();
 }
 
-var f = opentmp();
+var f = openTempFile();
 {
   var writer = f.writer();
   var str = '[]';

--- a/test/io/ferguson/json-linked-list2.chpl
+++ b/test/io/ferguson/json-linked-list2.chpl
@@ -15,7 +15,7 @@ myEntry.numbers.push_back(3);
 
 writef("testing json write: %jt\n", myEntry);
 
-var f = opentmp();
+var f = openTempFile();
 {
   var writer = f.writer();
   var str = '{"numbers": []}';

--- a/test/io/ferguson/json-list.chpl
+++ b/test/io/ferguson/json-list.chpl
@@ -10,7 +10,7 @@ use List, IO;
   writef("testing json write: %jt\n", mylist);
 }
 
-var f = opentmp();
+var f = openTempFile();
 {
   var writer = f.writer();
   var str = '[]';

--- a/test/io/ferguson/json-list2.chpl
+++ b/test/io/ferguson/json-list2.chpl
@@ -11,7 +11,7 @@ myEntry.numbers.append(3);
 
 writef("testing json write: %jt\n", myEntry);
 
-var f = opentmp();
+var f = openTempFile();
 {
   var writer = f.writer();
   var str = '{"numbers": []}';

--- a/test/io/ferguson/json.chpl
+++ b/test/io/ferguson/json.chpl
@@ -9,7 +9,7 @@ record MyRecord {
 writef("testing default stdout: %t\n", new MyRecord(1,2));
 writef("testing json stdout: %jt\n", new MyRecord(1,2));
 
-var f = opentmp();
+var f = openTempFile();
 
 {
   var writer = f.writer();

--- a/test/io/ferguson/read-string-zero.chpl
+++ b/test/io/ferguson/read-string-zero.chpl
@@ -3,7 +3,7 @@ use IO;
 
 var str = "hello\x00goodbye\n";
 
-var f = opentmp();
+var f = openTempFile();
 
 {
   var w = f.writer(kind=iokind.native);

--- a/test/io/ferguson/readThis/readarr.chpl
+++ b/test/io/ferguson/readThis/readarr.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = opentmp();
+var f = openTempFile();
 
 var w = f.writer();
 

--- a/test/io/ferguson/writef_readf.chpl
+++ b/test/io/ferguson/writef_readf.chpl
@@ -23,7 +23,7 @@ proc testio(fmts: [] string, values: [])
         if noisy then writeln("Testing try ", tryN, " with fmt '", usefmt, "'");
 
         var x = v;
-        var f = opentmp();
+        var f = openTempFile();
         {
           var ch = f.writer();
           if noisy then writeln("Writing ", x:string);

--- a/test/library/packages/HDF5/HDF5Preprocessors.chpl
+++ b/test/library/packages/HDF5/HDF5Preprocessors.chpl
@@ -18,8 +18,8 @@ module HDF5Preprocessors {
       use FileSystem, Path, Subprocess;
 
       try! {
-        // opentmp() doesn't seem to give me a file I can get the name of :(
-        //var f = opentmp();
+        // openTempFile() doesn't seem to give me a file I can get the name of :(
+        //var f = openTempFile();
         //const scriptName = f.realPath();
 
         const scriptName = "./hdf5TempScript.bash";

--- a/test/library/standard/IO/filePath/opentmp.chpl
+++ b/test/library/standard/IO/filePath/opentmp.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = opentmp();
+var f = openTempFile();
 
 // not checking OS-specific implementations for now...
 try {

--- a/test/types/bytes/io/json-io.chpl
+++ b/test/types/bytes/io/json-io.chpl
@@ -10,7 +10,7 @@ var r = new Rec(10, "some bytes":bytes);
 writef("testing default stdout: %t\n", r);
 writef("testing json stdout: %jt\n", r);
 
-var f = opentmp();
+var f = openTempFile();
 {
   var writer = f.writer();
   var str = '{"foo": 4, "bar":b"some written bytes"}';

--- a/test/types/bytes/io/writeread-pattern.chpl
+++ b/test/types/bytes/io/writeread-pattern.chpl
@@ -29,7 +29,7 @@ proc test(byteRange) {
     halt("Error creating bytes object with correct length");
   }
 
-  var bytesChannel = opentmp();
+  var bytesChannel = openTempFile();
 
   {
     // write them to a channel

--- a/test/types/bytes/io/writeread-random.chpl
+++ b/test/types/bytes/io/writeread-random.chpl
@@ -18,7 +18,7 @@ if randomBytes.size != nBytes {
   halt("Error creating bytes object with correct length");
 }
 
-var bytesChannel = opentmp();
+var bytesChannel = openTempFile();
 
 {
   // write them to a channel

--- a/test/types/records/expiring/ex.chpl
+++ b/test/types/records/expiring/ex.chpl
@@ -88,13 +88,13 @@ recordExample3LM();
 
 
 proc ioExample0LM() {
-  var tmp = opentmp();
+  var tmp = openTempFile();
 }
 ioExample0LM();
 
 proc ioExample1LM() {
   writeln("ioExample1LM");
-  var tmp = opentmp();
+  var tmp = openTempFile();
 
   var A = [1,2,3,4];
   var B:[A.domain] int;

--- a/test/unicode/write_read_euro.chpl
+++ b/test/unicode/write_read_euro.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 if unicodeSupported() {
-  var f = opentmp();
+  var f = openTempFile();
 
   var euro = new ioChar(0x20ac); // euro sign "?";
   var got = new ioChar(0);

--- a/test/unstable/iostyle/channelReadln.chpl
+++ b/test/unstable/iostyle/channelReadln.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = opentmp();
+var f = openTempFile();
 var ch = f.reader();
 var style = defaultIOStyleInternal();
 var i: int;

--- a/test/unstable/iostyle/channelReads.chpl
+++ b/test/unstable/iostyle/channelReads.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = opentmp();
+var f = openTempFile();
 var ch = f.reader();
 var style = defaultIOStyleInternal();
 var i: int;

--- a/test/unstable/iostyle/channelWrite.chpl
+++ b/test/unstable/iostyle/channelWrite.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = opentmp();
+var f = openTempFile();
 var ch = f.writer();
 var style = defaultIOStyleInternal();
 var i: int;

--- a/test/unstable/iostyle/channelWriteln.chpl
+++ b/test/unstable/iostyle/channelWriteln.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = opentmp();
+var f = openTempFile();
 var ch = f.writer();
 var style = defaultIOStyleInternal();
 var i: int;

--- a/test/unstable/iostyle/depOpentmp.chpl
+++ b/test/unstable/iostyle/depOpentmp.chpl
@@ -1,5 +1,5 @@
 use IO;
 
 var style = defaultIOStyleInternal();
-var f = opentmp(style=style);
+var f = openTempFile(style=style);
 f.close();

--- a/test/unstable/iostyle/depOpentmp.good
+++ b/test/unstable/iostyle/depOpentmp.good
@@ -1,1 +1,1 @@
-depOpentmp.chpl:4: warning: opentmp with a style argument is unstable
+depOpentmp.chpl:4: warning: openTempFile with a style argument is unstable

--- a/test/unstable/iostyle/lines.chpl
+++ b/test/unstable/iostyle/lines.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = opentmp();
+var f = openTempFile();
 var style = defaultIOStyleInternal();
 var l = f.lines(local_style=style);
 f.close();

--- a/test/unstable/iostyle/readerWriter.chpl
+++ b/test/unstable/iostyle/readerWriter.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = opentmp();
+var f = openTempFile();
 var style = defaultIOStyleInternal();
 param typ:iokind = iokind.native;
 var ch = f.writer(typ, style=style);


### PR DESCRIPTION
This name is more consistent with our naming conventions.

Resolves #20147 

While here, we were also intending to adjust the file handling, but it
turns out that some systems were already supporting the behavior
that we wanted without code modifications.  So instead update the
documentation to remove the TODO and include the information we
know.

Add a test locking in the deprecation warning.  Updated a bunch of
tests to use the new function name.  Passed a full paratest with
futures