### PR TITLE
Switch performance run of revcomp-blc-gcc8-algs to use 'waitFor' algorithm

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.perfcompopts
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.perfcompopts
@@ -1,1 +1,1 @@
--swaitAlg=Spin -sshiftAlg=SerForall -ssearchAlg=MemChr
+-swaitAlg=WaitFor -sshiftAlg=SerForall -ssearchAlg=MemChr


### PR DESCRIPTION
I originally wrote this performance test to use the spin-wait to see whether it was more stable than revcomp-blc-gcc8.chpl, but with CHPL_ATOMICS=intrinsics, as when using 'intel' compilers, the performance due to the contested reads is waaaay too slow.  I think switching to the waitFor() algorithm should be enough to speed it up, and is the preferred way to write this anyway.  If this doesn't fix the timeout, I'll add a skipif or suppressif...
