### PR TITLE
Document EofError case for channel.write[ln]

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5822,6 +5822,8 @@ proc _channel.read(type t ...?numTypes) throws where numTypes > 1 {
               value.writeThis() with the channel as an argument.
 
    :throws SystemError: Thrown if the values could not be written to the channel.
+   :throws EofError: Thrown if EOF is reached before all the arguments
+                      could be written.
  */
 pragma "fn exempt instantiation limit"
 inline proc _channel.write(const args ...?k) throws {
@@ -5880,6 +5882,8 @@ proc _channel.writeln() throws {
               value.writeThis() with the channel as an argument.
 
    :throws SystemError: Thrown if the values could not be written to the channel.
+   :throws EofError: Thrown if EOF is reached before all the arguments
+                      could be written.
  */
 proc _channel.writeln(const args ...?k) throws {
   try this.write((...args), new ioNewline());

--- a/test/library/standard/IO/writeOutOfRange.chpl
+++ b/test/library/standard/IO/writeOutOfRange.chpl
@@ -1,0 +1,26 @@
+use IO;
+
+var filename = "outOfRange.txt";
+var f = open(filename, iomode.cw);
+
+var writeCh = f.writer(region=0..3);
+try {
+    writeCh.writeln("blah blah blah");
+} catch e : EofError {
+    writeln("caught correct error [ ", e, " ]");
+} catch e {
+    writeln("caught wrong error type [ ", e, " ]");
+}
+writeCh.close();
+
+writeCh = f.writer(region=0..3);
+try {
+    writeCh.write("blah blah blah");
+} catch e : EofError {
+    writeln("caught correct error [ ", e, " ]");
+} catch e {
+    writeln("caught wrong error type [ ", e, " ]");
+}
+writeCh.close();
+
+f.close();

--- a/test/library/standard/IO/writeOutOfRange.cleanfiles
+++ b/test/library/standard/IO/writeOutOfRange.cleanfiles
@@ -1,0 +1,1 @@
+outOfRange.txt

--- a/test/library/standard/IO/writeOutOfRange.compopts
+++ b/test/library/standard/IO/writeOutOfRange.compopts
@@ -1,0 +1,1 @@
+-suseNewFileWriterRegionBounds=true

--- a/test/library/standard/IO/writeOutOfRange.good
+++ b/test/library/standard/IO/writeOutOfRange.good
@@ -1,0 +1,2 @@
+caught correct error [ EofError: end of file (while writing string with path "outOfRange.txt" offset 0) ]
+caught correct error [ EofError: end of file (while writing string with path "outOfRange.txt" offset 0) ]


### PR DESCRIPTION
Adds the following line to the documentation for `channel.write` and `channel.writeln`:
```
EofError – Thrown if EOF is reached before all the arguments could be written.
```
This clarifies which error type would be used to catch an EOF for a write[ln] call on a finite sized channel.

Also adds a test to ensure that the docs match the actual behavior.