### PR TITLE
Add an ifdef HAVE_LLVM for an llvm-only section of codegen

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1855,6 +1855,7 @@ static void codegen_header(std::set<const char*> & cnames,
   }
 
   if(!info->cfile) {
+#ifdef HAVE_LLVM
     // Codegen any type annotations that are necessary.
     // Start with primitive types in case they are referenced by
     // records or classes.
@@ -1875,6 +1876,7 @@ static void codegen_header(std::set<const char*> & cnames,
       if (isClass(typeSymbol->type))
         typeSymbol->codegenAggMetadata();
     }
+#endif
   }
 
   genComment("Function Prototypes");


### PR DESCRIPTION
The CHPL_LLVM=none build failed with an undefined function. The bad function call was in a section that should have only been included for LLVM.