### PR TITLE
Clarify language specification about parenless calls and POI

### DIFF
--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -510,9 +510,9 @@ from.  This call site is referred to as the *point of instantiation*.  If
 there are multiple enclosing generic functions or the call is nested
 within a concrete function that is, in turn, nested in generic
 function(s), the point of instantiation is the call site of the innermost
-generic function.  This point of instantiation rule only applies to
-function calls using parentheses. Calls to functions without parentheses
-(:ref:`Functions_without_Parentheses`) cannot use point of instantiation.
+generic function. This rule does not apply to non-method functions declared
+without parantheses (:ref:`Functions_without_Parentheses`): such
+functions cannot be discovered through the point of instantiation.
 
 If no candidate functions are found during the initial steps of
 identifying visible and candidate functions, function resolution

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -511,7 +511,7 @@ there are multiple enclosing generic functions or the call is nested
 within a concrete function that is, in turn, nested in generic
 function(s), the point of instantiation is the call site of the innermost
 generic function. This rule does not apply to non-method functions declared
-without parantheses (:ref:`Functions_without_Parentheses`): such
+without parentheses (:ref:`Functions_without_Parentheses`): such
 functions cannot be discovered through the point of instantiation.
 
 If no candidate functions are found during the initial steps of

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -505,11 +505,14 @@ Function Visibility in Generic Functions
 When resolving a function call, as defined in :ref:`Function_Resolution`,
 there is an additional source of visible functions when the call is
 nested within a generic function. The additional source is the functions
-visible from the call site that the enclosing generic function is invoked from.
-This call site is referred to as the *point of instantiation*.
-If there are multiple enclosing generic functions or the call is nested
-within a concrete function that is, in turn, nested in generic function(s),
-the point of instantiation is the call site of the innermost generic function.
+visible from the call site that the enclosing generic function is invoked
+from.  This call site is referred to as the *point of instantiation*.  If
+there are multiple enclosing generic functions or the call is nested
+within a concrete function that is, in turn, nested in generic
+function(s), the point of instantiation is the call site of the innermost
+generic function.  This point of instantiation rule only applies to
+function calls using parentheses. Calls to functions without parentheses
+(:ref:`Functions_without_Parentheses`) cannot use point of instantiation.
 
 If no candidate functions are found during the initial steps of
 identifying visible and candidate functions, function resolution

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -303,9 +303,15 @@ be called without parentheses.
    to use parentheses when calling ``foo`` or omit them when calling
    ``bar``.
 
+Note that functions called without parentheses cannot resolve to a
+function defined in a generic function's point of instantiation (see
+:ref:`Function_Visibility_in_Generic_Functions`).
+
+
 .. index::
    single: formal arguments
    single: functions; formal arguments
+
 .. _Formal_Arguments:
 
 Formal Arguments

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -303,8 +303,8 @@ be called without parentheses.
    to use parentheses when calling ``foo`` or omit them when calling
    ``bar``.
 
-Note that functions called without parentheses cannot resolve to a
-function defined in a generic function's point of instantiation (see
+Note that non-method functions called without parentheses cannot resolve
+to a function defined in a generic function's point of instantiation (see
 :ref:`Function_Visibility_in_Generic_Functions`).
 
 

--- a/frontend/test/resolution/testPoi.cpp
+++ b/frontend/test/resolution/testPoi.cpp
@@ -749,7 +749,7 @@ static void test6() {
   assert(rACallGeneric == rBCallGeneric);
 }
 
-// check that parenless calls do not use POI
+// check that parenless non-method calls do not use POI
 static void test7() {
   printf("test7\n");
   Context ctx;
@@ -805,6 +805,65 @@ static void test7() {
   assert(rFoo.mostSpecific().isEmpty());
 }
 
+// check that parenless method calls do use POI
+static void test8() {
+  printf("test8\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+    module Library {
+      proc callFoo(x) {
+        x.foo;
+      }
+    }
+    module Application {
+      use Library;
+      proc int.foo { return 1; }
+      proc main() {
+        callFoo(1);
+      }
+    }
+   )"""";
+
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+  assert(vec.size() == 2);
+  auto Lib = vec[0]->toModule();
+  auto App = vec[1]->toModule();
+  assert(Lib);
+  assert(Lib->numStmts() == 1);
+  assert(App);
+  assert(App->numStmts() == 3);
+
+  auto intFooDecl = App->stmt(1)->toFunction();
+  assert(intFooDecl);
+  auto main = App->stmt(2)->toFunction();
+  assert(main);
+  auto callCallFoo = main->stmt(0)->toCall();
+  assert(callCallFoo);
+  auto callFoo = Lib->stmt(0)->toFunction();
+  assert(callFoo);
+  auto dot = callFoo->stmt(0)->toDot();
+  assert(dot);
+  auto foo = dot->field() == "foo";
+  assert(foo);
+
+  auto rMain = resolveConcreteFunction(context, main->id());
+  assert(rMain);
+
+  auto rCallFoo = resolveOnlyCandidate(context, rMain->byAst(callCallFoo));
+  assert(rCallFoo);
+
+  auto rFoo = rCallFoo->byAst(dot);
+  assert(rFoo.associatedActions().size() == 0);
+  assert(!rFoo.mostSpecific().isEmpty());
+  assert(rFoo.mostSpecific().only().fn() != nullptr);
+  assert(rFoo.mostSpecific().only().fn()->id() == intFooDecl->id());
+}
+
 
 int main() {
   test1();
@@ -817,6 +876,7 @@ int main() {
   test5();
   test6();
   test7();
+  test8();
 
   return 0;
 }

--- a/frontend/test/resolution/testPoi.cpp
+++ b/frontend/test/resolution/testPoi.cpp
@@ -785,6 +785,8 @@ static void test7() {
   assert(App);
   assert(App->numStmts() == 3);
 
+  auto fooDecl = App->stmt(1)->toFunction();
+  assert(fooDecl);
   auto main = App->stmt(2)->toFunction();
   assert(main);
   auto callCallFoo = main->stmt(0)->toCall();

--- a/test/functions/resolution/parenless-method-poi.chpl
+++ b/test/functions/resolution/parenless-method-poi.chpl
@@ -1,0 +1,12 @@
+module Library {
+  proc callFoo(x) {
+    x.foo;
+  }
+}
+module Application {
+  use Library;
+  proc int.foo { writeln("In int.foo"); return 1; }
+  proc main() {
+    callFoo(1);
+  }
+}

--- a/test/functions/resolution/parenless-method-poi.good
+++ b/test/functions/resolution/parenless-method-poi.good
@@ -1,0 +1,1 @@
+In int.foo

--- a/test/functions/resolution/parenless-no-poi.chpl
+++ b/test/functions/resolution/parenless-no-poi.chpl
@@ -1,0 +1,15 @@
+module Library {
+  proc callFoo(type t) {
+    return foo;
+  }
+}
+
+module Application {
+  use Library;
+
+  proc foo { return 1; }
+
+  proc main() {
+    callFoo(int);
+  }
+}

--- a/test/functions/resolution/parenless-no-poi.good
+++ b/test/functions/resolution/parenless-no-poi.good
@@ -1,0 +1,2 @@
+parenless-no-poi.chpl:2: In function 'callFoo':
+parenless-no-poi.chpl:3: error: 'foo' undeclared (first use this function)

--- a/test/functions/resolution/parenless-overloads.bad
+++ b/test/functions/resolution/parenless-overloads.bad
@@ -1,24 +1,18 @@
-parenless-overloads.chpl:19: In function 'testParen1a':
-parenless-overloads.chpl:25: warning: R("p1a-yes")
-parenless-overloads.chpl:28: In function 'testParen1b':
-parenless-overloads.chpl:34: warning: R("p1b-yes")
-parenless-overloads.chpl:37: In function 'testParen2a':
-parenless-overloads.chpl:43: warning: R("p2a-yes")
-parenless-overloads.chpl:46: In function 'testParen2b':
-parenless-overloads.chpl:52: warning: R("p2b-yes")
-parenless-overloads.chpl:55: In function 'testParen3a':
-parenless-overloads.chpl:61: warning: R("p3a-yes")
-parenless-overloads.chpl:64: In function 'testParen3b':
-parenless-overloads.chpl:70: warning: R("p3b-yes")
-parenless-overloads.chpl:84: In function 'testNops1b':
-parenless-overloads.chpl:90: warning: R("n1b-yes")
-parenless-overloads.chpl:102: In function 'testNops2b':
-parenless-overloads.chpl:108: warning: R("n2b-yes")
-parenless-overloads.chpl:120: In function 'testNops3b':
-parenless-overloads.chpl:126: warning: R("n3b-yes")
-parenless-overloads.chpl:93: In function 'testNops2a':
-parenless-overloads.chpl:99: warning: R("n2a-no")
 parenless-overloads.chpl:75: In function 'testNops1a':
-parenless-overloads.chpl:80: error: unresolved call 'standinType()'
-parenless-overloads.chpl:78: note: this candidate did not match: standinType
-parenless-overloads.chpl:78: note: because where clause evaluated to false
+parenless-overloads.chpl:77: error: 'standinType' has multiple definitions
+parenless-overloads.chpl:78: note: redefined here
+parenless-overloads.chpl:84: In function 'testNops1b':
+parenless-overloads.chpl:86: error: 'standinType' has multiple definitions
+parenless-overloads.chpl:87: note: redefined here
+parenless-overloads.chpl:93: In function 'testNops2a':
+parenless-overloads.chpl:95: error: 'standinType' has multiple definitions
+parenless-overloads.chpl:96: note: redefined here
+parenless-overloads.chpl:102: In function 'testNops2b':
+parenless-overloads.chpl:104: error: 'standinType' has multiple definitions
+parenless-overloads.chpl:105: note: redefined here
+parenless-overloads.chpl:111: In function 'testNops3a':
+parenless-overloads.chpl:113: error: 'standinType' has multiple definitions
+parenless-overloads.chpl:114: note: redefined here
+parenless-overloads.chpl:120: In function 'testNops3b':
+parenless-overloads.chpl:122: error: 'standinType' has multiple definitions
+parenless-overloads.chpl:123: note: redefined here

--- a/test/functions/resolution/parenless-overloads.skipif
+++ b/test/functions/resolution/parenless-overloads.skipif
@@ -1,2 +1,0 @@
-# Skip this test under Dyno
-CHPL_DYNO_SCOPE_RESOLVE!=false


### PR DESCRIPTION
This PR updates the language specification to clarify POI behavior of non-method parenless calls.

 * adds a test to make sure that parenless non-method calls can't be resolved through POI and parenless method calls can be
 * also adds C++ dyno tests of the same
 * updates the language specification to describe this behavior
 * adjusts a few test-specific problems with a .future about parenless functions

The rationale for calls for parenless methods not being found through POI is primarily that it simplifies the case of resolving an identifier. Any identifier could potentially be a parenless call that is found through POI. At the same time, the production compiler has not considered POI as a source for parenless non-method calls. (And one reason for that is the way the production compiler separates scope resolution and function resolution). Since we do not have a rationale to change that behavior, this PR documents the current behavior in the spec.

Reviewed by @lydia-duncan - thanks!

- [x] full comm=none testing