### PR TITLE
Refactor channel.writebits to fileWriter.writeBits

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8676,7 +8676,7 @@ static Type* moveDetermineRhsTypeErrorIfInvalid(CallExpr* call) {
                 (
                     std::strcmp("write", rhsName) == 0 ||
                     std::strcmp("writeln", rhsName) == 0 ||
-                    std::strcmp("writebits", rhsName) == 0 ||
+                    std::strcmp("writeBits", rhsName) == 0 ||
                     std::strcmp("writeBytes", rhsName) == 0 ||
                     std::strcmp("writef", rhsName) == 0
                 )

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5938,7 +5938,7 @@ proc _channel.writebits(v:integral, nbits:integral) throws {
   :throws UnexpectedEofError: Thrown if the write operation exceeds the
                               ``fileWriter``'s specified range.
   :throws IllegalArgumentError: Thrown if writing more bits than fit into `x`.
-  :throws SystemError: Thrown if the bits could not be written to the channel.
+  :throws SystemError: Thrown if the bits could not be written to the ```fileWriter``.
 */
 proc fileWriter.writeBits(x: integral, numBits: int) : void throws {
   if castChecking {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5944,12 +5944,12 @@ proc fileWriter.writeBits(x: integral, numBits: int) : void throws {
   if castChecking {
     // Error if writing more bits than fit into x
     if Types.numBits(x.type) < numBits then
-      throw new owned IllegalArgumentError("x, numBits", 
+      throw new owned IllegalArgumentError("x, numBits",
               "writeBits numBits=" + numBits:string +
                " > bits in x:" + x.type:string);
     // Error if writing negative number of bits
     if isIntType(numBits.type) && numBits < 0 then
-      throw new owned IllegalArgumentError("numBits", 
+      throw new owned IllegalArgumentError("numBits",
               "writeBits numBits=" + numBits:string + " < 0");
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5945,7 +5945,7 @@ proc fileWriter.writeBits(x: integral, numBits: int) : void throws {
     // Error if writing more bits than fit into x
     if Types.numBits(x.type) < numBits then
       throw new owned IllegalArgumentError("x, numBits", 
-              "writeBits numBits=" + nbits:string +
+              "writeBits numBits=" + numBits:string +
                " > bits in x:" + x.type:string);
     // Error if writing negative number of bits
     if isIntType(numBits.type) && numBits < 0 then

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5949,7 +5949,7 @@ proc fileWriter.writeBits(x: integral, numBits: int) : void throws {
                " > bits in x:" + x.type:string);
     // Error if writing negative number of bits
     if isIntType(numBits.type) && numBits < 0 then
-      throw new owned IllegalArgumentError("nbits", 
+      throw new owned IllegalArgumentError("numBits", 
               "writeBits numBits=" + numBits:string + " < 0");
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5923,30 +5923,40 @@ proc fileReader.readBits(type resultType, numBits:int):resultType throws {
   return tmp;
 }
 
-/*
-   Write bits with binary I/O
 
-   :arg v: a value containing *nbits* bits to write the least-significant bits
-   :arg nbits: how many bits to write
-
-   :throws UnexpectedEofError: Thrown if the write operation exceeds the
-                               ``fileWriter``'s specified range.
-   :throws IllegalArgumentError: Thrown if writing more bits than fit into `v`.
-   :throws SystemError: Thrown if the bits could not be written to the channel.
- */
+deprecated "channel.writebits is deprecated - please use :proc:`fileWriter.writeBits` instead"
 proc _channel.writebits(v:integral, nbits:integral) throws {
+  this.writeBits(v, nbits:int);
+}
+
+/*
+  Write bits with binary I/O
+
+  :arg x: a value containing *numBits* bits to write the least-significant bits
+  :arg numBits: how many bits to write
+
+  :throws UnexpectedEofError: Thrown if the write operation exceeds the
+                              ``fileWriter``'s specified range.
+  :throws IllegalArgumentError: Thrown if writing more bits than fit into `x`.
+  :throws SystemError: Thrown if the bits could not be written to the channel.
+*/
+proc fileWriter.writeBits(x: integral, numBits: int) : void throws {
   if castChecking {
-    // Error if writing more bits than fit into v
-    if numBits(v.type) < nbits then
-      throw new owned IllegalArgumentError("v, nbits", "writebits nbits=" + nbits:string +
-                                                 " > bits in v:" + v.type:string);
+    // Error if writing more bits than fit into x
+    if Types.numBits(x.type) < numBits then
+      throw new owned IllegalArgumentError("x, numBits", 
+              "writeBits numBits=" + nbits:string +
+               " > bits in x:" + x.type:string);
     // Error if writing negative number of bits
-    if isIntType(nbits.type) && nbits < 0 then
-      throw new owned IllegalArgumentError("nbits", "writebits nbits=" + nbits:string + " < 0");
+    if isIntType(numBits.type) && numBits < 0 then
+      throw new owned IllegalArgumentError("nbits", 
+              "writeBits numBits=" + numBits:string + " < 0");
   }
 
-  try this.write(new ioBits(v:uint(64), nbits:int(8)));
+  try this.write(new ioBits(x:uint(64), numBits:int(8)));
 }
+
+
 
 /*
   Write ``size`` coidpoints from a :type:`~String.string` to a ``filewriter``

--- a/test/deprecated/IO/channel-writebits.catfiles
+++ b/test/deprecated/IO/channel-writebits.catfiles
@@ -1,0 +1,1 @@
+test.bin

--- a/test/deprecated/IO/channel-writebits.chpl
+++ b/test/deprecated/IO/channel-writebits.chpl
@@ -1,0 +1,13 @@
+use FileSystem;
+use IO;
+
+config const testfile="test.bin";
+var f = open(testfile, ioMode.cwr);
+var r = f.writer(kind=ionative);
+var tmp = 0b101;
+
+// should throw deprecation
+r.writebits(tmp, 3);
+
+FileSystem.remove(testfile);
+

--- a/test/deprecated/IO/channel-writebits.chpl
+++ b/test/deprecated/IO/channel-writebits.chpl
@@ -4,10 +4,9 @@ use IO;
 config const testfile="test.bin";
 var f = open(testfile, ioMode.cwr);
 var r = f.writer(kind=ionative);
-var tmp = 0b101;
+
 
 // should throw deprecation
-r.writebits(tmp, 3);
-
-FileSystem.remove(testfile);
-
+r.writebits(0x41, 8);
+r.writeBits(0x41, 8);
+r.writeBits(0xA, 8);

--- a/test/deprecated/IO/channel-writebits.cleanfiles
+++ b/test/deprecated/IO/channel-writebits.cleanfiles
@@ -1,0 +1,1 @@
+test.bin

--- a/test/deprecated/IO/channel-writebits.good
+++ b/test/deprecated/IO/channel-writebits.good
@@ -1,0 +1,1 @@
+channel-writebits.chpl:10: warning: channel.writebits is deprecated - please use fileWriter.writeBits instead

--- a/test/deprecated/IO/channel-writebits.good
+++ b/test/deprecated/IO/channel-writebits.good
@@ -1,1 +1,2 @@
 channel-writebits.chpl:10: warning: channel.writebits is deprecated - please use fileWriter.writeBits instead
+AA

--- a/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWritebits.chpl
+++ b/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWritebits.chpl
@@ -1,6 +1,6 @@
 use IO;
 
 var fw = openTempFile().writer();
-if fw.writebits(7, 3) {
+if fw.writeBits(7, 3) {
     writeln("nope");
 }

--- a/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWritebits.good
+++ b/test/deprecated/IO/specailWritersReturnErrorMessage/wrbWritebits.good
@@ -1,1 +1,1 @@
-wrbWritebits.chpl:4: error: illegal use of return value from 'writebits'. Note: if you wish to detect early EOF from a write call, check for an EofError using a try-catch block
+wrbWritebits.chpl:4: error: illegal use of return value from 'writeBits'. Note: if you wish to detect early EOF from a write call, check for an EofError using a try-catch block

--- a/test/exercises/Mandelbrot/MPlot.chpl
+++ b/test/exercises/Mandelbrot/MPlot.chpl
@@ -197,15 +197,15 @@ const header_size = 14;
         var nbits = 0;
         for j in Dom.dim(1) {
           var bit = (if NumSteps[i,j] then 255 else 0):uint;
-          outfile.writebits(bit, 8);
-          outfile.writebits(bit, 8);
-          outfile.writebits(bit, 8);
+          outfile.writeBits(bit, 8);
+          outfile.writeBits(bit, 8);
+          outfile.writeBits(bit, 8);
           nbits += 24;
         }
         // write the padding.
         // The padding is only rounding up to 4 bytes so
-        // can be written in a single writebits call.
-        outfile.writebits(0:uint, (row_size_bits-nbits):int(8));
+        // can be written in a single writeBits call.
+        outfile.writeBits(0:uint, (row_size_bits-nbits):int(8));
       }
     }
 
@@ -215,15 +215,15 @@ const header_size = 14;
         for j in Dom.dim(1) {
           var grey = ((255*NumSteps[i,j])/maxSteps):uint;
           // write 24-bit color value by repeating grey
-          outfile.writebits(grey, 8);
-          outfile.writebits(grey, 8);
-          outfile.writebits(grey, 8);
+          outfile.writeBits(grey, 8);
+          outfile.writeBits(grey, 8);
+          outfile.writeBits(grey, 8);
           nbits += 24;
         }
         // write the padding.
         // The padding is only rounding up to 4 bytes so
-        // can be written in a single writebits call.
-        outfile.writebits(0:uint, (row_size_bits-nbits):int(8));
+        // can be written in a single writeBits call.
+        outfile.writeBits(0:uint, (row_size_bits-nbits):int(8));
       }
     }
 
@@ -235,15 +235,15 @@ const header_size = 14;
           var blue:uint = 0;
           var red = ((255*NumSteps[i,j])/maxSteps):uint;
           // write 24-bit color value
-          outfile.writebits(blue, 8);
-          outfile.writebits(green, 8);
-          outfile.writebits(red, 8);
+          outfile.writeBits(blue, 8);
+          outfile.writeBits(green, 8);
+          outfile.writeBits(red, 8);
           nbits += 24;
         }
         // write the padding.
         // The padding is only rounding up to 4 bytes so
-        // can be written in a single writebits call.
-        outfile.writebits(0:uint, (row_size_bits-nbits):int(8));
+        // can be written in a single writeBits call.
+        outfile.writeBits(0:uint, (row_size_bits-nbits):int(8));
       }
     }
   }

--- a/test/exercises/c-ray/Image.chpl
+++ b/test/exercises/c-ray/Image.chpl
@@ -149,14 +149,14 @@ proc writeImageBMP(outfile, pixels) {
       var bluev = (p >> colorOffset(blue)) & colorMask;
 
       // write 24-bit color value
-      outfile.writebits(bluev, bitsPerColor);
-      outfile.writebits(greenv, bitsPerColor);
-      outfile.writebits(redv, bitsPerColor);
+      outfile.writeBits(bluev, bitsPerColor);
+      outfile.writeBits(greenv, bitsPerColor);
+      outfile.writeBits(redv, bitsPerColor);
       nbits += numColors * bitsPerColor;
     }
     // write the padding.
     // The padding is only rounding up to 4 bytes so
-    // can be written in a single writebits call.
-    outfile.writebits(0:uint, (rowSizeBits-nbits):int(8));
+    // can be written in a single writeBits call.
+    outfile.writeBits(0:uint, (rowSizeBits-nbits):int(8));
   }
 }

--- a/test/io/ferguson/bits-errors.big-writebits.good
+++ b/test/io/ferguson/bits-errors.big-writebits.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'x, numBits': writeBits numBits=9 > bits in v:uint(8)
+uncaught IllegalArgumentError: illegal argument 'x, numBits': writeBits numBits=9 > bits in x:uint(8)
   bits-errors.chpl:35: thrown here
   bits-errors.chpl:35: uncaught here

--- a/test/io/ferguson/bits-errors.big-writebits.good
+++ b/test/io/ferguson/bits-errors.big-writebits.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'v, nbits': writebits nbits=9 > bits in v:uint(8)
+uncaught IllegalArgumentError: illegal argument 'x, numBits': writeBits numBits=9 > bits in v:uint(8)
   bits-errors.chpl:35: thrown here
   bits-errors.chpl:35: uncaught here

--- a/test/io/ferguson/bits-errors.chpl
+++ b/test/io/ferguson/bits-errors.chpl
@@ -10,7 +10,7 @@ var f = open(testfile, ioMode.cwr);
   var w = f.writer(kind=ionative);
 
     // Write 011
-    w.writebits(0b011, 3);
+    w.writeBits(0b011, 3);
     w.close();
 }
 
@@ -21,7 +21,7 @@ if test == 1 {
     // Write 011
     var x = 0b011;
     var nbits = -1;
-    w.writebits(x, nbits);
+    w.writeBits(x, nbits);
     w.close();
 }
 
@@ -32,7 +32,7 @@ if test == 2 {
     // Write 011
     var x:uint(8) = 0b011;
     var nbits = 9;
-    w.writebits(x, nbits);
+    w.writeBits(x, nbits);
     w.close();
 }
 

--- a/test/io/ferguson/bits-errors.negative-writebits.good
+++ b/test/io/ferguson/bits-errors.negative-writebits.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'nbits': writebits nbits=-1 < 0
+uncaught IllegalArgumentError: illegal argument 'numBits': writeBits numBits=-1 < 0
   bits-errors.chpl:24: thrown here
   bits-errors.chpl:24: uncaught here

--- a/test/io/ferguson/bits-signed.chpl
+++ b/test/io/ferguson/bits-signed.chpl
@@ -38,7 +38,7 @@ if test == 2 { // uints
 
       // Write 011
       var x:uint = 0b011;
-      var nbits:uint = 3;
+      var nbits:int = 3;
       // now x, nbits are int
       w.writeBits(x, nbits);
       w.close();

--- a/test/io/ferguson/bits-signed.chpl
+++ b/test/io/ferguson/bits-signed.chpl
@@ -16,7 +16,7 @@ if test == 1 { // ints
       var x = 0b011;
       var nbits = 3;
       // now x, nbits are int
-      w.writebits(x, nbits);
+      w.writeBits(x, nbits);
       w.close();
   }
 
@@ -40,7 +40,7 @@ if test == 2 { // uints
       var x:uint = 0b011;
       var nbits:uint = 3;
       // now x, nbits are int
-      w.writebits(x, nbits);
+      w.writeBits(x, nbits);
       w.close();
   }
 
@@ -64,7 +64,7 @@ if test == 3 { // int(8)s
       var x:int(8) = 0b011;
       var nbits:int(8) = 3;
       // now x, nbits are int
-      w.writebits(x, nbits);
+      w.writeBits(x, nbits);
       w.close();
   }
 
@@ -88,7 +88,7 @@ if test == 4 { // uint(8)s
       var x:uint(8) = 0b011;
       var nbits:uint(8) = 3;
       // now x, nbits are int
-      w.writebits(x, nbits);
+      w.writeBits(x, nbits);
       w.close();
   }
 

--- a/test/io/ferguson/bits64error.chpl
+++ b/test/io/ferguson/bits64error.chpl
@@ -8,7 +8,7 @@ config const fname = "error.data";
   var myfile = open(fname, ioMode.cw).writer();
   for i in 0..#n {
     var x:uint = i:uint;
-    myfile.writebits(x, 63);
+    myfile.writeBits(x, 63);
   }
   myfile.close();
 }

--- a/test/io/ferguson/easybits.chpl
+++ b/test/io/ferguson/easybits.chpl
@@ -9,7 +9,7 @@ var f = open(testfile, ioMode.cwr);
     var w = f.writer(kind=ionative);
 
     // Write 011
-    w.writebits(0b011, 3);
+    w.writeBits(0b011, 3);
     w.close();
 }
 

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -341,9 +341,9 @@ if example == 0 || example == 7 {
     var w = f.writer(kind=ionative);
 
     // Write 011 0110 011110000
-    w.writebits(0b011, 3);
-    w.writebits(0b0110, 4);
-    w.writebits(0b011110000, 9);
+    w.writeBits(0b011, 3);
+    w.writeBits(0b0110, 4);
+    w.writeBits(0b011110000, 9);
     w.close();
   }
 


### PR DESCRIPTION
Based on discussion,`channel.writeBits` has been renamed to `fileWriter.writeBits`.

# Summary of changes
- The renamed function also had some argument names and types changed.
  ```chapel
  proc fileWriter.writeBits(x:integral, numBits:int):void throws
  ```
- `channel.writeBits` has been deprecated and now points to fileWriter.writeBits
- All modules/tests using `channel.writebits` have been updated to the new name

# New tests
- a new deprecation test for `channel.writebits`.

# Tested
- ran full paratest
- clicked through the docs to make sure they are still correct

Closes #19491 
Closes Cray/chapel-private#4351