### PR TITLE
dyno: Avoid emitting a module/file name mismatch error twice

### DIFF
--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -457,6 +457,7 @@ static const Module* const& getToplevelModuleQuery(Context* context,
   } else {
     // Check the module search path for the module.
     std::string check;
+    std::set<ID> seenModules;
 
     for (auto path : moduleSearchPath(context)) {
       check = path.str();
@@ -479,16 +480,18 @@ static const Module* const& getToplevelModuleQuery(Context* context,
         UniqueString emptyParentSymbolPath;
         const ModuleVec& v = parse(context, filePath, emptyParentSymbolPath);
         for (auto mod: v) {
+          if (seenModules.find(mod->id()) != seenModules.end()) continue;
+
           if (mod->name() == name) {
             result = mod;
             break;
           } else {
-            // TODO: is the error what we need in this case?
-            // What does the production compiler do?
+            // TODO: Production compiler does not emit this error, keep it?
             context->error(mod, "In use/imported file, module name %s "
                                 "does not match file name %s.chpl",
                                 mod->name().c_str(),
                                 name.c_str());
+            seenModules.insert(mod->id());
           }
         }
       }


### PR DESCRIPTION
Keep track of modules we've seen before when loading modules from
search paths in `getToplevelModule`. This avoids emitting the same
error twice in a row in the event that e.g., the search path `.`
appears twice.

For the following code:

```chapel
// SomeLibrary.chpl
module M {
  var x = 42;
}

// main.chpl
proc main() {
  use SomeLibrary only;
  writeln(SomeLibrary.M.x);
}
```

The error looks like:

```
/SomeLibrary.chpl:1: error: In use/imported file, module name M
does not match file name SomeLibrary.chpl
--> Old error appears from both production and dyno...
main.chpl:1: In function 'main':                                                                                                                                                     │
main.chpl:2: error: cannot find module or enum named 'SomeLibrary'
```

I think the new error is useful and we should consider keeping it,
so I've left it in.

I've opened a discussion thread in: #21702

Reviewed by @mppf. Thanks!