### PR TITLE
no-arg `IO.readLine()` bug fix

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6163,7 +6163,7 @@ proc readLine(ref b: bytes, maxSize=-1, stripNewline=false): bool throws{
 
 /* Equivalent to ``stdin.readLine``.  See :proc:`channel.readLine` */
 proc readLine(type t=string, maxSize=-1, stripNewline=false): t throws where t==string || t==bytes {
-  return stdin.readline(t, maxSize, stripNewline);
+  return stdin.readLine(t, maxSize, stripNewline);
 }
 
 /* Equivalent to ``stdin.readln``. See :proc:`channel.readln` */


### PR DESCRIPTION
When called with no arguments, `IO.readLine` produced the following error:
```
$CHPL_HOME/modules/standard/IO.chpl:6165: In function 'readLine':
$CHPL_HOME/modules/standard/IO.chpl:6166: error: unresolved call 'fileReader(dynamic,true).readline(type string, int(64), bool)'
$CHPL_HOME/modules/standard/IO.chpl:4556: note: this candidate did not match: _channel.readline(arg: [] uint(8), out numRead: int, start = arg.domain.lowBound, amount = arg.domain.highBound - start + 1)
$CHPL_HOME/modules/standard/IO.chpl:6166: note: because actual argument #1 is a type
$CHPL_HOME/modules/standard/IO.chpl:4556: note: but is passed to non-type formal 'arg: []'
...
```

because internally it made an erroneous call to the deprecated `channel.readline` method instead of `channel.readLine`.

This PR corrects that typo, which fixes the above error.

- [x] passing paratest