### PR TITLE
Move annotations from memLeaks to memLeaksFull

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1224,10 +1224,6 @@ memleaks:
     - Fix problem with new applied to a borrowed nilable type argument (#16380)
   09/17/20:
     - Fix some issues with constant domain optimization (#16397)
-  02/21/23:
-    - IO Encoders/Decoders prototype (#21586)
-  02/23/23:
-    - QIO fix Free the mark stack if it has been allocated (#21662)
 # End memleaks
 
 memleaksfull:
@@ -1466,6 +1462,10 @@ memleaksfull:
     - Clean up unmanaged classes in a test (#19695)
   09/30/22:
     - Begin the effort of improving Chapel's first-class-function support (#20554)
+  02/21/23:
+    - IO Encoders/Decoders prototype (#21586)
+  02/23/23:
+    - QIO fix Free the mark stack if it has been allocated (#21662)
 # End memleaksfull
 
 meteor:


### PR DESCRIPTION
In #21677, Elliot pointed out that I accidentally put the annotations under `memLeaks`, when they actually belonged under `memLeaksFull`.