### PR TITLE
Fix bug with throwing initializers found by CHAMPS

### DIFF
--- a/compiler/passes/InitErrorHandling.cpp
+++ b/compiler/passes/InitErrorHandling.cpp
@@ -248,9 +248,6 @@ InitErrorHandling::InitPhase InitErrorHandling::startPhase(BlockStmt* block) con
       }
 
     } else if (ForallStmt* forall = toForallStmt(stmt)) {
-      // Nothing to normalize in fRecIter*
-      INT_ASSERT(forall->fRecIterIRdef == NULL);
-
       InitPhase phase = startPhase(forall->loopBody());
 
       if (phase != defaultPhase) {

--- a/test/classes/initializers/siblingCall/reductionBefore.chpl
+++ b/test/classes/initializers/siblingCall/reductionBefore.chpl
@@ -1,0 +1,31 @@
+// This test is to track code that triggered an error at one point in CHAMPS
+// code since our testing system didn't track it otherwise.  The error has since
+// been fixed.
+class Foo {
+  var numGlobalNodes_: int = 0;
+  var connectivitySize_ : int = 0;
+  var connectivityDom_ : domain(1) = {0..#connectivitySize_};
+  var facet2NodeList_ : [connectivityDom_] int;
+
+  proc init(numGlobalNodes: int, connectivitySize : int, facet2NodeList : [?D] int) {
+    if D.size != connectivitySize then halt("Size of connectivity does not match length of facet2NodeList array: ", D.size, " != ", connectivitySize);
+    if (max reduce facet2NodeList) > numGlobalNodes then halt ("blah blah blah");
+
+    this.init(numGlobalNodes, connectivitySize);
+
+    this.facet2NodeList_ = facet2NodeList;
+  }
+
+  proc init(numGlobalNodes: int = 0, connectivitySize : int = 0) {
+    this.numGlobalNodes_ = numGlobalNodes;
+    this.connectivitySize_ = connectivitySize;
+  }
+}
+
+proc main() {
+  var nodeList: [0..<15] int = [2, 9, 3, 6, 2, 4, 3, 3, 6, 9, 2, 1, 4, 3, 7];
+  var x = new owned Foo(10, 15, nodeList);
+
+  writeln(x);
+
+}

--- a/test/classes/initializers/siblingCall/reductionBefore.good
+++ b/test/classes/initializers/siblingCall/reductionBefore.good
@@ -1,0 +1,1 @@
+{numGlobalNodes_ = 10, connectivitySize_ = 15, connectivityDom_ = {0..14}, facet2NodeList_ = 2 9 3 6 2 4 3 3 6 9 2 1 4 3 7}


### PR DESCRIPTION
It looks like our testing system didn't have any tests of initializers with
reductions in their body, which meant that I missed a bug in my prototypical
implementation of throwing initializers.  Fix that bug and add a small
reproducer I made to verify the fix.

<details>

This part of the code was copied from the checking in normalize, but the AST
will have changed in between those passes, so it's perfectly reasonable for a
forall to have the fRecIterIRdef field set.  However, it shouldn't be relevant
when determining the initializer's phase at this time, as the normalize checking
of initializers should have errored if there was any `super.init()` or
`this.init()` call in code that would be included there.

</details>

With this change, the CHAMPS test that failed built appropriately.  Running a
full paratest with futures now