### PR TITLE
Build both backends for gasnet and gasnet-smp images

### DIFF
--- a/util/packaging/docker/gasnet-smp/Dockerfile
+++ b/util/packaging/docker/gasnet-smp/Dockerfile
@@ -9,6 +9,7 @@ ENV CHPL_RT_OVERSUBSCRIBED yes
 # is far too small for us, so use the SystemV implementation instead.
 ENV CHPL_GASNET_MORE_CFG_OPTIONS "--disable-pshm-posix --enable-pshm-sysv"
 
-RUN make -C $CHPL_HOME \
+RUN CHPL_TARGET_COMPILER=llvm make -C $CHPL_HOME \
+    && CHPL_TARGET_COMPILER=gnu make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall

--- a/util/packaging/docker/gasnet/Dockerfile
+++ b/util/packaging/docker/gasnet/Dockerfile
@@ -3,7 +3,8 @@ FROM chapel/chapel:latest
 ENV CHPL_COMM gasnet
 ENV CHPL_RT_OVERSUBSCRIBED yes
 
-RUN make -C $CHPL_HOME \
+RUN CHPL_TARGET_COMPILER=llvm make -C $CHPL_HOME \
+    && CHPL_TARGET_COMPILER=gnu make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall
 


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/21538, which just made this change for the main Dockerfile. Prior to these changes, building gasnet or gasnet-smp images from the new Chapel image gave us both backends for `CHPL_COMM=none` but only `llvm` backend for `CHPL_COMM=gasnet`.

Related to https://github.com/chapel-lang/chapel/issues/21448.

No further testing is done for this as it is covered by 1) the testing done for identical changes in https://github.com/chapel-lang/chapel/pull/21538 and 2) validation to be done before the new images are pushed.