### PR TITLE
update chpldoc test helper for release

### DIFF
--- a/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
+++ b/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
@@ -5,7 +5,7 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/../../../compflags/bradc/printstuff/version.goodstart
 # During pre-release mode
-diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+#   { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-# echo ""
+echo ""


### PR DESCRIPTION
This PR updates the `chpldoc` version test helper for release mode,
similar to how `test/compflags/bradc/printstuff/versionhelp.sh` was
updated in https://github.com/chapel-lang/chapel/pull/21162/.

This will fix the four failing chpldoc tests we see in paratest:

TESTING:

- [x] `chpldoc` test failures below all pass

```
[Error matching compiler output for chpldoc/compflags/combinations/version.doc]
[Error matching compiler output for chpldoc/compflags/combinations/z_copy_version.doc]
[Error matching compiler output for chpldoc/compflags/combinations/z_copyright_help_version.doc]
[Error matching compiler output for chpldoc/compflags/combinations/z_help_version.doc]
```

reviewed by @bradcray - thanks!