### PR TITLE
Update hdf5 skipif to work with new showconfig output

### DIFF
--- a/test/library/packages/HDF5.skipif
+++ b/test/library/packages/HDF5.skipif
@@ -2,7 +2,7 @@
 
 # The HDF5 package requires the hdf5 library.
 
-if h5cc -showconfig 2>&1 | grep -q 'High-level library: yes' ; then
+if h5cc -showconfig 2>&1 | grep -q -E 'High-level library: yes|High-level library: ON' ; then
   echo 'False'
 else
   echo 'True'


### PR DESCRIPTION
Instead of "High-level library: yes" I'm seeing "High-level library: ON" for a spack installed hdf5 1.12.2.