### PR TITLE
Fix OS.POSIX tests for Cygwin

### DIFF
--- a/runtime/include/os-module-support/posix.h
+++ b/runtime/include/os-module-support/posix.h
@@ -141,7 +141,7 @@ int chpl_os_posix_stat(const char *restrict path,
   buf->st_gid = myBuf.st_gid;
   buf->st_rdev = myBuf.st_rdev;
   buf->st_size = myBuf.st_size;
-#if defined(__linux__)
+#if defined(__linux__) || defined(__CYGWIN__)
   buf->st_atim = myBuf.st_atim;
   buf->st_mtim = myBuf.st_mtim;
   buf->st_ctim = myBuf.st_ctim;

--- a/runtime/include/stdchpl.h
+++ b/runtime/include/stdchpl.h
@@ -78,7 +78,7 @@
 #include "chpl-gpu-gen-includes.h"
 #endif
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__)
 #include "os-module-support/posix.h"
 #endif
 


### PR DESCRIPTION
The include files for working with the OS.POSIX modules had ifdefs to make them only apply to Linux or Apple. Add Cygwin to the list.

Verified that the regressed Cygwin tests now pass.