### PR TITLE
Fix a bug with calling throwing initializers in try! expressions

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2105,6 +2105,8 @@ static void fixPrimNew(CallExpr* primNewToFix) {
 
   CallExpr* callInNew    = toCallExpr(primNewToFix->get(1));
   CallExpr* newNew       = new CallExpr(PRIM_NEW);
+  newNew->tryTag = primNewToFix->tryTag; // preserve the tryTag
+
   Expr*     exprModToken = NULL;
   Expr*     exprMod      = NULL;
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -372,6 +372,7 @@ void resolveNewInitializer(CallExpr* newExpr, Type* manager) {
   if (manager == dtBorrowed) {
     USR_WARN(newExpr, "creating a 'new borrowed' type is deprecated");
   }
+  TryTag newTryTag = newExpr->tryTag;
 
   INT_ASSERT(newExpr->isPrimitive(PRIM_NEW));
   AggregateType* at = resolveNewFindType(newExpr);
@@ -402,6 +403,7 @@ void resolveNewInitializer(CallExpr* newExpr, Type* manager) {
     initCall->get(1)->remove(); // '_mt'
     initCall->insertAtHead(new SymExpr(initType->symbol));
     CallExpr* newCall = toCallExpr(initCall->remove());
+    newCall->tryTag = newTryTag;
 
     initTemp->defPoint->remove();
 

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpression.chpl
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpression.chpl
@@ -1,0 +1,25 @@
+// Tracks a bug I found when using throwing initializers in practice
+module tryBangExpression {
+  proc validate(xVal: int) throws {
+    if xVal > 10 then
+      throw new Error("value too large");
+  }
+
+  class Foo {
+    var x: int;
+
+    proc init(xVal: int) throws {
+      x = xVal;
+      this.complete();
+      validate(xVal);
+    }
+  }
+
+  proc main() {
+    // Using a try! expression instead of a try! statement caused problems
+    var x: Foo = try! new Foo(8);
+    writeln(x);
+    var y: Foo = try! new Foo(15);
+    writeln(y);
+  }
+}

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpression.good
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpression.good
@@ -1,0 +1,4 @@
+{x = 8}
+uncaught Error: value too large
+  tryBangExpression.chpl:5: thrown here
+  tryBangExpression.chpl:22: uncaught here

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefault.chpl
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefault.chpl
@@ -1,0 +1,31 @@
+// Tracks a bug I found when using throwing initializers in practice
+module tryBangExpressionDefault {
+  proc validate(xVal: int) throws {
+    if xVal > 10 then
+      throw new Error("value too large");
+  }
+  record Bar {
+    var x: int;
+
+    proc type a { return new Bar(14); }
+    proc type b { return new Bar(11); }
+  }
+
+  class Foo {
+    var x: Bar;
+
+    // Using a default value that was slightly complicated, e.g. the result of a
+    // type method call triggered a specific error message
+    proc init(xVal: Bar = Bar.a) throws {
+      x = xVal;
+      this.complete();
+      validate(xVal.x);
+    }
+  }
+
+  proc main() {
+    // Using a try! expression instead of a try! statement also caused problems
+    var x: Foo = try! new Foo();
+    writeln(x);
+  }
+}

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefault.good
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefault.good
@@ -1,0 +1,3 @@
+uncaught Error: value too large
+  tryBangExpressionDefault.chpl:5: thrown here
+  tryBangExpressionDefault.chpl:28: uncaught here


### PR DESCRIPTION
Prior to this change, the compiler was not recognizing when
calls to throwing initializers were within `try!` expressions and
was incorrectly generating an error that they were not handled.

<details>

This was because both normalize and initializerResolution were
creating new calls and repopulating them, rather than copying
the original call or the fields associated with it.  This change
copies the tryTag field from the old calls to the new ones.

</details>

Adds two new tests that lock in:
- That you can call new for an initializer that throws in a try! expression
- That you can also do it if the initializer has a complicated default value
that involves a function call.

Passed a full paratest with futures
