### PR TITLE
Add tests for 21651: internal errors continue/breaking to labeled loop outside coforall or on statement

### DIFF
--- a/test/statements/loops/labeledLoopBreakWithoutNestedCoforall.chpl
+++ b/test/statements/loops/labeledLoopBreakWithoutNestedCoforall.chpl
@@ -1,0 +1,17 @@
+label outerer for qq in 1..3 do {
+  coforall loc in Locales[0..0] do on loc {
+    coforall tid in 0..<1 {
+      var j = 0;
+      label outer while j < 10 {
+	var i = 1;
+	do {
+	  writeln((i, j));
+	  if i == 3 then
+	    break outerer;
+	  i += 1;
+	  j += 1;
+	} while (i < 100);
+      }
+    }
+  }
+}

--- a/test/statements/loops/labeledLoopBreakWithoutNestedCoforall.good
+++ b/test/statements/loops/labeledLoopBreakWithoutNestedCoforall.good
@@ -1,0 +1,2 @@
+labeledLoopBreakWithoutNestedCoforall.chpl:10: error: 'break' to label 'outerer' outside of a 'coforall' statement is not allowed
+labeledLoopBreakWithoutNestedCoforall.chpl:3: note: cannot 'break' out of a 'coforall' statement

--- a/test/statements/loops/labeledLoopBreakWithoutOnStatement.chpl
+++ b/test/statements/loops/labeledLoopBreakWithoutOnStatement.chpl
@@ -1,0 +1,11 @@
+label outerer for qq in 1..3 do {
+  on Locales[0] {
+    var i = 1;
+    do {
+      writeln(i);
+      if i == 3 then
+	continue outerer;
+      i += 1;
+    } while (i < 100);
+  }
+}

--- a/test/statements/loops/labeledLoopBreakWithoutOnStatement.good
+++ b/test/statements/loops/labeledLoopBreakWithoutOnStatement.good
@@ -1,0 +1,2 @@
+labeledLoopBreakWithoutOnStatement.chpl:7: error: 'continue' to label 'outerer' outside of an 'on' statement is not allowed
+labeledLoopBreakWithoutOnStatement.chpl:2: note: cannot 'continue' out of an 'on' statement

--- a/test/statements/loops/labeledLoopContinueWithoutNestedCoforall.chpl
+++ b/test/statements/loops/labeledLoopContinueWithoutNestedCoforall.chpl
@@ -1,0 +1,17 @@
+label outerer for qq in 1..3 do {
+  coforall loc in Locales[0..0] do on loc {
+    coforall tid in 0..<1 {
+      var j = 0;
+      label outer while j < 10 {
+	var i = 1;
+	do {
+	  writeln((i, j));
+	  if i == 3 then
+	    continue outerer;
+	  i += 1;
+	  j += 1;
+	} while (i < 100);
+      }
+    }
+  }
+}

--- a/test/statements/loops/labeledLoopContinueWithoutNestedCoforall.good
+++ b/test/statements/loops/labeledLoopContinueWithoutNestedCoforall.good
@@ -1,0 +1,2 @@
+labeledLoopContinueWithoutNestedCoforall.chpl:10: error: 'continue' to label 'outerer' outside of a 'coforall' statement is not allowed
+labeledLoopContinueWithoutNestedCoforall.chpl:3: note: cannot 'continue' out of a 'coforall' statement

--- a/test/statements/loops/labeledLoopContinueWithoutOnStatement.chpl
+++ b/test/statements/loops/labeledLoopContinueWithoutOnStatement.chpl
@@ -1,0 +1,11 @@
+label outerer for qq in 1..3 do {
+  on Locales[0] {
+    var i = 1;
+    do {
+      writeln(i);
+      if i == 3 then
+	continue outerer;
+      i += 1;
+    } while (i < 100);
+  }
+}

--- a/test/statements/loops/labeledLoopContinueWithoutOnStatement.good
+++ b/test/statements/loops/labeledLoopContinueWithoutOnStatement.good
@@ -1,0 +1,2 @@
+labeledLoopContinueWithoutOnStatement.chpl:7: error: 'continue' to label 'outerer' outside of an 'on' statement is not allowed
+labeledLoopContinueWithoutOnStatement.chpl:2: note: cannot 'continue' out of an 'on' statement


### PR DESCRIPTION
These were futures, but have been fixed in the meantime by #21664.
