### PR TITLE
fix(chpldoc): make chpldoc detect CHPL_HOME if not set or passed

### DIFF
--- a/frontend/include/chpl/util/filesystem.h
+++ b/frontend/include/chpl/util/filesystem.h
@@ -91,6 +91,12 @@ std::error_code makeDir(std::string dirpath, bool makeParents=false);
 std::string getExecutablePath(const char* argv0, void* MainExecAddr);
 
 
+/*
+  Compare two paths to see if they point to the same filesystem object.
+  Utilizes llvm::sys::fs:equivalent to do the comparison.
+*/
+bool isSameFile(const char* path1, const char* path2);
+
 
 } // end namespace chpl
 

--- a/frontend/lib/util/filesystem.cpp
+++ b/frontend/lib/util/filesystem.cpp
@@ -208,5 +208,10 @@ std::string getExecutablePath(const char* argv0, void* MainExecAddr) {
   return getMainExecutable(argv0, MainExecAddr);
 }
 
+bool isSameFile(const char* path1, const char* path2) {
+  using namespace llvm::sys::fs;
+  return equivalent(path1, path2);
+}
+
 
 } // namespace chpl

--- a/frontend/lib/util/filesystem.cpp
+++ b/frontend/lib/util/filesystem.cpp
@@ -209,8 +209,7 @@ std::string getExecutablePath(const char* argv0, void* MainExecAddr) {
 }
 
 bool isSameFile(const char* path1, const char* path2) {
-  using namespace llvm::sys::fs;
-  return equivalent(path1, path2);
+  return llvm::sys::fs::equivalent(path1, path2);
 }
 
 

--- a/tools/chpldoc/CMakeLists.txt
+++ b/tools/chpldoc/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 add_executable(chpldoc "chpldoc.cpp")
 set_property(TARGET chpldoc PROPERTY CXX_STANDARD 14)
-target_sources(chpldoc PRIVATE arg.h arg.cpp arg-helpers.h arg-helpers.cpp version_num.h)
+target_sources(chpldoc PRIVATE arg.h arg.cpp arg-helpers.h arg-helpers.cpp version_num.h configured_prefix.h)
 target_link_libraries(chpldoc libdyno)
 target_include_directories(chpldoc PUBLIC
                            ${CHPL_MAIN_INCLUDE_DIR}

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -26,13 +26,8 @@
 #include <fstream>
 #include <limits>
 #include <regex>
-#include <sstream>
 #include <unordered_map>
-#include <unordered_set>
 #include <queue>
-
-#include <sys/stat.h>
-#include <unistd.h>
 
 #include "arg.h"
 #include "arg-helpers.h"
@@ -46,8 +41,6 @@
 #include "chpl/framework/query-impl.h"
 #include "chpl/framework/stringify-functions.h"
 #include "chpl/framework/update-functions.h"
-#include "chpl/uast/AstTag.h"
-#include "chpl/uast/ASTTypes.h"
 #include "chpl/uast/TypeDecl.h"
 #include "chpl/uast/all-uast.h"
 #include "chpl/util/string-escapes.h"
@@ -56,9 +49,7 @@
 #include "chpl/framework/global-strings.h"
 #include "chpl/resolution/scope-queries.h"
 
-#include "chpl/util/filesystem.h"
 #include "llvm/Support/FileSystem.h"
-
 
 
 using namespace chpl;

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -37,6 +37,7 @@
 #include "arg.h"
 #include "arg-helpers.h"
 #include "version_num.h"
+#include "configured_prefix.h"
 
 #include "chpl/parsing/Parser.h"
 #include "chpl/parsing/parsing-queries.h"
@@ -54,6 +55,9 @@
 #include "chpl/uast/chpl-syntax-printer.h"
 #include "chpl/framework/global-strings.h"
 #include "chpl/resolution/scope-queries.h"
+
+#include "chpl/util/filesystem.h"
+#include "llvm/Support/FileSystem.h"
 
 
 
@@ -192,6 +196,130 @@ static std::string get_version() {
   }
   return ret;
 }
+
+static std::string getMajorMinorVersion() {
+  std::string version = std::to_string(MAJOR_VERSION);
+  version += ".";
+  version += std::to_string(MINOR_VERSION);
+  return version;
+}
+
+static bool isMaybeChplHome(std::string path) {
+  // assume if we find subfolder util/ containing chplenv, we might be home
+  path += "/util/chplenv";
+  return llvm::sys::fs::exists(path);
+}
+
+static std::error_code findChplHome(char* argv0, void* mainAddr,
+                             std::string& chplHomeOut,
+                             bool& installed, bool& fromEnv,
+                             std::string& warningMessage) {
+  std::string versionString = getMajorMinorVersion();
+  std::string guess = getExecutablePath(argv0, mainAddr);
+
+  const char* chpl_home = getenv("CHPL_HOME");
+
+  if (!guess.empty()) {
+    // truncate path at /bin
+    char* tmp_guess = strdup(guess.c_str());
+    if ( tmp_guess[0] ) {
+      int j = strlen(tmp_guess) - 5; // /bin and '\0'
+      for ( ; j >= 0; j-- ) {
+        if ( tmp_guess[j] == '/' &&
+            tmp_guess[j+1] == 'b' &&
+            tmp_guess[j+2] == 'i' &&
+            tmp_guess[j+3] == 'n' ) {
+          tmp_guess[j] = '\0';
+          break;
+        }
+      }
+    }
+    guess = std::string(tmp_guess);
+    if (isMaybeChplHome(guess)) {
+      chplHomeOut = guess;
+    } else {
+      guess = "";
+    }
+  }
+
+  if (chpl_home) {
+    fromEnv = true;
+    if(strlen(chpl_home) > FILENAME_MAX)
+      // USR_FATAL("$CHPL_HOME=%s path too long", chpl_home);
+      // error_state
+      // TODO: customize error message?
+      return std::make_error_code(std::errc::filename_too_long);
+    if (guess.empty()) {
+      // Could not find exe path, but have a env var set
+      chplHomeOut = std::string(chpl_home);
+    } else {
+      // We have env var and found exe path.
+      // Check that they match and emit a warning if not.
+      if (!isSameFile(chpl_home, guess.c_str())) {
+        // Not the same. Emit warning.
+        //USR_WARN("$CHPL_HOME=%s mismatched with executable home=%s",
+        //         chpl_home, guess);
+        warningMessage = "$CHPL_HOME=" + std::string(chpl_home) + " is mismatched with executable home=" + guess;
+      }
+      // Since we have an enviro var, always use that.
+      chplHomeOut = std::string(chpl_home);
+    }
+  } else {
+    // Check in a default location too
+    if (guess.empty()) {
+      char TEST_HOME[FILENAME_MAX+1] = "";
+
+      // Check for Chapel libraries at installed prefix
+      // e.g. /usr/share/chapel/<vers>
+      int rc;
+      rc = snprintf(TEST_HOME, FILENAME_MAX, "%s/%s/%s",
+                    CONFIGURED_PREFIX, // e.g. /usr
+                    "share/chapel",
+                    versionString.c_str());
+      if (rc >= FILENAME_MAX) {
+        // USR_FATAL("Installed pathname too long");
+        // TODO: return an error here
+        return std::make_error_code(std::errc::filename_too_long);
+      }
+
+      if (isMaybeChplHome(TEST_HOME)) {
+        guess = strdup(TEST_HOME);
+        installed = true;
+       }
+    }
+
+    if (guess.empty()) {
+      // Could not find enviro var, and could not
+      // guess at exe's path name.
+      // USR_FATAL("$CHPL_HOME must be set to run chpl");
+      // TODO: customize the error message
+      return std::make_error_code(std::errc::no_such_file_or_directory);
+    } else {
+      int rc;
+
+      if (guess.length() > FILENAME_MAX) {
+      // USR_FATAL("chpl guessed home %s too long", guess);
+        return std::make_error_code(std::errc::filename_too_long);
+      }
+      // Determined exe path, but don't have a env var set
+        rc = setenv("CHPL_HOME", guess.c_str(), 0);
+        if ( rc ) {
+          // USR_FATAL("Could not setenv CHPL_HOME");
+          // TODO: customize the error message
+          return std::make_error_code(std::errc::no_such_file_or_directory);
+         }
+         chplHomeOut = guess;
+    }
+  }
+  // Check that the resulting path is a Chapel distribution.
+  if (!isMaybeChplHome(chplHomeOut.c_str())) {
+    // Bad enviro var.
+    //USR_WARN("CHPL_HOME=%s is not a Chapel distribution", CHPL_HOME);
+    warningMessage = "CHPL_HOME=" + chplHomeOut + " is not a Chapel distribution";
+  }
+  return std::error_code();
+}
+
 
 static void printStuff(const char* argv0, void* mainAddr) {
   bool shouldExit       = false;
@@ -2082,22 +2210,27 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir,
 
 
 int main(int argc, char** argv) {
-  // initial value of CHPL_HOME may be overridden by cmdline arg
-  if (getenv("CHPL_HOME") != NULL) {
-    CHPL_HOME = getenv("CHPL_HOME");
-  }
   Args args = parseArgs(argc, argv, (void*)main);
+  std::string warningMsg;
+  bool foundEnv = false;
+  bool installed = false;
+  // if user overrides CHPL_HOME from command line, don't go looking for trouble
   if (CHPL_HOME.empty()) {
-    fprintf(stderr, "CHPL_HOME not set. Please set CHPL_HOME or pass a value "
-                     "using the --home option\n" );
-    clean_exit(1);
+    std::error_code err = findChplHome(argv[0], (void*)main, CHPL_HOME, installed, foundEnv, warningMsg);
+    if (!warningMsg.empty()) {
+      fprintf(stderr, "%s\n", warningMsg.c_str());
+    }
+    if (err) {
+      fprintf(stderr, "CHPL_HOME not set to a valid value. Please set CHPL_HOME or pass a value "
+                      "using the --home option\n" );
+      clean_exit(1);
+    }
   }
+
   // TODO: there is a future for this, asking for a better error message and I
   // think we can provide it by checking here.
   // see test/chpldoc/compflags/folder/save-sphinx/saveSphinxInDocs.doc.future
-  // if (args.saveSphinx == "docs") {
-
-  // }
+  // if (args.saveSphinx == "docs") { }
 
   textOnly_ = args.textOnly;
   if (args.commentStyle.substr(0,2) != "/*") {

--- a/tools/chpldoc/configured_prefix.h
+++ b/tools/chpldoc/configured_prefix.h
@@ -1,0 +1,1 @@
+../../compiler/main/configured_prefix.h

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -241,8 +241,7 @@ if [ ! -z "$PREFIX" ]
 then
   myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$PREFIX/bin"
 else
-  tmp_bin_dir="bin/$CHPL_BIN_SUBDIR"
-  myinstallfile "$tmp_bin_dir"/chpl "$DEST_DIR/$tmp_bin_dir"
+  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpl "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"
 fi
 
 # copy runtime lib
@@ -347,15 +346,24 @@ then
   fi
 fi
 
+# create symlink for chpldoc-legacy
 if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc" ]
 then
-  # create a symbolic link for chpldoc
+  # Choose destination depending on installation mode {prefix, home}
   if [ ! -z "$PREFIX" ]
   then
-    (cd "$PREFIX/bin" && rm -f chpldoc && ln -s chpl chpldoc)
+    (cd "$PREFIX/bin" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)
   else
-    (cd "$DEST_DIR/bin/$CHPL_BIN_SUBDIR" && rm -f chpldoc && ln -s chpl chpldoc)
+    (cd "$DEST_DIR/bin/$CHPL_BIN_SUBDIR" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)
   fi
+fi
+
+# copy chpldoc
+if [ ! -z "$PREFIX" ]
+then
+  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$PREFIX/bin"
+else
+  myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"
 fi
 
 # copy chplconfig


### PR DESCRIPTION
This PR gives `chpldoc` the ability to detect `CHPL_HOME` if it is not set
nor given as a command-line option.
 
`chpl` has the ability to locate `CHPL_HOME` if it's not set in the environment
nor given from the command-line. Previously, `chpldoc` also had this 
functionality as it was just a symlink to `chpl`. When we moved to 
`dyno-chpldoc`, we did not maintain this functionality, which wasn't detected 
because the installation script was not properly copying the new `chpldoc`. 
Once the installation script was corrected, this missing feature caused test 
failures, which forced us to revert PR 20880 (the installation script fix). 
With this PR, we should be able to un-revert PR 20880 and verify that the 
installation works and `chpldoc` detects `CHPL_HOME` appropriately when
it's not set.

Added the revert of c25db55348b7de6d14d118065b9af442237bc24c, which reverted PR20880, 
so this PR effectively includes the changes of 20880 as well.

reviewed by @mppf - thank you!

TESTING:

- [x] paratest
- [x] `test_install.bash` works locally with changes from PR#20880 included
- [x] `chpldoc` reports `CHPL_HOME` mismatches as `chpl` reports them
- [x] `chpldoc` detects `CHPL_HOME` when not set or passed from command-line