### PR TITLE
Suppress the open* test failures when run as a windows service

### DIFF
--- a/test/library/standard/IO/open/checkPermissions.suppressif
+++ b/test/library/standard/IO/open/checkPermissions.suppressif
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Fails when run as a windows service, see JIRA issue 81
+
+if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
+  echo 1
+else
+  echo 0
+fi

--- a/test/library/standard/IO/openreader/checkPermissions.suppressif
+++ b/test/library/standard/IO/openreader/checkPermissions.suppressif
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Fails when run as a windows service, see JIRA issue 81
+
+if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
+  echo 1
+else
+  echo 0
+fi

--- a/test/library/standard/IO/openwriter/checkPermissions.suppressif
+++ b/test/library/standard/IO/openwriter/checkPermissions.suppressif
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Fails when run as a windows service, see JIRA issue 81
+
+if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
+  echo 1
+else
+  echo 0
+fi


### PR DESCRIPTION
These tests pass when run by hand with Cygwin testing but fail when run through our testing harness.

I copied this suppressif from test/library/standard/FileSystem/chmod/chmod_noprivilege.suppressif