### PR TITLE
Page-lock arrays allocated on host in array_on_device mode

### DIFF
--- a/runtime/include/chpl-gpu-impl.h
+++ b/runtime/include/chpl-gpu-impl.h
@@ -41,6 +41,7 @@ void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
 void* chpl_gpu_impl_mem_alloc(size_t size);
 void chpl_gpu_impl_mem_free(void* memAlloc);
 void* chpl_gpu_impl_memmove(void* dst, const void* src, size_t n);
+void chpl_gpu_impl_hostmem_register(void *memAlloc, size_t size);
 
 void chpl_gpu_impl_copy_device_to_host(void* dst, const void* src, size_t n);
 void chpl_gpu_impl_copy_host_to_device(void* dst, const void* src, size_t n);

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -106,6 +106,7 @@ void* chpl_gpu_mem_memalign(size_t boundary, size_t size,
                             chpl_mem_descInt_t description,
                             int32_t lineno, int32_t filename);
 void chpl_gpu_mem_free(void* memAlloc, int32_t lineno, int32_t filename);
+void chpl_gpu_hostmem_register(void *memAlloc, size_t size);
 
 void* chpl_gpu_memmove(void* dst, const void* src, size_t n);
 void chpl_gpu_copy_device_to_host(void* dst, const void* src, size_t n);

--- a/runtime/include/chpl-mem-array.h
+++ b/runtime/include/chpl-mem-array.h
@@ -96,13 +96,7 @@ void* chpl_mem_array_alloc(size_t nmemb, size_t eltSize,
   chpl_memhook_malloc_post(p, nmemb, eltSize, CHPL_RT_MD_ARRAY_ELEMENTS,
                            lineno, filename);
 #ifdef HAS_GPU_LOCALE
-  // The CUDA driver uses DMA to transfer page-locked memory to the GPU; if
-  // memory is not page-locked it must first be transfered into a page-locked
-  // buffer, which degrades performance. So in the array_on_device mode we
-  // choose to page-lock such memory even if it's on the host-side.
-  #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
-  cudaHostRegister(p, size, cudaHostRegisterPortable);
-  #endif
+  chpl_gpu_hostmem_register(p, size);
   }
 #endif
   return p;

--- a/runtime/include/chpl-mem-array.h
+++ b/runtime/include/chpl-mem-array.h
@@ -96,11 +96,17 @@ void* chpl_mem_array_alloc(size_t nmemb, size_t eltSize,
   chpl_memhook_malloc_post(p, nmemb, eltSize, CHPL_RT_MD_ARRAY_ELEMENTS,
                            lineno, filename);
 #ifdef HAS_GPU_LOCALE
+  // The CUDA driver uses DMA to transfer page-locked memory to the GPU; if
+  // memory is not page-locked it must first be transfered into a page-locked
+  // buffer, which degrades performance. So in the array_on_device mode we
+  // choose to page-lock such memory even if it's on the host-side.
+  #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
+  cudaHostRegister(p, size, cudaHostRegisterPortable);
+  #endif
   }
 #endif
   return p;
 }
-
 
 static inline
 void chpl_mem_array_postAlloc(void* p, size_t nmemb, size_t eltSize,

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -241,6 +241,11 @@ void* chpl_gpu_mem_memalign(size_t boundary, size_t size,
   return NULL;
 }
 
+void chpl_gpu_hostmem_register(void *memAlloc, size_t size) {
+  CHPL_GPU_DEBUG("chpl_gpu_hostmem_register is called. Ptr %p, size: %d\n", memAlloc, size);
+  chpl_gpu_impl_hostmem_register(memAlloc, size);
+}
+
 bool chpl_gpu_is_device_ptr(const void* ptr) {
   return chpl_gpu_impl_is_device_ptr(ptr);
 }

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -427,6 +427,16 @@ void chpl_gpu_impl_mem_free(void* memAlloc) {
   }
 }
 
+void chpl_gpu_impl_hostmem_register(void *memAlloc, size_t size) {
+  // The CUDA driver uses DMA to transfer page-locked memory to the GPU; if
+  // memory is not page-locked it must first be transfered into a page-locked
+  // buffer, which degrades performance. So in the array_on_device mode we
+  // choose to page-lock such memory even if it's on the host-side.
+  #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
+  cudaHostRegister(memAlloc, size, cudaHostRegisterPortable);
+  #endif
+}
+
 // This can be used for proper reallocation
 size_t chpl_gpu_impl_get_alloc_size(void* ptr) {
   return chpl_gpu_common_get_alloc_size(ptr);

--- a/runtime/src/gpu/rocm/gpu-rocm.c
+++ b/runtime/src/gpu/rocm/gpu-rocm.c
@@ -68,6 +68,8 @@ void* chpl_gpu_impl_memmove(void* dst, const void* src, size_t n) {
   return memmove(dst, src, n);
 }
 
+void chpl_gpu_impl_hostmem_register(void *memAlloc, size_t size) { }
+
 void chpl_gpu_impl_copy_device_to_host(void* dst, const void* src, size_t n) {}
 void chpl_gpu_impl_copy_host_to_device(void* dst, const void* src, size_t n) {}
 


### PR DESCRIPTION
Page-locking memory can lead to better data-transfer performance in CUDA. This PR page locks memory for all arrays allocated on the host when using the `array_on_device` memory strategy.

See https://developer.nvidia.com/blog/how-optimize-data-transfers-cuda-cc/ or https://stackoverflow.com/questions/5736968/why-is-cuda-pinned-memory-so-fast for more information

This change seems to work fine and improve performance with my limitted testing of it.

I think it makes sense to try and merge https://github.com/chapel-lang/chapel/pull/21459 (which adds a nightly performance test for array_on_device mode) first so we can see that it makes a change in our performance graphs.