### PR TITLE
Add future about extra message for try expressions around funcs with defaults

### DIFF
--- a/test/errhandling/lydia/tryExpressionDefaultValue.bad
+++ b/test/errhandling/lydia/tryExpressionDefaultValue.bad
@@ -1,0 +1,5 @@
+tryExpressionDefaultValue.chpl:12: In function 'callThrowingFunc':
+tryExpressionDefaultValue.chpl:7: error: call to throwing function throwingFunc_default_x is in a try but not handled
+tryExpressionDefaultValue.chpl:7: note: throwing function throwingFunc_default_x defined here
+tryExpressionDefaultValue.chpl:13: error: call to throwing function throwingFunc is in a try but not handled
+tryExpressionDefaultValue.chpl:7: note: throwing function throwingFunc defined here

--- a/test/errhandling/lydia/tryExpressionDefaultValue.chpl
+++ b/test/errhandling/lydia/tryExpressionDefaultValue.chpl
@@ -1,0 +1,18 @@
+record Bar {
+  var x: int;
+
+  proc type defaultVal { return new Bar(11); }
+}
+
+proc throwingFunc(x = Bar.defaultVal): Bar throws {
+  throw new Error("whatev");
+  return x;
+}
+
+proc callThrowingFunc() {
+  var y = try throwingFunc();
+}
+
+proc main() {
+  callThrowingFunc();
+}

--- a/test/errhandling/lydia/tryExpressionDefaultValue.future
+++ b/test/errhandling/lydia/tryExpressionDefaultValue.future
@@ -1,0 +1,2 @@
+error message: try expressions that call functions with default values generate extra errors for the user for things outside of their control
+#21491

--- a/test/errhandling/lydia/tryExpressionDefaultValue.good
+++ b/test/errhandling/lydia/tryExpressionDefaultValue.good
@@ -1,0 +1,3 @@
+tryExpressionDefaultValue.chpl:12: In function 'callThrowingFunc':
+tryExpressionDefaultValue.chpl:13: error: call to throwing function throwingFunc is in a try but not handled
+tryExpressionDefaultValue.chpl:7: note: throwing function throwingFunc defined here


### PR DESCRIPTION
Tracks the extra error message I was seeing when a throwing function with a
complex default value is called in a try expression

A fresh checkout of the future behaved as expected.