### PR TITLE
Skip my day11 AoC 2022 test for 32-bit platforms

### DIFF
--- a/test/studies/adventOfCode/2022/day11/bradc/SKIPIF
+++ b/test/studies/adventOfCode/2022/day11/bradc/SKIPIF
@@ -1,0 +1,8 @@
+# 32-bit platforms don't use native qthread 'sync' variables and are
+# painfully slow for this benchmark's full problem size, so skip them.
+# Arm also doesn't currently support native qthread 'sync' variables,
+# but should soon, so Elliot suggested not worrying about that for now
+# (and we're not seeing failures in our current testing configurations,
+# likely just due to not running these tests on arm).
+#
+CHPL_TARGET_PLATFORM <= 32


### PR DESCRIPTION
My day 11 solution is 'sync' variable based, and on 32-bit platforms,
'sync' is not implemented with native qthread syncs, so is painfully slow.
Skip this test in those configurations for that reason. ARM-based systems
also don't use native qthread 'sync', but should soon, and we're not seeing
failures with this test in those configs (most likely, not testing this test in
those configs), so I'm not skipping it for now.

This issue made me wonder whether we would want to have a CHPL_SYNCS
setting like CHPL_ATOMICS that said which implementation we were using s.t.
a skipif could focus on that rather than platform-specific details.