### PR TITLE
dyno: Fix bugs with deprecation and unstable warnings

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -333,6 +333,12 @@ CallResolutionResult resolveGeneratedCall(Context* context,
                                           const Scope* inScope,
                                           const PoiScope* inPoiScope);
 
+/**
+  Given a type 't', compute whether or not 't' is default initializable.
+  If 't' is a generic type, it is considered non-default-initializable.
+  Considers the fields and substitutions of composite types.
+*/
+bool isTypeDefaultInitializable(Context* context, const types::Type* t);
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -987,7 +987,7 @@ static bool isAstDeprecated(Context* context, const AstNode* ast) {
 
 static bool isAstUnstable(Context* context, const AstNode* ast) {
   auto attr = parsing::idToAttributeGroup(context, ast->id());
-  return attr && attr->isDeprecated();
+  return attr && attr->isUnstable();
 }
 
 static bool isAstFormal(Context* context, const AstNode* ast) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2689,26 +2689,34 @@ getDecoratedClassForNew(Context* context, const New* node,
   return ret;
 }
 
-// TODO: Emit warning about 'new borrowed' being unstable.
-// TODO: How do we handle '?'.
-void Resolver::resolveNewForClass(const New* node,
-                                  const ClassType* classType) {
-  ResolvedExpression& re = byPostorder.byAst(node);
-
-  // TODO: Verify initial class type?
-  auto cls = getDecoratedClassForNew(context, node, classType);
+static void resolveNewForClass(Resolver& rv, const New* node,
+                               const ClassType* classType) {
+  ResolvedExpression& re = rv.byPostorder.byAst(node);
+  auto cls = getDecoratedClassForNew(rv.context, node, classType);
   auto qt = QualifiedType(QualifiedType::VAR, cls);
   re.setType(qt);
 }
 
-void Resolver::resolveNewForRecord(const New* node,
-                                   const RecordType* recordType) {
-  ResolvedExpression& re = byPostorder.byAst(node);
+static void resolveNewForRecord(Resolver& rv, const New* node,
+                                const RecordType* recordType) {
+  ResolvedExpression& re = rv.byPostorder.byAst(node);
 
   if (node->management() != New::DEFAULT_MANAGEMENT) {
-    CHPL_REPORT(context, MemManagementNonClass, node, recordType);
+    CHPL_REPORT(rv.context, MemManagementNonClass, node, recordType);
   } else {
     auto qt = QualifiedType(QualifiedType::VAR, recordType);
+    re.setType(qt);
+  }
+}
+
+static void resolveNewForUnion(Resolver& rv, const New* node,
+                               const UnionType* unionType) {
+  ResolvedExpression& re = rv.byPostorder.byAst(node);
+
+  if (node->management() != New::DEFAULT_MANAGEMENT) {
+    CHPL_REPORT(rv.context, MemManagementNonClass, node, unionType);
+  } else {
+    auto qt = QualifiedType(QualifiedType::VAR, unionType);
     re.setType(qt);
   }
 }
@@ -2739,10 +2747,13 @@ void Resolver::exit(const New* node) {
     CHPL_ASSERT(false && "Expected fully decorated class type");
 
   } else if (auto classType = qtTypeExpr.type()->toClassType()) {
-    resolveNewForClass(node, classType);
+    resolveNewForClass(*this, node, classType);
 
   } else if (auto recordType = qtTypeExpr.type()->toRecordType()) {
-    resolveNewForRecord(node, recordType);
+    resolveNewForRecord(*this, node, recordType);
+
+  } else if (auto unionType = qtTypeExpr.type()->toUnionType()) {
+    resolveNewForUnion(*this, node, unionType);
 
   } else {
     if (node->management() != New::DEFAULT_MANAGEMENT) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -941,7 +941,7 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
       // for 'this' formals of class type, adjust them to be borrowed, so
       // e.g. proc C.foo() { } has 'this' of type 'borrowed C'.
       // This should not apply to parenthesized expressions.
-      if (isFormalThis &&
+      if (isFormalThis && typeExpr &&
           typeExprT.type() != nullptr && typeExprT.type()->isClassType() &&
           typeExpr->isIdentifier()) {
         auto ct = typeExprT.type()->toClassType();

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -384,14 +384,6 @@ struct Resolver {
   // prepare a CallInfo by inspecting the called expression and actuals
   CallInfo prepareCallInfoNormalCall(const uast::Call* call);
 
-  // resolve 'new R' for a given record type 'R'
-  void resolveNewForRecord(const uast::New* node,
-                           const types::RecordType* recordType);
-
-  // resolve 'new C' for a given class type 'C', including management
-  void resolveNewForClass(const uast::New* node,
-                          const types::ClassType* classType);
-
   std::vector<BorrowedIdsWithName>
   lookupIdentifier(const uast::Identifier* ident,
                    const Scope* receiverScope);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3326,6 +3326,14 @@ bool isNameOfField(Context* context, UniqueString name, const Type* t) {
   return isNameOfFieldQuery(context, name, ct);
 }
 
+// TODO: This is very early draft and is missing a lot, e.g.,
+//    - No valid default-initializer present
+//    - Instantiated generics must supply type/param arguments when
+//      searching for a default-initializer
+//    - Consideration of 'where' clauses
+//    - Composites with compilerError'd default-initializers
+//    - Mutually recursive class types
+//    - Non-nil 'owned' classes
 static bool
 isTypeDefaultInitializableImpl(Context* context, const Type* t) {
   const auto g = t->genericity();
@@ -3360,7 +3368,8 @@ isTypeDefaultInitializableImpl(Context* context, const Type* t) {
       for (int i = 0; i < rf.numFields(); i++) {
         auto ft = rf.fieldType(i).type();
 
-        // Skip to avoid recursive query.
+        // TODO: Skipping avoids a recursive query but doesn't handle
+        // mutually recursive classes.
         if (ft == t) continue;
 
         if (!isTypeDefaultInitializable(context, ft)) return false;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3373,7 +3373,7 @@ isTypeDefaultInitializableImpl(Context* context, const Type* t) {
   return false;
 }
 
-const bool&
+static const bool&
 isTypeDefaultInitializableQuery(Context* context, const Type* t) {
   QUERY_BEGIN(isTypeDefaultInitializableQuery, context, t);
   bool ret = isTypeDefaultInitializableImpl(context, t);

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1114,6 +1114,10 @@ doResolveUseStmt(Context* context, const Use* use,
               CHPL_REPORT(context, AsWithUseExcept, use, as);
             }
           }
+          // check that symbols named with 'except' actually exist
+          errorIfAnyLimitationNotInScope(context, clause, foundScope,
+                                         r, VIS_USE);
+
           // add the visibility clause for only/except
           r->addVisibilityClause(foundScope, kind, isPrivate,
                                  convertLimitations(context, clause));

--- a/frontend/test/resolution/testDeprecationUnstable.cpp
+++ b/frontend/test/resolution/testDeprecationUnstable.cpp
@@ -485,6 +485,7 @@ static void testNoUnstableWarningsForThisFormals(void) {
 
   assert(guard.error(0)->message() == "The class 'C' is unstable");
   assert(guard.error(1)->message() == "The record 'r' is unstable");
+  assert(guard.realizeErrors());
 }
 
 int main() {

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -185,7 +185,7 @@ static void usage(int argc, char** argv) {
          "  --trace enables query tracing\n"
          "  --time <outputFile> outputs query timing information to outputFile\n"
          "  --searchPath <path> adds to the module search path\n"
-         "  --warn-unstable path> turns on unstable warnings\n",
+         "  --warn-unstable turns on unstable warnings\n",
          argv[0]);
 }
 

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -20,6 +20,7 @@
 #include "test-resolution.h"
 
 #include "chpl/parsing/parsing-queries.h"
+#include "chpl/framework/compiler-configuration.h"
 #include "chpl/framework/query-impl.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -183,7 +184,8 @@ static void usage(int argc, char** argv) {
          "  --scope only performs scope resolution\n"
          "  --trace enables query tracing\n"
          "  --time <outputFile> outputs query timing information to outputFile\n"
-         "  --searchPath <path> adds to the module search path\n",
+         "  --searchPath <path> adds to the module search path\n"
+         "  --warn-unstable path> turns on unstable warnings\n",
          argv[0]);
 }
 
@@ -210,6 +212,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> cmdLinePaths;
   std::vector<std::string> files;
   bool enableStdLib = false;
+  bool warnUnstable = false;
   const char* timing = nullptr;
   for (int i = 1; i < argc; i++) {
     if (0 == strcmp(argv[i], "--std")) {
@@ -234,6 +237,8 @@ int main(int argc, char** argv) {
       i++;
     } else if (0 == strcmp(argv[i], "--brief")) {
       brief = true;
+    } else if (0 == strcmp(argv[i], "--warn-unstable")) {
+      warnUnstable = true;
     } else {
       files.push_back(argv[i]);
     }
@@ -266,6 +271,10 @@ int main(int argc, char** argv) {
     typeForBuiltin(ctx, UniqueString::get(ctx, "int"));
     ctx->setDebugTraceFlag(trace);
     if (timing) ctx->beginQueryTimingTrace(timing);
+
+    CompilerFlags flags;
+    flags.set(CompilerFlags::WARN_UNSTABLE, warnUnstable);
+    setCompilerFlags(ctx, std::move(flags));
 
     setupSearchPaths(ctx, enableStdLib, cmdLinePaths, files);
 

--- a/frontend/test/test-common.h
+++ b/frontend/test/test-common.h
@@ -26,6 +26,7 @@
 #endif
 
 #include "chpl/parsing/Parser.h"
+#include "chpl/framework/compiler-configuration.h"
 #include "chpl/framework/Context.h"
 #include "chpl/framework/UniqueString.h"
 #include "chpl/uast/BuilderResult.h"


### PR DESCRIPTION
dyno: Fix bugs with deprecation and unstable warnings

Fix a few bugs that were causing test failures when running tests
with the dyno scope resolver.

Add a query `isTypeDefaultInitializable` that is used to fix a bug
with initializers. The bug was screwing up unit tests.

The query is not complete and is missing some obvious logic like
returning `false` for non-nilable owned classes, or detecting when
a type's default initializer does not exist. I will improve it
in future efforts.

Reviewed by @mppf. Thanks!

TESTING

- [x] `paratest`, `--dyno`

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>