### PR TITLE
Adjust vim editor support indent settings

### DIFF
--- a/highlight/vim/README.rst
+++ b/highlight/vim/README.rst
@@ -77,6 +77,13 @@ Manual Installation:
 
   ``$ cp -i sample-vimrc .vimrc``
 
+- To adjust tabs settings for Chapel files, choose one of the following:
+
+  * To set tab settings only for Chapel files, modify this file:
+    $HOME/.vim/ftplugin/chpl.vim
+
+  * Or, to use tab settings for all file types, leave the tab settings
+    in chpl.vim commented out and adjust tab settings in your .vimrc.
 
 Enabling Chapel Support in Vim:
 ===============================
@@ -90,9 +97,7 @@ file (without the ":").
 
 .. code-block:: vim
 
-   " Enable automatic filetype detection
-   :filetype on
-   " Enable syntax highlighting scheme:
+   " Enable syntax highlighting:
    :syntax on
-   " Enable indenting scheme:
-   :filetype indent on
+   " Enable automatic filetype detection, plugins, and indent support
+   :filetype plugin indent on

--- a/highlight/vim/README.rst
+++ b/highlight/vim/README.rst
@@ -77,14 +77,6 @@ Manual Installation:
 
   ``$ cp -i sample-vimrc .vimrc``
 
-- To adjust tabs settings for Chapel files, choose one of the following:
-
-  * To set tab settings only for Chapel files, modify this file:
-    $HOME/.vim/ftplugin/chpl.vim
-
-  * Or, to use tab settings for all file types, leave the tab settings
-    in chpl.vim commented out and adjust tab settings in your .vimrc.
-
 Enabling Chapel Support in Vim:
 ===============================
 

--- a/highlight/vim/ftplugin/chpl.vim
+++ b/highlight/vim/ftplugin/chpl.vim
@@ -6,11 +6,3 @@ setlocal comments=s1:/*,ex:*/,://
 setlocal formatoptions+=n
 " Allow 1. * - lists (for use in chpl-doc comments)
 setlocal formatlistpat=^\\s*\\(\\d\\+[\\]:.)}\\t\ ]\\\|[*-][\\t\ ]\\)\\s*
-
-" To control tab settings for .chpl files, you can use setlocal commands
-" in this file.
-" Below are some example settings, but adjust to your preference.
-"
-" setlocal expandtab       " replace indents with spaces
-" setlocal shiftwidth=2    " set how many spaces per indent
-" setlocal smarttab        " use spaces as indents at the beginning of lines

--- a/highlight/vim/ftplugin/chpl.vim
+++ b/highlight/vim/ftplugin/chpl.vim
@@ -7,10 +7,10 @@ setlocal formatoptions+=n
 " Allow 1. * - lists (for use in chpl-doc comments)
 setlocal formatlistpat=^\\s*\\(\\d\\+[\\]:.)}\\t\ ]\\\|[*-][\\t\ ]\\)\\s*
 
-" If you prefer spaces to tabs, uncomment the following:
-"  (To get a real tab with these settings, do CTRL-V TAB)
-setlocal expandtab       " replace indents with spaces
-setlocal shiftwidth=2    " set how many spaces per indent
-setlocal smarttab        " use spaces as indents at the beginning of lines
-
-
+" To control tab settings for .chpl files, you can use setlocal commands
+" in this file.
+" Below are some example settings, but adjust to your preference.
+"
+" setlocal expandtab       " replace indents with spaces
+" setlocal shiftwidth=2    " set how many spaces per indent
+" setlocal smarttab        " use spaces as indents at the beginning of lines

--- a/highlight/vim/sample-vimrc
+++ b/highlight/vim/sample-vimrc
@@ -6,19 +6,17 @@ syntax on                  " enable syntax highlighting
 filetype plugin indent on  " enable filetype detection, plugins, indent
 set autoindent             " turn on auto indenting
 
-" To adjust tabs settings for Chapel files, choose one of the following ways:
+" If you prefer spaces to tabs, uncomment the following:
+"  (To get a real tab with these settings, do CTRL-V TAB)
+" These settings will affect file types that don't do adjust settings
+" in their ftplugin file (C, C++, Chapel) but not those that do (Python)
 "
-"  1. To configure tab settings only for Chapel files, adjust
-"     $HOME/.vim/ftplugin/chpl.vim
-"
-"  2. Or, to use tab settings for all file types, leave the tab settings
-"     in chpl.vim commented out and adjust tab settings here in your .vimrc.
-"     Below are some example settings, but adjust to your preference.
-"       set expandtab     " replace indents with spaces
-"       set shiftwidth=2  " set how many spaces per indent
-"       set smarttab      " use spaces as indents at the beginning of lines
+" set expandtab       " replace indents with spaces
+" set shiftwidth=2    " set how many spaces per indent
+" set smarttab        " use spaces as indents at the beginning of lines
 
 " Other useful commands, uncomment as desired:
+"
 " set background=dark " switch to color scheme for terminals with a dark background
 " set ignorecase      " ignore case when searching (turn off by ": set noignorecase")
 " set incsearch       " enable incremental search

--- a/highlight/vim/sample-vimrc
+++ b/highlight/vim/sample-vimrc
@@ -1,16 +1,22 @@
 " Sample vimrc Configuration file
 " This file should be named: $HOME/.vimrc
 
-set nocompatible    " allow for non-vi compatible features
-syntax on           " enable syntax highlighting
-filetype indent on  " turn on filetype detection and indenting
-set autoindent      " turn on auto indenting
+set nocompatible           " allow for non-vi compatible features
+syntax on                  " enable syntax highlighting
+filetype plugin indent on  " enable filetype detection, plugins, indent
+set autoindent             " turn on auto indenting
 
-" If you prefer spaces to tabs, uncomment the following:
-"  (To get a real tab with these settings, do CTRL-V TAB)
-" set expandtab       " replace indents with spaces
-" set shiftwidth=2    " set how many spaces per indent
-" set smarttab        " use spaces as indents at the beginning of lines
+" To adjust tabs settings for Chapel files, choose one of the following ways:
+"
+"  1. To configure tab settings only for Chapel files, adjust
+"     $HOME/.vim/ftplugin/chpl.vim
+"
+"  2. Or, to use tab settings for all file types, leave the tab settings
+"     in chpl.vim commented out and adjust tab settings here in your .vimrc.
+"     Below are some example settings, but adjust to your preference.
+"       set expandtab     " replace indents with spaces
+"       set shiftwidth=2  " set how many spaces per indent
+"       set smarttab      " use spaces as indents at the beginning of lines
 
 " Other useful commands, uncomment as desired:
 " set background=dark " switch to color scheme for terminals with a dark background


### PR DESCRIPTION
Resolves #21083

This PR adjusts the `ftplugin/chpl.vim` file to not set and indent level, instead relying upon the user's `.vimrc` to set that as appropriate. It updates some of the related comments and consolidates the commands to enable filetype detection, highlighting, and plugins.

Reviewed by @dlongnecke-cray - thanks!