### PR TITLE
Fix a bug in dyno scope resolver

### DIFF
--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -708,7 +708,8 @@ static bool doLookupInScope(Context* context,
           }
         }
 
-        bool got = doLookupInScope(context, cur, receiverScopes, resolving, name,
+        // never consider receiver scopes here; they are considered below
+        bool got = doLookupInScope(context, cur, {}, resolving, name,
                                    newConfig, checkedScopes, result);
         if (onlyInnermost && got) return true;
       }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -542,6 +542,75 @@ static bool doLookupInToplevelModules(Context* context,
   return true;
 }
 
+// Receiver scopes support two cases:
+// 1. For resolving names within a method (for the implicit 'this' feature)
+// 2. For resolving a dot expression (e.g. 'myObject.field')
+//    (note that 'field' could be a parenless secondary method)
+static bool
+doLookupInReceiverScopes(Context* context,
+                         const Scope* scope,
+                         llvm::ArrayRef<const Scope*> receiverScopes,
+                         const ResolvedVisibilityScope* resolving,
+                         UniqueString name,
+                         LookupConfig config,
+                         NamedScopeSet& checkedScopes,
+                         std::vector<BorrowedIdsWithName>& result) {
+  if (receiverScopes.empty()) {
+    return false;
+  }
+
+  // create a config that doesn't search receiver scopes parent scopes
+  // (such parent scopes are handled separately in doLookupInScope)
+  LookupConfig newConfig = config;
+  newConfig &= ~(LOOKUP_PARENTS|LOOKUP_GO_PAST_MODULES|LOOKUP_TOPLEVEL);
+  // and only consider methods/fields
+  // (but that's all that we should find in a record/class decl anyway...)
+  newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
+
+  bool got = false;
+  for (const auto& currentScope : receiverScopes) {
+    got |= doLookupInScope(context, currentScope, {}, resolving,
+                           name, newConfig, checkedScopes, result);
+  }
+  return got;
+}
+static bool
+doLookupInReceiverParentScopes(Context* context,
+                               const Scope* scope,
+                               llvm::ArrayRef<const Scope*> receiverScopes,
+                               const ResolvedVisibilityScope* resolving,
+                               UniqueString name,
+                               LookupConfig config,
+                               NamedScopeSet& checkedScopes,
+                               std::vector<BorrowedIdsWithName>& result) {
+  bool checkParents = (config & LOOKUP_PARENTS) != 0;
+  bool goPastModules = (config & LOOKUP_GO_PAST_MODULES) != 0;
+
+  // create a config that doesn't search receiver scopes parent scopes
+  // (such parent scopes are covered directly in the loop below)
+  LookupConfig newConfig = (config & ~LOOKUP_PARENTS);
+  // and only consider methods/fields
+  newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
+
+  bool got = false;
+
+  for (const auto& rcvScope : receiverScopes) {
+    for (const Scope* cur = rcvScope;
+         cur != nullptr;
+         cur = cur->parentScope()) {
+      got |= doLookupInScope(context, cur, {}, resolving,
+                             name, newConfig, checkedScopes, result);
+      // stop if we aren't looking at parents or if we reach a module
+      if (isModule(cur->tag()) && !goPastModules)
+        break;
+      if (!checkParents)
+        break;
+    }
+  }
+
+  return got;
+}
+
 static bool
 isScopeElseBlockOfConditionalWithIfVar(Context* context, const Scope* scope) {
   if (!scope->id().isEmpty() && asttags::isBlock(scope->tag())) {
@@ -592,12 +661,6 @@ static bool doLookupInScope(Context* context,
     }
   }
 
-  // Receiver scopes support two cases:
-  // 1. For resolving names within a method (for the implicit 'this' feature)
-  // 2. For resolving a dot expression (e.g. 'myObject.field')
-  //    (note that 'field' could be a parenless secondary method)
-  bool considerReceiverScopes = !receiverScopes.empty();
-
   // gather non-shadow scope information
   // (declarations in this scope as well as public use / import)
   {
@@ -643,24 +706,14 @@ static bool doLookupInScope(Context* context,
     if (onlyInnermost && got) return true;
   }
 
-  // Consider the receiver scopes directly (for fields).
-  // Only consider receiver scopes if we are at a method scope
-  // in order to get field vs. formal precedence correct.
-  // (other cases will be handled later in this function)
-  if (considerReceiverScopes && scope->isMethodScope()) {
-    // create a config that doesn't search receiver scopes parent scopes
-    // (such parent scopes are covered in later in this function)
-    LookupConfig newConfig = config;
-    newConfig &= ~(LOOKUP_PARENTS|LOOKUP_GO_PAST_MODULES|LOOKUP_TOPLEVEL);
-    // and only consider methods/fields
-    // (but that's all that we should find in a record/class decl anyway...)
-    newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
-
-    bool got = false;
-    for (const auto& currentScope : receiverScopes) {
-      got |= doLookupInScope(context, currentScope, {}, resolving,
-                             name, newConfig, checkedScopes, result);
-    }
+  // If we are at a method scope, consider receiver scopes now
+  // (so we imagine them to be just outside of the method scope).
+  // If we are not at a method scope (but within a method), it
+  // will be handled later.
+  if (scope->isMethodScope()) {
+    bool got = doLookupInReceiverScopes(context, scope, receiverScopes,
+                                        resolving, name, config,
+                                        checkedScopes, result);
     if (onlyInnermost && got) return true;
   }
 
@@ -708,10 +761,19 @@ static bool doLookupInScope(Context* context,
           }
         }
 
-        // never consider receiver scopes here; they are considered below
+        // search without considering receiver scopes
         bool got = doLookupInScope(context, cur, {}, resolving, name,
                                    newConfig, checkedScopes, result);
         if (onlyInnermost && got) return true;
+
+        // and then search only considering receiver scopes
+        // as if the receiver scope were just outside of this scope.
+        if (cur->isMethodScope()) {
+          bool got = doLookupInReceiverScopes(context, scope, receiverScopes,
+                                              resolving, name, newConfig,
+                                              checkedScopes, result);
+          if (onlyInnermost && got) return true;
+        }
       }
     }
 
@@ -753,26 +815,9 @@ static bool doLookupInScope(Context* context,
   // that the scope can be both found as a regular parent and also
   // as a parent of a receiver scope.
   // That is important to work with the 'checkedScopes' set.
-  if (considerReceiverScopes) {
-    // create a config that doesn't search receiver scopes parent scopes
-    // (such parent scopes are covered directly in the loop below)
-    LookupConfig newConfig = (config & ~LOOKUP_PARENTS);
-    // and only consider methods/fields
-    newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
-
-    for (const auto& rcvScope : receiverScopes) {
-      for (const Scope* cur = rcvScope;
-           cur != nullptr;
-           cur = cur->parentScope()) {
-        doLookupInScope(context, cur, {}, resolving,
-                        name, newConfig, checkedScopes, result);
-        // stop if we aren't looking at parents or if we reach a module
-        if (asttags::isModule(cur->tag()) && !goPastModules)
-          break;
-        if (!checkParents)
-          break;
-      }
-    }
+  if (checkParents) {
+    doLookupInReceiverParentScopes(context, scope, receiverScopes, resolving,
+                                   name, config, checkedScopes, result);
   }
 
   return result.size() > startSize;

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -436,6 +436,118 @@ static void test10s() {
   // TODO get the above case working with the full resolver
 }
 
+// test with parent scopes that should find a local not a field
+static void test11p() {
+  testIt("test11p.chpl",
+         R""""(
+            module M {
+              record rec {
+                var x: int;
+                proc foo() {
+                  var x: real;
+                  {
+                    var foo: string;
+                    {
+                      var bar: string;
+                      {
+                        x;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+         )"""",
+         "M.rec.foo",
+         "M.rec.foo@7",
+         "M.rec.foo@2" /* the local variable */,
+         /* scope resolve only to avoid errors today */ true);
+  // TODO get the above case working with the full resolver
+}
+static void test11s() {
+  testIt("test11s.chpl",
+         R""""(
+            module M {
+              record rec {
+                var x: int;
+              }
+              proc rec.foo() {
+                var x: real;
+                {
+                  var foo: string;
+                  {
+                    var bar: string;
+                    {
+                      x;
+                    }
+                  }
+                }
+              }
+            }
+         )"""",
+         "M.foo",
+         "M.foo@8",
+         "M.foo@3" /* the local variable */,
+         /* scope resolve only to avoid errors today */ true);
+  // TODO get the above case working with the full resolver
+}
+
+// same as above but with a formal rather than a local variable
+static void test12p() {
+  testIt("test12p.chpl",
+         R""""(
+            module M {
+              record rec {
+                var x: int;
+                proc foo(x: int) {
+                  var y: real;
+                  {
+                    var foo: string;
+                    {
+                      var bar: string;
+                      {
+                        x;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+         )"""",
+         "M.rec.foo",
+         "M.rec.foo@9",
+         "M.rec.foo@2" /* the formal */,
+         /* scope resolve only to avoid errors today */ true);
+  // TODO get the above case working with the full resolver
+}
+static void test12s() {
+  testIt("test12s.chpl",
+         R""""(
+            module M {
+              record rec {
+                var x: int;
+              }
+              proc rec.foo(x: int) {
+                var y: real;
+                {
+                  var foo: string;
+                  {
+                    var bar: string;
+                    {
+                      x;
+                    }
+                  }
+                }
+              }
+            }
+         )"""",
+         "M.foo",
+         "M.foo@10",
+         "M.foo@3" /* the formal */,
+         /* scope resolve only to avoid errors today */ true);
+  // TODO get the above case working with the full resolver
+}
+
 
 int main() {
   test1r();
@@ -461,6 +573,12 @@ int main() {
 
   test10p();
   test10s();
+
+  test11p();
+  test11s();
+
+  test12p();
+  test12s();
 
   return 0;
 }

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -548,6 +548,57 @@ static void test12s() {
   // TODO get the above case working with the full resolver
 }
 
+// field access vs parent module field
+static void test13p() {
+  testIt("test13p.chpl",
+         R""""(
+              module M {
+                record mat {
+                  var m, n: int;
+                  proc foo() {
+                    var b = 1;
+                    {
+                      var c = 2;
+                      n;
+                    }
+                  }
+                }
+
+                var n: real;
+              }
+         )"""",
+         "M.mat.foo",
+         "M.mat.foo@5",
+         "M.mat@2" /* the field */,
+         /* scope resolve only to avoid errors today */ true);
+  // TODO get the above case working with the full resolver
+}
+static void test13s() {
+  testIt("test13s.chpl",
+         R""""(
+            module M {
+              record mat {
+                var m, n: int;
+              }
+
+              proc mat.foo() {
+                var b = 1;
+                {
+                  var c = 2;
+                  n;
+                }
+              }
+
+              var n: real;
+            }
+         )"""",
+         "M.foo",
+         "M.foo@6",
+         "M.mat@2" /* the field */,
+         /* scope resolve only to avoid errors today */ true);
+  // TODO get the above case working with the full resolver
+}
+
 
 int main() {
   test1r();
@@ -579,6 +630,9 @@ int main() {
 
   test12p();
   test12s();
+
+  test13p();
+  test13s();
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes a bug in the dyno scope resolver where, if there is enough nesting, a field with the same name as a local variable was preferred to a local variable.

To fix it, this PR:
 * factors out lookup in receiver scopes to a helper `doLookupInReceiverScopes` and lookup in parents of receiver scopes to the helper `doLookupInReceiverParentScopes`
 * looks in receiver scopes just after the declarations / use import handling for a method scope
 * when considering parent scopes, if we arrive at a method scope, look in receiver scopes just after the declarations / use import handling for that parent scope. The key change here is that the check for declarations in a parent scope *does not* also check receiver scopes.
 
Reviewed by @riftEmber - thanks!

- [x] full local testing
- [x] no new failures with `--dyno`