### PR TITLE
Delete an extra .good file I accidentally added to the test/ directory

### DIFF
--- a/test/with-runtime-fields-errors.done.good
+++ b/test/with-runtime-fields-errors.done.good
@@ -1,3 +1,0 @@
-with-runtime-fields-errors.chpl:2: In module 'w':
-with-runtime-fields-errors.chpl:27: warning: creating a 'new borrowed' type is deprecated
-done


### PR DESCRIPTION
This .good file is at the top-level test directory and isn't used by any test. Remove it.