### PR TITLE
Move control flow checks into Dyno

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -634,8 +634,6 @@ static void checkIndicesForall(BaseAST* indices) {
 BlockStmt* ForallStmt::build(Expr* indices, Expr* iterator, CallExpr* intents,
                              BlockStmt* body, bool zippered, bool serialOK)
 {
-  checkControlFlow(body, "forall statement");
-
   if (!indices)
     indices = new UnresolvedSymExpr("chpl__elidedIdx");
   checkIndicesForall(indices);

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -47,93 +47,6 @@
 
 static BlockStmt* findStmtWithTag(PrimitiveTag tag, BlockStmt* blockStmt);
 
-void checkControlFlow(Expr* expr, const char* context) {
-  Vec<const char*> labelSet; // all labels in expr argument
-  Vec<BaseAST*> loopSet;     // all asts in a loop in expr argument
-  Vec<BaseAST*> innerFnSet;  // all asts in a function in expr argument
-  std::vector<BaseAST*> asts;
-  collect_asts(expr, asts);
-
-  //
-  // compute labelSet and loopSet
-  //
-  for_vector(BaseAST, ast, asts) {
-    if (DefExpr* def = toDefExpr(ast)) {
-      if (LabelSymbol* ls = toLabelSymbol(def->sym))
-        labelSet.set_add(ls->name);
-      else if (FnSymbol* fn = toFnSymbol(def->sym)) {
-        if (!innerFnSet.set_in(fn)) {
-          std::vector<BaseAST*> innerAsts;
-          collect_asts(fn, innerAsts);
-          for_vector(BaseAST, ast, innerAsts) {
-            innerFnSet.set_add(ast);
-          }
-        }
-      }
-    } else if (BlockStmt* block = toBlockStmt(ast)) {
-      if (block->isLoopStmt() && !loopSet.set_in(block)) {
-        if (block->userLabel != NULL) {
-          labelSet.set_add(block->userLabel);
-        }
-        std::vector<BaseAST*> loopAsts;
-        collect_asts(block, loopAsts);
-        for_vector(BaseAST, ast, loopAsts) {
-          loopSet.set_add(ast);
-        }
-      }
-    }
-  }
-
-  //
-  // check for illegal control flow
-  //
-  for_vector(BaseAST, ast1, asts) {
-    if (CallExpr* call = toCallExpr(ast1)) {
-      if (innerFnSet.set_in(call))
-        continue; // yield or return is in nested function/iterator
-      if (call->isPrimitive(PRIM_RETURN)) {
-        USR_FATAL_CONT(call, "return is not allowed in %s", context);
-      } else if (call->isPrimitive(PRIM_YIELD)) {
-        if (!strcmp(context, "begin statement"))
-          USR_FATAL_CONT(call, "yield is not allowed in %s", context);
-      }
-    } else if (GotoStmt* gs = toGotoStmt(ast1)) {
-      if (labelSet.set_in(gs->getName()))
-        continue; // break or continue target is in scope
-      if (toSymExpr(gs->label) && toSymExpr(gs->label)->symbol() == gNil && loopSet.set_in(gs))
-        continue; // break or continue loop is in scope
-      if (gs->gotoTag == GOTO_BREAK) {
-        // BLC: This check is being too strict for labeled 'break's
-        // and is preventing correct programs from working, so skip it
-        // unless it's unlabeled.  From what I can tell with a quick
-        // look, the problem is that the 'loopSet' isn't being
-        // maintained properly in nested cases, or is preventing
-        // labels from being added to the 'labelSet' incorrectly.  I
-        // feel mildly optimistic an illegal labeled break will be
-        // caught later in compilation.
-        if (toSymExpr(gs->label) && toSymExpr(gs->label)->symbol() == gNil) {
-          USR_FATAL_CONT(gs, "break is not allowed in %s", context);
-        }
-      } else if (gs->gotoTag == GOTO_CONTINUE) {
-        // see also resolveGotoLabels() -> handleForallGoto()
-        if (!strcmp(context, "forall statement")) {
-          if (!strcmp(gs->getName(), "nil"))
-            ; // plain 'continue' is OK in a forall
-          else
-            USR_FATAL_CONT(gs, "continue to a named loop outside of a forall is not allowed from inside the forall");
-        } else {
-          if (toSymExpr(gs->label) && toSymExpr(gs->label)->symbol() == gNil) {
-            USR_FATAL_CONT(gs, "continue is not allowed in %s", context);
-          }
-        }
-      } else {
-        USR_FATAL_CONT(gs, "illegal 'goto' usage; goto is deprecated anyway");
-      }
-    }
-  }
-}
-
-
 static void addPragmaFlags(Symbol* sym, Vec<const char*>* pragmas) {
   forv_Vec(const char, str, *pragmas) {
     Flag flag = pragma2flag(str);
@@ -1224,7 +1137,6 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
                                  bool zippered)
 {
   removeWrappingBlock(body); // may update 'body'
-  checkControlFlow(body, "coforall statement");
 
   // insert temporary index when elided by user
   if (!indices) {
@@ -2278,8 +2190,6 @@ static Expr* extractLocaleID(Expr* expr) {
 
 BlockStmt*
 buildOnStmt(Expr* expr, Expr* stmt) {
-  checkControlFlow(stmt, "on statement");
-
   CallExpr* onExpr = new CallExpr(PRIM_DEREF, extractLocaleID(expr));
 
   BlockStmt* body = toBlockStmt(stmt);
@@ -2332,8 +2242,6 @@ buildOnStmt(Expr* expr, Expr* stmt) {
 
 BlockStmt*
 buildBeginStmt(CallExpr* byref_vars, Expr* stmt) {
-  checkControlFlow(stmt, "begin statement");
-
   BlockStmt* body = toBlockStmt(stmt);
 
   //
@@ -2368,7 +2276,6 @@ buildBeginStmt(CallExpr* byref_vars, Expr* stmt) {
 
 BlockStmt*
 buildSyncStmt(Expr* stmt) {
-  checkControlFlow(stmt, "sync statement");
   BlockStmt* block = new BlockStmt();
   VarSymbol* endCountSave = newTempConst("_endCountSave");
   endCountSave->addFlag(FLAG_END_COUNT);
@@ -2433,8 +2340,6 @@ buildSyncStmt(Expr* stmt) {
 BlockStmt*
 buildCobeginStmt(CallExpr* byref_vars, BlockStmt* block) {
   BlockStmt* outer = block;
-
-  checkControlFlow(block, "cobegin statement");
 
   if (block->blockTag == BLOCK_SCOPELESS) {
     block = toBlockStmt(block->body.only());

--- a/compiler/include/build.h
+++ b/compiler/include/build.h
@@ -116,7 +116,6 @@ CallExpr* buildPrimitiveExpr(CallExpr* exprs);
 FnSymbol* buildIfExpr(Expr* e, Expr* e1, Expr* e2 = NULL);
 CallExpr* buildLetExpr(BlockStmt* decls, Expr* expr);
 BlockStmt* buildSerialStmt(Expr* cond, BlockStmt* body);
-void       checkControlFlow(Expr* expr, const char* context);
 void       checkIndices(BaseAST* indices);
 void       destructureIndices(BlockStmt* block,
                               BaseAST*   indices,

--- a/frontend/include/chpl/framework/parser-error-classes-list.h
+++ b/frontend/include/chpl/framework/parser-error-classes-list.h
@@ -45,6 +45,7 @@ PARSER_SYNTAX_CLASS(UseImportNeedsModule, bool)
 POSTPARSE_ERROR_CLASS(CantApplyPrivate, std::string)
 ERROR_CLASS(DisallowedControlFlow,
             const uast::AstNode*,
+            const uast::AstNode*,
             const uast::AstNode*)
 POSTPARSE_ERROR_CLASS(MultipleManagementStrategies, const uast::New::Management,
                       const uast::New::Management)

--- a/frontend/include/chpl/framework/parser-error-classes-list.h
+++ b/frontend/include/chpl/framework/parser-error-classes-list.h
@@ -43,6 +43,9 @@ PARSER_SYNTAX_CLASS(UseImportNeedsModule, bool)
 
 /* begin post-parse-checks errors */
 POSTPARSE_ERROR_CLASS(CantApplyPrivate, std::string)
+ERROR_CLASS(DisallowedControlFlow,
+            const uast::AstNode*,
+            const uast::AstNode*)
 POSTPARSE_ERROR_CLASS(MultipleManagementStrategies, const uast::New::Management,
                       const uast::New::Management)
 POSTPARSE_ERROR_CLASS(PostParseErr, std::string)

--- a/frontend/lib/framework/parser-error-classes-list.cpp
+++ b/frontend/lib/framework/parser-error-classes-list.cpp
@@ -121,25 +121,28 @@ void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
   }
 
   std::string blockingName = "";
+  std::string blockingNameArticle = "a";
   if (!blockingAst) {
     // Nothing
   } else if (blockingAst->isForall()) {
-    blockingName = "a 'forall' statement";
+    blockingName = "'forall' statement";
   } else if (blockingAst->isCoforall()) {
-    blockingName = "a 'coforall' statement";
+    blockingName = "'coforall' statement";
   } else if (blockingAst->isOn()) {
-    blockingName = "an 'on' statement";
+    blockingName = "'on' statement";
+    blockingNameArticle = "an";
   } else if (blockingAst->isBegin()) {
-    blockingName = "a 'begin' statement";
+    blockingName = "'begin' statement";
   } else if (blockingAst->isSync()) {
-    blockingName = "a 'sync' statement";
+    blockingName = "'sync' statement";
   } else if (blockingAst->isCobegin()) {
-    blockingName = "a 'cobegin' statement";
+    blockingName = "'cobegin' statement";
   } else if (auto fn = blockingAst->toFunction()) {
     if (fn->kind() == uast::Function::Kind::ITER) {
-      blockingName = "an iterator";
+      blockingName = "iterator";
+      blockingNameArticle = "an";
     } else {
-      blockingName = "a procedure";
+      blockingName = "procedure";
     }
   } else {
     CHPL_ASSERT(false && "not a blocking element handled by this error");
@@ -155,7 +158,8 @@ void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
     if (blockingAst) {
       // Didn't go all the way to the top, but stopped at a particular loop or fn.
       wr.note(blockingAst, "stopped searching here because '", astType, "' "
-              "statements are not allowed to jump outside ", blockingName, ":");
+              "statements are not allowed to jump outside ",
+              blockingNameArticle, " ", blockingName, ":");
       wr.code(blockingAst, { blockingAst });
     }
   } else if (!blockingAst || blockingAst->isFunction()) {
@@ -174,16 +178,19 @@ void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
     if (blockingAst) {
       CHPL_ASSERT(invalidAst->isBreak() || invalidAst->isContinue());
       wr.note(blockingAst, "stopped searching here because '", astType, "' "
-              "statements are not allowed to jump outside ", blockingName, ":");
+              "statements are not allowed to jump outside ",
+              blockingNameArticle, " ", blockingName, ":");
       wr.code(blockingAst, { blockingAst });
     }
   } else {
     // any piece of control flow banned within a particular language feature
     wr.heading(kind_, type_, invalidAst, "'", astType, "' is not allowed in ",
-               blockingName, ".");
+               blockingNameArticle, " ", blockingName, ".");
     wr.code(invalidAst, { invalidAst });
-    // wr.message("The mentioned '", blockingName, "' statement is here:");
-    // wr.code(blockingAst, { blockingAst });
+
+    // TODO: Re-enable when code printing doesn't dump whole code blocks
+    // wr.message("The ", blockingName, " is here:");
+    // wr.code(blockingAst);
   }
 }
 

--- a/test/errors/parsing/controlFlow-brief.good
+++ b/test/errors/parsing/controlFlow-brief.good
@@ -1,0 +1,79 @@
+controlFlow.chpl:1: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:2: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:4: In function 'wrapper':
+controlFlow.chpl:5: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:6: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:9: error: 'break' is not allowed outside of a loop
+controlFlow.chpl:10: error: 'continue' is not allowed outside of a loop
+controlFlow.chpl:11: error: 'return' is not allowed outside of a procedure or an iterator
+controlFlow.chpl:12: error: 'yield' is not allowed outside of an iterator
+controlFlow.chpl:14: In function 'wrapper2':
+controlFlow.chpl:15: error: 'break' is not allowed outside of a loop
+controlFlow.chpl:16: error: 'continue' is not allowed outside of a loop
+controlFlow.chpl:21: error: 'break' is not allowed in a 'forall' statement
+controlFlow.chpl:22: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:24: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:27: error: 'break' is not allowed in a 'coforall' statement
+controlFlow.chpl:28: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:29: error: 'continue' is not allowed in a 'coforall' statement
+controlFlow.chpl:30: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:33: error: 'break' is not allowed in an 'on' statement
+controlFlow.chpl:34: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:35: error: 'continue' is not allowed in an 'on' statement
+controlFlow.chpl:36: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:39: error: 'break' is not allowed in a 'begin' statement
+controlFlow.chpl:40: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:41: error: 'continue' is not allowed in a 'begin' statement
+controlFlow.chpl:42: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:45: error: 'break' is not allowed in a 'sync' statement
+controlFlow.chpl:46: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:47: error: 'continue' is not allowed in a 'sync' statement
+controlFlow.chpl:48: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:51: error: 'break' is not allowed in a 'cobegin' statement
+controlFlow.chpl:52: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:53: error: 'continue' is not allowed in a 'cobegin' statement
+controlFlow.chpl:54: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:58: In function 'wrapper2':
+controlFlow.chpl:59: error: 'break' is not allowed outside of a loop
+controlFlow.chpl:58: note: cannot 'break' out of a procedure
+controlFlow.chpl:60: error: 'break' to label 'actualLabel' outside of a procedure is not allowed
+controlFlow.chpl:58: note: cannot 'break' out of a procedure
+controlFlow.chpl:61: error: 'continue' is not allowed outside of a loop
+controlFlow.chpl:58: note: cannot 'continue' out of a procedure
+controlFlow.chpl:62: error: 'continue' to label 'actualLabel' outside of a procedure is not allowed
+controlFlow.chpl:58: note: cannot 'continue' out of a procedure
+controlFlow.chpl:67: error: 'break' is not allowed in a 'forall' statement
+controlFlow.chpl:68: error: 'break' to label 'actualLabel' outside of a 'forall' statement is not allowed
+controlFlow.chpl:66: note: cannot 'break' out of a 'forall' statement
+controlFlow.chpl:70: error: 'continue' to label 'actualLabel' outside of a 'forall' statement is not allowed
+controlFlow.chpl:66: note: cannot 'continue' out of a 'forall' statement
+controlFlow.chpl:73: error: 'break' is not allowed in a 'coforall' statement
+controlFlow.chpl:74: error: 'break' to label 'actualLabel' outside of a 'coforall' statement is not allowed
+controlFlow.chpl:72: note: cannot 'break' out of a 'coforall' statement
+controlFlow.chpl:75: error: 'continue' is not allowed in a 'coforall' statement
+controlFlow.chpl:76: error: 'continue' to label 'actualLabel' outside of a 'coforall' statement is not allowed
+controlFlow.chpl:72: note: cannot 'continue' out of a 'coforall' statement
+controlFlow.chpl:79: error: 'break' is not allowed in an 'on' statement
+controlFlow.chpl:80: error: 'break' to label 'actualLabel' outside of an 'on' statement is not allowed
+controlFlow.chpl:78: note: cannot 'break' out of an 'on' statement
+controlFlow.chpl:81: error: 'continue' is not allowed in an 'on' statement
+controlFlow.chpl:82: error: 'continue' to label 'actualLabel' outside of an 'on' statement is not allowed
+controlFlow.chpl:78: note: cannot 'continue' out of an 'on' statement
+controlFlow.chpl:85: error: 'break' is not allowed in a 'begin' statement
+controlFlow.chpl:86: error: 'break' to label 'actualLabel' outside of a 'begin' statement is not allowed
+controlFlow.chpl:84: note: cannot 'break' out of a 'begin' statement
+controlFlow.chpl:87: error: 'continue' is not allowed in a 'begin' statement
+controlFlow.chpl:88: error: 'continue' to label 'actualLabel' outside of a 'begin' statement is not allowed
+controlFlow.chpl:84: note: cannot 'continue' out of a 'begin' statement
+controlFlow.chpl:91: error: 'break' is not allowed in a 'sync' statement
+controlFlow.chpl:92: error: 'break' to label 'actualLabel' outside of a 'sync' statement is not allowed
+controlFlow.chpl:90: note: cannot 'break' out of a 'sync' statement
+controlFlow.chpl:93: error: 'continue' is not allowed in a 'sync' statement
+controlFlow.chpl:94: error: 'continue' to label 'actualLabel' outside of a 'sync' statement is not allowed
+controlFlow.chpl:90: note: cannot 'continue' out of a 'sync' statement
+controlFlow.chpl:97: error: 'break' is not allowed in a 'cobegin' statement
+controlFlow.chpl:98: error: 'break' to label 'actualLabel' outside of a 'cobegin' statement is not allowed
+controlFlow.chpl:96: note: cannot 'break' out of a 'cobegin' statement
+controlFlow.chpl:99: error: 'continue' is not allowed in a 'cobegin' statement
+controlFlow.chpl:100: error: 'continue' to label 'actualLabel' outside of a 'cobegin' statement is not allowed
+controlFlow.chpl:96: note: cannot 'continue' out of a 'cobegin' statement

--- a/test/errors/parsing/controlFlow-detailed.good
+++ b/test/errors/parsing/controlFlow-detailed.good
@@ -1,0 +1,436 @@
+─── error in controlFlow.chpl:1 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+      |
+    1 | break someLabel;
+      | ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+
+─── error in controlFlow.chpl:2 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+      |
+    2 | continue someLabel;
+      | ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+
+─── error in controlFlow.chpl:5 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+      |
+    5 |     break someLabel;
+      |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+
+─── error in controlFlow.chpl:6 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+      |
+    6 |     continue someLabel;
+      |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+
+─── error in controlFlow.chpl:9 [DisallowedControlFlow] ───
+  'break' is not allowed outside of a loop.
+      |
+    9 | break;
+      | ⎺⎺⎺⎺⎺⎺
+      |
+
+─── error in controlFlow.chpl:10 [DisallowedControlFlow] ───
+  'continue' is not allowed outside of a loop.
+       |
+    10 | continue;
+       | ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:11 [DisallowedControlFlow] ───
+  'return' is not allowed outside of a procedure or an iterator.
+       |
+    11 | return;
+       | ⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:12 [DisallowedControlFlow] ───
+  'yield' is not allowed outside of an iterator.
+       |
+    12 | yield 1;
+       | ⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:15 [DisallowedControlFlow] ───
+  'break' is not allowed outside of a loop.
+       |
+    15 |     break;
+       |     ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:16 [DisallowedControlFlow] ───
+  'continue' is not allowed outside of a loop.
+       |
+    16 |     continue;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:21 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'forall' statement.
+       |
+    21 |     break;
+       |     ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:22 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+       |
+    22 |     break someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:24 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+       |
+    24 |     continue someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:27 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'coforall' statement.
+       |
+    27 |     break;
+       |     ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:28 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+       |
+    28 |     break someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:29 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'coforall' statement.
+       |
+    29 |     continue;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:30 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+       |
+    30 |     continue someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:33 [DisallowedControlFlow] ───
+  'break' is not allowed in an 'on' statement.
+       |
+    33 |     break;
+       |     ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:34 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+       |
+    34 |     break someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:35 [DisallowedControlFlow] ───
+  'continue' is not allowed in an 'on' statement.
+       |
+    35 |     continue;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:36 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+       |
+    36 |     continue someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:39 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'begin' statement.
+       |
+    39 |     break;
+       |     ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:40 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+       |
+    40 |     break someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:41 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'begin' statement.
+       |
+    41 |     continue;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:42 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+       |
+    42 |     continue someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:45 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'sync' statement.
+       |
+    45 |     break;
+       |     ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:46 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+       |
+    46 |     break someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:47 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'sync' statement.
+       |
+    47 |     continue;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:48 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+       |
+    48 |     continue someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:51 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'cobegin' statement.
+       |
+    51 |     break;
+       |     ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:52 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+       |
+    52 |     break someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:53 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'cobegin' statement.
+       |
+    53 |     continue;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:54 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+       |
+    54 |     continue someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:59 [DisallowedControlFlow] ───
+  'break' is not allowed outside of a loop.
+       |
+    59 |         break;
+       |         ⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'break' out of a procedure.
+
+─── error in controlFlow.chpl:60 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of a procedure is not allowed.
+       |
+    60 |         break actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'break' out of a procedure.
+
+─── error in controlFlow.chpl:61 [DisallowedControlFlow] ───
+  'continue' is not allowed outside of a loop.
+       |
+    61 |         continue;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'continue' out of a procedure.
+
+─── error in controlFlow.chpl:62 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of a procedure is not allowed.
+       |
+    62 |         continue actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'continue' out of a procedure.
+
+─── error in controlFlow.chpl:67 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'forall' statement.
+       |
+    67 |         break;
+       |         ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:68 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of a 'forall' statement is not allowed.
+       |
+    68 |         break actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'break' out of a 'forall' statement.
+
+─── error in controlFlow.chpl:70 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of a 'forall' statement is not allowed.
+       |
+    70 |         continue actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'continue' out of a 'forall' statement.
+
+─── error in controlFlow.chpl:73 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'coforall' statement.
+       |
+    73 |         break;
+       |         ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:74 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of a 'coforall' statement is not allowed.
+       |
+    74 |         break actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'break' out of a 'coforall' statement.
+
+─── error in controlFlow.chpl:75 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'coforall' statement.
+       |
+    75 |         continue;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:76 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of a 'coforall' statement is not allowed.
+       |
+    76 |         continue actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'continue' out of a 'coforall' statement.
+
+─── error in controlFlow.chpl:79 [DisallowedControlFlow] ───
+  'break' is not allowed in an 'on' statement.
+       |
+    79 |         break;
+       |         ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:80 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of an 'on' statement is not allowed.
+       |
+    80 |         break actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'break' out of an 'on' statement.
+
+─── error in controlFlow.chpl:81 [DisallowedControlFlow] ───
+  'continue' is not allowed in an 'on' statement.
+       |
+    81 |         continue;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:82 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of an 'on' statement is not allowed.
+       |
+    82 |         continue actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'continue' out of an 'on' statement.
+
+─── error in controlFlow.chpl:85 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'begin' statement.
+       |
+    85 |         break;
+       |         ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:86 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of a 'begin' statement is not allowed.
+       |
+    86 |         break actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'break' out of a 'begin' statement.
+
+─── error in controlFlow.chpl:87 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'begin' statement.
+       |
+    87 |         continue;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:88 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of a 'begin' statement is not allowed.
+       |
+    88 |         continue actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'continue' out of a 'begin' statement.
+
+─── error in controlFlow.chpl:91 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'sync' statement.
+       |
+    91 |         break;
+       |         ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:92 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of a 'sync' statement is not allowed.
+       |
+    92 |         break actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'break' out of a 'sync' statement.
+
+─── error in controlFlow.chpl:93 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'sync' statement.
+       |
+    93 |         continue;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:94 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of a 'sync' statement is not allowed.
+       |
+    94 |         continue actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'continue' out of a 'sync' statement.
+
+─── error in controlFlow.chpl:97 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'cobegin' statement.
+       |
+    97 |         break;
+       |         ⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:98 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of a 'cobegin' statement is not allowed.
+       |
+    98 |         break actualLabel;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  Cannot 'break' out of a 'cobegin' statement.
+
+─── error in controlFlow.chpl:99 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'cobegin' statement.
+       |
+    99 |         continue;
+       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:100 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of a 'cobegin' statement is not allowed.
+        |
+    100 |         continue actualLabel;
+        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+        |
+  Cannot 'continue' out of a 'cobegin' statement.
+

--- a/test/errors/parsing/controlFlow.chpl
+++ b/test/errors/parsing/controlFlow.chpl
@@ -1,0 +1,102 @@
+break someLabel;
+continue someLabel;
+
+proc wrapper() {
+    break someLabel;
+    continue someLabel;
+}
+
+break;
+continue;
+return;
+yield 1;
+
+proc wrapper2() {
+    break;
+    continue;
+}
+
+// Each of the following block continues and returns.
+forall 1..10 {
+    break;
+    break someLabel;
+    continue;
+    continue someLabel;
+}
+coforall 1..10 {
+    break;
+    break someLabel;
+    continue;
+    continue someLabel;
+}
+on here {
+    break;
+    break someLabel;
+    continue;
+    continue someLabel;
+}
+begin {
+    break;
+    break someLabel;
+    continue;
+    continue someLabel;
+}
+sync {
+    break;
+    break someLabel;
+    continue;
+    continue someLabel;
+}
+cobegin {
+    break;
+    break someLabel;
+    continue;
+    continue someLabel;
+}
+
+label actualLabel for 1..10 {
+    proc wrapper2() {
+        break;
+        break actualLabel;
+        continue;
+        continue actualLabel;
+    }
+
+    // Each of the following block continues and returns.
+    forall 1..10 {
+        break;
+        break actualLabel;
+        continue;
+        continue actualLabel;
+    }
+    coforall 1..10 {
+        break;
+        break actualLabel;
+        continue;
+        continue actualLabel;
+    }
+    on here {
+        break;
+        break actualLabel;
+        continue;
+        continue actualLabel;
+    }
+    begin {
+        break;
+        break actualLabel;
+        continue;
+        continue actualLabel;
+    }
+    sync {
+        break;
+        break actualLabel;
+        continue;
+        continue actualLabel;
+    }
+    cobegin {
+        break;
+        break actualLabel;
+        continue;
+        continue actualLabel;
+    }
+}

--- a/test/errors/parsing/controlFlow.compopts
+++ b/test/errors/parsing/controlFlow.compopts
@@ -1,0 +1,2 @@
+--detailed-errors # controlFlow-detailed.good
+--no-detailed-errors # controlFlow-brief.good

--- a/test/functions/iterators/bharshbarg/moduleYield.good
+++ b/test/functions/iterators/bharshbarg/moduleYield.good
@@ -1,1 +1,1 @@
-moduleYield.chpl:1: error: yield statement is outside an iterator
+moduleYield.chpl:1: error: 'yield' is not allowed outside of an iterator

--- a/test/parallel/begin/deitz/test_control_flow.good
+++ b/test/parallel/begin/deitz/test_control_flow.good
@@ -30,7 +30,7 @@ test_control_flow.chpl:59: error: 'continue' is not allowed in a 'coforall' stat
 test_control_flow.chpl:63: error: 'return' is not allowed in a 'forall' statement
 test_control_flow.chpl:64: error: 'break' is not allowed in a 'forall' statement
 test_control_flow.chpl:69: In function 'baz':
-test_control_flow.chpl:75: error: could not find label 'namedOuter' for 'continue' statement
-test_control_flow.chpl:72: note: stopped searching here because 'continue' statements are not allowed to jump outside a 'forall' statement
-test_control_flow.chpl:81: error: could not find label 'namedOuter' for 'continue' statement
-test_control_flow.chpl:72: note: stopped searching here because 'continue' statements are not allowed to jump outside a 'forall' statement
+test_control_flow.chpl:75: error: 'continue' to label 'namedOuter' outside of a 'forall' statement is not allowed
+test_control_flow.chpl:72: note: cannot 'continue' out of a 'forall' statement
+test_control_flow.chpl:81: error: 'continue' to label 'namedOuter' outside of a 'forall' statement is not allowed
+test_control_flow.chpl:72: note: cannot 'continue' out of a 'forall' statement

--- a/test/parallel/begin/deitz/test_control_flow.good
+++ b/test/parallel/begin/deitz/test_control_flow.good
@@ -1,31 +1,36 @@
-test_control_flow.chpl:5: error: return is not allowed in begin statement
-test_control_flow.chpl:6: error: break is not allowed in begin statement
-test_control_flow.chpl:7: error: continue is not allowed in begin statement
-test_control_flow.chpl:10: error: return is not allowed in cobegin statement
-test_control_flow.chpl:11: error: break is not allowed in cobegin statement
-test_control_flow.chpl:12: error: continue is not allowed in cobegin statement
-test_control_flow.chpl:15: error: return is not allowed in on statement
-test_control_flow.chpl:16: error: break is not allowed in on statement
-test_control_flow.chpl:17: error: continue is not allowed in on statement
-test_control_flow.chpl:21: error: return is not allowed in coforall statement
-test_control_flow.chpl:22: error: break is not allowed in coforall statement
-test_control_flow.chpl:23: error: continue is not allowed in coforall statement
-test_control_flow.chpl:26: error: return is not allowed in forall statement
-test_control_flow.chpl:27: error: break is not allowed in forall statement
-test_control_flow.chpl:37: error: yield is not allowed in begin statement
-test_control_flow.chpl:38: error: return is not allowed in begin statement
-test_control_flow.chpl:39: error: break is not allowed in begin statement
-test_control_flow.chpl:40: error: continue is not allowed in begin statement
-test_control_flow.chpl:44: error: return is not allowed in cobegin statement
-test_control_flow.chpl:45: error: break is not allowed in cobegin statement
-test_control_flow.chpl:46: error: continue is not allowed in cobegin statement
-test_control_flow.chpl:50: error: return is not allowed in on statement
-test_control_flow.chpl:51: error: break is not allowed in on statement
-test_control_flow.chpl:52: error: continue is not allowed in on statement
-test_control_flow.chpl:57: error: return is not allowed in coforall statement
-test_control_flow.chpl:58: error: break is not allowed in coforall statement
-test_control_flow.chpl:59: error: continue is not allowed in coforall statement
-test_control_flow.chpl:63: error: return is not allowed in forall statement
-test_control_flow.chpl:64: error: break is not allowed in forall statement
-test_control_flow.chpl:75: error: continue to a named loop outside of a forall is not allowed from inside the forall
-test_control_flow.chpl:81: error: continue to a named loop outside of a forall is not allowed from inside the forall
+test_control_flow.chpl:2: In function 'foo':
+test_control_flow.chpl:5: error: 'return' is not allowed in a 'begin' statement
+test_control_flow.chpl:6: error: 'break' is not allowed in a 'begin' statement
+test_control_flow.chpl:7: error: 'continue' is not allowed in a 'begin' statement
+test_control_flow.chpl:10: error: 'return' is not allowed in a 'cobegin' statement
+test_control_flow.chpl:11: error: 'break' is not allowed in a 'cobegin' statement
+test_control_flow.chpl:12: error: 'continue' is not allowed in a 'cobegin' statement
+test_control_flow.chpl:15: error: 'return' is not allowed in an 'on' statement
+test_control_flow.chpl:16: error: 'break' is not allowed in an 'on' statement
+test_control_flow.chpl:17: error: 'continue' is not allowed in an 'on' statement
+test_control_flow.chpl:21: error: 'return' is not allowed in a 'coforall' statement
+test_control_flow.chpl:22: error: 'break' is not allowed in a 'coforall' statement
+test_control_flow.chpl:23: error: 'continue' is not allowed in a 'coforall' statement
+test_control_flow.chpl:26: error: 'return' is not allowed in a 'forall' statement
+test_control_flow.chpl:27: error: 'break' is not allowed in a 'forall' statement
+test_control_flow.chpl:34: In iterator 'bar':
+test_control_flow.chpl:37: error: 'yield' is not allowed in a 'begin' statement
+test_control_flow.chpl:38: error: 'return' is not allowed in a 'begin' statement
+test_control_flow.chpl:39: error: 'break' is not allowed in a 'begin' statement
+test_control_flow.chpl:40: error: 'continue' is not allowed in a 'begin' statement
+test_control_flow.chpl:44: error: 'return' is not allowed in a 'cobegin' statement
+test_control_flow.chpl:45: error: 'break' is not allowed in a 'cobegin' statement
+test_control_flow.chpl:46: error: 'continue' is not allowed in a 'cobegin' statement
+test_control_flow.chpl:50: error: 'return' is not allowed in an 'on' statement
+test_control_flow.chpl:51: error: 'break' is not allowed in an 'on' statement
+test_control_flow.chpl:52: error: 'continue' is not allowed in an 'on' statement
+test_control_flow.chpl:57: error: 'return' is not allowed in a 'coforall' statement
+test_control_flow.chpl:58: error: 'break' is not allowed in a 'coforall' statement
+test_control_flow.chpl:59: error: 'continue' is not allowed in a 'coforall' statement
+test_control_flow.chpl:63: error: 'return' is not allowed in a 'forall' statement
+test_control_flow.chpl:64: error: 'break' is not allowed in a 'forall' statement
+test_control_flow.chpl:69: In function 'baz':
+test_control_flow.chpl:75: error: could not find label 'namedOuter' for 'continue' statement
+test_control_flow.chpl:72: note: stopped searching here because 'continue' statements are not allowed to jump outside a 'forall' statement
+test_control_flow.chpl:81: error: could not find label 'namedOuter' for 'continue' statement
+test_control_flow.chpl:72: note: stopped searching here because 'continue' statements are not allowed to jump outside a 'forall' statement

--- a/test/statements/bharshbarg/breakOutsideOfLoop.good
+++ b/test/statements/bharshbarg/breakOutsideOfLoop.good
@@ -1,3 +1,2 @@
 breakOutsideOfLoop.chpl:1: In function 'main':
 breakOutsideOfLoop.chpl:2: error: 'break' is not allowed outside of a loop
-breakOutsideOfLoop.chpl:1: note: stopped searching here because 'break' statements are not allowed to jump outside a procedure

--- a/test/statements/bharshbarg/breakOutsideOfLoop.good
+++ b/test/statements/bharshbarg/breakOutsideOfLoop.good
@@ -1,2 +1,3 @@
 breakOutsideOfLoop.chpl:1: In function 'main':
-breakOutsideOfLoop.chpl:2: error: break or continue is not in a loop
+breakOutsideOfLoop.chpl:2: error: 'break' is not allowed outside of a loop
+breakOutsideOfLoop.chpl:1: note: stopped searching here because 'break' statements are not allowed to jump outside a procedure

--- a/test/statements/sungeun/bad_break.good
+++ b/test/statements/sungeun/bad_break.good
@@ -1,3 +1,3 @@
-bad_break.chpl:29: error: bad label 'l3' on break or continue
-bad_break.chpl:32: error: bad label 'l2' on break or continue
-bad_break.chpl:37: error: bad label 'l1' on break or continue
+bad_break.chpl:29: error: could not find label 'l3' for 'break' statement
+bad_break.chpl:32: error: could not find label 'l2' for 'break' statement
+bad_break.chpl:37: error: could not find label 'l1' for 'break' statement

--- a/test/statements/sungeun/bad_continue.good
+++ b/test/statements/sungeun/bad_continue.good
@@ -1,3 +1,3 @@
-bad_continue.chpl:29: error: bad label 'l3' on break or continue
-bad_continue.chpl:32: error: bad label 'l2' on break or continue
-bad_continue.chpl:37: error: bad label 'l1' on break or continue
+bad_continue.chpl:29: error: could not find label 'l3' for 'continue' statement
+bad_continue.chpl:32: error: could not find label 'l2' for 'continue' statement
+bad_continue.chpl:37: error: could not find label 'l1' for 'continue' statement

--- a/test/statements/sungeun/bad_label.good
+++ b/test/statements/sungeun/bad_label.good
@@ -1,3 +1,9 @@
 bad_label.chpl:7: syntax error: labels should not be terminated with semicolons
 bad_label.chpl:13: syntax error: labels should not be terminated with semicolons
 bad_label.chpl:20: syntax error: labels should not be terminated with semicolons
+bad_label.chpl:11: error: could not find label 'l1' for 'break' statement
+bad_label.chpl:17: error: could not find label 'l2' for 'break' statement
+bad_label.chpl:18: error: could not find label 'l1' for 'break' statement
+bad_label.chpl:24: error: could not find label 'l3' for 'break' statement
+bad_label.chpl:25: error: could not find label 'l2' for 'break' statement
+bad_label.chpl:26: error: could not find label 'l1' for 'break' statement

--- a/test/trivial/deitz/statements/return_error.good
+++ b/test/trivial/deitz/statements/return_error.good
@@ -1,1 +1,1 @@
-return_error.chpl:1: error: return statement is not in a function or iterator
+return_error.chpl:1: error: 'return' is not allowed outside of a procedure or an iterator

--- a/test/trivial/dinan/bad_return.good
+++ b/test/trivial/dinan/bad_return.good
@@ -1,1 +1,1 @@
-bad_return.chpl:1: error: return statement is not in a function or iterator
+bad_return.chpl:1: error: 'return' is not allowed outside of a procedure or an iterator

--- a/test/trivial/vass/error-return-at-top-level.good
+++ b/test/trivial/vass/error-return-at-top-level.good
@@ -1,1 +1,1 @@
-error-return-at-top-level.chpl:2: error: return statement is not in a function or iterator
+error-return-at-top-level.chpl:2: error: 'return' is not allowed outside of a procedure or an iterator

--- a/test/trivial/vass/error-yield-at-top-level.good
+++ b/test/trivial/vass/error-yield-at-top-level.good
@@ -1,1 +1,1 @@
-error-yield-at-top-level.chpl:2: error: yield statement is outside an iterator
+error-yield-at-top-level.chpl:2: error: 'yield' is not allowed outside of an iterator


### PR DESCRIPTION
Control-flow checks are syntactic, and are pretty easy to get working with Dyno. Furthermore, we can do them in a single traversal by keeping track of a stack of control-flow nodes (already accessible via `post-parse-checks.cpp`'s `Visitor`), instead of collecting ASTs every time a new loop is built. This also helps address the case where the deferred building of coforall nodes (see #21650) hides control flow errors in coforall loops.

Reviewed by @mppf and @benharsh - thanks!

## Testing
- [x] paratest
- [x] tests from https://github.com/chapel-lang/chapel/pull/21666 no longer error internally and report proper errors