### PR TITLE
update Attributes name after refactor

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -362,7 +362,7 @@ Resolver::getFormalTypes(const Function* fn) {
       isThis = namedDecl->name() == USTR("this");
     }
     Qualifier intent = resolveIntent(t, isThis, isInit);
-    if (auto attributes = formal->attributes()) {
+    if (auto attributes = formal->attributeGroup()) {
       if (attributes->hasPragma(PRAGMA_INTENT_REF_MAYBE_CONST_FORMAL)) {
         intent = Qualifier::REF_MAYBE_CONST;
       }


### PR DESCRIPTION
This PR fixes a bad name that slipped in between merging 
https://github.com/chapel-lang/chapel/pull/21357 and 
https://github.com/chapel-lang/chapel/pull/21396.

In #21357 I renamed `Attributes` to `AttributeGroup` and also renamed methods 
related to it. In #21396 the old name was used and while I rebased on `main` 
earlier today, #21396 came in between my last rebase and the merge of #21357.

reviewed by @DanilaFe - thanks!