### PR TITLE
Fix a test with a filename collision

### DIFF
--- a/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.chpl
+++ b/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.chpl
@@ -1,12 +1,13 @@
 use FileSystem;
 
-/* Test that copying a directory containing root-owned filed works */
+/* Test that copying a directory containing root-owned files with metadata
+   fails */
 
 config const path = '/usr/include/curses';
 
 proc main() {
   try {
-    FileSystem.copyTree(path, './usercopy', metadata=true);
+    FileSystem.copyTree(path, './usercopy2', metadata=true);
   } catch err {
     writeln(err);
   }

--- a/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.cleanfiles
+++ b/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.cleanfiles
@@ -1,1 +1,1 @@
-usercopy
+usercopy2

--- a/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.good
+++ b/test/library/standard/FileSystem/copyTree/copyRootMetadataBadPerms.good
@@ -1,1 +1,1 @@
-PermissionError: Operation not permitted (in chown with path "./usercopy/curses.h")
+PermissionError: Operation not permitted (in chown with path "./usercopy2")


### PR DESCRIPTION
This test used the same directory name as another test and so failed with a "directory already exists" error. Update it to use a different directory name.