### PR TITLE
dyno: throw errors when referencing fields of an outer class.

### DIFF
--- a/frontend/include/chpl/framework/resolution-error-classes-list.h
+++ b/frontend/include/chpl/framework/resolution-error-classes-list.h
@@ -53,6 +53,7 @@ ERROR_CLASS(ModuleAsVariable,
             const uast::Module*)
 ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const types::EnumType*, std::vector<ID>)
 ERROR_CLASS(MultipleQuestionArgs, const uast::FnCall*, const uast::AstNode*, const uast::AstNode*)
+ERROR_CLASS(NestedClassFieldRef, const uast::AggregateDecl*, const uast::AggregateDecl*, const uast::AstNode*, ID)
 ERROR_CLASS(NonIterable, const uast::IndexableLoop*, const uast::AstNode*, types::QualifiedType)
 ERROR_CLASS(PrivateToPublicInclude, const uast::Include*, const uast::Module*)
 ERROR_CLASS(ProcDefExplicitAnonFormal,

--- a/frontend/include/chpl/framework/resolution-error-classes-list.h
+++ b/frontend/include/chpl/framework/resolution-error-classes-list.h
@@ -53,7 +53,11 @@ ERROR_CLASS(ModuleAsVariable,
             const uast::Module*)
 ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const types::EnumType*, std::vector<ID>)
 ERROR_CLASS(MultipleQuestionArgs, const uast::FnCall*, const uast::AstNode*, const uast::AstNode*)
-ERROR_CLASS(NestedClassFieldRef, const uast::AggregateDecl*, const uast::AggregateDecl*, const uast::AstNode*, ID)
+ERROR_CLASS(NestedClassFieldRef,
+    const uast::AggregateDecl*,
+    const uast::AggregateDecl*,
+    const uast::AstNode*,
+    ID)
 ERROR_CLASS(NonIterable, const uast::IndexableLoop*, const uast::AstNode*, types::QualifiedType)
 ERROR_CLASS(PrivateToPublicInclude, const uast::Include*, const uast::Module*)
 ERROR_CLASS(ProcDefExplicitAnonFormal,

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -336,6 +336,33 @@ void ErrorMultipleQuestionArgs::write(ErrorWriterBase& wr) const {
   wr.code(secondQuestion, { secondQuestion });
 }
 
+void ErrorNestedClassFieldRef::write(ErrorWriterBase& wr) const {
+  auto outerDecl = std::get<0>(info);
+  auto innerDecl = std::get<1>(info);
+  auto reference = std::get<2>(info);
+  auto id = std::get<3>(info);
+
+  const char* outerName = outerDecl->isClass() ? "class" : "record";
+  const char* innerName = innerDecl->isClass() ? "class" : "record";
+
+  if (auto ident = reference->toIdentifier()) {
+    wr.heading(kind_, type_, reference, "illegal use of identifier '",
+               ident->name(), "' from enclosing type.");
+  } else {
+    wr.heading(kind_, type_, reference,
+               "illegal use of identifier from enclosing type.");
+  }
+  wr.code(reference, { reference });
+  wr.note(innerDecl, "the identifier is used within ", innerName, " '",
+          innerDecl->name(), "', declared here:");
+  wr.code(innerDecl);
+  wr.note(outerDecl, "however, the identifier refers to a field of an enclosing ",
+          outerName, " '", outerDecl->name(), "', declared here:");
+  wr.code(outerDecl);
+  wr.note(id, "field declared here:");
+  wr.code<ID, ID>(id, { id });
+}
+
 void ErrorNonIterable::write(ErrorWriterBase &wr) const {
   auto loop = std::get<const uast::IndexableLoop*>(info);
   auto iterand = std::get<const uast::AstNode*>(info);

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -344,6 +344,9 @@ void ErrorNestedClassFieldRef::write(ErrorWriterBase& wr) const {
 
   const char* outerName = outerDecl->isClass() ? "class" : "record";
   const char* innerName = innerDecl->isClass() ? "class" : "record";
+  // Shouldn't even be possible to trigger this with unions.
+  CHPL_ASSERT(!outerDecl->isUnion());
+  CHPL_ASSERT(!innerDecl->isUnion());
 
   if (auto ident = reference->toIdentifier()) {
     wr.heading(kind_, type_, reference, "illegal use of identifier '",

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1758,9 +1758,10 @@ void Resolver::validateAndSetToId(ResolvedExpression& r,
   r.setToId(id);
   if (id.isEmpty()) return;
 
-  // Validate the newly set to ID. It shouldn't refer to a module unless
-  // the node is an identifier in one of the places where module references
-  // are allowed (e.g. imports).
+  // Validate the newly set to ID.
+
+  // It shouldn't refer to a module unless the node is an identifier in one of
+  // the places where module references are allowed (e.g. imports).
   auto toAst = parsing::idToAst(context, id);
   if (toAst != nullptr) {
     if (auto mod = toAst->toModule()) {
@@ -1773,6 +1774,33 @@ void Resolver::validateAndSetToId(ResolvedExpression& r,
           CHPL_REPORT(context, ModuleAsVariable, node, parentAst, mod);
         }
       }
+    }
+  }
+
+  // If we're in a nested class, it shouldn't refer to an outer class' field.
+  auto scope = scopeForId(context, id);
+  auto parentId = scope->id();
+  auto parentAst = parsing::idToAst(context, parentId);
+  if (parentAst && parentAst->isAggregateDecl() &&
+      parentId.contains(node->id())) {
+    // Referring to a field of a class that's surrounding the current node.
+    // Loop upwards looking for a composite type.
+    auto searchId = parsing::idToParentId(context, node->id());
+    while (!searchId.isEmpty()) {
+      auto searchAst = parsing::idToAst(context, searchId);
+      if (searchAst == parentAst) {
+        // We found the aggregate type in which the to-ID is declared,
+        // so there's no nested class issues.
+        break;
+      } else if (auto searchAD = searchAst->toAggregateDecl()) {
+        // It's an error!
+        CHPL_REPORT(context, NestedClassFieldRef, parentAst->toAggregateDecl(),
+                    searchAD, node, id);
+        break;
+      }
+
+      // Move on to the surrounding ID.
+      searchId = parsing::idToParentId(context, searchId);
     }
   }
 }


### PR DESCRIPTION
This wasn't considered an error in Dyno until this commit, but is an error in the production compiler's scope resolution. 
This adds another validation check to `validateAndSetToId` function.

Reviewed by @dlongnecke-cray - thanks!

## Testing
- [x] full local (0 failures)
- [x] full local with `--dyno`, on top of Michael's forwarding fix #21510 (failures unchanged -- error messages differ).