### PR TITLE
Start storing class structure type instead of pointer type for TypeSymbols

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1199,7 +1199,7 @@ bool isOuterVarOfShadowVar(Expr* expr) {
 
 TypeSymbol::TypeSymbol(const char* init_name, Type* init_type) :
   Symbol(E_TypeSymbol, init_name, init_type),
-    llvmType(NULL),
+    llvmImplType(NULL),
     llvmTbaaTypeDescriptor(NULL),
     llvmTbaaAccessTag(NULL), llvmConstTbaaAccessTag(NULL),
     llvmTbaaAggTypeDescriptor(NULL),

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -458,7 +458,7 @@ void AggregateType::codegenDef() {
         }
 
         if (aggregateTag == AGGREGATE_CLASS) {
-          type = stype->getPointerTo();
+          type = stype;
         }
       }
 
@@ -468,9 +468,9 @@ void AggregateType::codegenDef() {
 
   if( !outfile ) {
 #ifdef HAVE_LLVM
-    if( ! this->symbol->llvmType ) {
+    if( ! this->symbol->getLLVMType() ) {
       info->lvt->addGlobalType(this->symbol->cname, type, false);
-      this->symbol->llvmType = type;
+      this->symbol->llvmImplType = type;
     }
 #endif
   }
@@ -496,7 +496,7 @@ void AggregateType::codegenPrototype() {
 
       llvm::PointerType* pt = llvm::PointerType::getUnqual(st);
       info->lvt->addGlobalType(symbol->cname, pt, false);
-      symbol->llvmType = pt;
+      symbol->llvmImplType = pt;
 #endif
     }
   }

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1861,7 +1861,7 @@ static void codegen_header(std::set<const char*> & cnames,
     forv_Vec(TypeSymbol, typeSymbol, gTypeSymbols) {
       if (typeSymbol->defPoint->parentExpr == rootModule->block &&
           isPrimitiveType(typeSymbol->type) &&
-          typeSymbol->llvmType) {
+          typeSymbol->getLLVMType()) {
         typeSymbol->codegenMetadata();
       }
     }

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -511,7 +511,7 @@ class TypeSymbol final : public Symbol {
   // for this type has already been codegen'd
   // and cache it if it has.
 #ifdef HAVE_LLVM
-  llvm::Type* llvmType;
+  llvm::Type* llvmImplType;
   llvm::MDNode* llvmTbaaTypeDescriptor;       // scalar type descriptor
   llvm::MDNode* llvmTbaaAccessTag;            // scalar access tag
   llvm::MDNode* llvmConstTbaaAccessTag;       // scalar const access tag
@@ -521,10 +521,12 @@ class TypeSymbol final : public Symbol {
   llvm::MDNode* llvmTbaaStructCopyNode;       // tbaa.struct for memcpy
   llvm::MDNode* llvmConstTbaaStructCopyNode;  // const tbaa.struct
   llvm::MDNode* llvmDIType;
+  llvm::Type* getLLVMStructureType();         // get structure type for class
+  llvm::Type* getLLVMType();                  // get pointer to structure type for class
 #else
   // Keep same layout so toggling HAVE_LLVM
   // will not lead to build errors without make clean
-  void* llvmType;
+  void* llvmImplType;
   void* llvmTbaaTypeDescriptor;
   void* llvmTbaaAccessTag;
   void* llvmConstTbaaAccessTag;

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -127,7 +127,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
   GenInfo* info = gGenInfo;
   const llvm::DataLayout& layout = info->module->getDataLayout();
 
-  llvm::Type* ty = type->symbol->llvmType;
+  llvm::Type* ty = type->symbol->getLLVMType();
   const char* name = type->symbol->name;
   ModuleSymbol* defModule = type->symbol->getModule();
   const char* defFile = type->symbol->fname();
@@ -274,7 +274,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
               const char* fieldDefFile = field->defPoint->fname();
               int fieldDefLine = field->defPoint->linenum();
               TypeSymbol* fts = field->type->symbol;
-              llvm::Type* fty = fts->llvmType;
+              llvm::Type* fty = fts->getLLVMType();
               llvm::DIType* mty;
               llvm::DIType* fditype =  get_type(field->type);
               if(fditype == NULL)
@@ -351,7 +351,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
       const char* fieldDefFile = field->defPoint->fname();
       int fieldDefLine = field->defPoint->linenum();
       TypeSymbol* fts = field->type->symbol;
-      llvm::Type* fty = fts->llvmType;
+      llvm::Type* fty = fts->getLLVMType();
       llvm::DIType* fditype =  get_type(field->type);
       if(fditype == NULL)
       // See line 270 for a comment about this if
@@ -453,11 +453,11 @@ llvm::DIType* debug_data::construct_type(Type *type)
   // These are some debug prints for helping find these types.
   //
   /*printf("Unhandled type: %s\n\ttype->astTag=%i\n", type->symbol->name, type->astTag);
-  if(type->symbol->llvmType) {
-    printf("\tllvmType->getTypeID() = %i\n", type->symbol->llvmType->getTypeID());
+  if(type->symbol->getLLVMType()) {
+    printf("\tllvmImplType->getTypeID() = %i\n", type->symbol->getLLVMType()->getTypeID());
   }
   else {
-    printf("\tllvmType is NULL\n");
+    printf("\tllvmImplType is NULL\n");
   }*/
 
   return NULL;


### PR DESCRIPTION
With opaque pointers we now need to store store the class structure type instead of the class pointer type because we need this information in a few places. So when storing this type don't make it a pointer.

Change the name of 'TypeSymbol::llvmType' to 'TypeSymbol::llvmImplType' and add accessors to get the field either as a pointer or as the underlying structure. Update accesses of llvmType to use the accessor that returns a pointer for classes.

The accessor that returns the structure is currently unused so is commented out to avoid unused function warnings. It will be used shortly.