### PR TITLE
Remove perf description for Arkouda XC graph generation

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -118,7 +118,9 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
 
     benchmark_opts="${benchmark_opts} --annotations $CHPL_HOME/test/ANNOTATIONS.yaml"
     if [[ -n $CHPL_TEST_PERF_DESCRIPTION ]]; then
-      benchmark_opts="${benchmark_opts} --description $CHPL_TEST_PERF_DESCRIPTION"
+        if [ "${CHPL_TEST_GEN_ARKOUDA_GRAPHS}" = "true" ] ; then
+            benchmark_opts="${benchmark_opts} --description $CHPL_TEST_PERF_DESCRIPTION"
+        fi
     fi
     if [[ -n $CHPL_TEST_PERF_CONFIG_NAME ]]; then
       benchmark_opts="${benchmark_opts} --platform $CHPL_TEST_PERF_CONFIG_NAME"


### PR DESCRIPTION
The Arkouda data files were being created in a `nightly` or `release` subdirectory under `dat-dir`, but for XC testing, since we are collating the data, rather than writing directly to the global file, we don't want that to be stored under a separate subdirectory.