### PR TITLE
Correct and improve Map.this() non-nilable class error, add tests

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -398,8 +398,8 @@ module Map {
     proc const this(k: keyType)
     where isNonNilableClass(valType) {
       _warnForParSafeIndexing();
-      compilerError("Cannot access nilable class directly. Use an",
-                    " appropriate accessor method instead.");
+      compilerError("Cannot index into a map with non-nilable class values. ",
+                    "Use an appropriate accessor method instead.");
     }
 
     /* Get a borrowed reference to the element at position `k`.

--- a/test/library/standard/Map/types/MapTest.chpl
+++ b/test/library/standard/Map/types/MapTest.chpl
@@ -1,6 +1,9 @@
 import Map.map;
 
-proc testMap(type t) {
+/* Tests indexing only for nilable classes.  testIndexing arg allows
+ * overriding to test the error for nonnilable, and to test indexing
+ * for records. */
+proc testMap(type t, param testIndexing = false) {
 
   var m = new map(int, t);
 
@@ -20,6 +23,32 @@ proc testMap(type t) {
   ret = m.remove(1);
   assert(ret);
   assert(!m.contains(2));
+
+  if isNilableClass(t) {
+    ret = m.add(0, nil:t);
+    assert(ret);
+    var n = m.getValue(0);
+    assert(n == nil);
+    ret = m.remove(0);
+    assert(ret);
+  }
+
+  if isNilableClass(t) || testIndexing {
+    var z: t;
+    z = if isTuple(t) then (new t[0](3), new t[1](4)) else new t(3);
+    m[3] = z;
+
+    assert(m.contains(3));
+
+    var zz: t = m[3];
+
+    ret = m.remove(3);
+    assert(ret);
+
+    if isUnmanagedClass(t) {
+      delete z;
+    }
+  }
 
   if isUnmanagedClass(t) {
     delete x;

--- a/test/library/standard/Map/types/testBorrowed.good
+++ b/test/library/standard/Map/types/testBorrowed.good
@@ -1,4 +1,4 @@
-./MapTest.chpl:3: In function 'testMap':
-./MapTest.chpl:8: warning: creating a 'new borrowed' type is deprecated
-./MapTest.chpl:15: warning: creating a 'new borrowed' type is deprecated
-  testBorrowed.chpl:9: called as testMap(type t = borrowed T)
+./MapTest.chpl:6: In function 'testMap':
+./MapTest.chpl:11: warning: creating a 'new borrowed' type is deprecated
+./MapTest.chpl:18: warning: creating a 'new borrowed' type is deprecated
+  testBorrowed.chpl:9: called as testMap(type t = borrowed T, param testIndexing = false)

--- a/test/library/standard/Map/types/testNilableBorrowed.chpl
+++ b/test/library/standard/Map/types/testNilableBorrowed.chpl
@@ -22,3 +22,22 @@ assert(!ret);
 ret = m.remove(1);
 assert(ret);
 assert(!m.contains(2));
+
+var z = new T(3);
+var zz: borrowed T? = z.borrow();
+
+m[4] = zz;
+assert(m.contains(4));
+var zzz: borrowed T? = m[4];
+assert(zzz!.value == 3);
+
+ret = m.add(0, nil);
+assert(ret);
+assert(m.contains(0));
+var zzzz = m.getValue(0);
+assert(zzzz == nil);
+ret = m.remove(0);
+assert(ret);
+
+ret = m.remove(4);
+assert(ret);

--- a/test/library/standard/Map/types/testNonNilableUnmanagedIndexingError.chpl
+++ b/test/library/standard/Map/types/testNonNilableUnmanagedIndexingError.chpl
@@ -1,0 +1,11 @@
+import MapTest;
+
+class T {
+  var value = 0;
+}
+
+type t = unmanaged T;
+
+// Test that using map.this() / map[i] indexing of a nonnilable type
+// generate an error.
+MapTest.testMap(t, testIndexing = true);

--- a/test/library/standard/Map/types/testNonNilableUnmanagedIndexingError.good
+++ b/test/library/standard/Map/types/testNonNilableUnmanagedIndexingError.good
@@ -1,0 +1,3 @@
+./MapTest.chpl:6: In function 'testMap':
+./MapTest.chpl:39: error: Cannot index into a map with non-nilable class values. Use an appropriate accessor method instead.
+  testNonNilableUnmanagedIndexingError.chpl:11: called as testMap(type t = unmanaged T, param testIndexing = true)

--- a/test/library/standard/Map/types/testRecord.chpl
+++ b/test/library/standard/Map/types/testRecord.chpl
@@ -6,4 +6,4 @@ record T {
 
 type t = T;
 
-MapTest.testMap(t);
+MapTest.testMap(t, testIndexing = true);

--- a/test/library/standard/Map/types/testTupleIndexingError.chpl
+++ b/test/library/standard/Map/types/testTupleIndexingError.chpl
@@ -1,0 +1,10 @@
+import MapTest;
+
+class T {
+  var value = 0;
+}
+
+type t = (shared T, shared T);
+
+// Test that indexing fails: Cannot assign to const variable
+MapTest.testMap(t, testIndexing = true);

--- a/test/library/standard/Map/types/testTupleIndexingError.good
+++ b/test/library/standard/Map/types/testTupleIndexingError.good
@@ -1,0 +1,3 @@
+./MapTest.chpl:6: In function 'testMap':
+./MapTest.chpl:39: error: cannot assign to const variable
+  testTupleIndexingError.chpl:10: called as testMap(type t = 2*shared T, param testIndexing = true)


### PR DESCRIPTION
The error is about non-nilable classes, not nilable classes, so correct it to say that.  Also have the error indicate that it's coming from a Map.this() routine to help the user identify what part of their code is to blame.

Update test/library/standard/Map/types tests to:

- Test indexing operations for maps with nilable classes and records as value types
- Test that maps with nilable class value types can have nil stored, retrieved, and removed.
- Test that indexing fails to compile for non-nilable classes and tuples.

Resolves #21222 