### PR TITLE
Alt approach for GPU threadblock barrier sync

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5003,12 +5003,14 @@ DEFINE_PRIM(GPU_SYNC_THREADS) {
     return;
   }
 #ifdef HAVE_LLVM
-  Type *chplReturnType = dtVoid;
+  /*Type *chplReturnType = dtVoid;
   llvm::Function *fun = llvm::Intrinsic::getDeclaration(gGenInfo->module,
     llvm::Intrinsic::nvvm_barrier0);
   ret.val = gGenInfo->irBuilder->CreateCall(fun);
   ret.isLVPtr = GEN_VAL;
-  ret.chplType = chplReturnType;
+  ret.chplType = chplReturnType;*/
+
+  ret = codegenCallExpr("chpl_gpu_force_sync");
 #endif
 }
 

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5003,7 +5003,18 @@ DEFINE_PRIM(GPU_SYNC_THREADS) {
     return;
   }
 #ifdef HAVE_LLVM
-  /*Type *chplReturnType = dtVoid;
+  /* One approach to generating the barrier to call the
+   llvm intrinsic function for it, however
+   this approach ended up causing issues for us likely due this bug
+   reported here:
+
+    https://github.com/llvm/llvm-project/issues/58626
+
+   So instead we call a function in our runtime that includes inline
+   assembly to make the barrier call. If the llvm issue is resolved
+   we may want to change this back:
+
+  Type *chplReturnType = dtVoid;
   llvm::Function *fun = llvm::Intrinsic::getDeclaration(gGenInfo->module,
     llvm::Intrinsic::nvvm_barrier0);
   ret.val = gGenInfo->irBuilder->CreateCall(fun);

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -106,6 +106,14 @@ __device__ __host__ static inline void chpl_gpu_printTimeDelta(
   printf("%s%u\n", msg, end - start);
 }
 
+__device__ static inline void chpl_gpu_force_sync() {
+  asm volatile("bar.sync 0;" : : : "memory");
+}
+
+__host__ static inline void chpl_gpu_force_sync() {
+  // TODO
+}
+
 #endif // HAS_GPU_LOCALE
 
 #endif // _CHPL_GPU_GEN_INCLUDES_H

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -107,11 +107,14 @@ __device__ __host__ static inline void chpl_gpu_printTimeDelta(
 }
 
 __device__ static inline void chpl_gpu_force_sync() {
+  // Using __syncThreads() directly causes issues when compiling programs with
+  // --fast.  It's likely due to an issue with clang discussed here:
+  // https://github.com/llvm/llvm-project/issues/58626
   asm volatile("bar.sync 0;" : : : "memory");
 }
 
 __host__ static inline void chpl_gpu_force_sync() {
-  // TODO
+  chpl_internal_error("chpl_gpu_force_sync called from host");
 }
 
 #endif // HAS_GPU_LOCALE

--- a/test/GPU-GRAPHFILES
+++ b/test/GPU-GRAPHFILES
@@ -4,6 +4,7 @@ gpu/native/studies/shoc/kernel.graph
 gpu/native/studies/shoc/kernel2.graph
 gpu/native/studies/shoc/triad2.graph
 gpu/native/studies/shoc/bandwidth.graph
+gpu/native/studies/shoc/sort.graph
 
 gpu/native/streamPrototype/gpuStream.graph
 

--- a/test/gpu/native/studies/shoc/sort.chpl
+++ b/test/gpu/native/studies/shoc/sort.chpl
@@ -76,9 +76,9 @@ proc runSort(){
     const numSortGroups = size / (4 * SORT_BLOCK_SIZE);
     var dCounters, dCounterSums, dBlockOffsets : [0..<WARP_SIZE*numSortGroups] uint(32);
 
-    var sortDb = new ResultDatabase("Sort Rate", "GB/s", atts="", attsSuffix="items");
-    var pciDb = new ResultDatabase("Sort Rate PCIe", "GB/s", atts="", attsSuffix="items");
-    var parityDb = new ResultDatabase("Sort Parity", "N", atts="", attsSuffix="items");
+    var sortDb = new ResultDatabase("Sort Rate", "GB/s", atts="", attsSuffix=" items");
+    var pciDb = new ResultDatabase("Sort Rate PCIe", "GB/s", atts="", attsSuffix=" items");
+    var parityDb = new ResultDatabase("Sort Parity", "N", atts="", attsSuffix=" items");
 
     const iterations = passes;
     // They do timing using cudaEvent, ig we will just use our timer.
@@ -161,7 +161,6 @@ proc runSort(){
         sortDb.printPerfStats();
         pciDb.printPerfStats();
         parityDb.printPerfStats();
-
     }
 }
 

--- a/test/gpu/native/studies/shoc/sort.gpu-compopts
+++ b/test/gpu/native/studies/shoc/sort.gpu-compopts
@@ -1,0 +1,1 @@
+result.chpl --gpu-block-size=128 --main-module=sort

--- a/test/gpu/native/studies/shoc/sort.gpu-keys
+++ b/test/gpu/native/studies/shoc/sort.gpu-keys
@@ -1,3 +1,3 @@
-Sort Rate  25165824items Median:
-Sort Rate PCIe  25165824items Median:
+Sort Rate  25165824 items Median:
+Sort Rate PCIe  25165824 items Median:
 verify:-1: (kernel_launch = 249)

--- a/test/gpu/native/studies/shoc/sort.gpu-keys
+++ b/test/gpu/native/studies/shoc/sort.gpu-keys
@@ -1,0 +1,3 @@
+Sort Rate  25165824items Median:
+Sort Rate PCIe  25165824items Median:
+verify:-1: (kernel_launch = 249)

--- a/test/gpu/native/studies/shoc/sort.graph
+++ b/test/gpu/native/studies/shoc/sort.graph
@@ -1,4 +1,4 @@
-perfkeys: Sort Rate  25165824items Median:, Sort Rate PCIe  25165824items Median:
+perfkeys: Sort Rate  25165824 items Median:, Sort Rate PCIe  25165824 items Median:
 files: sort.dat
 graphkeys: Sort (sort time only), Sort (w/ memory transfer time)
 ylabel: Bandwidth (GB/s)

--- a/test/gpu/native/studies/shoc/sort.graph
+++ b/test/gpu/native/studies/shoc/sort.graph
@@ -1,0 +1,5 @@
+perfkeys: Sort Rate  25165824items Median:, Sort Rate PCIe  25165824items Median:
+files: sort.dat
+graphkeys: Sort (sort time only), Sort (w/ memory transfer time)
+ylabel: Bandwidth (GB/s)
+graphtitle: SHOC Sort - Bandwidth


### PR DESCRIPTION
This PR makes two changes:
* Changes how we generate threadblock barrier sync calls
* Starts gathering performance data for SHOC sort benchmark

To give some context ---

As discussed here (https://github.com/Cray/chapel-private/issues/4179) with our Chapel implementation of the SHOC sort benchmark we were running into an issue where we'd succeed when not compiling with `--fast` and fail when using `--fast).

I was able to narrow this down to a small reproducer example (seen here https://github.com/Cray/chapel-private/issues/4179#issuecomment-1382366379), which looks incredibly similar to this example on an LLVM bug report: https://github.com/llvm/llvm-project/issues/58626

In that bug report the author shows they can work around it by using inline assembly (marked volatile) to generate the sync call instead.

This might be fixed in later versions of clang. I don't know. This seems like a reasonable workaround in the interim.