### PR TITLE
Fix AST dump invocation in uAST conversion

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -998,7 +998,7 @@ static ModuleSymbol* dynoParseFile(const char* fileName,
 
 #if DUMP_WHEN_CONVERTING_UAST_TO_AST
     printf("> Dumping uAST for module %s\n", mod->name().c_str());
-    chpl::uast::ASTNode::dump(mod);
+    mod->dump();
 #endif
 
     initializeGlobalParserState(fileName, modTag, namedOnCommandLine);


### PR DESCRIPTION
Fixes an outdated invocation of AST dump method which does not compile.

This compilation failure likely hasn't been encountered thus far because it is guarded by a macro that must be manually set true for this to get compiled.