### PR TITLE
Add future for #21193

### DIFF
--- a/test/library/standard/Map/types/ClassWithMapWithRecord.bad
+++ b/test/library/standard/Map/types/ClassWithMapWithRecord.bad
@@ -1,0 +1,6 @@
+internal error: RES-CUL-CES-1763 chpl version 1.30.0 pre-release (b'ae52de5bbc')
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.
+

--- a/test/library/standard/Map/types/ClassWithMapWithRecord.chpl
+++ b/test/library/standard/Map/types/ClassWithMapWithRecord.chpl
@@ -1,0 +1,46 @@
+use IO, Map;
+const filename = "foo";
+
+/////////////////////////////////////////////////////////////////////////////
+// a simplified example
+
+record MyRecord {
+  var de: unmanaged object;
+// this works: var de = new unmanaged object();
+}
+
+class MyClass {
+  var files = new map(string, MyRecord);
+}
+
+const myC = new unmanaged MyClass();
+
+// TODO: The following seems to create an extra new unmanaged object()
+// that is not deleted by `myC.files[filename].de` below.
+// Once this test passes memleaks testing, remove the --memLeaks .execopts.
+myC.files[filename] = new MyRecord(new unmanaged object());
+
+writeln(myC);  // {files = {foo: (de = {})}}
+
+delete myC.files[filename].de;
+delete myC;
+
+/////////////////////////////////////////////////////////////////////////////
+// the original recursive case by @cassella
+
+record recordthatcontainsadirent {
+  var de: unmanaged dirent;
+}
+
+class dirent {
+  var files = new map(string, recordthatcontainsadirent);
+}
+
+var curdir = new unmanaged dirent();
+
+curdir.files[filename] = new recordthatcontainsadirent(new unmanaged dirent());
+
+writeln(curdir);  // {files = {foo: (de = {files = {}})}}
+
+delete curdir.files[filename].de;
+delete curdir;

--- a/test/library/standard/Map/types/ClassWithMapWithRecord.execopts
+++ b/test/library/standard/Map/types/ClassWithMapWithRecord.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/library/standard/Map/types/ClassWithMapWithRecord.future
+++ b/test/library/standard/Map/types/ClassWithMapWithRecord.future
@@ -1,0 +1,2 @@
+bug: Internal error with a record containing a class containing a map of string to said record
+#21193

--- a/test/library/standard/Map/types/ClassWithMapWithRecord.good
+++ b/test/library/standard/Map/types/ClassWithMapWithRecord.good
@@ -1,0 +1,2 @@
+{files = {foo: (de = {})}}
+{files = {foo: (de = {files = {}})}}


### PR DESCRIPTION
Add a future for #21193.

This test is developed in @cassella in #21307 - many thanks! This PR replaces that one with a slightly polished version of the test.

I am adding .execopts with --memLeaks because I suspect that even if the test compiles, it will leak an object or two. See a comment in the source.

Once this test works without memleaks, the --memLeaks should be removed so that most testing configs run without it just like for most other tests.
