### PR TITLE
Fix prediff for test

### DIFF
--- a/test/multilocale/bradc/needMultiLocales/writeThisUsingOn.prediff
+++ b/test/multilocale/bradc/needMultiLocales/writeThisUsingOn.prediff
@@ -7,7 +7,11 @@ outfile = sys.argv[2]
 with open (outfile, 'r') as f:
     lines = f.readlines()
 
+final_text = ""
 with open (outfile, 'w') as f:
     for line in lines:
         if 'halt reached - Timed out' in line:
-            f.write(line)
+            final_text += line.strip()
+        if 'C is' in line:
+            final_text += line.strip()
+    f.write(final_text+'\n')


### PR DESCRIPTION
This PR fixes a prediff that was only printing out one line of output, when the output was expecting that there be two.