### PR TITLE
Fix a bug involving virtual method calls with ref arguments

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1047,7 +1047,8 @@ makeHeapAllocations() {
           call->insertBefore(new DefExpr(tmp));
           call->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_GET_MEMBER, var, heapType->getField(1))));
           def->replace(new SymExpr(tmp));
-        } else if (call->isResolved()) {
+        } else if (call->isResolved() ||
+                   call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
             ArgSymbol* formal = actual_to_formal(def);
             if (formal->isRef()) {
               VarSymbol* tmp = newTemp(var->type);


### PR DESCRIPTION
In makeHeapAllocations() we walk all defs and make certain transformations for
them. Treat virtual method calls the same as regular function calls when doing
these transformations. This fixes a regression in
test/optimizations/copyPropagation/cp-problem2.chpl with --no-local from
#21080.