### PR TITLE
Simplify the implementation of chpl__first|lastForIter for bounded ranges

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -956,20 +956,24 @@ module ChapelRange {
 
   pragma "no doc"
   inline proc range.chpl_firstAsIntForIter {
-    if ! stridable {
-      return chpl__idxToInt(lowBoundForIter(this));
+    if this.boundedType == BoundedRangeType.bounded {
+      return this.firstAsInt;
     } else {
-      if _stride > 0 {
-        if hasLowBound() {
-          return helpAlignLow(chpl__idxToInt(lowBoundForIter(this)), _alignment, _stride);
-        } else {
-          return chpl__idxToInt(lowBoundForIter(this));
-        }
+      if ! stridable {
+        return chpl__idxToInt(lowBoundForIter(this));
       } else {
-        if hasHighBound() {
-          return helpAlignHigh(chpl__idxToInt(highBoundForIter(this)), _alignment, _stride);
+        if _stride > 0 {
+          if hasLowBound() {
+            return helpAlignLow(chpl__idxToInt(lowBoundForIter(this)), _alignment, _stride);
+          } else {
+            return chpl__idxToInt(lowBoundForIter(this));
+          }
         } else {
-          return chpl__idxToInt(highBoundForIter(this));
+          if hasHighBound() {
+            return helpAlignHigh(chpl__idxToInt(highBoundForIter(this)), _alignment, _stride);
+          } else {
+            return chpl__idxToInt(highBoundForIter(this));
+          }
         }
       }
     }
@@ -1007,12 +1011,16 @@ module ChapelRange {
 
   pragma "no doc"
   inline proc range.chpl_lastAsIntForIter {
-    if ! stridable {
-      return chpl__idxToInt(highBoundForIter(this));
-    } else if _stride > 0 {
-      return helpAlignHigh(chpl__idxToInt(highBoundForIter(this)), _alignment, _stride);
+    if this.boundedType == BoundedRangeType.bounded {
+      return this.lastAsInt;
     } else {
-      return helpAlignLow(chpl__idxToInt(lowBoundForIter(this)), _alignment, _stride);
+      if ! stridable {
+        return chpl__idxToInt(highBoundForIter(this));
+      } else if _stride > 0 {
+        return helpAlignHigh(chpl__idxToInt(highBoundForIter(this)), _alignment, _stride);
+      } else {
+        return helpAlignLow(chpl__idxToInt(lowBoundForIter(this)), _alignment, _stride);
+      }
     }
   }
 


### PR DESCRIPTION
Looking at the 'anonymousRangeIter' failure caused by merging #21332, it appeared the the expression for computing the first/last element in a typical bounded range iteration had become more complicated by my refactoring.  Here, I'm splitting the common case of a completely bounded range into its own case and handling it identically to how we did prior to #21332, which should limit the complicated cases to iterations over unbounded ranges of enum and bool (the motivation for my refactoring).  This resolves the anonymousRangeIter test and makes the generated code much more similar to what we had before.

This change seems more likely to affect/improve the performance of range iteration than #21405, so I am cautiously optimistic that it will restore the performance of cases that slipped as tracked in https://github.com/Cray/chapel-private/issues/4228
