### PR TITLE
Remove idxType from Bytes

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -32,9 +32,6 @@ module Bytes {
   public use BytesCasts;
   public use BytesStringCommon only decodePolicy;  // expose decodePolicy
 
-  pragma "no doc"
-  type idxType = int;
-
   //
   // createBytes* functions
   //
@@ -560,8 +557,8 @@ module Bytes {
               :type:`bytes`.
    */
   inline proc bytes.find(pattern: bytes,
-                         indices: range(?) = this.indices) : idxType {
-    return doSearchNoEnc(this, pattern, indices, count=false): idxType;
+                         indices: range(?) = this.indices) : int {
+    return doSearchNoEnc(this, pattern, indices, count=false);
   }
 
   /*
@@ -578,9 +575,9 @@ module Bytes {
               :type:`bytes`.
    */
   inline proc bytes.rfind(pattern: bytes,
-                          indices: range(?) = this.indices) : idxType {
+                          indices: range(?) = this.indices) : int {
     return doSearchNoEnc(this, pattern, indices, count=false,
-                         fromLeft=false): idxType;
+                         fromLeft=false);
   }
 
   /*

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -522,7 +522,7 @@ module BytesStringCommon {
 
   proc getIndexType(type t) type {
     import Bytes, String;
-    if t==bytes then return Bytes.idxType;
+    if t==bytes then return int;
     else if t==string then return String.byteIndex;
     else compilerError("This function should only be used by bytes or string");
   }
@@ -629,7 +629,7 @@ module BytesStringCommon {
     var chunk : t;
 
     var inChunk : bool = false;
-    var chunkStart : idxType;
+    var chunkStart : int;
 
     // emit whole string, unless all whitespace
     // TODO Engin: Why is noSplit check inside the loop?
@@ -1244,8 +1244,8 @@ module BytesStringCommon {
     const localX: t = x.localize();
     const localChars: t = chars.localize();
 
-    var start: idxType = 0;
-    var end: idxType = localX.buffLen-1;
+    var start: int = 0;
+    var end: int = localX.buffLen-1;
 
     if leading {
       label outer for (i, xChar) in zip(x.indices, localX.bytes()) {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3117,7 +3117,7 @@ module TwoArrayPartitioning {
 
     // Always use state 1 for small subproblems...
     ref state = state1;
-    coforall (loc,tid) in zip(A.targetLocales(),0:idxType..) with (ref state) do
+    coforall (loc,tid) in zip(A.targetLocales(),0..) with (ref state) do
     on loc {
       // Get the tasks to sort here
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -307,7 +307,7 @@ module Random {
       } else if isDomainType(sizeType) {
         if size.size <= 0 then
           throw new owned IllegalArgumentError('choice() size domain can not be empty');
-        if !replace && size.size > X.sizeAs(idxType) then
+        if !replace && size.size > X.sizeAs(X.idxType) then
           throw new owned IllegalArgumentError('choice() size must be smaller than x.size when replace=false');
       } else {
         compilerError('choice() size must be integral or domain');
@@ -331,7 +331,7 @@ module Random {
 
     if isNothingType(sizeType) {
       // Return 1 sample
-      var randVal = stream.getNext(resultType=int, 0, X.sizeAs(idxType)-1);
+      var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
       var randIdx = X.dim(0).orderToIndex(randVal);
       return randIdx;
     } else {
@@ -350,16 +350,16 @@ module Random {
 
       if replace {
         for sample in samples {
-          var randVal = stream.getNext(resultType=int, 0, X.sizeAs(idxType)-1);
+          var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
           var randIdx = X.dim(0).orderToIndex(randVal);
           sample = randIdx;
         }
       } else {
-        if numElements < log2(X.sizeAs(idxType)) {
+        if numElements < log2(X.sizeAs(X.idxType)) {
           var indices: set(int);
           var i: int = 0;
           while i < numElements {
-            var randVal = stream.getNext(resultType=int, 0, X.sizeAs(idxType)-1);
+            var randVal = stream.getNext(resultType=int, 0, X.sizeAs(X.idxType)-1);
             if !indices.contains(randVal) {
               var randIdx = X.dim(0).orderToIndex(randVal);
               samples[i] = randIdx;
@@ -390,7 +390,7 @@ module Random {
     import Search;
     import Sort;
 
-    if prob.size != X.sizeAs(idxType) {
+    if prob.size != X.sizeAs(X.idxType) {
       throw new owned IllegalArgumentError('choice() x.size must be equal to prob.size');
     }
 
@@ -399,7 +399,7 @@ module Random {
 
     const low = X.low,
           stride = abs(X.stride);
-    ref P = prob.reindex(0..<X.sizeAs(idxType));
+    ref P = prob.reindex(0..<X.sizeAs(X.idxType));
 
     // Construct cumulative sum array
     var cumulativeArr = (+ scan P): real;


### PR DESCRIPTION
This PR drops `no doc`ed `type idxType` from the Bytes module.

It has no clear purpose and currently seeps into user's namespace.

Test
- [x] standard linux64
- [x] gasnet