### PR TITLE
Build Docker image for multiple backends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,9 @@ ENV CHPL_HOME=/opt/chapel \
 WORKDIR $CHPL_HOME
 COPY . .
 
-# build Chapel for both C (with Clang or GCC) and LLVM backends
-RUN CHPL_TARGET_COMPILER=gnu make \
-    CHPL_TARGET_COMPILER=clang make \
-    CHPL_TARGET_COMPILER=llvm make \
+# build Chapel for both C and LLVM backends
+RUN CHPL_TARGET_COMPILER=llvm make \
+    && CHPL_TARGET_COMPILER=gnu make \
     && make chpldoc test-venv mason \
     && make cleanall
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,10 @@ ENV CHPL_HOME=/opt/chapel \
 WORKDIR $CHPL_HOME
 COPY . .
 
-# build Chapel
-RUN make \
+# build Chapel for both C (with Clang or GCC) and LLVM backends
+RUN CHPL_TARGET_COMPILER=gnu make \
+    CHPL_TARGET_COMPILER=clang make \
+    CHPL_TARGET_COMPILER=llvm make \
     && make chpldoc test-venv mason \
     && make cleanall
 


### PR DESCRIPTION
Adds support for using the C backend (in addition to currently-supported LLVM backend) in the Docker image.

This is accomplished by building Chapel with `CHPL_TARGET_COMPILER` having each value of `{gnu, llvm}`. The runtime and some third-party support code is rebuilt to accomplish this, mildly increasing the size and complexity of the image.

The `chpldoc`, `test-venv`, and `mason` targets are not rebuilt as I consider them unlikely to be behave differently with different target compilers.

Resolves https://github.com/chapel-lang/chapel/issues/21448.

Testing:
- [x] multi-arch Docker image build succeeds
- [x] native Docker image allows `chpl` to be successfully invoked with `--target-compiler={gnu,llvm}`
- [x] native-arch Docker image build is not significantly slower