### PR TITLE
Fix a typo from opaque-pointer changes

### DIFF
--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -719,7 +719,7 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
 #if HAVE_LLVM_VER >= 150
         Type* DstTy = oldStore->getType();
 #else
-        Type* origDstTy = oldStore->getValueOperand()->getType();
+        Type* origDstTy = oldStore->getPointerOperand()->getType();
         Type* DstTy = origDstTy->getPointerElementType()->getPointerTo(0);
 #endif
         Value* Dst = irBuilder.CreatePointerCast(i8Dst, DstTy);


### PR DESCRIPTION
Fixes an unintentional change from https://github.com/chapel-lang/chapel/pull/21121 that caused nightly test failures.

Thanks @mppf for the debugging help.

Testing:
- manually verified this resolves the observed nightly test failure