### PR TITLE
Remove an extraneous space before a period in docs

### DIFF
--- a/doc/rst/developer/index.rst
+++ b/doc/rst/developer/index.rst
@@ -14,6 +14,6 @@ Please read our `code of conduct`_ before contributing.
    compiler-internals/index
 
 Please note that additional materials are available at
-https://github.com/chapel-lang/chapel/tree/main/doc/rst/developer .
+https://github.com/chapel-lang/chapel/tree/main/doc/rst/developer.
 
 .. _code of conduct: https://github.com/chapel-lang/chapel/blob/main/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Extra space before the last period at https://chapel-lang.org/docs/1.29/developer/index.html does not appear necessary for the link to render properly.