### PR TITLE
Add future for 14740: User definition of a class operator= not detected when unused in its module

### DIFF
--- a/test/classes/assignments/noAssignClassModuleScope.bad
+++ b/test/classes/assignments/noAssignClassModuleScope.bad
@@ -1,0 +1,3 @@
+{frominit = 1, fromassign = 0, count = 1}
+{frominit = 2, fromassign = 0, count = 1}
+{frominit = 2, fromassign = 0, count = 1}

--- a/test/classes/assignments/noAssignClassModuleScope.chpl
+++ b/test/classes/assignments/noAssignClassModuleScope.chpl
@@ -1,0 +1,28 @@
+module Main {
+  module Mod {
+    class Obj {
+      var frominit, fromassign, count: int;
+
+      proc init(x:int){
+        this.frominit = x;
+        this.fromassign = 0;
+	this.count = 1;
+      }
+    }
+
+    operator =(ref lhs: Obj, rhs: Obj) {
+      halt("In my Obj.operator= -- should not be callable");
+      lhs.fromassign = rhs.frominit;
+      lhs.count += 1;
+    }
+  }
+
+  use Mod;
+
+  var oa: owned Obj? = new Obj(1);
+  writeln(oa);
+  var ob: owned Obj? = new Obj(2);
+  writeln(ob);
+  oa = ob;
+  writeln(oa);
+}

--- a/test/classes/assignments/noAssignClassModuleScope.future
+++ b/test/classes/assignments/noAssignClassModuleScope.future
@@ -1,0 +1,6 @@
+bug: User definition of a class operator= not detected when unused in its module
+#14740
+
+When the definition of the = operator is moved out into Main, or
+the contents of Main are moved into Mod, the compiler detects the
+error.

--- a/test/classes/assignments/noAssignClassModuleScope.good
+++ b/test/classes/assignments/noAssignClassModuleScope.good
@@ -1,0 +1,1 @@
+noAssignClassModuleScope.chpl:13: error: Can't overload assignments for class types


### PR DESCRIPTION
Add future for #14740 