### PR TITLE
Remove an unused variable in a dyno test

### DIFF
--- a/frontend/test/resolution/testMaybeConst.cpp
+++ b/frontend/test/resolution/testMaybeConst.cpp
@@ -29,8 +29,6 @@
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
 
-static const bool ERRORS_EXPECTED=true;
-
 static void
 testMaybeRef(const char* test,
              const char* program,


### PR DESCRIPTION
Follow-up to #21396 to address a warning-as-error
that occurs with clang when compiling with

    make test-dyno WARNINGS=1

Trivial and not reviewed.