### PR TITLE
Update function 'codegenTernary' to avoid getPointerElementType()

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2166,7 +2166,7 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
 
     func->getBasicBlockList().push_back(blockEnd);
     info->irBuilder->SetInsertPoint(blockEnd);
-    ret.val = info->irBuilder->CreateLoad(ret.chplType->symbol->getLLVMStructureType(), tmp);
+    ret.val = info->irBuilder->CreateLoad(ifTrue.chplType->symbol->getLLVMStructureType(), tmp);
 
     ret.isUnsigned = !values.isSigned;
 #endif

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2166,11 +2166,8 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
 
     func->getBasicBlockList().push_back(blockEnd);
     info->irBuilder->SetInsertPoint(blockEnd);
-#if HAVE_LLVM_VER >= 130
-    ret.val = info->irBuilder->CreateLoad(tmp->getType()->getPointerElementType(), tmp);
-#else
-    ret.val = info->irBuilder->CreateLoad(tmp);
-#endif
+    ret.val = info->irBuilder->CreateLoad(ret.chplType->symbol->getLLVMStructureType(), tmp);
+
     ret.isUnsigned = !values.isSigned;
 #endif
   }

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1725,12 +1725,10 @@ void TypeSymbol::codegenAggMetadata() {
 }
 
 #ifdef HAVE_LLVM
-#if 0
 // get structure type for class
 llvm::Type* TypeSymbol::getLLVMStructureType() {
   return llvmImplType;
 }
-#endif
 
 // get pointer to structure type for class
 llvm::Type* TypeSymbol::getLLVMType() {


### PR DESCRIPTION
Instead of getPointerElementType(), use the type stored in TypeSymbols.