### PR TITLE
Fix broken tests (gpuDebug config const)

### DIFF
--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -176,6 +176,8 @@ CopyAggregation
   from print-module-resolution.ChapelStandard.ChapelAutoAggregation.CopyAggregation
 ChapelAutoAggregation
   from print-module-resolution.ChapelStandard.ChapelAutoAggregation
+ChapelGpuSupport
+  from print-module-resolution.ChapelStandard.ChapelGpuSupport
 Types
   from print-module-resolution.ChapelStandard.Types
 stopInitCommDiags

--- a/test/execflags/configs/privateconfigs-help-set.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help-set.comm-none.good
@@ -19,6 +19,7 @@ Built-in config vars:
                            memLog: string
                       memLeaksLog: string
                    memLeaksByDesc: string
+                         debugGpu: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)
 

--- a/test/execflags/configs/privateconfigs-help.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help.comm-none.good
@@ -19,6 +19,7 @@ Built-in config vars:
                            memLog: string
                       memLeaksLog: string
                    memLeaksByDesc: string
+                         debugGpu: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)
 

--- a/test/execflags/ferguson/help2.good
+++ b/test/execflags/ferguson/help2.good
@@ -31,5 +31,6 @@ CONFIG VARS:
                            memLog: string
                       memLeaksLog: string
                    memLeaksByDesc: string
+                         debugGpu: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)

--- a/test/execflags/shannon/configs/help/basehelp.txt
+++ b/test/execflags/shannon/configs/help/basehelp.txt
@@ -20,6 +20,7 @@ Built-in config vars:
                           memLog: string
                      memLeaksLog: string
                   memLeaksByDesc: string
+                        debugGpu: bool 
  defaultHashTableResizeThreshold: real(64) 
                       numLocales: int(64)
 

--- a/test/execflags/shannon/help.good
+++ b/test/execflags/shannon/help.good
@@ -18,5 +18,6 @@ CONFIG VARS:
                            memLog: string
                       memLeaksLog: string
                    memLeaksByDesc: string
+                         debugGpu: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -44,6 +44,7 @@ Initializing Modules:
     MemTracking
     ChapelUtil
     ExportWrappers
+    ChapelGpuSupport
     Types
     AlignedTSupport
     CopyAggregation


### PR DESCRIPTION
The introduction of the gpuDebug config const (and ChapelGpuSupport module) has broken some tests. I've regolded as needed.