### PR TITLE
Fix compiler build with CHPL_LLVM=none

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4924,7 +4924,8 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   return codegenCallExprWithArgs(fn, args);
 #else
   INT_FATAL("Unexpected code path: gpu code generation without LLVM as target");
-  return nullptr;
+  GenRet dummy;
+  return dummy;
 #endif
 }
 


### PR DESCRIPTION
This change is needed to enable building the compiler under CHPL_LLVM=none.

Testing:
* the compiler builds for CHPL_LLVM=none on my mac
* hello4 passes
