### PR TITLE
Adjust gdb.commands

### DIFF
--- a/compiler/etc/gdb.commands
+++ b/compiler/etc/gdb.commands
@@ -1,6 +1,7 @@
 set $forcecmd = 0
 define hook-run
   if ($forcecmd != 1)
+    set $forcecmd = 1
     if (tmpdirname != 0)
       call cleanup_for_exit()
     end
@@ -9,6 +10,7 @@ define hook-run
 end
 define hook-quit
   if ($forcecmd != 1)
+    set $forcecmd = 1
     if (tmpdirname != 0)
       call cleanup_for_exit()
     end


### PR DESCRIPTION
This should resolve failures in nightly testing in this test:

    test/compflags/bradc/gdbddash/declint.chpl

on systems running gdb 8.2 or later.

On these systems, gdb goes into an infinite loop generating the error `'tmpdirname' has unknown type; cast it to its declared type`. The change in this PR avoids the infinite loop.

### Background

gdb 8.0.1 does not go into an infinite loop because it prints out 'tmpdirname' as an int, given a nondevel-built compiler, even though it is a char*. My speculation is that gdb devs changed it to an error thinking that it would be a better behavior in the case where the type is unknown.

tmpdirname is referenced in the hooks in compiler/etc/gdb.commands:

    define hook-quit
      if ($forcecmd != 1)
      if (tmpdirname != 0)
        call cleanup_for_exit()
	end
      end
      set $forcecmd = 0
    end

Note that `cleanup_for_exit` is a `static` function in compiler/util/misc.cpp so calling it does not work given a nodevel-built compiler: `No symbol "cleanup_for_exit" in current context.`

I would like us to consider removing these hooks altogether. However this is outside the scope of this PR.
