### PR TITLE
Replace the bigint initializers that halt or return error codes with one that throws

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -578,7 +578,7 @@ module BigInteger {
   }
 
   pragma "no doc"
-  inline operator :(src: string, type toType: bigint): bigint {
+  inline operator :(src: string, type toType: bigint): bigint throws {
     return new bigint(src);
   }
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -257,7 +257,7 @@ module BigInteger {
       this.init(num);
     }
 
-    deprecated "bigint initializers that halt are deprecated, please set the config param :config:`bigintInitThrows` to 'true' to opt in to using the new initializer that throws"
+    deprecated "bigint initializers that halt are deprecated, please set the config param :param:`bigintInitThrows` to 'true' to opt in to using the new initializer that throws"
     proc init(str: string, base: int = 0) where bigintInitThrows == false {
       this.complete();
       const str_  = str.localize().c_str();
@@ -272,7 +272,7 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    deprecated "bigint initializers that return the :type:`errorCode` type via an 'out' argument are deprecated, please remove the argument and ensure the config param :config:`bigintInitThrows` is set to 'true' to opt in to using the new initializer that throws"
+    deprecated "bigint initializers that return the :type:`errorCode` type via an 'out' argument are deprecated, please remove the argument and ensure the config param :param:`bigintInitThrows` is set to 'true' to opt in to using the new initializer that throws"
     proc init(str: string, base: int = 0, out error: errorCode) {
 
       this.complete();

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -272,7 +272,7 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    deprecated "bigint initializers that return the :type:`~OS.errorCode` type via an 'out' argument are deprecated, please remove the argument and ensure the config param :param:`bigintInitThrows` is set to 'true' to opt in to using the new initializer that throws"
+    deprecated "bigint initializers that return the errorCode type via an 'out' argument are deprecated, please remove the argument and ensure the config param :param:`bigintInitThrows` is set to 'true' to opt in to using the new initializer that throws"
     proc init(str: string, base: int = 0, out error: errorCode) {
 
       this.complete();

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -192,10 +192,10 @@ module BigInteger {
      that take a string argument.
 
      When ``false``, the deprecated behavior is used (i.e., errors will trigger
-     a halt at execution.
+     a halt at execution.)
 
      When ``true``, the new behavior is used (i.e., errors will cause a
-     :type:`BadFormatError` to be thrown)
+     :type:`~OS.BadFormatError` to be thrown)
   */
   config param bigintInitThrows = false;
 
@@ -272,7 +272,7 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    deprecated "bigint initializers that return the :type:`errorCode` type via an 'out' argument are deprecated, please remove the argument and ensure the config param :param:`bigintInitThrows` is set to 'true' to opt in to using the new initializer that throws"
+    deprecated "bigint initializers that return the :type:`~OS.errorCode` type via an 'out' argument are deprecated, please remove the argument and ensure the config param :param:`bigintInitThrows` is set to 'true' to opt in to using the new initializer that throws"
     proc init(str: string, base: int = 0, out error: errorCode) {
 
       this.complete();
@@ -290,7 +290,23 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    /* TODO: DOCUMENT
+    /* Initialize a :type:`bigint` from a string and optionally a provided base
+       to use with the string.  If the string is not a correct base ``base``
+       number, will throw a :type:`~OS.BadFormatError`.
+
+       :arg str: The value to be stored in the resulting :type:`bigint`.
+       :type str: `string`
+
+       :arg base: The base to use when creating the :type:`bigint` from ``str``.
+                  May vary from ``2`` to ``62`` or be ``0``.  Defaults to ``0``,
+                  which causes the base to be read from the start of the ``str``
+                  itself (``0x`` and ``0X`` will give hexadecimal, ``0b`` and
+                  ``0B`` will give binary, ``0`` will give octal, and everything
+                  else will be interpreted as decimal).
+       :type base: `int`
+
+       :throws BadFormatError: Thrown when ``str`` is not a correctly formatted
+                               number in base ``base``.
 
      */
     proc init(str: string, base: int = 0) throws where bigintInitThrows == true {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -150,7 +150,6 @@ module BigInteger {
   use CTypes;
   use GMP;
   use HaltWrappers;
-  use CTypes;
   use OS;
 
 
@@ -273,7 +272,7 @@ module BigInteger {
       this.localeId = chpl_nodeID;
     }
 
-    deprecated "bigint initializers that return :type:`errorCode` via an 'out' argument are deprecated, please remove the argument and ensure the config param :config:`bigintInitThrows` is set to 'true' to opt in to using the new initializer that throws"
+    deprecated "bigint initializers that return the :type:`errorCode` type via an 'out' argument are deprecated, please remove the argument and ensure the config param :config:`bigintInitThrows` is set to 'true' to opt in to using the new initializer that throws"
     proc init(str: string, base: int = 0, out error: errorCode) {
 
       this.complete();

--- a/test/deprecated/BigInteger/deprecatedInitializers.chpl
+++ b/test/deprecated/BigInteger/deprecatedInitializers.chpl
@@ -1,0 +1,9 @@
+use BigInteger;
+use OS;
+
+var b1 = new bigint("303948673745");
+writeln(b1);
+var err: errorCode;
+var b2 = new bigint("373724632625625626523", error=err);
+writeln(b2);
+writeln(err == 0);

--- a/test/deprecated/BigInteger/deprecatedInitializers.good
+++ b/test/deprecated/BigInteger/deprecatedInitializers.good
@@ -1,0 +1,5 @@
+deprecatedInitializers.chpl:4: warning: bigint initializers that halt are deprecated, please set the config param bigintInitThrows to 'true' to opt in to using the new initializer that throws
+deprecatedInitializers.chpl:7: warning: bigint initializers that return the errorCode type via an 'out' argument are deprecated, please remove the argument and ensure the config param bigintInitThrows is set to 'true' to opt in to using the new initializer that throws
+303948673745
+373724632625625626523
+true

--- a/test/library/standard/BigInteger/badFormat.chpl
+++ b/test/library/standard/BigInteger/badFormat.chpl
@@ -1,0 +1,13 @@
+// Tests that we throw a BadFormatError appropriately
+use BigInteger;
+use OS;
+
+try {
+  var bad = new bigint("edy102920");
+} catch e: BadFormatError {
+  writeln("correctly threw BadFormatError");
+  writeln(e.message());
+} catch e : Error {
+  writeln("uh oh, caught other error!");
+  writeln(e.message());
+}

--- a/test/library/standard/BigInteger/badFormat.compopts
+++ b/test/library/standard/BigInteger/badFormat.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/BigInteger/badFormat.good
+++ b/test/library/standard/BigInteger/badFormat.good
@@ -1,0 +1,2 @@
+correctly threw BadFormatError
+bad format (Error initializing big integer)

--- a/test/library/standard/BigInteger/exponentiation.compopts
+++ b/test/library/standard/BigInteger/exponentiation.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/BigInteger/fitsIntoMethod64.compopts
+++ b/test/library/standard/BigInteger/fitsIntoMethod64.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/BigInteger/modCorrectness.compopts
+++ b/test/library/standard/BigInteger/modCorrectness.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/BigInteger/testHash.compopts
+++ b/test/library/standard/BigInteger/testHash.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/BigInteger/testOps.compopts
+++ b/test/library/standard/BigInteger/testOps.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/GMP/congruence.compopts
+++ b/test/library/standard/GMP/congruence.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/GMP/ferguson/gmp_dist_array.compopts
+++ b/test/library/standard/GMP/ferguson/gmp_dist_array.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/GMP/ferguson/gmp_test.compopts
+++ b/test/library/standard/GMP/ferguson/gmp_test.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_number_theoretic.compopts
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_number_theoretic.compopts
@@ -1,1 +1,1 @@
--s InvertReturnInt=false
+-s InvertReturnInt=false -sbigintInitThrows=true

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_record_constructors.compopts
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_record_constructors.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true


### PR DESCRIPTION
Resolves #17686
Resolves Cray/chapel-private#4257

The old initializers were not in keeping with behavior we want -
library operations should not halt, and returning error codes
via out arguments (or otherwise) is a strategy we have stopped
following since the addition of proper error handling.

This PR adds a new initializer that will throw when the arguments
would not result in a proper `bigint`.  Since it has the same
arguments as the halting version, add a new `config` to control
which behavior is used.  This config is off by default, giving
users a deprecation message indicating that they will need to
adjust their code.

<details>

Note that since initializers can only call throwing functions now
rather than throwing themselves, this adds a private proc to
perform the `throw`.  This was not particularly burdensome,
but will need to be cleaned up when throwing initializers are more
extensively supported

</details>

As a result of supporting throwing for this particular argument
list, one of the `bigint` cast operators needed to be declared
`throws` as well.

I also removed an extra `use` of the CTypes module while I was
there.

Adjusts several existing tests to opt into the new behavior by
compiling with the new config.

Adds two tests:
- Checks that the deprecation warning fires for both the
halting and the error code version
- Checks that we appropriately throw the BadFormatError when
calling the initializer with a bad argument.  It seems as though
this was not tested before

Passed a full paratest with futures and checked that the docs
looked good