### PR TITLE
Fix topo/comm initialization sequence.

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -185,6 +185,12 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len);
 int32_t chpl_comm_getMaxThreads(void);
 
 
+// initialization required to enable comm calls made by the topo layer
+// during its initialization, specifically:
+//  * chpl_get_num_locales_on_node
+//
+void chpl_comm_pre_topo_init(void);
+
 //
 // initializes the communications package
 //   set chpl_nodeID and chpl_numNodes

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -37,7 +37,6 @@ extern "C" {
 // initialize the topology support
 //
 void chpl_topo_init(void);
-void chpl_topo_post_comm_init(void);
 void chpl_topo_post_args_init(void);
 void chpl_topo_exit(void);
 

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -226,9 +226,9 @@ void chpl_rt_init(int argc, char* argv[]) {
   parseArgs(false, parse_dash_E, &argc, argv);
 
   chpl_error_init();  // This does local-only initialization
+  chpl_comm_pre_topo_init();
   chpl_topo_init();
   chpl_comm_init(&argc, &argv);
-  chpl_topo_post_comm_init();
   chpl_comm_pre_mem_init();
   chpl_mem_init();
   chpl_comm_post_mem_init();

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -836,6 +836,11 @@ static void set_num_comm_domains() {
 #endif
 }
 
+void chpl_comm_pre_topo_init(void) {
+  // not supported on this platform
+  chpl_set_num_locales_on_node(1);
+}
+
 void chpl_comm_init(int *argc_p, char ***argv_p) {
 //  int status; // Some compilers complain about unused variable 'status'.
 
@@ -930,9 +935,6 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
 #endif
 
   gasnet_set_waitmode(GASNET_WAIT_BLOCK);
-
-  // not supported on this platform
-  chpl_set_num_locales_on_node(1);
 }
 
 void chpl_comm_pre_mem_init(void) { }

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -107,10 +107,13 @@ int32_t chpl_comm_getMaxThreads(void) {
   return 0;
 }
 
+void chpl_comm_pre_topo_init(void) {
+  chpl_set_num_locales_on_node(1);
+}
+
 void chpl_comm_init(int *argc_p, char ***argv_p) {
   chpl_numNodes = 1;
   chpl_nodeID = 0;
-  chpl_set_num_locales_on_node(1);
 }
 
 void chpl_comm_pre_mem_init(void) { }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -991,7 +991,7 @@ static chpl_bool mrGetKey(uint64_t*, uint64_t*, int, void*, size_t);
 static chpl_bool mrGetLocalKey(void*, size_t);
 static chpl_bool mrGetDesc(void**, void*, size_t);
 
-void chpl_comm_init(int *argc_p, char ***argv_p) {
+void chpl_comm_pre_topo_init(void) {
   chpl_comm_ofi_abort_on_error =
     (chpl_env_rt_get("COMM_OFI_ABORT_ON_ERROR", NULL) != NULL);
   time_init();
@@ -1003,6 +1003,9 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   if (rank != -1) {
     chpl_set_local_rank(rank);
   }
+}
+
+void chpl_comm_init(int *argc_p, char ***argv_p) {
   //
   // Gather run-invariant environment info as early as possible.
   //
@@ -1048,10 +1051,9 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
 
 void chpl_comm_pre_mem_init(void) {
   //
-  // Reserve cores for the AM handlers. This is done here because it has
-  // to happen after chpl_topo_post_comm_init has been called, but before
-  // other functions access information about the cores, such as pinning the
-  // heap.
+  // Reserve cores for the AM handlers. This is done here because it has to
+  // happen after chpl_topo_init has been called, but before other functions
+  // access information about the cores, such as pinning the heap.
   //
   init_ofiReserveCores();
 }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1825,9 +1825,7 @@ int32_t chpl_comm_getMaxThreads(void)
   return 0;
 }
 
-
-void chpl_comm_init(int *argc_p, char ***argv_p)
-{
+void chpl_comm_pre_topo_init(void) {
   if (fork_op_num_ops > (1 << FORK_OP_BITS))
     CHPL_INTERNAL_ERROR("too many fork OPs for internal encoding");
 
@@ -1868,6 +1866,11 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
     CHPL_INTERNAL_ERROR("PMI_Get_numpes_in_app_on_smp() failed");
   }
   chpl_set_num_locales_on_node((int32_t) count);
+}
+
+
+void chpl_comm_init(int *argc_p, char ***argv_p)
+{
 
   {
     GNI_CHECK(GNI_GetDeviceType(&nic_type));

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -85,6 +85,8 @@ static hwloc_cpuset_t physAccSet = NULL;
 static hwloc_cpuset_t physReservedSet = NULL;
 static hwloc_cpuset_t logAccSet = NULL;
 
+static void cpuInfoInit(void);
+
 // Accessible NUMA nodes
 
 static hwloc_nodeset_t numaSet = NULL;
@@ -193,6 +195,8 @@ void chpl_topo_init(void) {
   //
 
   root = hwloc_get_root_obj(topology);
+
+  cpuInfoInit();
 }
 
 
@@ -235,15 +239,22 @@ static int numCPUsLogAll  = -1;
 
 int chpl_topo_getNumCPUsPhysical(chpl_bool accessible_only) {
   okToReserveCPU = false;
-  return (accessible_only) ? numCPUsPhysAcc : numCPUsPhysAll;
+  int cpus = (accessible_only) ? numCPUsPhysAcc : numCPUsPhysAll;
+  if (cpus == -1) {
+    chpl_error("number of cpus is uninitialized", 0, 0);
+  }
+  return cpus;
 }
 
 
 int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
   okToReserveCPU = false;
-  return (accessible_only) ? numCPUsLogAcc : numCPUsLogAll;
+  int cpus = (accessible_only) ? numCPUsLogAcc : numCPUsLogAll;
+  if (cpus == -1) {
+    chpl_error("number of cpus is uninitialized", 0, 0);
+  }
+  return cpus;
 }
-
 
 
 //
@@ -251,8 +262,8 @@ int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
 // toplogy.
 //
 
-void chpl_topo_post_comm_init(void) {
-  _DBG_P("chpl_topo_post_comm_init");
+static void cpuInfoInit(void) {
+  _DBG_P("cpuInfoInit");
   //
   // accessible cores and PUs
   //

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -33,9 +33,6 @@
 
 void chpl_topo_init(void) { }
 
-
-void chpl_topo_post_comm_init(void) { }
-
 void chpl_topo_post_args_init(void) { }
 
 void chpl_topo_exit(void) { }


### PR DESCRIPTION
The topology layer is initialized before the comm layer, however the topology layer calls `chpl_get_num_locales_on_node` during initialization, which requires that the comm layer be initialized enough to be able to provide this value. The new function `chpl_comm_pre_topo_init` does enough initialization so that `chpl_get_num_locales_on_node` returns the correct value. Also added error checking that the number of CPUs is set before it is used.

Resolves https://github.com/Cray/chapel-private/issues/4236 and closes https://github.com/Cray/chapel-private/issues/4281.

Also resolves https://github.com/Cray/chapel-private/issues/4229 and closes https://github.com/Cray/chapel-private/issues/4282. Initial experiments show that the performance of the tests that experienced regressions as a result of https://github.com/chapel-lang/chapel/pull/21057 has been corrected. Here are the results on a 16-node CS.

| Benchmark                                              | Units | pre-21057 | 21057  | this PR     |
|--------------------------------------------------------|-----------|-----------|--------|--------|
| HPCC: STREAM-EP Perf max stream-ep GB/s (gn-ibv-fast)  | GB/s |98.2      | 61.6   | 98.2   |
| NPB: FT Perf prim-comm ft MFlop/s (gn-ibv-fast)        | Mflops | 660289    | 555354 | 657552 |

\
Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>
