### PR TITLE
update required version of sphinxcontrib-chapeldomain

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 sphinx-rtd-theme==1.0.0
-sphinxcontrib-chapeldomain==0.0.23
+sphinxcontrib-chapeldomain==0.0.24
 breathe==4.31.0


### PR DESCRIPTION
This PR updates the version number of the `sphinxcontrib-chapeldomain` package
required for building docs from `0.0.23` to `0.0.24`. The change corresponds
to the release of an updated package which can correctly format function
signatures that have a `this` intent type of `ref`, such as `proc ref myFunc()`

Changes motivated by https://github.com/chapel-lang/chapel/issues/13983

TESTING: 

- [x] `make docs` pulls latest `sphinxcontrib-chapeldomain` package
- [x] docs build with latest version of package