### PR TITLE
Move and rename newBlockDist/newBlockArr and newCyclicDist/newCyclicArr

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -256,10 +256,10 @@ domain or array.
 
     use BlockDist;
 
-    var BlockDom1 = newBlockDom({1..5, 1..5});
-    var BlockArr1 = newBlockArr({1..5, 1..5}, real);
-    var BlockDom2 = newBlockDom(1..5, 1..5);
-    var BlockArr2 = newBlockArr(1..5, 1..5, real);
+    var BlockDom1 = Block.createDomain({1..5, 1..5});
+    var BlockArr1 = Block.createArray({1..5, 1..5}, real);
+    var BlockDom2 = Block.createDomain(1..5, 1..5);
+    var BlockArr2 = Block.createArray(1..5, 1..5, real);
 
 **Data-Parallel Iteration**
 
@@ -731,6 +731,24 @@ iter Block.activeTargetLocales(const space : domain = boundingBox) {
     if locSpace[(...chunk)].sizeAs(int) > 0 then
       yield i;
   }
+}
+
+proc type Block.createDomain(dom: domain) {
+  return dom dmapped Block(dom);
+}
+
+proc type Block.createDomain(rng: range...) {
+  return createDomain({(...rng)});
+}
+
+proc type Block.createArray(dom: domain, type eltType) {
+  var D = createDomain(dom);
+  var A: [D] eltType;
+  return A;
+}
+
+proc type Block.createArray(rng: range..., type eltType) {
+  return createArray({(...rng)}, eltType);
 }
 
 proc chpl__computeBlock(locid, targetLocBox:domain, boundingBox:domain,
@@ -1886,23 +1904,26 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
   return res;
 }
 
-
 ////// Factory functions ////////////////////////////////////////////////////
 
+deprecated "'newBlockDom' is deprecated - please use 'Block.createDomain' instead"
 proc newBlockDom(dom: domain) {
   return dom dmapped Block(dom);
 }
 
+deprecated "'newBlockArr' is deprecated - please use 'Block.createArray' instead"
 proc newBlockArr(dom: domain, type eltType) {
   var D = newBlockDom(dom);
   var A: [D] eltType;
   return A;
 }
 
+deprecated "'newBlockDom' is deprecated - please use 'Block.createDomain' instead"
 proc newBlockDom(rng: range...) {
   return newBlockDom({(...rng)});
 }
 
+deprecated "'newBlockArr' is deprecated - please use 'Block.createArray' instead"
 proc newBlockArr(rng: range..., type eltType) {
   return newBlockArr({(...rng)}, eltType);
 }

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -160,10 +160,10 @@ domain or array.
 
     use CyclicDist;
 
-    var CyclicDom1 = newCyclicDom({1..5, 1..5});
-    var CyclicArr1 = newCyclicArr({1..5, 1..5}, real);
-    var CyclicDom2 = newCyclicDom(1..5, 1..5);
-    var CyclicArr2 = newCyclicArr(1..5, 1..5, real);
+    var CyclicDom1 = Cyclic.createDomain({1..5, 1..5});
+    var CyclicArr1 = Cyclic.createArray({1..5, 1..5}, real);
+    var CyclicDom2 = Cyclic.createDomain(1..5, 1..5);
+    var CyclicArr2 = Cyclic.createArray(1..5, 1..5, real);
 
 
 **Data-Parallel Iteration**
@@ -1254,6 +1254,24 @@ proc Cyclic.dsiTargetLocales() const ref {
   return targetLocs;
 }
 
+proc type Cyclic.createDomain(dom: domain) {
+  return dom dmapped Cyclic(startIdx=dom.lowBound);
+}
+
+proc type Cyclic.createDomain(rng: range...) {
+  return createDomain({(...rng)});
+}
+
+proc type Cyclic.createArray(dom: domain, type eltType) {
+  var D = createDomain(dom);
+  var A: [D] eltType;
+  return A;
+}
+
+proc type Cyclic.createArray(rng: range..., type eltType) {
+  return createArray({(...rng)}, eltType);
+}
+
 // Cyclic subdomains are represented as a single domain
 
 proc CyclicArr.dsiHasSingleLocalSubdomain() param return true;
@@ -1281,20 +1299,24 @@ proc CyclicDom.dsiLocalSubdomain(loc: locale) {
   }
 }
 
+deprecated "'newCyclicDom' is deprecated - please use 'Cyclic.createDomain' instead"
 proc newCyclicDom(dom: domain) {
   return dom dmapped Cyclic(startIdx=dom.lowBound);
 }
 
+deprecated "'newCyclicArr' is deprecated - please use 'Cyclic.createArray' instead"
 proc newCyclicArr(dom: domain, type eltType) {
   var D = newCyclicDom(dom);
   var A: [D] eltType;
   return A;
 }
 
+deprecated "'newCyclicDom' is deprecated - please use 'Cyclic.createDomain' instead"
 proc newCyclicDom(rng: range...) {
   return newCyclicDom({(...rng)});
 }
 
+deprecated "'newCyclicArr' is deprecated - please use 'Cyclic.createArray' instead"
 proc newCyclicArr(rng: range..., type eltType) {
   return newCyclicArr({(...rng)}, eltType);
 }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2299,7 +2299,7 @@ module TwoArrayPartitioning {
     type bucketizerType;
 
     var numLocales:int;
-    var perLocale = newBlockArr(0..#numLocales,
+    var perLocale = Block.createArray(0..#numLocales,
         TwoArrayDistributedBucketizerStatePerLocale(bucketizerType));
 
     const baseCaseSize:int;
@@ -2797,7 +2797,7 @@ module TwoArrayPartitioning {
                                startbit,
                                0, state1.numLocales-1);
     var nextDistTaskElts: list(TwoArrayDistSortPerBucketTask, parSafe=true);
-    var smallTasksPerLocale = newBlockArr(0..#numLocales,
+    var smallTasksPerLocale = Block.createArray(0..#numLocales,
                                           list(TwoArraySortTask, parSafe=true));
 
     assert(!distTask.isEmpty());

--- a/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.chpl
+++ b/test/arrays/ferguson/array-initialization-patterns/array-initialization-patterns-dists.chpl
@@ -61,9 +61,9 @@ proc makeInitialArray() {
     var ret: [1..1] int;
     return ret;
   } else if distType == DistType.block {
-    return newBlockArr(1..1, int);
+    return Block.createArray(1..1, int);
   } else if distType == DistType.cyclic {
-    return newCyclicArr(1..1, int);
+    return Cyclic.createArray(1..1, int);
   } else if distType == DistType.blockcyclic {
     var D = {1..1} dmapped BlockCyclic(startIdx=(1,), (3,));
     var ret: [D] int;

--- a/test/arrays/ferguson/array-initialization-patterns/post-alloc-dists.chpl
+++ b/test/arrays/ferguson/array-initialization-patterns/post-alloc-dists.chpl
@@ -18,9 +18,9 @@ proc makeA() {
     var ret: [1..1] int;
     return ret;
   } else if distType == DistType.block {
-    return newBlockArr(1..1, int);
+    return Block.createArray(1..1, int);
   } else if distType == DistType.cyclic {
-    return newCyclicArr(1..1, int);
+    return Cyclic.createArray(1..1, int);
   } else if distType == DistType.blockcyclic {
     var D = {1..1} dmapped BlockCyclic(startIdx=(1,), (3,));
     var ret: [D] int;

--- a/test/arrays/slices/localSliceDRSlice.chpl
+++ b/test/arrays/slices/localSliceDRSlice.chpl
@@ -25,7 +25,7 @@ module Spam {
       {
         const Space = {0..#16};
         var A: [Space] int = Space;
-        var distA = newBlockArr(Space, int);
+        var distA = Block.createArray(Space, int);
         distA = A;
 
         sliceAndDice(getRoutineName(), getLineNumber(), A);
@@ -36,7 +36,7 @@ module Spam {
       {
         const Space = {1..4, 1..4};
         var A: [Space] int = [(i,j) in Space] (i-1)*4 + j;
-        var distA = newBlockArr(Space, int);
+        var distA = Block.createArray(Space, int);
         distA = A;
 
         sliceAndDice(getRoutineName(), getLineNumber(), A);

--- a/test/arrays/slices/sliceUsesDom-locality.chpl
+++ b/test/arrays/slices/sliceUsesDom-locality.chpl
@@ -3,7 +3,7 @@ use BlockDist;
 var D = {1..9, 1..9};
 var SubD = {4..6, 4..6};
 
-var DB = newBlockDom(D);
+var DB = Block.createDomain(D);
 var SubDB = DB[SubD];
 
 testit(D, SubD);

--- a/test/arrays/slices/sliceUsesDom.chpl
+++ b/test/arrays/slices/sliceUsesDom.chpl
@@ -3,7 +3,7 @@ use BlockDist;
 var D = {1..9, 1..9};
 var SubD = {2..4, 2..4};
 
-var DB = newBlockDom(D);
+var DB = Block.createDomain(D);
 var SubDB = DB[SubD];
 
 testit(D);

--- a/test/arrays/views/viewDomBug.chpl
+++ b/test/arrays/views/viewDomBug.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var blockDom = newBlockDom(3..8);
+var blockDom = Block.createDomain(3..8);
 var localArr: [1..10] int;
 
 ref slice = localArr[blockDom];

--- a/test/deprecated/distFuncs.chpl
+++ b/test/deprecated/distFuncs.chpl
@@ -1,0 +1,25 @@
+use BlockDist;
+use CyclicDist;
+var rng = (1..10, 1..10);
+var D = {(...rng)};
+
+// Old way:
+var BD1 = newBlockDom(D);
+var BA1 = newBlockArr(D, int);
+var BD2 = newBlockDom((...rng));
+var BA2 = newBlockArr((...rng), int);
+
+var CD1 = newCyclicDom(D);
+var CA1 = newCyclicArr(D, int);
+var CD2 = newCyclicDom((...rng));
+var CA2 = newCyclicArr((...rng), int);
+
+// New way:
+var newBD1 = Block.createDomain(D);
+var newBA1 = Block.createArray(D, int);
+var newBD2 = Block.createDomain((...rng));
+var newBA2 = Block.createArray((...rng), int);
+var newCD1 = Cyclic.createDomain(D);
+var newCA1 = Cyclic.createArray(D, int);
+var newCD2 = Cyclic.createDomain((...rng));
+var newCA2 = Cyclic.createArray((...rng), int);

--- a/test/deprecated/distFuncs.good
+++ b/test/deprecated/distFuncs.good
@@ -1,0 +1,8 @@
+distFuncs.chpl:7: warning: 'newBlockDom' is deprecated - please use 'Block.createDomain' instead
+distFuncs.chpl:8: warning: 'newBlockArr' is deprecated - please use 'Block.createArray' instead
+distFuncs.chpl:9: warning: 'newBlockDom' is deprecated - please use 'Block.createDomain' instead
+distFuncs.chpl:10: warning: 'newBlockArr' is deprecated - please use 'Block.createArray' instead
+distFuncs.chpl:12: warning: 'newCyclicDom' is deprecated - please use 'Cyclic.createDomain' instead
+distFuncs.chpl:13: warning: 'newCyclicArr' is deprecated - please use 'Cyclic.createArray' instead
+distFuncs.chpl:14: warning: 'newCyclicDom' is deprecated - please use 'Cyclic.createDomain' instead
+distFuncs.chpl:15: warning: 'newCyclicArr' is deprecated - please use 'Cyclic.createArray' instead

--- a/test/distributions/diten/testBlockUtilityFns.chpl
+++ b/test/distributions/diten/testBlockUtilityFns.chpl
@@ -2,10 +2,10 @@ use BlockDist;
 var rng = (1..10, 1..10);
 var D = {(...rng)};
 
-var BD1 = newBlockDom(D);
-var BA1 = newBlockArr(D, int);
-var BD2 = newBlockDom((...rng));
-var BA2 = newBlockArr((...rng), int);
+var BD1 = Block.createDomain(D);
+var BA1 = Block.createArray(D, int);
+var BD2 = Block.createDomain((...rng));
+var BA2 = Block.createArray((...rng), int);
 
 printLocales(BD1);
 writeln();

--- a/test/distributions/diten/testCyclicUtilityFns.chpl
+++ b/test/distributions/diten/testCyclicUtilityFns.chpl
@@ -2,10 +2,10 @@ use CyclicDist;
 var rng = (1..10, 1..10);
 var D = {(...rng)};
 
-var CD1 = newCyclicDom(D);
-var CA1 = newCyclicArr(D, int);
-var CD2 = newCyclicDom((...rng));
-var CA2 = newCyclicArr((...rng), int);
+var CD1 = Cyclic.createDomain(D);
+var CA1 = Cyclic.createArray(D, int);
+var CD2 = Cyclic.createDomain((...rng));
+var CA2 = Cyclic.createArray((...rng), int);
 
 printLocales(CD1);
 writeln();

--- a/test/distributions/sparseBlock/standaloneIter.chpl
+++ b/test/distributions/sparseBlock/standaloneIter.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var A = newBlockArr({1..10 by 2, 2..10 by 2}, real);
+var A = Block.createArray({1..10 by 2, 2..10 by 2}, real);
 var DS: sparse subdomain(A.domain);
 var AS: [DS] real;
 

--- a/test/domains/bradc/stringCast.chpl
+++ b/test/domains/bradc/stringCast.chpl
@@ -1,8 +1,8 @@
 use BlockDist, CyclicDist, ReplicatedDist;
 
 const D = {1..10};
-const BD = newBlockDom({1..11});
-const CD = newCyclicDom({1..12});
+const BD = Block.createDomain({1..11});
+const CD = Cyclic.createDomain({1..12});
 const RD = {1..13} dmapped Replicated();
 var SD: sparse subdomain(D);
 for i in 1..10 do

--- a/test/errhandling/parallel/forall-calls-throwing-fn2.chpl
+++ b/test/errhandling/parallel/forall-calls-throwing-fn2.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var A = newBlockArr({1..10}, real);
+var A = Block.createArray({1..10}, real);
 
 proc throwingFunction() throws {
   throw new owned Error("die!");

--- a/test/extern/bradc/blockToExtern.chpl
+++ b/test/extern/bradc/blockToExtern.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var B = newBlockArr({1..10}, real);
+var B = Block.createArray({1..10}, real);
 
 extern proc cprintarr(X: [] real);
 

--- a/test/io/diten/testCheckpoint.chpl
+++ b/test/io/diten/testCheckpoint.chpl
@@ -5,7 +5,7 @@ config const filename = "myBlockArr.bin";
 
 config const m = 5, n = 4;
 
-var Dom = newBlockDom({1..m, 1..n});
+var Dom = Block.createDomain({1..m, 1..n});
 
 var A: [Dom] int;
 

--- a/test/io/ferguson/json-distributed-arrays.chpl
+++ b/test/io/ferguson/json-distributed-arrays.chpl
@@ -29,7 +29,7 @@ var expectfile = openMemFile();
 
 {
   writeln("Testing block array");
-  var A = newBlockArr({1..5}, int);
+  var A = Block.createArray({1..5}, int);
   A = 1..5;
 
   writef("%jt\n", A);
@@ -45,7 +45,7 @@ var expectfile = openMemFile();
 
 {
   writeln("Testing cyclic array");
-  var A = newCyclicArr({1..5}, int);
+  var A = Cyclic.createArray({1..5}, int);
   A = 1..5;
 
   writef("%jt\n", A);

--- a/test/library/draft/DistributedMap/use-distributed-map.chpl
+++ b/test/library/draft/DistributedMap/use-distributed-map.chpl
@@ -54,7 +54,7 @@ verify(dm2, "check2");
 // randomStrings: generate random strings from "-32768" to "32767"
 
 record randomStrings {
-  const dom    = newBlockDom({0..#numStrings});
+  const dom    = Block.createDomain({0..#numStrings});
   const seed   = defaultSeed;
   const stream = createRandomStream(stringsType, seed, parSafe=false);
 

--- a/test/library/packages/HDF5/parallelHdf5WriteSingleFile.chpl
+++ b/test/library/packages/HDF5/parallelHdf5WriteSingleFile.chpl
@@ -6,7 +6,7 @@ proc main {
   use Hdf5PathHelp;
 
   const pathPrefix = readPrefixEnv();
-  var A = newBlockArr({1..100, 1..100}, c_int);
+  var A = Block.createArray({1..100, 1..100}, c_int);
 
   for (i,j) in A.domain {
     A[i,j] = (i*1000+j): c_int;
@@ -16,7 +16,7 @@ proc main {
   hdf5WriteDistributedArray(A, pathPrefix + fileName, dsetName);
   writeln("Wrote array");
 
-  var B = newBlockArr({1..100, 1..100}, c_int);
+  var B = Block.createArray({1..100, 1..100}, c_int);
   writeln("Reading array");
   hdf5ReadDistributedArray(B, pathPrefix + fileName, dsetName);
   writeln("Read array");

--- a/test/library/packages/HDF5/readDistribMultipleFiles/distribReader.chpl
+++ b/test/library/packages/HDF5/readDistribMultipleFiles/distribReader.chpl
@@ -145,7 +145,7 @@ proc main() {
   // Declare the distributed array that holds the same number of elements
   // as all of the files involved combined.
   const bbox = {0..#numElements};
-  const blockDom = newBlockDom(bbox);
+  const blockDom = Block.createDomain(bbox);
   var blockArr: [blockDom] eltType;
 
   // Read the files into the distributed array

--- a/test/library/packages/LinearAlgebra/correctness/testIsDistributed.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/testIsDistributed.chpl
@@ -4,7 +4,7 @@ use BlockDist;
 use LayoutCS;
 
 
-var distArr = newBlockArr({1..10}, int);
+var distArr = Block.createArray({1..10}, int);
 var sliceOfDist = distArr[1..8];
 var locArr: [1..8] int;
 

--- a/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
+++ b/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
@@ -14,7 +14,7 @@ proc simpletestcore(input:[]) {
   var localCopy = input;
   shuffle(localCopy, seed);
 
-  const blockDom = newBlockDom(input.domain);
+  const blockDom = Block.createDomain(input.domain);
   var A: [blockDom] uint = localCopy;
 
   if debug {
@@ -65,7 +65,7 @@ simpletest([0x01:uint,
 
 
 proc randomtest(n:int) {
-  const blockDom = newBlockDom({0..#n});
+  const blockDom = Block.createDomain({0..#n});
   var A: [blockDom] uint;
   var seed = SeedGenerator.oddCurrentTime;
   fillRandom(A, seed);

--- a/test/library/packages/Sort/RadixSort/ips4o-like.chpl
+++ b/test/library/packages/Sort/RadixSort/ips4o-like.chpl
@@ -1836,7 +1836,7 @@ proc simpletestcore(input:[], seed:int) {
   var localCopy = input;
   shuffle(localCopy, seed);
 
-  const blockDom = input.domain; //newBlockDom(input.domain);
+  const blockDom = input.domain; //Block.createDomain(input.domain);
   var A: [blockDom] uint = localCopy;
 
   assert(isSorted(input));
@@ -1897,7 +1897,7 @@ simpletest([0xda524a179483bc7:uint,
             0xde0546a7b5c06e9:uint]);
 
 proc randomtest(n:int) {
-  const blockDom = {0..#n}; //newBlockDom({0..#n});
+  const blockDom = {0..#n}; //Block.createDomain({0..#n});
   var A: [blockDom] uint;
 
   if skew {

--- a/test/library/packages/Sort/performance/dist-performance.chpl
+++ b/test/library/packages/Sort/performance/dist-performance.chpl
@@ -68,7 +68,7 @@ inline proc endDiag(name, x) {
 }
 
 proc main() {
-  var A = newBlockArr({1..nElems}, elemType);
+  var A = Block.createArray({1..nElems}, elemType);
   fillRandom(A, seed=314159265);
 
   startDiag();

--- a/test/optimizations/autoAggregation/aggWithLocalAccess.chpl
+++ b/test/optimizations/autoAggregation/aggWithLocalAccess.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var distArr = newBlockArr(0..9, int);
+var distArr = Block.createArray(0..9, int);
 var localArr: [0..9] int;
 
 distArr = 3;

--- a/test/optimizations/autoAggregation/arrElemFromAlignedFollower.chpl
+++ b/test/optimizations/autoAggregation/arrElemFromAlignedFollower.chpl
@@ -2,7 +2,7 @@ writeln();
 
 use BlockDist;
 
-var dom = newBlockDom(0..10);
+var dom = Block.createDomain(0..10);
 
 var a: [dom] int, b: [dom] int;
 

--- a/test/optimizations/autoAggregation/arrElemFromDynFastFollower.chpl
+++ b/test/optimizations/autoAggregation/arrElemFromDynFastFollower.chpl
@@ -1,8 +1,8 @@
 use BlockDist;
 
-var A = newBlockArr(0..10, int);
-var B = newBlockArr(0..10, int);
-var someOther = newBlockArr(0..10, int);
+var A = Block.createArray(0..10, int);
+var B = Block.createArray(0..10, int);
+var someOther = Block.createArray(0..10, int);
 
 // B is a dynamic fast follower, so we should be able to see `b` as local within
 // the fast follower body, and source-aggregate

--- a/test/optimizations/autoAggregation/arrTypes.chpl
+++ b/test/optimizations/autoAggregation/arrTypes.chpl
@@ -2,7 +2,7 @@ use BlockDist;
 
 config type elemType = int;
 
-var A = newBlockArr(0..10, elemType);
+var A = Block.createArray(0..10, elemType);
 
 forall (a, i) in zip(A, A.domain) {
   a = A[10-i];

--- a/test/optimizations/autoAggregation/basicDestAgg.chpl
+++ b/test/optimizations/autoAggregation/basicDestAgg.chpl
@@ -2,8 +2,8 @@ writeln();
 
 use BlockDist;
 
-var a = newBlockArr(0..10, int);
-var b = newBlockArr(0..10, int);
+var a = Block.createArray(0..10, int);
+var b = Block.createArray(0..10, int);
 
 for i in a.domain {
   a[i] = i;

--- a/test/optimizations/autoAggregation/basicSourceAgg.chpl
+++ b/test/optimizations/autoAggregation/basicSourceAgg.chpl
@@ -2,8 +2,8 @@ writeln();
 
 use BlockDist;
 
-var a = newBlockArr(0..10, int);
-var b = newBlockArr(0..10, int);
+var a = Block.createArray(0..10, int);
+var b = Block.createArray(0..10, int);
 
 for i in b.domain {
   b[i] = i;

--- a/test/optimizations/autoAggregation/bothLocal.chpl
+++ b/test/optimizations/autoAggregation/bothLocal.chpl
@@ -1,9 +1,9 @@
 use BlockDist;
 use CyclicDist;
 
-var a = newBlockArr(0..10, int);
-var b = newBlockArr(0..10, int);
-var c = newCyclicArr(0..10, int);
+var a = Block.createArray(0..10, int);
+var b = Block.createArray(0..10, int);
+var c = Cyclic.createArray(0..10, int);
 
 for i in b.domain {
   b[i] = i;

--- a/test/optimizations/autoAggregation/childNotAggregatable.chpl
+++ b/test/optimizations/autoAggregation/childNotAggregatable.chpl
@@ -1,7 +1,7 @@
 use BlockDist;
 
-var a = newBlockArr(0..10, int);
-var b = newBlockArr(0..10, int);
+var a = Block.createArray(0..10, int);
+var b = Block.createArray(0..10, int);
 
 for i in b.domain {
   b[i] = i;

--- a/test/optimizations/autoAggregation/domElemFromAlignedFollower.chpl
+++ b/test/optimizations/autoAggregation/domElemFromAlignedFollower.chpl
@@ -2,7 +2,7 @@ writeln();
 
 use BlockDist;
 
-var dom = newBlockDom(0..10);
+var dom = Block.createDomain(0..10);
 
 var a: [dom] int, b: [dom] int;
 

--- a/test/optimizations/autoAggregation/dynamicallyAlignedFollowers.chpl
+++ b/test/optimizations/autoAggregation/dynamicallyAlignedFollowers.chpl
@@ -1,9 +1,9 @@
 use BlockDist;
 
-var dom = newBlockDom(0..10);
+var dom = Block.createDomain(0..10);
 var a: [dom] int;
 var b: [dom] int;
-var c = newBlockArr(0..10, int);
+var c = Block.createArray(0..10, int);
 
 // as we can not statically say that the iterators are aligned, we never see
 // `a[i]` as local. So we'll aggregate the second assignment, though we

--- a/test/optimizations/autoAggregation/insideGenericFunction.chpl
+++ b/test/optimizations/autoAggregation/insideGenericFunction.chpl
@@ -1,13 +1,13 @@
 use BlockDist;
 
-var myArr = newBlockArr({0..10}, int);
+var myArr = Block.createArray({0..10}, int);
 
 proc main() {
   foo(myArr);
 }
 
 proc foo(a) {
-  var b = newBlockArr({0..10}, int);
+  var b = Block.createArray({0..10}, int);
   for bb in b do bb = 1;
 
   writeln("Loop 1");

--- a/test/optimizations/autoAggregation/lastStmtIsConditional.chpl
+++ b/test/optimizations/autoAggregation/lastStmtIsConditional.chpl
@@ -6,8 +6,8 @@ config var flag = true;
 
 var alwaysTrue = true; // to make sure we run the ifs with no elses
 
-var a = newBlockArr(0..10, int);
-var b = newBlockArr(0..10, int);
+var a = Block.createArray(0..10, int);
+var b = Block.createArray(0..10, int);
 
 for i in b.domain {
   b[i] = i;

--- a/test/optimizations/autoAggregation/literalsAreLocal.chpl
+++ b/test/optimizations/autoAggregation/literalsAreLocal.chpl
@@ -2,10 +2,10 @@ writeln();
 
 use BlockDist;
 
-var dom = newBlockDom(0..10);
+var dom = Block.createDomain(0..10);
 var a: [dom] int;
 var b: [dom] int;
-var c = newBlockArr(0..10, int);
+var c = Block.createArray(0..10, int);
 
 writeln("Loop 1 -- expecting destination aggregation");
 forall i in a.domain {

--- a/test/optimizations/autoAggregation/localFlagDisablesAggregation.chpl
+++ b/test/optimizations/autoAggregation/localFlagDisablesAggregation.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var dom = newBlockDom({0..10});
+var dom = Block.createDomain({0..10});
 
 var a: [dom] int;
 var b: [dom] int;

--- a/test/optimizations/autoAggregation/localVariables.chpl
+++ b/test/optimizations/autoAggregation/localVariables.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var a = newBlockArr(0..10, int);
+var a = Block.createArray(0..10, int);
 
 forall i in a.domain {
   var d: 11*int;

--- a/test/optimizations/autoAggregation/paramsAreLocal.chpl
+++ b/test/optimizations/autoAggregation/paramsAreLocal.chpl
@@ -4,10 +4,10 @@ use BlockDist;
 
 param dummy = 1;
 
-var dom = newBlockDom(0..10);
+var dom = Block.createDomain(0..10);
 var a: [dom] int;
 var b: [dom] int;
-var c = newBlockArr(0..10, int);
+var c = Block.createArray(0..10, int);
 
 writeln("Loop 1 -- expecting destination aggregation");
 forall i in a.domain {

--- a/test/optimizations/autoAggregation/removeAggCondInFastFollowers.chpl
+++ b/test/optimizations/autoAggregation/removeAggCondInFastFollowers.chpl
@@ -2,7 +2,7 @@ use BlockDist;
 
 class Arr {
   type t;
-  var d = newBlockDom(1..10);
+  var d = Block.createDomain(1..10);
   var a: [d] t;
 
 }

--- a/test/optimizations/autoLocalAccess/allDynamicsFailStatic.chpl
+++ b/test/optimizations/autoLocalAccess/allDynamicsFailStatic.chpl
@@ -5,7 +5,7 @@ var D = createDom({1..10});
 
 
 var A: [D] int;
-var B = newCyclicArr({1..10}, int);
+var B = Cyclic.createArray({1..10}, int);
 
 // A is a static candidate, and will pass the static check
 // B is a dynamic candidate that'll fail static check, in that case, we want

--- a/test/optimizations/autoLocalAccess/callRejectReason.chpl
+++ b/test/optimizations/autoLocalAccess/callRejectReason.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var D = newBlockDom(1..10, 1..10);
+var D = Block.createDomain(1..10, 1..10);
 
 {
   // access index doesn't match cleanly

--- a/test/optimizations/autoLocalAccess/common.chpl
+++ b/test/optimizations/autoLocalAccess/common.chpl
@@ -12,10 +12,10 @@ proc createDom(space) {
   }
 
   if distType == Block {
-    return newBlockDom(space);
+    return Block.createDomain(space);
   }
   else if distType == Cyclic {
-    return newCyclicDom(space);
+    return Cyclic.createDomain(space);
   }
   else if distType == BlockCyclic {
     if space.rank == 1 {

--- a/test/optimizations/autoLocalAccess/differentDistView.chpl
+++ b/test/optimizations/autoLocalAccess/differentDistView.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var arr = newBlockArr(1..10, int);
+var arr = Block.createArray(1..10, int);
 
 ref localSlice = arr[{3..8}];
 

--- a/test/optimizations/autoLocalAccess/distSliceofDR.chpl
+++ b/test/optimizations/autoLocalAccess/distSliceofDR.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var blockDom = newBlockDom(3..8);
+var blockDom = Block.createDomain(3..8);
 var localArr: [1..10] int;
 
 ref slice = localArr[blockDom];

--- a/test/optimizations/autoLocalAccess/elemAsIndex.chpl
+++ b/test/optimizations/autoLocalAccess/elemAsIndex.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var A = newBlockArr({1..10}, int);
+var A = Block.createArray({1..10}, int);
 
 for (a,i) in zip(A, A.domain) do a=i;
 

--- a/test/optimizations/autoLocalAccess/interveningForallExpr.chpl
+++ b/test/optimizations/autoLocalAccess/interveningForallExpr.chpl
@@ -1,8 +1,8 @@
 use BlockDist;
 use CyclicDist;
 
-var blockArr = newBlockArr(1..10, int);
-var cyclicDom = newCyclicDom(1..10);
+var blockArr = Block.createArray(1..10, int);
+var cyclicDom = Cyclic.createDomain(1..10);
 
 var sums: [1..10] int;
 

--- a/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/allDynamicsFailStatic.chpl
@@ -5,7 +5,7 @@ var D = createDom({1..10});
 
 
 var A: [D] int;
-var B = newCyclicArr({1..10}, int);
+var B = Cyclic.createArray({1..10}, int);
 
 // A is a static candidate, and will pass the static check
 // B is a dynamic candidate that'll fail dynamic check, in that case, we want

--- a/test/optimizations/autoLocalAccess/zipper/elemAsIndex.chpl
+++ b/test/optimizations/autoLocalAccess/zipper/elemAsIndex.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var A = newBlockArr({1..10}, int);
+var A = Block.createArray({1..10}, int);
 
 for (a,i) in zip(A, A.domain) do a=i;
 

--- a/test/optimizations/fastFollowers/staticCheck.chpl
+++ b/test/optimizations/fastFollowers/staticCheck.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var D = newBlockDom({1..10});
+var D = Block.createDomain({1..10});
 
 var A: [D] int;
 var B: [D] int;

--- a/test/optimizations/remoteValueForwarding/zippedSlices/promotion.chpl
+++ b/test/optimizations/remoteValueForwarding/zippedSlices/promotion.chpl
@@ -6,9 +6,9 @@ config param doForall = false;
 
 proc main() {
 
-  var A = newBlockArr(1..n, int);
-  var B = newBlockArr(1..n, int);
-  var C = newBlockArr(1..n, int);
+  var A = Block.createArray(1..n, int);
+  var B = Block.createArray(1..n, int);
+  var C = Block.createArray(1..n, int);
 
   var alpha = 2;
 

--- a/test/optimizations/remoteValueForwarding/zippedSlices/promotionMany.chpl
+++ b/test/optimizations/remoteValueForwarding/zippedSlices/promotionMany.chpl
@@ -6,12 +6,12 @@ config const n = 10;
 
 proc main() {
 
-  var A = newBlockArr(1..n, int);
-  var B = newBlockArr(1..n, int);
-  var C = newBlockArr(1..n, int);
-  var D = newBlockArr(1..n, int);
-  var E = newBlockArr(1..n, int);
-  var F = newBlockArr(1..n, int);
+  var A = Block.createArray(1..n, int);
+  var B = Block.createArray(1..n, int);
+  var C = Block.createArray(1..n, int);
+  var D = Block.createArray(1..n, int);
+  var E = Block.createArray(1..n, int);
+  var F = Block.createArray(1..n, int);
 
   var alpha = 2;
 

--- a/test/optimizations/remoteValueForwarding/zippedSlices/sliceCombos.chpl
+++ b/test/optimizations/remoteValueForwarding/zippedSlices/sliceCombos.chpl
@@ -4,7 +4,7 @@ use CommDiagnostics;
 config const printTable = false;
 config const printArrays = false;
 
-var dom = newBlockDom(1..10);
+var dom = Block.createDomain(1..10);
 var innerDom = dom.expand(-1);
 
 var A: [dom] int;

--- a/test/optimizations/sungeun/optimized-on/loop.chpl
+++ b/test/optimizations/sungeun/optimized-on/loop.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var A = newBlockArr({1..numLocales}, int);
+var A = Block.createArray({1..numLocales}, int);
 
 on Locales[numLocales-1] {
   A.localAccess[numLocales] = numLocales;

--- a/test/parallel/forall/task-private-vars/count-tpvs.chpl
+++ b/test/parallel/forall/task-private-vars/count-tpvs.chpl
@@ -16,7 +16,7 @@ writeln("block");  /////////////////////////////////
 a.write(0);
 
 use BlockDist;
-var A = newBlockArr({1..10000}, int);
+var A = Block.createArray({1..10000}, int);
 
 forall a in A with (var r = new R()) { }
 assert(a.read() == totalTasks);

--- a/test/runtime/configMatters/comm/comm-ops.chpl
+++ b/test/runtime/configMatters/comm/comm-ops.chpl
@@ -41,8 +41,8 @@ record padded {
 }
 
 // Create arrays and warmup / init RAD cache
-var A = newBlockArr(1..numTasks*2, padded(atomic int));
-var B = newBlockArr(1..numTasks*2, padded(int));
+var A = Block.createArray(1..numTasks*2, padded(atomic int));
+var B = Block.createArray(1..numTasks*2, padded(int));
 for loc in Locales do on loc {
   coforall tid in 1..numTasks*2 {
     A[tid].val.write(0);

--- a/test/scan/scanDRSliceOfBlock.chpl
+++ b/test/scan/scanDRSliceOfBlock.chpl
@@ -1,5 +1,5 @@
 use BlockDist;
-var A = newBlockArr({1..10}, int);
+var A = Block.createArray({1..10}, int);
 forall i in A.domain do
   A[i] = i;
 ref Aview = A[{2..9}];

--- a/test/scan/scanWithFCF.chpl
+++ b/test/scan/scanWithFCF.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var A = newBlockArr({1..10}, real);
+var A = Block.createArray({1..10}, real);
 A = 1.0;
 var B = + scan A;
 

--- a/test/scan/scanWithObjWrite.chpl
+++ b/test/scan/scanWithObjWrite.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var A = newBlockArr({1..10}, real);
+var A = Block.createArray({1..10}, real);
 A = 1.0;
 var B = + scan A;
 

--- a/test/scan/testScanPOD.chpl
+++ b/test/scan/testScanPOD.chpl
@@ -24,4 +24,4 @@ proc test(dom) {
 }
 
 test({1..10});
-test(newBlockDom({1..10}));
+test(Block.createDomain({1..10}));

--- a/test/studies/bale/aggregation/histo.chpl
+++ b/test/studies/bale/aggregation/histo.chpl
@@ -27,11 +27,11 @@ proc stopTimer(name) {
 }
 
 proc main() {
-  const D = if useBlockArr then newBlockDom(0..#tableSize)
-                           else newCyclicDom(0..#tableSize);
+  const D = if useBlockArr then Block.createDomain(0..#tableSize)
+                           else Cyclic.createDomain(0..#tableSize);
   var AggA: [D] AggregatedAtomic(int);
 
-  const D2 = newBlockDom(0..#numUpdates);
+  const D2 = Block.createDomain(0..#numUpdates);
   var Rindex: [D2] int;
 
   fillRandom(Rindex, 208);

--- a/test/studies/bale/aggregation/ig.chpl
+++ b/test/studies/bale/aggregation/ig.chpl
@@ -31,11 +31,11 @@ proc stopTimer(name) {
 }
 
 proc main() {
-  const D = if useBlockArr then newBlockDom(0..#tableSize)
-                           else newCyclicDom(0..#tableSize);
+  const D = if useBlockArr then Block.createDomain(0..#tableSize)
+                           else Cyclic.createDomain(0..#tableSize);
   var A: [D] int = D;
 
-  const UpdatesDom = newBlockDom(0..#numUpdates);
+  const UpdatesDom = Block.createDomain(0..#numUpdates);
   var Rindex: [UpdatesDom] int;
 
   fillRandom(Rindex, 208);

--- a/test/studies/mstrout/wordCount.chpl
+++ b/test/studies/mstrout/wordCount.chpl
@@ -63,7 +63,7 @@ for f in findFiles(inputDir) {
     filenamesList.append(f);
 }
 // Create an array blocked into pieces per locale.
-var filenames = newBlockArr(0..#filenamesList.size, string);
+var filenames = Block.createArray(0..#filenamesList.size, string);
 filenames = filenamesList;
 
 // Execute using distributed parallelism across locales if executing

--- a/test/types/collections/arrIndicesAreLoc.chpl
+++ b/test/types/collections/arrIndicesAreLoc.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-var A = newBlockArr({1..10}, real);
+var A = Block.createArray({1..10}, real);
 
 forall i in A.indices do
   A[i] = here.id;

--- a/test/types/cptr/c_ptrToBlock.chpl
+++ b/test/types/cptr/c_ptrToBlock.chpl
@@ -1,5 +1,5 @@
 use BlockDist, CTypes;
 
-var B = newBlockArr({1..10}, real);
+var B = Block.createArray({1..10}, real);
 
 var bptr = c_ptrTo(B);


### PR DESCRIPTION
This PR:

* Deprecates and moves newBlockDist/newBlockArr and newCyclicDist/newCyclicArr into their respective types as methods and renames them to createDistribution/createArray.
* Updates existing module and test code to use the new functions
* Adds a test locking down that we get the deprecation warning if we call the old function

Looking at user codes: grepping "newBlock" and "newCyclic" doesn't give any results in CHAMPS or ChOp.  "newBlockDom" does appear a number of times in Arkouda.