### PR TITLE
Dyno scope resolver: chain rename and other `as`-related warnings.

### DIFF
--- a/compiler/AST/ImportStmt.cpp
+++ b/compiler/AST/ImportStmt.cpp
@@ -329,7 +329,10 @@ bool ImportStmt::checkValid(Expr* expr) const {
 *                                                                             *
 ************************************** | *************************************/
 void ImportStmt::validateList() {
-  noRepeats();
+  // Dyno already issues these warnings and errors.
+  if (!fDynoCompilerLibrary) {
+    noRepeats();
+  }
 
   validateUnqualified();
   validateRenamed();

--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -312,7 +312,10 @@ bool UseStmt::isValid(Expr* expr) const {
 
 void UseStmt::validateList() {
   if (isPlainUse() == false) {
-    noRepeats();
+    // Dyno already issues these warnings and errors.
+    if (!fDynoCompilerLibrary) {
+      noRepeats();
+    }
 
     validateNamed();
     validateRenamed();

--- a/frontend/include/chpl/framework/resolution-error-classes-list.h
+++ b/frontend/include/chpl/framework/resolution-error-classes-list.h
@@ -79,8 +79,22 @@ ERROR_CLASS(TupleExpansionNamedArgs, const uast::OpCall*, const uast::FnCall*)
 ERROR_CLASS(TupleExpansionNonTuple, const uast::FnCall*, const uast::OpCall*, types::QualifiedType)
 ERROR_CLASS(UnknownEnumElem, const uast::AstNode*, chpl::UniqueString, const types::EnumType*)
 ERROR_CLASS(UnsupportedAsIdent, const uast::As*, const uast::AstNode*)
+ERROR_CLASS(UseImportMultiplyDefined,
+            chpl::UniqueString,
+            const uast::AstNode*,
+            const uast::AstNode*)
+WARNING_CLASS(UseImportMultiplyMentioned,
+              chpl::UniqueString,
+              const uast::AstNode*,
+              const uast::AstNode*)
 ERROR_CLASS(UseImportNotModule, const ID, const resolution::VisibilityStmtKind,
             std::string)
+WARNING_CLASS(UseImportTransitiveRename,
+              chpl::UniqueString,
+              chpl::UniqueString,
+              chpl::UniqueString,
+              const uast::AstNode*,
+              const uast::AstNode*)
 ERROR_CLASS(UseImportUnknownMod,
             const ID,
             const resolution::VisibilityStmtKind,

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -557,7 +557,7 @@ void ErrorUseImportMultiplyDefined::write(ErrorWriterBase& wr) const {
 
   wr.heading(kind_, type_, secondOccurrence, "'",
              symbolName, "' is multiply defined.");
-  wr.note(firstOccurrence, "'", symbolName, "' was first defined here:");
+  wr.message("'", symbolName, "' was first defined here:");
   wr.code(firstOccurrence, { firstOccurrence });
   wr.message("Redefined here:");
   wr.code(secondOccurrence, { secondOccurrence });
@@ -570,7 +570,7 @@ void ErrorUseImportMultiplyMentioned::write(ErrorWriterBase& wr) const {
 
   wr.heading(kind_, type_, secondOccurrence, "'",
              symbolName, "' is repeated.");
-  wr.note(firstOccurrence, "'", symbolName, "' was first mentioned here:");
+  wr.message("'", symbolName, "' was first mentioned here:");
   wr.code(firstOccurrence, { firstOccurrence });
   wr.message("Mentioned again here:");
   wr.code(secondOccurrence, { secondOccurrence });

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -555,7 +555,7 @@ void ErrorUseImportMultiplyDefined::write(ErrorWriterBase& wr) const {
   auto firstOccurrence = std::get<1>(info);
   auto secondOccurrence = std::get<2>(info);
 
-  wr.heading(kind_, type_, secondOccurrence, "identfier '",
+  wr.heading(kind_, type_, secondOccurrence, "'",
              symbolName, "' is multiply defined.");
   wr.note(firstOccurrence, "'", symbolName, "' was first defined here:");
   wr.code(firstOccurrence, { firstOccurrence });
@@ -568,7 +568,7 @@ void ErrorUseImportMultiplyMentioned::write(ErrorWriterBase& wr) const {
   auto firstOccurrence = std::get<1>(info);
   auto secondOccurrence = std::get<2>(info);
 
-  wr.heading(kind_, type_, secondOccurrence, "identfier '",
+  wr.heading(kind_, type_, secondOccurrence, "'",
              symbolName, "' is repeated.");
   wr.note(firstOccurrence, "'", symbolName, "' was first mentioned here:");
   wr.code(firstOccurrence, { firstOccurrence });
@@ -597,7 +597,7 @@ void ErrorUseImportTransitiveRename::write(ErrorWriterBase& wr) const {
   auto firstRename = std::get<3>(info);
   auto secondRename = std::get<4>(info);
 
-  wr.heading(kind_, type_, secondRename, "identfier '",
+  wr.heading(kind_, type_, secondRename, "'",
              middle, "' is repeated.");
   wr.message("First, '", from, "' is renamed to '", middle, "'.");
   wr.code(firstRename, {firstRename});

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -550,6 +550,32 @@ void ErrorUnsupportedAsIdent::write(ErrorWriterBase& wr) const {
   wr.code(expectedIdentifier, { expectedIdentifier });
 }
 
+void ErrorUseImportMultiplyDefined::write(ErrorWriterBase& wr) const {
+  auto symbolName = std::get<UniqueString>(info);
+  auto firstOccurrence = std::get<1>(info);
+  auto secondOccurrence = std::get<2>(info);
+
+  wr.heading(kind_, type_, secondOccurrence, "identfier '",
+             symbolName, "' is multiply defined.");
+  wr.note(firstOccurrence, "'", symbolName, "' was first defined here:");
+  wr.code(firstOccurrence, { firstOccurrence });
+  wr.message("Redefined here:");
+  wr.code(secondOccurrence, { secondOccurrence });
+}
+
+void ErrorUseImportMultiplyMentioned::write(ErrorWriterBase& wr) const {
+  auto symbolName = std::get<UniqueString>(info);
+  auto firstOccurrence = std::get<1>(info);
+  auto secondOccurrence = std::get<2>(info);
+
+  wr.heading(kind_, type_, secondOccurrence, "identfier '",
+             symbolName, "' is repeated.");
+  wr.note(firstOccurrence, "'", symbolName, "' was first mentioned here:");
+  wr.code(firstOccurrence, { firstOccurrence });
+  wr.message("Mentioned again here:");
+  wr.code(secondOccurrence, { secondOccurrence });
+}
+
 void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
   auto id = std::get<const ID>(info);
   auto moduleName = std::get<std::string>(info);
@@ -561,6 +587,24 @@ void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
   wr.code<ID, ID>(id, { id });
   wr.message("Only ", allowedItems(useOrImport), " can be used with '",
              useOrImport, "' statements.");
+}
+
+void ErrorUseImportTransitiveRename::write(ErrorWriterBase& wr) const {
+  auto from = std::get<0>(info);
+  auto middle = std::get<1>(info);
+  auto to = std::get<2>(info);
+
+  auto firstRename = std::get<3>(info);
+  auto secondRename = std::get<4>(info);
+
+  wr.heading(kind_, type_, secondRename, "identfier '",
+             middle, "' is repeated.");
+  wr.message("First, '", from, "' is renamed to '", middle, "'.");
+  wr.code(firstRename, {firstRename});
+  wr.message("Then, '", middle, "' is renamed to '", to, "'.");
+  wr.code(secondRename, {secondRename});
+  wr.note(firstRename, "did you mean to rename '", from, "' to '", to, "'?");
+  wr.message("You can do so by a single rename, '", from, " as ", to, "'.");
 }
 
 void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1023,10 +1023,18 @@ validateAndPushRename(Context* context,
     auto renameNode = visibilityClause->limitation(i);
 
     if (rename.second == toPush.second) {
-      // Renamed to the same thing, that's an error.
-      CHPL_REPORT(context, UseImportMultiplyDefined,
-                  rename.second, renameNode, toPushNode);
-      return;
+      // The target name is the same, but we could still be okay. For instance,
+      // import M.{x,x} as fine. For this to be an error, one of the "renames"
+      // must actually rename a symbol, like {x, y as x} or {y as x, x}.
+      if (rename.first != rename.second ||
+          toPush.first != toPush.second) {
+        // Renamed different things to the same thing, that's an error.
+        CHPL_REPORT(context, UseImportMultiplyDefined,
+                    rename.second, renameNode, toPushNode);
+        return;
+      } else {
+        // Fall through to the next if-statement.
+      }
     }
 
     if (rename.first == toPush.first) {


### PR DESCRIPTION
The production compiler reports when a user tries to rename a variable twice in an import list:
```Chapel
import M.{a as b, b as c}
```
The result of the above import is _not_ an import of `a as c`, but rather, `M.a` being imported as `b` and `M.b` being imported as `c` (if it exists). The warning is thus issued to help users diagnose `M.b not found` if they intended the import to work in the former way.
```
renameChain.chpl:5: warning: identifier 'bar' is repeated
note: Did you mean to rename 'foo' to 'baz'?
renameChain.chpl:5: error: Bad identifier in rename, no known 'bar' in 'M'
```
Dyno didn't have this functionality, or indeed any `as`-validation functionality. This PR adds this, by modifying `convertLimitations` to validate each additional limitation against preceding ones. This makes it possible to mimic the production compiler's errors, and more.

<details>
<summary>Pictures of the new errors, including detailed output and text decoration</summary>
<img width="697" alt="Screen Shot 2023-02-15 at 11 50 02 AM" src="https://user-images.githubusercontent.com/4361282/219137397-46ce15d4-0998-45cf-a330-d3a9418c25bb.png">
<img width="814" alt="Screen Shot 2023-02-15 at 11 50 10 AM" src="https://user-images.githubusercontent.com/4361282/219137413-fa11caa0-e248-4ac0-abed-da9fc449b286.png">
</details>

Why did I change `convertLimitations` instead of adding a method to `VisibilityClause` or something? By the time we get a list of names in `VisibilityClause`, they are completely normalized, and detached from the ASTs that produce them. Furthermore, the context is not currently piped through. Thus, to make it possible to report the errors, including the locations of the broken renames, we'd need to feed in a bunch of additional arguments, and perform additional processing. Furthermore, semantically, a `VisibilityClause` represents a part of a "normalized" representation of uses and imports, detached from the specific syntax. Thus, feeding the ASTs back in feels like muddying the water.

Reviewed by @mppf - thanks!

## Testing
- [x] full local testing
- [x] full local testing with `--dyno` (introduces new ".good-only" changes, using the changes in #21596)
