### PR TITLE
Add a 'metadata' argument to 'copyTree'

### DIFF
--- a/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.chpl
+++ b/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.chpl
@@ -1,0 +1,13 @@
+use FileSystem;
+
+/* Test that copying a directory containing root-owned filed works */
+
+config const path = '/usr/include/curses';
+
+proc main() {
+  try {
+    FileSystem.copyTree(path, './usercopy', metadata=true);
+  } catch err {
+    writeln(err);
+  }
+}

--- a/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.cleanfiles
+++ b/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.cleanfiles
@@ -1,0 +1,1 @@
+usercopy

--- a/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.good
+++ b/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.good
@@ -1,0 +1,1 @@
+PermissionError: Operation not permitted (in chown with path "./usercopy/curses.h")

--- a/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.skipif
+++ b/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.skipif
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This test depends on a root-owned directory containing a file existing
+FILE='/usr/include/curses/curses.h'
+
+if [ -f "$FILE" ]; then
+    # don't skip
+    echo 0
+else
+    # skip
+    echo 1
+fi


### PR DESCRIPTION
If the 'metadata' argument is true, copy the UID and GID from the original directory.

When copying files, forward the 'metadata' argument to 'copy'.

Add a test that tries to copy a directory owned by root with metadata=true. Since that's not allowed as a non-root user it expects and gets a Permission error.

I also tested a modified version of this test that prints the UID and GID of the copied directory and ran it with 'start_test --launchcmd fakeroot' and verified that the UID and GID of the copy were both 0 (root).

Closes https://github.com/chapel-lang/chapel/issues/19664
Closes https://github.com/Cray/chapel-private/issues/4304