### PR TITLE
dyno: fix lookups extending outside scopes

### DIFF
--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -540,32 +540,34 @@ static bool doLookupInScope(Context* context,
         if (isElseBlockOfConditionalWithIfVar(context, ast))
           skipClosestConditional = true;
 
-    for (cur = scope->parentScope(); cur != nullptr; cur = cur->parentScope()) {
-      if (asttags::isModule(cur->tag())) {
-        reachedModule = true;
-        break;
-      }
-
-      auto ast = !cur->id().isEmpty() ? parsing::idToAst(context, cur->id())
-                                      : nullptr;
-
-      // We could be in a nested block, so check for the else-block to
-      // trigger the pattern matching as we walk up...
-      if (!skipClosestConditional && ast)
-        if (isElseBlockOfConditionalWithIfVar(context, ast))
-          skipClosestConditional = true;
-
-      // Skip the first conditional's scope if we need to.
-      if (skipClosestConditional) {
-        if (ast && ast->isConditional()) {
-          skipClosestConditional = false;
-          continue;
+    if (!asttags::isModule(scope->tag())) {
+      for (cur = scope->parentScope(); cur != nullptr; cur = cur->parentScope()) {
+        if (asttags::isModule(cur->tag())) {
+          reachedModule = true;
+          break;
         }
-      }
 
-      bool got = doLookupInScope(context, cur, receiverScope, resolving, name,
-                                 newConfig, checkedScopes, result);
-      if (onlyInnermost && got) return true;
+        auto ast = !cur->id().isEmpty() ? parsing::idToAst(context, cur->id())
+                                        : nullptr;
+
+        // We could be in a nested block, so check for the else-block to
+        // trigger the pattern matching as we walk up...
+        if (!skipClosestConditional && ast)
+          if (isElseBlockOfConditionalWithIfVar(context, ast))
+            skipClosestConditional = true;
+
+        // Skip the first conditional's scope if we need to.
+        if (skipClosestConditional) {
+          if (ast && ast->isConditional()) {
+            skipClosestConditional = false;
+            continue;
+          }
+        }
+
+        bool got = doLookupInScope(context, cur, receiverScope, resolving, name,
+                                   newConfig, checkedScopes, result);
+        if (onlyInnermost && got) return true;
+      }
     }
 
     // Skip should have been performed if needed, at least once.


### PR DESCRIPTION
The current mechanism for looking up a variable in a scope traverses the scope chain upwards until it hits a module. Unfortunately, when the _starting_ scope is a module, this meant that the _starting_ scope's parents, their parents, and so on, would be checked. This is improper, since a variable declared inside an inner module should not have access to the variables in the outer module.

<details>
<summary>Test program and output</summary>

__Program__
```Chapel
module A {
    param x = 1;
    module B {
        param y = x;
    }
}
```

__Compiler output__
```
➜  chapel git:(daniel-scope-resolve-6) chpl nesting.chpl --main-module A.B
nesting.chpl:3: In module 'B':
nesting.chpl:4: error: 'x' undeclared (first use this function)
```
</details>

So, this PR adds a check to prevent the parent-scope iteration if the current scope is a module.

## Testing
- [x] full local testing (0 failures)
- [x] full local testing with `--dyno` (130 failures, down from 132 on main at the time of fork)

Reviewed by @dlongnecke-cray -- thanks!

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>