### PR TITLE
Add COMPOPTS and EXECENV for HDF5 tests

### DIFF
--- a/test/library/packages/HDF5.skipif
+++ b/test/library/packages/HDF5.skipif
@@ -2,7 +2,7 @@
 
 # The HDF5 package requires the hdf5 library.
 
-if h5cc -showconfig 2>&1 | grep -q 'High-level library: yes' ; then
+if h5cc -showconfig 2>&1 | grep 'High-level library: ' | grep -q 'yes\|ON' ; then
   echo 'False'
 else
   echo 'True'

--- a/test/library/packages/HDF5/COMPOPTS
+++ b/test/library/packages/HDF5/COMPOPTS
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+INSTALL_DIR=`h5cc -showconfig | sed -n -e 's/ *Installation point: \(.*\)/\1/p'`
+INC_FLAGS="-I$INSTALL_DIR/include"
+LIB_FLAGS="-L$INSTALL_DIR/lib -lhdf5"
+
+
+echo $INC_FLAGS $LIB_FLAGS

--- a/test/library/packages/HDF5/EXECENV
+++ b/test/library/packages/HDF5/EXECENV
@@ -2,4 +2,4 @@
 
 INSTALL_DIR=`h5cc -showconfig | sed -n -e 's/ *Installation point: \(.*\)/\1/p'`
 
-echo "LD_LIBRARY_PATH=$INSTALL_DIR/lib"
+echo "LD_LIBRARY_PATH=$INSTALL_DIR/lib:LD_LIBRARY_PATH"

--- a/test/library/packages/HDF5/EXECENV
+++ b/test/library/packages/HDF5/EXECENV
@@ -2,4 +2,4 @@
 
 INSTALL_DIR=`h5cc -showconfig | sed -n -e 's/ *Installation point: \(.*\)/\1/p'`
 
-echo "LD_LIBRARY_PATH=$INSTALL_DIR/lib:LD_LIBRARY_PATH"
+echo "LD_LIBRARY_PATH=$INSTALL_DIR/lib:$LD_LIBRARY_PATH"

--- a/test/library/packages/HDF5/EXECENV
+++ b/test/library/packages/HDF5/EXECENV
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+INSTALL_DIR=`h5cc -showconfig | sed -n -e 's/ *Installation point: \(.*\)/\1/p'`
+
+echo "LD_LIBRARY_PATH=$INSTALL_DIR/lib"


### PR DESCRIPTION
Add a COMPOPTS to set include directories and lib directories for HDF5 and add -lhdf5 to the compile command.

Add an EXECENV to set the LD_LIBRARY_PATH for HDF5.

Update the directory-wide .skipif file to make it work with both XC systems and chapdl.