### PR TITLE
Fix support for gmake 4.4

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -114,22 +114,22 @@ endif
 # query gcc version
 #
 ifndef GNU_GCC_MAJOR_VERSION
-export GNU_GCC_MAJOR_VERSION = $(shell $(CC) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}')
+export GNU_GCC_MAJOR_VERSION := $(shell $(CC) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}')
 endif
 ifndef GNU_GCC_MINOR_VERSION
-export GNU_GCC_MINOR_VERSION = $(shell $(CC) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[2]);}')
+export GNU_GCC_MINOR_VERSION := $(shell $(CC) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[2]);}')
 endif
 ifndef GNU_GPP_MAJOR_VERSION
-export GNU_GPP_MAJOR_VERSION = $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}')
+export GNU_GPP_MAJOR_VERSION := $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}')
 endif
 ifndef GNU_GPP_MINOR_VERSION
-export GNU_GPP_MINOR_VERSION = $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[2]);}')
+export GNU_GPP_MINOR_VERSION := $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[2]);}')
 endif
 ifndef GNU_GPP_SUPPORTS_MISSING_DECLS
-export GNU_GPP_SUPPORTS_MISSING_DECLS = $(shell test $(GNU_GPP_MAJOR_VERSION) -lt 4 || (test $(GNU_GPP_MAJOR_VERSION) -eq 4 && test $(GNU_GPP_MINOR_VERSION) -le 2); echo "$$?")
+export GNU_GPP_SUPPORTS_MISSING_DECLS := $(shell test $(GNU_GPP_MAJOR_VERSION) -lt 4 || (test $(GNU_GPP_MAJOR_VERSION) -eq 4 && test $(GNU_GPP_MINOR_VERSION) -le 2); echo "$$?")
 endif
 ifndef GNU_GCC_SUPPORTS_STRICT_OVERFLOW
-export GNU_GCC_SUPPORTS_STRICT_OVERFLOW = $(shell test $(GNU_GCC_MAJOR_VERSION) -lt 4 || (test $(GNU_GCC_MAJOR_VERSION) -eq 4 && test $(GNU_GCC_MINOR_VERSION) -le 2); echo "$$?")
+export GNU_GCC_SUPPORTS_STRICT_OVERFLOW := $(shell test $(GNU_GCC_MAJOR_VERSION) -lt 4 || (test $(GNU_GCC_MAJOR_VERSION) -eq 4 && test $(GNU_GCC_MINOR_VERSION) -le 2); echo "$$?")
 endif
 
 #

--- a/make/platform/Makefile.linux32
+++ b/make/platform/Makefile.linux32
@@ -19,7 +19,7 @@
 # Makefile.linux32
 
 ifndef CHPL_LSB_RELEASE
-  export CHPL_LSB_RELEASE = $(shell lsb_release -s -i -r 2>/dev/null)
+  export CHPL_LSB_RELEASE := $(shell lsb_release -s -i -r 2>/dev/null)
   # e.g. Ubuntu 14.04
 endif
 


### PR DESCRIPTION
Gmake 4.4 now supports exporting exported variables to `$(shell ...)` commands. This caused issues for variables like `GNU_GCC_MAJOR_VERSION` that we were lazily setting and recursively using through subsequent shell invocations. Fix that here by using immediate set to avoid lazy evaluation.

Without this, we got screens full of messages like:

```
/bin/sh: line 0: test: -lt: unary operator expected
/bin/sh: line 0: test: -eq: unary operator expected
```

and could add the wrong or not enough CFLAGS for gcc because `GNU_GCC_MAJOR_VERSION` and friends weren't set when trying to do version checks like `$(shell test $(GNU_GCC_MAJOR_VERSION) -lt 4)`.

From https://lists.gnu.org/archive/html/info-gnu/2022-10/msg00008.html (gmake 4.4 release notes):

```
* WARNING: Backward-incompatibility!
  Previously makefile variables marked as export were not exported to commands
  started by the $(shell ...) function.  Now, all exported variables are
  exported to $(shell ...).  If this leads to recursion during expansion, then
  for backward-compatibility the value from the original environment is used.
  To detect this change search for 'shell-export' in the .FEATURES variable.
```

Bug report and suggested fix courtesy of Paul Hargrove from the GASNet team.