### PR TITLE
Make EEOF, ESHORT, and EFORMAT private

### DIFF
--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -977,10 +977,10 @@ module Curl {
           return cc.saved_error;
       }
 
-      // Return EEOF if the connection is no longer running
+      // Return EIO if the connection is no longer running
       space = qio_channel_nbytes_available_unlocked(ch);
       if cc.running_handles == 0 && space < amt then
-        return EEOF;
+        return EIO;
 
       return 0;
     }
@@ -1119,11 +1119,11 @@ module Curl {
           return cc.saved_error;
       }
 
-      // Return EEOF if the connection is no longer running
+      // Return EIO if the connection is no longer running
       space = qio_channel_nbytes_write_behind_unlocked(ch);
       if cc.running_handles == 0 && space > target_space {
-        writeln("RETURNING EOF");
-        return EEOF;
+        writeln("RETURNING EIO");
+        return EIO;
       }
 
       return 0;

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -165,6 +165,11 @@ module Curl {
   require "-lcurl";
 
 
+  /*
+   Local copy of IO.EEOF as it is being phased out and is private in IO
+   */
+  private extern proc chpl_macro_int_EEOF():c_int;
+
   /* Returns the ``CURL`` handle connected to a channel opened with
      :proc:`URL.openUrlReader` or :proc:`URL.openUrlWriter`.
    */
@@ -977,10 +982,10 @@ module Curl {
           return cc.saved_error;
       }
 
-      // Return EIO if the connection is no longer running
+      // Return EEOF if the connection is no longer running
       space = qio_channel_nbytes_available_unlocked(ch);
       if cc.running_handles == 0 && space < amt then
-        return EIO;
+        return chpl_macro_int_EEOF():errorCode;
 
       return 0;
     }
@@ -1119,11 +1124,11 @@ module Curl {
           return cc.saved_error;
       }
 
-      // Return EIO if the connection is no longer running
+      // Return EEOF if the connection is no longer running
       space = qio_channel_nbytes_write_behind_unlocked(ch);
       if cc.running_handles == 0 && space > target_space {
-        writeln("RETURNING EIO");
-        return EIO;
+        writeln("RETURNING EEOF");
+        return chpl_macro_int_EEOF():errorCode;
       }
 
       return 0;

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -495,7 +495,7 @@ module HDFS {
         var rc = hdfsPread(file.fs.hfs, file.hfile, offset, ptr, len:int(32));
         if rc == 0 {
           // end of file
-          return EEOF;
+          return EIO;
         } else if rc < 0 {
           // error
           return qio_mkerror_errno();

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -130,6 +130,11 @@ module HDFS {
 
   require "hdfs.h";
 
+  /*
+   Local copy of IO.EEOF as it is being phased out and is private in IO
+   */
+  private extern proc chpl_macro_int_EEOF():c_int;
+
   pragma "no doc"
   extern "struct hdfs_internal" record hdfs_internal { }
   pragma "no doc"
@@ -495,7 +500,7 @@ module HDFS {
         var rc = hdfsPread(file.fs.hfs, file.hfile, offset, ptr, len:int(32));
         if rc == 0 {
           // end of file
-          return EIO;
+          return chpl_macro_int_EEOF():errorCode;
         } else if rc < 0 {
           // error
           return qio_mkerror_errno();

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -151,8 +151,13 @@ module BigInteger {
   use GMP;
   use HaltWrappers;
   use CTypes;
-  use IO only EFORMAT;
   use OS;
+
+
+  /*
+   Local copy of IO.EFORMAT as it is being phased out and is private in IO
+   */
+  private extern proc chpl_macro_int_EFORMAT():c_int;
 
   /*
     .. warning::
@@ -259,7 +264,7 @@ module BigInteger {
       if mpz_init_set_str(this.mpz, str_, base_) != 0 {
         mpz_clear(this.mpz);
 
-        error = EFORMAT;
+        error = chpl_macro_int_EFORMAT();
       } else {
         error = 0;
       }

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -148,6 +148,7 @@ module ChapelIO {
 
   use IO;
   import CTypes.{c_int};
+
   /*
    Local copies of IO.{EEOF,ESHORT,EFORMAT} as these are being phased out
    and are now private in IO
@@ -155,8 +156,11 @@ module ChapelIO {
   private extern proc chpl_macro_int_EEOF():c_int;
   private extern proc chpl_macro_int_ESHORT():c_int;
   private extern proc chpl_macro_int_EFORMAT():c_int;
+  pragma "no doc"
   private inline proc EEOF return chpl_macro_int_EEOF():c_int;
+  pragma "no doc"
   private inline proc ESHORT return chpl_macro_int_ESHORT():c_int;
+  pragma "no doc"
   private inline proc EFORMAT return chpl_macro_int_EFORMAT():c_int;
 
     private

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -147,6 +147,17 @@ module ChapelIO {
   }
 
   use IO;
+  import CTypes.{c_int};
+  /*
+   Local copies of IO.{EEOF,ESHORT,EFORMAT} as these are being phased out
+   and are now private in IO
+   */
+  private extern proc chpl_macro_int_EEOF():c_int;
+  private extern proc chpl_macro_int_ESHORT():c_int;
+  private extern proc chpl_macro_int_EFORMAT():c_int;
+  private inline proc EEOF return chpl_macro_int_EEOF():c_int;
+  private inline proc ESHORT return chpl_macro_int_ESHORT():c_int;
+  private inline proc EFORMAT return chpl_macro_int_EFORMAT():c_int;
 
     private
     proc isIoField(x, param i) param {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2481,14 +2481,14 @@ inline operator :(x: ioBits, type t:string) {
 }
 
 /*
- EEOF, ESHORT, and EFORMAT are Chapel-specific IO error codes.
+ EEOF, ESHORT, and EFORMAT are internal, Chapel-specific IO error codes.
  */
 
 private extern proc chpl_macro_int_EEOF():c_int;
 /* An error code indicating the end of file has been reached (Chapel specific)
  */
 pragma "no doc"
-inline proc EEOF return chpl_macro_int_EEOF():c_int;
+private inline proc EEOF return chpl_macro_int_EEOF():c_int;
 
 private extern proc chpl_macro_int_ESHORT():c_int;
 /* An error code indicating that the end of file or the end of the
@@ -2496,7 +2496,7 @@ private extern proc chpl_macro_int_ESHORT():c_int;
    (Chapel specific)
   */
 pragma "no doc"
-inline proc ESHORT return chpl_macro_int_ESHORT():c_int;
+private inline proc ESHORT return chpl_macro_int_ESHORT():c_int;
 
 private extern proc chpl_macro_int_EFORMAT():c_int;
 /* An error code indicating a format error; for example when reading a quoted
@@ -2504,7 +2504,7 @@ private extern proc chpl_macro_int_EFORMAT():c_int;
    opening quote. (Chapel specific)
   */
 pragma "no doc"
-inline proc EFORMAT return chpl_macro_int_EFORMAT():c_int;
+private inline proc EFORMAT return chpl_macro_int_EFORMAT():c_int;
 
 
 pragma "no doc"

--- a/test/io/ferguson/inteof.chpl
+++ b/test/io/ferguson/inteof.chpl
@@ -38,10 +38,14 @@ for i in 0..sizes.size-1
       }
 
       var badint: int;
+      var dataRemains: bool = false;
       try! {
-        reader.read(badint);
+        dataRemains = reader.read(badint);
       } catch e: SystemError {
-        if (e.err != EEOF) then halt("Data remains at end of file");
+        dataRemains = true;
+      }
+      if (dataRemains) {
+        halt("Data remains at end of file");
       }
 
       infile.close();
@@ -74,10 +78,14 @@ for i in 0..sizes.size-1
       }
 
       var badint: int;
+      var dataRemains: bool = false;
       try! {
-        reader.read(badint);
+        dataRemains = reader.read(badint);
       } catch e: SystemError {
-        if (e.err != EEOF) then halt("Data remains at end of file");
+        dataRemains = true;
+      }
+      if (dataRemains) {
+        halt("Data remains at end of file");
       }
 
       infile.close();
@@ -110,10 +118,14 @@ for i in 0..sizes.size-1
       }
 
       var badint: int;
+      var dataRemains: bool = false;
       try! {
-        reader.read(badint);
+        dataRemains = reader.read(badint);
       } catch e: SystemError {
-        if (e.err != EEOF) then halt("Data remains at end of file");
+        dataRemains = true;
+      }
+      if (dataRemains) {
+        halt("Data remains at end of file");
       }
 
       infile.close();

--- a/test/studies/lulesh/bradc/tests/lulesh-eof.chpl
+++ b/test/studies/lulesh/bradc/tests/lulesh-eof.chpl
@@ -234,10 +234,14 @@ writeln("Doing EOF check");
 
 // Make sure we're at the end of the input file, for sanity
 var badint: int;
+var dataRemains: bool = false;
 try! {
-  reader.read(badint);
+  dataRemains = reader.read(badint);
 } catch e: SystemError {
-  if (e.err != EEOF) then halt("Data remains at end of file");
+  dataRemains = true;
+}
+if (dataRemains) {
+  halt("Data remains at end of file");
 }
 
 writeln("Made it past EOF check");

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -351,11 +351,15 @@ proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
 
 proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {
   var temp:IONumType;
+  var dataRemains:bool = false;
   try! {
-    chan.read(temp);
+    dataRemains = chan.read(temp);
   } catch e: SystemError {
     // temp==0 is a workaround for unending large files
-    if e.err != EEOF && temp != 0 then
+    if temp != 0 then
+      dataRemains = true;
+  }
+  if (dataRemains) {
       myerror("did not reach EOF in '", snapshot_prefix, file_suffix,
               "'  the next value is ", temp);
   }

--- a/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
@@ -503,11 +503,15 @@ proc createGraphFile(prefix:string, suffix:string, param forWriting:bool) {
 
 proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {
   var temp:IONumType;
+  var dataRemains:bool = false;
   try! {
-    chan.read(temp);
+    dataRemains = chan.read(temp);
   } catch e: SystemError {
     // temp==0 is a workaround for unending large files
-    if e.err != EEOF && temp != 0 then
+    if temp != 0 then
+      dataRemains = true;
+  }
+  if (dataRemains) {
       myerror("did not reach EOF in '", snapshot_prefix, file_suffix,
               "'  the next value is ", temp);
   }


### PR DESCRIPTION
These internal Chapel-specific `IO` error codes should not be user facing, but were unintentionally left that way in https://github.com/chapel-lang/chapel/pull/20834.

This is a follow-up to https://github.com/chapel-lang/chapel/pull/21199 which `no doc`'d the symbols but did not `private` them due to code being frozen for 1.29 release. Getting rid of or otherwise modifying the subclasses of `SystemError` corresponding to these error codes will be done in a future PR.

Testing:
- [x] paratest with futures