### PR TITLE
Update c2chapel testing to handle help output from newer Python

### DIFF
--- a/tools/c2chapel/test/help.2.good
+++ b/tools/c2chapel/test/help.2.good
@@ -1,0 +1,19 @@
+usage: c2chapel [-h] [--no-typedefs] [--debug] [--no-fake-headers]
+                [--no-comments] [-V] [--gnu-extensions]
+                file [cppFlags ...]
+
+Generate C bindings for Chapel
+
+positional arguments:
+  file               C99 file for which to generate bindings
+  cppFlags           flags forwarded to the C preprocessor (invoked with cc
+                     -E)
+
+options:
+  -h, --help         show this help message and exit
+  --no-typedefs      do not generate extern types for C typedefs
+  --debug            enable debugging output
+  --no-fake-headers  do not use fake headers included with c2chapel
+  --no-comments      instruct c2chapel to not generate comments
+  -V, --version      show program's version number and exit
+  --gnu-extensions   allow GNU extensions in C99 files

--- a/tools/c2chapel/test/no-args.3.good
+++ b/tools/c2chapel/test/no-args.3.good
@@ -1,0 +1,4 @@
+usage: c2chapel [-h] [--no-typedefs] [--debug] [--no-fake-headers]
+                [--no-comments] [-V] [--gnu-extensions]
+                file [cppFlags ...]
+c2chapel: error: the following arguments are required: file, cppFlags

--- a/tools/c2chapel/test/tester.sh
+++ b/tools/c2chapel/test/tester.sh
@@ -34,6 +34,7 @@ function helper() {
   args=$2
   good=$3
   good2=$4
+  good3=$5
 
   outFile=out.c2chapel.tmp
   diffFile=diff.c2chapel.tmp
@@ -42,12 +43,19 @@ function helper() {
     # it will just diff against the one good file twice, harmlessly
     good2=$good
   fi
+  if [ -z "$good3" ]; then
+    # it will just diff against the one good file twice, harmlessly
+    good3=$good
+  fi
+
 
   printf "%s: " "$msg"
   "$C2CHAPEL" $args > $outFile 2>&1
   if diff $outFile $good > $diffFile 2>&1; then
     printf "${GREEN}OK${NORMAL}\n"
   elif diff $outFile $good2 > $diffFile 2>&1; then
+    printf "${GREEN}OK${NORMAL}\n"
+  elif diff $outFile $good3 > $diffFile 2>&1; then
     printf "${GREEN}OK${NORMAL}\n"
   else
     printf "${RED}ERROR${NORMAL}\n"
@@ -64,8 +72,8 @@ function helper() {
 
 echo "Testing c2chapel..."
 
-helper "No arguments" "" "no-args.good" "no-args.2.good"
-helper "--help" "--help" "help.good"
+helper "No arguments" "" "no-args.good" "no-args.2.good" "no-args.3.good"
+helper "--help" "--help" "help.good" "help.2.good"
 helper "File not found" "notFound.h" "notFound.good"
 
 for f in *.h ; do


### PR DESCRIPTION
Python 3.10 seems to have slightly different help output,
so add that as an alternative.

Reviewed by @bmcdonald3 - thanks!