### PR TITLE
chore(docs): update prereqs to indicate cmake requirement for installs

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -59,6 +59,9 @@ In addition, several optional components have additional requirements:
 
   * ``pkg-config`` is required for the ``mason system`` subcommands
 
+  * ``cmake`` 3.16 or newer is required to install ``chpl`` when choosing an
+    installation with ``./configure --chpl-home=/path/to/install``
+
 
 .. _readme-prereqs-installation:
 


### PR DESCRIPTION
This PR updates the optional prerequisites section of our docs to
indicate that `cmake` version 3.16 or newer is required to install
`chpl` after choosing an installation with `./configure --chpl-home=/path/to/install`.

This change was motivated by changes in https://github.com/chapel-lang/chapel/pull/21271,
which added an error when `cmake` < 3.16 and `./configure --chpl-home=/path/to/install`
has been ran. 

TESTING:

- [x] make docs and visually inspect prerequisite section

reviewed by @mppf - thank you!