### PR TITLE
Remove this file, which was used by tests that have now been removed

### DIFF
--- a/test/deprecated/testFile.txt
+++ b/test/deprecated/testFile.txt
@@ -1,1 +1,0 @@
-random test data


### PR DESCRIPTION
This was used when deprecating the `out error` pattern 5 years ago and
accidentally got left behind when those tests were cleaned up.  Remove
it now to reduce clutter

I'm planning on running a full paratest to make sure this doesn't cause
problems for any other tests, just in case.  Not planning on asking for a
review, but have let the team know I'm doing this so folks can object if
they feel so moved.