### PR TITLE
Upgrade Arkouda release testing from 1.27.0 to 1.29.0

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -57,7 +57,7 @@ function test_release() {
   export CHPL_TEST_PERF_DESCRIPTION=release
   export CHPL_TEST_PERF_CONFIGS="release:v,nightly"
   currentSha=`git rev-parse HEAD`
-  git checkout 1.27.0
+  git checkout 1.29.0
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
   git checkout $currentSha -- $CHPL_HOME/util/test/perf/


### PR DESCRIPTION
Apparently I missed upgrading to 1.28 before, but there were no major perf changes in 1.28 so this wasn't a big deal.

See Bears-R-Us/arkouda#1966