### PR TITLE
dyno: Implement correct scoping for if-vars in conditionals

### DIFF
--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -308,6 +308,11 @@ class Scope {
       be called to populate the root scope with builtins. */
   void addBuiltin(UniqueString name);
 
+  /** Add an out-of-scope entry to this scope. Right now, this exists
+      to populate the scope for the 'then branch' of a conditional
+      with the declaration of an 'if-var'. */
+  void addOutOfScopeEntry(const uast::NamedDecl* ast);
+
   /** Return the parent scope for this scope. */
   const Scope* parentScope() const { return parentScope_; }
 

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -218,8 +218,10 @@ void VarScopeVisitor::exitFrame(const AstNode* ast) {
     }
     if (savedSubBlock) {
       // frame will be processed with parent block
-      bool isParentAstConditional = parsing::parentAst(context, ast);
+      auto parentAst = parsing::parentAst(context, ast);
+      bool isParentAstConditional = parentAst && parentAst->isConditional();
       assert(isParentAstConditional || parentFrame->scopeAst->isTry());
+      std::ignore = isParentAstConditional; // For CI checks.
     } else if (auto cond = ast->toConditional()) {
       handleConditional(cond);
       if (parentFrame != nullptr) {

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -171,8 +171,9 @@ class VarScopeVisitor {
 
  public:
   // ----- visitor implementation
-  void enterScope(const uast::AstNode* ast);
-  void exitScope(const uast::AstNode* ast);
+  bool createsFrame(const uast::AstNode* ast);
+  void enterFrame(const uast::AstNode* ast);
+  void exitFrame(const uast::AstNode* ast);
 
   bool enter(const VarLikeDecl* ast, RV& rv);
   void exit(const VarLikeDecl* ast, RV& rv);

--- a/frontend/lib/resolution/scope-help.h
+++ b/frontend/lib/resolution/scope-help.h
@@ -28,6 +28,8 @@ namespace uast {
 }
 namespace resolution {
 
+void gather(DeclMap& declared, UniqueString name, const uast::AstNode* d,
+            uast::Decl::Visibility visibility);
 
 void gatherDeclsWithin(const uast::AstNode* ast,
                        DeclMap& declared,

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -86,6 +86,10 @@ void Scope::addBuiltin(UniqueString name) {
   declared_.emplace(name, OwnedIdsWithName(ID(), uast::Decl::PUBLIC));
 }
 
+void Scope::addOutOfScopeEntry(const uast::NamedDecl* ast) {
+  gather(declared_, ast->name(), ast, ast->visibility());
+}
+
 const Scope* Scope::moduleScope() const {
   const Scope* cur;
   for (cur = this;


### PR DESCRIPTION
dyno: Implement correct scoping for if-vars in conditionals

Fix bugs in scope resolution for 'if-vars' that were leading to test
failures, and properly implement the remaining semantics of if-vars.

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>