### PR TITLE
Address cases of stacking class memory management types in our code

### DIFF
--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1329,7 +1329,7 @@ module ChapelDomain {
       if isGenericType(eltType) {
         compilerWarning("creating an array with element type " +
                         eltType:string);
-        if isClassType(eltType) && !isGenericType(borrowed eltType) {
+        if isClassType(eltType) && !isGenericType(eltType:borrowed) {
           compilerWarning("which now means class type with generic management");
         }
         compilerError("array element type cannot currently be generic");

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -56,7 +56,7 @@ module SortedMap {
     if isGenericType(keyType) {
       compilerWarning("creating a sortedMap with key type " +
                       keyType:string);
-      if isClassType(keyType) && !isGenericType(borrowed keyType) {
+      if isClassType(keyType) && !isGenericType(keyType:borrowed) {
         compilerWarning("which now means class type with generic management");
       }
       compilerError("sortedMap key type cannot currently be generic");
@@ -68,7 +68,7 @@ module SortedMap {
     if isGenericType(valType) {
       compilerWarning("creating a sortedMap with value type " +
                       valType:string);
-      if isClassType(valType) && !isGenericType(borrowed valType) {
+      if isClassType(valType) && !isGenericType(valType:borrowed) {
         compilerWarning("which now means class type with generic management");
       }
       compilerError("sortedMap value type cannot currently be generic");

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -80,7 +80,7 @@ module Heap {
     if isGenericType(eltType) {
       compilerWarning("creating a heap with element type " +
                       eltType:string);
-      if isClassType(eltType) && !isGenericType(borrowed eltType) {
+      if isClassType(eltType) && !isGenericType(eltType:borrowed) {
         compilerWarning("which now means class type with generic management");
       }
       compilerError("heap element type cannot currently be generic");

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -107,7 +107,7 @@ module List {
     if isGenericType(eltType) {
       compilerWarning("creating a list with element type " +
                       eltType:string);
-      if isClassType(eltType) && !isGenericType(borrowed eltType) {
+      if isClassType(eltType) && !isGenericType(eltType:borrowed) {
         compilerWarning("which now means class type with generic management");
       }
       compilerError("list element type cannot currently be generic");

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -55,7 +55,7 @@ module Map {
   private proc _checkKeyAndValType(type K, type V) {
     if isGenericType(K) {
       compilerWarning('creating a map with key type ', K:string, 2);
-      if isClassType(K) && !isGenericType(borrowed K) {
+      if isClassType(K) && !isGenericType(K:borrowed) {
         compilerWarning('which now means class type with generic ',
                         'management', 2);
       }
@@ -63,7 +63,7 @@ module Map {
     }
     if isGenericType(V) {
       compilerWarning('creating a map with value type ', V:string, 2);
-      if isClassType(V) && !isGenericType(borrowed V) {
+      if isClassType(V) && !isGenericType(V:borrowed) {
         compilerWarning('which now means class type with generic ',
                         'management', 2);
       }

--- a/test/arrays/compilerErrors/arrayFieldOfSharedGenericClassType.chpl
+++ b/test/arrays/compilerErrors/arrayFieldOfSharedGenericClassType.chpl
@@ -1,0 +1,18 @@
+param entries:int = 4;
+
+record table {
+    param entries;
+    forwarding var columns: [0..entries-1] shared column;
+
+    proc init(param entries:int) {
+        this.entries = entries;
+	this.columns = [i in 0..entries-1] new shared column(entries);
+	}
+}
+
+class column {
+    param x:int;
+}
+
+var data = new table(entries);
+writeln(data);

--- a/test/arrays/compilerErrors/arrayFieldOfSharedGenericClassType.good
+++ b/test/arrays/compilerErrors/arrayFieldOfSharedGenericClassType.good
@@ -1,0 +1,4 @@
+arrayFieldOfSharedGenericClassType.chpl:7: In initializer:
+arrayFieldOfSharedGenericClassType.chpl:5: warning: creating an array with element type shared column
+arrayFieldOfSharedGenericClassType.chpl:5: error: array element type cannot currently be generic
+  arrayFieldOfSharedGenericClassType.chpl:17: called as table.init(param entries = 4)


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/issues/21417#issuecomment-1402165732, it was noted that our internal domain module code has been using stacking of memory management types (e.g., 'borrowed shared C') in order to print out its errors, which is no longer supported.  Here, I'm rewriting it from 'borrowed t' to 't: borrowed'.  With a 'git grep', I also found other instances of this pattern in the collection modules, so have updated those as well.  I've added the test that led to this error.
