### PR TITLE
Switch the error system away from using queries towards `owned` pointers.

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -923,7 +923,8 @@ static ModuleSymbol* dynoParseFile(const char* fileName,
   // see if there were any parse errors.
   chpl::UniqueString emptySymbolPath;
   auto& builderResult =
-    chpl::parsing::parseFileToBuilderResult(gContext, path, emptySymbolPath);
+    chpl::parsing::parseFileToBuilderResultAndCheck(gContext, path,
+                                                    emptySymbolPath);
   gFilenameLookup.push_back(path.c_str());
 
   if (dynoRealizeErrors()) USR_STOP();

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -34,7 +34,6 @@
 #include "misc.h"
 
 #include "chpl/parsing/parsing-queries.h"
-#include "llvm/ADT/SmallPtrSet.h"
 
 // Turn this on to dump AST/uAST when using --dyno.
 #define DUMP_WHEN_CONVERTING_UAST_TO_AST 0
@@ -889,11 +888,9 @@ static DynoErrorHandler* gDynoErrorHandler = nullptr;
 static bool dynoRealizeErrors(void) {
   INT_ASSERT(gDynoErrorHandler);
   bool hadErrors = false;
-  llvm::SmallPtrSet<const chpl::ErrorBase*, 10> issuedErrors;
   for (auto& err : gDynoErrorHandler->errors()) {
     hadErrors = true;
     // skip issuing errors that have already been issued
-    if (!issuedErrors.insert(err.get()).second) continue;
     if (fDetailedErrors) {
       chpl::Context::defaultReportError(gContext, err.get());
       // Use production compiler's exit-on-error functionality for errors

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -111,8 +111,8 @@ class DynoErrorHandler : public chpl::Context::ErrorHandler {
   }
 
   virtual void
-  report(chpl::Context* context, chpl::owned<chpl::ErrorBase> err) override {
-    errors_.push_back(std::move(err));
+  report(chpl::Context* context, const chpl::ErrorBase* err) override {
+    errors_.push_back(err->clone());
   }
 
   inline void clear() { errors_.clear(); }

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -929,10 +929,6 @@ static ModuleSymbol* dynoParseFile(const char* fileName,
     chpl::parsing::parseFileToBuilderResult(gContext, path, emptySymbolPath);
   gFilenameLookup.push_back(path.c_str());
 
-  // Manually report any parsing errors collected by the builder.
-  // TODO skipping this now, since the builder shouldn't have any errors
-  // for (auto e : builderResult.errors()) gContext->report(e);
-
   if (dynoRealizeErrors()) USR_STOP();
 
   ModuleSymbol* lastModSym = nullptr;

--- a/frontend/include/chpl/framework/Context-detail.h
+++ b/frontend/include/chpl/framework/Context-detail.h
@@ -221,7 +221,7 @@ static inline void queryArgsPrint(const std::tuple<>& tuple) {
 }
 
 using QueryDependencyVec = std::vector<const QueryMapResultBase*>;
-using QueryErrorVec = std::vector<const ErrorBase*>;
+using QueryErrorVec = std::vector<owned<ErrorBase>>;
 
 class QueryMapResultBase {
  public:
@@ -244,13 +244,7 @@ class QueryMapResultBase {
 
   QueryMapResultBase(RevisionNumber lastChecked,
                      RevisionNumber lastChanged,
-                     QueryMapBase* parentQueryMap)
-    : lastChecked(lastChecked),
-      lastChanged(lastChanged),
-      dependencies(),
-      errors(),
-      parentQueryMap(parentQueryMap) {
-  }
+                     QueryMapBase* parentQueryMap);
   virtual ~QueryMapResultBase() = 0; // this is an abstract base class
   virtual void recompute(Context* context) const = 0;
   virtual void markUniqueStringsInResult(Context* context) const = 0;

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -80,7 +80,7 @@ class Context {
   class ErrorHandler {
    public:
     virtual ~ErrorHandler() = default;
-    virtual void report(Context* context, const ErrorBase* err) = 0;
+    virtual void report(Context* context, owned<ErrorBase> err) = 0;
   };
 
  private:
@@ -90,8 +90,8 @@ class Context {
    public:
     DefaultErrorHandler() = default;
     ~DefaultErrorHandler() = default;
-    virtual void report(Context* context, const ErrorBase* err) override {
-      defaultReportError(context, err);
+    virtual void report(Context* context, owned<ErrorBase> err) override {
+      defaultReportError(context, err.get());
     }
   };
 
@@ -100,9 +100,7 @@ class Context {
     = toOwned<ErrorHandler>(new DefaultErrorHandler());
 
   // Report an error to the current handler.
-  void reportError(Context* context, const ErrorBase* err) {
-    handler_->report(context, err);
-  }
+  void reportError(Context* context, owned<ErrorBase> err);
 
   // The CHPL_HOME variable
   const std::string chplHome_;
@@ -510,16 +508,15 @@ class Context {
 
     If no query is currently running, it just reports the error.
 
-    Returns the passed-in error for convenience.
    */
-  const ErrorBase* report(const ErrorBase* error);
+  void report(owned<ErrorBase> error);
 
   /**
     Note an error for the currently running query.
     This is a convenience overload.
     This version takes in a Location and a printf-style format string.
    */
-  const ErrorBase* error(Location loc, const char* fmt, ...)
+  void error(Location loc, const char* fmt, ...)
   #ifndef DOXYGEN
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.
@@ -533,7 +530,7 @@ class Context {
     This version takes in an ID and a printf-style format string.
     The ID is used to compute a Location using parsing::locateId.
    */
-  const ErrorBase* error(ID id, const char* fmt, ...)
+  void error(ID id, const char* fmt, ...)
   #ifndef DOXYGEN
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.
@@ -547,7 +544,7 @@ class Context {
     This version takes in an AST node and a printf-style format string.
     The AST node is used to compute a Location by using a parsing::locateAst.
    */
-  const ErrorBase* error(const uast::AstNode* ast, const char* fmt, ...)
+  void error(const uast::AstNode* ast, const char* fmt, ...)
   #ifndef DOXYGEN
     // docs generator has trouble with the attribute applied to 'build'
     // so the above ifndef works around the issue.
@@ -563,7 +560,7 @@ class Context {
     The AST node is used to compute a Location by using a parsing::locateAst.
     The TypedFnSignature is used to print out instantiation information.
    */
-  const ErrorBase* error(const resolution::TypedFnSignature* inFn,
+  void error(const resolution::TypedFnSignature* inFn,
              const uast::AstNode* ast,
              const char* fmt, ...)
   #ifndef DOXYGEN

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -80,7 +80,7 @@ class Context {
   class ErrorHandler {
    public:
     virtual ~ErrorHandler() = default;
-    virtual void report(Context* context, owned<ErrorBase> err) = 0;
+    virtual void report(Context* context, const ErrorBase* err) = 0;
   };
 
  private:
@@ -90,8 +90,8 @@ class Context {
    public:
     DefaultErrorHandler() = default;
     ~DefaultErrorHandler() = default;
-    virtual void report(Context* context, owned<ErrorBase> err) override {
-      defaultReportError(context, err.get());
+    virtual void report(Context* context, const ErrorBase* err) override {
+      defaultReportError(context, err);
     }
   };
 
@@ -100,7 +100,7 @@ class Context {
     = toOwned<ErrorHandler>(new DefaultErrorHandler());
 
   // Report an error to the current handler.
-  void reportError(Context* context, owned<ErrorBase> err);
+  void reportError(Context* context, const ErrorBase* err);
 
   // The CHPL_HOME variable
   const std::string chplHome_;

--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -195,29 +195,25 @@ class GeneralError : public BasicError {
                  std::move(message), std::move(notes)) {}
 
   static const owned<GeneralError>&
-  getGeneralErrorForID(Context* context, ErrorBase::Kind kind, ID id, std::string message);
+  getGeneralErrorForID(ErrorBase::Kind kind, ID id, std::string message);
 
   static const owned<GeneralError>&
-  getGeneralErrorForLocation(Context* context, ErrorBase::Kind kind, Location loc, std::string message);
+  getGeneralErrorForLocation(ErrorBase::Kind kind, Location loc, std::string message);
  public:
 
-  static owned<GeneralError> vbuild(Context* context,
-                                    ErrorBase::Kind kind, ID id,
+  static owned<GeneralError> vbuild(ErrorBase::Kind kind, ID id,
                                     const char* fmt,
                                     va_list vl);
-  static owned<GeneralError> vbuild(Context* context,
-                                    ErrorBase::Kind kind, Location loc,
+  static owned<GeneralError> vbuild(ErrorBase::Kind kind, Location loc,
                                     const char* fmt,
                                     va_list vl);
 
-  static owned<GeneralError> get(Context* context,
-                                 ErrorBase::Kind kind,
+  static owned<GeneralError> get(ErrorBase::Kind kind,
                                  Location loc,
                                  std::string msg);
 
   /* Convenience overload to call ::get with the ERROR kind. */
-  static owned<GeneralError> error(Context* context,
-                                   Location loc,
+  static owned<GeneralError> error(Location loc,
                                    std::string msg);
 
   owned<ErrorBase> clone() const override;
@@ -238,8 +234,6 @@ class GeneralError : public BasicError {
     Error##NAME__(ErrorInfo info) :\
       ErrorBase(KIND__, NAME__), info(std::move(info)) {}\
 \
-    static const owned<Error##NAME__>&\
-    getError##NAME__(Context* context, ErrorInfo info);\
    protected:\
     bool contentsMatchInner(const ErrorBase* other) const override {\
       auto otherCast = static_cast<const Error##NAME__*>(other);\

--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -44,7 +44,7 @@ namespace chpl {
 // Shorthands specific to post-parse-checks errors, which provide node IDs
 // that should connect to locations by the time we report out errors
 #define POSTPARSE_DIAGNOSTIC_CLASS(NAME, KIND, EINFO...) \
-  DIAGNOSTIC_CLASS(NAME, KIND, const ID, ##EINFO)
+  DIAGNOSTIC_CLASS(NAME, KIND, const uast::AstNode*, ##EINFO)
 #define POSTPARSE_ERROR_CLASS(NAME, EINFO...) \
   POSTPARSE_DIAGNOSTIC_CLASS(NAME, ERROR, ##EINFO)
 #define POSTPARSE_WARNING_CLASS(NAME, EINFO...) \

--- a/frontend/include/chpl/framework/query-impl.h
+++ b/frontend/include/chpl/framework/query-impl.h
@@ -299,7 +299,7 @@ Context::QueryStatus Context::queryStatus(
   // found an entry for this query
   QueryMapBase* base = search->second.get();
   auto queryMap = (QueryMap<ResultType, ArgTs...>*)base;
-  auto key = QueryMapResult<ResultType, ArgTs...>(queryMap, tupleOfArgs);
+  QueryMapResult<ResultType, ArgTs...> key(queryMap, tupleOfArgs);
   auto search2 = queryMap->map.find(key);
   if (search2 == queryMap->map.end()) {
     return NOT_CHECKED_NOT_CHANGED;
@@ -481,7 +481,7 @@ Context::hasCurrentResultForQuery(
   // found an entry for this query
   QueryMapBase* base = search->second.get();
   auto queryMap = (QueryMap<ResultType, ArgTs...>*)base;
-  auto key = QueryMapResult<ResultType, ArgTs...>(queryMap, tupleOfArgs);
+  QueryMapResult<ResultType, ArgTs...> key(queryMap, tupleOfArgs);
   auto search2 = queryMap->map.find(key);
   if (search2 == queryMap->map.end()) {
     return false;
@@ -507,7 +507,7 @@ Context::isQueryRunning(
   // found an entry for this query
   QueryMapBase* base = search->second.get();
   auto queryMap = (QueryMap<ResultType, ArgTs...>*)base;
-  auto key = QueryMapResult<ResultType, ArgTs...>(queryMap, tupleOfArgs);
+  QueryMapResult<ResultType, ArgTs...> key(queryMap, tupleOfArgs);
   auto search2 = queryMap->map.find(key);
   if (search2 == queryMap->map.end()) {
     return false;

--- a/frontend/include/chpl/parsing/parser-error.h
+++ b/frontend/include/chpl/parsing/parser-error.h
@@ -32,8 +32,7 @@
   P_CONTEXT__->report(LOC__,                                       \
     CHPL_PARSER_GET_ERROR(P_CONTEXT__, NAME__, LOC__, ##EINFO__))
 #define CHPL_PARSER_GET_ERROR(P_CONTEXT__, NAME__, LOC__, EINFO__...) \
-  CHPL_GET_ERROR(P_CONTEXT__->context(), NAME__,                      \
-                 P_CONTEXT__->convertLocation(LOC__), ##EINFO__)
+  CHPL_GET_ERROR(NAME__, P_CONTEXT__->convertLocation(LOC__), ##EINFO__)
 
 /**
   Helper macros to report errors from the lexer, including retrieving the
@@ -60,8 +59,8 @@
 /**
  * Helper macro to report errors in post-parse-checks to the Builder
  */
+// TODO: no longer storing errors in the builder
 #define CHPL_POSTPARSE_REPORT(BUILDER__, NAME__, NODE__, EINFO__...) \
-  (BUILDER__).addError(                                                \
-      CHPL_GET_ERROR((BUILDER__).context(), NAME__, NODE__->id(), EINFO__))
+  CHPL_REPORT((BUILDER__).context(), NAME__, NODE__->id(), EINFO__)
 
 #endif

--- a/frontend/include/chpl/parsing/parser-error.h
+++ b/frontend/include/chpl/parsing/parser-error.h
@@ -56,10 +56,4 @@
                      getLocation(SCANNER__, NLINES__, NCOLS__, MOVE_TO_END__), \
                      ##EINFO__);
 
-/**
- * Helper macro to report errors in post-parse-checks to the Builder
- */
-#define CHPL_POSTPARSE_REPORT(BUILDER__, NAME__, NODE__, EINFO__...) \
-  CHPL_REPORT((BUILDER__).context(), NAME__, NODE__->id(), EINFO__)
-
 #endif

--- a/frontend/include/chpl/parsing/parser-error.h
+++ b/frontend/include/chpl/parsing/parser-error.h
@@ -59,7 +59,6 @@
 /**
  * Helper macro to report errors in post-parse-checks to the Builder
  */
-// TODO: no longer storing errors in the builder
 #define CHPL_POSTPARSE_REPORT(BUILDER__, NAME__, NODE__, EINFO__...) \
   CHPL_REPORT((BUILDER__).context(), NAME__, NODE__->id(), EINFO__)
 

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -78,10 +78,6 @@ bool hasFileText(Context* context, const std::string& path);
 /**
   This query reads a file (with the fileText query) and then parses it.
 
-  Errors encountered are stored in the returned 'BuilderResult' and are
-  not reported to the Context. They must be handled manually, or they
-  can be reported by calling the 'parse' query instead.
-
   The 'parentSymbolPath' is relevant for submodules that are in separate files
   with 'module include'. When parsing the included module for a 'module
   include', 'parentSymbolPath' should match the symbolPath of the ID of the
@@ -92,6 +88,14 @@ bool hasFileText(Context* context, const std::string& path);
 const uast::BuilderResult&
 parseFileToBuilderResult(Context* context, UniqueString path,
                          UniqueString parentSymbolPath);
+
+/**
+  Like parseFileToBuilderResult but also runs post-parse checks on the resulting
+  builder result.
+ */
+const uast::BuilderResult&
+parseFileToBuilderResultAndCheck(Context* context, UniqueString path,
+                                 UniqueString parentSymbolPath);
 
 /**
   Like parseFileToBuilderResult but parses whatever file contained 'id'.

--- a/frontend/include/chpl/uast/Builder.h
+++ b/frontend/include/chpl/uast/Builder.h
@@ -55,7 +55,6 @@ class Builder final {
   UniqueString filepath_;
   UniqueString startingSymbolPath_;
   AstList topLevelExpressions_;
-  std::vector<const ErrorBase*> errors_;
 
   // note: notedLocations_ might have keys pointing to deleted uAST
   // nodes in the event one is created temporarily during parsing.
@@ -102,11 +101,6 @@ class Builder final {
     This is called by the parser.
    */
   void addToplevelExpression(owned<AstNode> e);
-
-  /**
-    Save an error.
-   */
-  void addError(const ErrorBase*);
 
   /**
     Record the location of an AST element.

--- a/frontend/include/chpl/uast/Builder.h
+++ b/frontend/include/chpl/uast/Builder.h
@@ -79,7 +79,6 @@ class Builder final {
   void doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
                    int& commentIndex, pathVecT& pathVec,
                    declaredHereT& duplicates);
-  void postParseChecks();
 
  public:
   /** Construct a Builder for parsing a top-level module */

--- a/frontend/include/chpl/uast/BuilderResult.h
+++ b/frontend/include/chpl/uast/BuilderResult.h
@@ -81,7 +81,6 @@ class BuilderResult final {
  private:
   UniqueString filePath_;
   AstList topLevelExpressions_;
-  std::vector<const ErrorBase*> errors_;
 
   // Given an ID, what is the AstNode?
   llvm::DenseMap<ID, const AstNode*> idToAst_;
@@ -133,26 +132,6 @@ class BuilderResult final {
     return nullptr;
   }
 
-  /** return the number of errors */
-  int numErrors() const {
-    return errors_.size();
-  }
-
-  /** return the i'th error */
-  const ErrorBase* error(int i) const {
-    return errors_[i];
-  }
-
-  // An iterable over the errors of this.
-  using ErrorIterable = Iterable<std::vector<const ErrorBase*>>;
-
-  /**
-    Iterate over the errors.
-  */
-  ErrorIterable errors() const {
-    return ErrorIterable(errors_);
-  }
-
   /** Find the AstNode* corresponding to a particular ID, or return
       nullptr if there is not one in this result. */
   const AstNode* idToAst(ID id) const;
@@ -180,7 +159,6 @@ class BuilderResult final {
 
   // these two should only be called by the parser
   static void updateFilePaths(Context* context, const BuilderResult& keep);
-  static void appendError(BuilderResult& keep, const ErrorBase* error);
 };
 
 

--- a/frontend/include/chpl/uast/post-parse-checks.h
+++ b/frontend/include/chpl/uast/post-parse-checks.h
@@ -17,32 +17,25 @@
  * limitations under the License.
  */
 
-#ifndef TEST_COMMON_H
-#define TEST_COMMON_H
+#ifndef CHPL_UAST_POST_PARSE_CHECKS_H
+#define CHPL_UAST_POST_PARSE_CHECKS_H
 
-// always check assertions in the tests
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
-#include "chpl/parsing/Parser.h"
 #include "chpl/framework/Context.h"
-#include "chpl/framework/UniqueString.h"
 #include "chpl/uast/BuilderResult.h"
-#include <cassert>
-#include "./ErrorGuard.h"
 
-/** Use the name of the enclosing CPP function as the name for a Chapel
-    source file. Returns a UniqueString. */
-#define TEST_NAME_FROM_FN_NAME(context__) \
-  chpl::UniqueString::getConcat(context__, __FUNCTION__, ".chpl")
+namespace chpl {
+namespace uast {
 
-/** Parse to BuilderResult but report encountered errors to the context. */
-const chpl::uast::BuilderResult&
-parseAndReportErrors(chpl::Context* context, chpl::UniqueString path);
+/**
+  Runs post-parse checks on the given given builder result, constructed from
+  the contents of the file at path. This is not itself a query, and thus
+  errors are reported to the calling query.
+  */
+void
+checkBuilderResult(Context* context, UniqueString path,
+                   const BuilderResult& result);
 
-chpl::uast::BuilderResult
-parseStringAndReportErrors(chpl::parsing::Parser* parser, const char* filename,
-                           const char* content);
+} // end namespace uast
+} // end namespace chpl
 
 #endif

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -594,7 +594,7 @@ static void logErrorInContext(Context* context,
   context->report(std::move(err));
 }
 
-void logErrorInContext(Context* context,
+static void logErrorInContext(Context* context,
                               ErrorBase::Kind kind,
                               const uast::AstNode* ast,
                               const char* fmt,

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -581,7 +581,7 @@ static void logErrorInContext(Context* context,
                               Location loc,
                               const char* fmt,
                               va_list vl) {
-  auto err = GeneralError::vbuild(context, kind, loc, fmt, vl);
+  auto err = GeneralError::vbuild(kind, loc, fmt, vl);
   context->report(std::move(err));
 }
 
@@ -590,7 +590,7 @@ static void logErrorInContext(Context* context,
                               ID id,
                               const char* fmt,
                               va_list vl) {
-  auto err = GeneralError::vbuild(context, kind, id, fmt, vl);
+  auto err = GeneralError::vbuild(kind, id, fmt, vl);
   context->report(std::move(err));
 }
 
@@ -599,7 +599,7 @@ void logErrorInContext(Context* context,
                               const uast::AstNode* ast,
                               const char* fmt,
                               va_list vl) {
-  auto err = GeneralError::vbuild(context, kind, ast->id(), fmt, vl);
+  auto err = GeneralError::vbuild(kind, ast->id(), fmt, vl);
   context->report(std::move(err));
 }
 

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -72,6 +72,10 @@ namespace chpl {
 
 using namespace chpl::querydetail;
 
+void Context::reportError(Context* context, owned<ErrorBase> err) {
+  handler_->report(context, std::move(err));
+}
+
 const std::string& Context::chplHome() const {
   return chplHome_;
 }
@@ -561,71 +565,69 @@ void Context::collectGarbage() {
   }
 }
 
-const ErrorBase* Context::report(const ErrorBase* error) {
+void Context::report(owned<ErrorBase> error) {
   gdbShouldBreakHere();
-  if (queryStack.size() > 0) {
-    queryStack.back()->errors.push_back(std::move(error));
-    reportError(this, queryStack.back()->errors.back());
-  } else {
-    reportError(this, error);
-  }
 
-  return error;
+  // TODO: how do we track it in both places?
+  // if (queryStack.size() > 0) {
+  //   queryStack.back()->errors.push_back(std::move(error));
+  //   reportError(this, queryStack.back()->errors.back());
+  // } else {
+  //   reportError(this, error);
+  // }
+
+  reportError(this, std::move(error));
 }
 
-static const ErrorBase* logErrorInContext(Context* context,
+static void logErrorInContext(Context* context,
                               ErrorBase::Kind kind,
                               Location loc,
                               const char* fmt,
                               va_list vl) {
   auto err = GeneralError::vbuild(context, kind, loc, fmt, vl);
-  context->report(err);
-  return err;
+  context->report(std::move(err));
 }
 
-static const ErrorBase* logErrorInContext(Context* context,
+static void logErrorInContext(Context* context,
                               ErrorBase::Kind kind,
                               ID id,
                               const char* fmt,
                               va_list vl) {
   auto err = GeneralError::vbuild(context, kind, id, fmt, vl);
-  context->report(err);
-  return err;
+  context->report(std::move(err));
 }
 
-static const ErrorBase* logErrorInContext(Context* context,
+void logErrorInContext(Context* context,
                               ErrorBase::Kind kind,
                               const uast::AstNode* ast,
                               const char* fmt,
                               va_list vl) {
   auto err = GeneralError::vbuild(context, kind, ast->id(), fmt, vl);
-  context->report(err);
-  return err;
+  context->report(std::move(err));
 }
 
 #define CHPL_CONTEXT_LOG_ERROR_HELPER(context__, kind__, pin__, fmt__) \
   do { \
     va_list vl; \
     va_start(vl, fmt__); \
-    auto err = logErrorInContext(context__, kind__, pin__, fmt__, vl); \
+    logErrorInContext(context__, kind__, pin__, fmt__, vl); \
     va_end(vl); \
-    return err; \
   } while (0)
 
 // TODO: Similar overloads for NOTE, WARN, etc.
-const ErrorBase* Context::error(Location loc, const char* fmt, ...) {
+void Context::error(Location loc, const char* fmt, ...) {
   CHPL_CONTEXT_LOG_ERROR_HELPER(this, ErrorBase::ERROR, loc, fmt);
 }
 
-const ErrorBase* Context::error(ID id, const char* fmt, ...) {
+void Context::error(ID id, const char* fmt, ...) {
   CHPL_CONTEXT_LOG_ERROR_HELPER(this, ErrorBase::ERROR, id, fmt);
 }
 
-const ErrorBase* Context::error(const uast::AstNode* ast, const char* fmt, ...) {
+void Context::error(const uast::AstNode* ast, const char* fmt, ...) {
   CHPL_CONTEXT_LOG_ERROR_HELPER(this, ErrorBase::ERROR, ast, fmt);
 }
 
-const ErrorBase* Context::error(const resolution::TypedFnSignature* inFn,
+void Context::error(const resolution::TypedFnSignature* inFn,
                     const uast::AstNode* ast,
                     const char* fmt, ...) {
   CHPL_CONTEXT_LOG_ERROR_HELPER(this, ErrorBase::ERROR, ast, fmt);
@@ -708,9 +710,10 @@ void Context::updateForReuse(const QueryMapResultBase* resultEntry) {
   resultEntry->lastChecked = this->currentRevisionNumber;
 
   // Update error locations if needed and re-report the error
-  for (auto& err: resultEntry->errors) {
-    reportError(this, err);
-  }
+  // TODO what to do here?
+  // for (auto& err: resultEntry->errors) {
+  //   reportError(this, err);
+  // }
 }
 
 bool Context::queryCanUseSavedResult(

--- a/frontend/lib/framework/ErrorBase.cpp
+++ b/frontend/lib/framework/ErrorBase.cpp
@@ -165,22 +165,22 @@ void BasicError::mark(Context* context) const {
   }
 }
 
-owned<GeneralError> GeneralError::vbuild(Context* context, Kind kind, ID id, const char* fmt, va_list vl) {
+owned<GeneralError> GeneralError::vbuild(Kind kind, ID id, const char* fmt, va_list vl) {
   auto message = vprintToString(fmt, vl);
   return owned<GeneralError>(new GeneralError(kind, std::move(id), std::move(message), {}));
 }
 
-owned<GeneralError> GeneralError::vbuild(Context* context, Kind kind, Location loc, const char* fmt, va_list vl) {
+owned<GeneralError> GeneralError::vbuild(Kind kind, Location loc, const char* fmt, va_list vl) {
   auto message = vprintToString(fmt, vl);
   return owned<GeneralError>(new GeneralError(kind, std::move(loc), std::move(message), {}));
 }
 
-owned<GeneralError> GeneralError::get(Context* context, Kind kind, Location loc, std::string msg) {
+owned<GeneralError> GeneralError::get(Kind kind, Location loc, std::string msg) {
   return owned<GeneralError>(new GeneralError(kind, std::move(loc), std::move(msg), {}));
 }
 
-owned<GeneralError> GeneralError::error(Context* context, Location loc, std::string msg) {
-  return GeneralError::get(context, ErrorBase::ERROR, std::move(loc), std::move(msg));
+owned<GeneralError> GeneralError::error(Location loc, std::string msg) {
+  return GeneralError::get(ErrorBase::ERROR, std::move(loc), std::move(msg));
 }
 
 owned<ErrorBase> GeneralError::clone() const {

--- a/frontend/lib/framework/ErrorBase.cpp
+++ b/frontend/lib/framework/ErrorBase.cpp
@@ -183,4 +183,8 @@ owned<GeneralError> GeneralError::error(Context* context, Location loc, std::str
   return GeneralError::get(context, ErrorBase::ERROR, std::move(loc), std::move(msg));
 }
 
+owned<ErrorBase> GeneralError::clone() const {
+  return owned<ErrorBase>(new GeneralError(*this));
+}
+
 } // end namespace 'chpl'

--- a/frontend/lib/framework/ErrorBase.cpp
+++ b/frontend/lib/framework/ErrorBase.cpp
@@ -165,35 +165,21 @@ void BasicError::mark(Context* context) const {
   }
 }
 
-const owned<GeneralError>&
-GeneralError::getGeneralErrorForID(Context* context, Kind kind, ID id, std::string message) {
-  QUERY_BEGIN(getGeneralErrorForID, context, kind, id, message);
-  auto result = owned<GeneralError>(new GeneralError(kind, id, std::move(message), {}));
-  return QUERY_END(result);
-}
-
-const owned<GeneralError>&
-GeneralError::getGeneralErrorForLocation(Context* context, Kind kind, Location loc, std::string message) {
-  QUERY_BEGIN(getGeneralErrorForLocation, context, kind, loc, message);
-  auto result = owned<GeneralError>(new GeneralError(kind, loc, std::move(message), {}));
-  return QUERY_END(result);
-}
-
-const GeneralError* GeneralError::vbuild(Context* context, Kind kind, ID id, const char* fmt, va_list vl) {
+owned<GeneralError> GeneralError::vbuild(Context* context, Kind kind, ID id, const char* fmt, va_list vl) {
   auto message = vprintToString(fmt, vl);
-  return getGeneralErrorForID(context, kind, id, message).get();
+  return owned<GeneralError>(new GeneralError(kind, std::move(id), std::move(message), {}));
 }
 
-const GeneralError* GeneralError::vbuild(Context* context, Kind kind, Location loc, const char* fmt, va_list vl) {
+owned<GeneralError> GeneralError::vbuild(Context* context, Kind kind, Location loc, const char* fmt, va_list vl) {
   auto message = vprintToString(fmt, vl);
-  return getGeneralErrorForLocation(context, kind, loc, message).get();
+  return owned<GeneralError>(new GeneralError(kind, std::move(loc), std::move(message), {}));
 }
 
-const GeneralError* GeneralError::get(Context* context, Kind kind, Location loc, std::string msg) {
-  return getGeneralErrorForLocation(context, kind, loc, std::move(msg)).get();
+owned<GeneralError> GeneralError::get(Context* context, Kind kind, Location loc, std::string msg) {
+  return owned<GeneralError>(new GeneralError(kind, std::move(loc), std::move(msg), {}));
 }
 
-const GeneralError* GeneralError::error(Context* context, Location loc, std::string msg) {
+owned<GeneralError> GeneralError::error(Context* context, Location loc, std::string msg) {
   return GeneralError::get(context, ErrorBase::ERROR, std::move(loc), std::move(msg));
 }
 

--- a/frontend/lib/framework/parser-error-classes-list.cpp
+++ b/frontend/lib/framework/parser-error-classes-list.cpp
@@ -245,23 +245,23 @@ void ErrorUseImportNeedsModule::write(ErrorWriterBase& wr) const {
 /* begin post-parse-checks errors */
 
 void ErrorCantApplyPrivate::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
+  auto node = std::get<const uast::AstNode*>(info);
   auto appliedToWhat = std::get<std::string>(info);
-  wr.heading(kind_, type_, id, "can't apply private to ", appliedToWhat,
+  wr.heading(kind_, type_, node, "can't apply private to ", appliedToWhat,
              " yet.");
   wr.message("The following declaration has unsupported 'private' modifier:");
-  wr.code(id);
+  wr.code(node);
 }
 
 void ErrorMultipleManagementStrategies::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
+  auto node = std::get<const uast::AstNode*>(info);
   auto outerMgt = std::get<1>(info);
   auto innerMgt = std::get<2>(info);
-  wr.heading(kind_, type_, id,
+  wr.heading(kind_, type_, node,
              "type expression uses multiple memory management strategies ('",
              outerMgt, "' and '", innerMgt, "').");
   wr.message("Multiple class kinds used in type expression here:");
-  wr.code(id);
+  wr.code(node);
   if (outerMgt == innerMgt) {
     wr.message(
         "The same strategy is listed twice; one instance should be removed.");
@@ -271,21 +271,21 @@ void ErrorMultipleManagementStrategies::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorPostParseErr::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
+  auto node = std::get<const uast::AstNode*>(info);
   auto errorMessage = std::get<std::string>(info);
   CHPL_ASSERT(errorMessage.back() == '.' &&
          "expected a period at the end of ErrorPostParseErr message");
-  wr.heading(kind_, type_, id, errorMessage);
-  wr.code(id);
+  wr.heading(kind_, type_, node, errorMessage);
+  wr.code(node);
 }
 
 void ErrorPostParseWarn::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
+  auto node = std::get<const uast::AstNode*>(info);
   auto errorMessage = std::get<std::string>(info);
   CHPL_ASSERT(errorMessage.back() == '.' &&
          "expected a period at the end of ErrorPostParseWarn message");
-  wr.heading(kind_, type_, id, errorMessage);
-  wr.code(id);
+  wr.heading(kind_, type_, node, errorMessage);
+  wr.code(node);
 }
 
 /* end post-parse-checks errors */

--- a/frontend/lib/parsing/Parser.cpp
+++ b/frontend/lib/parsing/Parser.cpp
@@ -74,11 +74,6 @@ static void updateParseResult(ParserContext* parserContext) {
     }
     delete parserContext->comments;
   }
-
-  // Save the parse errors to the builder
-  for (const auto* error : parserContext->errors) {
-    builder->addError(error);
-  }
 }
 
 
@@ -94,9 +89,6 @@ BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
 
   FILE* fp = openfile(path, "r", fileError);
   if (fp == NULL) {
-    // TODO: do we need to track errors in the builder?
-    // builder->addError(
-    //     GeneralError::error(this->context(), Location(), fileError));
     context_->report(GeneralError::error(this->context(), Location(), fileError));
     return builder->result();
   }

--- a/frontend/lib/parsing/Parser.cpp
+++ b/frontend/lib/parsing/Parser.cpp
@@ -89,7 +89,7 @@ BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
 
   FILE* fp = openfile(path, "r", fileError);
   if (fp == NULL) {
-    context_->report(GeneralError::error(this->context(), Location(), fileError));
+    context_->report(GeneralError::error(Location(), fileError));
     return builder->result();
   }
 
@@ -160,10 +160,7 @@ BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
   yychpl_lex_destroy(parserContext.scanner);
 
   if (closefile(fp, path, fileError)) {
-    // TODO do we need to add errors to the builder?
-    // builder->addError(
-    //     GeneralError::error(this->context(), Location(), fileError));
-    context_->report(GeneralError::error(this->context(), Location(), fileError));
+    context_->report(GeneralError::error(Location(), fileError));
   }
 
   updateParseResult(&parserContext);

--- a/frontend/lib/parsing/Parser.cpp
+++ b/frontend/lib/parsing/Parser.cpp
@@ -94,8 +94,10 @@ BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
 
   FILE* fp = openfile(path, "r", fileError);
   if (fp == NULL) {
-    builder->addError(
-        GeneralError::error(this->context(), Location(), fileError));
+    // TODO: do we need to track errors in the builder?
+    // builder->addError(
+    //     GeneralError::error(this->context(), Location(), fileError));
+    context_->report(GeneralError::error(this->context(), Location(), fileError));
     return builder->result();
   }
 
@@ -166,8 +168,10 @@ BuilderResult Parser::parseFile(const char* path, ParserStats* parseStats) {
   yychpl_lex_destroy(parserContext.scanner);
 
   if (closefile(fp, path, fileError)) {
-    builder->addError(
-        GeneralError::error(this->context(), Location(), fileError));
+    // TODO do we need to add errors to the builder?
+    // builder->addError(
+    //     GeneralError::error(this->context(), Location(), fileError));
+    context_->report(GeneralError::error(this->context(), Location(), fileError));
   }
 
   updateParseResult(&parserContext);

--- a/frontend/lib/parsing/ParserContext.h
+++ b/frontend/lib/parsing/ParserContext.h
@@ -45,7 +45,6 @@ struct ParserContext {
   parsing::ParserStats* parseStats;
 
   ParserExprList* topLevelStatements;
-  std::vector<const ErrorBase*> errors;
 
   // TODO: this should just hash on the pointer; the void* is a hack to do that
   std::unordered_map<void*, YYLTYPE> commentLocations;

--- a/frontend/lib/parsing/ParserContext.h
+++ b/frontend/lib/parsing/ParserContext.h
@@ -169,7 +169,7 @@ struct ParserContext {
     };
   }
 
-  ErroneousExpression* report(YYLTYPE loc, const ErrorBase* error);
+  ErroneousExpression* report(YYLTYPE loc, owned<ErrorBase> error);
   ErroneousExpression* error(YYLTYPE loc, const char* fmt, ...);
   ErroneousExpression* syntax(YYLTYPE loc, const char* fmt, ...);
 

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -333,7 +333,6 @@ void ParserContext::exitScope(asttags::AstTag tag, UniqueString name) {
 
 
 ErroneousExpression* ParserContext::report(YYLTYPE loc, owned<ErrorBase> error) {
-  // TODO do we need to track the errors in the list?
   context()->report(std::move(error));
   return ErroneousExpression::build(builder, convertLocation(loc)).release();
 }

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -344,7 +344,7 @@ ErroneousExpression* ParserContext::report(YYLTYPE loc, owned<ErrorBase> error) 
     va_start(vl, fmt); \
     auto reportLoc = p_context__->convertLocation(loc__); \
     auto result = p_context__->report(loc__, \
-        GeneralError::vbuild(context(), kind__, reportLoc, fmt__, vl)); \
+        GeneralError::vbuild(kind__, reportLoc, fmt__, vl)); \
     va_end(vl); \
     return result; \
   } while(false)

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -332,8 +332,9 @@ void ParserContext::exitScope(asttags::AstTag tag, UniqueString name) {
 }
 
 
-ErroneousExpression* ParserContext::report(YYLTYPE loc, const ErrorBase* error) {
-  errors.push_back(context()->report(error));
+ErroneousExpression* ParserContext::report(YYLTYPE loc, owned<ErrorBase> error) {
+  // TODO do we need to track the errors in the list?
+  context()->report(std::move(error));
   return ErroneousExpression::build(builder, convertLocation(loc)).release();
 }
 

--- a/frontend/lib/parsing/lexer-help.h
+++ b/frontend/lib/parsing/lexer-help.h
@@ -71,8 +71,7 @@ static void syntax(yyscan_t scanner, int nLines, int nCols,
   Location loc = pContext->convertLocation(flexLoc);
   va_list args;
   va_start(args, fmt);
-  auto error = GeneralError::vbuild(pContext->context(),
-                                    ErrorBase::SYNTAX, loc, fmt, args);
+  auto error = GeneralError::vbuild(ErrorBase::SYNTAX, loc, fmt, args);
   pContext->report(flexLoc, std::move(error));
   va_end(args);
 }

--- a/frontend/lib/parsing/lexer-help.h
+++ b/frontend/lib/parsing/lexer-help.h
@@ -73,7 +73,7 @@ static void syntax(yyscan_t scanner, int nLines, int nCols,
   va_start(args, fmt);
   auto error = GeneralError::vbuild(pContext->context(),
                                     ErrorBase::SYNTAX, loc, fmt, args);
-  pContext->report(flexLoc, error);
+  pContext->report(flexLoc, std::move(error));
   va_end(args);
 }
 

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -184,12 +184,6 @@ const ModuleVec& parse(Context* context, UniqueString path,
   const BuilderResult& p = parseFileToBuilderResult(context, path,
                                                     parentSymbolPath);
 
-  // Report any errors encountered to the context.
-  // TODO: have these not been reported already?
-  // for (auto& e : p.errors())
-  //   if (e != nullptr)
-  //     context->report(e);
-
   // Compute a vector of Modules
   ModuleVec result;
   for (auto topLevelExpression : p.topLevelExpressions()) {

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -116,10 +116,6 @@ parseFileToBuilderResult(Context* context, UniqueString path,
     BuilderResult tmpResult = parser.parseString(pathc, textc);
     result.swap(tmpResult);
     BuilderResult::updateFilePaths(context, result);
-  } else {
-    // Error should have already been reported in the fileText query.
-    // Just record an error here as well so follow-ons are clear
-    BuilderResult::appendError(result, error);
   }
 
   return QUERY_END(result);

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -24,6 +24,7 @@
 #include "chpl/framework/query-impl.h"
 #include "chpl/parsing/Parser.h"
 #include "chpl/types/RecordType.h"
+#include "chpl/uast/post-parse-checks.h"
 #include "chpl/uast/AggregateDecl.h"
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/Function.h"
@@ -119,6 +120,20 @@ parseFileToBuilderResult(Context* context, UniqueString path,
   }
 
   return QUERY_END(result);
+}
+
+// TODO: can't make this a query because can't store the uast::BuilderResult&
+//       as a query result. Might be some template specialization magic we
+//       can do to support this use case, but for now, this will just end up
+//       reporting errors to the caller query.
+const uast::BuilderResult&
+parseFileToBuilderResultAndCheck(Context* context, UniqueString path,
+                                 UniqueString parentSymbolPath) {
+  auto& result = parseFileToBuilderResult(context, path, parentSymbolPath);
+  if (result.numTopLevelExpressions() == 0) return result;
+
+  checkBuilderResult(context, path, result);
+  return result;
 }
 
 // parses whatever file exists that contains the passed ID and returns it

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -57,7 +57,8 @@ const FileContents& fileTextQuery(Context* context, std::string path) {
   std::string error;
   const ErrorBase* parseError = nullptr;
   if (!readfile(path.c_str(), text, error)) {
-    parseError = context->error(Location(), "error reading file: %s\n", error.c_str());
+    // TODO does this need to be stored in FileContents?
+    context->error(Location(), "error reading file: %s\n", error.c_str());
   }
   auto result = FileContents(std::move(text), parseError);
   return QUERY_END(result);
@@ -188,9 +189,10 @@ const ModuleVec& parse(Context* context, UniqueString path,
                                                     parentSymbolPath);
 
   // Report any errors encountered to the context.
-  for (auto& e : p.errors())
-    if (e != nullptr)
-      context->report(e);
+  // TODO: have these not been reported already?
+  // for (auto& e : p.errors())
+  //   if (e != nullptr)
+  //     context->report(e);
 
   // Compute a vector of Modules
   ModuleVec result;

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -181,8 +181,8 @@ const ModuleVec& parse(Context* context, UniqueString path,
   QUERY_BEGIN(parse, context, path, parentSymbolPath);
 
   // Get the result of parsing
-  const BuilderResult& p = parseFileToBuilderResult(context, path,
-                                                    parentSymbolPath);
+  const BuilderResult& p = parseFileToBuilderResultAndCheck(context, path,
+                                                            parentSymbolPath);
 
   // Compute a vector of Modules
   ModuleVec result;

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -104,10 +104,6 @@ void Builder::addToplevelExpression(owned<AstNode> e) {
   this->topLevelExpressions_.push_back(std::move(e));
 }
 
-void Builder::addError(const ErrorBase* e) {
-  this->errors_.push_back(e);
-}
-
 void Builder::noteLocation(AstNode* ast, Location loc) {
   notedLocations_[ast] = loc;
 }
@@ -125,7 +121,6 @@ BuilderResult Builder::result() {
 
   BuilderResult ret(filepath_);
   ret.topLevelExpressions_.swap(topLevelExpressions_);
-  ret.errors_.swap(errors_);
   ret.idToAst_.swap(idToAst_);
   ret.idToLocation_.swap(idToLocation_);
   ret.commentIdToLocation_.swap(commentToLocation_);
@@ -497,12 +492,6 @@ owned <AstNode> Builder::parseDummyNodeForInitExpr(Variable* var, std::string va
   path += var->name().str();
   path += ")";
   auto parseResult = parser.parseString(path.c_str(), inputText.c_str());
-  // Propagate any parse errors from the dummy node to builder errors
-  if (parseResult.numErrors() > 0) {
-   for (const ErrorBase* error : parseResult.errors()) {
-     addError(error);
-   }
-  }
   auto mod = parseResult.singleModule();
   CHPL_ASSERT(mod);
   owned<AstNode> initNode;

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -111,7 +111,6 @@ void Builder::noteLocation(AstNode* ast, Location loc) {
 BuilderResult Builder::result() {
   this->createImplicitModuleIfNeeded();
   this->assignIDs();
-  this->postParseChecks();
 
   // Performance: We could consider copying all of these AST
   // nodes to a newly allocated buffer big enough to hold them

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -193,12 +193,13 @@ void Builder::createImplicitModuleIfNeeded() {
     topLevelExpressions_.push_back(std::move(ownedModule));
 
     // emit warnings as needed
+    // TODO no longer saving the errors but logging them directly
     if (firstUseImportOrRequire && !containsOther && nModules == 1) {
-      addError(ErrorImplicitFileModule::get(context(),
-            std::make_tuple(firstUseImportOrRequire, lastModule, implicitModule)));
+      CHPL_REPORT(context(), ImplicitFileModule,
+                  firstUseImportOrRequire, lastModule, implicitModule);
     } else if (nModules >= 1 && !containsOnlyModules) {
-      addError(ErrorImplicitFileModule::get(context(),
-            std::make_tuple(firstNonModule, lastModule, implicitModule)));
+      CHPL_REPORT(context(), ImplicitFileModule,
+                  firstNonModule, lastModule, implicitModule);
     }
   }
 }
@@ -404,9 +405,9 @@ void Builder::checkConfigPreviouslyUsed(const Variable* var, std::string& config
   useConfigSetting(context(), configNameUsed, var->id());
   auto usedId = nameToConfigSettingId(context(), configNameUsed);
 
+  // TODO no longer saving the errors but logging them directly
   if (usedId != var->id()) {
-    addError(ErrorAmbiguousConfigName::get(context(),
-          std::make_tuple(configNameUsed, var, usedId)));
+    CHPL_REPORT(context(), AmbiguousConfigName, configNameUsed, var, usedId);
   }
 }
 
@@ -449,8 +450,9 @@ void Builder::lookupConfigSettingsForVar(Variable* var, pathVecT& pathVec, std::
       if (!configMatched.first.empty() &&
           configMatched.first != configPair.first) {
 
-        addError(ErrorAmbiguousConfigSet::get(context(),
-              std::make_tuple(var, configMatched.first, configPair.first)));
+        // TODO no longer saving the errors but logging them directly
+        CHPL_REPORT(context(), AmbiguousConfigSet,
+                    var, configMatched.first, configPair.first);
       }
       configMatched = configPair;
     }

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -188,7 +188,6 @@ void Builder::createImplicitModuleIfNeeded() {
     topLevelExpressions_.push_back(std::move(ownedModule));
 
     // emit warnings as needed
-    // TODO no longer saving the errors but logging them directly
     if (firstUseImportOrRequire && !containsOther && nModules == 1) {
       CHPL_REPORT(context(), ImplicitFileModule,
                   firstUseImportOrRequire, lastModule, implicitModule);
@@ -400,7 +399,6 @@ void Builder::checkConfigPreviouslyUsed(const Variable* var, std::string& config
   useConfigSetting(context(), configNameUsed, var->id());
   auto usedId = nameToConfigSettingId(context(), configNameUsed);
 
-  // TODO no longer saving the errors but logging them directly
   if (usedId != var->id()) {
     CHPL_REPORT(context(), AmbiguousConfigName, configNameUsed, var, usedId);
   }
@@ -445,7 +443,6 @@ void Builder::lookupConfigSettingsForVar(Variable* var, pathVecT& pathVec, std::
       if (!configMatched.first.empty() &&
           configMatched.first != configPair.first) {
 
-        // TODO no longer saving the errors but logging them directly
         CHPL_REPORT(context(), AmbiguousConfigSet,
                     var, configMatched.first, configPair.first);
       }

--- a/frontend/lib/uast/BuilderResult.cpp
+++ b/frontend/lib/uast/BuilderResult.cpp
@@ -72,7 +72,6 @@ void computeIdMaps(
 void BuilderResult::swap(BuilderResult& other) {
   filePath_.swap(other.filePath_);
   topLevelExpressions_.swap(other.topLevelExpressions_);
-  errors_.swap(other.errors_);
   idToAst_.swap(other.idToAst_);
   idToLocation_.swap(other.idToLocation_);
   commentIdToLocation_.swap(other.commentIdToLocation_);
@@ -85,9 +84,6 @@ bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {
 
   // update the filePath
   changed |= defaultUpdate(keep.filePath_, addin.filePath_);
-
-  // update the errors
-  changed |= defaultUpdate(keep.errors_, addin.errors_);
 
   // update the ASTs
   changed |= updateAstList(keep.topLevelExpressions_,
@@ -141,8 +137,6 @@ void BuilderResult::mark(Context* context) const {
     loc.mark(context);
   }
 
-  chpl::mark<decltype(errors_)>{}(context, errors_);
-
   // update the filePathForModuleName query
   BuilderResult::updateFilePaths(context, *this);
 }
@@ -156,11 +150,6 @@ void BuilderResult::updateFilePaths(Context* context,
       context->setFilePathForModuleId(mod->id(), path);
     }
   }
-}
-
-void BuilderResult::appendError(BuilderResult& keep,
-                                const ErrorBase* error) {
-  keep.errors_.push_back(error);
 }
 
 const AstNode* BuilderResult::idToAst(ID id) const {

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -162,8 +162,9 @@ struct Visitor {
 void Visitor::report(const AstNode* node, ErrorBase::Kind kind,
                      const char* fmt,
                      va_list vl) {
-  auto err = GeneralError::vbuild(context_, kind, node->id(), fmt, vl);
-  builder_.addError(std::move(err));
+  // TODO no longer storing the error in builder, passing straight to ctx.
+  // builder_.addError(std::move(err));
+  context_->report(GeneralError::vbuild(context_, kind, node->id(), fmt, vl));
 }
 
 void Visitor::error(const AstNode* node, const char* fmt, ...) {

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "chpl/uast/post-parse-checks.h"
 
 #include "chpl/framework/compiler-configuration.h"
 #include "chpl/framework/global-strings.h"
@@ -882,18 +883,11 @@ bool Visitor::isUserFilePath(Context* context, UniqueString filepath) {
 } // end anonymous namespace
 
 namespace chpl {
-namespace parsing {
+namespace uast {
 
-// TODO: can't make this a query because can't store the uast::BuilderResult&
-//       as a query result. Might me some template specialization magic we
-//       can do to support this use case, but for now, this will just end up
-//       reporting errors to the caller query.
-const uast::BuilderResult&
-parseFileToBuilderResultAndCheck(Context* context, UniqueString path,
-                                 UniqueString parentSymbolPath) {
-  auto& result = parseFileToBuilderResult(context, path, parentSymbolPath);
-  if (result.numTopLevelExpressions() == 0) return result;
-
+void
+checkBuilderResult(Context* context, UniqueString path,
+                   const BuilderResult& result) {
   bool isUserCode = Visitor::isUserFilePath(context, path);
   auto v = Visitor(context, isUserCode);
 
@@ -901,8 +895,6 @@ parseFileToBuilderResultAndCheck(Context* context, UniqueString path,
     if (ast->isComment()) continue;
     v.check(ast);
   }
-
-  return result;
 }
 
 } // end namespace uast

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -164,7 +164,7 @@ void Visitor::report(const AstNode* node, ErrorBase::Kind kind,
                      va_list vl) {
   // TODO no longer storing the error in builder, passing straight to ctx.
   // builder_.addError(std::move(err));
-  context_->report(GeneralError::vbuild(context_, kind, node->id(), fmt, vl));
+  context_->report(GeneralError::vbuild(kind, node->id(), fmt, vl));
 }
 
 void Visitor::error(const AstNode* node, const char* fmt, ...) {

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -162,8 +162,6 @@ struct Visitor {
 void Visitor::report(const AstNode* node, ErrorBase::Kind kind,
                      const char* fmt,
                      va_list vl) {
-  // TODO no longer storing the error in builder, passing straight to ctx.
-  // builder_.addError(std::move(err));
   context_->report(GeneralError::vbuild(kind, node->id(), fmt, vl));
 }
 

--- a/frontend/test/ErrorGuard.h
+++ b/frontend/test/ErrorGuard.h
@@ -43,8 +43,8 @@ class AggregatingErrorHandler : BaseHandler {
   }
 
   virtual void
-  report(chpl::Context* context, chpl::owned<chpl::ErrorBase> err) override {
-    errors_.push_back(std::move(err));
+  report(chpl::Context* context, const chpl::ErrorBase* err) override {
+    errors_.push_back(err->clone());
   }
 
   inline void clear() { errors_.clear(); }

--- a/frontend/test/ErrorGuard.h
+++ b/frontend/test/ErrorGuard.h
@@ -27,18 +27,24 @@
 using BaseHandler = chpl::Context::ErrorHandler;
 
 class AggregatingErrorHandler : BaseHandler {
-  std::vector<const chpl::ErrorBase*> errors_;
+  std::vector<chpl::owned<chpl::ErrorBase>> errors_;
  public:
   AggregatingErrorHandler() = default;
   ~AggregatingErrorHandler() = default;
 
-  const std::vector<const chpl::ErrorBase*>& errors() const {
+  const std::vector<chpl::owned<chpl::ErrorBase>>& errors() const {
     return errors_;
   }
 
+  template <typename C>
+  void moveErrors(C& container) {
+    std::move(errors_.begin(), errors_.end(), std::back_inserter(container));
+    errors_.clear();
+  }
+
   virtual void
-  report(chpl::Context* context, const chpl::ErrorBase* err) override {
-    errors_.push_back(err);
+  report(chpl::Context* context, chpl::owned<chpl::ErrorBase> err) override {
+    errors_.push_back(std::move(err));
   }
 
   inline void clear() { errors_.clear(); }
@@ -66,7 +72,7 @@ class ErrorGuard {
   inline chpl::Context* context() const { return ctx_; }
 
   /** A way to iterate over the errors contained in the guard. */
-  const std::vector<const chpl::ErrorBase*>& errors() const {
+  const std::vector<chpl::owned<chpl::ErrorBase>>& errors() const {
     assert(handler_);
     return handler_->errors();
   }
@@ -74,9 +80,14 @@ class ErrorGuard {
   /** Get the number of errors contained in the guard. */
   inline size_t numErrors() const { return this->errors().size(); }
 
-  const chpl::ErrorBase* error(size_t idx) const {
+  const chpl::owned<chpl::ErrorBase>& error(size_t idx) const {
     assert(idx < numErrors());
     return this->errors()[idx];
+  }
+
+  void clearErrors() {
+    assert(handler_);
+    handler_->clear();
   }
 
   /** Print the errors contained in this guard and then clear the guard
@@ -90,12 +101,17 @@ class ErrorGuard {
     return ret;
   }
 
+  template <typename C>
+  void moveErrors(C& container) {
+    handler_->moveErrors(container);
+  }
+
   /** Print the errors contained in this guard in a detailed manner. */
   void printErrors() const {
     chpl::ErrorWriter ew(this->context(), std::cout,
                          chpl::ErrorWriter::DETAILED,
                          false);
-    for (auto err: this->errors()) err->write(ew);
+    for (auto& err: this->errors()) err->write(ew);
   }
 
   /** The guard destructor will assert that no errors have occurred. */

--- a/frontend/test/parsing/testParse.cpp
+++ b/frontend/test/parsing/testParse.cpp
@@ -35,8 +35,9 @@
 #include "chpl/uast/Variable.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl", "");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test0") == 0);
@@ -44,8 +45,9 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl", "x;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1") == 0);
@@ -56,8 +58,9 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl", "x; y;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test2") == 0);
@@ -67,8 +70,9 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl", "/* hi */ y;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test3") == 0);
@@ -78,8 +82,9 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl", "/* hi */ y; /* bye */");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test4") == 0);
@@ -90,11 +95,12 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
                                          "// hi\n"
                                          "a;\n"
                                          "// bye\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -104,9 +110,10 @@ static void test5(Parser* parser) {
 }
 
 static void test6(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test6.chpl",
                                          "{ }");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -114,9 +121,10 @@ static void test6(Parser* parser) {
 }
 
 static void test7(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test7.chpl",
                                          "{ a; }");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -127,8 +135,9 @@ static void test7(Parser* parser) {
 }
 
 static void test8(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("t.chpl", "aVeryLongIdentifierName;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -136,9 +145,10 @@ static void test8(Parser* parser) {
 }
 
 static void test9(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test9.chpl",
                                          "{ /* this is a comment */ }");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -149,13 +159,14 @@ static void test9(Parser* parser) {
 }
 
 static void test10(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test10.chpl",
                                          "{\n"
                                          "/* this is comment 2 */\n"
                                          "aVeryLongIdentifierName;\n"
                                          "/* this is comment 3 */\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -169,6 +180,7 @@ static void test10(Parser* parser) {
 
 
 static void test11(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test11.chpl",
                                          "/* this is comment 1 */\n"
                                          "{\n"
@@ -177,7 +189,7 @@ static void test11(Parser* parser) {
                                          "/* this is comment 3 */\n"
                                          "}\n"
                                          "/* this is comment 4 */");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -192,6 +204,7 @@ static void test11(Parser* parser) {
 }
 
 static void test12(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test12.chpl",
                                          "/* this is comment 1 */\n"
                                          "/* this is comment 2 */\n"
@@ -204,7 +217,7 @@ static void test12(Parser* parser) {
                                          "}\n"
                                          "/* this is comment 5 */\n"
                                          "/* this is comment 6 */");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 5);
@@ -223,10 +236,11 @@ static void test12(Parser* parser) {
 }
 
 static void test13(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test13.chpl",
                                          "var a;\n"
                                          "a;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -235,12 +249,13 @@ static void test13(Parser* parser) {
 }
 
 static void test14(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test14.chpl",
                                          "{\n"
                                          " //a\n"
                                          " //b\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -252,13 +267,14 @@ static void test14(Parser* parser) {
 }
 
 static void test15(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test15.chpl",
                                          "{\n"
                                          " x;\n"
                                          " //a\n"
                                          " //b\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -271,9 +287,10 @@ static void test15(Parser* parser) {
 }
 
 static void testCalls1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testCalls1.chpl",
                                          "f();\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -288,9 +305,10 @@ static void testCalls1(Parser* parser) {
 }
 
 static void testCalls2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testCalls2.chpl",
                                          "f[];\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -305,9 +323,10 @@ static void testCalls2(Parser* parser) {
 }
 
 static void testCalls3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testCalls3.chpl",
                                          "f(x);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -324,9 +343,10 @@ static void testCalls3(Parser* parser) {
 }
 
 static void testCalls3a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testCalls3a.chpl",
                                          "f(g(x));\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -350,9 +370,10 @@ static void testCalls3a(Parser* parser) {
 }
 
 static void testCalls4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testCalls4.chpl",
                                          "f[x];\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -369,9 +390,10 @@ static void testCalls4(Parser* parser) {
 }
 
 static void testCalls5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testCalls5.chpl",
                                          "f(a,b,c);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -396,9 +418,10 @@ static void testCalls5(Parser* parser) {
 }
 
 static void testCalls6(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testCalls6.chpl",
                                          "f(a=aa,b=bb,c=cc);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -422,9 +445,10 @@ static void testCalls6(Parser* parser) {
 }
 
 static void testCalls7(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testCalls6.chpl",
                                          "f(aa,b=bb,cc);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -448,9 +472,10 @@ static void testCalls7(Parser* parser) {
 }
 
 static void testOp1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testOp1.chpl",
                                          "a=b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -464,9 +489,10 @@ static void testOp1(Parser* parser) {
 }
 
 static void testOp2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testOp1.chpl",
                                          "a=b+c;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -486,9 +512,10 @@ static void testOp2(Parser* parser) {
 }
 
 static void testDot1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testDot1.chpl",
                                          "a.b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -503,9 +530,10 @@ static void testDot1(Parser* parser) {
 }
 
 static void testDot2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testDot2.chpl",
                                          "a.type;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -520,9 +548,10 @@ static void testDot2(Parser* parser) {
 }
 
 static void testDot3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testDot3.chpl",
                                          "a.f(b=c);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -545,9 +574,10 @@ static void testDot3(Parser* parser) {
 }
 
 static void testComment1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testComment1.chpl",
                                          "// bla\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -558,9 +588,10 @@ static void testComment1(Parser* parser) {
 }
 
 static void testComment2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testComment2.chpl",
                                          "// bla");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -571,9 +602,10 @@ static void testComment2(Parser* parser) {
 }
 
 static void testComment3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testComment3.chpl",
                                          "/* bla */");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -584,9 +616,10 @@ static void testComment3(Parser* parser) {
 }
 
 static void testComment4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testComment4.chpl",
                                          "/* bla");
-  assert(parseResult.numErrors() >= 1);
+  assert(guard.realizeErrors() >= 1);
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -597,9 +630,10 @@ static void testComment4(Parser* parser) {
 }
 
 static void testComment5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testComment5.chpl",
                                          "/* /* bla */ */");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -610,9 +644,10 @@ static void testComment5(Parser* parser) {
 }
 
 static void testComment6(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testComment6.chpl",
                                          "/* /* bla */");
-  assert(parseResult.numErrors() >= 1);
+  assert(guard.realizeErrors() >= 1);
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -623,9 +658,10 @@ static void testComment6(Parser* parser) {
 }
 
 static void testBoolLiteral0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testBoolLiteral0.chpl",
                                          "var f = false;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -640,9 +676,10 @@ static void testBoolLiteral0(Parser* parser) {
 }
 
 static void testBoolLiteral1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testBoolLiteral1.chpl",
                                          "var f = true;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -657,9 +694,10 @@ static void testBoolLiteral1(Parser* parser) {
 }
 
 static void testPrimCall0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testPrimCall0.chpl",
                                          "__primitive(\"u-\");\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -672,9 +710,10 @@ static void testPrimCall0(Parser* parser) {
   assert(prim->prim() == PRIM_UNARY_MINUS);
 }
 static void testPrimCall1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("testPrimCall1.chpl",
                                          "__primitive(\"u-\", x);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParse.cpp
+++ b/frontend/test/parsing/testParse.cpp
@@ -36,7 +36,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl", "");
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl", "");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -46,7 +46,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl", "x;");
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl", "x;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -59,7 +59,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl", "x; y;");
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl", "x; y;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -71,7 +71,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl", "/* hi */ y;");
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl", "/* hi */ y;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -83,7 +83,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl", "/* hi */ y; /* bye */");
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl", "/* hi */ y; /* bye */");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -96,7 +96,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
                                          "// hi\n"
                                          "a;\n"
                                          "// bye\n");
@@ -111,7 +111,7 @@ static void test5(Parser* parser) {
 
 static void test6(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test6.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test6.chpl",
                                          "{ }");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -122,7 +122,7 @@ static void test6(Parser* parser) {
 
 static void test7(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test7.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test7.chpl",
                                          "{ a; }");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -136,7 +136,7 @@ static void test7(Parser* parser) {
 
 static void test8(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("t.chpl", "aVeryLongIdentifierName;");
+  auto parseResult = parseStringAndReportErrors(parser, "t.chpl", "aVeryLongIdentifierName;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -146,7 +146,7 @@ static void test8(Parser* parser) {
 
 static void test9(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test9.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test9.chpl",
                                          "{ /* this is a comment */ }");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -160,7 +160,7 @@ static void test9(Parser* parser) {
 
 static void test10(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test10.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test10.chpl",
                                          "{\n"
                                          "/* this is comment 2 */\n"
                                          "aVeryLongIdentifierName;\n"
@@ -181,7 +181,7 @@ static void test10(Parser* parser) {
 
 static void test11(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test11.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test11.chpl",
                                          "/* this is comment 1 */\n"
                                          "{\n"
                                          "/* this is comment 2 */\n"
@@ -205,7 +205,7 @@ static void test11(Parser* parser) {
 
 static void test12(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test12.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test12.chpl",
                                          "/* this is comment 1 */\n"
                                          "/* this is comment 2 */\n"
                                          "{\n"
@@ -237,7 +237,7 @@ static void test12(Parser* parser) {
 
 static void test13(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test13.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test13.chpl",
                                          "var a;\n"
                                          "a;");
   assert(!guard.realizeErrors());
@@ -250,7 +250,7 @@ static void test13(Parser* parser) {
 
 static void test14(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test14.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test14.chpl",
                                          "{\n"
                                          " //a\n"
                                          " //b\n"
@@ -268,7 +268,7 @@ static void test14(Parser* parser) {
 
 static void test15(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test15.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test15.chpl",
                                          "{\n"
                                          " x;\n"
                                          " //a\n"
@@ -288,7 +288,7 @@ static void test15(Parser* parser) {
 
 static void testCalls1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testCalls1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testCalls1.chpl",
                                          "f();\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -306,7 +306,7 @@ static void testCalls1(Parser* parser) {
 
 static void testCalls2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testCalls2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testCalls2.chpl",
                                          "f[];\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -324,7 +324,7 @@ static void testCalls2(Parser* parser) {
 
 static void testCalls3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testCalls3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testCalls3.chpl",
                                          "f(x);\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -344,7 +344,7 @@ static void testCalls3(Parser* parser) {
 
 static void testCalls3a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testCalls3a.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testCalls3a.chpl",
                                          "f(g(x));\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -371,7 +371,7 @@ static void testCalls3a(Parser* parser) {
 
 static void testCalls4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testCalls4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testCalls4.chpl",
                                          "f[x];\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -391,7 +391,7 @@ static void testCalls4(Parser* parser) {
 
 static void testCalls5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testCalls5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testCalls5.chpl",
                                          "f(a,b,c);\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -419,7 +419,7 @@ static void testCalls5(Parser* parser) {
 
 static void testCalls6(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testCalls6.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testCalls6.chpl",
                                          "f(a=aa,b=bb,c=cc);\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -446,7 +446,7 @@ static void testCalls6(Parser* parser) {
 
 static void testCalls7(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testCalls6.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testCalls6.chpl",
                                          "f(aa,b=bb,cc);\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -473,7 +473,7 @@ static void testCalls7(Parser* parser) {
 
 static void testOp1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testOp1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testOp1.chpl",
                                          "a=b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -490,7 +490,7 @@ static void testOp1(Parser* parser) {
 
 static void testOp2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testOp1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testOp1.chpl",
                                          "a=b+c;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -513,7 +513,7 @@ static void testOp2(Parser* parser) {
 
 static void testDot1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testDot1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testDot1.chpl",
                                          "a.b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -531,7 +531,7 @@ static void testDot1(Parser* parser) {
 
 static void testDot2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testDot2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testDot2.chpl",
                                          "a.type;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -549,7 +549,7 @@ static void testDot2(Parser* parser) {
 
 static void testDot3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testDot3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testDot3.chpl",
                                          "a.f(b=c);\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -575,7 +575,7 @@ static void testDot3(Parser* parser) {
 
 static void testComment1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testComment1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testComment1.chpl",
                                          "// bla\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -589,7 +589,7 @@ static void testComment1(Parser* parser) {
 
 static void testComment2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testComment2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testComment2.chpl",
                                          "// bla");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -603,7 +603,7 @@ static void testComment2(Parser* parser) {
 
 static void testComment3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testComment3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testComment3.chpl",
                                          "/* bla */");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -617,7 +617,7 @@ static void testComment3(Parser* parser) {
 
 static void testComment4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testComment4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testComment4.chpl",
                                          "/* bla");
   assert(guard.realizeErrors() >= 1);
   auto mod = parseResult.singleModule();
@@ -631,7 +631,7 @@ static void testComment4(Parser* parser) {
 
 static void testComment5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testComment5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testComment5.chpl",
                                          "/* /* bla */ */");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -645,7 +645,7 @@ static void testComment5(Parser* parser) {
 
 static void testComment6(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testComment6.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testComment6.chpl",
                                          "/* /* bla */");
   assert(guard.realizeErrors() >= 1);
   auto mod = parseResult.singleModule();
@@ -659,7 +659,7 @@ static void testComment6(Parser* parser) {
 
 static void testBoolLiteral0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testBoolLiteral0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testBoolLiteral0.chpl",
                                          "var f = false;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -677,7 +677,7 @@ static void testBoolLiteral0(Parser* parser) {
 
 static void testBoolLiteral1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testBoolLiteral1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testBoolLiteral1.chpl",
                                          "var f = true;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -695,7 +695,7 @@ static void testBoolLiteral1(Parser* parser) {
 
 static void testPrimCall0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testPrimCall0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testPrimCall0.chpl",
                                          "__primitive(\"u-\");\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -711,7 +711,7 @@ static void testPrimCall0(Parser* parser) {
 }
 static void testPrimCall1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("testPrimCall1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "testPrimCall1.chpl",
                                          "__primitive(\"u-\", x);\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();

--- a/frontend/test/parsing/testParseAggregate.cpp
+++ b/frontend/test/parsing/testParseAggregate.cpp
@@ -35,8 +35,9 @@ static BuilderResult parseAggregate(Parser* parser,
                                     const AggregateDecl*& agg,
                                     const char* testname,
                                     const char* prog) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString(testname, prog);
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
 
@@ -470,6 +471,7 @@ static void test10(Parser* parser) {
 }
 
 static void test11(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test11.chpl",
         "extern record foo {}\n"
         "extern \"struct bar\" record bar {}\n"
@@ -478,7 +480,7 @@ static void test11(Parser* parser) {
         "extern union baz {}\n"
         "extern \"union thing\" union thing {}\n");
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 6);
@@ -529,6 +531,7 @@ static void test11(Parser* parser) {
 // Test failure for exporting or externing a class.
 // Test failure for exporting a union.
 static void test12(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test12.chpl",
         "extern class foo {};\n"
         "extern \"foo\" class foo {};\n"
@@ -537,7 +540,7 @@ static void test12(Parser* parser) {
         "export union baz {}\n"
         "export \"baz\" union baz {}\n");
 
-  assert(parseResult.numErrors() == 6);
+  assert(guard.realizeErrors() == 6);
   auto mod = parseResult.singleModule();
   assert(mod);
 }

--- a/frontend/test/parsing/testParseAggregate.cpp
+++ b/frontend/test/parsing/testParseAggregate.cpp
@@ -36,7 +36,7 @@ static BuilderResult parseAggregate(Parser* parser,
                                     const char* testname,
                                     const char* prog) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString(testname, prog);
+  auto parseResult = parseStringAndReportErrors(parser, testname, prog);
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -393,7 +393,7 @@ static void test9(Parser* parser) {
 }
 
 static void test10(Parser* parser) {
-  auto parseResult = parser->parseString("test10.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test10.chpl",
                                          "/*1*/ class C1 {\n"
                                          "  /*1a*/ var a;\n"
                                          "  /*1aa*/ var aa;\n"
@@ -471,7 +471,7 @@ static void test10(Parser* parser) {
 
 static void test11(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test11.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test11.chpl",
         "extern record foo {}\n"
         "extern \"struct bar\" record bar {}\n"
         "export record dog { var x = 0; }\n"
@@ -531,7 +531,7 @@ static void test11(Parser* parser) {
 // Test failure for exporting a union.
 static void test12(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test12.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test12.chpl",
         "extern class foo {};\n"
         "extern \"foo\" class foo {};\n"
         "export class bar { var x = 0; }\n"

--- a/frontend/test/parsing/testParseAggregate.cpp
+++ b/frontend/test/parsing/testParseAggregate.cpp
@@ -213,7 +213,6 @@ static void test8(Parser* parser) {
                             "  /*F*/\n"
                             "}\n"
                             "/*G*/\n");
-  assert(!res.numErrors());
   auto mod = res.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseArrayDomainRange.cpp
+++ b/frontend/test/parsing/testParseArrayDomainRange.cpp
@@ -37,6 +37,7 @@ static void testRange(Parser* parser, const char* testName,
                       const char* intervalStr,
                       bool hasLowerBound,
                       bool hasUpperBound) {
+  ErrorGuard guard(parser->context());
   const char* lowerStr = hasLowerBound ? "0" : "";
   const char* upperStr = hasUpperBound ? "8" : "";
 
@@ -48,7 +49,7 @@ static void testRange(Parser* parser, const char* testName,
 
   auto parseResult = parser->parseString(testName, test.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -86,6 +87,7 @@ static void testArrayDomain(Parser* parser, const char* testName,
   // These initializers must have at least one element.
   assert(numElements > 0);
 
+  ErrorGuard guard(parser->context());
   std::string test = isArray ? "var a = " : "var d = ";
   test += isArray ? "[" : "{";
 
@@ -104,7 +106,7 @@ static void testArrayDomain(Parser* parser, const char* testName,
 
   auto parseResult = parser->parseString(testName, test.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseArrayDomainRange.cpp
+++ b/frontend/test/parsing/testParseArrayDomainRange.cpp
@@ -47,7 +47,7 @@ static void testRange(Parser* parser, const char* testName,
   test += upperStr;
   test += ";\n";
 
-  auto parseResult = parser->parseString(testName, test.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testName, test.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -104,7 +104,7 @@ static void testArrayDomain(Parser* parser, const char* testName,
   test += isArray ? "]" : "}";
   test += ";\n";
 
-  auto parseResult = parser->parseString(testName, test.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testName, test.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();

--- a/frontend/test/parsing/testParseAttributes.cpp
+++ b/frontend/test/parsing/testParseAttributes.cpp
@@ -55,7 +55,7 @@ static bool areAttributesEqual(const Decl* lhs, const Decl* rhs) {
 // Make sure MultiDecl attributes equal component attributes.
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "pragma \"no doc\"\n"
       "var a, b, c = 0;\n");
   assert(!guard.realizeErrors());
@@ -81,7 +81,7 @@ static void test0(Parser* parser) {
 // Make sure TupleDecl attributes equal component attributes.
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "pragma \"no doc\"\n"
       "var (a, b, c) = foo;\n");
   assert(!guard.realizeErrors());
@@ -182,7 +182,7 @@ static void testAggregateAttributes(Parser* parser,
                                          numPragmas,
                                          doChildrenHavePragmas,
                                          numChildVars);
-  auto parseResult = parser->parseString("test-aggregate.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test-aggregate.chpl",
                                          code.c_str());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -285,7 +285,7 @@ static void test2(Parser* parser) {
 // Simple test for deprecation message on a variable.
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "pragma \"no doc\"\n"
       "deprecated \"Thingy is deprecated\"\n"
       "var x = 0;\n");
@@ -308,7 +308,7 @@ static void test3(Parser* parser) {
 // Module, enum, and a var decl.
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "pragma \"no doc\"\n"
       "deprecated \"Module is deprecated\"\n"
       "module Foo {\n"
@@ -332,7 +332,7 @@ static void test4(Parser* parser) {
 // Procedures, formals, nested procedures.
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "pragma \"no doc\"\n"
       "deprecated \"P1 is deprecated\"\n"
       "proc p1() {}\n"
@@ -440,7 +440,7 @@ static void test5(Parser* parser) {
 // Enum elements can be deprecated.
 static void test6(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test7.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test7.chpl",
       "pragma \"no doc\"\n"
       "deprecated \"Enum is deprecated\"\n"
       "enum Foo {\n"

--- a/frontend/test/parsing/testParseAttributes.cpp
+++ b/frontend/test/parsing/testParseAttributes.cpp
@@ -54,10 +54,11 @@ static bool areAttributesEqual(const Decl* lhs, const Decl* rhs) {
 
 // Make sure MultiDecl attributes equal component attributes.
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "pragma \"no doc\"\n"
       "var a, b, c = 0;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -79,10 +80,11 @@ static void test0(Parser* parser) {
 
 // Make sure TupleDecl attributes equal component attributes.
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "pragma \"no doc\"\n"
       "var (a, b, c) = foo;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -235,6 +237,7 @@ static void testAggregateAttributes(Parser* parser,
 
 // Make sure attributes for aggregates get attached properly.
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   testAggregateAttributes(parser, /*aggKind*/ asttags::Class,
                           /*isDeprecated*/ false,
                           /*hasDeprecationMsg*/ false,
@@ -281,11 +284,12 @@ static void test2(Parser* parser) {
 
 // Simple test for deprecation message on a variable.
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "pragma \"no doc\"\n"
       "deprecated \"Thingy is deprecated\"\n"
       "var x = 0;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -303,6 +307,7 @@ static void test3(Parser* parser) {
 
 // Module, enum, and a var decl.
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "pragma \"no doc\"\n"
       "deprecated \"Module is deprecated\"\n"
@@ -313,7 +318,7 @@ static void test4(Parser* parser) {
       "  pragma \"ref\"\n"
       "  var y = 0;\n"
       "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
 
@@ -326,6 +331,7 @@ static void test4(Parser* parser) {
 
 // Procedures, formals, nested procedures.
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "pragma \"no doc\"\n"
       "deprecated \"P1 is deprecated\"\n"
@@ -345,7 +351,7 @@ static void test5(Parser* parser) {
       "proc p5(x, pragma \"no init\" y) {}\n"
       "pragma \"no doc\"\n"
       "proc p6() { var x = 0; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 6);
@@ -433,6 +439,7 @@ static void test5(Parser* parser) {
 
 // Enum elements can be deprecated.
 static void test6(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test7.chpl",
       "pragma \"no doc\"\n"
       "deprecated \"Enum is deprecated\"\n"
@@ -442,7 +449,7 @@ static void test6(Parser* parser) {
       "  b = 0,\n"
       "  c,\n"
       "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseBegin.cpp
+++ b/frontend/test/parsing/testParseBegin.cpp
@@ -31,7 +31,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "begin /* comment 2 */\n"
       "with /* comment 3 */ (ref a, var b = foo()) /* comment 4 */ {\n"
@@ -68,7 +68,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "begin /* comment 2 */ {\n"
       "  /* comment 5 */\n"
@@ -96,7 +96,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "begin /* comment 2 */\n"
       "with /* comment 3 */ (ref a, var b = foo()) /* comment 4 */\n"

--- a/frontend/test/parsing/testParseBegin.cpp
+++ b/frontend/test/parsing/testParseBegin.cpp
@@ -30,6 +30,7 @@
 #include "chpl/uast/TaskVar.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "begin /* comment 2 */\n"
@@ -39,7 +40,7 @@ static void test0(Parser* parser) {
       "  /* comment 6 */\n"
       "}\n"
       "/* comment 7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -66,6 +67,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "begin /* comment 2 */ {\n"
@@ -74,7 +76,7 @@ static void test1(Parser* parser) {
       "  /* comment 6 */\n"
       "}\n"
       "/* comment 7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -93,6 +95,7 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "begin /* comment 2 */\n"
@@ -100,7 +103,7 @@ static void test2(Parser* parser) {
       "  /* comment 5 */\n"
       "  writeln(a);\n"
       "/* comment 7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseBracketLoop.cpp
+++ b/frontend/test/parsing/testParseBracketLoop.cpp
@@ -35,7 +35,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "[x in foo]\n"
       "  /* comment 2 */\n"
@@ -65,7 +65,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "[x in foo with (ref thing)] {\n"
       "  /* comment 2 */\n"
@@ -104,7 +104,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "[x in zip(a, b)] {\n"
       "  foo();\n"
@@ -135,7 +135,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "[x in zip(a, b, foo()) with (const ref thing1, in thing2=d)] {\n"
       "  writeln(thing1);\n"
@@ -183,7 +183,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* comment 1 */\n"
       "[foo()]\n"
       "  /* comment 2 */\n"
@@ -212,7 +212,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/* comment 1 */\n"
       "[zip(a, b) with (var r=thing1)] {\n"
       "  writeln(r);\n"

--- a/frontend/test/parsing/testParseBracketLoop.cpp
+++ b/frontend/test/parsing/testParseBracketLoop.cpp
@@ -34,13 +34,14 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "[x in foo]\n"
       "  /* comment 2 */\n"
       "  foo();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -63,6 +64,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "[x in foo with (ref thing)] {\n"
@@ -71,7 +73,7 @@ static void test1(Parser* parser) {
       "  /* comment 3 */\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -101,13 +103,14 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "[x in zip(a, b)] {\n"
       "  foo();\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -131,6 +134,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "[x in zip(a, b, foo()) with (const ref thing1, in thing2=d)] {\n"
@@ -138,7 +142,7 @@ static void test3(Parser* parser) {
       "  thing2 = thing3;\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -178,13 +182,14 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* comment 1 */\n"
       "[foo()]\n"
       "  /* comment 2 */\n"
       "  bar();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -206,13 +211,14 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/* comment 1 */\n"
       "[zip(a, b) with (var r=thing1)] {\n"
       "  writeln(r);\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseChecks.cpp
+++ b/frontend/test/parsing/testParseChecks.cpp
@@ -70,7 +70,7 @@ static void test0(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test0.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 1);
   displayErrors(ctx, guard);
@@ -90,7 +90,7 @@ static void test1(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test1.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 1);
   displayErrors(ctx, guard);
@@ -110,7 +110,7 @@ static void test2(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test2.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 3);
   displayErrors(ctx, guard);
@@ -138,7 +138,7 @@ static void test3(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test3.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 3);
   displayErrors(ctx, guard);
@@ -176,7 +176,7 @@ static void test4(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test4.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 10);
   displayErrors(ctx, guard);
@@ -220,7 +220,7 @@ static void test5(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test5.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 2);
   displayErrors(ctx, guard);
@@ -248,7 +248,7 @@ static void test6(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test6.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 4);
   displayErrors(ctx, guard);
@@ -277,7 +277,7 @@ static void test7(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test7.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 1);
   displayErrors(ctx, guard);
@@ -296,7 +296,7 @@ static void test8(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test8.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 1);
   displayErrors(ctx, guard);
@@ -317,7 +317,7 @@ static void test9(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test9.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 4);
   displayErrors(ctx, guard);
@@ -342,7 +342,7 @@ static void test10(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test10.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 1);
   displayErrors(ctx, guard);
@@ -364,7 +364,7 @@ static void test11(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test11.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 2);
   displayErrors(ctx, guard);
@@ -388,7 +388,7 @@ static void test12(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test12.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 4);
   displayErrors(ctx, guard);
@@ -430,7 +430,7 @@ static void test13(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test13.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 6);
   displayErrors(ctx, guard);
@@ -471,7 +471,7 @@ static void test14(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test14.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 1);
   displayErrors(ctx, guard);
@@ -496,7 +496,7 @@ static void test15(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test15.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 1);
   displayErrors(ctx, guard);
@@ -519,7 +519,7 @@ static void test16(void) {
     )"""";
   auto path = UniqueString::get(ctx, "test16.chpl");
   setFileText(ctx, path, text);
-  parseFileToBuilderResult(ctx, path, UniqueString());
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
 
   assert(guard.numErrors() == 1);
   displayErrors(ctx, guard);

--- a/frontend/test/parsing/testParseCobegin.cpp
+++ b/frontend/test/parsing/testParseCobegin.cpp
@@ -31,7 +31,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "cobegin /* comment 2 */\n"
       "with /* comment 3 */ (ref a, var b = foo()) /* comment 4 */ {\n"
@@ -81,7 +81,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "cobegin /* comment 2 */ {\n"
       "  /* comment 5 */\n"

--- a/frontend/test/parsing/testParseCobegin.cpp
+++ b/frontend/test/parsing/testParseCobegin.cpp
@@ -30,6 +30,7 @@
 #include "chpl/uast/TaskVar.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "cobegin /* comment 2 */\n"
@@ -39,7 +40,7 @@ static void test0(Parser* parser) {
       "  /* comment 6 */\n"
       "}\n"
       "/* comment 7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -79,6 +80,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "cobegin /* comment 2 */ {\n"
@@ -87,7 +89,7 @@ static void test1(Parser* parser) {
       "  /* comment 6 */\n"
       "}\n"
       "/* comment 7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseCoforall.cpp
+++ b/frontend/test/parsing/testParseCoforall.cpp
@@ -33,13 +33,14 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "coforall x in foo do\n"
       "  /* comment 2 */\n"
       "  foo();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -61,6 +62,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "coforall x in foo with (ref thing) do {\n"
@@ -69,7 +71,7 @@ static void test1(Parser* parser) {
       "  /* comment 3 */\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -99,13 +101,14 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "coforall x in zip(a, b) {\n"
       "  foo();\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -129,6 +132,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "coforall x in zip(a, b, foo()) with (const ref thing1, in thing2=d) {\n"
@@ -136,7 +140,7 @@ static void test3(Parser* parser) {
       "  thing2 = thing3;\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -176,13 +180,14 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* comment 1 */\n"
       "coforall foo() do\n"
       "  /* comment 2 */\n"
       "  bar();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseCoforall.cpp
+++ b/frontend/test/parsing/testParseCoforall.cpp
@@ -34,7 +34,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "coforall x in foo do\n"
       "  /* comment 2 */\n"
@@ -63,7 +63,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "coforall x in foo with (ref thing) do {\n"
       "  /* comment 2 */\n"
@@ -102,7 +102,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "coforall x in zip(a, b) {\n"
       "  foo();\n"
@@ -133,7 +133,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "coforall x in zip(a, b, foo()) with (const ref thing1, in thing2=d) {\n"
       "  writeln(thing1);\n"
@@ -181,7 +181,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* comment 1 */\n"
       "coforall foo() do\n"
       "  /* comment 2 */\n"

--- a/frontend/test/parsing/testParseComments.cpp
+++ b/frontend/test/parsing/testParseComments.cpp
@@ -29,10 +29,11 @@
 #include "chpl/framework/Context.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "foo();\n"
       "//c2");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->stmt(0)->isFnCall());

--- a/frontend/test/parsing/testParseComments.cpp
+++ b/frontend/test/parsing/testParseComments.cpp
@@ -30,7 +30,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "foo();\n"
       "//c2");
   assert(!guard.realizeErrors());

--- a/frontend/test/parsing/testParseConditional.cpp
+++ b/frontend/test/parsing/testParseConditional.cpp
@@ -37,6 +37,7 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* c1 */\n"
       "if /* c2 */ foo /* c3 */ then\n"
@@ -47,7 +48,7 @@ static void test0(Parser* parser) {
       "  /* c6 */\n"
       "  baz();\n"
       "/* c7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -101,6 +102,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* c1 */\n"
       "if /* c2 */ foo() /* c3 */ {\n"
@@ -113,7 +115,7 @@ static void test1(Parser* parser) {
       "  /* c9 */\n"
       "}\n"
       "/* c10 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -171,6 +173,7 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* c1 */\n"
       "if /* c2 */ foo /* c3 */ then {\n"
@@ -180,7 +183,7 @@ static void test2(Parser* parser) {
       "  /* c5 */\n"
       "} /* c6 */ else /* c7 */ ding();\n"
       "/* c8 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -206,13 +209,14 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* c1 */\n"
       "if /* c2 */ foo /* c3 */ then\n"
       "  /* c4 */\n"
       "  bar();\n"
       "/* c5 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -247,12 +251,13 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* c1 */\n"
       "if foo += bar() then\n"
       "  baz();\n"
       "/* c2 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -273,12 +278,13 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/* c1 */\n"
       "if var foo = bar() then\n"
       "  baz();\n"
       "/* c2 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseConditional.cpp
+++ b/frontend/test/parsing/testParseConditional.cpp
@@ -38,7 +38,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* c1 */\n"
       "if /* c2 */ foo /* c3 */ then\n"
       "  /* c4 */\n"
@@ -103,7 +103,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* c1 */\n"
       "if /* c2 */ foo() /* c3 */ {\n"
       "  /* c4 */\n"
@@ -174,7 +174,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* c1 */\n"
       "if /* c2 */ foo /* c3 */ then {\n"
       "  /* c4 */\n"
@@ -210,7 +210,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* c1 */\n"
       "if /* c2 */ foo /* c3 */ then\n"
       "  /* c4 */\n"
@@ -252,7 +252,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* c1 */\n"
       "if foo += bar() then\n"
       "  baz();\n"
@@ -279,7 +279,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/* c1 */\n"
       "if var foo = bar() then\n"
       "  baz();\n"

--- a/frontend/test/parsing/testParseDefer.cpp
+++ b/frontend/test/parsing/testParseDefer.cpp
@@ -30,7 +30,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "defer /* comment 2 */\n"
       "  foo();\n"
@@ -66,7 +66,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "defer /* comment 2 */ {\n"
       "  /* comment 3 */\n"

--- a/frontend/test/parsing/testParseDefer.cpp
+++ b/frontend/test/parsing/testParseDefer.cpp
@@ -29,12 +29,13 @@
 #include "chpl/uast/Module.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "defer /* comment 2 */\n"
       "  foo();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -64,6 +65,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "defer /* comment 2 */ {\n"
@@ -72,7 +74,7 @@ static void test1(Parser* parser) {
       "  /* comment 4 */\n"
       "}\n"
       "/* comment 5 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseDelete.cpp
+++ b/frontend/test/parsing/testParseDelete.cpp
@@ -29,7 +29,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "delete foo, /* comment 2 */ bar, /* comment 3*/ baz;\n"
       "/* comment 4 */\n");

--- a/frontend/test/parsing/testParseDelete.cpp
+++ b/frontend/test/parsing/testParseDelete.cpp
@@ -28,11 +28,12 @@
 #include "chpl/uast/Module.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "delete foo, /* comment 2 */ bar, /* comment 3*/ baz;\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseDoWhile.cpp
+++ b/frontend/test/parsing/testParseDoWhile.cpp
@@ -32,6 +32,7 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "do {\n"
@@ -40,7 +41,7 @@ static void test0(Parser* parser) {
       "  /* comment 3 */\n"
       "} while /* comment 4 */ foo();\n"
       "/* comment 5 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -59,6 +60,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "do /* comment 2 */\n"
@@ -68,7 +70,7 @@ static void test1(Parser* parser) {
       "  /* comment 4 */\n"
       "while /* comment 5 */ condition;\n"
       "/* comment 6 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -98,6 +100,7 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "do\n"
@@ -110,7 +113,7 @@ static void test2(Parser* parser) {
       "  /* comment 7 */\n"
       "while condition2;\n"
       "/* comment 8 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseDoWhile.cpp
+++ b/frontend/test/parsing/testParseDoWhile.cpp
@@ -33,7 +33,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "do {\n"
       "  /* comment 2 */\n"
@@ -61,7 +61,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "do /* comment 2 */\n"
       "  for x in thing do\n"
@@ -101,7 +101,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "do\n"
       "  /* comment 2 */\n"

--- a/frontend/test/parsing/testParseEmptyStmt.cpp
+++ b/frontend/test/parsing/testParseEmptyStmt.cpp
@@ -30,6 +30,7 @@
 #include "chpl/uast/Cobegin.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
         "hi();\n"
          ";\n"
@@ -40,7 +41,7 @@ static void test0(Parser* parser) {
          ";\n"
          "bye();\n");
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 8);
@@ -83,11 +84,12 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
         "while true do\n"
          ";\n");
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -111,10 +113,11 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
         "cobegin { ; writeln['']; }\n");
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -139,13 +142,14 @@ static void test3(Parser* parser) {
   // error in both the production and dyno compilers"
   // It originated from test/users/thom/topLevelCode.chpl and causes some
   // discrepancy in the test result between dyno and production
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
         "proc myProc();\n"
         "{\n //comment;\n"
         "}");
 
   // Now has error: "non-extern functions must have a body"!
-  assert(parseResult.numErrors() == 1);
+  assert(guard.realizeErrors() == 1);
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);

--- a/frontend/test/parsing/testParseEmptyStmt.cpp
+++ b/frontend/test/parsing/testParseEmptyStmt.cpp
@@ -31,7 +31,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
         "hi();\n"
          ";\n"
          ";\n"
@@ -85,7 +85,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
         "while true do\n"
          ";\n");
 
@@ -114,7 +114,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
         "cobegin { ; writeln['']; }\n");
 
   assert(!guard.realizeErrors());
@@ -143,7 +143,7 @@ static void test3(Parser* parser) {
   // It originated from test/users/thom/topLevelCode.chpl and causes some
   // discrepancy in the test result between dyno and production
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
         "proc myProc();\n"
         "{\n //comment;\n"
         "}");

--- a/frontend/test/parsing/testParseEnums.cpp
+++ b/frontend/test/parsing/testParseEnums.cpp
@@ -27,9 +27,10 @@
 #include "chpl/uast/Module.h"
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
                                          "enum myEnum { a }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -43,9 +44,10 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
                                          "enum myEnum { a=ii }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -61,9 +63,10 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
                                          "enum myEnum { a=ii, b=jj }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -88,9 +91,10 @@ static void checkTest4(const Enum* enumDecl,
                        const EnumElement* b);
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
                                          "enum myEnum { a=ii, b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -125,9 +129,10 @@ static void checkTest4(const Enum* enumDecl,
 }
 
 static void test4a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4a.chpl",
                                          "/* c */ enum myEnum { a=ii, b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -141,9 +146,10 @@ static void test4a(Parser* parser) {
 }
 
 static void test4b(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4b.chpl",
                                          "enum /* c */ myEnum { a=ii, b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -156,9 +162,10 @@ static void test4b(Parser* parser) {
 }
 
 static void test4c(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4c.chpl",
                                          "enum myEnum /* c */ { a=ii, b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -171,9 +178,10 @@ static void test4c(Parser* parser) {
 }
 
 static void test4d(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4d.chpl",
                                          "enum myEnum { /* c */ a=ii, b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -187,9 +195,10 @@ static void test4d(Parser* parser) {
 }
 
 static void test4e(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4e.chpl",
                                          "enum myEnum { a /* c */ =ii, b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -202,9 +211,10 @@ static void test4e(Parser* parser) {
 }
 
 static void test4f(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4f.chpl",
                                          "enum myEnum { a = /* c */ ii, b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -217,9 +227,10 @@ static void test4f(Parser* parser) {
 }
 
 static void test4g(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4g.chpl",
                                          "enum myEnum { a = ii /* c */, b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -232,9 +243,10 @@ static void test4g(Parser* parser) {
 }
 
 static void test4h(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4h.chpl",
                                          "enum myEnum { a = ii, /* c */ b }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -248,9 +260,10 @@ static void test4h(Parser* parser) {
 }
 
 static void test4i(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4i.chpl",
                                          "enum myEnum { a = ii, b /* c */ }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -264,9 +277,10 @@ static void test4i(Parser* parser) {
 }
 
 static void test4j(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4i.chpl",
                                          "enum myEnum { a = ii, b, /*c*/ }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseEnums.cpp
+++ b/frontend/test/parsing/testParseEnums.cpp
@@ -28,7 +28,7 @@
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
                                          "enum myEnum { a }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -45,7 +45,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
                                          "enum myEnum { a=ii }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -64,7 +64,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
                                          "enum myEnum { a=ii, b=jj }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -92,7 +92,7 @@ static void checkTest4(const Enum* enumDecl,
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
                                          "enum myEnum { a=ii, b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -130,7 +130,7 @@ static void checkTest4(const Enum* enumDecl,
 
 static void test4a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4a.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4a.chpl",
                                          "/* c */ enum myEnum { a=ii, b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -147,7 +147,7 @@ static void test4a(Parser* parser) {
 
 static void test4b(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4b.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4b.chpl",
                                          "enum /* c */ myEnum { a=ii, b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -163,7 +163,7 @@ static void test4b(Parser* parser) {
 
 static void test4c(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4c.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4c.chpl",
                                          "enum myEnum /* c */ { a=ii, b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -179,7 +179,7 @@ static void test4c(Parser* parser) {
 
 static void test4d(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4d.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4d.chpl",
                                          "enum myEnum { /* c */ a=ii, b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -196,7 +196,7 @@ static void test4d(Parser* parser) {
 
 static void test4e(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4e.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4e.chpl",
                                          "enum myEnum { a /* c */ =ii, b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -212,7 +212,7 @@ static void test4e(Parser* parser) {
 
 static void test4f(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4f.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4f.chpl",
                                          "enum myEnum { a = /* c */ ii, b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -228,7 +228,7 @@ static void test4f(Parser* parser) {
 
 static void test4g(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4g.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4g.chpl",
                                          "enum myEnum { a = ii /* c */, b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -244,7 +244,7 @@ static void test4g(Parser* parser) {
 
 static void test4h(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4h.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4h.chpl",
                                          "enum myEnum { a = ii, /* c */ b }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -261,7 +261,7 @@ static void test4h(Parser* parser) {
 
 static void test4i(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4i.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4i.chpl",
                                          "enum myEnum { a = ii, b /* c */ }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -278,7 +278,7 @@ static void test4i(Parser* parser) {
 
 static void test4j(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4i.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4i.chpl",
                                          "enum myEnum { a = ii, b, /*c*/ }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();

--- a/frontend/test/parsing/testParseFor.cpp
+++ b/frontend/test/parsing/testParseFor.cpp
@@ -31,7 +31,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "for /*comment 2*/ foo /*comment 3*/ do\n"
       "  /* comment 4 */\n"
@@ -57,7 +57,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "for foo in /* comment 2 */ bar do\n"
       "  /* comment 3 */\n"
@@ -84,7 +84,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "for /* comment 2 */ param foo in bar do\n"
       "  /* comment 3 */\n"
@@ -111,7 +111,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "for foo in bar /* comment 2 */ {\n"
       "  /* comment 3 */\n"
@@ -141,7 +141,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* comment 1 */\n"
       "for foo in bar do\n"
       "/* comment 2 */\n"

--- a/frontend/test/parsing/testParseFor.cpp
+++ b/frontend/test/parsing/testParseFor.cpp
@@ -30,12 +30,13 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "for /*comment 2*/ foo /*comment 3*/ do\n"
       "  /* comment 4 */\n"
       "  var a;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -55,12 +56,13 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "for foo in /* comment 2 */ bar do\n"
       "  /* comment 3 */\n"
       "  var a;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -81,12 +83,13 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "for /* comment 2 */ param foo in bar do\n"
       "  /* comment 3 */\n"
       "  var a;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -107,6 +110,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "for foo in bar /* comment 2 */ {\n"
@@ -114,7 +118,7 @@ static void test3(Parser* parser) {
       "  var a;\n"
       "  /* comment 4 */\n"
       "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -136,6 +140,7 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* comment 1 */\n"
       "for foo in bar do\n"
@@ -145,7 +150,7 @@ static void test4(Parser* parser) {
       "  var a;\n"
       "  /* comment 3 */\n"
       "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);

--- a/frontend/test/parsing/testParseForall.cpp
+++ b/frontend/test/parsing/testParseForall.cpp
@@ -34,7 +34,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "forall x in foo do\n"
       "  /* comment 2 */\n"
@@ -63,7 +63,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "forall x in foo with (ref thing) {\n"
       "  /* comment 2 */\n"
@@ -102,7 +102,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "forall x in zip(a, b) {\n"
       "  foo();\n"
@@ -133,7 +133,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "forall x in zip(a, b, foo()) with (const ref thing1, in thing2=d) {\n"
       "  writeln(thing1);\n"
@@ -181,7 +181,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* comment 1 */\n"
       "forall foo() do\n"
       "  /* comment 2 */\n"
@@ -209,7 +209,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/* comment 1 */\n"
       "forall zip(a, b) with (var r=thing1) do {\n"
       "  writeln(r);\n"

--- a/frontend/test/parsing/testParseForall.cpp
+++ b/frontend/test/parsing/testParseForall.cpp
@@ -33,13 +33,14 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "forall x in foo do\n"
       "  /* comment 2 */\n"
       "  foo();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -61,6 +62,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "forall x in foo with (ref thing) {\n"
@@ -69,7 +71,7 @@ static void test1(Parser* parser) {
       "  /* comment 3 */\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -99,13 +101,14 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "forall x in zip(a, b) {\n"
       "  foo();\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -129,6 +132,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "forall x in zip(a, b, foo()) with (const ref thing1, in thing2=d) {\n"
@@ -136,7 +140,7 @@ static void test3(Parser* parser) {
       "  thing2 = thing3;\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -176,13 +180,14 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* comment 1 */\n"
       "forall foo() do\n"
       "  /* comment 2 */\n"
       "  bar();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -203,13 +208,14 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/* comment 1 */\n"
       "forall zip(a, b) with (var r=thing1) do {\n"
       "  writeln(r);\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseForeach.cpp
+++ b/frontend/test/parsing/testParseForeach.cpp
@@ -34,7 +34,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "foreach x in foo do\n"
       "  /* comment 2 */\n"
@@ -62,7 +62,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "foreach x in foo with (ref thing) {\n"
       "  /* comment 2 */\n"
@@ -100,7 +100,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "foreach x in zip(a, b) {\n"
       "  foo();\n"
@@ -130,7 +130,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "foreach x in zip(a, b, foo()) with (const ref thing1, in thing2=d) {\n"
       "  writeln(thing1);\n"
@@ -177,7 +177,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* comment 1 */\n"
       "foreach foo() do\n"
       "  /* comment 2 */\n"
@@ -204,7 +204,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/* comment 1 */\n"
       "foreach zip(a, b) with (var r=thing1) do {\n"
       "  writeln(r);\n"

--- a/frontend/test/parsing/testParseForeach.cpp
+++ b/frontend/test/parsing/testParseForeach.cpp
@@ -33,13 +33,14 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "foreach x in foo do\n"
       "  /* comment 2 */\n"
       "  foo();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -60,6 +61,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "foreach x in foo with (ref thing) {\n"
@@ -68,7 +70,7 @@ static void test1(Parser* parser) {
       "  /* comment 3 */\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -97,13 +99,14 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "foreach x in zip(a, b) {\n"
       "  foo();\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -126,6 +129,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "foreach x in zip(a, b, foo()) with (const ref thing1, in thing2=d) {\n"
@@ -133,7 +137,7 @@ static void test3(Parser* parser) {
       "  thing2 = thing3;\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -172,13 +176,14 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* comment 1 */\n"
       "foreach foo() do\n"
       "  /* comment 2 */\n"
       "  bar();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -198,13 +203,14 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/* comment 1 */\n"
       "foreach zip(a, b) with (var r=thing1) do {\n"
       "  writeln(r);\n"
       "}\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseForwardingDecl.cpp
+++ b/frontend/test/parsing/testParseForwardingDecl.cpp
@@ -32,7 +32,7 @@
 #include "chpl/uast/VisibilityClause.h"
 
 static void test0(Parser* parser) {
-
+  ErrorGuard guard(parser->context());
   const std::string myCircle =
         "record MyCircle {\n"
           "forwarding var impl: MyCircleImpl;\n"
@@ -40,7 +40,7 @@ static void test0(Parser* parser) {
 
   auto parseResult = parser->parseString("test0.chpl", myCircle.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -58,6 +58,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   const std::string myCircle =
                     "record MyCircle {\n"
                       "var impl: MyCircleImpl;\n"
@@ -72,7 +73,7 @@ static void test1(Parser* parser) {
                      "}\n";
 
   auto parseResult = parser->parseString("test1.chpl", myCircle.c_str());
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
 
@@ -93,6 +94,7 @@ static void test1(Parser* parser) {
 
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   const std::string myCircle =
                     "record MyCircle {\n"
                       "var impl: MyCircleImpl;\n"
@@ -102,7 +104,7 @@ static void test2(Parser* parser) {
 
   auto parseResult = parser->parseString("test2.chpl", myCircle.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -128,6 +130,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   const std::string myCircle =
                     "record MyCircle {\n"
                       "var impl: MyCircleImpl;\n"
@@ -137,7 +140,7 @@ static void test3(Parser* parser) {
 
   auto parseResult = parser->parseString("test3.chpl", myCircle.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -161,6 +164,7 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   const std::string myCircle =
                     "record MyCircle {\n"
                       "var impl: MyCircleImpl;\n"
@@ -170,7 +174,7 @@ static void test4(Parser* parser) {
 
   auto parseResult = parser->parseString("test4.chpl", myCircle.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -193,6 +197,7 @@ static void test4(Parser* parser) {
 
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   const std::string myCircle =
                         "module test5 {\n"
                           "class MyCircleImpl {\n"
@@ -215,7 +220,7 @@ static void test5(Parser* parser) {
 
   auto parseResult = parser->parseString("test5.chpl", myCircle.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 4);
@@ -248,18 +253,18 @@ static void test5(Parser* parser) {
 */
 
 // static void test6(Parser* parser) {
-
+//   ErrorGuard guard(parser->context());
 //   const std::string myCircle =
 //         "record MyCircle {\n"
 //           "forwarding private var impl: MyCircleImpl;\n"
 //         "}\n";
 
 //   auto parseResult = parser->parseString("test6.chpl", myCircle.c_str());
-//   for (int i=0;i<parseResult.numErrors();i++){
+//   for (int i=0;i<guard.realizeErrors();i++){
 //     fprintf(stderr, "parse error: %s\n", parseResult.error(i).message().c_str());
 //   }
 
-//   assert(!parseResult.numErrors());
+//   assert(!guard.realizeErrors());
 //   auto mod = parseResult.singleModule();
 //   assert(mod);
 //   assert(mod->numStmts() == 1);
@@ -282,7 +287,7 @@ static void test5(Parser* parser) {
  *
 */
 // static void test7(Parser* parser) {
-
+//   ErrorGuard guard(parser->context());
 //   const std::string myCircle =
 //         "record MyCircle {\n"
 //           "forwarding public var impl: MyCircleImpl;\n"
@@ -290,7 +295,7 @@ static void test5(Parser* parser) {
 
 //   auto parseResult = parser->parseString("test7.chpl", myCircle.c_str());
 
-//   assert(!parseResult.numErrors());
+//   assert(!guard.realizeErrors());
 //   auto mod = parseResult.singleModule();
 //   assert(mod);
 //   assert(mod->numStmts() == 1);
@@ -308,7 +313,7 @@ static void test5(Parser* parser) {
 // }
 
 static void test8(Parser* parser) {
-
+  ErrorGuard guard(parser->context());
   const std::string myCircle =
         "record MyCircle {\n"
           "pragma \"no doc\"\n"
@@ -317,7 +322,7 @@ static void test8(Parser* parser) {
 
   auto parseResult = parser->parseString("test8.chpl", myCircle.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -340,7 +345,7 @@ static void test8(Parser* parser) {
 }
 
 static void test9(Parser* parser) {
-
+  ErrorGuard guard(parser->context());
   const std::string myCircle =
         "record MyCircle {\n"
           "deprecated \"don't use this anymore\"\n"
@@ -349,7 +354,7 @@ static void test9(Parser* parser) {
 
   auto parseResult = parser->parseString("test9.chpl", myCircle.c_str());
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseForwardingDecl.cpp
+++ b/frontend/test/parsing/testParseForwardingDecl.cpp
@@ -38,7 +38,7 @@ static void test0(Parser* parser) {
           "forwarding var impl: MyCircleImpl;\n"
         "}\n";
 
-  auto parseResult = parser->parseString("test0.chpl", myCircle.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl", myCircle.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -72,7 +72,7 @@ static void test1(Parser* parser) {
                       "forwarding getImplOrFail();\n"
                      "}\n";
 
-  auto parseResult = parser->parseString("test1.chpl", myCircle.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl", myCircle.c_str());
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -102,7 +102,7 @@ static void test2(Parser* parser) {
                       "/* some comments after forwarding*/\n"
                     "}\n";
 
-  auto parseResult = parser->parseString("test2.chpl", myCircle.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl", myCircle.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -138,7 +138,7 @@ static void test3(Parser* parser) {
                       "forwarding impl except circumference;\n"
                     "}\n";
 
-  auto parseResult = parser->parseString("test3.chpl", myCircle.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl", myCircle.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -172,7 +172,7 @@ static void test4(Parser* parser) {
                       "forwarding var x = 10;\n"
                     "}\n";
 
-  auto parseResult = parser->parseString("test4.chpl", myCircle.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl", myCircle.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -218,7 +218,7 @@ static void test5(Parser* parser) {
                           "// writeln(c.area());\n"
                         "}\n";
 
-  auto parseResult = parser->parseString("test5.chpl", myCircle.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl", myCircle.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -259,7 +259,7 @@ static void test5(Parser* parser) {
 //           "forwarding private var impl: MyCircleImpl;\n"
 //         "}\n";
 
-//   auto parseResult = parser->parseString("test6.chpl", myCircle.c_str());
+//   auto parseResult = parseStringAndReportErrors(parser, "test6.chpl", myCircle.c_str());
 //   for (int i=0;i<guard.realizeErrors();i++){
 //     fprintf(stderr, "parse error: %s\n", parseResult.error(i).message().c_str());
 //   }
@@ -293,7 +293,7 @@ static void test5(Parser* parser) {
 //           "forwarding public var impl: MyCircleImpl;\n"
 //         "}\n";
 
-//   auto parseResult = parser->parseString("test7.chpl", myCircle.c_str());
+//   auto parseResult = parseStringAndReportErrors(parser, "test7.chpl", myCircle.c_str());
 
 //   assert(!guard.realizeErrors());
 //   auto mod = parseResult.singleModule();
@@ -320,7 +320,7 @@ static void test8(Parser* parser) {
           "forwarding var impl: MyCircleImpl;\n"
         "}\n";
 
-  auto parseResult = parser->parseString("test8.chpl", myCircle.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, "test8.chpl", myCircle.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -352,7 +352,7 @@ static void test9(Parser* parser) {
           "forwarding var impl: MyCircleImpl;\n"
         "}\n";
 
-  auto parseResult = parser->parseString("test9.chpl", myCircle.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, "test9.chpl", myCircle.c_str());
 
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();

--- a/frontend/test/parsing/testParseFunctions.cpp
+++ b/frontend/test/parsing/testParseFunctions.cpp
@@ -32,7 +32,7 @@
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
                                          "proc f() { }");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -57,7 +57,7 @@ static void test1(Parser* parser) {
 }
 static void test1a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1a.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1a.chpl",
                                          "/* comment 1 */\n"
                                          "proc f() {\n"
                                          "  /* comment 2 */\n"
@@ -78,7 +78,7 @@ static void test1a(Parser* parser) {
 }
 static void test1b(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1a.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1a.chpl",
                                          "/* comment 1 */\n"
                                          "proc f() {\n"
                                          "  /* comment 2 */\n"
@@ -104,7 +104,7 @@ static void test1b(Parser* parser) {
 
 static void test1c(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1c.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1c.chpl",
                                          "/* comment 1 */\n"
                                          "public inline\n"
                                          "proc f() {\n"
@@ -125,7 +125,7 @@ static void test1c(Parser* parser) {
 
 static void test1d(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1d.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1d.chpl",
                                          "public\n"
                                          "/* comment 1 */\n"
                                          "inline\n"
@@ -146,7 +146,7 @@ static void test1d(Parser* parser) {
 
 static void test1e(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1e.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1e.chpl",
                                          "public\n"
                                          "inline\n"
                                          "/* comment 1 */\n"
@@ -167,7 +167,7 @@ static void test1e(Parser* parser) {
 
 static void test1f(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1f.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1f.chpl",
                                          "proc f(/* comment 1 */) {\n"
                                          "  x;\n"
                                          "}\n");
@@ -185,7 +185,7 @@ static void test1f(Parser* parser) {
 
 static void test1g(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1g.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1g.chpl",
                                          "proc f()\n"
                                          "/* comment 1 */ where a \n"
                                          "{\n"
@@ -205,7 +205,7 @@ static void test1g(Parser* parser) {
 
 static void test1h(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1h.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1h.chpl",
                                          "proc f()\n"
                                          "where a /* comment 1 */\n"
                                          "{\n"
@@ -225,7 +225,7 @@ static void test1h(Parser* parser) {
 
 static void test1i(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1i.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1i.chpl",
                                          "proc f()\n"
                                          "lifetime /* comment 1 */ a=b\n"
                                          "{\n"
@@ -245,7 +245,7 @@ static void test1i(Parser* parser) {
 
 static void test1j(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1j.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1j.chpl",
                                          "proc f()\n"
                                          "lifetime a=b /* comment 1 */\n"
                                          "{\n"
@@ -273,7 +273,7 @@ static BuilderResult parseFunction(Parser* parser,
                                    const Function*& f,
                                    const char* contents) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString(filename, contents);
+  auto parseResult = parseStringAndReportErrors(parser, filename, contents);
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);

--- a/frontend/test/parsing/testParseFunctions.cpp
+++ b/frontend/test/parsing/testParseFunctions.cpp
@@ -31,9 +31,10 @@
 #include "chpl/uast/OpCall.h"
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
                                          "proc f() { }");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1") == 0);
@@ -55,13 +56,14 @@ static void test1(Parser* parser) {
   assert(functionDecl->numStmts() == 0);
 }
 static void test1a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1a.chpl",
                                          "/* comment 1 */\n"
                                          "proc f() {\n"
                                          "  /* comment 2 */\n"
                                          "}\n"
                                          "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1a") == 0);
@@ -75,6 +77,7 @@ static void test1a(Parser* parser) {
   assert(functionDecl->stmt(0)->isComment());
 }
 static void test1b(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1a.chpl",
                                          "/* comment 1 */\n"
                                          "proc f() {\n"
@@ -83,7 +86,7 @@ static void test1b(Parser* parser) {
                                          "  /* comment 3 */\n"
                                          "}\n"
                                          "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1a") == 0);
@@ -100,13 +103,14 @@ static void test1b(Parser* parser) {
 }
 
 static void test1c(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1c.chpl",
                                          "/* comment 1 */\n"
                                          "public inline\n"
                                          "proc f() {\n"
                                          "  x;\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1c") == 0);
@@ -120,6 +124,7 @@ static void test1c(Parser* parser) {
 }
 
 static void test1d(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1d.chpl",
                                          "public\n"
                                          "/* comment 1 */\n"
@@ -127,7 +132,7 @@ static void test1d(Parser* parser) {
                                          "proc f() {\n"
                                          "  x;\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1d") == 0);
@@ -140,6 +145,7 @@ static void test1d(Parser* parser) {
 }
 
 static void test1e(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1e.chpl",
                                          "public\n"
                                          "inline\n"
@@ -147,7 +153,7 @@ static void test1e(Parser* parser) {
                                          "proc f() {\n"
                                          "  x;\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1e") == 0);
@@ -160,11 +166,12 @@ static void test1e(Parser* parser) {
 }
 
 static void test1f(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1f.chpl",
                                          "proc f(/* comment 1 */) {\n"
                                          "  x;\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1f") == 0);
@@ -177,13 +184,14 @@ static void test1f(Parser* parser) {
 }
 
 static void test1g(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1g.chpl",
                                          "proc f()\n"
                                          "/* comment 1 */ where a \n"
                                          "{\n"
                                          "  x;\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1g") == 0);
@@ -196,13 +204,14 @@ static void test1g(Parser* parser) {
 }
 
 static void test1h(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1h.chpl",
                                          "proc f()\n"
                                          "where a /* comment 1 */\n"
                                          "{\n"
                                          "  x;\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1h") == 0);
@@ -215,13 +224,14 @@ static void test1h(Parser* parser) {
 }
 
 static void test1i(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1i.chpl",
                                          "proc f()\n"
                                          "lifetime /* comment 1 */ a=b\n"
                                          "{\n"
                                          "  x;\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1i") == 0);
@@ -234,13 +244,14 @@ static void test1i(Parser* parser) {
 }
 
 static void test1j(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1j.chpl",
                                          "proc f()\n"
                                          "lifetime a=b /* comment 1 */\n"
                                          "{\n"
                                          "  x;\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->name().compare("test1j") == 0);
@@ -261,8 +272,9 @@ static BuilderResult parseFunction(Parser* parser,
                                    const char* filename,
                                    const Function*& f,
                                    const char* contents) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString(filename, contents);
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -273,6 +285,7 @@ static BuilderResult parseFunction(Parser* parser,
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   const Function* function = nullptr;
   auto parse = parseFunction(
       parser,
@@ -311,6 +324,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   const Function* function = nullptr;
   auto parse = parseFunction(
       parser,
@@ -361,6 +375,7 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   const Function* function = nullptr;
   auto parse = parseFunction(
       parser,
@@ -397,9 +412,10 @@ static void test4(Parser* parser) {
 
 
 static void test5(Parser* p) {
+  ErrorGuard guard(p->context());
   auto parseResult = p->parseString("test5.chpl",
                                     "private extern proc hello();\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts()==1);

--- a/frontend/test/parsing/testParseImport.cpp
+++ b/frontend/test/parsing/testParseImport.cpp
@@ -35,11 +35,12 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/*c1*/\n"
       "import /*c2*/ Foo as X /*c3*/;\n"
       "/*c4*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -61,11 +62,12 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/*c1*/\n"
       "public import /*c2*/ A as X, /*c3*/ B.SM1 as Y, /*c4*/ C as Z;\n"
       "/*c5*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -128,11 +130,12 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/*c1*/\n"
       "private import /*c2*/ A as X, B.{Y, Z};\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -184,11 +187,12 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/*c1*/\n"
       "private import /*c2*/ B.{Y};\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -205,11 +209,12 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/*c1*/\n"
       "import /*c2*/ B.{Y as Z};\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -231,11 +236,12 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/*c1*/\n"
       "import /*c2*/ 1+1;\n"
       "/*c7*/\n");
-  assert(parseResult.numErrors() >= 1);
+  assert(guard.realizeErrors() >= 1);
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -245,11 +251,12 @@ static void test5(Parser* parser) {
 }
 
 static void test6(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test6.chpl",
       "/*c1*/\n"
       "private import /*c2*/ B.{+};\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseImport.cpp
+++ b/frontend/test/parsing/testParseImport.cpp
@@ -36,7 +36,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/*c1*/\n"
       "import /*c2*/ Foo as X /*c3*/;\n"
       "/*c4*/\n");
@@ -63,7 +63,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/*c1*/\n"
       "public import /*c2*/ A as X, /*c3*/ B.SM1 as Y, /*c4*/ C as Z;\n"
       "/*c5*/\n");
@@ -131,7 +131,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/*c1*/\n"
       "private import /*c2*/ A as X, B.{Y, Z};\n"
       "/*c7*/\n");
@@ -188,7 +188,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/*c1*/\n"
       "private import /*c2*/ B.{Y};\n"
       "/*c7*/\n");
@@ -210,7 +210,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/*c1*/\n"
       "import /*c2*/ B.{Y as Z};\n"
       "/*c7*/\n");
@@ -237,7 +237,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/*c1*/\n"
       "import /*c2*/ 1+1;\n"
       "/*c7*/\n");
@@ -252,7 +252,7 @@ static void test5(Parser* parser) {
 
 static void test6(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test6.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test6.chpl",
       "/*c1*/\n"
       "private import /*c2*/ B.{+};\n"
       "/*c7*/\n");

--- a/frontend/test/parsing/testParseInclude.cpp
+++ b/frontend/test/parsing/testParseInclude.cpp
@@ -31,7 +31,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "include module Foo;\n"
       "/* comment 2 */\n"

--- a/frontend/test/parsing/testParseInclude.cpp
+++ b/frontend/test/parsing/testParseInclude.cpp
@@ -30,6 +30,7 @@
 #include "chpl/uast/Module.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "include module Foo;\n"
@@ -40,7 +41,7 @@ static void test0(Parser* parser) {
       "include private prototype module Zing;\n"
       "include public prototype module A;\n"
       "include public module B;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 9);

--- a/frontend/test/parsing/testParseInterface.cpp
+++ b/frontend/test/parsing/testParseInterface.cpp
@@ -28,13 +28,14 @@
 #include "chpl/framework/Context.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       " /* c1 */\n"
       " interface Foo(a, b, c) {\n"
       "   proc foo() {}\n"
       " }\n"
       " /* c2 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseInterface.cpp
+++ b/frontend/test/parsing/testParseInterface.cpp
@@ -29,7 +29,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       " /* c1 */\n"
       " interface Foo(a, b, c) {\n"
       "   proc foo() {}\n"

--- a/frontend/test/parsing/testParseLabelContinueBreak.cpp
+++ b/frontend/test/parsing/testParseLabelContinueBreak.cpp
@@ -35,6 +35,7 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
     "/*c1*/\n"
     "var thing = 0;\n"
@@ -45,7 +46,7 @@ static void test0(Parser* parser) {
     "  /*c3*/\n"
     "}\n"
     "/*c12*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 4);
@@ -77,6 +78,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
     "/*c1*/\n"
     "label outer for i in myRange {\n"
@@ -85,7 +87,7 @@ static void test1(Parser* parser) {
     "  /*c5*/\n"
     "}\n"
     "/*c6*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseLabelContinueBreak.cpp
+++ b/frontend/test/parsing/testParseLabelContinueBreak.cpp
@@ -36,7 +36,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
     "/*c1*/\n"
     "var thing = 0;\n"
     "label outer for i in myRange1 {\n"
@@ -79,7 +79,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
     "/*c1*/\n"
     "label outer for i in myRange {\n"
     "  if i%2 then /*c2*/ continue /*c3*/ outer /*c4*/;\n"

--- a/frontend/test/parsing/testParseLocal.cpp
+++ b/frontend/test/parsing/testParseLocal.cpp
@@ -29,13 +29,14 @@
 #include "chpl/uast/Module.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "local /* comment 2 */ do\n"
       "  /* comment 3 */\n"
       "  var a;\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -53,12 +54,13 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "local /* comment 2 */ foo /* comment 3 */ do\n"
       "  var a;\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -75,6 +77,7 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "local /* comment 2 */ {\n"
@@ -83,7 +86,7 @@ static void test2(Parser* parser) {
       "  /* comment 4 */\n"
       "}\n"
       "/* comment 5 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -101,6 +104,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "local /* comment 2 */ foo /* comment 3 */ {\n"
@@ -109,7 +113,7 @@ static void test3(Parser* parser) {
       "  /* comment 5 */\n"
       "}\n"
       "/* comment 6 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -128,10 +132,11 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* comment 1 */\n"
       "local do { var a; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -146,10 +151,11 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/* comment 1 */\n"
       "local foo do { var a; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);

--- a/frontend/test/parsing/testParseLocal.cpp
+++ b/frontend/test/parsing/testParseLocal.cpp
@@ -30,7 +30,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "local /* comment 2 */ do\n"
       "  /* comment 3 */\n"
@@ -55,7 +55,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "local /* comment 2 */ foo /* comment 3 */ do\n"
       "  var a;\n"
@@ -78,7 +78,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "local /* comment 2 */ {\n"
       "  /* comment 3 */\n"
@@ -105,7 +105,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "local /* comment 2 */ foo /* comment 3 */ {\n"
       "  /* comment 4 */\n"
@@ -133,7 +133,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* comment 1 */\n"
       "local do { var a; }\n");
   assert(!guard.realizeErrors());
@@ -152,7 +152,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/* comment 1 */\n"
       "local foo do { var a; }\n");
   assert(!guard.realizeErrors());

--- a/frontend/test/parsing/testParseModules.cpp
+++ b/frontend/test/parsing/testParseModules.cpp
@@ -25,9 +25,10 @@
 #include "chpl/uast/Module.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
                                          "x;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->kind() == Module::IMPLICIT);
@@ -39,11 +40,12 @@ static void test0(Parser* parser) {
 }
 
 static void test0a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
                                          "/* comment1 */\n"
                                          "x;\n"
                                          "/* comment2 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->kind() == Module::IMPLICIT);
@@ -55,10 +57,11 @@ static void test0a(Parser* parser) {
 }
 
 static void test0b(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
                                          "/* comment1 */\n"
                                          "/* comment2 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->kind() == Module::IMPLICIT);
@@ -71,9 +74,10 @@ static void test0b(Parser* parser) {
 
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
                                          "module M { x; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->kind() == Module::DEFAULT_MODULE_KIND);
@@ -85,6 +89,7 @@ static void test1(Parser* parser) {
 }
 
 static void test1a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1a.chpl",
                                          "/* comment 1 */\n"
                                          "module M {\n"
@@ -93,7 +98,7 @@ static void test1a(Parser* parser) {
                                          "  /* comment 3 */\n"
                                          "}\n"
                                          "/* comment 4 */");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   assert(parseResult.numTopLevelExpressions() == 3);
   assert(parseResult.topLevelExpression(0)->isComment());
   assert(parseResult.topLevelExpression(1)->isModule());
@@ -108,10 +113,11 @@ static void test1a(Parser* parser) {
 }
 
 static void test1b(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1b.chpl",
                                          "module M {\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->kind() == Module::DEFAULT_MODULE_KIND);
@@ -120,6 +126,7 @@ static void test1b(Parser* parser) {
 }
 
 static void test1c(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1c.chpl",
                                          "/* comment 1 */\n"
                                          "module M {\n"
@@ -127,7 +134,7 @@ static void test1c(Parser* parser) {
                                          "  /* comment 3 */\n"
                                          "}\n"
                                          "/* comment 4 */");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   assert(parseResult.numTopLevelExpressions() == 3);
   assert(parseResult.topLevelExpression(0)->isComment());
   assert(parseResult.topLevelExpression(1)->isModule());
@@ -141,10 +148,11 @@ static void test1c(Parser* parser) {
 }
 
 static void test1d(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1d.chpl",
                                          "module /* comment */ M {\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->kind() == Module::DEFAULT_MODULE_KIND);
@@ -153,10 +161,11 @@ static void test1d(Parser* parser) {
 }
 
 static void test1e(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1d.chpl",
                                          "prototype /* comment */ module M {\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->kind() == Module::PROTOTYPE);
@@ -165,10 +174,11 @@ static void test1e(Parser* parser) {
 }
 
 static void test1f(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1f.chpl",
                                          "public /* comment */ module M {\n"
                                          "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->kind() == Module::DEFAULT_MODULE_KIND);
@@ -178,10 +188,11 @@ static void test1f(Parser* parser) {
 
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
                                          "module M { x; }\n"
                                          "module N { y; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   assert(parseResult.numTopLevelExpressions() == 2);
   assert(parseResult.topLevelExpression(0)->isModule());
   assert(parseResult.topLevelExpression(1)->isModule());
@@ -206,6 +217,7 @@ static void test2(Parser* parser) {
 }
 
 static void test2a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2a.chpl",
                                          "/* comment 1 */\n"
                                          "module M {\n"
@@ -225,7 +237,7 @@ static void test2a(Parser* parser) {
                                          "  /* comment 10 */\n"
                                          "}\n"
                                          "/* comment 11 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   assert(parseResult.numTopLevelExpressions() == 5);
   assert(parseResult.topLevelExpression(0)->isComment());
   assert(parseResult.topLevelExpression(1)->isModule());
@@ -258,11 +270,12 @@ static void test2a(Parser* parser) {
 }
 
 static void test2b(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2b.chpl",
                                          "/* comment */\n"
                                          "module M { x; }\n"
                                          "module N { y; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   assert(parseResult.numTopLevelExpressions() == 3);
   assert(parseResult.topLevelExpression(0)->isComment());
   assert(parseResult.topLevelExpression(1)->isModule());
@@ -270,11 +283,12 @@ static void test2b(Parser* parser) {
 }
 
 static void test2c(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2c.chpl",
                                          "module M { x; }\n"
                                          "/* comment */\n"
                                          "module N { y; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   assert(parseResult.numTopLevelExpressions() == 3);
   assert(parseResult.topLevelExpression(0)->isModule());
   assert(parseResult.topLevelExpression(1)->isComment());
@@ -282,11 +296,12 @@ static void test2c(Parser* parser) {
 }
 
 static void test2d(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2d.chpl",
                                          "module M { x; }\n"
                                          "module N { y; }\n"
                                          "/* comment */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   assert(parseResult.numTopLevelExpressions() == 3);
   assert(parseResult.topLevelExpression(0)->isModule());
   assert(parseResult.topLevelExpression(1)->isModule());

--- a/frontend/test/parsing/testParseModules.cpp
+++ b/frontend/test/parsing/testParseModules.cpp
@@ -26,7 +26,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
                                          "x;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -41,7 +41,7 @@ static void test0(Parser* parser) {
 
 static void test0a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
                                          "/* comment1 */\n"
                                          "x;\n"
                                          "/* comment2 */\n");
@@ -58,7 +58,7 @@ static void test0a(Parser* parser) {
 
 static void test0b(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
                                          "/* comment1 */\n"
                                          "/* comment2 */\n");
   assert(!guard.realizeErrors());
@@ -75,7 +75,7 @@ static void test0b(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
                                          "module M { x; }\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -90,7 +90,7 @@ static void test1(Parser* parser) {
 
 static void test1a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1a.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1a.chpl",
                                          "/* comment 1 */\n"
                                          "module M {\n"
                                          "  /* comment 2 */\n"
@@ -114,7 +114,7 @@ static void test1a(Parser* parser) {
 
 static void test1b(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1b.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1b.chpl",
                                          "module M {\n"
                                          "}\n");
   assert(!guard.realizeErrors());
@@ -127,7 +127,7 @@ static void test1b(Parser* parser) {
 
 static void test1c(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1c.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1c.chpl",
                                          "/* comment 1 */\n"
                                          "module M {\n"
                                          "  /* comment 2 */\n"
@@ -149,7 +149,7 @@ static void test1c(Parser* parser) {
 
 static void test1d(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1d.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1d.chpl",
                                          "module /* comment */ M {\n"
                                          "}\n");
   assert(!guard.realizeErrors());
@@ -162,7 +162,7 @@ static void test1d(Parser* parser) {
 
 static void test1e(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1d.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1d.chpl",
                                          "prototype /* comment */ module M {\n"
                                          "}\n");
   assert(!guard.realizeErrors());
@@ -175,7 +175,7 @@ static void test1e(Parser* parser) {
 
 static void test1f(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1f.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1f.chpl",
                                          "public /* comment */ module M {\n"
                                          "}\n");
   assert(!guard.realizeErrors());
@@ -189,7 +189,7 @@ static void test1f(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
                                          "module M { x; }\n"
                                          "module N { y; }\n");
   assert(!guard.realizeErrors());
@@ -218,7 +218,7 @@ static void test2(Parser* parser) {
 
 static void test2a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2a.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2a.chpl",
                                          "/* comment 1 */\n"
                                          "module M {\n"
                                          "  /* comment 2 */\n"
@@ -271,7 +271,7 @@ static void test2a(Parser* parser) {
 
 static void test2b(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2b.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2b.chpl",
                                          "/* comment */\n"
                                          "module M { x; }\n"
                                          "module N { y; }\n");
@@ -284,7 +284,7 @@ static void test2b(Parser* parser) {
 
 static void test2c(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2c.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2c.chpl",
                                          "module M { x; }\n"
                                          "/* comment */\n"
                                          "module N { y; }\n");
@@ -297,7 +297,7 @@ static void test2c(Parser* parser) {
 
 static void test2d(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2d.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2d.chpl",
                                          "module M { x; }\n"
                                          "module N { y; }\n"
                                          "/* comment */\n");

--- a/frontend/test/parsing/testParseMultiVar.cpp
+++ b/frontend/test/parsing/testParseMultiVar.cpp
@@ -26,8 +26,9 @@
 #include "chpl/uast/Variable.h"
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl", "var x, y;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -55,8 +56,9 @@ static void test1(Parser* parser) {
   assert(i == 2);
 }
 static void test1a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1a.chpl", "const x, y;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -75,8 +77,9 @@ static void test1a(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl", "var x, y = ii;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -103,8 +106,9 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl", "var x, y: int;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -136,12 +140,13 @@ static void checkTest4Decls(const MultiDecl* multi,
                             bool isConfig=false);
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
                                          "var a,\n"
                                          "    b: int,\n"
                                          "    c,\n"
                                          "    d = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -198,13 +203,14 @@ static void checkTest4Decls(const MultiDecl* multi,
 }
 
 static void test4a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4a.chpl",
                                          "/* comment */\n"
                                          "var a,\n"
                                          "    b: int,\n"
                                          "    c,\n"
                                          "    d = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -219,12 +225,13 @@ static void test4a(Parser* parser) {
 }
 
 static void test4b(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4b.chpl",
                                          "var /*comment*/ a,\n"
                                          "    b: int,\n"
                                          "    c,\n"
                                          "    d = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -239,12 +246,13 @@ static void test4b(Parser* parser) {
 }
 
 static void test4c(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4c.chpl",
                                          "var a,\n"
                                          "    /*comment*/ b: int,\n"
                                          "    c,\n"
                                          "    d = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -259,12 +267,13 @@ static void test4c(Parser* parser) {
 }
 
 static void test4d(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4d.chpl",
                                          "var a,\n"
                                          "    b /* comment */ : int,\n"
                                          "    c,\n"
                                          "    d = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -278,12 +287,13 @@ static void test4d(Parser* parser) {
 }
 
 static void test4e(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4e.chpl",
                                          "var a,\n"
                                          "    b : /* comment */ int,\n"
                                          "    c,\n"
                                          "    d = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -297,12 +307,13 @@ static void test4e(Parser* parser) {
 }
 
 static void test4f(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4f.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    /*comment */ c,\n"
                                          "    d = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -317,12 +328,13 @@ static void test4f(Parser* parser) {
 }
 
 static void test4g(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4g.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    c,\n"
                                          "    /* comment */ d = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -337,12 +349,13 @@ static void test4g(Parser* parser) {
 }
 
 static void test4h(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4h.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    c,\n"
                                          "    d /* comment */ = ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -356,12 +369,13 @@ static void test4h(Parser* parser) {
 }
 
 static void test4i(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4i.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    c,\n"
                                          "    d = /* comment */ ii;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -375,12 +389,13 @@ static void test4i(Parser* parser) {
 }
 
 static void test4j(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4j.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    c,\n"
                                          "    d = ii /* comment */ ;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -394,12 +409,13 @@ static void test4j(Parser* parser) {
 }
 
 static void test4k(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4k.chpl",
       "config var a,\n"
       "           b : int,\n"
       "           c,\n"
       "           d = ii /* comment */ ;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -414,10 +430,11 @@ static void test4k(Parser* parser) {
 
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "type vec3 = 3*real,\n"
       "     arr33 = 3*vec3;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseMultiVar.cpp
+++ b/frontend/test/parsing/testParseMultiVar.cpp
@@ -27,7 +27,7 @@
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl", "var x, y;");
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl", "var x, y;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -57,7 +57,7 @@ static void test1(Parser* parser) {
 }
 static void test1a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1a.chpl", "const x, y;");
+  auto parseResult = parseStringAndReportErrors(parser, "test1a.chpl", "const x, y;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -78,7 +78,7 @@ static void test1a(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl", "var x, y = ii;");
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl", "var x, y = ii;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -107,7 +107,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl", "var x, y: int;");
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl", "var x, y: int;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -141,7 +141,7 @@ static void checkTest4Decls(const MultiDecl* multi,
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
                                          "var a,\n"
                                          "    b: int,\n"
                                          "    c,\n"
@@ -204,7 +204,7 @@ static void checkTest4Decls(const MultiDecl* multi,
 
 static void test4a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4a.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4a.chpl",
                                          "/* comment */\n"
                                          "var a,\n"
                                          "    b: int,\n"
@@ -226,7 +226,7 @@ static void test4a(Parser* parser) {
 
 static void test4b(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4b.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4b.chpl",
                                          "var /*comment*/ a,\n"
                                          "    b: int,\n"
                                          "    c,\n"
@@ -247,7 +247,7 @@ static void test4b(Parser* parser) {
 
 static void test4c(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4c.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4c.chpl",
                                          "var a,\n"
                                          "    /*comment*/ b: int,\n"
                                          "    c,\n"
@@ -268,7 +268,7 @@ static void test4c(Parser* parser) {
 
 static void test4d(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4d.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4d.chpl",
                                          "var a,\n"
                                          "    b /* comment */ : int,\n"
                                          "    c,\n"
@@ -288,7 +288,7 @@ static void test4d(Parser* parser) {
 
 static void test4e(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4e.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4e.chpl",
                                          "var a,\n"
                                          "    b : /* comment */ int,\n"
                                          "    c,\n"
@@ -308,7 +308,7 @@ static void test4e(Parser* parser) {
 
 static void test4f(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4f.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4f.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    /*comment */ c,\n"
@@ -329,7 +329,7 @@ static void test4f(Parser* parser) {
 
 static void test4g(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4g.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4g.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    c,\n"
@@ -350,7 +350,7 @@ static void test4g(Parser* parser) {
 
 static void test4h(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4h.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4h.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    c,\n"
@@ -370,7 +370,7 @@ static void test4h(Parser* parser) {
 
 static void test4i(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4i.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4i.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    c,\n"
@@ -390,7 +390,7 @@ static void test4i(Parser* parser) {
 
 static void test4j(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4j.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4j.chpl",
                                          "var a,\n"
                                          "    b : int,\n"
                                          "    c,\n"
@@ -410,7 +410,7 @@ static void test4j(Parser* parser) {
 
 static void test4k(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4k.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4k.chpl",
       "config var a,\n"
       "           b : int,\n"
       "           c,\n"
@@ -431,7 +431,7 @@ static void test4k(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "type vec3 = 3*real,\n"
       "     arr33 = 3*vec3;");
   assert(!guard.realizeErrors());

--- a/frontend/test/parsing/testParseNew.cpp
+++ b/frontend/test/parsing/testParseNew.cpp
@@ -33,10 +33,11 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "x = new r();\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -55,10 +56,11 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "x = new r(a=b, c);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -79,10 +81,11 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "x = new owned C(a=b, c);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -103,10 +106,11 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "x = new shared C(a=b, c);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -127,10 +131,11 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* comment 1 */\n"
       "x = new borrowed C(a=b, c);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -151,10 +156,11 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/* comment 1 */\n"
       "x = new unmanaged C(a=b, c);\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);

--- a/frontend/test/parsing/testParseNew.cpp
+++ b/frontend/test/parsing/testParseNew.cpp
@@ -34,7 +34,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "x = new r();\n");
   assert(!guard.realizeErrors());
@@ -57,7 +57,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "x = new r(a=b, c);\n");
   assert(!guard.realizeErrors());
@@ -82,7 +82,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "x = new owned C(a=b, c);\n");
   assert(!guard.realizeErrors());
@@ -107,7 +107,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "x = new shared C(a=b, c);\n");
   assert(!guard.realizeErrors());
@@ -132,7 +132,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* comment 1 */\n"
       "x = new borrowed C(a=b, c);\n");
   assert(!guard.realizeErrors());
@@ -157,7 +157,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/* comment 1 */\n"
       "x = new unmanaged C(a=b, c);\n");
   assert(!guard.realizeErrors());

--- a/frontend/test/parsing/testParseNumericLiterals.cpp
+++ b/frontend/test/parsing/testParseNumericLiterals.cpp
@@ -32,11 +32,12 @@ static void testIntLiteral(Parser* parser,
                            const char* testname,
                            const char* lit,
                            int64_t expectValue) {
+  ErrorGuard guard(parser->context());
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
   auto parseResult = parser->parseString(testname, toparse.c_str());
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -51,11 +52,12 @@ static void testUintLiteral(Parser* parser,
                             const char* testname,
                             const char* lit,
                             uint64_t expectValue) {
+  ErrorGuard guard(parser->context());
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
   auto parseResult = parser->parseString(testname, toparse.c_str());
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -70,11 +72,12 @@ static void testRealLiteral(Parser* parser,
                             const char* testname,
                             const char* lit,
                             double expectValue) {
+  ErrorGuard guard(parser->context());
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
   auto parseResult = parser->parseString(testname, toparse.c_str());
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -89,11 +92,12 @@ static void testImagLiteral(Parser* parser,
                             const char* testname,
                             const char* lit,
                             double expectValue) {
+  ErrorGuard guard(parser->context());
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
   auto parseResult = parser->parseString(testname, toparse.c_str());
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -109,11 +113,12 @@ static void testImagLiteral(Parser* parser,
 static void testBadLiteral(Parser* parser,
                            const char* testname,
                            const char* lit) {
+  ErrorGuard guard(parser->context());
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
   auto parseResult = parser->parseString(testname, toparse.c_str());
-  assert(parseResult.numErrors() >= 1);
+  assert(guard.realizeErrors() >= 1);
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseNumericLiterals.cpp
+++ b/frontend/test/parsing/testParseNumericLiterals.cpp
@@ -36,7 +36,7 @@ static void testIntLiteral(Parser* parser,
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
-  auto parseResult = parser->parseString(testname, toparse.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testname, toparse.c_str());
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -56,7 +56,7 @@ static void testUintLiteral(Parser* parser,
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
-  auto parseResult = parser->parseString(testname, toparse.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testname, toparse.c_str());
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -76,7 +76,7 @@ static void testRealLiteral(Parser* parser,
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
-  auto parseResult = parser->parseString(testname, toparse.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testname, toparse.c_str());
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -96,7 +96,7 @@ static void testImagLiteral(Parser* parser,
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
-  auto parseResult = parser->parseString(testname, toparse.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testname, toparse.c_str());
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -117,7 +117,7 @@ static void testBadLiteral(Parser* parser,
   std::string toparse = "var x = ";
   toparse += lit;
   toparse += ";\n";
-  auto parseResult = parser->parseString(testname, toparse.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testname, toparse.c_str());
   assert(guard.realizeErrors() >= 1);
   auto mod = parseResult.singleModule();
   assert(mod);

--- a/frontend/test/parsing/testParseOn.cpp
+++ b/frontend/test/parsing/testParseOn.cpp
@@ -30,7 +30,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "on /* comment 2 */ foo /* comment 3 */ do\n"
       "  var a;\n"
@@ -53,7 +53,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "on /* comment 2 */ foo /* comment 3 */ {\n"
       "  /* comment 4 */\n"
@@ -81,7 +81,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "on foo do { var a; }\n");
   assert(!guard.realizeErrors());

--- a/frontend/test/parsing/testParseOn.cpp
+++ b/frontend/test/parsing/testParseOn.cpp
@@ -29,12 +29,13 @@
 #include "chpl/uast/On.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "on /* comment 2 */ foo /* comment 3 */ do\n"
       "  var a;\n"
       "/* comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -51,6 +52,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "on /* comment 2 */ foo /* comment 3 */ {\n"
@@ -59,7 +61,7 @@ static void test1(Parser* parser) {
       "  /* comment 5 */\n"
       "}\n"
       "/* comment 6 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -78,10 +80,11 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "on foo do { var a; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);

--- a/frontend/test/parsing/testParseReturn.cpp
+++ b/frontend/test/parsing/testParseReturn.cpp
@@ -30,7 +30,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "proc foo() {\n"
       "  /* comment 2 */\n"
@@ -61,7 +61,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "proc foo() {\n"
       "  /* comment 2 */\n"

--- a/frontend/test/parsing/testParseReturn.cpp
+++ b/frontend/test/parsing/testParseReturn.cpp
@@ -29,6 +29,7 @@
 #include "chpl/uast/Return.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "proc foo() {\n"
@@ -38,7 +39,7 @@ static void test0(Parser* parser) {
       "  /* comment 6 */\n"
       "}\n"
       "/* comment 7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -59,6 +60,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "proc foo() {\n"
@@ -68,7 +70,7 @@ static void test1(Parser* parser) {
       "  /* comment 5 */\n"
       "}\n"
       "/* comment 6 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseSelect.cpp
+++ b/frontend/test/parsing/testParseSelect.cpp
@@ -33,7 +33,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* c1 */\n"
       "select /* c2 */ foo /* c3 */ {\n"
       "  when /* c4 */ x do /* c5 */ f1();\n"
@@ -106,7 +106,7 @@ static void test0(Parser* parser) {
 // Should be parse error.
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* c1 */\n"
       "select foo {\n"
       "  when x do f1();\n"
@@ -130,7 +130,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* c1 */\n"
       "select foo {\n"
       "  when x, y do f1();\n"
@@ -158,7 +158,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* c1 */\n"
       "select foo {\n"
       "  otherwise do { f1(); }\n"

--- a/frontend/test/parsing/testParseSelect.cpp
+++ b/frontend/test/parsing/testParseSelect.cpp
@@ -32,6 +32,7 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* c1 */\n"
       "select /* c2 */ foo /* c3 */ {\n"
@@ -42,7 +43,7 @@ static void test0(Parser* parser) {
       "  otherwise /* c10 */ { f5(); }\n"
       "}\n"
       "/* c11 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -104,6 +105,7 @@ static void test0(Parser* parser) {
 
 // Should be parse error.
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* c1 */\n"
       "select foo {\n"
@@ -113,19 +115,21 @@ static void test1(Parser* parser) {
       "  otherwise do { f4(); }\n"
       "}\n"
       "/* c2 */\n");
-  assert(parseResult.numErrors() == 1);
+  assert(guard.numErrors() == 1);
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->stmt(0)->isComment());
   assert(mod->stmt(1)->isErroneousExpression());
   assert(mod->stmt(2)->isComment());
-  auto error = parseResult.error(0);
+  auto& error = guard.error(0);
   const char* expected = "select has multiple otherwise clauses";
   auto actual = error->message();
   assert(actual == expected);
+  guard.clearErrors();
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* c1 */\n"
       "select foo {\n"
@@ -133,7 +137,7 @@ static void test2(Parser* parser) {
       "  otherwise do f2();\n"
       "}\n"
       "/* c2 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -153,13 +157,14 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* c1 */\n"
       "select foo {\n"
       "  otherwise do { f1(); }\n"
       "}\n"
       "/* c2 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseSerial.cpp
+++ b/frontend/test/parsing/testParseSerial.cpp
@@ -29,7 +29,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "serial /* comment 2 */ do\n"
       "  /* comment 3 */\n"
@@ -53,7 +53,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "serial /* comment 2 */ foo /* comment 3 */ do\n"
       "  /* comment 4 */\n"
@@ -78,7 +78,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "serial /* comment 2 */ {\n"
       "  /* comment 3 */\n"
@@ -104,7 +104,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "serial /* comment 2 */ foo /* comment 3 */ {\n"
       "  /* comment 4 */\n"
@@ -132,7 +132,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/* comment 1 */\n"
       "serial do { var a; }\n");
   assert(!guard.realizeErrors());
@@ -151,7 +151,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/* comment 1 */\n"
       "serial foo do { var a; }\n");
   assert(!guard.realizeErrors());

--- a/frontend/test/parsing/testParseSerial.cpp
+++ b/frontend/test/parsing/testParseSerial.cpp
@@ -28,13 +28,14 @@
 #include "chpl/uast/Serial.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "serial /* comment 2 */ do\n"
       "  /* comment 3 */\n"
       "  var a;\n"
       "/*comment 4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -51,13 +52,14 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "serial /* comment 2 */ foo /* comment 3 */ do\n"
       "  /* comment 4 */\n"
       "  var a;\n"
       "/* comment 5 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -75,6 +77,7 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "serial /* comment 2 */ {\n"
@@ -83,7 +86,7 @@ static void test2(Parser* parser) {
       "  /* comment 4 */\n"
       "}\n"
       "/* comment 5 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -100,6 +103,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "serial /* comment 2 */ foo /* comment 3 */ {\n"
@@ -108,7 +112,7 @@ static void test3(Parser* parser) {
       "  /* comment 5 */\n"
       "}\n"
       "/* comment 6 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -127,10 +131,11 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/* comment 1 */\n"
       "serial do { var a; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -145,10 +150,11 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/* comment 1 */\n"
       "serial foo do { var a; }\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);

--- a/frontend/test/parsing/testParseStringBytesLiterals.cpp
+++ b/frontend/test/parsing/testParseStringBytesLiterals.cpp
@@ -35,7 +35,7 @@ static uast::BuilderResult parseExprAsVarInit(Parser* parser,
   std::string toparse = "var x = ";
   toparse += init;
   toparse += ";\n";
-  auto parseResult = parser->parseString(testname.c_str(), toparse.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testname.c_str(), toparse.c_str());
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -146,7 +146,7 @@ static void testBadLiteral(Parser* parser,
   std::string toparse = "var x = ";
   toparse += str;
   toparse += ";\n";
-  auto parseResult = parser->parseString(testname, toparse.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testname, toparse.c_str());
   assert(guard.realizeErrors() > 0);
   auto mod = parseResult.singleModule();
   assert(mod);

--- a/frontend/test/parsing/testParseStringBytesLiterals.cpp
+++ b/frontend/test/parsing/testParseStringBytesLiterals.cpp
@@ -31,11 +31,12 @@ static uast::BuilderResult parseExprAsVarInit(Parser* parser,
                                               const std::string& testname,
                                               const std::string& init,
                                               const AstNode*& exprOut) {
+  ErrorGuard guard(parser->context());
   std::string toparse = "var x = ";
   toparse += init;
   toparse += ";\n";
   auto parseResult = parser->parseString(testname.c_str(), toparse.c_str());
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -141,11 +142,12 @@ static void testSingleLiteral(Parser* parser,
 static void testBadLiteral(Parser* parser,
                            const char* testname,
                            const char* str) {
+  ErrorGuard guard(parser->context());
   std::string toparse = "var x = ";
   toparse += str;
   toparse += ";\n";
   auto parseResult = parser->parseString(testname, toparse.c_str());
-  assert(parseResult.numErrors() > 0);
+  assert(guard.realizeErrors() > 0);
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseSync.cpp
+++ b/frontend/test/parsing/testParseSync.cpp
@@ -30,12 +30,13 @@
 #include "chpl/framework/Context.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "sync /* comment 2 */\n"
       "  begin foo();\n"
       "/* comment 3 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -73,6 +74,7 @@ static void test0(Parser* parser) {
 
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "sync /* comment 2 */ {\n"
@@ -81,7 +83,7 @@ static void test1(Parser* parser) {
       "  /* comment 4 */\n"
       "}\n"
       "/* comment 5 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -116,6 +118,7 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "sync /* comment 2 */ {\n"
@@ -125,7 +128,7 @@ static void test2(Parser* parser) {
       "  /* comment 4 */\n"
       "}\n"
       "/* comment 5 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseSync.cpp
+++ b/frontend/test/parsing/testParseSync.cpp
@@ -31,7 +31,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "sync /* comment 2 */\n"
       "  begin foo();\n"
@@ -75,7 +75,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "sync /* comment 2 */ {\n"
       "  /* comment 3 */\n"
@@ -119,7 +119,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "sync /* comment 2 */ {\n"
       "  /* comment 3 */\n"

--- a/frontend/test/parsing/testParseTryCatchThrow.cpp
+++ b/frontend/test/parsing/testParseTryCatchThrow.cpp
@@ -32,7 +32,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* c1 */\n"
       "var x = try /* c2 */ foo();\n"
       "var y = try! bar();\n"
@@ -126,7 +126,7 @@ static void tryCatchTest(Parser* parser, const char* testName,
                          bool hasErrorType) {
   ErrorGuard guard(parser->context());
   auto test = constructTryCatchTest(isTryBang, hasError, hasErrorType);
-  auto parseResult = parser->parseString(testName, test.c_str());
+  auto parseResult = parseStringAndReportErrors(parser, testName, test.c_str());
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -180,7 +180,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* c1 */\n"
       "try {\n"
       "  throw fooError();\n"
@@ -220,7 +220,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       R""""(
         module M {
           try {

--- a/frontend/test/parsing/testParseTryCatchThrow.cpp
+++ b/frontend/test/parsing/testParseTryCatchThrow.cpp
@@ -31,6 +31,7 @@
 #include "chpl/uast/Try.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* c1 */\n"
       "var x = try /* c2 */ foo();\n"
@@ -39,7 +40,7 @@ static void test0(Parser* parser) {
       "try! bar();\n"
       "throw baz();\n"
       "/* c4 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 7);
@@ -123,9 +124,10 @@ static void tryCatchTest(Parser* parser, const char* testName,
                          bool isTryBang,
                          bool hasError,
                          bool hasErrorType) {
+  ErrorGuard guard(parser->context());
   auto test = constructTryCatchTest(isTryBang, hasError, hasErrorType);
   auto parseResult = parser->parseString(testName, test.c_str());
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -177,6 +179,7 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* c1 */\n"
       "try {\n"
@@ -189,7 +192,7 @@ static void test2(Parser* parser) {
       "  halt('Unknown error');\n"
       "}\n"
       "/* c2 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->stmt(0)->isComment());
@@ -216,6 +219,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       R""""(
         module M {
@@ -227,7 +231,7 @@ static void test3(Parser* parser) {
           }
         }
       )"""");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseTupleVar.cpp
+++ b/frontend/test/parsing/testParseTupleVar.cpp
@@ -29,7 +29,7 @@
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl", "var (x, y);");
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl", "var (x, y);");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -57,7 +57,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl", "const (x, y);");
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl", "const (x, y);");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -83,7 +83,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl", "var (x, y): typ;");
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl", "var (x, y): typ;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -109,7 +109,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl", "var (x, y) = tup;");
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl", "var (x, y) = tup;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -135,7 +135,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
                                          "var (x, y):typ = tup;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -162,7 +162,7 @@ static void test5(Parser* parser) {
 
 static void check6(Parser* parser, const char* path, const char* str) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString(path, str);
+  auto parseResult = parseStringAndReportErrors(parser, path, str);
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -243,7 +243,7 @@ static void test6(Parser* parser) {
 
 static void test7(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test7.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test7.chpl",
                                          "var (x, y), z;");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();

--- a/frontend/test/parsing/testParseTupleVar.cpp
+++ b/frontend/test/parsing/testParseTupleVar.cpp
@@ -28,8 +28,9 @@
 #include "chpl/uast/Variable.h"
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl", "var (x, y);");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -55,8 +56,9 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl", "const (x, y);");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -80,8 +82,9 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl", "var (x, y): typ;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -105,8 +108,9 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl", "var (x, y) = tup;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -130,9 +134,10 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
                                          "var (x, y):typ = tup;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -156,8 +161,9 @@ static void test5(Parser* parser) {
 }
 
 static void check6(Parser* parser, const char* path, const char* str) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString(path, str);
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -236,9 +242,10 @@ static void test6(Parser* parser) {
 }
 
 static void test7(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test7.chpl",
                                          "var (x, y), z;");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseUse.cpp
+++ b/frontend/test/parsing/testParseUse.cpp
@@ -35,11 +35,12 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/*c1*/\n"
       "use /*c2*/ Foo as X /*c3*/;\n"
       "/*c4*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -61,11 +62,12 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/*c1*/\n"
       "public use /*c2*/ A as X, /*c3*/ B.SM1 as Y, /*c4*/ C as Z;\n"
       "/*c5*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -128,11 +130,12 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/*c1*/\n"
       "private use /*c2*/ A as X /*c3*/ except Foo, /*c5*/ Bar, Baz /*c6*/;\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -169,11 +172,12 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/*c1*/\n"
       "use A.SM1 only Foo as X, Bar, Baz as Y;\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -216,11 +220,12 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
       "/*c1*/\n"
       "use Foo only;\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -238,11 +243,12 @@ static void test4(Parser* parser) {
 }
 
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
       "/*c1*/\n"
       "use Foo except %;\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -262,11 +268,12 @@ static void test5(Parser* parser) {
 }
 
 static void test6(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test6.chpl",
       "/*c1*/\n"
       "use 1+1;\n"
       "/*c7*/\n");
-  assert(parseResult.numErrors() >= 1);
+  assert(guard.realizeErrors() >= 1);
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -276,11 +283,12 @@ static void test6(Parser* parser) {
 }
 
 static void test7(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test7.chpl",
       "/*c1*/\n"
       "use Foo only +;\n"
       "/*c7*/\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/parsing/testParseUse.cpp
+++ b/frontend/test/parsing/testParseUse.cpp
@@ -36,7 +36,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/*c1*/\n"
       "use /*c2*/ Foo as X /*c3*/;\n"
       "/*c4*/\n");
@@ -63,7 +63,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/*c1*/\n"
       "public use /*c2*/ A as X, /*c3*/ B.SM1 as Y, /*c4*/ C as Z;\n"
       "/*c5*/\n");
@@ -131,7 +131,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/*c1*/\n"
       "private use /*c2*/ A as X /*c3*/ except Foo, /*c5*/ Bar, Baz /*c6*/;\n"
       "/*c7*/\n");
@@ -173,7 +173,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/*c1*/\n"
       "use A.SM1 only Foo as X, Bar, Baz as Y;\n"
       "/*c7*/\n");
@@ -221,7 +221,7 @@ static void test3(Parser* parser) {
 
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
       "/*c1*/\n"
       "use Foo only;\n"
       "/*c7*/\n");
@@ -244,7 +244,7 @@ static void test4(Parser* parser) {
 
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "/*c1*/\n"
       "use Foo except %;\n"
       "/*c7*/\n");
@@ -269,7 +269,7 @@ static void test5(Parser* parser) {
 
 static void test6(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test6.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test6.chpl",
       "/*c1*/\n"
       "use 1+1;\n"
       "/*c7*/\n");
@@ -284,7 +284,7 @@ static void test6(Parser* parser) {
 
 static void test7(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test7.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test7.chpl",
       "/*c1*/\n"
       "use Foo only +;\n"
       "/*c7*/\n");

--- a/frontend/test/parsing/testParseVariables.cpp
+++ b/frontend/test/parsing/testParseVariables.cpp
@@ -36,9 +36,10 @@
 #include "chpl/uast/Variable.h"
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
                                          "var a: int;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -58,9 +59,10 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
                                          "var a = b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -80,9 +82,10 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
                                          "var a: int = b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -102,9 +105,10 @@ static void test3(Parser* parser) {
 }
 
 static void test3a(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3a.chpl",
                                          "var /* comment */ a: int = b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -124,9 +128,10 @@ static void test3a(Parser* parser) {
 }
 
 static void test3b(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3b.chpl",
                                          "var a /* comment */ : int = b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -146,9 +151,10 @@ static void test3b(Parser* parser) {
 }
 
 static void test3c(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3c.chpl",
                                          "var a : /* comment */ int = b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -168,9 +174,10 @@ static void test3c(Parser* parser) {
 }
 
 static void test3d(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3d.chpl",
                                          "var a : int /* comment */ = b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -190,9 +197,10 @@ static void test3d(Parser* parser) {
 }
 
 static void test3e(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3e.chpl",
                                          "var a : int = /* comment */ b;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -212,9 +220,10 @@ static void test3e(Parser* parser) {
 }
 
 static void test3f(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3f.chpl",
                                          "var a : int = b /* comment */;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -234,9 +243,10 @@ static void test3f(Parser* parser) {
 }
 
 static void test3g(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3g.chpl",
       "config var a : int = b /* comment */;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);
@@ -260,12 +270,13 @@ static void test3g(Parser* parser) {
 
 // Extern variables.
 static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test4.chpl",
     "extern var x: int = 0;\n"
     "public extern var y = 0.0;\n"
     "private extern \"foo\" ref z: int;\n");
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -302,11 +313,12 @@ static void test4(Parser* parser) {
 // Yes, it is a parse error (for now).
 /*
 static void test5(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test5.chpl",
     "export var foo = 0;\n"
     "export \"bar\" var bar: real = 0.0;\n");
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   // TODO: More if not parse error.
@@ -315,6 +327,7 @@ static void test5(Parser* parser) {
 
 // Type variables (also config and extern).
 static void test6(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test6.chpl",
     "public type foo = bar;\n"
     "type foo;\n"
@@ -323,7 +336,7 @@ static void test6(Parser* parser) {
     "extern type foo = bar;\n"
     "extern type foo;\n");
 
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 6);
@@ -372,9 +385,10 @@ static void test6(Parser* parser) {
 }
 
 static void test7(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test7.chpl",
                                          "var foo = noinit;\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 1);

--- a/frontend/test/parsing/testParseVariables.cpp
+++ b/frontend/test/parsing/testParseVariables.cpp
@@ -37,7 +37,7 @@
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
                                          "var a: int;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -60,7 +60,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
                                          "var a = b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -83,7 +83,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
                                          "var a: int = b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -106,7 +106,7 @@ static void test3(Parser* parser) {
 
 static void test3a(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3a.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3a.chpl",
                                          "var /* comment */ a: int = b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -129,7 +129,7 @@ static void test3a(Parser* parser) {
 
 static void test3b(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3b.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3b.chpl",
                                          "var a /* comment */ : int = b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -152,7 +152,7 @@ static void test3b(Parser* parser) {
 
 static void test3c(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3c.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3c.chpl",
                                          "var a : /* comment */ int = b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -175,7 +175,7 @@ static void test3c(Parser* parser) {
 
 static void test3d(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3d.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3d.chpl",
                                          "var a : int /* comment */ = b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -198,7 +198,7 @@ static void test3d(Parser* parser) {
 
 static void test3e(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3e.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3e.chpl",
                                          "var a : int = /* comment */ b;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -221,7 +221,7 @@ static void test3e(Parser* parser) {
 
 static void test3f(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3f.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3f.chpl",
                                          "var a : int = b /* comment */;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -244,7 +244,7 @@ static void test3f(Parser* parser) {
 
 static void test3g(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3g.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3g.chpl",
       "config var a : int = b /* comment */;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
@@ -271,7 +271,7 @@ static void test3g(Parser* parser) {
 // Extern variables.
 static void test4(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
     "extern var x: int = 0;\n"
     "public extern var y = 0.0;\n"
     "private extern \"foo\" ref z: int;\n");
@@ -314,7 +314,7 @@ static void test4(Parser* parser) {
 /*
 static void test5(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test5.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
     "export var foo = 0;\n"
     "export \"bar\" var bar: real = 0.0;\n");
 
@@ -328,7 +328,7 @@ static void test5(Parser* parser) {
 // Type variables (also config and extern).
 static void test6(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test6.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test6.chpl",
     "public type foo = bar;\n"
     "type foo;\n"
     "public config type foo = bar;\n"
@@ -386,7 +386,7 @@ static void test6(Parser* parser) {
 
 static void test7(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test7.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test7.chpl",
                                          "var foo = noinit;\n");
   assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();

--- a/frontend/test/parsing/testParseWhile.cpp
+++ b/frontend/test/parsing/testParseWhile.cpp
@@ -30,12 +30,13 @@
 #include <iostream>
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "while foo() do\n"
       "  /* comment 2 */\n"
       "  bar();\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -52,13 +53,14 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test1.chpl",
       "/* comment 1 */\n"
       "while foo() {\n"
       "  /* comment 2 */\n"
       "  bar();\n"
       "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -75,13 +77,14 @@ static void test1(Parser* parser) {
 }
 
 static void test2(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test2.chpl",
       "/* comment 1 */\n"
       "while foo() do {\n"
       "  /* comment 2 */\n"
       "  bar();\n"
       "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);
@@ -98,6 +101,7 @@ static void test2(Parser* parser) {
 }
 
 static void test3(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test3.chpl",
       "/* comment 1 */\n"
       "while condition1 {\n"
@@ -107,7 +111,7 @@ static void test3(Parser* parser) {
       "   bar();\n"
       "  /* comment 4 */\n"
       "}\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 2);

--- a/frontend/test/parsing/testParseWhile.cpp
+++ b/frontend/test/parsing/testParseWhile.cpp
@@ -31,7 +31,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "while foo() do\n"
       "  /* comment 2 */\n"
@@ -54,7 +54,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test1.chpl",
       "/* comment 1 */\n"
       "while foo() {\n"
       "  /* comment 2 */\n"
@@ -78,7 +78,7 @@ static void test1(Parser* parser) {
 
 static void test2(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test2.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test2.chpl",
       "/* comment 1 */\n"
       "while foo() do {\n"
       "  /* comment 2 */\n"
@@ -102,7 +102,7 @@ static void test2(Parser* parser) {
 
 static void test3(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test3.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test3.chpl",
       "/* comment 1 */\n"
       "while condition1 {\n"
       "  /* comment 2 */\n"

--- a/frontend/test/parsing/testParseYield.cpp
+++ b/frontend/test/parsing/testParseYield.cpp
@@ -31,7 +31,7 @@
 
 static void test0(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "iter foo(): int {\n"
       "  /* comment 2 */\n"
@@ -63,7 +63,7 @@ static void test0(Parser* parser) {
 
 static void test1(Parser* parser) {
   ErrorGuard guard(parser->context());
-  auto parseResult = parser->parseString("test0.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test0.chpl",
       "/* comment 1 */\n"
       "iter foo(): int {\n"
       "  /* comment 2 */\n"

--- a/frontend/test/parsing/testParseYield.cpp
+++ b/frontend/test/parsing/testParseYield.cpp
@@ -30,6 +30,7 @@
 #include "chpl/uast/Try.h"
 
 static void test0(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "iter foo(): int {\n"
@@ -39,7 +40,7 @@ static void test0(Parser* parser) {
       "  /* comment 6 */\n"
       "}\n"
       "/* comment 7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);
@@ -61,6 +62,7 @@ static void test0(Parser* parser) {
 }
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   auto parseResult = parser->parseString("test0.chpl",
       "/* comment 1 */\n"
       "iter foo(): int {\n"
@@ -70,7 +72,7 @@ static void test1(Parser* parser) {
       "  /* comment 6 */\n"
       "}\n"
       "/* comment 7 */\n");
-  assert(!parseResult.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
   assert(mod->numStmts() == 3);

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -219,7 +219,7 @@ static void test4() {
 
   // Get the modules.
   auto& br = parseFileToBuilderResult(context, path, UniqueString());
-  assert(!br.numErrors());
+  assert(!guard.realizeErrors());
   assert(br.numTopLevelExpressions() == 2);
   auto modA = br.topLevelExpression(0)->toModule();
   assert(modA);

--- a/frontend/test/test-common.cpp
+++ b/frontend/test/test-common.cpp
@@ -26,7 +26,8 @@ using namespace chpl;
 const uast::BuilderResult&
 parseAndReportErrors(Context* context, UniqueString path) {
   auto& ret = parsing::parseFileToBuilderResult(context, path, {});
-  for (auto e : ret.errors()) context->report(e);
+  // TODO should no longer need to do this since they get logged right away
+  // for (auto e : ret.errors()) context->report(e);
   return ret;
 }
 

--- a/frontend/test/test-common.cpp
+++ b/frontend/test/test-common.cpp
@@ -25,7 +25,7 @@ using namespace chpl;
 
 const uast::BuilderResult&
 parseAndReportErrors(Context* context, UniqueString path) {
-  auto& ret = parsing::parseFileToBuilderResult(context, path, {});
+  auto& ret = parsing::parseFileToBuilderResultAndCheck(context, path, {});
   return ret;
 }
 

--- a/frontend/test/test-common.cpp
+++ b/frontend/test/test-common.cpp
@@ -26,8 +26,6 @@ using namespace chpl;
 const uast::BuilderResult&
 parseAndReportErrors(Context* context, UniqueString path) {
   auto& ret = parsing::parseFileToBuilderResult(context, path, {});
-  // TODO should no longer need to do this since they get logged right away
-  // for (auto e : ret.errors()) context->report(e);
   return ret;
 }
 

--- a/frontend/test/test-common.cpp
+++ b/frontend/test/test-common.cpp
@@ -20,6 +20,7 @@
 #include "test-common.h"
 
 #include "chpl/parsing/parsing-queries.h"
+#include "chpl/uast/post-parse-checks.h"
 
 using namespace chpl;
 
@@ -29,3 +30,11 @@ parseAndReportErrors(Context* context, UniqueString path) {
   return ret;
 }
 
+uast::BuilderResult
+parseStringAndReportErrors(parsing::Parser* parser, const char* filename,
+                           const char* content) {
+  auto path = UniqueString::get(parser->context(), filename);
+  auto result = parser->parseString(filename, content);
+  uast::checkBuilderResult(parser->context(), path, result);
+  return result;
+}

--- a/frontend/test/uast/testBuildIDs.cpp
+++ b/frontend/test/uast/testBuildIDs.cpp
@@ -142,6 +142,7 @@ static void test1() {
 static  void test2() {
   Context context;
   Context* ctx = &context;
+  ErrorGuard guard(ctx);
 
   auto builder = Builder::createForTopLevelModule(ctx, "path/to/test.chpl");
   Builder* b   = builder.get();
@@ -162,7 +163,7 @@ static  void test2() {
   }
 
   BuilderResult r = b->result();
-  assert(!r.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = r.singleModule();
   assert(0 == mod->name().compare("test"));
   //assert(r.astToLocation.size() == 5); // +1 module
@@ -248,6 +249,7 @@ static  void test2() {
 static void test3() {
   Context context;
   Context* ctx = &context;
+  ErrorGuard guard(ctx);
 
   auto builder = Builder::createForTopLevelModule(ctx, "path/to/test.chpl");
   Builder* b   = builder.get();
@@ -276,7 +278,7 @@ static void test3() {
   }
 
   BuilderResult r = b->result();
-  assert(!r.numErrors());
+  assert(!guard.realizeErrors());
   auto mod = r.singleModule();
   //assert(r.astToLocation.size() == 7); // +1 module
   assert(mod->stmt(0)->isBlock());
@@ -312,6 +314,7 @@ static void test3() {
 static void test4() {
   Context context;
   Context* ctx = &context;
+  ErrorGuard guard(ctx);
 
   auto builder = Builder::createForTopLevelModule(ctx, "path/to/test.chpl");
   Builder* b   = builder.get();
@@ -362,7 +365,7 @@ static void test4() {
   }
 
   BuilderResult r = b->result();
-  assert(!r.numErrors());
+  assert(!guard.realizeErrors());
   auto modM = r.singleModule();
   //assert(r.astToLocation.size() == 6);
   assert(modM->stmt(0)->isModule());
@@ -435,6 +438,7 @@ static void test4() {
 static void test5() {
   Context context;
   Context* ctx = &context;
+  ErrorGuard guard(ctx);
 
   const char* path = "path/to/file-name.sub.chpl";
   auto builder = Builder::createForTopLevelModule(ctx, path);
@@ -454,7 +458,7 @@ static void test5() {
   }
 
   BuilderResult r = b->result();
-  assert(!r.numErrors());
+  assert(!guard.realizeErrors());
   auto implicitMod = r.singleModule();
   assert(implicitMod->numStmts() == 1);
   assert(implicitMod->stmt(0)->isIdentifier());

--- a/frontend/test/uast/testStringify.cpp
+++ b/frontend/test/uast/testStringify.cpp
@@ -91,6 +91,7 @@ static void stringifyNode(const AstNode* node, chpl::StringifyKind kind) {
 
 
 static void test1(Parser* parser) {
+  ErrorGuard guard(parser->context());
   // the one test to rule them all
   std::string testCode;
   testCode = R""""(
@@ -345,13 +346,14 @@ static void test1(Parser* parser) {
   )"""";
   auto parseResult = parser->parseString("Test1.chpl",
                                          testCode.c_str());
-  for (int i = 0; i < parseResult.numErrors(); i++) {
-    const ErrorBase* err = parseResult.error(i);
+  for (auto& error : guard.errors()) {
+    const ErrorBase* err = error.get();
     // ignore implicit module warning
     assert(err->kind() != ErrorBase::SYNTAX);
     std::cout << err->message().c_str() << std::endl;
     assert(err->kind() != ErrorBase::ERROR);
   }
+  guard.clearErrors();
   auto mod = parseResult.singleModule();
   assert(mod);
   stringifyNode(mod, CHPL_SYNTAX);

--- a/frontend/test/uast/testStringify.cpp
+++ b/frontend/test/uast/testStringify.cpp
@@ -49,7 +49,9 @@ using namespace parsing;
 #define TEST_USER_STRING(funcDef, val)                           \
 {                                                                \
   std::ostringstream ss;                                         \
-  auto parseResult = parser->parseString("test3.chpl", funcDef); \
+  auto parseResult = parseStringAndReportErrors(parser,          \
+                                                "test3.chpl",    \
+                                                funcDef);        \
   auto mod = parseResult.singleModule();                         \
   auto funcDecl = mod->stmt(0)->toFunction();                    \
   assert(funcDecl);                                              \
@@ -62,7 +64,9 @@ using namespace parsing;
 #define TEST_CHPL_SYNTAX(src, val)                           \
 {                                                            \
   std::ostringstream ss;                                     \
-  auto parseResult = parser->parseString("test5.chpl", src); \
+  auto parseResult = parseStringAndReportErrors(parser,      \
+                                                "test5.chpl",\
+                                                src);        \
   auto mod = parseResult.singleModule();                     \
   assert(mod);                                               \
   printChapelSyntax(ss, mod);                                \
@@ -344,7 +348,7 @@ static void test1(Parser* parser) {
   XNew(ij) = (X(ij+north) + X(ij+south) + X(ij+east) + X(ij+west)) / 4.0;
   proc multiDimension(): [1..3, 2..8] string {}
   )"""";
-  auto parseResult = parser->parseString("Test1.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "Test1.chpl",
                                          testCode.c_str());
   for (auto& error : guard.errors()) {
     const ErrorBase* err = error.get();
@@ -445,7 +449,7 @@ static void test3(Parser* parser) {
 }
 
 static void test4(Parser* parser) {
-  auto parseResult = parser->parseString("test4.chpl",
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
                                           "class C {\n"
                                           "proc ref setClt(rhs: borrowed C) {\n}\n}\n");
   auto mod = parseResult.singleModule();

--- a/frontend/test/uast/testVisit.cpp
+++ b/frontend/test/uast/testVisit.cpp
@@ -28,6 +28,7 @@ using namespace chpl;
 using namespace uast;
 
 static BuilderResult makeAST(Context* ctx, const uast::Module*& modOut) {
+  ErrorGuard guard(ctx);
   auto builder = Builder::createForTopLevelModule(ctx, "path/to/test.chpl");
   Builder* b   = builder.get();
   Location dummyLoc(UniqueString::get(ctx, "path/to/test.chpl"));
@@ -47,7 +48,7 @@ static BuilderResult makeAST(Context* ctx, const uast::Module*& modOut) {
   }
 
   BuilderResult r = b->result();
-  assert(!r.numErrors());
+  assert(!guard.numErrors());
   auto mod = r.singleModule();
   assert(mod);
   assert(0 == mod->name().compare("test"));

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -2208,9 +2208,8 @@ int main(int argc, char** argv) {
     // TODO: Change which query we use to parse files as suggested by @mppf
     // parseFileContainingIdToBuilderResult(Context* context, ID id);
     // and then work with the module ID to find the preceding comment.
-    const BuilderResult& builderResult = parseFileToBuilderResult(ctx,
-                                                                  path,
-                                                                  emptyParent);
+    const BuilderResult& builderResult =
+      parseFileToBuilderResultAndCheck(ctx, path, emptyParent);
 
     if (erroHandler->numErrors() > 0) {
       erroHandler->printAndExitIfError(ctx);

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1293,8 +1293,8 @@ struct RstResultBuilder {
       // process the warning about comments
       auto br = parseFileContainingIdToBuilderResult(context_, node->id());
       auto loc = br->commentToLocation(lastComment);
-      auto err = GeneralError::get(context_, ErrorBase::WARNING, loc, errMsg);
-      context_->report(err);
+      auto err = GeneralError::get(ErrorBase::WARNING, loc, errMsg);
+      context_->report(std::move(err));
     }
     // TODO: The presence of these node exceptions means we're probably missing
     //  something from the old implementation
@@ -1488,8 +1488,8 @@ struct RstResultBuilder {
             // process the warning about comments
             auto br = parseFileContainingIdToBuilderResult(context_, m->id());
             auto loc = br->commentToLocation(lastComment);
-            auto err = GeneralError::get(context_, GeneralError::WARNING, loc, errMsg);
-            context_->report(err);
+            auto err = GeneralError::get(GeneralError::WARNING, loc, errMsg);
+            context_->report(std::move(err));
           }
           if (!synopsis.empty()) {
             indentStream(os_, 1 * indentPerDepth);
@@ -2052,6 +2052,38 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir,
   }
 }
 
+class ChpldocErrorHandler : public Context::ErrorHandler {
+ private:
+  std::vector<owned<ErrorBase>> reportedErrors;
+
+ public:
+  void report(Context* context, const ErrorBase* error) override {
+    reportedErrors.push_back(error->clone());
+  }
+
+  size_t numErrors() const {
+    return reportedErrors.size();
+  }
+
+  void printAndExitIfError(Context* context) {
+    // TODO: handle errors better, don't rely on parse query to emit them
+    // per @mppf: if dyno-chpldoc wants to quit on an error, it should
+    // configure Context::reportError to have a custom function that does so.
+    bool fatal = false;
+    for (auto& e : reportedErrors) {
+    // just display the error messages right now, see TODO above
+      if (e->kind() == ErrorBase::Kind::ERROR ||
+          e->kind() == ErrorBase::Kind::SYNTAX) {
+            fatal = true;
+      }
+      Context::defaultReportError(context, e.get());
+    }
+    if (fatal) {
+      exit(1);
+    }
+    reportedErrors.clear();
+  }
+};
 
 int main(int argc, char** argv) {
   Args args = parseArgs(argc, argv, (void*)main);
@@ -2087,6 +2119,8 @@ int main(int argc, char** argv) {
 
   Context context(CHPL_HOME);
   Context *ctx = &context;
+  auto erroHandler = new ChpldocErrorHandler(); // wraped in owned on next line
+  ctx->installErrorHandler(owned<Context::ErrorHandler>(erroHandler));
   ctx->setDetailedErrorOutput(false);
   auto chplEnv = ctx->getChplEnv();
   assert(!chplEnv.getError() && "not handling chplenv errors yet");
@@ -2178,22 +2212,8 @@ int main(int argc, char** argv) {
                                                                   path,
                                                                   emptyParent);
 
-    if (builderResult.numErrors() > 0) {
-      // TODO: handle errors better, don't rely on parse query to emit them
-      // per @mppf: if dyno-chpldoc wants to quit on an error, it should
-      // configure Context::reportError to have a custom function that does so.
-      bool fatal = false;
-      for (auto e : builderResult.errors()) {
-      // just display the error messages right now, see TODO above
-        if (e->kind() == ErrorBase::Kind::ERROR ||
-            e->kind() == ErrorBase::Kind::SYNTAX) {
-              fatal = true;
-        }
-        context.report(e);
-      }
-      if (fatal) {
-        return 1;
-      }
+    if (erroHandler->numErrors() > 0) {
+      erroHandler->printAndExitIfError(ctx);
     }
     // gather all the top level and used/imported/included module IDs
     for (const chpl::uast::AstNode* ast : builderResult.topLevelExpressions()) {
@@ -2235,6 +2255,9 @@ int main(int argc, char** argv) {
         r->outputModule(outdir, moduleName, indentPerDepth);
      }
    }
+
+  // chpldoc-specific warnings could've been issued, make sure they're printed.
+  erroHandler->printAndExitIfError(ctx);
 
   if (!textOnly_ && !args.noHTML) {
     generateSphinxOutput(docsSphinxDir, docsOutputDir,args.projectVersion,


### PR DESCRIPTION
This PR switches the new error system away from using queries for creating unique errors, and towards simply using `owned` pointers. This is, for the most part, a mechanical change -- error reporting, as done via macros, remains unchanged. The main difference is that this makes it impossible to store errors in more than one place at a time (due `unique_ptr`'s single ownership policy). This, in turn, motivates the removal of the `errors` vectors from `Builder`, `BuilderResult`, and `ParserContext`, in favor of simply reporting the errors directly to the `Context` contained within.

The motivation for this PR is the large memory usage of the query system. Since we were, prior to this PR, using one Dyno query per error message type, and since the error queries used a lot of C++ templating, this made the size of the generated object files, as well as the memory usage of the compiler, increase significantly. This PR moves away from queries and templating, hopefully reducing the size of the generated code and the compiler memory usage. I will post results in this issue as I measure them.

Since errors are now emitted during the creation of a builder result (and thus before IDs are assigned to AST nodes), this means that errors based on IDs during parsing and post-parse checks cannot be converted to locations. This is fixed by splitting post-parse checks into their own query, which runs after the `BuilderResult`-producing parsing has completed, thus making ID-to-location conversion available. This change, however, means that `Parser::parseString` no longer runs post-parse checks; call sites are updated to ensure that functions that called `parseFileToBuilderResult` or `parseString` and relied on them for post-parse checks now invoke post-parse checks themselves (typically via a helper function like `parseFileToBuilderResultAndCheck`, or `parseStringAndReportErrors`).

Reviewed by @riftEmber -- thanks!

## Testing
- [x] paratest