### PR TITLE
Return pc path from read_bundled_pkg_config_file

### DIFF
--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -133,7 +133,7 @@ def pkgconfig_get_system_compile_args(pkg):
 # Returns a 2-tuple of lists
 #  (compiler_bundled_args, compiler_system_args)
 def pkgconfig_get_bundled_compile_args(pkg, ucp='', pcfile=''):
-    d = read_bundled_pkg_config_file(pkg, ucp, pcfile)
+    (d, pcpath) = read_bundled_pkg_config_file(pkg, ucp, pcfile)
 
     # Return empty tuple if no .pc file was found (e.g. pkg not built yet)
     if d == None:
@@ -216,7 +216,7 @@ def pkgconfig_get_bundled_link_args(pkg, ucp='', pcfile='',
     install_path = get_bundled_install_path(pkg, ucp)
     lib_dir = os.path.join(install_path, 'lib')
 
-    d = read_bundled_pkg_config_file(pkg, ucp, pcfile)
+    (d, pcpath) = read_bundled_pkg_config_file(pkg, ucp, pcfile)
 
     # Return empty tuple if no .pc file was found (e.g. pkg not built yet)
     if d == None:
@@ -411,16 +411,16 @@ def read_bundled_pkg_config_file(pkg, ucp='', pcfile=''):
 
     # give up early if the 3rd party package hasn't been built
     if not os.path.exists(install_path):
-        return None
+        return (None, None)
 
     pcpath = os.path.join(install_path, 'lib', 'pkgconfig', pcfile)
 
     # if we get this far, we should have a .pc file. check that it exists.
     if not os.access(pcpath, os.R_OK):
         error("Could not find '{0}'".format(pcpath), ValueError)
-        return None
+        return (None, pcpath)
 
     find_path = os.path.join('third-party', pkg, 'install', ucp)
     replace_path = install_path
 
-    return read_pkg_config_file(pcpath, find_path, replace_path)
+    return (read_pkg_config_file(pcpath, find_path, replace_path), pcpath)

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -397,8 +397,9 @@ def read_pkg_config_file(pcpath, find_third_party, replace_third_party):
 #   third-party/<pkg>/install/<ucp>/lib/pkgconfig/<pcfile>
 #   where pcfile defaults to pkg.pc
 #
-# If the .pc file could not be read, returns None
-# Otherwise, returns the dictionary of values read from the .pc file
+# Returns a tuple. The first member is None if the .pc file could not be read,
+# otherwise it's a dictionary of values read from the .pc file. The second
+# member is the name of the pc file, if it could be determined.
 def read_bundled_pkg_config_file(pkg, ucp='', pcfile=''):
     # compute the default ucp
     if ucp == '':


### PR DESCRIPTION
Modified `read_bundled_pkg_config_file` to also return the path to the pc file for use in subsequent warning messages.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>