### PR TITLE
Remove nightly -cron from homebrew test

### DIFF
--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -32,4 +32,3 @@ log_info "Building tarball with version: ${version}"
 source $CWD/common-homebrew.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="homebrew"
-$CWD/nightly -cron


### PR DESCRIPTION
Fix for the failure in the weekly homebrew jenkins testun:
https://chapel-ci.us.cray.com/job/homebrew-test-homebrew/lastBuild/consoleFull

Removed $CWD/nightly.

homebre-test in cron runs pidig to verify chpl install so $CWD/nightly -cron does not seem to add any value here.
Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>