### PR TITLE
Fix typo in error message for uninitialized task-private variable

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -80,7 +80,7 @@ static ShadowVarSymbol* buildShadowVariable(ShadowVarPrefix prefix,
       // This keyword is for a TPV.
       // Whereas the user provided neither a type nor an init.
       USR_FATAL_CONT(ovar, "a task private variable '%s'"
-                     "requires a type and/or initializing expression", name);
+                     " requires a type and/or initializing expression", name);
       break;
   }
 

--- a/test/parallel/forall/task-private-vars/tpv-no-init.chpl
+++ b/test/parallel/forall/task-private-vars/tpv-no-init.chpl
@@ -1,0 +1,4 @@
+var x = 5;
+
+forall i in 1..x with (var z) {
+}

--- a/test/parallel/forall/task-private-vars/tpv-no-init.good
+++ b/test/parallel/forall/task-private-vars/tpv-no-init.good
@@ -1,0 +1,1 @@
+tpv-no-init.chpl:3: error: a task private variable 'z' requires a type and/or initializing expression


### PR DESCRIPTION
Fix a missing space in the error message for not initializing a task-private variable. Also adds a simple test of the error message.

Observed while working on https://github.com/Cray/chapel-private/issues/2716.

[trivial, not reviewed]

Testing:
- [x] paratest with futures