### PR TITLE
Add the missing skipif for a regex test

### DIFF
--- a/test/deprecated/regexSubSubn.skipif
+++ b/test/deprecated/regexSubSubn.skipif
@@ -1,0 +1,1 @@
+CHPL_RE2==none


### PR DESCRIPTION
Adds the skipif that I forgot to add in https://github.com/chapel-lang/chapel/pull/21600.