### PR TITLE
Mark GPU and GPUDiagnostic modules unstable

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -31,6 +31,7 @@
     For the most up-to-date information about GPU support see the
     :ref:`technical note <readme-gpu>` about it.
 */
+@unstable "The GPU module is unstable and its interface is subject to change in the future."
 module GPU
 {
   pragma "no doc"

--- a/modules/standard/GPUDiagnostics.chpl
+++ b/modules/standard/GPUDiagnostics.chpl
@@ -25,7 +25,13 @@
     This module is unstable and its interface is subject to change in the
     future.
 
+    GPU support is a relatively new feature to Chapel and is under active
+    development.
+
+    For the most up-to-date information about GPU support see the
+    :ref:`technical note <readme-gpu>` about it.
 */
+@unstable "The GPUDiagnostics module is unstable and its interface is subject to change in the future."
 module GPUDiagnostics
 {
 


### PR DESCRIPTION
Produce a warning message when using the `GPU` and/or `GPUDiagnostics` module with `--warn-unstable`.

I give a more detailed message on the doc. I've manually verified that the message on the `@unstable` keyword doesn't conflict with the warning on the doc.