### PR TITLE
Continued test updates for debugGpu config const

### DIFF
--- a/test/execflags/configs/privateconfigs-help-set.good
+++ b/test/execflags/configs/privateconfigs-help-set.good
@@ -19,6 +19,7 @@ Built-in config vars:
                            memLog: string
                       memLeaksLog: string
                    memLeaksByDesc: string
+                         debugGpu: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64) (configured to 1)
 

--- a/test/execflags/configs/privateconfigs-help.good
+++ b/test/execflags/configs/privateconfigs-help.good
@@ -19,6 +19,7 @@ Built-in config vars:
                            memLog: string
                       memLeaksLog: string
                    memLeaksByDesc: string
+                         debugGpu: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64) (configured to 1)
 


### PR DESCRIPTION
This is a continuation of https://github.com/chapel-lang/chapel/pull/21143 (fix broken debugGpu tests) for tests that are not `COMM=none` specific.