### PR TITLE
dyno: handle shadow scopes for 'private use'

### DIFF
--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -417,14 +417,7 @@ class Scope {
     }
   }
 
-  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
-    ss << "Scope ";
-    ss << tagToString(tag());
-    ss << " ";
-    id().stringify(ss, stringKind);
-    ss << " ";
-    ss << std::to_string(numDeclared());
-  }
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
   /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;
@@ -478,12 +471,26 @@ class VisibilitySymbols {
     CONTENTS_EXCEPT,
   };
 
+  /** Indicating shadow scopes */
+  enum ShadowScope {
+    // public use / private import / public import all work at the same
+    // scope level as symbols declared within a module, and
+    // REGULAR_SCOPE indicates that.
+    REGULAR_SCOPE = 0,
+
+    // 'private use' aka just 'use' introduces 2 shadow scopes
+    // that appear to be between the module and any parent symbols
+    SHADOW_SCOPE_ONE = 1, // for module contents brought in by a 'private use'
+    SHADOW_SCOPE_TWO = 2, // for module name from a 'private use'
+  };
+
  private:
   const Scope* scope_; // Scope of the Module etc
                        // This could technically be an ID but basically
                        // anything we do with it needs a Scope* anyway.
   Kind kind_ = SYMBOL_ONLY;
   bool isPrivate_ = true;
+  int8_t shadowScopeLevel_ = REGULAR_SCOPE;
 
   // the names/renames:
   //  pair.first is the name as declared
@@ -492,11 +499,17 @@ class VisibilitySymbols {
 
  public:
   VisibilitySymbols() { }
-  VisibilitySymbols(const Scope* scope, Kind kind, bool isPrivate,
+  VisibilitySymbols(const Scope* scope, Kind kind,
+                    bool isPrivate, ShadowScope shadowScopeLevel,
                     std::vector<std::pair<UniqueString,UniqueString>> names)
-    : scope_(scope), kind_(kind), isPrivate_(isPrivate),
+    : scope_(scope), kind_(kind),
+      isPrivate_(isPrivate), shadowScopeLevel_(shadowScopeLevel),
       names_(std::move(names))
-  { }
+  {
+    CHPL_ASSERT(shadowScopeLevel == REGULAR_SCOPE ||
+                shadowScopeLevel == SHADOW_SCOPE_ONE ||
+                shadowScopeLevel == SHADOW_SCOPE_TWO);
+  }
 
   /** Return the imported scope */
   const Scope* scope() const { return scope_; }
@@ -506,6 +519,11 @@ class VisibilitySymbols {
 
   /** Return whether or not the imported symbol is private */
   bool isPrivate() const { return isPrivate_; }
+
+  /** Returns the shadow scope level of the symbols here */
+  ShadowScope shadowScopeLevel() const {
+    return (ShadowScope) shadowScopeLevel_;
+  }
 
   /** Lookup the declared name for a given name
       Returns true if `name` is found in the list of renamed names and
@@ -526,7 +544,8 @@ class VisibilitySymbols {
     return scope_ == other.scope_ &&
            kind_ == other.kind_ &&
            names_ == other.names_ &&
-           isPrivate_ == other.isPrivate_;
+           isPrivate_ == other.isPrivate_ &&
+           shadowScopeLevel_ == other.shadowScopeLevel_;
   }
   bool operator!=(const VisibilitySymbols& other) const {
     return !(*this == other);
@@ -537,6 +556,7 @@ class VisibilitySymbols {
     std::swap(kind_, other.kind_);
     names_.swap(other.names_);
     std::swap(isPrivate_, other.isPrivate_);
+    std::swap(shadowScopeLevel_, other.shadowScopeLevel_);
   }
 
   static bool update(VisibilitySymbols& keep,
@@ -551,6 +571,12 @@ class VisibilitySymbols {
       p.second.mark(context);
     }
   }
+
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /**
@@ -579,9 +605,21 @@ class ResolvedVisibilityScope {
   /** Add a visibility clause */
   void addVisibilityClause(const Scope* scope, VisibilitySymbols::Kind kind,
                            bool isPrivate,
+                           VisibilitySymbols::ShadowScope shadowScopeLevel,
                            std::vector<std::pair<UniqueString,UniqueString>> n)
   {
-    visibilityClauses_.emplace_back(scope, kind, isPrivate, std::move(n));
+    auto elt = VisibilitySymbols(scope, kind,
+                                 isPrivate, shadowScopeLevel,
+                                 std::move(n));
+    visibilityClauses_.push_back(std::move(elt));
+  }
+  // temporary function
+  void addVisibilityClause(const Scope* scope, VisibilitySymbols::Kind kind,
+                           bool isPrivate,
+                           std::vector<std::pair<UniqueString,UniqueString>> n)
+  {
+    return addVisibilityClause(scope, kind, isPrivate,
+                               VisibilitySymbols::REGULAR_SCOPE, std::move(n));
   }
 
   bool operator==(const ResolvedVisibilityScope& other) const {
@@ -601,6 +639,10 @@ class ResolvedVisibilityScope {
       sym.mark(context);
     }
   }
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+  /// \cond DO_NOT_DOCUMENT
+  DECLARE_DUMP;
+  /// \endcond DO_NOT_DOCUMENT
 };
 
 /*

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -613,14 +613,6 @@ class ResolvedVisibilityScope {
                                  std::move(n));
     visibilityClauses_.push_back(std::move(elt));
   }
-  // temporary function
-  void addVisibilityClause(const Scope* scope, VisibilitySymbols::Kind kind,
-                           bool isPrivate,
-                           std::vector<std::pair<UniqueString,UniqueString>> n)
-  {
-    return addVisibilityClause(scope, kind, isPrivate,
-                               VisibilitySymbols::REGULAR_SCOPE, std::move(n));
-  }
 
   bool operator==(const ResolvedVisibilityScope& other) const {
     return scope_ == other.scope_ &&

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -471,17 +471,37 @@ class VisibilitySymbols {
     CONTENTS_EXCEPT,
   };
 
-  /** Indicating shadow scopes */
+  /** Indicating which shadow scope level to use, if any */
   enum ShadowScope {
-    // public use / private import / public import all work at the same
-    // scope level as symbols declared within a module, and
-    // REGULAR_SCOPE indicates that.
+    /**
+      `REGULAR_SCOPE` indicates that no shadow scope is used for the symbols
+      brought in by this VisibilitySymbols. In other words, the symbols
+      brought in are at the same scope level as a variable declared next to
+      the `use` / `import`. `REGULAR_SCOPE` is the shadow scope level
+      used for:
+
+        * `public use`
+        * `import` aka `private import`
+        * `public import`
+     */
     REGULAR_SCOPE = 0,
 
     // 'private use' aka just 'use' introduces 2 shadow scopes
     // that appear to be between the module and any parent symbols
-    SHADOW_SCOPE_ONE = 1, // for module contents brought in by a 'private use'
-    SHADOW_SCOPE_TWO = 2, // for module name from a 'private use'
+
+    /**
+      `SHADOW_SCOPE_ONE` indicates a shadow scope just outside of
+      `REGULAR_SCOPE` but before `SHADOW_SCOPE_TWO`. This level is
+      used for the module contents brought in by a non-public `use`.
+     */
+    SHADOW_SCOPE_ONE = 1,
+
+    /**
+      `SHADOW_SCOPE_TWO` indicates a shadow scope just outside of
+      `SHADOW_SCOPE_ONE` but before any parent scopes. This level
+      is used for the module name brought in by a non-public `use`.
+     */
+    SHADOW_SCOPE_TWO = 2,
   };
 
  private:

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -373,7 +373,7 @@ static bool isRecordLike(const Type* t) {
 }
 
 static bool typeNeedsInitDeinitCall(const Type* t) {
-  if (t->isUnknownType() || t->isErroneousType()) {
+  if (t == nullptr || t->isUnknownType() || t->isErroneousType()) {
     // can't do anything with these
     return false;
   } else if (t->isPrimitiveType() || t->isBuiltinType() || t->isCStringType() ||
@@ -607,8 +607,7 @@ void CallInitDeinit::resolveMoveInit(const AstNode* ast,
                        getTypeGenericity(context, rhsType) != Type::CONCRETE;
       // resolve a copy init and a deinit to deinit the temporary
       if (lhsGenUnk || rhsGenUnk) {
-        // TODO: this should not happen
-        printf("Warning: should not be reached\n");
+        CHPL_ASSERT(false && "should not be reached");
       } else {
         resolveCopyInit(ast, rhsAst, lhsType, rhsType,
                         /* forMoveInit */ true,

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -363,29 +363,28 @@ static const Scope* const& scopeForAutoModule(Context* context) {
   return QUERY_END(result);
 }
 
-static bool doLookupInImports(Context* context,
-                              const Scope* scope,
-                              const ResolvedVisibilityScope* resolving,
-                              UniqueString name,
-                              bool onlyInnermost,
-                              bool skipPrivateVisibilities,
-                              NamedScopeSet& checkedScopes,
-                              std::vector<BorrowedIdsWithName>& result) {
-  // Get the resolved visibility statements, if available
-  const ResolvedVisibilityScope* r = nullptr;
-  if (resolving && resolving->scope() == scope) {
-    r = resolving;
-  } else {
-    r = resolveVisibilityStmts(context, scope);
-  }
+static bool doLookupInImportsAndUses(Context* context,
+                                     const Scope* scope,
+                                     const ResolvedVisibilityScope* resolving,
+                                     const ResolvedVisibilityScope* cur,
+                                     UniqueString name,
+                                     bool onlyInnermost,
+                                     bool skipPrivateVisibilities,
+                                     VisibilitySymbols::ShadowScope shadowScope,
+                                     NamedScopeSet& checkedScopes,
+                                     std::vector<BorrowedIdsWithName>& result) {
+  bool found = false;
 
-  if (r != nullptr) {
+  if (cur != nullptr) {
     // check to see if it's mentioned in names/renames
-    bool found = false;
-    for (const VisibilitySymbols& is: r->visibilityClauses()) {
+    for (const VisibilitySymbols& is: cur->visibilityClauses()) {
       // if we should not continue transitively through private use/includes,
       // and this is private, skip it
       if (skipPrivateVisibilities && is.isPrivate()) {
+        continue;
+      }
+      // skip this clause if we are searching a different shadow scope level
+      if (is.shadowScopeLevel() != shadowScope) {
         continue;
       }
       UniqueString from = name;
@@ -431,31 +430,40 @@ static bool doLookupInImports(Context* context,
       }
     }
 
-    if (found && onlyInnermost) {
-      return true;
-    }
   }
+
+  return found;
+}
+
+static bool doLookupInAutoModules(Context* context,
+                                  const Scope* scope,
+                                  const ResolvedVisibilityScope* resolving,
+                                  UniqueString name,
+                                  bool onlyInnermost,
+                                  bool skipPrivateVisibilities,
+                                  NamedScopeSet& checkedScopes,
+                                  std::vector<BorrowedIdsWithName>& result) {
+  bool found = false;
 
   if (scope->autoUsesModules() && !skipPrivateVisibilities) {
     const Scope* autoModScope = scopeForAutoModule(context);
     if (autoModScope) {
       LookupConfig newConfig = LOOKUP_DECLS |
-                               LOOKUP_IMPORT_AND_USE;
+                               LOOKUP_IMPORT_AND_USE |
+                               LOOKUP_SKIP_PRIVATE_VIS;
 
       if (onlyInnermost) {
         newConfig |= LOOKUP_INNERMOST;
       }
 
       // find it in that scope
-      bool found = doLookupInScope(context, autoModScope, {}, resolving,
-                                   name, newConfig,
-                                   checkedScopes, result);
-      if (found && onlyInnermost)
-        return true;
+      found = doLookupInScope(context, autoModScope, {}, resolving,
+                              name, newConfig,
+                              checkedScopes, result);
     }
   }
 
-  return false;
+  return found;
 }
 
 static bool doLookupInToplevelModules(Context* context,
@@ -494,14 +502,6 @@ static bool doLookupInScope(Context* context,
   // through module boundaries if we aren't traversing the scope chain?
   CHPL_ASSERT(!goPastModules || checkParents);
 
-  // TODO: to include checking for symbol privacy,
-  // add a findPrivate argument to doLookupInScope and set it
-  // to false when traversing a use/import of a module not visible.
-  // Adjust the checkedScopes set to be a map to bool, where
-  // the bool indicates if findPrivate was true or not. If we
-  // have visited but only got public symbols, we have to visit again
-  // for private symbols. But we'd like to avoid splitting overloads into
-  // two 'result' vector entries in that case...
   size_t startSize = result.size();
 
   auto pair = checkedScopes.insert(std::make_pair(name, scope));
@@ -511,19 +511,57 @@ static bool doLookupInScope(Context* context,
     return false;
   }
 
-  if (checkDecls) {
-    bool got = scope->lookupInScope(name, result, skipPrivateVisibilities);
+  // Get the resolved visibility statements, if available
+  const ResolvedVisibilityScope* r = nullptr;
+  if (checkUseImport) {
+    if (resolving && resolving->scope() == scope) {
+      r = resolving;
+    } else {
+      r = resolveVisibilityStmts(context, scope);
+    }
+  }
+
+  // gather non-shadow scope information
+  // (declarations in this scope as well as public use / import)
+  {
+    bool got = false;
+    if (checkDecls) {
+      got |= scope->lookupInScope(name, result, skipPrivateVisibilities);
+    }
+    if (checkUseImport) {
+      got |= doLookupInImportsAndUses(context, scope, resolving, r, name,
+                                      onlyInnermost, skipPrivateVisibilities,
+                                      VisibilitySymbols::REGULAR_SCOPE,
+                                      checkedScopes, result);
+    }
     if (onlyInnermost && got) return true;
   }
 
-  // Look at use/import statements in the current scope
+  // now check shadow scope 1 (only relevant for 'private use')
   if (checkUseImport) {
     bool got = false;
-    got = doLookupInImports(context, scope, resolving,
-                            name, onlyInnermost, skipPrivateVisibilities,
-                            checkedScopes, result);
+    got |= doLookupInImportsAndUses(context, scope, resolving, r, name,
+                                    onlyInnermost, skipPrivateVisibilities,
+                                    VisibilitySymbols::SHADOW_SCOPE_ONE,
+                                    checkedScopes, result);
+
+    // treat the auto-used modules as if they were 'private use'd
+    got |= doLookupInAutoModules(context, scope, resolving, name,
+                                 onlyInnermost, skipPrivateVisibilities,
+                                 checkedScopes, result);
     if (onlyInnermost && got) return true;
   }
+
+  // now check shadow scope 2 (only relevant for 'private use')
+  if (checkUseImport) {
+    bool got = false;
+    got = doLookupInImportsAndUses(context, scope, resolving, r, name,
+                                   onlyInnermost, skipPrivateVisibilities,
+                                   VisibilitySymbols::SHADOW_SCOPE_TWO,
+                                   checkedScopes, result);
+    if (onlyInnermost && got) return true;
+  }
+
 
   if (checkParents) {
     LookupConfig newConfig = LOOKUP_DECLS;
@@ -630,6 +668,9 @@ static bool doLookupInScope(Context* context,
   return result.size() > startSize;
 }
 
+// This function supports scope lookup when resolving what modules
+// a 'use' / 'import' refer to.
+//
 // It can return multiple results because that is important for 'import'.
 // 'isFirstPart' is true for A in A.B.C but not for B or C.
 // On return:
@@ -1087,21 +1128,36 @@ doResolveUseStmt(Context* context, const Use* use,
 
       maybeEmitWarningsForId(context, expr->id(), foundScope->id());
 
-      // First, add VisibilitySymbols entry for the symbol itself.
-      // Per the spec, we only have visibility of the symbol itself if the
-      // use is renamed (with 'as') or non-public.
-      if (!newName.isEmpty()) {
-        if (newName == USTR("_")) {
-          // Do not introduce the name at all.
-          r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
-                                 isPrivate, emptyNames());
+      // 'private use' brings the module name into a shadow scope
+      // but 'public use' does not.
+      auto moduleSymShadowScopeLevel = VisibilitySymbols::REGULAR_SCOPE;
+      if (isPrivate) {
+        moduleSymShadowScopeLevel = VisibilitySymbols::SHADOW_SCOPE_TWO;
+      }
+
+      if (newName == USTR("_")) {
+        // e.g. 'use M as _'. Do not introduce the name at all.
+      } else if (newName.isEmpty()) {
+        // There is no renaming with 'as' involved.
+        if (isPrivate == false) {
+          // 'public use' does not enable qualified access
+          // (in other words, it does not bring in the module name)
         } else {
+          // 'private use' brings in the module name (in a shadow scope)
           r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
-                                 isPrivate, convertOneRename(oldName, newName));
+                                 isPrivate, moduleSymShadowScopeLevel,
+                                 convertOneName(oldName));
         }
-      } else if (isPrivate) {
+      } else {
+        // there is an 'as' involved, so the name will always be brought in
         r->addVisibilityClause(foundScope, VisibilitySymbols::SYMBOL_ONLY,
-                               isPrivate, convertOneName(oldName));
+                               isPrivate, moduleSymShadowScopeLevel,
+                               convertOneRename(oldName, newName));
+      }
+
+      auto moduleContentsShadowScopeLevel = VisibilitySymbols::REGULAR_SCOPE;
+      if (isPrivate) {
+        moduleContentsShadowScopeLevel = VisibilitySymbols::SHADOW_SCOPE_ONE;
       }
 
       // Then, add the entries for anything imported
@@ -1116,7 +1172,8 @@ doResolveUseStmt(Context* context, const Use* use,
             }
           }
           // add the visibility clause for only/except
-          r->addVisibilityClause(foundScope, kind, isPrivate,
+          r->addVisibilityClause(foundScope, kind,
+                                 isPrivate, moduleContentsShadowScopeLevel,
                                  convertLimitations(context, clause));
           break;
         case VisibilityClause::ONLY:
@@ -1125,12 +1182,15 @@ doResolveUseStmt(Context* context, const Use* use,
           errorIfAnyLimitationNotInScope(context, clause, foundScope,
                                          r, VIS_USE);
           // add the visibility clause for only/except
-          r->addVisibilityClause(foundScope, kind, isPrivate,
+          r->addVisibilityClause(foundScope, kind,
+                                 isPrivate, moduleContentsShadowScopeLevel,
                                  convertLimitations(context, clause));
           break;
         case VisibilityClause::NONE:
           kind = VisibilitySymbols::ALL_CONTENTS;
-          r->addVisibilityClause(foundScope, kind, isPrivate, emptyNames());
+          r->addVisibilityClause(foundScope, kind,
+                                 isPrivate, moduleContentsShadowScopeLevel,
+                                 emptyNames());
           break;
         case VisibilityClause::BRACES:
           CHPL_ASSERT(false && "Should not be possible");
@@ -1185,6 +1245,9 @@ doResolveImportStmt(Context* context, const Import* imp,
     if (foundScope != nullptr) {
       VisibilitySymbols::Kind kind;
 
+      // 'import' never uses a shadow scope.
+      auto importShadowScopeLevel = VisibilitySymbols::REGULAR_SCOPE;
+
       maybeEmitWarningsForId(context, expr->id(), foundScope->id());
 
       if (!dotName.isEmpty()) {
@@ -1203,11 +1266,13 @@ doResolveImportStmt(Context* context, const Import* imp,
                                   /* isRename */ !newName.isEmpty());
             if (newName.isEmpty()) {
               // e.g. 'import M.f'
-              r->addVisibilityClause(foundScope, kind, isPrivate,
+              r->addVisibilityClause(foundScope, kind,
+                                     isPrivate, importShadowScopeLevel,
                                      convertOneName(dotName));
             } else {
               // e.g. 'import M.f as g'
-              r->addVisibilityClause(foundScope, kind, isPrivate,
+              r->addVisibilityClause(foundScope, kind,
+                                     isPrivate, importShadowScopeLevel,
                                      convertOneRename(dotName, newName));
             }
             break;
@@ -1228,14 +1293,18 @@ doResolveImportStmt(Context* context, const Import* imp,
             kind = VisibilitySymbols::SYMBOL_ONLY;
             if (newName.isEmpty()) {
               // e.g. 'import OtherModule'
-              r->addVisibilityClause(foundScope, kind, isPrivate,
+              r->addVisibilityClause(foundScope, kind,
+                                     isPrivate, importShadowScopeLevel,
                                      convertOneName(oldName));
             } if (newName == USTR("_")) {
               // e.g. 'import OtherModule as _'
-              r->addVisibilityClause(foundScope, kind, isPrivate, emptyNames());
+              /*r->addVisibilityClause(foundScope, kind,
+                                     isPrivate, importShadowScopeLevel,
+                                     emptyNames());*/
             } else {
               // e.g. 'import OtherModule as Foo'
-              r->addVisibilityClause(foundScope, kind, isPrivate,
+              r->addVisibilityClause(foundScope, kind,
+                                     isPrivate, importShadowScopeLevel,
                                      convertOneRename(oldName, newName));
             }
             break;
@@ -1247,7 +1316,8 @@ doResolveImportStmt(Context* context, const Import* imp,
                                            r, VIS_IMPORT);
 
             // add the visibility clause with the named symbols
-            r->addVisibilityClause(foundScope, kind, isPrivate,
+            r->addVisibilityClause(foundScope, kind,
+                                   isPrivate, importShadowScopeLevel,
                                    convertLimitations(context, clause));
             break;
         }

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -102,9 +102,94 @@ const Scope* Scope::parentModuleScope() const {
   return nullptr;
 }
 
+void Scope::stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
+  ss << "Scope ";
+  ss << tagToString(tag());
+  ss << " ";
+  id().stringify(ss, stringKind);
+  ss << " ";
+  ss << std::to_string(numDeclared());
+}
+
+void VisibilitySymbols::stringify(std::ostream& ss,
+                                  chpl::StringifyKind stringKind) const {
+  ss << "VisibilitySymbols";
+  if (scope_) {
+    ss << " mod-scope=(";
+    scope_->stringify(ss, stringKind);
+    ss << " )";
+  }
+  const char* kindStr = "<unknown>";
+  switch (kind_) {
+    case SYMBOL_ONLY:
+      kindStr = "symbol-only";
+      break;
+    case ALL_CONTENTS:
+      kindStr = "all-contents";
+      break;
+    case ONLY_CONTENTS:
+      kindStr = "only-contents";
+      break;
+    case CONTENTS_EXCEPT:
+      kindStr = "contents-except";
+      break;
+  }
+  ss << " kind=" << kindStr;
+
+  if (isPrivate_) {
+    ss << " private";
+  } else {
+    ss << " public";
+  }
+
+  const char* shadowStr = "<unknown>";
+  switch (shadowScopeLevel_) {
+    case REGULAR_SCOPE:
+      shadowStr = "regular";
+      break;
+    case SHADOW_SCOPE_ONE:
+      shadowStr = "shadow-scope-one";
+      break;
+    case SHADOW_SCOPE_TWO:
+      shadowStr = "shadow-scope-two";
+      break;
+  }
+
+  if (shadowScopeLevel_ != REGULAR_SCOPE) {
+    ss << " " << shadowStr;
+  }
+
+  for (auto pair : names_) {
+    ss << " " << pair.first.c_str();
+    if (!pair.second.isEmpty()) {
+      ss << " as " << pair.second.c_str();
+    }
+  }
+}
+
+void ResolvedVisibilityScope::stringify(std::ostream& ss,
+                                        chpl::StringifyKind stringKind) const {
+
+  if (scope_) {
+    ss << " cur-scope=(";
+    scope_->stringify(ss, stringKind);
+    ss << " )";
+  }
+
+  int i = 0;
+  for (auto clause : visibilityClauses_) {
+    ss << "clause " << i << "(";
+    clause.stringify(ss, stringKind);
+    ss << ")";
+    i++;
+  }
+}
+
 IMPLEMENT_DUMP(OwnedIdsWithName);
 IMPLEMENT_DUMP(BorrowedIdsWithName);
 IMPLEMENT_DUMP(Scope);
+IMPLEMENT_DUMP(VisibilitySymbols);
+IMPLEMENT_DUMP(ResolvedVisibilityScope);
 IMPLEMENT_DUMP(PoiScope);
 IMPLEMENT_DUMP(InnermostMatch);
 

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -105,9 +105,9 @@ const Scope* Scope::parentModuleScope() const {
 void Scope::stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
   ss << "Scope ";
   ss << tagToString(tag());
-  ss << " ";
+  ss << " kind=";
   id().stringify(ss, stringKind);
-  ss << " ";
+  ss << " numDeclared=";
   ss << std::to_string(numDeclared());
 }
 
@@ -161,7 +161,7 @@ void VisibilitySymbols::stringify(std::ostream& ss,
 
   for (auto pair : names_) {
     ss << " " << pair.first.c_str();
-    if (!pair.second.isEmpty()) {
+    if (pair.first != pair.second) {
       ss << " as " << pair.second.c_str();
     }
   }
@@ -178,7 +178,7 @@ void ResolvedVisibilityScope::stringify(std::ostream& ss,
 
   int i = 0;
   for (auto clause : visibilityClauses_) {
-    ss << "clause " << i << "(";
+    ss << "  clause " << i << "(";
     clause.stringify(ss, stringKind);
     ss << ")";
     i++;

--- a/frontend/test/resolution/testScopeResolve.cpp
+++ b/frontend/test/resolution/testScopeResolve.cpp
@@ -700,6 +700,161 @@ static void test17() {
   guard.realizeErrors();
 }
 
+// check that 'private use M' puts its contents in a shadow scope
+// further from a 'public use' (which isn't in a shadow scope)
+static void test18() {
+  printf("test18\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module M {
+        var myvar: int;
+      }
+
+      module N {
+        var myvar: real;
+      }
+
+      module O {
+        public use M;
+        private use N;
+
+        var x = myvar;
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+
+  const ResolvedExpression& reY = scopeResolveIt(context, x->initExpression());
+  assert(reY.toId().str() == "M@1");
+}
+// check that 'private use M' puts M in a further shadow scope from contents
+static void test19() {
+  printf("test19\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module M {
+        var M: int;
+      }
+
+      module O {
+        use M;
+
+        var x = M; // should refer to var M, not module M
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+
+  const ResolvedExpression& reY = scopeResolveIt(context, x->initExpression());
+  assert(reY.toId().str() == "M@1");
+}
+// check that 'public use M' does not bring in a symbol named M
+static void test20() {
+  printf("test20\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module M {
+        var M: int;
+      }
+
+      module O {
+        public use M;
+
+        var x = M; // should refer to var M, not module M
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+
+  const ResolvedExpression& reY = scopeResolveIt(context, x->initExpression());
+  assert(reY.toId().str() == "M@1");
+}
+static void test21() {
+  printf("test21\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module Outer {
+        module M {
+          var myvar: int;
+        }
+      }
+
+      module O {
+        public use Outer.M;
+        use M; // should result in an error
+        var x = myvar;
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+
+  for (auto mod : vec) {
+    scopeResolveModule(context, mod->id());
+  }
+  assert(guard.realizeErrors() == 1);
+}
+// but 'public use M as M' does bring in module named M
+static void test22() {
+  printf("test22\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module M {
+        var myvar: int;
+      }
+
+      module O {
+        public use M as M;
+
+        var x = M.myvar;
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+
+  const ResolvedExpression& reY = scopeResolveIt(context, x->initExpression());
+  assert(reY.toId().str() == "M@1");
+}
+
 int main() {
   test1();
   test2();
@@ -718,6 +873,11 @@ int main() {
   test15();
   test16();
   test17();
+  test18();
+  test19();
+  test20();
+  test21();
+  test22();
 
   return 0;
 }


### PR DESCRIPTION
This PR updates the dyno scope resolver to follow the current language design rules about shadow scopes. These evolved a bit after the dyno scope resolver was created (see PR #19306). See also [this spec section](https://chapel-lang.org/docs/language/spec/modules.html#using-and-importing).

To do so:
 * added a field to `VisibilitySymbols` to indicate which shadow scope (if any) the use/imported symbols go into
 * renamed `doLookupInImports` to `doLookupInImportsAndUses` and have it only consider symbols at the current shadow scope level
 * created `doLookupInAutoModules` (pulled out of `doLookupInImports`)
 * adjusted `doLookupInScope` to check the non-shadow scope and then the two shadow scopes
 * adjusted `doResolveUseStmt` and `doResolveImportStmt` to provide a shadow scope value when constructing a `VisibilitySymbols`
 * improved stringify/dump for `VisibilitySymbols` and `ResolvedVisibilityScope`
 * added testing for some of these cases to `testScopeResolve.cpp`
 
This fixes a number of tests that fail with `--dyno` (which activates the dyno scope resolver):

```
modules/shadowing/issue-19167-3-x
modules/shadowing/issue-19167-5-x
modules/shadowing/var-shadows-private-import
modules/shadowing/var-shadows-public-import
modules/shadowing/var-shadows-public-use
visibility/import/rename/same_name_in_mod
visibility/import/rename/same_name_in_mod2
```

Reviewed by @DanilaFe - thanks!

- [x] full local testing
- [x] full local `--dyno` testing