### PR TITLE
Update the tmbundle update instructions for testing highlight changes.

### DIFF
--- a/highlight/tmbundle/README.md
+++ b/highlight/tmbundle/README.md
@@ -16,7 +16,7 @@ Updating Chapel bundle
 0. Fork and clone the [chapel-lang/chapel-tmbundle][1] repo.
 0. Manually update the PList/XML in `Syntaxes/Chapel.tmLanguage` with whatever
    changes you need.
-0. Test the changes, e.g. using Jetbrains' [CLion][4] or another IDE that
+0. Test the changes, e.g. using JetBrains' [CLion][4] or another IDE that
    supports TextMate bundles.  Opening a copy of [lulesh][5] may be useful.
 0. Open a PR for the chapel-tmbundle repo and follow the normal merge process.
 0. That's it! The next time [github/linguist][2] is released, the changes will

--- a/highlight/tmbundle/README.md
+++ b/highlight/tmbundle/README.md
@@ -16,8 +16,8 @@ Updating Chapel bundle
 0. Fork and clone the [chapel-lang/chapel-tmbundle][1] repo.
 0. Manually update the PList/XML in `Syntaxes/Chapel.tmLanguage` with whatever
    changes you need.
-0. Test the changes, e.g. using [Jetbrains][4].  Opening a copy of [lulesh][5]
-   may be useful.
+0. Test the changes, e.g. using Jetbrains' [CLion][4] or another IDE that
+   supports TextMate bundles.  Opening a copy of [lulesh][5] may be useful.
 0. Open a PR for the chapel-tmbundle repo and follow the normal merge process.
 0. That's it! The next time [github/linguist][2] is released, the changes will
    automatically be picked up.

--- a/highlight/tmbundle/README.md
+++ b/highlight/tmbundle/README.md
@@ -16,14 +16,16 @@ Updating Chapel bundle
 0. Fork and clone the [chapel-lang/chapel-tmbundle][1] repo.
 0. Manually update the PList/XML in `Syntaxes/Chapel.tmLanguage` with whatever
    changes you need.
-0. Test the changes using [lightshow][4]. Try this [lulesh example][5].
+0. Test the changes, e.g. using [Jetbrains][4].  Opening a copy of [lulesh][5]
+   may be useful.
+0. Open a PR for the chapel-tmbundle repo and follow the normal merge process.
 0. That's it! The next time [github/linguist][2] is released, the changes will
    automatically be picked up.
 
 [1]: https://github.com/chapel-lang/chapel-tmbundle
 [2]: https://github.com/github/linguist
-[4]: https://github-lightshow.herokuapp.com/
-[5]: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fchapel-lang%2Fchapel-tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FChapel.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fchapel-lang%2Fchapel%2Fblob%2Fmaster%2Ftest%2Frelease%2Fexamples%2Fbenchmarks%2Flulesh%2Flulesh.chpl&code=
+[4]: https://www.jetbrains.com/help/clion/tutorial-using-textmate-bundles.html#importing-bundles
+[5]: https://github.com/chapel-lang/chapel/blob/main/test/release/examples/benchmarks/lulesh/lulesh.chpl
 
 If you can figure out how to use the [Textmate bundle editor][3], please update
 these instructions accordingly.


### PR DESCRIPTION
Github Lightshow appears to now be deprecated or paid-only, so replace the instructions involving it with ones that worked this time around.

While here, also mentioned that you need to merge a PR with the changes, since the old instructions could be construed to imply that merely making the changes on your local copy was sufficient.