### PR TITLE
Fix forwarding after dyno scope resolution

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1940,41 +1940,19 @@ void applyPrivateToBlock(BlockStmt* block) {
   }
 }
 
-static
-DefExpr* buildForwardingExprFnDef(Expr* expr) {
-  // Put expr into a method and return the DefExpr for that method.
-  // This way, we can work with the rest of the compiler that
-  // assumes that 'this' is an ArgSymbol.
-  static int delegate_counter = 0;
-  const char* name = astr("chpl_forwarding_expr", istr(++delegate_counter));
-  if (UnresolvedSymExpr* usex = toUnresolvedSymExpr(expr))
-    name = astr(name, "_", usex->unresolved);
-  FnSymbol* fn = new FnSymbol(name);
-
-  fn->addFlag(FLAG_INLINE);
-  fn->addFlag(FLAG_MAYBE_REF);
-  fn->addFlag(FLAG_REF_TO_CONST_WHEN_CONST_THIS);
-  fn->addFlag(FLAG_COMPILER_GENERATED);
-
-  fn->body->insertAtTail(new CallExpr(PRIM_RETURN, expr));
-
-  DefExpr* def = new DefExpr(fn);
-
-  return def;
-}
-
-
 // handle syntax like
 //    var instance:someType;
 //    forwarding instance;
-BlockStmt* buildForwardingStmt(Expr* expr) {
-  return buildChapelStmt(new ForwardingStmt(buildForwardingExprFnDef(expr)));
+ForwardingStmt* buildForwardingStmt(DefExpr* fnDef) {
+  return new ForwardingStmt(fnDef);
 }
 
 // handle syntax like
 //    var instance:someType;
 //    forwarding instance only foo;
-BlockStmt* buildForwardingStmt(Expr* expr, std::vector<PotentialRename*>* names, bool except) {
+ForwardingStmt* buildForwardingStmt(DefExpr* fnDef,
+                                    std::vector<PotentialRename*>* names,
+                                    bool except) {
   std::set<const char*> namesSet;
   std::map<const char*, const char*> renameMap;
 
@@ -2004,45 +1982,15 @@ BlockStmt* buildForwardingStmt(Expr* expr, std::vector<PotentialRename*>* names,
         }
         break;
     }
-
   }
 
-  DefExpr* fnDef = buildForwardingExprFnDef(expr);
   ForwardingStmt* ret = new ForwardingStmt(fnDef,
-                                       &namesSet,
-                                       except,
-                                       &renameMap);
-  return buildChapelStmt(ret);
+                                           &namesSet,
+                                           except,
+                                           &renameMap);
+  return ret;
 }
 
-
-// handle syntax like
-//    forwarding var instance:someType;
-// by translating it into
-//    var instance:someType;
-//    forwarding instance;
-BlockStmt* buildForwardingDeclStmt(BlockStmt* stmts) {
-  for_alist(stmt, stmts->body) {
-    if (DefExpr* defExpr = toDefExpr(stmt)) {
-      if (VarSymbol* var = toVarSymbol(defExpr->sym)) {
-        // Append a ForwardingStmt
-        BlockStmt* toAppend = buildForwardingStmt(new UnresolvedSymExpr(var->name));
-
-        // Remove the END_OF_STATEMENT marker, not used for fields
-        Expr* last = stmts->body.last();
-        if (last && isEndOfStatementMarker(stmts->body.last()))
-          last->remove();
-
-        for_alist(tmp, toAppend->body) {
-          stmts->insertAtTail(tmp->remove());
-        }
-      } else {
-        INT_FATAL("case not handled in buildForwardingDeclStmt");
-      }
-    }
-  }
-  return stmts;
-}
 
 FnSymbol*
 buildFunctionFormal(FnSymbol* fn, DefExpr* def) {

--- a/compiler/include/build.h
+++ b/compiler/include/build.h
@@ -34,6 +34,7 @@ class CallExpr;
 class DefExpr;
 class Expr;
 class FnSymbol;
+class ForwardingStmt;
 class ImportStmt;
 class ModuleSymbol;
 class Type;
@@ -194,9 +195,10 @@ BlockStmt* buildFunctionDecl(FnSymbol*   fn,
                              Expr*       optLifetimeConstraints,
                              BlockStmt*  optFnBody);
 void applyPrivateToBlock(BlockStmt* block);
-BlockStmt* buildForwardingStmt(Expr* expr);
-BlockStmt* buildForwardingStmt(Expr* expr, std::vector<PotentialRename*>* names, bool except);
-BlockStmt* buildForwardingDeclStmt(BlockStmt*);
+ForwardingStmt* buildForwardingStmt(DefExpr* fnDef);
+ForwardingStmt* buildForwardingStmt(DefExpr* fnDef,
+                                    std::vector<PotentialRename*>* names,
+                                    bool except);
 BlockStmt* buildLocalStmt(Expr* condExpr, Expr* stmt);
 BlockStmt* buildLocalStmt(Expr* stmt);
 BlockStmt* buildManagerBlock(Expr* managerExpr, std::set<Flag>* flags,

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -200,7 +200,7 @@ struct Converter {
        const resolution::ResolutionResultByPostorderID* resolved);
   void popFromSymStack(const uast::AstNode* ast, BaseAST* ret);
   const resolution::ResolutionResultByPostorderID* currentResolutionResult();
- 
+
   bool shouldScopeResolve(ID symbolId) {
     if (canScopeResolve) {
       return fDynoScopeBundled ||

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -378,9 +378,6 @@ struct Converter {
   }
 
   Expr* resolvedIdentifier(const uast::Identifier* node) {
-    if (node->id().str() == "array-member-nil-error.Wrapper@9")
-      gdbShouldBreakHere();
-
     // Don't try to resolve identifiers in use/import yet
     // (it messes up the current use/import build routines)
     if (inImportOrUse) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -141,7 +141,6 @@ struct Converter {
   bool canScopeResolve = false;
   bool trace = false;
   int delegateCounter = 0;
-  FnSymbol* inForwardingMethod = nullptr;
 
   ModTag topLevelModTag;
   std::vector<ModStackEntry> modStack;
@@ -2372,9 +2371,6 @@ struct Converter {
                                                  dtMethodToken)));
     fn->insertFormalAtTail(new DefExpr(arg));
 
-    // Should not be possible to nest forwarding decls
-    INT_ASSERT(!inForwardingMethod);
-
     // note that we're in a forwarding declaration working with 'fn'
     // to get the field accesses to convert correctly
     methodThisStack.push_back(fn->_this);
@@ -2649,6 +2645,7 @@ struct Converter {
 
             convertedReceiver = toArgSymbol(conv->sym);
             INT_ASSERT(convertedReceiver);
+            methodThisStack.push_back(convertedReceiver);
 
             conv->sym->addFlag(FLAG_ARG_THIS);
 
@@ -2705,7 +2702,6 @@ struct Converter {
       if (node->isPrimaryMethod()) {
         fn->addFlag(FLAG_METHOD_PRIMARY);
       }
-      methodThisStack.push_back(convertedReceiver);
     }
 
     if (fn->name == astrDeinit)

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -340,6 +340,8 @@ static void test6b() {
   assert(qt.type()->isErroneousType());
 }
 
+// TODO: forwarding with only, except
+
 
 int main() {
   test1();

--- a/test/classes/forwarding/forwarding-lambda-inner-record.chpl
+++ b/test/classes/forwarding/forwarding-lambda-inner-record.chpl
@@ -1,0 +1,26 @@
+// a tricky case brought up in reviewing PR #21510
+
+proc string.method() {
+    writeln("Called on a string: ", this);
+}
+
+proc int.method() {
+    writeln("Called on an int: ", this);
+}
+
+record GlobalRecord {
+    var x = "hello";
+    forwarding ((lambda (){
+        record LocalRecord {
+            var x = 42;
+
+            proc methodThatUsesThis() {
+                return x;
+            }
+        }
+        var localRecord: LocalRecord;
+        return localRecord.methodThatUsesThis();
+    })());
+}
+var r: GlobalRecord;
+r.method();

--- a/test/classes/forwarding/forwarding-lambda-inner-record.good
+++ b/test/classes/forwarding/forwarding-lambda-inner-record.good
@@ -1,0 +1,1 @@
+Called on an int: 42


### PR DESCRIPTION
This PR is intended to resolve some test failures with `--dyno` to activate the new scope resolver after PR #21470.

The approach is to separate the construction of the lowered forwarding method from the construction of the target for the forwarding expression. That way, it is possible to arrange for the forwarding method's `this` function to be used when converting a field access.

Reviewed by @DanilaFe - thanks!

 - [x] full local testing
 - [x] testing with `--dyno` fixes the new failures