### PR TITLE
Stop overriding user supplied `CHPL_*_MEM`

### DIFF
--- a/util/chplenv/chpl_mem.py
+++ b/util/chplenv/chpl_mem.py
@@ -17,22 +17,22 @@ def get(flag='host'):
     chpl_mem = overrides.get('CHPL_MEM')
 
     if flag == 'target':
-        if cygwin or mac_arm:
-            mem_val = 'cstdlib'
-        elif chpl_target_mem:
+        if chpl_target_mem:
             mem_val = chpl_target_mem
             if chpl_mem and chpl_target_mem != chpl_mem:
                 warning("CHPL_MEM and CHPL_TARGET_MEM are both set, "
                         "taking value from CHPL_TARGET_MEM")
         elif chpl_mem:
             mem_val = chpl_mem
+        elif cygwin or mac_arm:
+            mem_val = 'cstdlib'
         else:
             mem_val = 'jemalloc'
     elif flag == 'host':
-        if cygwin or mac:
-            mem_val = 'cstdlib'
-        elif chpl_host_mem:
+        if chpl_host_mem:
             mem_val = chpl_host_mem
+        elif cygwin or mac:
+            mem_val = 'cstdlib'
         else:
             mem_val = 'jemalloc'
     else:


### PR DESCRIPTION
Our chplenv scripts typically just define defaults, but allow users to override even if they select unsupported configs. However, `CHPL_MEM` was forcing the default for some cases and wouldn't allow users to override. This wasn't a huge issue because jemalloc doesn't work on cygwin or as a target allocator for ARM macs. However, it also prevented using jemalloc as a host compiler on macs, but that configuration should work, we just haven't figured out rpath stuff to make it the default.

Part of Cray/chapel-private#4113