### PR TITLE
Fix symbolic links for array_on_device perf test

### DIFF
--- a/test/gpu/native/array_on_device/studies/shoc/EXECOPTS
+++ b/test/gpu/native/array_on_device/studies/shoc/EXECOPTS
@@ -1,1 +1,1 @@
-/home/stonea/chapel/test/gpu/native/studies/shoc/EXECOPTS
+../../../studies/shoc/EXECOPTS

--- a/test/gpu/native/array_on_device/studies/shoc/GPU-COMPOPTS
+++ b/test/gpu/native/array_on_device/studies/shoc/GPU-COMPOPTS
@@ -1,1 +1,1 @@
-/home/stonea/chapel/test/gpu/native/studies/shoc/GPU-COMPOPTS
+../../../studies/shoc/GPU-COMPOPTS

--- a/test/gpu/native/array_on_device/studies/shoc/GPU-EXECOPTS
+++ b/test/gpu/native/array_on_device/studies/shoc/GPU-EXECOPTS
@@ -1,1 +1,1 @@
-/home/stonea/chapel/test/gpu/native/studies/shoc/GPU-EXECOPTS
+../../../studies/shoc/GPU-EXECOPTS

--- a/test/gpu/native/array_on_device/studies/shoc/result.chpl
+++ b/test/gpu/native/array_on_device/studies/shoc/result.chpl
@@ -1,1 +1,1 @@
-/home/stonea/chapel/test/gpu/native/studies/shoc/result.chpl
+../../../studies/shoc/result.chpl

--- a/test/gpu/native/array_on_device/studies/shoc/result.notest
+++ b/test/gpu/native/array_on_device/studies/shoc/result.notest
@@ -1,1 +1,1 @@
-/home/stonea/chapel/test/gpu/native/studies/shoc/result.notest
+../../../studies/shoc/result.notest


### PR DESCRIPTION
In #21459 (adding nightly testing for array_on_device mode with GPU support) I added some symbolic links; these links should have used relative paths but I accidentally had them using absolute paths.  This PR updates this.