### PR TITLE
Deprecate ioBits in favor of readBits/writeBits

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2940,8 +2940,7 @@ deprecated "ioBits type is deprecated - please use :proc:`fileReader.readBits` a
 type ioBits = _internalIoBits;
 
 pragma "no doc"
-pragma "compiler generated"
-inline operator :(x: ioBits, type t:string) {
+inline operator :(x: _internalIoBits, type t:string) {
   const ret = "ioBits(v=" + x.v:string + ", nbits=" + x.nbits:string + ")";
   return ret;
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2925,7 +2925,7 @@ inline operator :(x: ioLiteral, type t:string) {
 }
 
 pragma "no doc"
-record _ioBits {
+record _internalIoBits {
   /* The bottom ``numBits`` of x will be read or written */
   var x:uint(64);
   /* How many of the low-order bits of ``x`` should we read or write? */
@@ -2937,7 +2937,7 @@ record _ioBits {
 }
 
 deprecated "ioBits type is deprecated - please use :proc:`fileReader.readBits` and :proc:`fileWriter.writeBits` instead"
-type ioBits = _ioBits;
+type ioBits = _internalIoBits;
 
 pragma "no doc"
 pragma "compiler generated"
@@ -3926,7 +3926,7 @@ proc _isIoPrimitiveType(type t) param return
 
 pragma "no doc"
  proc _isIoPrimitiveTypeOrNewline(type t) param return
-  _isIoPrimitiveType(t) || t == ioNewline || t == ioLiteral || t == ioChar || t == _ioBits;
+  _isIoPrimitiveType(t) || t == ioNewline || t == ioLiteral || t == ioChar || t == _internalIoBits;
 
 // Read routines for all primitive types.
 private proc _read_text_internal(_channel_internal:qio_channel_ptr_t,
@@ -4286,7 +4286,7 @@ proc _channel._decodeOne(ref x:?t, loc:locale) throws {
                               _readWriteThisFromLocale=loc);
   defer { reader._channel_internal = QIO_CHANNEL_PTR_NULL; }
 
-  if t == ioLiteral || t == ioNewline || t == _ioBits || t == ioChar {
+  if t == ioLiteral || t == ioNewline || t == _internalIoBits || t == ioChar {
     reader._readOne(reader.kind, x, reader.getLocaleOfIoRequest());
     return;
   }
@@ -4364,7 +4364,7 @@ private proc _read_io_type_internal(_channel_internal:qio_channel_ptr_t,
     return qio_channel_scan_literal(false, _channel_internal,
                                     x.val.localize().c_str(),
                                     x.val.numBytes: c_ssize_t, x.ignoreWhiteSpace);
-  } else if t == _ioBits {
+  } else if t == _internalIoBits {
     return qio_channel_read_bits(false, _channel_internal, x.x, x.numBits);
   } else if kind == iokind.dynamic {
     var binary:uint(8) = qio_channel_binary(_channel_internal);
@@ -4418,7 +4418,7 @@ private proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
     return qio_channel_write_char(false, _channel_internal, x.ch);
   } else if t == ioLiteral {
     return qio_channel_print_literal(false, _channel_internal, x.val.localize().c_str(), x.val.numBytes:c_ssize_t);
-  } else if t == _ioBits {
+  } else if t == _internalIoBits {
     return qio_channel_write_bits(false, _channel_internal, x.x, x.numBits);
   } else if kind == iokind.dynamic {
     var binary:uint(8) = qio_channel_binary(_channel_internal);
@@ -5892,7 +5892,7 @@ proc fileReader.readBits(ref x:integral, numBits:int):bool throws {
       throw new owned IllegalArgumentError("numBits", "readBits numBits=" + numBits:string + " < 0");
   }
 
-  var tmp:_ioBits;
+  var tmp:_internalIoBits;
   tmp.numBits = numBits:int(8);
   var ret = try this.read(tmp);
   x = tmp.x:x.type;
@@ -5946,7 +5946,7 @@ proc fileWriter.writeBits(x: integral, numBits: int) : void throws {
               "writeBits numBits=" + numBits:string + " < 0");
   }
 
-  try this.write(new _ioBits(x:uint(64), numBits:int(8)));
+  try this.write(new _internalIoBits(x:uint(64), numBits:int(8)));
 }
 
 

--- a/test/deprecated/IO/ioBits.chpl
+++ b/test/deprecated/IO/ioBits.chpl
@@ -1,0 +1,3 @@
+use IO;
+
+var bits: ioBits;

--- a/test/deprecated/IO/ioBits.good
+++ b/test/deprecated/IO/ioBits.good
@@ -1,0 +1,1 @@
+ioBits.chpl:3: warning: ioBits type is deprecated - please use fileReader.readBits and fileWriter.writeBits instead

--- a/test/io/ferguson/io_test.chpl
+++ b/test/io/ferguson/io_test.chpl
@@ -132,7 +132,6 @@ proc main() {
   testio(new ioChar(97));
   testio(new ioNewline());
   testio(new ioLiteral("test"));
-  testio(new ioBits(0b011011001101000110101101, 24));
   
   test_readlines();
 }

--- a/test/io/jade/readWriteBits.chpl
+++ b/test/io/jade/readWriteBits.chpl
@@ -1,0 +1,55 @@
+use IO;
+
+config const noisy = false;
+
+proc testio(param typ:iokind, style:iostyleInternal, x:int, numBits:int)
+{
+  if noisy then writeln("Testing ",typ:int(64)," ",x.type:string," ",style.binary:int(64)," ",style.byteorder:int(64)," ",style.str_style);
+  var f = openTempFile();
+  {
+    var ch = f.writer(typ, style=style);
+    if noisy then writeln("Writing ", x:string);
+    ch.writeBits(x, numBits);
+    ch.close();
+  }
+  {
+    var ch = f.reader(typ, style=style);
+    var y = x;
+    var z = x;
+    if noisy then writeln("Reading element");
+    var got = ch.readBits(y, numBits);
+    if noisy then writeln("Read ", y:string);
+    assert( got );
+    assert( y == x );
+
+    // Try reading another item -- should get EOF
+    if noisy then writeln("Reading another - should get EOF");
+    got = ch.readBits(z, numBits);
+    assert( !got );
+
+    ch.close();
+  }
+  f.close();
+}
+
+proc testio(x:int, numBits:int)
+{
+  // Set up some I/O styles.
+  var styles = ( defaultIOStyleInternal().native(), defaultIOStyleInternal().little(), defaultIOStyleInternal().big(), defaultIOStyleInternal().text() );
+
+  for i in 0..#styles.size {
+    var style = styles[i];
+    if noisy then writeln("STYLE ", i, " iodynamic");
+    testio(iodynamic, style, x, numBits);
+    if noisy then writeln("STYLE ", i, " ionative");
+    testio(ionative, style, x, numBits);
+    if noisy then writeln("STYLE ", i, " iobig");
+    testio(iobig, style, x, numBits);
+    if noisy then writeln("STYLE ", i, " iolittle");
+    testio(iolittle, style, x, numBits);
+  }
+}
+
+proc main() {
+  testio(0b011011001101000110101101, 24);
+}


### PR DESCRIPTION
Based on discussion, deprecates externally facing `ioBits` in favor of `readBits`/`writeBits`

# Summary of changes
- rename `ioBits` to `_internalIoBits`
- make `ioBits` a type alias and deprecate the type
- rename all internal uses to new name

# New tests
- deprecation test for `ioBits`
- move `ioBits` test from generic `io_test` to its own test with `readBits` and `writeBits`

# Tested
- ran full paratest
- clicked through the docs to make sure they are still correct

Closes #20258 
Closes Cray/chapel-private#4364