### PR TITLE
QIO fix: Free the mark stack if it has been allocated

### DIFF
--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1861,6 +1861,11 @@ void _qio_channel_destroy(qio_channel_t* ch)
   qio_file_release(ch->file);
   ch->file = NULL;
 
+  // If mark_stack has been (re)allocated, free it.
+  if (ch->mark_stack != ch->mark_space) {
+    qio_free(ch->mark_stack);
+  }
+
   DO_DESTROY_REFCNT(ch);
 
   qio_free(ch);


### PR DESCRIPTION
The mark stack starts off pointing to a fixed-size c array, but can later be allocated or reallocated when the stack size increases. Somehow this hasn't bitten us in testing before, and so it was never large enough to be resized, and so was never leaked.

Testing:
- [x] full local
- [x] memleaks