### PR TITLE
Additional ofi sanity checks

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -289,6 +289,8 @@ size_t chpl_comm_ofi_hp_gethugepagesize(void);
 //
 double chpl_comm_ofi_time_get(void);
 
+extern const char *chpl_comm_oob;
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/src/comm/ofi/comm-ofi-locales.c
+++ b/runtime/src/comm/ofi/comm-ofi-locales.c
@@ -22,6 +22,8 @@
 #include "arg.h"
 #include "chpl-comm-locales.h"
 #include "error.h"
+#include "chpl-comm.h"
+#include "comm-ofi-internal.h"
 
 int64_t chpl_comm_default_num_locales(void) {
   return chpl_specify_locales_error();
@@ -29,4 +31,14 @@ int64_t chpl_comm_default_num_locales(void) {
 
 
 void chpl_comm_verify_num_locales(int64_t proposedNumLocales) {
+#ifndef LAUNCHER
+  if (proposedNumLocales != chpl_numNodes) {
+    char msg[100];
+    snprintf(msg, sizeof(msg),
+             "Number of locales from command-line doesn't match "
+             "number from OOB %s (%lld != %d)",
+             chpl_comm_oob, proposedNumLocales, chpl_numNodes);
+    chpl_error(msg,0,0);
+  }
+#endif
 }

--- a/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
@@ -55,8 +55,9 @@ void chpl_comm_ofi_oob_init(void) {
   MPI_CHK(MPI_Comm_size(MPI_COMM_WORLD, &size));
   chpl_numNodes = (int32_t) size;
 
-  DBG_PRINTF(DBG_OOB, "OOB init: node %" PRI_c_nodeid_t " of %" PRId32,
-             chpl_nodeID, chpl_numNodes);
+  chpl_comm_oob = "MPI";
+  DBG_PRINTF(DBG_OOB, "OOB %s init: node %" PRI_c_nodeid_t " of %" PRId32,
+             chpl_comm_oob, chpl_nodeID, chpl_numNodes);
 }
 
 

--- a/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-pmi2.c
@@ -105,8 +105,9 @@ void chpl_comm_ofi_oob_init(void) {
     chpl_numNodes = (int32_t) size;
   }
 
-  DBG_PRINTF(DBG_OOB, "OOB init: node %" PRI_c_nodeid_t " of %" PRId32,
-             chpl_nodeID, chpl_numNodes);
+  chpl_comm_oob = "PMI/PMI2";
+  DBG_PRINTF(DBG_OOB, "OOB %s init: node %" PRI_c_nodeid_t " of %" PRId32,
+             chpl_comm_oob, chpl_nodeID, chpl_numNodes);
 }
 
 

--- a/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
@@ -69,6 +69,7 @@ void chpl_comm_ofi_oob_init(void) {
   } else {
     INTERNAL_ERROR_V("need slurm system launcher");
   }
+  chpl_comm_oob = "sockets";
 }
 
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -977,6 +977,12 @@ static void init_bar(void);
 
 static void init_broadcast_private(void);
 
+////////////////////////////////////////
+//
+// Misc.
+//
+
+const char *chpl_comm_oob = "unknown";
 
 //
 // forward decls
@@ -2317,6 +2323,7 @@ void init_ofiEp(void) {
   numRxCtxs = numAmHandlers;
 
   tciTabLen = numTxCtxs;
+  CHK_TRUE(tciTabLen > 0);
   CHPL_CALLOC(tciTab, tciTabLen);
 
   // Use "hybrid" MR mode for the cxi provider if it's available
@@ -5574,6 +5581,8 @@ struct perTxCtxInfo_t* findFreeTciTabEntry(chpl_bool bindToAmHandler) {
   //
   const int numWorkerTxCtxs = tciTabLen - numAmHandlers;
   struct perTxCtxInfo_t* tcip;
+
+  CHK_TRUE(numWorkerTxCtxs > 0);
 
   if (bindToAmHandler) {
     //


### PR DESCRIPTION
Added a few sanity checks to `comm=ofi` to prevent seg faults in situations that shouldn't happen, but might if the system is misconfigured:

* Added a check that the `tci` table is not zero-size.

* Added a check that the `tci` table index is valid when allocating an entry.

* Added functionality to `chpl_comm_verify_num_locales` to verify that the number of locales specified on the command-line matches that determined by the OOB module. This is only checked in runtime and not in the launcher.

* Added `chpl_comm_oob` that contains the name of the OOB module for use in `ofi` OOB messages and debugging.

Passes all multi-locale tests. 

This resolves https://github.com/Cray/chapel-private/issues/4089.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>