### PR TITLE
Replace `file.check` with `file.isOpen`

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1355,10 +1355,11 @@ proc sameFile(file1: file, file2: file): bool throws {
   extern proc chpl_fs_samefile(ref ret: c_int, file1: qio_file_ptr_t,
                                file2: qio_file_ptr_t): errorCode;
 
-  // If one of the files references a null file, propagate to avoid a segfault.
-  try {
-    file1.check();
-    file2.check();
+  // If one of the files references a null or closed file, throw to avoid a
+  // segfault.
+  if (!file1.isOpen() || !file2.isOpen()) {
+    throw createSystemError(EBADF,
+                            "Operation attempted on a file that is not open");
   }
 
   var ret:c_int;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1572,7 +1572,7 @@ proc file.checkAssumingLocal() throws {
  deprecated "'file.check()' is deprecated, please use :proc:`file.isOpen` instead"
 proc file.check() throws {
   on this._home {
-    this.checkAssumingLocal(); // Remove this function, too
+    this.checkAssumingLocal(); // Remove this function, too?
   }
 }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1569,9 +1569,21 @@ proc file.checkAssumingLocal() throws {
 
    :throws SystemError: Indicates that `this` does not represent an OS file.
 */
+ deprecated "'file.check()' is deprecated, please use :proc:`file.isOpen` instead"
 proc file.check() throws {
   on this._home {
-    this.checkAssumingLocal();
+    this.checkAssumingLocal(); // Remove this function, too
+  }
+}
+
+/* Indicates if the file is currently open.  Will return ``false`` for both
+   closed and invalid files
+*/
+proc file.isOpen(): bool {
+  if (is_c_nil(_file_internal)) {
+    return false;
+  } else {
+    return qio_file_isopen(_file_internal);
   }
 }
 

--- a/test/deprecated/IO/fileCheck.chpl
+++ b/test/deprecated/IO/fileCheck.chpl
@@ -1,0 +1,12 @@
+use IO;
+
+var f = open("foo.txt", iomode.cw);
+try {
+  f.check();
+} catch e: Error {
+  writeln(e.message());
+}
+f.close();
+
+use FileSystem;
+remove("foo.txt"); // So we don't have to clean it up via the testing system

--- a/test/deprecated/IO/fileCheck.good
+++ b/test/deprecated/IO/fileCheck.good
@@ -1,0 +1,1 @@
+fileCheck.chpl:5: warning: 'file.check()' is deprecated, please use file.isOpen instead

--- a/test/io/dtjong/file-close-check.chpl
+++ b/test/io/dtjong/file-close-check.chpl
@@ -5,17 +5,18 @@ var f: file;
 try {
   try {
     f = open("foo", iomode.cw);
-    f.check();
+    if (!f.isOpen()) {
+      writeln("There was a problem with the file");
+    }
     writeln(f.path);
     f.close();
   } catch e: SystemError {
     writeln("open error:  " + e.details);  
   }
-  try {
-    f.check();
+  if (!f.isOpen()) {
+    writeln("File was closed successfully");
+  } else {
     writeln("You shouldn't see this");
-  } catch e: SystemError {
-    writeln("Task failed successfully");  
   }
 } catch {
   halt("catchall");

--- a/test/io/dtjong/file-close-check.good
+++ b/test/io/dtjong/file-close-check.good
@@ -1,2 +1,2 @@
 {CHPL_HOME}/test/io/dtjong/foo
-Task failed successfully
+File was closed successfully

--- a/test/library/standard/FileSystem/lydia/sameFile/givenNull.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/givenNull.good
@@ -1,3 +1,3 @@
-uncaught SystemError: Bad file descriptor (Operation attempted on an invalid file)
+uncaught SystemError: Bad file descriptor (Operation attempted on a file that is not open)
   givenNull.chpl:7: thrown here
   givenNull.chpl:7: uncaught here

--- a/test/library/standard/FileSystem/lydia/sameFile/givenNull2.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/givenNull2.good
@@ -1,3 +1,3 @@
-uncaught SystemError: Bad file descriptor (Operation attempted on an invalid file)
+uncaught SystemError: Bad file descriptor (Operation attempted on a file that is not open)
   givenNull2.chpl:7: thrown here
   givenNull2.chpl:7: uncaught here

--- a/test/library/standard/FileSystem/lydia/sameFile/givenNull3.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/givenNull3.good
@@ -1,3 +1,3 @@
-uncaught SystemError: Bad file descriptor (Operation attempted on an invalid file)
+uncaught SystemError: Bad file descriptor (Operation attempted on a file that is not open)
   givenNull3.chpl:6: thrown here
   givenNull3.chpl:6: uncaught here


### PR DESCRIPTION
Resolves #20153 
Resolves Cray/chapel-private#4256

This method was intended to guard against performing operations on null or
closed files.  Replace it with something that is more explicitly for that, to
make it more obvious for users.

Adds a test locking in the deprecation message.

Adjusts the modules and testing system to use the new method:
- in FileSystem.sameFile, ensure both files are open and if not, throw an EBADF
about the operation, to maintain the original behavior
- Adjust the tests of sameFile for this new error message when it would be
triggered
- adjust file-close-check.chpl to use the new functions and not put the calls in
try/catches since it doesn't throw any more.  I also adjusted the output
slightly to reflect the new method name.  I chose not to rename the test since
we are still checking the closed files, just not by calling a method named
check.

Passed full paratest with futures and looked at the built docs