### PR TITLE
Add paratest.chapdl wrapper

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -112,7 +112,7 @@ def get_good_nodepara():
     Get a "good" nodepara value. Currently defaults to 6, but we could adjust
     based on parition, comm, or whether other jobs are running.
     """
-    nodepara = 6
+    nodepara = int(os.getenv('CHPL_TEST_NODEPARA', '6'))
     return nodepara
 
 

--- a/util/test/paratest.chapdl
+++ b/util/test/paratest.chapdl
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+CHPL_TEST_PARTITION=chapdl CHPL_TEST_NODEPARA=8 $CWD/paratest.chapcs $@


### PR DESCRIPTION
Add paratest.chapdl as a variant of paratest.chapcs that sets the new partition and increases oversubscription.