### PR TITLE
1.29 Release : Remove pre-release tags

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -32,6 +32,6 @@ static const char* BUILD_VERSION =
 // Flip this to 'true' when we're ready to roll out a release; then
 // back after branching
 //
-static bool officialRelease = false;
+static bool officialRelease = true;
 
 #endif

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -81,8 +81,8 @@ shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.29.0 (pre-release)'
-#release = '1.29.0'
+#release = '1.29.0 (pre-release)'
+release = '1.29.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/language/archivedSpecs.rst
+++ b/doc/rst/language/archivedSpecs.rst
@@ -5,6 +5,7 @@ Documentation Archives
 
 Online Documentation Archives
 -----------------------------
+* `Chapel 1.28 <https://chapel-lang.org/docs/1.28/index.html>`_
 * `Chapel 1.27 <https://chapel-lang.org/docs/1.27/index.html>`_
 * `Chapel 1.26 <https://chapel-lang.org/docs/1.26/index.html>`_
 * `Chapel 1.25 <https://chapel-lang.org/docs/1.25/index.html>`_

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -21,7 +21,7 @@ full-featured version of Chapel, refer to
    packages you should have available to build and run Chapel.
 
 
-1) If you don't already have the Chapel 1.28 source release, see
+1) If you don't already have the Chapel 1.29 source release, see
    https://chapel-lang.org/download.html.
 
 
@@ -31,14 +31,14 @@ full-featured version of Chapel, refer to
 
       .. code-block:: bash
 
-         tar xzf chapel-1.28.0.tar.gz
+         tar xzf chapel-1.29.0.tar.gz
 
    b. Make sure that you are in the directory that was created when
       unpacking the source release, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.28.0
+         cd chapel-1.29.0
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than ``bash`` or ``zsh``,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -37,7 +37,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.28.0
+        export CHPL_HOME=~/chapel-1.29.0
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.29.0 pre-release
+:Version: 1.29.0 
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.29.0 pre-release
+:Version: 1.29.0 
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,10 +5,10 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 # During pre-release mode
-diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+#diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+#  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-# echo ""
+echo ""
 
 if [ "$CHPL_LLVM" != "none" ]
 then


### PR DESCRIPTION
As part of 1.29 release check list,  remove pre-release tags and update the current chapel version(1.29)

https://github.com/Cray/chapel-private/issues/4055
 

- [x]  Dec 5: Remove pre-release numbers from the code

Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>