### PR TITLE
Stop generating graphs for XC

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -102,7 +102,7 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
 
   # Run benchmarks
   if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-    benchmark_opts="--dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
+    benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
 
     if [ "${CHPL_TEST_SYNC_ARKOUDA_GRAPHS}" = "true" ] ; then
       benchmark_opts="${benchmark_opts} --gen-graphs"

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -102,7 +102,11 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
 
   # Run benchmarks
   if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-    benchmark_opts="--gen-graphs --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
+    benchmark_opts="--dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
+
+    if [ "${CHPL_TEST_SYNC_ARKOUDA_GRAPHS}" = "true" ] ; then
+      benchmark_opts="${benchmark_opts} --gen-graphs"
+    fi
 
     benchmark_opts="${benchmark_opts} --annotations $CHPL_HOME/test/ANNOTATIONS.yaml"
     if [[ -n $CHPL_TEST_PERF_DESCRIPTION ]]; then

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -102,10 +102,10 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
 
   # Run benchmarks
   if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-    benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
+    benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR"
 
-    if [ "${CHPL_TEST_SYNC_ARKOUDA_GRAPHS}" = "true" ] ; then
-      benchmark_opts="${benchmark_opts} --gen-graphs"
+    if [ "${GEN_ARKOUDA_GRAPHS}" = "true" ] ; then
+      benchmark_opts="${benchmark_opts} --gen-graphs --graph-dir $CHPL_TEST_PERF_DIR/html"
     fi
 
     benchmark_opts="${benchmark_opts} --annotations $CHPL_HOME/test/ANNOTATIONS.yaml"

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -11,6 +11,7 @@ fi
 
 # Perf configuration
 export CHPL_TEST_ARKOUDA_PERF=${CHPL_TEST_ARKOUDA_PERF:-true}
+export CHPL_TEST_SYNC_AK_GRAPHS=${CHPL_TEST_SYNC_ARKOUDA_GRAPHS:-true}
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ]; then
   source $CWD/common-perf.bash
   ARKOUDA_PERF_DIR=${ARKOUDA_PERF_DIR:-$COMMON_DIR/NightlyPerformance/arkouda}

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -11,7 +11,7 @@ fi
 
 # Perf configuration
 export CHPL_TEST_ARKOUDA_PERF=${CHPL_TEST_ARKOUDA_PERF:-true}
-export CHPL_TEST_SYNC_AK_GRAPHS=${CHPL_TEST_SYNC_ARKOUDA_GRAPHS:-true}
+export GEN_ARKOUDA_GRAPHS=${GEN_ARKOUDA_GRAPHS:-true}
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ]; then
   source $CWD/common-perf.bash
   ARKOUDA_PERF_DIR=${ARKOUDA_PERF_DIR:-$COMMON_DIR/NightlyPerformance/arkouda}

--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 
 export CHPL_TEST_PERF_CONFIG_NAME='16-node-xc'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda"
-export CHPL_TEST_SYNC_ARKOUDA_GRAPHS="false"
+export GEN_ARKOUDA_GRAPHS="false"
 
 # setup arkouda
 source $CWD/common-arkouda.bash

--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -6,6 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 
 export CHPL_TEST_PERF_CONFIG_NAME='16-node-xc'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda"
+export CHPL_TEST_SYNC_ARKOUDA_GRAPHS="false"
 
 # setup arkouda
 source $CWD/common-arkouda.bash
@@ -30,4 +31,3 @@ export CHPL_LAUNCHER=slurm-srun
 nightly_args="${nightly_args} -no-buildcheck"
 
 test_nightly
-sync_graphs

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -33,4 +33,3 @@ export CHPL_LAUNCHER=slurm-srun
 nightly_args="${nightly_args} -no-buildcheck"
 
 test_release
-sync_graphs

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 
 export CHPL_TEST_PERF_CONFIG_NAME='16-node-xc'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda.release"
-export CHPL_TEST_SYNC_ARKOUDA_GRAPHS="false"
+export GEN_ARKOUDA_GRAPHS="false"
 
 # setup arkouda
 source $CWD/common-arkouda.bash

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -6,6 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 
 export CHPL_TEST_PERF_CONFIG_NAME='16-node-xc'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda.release"
+export CHPL_TEST_SYNC_ARKOUDA_GRAPHS="false"
 
 # setup arkouda
 source $CWD/common-arkouda.bash


### PR DESCRIPTION
In order to bring Arkouda testing more in line with the non-Arkouda XC testing, this PR adds an environment variable that allows you to opt out of graph generation.