### PR TITLE
Remove use of --verbose for gpu debugging

### DIFF
--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -1,0 +1,10 @@
+module ChapelGpuSupport {
+  use ChapelBase;
+
+  extern var chpl_gpu_debug: bool;
+
+  config const debugGpu = false;
+
+  // by virtue of module initialization:
+  chpl_gpu_debug = debugGpu;
+}

--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -1,7 +1,7 @@
 module ChapelGpuSupport {
   use ChapelBase;
 
-  extern var chpl_gpu_debug: bool;
+  extern var chpl_gpu_debug : bool;
 
   config const debugGpu = false;
 

--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -1,3 +1,23 @@
+/*
+ * Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 module ChapelGpuSupport {
   use ChapelBase;
 

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -71,6 +71,7 @@ module ChapelStandard {
   public use ChapelSerializedBroadcast;
   public use ExportWrappers;
   public use ChapelAutoAggregation;
+  public use ChapelGpuSupport;
 
   // Standard modules.
   public use Types as Types;

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -31,8 +31,10 @@ extern "C" {
 
 #ifdef HAS_GPU_LOCALE
 
+extern bool chpl_gpu_debug;
+
 static inline void CHPL_GPU_DEBUG(const char *str, ...) {
-  if (verbosity >= 2) {
+  if (chpl_gpu_debug) {
     va_list args;
     va_start(args, str);
     vfprintf(stdout, str, args);

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -29,9 +29,12 @@
 extern "C" {
 #endif
 
-#ifdef HAS_GPU_LOCALE
-
+// We need to declare this variable outside of the commented out HAS_GPU_LOCALE
+// section due to the fact that GPUDiagnostics module accesses it (and this
+// module can be used despite what locale model you're using).
 extern bool chpl_gpu_debug;
+
+#ifdef HAS_GPU_LOCALE
 
 static inline void CHPL_GPU_DEBUG(const char *str, ...) {
   if (chpl_gpu_debug) {

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -17,6 +17,12 @@
  * limitations under the License.
  */
 
+// We need to define this variable outside of the commented out HAS_GPU_LOCALE
+// section due to the fact that GPUDiagnostics module accesses it (and this
+// module can be used despite what locale model you're using).
+#include <stdbool.h>
+bool chpl_gpu_debug = false;
+
 #ifdef HAS_GPU_LOCALE
 
 #include "chplrt.h"
@@ -27,8 +33,6 @@
 #include "error.h"
 #include "chplcgfns.h"
 #include "chpl-linefile-support.h"
-
-bool chpl_gpu_debug = false;
 
 void chpl_gpu_init(void) {
   chpl_gpu_impl_init();

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -28,6 +28,8 @@
 #include "chplcgfns.h"
 #include "chpl-linefile-support.h"
 
+bool chpl_gpu_debug = false;
+
 void chpl_gpu_init(void) {
   chpl_gpu_impl_init();
 }

--- a/test/gpu/native/promotion.execopts
+++ b/test/gpu/native/promotion.execopts
@@ -1,1 +1,1 @@
---verbose
+-sdebugGpu=true

--- a/test/gpu/native/varInInnerBlock.execopts
+++ b/test/gpu/native/varInInnerBlock.execopts
@@ -1,1 +1,1 @@
---verbose
+-sdebugGpu=true


### PR DESCRIPTION
Prior to this PR, to get verbose debug output for GPUs you would pass `--verbose` to a chapel program.  `--verbose` is used in other contexts and it seems like it would be better if this was separated out.

This PR introduces a new config constant `debugGpu` that can be used for this.

So instead of invoking a program like:

`./foo --verbose`

You would do:

`./foo -sdebugGpu=true`

To get the same verbose GPU debugging output.

The bulk of this PR is from work Engin did but didn't get around to committing before:

https://github.com/chapel-lang/chapel/compare/main...e-kayrakli:chapel:gpu-verbose-v2