### PR TITLE
Update docs menu/button to reflect staged release

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -76,13 +76,13 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.29'                  # TODO -- parse from `chpl --version`
+chplversion = '1.30'                  # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-#release = '1.29.0 (pre-release)'
-release = '1.29.0'
+release = '1.29.0 (pre-release)'
+#release = '1.29.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -89,7 +89,7 @@ if (pagePath == "") {
 function dropSetup() {
   var currentRelease = "1.28"; // what does the public have?
   var stagedRelease = "1.29";  // is there a release staged but not yet public?
-  var nextRelease = "1.29";    // what's the next release? (on docs/main)
+  var nextRelease = "1.30";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";


### PR DESCRIPTION
This is the usual post-branch, pre-release update to the
docs button while capturing docs to chapel-www.