### PR TITLE
additional fix for hadoop nightly tests

### DIFF
--- a/util/cron/test-networking-packages.bash
+++ b/util/cron/test-networking-packages.bash
@@ -19,7 +19,8 @@ $HADOOP_HOME/bin/hdfs namenode -format test
 #start hdfs
 $HADOOP_HOME/sbin/start-dfs.sh
 $HADOOP_HOME/bin/hdfs dfsadmin -safemode leave
-
+# make sure files are owned by the user
+$HADOOP_HOME/bin/hdfs dfs -chown -R $USER /
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="networking-packages"
 export CHPL_NIGHTLY_TEST_DIRS="library/packages/Curl library/packages/HDFS"


### PR DESCRIPTION
Adds a permission change for the root directory to the currently running user. This should prevent further permissions issues with the nightly testing, as well as be more robust against local testing.

After watching the tests over a few days, the problem does seem to now be fixed. Changing the ownership of the DFS root node to the current user allows the tests to run. The fix to the script should allow users to run the tests manually without disturbing the nightly environment