### PR TITLE
fix(test): add make args to make docs command

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -223,7 +223,7 @@ if [ $DOCS -eq 1 ]; then
     # Build chpldoc, make sure the chpldoc primer runs, and the docs build.
     make -j${num_procs} $chpl_make_args chpldoc && \
         make $chpl_make_args check-chpldoc && \
-        make docs || exit 2
+        make $chpl_make_args docs || exit 2
 fi
 
 if [ $MASON -eq 1 ]; then


### PR DESCRIPTION
This PR aligns the `make` args used for building `chpl`, `chpldoc`, and the 
chapel documentation from the `nightly` script. Previously, `chpl` and 
`chpldoc` were built with the `make` args `DEBUG=0 WARNINGS=1 OPTIMIZE=1`, 
but the `doc` target was not getting any of those args. 

Since the changes in PR #20920, CI builds for the `make doc` step have 
been running noticeably longer. This is because the presence/absence of those
`make` args made `CMake` see the need for different builds, so it would build
the compiler twice. 
This change returns the CI to a more reasonable running time.


1. Last CI prior to #20920: https://github.com/chapel-lang/chapel/actions/runs/3707337056
   make docs runtime ~ 11 minutes (same as `make check`)
 
2. After #20920, the runtime jumped to ~23 minutes: https://github.com/chapel- lang/chapel/actions/runs/3707520039

3. This PR gets us back down to ~10 minutes: https://github.com/chapel-lang/chapel/actions/runs/3753418549