### PR TITLE
Remove -Og for CHPL_DEVELOPER builds with GCC

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -32,7 +32,7 @@ RANLIB = ranlib
 # General Flags
 #
 
-DEBUG_CFLAGS = -g -Og
+DEBUG_CFLAGS = -g
 DEPEND_CFLAGS = -MMD -MP
 OPT_CFLAGS = -O3
 PROFILE_CFLAGS = -pg


### PR DESCRIPTION
Remove `-Og` optimization flag from GCC builds which was added in https://github.com/chapel-lang/chapel/pull/21434.

Unfortunately it seems that `-Og` causes us to run afoul of a GCC implementation quirk/bug which spuriously warns of maybe-uninitialized variables when using specifically the `-Og` level of optimization, but not higher levels of optimization or no optimization. [Here](https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=may%20be%20uninitialized) is a reference for GCC bugs with maybe-uninitialized warnings, and [this bug comment](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90710#c1) explains why this can happen for `-Og` specifically.

We considered the option of suppressing these warnings-as-errors with `-Wno-error=maybe-uninitialized` when using `-Og`, but this could potentially lead to a user of the debug configuration ignoring a valid maybe-uninitialized warning and only running into it later.

With this change, we are no longer using `-Og` in any configuration; https://github.com/chapel-lang/chapel/pull/21434 is completely undone.