### PR TITLE
Update prereqs install commands

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -121,6 +121,13 @@ We have used the following commands to install the above prerequisites:
       sudo dnf install llvm-devel clang clang-devel
 
 
+  * CentOS Stream 9::
+
+      sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
+      sudo dnf install which diffutils
+      sudo dnf install llvm-devel-14.0.6 clang-14.0.6 clang-devel-14.0.6
+
+
   * Debian 10 "Buster"::
 
       sudo apt-get update
@@ -135,7 +142,7 @@ We have used the following commands to install the above prerequisites:
       sudo apt-get install llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev
 
 
-  * Fedora 31, 32, 33, 34, 35, 36::
+  * Fedora 34, 35, 36::
 
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
       sudo dnf install which diffutils
@@ -172,8 +179,15 @@ We have used the following commands to install the above prerequisites:
       sudo apt-get install llvm-12-dev llvm-12 llvm-12-tools clang-12 libclang-12-dev libclang-cpp12-dev libedit-dev
 
 
-  * Ubuntu 21.10 "Impish Indri", 22.04 "Jammy Jellyfish", 22.10 "Kinetic Kudu"::
+  * Ubuntu 22.04 "Jammy Jellyfish"::
 
       sudo apt-get update
       sudo apt-get install gcc g++ m4 perl python3 python3-dev bash make mawk git pkg-config cmake
       sudo apt-get install llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev
+
+
+  * Ubuntu 22.10 "Kinetic Kudu"::
+
+      sudo apt-get update
+      sudo apt-get install gcc g++ m4 perl python3 python3-dev bash make mawk git pkg-config cmake
+      sudo apt-get install llvm-14-dev llvm-14 llvm-14-tools clang-14 libclang-14-dev libclang-cpp14-dev libedit-dev


### PR DESCRIPTION
This PR updates prereqs.rst with the automatically generated commands to install prerequisites based upon the updates to portability testing from PR #21128.

Further notes:
 * We can test for Fedora 37 but I removed the generated Fedora 37 docs since I couldn't figure out the command to install clang 14 on that platform (I think something is missing).
 * Fedora 31, 32, 33, and Ubuntu 21.10 are removed because they have reached end-of-life.
 * CentOS Stream 9 commands are now present since I was able to add testing for it.
 * Ubuntu 22.10 now defaults to LLVM 15 which we don't support yet, so it has a separate section to install LLVM 14.

Reviewed by @lydia-duncan - thanks!