### PR TITLE
Fix checking for .chpl suffix on too-short filenames

### DIFF
--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1233,10 +1233,9 @@ const owned<ResolvedVisibilityScope>& resolveVisibilityStmtsQuery(
     for (auto req : requireNodes) {
       for (const AstNode* child : req->children()) {
         if (const StringLiteral* str = child->toStringLiteral()) {
-          const auto& path = str->value().str();
-          const std::string suffix = ".chpl";
-          if (path.compare(path.size() - suffix.size(), suffix.size(), suffix) == 0) {
-            parsing::parseFileToBuilderResult(context, str->value(), UniqueString());
+          const UniqueString path = str->value();
+          if (path.endsWith(".chpl")) {
+            parsing::parseFileToBuilderResult(context, path, UniqueString());
           }
         }
       }


### PR DESCRIPTION
Fixes an out-of-bounds error which occurred when trying to manually check for the `.chpl` suffix on the name of a required file. In this instance, the filename `cf.h` was shorter than the length of the suffix, so we were trying to check beginning from a negative index (which underflows).

Relies on `UniqueString::endsWith` introduced in https://github.com/chapel-lang/chapel/pull/21328, so will be merged and tested after that.

Resolves https://github.com/Cray/chapel-private/issues/4231.

[reviewer info placeholder]

Testing:
- [ ] paratest