### PR TITLE
Update two .bad files after removing unnecessary default-init

### DIFF
--- a/test/classes/initializers/records/array-from-for-expr.bad
+++ b/test/classes/initializers/records/array-from-for-expr.bad
@@ -1,6 +1,2 @@
 array-from-for-expr.chpl:35: In function 'main':
 array-from-for-expr.chpl:36: error: const actual is passed to a 'ref' formal of chpl__initCopy()
-array-from-for-expr.chpl:36: error: unresolved call 'RRR.init()'
-array-from-for-expr.chpl:19: note: this candidate did not match: RRR.init(idx: int)
-$CHPL_HOME/modules/internal/ChapelBase.chpl:948: note: because call does not supply enough arguments
-array-from-for-expr.chpl:19: note: it is missing a value for formal 'idx: int(64)'

--- a/test/expressions/loop-expr/recordWrappedClassBug.bad
+++ b/test/expressions/loop-expr/recordWrappedClassBug.bad
@@ -1,7 +1,1 @@
 recordWrappedClassBug.chpl:15: error: const actual is passed to a 'ref' formal of chpl__initCopy()
-$CHPL_HOME/modules/internal/ChapelBase.chpl:880: In function 'init_elts':
-$CHPL_HOME/modules/internal/ChapelBase.chpl:897: error: default initialization with type 'R(owned C?)' is not yet supported
-recordWrappedClassBug.chpl:6: note: field 'c' is a generic value
-recordWrappedClassBug.chpl:6: note: consider separately declaring a type field for it or using a 'new' call
-  $CHPL_HOME/modules/internal/DefaultRectangular.chpl:1258: called as init_elts(x: _ddata(R(owned C?)), s: int(64), type t = R(owned C?), lo: int(64))
-  within internal functions (use --print-callstack-on-error to see)


### PR DESCRIPTION
Follow-up to PR #21263 which removed an unnecessary default initialization which now no longer appears in error messages in the .bad files. These tests still do not work as intended for other reasons, however.

Test change only - not reviewed

