### PR TITLE
Adjust .good for negative stride

### DIFF
--- a/test/library/packages/FFTW/guru-interface-example.chpl
+++ b/test/library/packages/FFTW/guru-interface-example.chpl
@@ -24,7 +24,7 @@ var a1,b1,a2,b2: [D]complex;
 
 
 fillRandom(a1); // Original array
-a2 = reshape(a1, D by -1);
+a2 = reshape(a1, D by -1);   // neg-stride temp array created by reshape()
 
 if verbose {
   writeln("The original array :");

--- a/test/library/packages/FFTW/guru-interface-example.good
+++ b/test/library/packages/FFTW/guru-interface-example.good
@@ -1,1 +1,2 @@
 SUCCESS
+guru-interface-example.chpl:27: warning: arrays and array slices with negatively-strided dimensions are currently unsupported and may lead to unexpected behavior; compile with -snoNegativeStrideWarnings to suppress this warning; the dimension(s) are: (0..99 by -1, 0..23 by -1)


### PR DESCRIPTION
The test guru-interface-example.chpl creates a temp negative-stride array when calling reshape(), in order to reverse the order of elements of a unit-stride array and store the result in another unit-stride array.

This PR adjusts its .good to account for the warning about the negative stride that is now issued due to #21496, the same way I adjusted other tests in that PR.

Trivial, not reviewed.