### PR TITLE
add (de)serialize methods for all remaining uAST nodes

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -286,6 +286,8 @@ extern bool fDynoCompilerLibrary;
 extern bool fDynoScopeProduction;
 extern bool fDynoScopeBundled;
 extern bool fDynoDebugTrace;
+extern bool fDynoSerialize;
+extern char dynoBinAstDir[FILENAME_MAX + 1];
 
 extern size_t fDynoBreakOnHash;
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -312,6 +312,8 @@ bool fDynoScopeProduction = true;
 bool fDynoScopeBundled = false;
 bool fDynoDebugTrace = false;
 size_t fDynoBreakOnHash = 0;
+bool fDynoSerialize = false;
+char dynoBinAstDir[FILENAME_MAX + 1] = "dyno.ast/";
 
 std::vector<std::string> gDynoPrependInternalModulePaths;
 std::vector<std::string> gDynoPrependStandardModulePaths;
@@ -919,6 +921,10 @@ static void setLogDir(const ArgumentDescription* desc, const char* arg) {
   fLogDir = true;
 }
 
+static void setDynoSerialize(const ArgumentDescription* desc, const char* arg) {
+  fDynoSerialize = true;
+}
+
 static void setLogPass(const ArgumentDescription* desc, const char* arg) {
   logSelectPass(arg);
 }
@@ -1239,6 +1245,8 @@ static ArgumentDescription arg_desc[] = {
  {"dyno-scope-bundled", ' ', NULL, "Enable [disable] using dyno to scope resolve bundled modules", "N", &fDynoScopeBundled, "CHPL_DYNO_SCOPE_BUNDLED", NULL},
  {"dyno-debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using dyno compiler library", "N", &fDynoDebugTrace, "CHPL_DYNO_DEBUG_TRACE", NULL},
  {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "X", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
+ {"dyno-serialize", ' ', NULL, "Serialize AST to binary files in a directory", "N", &fDynoSerialize, "CHPL_DYNO_COMPILER_LIBRARY", NULL},
+ {"dyno-serialize-dir", ' ', "<path>", "Specify directory for binary .dyno.ast files", "P", dynoBinAstDir, "CHPL_DYNO_SERIALIZE_DIR", setDynoSerialize},
 
 
  DRIVER_ARG_PRINT_CHPL_HOME,

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -946,11 +946,12 @@ static ModuleSymbol* dynoParseFile(const char* fileName,
     auto res = chpl::uast::BuilderResult::deserializeFromFile(gContext, ss);
 
     if (builderResult.compare(res) == false) {
-      printf("FAIL: %s\n", builderResult.filePath().c_str());
-    } else {
-      printf("SUCCESS: %s\n", builderResult.filePath().c_str());
+      //printf("FAIL: %s\n", builderResult.filePath().c_str());
+      USR_FATAL("FAILED TO (DE)SERIALIZE %s\n", builderResult.filePath().c_str());
+//    } else {
+      //printf("SUCCESS: %s\n", builderResult.filePath().c_str());
     }
-    builderResult.printNumNodes();
+//    builderResult.printNumNodes();
   }
 
   ModuleSymbol* lastModSym = nullptr;

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -934,6 +934,25 @@ static ModuleSymbol* dynoParseFile(const char* fileName,
 
   if (dynoRealizeErrors()) USR_STOP();
 
+
+  if (fDynoSerialize) {
+    //auto sfname = builderResult.serializeToDir(dynoBinAstDir);
+    //// 'res' = AstList for now - eventually will be a BuilderResult
+    //auto res = chpl::uast::BuilderResult::deserializeFromFile(gContext, sfname);
+
+    std::stringstream ss;
+    builderResult.serializeToDir(ss);
+    // 'res' = AstList for now - eventually will be a BuilderResult
+    auto res = chpl::uast::BuilderResult::deserializeFromFile(gContext, ss);
+
+    if (builderResult.compare(res) == false) {
+      printf("FAIL: %s\n", builderResult.filePath().c_str());
+    } else {
+      printf("SUCCESS: %s\n", builderResult.filePath().c_str());
+    }
+    builderResult.printNumNodes();
+  }
+
   ModuleSymbol* lastModSym = nullptr;
   int numModSyms = 0;
 

--- a/frontend/include/chpl/framework/CommentID.h
+++ b/frontend/include/chpl/framework/CommentID.h
@@ -42,6 +42,15 @@ class CommentID {
 
   /** Return the index of the comment id */
   int index() const { return index_; }
+
+  void serialize(Serializer& ser) const {
+    ser.write<int32_t>(index_);
+  }
+
+  static CommentID deserialize(Deserializer& des) {
+    int val = (int)des.read<int32_t>();
+    return CommentID(val);
+  }
 };
 
 } // end namespace chpl

--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -205,6 +205,18 @@ class ID final {
   /// \endcond
 
   std::string str() const;
+
+  void serialize(Serializer& ser) const {
+    ser(symbolPath_);
+    ser((int64_t)postOrderId_);
+    ser((int64_t)numChildIds_);
+  }
+  static ID deserialize(Deserializer& des) {
+    auto path = des.read<UniqueString>();
+    auto poi = des.read<int64_t>();
+    auto nci = des.read<int64_t>();
+    return ID(path, (int)poi, (int)nci);
+  }
 };
 
 // docs are turned off for this as a workaround for breathe errors

--- a/frontend/include/chpl/framework/UniqueString.h
+++ b/frontend/include/chpl/framework/UniqueString.h
@@ -27,6 +27,7 @@
 
 #include "chpl/framework/UniqueString-detail.h"
 #include "chpl/framework/stringify-functions.h"
+#include "chpl/framework/serialize-functions.h"
 #include "chpl/util/hash.h"
 
 #include <cassert>
@@ -146,6 +147,24 @@ class UniqueString final {
 
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  void serialize(Serializer& ser) const {
+    ser((uint64_t)length());
+    if (length() > 0) {
+      ser.os().write(c_str(), length());
+    }
+  }
+
+  static UniqueString deserialize(Deserializer& des) {
+    auto len = des.read<uint64_t>();
+    char* buf = nullptr;
+    if (len > 0) {
+      buf = (char*)malloc(len+1);
+      des.is().read(buf, len);
+      buf[len] = '\0';
+    }
+    return UniqueString::get(des.context(), buf, len);
+  }
 
   bool isEmpty() const {
     return s.i.c_str()[0] == '\0';

--- a/frontend/include/chpl/framework/serialize-functions.h
+++ b/frontend/include/chpl/framework/serialize-functions.h
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  This file implements the generic chpl::stringify
+  as well as specializations for some common types.
+
+  stringify can be used to get a string representation of an object
+  for debugging purposes or whenever a string representation of an
+  object is needed
+ */
+
+#ifndef CHPL_QUERIES_SERIALIZE_FUNCTIONS_H
+#define CHPL_QUERIES_SERIALIZE_FUNCTIONS_H
+
+#include "chpl/util/memory.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+
+namespace chpl {
+class Context;
+
+template<typename T> struct serialize;
+template<typename T> struct deserialize;
+
+class Serializer {
+private:
+  std::ostream& os_;
+
+public:
+  Serializer(std::ostream& os): os_(os) {
+  }
+
+  std::ostream& os() const {
+    return os_;
+  }
+
+  template <typename T>
+  void write(const T& data) {
+    chpl::serialize<T>{}(*this, data);
+  }
+
+  template <typename T>
+  void operator()(const T& data) {
+    chpl::serialize<T>{}(*this, data);
+  }
+};
+
+class Deserializer {
+  private:
+    Context* context_;
+    std::istream& is_;
+
+  public:
+    Deserializer(Context* context, std::istream& is)
+      : context_(context), is_(is) { }
+
+    Context* context() const {
+      return context_;
+    }
+
+    std::istream& is() const {
+      return is_;
+    }
+
+    template <typename T>
+    T operator()() {
+      return chpl::deserialize<T>{}(*this);
+    }
+
+    template <typename T>
+    T read() {
+      return chpl::deserialize<T>{}(*this);
+    }
+};
+
+// define the generic serialize template
+template<typename T> struct serialize {
+  void operator()(Serializer& ser, const T& value) {
+    value.serialize(ser);
+  };
+};
+
+// define serialize for pointers to call stringify on a reference to avoid
+//  duplication for types that appear both as references and as pointers
+template<typename T> struct serialize<const T*> {
+  void operator()(Serializer& ser,
+                  const T* value) const {
+    assert(value != nullptr);
+    serialize<T>{}(ser, *value);
+  }
+};
+
+// define the generic deserialize template
+template<typename T> struct deserialize {
+  T operator()(Deserializer& des) {
+    return T::deserialize(des);
+  }
+};
+
+
+/*
+ * Helper macro for enums
+ */
+#define DECLARE_SERDE_ENUM(TYPE, CONV) \
+template<> struct serialize<TYPE> { \
+  void operator()(Serializer& ser, TYPE val) { \
+    ser((CONV)val); \
+  } \
+}; \
+template<> struct deserialize<TYPE> { \
+  TYPE operator()(Deserializer& des) { \
+    auto ret = des.read<CONV>(); \
+    return static_cast<TYPE>(ret); \
+  } \
+};
+
+/*
+  Templates for integral types start here
+*/
+#define SERIALIZE_PRIM(TYPE) \
+template<> struct serialize<TYPE> { \
+  void operator()(Serializer& ser, \
+                  TYPE val) const { \
+    ser.os().write(reinterpret_cast<const char*>(&val), sizeof(val)); \
+  } \
+}; \
+template<> struct deserialize<TYPE> { \
+  TYPE operator()(Deserializer& des) { \
+    TYPE ret; \
+    des.is().read(reinterpret_cast<char*>(&ret), sizeof(ret)); \
+    return ret; \
+  } \
+};
+
+SERIALIZE_PRIM(uint8_t);
+SERIALIZE_PRIM(uint16_t);
+SERIALIZE_PRIM(uint32_t);
+SERIALIZE_PRIM(uint64_t);
+SERIALIZE_PRIM(int8_t);
+SERIALIZE_PRIM(int16_t);
+SERIALIZE_PRIM(int32_t);
+SERIALIZE_PRIM(int64_t);
+SERIALIZE_PRIM(double);
+
+#undef SERIALIZE_PRIM
+
+template<> struct serialize<bool> {
+  void operator()(Serializer& ser, bool val) const {
+    uint8_t copy = val;
+    ser.os().write(reinterpret_cast<const char*>(&copy), sizeof(copy));
+  }
+};
+
+template<> struct deserialize<bool> {
+  bool operator()(Deserializer& des) {
+    uint8_t val;
+    des.is().read(reinterpret_cast<char*>(&val), sizeof(val));
+    return (bool)val;
+  }
+};
+
+/*
+ * Serialize std::string
+ */
+template<> struct serialize<std::string> {
+  void operator()(Serializer& ser, const std::string& val) const {
+    ser((uint64_t)val.size());
+    if (val.size() > 0) {
+      ser.os().write(val.c_str(), val.size());
+    }
+  }
+};
+
+template<> struct deserialize<std::string> {
+  std::string operator()(Deserializer& des) {
+    size_t len = (size_t)des.read<uint64_t>();
+    char* buf = nullptr;
+    if (len > 0) {
+      buf = (char*)malloc(len+1);
+      des.is().read(buf, len);
+      buf[len] = '\0';
+    }
+    return std::string(buf, len);
+  }
+};
+
+// stringify a vector by stringifying each element; uses [a, b, c] formatting
+template<typename T>
+static inline void defaultSerializeVec(Serializer& ser,
+                                       const std::vector<T>& stringVec) {
+  ser((uint64_t)stringVec.size());
+  for (const auto &elt : stringVec ) {
+    ser(elt);
+  }
+}
+
+template<typename T>
+static inline void defaultDeserializeVec(Deserializer& des,
+                                         std::vector<T>& vec) {
+  auto n = des.read<uint64_t>();
+  for (uint64_t i = 0; i < n; i++) {
+    vec.push_back(des.read<T>());
+  }
+}
+
+template<typename T>
+static inline void defaultSerializeSet(Serializer& ser,
+                                       const std::set<T>& val) {
+  ser((uint64_t)val.size());
+  for (const auto& elt : val) {
+    ser(elt);
+  }
+}
+
+template<typename T>
+static inline void defaultDeserializeSet(Deserializer& des,
+                                         std::set<T>& val) {
+  auto len = des.read<uint64_t>();
+  for (uint64_t i = 0; i < len; i++) {
+    val.insert(des.read<T>());
+  }
+}
+
+template<typename T> struct serialize<std::vector<T>> {
+ void operator()(Serializer& ser,
+                 const std::vector<T>& stringMe) const {
+   defaultSerializeVec(ser, stringMe);
+ }
+};
+
+template<typename T> struct deserialize<std::vector<T>> {
+  std::vector<T> operator()(Deserializer& des) const {
+    std::vector<T> ret;
+    defaultDeserializeVec(des, ret);
+    return ret;
+  }
+};
+
+template<typename T> struct serialize<std::set<T>> {
+ void operator()(Serializer& ser,
+                 const std::set<T>& val) const {
+   defaultSerializeSet(ser, val);
+ }
+};
+
+template<typename T> struct deserialize<std::set<T>> {
+  std::set<T> operator()(Deserializer& des) const {
+    std::set<T> ret;
+    defaultDeserializeSet(des, ret);
+    return ret;
+  }
+};
+
+
+} // end namespace chpl
+
+#endif

--- a/frontend/include/chpl/types/ParamTag.h
+++ b/frontend/include/chpl/types/ParamTag.h
@@ -60,6 +60,9 @@ enum ParamTag {
 using chpl::types::paramtags::ParamTag;
 
 } // end namespace types
+
+DECLARE_SERDE_ENUM(types::ParamTag, uint8_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/AggregateDecl.h
+++ b/frontend/include/chpl/uast/AggregateDecl.h
@@ -78,6 +78,12 @@ class AggregateDecl : public TypeDecl {
     assert(validAggregateChildren(declOrComments()));
   }
 
+  AggregateDecl(AstTag tag, Deserializer& des)
+    : TypeDecl(tag, des) {
+    elementsChildNum_ = des.read<int>();
+    numElements_ = des.read<int>();
+  }
+
   ~AggregateDecl() = 0; // this is an abstract base class
 
   /**
@@ -119,6 +125,12 @@ class AggregateDecl : public TypeDecl {
     return AstListNoCommentsIteratorPair<Decl>(
               children_.begin() + elementsChildNum_,
               children_.begin() + elementsChildNum_ + numElements_);
+  }
+
+  void serializePart(Serializer& ser) const {
+    TypeDecl::serializePart(ser);
+    ser(elementsChildNum_);
+    ser(numElements_);
   }
 };
 

--- a/frontend/include/chpl/uast/As.h
+++ b/frontend/include/chpl/uast/As.h
@@ -43,6 +43,7 @@ namespace uast {
 class As final : public AstNode {
  private:
   As(AstList children) : AstNode(asttags::As, std::move(children)) {}
+  As(Deserializer& des) : AstNode(asttags::As, des) {}
 
   // No need to match 'symbolChildNum_' or 'renameChildNum_', they are const.
   bool contentsMatchInner(const AstNode* other) const override {
@@ -81,6 +82,12 @@ class As final : public AstNode {
     auto ret = child(renameChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(As);
 
 };
 

--- a/frontend/include/chpl/uast/AstTag.h
+++ b/frontend/include/chpl/uast/AstTag.h
@@ -125,6 +125,8 @@ template<> struct stringify<uast::AstTag> {
   }
 };
 
+DECLARE_SERDE_ENUM(uast::AstTag, uint8_t);
+
 /// \endcond
 
 

--- a/frontend/include/chpl/uast/Attributes.h
+++ b/frontend/include/chpl/uast/Attributes.h
@@ -68,6 +68,16 @@ class Attributes final : public AstNode {
     assert(pragmas_.size() <= NUM_KNOWN_PRAGMAS);
   }
 
+  Attributes(Deserializer& des)
+    : AstNode(asttags::Attributes, des) {
+      pragmas_ = des.read<std::set<PragmaTag>>();
+      isDeprecated_ = des.read<bool>();
+      isUnstable_ = des.read<bool>();
+      deprecationMessage_ = des.read<UniqueString>();
+      unstableMessage_ = des.read<UniqueString>();
+    }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Attributes* rhs = (const Attributes*)other;
     return this->pragmas_ == rhs->pragmas_ &&
@@ -139,6 +149,18 @@ class Attributes final : public AstNode {
   UniqueString unstableMessage() const {
     return unstableMessage_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+
+    ser(pragmas_);
+    ser(isDeprecated_);
+    ser(isUnstable_);
+    ser(deprecationMessage_);
+    ser(unstableMessage_);
+  }
+
+  DECLARE_STATIC_DES(Attributes);
 
 };
 

--- a/frontend/include/chpl/uast/Begin.h
+++ b/frontend/include/chpl/uast/Begin.h
@@ -56,6 +56,11 @@ class Begin final : public SimpleBlockLike {
       withClauseChildNum_(withClauseChildNum) {
   }
 
+    Begin(Deserializer& des)
+    : SimpleBlockLike(asttags::Begin, des) {
+      withClauseChildNum_ = des.read<int8_t>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Begin* lhs = this;
     const Begin* rhs = (const Begin*) other;
@@ -95,6 +100,13 @@ class Begin final : public SimpleBlockLike {
     assert(ret->isWithClause());
     return (const WithClause*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(withClauseChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Begin);
 
 };
 

--- a/frontend/include/chpl/uast/Block.h
+++ b/frontend/include/chpl/uast/Block.h
@@ -42,6 +42,9 @@ class Block final : public SimpleBlockLike {
     assert(bodyChildNum_ >= 0);
   }
 
+  Block(Deserializer& des)
+    : SimpleBlockLike(asttags::Block, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);
   }
@@ -57,6 +60,12 @@ class Block final : public SimpleBlockLike {
    Create and return a Block containing the passed stmts.
    */
   static owned<Block> build(Builder* builder, Location loc, AstList stmts);
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Block);
 
 };
 

--- a/frontend/include/chpl/uast/BlockStyle.h
+++ b/frontend/include/chpl/uast/BlockStyle.h
@@ -20,6 +20,8 @@
 #ifndef CHPL_UAST_BLOCKSTYLE_H
 #define CHPL_UAST_BLOCKSTYLE_H
 
+#include "chpl/framework/serialize-functions.h"
+
 namespace chpl {
 namespace uast {
 
@@ -53,6 +55,9 @@ enum struct BlockStyle {
 };
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::BlockStyle, uint8_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/BoolLiteral.h
+++ b/frontend/include/chpl/uast/BoolLiteral.h
@@ -37,6 +37,11 @@ class BoolLiteral final : public Literal {
     : Literal(asttags::BoolLiteral, value) {
   }
 
+  BoolLiteral(Deserializer& des)
+    : Literal(asttags::BoolLiteral, des) {
+    assert(value_->isBoolParam());
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const BoolLiteral* rhs = (const BoolLiteral*) other;
     return literalContentsMatchInner(rhs);
@@ -62,6 +67,13 @@ class BoolLiteral final : public Literal {
     auto p = (const types::BoolParam*) value_;
     return p->value() != 0;
   }
+
+  void serialize(Serializer& ser) const override {
+    Literal::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(BoolLiteral);
+
 };
 
 

--- a/frontend/include/chpl/uast/BracketLoop.h
+++ b/frontend/include/chpl/uast/BracketLoop.h
@@ -58,6 +58,9 @@ class BracketLoop final : public IndexableLoop {
                     isExpressionLevel) {
   }
 
+  BracketLoop(Deserializer& des)
+    : IndexableLoop(asttags::BracketLoop, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());
   }
@@ -84,6 +87,12 @@ class BracketLoop final : public IndexableLoop {
    * Check if this bracket loop is actually an array type
    */
   bool isMaybeArrayType() const;
+
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(BracketLoop);
 
 };
 

--- a/frontend/include/chpl/uast/Break.h
+++ b/frontend/include/chpl/uast/Break.h
@@ -48,6 +48,11 @@ class Break : public AstNode {
     assert(numChildren() <= 1);
   }
 
+  Break(Deserializer& des)
+   : AstNode(asttags::Break, des) {
+    targetChildNum_ = des.read<int8_t>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Break* lhs = this;
     const Break* rhs = other->toBreak();
@@ -81,6 +86,13 @@ class Break : public AstNode {
     assert(ret->isIdentifier());
     return (const Identifier*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(targetChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Break);
 
 };
 

--- a/frontend/include/chpl/uast/BuilderResult.h
+++ b/frontend/include/chpl/uast/BuilderResult.h
@@ -181,6 +181,13 @@ class BuilderResult final {
   // these two should only be called by the parser
   static void updateFilePaths(Context* context, const BuilderResult& keep);
   static void appendError(BuilderResult& keep, const ErrorBase* error);
+
+  std::string serializeToDir(const char* dirName) const;
+  void serializeToDir(std::ostream& os) const;
+  static AstList deserializeFromFile(Context* context, std::string& sfname);
+  static AstList deserializeFromFile(Context* context, std::istream& is);
+  bool compare(const AstList& other) const;
+  void printNumNodes() const;
 };
 
 

--- a/frontend/include/chpl/uast/BytesLiteral.h
+++ b/frontend/include/chpl/uast/BytesLiteral.h
@@ -39,6 +39,10 @@ class BytesLiteral final : public StringLikeLiteral {
     : StringLikeLiteral(asttags::BytesLiteral, value, quotes)
   { }
 
+  BytesLiteral(Deserializer& des)
+    : StringLikeLiteral(asttags::BytesLiteral, des)
+  { }
+
   // contentsMatchInner / markUniqueStringsInner are in StringLikeLiteral
   // and would need to be defined here if any fields are added.
 
@@ -58,6 +62,13 @@ class BytesLiteral final : public StringLikeLiteral {
     const types::StringParam* p = (const types::StringParam*) value_;
     return p->value();
   }
+
+  void serialize(Serializer& ser) const override {
+    StringLikeLiteral::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(BytesLiteral);
+
 };
 
 

--- a/frontend/include/chpl/uast/CStringLiteral.h
+++ b/frontend/include/chpl/uast/CStringLiteral.h
@@ -38,6 +38,10 @@ class CStringLiteral final : public StringLikeLiteral {
     : StringLikeLiteral(asttags::CStringLiteral, value, quotes)
   { }
 
+  CStringLiteral(Deserializer& des)
+    : StringLikeLiteral(asttags::CStringLiteral, des)
+  { }
+
   // contentsMatchInner / markUniqueStringsInner are in StringLikeLiteral
   // and would need to be defined here if any fields are added.
 
@@ -57,6 +61,13 @@ class CStringLiteral final : public StringLikeLiteral {
     const types::StringParam* p = (const types::StringParam*) value_;
     return p->value();
   }
+
+  void serialize(Serializer& ser) const override {
+    StringLikeLiteral::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(CStringLiteral);
+
 };
 
 

--- a/frontend/include/chpl/uast/Call.h
+++ b/frontend/include/chpl/uast/Call.h
@@ -43,6 +43,10 @@ class Call : public AstNode {
     : AstNode(tag, std::move(children)),
       hasCalledExpression_(hasCalledExpression) {
   }
+  Call(AstTag tag, Deserializer& des)
+    : AstNode(tag, des) {
+    hasCalledExpression_ = des.read<bool>();
+  }
 
   bool callContentsMatchInner(const Call* other) const {
     return true;
@@ -87,6 +91,11 @@ class Call : public AstNode {
       const AstNode* ast = this->child(0);
       return ast;
     }
+  }
+
+  void serializePart(Serializer& ser) const {
+    AstNode::serializePart(ser);
+    ser(hasCalledExpression_);
   }
 };
 

--- a/frontend/include/chpl/uast/Catch.h
+++ b/frontend/include/chpl/uast/Catch.h
@@ -54,6 +54,13 @@ class Catch final : public AstNode {
       hasParensAroundError_(hasParensAroundError) {
   }
 
+  Catch(Deserializer& des)
+    : AstNode(asttags::Catch, des) {
+        errorChildNum_ = des.read<int8_t>();
+        bodyChildNum_ = des.read<int8_t>();
+        hasParensAroundError_ = des.read<bool>();
+      }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Catch* rhs = other->toCatch();
     return this->errorChildNum_ == rhs->errorChildNum_ &&
@@ -126,6 +133,15 @@ class Catch final : public AstNode {
   bool hasParensAroundError() const {
     return hasParensAroundError_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(errorChildNum_);
+    ser(bodyChildNum_);
+    ser(hasParensAroundError_);
+  }
+
+  DECLARE_STATIC_DES(Catch);
 
 };
 

--- a/frontend/include/chpl/uast/Class.h
+++ b/frontend/include/chpl/uast/Class.h
@@ -65,7 +65,9 @@ class Class final : public AggregateDecl {
   }
 
   Class(Deserializer& des)
-    : AggregateDecl(asttags::Class, des) { }
+    : AggregateDecl(asttags::Class, des) {
+      parentClassChildNum_ = des.read<int>();
+     }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Class* lhs = this;
@@ -102,6 +104,7 @@ class Class final : public AggregateDecl {
 
   void serialize(Serializer& ser) const override {
     AggregateDecl::serializePart(ser);
+    ser(parentClassChildNum_);
   }
 
   DECLARE_STATIC_DES(Class);

--- a/frontend/include/chpl/uast/Class.h
+++ b/frontend/include/chpl/uast/Class.h
@@ -64,6 +64,9 @@ class Class final : public AggregateDecl {
            child(parentClassChildNum_)->isIdentifier());
   }
 
+  Class(Deserializer& des)
+    : AggregateDecl(asttags::Class, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Class* lhs = this;
     const Class* rhs = (const Class*) other;
@@ -96,6 +99,13 @@ class Class final : public AggregateDecl {
     auto ret = child(parentClassChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AggregateDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Class);
+
 };
 
 

--- a/frontend/include/chpl/uast/Cobegin.h
+++ b/frontend/include/chpl/uast/Cobegin.h
@@ -55,6 +55,12 @@ class Cobegin final : public AstNode {
       numTaskBodies_(numTaskBodies) {
   }
 
+  Cobegin(Deserializer& des) : AstNode(asttags::Cobegin, des) {
+    withClauseChildNum_ = des.read<int8_t>();
+    bodyChildNum_ = des.read<int>();
+    numTaskBodies_ = des.read<int>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Cobegin* lhs = this;
     const Cobegin* rhs = (const Cobegin*) other;
@@ -122,6 +128,12 @@ class Cobegin final : public AstNode {
     const AstNode* ast = this->child(i + bodyChildNum_);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Cobegin);
 
 };
 

--- a/frontend/include/chpl/uast/Cobegin.h
+++ b/frontend/include/chpl/uast/Cobegin.h
@@ -131,6 +131,9 @@ class Cobegin final : public AstNode {
 
   void serialize(Serializer& ser) const override {
     AstNode::serializePart(ser);
+    ser(withClauseChildNum_ );
+    ser(bodyChildNum_);
+    ser(numTaskBodies_);
   }
 
   DECLARE_STATIC_DES(Cobegin);

--- a/frontend/include/chpl/uast/Coforall.h
+++ b/frontend/include/chpl/uast/Coforall.h
@@ -59,6 +59,8 @@ class Coforall final : public IndexableLoop {
                     /*isExpressionLevel*/ false) {
   }
 
+  Coforall(Deserializer& des) : IndexableLoop(asttags::Coforall, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());
   }
@@ -80,6 +82,11 @@ class Coforall final : public IndexableLoop {
                                BlockStyle blockStyle,
                                owned<Block> body);
 
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Coforall);
 
 };
 

--- a/frontend/include/chpl/uast/Comment.h
+++ b/frontend/include/chpl/uast/Comment.h
@@ -49,6 +49,12 @@ class Comment final : public AstNode {
     : AstNode(asttags::Comment), comment_(std::move(s)) {
   }
 
+  Comment(Deserializer& des)
+    : AstNode(asttags::Comment, des) {
+    comment_ = des.read<std::string>();
+    commentId_ = des.read<CommentID>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Comment* lhs = this;
     const Comment* rhs = (const Comment*) other;
@@ -77,6 +83,14 @@ class Comment final : public AstNode {
      its BuilderResult
   */
   CommentID commentId() const { return commentId_; }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(comment_);
+    ser(commentId_);
+  }
+
+  DECLARE_STATIC_DES(Comment);
 
  protected:
   /**

--- a/frontend/include/chpl/uast/Conditional.h
+++ b/frontend/include/chpl/uast/Conditional.h
@@ -80,6 +80,13 @@ class Conditional final : public AstNode {
     assert(thenBodyChildNum_ < (int) children_.size());
   }
 
+  Conditional(Deserializer& des)
+    : AstNode(asttags::Conditional, des) {
+    thenBlockStyle_ = des.read<BlockStyle>();
+    elseBlockStyle_ = des.read<BlockStyle>();
+    isExpressionLevel_ = des.read<bool>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Conditional* lhs = this;
     const Conditional* rhs = other->toConditional();
@@ -250,6 +257,15 @@ class Conditional final : public AstNode {
   bool isExpressionLevel() const {
     return isExpressionLevel_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(thenBlockStyle_);
+    ser(elseBlockStyle_);
+    ser(isExpressionLevel_);
+  }
+
+  DECLARE_STATIC_DES(Conditional);
 
 };
 

--- a/frontend/include/chpl/uast/Continue.h
+++ b/frontend/include/chpl/uast/Continue.h
@@ -87,7 +87,7 @@ class Continue : public AstNode {
   }
 
   void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+    AstNode::serializePart(ser);
     ser(targetChildNum_);
   }
 

--- a/frontend/include/chpl/uast/Continue.h
+++ b/frontend/include/chpl/uast/Continue.h
@@ -47,6 +47,11 @@ class Continue : public AstNode {
     assert(numChildren() <= 1);
   }
 
+  Continue(Deserializer& des)
+    : AstNode(asttags::Continue, des) {
+    targetChildNum_ = des.read<int8_t>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Continue* lhs = this;
     const Continue* rhs = other->toContinue();
@@ -80,6 +85,13 @@ class Continue : public AstNode {
     assert(ret->isIdentifier());
     return (const Identifier*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser(targetChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Continue);
 
 };
 

--- a/frontend/include/chpl/uast/Decl.h
+++ b/frontend/include/chpl/uast/Decl.h
@@ -92,6 +92,14 @@ class Decl : public AstNode {
                  linkageNameChildNum_ < (ssize_t)children_.size());
   }
 
+  Decl(AstTag tag, Deserializer& des)
+    : AstNode(tag, des) {
+      attributesChildNum_ = (int)des.read<int32_t>();
+      visibility_ = des.read<Decl::Visibility>();
+      linkage_ = des.read<Decl::Linkage>();
+      linkageNameChildNum_ = (int)des.read<int32_t>();
+  }
+
   bool declContentsMatchInner(const Decl* other) const {
     return this->visibility_ == other->visibility_ &&
            this->linkage_ == other->linkage_ &&
@@ -151,10 +159,24 @@ class Decl : public AstNode {
     return (const Attributes*)ret;
   }
 
+  void serializePart(Serializer& ser) const {
+    AstNode::serializePart(ser);
+
+    ser((int32_t)attributesChildNum_);
+    ser(visibility_);
+    ser(linkage_);
+    ser((int32_t)linkageNameChildNum_);
+  }
+
 };
 
 
+
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::Decl::Visibility, uint8_t);
+DECLARE_SERDE_ENUM(uast::Decl::Linkage, uint8_t);
+
 } // end namespace chpl
 
 namespace std {

--- a/frontend/include/chpl/uast/Defer.h
+++ b/frontend/include/chpl/uast/Defer.h
@@ -57,6 +57,9 @@ class Defer final : public SimpleBlockLike {
     assert(bodyChildNum_ >= 0);
   }
 
+  Defer(Deserializer& des)
+  : SimpleBlockLike(asttags::Defer, des) {}
+
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);
   }
@@ -74,6 +77,12 @@ class Defer final : public SimpleBlockLike {
   static owned<Defer> build(Builder* builder, Location loc,
                             BlockStyle blockStyle,
                             AstList stmts);
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Defer);
 
 };
 

--- a/frontend/include/chpl/uast/Delete.h
+++ b/frontend/include/chpl/uast/Delete.h
@@ -45,6 +45,9 @@ class Delete final : public AstNode {
     : AstNode(asttags::Delete, std::move(children)) {
   }
 
+  Delete(Deserializer& des)
+    : AstNode(asttags::Delete, des) {}
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -82,6 +85,14 @@ class Delete final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Delete);
+
+
 };
 
 

--- a/frontend/include/chpl/uast/DoWhile.h
+++ b/frontend/include/chpl/uast/DoWhile.h
@@ -56,6 +56,11 @@ class DoWhile final : public Loop {
     assert(condition());
   }
 
+  DoWhile(Deserializer& des)
+    : Loop(asttags::DoWhile, des) {
+      conditionChildNum_ = des.read<int>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const DoWhile* lhs = this;
     const DoWhile* rhs = (const DoWhile*) other;
@@ -94,6 +99,13 @@ class DoWhile final : public Loop {
     auto ret = child(conditionChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    Loop::serializePart(ser);
+    ser(conditionChildNum_);
+  }
+
+  DECLARE_STATIC_DES(DoWhile);
 
 };
 

--- a/frontend/include/chpl/uast/Domain.h
+++ b/frontend/include/chpl/uast/Domain.h
@@ -49,6 +49,10 @@ class Domain final : public AstNode {
     : AstNode(asttags::Domain, std::move(children)),
       usedCurlyBraces_(usedCurlyBraces) {
   }
+  Domain(Deserializer& des)
+    : AstNode(asttags::Domain, des) {
+    usedCurlyBraces_ = des.read<bool>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Domain* rhs = (const Domain*) other;
@@ -97,6 +101,13 @@ class Domain final : public AstNode {
   bool usedCurlyBraces() const {
     return usedCurlyBraces_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(usedCurlyBraces_);
+  }
+
+  DECLARE_STATIC_DES(Domain);
 
 };
 

--- a/frontend/include/chpl/uast/Dot.h
+++ b/frontend/include/chpl/uast/Dot.h
@@ -55,6 +55,10 @@ class Dot final : public AstNode {
       fieldName_(fieldName) {
     assert(children_.size() == 1);
   }
+  Dot(Deserializer& des)
+    : AstNode(asttags::Dot, des) {
+    fieldName_ = des.read<UniqueString>();
+  }
   bool contentsMatchInner(const AstNode* other) const override {
     const Dot* lhs = this;
     const Dot* rhs = (const Dot*) other;
@@ -84,6 +88,13 @@ class Dot final : public AstNode {
   UniqueString field() const {
     return fieldName_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(fieldName_);
+  }
+
+  DECLARE_STATIC_DES(Dot);
 };
 
 

--- a/frontend/include/chpl/uast/EmptyStmt.h
+++ b/frontend/include/chpl/uast/EmptyStmt.h
@@ -47,6 +47,8 @@ private:
     : AstNode(asttags::EmptyStmt) {
     assert(numChildren() == 0);
   }
+  EmptyStmt(Deserializer& des)
+    : AstNode(asttags::EmptyStmt, des) { }
 
     bool contentsMatchInner(const AstNode* other) const override {
     const EmptyStmt* rhs = other->toEmptyStmt();
@@ -64,6 +66,11 @@ public:
   */
   static owned<EmptyStmt> build(Builder* builder, Location loc);
 
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(EmptyStmt);
 
 }; // end EmptyStmt
 

--- a/frontend/include/chpl/uast/Enum.h
+++ b/frontend/include/chpl/uast/Enum.h
@@ -63,6 +63,9 @@ class Enum final : public TypeDecl {
     #endif
   }
 
+  Enum(Deserializer& des)
+    : TypeDecl(asttags::Enum, des) {}
+
   int declOrCommentChildNum() const {
     return attributes() ? 1 : 0;
   }
@@ -123,6 +126,13 @@ class Enum final : public TypeDecl {
     auto end = begin + numDeclOrComments();
     return AstListNoCommentsIteratorPair<EnumElement>(begin, end);
   }
+
+  void serialize(Serializer& ser) const override {
+    TypeDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Enum);
+
 };
 
 

--- a/frontend/include/chpl/uast/EnumElement.h
+++ b/frontend/include/chpl/uast/EnumElement.h
@@ -53,6 +53,9 @@ class EnumElement final : public NamedDecl {
     assert(children_.size() <= 2);
   }
 
+  EnumElement(Deserializer& des)
+    : NamedDecl(asttags::EnumElement, des) {}
+
   bool contentsMatchInner(const AstNode* other) const override {
     const EnumElement* lhs = (const EnumElement*) this;
     const EnumElement* rhs = (const EnumElement*) other;
@@ -102,6 +105,13 @@ class EnumElement final : public NamedDecl {
       return nullptr;
     }
   }
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(EnumElement);
+
 };
 
 

--- a/frontend/include/chpl/uast/ErroneousExpression.h
+++ b/frontend/include/chpl/uast/ErroneousExpression.h
@@ -35,6 +35,11 @@ class ErroneousExpression final : public AstNode {
   ErroneousExpression()
     : AstNode(asttags::ErroneousExpression) {
   }
+
+  ErroneousExpression(Deserializer& des)
+    : AstNode(asttags::ErroneousExpression, des) {}
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -44,6 +49,13 @@ class ErroneousExpression final : public AstNode {
  public:
   ~ErroneousExpression() = default;
   static owned<ErroneousExpression> build(Builder* builder, Location loc);
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(ErroneousExpression);
+
 };
 
 

--- a/frontend/include/chpl/uast/ExternBlock.h
+++ b/frontend/include/chpl/uast/ExternBlock.h
@@ -55,6 +55,11 @@ class ExternBlock final : public AstNode {
     assert(numChildren() == 0);
   }
 
+  ExternBlock(Deserializer& des)
+    : AstNode(asttags::ExternBlock, des) {
+      code_ = des.read<std::string>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const ExternBlock* rhs = (const ExternBlock*)other;
     return this->code_ == rhs->code_;
@@ -74,6 +79,11 @@ class ExternBlock final : public AstNode {
 
   const std::string& code() const {
     return code_;
+  }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(code_);
   }
 
 };

--- a/frontend/include/chpl/uast/FnCall.h
+++ b/frontend/include/chpl/uast/FnCall.h
@@ -62,6 +62,11 @@ class FnCall : public Call {
       actualNames_(std::move(actualNames)),
       callUsedSquareBrackets_(callUsedSquareBrackets) {
   }
+  FnCall(Deserializer& des)
+    : Call(asttags::FnCall, des) {
+    actualNames_ = des.read<std::vector<UniqueString>>();
+    callUsedSquareBrackets_ = des.read<bool>();
+  }
   bool contentsMatchInner(const AstNode* other) const override {
     const FnCall* lhs = this;
     const FnCall* rhs = (const FnCall*) other;
@@ -128,6 +133,14 @@ class FnCall : public Call {
   bool callUsedSquareBrackets() const {
     return callUsedSquareBrackets_;
   }
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+    ser(actualNames_);
+    ser(callUsedSquareBrackets_);
+  }
+
+  DECLARE_STATIC_DES(FnCall);
 };
 
 

--- a/frontend/include/chpl/uast/For.h
+++ b/frontend/include/chpl/uast/For.h
@@ -62,6 +62,11 @@ class For final : public IndexableLoop {
     assert(withClause() == nullptr);
   }
 
+  For(Deserializer& des)
+    : IndexableLoop(asttags::For, des) {
+    isParam_ = des.read<bool>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const For* lhs = this;
     const For* rhs = (const For*) other;
@@ -101,6 +106,13 @@ class For final : public IndexableLoop {
   bool isParam() const {
     return isParam_;
   }
+
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serializePart(ser);
+    ser(isParam_);
+  }
+
+  DECLARE_STATIC_DES(For);
 
 };
 

--- a/frontend/include/chpl/uast/Forall.h
+++ b/frontend/include/chpl/uast/Forall.h
@@ -61,6 +61,10 @@ class Forall final : public IndexableLoop {
                     isExpressionLevel) {
   }
 
+  Forall(Deserializer& des)
+    : IndexableLoop(asttags::Forall, des) {
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());
   }
@@ -82,6 +86,12 @@ class Forall final : public IndexableLoop {
                              BlockStyle blockStyle,
                              owned<Block> body,
                              bool isExpressionLevel);
+
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Forall);
 
 };
 

--- a/frontend/include/chpl/uast/Foreach.h
+++ b/frontend/include/chpl/uast/Foreach.h
@@ -61,6 +61,9 @@ class Foreach final : public IndexableLoop {
 
   }
 
+  Foreach(Deserializer& des)
+    : IndexableLoop(asttags::Foreach, des) {}
+
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());
   }
@@ -82,6 +85,12 @@ class Foreach final : public IndexableLoop {
                               BlockStyle blockStyle,
                               owned<Block> body);
 
+
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Foreach);
 
 };
 

--- a/frontend/include/chpl/uast/Formal.h
+++ b/frontend/include/chpl/uast/Formal.h
@@ -72,6 +72,9 @@ class Formal final : public VarLikeDecl {
                   typeExpressionChildNum,
                   initExpressionChildNum) {
   }
+  Formal(Deserializer& des)
+    : VarLikeDecl(asttags::Formal, des) {
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Formal* lhs = this;
@@ -110,6 +113,12 @@ class Formal final : public VarLikeDecl {
   inline bool isExplicitlyAnonymous() const {
     return name() == USTR("_");
   }
+
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Formal);
 
 };
 

--- a/frontend/include/chpl/uast/ForwardingDecl.h
+++ b/frontend/include/chpl/uast/ForwardingDecl.h
@@ -69,6 +69,9 @@ private:
     assert(children_.size() >= 0 && children_.size() <= 2);
   }
 
+  ForwardingDecl(Deserializer& des)
+    : Decl(asttags::ForwardingDecl, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const ForwardingDecl* lhs = (const ForwardingDecl*) this;
     const ForwardingDecl* rhs = (const ForwardingDecl*) other;
@@ -107,6 +110,13 @@ private:
       return nullptr;
     }
   }
+
+  void serialize(Serializer& ser) const override {
+    Decl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(ForwardingDecl);
+
 };
 
 

--- a/frontend/include/chpl/uast/Function.h
+++ b/frontend/include/chpl/uast/Function.h
@@ -165,6 +165,27 @@ class Function final : public NamedDecl {
     #endif
   }
 
+  Function(Deserializer& des)
+    : NamedDecl(asttags::Function, des) {
+    inline_        = des.read<bool>();
+    override_      = des.read<bool>();
+    kind_          = des.read<Kind>();
+    returnIntent_  = des.read<ReturnIntent>();
+    throws_        = des.read<bool>();
+    primaryMethod_ = des.read<bool>();
+    parenless_     = des.read<bool>();
+
+    formalsChildNum_    = (int)des.read<int32_t>();
+    thisFormalChildNum_ = (int)des.read<int32_t>();
+    numFormals_         = (int)des.read<int32_t>();
+    returnTypeChildNum_ = (int)des.read<int32_t>();
+    whereChildNum_      = (int)des.read<int32_t>();
+    lifetimeChildNum_   = (int)des.read<int32_t>();
+    numLifetimeParts_   = (int)des.read<int32_t>();
+    bodyChildNum_       = (int)des.read<int32_t>();
+  }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Function* lhs = this;
     const Function* rhs = (const Function*) other;
@@ -382,9 +403,34 @@ class Function final : public NamedDecl {
   static std::string returnIntentToString(ReturnIntent intent);
 
   static std::string kindToString(Kind kind);
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+    ser(inline_);
+    ser(override_);
+    ser(kind_);
+    ser(returnIntent_);
+    ser(throws_);
+    ser(primaryMethod_);
+    ser(parenless_);
+
+    ser.write<int32_t>(formalsChildNum_);
+    ser.write<int32_t>(thisFormalChildNum_);
+    ser.write<int32_t>(numFormals_);
+    ser.write<int32_t>(returnTypeChildNum_);
+    ser.write<int32_t>(whereChildNum_);
+    ser.write<int32_t>(lifetimeChildNum_);
+    ser.write<int32_t>(numLifetimeParts_);
+    ser.write<int32_t>(bodyChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Function);
 };
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::Function::Kind, uint8_t);
+DECLARE_SERDE_ENUM(uast::Function::ReturnIntent, uint8_t);
 
 
 /// \cond DO_NOT_DOCUMENT

--- a/frontend/include/chpl/uast/FunctionSignature.h
+++ b/frontend/include/chpl/uast/FunctionSignature.h
@@ -86,6 +86,18 @@ class FunctionSignature final : public AstNode {
                  returnTypeChildNum_ < (ssize_t)children_.size());
   }
 
+  FunctionSignature(Deserializer& des)
+    : AstNode(asttags::FunctionSignature, des) {
+      kind_ = des.read<Kind>();
+      returnIntent_ = des.read<ReturnIntent>();
+      formalsChildNum_ = des.read<int>();
+      thisFormalChildNum_ = des.read<int>();
+      numFormals_= des.read<int>();
+      returnTypeChildNum_ = des.read<int>();
+      throws_ = des.read<bool>();
+      isParenless_ = des.read<bool>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     auto lhs = this;
     auto rhs = (const FunctionSignature*) other;
@@ -159,6 +171,20 @@ class FunctionSignature final : public AstNode {
     const AstNode* ret = this->child(returnTypeChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(kind_);
+    ser(returnIntent_);
+    ser(formalsChildNum_);
+    ser(thisFormalChildNum_);
+    ser(numFormals_);
+    ser(returnTypeChildNum_);
+    ser(throws_);
+    ser(isParenless_);
+  }
+
+  DECLARE_STATIC_DES(FunctionSignature);
 
 };
 

--- a/frontend/include/chpl/uast/Identifier.h
+++ b/frontend/include/chpl/uast/Identifier.h
@@ -50,6 +50,12 @@ class Identifier final : public AstNode {
     assert(!name.isEmpty());
   }
 
+  Identifier(Deserializer& des)
+    : AstNode(asttags::Identifier, des) {
+    name_ = des.read<UniqueString>();
+  }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Identifier* lhs = this;
     const Identifier* rhs = (const Identifier*) other;
@@ -63,6 +69,13 @@ class Identifier final : public AstNode {
   ~Identifier() override = default;
   static owned<Identifier> build(Builder* builder, Location loc, UniqueString name);
   UniqueString name() const { return name_; }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(name_);
+  }
+
+  DECLARE_STATIC_DES(Identifier);
 };
 
 /*

--- a/frontend/include/chpl/uast/ImagLiteral.h
+++ b/frontend/include/chpl/uast/ImagLiteral.h
@@ -36,6 +36,10 @@ class ImagLiteral final : public NumericLiteral<double, types::RealParam> {
     : NumericLiteral(asttags::ImagLiteral, value, text)
   { }
 
+  ImagLiteral(Deserializer& des)
+    : NumericLiteral(asttags::ImagLiteral, des)
+  { }
+
   // contentsMatchInner / markUniqueStringsInner are in NumericLiteral
   // and would need to be defined here if any fields are added.
 
@@ -44,6 +48,12 @@ class ImagLiteral final : public NumericLiteral<double, types::RealParam> {
 
   static owned<ImagLiteral> build(Builder* builder, Location loc,
                                   double value, UniqueString text);
+
+  void serialize(Serializer& ser) const override {
+    NumericLiteral::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(ImagLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Implements.h
+++ b/frontend/include/chpl/uast/Implements.h
@@ -78,6 +78,11 @@ class Implements final : public AstNode {
            interfaceExpr()->isFnCall());
   }
 
+  Implements(Deserializer& des)
+    : AstNode(asttags::Implements, des) {
+      typeIdentChildNum_ = des.read<int8_t>();
+      isExpressionLevel_ = des.read<bool>();
+    }
   bool contentsMatchInner(const AstNode* other) const override {
     const Implements* lhs = this;
     const Implements* rhs = (const Implements*) other;
@@ -164,6 +169,15 @@ class Implements final : public AstNode {
                                  owned<Identifier> typeIdent,
                                  owned<AstNode> interfaceExpr,
                                  bool isExpressionLevel);
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(typeIdentChildNum_);
+    ser(isExpressionLevel_);
+  }
+
+  DECLARE_STATIC_DES(Implements);
+
 };
 
 

--- a/frontend/include/chpl/uast/Import.h
+++ b/frontend/include/chpl/uast/Import.h
@@ -59,6 +59,10 @@ class Import final : public AstNode {
     #endif
   }
 
+  Import(Deserializer& des)
+    : AstNode(asttags::Import, des)
+      {visibility_=des.read<Decl::Visibility>();}
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Import* rhs = other->toImport();
     return this->visibility_ == rhs->visibility_;
@@ -108,6 +112,13 @@ class Import final : public AstNode {
     assert(ret->isVisibilityClause());
     return (const VisibilityClause*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(visibility_);
+  }
+
+  DECLARE_STATIC_DES(Import);
 
 };
 

--- a/frontend/include/chpl/uast/Include.h
+++ b/frontend/include/chpl/uast/Include.h
@@ -58,6 +58,14 @@ class Include final : public AstNode {
     assert(!name_.isEmpty());
   }
 
+  Include(Deserializer& des)
+    : AstNode(asttags::Include, des) {
+      visibility_ = des.read<Decl::Visibility>();
+      isPrototype_ = des.read<bool>();
+      name_ = des.read<UniqueString>();
+    }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Include* lhs = this;
     const Include* rhs = other->toInclude();
@@ -100,6 +108,16 @@ class Include final : public AstNode {
   UniqueString name() const {
     return name_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(visibility_);
+    ser(isPrototype_);
+    ser(name_);
+  }
+
+  DECLARE_STATIC_DES(Include);
+
 };
 
 

--- a/frontend/include/chpl/uast/IndexableLoop.h
+++ b/frontend/include/chpl/uast/IndexableLoop.h
@@ -51,6 +51,14 @@ class IndexableLoop : public Loop {
     assert(iterandChildNum >= 0);
   }
 
+  IndexableLoop(AstTag tag, Deserializer& des)
+    : Loop(tag, des) {
+    indexChildNum_ = des.read<int8_t>();
+    iterandChildNum_ = des.read<int8_t>();
+    withClauseChildNum_ = des.read<int8_t>();
+    isExpressionLevel_ = des.read<bool>();
+  }
+
   bool indexableLoopContentsMatchInner(const IndexableLoop* other) const {
     const IndexableLoop* lhs = this;
     const IndexableLoop* rhs = other;
@@ -121,6 +129,14 @@ class IndexableLoop : public Loop {
   */
   bool isExpressionLevel() const {
     return isExpressionLevel_;
+  }
+
+  void serializePart(Serializer& ser) const {
+    Loop::serializePart(ser);
+    ser(indexChildNum_);
+    ser(iterandChildNum_);
+    ser(withClauseChildNum_);
+    ser(isExpressionLevel_);
   }
 
 };

--- a/frontend/include/chpl/uast/IntLiteral.h
+++ b/frontend/include/chpl/uast/IntLiteral.h
@@ -40,6 +40,10 @@ class IntLiteral final : public NumericLiteral<int64_t, types::IntParam> {
     : NumericLiteral(asttags::IntLiteral, value, text)
   { }
 
+  IntLiteral(Deserializer& des)
+    : NumericLiteral(asttags::IntLiteral, des)
+  { }
+
   // contentsMatchInner / markUniqueStringsInner are in NumericLiteral
   // and would need to be defined here if any fields are added.
 
@@ -48,6 +52,12 @@ class IntLiteral final : public NumericLiteral<int64_t, types::IntParam> {
 
   static owned<IntLiteral> build(Builder* builder, Location loc,
                                  int64_t value, UniqueString text);
+
+  void serialize(Serializer& ser) const override {
+    NumericLiteral::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(IntLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/IntentList.h
+++ b/frontend/include/chpl/uast/IntentList.h
@@ -20,6 +20,8 @@
 #ifndef CHPL_UAST_INTENTLIST_H
 #define CHPL_UAST_INTENTLIST_H
 
+#include "chpl/framework/serialize-functions.h"
+
 namespace chpl {
 namespace uast {
 
@@ -98,6 +100,9 @@ enum struct IntentList {
 
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::IntentList, uint8_t);
+
 } // end namespace chpl
 
 namespace std {

--- a/frontend/include/chpl/uast/Interface.h
+++ b/frontend/include/chpl/uast/Interface.h
@@ -75,6 +75,15 @@ class Interface final : public NamedDecl {
     // TODO: Some assertions here...
   }
 
+  Interface(Deserializer& des)
+    : NamedDecl(asttags::Interface, des) {
+      interfaceFormalsChildNum_ = des.read<int>();
+      numInterfaceFormals_ = des.read<int>();
+      bodyChildNum_ = des.read<int>();
+      numBodyStmts_ = des.read<int>();
+      isFormalListExplicit_ = des.read<bool>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Interface* lhs = this;
     const Interface* rhs = (const Interface*) other;
@@ -183,6 +192,18 @@ class Interface final : public NamedDecl {
                                 bool isFormalListExplicit,
                                 AstList formals,
                                 AstList body);
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+    ser(interfaceFormalsChildNum_);
+    ser(numInterfaceFormals_);
+    ser(bodyChildNum_);
+    ser(numBodyStmts_);
+    ser(isFormalListExplicit_);
+  }
+
+  DECLARE_STATIC_DES(Interface);
+
 };
 
 

--- a/frontend/include/chpl/uast/Label.h
+++ b/frontend/include/chpl/uast/Label.h
@@ -50,6 +50,11 @@ class Label final : public AstNode {
     assert(numChildren() == 1);
   }
 
+  Label(Deserializer& des)
+    : AstNode(asttags::Label, des) {
+      name_ = des.read<UniqueString>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Label* lhs = this;
     const Label* rhs = other->toLabel();
@@ -94,6 +99,14 @@ class Label final : public AstNode {
   UniqueString name() const {
     return name_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(name_);
+  }
+
+  DECLARE_STATIC_DES(Label);
+
 
 };
 

--- a/frontend/include/chpl/uast/Let.h
+++ b/frontend/include/chpl/uast/Let.h
@@ -51,6 +51,11 @@ class Let final : public AstNode {
     assert(1 <= numDecls && (numDecls == numChildren() - 1));
   }
 
+  Let(Deserializer& des)
+    : AstNode(asttags::Let, des) {
+      numDecls_ = des.read<int>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Let* lhs = this;
     const Let* rhs = other->toLet();
@@ -104,6 +109,13 @@ class Let final : public AstNode {
     assert(ret);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(numDecls_);
+  }
+
+  DECLARE_STATIC_DES(Let);
 
 };
 

--- a/frontend/include/chpl/uast/Literal.h
+++ b/frontend/include/chpl/uast/Literal.h
@@ -41,6 +41,11 @@ class Literal : public AstNode {
     assert(value_ != nullptr);
   }
 
+  Literal(AstTag tag, Deserializer& des)
+    : AstNode(tag, des), value_(types::Param::deserializeFromFile(des)) {
+    assert(value_ != nullptr);
+  }
+
   bool literalContentsMatchInner(const Literal* other) const {
     return this->value_ == other->value_;
   }
@@ -56,6 +61,11 @@ class Literal : public AstNode {
    */
   const types::Param* param() const {
     return value_;
+  }
+
+  void serializePart(Serializer& ser) const {
+    AstNode::serializePart(ser);
+    value_->serialize(ser);
   }
 };
 

--- a/frontend/include/chpl/uast/Local.h
+++ b/frontend/include/chpl/uast/Local.h
@@ -59,6 +59,11 @@ class Local final : public SimpleBlockLike {
       condChildNum_(condChildNum) {
   }
 
+  Local(Deserializer& des)
+    : SimpleBlockLike(asttags::Local, des) {
+    condChildNum_ = des.read<int8_t>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Local* lhs = this;
     const Local* rhs = (const Local*) other;
@@ -104,6 +109,13 @@ class Local final : public SimpleBlockLike {
   const AstNode* condition() const {
     return condChildNum_ < 0 ? nullptr : child(condChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(condChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Local);
 
 };
 

--- a/frontend/include/chpl/uast/Loop.h
+++ b/frontend/include/chpl/uast/Loop.h
@@ -45,6 +45,12 @@ class Loop: public AstNode {
     assert(children_[loopBodyChildNum_]->isBlock());
   }
 
+  Loop(AstTag tag, Deserializer& des)
+    : AstNode(tag, des) {
+    blockStyle_ = des.read<BlockStyle>();
+    loopBodyChildNum_ = des.read<int>();
+  }
+
   bool loopContentsMatchInner(const Loop* other) const {
     const Loop* lhs = this;
     const Loop* rhs = other;
@@ -101,6 +107,12 @@ class Loop: public AstNode {
   */
   BlockStyle blockStyle() const {
     return blockStyle_;
+  }
+
+  void serializePart(Serializer& ser) const {
+    AstNode::serializePart(ser);
+    ser(blockStyle_);
+    ser(loopBodyChildNum_);
   }
 };
 

--- a/frontend/include/chpl/uast/Manage.h
+++ b/frontend/include/chpl/uast/Manage.h
@@ -67,6 +67,13 @@ class Manage final : public SimpleBlockLike {
     #endif
   }
 
+  Manage(Deserializer& des)
+    : SimpleBlockLike(asttags::Manage, des) {
+      managerExprChildNum_ = des.read<int>();
+      numManagerExprs_ = des.read<int>();
+    }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Manage* lhs = this;
     const Manage* rhs = (const Manage*) other;
@@ -117,6 +124,15 @@ class Manage final : public SimpleBlockLike {
     auto ret = child(managerExprChildNum_ + i);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(managerExprChildNum_);
+    ser(numManagerExprs_);
+  }
+
+  DECLARE_STATIC_DES(Manage);
+
 };
 
 

--- a/frontend/include/chpl/uast/Module.h
+++ b/frontend/include/chpl/uast/Module.h
@@ -61,6 +61,12 @@ class Module final : public NamedDecl {
 
   }
 
+  Module(Deserializer& des)
+    : NamedDecl(asttags::Module, des) {
+    kind_ = des.read<Kind>();
+  }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Module* lhs = this;
     const Module* rhs = (const Module*) other;
@@ -117,10 +123,20 @@ class Module final : public NamedDecl {
     const AstNode* ast = this->child(i + stmtChildNum());
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+    ser(kind_);
+  }
+
+  DECLARE_STATIC_DES(Module);
 };
 
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::Module::Kind, uint8_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/MultiDecl.h
+++ b/frontend/include/chpl/uast/MultiDecl.h
@@ -63,6 +63,9 @@ class MultiDecl final : public Decl {
     assert(isAcceptableMultiDecl());
   }
 
+  MultiDecl(Deserializer& des)
+    : Decl(asttags::MultiDecl, des) { }
+
   bool isAcceptableMultiDecl();
 
   int declOrCommentChildNum() const {
@@ -126,6 +129,12 @@ class MultiDecl final : public Decl {
     auto end = begin + numDeclOrComments();
     return AstListNoCommentsIteratorPair<Decl>(begin, end);
   }
+
+  void serialize(Serializer& ser) const override {
+    Decl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(MultiDecl);
 
 };
 

--- a/frontend/include/chpl/uast/NamedDecl.h
+++ b/frontend/include/chpl/uast/NamedDecl.h
@@ -54,6 +54,12 @@ class NamedDecl : public Decl {
       name_(name) {
   }
 
+  NamedDecl(AstTag tag, Deserializer& des)
+    : Decl(tag, des) {
+    name_ = des.read<UniqueString>();
+  }
+
+
   bool namedDeclContentsMatchInner(const NamedDecl* other) const {
     return this->name_ == other->name_ &&
            declContentsMatchInner(other);
@@ -65,6 +71,11 @@ class NamedDecl : public Decl {
 
  public:
   virtual ~NamedDecl() = 0; // this is an abstract base class
+
+  void serializePart(Serializer& ser) const {
+    Decl::serializePart(ser);
+    ser(name_);
+  }
 
   UniqueString name() const { return name_; }
 };

--- a/frontend/include/chpl/uast/New.h
+++ b/frontend/include/chpl/uast/New.h
@@ -68,6 +68,11 @@ class New : public AstNode {
     : AstNode(asttags::New, std::move(children)),
       management_(management) {}
 
+  New(Deserializer& des)
+    : AstNode(asttags::New, des) {
+        management_ = des.read<Management>();
+      }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const New* lhs = this;
     const New* rhs = (const New*) other;
@@ -107,10 +112,20 @@ class New : public AstNode {
     return management_;
   }
 
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(management_);
+  }
+
+  DECLARE_STATIC_DES(New);
+
 };
 
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::New::Management, uint8_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/NumericLiteral.h
+++ b/frontend/include/chpl/uast/NumericLiteral.h
@@ -41,6 +41,11 @@ class NumericLiteral : public Literal {
       text_(text)
   { }
 
+  NumericLiteral(AstTag tag, Deserializer& des)
+    : Literal(tag, des) {
+    text_ = des.read<UniqueString>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     auto lhs = this;
     auto* rhs = (const NumericLiteral<ValueT, ParamT>*) other;
@@ -61,6 +66,11 @@ class NumericLiteral : public Literal {
   ValueT value() const {
     const ParamT* p = (const ParamT*) value_;
     return p->value();
+  }
+
+  void serializePart(Serializer& ser) const {
+    Literal::serializePart(ser);
+    ser(text_);
   }
 
   /**

--- a/frontend/include/chpl/uast/On.h
+++ b/frontend/include/chpl/uast/On.h
@@ -51,6 +51,9 @@ class On final : public SimpleBlockLike {
                       numBodyStmts) {
   }
 
+  On(Deserializer& des)
+    : SimpleBlockLike(asttags::On, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);
   }
@@ -78,6 +81,12 @@ class On final : public SimpleBlockLike {
     auto ret = child(destChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(On);
 
 };
 

--- a/frontend/include/chpl/uast/OpCall.h
+++ b/frontend/include/chpl/uast/OpCall.h
@@ -45,6 +45,10 @@ class OpCall final : public Call {
            /* hasCalledExpression */ false),
       op_(op) {
   }
+  OpCall(Deserializer& des)
+    : Call(asttags::OpCall, des) {
+    op_ = des.read<UniqueString>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const OpCall* lhs = this;
@@ -81,6 +85,13 @@ class OpCall final : public Call {
   bool isBinaryOp() const { return children_.size() == 2; }
   /** Returns true if this is a unary operator */
   bool isUnaryOp() const { return children_.size() == 1; }
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+    ser(op_);
+  }
+
+  DECLARE_STATIC_DES(OpCall);
 };
 
 // Returns true if the given string is an operator name

--- a/frontend/include/chpl/uast/Pragma.h
+++ b/frontend/include/chpl/uast/Pragma.h
@@ -20,6 +20,8 @@
 #ifndef CHPL_UAST_PRAGMA_H
 #define CHPL_UAST_PRAGMA_H
 
+#include "chpl/framework/serialize-functions.h"
+
 namespace chpl {
 namespace uast {
 namespace pragmatags {
@@ -47,6 +49,9 @@ PragmaTag pragmaNameToTag(const char* name);
 using namespace pragmatags;
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::PragmaTag, uint16_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/PrimCall.h
+++ b/frontend/include/chpl/uast/PrimCall.h
@@ -52,6 +52,10 @@ class PrimCall final : public Call {
            /* hasCalledExpression */ false),
       prim_(prim) {
   }
+  PrimCall(Deserializer& des)
+    : Call(asttags::PrimCall, des) {
+    prim_ = des.read<PrimitiveTag>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const PrimCall* lhs = this;
@@ -78,6 +82,13 @@ class PrimCall final : public Call {
 
   /** Returns the enum value of the primitive called */
   PrimitiveTag prim() const { return prim_; }
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+    ser(prim_);
+  }
+
+  DECLARE_STATIC_DES(PrimCall);
 };
 
 

--- a/frontend/include/chpl/uast/PrimOp.h
+++ b/frontend/include/chpl/uast/PrimOp.h
@@ -20,6 +20,8 @@
 #ifndef CHPL_UAST_PRIM_OP_H
 #define CHPL_UAST_PRIM_OP_H
 
+#include "chpl/framework/serialize-functions.h"
+
 namespace chpl {
 namespace uast {
 namespace primtags {
@@ -47,6 +49,9 @@ PrimitiveTag primNameToTag(const char* name);
 using namespace primtags;
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::PrimitiveTag, uint16_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/Range.h
+++ b/frontend/include/chpl/uast/Range.h
@@ -59,6 +59,13 @@ class Range final : public AstNode {
     }
   }
 
+  Range(Deserializer& des)
+    : AstNode(asttags::Range, des) {
+    opKind_ = des.read<OpKind>();
+    lowerBoundChildNum_ = des.read<int8_t>();
+    upperBoundChildNum_ = des.read<int8_t>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Range* rhs = other->toRange();
     return this->opKind_ == rhs->opKind_ &&
@@ -109,10 +116,22 @@ class Range final : public AstNode {
     return ret;
   }
 
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(opKind_);
+    ser(lowerBoundChildNum_);
+    ser(upperBoundChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Range);
+
 };
 
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::Range::OpKind, uint8_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/RealLiteral.h
+++ b/frontend/include/chpl/uast/RealLiteral.h
@@ -37,6 +37,10 @@ class RealLiteral final : public NumericLiteral<double, types::RealParam> {
     : NumericLiteral(asttags::RealLiteral, value, text)
   { }
 
+  RealLiteral(Deserializer& des)
+    : NumericLiteral(asttags::RealLiteral, des)
+  { }
+
   // contentsMatchInner / markUniqueStringsInner are in NumericLiteral
   // and would need to be defined here if any fields are added.
 
@@ -45,6 +49,12 @@ class RealLiteral final : public NumericLiteral<double, types::RealParam> {
 
   static owned<RealLiteral> build(Builder* builder, Location loc,
                                   double value, UniqueString text);
+
+  void serialize(Serializer& ser) const override {
+    NumericLiteral::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(RealLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Record.h
+++ b/frontend/include/chpl/uast/Record.h
@@ -60,6 +60,9 @@ class Record final : public AggregateDecl {
                     numElements) {
   }
 
+  Record(Deserializer& des)
+    : AggregateDecl(asttags::Record, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Record* lhs = this;
     const Record* rhs = (const Record*) other;
@@ -80,6 +83,12 @@ class Record final : public AggregateDecl {
                              owned<AstNode> linkageName,
                              UniqueString name,
                              AstList contents);
+
+  void serialize(Serializer& ser) const override {
+    AggregateDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Record);
 };
 
 

--- a/frontend/include/chpl/uast/Reduce.h
+++ b/frontend/include/chpl/uast/Reduce.h
@@ -73,6 +73,9 @@ class Reduce final : public Call {
     assert(numChildren() == 2);
   }
 
+  Reduce(Deserializer& des)
+      : Call(asttags::Reduce, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Reduce* rhs = other->toReduce();
     return this->callContentsMatchInner(rhs);
@@ -109,6 +112,12 @@ class Reduce final : public Call {
   const AstNode* iterand() const {
     return this->child(iterandExprChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Reduce);
 
 };
 

--- a/frontend/include/chpl/uast/ReduceIntent.h
+++ b/frontend/include/chpl/uast/ReduceIntent.h
@@ -63,6 +63,9 @@ class ReduceIntent final : public NamedDecl {
     assert(numChildren() == 1);
   }
 
+  ReduceIntent(Deserializer& des)
+    : NamedDecl(asttags::ReduceIntent, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const ReduceIntent* rhs = other->toReduceIntent();
     return this->namedDeclContentsMatchInner(rhs);
@@ -91,6 +94,12 @@ class ReduceIntent final : public NamedDecl {
   const AstNode* op() const {
     return this->child(opChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(ReduceIntent);
 
 };
 

--- a/frontend/include/chpl/uast/Require.h
+++ b/frontend/include/chpl/uast/Require.h
@@ -44,6 +44,9 @@ class Require final : public AstNode {
     : AstNode(asttags::Require, std::move(children)) {
   }
 
+  Require(Deserializer& des)
+    : AstNode(asttags::Require, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -82,6 +85,12 @@ class Require final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Require);
 
 };
 

--- a/frontend/include/chpl/uast/Return.h
+++ b/frontend/include/chpl/uast/Return.h
@@ -48,6 +48,10 @@ class Return final : public AstNode {
       valueChildNum_(valueChildNum) {
     assert(valueChildNum_ <= 0);
   }
+  Return(Deserializer& des)
+    : AstNode(asttags::Return, des) {
+    valueChildNum_ = des.read<int8_t>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Return* lhs = this;
@@ -83,6 +87,13 @@ class Return final : public AstNode {
     auto ret = child(valueChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(valueChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Return);
 
 };
 

--- a/frontend/include/chpl/uast/Scan.h
+++ b/frontend/include/chpl/uast/Scan.h
@@ -50,6 +50,9 @@ class Scan final : public Call {
     assert(numChildren() == 2);
   }
 
+  Scan(Deserializer& des)
+    : Call(asttags::Scan, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Scan* rhs = other->toScan();
     return this->callContentsMatchInner(rhs);
@@ -82,6 +85,12 @@ class Scan final : public Call {
   const AstNode* iterand() const {
     return this->child(iterandChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Scan);
 
 };
 

--- a/frontend/include/chpl/uast/Select.h
+++ b/frontend/include/chpl/uast/Select.h
@@ -51,6 +51,10 @@ class Select final : public AstNode {
       numWhenStmts_(numWhenStmts) {
   }
 
+  Select(Deserializer& des) : AstNode(asttags::Select, des) {
+    numWhenStmts_ = des.read<int>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Select* rhs = other->toSelect();
     return this->numWhenStmts_ == rhs->numWhenStmts_;
@@ -109,6 +113,13 @@ class Select final : public AstNode {
     auto end = begin + numWhenStmts_;
     return AstListIteratorPair<When>(begin, end);
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(numWhenStmts_);
+  }
+
+  DECLARE_STATIC_DES(Select);
 
 };
 

--- a/frontend/include/chpl/uast/Serial.h
+++ b/frontend/include/chpl/uast/Serial.h
@@ -59,6 +59,11 @@ class Serial final : public SimpleBlockLike {
       condChildNum_(condChildNum) {
   }
 
+  Serial(Deserializer& des)
+    : SimpleBlockLike(asttags::Serial, des) {
+      condChildNum_ = des.read<int8_t>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Serial* lhs = this;
     const Serial* rhs = (const Serial*) other;
@@ -104,6 +109,13 @@ class Serial final : public SimpleBlockLike {
   const AstNode* condition() const {
     return condChildNum_ < 0 ? nullptr : child(condChildNum_);
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(condChildNum_);
+  }
+
+  DECLARE_STATIC_DES(Serial);
 
 };
 

--- a/frontend/include/chpl/uast/SimpleBlockLike.h
+++ b/frontend/include/chpl/uast/SimpleBlockLike.h
@@ -57,6 +57,14 @@ class SimpleBlockLike : public AstNode {
 
   }
 
+  SimpleBlockLike(AstTag tag, Deserializer& des)
+    : AstNode(tag, des) {
+    blockStyle_ = des.read<BlockStyle>();
+    bodyChildNum_ = (int)des.read<int32_t>();
+    numBodyStmts_ = (int)des.read<int32_t>();
+  }
+
+
   bool simpleBlockLikeContentsMatchInner(const AstNode* other) const {
     const SimpleBlockLike* lhs = this;
     const SimpleBlockLike* rhs = other->toSimpleBlockLike();
@@ -113,6 +121,13 @@ class SimpleBlockLike : public AstNode {
   */
   BlockStyle blockStyle() const {
     return blockStyle_;
+  }
+
+  void serializePart(Serializer& ser) const {
+    AstNode::serializePart(ser);
+    ser(blockStyle_);
+    ser.write<int32_t>(bodyChildNum_);
+    ser.write<int32_t>(numBodyStmts_);
   }
 
 };

--- a/frontend/include/chpl/uast/StringLikeLiteral.h
+++ b/frontend/include/chpl/uast/StringLikeLiteral.h
@@ -47,6 +47,11 @@ class StringLikeLiteral : public Literal {
       quotes_(quotes)
   { }
 
+  StringLikeLiteral(AstTag tag, Deserializer& des)
+    : Literal(tag, des) {
+    quotes_ = des.read<QuoteStyle>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const StringLikeLiteral* lhs = this;
     const StringLikeLiteral* rhs = (const StringLikeLiteral*) other;
@@ -64,10 +69,18 @@ class StringLikeLiteral : public Literal {
    Returns the type of quotes used for this string literal.
    */
   QuoteStyle quoteStyle() const { return this->quotes_; }
+
+  void serializePart(Serializer& ser) const {
+    Literal::serializePart(ser);
+    ser(quotes_);
+  }
 };
 
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::StringLikeLiteral::QuoteStyle, uint8_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/StringLiteral.h
+++ b/frontend/include/chpl/uast/StringLiteral.h
@@ -38,6 +38,10 @@ class StringLiteral final : public StringLikeLiteral {
     : StringLikeLiteral(asttags::StringLiteral, value, quotes)
   { }
 
+  StringLiteral(Deserializer& des)
+    : StringLikeLiteral(asttags::StringLiteral, des)
+  { }
+
   // contentsMatchInner / markUniqueStringsInner are in StringLikeLiteral
   // and would need to be defined here if any fields are added.
 
@@ -57,6 +61,12 @@ class StringLiteral final : public StringLikeLiteral {
     const types::StringParam* p = (const types::StringParam*) value_;
     return p->value();
   }
+
+  void serialize(Serializer& ser) const override {
+    StringLikeLiteral::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(StringLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Sync.h
+++ b/frontend/include/chpl/uast/Sync.h
@@ -60,6 +60,9 @@ class Sync final : public SimpleBlockLike {
     assert(bodyChildNum_ >= 0);
   }
 
+  Sync(Deserializer& des)
+    : SimpleBlockLike(asttags::Sync, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);
   }
@@ -77,6 +80,13 @@ class Sync final : public SimpleBlockLike {
   static owned<Sync> build(Builder* builder, Location loc,
                            BlockStyle blockStyle,
                            AstList stmts);
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Sync);
+
 };
 
 

--- a/frontend/include/chpl/uast/TaskVar.h
+++ b/frontend/include/chpl/uast/TaskVar.h
@@ -73,6 +73,11 @@ class TaskVar final : public VarLikeDecl {
                     initExpressionChildNum) {
   }
 
+  TaskVar(Deserializer& des)
+      : VarLikeDecl(asttags::TaskVar, des) {
+
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const TaskVar* lhs = this;
     const TaskVar* rhs = (const TaskVar*) other;
@@ -99,10 +104,21 @@ class TaskVar final : public VarLikeDecl {
   */
   Intent intent() const { return (Intent)((int)storageKind()); }
 
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(TaskVar);
+
 };
+
+// DECLARE_SERDE_ENUM(uast::TaskVar::Intent, uint8_t);
 
 
 } // end namespace uast
+
+
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/Throw.h
+++ b/frontend/include/chpl/uast/Throw.h
@@ -47,6 +47,9 @@ class Throw final : public AstNode {
     assert(numChildren() == 1);
   }
 
+  Throw(Deserializer& des)
+    : AstNode(asttags::Throw, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -72,6 +75,12 @@ class Throw final : public AstNode {
     const AstNode* ast = this->child(errorExprChildNum_);
     return ast;
   }
+
+  void serialize(Serializer& ser) {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Throw);
 
 };
 

--- a/frontend/include/chpl/uast/Try.h
+++ b/frontend/include/chpl/uast/Try.h
@@ -74,6 +74,14 @@ class Try final : public AstNode {
     }
   }
 
+  Try(Deserializer& des)
+    : AstNode(asttags::Try, des) {
+      numHandlers_ = des.read<int>();
+      containsBlock_ = des.read<bool>();
+      isExpressionLevel_ = des.read<bool>();
+      isTryBang_ = des.read<bool>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Try* rhs = other->toTry();
     return this->numHandlers_ == rhs->numHandlers_ &&
@@ -206,6 +214,16 @@ class Try final : public AstNode {
   bool isTryBang() const {
     return isTryBang_;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(numHandlers_);
+    ser(containsBlock_);
+    ser(isExpressionLevel_);
+    ser(isTryBang_);
+  }
+
+  DECLARE_STATIC_DES(Try);
 
 };
 

--- a/frontend/include/chpl/uast/Tuple.h
+++ b/frontend/include/chpl/uast/Tuple.h
@@ -48,6 +48,9 @@ class Tuple final : public Call {
     assert(numChildren() >= 1);
   }
 
+  Tuple(Deserializer& des)
+    : Call(asttags::Tuple, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return this->callContentsMatchInner(other->toCall());
   }
@@ -65,6 +68,12 @@ class Tuple final : public Call {
   static owned<Tuple> build(Builder* builder,
                             Location loc,
                             AstList exprs);
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Tuple);
 
 };
 

--- a/frontend/include/chpl/uast/TupleDecl.h
+++ b/frontend/include/chpl/uast/TupleDecl.h
@@ -95,6 +95,14 @@ class TupleDecl final : public Decl {
     assert(assertAcceptableTupleDecl());
   }
 
+  TupleDecl(Deserializer& des)
+    : Decl(asttags::TupleDecl, des) {
+      intentOrKind_ = des.read<IntentOrKind>();
+      numElements_ = des.read<int>();
+      typeExpressionChildNum_ = des.read<int>();
+      initExpressionChildNum_ = des.read<int>();
+    }
+
   bool assertAcceptableTupleDecl();
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -186,10 +194,26 @@ class TupleDecl final : public Decl {
       return nullptr;
     }
   }
+
+  void serialize(Serializer& ser) const override {
+    Decl::serializePart(ser);
+    ser(intentOrKind_);
+    ser(numElements_);
+    ser(typeExpressionChildNum_);
+    ser(initExpressionChildNum_);
+  }
+
+  DECLARE_STATIC_DES(TupleDecl);
+
 };
 
 
 } // end namespace uast
+
+
+DECLARE_SERDE_ENUM(uast::TupleDecl::IntentOrKind, uint8_t);
+
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/TypeDecl.h
+++ b/frontend/include/chpl/uast/TypeDecl.h
@@ -43,6 +43,8 @@ class TypeDecl : public NamedDecl {
                 name) {
 
   }
+  TypeDecl(AstTag tag, Deserializer& des)
+    : NamedDecl(tag, des) { }
 
   bool typeDeclContentsMatchInner(const TypeDecl* other) const {
     return namedDeclContentsMatchInner(other);
@@ -54,6 +56,10 @@ class TypeDecl : public NamedDecl {
 
  public:
   virtual ~TypeDecl() = 0; // this is an abstract base class
+
+  void serializePart(Serializer& ser) const {
+    NamedDecl::serializePart(ser);
+  }
 };
 
 

--- a/frontend/include/chpl/uast/TypeQuery.h
+++ b/frontend/include/chpl/uast/TypeQuery.h
@@ -57,6 +57,9 @@ class TypeQuery final : public NamedDecl {
     assert(!name.isEmpty() && name.c_str()[0] != '?');
   }
 
+  TypeQuery(Deserializer& des)
+    : NamedDecl(asttags::TypeQuery, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const TypeQuery* lhs = this;
     const TypeQuery* rhs = (const TypeQuery*) other;
@@ -72,6 +75,12 @@ class TypeQuery final : public NamedDecl {
 
   static owned<TypeQuery> build(Builder* builder, Location loc,
                                 UniqueString name);
+
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(TypeQuery);
 };
 
 

--- a/frontend/include/chpl/uast/UintLiteral.h
+++ b/frontend/include/chpl/uast/UintLiteral.h
@@ -38,6 +38,10 @@ class UintLiteral final : public NumericLiteral<uint64_t, types::UintParam> {
     : NumericLiteral(asttags::UintLiteral, value, text)
   { }
 
+  UintLiteral(Deserializer& des)
+    : NumericLiteral(asttags::UintLiteral, des)
+  { }
+
   // contentsMatchInner / markUniqueStringsInner are in NumericLiteral
   // and would need to be defined here if any fields are added.
 
@@ -46,6 +50,12 @@ class UintLiteral final : public NumericLiteral<uint64_t, types::UintParam> {
 
   static owned<UintLiteral> build(Builder* builder, Location loc,
                                   uint64_t value, UniqueString text);
+
+  void serialize(Serializer& ser) const override {
+    NumericLiteral::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(UintLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Union.h
+++ b/frontend/include/chpl/uast/Union.h
@@ -63,6 +63,10 @@ class Union final : public AggregateDecl {
     assert(linkage != Decl::EXPORT);
   }
 
+  Union(Deserializer& des)
+    : AggregateDecl(asttags::Union, des) { }
+
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Union* lhs = this;
     const Union* rhs = (const Union*) other;
@@ -83,6 +87,13 @@ class Union final : public AggregateDecl {
                             owned<AstNode> linkageName,
                             UniqueString name,
                             AstList contents);
+
+  void serialize(Serializer& ser) const override {
+    AggregateDecl::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Union);
+
 };
 
 

--- a/frontend/include/chpl/uast/Use.h
+++ b/frontend/include/chpl/uast/Use.h
@@ -65,6 +65,10 @@ class Use final : public AstNode {
     #endif
   }
 
+  Use(Deserializer& des) : AstNode(asttags::Use, des) {
+    visibility_ = des.read<Decl::Visibility>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Use* rhs = other->toUse();
     return this->visibility_ == rhs->visibility_;
@@ -114,6 +118,13 @@ class Use final : public AstNode {
     assert(ret->isVisibilityClause());
     return (const VisibilityClause*)ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(visibility_);
+  }
+
+  DECLARE_STATIC_DES(Use);
 
 };
 

--- a/frontend/include/chpl/uast/VarArgFormal.h
+++ b/frontend/include/chpl/uast/VarArgFormal.h
@@ -64,6 +64,11 @@ class VarArgFormal final : public VarLikeDecl {
       countChildNum_(countChildNum) {
   }
 
+  VarArgFormal(Deserializer& des)
+    : VarLikeDecl(asttags::VarArgFormal, des) {
+      countChildNum_ = des.read<int>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const VarArgFormal* lhs = this;
     const VarArgFormal* rhs = (const VarArgFormal*) other;
@@ -105,6 +110,13 @@ class VarArgFormal final : public VarLikeDecl {
     auto ret = child(countChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serializePart(ser);
+    ser(countChildNum_);
+  }
+
+  DECLARE_STATIC_DES(VarArgFormal);
 
 };
 

--- a/frontend/include/chpl/uast/VarLikeDecl.h
+++ b/frontend/include/chpl/uast/VarLikeDecl.h
@@ -64,6 +64,14 @@ class VarLikeDecl : public NamedDecl {
     }
   }
 
+  VarLikeDecl(AstTag tag, Deserializer& des)
+    : NamedDecl(tag, des) {
+    storageKind_ = des.read<IntentList>();
+    typeExpressionChildNum_ = des.read<int8_t>();
+    initExpressionChildNum_ = des.read<int8_t>();
+  }
+
+
   bool varLikeDeclContentsMatchInner(const AstNode* other) const {
     const VarLikeDecl* lhs = this;
     const VarLikeDecl* rhs = (const VarLikeDecl*) other;
@@ -114,10 +122,18 @@ class VarLikeDecl : public NamedDecl {
       return nullptr;
     }
   }
+
+  void serializePart(Serializer& ser) const {
+    NamedDecl::serializePart(ser);
+    ser(storageKind_);
+    ser(typeExpressionChildNum_);
+    ser(initExpressionChildNum_);
+  }
 };
 
 
 } // end namespace uast
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/Variable.h
+++ b/frontend/include/chpl/uast/Variable.h
@@ -85,6 +85,12 @@ class Variable final : public VarLikeDecl {
         isField_(isField) {
   }
 
+  Variable(Deserializer& des)
+    : VarLikeDecl(asttags::Variable, des) {
+    isConfig_ = des.read<bool>();
+    isField_ = des.read<bool>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Variable* lhs = this;
     const Variable* rhs = (const Variable*) other;
@@ -135,10 +141,21 @@ class Variable final : public VarLikeDecl {
   */
   bool isField() const { return this->isField_; }
 
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serializePart(ser);
+    ser(isConfig_);
+    ser(isField_);
+  }
+
+  DECLARE_STATIC_DES(Variable);
+
 };
 
 
 } // end namespace uast
+
+DECLARE_SERDE_ENUM(uast::Variable::Kind, uint8_t);
+
 } // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/uast/VisibilityClause.h
+++ b/frontend/include/chpl/uast/VisibilityClause.h
@@ -79,6 +79,12 @@ class VisibilityClause final : public AstNode {
     }
   }
 
+  VisibilityClause(Deserializer& des)
+    : AstNode(asttags::VisibilityClause, des) {
+    limitationKind_ = des.read<LimitationKind>();
+    numLimitations_ = (int)des.read<int32_t>();
+  }
+
   // No need to check 'symbolChildNum_' or 'limitationChildNum_'.
   bool contentsMatchInner(const AstNode* other) const override {
     const VisibilityClause* rhs = other->toVisibilityClause();
@@ -160,6 +166,14 @@ class VisibilityClause final : public AstNode {
     return ast;
   }
 
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+    ser(limitationKind_);
+    ser.write<int32_t>(numLimitations_);
+  }
+
+  DECLARE_STATIC_DES(VisibilityClause);
+
 };
 
 
@@ -196,6 +210,8 @@ struct mark<uast::VisibilityClause::LimitationKind> {
     // No need to mark enums
   }
 };
+
+DECLARE_SERDE_ENUM(uast::VisibilityClause::LimitationKind, uint8_t);
 
 /// \endcond
 

--- a/frontend/include/chpl/uast/When.h
+++ b/frontend/include/chpl/uast/When.h
@@ -44,6 +44,11 @@ class When final : public SimpleBlockLike {
       numCaseExprs_(numCaseExprs) {
   }
 
+  When(Deserializer& des)
+    : SimpleBlockLike(asttags::When, des) {
+      numCaseExprs_ = des.read<int>();
+    }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const When* rhs = other->toWhen();
     return this->numCaseExprs_ == rhs->numCaseExprs_ &&
@@ -102,6 +107,13 @@ class When final : public SimpleBlockLike {
   bool isOtherwise() const {
     return numCaseExprs_ == 0;
   }
+
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serializePart(ser);
+    ser(numCaseExprs_);
+  }
+
+  DECLARE_STATIC_DES(When);
 
 };
 

--- a/frontend/include/chpl/uast/While.h
+++ b/frontend/include/chpl/uast/While.h
@@ -55,6 +55,11 @@ class While final : public Loop {
     assert(condition());
   }
 
+  While(Deserializer& des)
+    : Loop(asttags::While, des) {
+    conditionChildNum_ = des.read<int8_t>();
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const While* lhs = this;
     const While* rhs = (const While*) other;
@@ -93,6 +98,13 @@ class While final : public Loop {
     auto ret = child(conditionChildNum_);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    Loop::serializePart(ser);
+    ser(conditionChildNum_);
+  }
+
+  DECLARE_STATIC_DES(While);
 
 };
 

--- a/frontend/include/chpl/uast/WithClause.h
+++ b/frontend/include/chpl/uast/WithClause.h
@@ -49,6 +49,9 @@ class WithClause final : public AstNode {
     : AstNode(asttags::WithClause, std::move(exprs)) {
   }
 
+  WithClause(Deserializer& des)
+    : AstNode(asttags::WithClause, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -86,6 +89,13 @@ class WithClause final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(WithClause);
+
 };
 
 

--- a/frontend/include/chpl/uast/Yield.h
+++ b/frontend/include/chpl/uast/Yield.h
@@ -48,6 +48,10 @@ class Yield final : public AstNode {
     assert(children_.size() == 1);
   }
 
+  Yield(Deserializer& des)
+    : AstNode(asttags::Yield, des) {
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     // The 'valueChildNum_' is const and does not need to be compared.
     return true;
@@ -76,6 +80,12 @@ class Yield final : public AstNode {
     assert(ret);
     return ret;
   }
+
+  void serialize(Serializer& ser) const override {
+    AstNode::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Yield);
 
 };
 

--- a/frontend/include/chpl/uast/Zip.h
+++ b/frontend/include/chpl/uast/Zip.h
@@ -37,6 +37,9 @@ class Zip final : public Call {
            /*hasCalledExpression*/ false) {
   }
 
+  Zip(Deserializer& des)
+    : Call(asttags::Zip, des) { }
+
   bool contentsMatchInner(const AstNode* other) const override {
     return callContentsMatchInner(other->toCall());
   }
@@ -52,6 +55,12 @@ class Zip final : public Call {
     Create and return a zip expression.
   */
   static owned<Zip> build(Builder* builder, Location loc, AstList actuals);
+
+  void serialize(Serializer& ser) const override {
+    Call::serializePart(ser);
+  }
+
+  DECLARE_STATIC_DES(Zip);
 
 };
 

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -366,6 +366,27 @@ void Param::stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
 
 }
 
+void Param::serialize(Serializer& ser) const {
+  ser(tag_);
+}
+
+const Param* Param::deserializeFromFile(Deserializer& des) {
+  ParamTag tag = des.read<ParamTag>();
+
+  switch (tag) {
+#define PARAM_NODE(NAME, VALTYPE) \
+    case paramtags::NAME: { \
+      return NAME::deserialize(des); \
+      break; \
+    }
+#include "chpl/types/param-classes-list.h"
+#undef PARAM_NODE
+  }
+
+  assert(false);
+  return nullptr;
+}
+
 uint64_t Param::binStr2uint64(const char* str, size_t len, std::string& err) {
   if (str == nullptr ||
       !(str[0] == '0' && (str[1] == 'b' || str[1] == 'B')) ||

--- a/frontend/lib/uast/BuilderResult.cpp
+++ b/frontend/lib/uast/BuilderResult.cpp
@@ -272,7 +272,7 @@ AstList BuilderResult::deserializeFromFile(Context* context, std::istream& is) {
 
 bool BuilderResult::compare(const AstList& other) const {
   const int n = numTopLevelExpressions();
-  if (other.size() != n) {
+  if (other.size() != (size_t)n) {
     return false;
   }
   for (int i = 0; i < n; i++) {


### PR DESCRIPTION
This PR implements the serialize/deserialize methods for the remaining uAST nodes.

So far, the only testing has been that `hello.chpl` compiles without errors with `--dyno-serialize`.



TESTING:

- [ ] paratest
