### PR TITLE
Add -Og flag to CHPL_DEVELOPER builds on GCC/Clang

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -34,7 +34,7 @@ RANLIB = ranlib
 # General Flags
 #
 
-DEBUG_CFLAGS = -g
+DEBUG_CFLAGS = -g -Og
 DEPEND_CFLAGS = -MMD -MP
 OPT_CFLAGS = -O3
 #PROFILE_CFLAGS = -pg

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -32,7 +32,7 @@ RANLIB = ranlib
 # General Flags
 #
 
-DEBUG_CFLAGS = -g
+DEBUG_CFLAGS = -g -Og
 DEPEND_CFLAGS = -MMD -MP
 OPT_CFLAGS = -O3
 PROFILE_CFLAGS = -pg


### PR DESCRIPTION
Adds `-Og` flag to debug builds with GCC/Clang, which includes any build with `CHPL_DEVELOPER` set. This flag is intended to provide a level of optimization ideal for debugging. Flags for building with other compilers are unaffected.

Resolves https://github.com/Cray/chapel-private/issues/3202.

Testing:
- [x] paratest