### PR TITLE
Add a suppressif for a test that fails on cygwin64

### DIFF
--- a/test/library/standard/FileSystem/nonUTF8/basic.suppressif
+++ b/test/library/standard/FileSystem/nonUTF8/basic.suppressif
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Fails when run in the nightly test directory for cygwin64, see issue #4097
+
+if test "$OS" = Windows_NT; then
+  echo 1
+else
+  echo 0
+fi


### PR DESCRIPTION
This test fails in a way we suspect is related to issue https://github.com/Cray/chapel-private/issues/4097. Suppress the failure for Windows testing.