### PR TITLE
Switch to storing data in workspace instead of Arkouda dir for XC testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -102,9 +102,8 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
 
   # Run benchmarks
   if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-    if [ "${GEN_ARKOUDA_GRAPHS}" = "true" ] ; then
-        benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --gen-graphs --graph-dir $CHPL_TEST_PERF_DIR/html"
-    else
+    benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --gen-graphs --graph-dir $CHPL_TEST_PERF_DIR/html"
+    if [ "${CHPL_TEST_GEN_ARKOUDA_GRAPHS}" = "false" ] ; then
         # Where should perf logs go?
         export ARKOUDA_TEST_PERF_DIR="${ARKOUDA_HOME}/perfData"
         test_start "make perf dir"

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -107,9 +107,14 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
     else
         # Where should perf logs go?
         export ARKOUDA_TEST_PERF_DIR="${ARKOUDA_HOME}/perfData"
-        mkdir -p $ARKOUDA_TEST_PERF_DIR
+        test_start "make perf dir"
+        if mkdir -p $ARKOUDA_TEST_PERF_DIR ; then
+            log_success "created perf directory $ARKOUDA_TEST_PERF_DIR"
+        else
+            log_error "creating perf directory"
+        fi
+        test_end
         benchmark_opts="--save-data --dat-dir $ARKOUDA_TEST_PERF_DIR"
-        log_success "$benchmark_opts"
     fi
 
     benchmark_opts="${benchmark_opts} --annotations $CHPL_HOME/test/ANNOTATIONS.yaml"

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -105,7 +105,7 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
     benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --gen-graphs --graph-dir $CHPL_TEST_PERF_DIR/html"
     if [ "${CHPL_TEST_GEN_ARKOUDA_GRAPHS}" = "false" ] ; then
         # Where should perf logs go?
-        export ARKOUDA_TEST_PERF_DIR="${ARKOUDA_HOME}/perfData"
+        export ARKOUDA_TEST_PERF_DIR="${WORKSPACE}/perfData"
         test_start "make perf dir"
         if mkdir -p $ARKOUDA_TEST_PERF_DIR ; then
             log_success "created perf directory $ARKOUDA_TEST_PERF_DIR"

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -11,7 +11,7 @@ fi
 
 # Perf configuration
 export CHPL_TEST_ARKOUDA_PERF=${CHPL_TEST_ARKOUDA_PERF:-true}
-export GEN_ARKOUDA_GRAPHS=${GEN_ARKOUDA_GRAPHS:-true}
+export CHPL_TEST_GEN_ARKOUDA_GRAPHS=${CHPL_TEST_GEN_ARKOUDA_GRAPHS:-true}
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ]; then
   source $CWD/common-perf.bash
   ARKOUDA_PERF_DIR=${ARKOUDA_PERF_DIR:-$COMMON_DIR/NightlyPerformance/arkouda}

--- a/util/cron/test-perf.cray-xc.arkouda.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.bash
@@ -6,11 +6,12 @@ CWD=$(cd $(dirname $0) ; pwd)
 
 export CHPL_TEST_PERF_CONFIG_NAME='16-node-xc'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda"
-export GEN_ARKOUDA_GRAPHS="false"
 
 # setup arkouda
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
+
+export CHPL_TEST_GEN_ARKOUDA_GRAPHS="false"
 
 module list
 

--- a/util/cron/test-perf.cray-xc.arkouda.release.bash
+++ b/util/cron/test-perf.cray-xc.arkouda.release.bash
@@ -6,11 +6,12 @@ CWD=$(cd $(dirname $0) ; pwd)
 
 export CHPL_TEST_PERF_CONFIG_NAME='16-node-xc'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-xc.arkouda.release"
-export GEN_ARKOUDA_GRAPHS="false"
 
 # setup arkouda
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
+
+export CHPL_TEST_GEN_ARKOUDA_GRAPHS="false"
 
 module list
 


### PR DESCRIPTION
This PR switches to making the data directory relative to the `WORKSPACE`, which is where Jenkins artifacts start their search, so that directory is needed to match with the location relative to the top level workspace, not `ARKOUDA_HOME`, which is located at `$CHPL_HOME/test/studies/arkouda/arkouda/` for XC testing currently.