### PR TITLE
Remove 'It's us, not you' from internal error message

### DIFF
--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -759,12 +759,15 @@ static void printErrorFooter(int guess) {
   // Apologize for our internal errors to the end-user
   //
   if (!developer && !err_user) {
-    print_error("\n\n"
-      "Internal errors indicate a bug in the Chapel compiler (\"It's us, not you\"),\n"
-      "and we're sorry for the hassle.  We would appreciate your reporting this bug --\n"
-      "please see %s for instructions.%s\n\n", help_url,
-      (guess == -1) ? "" : "  In the meantime,\n"
-      "the filename + line number above may be useful in working around the issue.");
+    print_error(
+        "\n\n"
+        "Internal errors indicate a bug in the Chapel compiler,\nand we're "
+        "sorry for the hassle.  We would appreciate your reporting this bug "
+        "--\nplease see %s for instructions.%s\n\n",
+        help_url,
+        (guess == -1) ? ""
+                      : "  In the meantime,\nthe filename + line number above "
+                        "may be useful in working around the issue.");
 
     //
     // and exit if it's fatal (isn't it always?)

--- a/test/constrained-generics/basic/generic/ic-req-function.bad
+++ b/test/constrained-generics/basic/generic/ic-req-function.bad
@@ -1,7 +1,7 @@
 ic-req-function.chpl:11: internal error: RES-INT-ION-nnnn chpl version mmmm
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/constrained-generics/basic/set3/hashtable-table.bad
+++ b/test/constrained-generics/basic/set3/hashtable-table.bad
@@ -1,7 +1,7 @@
 hashtable-table.chpl:40: internal error: COD-CG--XPR-nnnn chpl version mmmm
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/expressions/loop-expr/ifExprWithForallBug.bad
+++ b/test/expressions/loop-expr/ifExprWithForallBug.bad
@@ -1,7 +1,7 @@
 ifExprWithForallBug.chpl:6: internal error: RES-RES-ION-nnnn chpl version mmmm
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/extern/ferguson/bug-global-c-array.bad
+++ b/test/extern/ferguson/bug-global-c-array.bad
@@ -1,7 +1,7 @@
 bug-global-c-array.chpl:16: internal error: COD-CG--XPR-0590 chpl version 1.30.0 pre-release (b72fbacc85)
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
@@ -2,7 +2,7 @@ Incorrect number of arguments passed to called function!
   %4 = call i32 @returnIntFromIntArg() #0
 internal error: COD-CG--BOL-nnnn chpl version mmmm
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.
 

--- a/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.bad
@@ -2,7 +2,7 @@ Incorrect number of arguments passed to called function!
   %2 = call i32 @returnIntFromIntArg() #0
 internal error: COD-CG--BOL-nnnn chpl version mmmm
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.
 

--- a/test/functions/bradc/paramThis/funParamThis3.bad
+++ b/test/functions/bradc/paramThis/funParamThis3.bad
@@ -1,6 +1,6 @@
 funParamThis3.chpl:2: internal error: AST-FNS-BOL-0107 chpl version 1.19.0 pre-release (cfeb6592b3)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/functions/iterators/bradc/captureEmpty.bad
+++ b/test/functions/iterators/bradc/captureEmpty.bad
@@ -1,6 +1,6 @@
 captureEmpty.chpl:5: internal error: RES-CLE-UPS-nnnn chpl version mmmm
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/functions/iterators/errors/mistakenIteratorShape.bad
+++ b/test/functions/iterators/errors/mistakenIteratorShape.bad
@@ -1,7 +1,7 @@
 mistakenIteratorShape.chpl:16: internal error: AST-ITE-TOR-0522 chpl version 1.30.0 pre-release (b'ae52de5bbc')
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.bad
+++ b/test/functions/iterators/recursive/recursive-iter-yield-recursive-iter.bad
@@ -1,7 +1,7 @@
 recursive-iter-yield-recursive-iter.chpl:3: internal error: UTI-MIS-nnnn chpl version mmmm
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/functions/promotion/declareVarFromPromotedType.bad
+++ b/test/functions/promotion/declareVarFromPromotedType.bad
@@ -1,7 +1,7 @@
 declareVarFromPromotedType.chpl:2: internal error: RES-FUN-ION-10082 chpl version 1.23.0 pre-release (1032009515)
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/library/standard/Map/types/ClassWithMapWithRecord.bad
+++ b/test/library/standard/Map/types/ClassWithMapWithRecord.bad
@@ -1,6 +1,6 @@
 internal error: RES-CUL-CES-1763 chpl version 1.30.0 pre-release (b'ae52de5bbc')
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.
 

--- a/test/parallel/taskPar/taskIntents/inCopyPassedToRef.verify.bad
+++ b/test/parallel/taskPar/taskIntents/inCopyPassedToRef.verify.bad
@@ -1,7 +1,7 @@
 inCopyPassedToRef.verify.chpl:1: In function 'main':
 inCopyPassedToRef.verify.chpl:7: internal error: MAI-CHE-CKS-nnnn chpl version mmmm
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/reductions/classes/classReduction.bad
+++ b/test/reductions/classes/classReduction.bad
@@ -1,6 +1,6 @@
 classReduction.chpl:12: internal error: RES-VIS-ONS-0819 chpl version 1.23.0 pre-release (152a058832)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/reductions/vass/reduce-of-more-promoted.bad
+++ b/test/reductions/vass/reduce-of-more-promoted.bad
@@ -1,7 +1,7 @@
 $CHPL_HOME/modules/internal/ChapelReduce.chpl:nnnn: internal error: RES-FUN-ION-nnnn chpl version mmmm
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.verify.bad
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.verify.bad
@@ -1,7 +1,7 @@
 revcomp-blc-begin-const-ref.verify.chpl:20: In function 'main':
 revcomp-blc-begin-const-ref.verify.chpl:49: internal error: MAI-CHE-CKS-nnnn chpl version mmmm
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug.bad
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug.bad
@@ -1,6 +1,6 @@
 revcomp-blc-copyPropBug.chpl:51: internal error: OPT-COP-ION-0949 chpl version 1.27.0 pre-release (d3784d28a2)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-dowhile-bug.bad
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-dowhile-bug.bad
@@ -1,6 +1,6 @@
 revcomp-dowhile-bug.chpl:58: internal error: OPT-COP-ION-0904 chpl version 1.23.0 pre-release (dc8c98a9ae)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/types/enum/lydia/declaredInClass-initializer.bad
+++ b/test/types/enum/lydia/declaredInClass-initializer.bad
@@ -1,7 +1,7 @@
 declaredInClass-initializer.chpl:21: internal error: UTI-MIS-0597 chpl version 1.19.0 pre-release (cfeb6592b3)
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/types/records/tupleFields/detupleFieldDecl.bad
+++ b/test/types/records/tupleFields/detupleFieldDecl.bad
@@ -1,6 +1,6 @@
 detupleFieldDecl.chpl:10: internal error: AST-AGG-YPE-0422 chpl version 1.19.0 pre-release (cfeb6592b3)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/types/tuple/errors/tuple-init.bad
+++ b/test/types/tuple/errors/tuple-init.bad
@@ -1,7 +1,7 @@
 $CHPL_HOME/modules/internal/ChapelBase.chpl:1347: internal error: UTI-MIS-0939 chpl version 1.27.0 pre-release (b832268935)
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/types/tuple/heterogeneous/loops/varargsHetTuple.bad
+++ b/test/types/tuple/heterogeneous/loops/varargsHetTuple.bad
@@ -1,7 +1,7 @@
 varargsHetTuple.chpl:16: internal error: COD-CG--XPR-5628 chpl version 1.22.0.0ce16d314b
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/types/tuple/split-init/multipleInit.bad
+++ b/test/types/tuple/split-init/multipleInit.bad
@@ -1,6 +1,6 @@
 multipleInit.chpl:2: internal error: AST-PRI-IVE-0235 chpl version 1.24.0 pre-release (8b0484037d)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/types/tuple/these/iterHetTupleArg.bad
+++ b/test/types/tuple/these/iterHetTupleArg.bad
@@ -1,7 +1,7 @@
 iterHetTupleArg.chpl:14: internal error: COD-CG--XPR-5708 chpl version 1.24.0 pre-release (a721b8db24)
 Note: This source location is a guess.
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/users/engin/retInnerFunction.bad
+++ b/test/users/engin/retInnerFunction.bad
@@ -1,6 +1,6 @@
 retInnerFunction.chpl:5: internal error: RES-ADD-LLS-0719 chpl version 1.21.0 pre-release (3b498c4d5f)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/users/vass/uniquify/u1-local-user-extern.bad
+++ b/test/users/vass/uniquify/u1-local-user-extern.bad
@@ -1,6 +1,6 @@
 u1-local-user-extern.chpl:12: internal error: COD-COD-GEN-1030 chpl version 1.19.0 pre-release (cfeb6592b3)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.

--- a/test/users/vass/uniquify/u2-local-extern-extern.bad
+++ b/test/users/vass/uniquify/u2-local-extern-extern.bad
@@ -1,6 +1,6 @@
 u2-local-extern-extern.chpl:8: internal error: COD-COD-GEN-1030 chpl version 1.19.0 pre-release (cfeb6592b3)
 
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
 please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
 the filename + line number above may be useful in working around the issue.


### PR DESCRIPTION
Removes the parenthetical "It's us, not you" from our internal error message.

Resolves https://github.com/Cray/chapel-private/issues/4144.

Testing:
- [x] paratest with futures