### PR TITLE
fix(build): add chpl .cpp sources back to ETAGS command input

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -46,7 +46,13 @@ endif
 
 #
 # include source subdirectories here
-#
+# include these subdirs so ETAGS builds tags for .cpp files too
+include adt/Makefile.include
+include AST/Makefile.include
+include backend/Makefile.include
+include codegen/Makefile.include
+include llvm/Makefile.include
+include main/Makefile.include
 include ../frontend/lib/immediates/Makefile.include
 include ../frontend/lib/parsing/Makefile.include
 include ../frontend/lib/framework/Makefile.include
@@ -54,6 +60,12 @@ include ../frontend/lib/resolution/Makefile.include
 include ../frontend/lib/types/Makefile.include
 include ../frontend/lib/uast/Makefile.include
 include ../frontend/lib/util/Makefile.include
+include optimizations/Makefile.include
+include parser/Makefile.include
+include passes/Makefile.include
+include resolution/Makefile.include
+include util/Makefile.include
+
 
 TARGETS = $(CHPL)
 


### PR DESCRIPTION
This PR adds the compiler sources (.cpp files) back to the ETAGS
command input. The sources were previously dropped in https://github.com/chapel-lang/chapel/pull/20920.

