### PR TITLE
Documentation improvements for `weakPointer`

### DIFF
--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -664,13 +664,13 @@ tandem with :record:`~SharedObject.shared` objects.
 
 A ``weakPointer`` provides a reference to a ``shared`` class object without
 requiring it to stay allocated. Such a pattern is useful for implementing graph
-or tree structures with bidirectional references, or for implementing a cash-like
+or tree structures with bidirectional references, or for implementing cache-like
 data structures that maintain a list of objects but don't require them to stay
 allocated.
 
 A "strong" shared reference to the relevant class object can be obtained via
 the :proc:`~WeakPointer.weakPointer.upgrade` method, or by casting the
-weakPointer to a ``shared t`` or a ``shared t?``. If the underlying class is
+weakPointer to a ``shared t`` or a ``shared t?``. If the underlying object is
 not valid (i.e., its shared reference count has already dropped to zero
 causing it to be de-initialized) the upgrade attempt will fail.
 

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -432,7 +432,7 @@ module SharedObject {
     /*
       Create a :record:`~WeakPointer.weakPointer` to this object
     */
-    @unstable "The 'weakPointer' type is still under development and may change in the future"
+    @unstable "the 'weakPointer' interface is experimental - this method is likely to change in the future"
     proc downgrade() {
       return new WeakPointer.weakPointer(this);
     }
@@ -664,17 +664,21 @@ tandem with :record:`~SharedObject.shared` objects.
 
 A ``weakPointer`` provides a reference to a ``shared`` class object without
 requiring it to stay allocated. Such a pattern is useful for implementing graph
-or tree structures with bidirectional references, or for implementing a cash-
-like data structure that maintains a list of objects but doesn't require them
-to stay allocated.
+or tree structures with bidirectional references, or for implementing a cash-like
+data structures that maintain a list of objects but don't require them to stay
+allocated.
 
 A "strong" shared reference to the relevant class object can be obtained via
 the :proc:`~WeakPointer.weakPointer.upgrade` method, or by casting the
 weakPointer to a ``shared t`` or a ``shared t?``. If the underlying class is
-not valid (i.e., its shared reference count has dropped to zero causing it to
-be deinitialized) the upgrade attempt will fail.
+not valid (i.e., its shared reference count has already dropped to zero
+causing it to be de-initialized) the upgrade attempt will fail.
 
 Weak pointers are implemented using task-safe reference counting.
+
+.. Warning::
+  The ``weakPointer`` type is experimental, please use this feature with caution.
+
 */
 module WeakPointer {
     use Errors, Atomics, ChapelBase;
@@ -727,7 +731,7 @@ module WeakPointer {
         /*
             Create a new weak pointer to a shared class instance 'c'
         */
-        @unstable "The 'weakPointer' type is still under development and may change in the future"
+        @unstable "The 'weakPointer' type is experimental and is likely to change in the future"
         proc init(c : shared) {
             var ptr = c.chpl_p: _to_nilable(_to_unmanaged(c.chpl_t));
             var count = c.chpl_pn;

--- a/test/classes/weakPointers/concurrentUpgrades.good
+++ b/test/classes/weakPointers/concurrentUpgrades.good
@@ -1,5 +1,5 @@
 concurrentUpgrades.chpl:11: In function 'concurrentlyUpgrade':
-concurrentUpgrades.chpl:12: warning: The 'weakPointer' type is still under development and may change in the future
+concurrentUpgrades.chpl:12: warning: The 'weakPointer' type is experimental and is likely to change in the future
   concurrentUpgrades.chpl:39: called as concurrentlyUpgrade(s: shared basicClass)
 true
 true

--- a/test/classes/weakPointers/initWeakPtr.good
+++ b/test/classes/weakPointers/initWeakPtr.good
@@ -1,6 +1,6 @@
-initWeakPtr.chpl:17: warning: The 'weakPointer' type is still under development and may change in the future
-initWeakPtr.chpl:27: warning: The 'weakPointer' type is still under development and may change in the future
-initWeakPtr.chpl:43: warning: The 'weakPointer' type is still under development and may change in the future
+initWeakPtr.chpl:17: warning: The 'weakPointer' type is experimental and is likely to change in the future
+initWeakPtr.chpl:27: warning: The 'weakPointer' type is experimental and is likely to change in the future
+initWeakPtr.chpl:43: warning: the 'weakPointer' interface is experimental - this method is likely to change in the future
 1
 	shared: '{x = 1}' 	type: 'shared basicClass' 		sc: 1
 	weak: '{x = 1}' 	type: 'weakPointer(shared basicClass)' 	sc: 1	 wc: 1

--- a/test/classes/weakPointers/passiveCache.good
+++ b/test/classes/weakPointers/passiveCache.good
@@ -1,5 +1,5 @@
 passiveCache.chpl:46: In method 'buildAndSave':
-passiveCache.chpl:48: warning: The 'weakPointer' type is still under development and may change in the future
+passiveCache.chpl:48: warning: The 'weakPointer' type is experimental and is likely to change in the future
   passiveCache.chpl:38: called as (PassiveCache(basicClass)).buildAndSave(key: int(64)) from method 'getOrBuild'
   passiveCache.chpl:66: called as (PassiveCache(basicClass)).getOrBuild(key: int(64))
 true


### PR DESCRIPTION
This PR makes it more clear that the `weakPointer` type is experimental.

- Adds an extra warning to the top of the `weakPointer` docs page
- Re-words the unstable warning on `shared.downgrade` to make it clear that the method itself is unstable, not just the `weakPointer` type
- Makes some minor working improvements