### PR TITLE
Fix a GCC 12 warning that appears with -Og

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -447,8 +447,8 @@ static void handleCallMacro(const IdentifierInfo* origID,
       actual2 = *tok;
   }
 
-  IdentifierInfo* formal1;
-  IdentifierInfo* formal2;
+  IdentifierInfo* formal1 = nullptr;
+  IdentifierInfo* formal2 = nullptr;
   count = 0;
   for (MacroInfo::param_iterator param = calledMacro->param_begin();
        param != calledMacro->param_end(); ++param) {


### PR DESCRIPTION
I started seeing a warning for a potentially uninitialized variable after PR #21434. This PR fixes the warning by initializing two pointer variables to `nullptr`.

Reviewed by @daviditen - thanks!

- [x] full local testing