### PR TITLE
Changes to scope resolver errors to prepare for full `--dyno`-by-default switch.

### DIFF
--- a/frontend/include/chpl/framework/ErrorWriter.h
+++ b/frontend/include/chpl/framework/ErrorWriter.h
@@ -275,6 +275,15 @@ class ErrorWriterBase {
   }
 
   /**
+    Same as ErrorWriter::heading, but doesn't tweak the resulting error message
+    to remove punctuation.
+   */
+  template <typename LocationType, typename ... Ts>
+  void headingVerbatim(ErrorBase::Kind kind, ErrorType type, LocationType loc, Ts ... ts) {
+    writeHeading(kind, type, loc, toString(std::forward<Ts>(ts)...));
+  }
+
+  /**
     Write a note about the error. Unlike messages, notes are printed
     even in brief mode. Thus, notes can be used to provide information
     that is useful "in all cases" (e.g., the location of a duplicate
@@ -302,6 +311,15 @@ class ErrorWriterBase {
     auto str = toString(std::forward<Ts>(ts)...);
     tweakErrorString(str);
     writeNote(loc, str);
+  }
+
+  /**
+    Same as ErrorWriter::note, but doesn't tweak the resulting error message
+    to remove punctuation.
+   */
+  template <typename LocationType, typename ... Ts>
+  void noteVerbatim(ErrorBase::Kind kind, ErrorType type, LocationType loc, Ts ... ts) {
+    writeNote(kind, type, loc, toString(std::forward<Ts>(ts)...));
   }
 
   /**

--- a/frontend/include/chpl/framework/resolution-error-classes-list.h
+++ b/frontend/include/chpl/framework/resolution-error-classes-list.h
@@ -85,6 +85,7 @@ ERROR_CLASS(UseImportUnknownMod,
             const ID,
             const resolution::VisibilityStmtKind,
             std::string,
+            std::string,
             std::vector<const uast::AstNode*>)
 ERROR_CLASS(UseImportUnknownSym,
             std::string,

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -555,7 +555,7 @@ void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
   auto moduleName = std::get<std::string>(info);
   auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
 
-  wr.heading(kind_, type_, id, "cannot '", useOrImport, "' '", moduleName,
+  wr.heading(kind_, type_, id, "cannot '", useOrImport, "' symbol '", moduleName,
              "', which is not a ", allowedItem(useOrImport), ".");
   wr.message("In the following '", useOrImport, "' statement:");
   wr.code<ID, ID>(id, { id });

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -680,7 +680,7 @@ void ErrorDeprecation::write(ErrorWriterBase& wr) const {
   auto target = std::get<const uast::NamedDecl*>(info);
   CHPL_ASSERT(mention && target);
 
-  wr.heading(kind_, type_, mention, msg);
+  wr.headingVerbatim(kind_, type_, mention, msg);
   wr.code(mention, {mention});
 
   /* TODO: Need to know whether the symbol is user or not:
@@ -698,7 +698,7 @@ void ErrorUnstable::write(ErrorWriterBase& wr) const {
   auto target = std::get<const uast::NamedDecl*>(info);
   CHPL_ASSERT(mention && target);
 
-  wr.heading(kind_, type_, mention, msg);
+  wr.headingVerbatim(kind_, type_, mention, msg);
   wr.code(mention, {mention});
 
   /* TODO: Need to know whether the symbol is user or not:

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -565,12 +565,19 @@ void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
 
 void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
-  auto moduleName = std::get<std::string>(info);
+  auto moduleName = std::get<2>(info);
+  auto previousPartName = std::get<3>(info);
   auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
   auto& improperMatches = std::get<std::vector<const uast::AstNode*>>(info);
 
-  wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
-             " '", moduleName, "' for '", useOrImport, "' statement.");
+  if (previousPartName.empty()) {
+    wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
+               " '", moduleName, "' for '", useOrImport, "' statement.");
+  } else {
+    wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
+               " '", moduleName, "' in module '", previousPartName, "' for '",
+               useOrImport, "' statement.");
+  }
   wr.message("In the following '", useOrImport, "' statement:");
   wr.code<ID, ID>(id, { id });
   if (!improperMatches.empty()) {

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -53,7 +53,7 @@ static types::QualifiedType decayToValue(const types::QualifiedType& qt) {
 }
 
 static const char* allowedItem(resolution::VisibilityStmtKind kind) {
-  return kind == resolution::VIS_USE ? "module or 'enum'" : "module";
+  return kind == resolution::VIS_USE ? "module or enum" : "module";
 }
 
 static const char* allowedItems(resolution::VisibilityStmtKind kind) {
@@ -572,11 +572,10 @@ void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
 
   if (previousPartName.empty()) {
     wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
-               " '", moduleName, "' for '", useOrImport, "' statement.");
+               " named '", moduleName, "'.");
   } else {
     wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
-               " '", moduleName, "' in module '", previousPartName, "' for '",
-               useOrImport, "' statement.");
+               " named '", moduleName, "' in module '", previousPartName, "'.");
   }
   wr.message("In the following '", useOrImport, "' statement:");
   wr.code<ID, ID>(id, { id });

--- a/test/errors/fullImportPath-brief.good
+++ b/test/errors/fullImportPath-brief.good
@@ -1,4 +1,5 @@
-error in fullImportPath.chpl:9: cannot find module 'ToLookFor' for 'import' statement
-  note in fullImportPath.chpl:3: a module named 'ToLookFor' is defined here
-  note in fullImportPath.chpl:3: however, a full path or an explicit relative import is required for modules that are not at the root level
-  note in fullImportPath.chpl:9: For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'
+fullImportPath.chpl:8: In module 'M4':
+fullImportPath.chpl:9: error: cannot find module named 'ToLookFor'
+fullImportPath.chpl:3: note: a module named 'ToLookFor' is defined here
+fullImportPath.chpl:3: note: however, a full path or an explicit relative import is required for modules that are not at the root level
+fullImportPath.chpl:9: note: For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'

--- a/test/errors/fullImportPath-detailed.good
+++ b/test/errors/fullImportPath-detailed.good
@@ -1,5 +1,5 @@
 ─── error in fullImportPath.chpl:9 [UseImportUnknownMod] ───
-  Cannot find module 'ToLookFor' for 'import' statement.
+  Cannot find module named 'ToLookFor'.
   In the following 'import' statement:
       |
     9 |                 import ToLookFor;

--- a/test/errors/fullUsePath-brief.good
+++ b/test/errors/fullUsePath-brief.good
@@ -1,4 +1,5 @@
-warning in fullUsePath.chpl:1: an implicit module named 'fullUsePath' is being introduced to contain file-scope code
-error in fullUsePath.chpl:9: cannot find module or enum 'ToLookFor' for 'use' statement
-  note in fullUsePath.chpl:1: a declaration of 'ToLookFor' is here
-  note in fullUsePath.chpl:1: however, 'use' statements can only be used with modules or enums (and this 'ToLookFor' is not a module or enum)
+fullUsePath.chpl:1: warning: an implicit module named 'fullUsePath' is being introduced to contain file-scope code
+fullUsePath.chpl:8: In module 'M4':
+fullUsePath.chpl:9: error: cannot find module or enum named 'ToLookFor'
+fullUsePath.chpl:1: note: a declaration of 'ToLookFor' is here
+fullUsePath.chpl:1: note: however, 'use' statements can only be used with modules or enums (and this 'ToLookFor' is not a module or enum)

--- a/test/errors/fullUsePath-detailed.good
+++ b/test/errors/fullUsePath-detailed.good
@@ -8,7 +8,7 @@
   Note that all of the file's contents -- including module 'M1' -- will be placed into the new 'fullUsePath' module.
 
 ─── error in fullUsePath.chpl:9 [UseImportUnknownMod] ───
-  Cannot find module or enum 'ToLookFor' for 'use' statement.
+  Cannot find module or enum named 'ToLookFor'.
   In the following 'use' statement:
       |
     9 |                 use ToLookFor;

--- a/test/errors/useImportUnknownMod-brief.good
+++ b/test/errors/useImportUnknownMod-brief.good
@@ -1,1 +1,2 @@
-error in useImportUnknownMod.chpl:6: cannot find module 'X' for 'import'
+useImportUnknownMod.chpl:5: In module 'N':
+useImportUnknownMod.chpl:6: error: cannot find module named 'X'

--- a/test/errors/useImportUnknownMod-detailed.good
+++ b/test/errors/useImportUnknownMod-detailed.good
@@ -1,5 +1,5 @@
 ─── error in useImportUnknownMod.chpl:6 [UseImportUnknownMod] ───
-  Cannot find module 'X' for 'import'.
+  Cannot find module named 'X'.
   In the following 'import' statement:
       |
     6 |   import X.b;

--- a/test/errors/useImportUnknownSym-brief.good
+++ b/test/errors/useImportUnknownSym-brief.good
@@ -1,1 +1,2 @@
-error in useImportUnknownSym.chpl:6: cannot find symbol 'b' for import
+useImportUnknownSym.chpl:5: In module 'N':
+useImportUnknownSym.chpl:6: error: cannot 'import' symbol 'b' as it is not defined in 'M'

--- a/test/errors/useImportUnknownSym-detailed.good
+++ b/test/errors/useImportUnknownSym-detailed.good
@@ -1,5 +1,5 @@
 ─── error in useImportUnknownSym.chpl:6 [UseImportUnknownSym] ───
-  Cannot find symbol 'b' for import.
+  Cannot 'import' symbol 'b' as it is not defined in 'M'.
   In the following 'import' statement:
       |
     6 |   import M.b;


### PR DESCRIPTION
A few minor things in here to make the error messages better.

1. Deprecation and unstable warnings now print their text verbatim, without mangling punctuation. It seems to make sense to forward what the user wrote in the "deprecated" attribute directly rather than possibly surprising them by changing it.
2. Tweak the wording of some module-related errors (`cannot 'import' 'bla'` => `cannot 'import' symbol 'bla'`, `cannot find module or 'enum' 'bla' for 'import'` => `cannot find module or enum named 'bla'`)
3. Print what module was searched when unable to find an import (i.e., `could not find N in M` vs previous `could not find N`).

Reviewed by @benharsh and @riftEmber - thanks!

## Testing
- [x] full local
- [x] full local with `--dyno` (only cosmetic changes, as tested from the tip of #21596)