### PR TITLE
Add fixes to prevent permissions errors with nightly HDFS

### DIFF
--- a/util/cron/test-networking-packages.bash
+++ b/util/cron/test-networking-packages.bash
@@ -26,5 +26,8 @@ export CHPL_NIGHTLY_TEST_DIRS="library/packages/Curl library/packages/HDFS"
 
 $CWD/nightly -cron ${nightly_args}
 
+# clean up test files
+$HADOOP_HOME/bin/hdfs dfs -rm -r -f /tmp
+
 #stop hdfs
 $HADOOP_HOME/sbin/stop-dfs.sh

--- a/util/cron/test-networking-packages.bash
+++ b/util/cron/test-networking-packages.bash
@@ -12,13 +12,13 @@ export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/lib/native:$JAVA_HOME/lib:$JAVA_HOME/lib/amd64/server
 
 # remove storage directory root
-rm -rf /tmp/hadoop-chapelu/
+rm -rf /tmp/hadoop-$USER/
 
 #reformat hdfs filesystem
 $HADOOP_HOME/bin/hdfs namenode -format test
 #start hdfs
 $HADOOP_HOME/sbin/start-dfs.sh
-$HADOOP_HOME/bin hdfs dfsadmin -safemode leave
+$HADOOP_HOME/bin/hdfs dfsadmin -safemode leave
 
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="networking-packages"


### PR DESCRIPTION
Fixes a few lines and adds a cleanup command in nightly test script for HDFS tests

# Original issue
nightly HDFS tests failed with
```
RemoteException: Permission denied: user=chapelu, access=WRITE, inode="/tmp":abrahaja:supergroup:drwxr-xr-x
```
This was caused by manual testing of the HDFS leaving behind files. These left behind files (/tmp/lots-of-numbers.txt and /tmp/testfile.txt) where owned by the user `abrahaja`. When the nightly test then tried to overwrite these files as user `chapelu`, the tests failed with the above permission issues. This is manually fixed by just deleting the files, but adding them to the testing script will hopefully prevent these issues in the future.

# Changes
- make existing code more user agnostic
- fix typo that was erroring
- add cleanup of `/tmp`

# Testing
- tested manually
- will watch nightly reports to ensure errors don't continue
