### PR TITLE
dyno: Fix CI test failure after #21529

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1074,9 +1074,9 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
       // for 'this' formals of class type, adjust them to be borrowed, so
       // e.g. proc C.foo() { } has 'this' of type 'borrowed C'.
       // This should not apply to parenthesized expressions.
-      if (isFormalThis && typeExpr &&
-          typeExprT.type() != nullptr && typeExprT.type()->isClassType() &&
-          (typeExpr == nullptr || typeExpr->isIdentifier())) {
+      bool identOrNoTypeExpr = !typeExpr || typeExpr->isIdentifier();
+      bool isClassType = typeExprT.type() && typeExprT.type()->isClassType();
+      if (isFormalThis && isClassType && identOrNoTypeExpr) {
         auto ct = typeExprT.type()->toClassType();
         auto dec = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
         typeExprT = QualifiedType(typeExprT.kind(),


### PR DESCRIPTION
I didn't rebase onto the latest main and let a test failure slip through.
Fix the failure and clean up some complicated boolean logic by
moving expressions into local variables.

Reviewed by @mppf. Thanks!

Signed-off-by: David Longnecker <dlongnecke-cray@users.noreply.github.com>