### PR TITLE
Error system tweaks

### DIFF
--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -519,7 +519,7 @@ class Context {
     This is a convenience overload.
     This version takes in a Location and a printf-style format string.
    */
-  void error(Location loc, const char* fmt, ...)
+  const ErrorBase* error(Location loc, const char* fmt, ...)
   #ifndef DOXYGEN
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.
@@ -533,7 +533,7 @@ class Context {
     This version takes in an ID and a printf-style format string.
     The ID is used to compute a Location using parsing::locateId.
    */
-  void error(ID id, const char* fmt, ...)
+  const ErrorBase* error(ID id, const char* fmt, ...)
   #ifndef DOXYGEN
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.
@@ -547,7 +547,7 @@ class Context {
     This version takes in an AST node and a printf-style format string.
     The AST node is used to compute a Location by using a parsing::locateAst.
    */
-  void error(const uast::AstNode* ast, const char* fmt, ...)
+  const ErrorBase* error(const uast::AstNode* ast, const char* fmt, ...)
   #ifndef DOXYGEN
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.
@@ -563,7 +563,7 @@ class Context {
     The AST node is used to compute a Location by using a parsing::locateAst.
     The TypedFnSignature is used to print out instantiation information.
    */
-  void error(const resolution::TypedFnSignature* inFn,
+  const ErrorBase* error(const resolution::TypedFnSignature* inFn,
              const uast::AstNode* ast,
              const char* fmt, ...)
   #ifndef DOXYGEN

--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -60,7 +60,7 @@ namespace chpl {
 
 class ErrorWriterBase;
 
-using Note = std::tuple<ID, Location, std::string>;
+using Note = std::tuple<IdOrLocation, std::string>;
 
 /** Enum representing the different types of errors in Dyno. */
 enum ErrorType {

--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -59,7 +59,7 @@ enum ErrorType {
   // GeneralError is not defined via macro to make it easier to provide special
   // behavior for it (e.g. vbuild). Its tags are thus also not provided via the
   // macro.
-  GENERAL,
+  General,
 // Include each error specified in error-classes-list.h as an enum element here
 #define DIAGNOSTIC_CLASS(NAME, KIND, EINFO...) NAME,
 #include "chpl/framework/error-classes-list.h"
@@ -189,7 +189,7 @@ class GeneralError : public BasicError {
  protected:
   GeneralError(ErrorBase::Kind kind, IdOrLocation idOrLoc,
                std::string message, std::vector<Note> notes)
-    : BasicError(kind, GENERAL, std::move(idOrLoc),
+    : BasicError(kind, General, std::move(idOrLoc),
                  std::move(message), std::move(notes)) {}
 
   static const owned<GeneralError>&

--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -30,8 +30,6 @@ namespace chpl {
 // Convenience shorthands for DIAGNOSTIC_CLASS.
 #define ERROR_CLASS(NAME, EINFO...) DIAGNOSTIC_CLASS(NAME, ERROR, EINFO)
 #define WARNING_CLASS(NAME, EINFO...) DIAGNOSTIC_CLASS(NAME, WARNING, EINFO)
-#define SYNTAX_CLASS(NAME, EINFO...) DIAGNOSTIC_CLASS(NAME, SYNTAX, EINFO)
-#define NOTE_CLASS(NAME, EINFO...) DIAGNOSTIC_CLASS(NAME, NOTE, EINFO)
 
 // Shorthands specific to parser errors, which provide explicit Locations
 #define PARSER_DIAGNOSTIC_CLASS(NAME, KIND, EINFO...) \
@@ -42,8 +40,6 @@ namespace chpl {
   PARSER_DIAGNOSTIC_CLASS(NAME, WARNING, ##EINFO)
 #define PARSER_SYNTAX_CLASS(NAME, EINFO...) \
   PARSER_DIAGNOSTIC_CLASS(NAME, SYNTAX, ##EINFO)
-#define PARSER_NOTE_CLASS(NAME, EINFO...) \
-  PARSER_DIAGNOSTIC_CLASS(NAME, NOTE, ##EINFO)
 
 // Shorthands specific to post-parse-checks errors, which provide node IDs
 // that should connect to locations by the time we report out errors
@@ -53,10 +49,6 @@ namespace chpl {
   POSTPARSE_DIAGNOSTIC_CLASS(NAME, ERROR, ##EINFO)
 #define POSTPARSE_WARNING_CLASS(NAME, EINFO...) \
   POSTPARSE_DIAGNOSTIC_CLASS(NAME, WARNING, ##EINFO)
-#define POSTPARSE_SYNTAX_CLASS(NAME, EINFO...) \
-  POSTPARSE_DIAGNOSTIC_CLASS(NAME, SYNTAX, ##EINFO)
-#define POSTPARSE_NOTE_CLASS(NAME, EINFO...) \
-  POSTPARSE_DIAGNOSTIC_CLASS(NAME, NOTE, ##EINFO)
 
 class ErrorWriterBase;
 

--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -212,6 +212,11 @@ class GeneralError : public BasicError {
                                  ErrorBase::Kind kind,
                                  Location loc,
                                  std::string msg);
+
+  /* Convenience overload to call ::get with the ERROR kind. */
+  static const GeneralError* error(Context* context,
+                                   Location loc,
+                                   std::string msg);
 };
 
 // The error-classes-list.h header will expand the DIAGNOSTIC_CLASS macro

--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -165,32 +165,22 @@ class ErrorBase {
  */
 class BasicError : public ErrorBase {
  private:
-  /**
-    The ID where the error occurred. Much like ErrorMessage, if the ID
-    is empty, then BasicError::loc_ should be used instead.
-   */
-  ID id_;
-  /**
-    The location of the error message. Should be used only if BasicError::id_
-    is empty.
-   */
-  Location loc_;
+  IdOrLocation idOrLoc_;
   /** The error's message. */
   std::string message_;
   /** Additional notes / details attached to the error. */
   std::vector<Note> notes_;
 
  protected:
-  BasicError(Kind kind, ErrorType type, ID id, Location loc,
+  BasicError(Kind kind, ErrorType type, IdOrLocation idOrLoc,
              std::string message,
              std::vector<Note> notes) :
-    ErrorBase(kind, type), id_(std::move(id)), loc_(std::move(loc)),
+    ErrorBase(kind, type), idOrLoc_(std::move(idOrLoc)),
     message_(std::move(message)), notes_(std::move(notes)) {}
 
   bool contentsMatchInner(const ErrorBase* other) const override {
     auto otherBasic = static_cast<const BasicError*>(other);
-    return id_ == otherBasic->id_ &&
-      loc_ == otherBasic->loc_ &&
+    return idOrLoc_ == otherBasic->idOrLoc_ &&
       message_ == otherBasic->message_ &&
       notes_ == otherBasic->notes_;
   }
@@ -205,14 +195,9 @@ class BasicError : public ErrorBase {
  */
 class GeneralError : public BasicError {
  protected:
-  GeneralError(ErrorBase::Kind kind, ID id,
+  GeneralError(ErrorBase::Kind kind, IdOrLocation idOrLoc,
                std::string message, std::vector<Note> notes)
-    : BasicError(kind, GENERAL, std::move(id), Location(),
-                 std::move(message), std::move(notes)) {}
-
-  GeneralError(ErrorBase::Kind kind, Location loc,
-               std::string message, std::vector<Note> notes)
-    : BasicError(kind, GENERAL, ID(), std::move(loc),
+    : BasicError(kind, GENERAL, std::move(idOrLoc),
                  std::move(message), std::move(notes)) {}
 
   static const owned<GeneralError>&

--- a/frontend/include/chpl/framework/ErrorMessage.h
+++ b/frontend/include/chpl/framework/ErrorMessage.h
@@ -31,11 +31,42 @@
 
 namespace chpl {
 
+class IdOrLocation {
+ protected:
+  // if id_ is set, it is used instead of location_
+  ID id_;
+  // location_ should only be used if id_ is empty which happens for
+  // parser errors
+  Location location_;
+
+ public:
+  IdOrLocation() = default;
+  IdOrLocation(ID id) : id_(std::move(id)) {}
+  IdOrLocation(Location location) : location_(std::move(location)) {}
+
+  /**
+    Return the location in the source code where this error occurred.
+  */
+  Location computeLocation(Context* context) const;
+  const ID& id() const { return id_; }
+  const Location& location() const { return location_; }
+
+  bool operator==(const IdOrLocation& other) const {
+    return id_ == other.id_ &&
+           location_ == other.location_;
+  }
+
+  void mark(Context* context) const {
+    id_.mark(context);
+    location_.mark(context);
+  }
+};
+
 /**
   This class represents an error/warning message. The message
   is saved (in the event it needs to be reported again).
  */
-class ErrorMessage final {
+class ErrorMessage final : public IdOrLocation {
  public:
   enum Kind {
     NOTE,
@@ -46,11 +77,6 @@ class ErrorMessage final {
 
  private:
   Kind kind_;
-  // if id_ is set, it is used instead of location_
-  ID id_;
-  // location_ should only be used if id_ is empty
-  // which happens for parser errors
-  Location location_;
 
   std::string message_;
 
@@ -61,8 +87,7 @@ class ErrorMessage final {
   // TODO: how to handle a callstack of sorts?
 
  public:
-  ErrorMessage(Kind kind, Location location, std::string message);
-  ErrorMessage(Kind kind, ID id, std::string message);
+  ErrorMessage(Kind kind, IdOrLocation idOrLoc, std::string message);
 
   /** Add an ErrorMessage as detail information to this ErrorMessage. */
   void addDetail(ErrorMessage err);
@@ -74,25 +99,15 @@ class ErrorMessage final {
   */
   bool isEmpty() const { return message_.empty() && details_.empty(); }
 
-  /**
-    Return the location in the source code where this error occurred.
-  */
-  Location computeLocation(Context* context) const;
-
   const std::string& message() const { return message_; }
 
   const std::vector<ErrorMessage>& details() const { return details_; }
 
   Kind kind() const { return kind_; }
 
-  inline ID id() const { return id_; }
-
-  inline Location location() const { return location_; }
-
   inline bool operator==(const ErrorMessage& other) const {
-    return kind_ == other.kind_ &&
-           id_ == other.id_ &&
-           location_ == other.location_ &&
+    return IdOrLocation::operator==(other) &&
+           kind_ == other.kind_ &&
            message_ == other.message_ &&
            details_ == other.details_;
   }

--- a/frontend/include/chpl/framework/ErrorWriter.h
+++ b/frontend/include/chpl/framework/ErrorWriter.h
@@ -60,6 +60,9 @@ inline Location locate(Context* context, const uast::AstNode* node) {
 inline Location locate(Context* context, const Location& loc) {
   return loc;
 }
+inline Location locate(Context* context, const IdOrLocation& idOrLoc) {
+  return idOrLoc.computeLocation(context);
+}
 
 /// \cond DO_NOT_DOCUMENT
 /**
@@ -208,9 +211,8 @@ class ErrorWriterBase {
     The location given to this function and its overloads is considered
     the error's main location.
    */
-  virtual void writeHeading(ErrorBase::Kind kind, ErrorType type, Location loc, const std::string& message) = 0;
-  virtual void writeHeading(ErrorBase::Kind kind, ErrorType type, const ID& id, const std::string& message);
-  virtual void writeHeading(ErrorBase::Kind kind, ErrorType type, const uast::AstNode* ast, const std::string& message);
+  virtual void writeHeading(ErrorBase::Kind kind, ErrorType type, IdOrLocation idOrLoc, const std::string& message) = 0;
+  void writeHeading(ErrorBase::Kind kind, ErrorType type, const uast::AstNode* ast, const std::string& message);
   template <typename T>
   void writeHeading(ErrorBase::Kind kind, ErrorType type, errordetail::LocationOnly<T> t, const std::string& message) {
     writeHeading(kind, type, errordetail::locate(context, t.t), message);
@@ -229,9 +231,8 @@ class ErrorWriterBase {
     that is useful "in all cases" (e.g., the location of a duplicate
     definition).
    */
-  virtual void writeNote(Location loc, const std::string& message) = 0;
-  virtual void writeNote(const ID& id, const std::string& message);
-  virtual void writeNote(const uast::AstNode* ast, const std::string& message);
+  virtual void writeNote(IdOrLocation loc, const std::string& message) = 0;
+  void writeNote(const uast::AstNode* ast, const std::string& message);
   template <typename T>
   void writeNote(errordetail::LocationOnly<T> t, const std::string& message) {
     writeNote(errordetail::locate(context, t.t), message);
@@ -336,7 +337,7 @@ class ErrorWriter : public ErrorWriterBase {
 
   void setColor(TermColorName color);
 
-  void writeHeading(ErrorBase::Kind kind, ErrorType type, Location loc,
+  void writeHeading(ErrorBase::Kind kind, ErrorType type, IdOrLocation idOrLoc,
                     const std::string& message) override;
   void writeMessage(const std::string& message) override {
     if (outputFormat_ == DETAILED) {
@@ -345,7 +346,7 @@ class ErrorWriter : public ErrorWriterBase {
       oss_ << message << std::endl;
     }
   }
-  void writeNote(Location loc, const std::string& message) override;
+  void writeNote(IdOrLocation idOrLoc, const std::string& message) override;
   void writeCode(const Location& place,
                  const std::vector<Location>& toHighlight = {}) override;
  public:

--- a/frontend/include/chpl/parsing/FileContents.h
+++ b/frontend/include/chpl/parsing/FileContents.h
@@ -42,7 +42,7 @@ class FileContents {
   std::string text_;
   // TODO: it would be better to use the LLVM error handling strategy here,
   //       instead of storing errors created via Context.
-  const ErrorParseErr* error_;
+  const ErrorBase* error_;
 
  public:
   /** Construct a FileContents containing empty text and no error */
@@ -52,14 +52,14 @@ class FileContents {
   FileContents(std::string text)
     : text_(std::move(text)), error_() { }
   /** Construct a FileContents containing the passed text and error */
-  FileContents(std::string text, const ErrorParseErr* error)
+  FileContents(std::string text, const ErrorBase* error)
     : text_(std::move(text)), error_(error) { }
 
   /** Return a reference to the contents of this file */
   const std::string& text() const { return text_; }
 
   /** Return a reference to an error encountered when reading this file */
-  const ErrorParseErr* error() const { return error_; }
+  const ErrorBase* error() const { return error_; }
 
   bool operator==(const FileContents& other) const {
     return text_ == other.text_ &&

--- a/frontend/include/chpl/parsing/parser-error.h
+++ b/frontend/include/chpl/parsing/parser-error.h
@@ -28,20 +28,12 @@
   Evaluates to an ErroneousExpression error sentinel at the location of the
   error, which may be used or ignored.
  */
-#define CHPL_PARSER_REPORT(P_CONTEXT__, NAME__, LOC__, EINFO__...)         \
-  (P_CONTEXT__->saveError(CHPL_REPORT(P_CONTEXT__->context(), NAME__,      \
-                                      P_CONTEXT__->convertLocation(LOC__), \
-                                      ##EINFO__)),                         \
-   ErroneousExpression::build(P_CONTEXT__->builder,                        \
-                              P_CONTEXT__->convertLocation(LOC__))         \
-       .release())
-
-// Simplified versions of CHPL_PARSER_REPORT which report an error/syntax error
-// message without a specialized error class or additional info
-#define CHPL_PARSER_REPORT_ERR(P_CONTEXT__, LOC__, MSG__) \
-  CHPL_PARSER_REPORT(P_CONTEXT__, ParseErr, LOC__, MSG__)
-#define CHPL_PARSER_REPORT_SYNTAX(P_CONTEXT__, LOC__, MSG__) \
-  CHPL_PARSER_REPORT(P_CONTEXT__, ParseSyntax, LOC__, MSG__)
+#define CHPL_PARSER_REPORT(P_CONTEXT__, NAME__, LOC__, EINFO__...) \
+  P_CONTEXT__->report(LOC__,                                       \
+    CHPL_PARSER_GET_ERROR(P_CONTEXT__, NAME__, LOC__, ##EINFO__))
+#define CHPL_PARSER_GET_ERROR(P_CONTEXT__, NAME__, LOC__, EINFO__...) \
+  CHPL_GET_ERROR(P_CONTEXT__->context(), NAME__,                      \
+                 P_CONTEXT__->convertLocation(LOC__), ##EINFO__)
 
 /**
   Helper macros to report errors from the lexer, including retrieving the

--- a/frontend/include/chpl/parsing/parser-error.h
+++ b/frontend/include/chpl/parsing/parser-error.h
@@ -45,24 +45,17 @@
   CHPL_LEXER_REPORT_ACTUAL(SCANNER__, NLINES__, NCOLS__,                    \
                            /* MOVE_TO_END__ */ false, NAME__, ##EINFO__)
 
-#define CHPL_LEXER_REPORT_SYNTAX(SCANNER__, NLINES__, NCOLS__, MSG__) \
-  CHPL_LEXER_REPORT(SCANNER__, NLINES__, NCOLS__, ParseSyntax, MSG__)
-
 // this variant moves the beginning of the reported location to its current end
 #define CHPL_LEXER_REPORT_END(SCANNER__, NLINES__, NCOLS__, NAME__, \
                               EINFO__...)                           \
   CHPL_LEXER_REPORT_ACTUAL(SCANNER__, NLINES__, NCOLS__,            \
                            /* MOVE_TO_END__ */ true, NAME__, ##EINFO__)
 
-#define CHPL_LEXER_REPORT_ACTUAL(SCANNER__, NLINES__, NCOLS__, MOVE_TO_END__, \
-                                 NAME__, EINFO__...)                          \
-  {                                                                           \
-    ParserContext* pContext = yyget_extra(SCANNER__);                         \
-    YYLTYPE loc = *yyget_lloc(SCANNER__);                                     \
-    updateLocation(&loc, NLINES__, NCOLS__);                                  \
-    if (MOVE_TO_END__) loc = pContext->makeLocationAtLast(loc);               \
-    CHPL_PARSER_REPORT(pContext, NAME__, loc, ##EINFO__);                     \
-  }
+#define CHPL_LEXER_REPORT_ACTUAL(SCANNER__, NLINES__, NCOLS__, MOVE_TO_END__,  \
+                                 NAME__, EINFO__...)                           \
+  CHPL_PARSER_REPORT(yyget_extra(SCANNER__), NAME__,                           \
+                     getLocation(SCANNER__, NLINES__, NCOLS__, MOVE_TO_END__), \
+                     ##EINFO__);
 
 /**
  * Helper macro to report errors in post-parse-checks to the Builder

--- a/frontend/include/chpl/uast/Builder.h
+++ b/frontend/include/chpl/uast/Builder.h
@@ -109,12 +109,6 @@ class Builder final {
   void addError(const ErrorBase*);
 
   /**
-    Construct and save a generic post-parse error/warning.
-   */
-  void addPostParseError(const AstNode* node, const char* fmt, ...);
-  void addPostParseWarning(const AstNode* node, const char* fmt, ...);
-
-  /**
     Record the location of an AST element.
    */
   void noteLocation(AstNode* ast, Location loc);

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -573,55 +573,59 @@ const ErrorBase* Context::report(const ErrorBase* error) {
   return error;
 }
 
-static void logErrorInContext(Context* context,
+static const ErrorBase* logErrorInContext(Context* context,
                               ErrorBase::Kind kind,
                               Location loc,
                               const char* fmt,
                               va_list vl) {
   auto err = GeneralError::vbuild(context, kind, loc, fmt, vl);
   context->report(err);
+  return err;
 }
 
-static void logErrorInContext(Context* context,
+static const ErrorBase* logErrorInContext(Context* context,
                               ErrorBase::Kind kind,
                               ID id,
                               const char* fmt,
                               va_list vl) {
   auto err = GeneralError::vbuild(context, kind, id, fmt, vl);
   context->report(err);
+  return err;
 }
 
-static void logErrorInContext(Context* context,
+static const ErrorBase* logErrorInContext(Context* context,
                               ErrorBase::Kind kind,
                               const uast::AstNode* ast,
                               const char* fmt,
                               va_list vl) {
   auto err = GeneralError::vbuild(context, kind, ast->id(), fmt, vl);
   context->report(err);
+  return err;
 }
 
 #define CHPL_CONTEXT_LOG_ERROR_HELPER(context__, kind__, pin__, fmt__) \
   do { \
     va_list vl; \
     va_start(vl, fmt__); \
-    logErrorInContext(context__, kind__, pin__, fmt__, vl); \
+    auto err = logErrorInContext(context__, kind__, pin__, fmt__, vl); \
     va_end(vl); \
+    return err; \
   } while (0)
 
 // TODO: Similar overloads for NOTE, WARN, etc.
-void Context::error(Location loc, const char* fmt, ...) {
+const ErrorBase* Context::error(Location loc, const char* fmt, ...) {
   CHPL_CONTEXT_LOG_ERROR_HELPER(this, ErrorBase::ERROR, loc, fmt);
 }
 
-void Context::error(ID id, const char* fmt, ...) {
+const ErrorBase* Context::error(ID id, const char* fmt, ...) {
   CHPL_CONTEXT_LOG_ERROR_HELPER(this, ErrorBase::ERROR, id, fmt);
 }
 
-void Context::error(const uast::AstNode* ast, const char* fmt, ...) {
+const ErrorBase* Context::error(const uast::AstNode* ast, const char* fmt, ...) {
   CHPL_CONTEXT_LOG_ERROR_HELPER(this, ErrorBase::ERROR, ast, fmt);
 }
 
-void Context::error(const resolution::TypedFnSignature* inFn,
+const ErrorBase* Context::error(const resolution::TypedFnSignature* inFn,
                     const uast::AstNode* ast,
                     const char* fmt, ...) {
   CHPL_CONTEXT_LOG_ERROR_HELPER(this, ErrorBase::ERROR, ast, fmt);

--- a/frontend/lib/framework/ErrorBase.cpp
+++ b/frontend/lib/framework/ErrorBase.cpp
@@ -42,10 +42,7 @@ const char* ErrorBase::getTypeName(ErrorType type) {
  */
 class CompatibilityWriter : public ErrorWriterBase {
  private:
-  /** The ID of where the error occurred. */
-  ID id_;
-  /** The location of where the error occurred. Only used if ::id_ is empty. */
-  Location loc_;
+  IdOrLocation idOrLoc_;
   /** The computed location (derived from the ::id_ or ::loc_) */
   Location computedLoc_;
   /** The error's brief message */
@@ -58,16 +55,9 @@ class CompatibilityWriter : public ErrorWriterBase {
     : ErrorWriterBase(context, OutputFormat::BRIEF) {}
 
   void writeHeading(ErrorBase::Kind kind, ErrorType type,
-                    Location loc, const std::string& message) override {
-    this->loc_ = loc;
-    this->computedLoc_ = std::move(loc);
-    this->message_ = message;
-  }
-  void writeHeading(ErrorBase::Kind kind, ErrorType type,
-                    const ID& id, const std::string& message) override {
-    // Just store the ID, but don't pollute the output stream.
-    this->id_ = id;
-    this->computedLoc_ = errordetail::locate(context, id);
+                    IdOrLocation idOrLoc, const std::string& message) override {
+    this->computedLoc_ = errordetail::locate(context, idOrLoc);
+    this->idOrLoc_ = std::move(idOrLoc);
     this->message_ = message;
   }
 
@@ -75,11 +65,8 @@ class CompatibilityWriter : public ErrorWriterBase {
   void writeCode(const Location& loc,
                  const std::vector<Location>& hl) override {}
 
-  void writeNote(Location loc, const std::string& message) override {
-    this->notes_.push_back(std::make_tuple(ID(), std::move(loc), message));
-  }
-  void writeNote(const ID& id, const std::string& message) override {
-    this->notes_.push_back(std::make_tuple(std::move(id), Location(), message));
+  void writeNote(IdOrLocation loc, const std::string& message) override {
+    this->notes_.push_back(std::make_tuple(std::move(loc), message));
   }
 
   /**
@@ -88,14 +75,14 @@ class CompatibilityWriter : public ErrorWriterBase {
     This only works after ErrorBase::write was invoked with this
     CompatibilityWriter.
    */
-  inline ID id() const { return id_; }
+  inline ID id() const { return idOrLoc_.id(); }
   /**
     Get the error's location (could be empty in favor of the ID)
 
     This only works after ErrorBase::write was invoked with this
     CompatibilityWriter.
    */
-  inline Location location() const { return loc_; }
+  inline Location location() const { return idOrLoc_.location(); }
   /**
     Return the location that should be reported to the user.
 
@@ -150,10 +137,10 @@ ErrorMessage ErrorBase::toErrorMessage(Context* context) const {
   for (auto note : ew.notes()) {
     auto detailKind = ErrorMessage::NOTE;
     auto detailmessage = std::get<std::string>(note);
-    message.addDetail(std::get<ID>(note).isEmpty() ?
-        ErrorMessage(detailKind, std::get<Location>(note), std::move(detailmessage)) :
-        ErrorMessage(detailKind, std::get<ID>(note), std::move(detailmessage))
-    );
+    message.addDetail(
+        ErrorMessage(detailKind,
+                     std::get<IdOrLocation>(note),
+                     std::get<std::string>(note)));
   }
   return message;
 }
@@ -166,14 +153,9 @@ void BasicError::write(ErrorWriterBase& wr) const {
     wr.heading(kind_, type_, loc_, message_);
   }
   for (auto note : notes_) {
-    auto& id = std::get<ID>(note);
-    auto& location = std::get<Location>(note);
+    auto& idOrLoc = std::get<IdOrLocation>(note);
     auto& message = std::get<std::string>(note);
-    if (!id.isEmpty()) {
-      wr.note(id, message);
-    } else {
-      wr.note(location, message);
-    }
+    wr.note(idOrLoc, message);
   }
 }
 

--- a/frontend/lib/framework/ErrorBase.cpp
+++ b/frontend/lib/framework/ErrorBase.cpp
@@ -193,4 +193,8 @@ const GeneralError* GeneralError::get(Context* context, Kind kind, Location loc,
   return getGeneralErrorForLocation(context, kind, loc, std::move(msg)).get();
 }
 
+const GeneralError* GeneralError::error(Context* context, Location loc, std::string msg) {
+  return GeneralError::get(context, ErrorBase::ERROR, std::move(loc), std::move(msg));
+}
+
 } // end namespace 'chpl'

--- a/frontend/lib/framework/ErrorMessage.cpp
+++ b/frontend/lib/framework/ErrorMessage.cpp
@@ -26,21 +26,7 @@
 
 namespace chpl {
 
-ErrorMessage::ErrorMessage(Kind kind, Location location, std::string message)
-    : kind_(kind), id_(), location_(location), message_(message) {
-  gdbShouldBreakHere();
-}
-
-ErrorMessage::ErrorMessage(Kind kind, ID id, std::string message)
-    : kind_(kind), id_(id), location_(), message_(message) {
-  gdbShouldBreakHere();
-}
-
-void ErrorMessage::addDetail(ErrorMessage err) {
-  details_.push_back(std::move(err));
-}
-
-Location ErrorMessage::computeLocation(Context* context) const {
+Location IdOrLocation::computeLocation(Context* context) const {
   // if the ID is set, determine the location from that
   if (!id_.isEmpty()) {
     Location loc = parsing::locateId(context, id_);
@@ -49,6 +35,15 @@ Location ErrorMessage::computeLocation(Context* context) const {
 
   // otherwise, use the location stored here
   return location_;
+}
+
+ErrorMessage::ErrorMessage(Kind kind, IdOrLocation idOrLoc, std::string message)
+    : IdOrLocation(std::move(idOrLoc)), kind_(kind), message_(std::move(message)) {
+
+}
+
+void ErrorMessage::addDetail(ErrorMessage err) {
+  details_.push_back(std::move(err));
 }
 
 } // namespace chpl

--- a/frontend/lib/framework/ErrorWriter.cpp
+++ b/frontend/lib/framework/ErrorWriter.cpp
@@ -39,20 +39,11 @@ void ErrorWriterBase::tweakErrorString(std::string& str) const {
   }
 }
 
-void ErrorWriterBase::writeHeading(ErrorBase::Kind kind, ErrorType type,
-                                   const ID& id, const std::string& str) {
-  writeHeading(kind, type, errordetail::locate(context, id), str);
-}
-
 void ErrorWriterBase::writeHeading(ErrorBase::Kind kind,
                                    ErrorType type,
                                    const uast::AstNode* node,
                                    const std::string& str) {
   writeHeading(kind, type, node->id(), str);
-}
-
-void ErrorWriterBase::writeNote(const ID& id, const std::string& str) {
-  writeNote(errordetail::locate(context, id), str);
 }
 
 void ErrorWriterBase::writeNote(const uast::AstNode* ast, const std::string& str) {
@@ -125,7 +116,7 @@ static void writeFile(std::ostream& oss, const Location& loc) {
 }
 
 void ErrorWriter::writeHeading(ErrorBase::Kind kind, ErrorType type,
-                               Location loc, const std::string& str) {
+                               IdOrLocation loc, const std::string& str) {
   if (outputFormat_ == DETAILED) {
     // In detailed mode, print some error decoration
     oss_ << "─── ";
@@ -135,7 +126,7 @@ void ErrorWriter::writeHeading(ErrorBase::Kind kind, ErrorType type,
   oss_ << kindText(kind);
   setColor(CLEAR);
   oss_ << " in ";
-  writeFile(oss_, loc);
+  writeFile(oss_, errordetail::locate(context, loc));
   if (outputFormat_ == DETAILED) {
     // Second part of the error decoration
     const char* name = ErrorBase::getTypeName(type);
@@ -153,11 +144,11 @@ void ErrorWriter::writeHeading(ErrorBase::Kind kind, ErrorType type,
   oss_ << str << std::endl;
 }
 
-void ErrorWriter::writeNote(Location loc, const std::string& str) {
+void ErrorWriter::writeNote(IdOrLocation loc, const std::string& str) {
   if (outputFormat_ == BRIEF) {
     // Indent notes in brief mode to make things easier to organize
     oss_ << "  note in ";
-    writeFile(oss_, loc);
+    writeFile(oss_, errordetail::locate(context, loc));
     oss_ << ": ";
   } else {
     // In detailed mode, the body is indented.

--- a/frontend/lib/parsing/Parser.cpp
+++ b/frontend/lib/parsing/Parser.cpp
@@ -94,8 +94,8 @@ BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
 
   FILE* fp = openfile(path, "r", fileError);
   if (fp == NULL) {
-    builder->addError(ErrorParseErr::get(
-        this->context(), std::make_tuple(Location(), fileError)));
+    builder->addError(
+        GeneralError::error(this->context(), Location(), fileError));
     return builder->result();
   }
 
@@ -166,8 +166,8 @@ BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
   yychpl_lex_destroy(parserContext.scanner);
 
   if (closefile(fp, path, fileError)) {
-    builder->addError(ErrorParseErr::get(
-        this->context(), std::make_tuple(Location(), fileError)));
+    builder->addError(
+        GeneralError::error(this->context(), Location(), fileError));
   }
 
   updateParseResult(&parserContext);

--- a/frontend/lib/parsing/ParserContext.h
+++ b/frontend/lib/parsing/ParserContext.h
@@ -169,7 +169,9 @@ struct ParserContext {
     };
   }
 
-  void saveError(const ErrorBase* error) { errors.push_back(error); }
+  ErroneousExpression* report(YYLTYPE loc, const ErrorBase* error);
+  ErroneousExpression* error(YYLTYPE loc, const char* fmt, ...);
+  ErroneousExpression* syntax(YYLTYPE loc, const char* fmt, ...);
 
   void noteComment(YYLTYPE loc, const char* data, long size);
   std::vector<ParserComment>* gatherComments(YYLTYPE location);

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -160,8 +160,7 @@ PODUniqueString ParserContext::notePragma(YYLTYPE loc,
     auto tag = pragmaNameToTag(ret.c_str());
 
     if (tag == PRAGMA_UNKNOWN)
-      CHPL_PARSER_REPORT_ERR(
-          this, loc, "unknown pragma \"" + strLit->value().str() + "\".");
+      error(loc, "unknown pragma \"%s\".", strLit->value().c_str());
 
     // Initialize the pragma flags if needed.
     auto& pragmas = attributeParts.pragmas;
@@ -256,8 +255,7 @@ ParserContext::buildPragmaStmt(YYLTYPE loc, CommentsAndStmt cs) {
       CHPL_ASSERT(attributeParts.pragmas == nullptr);
       CHPL_ASSERT(attributeParts.isDeprecated);
       CHPL_ASSERT(attributeParts.isUnstable);
-      CHPL_PARSER_REPORT_SYNTAX(
-          this, loc, "pragma list must come before deprecation statement.");
+      syntax(loc, "pragma list must come before deprecation statement.");
     }
 
   } else {
@@ -331,6 +329,30 @@ void ParserContext::exitScope(asttags::AstTag tag, UniqueString name) {
   CHPL_ASSERT(scopeStack.back().tag == tag);
   CHPL_ASSERT(scopeStack.back().name == name);
   scopeStack.pop_back();
+}
+
+
+ErroneousExpression* ParserContext::report(YYLTYPE loc, const ErrorBase* error) {
+  errors.push_back(context()->report(error));
+  return ErroneousExpression::build(builder, convertLocation(loc)).release();
+}
+
+#define CHPL_PARSER_CONTEXT_LOG_ERROR_HELPER(p_context__, loc__, kind__, fmt__) \
+  do { \
+    va_list vl; \
+    va_start(vl, fmt); \
+    auto reportLoc = p_context__->convertLocation(loc__); \
+    auto result = p_context__->report(loc__, \
+        GeneralError::vbuild(context(), kind__, reportLoc, fmt__, vl)); \
+    va_end(vl); \
+    return result; \
+  } while(false)
+
+ErroneousExpression* ParserContext::error(YYLTYPE loc, const char* fmt, ...) {
+  CHPL_PARSER_CONTEXT_LOG_ERROR_HELPER(this, loc, ErrorBase::ERROR, fmt);
+}
+ErroneousExpression* ParserContext::syntax(YYLTYPE loc, const char* fmt, ...) {
+  CHPL_PARSER_CONTEXT_LOG_ERROR_HELPER(this, loc, ErrorBase::SYNTAX, fmt);
 }
 
 void ParserContext::noteComment(YYLTYPE loc, const char* data, long size) {
@@ -642,19 +664,16 @@ AstNode* ParserContext::buildPrimCall(YYLTYPE location,
 
   if (anyNames || primName.isEmpty()) {
     if (anyNames)
-      CHPL_PARSER_REPORT_SYNTAX(this, location,
-                                "primitive calls cannot use named arguments.");
+      syntax(location, "primitive calls cannot use named arguments.");
     else
-      CHPL_PARSER_REPORT_SYNTAX(
-          this, location, "primitive calls must start with string literal.");
+      syntax(location, "primitive calls must start with string literal.");
 
     return ErroneousExpression::build(builder, loc).release();
   }
 
   PrimitiveTag tag = primNameToTag(primName.c_str());
   if (tag == PRIM_UNKNOWN) {
-    CHPL_PARSER_REPORT_ERR(this, location,
-                              "unknown primitive '" + primName.str() + "'.");
+    error(location, "unknown primitive '%s'.", primName.c_str());
     return ErroneousExpression::build(builder, loc).release();
   }
 
@@ -1025,14 +1044,13 @@ CommentsAndStmt ParserContext::buildFunctionDecl(YYLTYPE location,
   // in the function as well as the receiver formal.
   if (!f->isMethod() && fp.thisIntent != Formal::DEFAULT_INTENT) {
     if (fp.thisIntent == Formal::TYPE) {
-      CHPL_PARSER_REPORT_ERR(this, location,
-                                "missing type for secondary type method '" +
-                                    identName->name().str() + "'.");
+      error(location, "missing type for secondary type method '%s'.",
+            identName->name().c_str());
     } else {
-      CHPL_PARSER_REPORT_ERR(
-          this, location,
-          "'this' intents can only be applied to methods, but '" +
-              identName->name().str() + "' is not a method.");
+      error(location,
+            "'this' intents can only be applied to methods, "
+            "but '%s' is not a method",
+            identName->name().c_str());
     }
   }
 
@@ -1301,8 +1319,7 @@ AstNode* ParserContext::buildNewExpr(YYLTYPE location,
       // and var z20c = new C()?.tmeth;
       if (expr->toDot()->receiver()->isFnCall() ||
           expr->toDot()->receiver()->isOpCall()) {
-        CHPL_PARSER_REPORT_SYNTAX(
-            this, location,
+        syntax(location,
             "must use parentheses to disambiguate dot expression after 'new'.");
       } else {
         // try to capture case of new M.Q;
@@ -1517,8 +1534,7 @@ CommentsAndStmt ParserContext::buildBracketLoopStmt(YYLTYPE locLeftBracket,
 
   if (iterExprs->size() > 1) {
     return {.comments = comments,
-            .stmt = CHPL_PARSER_REPORT_ERR(this, locIterExprs,
-                                              "invalid iterand expression.")};
+            .stmt = error(locIterExprs, "invalid iterand expression.")};
   } else {
     auto uncastedIterandExpr = consumeList(iterExprs)[0].release();
     iterandExpr = uncastedIterandExpr;
@@ -1850,13 +1866,12 @@ buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol,
       if (asExpr) {
         if (!asExpr->symbol()->isIdentifier() ||
             !asExpr->rename()->isIdentifier()) {
-          error = CHPL_PARSER_REPORT_SYNTAX(this, location,
-                                            "incorrect expression in 'import' "
-                                            "list rename, identifier expected.");
+          error = syntax(location,
+                         "incorrect expression in 'import' "
+                         "list rename, identifier expected.");
         }
       } else {
-        error = CHPL_PARSER_REPORT_SYNTAX(
-            this, location,
+        error = syntax(location,
             "incorrect expression in 'import' for unqualified access, "
             "identifier expected.");
       }
@@ -1891,8 +1906,7 @@ buildForwardingDecl(YYLTYPE location, owned<Attributes> attributes,
 
   auto comments = gatherComments(location);
   if (attributes && attributes->isDeprecated()) {
-    CHPL_PARSER_REPORT_ERR(this, location,
-                              "can't deprecate a forwarding statement.");
+    error(location, "can't deprecate a forwarding statement.");
   }
   if (limitationKind == VisibilityClause::NONE) {
     auto node = ForwardingDecl::build(builder, convertLocation(location),
@@ -2136,15 +2150,14 @@ void ParserContext::validateExternTypeDeclParts(YYLTYPE location,
                                                 TypeDeclParts& parts) {
   if (parts.tag == asttags::Class) {
     CHPL_ASSERT(parts.linkage != Decl::DEFAULT_LINKAGE);
-    CHPL_PARSER_REPORT_ERR(this, location,
-                       "cannot declare class types as export or extern.");
+    error(location, "cannot declare class types as export or extern.");
 
     // Clear the linkage state for this so that parsing can continue.
     clearTypeDeclPartsLinkage(parts);
   }
 
   if (parts.tag == asttags::Union && parts.linkage == Decl::EXPORT) {
-    CHPL_PARSER_REPORT_ERR(this, location, "cannot export union types.");
+    error(location, "cannot export union types.");
 
     // Clear the linkage state for this so that parsing can continue.
     clearTypeDeclPartsLinkage(parts);
@@ -2180,19 +2193,16 @@ ParserContext::buildAggregateTypeDecl(YYLTYPE location,
         CHPL_PARSER_REPORT(this, RecordInheritanceNotSupported, inheritLoc,
                            parts.name.str());
       } else if (parts.tag == asttags::Union) {
-        CHPL_PARSER_REPORT_ERR(this, inheritLoc, "unions cannot inherit.");
+        error(inheritLoc, "unions cannot inherit.");
       } else {
         if (optInherit->size() > 1)
-          CHPL_PARSER_REPORT_ERR(this, inheritLoc,
-                                    "only single inheritance is supported.");
+          error(inheritLoc, "only single inheritance is supported.");
         AstNode* ast = (*optInherit)[0];
         if (ast->isIdentifier()) {
           inheritIdentifier = toOwned(ast->toIdentifier());
           (*optInherit)[0] = nullptr;
         } else {
-          CHPL_PARSER_REPORT_SYNTAX(
-              this, inheritLoc,
-              "non-Identifier expression cannot be inherited.");
+          syntax(inheritLoc, "non-Identifier expression cannot be inherited.");
         }
       }
     }
@@ -2276,8 +2286,7 @@ AstNode* ParserContext::buildReduceIntent(YYLTYPE location,
   (void) locOp;
   const Identifier* ident = iterand->toIdentifier();
   if (ident == nullptr) {
-    return CHPL_PARSER_REPORT_SYNTAX(
-        this, location, "expected identifier for reduce intent name.");
+    return syntax(location, "expected identifier for reduce intent name.");
   }
   auto node = ReduceIntent::build(builder, convertLocation(location),
                                   toOwned(op),
@@ -2503,8 +2512,7 @@ ParserContext::buildSelectStmt(YYLTYPE location, owned<AstNode> expr,
     if (when->isOtherwise() && numOtherwise++) {
       CommentsAndStmt cs = {
           .comments = comments,
-          .stmt = CHPL_PARSER_REPORT_SYNTAX(
-              this, location, "select has multiple otherwise clauses.")};
+          .stmt = syntax(location, "select has multiple otherwise clauses.")};
       return cs;
     }
   }

--- a/frontend/lib/parsing/bison-chpl-lib.cpp
+++ b/frontend/lib/parsing/bison-chpl-lib.cpp
@@ -915,56 +915,56 @@ static const yytype_int16 yyrline[] =
     1722,  1726,  1730,  1734,  1738,  1742,  1746,  1750,  1754,  1759,
     1764,  1769,  1777,  1792,  1810,  1814,  1821,  1822,  1827,  1832,
     1833,  1834,  1835,  1836,  1837,  1838,  1839,  1840,  1841,  1842,
-    1843,  1844,  1854,  1855,  1856,  1857,  1866,  1867,  1871,  1875,
-    1879,  1886,  1890,  1894,  1901,  1905,  1909,  1913,  1920,  1921,
-    1925,  1929,  1933,  1940,  1953,  1969,  1977,  1981,  1990,  1991,
-    1995,  1999,  2004,  2012,  2017,  2021,  2028,  2029,  2033,  2042,
-    2047,  2058,  2065,  2066,  2067,  2071,  2072,  2076,  2080,  2084,
-    2088,  2092,  2099,  2116,  2129,  2136,  2141,  2148,  2147,  2158,
-    2164,  2163,  2177,  2179,  2178,  2187,  2186,  2198,  2197,  2206,
-    2205,  2216,  2223,  2235,  2253,  2250,  2278,  2282,  2283,  2285,
-    2290,  2291,  2295,  2296,  2300,  2303,  2305,  2312,  2313,  2325,
-    2346,  2345,  2361,  2360,  2378,  2388,  2385,  2419,  2427,  2435,
-    2446,  2457,  2466,  2481,  2482,  2486,  2487,  2488,  2497,  2498,
-    2499,  2500,  2501,  2502,  2503,  2504,  2505,  2506,  2507,  2508,
-    2509,  2510,  2511,  2512,  2513,  2514,  2515,  2516,  2517,  2518,
-    2519,  2520,  2521,  2525,  2526,  2527,  2528,  2529,  2530,  2531,
-    2532,  2533,  2534,  2535,  2536,  2541,  2542,  2546,  2547,  2548,
-    2552,  2553,  2557,  2558,  2562,  2563,  2567,  2568,  2572,  2576,
-    2577,  2581,  2585,  2590,  2595,  2600,  2605,  2614,  2618,  2626,
-    2627,  2628,  2629,  2630,  2631,  2632,  2633,  2634,  2638,  2639,
-    2640,  2641,  2642,  2643,  2647,  2648,  2649,  2653,  2654,  2655,
-    2656,  2657,  2658,  2662,  2663,  2666,  2667,  2671,  2672,  2676,
-    2681,  2682,  2684,  2686,  2688,  2693,  2695,  2700,  2702,  2704,
-    2706,  2708,  2710,  2712,  2717,  2718,  2722,  2731,  2735,  2743,
-    2747,  2754,  2775,  2776,  2778,  2786,  2787,  2788,  2789,  2790,
-    2795,  2794,  2803,  2811,  2815,  2822,  2838,  2855,  2859,  2863,
-    2870,  2872,  2874,  2881,  2882,  2883,  2887,  2891,  2895,  2899,
-    2903,  2907,  2911,  2919,  2920,  2921,  2922,  2926,  2927,  2931,
-    2932,  2936,  2937,  2938,  2939,  2940,  2960,  2964,  2968,  2972,
-    2979,  2980,  2981,  2985,  2990,  2998,  3003,  3007,  3014,  3015,
-    3016,  3017,  3021,  3025,  3026,  3032,  3033,  3034,  3035,  3039,
-    3040,  3044,  3045,  3046,  3050,  3054,  3061,  3062,  3066,  3071,
-    3080,  3081,  3082,  3083,  3087,  3088,  3099,  3101,  3103,  3105,
-    3112,  3113,  3114,  3115,  3116,  3117,  3119,  3121,  3123,  3125,
-    3131,  3133,  3136,  3138,  3140,  3142,  3144,  3146,  3148,  3150,
-    3152,  3154,  3159,  3168,  3177,  3185,  3199,  3213,  3227,  3236,
-    3245,  3253,  3267,  3281,  3295,  3312,  3321,  3330,  3345,  3363,
-    3381,  3389,  3390,  3391,  3392,  3393,  3394,  3395,  3399,  3400,
-    3404,  3413,  3414,  3418,  3427,  3428,  3432,  3447,  3451,  3458,
-    3459,  3460,  3461,  3462,  3463,  3467,  3469,  3471,  3473,  3475,
-    3481,  3488,  3500,  3512,  3525,  3542,  3549,  3554,  3559,  3564,
-    3570,  3576,  3606,  3613,  3620,  3621,  3625,  3626,  3627,  3628,
-    3629,  3630,  3631,  3632,  3633,  3634,  3635,  3636,  3640,  3641,
-    3645,  3646,  3647,  3651,  3652,  3653,  3654,  3663,  3664,  3667,
-    3668,  3669,  3673,  3685,  3697,  3704,  3706,  3708,  3710,  3712,
-    3718,  3731,  3732,  3736,  3740,  3747,  3748,  3752,  3753,  3757,
-    3758,  3759,  3760,  3761,  3762,  3763,  3764,  3769,  3774,  3778,
-    3783,  3787,  3796,  3801,  3810,  3811,  3812,  3813,  3814,  3815,
-    3816,  3817,  3818,  3819,  3820,  3821,  3822,  3823,  3824,  3825,
-    3826,  3827,  3828,  3829,  3830,  3831,  3832,  3836,  3837,  3838,
-    3839,  3840,  3841,  3844,  3848,  3852,  3856,  3860,  3867,  3871,
-    3875,  3879,  3887,  3888,  3889,  3890,  3891,  3892,  3893
+    1843,  1844,  1853,  1854,  1855,  1856,  1865,  1866,  1870,  1874,
+    1878,  1885,  1889,  1893,  1900,  1904,  1908,  1912,  1919,  1920,
+    1924,  1928,  1932,  1939,  1952,  1968,  1976,  1980,  1989,  1990,
+    1994,  1998,  2003,  2011,  2016,  2020,  2027,  2028,  2032,  2041,
+    2046,  2057,  2064,  2065,  2066,  2070,  2071,  2075,  2079,  2083,
+    2087,  2091,  2098,  2115,  2128,  2135,  2140,  2147,  2146,  2157,
+    2163,  2162,  2176,  2178,  2177,  2186,  2185,  2197,  2196,  2205,
+    2204,  2215,  2222,  2234,  2252,  2249,  2277,  2281,  2282,  2284,
+    2289,  2290,  2294,  2295,  2299,  2302,  2304,  2311,  2312,  2324,
+    2345,  2344,  2360,  2359,  2377,  2387,  2384,  2418,  2426,  2434,
+    2445,  2456,  2465,  2480,  2481,  2485,  2486,  2487,  2496,  2497,
+    2498,  2499,  2500,  2501,  2502,  2503,  2504,  2505,  2506,  2507,
+    2508,  2509,  2510,  2511,  2512,  2513,  2514,  2515,  2516,  2517,
+    2518,  2519,  2520,  2524,  2525,  2526,  2527,  2528,  2529,  2530,
+    2531,  2532,  2533,  2534,  2535,  2540,  2541,  2545,  2546,  2547,
+    2551,  2552,  2556,  2557,  2561,  2562,  2566,  2567,  2571,  2575,
+    2576,  2580,  2584,  2589,  2594,  2599,  2604,  2612,  2616,  2624,
+    2625,  2626,  2627,  2628,  2629,  2630,  2631,  2632,  2636,  2637,
+    2638,  2639,  2640,  2641,  2645,  2646,  2647,  2651,  2652,  2653,
+    2654,  2655,  2656,  2660,  2661,  2664,  2665,  2669,  2670,  2674,
+    2679,  2680,  2682,  2684,  2686,  2691,  2693,  2698,  2700,  2702,
+    2704,  2706,  2708,  2710,  2715,  2716,  2720,  2729,  2733,  2741,
+    2745,  2752,  2773,  2774,  2776,  2784,  2785,  2786,  2787,  2788,
+    2793,  2792,  2801,  2809,  2813,  2820,  2836,  2853,  2857,  2861,
+    2868,  2870,  2872,  2879,  2880,  2881,  2885,  2889,  2893,  2897,
+    2901,  2905,  2909,  2916,  2917,  2918,  2919,  2923,  2924,  2928,
+    2929,  2933,  2934,  2935,  2936,  2937,  2957,  2961,  2965,  2969,
+    2976,  2977,  2978,  2982,  2987,  2995,  3000,  3004,  3011,  3012,
+    3013,  3014,  3018,  3022,  3023,  3029,  3030,  3031,  3032,  3036,
+    3037,  3041,  3042,  3043,  3047,  3051,  3058,  3059,  3063,  3068,
+    3077,  3078,  3079,  3080,  3084,  3085,  3096,  3098,  3100,  3102,
+    3109,  3110,  3111,  3112,  3113,  3114,  3116,  3118,  3120,  3122,
+    3128,  3130,  3133,  3135,  3137,  3139,  3141,  3143,  3145,  3147,
+    3149,  3151,  3156,  3165,  3174,  3182,  3196,  3210,  3224,  3233,
+    3242,  3250,  3264,  3278,  3292,  3309,  3318,  3327,  3342,  3360,
+    3378,  3386,  3387,  3388,  3389,  3390,  3391,  3392,  3396,  3397,
+    3401,  3410,  3411,  3415,  3424,  3425,  3429,  3443,  3447,  3454,
+    3455,  3456,  3457,  3458,  3459,  3463,  3465,  3467,  3469,  3471,
+    3477,  3484,  3496,  3508,  3521,  3538,  3545,  3550,  3555,  3560,
+    3566,  3572,  3602,  3609,  3616,  3617,  3621,  3622,  3623,  3624,
+    3625,  3626,  3627,  3628,  3629,  3630,  3631,  3632,  3636,  3637,
+    3641,  3642,  3643,  3647,  3648,  3649,  3650,  3659,  3660,  3663,
+    3664,  3665,  3669,  3681,  3693,  3700,  3702,  3704,  3706,  3708,
+    3714,  3727,  3728,  3732,  3736,  3743,  3744,  3748,  3749,  3753,
+    3754,  3755,  3756,  3757,  3758,  3759,  3760,  3765,  3770,  3774,
+    3779,  3783,  3792,  3797,  3806,  3807,  3808,  3809,  3810,  3811,
+    3812,  3813,  3814,  3815,  3816,  3817,  3818,  3819,  3820,  3821,
+    3822,  3823,  3824,  3825,  3826,  3827,  3828,  3832,  3833,  3834,
+    3835,  3836,  3837,  3840,  3844,  3848,  3852,  3856,  3863,  3867,
+    3871,  3875,  3883,  3884,  3885,  3886,  3887,  3888,  3889
 };
 #endif
 
@@ -8375,131 +8375,130 @@ yyreduce:
   case 261: /* implements_type_ident: implements_type_error_ident  */
 #line 1845 "chpl.ypp"
   {
-    CHPL_PARSER_REPORT_SYNTAX(
-        context, (yyloc), "type '" + (yyvsp[0].uniqueStr).str() + "' cannot implement an interface.");
+    context->syntax((yyloc), "type '%s' cannot implement an interface.", (yyvsp[0].uniqueStr).c_str());
     (yyval.uniqueStr) = (yyvsp[0].uniqueStr);
   }
-#line 8383 "bison-chpl-lib.cpp"
+#line 8382 "bison-chpl-lib.cpp"
     break;
 
   case 268: /* implements_stmt: TIMPLEMENTS ident_def TLP actual_ls TRP TSEMI  */
-#line 1872 "chpl.ypp"
+#line 1871 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildImplementsStmt((yyloc), YLOC2((yylsp[-4]), (yylsp[-1])), (yyvsp[-4].uniqueStr), (yyvsp[-2].maybeNamedActualList));
   }
-#line 8391 "bison-chpl-lib.cpp"
+#line 8390 "bison-chpl-lib.cpp"
     break;
 
   case 269: /* implements_stmt: implements_type_ident TIMPLEMENTS ident_def TSEMI  */
-#line 1876 "chpl.ypp"
+#line 1875 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildImplementsStmt((yyloc), (yylsp[-3]), (yyvsp[-3].uniqueStr), (yylsp[-1]), (yyvsp[-1].uniqueStr), nullptr);
   }
-#line 8399 "bison-chpl-lib.cpp"
+#line 8398 "bison-chpl-lib.cpp"
     break;
 
   case 270: /* implements_stmt: implements_type_ident TIMPLEMENTS ident_def TLP actual_ls TRP TSEMI  */
-#line 1880 "chpl.ypp"
+#line 1879 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildImplementsStmt((yyloc), (yylsp[-6]), (yyvsp[-6].uniqueStr), YLOC2((yylsp[-4]), (yylsp[-1])), (yyvsp[-4].uniqueStr), (yyvsp[-2].maybeNamedActualList));
   }
-#line 8407 "bison-chpl-lib.cpp"
+#line 8406 "bison-chpl-lib.cpp"
     break;
 
   case 271: /* ifc_constraint: TIMPLEMENTS ident_def TLP actual_ls TRP  */
-#line 1887 "chpl.ypp"
+#line 1886 "chpl.ypp"
   {
     (yyval.expr) = context->buildImplementsConstraint((yyloc), YLOC2((yylsp[-3]), (yylsp[0])), (yyvsp[-3].uniqueStr), (yyvsp[-1].maybeNamedActualList));
   }
-#line 8415 "bison-chpl-lib.cpp"
+#line 8414 "bison-chpl-lib.cpp"
     break;
 
   case 272: /* ifc_constraint: implements_type_ident TIMPLEMENTS ident_def  */
-#line 1891 "chpl.ypp"
+#line 1890 "chpl.ypp"
   {
     (yyval.expr) = context->buildImplementsConstraint((yyloc), (yylsp[-2]), (yyvsp[-2].uniqueStr), (yylsp[0]), (yyvsp[0].uniqueStr), nullptr);
   }
-#line 8423 "bison-chpl-lib.cpp"
+#line 8422 "bison-chpl-lib.cpp"
     break;
 
   case 273: /* ifc_constraint: implements_type_ident TIMPLEMENTS ident_def TLP actual_ls TRP  */
-#line 1895 "chpl.ypp"
+#line 1894 "chpl.ypp"
   {
     (yyval.expr) = context->buildImplementsConstraint((yyloc), (yylsp[-5]), (yyvsp[-5].uniqueStr), YLOC2((yylsp[-3]), (yylsp[0])), (yyvsp[-3].uniqueStr), (yyvsp[-1].maybeNamedActualList));
   }
-#line 8431 "bison-chpl-lib.cpp"
+#line 8430 "bison-chpl-lib.cpp"
     break;
 
   case 274: /* try_stmt: TTRY tryable_stmt  */
-#line 1902 "chpl.ypp"
+#line 1901 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildTryExprStmt((yyloc), (yyvsp[0].commentsAndStmt), false);
   }
-#line 8439 "bison-chpl-lib.cpp"
+#line 8438 "bison-chpl-lib.cpp"
     break;
 
   case 275: /* try_stmt: TTRYBANG tryable_stmt  */
-#line 1906 "chpl.ypp"
+#line 1905 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildTryExprStmt((yyloc), (yyvsp[0].commentsAndStmt), true);
   }
-#line 8447 "bison-chpl-lib.cpp"
+#line 8446 "bison-chpl-lib.cpp"
     break;
 
   case 276: /* try_stmt: TTRY block_stmt catch_expr_ls  */
-#line 1910 "chpl.ypp"
+#line 1909 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildTryCatchStmt((yyloc), (yyvsp[-1].commentsAndStmt), (yyvsp[0].exprList), false);
   }
-#line 8455 "bison-chpl-lib.cpp"
+#line 8454 "bison-chpl-lib.cpp"
     break;
 
   case 277: /* try_stmt: TTRYBANG block_stmt catch_expr_ls  */
-#line 1914 "chpl.ypp"
+#line 1913 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildTryCatchStmt((yyloc), (yyvsp[-1].commentsAndStmt), (yyvsp[0].exprList), true);
   }
-#line 8463 "bison-chpl-lib.cpp"
+#line 8462 "bison-chpl-lib.cpp"
     break;
 
   case 278: /* catch_expr_ls: %empty  */
-#line 1920 "chpl.ypp"
+#line 1919 "chpl.ypp"
                             { (yyval.exprList) = context->makeList(); }
-#line 8469 "bison-chpl-lib.cpp"
+#line 8468 "bison-chpl-lib.cpp"
     break;
 
   case 279: /* catch_expr_ls: catch_expr_ls catch_expr  */
-#line 1921 "chpl.ypp"
+#line 1920 "chpl.ypp"
                             { (yyval.exprList) = context->appendList((yyvsp[-1].exprList), (yyvsp[0].expr)); }
-#line 8475 "bison-chpl-lib.cpp"
+#line 8474 "bison-chpl-lib.cpp"
     break;
 
   case 280: /* catch_expr: TCATCH block_stmt  */
-#line 1926 "chpl.ypp"
+#line 1925 "chpl.ypp"
   {
     (yyval.expr) = context->buildCatch((yyloc), nullptr, (yyvsp[0].commentsAndStmt), false);
   }
-#line 8483 "bison-chpl-lib.cpp"
+#line 8482 "bison-chpl-lib.cpp"
     break;
 
   case 281: /* catch_expr: TCATCH catch_expr_inner block_stmt  */
-#line 1930 "chpl.ypp"
+#line 1929 "chpl.ypp"
   {
     (yyval.expr) = context->buildCatch((yyloc), (yyvsp[-1].expr), (yyvsp[0].commentsAndStmt), false);
   }
-#line 8491 "bison-chpl-lib.cpp"
+#line 8490 "bison-chpl-lib.cpp"
     break;
 
   case 282: /* catch_expr: TCATCH TLP catch_expr_inner TRP block_stmt  */
-#line 1934 "chpl.ypp"
+#line 1933 "chpl.ypp"
   {
     (yyval.expr) = context->buildCatch((yyloc), (yyvsp[-2].expr), (yyvsp[0].commentsAndStmt), true);
   }
-#line 8499 "bison-chpl-lib.cpp"
+#line 8498 "bison-chpl-lib.cpp"
     break;
 
   case 283: /* catch_expr_inner: ident_def  */
-#line 1941 "chpl.ypp"
+#line 1940 "chpl.ypp"
   {
     (yyval.expr) = Variable::build(BUILDER, LOC((yyloc)), /*attributes*/ nullptr,
                          Decl::DEFAULT_VISIBILITY,
@@ -8512,11 +8511,11 @@ yyreduce:
                          /*typeExpression*/ nullptr,
                          /*initExpression*/ nullptr).release();
   }
-#line 8516 "bison-chpl-lib.cpp"
+#line 8515 "bison-chpl-lib.cpp"
     break;
 
   case 284: /* catch_expr_inner: ident_def TCOLON expr  */
-#line 1954 "chpl.ypp"
+#line 1953 "chpl.ypp"
   {
     (yyval.expr) = Variable::build(BUILDER, LOC((yyloc)), /*attributes*/ nullptr,
                          Decl::DEFAULT_VISIBILITY,
@@ -8529,221 +8528,221 @@ yyreduce:
                          /*typeExpression*/ toOwned((yyvsp[0].expr)),
                          /*initExpression*/ nullptr).release();
   }
-#line 8533 "bison-chpl-lib.cpp"
+#line 8532 "bison-chpl-lib.cpp"
     break;
 
   case 285: /* throw_stmt: TTHROW expr TSEMI  */
-#line 1970 "chpl.ypp"
+#line 1969 "chpl.ypp"
   {
     auto comments = context->gatherComments((yylsp[-2]));
     auto node = Throw::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-1].expr)));
     (yyval.commentsAndStmt) = { .comments=comments, .stmt=node.release() };
   }
-#line 8543 "bison-chpl-lib.cpp"
+#line 8542 "bison-chpl-lib.cpp"
     break;
 
   case 286: /* select_stmt: TSELECT expr TLCBR when_stmt_ls TRCBR  */
-#line 1978 "chpl.ypp"
+#line 1977 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildSelectStmt((yyloc), toOwned((yyvsp[-3].expr)), (yyvsp[-1].exprList));
   }
-#line 8551 "bison-chpl-lib.cpp"
+#line 8550 "bison-chpl-lib.cpp"
     break;
 
   case 287: /* select_stmt: TSELECT expr TLCBR error TRCBR  */
-#line 1982 "chpl.ypp"
+#line 1981 "chpl.ypp"
   {
     auto comments = context->gatherComments((yyloc));
     auto node = ErroneousExpression::build(BUILDER, LOC((yylsp[-1])));
     (yyval.commentsAndStmt) = { .comments=comments, .stmt=node.release() };
   }
-#line 8561 "bison-chpl-lib.cpp"
+#line 8560 "bison-chpl-lib.cpp"
     break;
 
   case 288: /* when_stmt_ls: %empty  */
-#line 1990 "chpl.ypp"
+#line 1989 "chpl.ypp"
                           { (yyval.exprList) = context->makeList(); }
-#line 8567 "bison-chpl-lib.cpp"
+#line 8566 "bison-chpl-lib.cpp"
     break;
 
   case 289: /* when_stmt_ls: when_stmt_ls when_stmt  */
-#line 1991 "chpl.ypp"
+#line 1990 "chpl.ypp"
                           { (yyval.exprList) = context->appendList((yyvsp[-1].exprList), (yyvsp[0].commentsAndStmt)); }
-#line 8573 "bison-chpl-lib.cpp"
+#line 8572 "bison-chpl-lib.cpp"
     break;
 
   case 290: /* when_stmt: TWHEN expr_ls do_stmt  */
-#line 1996 "chpl.ypp"
+#line 1995 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildWhenStmt((yyloc), (yyvsp[-1].exprList), (yyvsp[0].blockOrDo));
   }
-#line 8581 "bison-chpl-lib.cpp"
+#line 8580 "bison-chpl-lib.cpp"
     break;
 
   case 291: /* when_stmt: TOTHERWISE stmt  */
-#line 2000 "chpl.ypp"
+#line 1999 "chpl.ypp"
   {
     BlockOrDo blockOrDo = { .cs=(yyvsp[0].commentsAndStmt), .usesDo=false };
     (yyval.commentsAndStmt) = context->buildWhenStmt((yyloc), nullptr, blockOrDo);
   }
-#line 8590 "bison-chpl-lib.cpp"
+#line 8589 "bison-chpl-lib.cpp"
     break;
 
   case 292: /* when_stmt: TOTHERWISE TDO stmt  */
-#line 2005 "chpl.ypp"
+#line 2004 "chpl.ypp"
   {
     BlockOrDo blockOrDo = { .cs=(yyvsp[0].commentsAndStmt), .usesDo=true };
     (yyval.commentsAndStmt) = context->buildWhenStmt((yyloc), nullptr, blockOrDo);
   }
-#line 8599 "bison-chpl-lib.cpp"
+#line 8598 "bison-chpl-lib.cpp"
     break;
 
   case 293: /* manager_expr: expr TAS var_decl_type ident_def  */
-#line 2013 "chpl.ypp"
+#line 2012 "chpl.ypp"
   {
     (yyval.expr) = context->buildManagerExpr((yyloc), (yyvsp[-3].expr), (yyvsp[-1].variableKind), (yylsp[0]), (yyvsp[0].uniqueStr));
     context->resetDeclState();
   }
-#line 8608 "bison-chpl-lib.cpp"
+#line 8607 "bison-chpl-lib.cpp"
     break;
 
   case 294: /* manager_expr: expr TAS ident_def  */
-#line 2018 "chpl.ypp"
+#line 2017 "chpl.ypp"
   {
     (yyval.expr) = context->buildManagerExpr((yyloc), (yyvsp[-2].expr), (yylsp[0]), (yyvsp[0].uniqueStr));
   }
-#line 8616 "bison-chpl-lib.cpp"
+#line 8615 "bison-chpl-lib.cpp"
     break;
 
   case 295: /* manager_expr: expr  */
-#line 2022 "chpl.ypp"
+#line 2021 "chpl.ypp"
   {
     (yyval.expr) = (yyvsp[0].expr);
   }
-#line 8624 "bison-chpl-lib.cpp"
+#line 8623 "bison-chpl-lib.cpp"
     break;
 
   case 296: /* manager_expr_ls: manager_expr  */
-#line 2028 "chpl.ypp"
+#line 2027 "chpl.ypp"
                                         { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 8630 "bison-chpl-lib.cpp"
+#line 8629 "bison-chpl-lib.cpp"
     break;
 
   case 297: /* manager_expr_ls: manager_expr_ls TCOMMA manager_expr  */
-#line 2029 "chpl.ypp"
+#line 2028 "chpl.ypp"
                                         { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 8636 "bison-chpl-lib.cpp"
+#line 8635 "bison-chpl-lib.cpp"
     break;
 
   case 298: /* manage_stmt: TMANAGE manager_expr_ls do_stmt  */
-#line 2034 "chpl.ypp"
+#line 2033 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildManageStmt((yyloc), (yyvsp[-1].exprList), (yylsp[0]), (yyvsp[0].blockOrDo));
   }
-#line 8644 "bison-chpl-lib.cpp"
+#line 8643 "bison-chpl-lib.cpp"
     break;
 
   case 299: /* class_decl_stmt: class_start opt_inherit TLCBR class_level_stmt_ls TRCBR  */
-#line 2043 "chpl.ypp"
+#line 2042 "chpl.ypp"
     {
       (yyval.commentsAndStmt) = context->buildAggregateTypeDecl((yyloc), (yyvsp[-4].typeDeclParts), (yylsp[-3]), (yyvsp[-3].exprList), (yylsp[-2]), (yyvsp[-1].exprList), (yylsp[0]));
       context->exitScope((yyvsp[-4].typeDeclParts).tag, (yyvsp[-4].typeDeclParts).name);
     }
-#line 8653 "bison-chpl-lib.cpp"
+#line 8652 "bison-chpl-lib.cpp"
     break;
 
   case 300: /* class_decl_stmt: class_start opt_inherit TLCBR error TRCBR  */
-#line 2048 "chpl.ypp"
+#line 2047 "chpl.ypp"
     {
       auto contents =
         context->makeList(ErroneousExpression::build(BUILDER, LOC((yylsp[-1]))));
       (yyval.commentsAndStmt) = context->buildAggregateTypeDecl((yyloc), (yyvsp[-4].typeDeclParts), (yylsp[-3]), (yyvsp[-3].exprList), (yylsp[-2]), contents, (yylsp[0]));
       context->exitScope((yyvsp[-4].typeDeclParts).tag, (yyvsp[-4].typeDeclParts).name);
     }
-#line 8664 "bison-chpl-lib.cpp"
+#line 8663 "bison-chpl-lib.cpp"
     break;
 
   case 301: /* class_start: class_tag ident_def  */
-#line 2059 "chpl.ypp"
+#line 2058 "chpl.ypp"
   {
     (yyval.typeDeclParts) = context->enterScopeAndBuildTypeDeclParts((yylsp[-1]), (yyvsp[0].uniqueStr), (yyvsp[-1].astTag));
   }
-#line 8672 "bison-chpl-lib.cpp"
+#line 8671 "bison-chpl-lib.cpp"
     break;
 
   case 302: /* class_tag: TCLASS  */
-#line 2065 "chpl.ypp"
+#line 2064 "chpl.ypp"
            { (yyval.astTag) = asttags::Class; }
-#line 8678 "bison-chpl-lib.cpp"
+#line 8677 "bison-chpl-lib.cpp"
     break;
 
   case 303: /* class_tag: TRECORD  */
-#line 2066 "chpl.ypp"
+#line 2065 "chpl.ypp"
            { (yyval.astTag) = asttags::Record; }
-#line 8684 "bison-chpl-lib.cpp"
+#line 8683 "bison-chpl-lib.cpp"
     break;
 
   case 304: /* class_tag: TUNION  */
-#line 2067 "chpl.ypp"
+#line 2066 "chpl.ypp"
            { (yyval.astTag) = asttags::Union; }
-#line 8690 "bison-chpl-lib.cpp"
+#line 8689 "bison-chpl-lib.cpp"
     break;
 
   case 305: /* opt_inherit: %empty  */
-#line 2071 "chpl.ypp"
+#line 2070 "chpl.ypp"
                   { (yyval.exprList) = nullptr; }
-#line 8696 "bison-chpl-lib.cpp"
+#line 8695 "bison-chpl-lib.cpp"
     break;
 
   case 306: /* opt_inherit: TCOLON expr_ls  */
-#line 2072 "chpl.ypp"
+#line 2071 "chpl.ypp"
                   { (yyval.exprList) = (yyvsp[0].exprList); }
-#line 8702 "bison-chpl-lib.cpp"
+#line 8701 "bison-chpl-lib.cpp"
     break;
 
   case 307: /* class_level_stmt_ls: %empty  */
-#line 2076 "chpl.ypp"
+#line 2075 "chpl.ypp"
   {
     /* nothing */
     (yyval.exprList) = context->makeList();
   }
-#line 8711 "bison-chpl-lib.cpp"
+#line 8710 "bison-chpl-lib.cpp"
     break;
 
   case 308: /* class_level_stmt_ls: class_level_stmt_ls deprecated_class_level_stmt  */
-#line 2081 "chpl.ypp"
+#line 2080 "chpl.ypp"
   {
     context->appendList((yyvsp[-1].exprList), (yyvsp[0].commentsAndStmt));
   }
-#line 8719 "bison-chpl-lib.cpp"
+#line 8718 "bison-chpl-lib.cpp"
     break;
 
   case 309: /* class_level_stmt_ls: class_level_stmt_ls unstable_class_level_stmt  */
-#line 2085 "chpl.ypp"
+#line 2084 "chpl.ypp"
   {
     context->appendList((yyvsp[-1].exprList), (yyvsp[0].commentsAndStmt));
   }
-#line 8727 "bison-chpl-lib.cpp"
+#line 8726 "bison-chpl-lib.cpp"
     break;
 
   case 310: /* class_level_stmt_ls: class_level_stmt_ls pragma_ls deprecated_class_level_stmt  */
-#line 2089 "chpl.ypp"
+#line 2088 "chpl.ypp"
   {
     context->appendList((yyvsp[-2].exprList), context->buildPragmaStmt((yylsp[0]), (yyvsp[0].commentsAndStmt)));
   }
-#line 8735 "bison-chpl-lib.cpp"
+#line 8734 "bison-chpl-lib.cpp"
     break;
 
   case 311: /* class_level_stmt_ls: class_level_stmt_ls pragma_ls unstable_class_level_stmt  */
-#line 2093 "chpl.ypp"
+#line 2092 "chpl.ypp"
   {
     context->appendList((yyvsp[-2].exprList), context->buildPragmaStmt((yylsp[0]), (yyvsp[0].commentsAndStmt)));
   }
-#line 8743 "bison-chpl-lib.cpp"
+#line 8742 "bison-chpl-lib.cpp"
     break;
 
   case 312: /* enum_decl_stmt: enum_header_lcbr enum_ls TRCBR  */
-#line 2100 "chpl.ypp"
+#line 2099 "chpl.ypp"
     {
       TypeDeclParts parts = (yyvsp[-2].typeDeclParts);
       ParserExprList* list = (yyvsp[-1].exprList);
@@ -8760,11 +8759,11 @@ yyreduce:
       context->resetDeclState();
       context->clearComments();
     }
-#line 8764 "bison-chpl-lib.cpp"
+#line 8763 "bison-chpl-lib.cpp"
     break;
 
   case 313: /* enum_decl_stmt: enum_header_lcbr error TRCBR  */
-#line 2117 "chpl.ypp"
+#line 2116 "chpl.ypp"
     {
       TypeDeclParts parts = (yyvsp[-2].typeDeclParts);
       auto err = ErroneousExpression::build(BUILDER, LOC((yylsp[-1])));
@@ -8774,158 +8773,158 @@ yyreduce:
       context->resetDeclState();
       context->clearComments();
     }
-#line 8778 "bison-chpl-lib.cpp"
+#line 8777 "bison-chpl-lib.cpp"
     break;
 
   case 314: /* enum_header_lcbr: TENUM ident_def TLCBR  */
-#line 2130 "chpl.ypp"
+#line 2129 "chpl.ypp"
   {
     (yyval.typeDeclParts) = context->enterScopeAndBuildTypeDeclParts((yylsp[-2]), (yyvsp[-1].uniqueStr), asttags::Enum);
   }
-#line 8786 "bison-chpl-lib.cpp"
+#line 8785 "bison-chpl-lib.cpp"
     break;
 
   case 315: /* enum_ls: deprecated_enum_item  */
-#line 2137 "chpl.ypp"
+#line 2136 "chpl.ypp"
   {
     (yyval.exprList) = context->makeList((yyvsp[0].commentsAndStmt));
     context->resetAttributePartsState();
   }
-#line 8795 "bison-chpl-lib.cpp"
+#line 8794 "bison-chpl-lib.cpp"
     break;
 
   case 316: /* enum_ls: enum_ls TCOMMA  */
-#line 2142 "chpl.ypp"
+#line 2141 "chpl.ypp"
   {
     (yyval.exprList) = (yyvsp[-1].exprList);
     context->clearCommentsBefore((yylsp[0]));
     context->resetAttributePartsState();
   }
-#line 8805 "bison-chpl-lib.cpp"
+#line 8804 "bison-chpl-lib.cpp"
     break;
 
   case 317: /* $@13: %empty  */
-#line 2148 "chpl.ypp"
+#line 2147 "chpl.ypp"
   {
     context->clearCommentsBefore((yylsp[0]));
     context->resetAttributePartsState();
   }
-#line 8814 "bison-chpl-lib.cpp"
+#line 8813 "bison-chpl-lib.cpp"
     break;
 
   case 318: /* enum_ls: enum_ls TCOMMA $@13 deprecated_enum_item  */
-#line 2153 "chpl.ypp"
+#line 2152 "chpl.ypp"
   {
     context->appendList((yyvsp[-3].exprList), (yyvsp[0].commentsAndStmt));
     context->resetAttributePartsState();
   }
-#line 8823 "bison-chpl-lib.cpp"
+#line 8822 "bison-chpl-lib.cpp"
     break;
 
   case 319: /* enum_ls: unstable_enum_item  */
-#line 2159 "chpl.ypp"
+#line 2158 "chpl.ypp"
   {
     (yyval.exprList) = context->makeList((yyvsp[0].commentsAndStmt));
     context->resetAttributePartsState();
   }
-#line 8832 "bison-chpl-lib.cpp"
+#line 8831 "bison-chpl-lib.cpp"
     break;
 
   case 320: /* $@14: %empty  */
-#line 2164 "chpl.ypp"
+#line 2163 "chpl.ypp"
   {
     context->clearCommentsBefore((yylsp[0]));
     context->resetAttributePartsState();
   }
-#line 8841 "bison-chpl-lib.cpp"
+#line 8840 "bison-chpl-lib.cpp"
     break;
 
   case 321: /* enum_ls: enum_ls TCOMMA $@14 unstable_enum_item  */
-#line 2169 "chpl.ypp"
+#line 2168 "chpl.ypp"
   {
     context->appendList((yyvsp[-3].exprList), (yyvsp[0].commentsAndStmt));
     context->resetAttributePartsState();
   }
-#line 8850 "bison-chpl-lib.cpp"
+#line 8849 "bison-chpl-lib.cpp"
     break;
 
   case 323: /* $@15: %empty  */
-#line 2179 "chpl.ypp"
+#line 2178 "chpl.ypp"
   {
     context->noteDeprecation((yyloc), (yyvsp[0].expr));
   }
-#line 8858 "bison-chpl-lib.cpp"
+#line 8857 "bison-chpl-lib.cpp"
     break;
 
   case 324: /* deprecated_enum_item: TDEPRECATED STRINGLITERAL $@15 enum_item  */
-#line 2183 "chpl.ypp"
+#line 2182 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = (yyvsp[0].commentsAndStmt);
   }
-#line 8866 "bison-chpl-lib.cpp"
+#line 8865 "bison-chpl-lib.cpp"
     break;
 
   case 325: /* $@16: %empty  */
-#line 2187 "chpl.ypp"
+#line 2186 "chpl.ypp"
   {
     context->noteDeprecation((yyloc), nullptr);
   }
-#line 8874 "bison-chpl-lib.cpp"
+#line 8873 "bison-chpl-lib.cpp"
     break;
 
   case 326: /* deprecated_enum_item: TDEPRECATED $@16 enum_item  */
-#line 2191 "chpl.ypp"
+#line 2190 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = (yyvsp[0].commentsAndStmt);
   }
-#line 8882 "bison-chpl-lib.cpp"
+#line 8881 "bison-chpl-lib.cpp"
     break;
 
   case 327: /* $@17: %empty  */
-#line 2198 "chpl.ypp"
+#line 2197 "chpl.ypp"
   {
     context->noteUnstable((yyloc), (yyvsp[0].expr));
   }
-#line 8890 "bison-chpl-lib.cpp"
+#line 8889 "bison-chpl-lib.cpp"
     break;
 
   case 328: /* unstable_enum_item: TUNSTABLE STRINGLITERAL $@17 enum_item  */
-#line 2202 "chpl.ypp"
+#line 2201 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = (yyvsp[0].commentsAndStmt);
   }
-#line 8898 "bison-chpl-lib.cpp"
+#line 8897 "bison-chpl-lib.cpp"
     break;
 
   case 329: /* $@18: %empty  */
-#line 2206 "chpl.ypp"
+#line 2205 "chpl.ypp"
   {
     context->noteUnstable((yyloc), nullptr);
   }
-#line 8906 "bison-chpl-lib.cpp"
+#line 8905 "bison-chpl-lib.cpp"
     break;
 
   case 330: /* unstable_enum_item: TUNSTABLE $@18 enum_item  */
-#line 2210 "chpl.ypp"
+#line 2209 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = (yyvsp[0].commentsAndStmt);
   }
-#line 8914 "bison-chpl-lib.cpp"
+#line 8913 "bison-chpl-lib.cpp"
     break;
 
   case 331: /* enum_item: ident_def  */
-#line 2217 "chpl.ypp"
+#line 2216 "chpl.ypp"
     {
       auto decl = EnumElement::build(BUILDER, LOC((yyloc)),
                                      context->buildAttributes((yyloc)),
                                      (yyvsp[0].uniqueStr));
       (yyval.commentsAndStmt) = STMT((yyloc), decl.release());
     }
-#line 8925 "bison-chpl-lib.cpp"
+#line 8924 "bison-chpl-lib.cpp"
     break;
 
   case 332: /* enum_item: ident_def TASSIGN expr  */
-#line 2224 "chpl.ypp"
+#line 2223 "chpl.ypp"
     {
       auto decl = EnumElement::build(BUILDER, LOC((yyloc)),
                                      context->buildAttributes((yyloc)),
@@ -8934,11 +8933,11 @@ yyreduce:
       (yyval.commentsAndStmt) = STMT((yyloc), decl.release());
       context->clearCommentsBefore((yylsp[0]));
     }
-#line 8938 "bison-chpl-lib.cpp"
+#line 8937 "bison-chpl-lib.cpp"
     break;
 
   case 333: /* lambda_decl_start: TLAMBDA  */
-#line 2236 "chpl.ypp"
+#line 2235 "chpl.ypp"
     {
       FunctionParts fp = context->makeFunctionParts(false, false);
       context->noteDeclStartLoc((yylsp[0]));
@@ -8950,21 +8949,21 @@ yyreduce:
       fp.kind = Function::PROC;
       (yyval.functionParts) = fp;
     }
-#line 8954 "bison-chpl-lib.cpp"
+#line 8953 "bison-chpl-lib.cpp"
     break;
 
   case 334: /* $@19: %empty  */
-#line 2253 "chpl.ypp"
+#line 2252 "chpl.ypp"
     {
       context->clearComments();
       context->resetDeclState();
       context->enterScope(asttags::Function, STR("lambda"));
     }
-#line 8964 "bison-chpl-lib.cpp"
+#line 8963 "bison-chpl-lib.cpp"
     break;
 
   case 335: /* lambda_decl_expr: lambda_decl_start req_formal_ls opt_ret_tag opt_type opt_throws_error opt_lifetime_where $@19 function_body_stmt  */
-#line 2259 "chpl.ypp"
+#line 2258 "chpl.ypp"
     {
       FunctionParts fp = (yyvsp[-7].functionParts);
       fp.name = context->buildIdent((yylsp[-7]), STR("lambda"));
@@ -8982,85 +8981,85 @@ yyreduce:
 
       (yyval.expr) = context->buildLambda((yyloc), fp);
     }
-#line 8986 "bison-chpl-lib.cpp"
+#line 8985 "bison-chpl-lib.cpp"
     break;
 
   case 337: /* linkage_spec: linkage_spec_empty  */
-#line 2282 "chpl.ypp"
+#line 2281 "chpl.ypp"
                      { (yyval.functionParts) = context->makeFunctionParts(false, false); }
-#line 8992 "bison-chpl-lib.cpp"
+#line 8991 "bison-chpl-lib.cpp"
     break;
 
   case 338: /* linkage_spec: TINLINE  */
-#line 2283 "chpl.ypp"
+#line 2282 "chpl.ypp"
                      { context->noteDeclStartLoc((yylsp[0]));
                        (yyval.functionParts) = context->makeFunctionParts(true, false); }
-#line 8999 "bison-chpl-lib.cpp"
+#line 8998 "bison-chpl-lib.cpp"
     break;
 
   case 339: /* linkage_spec: TOVERRIDE  */
-#line 2285 "chpl.ypp"
+#line 2284 "chpl.ypp"
                      { context->noteDeclStartLoc((yylsp[0]));
                        (yyval.functionParts) = context->makeFunctionParts(false, true); }
-#line 9006 "bison-chpl-lib.cpp"
+#line 9005 "bison-chpl-lib.cpp"
     break;
 
   case 340: /* opt_fn_type_formal_ls: %empty  */
-#line 2290 "chpl.ypp"
+#line 2289 "chpl.ypp"
                                           { (yyval.exprList) = context->makeList(); }
-#line 9012 "bison-chpl-lib.cpp"
+#line 9011 "bison-chpl-lib.cpp"
     break;
 
   case 341: /* opt_fn_type_formal_ls: fn_type_formal_ls  */
-#line 2291 "chpl.ypp"
+#line 2290 "chpl.ypp"
                                           { (yyval.exprList) = (yyvsp[0].exprList); }
-#line 9018 "bison-chpl-lib.cpp"
+#line 9017 "bison-chpl-lib.cpp"
     break;
 
   case 342: /* fn_type_formal_ls: fn_type_formal  */
-#line 2295 "chpl.ypp"
+#line 2294 "chpl.ypp"
                                           { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 9024 "bison-chpl-lib.cpp"
+#line 9023 "bison-chpl-lib.cpp"
     break;
 
   case 343: /* fn_type_formal_ls: fn_type_formal_ls TCOMMA fn_type_formal  */
-#line 2296 "chpl.ypp"
+#line 2295 "chpl.ypp"
                                           { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 9030 "bison-chpl-lib.cpp"
+#line 9029 "bison-chpl-lib.cpp"
     break;
 
   case 344: /* fn_type_formal: named_formal  */
-#line 2301 "chpl.ypp"
+#line 2300 "chpl.ypp"
   { (yyval.expr) = (yyvsp[0].expr); }
-#line 9036 "bison-chpl-lib.cpp"
+#line 9035 "bison-chpl-lib.cpp"
     break;
 
   case 345: /* fn_type_formal: required_intent_tag TCOLON formal_type  */
-#line 2304 "chpl.ypp"
+#line 2303 "chpl.ypp"
   { (yyval.expr) = context->buildAnonFormal((yyloc), (yylsp[-2]), (yyvsp[-2].intentTag), (yyvsp[0].expr)); }
-#line 9042 "bison-chpl-lib.cpp"
+#line 9041 "bison-chpl-lib.cpp"
     break;
 
   case 346: /* fn_type_formal: formal_type  */
-#line 2306 "chpl.ypp"
+#line 2305 "chpl.ypp"
   { (yyval.expr) = context->buildAnonFormal((yyloc), (yyvsp[0].expr)); }
-#line 9048 "bison-chpl-lib.cpp"
+#line 9047 "bison-chpl-lib.cpp"
     break;
 
   case 347: /* opt_fn_type_ret_type: %empty  */
-#line 2312 "chpl.ypp"
+#line 2311 "chpl.ypp"
                   { (yyval.expr) = nullptr; }
-#line 9054 "bison-chpl-lib.cpp"
+#line 9053 "bison-chpl-lib.cpp"
     break;
 
   case 348: /* opt_fn_type_ret_type: TCOLON expr  */
-#line 2313 "chpl.ypp"
+#line 2312 "chpl.ypp"
                   { (yyval.expr) = (yyvsp[0].expr); }
-#line 9060 "bison-chpl-lib.cpp"
+#line 9059 "bison-chpl-lib.cpp"
     break;
 
   case 349: /* fn_type: TPROCLP opt_fn_type_formal_ls TRP opt_ret_tag opt_fn_type_ret_type opt_throws_error  */
-#line 2327 "chpl.ypp"
+#line 2326 "chpl.ypp"
   {
     FunctionParts fp = context->makeFunctionParts(false, false);
     fp.kind = Function::PROC;
@@ -9075,21 +9074,21 @@ yyreduce:
     fp.visibility = context->visibility;
     (yyval.functionParts) = fp;
   }
-#line 9079 "bison-chpl-lib.cpp"
+#line 9078 "bison-chpl-lib.cpp"
     break;
 
   case 350: /* $@20: %empty  */
-#line 2346 "chpl.ypp"
+#line 2345 "chpl.ypp"
   {
     context->clearComments();
     context->resetDeclState();
     context->enterScope(asttags::Function, STR("proc"));
   }
-#line 9089 "bison-chpl-lib.cpp"
+#line 9088 "bison-chpl-lib.cpp"
     break;
 
   case 351: /* fn_expr: fn_type $@20 block_stmt_body  */
-#line 2352 "chpl.ypp"
+#line 2351 "chpl.ypp"
   {
     FunctionParts fp = (yyvsp[-2].functionParts);
     fp.isBodyNonBlockExpression = false;
@@ -9098,21 +9097,21 @@ yyreduce:
     context->exitScope(asttags::Function, STR("proc"));
     (yyval.functionParts) = fp;
   }
-#line 9102 "bison-chpl-lib.cpp"
+#line 9101 "bison-chpl-lib.cpp"
     break;
 
   case 352: /* $@21: %empty  */
-#line 2361 "chpl.ypp"
+#line 2360 "chpl.ypp"
   {
     context->clearComments();
     context->resetDeclState();
     context->enterScope(asttags::Function, STR("proc"));
   }
-#line 9112 "bison-chpl-lib.cpp"
+#line 9111 "bison-chpl-lib.cpp"
     break;
 
   case 353: /* fn_expr: fn_type TALIAS $@21 expr  */
-#line 2367 "chpl.ypp"
+#line 2366 "chpl.ypp"
   {
     FunctionParts fp = (yyvsp[-3].functionParts);
     fp.isBodyNonBlockExpression = true;
@@ -9121,19 +9120,19 @@ yyreduce:
     context->exitScope(asttags::Function, STR("proc"));
     (yyval.functionParts) = fp;
   }
-#line 9125 "bison-chpl-lib.cpp"
+#line 9124 "bison-chpl-lib.cpp"
     break;
 
   case 354: /* fn_decl_stmt_complete: fn_decl_stmt  */
-#line 2379 "chpl.ypp"
+#line 2378 "chpl.ypp"
     {
       (yyval.commentsAndStmt) = context->buildRegularFunctionDecl((yyloc), (yyvsp[0].functionParts));
     }
-#line 9133 "bison-chpl-lib.cpp"
+#line 9132 "bison-chpl-lib.cpp"
     break;
 
   case 355: /* $@22: %empty  */
-#line 2388 "chpl.ypp"
+#line 2387 "chpl.ypp"
   {
     context->clearComments();
     context->resetDeclState();
@@ -9143,11 +9142,11 @@ yyreduce:
       context->enterScope(asttags::Function, (yyvsp[-4].functionParts).name->name());
     }
   }
-#line 9147 "bison-chpl-lib.cpp"
+#line 9146 "bison-chpl-lib.cpp"
     break;
 
   case 356: /* fn_decl_stmt: fn_decl_stmt_inner opt_ret_tag opt_ret_type opt_throws_error opt_lifetime_where $@22 opt_function_body_stmt  */
-#line 2398 "chpl.ypp"
+#line 2397 "chpl.ypp"
   {
     FunctionParts fp = (yyvsp[-6].functionParts);
     fp.returnIntent = (yyvsp[-5].returnTag);
@@ -9166,11 +9165,11 @@ yyreduce:
 
     (yyval.functionParts) = fp;
   }
-#line 9170 "bison-chpl-lib.cpp"
+#line 9169 "bison-chpl-lib.cpp"
     break;
 
   case 357: /* fn_decl_stmt_inner: fn_decl_stmt_start opt_this_intent_tag fn_ident opt_formal_ls  */
-#line 2420 "chpl.ypp"
+#line 2419 "chpl.ypp"
     {
       FunctionParts fp = (yyvsp[-3].functionParts);
       fp.thisIntent = (yyvsp[-2].intentTag);
@@ -9178,11 +9177,11 @@ yyreduce:
       fp.formals = (yyvsp[0].exprList);
       (yyval.functionParts) = fp;
     }
-#line 9182 "bison-chpl-lib.cpp"
+#line 9181 "bison-chpl-lib.cpp"
     break;
 
   case 358: /* fn_decl_stmt_inner: fn_decl_stmt_start opt_this_intent_tag assignop_ident opt_formal_ls  */
-#line 2428 "chpl.ypp"
+#line 2427 "chpl.ypp"
     {
       FunctionParts fp = (yyvsp[-3].functionParts);
       fp.thisIntent = (yyvsp[-2].intentTag);
@@ -9190,11 +9189,11 @@ yyreduce:
       fp.formals = (yyvsp[0].exprList);
       (yyval.functionParts) = fp;
     }
-#line 9194 "bison-chpl-lib.cpp"
+#line 9193 "bison-chpl-lib.cpp"
     break;
 
   case 359: /* fn_decl_stmt_inner: fn_decl_stmt_start opt_this_intent_tag fn_decl_receiver_expr TDOT fn_ident opt_formal_ls  */
-#line 2436 "chpl.ypp"
+#line 2435 "chpl.ypp"
     {
       FunctionParts fp = (yyvsp[-5].functionParts);
       fp.thisIntent = (yyvsp[-4].intentTag);
@@ -9205,11 +9204,11 @@ yyreduce:
       fp.formals = (yyvsp[0].exprList);
       (yyval.functionParts) = fp;
     }
-#line 9209 "bison-chpl-lib.cpp"
+#line 9208 "bison-chpl-lib.cpp"
     break;
 
   case 360: /* fn_decl_stmt_inner: fn_decl_stmt_start opt_this_intent_tag fn_decl_receiver_expr TDOT assignop_ident opt_formal_ls  */
-#line 2447 "chpl.ypp"
+#line 2446 "chpl.ypp"
     {
       FunctionParts fp = (yyvsp[-5].functionParts);
       fp.thisIntent = (yyvsp[-4].intentTag);
@@ -9220,21 +9219,21 @@ yyreduce:
       fp.formals = (yyvsp[0].exprList);
       (yyval.functionParts) = fp;
     }
-#line 9224 "bison-chpl-lib.cpp"
+#line 9223 "bison-chpl-lib.cpp"
     break;
 
   case 361: /* fn_decl_stmt_inner: fn_decl_stmt_start opt_this_intent_tag error opt_formal_ls  */
-#line 2458 "chpl.ypp"
+#line 2457 "chpl.ypp"
     {
       FunctionParts fp = (yyvsp[-3].functionParts);
       fp.errorExpr = ErroneousExpression::build(BUILDER, LOC((yyloc))).release();
       (yyval.functionParts) = fp;
     }
-#line 9234 "bison-chpl-lib.cpp"
+#line 9233 "bison-chpl-lib.cpp"
     break;
 
   case 362: /* fn_decl_stmt_start: linkage_spec proc_iter_or_op  */
-#line 2467 "chpl.ypp"
+#line 2466 "chpl.ypp"
     {
       FunctionParts fp = (yyvsp[-1].functionParts);
       context->noteDeclStartLoc((yylsp[0]));
@@ -9246,484 +9245,483 @@ yyreduce:
       fp.kind = (yyvsp[0].functionKind);
       (yyval.functionParts) = fp;
     }
-#line 9250 "bison-chpl-lib.cpp"
+#line 9249 "bison-chpl-lib.cpp"
     break;
 
   case 364: /* fn_decl_receiver_expr: TLP expr TRP  */
-#line 2482 "chpl.ypp"
+#line 2481 "chpl.ypp"
                       { (yyval.expr) = (yyvsp[-1].expr); }
-#line 9256 "bison-chpl-lib.cpp"
+#line 9255 "bison-chpl-lib.cpp"
     break;
 
   case 367: /* fn_ident: ident_def TBANG  */
-#line 2489 "chpl.ypp"
+#line 2488 "chpl.ypp"
   {
     std::string s = (yyvsp[-1].uniqueStr).c_str();
     s += "!";
     (yyval.uniqueStr) = STR(s.c_str());
   }
-#line 9266 "bison-chpl-lib.cpp"
+#line 9265 "bison-chpl-lib.cpp"
     break;
 
   case 407: /* formal_var_arg_expr: TDOTDOTDOT  */
-#line 2546 "chpl.ypp"
+#line 2545 "chpl.ypp"
                          { (yyval.expr) = nullptr; }
-#line 9272 "bison-chpl-lib.cpp"
+#line 9271 "bison-chpl-lib.cpp"
     break;
 
   case 408: /* formal_var_arg_expr: TDOTDOTDOT expr  */
-#line 2547 "chpl.ypp"
+#line 2546 "chpl.ypp"
                          { (yyval.expr) = (yyvsp[0].expr); }
-#line 9278 "bison-chpl-lib.cpp"
+#line 9277 "bison-chpl-lib.cpp"
     break;
 
   case 409: /* formal_var_arg_expr: TDOTDOTDOT query_expr  */
-#line 2548 "chpl.ypp"
+#line 2547 "chpl.ypp"
                          { (yyval.expr) = (yyvsp[0].expr); }
-#line 9284 "bison-chpl-lib.cpp"
+#line 9283 "bison-chpl-lib.cpp"
     break;
 
   case 410: /* opt_formal_ls: %empty  */
-#line 2552 "chpl.ypp"
+#line 2551 "chpl.ypp"
                      { (yyval.exprList) = context->parenlessMarker; }
-#line 9290 "bison-chpl-lib.cpp"
+#line 9289 "bison-chpl-lib.cpp"
     break;
 
   case 411: /* opt_formal_ls: TLP formal_ls TRP  */
-#line 2553 "chpl.ypp"
+#line 2552 "chpl.ypp"
                      { (yyval.exprList) = (yyvsp[-1].exprList); }
-#line 9296 "bison-chpl-lib.cpp"
+#line 9295 "bison-chpl-lib.cpp"
     break;
 
   case 412: /* req_formal_ls: TLP TRP  */
-#line 2557 "chpl.ypp"
+#line 2556 "chpl.ypp"
                             { (yyval.exprList) = context->makeList(); }
-#line 9302 "bison-chpl-lib.cpp"
+#line 9301 "bison-chpl-lib.cpp"
     break;
 
   case 413: /* req_formal_ls: TLP formal_ls_inner TRP  */
-#line 2558 "chpl.ypp"
+#line 2557 "chpl.ypp"
                             { (yyval.exprList) = (yyvsp[-1].exprList); }
-#line 9308 "bison-chpl-lib.cpp"
+#line 9307 "bison-chpl-lib.cpp"
     break;
 
   case 414: /* formal_ls_inner: formal  */
-#line 2562 "chpl.ypp"
+#line 2561 "chpl.ypp"
                                  { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 9314 "bison-chpl-lib.cpp"
+#line 9313 "bison-chpl-lib.cpp"
     break;
 
   case 415: /* formal_ls_inner: formal_ls_inner TCOMMA formal  */
-#line 2563 "chpl.ypp"
+#line 2562 "chpl.ypp"
                                  { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 9320 "bison-chpl-lib.cpp"
+#line 9319 "bison-chpl-lib.cpp"
     break;
 
   case 416: /* formal_ls: %empty  */
-#line 2567 "chpl.ypp"
+#line 2566 "chpl.ypp"
                            { (yyval.exprList) = context->makeList(); }
-#line 9326 "bison-chpl-lib.cpp"
+#line 9325 "bison-chpl-lib.cpp"
     break;
 
   case 417: /* formal_ls: formal_ls_inner  */
-#line 2568 "chpl.ypp"
+#line 2567 "chpl.ypp"
                            { (yyval.exprList) = (yyvsp[0].exprList); }
-#line 9332 "bison-chpl-lib.cpp"
+#line 9331 "bison-chpl-lib.cpp"
     break;
 
   case 421: /* named_formal: opt_formal_intent_tag formal_ident_def opt_colon_formal_type opt_init_expr  */
-#line 2582 "chpl.ypp"
+#line 2581 "chpl.ypp"
   {
     (yyval.expr) = context->buildFormal((yyloc), (yyvsp[-3].intentTag), (yyvsp[-2].uniqueStr), (yyvsp[-1].expr), (yyvsp[0].expr));
   }
-#line 9340 "bison-chpl-lib.cpp"
+#line 9339 "bison-chpl-lib.cpp"
     break;
 
   case 422: /* named_formal: pragma_ls opt_formal_intent_tag formal_ident_def opt_colon_formal_type opt_init_expr  */
-#line 2587 "chpl.ypp"
+#line 2586 "chpl.ypp"
   {
     (yyval.expr) = context->buildFormal((yyloc), (yyvsp[-3].intentTag), (yyvsp[-2].uniqueStr), (yyvsp[-1].expr), (yyvsp[0].expr), true);
   }
-#line 9348 "bison-chpl-lib.cpp"
+#line 9347 "bison-chpl-lib.cpp"
     break;
 
   case 423: /* named_formal: opt_formal_intent_tag formal_ident_def opt_colon_formal_type formal_var_arg_expr  */
-#line 2592 "chpl.ypp"
+#line 2591 "chpl.ypp"
   {
     (yyval.expr) = context->buildVarArgFormal((yyloc), (yyvsp[-3].intentTag), (yyvsp[-2].uniqueStr), (yyvsp[-1].expr), (yyvsp[0].expr));
   }
-#line 9356 "bison-chpl-lib.cpp"
+#line 9355 "bison-chpl-lib.cpp"
     break;
 
   case 424: /* named_formal: pragma_ls opt_formal_intent_tag formal_ident_def opt_colon_formal_type formal_var_arg_expr  */
-#line 2597 "chpl.ypp"
+#line 2596 "chpl.ypp"
   {
     (yyval.expr) = context->buildVarArgFormal((yyloc), (yyvsp[-3].intentTag), (yyvsp[-2].uniqueStr), (yyvsp[-1].expr), (yyvsp[0].expr), true);
   }
-#line 9364 "bison-chpl-lib.cpp"
+#line 9363 "bison-chpl-lib.cpp"
     break;
 
   case 425: /* named_formal: opt_formal_intent_tag TLP tuple_var_decl_stmt_inner_ls TRP opt_colon_formal_type opt_init_expr  */
-#line 2602 "chpl.ypp"
+#line 2601 "chpl.ypp"
   {
     (yyval.expr) = context->buildTupleFormal((yyloc), (yyvsp[-5].intentTag), (yyvsp[-3].exprList), (yyvsp[-1].expr), (yyvsp[0].expr));
   }
-#line 9372 "bison-chpl-lib.cpp"
+#line 9371 "bison-chpl-lib.cpp"
     break;
 
   case 426: /* named_formal: opt_formal_intent_tag TLP tuple_var_decl_stmt_inner_ls TRP opt_colon_formal_type formal_var_arg_expr  */
-#line 2607 "chpl.ypp"
+#line 2606 "chpl.ypp"
   {
-    (yyval.expr) = CHPL_PARSER_REPORT_SYNTAX(
-        context, (yyloc), "variable-length argument may not be grouped in a tuple.");
+    (yyval.expr) = context->syntax((yyloc), "variable-length argument may not be grouped in a tuple.");
   }
-#line 9381 "bison-chpl-lib.cpp"
+#line 9379 "bison-chpl-lib.cpp"
     break;
 
   case 427: /* opt_formal_intent_tag: %empty  */
-#line 2614 "chpl.ypp"
+#line 2612 "chpl.ypp"
              {
     context->noteIsBuildingFormal(true);
     (yyval.intentTag) = Formal::DEFAULT_INTENT;
   }
-#line 9390 "bison-chpl-lib.cpp"
+#line 9388 "bison-chpl-lib.cpp"
     break;
 
   case 428: /* opt_formal_intent_tag: required_intent_tag  */
-#line 2619 "chpl.ypp"
+#line 2617 "chpl.ypp"
   {
     context->noteIsBuildingFormal(true);
     (yyval.intentTag) = (yyvsp[0].intentTag);
   }
-#line 9399 "bison-chpl-lib.cpp"
+#line 9397 "bison-chpl-lib.cpp"
     break;
 
   case 429: /* required_intent_tag: TIN  */
-#line 2626 "chpl.ypp"
+#line 2624 "chpl.ypp"
               { (yyval.intentTag) = Formal::IN; }
-#line 9405 "bison-chpl-lib.cpp"
+#line 9403 "bison-chpl-lib.cpp"
     break;
 
   case 430: /* required_intent_tag: TINOUT  */
-#line 2627 "chpl.ypp"
+#line 2625 "chpl.ypp"
               { (yyval.intentTag) = Formal::INOUT; }
-#line 9411 "bison-chpl-lib.cpp"
+#line 9409 "bison-chpl-lib.cpp"
     break;
 
   case 431: /* required_intent_tag: TOUT  */
-#line 2628 "chpl.ypp"
+#line 2626 "chpl.ypp"
               { (yyval.intentTag) = Formal::OUT; }
-#line 9417 "bison-chpl-lib.cpp"
+#line 9415 "bison-chpl-lib.cpp"
     break;
 
   case 432: /* required_intent_tag: TCONST TIN  */
-#line 2629 "chpl.ypp"
+#line 2627 "chpl.ypp"
               { (yyval.intentTag) = Formal::CONST_IN; }
-#line 9423 "bison-chpl-lib.cpp"
+#line 9421 "bison-chpl-lib.cpp"
     break;
 
   case 433: /* required_intent_tag: TCONST TREF  */
-#line 2630 "chpl.ypp"
+#line 2628 "chpl.ypp"
               { (yyval.intentTag) = Formal::CONST_REF; }
-#line 9429 "bison-chpl-lib.cpp"
+#line 9427 "bison-chpl-lib.cpp"
     break;
 
   case 434: /* required_intent_tag: TCONST  */
-#line 2631 "chpl.ypp"
+#line 2629 "chpl.ypp"
               { (yyval.intentTag) = Formal::CONST; }
-#line 9435 "bison-chpl-lib.cpp"
+#line 9433 "bison-chpl-lib.cpp"
     break;
 
   case 435: /* required_intent_tag: TPARAM  */
-#line 2632 "chpl.ypp"
+#line 2630 "chpl.ypp"
               { (yyval.intentTag) = Formal::PARAM; }
-#line 9441 "bison-chpl-lib.cpp"
+#line 9439 "bison-chpl-lib.cpp"
     break;
 
   case 436: /* required_intent_tag: TREF  */
-#line 2633 "chpl.ypp"
+#line 2631 "chpl.ypp"
               { (yyval.intentTag) = Formal::REF; }
-#line 9447 "bison-chpl-lib.cpp"
+#line 9445 "bison-chpl-lib.cpp"
     break;
 
   case 437: /* required_intent_tag: TTYPE  */
-#line 2634 "chpl.ypp"
+#line 2632 "chpl.ypp"
               { (yyval.intentTag) = Formal::TYPE; }
-#line 9453 "bison-chpl-lib.cpp"
+#line 9451 "bison-chpl-lib.cpp"
     break;
 
   case 438: /* opt_this_intent_tag: %empty  */
-#line 2638 "chpl.ypp"
+#line 2636 "chpl.ypp"
                 { (yyval.intentTag) = Formal::DEFAULT_INTENT; }
-#line 9459 "bison-chpl-lib.cpp"
+#line 9457 "bison-chpl-lib.cpp"
     break;
 
   case 439: /* opt_this_intent_tag: TPARAM  */
-#line 2639 "chpl.ypp"
+#line 2637 "chpl.ypp"
                 { (yyval.intentTag) = Formal::PARAM; }
-#line 9465 "bison-chpl-lib.cpp"
+#line 9463 "bison-chpl-lib.cpp"
     break;
 
   case 440: /* opt_this_intent_tag: TREF  */
-#line 2640 "chpl.ypp"
+#line 2638 "chpl.ypp"
                 { (yyval.intentTag) = Formal::REF; }
-#line 9471 "bison-chpl-lib.cpp"
+#line 9469 "bison-chpl-lib.cpp"
     break;
 
   case 441: /* opt_this_intent_tag: TCONST TREF  */
-#line 2641 "chpl.ypp"
+#line 2639 "chpl.ypp"
                 { (yyval.intentTag) = Formal::CONST_REF; }
-#line 9477 "bison-chpl-lib.cpp"
+#line 9475 "bison-chpl-lib.cpp"
     break;
 
   case 442: /* opt_this_intent_tag: TCONST  */
-#line 2642 "chpl.ypp"
+#line 2640 "chpl.ypp"
                 { (yyval.intentTag) = Formal::CONST; }
-#line 9483 "bison-chpl-lib.cpp"
+#line 9481 "bison-chpl-lib.cpp"
     break;
 
   case 443: /* opt_this_intent_tag: TTYPE  */
-#line 2643 "chpl.ypp"
+#line 2641 "chpl.ypp"
                 { (yyval.intentTag) = Formal::TYPE; }
-#line 9489 "bison-chpl-lib.cpp"
+#line 9487 "bison-chpl-lib.cpp"
     break;
 
   case 444: /* proc_iter_or_op: TPROC  */
-#line 2647 "chpl.ypp"
+#line 2645 "chpl.ypp"
             { (yyval.functionKind) = Function::PROC; }
-#line 9495 "bison-chpl-lib.cpp"
+#line 9493 "bison-chpl-lib.cpp"
     break;
 
   case 445: /* proc_iter_or_op: TITER  */
-#line 2648 "chpl.ypp"
+#line 2646 "chpl.ypp"
             { (yyval.functionKind) = Function::ITER; }
-#line 9501 "bison-chpl-lib.cpp"
+#line 9499 "bison-chpl-lib.cpp"
     break;
 
   case 446: /* proc_iter_or_op: TOPERATOR  */
-#line 2649 "chpl.ypp"
+#line 2647 "chpl.ypp"
             { (yyval.functionKind) = Function::OPERATOR; }
-#line 9507 "bison-chpl-lib.cpp"
+#line 9505 "bison-chpl-lib.cpp"
     break;
 
   case 447: /* opt_ret_tag: %empty  */
-#line 2653 "chpl.ypp"
+#line 2651 "chpl.ypp"
                     { (yyval.returnTag) = Function::DEFAULT_RETURN_INTENT; }
-#line 9513 "bison-chpl-lib.cpp"
+#line 9511 "bison-chpl-lib.cpp"
     break;
 
   case 448: /* opt_ret_tag: TCONST  */
-#line 2654 "chpl.ypp"
+#line 2652 "chpl.ypp"
                     { (yyval.returnTag) = Function::CONST; }
-#line 9519 "bison-chpl-lib.cpp"
+#line 9517 "bison-chpl-lib.cpp"
     break;
 
   case 449: /* opt_ret_tag: TCONST TREF  */
-#line 2655 "chpl.ypp"
+#line 2653 "chpl.ypp"
                     { (yyval.returnTag) = Function::CONST_REF; }
-#line 9525 "bison-chpl-lib.cpp"
+#line 9523 "bison-chpl-lib.cpp"
     break;
 
   case 450: /* opt_ret_tag: TREF  */
-#line 2656 "chpl.ypp"
+#line 2654 "chpl.ypp"
                     { (yyval.returnTag) = Function::REF; }
-#line 9531 "bison-chpl-lib.cpp"
+#line 9529 "bison-chpl-lib.cpp"
     break;
 
   case 451: /* opt_ret_tag: TPARAM  */
-#line 2657 "chpl.ypp"
+#line 2655 "chpl.ypp"
                     { (yyval.returnTag) = Function::PARAM; }
-#line 9537 "bison-chpl-lib.cpp"
+#line 9535 "bison-chpl-lib.cpp"
     break;
 
   case 452: /* opt_ret_tag: TTYPE  */
-#line 2658 "chpl.ypp"
+#line 2656 "chpl.ypp"
                     { (yyval.returnTag) = Function::TYPE; }
-#line 9543 "bison-chpl-lib.cpp"
+#line 9541 "bison-chpl-lib.cpp"
     break;
 
   case 453: /* opt_throws_error: %empty  */
-#line 2662 "chpl.ypp"
+#line 2660 "chpl.ypp"
                           { (yyval.throwsTag) = ThrowsTag_DEFAULT; }
-#line 9549 "bison-chpl-lib.cpp"
+#line 9547 "bison-chpl-lib.cpp"
     break;
 
   case 454: /* opt_throws_error: TTHROWS  */
-#line 2663 "chpl.ypp"
+#line 2661 "chpl.ypp"
                           { (yyval.throwsTag) = ThrowsTag_THROWS; }
-#line 9555 "bison-chpl-lib.cpp"
+#line 9553 "bison-chpl-lib.cpp"
     break;
 
   case 455: /* opt_function_body_stmt: TSEMI  */
-#line 2666 "chpl.ypp"
+#line 2664 "chpl.ypp"
                       { context->clearComments(); (yyval.exprList) = nullptr; }
-#line 9561 "bison-chpl-lib.cpp"
+#line 9559 "bison-chpl-lib.cpp"
     break;
 
   case 456: /* opt_function_body_stmt: function_body_stmt  */
-#line 2667 "chpl.ypp"
+#line 2665 "chpl.ypp"
                       { (yyval.exprList) = (yyvsp[0].exprList); }
-#line 9567 "bison-chpl-lib.cpp"
+#line 9565 "bison-chpl-lib.cpp"
     break;
 
   case 457: /* function_body_stmt: block_stmt_body  */
-#line 2671 "chpl.ypp"
+#line 2669 "chpl.ypp"
                     { (yyval.exprList) = (yyvsp[0].exprList); }
-#line 9573 "bison-chpl-lib.cpp"
+#line 9571 "bison-chpl-lib.cpp"
     break;
 
   case 458: /* function_body_stmt: return_stmt  */
-#line 2672 "chpl.ypp"
+#line 2670 "chpl.ypp"
                     { context->clearComments(); (yyval.exprList) = context->makeList((yyvsp[0].commentsAndStmt)); }
-#line 9579 "bison-chpl-lib.cpp"
+#line 9577 "bison-chpl-lib.cpp"
     break;
 
   case 459: /* query_expr: TQUERIEDIDENT  */
-#line 2676 "chpl.ypp"
+#line 2674 "chpl.ypp"
                   { (yyval.expr) = context->buildTypeQuery((yyloc), (yyvsp[0].uniqueStr)); }
-#line 9585 "bison-chpl-lib.cpp"
+#line 9583 "bison-chpl-lib.cpp"
     break;
 
   case 460: /* opt_lifetime_where: %empty  */
-#line 2681 "chpl.ypp"
+#line 2679 "chpl.ypp"
   { (yyval.lifetimeAndWhere) = makeWhereAndLifetime(nullptr, nullptr); }
-#line 9591 "bison-chpl-lib.cpp"
+#line 9589 "bison-chpl-lib.cpp"
     break;
 
   case 461: /* opt_lifetime_where: TWHERE expr  */
-#line 2683 "chpl.ypp"
+#line 2681 "chpl.ypp"
   { (yyval.lifetimeAndWhere) = makeWhereAndLifetime((yyvsp[0].expr), nullptr); }
-#line 9597 "bison-chpl-lib.cpp"
+#line 9595 "bison-chpl-lib.cpp"
     break;
 
   case 462: /* opt_lifetime_where: TLIFETIME lifetime_components_expr  */
-#line 2685 "chpl.ypp"
+#line 2683 "chpl.ypp"
   { (yyval.lifetimeAndWhere) = makeWhereAndLifetime(nullptr, (yyvsp[0].exprList)); }
-#line 9603 "bison-chpl-lib.cpp"
+#line 9601 "bison-chpl-lib.cpp"
     break;
 
   case 463: /* opt_lifetime_where: TWHERE expr TLIFETIME lifetime_components_expr  */
-#line 2687 "chpl.ypp"
+#line 2685 "chpl.ypp"
   { (yyval.lifetimeAndWhere) = makeWhereAndLifetime((yyvsp[-2].expr), (yyvsp[0].exprList)); }
-#line 9609 "bison-chpl-lib.cpp"
+#line 9607 "bison-chpl-lib.cpp"
     break;
 
   case 464: /* opt_lifetime_where: TLIFETIME lifetime_components_expr TWHERE expr  */
-#line 2689 "chpl.ypp"
+#line 2687 "chpl.ypp"
   { (yyval.lifetimeAndWhere) = makeWhereAndLifetime((yyvsp[0].expr), (yyvsp[-2].exprList)); }
-#line 9615 "bison-chpl-lib.cpp"
+#line 9613 "bison-chpl-lib.cpp"
     break;
 
   case 465: /* lifetime_components_expr: lifetime_expr  */
-#line 2694 "chpl.ypp"
+#line 2692 "chpl.ypp"
   { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 9621 "bison-chpl-lib.cpp"
+#line 9619 "bison-chpl-lib.cpp"
     break;
 
   case 466: /* lifetime_components_expr: lifetime_components_expr TCOMMA lifetime_expr  */
-#line 2696 "chpl.ypp"
+#line 2694 "chpl.ypp"
   { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 9627 "bison-chpl-lib.cpp"
+#line 9625 "bison-chpl-lib.cpp"
     break;
 
   case 467: /* lifetime_expr: lifetime_ident TASSIGN lifetime_ident  */
-#line 2701 "chpl.ypp"
+#line 2699 "chpl.ypp"
     { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 9633 "bison-chpl-lib.cpp"
+#line 9631 "bison-chpl-lib.cpp"
     break;
 
   case 468: /* lifetime_expr: lifetime_ident TLESS lifetime_ident  */
-#line 2703 "chpl.ypp"
+#line 2701 "chpl.ypp"
     { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 9639 "bison-chpl-lib.cpp"
+#line 9637 "bison-chpl-lib.cpp"
     break;
 
   case 469: /* lifetime_expr: lifetime_ident TLESSEQUAL lifetime_ident  */
-#line 2705 "chpl.ypp"
+#line 2703 "chpl.ypp"
     { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 9645 "bison-chpl-lib.cpp"
+#line 9643 "bison-chpl-lib.cpp"
     break;
 
   case 470: /* lifetime_expr: lifetime_ident TEQUAL lifetime_ident  */
-#line 2707 "chpl.ypp"
+#line 2705 "chpl.ypp"
     { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 9651 "bison-chpl-lib.cpp"
+#line 9649 "bison-chpl-lib.cpp"
     break;
 
   case 471: /* lifetime_expr: lifetime_ident TGREATER lifetime_ident  */
-#line 2709 "chpl.ypp"
+#line 2707 "chpl.ypp"
     { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 9657 "bison-chpl-lib.cpp"
+#line 9655 "bison-chpl-lib.cpp"
     break;
 
   case 472: /* lifetime_expr: lifetime_ident TGREATEREQUAL lifetime_ident  */
-#line 2711 "chpl.ypp"
+#line 2709 "chpl.ypp"
     { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 9663 "bison-chpl-lib.cpp"
+#line 9661 "bison-chpl-lib.cpp"
     break;
 
   case 473: /* lifetime_expr: TRETURN lifetime_ident  */
-#line 2713 "chpl.ypp"
+#line 2711 "chpl.ypp"
     { (yyval.expr) = Return::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[0].expr))).release(); }
-#line 9669 "bison-chpl-lib.cpp"
+#line 9667 "bison-chpl-lib.cpp"
     break;
 
   case 474: /* lifetime_ident: TIDENT  */
-#line 2717 "chpl.ypp"
+#line 2715 "chpl.ypp"
          { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 9675 "bison-chpl-lib.cpp"
+#line 9673 "bison-chpl-lib.cpp"
     break;
 
   case 475: /* lifetime_ident: TTHIS  */
-#line 2718 "chpl.ypp"
+#line 2716 "chpl.ypp"
          { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 9681 "bison-chpl-lib.cpp"
+#line 9679 "bison-chpl-lib.cpp"
     break;
 
   case 476: /* type_alias_decl_stmt: type_alias_decl_stmt_start type_alias_decl_stmt_inner_ls TSEMI  */
-#line 2723 "chpl.ypp"
+#line 2721 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildVarOrMultiDeclStmt((yyloc), (yyvsp[-1].exprList));
     context->resetDeclState();
   }
-#line 9690 "bison-chpl-lib.cpp"
+#line 9688 "bison-chpl-lib.cpp"
     break;
 
   case 477: /* type_alias_decl_stmt_start: TTYPE  */
-#line 2732 "chpl.ypp"
+#line 2730 "chpl.ypp"
   {
     (yyval.variableKind) = context->noteVarDeclKind(Variable::TYPE);
   }
-#line 9698 "bison-chpl-lib.cpp"
+#line 9696 "bison-chpl-lib.cpp"
     break;
 
   case 478: /* type_alias_decl_stmt_start: TCONFIG TTYPE  */
-#line 2736 "chpl.ypp"
+#line 2734 "chpl.ypp"
   {
     (yyval.variableKind) = context->noteVarDeclKind(Variable::TYPE);
     context->noteIsVarDeclConfig(true);
   }
-#line 9707 "bison-chpl-lib.cpp"
+#line 9705 "bison-chpl-lib.cpp"
     break;
 
   case 479: /* type_alias_decl_stmt_inner_ls: type_alias_decl_stmt_inner  */
-#line 2744 "chpl.ypp"
+#line 2742 "chpl.ypp"
   {
     (yyval.exprList) = context->makeList((yyvsp[0].commentsAndStmt));
   }
-#line 9715 "bison-chpl-lib.cpp"
+#line 9713 "bison-chpl-lib.cpp"
     break;
 
   case 480: /* type_alias_decl_stmt_inner_ls: type_alias_decl_stmt_inner_ls TCOMMA type_alias_decl_stmt_inner  */
-#line 2748 "chpl.ypp"
+#line 2746 "chpl.ypp"
   {
     (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].commentsAndStmt));
   }
-#line 9723 "bison-chpl-lib.cpp"
+#line 9721 "bison-chpl-lib.cpp"
     break;
 
   case 481: /* type_alias_decl_stmt_inner: ident_def opt_init_type  */
-#line 2755 "chpl.ypp"
+#line 2753 "chpl.ypp"
   {
     // TODO (dlongnecke-cray): Add a helper to build this and var_decl_stmt.
     auto node = Variable::build(BUILDER, LOC((yyloc)),
@@ -9741,105 +9739,105 @@ yyreduce:
       (yyval.commentsAndStmt) = STMT((yylsp[-1]), node.release());
       context->clearComments();
   }
-#line 9745 "bison-chpl-lib.cpp"
+#line 9743 "bison-chpl-lib.cpp"
     break;
 
   case 482: /* opt_init_type: %empty  */
-#line 2775 "chpl.ypp"
+#line 2773 "chpl.ypp"
   { (yyval.expr) = nullptr; }
-#line 9751 "bison-chpl-lib.cpp"
+#line 9749 "bison-chpl-lib.cpp"
     break;
 
   case 483: /* opt_init_type: TASSIGN type_level_expr  */
-#line 2777 "chpl.ypp"
+#line 2775 "chpl.ypp"
   { (yyval.expr) = (yyvsp[0].expr); }
-#line 9757 "bison-chpl-lib.cpp"
+#line 9755 "bison-chpl-lib.cpp"
     break;
 
   case 484: /* opt_init_type: TASSIGN array_type  */
-#line 2779 "chpl.ypp"
+#line 2777 "chpl.ypp"
   {
     // Cannot be a type_level_expr as expr inherits from type_level_expr.
     (yyval.expr) = (yyvsp[0].expr);
   }
-#line 9766 "bison-chpl-lib.cpp"
+#line 9764 "bison-chpl-lib.cpp"
     break;
 
   case 485: /* var_decl_type: TPARAM  */
-#line 2786 "chpl.ypp"
+#line 2784 "chpl.ypp"
               { (yyval.variableKind) = context->noteVarDeclKind(Variable::PARAM); }
-#line 9772 "bison-chpl-lib.cpp"
+#line 9770 "bison-chpl-lib.cpp"
     break;
 
   case 486: /* var_decl_type: TCONST TREF  */
-#line 2787 "chpl.ypp"
+#line 2785 "chpl.ypp"
               { (yyval.variableKind) = context->noteVarDeclKind(Variable::CONST_REF); }
-#line 9778 "bison-chpl-lib.cpp"
+#line 9776 "bison-chpl-lib.cpp"
     break;
 
   case 487: /* var_decl_type: TREF  */
-#line 2788 "chpl.ypp"
+#line 2786 "chpl.ypp"
               { (yyval.variableKind) = context->noteVarDeclKind(Variable::REF); }
-#line 9784 "bison-chpl-lib.cpp"
+#line 9782 "bison-chpl-lib.cpp"
     break;
 
   case 488: /* var_decl_type: TCONST  */
-#line 2789 "chpl.ypp"
+#line 2787 "chpl.ypp"
               { (yyval.variableKind) = context->noteVarDeclKind(Variable::CONST); }
-#line 9790 "bison-chpl-lib.cpp"
+#line 9788 "bison-chpl-lib.cpp"
     break;
 
   case 489: /* var_decl_type: TVAR  */
-#line 2790 "chpl.ypp"
+#line 2788 "chpl.ypp"
               { (yyval.variableKind) = context->noteVarDeclKind(Variable::VAR); }
-#line 9796 "bison-chpl-lib.cpp"
+#line 9794 "bison-chpl-lib.cpp"
     break;
 
   case 490: /* $@23: %empty  */
-#line 2795 "chpl.ypp"
+#line 2793 "chpl.ypp"
   {
     // Use a mid-rule action to thread along 'isVarDeclConfig'.
     context->noteIsVarDeclConfig(true);
   }
-#line 9805 "bison-chpl-lib.cpp"
+#line 9803 "bison-chpl-lib.cpp"
     break;
 
   case 491: /* var_decl_stmt: TCONFIG $@23 var_decl_type var_decl_stmt_inner_ls TSEMI  */
-#line 2799 "chpl.ypp"
+#line 2797 "chpl.ypp"
                                              {
     (yyval.commentsAndStmt) = context->buildVarOrMultiDeclStmt((yyloc), (yyvsp[-1].exprList));
     context->resetDeclState();
   }
-#line 9814 "bison-chpl-lib.cpp"
+#line 9812 "bison-chpl-lib.cpp"
     break;
 
   case 492: /* var_decl_stmt: var_decl_type var_decl_stmt_inner_ls TSEMI  */
-#line 2804 "chpl.ypp"
+#line 2802 "chpl.ypp"
   {
     (yyval.commentsAndStmt) = context->buildVarOrMultiDeclStmt((yyloc), (yyvsp[-1].exprList));
     context->resetDeclState();
   }
-#line 9823 "bison-chpl-lib.cpp"
+#line 9821 "bison-chpl-lib.cpp"
     break;
 
   case 493: /* var_decl_stmt_inner_ls: var_decl_stmt_inner  */
-#line 2812 "chpl.ypp"
+#line 2810 "chpl.ypp"
     {
       (yyval.exprList) = context->makeList((yyvsp[0].commentsAndStmt));
     }
-#line 9831 "bison-chpl-lib.cpp"
+#line 9829 "bison-chpl-lib.cpp"
     break;
 
   case 494: /* var_decl_stmt_inner_ls: var_decl_stmt_inner_ls TCOMMA var_decl_stmt_inner  */
-#line 2816 "chpl.ypp"
+#line 2814 "chpl.ypp"
     {
       (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].commentsAndStmt));
     }
-#line 9839 "bison-chpl-lib.cpp"
+#line 9837 "bison-chpl-lib.cpp"
     break;
 
   case 495: /* var_decl_stmt_inner: ident_def opt_type opt_init_expr  */
-#line 2823 "chpl.ypp"
+#line 2821 "chpl.ypp"
     {
       auto varDecl = Variable::build(BUILDER, LOC((yyloc)),
                                      context->buildAttributes((yyloc)),
@@ -9855,11 +9853,11 @@ yyreduce:
       (yyval.commentsAndStmt) = STMT((yylsp[-2]), varDecl.release());
       context->clearComments();
     }
-#line 9859 "bison-chpl-lib.cpp"
+#line 9857 "bison-chpl-lib.cpp"
     break;
 
   case 496: /* var_decl_stmt_inner: TLP tuple_var_decl_stmt_inner_ls TRP opt_type opt_init_expr  */
-#line 2839 "chpl.ypp"
+#line 2837 "chpl.ypp"
     {
       auto intentOrKind = (TupleDecl::IntentOrKind) context->varDeclKind;
       auto tupleDecl = TupleDecl::build(BUILDER, LOC((yyloc)),
@@ -9873,583 +9871,582 @@ yyreduce:
       (yyval.commentsAndStmt) = STMT((yylsp[-4]), tupleDecl.release());
       context->clearComments();
     }
-#line 9877 "bison-chpl-lib.cpp"
+#line 9875 "bison-chpl-lib.cpp"
     break;
 
   case 497: /* tuple_var_decl_component: TUNDERSCORE  */
-#line 2856 "chpl.ypp"
+#line 2854 "chpl.ypp"
   {
     (yyval.expr) = context->buildTupleComponent((yyloc), (yyvsp[0].uniqueStr));
   }
-#line 9885 "bison-chpl-lib.cpp"
+#line 9883 "bison-chpl-lib.cpp"
     break;
 
   case 498: /* tuple_var_decl_component: ident_def  */
-#line 2860 "chpl.ypp"
+#line 2858 "chpl.ypp"
   {
     (yyval.expr) = context->buildTupleComponent((yyloc), (yyvsp[0].uniqueStr));
   }
-#line 9893 "bison-chpl-lib.cpp"
+#line 9891 "bison-chpl-lib.cpp"
     break;
 
   case 499: /* tuple_var_decl_component: TLP tuple_var_decl_stmt_inner_ls TRP  */
-#line 2864 "chpl.ypp"
+#line 2862 "chpl.ypp"
   {
     (yyval.expr) = context->buildTupleComponent((yyloc), (yyvsp[-1].exprList));
   }
-#line 9901 "bison-chpl-lib.cpp"
+#line 9899 "bison-chpl-lib.cpp"
     break;
 
   case 500: /* tuple_var_decl_stmt_inner_ls: tuple_var_decl_component  */
-#line 2871 "chpl.ypp"
+#line 2869 "chpl.ypp"
     { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 9907 "bison-chpl-lib.cpp"
+#line 9905 "bison-chpl-lib.cpp"
     break;
 
   case 501: /* tuple_var_decl_stmt_inner_ls: tuple_var_decl_stmt_inner_ls TCOMMA  */
-#line 2873 "chpl.ypp"
+#line 2871 "chpl.ypp"
     { (yyval.exprList) = (yyvsp[-1].exprList); }
-#line 9913 "bison-chpl-lib.cpp"
+#line 9911 "bison-chpl-lib.cpp"
     break;
 
   case 502: /* tuple_var_decl_stmt_inner_ls: tuple_var_decl_stmt_inner_ls TCOMMA tuple_var_decl_component  */
-#line 2875 "chpl.ypp"
+#line 2873 "chpl.ypp"
     { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 9919 "bison-chpl-lib.cpp"
+#line 9917 "bison-chpl-lib.cpp"
     break;
 
   case 503: /* opt_init_expr: %empty  */
-#line 2881 "chpl.ypp"
+#line 2879 "chpl.ypp"
                         { (yyval.expr) = nullptr; }
-#line 9925 "bison-chpl-lib.cpp"
+#line 9923 "bison-chpl-lib.cpp"
     break;
 
   case 504: /* opt_init_expr: TASSIGN TNOINIT  */
-#line 2882 "chpl.ypp"
+#line 2880 "chpl.ypp"
                         { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 9931 "bison-chpl-lib.cpp"
+#line 9929 "bison-chpl-lib.cpp"
     break;
 
   case 505: /* opt_init_expr: TASSIGN opt_try_expr  */
-#line 2883 "chpl.ypp"
+#line 2881 "chpl.ypp"
                         { (yyval.expr) = (yyvsp[0].expr); }
-#line 9937 "bison-chpl-lib.cpp"
+#line 9935 "bison-chpl-lib.cpp"
     break;
 
   case 506: /* ret_array_type: TLSBR TRSBR type_level_expr  */
-#line 2888 "chpl.ypp"
+#line 2886 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-2]), /*domainExprs*/ nullptr, (yyvsp[0].expr));
   }
-#line 9945 "bison-chpl-lib.cpp"
+#line 9943 "bison-chpl-lib.cpp"
     break;
 
   case 507: /* ret_array_type: TLSBR TRSBR  */
-#line 2892 "chpl.ypp"
+#line 2890 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-1]), nullptr, nullptr);
   }
-#line 9953 "bison-chpl-lib.cpp"
+#line 9951 "bison-chpl-lib.cpp"
     break;
 
   case 508: /* ret_array_type: TLSBR expr_ls TRSBR type_level_expr  */
-#line 2896 "chpl.ypp"
+#line 2894 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-2]), (yyvsp[-2].exprList), (yyvsp[0].expr));
   }
-#line 9961 "bison-chpl-lib.cpp"
+#line 9959 "bison-chpl-lib.cpp"
     break;
 
   case 509: /* ret_array_type: TLSBR expr_ls TRSBR  */
-#line 2900 "chpl.ypp"
+#line 2898 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-1]), (yyvsp[-1].exprList), /*typeExpr*/ nullptr);
   }
-#line 9969 "bison-chpl-lib.cpp"
+#line 9967 "bison-chpl-lib.cpp"
     break;
 
   case 510: /* ret_array_type: TLSBR TRSBR ret_array_type  */
-#line 2904 "chpl.ypp"
+#line 2902 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-2]), /*domainExprs*/ nullptr, (yyvsp[0].expr));
   }
-#line 9977 "bison-chpl-lib.cpp"
+#line 9975 "bison-chpl-lib.cpp"
     break;
 
   case 511: /* ret_array_type: TLSBR expr_ls TRSBR ret_array_type  */
-#line 2908 "chpl.ypp"
+#line 2906 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-2]), (yyvsp[-2].exprList), (yyvsp[0].expr));
   }
-#line 9985 "bison-chpl-lib.cpp"
+#line 9983 "bison-chpl-lib.cpp"
     break;
 
   case 512: /* ret_array_type: TLSBR error TRSBR  */
-#line 2912 "chpl.ypp"
+#line 2910 "chpl.ypp"
   {
-    (yyval.expr) = CHPL_PARSER_REPORT_SYNTAX(
-        context, (yyloc), "invalid expression for domain of array return type.");
+    (yyval.expr) = context->syntax((yyloc), "invalid expression for domain of array return type.");
   }
-#line 9994 "bison-chpl-lib.cpp"
+#line 9991 "bison-chpl-lib.cpp"
     break;
 
   case 513: /* ret_type: type_level_expr  */
-#line 2919 "chpl.ypp"
+#line 2916 "chpl.ypp"
                           { (yyval.expr) = (yyvsp[0].expr); }
-#line 10000 "bison-chpl-lib.cpp"
+#line 9997 "bison-chpl-lib.cpp"
     break;
 
   case 514: /* ret_type: ret_array_type  */
-#line 2920 "chpl.ypp"
+#line 2917 "chpl.ypp"
                           { (yyval.expr) = (yyvsp[0].expr); }
-#line 10006 "bison-chpl-lib.cpp"
+#line 10003 "bison-chpl-lib.cpp"
     break;
 
   case 515: /* ret_type: reserved_type_ident_use  */
-#line 2921 "chpl.ypp"
+#line 2918 "chpl.ypp"
                           { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 10012 "bison-chpl-lib.cpp"
+#line 10009 "bison-chpl-lib.cpp"
     break;
 
   case 516: /* ret_type: error  */
-#line 2922 "chpl.ypp"
+#line 2919 "chpl.ypp"
                           { (yyval.expr) = ErroneousExpression::build(BUILDER, LOC((yylsp[0]))).release(); }
-#line 10018 "bison-chpl-lib.cpp"
+#line 10015 "bison-chpl-lib.cpp"
     break;
 
   case 517: /* colon_ret_type: TCOLON ret_type  */
-#line 2926 "chpl.ypp"
+#line 2923 "chpl.ypp"
                   { (yyval.expr) = (yyvsp[0].expr); }
-#line 10024 "bison-chpl-lib.cpp"
+#line 10021 "bison-chpl-lib.cpp"
     break;
 
   case 518: /* colon_ret_type: error  */
-#line 2927 "chpl.ypp"
+#line 2924 "chpl.ypp"
                                  { (yyval.expr) = ErroneousExpression::build(BUILDER, LOC((yylsp[0]))).release(); }
-#line 10030 "bison-chpl-lib.cpp"
+#line 10027 "bison-chpl-lib.cpp"
     break;
 
   case 519: /* opt_ret_type: %empty  */
-#line 2931 "chpl.ypp"
+#line 2928 "chpl.ypp"
                     { (yyval.expr) = nullptr; }
-#line 10036 "bison-chpl-lib.cpp"
+#line 10033 "bison-chpl-lib.cpp"
     break;
 
   case 521: /* opt_type: %empty  */
-#line 2936 "chpl.ypp"
+#line 2933 "chpl.ypp"
                                  { (yyval.expr) = nullptr; }
-#line 10042 "bison-chpl-lib.cpp"
+#line 10039 "bison-chpl-lib.cpp"
     break;
 
   case 522: /* opt_type: TCOLON type_level_expr  */
-#line 2937 "chpl.ypp"
+#line 2934 "chpl.ypp"
                                  { (yyval.expr) = (yyvsp[0].expr); }
-#line 10048 "bison-chpl-lib.cpp"
+#line 10045 "bison-chpl-lib.cpp"
     break;
 
   case 523: /* opt_type: TCOLON array_type  */
-#line 2938 "chpl.ypp"
+#line 2935 "chpl.ypp"
                                  { (yyval.expr) = (yyvsp[0].expr); }
-#line 10054 "bison-chpl-lib.cpp"
+#line 10051 "bison-chpl-lib.cpp"
     break;
 
   case 524: /* opt_type: TCOLON reserved_type_ident_use  */
-#line 2939 "chpl.ypp"
+#line 2936 "chpl.ypp"
                                  { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 10060 "bison-chpl-lib.cpp"
+#line 10057 "bison-chpl-lib.cpp"
     break;
 
   case 525: /* opt_type: error  */
-#line 2940 "chpl.ypp"
+#line 2937 "chpl.ypp"
                                  { (yyval.expr) = ErroneousExpression::build(BUILDER, LOC((yylsp[0]))).release(); }
-#line 10066 "bison-chpl-lib.cpp"
+#line 10063 "bison-chpl-lib.cpp"
     break;
 
   case 526: /* array_type: TLSBR expr_ls TRSBR type_level_expr  */
-#line 2961 "chpl.ypp"
+#line 2958 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-2]), (yyvsp[-2].exprList), (yyvsp[0].expr));
   }
-#line 10074 "bison-chpl-lib.cpp"
+#line 10071 "bison-chpl-lib.cpp"
     break;
 
   case 527: /* array_type: TLSBR expr_ls TRSBR array_type  */
-#line 2965 "chpl.ypp"
+#line 2962 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-2]), (yyvsp[-2].exprList), (yyvsp[0].expr));
   }
-#line 10082 "bison-chpl-lib.cpp"
+#line 10079 "bison-chpl-lib.cpp"
     break;
 
   case 528: /* array_type: TLSBR expr_ls TIN expr TRSBR type_level_expr  */
-#line 2969 "chpl.ypp"
+#line 2966 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayTypeWithIndex((yyloc), (yylsp[-4]), (yyvsp[-4].exprList), (yyvsp[-2].expr), (yyvsp[0].expr));
   }
-#line 10090 "bison-chpl-lib.cpp"
+#line 10087 "bison-chpl-lib.cpp"
     break;
 
   case 529: /* array_type: TLSBR error TRSBR  */
-#line 2973 "chpl.ypp"
+#line 2970 "chpl.ypp"
   {
     (yyval.expr) = ErroneousExpression::build(BUILDER, LOC((yylsp[-1]))).release();
   }
-#line 10098 "bison-chpl-lib.cpp"
+#line 10095 "bison-chpl-lib.cpp"
     break;
 
   case 530: /* opt_formal_array_elt_type: %empty  */
-#line 2979 "chpl.ypp"
+#line 2976 "chpl.ypp"
                         { (yyval.expr) = nullptr; }
-#line 10104 "bison-chpl-lib.cpp"
+#line 10101 "bison-chpl-lib.cpp"
     break;
 
   case 531: /* opt_formal_array_elt_type: type_level_expr  */
-#line 2980 "chpl.ypp"
+#line 2977 "chpl.ypp"
                         { (yyval.expr) = (yyvsp[0].expr); }
-#line 10110 "bison-chpl-lib.cpp"
+#line 10107 "bison-chpl-lib.cpp"
     break;
 
   case 532: /* opt_formal_array_elt_type: query_expr  */
-#line 2981 "chpl.ypp"
+#line 2978 "chpl.ypp"
                         { (yyval.expr) = (yyvsp[0].expr); }
-#line 10116 "bison-chpl-lib.cpp"
+#line 10113 "bison-chpl-lib.cpp"
     break;
 
   case 533: /* formal_array_type: TLSBR TRSBR opt_formal_array_elt_type  */
-#line 2986 "chpl.ypp"
+#line 2983 "chpl.ypp"
   {
     auto domainLoc = context->makeSpannedLocation((yylsp[-2]), (yylsp[-1]));
     (yyval.expr) = context->buildArrayType((yyloc), domainLoc, /*domainExprs*/ nullptr, (yyvsp[0].expr));
   }
-#line 10125 "bison-chpl-lib.cpp"
+#line 10122 "bison-chpl-lib.cpp"
     break;
 
   case 534: /* formal_array_type: TLSBR expr_ls TRSBR opt_formal_array_elt_type  */
-#line 2991 "chpl.ypp"
+#line 2988 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-2]), (yyvsp[-2].exprList), (yyvsp[0].expr));
   }
-#line 10133 "bison-chpl-lib.cpp"
+#line 10130 "bison-chpl-lib.cpp"
     break;
 
   case 535: /* formal_array_type: TLSBR TRSBR formal_array_type  */
-#line 2999 "chpl.ypp"
+#line 2996 "chpl.ypp"
   {
     auto domainLoc = context->makeSpannedLocation((yylsp[-2]), (yylsp[-1]));
     (yyval.expr) = context->buildArrayType((yyloc), domainLoc, /*domainExprs*/ nullptr, (yyvsp[0].expr));
   }
-#line 10142 "bison-chpl-lib.cpp"
+#line 10139 "bison-chpl-lib.cpp"
     break;
 
   case 536: /* formal_array_type: TLSBR expr_ls TRSBR formal_array_type  */
-#line 3004 "chpl.ypp"
+#line 3001 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayType((yyloc), (yylsp[-2]), (yyvsp[-2].exprList), (yyvsp[0].expr));
   }
-#line 10150 "bison-chpl-lib.cpp"
+#line 10147 "bison-chpl-lib.cpp"
     break;
 
   case 537: /* formal_array_type: TLSBR expr_ls TIN expr TRSBR opt_formal_array_elt_type  */
-#line 3008 "chpl.ypp"
+#line 3005 "chpl.ypp"
   {
     (yyval.expr) = context->buildArrayTypeWithIndex((yyloc), (yylsp[-4]), (yyvsp[-4].exprList), (yyvsp[-2].expr), (yyvsp[0].expr));
   }
-#line 10158 "bison-chpl-lib.cpp"
+#line 10155 "bison-chpl-lib.cpp"
     break;
 
   case 540: /* formal_type: reserved_type_ident_use  */
-#line 3016 "chpl.ypp"
+#line 3013 "chpl.ypp"
                             { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 10164 "bison-chpl-lib.cpp"
+#line 10161 "bison-chpl-lib.cpp"
     break;
 
   case 542: /* colon_formal_type: TCOLON formal_type  */
-#line 3021 "chpl.ypp"
+#line 3018 "chpl.ypp"
                                  { (yyval.expr) = (yyvsp[0].expr); }
-#line 10170 "bison-chpl-lib.cpp"
+#line 10167 "bison-chpl-lib.cpp"
     break;
 
   case 543: /* opt_colon_formal_type: %empty  */
-#line 3025 "chpl.ypp"
+#line 3022 "chpl.ypp"
                         { (yyval.expr) = nullptr; }
-#line 10176 "bison-chpl-lib.cpp"
+#line 10173 "bison-chpl-lib.cpp"
     break;
 
   case 544: /* opt_colon_formal_type: colon_formal_type  */
-#line 3026 "chpl.ypp"
+#line 3023 "chpl.ypp"
                         { (yyval.expr) = (yyvsp[0].expr); }
-#line 10182 "bison-chpl-lib.cpp"
+#line 10179 "bison-chpl-lib.cpp"
     break;
 
   case 545: /* expr_ls: expr  */
-#line 3032 "chpl.ypp"
+#line 3029 "chpl.ypp"
                              { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 10188 "bison-chpl-lib.cpp"
+#line 10185 "bison-chpl-lib.cpp"
     break;
 
   case 546: /* expr_ls: query_expr  */
-#line 3033 "chpl.ypp"
+#line 3030 "chpl.ypp"
                              { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 10194 "bison-chpl-lib.cpp"
+#line 10191 "bison-chpl-lib.cpp"
     break;
 
   case 547: /* expr_ls: expr_ls TCOMMA expr  */
-#line 3034 "chpl.ypp"
+#line 3031 "chpl.ypp"
                              { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 10200 "bison-chpl-lib.cpp"
+#line 10197 "bison-chpl-lib.cpp"
     break;
 
   case 548: /* expr_ls: expr_ls TCOMMA query_expr  */
-#line 3035 "chpl.ypp"
+#line 3032 "chpl.ypp"
                              { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 10206 "bison-chpl-lib.cpp"
+#line 10203 "bison-chpl-lib.cpp"
     break;
 
   case 549: /* simple_expr_ls: expr  */
-#line 3039 "chpl.ypp"
+#line 3036 "chpl.ypp"
                                    { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 10212 "bison-chpl-lib.cpp"
+#line 10209 "bison-chpl-lib.cpp"
     break;
 
   case 550: /* simple_expr_ls: simple_expr_ls TCOMMA expr  */
-#line 3040 "chpl.ypp"
+#line 3037 "chpl.ypp"
                                    { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 10218 "bison-chpl-lib.cpp"
+#line 10215 "bison-chpl-lib.cpp"
     break;
 
   case 551: /* tuple_component: TUNDERSCORE  */
-#line 3044 "chpl.ypp"
+#line 3041 "chpl.ypp"
                 { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 10224 "bison-chpl-lib.cpp"
+#line 10221 "bison-chpl-lib.cpp"
     break;
 
   case 552: /* tuple_component: opt_try_expr  */
-#line 3045 "chpl.ypp"
+#line 3042 "chpl.ypp"
                 { (yyval.expr) = (yyvsp[0].expr); }
-#line 10230 "bison-chpl-lib.cpp"
+#line 10227 "bison-chpl-lib.cpp"
     break;
 
   case 553: /* tuple_component: query_expr  */
-#line 3046 "chpl.ypp"
+#line 3043 "chpl.ypp"
                 { (yyval.expr) = (yyvsp[0].expr); }
-#line 10236 "bison-chpl-lib.cpp"
+#line 10233 "bison-chpl-lib.cpp"
     break;
 
   case 554: /* tuple_expr_ls: tuple_component TCOMMA tuple_component  */
-#line 3051 "chpl.ypp"
+#line 3048 "chpl.ypp"
   {
     (yyval.exprList) = context->appendList(context->makeList((yyvsp[-2].expr)), (yyvsp[0].expr));
   }
-#line 10244 "bison-chpl-lib.cpp"
+#line 10241 "bison-chpl-lib.cpp"
     break;
 
   case 555: /* tuple_expr_ls: tuple_expr_ls TCOMMA tuple_component  */
-#line 3055 "chpl.ypp"
+#line 3052 "chpl.ypp"
   {
     (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr));
   }
-#line 10252 "bison-chpl-lib.cpp"
+#line 10249 "bison-chpl-lib.cpp"
     break;
 
   case 556: /* opt_actual_ls: %empty  */
-#line 3061 "chpl.ypp"
+#line 3058 "chpl.ypp"
              { (yyval.maybeNamedActualList) = new MaybeNamedActualList(); }
-#line 10258 "bison-chpl-lib.cpp"
+#line 10255 "bison-chpl-lib.cpp"
     break;
 
   case 557: /* opt_actual_ls: actual_ls  */
-#line 3062 "chpl.ypp"
+#line 3059 "chpl.ypp"
              { (yyval.maybeNamedActualList) = (yyvsp[0].maybeNamedActualList); }
-#line 10264 "bison-chpl-lib.cpp"
+#line 10261 "bison-chpl-lib.cpp"
     break;
 
   case 558: /* actual_ls: actual_expr  */
-#line 3067 "chpl.ypp"
+#line 3064 "chpl.ypp"
     { MaybeNamedActualList* lst = new MaybeNamedActualList();
       lst->push_back((yyvsp[0].maybeNamedActual));
       (yyval.maybeNamedActualList) = lst;
     }
-#line 10273 "bison-chpl-lib.cpp"
+#line 10270 "bison-chpl-lib.cpp"
     break;
 
   case 559: /* actual_ls: actual_ls TCOMMA actual_expr  */
-#line 3072 "chpl.ypp"
+#line 3069 "chpl.ypp"
     {
       MaybeNamedActualList* lst = (yyvsp[-2].maybeNamedActualList);
       lst->push_back((yyvsp[0].maybeNamedActual));
       (yyval.maybeNamedActualList) = lst;
     }
-#line 10283 "bison-chpl-lib.cpp"
+#line 10280 "bison-chpl-lib.cpp"
     break;
 
   case 560: /* actual_expr: ident_use TASSIGN query_expr  */
-#line 3080 "chpl.ypp"
+#line 3077 "chpl.ypp"
                                  { (yyval.maybeNamedActual) = makeMaybeNamedActual((yyvsp[0].expr), (yyvsp[-2].uniqueStr)); }
-#line 10289 "bison-chpl-lib.cpp"
+#line 10286 "bison-chpl-lib.cpp"
     break;
 
   case 561: /* actual_expr: ident_use TASSIGN opt_try_expr  */
-#line 3081 "chpl.ypp"
+#line 3078 "chpl.ypp"
                                  { (yyval.maybeNamedActual) = makeMaybeNamedActual((yyvsp[0].expr), (yyvsp[-2].uniqueStr)); }
-#line 10295 "bison-chpl-lib.cpp"
+#line 10292 "bison-chpl-lib.cpp"
     break;
 
   case 562: /* actual_expr: query_expr  */
-#line 3082 "chpl.ypp"
+#line 3079 "chpl.ypp"
                                  { (yyval.maybeNamedActual) = makeMaybeNamedActual((yyvsp[0].expr)); }
-#line 10301 "bison-chpl-lib.cpp"
+#line 10298 "bison-chpl-lib.cpp"
     break;
 
   case 563: /* actual_expr: opt_try_expr  */
-#line 3083 "chpl.ypp"
+#line 3080 "chpl.ypp"
                                  { (yyval.maybeNamedActual) = makeMaybeNamedActual((yyvsp[0].expr)); }
-#line 10307 "bison-chpl-lib.cpp"
+#line 10304 "bison-chpl-lib.cpp"
     break;
 
   case 564: /* ident_expr: ident_use  */
-#line 3087 "chpl.ypp"
+#line 3084 "chpl.ypp"
                  { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 10313 "bison-chpl-lib.cpp"
+#line 10310 "bison-chpl-lib.cpp"
     break;
 
   case 565: /* ident_expr: scalar_type  */
-#line 3088 "chpl.ypp"
+#line 3085 "chpl.ypp"
                  { (yyval.expr) = (yyvsp[0].expr); }
-#line 10319 "bison-chpl-lib.cpp"
+#line 10316 "bison-chpl-lib.cpp"
     break;
 
   case 566: /* type_level_expr: sub_type_level_expr  */
-#line 3100 "chpl.ypp"
+#line 3097 "chpl.ypp"
   { (yyval.expr) = (yyvsp[0].expr); }
-#line 10325 "bison-chpl-lib.cpp"
+#line 10322 "bison-chpl-lib.cpp"
     break;
 
   case 567: /* type_level_expr: sub_type_level_expr TQUESTION  */
-#line 3102 "chpl.ypp"
+#line 3099 "chpl.ypp"
   { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[0].uniqueStr), (yyvsp[-1].expr)); }
-#line 10331 "bison-chpl-lib.cpp"
+#line 10328 "bison-chpl-lib.cpp"
     break;
 
   case 568: /* type_level_expr: TQUESTION  */
-#line 3104 "chpl.ypp"
+#line 3101 "chpl.ypp"
   { (yyval.expr) = context->buildIdent((yyloc), (yyvsp[0].uniqueStr)); }
-#line 10337 "bison-chpl-lib.cpp"
+#line 10334 "bison-chpl-lib.cpp"
     break;
 
   case 569: /* type_level_expr: fn_type  */
-#line 3106 "chpl.ypp"
+#line 3103 "chpl.ypp"
   { (yyval.expr) = context->buildFunctionType((yyloc), (yyvsp[0].functionParts)); }
-#line 10343 "bison-chpl-lib.cpp"
+#line 10340 "bison-chpl-lib.cpp"
     break;
 
   case 575: /* sub_type_level_expr: TSINGLE expr  */
-#line 3118 "chpl.ypp"
+#line 3115 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 10349 "bison-chpl-lib.cpp"
+#line 10346 "bison-chpl-lib.cpp"
     break;
 
   case 576: /* sub_type_level_expr: TINDEX TLP opt_actual_ls TRP  */
-#line 3120 "chpl.ypp"
+#line 3117 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-3].uniqueStr), (yyvsp[-1].maybeNamedActualList)); }
-#line 10355 "bison-chpl-lib.cpp"
+#line 10352 "bison-chpl-lib.cpp"
     break;
 
   case 577: /* sub_type_level_expr: TDOMAIN TLP opt_actual_ls TRP  */
-#line 3122 "chpl.ypp"
+#line 3119 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-3].uniqueStr), (yyvsp[-1].maybeNamedActualList)); }
-#line 10361 "bison-chpl-lib.cpp"
+#line 10358 "bison-chpl-lib.cpp"
     break;
 
   case 578: /* sub_type_level_expr: TSUBDOMAIN TLP opt_actual_ls TRP  */
-#line 3124 "chpl.ypp"
+#line 3121 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-3].uniqueStr), (yyvsp[-1].maybeNamedActualList)); }
-#line 10367 "bison-chpl-lib.cpp"
+#line 10364 "bison-chpl-lib.cpp"
     break;
 
   case 579: /* sub_type_level_expr: TSPARSE TSUBDOMAIN TLP actual_expr TRP  */
-#line 3126 "chpl.ypp"
+#line 3123 "chpl.ypp"
   {
     auto locInner = context->makeSpannedLocation((yylsp[-3]), (yylsp[0]));
     auto inner = context->buildTypeConstructor(locInner, (yyvsp[-3].uniqueStr), (yyvsp[-1].maybeNamedActual));
     (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-4].uniqueStr), inner);
   }
-#line 10377 "bison-chpl-lib.cpp"
+#line 10374 "bison-chpl-lib.cpp"
     break;
 
   case 580: /* sub_type_level_expr: TATOMIC expr  */
-#line 3132 "chpl.ypp"
+#line 3129 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 10383 "bison-chpl-lib.cpp"
+#line 10380 "bison-chpl-lib.cpp"
     break;
 
   case 581: /* sub_type_level_expr: TSYNC expr  */
-#line 3134 "chpl.ypp"
+#line 3131 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 10389 "bison-chpl-lib.cpp"
+#line 10386 "bison-chpl-lib.cpp"
     break;
 
   case 582: /* sub_type_level_expr: TOWNED  */
-#line 3137 "chpl.ypp"
+#line 3134 "chpl.ypp"
   { (yyval.expr) = Identifier::build(BUILDER, LOC((yylsp[0])), (yyvsp[0].uniqueStr)).release(); }
-#line 10395 "bison-chpl-lib.cpp"
+#line 10392 "bison-chpl-lib.cpp"
     break;
 
   case 583: /* sub_type_level_expr: TOWNED expr  */
-#line 3139 "chpl.ypp"
+#line 3136 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 10401 "bison-chpl-lib.cpp"
+#line 10398 "bison-chpl-lib.cpp"
     break;
 
   case 584: /* sub_type_level_expr: TUNMANAGED  */
-#line 3141 "chpl.ypp"
+#line 3138 "chpl.ypp"
   { (yyval.expr) = Identifier::build(BUILDER, LOC((yylsp[0])), (yyvsp[0].uniqueStr)).release(); }
-#line 10407 "bison-chpl-lib.cpp"
+#line 10404 "bison-chpl-lib.cpp"
     break;
 
   case 585: /* sub_type_level_expr: TUNMANAGED expr  */
-#line 3143 "chpl.ypp"
+#line 3140 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 10413 "bison-chpl-lib.cpp"
+#line 10410 "bison-chpl-lib.cpp"
     break;
 
   case 586: /* sub_type_level_expr: TSHARED  */
-#line 3145 "chpl.ypp"
+#line 3142 "chpl.ypp"
   { (yyval.expr) = Identifier::build(BUILDER, LOC((yylsp[0])), (yyvsp[0].uniqueStr)).release(); }
-#line 10419 "bison-chpl-lib.cpp"
+#line 10416 "bison-chpl-lib.cpp"
     break;
 
   case 587: /* sub_type_level_expr: TSHARED expr  */
-#line 3147 "chpl.ypp"
+#line 3144 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 10425 "bison-chpl-lib.cpp"
+#line 10422 "bison-chpl-lib.cpp"
     break;
 
   case 588: /* sub_type_level_expr: TBORROWED  */
-#line 3149 "chpl.ypp"
+#line 3146 "chpl.ypp"
   { (yyval.expr) = Identifier::build(BUILDER, LOC((yylsp[0])), (yyvsp[0].uniqueStr)).release(); }
-#line 10431 "bison-chpl-lib.cpp"
+#line 10428 "bison-chpl-lib.cpp"
     break;
 
   case 589: /* sub_type_level_expr: TBORROWED expr  */
-#line 3151 "chpl.ypp"
+#line 3148 "chpl.ypp"
   { (yyval.expr) = context->buildTypeConstructor((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 10437 "bison-chpl-lib.cpp"
+#line 10434 "bison-chpl-lib.cpp"
     break;
 
   case 590: /* sub_type_level_expr: TCLASS  */
-#line 3153 "chpl.ypp"
+#line 3150 "chpl.ypp"
   { (yyval.expr) = Identifier::build(BUILDER, LOC((yylsp[0])), (yyvsp[0].uniqueStr)).release(); }
-#line 10443 "bison-chpl-lib.cpp"
+#line 10440 "bison-chpl-lib.cpp"
     break;
 
   case 591: /* sub_type_level_expr: TRECORD  */
-#line 3155 "chpl.ypp"
+#line 3152 "chpl.ypp"
   { (yyval.expr) = Identifier::build(BUILDER, LOC((yylsp[0])), (yyvsp[0].uniqueStr)).release(); }
-#line 10449 "bison-chpl-lib.cpp"
+#line 10446 "bison-chpl-lib.cpp"
     break;
 
   case 592: /* for_expr: TFOR expr TIN expr TDO expr  */
-#line 3160 "chpl.ypp"
+#line 3157 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-4]), toOwned((yyvsp[-4].expr)));
     (yyval.expr) = For::build(BUILDER, LOC((yyloc)), std::move(index), toOwned((yyvsp[-2].expr)),
@@ -10458,11 +10455,11 @@ yyreduce:
                     /*isExpressionLevel*/ true,
                     /*isParam*/ false).release();
   }
-#line 10462 "bison-chpl-lib.cpp"
+#line 10459 "bison-chpl-lib.cpp"
     break;
 
   case 593: /* for_expr: TFOR expr TIN zippered_iterator TDO expr  */
-#line 3169 "chpl.ypp"
+#line 3166 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-4]), toOwned((yyvsp[-4].expr)));
     (yyval.expr) = For::build(BUILDER, LOC((yyloc)), std::move(index), toOwned((yyvsp[-2].expr)),
@@ -10471,11 +10468,11 @@ yyreduce:
                     /*isExpressionLevel*/ true,
                     /*isParam*/ false).release();
   }
-#line 10475 "bison-chpl-lib.cpp"
+#line 10472 "bison-chpl-lib.cpp"
     break;
 
   case 594: /* for_expr: TFOR expr TDO expr  */
-#line 3178 "chpl.ypp"
+#line 3175 "chpl.ypp"
   {
     (yyval.expr) = For::build(BUILDER, LOC((yyloc)), /*index*/ nullptr, toOwned((yyvsp[-2].expr)),
                     BlockStyle::IMPLICIT,
@@ -10483,11 +10480,11 @@ yyreduce:
                     /*isExpressionLevel*/ true,
                     /*isParam*/ false).release();
   }
-#line 10487 "bison-chpl-lib.cpp"
+#line 10484 "bison-chpl-lib.cpp"
     break;
 
   case 595: /* for_expr: TFOR expr TIN expr TDO TIF expr TTHEN expr  */
-#line 3186 "chpl.ypp"
+#line 3183 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-7]), (yyvsp[-7].expr));
     auto ifExpr = Conditional::build(BUILDER, LOC2((yylsp[-3]), (yylsp[0])), toOwned((yyvsp[-2].expr)),
@@ -10501,11 +10498,11 @@ yyreduce:
                     /*isExpressionLevel*/ true,
                     /*isParam*/ false).release();
   }
-#line 10505 "bison-chpl-lib.cpp"
+#line 10502 "bison-chpl-lib.cpp"
     break;
 
   case 596: /* for_expr: TFOR expr TIN zippered_iterator TDO TIF expr TTHEN expr  */
-#line 3200 "chpl.ypp"
+#line 3197 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-7]), (yyvsp[-7].expr));
     auto ifExpr = Conditional::build(BUILDER, LOC2((yylsp[-3]), (yylsp[0])), toOwned((yyvsp[-2].expr)),
@@ -10519,11 +10516,11 @@ yyreduce:
                     /*isExpressionLevel*/ true,
                     /*isParam*/ false).release();
   }
-#line 10523 "bison-chpl-lib.cpp"
+#line 10520 "bison-chpl-lib.cpp"
     break;
 
   case 597: /* for_expr: TFOR expr TDO TIF expr TTHEN expr  */
-#line 3214 "chpl.ypp"
+#line 3211 "chpl.ypp"
   {
     auto ifExpr = Conditional::build(BUILDER, LOC2((yylsp[-3]), (yylsp[0])), toOwned((yyvsp[-2].expr)),
                                      BlockStyle::IMPLICIT,
@@ -10537,11 +10534,11 @@ yyreduce:
                     /*isExpressionLevel*/ true,
                     /*isParam*/ false).release();
   }
-#line 10541 "bison-chpl-lib.cpp"
+#line 10538 "bison-chpl-lib.cpp"
     break;
 
   case 598: /* for_expr: TFORALL expr TIN expr TDO expr  */
-#line 3228 "chpl.ypp"
+#line 3225 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-4]), toOwned((yyvsp[-4].expr)));
     (yyval.expr) = Forall::build(BUILDER, LOC((yyloc)), std::move(index), toOwned((yyvsp[-2].expr)),
@@ -10550,11 +10547,11 @@ yyreduce:
                        context->consumeToBlock((yylsp[0]), (yyvsp[0].expr)),
                        /*isExpressionLevel*/ true).release();
   }
-#line 10554 "bison-chpl-lib.cpp"
+#line 10551 "bison-chpl-lib.cpp"
     break;
 
   case 599: /* for_expr: TFORALL expr TIN zippered_iterator TDO expr  */
-#line 3237 "chpl.ypp"
+#line 3234 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-4]), toOwned((yyvsp[-4].expr)));
     (yyval.expr) = Forall::build(BUILDER, LOC((yyloc)), std::move(index), toOwned((yyvsp[-2].expr)),
@@ -10563,11 +10560,11 @@ yyreduce:
                        context->consumeToBlock((yylsp[0]), (yyvsp[0].expr)),
                        /*isExpressionLevel*/ true).release();
   }
-#line 10567 "bison-chpl-lib.cpp"
+#line 10564 "bison-chpl-lib.cpp"
     break;
 
   case 600: /* for_expr: TFORALL expr TDO expr  */
-#line 3246 "chpl.ypp"
+#line 3243 "chpl.ypp"
   {
     (yyval.expr) = Forall::build(BUILDER, LOC((yyloc)), /*index*/ nullptr, toOwned((yyvsp[-2].expr)),
                        /*withClause*/ nullptr,
@@ -10575,11 +10572,11 @@ yyreduce:
                        context->consumeToBlock((yylsp[0]), (yyvsp[0].expr)),
                        /*isExpressionLevel*/ true).release();
   }
-#line 10579 "bison-chpl-lib.cpp"
+#line 10576 "bison-chpl-lib.cpp"
     break;
 
   case 601: /* for_expr: TFORALL expr TIN expr TDO TIF expr TTHEN expr  */
-#line 3254 "chpl.ypp"
+#line 3251 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-7]), (yyvsp[-7].expr));
     auto ifExpr = Conditional::build(BUILDER, LOC2((yylsp[-3]), (yylsp[0])), toOwned((yyvsp[-2].expr)),
@@ -10593,11 +10590,11 @@ yyreduce:
                        context->consumeToBlock(ifLoc, ifExpr.release()),
                        /*isExpressionLevel*/ true).release();
   }
-#line 10597 "bison-chpl-lib.cpp"
+#line 10594 "bison-chpl-lib.cpp"
     break;
 
   case 602: /* for_expr: TFORALL expr TIN zippered_iterator TDO TIF expr TTHEN expr  */
-#line 3268 "chpl.ypp"
+#line 3265 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-7]), (yyvsp[-7].expr));
     auto ifExpr = Conditional::build(BUILDER, LOC2((yylsp[-3]), (yylsp[0])), toOwned((yyvsp[-2].expr)),
@@ -10611,11 +10608,11 @@ yyreduce:
                       context->consumeToBlock(ifLoc, ifExpr.release()),
                       /*isExpressionLevel*/ true).release();
   }
-#line 10615 "bison-chpl-lib.cpp"
+#line 10612 "bison-chpl-lib.cpp"
     break;
 
   case 603: /* for_expr: TFORALL expr TDO TIF expr TTHEN expr  */
-#line 3282 "chpl.ypp"
+#line 3279 "chpl.ypp"
   {
     auto ifExpr = Conditional::build(BUILDER, LOC2((yylsp[-3]), (yylsp[0])), toOwned((yyvsp[-2].expr)),
                                      BlockStyle::IMPLICIT,
@@ -10629,11 +10626,11 @@ yyreduce:
                        context->consumeToBlock(ifLoc, ifExpr.release()),
                        /*isExpressionLevel*/ true).release();
   }
-#line 10633 "bison-chpl-lib.cpp"
+#line 10630 "bison-chpl-lib.cpp"
     break;
 
   case 604: /* for_expr: TLSBR expr_ls TRSBR expr  */
-#line 3296 "chpl.ypp"
+#line 3293 "chpl.ypp"
   {
     owned<AstNode> iterand = nullptr;
     auto iterExprs = context->consumeList((yyvsp[-2].exprList));
@@ -10650,11 +10647,11 @@ yyreduce:
                             context->consumeToBlock((yylsp[0]), (yyvsp[0].expr)),
                             /*isExpressionLevel*/ true).release();
   }
-#line 10654 "bison-chpl-lib.cpp"
+#line 10651 "bison-chpl-lib.cpp"
     break;
 
   case 605: /* for_expr: TLSBR expr_ls TIN expr TRSBR expr  */
-#line 3313 "chpl.ypp"
+#line 3310 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-4]), (yyvsp[-4].exprList));
     (yyval.expr) = BracketLoop::build(BUILDER, LOC((yyloc)), std::move(index), toOwned((yyvsp[-2].expr)),
@@ -10663,11 +10660,11 @@ yyreduce:
                             context->consumeToBlock((yylsp[0]), (yyvsp[0].expr)),
                             /*isExpressionLevel*/ true).release();
   }
-#line 10667 "bison-chpl-lib.cpp"
+#line 10664 "bison-chpl-lib.cpp"
     break;
 
   case 606: /* for_expr: TLSBR expr_ls TIN zippered_iterator TRSBR expr  */
-#line 3322 "chpl.ypp"
+#line 3319 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-4]), (yyvsp[-4].exprList));
     (yyval.expr) = BracketLoop::build(BUILDER, LOC((yyloc)), std::move(index), toOwned((yyvsp[-2].expr)),
@@ -10676,11 +10673,11 @@ yyreduce:
                             context->consumeToBlock((yylsp[0]), (yyvsp[0].expr)),
                             /*isExpressionLevel*/ true).release();
   }
-#line 10680 "bison-chpl-lib.cpp"
+#line 10677 "bison-chpl-lib.cpp"
     break;
 
   case 607: /* for_expr: TLSBR expr_ls TIN expr TRSBR TIF expr TTHEN expr  */
-#line 3331 "chpl.ypp"
+#line 3328 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-7]), (yyvsp[-7].exprList));
     auto ifExpr = Conditional::build(BUILDER, LOC2((yylsp[-3]), (yylsp[0])), toOwned((yyvsp[-2].expr)),
@@ -10695,11 +10692,11 @@ yyreduce:
                             context->consumeToBlock(ifLoc, ifExpr.release()),
                             /*isExpressionLevel*/ true).release();
   }
-#line 10699 "bison-chpl-lib.cpp"
+#line 10696 "bison-chpl-lib.cpp"
     break;
 
   case 608: /* for_expr: TLSBR expr_ls TIN zippered_iterator TRSBR TIF expr TTHEN expr  */
-#line 3346 "chpl.ypp"
+#line 3343 "chpl.ypp"
   {
     auto index = context->buildLoopIndexDecl((yylsp[-7]), (yyvsp[-7].exprList));
     auto ifExpr = Conditional::build(BUILDER, LOC2((yylsp[-3]), (yylsp[0])), toOwned((yyvsp[-2].expr)),
@@ -10714,11 +10711,11 @@ yyreduce:
                             context->consumeToBlock(ifLoc, ifExpr.release()),
                             /*isExpressionLevel*/ true).release();
   }
-#line 10718 "bison-chpl-lib.cpp"
+#line 10715 "bison-chpl-lib.cpp"
     break;
 
   case 609: /* cond_expr: TIF expr TTHEN expr TELSE expr  */
-#line 3364 "chpl.ypp"
+#line 3361 "chpl.ypp"
   {
     auto node  = Conditional::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-4].expr)),
                                     BlockStyle::IMPLICIT,
@@ -10728,73 +10725,73 @@ yyreduce:
                                     /*isExpressionLevel*/ true);
     (yyval.expr) = node.release();
   }
-#line 10732 "bison-chpl-lib.cpp"
+#line 10729 "bison-chpl-lib.cpp"
     break;
 
   case 610: /* nil_expr: TNIL  */
-#line 3381 "chpl.ypp"
+#line 3378 "chpl.ypp"
             { (yyval.expr) = context->buildIdent((yylsp[0]), (yyvsp[0].uniqueStr)); }
-#line 10738 "bison-chpl-lib.cpp"
+#line 10735 "bison-chpl-lib.cpp"
     break;
 
   case 618: /* opt_task_intent_ls: %empty  */
-#line 3399 "chpl.ypp"
+#line 3396 "chpl.ypp"
                                 { (yyval.withClause) = nullptr; }
-#line 10744 "bison-chpl-lib.cpp"
+#line 10741 "bison-chpl-lib.cpp"
     break;
 
   case 619: /* opt_task_intent_ls: task_intent_clause  */
-#line 3400 "chpl.ypp"
+#line 3397 "chpl.ypp"
                                 { (yyval.withClause) = (yyvsp[0].withClause); }
-#line 10750 "bison-chpl-lib.cpp"
+#line 10747 "bison-chpl-lib.cpp"
     break;
 
   case 620: /* task_intent_clause: TWITH TLP task_intent_ls TRP  */
-#line 3405 "chpl.ypp"
+#line 3402 "chpl.ypp"
   {
     auto exprs = context->consumeList((yyvsp[-1].exprList));
     auto node = WithClause::build(BUILDER, LOC((yyloc)), std::move(exprs));
     (yyval.withClause) = node.release();
   }
-#line 10760 "bison-chpl-lib.cpp"
+#line 10757 "bison-chpl-lib.cpp"
     break;
 
   case 621: /* task_intent_ls: intent_expr  */
-#line 3413 "chpl.ypp"
+#line 3410 "chpl.ypp"
                                       { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 10766 "bison-chpl-lib.cpp"
+#line 10763 "bison-chpl-lib.cpp"
     break;
 
   case 622: /* task_intent_ls: task_intent_ls TCOMMA intent_expr  */
-#line 3414 "chpl.ypp"
+#line 3411 "chpl.ypp"
                                       { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 10772 "bison-chpl-lib.cpp"
+#line 10769 "bison-chpl-lib.cpp"
     break;
 
   case 623: /* forall_intent_clause: TWITH TLP forall_intent_ls TRP  */
-#line 3419 "chpl.ypp"
+#line 3416 "chpl.ypp"
   {
     auto exprs = context->consumeList((yyvsp[-1].exprList));
     auto node = WithClause::build(BUILDER, LOC((yyloc)), std::move(exprs));
     (yyval.withClause) = node.release();
   }
-#line 10782 "bison-chpl-lib.cpp"
+#line 10779 "bison-chpl-lib.cpp"
     break;
 
   case 624: /* forall_intent_ls: intent_expr  */
-#line 3427 "chpl.ypp"
+#line 3424 "chpl.ypp"
                                        { (yyval.exprList) = context->makeList((yyvsp[0].expr)); }
-#line 10788 "bison-chpl-lib.cpp"
+#line 10785 "bison-chpl-lib.cpp"
     break;
 
   case 625: /* forall_intent_ls: forall_intent_ls TCOMMA intent_expr  */
-#line 3428 "chpl.ypp"
+#line 3425 "chpl.ypp"
                                        { (yyval.exprList) = context->appendList((yyvsp[-2].exprList), (yyvsp[0].expr)); }
-#line 10794 "bison-chpl-lib.cpp"
+#line 10791 "bison-chpl-lib.cpp"
     break;
 
   case 626: /* intent_expr: task_var_prefix ident_expr opt_type opt_init_expr  */
-#line 3433 "chpl.ypp"
+#line 3430 "chpl.ypp"
   {
     if (auto ident = (yyvsp[-2].expr)->toIdentifier()) {
       auto name = ident->name();
@@ -10805,105 +10802,104 @@ yyreduce:
                                  toOwned((yyvsp[0].expr)));
       (yyval.expr) = node.release();
     } else {
-      (yyval.expr) = CHPL_PARSER_REPORT_SYNTAX(
-          context, (yyloc), "expected identifier for task variable name.");
+      (yyval.expr) = context->syntax((yyloc), "expected identifier for task variable name.");
     }
   }
-#line 10813 "bison-chpl-lib.cpp"
+#line 10809 "bison-chpl-lib.cpp"
     break;
 
   case 627: /* intent_expr: reduce_scan_op_expr TREDUCE ident_expr  */
-#line 3448 "chpl.ypp"
+#line 3444 "chpl.ypp"
   {
     (yyval.expr) = context->buildReduceIntent((yyloc), (yylsp[-2]), (yyvsp[-2].uniqueStr), (yyvsp[0].expr));
   }
-#line 10821 "bison-chpl-lib.cpp"
+#line 10817 "bison-chpl-lib.cpp"
     break;
 
   case 628: /* intent_expr: expr TREDUCE ident_expr  */
-#line 3452 "chpl.ypp"
+#line 3448 "chpl.ypp"
   {
     (yyval.expr) = context->buildReduceIntent((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
   }
-#line 10829 "bison-chpl-lib.cpp"
+#line 10825 "bison-chpl-lib.cpp"
     break;
 
   case 629: /* task_var_prefix: TCONST  */
-#line 3458 "chpl.ypp"
+#line 3454 "chpl.ypp"
                { (yyval.taskIntent) = TaskVar::CONST;     }
-#line 10835 "bison-chpl-lib.cpp"
+#line 10831 "bison-chpl-lib.cpp"
     break;
 
   case 630: /* task_var_prefix: TIN  */
-#line 3459 "chpl.ypp"
+#line 3455 "chpl.ypp"
                { (yyval.taskIntent) = TaskVar::IN;        }
-#line 10841 "bison-chpl-lib.cpp"
+#line 10837 "bison-chpl-lib.cpp"
     break;
 
   case 631: /* task_var_prefix: TCONST TIN  */
-#line 3460 "chpl.ypp"
+#line 3456 "chpl.ypp"
                { (yyval.taskIntent) = TaskVar::CONST_IN;  }
-#line 10847 "bison-chpl-lib.cpp"
+#line 10843 "bison-chpl-lib.cpp"
     break;
 
   case 632: /* task_var_prefix: TREF  */
-#line 3461 "chpl.ypp"
+#line 3457 "chpl.ypp"
                { (yyval.taskIntent) = TaskVar::REF;       }
-#line 10853 "bison-chpl-lib.cpp"
+#line 10849 "bison-chpl-lib.cpp"
     break;
 
   case 633: /* task_var_prefix: TCONST TREF  */
-#line 3462 "chpl.ypp"
+#line 3458 "chpl.ypp"
                { (yyval.taskIntent) = TaskVar::CONST_REF; }
-#line 10859 "bison-chpl-lib.cpp"
+#line 10855 "bison-chpl-lib.cpp"
     break;
 
   case 634: /* task_var_prefix: TVAR  */
-#line 3463 "chpl.ypp"
+#line 3459 "chpl.ypp"
                { (yyval.taskIntent) = TaskVar::VAR;       }
-#line 10865 "bison-chpl-lib.cpp"
+#line 10861 "bison-chpl-lib.cpp"
     break;
 
   case 635: /* new_maybe_decorated: TNEW  */
-#line 3468 "chpl.ypp"
+#line 3464 "chpl.ypp"
     { (yyval.newManagement) = New::DEFAULT_MANAGEMENT; }
-#line 10871 "bison-chpl-lib.cpp"
+#line 10867 "bison-chpl-lib.cpp"
     break;
 
   case 636: /* new_maybe_decorated: TNEW TOWNED  */
-#line 3470 "chpl.ypp"
+#line 3466 "chpl.ypp"
     { (yyval.newManagement) = New::OWNED; }
-#line 10877 "bison-chpl-lib.cpp"
+#line 10873 "bison-chpl-lib.cpp"
     break;
 
   case 637: /* new_maybe_decorated: TNEW TSHARED  */
-#line 3472 "chpl.ypp"
+#line 3468 "chpl.ypp"
     { (yyval.newManagement) = New::SHARED; }
-#line 10883 "bison-chpl-lib.cpp"
+#line 10879 "bison-chpl-lib.cpp"
     break;
 
   case 638: /* new_maybe_decorated: TNEW TUNMANAGED  */
-#line 3474 "chpl.ypp"
+#line 3470 "chpl.ypp"
     { (yyval.newManagement) = New::UNMANAGED; }
-#line 10889 "bison-chpl-lib.cpp"
+#line 10885 "bison-chpl-lib.cpp"
     break;
 
   case 639: /* new_maybe_decorated: TNEW TBORROWED  */
-#line 3476 "chpl.ypp"
+#line 3472 "chpl.ypp"
     { (yyval.newManagement) = New::BORROWED; }
-#line 10895 "bison-chpl-lib.cpp"
+#line 10891 "bison-chpl-lib.cpp"
     break;
 
   case 640: /* new_expr: new_maybe_decorated expr  */
-#line 3482 "chpl.ypp"
+#line 3478 "chpl.ypp"
   {
     (yyval.expr) = context->buildNewExpr((yyloc), (yyvsp[-1].newManagement), (yyvsp[0].expr));
   }
-#line 10903 "bison-chpl-lib.cpp"
+#line 10899 "bison-chpl-lib.cpp"
     break;
 
   case 641: /* new_expr: TNEW TOWNED TLP expr TRP TLP opt_actual_ls TRP  */
-#line 3489 "chpl.ypp"
+#line 3485 "chpl.ypp"
   {
     AstList actuals;
     std::vector<UniqueString> actualNames;
@@ -10915,11 +10911,11 @@ yyreduce:
                               /* square */ false);
     (yyval.expr) = context->buildNewExpr((yyloc), New::OWNED, call.release());
   }
-#line 10919 "bison-chpl-lib.cpp"
+#line 10915 "bison-chpl-lib.cpp"
     break;
 
   case 642: /* new_expr: TNEW TSHARED TLP expr TRP TLP opt_actual_ls TRP  */
-#line 3501 "chpl.ypp"
+#line 3497 "chpl.ypp"
   {
     AstList actuals;
     std::vector<UniqueString> actualNames;
@@ -10931,11 +10927,11 @@ yyreduce:
                               /* square */ false);
     (yyval.expr) = context->buildNewExpr((yyloc), New::SHARED, call.release());
   }
-#line 10935 "bison-chpl-lib.cpp"
+#line 10931 "bison-chpl-lib.cpp"
     break;
 
   case 643: /* new_expr: TNEW TOWNED TLP expr TRP TLP opt_actual_ls TRP TQUESTION  */
-#line 3513 "chpl.ypp"
+#line 3509 "chpl.ypp"
   {
     AstList actuals;
     std::vector<UniqueString> actualNames;
@@ -10948,11 +10944,11 @@ yyreduce:
                               /* square */ false);
     (yyval.expr) = context->buildNewExpr((yyloc), New::OWNED, call.release());
   }
-#line 10952 "bison-chpl-lib.cpp"
+#line 10948 "bison-chpl-lib.cpp"
     break;
 
   case 644: /* new_expr: TNEW TSHARED TLP expr TRP TLP opt_actual_ls TRP TQUESTION  */
-#line 3526 "chpl.ypp"
+#line 3522 "chpl.ypp"
   {
     AstList actuals;
     std::vector<UniqueString> actualNames;
@@ -10966,142 +10962,142 @@ yyreduce:
     (yyval.expr) = context->buildNewExpr((yyloc), New::SHARED, call.release());
 
   }
-#line 10970 "bison-chpl-lib.cpp"
+#line 10966 "bison-chpl-lib.cpp"
     break;
 
   case 645: /* let_expr: TLET var_decl_stmt_inner_ls TIN expr  */
-#line 3543 "chpl.ypp"
+#line 3539 "chpl.ypp"
   {
     (yyval.expr) = context->buildLetExpr((yyloc), (yyvsp[-2].exprList), (yyvsp[0].expr));
   }
-#line 10978 "bison-chpl-lib.cpp"
+#line 10974 "bison-chpl-lib.cpp"
     break;
 
   case 646: /* range_literal_expr: expr TDOTDOT expr  */
-#line 3550 "chpl.ypp"
+#line 3546 "chpl.ypp"
   {
     (yyval.expr) = Range::build(BUILDER, LOC((yyloc)), Range::DEFAULT, toOwned((yyvsp[-2].expr)),
                       toOwned((yyvsp[0].expr))).release();
   }
-#line 10987 "bison-chpl-lib.cpp"
+#line 10983 "bison-chpl-lib.cpp"
     break;
 
   case 647: /* range_literal_expr: expr TDOTDOTOPENHIGH expr  */
-#line 3555 "chpl.ypp"
+#line 3551 "chpl.ypp"
   {
     (yyval.expr) = Range::build(BUILDER, LOC((yyloc)), Range::OPEN_HIGH, toOwned((yyvsp[-2].expr)),
                       toOwned((yyvsp[0].expr))).release();
   }
-#line 10996 "bison-chpl-lib.cpp"
+#line 10992 "bison-chpl-lib.cpp"
     break;
 
   case 648: /* range_literal_expr: expr TDOTDOT  */
-#line 3560 "chpl.ypp"
+#line 3556 "chpl.ypp"
   {
     (yyval.expr) = Range::build(BUILDER, LOC((yyloc)), Range::DEFAULT, toOwned((yyvsp[-1].expr)),
                       /*upperBound*/ nullptr).release();
   }
-#line 11005 "bison-chpl-lib.cpp"
+#line 11001 "bison-chpl-lib.cpp"
     break;
 
   case 649: /* range_literal_expr: TDOTDOT expr  */
-#line 3565 "chpl.ypp"
+#line 3561 "chpl.ypp"
   {
     (yyval.expr) = Range::build(BUILDER, LOC((yyloc)), Range::DEFAULT,
                       /*lowerBound*/ nullptr,
                       toOwned((yyvsp[0].expr))).release();
   }
-#line 11015 "bison-chpl-lib.cpp"
+#line 11011 "bison-chpl-lib.cpp"
     break;
 
   case 650: /* range_literal_expr: TDOTDOTOPENHIGH expr  */
-#line 3571 "chpl.ypp"
+#line 3567 "chpl.ypp"
   {
     (yyval.expr) = Range::build(BUILDER, LOC((yyloc)), Range::OPEN_HIGH,
                       /*lowerBound*/ nullptr,
                       toOwned((yyvsp[0].expr))).release();
   }
-#line 11025 "bison-chpl-lib.cpp"
+#line 11021 "bison-chpl-lib.cpp"
     break;
 
   case 651: /* range_literal_expr: TDOTDOT  */
-#line 3577 "chpl.ypp"
+#line 3573 "chpl.ypp"
   {
     (yyval.expr) = Range::build(BUILDER, LOC((yyloc)), Range::DEFAULT,
                       /*lowerBound*/ nullptr,
                       /*upperBound*/ nullptr).release();
   }
-#line 11035 "bison-chpl-lib.cpp"
+#line 11031 "bison-chpl-lib.cpp"
     break;
 
   case 652: /* cast_expr: expr TCOLON expr  */
-#line 3607 "chpl.ypp"
+#line 3603 "chpl.ypp"
   {
     (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr));
   }
-#line 11043 "bison-chpl-lib.cpp"
+#line 11039 "bison-chpl-lib.cpp"
     break;
 
   case 653: /* tuple_expand_expr: TLP TDOTDOTDOT expr TRP  */
-#line 3614 "chpl.ypp"
+#line 3610 "chpl.ypp"
   {
     (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-2].uniqueStr), (yyvsp[-1].expr));
   }
-#line 11051 "bison-chpl-lib.cpp"
+#line 11047 "bison-chpl-lib.cpp"
     break;
 
   case 654: /* super_expr: fn_expr  */
-#line 3620 "chpl.ypp"
+#line 3616 "chpl.ypp"
           { (yyval.expr) = context->buildFunctionExpr((yyloc), (yyvsp[0].functionParts)); }
-#line 11057 "bison-chpl-lib.cpp"
+#line 11053 "bison-chpl-lib.cpp"
     break;
 
   case 668: /* opt_expr: %empty  */
-#line 3640 "chpl.ypp"
+#line 3636 "chpl.ypp"
                   { (yyval.expr) = nullptr; }
-#line 11063 "bison-chpl-lib.cpp"
+#line 11059 "bison-chpl-lib.cpp"
     break;
 
   case 669: /* opt_expr: expr  */
-#line 3641 "chpl.ypp"
+#line 3637 "chpl.ypp"
                   { (yyval.expr) = (yyvsp[0].expr); }
-#line 11069 "bison-chpl-lib.cpp"
+#line 11065 "bison-chpl-lib.cpp"
     break;
 
   case 670: /* opt_try_expr: TTRY expr  */
-#line 3645 "chpl.ypp"
+#line 3641 "chpl.ypp"
                   { (yyval.expr) = context->buildTryExpr((yyloc), (yyvsp[0].expr), false); }
-#line 11075 "bison-chpl-lib.cpp"
+#line 11071 "bison-chpl-lib.cpp"
     break;
 
   case 671: /* opt_try_expr: TTRYBANG expr  */
-#line 3646 "chpl.ypp"
+#line 3642 "chpl.ypp"
                   { (yyval.expr) = context->buildTryExpr((yyloc), (yyvsp[0].expr), true); }
-#line 11081 "bison-chpl-lib.cpp"
+#line 11077 "bison-chpl-lib.cpp"
     break;
 
   case 672: /* opt_try_expr: super_expr  */
-#line 3647 "chpl.ypp"
+#line 3643 "chpl.ypp"
                   { (yyval.expr) = (yyvsp[0].expr); }
-#line 11087 "bison-chpl-lib.cpp"
+#line 11083 "bison-chpl-lib.cpp"
     break;
 
   case 678: /* call_base_expr: expr TBANG  */
-#line 3664 "chpl.ypp"
+#line 3660 "chpl.ypp"
                                 { (yyval.expr) = context->buildUnaryOp((yyloc),
                                                              STR("postfix!"),
                                                              (yyvsp[-1].expr)); }
-#line 11095 "bison-chpl-lib.cpp"
+#line 11091 "bison-chpl-lib.cpp"
     break;
 
   case 679: /* call_base_expr: sub_type_level_expr TQUESTION  */
-#line 3667 "chpl.ypp"
+#line 3663 "chpl.ypp"
                                 { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[0].uniqueStr), (yyvsp[-1].expr)); }
-#line 11101 "bison-chpl-lib.cpp"
+#line 11097 "bison-chpl-lib.cpp"
     break;
 
   case 682: /* call_expr: call_base_expr TLP opt_actual_ls TRP  */
-#line 3674 "chpl.ypp"
+#line 3670 "chpl.ypp"
     {
       AstList actuals;
       std::vector<UniqueString> actualNames;
@@ -11113,11 +11109,11 @@ yyreduce:
                                   /* square */ false);
       (yyval.expr) = fnCall.release();
     }
-#line 11117 "bison-chpl-lib.cpp"
+#line 11113 "bison-chpl-lib.cpp"
     break;
 
   case 683: /* call_expr: call_base_expr TLSBR opt_actual_ls TRSBR  */
-#line 3686 "chpl.ypp"
+#line 3682 "chpl.ypp"
     {
       AstList actuals;
       std::vector<UniqueString> actualNames;
@@ -11129,464 +11125,464 @@ yyreduce:
                                   /* square */ true);
       (yyval.expr) = fnCall.release();
     }
-#line 11133 "bison-chpl-lib.cpp"
+#line 11129 "bison-chpl-lib.cpp"
     break;
 
   case 684: /* call_expr: TPRIMITIVE TLP opt_actual_ls TRP  */
-#line 3698 "chpl.ypp"
+#line 3694 "chpl.ypp"
     {
       (yyval.expr) = context->buildPrimCall((yyloc), (yyvsp[-1].maybeNamedActualList));
     }
-#line 11141 "bison-chpl-lib.cpp"
+#line 11137 "bison-chpl-lib.cpp"
     break;
 
   case 685: /* dot_expr: expr TDOT ident_use  */
-#line 3705 "chpl.ypp"
+#line 3701 "chpl.ypp"
     { (yyval.expr) = Dot::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-2].expr)), (yyvsp[0].uniqueStr)).release(); }
-#line 11147 "bison-chpl-lib.cpp"
+#line 11143 "bison-chpl-lib.cpp"
     break;
 
   case 686: /* dot_expr: expr TDOT TTYPE  */
-#line 3707 "chpl.ypp"
+#line 3703 "chpl.ypp"
     { (yyval.expr) = Dot::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-2].expr)), (yyvsp[0].uniqueStr)).release(); }
-#line 11153 "bison-chpl-lib.cpp"
+#line 11149 "bison-chpl-lib.cpp"
     break;
 
   case 687: /* dot_expr: expr TDOT TDOMAIN  */
-#line 3709 "chpl.ypp"
+#line 3705 "chpl.ypp"
     { (yyval.expr) = Dot::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-2].expr)), (yyvsp[0].uniqueStr)).release(); }
-#line 11159 "bison-chpl-lib.cpp"
+#line 11155 "bison-chpl-lib.cpp"
     break;
 
   case 688: /* dot_expr: expr TDOT TLOCALE  */
-#line 3711 "chpl.ypp"
+#line 3707 "chpl.ypp"
     { (yyval.expr) = Dot::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-2].expr)), (yyvsp[0].uniqueStr)).release(); }
-#line 11165 "bison-chpl-lib.cpp"
+#line 11161 "bison-chpl-lib.cpp"
     break;
 
   case 689: /* dot_expr: expr TDOT TBYTES TLP TRP  */
-#line 3713 "chpl.ypp"
+#line 3709 "chpl.ypp"
     {
       (yyval.expr) = FnCall::build(BUILDER, LOC((yyloc)),
                          Dot::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-4].expr)), (yyvsp[-2].uniqueStr)),
                          false).release();
     }
-#line 11175 "bison-chpl-lib.cpp"
+#line 11171 "bison-chpl-lib.cpp"
     break;
 
   case 690: /* dot_expr: expr TDOT TBYTES TLSBR TRSBR  */
-#line 3719 "chpl.ypp"
+#line 3715 "chpl.ypp"
     {
       (yyval.expr) = FnCall::build(BUILDER, LOC((yyloc)),
                          Dot::build(BUILDER, LOC((yyloc)), toOwned((yyvsp[-4].expr)), (yyvsp[-2].uniqueStr)),
                          true).release();
     }
-#line 11185 "bison-chpl-lib.cpp"
+#line 11181 "bison-chpl-lib.cpp"
     break;
 
   case 691: /* parenthesized_expr: TLP tuple_component TRP  */
-#line 3731 "chpl.ypp"
+#line 3727 "chpl.ypp"
                                     { (yyval.expr) = (yyvsp[-1].expr); }
-#line 11191 "bison-chpl-lib.cpp"
+#line 11187 "bison-chpl-lib.cpp"
     break;
 
   case 692: /* parenthesized_expr: TLP tuple_component TCOMMA TRP  */
-#line 3733 "chpl.ypp"
+#line 3729 "chpl.ypp"
   {
     (yyval.expr) = Tuple::build(BUILDER, LOC((yyloc)), context->consume((yyvsp[-2].expr))).release();
   }
-#line 11199 "bison-chpl-lib.cpp"
+#line 11195 "bison-chpl-lib.cpp"
     break;
 
   case 693: /* parenthesized_expr: TLP tuple_expr_ls TRP  */
-#line 3737 "chpl.ypp"
+#line 3733 "chpl.ypp"
   {
     (yyval.expr) = Tuple::build(BUILDER, LOC((yyloc)), context->consumeList((yyvsp[-1].exprList))).release();
   }
-#line 11207 "bison-chpl-lib.cpp"
+#line 11203 "bison-chpl-lib.cpp"
     break;
 
   case 694: /* parenthesized_expr: TLP tuple_expr_ls TCOMMA TRP  */
-#line 3741 "chpl.ypp"
+#line 3737 "chpl.ypp"
   {
     (yyval.expr) = Tuple::build(BUILDER, LOC((yyloc)), context->consumeList((yyvsp[-2].exprList))).release();
   }
-#line 11215 "bison-chpl-lib.cpp"
+#line 11211 "bison-chpl-lib.cpp"
     break;
 
   case 695: /* bool_literal: TFALSE  */
-#line 3747 "chpl.ypp"
+#line 3743 "chpl.ypp"
          { (yyval.expr) = BoolLiteral::build(BUILDER, LOC((yyloc)), false).release(); }
-#line 11221 "bison-chpl-lib.cpp"
+#line 11217 "bison-chpl-lib.cpp"
     break;
 
   case 696: /* bool_literal: TTRUE  */
-#line 3748 "chpl.ypp"
+#line 3744 "chpl.ypp"
          { (yyval.expr) = BoolLiteral::build(BUILDER, LOC((yyloc)), true).release(); }
-#line 11227 "bison-chpl-lib.cpp"
+#line 11223 "bison-chpl-lib.cpp"
     break;
 
   case 697: /* str_bytes_literal: STRINGLITERAL  */
-#line 3752 "chpl.ypp"
+#line 3748 "chpl.ypp"
                   { (yyval.expr) = (yyvsp[0].expr); }
-#line 11233 "bison-chpl-lib.cpp"
+#line 11229 "bison-chpl-lib.cpp"
     break;
 
   case 698: /* str_bytes_literal: BYTESLITERAL  */
-#line 3753 "chpl.ypp"
+#line 3749 "chpl.ypp"
                   { (yyval.expr) = (yyvsp[0].expr); }
-#line 11239 "bison-chpl-lib.cpp"
+#line 11235 "bison-chpl-lib.cpp"
     break;
 
   case 701: /* literal_expr: INTLITERAL  */
-#line 3759 "chpl.ypp"
+#line 3755 "chpl.ypp"
                  { (yyval.expr) = context->buildNumericLiteral((yyloc), (yyvsp[0].uniqueStr), INTLITERAL); }
-#line 11245 "bison-chpl-lib.cpp"
+#line 11241 "bison-chpl-lib.cpp"
     break;
 
   case 702: /* literal_expr: REALLITERAL  */
-#line 3760 "chpl.ypp"
+#line 3756 "chpl.ypp"
                  { (yyval.expr) = context->buildNumericLiteral((yyloc), (yyvsp[0].uniqueStr), REALLITERAL); }
-#line 11251 "bison-chpl-lib.cpp"
+#line 11247 "bison-chpl-lib.cpp"
     break;
 
   case 703: /* literal_expr: IMAGLITERAL  */
-#line 3761 "chpl.ypp"
+#line 3757 "chpl.ypp"
                  { (yyval.expr) = context->buildNumericLiteral((yyloc), (yyvsp[0].uniqueStr), IMAGLITERAL); }
-#line 11257 "bison-chpl-lib.cpp"
+#line 11253 "bison-chpl-lib.cpp"
     break;
 
   case 704: /* literal_expr: CSTRINGLITERAL  */
-#line 3762 "chpl.ypp"
+#line 3758 "chpl.ypp"
                       { (yyval.expr) = (yyvsp[0].expr); }
-#line 11263 "bison-chpl-lib.cpp"
+#line 11259 "bison-chpl-lib.cpp"
     break;
 
   case 705: /* literal_expr: TNONE  */
-#line 3763 "chpl.ypp"
+#line 3759 "chpl.ypp"
                       { (yyval.expr) = context->buildIdent((yyloc), (yyvsp[0].uniqueStr)); }
-#line 11269 "bison-chpl-lib.cpp"
+#line 11265 "bison-chpl-lib.cpp"
     break;
 
   case 706: /* literal_expr: TLCBR expr_ls TRCBR  */
-#line 3765 "chpl.ypp"
+#line 3761 "chpl.ypp"
   {
     (yyval.expr) = Domain::build(BUILDER, LOC((yyloc)), true,
                        context->consumeList((yyvsp[-1].exprList))).release();
   }
-#line 11278 "bison-chpl-lib.cpp"
+#line 11274 "bison-chpl-lib.cpp"
     break;
 
   case 707: /* literal_expr: TLCBR expr_ls TCOMMA TRCBR  */
-#line 3770 "chpl.ypp"
+#line 3766 "chpl.ypp"
   {
     (yyval.expr) = Domain::build(BUILDER, LOC((yyloc)), true,
                        context->consumeList((yyvsp[-2].exprList))).release();
   }
-#line 11287 "bison-chpl-lib.cpp"
+#line 11283 "bison-chpl-lib.cpp"
     break;
 
   case 708: /* literal_expr: TLSBR expr_ls TRSBR  */
-#line 3775 "chpl.ypp"
+#line 3771 "chpl.ypp"
   {
     (yyval.expr) = Array::build(BUILDER, LOC((yyloc)), context->consumeList((yyvsp[-1].exprList))).release();
   }
-#line 11295 "bison-chpl-lib.cpp"
+#line 11291 "bison-chpl-lib.cpp"
     break;
 
   case 709: /* literal_expr: TLSBR expr_ls TCOMMA TRSBR  */
-#line 3779 "chpl.ypp"
+#line 3775 "chpl.ypp"
   {
     // TODO (dlongnecke): Record trailing comma?
     (yyval.expr) = Array::build(BUILDER, LOC((yyloc)), context->consumeList((yyvsp[-2].exprList))).release();
   }
-#line 11304 "bison-chpl-lib.cpp"
+#line 11300 "bison-chpl-lib.cpp"
     break;
 
   case 710: /* literal_expr: TLSBR assoc_expr_ls TRSBR  */
-#line 3784 "chpl.ypp"
+#line 3780 "chpl.ypp"
   {
     (yyval.expr) = Array::build(BUILDER, LOC((yyloc)), context->consumeList((yyvsp[-1].exprList))).release();
   }
-#line 11312 "bison-chpl-lib.cpp"
+#line 11308 "bison-chpl-lib.cpp"
     break;
 
   case 711: /* literal_expr: TLSBR assoc_expr_ls TCOMMA TRSBR  */
-#line 3788 "chpl.ypp"
+#line 3784 "chpl.ypp"
   {
     // TODO (dlongnecke): Record trailing comma?
     (yyval.expr) = Array::build(BUILDER, LOC((yyloc)), context->consumeList((yyvsp[-2].exprList))).release();
   }
-#line 11321 "bison-chpl-lib.cpp"
+#line 11317 "bison-chpl-lib.cpp"
     break;
 
   case 712: /* assoc_expr_ls: expr TALIAS expr  */
-#line 3797 "chpl.ypp"
+#line 3793 "chpl.ypp"
   {
     auto node = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr));
     (yyval.exprList) = context->makeList(node);
   }
-#line 11330 "bison-chpl-lib.cpp"
+#line 11326 "bison-chpl-lib.cpp"
     break;
 
   case 713: /* assoc_expr_ls: assoc_expr_ls TCOMMA expr TALIAS expr  */
-#line 3802 "chpl.ypp"
+#line 3798 "chpl.ypp"
   {
     auto loc = context->makeSpannedLocation((yylsp[-2]), (yylsp[0]));
     auto node = context->buildBinOp(loc, (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr));
     (yyval.exprList) = context->appendList((yyvsp[-4].exprList), node);
   }
-#line 11340 "bison-chpl-lib.cpp"
+#line 11336 "bison-chpl-lib.cpp"
     break;
 
   case 714: /* binary_op_expr: expr TPLUS expr  */
-#line 3810 "chpl.ypp"
+#line 3806 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11346 "bison-chpl-lib.cpp"
+#line 11342 "bison-chpl-lib.cpp"
     break;
 
   case 715: /* binary_op_expr: expr TMINUS expr  */
-#line 3811 "chpl.ypp"
+#line 3807 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11352 "bison-chpl-lib.cpp"
+#line 11348 "bison-chpl-lib.cpp"
     break;
 
   case 716: /* binary_op_expr: expr TSTAR expr  */
-#line 3812 "chpl.ypp"
+#line 3808 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11358 "bison-chpl-lib.cpp"
+#line 11354 "bison-chpl-lib.cpp"
     break;
 
   case 717: /* binary_op_expr: expr TDIVIDE expr  */
-#line 3813 "chpl.ypp"
+#line 3809 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11364 "bison-chpl-lib.cpp"
+#line 11360 "bison-chpl-lib.cpp"
     break;
 
   case 718: /* binary_op_expr: expr TSHIFTLEFT expr  */
-#line 3814 "chpl.ypp"
+#line 3810 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11370 "bison-chpl-lib.cpp"
+#line 11366 "bison-chpl-lib.cpp"
     break;
 
   case 719: /* binary_op_expr: expr TSHIFTRIGHT expr  */
-#line 3815 "chpl.ypp"
+#line 3811 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11376 "bison-chpl-lib.cpp"
+#line 11372 "bison-chpl-lib.cpp"
     break;
 
   case 720: /* binary_op_expr: expr TMOD expr  */
-#line 3816 "chpl.ypp"
+#line 3812 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11382 "bison-chpl-lib.cpp"
+#line 11378 "bison-chpl-lib.cpp"
     break;
 
   case 721: /* binary_op_expr: expr TEQUAL expr  */
-#line 3817 "chpl.ypp"
+#line 3813 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11388 "bison-chpl-lib.cpp"
+#line 11384 "bison-chpl-lib.cpp"
     break;
 
   case 722: /* binary_op_expr: expr TNOTEQUAL expr  */
-#line 3818 "chpl.ypp"
+#line 3814 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11394 "bison-chpl-lib.cpp"
+#line 11390 "bison-chpl-lib.cpp"
     break;
 
   case 723: /* binary_op_expr: expr TLESSEQUAL expr  */
-#line 3819 "chpl.ypp"
+#line 3815 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11400 "bison-chpl-lib.cpp"
+#line 11396 "bison-chpl-lib.cpp"
     break;
 
   case 724: /* binary_op_expr: expr TGREATEREQUAL expr  */
-#line 3820 "chpl.ypp"
+#line 3816 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11406 "bison-chpl-lib.cpp"
+#line 11402 "bison-chpl-lib.cpp"
     break;
 
   case 725: /* binary_op_expr: expr TLESS expr  */
-#line 3821 "chpl.ypp"
+#line 3817 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11412 "bison-chpl-lib.cpp"
+#line 11408 "bison-chpl-lib.cpp"
     break;
 
   case 726: /* binary_op_expr: expr TGREATER expr  */
-#line 3822 "chpl.ypp"
+#line 3818 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11418 "bison-chpl-lib.cpp"
+#line 11414 "bison-chpl-lib.cpp"
     break;
 
   case 727: /* binary_op_expr: expr TBAND expr  */
-#line 3823 "chpl.ypp"
+#line 3819 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11424 "bison-chpl-lib.cpp"
+#line 11420 "bison-chpl-lib.cpp"
     break;
 
   case 728: /* binary_op_expr: expr TBOR expr  */
-#line 3824 "chpl.ypp"
+#line 3820 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11430 "bison-chpl-lib.cpp"
+#line 11426 "bison-chpl-lib.cpp"
     break;
 
   case 729: /* binary_op_expr: expr TBXOR expr  */
-#line 3825 "chpl.ypp"
+#line 3821 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11436 "bison-chpl-lib.cpp"
+#line 11432 "bison-chpl-lib.cpp"
     break;
 
   case 730: /* binary_op_expr: expr TAND expr  */
-#line 3826 "chpl.ypp"
+#line 3822 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11442 "bison-chpl-lib.cpp"
+#line 11438 "bison-chpl-lib.cpp"
     break;
 
   case 731: /* binary_op_expr: expr TOR expr  */
-#line 3827 "chpl.ypp"
+#line 3823 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11448 "bison-chpl-lib.cpp"
+#line 11444 "bison-chpl-lib.cpp"
     break;
 
   case 732: /* binary_op_expr: expr TEXP expr  */
-#line 3828 "chpl.ypp"
+#line 3824 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11454 "bison-chpl-lib.cpp"
+#line 11450 "bison-chpl-lib.cpp"
     break;
 
   case 733: /* binary_op_expr: expr TBY expr  */
-#line 3829 "chpl.ypp"
+#line 3825 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11460 "bison-chpl-lib.cpp"
+#line 11456 "bison-chpl-lib.cpp"
     break;
 
   case 734: /* binary_op_expr: expr TALIGN expr  */
-#line 3830 "chpl.ypp"
+#line 3826 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11466 "bison-chpl-lib.cpp"
+#line 11462 "bison-chpl-lib.cpp"
     break;
 
   case 735: /* binary_op_expr: expr THASH expr  */
-#line 3831 "chpl.ypp"
+#line 3827 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11472 "bison-chpl-lib.cpp"
+#line 11468 "bison-chpl-lib.cpp"
     break;
 
   case 736: /* binary_op_expr: expr TDMAPPED expr  */
-#line 3832 "chpl.ypp"
+#line 3828 "chpl.ypp"
                            { (yyval.expr) = context->buildBinOp((yyloc), (yyvsp[-2].expr), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11478 "bison-chpl-lib.cpp"
+#line 11474 "bison-chpl-lib.cpp"
     break;
 
   case 737: /* unary_op_expr: TPLUS expr  */
-#line 3836 "chpl.ypp"
+#line 3832 "chpl.ypp"
                                  { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11484 "bison-chpl-lib.cpp"
+#line 11480 "bison-chpl-lib.cpp"
     break;
 
   case 738: /* unary_op_expr: TMINUS expr  */
-#line 3837 "chpl.ypp"
+#line 3833 "chpl.ypp"
                                  { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11490 "bison-chpl-lib.cpp"
+#line 11486 "bison-chpl-lib.cpp"
     break;
 
   case 739: /* unary_op_expr: TMINUSMINUS expr  */
-#line 3838 "chpl.ypp"
+#line 3834 "chpl.ypp"
                                  { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11496 "bison-chpl-lib.cpp"
+#line 11492 "bison-chpl-lib.cpp"
     break;
 
   case 740: /* unary_op_expr: TPLUSPLUS expr  */
-#line 3839 "chpl.ypp"
+#line 3835 "chpl.ypp"
                                  { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11502 "bison-chpl-lib.cpp"
+#line 11498 "bison-chpl-lib.cpp"
     break;
 
   case 741: /* unary_op_expr: TBANG expr  */
-#line 3840 "chpl.ypp"
+#line 3836 "chpl.ypp"
                                  { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11508 "bison-chpl-lib.cpp"
+#line 11504 "bison-chpl-lib.cpp"
     break;
 
   case 742: /* unary_op_expr: expr TBANG  */
-#line 3841 "chpl.ypp"
+#line 3837 "chpl.ypp"
                                  { (yyval.expr) = context->buildUnaryOp((yyloc),
                                                               STR("postfix!"),
                                                               (yyvsp[-1].expr)); }
-#line 11516 "bison-chpl-lib.cpp"
+#line 11512 "bison-chpl-lib.cpp"
     break;
 
   case 743: /* unary_op_expr: TBNOT expr  */
-#line 3844 "chpl.ypp"
+#line 3840 "chpl.ypp"
                                  { (yyval.expr) = context->buildUnaryOp((yyloc), (yyvsp[-1].uniqueStr), (yyvsp[0].expr)); }
-#line 11522 "bison-chpl-lib.cpp"
+#line 11518 "bison-chpl-lib.cpp"
     break;
 
   case 744: /* reduce_expr: expr TREDUCE expr  */
+#line 3845 "chpl.ypp"
+  {
+    (yyval.expr) = context->buildReduce((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
+  }
+#line 11526 "bison-chpl-lib.cpp"
+    break;
+
+  case 745: /* reduce_expr: expr TREDUCE zippered_iterator  */
 #line 3849 "chpl.ypp"
   {
     (yyval.expr) = context->buildReduce((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
   }
-#line 11530 "bison-chpl-lib.cpp"
-    break;
-
-  case 745: /* reduce_expr: expr TREDUCE zippered_iterator  */
-#line 3853 "chpl.ypp"
-  {
-    (yyval.expr) = context->buildReduce((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
-  }
-#line 11538 "bison-chpl-lib.cpp"
+#line 11534 "bison-chpl-lib.cpp"
     break;
 
   case 746: /* reduce_expr: reduce_scan_op_expr TREDUCE expr  */
+#line 3853 "chpl.ypp"
+  {
+    (yyval.expr) = context->buildReduce((yyloc), (yylsp[-2]), (yyvsp[-2].uniqueStr), (yyvsp[0].expr));
+  }
+#line 11542 "bison-chpl-lib.cpp"
+    break;
+
+  case 747: /* reduce_expr: reduce_scan_op_expr TREDUCE zippered_iterator  */
 #line 3857 "chpl.ypp"
   {
     (yyval.expr) = context->buildReduce((yyloc), (yylsp[-2]), (yyvsp[-2].uniqueStr), (yyvsp[0].expr));
   }
-#line 11546 "bison-chpl-lib.cpp"
-    break;
-
-  case 747: /* reduce_expr: reduce_scan_op_expr TREDUCE zippered_iterator  */
-#line 3861 "chpl.ypp"
-  {
-    (yyval.expr) = context->buildReduce((yyloc), (yylsp[-2]), (yyvsp[-2].uniqueStr), (yyvsp[0].expr));
-  }
-#line 11554 "bison-chpl-lib.cpp"
+#line 11550 "bison-chpl-lib.cpp"
     break;
 
   case 748: /* scan_expr: expr TSCAN expr  */
+#line 3864 "chpl.ypp"
+  {
+    (yyval.expr) = context->buildScan((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
+  }
+#line 11558 "bison-chpl-lib.cpp"
+    break;
+
+  case 749: /* scan_expr: expr TSCAN zippered_iterator  */
 #line 3868 "chpl.ypp"
   {
     (yyval.expr) = context->buildScan((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
   }
-#line 11562 "bison-chpl-lib.cpp"
-    break;
-
-  case 749: /* scan_expr: expr TSCAN zippered_iterator  */
-#line 3872 "chpl.ypp"
-  {
-    (yyval.expr) = context->buildScan((yyloc), (yylsp[-2]), (yyvsp[-2].expr), (yyvsp[0].expr));
-  }
-#line 11570 "bison-chpl-lib.cpp"
+#line 11566 "bison-chpl-lib.cpp"
     break;
 
   case 750: /* scan_expr: reduce_scan_op_expr TSCAN expr  */
+#line 3872 "chpl.ypp"
+  {
+    (yyval.expr) = context->buildScan((yyloc), (yylsp[-2]), (yyvsp[-2].uniqueStr), (yyvsp[0].expr));
+  }
+#line 11574 "bison-chpl-lib.cpp"
+    break;
+
+  case 751: /* scan_expr: reduce_scan_op_expr TSCAN zippered_iterator  */
 #line 3876 "chpl.ypp"
   {
     (yyval.expr) = context->buildScan((yyloc), (yylsp[-2]), (yyvsp[-2].uniqueStr), (yyvsp[0].expr));
   }
-#line 11578 "bison-chpl-lib.cpp"
+#line 11582 "bison-chpl-lib.cpp"
     break;
 
-  case 751: /* scan_expr: reduce_scan_op_expr TSCAN zippered_iterator  */
-#line 3880 "chpl.ypp"
-  {
-    (yyval.expr) = context->buildScan((yyloc), (yylsp[-2]), (yyvsp[-2].uniqueStr), (yyvsp[0].expr));
-  }
+
 #line 11586 "bison-chpl-lib.cpp"
-    break;
-
-
-#line 11590 "bison-chpl-lib.cpp"
 
       default: break;
     }

--- a/frontend/lib/parsing/chpl.ypp
+++ b/frontend/lib/parsing/chpl.ypp
@@ -1843,8 +1843,7 @@ implements_type_ident:
 | TVOID
 | implements_type_error_ident
   {
-    CHPL_PARSER_REPORT_SYNTAX(
-        context, @$, "type '" + $1.str() + "' cannot implement an interface.");
+    context->syntax(@$, "type '%s' cannot implement an interface.", $1.c_str());
     $$ = $1;
   }
 ;
@@ -2605,8 +2604,7 @@ named_formal:
 | opt_formal_intent_tag TLP tuple_var_decl_stmt_inner_ls TRP
   opt_colon_formal_type formal_var_arg_expr
   {
-    $$ = CHPL_PARSER_REPORT_SYNTAX(
-        context, @$, "variable-length argument may not be grouped in a tuple.");
+    $$ = context->syntax(@$, "variable-length argument may not be grouped in a tuple.");
   }
 ;
 
@@ -2910,8 +2908,7 @@ ret_array_type:
   }
 | TLSBR error TRSBR
   {
-    $$ = CHPL_PARSER_REPORT_SYNTAX(
-        context, @$, "invalid expression for domain of array return type.");
+    $$ = context->syntax(@$, "invalid expression for domain of array return type.");
   }
 ;
 
@@ -3440,8 +3437,7 @@ intent_expr:
                                  toOwned($4));
       $$ = node.release();
     } else {
-      $$ = CHPL_PARSER_REPORT_SYNTAX(
-          context, @$, "expected identifier for task variable name.");
+      $$ = context->syntax(@$, "expected identifier for task variable name.");
     }
   }
 | reduce_scan_op_expr TREDUCE ident_expr

--- a/frontend/lib/parsing/flex-chpl-lib.cpp
+++ b/frontend/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 2 "flex-chpl-lib.cpp"
+#line 1 "flex-chpl-lib.cpp"
 
-#line 4 "flex-chpl-lib.cpp"
+#line 3 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -281,6 +281,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -445,7 +446,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -522,7 +523,7 @@ static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner 
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
 
 void *yyalloc ( yy_size_t , yyscan_t yyscanner );
 void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
@@ -569,7 +570,7 @@ static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (int) (yy_cp - yy_bp); \
+	yyleng = (yy_size_t) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
@@ -1118,8 +1119,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    int yy_n_chars;
-    int yyleng_r;
+    yy_size_t yy_n_chars;
+    yy_size_t yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -1176,7 +1177,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int yyget_leng ( yyscan_t yyscanner );
+			yy_size_t yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -1261,7 +1262,7 @@ static int input ( yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		yy_size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -2579,7 +2580,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2593,7 +2594,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2651,7 +2652,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -2758,7 +2759,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
+			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -3136,12 +3137,12 @@ YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	int i;
+	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
@@ -3226,7 +3227,7 @@ static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        int yyless_macro_arg = (n); \
+        yy_size_t yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = yyg->yy_hold_char; \
 		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
@@ -3294,7 +3295,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int yyget_leng  (yyscan_t yyscanner)
+yy_size_t yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/frontend/lib/parsing/flex-chpl-lib.cpp
+++ b/frontend/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 1 "flex-chpl-lib.cpp"
+#line 2 "flex-chpl-lib.cpp"
 
-#line 3 "flex-chpl-lib.cpp"
+#line 4 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -281,7 +281,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -446,7 +445,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -523,7 +522,7 @@ static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner 
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
 void *yyalloc ( yy_size_t , yyscan_t yyscanner );
 void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
@@ -570,7 +569,7 @@ static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
@@ -1119,8 +1118,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    yy_size_t yy_n_chars;
-    yy_size_t yyleng_r;
+    int yy_n_chars;
+    int yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -1177,7 +1176,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -1262,7 +1261,7 @@ static int input ( yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -2580,7 +2579,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -2594,7 +2593,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2652,7 +2651,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -2759,7 +2758,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -3137,12 +3136,12 @@ YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
@@ -3227,7 +3226,7 @@ static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        yy_size_t yyless_macro_arg = (n); \
+        int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = yyg->yy_hold_char; \
 		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
@@ -3295,7 +3294,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yyget_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/frontend/lib/parsing/flex-chpl-lib.cpp
+++ b/frontend/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 2 "flex-chpl-lib.cpp"
+#line 1 "flex-chpl-lib.cpp"
 
-#line 4 "flex-chpl-lib.cpp"
+#line 3 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1087,10 +1087,10 @@ static void processInvalidToken(yyscan_t scanner);
 static bool yy_has_state(yyscan_t scanner);
 }
 
-#line 1091 "flex-chpl-lib.cpp"
+#line 1090 "flex-chpl-lib.cpp"
 /* hex float literals, have decimal exponents indicating the power of 2 */
 
-#line 1094 "flex-chpl-lib.cpp"
+#line 1093 "flex-chpl-lib.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -1380,7 +1380,7 @@ YY_DECL
 #line 113 "chpl.lex"
 
 
-#line 1384 "flex-chpl-lib.cpp"
+#line 1383 "flex-chpl-lib.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2390,7 +2390,7 @@ YY_RULE_SETUP
 #line 330 "chpl.lex"
 ECHO;
 	YY_BREAK
-#line 2394 "flex-chpl-lib.cpp"
+#line 2393 "flex-chpl-lib.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();

--- a/frontend/lib/parsing/flex-chpl-lib.h
+++ b/frontend/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 6 "flex-chpl-lib.h"
+#line 5 "flex-chpl-lib.h"
 
-#line 8 "flex-chpl-lib.h"
+#line 7 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -730,6 +730,6 @@ extern int yylex \
 #line 330 "chpl.lex"
 
 
-#line 734 "flex-chpl-lib.h"
+#line 733 "flex-chpl-lib.h"
 #undef yychpl_IN_HEADER
 #endif /* yychpl_HEADER_H */

--- a/frontend/lib/parsing/flex-chpl-lib.h
+++ b/frontend/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 5 "flex-chpl-lib.h"
+#line 6 "flex-chpl-lib.h"
 
-#line 7 "flex-chpl-lib.h"
+#line 8 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -285,7 +285,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -399,7 +398,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -443,7 +442,7 @@ void yypop_buffer_state ( yyscan_t yyscanner );
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
 void *yyalloc ( yy_size_t , yyscan_t yyscanner );
 void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
@@ -497,7 +496,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 

--- a/frontend/lib/parsing/flex-chpl-lib.h
+++ b/frontend/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 6 "flex-chpl-lib.h"
+#line 5 "flex-chpl-lib.h"
 
-#line 8 "flex-chpl-lib.h"
+#line 7 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -285,6 +285,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -398,7 +399,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -442,7 +443,7 @@ void yypop_buffer_state ( yyscan_t yyscanner );
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
 
 void *yyalloc ( yy_size_t , yyscan_t yyscanner );
 void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
@@ -496,7 +497,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			int yyget_leng ( yyscan_t yyscanner );
+			yy_size_t yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 

--- a/frontend/lib/parsing/lexer-help.h
+++ b/frontend/lib/parsing/lexer-help.h
@@ -363,7 +363,7 @@ static std::string eatStringLiteral(yyscan_t scanner,
         break; // EOF reached, so stop
       } else {
         syntax(scanner, nLines, nCols,
-               "unexpected string escape: '%c'.", (char) c);
+               "unexpected string escape: '\\%c'.", (char) c);
         isErroneousOut = true;
       }
     } else {

--- a/frontend/lib/parsing/lexer-help.h
+++ b/frontend/lib/parsing/lexer-help.h
@@ -46,6 +46,15 @@ static void updateLocation(YYLTYPE* loc, int nLines, int nCols) {
   loc->last_column = startColumn + nCols;
 }
 
+static YYLTYPE getLocation(yyscan_t scanner, int nLines, int nCols,
+                        bool moveToEnd = false) {
+  ParserContext* pContext = yyget_extra(scanner);
+  YYLTYPE loc = *yyget_lloc(scanner);
+  updateLocation(&loc, nLines, nCols);
+  if (moveToEnd) loc = pContext->makeLocationAtLast(loc);
+  return loc;
+}
+
 int processNewline(yyscan_t scanner) {
   YYLTYPE* loc = yyget_lloc(scanner);
   updateLocation(loc, 1, 0);
@@ -53,6 +62,19 @@ int processNewline(yyscan_t scanner) {
   if (context->parseStats)
     context->parseStats->countNewline();
   return YYLEX_NEWLINE;
+}
+
+static void syntax(yyscan_t scanner, int nLines, int nCols,
+                   const char* fmt, ...) {
+  ParserContext* pContext = yychpl_get_extra(scanner);
+  YYLTYPE flexLoc = getLocation(scanner, nLines, nCols);
+  Location loc = pContext->convertLocation(flexLoc);
+  va_list args;
+  va_start(args, fmt);
+  auto error = GeneralError::vbuild(pContext->context(),
+                                    ErrorBase::SYNTAX, loc, fmt, args);
+  pContext->report(flexLoc, error);
+  va_end(args);
 }
 
 /************************************ | *************************************
@@ -260,8 +282,7 @@ static std::string eatStringLiteral(yyscan_t scanner,
     if (c == '\n') {
       // TODO: string literals with newline after backslash
       // are not documented in the spec
-      CHPL_LEXER_REPORT_SYNTAX(
-          scanner, nLines, nCols,
+      syntax(scanner, nLines, nCols,
           "end-of-line in a string literal without a preceding backslash.");
       isErroneousOut = true;
       s += c;
@@ -309,16 +330,16 @@ static std::string eatStringLiteral(yyscan_t scanner,
                "overflow/underflow shouldn't be possible in the allowed number "
                "of digits");
         if (!foundHex) {
-          CHPL_LEXER_REPORT_SYNTAX(scanner, nLines, nCols,
-                                   "non-hexadecimal character follows \\x.");
+          syntax(scanner, nLines, nCols,
+                 "non-hexadecimal character follows \\x.");
           isErroneousOut = true;
         } else if (0 <= hexChar && hexChar <= 255) {
           // append the character
           char cc = (char)hexChar;
           s += cc;
         } else {
-          CHPL_LEXER_REPORT_SYNTAX(scanner, nLines, nCols,
-                                   "unknown problem while reading \\x escape.");
+          syntax(scanner, nLines, nCols,
+                 "unknown problem while reading \\x escape.");
           isErroneousOut = true;
         }
 
@@ -326,15 +347,13 @@ static std::string eatStringLiteral(yyscan_t scanner,
           continue; // need to process c as the next character
 
       } else if (c == 'u' || c == 'U') {
-        CHPL_LEXER_REPORT_SYNTAX(
-            scanner, nLines, nCols,
-            "universal character name not yet supported in string literal.");
+        syntax(scanner, nLines, nCols,
+               "universal character name not yet supported in string literal.");
         s += "\\u"; // this is a dummy value
         isErroneousOut = true;
       } else if ('0' <= c && c <= '7' ) {
-        CHPL_LEXER_REPORT_SYNTAX(
-            scanner, nLines, nCols,
-            "octal escape not supported in string literal.");
+        syntax(scanner, nLines, nCols,
+               "octal escape not supported in string literal.");
         s += "\\";
         s += c; // a dummy value
         isErroneousOut = true;
@@ -343,9 +362,8 @@ static std::string eatStringLiteral(yyscan_t scanner,
         s += "\\";
         break; // EOF reached, so stop
       } else {
-        CHPL_LEXER_REPORT_SYNTAX(
-            scanner, nLines, nCols,
-            std::string("unexpected string escape: '\\") + (char)c + "'.");
+        syntax(scanner, nLines, nCols,
+               "unexpected string escape: '%c'.", (char) c);
         isErroneousOut = true;
       }
     } else {
@@ -526,8 +544,8 @@ static SizedStr eatExternCode(yyscan_t scanner) {
           break;
 
         case in_single_line_comment:
-          CHPL_LEXER_REPORT_SYNTAX(scanner, nLines, nCols,
-                            "missing newline after // comment in extern block.");
+          syntax(scanner, nLines, nCols,
+                 "missing newline after // comment in extern block.");
           break;
 
         case in_multi_line_comment:
@@ -786,8 +804,7 @@ static int processBlockComment(yyscan_t scanner) {
 
 static void processInvalidToken(yyscan_t scanner) {
   std::string pch = std::string(yyget_text(scanner));
-  CHPL_LEXER_REPORT_SYNTAX(scanner, 0, pch.length(),
-                           "invalid token: " + pch + ".");
+  syntax(scanner, 0, pch.length(), "invalid token: %s.", pch.c_str());
 }
 
 static int getNextYYChar(yyscan_t scanner) {

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -54,11 +54,9 @@ const FileContents& fileTextQuery(Context* context, std::string path) {
 
   std::string text;
   std::string error;
-  const ErrorParseErr* parseError = nullptr;
+  const ErrorBase* parseError = nullptr;
   if (!readfile(path.c_str(), text, error)) {
-    error = "error reading file: " + error;
-    context->report(
-        ErrorParseErr::get(context, std::make_tuple(Location(), error)));
+    parseError = context->error(Location(), "error reading file: %s\n", error.c_str());
   }
   auto result = FileContents(std::move(text), parseError);
   return QUERY_END(result);
@@ -105,7 +103,7 @@ parseFileToBuilderResult(Context* context, UniqueString path,
   // Run the fileText query to get the file contents
   const FileContents& contents = fileText(context, path);
   const std::string& text = contents.text();
-  const ErrorParseErr* error = contents.error();
+  const ErrorBase* error = contents.error();
   BuilderResult result(path);
 
   if (error == nullptr) {

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -108,20 +108,6 @@ void Builder::addError(const ErrorBase* e) {
   this->errors_.push_back(e);
 }
 
-void Builder::addPostParseError(const AstNode* node, const char* fmt, ...) {
-  va_list vl;
-  va_start(vl, fmt);
-  CHPL_POSTPARSE_REPORT(*this, PostParseErr, node, vprintToString(fmt, vl));
-  va_end(vl);
-}
-
-void Builder::addPostParseWarning(const AstNode* node, const char* fmt, ...) {
-  va_list vl;
-  va_start(vl, fmt);
-  CHPL_POSTPARSE_REPORT(*this, PostParseWarn, node, vprintToString(fmt, vl));
-  va_end(vl);
-}
-
 void Builder::noteLocation(AstNode* ast, Location loc) {
   notedLocations_[ast] = loc;
 }

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -49,6 +49,16 @@ struct Visitor {
       isUserCode_(isUserCode) {
   }
 
+  // Create and store an error in the builder (convenience overloads for
+  // both errors and warnings below). This factory function is provided
+  // because errors pinning on freshly parsed AST cannot be stored in
+  // the context at this point.
+  void report(const AstNode* node, ErrorBase::Kind kind,
+              const char* fmt,
+              va_list vl);
+  void error(const AstNode* node, const char* fmt, ...);
+  void warn(const AstNode* node, const char* fmt, ...);
+
   // Return true if a given flag is set.
   bool isFlagSet(CompilerFlags::Name flag) const;
 
@@ -144,6 +154,29 @@ struct Visitor {
   void visit(const FunctionSignature* node);
   void visit(const Union* node);
 };
+
+
+// Note that even though we pass in the IDs for error messages here, the
+// locations map is not actually populated for the user until after the
+// builder wraps up and produces a builder result.
+void Visitor::report(const AstNode* node, ErrorBase::Kind kind,
+                     const char* fmt,
+                     va_list vl) {
+  auto err = GeneralError::vbuild(context_, kind, node->id(), fmt, vl);
+  builder_.addError(std::move(err));
+}
+
+void Visitor::error(const AstNode* node, const char* fmt, ...) {
+  va_list vl;
+  va_start(vl, fmt);
+  report(node, ErrorBase::ERROR, fmt, vl);
+}
+
+void Visitor::warn(const AstNode* node, const char* fmt, ...) {
+  va_list vl;
+  va_start(vl, fmt);
+  report(node, ErrorBase::WARNING, fmt, vl);
+}
 
 bool Visitor::isFlagSet(CompilerFlags::Name flag) const {
   return chpl::isCompilerFlagSet(context_, flag);
@@ -247,9 +280,8 @@ void Visitor::checkDomainTypeQueryUsage(const TypeQuery* node) {
   }
 
   if (doEmitError) {
-    builder_.addPostParseError(node,
-                              "domain query expressions may currently only be "
-                              "used in formal argument types.");
+    error(node, "domain query expressions may currently only be "
+                "used in formal argument types.");
   }
 }
 
@@ -264,10 +296,10 @@ void Visitor::checkNoDuplicateNamedArguments(const FnCall* node) {
       if (!actualNames.insert(name).second) {
         auto actual = node->actual(i);
         CHPL_ASSERT(actual);
-        builder_.addPostParseError(actual,
-                                  "the named argument '%s' is used more than "
-                                  "once in the same function call.",
-                                  name.c_str());
+        error(actual,
+              "the named argument '%s' is used more than "
+              "once in the same function call.",
+              name.c_str());
       }
     }
   }
@@ -408,7 +440,7 @@ void Visitor::checkExplicitDeinitCalls(const FnCall* node) {
   }
 
   if (doEmitError) {
-    builder_.addPostParseError(node, "direct calls to deinit() are not allowed.");
+    error(node, "direct calls to deinit() are not allowed.");
   }
 }
 
@@ -423,7 +455,7 @@ void Visitor::checkConstVarNoInit(const Variable* node) {
 
   if (auto ident = node->initExpression()->toIdentifier()) {
     if (ident->name() == USTR("noinit")) {
-      builder_.addPostParseError(node, "const variables specified with noinit must be "
+      error(node, "const variables specified with noinit must be "
                   "explicitly initialized.");
     }
   }
@@ -470,15 +502,14 @@ void Visitor::checkConfigVar(const Variable* node) {
     const char* varTypeStr = configVarStr(node->kind());
     CHPL_ASSERT(varTypeStr);
 
-    builder_.addPostParseError(node, "configuration %s are allowed only at module scope.",
-        varTypeStr);
+    error(node, "configuration %s are allowed only at module scope.",
+          varTypeStr);
   }
 }
 
 void Visitor::checkExportVar(const Variable* node) {
   if (node->linkage() == Decl::EXPORT) {
-    builder_.addPostParseError(node,
-                              "export variables are not yet supported.");
+    error(node, "export variables are not yet supported.");
   }
 }
 
@@ -486,15 +517,12 @@ void Visitor::checkOperatorNameValidity(const Function* node) {
   if (node->kind() == Function::Kind::OPERATOR) {
     // operators must have valid operator names
     if (!isOpName(node->name())) {
-      builder_.addPostParseError(node,
-                                "'%s' is not a legal operator name.",
-                                node->name().c_str());
+      error(node, "'%s' is not a legal operator name.", node->name().c_str());
     }
   } else {
     // functions with operator names must be declared as operators
     if (isOpName(node->name())) {
-      builder_.addPostParseError(node,
-          "operators cannot be declared without the operator keyword.");
+      error(node, "operators cannot be declared without the operator keyword.");
     }
   }
 }
@@ -503,8 +531,7 @@ void Visitor::checkEmptyProcedureBody(const Function* node) {
   if (!node->body() && node->linkage() != Decl::EXTERN) {
     auto decl = searchParentsForDecl(nullptr);
     if (!decl || !decl->isInterface()) {
-      builder_.addPostParseError(node,
-          "no-op procedures are only legal for extern functions.");
+      error(node, "no-op procedures are only legal for extern functions.");
     }
   }
 }
@@ -513,18 +540,15 @@ void Visitor::checkExternProcedure(const Function* node) {
   if (node->linkage() != Decl::EXTERN) return;
 
   if (node->body()) {
-    builder_.addPostParseError(node,
-                              "extern functions cannot have a body.");
+    error(node, "extern functions cannot have a body.");
   }
 
   if (node->throws()) {
-    builder_.addPostParseError(node,
-                              "extern functions cannot throw errors.");
+    error(node, "extern functions cannot throw errors.");
   }
 
   if (node->kind() == Function::ITER) {
-    builder_.addPostParseError(node,
-                              "'iter' is not legal with 'extern'.");
+    error(node, "'iter' is not legal with 'extern'.");
   }
 }
 
@@ -532,28 +556,25 @@ void Visitor::checkExportProcedure(const Function* node) {
   if (node->linkage() != Decl::EXPORT) return;
 
   if (node->whereClause()) {
-    builder_.addPostParseError(node,
-                              "exported functions cannot have where clauses.");
+    error(node, "exported functions cannot have where clauses.");
   }
 }
 
 // TODO: Should this be confirming that the function is a method?
 void Visitor::checkProcedureRequiresParens(const Function* node) {
   if (node->name() == "this" && node->isParenless()) {
-    builder_.addPostParseError(node,
-                              "method 'this' must have parentheses.");
+    error(node, "method 'this' must have parentheses.");
   }
 
   if (node->name() == "these" && node->isParenless()) {
-    builder_.addPostParseError(node,
-                              "method 'these' must have parentheses.");
+    error(node, "method 'these' must have parentheses.");
   }
 }
 
 void Visitor::checkOverrideNonMethod(const Function* node) {
   if (!node->isMethod() && node->isOverride()) {
-    builder_.addPostParseError(node, "'override' cannot be applied to non-method '%s'.",
-        node->name().c_str());
+    error(node, "'override' cannot be applied to non-method '%s'.",
+          node->name().c_str());
   }
 }
 
@@ -580,9 +601,9 @@ void Visitor::checkFormalsForTypeOrParamProcs(const Function* node) {
 
     if (doEmitError) {
       CHPL_ASSERT(formalIntentStr);
-      builder_.addPostParseError(decl,
-          "cannot use '%s' intent in a function returning with '%s' intent.",
-          formalIntentStr, returnIntentStr);
+      error(decl,
+            "cannot use '%s' intent in a function returning with '%s' intent.",
+            formalIntentStr, returnIntentStr);
     }
   }
 }
@@ -606,11 +627,10 @@ void Visitor::checkNoReceiverClauseOnPrimaryMethod(const Function* node) {
           receiverTypeStr = ss.str();
         }
 
-        builder_.addPostParseError(node,
-                                  "type binding clauses ('%s.' in this case) "
-                                  "are not supported in declarations within a "
-                                  "class, record or union.",
-                                  receiverTypeStr.c_str());
+        error(node,
+              "type binding clauses ('%s.' in this case) are not supported in "
+              "declarations within a class, record or union.",
+              receiverTypeStr.c_str());
       }
     }
   }
@@ -635,9 +655,8 @@ void Visitor::checkLambdaReturnIntent(const Function* node) {
       break;
   }
   if (disallowedReturnType) {
-    builder_.addPostParseError(node,
-                              "'%s' return types are not allowed in lambdas.",
-                              disallowedReturnType);
+    error(node, "'%s' return types are not allowed in lambdas.",
+          disallowedReturnType);
   }
 }
 
@@ -683,8 +702,7 @@ void Visitor::checkPrivateDecl(const Decl* node) {
   if (!enclosingDecl) return;
 
   if (enclosingDecl->isFunction()) {
-    builder_.addPostParseWarning(node,
-        "private declarations within function bodies are meaningless.");
+    error(node, "private declarations within function bodies are meaningless.");
 
   } else if (enclosingDecl->isAggregateDecl() && !node->isTypeDecl()) {
     CHPL_POSTPARSE_REPORT(builder_, CantApplyPrivate, node,
@@ -698,13 +716,11 @@ void Visitor::checkPrivateDecl(const Decl* node) {
       }
 
     } else if (parent(0)->isBlock() && !isParentFalseBlock(0)) {
-      builder_.addPostParseWarning(node,
-          "private declarations within nested blocks are meaningless.");
+      error(node, "private declarations within nested blocks are meaningless.");
 
     } else if (parent(0) != mod) {
-      builder_.addPostParseWarning(node,
-                                 "private declarations are meaningless outside "
-                                 "of module level declarations.");
+      error(node, "private declarations are meaningless outside "
+                  "of module level declarations.");
     }
   }
 }
@@ -773,11 +789,9 @@ void Visitor::checkReservedSymbolName(const NamedDecl* node) {
   if (node->isTaskVar()) return;
 
   if (isNameReservedWord(node)) {
-    builder_.addPostParseError(node,
-        "attempt to redefine reserved word '%s'.", name.c_str());
+    error(node, "attempt to redefine reserved word '%s'.", name.c_str());
   } else if (isNameReservedType(name)) {
-    builder_.addPostParseError(node,
-        "attempt to redefine reserved type '%s'.", name.c_str());
+    error(node, "attempt to redefine reserved type '%s'.", name.c_str());
   }
 }
 
@@ -791,18 +805,17 @@ void Visitor::checkLinkageName(const NamedDecl* node) {
   if (node->isFunction()) return;
 
   if (!linkageName->isStringLiteral()) {
-    builder_.addPostParseError(linkageName,
-        "the linkage name for '%s' must be a string literal.",
-        node->name().c_str());
+    error(linkageName, "the linkage name for '%s' must be a string literal.",
+          node->name().c_str());
   }
 }
 
 // TODO: This relies on the "warn unstable" flag that we do not have.
 void Visitor::warnUnstableUnions(const Union* node) {
   if (!isFlagSet(CompilerFlags::WARN_UNSTABLE)) return;
-  builder_.addPostParseWarning(node,
-      "unions are currently unstable and are expected to change in ways that "
-      "will break their current uses.");
+  warn(node,
+       "unions are currently unstable and are expected to change in ways that "
+       "will break their current uses.");
 }
 
 void Visitor::warnUnstableSymbolNames(const NamedDecl* node) {
@@ -812,13 +825,13 @@ void Visitor::warnUnstableSymbolNames(const NamedDecl* node) {
   auto name = node->name();
 
   if (name.startsWith("_")) {
-    builder_.addPostParseWarning(node,
-        "symbol names with leading underscores (%s) are unstable.",
-        name.c_str());
+    warn(node,
+         "symbol names with leading underscores (%s) are unstable.",
+         name.c_str());
   }
 
   if (name.startsWith("chpl_")) {
-    builder_.addPostParseWarning(node,
+    warn(node,
         "symbol names beginning with 'chpl_' (%s) are unstable.", name.c_str());
   }
 }

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -702,7 +702,7 @@ void Visitor::checkPrivateDecl(const Decl* node) {
   if (!enclosingDecl) return;
 
   if (enclosingDecl->isFunction()) {
-    error(node, "private declarations within function bodies are meaningless.");
+    warn(node, "private declarations within function bodies are meaningless.");
 
   } else if (enclosingDecl->isAggregateDecl() && !node->isTypeDecl()) {
     CHPL_POSTPARSE_REPORT(builder_, CantApplyPrivate, node,
@@ -716,11 +716,11 @@ void Visitor::checkPrivateDecl(const Decl* node) {
       }
 
     } else if (parent(0)->isBlock() && !isParentFalseBlock(0)) {
-      error(node, "private declarations within nested blocks are meaningless.");
+      warn(node, "private declarations within nested blocks are meaningless.");
 
     } else if (parent(0) != mod) {
-      error(node, "private declarations are meaningless outside "
-                  "of module level declarations.");
+      warn(node, "private declarations are meaningless outside "
+                 "of module level declarations.");
     }
   }
 }

--- a/test/parsing/errors/stringLiteralEOF-detailed.good
+++ b/test/parsing/errors/stringLiteralEOF-detailed.good
@@ -1,8 +1,5 @@
-─── syntax in stringLiteralEOF.chpl:1 [ParseSyntax] ───
+─── syntax in stringLiteralEOF.chpl:1 ───
   End-of-line in a string literal without a preceding backslash.
-      |
-    1 | var x : string = "unterminated
-      |
 
 ─── syntax in stringLiteralEOF.chpl:1 [StringLiteralEOF] ───
   End-of-file in string literal.


### PR DESCRIPTION
Miscellaneous tweaks for the error system, such as:

* Removal of `ParseError` and `ParseSyntax` in favor of `GeneralError`
* Removal of `_NOTE` and `_SYNTAX` macros where appropriate (`NOTE` in particular will likely never be needed, since it's superseded by `ErrorWriter::note` calls from `ErrorBase::write`. 
* Merging of "empty `ID` or empty `Location`" logic into an `IdOrLocation` class to help reduce duplication.
* Switch from macros like `CHPL_REPORT` to `error` and `syntax` methods where possible (in particular for generic errors without special classes)
* Rename `ErrorType::GENERAL` to `ErrorType::General` to match every other generated `ErrorType`.

Reviewed by @dlongnecke-cray - thanks!

Testing:
- [x] Paratest