### PR TITLE
Deprecate 'Time.getCurrentTime'

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -754,23 +754,23 @@ module Random {
     record SeedGenerator {
       /*
         Generate a seed based on the current time in microseconds as
-        reported by :proc:`Time.getCurrentTime`. This seed is not
+        reported by :proc:`Time.timeSinceEpoch`. This seed is not
         suitable for the NPB RNG since that requires an odd seed.
       */
       proc type currentTime: int(64) {
         use Time;
-        const seed = getCurrentTime(unit=TimeUnits.microseconds):int(64);
+        const seed = (timeSinceEpoch().totalSeconds()*1_000_000):int(64);
         return seed;
 
       }
       /*
         Generate an odd seed based on the current time in microseconds as
-        reported by :proc:`Time.getCurrentTime`. This seed is suitable
+        reported by :proc:`Time.timeSinceEpoch`. This seed is suitable
         for the NPB RNG.
       */
       proc type oddCurrentTime: int(64) {
         use Time;
-        const seed = getCurrentTime(unit=TimeUnits.microseconds):int(64);
+        const seed = (timeSinceEpoch().totalSeconds()*1_000_000): int;
         const oddseed = if seed % 2 == 0 then seed + 1 else seed;
         return oddseed;
       }

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -1907,6 +1907,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
    :returns: The elapsed time since midnight, local time, in the units specified
    :rtype:   `real(64)`
  */
+deprecated "'getCurrentTime()' is deprecated please use 'timeSinceEpoch()' instead"
 proc getCurrentTime(unit: TimeUnits = TimeUnits.seconds) : real(64)
   return _convert_microseconds(unit, chpl_now_time());
 

--- a/test/chplvis/benchmarks-hpcc/fft-vdb.chpl
+++ b/test/chplvis/benchmarks-hpcc/fft-vdb.chpl
@@ -105,7 +105,7 @@ proc main() {
   initVectors(Twiddles, z);            // initialize twiddles and input vector z
 
   startVdebug("FFTvis");
-  const startTime = getCurrentTime();  // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();  // capture the start time
 
   [(a,b) in zip(Zblk, z)] a = conjg(b);      // store the conjugate of z in Zblk
   bitReverseShuffle(Zblk);                // permute Zblk
@@ -120,7 +120,7 @@ proc main() {
   forall (b, c) in zip(Zblk, Zcyc) do        // copy vector back to Block storage
     b = c;
 
-  const execTime = getCurrentTime() - startTime;     // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;     // store the elapsed time
   stopVdebug();
 
   const validAnswer = verifyResults(z, Zblk, Zcyc, Twiddles); // validate answer

--- a/test/chplvis/benchmarks-hpcc/hpl-vdb.chpl
+++ b/test/chplvis/benchmarks-hpcc/hpl-vdb.chpl
@@ -90,13 +90,13 @@ proc main() {
   initAB(Ab);
 
   startVdebug("HPLvis");
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, Ab, piv);                 // compute the LU factorization
 
   var x = backwardSub(n, Ab);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   stopVdebug();
   //
   // Validate the answer and print the results

--- a/test/chplvis/benchmarks-hpcc/ra-vdb.chpl
+++ b/test/chplvis/benchmarks-hpcc/ra-vdb.chpl
@@ -131,7 +131,7 @@ proc main() {
   [i in TableSpace] T[i] = i;
 
   startVdebug("RAvis");
-  const startTime = getCurrentTime();              // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
   //
   // The main computation: Iterate over the set of updates and the
@@ -157,7 +157,7 @@ proc main() {
     forall (_, r) in zip(Updates, RAStream()) do
       T[r & indexMask] ^= r;
 
-  const execTime = getCurrentTime() - startTime;   // capture the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;   // capture the elapsed time
   stopVdebug();
 
   const validAnswer = verifyResults(T);            // verify the updates

--- a/test/constrained-generics/random/MyRandom.chpl
+++ b/test/constrained-generics/random/MyRandom.chpl
@@ -713,23 +713,23 @@ module MyRandom {
     record SeedGenerator {
       /*
         Generate a seed based on the current time in microseconds as
-        reported by :proc:`Time.getCurrentTime`. This seed is not
+        reported by :proc:`Time.timeSinceEpoch`. This seed is not
         suitable for the NPB RNG since that requires an odd seed.
       */
       proc type currentTime: int(64) {
         use Time;
-        const seed = getCurrentTime(unit=TimeUnits.microseconds):int(64);
+        const seed = (timeSinceEpoch().totalSeconds()*1_000_000):int(64);
         return seed;
 
       }
       /*
         Generate an odd seed based on the current time in microseconds as
-        reported by :proc:`Time.getCurrentTime`. This seed is suitable
+        reported by :proc:`Time.timeSinceEpoch`. This seed is suitable
         for the NPB RNG.
       */
       proc type oddCurrentTime: int(64) {
         use Time;
-        const seed = getCurrentTime(unit=TimeUnits.microseconds):int(64);
+        const seed = (timeSinceEpoch().totalSeconds()*1_000_000):int(64);
         const oddseed = if seed % 2 == 0 then seed + 1 else seed;
         return oddseed;
       }

--- a/test/deprecated/timeGetCurrentTime.chpl
+++ b/test/deprecated/timeGetCurrentTime.chpl
@@ -1,0 +1,3 @@
+use Time;
+
+var t = getCurrentTime();

--- a/test/deprecated/timeGetCurrentTime.good
+++ b/test/deprecated/timeGetCurrentTime.good
@@ -1,0 +1,1 @@
+timeGetCurrentTime.chpl:3: warning: 'getCurrentTime()' is deprecated please use 'timeSinceEpoch()' instead

--- a/test/distributions/robust/arithmetic/kernels/hpl.chpl
+++ b/test/distributions/robust/arithmetic/kernels/hpl.chpl
@@ -78,13 +78,13 @@ proc main() {
 
   initAB(Ab);
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, Ab, piv);                 // compute the LU factorization
 
   x = backwardSub(n, A, b);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
   //
   // Validate the answer and print the results

--- a/test/distributions/robust/arithmetic/kernels/stream.chpl
+++ b/test/distributions/robust/arithmetic/kernels/stream.chpl
@@ -72,7 +72,7 @@ proc main() {
   var execTime: [1..numTrials] real;                 // an array of timings
 
   for trial in 1..numTrials {                        // loop over the trials
-    const startTime = getCurrentTime();              // capture the start time
+    const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
     //
     // The main loop: Iterate over the vectors A, B, and C in a
@@ -82,7 +82,7 @@ proc main() {
     forall (a, b, c) in zip(A, B, C) do
       a = b + alpha * c;
 
-    execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   }
 
   const validAnswer = verifyResults(A, B, C);        // verify...

--- a/test/domains/bradc/domEqualityPerf.chpl
+++ b/test/domains/bradc/domEqualityPerf.chpl
@@ -16,22 +16,22 @@ DA += 4.2;
 // Rectangular
 
 {
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
   for i in 1..numTrials do
     if (D == D) then
       ;
   else
     halt("Bad answer in D comparison");
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
   if printTimings then writeln("Time for rectangular equality = ", execTime);
 }
 
 {
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
   for i in 1..numTrials do
     if (D != D) then
       halt("Bad answer in D comparison");
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
   
   if printTimings then writeln("Time for rectangular inequality = ", execTime);
 }
@@ -39,44 +39,44 @@ DA += 4.2;
 // Sparse
 
 {
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
   for i in 1..numTrials do
     if (DS == DS) then
       ;
   else
     halt("Bad answer in D comparison");
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
   if printTimings then writeln("Time for sparse equality = ", execTime);
 }
 
 {
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
   for i in 1..numTrials do
     if (DS != DS) then
       halt("Bad answer in D comparison");
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
   if printTimings then writeln("Time for sparse inequality = ", execTime);
 }
 
 // Associative
 
 {
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
   for i in 1..numTrials do
     if (DA == DA) then
       ;
   else
     halt("Bad answer in D comparison");
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
   if printTimings then writeln("Time for associative equality = ", execTime);
 }
 
 {
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
   for i in 1..numTrials do
     if (DA != DA) then
       halt("Bad answer in D comparison");
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
   if printTimings then writeln("Time for associative inequality = ", execTime);
 }
 

--- a/test/gpu/native/page-locked-mem/stream.chpl
+++ b/test/gpu/native/page-locked-mem/stream.chpl
@@ -80,7 +80,7 @@ proc main() {
 
 
     for trial in 1..numTrials {                        // loop over the trials
-      const startTime = getCurrentTime();              // capture the start time
+      const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
       //
       // The main loop: Iterate over the vectors A, B, and C in a
@@ -91,7 +91,7 @@ proc main() {
       foreach (a, b, c) in zip(A, B, C) do
         a = b + alpha * c;
 
-      execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+      execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
     }
 
     /*const validAnswer = verifyResults(A, B, C);        // verify...*/

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -81,7 +81,7 @@ proc main() {
     var execTime: [1..numTrials] real;                 // an array of timings
 
     for trial in 1..numTrials {                        // loop over the trials
-      const startTime = getCurrentTime();              // capture the start time
+      const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
       //
       // The main loop: Iterate over the vectors A, B, and C in a
@@ -96,7 +96,7 @@ proc main() {
         forall (a, b, c) in zip(A, B, C) do
           a = b + alpha * c;
 
-      execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+      execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
     }
 
     const validAnswer = verifyResults(A, B, C);        // verify...

--- a/test/gpu/sidelnik/hpcc/stream32-domain.chpl
+++ b/test/gpu/sidelnik/hpcc/stream32-domain.chpl
@@ -87,7 +87,7 @@ proc main() {
   var execTime: [1..numTrials] real;                 // an array of timings
 
   for trial in 1..numTrials {                        // loop over the trials
-    const startTime = getCurrentTime();              // capture the start time
+    const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
     //
     // The main loop: Iterate over the vectors A, B, and C in a
@@ -99,7 +99,7 @@ proc main() {
     forall i in ProblemSpace do
     	    A(i) = B(i) + alpha * C(i);
 
-    execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   }
 
   _A = A;

--- a/test/gpu/sidelnik/hpcc/stream32-zipper.chpl
+++ b/test/gpu/sidelnik/hpcc/stream32-zipper.chpl
@@ -87,7 +87,7 @@ proc main() {
   var execTime: [1..numTrials] real;                 // an array of timings
 
   for trial in 1..numTrials {                        // loop over the trials
-    const startTime = getCurrentTime();              // capture the start time
+    const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
     //
     // The main loop: Iterate over the vectors A, B, and C in a
@@ -99,7 +99,7 @@ proc main() {
     //forall i in ProblemSpace do
     //	    A(i) = B(i) + alpha * C(i);
 
-    execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   }
 
   _A = A;

--- a/test/gpu/sidelnik/hpcc/stream64-domain.chpl
+++ b/test/gpu/sidelnik/hpcc/stream64-domain.chpl
@@ -87,7 +87,7 @@ proc main() {
   var execTime: [1..numTrials] real;                 // an array of timings
 
   for trial in 1..numTrials {                        // loop over the trials
-    const startTime = getCurrentTime();              // capture the start time
+    const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
     //
     // The main loop: Iterate over the vectors A, B, and C in a
@@ -100,7 +100,7 @@ proc main() {
     	    A(i) = B(i) + alpha * C(i);
 //	A = B + alpha * C;
 
-    execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   }
 
   _A = A;

--- a/test/gpu/sidelnik/hpcc/stream64-zipper.chpl
+++ b/test/gpu/sidelnik/hpcc/stream64-zipper.chpl
@@ -87,7 +87,7 @@ proc main() {
   var execTime: [1..numTrials] real;                 // an array of timings
 
   for trial in 1..numTrials {                        // loop over the trials
-    const startTime = getCurrentTime();              // capture the start time
+    const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
     //
     // The main loop: Iterate over the vectors A, B, and C in a
@@ -100,7 +100,7 @@ proc main() {
    // 	    A(i) = B(i) + alpha * C(i);
 //	A = B + alpha * C;
 
-    execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   }
 
   _A = A;

--- a/test/io/vass/time-write.chpl
+++ b/test/io/vass/time-write.chpl
@@ -123,7 +123,7 @@ proc sto_trial() {
 var tSave, tDummy, tcf, tcs, tlstr, tlcs, tgstr, tgcs, tnb, tsto: real;
 
 inline proc addTime(ref t: real) {
-  const tCurr = getCurrentTime();
+  const tCurr = timeSinceEpoch().totalSeconds();
   t += tCurr - tSave;
   tSave = tCurr;
 

--- a/test/library/standard/GMP/studies/gmp-chudnovsky.chpl
+++ b/test/library/standard/GMP/studies/gmp-chudnovsky.chpl
@@ -111,12 +111,12 @@ var top: c_long = 0;
 proc main() {
   writeln("#terms=", terms, ", depth=", depth);
 
-  const start = getCurrentTime();
+  const start = timeSinceEpoch().totalSeconds();
   write("sieve   ");
 
   build_sieve(sieve);
 
-  const mid0 = getCurrentTime();
+  const mid0 = timeSinceEpoch().totalSeconds();
   if (printTimings) then
     writeln("time = ", mid0-start);
   else
@@ -144,7 +144,7 @@ proc main() {
     bs(0, terms: c_ulong, 0, 0);
   }
 
-  const mid1 = getCurrentTime();
+  const mid1 = timeSinceEpoch().totalSeconds();
   write("\nbs      ");
   if (printTimings) then
     writeln("time = ", mid1-mid0);
@@ -209,7 +209,7 @@ proc main() {
 
   stackdom2.clear();
 
-  const mid2 = getCurrentTime();
+  const mid2 = timeSinceEpoch().totalSeconds();
 
   /* initialize temp float variables for sqrt & div */
   mpf_init(t1);
@@ -219,7 +219,7 @@ proc main() {
   /* final step */
   write("div     ");
   my_div(qi, pi, qi);
-  const mid3 = getCurrentTime();
+  const mid3 = timeSinceEpoch().totalSeconds();
   if (printTimings) then
     writeln("time = ", mid3-mid2);
   else
@@ -227,7 +227,7 @@ proc main() {
 
   write("sqrt    ");
   my_sqrt_ui(pi, C);
-  const mid4 = getCurrentTime();
+  const mid4 = timeSinceEpoch().totalSeconds();
   if (printTimings) then
     writeln("time = ", mid4-mid3);
   else
@@ -235,7 +235,7 @@ proc main() {
 
   write("mul     ");
   mpf_mul(qi, qi, pi);
-  const end = getCurrentTime();
+  const end = timeSinceEpoch().totalSeconds();
   if (printTimings) then
     writeln("time = ", end - mid4);
   else
@@ -671,9 +671,9 @@ proc bs(a: c_ulong, b: c_ulong, gflag: c_uint, level: c_long) {
 
     if (level>=4) {           // tuning parameter
       if do_gcd_time {
-        const t = getCurrentTime();
+        const t = timeSinceEpoch().totalSeconds();
         fac_remove_gcd(p2, fp2, g1, fg1);
-        gcd_time += getCurrentTime() - t;
+        gcd_time += timeSinceEpoch().totalSeconds() - t;
       } else {
         fac_remove_gcd(p2, fp2, g1, fg1);
       }

--- a/test/multilocale/deitz/needMultiLocales/raCommCheck.chpl
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheck.chpl
@@ -87,7 +87,7 @@ proc main() {
   //
   [i in TableSpace] T(i) = i;
 
-  const startTime = getCurrentTime();              // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
   //
   // The main computation: Iterate over the set of updates and the
@@ -104,7 +104,7 @@ proc main() {
       T(r & indexMask) ^= r;
   stopCommDiagnostics();
 
-  const execTime = getCurrentTime() - startTime;   // capture the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;   // capture the elapsed time
 
   var Diagnostics = getCommDiagnostics();
   writeln("Locale: (gets, puts, forks, fast forks, non-blocking forks)");

--- a/test/npb/cg/bradc/cg-commented.chpl
+++ b/test/npb/cg/bradc/cg-commented.chpl
@@ -110,7 +110,7 @@ proc main() {
     //
     // check the time
     //
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
 
     //
     // run for the specified number of iterations
@@ -141,7 +141,7 @@ proc main() {
     //
     // check the time again
     //
-    const runtime = getCurrentTime() - startTime;
+    const runtime = timeSinceEpoch().totalSeconds() - startTime;
 
     if printTiming then writeln("Execution time = ", runtime);
 

--- a/test/npb/cg/bradc/cg-dense.chpl
+++ b/test/npb/cg/bradc/cg-dense.chpl
@@ -55,7 +55,7 @@ proc main() {
   for trial in 1..numTrials {
     X = 1.0;
 
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
 
     for it in 1..niter {
       const (Z, rnorm) = conjGrad(A, X);
@@ -67,7 +67,7 @@ proc main() {
       X = (1.0 / sqrt(+ reduce(Z*Z))) * Z;
     }
 
-    const runtime = getCurrentTime() - startTime;
+    const runtime = timeSinceEpoch().totalSeconds() - startTime;
 
     if printTiming then writeln("Execution time = ", runtime);
 

--- a/test/npb/cg/bradc/cg-ideal.chpl
+++ b/test/npb/cg/bradc/cg-ideal.chpl
@@ -49,7 +49,7 @@ proc main() {
   for trial in 1..numTrials {
     X = 1.0;
 
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
 
     for it in 1..niter {
       const (Z, rnorm) = conjGrad(A, X);
@@ -61,7 +61,7 @@ proc main() {
       X = (1.0 / sqrt(+ reduce(Z*Z))) * Z;
     }
 
-    const runtime = getCurrentTime() - startTime;
+    const runtime = timeSinceEpoch().totalSeconds() - startTime;
 
     if printTiming then writeln("Execution time = ", runtime);
 

--- a/test/npb/cg/bradc/cg-sparse-partred.chpl
+++ b/test/npb/cg/bradc/cg-sparse-partred.chpl
@@ -51,7 +51,7 @@ proc main() {
   for trial in 1..numTrials {
     X = 1.0;
 
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
 
     for it in 1..niter {
       const (Z, rnorm) = conjGrad(A, X);
@@ -63,7 +63,7 @@ proc main() {
       X = (1.0 / sqrt(+ reduce(Z*Z))) * Z;
     }
 
-    const runtime = getCurrentTime() - startTime;
+    const runtime = timeSinceEpoch().totalSeconds() - startTime;
 
     if printTiming then writeln("Execution time = ", runtime);
 

--- a/test/npb/cg/bradc/cg-sparse.chpl
+++ b/test/npb/cg/bradc/cg-sparse.chpl
@@ -50,7 +50,7 @@ proc main() {
   for trial in 1..numTrials {
     X = 1.0;
 
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
 
     for it in 1..niter {
       const (Z, rnorm) = conjGrad(A, X);
@@ -62,7 +62,7 @@ proc main() {
       X = (1.0 / sqrt(+ reduce(Z*Z))) * Z;
     }
 
-    const runtime = getCurrentTime() - startTime;
+    const runtime = timeSinceEpoch().totalSeconds() - startTime;
 
     if printTiming then writeln("Execution time = ", runtime);
 

--- a/test/npb/cg/bradc/cg.chpl
+++ b/test/npb/cg/bradc/cg.chpl
@@ -36,7 +36,7 @@ proc main() {
   for trial in 1..numTrials {
     X = 1.0;
 
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
 
     for it in 1..numIter {
       const (rnorm, Z) = conjGrad(A, X);
@@ -50,7 +50,7 @@ proc main() {
       X = normTemp(2)*Z;
     }
 
-    const runtime = getCurrentTime() - startTime;
+    const runtime = timeSinceEpoch().totalSeconds() - startTime;
 
     writeln("Execution time = ", runtime);
 

--- a/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.chpl
+++ b/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.chpl
@@ -35,12 +35,12 @@ proc main() {
   var execTime: [1..numTrials] real;                 // an array of timings
 
   for trial in 1..numTrials {                        // loop over the trials
-    const startTime = getCurrentTime();              // capture the start time
+    const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
     forall i in ProblemSpace do
       A[i] = B[i+0];
 
-    execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   }
 
   const validAnswer = verifyResults(A, B);           // verify...

--- a/test/optimizations/bulkcomm/alberto/Block/AllCasesPerformance.chpl
+++ b/test/optimizations/bulkcomm/alberto/Block/AllCasesPerformance.chpl
@@ -10,7 +10,7 @@ config const printTime=false;
 config const printOutput=false;
 config const printComm=false;
 
-var st,dt=getCurrentTime();
+var st,dt=timeSinceEpoch().totalSeconds();
 var e=false;
 //writeln(" N:",n," P:",p," Q:",q);
 //EXAMPLES 2d Block with and without stride
@@ -34,11 +34,11 @@ var d2Dom2={1..n,1..n};
 
 if printOutput then writeln("Example 1. Block Dist: d2A = d2C");
 if printComm then startCommDiagnostics();
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A=d2C;
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -61,7 +61,7 @@ if printComm{
     stopCommDiagnostics();
     myPrintComms("");
 }
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 
 if printTime then writeln("Example 2. Time elapsed: ", dt);
   //for (a,b) in zip(d2A[d2Dom1],d2C[d2Dom2]) do if (a!=b) {writeln("ERROR!!!!");e=true;}
@@ -77,11 +77,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom1]=d2B[d2Dom2];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -100,11 +100,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom1]=d2C[d2Dom2];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -123,11 +123,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom1]=d2C[d2Dom2];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -146,11 +146,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom1]=d2B[d2Dom2];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -168,11 +168,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom5]=d2C[d2Dom5];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -190,11 +190,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom6]=d2B[d2Dom6];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -213,11 +213,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom6]=d2B[d2Dom5];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -242,11 +242,11 @@ var d3Dom1={1..p by 4,1..p by 3 ,1..p by 2};
 
 if printOutput then writeln("Example 10: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -260,11 +260,11 @@ d3Dom1={1..p,1..p by 4,1..p};
 
 if printOutput then writeln("Example 11: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -278,11 +278,11 @@ d3Dom1={1..p by 4,1..p ,1..p by 2};
 
 if printOutput then writeln("Example 12: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -296,11 +296,11 @@ d3Dom1={1..p by 4,1..p by 3 ,1..p};
 
 if printOutput then writeln("Example 13: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -314,11 +314,11 @@ d3Dom1={1..p,1..p by 3 ,1..p by 2};
 
 if printOutput then writeln("Example 14: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -332,11 +332,11 @@ d3Dom1={1..p by 4,1..p,1..p};
 
 if printOutput then writeln("Example 15: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -351,11 +351,11 @@ var d3Dom4={1..p,1..p ,1..2*p by 4};
 
 if printOutput then writeln("Example 16: d3A",d3Dom1, " = d3B",d3Dom4," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom4];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -370,11 +370,11 @@ d3Dom4={1..2*p by 4,1..p,1..p};
 
 if printOutput then writeln("Example 17: d3A",d3Dom1, " = d3B",d3Dom4," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom4];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -397,11 +397,11 @@ var d4Dom_1={1..q,1..q,1..q ,1..q by 2};
 
 if printOutput then writeln("Example 18: d4C",d4Dom_1, " = d4D",d4Dom_1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d4C[d4Dom_1]=d4D[d4Dom_1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -413,11 +413,11 @@ writeln();
 d4Dom_1={1..q,1..q,1..q by 2,1..q};
 if printOutput then writeln("Example 19: d4C",d4Dom_1, " = d4D",d4Dom_1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d4C[d4Dom_1]=d4D[d4Dom_1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -429,11 +429,11 @@ writeln();
 d4Dom_1={1..q,1..q by 2,1..q,1..q};
 if printOutput then writeln("Example 20: d4C",d4Dom_1, " = d4D",d4Dom_1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d4C[d4Dom_1]=d4D[d4Dom_1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -446,11 +446,11 @@ writeln();
 d4Dom_1={1..q by 2,1..q,1..q,1..q};
 if printOutput then writeln("Example 21: d4C",d4Dom_1, " = d4D",d4Dom_1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d4C[d4Dom_1]=d4D[d4Dom_1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");

--- a/test/optimizations/bulkcomm/alberto/Block/ArrayAssignment.chpl
+++ b/test/optimizations/bulkcomm/alberto/Block/ArrayAssignment.chpl
@@ -20,15 +20,15 @@ if printOutput
 
 writeln();
 var D1={1..n by 4,1..n by 3 ,1..n by 2};
-var st,dt=getCurrentTime();
+var st,dt=timeSinceEpoch().totalSeconds();
 var elem=1;
 
 if printOutput then writeln("Block Dist. Example 1: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
@@ -37,162 +37,162 @@ D1={1..n,1..n by 4,1..n};
 
 if printOutput then writeln("Block Dist. Example 2: A",D1, " = B",D1," on ",numLocales," Locales:");
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 4,1..n ,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 3: A",D1, " = B",D1," on ",numLocales," Locales:");
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 4,1..n by 3 ,1..n};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 4: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n,1..n by 3 ,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 5: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 4,1..n,1..n};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 6: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b){ writeln("ERROR!!!!");}
 
 writeln();
 D1={1..n,1..n ,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 7: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n,1..n ,1..n by 2}; //001
 var D2={1..n,1..n ,1..2*n by 4};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 8: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n,1..n by 2,1..n by 2}; //011
 D2={1..n,1..2*n by 4 ,1..2*n by 4};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 9: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b){ writeln("ERROR!!!!");}
 
 writeln();
 D1={1..n by 3,1..n by 2,1..n by 2}; //111
 D2={1..n by 3,1..2*n by 4,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 10: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 2,1..n,1..n by 2};
 D2={1..2*n by 4,1..n,1..n by 2};//101
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 11: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 2,1..n,1..n};
 D2={1..2*n by 4,1..n,1..n};//100
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 12: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n,1..n by 2,1..n};
 D2={1..n,1..2*n by 4,1..n};//010
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 13: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
@@ -212,10 +212,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 14: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -236,10 +236,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 15: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -260,10 +260,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 16: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -285,10 +285,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 17: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -309,10 +309,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 18: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -334,10 +334,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 19: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -358,10 +358,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 20: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -381,13 +381,13 @@ if printOutput
 }
 writeln();
 var D3={1..n,1..n,1..n ,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 21: C",D3, " = D",D3," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(C,{1..n*n*n*n}) do a=i;
 C[D3]=D[D3];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(C[D3],D[D3]) do if (a!=b) then writeln("ERROR!!!!");

--- a/test/optimizations/bulkcomm/alberto/Block/perfTest.chpl
+++ b/test/optimizations/bulkcomm/alberto/Block/perfTest.chpl
@@ -29,7 +29,7 @@ proc main(){
   var i:int;
   var D1={1..n,1..n};
   var D2={1..n,1..n};
-  var st,dt=getCurrentTime();
+  var st,dt=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A2,{1..n*n}) do a=i;
 
   if printOutput then writeln("Block Dist. Example 1:");
@@ -51,9 +51,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=C2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -72,9 +72,9 @@ proc main(){
   D2={1..n ,1..n};
   if printOutput then writeln("Block Dist. Example 2:A",D1," = C",D2);
   if doDiagnostics then startCommDiagnostics();
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=B2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -99,9 +99,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=C2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -126,9 +126,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=C2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -152,9 +152,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=B2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -178,9 +178,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=C2[D6];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -205,11 +205,11 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D7]=C2[D7];
   // writeln("A2: ", A2);
   // writeln("C2: ", C2);
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -232,11 +232,11 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D8]=C2[D8];
   //  writeln("A2: ", A2);
   //  writeln("C2: ", C2);
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -260,9 +260,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=B2[D6];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -287,9 +287,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=B2[D7];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -315,9 +315,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=B2[D7];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -343,9 +343,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=B2[D7];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -371,9 +371,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=ADR[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -399,9 +399,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=ADR[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -428,9 +428,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D2]=ADR[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -455,9 +455,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   ADR[D1]=A2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -483,9 +483,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   ADR[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -510,9 +510,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   ADR[D1]=A2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -540,9 +540,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   ADR[D1] = BDR[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -573,11 +573,11 @@ proc main(){
 	  startCommDiagnostics();
 	}
       }
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
   
       ADR[D1] = BDR[D2];
   
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	if printComm{
 	  stopCommDiagnostics();
@@ -614,13 +614,13 @@ proc main(){
 	  }
 	}
   
-	st = getCurrentTime();
+	st = timeSinceEpoch().totalSeconds();
   
 	on Locales(1){
 	  ADR[D1] = CDR[D2];
 	}
   
-	dt = getCurrentTime()-st;
+	dt = timeSinceEpoch().totalSeconds()-st;
 	if doDiagnostics {
 	  if printComm{
 	    stopCommDiagnostics();
@@ -656,13 +656,13 @@ proc main(){
 	}
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){ 
       ADR[D1] = CDR[D2];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	if printComm{
 	  stopCommDiagnostics();
@@ -698,13 +698,13 @@ proc main(){
 	}
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){ 
       CDR[D1] = ADR[D2];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	if printComm{
 	  stopCommDiagnostics();
@@ -734,7 +734,7 @@ proc main(){
   //    startCommDiagnostics();
   //  }
 
-  //  st = getCurrentTime();
+  //  st = timeSinceEpoch().totalSeconds();
 
   //  on Locales(1){
   //ADR[D3] = CDR[D3];
@@ -743,7 +743,7 @@ proc main(){
   H[D3] = G[D3];
   //  }
 
-  //  dt = getCurrentTime()-st;
+  //  dt = timeSinceEpoch().totalSeconds()-st;
   //  if doDiagnostics {
   //    stopCommDiagnostics();
   //    myPrintComms("");
@@ -775,13 +775,13 @@ proc main(){
 	startCommDiagnostics();
       }   
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       CDR[D3] = ADR[D3];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");
@@ -812,13 +812,13 @@ proc main(){
 	startCommDiagnostics();
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       ADR[D4] = CDR[D4];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");
@@ -849,13 +849,13 @@ proc main(){
 	startCommDiagnostics();
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       CDR[D4] = ADR[D4];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");
@@ -887,13 +887,13 @@ proc main(){
 	startCommDiagnostics();
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       ADR[D5] = CDR[D5];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");
@@ -924,13 +924,13 @@ proc main(){
 	startCommDiagnostics();
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       CDR[D5] = ADR[D5];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");

--- a/test/optimizations/bulkcomm/alberto/Cyclic/AllCasesPerformance_Cyclic.chpl
+++ b/test/optimizations/bulkcomm/alberto/Cyclic/AllCasesPerformance_Cyclic.chpl
@@ -10,7 +10,7 @@ config const printTime=false;
 config const printOutput=false;
 config const printComm=false;
 
-var st,dt=getCurrentTime();
+var st,dt=timeSinceEpoch().totalSeconds();
 var e=false;
 //writeln(" N:",n," P:",p," Q:",q);
 //EXAMPLES 2d Block with and without stride
@@ -34,11 +34,11 @@ d2A=1;
 
 if printOutput then writeln("Example 1. Block Dist: d2A = d2C");
 if printComm then startCommDiagnostics();
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A=d2C;
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -61,7 +61,7 @@ if printComm{
     stopCommDiagnostics();
     myPrintComms("");
 }
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 
 if printTime then writeln("Example 2. Time elapsed: ", dt);
   for (a,b) in zip(d2A[d2Dom1],d2C[d2Dom2]) do if (a!=b) {writeln("ERROR!!!!");e=true;}
@@ -77,11 +77,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom1]=d2B[d2Dom2];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -100,11 +100,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom1]=d2C[d2Dom2];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -123,11 +123,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom1]=d2C[d2Dom2];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -146,11 +146,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom1]=d2B[d2Dom2];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -168,11 +168,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom5]=d2C[d2Dom5];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -190,11 +190,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom6]=d2B[d2Dom6];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -213,11 +213,11 @@ if printComm{
     resetCommDiagnostics();
     startCommDiagnostics();
 }
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
   
 d2A[d2Dom6]=d2B[d2Dom5];
   
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
     stopCommDiagnostics();
     myPrintComms("");
@@ -242,11 +242,11 @@ var d3Dom1={1..p by 4,1..p by 3 ,1..p by 2};
 
 if printOutput then writeln("Example 10: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -260,11 +260,11 @@ d3Dom1={1..p,1..p by 4,1..p};
 
 if printOutput then writeln("Example 11: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -278,11 +278,11 @@ d3Dom1={1..p by 4,1..p ,1..p by 2};
 
 if printOutput then writeln("Example 12: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -296,11 +296,11 @@ d3Dom1={1..p by 4,1..p by 3 ,1..p};
 
 if printOutput then writeln("Example 13: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -314,11 +314,11 @@ d3Dom1={1..p,1..p by 3 ,1..p by 2};
 
 if printOutput then writeln("Example 14: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -332,11 +332,11 @@ d3Dom1={1..p by 4,1..p,1..p};
 
 if printOutput then writeln("Example 15: d3A",d3Dom1, " = d3B",d3Dom1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -351,11 +351,11 @@ var d3Dom4={1..p,1..p ,1..2*p by 4};
 
 if printOutput then writeln("Example 16: d3A",d3Dom1, " = d3B",d3Dom4," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom4];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -370,11 +370,11 @@ d3Dom4={1..2*p by 4,1..p,1..p};
 
 if printOutput then writeln("Example 17: d3A",d3Dom1, " = d3B",d3Dom4," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d3A[d3Dom1]=d3B[d3Dom4];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -397,11 +397,11 @@ var d4Dom_1={1..q,1..q,1..q ,1..q by 2};
 
 if printOutput then writeln("Example 18: d4C",d4Dom_1, " = d4D",d4Dom_1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d4C[d4Dom_1]=d4D[d4Dom_1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -413,11 +413,11 @@ writeln();
 d4Dom_1={1..q,1..q,1..q by 2,1..q};
 if printOutput then writeln("Example 19: d4C",d4Dom_1, " = d4D",d4Dom_1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d4C[d4Dom_1]=d4D[d4Dom_1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -429,11 +429,11 @@ writeln();
 d4Dom_1={1..q,1..q by 2,1..q,1..q};
 if printOutput then writeln("Example 20: d4C",d4Dom_1, " = d4D",d4Dom_1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d4C[d4Dom_1]=d4D[d4Dom_1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");
@@ -446,11 +446,11 @@ for (a,b) in zip(d4C[d4Dom_1],d4D[d4Dom_1]) do if (a!=b) {writeln("ERROR!!!!");e
 d4Dom_1={1..q by 2,1..q,1..q,1..q};
 if printOutput then writeln("Example 21: d4C",d4Dom_1, " = d4D",d4Dom_1," on ",numLocales," Locales:");
 if printComm{ resetCommDiagnostics(); startCommDiagnostics();}
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
   d4C[d4Dom_1]=d4D[d4Dom_1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printComm{
   stopCommDiagnostics();
   myPrintComms("");

--- a/test/optimizations/bulkcomm/alberto/Cyclic/ArrayAssignment.chpl
+++ b/test/optimizations/bulkcomm/alberto/Cyclic/ArrayAssignment.chpl
@@ -25,15 +25,15 @@ if printOutput
 
 writeln();
 var D1={1..n by 4,1..n by 3 ,1..n by 2};
-var st,dt=getCurrentTime();
+var st,dt=timeSinceEpoch().totalSeconds();
 var elem=1;
 
 if printOutput then writeln("Block Dist. Example 1: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
@@ -42,162 +42,162 @@ D1={1..n,1..n by 4,1..n};
 
 if printOutput then writeln("Block Dist. Example 2: A",D1, " = B",D1," on ",numLocales," Locales:");
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 4,1..n ,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 3: A",D1, " = B",D1," on ",numLocales," Locales:");
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 4,1..n by 3 ,1..n};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 4: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n,1..n by 3 ,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 5: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 4,1..n,1..n};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 6: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b){ writeln("ERROR!!!!");}
 
 writeln();
 D1={1..n,1..n ,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 7: A",D1, " = B",D1," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D1];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D1]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n,1..n ,1..n by 2}; //001
 var D2={1..n,1..n ,1..2*n by 4};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 8: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n,1..n by 2,1..n by 2}; //011
 D2={1..n,1..2*n by 4 ,1..2*n by 4};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 9: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b){ writeln("ERROR!!!!");}
 
 writeln();
 D1={1..n by 3,1..n by 2,1..n by 2}; //111
 D2={1..n by 3,1..2*n by 4,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 10: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 2,1..n,1..n by 2};
 D2={1..2*n by 4,1..n,1..n by 2};//101
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 11: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n by 2,1..n,1..n};
 D2={1..2*n by 4,1..n,1..n};//100
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 12: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
 writeln();
 D1={1..n,1..n by 2,1..n};
 D2={1..n,1..2*n by 4,1..n};//010
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 13: A",D1, " = B",D2," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(A,{1..n*n*n}) do a=i;
 A[D1]=B[D2];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 
@@ -217,10 +217,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 14: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -241,10 +241,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 15: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -265,10 +265,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 16: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -290,10 +290,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 17: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -314,10 +314,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 18: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -339,10 +339,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 19: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -363,10 +363,10 @@ for h in 0..#Dom1.rank
 if elem==1
 {
   if printOutput then writeln("Block Dist. Example 20: A",D1, " = B",D2," on ",numLocales," Locales:");
-  st=getCurrentTime();
+  st=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A,{1..n*n*n}) do a=i;
   A[D1]=B[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if printOutput then writeln("Time: ", dt);
   for (a,b) in zip(A[D1],B[D2]) do if (a!=b) then writeln("ERROR!!!!");
 }
@@ -391,13 +391,13 @@ if printOutput
 }
 writeln();
 var D3={1..n,1..n,1..n ,1..n by 2};
-st=getCurrentTime();
+st=timeSinceEpoch().totalSeconds();
 
 if printOutput then writeln("Block Dist. Example 21: C",D3, " = D",D3," on ",numLocales," Locales:");
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,i) in zip(C,{1..n*n*n*n}) do a=i;
 C[D3]=D[D3];
 
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then writeln("Time: ", dt);
 forall (a,b) in zip(C[D3],D[D3]) do if (a!=b) then writeln("ERROR!!!!");

--- a/test/optimizations/bulkcomm/alberto/Cyclic/BlockToCyclic.chpl
+++ b/test/optimizations/bulkcomm/alberto/Cyclic/BlockToCyclic.chpl
@@ -34,7 +34,7 @@ proc main(){
   var D3={1..n by 1,1..n by 1,1..n by 1};
   var D4={1..n by 1,1..n by 1,1..n by 1};
   
-  var st,dt=getCurrentTime();
+  var st,dt=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A2,{1..n*n}) do a=i;
 //2D Examples
 // ==============================================================================
@@ -51,9 +51,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -78,9 +78,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -105,9 +105,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 3:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -132,9 +132,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 4:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -159,9 +159,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 5:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -184,9 +184,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 6:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -210,9 +210,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 7:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -238,9 +238,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 8:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -263,9 +263,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -289,9 +289,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -317,9 +317,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -344,9 +344,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -371,9 +371,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -398,9 +398,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -425,9 +425,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -453,9 +453,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -480,9 +480,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -508,9 +508,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -535,9 +535,9 @@ if printOutput then writeln(" Cyclic Dist <-- Block Dist. Example 9:CY",D1," = B
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A3[D3]=BD3[D4];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();

--- a/test/optimizations/bulkcomm/alberto/Cyclic/CyclicToBlock.chpl
+++ b/test/optimizations/bulkcomm/alberto/Cyclic/CyclicToBlock.chpl
@@ -34,7 +34,7 @@ proc main(){
   var D3={1..n by 1,1..n by 1,1..n by 1};
   var D4={1..n by 1,1..n by 1,1..n by 1};
   
-  var st,dt=getCurrentTime();
+  var st,dt=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A2,{1..n*n}) do a=i;
 //2D Examples
 // ==============================================================================
@@ -51,9 +51,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -78,9 +78,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -105,9 +105,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -132,9 +132,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -159,9 +159,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -184,9 +184,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -210,9 +210,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -236,9 +236,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -262,9 +262,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -288,9 +288,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -316,9 +316,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -343,9 +343,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -370,9 +370,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -397,9 +397,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -424,9 +424,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -452,9 +452,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -479,9 +479,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -507,9 +507,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -534,9 +534,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD3[D4]=A3[D3];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();

--- a/test/optimizations/bulkcomm/alberto/Cyclic/perfTest.chpl
+++ b/test/optimizations/bulkcomm/alberto/Cyclic/perfTest.chpl
@@ -43,7 +43,7 @@ proc main(){
   var i:int;
   var D1={1..n by 1,1..n by 1};
   var D2={1..n by 1,1..n by 1};
-  var st,dt=getCurrentTime();
+  var st,dt=timeSinceEpoch().totalSeconds();
   for (a,i) in zip(A2,{1..n*n}) do a=i;
 
   if printOutput then writeln("Cyclic Dist. Example 1:");
@@ -65,9 +65,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=C2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -86,9 +86,9 @@ proc main(){
   D2={1..n ,1..n};
   if printOutput then writeln("Cyclic Dist. Example 2:A",D1," = C",D2);
   if doDiagnostics then startCommDiagnostics();
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=B2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -113,9 +113,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=C2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -140,9 +140,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=C2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -166,9 +166,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=B2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -192,9 +192,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=C2[D6];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -219,11 +219,11 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D7]=C2[D7];
   // writeln("A2: ", A2);
   // writeln("C2: ", C2);
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -246,11 +246,11 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D8]=C2[D8];
   //  writeln("A2: ", A2);
   //  writeln("C2: ", C2);
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -274,9 +274,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=B2[D6];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -301,9 +301,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=B2[D7];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -329,9 +329,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=B2[D7];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -357,9 +357,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D6]=B2[D7];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -385,9 +385,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -413,9 +413,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -440,9 +440,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -467,9 +467,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=BD[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -494,9 +494,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -522,9 +522,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -549,9 +549,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -576,9 +576,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   BD[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -602,9 +602,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=ADR[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -630,9 +630,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D1]=ADR[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -659,9 +659,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   A2[D2]=ADR[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -686,9 +686,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   ADR[D1]=A2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -714,9 +714,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   ADR[D2]=A2[D1];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -741,9 +741,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   ADR[D1]=A2[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -771,9 +771,9 @@ proc main(){
       startCommDiagnostics();
     }
   }
-  st = getCurrentTime();
+  st = timeSinceEpoch().totalSeconds();
   ADR[D1] = BDR[D2];
-  dt = getCurrentTime()-st;
+  dt = timeSinceEpoch().totalSeconds()-st;
   if doDiagnostics {
     if printComm{
       stopCommDiagnostics();
@@ -804,11 +804,11 @@ proc main(){
 	  startCommDiagnostics();
 	}
       }
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
   
       ADR[D1] = BDR[D2];
   
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	if printComm{
 	  stopCommDiagnostics();
@@ -845,13 +845,13 @@ proc main(){
 	  }
 	}
   
-	st = getCurrentTime();
+	st = timeSinceEpoch().totalSeconds();
   
 	on Locales(1){
 	  ADR[D1] = CDR[D2];
 	}
   
-	dt = getCurrentTime()-st;
+	dt = timeSinceEpoch().totalSeconds()-st;
 	if doDiagnostics {
 	  if printComm{
 	    stopCommDiagnostics();
@@ -887,13 +887,13 @@ proc main(){
 	}
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){ 
       ADR[D1] = CDR[D2];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	if printComm{
 	  stopCommDiagnostics();
@@ -929,13 +929,13 @@ proc main(){
 	}
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){ 
       CDR[D1] = ADR[D2];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	if printComm{
 	  stopCommDiagnostics();
@@ -965,7 +965,7 @@ proc main(){
   //    startCommDiagnostics();
   //  }
 
-  //  st = getCurrentTime();
+  //  st = timeSinceEpoch().totalSeconds();
 
   //  on Locales(1){
   //ADR[D3] = CDR[D3];
@@ -974,7 +974,7 @@ proc main(){
   H[D3] = G[D3];
   //  }
 
-  //  dt = getCurrentTime()-st;
+  //  dt = timeSinceEpoch().totalSeconds()-st;
   //  if doDiagnostics {
   //    stopCommDiagnostics();
   //    myPrintComms("");
@@ -1006,13 +1006,13 @@ proc main(){
 	startCommDiagnostics();
       }   
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       CDR[D3] = ADR[D3];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");
@@ -1043,13 +1043,13 @@ proc main(){
 	startCommDiagnostics();
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       ADR[D4] = CDR[D4];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");
@@ -1080,13 +1080,13 @@ proc main(){
 	startCommDiagnostics();
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       CDR[D4] = ADR[D4];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");
@@ -1118,13 +1118,13 @@ proc main(){
 	startCommDiagnostics();
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       ADR[D5] = CDR[D5];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");
@@ -1155,13 +1155,13 @@ proc main(){
 	startCommDiagnostics();
       }
 
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
 
       //  on Locales(1){
       CDR[D5] = ADR[D5];
       //  }
 
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
       if doDiagnostics {
 	stopCommDiagnostics();
 	myPrintComms("");

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_assignment.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_assignment.chpl
@@ -104,26 +104,26 @@ proc main() {
   
   initVectors(Twiddles, z);            // initialize twiddles and input vector z
   var t1,t2,T1,T2,T3,T4: real;
-  const startTime = getCurrentTime();  // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();  // capture the start time
   [(a,b) in zip(Zblk, z)] a = conjg(b);      // store the conjugate of z in Zblk
 
   //Comm y tieme bitReverse 
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   bitReverseShuffle(Zblk);                // permute Zblk
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T1=t2-t1;
 
   //Comm and Time dfft  
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   dfft(Zblk, Twiddles, cyclicPhase=false); // compute the DFFT, block phases
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T2=t2-t1;
 
   //Comm and Time first forall
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   //  copyBtoC(Zblk,Zcyc);
   Zcyc=Zblk;
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T3=t2-t1;
 
   /*
@@ -133,20 +133,20 @@ proc main() {
     writeln("ERROR = ",e);
     if (e==0.0) then writeln("Correct"); else writeln("Wrong!");
   */
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   dfft(Zcyc, Twiddles, cyclicPhase=true); // compute the DFFT, cyclic phases
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T2=T2+t2-t1; 
  
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   //    forall (b, c) in zip(Zblk, Zcyc) do        // copy vector back to Block storage
   //   b = c;
   //  copyCtoB(Zblk,Zcyc);
   Zblk=Zcyc;
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T4=t2-t1;
 
-  const execTime = getCurrentTime() - startTime;     // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;     // store the elapsed time
   //  writeln("bitReverse Time = ",T1);  
   //  writeln("dffts Time = ",T2," copyBtoC time= ",T3, " copyCtoB time= ",T4);
 

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_bulk.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_bulk.chpl
@@ -246,25 +246,25 @@ proc main() {
 
   initVectors(Twiddles, z);            // initialize twiddles and input vector z
   var t1,t2,T1,T2,T3,T4: real;
-  const startTime = getCurrentTime();  // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();  // capture the start time
   [(a,b) in zip(Zblk, z)] a = conjg(b);      // store the conjugate of z in Zblk
 
   //Comm y tieme bitReverse
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   bitReverseShuffle(Zblk);                // permute Zblk
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T1=t2-t1;
 
   //Comm and Time dfft
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   dfft(Zblk, Twiddles, cyclicPhase=false); // compute the DFFT, block phases
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T2=t2-t1;
 
   //Comm and Time first forall
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   copyBtoC(Zblk,Zcyc);
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T3=t2-t1;
 
   /*
@@ -274,19 +274,19 @@ proc main() {
     writeln("ERROR = ",e);
     if (e==0.0) then writeln("Correct"); else writeln("Wrong!");
   */
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   dfft(Zcyc, Twiddles, cyclicPhase=true); // compute the DFFT, cyclic phases
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T2=T2+t2-t1;
 
-  t1=getCurrentTime();
+  t1=timeSinceEpoch().totalSeconds();
   //    forall (b, c) in zip(Zblk, Zcyc) do        // copy vector back to Block storage
   //   b = c;
   copyCtoB(Zblk,Zcyc);
-  t2=getCurrentTime();
+  t2=timeSinceEpoch().totalSeconds();
   T4=t2-t1;
 
-  const execTime = getCurrentTime() - startTime;     // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;     // store the elapsed time
   //  writeln("bitReverse Time = ",T1);
   //  writeln("dffts Time = ",T2," copyBtoC time= ",T3, " copyCtoB time= ",T4);
 

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/PARACR-BC-bulk.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/PARACR-BC-bulk.chpl
@@ -201,7 +201,7 @@ proc main(){
     exit(0);
   }
 
-  if timer then t1=getCurrentTime();
+  if timer then t1=timeSinceEpoch().totalSeconds();
 
   /*********************/
   /* Elimination Phase */
@@ -225,10 +225,10 @@ proc main(){
   /********************************************/    
   /* Change from Block to Cyclic Distribution */
   /********************************************/
-  if timer then t5=getCurrentTime();
+  if timer then t5=timeSinceEpoch().totalSeconds();
   if (RedistStage&1) then {copyBtoC(AA,P);copyBtoC(BB,Q);copyBtoC(CC,R);copyBtoC(DD,S);}
   else {copyBtoC(A,P);copyBtoC(B,Q);copyBtoC(C,R);copyBtoC(D,S);}
-  if timer then t6=getCurrentTime(); 
+  if timer then t6=timeSinceEpoch().totalSeconds(); 
 
   /********************************************/    
   /*          Cyclic Distribution             */
@@ -254,7 +254,7 @@ proc main(){
     forall (x,s,q) in zip(X,S,Q) do x=s/q;
   }
 
-  if timer then t2=getCurrentTime();
+  if timer then t2=timeSinceEpoch().totalSeconds();
 	
   //writeln("Tridiagonal System Solution:");
   //PrintV(X);
@@ -297,7 +297,7 @@ proc Check()
 proc ComputeStage(A,B,C,D,AA,BB,CC,DD,j,Dom, msg="")
 {
   //  writeln("ComputeStage", msg, " j=", j);
-  if timer then t3=getCurrentTime();
+  if timer then t3=timeSinceEpoch().totalSeconds();
   const TtS:int=1<<(j-1); //// TtS stand for "Two to the Stage (minus 1)" which is = 2**(j-1)
   forall i in Dom do{
     //writeln("i ",i, " j ",j);
@@ -333,7 +333,7 @@ proc ComputeStage(A,B,C,D,AA,BB,CC,DD,j,Dom, msg="")
     }//if
   }//for all i
   if timer then {
-    t4=getCurrentTime();
+    t4=timeSinceEpoch().totalSeconds();
     CalcTime[j]=t4-t3;
     TotCalcTime+=CalcTime[j];
   }

--- a/test/optimizations/rafa/AgWCopyTest.chpl
+++ b/test/optimizations/rafa/AgWCopyTest.chpl
@@ -26,10 +26,10 @@ var B: [Dom] real;
     fillRandom(Ref, 31415);
   }
   A = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   A=B;
 
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in A.domain do
     if A[i] != Ref[i] then
       writeln("ERROR in whole array assignment: ", i);
@@ -46,9 +46,9 @@ var C: [Dom.translate(shift)] real;
     fillRandom(Ref, 92653);
   }
   A = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   A=C;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in A.domain do
     if A[i] != Ref[i] then
       writeln("ERROR in whole array assignment (+ offset): ", i);
@@ -65,9 +65,9 @@ var D: [Dom.translate(-shift)] real;
     fillRandom(Ref, 58979);
   }
   A = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   A=D;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in A.domain do
     if A[i] != Ref[i] then
       writeln("ERROR in whole array assignment (- offset): ", i);
@@ -89,9 +89,9 @@ ref Ba = B[DomSlice];
   }
   A = 0;
   Aa = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   Aa=Ba;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in Aa.domain do
     if Aa[i] != Refa[i] then
       writeln("ERROR in whole array assignment (alias): ", i);
@@ -109,9 +109,9 @@ ref Ca = C[DomSlice.translate(shift)];
   }
   A = 0;
   Aa = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   Aa=Ca;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in Aa.domain do
     if Aa[i] != Refa[i] then
       writeln("ERROR in whole array assignment (alias, + offset): ", i);
@@ -129,9 +129,9 @@ ref Da = D[DomSlice.translate(-shift)];
   }
   A = 0;
   Aa = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   Aa=Da;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in Aa.domain do
     if Aa[i] != Refa[i] then
       writeln("ERROR in whole array assignment (alias, - offset): ", i);

--- a/test/optimizations/sungeun/bulk_transfer/assign.chpl
+++ b/test/optimizations/sungeun/bulk_transfer/assign.chpl
@@ -21,9 +21,9 @@ var B: [Dom] real;
     fillRandom(Ref, 31415);
   }
   A = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   A = B;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in A.domain do
     if A[i] != Ref[i] then
       writeln("ERROR in whole array assignment: ", i);
@@ -40,9 +40,9 @@ var C: [Dom.translate(shift)] real;
     fillRandom(Ref, 92653);
   }
   A = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   A = C;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in A.domain do
     if A[i] != Ref[i] then
       writeln("ERROR in whole array assignment (+ offset): ", i);
@@ -59,9 +59,9 @@ var D: [Dom.translate(-shift)] real;
     fillRandom(Ref, 58979);
   }
   A = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   A = D;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in A.domain do
     if A[i] != Ref[i] then
       writeln("ERROR in whole array assignment (- offset): ", i);
@@ -83,9 +83,9 @@ ref Ba = B[DomSlice];
   }
   A = 0;
   Aa = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   Aa = Ba;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in Aa.domain do
     if Aa[i] != Refa[i] then
       writeln("ERROR in whole array assignment (alias): ", i);
@@ -103,9 +103,9 @@ ref Ca = C[DomSlice.translate(shift)];
   }
   A = 0;
   Aa = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   Aa = Ca;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in Aa.domain do
     if Aa[i] != Refa[i] then
       writeln("ERROR in whole array assignment (alias, + offset): ", i);
@@ -123,9 +123,9 @@ ref Da = D[DomSlice.translate(-shift)];
   }
   A = 0;
   Aa = -1;
-  var st = getCurrentTime();
+  var st = timeSinceEpoch().totalSeconds();
   Aa = Da;
-  var dt = getCurrentTime()-st;
+  var dt = timeSinceEpoch().totalSeconds()-st;
   for i in Aa.domain do
     if Aa[i] != Refa[i] then
       writeln("ERROR in whole array assignment (alias, - offset): ", i);

--- a/test/optimizations/sungeun/bulk_transfer/assignMultiloc.chpl
+++ b/test/optimizations/sungeun/bulk_transfer/assignMultiloc.chpl
@@ -164,22 +164,22 @@ proc assignMe(A, B) {
   var st, dt: real;
   select ttype {
     when testType.localGet {
-      st = getCurrentTime();
+      st = timeSinceEpoch().totalSeconds();
       A = B;
-      dt = getCurrentTime()-st;
+      dt = timeSinceEpoch().totalSeconds()-st;
     }
     when testType.localPut {
       on putLocale {
-        st = getCurrentTime();
+        st = timeSinceEpoch().totalSeconds();
         A = B;
-        dt = getCurrentTime()-st;
+        dt = timeSinceEpoch().totalSeconds()-st;
       }
     }
     when testType.remoteGet {
       on remoteLocale {
-        st = getCurrentTime();
+        st = timeSinceEpoch().totalSeconds();
         A = B;
-        dt = getCurrentTime()-st;
+        dt = timeSinceEpoch().totalSeconds()-st;
       }
     }
   }

--- a/test/parallel/begin/sungeun/initCopyWithBegin.chpl
+++ b/test/parallel/begin/sungeun/initCopyWithBegin.chpl
@@ -8,7 +8,7 @@ var glob: real;
 
 pragma "init copy fn"
 proc chpl__initCopy(r: R) {
-  begin with (ref glob) glob = getCurrentTime();
+  begin with (ref glob) glob = timeSinceEpoch().totalSeconds();
   return r;
 }
 

--- a/test/parallel/taskPar/figueroa/taskParallel.chpl
+++ b/test/parallel/taskPar/figueroa/taskParallel.chpl
@@ -8,7 +8,7 @@
 
 use Time;
 // This initializes the seed used for the random number generator.
-var seed: sync uint(32) = getCurrentTime() : uint(32);
+var seed: sync uint(32) = timeSinceEpoch().totalSeconds() : uint(32);
 
 var notThereYet: atomic bool;
 notThereYet.write(true);

--- a/test/parallel/taskPool/figueroa/ManyThreads.chpl
+++ b/test/parallel/taskPool/figueroa/ManyThreads.chpl
@@ -6,7 +6,7 @@ use Time;
 
 config const numThreads = 3000;
 var total: sync int = 0;
-var seed = getCurrentTime() : uint(32);
+var seed = timeSinceEpoch().totalSeconds() : uint(32);
 
 proc foo (x) {
 

--- a/test/performance/bradc/parOpEquals.chpl
+++ b/test/performance/bradc/parOpEquals.chpl
@@ -23,12 +23,12 @@ if printArrays then
 
 use Time;
 
-const startTime = getCurrentTime();
+const startTime = timeSinceEpoch().totalSeconds();
 
 for i in 1..numIters do
   A[B] += 1;
 
-const stopTime = getCurrentTime();
+const stopTime = timeSinceEpoch().totalSeconds();
 if printTiming then
   writeln("Time: ", stopTime-startTime);
 

--- a/test/performance/compiler/bradc/cg-sparse-timecomp.chpl
+++ b/test/performance/compiler/bradc/cg-sparse-timecomp.chpl
@@ -50,7 +50,7 @@ proc main() {
   for trial in 1..numTrials {
     X = 1.0;
 
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
 
     for it in 1..niter {
       const (Z, rnorm) = conjGrad(A, X);
@@ -62,7 +62,7 @@ proc main() {
       X = (1.0 / sqrt(+ reduce(Z*Z))) * Z;
     }
 
-    const runtime = getCurrentTime() - startTime;
+    const runtime = timeSinceEpoch().totalSeconds() - startTime;
 
     if printTiming then writeln("Execution time = ", runtime);
 

--- a/test/performance/compiler/bradc/fft-timecomp.chpl
+++ b/test/performance/compiler/bradc/fft-timecomp.chpl
@@ -34,13 +34,13 @@ proc main() {
 
   initVectors(Twiddles, z);
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
 
   Z = conjg(z);
   bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   const validAnswer = verifyResults(z, Z, Twiddles);
   printResults(validAnswer, execTime);

--- a/test/performance/sungeun/assign.chpl
+++ b/test/performance/sungeun/assign.chpl
@@ -13,11 +13,11 @@ writeln("n=", n, " m=", m);
 
 if initialize then
   fillRandom(B, 31415, algorithm=RNG.NPB);
-var st = getCurrentTime();
+var st = timeSinceEpoch().totalSeconds();
 for i in 1..n do
   for j in 1..m do
     A[i,j] = B[i,j];
-var dt = getCurrentTime()-st;
+var dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("assign serial:\n", A);
 if printTiming then
@@ -25,10 +25,10 @@ if printTiming then
 
 if initialize then
   fillRandom(B, 31415, algorithm=RNG.NPB);
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for (a,b) in zip(A,B) do
   a = b;
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("assign serial zipper:\n", A);
 if printTiming then
@@ -36,11 +36,11 @@ if printTiming then
 
 if initialize then
   fillRandom(B, 31415, algorithm=RNG.NPB);
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 forall i in 1..n do
   forall j in 1..m do
     A[i,j] = B[i,j];
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("assign nested forall:\n", A);
 if printTiming then
@@ -48,11 +48,11 @@ if printTiming then
 
 if initialize then
   fillRandom(B, 31415, algorithm=RNG.NPB);
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for i in 1..n do
   forall j in 1..m do
     A[i,j] = B[i,j];
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("assign for-forall:\n", A);
 if printTiming then
@@ -60,11 +60,11 @@ if printTiming then
 
 if initialize then
   fillRandom(B, 31415, algorithm=RNG.NPB);
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 forall i in 1..n do
   for j in 1..m do
     A[i,j] = B[i,j];
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("assign forall-for:\n", A);
 if printTiming then
@@ -72,10 +72,10 @@ if printTiming then
 
 if initialize then
   fillRandom(B, 31415, algorithm=RNG.NPB);
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 forall (a,b) in zip(A,B) do
   a = b;
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("assign forall zipper:\n", A);
 if printTiming then
@@ -83,9 +83,9 @@ if printTiming then
 
 if initialize then
   fillRandom(B, 31415, algorithm=RNG.NPB);
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 A = B;
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("assign whole array:\n", A);
 if printTiming then

--- a/test/performance/sungeun/assign_across_locales.chpl
+++ b/test/performance/sungeun/assign_across_locales.chpl
@@ -23,14 +23,14 @@ proc dit (A, param ttype: testTypes) {
       if loc.id != 0 then
         l[loc.id].readFE();
       if doCommDiag then startCommDiagnostics();
-      var st = getCurrentTime();
+      var st = timeSinceEpoch().totalSeconds();
       select ttype {
         when testTypes.init do A = loc.id+1;
         when testTypes.lhs do A = B;
         when testTypes.rhs do B = A;
         when testTypes.both do compilerError("Both is stupid.\n");
         }
-      var dt = getCurrentTime()-st;
+      var dt = timeSinceEpoch().totalSeconds()-st;
       if doCommDiag then stopCommDiagnostics();
       if printOutput {
         writeln("Remote ", ttype:string, " (Locale ", loc.id, "):");

--- a/test/performance/sungeun/copy_to_local.chpl
+++ b/test/performance/sungeun/copy_to_local.chpl
@@ -17,7 +17,7 @@ forall a in A do
 
 if printOutput then writeln(A);
 
-var st = getCurrentTime();
+var st = timeSinceEpoch().totalSeconds();
 coforall loc in Locales do on loc {
   const l = (here.id+1)%numLocales;
   var myA: [D] int(64);
@@ -37,6 +37,6 @@ coforall loc in Locales do on loc {
   }
   if printOutput then writeln(loc, ":\n", myA);
  }
-var dt = getCurrentTime()-st;
+var dt = timeSinceEpoch().totalSeconds()-st;
 
 if printTiming then writeln("Copy to local (", numLocales, " locales): ", dt);

--- a/test/performance/sungeun/dgemm.chpl
+++ b/test/performance/sungeun/dgemm.chpl
@@ -15,12 +15,12 @@ proc dgemm(p: indexType,       // number of rows in A
           B: [1..q, 1..r] t,
           C: [1..p, 1..r] t) {
   // Calculate (i,j) using a dot product of a row of A and a column of B.
-  const st = getCurrentTime();
+  const st = timeSinceEpoch().totalSeconds();
   for i in 1..p do
     for j in 1..r do
       for k in 1..q do
         C[i,j] -= A[i, k] * B[k, j];
-  const dt = getCurrentTime() - st;
+  const dt = timeSinceEpoch().totalSeconds() - st;
   if printOutput then
     writeln("dgemm:\n", C);
   if printTiming then
@@ -38,12 +38,12 @@ proc dgemm_local(p: indexType,       // number of rows in A
 
   A = A * 2.0 - 1.0;
   // Calculate (i,j) using a dot product of a row of A and a column of B.
-  const st = getCurrentTime();
+  const st = timeSinceEpoch().totalSeconds();
   for i in 1..p do
     for j in 1..r do
       for k in 1..q do
         C[i,j] -= A[i, k] * B[k, j];
-  const dt = getCurrentTime() - st;
+  const dt = timeSinceEpoch().totalSeconds() - st;
   if printOutput then
     writeln("dgemm_local:\n", C);
   if printTiming then

--- a/test/performance/sungeun/init.chpl
+++ b/test/performance/sungeun/init.chpl
@@ -9,41 +9,41 @@ var A: [1..n,1..m] real;
 
 writeln("n=", n, " m=", m);
 
-var st = getCurrentTime();
+var st = timeSinceEpoch().totalSeconds();
 for i in 1..n do
   for j in 1..m do
     A[i,j] = i+j;
-var dt = getCurrentTime()-st;
+var dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("init serial:\n", A);
 if printTiming then
   writeln("init serial: ", dt);
 
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 forall i in 1..n do
   forall j in 1..m do
     A[i,j] = i+j;
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("init nested forall:\n", A);
 if printTiming then
   writeln("init nested forall: ", dt);
 
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 for i in 1..n do
   forall j in 1..m do
     A[i,j] = i+j;
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("init for-forall:\n", A);
 if printTiming then
   writeln("init for-forall: ", dt);
 
-st = getCurrentTime();
+st = timeSinceEpoch().totalSeconds();
 forall i in 1..n do
   for j in 1..m do
     A[i,j] = i+j;
-dt = getCurrentTime()-st;
+dt = timeSinceEpoch().totalSeconds()-st;
 if printOutput then
   writeln("init forall-for:\n", A);
 if printTiming then

--- a/test/release/examples/benchmarks/hpcc/fft.chpl
+++ b/test/release/examples/benchmarks/hpcc/fft.chpl
@@ -102,7 +102,7 @@ proc main() {
 
   initVectors(Twiddles, z);            // initialize twiddles and input vector z
 
-  const startTime = getCurrentTime();  // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();  // capture the start time
 
   [(a,b) in zip(Zblk, z)] a = conjg(b);      // store the conjugate of z in Zblk
   bitReverseShuffle(Zblk);                // permute Zblk
@@ -117,7 +117,7 @@ proc main() {
   forall (b, c) in zip(Zblk, Zcyc) do        // copy vector back to Block storage
     b = c;
 
-  const execTime = getCurrentTime() - startTime;     // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;     // store the elapsed time
 
   const validAnswer = verifyResults(z, Zblk, Zcyc, Twiddles); // validate answer
   printResults(validAnswer, execTime);               // print the results

--- a/test/release/examples/benchmarks/hpcc/hpl.chpl
+++ b/test/release/examples/benchmarks/hpcc/hpl.chpl
@@ -86,13 +86,13 @@ proc main() {
 
   initAB(Ab);
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, Ab, piv);                 // compute the LU factorization
 
   var x = backwardSub(n, Ab);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
   //
   // Validate the answer and print the results

--- a/test/release/examples/benchmarks/hpcc/ptrans.chpl
+++ b/test/release/examples/benchmarks/hpcc/ptrans.chpl
@@ -90,7 +90,7 @@ proc main() {
   // Compute  C = beta C + A'
   // ------------------------
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
     
   if (beta == 1.0) then
     forall (i,j) in TransposeDom do
@@ -104,7 +104,7 @@ proc main() {
     forall (i,j) in TransposeDom do
       C[i,j] = beta * C[i,j]  +  A[j,i];
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
   
   const validAnswer = verifyResults(C, error_tolerance);
   printResults(validAnswer, execTime);

--- a/test/release/examples/benchmarks/hpcc/ra-atomics.chpl
+++ b/test/release/examples/benchmarks/hpcc/ra-atomics.chpl
@@ -108,7 +108,7 @@ proc main() {
   //
   [i in TableSpace] T(i).poke(i);
 
-  const startTime = getCurrentTime();              // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
   //
   // The main computation: Iterate over the set of updates and the
@@ -120,7 +120,7 @@ proc main() {
   forall (_, r) in zip(Updates, RAStream()) do
     T(r & indexMask).xor(r);
 
-  const execTime = getCurrentTime() - startTime;   // capture the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;   // capture the elapsed time
 
   const validAnswer = verifyResults(T);            // verify the updates
   printResults(validAnswer, execTime);             // print the results

--- a/test/release/examples/benchmarks/hpcc/ra.chpl
+++ b/test/release/examples/benchmarks/hpcc/ra.chpl
@@ -132,7 +132,7 @@ proc main() {
   //
   [i in TableSpace] T[i] = i;
 
-  const startTime = getCurrentTime();              // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
   //
   // The main computation: Iterate over the set of updates and the
@@ -154,7 +154,7 @@ proc main() {
     forall (_, r) in zip(Updates, RAStream()) do
       T[r & indexMask] ^= r;
 
-  const execTime = getCurrentTime() - startTime;   // capture the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;   // capture the elapsed time
 
   const validAnswer = verifyResults(T);            // verify the updates
   printResults(validAnswer, execTime);             // print the results

--- a/test/release/examples/benchmarks/hpcc/stream-ep.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream-ep.chpl
@@ -98,7 +98,7 @@ proc main() {
     initVectors(B, C);    // Initialize the input vectors, B and C
 
     for trial in 1..numTrials {                        // loop over the trials
-      const startTime = getCurrentTime();              // capture the start time
+      const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
       //
       // *** The main loop looks identical to stream.chpl.  However,
@@ -108,7 +108,7 @@ proc main() {
       forall (a, b, c) in zip(A, B, C) do
         a = b + alpha * c;
 
-      execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+      execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
     }
 
     //

--- a/test/release/examples/benchmarks/hpcc/stream.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream.chpl
@@ -72,7 +72,7 @@ proc main() {
   var execTime: [1..numTrials] real;                 // an array of timings
 
   for trial in 1..numTrials {                        // loop over the trials
-    const startTime = getCurrentTime();              // capture the start time
+    const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
     //
     // The main loop: Iterate over the vectors A, B, and C in a
@@ -82,7 +82,7 @@ proc main() {
     forall (a, b, c) in zip(A, B, C) do
       a = b + alpha * c;
 
-    execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   }
 
   const validAnswer = verifyResults(A, B, C);        // verify...

--- a/test/release/examples/benchmarks/hpcc/variants/ra-cleanloop.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/ra-cleanloop.chpl
@@ -128,7 +128,7 @@ proc main() {
   //
   [i in TableSpace] T[i] = i;
 
-  const startTime = getCurrentTime();              // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
   //
   // The main computation: Iterate over the set of updates and the
@@ -156,7 +156,7 @@ proc main() {
     forall (_, r) in zip(Updates, RAStream()) do
       T[r & indexMask] ^= r;
 
-  const execTime = getCurrentTime() - startTime;   // capture the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;   // capture the elapsed time
 
   const validAnswer = verifyResults(T);            // verify the updates
   printResults(validAnswer, execTime);             // print the results

--- a/test/release/examples/benchmarks/hpcc/variants/ra-unordered-atomics.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/ra-unordered-atomics.chpl
@@ -95,7 +95,7 @@ proc main() {
   //
   [i in TableSpace] T(i).poke(i);
 
-  const startTime = getCurrentTime();              // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
   //
   // The main computation: Iterate over the set of updates and the
@@ -107,7 +107,7 @@ proc main() {
   forall (_, r) in zip(Updates, RAStream()) do
     T(r & indexMask).unorderedXor(r);
 
-  const execTime = getCurrentTime() - startTime;   // capture the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;   // capture the elapsed time
 
   const validAnswer = verifyResults(T);            // verify the updates
   printResults(validAnswer, execTime);             // print the results

--- a/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
@@ -72,7 +72,7 @@ proc main() {
   var execTime: [1..numTrials] real;                 // an array of timings
 
   for trial in 1..numTrials {                        // loop over the trials
-    const startTime = getCurrentTime();              // capture the start time
+    const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
     //
     // The main loop: Use promotion/whole-array operations to compute
@@ -80,7 +80,7 @@ proc main() {
     //
     A = B + alpha * C;
 
-    execTime(trial) = getCurrentTime() - startTime;  // store the elapsed time
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   }
 
   const validAnswer = verifyResults(A, B, C);        // verify...

--- a/test/release/examples/benchmarks/lulesh/lulesh.chpl
+++ b/test/release/examples/benchmarks/lulesh/lulesh.chpl
@@ -285,9 +285,9 @@ proc main() {
   initLulesh();
 
   var st: real;
-  if doTiming then st = getCurrentTime();
+  if doTiming then st = timeSinceEpoch().totalSeconds();
   while (time < stoptime && cycle < maxcycles) {
-    const iterTime = if showProgress then getCurrentTime() else 0.0;
+    const iterTime = if showProgress then timeSinceEpoch().totalSeconds() else 0.0;
 
     TimeIncrement();
 
@@ -300,14 +300,14 @@ proc main() {
     }
     if showProgress then
       writef("time = %er, dt=%er, %s", time, deltatime,
-             if doTiming then ", elapsed = " + (getCurrentTime()-iterTime):string +"\n"
+             if doTiming then ", elapsed = " + (timeSinceEpoch().totalSeconds()-iterTime):string +"\n"
                          else "\n");
   }
   if (cycle == maxcycles) {
     writeln("Stopped early due to reaching maxnumsteps");
   }
   if doTiming {
-    const et = getCurrentTime();
+    const et = timeSinceEpoch().totalSeconds();
     writeln("Total Time: ", et-st);
     writeln("Time/Cycle: ", (et-st)/cycle);
   }

--- a/test/release/examples/primers/timers.chpl
+++ b/test/release/examples/primers/timers.chpl
@@ -87,9 +87,9 @@ t.stop();
 // idiom to time the number of seconds something will take:
 //
 
-const start = getCurrentTime();
+const start = timeSinceEpoch().totalSeconds();
 sleep(1);
-const elapsed = getCurrentTime() - start;
+const elapsed = timeSinceEpoch().totalSeconds() - start;
 
 if !quiet then
   writeln("E. ", elapsed, " seconds");

--- a/test/runtime/configMatters/comm/bigTransfer.chpl
+++ b/test/runtime/configMatters/comm/bigTransfer.chpl
@@ -48,12 +48,12 @@ on Locales[numLocales - 1] {
   var B: [1..n] elemType;
   [i in B.domain] B(i) = (n + 1 - i):B.eltType;
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
   if doGET then
     B = A;
   else
     A = B;
-  const elapsedTime = getCurrentTime() - startTime;
+  const elapsedTime = timeSinceEpoch().totalSeconds() - startTime;
 
   if verify {
     const arraysMatch = && reduce [i in 1..n by verifyStride] B(i) == A(i);

--- a/test/studies/dijkstra/driverEdgeBtw.chpl
+++ b/test/studies/dijkstra/driverEdgeBtw.chpl
@@ -16,7 +16,7 @@ proc main() {
   var fin3 = open(load_file, iomode.r).reader();
 
   var init_tm: real;
-  const init_t0 = getCurrentTime();
+  const init_t0 = timeSinceEpoch().totalSeconds();
 
   fin.readln(nEdges);
 
@@ -74,7 +74,7 @@ proc main() {
   }
   fin3.close();
 
-  init_tm = getCurrentTime() - init_t0;
+  init_tm = timeSinceEpoch().totalSeconds() - init_t0;
 //  writeln("Initialization time: ", init_tm);
 
   displayGraph(Nodes, nNodes);
@@ -85,14 +85,14 @@ proc main() {
   writeln("Dijkstra Algorithm: Source to All");
 
   var dijkstra_tm: real;
-  const dijkstra_t0 = getCurrentTime();
+  const dijkstra_t0 = timeSinceEpoch().totalSeconds();
 
   var D4 = {0..(nNodes-1)};
   forall i in D4 {
     dijkstra(i, nEdges, nNodes, Edges, Nodes);   // All-pairs
   }
 
-  dijkstra_tm = getCurrentTime() - dijkstra_t0;
+  dijkstra_tm = timeSinceEpoch().totalSeconds() - dijkstra_t0;
 //  writeln("Compute time: ", dijkstra_tm);
 
   for i in D1 {

--- a/test/studies/hpcc/CommDiags/PRECOMP
+++ b/test/studies/hpcc/CommDiags/PRECOMP
@@ -17,7 +17,7 @@
 
 import sys, shutil
 
-timerstr = 'getCurrentTime()'
+timerstr = 'timeSinceEpoch()'
 testname = sys.argv[1][0:sys.argv[1].find('_commDiags')]
 
 #

--- a/test/studies/hpcc/FFT/bradc/fft.chpl
+++ b/test/studies/hpcc/FFT/bradc/fft.chpl
@@ -55,12 +55,12 @@ proc main() {
 
 
   // TIMED SECTION
-  var startTime = getCurrentTime();
+  var startTime = timeSinceEpoch().totalSeconds();
 
   bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  var execTime = getCurrentTime() - startTime;
+  var execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   verifyResults(z, Z, execTime, Twiddles);
 }

--- a/test/studies/hpcc/FFT/bradc/parallel/fft.chpl
+++ b/test/studies/hpcc/FFT/bradc/parallel/fft.chpl
@@ -36,13 +36,13 @@ proc main() {
 
   initVectors(Twiddles, z);
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
 
   Z = conjg(z);
   bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   const validAnswer = verifyResults(z, Z, Twiddles);
   printResults(validAnswer, execTime);

--- a/test/studies/hpcc/FFT/diten/fft.chpl
+++ b/test/studies/hpcc/FFT/diten/fft.chpl
@@ -87,7 +87,7 @@ proc main() {
 
   initVectors(Twiddles, z);            // initialize twiddles and input vector z
 
-  const startTime = getCurrentTime();  // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();  // capture the start time
 
   Z = conjg(z);                        // store the conjugate of z in Z
   bitReverseShuffle(Z);                // permute Z
@@ -98,7 +98,7 @@ proc main() {
   forall (b, c) in zip(Z, Zcyc) do
     b = c;
 
-  const execTime = getCurrentTime() - startTime;     // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;     // store the elapsed time
 
   const validAnswer = verifyResults(z, Z, Zcyc, Twiddles); // validate the answer
   printResults(validAnswer, execTime);               // print the results

--- a/test/studies/hpcc/FFT/fft-candidate-2d.chpl
+++ b/test/studies/hpcc/FFT/fft-candidate-2d.chpl
@@ -36,13 +36,13 @@ proc main() {
 
   initVectors(Twiddles, z);
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
 
   Z = conjg(z);
   bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   const validAnswer = verifyResults(z, Z, Twiddles);
   printResults(validAnswer, execTime);

--- a/test/studies/hpcc/FFT/fft-hpcc06-mta.chpl
+++ b/test/studies/hpcc/FFT/fft-hpcc06-mta.chpl
@@ -36,13 +36,13 @@ proc main() {
 
   initVectors(Twiddles, z);
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
 
   Z = conjg(z);
   bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   const validAnswer = verifyResults(z, Z, Twiddles);
   printResults(validAnswer, execTime);

--- a/test/studies/hpcc/FFT/fft-hpcc06.chpl
+++ b/test/studies/hpcc/FFT/fft-hpcc06.chpl
@@ -36,13 +36,13 @@ proc main() {
 
   initVectors(Twiddles, z);
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
 
   Z = conjg(z);
   bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   const validAnswer = verifyResults(z, Z, Twiddles);
   printResults(validAnswer, execTime);

--- a/test/studies/hpcc/FFT/marybeth/fft-test-even.chpl
+++ b/test/studies/hpcc/FFT/marybeth/fft-test-even.chpl
@@ -45,12 +45,12 @@ proc main() {
 
 
   // TIMED SECTION
-  var startTime = getCurrentTime();
+  var startTime = timeSinceEpoch().totalSeconds();
 
   Z = bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  var execTime = getCurrentTime() - startTime;
+  var execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   verifyResults(z, Z, execTime, Twiddles);
 }

--- a/test/studies/hpcc/FFT/marybeth/fft.chpl
+++ b/test/studies/hpcc/FFT/marybeth/fft.chpl
@@ -45,12 +45,12 @@ proc main() {
 
 
   // TIMED SECTION
-  var startTime = getCurrentTime();
+  var startTime = timeSinceEpoch().totalSeconds();
 
   Z = bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  var execTime = getCurrentTime() - startTime;
+  var execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   verifyResults(z, Z, execTime, Twiddles);
 }

--- a/test/studies/hpcc/FFT/marybeth/fft2d.chpl
+++ b/test/studies/hpcc/FFT/marybeth/fft2d.chpl
@@ -45,12 +45,12 @@ proc main() {
 
 
   // TIMED SECTION
-  var startTime = getCurrentTime();
+  var startTime = timeSinceEpoch().totalSeconds();
 
   Z = bitReverseShuffle(Z);
   dfft(Z, Twiddles);
 
-  var execTime = getCurrentTime() - startTime;
+  var execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   verifyResults(z, Z, execTime, Twiddles);
 }

--- a/test/studies/hpcc/HPL/bradc/hpl-blc+vass-dimensional.chpl
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc+vass-dimensional.chpl
@@ -75,13 +75,13 @@ proc main() {
 
   initAB(Ab);
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, Ab, piv);                 // compute the LU factorization
 
   var x = backwardSub(n, Ab);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
   //
   // Validate the answer and print the results

--- a/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.chpl
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.chpl
@@ -75,13 +75,13 @@ proc main() {
 
   initAB(Ab);
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, Ab, piv);                 // compute the LU factorization
 
   var x = backwardSub(n, Ab);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
   //
   // Validate the answer and print the results

--- a/test/studies/hpcc/HPL/bradc/hpl-blc.chpl
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc.chpl
@@ -71,13 +71,13 @@ proc main() {
 
   initAB(Ab);
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, Ab, piv);                 // compute the LU factorization
 
   var x = backwardSub(n, A, b);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
   //
   // Validate the answer and print the results

--- a/test/studies/hpcc/HPL/vass/bc.dim.chpl
+++ b/test/studies/hpcc/HPL/vass/bc.dim.chpl
@@ -92,11 +92,11 @@ writeln("n = ", n, "\n", "blkSize = ", blkSize, "\n", "AbD = ", AbD, "\n",
         "starting offsets = ", st1, ", ", st2, //MBC //BC
         "\n");
 
-const startTime = getCurrentTime();     // capture the start time
+const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
 LUFactorize();
 
-const execTime = getCurrentTime() - startTime;  // store the elapsed time
+const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
 write("DONE ");
 if reproducible {

--- a/test/studies/hpcc/HPL/vass/bc.md.chpl
+++ b/test/studies/hpcc/HPL/vass/bc.md.chpl
@@ -92,11 +92,11 @@ writeln("n = ", n, "\n", "blkSize = ", blkSize, "\n", "AbD = ", AbD, "\n",
         "starting offsets = ", st1, ", ", st2, //MBC //BC
         "\n");
 
-const startTime = getCurrentTime();     // capture the start time
+const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
 LUFactorize();
 
-const execTime = getCurrentTime() - startTime;  // store the elapsed time
+const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
 write("DONE ");
 if reproducible {

--- a/test/studies/hpcc/HPL/vass/bl.dim.chpl
+++ b/test/studies/hpcc/HPL/vass/bl.dim.chpl
@@ -92,11 +92,11 @@ writeln("n = ", n, "\n", "blkSize = ", blkSize, "\n", "AbD = ", AbD, "\n",
       //"starting offsets = ", st1, ", ", st2, //MBC //BC
         "\n");
 
-const startTime = getCurrentTime();     // capture the start time
+const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
 LUFactorize();
 
-const execTime = getCurrentTime() - startTime;  // store the elapsed time
+const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
 write("DONE ");
 if reproducible {

--- a/test/studies/hpcc/HPL/vass/bl.md.chpl
+++ b/test/studies/hpcc/HPL/vass/bl.md.chpl
@@ -92,11 +92,11 @@ writeln("n = ", n, "\n", "blkSize = ", blkSize, "\n", "AbD = ", AbD, "\n",
       //"starting offsets = ", st1, ", ", st2, //MBC //BC
         "\n");
 
-const startTime = getCurrentTime();     // capture the start time
+const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
 LUFactorize();
 
-const execTime = getCurrentTime() - startTime;  // store the elapsed time
+const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
 write("DONE ");
 if reproducible {

--- a/test/studies/hpcc/HPL/vass/bug.chpl
+++ b/test/studies/hpcc/HPL/vass/bug.chpl
@@ -83,11 +83,11 @@ writeln("n = ", n, "\n", "blkSize = ", blkSize, "\n", "AbD = ", AbD, "\n",
         "starting offsets = ", st1, ", ", st2, //MBC //BC
         "\n");
 
-const startTime = getCurrentTime();     // capture the start time
+const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
 LUFactorize();
 
-const execTime = getCurrentTime() - startTime;  // store the elapsed time
+const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
 write("DONE ");
 if reproducible {

--- a/test/studies/hpcc/HPL/vass/chpl-seq-vs-c/hpl.chpl
+++ b/test/studies/hpcc/HPL/vass/chpl-seq-vs-c/hpl.chpl
@@ -83,13 +83,13 @@ proc main() {
    show2e(Ab); writeln();
   }
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, Ab, piv);                 // compute the LU factorization
 
   var x = backwardSub(n, Ab);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
   if verb || showresult { writeln("result"); show1e(x); writeln(); }
 

--- a/test/studies/hpcc/HPL/vass/hpl.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.chpl
@@ -118,13 +118,13 @@ config var reproducible = false, verbose = false;
 
   initAB();
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, piv);                 // compute the LU factorization
 
   var x = backwardSub(n);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 
   //
   // Validate the answer and print the results

--- a/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
@@ -200,7 +200,7 @@ compilerAssert(CHPL_NETWORK_ATOMICS == "none",
   if printArrays then
     writeln("after initAB, Ab=\n", Ab);
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
   LUFactorize(n, piv);                 // compute the LU factorization
 
@@ -216,7 +216,7 @@ compilerAssert(CHPL_NETWORK_ATOMICS == "none",
     writeln("after backwardSub, Ab=\n", Ab, "\nx=\n", x);
 
 
-  var execTime = getCurrentTime() - startTime;  // store the elapsed time
+  var execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   if execTime < 0 then execTime += 24*3600;          // adjust for date change
   printTime(execTime);
 

--- a/test/studies/hpcc/HPL/vass/hpl.performance.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.performance.chpl
@@ -205,14 +205,14 @@ var tInit, tPS1iter, tUBR1iter, tSC1call, tLF1iter, tBScall, tVer: VTimer;
 
   initAB();
 
-  const startTime = getCurrentTime();     // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();     // capture the start time
 
  if !onlyBsub then
   LUFactorize(n, piv);                 // compute the LU factorization
 
   ref x = backwardSub(n);  // perform the back substitution
 
-  const execTime = getCurrentTime() - startTime;  // store the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
   printTime(execTime);
   quit(doExit = false);
 

--- a/test/studies/hpcc/HPL/vass/schurComplement.chpl
+++ b/test/studies/hpcc/HPL/vass/schurComplement.chpl
@@ -91,11 +91,11 @@ var refsuccess = true;
 
 /////////// run it ///////////
 
-const startTime = getCurrentTime();
+const startTime = timeSinceEpoch().totalSeconds();
 
 schurComplement(blk);
 
-const execTime = getCurrentTime() - startTime;  // store the elapsed time
+const execTime = timeSinceEpoch().totalSeconds() - startTime;  // store the elapsed time
 write("DONE");
 if reproducible then writeln(); else writeln("  time = ", execTime);
 

--- a/test/studies/hpcc/HPL/vass/utils.chpl
+++ b/test/studies/hpcc/HPL/vass/utils.chpl
@@ -12,7 +12,7 @@ param vPrintMem = false;
 
   const vUserSep = "  ";
   const vGB = (1024**3):real;
-  const vStartTime = getCurrentTime();
+  const vStartTime = timeSinceEpoch().totalSeconds();
   var   vLapTime   = vStartTime;
   var   vLapMem    = getCurrentMem();
 
@@ -21,7 +21,7 @@ param vPrintMem = false;
 
   proc getCurrentTimeLoc() {  // go to the same node for the timer
     var result: vLapTime.type;
-    on vLapTime.locale do result = getCurrentTime();
+    on vLapTime.locale do result = timeSinceEpoch().totalSeconds();
     return result;
   }
 

--- a/test/studies/hpcc/RA/bradc/parallel/ra-dist.chpl
+++ b/test/studies/hpcc/RA/bradc/parallel/ra-dist.chpl
@@ -34,14 +34,14 @@ proc main() {
 
   const UpdateSpace: domain(1, indexType) dmapped UpdateDist = {0..N_U-1};
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
 
   [i in TableSpace] T(i) = i;
 
   forall (i,r) in zip(UpdateSpace, RAStream()) do
     T(r & indexMask) ^= r;
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   const validAnswer = verifyResults(T, UpdateSpace);
   printResults(validAnswer, execTime);

--- a/test/studies/hpcc/RA/diten/ra.chpl
+++ b/test/studies/hpcc/RA/diten/ra.chpl
@@ -108,7 +108,7 @@ proc main() {
       myBuckets = new unmanaged Buckets();
     }
   }
-  const startTime = getCurrentTime();              // capture the start time
+  const startTime = timeSinceEpoch().totalSeconds();              // capture the start time
 
   //
   // The main computation: Iterate over the set of updates and the
@@ -150,7 +150,7 @@ proc main() {
   }
 */
 
-  const execTime = getCurrentTime() - startTime;   // capture the elapsed time
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;   // capture the elapsed time
 
   const validAnswer = verifyResults();             // verify the updates
   printResults(validAnswer, execTime);             // print the results

--- a/test/studies/hpcc/RA/ra-hpcc06.chpl
+++ b/test/studies/hpcc/RA/ra-hpcc06.chpl
@@ -31,7 +31,7 @@ proc main() {
 
   const UpdateSpace: domain(1, indexType) = [0:indexType..#N_U];
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
 
   [i in TableSpace] T(i) = i;
 
@@ -39,7 +39,7 @@ proc main() {
     for r in RAStream(block.size, block.low) do
       T(r & indexMask) ^= r;
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   const validAnswer = verifyResults(T, UpdateSpace);
   printResults(validAnswer, execTime);

--- a/test/studies/hpcc/RA/ra-seq.chpl
+++ b/test/studies/hpcc/RA/ra-seq.chpl
@@ -49,14 +49,14 @@ proc main() {
 
   const UpdateSpace: domain(1, indexType) = {0:indexType..#N_U};
 
-  const startTime = getCurrentTime();
+  const startTime = timeSinceEpoch().totalSeconds();
 
   [i in TableSpace] T(i) = i;
 
   forall (_,r) in zip(myFakeLeader, RAStream()) do
     T(r & indexMask) ^= r;
 
-  const execTime = getCurrentTime() - startTime;
+  const execTime = timeSinceEpoch().totalSeconds() - startTime;
 
   const validAnswer = verifyResults(T, UpdateSpace);
   printResults(validAnswer, execTime);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
@@ -35,7 +35,7 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     // TODO: Want:
     // A = B + alpha * C;
     // But this doesn't yet result in parallelism
@@ -44,7 +44,7 @@ proc main() {
       A(i) = B(j) + alpha * C(k);
     }
 
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
@@ -35,7 +35,7 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     // TODO: Want:
     // A = B + alpha * C;
     // But this doesn't yet result in parallelism
@@ -44,7 +44,7 @@ proc main() {
       a = b + alpha * c;
     }
 
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
@@ -33,9 +33,9 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     A = B + alpha * C;
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
@@ -40,7 +40,7 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     // TODO: Want:
     // A = B + alpha * C;
     // But this doesn't yet result in parallelism
@@ -49,7 +49,7 @@ proc main() {
       a = b + alpha * c;
     }
 
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   t3.start();

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
@@ -37,7 +37,7 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     // TODO: Want:
     // A = B + alpha * C;
     // But this doesn't work because we don't support promotion over classes
@@ -46,7 +46,7 @@ proc main() {
       a = b + alpha * c;
     }
 
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
@@ -37,7 +37,7 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     // TODO: Ultimately, Want:
     //
     //   A = B + alpha * C;
@@ -57,7 +57,7 @@ proc main() {
       }
     }
           
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
@@ -37,7 +37,7 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     // TODO: Ultimately, Want:
     //
     // A = B + alpha * C;
@@ -65,7 +65,7 @@ proc main() {
       }
     }
 
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
@@ -31,7 +31,7 @@ proc main() {
   var allValidAnswer: [LocaleSpace] bool;
   
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     coforall loc in Locales {
       on loc {
         const MyProblemSpace: domain(1, indexType) 
@@ -46,7 +46,7 @@ proc main() {
         allValidAnswer(here.id) = verifyResults(A, B, C, (trial == numTrials));
       }
     }
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = & reduce allValidAnswer;

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
@@ -40,9 +40,9 @@ proc main() {
       initVectors(B, C, ProblemSpace);
 
       for trial in 1..numTrials {
-        const startTime = getCurrentTime();
+        const startTime = timeSinceEpoch().totalSeconds();
         A = B + alpha * C;
-        allExecTime(here.id)(trial) = getCurrentTime() - startTime;
+        allExecTime(here.id)(trial) = timeSinceEpoch().totalSeconds() - startTime;
       }
 
       allValidAnswer(here.id) = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-nopromote.chpl
@@ -33,9 +33,9 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     [i in ProblemSpace] A(i) = B(i) + alpha * C(i);
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-slice.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-slice.chpl
@@ -33,9 +33,9 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     A(ProblemSpace) = B(ProblemSpace) + alpha * C(ProblemSpace);
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
+++ b/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
@@ -40,9 +40,9 @@ proc main() {
       initVectors(B, C, ProblemSpace);
 
       for trial in 1..numTrials {
-        const startTime = getCurrentTime();
+        const startTime = timeSinceEpoch().totalSeconds();
         local do A = B + alpha * C;
-        allExecTime(here.id)(trial) = getCurrentTime() - startTime;
+        allExecTime(here.id)(trial) = timeSinceEpoch().totalSeconds() - startTime;
       }
 
       allValidAnswer(here.id) = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/elliot/stream-spmd-barrier.chpl
+++ b/test/studies/hpcc/STREAMS/elliot/stream-spmd-barrier.chpl
@@ -37,14 +37,14 @@ proc main() {
 
   var barrier = new Barrier(numTasks, barrierType);
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     coforall tid in 0..#numTasks {
       barrier.barrier();
       for i in chunk(1..m, numTasks, tid) {
         A[i] = B[i] + alpha * C[i];
       }
     }
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/elliot/stream-task-placement.chpl
+++ b/test/studies/hpcc/STREAMS/elliot/stream-task-placement.chpl
@@ -44,11 +44,11 @@ proc main() {
   }
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     forall (a, b, c) in zip(A, B, C) {
       a = b + alpha * c;
     }
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/stream-hpcc06.chpl
+++ b/test/studies/hpcc/STREAMS/stream-hpcc06.chpl
@@ -33,9 +33,9 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     A = B + alpha * C;
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/hpcc/STREAMS/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/stream-nopromote.chpl
@@ -31,9 +31,9 @@ proc main() {
   var execTime: [1..numTrials] real;
 
   for trial in 1..numTrials {
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     [i in ProblemSpace] A(i) = B(i) + alpha * C(i);
-    execTime(trial) = getCurrentTime() - startTime;
+    execTime(trial) = timeSinceEpoch().totalSeconds() - startTime;
   }
 
   const validAnswer = verifyResults(A, B, C);

--- a/test/studies/kmeans/kmeansonepassreduction-minchange.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction-minchange.chpl
@@ -151,9 +151,9 @@ proc clone()
 
     //used to identify where should we insert a timer.
     writeln("start reduce");
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     var (error, counts, c1) = kmeansReduction reduce data1;
-    const endTime = getCurrentTime() - startTime;
+    const endTime = timeSinceEpoch().totalSeconds() - startTime;
 
     write("finish reduce");
     if printTiming then

--- a/test/studies/kmeans/kmeansonepassreduction-norecord2.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction-norecord2.chpl
@@ -141,9 +141,9 @@ proc clone()
 
     //used to identify where should we insert a timer.
     writeln("start reduce");
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     var (error, counts, c1)  = kmeansReduction reduce data1;
-    const endTime = getCurrentTime() - startTime;
+    const endTime = timeSinceEpoch().totalSeconds() - startTime;
     
     write("finish reduce");
     if printTiming then

--- a/test/studies/kmeans/kmeansonepassreduction.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction.chpl
@@ -162,9 +162,9 @@ proc clone()
     //used to identify where should we insert a timer.
     writeln("start reduce");
     var OnePassRedObj: redObj;
-    const startTime = getCurrentTime();
+    const startTime = timeSinceEpoch().totalSeconds();
     OnePassRedObj = kmeansReduction reduce data1;
-    const endTime = getCurrentTime() - startTime;
+    const endTime = timeSinceEpoch().totalSeconds() - startTime;
 
     write("finish reduce");
     if printTiming then

--- a/test/studies/lulesh/bradc/lulesh-dense.chpl
+++ b/test/studies/lulesh/bradc/lulesh-dense.chpl
@@ -233,9 +233,9 @@ proc main() {
   initLulesh();
 
   var st: real;
-  if doTiming then st = getCurrentTime();
+  if doTiming then st = timeSinceEpoch().totalSeconds();
   while (time < stoptime && cycle < maxcycles) {
-    const iterTime = if showProgress then getCurrentTime() else 0.0;
+    const iterTime = if showProgress then timeSinceEpoch().totalSeconds() else 0.0;
 
     TimeIncrement();
 
@@ -248,14 +248,14 @@ proc main() {
     }
     if showProgress then
       writef("time = %er, dt=%er, %s", time, deltatime,
-             if doTiming then ", elapsed = " + (getCurrentTime()-iterTime):string +"\n"
+             if doTiming then ", elapsed = " + (timeSinceEpoch().totalSeconds()-iterTime):string +"\n"
                          else "\n");
   }
   if (cycle == maxcycles) {
     writeln("Stopped early due to reaching maxnumsteps");
   }
   if doTiming {
-    const et = getCurrentTime();
+    const et = timeSinceEpoch().totalSeconds();
     writeln("Total Time: ", et-st);
     writeln("Time/Cycle: ", (et-st)/cycle);
   }

--- a/test/studies/lulesh/bradc/xyztuple/lulesh-dense-3tuple.chpl
+++ b/test/studies/lulesh/bradc/xyztuple/lulesh-dense-3tuple.chpl
@@ -243,9 +243,9 @@ proc main() {
   initLulesh();
 
   var st: real;
-  if doTiming then st = getCurrentTime();
+  if doTiming then st = timeSinceEpoch().totalSeconds();
   while (time < stoptime && cycle < maxcycles) {
-    const iterTime = if showProgress then getCurrentTime() else 0.0;
+    const iterTime = if showProgress then timeSinceEpoch().totalSeconds() else 0.0;
 
     TimeIncrement();
 
@@ -258,14 +258,14 @@ proc main() {
     }
     if showProgress then
       writef("time = %er, dt=%er%s\n", time, deltatime, 
-       if doTiming then ", elapsed = " + (getCurrentTime()-iterTime):string
+       if doTiming then ", elapsed = " + (timeSinceEpoch().totalSeconds()-iterTime):string
                    else "");
   }
   if (cycle == maxcycles) {
     writeln("Stopped early due to reaching maxnumsteps");
   }
   if doTiming {
-    const et = getCurrentTime();
+    const et = timeSinceEpoch().totalSeconds();
     writeln("Total Time: ", et-st);
     writeln("Time/Cycle: ", (et-st)/cycle);
   }

--- a/test/studies/lulesh/intelVectBug/lulesh.chpl
+++ b/test/studies/lulesh/intelVectBug/lulesh.chpl
@@ -283,9 +283,9 @@ proc main() {
   initLulesh();
 
   var st: real;
-  if doTiming then st = getCurrentTime();
+  if doTiming then st = timeSinceEpoch().totalSeconds();
   while (time < stoptime && cycle < maxcycles) {
-    const iterTime = if showProgress then getCurrentTime() else 0.0;
+    const iterTime = if showProgress then timeSinceEpoch().totalSeconds() else 0.0;
 
     TimeIncrement();
 
@@ -298,14 +298,14 @@ proc main() {
     }
     if showProgress then
       writef("time = %er, dt=%er, %s", time, deltatime,
-             if doTiming then ", elapsed = " + (getCurrentTime()-iterTime) +"\n"
+             if doTiming then ", elapsed = " + (timeSinceEpoch().totalSeconds()-iterTime) +"\n"
                          else "\n");
   }
   if (cycle == maxcycles) {
     writeln("Stopped early due to reaching maxnumsteps");
   }
   if doTiming {
-    const et = getCurrentTime();
+    const et = timeSinceEpoch().totalSeconds();
     writeln("Total Time: ", et-st);
     writeln("Time/Cycle: ", (et-st)/cycle);
   }

--- a/test/studies/paracr/asenjo/PARACR-B.chpl
+++ b/test/studies/paracr/asenjo/PARACR-B.chpl
@@ -43,7 +43,7 @@ proc main(){
     exit(0);
   }
 
-  if timer then t1=getCurrentTime();
+  if timer then t1=timeSinceEpoch().totalSeconds();
 
 /*********************/
 /* Elimination Phase */
@@ -71,7 +71,7 @@ proc main(){
     forall (x,d,b) in zip(X,D,B) do x=d/b;
   }
 
-  if timer then t2=getCurrentTime();
+  if timer then t2=timeSinceEpoch().totalSeconds();
 	
   //writeln("Tridiagonal System Solution:");
   //PrintV(X);
@@ -96,7 +96,7 @@ proc main(){
 proc ComputeStage(A,B,C,D,AA,BB,CC,DD,j, msg="")
 {
   //  writeln("ComputeStage", msg, " j=", j);
-  // if timer then t3=getCurrentTime();
+  // if timer then t3=timeSinceEpoch().totalSeconds();
   const TtS:int=1<<(j-1); //// TtS stand for "Two to the Stage (minus 1)" which is = 2**(j-1)
   forall i in Dom do{
     //writeln("i ",i, " j ",j);
@@ -132,7 +132,7 @@ proc ComputeStage(A,B,C,D,AA,BB,CC,DD,j, msg="")
     }//if
   }//for all i
   //if timer then {
-  //  t4=getCurrentTime();
+  //  t4=timeSinceEpoch().totalSeconds();
   //  CalcTime[j]=t4-t3;
   //  TotCalcTime+=CalcTime[j];
   //}

--- a/test/studies/paracr/asenjo/PARACR-BC.chpl
+++ b/test/studies/paracr/asenjo/PARACR-BC.chpl
@@ -58,7 +58,7 @@ proc main(){
     exit(0);
   }
 
-  if timer then t1=getCurrentTime();
+  if timer then t1=timeSinceEpoch().totalSeconds();
 
 /*********************/
 /* Elimination Phase */
@@ -82,10 +82,10 @@ proc main(){
 /********************************************/    
 /* Change from Block to Cyclic Distribution */
 /********************************************/
-  if timer then t5=getCurrentTime();
+  if timer then t5=timeSinceEpoch().totalSeconds();
   if (RedistStage&1) then {P=AA;Q=BB;R=CC;S=DD;}
   else {P=A;Q=B;R=C;S=D;}
-  if timer then t6=getCurrentTime(); 
+  if timer then t6=timeSinceEpoch().totalSeconds(); 
 
 /********************************************/    
 /*          Cyclic Distribution             */
@@ -111,7 +111,7 @@ proc main(){
     forall (x,s,q) in zip(X,S,Q) do x=s/q;
   }
 
- if timer then t2=getCurrentTime();
+ if timer then t2=timeSinceEpoch().totalSeconds();
 	
   //writeln("Tridiagonal System Solution:");
   //PrintV(X);
@@ -154,7 +154,7 @@ proc Check()
 proc ComputeStage(A,B,C,D,AA,BB,CC,DD,j,Dom, msg="")
 {
   //  writeln("ComputeStage", msg, " j=", j);
-  // if timer then t3=getCurrentTime();
+  // if timer then t3=timeSinceEpoch().totalSeconds();
   const TtS:int=1<<(j-1); //// TtS stand for "Two to the Stage (minus 1)" which is = 2**(j-1)
   forall i in Dom do{
     //writeln("i ",i, " j ",j);
@@ -190,7 +190,7 @@ proc ComputeStage(A,B,C,D,AA,BB,CC,DD,j,Dom, msg="")
     }//if
   }//for all i
   //if timer then {
-  //  t4=getCurrentTime();
+  //  t4=timeSinceEpoch().totalSeconds();
   //  CalcTime[j]=t4-t3;
   //  TotCalcTime+=CalcTime[j];
   //}

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-multiple-meeting-places.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-multiple-meeting-places.chpl
@@ -239,7 +239,7 @@ proc main() {
   if (numChameneos1 < 2 || numChameneos2 < 2 || numMeetings < 0) {
     writeln("Please specify numChameneos1 and numChameneos2 of at least 2, and numMeetings of at least 0.");
   } else {
-    var startTimeTotal = getCurrentTime();
+    var startTimeTotal = timeSinceEpoch().totalSeconds();
 
     printColorChanges();
 
@@ -252,22 +252,22 @@ proc main() {
     const population2 = populate(numChameneos2);
 
     if (verbose) {
-      var startTime = getCurrentTime();
+      var startTime = timeSinceEpoch().totalSeconds();
       run(population1, numChameneos1, meetingPlaces);
-      var endTime = getCurrentTime();
+      var endTime = timeSinceEpoch().totalSeconds();
       writeln("time for chameneos1 to meet = ", endTime - startTime);
       printInfo(population1);
 
-      startTime = getCurrentTime();
+      startTime = timeSinceEpoch().totalSeconds();
       run(population2, numChameneos2, meetingPlaces);
-      endTime = getCurrentTime();
+      endTime = timeSinceEpoch().totalSeconds();
       writeln("time for chameneos2 to meet = ", endTime - startTime);
       printInfo(population2);
     } else {
       runQuiet(population1, numChameneos1, meetingPlaces);
       runQuiet(population2, numChameneos1, meetingPlaces);
     }
-    var endTimeTotal = getCurrentTime();
+    var endTimeTotal = timeSinceEpoch().totalSeconds();
     if (verbose) {
       writeln("total execution time = ", endTimeTotal - startTimeTotal);
     }

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-v1.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-v1.chpl
@@ -212,7 +212,7 @@ proc main() {
   if (numChameneos1 < 2 || numChameneos2 < 2 || numMeetings < 0) {
     writeln("Please specify numChameneos1 and numChameneos2 of at least 2, and numMeetings of at least 0.");
   } else  {
-    var startTimeTotal = getCurrentTime();
+    var startTimeTotal = timeSinceEpoch().totalSeconds();
 
     printColorChanges();
 
@@ -222,15 +222,15 @@ proc main() {
     const population2 = populate(numChameneos2);
 
     if (verbose) {
-      var startTime = getCurrentTime();
+      var startTime = timeSinceEpoch().totalSeconds();
       run(population1, forest);
-      var endTime = getCurrentTime();
+      var endTime = timeSinceEpoch().totalSeconds();
       writeln("time for chameneos1 to meet = ", endTime - startTime);
       printInfo(population1);
 
-      startTime = getCurrentTime();
+      startTime = timeSinceEpoch().totalSeconds();
       run(population2, forest);
-      endTime = getCurrentTime();
+      endTime = timeSinceEpoch().totalSeconds();
       writeln("time for chameneos2 to meet = ", endTime - startTime);
       printInfo(population2);
     } else {
@@ -238,7 +238,7 @@ proc main() {
       runQuiet(population2, forest);
     }
 
-    var endTimeTotal = getCurrentTime();
+    var endTimeTotal = timeSinceEpoch().totalSeconds();
 
     if (verbose) {
       writeln("total execution time = ", endTimeTotal - startTimeTotal);

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux.chpl
@@ -198,7 +198,7 @@ proc main() {
   if (numChameneos1 < 2 || numChameneos2 < 2 || numMeetings < 0) {
     writeln("Please specify numChameneos1 and numChameneos2 of at least 2, and numMeetings of at least 0.");
   } else  {
-    var startTimeTotal = getCurrentTime();
+    var startTimeTotal = timeSinceEpoch().totalSeconds();
 
     printColorChanges();
 
@@ -207,20 +207,20 @@ proc main() {
     const population2           = populate(numChameneos2);
 
     if (verbose) {
-      var startTime = getCurrentTime();
+      var startTime = timeSinceEpoch().totalSeconds();
 
       run(population1, forest);
 
-      var endTime = getCurrentTime();
+      var endTime = timeSinceEpoch().totalSeconds();
 
       writeln("time for chameneos1 to meet = ", endTime - startTime);
       printInfo(population1);
 
-      startTime = getCurrentTime();
+      startTime = timeSinceEpoch().totalSeconds();
 
       run(population2, forest);
 
-      endTime = getCurrentTime();
+      endTime = timeSinceEpoch().totalSeconds();
       writeln("time for chameneos2 to meet = ", endTime - startTime);
       printInfo(population2);
     } else {
@@ -228,7 +228,7 @@ proc main() {
       runQuiet(population2, forest);
     }
 
-    var endTimeTotal = getCurrentTime();
+    var endTimeTotal = timeSinceEpoch().totalSeconds();
 
     if (verbose) {
       writeln("total execution time = ", endTimeTotal - startTimeTotal);

--- a/test/studies/sort/radix.chpl
+++ b/test/studies/sort/radix.chpl
@@ -17,7 +17,7 @@ proc radix_sort(Values, Permute, radix:int(64), nbits:int(64)): void {
     var Permute_old: [D1] int(64) = Permute; // Old permutation array
 
     var sortTime: real;                           // overall timing
-    const sortStartTime = getCurrentTime();       // capture the start time
+    const sortStartTime = timeSinceEpoch().totalSeconds();       // capture the start time
 
     var npasses:int(64) = (nbits / radix);
     if ( (npasses * radix) < nbits ) then npasses = npasses + 1;
@@ -31,7 +31,7 @@ proc radix_sort(Values, Permute, radix:int(64), nbits:int(64)): void {
       var All_counts: [D1] int(64);      // Storage for counting sort tallies
 
       var phaseTime: real;                        // timing of pass
-      const phaseStartTime = getCurrentTime();    // capture the pass start
+      const phaseStartTime = timeSinceEpoch().totalSeconds();    // capture the pass start
 
       // Mask of bits sorted on this pass
       var mask:int(64) = (nbuckets - 1) << (pass * radix);
@@ -86,14 +86,14 @@ proc radix_sort(Values, Permute, radix:int(64), nbits:int(64)): void {
       Permute_old = Permute;
       Permute = Tmp;
 
-      phaseTime = getCurrentTime() - phaseStartTime; // store the elapsed pass
+      phaseTime = timeSinceEpoch().totalSeconds() - phaseStartTime; // store the elapsed pass
 //      writeln("Completed pass ", pass, " in ", phaseTime, " sec    mask=", mask);
 
     }
 
     Permute = Permute_old;
 
-    sortTime = getCurrentTime() - sortStartTime;  // store the elapsed time
+    sortTime = timeSinceEpoch().totalSeconds() - sortStartTime;  // store the elapsed time
 //    writeln(npasses, " passes in ", sortTime, " secs");
 
     return;
@@ -111,10 +111,10 @@ var Permute_G: [D] int(64);
 
 var rngTime: real;
 writeln("Generating random numbers...");
-const rngStartTime = getCurrentTime();
+const rngStartTime = timeSinceEpoch().totalSeconds();
 fillRandom(F, 65535, algorithm=RNG.NPB);
 F_prime = (F * 9223372036854775808):int(64);
-rngTime = getCurrentTime() - rngStartTime;
+rngTime = timeSinceEpoch().totalSeconds() - rngStartTime;
 //writeln("Finished generating numbers in ", rngTime, " sec");
 
 forall i in D {
@@ -124,16 +124,16 @@ forall i in D {
 }
 
 var mwTime: real;
-const mwStartTime = getCurrentTime();
+const mwStartTime = timeSinceEpoch().totalSeconds();
 
 radix_sort(F_prime, Permute_F, 16, 64);
 radix_sort(G, Permute_G, 5, 5);
 
-mwTime = getCurrentTime() - mwStartTime;
+mwTime = timeSinceEpoch().totalSeconds() - mwStartTime;
 //writeln("----- Total Time = ", mwTime, " sec -----------------------------------------");
 
 var selfcheckTime: real;
-const selfcheckStartTime = getCurrentTime();
+const selfcheckStartTime = timeSinceEpoch().totalSeconds();
 var nerr_f: int(64) = 0;
 var nerr_g: int(64) = 0;
 
@@ -144,6 +144,6 @@ for i in (1..(npoints-1)) {
   if (G[Permute_G[i]] < G[Permute_G[(i-1)]]) then nerr_g = nerr_g + 1;
 }
 
-selfcheckTime = getCurrentTime() - selfcheckStartTime;
+selfcheckTime = timeSinceEpoch().totalSeconds() - selfcheckStartTime;
 writeln("Number of errors: f=", nerr_f, "  g=", nerr_g);
 //writeln("Checked in ", selfcheckTime, " sec");

--- a/test/trivial/diten/pi_monte_carlo.chpl
+++ b/test/trivial/diten/pi_monte_carlo.chpl
@@ -9,7 +9,7 @@ var count:int;
 var pi, startTime, totalTime: real;
 var rs = new owned NPBRandomStream(real, seed);
 
-startTime = getCurrentTime(TimeUnits.microseconds);
+startTime = timeSinceEpoch().totalSeconds();
 
 // Find random points on the complex plane in (0..1+i)
 // and count how many are outside the unit circle.
@@ -20,6 +20,6 @@ pi = 4 * (n-count):real(64) / n;
 
 // Write out the results
 writeln(pi);
-totalTime = (getCurrentTime(TimeUnits.microseconds) - startTime) / 1000000;
+totalTime = (timeSinceEpoch().totalSeconds() - startTime);
 if (verbose) then
   writeln("Calculation took: ", totalTime, " seconds");

--- a/test/users/franzf/v0/chpl/main.chpl
+++ b/test/users/franzf/v0/chpl/main.chpl
@@ -71,11 +71,11 @@ proc main() {
     }    
     
     //  benchmark computation
-    startTime = getCurrentTime(TimeUnits.microseconds);
+    startTime = timeSinceEpoch().totalSeconds() * 1_000_000;
     for i in 1..NUMRUNS {
       fft(N, Y, X);
     }
-    execTime = (getCurrentTime(TimeUnits.microseconds) - startTime)/NUMRUNS;
+    execTime = (timeSinceEpoch().totalSeconds()*1_000_000 - startTime)/NUMRUNS;
     if (printTimings) then
       writeln("fft_", N, ": ", execTime, "us = ", ops / execTime, " Mflop/s");
     else

--- a/test/users/franzf/v1/chpl/main.chpl
+++ b/test/users/franzf/v1/chpl/main.chpl
@@ -71,11 +71,11 @@ proc main() {
     }    
     
     //  benchmark computation
-    startTime = getCurrentTime(TimeUnits.microseconds);
+    startTime = timeSinceEpoch().totalSeconds()*1_000_000;
     for i in 1..NUMRUNS {
       fft(N, Y, X);
     }
-    execTime = (getCurrentTime(TimeUnits.microseconds) - startTime)/NUMRUNS;
+    execTime = (timeSinceEpoch().totalSeconds()*1_000_000 - startTime)/NUMRUNS;
     if (printTimings) then
       writeln("fft_", N, ": ", execTime, "us = ", ops / execTime, " Mflop/s");
     else

--- a/test/users/franzf/v2/chpl/main.chpl
+++ b/test/users/franzf/v2/chpl/main.chpl
@@ -71,11 +71,11 @@ proc main() {
         }    
     
         //  benchmark computation
-        startTime = getCurrentTime(TimeUnits.microseconds);
+        startTime = timeSinceEpoch().totalSeconds()*1_000_000;
         for i in 1..NUMRUNS {
             fft(N, Y, X);
         }
-        execTime = (getCurrentTime(TimeUnits.microseconds) - startTime)/NUMRUNS;
+        execTime = (timeSinceEpoch().totalSeconds()*1_000_000 - startTime)/NUMRUNS;
 	if (printTimings) then
           writeln("fft_", N, ": ", execTime, "us = ", ops / execTime, " Mflop/s");
 	else


### PR DESCRIPTION
Add a deprecation warning for 'Time.getCurrentTime'.

Update the Time and Random modules to use 'Time.timeSinceEpoch' instead. Update tests to use 'Time.timeSinceEpoch' instead. Update a PREDIFF script to look for 'timeSinceEpoch' instead of 'getCurrentTime'.

Add a deprecation test for 'Time.getCurrentTime'.

Closes https://github.com/chapel-lang/chapel/issues/14571
Closes https://github.com/Cray/chapel-private/issues/4182