### PR TITLE
fix(docs): add formatted bang as part of `try!` symbols

### DIFF
--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -6,7 +6,7 @@
 Error Handling
 ==============
 
-The Chapel language supports ``throw``, ``try``, ``try``!, ``catch``,
+The Chapel language supports ``throw``, ``try``, ``try!``, ``catch``,
 and ``throws`` which are described below. Chapel supports several error
 handling modes, including a mode suitable for prototype development and
 a less-permissive mode intended for production code.
@@ -15,7 +15,7 @@ a less-permissive mode intended for production code.
 
    Additional information about the current implementation of
    error handling and the *strict* error handling mode, which is not
-   defined here, is available in the 
+   defined here, is available in the
    :ref:`errorHandling technical note <readme-errorHandling>`
 
 .. _Throwing_Errors:
@@ -47,7 +47,7 @@ thrown.
 
    *Example (throwing.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -71,7 +71,7 @@ Handling Errors
 
 There are three ways to handle an error:
 
--  Halt with ``try``!.
+-  Halt with ``try!``.
 
 -  Handle the error with ``catch`` blocks.
 
@@ -82,12 +82,12 @@ There are three ways to handle an error:
 Halting on error with try!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If an error is thrown by a call within the lexical scope of a ``try``!
-block or a ``try``! expression prefix, the program halts.
+If an error is thrown by a call within the lexical scope of a ``try!``
+block or a ``try!`` expression prefix, the program halts.
 
    *Example (try-bang.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -109,7 +109,7 @@ block or a ``try``! expression prefix, the program halts.
 Handling an error with catch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When an error is raised by a call in a ``try`` or ``try``! block, the
+When an error is raised by a call in a ``try`` or ``try!`` block, the
 rest of the block is abandoned and control flow is passed to its
 ``catch`` clause(s), if any.
 
@@ -118,7 +118,7 @@ rest of the block is abandoned and control flow is passed to its
 Catch clauses
 ^^^^^^^^^^^^^
 
-A ``try`` or ``try``! block can have one or more ``catch`` clauses.
+A ``try`` or ``try!`` block can have one or more ``catch`` clauses.
 
 A ``catch`` clause can specify the variable that refers to the caught
 error within the ``catch`` block. If the variable is given a type, for
@@ -141,7 +141,7 @@ statement after the ``try``-``catch`` blocks.
 
    *Example (catching-errors.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -169,12 +169,12 @@ statement after the ``try``-``catch`` blocks.
 try! with catch
 ^^^^^^^^^^^^^^^
 
-If an error is thrown within a ``try``! block and none of its ``catch``
+If an error is thrown within a ``try!`` block and none of its ``catch``
 clauses, if any, match that error, the program halts.
 
    *Example (catching-errors-halt.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -201,7 +201,7 @@ enclosing ``try`` block, when present.
 
    *Example (nested-try.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -220,7 +220,7 @@ enclosing ``try`` block, when present.
         }
       }
 
-   
+
 
    .. BLOCK-test-chapelpost
 
@@ -248,7 +248,7 @@ error raised in a ``try`` block.
 
    *Example (catching-errors-propagate.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -275,7 +275,7 @@ calls to clarify control flow.
 
    *Example (propagates-error.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -301,13 +301,13 @@ calls to clarify control flow.
 try expressions
 ^^^^^^^^^^^^^^^
 
-``try`` and ``try``! are available as expressions to clarify control
+``try`` and ``try!`` are available as expressions to clarify control
 flow at expression granularity. The expression form may not be used with
 ``catch`` clauses.
 
    *Example (expression-try.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -332,7 +332,7 @@ ways:
 
       *Example (warns-on-error.chpl)*.
 
-      
+
 
       .. code-block:: chapel
 
@@ -344,12 +344,12 @@ ways:
            }
          }
 
--  ``try``! instead of ``try``. This will halt the program if no
+-  ``try!`` instead of ``try``. This will halt the program if no
    matching ``catch`` clause is found, instead of propagating.
 
       *Example (halts-on-error.chpl)*.
 
-      
+
 
       .. code-block:: chapel
 
@@ -373,7 +373,7 @@ scope is exited, regardless of how it is exited.
 
    *Example (defer.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -409,7 +409,7 @@ throw if the overridden method does not throw.
 
    *Example (throwing-methods.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -436,7 +436,7 @@ will be propagated out of the ``on`` statement.
 
    *Example (handle-from-on.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -480,7 +480,7 @@ task.
 
    *Example (handle-from-begin.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -506,7 +506,7 @@ flattened ``TaskErrors`` error.
 
    *Example (handle-from-coforall.chpl)*.
 
-   
+
    .. BLOCK-test-chapelpre
 
      class DemoError : Error { }
@@ -602,7 +602,7 @@ the module documentation for :mod:`OS`.
 
    *Example (defining-errors.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -644,7 +644,7 @@ in the prototype mode:
 
    *Example (fatal-mode.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -660,7 +660,7 @@ in the prototype mode:
         alwaysThrows();
       }
 
-   
+
 
    .. BLOCK-test-chapelpost
 
@@ -676,7 +676,7 @@ prototype mode applies here, too.
 
    *Example (PrototypeModule.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -713,7 +713,7 @@ error will be propagated out, as with the prototype mode.
 
    *Example (ProductionModule.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 


### PR DESCRIPTION
This PR fixes the formatting of `try!` in the error-handling portion
of the language specification docs.

Previously, the bang was placed outside of the format indicators, so
it read like `try`! in the docs. This PR moves the bang inside the format
so it reads like `try!`

TESTING:

- [x] rebuilt docs and manually reviewed `language/spec/error-handling.html` in the browser

reviewed by @dlongnecke-cray - thank you!