### PR TITLE
Fix warnings from clang 15 due to unused variables

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -407,7 +407,7 @@ checkFunction(FnSymbol* fn) {
   collectMyCallExprs(fn, calls, fn);
   bool isIterator = fn->isIterator();
   bool notInAFunction = !isIterator && (fn->getModule()->initFn == fn);
-  int numVoidReturns = 0, numNonVoidReturns = 0, numYields = 0;
+  int numVoidReturns = 0, numNonVoidReturns = 0;
 
   for_vector(CallExpr, call, calls) {
     if (call->isPrimitive(PRIM_RETURN)) {
@@ -434,8 +434,6 @@ checkFunction(FnSymbol* fn) {
         USR_FATAL_CONT(call, "yield statement is outside an iterator");
       else if (!isIterator)
         USR_FATAL_CONT(call, "yield statement is in a non-iterator function");
-      else
-        numYields++;
     }
   }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6395,7 +6395,6 @@ static int compareSpecificity(ResolutionCandidate*         candidate1,
   bool                prefer1 = false;
   bool                prefer2 = false;
 
-  int                 nArgsSame = 0;
   int                 nArgsIncomparable = 0;
 
   for (int k = start; k < DC.actuals->n; ++k) {
@@ -6438,8 +6437,6 @@ static int compareSpecificity(ResolutionCandidate*         candidate1,
 
     if (p == -1) {
       nArgsIncomparable++;
-    } else if (p == 0) {
-      nArgsSame++;
     }
 
     if (actualParam) {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1328,7 +1328,6 @@ static void gatherTempsDeadLastMention(VarSymbol* v,
       // also handle out intent variables being inited here
       FnSymbol* fn = subCall ? subCall->resolvedOrVirtualFunction() : NULL;
       if (fn != NULL) {
-        int i = 1;
         for_formals_actuals(formal, actual, subCall) {
           bool outIntent = (formal->intent == INTENT_OUT ||
                             formal->originalIntent == INTENT_OUT);
@@ -1349,7 +1348,6 @@ static void gatherTempsDeadLastMention(VarSymbol* v,
               }
             }
           }
-          i++;
         }
       }
     }

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1856,8 +1856,6 @@ static void handleInIntent(FnSymbol* fn, CallExpr* call,
 static void handleOutIntents(FnSymbol* fn, CallExpr* call,
                              SymbolMap& inTmpToActualMap) {
 
-  int j = 0;
-
   // Function with no actuals can't use out intent
   // Returning early in that event simplifies the following code.
   if (call->numActuals() == 0)
@@ -1952,7 +1950,6 @@ static void handleOutIntents(FnSymbol* fn, CallExpr* call,
     }
 
     currActual = nextActual;
-    j++;
   }
 }
 

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -31,8 +31,6 @@
 
 #include "./ErrorGuard.h"
 
-static const bool ERRORS_EXPECTED=true;
-
 using ActionElt = std::tuple<AssociatedAction::Action,
                              std::string, /* ID where action occurs */
                              std::string /* ID acted upon or "" */ >;


### PR DESCRIPTION
This PR fixes 4 warnings from compiling Chapel with clang 15 and e.g. `CHPL_HOST_COMPILER=clang make WARNINGS=1`. In all of the cases, a local variable is not used other than being incremented.

Reviewed by @daviditen - thanks!

- [x] full local testing