### PR TITLE
fix: define Sync as a subclass of SimpleBlockLike

### DIFF
--- a/frontend/include/chpl/uast/uast-classes-list.h
+++ b/frontend/include/chpl/uast/uast-classes-list.h
@@ -72,7 +72,6 @@
   AST_NODE(Require)                    //
   AST_NODE(Return)                     //
   AST_NODE(Select)                     //
-  AST_NODE(Sync)                       //
   AST_NODE(Throw)                      //
   AST_NODE(Try)                        // old AST: TryStmt
   AST_NODE(TypeQuery)                  //
@@ -89,6 +88,7 @@
     AST_NODE(Manage)                   //
     AST_NODE(On)                       //
     AST_NODE(Serial)                   //
+    AST_NODE(Sync)                     //
     AST_NODE(When)                     //
   AST_END_SUBCLASSES(SimpleBlockLike)
 

--- a/frontend/test/parsing/testParseSync.cpp
+++ b/frontend/test/parsing/testParseSync.cpp
@@ -44,6 +44,9 @@ static void test0(Parser* parser) {
   assert(mod->stmt(2)->isComment());
   const Sync* sync = mod->stmt(1)->toSync();
   assert(sync);
+  assert(sync->isSimpleBlockLike());
+  auto block = sync->toSimpleBlockLike();
+  assert(block);
   assert(sync->blockStyle() == BlockStyle::IMPLICIT);
   assert(sync->numStmts() == 2);
   assert(sync->stmt(0)->isComment());


### PR DESCRIPTION
This PR fixes bug where `Sync` nodes would not respond
properly to `isSimpleBlockLike()` because they were listed
in `uast-classes-list.h` as deriving from `AstNode` directly.

TESTING:

- [x] paratest w/futures 
- [x] `isSimpleBlockLike()` returns true for a sync node
- [x] `syncNode->toSimpleBlockLike()` no longer returns `nullptr`

reviewed by @dlongnecke-cray - thanks!