### PR TITLE
fix(build): capture python subprocess output as string, not bytes

### DIFF
--- a/util/config/write-git-sha
+++ b/util/config/write-git-sha
@@ -24,7 +24,8 @@ dont_build_sha = False if os.getenv('CHPL_DONT_BUILD_SHA') is None else True
 if dont_build_sha:
     git_sha = "xxxxxxxxxx"
 else:
-    git_sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).strip()
+    git_sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
+                                      universal_newlines=True).strip()
 
 if not os.path.exists(args.location):
     os.makedirs(args.location)


### PR DESCRIPTION
This PR fixes a problem where a git-sha would be written out with a
preceding `'b'`. This was introduced with fixes for python 2.7 compatibility
that came in https://github.com/chapel-lang/chapel/pull/21268.

Testing:

- [x] python 2.7 builds
- [x] python 3 builds

reviewed by @riftEmber - thank you!