### PR TITLE
Add a retry to get commits payload step

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -26,9 +26,9 @@ jobs:
           LOG: ${{github.event.pull_request.body}}
         uses: nick-fields/retry@v2
         with:
-				max_attempts: 3
-				retry_on: error
-				timeout_seconds: 60  
+        max_attempts: 3
+			  retry_on: error
+			  timeout_seconds: 60  
         run: |
               curl --location --request GET $COMMIT_URL --header 'X-API-Key: ${{ secrets.GITHUB_TOKEN}}' -o commits.json
               echo "AUTHOR=$(jq -r '.[0].commit.author.name' commits.json)" >> $GITHUB_ENV   

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -27,8 +27,8 @@ jobs:
         uses: nick-fields/retry@v2
         with:
         max_attempts: 3
-			  retry_on: error
-			  timeout_seconds: 60  
+        retry_on: error
+        timeout_seconds: 60  
         run: |
               curl --location --request GET $COMMIT_URL --header 'X-API-Key: ${{ secrets.GITHUB_TOKEN}}' -o commits.json
               echo "AUTHOR=$(jq -r '.[0].commit.author.name' commits.json)" >> $GITHUB_ENV   

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -24,6 +24,11 @@ jobs:
         env:
           COMMIT_URL: ${{github.event.pull_request._links.commits.href}}
           LOG: ${{github.event.pull_request.body}}
+        uses: nick-fields/retry@v2
+        with:
+				max_attempts: 3
+				retry_on: error
+				timeout_seconds: 60  
         run: |
               curl --location --request GET $COMMIT_URL --header 'X-API-Key: ${{ secrets.GITHUB_TOKEN}}' -o commits.json
               echo "AUTHOR=$(jq -r '.[0].commit.author.name' commits.json)" >> $GITHUB_ENV   


### PR DESCRIPTION
To address issue in https://github.com/Cray/chapel-private/issues/4149

Added a retry logic in case of failure in get commits payload step.



Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>