### PR TITLE
Fix `--memTrack` under qthreads

### DIFF
--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -50,7 +50,7 @@ extern
 #ifdef __cplusplus
 "C"
 #endif
-volatile int chpl_qthread_done_initializing;
+volatile int chpl_qthread_initialized;
 
 #define CHPL_TASK_STD_MODULES_INITIALIZED chpl_task_stdModulesInitialized
 void chpl_task_stdModulesInitialized(void);
@@ -86,7 +86,7 @@ static inline chpl_qthread_tls_t* chpl_qthread_get_tasklocal(void)
 {
     chpl_qthread_tls_t* tls;
 
-    if (chpl_qthread_done_initializing) {
+    if (chpl_qthread_initialized) {
         tls = (chpl_qthread_tls_t*)
                qthread_get_tasklocal(sizeof(chpl_qthread_tls_t));
         if (tls == NULL) {


### PR DESCRIPTION
Since #19804, `--memTrack` calls `chpl_task_getRequestedSubloc`. Under qthreads this calls `chpl_qthread_get_tasklocal`, which only works when qthreads is initialized. This was coded to work before qthreads was initialized, but wasn't expecting to be called after qthreads had been deinitialized and #19804 resulted in these functions getting called after qthreads deinit. Fix that here by marking that qthreads is no longer initialized in a way `chpl_qthread_get_tasklocal` already checks.

Resolves Cray/chapel-private#3417