### PR TITLE
Rename formal in `IllegalArgumentError`'s initializer to `msg`

### DIFF
--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -117,8 +117,8 @@ module Errors {
   class IllegalArgumentError : Error {
     proc init() {}
 
-    proc init(info: string) {
-      super.init(info);
+    proc init(msg: string) {
+      super.init(msg);
     }
 
     proc init(formal: string, info: string) {

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -121,6 +121,13 @@ module Errors {
       super.init(msg);
     }
 
+    // This won't actually produce a deprecation message. It's here for documentation purposes only.
+    pragma "last resort"
+    deprecated "`new IllegalArgumentError(info=)` is deprecated; please use the initializer that takes a formal `msg` instead."
+    proc init(info: string) {
+      super.init(info);
+    }
+
     proc init(formal: string, info: string) {
       var msg = "illegal argument '" + formal + "': " + info;
       super.init(msg);

--- a/test/deprecated/illegalArgumentErrorInit.chpl
+++ b/test/deprecated/illegalArgumentErrorInit.chpl
@@ -1,0 +1,7 @@
+const iae1 = new IllegalArgumentError(info="bad argument!"),
+      iae2 = new IllegalArgumentError(msg="bad argument!"),
+      iae3 = new IllegalArgumentError("bad argument!");
+
+writeln(iae1);
+writeln(iae2);
+writeln(iae3);

--- a/test/deprecated/illegalArgumentErrorInit.good
+++ b/test/deprecated/illegalArgumentErrorInit.good
@@ -1,0 +1,3 @@
+IllegalArgumentError: bad argument!
+IllegalArgumentError: bad argument!
+IllegalArgumentError: bad argument!


### PR DESCRIPTION
Per discussion here: https://github.com/chapel-lang/chapel/issues/19803#issuecomment-1430187621, the formal in`IllegalArgumentError`'s one-argument initializer is being renamed from `info` to `msg`.

- [X] passing paratest
