### PR TITLE
 Followup for 21094.

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -32,7 +32,7 @@ jobs:
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
               echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
               echo $LOG
-              echo "MERGE_LOG= $(echo $LOG | sed 's/\\r\\n/<br>/g' ) " >> $GITHUB_ENV
+              echo "MERGE_LOG= $(echo $LOG | sed 's/\\r\\n\\r\\n/<p>/g'| sed 's/\\r\\n/<br>/g' ) " >> $GITHUB_ENV
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.


### PR DESCRIPTION
Discourse client html formatting does not treat double br as paragraph. This is to update the parsing to use the <p> tag instead of double br.

Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>