### PR TITLE
Remove an unnecessary LLVM check

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4838,9 +4838,6 @@ static bool isCStringImmediate(Symbol* sym) {
 }
 
 static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
-#ifdef HAVE_LLVM  // Needed to suppress warning; should always be true in code
-                  // path for GPU codegen
-
   // Used to codegen for PRIM_GPU_KERNEL_LAUNCH_FLAT and PRIM_GPU_KERNEL_LAUNCH.
   // They differ in number of arguments only. The first passes 1 integer for
   // grid and block size each, the other passes 3 for each.
@@ -4922,11 +4919,6 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
   }
 
   return codegenCallExprWithArgs(fn, args);
-#else
-  INT_FATAL("Unexpected code path: gpu code generation without LLVM as target");
-  GenRet dummy;
-  return dummy;
-#endif
 }
 
 DEFINE_PRIM(GPU_KERNEL_LAUNCH_FLAT) {


### PR DESCRIPTION
This `ifdef LLVM` was modified in df3f504.

However, I should have deleted it, as the LLVM call that it
protects was also removed in that commit. This PR deletes that
check, which also caused a ton of issues with `CHPL_LLVM=none`. 

Test:
- [x] `CHPL_LLVM=none` `make DEBUG=0 WARNINGS=1 ASSERTS=0 OPTIMIZE=1 -C compiler -j8`
- [x] standard linux64 `make check`
- [x] gpu `gpu/native/jacobi/jacobi.chpl` 