### PR TITLE
Testing fixes for EpochManager 

### DIFF
--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -412,6 +412,7 @@ module EpochManager {
 
   pragma "no doc"
   module VectorModule {
+    private use IO;
     /**
      * Obtained from https://github.com/pnnl/chgl/blob/master/src/Vectors.chpl
      */

--- a/test/library/draft/DistributedMap/v2/use-distributed-map.bad
+++ b/test/library/draft/DistributedMap/v2/use-distributed-map.bad
@@ -1,6 +1,6 @@
 ./Aggregator.chpl:36: In initializer:
 $CHPL_HOME/modules/standard/Types.chpl:250: warning: Initializing a type-inferred variable from a 'sync' is deprecated; apply a 'read??()' method to the right-hand side
-  ./DistributedMap.chpl:733: called as (aggregator(distributedMapImpl(string,int(64),nothing),proc(ref element: int))).init(clientInst: borrowed distributedMapImpl(string,int(64),nothing), updaterFcf: proc(ref element: int)) from method 'updateAggregator'
+  ./DistributedMap.chpl:743: called as (aggregator(distributedMapImpl(string,int(64),nothing),proc(ref element: int))).init(clientInst: borrowed distributedMapImpl(string,int(64),nothing), updaterFcf: proc(ref element: int)) from method 'updateAggregator'
   use-distributed-map.chpl:12: called as (distributedMapImpl(string,int(64),nothing)).updateAggregator(updater: proc(ref element: int))
 Jacob=2
 Jingleheimer=2


### PR DESCRIPTION
In #21586 I introduced a usage of ``fileReader`` without use-ing the IO module. Testing didn't pick this up due to some prediffs. This PR inserts the correct ``use`` and fixes a line number in a .bad file.