### PR TITLE
Updates to file initializers replacing openfp and openfd

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -199,7 +199,7 @@ Files
 
 There are several functions that open a file and return a :record:`file`
 including :proc:`open`, :proc:`openTempFile`, :proc:`openMemFile`, the
-:record:`file` initializer that takes a ``c_int`` argument, and the
+:record:`file` initializer that takes an ``int`` argument, and the
 :record:`file` initializer that takes a :type:`~CTypes.c_FILE` argument.
 
 Once a file is open, it is necessary to create associated channel(s) - see
@@ -278,8 +278,8 @@ more details on the situation in which this kind of data race can occur.
   for files created in the following situations:
 
     * with the file initializer that takes a :type:`~CTypes.c_FILE` argument
-    * with the file initializer that takes a ``c_int`` argument, where the
-      ``c_int`` represents a non-seekable system file descriptor
+    * with the file initializer that takes an ``int`` argument, where the
+      ``int`` represents a non-seekable system file descriptor
 
 
 Performing I/O with Channels
@@ -1646,10 +1646,11 @@ private proc initHelper2(ref f: file, fd: c_int, hints = ioHintSet.empty,
 }
 
 @unstable "initializing a file with a style argument is unstable"
-proc file.init(fd: c_int, hints=ioHintSet.empty, style:iostyle) throws {
+proc file.init(fileDescriptor: int, hints=ioHintSet.empty,
+               style:iostyle) throws {
   this.init();
 
-  initHelper2(this, fd, hints, style);
+  initHelper2(this, fileDescriptor.safeCast(c_int), hints, style);
 }
 
 /*
@@ -1676,16 +1677,16 @@ The system file descriptor will be closed when the Chapel file is closed.
   to files backed by non-seekable file descriptors.
 
 
-:arg fd: a system file descriptor.
+:arg fileDescriptor: a system file descriptor.
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :record:`ioHintSet`.
 
 :throws SystemError: Thrown if the file descriptor could not be retrieved.
 */
-proc file.init(fd: c_int, hints=ioHintSet.empty) throws {
+proc file.init(fileDescriptor: int, hints=ioHintSet.empty) throws {
   this.init();
 
-  initHelper2(this, fd, hints);
+  initHelper2(this, fileDescriptor.safeCast(c_int), hints);
 }
 
 pragma "no doc"

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -581,7 +581,7 @@ module Subprocess {
       // goes out of scope, but the channel will still keep
       // the file alive by referring to it.
       try {
-        var stdin_file = new file(stdin_fd, hints=ioHintSet.fromFlag(QIO_HINT_OWNED));
+        var stdin_file = new file(stdin_fd, own=true);
         ret.stdin_channel = stdin_file.writer();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -606,7 +606,7 @@ module Subprocess {
     if stdout_pipe {
       ret.stdout_pipe = true;
       try {
-        var stdout_file = new file(stdout_fd, hints=ioHintSet.fromFlag(QIO_HINT_OWNED));
+        var stdout_file = new file(stdout_fd, own=true);
         ret.stdout_channel = stdout_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;
@@ -620,7 +620,7 @@ module Subprocess {
     if stderr_pipe {
       ret.stderr_pipe = true;
       try {
-        ret.stderr_file = new file(stderr_fd, hints=ioHintSet.fromFlag(QIO_HINT_OWNED));
+        ret.stderr_file = new file(stderr_fd, own=true);
         ret.stderr_channel = ret.stderr_file.reader();
       } catch e: SystemError {
         ret.spawn_error = e.err;

--- a/test/library/standard/IO/initWithCFile/errorCase.chpl
+++ b/test/library/standard/IO/initWithCFile/errorCase.chpl
@@ -9,7 +9,7 @@ module m {
   extern proc openTestFile(): c_FILE;
 
   try! {
-    var f = new file(openTestFile(), hints = ioHintSet.fromFlag(QIO_HINT_OWNED));
+    var f = new file(openTestFile(), own=true);
     var r = f.reader();
     write(r.readLine());
   } catch e: SystemError {

--- a/test/library/standard/IO/initWithCFile/openCFile.chpl
+++ b/test/library/standard/IO/initWithCFile/openCFile.chpl
@@ -7,7 +7,7 @@ module m {
     extern proc openTestFile(): c_FILE;
 
     try! {
-        var f = new file(openTestFile(), hints = ioHintSet.fromFlag(QIO_HINT_OWNED));
+        var f = new file(openTestFile(), own=true);
         var r = f.reader();
         write(r.readLine());
     }


### PR DESCRIPTION
Resolves #20430 
Resolved Cray/chapel-private#4374

This changes gathers several updates to the file initializers into one
place.  Those updates include:
- Rename the fd argument, as decided
- Use `int` instead of `c_int` for the argument type
- add new `own` argument and use it instead of `QIO_HINT_OWNED`

Update places that were using `QIO_HINT_OWNED` outside of the
`IO` module to use the new argument instead, except for the
deprecation test of `openfp` because we haven't added the argument
to the deprecated function and don't intend to.

Passed a full paratest with futures