### PR TITLE
Add a polling interval in email workflow using polling_interval_seconds

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -29,9 +29,10 @@ jobs:
         with:
           max_attempts: 4
           retry_on_exit_code: 2
-          timeout_seconds: 60  
+          timeout_seconds: 180
+          polling_interval_seconds: 60  
           command: |
-              curl --location --request GET $COMMIT_URL --header 'X-API-Key: ${{ secrets.GITHUB_TOKEN}}' -o commits.json
+              curl  --location --request GET $COMMIT_URL --header 'X-API-Key: ${{ secrets.GITHUB_TOKEN}}' -o commits.json
               if [ $? -ne 0 ]; then
                 echo "curl command to get commits payload failed"
                 exit 2

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -32,7 +32,7 @@ jobs:
           timeout_seconds: 180
           polling_interval_seconds: 60  
           command: |
-              curl  --location --request GET $COMMIT_URL --header 'X-API-Key: ${{ secrets.GITHUB_TOKEN}}' -o commits.json
+              curl --location --request GET $COMMIT_URL --header 'X-API-Key: ${{ secrets.GITHUB_TOKEN}}' -o commits.json
               if [ $? -ne 0 ]; then
                 echo "curl command to get commits payload failed"
                 exit 2


### PR DESCRIPTION
Adding a polling interval to the retry.

https://github.com/Cray/chapel-private/issues/4149

We usually see timeouts if the git server is busy, the default retry polling wait is 1 sec, retrying every second will add more workload to already loaded system so increased the polling interval to 60 sec.

Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>