### PR TITLE
Avoid loading CUDA module at each kernel launch

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4924,7 +4924,7 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   return codegenCallExprWithArgs(fn, args);
 #else
   INT_FATAL("Unexpected code path: gpu code generation without LLVM as target");
-  return NULL;
+  return nullptr;
 #endif
 }
 

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4838,6 +4838,9 @@ static bool isCStringImmediate(Symbol* sym) {
 }
 
 static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
+#ifdef HAVE_LLVM  // Needed to suppress warning; should always be true in code
+                  // path for GPU codegen
+                  //
   // Used to codegen for PRIM_GPU_KERNEL_LAUNCH_FLAT and PRIM_GPU_KERNEL_LAUNCH.
   // They differ in number of arguments only. The first passes 1 integer for
   // grid and block size each, the other passes 3 for each.
@@ -4871,15 +4874,6 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   std::vector<GenRet> args;
   args.push_back(new_IntSymbol(call->astloc.lineno()));
   args.push_back(new_IntSymbol(gFilenameLookupCache[call->astloc.filename()]));
-
-  // We will emit the gpu code into a global variable named chpl_gpuBinary. Pass
-  // this variable to the launch call.
-  #ifdef HAVE_LLVM  // Needed to suppress warning; should always be true in code path for GPU codegen
-    GenInfo* info = gGenInfo;
-    args.push_back(info->lvt->getValue("chpl_gpuBinary"));
-  #else
-    INT_FATAL("Unexpected code path: gpu code generation without LLVM as target");
-  #endif
 
   // "Copy" arguments from primitive call to runtime library function call.
   int curArg = 1;
@@ -4928,6 +4922,10 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   }
 
   return codegenCallExprWithArgs(fn, args);
+#else
+  INT_FATAL("Unexpected code path: gpu code generation without LLVM as target");
+  return NULL;
+#endif
 }
 
 DEFINE_PRIM(GPU_KERNEL_LAUNCH_FLAT) {

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4840,7 +4840,7 @@ static bool isCStringImmediate(Symbol* sym) {
 static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
 #ifdef HAVE_LLVM  // Needed to suppress warning; should always be true in code
                   // path for GPU codegen
-                  //
+
   // Used to codegen for PRIM_GPU_KERNEL_LAUNCH_FLAT and PRIM_GPU_KERNEL_LAUNCH.
   // They differ in number of arguments only. The first passes 1 integer for
   // grid and block size each, the other passes 3 for each.

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -606,25 +606,6 @@ void GpuKernel::generateEarlyReturn() {
   fn_->insertAtTail(new CondStmt(new SymExpr(isOOB), thenBlock));
 }
 
-void GpuKernel::optimizeBody(FnSymbol *outlinedFunction) {
-
-  if (outlinedFunction->getModule()->modTag == MOD_USER) {
-    std::vector<CallExpr*> calls;
-    collectCallExprs(outlinedFunction, calls);
-
-    int numDerefs = 0;
-    for_vector(CallExpr, call, calls) {
-      if (call->isPrimitive(PRIM_DEREF)) {
-        numDerefs += 1;
-      }
-    }
-
-    if (numDerefs == 2) {
-      std::cout << "Kernel found" << std::endl;
-    }
-  }
-}
-
 void GpuKernel::populateBody(CForLoop *loop, FnSymbol *outlinedFunction) {
   std::set<Symbol*> handledSymbols;
   for_alist(node, loop->body) {

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -606,6 +606,25 @@ void GpuKernel::generateEarlyReturn() {
   fn_->insertAtTail(new CondStmt(new SymExpr(isOOB), thenBlock));
 }
 
+void GpuKernel::optimizeBody(FnSymbol *outlinedFunction) {
+
+  if (outlinedFunction->getModule()->modTag == MOD_USER) {
+    std::vector<CallExpr*> calls;
+    collectCallExprs(outlinedFunction, calls);
+
+    int numDerefs = 0;
+    for_vector(CallExpr, call, calls) {
+      if (call->isPrimitive(PRIM_DEREF)) {
+        numDerefs += 1;
+      }
+    }
+
+    if (numDerefs == 2) {
+      std::cout << "Kernel found" << std::endl;
+    }
+  }
+}
+
 void GpuKernel::populateBody(CForLoop *loop, FnSymbol *outlinedFunction) {
   std::set<Symbol*> handledSymbols;
   for_alist(node, loop->body) {

--- a/runtime/include/chpl-gpu-impl.h
+++ b/runtime/include/chpl-gpu-impl.h
@@ -29,12 +29,12 @@ void chpl_gpu_impl_init(void);
 void chpl_gpu_impl_on_std_modules_finished_initializing(void);
 
 void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
-                                 const char* fatbinData, const char* name,
+                                 const char* name,
                                  int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                  int blk_dim_x, int blk_dim_y, int blk_dim_z,
                                  int nargs, va_list args);
 void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
-                                 const char* fatbinPath, const char* name,
+                                 const char* name,
                                  int num_threads, int blk_dim,
                                  int nargs, va_list args);
 

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -46,6 +46,32 @@ static inline void CHPL_GPU_DEBUG(const char *str, ...) {
   }
 }
 
+#ifdef CHPL_GPU_ENABLE_PROFILE
+static inline long double get_time() {
+  struct timeval tv;
+
+  gettimeofday(&tv, NULL);
+
+  return (tv.tv_sec*1000000.0+tv.tv_usec)/1000.0;
+}
+
+#define CHPL_GPU_START_TIMER(t) \
+  long double t; \
+  long double start_##t; \
+  do { start_##t = get_time(); } while(0);
+
+#define CHPL_GPU_STOP_TIMER(t) \
+  do { t = get_time()-start_##t; } while(0);
+
+#define CHPL_GPU_PRINT_TIMERS(...) \
+  do { printf(__VA_ARGS__); } while(0);
+
+#else
+#define CHPL_GPU_START_TIMER(t) do {} while(0);
+#define CHPL_GPU_STOP_TIMER(t)
+#define CHPL_GPU_PRINT_TIMERS(...) do {} while(0);
+#endif
+
 static inline bool chpl_gpu_running_on_gpu_locale(void) {
   return chpl_task_getRequestedSubloc()>=0;
 }

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -47,6 +47,7 @@ static inline void CHPL_GPU_DEBUG(const char *str, ...) {
 }
 
 #ifdef CHPL_GPU_ENABLE_PROFILE
+// returns time from epoch in milliseconds. Used in macros below.
 static inline long double get_time() {
   struct timeval tv;
 

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -82,12 +82,12 @@ void chpl_gpu_on_std_modules_finished_initializing(void);
 void chpl_gpu_get_device_count(int* into);
 
 void chpl_gpu_launch_kernel(int ln, int32_t fn,
-                            const char* fatbinData, const char* name,
+                            const char* name,
                             int grd_dim_x, int grd_dim_y, int grd_dim_z,
                             int blk_dim_x, int blk_dim_y, int blk_dim_z,
                             int nargs, ...);
 void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
-                                 const char* fatbinPath, const char* name,
+                                 const char* name,
                                  int num_threads, int blk_dim,
                                  int nargs, ...);
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -42,7 +42,7 @@ void chpl_gpu_on_std_modules_finished_initializing(void) {
   chpl_gpu_impl_on_std_modules_finished_initializing();
 }
 
-inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
+void chpl_gpu_launch_kernel(int ln, int32_t fn,
                             const char* fatbinData, const char* name,
                             int grd_dim_x, int grd_dim_y, int grd_dim_z,
                             int blk_dim_x, int blk_dim_y, int blk_dim_z,
@@ -74,7 +74,7 @@ inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
                  name);
 }
 
-inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
+void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
                                  const char* fatbinData, const char* name,
                                  int num_threads, int blk_dim, int nargs, ...) {
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -42,7 +42,7 @@ void chpl_gpu_on_std_modules_finished_initializing(void) {
   chpl_gpu_impl_on_std_modules_finished_initializing();
 }
 
-void chpl_gpu_launch_kernel(int ln, int32_t fn,
+inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
                             const char* fatbinData, const char* name,
                             int grd_dim_x, int grd_dim_y, int grd_dim_z,
                             int blk_dim_x, int blk_dim_y, int blk_dim_z,
@@ -74,7 +74,7 @@ void chpl_gpu_launch_kernel(int ln, int32_t fn,
                  name);
 }
 
-void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
+inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
                                  const char* fatbinData, const char* name,
                                  int num_threads, int blk_dim, int nargs, ...) {
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -43,7 +43,7 @@ void chpl_gpu_on_std_modules_finished_initializing(void) {
 }
 
 inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
-                                   const char* fatbinData, const char* name,
+                                   const char* name,
                                    int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                    int blk_dim_x, int blk_dim_y, int blk_dim_z,
                                    int nargs, ...) {
@@ -62,7 +62,7 @@ inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
   chpl_gpu_diags_incr(kernel_launch);
 
   chpl_gpu_impl_launch_kernel(ln, fn,
-                              fatbinData, name,
+                              name,
                               grd_dim_x, grd_dim_y, grd_dim_z,
                               blk_dim_x, blk_dim_y, blk_dim_z,
                               nargs, args);
@@ -75,7 +75,7 @@ inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
 }
 
 inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
-                                        const char* fatbinData, const char* name,
+                                        const char* name,
                                         int num_threads, int blk_dim, int nargs,
                                         ...) {
 
@@ -94,7 +94,7 @@ inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
   chpl_gpu_diags_incr(kernel_launch);
 
   chpl_gpu_impl_launch_kernel_flat(ln, fn,
-                                   fatbinData, name,
+                                   name,
                                    num_threads, blk_dim,
                                    nargs, args);
   va_end(args);

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -43,10 +43,10 @@ void chpl_gpu_on_std_modules_finished_initializing(void) {
 }
 
 inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
-                            const char* fatbinData, const char* name,
-                            int grd_dim_x, int grd_dim_y, int grd_dim_z,
-                            int blk_dim_x, int blk_dim_y, int blk_dim_z,
-                            int nargs, ...) {
+                                   const char* fatbinData, const char* name,
+                                   int grd_dim_x, int grd_dim_y, int grd_dim_z,
+                                   int blk_dim_x, int blk_dim_y, int blk_dim_z,
+                                   int nargs, ...) {
   CHPL_GPU_DEBUG("Kernel launcher called. (subloc %d)\n"
                  "\tKernel: %s\n"
                  "\tNumArgs: %d\n",
@@ -75,8 +75,9 @@ inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
 }
 
 inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
-                                 const char* fatbinData, const char* name,
-                                 int num_threads, int blk_dim, int nargs, ...) {
+                                        const char* fatbinData, const char* name,
+                                        int num_threads, int blk_dim, int nargs,
+                                        ...) {
 
   CHPL_GPU_DEBUG("Kernel launcher called. (subloc %d)\n"
                  "\tKernel: %s\n"

--- a/runtime/src/gpu/common/cuda-shared.h
+++ b/runtime/src/gpu/common/cuda-shared.h
@@ -45,7 +45,6 @@ void* chpl_gpu_load_function(CUmodule cuda_module, const char* kernel_name) {
   assert(function);
 
   return (void*)function;
-
 }
 
 // this is part of the interface (used by the module code as an extern)

--- a/runtime/src/gpu/common/cuda-shared.h
+++ b/runtime/src/gpu/common/cuda-shared.h
@@ -28,18 +28,24 @@
 #include "cuda-utils.h"
 
 static inline
-void* chpl_gpu_getKernel(const char* fatbinData, const char* kernelName) {
+void* chpl_gpu_load_module(const char* fatbin_data) {
+  CUmodule cuda_module;
 
-  CUmodule    cudaModule;
-  CUfunction  function;
+  CUDA_CALL(cuModuleLoadData(&cuda_module, fatbin_data));
+  assert(cuda_module);
 
-  // Create module for object
-  CUDA_CALL(cuModuleLoadData(&cudaModule, fatbinData));
+  return (void*)cuda_module;
+}
 
-  // Get kernel function
-  CUDA_CALL(cuModuleGetFunction(&function, cudaModule, kernelName));
+static inline
+void* chpl_gpu_load_function(CUmodule cuda_module, const char* kernel_name) {
+  CUfunction function;
+
+  CUDA_CALL(cuModuleGetFunction(&function, cuda_module, kernel_name));
+  assert(function);
 
   return (void*)function;
+
 }
 
 // this is part of the interface (used by the module code as an extern)

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -42,7 +42,10 @@
 extern const char* chpl_gpuBinary;
 
 static CUcontext *chpl_gpu_primary_ctx;
+//
+// array indexed by device ID (we load the same module once for each GPU). 
 static CUmodule *chpl_gpu_cuda_modules;
+
 static int *deviceClockRates;
 
 

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -177,9 +177,6 @@ bool chpl_gpu_impl_is_host_ptr(const void* ptr) {
   return true;
 }
 
-#ifdef CHPL_GPU_PROFILE
-#endif
-
 static void chpl_gpu_launch_kernel_help(int ln,
                                         int32_t fn,
                                         const char* name,
@@ -217,8 +214,7 @@ static void chpl_gpu_launch_kernel_help(int ln,
   bool* was_memory_dynamically_allocated_for_kernel_param =
     chpl_malloc(nargs*sizeof(bool));
 
-  int i;
-  for (i=0 ; i<nargs ; i++) {
+  for (int i=0 ; i<nargs ; i++) {
     void* cur_arg = va_arg(args, void*);
     size_t cur_arg_size = va_arg(args, size_t);
 

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -261,7 +261,7 @@ static void chpl_gpu_launch_kernel_help(int ln,
   CHPL_GPU_START_TIMER(teardown_time);
 
   // free GPU memory allocated for kernel parameters
-  for (i=0 ; i<nargs ; i++) {
+  for (int i=0 ; i<nargs ; i++) {
     if (was_memory_dynamically_allocated_for_kernel_param[i]) {
       chpl_gpu_mem_free(*kernel_params[i], ln, fn);
     }

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -115,6 +115,11 @@ void chpl_gpu_impl_init() {
     chpl_gpu_primary_ctx[i] = context;
   }
 
+  // TODO should we have a current context set at this point?
+  // we need it to load the module, but how does that work with multi GPU setup?
+  if (!chpl_gpu_has_context()) {
+    CUDA_CALL(cuCtxPushCurrent(chpl_gpu_primary_ctx[0]));
+  }
   chpl_gpu_cuda_module = chpl_gpu_load_module(chpl_gpuBinary);
 }
 
@@ -177,7 +182,6 @@ bool chpl_gpu_impl_is_host_ptr(const void* ptr) {
 
 static void chpl_gpu_launch_kernel_help(int ln,
                                         int32_t fn,
-                                        const char* fatbinData,
                                         const char* name,
                                         int grd_dim_x,
                                         int grd_dim_y,
@@ -280,7 +284,6 @@ static void chpl_gpu_launch_kernel_help(int ln,
 }
 
 inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
-                                        const char* fatbinData,
                                         const char* name,
                                         int grd_dim_x,
                                         int grd_dim_y,
@@ -290,14 +293,13 @@ inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
                                         int blk_dim_z,
                                         int nargs, va_list args) {
   chpl_gpu_launch_kernel_help(ln, fn,
-                              fatbinData, name,
+                              name,
                               grd_dim_x, grd_dim_y, grd_dim_z,
                               blk_dim_x, blk_dim_y, blk_dim_z,
                               nargs, args);
 }
 
 inline void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
-                                             const char* fatbinData,
                                              const char* name,
                                              int num_threads,
                                              int blk_dim,
@@ -306,7 +308,7 @@ inline void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
   int grd_dim = (num_threads+blk_dim-1)/blk_dim;
 
   chpl_gpu_launch_kernel_help(ln, fn,
-                              fatbinData, name,
+                              name,
                               grd_dim, 1, 1,
                               blk_dim, 1, 1,
                               nargs, args);

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -312,7 +312,7 @@ static void chpl_gpu_launch_kernel_help(int ln,
 #endif
 }
 
-void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
+inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
                                  const char* fatbinData, const char* name,
                                  int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                  int blk_dim_x, int blk_dim_y, int blk_dim_z,
@@ -324,7 +324,7 @@ void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
                               nargs, args);
 }
 
-void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
+inline void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
                                       const char* fatbinData, const char* name,
                                       int num_threads, int blk_dim, int nargs,
                                       va_list args) {

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -42,8 +42,8 @@
 extern const char* chpl_gpuBinary;
 
 static CUcontext *chpl_gpu_primary_ctx;
-//
-// array indexed by device ID (we load the same module once for each GPU). 
+
+// array indexed by device ID (we load the same module once for each GPU).
 static CUmodule *chpl_gpu_cuda_modules;
 
 static int *deviceClockRates;

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -226,6 +226,9 @@ static void chpl_gpu_launch_kernel_help(int ln,
   int i;
   chpl_gpu_load_module(fatbinData);
   void* function = chpl_gpu_load_function(name);
+  /*void* function = chpl_gpu_getKernel(fatbinData, name);*/
+
+  
 
   load_time = get_time_in_ms() - start_time;
 

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -38,6 +38,9 @@
 #include <assert.h>
 #include <stdbool.h>
 
+// this is compiler-generated
+extern const char* chpl_gpuBinary;
+
 static CUcontext *chpl_gpu_primary_ctx;
 static int *deviceClockRates;
 
@@ -111,6 +114,8 @@ void chpl_gpu_impl_init() {
 
     chpl_gpu_primary_ctx[i] = context;
   }
+
+  chpl_gpu_cuda_module = chpl_gpu_load_module(chpl_gpuBinary);
 }
 
 static bool chpl_gpu_device_alloc = false;
@@ -189,9 +194,7 @@ static void chpl_gpu_launch_kernel_help(int ln,
   CHPL_GPU_STOP_TIMER(context_time);
   CHPL_GPU_START_TIMER(load_time);
 
-  if (chpl_gpu_cuda_module == NULL) {
-    chpl_gpu_cuda_module = chpl_gpu_load_module(fatbinData);
-  }
+  assert(chpl_gpu_cuda_module);
   void* function = chpl_gpu_load_function(chpl_gpu_cuda_module, name);
 
   CHPL_GPU_STOP_TIMER(load_time);

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -313,10 +313,15 @@ static void chpl_gpu_launch_kernel_help(int ln,
 }
 
 inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
-                                 const char* fatbinData, const char* name,
-                                 int grd_dim_x, int grd_dim_y, int grd_dim_z,
-                                 int blk_dim_x, int blk_dim_y, int blk_dim_z,
-                                 int nargs, va_list args) {
+                                        const char* fatbinData,
+                                        const char* name,
+                                        int grd_dim_x,
+                                        int grd_dim_y,
+                                        int grd_dim_z,
+                                        int blk_dim_x,
+                                        int blk_dim_y,
+                                        int blk_dim_z,
+                                        int nargs, va_list args) {
   chpl_gpu_launch_kernel_help(ln, fn,
                               fatbinData, name,
                               grd_dim_x, grd_dim_y, grd_dim_z,
@@ -325,9 +330,12 @@ inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
 }
 
 inline void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
-                                      const char* fatbinData, const char* name,
-                                      int num_threads, int blk_dim, int nargs,
-                                      va_list args) {
+                                             const char* fatbinData,
+                                             const char* name,
+                                             int num_threads,
+                                             int blk_dim,
+                                             int nargs,
+                                             va_list args) {
   int grd_dim = (num_threads+blk_dim-1)/blk_dim;
 
   chpl_gpu_launch_kernel_help(ln, fn,

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -42,7 +42,6 @@ static CUcontext *chpl_gpu_primary_ctx;
 static int *deviceClockRates;
 
 static CUmodule chpl_gpu_cuda_module;
-static void* function_table[256];
 
 static bool chpl_gpu_has_context() {
   CUcontext cuda_context = NULL;
@@ -111,10 +110,6 @@ void chpl_gpu_impl_init() {
     cuDeviceGetAttribute(&deviceClockRates[i], CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device);
 
     chpl_gpu_primary_ctx[i] = context;
-  }
-
-  for (i=0 ; i<256 ; i++) {
-    function_table[i] = NULL;
   }
 }
 

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -312,7 +312,7 @@ static void chpl_gpu_launch_kernel_help(int ln,
 #endif
 }
 
-inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
+void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
                                  const char* fatbinData, const char* name,
                                  int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                  int blk_dim_x, int blk_dim_y, int blk_dim_z,
@@ -324,7 +324,7 @@ inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
                               nargs, args);
 }
 
-inline void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
+void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
                                       const char* fatbinData, const char* name,
                                       int num_threads, int blk_dim, int nargs,
                                       va_list args) {

--- a/runtime/src/gpu/rocm/gpu-rocm.c
+++ b/runtime/src/gpu/rocm/gpu-rocm.c
@@ -45,13 +45,13 @@ void chpl_gpu_get_device_count(int* into) {
 }
 
 void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
-                                 const char* fatbinData, const char* name,
+                                 const char* name,
                                  int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                  int blk_dim_x, int blk_dim_y, int blk_dim_z,
                                  int nargs, va_list args) {}
 
 void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
-                                      const char* fatbinData, const char* name,
+                                      const char* name,
                                       int num_threads, int blk_dim, int nargs,
                                       va_list args) {}
 

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -88,7 +88,12 @@ proc main() {
       //
       // This forall loop will be offloaded onto the GPU.
       forall (a, b, c) in zip(A, B, C) do
-        a = b + alpha * c;
+        a = b + c;
+
+      // can we do direct indexing? And what would be the difference?
+      // we will have separate induction variables here, that may cause multiple
+      // muls
+      // try changing the array iterator do a memory walk.
 
       execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
     }

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -11,6 +11,8 @@ use GPUDiagnostics;
 //
 use HPCCProblemSize;
 
+config param useForeach = true;
+
 //
 // The number of vectors and element type of those vectors
 //
@@ -87,13 +89,12 @@ proc main() {
       // Compute the multiply-add on b and c, storing the result to a.
       //
       // This forall loop will be offloaded onto the GPU.
-      foreach (a, b, c) in zip(A, B, C) do
-        a = b + alpha * c;
-
-      // can we do direct indexing? And what would be the difference?
-      // we will have separate induction variables here, that may cause multiple
-      // muls
-      // try changing the array iterator do a memory walk.
+      if useForeach then
+        foreach (a, b, c) in zip(A, B, C) do
+          a = b + alpha * c;
+      else
+        forall (a, b, c) in zip(A, B, C) do
+          a = b + alpha * c;
 
       execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
     }

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -87,7 +87,8 @@ proc main() {
       // Compute the multiply-add on b and c, storing the result to a.
       //
       // This forall loop will be offloaded onto the GPU.
-      forall (a, b, c) in zip(A, B, C) do
+      /*forall (a, b, c) in zip(A, B, C) do*/
+      foreach (a, b, c) in zip(A, B, C) do
         a = b + c;
 
       // can we do direct indexing? And what would be the difference?

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -87,9 +87,8 @@ proc main() {
       // Compute the multiply-add on b and c, storing the result to a.
       //
       // This forall loop will be offloaded onto the GPU.
-      /*forall (a, b, c) in zip(A, B, C) do*/
       foreach (a, b, c) in zip(A, B, C) do
-        a = b + c;
+        a = b + alpha * c;
 
       // can we do direct indexing? And what would be the difference?
       // we will have separate induction variables here, that may cause multiple


### PR DESCRIPTION
This PR improves GPU kernel launch times by loading the binary CUDA module only
once per locale.

Previously, we used to re-load the module everytime we launch a kernel. There
was nothing smart behind it -- it was an artifact from earlier prototypes.

The change is relatively straightforward. The only interesting note is that
it appears that you have to load the module per context (i.e., per device).
Which is a bit strange, but that's what the documentation says and not doing
it that way breaks multi-gpu execution.

While there, this test also changes the stream prototype to use `foreach`
instead of `forall` to make it a more apples-to-apples comparison to a
single-GPU C+CUDA reference. `forall` option is available with a `config param`.

On my A100 based system, I am seeing 250 GB/s as opposed to 235 GB/s bandwidth
using 1GB vectors. 250 GB/s is also what I get on an NVIDIA bandwidth test.

Test:
- [x] gpu/native
- [x] AMD prototype