### PR TITLE
Improve SHOC-Sort implementation

### DIFF
--- a/test/gpu/native/studies/shoc/sort.chpl
+++ b/test/gpu/native/studies/shoc/sort.chpl
@@ -26,6 +26,10 @@ record innerArray {
   type t;
   var D = {0..-1};
   forwarding var A: [D] t;
+
+  proc resize(size: int) {
+    this.D = {0..#size};
+  }
 }
 
 on here.gpus[0] {
@@ -66,14 +70,14 @@ proc runSort(){
                     numScanElts : real / (4 * SCAN_BLOCK_SIZE)) : int) : uint(32);
         if(numBlocks > 1) {
             // Malloc device mem for block sums
-            scanBlockSums[level].D = {0..#numBlocks};
+            scanBlockSums[level].resize(numBlocks);
             level+=1;
         }
         numScanElts = numBlocks;
     } while (numScanElts > 1);
     // Print the above vars to see if they match the expected values
 
-    scanBlockSums[level].D = {0..0};
+    scanBlockSums[level].resize(1);
 
     // Allcoate device mem for sorting kernels
     var dKeys, dVals, dTempKeys, dTempVals : [0..<size] uint(32);

--- a/test/gpu/native/studies/shoc/sort.execopts
+++ b/test/gpu/native/studies/shoc/sort.execopts
@@ -1,0 +1,1 @@
+--gpuDiags

--- a/test/gpu/native/studies/shoc/sort.gpu-keys
+++ b/test/gpu/native/studies/shoc/sort.gpu-keys
@@ -1,3 +1,2 @@
 Sort Rate  25165824 items Median:
 Sort Rate PCIe  25165824 items Median:
-verify:-1: (kernel_launch = 249)


### PR DESCRIPTION
This PR updates the SHOC Sort benchmark implementation to make it closer to the reference C+CUDA version.

Changes:
- use foreach instead of forall: delivers small but noticable improvement
- use array-of-record-wrapped-arrays instead of array-of-lists to implement ragged arrays: delivers 2-3x improvement
- use param-unrolled loops to copy tuples (this is not necessarily making things closer with the reference. But, I believe it is a much better implementation. I am somewhat surprised that it didn't deliver performance improvements, though)

Test:
- [x] sort.chpl passes