### PR TITLE
Mark TaskErrors.first() as unstable

### DIFF
--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -297,6 +297,7 @@ module Errors {
     }
 
     /* Returns the first non-nil error contained in this TaskErrors group */
+    @unstable "`TaskErrors.first` is unstable; expect this method to change in the future."
     proc first() ref : owned Error? {
       var first = 0;
       for i in 0..#nErrors {

--- a/test/unstable/taskErrorsFirst.chpl
+++ b/test/unstable/taskErrorsFirst.chpl
@@ -1,0 +1,12 @@
+
+proc mightThrow(i: int) throws {
+    if i%2==0 then throw new Error("error!");
+}
+
+try {
+    coforall tid in 0..#5 {
+        mightThrow(tid);
+    }
+} catch e: TaskErrors {
+    writeln(e.first());
+} catch e { }

--- a/test/unstable/taskErrorsFirst.good
+++ b/test/unstable/taskErrorsFirst.good
@@ -1,0 +1,2 @@
+taskErrorsFirst.chpl:11: warning: `TaskErrors.first` is unstable; expect this method to change in the future.
+Error: error!


### PR DESCRIPTION
Per some discussion summarized here: https://github.com/chapel-lang/chapel/issues/21068#issuecomment-1431696946, we decided to mark `TaskErrors.first()` as unstable with the expectation that it may be renamed or modified in the future.

This PR adds the unstable annotation and an unstable test.

- [x] Passing paratest