### PR TITLE
dyno: Adjust dump methods to print to stdout and flush with newline

### DIFF
--- a/frontend/include/chpl/framework/stringify-functions.h
+++ b/frontend/include/chpl/framework/stringify-functions.h
@@ -410,7 +410,8 @@ template<typename... ArgTs> struct stringify<std::tuple<ArgTs...>> {
     dump(DEBUG_DETAIL); \
   } \
   void T::dump(chpl::StringifyKind debug_level) const { \
-    stringify(std::cerr, debug_level); \
+    stringify(std::cout, debug_level); \
+    std::cout << std::endl; \
   }
 
 


### PR DESCRIPTION
dyno: Adjust dump methods to print to stdout and flush with newline

"Dump" methods (literally `foo->dump()`) were added to dyno as a
useful way of debugging AST, IR for Chapel types, meta-types, and
generally any C++ type that stores information used for compilation.
They are modelled after similar helper methods in LLVM.

For awhile now `dump()` has not functioned correctly when used with
the LLDB debugger. For one reason or another, the debugger REPL and
the output of a `dump()` call clash with each other, resulting in
mangled or missing output.

After getting fed up with things, I discovered that flushing the
channel is sufficient - but only if done by printing a newline.

While here, also make `dump()` print to `stdout` instead of `stderr`,
as the latter seemed a bit strange for debugging output.

Reviewed by @arezaii. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>