### PR TITLE
dyno: improve uAST dumps

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -223,7 +223,7 @@ struct Converter {
     if (auto linkageName = node->linkageName()) {
       auto linkageStr = linkageName->toStringLiteral();
       INT_ASSERT(linkageStr);
-      auto ret = astr(linkageStr->str());
+      auto ret = astr(linkageStr->value());
       return ret;
     }
 
@@ -1840,7 +1840,7 @@ struct Converter {
 
   /// StringLikeLiterals ///
   Expr* visit(const uast::BytesLiteral* node) {
-    std::string quoted = escapeStringC(node->str().str());
+    std::string quoted = escapeStringC(node->value().str());
     SymExpr* se = buildBytesLiteral(quoted.c_str());
     VarSymbol* v = toVarSymbol(se->symbol());
     INT_ASSERT(v && v->immediate);
@@ -1850,7 +1850,7 @@ struct Converter {
   }
 
   Expr* visit(const uast::CStringLiteral* node) {
-    std::string quoted = escapeStringC(node->str().str());
+    std::string quoted = escapeStringC(node->value().str());
     SymExpr* se = buildCStringLiteral(quoted.c_str());
     VarSymbol* v = toVarSymbol(se->symbol());
     INT_ASSERT(v && v->immediate);
@@ -1861,7 +1861,7 @@ struct Converter {
   }
 
   Expr* visit(const uast::StringLiteral* node) {
-    std::string quoted = escapeStringC(node->str().str());
+    std::string quoted = escapeStringC(node->value().str());
     SymExpr* se = buildStringLiteral(quoted.c_str());
     VarSymbol* v = toVarSymbol(se->symbol());
     INT_ASSERT(v && v->immediate);

--- a/frontend/include/chpl/uast/AnonFormal.h
+++ b/frontend/include/chpl/uast/AnonFormal.h
@@ -86,6 +86,8 @@ class AnonFormal final : public AstNode {
 
   void markUniqueStringsInner(Context* context) const override {}
 
+  void dumpInner(const DumpSettings& s) const;
+
  public:
   ~AnonFormal() override = default;
 

--- a/frontend/include/chpl/uast/Array.h
+++ b/frontend/include/chpl/uast/Array.h
@@ -54,6 +54,8 @@ class Array final : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
+  void dumpInner(const DumpSettings& s) const;
+
  public:
   ~Array() override = default;
 

--- a/frontend/include/chpl/uast/As.h
+++ b/frontend/include/chpl/uast/As.h
@@ -52,6 +52,8 @@ class As final : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
+  void dumpInner(const DumpSettings& s) const;
+
   // These always exist and their position will never change.
   static const int8_t symbolChildNum_ = 0;
   static const int8_t renameChildNum_ = 1;

--- a/frontend/include/chpl/uast/AstList.h
+++ b/frontend/include/chpl/uast/AstList.h
@@ -20,7 +20,7 @@
 #ifndef CHPL_UAST_ASTLIST_H
 #define CHPL_UAST_ASTLIST_H
 
-#include "chpl/uast/ASTTypes.h"
+#include "chpl/uast/forward-declare-uast.h"
 #include "chpl/util/memory.h"
 
 #include <iterator>

--- a/frontend/include/chpl/uast/AstNode.h
+++ b/frontend/include/chpl/uast/AstNode.h
@@ -21,11 +21,11 @@
 #define CHPL_UAST_ASTNODE_H
 
 #include "chpl/framework/ID.h"
+#include "chpl/framework/stringify-functions.h"
 #include "chpl/uast/AstList.h"
 #include "chpl/uast/AstTag.h"
-#include "chpl/uast/ASTTypes.h"
+#include "chpl/uast/forward-declare-uast.h"
 #include "chpl/util/memory.h"
-#include "chpl/framework/stringify-functions.h"
 
 #include <functional>
 

--- a/frontend/include/chpl/uast/AstNode.h
+++ b/frontend/include/chpl/uast/AstNode.h
@@ -77,6 +77,34 @@ class AstNode {
    */
   virtual void markUniqueStringsInner(Context* context) const = 0;
 
+  struct DumpSettings {
+    chpl::StringifyKind kind = StringifyKind::DEBUG_DETAIL;
+    bool printId = true;
+    int idWidth = 0;
+    std::ostream& out;
+    DumpSettings(std::ostream& out) : out(out) { }
+  };
+
+  /**
+    This function can be defined by subclasses to include fields
+    in the uAST dump just after the tag. It should print a " "
+    before any fields printed. It is not expected
+    to print a newline.
+   */
+  virtual void dumpFieldsInner(const DumpSettings& s) const;
+
+  /**
+    This function can be defined by subclasses to emit a label for child 'i',
+    for example to indicate which Block is the Then part of a Conditional.
+   */
+  virtual std::string dumpChildLabelInner(int i) const;
+
+  static void dumpHelper(const DumpSettings& s,
+                         const AstNode* ast,
+                         int indent,
+                         const AstNode* parent,
+                         int parentIdx);
+
  protected:
   AstNode(AstTag tag)
     : tag_(tag), id_(), children_() {
@@ -188,6 +216,9 @@ class AstNode {
   void mark(Context* context) const;
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  // compute the maximum width of all of the IDs
+  int computeMaxIdStringWidth() const;
 
   /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;

--- a/frontend/include/chpl/uast/Attributes.h
+++ b/frontend/include/chpl/uast/Attributes.h
@@ -82,6 +82,8 @@ class Attributes final : public AstNode {
     unstableMessage_.mark(context);
   }
 
+  void dumpInner(const DumpSettings& s) const;
+
  public:
   ~Attributes() override = default;
 

--- a/frontend/include/chpl/uast/Begin.h
+++ b/frontend/include/chpl/uast/Begin.h
@@ -73,6 +73,8 @@ class Begin final : public SimpleBlockLike {
     simpleBlockLikeMarkUniqueStringsInner(context);
   }
 
+  std::string dumpChildLabelInner(int i) const override;
+
   int8_t withClauseChildNum_;
 
  public:

--- a/frontend/include/chpl/uast/BoolLiteral.h
+++ b/frontend/include/chpl/uast/BoolLiteral.h
@@ -46,6 +46,8 @@ class BoolLiteral final : public Literal {
     literalMarkUniqueStringsInner(context);
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+
  public:
   ~BoolLiteral() override = default;
 

--- a/frontend/include/chpl/uast/Break.h
+++ b/frontend/include/chpl/uast/Break.h
@@ -61,6 +61,8 @@ class Break : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
+  std::string dumpChildLabelInner(int i) const override;
+
   int8_t targetChildNum_;
 
  public:

--- a/frontend/include/chpl/uast/BytesLiteral.h
+++ b/frontend/include/chpl/uast/BytesLiteral.h
@@ -48,16 +48,6 @@ class BytesLiteral final : public StringLikeLiteral {
   static owned<BytesLiteral> build(Builder* builder, Location loc,
                                    const std::string& value,
                                    StringLikeLiteral::QuoteStyle quotes);
-
-  /**
-    Returns the value of this bytes literal as a UniqueString
-    which does not include the quotes.
-   */
-  UniqueString str() const {
-    CHPL_ASSERT(value_->isStringParam());
-    const types::StringParam* p = (const types::StringParam*) value_;
-    return p->value();
-  }
 };
 
 

--- a/frontend/include/chpl/uast/CStringLiteral.h
+++ b/frontend/include/chpl/uast/CStringLiteral.h
@@ -47,16 +47,6 @@ class CStringLiteral final : public StringLikeLiteral {
   static owned<CStringLiteral> build(Builder* builder, Location loc,
                                      const std::string& value,
                                      StringLikeLiteral::QuoteStyle quotes);
-
-  /**
-    Returns the value of this c string literal as a UniqueString
-    which does not include the quotes.
-   */
-  UniqueString str() const {
-    CHPL_ASSERT(value_->isStringParam());
-    const types::StringParam* p = (const types::StringParam*) value_;
-    return p->value();
-  }
 };
 
 

--- a/frontend/include/chpl/uast/Call.h
+++ b/frontend/include/chpl/uast/Call.h
@@ -50,6 +50,8 @@ class Call : public AstNode {
   void callMarkUniqueStringsInner(Context* context) const {
   }
 
+  virtual std::string dumpChildLabelInner(int i) const override;
+
  public:
   ~Call() override = 0;
 

--- a/frontend/include/chpl/uast/Catch.h
+++ b/frontend/include/chpl/uast/Catch.h
@@ -64,6 +64,8 @@ class Catch final : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
+  std::string dumpChildLabelInner(int i) const override;
+
   int8_t errorChildNum_;
   int8_t bodyChildNum_;
   bool hasParensAroundError_;

--- a/frontend/include/chpl/uast/Class.h
+++ b/frontend/include/chpl/uast/Class.h
@@ -75,6 +75,8 @@ class Class final : public AggregateDecl {
     aggregateDeclMarkUniqueStringsInner(context);
   }
 
+  std::string dumpChildLabelInner(int i) const override;
+
  public:
   ~Class() override = default;
 

--- a/frontend/include/chpl/uast/Cobegin.h
+++ b/frontend/include/chpl/uast/Cobegin.h
@@ -74,6 +74,8 @@ class Cobegin final : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
+  std::string dumpChildLabelInner(int i) const override;
+
   int8_t withClauseChildNum_;
   int bodyChildNum_;
   int numTaskBodies_;

--- a/frontend/include/chpl/uast/Comment.h
+++ b/frontend/include/chpl/uast/Comment.h
@@ -57,6 +57,8 @@ class Comment final : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+
  public:
   ~Comment() override = default;
   static owned<Comment> build(Builder* builder, Location loc, std::string c);

--- a/frontend/include/chpl/uast/Conditional.h
+++ b/frontend/include/chpl/uast/Conditional.h
@@ -99,6 +99,9 @@ class Conditional final : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+  std::string dumpChildLabelInner(int i) const override;
+
   // Condition always exists, and its position is always the same.
   static const int8_t conditionChildNum_ = 0;
   // Ditto then

--- a/frontend/include/chpl/uast/Continue.h
+++ b/frontend/include/chpl/uast/Continue.h
@@ -60,6 +60,8 @@ class Continue : public AstNode {
   void markUniqueStringsInner(Context* context) const override {
   }
 
+  std::string dumpChildLabelInner(int i) const override;
+
   int8_t targetChildNum_;
 
  public:

--- a/frontend/include/chpl/uast/Decl.h
+++ b/frontend/include/chpl/uast/Decl.h
@@ -102,6 +102,8 @@ class Decl : public AstNode {
   void declMarkUniqueStringsInner(Context* context) const {
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+  std::string dumpChildLabelInner(int i) const override;
 
   int attributesChildNum() const {
     return attributesChildNum_;
@@ -151,6 +153,15 @@ class Decl : public AstNode {
     return (const Attributes*)ret;
   }
 
+  /**
+    Convert Decl::Visibility to a string
+    */
+  static const char* visibilityToString(Visibility v);
+
+  /**
+    Convert Decl::Linkage to a string
+    */
+  static const char* linkageToString(Linkage x);
 };
 
 

--- a/frontend/include/chpl/uast/DoWhile.h
+++ b/frontend/include/chpl/uast/DoWhile.h
@@ -73,6 +73,8 @@ class DoWhile final : public Loop {
     loopMarkUniqueStringsInner(context);
   }
 
+  std::string dumpChildLabelInner(int i) const override;
+
   int conditionChildNum_;
 
  public:

--- a/frontend/include/chpl/uast/Dot.h
+++ b/frontend/include/chpl/uast/Dot.h
@@ -68,6 +68,8 @@ class Dot final : public AstNode {
     fieldName_.mark(context);
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+
  public:
   ~Dot() override = default;
   static owned<Dot> build(Builder* builder,

--- a/frontend/include/chpl/uast/FnCall.h
+++ b/frontend/include/chpl/uast/FnCall.h
@@ -87,6 +87,7 @@ class FnCall : public Call {
       str.mark(context);
     }
   }
+  void dumpFieldsInner(const DumpSettings& s) const override;
 
  public:
   ~FnCall() override = default;

--- a/frontend/include/chpl/uast/Formal.h
+++ b/frontend/include/chpl/uast/Formal.h
@@ -99,7 +99,7 @@ class Formal final : public VarLikeDecl {
    */
   Intent intent() const { return (Intent)((int)storageKind()); }
 
-  static std::string intentToString(Intent intent);
+  static const char* intentToString(Intent intent);
 
   /**
     If `true`, then this formal's name is '_', as in `proc(_: int)`. This is

--- a/frontend/include/chpl/uast/Function.h
+++ b/frontend/include/chpl/uast/Function.h
@@ -190,6 +190,9 @@ class Function final : public NamedDecl {
     namedDeclMarkUniqueStringsInner(context);
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+  std::string dumpChildLabelInner(int i) const override;
+
  public:
   ~Function() override = default;
 
@@ -379,9 +382,9 @@ class Function final : public NamedDecl {
     return b->stmt(i);
   }
 
-  static std::string returnIntentToString(ReturnIntent intent);
+  static const char* returnIntentToString(ReturnIntent intent);
 
-  static std::string kindToString(Kind kind);
+  static const char* kindToString(Kind kind);
 };
 
 } // end namespace uast

--- a/frontend/include/chpl/uast/Identifier.h
+++ b/frontend/include/chpl/uast/Identifier.h
@@ -59,6 +59,8 @@ class Identifier final : public AstNode {
     this->name_.mark(context);
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+
  public:
   ~Identifier() override = default;
   static owned<Identifier> build(Builder* builder, Location loc, UniqueString name);

--- a/frontend/include/chpl/uast/IndexableLoop.h
+++ b/frontend/include/chpl/uast/IndexableLoop.h
@@ -77,6 +77,9 @@ class IndexableLoop : public Loop {
     loopMarkUniqueStringsInner(context);
   }
 
+  virtual void dumpFieldsInner(const DumpSettings& s) const override;
+  virtual std::string dumpChildLabelInner(int i) const override;
+
   int8_t indexChildNum_;
   int8_t iterandChildNum_;
   int8_t withClauseChildNum_;

--- a/frontend/include/chpl/uast/Loop.h
+++ b/frontend/include/chpl/uast/Loop.h
@@ -61,6 +61,8 @@ class Loop: public AstNode {
   void loopMarkUniqueStringsInner(Context* context) const {
   }
 
+  virtual std::string dumpChildLabelInner(int i) const override;
+
   BlockStyle blockStyle_;
   int loopBodyChildNum_;
 

--- a/frontend/include/chpl/uast/NamedDecl.h
+++ b/frontend/include/chpl/uast/NamedDecl.h
@@ -63,6 +63,8 @@ class NamedDecl : public Decl {
     name_.mark(context);
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+
  public:
   virtual ~NamedDecl() = 0; // this is an abstract base class
 

--- a/frontend/include/chpl/uast/NumericLiteral.h
+++ b/frontend/include/chpl/uast/NumericLiteral.h
@@ -51,6 +51,9 @@ class NumericLiteral : public Literal {
     literalMarkUniqueStringsInner(context);
     text_.mark(context);
   }
+  void dumpFieldsInner(const DumpSettings& s) const override {
+    s.out << " " << value();
+  }
 
  public:
   virtual ~NumericLiteral() = 0; // this is an abstract base class

--- a/frontend/include/chpl/uast/OpCall.h
+++ b/frontend/include/chpl/uast/OpCall.h
@@ -63,6 +63,8 @@ class OpCall final : public Call {
     op_.mark(context);
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+
  public:
   ~OpCall() override = default;
   static owned<OpCall> build(Builder* builder,

--- a/frontend/include/chpl/uast/StringLikeLiteral.h
+++ b/frontend/include/chpl/uast/StringLikeLiteral.h
@@ -61,6 +61,16 @@ class StringLikeLiteral : public Literal {
   virtual ~StringLikeLiteral() = 0; // this is an abstract base class
 
   /**
+    Returns the value of this bytes literal as a UniqueString
+    which does not include the quotes.
+   */
+  UniqueString value() const {
+    CHPL_ASSERT(value_->isStringParam());
+    const types::StringParam* p = (const types::StringParam*) value_;
+    return p->value();
+  }
+
+  /**
    Returns the type of quotes used for this string literal.
    */
   QuoteStyle quoteStyle() const { return this->quotes_; }

--- a/frontend/include/chpl/uast/StringLikeLiteral.h
+++ b/frontend/include/chpl/uast/StringLikeLiteral.h
@@ -57,6 +57,8 @@ class StringLikeLiteral : public Literal {
     literalMarkUniqueStringsInner(context);
   }
 
+  void dumpFieldsInner(const DumpSettings& s) const override;
+
  public:
   virtual ~StringLikeLiteral() = 0; // this is an abstract base class
 
@@ -74,6 +76,12 @@ class StringLikeLiteral : public Literal {
    Returns the type of quotes used for this string literal.
    */
   QuoteStyle quoteStyle() const { return this->quotes_; }
+
+  /**
+    Returns a string containing the characters to open a quote with the
+    passed quote style
+   */
+  static const char* quoteStyleToString(QuoteStyle q);
 };
 
 

--- a/frontend/include/chpl/uast/StringLiteral.h
+++ b/frontend/include/chpl/uast/StringLiteral.h
@@ -47,16 +47,6 @@ class StringLiteral final : public StringLikeLiteral {
   static owned<StringLiteral> build(Builder* builder, Location loc,
                                     const std::string& value,
                                     StringLikeLiteral::QuoteStyle quotes);
-
-  /**
-    Returns the value of this string literal as a UniqueString
-    which does not include the quotes.
-   */
-  UniqueString str() const {
-    CHPL_ASSERT(value_->isStringParam());
-    const types::StringParam* p = (const types::StringParam*) value_;
-    return p->value();
-  }
 };
 
 

--- a/frontend/include/chpl/uast/chpl-syntax-printer.h
+++ b/frontend/include/chpl/uast/chpl-syntax-printer.h
@@ -23,8 +23,7 @@
 
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstTag.h"
-#include "chpl/uast/ASTTypes.h"
-#include "chpl/uast/all-uast.h"
+#include "chpl/uast/forward-declare-uast.h"
 
 
 #include<iostream>

--- a/frontend/include/chpl/uast/forward-declare-uast.h
+++ b/frontend/include/chpl/uast/forward-declare-uast.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_UAST_ASTTYPES_H
-#define CHPL_UAST_ASTTYPES_H
+#ifndef CHPL_FORWARD_DECLARE_UAST_H
+#define CHPL_FORWARD_DECLARE_UAST_H
 
 namespace chpl {
 namespace uast {

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -156,12 +156,12 @@ PODUniqueString ParserContext::notePragma(YYLTYPE loc,
 
   // Extract the string literal and convert it into a pragma flag.
   if (auto strLit = pragmaStr->toStringLiteral()) {
-    ret = PODUniqueString::get(context(), strLit->str().c_str());
+    ret = PODUniqueString::get(context(), strLit->value().c_str());
     auto tag = pragmaNameToTag(ret.c_str());
 
     if (tag == PRAGMA_UNKNOWN)
       CHPL_PARSER_REPORT_ERR(
-          this, loc, "unknown pragma \"" + strLit->str().str() + "\".");
+          this, loc, "unknown pragma \"" + strLit->value().str() + "\".");
 
     // Initialize the pragma flags if needed.
     auto& pragmas = attributeParts.pragmas;
@@ -190,7 +190,7 @@ void ParserContext::noteDeprecation(YYLTYPE loc, AstNode* messageStr) {
 
   if (messageStr) {
     if (auto strLit = messageStr->toStringLiteral()) {
-      attributeParts.deprecationMessage = strLit->str();
+      attributeParts.deprecationMessage = strLit->value();
     }
 
     delete messageStr;
@@ -210,7 +210,7 @@ void ParserContext::noteUnstable(YYLTYPE loc, AstNode* messageStr) {
 
   if (messageStr) {
     if (auto strLit = messageStr->toStringLiteral()) {
-      attributeParts.unstableMessage = strLit->str();
+      attributeParts.unstableMessage = strLit->value();
     }
 
     delete messageStr;
@@ -630,11 +630,11 @@ AstNode* ParserContext::buildPrimCall(YYLTYPE location,
   // first argument must be a string literal, might be a cstring though
   if (actuals.size() > 0) {
     if (auto lit = actuals[0]->toCStringLiteral()) {
-      primName = lit->str();
+      primName = lit->value();
       // and erase that element
       actuals.erase(actuals.begin());
     } else if (auto lit = actuals[0]->toStringLiteral()) {
-      primName = lit->str();
+      primName = lit->value();
       // and erase that element
       actuals.erase(actuals.begin());
     }

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -625,6 +625,7 @@ void callInitDeinit(Resolver& resolver) {
                                                        resolver.byPostorder,
                                                        splitInitedVars);
 
+  /*
   auto symName = UniqueString::get(resolver.context, "unknown");
   if (auto nd = resolver.symbol->toNamedDecl()) {
     symName = nd->name();
@@ -648,7 +649,7 @@ void callInitDeinit(Resolver& resolver) {
            id.str().c_str());
   }
   printf("\n");
-
+  */
 
   CallInitDeinit uv(resolver.context, resolver,
                     splitInitedVars, elidedCopyFromIds);

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1140,10 +1140,10 @@ const owned<ResolvedVisibilityScope>& resolveVisibilityStmtsQuery(
     for (auto req : requireNodes) {
       for (const AstNode* child : req->children()) {
         if (const StringLiteral* str = child->toStringLiteral()) {
-          const auto& path = str->str().str();
+          const auto& path = str->value().str();
           const std::string suffix = ".chpl";
           if (path.compare(path.size() - suffix.size(), suffix.size(), suffix) == 0) {
-            parsing::parseFileToBuilderResult(context, str->str(), UniqueString());
+            parsing::parseFileToBuilderResult(context, str->value(), UniqueString());
           }
         }
       }

--- a/frontend/lib/uast/AstList.cpp
+++ b/frontend/lib/uast/AstList.cpp
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-#include "chpl/uast/ASTTypes.h"
+#include "chpl/uast/AstList.h"
 
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstNode.h"

--- a/frontend/lib/uast/AstNode.cpp
+++ b/frontend/lib/uast/AstNode.cpp
@@ -32,6 +32,13 @@ namespace chpl {
 namespace uast {
 
 
+void AstNode::dumpFieldsInner(const DumpSettings& s) const {
+}
+
+std::string AstNode::dumpChildLabelInner(int i) const {
+  return "";
+}
+
 AstNode::~AstNode() {
 }
 
@@ -275,16 +282,11 @@ void AstNode::mark(Context* context) const {
 }
 
 static std::string getIdStr(const AstNode* ast) {
-  std::string idStr;
   if (ast == nullptr || ast->id().isEmpty()) {
-    idStr = "<no id>";
+    return "<no id>";
   } else {
-    std::ostringstream ss;
-    ast->id().stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
-    idStr = ss.str();
+    return ast->id().str();
   }
-
-  return idStr;
 }
 
 static void dumpMaxIdLen(const AstNode* ast, int& maxIdLen) {
@@ -299,61 +301,87 @@ static void dumpMaxIdLen(const AstNode* ast, int& maxIdLen) {
   }
 }
 
-static void dumpHelper(std::ostream& ss,
-                       const AstNode* ast,
-                       int maxIdLen,
-                       int depth,
-                       StringifyKind stringKind) {
-  std::string idStr = getIdStr(ast);
-  ss << std::setw(maxIdLen) << idStr;
+int AstNode::computeMaxIdStringWidth() const {
+  int maxIdLen = 0;
+  dumpMaxIdLen(this, maxIdLen);
+  return maxIdLen;
+}
 
+void AstNode::dumpHelper(const DumpSettings& s,
+                         const AstNode* ast,
+                         int indent,
+                         const AstNode* parent,
+                         int parentIdx) {
 
-  if (depth == 0) {
-    ss << " ";
-  }
-  for (int i = 0; i < depth; i++) {
-    ss << "  ";
-  }
-
-  if (ast == nullptr) {
-    ss << "nullptr\n";
-    return;
+  // output the id if desired
+  if (s.printId) {
+    std::string idStr = getIdStr(ast);
+    s.out << std::setw(s.idWidth) << idStr << std::setw(0);
   }
 
-  ss << asttags::tagToString(ast->tag()) << " ";
-
-  if (const NamedDecl* named = ast->toNamedDecl()) {
-    ss << named->name().str() << " ";
-  } else if (const Identifier* ident = ast->toIdentifier()) {
-    ss << ident->name().str() << " ";
-  } else if (const Comment* comment = ast->toComment()) {
-    ss << comment->str() << " ";
-  } else if (const Dot* dot = ast->toDot()) {
-    ss << "." << dot->field() << " ";
-  } else if (const OpCall* op = ast->toOpCall()) {
-    ss << op->op().str() << " ";
+  if (s.kind == StringifyKind::DEBUG_DETAIL) {
+    // add spacing according to depth
+    // (includes one space to separate id from the rest)
+    for (int i = 0; i <= indent; i++) {
+      s.out << "  ";
+    }
   }
 
-  //printf("(containing %i) ", ast->id().numContainedChildren());
-  //printf("%p", ast);
-  if (stringKind == StringifyKind::DEBUG_DETAIL)
-    ss << "\n";
+  // output the label if there is one
+  if (parent != nullptr) {
+    std::string label = parent->dumpChildLabelInner(parentIdx);
+    if (!label.empty()) {
+      s.out << label << " ";
+    }
+  }
 
+  // output the tag
+  s.out << asttags::tagToString(ast->tag());
+
+  // output the fields
+  ast->dumpFieldsInner(s);
+
+  if (s.kind == StringifyKind::DEBUG_DETAIL) {
+    s.out << "\n";
+  }
+
+  // output the child nodes
+  int i = 0;
   for (const AstNode* child : ast->children()) {
-    dumpHelper(ss, child, maxIdLen, depth+1, stringKind);
+    if (child != nullptr) {
+      dumpHelper(s, child, indent+1, ast, i);
+    } else {
+      s.out << "nullptr";
+    }
+    i++;
   }
+
+  return;
 }
 
 void AstNode::stringify(std::ostream& ss,
                         StringifyKind stringKind) const {
 
-  if (stringKind == StringifyKind::CHPL_SYNTAX) {
-    printChapelSyntax(ss, this);
-  } else {
-    int maxIdLen = 0;
-    int leadingSpaces = 0;
-    dumpMaxIdLen(this, maxIdLen);
-    dumpHelper(ss, this, maxIdLen, leadingSpaces, stringKind);
+  switch (stringKind) {
+    case StringifyKind::CHPL_SYNTAX:
+      // use the Chapel Syntax printer
+      printChapelSyntax(ss, this);
+      break;
+    case StringifyKind::DEBUG_SUMMARY:
+      // just print the ID
+      this->id().stringify(ss, stringKind);
+      break;
+    case StringifyKind::DEBUG_DETAIL:
+      {
+        auto s = DumpSettings(ss);
+        s.kind = stringKind;
+        s.printId = true;
+        // compute the maximum id width so it's a nice column
+        int maxIdLen = computeMaxIdStringWidth();
+        s.idWidth = maxIdLen;
+        dumpHelper(s, this, 0, /*parent*/ nullptr, /*parentIdx*/-1);
+      }
+      break;
   }
 }
 

--- a/frontend/lib/uast/Begin.cpp
+++ b/frontend/lib/uast/Begin.cpp
@@ -25,6 +25,14 @@ namespace chpl {
 namespace uast {
 
 
+std::string Begin::dumpChildLabelInner(int i) const {
+  if (withClauseChildNum_ >= 0 && i == withClauseChildNum_) {
+    return "with";
+  }
+
+  return "";
+}
+
 owned<Begin> Begin::build(Builder* builder,
                           Location loc,
                           owned<WithClause> withClause,

--- a/frontend/lib/uast/BoolLiteral.cpp
+++ b/frontend/lib/uast/BoolLiteral.cpp
@@ -25,6 +25,10 @@ namespace chpl {
 namespace uast {
 
 
+void BoolLiteral::dumpFieldsInner(const DumpSettings& s) const {
+  s.out << " " << value();
+}
+
 owned<BoolLiteral> BoolLiteral::build(Builder* builder, Location loc,
                                       bool value) {
   // construct the Param

--- a/frontend/lib/uast/Break.cpp
+++ b/frontend/lib/uast/Break.cpp
@@ -25,6 +25,14 @@ namespace chpl {
 namespace uast {
 
 
+std::string Break::dumpChildLabelInner(int i) const {
+  if (i == targetChildNum_) {
+    return "label";
+  }
+
+  return "";
+}
+
 owned<Break> Break::build(Builder* builder, Location loc,
                           owned<Identifier> target) {
   AstList lst;

--- a/frontend/lib/uast/Call.cpp
+++ b/frontend/lib/uast/Call.cpp
@@ -23,6 +23,21 @@ namespace chpl {
 namespace uast {
 
 
+std::string Call::dumpChildLabelInner(int i) const {
+  if (hasCalledExpression_ && i == 0) {
+    return "called-expr";
+  }
+
+  int shift = 0;
+  if (hasCalledExpression_) {
+    shift = 1;
+  }
+
+  std::string ret = "actual ";
+  ret += std::to_string(i - shift);
+  return ret;
+}
+
 Call::~Call() {
 }
 

--- a/frontend/lib/uast/Catch.cpp
+++ b/frontend/lib/uast/Catch.cpp
@@ -25,6 +25,16 @@ namespace chpl {
 namespace uast {
 
 
+std::string Catch::dumpChildLabelInner(int i) const {
+  if (i == errorChildNum_) {
+    return "error";
+  } else if (i == bodyChildNum_) {
+    return "body";
+  }
+
+  return "";
+}
+
 owned<Catch> Catch::build(Builder* builder, Location loc,
                           owned<Variable> error,
                           owned<Block> body,

--- a/frontend/lib/uast/Class.cpp
+++ b/frontend/lib/uast/Class.cpp
@@ -25,6 +25,14 @@ namespace chpl {
 namespace uast {
 
 
+std::string Class::dumpChildLabelInner(int i) const {
+  if (i == parentClassChildNum_) {
+    return "parent-class";
+  }
+
+  return "";
+}
+
 owned<Class> Class::build(Builder* builder, Location loc,
                           owned<Attributes> attributes,
                           Decl::Visibility vis,

--- a/frontend/lib/uast/Cobegin.cpp
+++ b/frontend/lib/uast/Cobegin.cpp
@@ -25,6 +25,18 @@ namespace chpl {
 namespace uast {
 
 
+std::string Cobegin::dumpChildLabelInner(int i) const {
+  if (i == withClauseChildNum_) {
+    return "with";
+  } else if (i > bodyChildNum_) {
+    std::string ret = "task-body ";
+    ret += std::to_string(i - bodyChildNum_);
+    return ret;
+  }
+
+  return "";
+}
+
 owned<Cobegin> Cobegin::build(Builder* builder,
                               Location loc,
                               owned<WithClause> withClause,

--- a/frontend/lib/uast/Comment.cpp
+++ b/frontend/lib/uast/Comment.cpp
@@ -25,6 +25,10 @@ namespace chpl {
 namespace uast {
 
 
+void Comment::dumpFieldsInner(const DumpSettings& s) const {
+  s.out << " #" << commentId_.index();
+}
+
 owned<Comment> Comment::build(Builder* builder, Location loc, std::string c) {
   Comment* ret = new Comment(std::move(c));
   builder->noteLocation(ret, loc);

--- a/frontend/lib/uast/Conditional.cpp
+++ b/frontend/lib/uast/Conditional.cpp
@@ -25,6 +25,23 @@ namespace chpl {
 namespace uast {
 
 
+void Conditional::dumpFieldsInner(const DumpSettings& s) const {
+  if (isExpressionLevel_) {
+    s.out << " expr";
+  }
+}
+std::string Conditional::dumpChildLabelInner(int i) const {
+  if (i == conditionChildNum_) {
+    return "condition";
+  } else if (i == thenBodyChildNum_) {
+    return "then";
+  } else if (i == elseBodyChildNum_) {
+    return "else";
+  }
+
+  return "";
+}
+
 owned<Conditional> Conditional::build(Builder* builder, Location loc,
                                       owned<AstNode> condition,
                                       BlockStyle thenBlockStyle,

--- a/frontend/lib/uast/Continue.cpp
+++ b/frontend/lib/uast/Continue.cpp
@@ -25,6 +25,14 @@ namespace chpl {
 namespace uast {
 
 
+std::string Continue::dumpChildLabelInner(int i) const {
+  if (i == targetChildNum_) {
+    return "label";
+  }
+
+  return "";
+}
+
 owned<Continue> Continue::build(Builder* builder, Location loc,
                                 owned<Identifier> target) {
   AstList lst;

--- a/frontend/lib/uast/Decl.cpp
+++ b/frontend/lib/uast/Decl.cpp
@@ -26,6 +26,47 @@ namespace uast {
 Decl::~Decl() {
 }
 
+void Decl::dumpFieldsInner(const DumpSettings& s) const {
+  const char* v = visibilityToString(visibility_);
+  const char* k = linkageToString(linkage_);
+  if (v[0] != 0) {
+    s.out << " " << v;
+  }
+  if (k[0] != 0) {
+    s.out << " " << k;
+  }
+}
+std::string Decl::dumpChildLabelInner(int i) const {
+  if (i == attributesChildNum_) {
+    return "attributes";
+  } else if (i == linkageNameChildNum_) {
+    return "linkage-name";
+  }
+
+  return "";
+}
+
+const char* Decl::visibilityToString(Visibility v) {
+  switch (v) {
+    case Visibility::DEFAULT_VISIBILITY: return "";
+    case Visibility::PUBLIC:             return "public";
+    case Visibility::PRIVATE:            return "private";
+  }
+  CHPL_ASSERT(false);
+  return "<unknown>";
+}
+
+
+const char* Decl::linkageToString(Linkage x) {
+  switch (x) {
+    case Linkage::DEFAULT_LINKAGE: return "";
+    case Linkage::EXTERN:          return "extern";
+    case Linkage::EXPORT:          return "export";
+  }
+  CHPL_ASSERT(false);
+  return "<unknown>";
+}
+
 
 } // namespace uast
 } // namespace chpl

--- a/frontend/lib/uast/DoWhile.cpp
+++ b/frontend/lib/uast/DoWhile.cpp
@@ -25,6 +25,14 @@ namespace chpl {
 namespace uast {
 
 
+std::string DoWhile::dumpChildLabelInner(int i) const {
+  if (i == conditionChildNum_) {
+    return "condition";
+  }
+
+  return "";
+}
+
 owned<DoWhile> DoWhile::build(Builder* builder, Location loc,
                               BlockStyle blockStyle,
                               owned<Block> body,

--- a/frontend/lib/uast/Dot.cpp
+++ b/frontend/lib/uast/Dot.cpp
@@ -25,6 +25,10 @@ namespace chpl {
 namespace uast {
 
 
+void Dot::dumpFieldsInner(const DumpSettings& s) const {
+  s.out << " ." << fieldName_.str();
+}
+
 owned<Dot> Dot::build(Builder* builder,
                       Location loc,
                       owned<AstNode> receiver,

--- a/frontend/lib/uast/FnCall.cpp
+++ b/frontend/lib/uast/FnCall.cpp
@@ -25,12 +25,28 @@ namespace chpl {
 namespace uast {
 
 
-  owned<FnCall> FnCall::build(Builder* builder,
-                              Location loc,
-                              owned<AstNode> calledExpression,
-                              AstList actuals,
-                              std::vector<UniqueString> actualNames,
-                              bool callUsedSquareBrackets) {
+void FnCall::dumpFieldsInner(const DumpSettings& s) const {
+  Call::dumpFieldsInner(s);
+
+  if (callUsedSquareBrackets_) {
+    s.out << "[]";
+  }
+
+  int i = 0;
+  for (auto name : actualNames_) {
+    if (!name.isEmpty()) {
+      s.out << " actual " << i << " name= " << name.str();
+    }
+    i++;
+  }
+}
+
+owned<FnCall> FnCall::build(Builder* builder,
+                            Location loc,
+                            owned<AstNode> calledExpression,
+                            AstList actuals,
+                            std::vector<UniqueString> actualNames,
+                            bool callUsedSquareBrackets) {
   AstList lst;
 
   lst.push_back(std::move(calledExpression));
@@ -44,6 +60,7 @@ namespace uast {
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }
+
 owned<FnCall> FnCall::build(Builder* builder,
                             Location loc,
                             owned<AstNode> calledExpression,
@@ -57,6 +74,7 @@ owned<FnCall> FnCall::build(Builder* builder,
                        std::move(emptyActualNames),
                        callUsedSquareBrackets);
 }
+
 owned<FnCall> FnCall::build(Builder* builder,
                             Location loc,
                             owned<AstNode> calledExpression,

--- a/frontend/lib/uast/Formal.cpp
+++ b/frontend/lib/uast/Formal.cpp
@@ -24,20 +24,21 @@
 namespace chpl {
 namespace uast {
 
-std::string Formal::intentToString(Formal::Intent intent) {
+
+const char* Formal::intentToString(Formal::Intent intent) {
   switch (intent) {
     case DEFAULT_INTENT: return "";
-    case CONST: return "const";
-    case CONST_REF: return "const ref";
-    case REF: return "ref";
-    case IN: return "in";
-    case CONST_IN: return "const in";
-    case OUT: return "out";
-    case INOUT: return "inout";
-    case PARAM: return "param";
-    case TYPE: return "type";
+    case CONST:          return "const";
+    case CONST_REF:      return "const ref";
+    case REF:            return "ref";
+    case IN:             return "in";
+    case CONST_IN:       return "const in";
+    case OUT:            return "out";
+    case INOUT:          return "inout";
+    case PARAM:          return "param";
+    case TYPE:           return "type";
   }
-  return "<error>";
+  return "<unknown>";
 }
 
 owned<Formal>

--- a/frontend/lib/uast/Identifier.cpp
+++ b/frontend/lib/uast/Identifier.cpp
@@ -26,6 +26,12 @@ namespace chpl {
 namespace uast {
 
 
+void Identifier::dumpFieldsInner(const DumpSettings& s) const {
+  if (!name_.isEmpty()) {
+    s.out << " " << name_.str();
+  }
+}
+
 owned<Identifier> Identifier::build(Builder* builder,
                                     Location loc, UniqueString name) {
   Identifier* ret = new Identifier(name);

--- a/frontend/lib/uast/IndexableLoop.cpp
+++ b/frontend/lib/uast/IndexableLoop.cpp
@@ -25,6 +25,24 @@ namespace chpl {
 namespace uast {
 
 
+void IndexableLoop::dumpFieldsInner(const DumpSettings& s) const {
+  if (isExpressionLevel_) {
+    s.out << " expr";
+  }
+}
+
+std::string IndexableLoop::dumpChildLabelInner(int i) const {
+  if (i == indexChildNum_) {
+    return "index";
+  } else if (i == iterandChildNum_) {
+    return "iterand";
+  } else if (i == withClauseChildNum_) {
+    return "with";
+  }
+
+  return Loop::dumpChildLabelInner(i);
+}
+
 IndexableLoop::~IndexableLoop(){
 }
 

--- a/frontend/lib/uast/Loop.cpp
+++ b/frontend/lib/uast/Loop.cpp
@@ -23,6 +23,13 @@ namespace chpl {
 namespace uast {
 
 
+std::string Loop::dumpChildLabelInner(int i) const {
+  if (i == loopBodyChildNum_) {
+    return "body";
+  }
+  return "";
+}
+
 Loop::~Loop() {
 }
 

--- a/frontend/lib/uast/NamedDecl.cpp
+++ b/frontend/lib/uast/NamedDecl.cpp
@@ -22,6 +22,12 @@
 namespace chpl {
 namespace uast {
 
+void NamedDecl::dumpFieldsInner(const DumpSettings& s) const {
+  Decl::dumpFieldsInner(s);
+  if (!name_.isEmpty()) {
+    s.out << " " << name_.str();
+  }
+}
 
 NamedDecl::~NamedDecl() {
 }

--- a/frontend/lib/uast/NumericLiteral.cpp
+++ b/frontend/lib/uast/NumericLiteral.cpp
@@ -25,6 +25,16 @@ namespace chpl {
 namespace uast {
 
 
+/*template void NumericLiteral<double, types::RealParam>::dumpFieldsInner(const DumpSettings& s) const {
+  s.out << " " << value();
+}
+void NumericLiteral<int64_t, types::RealParam>::dumpFieldsInner(const DumpSettings& s) const {
+  s.out << " " << value();
+}
+void NumericLiteral<uint64_t, types::RealParam>::dumpFieldsInner(const DumpSettings& s) const {
+  s.out << " " << value();
+}*/
+
 template NumericLiteral<double, types::RealParam>::~NumericLiteral();
 template NumericLiteral<int64_t, types::IntParam>::~NumericLiteral();
 template NumericLiteral<uint64_t, types::UintParam>::~NumericLiteral();

--- a/frontend/lib/uast/NumericLiteral.cpp
+++ b/frontend/lib/uast/NumericLiteral.cpp
@@ -25,16 +25,6 @@ namespace chpl {
 namespace uast {
 
 
-/*template void NumericLiteral<double, types::RealParam>::dumpFieldsInner(const DumpSettings& s) const {
-  s.out << " " << value();
-}
-void NumericLiteral<int64_t, types::RealParam>::dumpFieldsInner(const DumpSettings& s) const {
-  s.out << " " << value();
-}
-void NumericLiteral<uint64_t, types::RealParam>::dumpFieldsInner(const DumpSettings& s) const {
-  s.out << " " << value();
-}*/
-
 template NumericLiteral<double, types::RealParam>::~NumericLiteral();
 template NumericLiteral<int64_t, types::IntParam>::~NumericLiteral();
 template NumericLiteral<uint64_t, types::UintParam>::~NumericLiteral();

--- a/frontend/lib/uast/OpCall.cpp
+++ b/frontend/lib/uast/OpCall.cpp
@@ -26,6 +26,10 @@ namespace chpl {
 namespace uast {
 
 
+void OpCall::dumpFieldsInner(const DumpSettings& s) const {
+  s.out << " " << op_.str();
+}
+
 owned<OpCall> OpCall::build(Builder* builder,
                             Location loc,
                             UniqueString op,

--- a/frontend/lib/uast/StringLikeLiteral.cpp
+++ b/frontend/lib/uast/StringLikeLiteral.cpp
@@ -20,12 +20,50 @@
 #include "chpl/uast/StringLikeLiteral.h"
 
 #include "chpl/uast/Builder.h"
+#include "chpl/util/string-escapes.h"
 
 namespace chpl {
 namespace uast {
 
 
+void StringLikeLiteral::dumpFieldsInner(const DumpSettings& s) const {
+  const char* q = "\"";
+  const char* suffix = "";
+
+  switch (quotes_) {
+    case StringLikeLiteral::SINGLE:
+      q = "'";
+      break;
+    case StringLikeLiteral::DOUBLE:
+      break;
+    case StringLikeLiteral::TRIPLE_SINGLE:
+      q = "'";
+      suffix = " triple-single";
+      break;
+    case StringLikeLiteral::TRIPLE_DOUBLE:
+      suffix = " triple-double";
+      break;
+  }
+
+  s.out << q
+        << escapeStringC(value().str())
+        << q
+        << suffix;
+}
+
 StringLikeLiteral::~StringLikeLiteral() {
+}
+
+const char* StringLikeLiteral::quoteStyleToString(QuoteStyle q) {
+  switch (q) {
+    case StringLikeLiteral::SINGLE:        return "'";
+    case StringLikeLiteral::DOUBLE:        return "\"";
+    case StringLikeLiteral::TRIPLE_SINGLE: return "'''";
+    case StringLikeLiteral::TRIPLE_DOUBLE: return "\"\"\"";
+  }
+
+  CHPL_ASSERT(false && "should not be reached");
+  return "";
 }
 
 

--- a/frontend/lib/uast/chpl-syntax-printer.cpp
+++ b/frontend/lib/uast/chpl-syntax-printer.cpp
@@ -535,7 +535,7 @@ struct ChplSyntaxVisitor {
   }
 
   void visit(const BytesLiteral* node) {
-    ss_ << "b\"" << escapeStringC(node->str().str()) << '"';
+    ss_ << "b\"" << escapeStringC(node->value().str()) << '"';
   }
 
   void visit(const Catch* node) {
@@ -637,7 +637,7 @@ struct ChplSyntaxVisitor {
   }
 
   void visit(const CStringLiteral* node) {
-    ss_ << "c\"" << escapeStringC(node->str().str()) << '"';
+    ss_ << "c\"" << escapeStringC(node->value().str()) << '"';
   }
 
   void visit(const Defer* node) {
@@ -1178,7 +1178,7 @@ struct ChplSyntaxVisitor {
   }
 
   void visit(const StringLiteral* node) {
-    ss_ << '"' << escapeStringC(node->str().str()) << '"';
+    ss_ << '"' << escapeStringC(node->value().str()) << '"';
   }
 
   void visit(const Sync* node) {

--- a/frontend/lib/uast/chpl-syntax-printer.cpp
+++ b/frontend/lib/uast/chpl-syntax-printer.cpp
@@ -19,7 +19,9 @@
 
 
 #include "chpl/uast/chpl-syntax-printer.h"
+
 #include "chpl/framework/global-strings.h"
+#include "chpl/uast/all-uast.h"
 
 
 using namespace chpl;

--- a/frontend/test/parsing/testParseAggregate.cpp
+++ b/frontend/test/parsing/testParseAggregate.cpp
@@ -494,7 +494,7 @@ static void test11(Parser* parser) {
   assert(rec2->linkage() == Decl::Linkage::EXTERN);
   assert(rec2->linkageName());
   assert(rec2->linkageName()->isStringLiteral());
-  assert(rec2->linkageName()->toStringLiteral()->str() == "struct bar");
+  assert(rec2->linkageName()->toStringLiteral()->value() == "struct bar");
   assert(rec2->numDeclOrComments() == 0);
 
   auto rec3 = mod->stmt(2)->toRecord();
@@ -508,7 +508,7 @@ static void test11(Parser* parser) {
   assert(rec4->linkage() == Decl::Linkage::EXPORT);
   assert(rec4->linkageName());
   assert(rec4->linkageName()->isStringLiteral());
-  assert(rec4->linkageName()->toStringLiteral()->str() == "meow");
+  assert(rec4->linkageName()->toStringLiteral()->value() == "meow");
   assert(rec4->numDeclOrComments() == 1);
 
   auto uni5 = mod->stmt(4)->toUnion();
@@ -522,7 +522,7 @@ static void test11(Parser* parser) {
   assert(uni6->linkage() == Decl::Linkage::EXTERN);
   assert(uni6->linkageName());
   assert(uni6->linkageName()->isStringLiteral());
-  assert(uni6->linkageName()->toStringLiteral()->str() == "union thing");
+  assert(uni6->linkageName()->toStringLiteral()->value() == "union thing");
   assert(uni6->numDeclOrComments() == 0);
 }
 

--- a/frontend/test/parsing/testParseStringBytesLiterals.cpp
+++ b/frontend/test/parsing/testParseStringBytesLiterals.cpp
@@ -55,7 +55,7 @@ static void testStringLiteral(Parser* parser,
   auto strLit = initExpr->toStringLiteral();
   assert(strLit);
   assert(strLit->quoteStyle() == expectQuoteStyle);
-  assert(strLit->str().str() == expectValue);
+  assert(strLit->value().str() == expectValue);
 }
 static void testBytesLiteral(Parser* parser,
                              const std::string& testname,
@@ -67,7 +67,7 @@ static void testBytesLiteral(Parser* parser,
   auto bytesLit = initExpr->toBytesLiteral();
   assert(bytesLit);
   assert(bytesLit->quoteStyle() == expectQuoteStyle);
-  assert(bytesLit->str().str() == expectValue);
+  assert(bytesLit->value().str() == expectValue);
 }
 static void testCStringLiteral(Parser* parser,
                                const std::string& testname,
@@ -79,7 +79,7 @@ static void testCStringLiteral(Parser* parser,
   auto strLit = initExpr->toCStringLiteral();
   assert(strLit);
   assert(strLit->quoteStyle() == expectQuoteStyle);
-  assert(strLit->str().str() == expectValue);
+  assert(strLit->value().str() == expectValue);
 }
 
 static void testTripleLiteral(Parser* parser,

--- a/frontend/test/parsing/testParseVariables.cpp
+++ b/frontend/test/parsing/testParseVariables.cpp
@@ -294,7 +294,7 @@ static void test4(Parser* parser) {
   assert(var3->linkage() == Decl::EXTERN);
   assert(var3->linkageName() &&  var3->linkageName()->isStringLiteral());
   auto v3LinkageName = var3->linkageName()->toStringLiteral();
-  assert(v3LinkageName->str() == "foo");
+  assert(v3LinkageName->value() == "foo");
   assert(var3->visibility() == Decl::PRIVATE);
 }
 

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -27,26 +27,28 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 
-static UniqueString nameForAst(const AstNode* ast) {
-  UniqueString empty;
+#include <iomanip>
 
+static std::string nameForAst(const AstNode* ast) {
   if (ast == nullptr) {
-    return empty;
+    return "";
   } else if (auto ident = ast->toIdentifier()) {
-    return ident->name();
+    return ident->name().str();
   } else if (auto decl = ast->toNamedDecl()) {
-    return decl->name();
+    return decl->name().str();
   } else if (auto call = ast->toCall()) {
     return nameForAst(call->calledExpression());
   }
 
-  return empty;
+  return "";
 }
 
-static void printId(const AstNode* ast) {
-  std::ostringstream ss;
-  ast->id().stringify(ss, chpl::StringifyKind::DEBUG_SUMMARY);
-  printf("%-16s %-8s", ss.str().c_str(), nameForAst(ast).c_str());
+static const char* tagToString(const AstNode* ast) {
+  if (ast == nullptr) {
+    return "null";
+  } else {
+    return asttags::tagToString(ast->tag());
+  }
 }
 
 static const ResolvedExpression*
@@ -90,6 +92,10 @@ resolvedExpressionForAst(Context* context, const AstNode* ast,
     }
   }
 
+  if (inFn != nullptr && inFn->id() != ast->id() &&
+      inFn->id().contains(ast->id())) {
+    return &inFn->byAst(ast);
+  }
   return nullptr;
 }
 
@@ -98,8 +104,8 @@ computeAndPrintStuff(Context* context,
                      const AstNode* ast,
                      const ResolvedFunction* inFn,
                      std::set<const ResolvedFunction*>& calledFns,
-                     bool scopeResolveOnly) {
-
+                     bool scopeResolveOnly,
+                     int maxIdWidth) {
   // Scope resolve / resolve concrete functions before printing
   if (auto fn = ast->toFunction()) {
     if (scopeResolveOnly) {
@@ -114,45 +120,12 @@ computeAndPrintStuff(Context* context,
   }
 
   for (const AstNode* child : ast->children()) {
-    computeAndPrintStuff(context, child, inFn, calledFns, scopeResolveOnly);
+    computeAndPrintStuff(context, child, inFn, calledFns,
+                         scopeResolveOnly, maxIdWidth);
+    if (child->isModule() || child->isFunction()) {
+      std::cout << "\n";
+    }
   }
-
-  /*
-  if (auto ident = ast->toIdentifier()) {
-    const Scope* scope = scopeForId(context, ast->id());
-    assert(scope != nullptr);
-
-    auto name = ident->name();
-    const auto& m = findInnermostDecl(context, scope, name);
-
-    auto status = context->queryStatus(findInnermostDecl,
-                                       std::make_tuple(scope, name));
-
-    printId(ast);
-    printf(" refers to: ");
-
-    if (m.found == InnermostMatch::ZERO) {
-      printf("%-32s ", "no such name found");
-    } else if (m.found == InnermostMatch::ONE && m.id.isEmpty()) {
-      printf("%-32s ", "builtin");
-    } else if (m.found == InnermostMatch::ONE) {
-      std::ostringstream ss;
-      m.id.stringify(ss, chpl::StringifyKind::DEBUG_SUMMARY);
-      printf("%-32s ", ss.str().c_str());
-    } else {
-      printf("%-32s ", "ambiguity");
-    }
-
-    if (status == Context::NOT_CHECKED_NOT_CHANGED) {
-      printf("(not checked)");
-    } else if (status == Context::REUSED) {
-      printf("(reused)");
-    } else if (status == Context::CHANGED) {
-      printf("(changed)");
-    }
-
-    printf("\n");
-  }*/
 
   int beforeCount = context->numQueriesRunThisRevision();
   const ResolvedExpression* r =
@@ -177,40 +150,29 @@ computeAndPrintStuff(Context* context,
       }
     }
 
-    printId(ast);
-    std::ostringstream ss;
-    r->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
-    // TODO: Surely we can format when we stringify?
-    printf("%-35s ", ss.str().c_str());
+    std::string idStr = ast->id().str();
+    std::string tagStr = tagToString(ast);
+    std::string nameStr = nameForAst(ast);
+
+    // output the ID
+    std::cout << std::setw(maxIdWidth) << idStr << std::setw(0);
+
+    // output the tag and name (if any name)
+    std::string tagNameStr = " " + tagStr;
+    if (!nameStr.empty()) {
+      tagNameStr += " " + nameStr;
+    }
+    std::cout << std::setw(16) << tagNameStr << std::setw(0);
+
+    // output the resolution result
+    r->stringify(std::cout, chpl::StringifyKind::CHPL_SYNTAX);
+
     if (afterCount > beforeCount) {
-      printf(" (ran %i queries)", afterCount - beforeCount);
+      std::cout << " (ran " << (afterCount - beforeCount) << " queries)";
     }
-    printf("\n");
+    std::cout << "\n";
+
   }
-
-  // check the type
-  /*
-  if (!(ast->isLoop() || ast->isBlock())) {
-    const auto& t = typeForModuleLevelSymbol(context, ast->id());
-
-    printId(ast);
-    printf(" has type:  ");
-    std::ostringstream ss;
-    t.stringify(ss, chpl::StringifyKind::DEBUG_SUMMARY);
-    printf("%-32s ", ss.str().c_str());
-
-    auto status = context->queryStatus(typeForModuleLevelSymbol,
-                                       std::make_tuple(ast->id()));
-
-    if (status == Context::NOT_CHECKED_NOT_CHANGED) {
-      printf("(not checked)");
-    } else if (status == Context::REUSED) {
-      printf("(reused)");
-    } else if (status == Context::CHANGED) {
-      printf("(changed)");
-    }
-    printf("\n");
-  }*/
 }
 
 static void usage(int argc, char** argv) {
@@ -315,7 +277,9 @@ int main(int argc, char** argv) {
         mod->stringify(std::cout, chpl::StringifyKind::DEBUG_DETAIL);
         printf("\n");
 
-        computeAndPrintStuff(ctx, mod, nullptr, calledFns, scopeResolveOnly);
+        int maxIdWidth = mod->computeMaxIdStringWidth();
+        computeAndPrintStuff(ctx, mod, nullptr, calledFns,
+                             scopeResolveOnly, maxIdWidth);
         printf("\n");
       }
     }
@@ -347,8 +311,9 @@ int main(int argc, char** argv) {
             printf("Instantiation is ");
             sig->stringify(std::cout, chpl::StringifyKind::CHPL_SYNTAX);
             printf("\n");
+            int maxIdWidth = ast->computeMaxIdStringWidth();
             computeAndPrintStuff(ctx, ast, calledFn, calledFns,
-                                 scopeResolveOnly);
+                                 scopeResolveOnly, maxIdWidth);
             printf("\n");
           }
         }

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1014,7 +1014,7 @@ struct RstSignatureVisitor {
   }
 
   bool enter(const CStringLiteral* l) {
-    os_ << "c\"" << escapeStringC(l->str().c_str()) << '"';
+    os_ << "c\"" << escapeStringC(l->value().str()) << '"';
     return false;
   }
 
@@ -1251,7 +1251,7 @@ struct RstSignatureVisitor {
   }
 
   bool enter(const StringLiteral* l) {
-    os_ << '"' << escapeStringC(l->str().c_str()) << '"';
+    os_ << '"' << escapeStringC(l->value().str()) << '"';
     return false;
   }
 


### PR DESCRIPTION
This PR improves the dyno uAST dumps to make development easier. In particular, it seeks to add to the uAST dumps keywords to distinguish the role of child uAST nodes; for example between a Conditional's condition, then, or else parts. Additionally, it seeks to add important information that is otherwise stored only in fields and not currently output by a uAST dump; for example, what name an Identifier refers to. To enable that:
 * AstNode defines two new virtual methods:
   * dumpFieldsInner to output fields for subclasses
   * dumpChildLabelInner to output a label for particular child nodes.

Additionally, it takes two other clean-up steps

1. It renames `ASTTypes.h` to `forward-declare-uast.h` so its purpose is clearer and also so that it does not appear to define a class named ASTTypes.
2. It renames String/Bytes/CStringLiteral.str() to .value() and makes it available on StringLikeLiteral since it uses the same implementation for all 3. The reason to rename it is that `.str()` makes it sound like it returns a `std::string` like `UniqueString::str()` does. At the same time, the other Literals and Params use `.value()` to get the value of the literal.

### Example

Input chpl code:

<details>

``` chapel
proc foo() {
  return 1;
}

proc bar() {
  return 1.0;
}

proc f() {
  return true;
}

if f() then
  foo();
else 
  bar();
```

</details>

uAST and resolution dump from testInteractive before this PR:

<details>

```
      mymodule Module mymodule 
  mymodule.foo  Function foo 
mymodule.foo@2    Block 
mymodule.foo@1      Return 
mymodule.foo@0        IntLiteral 
  mymodule.bar  Function bar 
mymodule.bar@2    Block 
mymodule.bar@1      Return 
mymodule.bar@0        RealLiteral 
    mymodule.f  Function f 
  mymodule.f@2    Block 
  mymodule.f@1      Return 
  mymodule.f@0        BoolLiteral 
    mymodule@8  Conditional 
    mymodule@1    FnCall 
    mymodule@0      Identifier f 
    mymodule@4    Block 
    mymodule@3      FnCall 
    mymodule@2        Identifier foo 
    mymodule@7    Block 
    mymodule@6      FnCall 
    mymodule@5        Identifier bar 

mymodule.foo@0            : param int(64) = 1 ;              
mymodule.foo@1            : unknown ;                        
mymodule.bar@0            : param real(64) = 1.000000 ;      
mymodule.bar@1            : unknown ;                        
mymodule.f@0              : param bool = 1 ;                 
mymodule.f@1              : unknown ;                        
mymodule@0       f        : function ;  refers to mymodule.f  (ran 33 queries)
mymodule@1       f        : var bool ;  calls mymodule.f()   
mymodule@2       foo      : function ;  refers to mymodule.foo 
mymodule@3       foo      : var int(64) ;  calls mymodule.foo() 
mymodule@5       bar      : function ;  refers to mymodule.bar 
mymodule@6       bar      : var real(64) ;  calls mymodule.bar() 
mymodule@8                : unknown ;     
```

</details>

uAST and resolution dump from testInteractive after this PR:

<details>

```
      mymodule  Module mymodule
  mymodule.foo    Function proc
mymodule.foo@2      body Block
mymodule.foo@1        Return
mymodule.foo@0          IntLiteral 1
  mymodule.bar    Function proc
mymodule.bar@2      body Block
mymodule.bar@1        Return
mymodule.bar@0          RealLiteral 1
    mymodule.f    Function proc
  mymodule.f@2      body Block
  mymodule.f@1        Return
  mymodule.f@0          BoolLiteral 1
    mymodule@8    Conditional
    mymodule@1      condition FnCall
    mymodule@0        called-expr Identifier f
    mymodule@4      then Block
    mymodule@3        FnCall
    mymodule@2          called-expr Identifier foo
    mymodule@7      else Block
    mymodule@6        FnCall
    mymodule@5          called-expr Identifier bar

mymodule.foo@0      IntLiteral : param int(64) = 1 ; 
mymodule.foo@1          Return : unknown ; 
mymodule.foo@2           Block : unknown ; 

mymodule.bar@0     RealLiteral : param real(64) = 1.000000 ; 
mymodule.bar@1          Return : unknown ; 
mymodule.bar@2           Block : unknown ; 

  mymodule.f@0     BoolLiteral : param bool = 1 ; 
  mymodule.f@1          Return : unknown ; 
  mymodule.f@2           Block : unknown ; 

    mymodule@0    Identifier f : function ;  refers to mymodule.f (ran 33 queries)
    mymodule@1        FnCall f : var bool ;  calls mymodule.f()
    mymodule@2  Identifier foo : function ;  refers to mymodule.foo
    mymodule@3      FnCall foo : var int(64) ;  calls mymodule.foo()
    mymodule@5  Identifier bar : function ;  refers to mymodule.bar
    mymodule@6      FnCall bar : var real(64) ;  calls mymodule.bar()
    mymodule@8     Conditional : unknown ; 
```

</details>


Reviewed by @arezaii - thanks!

- [x] full local testing 5343564d4343126b74a09c12f1519ab91421ae22