### PR TITLE
Include chpl-env in files that use CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE  macro

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -33,6 +33,7 @@ bool chpl_gpu_debug = false;
 #include "error.h"
 #include "chplcgfns.h"
 #include "chpl-linefile-support.h"
+#include "chpl-env-gen.h"
 
 void chpl_gpu_init(void) {
   chpl_gpu_impl_init();

--- a/runtime/src/gpu/common/cuda-shared.h
+++ b/runtime/src/gpu/common/cuda-shared.h
@@ -24,6 +24,7 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "chpl-env-gen.h"
 
 #include "cuda-utils.h"
 


### PR DESCRIPTION
After this PR: https://github.com/chapel-lang/chapel/pull/21516 (Remove redundant redefinition of CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE) we need any file that uses the `CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE` macro to `#include "chpl-env-gen.h"`.

In this PR https://github.com/chapel-lang/chapel/pull/21644 I noticed this include was missing from one file and added it. This triggered a bug because there was another file that was missing it. In this PR I've added it.