### PR TITLE
Remove an outdated todo note about TAGS from docs

### DIFF
--- a/doc/rst/developer/bestPractices/CHPL_DEVELOPER.rst
+++ b/doc/rst/developer/bestPractices/CHPL_DEVELOPER.rst
@@ -36,9 +36,7 @@ possible.  In particular:
    be the only one; others have existed in the past).
 
 4) Builds an emacs TAGS and BROWSE file for the compiler and a TAGS
-   file for the runtime.  (Note: it seems we currently do this whether
-   or not ``CHPL_DEVELOPER`` is set, though this seems inappropriate...
-   We should fix this).
+   file for the runtime.
 
 5) Turns on ``--devel`` by default when invoking the ``chpl`` compiler.  This
    in turn has the following effects:


### PR DESCRIPTION
The note implied that `TAGS`/`BROWSE` are built even when `CHPL_DEVELOPER` is not set, which is not currently true; see discussion in https://github.com/chapel-lang/chapel/issues/21432.

Resolves https://github.com/chapel-lang/chapel/issues/21432.

[trivial, not reviewed]