### PR TITLE
Add support for linking annotations to private issues

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1088,6 +1088,8 @@ LCALS-raw-short: &lcals-base
     - Task intents to operate on fields of 'this' (#13840)
   09/10/19:
     - Restrict applicability of field intents (#14057)
+  02/14/23:
+    - LCALS perf back to normal (Cray/chapel-private#4228)
 LCALS-raw-medium:
   <<: *lcals-base
 LCALS-raw-long:

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -545,6 +545,12 @@ function computeGitHubLinks(text) {
     return "<a target='_blank' href='" + url + "'>" + m + "</a>";
   });
 
+  var private_re = /\(Cray\/chapel-private#([0-9]+)\)/gi;
+  text = text.replace(private_re, function(m, num) {
+    var url = "https://github.com/Cray/chapel-private/issues/" + num;
+    return "<a target='_blank' href='" + url + "'>" + m + "</a>";
+  });
+
   var ak_re = /\(Bears-R-Us\/arkouda#([0-9]+)\)/gi;
   text = text.replace(ak_re, function(m, num) {
     var url = "https://github.com/Bears-R-Us/arkouda/pull/" + num;


### PR DESCRIPTION
Historically annotations have just linked to PRs responsible for changes, but sometimes performance changes from other factors and it can be nice to link to issues that contain more detail. Add support for that here.