### PR TITLE
Fix one-element array literals in skipif'd tests

### DIFF
--- a/test/gpu/native/localeName.chpl
+++ b/test/gpu/native/localeName.chpl
@@ -2,7 +2,7 @@ use Subprocess;
 use IO;
 
 // get the hostname of the host running this test
-var sub = spawn(["hostname"], stdout=pipeStyle.pipe); sub.wait();
+var sub = spawn(["hostname", ], stdout=pipeStyle.pipe); sub.wait();
 var hostname: string;
 sub.stdout.readln(hostname);
 

--- a/test/library/standard/Spawn/spawn-checkmutate.chpl
+++ b/test/library/standard/Spawn/spawn-checkmutate.chpl
@@ -8,7 +8,7 @@ use Subprocess;
 }
 
 {
-  var runit = spawn(["./mutate-args", "a", "bc", "def"], ["test=test"]);
+  var runit = spawn(["./mutate-args", "a", "bc", "def"], ["test=test", ]);
   runit.wait();
   assert(runit.exitCode == 0);
 }

--- a/test/library/standard/Spawn/spawn-checkret.chpl
+++ b/test/library/standard/Spawn/spawn-checkret.chpl
@@ -8,7 +8,7 @@ use Subprocess;
 }
 
 {
-  var runit = spawn(["./return-10"]);
+  var runit = spawn(["./return-10", ]);
   runit.wait();
   assert(runit.exitCode == 10);
 }

--- a/test/library/standard/Spawn/spawn-print-args-env.chpl
+++ b/test/library/standard/Spawn/spawn-print-args-env.chpl
@@ -8,14 +8,14 @@ use Subprocess;
 }
 
 {
-  var runit = spawn(["./print-args-env", "a", "bc", "def"], ["test=test"]);
+  var runit = spawn(["./print-args-env", "a", "bc", "def"], ["test=test", ]);
   runit.wait();
   assert(runit.exitCode == 0);
 }
 
 config const printEnv = false;
 if printEnv {
-  var runit = spawn(["./print-args-env"]);
+  var runit = spawn(["./print-args-env", ]);
   runit.wait();
   assert(runit.exitCode == 0);
 }


### PR DESCRIPTION
This is a follow up to #21337 that adds a trailing comma to tests that
use 1-element array literals but are not part of the standard paratest
configuration (gnu-specific tests in one case; gpu-specific in the other).
