### PR TITLE
Parallelize array deinitialization

### DIFF
--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1146,7 +1146,7 @@ override proc StencilArr.dsiDestroyArr(deinitElts:bool) {
           // fluff is always deinited in the LocArr deinit
           param needsDestroy = __primitive("needs auto destroy", eltType);
           if needsDestroy {
-            if _deinitElementsIsParallel(eltType) {
+            if _deinitElementsIsParallel(eltType, arr.locDom.myBlock.size) {
               forall i in arr.locDom.myBlock {
                 chpl__autoDestroy(arr.myElems[i]);
               }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1960,16 +1960,14 @@ module ChapelArray {
     _do_destroy_arr(array._unowned, array._instance, deinitElts);
   }
 
-  proc _deinitElementsIsParallel(type eltType) param {
-    // TODO: Would anything be hurt if this always returned true?
-    // one guess: arrays of arrays where all inner arrays share a domain?
-    return false;
+  proc _deinitElementsIsParallel(type eltType, size: integral) {
+    return init_elts_method(size, eltType) == ArrayInit.parallelInit;
   }
 
   proc _deinitElements(array: _array) {
     param needsDestroy = __primitive("needs auto destroy", array.eltType);
     if needsDestroy {
-      if _deinitElementsIsParallel(array.eltType) {
+      if _deinitElementsIsParallel(array.eltType, array.size) {
         forall elt in array {
           chpl__autoDestroy(elt);
         }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1114,7 +1114,7 @@ module ChapelBase {
     param needsDestroy = __primitive("needs auto destroy",
                                      __primitive("deref", oldDdata[0]));
     if needsDestroy && (oldSize > newSize) {
-      if _deinitElementsIsParallel(eltType) {
+      if _deinitElementsIsParallel(eltType, oldSize) {
         forall i in newSize..oldSize-1 do
           chpl__autoDestroy(oldDdata[i]);
       } else {

--- a/modules/internal/ChapelHashtable.chpl
+++ b/modules/internal/ChapelHashtable.chpl
@@ -263,8 +263,8 @@ module ChapelHashtable {
       // Go through the full slots in the current table and run
       // chpl__autoDestroy on the index
       if _typeNeedsDeinit(keyType) || _typeNeedsDeinit(valType) {
-        if _deinitElementsIsParallel(keyType) &&
-           _deinitElementsIsParallel(valType) {
+        if (!_typeNeedsDeinit(keyType) || _deinitElementsIsParallel(keyType, tableSize)) &&
+           (!_typeNeedsDeinit(valType) || _deinitElementsIsParallel(valType, tableSize)) {
           forall slot in _allSlots(tableSize) {
             ref aSlot = table[slot];
             if _isSlotFull(aSlot) {

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -823,7 +823,7 @@ module DefaultAssociative {
     override proc dsiDestroyArr(deinitElts:bool) {
       if deinitElts && this.eltsNeedDeinit {
         if _elementNeedsDeinit() {
-          if _deinitElementsIsParallel(eltType) {
+          if _deinitElementsIsParallel(eltType, dom.table.tableSize) {
             forall slot in dom.table.allSlots() {
               if dom._isSlotFull(slot) {
                 _deinitElement(data[slot]);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1122,7 +1122,7 @@ module DefaultRectangular {
                                            __primitive("deref", data[0]));
 
           if needsDestroy {
-            if _deinitElementsIsParallel(eltType) {
+            if _deinitElementsIsParallel(eltType, numElts) {
               forall i in 0..#numElts {
                 chpl__autoDestroy(data[i]);
               }
@@ -1506,7 +1506,7 @@ module DefaultRectangular {
           param needsDestroy = __primitive("needs auto destroy", eltType);
           if needsDestroy {
             if reallocD.size < dom.dsiNumIndices {
-              if _deinitElementsIsParallel(eltType) {
+              if _deinitElementsIsParallel(eltType, dom.dsiNumIndices) {
                 forall i in dom {
                   if !keep.contains(i) {
                     chpl__autoDestroy(dsiAccess(i));

--- a/test/constrained-generics/hashtable/MyHashtable.chpl
+++ b/test/constrained-generics/hashtable/MyHashtable.chpl
@@ -283,8 +283,8 @@ module MyHashtable {
       // Go through the full slots in the current table and run
       // chpl__autoDestroy on the index
       if _typeNeedsDeinit(keyType) || _typeNeedsDeinit(valType) {
-        if _deinitElementsIsParallel(keyType) &&
-           _deinitElementsIsParallel(valType) {
+        if _deinitElementsIsParallel(keyType, tableSize) &&
+           _deinitElementsIsParallel(valType, tableSize) {
           forall slot in _allSlots(tableSize) {
             ref aSlot = table[slot];
             if _isSlotFull(aSlot) {

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -907,7 +907,7 @@ override proc AccumStencilArr.dsiDestroyArr(deinitElts:bool) {
           // fluff is always deinited in the LocArr deinit
           param needsDestroy = __primitive("needs auto destroy", eltType);
           if needsDestroy {
-            if _deinitElementsIsParallel(eltType) {
+            if _deinitElementsIsParallel(eltType, arr.locDom.myBlock.size) {
               forall i in arr.locDom.myBlock {
                 chpl__autoDestroy(arr.myElems[i]);
               }


### PR DESCRIPTION
Historically, we have deintialized array elements serially. For many codes this isn't an issue because POD types don't need any element deinit, but for types with non-trivial deinit (typically things that deallocate) like arrays-of-strings or arrays-of-bigints this can cause non-trivial slowdowns.

This changes array deinit to be parallel using the same heuristics as parallel init. This ensures we don't create a lot of tasks for small arrays and that affinity will be similar between init and deinit.

This speeds up deinit for most arrays whose elements require deinit, but slows down array-of-arrays since the performance hit from contentions on reference counters exceeds the speedup for parallel deallocation. Future improvements to speed up reference counting and do bulk counting for AoA is captured in Cray/chapel-private#1378 and Cray/chapel-private#4362. And while it is a regression, it just makes AoA deinit as slow as init.

Performance for arrayInitDeinitPerf on chapcs:

| config     | before | after  |
| ---------- | -----: | -----: |
| AoA   init | 12.56s | 12.54s |
| AoA deinit |  2.86s | 10.35s |
| AoR   init |  0.28s |  0.28s |
| AoR deinit |  0.99s |  0.04s |

For an arkouda bigint_conversion test (which most recently motivated this change) on 16-node-cs-hdr:

| config           | before | after  |
| ---------------- | -----: | -----: |
| bigint_from_uint | 2.19s  | 0.18s  |
| bigint_to_uint   | 2.63s  | 0.27s  |

Resolves #15215