### PR TITLE
 Fix Author and diff url

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -19,33 +19,16 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT" 
      # This workflow step will parse github env. The parsed env will be used in the email body.
-     #  MERGE_LOG env holds the request body(PR description) that is parsed to replace \n\r with <br> for html formatting    
-     # This step will be retried if there are any timeouts or issues parsing the json due to timeouts in curl command to get commits url.
       - name: get commits payload
+        id: build-payload
         env:
-          COMMIT_URL: ${{github.event.pull_request._links.commits.href}}
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 4
-          retry_on_exit_code: 2
-          timeout_seconds: 180
-          polling_interval_seconds: 60  
-          command: |
-              curl --location --request GET $COMMIT_URL --header 'X-API-Key: ${{ secrets.GITHUB_TOKEN}}' -o commits.json
-              if [ $? -ne 0 ]; then
-                echo "curl command to get commits payload failed"
-                exit 2
-              fi  
-              jq -r '.[0].commit.author.name' commits.json  
-              if [ $? -ne 0 ]  ; then
-                echo "error in processing .jq command"
-                exit 2
-              fi       
-              echo "AUTHOR=$(jq -r '.[0].commit.author.name' commits.json)" >> $GITHUB_ENV   
-              echo "LINK=$(jq -r '.[0].html_url' commits.json)" >> $GITHUB_ENV
-              echo "MESSAGE=$((jq  '.[0].commit.message' commits.json)| awk -F'\\\\n' '{print $1}' | sed 's/\"//g')" >> $GITHUB_ENV 
+           PR_LINK: ${{github.event.pull_request._links.html.href}}
+        run: |      
+              echo "LINK=$(echo $PR_LINK )" >> $GITHUB_ENV   
+              echo "AUTHOR=$(echo ${{github.actor}})" >> $GITHUB_ENV
               echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{ github.event.pull_request.merge_commit_sha}}' )" >> $GITHUB_ENV      
-              echo "FILES_CHANGED=$(echo '${{github.event.pull_request._links.html.href}}/files' )" >> $GITHUB_ENV
+              echo "FILES_CHANGED=$(echo '$PR_LINK/files' )" >> $GITHUB_ENV     
+  
       - name: checkout
         uses: actions/checkout@v3
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.


### PR DESCRIPTION
Email workflow cleanup.

The existing workflow is getting the author name from commits.json. There are issues when the author and the person merging the PR is different. The email prints the person merged the PR as author.
Fix that by using actor from the pull_request.

Diff is calculated usinf merge_commit_sha and head_sha(head of main) this will work if the branch is rebased with main before merging.

Use base_sha of the branch to get the diff instead and see if it works.
Please note that it cannot be tested using the [test repository
] (https://github.com/bhavanijayakumaran/workflow)  as I am the only user and there is no easy way to simulate the scenario.

Signed-off-by: bhavanijayakumaran <82669529+bhavanijayakumaran@users.noreply.github.com>