### PR TITLE
Make bigint mod operator operate on local copies

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -1156,7 +1156,8 @@ module BigInteger {
       mpz_tdiv_r(c.mpz, a.mpz, b.mpz);
     } else {
       const a_ = a;
-      mpz_tdiv_r(c.mpz, a_.mpz, b.mpz);
+      const b_ = b;
+      mpz_tdiv_r(c.mpz, a_.mpz, b_.mpz);
     }
 
     return c;


### PR DESCRIPTION
The modulus operator, when operating on remote data, was only creating a local copy of the LHS bigint value, so if the RHS was remote, this would cause a gasnet error.