### PR TITLE
Adjust smoke test to print out lines with tabs/spaces

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -105,10 +105,9 @@ echo ""
 if [ $LINT -eq 1 ]; then
     # Check for tabs.
     echo "Checking for tabs"
-    output=$($CHPL_HOME/util/devel/lookForTabs)
+    $CHPL_HOME/util/devel/lookForTabs
     if [ $? -ne 0 ] ; then
         echo "Found tabs :-("
-        echo $output
         exit 1
     fi
 
@@ -116,10 +115,9 @@ if [ $LINT -eq 1 ]; then
     # Need to clean up all of the trailing spaces before adding this
     # Check for trailing spaces
     echo "Checking for trailing spaces"
-    output=$($CHPL_HOME/util/devel/lookForTrailingSpaces)
+    $CHPL_HOME/util/devel/lookForTrailingSpaces
     if [ $? -ne 0 ] ; then
        echo "Found trailing spaces :-("
-        echo $output
        exit 1
     fi
 


### PR DESCRIPTION
Recently, I observed a CI failure where the only failure output was this:

```
Checking for tabs
Checking for trailing spaces
Error: Process completed with exit code 1.
```

I eventually determined that my PR added a trailing space. However, we would like `smokeTest` to print out the failing lines. The reason that it did not is that this script is running with `set -e`, which makes the script exit before it has a chance to print out the captured output from `util/devel/lookForTrailingSpaces`.

So, this PR adjusts the invocations of `lookForTabs` and `lookForTrailingSpaces` to not capture their output, so the problematic lines will be clear in CI testing.

When I add a tab somewhere, the smoke test output looks like this:

```
Checking for tabs
compiler/AST/view.cpp:1435:     return debugGetTheIteratorFn(fl);
```

When I add a trailing space instead, it looks like this:

```
Checking for tabs
Checking for trailing spaces
compiler/AST/view.cpp:1435:    return debugGetTheIteratorFn(fl); 
```

I think this is clear enough. Alternative approaches include checking the captured output length and using a subshell to avoid quitting on an error (the approach used in `grepstdchdrs`) -- or removing the `set -e` from this script.

Reviewed by @bhavanijayakumaran - thanks!