### PR TITLE
Update modules/noakes/mod-init-works

### DIFF
--- a/test/modules/noakes/mod-init-works.chpl
+++ b/test/modules/noakes/mod-init-works.chpl
@@ -1,8 +1,8 @@
 module Main {
-  use ChapelStandard.M1;
-  use ChapelStandard.M2;
-  use ChapelStandard.M3;
-  use ChapelStandard.M4;
+  import M1;
+  import M2;
+  import M3;
+  import M4;
 
   writeln();
   writeln('M.1: Module Main');


### PR DESCRIPTION
This PR updates a test that was added to show an internal error.

The test used a pattern like

    use ChapelStandard.M1;

to request the top-level scope.

However, that pattern is not documented anywhere, and does not work with the dyno scope resolver. This PR adjusts it to use

    import M1;

instead, to refer to the M1 in the top-level scope.

Test change only -- not reviewed.