### PR TITLE
Don't set CHPL_GMP to none for Arkouda smoke

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -165,7 +165,9 @@ if [ "$GITHUB_ACTIONS" != "true" ]; then
 fi
 
 # Disable GMP and re2 to speed up build.
-export CHPL_GMP=none
+if [ "$ARKOUDA_SMOKE_TEST" != "true" ]; then
+    export CHPL_GMP=none
+fi
 
 # mason currently requires CHPL_COMM=none -- https://github.com/chapel-lang/chapel/issues/12626
 COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`


### PR DESCRIPTION
Arkouda now needs `CHPL_GMP` for the newly added bigint module, so this PR skips setting `CHPL_GMP` to none if it is an Arkouda smoke test.

Companion PR: https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/942