### PR TITLE
Remove old support `CHPL_TARGET_PLATFORM=aarch64` from gmp chplenv

### DIFF
--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -32,8 +32,6 @@ def get():
             gmp_val = 'bundled'
         elif target_platform.startswith('cray-x'):
             gmp_val = 'system'
-        elif target_platform == 'aarch64':
-            gmp_val = 'system'
         else:
             gmp_val = 'none'
 


### PR DESCRIPTION
`CHPL_TARGET_PLATFORM=aarch64` was a temporary name for ARM on Cray XCs, which has since become just Cray XC with `CHPL_TARGET_ARCH=arm64`. This vestige should have been removed in 641c143850, but I missed it then.

Closes Cray/chapel-private#4289