### PR TITLE
Fix bad lowering for forall statements containing an 'if' expr

### DIFF
--- a/test/parsing/IfExprInArrayComp.chpl
+++ b/test/parsing/IfExprInArrayComp.chpl
@@ -1,0 +1,14 @@
+record row_t {
+    var data: [1..10] uint(8);
+}
+
+var table: [1..10] row_t;
+
+var row = new row_t();
+row.data(1) = 5;
+
+var another_row = new row_t();
+another_row.data(1) = 8;
+table = forall j in 1..10 do
+    if j<= 5 then row
+    else another_row;


### PR DESCRIPTION
Fix bad lowering for forall statements containing an 'if' expr

Resolves #21125.

Prior to this PR the code in #21125 would trigger an internal
assertion.

After removing the assertion, the existing pattern matching was
incorrectly catching all if-expr and discarding the else branch.
The builder only cares about: `forall i in x do if x then ...;`.
So tighten up the pattern to only match conditional expressions
without an else branch.

Reviewed by @mppf. Thanks!

TESTING

- [x] `linux64`, `standard`

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>
