### PR TITLE
Fix failing map tests and update getAndRemove deprecation message

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -513,7 +513,7 @@ module Map {
 
     /* Remove the element at position `k` from the map and return its value
      */
-    deprecated "'Map.getAndRemove' is deprecated. Please index into the map and then remove the value."
+    deprecated "'Map.getAndRemove' is deprecated. Consider 'Map.get' and 'Map.remove' instead?"
     proc getAndRemove(k: keyType) {
       _enter(); defer _leave();
       var (found, slot) = table.findFullSlot(k);

--- a/test/deprecated/Map/testGetRemove.good
+++ b/test/deprecated/Map/testGetRemove.good
@@ -1,3 +1,3 @@
-testGetRemove.chpl:11: warning: 'Map.getAndRemove' is deprecated. Please index into the map and then remove the value.
+testGetRemove.chpl:11: warning: 'Map.getAndRemove' is deprecated. Consider 'Map.get' and 'Map.remove' instead?
 {i = 1}
 {two: {i = 2}}

--- a/test/library/draft/DistributedMap/v2/use-distributed-map.bad
+++ b/test/library/draft/DistributedMap/v2/use-distributed-map.bad
@@ -1,6 +1,6 @@
 ./Aggregator.chpl:36: In initializer:
 $CHPL_HOME/modules/standard/Types.chpl:250: warning: Initializing a type-inferred variable from a 'sync' is deprecated; apply a 'read??()' method to the right-hand side
-  ./DistributedMap.chpl:763: called as (aggregator(distributedMapImpl(string,int(64),nothing),proc(ref element: int))).init(clientInst: borrowed distributedMapImpl(string,int(64),nothing), updaterFcf: proc(ref element: int)) from method 'updateAggregator'
+  ./DistributedMap.chpl:733: called as (aggregator(distributedMapImpl(string,int(64),nothing),proc(ref element: int))).init(clientInst: borrowed distributedMapImpl(string,int(64),nothing), updaterFcf: proc(ref element: int)) from method 'updateAggregator'
   use-distributed-map.chpl:12: called as (distributedMapImpl(string,int(64),nothing)).updateAggregator(updater: proc(ref element: int))
 Jacob=2
 Jingleheimer=2

--- a/test/library/standard/Map/testGetRemove.chpl
+++ b/test/library/standard/Map/testGetRemove.chpl
@@ -8,8 +8,10 @@ var m: map(string, shared C);
 m.add("one", new shared C(1));
 m.add("two", new shared C(2));
 
+// x is borrowed from m
 var x = m["one"];
-m.remove("one");
 
 writeln(x);
+// x now invaild
+m.remove("one");
 writeln(m);

--- a/test/library/standard/Map/testGetRemove.chpl
+++ b/test/library/standard/Map/testGetRemove.chpl
@@ -8,10 +8,9 @@ var m: map(string, shared C);
 m.add("one", new shared C(1));
 m.add("two", new shared C(2));
 
-// x is borrowed from m
-var x = m["one"];
+var sentinel = new shared C(3);
+var x = m.get("one", sentinel);
+m.remove("one");
 
 writeln(x);
-// x now invaild
-m.remove("one");
 writeln(m);


### PR DESCRIPTION
With the removal of `getAndRemove` in #21549, there was a test 
failing dueto a borrow of the class going invalid after the map 
value was removed, so this updates that to use the `get` method 
instead, which creates a deep copy. Additionally, a `.bad` file
for a gasnet test needed updating for line numbers.

- [x] paratest