### PR TITLE
Fix an uninitialized variable in dynoRealizeErrors

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -888,7 +888,7 @@ static DynoErrorHandler* gDynoErrorHandler = nullptr;
 
 static bool dynoRealizeErrors(void) {
   INT_ASSERT(gDynoErrorHandler);
-  bool hadErrors;
+  bool hadErrors = false;
   llvm::SmallPtrSet<const chpl::ErrorBase*, 10> issuedErrors;
   for (auto err : gDynoErrorHandler->errors()) {
     hadErrors = true;


### PR DESCRIPTION
Follow-up to #20919. Initializes the variable `hadErrors` to `false`.
I noticed this problem when running `valgrind` on the compiler for other reasons.

While this error is worth fixing, it's unlikely to present a problem in the 1.29 release (see details).

<details>

`dynoRealizeErrors` is only called as `if (dynoRealizeErrors()) USR_STOP();` and `USR_STOP` itself does nothing if there were no errors. In fact, I can compile Hello World if `dynoRealizeErrors` always returns `true`. Nonetheless, I think having `dynoRealizeErrors` return an accurate `bool` better communicates the intent here than relying on the behavior of `USR_STOP`. The one counter-argument than I can think of is that the current logic still relies on `USR_STOP` not stopping if only warnings were issued.

</details>

Reviewed by @riftEmber - thanks!

- [x] full local testing