### PR TITLE
Add two more default-argument-class-override test variants

### DIFF
--- a/test/functions/default-arguments/default-argument-class-override3c.chpl
+++ b/test/functions/default-arguments/default-argument-class-override3c.chpl
@@ -1,0 +1,27 @@
+// This used to produce an internal error (noted in #14167)
+proc f()       { return 0; }
+proc g() param { return 1; }
+
+class Parent {
+  proc method(arg:int = f()) {
+    writeln("in Parent.method arg=", arg);
+  }
+}
+
+class Child : Parent {
+  override proc method(arg:int = g()) {
+    writeln("in Child.method arg=", arg);
+  }
+}
+
+proc main() {
+  var x:Parent = new Child();
+  x.method();
+  //   run child's default (virtually dispatched) `g()` and so print out `in Child.method arg=1`
+
+  var y = new Child();
+  y.method(); // expect this to run `g` and so print `in Child.method arg=1`
+
+  var z = new Parent();
+  z.method();
+}

--- a/test/functions/default-arguments/default-argument-class-override3c.good
+++ b/test/functions/default-arguments/default-argument-class-override3c.good
@@ -1,0 +1,3 @@
+in Child.method arg=1
+in Child.method arg=1
+in Parent.method arg=0

--- a/test/functions/default-arguments/default-argument-class-override3d.chpl
+++ b/test/functions/default-arguments/default-argument-class-override3d.chpl
@@ -1,0 +1,26 @@
+proc f() param { return 0; }
+proc g()       { return 1; }
+
+class Parent {
+  proc method(arg:int = f()) {
+    writeln("in Parent.method arg=", arg);
+  }
+}
+
+class Child : Parent {
+  override proc method(arg:int = g()) {
+    writeln("in Child.method arg=", arg);
+  }
+}
+
+proc main() {
+  var x:Parent = new Child();
+  x.method();
+  //   run child's default (virtually dispatched) `g()` and so print out `in Child.method arg=1`
+
+  var y = new Child();
+  y.method(); // expect this to run `g` and so print `in Child.method arg=1`
+
+  var z = new Parent();
+  z.method();
+}

--- a/test/functions/default-arguments/default-argument-class-override3d.good
+++ b/test/functions/default-arguments/default-argument-class-override3d.good
@@ -1,0 +1,3 @@
+in Child.method arg=1
+in Child.method arg=1
+in Parent.method arg=0


### PR DESCRIPTION
One of them used to result in a compiler segfault, per #14167.

Resolves #14167