### PR TITLE
Add error for ambiguous use

### DIFF
--- a/frontend/include/chpl/framework/resolution-error-classes-list.h
+++ b/frontend/include/chpl/framework/resolution-error-classes-list.h
@@ -132,3 +132,7 @@ WARNING_CLASS(HiddenFormal,
     const uast::Formal*,
     const uast::VisibilityClause*,
     const resolution::VisibilityStmtKind)
+ERROR_CLASS(AmbiguousIdentifier,
+    UniqueString,
+    ID,
+    std::vector<ID>)

--- a/frontend/lib/framework/resolution-error-classes-list.cpp
+++ b/frontend/lib/framework/resolution-error-classes-list.cpp
@@ -828,6 +828,26 @@ void ErrorHiddenFormal::write(ErrorWriterBase& wr) const {
   return;
 }
 
+void ErrorAmbiguousIdentifier::write(ErrorWriterBase& wr) const {
+  auto name = std::get<UniqueString>(info);
+  auto mentionId = std::get<ID>(info);
+  auto potentialTargetIds = std::get<std::vector<ID>>(info);
+
+  wr.heading(kind_, type_, mentionId,
+             "'", name, "' is ambiguous");
+
+  wr.code<ID, ID>(mentionId, { mentionId });
+
+  bool printedOne = false;
+  for (auto& id : potentialTargetIds) {
+    wr.note(id, printedOne ? "or ":"", "it could refer to this '", name, "'");
+    printedOne = true;
+    wr.code<ID, ID>(id, { id });
+  }
+  return;
+}
+
+
 /* end resolution errors */
 
 } // end namespace 'chpl'


### PR DESCRIPTION
This is intended to resolve a failure with `--dyno` with the test

    modules/lydia/fnModNameConflict2

It adds an error for the case that a use/import statement can refer to multiple things. (PR #20866 added an assertion instead of an error for this case).

Example error messages:

```
$ chpl test/modules/lydia/fnModNameConflict2.chpl --dyno --detailed-errors
─── error in test/modules/lydia/fnModNameConflict2.chpl:14 [AmbiguousIdentifier] ───
  'M1' is ambiguous
       |
    14 |   use M1;
       |       ⎺⎺
       |
  It could refer to this 'M1'
      |
    3 |   proc M1() {
      |        ⎺⎺
      |
  Or it could refer to this 'M1'
      |
    7 |   module M1 {
      |   ⎺⎺⎺⎺⎺⎺⎺⎺⎺
      |

```

```
$ chpl test/modules/lydia/fnModNameConflict2.chpl --dyno 
test/modules/lydia/fnModNameConflict2.chpl:1: In module 'OuterModule':
test/modules/lydia/fnModNameConflict2.chpl:14: error: 'M1' is ambiguous
test/modules/lydia/fnModNameConflict2.chpl:3: note: it could refer to this 'M1'
test/modules/lydia/fnModNameConflict2.chpl:7: note: or it could refer to this 'M1'
```

Reviewed by @DanilaFe - thanks!

- [x] full local testing
- [x] no unexpected failures with `--dyno`