### PR TITLE
Update spack version for mason --external

### DIFF
--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -19,7 +19,7 @@
  */
 
 /* Version as of Chapel 1.25 - to be updated each release */
-const spackVersion = new VersionInfo('0.15.4');
+const spackVersion = new VersionInfo('0.19.0');
 const major = spackVersion.major:string;
 const minor = spackVersion.minor:string;
 const spackBranch = 'releases/v' + '.'.join(major, minor);
@@ -261,11 +261,14 @@ proc getSpackVersion : VersionInfo {
   const command = "spack --version";
   const tmpVersion = getSpackResult(command,true).strip();
   // on systems with their own spack, spack --version can provide
-  // a version string like x.x.x-xxxx-hash
+  // a version string like:
+  //    x.x.x-xxxx-hash
+  //    x.x.x (hash)
   // partitioning the string allows us to separate the major.minor.bug
   // from the remaining values
-  const version = tmpVersion.partition("-");
-  return new VersionInfo(version[0]);
+  const nodash = tmpVersion.partition("-")(0);
+  const nospace = tmpVersion.partition(" ")(0);
+  return new VersionInfo(nospace);
 }
 
 /* Lists available spack packages */


### PR DESCRIPTION
When running `mason external --setup` on Ubuntu 22.10 or SLES 15, I was seeing an error from Spack itself. That is because we had pinned version v0.15.4 in the mason source code and this version does not work with Python 3.10 (only Python 3.5 - 3.8).

The error included this from within Spack code:

    AttributeError: module 'collections' has no attribute 'MutableMapping'

Once I updated the version number to the current Spack release (v0.19.0), `mason external --setup` still did not work, because of differences in how `spack --version` output changed. So, I updated the trimming used when processing the output of `spack --version`.

- [ ] wait for https://github.com/spack/spack/issues/22548 to be resolved; or some other solution (say, using `/tmp` for the spack installs in our testing)