### PR TITLE
Add pass group (front-end, back-end, middle-end) output to `--print-passes`

### DIFF
--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -41,6 +41,8 @@ public:
 
   void                     ReportPass (unsigned long now)   const;
   static void              ReportTotal(unsigned long totalTime);
+  static void              ReportPassGroup(const char* text,
+                                           unsigned long totalTime);
 
   static void              ReportTime(const char* name, double secs);
   static void              ReportText(const char* text);
@@ -161,9 +163,44 @@ void PhaseTracker::ReportPass() const
   mPhases[index]->ReportPass(mTimer.elapsedUsecs());
 }
 
+static const char* passGroups[][2] = {
+  {"total time (front end)", "parallel"},
+  {"total time (middle end)", "denormalize"},
+  {"total time (back end)", "makeBinary"},
+};
+
 void PhaseTracker::ReportTotal() const
 {
-  Phase::ReportTotal(mTimer.elapsedUsecs());
+  unsigned long totalTime = mTimer.elapsedUsecs();
+
+  auto currentPass = mPhases.begin();
+  unsigned long lastStart = 0;
+  unsigned long passTime;
+  size_t numMetapasses = sizeof(passGroups) / sizeof(passGroups[0]);
+  for (int i = 0; i < numMetapasses; i++) {
+    const char* groupName = passGroups[i][0];
+    const char* groupLastPhase = passGroups[i][1];
+
+    currentPass = std::find_if(currentPass, mPhases.end(), [&](auto pass) {
+      if (pass->mName == nullptr) return false;
+      return strcmp(pass->mName, groupLastPhase) == 0;
+    });
+
+    // No such pass, we might've exited early.
+    if (currentPass == mPhases.end()) break;
+    auto nextPass = currentPass + 1;
+
+    if (nextPass != mPhases.end()) {
+      passTime = (*nextPass)->mStartTime - lastStart;
+      lastStart = (*nextPass)->mStartTime;
+    } else {
+      passTime = totalTime - lastStart;
+      lastStart = totalTime;
+    }
+    Phase::ReportPassGroup(groupName, passTime);
+  }
+
+  Phase::ReportTotal(totalTime);
 }
 
 void PhaseTracker::ReportRollup() const
@@ -325,6 +362,12 @@ void Phase::ReportTotal(unsigned long totalTime)
 {
   ReportTime("total time", totalTime / 1e6);
   ReportText("\n\n\n\n");
+}
+
+void Phase::ReportPassGroup(const char* label, unsigned long totalTime)
+{
+  ReportTime(label, totalTime / 1e6);
+  ReportText("\n");
 }
 
 void Phase::ReportTime(const char* name, double secs)

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -177,7 +177,7 @@ void PhaseTracker::ReportTotal() const
   unsigned long lastStart = 0;
   unsigned long passTime;
   size_t numMetapasses = sizeof(passGroups) / sizeof(passGroups[0]);
-  for (int i = 0; i < numMetapasses; i++) {
+  for (size_t i = 0; i < numMetapasses; i++) {
     const char* groupName = passGroups[i][0];
     const char* groupLastPhase = passGroups[i][1];
 

--- a/test/performance/compiler/elliot/passCheck.prediff
+++ b/test/performance/compiler/elliot/passCheck.prediff
@@ -43,6 +43,9 @@ with open(logfile, 'r') as f:
 # '<passname> : <time for pass>' and we want to remove <time for pass>
 with open(logfile, 'w') as f:
     for line in loglines:
+      # temporarily ignore group timings as we transition to coarser timings
+      if line.strip().startswith('total time (') :
+        continue
       splitline = line.split(':')[0].strip() + ' :'
       f.write(splitline + '\n')
       # --print-passes prints detailed output after printing the total


### PR DESCRIPTION
This PR is in service of the "coarse performance graphs" work. In brief, every
time a pass is added, renamed, moved, or deleted, our compiler performance data
has to be updated. This effort is manual, so pass changes basically require
additional manual intervention. Instead, we'd rather broadly group passes into
three categories: front-end, middle-end, and back-end. The compiler can report
timing totals for each pass category, and the performance graphs can just plot
these groups. Passes within groups can then be re-ordered, renamed, added,
etc., without requiring any additional work.

This PR in particular adds output for pass groups to the production compiler's
`--print-passes` flag.

Reviewed by @mppf and @ronawho - thanks!

## Testing
- [x] full local