### PR TITLE
refactor(uast):  rename Attributes and move to AstNode

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -257,7 +257,7 @@ struct Converter {
     return nullptr;
   }
 
-  Expr* visit(const uast::Attributes* node) {
+  Expr* visit(const uast::AttributeGroup* node) {
     INT_FATAL("Should not be called directly!");
     return nullptr;
   }
@@ -276,7 +276,7 @@ struct Converter {
   }
 
   void attachSymbolAttributes(const uast::Decl* node, Symbol* sym) {
-    auto attr = node->attributes();
+    auto attr = node->attributeGroup();
 
     if (!attr) return;
 

--- a/frontend/include/chpl/framework/all-global-strings.h
+++ b/frontend/include/chpl/framework/all-global-strings.h
@@ -76,6 +76,7 @@ X(uint_          , "uint")
 X(unmanaged      , "unmanaged")
 X(void_          , "void")
 
+X(atMark         , "@")
 X(equals         , "=")
 X(question       , "?")
 X(tripleDot      , "...")

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -347,7 +347,7 @@ ConfigSettingsList& configSettings(Context* context);
   Given an ID, returns the attributes associated with the ID. Only
   declarations can have associated attributes.
  */
-const uast::Attributes* idToAttributes(Context* context, ID id);
+const uast::AttributeGroup* idToAttributeGroup(Context* context, ID id);
 
 /**
   Given an ID 'idMention' representing a mention of a symbol, and an

--- a/frontend/include/chpl/uast/AggregateDecl.h
+++ b/frontend/include/chpl/uast/AggregateDecl.h
@@ -62,14 +62,14 @@ class AggregateDecl : public TypeDecl {
   }
 
  public:
-  AggregateDecl(AstTag tag, AstList children, int attributesChildNum,
+  AggregateDecl(AstTag tag, AstList children, int attributeGroupChildNum,
                 Decl::Visibility vis,
                 Decl::Linkage linkage,
                 int linkageNameChildNum,
                 UniqueString name,
                 int elementsChildNum,
                 int numElements)
-    : TypeDecl(tag, std::move(children), attributesChildNum, vis, linkage,
+    : TypeDecl(tag, std::move(children), attributeGroupChildNum, vis, linkage,
                linkageNameChildNum,
                name),
       elementsChildNum_(elementsChildNum),

--- a/frontend/include/chpl/uast/AttributeGroup.h
+++ b/frontend/include/chpl/uast/AttributeGroup.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_UAST_ATTRIBUTES_H
-#define CHPL_UAST_ATTRIBUTES_H
+#ifndef CHPL_UAST_ATTRIBUTE_GROUP_H
+#define CHPL_UAST_ATTRIBUTE_GROUP_H
 
 #include "chpl/framework/Location.h"
 #include "chpl/uast/AstNode.h"
@@ -36,22 +36,22 @@ namespace uast {
   Compiler pragmas and deprecation messages (both intended for internal
   use only) are both examples of attributes.
 */
-class Attributes final : public AstNode {
+class AttributeGroup final : public AstNode {
  private:
   std::set<PragmaTag> pragmas_;
   bool isDeprecated_;
-  bool isUnstable_; //new
+  bool isUnstable_;
   UniqueString deprecationMessage_;
-  UniqueString unstableMessage_; //new
+  UniqueString unstableMessage_;
 
   // TODO: Do we want to preserve the location of string literals used in
   // pragmas and deprecation messages?
-  Attributes(std::set<PragmaTag> pragmas,
-             bool isDeprecated,
-             bool isUnstable,
-             UniqueString deprecationMessage,
-             UniqueString unstableMessage)
-    : AstNode(asttags::Attributes),
+  AttributeGroup(std::set<PragmaTag> pragmas,
+                 bool isDeprecated,
+                 bool isUnstable,
+                 UniqueString deprecationMessage,
+                 UniqueString unstableMessage)
+    : AstNode(asttags::AttributeGroup),
       pragmas_(std::move(pragmas)),
       isDeprecated_(isDeprecated),
       isUnstable_(isUnstable),
@@ -68,8 +68,8 @@ class Attributes final : public AstNode {
     CHPL_ASSERT(pragmas_.size() <= NUM_KNOWN_PRAGMAS);
   }
 
-  Attributes(Deserializer& des)
-    : AstNode(asttags::Attributes, des) {
+  AttributeGroup(Deserializer& des)
+    : AstNode(asttags::AttributeGroup, des) {
       pragmas_ = des.read<std::set<PragmaTag>>();
       isDeprecated_ = des.read<bool>();
       isUnstable_ = des.read<bool>();
@@ -79,12 +79,12 @@ class Attributes final : public AstNode {
 
 
   bool contentsMatchInner(const AstNode* other) const override {
-    const Attributes* rhs = (const Attributes*)other;
+    const AttributeGroup* rhs = (const AttributeGroup*)other;
     return this->pragmas_ == rhs->pragmas_ &&
-      this->isDeprecated_ == rhs->isDeprecated_ &&
-      this->isUnstable_ == rhs->isUnstable_ &&
-      this->deprecationMessage_ == rhs->deprecationMessage_ &&
-      this->unstableMessage_ == rhs->unstableMessage_;
+           this->isDeprecated_ == rhs->isDeprecated_ &&
+           this->isUnstable_ == rhs->isUnstable_ &&
+           this->deprecationMessage_ == rhs->deprecationMessage_ &&
+           this->unstableMessage_ == rhs->unstableMessage_;
   }
 
   void markUniqueStringsInner(Context* context) const override {
@@ -95,17 +95,17 @@ class Attributes final : public AstNode {
   void dumpInner(const DumpSettings& s) const;
 
  public:
-  ~Attributes() override = default;
+  ~AttributeGroup() override = default;
 
-  static owned<Attributes> build(Builder* builder, Location loc,
-                                 std::set<PragmaTag> pragmas,
-                                 bool isDeprecated,
-                                 bool isUnstable,
-                                 UniqueString deprecationMessage,
-                                 UniqueString unstableMessage);
+  static owned<AttributeGroup> build(Builder* builder, Location loc,
+                                     std::set<PragmaTag> pragmas,
+                                     bool isDeprecated,
+                                     bool isUnstable,
+                                     UniqueString deprecationMessage,
+                                     UniqueString unstableMessage);
 
   /**
-    Returns true if the given pragma is set for this attributes.
+    Returns true if the given pragma is set for this attributeGroup.
   */
   bool hasPragma(PragmaTag tag) const {
     CHPL_ASSERT(tag >= 0 && tag < NUM_KNOWN_PRAGMAS);
@@ -123,7 +123,7 @@ class Attributes final : public AstNode {
   }
 
   /**
-    Returns true if the declaration associated with this attributes is
+    Returns true if the declaration associated with this attributeGroup is
     deprecated.
   */
   bool isDeprecated() const {
@@ -162,7 +162,7 @@ class Attributes final : public AstNode {
     ser.write(unstableMessage_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Attributes);
+  DECLARE_STATIC_DESERIALIZE(AttributeGroup);
 
 };
 

--- a/frontend/include/chpl/uast/Class.h
+++ b/frontend/include/chpl/uast/Class.h
@@ -46,21 +46,21 @@ class Class final : public AggregateDecl {
  private:
   int parentClassChildNum_;
 
-  Class(AstList children, int attributesChildNum, Decl::Visibility vis,
+  Class(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
         UniqueString name,
         int elementsChildNum,
         int numElements,
         int parentClassChildNum)
     : AggregateDecl(asttags::Class, std::move(children),
-                    attributesChildNum,
+                    attributeGroupChildNum,
                     vis,
                     Decl::DEFAULT_LINKAGE,
-                    /*linkageNameChildNum*/ -1,
+                    /*linkageNameChildNum*/ NO_CHILD,
                     name,
                     elementsChildNum,
                     numElements),
       parentClassChildNum_(parentClassChildNum) {
-    CHPL_ASSERT(parentClassChildNum_ == -1 ||
+    CHPL_ASSERT(parentClassChildNum_ == NO_CHILD ||
            child(parentClassChildNum_)->isIdentifier());
   }
 
@@ -86,7 +86,7 @@ class Class final : public AggregateDecl {
   ~Class() override = default;
 
   static owned<Class> build(Builder* builder, Location loc,
-                            owned<Attributes> attributes,
+                            owned<AttributeGroup> attributeGroup,
                             Decl::Visibility vis,
                             UniqueString name,
                             owned<AstNode> parentClass,

--- a/frontend/include/chpl/uast/Enum.h
+++ b/frontend/include/chpl/uast/Enum.h
@@ -44,12 +44,12 @@ namespace uast {
  */
 class Enum final : public TypeDecl {
  private:
-  Enum(AstList children, int attributesChildNum, Decl::Visibility vis,
+  Enum(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
        UniqueString name)
-    : TypeDecl(asttags::Enum, std::move(children), attributesChildNum,
+    : TypeDecl(asttags::Enum, std::move(children), attributeGroupChildNum,
                vis,
                Decl::DEFAULT_LINKAGE,
-               /*linkageNameChildNum*/ -1,
+               /*linkageNameChildNum*/ NO_CHILD,
                name) {
 
     #ifndef NDEBUG
@@ -57,7 +57,7 @@ class Enum final : public TypeDecl {
         CHPL_ASSERT(ast->isEnumElement() || ast->isComment());
       }
 
-      if (attributes()) {
+      if (attributeGroup()) {
         CHPL_ASSERT(declOrCommentChildNum() > 0);
       }
     #endif
@@ -67,7 +67,7 @@ class Enum final : public TypeDecl {
     : TypeDecl(asttags::Enum, des) {}
 
   int declOrCommentChildNum() const {
-    return attributes() ? 1 : 0;
+    return attributeGroup() ? 1 : 0;
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -84,7 +84,7 @@ class Enum final : public TypeDecl {
   ~Enum() override = default;
 
   static owned<Enum> build(Builder* builder, Location loc,
-                           owned<Attributes> attributes,
+                           owned<AttributeGroup> attributeGroup,
                            Decl::Visibility vis,
                            UniqueString name,
                            AstList stmts);
@@ -104,7 +104,7 @@ class Enum final : public TypeDecl {
    Return the number of EnumElements and Comments contained in this Enum.
    */
   int numDeclOrComments() const {
-    return attributes() ? numChildren() - 1 : numChildren();
+    return attributeGroup() ? numChildren() - 1 : numChildren();
   }
   /**
    Return the i'th EnumElement or Comment in this Enum.

--- a/frontend/include/chpl/uast/EnumElement.h
+++ b/frontend/include/chpl/uast/EnumElement.h
@@ -41,13 +41,13 @@ namespace uast {
  */
 class EnumElement final : public NamedDecl {
  private:
-  EnumElement(AstList children, int attributesChildNum,
+  EnumElement(AstList children, int attributeGroupChildNum,
               UniqueString name)
     : NamedDecl(asttags::EnumElement, std::move(children),
-                attributesChildNum,
+                attributeGroupChildNum,
                 Decl::DEFAULT_VISIBILITY,
                 Decl::DEFAULT_LINKAGE,
-                /*linkageNameChildNum*/ -1,
+                /*linkageNameChildNum*/ NO_CHILD,
                 name) {
 
     CHPL_ASSERT(children_.size() <= 2);
@@ -70,19 +70,19 @@ class EnumElement final : public NamedDecl {
     // if you blindly read this and try to access the underlying children_
     // array, you can segfault in the case that there is an attribute
     // but no init expression on this enum element.
-    return this->attributesChildNum() + 1;
+    return this->attributeGroupChildNum() + 1;
   }
 
  public:
   ~EnumElement() override = default;
 
   static owned<EnumElement> build(Builder* builder, Location loc,
-                                  owned<Attributes> attributes,
+                                  owned<AttributeGroup> attributeGroup,
                                   UniqueString name,
                                   owned<AstNode> initExpression);
 
   static owned<EnumElement> build(Builder* builder, Location loc,
-                                  owned<Attributes> attributes,
+                                  owned<AttributeGroup> attributeGroup,
                                   UniqueString name);
 
   /**
@@ -94,7 +94,7 @@ class EnumElement final : public NamedDecl {
     // in this case children_.size() is > 0, but initExpression should still be nullptr
     if (initExpressionChildNum() >= (int) children_.size()) {
       // either there are no children, or there's only an attribute
-      CHPL_ASSERT(children_.size() == 0 || this->child(0)->isAttributes());
+      CHPL_ASSERT(children_.size() == 0 || this->child(0)->isAttributeGroup());
       return nullptr;
     }
 

--- a/frontend/include/chpl/uast/For.h
+++ b/frontend/include/chpl/uast/For.h
@@ -53,7 +53,7 @@ class For final : public IndexableLoop {
     : IndexableLoop(asttags::For, std::move(children),
                     indexChildNum,
                     iterandChildNum,
-                    /*withClauseChildNum*/ -1,
+                    /*withClauseChildNum*/ NO_CHILD,
                     blockStyle,
                     loopBodyChildNum,
                     isExpressionLevel),

--- a/frontend/include/chpl/uast/Formal.h
+++ b/frontend/include/chpl/uast/Formal.h
@@ -58,15 +58,15 @@ class Formal final : public VarLikeDecl {
   };
 
  private:
-  Formal(AstList children, int attributesChildNum, UniqueString name,
+  Formal(AstList children, int attributeGroupChildNum, UniqueString name,
          Formal::Intent intent,
          int8_t typeExpressionChildNum,
          int8_t initExpressionChildNum)
     : VarLikeDecl(asttags::Formal, std::move(children),
-                  attributesChildNum,
+                  attributeGroupChildNum,
                   Decl::DEFAULT_VISIBILITY,
                   Decl::DEFAULT_LINKAGE,
-                  /*linkageNameChildNum*/ -1,
+                  /*linkageNameChildNum*/ NO_CHILD,
                   name,
                   (Qualifier)((int)intent),
                   typeExpressionChildNum,
@@ -90,7 +90,7 @@ class Formal final : public VarLikeDecl {
   ~Formal() override = default;
 
   static owned<Formal> build(Builder* builder, Location loc,
-                             owned<Attributes> attributes,
+                             owned<AttributeGroup> attributeGroup,
                              UniqueString name,
                              Intent intent,
                              owned<AstNode> typeExpression,

--- a/frontend/include/chpl/uast/ForwardingDecl.h
+++ b/frontend/include/chpl/uast/ForwardingDecl.h
@@ -59,11 +59,11 @@ class ForwardingDecl final : public Decl {
 
 private:
   ForwardingDecl(AstList children, Decl::Visibility visibility,
-                 int attributesChildNum)
-    : Decl(asttags::ForwardingDecl, std::move(children), attributesChildNum,
+                 int attributeGroupChildNum)
+    : Decl(asttags::ForwardingDecl, std::move(children), attributeGroupChildNum,
                 visibility,
                 Decl::DEFAULT_LINKAGE,
-                /*linkageNameChildNum*/ -1
+                /*linkageNameChildNum*/ NO_CHILD
                 ) {
 
     CHPL_ASSERT(children_.size() >= 0 && children_.size() <= 2);
@@ -83,7 +83,7 @@ private:
   }
 
   int exprChildNum() const {
-    return this->attributesChildNum() + 1;
+    return this->attributeGroupChildNum() + 1;
   }
 
  public:
@@ -91,11 +91,11 @@ private:
 
 
   static owned<ForwardingDecl> build(Builder* builder, Location loc,
-                                     owned<Attributes> attributes,
+                                     owned<AttributeGroup> attributeGroup,
                                      owned<AstNode> expr);
 
   static owned<ForwardingDecl> build(Builder* builder, Location loc,
-                                     owned<Attributes> attributes,
+                                     owned<AttributeGroup> attributeGroup,
                                      owned<AstNode> expr,
                                      Decl::Visibility visibility);
 

--- a/frontend/include/chpl/uast/Function.h
+++ b/frontend/include/chpl/uast/Function.h
@@ -91,7 +91,7 @@ class Function final : public NamedDecl {
   int bodyChildNum_;
 
   Function(AstList children,
-           int attributesChildNum,
+           int attributeGroupChildNum,
            Decl::Visibility vis,
            Decl::Linkage linkage,
            UniqueString name,
@@ -112,7 +112,7 @@ class Function final : public NamedDecl {
            int numLifetimeParts,
            int bodyChildNum)
     : NamedDecl(asttags::Function, std::move(children),
-                attributesChildNum,
+                attributeGroupChildNum,
                 vis,
                 linkage,
                 linkageNameChildNum,
@@ -133,17 +133,17 @@ class Function final : public NamedDecl {
       numLifetimeParts_(numLifetimeParts),
       bodyChildNum_(bodyChildNum) {
 
-    CHPL_ASSERT(-1 <= formalsChildNum_ &&
+    CHPL_ASSERT(NO_CHILD <= formalsChildNum_ &&
                  formalsChildNum_ < (ssize_t)children_.size());
-    CHPL_ASSERT(-1 <= thisFormalChildNum_ &&
+    CHPL_ASSERT(NO_CHILD <= thisFormalChildNum_ &&
                  thisFormalChildNum_ < (ssize_t)children_.size());
     CHPL_ASSERT(0 <= numFormals_ &&
                 numFormals_ <= (ssize_t)children_.size());
-    CHPL_ASSERT(-1 <= returnTypeChildNum_ &&
+    CHPL_ASSERT(NO_CHILD <= returnTypeChildNum_ &&
                  returnTypeChildNum_ < (ssize_t)children_.size());
-    CHPL_ASSERT(-1 <= whereChildNum_ &&
+    CHPL_ASSERT(NO_CHILD <= whereChildNum_ &&
                  whereChildNum_ < (ssize_t)children_.size());
-    CHPL_ASSERT(-1 <= lifetimeChildNum_ &&
+    CHPL_ASSERT(NO_CHILD <= lifetimeChildNum_ &&
                  lifetimeChildNum_ < (ssize_t)children_.size());
     CHPL_ASSERT(0 <= numLifetimeParts_ &&
                 numLifetimeParts_ <= (ssize_t)children_.size());
@@ -152,7 +152,7 @@ class Function final : public NamedDecl {
       CHPL_ASSERT(bodyChildNum_ < (ssize_t)children_.size());
       CHPL_ASSERT(children_[bodyChildNum_]->isBlock());
     } else {
-      CHPL_ASSERT(bodyChildNum_ == -1);
+      CHPL_ASSERT(bodyChildNum_ == NO_CHILD);
     }
 
     #ifndef NDEBUG
@@ -218,7 +218,7 @@ class Function final : public NamedDecl {
   ~Function() override = default;
 
   static owned<Function> build(Builder* builder, Location loc,
-                               owned<Attributes> attributes,
+                               owned<AttributeGroup> attributeGroup,
                                Decl::Visibility vis,
                                Decl::Linkage linkage,
                                owned<AstNode> linkageName,

--- a/frontend/include/chpl/uast/FunctionSignature.h
+++ b/frontend/include/chpl/uast/FunctionSignature.h
@@ -76,13 +76,13 @@ class FunctionSignature final : public AstNode {
       throws_(throws),
       isParenless_(isParenless) {
 
-    CHPL_ASSERT(-1 <= formalsChildNum_ &&
+    CHPL_ASSERT(NO_CHILD <= formalsChildNum_ &&
                  formalsChildNum_ < (ssize_t)children_.size());
-    CHPL_ASSERT(-1 <= thisFormalChildNum_ &&
+    CHPL_ASSERT(NO_CHILD <= thisFormalChildNum_ &&
                  thisFormalChildNum_ < (ssize_t)children_.size());
     CHPL_ASSERT(0 <= numFormals_ &&
                 numFormals_ <= (ssize_t)children_.size());
-    CHPL_ASSERT(-1 <= returnTypeChildNum_ &&
+    CHPL_ASSERT(NO_CHILD <= returnTypeChildNum_ &&
                  returnTypeChildNum_ < (ssize_t)children_.size());
   }
 

--- a/frontend/include/chpl/uast/Interface.h
+++ b/frontend/include/chpl/uast/Interface.h
@@ -54,7 +54,7 @@ class Interface final : public NamedDecl {
                      // isn't the body always the last thing here?
   bool isFormalListExplicit_;
 
-  Interface(AstList children, int attributesChildNum,
+  Interface(AstList children, int attributeGroupChildNum,
             Visibility visibility,
             UniqueString name,
             int interfaceFormalsChildNum,
@@ -63,7 +63,7 @@ class Interface final : public NamedDecl {
             int numBodyStmts,
             bool isFormalListExplicit)
       : NamedDecl(asttags::Interface, std::move(children),
-                  attributesChildNum,
+                  attributeGroupChildNum,
                   visibility,
                   Decl::DEFAULT_LINKAGE,
                   /*linkageNameChildNum*/ AstNode::NO_CHILD,
@@ -190,7 +190,7 @@ class Interface final : public NamedDecl {
   }
 
   static owned<Interface> build(Builder* builder, Location loc,
-                                owned<Attributes> attributes,
+                                owned<AttributeGroup> attributeGroup,
                                 Decl::Visibility visibility,
                                 UniqueString name,
                                 bool isFormalListExplicit,

--- a/frontend/include/chpl/uast/Module.h
+++ b/frontend/include/chpl/uast/Module.h
@@ -49,13 +49,13 @@ class Module final : public NamedDecl {
  private:
   Kind kind_;
 
-  Module(AstList children, int attributesChildNum, Decl::Visibility vis,
+  Module(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
          UniqueString name,
          Kind kind)
-    : NamedDecl(asttags::Module, std::move(children), attributesChildNum,
+    : NamedDecl(asttags::Module, std::move(children), attributeGroupChildNum,
                 vis,
                 Decl::DEFAULT_LINKAGE,
-                /*linkageNameChildNum*/ -1,
+                /*linkageNameChildNum*/ NO_CHILD,
                 name),
                 kind_(kind) {
 
@@ -79,7 +79,7 @@ class Module final : public NamedDecl {
   }
 
   int stmtChildNum() const {
-    return attributes() ? 1 : 0;
+    return attributeGroup() ? 1 : 0;
   }
 
   void dumpFieldsInner(const DumpSettings& s) const override;
@@ -88,7 +88,7 @@ class Module final : public NamedDecl {
   ~Module() override = default;
 
   static owned<Module> build(Builder* builder, Location loc,
-                             owned<Attributes> attributes,
+                             owned<AttributeGroup> attributeGroup,
                              Decl::Visibility vis,
                              UniqueString name,
                              Module::Kind kind,
@@ -114,7 +114,7 @@ class Module final : public NamedDecl {
     Return the number of statements in this module.
   */
   int numStmts() const {
-    return attributes() ? numChildren()-1 : numChildren();
+    return attributeGroup() ? numChildren()-1 : numChildren();
   }
 
   /**

--- a/frontend/include/chpl/uast/MultiDecl.h
+++ b/frontend/include/chpl/uast/MultiDecl.h
@@ -52,12 +52,12 @@ namespace uast {
  */
 class MultiDecl final : public Decl {
  private:
-  MultiDecl(AstList children, int attributesChildNum, Decl::Visibility vis,
+  MultiDecl(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
             Decl::Linkage linkage)
-    : Decl(asttags::MultiDecl, std::move(children), attributesChildNum,
+    : Decl(asttags::MultiDecl, std::move(children), attributeGroupChildNum,
            vis,
            linkage,
-           /*linkageNameChildNum*/ -1) {
+           /*linkageNameChildNum*/ NO_CHILD) {
 
     CHPL_ASSERT(isAcceptableMultiDecl());
   }
@@ -68,7 +68,7 @@ class MultiDecl final : public Decl {
   bool isAcceptableMultiDecl();
 
   int declOrCommentChildNum() const {
-    return attributes() ? 1 : 0;
+    return attributeGroup() ? 1 : 0;
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -85,7 +85,7 @@ class MultiDecl final : public Decl {
   ~MultiDecl() override = default;
 
   static owned<MultiDecl> build(Builder* builder, Location loc,
-                                owned<Attributes> attributes,
+                                owned<AttributeGroup> attributeGroup,
                                 Decl::Visibility vis,
                                 Decl::Linkage linkage,
                                 AstList varDecls);
@@ -105,7 +105,7 @@ class MultiDecl final : public Decl {
    Return the number of VariableDecls and Comments contained.
    */
   int numDeclOrComments() const {
-    return attributes() ? numChildren() - 1 : numChildren();
+    return attributeGroup() ? numChildren() - 1 : numChildren();
   }
 
   /**

--- a/frontend/include/chpl/uast/NamedDecl.h
+++ b/frontend/include/chpl/uast/NamedDecl.h
@@ -37,18 +37,17 @@ class NamedDecl : public Decl {
 
  protected:
   NamedDecl(AstTag tag, Decl::Visibility visibility, Decl::Linkage linkage,
-            int attributesChildNum,
             UniqueString name)
-    : Decl(tag, attributesChildNum, visibility, linkage),
+    : Decl(tag, visibility, linkage),
       name_(name) {
   }
 
-  NamedDecl(AstTag tag, AstList children, int attributesChildNum,
+  NamedDecl(AstTag tag, AstList children, int attributeGroupChildNum,
             Decl::Visibility visibility,
             Decl::Linkage linkage,
             int linkageNameChildNum,
             UniqueString name)
-    : Decl(tag, std::move(children), attributesChildNum, visibility,
+    : Decl(tag, std::move(children), attributeGroupChildNum, visibility,
            linkage,
            linkageNameChildNum),
       name_(name) {

--- a/frontend/include/chpl/uast/Record.h
+++ b/frontend/include/chpl/uast/Record.h
@@ -44,14 +44,14 @@ namespace uast {
  */
 class Record final : public AggregateDecl {
  private:
-  Record(AstList children, int attributesChildNum, Decl::Visibility vis,
+  Record(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
          Decl::Linkage linkage,
          int linkageNameChildNum,
          UniqueString name,
          int elementsChildNum,
          int numElements)
     : AggregateDecl(asttags::Record, std::move(children),
-                    attributesChildNum,
+                    attributeGroupChildNum,
                     vis,
                     linkage,
                     linkageNameChildNum,
@@ -77,7 +77,7 @@ class Record final : public AggregateDecl {
   ~Record() override = default;
 
   static owned<Record> build(Builder* builder, Location loc,
-                             owned<Attributes> attributes,
+                             owned<AttributeGroup> attributeGroup,
                              Decl::Visibility vis,
                              Decl::Linkage linkage,
                              owned<AstNode> linkageName,

--- a/frontend/include/chpl/uast/ReduceIntent.h
+++ b/frontend/include/chpl/uast/ReduceIntent.h
@@ -55,7 +55,7 @@ class ReduceIntent final : public NamedDecl {
 
   ReduceIntent(AstList children, UniqueString name)
       : NamedDecl(asttags::ReduceIntent, std::move(children),
-                  /* attributesChildNum= */ AstNode::NO_CHILD,
+                  /* attributeGroupChildNum= */ AstNode::NO_CHILD,
                   Decl::DEFAULT_VISIBILITY,
                   Decl::DEFAULT_LINKAGE,
                   /*linkageNameChildNum=*/ AstNode::NO_CHILD,

--- a/frontend/include/chpl/uast/TaskVar.h
+++ b/frontend/include/chpl/uast/TaskVar.h
@@ -58,15 +58,15 @@ class TaskVar final : public VarLikeDecl {
   };
 
  private:
-  TaskVar(AstList children, int attributesChildNum, UniqueString name,
+  TaskVar(AstList children, int attributeGroupChildNum, UniqueString name,
           TaskVar::Intent intent,
           int8_t typeExpressionChildNum,
           int8_t initExpressionChildNum)
       : VarLikeDecl(asttags::TaskVar, std::move(children),
-                    attributesChildNum,
+                    attributeGroupChildNum,
                     Decl::DEFAULT_VISIBILITY,
                     Decl::DEFAULT_LINKAGE,
-                    /*linkageNameChildNum*/ -1,
+                    /*linkageNameChildNum*/ NO_CHILD,
                     name,
                     (Qualifier)((int)intent),
                     typeExpressionChildNum,
@@ -93,7 +93,7 @@ class TaskVar final : public VarLikeDecl {
   ~TaskVar() override = default;
 
   static owned<TaskVar> build(Builder* builder, Location loc,
-                              owned<Attributes> attributes,
+                              owned<AttributeGroup> attributeGroup,
                               UniqueString name,
                               TaskVar::Intent intent,
                               owned<AstNode> typeExpression,

--- a/frontend/include/chpl/uast/TupleDecl.h
+++ b/frontend/include/chpl/uast/TupleDecl.h
@@ -75,16 +75,16 @@ class TupleDecl final : public Decl {
   int typeExpressionChildNum_;
   int initExpressionChildNum_;
 
-  TupleDecl(AstList children, int attributesChildNum, Decl::Visibility vis,
+  TupleDecl(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
             Decl::Linkage linkage,
             IntentOrKind intentOrKind,
             int numElements,
             int typeExpressionChildNum,
             int initExpressionChildNum)
-    : Decl(asttags::TupleDecl, std::move(children), attributesChildNum,
+    : Decl(asttags::TupleDecl, std::move(children), attributeGroupChildNum,
            vis,
            linkage,
-           /*linkageNameChildNum*/ -1),
+           /*linkageNameChildNum*/ NO_CHILD),
       intentOrKind_(intentOrKind),
       numElements_(numElements),
       typeExpressionChildNum_(typeExpressionChildNum),
@@ -121,14 +121,14 @@ class TupleDecl final : public Decl {
   std::string dumpChildLabelInner(int i) const override;
 
   int declChildNum() const {
-    return attributes() ? 1 : 0;
+    return attributeGroup() ? 1 : 0;
   }
 
  public:
   ~TupleDecl() override = default;
 
   static owned<TupleDecl> build(Builder* builder, Location loc,
-                                owned<Attributes> attributes,
+                                owned<AttributeGroup> attributeGroup,
                                 Decl::Visibility vis,
                                 Decl::Linkage linkage,
                                 IntentOrKind intentOrKind,

--- a/frontend/include/chpl/uast/TypeDecl.h
+++ b/frontend/include/chpl/uast/TypeDecl.h
@@ -32,12 +32,12 @@ namespace uast {
  */
 class TypeDecl : public NamedDecl {
  protected:
-  TypeDecl(asttags::AstTag tag, AstList children, int attributesChildNum,
+  TypeDecl(asttags::AstTag tag, AstList children, int attributeGroupChildNum,
            Decl::Visibility vis,
            Decl::Linkage linkage,
            int linkageNameChildNum,
            UniqueString name)
-    : NamedDecl(tag, std::move(children), attributesChildNum, vis,
+    : NamedDecl(tag, std::move(children), attributeGroupChildNum, vis,
                 linkage,
                 linkageNameChildNum,
                 name) {

--- a/frontend/include/chpl/uast/TypeQuery.h
+++ b/frontend/include/chpl/uast/TypeQuery.h
@@ -52,8 +52,7 @@ class TypeQuery final : public NamedDecl {
 
  private:
   TypeQuery(UniqueString name)
-    : NamedDecl(asttags::TypeQuery, DEFAULT_VISIBILITY, DEFAULT_LINKAGE,
-                /* attributesChildNum */ -1, name) {
+    : NamedDecl(asttags::TypeQuery, DEFAULT_VISIBILITY, DEFAULT_LINKAGE, name) {
     CHPL_ASSERT(!name.isEmpty() && name.c_str()[0] != '?');
   }
 

--- a/frontend/include/chpl/uast/Union.h
+++ b/frontend/include/chpl/uast/Union.h
@@ -44,14 +44,14 @@ namespace uast {
  */
 class Union final : public AggregateDecl {
  private:
-  Union(AstList children, int attributesChildNum, Decl::Visibility vis,
+  Union(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
         Decl::Linkage linkage,
         int linkageNameChildNum,
         UniqueString name,
         int elementsChildNum,
         int numElements)
     : AggregateDecl(asttags::Union, std::move(children),
-                    attributesChildNum,
+                    attributeGroupChildNum,
                     vis,
                     linkage,
                     linkageNameChildNum,
@@ -81,7 +81,7 @@ class Union final : public AggregateDecl {
   ~Union() override = default;
 
   static owned<Union> build(Builder* builder, Location loc,
-                            owned<Attributes> attributes,
+                            owned<AttributeGroup> attributeGroup,
                             Decl::Visibility vis,
                             Decl::Linkage linkage,
                             owned<AstNode> linkageName,

--- a/frontend/include/chpl/uast/VarArgFormal.h
+++ b/frontend/include/chpl/uast/VarArgFormal.h
@@ -47,20 +47,20 @@ class VarArgFormal final : public VarLikeDecl {
  private:
   int countChildNum_;
 
-  VarArgFormal(AstList children, int attributesChildNum, UniqueString name,
+  VarArgFormal(AstList children, int attributeGroupChildNum, UniqueString name,
                Formal::Intent intent,
                int8_t typeExpressionChildNum,
                int8_t countChildNum)
     : VarLikeDecl(asttags::VarArgFormal, std::move(children),
-                  attributesChildNum,
+                  attributeGroupChildNum,
                   Decl::DEFAULT_VISIBILITY,
                   Decl::DEFAULT_LINKAGE,
-                  // Use -1 to indicate so such child exists.
-                  /*linkageNameChildNum*/ -1,
+                  // Use NO_CHILD to indicate so such child exists.
+                  /*linkageNameChildNum*/ NO_CHILD,
                   name,
                   (Qualifier)((int)intent),
                   typeExpressionChildNum,
-                  /*initExpressionChildNum*/ -1),
+                  /*initExpressionChildNum*/ NO_CHILD),
       countChildNum_(countChildNum) {
   }
 
@@ -86,7 +86,7 @@ class VarArgFormal final : public VarLikeDecl {
   ~VarArgFormal() override = default;
 
   static owned<VarArgFormal> build(Builder* builder, Location loc,
-                                   owned<Attributes> attributes,
+                                   owned<AttributeGroup> attributeGroup,
                                    UniqueString name,
                                    Formal::Intent intent,
                                    owned<AstNode> typeExpression,

--- a/frontend/include/chpl/uast/VarLikeDecl.h
+++ b/frontend/include/chpl/uast/VarLikeDecl.h
@@ -38,7 +38,7 @@ class VarLikeDecl : public NamedDecl {
   int8_t typeExpressionChildNum_;
   int8_t initExpressionChildNum_;
 
-  VarLikeDecl(AstTag tag, AstList children, int attributesChildNum,
+  VarLikeDecl(AstTag tag, AstList children, int attributeGroupChildNum,
               Decl::Visibility vis,
               Decl::Linkage linkage,
               int linkageNameChildNum,
@@ -46,7 +46,7 @@ class VarLikeDecl : public NamedDecl {
               Qualifier storageKind,
               int8_t typeExpressionChildNum,
               int8_t initExpressionChildNum)
-    : NamedDecl(tag, std::move(children), attributesChildNum, vis,
+    : NamedDecl(tag, std::move(children), attributeGroupChildNum, vis,
                 linkage,
                 linkageNameChildNum,
                 name),

--- a/frontend/include/chpl/uast/Variable.h
+++ b/frontend/include/chpl/uast/Variable.h
@@ -63,7 +63,7 @@ class Variable final : public VarLikeDecl {
   };
 
  private:
-  Variable(AstList children, int attributesChildNum, Decl::Visibility vis,
+  Variable(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
            Decl::Linkage linkage,
            int linkageNameChildNum,
            UniqueString name,
@@ -73,7 +73,7 @@ class Variable final : public VarLikeDecl {
            int8_t typeExpressionChildNum,
            int8_t initExpressionChildNum)
       : VarLikeDecl(asttags::Variable, std::move(children),
-                    attributesChildNum,
+                    attributeGroupChildNum,
                     vis,
                     linkage,
                     linkageNameChildNum,
@@ -117,7 +117,7 @@ class Variable final : public VarLikeDecl {
   ~Variable() override = default;
 
   static owned<Variable> build(Builder* builder, Location loc,
-                               owned<Attributes> attributes,
+                               owned<AttributeGroup> attributeGroup,
                                Decl::Visibility vis,
                                Decl::Linkage linkage,
                                owned<AstNode> linkageName,

--- a/frontend/include/chpl/uast/all-uast.h
+++ b/frontend/include/chpl/uast/all-uast.h
@@ -21,7 +21,7 @@
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/Array.h"
 #include "chpl/uast/As.h"
-#include "chpl/uast/Attributes.h"
+#include "chpl/uast/AttributeGroup.h"
 #include "chpl/uast/Begin.h"
 #include "chpl/uast/Block.h"
 #include "chpl/uast/BoolLiteral.h"

--- a/frontend/include/chpl/uast/uast-classes-list.h
+++ b/frontend/include/chpl/uast/uast-classes-list.h
@@ -46,7 +46,7 @@
   AST_NODE(AnonFormal)                 //
   AST_NODE(As)                         //
   AST_NODE(Array)                      //
-  AST_LEAF(Attributes)                 //
+  AST_LEAF(AttributeGroup)             //
   //AST_NODE(AssociativeArray)         //
   AST_NODE(Break)                      // old AST: GotoStmt
   AST_NODE(Catch)                      // old AST: CatchStmt

--- a/frontend/lib/parsing/ParserContext.h
+++ b/frontend/lib/parsing/ParserContext.h
@@ -30,7 +30,8 @@ struct ParserComment {
 };
 
 // To store the different attributes of a symbol as they are built.
-struct AttributeParts {
+struct AttributeGroupParts {
+  ParserExprList* attributeGroup; // this is where the attributes are accumulated
   std::set<PragmaTag>* pragmas;
   bool isDeprecated;
   bool isUnstable;
@@ -65,8 +66,8 @@ struct ParserContext {
   Variable::Kind varDeclKind;
   bool isVarDeclConfig;
   bool isBuildingFormal;
-  AttributeParts attributeParts;
-  bool hasAttributeParts;
+  AttributeGroupParts attributeGroupParts;
+  bool hasAttributeGroupParts;
   int numAttributesBuilt;
   YYLTYPE declStartLocation;
 
@@ -100,8 +101,8 @@ struct ParserContext {
     this->varDeclKind             = Variable::VAR;
     this->isBuildingFormal        = false;
     this->isVarDeclConfig         = false;
-    this->attributeParts          = { nullptr, false, false, UniqueString(), UniqueString() };
-    this->hasAttributeParts       = false;
+    this->attributeGroupParts     = {nullptr, nullptr, false, false, UniqueString(), UniqueString() };
+    this->hasAttributeGroupParts  = false;
     this->numAttributesBuilt      = 0;
     YYLTYPE emptyLoc = {0};
     this->declStartLocation       = emptyLoc;
@@ -129,11 +130,11 @@ struct ParserContext {
   owned<AstNode> consumeVarDeclLinkageName(void);
 
   // If attributes do not exist yet, returns nullptr.
-  owned<Attributes> buildAttributes(YYLTYPE locationOfDecl);
+  owned<AttributeGroup> buildAttributeGroup(YYLTYPE locationOfDecl);
   PODUniqueString notePragma(YYLTYPE loc, AstNode* pragmaStr);
   void noteDeprecation(YYLTYPE loc, AstNode* messageStr);
   void noteUnstable(YYLTYPE loc, AstNode* messageStr);
-  void resetAttributePartsState();
+  void resetAttributeGroupPartsState();
 
   CommentsAndStmt buildPragmaStmt(YYLTYPE loc, CommentsAndStmt stmt);
 
@@ -278,14 +279,14 @@ struct ParserContext {
               PODUniqueString name,
               AstNode* typeExpr,
               AstNode* initExpr,
-              bool consumeAttributes=false);
+              bool consumeAttributeGroup=false);
 
   AstNode*
   buildVarArgFormal(YYLTYPE location, Formal::Intent intent,
                     PODUniqueString name,
                     AstNode* typeExpr,
                     AstNode* initExpr,
-                    bool consumeAttributes=false);
+                    bool consumeAttributeGroup=false);
 
   AstNode*
   buildTupleFormal(YYLTYPE location, Formal::Intent intent,
@@ -578,13 +579,13 @@ struct ParserContext {
                                   ParserExprList* whenStmts);
 
   CommentsAndStmt
-  buildForwardingDecl(YYLTYPE location, owned<Attributes> attributes,
+  buildForwardingDecl(YYLTYPE location, owned<AttributeGroup> attributeGroup,
                       owned<AstNode> expr,
                       VisibilityClause::LimitationKind limitationKind,
                       ParserExprList* limitations);
 
   CommentsAndStmt
-  buildForwardingDecl(YYLTYPE location, owned<Attributes> attributes,
+  buildForwardingDecl(YYLTYPE location, owned<AttributeGroup> attributeGroup,
                       CommentsAndStmt cs);
 
   AstNode* buildInterfaceFormal(YYLTYPE location, PODUniqueString name);

--- a/frontend/lib/parsing/bison-chpl-lib.cpp
+++ b/frontend/lib/parsing/bison-chpl-lib.cpp
@@ -6970,7 +6970,7 @@ yyreduce:
 
       ModuleParts parts = {
         .comments=context->gatherComments(loc),
-        .attributes=context->buildAttributes((yyloc)).release(),
+        .attributeGroup=context->buildAttributeGroup((yyloc)).release(),
         .visibility=(yyvsp[-3].visibilityTag),
         .kind=(yyvsp[-2].moduleKind),
         .name=(yyvsp[0].uniqueStr)
@@ -6991,7 +6991,7 @@ yyreduce:
       ModuleParts parts = (yyvsp[-2].moduleParts);
       ParserExprList* body = context->makeList();
       context->appendList(body, context->gatherComments((yylsp[0])));
-      auto mod = Module::build(BUILDER, LOC((yylsp[-2])), toOwned(parts.attributes),
+      auto mod = Module::build(BUILDER, LOC((yylsp[-2])), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -7010,7 +7010,7 @@ yyreduce:
       ModuleParts parts = (yyvsp[-3].moduleParts);
       ParserExprList* body = (yyvsp[-1].exprList);
       context->appendList(body, context->gatherComments((yylsp[0])));
-      auto mod = Module::build(BUILDER, LOC((yylsp[-3])), toOwned(parts.attributes),
+      auto mod = Module::build(BUILDER, LOC((yylsp[-3])), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -7027,7 +7027,7 @@ yyreduce:
       ModuleParts parts = (yyvsp[-3].moduleParts);
       auto err = ErroneousExpression::build(BUILDER, LOC((yylsp[-1])));
       ParserExprList* body = context->makeList(std::move(err));
-      auto mod = Module::build(BUILDER, LOC((yylsp[-3])), toOwned(parts.attributes),
+      auto mod = Module::build(BUILDER, LOC((yylsp[-3])), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -7714,7 +7714,7 @@ yyreduce:
   case 178: /* forwarding_decl_stmt: forwarding_decl_start expr TSEMI  */
 #line 1418 "chpl.ypp"
     {
-      (yyval.commentsAndStmt) = context->buildForwardingDecl((yyloc), toOwned((yyvsp[-2].attribute)), toOwned((yyvsp[-1].expr)),
+      (yyval.commentsAndStmt) = context->buildForwardingDecl((yyloc), toOwned((yyvsp[-2].attributeGroup)), toOwned((yyvsp[-1].expr)),
                                         VisibilityClause::NONE, nullptr);
     }
 #line 7721 "bison-chpl-lib.cpp"
@@ -7723,7 +7723,7 @@ yyreduce:
   case 179: /* forwarding_decl_stmt: forwarding_decl_start expr TEXCEPT renames_ls TSEMI  */
 #line 1423 "chpl.ypp"
     {
-      (yyval.commentsAndStmt) = context->buildForwardingDecl((yyloc), toOwned((yyvsp[-4].attribute)), toOwned((yyvsp[-3].expr)),
+      (yyval.commentsAndStmt) = context->buildForwardingDecl((yyloc), toOwned((yyvsp[-4].attributeGroup)), toOwned((yyvsp[-3].expr)),
                                         VisibilityClause::EXCEPT, (yyvsp[-1].exprList));
     }
 #line 7730 "bison-chpl-lib.cpp"
@@ -7732,7 +7732,7 @@ yyreduce:
   case 180: /* forwarding_decl_stmt: forwarding_decl_start expr TONLY opt_only_ls TSEMI  */
 #line 1428 "chpl.ypp"
     {
-      (yyval.commentsAndStmt) = context->buildForwardingDecl((yyloc), toOwned((yyvsp[-4].attribute)), toOwned((yyvsp[-3].expr)),
+      (yyval.commentsAndStmt) = context->buildForwardingDecl((yyloc), toOwned((yyvsp[-4].attributeGroup)), toOwned((yyvsp[-3].expr)),
                                         VisibilityClause::ONLY, (yyvsp[-1].exprList));
     }
 #line 7739 "bison-chpl-lib.cpp"
@@ -7741,7 +7741,7 @@ yyreduce:
   case 181: /* forwarding_decl_stmt: forwarding_decl_start var_decl_stmt  */
 #line 1433 "chpl.ypp"
     {
-      (yyval.commentsAndStmt) = context->buildForwardingDecl((yyloc), toOwned((yyvsp[-1].attribute)), (yyvsp[0].commentsAndStmt));
+      (yyval.commentsAndStmt) = context->buildForwardingDecl((yyloc), toOwned((yyvsp[-1].attributeGroup)), (yyvsp[0].commentsAndStmt));
     }
 #line 7747 "bison-chpl-lib.cpp"
     break;
@@ -7749,8 +7749,8 @@ yyreduce:
   case 182: /* forwarding_decl_start: TFORWARDING  */
 #line 1440 "chpl.ypp"
   {
-    (yyval.attribute) = context->buildAttributes((yyloc)).release();
-    context->resetAttributePartsState();
+    (yyval.attributeGroup) = context->buildAttributeGroup((yyloc)).release();
+    context->resetAttributeGroupPartsState();
   }
 #line 7756 "bison-chpl-lib.cpp"
     break;
@@ -8304,7 +8304,7 @@ yyreduce:
 #line 1778 "chpl.ypp"
   {
     auto varDecl = Variable::build(BUILDER, LOC((yyloc)),
-                                   /*attributes*/ nullptr,
+                                   /*attributeGroup*/ nullptr,
                                    Decl::DEFAULT_VISIBILITY,
                                    Decl::DEFAULT_LINKAGE,
                                    /*linkageName*/ nullptr,
@@ -8323,7 +8323,7 @@ yyreduce:
 #line 1793 "chpl.ypp"
   {
     auto varDecl = Variable::build(BUILDER, LOC((yyloc)),
-                                   /*attributes*/ nullptr,
+                                   /*attributeGroup*/ nullptr,
                                    Decl::DEFAULT_VISIBILITY,
                                    Decl::DEFAULT_LINKAGE,
                                    /*linkageName*/ nullptr,
@@ -8500,7 +8500,7 @@ yyreduce:
   case 283: /* catch_expr_inner: ident_def  */
 #line 1940 "chpl.ypp"
   {
-    (yyval.expr) = Variable::build(BUILDER, LOC((yyloc)), /*attributes*/ nullptr,
+    (yyval.expr) = Variable::build(BUILDER, LOC((yyloc)), /*attributeGroup*/ nullptr,
                          Decl::DEFAULT_VISIBILITY,
                          Decl::DEFAULT_LINKAGE,
                          /*linkageName*/ nullptr,
@@ -8517,7 +8517,7 @@ yyreduce:
   case 284: /* catch_expr_inner: ident_def TCOLON expr  */
 #line 1953 "chpl.ypp"
   {
-    (yyval.expr) = Variable::build(BUILDER, LOC((yyloc)), /*attributes*/ nullptr,
+    (yyval.expr) = Variable::build(BUILDER, LOC((yyloc)), /*attributeGroup*/ nullptr,
                          Decl::DEFAULT_VISIBILITY,
                          Decl::DEFAULT_LINKAGE,
                          /*linkageName*/ nullptr,
@@ -8749,7 +8749,7 @@ yyreduce:
       // get any comments after the last element but before the closing brace
       context->appendList(list, context->gatherComments((yylsp[0])));
 
-      auto decl = Enum::build(BUILDER, LOC((yyloc)), toOwned(parts.attributes),
+      auto decl = Enum::build(BUILDER, LOC((yyloc)), toOwned(parts.attributeGroup),
                               parts.visibility,
                               parts.name,
                               context->consumeList(list));
@@ -8788,7 +8788,7 @@ yyreduce:
 #line 2136 "chpl.ypp"
   {
     (yyval.exprList) = context->makeList((yyvsp[0].commentsAndStmt));
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 #line 8794 "bison-chpl-lib.cpp"
     break;
@@ -8798,7 +8798,7 @@ yyreduce:
   {
     (yyval.exprList) = (yyvsp[-1].exprList);
     context->clearCommentsBefore((yylsp[0]));
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 #line 8804 "bison-chpl-lib.cpp"
     break;
@@ -8807,7 +8807,7 @@ yyreduce:
 #line 2147 "chpl.ypp"
   {
     context->clearCommentsBefore((yylsp[0]));
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 #line 8813 "bison-chpl-lib.cpp"
     break;
@@ -8816,7 +8816,7 @@ yyreduce:
 #line 2152 "chpl.ypp"
   {
     context->appendList((yyvsp[-3].exprList), (yyvsp[0].commentsAndStmt));
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 #line 8822 "bison-chpl-lib.cpp"
     break;
@@ -8825,7 +8825,7 @@ yyreduce:
 #line 2158 "chpl.ypp"
   {
     (yyval.exprList) = context->makeList((yyvsp[0].commentsAndStmt));
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 #line 8831 "bison-chpl-lib.cpp"
     break;
@@ -8834,7 +8834,7 @@ yyreduce:
 #line 2163 "chpl.ypp"
   {
     context->clearCommentsBefore((yylsp[0]));
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 #line 8840 "bison-chpl-lib.cpp"
     break;
@@ -8843,7 +8843,7 @@ yyreduce:
 #line 2168 "chpl.ypp"
   {
     context->appendList((yyvsp[-3].exprList), (yyvsp[0].commentsAndStmt));
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 #line 8849 "bison-chpl-lib.cpp"
     break;
@@ -8916,7 +8916,7 @@ yyreduce:
 #line 2216 "chpl.ypp"
     {
       auto decl = EnumElement::build(BUILDER, LOC((yyloc)),
-                                     context->buildAttributes((yyloc)),
+                                     context->buildAttributeGroup((yyloc)),
                                      (yyvsp[0].uniqueStr));
       (yyval.commentsAndStmt) = STMT((yyloc), decl.release());
     }
@@ -8927,7 +8927,7 @@ yyreduce:
 #line 2223 "chpl.ypp"
     {
       auto decl = EnumElement::build(BUILDER, LOC((yyloc)),
-                                     context->buildAttributes((yyloc)),
+                                     context->buildAttributeGroup((yyloc)),
                                      (yyvsp[-2].uniqueStr),
                                      toOwned((yyvsp[0].expr)));
       (yyval.commentsAndStmt) = STMT((yyloc), decl.release());
@@ -8943,9 +8943,9 @@ yyreduce:
       context->noteDeclStartLoc((yylsp[0]));
       auto loc = context->declStartLoc((yyloc));
       fp.comments = context->gatherComments(loc);
-      fp.attributes = context->buildAttributes((yyloc)).release();
+      fp.attributeGroup = context->buildAttributeGroup((yyloc)).release();
       fp.visibility = context->visibility;
-      context->resetAttributePartsState();
+      context->resetAttributeGroupPartsState();
       fp.kind = Function::PROC;
       (yyval.functionParts) = fp;
     }
@@ -9070,7 +9070,7 @@ yyreduce:
     fp.throws = ((yyvsp[0].throwsTag) == ThrowsTag_THROWS);
     fp.body = nullptr;
     fp.comments = nullptr;
-    fp.attributes = nullptr;
+    fp.attributeGroup = nullptr;
     fp.visibility = context->visibility;
     (yyval.functionParts) = fp;
   }
@@ -9197,7 +9197,7 @@ yyreduce:
     {
       FunctionParts fp = (yyvsp[-5].functionParts);
       fp.thisIntent = (yyvsp[-4].intentTag);
-      fp.receiver = Formal::build(BUILDER, LOC((yylsp[-3])), /*attributes*/ nullptr,
+      fp.receiver = Formal::build(BUILDER, LOC((yylsp[-3])), /*attributeGroup*/ nullptr,
                                   STR("this"), (yyvsp[-4].intentTag), toOwned((yyvsp[-3].expr)),
                                   nullptr).release();
       fp.name = context->buildIdent((yylsp[-1]), (yyvsp[-1].uniqueStr));
@@ -9212,7 +9212,7 @@ yyreduce:
     {
       FunctionParts fp = (yyvsp[-5].functionParts);
       fp.thisIntent = (yyvsp[-4].intentTag);
-      fp.receiver = Formal::build(BUILDER, LOC((yylsp[-3])), /*attributes*/ nullptr,
+      fp.receiver = Formal::build(BUILDER, LOC((yylsp[-3])), /*attributeGroup*/ nullptr,
                                   STR("this"), (yyvsp[-4].intentTag), toOwned((yyvsp[-3].expr)),
                                   nullptr).release();
       fp.name = context->buildIdent((yylsp[-1]), (yyvsp[-1].uniqueStr));
@@ -9239,9 +9239,9 @@ yyreduce:
       context->noteDeclStartLoc((yylsp[0]));
       auto loc = context->declStartLoc((yyloc));
       fp.comments = context->gatherComments(loc);
-      fp.attributes = context->buildAttributes((yyloc)).release();
+      fp.attributeGroup = context->buildAttributeGroup((yyloc)).release();
       fp.visibility = context->visibility;
-      context->resetAttributePartsState();
+      context->resetAttributeGroupPartsState();
       fp.kind = (yyvsp[0].functionKind);
       (yyval.functionParts) = fp;
     }
@@ -9725,7 +9725,7 @@ yyreduce:
   {
     // TODO (dlongnecke-cray): Add a helper to build this and var_decl_stmt.
     auto node = Variable::build(BUILDER, LOC((yyloc)),
-                                context->buildAttributes((yyloc)),
+                                context->buildAttributeGroup((yyloc)),
                                 context->visibility,
                                 context->linkage,
                                 context->consumeVarDeclLinkageName(),
@@ -9840,7 +9840,7 @@ yyreduce:
 #line 2821 "chpl.ypp"
     {
       auto varDecl = Variable::build(BUILDER, LOC((yyloc)),
-                                     context->buildAttributes((yyloc)),
+                                     context->buildAttributeGroup((yyloc)),
                                      context->visibility,
                                      context->linkage,
                                      context->consumeVarDeclLinkageName(),
@@ -9861,7 +9861,7 @@ yyreduce:
     {
       auto intentOrKind = (TupleDecl::IntentOrKind) context->varDeclKind;
       auto tupleDecl = TupleDecl::build(BUILDER, LOC((yyloc)),
-                                        context->buildAttributes((yyloc)),
+                                        context->buildAttributeGroup((yyloc)),
                                         context->visibility,
                                         context->linkage,
                                         intentOrKind,
@@ -10795,7 +10795,7 @@ yyreduce:
   {
     if (auto ident = (yyvsp[-2].expr)->toIdentifier()) {
       auto name = ident->name();
-      auto node = TaskVar::build(BUILDER, LOC((yyloc)), /*attributes*/ nullptr,
+      auto node = TaskVar::build(BUILDER, LOC((yyloc)), /*attributeGroup*/ nullptr,
                                  name,
                                  /*intent*/ (yyvsp[-3].taskIntent),
                                  toOwned((yyvsp[-1].expr)),

--- a/frontend/lib/parsing/bison-chpl-lib.h
+++ b/frontend/lib/parsing/bison-chpl-lib.h
@@ -127,7 +127,7 @@ extern int yychpl_debug;
     bool isBodyNonBlockExpression;
     std::vector<ParserComment>* comments;
     ErroneousExpression* errorExpr; // only used for parser error
-    Attributes* attributes;
+    AttributeGroup* attributeGroup;
     Decl::Visibility visibility;
     Decl::Linkage linkage;
     AstNode* linkageNameExpr;
@@ -149,7 +149,7 @@ extern int yychpl_debug;
   // A struct to thread along some pieces of a module before it is built.
   struct ModuleParts {
     std::vector<ParserComment>* comments;
-    Attributes* attributes;
+    AttributeGroup* attributeGroup;
     Decl::Visibility visibility;
     Module::Kind kind;
     PODUniqueString name;
@@ -161,7 +161,7 @@ extern int yychpl_debug;
     Decl::Visibility visibility;
     Decl::Linkage linkage;
     AstNode* linkageName;
-    Attributes* attributes;
+    AttributeGroup* attributeGroup;
     PODUniqueString name;
     asttags::AstTag tag;
   };
@@ -225,7 +225,7 @@ extern int yychpl_debug;
     Variable::Kind variableKind;
 
     // simple pointer values
-    Attributes* attribute;
+    AttributeGroup* attributeGroup;
     Block* block;
     Call* call;
     Function* function;

--- a/frontend/lib/parsing/chpl.ypp
+++ b/frontend/lib/parsing/chpl.ypp
@@ -154,7 +154,7 @@
     bool isBodyNonBlockExpression;
     std::vector<ParserComment>* comments;
     ErroneousExpression* errorExpr; // only used for parser error
-    Attributes* attributes;
+    AttributeGroup* attributeGroup;
     Decl::Visibility visibility;
     Decl::Linkage linkage;
     AstNode* linkageNameExpr;
@@ -176,7 +176,7 @@
   // A struct to thread along some pieces of a module before it is built.
   struct ModuleParts {
     std::vector<ParserComment>* comments;
-    Attributes* attributes;
+    AttributeGroup* attributeGroup;
     Decl::Visibility visibility;
     Module::Kind kind;
     PODUniqueString name;
@@ -188,7 +188,7 @@
     Decl::Visibility visibility;
     Decl::Linkage linkage;
     AstNode* linkageName;
-    Attributes* attributes;
+    AttributeGroup* attributeGroup;
     PODUniqueString name;
     asttags::AstTag tag;
   };
@@ -252,7 +252,7 @@
     Variable::Kind variableKind;
 
     // simple pointer values
-    Attributes* attribute;
+    AttributeGroup* attributeGroup;
     Block* block;
     Call* call;
     Function* function;
@@ -540,7 +540,7 @@
 %type <commentsAndStmt> class_level_stmt
 %type <commentsAndStmt> inner_class_level_stmt
 %type <commentsAndStmt> forwarding_decl_stmt
-%type <attribute> forwarding_decl_start
+%type <attributeGroup> forwarding_decl_start
 %type <commentsAndStmt> extern_export_decl_stmt
 %type <commentsAndStmt> extern_block_stmt
 %type <commentsAndStmt> return_stmt
@@ -891,7 +891,7 @@ module_decl_start:
 
       ModuleParts parts = {
         .comments=context->gatherComments(loc),
-        .attributes=context->buildAttributes(@$).release(),
+        .attributeGroup=context->buildAttributeGroup(@$).release(),
         .visibility=$1,
         .kind=$2,
         .name=$4
@@ -911,7 +911,7 @@ module_decl_stmt:
       ModuleParts parts = $1;
       ParserExprList* body = context->makeList();
       context->appendList(body, context->gatherComments(@3));
-      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributes),
+      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -926,7 +926,7 @@ module_decl_stmt:
       ModuleParts parts = $1;
       ParserExprList* body = $3;
       context->appendList(body, context->gatherComments(@4));
-      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributes),
+      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -939,7 +939,7 @@ module_decl_stmt:
       ModuleParts parts = $1;
       auto err = ErroneousExpression::build(BUILDER, LOC(@3));
       ParserExprList* body = context->makeList(std::move(err));
-      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributes),
+      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -1438,8 +1438,8 @@ forwarding_decl_stmt:
 forwarding_decl_start:
   TFORWARDING
   {
-    $$ = context->buildAttributes(@$).release();
-    context->resetAttributePartsState();
+    $$ = context->buildAttributeGroup(@$).release();
+    context->resetAttributeGroupPartsState();
   }
 ;
 
@@ -1777,7 +1777,7 @@ ifvar:
   TVAR   ident_def TASSIGN expr
   {
     auto varDecl = Variable::build(BUILDER, LOC(@$),
-                                   /*attributes*/ nullptr,
+                                   /*attributeGroup*/ nullptr,
                                    Decl::DEFAULT_VISIBILITY,
                                    Decl::DEFAULT_LINKAGE,
                                    /*linkageName*/ nullptr,
@@ -1792,7 +1792,7 @@ ifvar:
 | TCONST ident_def TASSIGN expr
   {
     auto varDecl = Variable::build(BUILDER, LOC(@$),
-                                   /*attributes*/ nullptr,
+                                   /*attributeGroup*/ nullptr,
                                    Decl::DEFAULT_VISIBILITY,
                                    Decl::DEFAULT_LINKAGE,
                                    /*linkageName*/ nullptr,
@@ -1938,7 +1938,7 @@ catch_expr:
 catch_expr_inner:
   ident_def
   {
-    $$ = Variable::build(BUILDER, LOC(@$), /*attributes*/ nullptr,
+    $$ = Variable::build(BUILDER, LOC(@$), /*attributeGroup*/ nullptr,
                          Decl::DEFAULT_VISIBILITY,
                          Decl::DEFAULT_LINKAGE,
                          /*linkageName*/ nullptr,
@@ -1951,7 +1951,7 @@ catch_expr_inner:
   }
 | ident_def TCOLON expr
   {
-    $$ = Variable::build(BUILDER, LOC(@$), /*attributes*/ nullptr,
+    $$ = Variable::build(BUILDER, LOC(@$), /*attributeGroup*/ nullptr,
                          Decl::DEFAULT_VISIBILITY,
                          Decl::DEFAULT_LINKAGE,
                          /*linkageName*/ nullptr,
@@ -2102,7 +2102,7 @@ enum_decl_stmt:
       // get any comments after the last element but before the closing brace
       context->appendList(list, context->gatherComments(@3));
 
-      auto decl = Enum::build(BUILDER, LOC(@$), toOwned(parts.attributes),
+      auto decl = Enum::build(BUILDER, LOC(@$), toOwned(parts.attributeGroup),
                               parts.visibility,
                               parts.name,
                               context->consumeList(list));
@@ -2135,39 +2135,39 @@ enum_ls:
   deprecated_enum_item
   {
     $$ = context->makeList($1);
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 | enum_ls TCOMMA
   {
     $$ = $1;
     context->clearCommentsBefore(@2);
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 | enum_ls TCOMMA
   {
     context->clearCommentsBefore(@2);
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
   deprecated_enum_item
   {
     context->appendList($1, $4);
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 |
   unstable_enum_item
   {
     $$ = context->makeList($1);
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 | enum_ls TCOMMA
   {
     context->clearCommentsBefore(@2);
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
   unstable_enum_item
   {
     context->appendList($1, $4);
-    context->resetAttributePartsState();
+    context->resetAttributeGroupPartsState();
   }
 
 ;
@@ -2215,14 +2215,14 @@ enum_item:
   ident_def
     {
       auto decl = EnumElement::build(BUILDER, LOC(@$),
-                                     context->buildAttributes(@$),
+                                     context->buildAttributeGroup(@$),
                                      $1);
       $$ = STMT(@$, decl.release());
     }
 | ident_def TASSIGN expr
     {
       auto decl = EnumElement::build(BUILDER, LOC(@$),
-                                     context->buildAttributes(@$),
+                                     context->buildAttributeGroup(@$),
                                      $1,
                                      toOwned($3));
       $$ = STMT(@$, decl.release());
@@ -2237,9 +2237,9 @@ lambda_decl_start:
       context->noteDeclStartLoc(@1);
       auto loc = context->declStartLoc(@$);
       fp.comments = context->gatherComments(loc);
-      fp.attributes = context->buildAttributes(@$).release();
+      fp.attributeGroup = context->buildAttributeGroup(@$).release();
       fp.visibility = context->visibility;
-      context->resetAttributePartsState();
+      context->resetAttributeGroupPartsState();
       fp.kind = Function::PROC;
       $$ = fp;
     }
@@ -2333,7 +2333,7 @@ fn_type:
     fp.throws = ($6 == ThrowsTag_THROWS);
     fp.body = nullptr;
     fp.comments = nullptr;
-    fp.attributes = nullptr;
+    fp.attributeGroup = nullptr;
     fp.visibility = context->visibility;
     $$ = fp;
   }
@@ -2435,7 +2435,7 @@ fn_decl_stmt_inner:
     {
       FunctionParts fp = $1;
       fp.thisIntent = $2;
-      fp.receiver = Formal::build(BUILDER, LOC(@3), /*attributes*/ nullptr,
+      fp.receiver = Formal::build(BUILDER, LOC(@3), /*attributeGroup*/ nullptr,
                                   STR("this"), $2, toOwned($3),
                                   nullptr).release();
       fp.name = context->buildIdent(@5, $5);
@@ -2446,7 +2446,7 @@ fn_decl_stmt_inner:
     {
       FunctionParts fp = $1;
       fp.thisIntent = $2;
-      fp.receiver = Formal::build(BUILDER, LOC(@3), /*attributes*/ nullptr,
+      fp.receiver = Formal::build(BUILDER, LOC(@3), /*attributeGroup*/ nullptr,
                                   STR("this"), $2, toOwned($3),
                                   nullptr).release();
       fp.name = context->buildIdent(@5, $5);
@@ -2468,9 +2468,9 @@ fn_decl_stmt_start:
       context->noteDeclStartLoc(@2);
       auto loc = context->declStartLoc(@$);
       fp.comments = context->gatherComments(loc);
-      fp.attributes = context->buildAttributes(@$).release();
+      fp.attributeGroup = context->buildAttributeGroup(@$).release();
       fp.visibility = context->visibility;
-      context->resetAttributePartsState();
+      context->resetAttributeGroupPartsState();
       fp.kind = $2;
       $$ = fp;
     }
@@ -2753,7 +2753,7 @@ type_alias_decl_stmt_inner:
   {
     // TODO (dlongnecke-cray): Add a helper to build this and var_decl_stmt.
     auto node = Variable::build(BUILDER, LOC(@$),
-                                context->buildAttributes(@$),
+                                context->buildAttributeGroup(@$),
                                 context->visibility,
                                 context->linkage,
                                 context->consumeVarDeclLinkageName(),
@@ -2820,7 +2820,7 @@ var_decl_stmt_inner:
   ident_def opt_type opt_init_expr
     {
       auto varDecl = Variable::build(BUILDER, LOC(@$),
-                                     context->buildAttributes(@$),
+                                     context->buildAttributeGroup(@$),
                                      context->visibility,
                                      context->linkage,
                                      context->consumeVarDeclLinkageName(),
@@ -2837,7 +2837,7 @@ var_decl_stmt_inner:
     {
       auto intentOrKind = (TupleDecl::IntentOrKind) context->varDeclKind;
       auto tupleDecl = TupleDecl::build(BUILDER, LOC(@$),
-                                        context->buildAttributes(@$),
+                                        context->buildAttributeGroup(@$),
                                         context->visibility,
                                         context->linkage,
                                         intentOrKind,
@@ -3430,7 +3430,7 @@ intent_expr:
   {
     if (auto ident = $2->toIdentifier()) {
       auto name = ident->name();
-      auto node = TaskVar::build(BUILDER, LOC(@$), /*attributes*/ nullptr,
+      auto node = TaskVar::build(BUILDER, LOC(@$), /*attributeGroup*/ nullptr,
                                  name,
                                  /*intent*/ $1,
                                  toOwned($3),

--- a/frontend/lib/parsing/flex-chpl-lib.cpp
+++ b/frontend/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 1 "flex-chpl-lib.cpp"
+#line 2 "flex-chpl-lib.cpp"
 
-#line 3 "flex-chpl-lib.cpp"
+#line 4 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1087,10 +1087,10 @@ static void processInvalidToken(yyscan_t scanner);
 static bool yy_has_state(yyscan_t scanner);
 }
 
-#line 1090 "flex-chpl-lib.cpp"
+#line 1091 "flex-chpl-lib.cpp"
 /* hex float literals, have decimal exponents indicating the power of 2 */
 
-#line 1093 "flex-chpl-lib.cpp"
+#line 1094 "flex-chpl-lib.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -1380,7 +1380,7 @@ YY_DECL
 #line 113 "chpl.lex"
 
 
-#line 1383 "flex-chpl-lib.cpp"
+#line 1384 "flex-chpl-lib.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2390,7 +2390,7 @@ YY_RULE_SETUP
 #line 330 "chpl.lex"
 ECHO;
 	YY_BREAK
-#line 2393 "flex-chpl-lib.cpp"
+#line 2394 "flex-chpl-lib.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();

--- a/frontend/lib/parsing/flex-chpl-lib.h
+++ b/frontend/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 5 "flex-chpl-lib.h"
+#line 6 "flex-chpl-lib.h"
 
-#line 7 "flex-chpl-lib.h"
+#line 8 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -730,6 +730,6 @@ extern int yylex \
 #line 330 "chpl.lex"
 
 
-#line 733 "flex-chpl-lib.h"
+#line 734 "flex-chpl-lib.h"
 #undef yychpl_IN_HEADER
 #endif /* yychpl_HEADER_H */

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -927,14 +927,14 @@ ConfigSettingsList& configSettings(Context* context) {
   return QUERY_END(result);
 }
 
-const uast::Attributes* idToAttributes(Context* context, ID id) {
-  const uast::Attributes* ret = nullptr;
+const uast::AttributeGroup* idToAttributeGroup(Context* context, ID id) {
+  const uast::AttributeGroup* ret = nullptr;
   if (id.isEmpty()) return ret;
 
   auto ast = parsing::idToAst(context, id);
   if (ast && ast->isDecl()) {
     auto decl = ast->toDecl();
-    ret = decl->attributes();
+    ret = decl->attributeGroup();
   }
 
   return ret;
@@ -956,12 +956,12 @@ anyParentMatches(Context* context, ID id,
 }
 
 static bool isAstDeprecated(Context* context, const AstNode* ast) {
-  auto attr = parsing::idToAttributes(context, ast->id());
+  auto attr = parsing::idToAttributeGroup(context, ast->id());
   return attr && attr->isDeprecated();
 }
 
 static bool isAstUnstable(Context* context, const AstNode* ast) {
-  auto attr = parsing::idToAttributes(context, ast->id());
+  auto attr = parsing::idToAttributeGroup(context, ast->id());
   return attr && attr->isDeprecated();
 }
 
@@ -983,7 +983,7 @@ static bool
 deprecationWarningForIdImpl(Context* context, ID idMention, ID idTarget) {
   if (idMention.isEmpty() || idTarget.isEmpty()) return false;
 
-  auto attributes = parsing::idToAttributes(context, idTarget);
+  auto attributes = parsing::idToAttributeGroup(context, idTarget);
   if (!attributes) return false;
 
   bool isDeprecated = attributes->hasPragma(PRAGMA_DEPRECATED) ||
@@ -1018,7 +1018,7 @@ static bool
 unstableWarningForIdImpl(Context* context, ID idMention, ID idTarget) {
   if (idMention.isEmpty() || idTarget.isEmpty()) return false;
 
-  auto attributes = parsing::idToAttributes(context, idTarget);
+  auto attributes = parsing::idToAttributeGroup(context, idTarget);
   if (!attributes) return false;
 
   bool isUnstable = attributes->hasPragma(PRAGMA_UNSTABLE) ||
@@ -1051,7 +1051,7 @@ unstableWarningForIdQuery(Context* context, ID idMention, ID idTarget) {
 
 void
 reportDeprecationWarningForId(Context* context, ID idMention, ID idTarget) {
-  auto attr = parsing::idToAttributes(context, idTarget);
+  auto attr = parsing::idToAttributeGroup(context, idTarget);
 
   // Nothing to do, symbol is not deprecated.
   if (!attr || !attr->isDeprecated()) return;
@@ -1064,7 +1064,7 @@ reportDeprecationWarningForId(Context* context, ID idMention, ID idTarget) {
 
 void
 reportUnstableWarningForId(Context* context, ID idMention, ID idTarget) {
-  auto attr = parsing::idToAttributes(context, idTarget);
+  auto attr = parsing::idToAttributeGroup(context, idTarget);
 
   // Nothing to do, symbol is not unstable.
   if (!attr || !attr->isUnstable()) return;

--- a/frontend/lib/uast/AttributeGroup.cpp
+++ b/frontend/lib/uast/AttributeGroup.cpp
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-#include "chpl/uast/Attributes.h"
+#include "chpl/uast/AttributeGroup.h"
 
 #include "chpl/uast/Builder.h"
 
@@ -25,7 +25,7 @@ namespace chpl {
 namespace uast {
 
 
-owned<Attributes> Attributes::build(Builder* builder, Location loc,
+owned<AttributeGroup> AttributeGroup::build(Builder* builder, Location loc,
                                     std::set<PragmaTag> pragmas,
                                     bool isDeprecated,
                                     bool isUnstable,
@@ -37,7 +37,7 @@ owned<Attributes> Attributes::build(Builder* builder, Location loc,
     }
   #endif
 
-  Attributes* ret = new Attributes(std::move(pragmas), isDeprecated,
+  AttributeGroup* ret = new AttributeGroup(std::move(pragmas), isDeprecated,
                                    isUnstable,
                                    deprecationMessage,
                                    unstableMessage);

--- a/frontend/lib/uast/Begin.cpp
+++ b/frontend/lib/uast/Begin.cpp
@@ -39,7 +39,7 @@ owned<Begin> Begin::build(Builder* builder,
                           BlockStyle blockStyle,
                           AstList stmts) {
   AstList lst;
-  int8_t withClauseChildNum = -1;
+  int8_t withClauseChildNum = NO_CHILD;
 
   if (withClause.get() != nullptr) {
     withClauseChildNum = lst.size();

--- a/frontend/lib/uast/BracketLoop.cpp
+++ b/frontend/lib/uast/BracketLoop.cpp
@@ -37,9 +37,9 @@ owned<BracketLoop> BracketLoop::build(Builder* builder, Location loc,
   CHPL_ASSERT(body.get() != nullptr);
 
   AstList lst;
-  int8_t indexChildNum = -1;
-  int8_t iterandChildNum = -1;
-  int8_t withClauseChildNum = -1;
+  int8_t indexChildNum = NO_CHILD;
+  int8_t iterandChildNum = NO_CHILD;
+  int8_t withClauseChildNum = NO_CHILD;
 
   if (index.get() != nullptr) {
     indexChildNum = lst.size();

--- a/frontend/lib/uast/Break.cpp
+++ b/frontend/lib/uast/Break.cpp
@@ -36,7 +36,7 @@ std::string Break::dumpChildLabelInner(int i) const {
 owned<Break> Break::build(Builder* builder, Location loc,
                           owned<Identifier> target) {
   AstList lst;
-  int8_t targetChildNum = -1;
+  int8_t targetChildNum = NO_CHILD;
 
   if (target.get() != nullptr) {
     targetChildNum = lst.size();

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -178,7 +178,7 @@ void Builder::createImplicitModuleIfNeeded() {
     stmts.swap(topLevelExpressions_);
     auto loc = Location(filepath_, 1, 1, 1, 1);
     auto ownedModule = Module::build(this, std::move(loc),
-                                     /*attributes*/ nullptr,
+                                     /*attributeGroup*/ nullptr,
                                      Decl::DEFAULT_VISIBILITY,
                                      inferredModuleName,
                                      Module::IMPLICIT,
@@ -427,7 +427,7 @@ void Builder::lookupConfigSettingsForVar(Variable* var, pathVecT& pathVec, std::
         || configPair.first == possibleModule + var->name().str()) {
       // found a config that was set via cmd line
       // handle deprecations
-      if (auto attribs = var->attributes()) {
+      if (auto attribs = var->attributeGroup()) {
         if (attribs->isDeprecated()) {
           // TODO: Need proper message handling here
           std::string msg = "'" + var->name().str() + "' was set via a compiler flag";

--- a/frontend/lib/uast/CMakeLists.txt
+++ b/frontend/lib/uast/CMakeLists.txt
@@ -25,7 +25,7 @@ target_sources(ChplFrontend-obj
                AstNode.cpp
                AstTag.cpp
                As.cpp
-               Attributes.cpp
+               AttributeGroup.cpp
                Begin.cpp
                Block.cpp
                BoolLiteral.cpp

--- a/frontend/lib/uast/Catch.cpp
+++ b/frontend/lib/uast/Catch.cpp
@@ -42,8 +42,8 @@ owned<Catch> Catch::build(Builder* builder, Location loc,
   CHPL_ASSERT(body.get() != nullptr);
 
   AstList lst;
-  int8_t errorChildNum = -1;
-  int8_t bodyChildNum = -1;
+  int8_t errorChildNum = NO_CHILD;
+  int8_t bodyChildNum = NO_CHILD;
 
   if (error.get() != nullptr) {
     errorChildNum = lst.size();

--- a/frontend/lib/uast/Class.cpp
+++ b/frontend/lib/uast/Class.cpp
@@ -34,20 +34,20 @@ std::string Class::dumpChildLabelInner(int i) const {
 }
 
 owned<Class> Class::build(Builder* builder, Location loc,
-                          owned<Attributes> attributes,
+                          owned<AttributeGroup> attributeGroup,
                           Decl::Visibility vis,
                           UniqueString name,
                           owned<AstNode> parentClass,
                           AstList contents) {
   AstList lst;
-  int attributesChildNum = -1;
-  int parentClassChildNum = -1;
-  int elementsChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
+  int parentClassChildNum = NO_CHILD;
+  int elementsChildNum = NO_CHILD;
   int numElements = 0;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (parentClass.get() != nullptr) {
@@ -62,7 +62,7 @@ owned<Class> Class::build(Builder* builder, Location loc,
     }
   }
 
-  Class* ret = new Class(std::move(lst), attributesChildNum, vis, name,
+  Class* ret = new Class(std::move(lst), attributeGroupChildNum, vis, name,
                          elementsChildNum,
                          numElements,
                          parentClassChildNum);

--- a/frontend/lib/uast/Cobegin.cpp
+++ b/frontend/lib/uast/Cobegin.cpp
@@ -42,7 +42,7 @@ owned<Cobegin> Cobegin::build(Builder* builder,
                               owned<WithClause> withClause,
                               AstList taskBodies) {
   AstList lst;
-  int8_t withClauseChildNum = -1;
+  int8_t withClauseChildNum = NO_CHILD;
 
   if (withClause.get() != nullptr) {
     withClauseChildNum = lst.size();

--- a/frontend/lib/uast/Coforall.cpp
+++ b/frontend/lib/uast/Coforall.cpp
@@ -36,9 +36,9 @@ owned<Coforall> Coforall::build(Builder* builder, Location loc,
   CHPL_ASSERT(body.get() != nullptr);
 
   AstList lst;
-  int8_t indexChildNum = -1;
-  int8_t iterandChildNum = -1;
-  int8_t withClauseChildNum = -1;
+  int8_t indexChildNum = NO_CHILD;
+  int8_t iterandChildNum = NO_CHILD;
+  int8_t withClauseChildNum = NO_CHILD;
 
   if (index.get() != nullptr) {
     indexChildNum = lst.size();

--- a/frontend/lib/uast/Continue.cpp
+++ b/frontend/lib/uast/Continue.cpp
@@ -36,7 +36,7 @@ std::string Continue::dumpChildLabelInner(int i) const {
 owned<Continue> Continue::build(Builder* builder, Location loc,
                                 owned<Identifier> target) {
   AstList lst;
-  int8_t targetChildNum = -1;
+  int8_t targetChildNum = NO_CHILD;
 
   if (target.get() != nullptr) {
     targetChildNum = lst.size();

--- a/frontend/lib/uast/Decl.cpp
+++ b/frontend/lib/uast/Decl.cpp
@@ -37,9 +37,7 @@ void Decl::dumpFieldsInner(const DumpSettings& s) const {
   }
 }
 std::string Decl::dumpChildLabelInner(int i) const {
-  if (i == attributesChildNum_) {
-    return "attributes";
-  } else if (i == linkageNameChildNum_) {
+  if (i == linkageNameChildNum_) {
     return "linkage-name";
   }
 

--- a/frontend/lib/uast/Enum.cpp
+++ b/frontend/lib/uast/Enum.cpp
@@ -26,23 +26,23 @@ namespace uast {
 
 
 owned<Enum> Enum::build(Builder* builder, Location loc,
-                        owned<Attributes> attributes,
+                        owned<AttributeGroup> attributeGroup,
                         Decl::Visibility vis,
                         UniqueString name,
                         AstList stmts) {
   AstList lst;
-  int attributesChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   for (auto& ast : stmts) {
     lst.push_back(std::move(ast));
   }
 
-  Enum* ret = new Enum(std::move(lst), attributesChildNum, vis, name);
+  Enum* ret = new Enum(std::move(lst), attributeGroupChildNum, vis, name);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/frontend/lib/uast/EnumElement.cpp
+++ b/frontend/lib/uast/EnumElement.cpp
@@ -26,31 +26,31 @@ namespace uast {
 
 
 owned<EnumElement> EnumElement::build(Builder* builder, Location loc,
-                                      owned<Attributes> attributes,
+                                      owned<AttributeGroup> attributeGroup,
                                       UniqueString name,
                                       owned<AstNode> initExpression) {
   AstList lst;
-  int attributesChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (initExpression.get() != nullptr) {
     lst.push_back(std::move(initExpression));
   }
 
-  EnumElement* ret = new EnumElement(std::move(lst), attributesChildNum,
+  EnumElement* ret = new EnumElement(std::move(lst), attributeGroupChildNum,
                                      name);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }
 
 owned<EnumElement> EnumElement::build(Builder* builder, Location loc,
-                                      owned<Attributes> attributes,
+                                      owned<AttributeGroup> attributeGroup,
                                       UniqueString name) {
-  return EnumElement::build(builder, loc, std::move(attributes),
+  return EnumElement::build(builder, loc, std::move(attributeGroup),
                             name,
                             /*initExpression*/ nullptr);
 }

--- a/frontend/lib/uast/For.cpp
+++ b/frontend/lib/uast/For.cpp
@@ -45,8 +45,8 @@ owned<For> For::build(Builder* builder,
   if (isParam) CHPL_ASSERT(!isExpressionLevel);
 
   AstList lst;
-  int8_t indexChildNum = -1;
-  int8_t iterandChildNum = -1;
+  int8_t indexChildNum = NO_CHILD;
+  int8_t iterandChildNum = NO_CHILD;
 
   if (index.get() != nullptr) {
     indexChildNum = lst.size();

--- a/frontend/lib/uast/Forall.cpp
+++ b/frontend/lib/uast/Forall.cpp
@@ -36,9 +36,9 @@ owned<Forall> Forall::build(Builder* builder, Location loc,
   CHPL_ASSERT(body.get() != nullptr);
 
   AstList lst;
-  int8_t indexChildNum = -1;
-  int8_t iterandChildNum = -1;
-  int8_t withClauseChildNum = -1;
+  int8_t indexChildNum = NO_CHILD;
+  int8_t iterandChildNum = NO_CHILD;
+  int8_t withClauseChildNum = NO_CHILD;
 
   if (index.get() != nullptr) {
     indexChildNum = lst.size();

--- a/frontend/lib/uast/Foreach.cpp
+++ b/frontend/lib/uast/Foreach.cpp
@@ -37,9 +37,9 @@ owned<Foreach> Foreach::build(Builder* builder,
   CHPL_ASSERT(body.get() != nullptr);
 
   AstList lst;
-  int8_t indexChildNum = -1;
-  int8_t iterandChildNum = -1;
-  int8_t withClauseChildNum = -1;
+  int8_t indexChildNum = NO_CHILD;
+  int8_t iterandChildNum = NO_CHILD;
+  int8_t withClauseChildNum = NO_CHILD;
 
   if (index.get() != nullptr) {
     indexChildNum = lst.size();

--- a/frontend/lib/uast/Formal.cpp
+++ b/frontend/lib/uast/Formal.cpp
@@ -42,19 +42,20 @@ const char* Formal::intentToString(Formal::Intent intent) {
 }
 
 owned<Formal>
-Formal::build(Builder* builder, Location loc, owned<Attributes> attributes,
+Formal::build(Builder* builder, Location loc,
+              owned<AttributeGroup> attributeGroup,
               UniqueString name,
               Formal::Intent intent,
               owned<AstNode> typeExpression,
               owned<AstNode> initExpression) {
   AstList lst;
-  int attributesChildNum = -1;
-  int8_t typeExpressionChildNum = -1;
-  int8_t initExpressionChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
+  int8_t typeExpressionChildNum = NO_CHILD;
+  int8_t initExpressionChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (typeExpression.get() != nullptr) {
@@ -67,7 +68,7 @@ Formal::build(Builder* builder, Location loc, owned<Attributes> attributes,
     lst.push_back(std::move(initExpression));
   }
 
-  Formal* ret = new Formal(std::move(lst), attributesChildNum,
+  Formal* ret = new Formal(std::move(lst), attributeGroupChildNum,
                            name,
                            intent,
                            typeExpressionChildNum,

--- a/frontend/lib/uast/ForwardingDecl.cpp
+++ b/frontend/lib/uast/ForwardingDecl.cpp
@@ -26,27 +26,27 @@ namespace uast {
 
 
 owned<ForwardingDecl> ForwardingDecl::build(Builder* builder, Location loc,
-                                            owned<Attributes> attributes,
+                                            owned<AttributeGroup> attributeGroup,
                                             owned<AstNode> expr) {
   CHPL_ASSERT(expr.get() != nullptr);
 
-  return ForwardingDecl::build(builder, loc, std::move(attributes),
+  return ForwardingDecl::build(builder, loc, std::move(attributeGroup),
                                std::move(expr),
                                Decl::DEFAULT_VISIBILITY);
 }
 
 owned<ForwardingDecl> ForwardingDecl::build(Builder* builder, Location loc,
-                                            owned<Attributes> attributes,
+                                            owned<AttributeGroup> attributeGroup,
                                             owned<AstNode> expr,
                                             Decl::Visibility visibility) {
   CHPL_ASSERT(expr.get() != nullptr);
-  int attributesChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
   AstList lst;
 
-  // store the attributes and the location of the attributes node if one exists
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  // store the attributeGroup and the location of the attributeGroup node
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   // store the child node
@@ -54,7 +54,7 @@ owned<ForwardingDecl> ForwardingDecl::build(Builder* builder, Location loc,
 
   ForwardingDecl* ret = new ForwardingDecl(std::move(lst),
                                            visibility,
-                                           attributesChildNum);
+                                           attributeGroupChildNum);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/frontend/lib/uast/Function.cpp
+++ b/frontend/lib/uast/Function.cpp
@@ -98,7 +98,7 @@ const char* Function::kindToString(Kind kind) {
 
 
 owned<Function> Function::build(Builder* builder, Location loc,
-                                owned<Attributes> attributes,
+                                owned<AttributeGroup> attributeGroup,
                                 Decl::Visibility vis,
                                 Function::Linkage linkage,
                                 owned<AstNode> linkageNameExpr,
@@ -118,20 +118,20 @@ owned<Function> Function::build(Builder* builder, Location loc,
                                 owned<Block> body) {
   AstList lst;
 
-  int attributesChildNum = -1;
-  int linkageNameExprChildNum = -1;
-  int formalsChildNum = -1;
-  int thisFormalChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
+  int linkageNameExprChildNum = NO_CHILD;
+  int formalsChildNum = NO_CHILD;
+  int thisFormalChildNum = NO_CHILD;
   int numFormals = 0;
-  int returnTypeChildNum = -1;
-  int whereChildNum = -1;
-  int lifetimeChildNum = -1;
+  int returnTypeChildNum = NO_CHILD;
+  int whereChildNum = NO_CHILD;
+  int lifetimeChildNum = NO_CHILD;
   int numLifetimeParts = 0;
-  int bodyChildNum = -1;
+  int bodyChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (linkageNameExpr.get() != nullptr) {
@@ -140,7 +140,7 @@ owned<Function> Function::build(Builder* builder, Location loc,
   }
 
   if (receiver.get() == nullptr && formals.size() == 0) {
-    // leave formalsChildNum == -1
+    // leave formalsChildNum == NO_CHILD
   } else {
     formalsChildNum = lst.size();
     if (receiver.get() != nullptr) {
@@ -176,7 +176,7 @@ owned<Function> Function::build(Builder* builder, Location loc,
     lst.push_back(std::move(body));
   }
 
-  Function* ret = new Function(std::move(lst), attributesChildNum, vis,
+  Function* ret = new Function(std::move(lst), attributeGroupChildNum, vis,
                                linkage,
                                name,
                                inline_,

--- a/frontend/lib/uast/Interface.cpp
+++ b/frontend/lib/uast/Interface.cpp
@@ -45,22 +45,22 @@ std::string Interface::dumpChildLabelInner(int i) const {
 
 
 owned<Interface> Interface::build(Builder* builder, Location loc,
-                                  owned<Attributes> attributes,
+                                  owned<AttributeGroup> attributeGroup,
                                   Decl::Visibility visibility,
                                   UniqueString name,
                                   bool isFormalListPresent,
                                   AstList formals,
                                   AstList body) {
   AstList children;
-  int attributesChildNum = AstNode::NO_CHILD;
+  int attributeGroupChildNum = AstNode::NO_CHILD;
   int interfaceFormalsChildNum = AstNode::NO_CHILD;
   int numInterfaceFormals = 0;
   int bodyChildNum = AstNode::NO_CHILD;
   int numBodyStmts = 0;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = children.size();
-    children.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = children.size();
+    children.push_back(std::move(attributeGroup));
   }
 
   if (formals.size() != 0) {
@@ -75,7 +75,7 @@ owned<Interface> Interface::build(Builder* builder, Location loc,
     for (auto& ast : body) children.push_back(std::move(ast));
   }
 
-  Interface* ret = new Interface(std::move(children), attributesChildNum,
+  Interface* ret = new Interface(std::move(children), attributeGroupChildNum,
                                  visibility,
                                  name,
                                  interfaceFormalsChildNum,

--- a/frontend/lib/uast/Local.cpp
+++ b/frontend/lib/uast/Local.cpp
@@ -39,7 +39,7 @@ owned<Local> Local::build(Builder* builder,
                           AstList stmts) {
 
   AstList lst;
-  int8_t condChildNum = -1;
+  int8_t condChildNum = NO_CHILD;
 
   const int bodyChildNum = lst.size();
   const int numBodyStmts = stmts.size();
@@ -63,7 +63,7 @@ owned<Local> Local::build(Builder* builder,
   CHPL_ASSERT(condition.get() != nullptr);
 
   AstList lst;
-  int8_t condChildNum = -1;
+  int8_t condChildNum = NO_CHILD;
 
   if (condition.get() != nullptr) {
     condChildNum = lst.size();

--- a/frontend/lib/uast/Makefile.include
+++ b/frontend/lib/uast/Makefile.include
@@ -28,7 +28,7 @@ FRONTEND_UAST_SRCS = \
   AstNode.cpp \
   AstTag.cpp \
   As.cpp \
-  Attributes.cpp \
+  AttributeGroup.cpp \
   Begin.cpp \
   Block.cpp \
   BoolLiteral.cpp \

--- a/frontend/lib/uast/Manage.cpp
+++ b/frontend/lib/uast/Manage.cpp
@@ -37,9 +37,9 @@ owned<Manage> Manage::build(Builder* builder, Location loc,
                             AstList managers,
                             BlockStyle blockStyle,
                             AstList stmts) {
-  int managerExprChildNum = -1;
+  int managerExprChildNum = NO_CHILD;
   const int numManagerExprs = managers.size();
-  int bodyChildNum = -1;
+  int bodyChildNum = NO_CHILD;
   const int numBodyStmts = stmts.size();
   AstList children;
 

--- a/frontend/lib/uast/Module.cpp
+++ b/frontend/lib/uast/Module.cpp
@@ -45,23 +45,23 @@ void Module::dumpFieldsInner(const DumpSettings& s) const {
 
 owned<Module>
 Module::build(Builder* builder, Location loc,
-              owned<Attributes> attributes,
+              owned<AttributeGroup> attributeGroup,
               Decl::Visibility vis,
               UniqueString name,
               Module::Kind kind, AstList stmts) {
   AstList lst;
-  int attributesChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   for (auto& ast : stmts) {
     lst.push_back(std::move(ast));
   }
 
-  Module* ret = new Module(std::move(lst), attributesChildNum, vis,
+  Module* ret = new Module(std::move(lst), attributeGroupChildNum, vis,
                            name,
                            kind);
   builder->noteLocation(ret, loc);

--- a/frontend/lib/uast/MultiDecl.cpp
+++ b/frontend/lib/uast/MultiDecl.cpp
@@ -36,16 +36,16 @@ bool MultiDecl::isAcceptableMultiDecl() {
 }
 
 owned<MultiDecl> MultiDecl::build(Builder* builder, Location loc,
-                                  owned<Attributes> attributes,
+                                  owned<AttributeGroup> attributeGroup,
                                   Decl::Visibility vis,
                                   Decl::Linkage linkage,
                                   AstList varDecls) {
   AstList lst;
-  int attributesChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   for (auto& ast : varDecls) {
@@ -53,7 +53,7 @@ owned<MultiDecl> MultiDecl::build(Builder* builder, Location loc,
   }
 
 
-  MultiDecl* ret = new MultiDecl(std::move(lst), attributesChildNum,
+  MultiDecl* ret = new MultiDecl(std::move(lst), attributeGroupChildNum,
                                  vis,
                                  linkage);
   builder->noteLocation(ret, loc);

--- a/frontend/lib/uast/Range.cpp
+++ b/frontend/lib/uast/Range.cpp
@@ -55,8 +55,8 @@ owned<Range> Range::build(Builder* builder, Location loc,
                           owned<AstNode> lowerBound,
                           owned<AstNode> upperBound) {
   AstList lst;
-  int8_t lowerBoundChildNum = -1;
-  int8_t upperBoundChildNum = -1;
+  int8_t lowerBoundChildNum = NO_CHILD;
+  int8_t upperBoundChildNum = NO_CHILD;
 
   if (lowerBound.get() != nullptr) {
     lowerBoundChildNum = lst.size();

--- a/frontend/lib/uast/Record.cpp
+++ b/frontend/lib/uast/Record.cpp
@@ -26,21 +26,21 @@ namespace uast {
 
 
 owned<Record> Record::build(Builder* builder, Location loc,
-                            owned<Attributes> attributes,
+                            owned<AttributeGroup> attributeGroup,
                             Decl::Visibility vis,
                             Decl::Linkage linkage,
                             owned<AstNode> linkageName,
                             UniqueString name,
                             AstList contents) {
   AstList lst;
-  int attributesChildNum = -1;
-  int elementsChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
+  int elementsChildNum = NO_CHILD;
   int numElements = contents.size();
-  int linkageNameChildNum = -1;
+  int linkageNameChildNum = NO_CHILD;
 
-  if (attributes.get()) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get()) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (linkageName.get()) {
@@ -53,7 +53,7 @@ owned<Record> Record::build(Builder* builder, Location loc,
     lst.push_back(std::move(ast));
   }
 
-  Record* ret = new Record(std::move(lst), attributesChildNum, vis,
+  Record* ret = new Record(std::move(lst), attributeGroupChildNum, vis,
                            linkage,
                            linkageNameChildNum,
                            name,

--- a/frontend/lib/uast/Return.cpp
+++ b/frontend/lib/uast/Return.cpp
@@ -28,7 +28,7 @@ namespace uast {
 owned<Return> Return::build(Builder* builder, Location loc,
                             owned<AstNode> value) {
   AstList lst;
-  int8_t valueChildNum = -1;
+  int8_t valueChildNum = NO_CHILD;
 
   if (value.get() != nullptr) {
     valueChildNum = lst.size();

--- a/frontend/lib/uast/Serial.cpp
+++ b/frontend/lib/uast/Serial.cpp
@@ -39,7 +39,7 @@ owned<Serial> Serial::build(Builder* builder,
                           AstList stmts) {
 
   AstList lst;
-  int8_t condChildNum = -1;
+  int8_t condChildNum = NO_CHILD;
 
   const int bodyChildNum = lst.size();
   const int numBodyStmts = stmts.size();
@@ -63,7 +63,7 @@ owned<Serial> Serial::build(Builder* builder,
   CHPL_ASSERT(condition.get() != nullptr);
 
   AstList lst;
-  int8_t condChildNum = -1;
+  int8_t condChildNum = NO_CHILD;
 
   if (condition.get() != nullptr) {
     condChildNum = lst.size();

--- a/frontend/lib/uast/TaskVar.cpp
+++ b/frontend/lib/uast/TaskVar.cpp
@@ -26,19 +26,19 @@ namespace uast {
 
 
 owned<TaskVar> TaskVar::build(Builder* builder, Location loc,
-                              owned<Attributes> attributes,
+                              owned<AttributeGroup> attributeGroup,
                               UniqueString name,
                               TaskVar::Intent intent,
                               owned<AstNode> typeExpression,
                               owned<AstNode> initExpression) {
   AstList lst;
-  int attributesChildNum = -1;
-  int8_t typeExpressionChildNum = -1;
-  int8_t initExpressionChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
+  int8_t typeExpressionChildNum = NO_CHILD;
+  int8_t initExpressionChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (typeExpression.get() != nullptr) {
@@ -51,7 +51,7 @@ owned<TaskVar> TaskVar::build(Builder* builder, Location loc,
     lst.push_back(std::move(initExpression));
   }
 
-  TaskVar* ret = new TaskVar(std::move(lst), attributesChildNum,
+  TaskVar* ret = new TaskVar(std::move(lst), attributeGroupChildNum,
                              name,
                              intent,
                              typeExpressionChildNum,

--- a/frontend/lib/uast/TupleDecl.cpp
+++ b/frontend/lib/uast/TupleDecl.cpp
@@ -53,7 +53,7 @@ bool TupleDecl::assertAcceptableTupleDecl() {
   int i = 0;
 
   for (const auto& elt: children_) {
-    if (elt.get() == attributes()) {
+    if (elt.get() == attributeGroup()) {
       // TODO: Make sure it is equivalent to components?
     } else if (i == typeExpressionChildNum_) {
       // no checking needed
@@ -82,7 +82,7 @@ bool TupleDecl::assertAcceptableTupleDecl() {
 }
 
 owned<TupleDecl> TupleDecl::build(Builder* builder, Location loc,
-                                  owned<Attributes> attributes,
+                                  owned<AttributeGroup> attributeGroup,
                                   Decl::Visibility vis,
                                   Decl::Linkage linkage,
                                   TupleDecl::IntentOrKind intentOrKind,
@@ -90,14 +90,14 @@ owned<TupleDecl> TupleDecl::build(Builder* builder, Location loc,
                                   owned<AstNode> typeExpression,
                                   owned<AstNode> initExpression) {
   AstList list;
-  int attributesChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
   int numElements = 0;
-  int typeExpressionChildNum = -1;
-  int initExpressionChildNum = -1;
+  int typeExpressionChildNum = NO_CHILD;
+  int initExpressionChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = list.size();
-    list.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = list.size();
+    list.push_back(std::move(attributeGroup));
   }
 
   numElements = elements.size();
@@ -117,7 +117,7 @@ owned<TupleDecl> TupleDecl::build(Builder* builder, Location loc,
     list.push_back(std::move(initExpression));
   }
 
-  TupleDecl* ret = new TupleDecl(std::move(list), attributesChildNum,
+  TupleDecl* ret = new TupleDecl(std::move(list), attributeGroupChildNum,
                                  vis,
                                  linkage,
                                  intentOrKind,

--- a/frontend/lib/uast/Union.cpp
+++ b/frontend/lib/uast/Union.cpp
@@ -26,21 +26,21 @@ namespace uast {
 
 
 owned<Union> Union::build(Builder* builder, Location loc,
-                          owned<Attributes> attributes,
+                          owned<AttributeGroup> attributeGroup,
                           Decl::Visibility vis,
                           Decl::Linkage linkage,
                           owned<AstNode> linkageName,
                           UniqueString name,
                           AstList contents) {
   AstList lst;
-  int attributesChildNum = -1;
-  int elementsChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
+  int elementsChildNum = NO_CHILD;
   int numElements = contents.size();
-  int linkageNameChildNum = -1;
+  int linkageNameChildNum = NO_CHILD;
 
-  if (attributes.get()) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get()) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (linkageName.get()) {
@@ -53,7 +53,7 @@ owned<Union> Union::build(Builder* builder, Location loc,
     lst.push_back(std::move(ast));
   }
 
-  Union* ret = new Union(std::move(lst), attributesChildNum, vis,
+  Union* ret = new Union(std::move(lst), attributeGroupChildNum, vis,
                          linkage,
                          linkageNameChildNum,
                          name,

--- a/frontend/lib/uast/VarArgFormal.cpp
+++ b/frontend/lib/uast/VarArgFormal.cpp
@@ -34,19 +34,19 @@ std::string VarArgFormal::dumpChildLabelInner(int i) const {
 }
 
 owned<VarArgFormal> VarArgFormal::build(Builder* builder, Location loc,
-                                        owned<Attributes> attributes,
+                                        owned<AttributeGroup> attributeGroup,
                                         UniqueString name,
                                         Formal::Intent intent,
                                         owned<AstNode> typeExpression,
                                         owned<AstNode> count) {
   AstList lst;
-  int attributesChildNum = -1;
-  int8_t typeExpressionChildNum = -1;
-  int8_t countChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
+  int8_t typeExpressionChildNum = NO_CHILD;
+  int8_t countChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (typeExpression.get() != nullptr) {
@@ -59,7 +59,7 @@ owned<VarArgFormal> VarArgFormal::build(Builder* builder, Location loc,
     lst.push_back(std::move(count));
   }
 
-  VarArgFormal* ret = new VarArgFormal(std::move(lst), attributesChildNum,
+  VarArgFormal* ret = new VarArgFormal(std::move(lst), attributeGroupChildNum,
                                        name,
                                        intent,
                                        typeExpressionChildNum,

--- a/frontend/lib/uast/Variable.cpp
+++ b/frontend/lib/uast/Variable.cpp
@@ -37,7 +37,7 @@ void Variable::dumpFieldsInner(const DumpSettings& s) const {
 
 owned<Variable>
 Variable::build(Builder* builder, Location loc,
-                owned<Attributes> attributes,
+                owned<AttributeGroup> attributeGroup,
                 Decl::Visibility vis,
                 Decl::Linkage linkage,
                 owned<AstNode> linkageName,
@@ -48,14 +48,14 @@ Variable::build(Builder* builder, Location loc,
                 owned<AstNode> typeExpression,
                 owned<AstNode> initExpression) {
   AstList lst;
-  int attributesChildNum = -1;
-  int linkageNameChildNum = -1;
-  int8_t typeExpressionChildNum = -1;
-  int8_t initExpressionChildNum = -1;
+  int attributeGroupChildNum = NO_CHILD;
+  int linkageNameChildNum = NO_CHILD;
+  int8_t typeExpressionChildNum = NO_CHILD;
+  int8_t initExpressionChildNum = NO_CHILD;
 
-  if (attributes.get() != nullptr) {
-    attributesChildNum = lst.size();
-    lst.push_back(std::move(attributes));
+  if (attributeGroup.get() != nullptr) {
+    attributeGroupChildNum = lst.size();
+    lst.push_back(std::move(attributeGroup));
   }
 
   if (linkageName.get() != nullptr) {
@@ -73,7 +73,7 @@ Variable::build(Builder* builder, Location loc,
     lst.push_back(std::move(initExpression));
   }
 
-  Variable* ret = new Variable(std::move(lst), attributesChildNum,
+  Variable* ret = new Variable(std::move(lst), attributeGroupChildNum,
                                vis,
                                linkage,
                                linkageNameChildNum,
@@ -88,14 +88,15 @@ Variable::build(Builder* builder, Location loc,
 }
 
 void Variable::setInitExprForConfig(owned<AstNode> ie) {
-  if (this->initExpressionChildNum_ > -1) {
+  if (this->initExpressionChildNum_ > NO_CHILD) {
     // have an existing initExpr, swap it
     this->children_[this->initExpressionChildNum_].swap(ie);
   } else {
     // no initExpr and no typeExpr nor attribute
     initExpressionChildNum_ = children_.size();
     children_.push_back(std::move(ie));
-    if (this->typeExpressionChildNum_ > -1 || this->attributesChildNum() > -1) {
+    if (this->typeExpressionChildNum_ > NO_CHILD ||
+        this->attributeGroupChildNum() > NO_CHILD) {
       CHPL_ASSERT(numChildren() > 1);
     } else {
       CHPL_ASSERT(numChildren() == 1);

--- a/frontend/lib/uast/When.cpp
+++ b/frontend/lib/uast/When.cpp
@@ -39,7 +39,7 @@ owned<When> When::build(Builder* builder, Location loc,
   AstList lst;
   const int numCaseExprs = caseExprs.size();
   const int numBodyStmts = stmts.size();
-  int bodyChildNum = -1;
+  int bodyChildNum = NO_CHILD;
 
   for (auto& ast : caseExprs) {
     lst.push_back(std::move(ast));

--- a/frontend/lib/uast/chpl-syntax-printer.cpp
+++ b/frontend/lib/uast/chpl-syntax-printer.cpp
@@ -113,10 +113,10 @@ static const char* kindToString(VisibilityClause::LimitationKind kind) {
 
 static std::string pragmaFlagsToString(const Decl* node) {
   std::string ret;
-  if (!node->attributes()) return ret;
+  if (!node->attributeGroup()) return ret;
 
   // TODO: Add spaces after parsers are merged.
-  for (auto pragma : node->attributes()->pragmas()) {
+  for (auto pragma : node->attributeGroup()->pragmas()) {
     ret += "pragma";
     ret += "\"";
     ret += pragmaTagToName(pragma);
@@ -126,7 +126,7 @@ static std::string pragmaFlagsToString(const Decl* node) {
 }
 
 
-// TODO: Attributes
+// TODO: AttributeGroup
 
 struct ChplSyntaxVisitor {
   std::stringstream ss_;
@@ -472,7 +472,7 @@ struct ChplSyntaxVisitor {
     printAst(node->rename());
   }
 
-  //Attributes
+  //AttributeGroup
 
   void visit(const Begin* node) {
     ss_ << "begin ";
@@ -815,7 +815,7 @@ struct ChplSyntaxVisitor {
   }
 
   void visit(const Formal* node) {
-    if (node->attributes()) ss_ << pragmaFlagsToString(node);
+    if (node->attributeGroup()) ss_ << pragmaFlagsToString(node);
 
     if (node->intent() != Formal::DEFAULT_INTENT) {
       ss_ << kindToString((Qualifier) node->intent()) << " ";

--- a/frontend/test/parsing/testParseAttributes.cpp
+++ b/frontend/test/parsing/testParseAttributes.cpp
@@ -24,8 +24,8 @@
 #include "chpl/uast/all-uast.h"
 
 static bool areAttributesEqual(const Decl* lhs, const Decl* rhs) {
-  auto lhsAttr = lhs->attributes();
-  auto rhsAttr = rhs->attributes();
+  auto lhsAttr = lhs->attributeGroup();
+  auto rhsAttr = rhs->attributeGroup();
 
   if (!lhsAttr && !rhsAttr) return true;
   if (!lhsAttr || !rhsAttr) return false;
@@ -52,7 +52,7 @@ static bool areAttributesEqual(const Decl* lhs, const Decl* rhs) {
     equalPragmas;
 }
 
-// Make sure MultiDecl attributes equal component attributes.
+// Make sure MultiDecl attributeGroup equal component attributeGroup.
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
   auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
@@ -66,7 +66,7 @@ static void test0(Parser* parser) {
   auto multiVar = mod->stmt(0)->toMultiDecl();
   assert(multiVar);
 
-  auto parentAttr = multiVar->attributes();
+  auto parentAttr = multiVar->attributeGroup();
   assert(parentAttr);
   assert(!parentAttr->isDeprecated());
   assert(parentAttr->deprecationMessage().isEmpty());
@@ -78,7 +78,7 @@ static void test0(Parser* parser) {
   }
 }
 
-// Make sure TupleDecl attributes equal component attributes.
+// Make sure TupleDecl attributeGroup equal component attributeGroup.
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
   auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
@@ -92,7 +92,7 @@ static void test1(Parser* parser) {
   auto tupleVar = mod->stmt(0)->toTupleDecl();
   assert(tupleVar);
 
-  auto parentAttr = tupleVar->attributes();
+  auto parentAttr = tupleVar->attributeGroup();
   assert(parentAttr);
   assert(!parentAttr->isDeprecated());
   assert(parentAttr->deprecationMessage().isEmpty());
@@ -192,7 +192,7 @@ static void testAggregateAttributes(Parser* parser,
   assert(agg);
 
   assert(agg->tag() == aggKind);
-  auto attr = agg->attributes();
+  auto attr = agg->attributeGroup();
 
   if (isDeprecated) {
     assert(attr);
@@ -219,11 +219,11 @@ static void testAggregateAttributes(Parser* parser,
     auto var = agg->declOrComment(i)->toVariable();
     assert(var);
 
-    // Important to make sure the attributes are not incorrectly carried
+    // Important to make sure the attributeGroup are not incorrectly carried
     // down to children here.
     assert(!areAttributesEqual(var, agg));
 
-    auto varAttr = var->attributes();
+    auto varAttr = var->attributeGroup();
 
     if (doChildrenHavePragmas) {
       assert(varAttr);
@@ -235,7 +235,7 @@ static void testAggregateAttributes(Parser* parser,
   }
 }
 
-// Make sure attributes for aggregates get attached properly.
+// Make sure attributeGroup for aggregates get attached properly.
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
   testAggregateAttributes(parser, /*aggKind*/ asttags::Class,
@@ -297,7 +297,7 @@ static void test3(Parser* parser) {
   auto var = mod->stmt(0)->toVariable();
   assert(var);
 
-  auto varAttr = var->attributes();
+  auto varAttr = var->attributeGroup();
   assert(varAttr);
 
   assert(varAttr->hasPragma(PRAGMA_NO_DOC));
@@ -322,7 +322,7 @@ static void test4(Parser* parser) {
   auto mod = parseResult.singleModule();
   assert(mod);
 
-  auto modAttr = mod->attributes();
+  auto modAttr = mod->attributeGroup();
   assert(modAttr);
   assert(modAttr->isDeprecated());
   assert(modAttr->deprecationMessage() == "Module is deprecated");
@@ -358,18 +358,18 @@ static void test5(Parser* parser) {
 
   auto p1 = mod->stmt(0)->toFunction();
   assert(p1);
-  auto p1Attr = p1->attributes();
+  auto p1Attr = p1->attributeGroup();
   assert(p1Attr);
   assert(p1Attr->isDeprecated());
   assert(p1Attr->deprecationMessage() == "P1 is deprecated");
   assert(p1Attr->hasPragma(PRAGMA_NO_DOC));
 
   auto p2 = mod->stmt(1)->toFunction();
-  assert(!p2->attributes());
+  assert(!p2->attributeGroup());
 
   auto p3 = mod->stmt(2)->toFunction();
   assert(p3);
-  auto p3Attr = p3->attributes();
+  auto p3Attr = p3->attributeGroup();
   assert(p3Attr);
   assert(!p3Attr->isDeprecated());
   assert(p3Attr->deprecationMessage().isEmpty());
@@ -378,10 +378,10 @@ static void test5(Parser* parser) {
   assert(p3->numStmts() == 2);
   auto p3n1 = p3->stmt(0)->toFunction();
   assert(p3n1);
-  assert(!p3n1->attributes());
+  assert(!p3n1->attributeGroup());
   auto p3n2 = p3->stmt(1)->toFunction();
   assert(p3n2);
-  auto p3n2Attr = p3n2->attributes();
+  auto p3n2Attr = p3n2->attributeGroup();
   assert(p3n2Attr);
   assert(p3n2Attr->isDeprecated());
   assert(p3n2Attr->deprecationMessage() == "N2 is deprecated");
@@ -389,7 +389,7 @@ static void test5(Parser* parser) {
 
   auto p4 = mod->stmt(3)->toFunction();
   assert(p4);
-  auto p4Attr = p4->attributes();
+  auto p4Attr = p4->attributeGroup();
   assert(p4Attr);
   assert(p4Attr->isDeprecated());
   assert(p4Attr->deprecationMessage() == "P4 is deprecated");
@@ -397,29 +397,29 @@ static void test5(Parser* parser) {
   assert(p4->numFormals() == 2);
   auto p4f1 = p4->formal(0)->toFormal();
   assert(p4f1);
-  auto p4f1Attr = p4f1->attributes();
+  auto p4f1Attr = p4f1->attributeGroup();
   assert(p4f1Attr);
   assert(!p4f1Attr->isDeprecated());
   assert(p4f1Attr->deprecationMessage().isEmpty());
   assert(p4f1Attr->hasPragma(PRAGMA_NO_INIT));
   auto p4f2 = p4->formal(1)->toFormal();
   assert(p4f2);
-  assert(!p4f2->attributes());
+  assert(!p4f2->attributeGroup());
 
   auto p5 = mod->stmt(4)->toFunction();
   assert(p5);
-  auto p5Attr = p5->attributes();
+  auto p5Attr = p5->attributeGroup();
   assert(p5Attr);
   assert(p5Attr->isDeprecated());
   assert(p5Attr->deprecationMessage() == "P5 is deprecated");
   assert(p5->numFormals() == 2);
   auto p5f1 = p5->formal(0)->toFormal();
   assert(p5f1);
-  assert(!p5f1->attributes());
+  assert(!p5f1->attributeGroup());
 
   auto p5f2 = p5->formal(1)->toFormal();
   assert(p5f2);
-  auto p5f2Attr = p5f2->attributes();
+  auto p5f2Attr = p5f2->attributeGroup();
   assert(p5f2Attr);
   assert(!p5f2Attr->isDeprecated());
   assert(p5f2Attr->deprecationMessage().isEmpty());
@@ -427,14 +427,14 @@ static void test5(Parser* parser) {
 
   auto p6 = mod->stmt(5)->toFunction();
   assert(p6);
-  auto p6Attr = p6->attributes();
+  auto p6Attr = p6->attributeGroup();
   assert(p6Attr);
   assert(!p6Attr->isDeprecated());
   assert(p6Attr->hasPragma(PRAGMA_NO_DOC));
   assert(p6->numStmts() == 1);
   auto p6v1 = p6->stmt(0)->toVariable();
   assert(p6v1);
-  assert(!p6v1->attributes());
+  assert(!p6v1->attributeGroup());
 }
 
 // Enum elements can be deprecated.
@@ -455,7 +455,7 @@ static void test6(Parser* parser) {
   assert(mod->numStmts() == 1);
   auto en = mod->stmt(0)->toEnum();
   assert(en);
-  auto enAttr = en->attributes();
+  auto enAttr = en->attributeGroup();
   assert(enAttr);
   assert(enAttr->isDeprecated());
   assert(enAttr->deprecationMessage() == "Enum is deprecated");
@@ -463,18 +463,18 @@ static void test6(Parser* parser) {
   assert(en->numDeclOrComments() == 3);
   auto ee1 = en->declOrComment(0)->toEnumElement();
   assert(ee1);
-  assert(!ee1->attributes());
+  assert(!ee1->attributeGroup());
   auto ee2 = en->declOrComment(1)->toEnumElement();
   assert(ee2);
   assert(ee2->initExpression());
-  assert(!ee2->initExpression()->isAttributes());
-  auto ee2Attr = ee2->attributes();
+  assert(!ee2->initExpression()->isAttributeGroup());
+  auto ee2Attr = ee2->attributeGroup();
   assert(ee2Attr);
   assert(ee2Attr->isDeprecated());
   assert(ee2Attr->deprecationMessage() == "Element b is deprecated");
   auto ee3 = en->declOrComment(2)->toEnumElement();
   assert(ee3);
-  assert(!ee3->attributes());
+  assert(!ee3->attributeGroup());
 }
 
 int main() {

--- a/frontend/test/parsing/testParseForwardingDecl.cpp
+++ b/frontend/test/parsing/testParseForwardingDecl.cpp
@@ -334,8 +334,8 @@ static void test8(Parser* parser) {
   const ForwardingDecl* fwd = record->child(0)->toForwardingDecl();
   assert(fwd);
   assert(fwd->expr()->isVariable());
-  assert(fwd->attributes());
-  auto attr = fwd->attributes();
+  assert(fwd->attributeGroup());
+  auto attr = fwd->attributeGroup();
   assert(attr);
   assert(!attr->isDeprecated());
   assert(attr->hasPragma(PRAGMA_NO_DOC));
@@ -367,8 +367,8 @@ static void test9(Parser* parser) {
   assert(fwd);
   assert(fwd->numChildren() == 2);
   assert(fwd->expr()->isVariable());
-  assert(fwd->attributes());
-  auto attr = fwd->attributes();
+  assert(fwd->attributeGroup());
+  auto attr = fwd->attributeGroup();
   assert(attr);
   assert(attr->isDeprecated());
   assert(!attr->hasPragma(PRAGMA_NO_DOC));

--- a/frontend/test/uast/testBuildIDs.cpp
+++ b/frontend/test/uast/testBuildIDs.cpp
@@ -347,7 +347,7 @@ static void test4() {
       ii.push_back(Identifier::build(b, dummyLoc, strA));
       ii.push_back(Identifier::build(b, dummyLoc, strB));
       ii.push_back(Identifier::build(b, dummyLoc, strC));
-      inner.push_back(Module::build(b, dummyLoc, /*attributes*/ nullptr,
+      inner.push_back(Module::build(b, dummyLoc, /*attributeGroup*/ nullptr,
                                     Decl::DEFAULT_VISIBILITY,
                                     strI,
                                     Module::DEFAULT_MODULE_KIND,
@@ -355,7 +355,7 @@ static void test4() {
     }
     inner.push_back(Identifier::build(b, dummyLoc, strX));
 
-    auto mod = Module::build(b, dummyLoc, /*attributes*/ nullptr,
+    auto mod = Module::build(b, dummyLoc, /*attributeGroup*/ nullptr,
                              Decl::DEFAULT_VISIBILITY,
                              strM,
                              Module::DEFAULT_MODULE_KIND,

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -235,7 +235,7 @@ or
    import $MODULE;)RAW";
 
 static bool isNoDoc(const Decl* e) {
-  if (auto attrs = e->attributes()) {
+  if (auto attrs = e->attributeGroup()) {
     return attrs->hasPragma(pragmatags::PRAGMA_NO_DOC);
   }
   return false;
@@ -1330,7 +1330,7 @@ struct RstResultBuilder {
   }
 
   void showUnstableWarning(const Decl* node, bool indentComment=true) {
-    if (auto attrs = node->attributes()) {
+    if (auto attrs = node->attributeGroup()) {
       if (attrs->isUnstable()) {
         int commentShift = 0;
           if (indentComment) {
@@ -1346,7 +1346,7 @@ struct RstResultBuilder {
   }
 
   void showDeprecationMessage(const Decl* node, bool indentComment=true) {
-    if (auto attrs = node->attributes()) {
+    if (auto attrs = node->attributeGroup()) {
       if (attrs->isDeprecated() && !textOnly_) {
         auto comment = previousComment(context_, node->id());
         if (comment && !comment->str().empty() &&
@@ -1456,7 +1456,7 @@ struct RstResultBuilder {
     }
     assert(!moduleName.empty());
     const Comment* lastComment = nullptr;
-    if (auto attrs = m->attributes()) {
+    if (auto attrs = m->attributeGroup()) {
       if (attrs->hasPragma(pragmatags::PRAGMA_MODULE_INCLUDED_BY_DEFAULT)) {
         includedByDefault = true;
       }
@@ -1626,7 +1626,7 @@ struct RstResultBuilder {
       }
       showComment(md, true);
 
-      if (auto attrs = md->attributes()) {
+      if (auto attrs = md->attributeGroup()) {
         if (attrs->isDeprecated() && !textOnly_) {
           indentStream(os_, 1 * indentPerDepth) << ".. warning::\n";
           indentStream(os_, 2 * indentPerDepth) << attrs->deprecationMessage();


### PR DESCRIPTION
This PR renames the uast node `Attributes` to `AttributeGroup` and
moves the location from `Decl` to its parent, `AstNode`. 

The purpose of these changes is to support placing attributes on
loops and other non-decl nodes, and moving it to the base AstNode 
provides the most flexibility.

While making this change I also replaced all the uses of the literal
`-1` to indicate "no-child" to the constant `AstNode::NO_CHILD`

TESTING:

- [x] paratest w/futures `[Summary: #Successes = 14439 | #Failures = 0 | #Futures = 898]`


reviewed by @DanilaFe - thank you!