### PR TITLE
Don't include comm-ofi-internal.h when building the launcher

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-locales.c
+++ b/runtime/src/comm/ofi/comm-ofi-locales.c
@@ -23,7 +23,10 @@
 #include "chpl-comm-locales.h"
 #include "error.h"
 #include "chpl-comm.h"
+
+#ifndef LAUNCHER
 #include "comm-ofi-internal.h"
+#endif
 
 int64_t chpl_comm_default_num_locales(void) {
   return chpl_specify_locales_error();

--- a/runtime/src/comm/ofi/comm-ofi-locales.c
+++ b/runtime/src/comm/ofi/comm-ofi-locales.c
@@ -22,9 +22,9 @@
 #include "arg.h"
 #include "chpl-comm-locales.h"
 #include "error.h"
-#include "chpl-comm.h"
 
 #ifndef LAUNCHER
+#include "chpl-comm.h"
 #include "comm-ofi-internal.h"
 #endif
 


### PR DESCRIPTION
The launcher is built with the host compiler and `comm-ofi-internal.h` includes headers that might not be available, e.g., `rdma/fabric.h`. The fix is to not include `comm-ofi-internal.h` when building the launcher.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>