### PR TITLE
Fix try! expressions around new calls for records, too

### DIFF
--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -294,6 +294,7 @@ static CallExpr* buildInitCall(CallExpr* newExpr,
 
   VarSymbol* tmp = newTemp("initTemp", rootType);
   CallExpr* call = new CallExpr("init", gMethodToken, new NamedExpr("this", new SymExpr(tmp)));
+  call->tryTag = newExpr->tryTag;
 
   insertNamedInstantiationInfo(newExpr, call, at);
 
@@ -372,7 +373,6 @@ void resolveNewInitializer(CallExpr* newExpr, Type* manager) {
   if (manager == dtBorrowed) {
     USR_WARN(newExpr, "creating a 'new borrowed' type is deprecated");
   }
-  TryTag newTryTag = newExpr->tryTag;
 
   INT_ASSERT(newExpr->isPrimitive(PRIM_NEW));
   AggregateType* at = resolveNewFindType(newExpr);
@@ -403,7 +403,6 @@ void resolveNewInitializer(CallExpr* newExpr, Type* manager) {
     initCall->get(1)->remove(); // '_mt'
     initCall->insertAtHead(new SymExpr(initType->symbol));
     CallExpr* newCall = toCallExpr(initCall->remove());
-    newCall->tryTag = newTryTag;
 
     initTemp->defPoint->remove();
 

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefaultRecord.chpl
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefaultRecord.chpl
@@ -1,0 +1,31 @@
+// Tracks a bug I found when using throwing initializers in practice
+module tryBangExpressionDefault {
+  proc validate(xVal: int) throws {
+    if xVal > 10 then
+      throw new Error("value too large");
+  }
+  record Bar {
+    var x: int;
+
+    proc type a { return new Bar(14); }
+    proc type b { return new Bar(11); }
+  }
+
+  record Foo {
+    var x: Bar;
+
+    // Using a default value that was slightly complicated, e.g. the result of a
+    // type method call triggered a specific error message
+    proc init(xVal: Bar = Bar.a) throws {
+      x = xVal;
+      this.complete();
+      validate(xVal.x);
+    }
+  }
+
+  proc main() {
+    // Using a try! expression instead of a try! statement also caused problems
+    var x: Foo = try! new Foo();
+    writeln(x);
+  }
+}

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefaultRecord.good
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefaultRecord.good
@@ -1,0 +1,3 @@
+uncaught Error: value too large
+  tryBangExpressionDefaultRecord.chpl:5: thrown here
+  tryBangExpressionDefaultRecord.chpl:28: uncaught here

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpressionRecord.chpl
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpressionRecord.chpl
@@ -1,0 +1,25 @@
+// Tracks a bug I found when using throwing initializers in practice
+module tryBangExpression {
+  proc validate(xVal: int) throws {
+    if xVal > 10 then
+      throw new Error("value too large");
+  }
+
+  record Foo {
+    var x: int;
+
+    proc init(xVal: int) throws {
+      x = xVal;
+      this.complete();
+      validate(xVal);
+    }
+  }
+
+  proc main() {
+    // Using a try! expression instead of a try! statement caused problems
+    var x: Foo = try! new Foo(8);
+    writeln(x);
+    var y: Foo = try! new Foo(15);
+    writeln(y);
+  }
+}

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpressionRecord.good
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpressionRecord.good
@@ -1,0 +1,4 @@
+(x = 8)
+uncaught Error: value too large
+  tryBangExpressionRecord.chpl:5: thrown here
+  tryBangExpressionRecord.chpl:22: uncaught here


### PR DESCRIPTION
I had only tested classes before, but the change I made earlier
didn't work for records.  Fix that oversight and verified that this
allowed me to remove the stdout and stderr workarounds in my
other branch.

Added a pair of the same tests but for records.  These tests
failed before and now work.

Passed a full paratest with futures