### PR TITLE
Remove -Og for CHPL_DEVELOPER builds with Clang

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -34,7 +34,7 @@ RANLIB = ranlib
 # General Flags
 #
 
-DEBUG_CFLAGS = -g -Og
+DEBUG_CFLAGS = -g
 DEPEND_CFLAGS = -MMD -MP
 OPT_CFLAGS = -O3
 #PROFILE_CFLAGS = -pg


### PR DESCRIPTION
Remove `-Og` optimization flag from Clang builds which was added in https://github.com/chapel-lang/chapel/pull/21434.

This flag seems to break debuggability as mentioned in the OP of https://github.com/Cray/chapel-private/issues/3202; I was optimistically hoping it would "just work".

[trivial, urgent, not reviewed]