### PR TITLE
 Add additional email recipients

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -58,7 +58,7 @@ jobs:
            # Required mail subject:
            subject: "[Chapel Merge] ${{github.event.pull_request.title}}"
            # Required recipients' addresses:
-           to: chapel+commits@discoursemail.com
+           to: chapel+commits@discoursemail.com, bradford.chamberlain@hpe.com , bhavani@hpe.com
            # Required sender full name (address can be skipped):
            from:  ${{env.AUTHOR}}
            html_body: |


### PR DESCRIPTION
Adding @bradcray and @bhavanijayakumaran recipient to compare the html formatting between the email clients(outlook vs discource).


Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>