### PR TITLE
Have VarScopeVisitor skip param-elided branches.

### DIFF
--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -211,6 +211,9 @@ class VarScopeVisitor {
   bool enter(const Identifier* ast, RV& rv);
   void exit(const Identifier* ast, RV& rv);
 
+  bool enter(const uast::Conditional* node, RV& rv);
+  void exit(const uast::Conditional* node, RV& rv);
+
   bool enter(const uast::AstNode* node, RV& rv);
   void exit(const uast::AstNode* node, RV& rv);
 };

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -978,7 +978,7 @@ void CallInitDeinit::handleConditional(const Conditional* cond, RV& rv) {
   VarFrame* elseFrame = currentElseFrame();
 
   // process end-of-block deinits in then/else blocks and then propagate
-  if (!thenFrame->returnsOrThrows) {
+  if (thenFrame && !thenFrame->returnsOrThrows) {
     processDeinitsAndPropagate(thenFrame, frame, rv);
   }
   if (elseFrame && !elseFrame->returnsOrThrows) {


### PR DESCRIPTION
Currently some logic in the standard library conditionally declares a variable depending on an input type. Something like:
```Chapel
proc f(type t) {
  if isNumber(t) { return true; }
  else {
    var x: t;
    // ...
  }
}
```
Currently, Dyno fails to handle cases like these because it attempts to perform various analyses in the vein of copy elision, init-deinit, and others backed by `VarScopeVisitor`. However, some of these analyses require type information; they therefore require to know the type of `x` in the else branch, even if `isNumber(t)` is `param true`. However, the resolver does not visit `param false` branches, so this information is absent, and errors occur.

This PR therefore changes the behavior of VarScopeVisitor to skip param-elided branches, and therefore avoid requesting type information that is not computed.

## Future work
We still need to figure out if completely skipping param-elided branches in the VarScopeVisitor is the way to go in terms of language design; see issue https://github.com/chapel-lang/chapel/issues/14996 for discussion. In particular, this PR effectively implements option 2 from https://github.com/chapel-lang/chapel/issues/14996#issuecomment-1398412487 (ignore param false branches, make split init etc. happen after param folding). 

## Testing
- [x] paratest
- [x] paratest with --dyno (post-patch reports 39 errors, nothing that hasn't been tracked)

Reviewed by @mppf - thanks!

Signed-off-by: Danila Fedorin <daniel.fedorin@hpe.com>