### PR TITLE
Add array deinit perf test

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -215,6 +215,7 @@ arrays/ferguson/return-array-40000000.graph
 domains/ferguson/build-associative.graph
 performance/sparse/domainAssignment-similar.graph
 performance/sparse/domainAssignment-dissimilar.graph
+arrays/elliot/arrayInitDeinitPerf.graph
 # suite: Atomic performance
 types/atomic/ferguson/atomictest.graph
 # suite: Dynamic iterators

--- a/test/arrays/elliot/arrayInitDeinitPerf.chpl
+++ b/test/arrays/elliot/arrayInitDeinitPerf.chpl
@@ -1,0 +1,33 @@
+use Time, CTypes;
+config const size = 40_000_000;
+config const innerSize = 40;
+
+config const printTiming = true;
+
+proc timeit(type T, desc: string) {
+  var t: stopwatch;
+  {
+    t.start();
+    var A: T;
+    if printTiming {
+      writef("%s   init: %.3drs\n", desc, t.elapsed());
+      t.clear();
+    }
+  }
+  if printTiming {
+    writef("%s deinit: %.3drs\n", desc, t.elapsed());
+    t.clear();
+  }
+}
+
+record RAlloc {
+  var p: c_ptr(int);
+  proc init() {
+    p = c_malloc(int, innerSize);
+    for i in 0..<innerSize do p[i] = 0;
+  }
+  proc deinit() { c_free(p); }
+}
+
+timeit([1..size][1..innerSize] int, "AoA");
+timeit([1..size] RAlloc,            "AoR");

--- a/test/arrays/elliot/arrayInitDeinitPerf.execopts
+++ b/test/arrays/elliot/arrayInitDeinitPerf.execopts
@@ -1,0 +1,1 @@
+--size=50 --printTiming=false

--- a/test/arrays/elliot/arrayInitDeinitPerf.graph
+++ b/test/arrays/elliot/arrayInitDeinitPerf.graph
@@ -1,0 +1,5 @@
+perfkeys: AoA   init:, AoA deinit:, AoR   init:, AoR deinit:
+graphkeys: AoA init, AoA deinit, AoR init, AoR deinit
+repeat-files: arrayInitDeinitPerf.dat
+ylabel: Time (seconds)
+graphtitle: Array init/deinit performance, 40000000 element array

--- a/test/arrays/elliot/arrayInitDeinitPerf.perfkeys
+++ b/test/arrays/elliot/arrayInitDeinitPerf.perfkeys
@@ -1,0 +1,4 @@
+AoA   init:
+AoA deinit:
+AoR   init:
+AoR deinit:


### PR DESCRIPTION
Add a performance test to track deinit times for array-of-arrays and array-of-records (with alloc/dealloc). This is meant to track the impact of an upcoming patch to parallelize array deinitialization.

Part of #15215