### PR TITLE
dyno: fill in details to call init, deinit, etc

### DIFF
--- a/frontend/include/chpl/framework/UniqueString-detail.h
+++ b/frontend/include/chpl/framework/UniqueString-detail.h
@@ -199,6 +199,16 @@ struct InlinedString {
     return std::string(c_str(), length());
   }
 
+  bool isEmpty() const {
+    if (isInline()) {
+      return c_str()[0] == '\0';
+    }
+
+    // otherwise, the pointed-to string should not be empty
+    assert(length() > 0);
+    return false;
+  }
+
   // mark the string as used this revision (so it is not GC'd)
   void mark(Context* context) const;
 };
@@ -253,7 +263,7 @@ struct PODUniqueString {
   }
 
   bool isEmpty() const {
-    return i.c_str()[0] == '\0';
+    return i.isEmpty();
   }
   inline bool operator==(const PODUniqueString other) const {
     return this->i.v == other.i.v;

--- a/frontend/include/chpl/framework/UniqueString-detail.h
+++ b/frontend/include/chpl/framework/UniqueString-detail.h
@@ -205,7 +205,7 @@ struct InlinedString {
     }
 
     // otherwise, the pointed-to string should not be empty
-    assert(length() > 0);
+    CHPL_ASSERT(length() > 0);
     return false;
   }
 

--- a/frontend/include/chpl/framework/UniqueString.h
+++ b/frontend/include/chpl/framework/UniqueString.h
@@ -147,7 +147,7 @@ class UniqueString final {
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
   bool isEmpty() const {
-    return s.i.c_str()[0] == '\0';
+    return s.isEmpty();
   }
 
   detail::PODUniqueString podUniqueString() const {

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -270,6 +270,12 @@ uast::AstTag idToTag(Context* context, ID id);
 bool idIsParenlessFunction(Context* context, ID id);
 
 /**
+ If the ID represents a field in a record/class/union, returns
+ the name of that field. Otherwise, returns the empty string.
+ */
+UniqueString fieldIdToName(Context* context, ID id);
+
+/**
  Returns true if the ID is a field in a record/class/union.
  */
 bool idIsField(Context* context, ID id);

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -183,10 +183,10 @@ CanPassResult canPass(Context* context,
 using KindRequirement = llvm::Optional<chpl::types::QualifiedType::Kind>;
 
 /**
-  Given a (non-empty) list of types (e.g., the types of various return statements
-  in a function), determine the type, if any, that can be used to represent
-  all of them. Returns an llvm::Optional that contains the qualified type
-  if one is found, or is empty otherwise.
+  Given a (non-empty) list of types (e.g., the types of various return
+  statements in a function), determine the type, if any, that can be used to
+  represent all of them. Returns an llvm::Optional that contains the qualified
+  type if one is found, or is empty otherwise.
 
   If useRequiredKind=true is specified, the requiredKind argument is treated
   as a strict constraint on the kinds of the given types. For instance,

--- a/frontend/include/chpl/resolution/copy-elision.h
+++ b/frontend/include/chpl/resolution/copy-elision.h
@@ -35,8 +35,8 @@ namespace resolution {
        the ID of the initialized variable is stored in the set.
      * If the elided initialization point is an '=' call,
        the ID of the OpCall is stored in the set.
-     * If the elided initialization point is an actual passed by 'in' intent,
-       the ID of the actual is stored in the set.
+     * If the elided initialization point is an actual passed by 'in'
+       intent, the ID of the actual is stored in the set.
    Does not consider copy elision that only work with temporary
    variables (e.g. acceptsWithIn(returnsByValue())).
 

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -257,7 +257,13 @@ const types::QualifiedType& returnType(Context* context,
   Compute the types for any generic 'out' formal types after instantiation
   of any other generic arguments.
 
-  The 'out' formal types are inferred from the body of the function.
+  'out' formals with concrete type will already have their types
+  represented in the 'sig' passed here (through typedSignatureInitial and
+  potentially instantiateSignature).
+
+  For the generic 'out' formals, their types are inferred from the
+  body of the function.
+
   The returned TypedFnSignature* will have the inferred out formal types.
  */
 const TypedFnSignature* inferOutFormals(Context* context,

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -253,6 +253,17 @@ const types::QualifiedType& returnType(Context* context,
                                        const TypedFnSignature* sig,
                                        const PoiScope* poiScope);
 
+/**
+  Compute the types for any generic 'out' formal types after instantiation
+  of any other generic arguments.
+
+  The 'out' formal types are inferred from the body of the function.
+  The returned TypedFnSignature* will have the inferred out formal types.
+ */
+const TypedFnSignature* inferOutFormals(Context* context,
+                                        const TypedFnSignature* sig,
+                                        const PoiScope* poiScope);
+
 /////// call resolution
 
 /**

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -950,6 +950,12 @@ class MostSpecificCandidates {
       context->markPointer(sig);
     }
   }
+
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /** CallResolutionResult */
@@ -999,6 +1005,12 @@ class CallResolutionResult {
     exprType_.swap(other.exprType_);
     poiInfo_.swap(other.poiInfo_);
   }
+
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 class ResolvedParamLoop;

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -758,7 +758,7 @@ class TypedFnSignature {
     const TypedFnSignature* ret = this;
     if (ret->isRefinementOnly_) {
       ret = ret->instantiatedFrom_;
-      assert(!ret->isRefinementOnly_);
+      CHPL_ASSERT(!ret->isRefinementOnly_);
     }
     return ret;
   }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -313,7 +313,7 @@ class CallInfoActual {
 
  public:
   CallInfoActual(types::QualifiedType type, UniqueString byName)
-      : type_(type), byName_(byName) {}
+      : type_(std::move(type)), byName_(byName) {}
 
   /** return the qualified type */
   const types::QualifiedType& type() const { return type_; }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -351,6 +351,8 @@ class CallInfo {
   bool isOpCall_ = false;               // is an operator call
   bool hasQuestionArg_ = false;         // includes ? arg for type constructor
   bool isParenless_ = false;            // is a parenless call
+
+  // Performance TODO: use SmallVector here?
   std::vector<CallInfoActual> actuals_; // types/params/names of actuals
 
  public:
@@ -1037,6 +1039,10 @@ class ResolvedExpression {
   const PoiScope *poiScope_ = nullptr;
 
   // functions associated with or used to implement this expression
+  // TODO: change to associatedActions
+  //   * with action (an enum)
+  //   * with ID (for e.g. a var or tmp deinit)
+  //   * with TypedFnSignature
   std::vector<const TypedFnSignature*> associatedFns_;
 
   const ResolvedParamLoop* paramLoop_ = nullptr;

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1112,6 +1112,8 @@ class AssociatedAction {
   }
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  static const char* kindToString(Action a);
 };
 
 /**

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -754,6 +754,10 @@ class TypedFnSignature {
     return formalsInstantiated_[i];
   }
 
+  const Bitmap& formalsInstantiatedBitmap() const {
+    return formalsInstantiated_;
+  }
+
   /**
      Is this for an inner Function? If so, what is the parent
      function signature?
@@ -839,6 +843,12 @@ class MostSpecificCandidates {
     ret.emptyDueToAmbiguity = true;
     return ret;
   }
+
+  /**
+    Adjust each candidate signature by inferring generic 'out' intent formals
+    if there are any.
+   */
+  void inferOutFormals(Context* context, const PoiScope* poiScope);
 
   const TypedFnSignature* const* begin() const {
     return &candidates[0];

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1137,11 +1137,8 @@ class ResolvedExpression {
   // resolving functions in mostSpecific?
   const PoiScope *poiScope_ = nullptr;
 
-  // functions associated with or used to implement this expression
-  // TODO: change to associatedActions
-  //   * with action (an enum)
-  //   * with ID (for e.g. a var or tmp deinit)
-  //   * with TypedFnSignature
+  // actions associated with this expression
+  // (e.g. default init, copy init, deinit)
   std::vector<AssociatedAction> associatedActions_;
 
   const ResolvedParamLoop* paramLoop_ = nullptr;

--- a/frontend/include/chpl/types/QualifiedType.h
+++ b/frontend/include/chpl/types/QualifiedType.h
@@ -199,6 +199,16 @@ class QualifiedType final {
            kind_ == Kind::MODULE;
   }
 
+  /**
+    Returns true if the kind is one of the non-concrete intents
+    (unknown, default intent, or const intent) and false otherwise.
+   */
+  bool isNonConcreteIntent() const {
+    return (kind_ == Kind::UNKNOWN ||
+            kind_ == Kind::DEFAULT_INTENT ||
+            kind_ == Kind::CONST_INTENT);
+  }
+
   bool operator==(const QualifiedType& other) const {
     return kind_ == other.kind_ &&
            type_ == other.type_ &&

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -650,19 +650,28 @@ bool idIsParenlessFunction(Context* context, ID id) {
   return idIsParenlessFunctionQuery(context, id);
 }
 
-static const bool& idIsFieldQuery(Context* context, ID id) {
-  QUERY_BEGIN(idIsFieldQuery, context, id);
+static const UniqueString& fieldIdToNameQuery(Context* context, ID id) {
+  QUERY_BEGIN(fieldIdToNameQuery, context, id);
 
-  bool result = false;
-  if (auto ast = astForIDQuery(context, id))
-    if (auto var = ast->toVariable())
-      result = var->isField();
+  UniqueString result;
+  if (auto ast = astForIDQuery(context, id)) {
+    if (auto var = ast->toVariable()) {
+      if (var->isField()) {
+        result = var->name();
+      }
+    }
+  }
 
   return QUERY_END(result);
 }
 
+UniqueString fieldIdToName(Context* context, ID id) {
+  return fieldIdToNameQuery(context, id);
+}
+
 bool idIsField(Context* context, ID id) {
-  return idIsFieldQuery(context, id);
+  UniqueString name = fieldIdToName(context, id);
+  return !name.isEmpty();
 }
 
 const ID& idToParentId(Context* context, ID id) {

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -217,7 +217,7 @@ InitResolver::computeTypedSignature(const Type* newRecvType) {
 
   ret = TypedFnSignature::get(ctx_, ufs, formalTypes,
                               tfs->whereClauseResult(),
-                              false,
+                              /* needsInstantiation */ false,
                               tfs->instantiatedFrom(),
                               tfs->parentFn(),
                               formalsInstantiated);

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -288,7 +288,9 @@ struct Resolver {
   void handleResolvedAssociatedCall(ResolvedExpression& r,
                                     const uast::AstNode* astForErr,
                                     const CallInfo& ci,
-                                    const CallResolutionResult& c);
+                                    const CallResolutionResult& c,
+                                    AssociatedAction::Action action,
+                                    ID id);
 
   // If the variable with the passed ID has unknown or generic type,
   // and it has not yet been initialized, set its type to rhsType.

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -465,7 +465,7 @@ computeActualFormalIntents(Context* context,
 
   int nFns = candidates.numBest();
   if (nFns == 0) {
-    // return early if there are no actual candidates
+    // return early if there are no candidates
     return;
   }
 

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -93,15 +93,15 @@ class VarScopeVisitor {
   /** Called to process a Conditional after handling its contents --
       should update currentFrame() which is the frame for the Conditional.
       The then/else frames are sitting in currentFrame().subBlocks. */
-  virtual void handleConditional(const uast::Conditional* cond) = 0;
+  virtual void handleConditional(const uast::Conditional* cond, RV& rv) = 0;
   /** Called to process a Try after handling its contents --
       should update currentFrame() which is the frame for the Try.
       The catch clause frames are sitting in currentFrame().subBlocks. */
-  virtual void handleTry(const uast::Try* t) = 0;
+  virtual void handleTry(const uast::Try* t, RV& rv) = 0;
   /** Called to process any other Scope after handling its contents --
       should update scopeStack.back() which is the frame for the Try.
       Not called for Conditional or Try. */
-  virtual void handleScope(const uast::AstNode* ast) = 0;
+  virtual void handleScope(const uast::AstNode* ast, RV& rv) = 0;
 
 
   // ----- methods for use by specific analysis subclasses
@@ -171,8 +171,8 @@ class VarScopeVisitor {
 
  public:
   // ----- visitor implementation
-  void enterScope(const uast::AstNode* ast);
-  void exitScope(const uast::AstNode* ast);
+  void enterScope(const uast::AstNode* ast, RV& rv);
+  void exitScope(const uast::AstNode* ast, RV& rv);
 
   bool enter(const VarLikeDecl* ast, RV& rv);
   void exit(const VarLikeDecl* ast, RV& rv);
@@ -215,7 +215,7 @@ struct CopyElisionState {
     Keeping them declared here keeps things simple. */
 struct VarFrame {
   // ----- variables used by VarScopeVisitor
-  const AstNode* scopeAst = nullptr; // for debugging
+  const AstNode* scopeAst = nullptr;
 
   // Which variables are declared in this scope?
   // For split init, only variables without init expressions.

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -257,7 +257,9 @@ struct VarFrame {
   // order to create a single stack for cleanup operations to be executed.
   // In particular, the ordering between defer blocks and locals matters,
   // in addition to the ordering within each group.
-  std::vector<const AstNode*> localsAndDefers;
+  // It stores variables in initialization order. It does not store
+  // declared but not-yet-initialized variables.
+  std::vector<ID> localsAndDefers;
 
   // Which outer variables have been initialized in this scope?
   // This vector lists them in initialization order.

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -193,12 +193,6 @@ void CallInitDeinit::processDeinitsAndPropagate(VarFrame* frame,
 
 void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
 
-  /*auto formal = ast->toFormal();
-  if (formal != nullptr && formal->intent() != Formal::OUT) {
-    // don't try to default init formal values unless they are 'out'.
-    return;
-  }*/
-
   ResolvedExpression& varRes = rv.byAst(ast);
   QualifiedType varType = varRes.type();
 
@@ -296,7 +290,9 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
     auto c = resolveGeneratedCall(context, ast, ci, scope,
                                   resolver.poiScope);
     ResolvedExpression& opR = rv.byAst(ast);
-    resolver.handleResolvedAssociatedCall(opR, ast, ci, c);
+    resolver.handleResolvedAssociatedCall(opR, ast, ci, c,
+                                          AssociatedAction::DEFAULT_INIT,
+                                          ast->id());
   }
 }
 
@@ -317,7 +313,9 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
   auto c = resolveGeneratedCall(context, ast, ci, scope,
                                 resolver.poiScope);
   ResolvedExpression& opR = rv.byAst(ast);
-  resolver.handleResolvedAssociatedCall(opR, ast, ci, c);
+  resolver.handleResolvedAssociatedCall(opR, ast, ci, c,
+                                        AssociatedAction::ASSIGN,
+                                        ast->id());
 }
 
 void CallInitDeinit::resolveCopyInit(const AstNode* ast,
@@ -337,7 +335,8 @@ void CallInitDeinit::resolveCopyInit(const AstNode* ast,
   auto c = resolveGeneratedCall(context, ast, ci, scope,
                                 resolver.poiScope);
   ResolvedExpression& opR = rv.byAst(ast);
-  resolver.handleResolvedAssociatedCall(opR, ast, ci, c);
+  resolver.handleResolvedAssociatedCall(opR, ast, ci, c,
+                                        AssociatedAction::COPY_INIT, ast->id());
 }
 
 static bool isValue(QualifiedType::Kind kind) {
@@ -401,7 +400,8 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
   auto c = resolveGeneratedCall(context, ast, ci, scope,
                                 resolver.poiScope);
   ResolvedExpression& opR = rv.byAst(ast);
-  resolver.handleResolvedAssociatedCall(opR, ast, ci, c);
+  resolver.handleResolvedAssociatedCall(opR, ast, ci, c,
+                                        AssociatedAction::DEINIT, ast->id());
 }
 
 void CallInitDeinit::handleDeclaration(const VarLikeDecl* ast, RV& rv) {

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -139,10 +139,13 @@ void CallInitDeinit::processDeinitsAndPropagate(VarFrame* frame,
   for (ssize_t i = n - 1; i >= 0; i--) {
     ID varOrDeferId = frame->localsAndDefers[i]; 
 
-    ResolvedExpression& re = rv.byId(varOrDeferId);
-    QualifiedType type = re.type();
+    // don't deinit it if it was already destroyed by moving from it
+    if (frame->deinitedVars.count(varOrDeferId) == 0) {
+      ResolvedExpression& re = rv.byId(varOrDeferId);
+      QualifiedType type = re.type();
 
-    resolveDeinit(frame->scopeAst, varOrDeferId, type, rv);
+      resolveDeinit(frame->scopeAst, varOrDeferId, type, rv);
+    }
   }
 
   if (parent != nullptr) {
@@ -152,7 +155,7 @@ void CallInitDeinit::processDeinitsAndPropagate(VarFrame* frame,
       }
     }
     for (auto id : frame->deinitedVars) {
-      if (parent->declaredVars.count(id) == 0) {
+      if (frame->declaredVars.count(id) == 0) {
         parent->deinitedVars.insert(id);
       }
     }

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -550,7 +550,12 @@ void callInitDeinit(Resolver& resolver) {
                                                        resolver.byPostorder,
                                                        splitInitedVars);
 
-  printf("\nSplit Init Report:\n");
+  auto symName = UniqueString::get(resolver.context, "unknown");
+  if (auto nd = resolver.symbol->toNamedDecl()) {
+    symName = nd->name();
+  }
+
+  printf("\nSplit Init Report for '%s':\n", symName.c_str());
   for (auto varId : splitInitedVars) {
     auto ast = parsing::idToAst(resolver.context, varId);
     if (ast) {
@@ -562,7 +567,7 @@ void callInitDeinit(Resolver& resolver) {
   }
   printf("\n");
 
-  printf("\nCopy Elision Report:\n");
+  printf("\nCopy Elision Report for '%s':\n", symName.c_str());
   for (auto id : elidedCopyFromIds) {
     printf("  Copy eliding ID %s\n",
            id.str().c_str());

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -109,7 +109,7 @@ struct CallInitDeinit : VarScopeVisitor {
 // localsAndDefers/initedOuterVars vectors.
 // Does not update any sets
 void CallInitDeinit::recordInitializationOrder(VarFrame* frame, ID varId) {
-  assert(!varId.isEmpty()); // caller error
+  CHPL_ASSERT(!varId.isEmpty()); // caller error
   if (frame->declaredVars.count(varId) > 0) {
     // it is declared in the local scope
     frame->localsAndDefers.push_back(varId);
@@ -496,7 +496,7 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
   } else if (splitInited) {
     if (isRef(lhsType.kind())) {
       // e.g. ref x = returnAValue();
-      assert(false && "TODO");
+      CHPL_ASSERT(false && "TODO");
     } else if (elidedCopyFromIds.count(ast->id()) > 0) {
       // it is move initialization
       resolveMoveInit(ast, lhsType, rhsType, rv);
@@ -505,7 +505,7 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
       // so note that in deinitedVars.
       ID rhsId = refersToId(rhsAst, rv);
       // copy elision with '=' should only apply to myVar = myOtherVar
-      assert(!rhsId.isEmpty());
+      CHPL_ASSERT(!rhsId.isEmpty());
       frame->deinitedVars.insert(rhsId);
     } else if (rhsRe.toId().isEmpty() && !isRef(rhsType.kind())) {
       // e.g. var x; x = callReturningValue();
@@ -570,7 +570,7 @@ void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
     // so note that in deinitedVars.
     ID actualId = refersToId(actual, rv);
     // copy elision should only apply to copies from variables
-    assert(!actualId.isEmpty());
+    CHPL_ASSERT(!actualId.isEmpty());
     frame->deinitedVars.insert(actualId);
   }
 }

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -74,9 +74,9 @@ struct FindElidedCopies : VarScopeVisitor {
                          RV& rv) override;
 
   void handleReturnOrThrow(const uast::AstNode* ast, RV& rv) override;
-  void handleConditional(const Conditional* cond) override;
-  void handleTry(const Try* t) override;
-  void handleScope(const AstNode* ast) override;
+  void handleConditional(const Conditional* cond, RV& rv) override;
+  void handleTry(const Try* t, RV& rv) override;
+  void handleScope(const AstNode* ast, RV& rv) override;
 };
 
 static bool kindAllowsCopyElision(IntentList kind) {
@@ -275,7 +275,7 @@ void FindElidedCopies::handleReturnOrThrow(const uast::AstNode* ast, RV& rv) {
   saveElidedCopies(frame);
 }
 
-void FindElidedCopies::handleConditional(const Conditional* cond) {
+void FindElidedCopies::handleConditional(const Conditional* cond, RV& rv) {
   VarFrame* frame = currentFrame();
   VarFrame* thenFrame = currentThenFrame();
   VarFrame* elseFrame = currentElseFrame();
@@ -364,10 +364,10 @@ void FindElidedCopies::handleConditional(const Conditional* cond) {
   }
 
   // now that the current frame is updated, propagate to the parent
-  handleScope(cond);
+  handleScope(cond, rv);
 }
 
-void FindElidedCopies::handleTry(const Try* t) {
+void FindElidedCopies::handleTry(const Try* t, RV& rv) {
 
   VarFrame* tryFrame = currentFrame();
 
@@ -375,7 +375,7 @@ void FindElidedCopies::handleTry(const Try* t) {
   // if there are no catch clauses, treat it like any other scope
   if (nCatchFrames == 0) {
     // will handle variables local to the try
-    handleScope(t);
+    handleScope(t, rv);
     return;
   }
 
@@ -420,7 +420,7 @@ void FindElidedCopies::handleTry(const Try* t) {
 
   tryFrame->copyElisionState.swap(updatedState);
 
-  handleScope(t);
+  handleScope(t, rv);
 }
 
 static bool allowsCopyElision(const AstNode* ast) {
@@ -431,7 +431,7 @@ static bool allowsCopyElision(const AstNode* ast) {
          ast->isTry();
 }
 
-void FindElidedCopies::handleScope(const AstNode* ast) {
+void FindElidedCopies::handleScope(const AstNode* ast, RV& rv) {
   VarFrame* frame = currentFrame();
   VarFrame* parent = currentParentFrame();
 

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -829,30 +829,35 @@ void CallResolutionResult::stringify(std::ostream& ss,
 }
 
 
-void AssociatedAction::stringify(std::ostream& ss,
-                                 chpl::StringifyKind stringKind) const {
-  const char* kind = "<unknown>";
-  switch (action_) {
+const char* AssociatedAction::kindToString(Action a) {
+  const char* s = "<unknown>";
+  switch (a) {
     case ASSIGN:
-      kind = "assign";
+      s = "assign";
       break;
     case COPY_INIT:
-      kind = "copy-init";
+      s = "copy-init";
       break;
     case DEFAULT_INIT:
-      kind = "default-init";
+      s = "default-init";
       break;
     case DEINIT:
-      kind = "deinit";
+      s = "deinit";
       break;
     case ITERATE:
-      kind = "these";
+      s = "these";
       break;
     case NEW_INIT:
-      kind = "new-init";
+      s = "new-init";
       break;
   }
 
+  return s;
+}
+
+void AssociatedAction::stringify(std::ostream& ss,
+                                 chpl::StringifyKind stringKind) const {
+  const char* kind = AssociatedAction::kindToString(action_);
 
   ss << "assoc " << kind;
   if (fn_ != nullptr) {

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -499,6 +499,13 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
           qt = tup->elementType(j);
         }
 
+        // if the formal has concrete intent (e.g. 'out' or 'in' or 'ref'),
+        // use the intent of the formal for the intent of the actual->formal
+        // mapping entry.
+        if (!formalQT.isNonConcreteIntent()) {
+          qt = QualifiedType(formalQT.kind(), qt.type(), qt.param());
+        }
+
         entry.formal_ = decl;
         entry.hasActual_ = false;
         entry.formalIdx_ = i;

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -761,6 +761,16 @@ bool PoiInfo::canReuse(const PoiInfo& check) const {
   return false; // TODO -- consider function names etc -- see PR #16261
 }
 
+void MostSpecificCandidates::inferOutFormals(Context* context,
+                                             const PoiScope* poiScope) {
+  for (int i = 0; i < NUM_INTENTS; i++) {
+    const TypedFnSignature*& c = candidates[i];
+    if (c != nullptr) {
+      c = chpl::resolution::inferOutFormals(context, c, poiScope);
+    }
+  }
+}
+
 void MostSpecificCandidates::stringify(std::ostream& ss,
                                        chpl::StringifyKind stringKind) const {
   auto onlyFn = only();

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -829,6 +829,42 @@ void CallResolutionResult::stringify(std::ostream& ss,
 }
 
 
+void AssociatedAction::stringify(std::ostream& ss,
+                                 chpl::StringifyKind stringKind) const {
+  const char* kind = "<unknown>";
+  switch (action_) {
+    case ASSIGN:
+      kind = "assign";
+      break;
+    case COPY_INIT:
+      kind = "copy-init";
+      break;
+    case DEFAULT_INIT:
+      kind = "default-init";
+      break;
+    case DEINIT:
+      kind = "deinit";
+      break;
+    case ITERATE:
+      kind = "these";
+      break;
+    case NEW_INIT:
+      kind = "new-init";
+      break;
+  }
+
+
+  ss << "assoc " << kind;
+  if (fn_ != nullptr) {
+    ss << " fn=";
+    fn_->stringify(ss, stringKind);
+  }
+  if (!id_.isEmpty()) {
+    ss << " id=";
+    id_.stringify(ss, stringKind);
+  }
+}
+
 void ResolvedExpression::stringify(std::ostream& ss,
                                    chpl::StringifyKind stringKind) const {
   ss << " : ";
@@ -841,11 +877,8 @@ void ResolvedExpression::stringify(std::ostream& ss,
     mostSpecific_.stringify(ss, stringKind);
   }
 
-  for (auto sig : associatedFns_) {
-    if (sig != nullptr) {
-      ss << " assoc ";
-      sig->stringify(ss, stringKind);
-    }
+  for (auto a : associatedActions_) {
+    a.stringify(ss, stringKind);
   }
 }
 

--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -63,9 +63,9 @@ struct FindSplitInits : VarScopeVisitor {
                          RV& rv) override;
 
   void handleReturnOrThrow(const uast::AstNode* ast, RV& rv) override;
-  void handleConditional(const Conditional* cond) override;
-  void handleTry(const Try* t) override;
-  void handleScope(const AstNode* ast) override;
+  void handleConditional(const Conditional* cond, RV& rv) override;
+  void handleTry(const Try* t, RV& rv) override;
+  void handleScope(const AstNode* ast, RV& rv) override;
 };
 
 struct SplitInitVarStatus {
@@ -209,7 +209,7 @@ void FindSplitInits::handleReturnOrThrow(const uast::AstNode* ast, RV& rv) {
 
 // updates the back frame with the combined result from
 // the then/else blocks from the conditional
-void FindSplitInits::handleConditional(const Conditional* cond) {
+void FindSplitInits::handleConditional(const Conditional* cond, RV& rv) {
   VarFrame* frame = currentFrame();
   VarFrame* thenFrame = currentThenFrame();
   VarFrame* elseFrame = currentElseFrame();
@@ -377,15 +377,15 @@ void FindSplitInits::handleConditional(const Conditional* cond) {
     }
   }
 
-  handleScope(cond);
+  handleScope(cond, rv);
 }
 
-void FindSplitInits::handleTry(const Try* t) {
+void FindSplitInits::handleTry(const Try* t, RV& rv) {
   VarFrame* tryFrame = currentFrame();
   int nCatchFrames = currentNumCatchFrames();
   // if there are no catch clauses, treat it like any other scope
   if (nCatchFrames == 0) {
-    handleScope(t);
+    handleScope(t, rv);
     return;
   }
 
@@ -461,7 +461,7 @@ void FindSplitInits::handleTry(const Try* t) {
   tryFrame->initedVarsVec.swap(tryInitedVarsVec);
   tryFrame->mentionedVars.swap(tryMentionedVars);
 
-  handleScope(t);
+  handleScope(t, rv);
 }
 
 static bool allowsSplitInit(const AstNode* ast) {
@@ -472,7 +472,7 @@ static bool allowsSplitInit(const AstNode* ast) {
          ast->isTry();
 }
 
-void FindSplitInits::handleScope(const AstNode* ast) {
+void FindSplitInits::handleScope(const AstNode* ast, RV& rv) {
   VarFrame* frame = currentFrame();
   VarFrame* parent = currentParentFrame();
 

--- a/frontend/test/framework/testUniqueString.cpp
+++ b/frontend/test/framework/testUniqueString.cpp
@@ -226,6 +226,20 @@ static void test1() {
   UniqueString empty;
   assert(empty == UniqueString::get(ctx, ""));
 
+  // check that strings with null bytes are uniqued differently
+  UniqueString h_plus = UniqueString::get(ctx, "hello\0plus", 10);
+  assert(h_plus != h1);
+  assert(h_plus.length() == 10);
+  assert(!h_plus.isEmpty());
+  UniqueString h_p = UniqueString::get(ctx, "hello\0p", 7);
+  assert(h_p != h_plus && h_p != h1);
+  assert(h_p.length() == 7);
+  assert(!h_p.isEmpty());
+  UniqueString z_boo = UniqueString::get(ctx, "\0boo", 4);
+  assert(z_boo.length() == 4);
+  assert(z_boo != empty);
+  assert(!z_boo.isEmpty());
+
   // check that truncation works for short strings and long ones
   assert(h1 == UniqueString::get(ctx, "hello____", strlen("hello")));
   assert(t1 == UniqueString::get(ctx, TEST1STRING "_____",

--- a/frontend/test/resolution/CMakeLists.txt
+++ b/frontend/test/resolution/CMakeLists.txt
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+comp_unit_test(testCallInitDeinit)
 comp_unit_test(testCanPass)
 comp_unit_test(testClasses)
 comp_unit_test(testCopyElision)
@@ -27,8 +28,8 @@ comp_unit_test(testFieldAccess)
 comp_unit_test(testFindDecl)
 comp_unit_test(testFunctionCalls)
 comp_unit_test(testGenericDefaults)
-comp_unit_test(testInteractive)
 comp_unit_test(testInitSemantics)
+comp_unit_test(testInteractive)
 comp_unit_test(testLocation)
 comp_unit_test(testLoopIndexVars)
 comp_unit_test(testMultiDecl)

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test-resolution.h"
+
+#include "chpl/parsing/parsing-queries.h"
+#include "chpl/resolution/resolution-queries.h"
+#include "chpl/resolution/scope-queries.h"
+#include "chpl/resolution/split-init.h"
+#include "chpl/uast/Call.h"
+#include "chpl/uast/Comment.h"
+#include "chpl/uast/Identifier.h"
+#include "chpl/uast/Module.h"
+#include "chpl/uast/Variable.h"
+
+#include "./ErrorGuard.h"
+
+static const bool ERRORS_EXPECTED=true;
+
+using ActionElt = std::tuple<AssociatedAction::Action,
+                             std::string, /* ID where action occurs */
+                             std::string /* ID acted upon or "" */ >;
+using Actions = std::vector<ActionElt>;
+
+static void gatherActions(const AstNode* ast,
+                          const ResolvedFunction* r,
+                          Actions& actions) {
+
+  // gather actions for child nodes
+  for (auto child : ast->children()) {
+    gatherActions(child, r, actions);
+  }
+
+  // gather actions for this node
+  const ResolvedExpression* re = r->resolutionById().byAstOrNull(ast);
+  if (re != nullptr) {
+    for (auto act: re->associatedActions()) {
+      // ignore acted-upon ID expect for DEINIT
+      if (act.action() != AssociatedAction::DEINIT) {
+        actions.push_back(std::make_tuple(act.action(), ast->id().str(), ""));
+      } else {
+        actions.push_back(
+            std::make_tuple(act.action(), ast->id().str(), act.id().str()));
+      }
+    }
+  }
+}
+
+
+static void printAction(const ActionElt& a) {
+  AssociatedAction::Action gotAction;
+  std::string gotInId;
+  std::string gotActId;
+
+  gotAction = std::get<0>(a);
+  gotInId = std::get<1>(a);
+  gotActId = std::get<2>(a);
+
+  printf("  %s %s %s\n",
+         AssociatedAction::kindToString(gotAction),
+         gotInId.c_str(),
+         gotActId.c_str());
+}
+
+static void printActions(const Actions& actions) {
+  for (auto act : actions) {
+    printAction(act);
+  }
+}
+
+// resolves the last function
+// checks that the actions match the passed ones
+static void testActions(const char* test,
+                        const char* program,
+                        Actions expected,
+                        bool expectErrors=false) {
+  printf("### %s\n\n", test);
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string testname = test;
+  testname += ".chpl";
+  auto path = UniqueString::get(context, testname);
+  std::string contents = program;
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+  assert(vec.size() == 1);
+  const Module* M = vec[0]->toModule();
+  assert(M);
+  assert(M->numStmts() >= 1);
+
+  const Function* func = M->stmt(M->numStmts()-1)->toFunction();
+  assert(func);
+
+  printf("uAST:\n");
+  func->dump();
+
+  // resolve runM1
+  const ResolvedFunction* r = resolveConcreteFunction(context, func->id());
+  assert(r);
+
+  Actions actions;
+  gatherActions(func, r, actions);
+
+  printf("Expecting:\n");
+  printActions(expected);
+  printf("Got:\n");
+  printActions(actions);
+  printf("\n");
+
+  size_t i = 0;
+  size_t j = 0;
+  while (i < actions.size() && j < expected.size()) {
+    AssociatedAction::Action gotAction, expectAction;
+    std::string gotInId, expectInId;
+    std::string gotActId, expectActId;
+
+    gotAction = std::get<0>(actions[i]);
+    gotInId = std::get<1>(actions[i]);
+    gotActId = std::get<2>(actions[i]);
+
+    expectAction = std::get<0>(expected[i]);
+    expectInId = std::get<1>(expected[i]);
+    expectActId = std::get<2>(expected[i]);
+
+    if (gotAction != expectAction) {
+      assert(false && "Failure: mismatched action type");
+    }
+
+    if (gotInId != expectInId) {
+      assert(false && "Failure: mismatched containing ID");
+    }
+    if (gotActId != expectActId) {
+      assert(false && "Failure: mismatched acted upon ID");
+    }
+
+    i++;
+    j++;
+  }
+
+  if (i < actions.size()) {
+    assert(false && "Failure: extra action");
+  }
+
+  if (j < actions.size()) {
+    assert(false && "Failure: expected action is missing");
+  }
+
+  size_t errCount = guard.realizeErrors();
+  if (expectErrors) {
+    assert(errCount > 0);
+  } else {
+    assert(errCount == 0);
+  }
+}
+
+static void test1() {
+  testActions("test1",
+    R""""(
+      module M {
+        record R { }
+        proc R.init() { }
+        proc R.deinit() { }
+        proc test() {
+          var x:R;
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::DEFAULT_INIT, "M.test@1", ""},
+      {AssociatedAction::DEINIT, "M.test@2", "M.test@1"}
+    });
+}
+
+static void test2() {
+  testActions("test2",
+    R""""(
+      module M {
+        record R { }
+        proc R.init() { }
+        proc R.init=(other: R) { }
+        proc R.deinit() { }
+        proc makeR() {
+          return new R();
+        }
+        proc test() {
+          var x:R;
+          var y:R;
+          y = makeR();
+          x = makeR();
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::DEINIT, "M.test@12", "M.test@1"},
+      {AssociatedAction::DEINIT, "M.test@12", "M.test@3"}
+    });
+}
+
+static void test3() {
+  testActions("test3",
+    R""""(
+      module M {
+        record R { }
+        proc R.init() { }
+        proc R.init=(other: R) { }
+        proc R.deinit() { }
+        proc makeR() {
+          return new R();
+        }
+        proc test() {
+          var x:R;
+          var y:R;
+          x = makeR();
+          y = makeR();
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::DEINIT, "M.test@12", "M.test@3"},
+      {AssociatedAction::DEINIT, "M.test@12", "M.test@1"}
+    });
+}
+
+static void test4() {
+  testActions("test4",
+    R""""(
+      module M {
+        record R { }
+        proc R.init() { }
+        proc R.init=(other: R) { }
+        proc R.deinit() { }
+        proc makeR() {
+          return new R();
+        }
+        proc test() {
+          var x:R;
+          var y:R;
+          {
+            x = makeR();
+            y = makeR();
+          }
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::DEINIT, "M.test@13", "M.test@3"},
+      {AssociatedAction::DEINIT, "M.test@13", "M.test@1"}
+    });
+}
+
+
+
+
+
+int main() {
+  test1();
+  test2();
+  test3();
+  test4();
+
+  return 0;
+}

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -167,6 +167,14 @@ computeAndPrintStuff(Context* context,
         }
       }
     }
+    for (const TypedFnSignature* sig : r->associatedFns()) {
+      if (sig != nullptr) {
+        if (sig->untyped()->idIsFunction()) {
+          auto fn = resolveFunction(context, sig, r->poiScope());
+          calledFns.insert(fn);
+        }
+      }
+    }
 
     printId(ast);
     std::ostringstream ss;

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -167,7 +167,8 @@ computeAndPrintStuff(Context* context,
         }
       }
     }
-    for (const TypedFnSignature* sig : r->associatedFns()) {
+    for (auto a : r->associatedActions()) {
+      auto sig = a.fn();
       if (sig != nullptr) {
         if (sig->untyped()->idIsFunction()) {
           auto fn = resolveFunction(context, sig, r->poiScope());

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -47,6 +47,8 @@ static auto recIter = std::string(R""""(
                         iter these() {
                           yield 1;
                         }
+                        proc init() { }
+                        proc deinit() { }
                       }
 
                       )"""");

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -294,10 +294,10 @@ static void testTheseNoIndex() {
   //
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
   auto& iterandRE = rr.byAst(loop->iterand());
-  auto& associatedFns = iterandRE.associatedFns();
-  assert(associatedFns.size() == 1);
+  auto& associatedActions = iterandRE.associatedActions();
+  assert(associatedActions.size() == 1);
 
-  auto theseFn = associatedFns[0];
+  auto theseFn = associatedActions[0].fn();
   auto recR = m->stmt(0)->toRecord();
   auto recThese = recR->declOrComment(0)->toFunction();
   assert(theseFn->id() == recThese->id());

--- a/frontend/test/resolution/testResolveNew.cpp
+++ b/frontend/test/resolution/testResolveNew.cpp
@@ -89,9 +89,9 @@ static void testEmptyRecordUserInit() {
   assert(qtNewExpr == qtNewCall);
 
   // The 'new' call should have 'init' as an associated function.
-  auto& associatedFns = reNewCall.associatedFns();
-  assert(associatedFns.size() == 1);
-  auto initTfs = associatedFns[0];
+  auto& associatedActions = reNewCall.associatedActions();
+  assert(associatedActions.size() == 1);
+  auto initTfs = associatedActions[0].fn();
   assert(initTfs->id() == fnInit->id());
   assert(initTfs->numFormals() == 1);
   assert(initTfs->formalName(0) == "this");
@@ -153,9 +153,9 @@ static void testEmptyRecordCompilerGenInit() {
 
   // The 'new' call should have 'init' as an associated function.
   // This 'init' is compiler generated.
-  auto& associatedFns = reNewCall.associatedFns();
-  assert(associatedFns.size() == 1);
-  auto initTfs = associatedFns[0];
+  auto& associatedActions = reNewCall.associatedActions();
+  assert(associatedActions.size() == 1);
+  auto initTfs = associatedActions[0].fn();
   assert(initTfs->id() == r->id());
   assert(initTfs->numFormals() == 1);
   assert(initTfs->formalName(0) == "this");
@@ -243,8 +243,8 @@ static void testTertMethodCallCrossModule() {
   auto& reNewExpr = rr.byAst(newExpr);
   assert(reNewExpr.type() == reInitExpr.type());
 
-  assert(reInitExpr.associatedFns().size() == 1);
-  auto tfsInit = reInitExpr.associatedFns()[0];
+  assert(reInitExpr.associatedActions().size() == 1);
+  auto tfsInit = reInitExpr.associatedActions()[0].fn();
   assert(tfsInit);
   auto ufsInit = tfsInit->untyped();
   assert(ufsInit);
@@ -503,8 +503,8 @@ static void testGenericRecordUserInitDependentField() {
   auto newCall = obj->initExpression();
   auto reNewCall = rr.byAst(newCall);
   assert(reNewCall.type() == reObj.type());
-  assert(reNewCall.associatedFns().size() == 1);
-  auto initTfs = reNewCall.associatedFns()[0];
+  assert(reNewCall.associatedActions().size() == 1);
+  auto initTfs = reNewCall.associatedActions()[0].fn();
   assert(initTfs);
   assert(initTfs->untyped()->name() == "init");
   assert(initTfs->untyped()->numFormals() == 3);

--- a/frontend/test/resolution/testSplitInit.cpp
+++ b/frontend/test/resolution/testSplitInit.cpp
@@ -567,6 +567,8 @@ static void test21() {
     {"x", "y"},
     /* expect errors for now as a temporary workaround */ ERRORS_EXPECTED);
 }
+
+/* not tested -- "ount intent varargs are not supported"
 static void test22() {
   testSplitInit("test22",
     R""""(
@@ -589,6 +591,7 @@ static void test22() {
     )"""",
     {"x"});
 }
+
 static void test23() {
   testSplitInit("test23",
     R""""(
@@ -612,7 +615,7 @@ static void test23() {
     )"""",
     {"x", "y"});
 }
-/* Uncomment these tests after we enough tuple support implemented
+
 static void test24() {
   testSplitInit("test24",
     R""""(
@@ -1167,7 +1170,7 @@ static void test46() {
           } else {
             try {
               return;
-            } catch e {
+            } catch {
               return;
             }
           }
@@ -1200,10 +1203,10 @@ int main() {
   test19();
   test20();
   test21();
-  test22();
-  test23();
-  //test24(); TODO
-  //test25(); TODO
+  //test22(); out intent varargs
+  //test23(); out intent varargs
+  //test24(); out intent varargs
+  //test25(); out intent varargs
   test26a();
   test26b();
   test26c();

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -171,6 +171,8 @@ static void test6() {
   auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { }
+                  proc R.init() { }
+                  proc R.deinit() { }
                   proc f() {
                     var r: R;
                     return (r, r);

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1246,6 +1246,7 @@ static void test41() {
                           }
                           record R {
                             param p;
+                            proc init(param p) { this.p = p; }
                           }
                           var x = useType(R(1));
                         )"""");
@@ -1278,6 +1279,7 @@ static void test42() {
                           }
                           record R {
                             param p;
+                            proc init(param p) { this.p = p; }
                           }
                           var x = useType(R);
                         )"""");

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1221,6 +1221,8 @@ static void test40() {
                             return ret;
                           }
                           record R { }
+                          proc R.init() { }
+                          proc R.deinit() { }
                           var x = useType(R);
                         )"""");
 
@@ -1247,6 +1249,7 @@ static void test41() {
                           record R {
                             param p;
                             proc init(param p) { this.p = p; }
+                            proc deinit() { }
                           }
                           var x = useType(R(1));
                         )"""");
@@ -1280,6 +1283,7 @@ static void test42() {
                           record R {
                             param p;
                             proc init(param p) { this.p = p; }
+                            proc deinit() { }
                           }
                           var x = useType(R);
                         )"""");

--- a/frontend/test/resolution/testTypeQueries.cpp
+++ b/frontend/test/resolution/testTypeQueries.cpp
@@ -414,6 +414,10 @@ static void test15() {
   auto qt = resolveTypeOfXInit(context,
                 R""""(
                   record R { type t1; type t2; }
+                  proc R.init(type t1, type t2) {
+                    this.t1 = t1;
+                    this.t2 = t2;
+                  }
                   proc f(a: R(?t, if t == bool then string else int)) {
                     return a;
                   }
@@ -431,6 +435,10 @@ static void test16() {
   std::string setup =
                 R""""(
                   record R { type t1; type t2; }
+                  proc R.init(type t1, type t2) {
+                    this.t1 = t1;
+                    this.t2 = t2;
+                  }
                   proc f(a: R(?t, if t == bool then string else int)...) type {
                     return t;
                   }
@@ -471,6 +479,10 @@ static void test17() {
   std::string setup =
                 R""""(
                   record R { type t1; type t2; }
+                  proc R.init(type t1, type t2) {
+                    this.t1 = t1;
+                    this.t2 = t2;
+                  }
                   proc f(a: R(?t, if t == bool then string else int)...) type {
                     return t;
                   }


### PR DESCRIPTION
* Fixes a bug with UniqueStrings starting with the zero byte returning `true` for `isEmpty()` even if that is not the case
* Adjusts the resolver to infer the types of generic/untyped `out` formals from the function body. Added a concept of `inferredFrom` to `TypedFnSignature` to support that & avoid resolving function bodies twice (because the `TypedFnSignature` with the different `out` values is actually a different input to the queries to resolve the function, so we go back to the version without that inference when resolving).
* Changes associatedFns to associatedActions to include a wider variety of things we need to resolve. For now, deinits are associatedActions attached to the Block in which the deinit occurs. Each associatedAction includes an enum value indicating what type of action it is, a TypedFnSignature that it can use. Deinits also need an ID (which thing is deinited?).
* Added fieldIdToName query to support other elements
* Adjusted a number of tests to avoid assertion failures with default init/deinit etc not being generated yet, to separate that effort from this one.

Reviewed by @DanilaFe - thanks!

Future Work:
 * add more test cases & get them working -- including copy-init for `var x = y;`
 * look at deinit end-of-block vs end-of-statement rules