### PR TITLE
Revert changes to a submitted shootout, update good file instead

### DIFF
--- a/test/studies/shootout/submitted/regexredux3.chpl
+++ b/test/studies/shootout/submitted/regexredux3.chpl
@@ -31,7 +31,7 @@ proc main(args: [] string) {
   const initLen = data.size;
 
   // remove newlines
-  data = data.replace(compile(b">.*\n|\n"), b"");
+  data = compile(b">.*\n|\n").sub(b"", data);
 
   var copy = data; // make a copy so we can perform replacements in parallel
 
@@ -41,7 +41,7 @@ proc main(args: [] string) {
     // fire off a task to perform replacements
     begin with (ref copy) {
       for (f, r) in subst do
-        copy = copy.replace(compile(f), r);
+        copy = compile(f).sub(r, copy);
     }
 
     // count patterns

--- a/test/studies/shootout/submitted/regexredux3.good
+++ b/test/studies/shootout/submitted/regexredux3.good
@@ -1,5 +1,7 @@
 regexredux3.chpl:11: In function 'main':
 regexredux3.chpl:30: warning: 'readbytes' is deprecated; please use 'readBytes' instead
+regexredux3.chpl:34: warning: regex.sub is deprecated. Please use string.replace.
+regexredux3.chpl:44: warning: regex.sub is deprecated. Please use string.replace.
 agggtaaa|tttaccct 1
 [cgt]gggtaaa|tttaccc[acg] 0
 a[act]ggtaaa|tttacc[agt]t 0


### PR DESCRIPTION
I changed a `submitted` implementation of a shootout in https://github.com/chapel-lang/chapel/pull/21600. This reverts the change and updates the good file instead.

Thanks @lydia-duncan for noticing it. 