### PR TITLE
dyno: draft const checking for the dyno resolver

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1092,14 +1092,13 @@ class ResolvedParamLoop;
 /**
 
   This type represents an associated action (for use within a
-  ResolvedExpression)
+  ResolvedExpression).
 
  */
 class AssociatedAction {
  public:
   enum Action {
-    ASSIGN,       // = from the same type
-    ASSIGN_OTHER, // = from other type
+    ASSIGN,       // same type or different type assign
     COPY_INIT,    // init= from same type
     INIT_OTHER,   // init= from other type
     DEFAULT_INIT,
@@ -1127,8 +1126,10 @@ class AssociatedAction {
   }
   /** Returns which action this represents */
   Action action() const { return action_; }
+
   /** Return which function is called to help with the action */
   const TypedFnSignature* fn() const { return fn_; }
+
   /** Return the ID is associated with the action */
   const ID& id() const { return id_; }
 

--- a/frontend/lib/resolution/maybe-const.cpp
+++ b/frontend/lib/resolution/maybe-const.cpp
@@ -278,6 +278,15 @@ bool AdjustMaybeRefs::enter(const Call* ast, RV& rv) {
       if (fa->hasActual()) {
         const AstNode* actualAst = actualAsts[actualIdx];
         Access access = accessForQualifier(fa->formalType().kind());
+
+        // check for const-ness errors
+        if (access == REF) {
+          ResolvedExpression& actualRe = rv.byAst(actualAst);
+          if (actualRe.type().isConst()) {
+            context->error(actualAst, "cannot pass const to non-const");
+          }
+        }
+
         exprStack.push_back(ExprStackEntry(actualAst, access,
                                            fn, formalIdx));
 

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -837,35 +837,25 @@ void CallResolutionResult::stringify(std::ostream& ss,
 
 
 const char* AssociatedAction::kindToString(Action a) {
-  const char* s = "<unknown>";
   switch (a) {
     case ASSIGN:
-      s = "assign";
-      break;
-    case ASSIGN_OTHER:
-      s = "assign-from-other";
-      break;
+      return "assign";
     case COPY_INIT:
-      s = "copy-init";
-      break;
+      return "copy-init";
     case DEFAULT_INIT:
-      s = "default-init";
-      break;
+      return "default-init";
     case INIT_OTHER:
-      s = "init-from-other";
-      break;
+      return "init-from-other";
     case DEINIT:
-      s = "deinit";
-      break;
+      return "deinit";
     case ITERATE:
-      s = "these";
-      break;
+      return "these";
     case NEW_INIT:
-      s = "new-init";
-      break;
+      return "new-init";
+    // no default to get a warning if new Actions are added
   }
 
-  return s;
+  return "<unknown>";
 }
 
 void AssociatedAction::stringify(std::ostream& ss,

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -50,6 +50,10 @@ namespace resolution {
 using namespace uast;
 using namespace types;
 
+// forward declarations
+static QualifiedType adjustForReturnIntent(uast::Function::ReturnIntent ri,
+                                           QualifiedType retType);
+
 
 // Get a Type for an AggregateDecl
 // poiScope, instantiatedFrom are nullptr if not instantiating
@@ -286,7 +290,8 @@ QualifiedType ReturnTypeInferrer::returnedType() {
       context->error(astForErr, "could not determine return type for function");
       retType = QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
     }
-    return retType.getValue();
+    auto adjType = adjustForReturnIntent(returnIntent, retType.getValue());
+    return adjType;
   }
 }
 
@@ -453,8 +458,8 @@ static QualifiedType adjustForReturnIntent(uast::Function::ReturnIntent ri,
   QualifiedType::Kind kind = (QualifiedType::Kind) ri;
   // adjust default / const return intent to 'var'
   if (kind == QualifiedType::DEFAULT_INTENT ||
-      kind == QualifiedType::CONST_VAR) {
-    kind = QualifiedType::VAR;
+      kind == QualifiedType::VAR) {
+    kind = QualifiedType::CONST_VAR;
   }
   return QualifiedType(kind, retType.type(), retType.param());
 }

--- a/frontend/test/resolution/CMakeLists.txt
+++ b/frontend/test/resolution/CMakeLists.txt
@@ -18,6 +18,7 @@
 comp_unit_test(testCallInitDeinit)
 comp_unit_test(testCanPass)
 comp_unit_test(testClasses)
+comp_unit_test(testConstChecking)
 comp_unit_test(testCopyElision)
 comp_unit_test(testDeprecationUnstable)
 comp_unit_test(testDisambiguation)

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -316,7 +316,7 @@ static void test3a() {
     {
       {AssociatedAction::DEFAULT_INIT, "x",        ""},
       {AssociatedAction::DEFAULT_INIT, "y",        ""},
-      {AssociatedAction::ASSIGN,       "M.test@7", ""},
+      // assignment x=y is resolved but not as an associated action
       {AssociatedAction::DEINIT,       "M.test@8", "y"},
       {AssociatedAction::DEINIT,       "M.test@8", "x"}
     });

--- a/frontend/test/resolution/testConstChecking.cpp
+++ b/frontend/test/resolution/testConstChecking.cpp
@@ -290,8 +290,54 @@ static void test5b() {
     {6});
 }
 
-// TODO: check mutating a const / const ref with =
-// TODO: ditto with split init
+static void test6a() {
+  testConstChecking("test6a",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
+        proc test() {
+          const x: int = 0;
+          x = 34;
+        }
+      }
+    )"""",
+    {8});
+}
+static void test6b() {
+  testConstChecking("test6b",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
+        proc test() {
+          const x: int = 0;
+          const ref y = x;
+          y = 34;
+        }
+      }
+    )"""",
+    {9});
+}
+static void test6c() {
+  testConstChecking("test6c",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
+        proc test() {
+          const x: int = 0;
+          ref y = x;
+          y = 34;
+        }
+      }
+    )"""",
+    {8});
+}
+
 
 int main() {
   test1a();
@@ -312,6 +358,10 @@ int main() {
 
   test5a();
   test5b();
+
+  test6a();
+  test6b();
+  test6c();
 
   return 0;
 }

--- a/frontend/test/resolution/testConstChecking.cpp
+++ b/frontend/test/resolution/testConstChecking.cpp
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test-resolution.h"
+
+#include "chpl/parsing/parsing-queries.h"
+#include "chpl/resolution/resolution-queries.h"
+#include "chpl/resolution/scope-queries.h"
+#include "chpl/resolution/split-init.h"
+#include "chpl/uast/Call.h"
+#include "chpl/uast/Comment.h"
+#include "chpl/uast/Identifier.h"
+#include "chpl/uast/Module.h"
+#include "chpl/uast/Variable.h"
+
+static void
+testConstChecking(const char* test,
+                  const char* program,
+                  // vector of line numbers with an error expected
+                  std::vector<int> expectedErrorLines) {
+  printf("\n### %s\n", test);
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string testname = test;
+  testname += ".chpl";
+  auto path = UniqueString::get(context, testname);
+  std::string contents = program;
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+  assert(vec.size() == 1);
+  const Module* M = vec[0]->toModule();
+  assert(M);
+  assert(M->numStmts() >= 1);
+
+  M->dump();
+
+  resolveModule(context, M->id());
+
+  // and make sure to resolve any concrete functions
+  for (auto stmt : M->stmts()) {
+    if (auto fn = stmt->toFunction()) {
+      // resolve concrete functions (ignore generics)
+      resolveConcreteFunction(context, fn->id());
+    }
+  }
+
+  guard.printErrors();
+
+  std::set<int> expectedSet;
+  std::set<int> gotSet;
+  for (auto line : expectedErrorLines) {
+    expectedSet.insert(line);
+  }
+
+  for (const auto& err : guard.errors()) {
+    Location errLoc = err->location(context);
+    gotSet.insert(errLoc.line());
+  }
+
+  if (expectedSet != gotSet) {
+    assert(false && "Error locations do not match expected locations");
+  }
+
+  guard.clearErrors();
+}
+
+static void test1a() {
+  testConstChecking("test1a",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        proc test() {
+          const x: int;
+          acceptsRef(x);
+        }
+      }
+    )"""",
+    {6});
+}
+static void test1b() {
+  testConstChecking("test1b",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        proc test() {
+          var x: int;
+          acceptsRef(x);
+        }
+      }
+    )"""",
+    {});
+}
+static void test1c() {
+  testConstChecking("test1c",
+    R""""(
+      module M {
+        proc acceptsConstRef(const ref arg) { }
+        proc test() {
+          const x: int;
+          acceptsConstRef(x);
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test2a() {
+  testConstChecking("test2a",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        proc test() {
+          const x: int;
+          const ref y = x;
+          acceptsRef(y);
+        }
+      }
+    )"""",
+    {7});
+}
+
+static void test3a() {
+  testConstChecking("test3a",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        var global: int;
+        proc foo() ref { return global; }
+        proc test() {
+          acceptsRef(foo());
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test3b() {
+  testConstChecking("test3b",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        var global: int;
+        proc foo() const ref { return global; }
+        proc test() {
+          acceptsRef(foo());
+        }
+      }
+    )"""",
+    {7});
+}
+
+static void test3c() {
+  testConstChecking("test3c",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        var global: int;
+        proc foo() { return global; }
+        proc test() {
+          acceptsRef(foo());
+        }
+      }
+    )"""",
+    {7});
+}
+static void test3d() {
+  testConstChecking("test3d",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        var global: int;
+        proc foo() : int { return global; }
+        proc test() {
+          acceptsRef(foo());
+        }
+      }
+    )"""",
+    {7});
+}
+
+static void test4a() {
+  testConstChecking("test4a",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        var global: int;
+        proc foo() ref { return global; }
+        proc foo() const ref { return global; }
+        proc test() {
+          acceptsRef(foo());
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test4b() {
+  testConstChecking("test4b",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        var global: int;
+        proc foo() { return global; }
+        proc foo() ref { return global; }
+        proc test() {
+          acceptsRef(foo());
+        }
+      }
+    )"""",
+    {});
+}
+
+static void test4c() {
+  testConstChecking("test4c",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        var global: int;
+        proc foo() { return global; }
+        proc foo() const ref { return global; }
+        proc test() {
+          acceptsRef(foo());
+        }
+      }
+    )"""",
+    {8});
+}
+
+static void test4d() {
+  testConstChecking("test4d",
+    R""""(
+      module M {
+        proc acceptsRef(ref arg) { }
+        var global: int;
+        proc foo() { return global; }
+        proc foo() ref { return global; }
+        proc foo() const ref { return global; }
+        proc test() {
+          acceptsRef(foo());
+        }
+      }
+    )"""",
+    {});
+}
+
+
+
+int main() {
+  test1a();
+  test1b();
+  test1c();
+
+  test2a();
+
+  test3a();
+  test3b();
+  test3c();
+  test3d();
+
+  test4a();
+  test4b();
+  test4c();
+  test4d();
+
+  return 0;
+}

--- a/frontend/test/resolution/testConstChecking.cpp
+++ b/frontend/test/resolution/testConstChecking.cpp
@@ -338,6 +338,8 @@ static void test6c() {
     {8});
 }
 
+// TODO: test const checking for associated functions
+
 
 int main() {
   test1a();

--- a/frontend/test/resolution/testConstChecking.cpp
+++ b/frontend/test/resolution/testConstChecking.cpp
@@ -263,7 +263,35 @@ static void test4d() {
     {});
 }
 
+static void test5a() {
+  testConstChecking("test5a",
+    R""""(
+      module M {
+        proc acceptsOut(out arg: int) { }
+        proc test() {
+          const x: int;
+          acceptsOut(x);
+        }
+      }
+    )"""",
+    {6});
+}
+static void test5b() {
+  testConstChecking("test5b",
+    R""""(
+      module M {
+        proc acceptsInout(inout arg: int) { }
+        proc test() {
+          const x: int;
+          acceptsInout(x);
+        }
+      }
+    )"""",
+    {6});
+}
 
+// TODO: check mutating a const / const ref with =
+// TODO: ditto with split init
 
 int main() {
   test1a();
@@ -281,6 +309,9 @@ int main() {
   test4b();
   test4c();
   test4d();
+
+  test5a();
+  test5b();
 
   return 0;
 }

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -27,6 +27,8 @@
 
 // an initial example
 static void test1() {
+  printf("test1\n");
+
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -57,6 +59,8 @@ static void test1() {
 
 // forwarding -> forwarding
 static void test2() {
+  printf("test2\n");
+
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -90,6 +94,8 @@ static void test2() {
 
 // error for cycle of forwarding
 static void test3() {
+  printf("test3\n");
+
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -118,6 +124,8 @@ static void test3() {
 
 // forwarding statement that isn't forwarding var
 static void test4() {
+  printf("test4\n");
+
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -125,6 +133,7 @@ static void test4() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner {
         var i: int;
@@ -150,6 +159,8 @@ static void test4() {
 
 // two forwarding statements
 static void test5a() {
+  printf("test5a\n");
+
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -157,6 +168,7 @@ static void test5a() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -186,6 +198,8 @@ static void test5a() {
 }
 // same but expecting ambiguity
 static void test5b() {
+  printf("test5b\n");
+
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -193,6 +207,7 @@ static void test5b() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -232,6 +247,8 @@ static void test5b() {
 
 // two forwarding statements -> two forwarding statements
 static void test6a() {
+  printf("test6a\n");
+
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -239,6 +256,7 @@ static void test6a() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -282,6 +300,8 @@ static void test6a() {
 }
 // same, but expecting ambiguity error
 static void test6b() {
+  printf("test6b\n");
+
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -289,6 +309,7 @@ static void test6b() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -110,7 +110,8 @@ R"""( i in myiter() {
   assert(idxType.type() == IntType::get(context, 0));
 
   auto xType = rr.byAst(xVar).type();
-  assert(idxType == xType);
+  assert(idxType.type() == xType.type());
+  assert(idxType.kind() == Qualifier::CONST_VAR);
 }
 
 //

--- a/frontend/test/resolution/testMaybeConst.cpp
+++ b/frontend/test/resolution/testMaybeConst.cpp
@@ -275,6 +275,9 @@ static void test3h() {
   testMaybeRef("test3h",
     R""""(
       module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() const ref { return global; }   // M.foo#1
@@ -292,6 +295,9 @@ static void test3i() {
   testMaybeRef("test3i",
     R""""(
       module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() const ref { return global; }   // M.foo#1
@@ -425,6 +431,9 @@ static void test4h() {
   testMaybeRef("test4h",
     R""""(
       module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() { return global; }             // M.foo#1
@@ -442,6 +451,9 @@ static void test4i() {
   testMaybeRef("test4i",
     R""""(
       module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() { return global; }             // M.foo#1
@@ -517,7 +529,8 @@ static void test5d() {
       }
     )"""",
     {},
-    {{"M.test@1", "M.foo#1"}});
+    {{"M.test@1", "M.foo#1"}},
+    /* expectErrors */ true);
 }
 
 static void test5e() {
@@ -735,6 +748,9 @@ static void test6h() {
   testMaybeRef("test6h",
     R""""(
       module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
         var global: int;
         proc foo() const ref { return global; }     // M.foo
         proc foo() { return global; }               // M.foo#1
@@ -753,6 +769,9 @@ static void test6i() {
   testMaybeRef("test6i",
     R""""(
       module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) { }
+
         var global: int;
         proc foo() ref { return global; }        // M.foo
         proc foo() const ref { return global; }  // M.foo#1

--- a/frontend/test/resolution/testMaybeConst.cpp
+++ b/frontend/test/resolution/testMaybeConst.cpp
@@ -534,7 +534,8 @@ static void test5e() {
       }
     )"""",
     {},
-    {{"M.test@2", "M.foo"}});
+    {{"M.test@2", "M.foo"}},
+    /* expectErrors */ true);
 }
 
 static void test5f() {
@@ -585,7 +586,8 @@ static void test5h() {
       }
     )"""",
     {},
-    {{"M.test@2", "M.foo"}});
+    {{"M.test@2", "M.foo"}},
+    /* expectErrors */ true);
 }
 
 static void test5i() {
@@ -602,7 +604,8 @@ static void test5i() {
       }
     )"""",
     {},
-    {{"M.test@2", "M.foo"}});
+    {{"M.test@2", "M.foo"}},
+    /* expectErrors */ true);
 }
 
 // test ref/const ref/value return intent overload

--- a/frontend/test/resolution/testOperatorOverloads.cpp
+++ b/frontend/test/resolution/testOperatorOverloads.cpp
@@ -50,7 +50,7 @@ static void test1() {
     )""""
   );
   assert(qt2.type() && qt2.type()->isIntType());
-  assert(qt2.kind() == QualifiedType::VAR);
+  assert(qt2.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 
   // secondary operator method
@@ -65,7 +65,7 @@ static void test1() {
     )""""
   );
   assert(qt3.type() && qt3.type()->isIntType());
-  assert(qt3.kind() == QualifiedType::VAR);
+  assert(qt3.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 
   // non-method operator
@@ -80,7 +80,7 @@ static void test1() {
     )""""
   );
   assert(qt4.type() && qt4.type()->isIntType());
-  assert(qt4.kind() == QualifiedType::VAR);
+  assert(qt4.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 }
 
@@ -121,7 +121,7 @@ static void test2() {
     )""""
   );
   assert(qt2.type() && qt2.type()->isIntType());
-  assert(qt2.kind() == QualifiedType::VAR);
+  assert(qt2.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 }
 
@@ -157,7 +157,7 @@ static void test3() {
     )""""
   );
   assert(qt2.type() && qt2.type()->isIntType());
-  assert(qt2.kind() == QualifiedType::VAR);
+  assert(qt2.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 
   // overloading more operators
@@ -172,7 +172,7 @@ static void test3() {
     )""""
   );
   assert(qt3.type() && qt3.type()->isIntType());
-  assert(qt3.kind() == QualifiedType::VAR);
+  assert(qt3.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 
   QualifiedType qt4 = resolveTypeOfXInit(context,
@@ -186,7 +186,7 @@ static void test3() {
     )""""
   );
   assert(qt4.type() && qt4.type()->isBoolType());
-  assert(qt4.kind() == QualifiedType::VAR);
+  assert(qt4.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 
   QualifiedType qt5 = resolveTypeOfXInit(context,
@@ -201,7 +201,7 @@ static void test3() {
     )""""
   );
   assert(qt5.type() && qt5.type()->isIntType());
-  assert(qt5.kind() == QualifiedType::VAR);
+  assert(qt5.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 
   // overloading operator for non-compound types
@@ -214,7 +214,7 @@ static void test3() {
     )""""
   );
   assert(qt6.type() && qt6.type()->isBoolType());
-  assert(qt6.kind() == QualifiedType::VAR);
+  assert(qt6.kind() == QualifiedType::CONST_VAR);
   ctx.advanceToNextRevision(false);
 }
 

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -180,7 +180,7 @@ static void test6() {
                   var x = f();
                 )"""");
 
-  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.kind() == QualifiedType::CONST_VAR);
   assert(qt.type()->isTupleType());
   auto tt = qt.type()->toTupleType();
   auto rt = tt->toReferentialTuple(context);
@@ -229,7 +229,7 @@ static void test8() {
                   var x = f();
                 )"""");
 
-  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.kind() == QualifiedType::CONST_VAR);
   assert(qt.type()->isTupleType());
   auto tt = qt.type()->toTupleType();
   auto rt = tt->toReferentialTuple(context);
@@ -317,7 +317,7 @@ static void test11() {
                   var x = f( (1,2) );
                 )"""");
 
-  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.kind() == QualifiedType::CONST_VAR);
   assert(qt.type()->isTupleType());
   auto tt = qt.type()->toTupleType();
 
@@ -342,7 +342,7 @@ static void test12() {
                 )"""");
 
 
-  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.kind() == QualifiedType::CONST_VAR);
   assert(qt.type()->isTupleType());
   auto tt = qt.type()->toTupleType();
 
@@ -372,7 +372,7 @@ static void test13() {
                 )"""");
 
 
-  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.kind() == QualifiedType::CONST_VAR);
   assert(qt.type()->isTupleType());
   auto tt = qt.type()->toTupleType();
 
@@ -401,7 +401,7 @@ static void test14() {
                   var x = f( 1, (2.0, 3) );
                 )"""");
 
-  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.kind() == QualifiedType::CONST_VAR);
   assert(qt.type()->isTupleType());
   auto tt = qt.type()->toTupleType();
 


### PR DESCRIPTION
This PR adjusts `maybe-const.cpp` to also include doing const checking after return intent overloading.

In order to support that:
 * Adjusted functions that return by value to end up with a return type with kind `Qualifier::CONST_VAR` (instead of `Qualifier::VAR`). Generally speaking, the Chapel compiler does not allow a value returned by a function to be mutated. (The production compiler currently has an exception for arrays, where returning an array by value does return something mutable).
 * Changed `call-init-deinit.cpp` to make `=` calls that are not split-init initializations resolve more normally instead of always resolving them as associated actions

While working in this area, I also shortened `AssociatedAction::kindToString` by using `return` within each case.

Future Work:
 * Add const checking for associated actions, for example when an `const` `owned` is passed by `in` intent, there should be an error, because the copy-init call involves mutating the RHS.

Reviewed by @arezaii - thanks!

- [x] full local testing