### PR TITLE
fix(test): add local cmake for nightly testing on raptor

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -27,6 +27,8 @@ if [ -f /data/cf/chapel/setup_cmake_nightly.bash ] ; then
   source /data/cf/chapel/setup_cmake_nightly.bash
 elif [ -f /cray/css/users/chapelu/setup_cmake_nightly.bash ] ; then
   source /cray/css/users/chapelu/setup_cmake_nightly.bash
+elif [ -f /cy/users/chapelu/setup_cmake_nightly.bash ] ; then
+  source /cy/users/chapelu/setup_cmake_nightly.bash
 fi
 
 log_info "gcc version: $(which gcc)"


### PR DESCRIPTION
This PR adds another nightly script for sourcing to the `common.bash` file. 

I added a local install of `cmake 3.25.1` to `/cy/users/chapelu`,
along with a script to add it to the path for nightly testing. 
This change makes the `common.bash` script aware of the `cmake` 
setup script.

This change, along with the local `cmake` install, should fix
a number of nightly test failures.

TESTING:

- [x] sourcing `setup_cmake_nightly.bash` puts `cmake` in path
- [x] `chpl` builds and compiles `hello.chpl` after `cmake` in path

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>