### PR TITLE
Skip this test under valgrind

### DIFF
--- a/test/library/standard/IO/initWithCFile/errorCase.chpl
+++ b/test/library/standard/IO/initWithCFile/errorCase.chpl
@@ -4,6 +4,8 @@ module m {
   use IO;
   use CTypes;
 
+  // If this test starts randomly segfaulting due to touching bad memory, it's
+  // okay to remove it
   extern proc openTestFile(): c_FILE;
 
   try! {

--- a/test/library/standard/IO/initWithCFile/errorCase.skipif
+++ b/test/library/standard/IO/initWithCFile/errorCase.skipif
@@ -1,0 +1,2 @@
+# don't run with valgrind, we're intentionally messing with bad memory
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Valgrind complains about trying to access memory that has been free'd, but
that's a case we're intentionally trying to test, so it's okay not to worry
about it.

I was seeing a segfault with valgrind on Mac - if that proves to be symptomatic
of a broader problem, we should remove the test.  Leave a note on the test
indicating it is okay to remove it.

Double checked that a fresh checkout behaved as expected.  Discussed with
Jeremiah.