### PR TITLE
Avoid calling the deprecated chmod()

### DIFF
--- a/test/library/standard/IO/open/checkPermissions.chpl
+++ b/test/library/standard/IO/open/checkPermissions.chpl
@@ -6,7 +6,7 @@ var w = openwriter(filename);
 w.writeln("something");
 w.close();
 
-chmod(filename, 0o0400); // set it to read only now that it has contents
+chmod(filename.c_str(), 0o0400: mode_t); // set it to read only now that it has contents
 
 try {
   var f = open(filename, iomode.cw);

--- a/test/library/standard/IO/openwriter/checkPermissions.chpl
+++ b/test/library/standard/IO/openwriter/checkPermissions.chpl
@@ -6,7 +6,7 @@ var w = openwriter(filename);
 w.writeln("something");
 w.close();
 
-chmod(filename, 0o0400); // set it to read only now that it has contents
+chmod(filename.c_str(), 0o0400: mode_t); // set it to read only now that it has contents
 
 try {
   var f = openwriter(filename);


### PR DESCRIPTION
#21130 deprecated FileSystem.chmod().
This PR switches two tests from this chmod
to its replacement in OS.POSIX, to avoid .good mismatches.

The two chmod overloads have different types of formals.
Both overloads are visible in these tests.
The switch is achieved by adjusting the types of the actuals.
