### PR TITLE
Fix failure to forward error code from gpu codegen

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2737,6 +2737,11 @@ void codegen() {
       while (wait(&status) != pid) {
         // wait for child process
       }
+
+      // The 'status' argument to 'wait' contains more info than just the value
+      // passed to 'exit()'. Extract the value passed to 'exit()' from 'status'.
+      status = WEXITSTATUS(status);
+
       // If there was an error in GPU code generation then the .fatbin file (containing
       // the generated GPU code) was not created and we won't be able to continue.
       if(status != 0) {

--- a/test/gpu/native/environment/gpuCodegenErrorExitStatus.chpl
+++ b/test/gpu/native/environment/gpuCodegenErrorExitStatus.chpl
@@ -1,0 +1,17 @@
+// This test causes an error in GPU codegen because the gpu function 'foo' is
+// not found. The GPU codegen process exits with a code of 1, but the main
+// process was exiting with a code of 0. This was causing problems with
+// start_test because the compiler returned success but didn't generate
+// an executable. The compiler is now correctly returning != 0 when GPU
+// codegen fails, so this test now passes.
+
+use GPU;
+pragma "codegen for GPU"
+extern proc foo() : void;
+
+on here.gpus[0] {
+  foreach i in 0..10 {
+    assertOnGpu();
+    foo();
+  }
+}

--- a/test/gpu/native/environment/gpuCodegenErrorExitStatus.compopts
+++ b/test/gpu/native/environment/gpuCodegenErrorExitStatus.compopts
@@ -1,0 +1,1 @@
+--no-checks

--- a/test/gpu/native/environment/gpuCodegenErrorExitStatus.good
+++ b/test/gpu/native/environment/gpuCodegenErrorExitStatus.good
@@ -1,0 +1,1 @@
+gpuCodegenErrorExitStatus.chpl:10: error: Could not find C function for foo;  perhaps it is missing or is a macro?


### PR DESCRIPTION
When GPU codegen has a failure, it exits the GPU subprocess with a non-zero exit code. The main compiler process then sees that the code from 'wait' is non-zero and also exits with that code. But the code from 'wait' is not just the code the subprocess exited with, so this ends up being equivalent to 'exit(0)'. Extract the actual exit code from the code set by 'wait' and exit with that code instead.

Add a test that causes GPU codegen to fail. start_test was previously failing for this test with errors like:
"[Error could not locate executable gpuCodegenErrorExitStatus for gpu/native/environment/gpuCodegenErrorExitStatus]".

Now it correctly detects that the compilation failed and stops there and diffs the compilation output vs. the .good file.

Fixes https://github.com/chapel-lang/chapel/issues/20639 and https://github.com/Cray/chapel-private/issues/4268