### PR TITLE
Deprecate the FileSystem.copyFile function - use copy instead

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -260,11 +260,14 @@ proc chown(name: string, uid: int, gid: int) throws {
    :arg metadata: This argument indicates whether to copy metadata associated
                   with the source file.  It is set to `false` by default.
    :type metadata: `bool`
+   :arg permissions: This argument indicates whether to copy file permissions
+                     from the source file. It is set to `true` by default.
+   :type permissions: `bool`
 
    :throws IsADirectoryError: when `dest` is directory.
    :throws SystemError: thrown to describe another error if it occurs.
 */
-proc copy(src: string, dest: string, metadata: bool = false) throws {
+proc copy(src: string, dest: string, metadata: bool = false, permissions: bool = true) throws {
   var destFile = dest;
 
   proc copyMode(src: string, dest: string) throws {
@@ -319,8 +322,11 @@ proc copy(src: string, dest: string, metadata: bool = false) throws {
     // Destination didn't exist before, and we're overwriting it anyways.
   }
 
-  try copyFile(src, destFile);
-  try copyMode(src, destFile);
+  try copyFileImpl(src, destFile);
+
+  if permissions {
+    try copyMode(src, destFile);
+  }
 
   if (metadata) {
     extern proc chpl_fs_copy_metadata(source: c_string, dest: c_string): errorCode;
@@ -356,7 +362,7 @@ proc copy(src: string, dest: string, metadata: bool = false) throws {
                         when `dest` is not writable,
                         or to describe another error if it occurs.
 */
-proc copyFile(src: string, dest: string) throws {
+private proc copyFileImpl(src: string, dest: string) throws {
   // This implementation is based off of the python implementation for copyfile,
   // with some slight differences.  That implementation was found at:
   // https://bitbucket.org/mirror/cpython/src/c8ce5bca0fcda4307f7ac5d69103ce128a562705/Lib/shutil.py?at=default
@@ -438,6 +444,11 @@ proc copyFile(src: string, dest: string) throws {
   try srcChnl.close();
   try destFile.close();
   try srcFile.close();
+}
+
+deprecated "'FileSystem.copyFile' is deprecated. Please use 'FileSystem.copy' instead"
+proc copyFile(src: string, dest: string) throws {
+  copyFileImpl(src, dest);
 }
 
 /* Copies the permissions of the file indicated by `src` to the file indicated

--- a/test/deprecated/deprecate-copyFile.chpl
+++ b/test/deprecated/deprecate-copyFile.chpl
@@ -1,0 +1,6 @@
+use FileSystem;
+
+try {
+  copyFile("fileThatDoesNotExist1.badext", "fileThatDoesNotExist2.badext");
+} catch {
+}

--- a/test/deprecated/deprecate-copyFile.good
+++ b/test/deprecated/deprecate-copyFile.good
@@ -1,0 +1,1 @@
+deprecate-copyFile.chpl:4: warning: 'FileSystem.copyFile' is deprecated. Please use 'FileSystem.copy' instead

--- a/test/library/packages/HDF5/ex_lite2.chpl
+++ b/test/library/packages/HDF5/ex_lite2.chpl
@@ -15,7 +15,7 @@ proc main {
 
   if pathPrefix != "" {
     use FileSystem;
-    copyFile(filename, pathPrefix + filename);
+    copy(filename, pathPrefix + filename, permissions=false);
   }
 
   /* open file from ex_lite1.chpl */

--- a/test/library/packages/HDF5/readChunks1D.chpl
+++ b/test/library/packages/HDF5/readChunks1D.chpl
@@ -6,7 +6,7 @@ config const dsetName = "Ai";
 const pathPrefix = readPrefixEnv();
 if pathPrefix != "" {
   use FileSystem;
-  copyFile(infileName, pathPrefix + infileName);
+  copy(infileName, pathPrefix + infileName, permissions=false);
 }
 
 for A in hdf5ReadChunks(pathPrefix + infileName, dsetName,

--- a/test/library/packages/HDF5/readChunks1DPreprocess.chpl
+++ b/test/library/packages/HDF5/readChunks1DPreprocess.chpl
@@ -6,7 +6,7 @@ config const dsetName = "Ai";
 const pathPrefix = readPrefixEnv();
 if pathPrefix != "" {
   use FileSystem;
-  copyFile(infileName, pathPrefix + infileName);
+  copy(infileName, pathPrefix + infileName, permissions=false);
 }
 
 const script = """#!/usr/bin/env bash

--- a/test/library/standard/FileSystem/copyFile/copyFile.chpl
+++ b/test/library/standard/FileSystem/copyFile/copyFile.chpl
@@ -5,7 +5,7 @@ proc main(args: [] string) {
   const infile = base + ".in";
   const outfile = base + ".out";
 
-  copyFile(infile, outfile);
+  copy(infile, outfile, permissions=false);
 
   var sub = spawn(["diff", infile, outfile]);
   sub.communicate();

--- a/test/library/standard/FileSystem/lydia/copyFile/copyingContents.chpl
+++ b/test/library/standard/FileSystem/lydia/copyFile/copyingContents.chpl
@@ -3,4 +3,4 @@ use FileSystem;
 var src = "foo.txt";
 var dest = "bar.txt";
 
-copyFile(src, dest);
+copy(src, dest, permissions=false);

--- a/test/mason/mason-modify/masonModifyTest.chpl
+++ b/test/mason/mason-modify/masonModifyTest.chpl
@@ -22,7 +22,7 @@ proc main(args: [] string) {
   // Replace manifest file
   const tomlFile = basename + '.toml';
   const manifestFile = 'tmp/' + basename + '/Mason.toml';
-  FileSystem.copyFile(tomlFile, manifestFile);
+  FileSystem.copy(tomlFile, manifestFile, permissions=false);
 
   here.chdir('tmp/' + basename);
 

--- a/test/mason/masonAddBadDep.chpl
+++ b/test/mason/masonAddBadDep.chpl
@@ -11,7 +11,7 @@ proc main() {
 
   const tomlFile = basename + '.toml';
   const manifestFile = 'tmp/' + basename + '/Mason.toml';
-  FileSystem.copyFile(tomlFile, manifestFile);
+  FileSystem.copy(tomlFile, manifestFile, permissions=false);
 
   here.chdir('tmp/' + basename);
 


### PR DESCRIPTION
Add an argument 'permissions' to 'FileSystem.copy' that defaults to true to copy the file's permissions, but can be set to false to match the behavior of the old 'copyFile' function.

Deprecate 'copyFile' and update tests that used it. Add a deprecated/ test for 'copyFile'.

Closes https://github.com/chapel-lang/chapel/issues/19663
Closes https://github.com/Cray/chapel-private/issues/4273