### PR TITLE
Deprecate `regex.sub/subn` in favor of `replace` and `replaceAndCount` on `string` and `bytes`

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -214,7 +214,7 @@ module TomlParser {
 
     proc parseTable() {
       var toke = getToken(source);
-      var tablename = brackets.sub('', toke);
+      var tablename = toke.replace(brackets, '');
       var tblD: domain(string);
       var tbl: [tblD] shared Toml?;
       if !rootTable.pathExists(tablename) {

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -982,7 +982,7 @@ record regex {
      :arg global: if true, replace multiple matches
      :returns: the new string or bytes
    */
-  deprecated "regex.sub is deprecated. Please use string.replace(regex, string)."
+  deprecated "regex.sub is deprecated. Please use string.replace."
   proc sub(repl: exprType, text: exprType, global = true )
   {
     if global then

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -338,8 +338,10 @@ Regular Expression Types and Methods
 module Regex {
   private use OS, CTypes;
 
+  // Ideally, should be a config const, but it pollutes --help output
+  // unnecessarily even though it is private
   pragma "no doc"
-  private config const initBufferSizeForSlowReplaceAndCount = 16;
+  private const initBufferSizeForSlowReplaceAndCount = 16;
 
 pragma "no doc"
 extern type qio_regex_t;

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1129,7 +1129,7 @@ proc bytes.find(pattern: regex(bytes)):byteIndex
 }
 
 /* Search the receiving string for the pattern. Returns a new string where the
-   match(es) to the pattern is replaced with a replacement. 
+   match(es) to the pattern is replaced with a replacement.
 
    :arg pattern: the compiled regular expression to search for
    :arg replacement: string to replace with
@@ -1143,7 +1143,7 @@ proc string.replace(pattern: regex(string), replacement:string,
 }
 
 /* Search the receiving bytes for the pattern. Returns a new bytes where the
-   match(es) to the pattern is replaced with a replacement. 
+   match(es) to the pattern is replaced with a replacement.
 
    :arg pattern: the compiled regular expression to search for
    :arg replacement: bytes to replace with
@@ -1157,7 +1157,7 @@ proc bytes.replace(pattern: regex(bytes), replacement:bytes, count=-1): bytes {
 
 /* Search the receiving string for the pattern. Returns a new string where the
    match(es) to the pattern is replaced with a replacement and number of
-   replacements. 
+   replacements.
 
    :arg pattern: the compiled regular expression to search for
    :arg replacement: string to replace with
@@ -1171,7 +1171,7 @@ proc string.replaceAndCount(pattern: regex(string), replacement:string,
 
 /* Search the receiving bytes for the pattern. Returns a new bytes where the
    match(es) to the pattern is replaced with a replacement and number of
-   replacements. 
+   replacements.
 
    :arg pattern: the compiled regular expression to search for
    :arg replacement: bytes to replace with

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1258,11 +1258,11 @@ private proc doReplaceAndCountSlow(x: ?t, pattern: regex(t), replacement: t,
   var ret: t;
 
   if t == string then
-    ret = try! createStringWithNewBuffer(newBuff, length=numBytesInResult,
-                                         size=buffSize);
+    ret = try! createStringWithOwnedBuffer(newBuff, length=numBytesInResult,
+                                           size=buffSize);
   else
-    ret = createBytesWithNewBuffer(newBuff, length=numBytesInResult,
-                                   size=buffSize);
+    ret = createBytesWithOwnedBuffer(newBuff, length=numBytesInResult,
+                                     size=buffSize);
 
   return (ret, totalChunksToRemove);
 }

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1275,7 +1275,6 @@ private proc doReplaceAndCountFast(x: ?t, pattern: regex(t), replacement: t,
   if pattern.home != here then regexCopy = pattern;
   const localRegex = if pattern.home != here then regexCopy._regex
                                              else pattern._regex;
-  // TODO -- move subn after sub for documentation clarity
   var pos:byteIndex;
   var endpos:byteIndex;
 

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1132,7 +1132,7 @@ proc bytes.find(pattern: regex(bytes)):byteIndex
                replaces all occurrences
  */
 proc string.replace(pattern: regex(string), replacement:string,
-    count=-1): string {
+                    count=-1): string {
   var (str, dummy) = doReplaceAndCount(this, pattern, replacement, count);
   return str;
 }
@@ -1145,8 +1145,7 @@ proc string.replace(pattern: regex(string), replacement:string,
    :arg count: number of maximum replacements to make, values less than zero
                replaces all occurrences
  */
-proc bytes.replace(pattern: regex(bytes), replacement:bytes,
-    count=-1): bytes {
+proc bytes.replace(pattern: regex(bytes), replacement:bytes, count=-1): bytes {
   var (str, dummy) = doReplaceAndCount(this, pattern, replacement, count);
   return str;
 }
@@ -1175,7 +1174,7 @@ proc string.replaceAndCount(pattern: regex(string), replacement:string,
                replaces all occurrences
  */
 proc bytes.replaceAndCount(pattern: regex(bytes), replacement:bytes,
-                            count=-1): (bytes, int) {
+                           count=-1): (bytes, int) {
   return doReplaceAndCount(this, pattern, replacement, count);
 }
 

--- a/test/deprecated/regexSubSubn.chpl
+++ b/test/deprecated/regexSubSubn.chpl
@@ -1,0 +1,7 @@
+use Regex;
+
+var myStr = "AABBCC";
+var r = compile("A.*B");
+
+writeln(r.sub(myStr, "x"));
+writeln(r.subn(myStr, "x"));

--- a/test/deprecated/regexSubSubn.good
+++ b/test/deprecated/regexSubSubn.good
@@ -1,0 +1,4 @@
+regexSubSubn.chpl:6: warning: regex.sub is deprecated. Please use string.replace.
+regexSubSubn.chpl:7: warning: regex.subn is deprecated. Please use string.replaceAndCount.
+x
+(x, 0)

--- a/test/regex/correctness.chpl
+++ b/test/regex/correctness.chpl
@@ -101,7 +101,7 @@ on locales1 {
 
 r4 = compile("a+":t);
 on locales1 {
-  var (s, n) = r4.subn("hello":t, "aaaa world aa":t);
+  var (s, n) = ("aaaa world aa":t).replaceAndCount(r4, "hello":t);
   assert(n == 2);
   assert(s == "hello world hello":t);
 }
@@ -259,7 +259,7 @@ proc inafunction() {
 
   r4 = compile("a+":t);
   on locales1 {
-    var (s, n) = r4.subn("hello":t, "aaaa world aa":t);
+    var (s, n) = ("aaaa world aa":t).replaceAndCount(r4, "hello":t);
     assert(n == 2);
     assert(s == "hello world hello":t);
   }

--- a/test/regex/emptyregex.chpl
+++ b/test/regex/emptyregex.chpl
@@ -29,4 +29,4 @@ for x in r.split(s) do
   writef("%t\n", x);
 
 writeln();
-writeln(r.subn("A", "one"));
+writeln("one".replaceAndCount(r, "A"));

--- a/test/regex/ferguson/regex-no-leak.good
+++ b/test/regex/ferguson/regex-no-leak.good
@@ -97,9 +97,9 @@ words.
 Words
 words
 words.
-sub 1
+Replace 1
 Words, w-ords, w-ord.
-sub 2
+Replace 2
 (Words, w-ords, w-ord., 2)
-sub 3
+Replace 3
 Words, w-ords, word.

--- a/test/regex/ferguson/regexp.chpl
+++ b/test/regex/ferguson/regexp.chpl
@@ -243,23 +243,23 @@ writeln("Split 6");
   }
 }
 
-writeln("sub 1");
+writeln("Replace 1");
 {
   var re = compile("(w)(\\w+)":t);
   var str = "Words, words, word.":t;
-  writeln(re.sub("\\1-\\2":t, str, true));
+  writeln(str.replace(re, "\\1-\\2":t, count=-1));
 }
 
-writeln("sub 2");
+writeln("Replace 2");
 {
   var re = compile("(w)(\\w+)":t);
   var str = "Words, words, word.":t;
-  writeln(re.subn("\\1-\\2":t, str, true));
+  writeln(str.replaceAndCount(re, "\\1-\\2":t, count=-1));
 }
 
-writeln("sub 3");
+writeln("Replace 3");
 {
   var re = compile("(w)(\\w+)":t);
   var str = "Words, words, word.":t;
-  writeln(re.sub("\\1-\\2":t, str, false));
+  writeln(str.replace(re, "\\1-\\2":t, count=1));
 }

--- a/test/regex/ferguson/regexp.good
+++ b/test/regex/ferguson/regexp.good
@@ -97,9 +97,9 @@ words.
 Words
 words
 words.
-sub 1
+Replace 1
 Words, w-ords, w-ord.
-sub 2
+Replace 2
 (Words, w-ords, w-ord., 2)
-sub 3
+Replace 3
 Words, w-ords, word.

--- a/test/regex/localFastPath.chpl
+++ b/test/regex/localFastPath.chpl
@@ -84,7 +84,7 @@ proc subL() {
   var s = "abaabaaab":t;
   var r = compile("a+":t);
   writeln("subL");
-  writeln(r.sub("A":t, s));
+  writeln(s.replace(r, "A":t));
   writeln();
 }
 
@@ -94,7 +94,7 @@ proc subR(param rvf=true) {
   on locales1 {
     if !rvf then preventRvf(r);
     writef("subR(rvf=%t)\n", rvf);
-    writeln(r.sub("A":t, s));
+    writeln(s.replace(r, "A":t));
     writeln();
   }
 }

--- a/test/regex/nullByteBug.chpl
+++ b/test/regex/nullByteBug.chpl
@@ -4,7 +4,7 @@ var myRegex = compile(b"a+");
 
 var str = b"oneatwo";
 
-writef("%t\n", myRegex.subn(b"\x00", str));
+writef("%t\n", str.replaceAndCount(myRegex, b"\x00"));
 
 writef("%t\n", compile(b"\x00"):bytes);
 writef("%t\n", compile(b"a\x00"):bytes);
@@ -14,4 +14,4 @@ var r3 = compile(b"\x00+");
 
 writef("%t\n", r3:bytes);
 
-writef("%t\n", r3.sub(b"A", b"a\x00b\x00\x00c\x00\x00\x00"));
+writef("%t\n", b"a\x00b\x00\x00c\x00\x00\x00".replace(r3, b"A"));

--- a/test/regex/replaceAndCount.chpl
+++ b/test/regex/replaceAndCount.chpl
@@ -23,6 +23,7 @@ test("foo", "o", "X", count=-123);
 
 test("11111", "1+", "0", count=2);
 test("11a11", "1+", "0", count=3);
+test("1a111", "1+", "0", count=3);
 test("11a11"*2, "1+", "0", count=2);
 
 test("banana", "ana", "X", count=2);

--- a/test/regex/replaceAndCount.chpl
+++ b/test/regex/replaceAndCount.chpl
@@ -1,0 +1,28 @@
+use Regex;
+use IO;
+
+proc test(str, pattern, repl, count) {
+  var r = compile(pattern);
+  writeln("%s.replaceAndCount(%s, %s)".format(str, pattern, repl));
+  const base = str.replaceAndCount(r, repl);
+  // these two are testing the fast path
+  writeln("Default: ", base);
+  writeln("count=1: ", str.replaceAndCount(r, repl, count=1));
+
+  // these two are testing the slow path. The first one is effectively doing the
+  // same thing as "Default" above.
+  writeln("count=", base[1], ": ",  str.replaceAndCount(r, repl, count=base[1]));
+  writeln("count=", count, ": ", str.replaceAndCount(r, repl, count=count));
+  writeln();
+}
+
+test("", "", "X", count=0);
+
+test("foo", "o", "X", count=0);
+test("foo", "o", "X", count=-123);
+
+test("11111", "1+", "0", count=2);
+test("11a11", "1+", "0", count=3);
+test("11a11"*2, "1+", "0", count=2);
+
+test("banana", "ana", "X", count=2);

--- a/test/regex/replaceAndCount.execopts
+++ b/test/regex/replaceAndCount.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/regex/replaceAndCount.good
+++ b/test/regex/replaceAndCount.good
@@ -28,6 +28,12 @@ count=1: (0a11, 1)
 count=2: (0a0, 2)
 count=3: (0a0, 2)
 
+1a111.replaceAndCount(1+, 0)
+Default: (0a0, 2)
+count=1: (0a111, 1)
+count=2: (0a0, 2)
+count=3: (0a0, 2)
+
 11a1111a11.replaceAndCount(1+, 0)
 Default: (0a0a0, 3)
 count=1: (0a1111a11, 1)

--- a/test/regex/replaceAndCount.good
+++ b/test/regex/replaceAndCount.good
@@ -1,0 +1,42 @@
+.replaceAndCount(, X)
+Default: (X, 1)
+count=1: (X, 1)
+count=1: (X, 1)
+count=0: (, 0)
+
+foo.replaceAndCount(o, X)
+Default: (fXX, 2)
+count=1: (fXo, 1)
+count=2: (fXX, 2)
+count=0: (foo, 0)
+
+foo.replaceAndCount(o, X)
+Default: (fXX, 2)
+count=1: (fXo, 1)
+count=2: (fXX, 2)
+count=-123: (fXX, 2)
+
+11111.replaceAndCount(1+, 0)
+Default: (0, 1)
+count=1: (0, 1)
+count=1: (0, 1)
+count=2: (0, 1)
+
+11a11.replaceAndCount(1+, 0)
+Default: (0a0, 2)
+count=1: (0a11, 1)
+count=2: (0a0, 2)
+count=3: (0a0, 2)
+
+11a1111a11.replaceAndCount(1+, 0)
+Default: (0a0a0, 3)
+count=1: (0a1111a11, 1)
+count=3: (0a0a0, 3)
+count=2: (0a0a11, 2)
+
+banana.replaceAndCount(ana, X)
+Default: (bXna, 1)
+count=1: (bXna, 1)
+count=1: (bXna, 1)
+count=2: (bXna, 1)
+

--- a/test/regex/replaceAndCountPerf.chpl
+++ b/test/regex/replaceAndCountPerf.chpl
@@ -8,6 +8,7 @@ config const repeatCount = 4;
 config const replacementCount = repeatCount;
 config const verify = true;
 config const printResult = true;
+config const printTime = false;
 config const numIter = 10;
 
 if useGlobal then assert(replacementCount == repeatCount);
@@ -40,4 +41,4 @@ if verify {
   }
 }
 
-writeln("Time per iteration (s): ", t.elapsed()/numIter);
+if printTime then writeln("Time per iteration (s): ", t.elapsed()/numIter);

--- a/test/regex/replaceAndCountPerf.chpl
+++ b/test/regex/replaceAndCountPerf.chpl
@@ -1,0 +1,43 @@
+use Regex;
+use Time;
+
+config const useGlobal = false;
+config const nonMatchingIntervalLen = 3;
+config const matchingIntervalLen = 3;
+config const repeatCount = 4;
+config const replacementCount = repeatCount;
+config const verify = true;
+config const printResult = true;
+config const numIter = 10;
+
+if useGlobal then assert(replacementCount == repeatCount);
+if replacementCount != repeatCount {
+  writeln("Warning: can't use `useGlobal` to compare performance");
+}
+
+var r = compile("1+");
+var s = ("a"*nonMatchingIntervalLen+"1"*matchingIntervalLen)*repeatCount;
+var t: stopwatch;
+
+var ret: (string, int);
+for i in 0..numIter {
+  if i==1 then t.start();
+  if useGlobal then
+    ret = s.replaceAndCount(r, "0");
+  else
+    ret = s.replaceAndCount(r, "0", count=replacementCount);
+}
+t.stop();
+
+if printResult then writeln(ret);
+
+if verify {
+  if repeatCount == replacementCount {
+    assert(ret == s.replaceAndCount(r, "0"));
+  }
+  else {
+    writeln("Can't verify the result");
+  }
+}
+
+writeln("Time per iteration (s): ", t.elapsed()/numIter);

--- a/test/regex/replaceAndCountPerf.good
+++ b/test/regex/replaceAndCountPerf.good
@@ -1,0 +1,2 @@
+(aaa0aaa0aaa0aaa0, 4)
+Time per iteration (s): 4.1e-06

--- a/test/regex/replaceAndCountPerf.good
+++ b/test/regex/replaceAndCountPerf.good
@@ -1,2 +1,1 @@
 (aaa0aaa0aaa0aaa0, 4)
-Time per iteration (s): 4.1e-06

--- a/test/release/examples/benchmarks/shootout/regexdna-redux.chpl
+++ b/test/release/examples/benchmarks/shootout/regexdna-redux.chpl
@@ -33,7 +33,7 @@ proc main(args: [] string) {
   const initLen = data.size;
 
   // remove newlines
-  data = compile(">.*\n|\n").sub("", data);
+  data = data.replace(compile(">.*\n|\n"), "");
 
   var copy = data; // make a copy so we can perform replacements in parallel
 
@@ -43,7 +43,7 @@ proc main(args: [] string) {
     // fire off a task to perform replacements
     begin with (ref copy) {
       for (f, r) in subst do
-        copy = compile(f).sub(r, copy);
+        copy = copy.replace(compile(f), r);
     }
 
     // count patterns

--- a/test/release/examples/benchmarks/shootout/regexdna.chpl
+++ b/test/release/examples/benchmarks/shootout/regexdna.chpl
@@ -32,7 +32,7 @@ proc main(args: [] string) {
   const initLen = data.size;
 
   // remove newlines
-  data = compile(">.*\n|\n").sub("", data);
+  data = data.replace(compile(">.*\n|\n"), "");
 
   var copy = data; // make a copy so we can perform replacements in parallel
 
@@ -42,7 +42,7 @@ proc main(args: [] string) {
     // fire off a task to perform replacements
     begin with (ref copy) {
       for (f, r) in subst do
-        copy = compile(f).sub(r, copy);
+        copy = copy.replace(compile(f), r);
     }
 
     // count patterns

--- a/test/studies/shootout/regex-dna/bharshbarg/regexdna.chpl
+++ b/test/studies/shootout/regex-dna/bharshbarg/regexdna.chpl
@@ -32,7 +32,7 @@ proc main(args: [] string) {
   const initLen = data.size;
 
   // remove newlines
-  data = compile(">.*\n|\n").sub("", data);
+  data = data.replace(compile(">.*\n|\n"), "");
 
   var copy = data; // make a copy so we can perform replacements in parallel
 
@@ -42,7 +42,7 @@ proc main(args: [] string) {
     // fire off a task to perform replacements
     begin with (ref copy) {
       for (f, r) in subst do
-        copy = compile(f).sub(r, copy);
+        copy = copy.replace(compile(f), r);
     }
 
     // count patterns

--- a/test/studies/shootout/regexdna-redux/engin/regexredux.chpl
+++ b/test/studies/shootout/regexdna-redux/engin/regexredux.chpl
@@ -31,7 +31,7 @@ proc main(args: [] string) {
   const initLen = data.size;
 
   // remove newlines
-  data = compile(b">.*\n|\n").sub(b"", data);
+  data = data.replace(compile(b">.*\n|\n"), b"");
 
   var copy = data; // make a copy so we can perform replacements in parallel
 
@@ -41,7 +41,7 @@ proc main(args: [] string) {
     // fire off a task to perform replacements
     begin with (ref copy) {
       for (f, r) in subst do
-        copy = compile(f).sub(r, copy);
+        copy = copy.replace(compile(f), r);
     }
 
     // count patterns

--- a/test/studies/shootout/submitted/regexredux2.chpl
+++ b/test/studies/shootout/submitted/regexredux2.chpl
@@ -30,7 +30,7 @@ proc main(args: [] string) {
   const initLen = data.size;
 
   // remove newlines
-  data = compile(">.*\n|\n").sub("", data);
+  data = data.replace(compile(">.*\n|\n"), "");
 
   var copy = data; // make a copy so we can perform replacements in parallel
 
@@ -40,7 +40,7 @@ proc main(args: [] string) {
     // fire off a task to perform replacements
     begin with (ref copy) {
       for (f, r) in subst do
-        copy = compile(f).sub(r, copy);
+        copy = copy.replace(compile(f), r);
     }
 
     // count patterns

--- a/test/studies/shootout/submitted/regexredux2.chpl
+++ b/test/studies/shootout/submitted/regexredux2.chpl
@@ -30,7 +30,7 @@ proc main(args: [] string) {
   const initLen = data.size;
 
   // remove newlines
-  data = data.replace(compile(">.*\n|\n"), "");
+  data = compile(">.*\n|\n").sub("", data);
 
   var copy = data; // make a copy so we can perform replacements in parallel
 
@@ -40,7 +40,7 @@ proc main(args: [] string) {
     // fire off a task to perform replacements
     begin with (ref copy) {
       for (f, r) in subst do
-        copy = copy.replace(compile(f), r);
+        copy = compile(f).sub(r, copy);
     }
 
     // count patterns

--- a/test/studies/shootout/submitted/regexredux2.good
+++ b/test/studies/shootout/submitted/regexredux2.good
@@ -1,5 +1,7 @@
 regexredux2.chpl:10: In function 'main':
 regexredux2.chpl:29: warning: 'readstring' is deprecated; please use 'readString' instead
+regexredux2.chpl:33: warning: regex.sub is deprecated. Please use string.replace.
+regexredux2.chpl:43: warning: regex.sub is deprecated. Please use string.replace.
 agggtaaa|tttaccct 1
 [cgt]gggtaaa|tttaccc[acg] 0
 a[act]ggtaaa|tttacc[agt]t 0

--- a/test/studies/shootout/submitted/regexredux3.chpl
+++ b/test/studies/shootout/submitted/regexredux3.chpl
@@ -31,7 +31,7 @@ proc main(args: [] string) {
   const initLen = data.size;
 
   // remove newlines
-  data = compile(b">.*\n|\n").sub(b"", data);
+  data = data.replace(compile(b">.*\n|\n"), b"");
 
   var copy = data; // make a copy so we can perform replacements in parallel
 
@@ -41,7 +41,7 @@ proc main(args: [] string) {
     // fire off a task to perform replacements
     begin with (ref copy) {
       for (f, r) in subst do
-        copy = compile(f).sub(r, copy);
+        copy = copy.replace(compile(f), r);
     }
 
     // count patterns


### PR DESCRIPTION
With this PR a new `doReplaceAndCount` internal helper will handle all the regex-based replacement. This function chooses between `doReplaceAndCountSlow` and `doReplaceAndCountFast` implementations. The latter is pretty much the same as the current `regex.subn` implementation. The former allows arbitrary `count`s to be passed to match `string.replace(string,count=-1)` interface. This implementation can't fully rely on RE2, so it does its own bookkeeping. In quick performance tests, I observed this function to perform 10% slower compared to the other one when both of them are doing the same effective operation.

Resolves https://github.com/chapel-lang/chapel/issues/19079

Test:
- [x] standard
- [x] gasnet