### PR TITLE
Fix typos

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2398,7 +2398,7 @@ struct Converter {
         // forwarding var bla;
         expr = new UnresolvedSymExpr(varName.c_str());
       } else {
-        // fowarding someExpression();
+        // forwarding someExpression();
         expr = convertExprOrNull(node->expr());
       }
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -727,7 +727,7 @@ forwardingCycleCheckQuery(Context* context, const CompositeType* ct) {
   return QUERY_END(result);
 }
 
-// returns 'true' if a fowarding cycle was detected & error emitted
+// returns 'true' if a forwarding cycle was detected & error emitted
 static bool
 emitErrorForForwardingCycles(Context* context, const CompositeType* ct) {
   bool cycleFound = false;
@@ -2865,12 +2865,12 @@ gatherAndFilterCandidatesForwarding(Context* context,
 // call can be nullptr. in that event, ci.name() will be used
 // to find the call with that name.
 //
-// forwardingTo is a vector that will be empty unless forwardiing
+// forwardingTo is a vector that will be empty unless forwarding
 // is used for some candidates.
 //
 // If forwarding is used, it will have an element for each of the returned
 // candidates and will indicate the actual type that is passed
-// to the 'this' reciever formal.
+// to the 'this' receiver formal.
 static CandidatesVec
 gatherAndFilterCandidates(Context* context,
                           const Call* call,

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -46,7 +46,7 @@ namespace resolution {
 using namespace uast;
 using namespace types;
 
-// Mimicks helper in Resolver but without corresponding target constraints.
+// Mimics helper in Resolver but without corresponding target constraints.
 static void maybeEmitWarningsForId(Context* context, ID idMention,
                                    ID idTarget) {
   if (idMention.isEmpty() || idTarget.isEmpty()) return;

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -143,7 +143,7 @@ module GPU
     can be used for either communication to or from the GPU
 
     Returns a handle that can be passed to `waitGpuComm` to pause execution
-    until completion of this asyhcronous transfer
+    until completion of this asynchronous transfer
   */
   pragma "no doc"
   proc asyncGpuComm(dstArr : ?t1, srcArr : ?t2) : GpuAsyncCommHandle

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5441,7 +5441,7 @@ proc _channel.writebits(v:integral, nbits:integral) throws {
 }
 
 /*
-  Write ``size`` coidpoints from a :type:`~String.string` to a ``filewriter``
+  Write ``size`` codepoints from a :type:`~String.string` to a ``fileWriter``
 
   :arg s: the ``string`` to write
   :arg size: the number of codepoints to write from the ``string``
@@ -5882,7 +5882,7 @@ proc fileReader.readBinary(ref b: bytes, maxSize: int): bool throws {
 
 
 /*
-  Controlls the return type of the ``readBinary`` overloads that take an
+  Controls the return type of the ``readBinary`` overloads that take an
   array argument. Those are:
 
   ``fileReader.readBinary(ref data: [], param endian = ioendian.native)``
@@ -5969,7 +5969,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): b
    :arg endian: :type:`ioendian` compile-time argument that specifies the byte order in which
               to read the numbers. Defaults to ``ioendian.native``.
    :returns: the number of values that were read into the array. This can be
-              less than ``data.size`` if EOF was reached, or an error occured,
+              less than ``data.size`` if EOF was reached, or an error occurred,
               before filling the array.
 
    :throws SystemError: Thrown if an error occurred while reading from the fileReader
@@ -6062,7 +6062,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):bool throws
    :arg endian: :type:`ioendian` specifies the byte order in which
               to read the number.
    :returns: the number of values that were read into the array. This can be
-              less than ``data.size`` if EOF was reached, or an error occured,
+              less than ``data.size`` if EOF was reached, or an error occurred,
               before filling the array.
 
    :throws SystemError: Thrown if an error occurred while reading the from fileReader

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -442,7 +442,7 @@ void chpl_gpu_impl_mem_free(void* memAlloc) {
 
 void chpl_gpu_impl_hostmem_register(void *memAlloc, size_t size) {
   // The CUDA driver uses DMA to transfer page-locked memory to the GPU; if
-  // memory is not page-locked it must first be transfered into a page-locked
+  // memory is not page-locked it must first be transferred into a page-locked
   // buffer, which degrades performance. So in the array_on_device mode we
   // choose to page-lock such memory even if it's on the host-side.
   #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -259,7 +259,7 @@ int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
 
 //
 // Initializes information about CPUs (cores and PUs) and and NICs from the
-// toplogy.
+// topology.
 //
 
 static void cpuInfoInit(void) {
@@ -416,7 +416,7 @@ static void cpuInfoInit(void) {
   oversubscribed = chpl_env_rt_get_bool("OVERSUBSCRIBED", oversubscribed);
 
   if ((verbosity >= 2) && (chpl_nodeID == 0)) {
-    printf("overscribed = %s\n", oversubscribed ? "True" : "False");
+    printf("oversubscribed = %s\n", oversubscribed ? "True" : "False");
   }
 
   // Find the NUMA nodes.


### PR DESCRIPTION
Fix typos in

convert-uast.cpp, resolution-queries.cpp, scope-queries.cpp,
GPU.chpl, IO.chpl,
gpu-cuda.c, topo-hwloc.c
