### PR TITLE
Add async comm functions to GPU module

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -139,21 +139,25 @@ module GPU
   type GpuAsyncCommHandle = c_void_ptr;
 
   /*
-    Copy srcArr to dstArr, atleast one array must be on a GPU; this function
+    Copy srcArr to dstArr, at least one array must be on a GPU; this function
     can be used for either communication to or from the GPU
 
     Returns a handle that can be passed to `waitGpuComm` to pause execution
     until completion of this asyhcronous transfer
   */
   pragma "no doc"
-  proc asyncGpuComm(dstArr, srcArr) : GpuAsyncCommHandle {
+  proc asyncGpuComm(dstArr, srcArr) : GpuAsyncCommHandle
+  {
+    if(!isArrayType(dstArr.type) || !isArrayType(srcArr.type)) {
+      compilerError("Non-array argument passed to asyncGpuComm.");
+    }
+
     extern proc chpl_gpu_comm_async(dstArr : c_void_ptr, srcArr : c_void_ptr,
        n : c_size_t) : c_void_ptr;
 
     if(dstArr.size != srcArr.size) {
-      writeln("SIZE MISMATCH: ", dstArr.size, " ", srcArr.size);
+      halt("SIZE MISMATCH: ", dstArr.size, " ", srcArr.size);
     }
-    assert(dstArr.size == srcArr.size);
     return chpl_gpu_comm_async(c_ptrTo(dstArr), c_ptrTo(srcArr),
       dstArr.size * numBytes(dstArr.eltType));
  }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -146,21 +146,19 @@ module GPU
     until completion of this asyhcronous transfer
   */
   pragma "no doc"
-  proc asyncGpuComm(dstArr, srcArr) : GpuAsyncCommHandle
+  proc asyncGpuComm(dstArr : ?t1, srcArr : ?t2) : GpuAsyncCommHandle
+    where isArrayType(t1) && isArrayType(t2)
   {
-    if(!isArrayType(dstArr.type) || !isArrayType(srcArr.type)) {
-      compilerError("Non-array argument passed to asyncGpuComm.");
-    }
-
     extern proc chpl_gpu_comm_async(dstArr : c_void_ptr, srcArr : c_void_ptr,
        n : c_size_t) : c_void_ptr;
 
     if(dstArr.size != srcArr.size) {
-      halt("SIZE MISMATCH: ", dstArr.size, " ", srcArr.size);
+      halt("Arrays passed to asyncGpuComm must have the same number of elements. ",
+        "Sizes passed: ", dstArr.size, " and ", srcArr.size);
     }
     return chpl_gpu_comm_async(c_ptrTo(dstArr), c_ptrTo(srcArr),
       dstArr.size * numBytes(dstArr.eltType));
- }
+  }
 
   /*
      Wait for communication to complete, the handle passed in should be from the return

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -34,6 +34,8 @@
 @unstable "The GPU module is unstable and its interface is subject to change in the future."
 module GPU
 {
+  use CTypes;
+
   pragma "no doc"
   pragma "codegen for CPU and GPU"
   extern proc chpl_gpu_write(const str : c_string) : void;
@@ -131,5 +133,39 @@ module GPU
    */
   proc gpuClocksPerSec(devNum : int) {
     return chpl_gpu_device_clock_rate(devNum : int(32));
+  }
+
+  pragma "no doc"
+  type GpuAsyncCommHandle = c_void_ptr;
+
+  /*
+    Copy srcArr to dstArr, atleast one array must be on a GPU; this function
+    can be used for either communication to or from the GPU
+
+    Returns a handle that can be passed to `waitGpuComm` to pause execution
+    until completion of this asyhcronous transfer
+  */
+  pragma "no doc"
+  proc asyncGpuComm(dstArr, srcArr) : GpuAsyncCommHandle {
+    extern proc chpl_gpu_comm_async(dstArr : c_void_ptr, srcArr : c_void_ptr,
+       n : c_size_t) : c_void_ptr;
+
+    if(dstArr.size != srcArr.size) {
+      writeln("SIZE MISMATCH: ", dstArr.size, " ", srcArr.size);
+    }
+    assert(dstArr.size == srcArr.size);
+    return chpl_gpu_comm_async(c_ptrTo(dstArr), c_ptrTo(srcArr),
+      dstArr.size * numBytes(dstArr.eltType));
+ }
+
+  /*
+     Wait for communication to complete, the handle passed in should be from the return
+     value of a previous call to `asyncGpuComm`.
+  */
+  pragma "no doc"
+  proc gpuCommWait(gpuHandle : GpuAsyncCommHandle) {
+    extern proc chpl_gpu_comm_wait(stream : c_void_ptr);
+
+    chpl_gpu_comm_wait(gpuHandle);
   }
 }

--- a/runtime/include/chpl-gpu-impl.h
+++ b/runtime/include/chpl-gpu-impl.h
@@ -48,6 +48,9 @@ void chpl_gpu_impl_copy_host_to_device(void* dst, const void* src, size_t n);
 // this is all about copying within the same device that is on this subloc
 void chpl_gpu_impl_copy_device_to_device(void* dst, const void* src, size_t n);
 
+void* chpl_gpu_impl_comm_async(void *dst, void *src, size_t n);
+void chpl_gpu_impl_comm_wait(void *stream);
+
 // module code uses this to pick the right deallocator for a pointer
 bool chpl_gpu_impl_is_device_ptr(const void* ptr);
 

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -110,6 +110,8 @@ void chpl_gpu_mem_free(void* memAlloc, int32_t lineno, int32_t filename);
 void* chpl_gpu_memmove(void* dst, const void* src, size_t n);
 void chpl_gpu_copy_device_to_host(void* dst, const void* src, size_t n);
 void chpl_gpu_copy_host_to_device(void* dst, const void* src, size_t n);
+void* chpl_gpu_comm_async(void *dst, void *src, size_t n);
+void chpl_gpu_comm_wait(void *stream);
 
 bool chpl_gpu_is_device_ptr(const void* ptr);
 bool chpl_gpu_is_host_ptr(const void* ptr);

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -134,6 +134,18 @@ void chpl_gpu_copy_host_to_device(void* dst, const void* src, size_t n) {
   CHPL_GPU_DEBUG("Copy successful\n");
 }
 
+void* chpl_gpu_comm_async(void *dst, void *src, size_t n) {
+  assert(chpl_gpu_is_device_ptr(dst) || chpl_gpu_is_device_ptr(src));
+
+  CHPL_GPU_DEBUG("Copying %zu bytes asynchronously between host and device\n", n);
+
+  return chpl_gpu_impl_comm_async(dst, src, n);
+}
+
+void chpl_gpu_comm_wait(void *stream) {
+  chpl_gpu_impl_comm_wait(stream);
+}
+
 size_t chpl_gpu_get_alloc_size(void* ptr) {
   return chpl_gpu_impl_get_alloc_size(ptr);
 }

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -359,6 +359,19 @@ void chpl_gpu_impl_copy_device_to_device(void* dst, const void* src, size_t n) {
   CUDA_CALL(cuMemcpyDtoD((CUdeviceptr)dst, (CUdeviceptr)src, n));
 }
 
+
+void* chpl_gpu_impl_comm_async(void *dst, void *src, size_t n) {
+  CUstream stream;
+  cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING);
+  cuMemcpyAsync((CUdeviceptr)dst, (CUdeviceptr)src, n, stream);
+  return stream;
+}
+
+void chpl_gpu_impl_comm_wait(void *stream) {
+  cuStreamSynchronize((CUstream)stream);
+  cuStreamDestroy((CUstream)stream);
+}
+
 void* chpl_gpu_mem_array_alloc(size_t size, chpl_mem_descInt_t description,
                                int32_t lineno, int32_t filename) {
   chpl_gpu_ensure_context();

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.chpl
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.chpl
@@ -1,0 +1,209 @@
+use Time;
+use ResultDB;
+use IO.FormattedIO;
+use GPUDiagnostics;
+use Memory.Diagnostics;
+use GPU;
+
+config const passes = 1; //10;
+config const alpha = 1.75: real(32);
+config const noisy = false;
+config var tolerance = 1;
+config const output = true;
+config const perftest = false;
+
+proc main() {
+    var timer: stopwatch;
+    var kernelTimer: stopwatch;
+
+    // Numbers just copied from cuda version
+    // 256K through 8M bytes. (scaled down by 1024)
+    const blockSizes = if(perftest) then [64, 16384] else [64, /*128, 256, 512, 1024, 2048, 4096, 8192,*/ 16384];
+    param maxProblemSize = 16384;
+    param numMaxFloats = 1024 * maxProblemSize / numBytes(real(32));
+    param halfNumFloats = numMaxFloats/2;
+    const maxBlockSize = blockSizes.last * 1024 / numBytes(real(32));
+
+    var hos: [0..#numMaxFloats] real(32);
+    //startVerboseMem();
+    startGPUDiagnostics();
+
+    var flopsDB = new ResultDatabase("TriadFlops", "GFLOP/s");
+    var bdwthDB = new ResultDatabase("TriadBdwth", "GB/s");
+    var triadDB = new ResultDatabase("Triad Time", "sec");
+    var kernelDB = new ResultDatabase("Kernel Time", "sec");
+
+    var bwBlockSize64 = 0.0;
+    var bwBlockSize16384 = 0.0;
+
+    on here.gpus[0] {
+        var kernelLaunches = 0;
+
+        // Make A's
+        var A0 : [0..#maxBlockSize] real(32);
+        var A1 : [0..#maxBlockSize] real(32);
+
+        // ... Make B's and C's ....
+        var B0 : [0..#maxBlockSize] real(32);
+        var B1 : [0..#maxBlockSize] real(32);
+
+        var C0 : [0..#maxBlockSize] real(32);
+        var C1 : [0..#maxBlockSize] real(32);
+
+        // N passes determined by a config const
+        for pass in 0..#passes{
+            for blkSize in blockSizes {
+                // Populate host with arbitrary memory
+                // The reference (CUDA) implementation of SHOC fills hos
+                // with random values, in our implementation we fill with
+                // known sample values so we can later verify the result.
+                // This difference shouldn't impact performance.
+                for i in 0..#halfNumFloats {
+                    hos[i] = i:int(32)%16:int(32) + 0.12:real(32);
+                    hos[halfNumFloats+i] = hos[i] ;
+                }
+
+                // Number of floats that fit in the number of bytes denoted
+                // by problem size. Converting MB to Bytes and dividing by
+                // size of real(32)
+                var elemsInBlock = blkSize * 1024 / numBytes(real(32));
+
+                if noisy then
+                writeln(" >>> Executing Triad with arrays of length ", numMaxFloats,
+                        " and block size of ", elemsInBlock, " elements");
+
+                var A0, A1, B0, B1, C0, C1 : [0..<elemsInBlock] real(32);
+
+                timer.start();
+
+                var currentIdx = 0;
+                while(currentIdx + elemsInBlock <= numMaxFloats) {
+                  const blk0Range = currentIdx..#elemsInBlock;
+                  const blk1Range = (currentIdx+elemsInBlock)..#elemsInBlock;
+
+                  // Populate left hand synchronously
+                  A0 = hos[blk0Range];
+                  B0 = hos[blk0Range];
+
+                  // Populate right half of array in background
+                  var ev1, ev2 : GpuAsyncCommHandle;
+                  if(currentIdx + elemsInBlock*2 <= numMaxFloats) {
+                    ev1 = asyncGpuComm(A1, hos[blk1Range]);
+                    ev2 = asyncGpuComm(B1, hos[blk1Range]);
+                  }
+
+                  // Triad computation for left half
+                  foreach i in 0..<elemsInBlock {
+                    assertOnGpu();
+                    C0[i] = A0[i] + alpha * B0[i];
+                  }
+
+                  // Copy result back to host asynchronously
+                  var ev3 = asyncGpuComm(hos[blk0Range], C0);
+
+                  // Triad computation for right half
+                  if(currentIdx + elemsInBlock*2 <= numMaxFloats) {
+                    gpuCommWait(ev1);
+                    gpuCommWait(ev2);
+                    foreach i in 0..<elemsInBlock {
+                      assertOnGpu();
+                      C1[i] = A1[i] + alpha * B1[i];
+                    }
+                  }
+
+                  hos[blk1Range] = C1;
+                  gpuCommWait(ev3);
+
+                  currentIdx += (elemsInBlock*2);
+                }
+                timer.stop();
+
+                var timeElapsedInNanoseconds = timer.elapsed() * 1e9;
+                var triad = (numMaxFloats * 2.0) / timeElapsedInNanoseconds;
+                var bdwth = (numMaxFloats * numBytes(real(32)) * 3.0)
+                /timeElapsedInNanoseconds;
+
+                if noisy {
+                    writeln("TriadFlops\t",
+                    "Block",blkSize, "KB\t",
+                    "GFLOP/s\t",
+                    triad);
+
+                    writeln("TriadBdwth\t",
+                    "Block",blkSize, "KB\t",
+                    "GB/s\t",
+                    bdwth);
+
+                    writeln("Triad Time : ", timer.elapsed());
+                    writeln("Kernel Time : ", kernelTimer.elapsed());
+                    writeln("Kernel Launches : ", kernelLaunches);
+                }
+
+// The following will introduce the following error on program termination when built with
+// GPU_MEM_STRATEGY array_on_device
+//                flopsDB.addToDatabase("%{#####}".format(blkSize), triad);
+//                bdwthDB.addToDatabase("%{#####}".format(blkSize), bdwth);
+//                triadDB.addToDatabase("%{#####}".format(blkSize), timer.elapsed());
+//                kernelDB.addToDatabase("%{#####}".format(blkSize), kernelTimer.elapsed());
+
+                if(blkSize == 64) {
+                  bwBlockSize64 = bdwth;
+                } else {
+//                  assert(blkSize == 16384);
+                  bwBlockSize16384 = bdwth;
+                }
+
+                kernelLaunches = 0;
+                kernelTimer.clear();
+                timer.clear();
+
+                // Error Checking for the correct anwer
+                // Since we gave the kernel arbitrary numbers we know what the answer
+                // to the computation is
+                // The formula used to calculate the index i on hos was
+                // hos[i] = i%16 + 0.12;
+                // Therefore the numbers in host repeat the following sequence over
+                // and over: 0.12 1.12 2.12 3.12 4.12 5.12 6.12 7.12 8.12 9.12 10.12 11.12 12.12. 13.12. 14.12 15.12
+                // The computation was
+                // hos[i] = hos[i] * alpha + hos[i]
+                // Therefore the answers should be equal to that
+                // Each hos[i] after the computation is therefore as follows
+                // hos[i] = (i%16+0.12) * alpha + (i%16+0.12)
+                // The first expected answer, for example, will then be 0.12*1.75 + 0.12 = 0.33
+                // Remember this was only for half of the memory.
+                // The other half was just a copy of the first half
+                // Check that on the CPU instead of the GPU
+                for i in 0..#halfNumFloats {
+                    var expected:real(32) = (i:int(32)%16:int(32) + 0.12:real(32)) * alpha + (i:int(32)%16:int(32) + 0.12:real(32));
+                    var actual = hos[i];
+                    if(noisy && !isclose(actual, expected)) {
+                        writeln("Pass: ", pass,
+                        "\nBlock Size:", blkSize,
+                        "\nIndex: ", i,
+                        "\nExpected: ", expected, "\nActual: ", actual);
+                    }
+                    assert(isclose(actual , expected));
+                      assert(hos[halfNumFloats+i] == hos[i]);
+                    }
+            }
+        }
+    }
+
+    //stopVerboseMem();
+    if(output) {
+        flopsDB.printDatabaseStats();
+        bdwthDB.printDatabaseStats();
+        triadDB.printDatabaseStats();
+        kernelDB.printDatabaseStats();
+    }
+    if(perftest){
+//        bdwthDB.printPerfStats();
+//        triadDB.printPerfStats();
+//        kernelDB.printPerfStats();
+      writeln("BW block size 64 = ", bwBlockSize64, " GB/s");
+      writeln("BW block size 16384 = ", bwBlockSize16384, " GB/s");
+    }
+
+    stopGPUDiagnostics();
+    writeln(getGPUDiagnostics());
+}

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.compopts
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.compopts
@@ -1,0 +1,1 @@
+--fast --gpu-block-size=128 result.chpl

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.good
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.good
@@ -1,0 +1,1 @@
+(kernel_launch = 275)

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.gpu-keys
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.gpu-keys
@@ -1,0 +1,3 @@
+BW block size 64 =
+BW block size 16384 =
+verify:-1: (kernel_launch = 1351)

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodBw1.graph
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodBw1.graph
@@ -1,5 +1,5 @@
-perfkeys: BW block size 64 =
-files: triadAOD.dat
-graphkeys: Triad
+perfkeys: BW block size 64 =, BW block size 64 =
+files: triadAOD.dat, triadAodAsync.dat
+graphkeys: Triad, Async comm
 ylabel: Time (s)
 graphtitle: SHOC Triad (array on device) - Bandwidth - 64KB

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodBw2.graph
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodBw2.graph
@@ -1,5 +1,5 @@
-perfkeys: BW block size 16384 =
-files: triadAOD.dat
-graphkeys: Triad
+perfkeys: BW block size 16384 =, BW block size 16384 =
+files: triadAOD.dat, triadAodAsync.dat
+graphkeys: Triad, Async comm
 ylabel: Time (s)
 graphtitle: SHOC Triad (array on device) - Bandwidth - 16384KB


### PR DESCRIPTION
This PR:

* adds a couple of functions to the GPU module that can be used to perform asynchronous communication: `asyncGpuComm` and `gpuCommWait`
* adds a version of the `array_on_device` version of SHOC triad that uses these new functions

For the time being I no doc these functions as we may wish to change their design in the near future. Nevertheless I'd like to have this feature submitted so that we have some groundwork set and can explore its impact on performance.