### PR TITLE
fix the script to use jenkins parameter name instead of param location

### DIFF
--- a/util/cron/publish-docker-images.bash
+++ b/util/cron/publish-docker-images.bash
@@ -23,13 +23,7 @@ log_info "Setting CHPL_HOME to: ${CHPL_HOME}"
 
 start_docker
 
-if [ $? -ne 0 ] 
-then
-      echo " Docker login failed "
-      exit 1
-else
-      echo "docker login succeeded "
-fi        
+       
 # build_publish will build multi platform chapel docker images, tags them, and pushes the images to the docker repository .
 
 build_publish(){
@@ -54,15 +48,37 @@ fi
 # Get the repository name and chapel version, Build chapel docker images and push to docker hub repository . 
 #build and publish chapel docker image
 docker login -u $username -p $password
+if [ $? -ne 0 ] 
+then
+      echo " Docker login failed "
+      exit 1
+else
+      echo "docker login succeeded "
+fi 
+
 cd $CHPL_HOME
 build_publish $docker_repository  chapel $image_version
 
 docker login -u $username -p $password
+if [ $? -ne 0 ] 
+then
+      echo " Docker login failed "
+      exit 1
+else
+      echo "docker login succeeded "
+fi 
 #build and publish chapel-gasnet docker image
 cd $CHPL_HOME/util/packaging/docker/gasnet
 build_publish $docker_repository  chapel-gasnet $image_version
 
 docker login -u $username -p $password
+if [ $? -ne 0 ] 
+then
+      echo " Docker login failed "
+      exit 1
+else
+      echo "docker login succeeded "
+fi 
 #build and publish chapel-gasnet-smp docker image
 cd $CHPL_HOME/util/packaging/docker/gasnet-smp
 build_publish $docker_repository  chapel-gasnet-smp $image_version

--- a/util/cron/publish-docker-images.bash
+++ b/util/cron/publish-docker-images.bash
@@ -9,7 +9,6 @@ for var in ${required_vars[@]}; do
         echo "${var} must be set."
         exit 1
     fi
-    echo "${var} is set to: ${!var}"
 done
 
 echo "RepositoryName: $docker_repository"

--- a/util/cron/publish-docker-images.bash
+++ b/util/cron/publish-docker-images.bash
@@ -3,14 +3,17 @@
 # This script will build the docker images for 'amd' and 'arm' platforms using buildx and publish the images to the docker registry
 
 # Check if the script is run with correct arguement if not fail
-if [  $# -ne 4  ]
-then
-    echo " Docker repository and/or image-version not supplied "
-    echo " run with ./publish-docker-images.bash doc_repository image_version username password"
-    exit 1
-fi
-echo "RepositoryName: $1"
-echo "imageVersion: $2"
+required_vars=(docker_repository image_version username password)
+for var in ${required_vars[@]}; do
+    if [ -z "${!var}" ] ; then
+        echo "${var} must be set."
+        exit 1
+    fi
+    echo "${var} is set to: ${!var}"
+done
+
+echo "RepositoryName: $docker_repository"
+echo "imageVersion: $image_version"
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
@@ -19,7 +22,7 @@ export CHPL_HOME=$(cd $CWD/../.. ; pwd)
 log_info "Setting CHPL_HOME to: ${CHPL_HOME}"
 
 start_docker
-docker login -u $3 -p $4
+
 if [ $? -ne 0 ] 
 then
       echo " Docker login failed "
@@ -50,11 +53,16 @@ fi
 
 # Get the repository name and chapel version, Build chapel docker images and push to docker hub repository . 
 #build and publish chapel docker image
+docker login -u $username -p $password
 cd $CHPL_HOME
-build_publish $1  chapel $2
+build_publish $docker_repository  chapel $image_version
+
+docker login -u $username -p $password
 #build and publish chapel-gasnet docker image
 cd $CHPL_HOME/util/packaging/docker/gasnet
-build_publish $1  chapel-gasnet $2
+build_publish $docker_repository  chapel-gasnet $image_version
+
+docker login -u $username -p $password
 #build and publish chapel-gasnet-smp docker image
 cd $CHPL_HOME/util/packaging/docker/gasnet-smp
-build_publish $1  chapel-gasnet-smp $2
+build_publish $docker_repository  chapel-gasnet-smp $image_version


### PR DESCRIPTION
Problem : On demand docker publish is not recognizing the command line parameter referenced by $n 
Fix: Use the jenkins $parametername instead of  $n