### PR TITLE
Always create perf directory for Arkouda XC testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -67,13 +67,6 @@ if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
     grep "Statements emitted:" $ARKOUDA_EMITTED_CODE_SIZE_FILE.tmp > $ARKOUDA_EMITTED_CODE_SIZE_FILE
     rm -f $ARKOUDA_EMITTED_CODE_SIZE_FILE.tmp
   fi
-
-  # Where should perf logs go?
-  export ARKOUDA_TEST_PERF_DIR=${ARKOUDA_TEST_PERF_DIR:-$CWD/perfData}
-
-  if [ ! -d "${ARKOUDA_TEST_PERF_DIR}" ] ; then
-      mkdir -p $ARKOUDA_TEST_PERF_DIR
-  fi
 else
   if ! make ; then
     log_fatal_error "compiling arkouda"
@@ -112,8 +105,11 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
     if [ "${GEN_ARKOUDA_GRAPHS}" = "true" ] ; then
         benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --gen-graphs --graph-dir $CHPL_TEST_PERF_DIR/html"
     else
-        # generate via a different script locally, rather than globally
+        # Where should perf logs go?
+        export ARKOUDA_TEST_PERF_DIR="${ARKOUDA_HOME}/perfData"
+        mkdir -p $ARKOUDA_TEST_PERF_DIR
         benchmark_opts="--save-data --dat-dir $ARKOUDA_TEST_PERF_DIR"
+        log_success "$benchmark_opts"
     fi
 
     benchmark_opts="${benchmark_opts} --annotations $CHPL_HOME/test/ANNOTATIONS.yaml"


### PR DESCRIPTION
This PR changes the path for the Arkouda perf data directory to be based off of ARKOUDA_HOME, rather than the CWD to make sure that we've got the path right.