### PR TITLE
Paratest the slowest directories first

### DIFF
--- a/util/test/find_slow_tests.py
+++ b/util/test/find_slow_tests.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+'''
+Report or reason about chpl test (compilation, execution, directory) times.
+'''
+
+import re
+import argparse
+
+def create_parser():
+    ''' Create argument parser '''
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--timefile', help='file with test/dir timings', required=True)
+    parser.add_argument('-n', type=int, default=10, help='number of tests/dirs to report')
+    parser.add_argument('--sort-list', nargs='+', help='sort list of tests/dirs based on times from timefile')
+
+    parser.set_defaults(mode='execution')
+    parser.add_argument('--compilation', action='store_const', dest='mode', const='compilation')
+    parser.add_argument('--execution',   action='store_const', dest='mode', const='execution')
+    parser.add_argument('--directory',   action='store_const', dest='mode', const='directory')
+
+    return parser
+
+
+def get_pattern(mode):
+    ''' Get regex pattern used to extract (test/dir, time) data '''
+    if mode =='directory':
+        pattern = re.compile('\[Finished subtest "(.*)" - (.*) seconds')
+    else:
+        pattern = re.compile('\[Elapsed {} time for "(.*)" - (.*) seconds'.format(mode))
+    return pattern
+
+
+def sort_chpl_tests(tests, timing_file, mode):
+    '''
+    Sort a lists of tests (comp, exec, or dir according to mode) using
+    historical data in the timing file
+    '''
+    try:
+        # Pull timings into dict, use to sort tests, put unknown tests early
+        pattern = get_pattern(mode)
+        with open(timing_file, 'r') as f:
+            times = {m.group(1): float(m.group(2)) for m in pattern.finditer(f.read())}
+        tests.sort(reverse=True, key=lambda test: times.get(test.lstrip('./'), 1000.0))
+    except FileNotFoundError:
+        pass
+
+    return tests
+
+
+def _main():
+    args = create_parser().parse_args()
+
+    if args.sort_list:
+        print(' '.join(sort_chpl_tests(args.sort_list, args.timefile, args.mode)))
+    else:
+        with open(args.timefile, 'r') as f:
+            pattern = get_pattern(args.mode)
+            res = [(float(m.group(2)), m.group(1)) for m in pattern.finditer(f.read())]
+            res.sort(reverse=True)
+
+        print('Top {} {}:'.format(args.n, args.mode))
+        for r in res[:args.n]:
+            print(r)
+
+if __name__ == '__main__':
+    _main()
+
+
+

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -51,6 +51,7 @@ $show_all_errors = 0;
 $junit_xml = 0;
 $junit_xml_file = "";
 $junit_remove_prefix = "";
+$timing_file = "";
 # Once a node has timed out, we don't send it any more work, so this timeout
 # should be set higher than the time needed to process the largest directory.
 # -1 means "never time out".
@@ -164,6 +165,11 @@ sub collect_logs {
 
     systemd ("cat $fin_log.summary >> $fin_log");
 
+    # generate subtest/dir timings
+    if ($timing_file ne "" &&  int($failures) < 10) {
+        systemd ("grep -a '^\\[Finished subtest' $fin_log > $timing_file");
+    }
+
     print "\n[Summary: #Successes = $successes | #Failures = $failures | #Futures = $futures]\n";
 
 }
@@ -220,7 +226,6 @@ sub feed_nodes {
       print $activate_venv_output;
       systemd ("echo '$activate_venv_output' >> $fin_logfile");
     } else {
-      @testdir_list = sort @testdir_list;
       print $nodeCount; print " worker(s) (@node_list)\n";
       print "timeout = $timeout\n" if $debug > 0;
       my $startCount = $#testdir_list + 1;
@@ -784,6 +789,11 @@ sub main {
         } else {
             print "[Collecting test directories in $cwd]\n";
             @testdir_list = find_subdirs (".", 0);
+            $comm = `$ENV{CHPL_HOME}/util/chplenv/chpl_comm.py`; chomp $comm;
+            $timing_dir = "$ENV{HOME}/.chpl/paratest_times";
+            systemd ("mkdir -p $timing_dir");
+            $timing_file = "$timing_dir/comm-$comm-dir-times";
+            @testdir_list = split(' ', `$ENV{CHPL_HOME}/util/test/find_slow_tests.py --directory --timefile $timing_file --sort-list @testdir_list`);
         }
     }
 


### PR DESCRIPTION
Paratest farms out directories to worker nodes to parallelize and speed up testing. Previously, it farmed out in lexicographic order, but this could result in a long tail of tests if a long running directory was handed out near the end. This updates paratest to try and run the slowest directories first. It does this by extracting directory timings from a previous test log into a file in `$HOME/.chpl/paratest_times/`.

For this first version, only save the historical data if we're running the full test suite and there were less than 10 failures. Results are saved into comm layer specific files since `comm==none` vs `comm!=none` will likely have a big impact on what tests are run and how long they take.  Longer term, we may want to include other things that impact results (valgrind/asan, headnode/slurm-partition) and we'll want to be able to store and use results if a subset of tests are run. Using old results makes sense, but it's not obvious when we should override historical results (don't want to throw away a full test suite of data when running a few directories.)

This should have a non-trivial impact on parallel testing speed by getting rid of a long tail. On chapdl this takes a std paratest from 13 minutes to 8 minutes.

The script to sort directories also has code to identify long running tests/directories. I've been using an earlier version of this to find and speed up slow running executables and dirs and thought it'd be useful to have committed.

Part of Cray/chapel-private#3211