### PR TITLE
Fix some tests that broke due to the FileSystem permissions deprecation

### DIFF
--- a/test/library/packages/HDF5/HDF5Preprocessors.chpl
+++ b/test/library/packages/HDF5/HDF5Preprocessors.chpl
@@ -15,7 +15,7 @@ module HDF5Preprocessors {
     const script: string;
 
     override proc preprocess(A: []) {
-      use FileSystem, Path, Subprocess;
+      use FileSystem, OS.POSIX, Path, Subprocess;
 
       try! {
         // openTempFile() doesn't seem to give me a file I can get the name of :(
@@ -35,7 +35,7 @@ module HDF5Preprocessors {
         f.close();
 
         // give the file executable permission
-        chmod(scriptName, 0o755);
+        chmod(scriptName.c_str(), 0o755:mode_t);
 
         // spawn the script, connect stdin and stdout
         var sub = spawn([scriptName], stdin=pipeStyle.pipe, stdout=pipeStyle.pipe);

--- a/test/library/standard/FileSystem/nonUTF8/basic.chpl
+++ b/test/library/standard/FileSystem/nonUTF8/basic.chpl
@@ -2,6 +2,15 @@ use FileSystem;
 use IO;
 use Sort;
 use List;
+use OS.POSIX;
+
+proc getMode(filename: string) throws {
+
+  var structStat: struct_stat;
+  var err = stat(filename.encode(policy=encodePolicy.unescape).c_str(), c_ptrTo(structStat));
+  if err != 0 then halt("Error in stat call");
+  return structStat.st_mode:c_int & 0x1ff;
+}
 
 config param useNonUTF8 = true;
 
@@ -52,7 +61,7 @@ writeln("exists works: ", exists(filename1) == true);
 
 const gid = getGid(filename1);
 const uid = getUid(filename1);
-const mode = getMode(filename1);
+const mode = getMode(filename1); 
 const size = getFileSize(filename1);
 writeln();
 
@@ -77,9 +86,9 @@ catch e: PermissionError {
 writeln();
 
 writeln("chmod'ing the file");
-chmod(filename2, 644);
-writeln("chmod works: ", getMode(filename2) == 644);
-chmod(filename2, mode); // change it back
+chmod(filename2.c_str(), 0o644:mode_t);
+writeln("chmod works: ", getMode(filename2) == 0o644);
+chmod(filename2.c_str(), mode:mode_t); // change it back
 writeln();
 
 


### PR DESCRIPTION
I added a local version of 'copyMode' that uses local versions of 'getMode' and 'chmod' to the FileSystem.copy function. It would be nice to make 'copy' work with only the OS.POSIX functions, but in at least one case it isn't currently working that way.

Updated tests to work with FileSystem permissions functions deprecated.