### PR TITLE
Adjust declint.prediff

### DIFF
--- a/test/compflags/bradc/gdbddash/declint.prediff
+++ b/test/compflags/bradc/gdbddash/declint.prediff
@@ -8,7 +8,7 @@ set tmpfile = $outfile.raw.tmp
 # some gdbs print out extra stuff.  This filters it out
 #
 mv $outfile $tmpfile
-grep -v "Using host libthread_db library" $tmpfile | grep -v "Breakpoint 1 at" | grep -v "no debugging symbols found" | grep -v "Reading symbols" > $outfile
+cat $tmpfile | grep -vE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's@(gdb) quit@(gdb) @' > $outfile
 rm $tmpfile
 
 #


### PR DESCRIPTION
This PR adjusts the prediff for this test:

    test/compflags/bradc/gdbddash/declint.chpl

to ignore more cases in gdb output that are reasonable yet resulted in .good mismatches after #21269.
For example:

    Reading symbols from /path/to/chpl...
    Breakpoint 1 at 0x33890
    (gdb) 'tmpdirname' has unknown type; cast it to its declared type
    (gdb) quit

Tested by running start_test on this test
in a linux64 and a linux32 configurations.

Merging for expediency. Post-merge review is welcome.