### PR TITLE
Warn for partial instantiations without '?'

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3406,23 +3406,20 @@ static void warnForPartialInstantantiationNoQ(CallExpr* call, Type* t) {
         Type* tt = canonicalClassType(t);
         if (tt && tt->symbol->hasFlag(FLAG_GENERIC)) {
           // print out which field
-          USR_WARN(checkCall, "type construction call is surprisingly generic");
-          USR_PRINT(checkCall, "it does not set all generic fields so the result is generic");
-          USR_PRINT(checkCall, "to fully instantiate, add type constructor arguments");
-          USR_PRINT(checkCall, "or, opt in to partial instantiation with trailing '?' argument");
-          // which field name is generic?
+          USR_WARN(checkCall, "partial instantiation without '?' argument");
+          USR_PRINT(checkCall, "opt in to partial instantiation explicitly with a trailing '?' argument");
+          USR_PRINT(checkCall, "or, add arguments to instantiate the following fields in generic type '%s':", tt->symbol->name);
+         // to fully instantiate, add type constructor arguments for the following uninstantiated generic fields in '%s'", tt->symbol->name);
+          // which field names are generic?
           if (AggregateType* at = toAggregateType(tt)) {
-            Symbol* firstGenericField = nullptr;
             for_fields(field, at) {
               if (field->type == dtUnknown ||
                   field->type->symbol->hasFlag(FLAG_GENERIC)) {
-                firstGenericField = field;
-                break;
+                const char* k = "";
+                if (field->hasFlag(FLAG_TYPE_VARIABLE)) k = " type";
+                else if (field->hasFlag(FLAG_PARAM)) k = " param";
+                USR_PRINT(field, "  generic%s field '%s'", k, field->name);
               }
-            }
-            if (firstGenericField) {
-              USR_PRINT(firstGenericField, "the generic field '%s' is not set in the type construction call",
-                        firstGenericField->name);
             }
           }
         }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3405,7 +3405,26 @@ static void warnForPartialInstantantiationNoQ(CallExpr* call, Type* t) {
       if (!foundQuestionMarkArg) {
         Type* tt = canonicalClassType(t);
         if (tt && tt->symbol->hasFlag(FLAG_GENERIC)) {
-          USR_WARN(checkCall, "partial instantiation should use ?");
+          // print out which field
+          USR_WARN(checkCall, "type construction call is surprisingly generic");
+          USR_PRINT(checkCall, "it does not set all generic fields so the result is generic");
+          USR_PRINT(checkCall, "to fully instantiate, add type constructor arguments");
+          USR_PRINT(checkCall, "or, opt in to partial instantiation with trailing '?' argument");
+          // which field name is generic?
+          if (AggregateType* at = toAggregateType(tt)) {
+            Symbol* firstGenericField = nullptr;
+            for_fields(field, at) {
+              if (field->type == dtUnknown ||
+                  field->type->symbol->hasFlag(FLAG_GENERIC)) {
+                firstGenericField = field;
+                break;
+              }
+            }
+            if (firstGenericField) {
+              USR_PRINT(firstGenericField, "the generic field '%s' is not set in the type construction call",
+                        firstGenericField->name);
+            }
+          }
         }
       }
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3439,6 +3439,23 @@ static Type* resolveTypeSpecifier(CallInfo& info) {
         again->remove();
       }
     }
+
+    bool foundQuestionMarkArg = false;
+    for_actuals(actual, call) {
+      if (SymExpr* se = toSymExpr(actual)) {
+        if (se->symbol() == gUninstantiated) {
+          foundQuestionMarkArg = true;
+        }
+      }
+    }
+
+    // is the resulting type generic?
+    if (ret && !foundQuestionMarkArg && call->numActuals() > 0) {
+      Type* t = canonicalClassType(ret);
+      if (t && t->symbol->hasFlag(FLAG_GENERIC)) {
+        USR_WARN(call, "partial instantiation should use ?");
+      }
+    }
   }
 
   if (ret != NULL) {

--- a/modules/packages/Channel.chpl
+++ b/modules/packages/Channel.chpl
@@ -276,8 +276,8 @@ module Channel {
     var recvIdx = 0;
     var count = 0;
     var closed = false;
-    var sendWaiters : WaiterQueue;
-    var recvWaiters : WaiterQueue;
+    var sendWaiters : owned WaiterQueue;
+    var recvWaiters : owned WaiterQueue;
     var lock$ = new _LockWrapper();
 
     proc init(type elt, size = 0) {

--- a/test/classes/initializers/initequals/changing-param-field.chpl
+++ b/test/classes/initializers/initequals/changing-param-field.chpl
@@ -52,7 +52,7 @@ proc main() {
   var d:R = start; // specified generic type
   writeln(d.type:string, " ", d);
 
-  var e:R(true) = start; // specified partial type
+  var e:R(true, ?) = start; // specified partial type
   writeln(e.type:string, " ", e);
   
   var f:R(true, true) = start; // specified concrete type

--- a/test/constrained-generics/basic/set2/record-instantiations.chpl
+++ b/test/constrained-generics/basic/set2/record-instantiations.chpl
@@ -18,14 +18,14 @@ interface IFC {
               formal2: AT
               ): RR(Self);
   type AT;
-  implements I2(PP(AT));
+  implements I2(PP(AT, ?));
 }
 
 int implements IFC;
 proc int.AT type return string;
 
 interface I2 { }
-implements I2(PP(string));
+implements I2(PP(string, ?));
 
 proc reqFn(formal1: RR(int),
            formal2: PP(RR(int)),

--- a/test/library/draft/DistributedMap/v2/DistributedMap.chpl
+++ b/test/library/draft/DistributedMap/v2/DistributedMap.chpl
@@ -32,7 +32,7 @@ module DistributedMap {
     type keyType;
     type valType;
     pragma "no doc"
-    var m: shared distributedMapImpl(keyType, valType)?;
+    var m: shared distributedMapImpl(keyType, valType, ?)?;
     forwarding m!;
 
     proc init(type keyType, type valType) {

--- a/test/library/draft/DistributedMap/v3/DistributedMap.chpl
+++ b/test/library/draft/DistributedMap/v3/DistributedMap.chpl
@@ -13,7 +13,7 @@ module DistributedMap {
         type keyType;
         type valType;
 
-        var instance: shared distMapInternal(keyType, valType)?;
+        var instance: shared distMapInternal(keyType, valType, ?)?;
         forwarding instance!;
 
         proc init(type keyType, type valType) {

--- a/test/library/standard/List/initEquals/list-init-eq-many.chpl
+++ b/test/library/standard/List/initEquals/list-init-eq-many.chpl
@@ -36,9 +36,9 @@ proc initCopyFromList() {
 
   var a: list = x;
   writeln("a:", a.type:string, " = ", a);
-  var b: list(parSafe=false) = x;
+  var b: list(parSafe=false, ?) = x;
   writeln("b:", b.type:string, " = ", b);
-  var c: list(parSafe=true) = x;
+  var c: list(parSafe=true, ?) = x;
   writeln("c:", c.type:string, " = ", c);
 
   var y:list(parSafe=true, int);
@@ -47,9 +47,9 @@ proc initCopyFromList() {
 
   var d: list = y;
   writeln("d:", d.type:string, " = ", d);
-  var e: list(parSafe=false) = y;
+  var e: list(parSafe=false, ?) = y;
   writeln("e:", e.type:string, " = ", e);
-  var f: list(parSafe=true) = y;
+  var f: list(parSafe=true, ?) = y;
   writeln("f:", f.type:string, " = ", f);
 
   // other forms
@@ -95,9 +95,9 @@ proc initCopyFromArray() {
 
   var a: list = x;
   writeln("a:", a.type:string, " = ", a);
-  var b: list(parSafe=false) = x;
+  var b: list(parSafe=false, ?) = x;
   writeln("b:", b.type:string, " = ", b);
-  var c: list(parSafe=true) = x;
+  var c: list(parSafe=true, ?) = x;
   writeln("c:", c.type:string, " = ", c);
 
   var z:[1..2] int(8) = (1:int(8))..(2:int(8));
@@ -135,9 +135,9 @@ proc initCopyFromRange() {
 
   var a: list = x;
   writeln("a:", a.type:string, " = ", a);
-  var b: list(parSafe=false) = x;
+  var b: list(parSafe=false, ?) = x;
   writeln("b:", b.type:string, " = ", b);
-  var c: list(parSafe=true) = x;
+  var c: list(parSafe=true, ?) = x;
   writeln("c:", c.type:string, " = ", c);
 
   var z = (1:int(8))..(2:int(8));
@@ -183,9 +183,9 @@ proc initCopyFromIter() {
   writeln("b:", b.type:string, " = ", b);
   var c:list = (1..2).these();
   writeln("c:", c.type:string, " = ", c);
-  var d:list(parSafe=false) = [i in 1..2] i;
+  var d:list(parSafe=false, ?) = [i in 1..2] i;
   writeln("d:", d.type:string, " = ", d);
-  var e:list(parSafe=true) = myIter();
+  var e:list(parSafe=true, ?) = myIter();
   writeln("e:", e.type:string, " = ", e);
 
   var j: list(int) = for i in 1..2 do i:int(8);

--- a/test/types/partial/bad-managed-init.chpl
+++ b/test/types/partial/bad-managed-init.chpl
@@ -8,7 +8,7 @@ class C {
 
 proc main() {
   if useOwned then
-    var o : owned C(int) = new owned C(real, 4);
+    var o : owned C(int, ?) = new owned C(real, 4);
   else
-    var s : shared C(int) = new shared C(real, 4);
+    var s : shared C(int, ?) = new shared C(real, 4);
 }

--- a/test/types/partial/default-init-generic2.chpl
+++ b/test/types/partial/default-init-generic2.chpl
@@ -10,9 +10,9 @@ record R {
 }
 
 proc main() {
-  var B : R(real);
+  var B : R(real, ?);
   writeln(B.type:string, ": ", B);
 
-  var C : R(n=3);
+  var C : R(n=3, ?);
   writeln(C.type:string, ": ", C);
 }

--- a/test/types/partial/inOrder.chpl
+++ b/test/types/partial/inOrder.chpl
@@ -18,8 +18,8 @@ proc makeRIS(type X, param x : int) {
 }
 
 proc testAliases() {
-  type RI = R(int);
-  type RIS = RI(string);
+  type RI = R(int, ?);
+  type RIS = RI(string, ?);
   type RIS5 = RIS(5);
 
   writeln("RI = ", RI:string);
@@ -40,11 +40,11 @@ proc testFunctions() {
   writeln(A.type:string);
   writeln(A);
 
-  var B = makeRI(R(int), string, 5);
+  var B = makeRI(R(int, ?), string, 5);
   writeln(B.type:string);
   writeln(B);
 
-  var C = makeRIS(R(int, string), 5);
+  var C = makeRIS(R(int, string, ?), 5);
   writeln(C.type:string);
   writeln(C);
 }

--- a/test/types/partial/inheritance.chpl
+++ b/test/types/partial/inheritance.chpl
@@ -25,18 +25,18 @@ class Z : Y {
 
 proc main() {
   {
-    type A = Child(T=int, U=real);
+    type A = Child(T=int, U=real, ?);
     writeln(A:string);
-    type B = A(y=5.0);
+    type B = A(y=5.0, ?);
     writeln(B:string);
     type C = B(100);
     writeln(C:string);
   }
   writeln();
   {
-    type A = Z(T=int, p=100);
+    type A = Z(T=int, p=100, ?);
     writeln(A:string);
-    type B = A(U=real);
+    type B = A(U=real, ?);
     writeln(B:string);
     type C = B(false, 123.456);
     writeln(C:string);

--- a/test/types/partial/initeq.chpl
+++ b/test/types/partial/initeq.chpl
@@ -35,7 +35,7 @@ proc helper(type T, val) {
 
 proc main() {
   {
-    var r : R(string) = "hi";
+    var r : R(string, ?) = "hi";
     writeln(r.type:string);
     writeln(r.p);
   }

--- a/test/types/partial/invalid-set-param-again-type-ctor.chpl
+++ b/test/types/partial/invalid-set-param-again-type-ctor.chpl
@@ -3,5 +3,5 @@ record T {
   param otherParamField;
 }
 
-type T1 = T(paramField=1);
+type T1 = T(paramField=1, ?);
 var x: T1(paramField=2, otherParamField=5); // Should complain

--- a/test/types/partial/isFieldBound.chpl
+++ b/test/types/partial/isFieldBound.chpl
@@ -9,7 +9,7 @@ record R {
 }
 
 proc main() {
-  type T = R(int, U=real);
+  type T = R(int, U=real, ?);
 
   for param i in 0..<numFields(T) {
     param name = getFieldName(T, i);

--- a/test/types/partial/managed-alias.chpl
+++ b/test/types/partial/managed-alias.chpl
@@ -9,12 +9,12 @@ proc main() {
     type A = MyClass;
     type B = unmanaged A;
     writeln(B:string);
-    type C = B(int);
+    type C = B(int, ?);
     writeln(C:string);
     type D = C(5);
     writeln(D:string);
 
-    type X = B(n=5);
+    type X = B(n=5, ?);
     writeln(X:string);
     type Y = X(int);
     writeln(Y:string);
@@ -24,12 +24,12 @@ proc main() {
     type A = MyClass;
     type B = borrowed A;
     writeln(B:string);
-    type C = B(int);
+    type C = B(int, ?);
     writeln(C:string);
     type D = C(5);
     writeln(D:string);
 
-    type X = B(n=5);
+    type X = B(n=5, ?);
     writeln(X:string);
     type Y = X(int);
     writeln(Y:string);
@@ -39,12 +39,12 @@ proc main() {
     type A = MyClass;
     type B = owned A;
     writeln(B:string);
-    type C = B(int);
+    type C = B(int, ?);
     writeln(C:string);
     type D = C(5);
     writeln(D:string);
 
-    type X = B(n=5);
+    type X = B(n=5, ?);
     writeln(X:string);
     type Y = X(int);
     writeln(Y:string);
@@ -54,12 +54,12 @@ proc main() {
     type A = MyClass;
     type B = shared A;
     writeln(B:string);
-    type C = B(int);
+    type C = B(int, ?);
     writeln(C:string);
     type D = C(5);
     writeln(D:string);
 
-    type X = B(n=5);
+    type X = B(n=5, ?);
     writeln(X:string);
     type Y = X(int);
     writeln(Y:string);

--- a/test/types/partial/outOfOrder.chpl
+++ b/test/types/partial/outOfOrder.chpl
@@ -14,9 +14,9 @@ record D {
 proc main() {
   {
     writeln("----- middle-first-last -----");
-    type R_S_ = R(U=string);
+    type R_S_ = R(U=string, ?);
     writeln(R_S_:string);
-    type RIS_ = R_S_(int);
+    type RIS_ = R_S_(int, ?);
     writeln(RIS_:string);
     type RIS5 = RIS_(5);
     writeln(RIS5:string);
@@ -24,8 +24,8 @@ proc main() {
 
   {
     writeln("----- middle-last-first -----");
-    type R_S_ = R(U=string);
-    type R_S5 = R_S_(x=5);
+    type R_S_ = R(U=string, ?);
+    type R_S5 = R_S_(x=5, ?);
     writeln(R_S5:string);
     type RIS5 = R_S5(int);
     writeln(RIS5:string);
@@ -33,7 +33,7 @@ proc main() {
 
   {
     writeln("----- first-last-middle -----");
-    type RI_5 = R(int, x=5);
+    type RI_5 = R(int, x=5, ?);
     writeln(RI_5:string);
     type RIS5 = RI_5(string);
     writeln(RIS5:string);
@@ -41,7 +41,7 @@ proc main() {
 
   {
     writeln("----- first-last-dependent -----");
-    type DU_5 = D(uint(8), p=55);
+    type DU_5 = D(uint(8), p=55, ?);
     writeln(DU_5:string);
   }
 }

--- a/test/types/partial/owned-shared.chpl
+++ b/test/types/partial/owned-shared.chpl
@@ -20,24 +20,24 @@ proc print(x) {
 proc testOwned() {
   var a : owned Parent = new owned Parent(int, 3);
   print(a);
-  var b : owned Parent(int) = new owned Parent(int, 3);
+  var b : owned Parent(int, ?) = new owned Parent(int, 3);
   print(b);
 
   var c : owned Parent = new owned Child(int, 3, U=real);
   print(c);
-  var d : owned Child(int) = new owned Child(int, 3 , U=real);
+  var d : owned Child(int, ?) = new owned Child(int, 3 , U=real);
   print(d);
 }
 
 proc testShared() {
   var a : shared Parent = new shared Parent(int, 3);
   print(a);
-  var b : shared Parent(int) = new shared Parent(int, 3);
+  var b : shared Parent(int, ?) = new shared Parent(int, 3);
   print(b);
 
   var c : shared Parent = new shared Child(int, 3, U=real);
   print(c);
-  var d : shared Child(int) = new shared Child(int, 3 , U=real);
+  var d : shared Child(int, ?) = new shared Child(int, 3 , U=real);
   print(d);
 }
 

--- a/test/types/partial/partial-no-q-warning.chpl
+++ b/test/types/partial/partial-no-q-warning.chpl
@@ -1,0 +1,7 @@
+record r {
+  type t;
+  type tt;
+}
+
+type t = r(int);
+var x: t(real);

--- a/test/types/partial/partial-no-q-warning.chpl
+++ b/test/types/partial/partial-no-q-warning.chpl
@@ -13,3 +13,11 @@ class C {
 
 type tt = unmanaged C(1)?;
 var y: tt(2);
+
+record rr {
+  var x;
+  var y;
+}
+
+type ttt = rr(real);
+var z: ttt(int);

--- a/test/types/partial/partial-no-q-warning.chpl
+++ b/test/types/partial/partial-no-q-warning.chpl
@@ -5,3 +5,11 @@ record r {
 
 type t = r(int);
 var x: t(real);
+
+class C {
+  param p1;
+  param p2;
+}
+
+type tt = unmanaged C(1)?;
+var y: tt(2);

--- a/test/types/partial/partial-no-q-warning.good
+++ b/test/types/partial/partial-no-q-warning.good
@@ -1,10 +1,12 @@
-partial-no-q-warning.chpl:6: warning: type construction call is surprisingly generic
-partial-no-q-warning.chpl:6: note: it does not set all generic fields so the result is generic
-partial-no-q-warning.chpl:6: note: to fully instantiate, add type constructor arguments
-partial-no-q-warning.chpl:6: note: or, opt in to partial instantiation with trailing '?' argument
-partial-no-q-warning.chpl:3: note: the generic field 'tt' is not set in the type construction call
-partial-no-q-warning.chpl:14: warning: type construction call is surprisingly generic
-partial-no-q-warning.chpl:14: note: it does not set all generic fields so the result is generic
-partial-no-q-warning.chpl:14: note: to fully instantiate, add type constructor arguments
-partial-no-q-warning.chpl:14: note: or, opt in to partial instantiation with trailing '?' argument
-partial-no-q-warning.chpl:11: note: the generic field 'p2' is not set in the type construction call
+partial-no-q-warning.chpl:6: warning: partial instantiation without '?' argument
+partial-no-q-warning.chpl:6: note: opt in to partial instantiation explicitly with a trailing '?' argument
+partial-no-q-warning.chpl:6: note: or, add arguments to instantiate the following fields in generic type 'r(int(64))':
+partial-no-q-warning.chpl:3: note:   generic type field 'tt'
+partial-no-q-warning.chpl:14: warning: partial instantiation without '?' argument
+partial-no-q-warning.chpl:14: note: opt in to partial instantiation explicitly with a trailing '?' argument
+partial-no-q-warning.chpl:14: note: or, add arguments to instantiate the following fields in generic type 'C(1)':
+partial-no-q-warning.chpl:11: note:   generic param field 'p2'
+partial-no-q-warning.chpl:22: warning: partial instantiation without '?' argument
+partial-no-q-warning.chpl:22: note: opt in to partial instantiation explicitly with a trailing '?' argument
+partial-no-q-warning.chpl:22: note: or, add arguments to instantiate the following fields in generic type 'rr(real(64))':
+partial-no-q-warning.chpl:19: note:   generic field 'y'

--- a/test/types/partial/partial-no-q-warning.good
+++ b/test/types/partial/partial-no-q-warning.good
@@ -1,1 +1,10 @@
-partial-no-q-warning.chpl:6: warning: partial instantiation should use ?
+partial-no-q-warning.chpl:6: warning: type construction call is surprisingly generic
+partial-no-q-warning.chpl:6: note: it does not set all generic fields so the result is generic
+partial-no-q-warning.chpl:6: note: to fully instantiate, add type constructor arguments
+partial-no-q-warning.chpl:6: note: or, opt in to partial instantiation with trailing '?' argument
+partial-no-q-warning.chpl:3: note: the generic field 'tt' is not set in the type construction call
+partial-no-q-warning.chpl:14: warning: type construction call is surprisingly generic
+partial-no-q-warning.chpl:14: note: it does not set all generic fields so the result is generic
+partial-no-q-warning.chpl:14: note: to fully instantiate, add type constructor arguments
+partial-no-q-warning.chpl:14: note: or, opt in to partial instantiation with trailing '?' argument
+partial-no-q-warning.chpl:11: note: the generic field 'p2' is not set in the type construction call

--- a/test/types/partial/partial-no-q-warning.good
+++ b/test/types/partial/partial-no-q-warning.good
@@ -1,0 +1,1 @@
+partial-no-q-warning.chpl:6: warning: partial instantiation should use ?

--- a/test/types/partial/partial-type-alias-generic.chpl
+++ b/test/types/partial/partial-type-alias-generic.chpl
@@ -6,7 +6,7 @@ record G {
   param q;
 }
 
-type GT = G(p=true);
+type GT = G(p=true, ?);
 
 record R {
   param q;

--- a/test/types/partial/partialIsSubtype.chpl
+++ b/test/types/partial/partialIsSubtype.chpl
@@ -4,11 +4,11 @@ class QuiteGeneric {
   var x;
 }
 
-type partial1 = QuiteGeneric(int);
+type partial1 = QuiteGeneric(int, ?);
 writeln(partial1: string);
 writeln(isSubtype(partial1, QuiteGeneric)); // true
 
-type partial2 = QuiteGeneric(int, 3);
+type partial2 = QuiteGeneric(int, 3, ?);
 writeln(partial2: string);
 writeln(isSubtype(partial2, QuiteGeneric)); // true
 writeln(isSubtype(partial2, partial1)); // true

--- a/test/types/partial/partialTypeFormal.chpl
+++ b/test/types/partial/partialTypeFormal.chpl
@@ -6,7 +6,7 @@ record R {
   param n : int;
 }
 
-proc foo(type T, x : T(int)) {
+proc foo(type T, x : T(int, ?)) {
   writeln(x.type:string, ": ", x);
 }
 

--- a/test/types/partial/partialTypeFormal.error.good
+++ b/test/types/partial/partialTypeFormal.error.good
@@ -1,5 +1,4 @@
 partialTypeFormal.chpl:13: In function 'main':
 partialTypeFormal.chpl:19: error: unresolved call 'foo(type R, R(real(64),5))'
-partialTypeFormal.chpl:9: note: this candidate did not match: foo(type T, x: T(int))
-partialTypeFormal.chpl:19: note: because actual argument #2 with type 'R(real(64),5)'
-partialTypeFormal.chpl:9: note: is passed to formal 'x: R(int(64))'
+partialTypeFormal.chpl:9: note: this candidate did not match: foo(type T, x: T(int, ?))
+partialTypeFormal.chpl:9: note: because an argument was incompatible

--- a/test/types/records/generic/partial-instantiation-equivalence.chpl
+++ b/test/types/records/generic/partial-instantiation-equivalence.chpl
@@ -2,8 +2,8 @@ record R {
   param x, y;
 }
 
-type Rx = R(x=1);
-type Ry = R(y=1);
+type Rx = R(x=1, ?);
+type Ry = R(y=1, ?);
 
 writeln("Rx == Rx: ", Rx == Rx);
 writeln("Rx == Ry: ", Rx == Ry);


### PR DESCRIPTION
This PR is intended to resolve #18665. It adds a warning for partial instantiations that do not include a `?` argument.

Chapel supports partial instantiations when some, but not all, arguments are provided to the type constructor for a generic type. So, partial instantiations are generic (vs complete instantiations which are concrete). Partial instantiations are described in the technote: https://chapel-lang.org/docs/technotes/partialInstantiations.html

Now, a partial instantiation can end with `?` to indicate "the rest is generic". This syntax can also be useful when working with a type with generic defaults. For example, `range(?)` refers to a generic type but `range` refers to the type with the defaults applied (although we are thinking of changing that).

At the same time, it has come up before that a partial instantiation is accidentally created when some type construction arguments are missing. However, the code can clearly indicate that a generic type (a partial instantiation and not a full instantiation) is desired by using the `?` argument. By having a warning when that is not done, code that does not cause the warning has the property that a type construction call like `someType(a, b, c)` always produces a concrete type. That can make it easier to understand at a glance whether or not a type is generic (and, in particular, misunderstanding about when a field is generic can cause problems). Additionally, partial instantiation is a relatively advanced feature and we don't want people to accidentally use it if they forget to provide an argument for a type construction call.

So, this PR adjusts the compiler to emit a warning for partial instantiations that do not include `?` as an argument.

For example:

``` chapel
record GenericRecord {
 type indexType;
 type elementType;
}

GenericRecord(int)       // warning: this partial instantiation needs a ?
GenericRecord(int, ?)    // OK, partial instantiation using ? to be clear
GenericRecord(int, real) // OK, it is a concrete type / full instantiation
GenericRecord            // OK, it is a generic type & not a partial instantiation
```

It is a draft PR in order to stimulate discussion about this language design direction.

Here is an example of the warning:

aa.chpl:
```
1 record r {
2   type t;
3   type tt;
4 }
5
6 type t = r(int);
```

```
aa.chpl:1: In module 'aa':
aa.chpl:6: warning: partial instantiation without '?' argument
aa.chpl:6: note: opt in to partial instantiation explicitly with a trailing '?' argument
aa.chpl:6: note: or, add arguments to instantiate the following fields in generic type 'r(int(64))':
aa.chpl:3: note:   generic type field 'tt'
```

Reviewed by @benharsh - thanks!

- [x] full local futures testing