### PR TITLE
Fix accidental commit

### DIFF
--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -23,7 +23,7 @@ module ChapelGpuSupport {
 
   extern var chpl_gpu_debug : bool;
 
-  private config const debugGpu = false;
+  config const debugGpu = false;
 
   // by virtue of module initialization:
   chpl_gpu_debug = debugGpu;


### PR DESCRIPTION
That made `debugGpu` a private config param

I didn't intend to submit this but it accidentally got rolled into https://github.com/chapel-lang/chapel/pull/21175