### PR TITLE
dyno scope resolver: fix three more failing tests

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4143,8 +4143,11 @@ void Converter::popFromSymStack(const uast::AstNode* ast, BaseAST* ret) {
     CHPL_ASSERT(false && "stack error");
   }
   if (trace) {
-    printf("Exiting %s %s\n",
-           astName(ast).c_str(), ast->id().str().c_str());
+    int id = 0;
+    if (ret != nullptr) id = ret->id;
+
+    printf("Exiting %s %s [%i]\n",
+           astName(ast).c_str(), ast->id().str().c_str(), id);
   }
   symStack.pop_back();
 }
@@ -4161,8 +4164,9 @@ void ConvertedSymbolsMap::noteConvertedSym(const uast::AstNode* ast,
                                            Symbol* sym,
                                            bool trace) {
   if (trace) {
-    printf("Converted sym %s %s and noting it in %s\n",
+    printf("Converted sym %s %s to %s[%i] and noting it in %s\n",
            astName(ast).c_str(), ast->id().str().c_str(),
+           sym->name, sym->id,
            computeMapName(inSymbolId).c_str());
   }
 
@@ -4174,9 +4178,10 @@ void ConvertedSymbolsMap::noteConvertedFn(
                                 FnSymbol* fn,
                                 bool trace) {
   if (trace) {
-    printf("Converted fn %s %s and noting it in %s\n",
+    printf("Converted fn %s %s to %s[%i] and noting it in %s\n",
            sig->untyped()->name().c_str(),
            sig->untyped()->id().str().c_str(),
+           fn->name, fn->id,
            computeMapName(inSymbolId).c_str());
   }
 
@@ -4187,7 +4192,8 @@ void ConvertedSymbolsMap::noteIdentFixupNeeded(SymExpr* se, ID id,
                                                ConvertedSymbolsMap* cur,
                                                bool trace) {
   if (trace) {
-    printf("Noting fixup needed for mention of %s within %s in map for %s\n",
+    printf("Noting fixup needed [%i] for mention of %s within %s in map for %s\n",
+           se->id,
            id.str().c_str(),
            computeMapName(cur->inSymbolId).c_str(),
            computeMapName(this->inSymbolId).c_str());
@@ -4201,7 +4207,8 @@ void ConvertedSymbolsMap::noteCallFixupNeeded(SymExpr* se,
                                 ConvertedSymbolsMap* cur,
                                 bool trace) {
   if (trace) {
-    printf("Noting fixup needed for mention of %s within %s in map for %s\n",
+    printf("Noting fixup needed [%i] for mention of %s within %s in map for %s\n",
+           se->id,
            sig->untyped()->id().str().c_str(),
            computeMapName(cur->inSymbolId).c_str(),
            computeMapName(this->inSymbolId).c_str());

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -325,24 +325,36 @@ filterCandidatesInstantiating(Context* context,
   scope of that call, and a PoiScope representing the point-of-instantiation
   scope of that call, find the most specific candidates as well
   as the point-of-instantiation scopes that were used when resolving them.
+
+  When a resolving a call within a method, the implicitReceiver should be
+  set to the 'this' type of the method. 'nullptr' is sufficient for
+  operator calls and method calls.
  */
-CallResolutionResult resolveCall(Context* context,
-                                 const uast::Call* call,
-                                 const CallInfo& ci,
-                                 const Scope* inScope,
-                                 const PoiScope* inPoiScope);
+CallResolutionResult
+resolveCall(Context* context,
+            const uast::Call* call,
+            const CallInfo& ci,
+            const Scope* inScope,
+            const PoiScope* inPoiScope,
+            const types::CompositeType* implicitReceiver);
 
 /**
   Given a CallInfo representing a call, a Scope representing the
   scope of that call, and a PoiScope representing the point-of-instantiation
   scope of that call, find the most specific candidates as well
   as the point-of-instantiation scopes that were used when resolving them.
+
+  When a resolving a call within a method, the implicitRcvr should be
+  set to the 'this' type of the method. 'nullptr' is sufficient for
+  operator calls and method calls.
  */
-CallResolutionResult resolveGeneratedCall(Context* context,
-                                          const uast::AstNode* astForErr,
-                                          const CallInfo& ci,
-                                          const Scope* inScope,
-                                          const PoiScope* inPoiScope);
+CallResolutionResult
+resolveGeneratedCall(Context* context,
+                     const uast::AstNode* astForErr,
+                     const CallInfo& ci,
+                     const Scope* inScope,
+                     const PoiScope* inPoiScope,
+                     const types::CompositeType* implicitRcvr);
 
 /**
   Given a type 't', compute whether or not 't' is default initializable.

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -330,31 +330,56 @@ filterCandidatesInstantiating(Context* context,
   set to the 'this' type of the method. 'nullptr' is sufficient for
   operator calls and method calls.
  */
-CallResolutionResult
-resolveCall(Context* context,
-            const uast::Call* call,
-            const CallInfo& ci,
-            const Scope* inScope,
-            const PoiScope* inPoiScope,
-            const types::CompositeType* implicitReceiver);
+CallResolutionResult resolveCall(Context* context,
+                                 const uast::Call* call,
+                                 const CallInfo& ci,
+                                 const Scope* inScope,
+                                 const PoiScope* inPoiScope);
+
+/**
+  Similar to resolveCall, but handles the implicit scope provided by a method.
+
+  When a resolving a call within a method, the implicitReceiver should be
+  set to the 'this' type of the method.
+
+  If implicitReceiver.type() == nullptr, it will be ignored.
+ */
+CallResolutionResult resolveCallInMethod(Context* context,
+                                         const uast::Call* call,
+                                         const CallInfo& ci,
+                                         const Scope* inScope,
+                                         const PoiScope* inPoiScope,
+                                         types::QualifiedType implicitReceiver);
 
 /**
   Given a CallInfo representing a call, a Scope representing the
   scope of that call, and a PoiScope representing the point-of-instantiation
   scope of that call, find the most specific candidates as well
   as the point-of-instantiation scopes that were used when resolving them.
+ */
+CallResolutionResult resolveGeneratedCall(Context* context,
+                                          const uast::AstNode* astForErr,
+                                          const CallInfo& ci,
+                                          const Scope* inScope,
+                                          const PoiScope* inPoiScope);
 
-  When a resolving a call within a method, the implicitRcvr should be
-  set to the 'this' type of the method. 'nullptr' is sufficient for
-  operator calls and method calls.
+/**
+  Similar to resolveGeneratedCall but handles the implicit scope
+  provided by a method.
+
+  When a resolving a call within a method, the implicitReceiver should be
+  set to the 'this' type of the method.
+
+  If implicitReceiver.type() == nullptr, it will be ignored.
  */
 CallResolutionResult
-resolveGeneratedCall(Context* context,
-                     const uast::AstNode* astForErr,
-                     const CallInfo& ci,
-                     const Scope* inScope,
-                     const PoiScope* inPoiScope,
-                     const types::CompositeType* implicitRcvr);
+resolveGeneratedCallInMethod(Context* context,
+                             const uast::AstNode* astForErr,
+                             const CallInfo& ci,
+                             const Scope* inScope,
+                             const PoiScope* inPoiScope,
+                             types::QualifiedType implicitReceiver);
+
 
 /**
   Given a type 't', compute whether or not 't' is default initializable.

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -326,9 +326,8 @@ filterCandidatesInstantiating(Context* context,
   scope of that call, find the most specific candidates as well
   as the point-of-instantiation scopes that were used when resolving them.
 
-  When a resolving a call within a method, the implicitReceiver should be
-  set to the 'this' type of the method. 'nullptr' is sufficient for
-  operator calls and method calls.
+  'resolveCallInMethod' should be used instead when resolving a non-method call
+  within a method.
  */
 CallResolutionResult resolveCall(Context* context,
                                  const uast::Call* call,

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -409,6 +409,11 @@ class CallInfo {
                          bool raiseErrors = true,
                          std::vector<const uast::AstNode*>* actualAsts=nullptr);
 
+  /** Construct a CallInfo by adding a method receiver argument to
+      the passed CallInfo. */
+  static CallInfo createWithReceiver(const CallInfo& ci,
+                                     types::QualifiedType receiverType);
+
   /** Prepare actuals for a call for later use in creating a CallInfo.
       This is a helper function for CallInfo::create that is sometimes
       useful to call separately.
@@ -992,6 +997,14 @@ class MostSpecificCandidates {
     CHPL_ASSERT(!emptyDueToAmbiguity || isEmpty());
 
     return emptyDueToAmbiguity;
+  }
+
+  /**
+    Returns 'true' if any candidate was found, including
+    if there was no best candidate due to ambiguity.
+   */
+  bool foundCandidates() const {
+    return isAmbiguous() || !isEmpty();
   }
 
   bool operator==(const MostSpecificCandidates& other) const {

--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -55,8 +55,8 @@ namespace resolution {
     'receiverScopes' is the scope of a type containing the name, in the case
     of method calls, field accesses, and resolving a name within a method.
     It is a Scope representing the record/class/union itself for the
-    receiver. If provided, the receiverScopes will be consulted before
-    'scope' and its parents.
+    receiver. If provided, the receiverScopes will be consulted after
+    declarations within 'scope' but before its parents.
 
     The config argument is a group of or-ed together bit flags
     that adjusts the behavior of the lookup:

--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -52,25 +52,16 @@ namespace resolution {
 
     'scope' is the context in which the name occurs (e.g. as an Identifier)
 
-    'receiverScopes' is the scope of a type containing the name, in the case
-    of method calls, field accesses, and resolving a name within a method.
-    It is a Scope representing the record/class/union itself for the
-    receiver. If provided, the receiverScopes will be consulted after
-    declarations within 'scope' but before its parents.
+    'receiverScopes' is the scope of a type containing the name, in the case of
+    method calls, field accesses, and resolving a name within a method.  It is a
+    Scope representing the record/class/union itself for the receiver. If
+    provided, the receiverScopes will be consulted after declarations within
+    'scope' but before its parents. It accepts multiple scopes in order to
+    handle classes with inheritance.
 
-    The config argument is a group of or-ed together bit flags
-    that adjusts the behavior of the lookup:
-
-    * If LOOKUP_DECLS is set, looks for symbols declared in 'scope'
-      and 'receiverScopes'.
-    * If LOOKUP_IMPORT_AND_USE is set, looks for symbols from use/import
-      statements in this 'scope' and 'receiverScopes'.
-    * If LOOKUP_PARENTS is set, looks for symbols from parent scopes (but not
-      parent modules of a module) including looking for declarations and
-      handling imports, and including finding declarations in the root module.
-    * If LOOKUP_TOPLEVEL is set, checks for a toplevel module with this name.
-    * If LOOKUP_INNERMOST is true, limits search to the innermost scope with a
-      match.
+    The config argument is a group of or-ed together bit flags that adjusts the
+    behavior of the lookup. Please see 'LookupConfig' and the related constants
+    such as 'LOOKUP_DECLS' for further details.
    */
   std::vector<BorrowedIdsWithName>
   lookupNameInScope(Context* context,

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -743,18 +743,21 @@ enum VisibilityStmtKind {
 
 enum {
   /**
-    Find symbols declared at this scope.
+    When looking at a scope, find symbols declared in that scope.
    */
   LOOKUP_DECLS = 1,
 
   /**
-    Consider symbols brought in by 'import' and 'use'.
+    When looking at a scope, consider symbols brought in to that scope by
+    'import' and 'use' statements.
    */
   LOOKUP_IMPORT_AND_USE = 2,
 
   /**
-    Search in parent scopes. Stops when a module scope is found
-    unless LOOKUP_GO_PAST_MODULES is included.
+    When looking at a scope, also search parent scopes (those that lexically
+    contain this scope). Stops when a module scope is found unless
+    LOOKUP_GO_PAST_MODULES is included. Additionally, looks for symbols in the
+    root module.
    */
   LOOKUP_PARENTS = 4,
 

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -53,7 +53,8 @@ class IdAndVis {
 
   bool operator==(const IdAndVis& other) const {
     return id_ == other.id_ &&
-           vis_ == other.vis_;
+           vis_ == other.vis_ &&
+           isMethodOrField_ == other.isMethodOrField_;
   }
   bool operator!=(const IdAndVis& other) const {
     return !(*this == other);
@@ -63,6 +64,7 @@ class IdAndVis {
     size_t ret = 0;
     ret = hash_combine(ret, chpl::hash(id_));
     ret = hash_combine(ret, chpl::hash(vis_));
+    ret = hash_combine(ret, chpl::hash(isMethodOrField_));
     return ret;
   }
 

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -37,22 +37,22 @@ namespace resolution {
 class BorrowedIdsWithName;
 
 /** Helper type to store an ID and visibility constraints. */
-struct IdAndVis {
-  //friend class OwnedIdsWithName;
-  //friend class BorrowedIdsWithName;
+class IdAndVis {
+  friend class OwnedIdsWithName;
+  friend class BorrowedIdsWithName;
 
-  ID first;
-  uast::Decl::Visibility second;
+  ID id_;
+  uast::Decl::Visibility vis_;
 
- //public:
+ public:
   IdAndVis(ID id, uast::Decl::Visibility vis)
-    : first(std::move(id)), second(vis)
+    : id_(std::move(id)), vis_(vis)
   {
   }
 
   bool operator==(const IdAndVis& other) const {
-    return first == other.first &&
-           second == other.second;
+    return id_ == other.id_ &&
+           vis_ == other.vis_;
   }
   bool operator!=(const IdAndVis& other) const {
     return !(*this == other);
@@ -60,10 +60,13 @@ struct IdAndVis {
 
   size_t hash() const {
     size_t ret = 0;
-    ret = hash_combine(ret, chpl::hash(first));
-    ret = hash_combine(ret, chpl::hash(second));
+    ret = hash_combine(ret, chpl::hash(id_));
+    ret = hash_combine(ret, chpl::hash(vis_));
     return ret;
   }
+
+  const ID& id() const { return id_; }
+  uast::Decl::Visibility vis() const { return vis_; }
 };
 
 /**
@@ -116,10 +119,10 @@ class OwnedIdsWithName {
     return !(*this == other);
   }
   void mark(Context* context) const {
-    idv_.first.mark(context);
+    idv_.id_.mark(context);
     if (auto ptr = moreIdvs_.get()) {
       for (auto const& elt : *ptr) {
-        context->markOwnedPointer(&elt.first);
+        context->markOwnedPointer(&elt.id_);
       }
     }
   }
@@ -144,7 +147,7 @@ class BorrowedIdsWithName {
  private:
   static inline bool isIdVisible(const IdAndVis& idv,
                                  bool arePrivateIdsIgnored) {
-    return !arePrivateIdsIgnored || idv.second != uast::Decl::PRIVATE;
+    return !arePrivateIdsIgnored || idv.vis_ != uast::Decl::PRIVATE;
   }
 
   bool isIdVisible(const IdAndVis& idv) const {
@@ -204,7 +207,7 @@ class BorrowedIdsWithName {
       fastForward();
       return *this;
     }
-    inline const ID& operator*() const { return currentIdv->first; }
+    inline const ID& operator*() const { return currentIdv->id_; }
   };
  private:
   /**
@@ -274,7 +277,7 @@ class BorrowedIdsWithName {
 
   /** Returns the first ID in this list. */
   const ID& firstId() const {
-    return idv_.first;
+    return idv_.id_;
   }
 
   BorrowedIdsWithNameIter begin() const {

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -742,16 +742,51 @@ enum VisibilityStmtKind {
 };
 
 enum {
+  /**
+    Find symbols declared at this scope.
+   */
   LOOKUP_DECLS = 1,
+
+  /**
+    Consider symbols brought in by 'import' and 'use'.
+   */
   LOOKUP_IMPORT_AND_USE = 2,
+
+  /**
+    Search in parent scopes. Stops when a module scope is found
+    unless LOOKUP_GO_PAST_MODULES is included.
+   */
   LOOKUP_PARENTS = 4,
+
+  /**
+    Find toplevel modules with the matching name.
+   */
   LOOKUP_TOPLEVEL = 8,
+
+  /**
+    Find only the innermost match or matches.
+   */
   LOOKUP_INNERMOST = 16,
+
+  /**
+    Find only public symbols.
+   */
   LOOKUP_SKIP_PRIVATE_VIS = 32,
+
+  /**
+    Continue the scope search to parent modules instead of stopping
+    at the module scope. This setting supports error messages.
+   */
   LOOKUP_GO_PAST_MODULES = 64,
+
+  /**
+    Lookup only methods, fields, and class/record/union declarations
+    directly nested within a class/record/union
+   */
   LOOKUP_ONLY_METHODS_FIELDS = 128,
 };
 
+/** LookupConfig is a bit-set of the LOOKUP_ flags defined above */
 using LookupConfig = unsigned int;
 
 /**

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -313,6 +313,7 @@ class Scope {
   bool containsUseImport_ = false;
   bool containsFunctionDecls_ = false;
   bool autoUsesModules_ = false;
+  bool methodScope_ = false;
   ID id_;
   UniqueString name_;
   DeclMap declared_;
@@ -362,9 +363,12 @@ class Scope {
 
   /** Returns 'true' if the Scope includes the automatic 'use' for
       the standard library. */
-  bool autoUsesModules() const {
-    return autoUsesModules_;
-  }
+  bool autoUsesModules() const { return autoUsesModules_; }
+
+  /** Returns 'true' if this Scope represents a method's scope.
+      Methods have special scoping behavior to use other fields/methods
+      without writing 'this.bla'. */
+  bool isMethodScope() const { return methodScope_; }
 
   /** Returns 'true' if this Scope directly contains any Functions */
   bool containsFunctionDecls() const { return containsFunctionDecls_; }
@@ -396,6 +400,7 @@ class Scope {
            containsUseImport_ == other.containsUseImport_ &&
            containsFunctionDecls_ == other.containsFunctionDecls_ &&
            autoUsesModules_ == other.autoUsesModules_ &&
+           methodScope_ == other.methodScope_ &&
            id_ == other.id_ &&
            declared_ == other.declared_ &&
            name_ == other.name_;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -816,7 +816,8 @@ const Type* Resolver::tryResolveCrossTypeInitEq(const AstNode* ast,
                         /* isParenless */ false,
                         actuals);
     const Scope* scope = scopeForId(context, ast->id());
-    auto c = resolveGeneratedCall(context, ast, ci, scope, poiScope);
+    auto c = resolveGeneratedCall(context, ast, ci, scope, poiScope,
+                                  /* implicitReceiver */ nullptr);
     if (c.mostSpecific().isEmpty()) {
       return nullptr;
     } else {
@@ -1450,7 +1451,8 @@ void Resolver::resolveTupleUnpackAssign(ResolvedExpression& r,
                           /* isParenless */ false,
                           actuals);
 
-      auto c = resolveGeneratedCall(context, actual, ci, scope, poiScope);
+      auto c = resolveGeneratedCall(context, actual, ci, scope, poiScope,
+                                    /* implicitReciever */ nullptr);
       handleResolvedAssociatedCall(r, astForErr, ci, c,
                                    AssociatedAction::ASSIGN,
                                    lhsTuple->id());
@@ -1598,7 +1600,8 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
   auto inPoiScope = poiScope;
 
   // note: the resolution machinery will get compiler generated candidates
-  auto crr = resolveGeneratedCall(context, call, ci, inScope, inPoiScope);
+  auto crr = resolveGeneratedCall(context, call, ci, inScope, inPoiScope,
+                                  /* implicitReciever */ nullptr);
 
   CHPL_ASSERT(crr.mostSpecific().numBest() <= 1);
 
@@ -2103,7 +2106,8 @@ bool Resolver::resolveIdentifier(const Identifier* ident,
                             /* isParenless */ true,
                             actuals);
         auto inScope = scopeStack.back();
-        auto c = resolveGeneratedCall(context, ident, ci, inScope, poiScope);
+        auto c = resolveGeneratedCall(context, ident, ci, inScope, poiScope,
+                                      methodReceiverType());
         // save the most specific candidates in the resolution result for the id
         ResolvedExpression& r = byPostorder.byAst(ident);
         handleResolvedCall(r, ident, ci, c);
@@ -2637,7 +2641,8 @@ void Resolver::exit(const Call* call) {
   }
 
   if (!skip) {
-    CallResolutionResult c = resolveCall(context, call, ci, scope, poiScope);
+    CallResolutionResult c = resolveCall(context, call, ci, scope, poiScope,
+                                         methodReceiverType());
 
     // save the most specific candidates in the resolution result for the id
     ResolvedExpression& r = byPostorder.byAst(call);
@@ -2787,7 +2792,8 @@ void Resolver::exit(const Dot* dot) {
                       /* isParenless */ true,
                       actuals);
   auto inScope = scopeStack.back();
-  auto c = resolveGeneratedCall(context, dot, ci, inScope, poiScope);
+  auto c = resolveGeneratedCall(context, dot, ci, inScope, poiScope,
+                                /* implicitReceiver */ nullptr);
   // save the most specific candidates in the resolution result for the id
   ResolvedExpression& r = byPostorder.byAst(dot);
   handleResolvedCall(r, dot, ci, c);
@@ -2948,7 +2954,9 @@ static QualifiedType resolveSerialIterType(Resolver& resolver,
                         /* isParenless */ false,
                         actuals);
     auto inScope = resolver.scopeStack.back();
-    auto c = resolveGeneratedCall(context, iterand, ci, inScope, resolver.poiScope);
+    auto c = resolveGeneratedCall(context, iterand, ci,
+                                  inScope, resolver.poiScope,
+                                  /* implicitReceiver */ nullptr);
 
     if (c.mostSpecific().only() != nullptr) {
       idxType = c.exprType();

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1757,8 +1757,9 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
       ct = inCompositeType;
     } else {
       if (auto rt = methodReceiverType().type()) {
-        if (ct != rt->getCompositeType()) {
-          if (auto bct = ct->toBasicClassType()) {
+        if (auto comprt = rt->getCompositeType()) {
+          ct = comprt; // start with the receiver type
+          if (auto bct = comprt->toBasicClassType()) {
             // if it's a class, check for parent classes to decide
             // which type corresponds to the uAST ID parentId
             while (bct != nullptr) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1761,17 +1761,19 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
       ct = inCompositeType;
     } else {
       ct = methodReceiverType();
-      if (auto bct = ct->toBasicClassType()) {
-        // if it's a class, check for parent classes to decide
-        // which type corresponds to the uAST ID parentId
-        while (bct != nullptr) {
-          if (bct->id() == parentId) {
-            // found the matching type
-            ct = bct;
-            break;
+      if (ct != nullptr) {
+        if (auto bct = ct->toBasicClassType()) {
+          // if it's a class, check for parent classes to decide
+          // which type corresponds to the uAST ID parentId
+          while (bct != nullptr) {
+            if (bct->id() == parentId) {
+              // found the matching type
+              ct = bct;
+              break;
+            }
+            // otherwise, try the parent class type
+            bct = bct->parentClassType();
           }
-          // otherwise, try the parent class type
-          bct = bct->parentClassType();
         }
       }
     }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -552,7 +552,7 @@ Resolver::ReceiverScopesVec Resolver::methodReceiverScopes(bool recompute) {
   return savedReceiverScopes;
 }
 
-const QualifiedType Resolver::methodReceiverType() {
+QualifiedType Resolver::methodReceiverType() {
   if (typedSignature && typedSignature->untyped()->isMethod()) {
     return typedSignature->formalType(0);
   }

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -231,9 +231,9 @@ struct Resolver {
   ReceiverScopesVec methodReceiverScopes(bool recompute = false);
 
   /* Compute the receiver type (when resolving a method)
-     and return nullptr if it is not applicable.
+     and return a type containing nullptr if it is not applicable.
    */
-  const types::CompositeType* methodReceiverType();
+  const types::QualifiedType methodReceiverType();
 
   /* When resolving a generic record or a generic function,
      there might be generic types that we don't know yet.

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -233,7 +233,7 @@ struct Resolver {
   /* Compute the receiver type (when resolving a method)
      and return a type containing nullptr if it is not applicable.
    */
-  const types::QualifiedType methodReceiverType();
+  types::QualifiedType methodReceiverType();
 
   /* When resolving a generic record or a generic function,
      there might be generic types that we don't know yet.

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -477,8 +477,8 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
                         /* isParenless */ false,
                         std::move(actuals));
     const Scope* scope = scopeForId(context, ast->id());
-    auto c = resolveGeneratedCall(context, ast, ci, scope,
-                                  resolver.poiScope);
+    auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope,
+                                  /* implicitReceiver */ nullptr);
     ResolvedExpression& opR = rv.byAst(ast);
     resolver.handleResolvedAssociatedCall(opR, ast, ci, c,
                                           AssociatedAction::DEFAULT_INIT,
@@ -500,8 +500,8 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope,
-                                resolver.poiScope);
+  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope,
+                                /* implicitReceiver */ nullptr);
   ResolvedExpression& opR = rv.byAst(ast);
 
   auto op = ast->toOpCall();
@@ -537,8 +537,8 @@ void CallInitDeinit::resolveCopyInit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope,
-                                resolver.poiScope);
+  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope,
+                                /* implicitReceiver */ nullptr);
 
   std::vector<const AstNode*> actualAsts;
   actualAsts.push_back(ast);
@@ -711,8 +711,8 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope,
-                                resolver.poiScope);
+  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope,
+                                /* implicitReceiver */ nullptr);
 
   // Should we associate it with the current statement or the current block?
   const AstNode* assocAst = currentStatement();

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -477,8 +477,7 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
                         /* isParenless */ false,
                         std::move(actuals));
     const Scope* scope = scopeForId(context, ast->id());
-    auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope,
-                                  /* implicitReceiver */ nullptr);
+    auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
     ResolvedExpression& opR = rv.byAst(ast);
     resolver.handleResolvedAssociatedCall(opR, ast, ci, c,
                                           AssociatedAction::DEFAULT_INIT,
@@ -500,8 +499,7 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope,
-                                /* implicitReceiver */ nullptr);
+  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
   ResolvedExpression& opR = rv.byAst(ast);
 
   auto op = ast->toOpCall();
@@ -537,8 +535,7 @@ void CallInitDeinit::resolveCopyInit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope,
-                                /* implicitReceiver */ nullptr);
+  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
 
   std::vector<const AstNode*> actualAsts;
   actualAsts.push_back(ast);
@@ -711,8 +708,7 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope,
-                                /* implicitReceiver */ nullptr);
+  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
 
   // Should we associate it with the current statement or the current block?
   const AstNode* assocAst = currentStatement();

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -131,8 +131,7 @@ bool FindElidedCopies::hasCrossTypeInitAssignWithIn(
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, poiScope,
-                                /* implicitReceiver */ nullptr);
+  auto c = resolveGeneratedCall(context, ast, ci, scope, poiScope);
   const MostSpecificCandidates& fns = c.mostSpecific();
   // return intent overloading should not be possible with an init=
   CHPL_ASSERT(fns.numBest() <= 1);

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -131,7 +131,8 @@ bool FindElidedCopies::hasCrossTypeInitAssignWithIn(
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, poiScope);
+  auto c = resolveGeneratedCall(context, ast, ci, scope, poiScope,
+                                /* implicitReceiver */ nullptr);
   const MostSpecificCandidates& fns = c.mostSpecific();
   // return intent overloading should not be possible with an init=
   CHPL_ASSERT(fns.numBest() <= 1);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2896,17 +2896,6 @@ gatherAndFilterCandidates(Context* context,
     // compute the potential functions that it could resolve to
     auto v = lookupCalledExpr(context, inScope, ci, visited);
 
-    /*
-    printf("Visible functions for\n");
-    ci.dump();
-    printf("\n");
-    for (auto c : v) {
-      c.dump();
-      printf("\n");
-    }
-    printf("\n\n");
-    */
-
     // filter without instantiating yet
     const auto& initialCandidates = filterCandidatesInitial(context, v, ci);
 
@@ -3027,6 +3016,7 @@ resolveFnCallFilterAndFindMostSpecific(Context* context,
                                        const Scope* inScope,
                                        const PoiScope* inPoiScope,
                                        PoiInfo& poiInfo) {
+
   // search for candidates at each POI until we have found candidate(s)
   size_t firstPoiCandidate = 0;
   ForwardingInfoVec forwardingInfo;
@@ -3070,8 +3060,6 @@ CallResolutionResult resolveFnCall(Context* context,
     // * filter and instantiate
     // * disambiguate
     // * note any most specific candidates from POI in poiInfo.
-
-    // try
     mostSpecific = resolveFnCallFilterAndFindMostSpecific(context, call, ci,
                                                           inScope, inPoiScope,
                                                           poiInfo);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2650,6 +2650,7 @@ lookupCalledExpr(Context* context,
 
   // For method calls, also consider the receiver scope.
   if (ci.isMethodCall() || ci.isOpCall()) {
+    // TODO: should types of all arguments be considered for an op call?
     CHPL_ASSERT(ci.numActuals() >= 1);
     auto& qtReceiver = ci.actual(0).type();
     if (auto t = qtReceiver.type()) {
@@ -2885,6 +2886,7 @@ gatherAndFilterCandidates(Context* context,
     // compute the potential functions that it could resolve to
     auto v = lookupCalledExpr(context, inScope, ci, visited);
 
+    /*
     printf("Visible functions for\n");
     ci.dump();
     printf("\n");
@@ -2893,6 +2895,7 @@ gatherAndFilterCandidates(Context* context,
       printf("\n");
     }
     printf("\n\n");
+    */
 
     // filter without instantiating yet
     const auto& initialCandidates = filterCandidatesInitial(context, v, ci);
@@ -3014,7 +3017,6 @@ resolveFnCallFilterAndFindMostSpecific(Context* context,
                                        const Scope* inScope,
                                        const PoiScope* inPoiScope,
                                        PoiInfo& poiInfo) {
-
   // search for candidates at each POI until we have found candidate(s)
   size_t firstPoiCandidate = 0;
   ForwardingInfoVec forwardingInfo;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2765,7 +2765,8 @@ gatherAndFilterCandidatesForwarding(Context* context,
     //   equally as sources of candidates
     // * do not consider forwarding (since we are considering it now!)
 
-    NamedScopeSet visited;
+    std::vector<NamedScopeSet> visited;
+    visited.resize(numForwards);
 
     for (auto fci : forwardingCis) {
       size_t start = nonPoiCandidates.size();
@@ -2777,24 +2778,30 @@ gatherAndFilterCandidatesForwarding(Context* context,
     }
 
     // next, look for candidates without using POI.
-    for (auto fci : forwardingCis) {
-      size_t start = nonPoiCandidates.size();
-      // compute the potential functions that it could resolve to
-      auto v = lookupCalledExpr(context, inScope, fci, visited);
+    {
+      int i = 0;
+      for (auto fci : forwardingCis) {
+        size_t start = nonPoiCandidates.size();
+        // compute the potential functions that it could resolve to
+        auto v = lookupCalledExpr(context, inScope, fci, visited[i]);
 
-      // filter without instantiating yet
-      const auto& initialCandidates = filterCandidatesInitial(context, v, fci);
+        // filter without instantiating yet
+        const auto& initialCandidates =
+          filterCandidatesInitial(context, v, fci);
 
-      // find candidates, doing instantiation if necessary
-      filterCandidatesInstantiating(context,
-                                    initialCandidates,
-                                    fci,
-                                    inScope,
-                                    inPoiScope,
-                                    nonPoiCandidates);
+        // find candidates, doing instantiation if necessary
+        filterCandidatesInstantiating(context,
+                                      initialCandidates,
+                                      fci,
+                                      inScope,
+                                      inPoiScope,
+                                      nonPoiCandidates);
 
-      // update forwardingTo
-      helpComputeForwardingTo(fci, start, nonPoiCandidates, nonPoiForwardingTo);
+        // update forwardingTo
+        helpComputeForwardingTo(fci, start,
+                                nonPoiCandidates, nonPoiForwardingTo);
+        i++;
+      }
     }
 
     // next, look for candidates using POI
@@ -2807,11 +2814,13 @@ gatherAndFilterCandidatesForwarding(Context* context,
         break;
       }
 
+
+      int i = 0;
       for (auto fci : forwardingCis) {
         size_t start = poiCandidates.size();
 
         // compute the potential functions that it could resolve to
-        auto v = lookupCalledExpr(context, curPoi->inScope(), fci, visited);
+        auto v = lookupCalledExpr(context, curPoi->inScope(), fci, visited[i]);
 
         // filter without instantiating yet
         auto& initialCandidates = filterCandidatesInitial(context, v, fci);
@@ -2826,6 +2835,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
 
         // update forwardingTo
         helpComputeForwardingTo(fci, start, poiCandidates, poiForwardingTo);
+        i++;
       }
     }
 

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -370,7 +370,19 @@ CallInfo CallInfo::create(Context* context,
   return ret;
 }
 
+CallInfo CallInfo::createWithReceiver(const CallInfo& ci,
+                                      QualifiedType receiverType) {
+  std::vector<CallInfoActual> newActuals;
+  newActuals.push_back(CallInfoActual(receiverType, USTR("this")));
+  // append the other actuals
+  newActuals.insert(newActuals.end(), ci.actuals_.begin(), ci.actuals_.end());
 
+  return CallInfo(ci.name_, receiverType,
+                  /* isMethodCall */ true,
+                  ci.hasQuestionArg_,
+                  ci.isParenless_,
+                  std::move(newActuals));
+}
 
 void ResolutionResultByPostorderID::setupForSymbol(const AstNode* ast) {
   CHPL_ASSERT(Builder::astTagIndicatesNewIdScope(ast->tag()));

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -569,20 +569,11 @@ static bool doLookupInScope(Context* context,
     }
   }
 
-  bool considerReceiverScopes = false;
-  // Receiver scopes should be considered in two cases.
+  // Receiver scopes support two cases:
   // 1. For resolving names within a method (for the implicit 'this' feature)
   // 2. For resolving a dot expression (e.g. 'myObject.field')
-  //
-  // If receiver scopes are provided, this code assumes it is in case
-  // (1) if checkParents=true, and in case (2) otherwise.
-  if (!receiverScopes.empty()) {
-    if (checkParents) {
-      considerReceiverScopes = scope->isMethodScope(); // for implicit 'this'
-    } else {
-      considerReceiverScopes = true; // for e.g. 'myObject.field'
-    }
-  }
+  //    (note that 'field' could be a parenless secondary method)
+  bool considerReceiverScopes = !receiverScopes.empty();
 
   // gather non-shadow scope information
   // (declarations in this scope as well as public use / import)

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -537,6 +537,10 @@ static bool doLookupInScope(Context* context,
                             NamedScopeSet& checkedScopes,
                             std::vector<BorrowedIdsWithName>& result) {
 
+  if (name == "field") {
+    gdbShouldBreakHere();
+  }
+
   bool checkDecls = (config & LOOKUP_DECLS) != 0;
   bool checkUseImport = (config & LOOKUP_IMPORT_AND_USE) != 0;
   bool checkParents = (config & LOOKUP_PARENTS) != 0;

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -624,7 +624,7 @@ static bool doLookupInScope(Context* context,
     // create a config that doesn't search receiver scopes parent scopes
     // (such parent scopes are covered in later in this function)
     LookupConfig newConfig = config;
-    newConfig &= ~(LOOKUP_PARENTS|LOOKUP_GO_PAST_MODULES);
+    newConfig &= ~(LOOKUP_PARENTS|LOOKUP_GO_PAST_MODULES|LOOKUP_TOPLEVEL);
     // and only consider methods/fields
     // (but that's all that we should find in a record/class decl anyway...)
     newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
@@ -639,10 +639,10 @@ static bool doLookupInScope(Context* context,
 
   // consider the parent scopes due to nesting
   if (checkParents) {
-    // create a config that doesn't search parent scopes
-    // (parent scopes are covered directly in the loop below)
+    // create a config that doesn't search parent scopes or toplevel scopes
+    // (such scopes are covered directly later in this function)
     LookupConfig newConfig = config;
-    newConfig &= ~(LOOKUP_PARENTS|LOOKUP_GO_PAST_MODULES);
+    newConfig &= ~(LOOKUP_PARENTS|LOOKUP_GO_PAST_MODULES|LOOKUP_TOPLEVEL);
 
     // Search parent scopes, if any, until a module is encountered
     const Scope* cur = nullptr;
@@ -957,7 +957,7 @@ errorIfAnyLimitationNotInScope(Context* context,
     if (auto ident = e->toIdentifier()) {
       errorIfNameNotInScope(context, scope, resolving, ident->name(),
                             ident, clause, useOrImport,
-                            /* isRename */ true);
+                            /* isRename */ false);
     } else if (auto as = e->toAs()) {
       if (auto ident = as->symbol()->toIdentifier()) {
         errorIfNameNotInScope(context, scope, resolving, ident->name(),

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -434,11 +434,13 @@ static bool doLookupInImportsAndUses(Context* context,
         auto scopeAst = parsing::idToAst(context, is.scope()->id());
         auto visibility = scopeAst->toDecl()->visibility();
         bool isMethodOrField = false;
+        bool onlyMethodsFields = false;
         auto foundIds =
           BorrowedIdsWithName::createWithSingleId(is.scope()->id(),
                                                   visibility,
                                                   isMethodOrField,
-                                                  skipPrivateVisibilities);
+                                                  skipPrivateVisibilities,
+                                                  onlyMethodsFields);
         if (foundIds) {
           result.push_back(std::move(foundIds.getValue()));
           found = true;
@@ -513,6 +515,7 @@ static bool doLookupInScope(Context* context,
   bool onlyInnermost = (config & LOOKUP_INNERMOST) != 0;
   bool skipPrivateVisibilities = (config & LOOKUP_SKIP_PRIVATE_VIS) != 0;
   bool goPastModules = (config & LOOKUP_GO_PAST_MODULES) != 0;
+  bool onlyMethodsFields = (config & LOOKUP_ONLY_METHODS_FIELDS) != 0;
 
   // goPastModules should imply checkParents; otherwise, why would we proceed
   // through module boundaries if we aren't traversing the scope chain?
@@ -542,7 +545,8 @@ static bool doLookupInScope(Context* context,
   {
     bool got = false;
     if (checkDecls) {
-      got |= scope->lookupInScope(name, result, skipPrivateVisibilities);
+      got |= scope->lookupInScope(name, result,
+                                  skipPrivateVisibilities, onlyMethodsFields);
     }
     if (checkUseImport) {
       got |= doLookupInImportsAndUses(context, scope, resolving, r, name,

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -19,6 +19,7 @@
 
 #include "chpl/resolution/scope-types.h"
 
+#include "chpl/uast/Function.h"
 #include "chpl/uast/NamedDecl.h"
 
 #include "scope-help.h"
@@ -75,6 +76,9 @@ Scope::Scope(const uast::AstNode* ast, const Scope* parentScope,
   id_ = ast->id();
   if (auto decl = ast->toNamedDecl()) {
     name_ = decl->name();
+  }
+  if (auto fn = ast->toFunction()) {
+    methodScope_ = fn->isMethod();
   }
   gatherDeclsWithin(ast, declared_, containsUseImport_, containsFunctionDecls_);
 }

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -88,7 +88,10 @@ void Scope::addBuiltin(UniqueString name) {
   // Just refer to empty ID since builtin type declarations don't
   // actually exist in the AST.
   // The resolver knows that the empty ID means a builtin thing.
-  declared_.emplace(name, OwnedIdsWithName(ID(), uast::Decl::PUBLIC));
+  declared_.emplace(name,
+                    OwnedIdsWithName(ID(),
+                                     uast::Decl::PUBLIC,
+                                     /*isMethodOrField*/ false));
 }
 
 const Scope* Scope::moduleScope() const {

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -32,11 +32,11 @@ void OwnedIdsWithName::stringify(std::ostream& ss,
                                  chpl::StringifyKind stringKind) const {
   if (auto ptr = moreIdvs_.get()) {
     for (const auto& elt : *ptr) {
-      elt.first.stringify(ss, stringKind);
+      elt.id_.stringify(ss, stringKind);
     }
   } else {
-    if (!idv_.first.isEmpty()) {
-      idv_.first.stringify(ss, stringKind);
+    if (!idv_.id_.isEmpty()) {
+      idv_.id_.stringify(ss, stringKind);
     }
   }
 }

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -30,31 +30,32 @@ namespace resolution {
 
 void OwnedIdsWithName::stringify(std::ostream& ss,
                                  chpl::StringifyKind stringKind) const {
-  if (auto ptr = moreIds_.get()) {
+  if (auto ptr = moreIdvs_.get()) {
     for (const auto& elt : *ptr) {
       elt.first.stringify(ss, stringKind);
     }
   } else {
-    if (!id_.first.isEmpty()) {
-      id_.first.stringify(ss, stringKind);
+    if (!idv_.first.isEmpty()) {
+      idv_.first.stringify(ss, stringKind);
     }
   }
 }
 
 llvm::Optional<BorrowedIdsWithName> OwnedIdsWithName::borrow(bool skipPrivateVisibilities) const {
-  if (BorrowedIdsWithName::isIdVisible(id_, skipPrivateVisibilities)) {
-    return BorrowedIdsWithName(id_, moreIds_.get(), skipPrivateVisibilities);
+  if (BorrowedIdsWithName::isIdVisible(idv_, skipPrivateVisibilities)) {
+    return BorrowedIdsWithName(idv_, moreIdvs_.get(), skipPrivateVisibilities);
   }
   // The first ID isn't visible; are others?
-  if (moreIds_.get() == nullptr) {
+  if (moreIdvs_.get() == nullptr) {
     return llvm::None;
   }
 
-  for (auto& id : *moreIds_) {
-    if (!BorrowedIdsWithName::isIdVisible(id, skipPrivateVisibilities)) continue;
+  for (auto& idv : *moreIdvs_) {
+    if (!BorrowedIdsWithName::isIdVisible(idv, skipPrivateVisibilities))
+      continue;
 
     // Found a visible ID!
-    return BorrowedIdsWithName(id, moreIds_.get(), skipPrivateVisibilities);
+    return BorrowedIdsWithName(idv, moreIdvs_.get(), skipPrivateVisibilities);
   }
 
   // No ID was visible, so we can't borrow.

--- a/frontend/test/resolution/testDeprecationUnstable.cpp
+++ b/frontend/test/resolution/testDeprecationUnstable.cpp
@@ -278,8 +278,8 @@ static void testDeprecationWarningsForTypes(void) {
       }
 
       {
-        import mod1;
-        import mod2;
+        import this.mod1;
+        import this.mod2;
       }
 
       var v13 = e1.e1k1;  // OK

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -65,7 +65,7 @@ static void testIt(const char* testName,
   assert(identAst->isIdentifier());
   auto fieldAst = parsing::idToAst(context, fieldId);
   assert(fieldAst);
-  assert(fieldAst->isVariable());
+  assert(fieldAst->isVariable() || fieldAst->isFormal());
 
   // check the scope resolver
   const ResolvedFunction* sr = scopeResolveFunction(context, methodId);
@@ -315,7 +315,27 @@ static void test7() {
   // TODO get the above case working with the full resolver
 }
 
+// test with a formal vs a parent class field
+static void test8() {
+  testIt("test8.chpl",
+         R""""(
+            module M {
+              class Base {
+                var x: int;
+              }
 
+              class C : Base {
+              }
+
+              proc C.secondary(x: real) {
+                x;
+              }
+            }
+         )"""",
+         "M.secondary",
+         "M.secondary@4",
+         "M.secondary@3" /* the formal */ );
+}
 
 
 int main() {
@@ -334,6 +354,8 @@ int main() {
 
   test6();
   test7();
+
+  test8();
 
   return 0;
 }

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -337,6 +337,29 @@ static void test8() {
          "M.secondary@3" /* the formal */ );
 }
 
+// test with a formal vs a class field
+static void test9() {
+  testIt("test9.chpl",
+         R""""(
+            module M {
+              record R {
+                var tz:int;
+                proc init() { }
+                proc foo(tzinfo: real) { }
+              }
+
+              proc R.now(tz:real = 1.4) {
+                var x:R;
+                x.foo(tz);
+              }
+            }
+         )"""",
+         "M.now",
+         "M.now@9",
+         "M.now@4" /* the formal */ );
+}
+
+
 
 int main() {
   test1r();
@@ -356,6 +379,7 @@ int main() {
   test7();
 
   test8();
+  test9();
 
   return 0;
 }


### PR DESCRIPTION
This PR includes changes to fix the following tests when running with `--dyno`:

    classes/diten/nesting_with_inheritance.chpl
    reductions/thomasvandoren/test/TestScanCounts.chpl
    reductions/thomasvandoren/test/TestScanCountsInherit.chpl

The `scan` tests are fixed through a bug fix for `Converter::noteAllContainedFixups` in `convert-uast.cpp`. That function does not visit nested functions (because they should be handled as separate symbols). However, converting a scan expression generates an special inner function that wasn't being visited by the traversal to note a contained TemporaryConversionSymbol for later fixup. Use the fact that such generated functions are marked with `FLAG_COMPILER_NESTED_FUNCTION` to address the issue. To help debugging such errors in the future, this PR includes some improvements to tracing in `convert-uast.cpp`.

The `nesting_with_inheritance.chpl` test is fixed with changes to `doLookupInScope`. When at a method scope, it checks for fields before considering parent scopes. That way, formals are preferred to fields, but fields will be used before any outer variables. I noticed that the language specification is not particularly clear about this so I have also created PR #21556 to clarify the spec. Added a few C++ tests for tricky cases with this pattern.

To get the above changes to make sense with type and call resolution, this PR also makes a number of changes for other parts of the dyno resolver.
 * changes IdAndVis from a `std::pair` to a type so that it can track a 3rd field: whether a symbol is a method/field.
 * renamed various fields and variables that refer to IdAndVis to indicate that (e.g. `id_` renamed to `idv_`) since the code is also often working with `ID`s.
 * enable `BorrowedIdsWithName` to filter on method/field-ness in addition to visibility
 * added `LOOKUP_ONLY_METHODS_FIELDS` to configure scope lookup to only consider methods/fields
 * merged `lookupCalledExprConsideringReceiver` with `lookupCalledExpr` to simplify the code a bit
 * adjusted `gatherAndFilterCandidatesForwarding` to track separate visited sets for each forwarding target
 * adds `resolveCallInMethod` and `resolveGeneratedCallInMethod` to consider the way that `foo()` might turn into `this.foo()` if possible
 * cleaned up scope resolution adjustments with `isElseBlockOfConditionalWithIfVar` to reduce incremental re-computation & to use a query.
 * includes a bug fix for a bug I noticed with a `use`/`import` error. The bug fix improves the error message for `visibility/import/enablesUnqualified/multipleUnqualified/badName` and `visibility/only/badName`.

Future Work:
 * Consider moving the implicit-`this` handling more directly within the Resolver and/or adjusting function resolution code to accept a vector of receiver types to try with a single CallInfo.
 * Consider moving duplicate definition check to its own query

Reviewed by @riftEmber - thanks!

- [x] full local testing
- [x] full local `--dyno` testing