### PR TITLE
Remove redundant redifinition of CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE

### DIFF
--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -54,8 +54,6 @@ def get_runtime_includes_and_defines():
         # this -D is needed since it affects code inside of headers
         bundled.append("-DHAS_GPU_LOCALE")
         memtype = chpl_gpu.get_gpu_mem_strategy()
-        if memtype == "array_on_device":
-            bundled.append("-DCHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE")
 
         # If compiling for GPU locales, add CUDA runtime headers to include path
         gpu_type = chpl_gpu.get()


### PR DESCRIPTION
We auto generate a header `chpl-env-gen.h` that defines macros named as the key/value pairs (separated by an underscore) for various CHPL_ environment variables (including CHPL_GPU_MEM_STRATEGY). Previously, we also passed in as a macro (with `-D`) `CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE` when using the `array_on_device` memory strategy. These two approaches led to `CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE` being defined multiple times.

To avoid this I've modified `chplenv/compile_link_args_utils.py` to not pass in this macro and instead rely on including and using the version passed in by `chpl-env-gen.h`.