### PR TITLE
fix(build): check for existence of git binary in CMake

### DIFF
--- a/frontend/lib/CMakeLists.txt
+++ b/frontend/lib/CMakeLists.txt
@@ -20,24 +20,26 @@
 # If one exists, the write-git-sha script will only update it if the
 # values are different.
 # If CHPL_DONT_BUILD_SHA is set in the ENV, the git-sha will always be xxxxxxxxxx
-if (EXISTS ${CMAKE_SOURCE_DIR}/.git)
-        execute_process(COMMAND ${CHPL_CMAKE_PYTHON}
-                                ${CMAKE_SOURCE_DIR}/util/config/write-git-sha
-                                ${CMAKE_CURRENT_SOURCE_DIR}/util
-                                --build-version
-                                --chpl-home=${CHPL_HOME})
-        message(STATUS "wrote git-version.cpp")
+find_package(Git)
+if (EXISTS ${CMAKE_SOURCE_DIR}/.git AND Git_FOUND)
+  execute_process(COMMAND ${CHPL_CMAKE_PYTHON}
+                          ${CMAKE_SOURCE_DIR}/util/config/write-git-sha
+                          ${CMAKE_CURRENT_SOURCE_DIR}/util
+                          --build-version
+                          --chpl-home=${CHPL_HOME}
+                          )
+  message(STATUS "wrote git-version.cpp")
 elseif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/util/git-version.cpp)
-# if we are not in a git repo, but we don't already have a git-version.cpp file,
-# write one as if CHPL_DONT_BUILD_SHA was set so we dont execute the git command
-        execute_process(COMMAND ${CMAKE_COMMAND} -E env
-                        CHPL_DONT_BUILD_SHA=1
-                        ${CHPL_CMAKE_PYTHON}
-                        ${CMAKE_SOURCE_DIR}/util/config/write-git-sha
-                        ${CMAKE_CURRENT_SOURCE_DIR}/util
-        --build-version
-        --chpl-home=${CHPL_HOME})
-        message(STATUS "wrote git-version.cpp")
+# if we are not in a git repo, or the git binary doesn't exist on this machine,
+# write a git-version.cpp file (if one doesn't exist) as if CHPL_DONT_BUILD_SHA
+# was set so we dont try to execute the git command
+  execute_process(COMMAND ${CMAKE_COMMAND} -E env CHPL_DONT_BUILD_SHA=1
+                          ${CHPL_CMAKE_PYTHON}
+                          ${CMAKE_SOURCE_DIR}/util/config/write-git-sha
+                          ${CMAKE_CURRENT_SOURCE_DIR}/util
+                          --build-version
+                          --chpl-home=${CHPL_HOME})
+  message(STATUS "wrote git-version.cpp with dummy xxxxxxxxxx git sha")
 endif()
 
 add_library(git-sha-obj OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/util/git-version.cpp)

--- a/frontend/lib/CMakeLists.txt
+++ b/frontend/lib/CMakeLists.txt
@@ -39,7 +39,7 @@ elseif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/util/git-version.cpp)
                           ${CMAKE_CURRENT_SOURCE_DIR}/util
                           --build-version
                           --chpl-home=${CHPL_HOME})
-  message(STATUS "wrote git-version.cpp with dummy xxxxxxxxxx git sha")
+  message(STATUS "wrote git-version.cpp with dummy sha")
 endif()
 
 add_library(git-sha-obj OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/util/git-version.cpp)


### PR DESCRIPTION
This PR modifies the build system behavior to check for the existence
of the git binary before trying to write a git sha value to `git-version.cpp`.
If git is not found or .git is not found, and we don't have an existing
`git-version.cpp` file, then write a dummy sha (`xxxxxxxxxx`) to the file.

TESTING:

- [x] builds in Docker without git installed
- [x] builds locally with git installed

reviewed by @mppf - thanks!