### PR TITLE
Add a trailing comma to a test-specific one-element array literal

### DIFF
--- a/test/library/packages/HDF5/HDF5Preprocessors.chpl
+++ b/test/library/packages/HDF5/HDF5Preprocessors.chpl
@@ -38,7 +38,7 @@ module HDF5Preprocessors {
         chmod(scriptName.c_str(), 0o755:mode_t);
 
         // spawn the script, connect stdin and stdout
-        var sub = spawn([scriptName], stdin=pipeStyle.pipe, stdout=pipeStyle.pipe);
+        var sub = spawn([scriptName, ], stdin=pipeStyle.pipe, stdout=pipeStyle.pipe);
 
         cobegin {
           // dump the array to the script's stdin


### PR DESCRIPTION
This one slipped by me because we don't test these in general due the HDF5 requirement, and we hadn't run the xc configuations that do since #21337 was merged.
