### PR TITLE
fix(build): don't copy chpldoc in install.sh

### DIFF
--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -343,21 +343,6 @@ then
   fi
 fi
 
-# copy chpldoc
-# and create symlink for chpldoc-legacy
-if [ -f "bin/$CHPL_BIN_SUBDIR/chpldoc" ]
-then
-  # Choose destination depending on installation mode {prefix, home}
-  if [ ! -z "$PREFIX" ]
-  then
-    myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$PREFIX/bin"
-    (cd "$PREFIX/bin" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)
-  else
-    myinstallfile "bin/$CHPL_BIN_SUBDIR"/chpldoc "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"
-    (cd "$DEST_DIR/bin/$CHPL_BIN_SUBDIR" && rm -f chpldoc-legacy && ln -s chpl chpldoc-legacy)
-  fi
-fi
-
 
 # copy chplconfig
 if [ -f chplconfig ]


### PR DESCRIPTION
This PR removes the portion of the install.sh script that was responsible for 
copying chpldoc and creating the chpldoc-legacy link. This step is no longer 
needed as it is being handled by CMake now, and continuing to copy and 
overwrite the chpldoc file creates errors when trying to run chpldoc 
w.r.t shared library libdyno.so

This should fix a failing `make-install-check` nightly test

TESTING:

- [x] `util/buildRelease/test_install.bash` passes 

reviewed by @riftEmber - thank you!
