### PR TITLE
Add nightly ChOp + GPU performance testing

### DIFF
--- a/test/GPU-GRAPHFILES
+++ b/test/GPU-GRAPHFILES
@@ -11,3 +11,5 @@ gpu/native/studies/compiler-performance/transform.graph
 gpu/native/studies/compiler-performance/end-to-end.graph
 
 gpu/native/studies/kernelLaunch/emptyKernelLaunch.graph
+
+gpu/native/studies/chop/chplGPU.graph

--- a/test/gpu/native/studies/chop/README
+++ b/test/gpu/native/studies/chop/README
@@ -1,0 +1,12 @@
+This directory is for our nightly performance testing of ChOp + GPU support.
+
+Note that the executable .skipif file runs before we start doing any testing
+and will download the "latest and greatest" version of ChOp before proceeding.
+
+Also note that the .skipif file will silently skip the test if: CHPL_TEST_PERF
+is unset or if the machine isn't able to access GitLab.
+
+To run this test locally, execute the following commands:
+
+    export CHPL_TEST_PERF=true
+    start_test -perflabel gpu- .

--- a/test/gpu/native/studies/chop/chplGPU.chpl
+++ b/test/gpu/native/studies/chop/chplGPU.chpl
@@ -1,0 +1,1 @@
+ChOp/other_codes/chplGPU/chplGPU.chpl

--- a/test/gpu/native/studies/chop/chplGPU.gpu-compopts
+++ b/test/gpu/native/studies/chop/chplGPU.gpu-compopts
@@ -1,1 +1,1 @@
--M modules/ --gpu-block-size=128 --fast
+-M modules/ --gpu-block-size=128

--- a/test/gpu/native/studies/chop/chplGPU.gpu-compopts
+++ b/test/gpu/native/studies/chop/chplGPU.gpu-compopts
@@ -1,0 +1,1 @@
+-M modules/ --gpu-block-size=128 --fast

--- a/test/gpu/native/studies/chop/chplGPU.gpu-execopts
+++ b/test/gpu/native/studies/chop/chplGPU.gpu-execopts
@@ -1,0 +1,3 @@
+--size=15 --initial_depth=5 # chop-15
+--size=16 --initial_depth=5 # chop-16
+--size=17 --initial_depth=5 # chop-17

--- a/test/gpu/native/studies/chop/chplGPU.gpu-keys
+++ b/test/gpu/native/studies/chop/chplGPU.gpu-keys
@@ -1,0 +1,1 @@
+Elapsed time:

--- a/test/gpu/native/studies/chop/chplGPU.graph
+++ b/test/gpu/native/studies/chop/chplGPU.graph
@@ -1,0 +1,5 @@
+perfkeys: Elapsed time:, Elapsed time:, Elapsed time:
+files: chop-15.dat, chop-16.dat, chop-17.dat
+graphkeys: Size 15, Size 16, Size 17
+ylabel: Time (s)
+graphtitle: ChOp Time

--- a/test/gpu/native/studies/chop/chplGPU.skipif
+++ b/test/gpu/native/studies/chop/chplGPU.skipif
@@ -12,12 +12,13 @@ ping -c 1 github.com &> /dev/null
 status=$?
 if ! [ $status -eq 0 ]; then
   echo "True"
+  exit 1
 fi
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-CHOP_URL=https://github.com/tcarneirop/ChOp.git
-#CHOP_URL=git@github.com:tcarneirop/ChOp.git
 CHOP_BRANCH=main
+CHOP_URL=${CHOP_URL:-https://github.com/tcarneirop/ChOp.git}
+CHOP_BRANCH=${CHOP_BRANCH:-main}
 
 # Clone ChOp, skipif clone failed, add extra output to fail nightly job
 rm -rf ChOp
@@ -29,4 +30,3 @@ if ! git clone ${CHOP_URL} --branch=${CHOP_BRANCH} --depth=1 2>gitClone.out; the
 fi
 
 echo "False"
-exit 0

--- a/test/gpu/native/studies/chop/chplGPU.skipif
+++ b/test/gpu/native/studies/chop/chplGPU.skipif
@@ -12,7 +12,9 @@ ping -c 1 github.com &> /dev/null
 status=$?
 if ! [ $status -eq 0 ]; then
   echo "True"
-  exit 1
+  # exit 0 as we want test to be considered a success as to not fail nightly
+  # Jenkins job.
+  exit 0  
 fi
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)

--- a/test/gpu/native/studies/chop/chplGPU.skipif
+++ b/test/gpu/native/studies/chop/chplGPU.skipif
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Skip if not doing performance testing
+if [ -z "$CHPL_TEST_PERF" ]; then
+  echo "True"
+  exit
+fi
+
+# Skip this test if we cannot connect to github, which is required to
+# run the test.
+ping -c 1 github.com &> /dev/null
+status=$?
+if ! [ $status -eq 0 ]; then
+  echo "True"
+fi
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+#CHOP_URL=https://github.com/tcarneirop/ChOp.git
+CHOP_URL=git@github.com:tcarneirop/ChOp.git
+CHOP_BRANCH=main
+
+# Clone ChOp, skipif clone failed, add extra output to fail nightly job
+rm -rf ChOp
+if ! git clone ${CHOP_URL} --branch=${CHOP_BRANCH} --depth=1 2>gitClone.out; then
+  echo "git clone failed; output:"
+  cat gitClone.out
+  echo "True"
+  exit
+fi
+
+echo "False"
+exit 0

--- a/test/gpu/native/studies/chop/chplGPU.skipif
+++ b/test/gpu/native/studies/chop/chplGPU.skipif
@@ -15,8 +15,8 @@ if ! [ $status -eq 0 ]; then
 fi
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-#CHOP_URL=https://github.com/tcarneirop/ChOp.git
-CHOP_URL=git@github.com:tcarneirop/ChOp.git
+CHOP_URL=https://github.com/tcarneirop/ChOp.git
+#CHOP_URL=git@github.com:tcarneirop/ChOp.git
 CHOP_BRANCH=main
 
 # Clone ChOp, skipif clone failed, add extra output to fail nightly job

--- a/test/gpu/native/studies/chop/headers
+++ b/test/gpu/native/studies/chop/headers
@@ -1,0 +1,1 @@
+ChOp/other_codes/chplGPU/headers

--- a/test/gpu/native/studies/chop/modules
+++ b/test/gpu/native/studies/chop/modules
@@ -1,0 +1,1 @@
+ChOp/other_codes/chplGPU/modules


### PR DESCRIPTION
This sets up nightly performance testing for ChOp with GPU support enabled. We intend to run this on the same Cray CS machine we do other GPU testing with.

In order to automatically download ChOp before running the test I make <strike>hacky</strike> clever use of an executable `.skipif` file that will clone the ChOp repos. The test dir has symbolic links into the relevant files/dirs of the (to be downloaded) clone that we want to test. Before cloning the ChOp repos these links will be pointing to invalid targets but that's fine (it'll be fixed before the test actually runs).

---

I have some concern about whether `chapelu` can do a git clone of the repos from the `https` address on this machine due to the fact that I get an OpenSSL error if I do that under my user account. See this issue for more info about that: https://github.com/Cray/chapel-private/issues/3781

If that fails I can switch it to using ssh instead but will have to set up keys for Github on this machine (if it's not already there).