### PR TITLE
Update the comment in this test file

### DIFF
--- a/test/classes/initializers/cond-only-then-2.chpl
+++ b/test/classes/initializers/cond-only-then-2.chpl
@@ -1,4 +1,4 @@
-// Confirm that the compiler rejects a conditional with inconsistent
+// Confirm that the compiler accepts a conditional with different
 // use of field initializers
 
 record MyRec {


### PR DESCRIPTION
This test file comment was out of date - conditionals with different uses of field initializers are fine

Noticed while working on supporting initializers that throw during Phase 2.

Passed a fresh checkout of the test