### PR TITLE
fix(build): adjust Makefile path for building parser

### DIFF
--- a/frontend/Makefile.help
+++ b/frontend/Makefile.help
@@ -65,7 +65,7 @@ $(LIBCOMPILER_BUILD_DIR):
 	    -DBUILD_SHARED_LIBS=OFF
 
 parser: $(LIBCOMPILER_BUILD_DIR) FORCE
-	cd $(LIBCOMPILER_BUILD_DIR)/lib/parsing && $(CMAKE) --build . --target parser
+	cd $(LIBCOMPILER_BUILD_DIR)/frontend/lib/parsing && $(CMAKE) --build . --target parser
 
 chpldoc: $(LIBCOMPILER_BUILD_DIR) FORCE
 	+cd $(LIBCOMPILER_BUILD_DIR)/tools/chpldoc && $(CMAKE) --build . --target chpldoc


### PR DESCRIPTION
This PR adjusts the path used when building the parser
using the `make parser` command. The change allows for 
building of the parser where it would fail before due to
an invalid path specification. 

I believe this was caused by changes to `frontend/Makefile.help` in https://github.com/chapel-lang/chapel/pull/20815
that were modified with https://github.com/chapel-lang/chapel/pull/20920

Thanks to @DanilaFe for reporting this!

TESTING:

- [x] can `make parser` again

reviewed by @dlongnecke-cray - thanks!