### PR TITLE
Reduce filesystem load of `--html` tests

### DIFF
--- a/test/compflags/bradc/html/testit.compopts
+++ b/test/compflags/bradc/html/testit.compopts
@@ -1,1 +1,1 @@
---html
+--html-user

--- a/test/compflags/diten/noInlineAndHtml.compopts
+++ b/test/compflags/diten/noInlineAndHtml.compopts
@@ -1,1 +1,1 @@
---no-inline --html
+--no-inline --html-user


### PR DESCRIPTION
Switch tests from `--html` to `--html-user`. `--html` results in 200M of data in ~3500 files and `--html-user` only results in 300K of data in 40 files. This speeds up these tests on slower filesystems, especially NFS. On a fairly good NFS, this takes the tests from 120s to 5s.

Another alternative would be to write the full logs a tmp directory if we think there's value in generating the full log.

Part of Cray/chapel-private#3211
Part of Cray/chapel-private#4110