### PR TITLE
Fix .dat file referred to in triad array-on-device tests

### DIFF
--- a/test/gpu/native/array_on_device/studies/shoc/triadAodBw1.graph
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodBw1.graph
@@ -1,5 +1,5 @@
 perfkeys: BW block size 64 =
-files: triadAodBw64.dat
+files: triadAOD.dat
 graphkeys: Triad
 ylabel: Time (s)
 graphtitle: SHOC Triad (array on device) - Bandwidth - 64KB

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodBw2.graph
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodBw2.graph
@@ -1,5 +1,5 @@
 perfkeys: BW block size 16384 =
-files: triadAodBw16384.dat
+files: triadAOD.dat
 graphkeys: Triad
 ylabel: Time (s)
 graphtitle: SHOC Triad (array on device) - Bandwidth - 16384KB


### PR DESCRIPTION
I accidentally referred to the wrong .dat file in `triadAodBw1.graph` (graph file for doing performance testing of SHOC triad when using the array_on_device memory strategy.