### PR TITLE
Handle --mem correctly in vflag slurm-srun launcher tests

### DIFF
--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-slurm-srun.goodstart
@@ -1,7 +1,14 @@
 #!/bin/sh
+
+if [[ -z ${CHPL_LAUNCHER_MEM:+x} ]] ; then
+    export CHPL_LAUNCHER_MEM=0
+elif [[ $CHPL_LAUNCHER_MEM == "unset" ]] ; then
+    unset CHPL_LAUNCHER_MEM
+fi
+
 echo "EVARS=vals" \
      "srun --job-name=CHPL-testVFlag --quiet" \
      "--nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N" \
-     "--exclusive --mem=0" \
+     "--exclusive${CHPL_LAUNCHER_MEM:+ --mem=M}" \
      "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P}${CHPL_LAUNCHER_EXCLUDE:+ --exclude=E} " \
      "./testVFlag_real -v -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVFlag.prediff
@@ -71,6 +71,7 @@ case $launcher in
   slurm-srun) sed -e "s/ \(--cpus-per-task\)=[1-9][0-9]* / \1=N /" \
                   -e "s/ \(--partition\)=[^ ]* / \1=P /" \
                   -e "s/ \(--exclude\)=[^ ]* / \1=E /" \
+                  -e "s/ \(--mem\)=[^ ]* / \1=M /" \
                   -e "s/ --time=[^ ]*//" \
                   -e 's/ *$//' \
                   $2 > $2.tmp &&

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-slurm-srun.goodstart
@@ -1,7 +1,14 @@
 #!/bin/sh
+
+if [[ -z ${CHPL_LAUNCHER_MEM:+x} ]] ; then
+    export CHPL_LAUNCHER_MEM=0
+elif [[ $CHPL_LAUNCHER_MEM == "unset" ]] ; then
+    unset CHPL_LAUNCHER_MEM
+fi
+
 echo "EVARS=vals" \
      "srun --job-name=CHPL-testVerbos --quiet" \
      "--nodes=1 --ntasks=1 --ntasks-per-node=1 --cpus-per-task=N" \
-     "--exclusive --mem=0" \
+     "--exclusive${CHPL_LAUNCHER_MEM:+ --mem=M}" \
      "--kill-on-bad-exit${CHPL_LAUNCHER_PARTITION:+ --partition=P}${CHPL_LAUNCHER_EXCLUDE:+ --exclude=E} " \
      "./testVerboseFlag_real --verbose -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
@@ -71,6 +71,7 @@ case $launcher in
   slurm-srun) sed -e "s/ \(--cpus-per-task\)=[1-9][0-9]* / \1=N /" \
                   -e "s/ \(--partition\)=[^ ]* / \1=P /" \
                   -e "s/ \(--exclude\)=[^ ]* / \1=E /" \
+                  -e "s/ \(--mem\)=[^ ]* / \1=M /" \
                   -e "s/ --time=[^ ]*//" \
                   -e 's/ *$//' \
                   $2 > $2.tmp &&


### PR DESCRIPTION
The `testVFlag` and `testVerboseFlag` tests assumed that `--mem=0` is passed to `srun`. However, the `CHPL_LAUNCHER_MEM` variable controls the `--mem` argument and can break these tests. If `CHPL_LAUNCHER_MEM` is not set then the default value of 0 is used with `--mem`, otherwise if the value of `CHPL_LAUNCHER_MEM` is "unset" the `--mem` option is not passed to `srun`, otherwise the value of `CHPL_LAUNCHER_MEM` is used with `--mem`. The exact value passed to `--mem` is not tested, just whether or not it appears as an argument to `srun`.
