### PR TITLE
Alphabetize and group error lists

### DIFF
--- a/frontend/include/chpl/framework/error-classes-list.h
+++ b/frontend/include/chpl/framework/error-classes-list.h
@@ -32,9 +32,15 @@
 // order their compilation stages occur in.
 
 /* begin parser errors */
+// Bison* errors are reported by the Bison parser to yyerror
+PARSER_ERROR_CLASS(BisonMemoryExhausted)
+PARSER_SYNTAX_CLASS(BisonSyntaxError, std::string)
+PARSER_ERROR_CLASS(BisonUnknownError, std::string, std::string)
 PARSER_SYNTAX_CLASS(CannotAttachPragmas, const uast::AstNode*)
+PARSER_SYNTAX_CLASS(CommentEOF, Location, Location)
 PARSER_SYNTAX_CLASS(ExceptOnlyInvalidExpr,
                     uast::VisibilityClause::LimitationKind)
+PARSER_SYNTAX_CLASS(ExternUnclosedPair, std::string)
 PARSER_SYNTAX_CLASS(InvalidIndexExpr)
 PARSER_SYNTAX_CLASS(InvalidNewForm, const uast::AstNode*)
 PARSER_SYNTAX_CLASS(InvalidNumericLiteral, std::string)
@@ -47,18 +53,8 @@ PARSER_ERROR_CLASS(ParseErr, std::string)
 PARSER_SYNTAX_CLASS(ParseSyntax, std::string)
 PARSER_WARNING_CLASS(PreIncDecOp, bool)
 PARSER_ERROR_CLASS(RecordInheritanceNotSupported, std::string)
-PARSER_SYNTAX_CLASS(UseImportNeedsModule, bool)
-/* begin Bison-specific parser errors */
-// Bison* errors are reported by the Bison parser to yyerror
-PARSER_ERROR_CLASS(BisonMemoryExhausted)
-PARSER_SYNTAX_CLASS(BisonSyntaxError, std::string)
-PARSER_ERROR_CLASS(BisonUnknownError, std::string, std::string)
-/* end Bison-specific parser errors */
-/* begin lexer-specific parser errors */
-PARSER_SYNTAX_CLASS(CommentEOF, Location, Location)
-PARSER_SYNTAX_CLASS(ExternUnclosedPair, std::string)
 PARSER_SYNTAX_CLASS(StringLiteralEOF, char, int)
-/* end lexer-specific parser errors */
+PARSER_SYNTAX_CLASS(UseImportNeedsModule, bool)
 /* end parser errors */
 
 /* begin post-parse-checks errors */
@@ -133,4 +129,3 @@ ERROR_CLASS(UseImportUnknownSym, const uast::VisibilityClause*,
 ERROR_CLASS(UseOfLaterVariable, const uast::AstNode*, ID)
 ERROR_CLASS(ValueUsedAsType, const uast::AstNode*, types::QualifiedType)
 /* end resolution errors */
-

--- a/frontend/include/chpl/framework/error-classes-list.h
+++ b/frontend/include/chpl/framework/error-classes-list.h
@@ -26,100 +26,111 @@
 //
 // Calls to the ERROR_CLASS/WARNING_CLASS/etc. macros should list the new
 // error's name first, followed a list of types describing error details.
+//
+// Errors are grouped by which compilation stage they relate to, and sorted
+// alphabetically within these groups. Groups themselves are ordered by the
+// order their compilation stages occur in.
 
-ERROR_CLASS(IncompatibleIfBranches,
-    const uast::Conditional*,
-    types::QualifiedType,
-    types::QualifiedType)
-ERROR_CLASS(TupleExpansionNamedArgs, const uast::OpCall*, const uast::FnCall*)
-ERROR_CLASS(MemManagementNonClass, const uast::New*, const types::Type*)
-ERROR_CLASS(PrivateToPublicInclude, const uast::Include*, const uast::Module*)
-ERROR_CLASS(PrototypeInclude, const uast::Include*, const uast::Module*)
-ERROR_CLASS(MissingInclude, const uast::Include*, std::string)
-ERROR_CLASS(UseImportUnknownSym, const uast::VisibilityClause*,
-            const resolution::Scope*, const resolution::VisibilityStmtKind,
-            std::string)
-ERROR_CLASS(UseImportUnknownMod, const ID, const resolution::VisibilityStmtKind,
-            std::string)
-ERROR_CLASS(UseImportNotModule, const ID, const resolution::VisibilityStmtKind,
-            std::string)
-ERROR_CLASS(AsWithUseExcept, const uast::Use*, const uast::As*)
-ERROR_CLASS(DotExprInUseImport, const uast::VisibilityClause*,
-            const uast::VisibilityClause::LimitationKind, const uast::Dot*)
-ERROR_CLASS(UnsupportedAsIdent, const uast::As*, const uast::AstNode*)
-ERROR_CLASS(Redefinition, const uast::NamedDecl*, std::vector<ID>)
+/* begin parser errors */
+PARSER_SYNTAX_CLASS(CannotAttachPragmas, const uast::AstNode*)
+PARSER_SYNTAX_CLASS(ExceptOnlyInvalidExpr,
+                    uast::VisibilityClause::LimitationKind)
+PARSER_SYNTAX_CLASS(InvalidIndexExpr)
+PARSER_SYNTAX_CLASS(InvalidNewForm, const uast::AstNode*)
+PARSER_SYNTAX_CLASS(InvalidNumericLiteral, std::string)
+PARSER_SYNTAX_CLASS(LabelIneligibleStmt, const uast::AstNode*)
+PARSER_ERROR_CLASS(MultipleExternalRenaming)
+PARSER_SYNTAX_CLASS(NewWithoutArgs, const uast::AstNode*)
+// ParseErr and ParseSyntax are catch-alls for simple parsing errors that do not
+// have a specialized error class
+PARSER_ERROR_CLASS(ParseErr, std::string)
+PARSER_SYNTAX_CLASS(ParseSyntax, std::string)
+PARSER_WARNING_CLASS(PreIncDecOp, bool)
+PARSER_ERROR_CLASS(RecordInheritanceNotSupported, std::string)
+PARSER_SYNTAX_CLASS(UseImportNeedsModule, bool)
+/* begin Bison-specific parser errors */
+// Bison* errors are reported by the Bison parser to yyerror
+PARSER_ERROR_CLASS(BisonMemoryExhausted)
+PARSER_SYNTAX_CLASS(BisonSyntaxError, std::string)
+PARSER_ERROR_CLASS(BisonUnknownError, std::string, std::string)
+/* end Bison-specific parser errors */
+/* begin lexer-specific parser errors */
+PARSER_SYNTAX_CLASS(CommentEOF, Location, Location)
+PARSER_SYNTAX_CLASS(ExternUnclosedPair, std::string)
+PARSER_SYNTAX_CLASS(StringLiteralEOF, char, int)
+/* end lexer-specific parser errors */
+/* end parser errors */
+
+/* begin post-parse-checks errors */
+POSTPARSE_ERROR_CLASS(CantApplyPrivate, std::string)
+POSTPARSE_ERROR_CLASS(MultipleManagementStrategies, const uast::New::Management,
+                      const uast::New::Management)
+POSTPARSE_ERROR_CLASS(PostParseErr, std::string)
+POSTPARSE_WARNING_CLASS(PostParseWarn, std::string)
+/* end post-parse-checks errors */
+
+/* begin resolution errors */
 ERROR_CLASS(AmbiguousConfigName, std::string, const uast::Variable*, ID)
 ERROR_CLASS(AmbiguousConfigSet,
     const uast::Variable*,
     std::string,
     std::string)
-ERROR_CLASS(ValueUsedAsType, const uast::AstNode*, types::QualifiedType)
+ERROR_CLASS(AsWithUseExcept, const uast::Use*, const uast::As*)
+ERROR_CLASS(DotExprInUseImport, const uast::VisibilityClause*,
+            const uast::VisibilityClause::LimitationKind, const uast::Dot*)
+WARNING_CLASS(ImplicitFileModule,
+    const uast::AstNode*,
+    const uast::Module*,
+    const uast::Module*)
+ERROR_CLASS(IncompatibleIfBranches,
+    const uast::Conditional*,
+    types::QualifiedType,
+    types::QualifiedType)
 ERROR_CLASS(IncompatibleKinds,
     types::QualifiedType::Kind,
     const uast::AstNode*,
     types::QualifiedType)
+ERROR_CLASS(IncompatibleRangeBounds, const uast::Range*, types::QualifiedType, types::QualifiedType)
 ERROR_CLASS(IncompatibleTypeAndInit,
     const uast::AstNode*,
     const uast::AstNode*,
     const uast::AstNode*,
     const types::Type*,
     const types::Type*)
-ERROR_CLASS(TupleDeclUnknownType, const uast::TupleDecl*)
-ERROR_CLASS(TupleDeclNotTuple, const uast::TupleDecl*, const types::Type*)
-ERROR_CLASS(TupleDeclMismatchedElems, const uast::TupleDecl*, const types::TupleType*)
-ERROR_CLASS(UseOfLaterVariable, const uast::AstNode*, ID)
-ERROR_CLASS(IncompatibleRangeBounds, const uast::Range*, types::QualifiedType, types::QualifiedType)
-ERROR_CLASS(UnknownEnumElem, const uast::AstNode*, chpl::UniqueString, const types::EnumType*)
-ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const types::EnumType*, std::vector<ID>)
 ERROR_CLASS(InvalidNewTarget, const uast::New*, types::QualifiedType)
+ERROR_CLASS(MemManagementNonClass, const uast::New*, const types::Type*)
+ERROR_CLASS(MissingInclude, const uast::Include*, std::string)
+ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const types::EnumType*, std::vector<ID>)
 ERROR_CLASS(MultipleQuestionArgs, const uast::FnCall*, const uast::AstNode*, const uast::AstNode*)
-ERROR_CLASS(TupleExpansionNonTuple, const uast::FnCall*, const uast::OpCall*, types::QualifiedType)
 ERROR_CLASS(NonIterable, const uast::IndexableLoop*, const uast::AstNode*, types::QualifiedType)
-WARNING_CLASS(ImplicitFileModule,
-    const uast::AstNode*,
-    const uast::Module*,
-    const uast::Module*)
-ERROR_CLASS(ProcTypeUnannotatedFormal,
-    const uast::FunctionSignature*,
-    const uast::AnonFormal*)
+ERROR_CLASS(PrivateToPublicInclude, const uast::Include*, const uast::Module*)
 ERROR_CLASS(ProcDefExplicitAnonFormal,
     const uast::Function*,
     const uast::Formal*)
+ERROR_CLASS(ProcTypeUnannotatedFormal,
+    const uast::FunctionSignature*,
+    const uast::AnonFormal*)
+ERROR_CLASS(PrototypeInclude, const uast::Include*, const uast::Module*)
+ERROR_CLASS(Redefinition, const uast::NamedDecl*, std::vector<ID>)
 ERROR_CLASS(SuperFromTopLevelModule,
     const uast::AstNode*,
     const uast::Module*,
     resolution::VisibilityStmtKind)
+ERROR_CLASS(TupleDeclMismatchedElems, const uast::TupleDecl*, const types::TupleType*)
+ERROR_CLASS(TupleDeclNotTuple, const uast::TupleDecl*, const types::Type*)
+ERROR_CLASS(TupleDeclUnknownType, const uast::TupleDecl*)
+ERROR_CLASS(TupleExpansionNamedArgs, const uast::OpCall*, const uast::FnCall*)
+ERROR_CLASS(TupleExpansionNonTuple, const uast::FnCall*, const uast::OpCall*, types::QualifiedType)
+ERROR_CLASS(UnknownEnumElem, const uast::AstNode*, chpl::UniqueString, const types::EnumType*)
+ERROR_CLASS(UnsupportedAsIdent, const uast::As*, const uast::AstNode*)
+ERROR_CLASS(UseImportNotModule, const ID, const resolution::VisibilityStmtKind,
+            std::string)
+ERROR_CLASS(UseImportUnknownMod, const ID, const resolution::VisibilityStmtKind,
+            std::string)
+ERROR_CLASS(UseImportUnknownSym, const uast::VisibilityClause*,
+            const resolution::Scope*, const resolution::VisibilityStmtKind,
+            std::string)
+ERROR_CLASS(UseOfLaterVariable, const uast::AstNode*, ID)
+ERROR_CLASS(ValueUsedAsType, const uast::AstNode*, types::QualifiedType)
+/* end resolution errors */
 
-/* parser errors */
-// catch-all for simple parsing errors that do not have a specialized error
-// class
-PARSER_ERROR_CLASS(ParseErr, std::string)
-PARSER_SYNTAX_CLASS(ParseSyntax, std::string)
-PARSER_SYNTAX_CLASS(CannotAttachPragmas, const uast::AstNode*)
-PARSER_SYNTAX_CLASS(InvalidIndexExpr)
-PARSER_ERROR_CLASS(RecordInheritanceNotSupported, std::string)
-PARSER_SYNTAX_CLASS(InvalidNumericLiteral, std::string)
-PARSER_ERROR_CLASS(MultipleExternalRenaming)
-PARSER_WARNING_CLASS(PreIncDecOp, bool)
-PARSER_SYNTAX_CLASS(InvalidNewForm, const uast::AstNode*)
-PARSER_SYNTAX_CLASS(NewWithoutArgs, const uast::AstNode*)
-PARSER_SYNTAX_CLASS(UseImportNeedsModule, bool)
-PARSER_SYNTAX_CLASS(ExceptOnlyInvalidExpr,
-                    uast::VisibilityClause::LimitationKind)
-PARSER_SYNTAX_CLASS(LabelIneligibleStmt, const uast::AstNode*)
-// Bison* errors are reported by the Bison parser to yyerror
-PARSER_ERROR_CLASS(BisonMemoryExhausted)
-PARSER_ERROR_CLASS(BisonUnknownError, std::string, std::string)
-PARSER_SYNTAX_CLASS(BisonSyntaxError, std::string)
-
-/* post-parse-checks errors */
-POSTPARSE_ERROR_CLASS(PostParseErr, std::string)
-POSTPARSE_WARNING_CLASS(PostParseWarn, std::string)
-POSTPARSE_ERROR_CLASS(MultipleManagementStrategies, const uast::New::Management,
-                      const uast::New::Management)
-POSTPARSE_ERROR_CLASS(CantApplyPrivate, std::string)
-
-/* lexer-specific parser errors */
-PARSER_SYNTAX_CLASS(StringLiteralEOF, char, int)
-PARSER_SYNTAX_CLASS(ExternUnclosedPair, std::string)
-PARSER_SYNTAX_CLASS(CommentEOF, Location, Location)

--- a/frontend/lib/framework/error-classes-list.cpp
+++ b/frontend/lib/framework/error-classes-list.cpp
@@ -24,7 +24,6 @@
 #include "chpl/framework/query-impl.h"
 #include "chpl/uast/VisibilityClause.h"
 #include "chpl/uast/AstTag.h"
-/* #include "chpl/uast/New.h" */
 #include "chpl/types/all-types.h"
 #include <sstream>
 #include <cstring>
@@ -70,134 +69,278 @@ static types::QualifiedType decayToValue(const types::QualifiedType& qt) {
 // the specialized work.
 //
 
-void ErrorIncompatibleIfBranches::write(ErrorWriterBase& wr) const {
-  auto ifExpr = std::get<const uast::Conditional*>(info);
-  auto qt1 = std::get<1>(info);
-  auto qt2 = std::get<2>(info);
+/* begin parser errors */
 
-  wr.heading(kind_, type_, ifExpr, "branches of if-expression have incompatible types.");
-  wr.message("In the following if-expression:");
-  wr.code(ifExpr, { ifExpr->thenBlock(), ifExpr->elseBlock() });
-  if (qt1.kind() == types::QualifiedType::TYPE ||
-      qt2.kind() == types::QualifiedType::TYPE) {
-    // If any of the branches is not a value (i.e. a type, since we pretend
-    // params are values for the sake of clarity) then we need to be more
-    // clear about when something is a type and when it isn't.
-    wr.message("the first branch is ", decayToValue(qt1),
-                ", while the second is ", decayToValue(qt2), ".");
+void ErrorCannotAttachPragmas::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto stmt = std::get<const uast::AstNode*>(info);
+  wr.heading(kind_, type_, loc, "cannot attach 'pragma's to this statement.");
+  if (stmt) {
+    wr.code(stmt);
+  }
+  wr.message(
+      "Only declarations, such as variable declarations, can have 'pragma's "
+      "attached to them.");
+}
+
+void ErrorExceptOnlyInvalidExpr::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto limitationKind = std::get<uast::VisibilityClause::LimitationKind>(info);
+  wr.heading(kind_, type_, loc, "incorrect expression in '", limitationKind,
+             "' list, identifier expected.");
+  wr.message("In the '", limitationKind, "' list here:");
+  wr.code(loc);
+}
+
+void ErrorInvalidIndexExpr::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  wr.heading(kind_, type_, loc,
+             "only identifiers or tuples of identifiers are allowed as index "
+             "expressions.");
+  wr.message("Invalid index expression used here:");
+  wr.code(loc);
+}
+
+void ErrorInvalidNewForm::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto newExpr = std::get<const uast::AstNode*>(info);
+  wr.heading(kind_, type_, loc, "Invalid form for 'new' expression.");
+  wr.message("'new' expression used here:");
+  wr.code(loc, {newExpr});
+}
+
+void ErrorInvalidNumericLiteral::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto errMessage = std::get<std::string>(info);
+  CHPL_ASSERT(!errMessage.empty());
+  CHPL_ASSERT(errMessage.back() == '.' &&
+         "expected a period at the end of InvalidNumericLiteral message");
+  errMessage[0] = std::tolower(errMessage[0]);
+  wr.heading(kind_, type_, loc, errMessage);
+  wr.message("Numeric literal encountered here:");
+  wr.code(loc);
+}
+
+void ErrorLabelIneligibleStmt::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto maybeStmt = std::get<const uast::AstNode*>(info);
+  if (maybeStmt && maybeStmt->tag() == uast::AstTag::EmptyStmt) {
+    // this is the case where there is a semicolon following the label name
+    wr.heading(kind_, type_, loc,
+               "labels should not be terminated with semicolons.");
   } else {
-    // Otherwise, both things are values, so just talk about their types.
-    wr.message("the first branch is of type '", qt1.type(), "'"
-                ", while the second is of type '", qt2.type(), "'.");
+    wr.heading(kind_, type_, loc, "cannot label this kind of statement.");
+  }
+  wr.message("Label on ineligible statement here:");
+  wr.code(loc);
+  wr.message("Only 'for', 'while', and 'do-while' statements can have labels.");
+}
+
+void ErrorMultipleExternalRenaming::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  wr.heading(
+      kind_, type_, loc,
+      "external symbol renaming can only be applied to one symbol at a time.");
+  wr.message("Multiple renaming used here:");
+  wr.code(loc);
+}
+
+void ErrorNewWithoutArgs::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto expr = std::get<const uast::AstNode*>(info);
+  wr.heading(kind_, type_, loc,
+             "'new' expression is missing its argument list.");
+  wr.message("'new' expression used here:");
+  wr.code(loc, { expr });
+  wr.message("Perhaps you intended to write 'new ", expr, "()' instead?");
+}
+
+void ErrorParseErr::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto errorMessage = std::get<std::string>(info);
+  CHPL_ASSERT(errorMessage.back() == '.' &&
+         "expected a period at the end of ErrorParseErr message");
+  wr.heading(kind_, type_, loc, errorMessage);
+  wr.code(loc);
+}
+
+void ErrorParseSyntax::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto errorMessage = std::get<std::string>(info);
+  CHPL_ASSERT(errorMessage.back() == '.' &&
+         "expected a period at the end of ErrorParseSyntax message");
+  wr.heading(kind_, type_, loc, errorMessage);
+  wr.code(loc);
+}
+
+void ErrorPreIncDecOp::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto isDoublePlus = std::get<bool>(info);
+  if (isDoublePlus) {
+    wr.heading(kind_, type_, loc, "'++' is not a pre-increment.");
+  } else {
+    wr.heading(kind_, type_, loc, "'--' is not a pre-decrement.");
+  }
+  wr.message("Used here:");
+  wr.code(loc);
+}
+
+void ErrorRecordInheritanceNotSupported::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto recordName = std::get<std::string>(info);
+  wr.heading(kind_, type_, loc,
+             "inheritance is not currently supported for records.");
+  wr.note(loc, recordName, " declared as a record here:");
+  wr.code(loc);
+  wr.message(
+      "Thoughts on what record inheritance should entail can be added to "
+      "https://github.com/chapel-lang/chapel/issues/6851.");
+}
+
+void ErrorUseImportNeedsModule::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto isImport = std::get<bool>(info);
+  std::string useOrImport = isImport ? "import" : "use";
+  wr.heading(kind_, type_, loc, "'", useOrImport,
+             "' statements must refer to module",
+             (isImport ? "" : " or 'enum'"), " symbols.");
+  wr.message("In the following '", useOrImport, "' statement:");
+  wr.code(loc);
+}
+
+/* begin Bison-specific parser errors */
+void ErrorBisonMemoryExhausted::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  wr.heading(kind_, type_, loc, "memory exhausted while parsing.");
+}
+
+void ErrorBisonSyntaxError::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto nearestToken = std::get<std::string>(info);
+  wr.heading(kind_, type_, loc,
+             (nearestToken.empty() ? "(no token given)"
+                                   : "near '" + nearestToken + "'"),
+             ":");
+  wr.code(loc);
+}
+
+void ErrorBisonUnknownError::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto errorMessage = std::get<1>(info);
+  auto nearestToken = std::get<2>(info);
+  wr.heading(kind_, type_, loc,
+             "unknown error from Bison parser: ", errorMessage, ".");
+  if (!nearestToken.empty()) {
+    wr.note(loc, "Nearest token when error was encountered: '", nearestToken,
+            "'");
   }
 }
 
-void ErrorTupleExpansionNamedArgs::write(ErrorWriterBase& wr) const {
-  auto fnCall = std::get<const uast::FnCall*>(info);
-  auto tupleOp = std::get<const uast::OpCall*>(info);
+/* end Bison-specific parser errors */
 
-  wr.heading(kind_, type_, fnCall, "tuple expansion cannot be used to pass "
-             "values to a non-variadic named argument.");
-  wr.message("A tuple is being expanded here:");
-  wr.code(fnCall, { tupleOp });
+/* begin lexer-specific parser errors */
+void ErrorCommentEOF::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<0>(info);
+  auto startLoc = std::get<1>(info);
+  auto nestedLoc = std::get<2>(info);
+  wr.heading(kind_, type_, loc, "end-of-file in comment.");
+  wr.note(startLoc, "unterminated comment here:");
+  wr.code(startLoc);
+  if (!nestedLoc.isEmpty()) {
+    wr.note(nestedLoc, "nested comment here:");
+    wr.code(nestedLoc);
+  }
 }
 
-void ErrorMemManagementNonClass::write(ErrorWriterBase& wr) const {
-  auto newCall = std::get<const uast::New*>(info);
-  auto type = std::get<const types::Type*>(info);
-  auto record = type ? type->toRecordType() : nullptr;
+void ErrorExternUnclosedPair::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto pairSymbol = std::get<std::string>(info);
+  wr.heading(kind_, type_, loc, "missing closing ", pairSymbol,
+             " symbol in extern block.");
+  wr.message("In this extern block:");
+  wr.code(loc);
+}
 
-  if (record) {
-    wr.heading(kind_, type_, newCall,
-               "cannot use memory management strategy '",
-               uast::New::managementToString(newCall->management()),
-               "' with record '",
-               record->name(), "'.");
-  } else {
-    wr.heading(kind_, type_, newCall,
-               "cannot use memory management strategy '",
-               uast::New::managementToString(newCall->management()),
-               "' with non-class type '", type, "'.");
-  }
-  wr.code(newCall, { newCall->typeExpression() });
-  wr.message("Memory management strategies can only be used with classes.");
-  if (record) {
-    wr.note(record->id(), "'", record->name(), "' declared as record here:");
-    wr.code(record->id());
+void ErrorStringLiteralEOF::write(ErrorWriterBase& wr) const {
+  auto loc = std::get<const Location>(info);
+  auto startChar = std::get<char>(info);
+  auto startCharCount = std::get<int>(info);
+  auto startDelimiter = std::string((size_t)startCharCount, startChar);
+  wr.heading(kind_, type_, loc, "end-of-file in string literal.");
+  wr.message("Unterminated string literal here:");
+  wr.code(loc);
+  wr.message("This string literal began with ", startDelimiter,
+             " and must end with the same un-escaped delimiter.");
+}
+
+/* end lexer-specific parser errors */
+/* end parser errors */
+
+/* begin post-parse-checks errors */
+void ErrorCantApplyPrivate::write(ErrorWriterBase& wr) const {
+  auto id = std::get<const ID>(info);
+  auto appliedToWhat = std::get<std::string>(info);
+  wr.heading(kind_, type_, id, "can't apply private to ", appliedToWhat,
+             " yet.");
+  wr.message("The following declaration has unsupported 'private' modifier:");
+  wr.code(id);
+}
+
+void ErrorMultipleManagementStrategies::write(ErrorWriterBase& wr) const {
+  auto id = std::get<const ID>(info);
+  auto outerMgt = std::get<1>(info);
+  auto innerMgt = std::get<2>(info);
+  wr.heading(kind_, type_, id,
+             "type expression uses multiple memory management strategies ('",
+             outerMgt, "' and '", innerMgt, "').");
+  wr.message("Multiple class kinds used in type expression here:");
+  wr.code(id);
+  if (outerMgt == innerMgt) {
     wr.message(
-               "Consider removing the '", uast::New::managementToString(newCall->management()),
-               "' keyword to fix this error, or defining '", record->name(),
-               "' as a class.");
+        "The same strategy is listed twice; one instance should be removed.");
+  } else {
+    wr.message("These strategies are incompatible; one should be removed.");
   }
 }
 
-void ErrorPrivateToPublicInclude::write(ErrorWriterBase& wr) const {
-  auto moduleInclude = std::get<const uast::Include*>(info);
-  auto moduleDef = std::get<const uast::Module*>(info);
-  wr.heading(kind_, type_, moduleInclude,
-             "cannot make a private module public through "
-             "an include statement");
-  wr.code(moduleInclude);
-  wr.note(moduleDef, "module declared private here:");
-  wr.code(moduleDef);
-}
-
-void ErrorPrototypeInclude::write(ErrorWriterBase& wr) const {
-  auto moduleInclude = std::get<const uast::Include*>(info);
-  auto moduleDef = std::get<const uast::Module*>(info);
-  wr.heading(kind_, type_, moduleInclude,
-             "cannot apply prototype to module in include statement");
-  wr.code(moduleInclude);
-  wr.note(moduleDef, "put prototype keyword at module declaration here:");
-  wr.code(moduleDef);
-}
-
-void ErrorMissingInclude::write(ErrorWriterBase& wr) const {
-  auto moduleInclude = std::get<const uast::Include*>(info);
-  auto& filePath = std::get<std::string>(info);
-  wr.heading(kind_, type_, moduleInclude, "cannot find included submodule");
-  wr.code(moduleInclude);
-  wr.note(moduleInclude, "expected file at path '", filePath, "'");
-}
-
-void ErrorUseImportUnknownSym::write(ErrorWriterBase& wr) const {
-  auto visibilityClause = std::get<const uast::VisibilityClause*>(info);
-  auto symbolName = std::get<std::string>(info);
-  auto searchedScope = std::get<const resolution::Scope*>(info);
-  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  wr.heading(kind_, type_, locationOnly(visibilityClause),
-             "cannot find symbol '", symbolName, "' for ", useOrImport, ".");
-  wr.message("In the following '", useOrImport, "' statement:");
-  wr.code(visibilityClause, { visibilityClause });
-  // get class name of AstNode that generated scope (probably Module or Enum)
-  // and lowercase it for readability
-  std::string whatIsSearched = tagToString(searchedScope->tag());
-  whatIsSearched[0] = std::tolower(whatIsSearched[0]);
-  wr.message("Searching in the scope of ", whatIsSearched, " '",
-             searchedScope->name(), "':");
-  wr.code(searchedScope->id());
-}
-
-void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
+void ErrorPostParseErr::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
-  auto moduleName = std::get<std::string>(info);
-  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  wr.heading(kind_, type_, id, "cannot find module '", moduleName,
-             "' for '", useOrImport, "'.");
-  wr.message("In the following '", useOrImport, "' statement:");
-  wr.code<ID, ID>(id, { id });
+  auto errorMessage = std::get<std::string>(info);
+  CHPL_ASSERT(errorMessage.back() == '.' &&
+         "expected a period at the end of ErrorPostParseErr message");
+  wr.heading(kind_, type_, id, errorMessage);
+  wr.code(id);
 }
 
-void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
+void ErrorPostParseWarn::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
-  auto moduleName = std::get<std::string>(info);
-  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  wr.heading(kind_, type_, id, "cannot '", useOrImport, "' '", moduleName,
-             "', which is not a module.");
-  wr.message("In the following '", useOrImport, "' statement:");
-  wr.code<ID, ID>(id, { id });
-  wr.message("Only modules and enums can be used with '", useOrImport,
-             "' statements.");
+  auto errorMessage = std::get<std::string>(info);
+  CHPL_ASSERT(errorMessage.back() == '.' &&
+         "expected a period at the end of ErrorPostParseWarn message");
+  wr.heading(kind_, type_, id, errorMessage);
+  wr.code(id);
+}
+
+/* end post-parse-checks errors */
+
+/* begin resolution errors */
+void ErrorAmbiguousConfigName::write(ErrorWriterBase& wr) const {
+  auto& name = std::get<std::string>(info);
+  auto variable = std::get<const uast::Variable*>(info);
+  auto otherId = std::get<ID>(info);
+  wr.heading(kind_, type_, locationOnly(variable), "ambiguous config name (", name, ").");
+  wr.code(variable);
+  wr.note(locationOnly(otherId), "also defined here:");
+  wr.code(otherId);
+  wr.note(locationOnly(otherId), "(disambiguate using -s<modulename>.", name, "...)");
+}
+
+void ErrorAmbiguousConfigSet::write(ErrorWriterBase& wr) const {
+  auto& name1 = std::get<1>(info);
+  auto& name2 = std::get<2>(info);
+  auto variable = std::get<const uast::Variable*>(info);
+  wr.heading(kind_, type_, locationOnly(variable),
+            "config set ambiguously via '-s", name1, "' and '-s", name2, "'");
 }
 
 void ErrorAsWithUseExcept::write(ErrorWriterBase& wr) const {
@@ -222,58 +365,6 @@ void ErrorDotExprInUseImport::write(ErrorWriterBase& wr) const {
       "'use' or 'import'.");
 }
 
-void ErrorUnsupportedAsIdent::write(ErrorWriterBase& wr) const {
-  auto as = std::get<const uast::As*>(info);
-  auto expectedIdentifier = std::get<const uast::AstNode*>(info);
-  wr.heading(kind_, type_, locationOnly(as),
-             "this form of 'as' is not yet supported.");
-  // determine and report which of the original or new name is invalid
-  std::string whichName;
-  if (expectedIdentifier == as->symbol()) {
-    whichName = "original";
-  } else if (expectedIdentifier == as->rename()) {
-    whichName = "new";
-  } else {
-    CHPL_ASSERT(false && "should not be reachable");
-  }
-  wr.message("'as' requires the ", whichName,
-             " name to be a simple identifier, but instead got the following:");
-  wr.code(expectedIdentifier, { expectedIdentifier });
-}
-
-void ErrorRedefinition::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<const uast::NamedDecl*>(info);
-  auto& ids = std::get<std::vector<ID>>(info);
-  wr.heading(kind_, type_, decl, "'", decl->name(), "' has multiple definitions.");
-  wr.message("The first definition is here:");
-  wr.code(decl);
-  for (const ID& id : ids) {
-    if (id != decl->id()) {
-      wr.note(id, "redefined here:");
-      wr.code<ID, ID>(id);
-    }
-  }
-}
-
-void ErrorAmbiguousConfigName::write(ErrorWriterBase& wr) const {
-  auto& name = std::get<std::string>(info);
-  auto variable = std::get<const uast::Variable*>(info);
-  auto otherId = std::get<ID>(info);
-  wr.heading(kind_, type_, locationOnly(variable), "ambiguous config name (", name, ").");
-  wr.code(variable);
-  wr.note(locationOnly(otherId), "also defined here:");
-  wr.code(otherId);
-  wr.note(locationOnly(otherId), "(disambiguate using -s<modulename>.", name, "...)");
-}
-
-void ErrorAmbiguousConfigSet::write(ErrorWriterBase& wr) const {
-  auto& name1 = std::get<1>(info);
-  auto& name2 = std::get<2>(info);
-  auto variable = std::get<const uast::Variable*>(info);
-  wr.heading(kind_, type_, locationOnly(variable),
-            "config set ambiguously via '-s", name1, "' and '-s", name2, "'");
-}
-
 void ErrorImplicitFileModule::write(ErrorWriterBase& wr) const {
   auto code = std::get<const uast::AstNode*>(info);
   auto lastModule = std::get<1>(info);
@@ -291,14 +382,26 @@ void ErrorImplicitFileModule::write(ErrorWriterBase& wr) const {
              implicitModule->name(), "' module.");
 }
 
-void ErrorValueUsedAsType::write(ErrorWriterBase& wr) const {
-  auto typeExpr = std::get<const uast::AstNode*>(info);
-  auto type = std::get<types::QualifiedType>(info);
-  wr.heading(kind_, type_, typeExpr,
-             "type specifier is ", type, ", but it was expected to be a type.");
-  wr.message("In the following type specifier:");
-  wr.code(typeExpr, { typeExpr });
-  // wr.message("Did you mean to use '.type'?");
+void ErrorIncompatibleIfBranches::write(ErrorWriterBase& wr) const {
+  auto ifExpr = std::get<const uast::Conditional*>(info);
+  auto qt1 = std::get<1>(info);
+  auto qt2 = std::get<2>(info);
+
+  wr.heading(kind_, type_, ifExpr, "branches of if-expression have incompatible types.");
+  wr.message("In the following if-expression:");
+  wr.code(ifExpr, { ifExpr->thenBlock(), ifExpr->elseBlock() });
+  if (qt1.kind() == types::QualifiedType::TYPE ||
+      qt2.kind() == types::QualifiedType::TYPE) {
+    // If any of the branches is not a value (i.e. a type, since we pretend
+    // params are values for the sake of clarity) then we need to be more
+    // clear about when something is a type and when it isn't.
+    wr.message("the first branch is ", decayToValue(qt1),
+                ", while the second is ", decayToValue(qt2), ".");
+  } else {
+    // Otherwise, both things are values, so just talk about their types.
+    wr.message("the first branch is of type '", qt1.type(), "'"
+                ", while the second is of type '", qt2.type(), "'.");
+  }
 }
 
 void ErrorIncompatibleKinds::write(ErrorWriterBase& wr) const {
@@ -350,69 +453,6 @@ void ErrorIncompatibleKinds::write(ErrorWriterBase& wr) const {
   }
 }
 
-void ErrorIncompatibleTypeAndInit::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<0>(info);
-  auto type = std::get<1>(info);
-  auto init = std::get<2>(info);
-  auto typeExprType = std::get<3>(info);
-  auto initExprType = std::get<4>(info);
-
-  if (auto namedDecl = decl->toNamedDecl()) {
-    wr.heading(kind_, type_, decl,
-               "type mismatch between declared type of '", namedDecl->name(),
-               "' and initialization expression.");
-  } else {
-    wr.heading(kind_, type_, decl,
-               "type mismatch between declared type and initialization expression.");
-  }
-  wr.message("In the following declaration:");
-  wr.code(decl, { type, init });
-  wr.message("the type specifier has type '", typeExprType, "', while the "
-             "initial value has type '", initExprType, "'.");
-}
-
-void ErrorTupleDeclUnknownType::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<const uast::TupleDecl*>(info);
-  wr.heading(kind_, type_, decl,
-             "value of unknown type cannot be split using tuple assignment.");
-  wr.code(decl);
-}
-
-void ErrorTupleDeclNotTuple::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<const uast::TupleDecl*>(info);
-  auto type = std::get<const types::Type*>(info);
-  wr.heading(kind_, type_, decl,
-            "value of non-tuple type '", type, "' cannot be split using a tuple "
-            "declaration.");
-  wr.message("In the following tuple declaration:");
-  wr.code(decl);
-  wr.message("the initialization expression has type '", type, "', while it is expected "
-             "to be a ", decl->numDecls(), "-tuple.");
-}
-
-void ErrorTupleDeclMismatchedElems::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<const uast::TupleDecl*>(info);
-  auto type = std::get<const types::TupleType*>(info);
-  wr.heading(kind_, type_, decl,
-            "tuple size mismatch in split tuple declaration.");
-  wr.code(decl);
-  wr.message("The left-hand side of the declaration expects a ",
-             decl->numDecls(), "-tuple, but the right-hand side is a ",
-             type->numElements(), "-tuple, '", type, "'.");
-}
-
-void ErrorUseOfLaterVariable::write(ErrorWriterBase& wr) const {
-  auto stmt = std::get<const uast::AstNode*>(info);
-  auto laterId = std::get<ID>(info);
-  wr.heading(kind_, type_, stmt,
-             "statement references a variable before it is defined.");
-  wr.message("In the following statement:");
-  wr.code(stmt);
-  wr.message("there is a reference to a variable defined later:");
-  wr.code(laterId);
-  wr.message("Variables cannot be referenced before they are defined.");
-}
-
 void ErrorIncompatibleRangeBounds::write(ErrorWriterBase& wr) const {
   auto range = std::get<const uast::Range*>(info);
   auto qt1 = std::get<1>(info);
@@ -435,33 +475,25 @@ void ErrorIncompatibleRangeBounds::write(ErrorWriterBase& wr) const {
   }
 }
 
-void ErrorUnknownEnumElem::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
-  auto elemName = std::get<UniqueString>(info);
-  auto enumType = std::get<const types::EnumType*>(info);
+void ErrorIncompatibleTypeAndInit::write(ErrorWriterBase& wr) const {
+  auto decl = std::get<0>(info);
+  auto type = std::get<1>(info);
+  auto init = std::get<2>(info);
+  auto typeExprType = std::get<3>(info);
+  auto initExprType = std::get<4>(info);
 
-  wr.heading(kind_, type_, node, "enum '", enumType->name(),
-             "' has no element named '", elemName, "'.");
-  wr.code(node, { node });
-  wr.note(enumType->id(), "'", enumType->name(), "' is declared here.");
-  wr.code(enumType->id());
-}
-
-void ErrorMultipleEnumElems::write(ErrorWriterBase& wr) const {
-  auto enumType = std::get<const types::EnumType*>(info);
-  auto elemName = std::get<UniqueString>(info);
-  auto& possibleElems = std::get<std::vector<ID>>(info);
-
-  wr.heading(kind_, type_, enumType->id(), "enum '", enumType->name(),
-             "' has multiple elements named '", elemName, "'.");
-  wr.code(enumType->id());
-  bool printedOne = false;
-  for (auto& id : possibleElems) {
-    wr.note(id, printedOne ? "another" : "one", " instance occurs here:");
-    printedOne = true;
-    wr.code<ID, ID>(id, { id });
+  if (auto namedDecl = decl->toNamedDecl()) {
+    wr.heading(kind_, type_, decl,
+               "type mismatch between declared type of '", namedDecl->name(),
+               "' and initialization expression.");
+  } else {
+    wr.heading(kind_, type_, decl,
+               "type mismatch between declared type and initialization expression.");
   }
-  wr.message("An enum cannot have repeated elements of the same name.");
+  wr.message("In the following declaration:");
+  wr.code(decl, { type, init });
+  wr.message("the type specifier has type '", typeExprType, "', while the "
+             "initial value has type '", initExprType, "'.");
 }
 
 void ErrorInvalidNewTarget::write(ErrorWriterBase& wr) const {
@@ -485,6 +517,60 @@ void ErrorInvalidNewTarget::write(ErrorWriterBase& wr) const {
   wr.message("The 'new' expression can only be used with records or classes.");
 }
 
+void ErrorMemManagementNonClass::write(ErrorWriterBase& wr) const {
+  auto newCall = std::get<const uast::New*>(info);
+  auto type = std::get<const types::Type*>(info);
+  auto record = type ? type->toRecordType() : nullptr;
+
+  if (record) {
+    wr.heading(kind_, type_, newCall,
+               "cannot use memory management strategy '",
+               uast::New::managementToString(newCall->management()),
+               "' with record '",
+               record->name(), "'.");
+  } else {
+    wr.heading(kind_, type_, newCall,
+               "cannot use memory management strategy '",
+               uast::New::managementToString(newCall->management()),
+               "' with non-class type '", type, "'.");
+  }
+  wr.code(newCall, { newCall->typeExpression() });
+  wr.message("Memory management strategies can only be used with classes.");
+  if (record) {
+    wr.note(record->id(), "'", record->name(), "' declared as record here:");
+    wr.code(record->id());
+    wr.message(
+               "Consider removing the '", uast::New::managementToString(newCall->management()),
+               "' keyword to fix this error, or defining '", record->name(),
+               "' as a class.");
+  }
+}
+
+void ErrorMissingInclude::write(ErrorWriterBase& wr) const {
+  auto moduleInclude = std::get<const uast::Include*>(info);
+  auto& filePath = std::get<std::string>(info);
+  wr.heading(kind_, type_, moduleInclude, "cannot find included submodule");
+  wr.code(moduleInclude);
+  wr.note(moduleInclude, "expected file at path '", filePath, "'");
+}
+
+void ErrorMultipleEnumElems::write(ErrorWriterBase& wr) const {
+  auto enumType = std::get<const types::EnumType*>(info);
+  auto elemName = std::get<UniqueString>(info);
+  auto& possibleElems = std::get<std::vector<ID>>(info);
+
+  wr.heading(kind_, type_, enumType->id(), "enum '", enumType->name(),
+             "' has multiple elements named '", elemName, "'.");
+  wr.code(enumType->id());
+  bool printedOne = false;
+  for (auto& id : possibleElems) {
+    wr.note(id, printedOne ? "another" : "one", " instance occurs here:");
+    printedOne = true;
+    wr.code<ID, ID>(id, { id });
+  }
+  wr.message("An enum cannot have repeated elements of the same name.");
+}
+
 void ErrorMultipleQuestionArgs::write(ErrorWriterBase& wr) const {
   auto call = std::get<const uast::FnCall*>(info);
   auto firstQuestion = std::get<1>(info);
@@ -497,19 +583,6 @@ void ErrorMultipleQuestionArgs::write(ErrorWriterBase& wr) const {
   wr.code(secondQuestion, { secondQuestion });
 }
 
-void ErrorTupleExpansionNonTuple::write(ErrorWriterBase& wr) const {
-  auto call = std::get<const uast::FnCall*>(info);
-  auto expansion = std::get<const uast::OpCall*>(info);
-  auto& type = std::get<types::QualifiedType>(info);
-
-  wr.heading(kind_, type_, call, "cannot apply tuple expansion to an "
-             "expression of non-tuple type");
-  wr.message("In the following function call:");
-  wr.code(call, { expansion });
-  wr.message("the expanded element has non-tuple type '", type.type(), "', "
-             "but expansion can only be used on tuples.");
-}
-
 void ErrorNonIterable::write(ErrorWriterBase &wr) const {
   auto loop = std::get<const uast::IndexableLoop*>(info);
   auto iterand = std::get<const uast::AstNode*>(info);
@@ -517,6 +590,25 @@ void ErrorNonIterable::write(ErrorWriterBase &wr) const {
   wr.heading(kind_, type_, loop, "cannot iterate over ", decayToValue(iterandType), ".");
   wr.message("In the following loop:");
   wr.code(loop, { iterand });
+}
+
+void ErrorPrivateToPublicInclude::write(ErrorWriterBase& wr) const {
+  auto moduleInclude = std::get<const uast::Include*>(info);
+  auto moduleDef = std::get<const uast::Module*>(info);
+  wr.heading(kind_, type_, moduleInclude,
+             "cannot make a private module public through "
+             "an include statement");
+  wr.code(moduleInclude);
+  wr.note(moduleDef, "module declared private here:");
+  wr.code(moduleDef);
+}
+
+void ErrorProcDefExplicitAnonFormal::write(ErrorWriterBase& wr) const {
+  auto fn = std::get<const uast::Function*>(info);
+  auto formal = std::get<const uast::Formal*>(info);
+  wr.heading(kind_, type_, formal, "formals in a procedure definition must "
+                            "be named");
+  wr.code(fn, {formal});
 }
 
 void ErrorProcTypeUnannotatedFormal::write(ErrorWriterBase& wr) const {
@@ -531,12 +623,28 @@ void ErrorProcTypeUnannotatedFormal::write(ErrorWriterBase& wr) const {
              "type or name.");
 }
 
-void ErrorProcDefExplicitAnonFormal::write(ErrorWriterBase& wr) const {
-  auto fn = std::get<const uast::Function*>(info);
-  auto formal = std::get<const uast::Formal*>(info);
-  wr.heading(kind_, type_, formal, "formals in a procedure definition must "
-                            "be named");
-  wr.code(fn, {formal});
+void ErrorPrototypeInclude::write(ErrorWriterBase& wr) const {
+  auto moduleInclude = std::get<const uast::Include*>(info);
+  auto moduleDef = std::get<const uast::Module*>(info);
+  wr.heading(kind_, type_, moduleInclude,
+             "cannot apply prototype to module in include statement");
+  wr.code(moduleInclude);
+  wr.note(moduleDef, "put prototype keyword at module declaration here:");
+  wr.code(moduleDef);
+}
+
+void ErrorRedefinition::write(ErrorWriterBase& wr) const {
+  auto decl = std::get<const uast::NamedDecl*>(info);
+  auto& ids = std::get<std::vector<ID>>(info);
+  wr.heading(kind_, type_, decl, "'", decl->name(), "' has multiple definitions.");
+  wr.message("The first definition is here:");
+  wr.code(decl);
+  for (const ID& id : ids) {
+    if (id != decl->id()) {
+      wr.note(id, "redefined here:");
+      wr.code<ID, ID>(id);
+    }
+  }
 }
 
 void ErrorSuperFromTopLevelModule::write(ErrorWriterBase& wr) const {
@@ -554,252 +662,152 @@ void ErrorSuperFromTopLevelModule::write(ErrorWriterBase& wr) const {
   wr.code(mod);
 }
 
-/* parser errors */
-
-void ErrorParseErr::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto errorMessage = std::get<std::string>(info);
-  CHPL_ASSERT(errorMessage.back() == '.' &&
-         "expected a period at the end of ErrorParseErr message");
-  wr.heading(kind_, type_, loc, errorMessage);
-  wr.code(loc);
+void ErrorTupleDeclMismatchedElems::write(ErrorWriterBase& wr) const {
+  auto decl = std::get<const uast::TupleDecl*>(info);
+  auto type = std::get<const types::TupleType*>(info);
+  wr.heading(kind_, type_, decl,
+            "tuple size mismatch in split tuple declaration.");
+  wr.code(decl);
+  wr.message("The left-hand side of the declaration expects a ",
+             decl->numDecls(), "-tuple, but the right-hand side is a ",
+             type->numElements(), "-tuple, '", type, "'.");
 }
 
-// same as ErrorParseErr, but for syntax errors
-void ErrorParseSyntax::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto errorMessage = std::get<std::string>(info);
-  CHPL_ASSERT(errorMessage.back() == '.' &&
-         "expected a period at the end of ErrorParseSyntax message");
-  wr.heading(kind_, type_, loc, errorMessage);
-  wr.code(loc);
+void ErrorTupleDeclNotTuple::write(ErrorWriterBase& wr) const {
+  auto decl = std::get<const uast::TupleDecl*>(info);
+  auto type = std::get<const types::Type*>(info);
+  wr.heading(kind_, type_, decl,
+            "value of non-tuple type '", type, "' cannot be split using a tuple "
+            "declaration.");
+  wr.message("In the following tuple declaration:");
+  wr.code(decl);
+  wr.message("the initialization expression has type '", type, "', while it is expected "
+             "to be a ", decl->numDecls(), "-tuple.");
 }
 
-void ErrorCannotAttachPragmas::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto stmt = std::get<const uast::AstNode*>(info);
-  wr.heading(kind_, type_, loc, "cannot attach 'pragma's to this statement.");
-  if (stmt) {
-    wr.code(stmt);
-  }
-  wr.message(
-      "Only declarations, such as variable declarations, can have 'pragma's "
-      "attached to them.");
+void ErrorTupleDeclUnknownType::write(ErrorWriterBase& wr) const {
+  auto decl = std::get<const uast::TupleDecl*>(info);
+  wr.heading(kind_, type_, decl,
+             "value of unknown type cannot be split using tuple assignment.");
+  wr.code(decl);
 }
 
-void ErrorInvalidIndexExpr::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  wr.heading(kind_, type_, loc,
-             "only identifiers or tuples of identifiers are allowed as index "
-             "expressions.");
-  wr.message("Invalid index expression used here:");
-  wr.code(loc);
+void ErrorTupleExpansionNamedArgs::write(ErrorWriterBase& wr) const {
+  auto fnCall = std::get<const uast::FnCall*>(info);
+  auto tupleOp = std::get<const uast::OpCall*>(info);
+
+  wr.heading(kind_, type_, fnCall, "tuple expansion cannot be used to pass "
+             "values to a non-variadic named argument.");
+  wr.message("A tuple is being expanded here:");
+  wr.code(fnCall, { tupleOp });
 }
 
-void ErrorRecordInheritanceNotSupported::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto recordName = std::get<std::string>(info);
-  wr.heading(kind_, type_, loc,
-             "inheritance is not currently supported for records.");
-  wr.note(loc, recordName, " declared as a record here:");
-  wr.code(loc);
-  wr.message(
-      "Thoughts on what record inheritance should entail can be added to "
-      "https://github.com/chapel-lang/chapel/issues/6851.");
+void ErrorTupleExpansionNonTuple::write(ErrorWriterBase& wr) const {
+  auto call = std::get<const uast::FnCall*>(info);
+  auto expansion = std::get<const uast::OpCall*>(info);
+  auto& type = std::get<types::QualifiedType>(info);
+
+  wr.heading(kind_, type_, call, "cannot apply tuple expansion to an "
+             "expression of non-tuple type");
+  wr.message("In the following function call:");
+  wr.code(call, { expansion });
+  wr.message("the expanded element has non-tuple type '", type.type(), "', "
+             "but expansion can only be used on tuples.");
 }
 
-void ErrorInvalidNumericLiteral::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto errMessage = std::get<std::string>(info);
-  CHPL_ASSERT(!errMessage.empty());
-  CHPL_ASSERT(errMessage.back() == '.' &&
-         "expected a period at the end of InvalidNumericLiteral message");
-  errMessage[0] = std::tolower(errMessage[0]);
-  wr.heading(kind_, type_, loc, errMessage);
-  wr.message("Numeric literal encountered here:");
-  wr.code(loc);
+void ErrorUnknownEnumElem::write(ErrorWriterBase& wr) const {
+  auto node = std::get<const uast::AstNode*>(info);
+  auto elemName = std::get<UniqueString>(info);
+  auto enumType = std::get<const types::EnumType*>(info);
+
+  wr.heading(kind_, type_, node, "enum '", enumType->name(),
+             "' has no element named '", elemName, "'.");
+  wr.code(node, { node });
+  wr.note(enumType->id(), "'", enumType->name(), "' is declared here.");
+  wr.code(enumType->id());
 }
 
-void ErrorMultipleExternalRenaming::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  wr.heading(
-      kind_, type_, loc,
-      "external symbol renaming can only be applied to one symbol at a time.");
-  wr.message("Multiple renaming used here:");
-  wr.code(loc);
-}
-
-void ErrorPreIncDecOp::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto isDoublePlus = std::get<bool>(info);
-  if (isDoublePlus) {
-    wr.heading(kind_, type_, loc, "'++' is not a pre-increment.");
+void ErrorUnsupportedAsIdent::write(ErrorWriterBase& wr) const {
+  auto as = std::get<const uast::As*>(info);
+  auto expectedIdentifier = std::get<const uast::AstNode*>(info);
+  wr.heading(kind_, type_, locationOnly(as),
+             "this form of 'as' is not yet supported.");
+  // determine and report which of the original or new name is invalid
+  std::string whichName;
+  if (expectedIdentifier == as->symbol()) {
+    whichName = "original";
+  } else if (expectedIdentifier == as->rename()) {
+    whichName = "new";
   } else {
-    wr.heading(kind_, type_, loc, "'--' is not a pre-decrement.");
+    CHPL_ASSERT(false && "should not be reachable");
   }
-  wr.message("Used here:");
-  wr.code(loc);
+  wr.message("'as' requires the ", whichName,
+             " name to be a simple identifier, but instead got the following:");
+  wr.code(expectedIdentifier, { expectedIdentifier });
 }
 
-void ErrorInvalidNewForm::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto newExpr = std::get<const uast::AstNode*>(info);
-  wr.heading(kind_, type_, loc, "Invalid form for 'new' expression.");
-  wr.message("'new' expression used here:");
-  wr.code(loc, {newExpr});
-}
-
-void ErrorNewWithoutArgs::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto expr = std::get<const uast::AstNode*>(info);
-  wr.heading(kind_, type_, loc,
-             "'new' expression is missing its argument list.");
-  wr.message("'new' expression used here:");
-  wr.code(loc, { expr });
-  wr.message("Perhaps you intended to write 'new ", expr, "()' instead?");
-}
-
-void ErrorUseImportNeedsModule::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto isImport = std::get<bool>(info);
-  std::string useOrImport = isImport ? "import" : "use";
-  wr.heading(kind_, type_, loc, "'", useOrImport,
-             "' statements must refer to module",
-             (isImport ? "" : " or 'enum'"), " symbols.");
+void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
+  auto id = std::get<const ID>(info);
+  auto moduleName = std::get<std::string>(info);
+  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
+  wr.heading(kind_, type_, id, "cannot '", useOrImport, "' '", moduleName,
+             "', which is not a module.");
   wr.message("In the following '", useOrImport, "' statement:");
-  wr.code(loc);
+  wr.code<ID, ID>(id, { id });
+  wr.message("Only modules and enums can be used with '", useOrImport,
+             "' statements.");
 }
 
-void ErrorExceptOnlyInvalidExpr::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto limitationKind = std::get<uast::VisibilityClause::LimitationKind>(info);
-  wr.heading(kind_, type_, loc, "incorrect expression in '", limitationKind,
-             "' list, identifier expected.");
-  wr.message("In the '", limitationKind, "' list here:");
-  wr.code(loc);
-}
-
-void ErrorLabelIneligibleStmt::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto maybeStmt = std::get<const uast::AstNode*>(info);
-  if (maybeStmt && maybeStmt->tag() == uast::AstTag::EmptyStmt) {
-    // this is the case where there is a semicolon following the label name
-    wr.heading(kind_, type_, loc,
-               "labels should not be terminated with semicolons.");
-  } else {
-    wr.heading(kind_, type_, loc, "cannot label this kind of statement.");
-  }
-  wr.message("Label on ineligible statement here:");
-  wr.code(loc);
-  wr.message("Only 'for', 'while', and 'do-while' statements can have labels.");
-}
-
-void ErrorBisonMemoryExhausted::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  wr.heading(kind_, type_, loc, "memory exhausted while parsing.");
-}
-
-void ErrorBisonUnknownError::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto errorMessage = std::get<1>(info);
-  auto nearestToken = std::get<2>(info);
-  wr.heading(kind_, type_, loc,
-             "unknown error from Bison parser: ", errorMessage, ".");
-  if (!nearestToken.empty()) {
-    wr.note(loc, "Nearest token when error was encountered: '", nearestToken,
-            "'");
-  }
-}
-
-void ErrorBisonSyntaxError::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto nearestToken = std::get<std::string>(info);
-  wr.heading(kind_, type_, loc,
-             (nearestToken.empty() ? "(no token given)"
-                                   : "near '" + nearestToken + "'"),
-             ":");
-  wr.code(loc);
-}
-
-/* post-parse-checks errors */
-void ErrorPostParseErr::write(ErrorWriterBase& wr) const {
+void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
-  auto errorMessage = std::get<std::string>(info);
-  CHPL_ASSERT(errorMessage.back() == '.' &&
-         "expected a period at the end of ErrorPostParseErr message");
-  wr.heading(kind_, type_, id, errorMessage);
-  wr.code(id);
+  auto moduleName = std::get<std::string>(info);
+  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
+  wr.heading(kind_, type_, id, "cannot find module '", moduleName,
+             "' for '", useOrImport, "'.");
+  wr.message("In the following '", useOrImport, "' statement:");
+  wr.code<ID, ID>(id, { id });
 }
 
-void ErrorPostParseWarn::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
-  auto errorMessage = std::get<std::string>(info);
-  CHPL_ASSERT(errorMessage.back() == '.' &&
-         "expected a period at the end of ErrorPostParseWarn message");
-  wr.heading(kind_, type_, id, errorMessage);
-  wr.code(id);
+void ErrorUseImportUnknownSym::write(ErrorWriterBase& wr) const {
+  auto visibilityClause = std::get<const uast::VisibilityClause*>(info);
+  auto symbolName = std::get<std::string>(info);
+  auto searchedScope = std::get<const resolution::Scope*>(info);
+  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
+  wr.heading(kind_, type_, locationOnly(visibilityClause),
+             "cannot find symbol '", symbolName, "' for ", useOrImport, ".");
+  wr.message("In the following '", useOrImport, "' statement:");
+  wr.code(visibilityClause, { visibilityClause });
+  // get class name of AstNode that generated scope (probably Module or Enum)
+  // and lowercase it for readability
+  std::string whatIsSearched = tagToString(searchedScope->tag());
+  whatIsSearched[0] = std::tolower(whatIsSearched[0]);
+  wr.message("Searching in the scope of ", whatIsSearched, " '",
+             searchedScope->name(), "':");
+  wr.code(searchedScope->id());
 }
 
-void ErrorMultipleManagementStrategies::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
-  auto outerMgt = std::get<1>(info);
-  auto innerMgt = std::get<2>(info);
-  wr.heading(kind_, type_, id,
-             "type expression uses multiple memory management strategies ('",
-             outerMgt, "' and '", innerMgt, "').");
-  wr.message("Multiple class kinds used in type expression here:");
-  wr.code(id);
-  if (outerMgt == innerMgt) {
-    wr.message(
-        "The same strategy is listed twice; one instance should be removed.");
-  } else {
-    wr.message("These strategies are incompatible; one should be removed.");
-  }
+void ErrorUseOfLaterVariable::write(ErrorWriterBase& wr) const {
+  auto stmt = std::get<const uast::AstNode*>(info);
+  auto laterId = std::get<ID>(info);
+  wr.heading(kind_, type_, stmt,
+             "statement references a variable before it is defined.");
+  wr.message("In the following statement:");
+  wr.code(stmt);
+  wr.message("there is a reference to a variable defined later:");
+  wr.code(laterId);
+  wr.message("Variables cannot be referenced before they are defined.");
 }
 
-void ErrorCantApplyPrivate::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
-  auto appliedToWhat = std::get<std::string>(info);
-  wr.heading(kind_, type_, id, "can't apply private to ", appliedToWhat,
-             " yet.");
-  wr.message("The following declaration has unsupported 'private' modifier:");
-  wr.code(id);
+void ErrorValueUsedAsType::write(ErrorWriterBase& wr) const {
+  auto typeExpr = std::get<const uast::AstNode*>(info);
+  auto type = std::get<types::QualifiedType>(info);
+  wr.heading(kind_, type_, typeExpr,
+             "type specifier is ", type, ", but it was expected to be a type.");
+  wr.message("In the following type specifier:");
+  wr.code(typeExpr, { typeExpr });
+  // wr.message("Did you mean to use '.type'?");
 }
 
-/* lexer errors */
-
-void ErrorStringLiteralEOF::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto startChar = std::get<char>(info);
-  auto startCharCount = std::get<int>(info);
-  auto startDelimiter = std::string((size_t)startCharCount, startChar);
-  wr.heading(kind_, type_, loc, "end-of-file in string literal.");
-  wr.message("Unterminated string literal here:");
-  wr.code(loc);
-  wr.message("This string literal began with ", startDelimiter,
-             " and must end with the same un-escaped delimiter.");
-}
-
-void ErrorExternUnclosedPair::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto pairSymbol = std::get<std::string>(info);
-  wr.heading(kind_, type_, loc, "missing closing ", pairSymbol,
-             " symbol in extern block.");
-  wr.message("In this extern block:");
-  wr.code(loc);
-}
-
-void ErrorCommentEOF::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<0>(info);
-  auto startLoc = std::get<1>(info);
-  auto nestedLoc = std::get<2>(info);
-  wr.heading(kind_, type_, loc, "end-of-file in comment.");
-  wr.note(startLoc, "unterminated comment here:");
-  wr.code(startLoc);
-  if (!nestedLoc.isEmpty()) {
-    wr.note(nestedLoc, "nested comment here:");
-    wr.code(nestedLoc);
-  }
-}
+/* end resolution errors */
 
 } // end namespace 'chpl'


### PR DESCRIPTION
Error macros in `error-classes-list.h` and their corresponding `write` definitions in `error-classes-list.cpp` are now grouped by compilation stage, and alphabetized within their groups. Delineation between groups is made more clear, and groups are ordered by the order they occur in compilation.

Resolves https://github.com/Cray/chapel-private/issues/4136.