### PR TITLE
fix(build): write temp git-sha file to temp location

### DIFF
--- a/util/config/write-git-sha
+++ b/util/config/write-git-sha
@@ -4,6 +4,7 @@ import os
 import errno
 import argparse
 import subprocess
+import tempfile
 
 parser = argparse.ArgumentParser(description='Write the git SHA to git-version.cpp')
 parser.add_argument('location', help='The location to write git-version.cpp')
@@ -13,8 +14,15 @@ parser.add_argument('--chpl-home', dest='chpl_home', help='the location of the c
 
 args = parser.parse_args()
 
+# Write the git-sha to a .cpp file so we can include it in our version info string
+# Some users don't like the SHA being there because it causes re-linking after
+# every new commit, even when no source files changed. The CHPL_DONT_BUILD_SHA
+# env var will replace the actual SHA with a dummy, so re-linking will not occur
+# For normal usage, we write a temp file and then use the update-if-different
+# script to update the contents of git-version.cpp if they differ
+# The update-if-different script takes care of deleting the temp file
 out_file = os.path.join(args.location, 'git-version.cpp')
-tmp_file = os.path.join(args.location, 'git-version.cpp.in')
+(_,tmp_file) = tempfile.mkstemp(prefix='chpl-git-version-deleteme', suffix=".in", text=True)
 update_if_diff = os.path.join(args.chpl_home,'util/config/update-if-different')
 build_version_file = os.path.join(args.chpl_home, 'compiler/main/BUILD_VERSION')
 


### PR DESCRIPTION
This PR makes a small but important change to how we generate
the `git-version.cpp` file. Rather than write the temp file
in-source, we will now write it to a temp directory to avoid
the possibility of getting a race condition when using an IDE
that supports multiple build configurations (e.g., CLion).

TESTING: 

- [x] parallel configurations work in CLion
- [x] can build with python3
- [x] can build with python2.7

reviewed by @dlongnecke-cray - thank you!