### PR TITLE
Enable pkg-config support for our protobuf tooling

### DIFF
--- a/test/library/packages/ProtobufProtocolSupport/EXECENV
+++ b/test/library/packages/ProtobufProtocolSupport/EXECENV
@@ -1,1 +1,4 @@
-PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH
+#!/usr/bin/env bash
+
+echo "PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH"
+echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pkg-config protobuf --variable=libdir 2>/dev/null)"

--- a/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
+++ b/test/library/packages/ProtobufProtocolSupport/anyRunner.skipif
@@ -6,7 +6,15 @@ import os
 
 chplPath = os.path.join(os.environ['CHPL_HOME'], "bin", os.environ['CHPL_HOST_BIN_SUBDIR'])
 
-if which("protoc") is not None and which("protoc-gen-chpl", path=chplPath) is not None:
+have_protoc = which("protoc") is not None
+have_proto_gen_chpl = which("protoc-gen-chpl", path=chplPath) is not None
+try:
+    import google.protobuf
+    have_python_protobuf = True
+except ImportError:
+    have_python_protobuf = False
+
+if have_protoc and have_proto_gen_chpl and have_python_protobuf:
     print(False)
 else:
     print(True)

--- a/tools/protoc-gen-chpl/Makefile
+++ b/tools/protoc-gen-chpl/Makefile
@@ -31,8 +31,8 @@ linkFile=$(bdir)/protoc-gen-chpl
 
 SOURCES=$(wildcard *.cpp)
 HEADERS=$(wildcard *.h)
-LDFLAGS = -lprotobuf -lprotoc
-CPPFLAGS = -I. -std=c++11
+LDFLAGS = $(shell pkg-config --libs protobuf 2>/dev/null) -lprotobuf -lprotoc
+CPPFLAGS = $(shell pkg-config --cflags protobuf 2>/dev/null) -I. -std=c++11
 
 ifeq ($(CHPL_MAKE_PLATFORM),darwin)
 	PROTOC_LIB_LOC=$(dir $(shell which protoc))../lib


### PR DESCRIPTION
Previously, our protobuf support and tests assumed that protoc and other things were provided by a "system" install. Adjust them here to work in an environment where pkg-config provides paths (such as a spack installed env). Note that system installs still work, this just adds support for additional support for pkg-config .

Tested (ProtobufProtocolSupport tests pass) on:
 - mac with brew install protobuf and pip installed python protobuf
 - chapdl with spack install protobuf and py-protobuf
 - chapcs with custom built protobuf and python protobuf

Tested (properly skipped or doesn't blow up) on:
 - system without pkg-config
 - system with pkg-config, but no protobuf
 - system with protobuf, but no python protobuf

Part of Cray/chapel-private#4291