### PR TITLE
spec: clarify less-generic rule applies with same type

### DIFF
--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -1485,8 +1485,9 @@ mapping:
 1. If one of the formals requires promotion and the other does not, the
    formal not requiring promotion is better
 
-2. If one of the formals is less generic than the other formal, the
-   less-generic formal is better
+2. If both of the formals have the same type after instantiation and one
+   of the formals is less generic than the other formal, the less-generic
+   formal is better
 
 3. If one of the formals is ``param`` and the other is not, the ``param``
    formal is better


### PR DESCRIPTION
Follow-up to PR #20755. Since the genericity of formals is now only considered if they are the same instantiated type, add that to the spec.

Reviewed by @DanilaFe - thanks!