### PR TITLE
fix(release): copy generated files that contain SHA value into archive

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -26,7 +26,7 @@
 #include "chpl/util/version-info.h"
 
 void get_version(char* buf, size_t bufsize) {
-  std::string ret = chpl::getVersion(developer);
+  std::string ret = chpl::getVersion();
   strcpy(buf, ret.c_str());
 }
 
@@ -48,7 +48,7 @@ int get_update_version() {
   return chpl::getUpdateVersion();
 }
 const char* get_build_version() {
-  return chpl::getBuildVersion(developer);
+  return chpl::getBuildVersion();
 }
 bool get_is_official_release() {
   return chpl::getIsOfficialRelease();

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -47,9 +47,6 @@ int get_minor_version() {
 int get_update_version() {
   return chpl::getUpdateVersion();
 }
-const char* get_build_version() {
-  return chpl::getBuildVersion();
-}
 bool get_is_official_release() {
   return chpl::getIsOfficialRelease();
 }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -47,6 +47,8 @@
 
 #include "global-ast-vecs.h"
 
+#include "chpl/util/version-info.h"
+
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
@@ -2085,7 +2087,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
   case PRIM_VERSION_SHA: {
     retval = (get_is_official_release() ?
               new SymExpr(new_StringSymbol("")) :
-              new SymExpr(new_StringSymbol(get_build_version())));
+              new SymExpr(new_StringSymbol(chpl::getCommitHash())));
     call->replace(retval);
     break;
   }

--- a/frontend/include/chpl/util/version-info.h
+++ b/frontend/include/chpl/util/version-info.h
@@ -28,7 +28,7 @@ namespace chpl
   Returns the gitSHA value from the most recent source modification that was
   committed.
 */
-const char* gitSHA();
+const char* getCommitHash();
 
 /*
   The chpl major version value
@@ -58,22 +58,17 @@ const char* getConfiguredPrefix();
 std::string getMajorMinorVersion();
 
 /*
-  get the chpl version string. release versions will have format Major.Minor.Patch or
+  Get the chpl version string. Release versions will have format Major.Minor.Patch or
   Major.Minor.Patch.Build. Pre-release versions will be Major.Minor.Patch pre-release (git-sha)
 */
 std::string getVersion();
 
 /*
-  get the official release flag that was set through the top-level CMakeLists.txt
-  file.
+  Get the official release flag that was set through the top-level CMakeLists.txt
+  file, defined there as CHPL_OFFICIAL_RELEASE.
 */
 bool getIsOfficialRelease();
 
-/*
-  get the build version value. This may be an integer or a git-sha depending on
-  the value of official_release flag.
-*/
-const char* getBuildVersion();
 
 } // namespace chpl
 

--- a/frontend/include/chpl/util/version-info.h
+++ b/frontend/include/chpl/util/version-info.h
@@ -58,10 +58,10 @@ const char* getConfiguredPrefix();
 std::string getMajorMinorVersion();
 
 /*
-  get the chpl version string. Developer flag helps decide if a git-sha is
-  included or not
+  get the chpl version string. release versions will have format Major.Minor.Patch or
+  Major.Minor.Patch.Build. Pre-release versions will be Major.Minor.Patch pre-release (git-sha)
 */
-std::string getVersion(bool developer);
+std::string getVersion();
 
 /*
   get the official release flag that was set through the top-level CMakeLists.txt
@@ -71,9 +71,9 @@ bool getIsOfficialRelease();
 
 /*
   get the build version value. This may be an integer or a git-sha depending on
-  the value of official_release and developer.
+  the value of official_release flag.
 */
-const char* getBuildVersion(bool developer);
+const char* getBuildVersion();
 
 } // namespace chpl
 

--- a/frontend/lib/util/version-info.cpp
+++ b/frontend/lib/util/version-info.cpp
@@ -26,7 +26,7 @@ namespace chpl {
 
 extern const char* GIT_SHA;
 
-const char* gitSHA() {
+const char* getCommitHash() {
   return GIT_SHA;
 }
 
@@ -57,11 +57,9 @@ std::string getVersion() {
         std::to_string(getMinorVersion()) + "." +
         std::to_string(getUpdateVersion());
   if (!CHPL_OFFICIAL_RELEASE) {
-    ret += " pre-release (" + std::string(gitSHA()) + ")";
+    ret += " pre-release (" + std::string(getCommitHash()) + ")";
   } else {
-    // It's is an official release.
-    // based on discussion in https://github.com/Cray/chapel-private/issues/4285
-    // don't include git sha in this case
+    // It's is an official release, don't include git sha in this case.
     std::string build = std::string(CHPL_BUILD_VERSION);
     if (build.compare("0") == 0) {
       // no need to append a .0
@@ -77,12 +75,5 @@ bool getIsOfficialRelease() {
   return CHPL_OFFICIAL_RELEASE;
 }
 
-const char* getBuildVersion() {
-  if (!CHPL_OFFICIAL_RELEASE) {
-    return gitSHA();
-  } else {
-    return CHPL_BUILD_VERSION;
-  }
-}
 
 } // namespace chpl

--- a/frontend/lib/util/version-info.cpp
+++ b/frontend/lib/util/version-info.cpp
@@ -51,21 +51,19 @@ std::string getMajorMinorVersion() {
   return version;
 }
 
-std::string getVersion(bool developer) {
+std::string getVersion() {
   std::string ret;
   ret = std::to_string(getMajorVersion()) + "." +
         std::to_string(getMinorVersion()) + "." +
         std::to_string(getUpdateVersion());
   if (!CHPL_OFFICIAL_RELEASE) {
-    ret += " pre-release (" + std::string(getBuildVersion(developer)) + ")";
+    ret += " pre-release (" + std::string(gitSHA()) + ")";
   } else {
     // It's is an official release.
-    // Try to decide whether or not to include the BUILD_VERSION
-    // based on its string length. A short git sha is 10 characters.
-    std::string build = std::string(getBuildVersion(developer));
-    if (build.length() > 2 && !developer) {
-      // assume it is a sha, so don't include it
-    } else if (build.compare("0") == 0) {
+    // based on discussion in https://github.com/Cray/chapel-private/issues/4285
+    // don't include git sha in this case
+    std::string build = std::string(CHPL_BUILD_VERSION);
+    if (build.compare("0") == 0) {
       // no need to append a .0
     } else {
       // include the BUILD_VERSION contents to add e.g. a .1
@@ -79,8 +77,8 @@ bool getIsOfficialRelease() {
   return CHPL_OFFICIAL_RELEASE;
 }
 
-const char* getBuildVersion(bool developer) {
-  if (!CHPL_OFFICIAL_RELEASE || developer) {
+const char* getBuildVersion() {
+  if (!CHPL_OFFICIAL_RELEASE) {
     return gitSHA();
   } else {
     return CHPL_BUILD_VERSION;

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -170,7 +170,7 @@ static void printStuff(const char* argv0, void* mainAddr) {
   bool printedSomething = false;
 
   if (fPrintVersion) {
-    std::string version = chpl::getVersion(developer);
+    std::string version = chpl::getVersion();
     fprintf(stdout, "%s version %s\n", sArgState.program_name, version.c_str());
 
     fPrintCopyright  = true;

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -88,21 +88,18 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     print "[gen_release] Confirm final Git source version used.\n";
     SystemOrDie("cd $rootdir && git --no-pager status && git --no-pager log -1");
 
-    # Leaving this here for now, but this has been replaced by CMake logic
-    # to write the BUILD_VERSION value into config.h
-    # if ($version eq "" or $version eq "developer") {
-    #   print "[gen_release] Create BUILD_VERSION file.\n";
-    #   SystemOrDie("cd $rootdir/compiler && make main/BUILD_VERSION");
-    # }
 
+
+    # write the git-sha while we have the .git directory
+    SystemOrDie("cd $rootdir && util/config/write-git-sha frontend/lib/util --build-version --chpl-home=$rootdir");
+    # use git archive to copy all the files under source control into the archive directory.
     print "[gen_release] Creating build workspace with git archive...\n";
     SystemOrDie("cd $rootdir && git archive --format=tar HEAD | (cd $archive_dir && tar -xf -)");
-
-    if ($version eq "" or $version eq "developer") {
-      print "[gen_release] Copying BUILD_VERSION file.\n";
-      SystemOrDie("util/config/write-git-sha frontend/lib/util --build-version --chpl-home=$archive_dir");
-      SystemOrDie("cp $rootdir/compiler/main/BUILD_VERSION $archive_dir/compiler/main/BUILD_VERSION");
-    }
+    # explicitly copy the BUILD_VERSION file and git-version.cpp files
+    print "[gen_release] Copying BUILD_VERSION file.\n";
+    SystemOrDie("cp $rootdir/compiler/main/BUILD_VERSION $archive_dir/compiler/main/BUILD_VERSION");
+    print "[gen_release] Copying git-version.cpp\n";
+    SystemOrDie("cp $rootdir/frontend/lib/util/git-version.cpp $archive_dir/frontend/lib/util/git-version.cpp");
 
     if (defined($ENV{"CHPL_HOME"})) {
         $resultdir = $ENV{"CHPL_HOME"};
@@ -210,8 +207,6 @@ if (not exists($ENV{"CHPL_GEN_RELEASE_SKIP_DOCS"})) {
   SystemOrDie("make man");
   SystemOrDie("make man-chpldoc");
 } else {
-  # Write git-version.cpp (and BUILD_VERSION) since docs were skipped
-  SystemOrDie("util/config/write-git-sha frontend/lib/util --build-version --chpl-home=$archive_dir");
   SystemOrDie("mkdir -p man/man1");
 }
 


### PR DESCRIPTION
This PR fixes a bug in `gen_release` that would prevent building
from a non-local repo. There are some other fixes for carrying the
git SHA forward from the source when using `gen_release` to build
from a remote repo. 

The major change is and update to `gen_release` to explicitly copy 
the generated files that contain the git SHA, `git-version.cpp` and
`BUILD_VERSION`. This is to fix a bug that always forced the dummy 
SHA if not using the local git repo with `CHPL_GEN_RELEASE_NO_CLONE`
This bug was introduced in https://github.com/chapel-lang/chapel/pull/20920.

The first deviation from previous behavior in `gen_release` is that we will include the
git SHA in the tarball regardless of how `gen_release` was called. This will place
all of the decision of whether to print a git `SHA` from `--version` or not with 
the status of the `official_release` flag.

The second deviation from previous behavior is that the output of `--version`
will no longer depend on the developer flag with official releases. The behavior 
will be to always print the git SHA if we are not in an official release, 
as indicated by the `official_release` flag, and never print the SHA if the flag is set.

Additional discussion on https://github.com/Cray/chapel-private/issues/4285 also led
to a decision to stop printing the git SHA when the `official_release` flag is set
and those changes are included here as well.

TESTING:

- [x] `paratest` `[Summary: #Successes = 14452 | #Failures = 0 | #Futures = 898]`
- [x] `gen_release 1.30` (SHA exists, but only printed if `offical_release` is false when building from the tarball)
- [x] `gen_release` (SHA exists and is only printed if `official_release` if false when building from the tarball)


reviewed by @mppf - thank you!