### PR TITLE
Adjust convert-uast for module include

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -789,9 +789,9 @@ struct Converter {
 
     UniqueString filePath;
 
-   if (builderResult != nullptr) {
-     filePath = builderResult->filePath();
-   }
+    if (builderResult != nullptr) {
+      filePath = builderResult->filePath();
+    }
 
     // convert the included module
 
@@ -816,6 +816,9 @@ struct Converter {
 
     // allow production compiler to take action now that it is parsed
     noteParsedIncludedModule(mod, astr(filePath));
+
+    // note that the converted 'module include' is the same as 'mod'
+    noteConvertedSym(node, mod);
 
     return buildChapelStmt(new DefExpr(mod));
   }


### PR DESCRIPTION
Resolves a failure with --dyno scope resolving

     visibility/submodule-in-file/errors/DoubleNested

- [x] full local testing
- [x] no new failures with '--dyno' testing

Reviewed by @arezaii - thanks!