### PR TITLE
fix un tar issue in mac

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -135,7 +135,6 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
        "util/setchplenv.sh",
        "util/start_test",
        "util/chpltags",
-       "tools/chpldoc/COPYRIGHT",
        "frontend/include/chpl/config/config.h.cmake",
 );
 


### PR DESCRIPTION
Un-tar in mac fails with  chapel-1.29.0/tools/chpldoc/COPYRIGHT: Skipping hardlink pointing to itself: chapel-1.29.0/tools/chpldoc/COPYRIGHT

Based on a previous fix 
https://github.com/chapel-lang/chapel/pull/20679 removed COPYRIGHT from util/buildRelease/gen_release
Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>