### PR TITLE
Verify that --stop-after-pass pass actually exists

### DIFF
--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -39,7 +39,7 @@ struct PassInfo {
   char        logTag;
 };
 
-// These entries should be kept in the same order as the entries in passlist.h.
+// These entries should be kept in the same order as those in the pass list
 #define LOG_parse                              'p'
 #define LOG_checkParsed                        LOG_NEVER
 #define LOG_readExternC                        LOG_NO_SHORT
@@ -160,6 +160,21 @@ void runPasses(PhaseTracker& tracker) {
 
   if (printPasses == true || printPassesFile != 0) {
     tracker.ReportPass();
+  }
+
+  // verify that user-specified pass to stop after actually exists
+  if (stopAfterPass[0]) {
+    bool stopAfterPassValid = false;
+    for (size_t i = 0; i < passListSize; i++) {
+      if (strcmp(sPassList[i].name, stopAfterPass) == 0) {
+        stopAfterPassValid = true;
+        break;
+      }
+    }
+    if (!stopAfterPassValid) {
+      USR_FATAL("Requested to stop after pass '%s', but no such pass exists",
+                stopAfterPass);
+    }
   }
 
   for (size_t i = 0; i < passListSize; i++) {

--- a/test/compflags/stopAfterNonexistentPass.chpl
+++ b/test/compflags/stopAfterNonexistentPass.chpl
@@ -1,0 +1,1 @@
+writeln("hello, world");

--- a/test/compflags/stopAfterNonexistentPass.compopts
+++ b/test/compflags/stopAfterNonexistentPass.compopts
@@ -1,0 +1,1 @@
+--stop-after-pass youshallnotpass

--- a/test/compflags/stopAfterNonexistentPass.good
+++ b/test/compflags/stopAfterNonexistentPass.good
@@ -1,0 +1,1 @@
+error: Requested to stop after pass 'youshallnotpass', but no such pass exists


### PR DESCRIPTION
This PR adds functionality to ensure that a pass specified with `--stop-after-pass` actually exists. If it does not, we emit a fatal error.

While working on https://github.com/chapel-lang/chapel/pull/21063, I realized this would be nice to have when trying to determine if the user has specified any flags that would cause compilation to stop before `makeBinary`.

Testing:
- [x] paratest