### PR TITLE
Update and defuturize types/records/ferguson/leak-futures

### DIFF
--- a/test/types/records/ferguson/leak-futures/iterate-loop-break.chpl
+++ b/test/types/records/ferguson/leak-futures/iterate-loop-break.chpl
@@ -2,7 +2,7 @@ use myrecord;
 
 proc make(i:int) {
   var ret: R;
-  ret.init(x = i);
+  ret.setup(x = i);
   ret.verify();
   return ret;
 }

--- a/test/types/records/ferguson/leak-futures/iterate-loop-break.future
+++ b/test/types/records/ferguson/leak-futures/iterate-loop-break.future
@@ -1,3 +1,0 @@
-bug: iterator 1 leaks memory if caller breaks out of loop
-
-see issue #6540

--- a/test/types/records/ferguson/leak-futures/iterate-loop-break2.chpl
+++ b/test/types/records/ferguson/leak-futures/iterate-loop-break2.chpl
@@ -2,7 +2,7 @@ use myrecord;
 
 proc make(i:int) {
   var ret: R;
-  ret.init(x = i);
+  ret.setup(x = i);
   ret.verify();
   return ret;
 }

--- a/test/types/records/ferguson/leak-futures/iterate-loop-break2.future
+++ b/test/types/records/ferguson/leak-futures/iterate-loop-break2.future
@@ -1,3 +1,0 @@
-bug: iterator 2 leaks memory if caller breaks out of loop
-
-see issue #6540

--- a/test/types/records/ferguson/leak-futures/iterate-twice-break.chpl
+++ b/test/types/records/ferguson/leak-futures/iterate-twice-break.chpl
@@ -2,7 +2,7 @@ use myrecord;
 
 proc make(i:int) {
   var ret: R;
-  ret.init(x = i);
+  ret.setup(x = i);
   ret.verify();
   return ret;
 }

--- a/test/types/records/ferguson/leak-futures/iterate-twice-break.future
+++ b/test/types/records/ferguson/leak-futures/iterate-twice-break.future
@@ -1,3 +1,0 @@
-bug: non-inlined iterator leaks memory if caller breaks out of loop
-
-see issue #6540

--- a/test/types/records/ferguson/tracking-record/myrecord.chpl
+++ b/test/types/records/ferguson/tracking-record/myrecord.chpl
@@ -1,5 +1,5 @@
 /* This test record keeps a class pointer hanging off of
-   a field an tracks allocation/free operations on that
+   a field and tracks allocation/free operations on that
    class pointer.
  */
 

--- a/test/types/records/ferguson/tracking/Tracking.chpl
+++ b/test/types/records/ferguson/tracking/Tracking.chpl
@@ -93,7 +93,7 @@ proc checkAllocations() {
 
   proc printthem(arr)
   {
-    for id in sorted(arr.valuesToArray()) {
+    for id in sorted(arr.keysToArray()) {
       write("(id=", id, " x=", to_x[id], ") ");
     }
   }
@@ -131,4 +131,3 @@ proc checkAllocations() {
   }
   return true;
 }
-


### PR DESCRIPTION
Fix Tracking.chpl printthem() to use arr keys instead of values to index into to_x.  This fixed a Map out-of-bounds error in at least iterate-twice-break.chpl.

Fix the make() routine in iterate-twice-break, iterate-loop-break, iterate-loop-break2 to call ret.setup() instead of ret.init().  This seems to resolve the leaks -- self-reported and via --memLeaks=true.

Remove those tests' futures, as they now pass.

Fix a typo in myrecord.chpl
