### PR TITLE
Fix a docs link to user-defined reductions page

### DIFF
--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -746,7 +746,7 @@ reduction applied to all of the elements in the aggregate up to that
 expression. Chapel provides a number of predefined reduction and scan
 operators, and also supports a mechanism for the user to define
 additional reductions and scans
-(Chapter `[User_Defined_Reductions_and_Scans] <#User_Defined_Reductions_and_Scans>`__).
+(:ref:`Chapter-User_Defined_Reductions_and_Scans`).
 
 .. _reduce:
 


### PR DESCRIPTION
Fixes an invalid link under [Reductions and Scans](https://chapel-lang.org/docs/1.29/language/spec/data-parallelism.html#reductions-and-scans) to the page on [User-Defined Reductions and Scans](https://chapel-lang.org/docs/1.29/language/spec/user-defined-reductions-and-scans.html#chapter-user-defined-reductions-and-scans).

[trivial, not reviewed]