### PR TITLE
Update string.items() doc example

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1186,7 +1186,7 @@ module String {
     .. code-block:: chapel
 
       var str = "abcd";
-      for c in str {
+      for c in str.items() {
         writeln(c);
       }
 


### PR DESCRIPTION
Have the documented example of using string.items() actually invoke string.items() instead of relying on the implicit string.these() being equivalent.

---
Signed-off-by: Paul Cassella <gitgitgit@manetheren.bigw.org>