### PR TITLE
Workaround tj actions limitations with using newline as separator.

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -42,7 +42,16 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v34
         with:
-          separator: ","                 
+          separator: "," 
+      # tj-actions' limiation prevents the user from using "\n" as ouptput seperator.
+      # parse the list of changed files and add <br> to add line feeds.   
+      - name: Parse changed files
+        id: parsed-output
+        run: |      
+                echo "MODIFIED= $(echo ${{steps.changed-files.outputs.modified_files}} |  sed 's/\,/<br>/g' )" >> $GITHUB_ENV
+                echo "ADDED= $(echo ${{steps.changed-files.outputs.added_files}} |  sed 's/\,/<br>/g' )" >> $GITHUB_ENV
+                echo "DELETED= $(echo ${{steps.changed-files.outputs.deleted_files}} |  sed 's/\,/<br>/g' )" >> $GITHUB_ENV
+
       - name: Send mail  
         uses: dawidd6/action-send-mail@v3
         with:
@@ -76,11 +85,11 @@ jobs:
               Compare: ${{env.COMPARE_URL}} <br> 
               Diff: ${{github.event.pull_request.diff_url}} <br>
               Modified Files: <br>
-                   ${{steps.changed-files.outputs.modified_files}} <br><br>
+                   ${{env.MODIFIED}} <br><br>
               Added Files: <br>
-                   ${{steps.changed-files.outputs.added_files}} <br><br>    
+                   ${{env.ADDED}} <br><br>    
               Removed Files: <br>     
-                   ${{steps.changed-files.outputs.deleted_files}} <br>
+                   ${{env.DELETED}} <br>
              
               </p>
               </body>

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -43,7 +43,7 @@ jobs:
         uses: tj-actions/changed-files@v34
         with:
           separator: "," 
-      # tj-actions' limitaion prevents the user from using "\n" as output seperator.
+      # tj-actions' limitation prevents the user from using "\n" as output seperator.
       # Solution: parse the list of changed files and replace each comma delimiter with a <br>.   
       - name: Parse changed files
         id: parsed-output

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -43,8 +43,8 @@ jobs:
         uses: tj-actions/changed-files@v34
         with:
           separator: "," 
-      # tj-actions' limiation prevents the user from using "\n" as ouptput seperator.
-      # parse the list of changed files and add <br> to add line feeds.   
+      # tj-actions' limitaion prevents the user from using "\n" as output seperator.
+      # Solution: parse the list of changed files and replace each comma delimiter with a <br>.   
       - name: Parse changed files
         id: parsed-output
         run: |      


### PR DESCRIPTION
This will address

https://github.com/Cray/chapel-private/issues/3995

- [x]  Fix the body to have linefeeds between files rather than commas

Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>