### PR TITLE
Update future for 12055 global extern record containing array

### DIFF
--- a/test/extern/ferguson/bug-global-c-array.bad
+++ b/test/extern/ferguson/bug-global-c-array.bad
@@ -1,0 +1,8 @@
+bug-global-c-array.chpl:16: internal error: COD-CG--XPR-0590 chpl version 1.30.0 pre-release (b72fbacc85)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/extern/ferguson/bug-global-c-array.chpl
+++ b/test/extern/ferguson/bug-global-c-array.chpl
@@ -1,3 +1,5 @@
+use CTypes;
+
 extern record myrec {
   var a: c_int;
   var b: c_ptr(c_int);

--- a/test/extern/ferguson/bug-global-c-array.future
+++ b/test/extern/ferguson/bug-global-c-array.future
@@ -1,2 +1,4 @@
 bug: compilation errors for global extern record containing array
 #12055
+
+Remove the skipif once this works non-CHPL_COMM=none

--- a/test/extern/ferguson/bug-global-c-array.skipif
+++ b/test/extern/ferguson/bug-global-c-array.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM == none


### PR DESCRIPTION
Update the #12055 future.

Add "use CTypes" to test.
Add .bad file for internal error with COMM=gasnet
Add skipif since internal error doesn't happen with COMM=none
