### PR TITLE
Drop problem sizes for some slow running tests

### DIFF
--- a/test/io/ferguson/seeking.chpl
+++ b/test/io/ferguson/seeking.chpl
@@ -2,7 +2,7 @@ use Random, IO, CTypes;
 
 config const path = "binary-output.bin";
 config const maxbyte = 255;
-config const maxint = 32*1024;
+config const maxint = 1024;
 config const seed = SeedGenerator.oddCurrentTime;
 
 config const bufsz = 0;

--- a/test/library/packages/LinearAlgebra/performance/me/me-perf.execopts
+++ b/test/library/packages/LinearAlgebra/performance/me/me-perf.execopts
@@ -1,1 +1,1 @@
---correctness=true
+--correctness=true --iters=1 --iterLimit=1

--- a/test/library/standard/Random/RandomStreamInterface/choiceTestUtils.chpl
+++ b/test/library/standard/Random/RandomStreamInterface/choiceTestUtils.chpl
@@ -2,7 +2,7 @@ use Random, Map;
 
 config const debug = false;
 
-proc test(stream, X, size:?sizeType=none, replace=true, prob:?probType=none, trials=10000) throws {
+proc test(stream, X, size:?sizeType=none, replace=true, prob:?probType=none, trials=1000) throws {
   var counts;
   if isArrayValue(X) {
     counts = new map(X.eltType, int);


### PR DESCRIPTION
Decrease some problem sizes for:
 - me-perf: 240s -> 1s
 - seeking: 120s -> 1s (for all 4 execopts on NFS)
 - choiceTest{Arr,Dom,Rng}: 200s -> 20s (for all three tests)

Part of Cray/chapel-private#3211