### PR TITLE
Update path used to clone ChOp for testing

### DIFF
--- a/util/cron/test-perf.cray-cs-hdr.gpu.bash
+++ b/util/cron/test-perf.cray-cs-hdr.gpu.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Run GPU performance tests on osprey.
+# Run GPU performance tests
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-native-gpu.bash
@@ -9,6 +9,8 @@ export CHPL_COMM=none
 export CHPL_TEST_PERF_CONFIG_NAME='gpu'
 source $CWD/common-perf.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs-hdr.gpu"
+
+export CHOP_URL="git@github.com:tcarneirop/ChOp.git"
 
 nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5 -startdate 07/15/22"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
The URL we were using, although valid, fails on the particular machine we do nightly testing on. Update our nightly tests to use a different URL.