### PR TITLE
Workaround problems when statically linking with older LLVMs

### DIFF
--- a/frontend/lib/CMakeLists.txt
+++ b/frontend/lib/CMakeLists.txt
@@ -84,7 +84,6 @@ target_include_directories(libdyno PUBLIC
                            ${CHPL_MAIN_INCLUDE_DIR}
                            ${CHPL_INCLUDE_DIR})
 
-# bla
 if(APPLE)
   if (CHPL_LLVM_VERSION VERSION_LESS 14.0)
     # we see problems with statically linking and using PUBLIC
@@ -93,8 +92,16 @@ if(APPLE)
     # to work OK with LLVM 14.
     message(FATAL_ERROR "LLVM >= 14.0 required for MacOS builds")
   endif()
+  # link the LLVM dependencies with the generated .dylib
+  # (we get linker errors on Mac OS X here if it uses INTERFACE)
+  # an alternative would be to add link option -undefined dynamic_lookup
   target_link_libraries(libdyno PUBLIC ${CHPL_LLVM_LINK_ARGS})
 else()
+  # Using PUBLIC here causes problems in some configurations with LLVM<14
+  # when the LLVM libraries are included in the .so generated here
+  # and also linked in statically with the resulting executable.
+  # With INTERFACE, the LLVM libraries are only linked with at
+  # the time that this library is used.
   target_link_libraries(libdyno INTERFACE ${CHPL_LLVM_LINK_ARGS})
 endif()
 

--- a/frontend/lib/CMakeLists.txt
+++ b/frontend/lib/CMakeLists.txt
@@ -84,7 +84,20 @@ target_include_directories(libdyno PUBLIC
                            ${CHPL_MAIN_INCLUDE_DIR}
                            ${CHPL_INCLUDE_DIR})
 
-target_link_libraries(libdyno PUBLIC ${CHPL_LLVM_LINK_ARGS})
+# bla
+if(APPLE)
+  if (CHPL_LLVM_VERSION VERSION_LESS 14.0)
+    # we see problems with statically linking and using PUBLIC
+    # here because we are building a shared object & that would
+    # include some of the LLVM libraries. But this pattern seems
+    # to work OK with LLVM 14.
+    message(FATAL_ERROR "LLVM >= 14.0 required for MacOS builds")
+  endif()
+  target_link_libraries(libdyno PUBLIC ${CHPL_LLVM_LINK_ARGS})
+else()
+  target_link_libraries(libdyno INTERFACE ${CHPL_LLVM_LINK_ARGS})
+endif()
+
 # TODO: Get printchplenv output proper so that we don't need to SHELL here
 target_compile_options(libdyno PUBLIC
                        SHELL:$<$<COMPILE_LANGUAGE:CXX>:${CHPL_LLVM_COMP_ARGS}>)


### PR DESCRIPTION
This PR adjusts how liblibdyno.so links with LLVM to avoid including LLVM symbols within it to avoid errors like this:

    : CommandLine Error: Option 'help-list' registered more than once!
    LLVM ERROR: inconsistency in registered CommandLine options

which seem to occur with LLVM 11 or 12

Reviewed by @arezaii - thanks!