### PR TITLE
Add errors for explicit relative imports

### DIFF
--- a/frontend/include/chpl/framework/mark-functions.h
+++ b/frontend/include/chpl/framework/mark-functions.h
@@ -90,6 +90,15 @@ template<typename T> struct mark<std::vector<T>> {
   }
 };
 
+template<typename T> struct mark<std::set<T>> {
+  void operator()(Context* context, const std::set<T>& keep) const {
+    for (auto const &elt : keep) {
+      chpl::mark<T> marker;
+      marker(context, elt);
+    }
+  }
+};
+
 template<typename K, typename V> struct mark<std::unordered_map<K,V>> {
   void operator()(Context* context, std::unordered_map<K,V>& keep) const {
     for (auto const &pair : keep) {

--- a/frontend/include/chpl/framework/resolution-error-classes-list.h
+++ b/frontend/include/chpl/framework/resolution-error-classes-list.h
@@ -77,7 +77,7 @@ ERROR_CLASS(UnsupportedAsIdent, const uast::As*, const uast::AstNode*)
 ERROR_CLASS(UseImportNotModule, const ID, const resolution::VisibilityStmtKind,
             std::string)
 ERROR_CLASS(UseImportUnknownMod, const ID, const resolution::VisibilityStmtKind,
-            std::string)
+            std::string, std::set<std::pair<ID, uast::asttags::AstTag>>)
 ERROR_CLASS(UseImportUnknownSym,
             std::string,
             const uast::AstNode*,

--- a/frontend/include/chpl/framework/resolution-error-classes-list.h
+++ b/frontend/include/chpl/framework/resolution-error-classes-list.h
@@ -76,8 +76,11 @@ ERROR_CLASS(UnknownEnumElem, const uast::AstNode*, chpl::UniqueString, const typ
 ERROR_CLASS(UnsupportedAsIdent, const uast::As*, const uast::AstNode*)
 ERROR_CLASS(UseImportNotModule, const ID, const resolution::VisibilityStmtKind,
             std::string)
-ERROR_CLASS(UseImportUnknownMod, const ID, const resolution::VisibilityStmtKind,
-            std::string, std::set<const uast::AstNode*>)
+ERROR_CLASS(UseImportUnknownMod,
+            const ID,
+            const resolution::VisibilityStmtKind,
+            std::string,
+            std::vector<const uast::AstNode*>)
 ERROR_CLASS(UseImportUnknownSym,
             std::string,
             const uast::AstNode*,

--- a/frontend/include/chpl/framework/resolution-error-classes-list.h
+++ b/frontend/include/chpl/framework/resolution-error-classes-list.h
@@ -77,7 +77,7 @@ ERROR_CLASS(UnsupportedAsIdent, const uast::As*, const uast::AstNode*)
 ERROR_CLASS(UseImportNotModule, const ID, const resolution::VisibilityStmtKind,
             std::string)
 ERROR_CLASS(UseImportUnknownMod, const ID, const resolution::VisibilityStmtKind,
-            std::string, std::set<std::pair<ID, uast::asttags::AstTag>>)
+            std::string, std::set<const uast::AstNode*>)
 ERROR_CLASS(UseImportUnknownSym,
             std::string,
             const uast::AstNode*,

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -618,6 +618,7 @@ enum {
   LOOKUP_TOPLEVEL = 8,
   LOOKUP_INNERMOST = 16,
   LOOKUP_SKIP_PRIVATE_VIS = 32,
+  LOOKUP_GO_PAST_MODULES = 64,
 };
 
 using LookupConfig = unsigned int;

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -537,7 +537,7 @@ void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
   auto moduleName = std::get<std::string>(info);
   auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  auto& improperMatches = std::get<std::set<std::pair<ID, uast::asttags::AstTag>>>(info);
+  auto& improperMatches = std::get<std::set<const uast::AstNode*>>(info);
 
   wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
              " '", moduleName, "' for '", useOrImport, "' statement.");
@@ -549,14 +549,14 @@ void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
     // Do we need to tell the user how to use super.M or this.M?
     bool explainRelativeImport = false;
 
-    for (auto idAndTag : improperMatches) {
+    for (auto ast : improperMatches) {
       // Separate out the various suggestions.
       wr.message("");
 
       // Use locationOnly to avoid printing 'in module M' for every suggestion.
 
-      auto& improperId = idAndTag.first;
-      auto tag = idAndTag.second;
+      auto improperId = ast->id();
+      auto tag = ast->tag();
       if (tag == uast::asttags::AstTag::Module) {
         wr.note(locationOnly(improperId),
                 "a module named '", moduleName, "' is defined here:");

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -581,7 +581,9 @@ void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
 
     if (explainRelativeImport) {
       wr.message("");
-      wr.note(id, "For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'");
+      wr.note(id, "For non-root-level modules, please specify the full path "
+                  "to the module or use a relative import e.g. 'import this.M' "
+                  "or 'import super.M'");
     }
   }
 }

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -52,6 +52,14 @@ static types::QualifiedType decayToValue(const types::QualifiedType& qt) {
   return qt;
 }
 
+static const char* allowedItem(resolution::VisibilityStmtKind kind) {
+  return kind == resolution::VIS_USE ? "module or 'enum'" : "module";
+}
+
+static const char* allowedItems(resolution::VisibilityStmtKind kind) {
+  return kind == resolution::VIS_USE ? "modules or enums" : "modules";
+}
+
 //
 // Below are the implementations of 'write' for each error class, which does
 // the specialized work.
@@ -516,20 +524,22 @@ void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
   auto moduleName = std::get<std::string>(info);
   auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
+
   wr.heading(kind_, type_, id, "cannot '", useOrImport, "' '", moduleName,
-             "', which is not a module.");
+             "', which is not a ", allowedItem(useOrImport), ".");
   wr.message("In the following '", useOrImport, "' statement:");
   wr.code<ID, ID>(id, { id });
-  wr.message("Only modules and enums can be used with '", useOrImport,
-             "' statements.");
+  wr.message("Only ", allowedItems(useOrImport), " can be used with '",
+             useOrImport, "' statements.");
 }
 
 void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
   auto moduleName = std::get<std::string>(info);
   auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  wr.heading(kind_, type_, id, "cannot find module '", moduleName,
-             "' for '", useOrImport, "'.");
+
+  wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
+             " '", moduleName, "' for '", useOrImport, "' statement.");
   wr.message("In the following '", useOrImport, "' statement:");
   wr.code<ID, ID>(id, { id });
 }

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -537,7 +537,7 @@ void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
   auto moduleName = std::get<std::string>(info);
   auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  auto& improperMatches = std::get<std::set<const uast::AstNode*>>(info);
+  auto& improperMatches = std::get<std::vector<const uast::AstNode*>>(info);
 
   wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
              " '", moduleName, "' for '", useOrImport, "' statement.");

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -943,13 +943,13 @@ static const Scope* findScopeViz(Context* context, const Scope* scope,
     // If we failed to find a proper import, we could've gotten back any number
     // of IDs that could be what the user meant to import. Store them in a set
     // and give them to the error.
-    std::set<std::pair<ID, asttags::AstTag>> improperMatchSet;
+    std::set<const AstNode*> improperMatchSet;
     for (auto& bids : improperMatches) {
       // For each improper match, also compute its tag, to make the error
       // message be able to provide more concrete results.
       for (auto id : bids) {
-        auto tag = parsing::idToTag(context, id);
-        improperMatchSet.insert(std::make_pair(id, tag));
+        auto ast = parsing::idToAst(context, id);
+        improperMatchSet.insert(ast);
       }
     }
 

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -943,18 +943,19 @@ static const Scope* findScopeViz(Context* context, const Scope* scope,
     // If we failed to find a proper import, we could've gotten back any number
     // of IDs that could be what the user meant to import. Store them in a set
     // and give them to the error.
-    std::set<const AstNode*> improperMatchSet;
+    std::vector<const AstNode*> improperMatchVec;
     for (auto& bids : improperMatches) {
       // For each improper match, also compute its tag, to make the error
       // message be able to provide more concrete results.
       for (auto id : bids) {
         auto ast = parsing::idToAst(context, id);
-        improperMatchSet.insert(ast);
+        improperMatchVec.push_back(ast);
       }
     }
+    std::reverse(improperMatchVec.begin(), improperMatchVec.end());
 
     CHPL_REPORT(context, UseImportUnknownMod, idForErrs, useOrImport,
-                nameInScope.c_str(), std::move(improperMatchSet));
+                nameInScope.c_str(), std::move(improperMatchVec));
     return nullptr;
   }
 

--- a/test/errors/fullImportPath-brief.good
+++ b/test/errors/fullImportPath-brief.good
@@ -1,0 +1,4 @@
+error in fullImportPath.chpl:9: cannot find module 'ToLookFor' for 'import' statement
+  note in fullImportPath.chpl:3: a module named 'ToLookFor' is defined here
+  note in fullImportPath.chpl:3: however, a full path or an explicit relative import is required for modules that are not at the root level
+  note in fullImportPath.chpl:9: For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'

--- a/test/errors/fullImportPath-detailed.good
+++ b/test/errors/fullImportPath-detailed.good
@@ -1,0 +1,18 @@
+─── error in fullImportPath.chpl:9 [UseImportUnknownMod] ───
+  Cannot find module 'ToLookFor' for 'import' statement.
+  In the following 'import' statement:
+      |
+    9 |                 import ToLookFor;
+      |                        ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+  The following declarations are not covered by the 'import' statement but seem similar to what you meant.
+  
+  A module named 'ToLookFor' is defined here:
+      |
+    3 |     module ToLookFor {}
+      |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+  However, a full path or an explicit relative import is required for modules that are not at the root level.
+  
+  For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'
+

--- a/test/errors/fullImportPath.chpl
+++ b/test/errors/fullImportPath.chpl
@@ -1,0 +1,14 @@
+// param ToLookFor = "??";
+module M1 {
+    module ToLookFor {}
+    module M2 {
+        module ToLookFor {}
+        module M3 {
+            module ToLookFor {}
+            module M4 {
+                import ToLookFor;
+                var x = ToLookFor.x;
+            }
+        }
+    }
+}

--- a/test/errors/fullImportPath.compopts
+++ b/test/errors/fullImportPath.compopts
@@ -1,0 +1,2 @@
+--detailed-errors # fullImportPath-detailed.good
+--no-detailed-errors # fullImportPath-brief.good

--- a/test/errors/fullUsePath-brief.good
+++ b/test/errors/fullUsePath-brief.good
@@ -1,0 +1,4 @@
+warning in fullUsePath.chpl:1: an implicit module named 'fullUsePath' is being introduced to contain file-scope code
+error in fullUsePath.chpl:9: cannot find module or enum 'ToLookFor' for 'use' statement
+  note in fullUsePath.chpl:1: a declaration of 'ToLookFor' is here
+  note in fullUsePath.chpl:1: however, 'use' statements can only be used with modules or enums (and this 'ToLookFor' is not a module or enum)

--- a/test/errors/fullUsePath-detailed.good
+++ b/test/errors/fullUsePath-detailed.good
@@ -1,0 +1,25 @@
+─── warning in fullUsePath.chpl:1 [ImplicitFileModule] ───
+  An implicit module named 'fullUsePath' is being introduced to contain file-scope code.
+  The following is the first file-scope statement:
+      |
+    1 | param ToLookFor = "??";
+      |
+  The implicit module 'fullUsePath' is being created because the above code is outside of any module declarations (e.g., 'module M1').
+  Note that all of the file's contents -- including module 'M1' -- will be placed into the new 'fullUsePath' module.
+
+─── error in fullUsePath.chpl:9 [UseImportUnknownMod] ───
+  Cannot find module or enum 'ToLookFor' for 'use' statement.
+  In the following 'use' statement:
+      |
+    9 |                 use ToLookFor;
+      |                     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+  The following declarations are not covered by the 'use' statement but seem similar to what you meant.
+  
+  A declaration of 'ToLookFor' is here:
+      |
+    1 | param ToLookFor = "??";
+      |       ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+  However, 'use' statements can only be used with modules or enums (and this 'ToLookFor' is not a module or enum).
+

--- a/test/errors/fullUsePath.chpl
+++ b/test/errors/fullUsePath.chpl
@@ -1,0 +1,14 @@
+param ToLookFor = "??";
+module M1 {
+    module ToLookFor {}
+    module M2 {
+        module ToLookFor {}
+        module M3 {
+            module ToLookFor {}
+            module M4 {
+                use ToLookFor;
+                var x = ToLookFor.x;
+            }
+        }
+    }
+}

--- a/test/errors/fullUsePath.compopts
+++ b/test/errors/fullUsePath.compopts
@@ -1,0 +1,2 @@
+--detailed-errors # fullUsePath-detailed.good
+--no-detailed-errors # fullUsePath-brief.good

--- a/test/visibility/relative-use/relative-use-error2.chpl
+++ b/test/visibility/relative-use/relative-use-error2.chpl
@@ -15,7 +15,7 @@ module M {
   }
 
   proc main() {
-    import this.SubModuleSubSubModule;
+    import this.SubModule.SubSubModule;
     SubSubModule.foo();
   }
 }


### PR DESCRIPTION
The production compiler reports errors when you try to import or use a module that's not at the top level, or if you try to use an implicit relative import. It typically shows the name of the module, but points out that this module cannot be imported and recommends to use `super.M` or `this.M`. Dyno, however, at the moment simply reports that a module cannot be found. This PR adds an extra step that occurs if a module could not be found, which performs another search for that module name. This second search is more lax, and only serves to find possible candidates that the user _wanted_ to use or import, but was forbidden from importing by the `use`/`import` rules. These candidates are then printed as part of the error message, thus matching the production compiler's output (roughly).

The new error messages look like this:
__Brief:__
<img width="1346" alt="Screen Shot 2023-01-18 at 4 55 08 PM" src="https://user-images.githubusercontent.com/4361282/213330508-3fc19a1d-8d6c-44ab-9d73-f2c2389533f9.png">
__Detailed:__
<img width="1001" alt="Screen Shot 2023-01-18 at 4 55 25 PM" src="https://user-images.githubusercontent.com/4361282/213330515-186dd2bb-c655-430a-96af-0f2b00239248.png">

Reviewed by @dlongnecke-cray - thanks!

## Testing
- [x] paratest
- [x] paratest with --dyno on top of Michael's #21510 (failures unchanged; errors are now due to error message differences, tracked in https://github.com/Cray/chapel-private/issues/3902).
