### PR TITLE
Suppressif two more mason external tests

### DIFF
--- a/test/mason/mason-external/masonExternalRanges/masonExternalExitCodes.suppressif
+++ b/test/mason/mason-external/masonExternalRanges/masonExternalExitCodes.suppressif
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+
+from os import environ
+import sys
+
+# Mason's version of spack doesn't work on m1 currently:
+# https://github.com/Cray/chapel-private/issues/3518
+arm_mac = (environ['CHPL_TARGET_PLATFORM'] == 'darwin' and
+           environ['CHPL_TARGET_ARCH'] == 'arm64')
+# Mason's version of spack doesn't work with python >= 3.9
+# https://github.com/chapel-lang/chapel/issues/19517
+bad_python = sys.version_info.minor > 8
+
+print(arm_mac or bad_python)

--- a/test/mason/mason-help-tests/masonHelpTests.suppressif
+++ b/test/mason/mason-help-tests/masonHelpTests.suppressif
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+
+from os import environ
+import sys
+
+# Mason's version of spack doesn't work on m1 currently:
+# https://github.com/Cray/chapel-private/issues/3518
+arm_mac = (environ['CHPL_TARGET_PLATFORM'] == 'darwin' and
+           environ['CHPL_TARGET_ARCH'] == 'arm64')
+# Mason's version of spack doesn't work with python >= 3.9
+# https://github.com/chapel-lang/chapel/issues/19517
+bad_python = sys.version_info.minor > 8
+
+print(arm_mac or bad_python)


### PR DESCRIPTION
Continuing #20118.

This PR suppresses failures on two mason-external tests until we're able to upgrade spack versions (see https://github.com/Cray/chapel-private/issues/3518 and #21439).

Reviewed by @ronawho - thanks!