### PR TITLE
Disable ugni MR checks when the cache is enabled

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1901,8 +1901,12 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
   // We can reach 16k memory regions on Aries.
   max_mem_regions = chpl_env_rt_get_int("COMM_UGNI_MAX_MEM_REGIONS", 16384);
 
+  // Do extent MR checks to help catch subtle implementation bugs, but only
+  // when the cache is off. Our extent MR tracking is based on our allocation
+  // size, but the cache can read past an allocation to the end of a page
+  // (safe because the kernel MR extends that far, but our tracking doesn't.)
   do_mr_extent_checks = chpl_env_rt_get_bool("COMM_UGNI_DO_MR_EXTENT_CHECKS",
-                                             true);
+                                             !chpl_cache_enabled());
   cache_max_readahead_size = chpl_getSysPageSize();
 
   //


### PR DESCRIPTION
Disable memory registration extent checks when the remote cache is enabled since we've been getting some false-positives. These checks were added in #19127 and were meant to help catch subtle implementation bugs where a single RDMA transfer crossed multiple memory registration regions. Our MR extents are precise (in that they track the allocation start and end exactly) but the cache can read to the end of a page, which caused false-positives. We tried to quiet them in #19516 and #20642, but we've still been seeing errors sporadically in nightly. Reading to the end of a page is safe since the kernel's memory registration covers that so it was really just our checks being overly conservative. We could probably tighten up our checks, but given that ugni is no longer under active development I think it's ok to just disable these checks when the cache is on.

Resolves Cray/chapel-private#3341