### PR TITLE
(GPU) Force -O3 flag for ptxas when compiling --fast.

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -259,6 +259,7 @@ extern int breakOnRemoveID;
 
 extern int fGPUBlockSize;
 extern char fGpuArch[16];
+extern bool fGpuPtxasEnforceOpt;
 extern const char* gGpuSdkPath;
 
 extern char stopAfterPass[128];

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4050,16 +4050,14 @@ static llvm::CodeGenFileType getCodeGenFileType() {
 static void stripPtxDebugDirective(const std::string& artifactFilename) {
   std::string line;
   std::vector<std::string> lines;
-  const char* prefix = ".target";
-  size_t prefixLen = strlen(prefix);
-  const char* suffix = ", debug";
-  size_t suffixLen = strlen(suffix);
+  std::string prefix = ".target";
+  std::string suffix = ", debug";
   {
     std::ifstream ptxFile(artifactFilename);
     while (std::getline(ptxFile, line)) {
-      if (strncmp(line.c_str(), prefix, prefixLen) == 0 /* line.starts_with(".target") */ &&
-          strncmp(line.c_str() + line.size() - suffixLen, suffix, suffixLen) == 0 /* line.ends_with(", debug") */) {
-        line.resize(line.size() - suffixLen);
+      if (line.compare(0, prefix.size(), prefix) == 0 /* line.starts_with(".target") */ &&
+          line.compare(line.size() - suffix.size(), suffix.size(), suffix) == 0 /* line.ends_with(", debug") */) {
+        line.resize(line.size() - suffix.size());
       }
       lines.push_back(std::move(line));
     }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -322,6 +322,7 @@ std::vector<std::string> gDynoPrependStandardModulePaths;
 
 int fGPUBlockSize = 0;
 char fGpuArch[16];
+bool fGpuPtxasEnforceOpt;
 const char* gGpuSdkPath = NULL;
 
 chpl::Context* gContext = nullptr;
@@ -1196,6 +1197,7 @@ static ArgumentDescription arg_desc[] = {
  {"infer-const-refs", ' ', NULL, "Enable [disable] inferring const refs", "n", &fNoInferConstRefs, NULL, NULL},
  {"gpu-block-size", ' ', "<block-size>", "Block size for GPU launches", "I", &fGPUBlockSize, "CHPL_GPU_BLOCK_SIZE", NULL},
  {"gpu-arch", ' ', "<cuda-architecture>", "CUDA architecture to use", "S16", &fGpuArch, "_CHPL_GPU_ARCH", setEnv},
+ {"gpu-ptxas-enforce-optimization", ' ', NULL, "Modify generated .ptxas file to enable optimizations", "F", &fGpuPtxasEnforceOpt, NULL, NULL},
  {"library", ' ', NULL, "Generate a Chapel library file", "F", &fLibraryCompile, NULL, NULL},
  {"library-dir", ' ', "<directory>", "Save generated library helper files in directory", "P", libDir, "CHPL_LIB_SAVE_DIR", verifySaveLibDir},
  {"library-header", ' ', "<filename>", "Name generated header file", "P", libmodeHeadername, NULL, setLibmode},

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -80,6 +80,7 @@ _chpl ()
 --gmp \
 --gpu-arch \
 --gpu-block-size \
+--gpu-ptxas-enforce-optimization \
 --hdr-search-path \
 --help \
 --help-env \


### PR DESCRIPTION
This includes a hack to strip out the debug directive from the generated PTX assembly file (since changing llvm::DIBuilder configuration causes segfaults inside LLVM for some reason). The implementation of stripping is probably not very efficient (it reads into memory, then writes back out; that helps avoid needing to use `mv` or the like, but how big does the assembly file get?).

Signed-off-by: Daniel Fedorin <daniel.fedorin@hpe.com>

Reviewed by @e-kayrakli - thanks!

## Testing
- [x] paratest
- [x] `start_test test/gpu/native`