### PR TITLE
Add rationale for deprecation of unicodeSupported

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6195,7 +6195,7 @@ proc readln(type t ...?numTypes) throws {
 /*
    :returns: `true` if this version of the Chapel runtime supports UTF-8 output.
  */
-deprecated "unicodeSupported is deprecated"
+deprecated "unicodeSupported is deprecated due to always returning true"
 proc unicodeSupported():bool {
   return true;
 }

--- a/test/deprecated/IO/unicodeSupported.good
+++ b/test/deprecated/IO/unicodeSupported.good
@@ -1,3 +1,3 @@
-unicodeSupported.chpl:1: warning: unicodeSupported is deprecated
-unicodeSupported.chpl:3: warning: unicodeSupported is deprecated
+unicodeSupported.chpl:1: warning: unicodeSupported is deprecated due to always returning true
+unicodeSupported.chpl:3: warning: unicodeSupported is deprecated due to always returning true
 true


### PR DESCRIPTION
At @bradcray's suggestion, adding rationale for deprecation to the deprecation message of `unicodeSupported`. (`unicodeSupported` was recently deprecated in https://github.com/chapel-lang/chapel/pull/21086.)

Testing:
- [x] paratest