### PR TITLE
Mark 'Map.parsafe' unstable

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -78,6 +78,7 @@ module Map {
     type valType;
 
     /* If `true`, this map will perform parallel safe operations. */
+    @unstable "'map.parSafe' is unstable"
     param parSafe = false;
 
     /*

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -78,7 +78,6 @@ module Map {
     type valType;
 
     /* If `true`, this map will perform parallel safe operations. */
-    @unstable "'map.parSafe' is unstable"
     param parSafe = false;
 
     /*
@@ -121,6 +120,35 @@ module Map {
 
       :arg keyType: The type of the keys of this map.
       :arg valType: The type of the values of this map.
+      :arg resizeThreshold: Fractional value that specifies how full this map
+                            can be before requesting additional memory.
+      :arg initialCapacity: Integer value that specifies starting map size. The
+                            map can hold at least this many values before
+                            attempting to resize.
+    */
+    proc init(type keyType, type valType,
+              resizeThreshold=defaultHashTableResizeThreshold,
+              initialCapacity=16) {
+      _checkKeyAndValType(keyType, valType);
+      this.keyType = keyType;
+      this.valType = valType;
+      this.parSafe = false;
+      if resizeThreshold <= 0 || resizeThreshold >= 1 {
+        warning("'resizeThreshold' must be between 0 and 1.",
+                        " 'resizeThreshold' will be set to 0.5");
+        this.resizeThreshold = 0.5;
+      } else {
+        this.resizeThreshold = resizeThreshold;
+      }
+      table = new chpl__hashtable(keyType, valType, this.resizeThreshold,
+                                  initialCapacity);
+    }
+
+    /*
+      Initializes an empty map containing keys and values of given types.
+
+      :arg keyType: The type of the keys of this map.
+      :arg valType: The type of the values of this map.
       :arg parSafe: If `true`, this map will use parallel safe operations.
       :arg resizeThreshold: Fractional value that specifies how full this map
                             can be before requesting additional memory.
@@ -128,7 +156,8 @@ module Map {
                             map can hold at least this many values before
                             attempting to resize.
     */
-    proc init(type keyType, type valType, param parSafe=false,
+    @unstable "'Map.parSafe' is unstable"
+    proc init(type keyType, type valType, param parSafe,
               resizeThreshold=defaultHashTableResizeThreshold,
               initialCapacity=16) {
       _checkKeyAndValType(keyType, valType);
@@ -146,7 +175,27 @@ module Map {
                                   initialCapacity);
     }
 
-    proc init(type keyType, type valType, param parSafe=false,
+    proc init(type keyType, type valType,
+              resizeThreshold=defaultHashTableResizeThreshold,
+              initialCapacity=16)
+      where isNonNilableClass(valType) {
+      _checkKeyAndValType(keyType, valType);
+      this.keyType = keyType;
+      this.valType = valType;
+      this.parSafe = false;
+      if resizeThreshold <= 0 || resizeThreshold >= 1 {
+        warning("'resizeThreshold' must be between 0 and 1.",
+                        " 'resizeThreshold' will be set to 0.5");
+        this.resizeThreshold = 0.5;
+      } else {
+        this.resizeThreshold = resizeThreshold;
+      }
+      table = new chpl__hashtable(keyType, valType, this.resizeThreshold,
+                                  initialCapacity);
+    }
+
+    @unstable "'Map.parSafe' is unstable"
+    proc init(type keyType, type valType, param parSafe,
               resizeThreshold=defaultHashTableResizeThreshold,
               initialCapacity=16)
     where isNonNilableClass(valType) {
@@ -619,7 +668,14 @@ module Map {
     // TODO: rewrite to use formatter interface
     //
     pragma "no doc"
-    proc init(type keyType, type valType, param parSafe=false, r: fileReader) {
+    proc init(type keyType, type valType, r: fileReader) {
+      this.init(keyType, valType, parSafe);
+      readThis(r);
+    }
+
+    pragma "no doc"
+    @unstable "'Map.parSafe' is unstable"
+    proc init(type keyType, type valType, param parSafe, r: fileReader) {
       this.init(keyType, valType, parSafe);
       readThis(r);
     }

--- a/test/classes/weakPointers/passiveCache.chpl
+++ b/test/classes/weakPointers/passiveCache.chpl
@@ -12,7 +12,7 @@ class PassiveCache {
 
     proc init(type dt) {
         this.dataType = dt;
-        this.items = new map(int, weakPointer(shared dt), parSafe=true);
+        this.items = new map(int, weakPointer(shared dt));
     }
 
     inline proc lock() {

--- a/test/unstable/Map/COMPOPTS
+++ b/test/unstable/Map/COMPOPTS
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/unstable/Map/parSafe.chpl
+++ b/test/unstable/Map/parSafe.chpl
@@ -1,0 +1,13 @@
+use Map;
+
+var m1 = new map(int, int);
+var m2 = new map(int, int, parSafe=true);
+var m3 = new map(int, int, parSafe=false);
+
+class MyClass {
+  var i: int;
+}
+
+var m4 = new map(int, shared MyClass);
+var m5 = new map(int, shared MyClass, parSafe=true);
+var m6 = new map(int, shared MyClass, parSafe=false);

--- a/test/unstable/Map/parSafe.good
+++ b/test/unstable/Map/parSafe.good
@@ -1,0 +1,4 @@
+parSafe.chpl:4: warning: 'Map.parSafe' is unstable
+parSafe.chpl:5: warning: 'Map.parSafe' is unstable
+parSafe.chpl:12: warning: 'Map.parSafe' is unstable
+parSafe.chpl:13: warning: 'Map.parSafe' is unstable


### PR DESCRIPTION
`parSafe` is being marked unstable for map since the decision has
not been made how to handle `parSafe` with the new distributed map
implementation. The `init` procs have now been duplicated, with
one having a `parSafe` argument with no default so, if a map is
attempted to be created setting `parSafe`, only at creation will
an unstable warning be issued.

- [x] paratest