### PR TITLE
Update version button to reflect 1.29 release

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -87,8 +87,8 @@ if (pagePath == "") {
   pagePath = "index";
 }
 function dropSetup() {
-  var currentRelease = "1.28"; // what does the public have?
-  var stagedRelease = "1.29";  // is there a release staged but not yet public?
+  var currentRelease = "1.29"; // what does the public have?
+  var stagedRelease = "1.30";  // is there a release staged but not yet public?
   var nextRelease = "1.30";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle


### PR DESCRIPTION
This is the standard change to make the 1.29 docs the default for today's release
