### PR TITLE
fix: check that terminal supports color before clearing

### DIFF
--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -179,6 +179,12 @@ class Context {
     }
   }
 
+  void clearTerminalColor(std::ostream& os) {
+    if (currentTerminalSupportsColor_) {
+      os << getClearColorFormat();
+    }
+  }
+
 
 
   // The following are only used for UniqueString garbage collection

--- a/frontend/include/chpl/framework/query-impl.h
+++ b/frontend/include/chpl/framework/query-impl.h
@@ -135,14 +135,16 @@ void Context::queryBeginTrace(const char* traceQueryName,
       // QUERY BEGIN
       setQueryDepthColor(queryTraceDepth, std::cout);
       std::cout << queryTraceDepth
-                << " { "
-                << clearTerminalColor() << traceQueryName << " (";
+                << " { ";
+      clearTerminalColor(std::cout);
+      std::cout << traceQueryName << " (";
       queryArgsPrint(tupleOfArg);
       std::cout << ") ";
       setTerminalColor(CYAN, std::cout);
       std::cout <<"hash: 0x"
-                << std::hex << queryAndArgsHash
-                << clearTerminalColor() << std::endl;
+                << std::hex << queryAndArgsHash;
+      clearTerminalColor(std::cout);
+      std::cout << std::endl;
     }
     if (breakSet && queryAndArgsHash == breakOnHash) {
       debuggerBreakHere();
@@ -338,9 +340,9 @@ Context::queryEnd(
                    traceQueryName) == queryTraceIgnoreQueries.end()) {
     // QUERY END
     setQueryDepthColor(queryTraceDepth, std::cout);
-    std::cout << queryTraceDepth
-              << clearTerminalColor()
-              << "   " << traceQueryName
+    std::cout << queryTraceDepth;
+    clearTerminalColor(std::cout);
+    std::cout << "   " << traceQueryName
               << " ";
     if (ret->lastChanged == this->currentRevisionNumber) {
       setTerminalColor(YELLOW, std::cout);
@@ -350,9 +352,9 @@ Context::queryEnd(
       std::cout << "unchanged";
     }
     setQueryDepthColor(queryTraceDepth, std::cout);
-    std::cout << " } "
-              << clearTerminalColor()
-              << std::endl;
+    std::cout << " } ";
+    clearTerminalColor(std::cout);
+    std::cout << std::endl;
     queryTraceDepth--;
     CHPL_ASSERT(r->lastChecked == this->currentRevisionNumber);
     //for (auto dep : r->dependencies) {

--- a/frontend/include/chpl/util/terminal.h
+++ b/frontend/include/chpl/util/terminal.h
@@ -49,7 +49,7 @@ std::string getColorFormat(TermColorName colorName);
 
 bool terminalSupportsColor(const char* term);
 
-std::string clearTerminalColor();
+std::string getClearColorFormat();
 
 } // end namespace chpl
 

--- a/frontend/lib/util/terminal.cpp
+++ b/frontend/lib/util/terminal.cpp
@@ -55,7 +55,7 @@ std::string getColorFormat(TermColorName colorName) {
   return ret.c_str();
 }
 
-std::string clearTerminalColor() {
+std::string getClearColorFormat() {
   std::string ret = getColorFormat(CLEAR);
   return ret;
 }


### PR DESCRIPTION
This PR corrects a bug where dyno debug statements were adding the terminal code to reset font color before checking to make sure that the terminal supported color, as it does when setting the font color. This caused escape sequences to reset the terminal font color to be present even when capturing the output to a file. 

TESTING: 

- [x] `chpl hello.chpl --dyno-debug-trace > out.txt 2>&1` does not include any terminal color codes
- [x] `chpl hello.chpl --dyno-debug-trace` still has colorization

reviewed by @benharsh - thank you!