### PR TITLE
No-doc Chapel-specific IO error codes

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2487,6 +2487,7 @@ inline operator :(x: ioBits, type t:string) {
 private extern proc chpl_macro_int_EEOF():c_int;
 /* An error code indicating the end of file has been reached (Chapel specific)
  */
+pragma "no doc"
 inline proc EEOF return chpl_macro_int_EEOF():c_int;
 
 private extern proc chpl_macro_int_ESHORT():c_int;
@@ -2494,6 +2495,7 @@ private extern proc chpl_macro_int_ESHORT():c_int;
    input was reached before the requested amount of data could be read.
    (Chapel specific)
   */
+pragma "no doc"
 inline proc ESHORT return chpl_macro_int_ESHORT():c_int;
 
 private extern proc chpl_macro_int_EFORMAT():c_int;
@@ -2501,6 +2503,7 @@ private extern proc chpl_macro_int_EFORMAT():c_int;
    string literal, this would be returned if we never encountered the
    opening quote. (Chapel specific)
   */
+pragma "no doc"
 inline proc EFORMAT return chpl_macro_int_EFORMAT():c_int;
 
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2435,7 +2435,7 @@ Used to represent a constant string we want to read or write.
 When writing, the ``ioLiteral`` is output without any quoting or escaping.
 
 When reading, the ``ioLiteral`` must be matched exactly - or else the read call
-will return an error with code :data:`EFORMAT`.
+will return an error for incorrectly formatted input
 
 */
 record ioLiteral {

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1311,7 +1311,7 @@ module OS {
 
   /*
      :class:`EofError` is the subclass of :class:`IoError` corresponding to
-     :const:`IO.EEOF`.
+     encountering end-of-file.
   */
   class EofError : IoError {
     proc init(details: string = "", err: errorCode = EEOF:errorCode) {
@@ -1321,7 +1321,8 @@ module OS {
 
   /*
      :class:`UnexpectedEofError` is the subclass of :class:`IoError`
-     corresponding to :const:`IO.ESHORT`.
+     corresponding to encountering end-of-file before the requested amount of
+     input could be read.
   */
   class UnexpectedEofError : IoError {
     proc init(details: string = "", err: errorCode = ESHORT:errorCode) {
@@ -1331,7 +1332,7 @@ module OS {
 
   /*
      :class:`BadFormatError` is the subclass of :class:`IoError` corresponding
-     to :const:`IO.EFORMAT`.
+     to incorrectly-formatted input.
   */
   class BadFormatError : IoError {
     proc init(details: string = "", err: errorCode = EFORMAT:errorCode) {

--- a/modules/standard/SysBasic.chpl
+++ b/modules/standard/SysBasic.chpl
@@ -56,7 +56,7 @@ private extern proc chpl_macro_int_EEOF():c_int;
 /* An error code indicating the end of file has been reached (Chapel specific)
  */
 pragma "last resort"
-deprecated "'SysBasic.EEOF' has been deprecated; please use 'IO.EEOF' instead."
+deprecated "'SysBasic.EEOF' has been deprecated"
 inline proc EEOF return chpl_macro_int_EEOF():c_int;
 
 private extern proc chpl_macro_int_ESHORT():c_int;
@@ -66,7 +66,7 @@ private extern proc chpl_macro_int_ESHORT():c_int;
    (Chapel specific)
   */
 pragma "last resort"
-deprecated "'SysBasic.ESHORT' has been deprecated; please use 'IO.ESHORT' instead."
+deprecated "'SysBasic.ESHORT' has been deprecated"
 inline proc ESHORT return chpl_macro_int_ESHORT():c_int;
 
 private extern proc chpl_macro_int_EFORMAT():c_int;
@@ -76,7 +76,7 @@ private extern proc chpl_macro_int_EFORMAT():c_int;
    opening quote. (Chapel specific)
   */
 pragma "last resort"
-deprecated "'SysBasic.EFORMAT' has been deprecated; please use 'IO.EFORMAT' instead."
+deprecated "'SysBasic.EFORMAT' has been deprecated"
 inline proc EFORMAT return chpl_macro_int_EFORMAT():c_int;
 
 // system error numbers

--- a/test/deprecated/SysBasic/chapel_specific_errors.good
+++ b/test/deprecated/SysBasic/chapel_specific_errors.good
@@ -1,7 +1,7 @@
-chapel_specific_errors.chpl:1: warning: 'SysBasic.EEOF' has been deprecated; please use 'IO.EEOF' instead.
-chapel_specific_errors.chpl:1: warning: 'SysBasic.ESHORT' has been deprecated; please use 'IO.ESHORT' instead.
-chapel_specific_errors.chpl:1: warning: 'SysBasic.EFORMAT' has been deprecated; please use 'IO.EFORMAT' instead.
+chapel_specific_errors.chpl:1: warning: 'SysBasic.EEOF' has been deprecated
+chapel_specific_errors.chpl:1: warning: 'SysBasic.ESHORT' has been deprecated
+chapel_specific_errors.chpl:1: warning: 'SysBasic.EFORMAT' has been deprecated
 chapel_specific_errors.chpl:1: warning: The SysBasic module has been deprecated; most symbols have been moved to IO or OS as appropriate
-chapel_specific_errors.chpl:4: warning: 'SysBasic.EEOF' has been deprecated; please use 'IO.EEOF' instead.
-chapel_specific_errors.chpl:5: warning: 'SysBasic.ESHORT' has been deprecated; please use 'IO.ESHORT' instead.
-chapel_specific_errors.chpl:6: warning: 'SysBasic.EFORMAT' has been deprecated; please use 'IO.EFORMAT' instead.
+chapel_specific_errors.chpl:4: warning: 'SysBasic.EEOF' has been deprecated
+chapel_specific_errors.chpl:5: warning: 'SysBasic.ESHORT' has been deprecated
+chapel_specific_errors.chpl:6: warning: 'SysBasic.EFORMAT' has been deprecated


### PR DESCRIPTION
Add `pragma "no doc"` to the Chapel-specific `IO` error codes `EEOF`, `ESHORT`, and `EFORMAT`.

I should have done this for https://github.com/chapel-lang/chapel/issues/20130 (implemented in https://github.com/chapel-lang/chapel/pull/20834) but misunderstood and left them user-facing after the move. Additionally, these symbols should be made `private`, but as we are past code freeze for the 1.29 release that will be done in a follow-up PR.

Testing:
- [x] paratest (just to be safe)
- [x] make_doc CI check