### PR TITLE
Make primary method `this` formals not have type exprs.

### DIFF
--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -986,16 +986,14 @@ CommentsAndStmt ParserContext::buildFunctionDecl(YYLTYPE location,
 
   // Detect primary methods and create a receiver for them
   bool primaryMethod = false;
-  auto scope = currentScope();
   if (currentScopeIsAggregate()) {
     if (fp.receiver == nullptr) {
       auto loc = convertLocation(location);
       auto ths = UniqueString::get(context(), "this");
-      UniqueString cls = scope.name;
       fp.receiver = Formal::build(builder, loc, /*attributeGroup*/ nullptr,
                                   ths,
                                   fp.thisIntent,
-                                  Identifier::build(builder, loc, cls),
+                                  nullptr,
                                   nullptr).release();
       primaryMethod = true;
     }

--- a/frontend/test/parsing/testParseAggregate.cpp
+++ b/frontend/test/parsing/testParseAggregate.cpp
@@ -57,12 +57,17 @@ static BuilderResult parseAggregate(Parser* parser,
 
 static void checkThisFormal(const Function* fn,
                             const char* receiverType,
-                            Formal::Intent expectIntent) {
+                            Formal::Intent expectIntent,
+                            bool isPrimary) {
   assert(fn->thisFormal() != nullptr);
   assert(fn->thisFormal() == fn->formal(0));
   auto formal = fn->thisFormal();
-  assert(formal->typeExpression()->isIdentifier());
-  assert(formal->typeExpression()->toIdentifier()->name() == receiverType);
+  if (isPrimary) {
+    assert(formal->typeExpression() == nullptr);
+  } else {
+    assert(formal->typeExpression()->isIdentifier());
+    assert(formal->typeExpression()->toIdentifier()->name() == receiverType);
+  }
   assert(formal->initExpression() == nullptr);
   assert(formal->name() == "this");
   assert(formal->intent() == expectIntent);
@@ -130,7 +135,7 @@ static void test3(Parser* parser) {
   assert(mtd->name() == "method");
   assert(mtd->thisFormal());
   assert(mtd->isPrimaryMethod());
-  checkThisFormal(mtd, "C", Formal::DEFAULT_INTENT);
+  checkThisFormal(mtd, "C", Formal::DEFAULT_INTENT, /* isPrimary */ true);
 }
 
 static void test4(Parser* parser) {
@@ -176,7 +181,7 @@ static void test6(Parser* parser) {
   assert(mtd->name() == "method");
   assert(mtd->thisFormal());
   assert(mtd->isPrimaryMethod());
-  checkThisFormal(mtd, "R", Formal::DEFAULT_INTENT);
+  checkThisFormal(mtd, "R", Formal::DEFAULT_INTENT, /* isPrimary */ true);
 }
 
 static void test7(Parser* parser) {
@@ -198,7 +203,7 @@ static void test7(Parser* parser) {
   assert(mtd->name() == "method");
   assert(mtd->thisFormal());
   assert(mtd->isPrimaryMethod());
-  checkThisFormal(mtd, "U", Formal::DEFAULT_INTENT);
+  checkThisFormal(mtd, "U", Formal::DEFAULT_INTENT, /* isPrimary */ true);
 }
 
 static void test8(Parser* parser) {
@@ -244,7 +249,7 @@ static void test8(Parser* parser) {
   assert(mtd->name() == "foo");
   assert(mtd->thisFormal());
   assert(mtd->isPrimaryMethod());
-  checkThisFormal(mtd, "C", Formal::DEFAULT_INTENT);
+  checkThisFormal(mtd, "C", Formal::DEFAULT_INTENT, /* isPrimary */ true);
 }
 
 static void test9(Parser* parser) {
@@ -291,42 +296,42 @@ static void test9(Parser* parser) {
     assert(df->returnIntent() == Function::DEFAULT_RETURN_INTENT);
     assert(df->thisFormal());
     assert(df->isPrimaryMethod());
-    checkThisFormal(df, "R", Formal::DEFAULT_INTENT);
+    checkThisFormal(df, "R", Formal::DEFAULT_INTENT, /* isPrimary */ true);
     assert(df->numFormals() == 2);
 
     assert(cnst->name() == "cnst");
     assert(cnst->returnIntent() == Function::CONST);
     assert(cnst->thisFormal());
     assert(cnst->isPrimaryMethod());
-    checkThisFormal(cnst, "R", Formal::CONST);
+    checkThisFormal(cnst, "R", Formal::CONST, /* isPrimary */ true);
     assert(cnst->numFormals() == 2);
 
     assert(cnstrf->name() == "cnstrf");
     assert(cnstrf->returnIntent() == Function::CONST_REF);
     assert(cnstrf->thisFormal());
     assert(cnstrf->isPrimaryMethod());
-    checkThisFormal(cnstrf, "R", Formal::CONST_REF);
+    checkThisFormal(cnstrf, "R", Formal::CONST_REF, /* isPrimary */ true);
     assert(cnstrf->numFormals() == 2);
 
     assert(rf->name() == "rf");
     assert(rf->returnIntent() == Function::REF);
     assert(rf->thisFormal());
     assert(rf->isPrimaryMethod());
-    checkThisFormal(rf, "R", Formal::REF);
+    checkThisFormal(rf, "R", Formal::REF, /* isPrimary */ true);
     assert(rf->numFormals() == 2);
 
     assert(prm->name() == "prm");
     assert(prm->returnIntent() == Function::PARAM);
     assert(prm->thisFormal());
     assert(prm->isPrimaryMethod());
-    checkThisFormal(prm, "R", Formal::PARAM);
+    checkThisFormal(prm, "R", Formal::PARAM, /* isPrimary */ true);
     assert(prm->numFormals() == 2);
 
     assert(tp->name() == "tp");
     assert(tp->returnIntent() == Function::TYPE);
     assert(tp->thisFormal());
     assert(tp->isPrimaryMethod());
-    checkThisFormal(tp, "R", Formal::TYPE);
+    checkThisFormal(tp, "R", Formal::TYPE, /* isPrimary */ true);
     assert(tp->numFormals() == 2);
   }
 
@@ -352,42 +357,42 @@ static void test9(Parser* parser) {
     assert(df2->returnIntent() == Function::DEFAULT_RETURN_INTENT);
     assert(df2->thisFormal());
     assert(df2->isPrimaryMethod() == false);
-    checkThisFormal(df2, "R", Formal::DEFAULT_INTENT);
+    checkThisFormal(df2, "R", Formal::DEFAULT_INTENT, /* isPrimary */ false);
     assert(df2->numFormals() == 2);
 
     assert(cnst2->name() == "cnst2");
     assert(cnst2->returnIntent() == Function::CONST);
     assert(cnst2->thisFormal());
     assert(cnst2->isPrimaryMethod() == false);
-    checkThisFormal(cnst2, "R", Formal::CONST);
+    checkThisFormal(cnst2, "R", Formal::CONST, /* isPrimary */ false);
     assert(cnst2->numFormals() == 2);
 
     assert(cnstrf2->name() == "cnstrf2");
     assert(cnstrf2->returnIntent() == Function::CONST_REF);
     assert(cnstrf2->thisFormal());
     assert(cnstrf2->isPrimaryMethod() == false);
-    checkThisFormal(cnstrf2, "R", Formal::CONST_REF);
+    checkThisFormal(cnstrf2, "R", Formal::CONST_REF, /* isPrimary */ false);
     assert(cnstrf2->numFormals() == 2);
 
     assert(rf2->name() == "rf2");
     assert(rf2->returnIntent() == Function::REF);
     assert(rf2->thisFormal());
     assert(rf2->isPrimaryMethod() == false);
-    checkThisFormal(rf2, "R", Formal::REF);
+    checkThisFormal(rf2, "R", Formal::REF, /* isPrimary */ false);
     assert(rf2->numFormals() == 2);
 
     assert(prm2->name() == "prm2");
     assert(prm2->returnIntent() == Function::PARAM);
     assert(prm2->thisFormal());
     assert(prm2->isPrimaryMethod() == false);
-    checkThisFormal(prm2, "R", Formal::PARAM);
+    checkThisFormal(prm2, "R", Formal::PARAM, /* isPrimary */ false);
     assert(prm2->numFormals() == 2);
 
     assert(tp2->name() == "tp2");
     assert(tp2->returnIntent() == Function::TYPE);
     assert(tp2->thisFormal());
     assert(tp2->isPrimaryMethod() == false);
-    checkThisFormal(tp2, "R", Formal::TYPE);
+    checkThisFormal(tp2, "R", Formal::TYPE, /* isPrimary */ false);
     assert(tp2->numFormals() == 2);
   }
 }

--- a/frontend/test/resolution/testMaybeConst.cpp
+++ b/frontend/test/resolution/testMaybeConst.cpp
@@ -151,7 +151,7 @@ static void test2() {
 
       }
     )"""",
-    {{"M.R.method@1", true}},
+    {{"M.R.method@0", true}},
     {});
 }
 


### PR DESCRIPTION
Prior to this commit, Dyno inserted an implicit `this` formal for all methods. For secondary methods, the type expression of this implicit formal was derived from the type expression in the user code. That is to say, the following secondary method:

```Chapel
proc (someTypeExpr).foo() {}
```

translated to the following:

```Chapel
proc foo(this: someTypeExpr) {}
```

In the case of primary methods, however, the type expression was simply the name of the class in which the method is being declared. For instance, the following:

```Chapel
record R {
    proc foo() {}
}
```

becomes:

```Chapel
proc foo(this: R) {}
```

However, this led to problems in the case that a field of the record had the same name as the record itself. In these situations, the Dyno resolver would decide that `this` refers not to the record, but to the field. This commit/PR changes the behavior to instead translate the function as follows:

```Chapel
proc foo(this) {}
```

The resolver is also adjusted to provide special treatment to `this` formals without a type expression; the ID that the type expression refers to is automatically assumed to be that of the record or class in which the primary method is being defined.

Reviewed by @dlongnecke-cray - thanks!

## Testing
- [x] paratest
- [x] paratest with --dyno on top of Michael's #21510 (down 2 from main).

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>