### PR TITLE
Add a chplType field to the LVT

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -855,7 +855,7 @@ void VarSymbol::codegenGlobalDef(bool isHeader) {
                                  : llvm::GlobalVariable::InternalLinkage,
             llvm::Constant::getNullValue(llTy), /* initializer, */
             cname);
-      info->lvt->addGlobalValue(cname, gVar, GEN_PTR, ! is_signed(type) );
+      info->lvt->addGlobalValue(cname, gVar, GEN_PTR, ! is_signed(type), type);
 
       gVar->setDSOLocal(true);
 
@@ -922,7 +922,7 @@ void VarSymbol::codegenDef() {
         globalValue->setInitializer(llvm::cast<llvm::Constant>(
               codegenImmediateLLVM(immediate)));
       }
-      info->lvt->addGlobalValue(cname, globalValue, GEN_VAL, ! is_signed(type));
+      info->lvt->addGlobalValue(cname, globalValue, GEN_VAL, ! is_signed(type), type);
     }
 
 #if HAVE_LLVM_VER >= 100

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -222,7 +222,7 @@ genGlobalDefClassId(const char* cname, int id, bool isHeader) {
         info->module->getOrInsertGlobal(name, id_type));
     gv->setInitializer(info->irBuilder->getInt32(id));
     gv->setConstant(true);
-    info->lvt->addGlobalValue(name, gv, GEN_PTR, ! is_signed(CLASS_ID_TYPE));
+    info->lvt->addGlobalValue(name, gv, GEN_PTR, ! is_signed(CLASS_ID_TYPE), CLASS_ID_TYPE);
 #endif
   }
 }
@@ -240,7 +240,7 @@ genGlobalString(const char *cname, const char *value) {
       globalString->setInitializer(llvm::cast<llvm::GlobalVariable>(
             new_CStringSymbol(value)->codegen().val)->getInitializer());
       globalString->setConstant(true);
-      info->lvt->addGlobalValue(cname, globalString, GEN_PTR, true);
+      info->lvt->addGlobalValue(cname, globalString, GEN_PTR, true, dtStringC);
     }
 #endif
   }
@@ -272,7 +272,7 @@ static void genGlobalRawString(const char *cname, std::string &value, size_t len
         ty, globalStringIr, 0, 0);
       globalString->setInitializer(llvm::cast<llvm::Constant>(correctlyTypedValue));
       globalString->setConstant(true);
-      info->lvt->addGlobalValue(cname, globalString, GEN_PTR, true);
+      info->lvt->addGlobalValue(cname, globalString, GEN_PTR, true, dtStringC);
     }
   }
 }
@@ -293,7 +293,7 @@ genGlobalInt(const char* cname, int value, bool isHeader) {
           cname, llvm::IntegerType::getInt32Ty(info->module->getContext())));
     globalInt->setInitializer(info->irBuilder->getInt32(value));
     globalInt->setConstant(true);
-    info->lvt->addGlobalValue(cname, globalInt, GEN_PTR, false);
+    info->lvt->addGlobalValue(cname, globalInt, GEN_PTR, false, dtInt[INT_SIZE_32]);
 #endif
   }
 }
@@ -309,7 +309,7 @@ static void genGlobalInt32(const char *cname, int value) {
             cname, llvm::IntegerType::getInt32Ty(info->module->getContext())));
     globalInt->setInitializer(info->irBuilder->getInt32(value));
     globalInt->setConstant(true);
-    info->lvt->addGlobalValue(cname, globalInt, GEN_PTR, false);
+    info->lvt->addGlobalValue(cname, globalInt, GEN_PTR, false, dtInt[INT_SIZE_32]);
 #endif
   }
 }
@@ -486,7 +486,7 @@ static void codegenGlobalConstArray(const char*          name,
   globalTable->setInitializer(llvm::ConstantArray::get(tableType, table));
   globalTable->setConstant(true);
 
-  info->lvt->addGlobalValue(name, globalTable, GEN_VAL, true);
+  info->lvt->addGlobalValue(name, globalTable, GEN_VAL, true, /* chplType=*/ nullptr);
 #endif
   }
 }
@@ -1436,7 +1436,7 @@ static void genGlobalSerializeTable(GenInfo* info) {
         llvm::ConstantArray::get(
           global_serializeTableType, global_serializeTable));
     info->lvt->addGlobalValue("chpl_global_serialize_table",
-                              global_serializeTableGVar, GEN_PTR, true);
+                              global_serializeTableGVar, GEN_PTR, true, dtCVoidPtr);
 #endif
   }
 }
@@ -1930,7 +1930,7 @@ static void codegen_header(std::set<const char*> & cnames,
         llvm::Constant::getNullValue(
           chpl_globals_registryGVar->getType()->getContainedType(0)));
     info->lvt->addGlobalValue("chpl_globals_registry",
-                              chpl_globals_registryGVar, GEN_PTR, true);
+                              chpl_globals_registryGVar, GEN_PTR, true, /* chplType= */ nullptr);
 #endif
   }
   if( hdrfile ) {
@@ -1956,7 +1956,7 @@ static void codegen_header(std::set<const char*> & cnames,
     chpl_memDescsGVar->setInitializer(
         llvm::ConstantArray::get(memDescTableType, memDescTable));
     chpl_memDescsGVar->setConstant(true);
-    info->lvt->addGlobalValue("chpl_mem_descs",chpl_memDescsGVar,GEN_PTR,true);
+    info->lvt->addGlobalValue("chpl_mem_descs", chpl_memDescsGVar, GEN_PTR, true, dtStringC);
 #endif
   }
 
@@ -2005,7 +2005,7 @@ static void codegen_header(std::set<const char*> & cnames,
         llvm::ConstantArray::get(
           private_broadcastTableType, private_broadcastTable));
     info->lvt->addGlobalValue("chpl_private_broadcast_table",
-                              private_broadcastTableGVar, GEN_PTR, true);
+                              private_broadcastTableGVar, GEN_PTR, true, dtCVoidPtr);
     genGlobalInt("chpl_private_broadcast_table_len",
                  private_broadcastTable.size(), false);
 #endif

--- a/compiler/include/LayeredValueTable.h
+++ b/compiler/include/LayeredValueTable.h
@@ -99,6 +99,8 @@ class LayeredValueTable
       bool addedToChapelAST;
       // Line and file info for the C declaration
       astlocT astloc;
+      // Store the type of the value so we can figure out the element type of
+      // LLVM opaque pointers.
       Type* chplType;
 
       Storage() : astloc(0, NULL) {
@@ -130,7 +132,7 @@ class LayeredValueTable
     void addLayer();
     void removeLayer();
     void addValue(llvm::StringRef name, llvm::Value *value, uint8_t isLVPtr, bool isUnsigned);
-    void addGlobalValue(llvm::StringRef name, llvm::Value *value, uint8_t isLVPtr, bool isUnsigned, Type* type=NULL);
+    void addGlobalValue(llvm::StringRef name, llvm::Value *value, uint8_t isLVPtr, bool isUnsigned, Type* type);
     void addGlobalValue(llvm::StringRef name, GenRet gend);
     void addGlobalType(llvm::StringRef name, llvm::Type *type, bool isUnsigned);
     void addGlobalCDecl(clang::NamedDecl* cdecl);

--- a/compiler/include/LayeredValueTable.h
+++ b/compiler/include/LayeredValueTable.h
@@ -99,6 +99,7 @@ class LayeredValueTable
       bool addedToChapelAST;
       // Line and file info for the C declaration
       astlocT astloc;
+      Type* chplType;
 
       Storage() : astloc(0, NULL) {
         u.value = NULL;
@@ -113,6 +114,7 @@ class LayeredValueTable
         isLVPtr = GEN_VAL;
         isUnsigned = false;
         addedToChapelAST = false;
+        chplType = NULL;
       }
     };
 
@@ -128,7 +130,7 @@ class LayeredValueTable
     void addLayer();
     void removeLayer();
     void addValue(llvm::StringRef name, llvm::Value *value, uint8_t isLVPtr, bool isUnsigned);
-    void addGlobalValue(llvm::StringRef name, llvm::Value *value, uint8_t isLVPtr, bool isUnsigned); //, Type* type=NULL);
+    void addGlobalValue(llvm::StringRef name, llvm::Value *value, uint8_t isLVPtr, bool isUnsigned, Type* type=NULL);
     void addGlobalValue(llvm::StringRef name, GenRet gend);
     void addGlobalType(llvm::StringRef name, llvm::Type *type, bool isUnsigned);
     void addGlobalCDecl(clang::NamedDecl* cdecl);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3000,7 +3000,7 @@ void LayeredValueTable::addValue(
 }
 
 void LayeredValueTable::addGlobalValue(
-    StringRef name, Value *value, uint8_t isLVPtr, bool isUnsigned) {
+    StringRef name, Value *value, uint8_t isLVPtr, bool isUnsigned, ::Type* type) {
   Storage store;
   store.u.value = value;
   store.isLVPtr = isLVPtr;
@@ -3009,7 +3009,7 @@ void LayeredValueTable::addGlobalValue(
 }
 
 void LayeredValueTable::addGlobalValue(StringRef name, GenRet gend) {
-  addGlobalValue(name, gend.val, gend.isLVPtr, gend.isUnsigned);
+  addGlobalValue(name, gend.val, gend.isLVPtr, gend.isUnsigned, gend.chplType);
 }
 
 void LayeredValueTable::addGlobalType(StringRef name, llvm::Type *type, bool isUnsigned) {
@@ -3127,6 +3127,7 @@ GenRet LayeredValueTable::getValue(StringRef name) {
       ret.val = store->u.value;
       ret.isLVPtr = store->isLVPtr;
       ret.isUnsigned = store->isUnsigned;
+      ret.chplType = store->chplType;
       return ret;
     }
     if( store->u.cValueDecl ) {
@@ -3140,6 +3141,7 @@ GenRet LayeredValueTable::getValue(StringRef name) {
       store->u.value = ret.val;
       store->isLVPtr = ret.isLVPtr;
       store->isUnsigned = ret.isUnsigned;
+
       return ret;
     }
     if( store->u.chplVar && isVarSymbol(store->u.chplVar) ) {


### PR DESCRIPTION
Add a 'Type* chplType' field to the LVT to track pointer types. Adjust the LayeredValueTable::addGlobalValue() function to take a Type* argument and set the chplType field.

Adjust all calls to addGlobalValue() to pass a Chapel Type* to the new argument.

Adjust LayeredValueTable::getValue() to set the returned GenRet's chplType to the field set by addGlobalValue().