### PR TITLE
Resolve task/loop intents in Dyno

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3136,13 +3136,16 @@ static bool computeTaskIntentInfo(Resolver& resolver, const NamedDecl* intent,
 }
 
 bool Resolver::enter(const ReduceIntent* reduce) {
-
   ID id;
   QualifiedType type;
   ResolvedExpression& result = byPostorder.byAst(reduce);
 
   if (computeTaskIntentInfo(*this, reduce, id, type)) {
     validateAndSetToId(result, reduce, id);
+    // set reduce intent shadow variable to a VAR with type of shadowed variable
+    QualifiedType reduceIntentType =
+        QualifiedType(QualifiedType::Kind::VAR, type.type());
+    result.setType(reduceIntentType);
   } else if (!scopeResolveOnly) {
     context->error(reduce, "Unable to find declaration of \"%s\" for reduction", reduce->name().c_str());
   }
@@ -3292,6 +3295,7 @@ bool Resolver::enter(const uast::Reduce* reduce) {
 void Resolver::exit(const uast::Reduce* reduce) {
 }
 
+// helper to determine if a TaskVar is a task intent
 static bool isTaskIntent(const TaskVar* taskVar) {
   return taskVar->typeExpression() == nullptr &&
          taskVar->initExpression() == nullptr;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3290,13 +3290,15 @@ bool Resolver::enter(const uast::Reduce* reduce) {
 }
 
 void Resolver::exit(const uast::Reduce* reduce) {
+}
 
+static bool isTaskIntent(const TaskVar* taskVar) {
+  return taskVar->typeExpression() == nullptr &&
+         taskVar->initExpression() == nullptr;
 }
 
 bool Resolver::enter(const TaskVar* taskVar) {
-  const bool isTaskIntent = taskVar->typeExpression() == nullptr &&
-                            taskVar->initExpression() == nullptr;
-  if (isTaskIntent) {
+  if (isTaskIntent(taskVar)) {
     ID id;
     QualifiedType type;
     ResolvedExpression& result = byPostorder.byAst(taskVar);
@@ -3316,10 +3318,9 @@ bool Resolver::enter(const TaskVar* taskVar) {
     return true;
   }
 }
+
 void Resolver::exit(const TaskVar* taskVar) {
-  const bool isTaskIntent = taskVar->typeExpression() == nullptr &&
-                            taskVar->initExpression() == nullptr;
-  if (isTaskIntent == false) {
+  if (!isTaskIntent(taskVar)) {
     exitScope(taskVar);
   }
 }

--- a/frontend/test/resolution/testTaskIntents.cpp
+++ b/frontend/test/resolution/testTaskIntents.cpp
@@ -321,14 +321,13 @@ var x = 0;
 })""";
 
   auto col = customHelper(program, context);
-  /* const auto intType = IntType::get(context, 0); */
 
   // Test shadow variable type is as expected
-  // TODO: currently fails
   {
-    /* QualifiedType expected = QualifiedType(Qualifier::VAR, intType); */
-    /* QualifiedType shadowX = col.onlyShadow("x"); */
-    /* assert(expected == shadowX); */
+    const auto intType = IntType::get(context, 0);
+    QualifiedType expected = QualifiedType(Qualifier::VAR, intType);
+    QualifiedType shadowX = col.onlyShadow("x").type();
+    assert(expected == shadowX);
   }
 
   // Test that the shadow variable points to the original
@@ -353,7 +352,6 @@ static void testReduce() {
 
 //
 // TODO:
-// - type resolution for reduce-intents
 // - implicit shadow variables (flat, nested)
 // - reduce intents for begin/cobegin, if those are implemented in future
 //

--- a/frontend/test/resolution/testTaskIntents.cpp
+++ b/frontend/test/resolution/testTaskIntents.cpp
@@ -364,8 +364,6 @@ static void testReduce() {
 //
 // TODO:
 // - type resolution for reduce-intents
-// - type resolution for `in` task-intents
-// - const-checking
 // - implicit shadow variables (flat, nested)
 // - reduce intents for begin/cobegin, if those are implemented in future
 //

--- a/frontend/test/resolution/testTaskIntents.cpp
+++ b/frontend/test/resolution/testTaskIntents.cpp
@@ -354,6 +354,7 @@ static void testReduce() {
 // TODO:
 // - implicit shadow variables (flat, nested)
 // - reduce intents for begin/cobegin, if those are implemented in future
+// - type resolve in-intents where type can change (e.g. array slices)
 //
 int main(int argc, char** argv) {
   for (int i = 1; i < argc; i++) {


### PR DESCRIPTION
Type resolve shadow variable in reduce intents, and improve resolution testing for reduce and task/loop intents.

Type resolution for task/loop intents besides reduce intents was already implemented, so the main thing this PR adds is resolution for reduce intents.

Type resolution of `in` intents where type can change, such as array slices, is not implemented in this PR.

Resolves https://github.com/Cray/chapel-private/issues/2716.

Testing:
- [x] paratest with `--dyno` on this branch vs `main` have same failures
- [x] dyno tests