### PR TITLE
Add a note to the spec about intepreting identifiers as fields

### DIFF
--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -1705,7 +1705,10 @@ omitted when the field access is within a method. In this case the
 receiver is the method’s receiver. The receiver clause can also be
 omitted when the field access is within a class declaration. In this
 case the receiver is the instance being implicitly defined or
-referenced.
+referenced. When the receiver clause is omitted, the compiler will
+consider the possibility that the identifier refers to a field after
+considering if it refers to a method formal argument but before
+considering if it refers to a variable in another parent scope.
 
 The identifier in the field access expression indicates which field is
 accessed.

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -1706,9 +1706,10 @@ receiver is the method’s receiver. The receiver clause can also be
 omitted when the field access is within a class declaration. In this
 case the receiver is the instance being implicitly defined or
 referenced. When the receiver clause is omitted, the compiler will
-consider the possibility that the identifier refers to a field after
-considering if it refers to a method formal argument but before
-considering if it refers to a variable in another parent scope.
+consider the possibility that the identifier refers to a field, but in
+that case, it could also refer to something declared outside of the
+class. In particular, a local variable or formal will shadow a field,
+but a field will shadow a module-scope variable declared outside of the method.
 
 The identifier in the field access expression indicates which field is
 accessed.

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -1302,8 +1302,8 @@ function call and one of the following conditions is met:
   and the call qualifies the function name with the module name,
   see also :ref:`Importing_Modules`.
 
-- :math:`X` is a method and it is defined in the same module that defines
-  the receiver type.
+- :math:`X` is a method and it is visible in the module that defines the
+  receiver type.
 
 .. _Determining_Candidate_Functions:
 


### PR DESCRIPTION
This PR updates the language specification to clarify how an identifier within a method is interpreted. If the identifier has the same name as both a formal and a field, the formal will take precedence over a field. But, if the identifier has the same name as a field and an outer variable, it will be interpreted as referring to the field.

Future Work:
 * seek to clarify other test cases mentioned in https://github.com/Cray/chapel-private/issues/5163

Reviewed by @lydia-duncan - thanks!