### PR TITLE
Deprecate support for %= on reals for now

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2012,7 +2012,7 @@ module ChapelBase {
         halt("Attempt to compute a modulus by zero");
     __primitive("%=", lhs, rhs);
   }
-  deprecated "'%=' is deprecated for 'real' values with no expectation to replace it"
+  deprecated "'%=' is deprecated for 'real' values for the time being because it does not work"
   inline operator %=(ref lhs:real(?w), rhs:real(w)) {
     __primitive("%=", lhs, rhs);
   }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2012,6 +2012,7 @@ module ChapelBase {
         halt("Attempt to compute a modulus by zero");
     __primitive("%=", lhs, rhs);
   }
+  deprecated "'%=' is deprecated for 'real' values with no expectation to replace it"
   inline operator %=(ref lhs:real(?w), rhs:real(w)) {
     __primitive("%=", lhs, rhs);
   }

--- a/test/deprecated/modOnReal.chpl
+++ b/test/deprecated/modOnReal.chpl
@@ -1,0 +1,3 @@
+var a, b: real = 2.0;
+a %= b;
+writeln(a);

--- a/test/deprecated/modOnReal.compopts
+++ b/test/deprecated/modOnReal.compopts
@@ -1,0 +1,1 @@
+--no-codegen

--- a/test/deprecated/modOnReal.good
+++ b/test/deprecated/modOnReal.good
@@ -1,0 +1,1 @@
+modOnReal.chpl:2: warning: '%=' is deprecated for 'real' values with no expectation to replace it

--- a/test/deprecated/modOnReal.good
+++ b/test/deprecated/modOnReal.good
@@ -1,1 +1,1 @@
-modOnReal.chpl:2: warning: '%=' is deprecated for 'real' values with no expectation to replace it
+modOnReal.chpl:2: warning: '%=' is deprecated for 'real' values for the time being because it does not work

--- a/test/deprecated/modOnReal.noexec
+++ b/test/deprecated/modOnReal.noexec
@@ -1,0 +1,1 @@
+We're not codegen-ing, so don't execute either


### PR DESCRIPTION
It looks like I added this `%=` overload on reals in commit
433d9c5558 without rationale, which makes me think it
was a mistake, particularly since (a) we don't support a `%`
on reals, and (b) it doesn't seem to work (with the C back-end,
at least).  As a result, I'm deprecating it.

Issues #19255 and #6205 propose implementing these
operators in terms of `fmod()` on reals, and I don't have
any objection to proceeding with that plan, but am only trying
to remove a place where it feels like we're exposed for now.

I think that, arguably, since the feature doesn't work, we could
remove it without deprecation, but given that Arkouda was
briefly relying on it (compiling at least) in 1.28, I felt a little
nervous just pulling it without warning.  And maybe by
deprecating it, I'll be more motivated to implement the fmod-
based solution when I have more time and am removing the
deprecation.