### PR TITLE
Simplify a range iterator's check for an empty/degenerate range

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2625,7 +2625,8 @@ operator :(r: range(?), type t: range(?)) {
       // relational operator. Such ranges are supposed to iterate 0 times
       var i: intIdxType;
       const start = chpl_firstAsIntForIter;
-      const end: intIdxType = if chpl__idxToInt(lowBoundForIter(this)) > chpl__idxToInt(highBoundForIter(this)) then start else chpl_lastAsIntForIter + stride: intIdxType;
+      const end: intIdxType = if this._low > this._high then start
+                              else chpl_lastAsIntForIter + stride: intIdxType;
       while __primitive("C for loop",
                         __primitive( "=", i, start),
                         __primitive("!=", i, end),


### PR DESCRIPTION
In implementing #21332, I changed a degenerate range check from comparing ._low and ._high to something involving more helper routines and translating between representations.  This resulted in generating code that caused the C compiler to warn about comparisons that were tautologically true or false (like how the following will never be true):

```
if ((int)(x == y) > (int)true)
```

Here, I'm changing them back, which simplifies the code for readers, doesn't break any of the new tests I added, and makes the warnings go away (ironically, probably just by making the values less evident to the C compiler :).

We also saw some performance regressions in our nightly runs, and I'm wondering whether this could have been a factor.  On one hand, it's a long-shot that this happens to be it; on the other hand, it did complicate an expression somewhat.