### PR TITLE
Remove unused variable from resolution-queries.cpp

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2308,7 +2308,6 @@ isInitialTypedSignatureApplicable(Context* context,
   }
 
   // Next, check that the types are compatible
-  int formalIdx = 0;
   int numVarArgActuals = 0;
   QualifiedType varArgType;
   for (const FormalActual& entry : faMap.byFormals()) {
@@ -2341,8 +2340,6 @@ isInitialTypedSignatureApplicable(Context* context,
         return false;
       }
     }
-
-    formalIdx++;
   }
 
   if (!varArgType.isUnknown()) {


### PR DESCRIPTION
This is an almost-trivial change. This unused variable is something that our testing infra didn't catch, but leads to compiler warnings (and therefore errors) in others' builds. 

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>

Reviewed by @mppf - thanks!

## Testing
- [x] full local testing