### PR TITLE
dyno: avoid a gcc warning

### DIFF
--- a/frontend/test/resolution/testDeprecationUnstable.cpp
+++ b/frontend/test/resolution/testDeprecationUnstable.cpp
@@ -65,7 +65,7 @@ mentionNameFromExpression(const AstNode* ast, bool isReceiver) {
   return UniqueString();
 }
 
-std::vector<const NamedDecl*> collectAllNamedDecls(const AstNode* ast) {
+static std::vector<const NamedDecl*> collectAllNamedDecls(const AstNode* ast) {
   std::vector<const NamedDecl*> ret;
   for (auto ast : ast->children()) {
     auto v = collectAllNamedDecls(ast);


### PR DESCRIPTION
This PR fixes warning from GCC 12 that appeared after PR #21328 when running `make test-dyno`.

Trivial and not reviewed.