### PR TITLE
Add support to one-line-only code output to detailed error messages

### DIFF
--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -342,9 +342,8 @@ void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
                  blockingName, " is not allowed.");
       wr.code(invalidAst, { invalidAst });
       wr.note(locationOnly(blockingAst), "cannot '", astType, "' "
-              "out of ", blockingNameArticle, " ", blockingName, ".");
-      // TODO: Re-enable when code printing doesn't dump whole code blocks
-      // wr.code(blockingAst, { blockingAst });
+              "out of ", blockingNameArticle, " ", blockingName, ":");
+      wr.codeForLocation(blockingAst);
     }
 
   } else if (!blockingAst || blockingAst->isFunction()) {
@@ -367,19 +366,16 @@ void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
     if (blockingAst && allowingAst) {
       CHPL_ASSERT(invalidAst->isBreak() || invalidAst->isContinue());
       wr.note(locationOnly(blockingAst), "cannot '", astType, "' "
-              "out of ", blockingNameArticle, " ", blockingName, ".");
-      // TODO: Re-enable when code printing doesn't dump whole code blocks
-      // wr.code(blockingAst, { blockingAst });
+              "out of ", blockingNameArticle, " ", blockingName, ":");
+      wr.codeForLocation(blockingAst);
     }
   } else {
     // any piece of control flow banned within a particular language feature
     wr.heading(kind_, type_, invalidAst, "'", astType, "' is not allowed in ",
                blockingNameArticle, " ", blockingName, ".");
     wr.code(invalidAst, { invalidAst });
-
-    // TODO: Re-enable when code printing doesn't dump whole code blocks
-    // wr.message("The ", blockingName, " is here:");
-    // wr.code(blockingAst);
+    wr.message("The relevant ", blockingName, " is here:");
+    wr.codeForLocation(blockingAst);
   }
 }
 

--- a/test/errors/parsing/controlFlow.2.good
+++ b/test/errors/parsing/controlFlow.2.good
@@ -74,6 +74,10 @@
     21 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
+  The relevant 'forall' statement is here:
+       |
+    20 | forall 1..10 {
+       |
 
 ─── error in controlFlow.chpl:22 [DisallowedControlFlow] ───
   Could not find label 'someLabel' for 'break' statement.
@@ -95,6 +99,10 @@
     27 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
+  The relevant 'coforall' statement is here:
+       |
+    26 | coforall 1..10 {
+       |
 
 ─── error in controlFlow.chpl:28 [DisallowedControlFlow] ───
   Could not find label 'someLabel' for 'break' statement.
@@ -108,6 +116,10 @@
        |
     29 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'coforall' statement is here:
+       |
+    26 | coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:30 [DisallowedControlFlow] ───
@@ -123,6 +135,10 @@
     33 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
+  The relevant 'on' statement is here:
+       |
+    32 | on here {
+       |
 
 ─── error in controlFlow.chpl:34 [DisallowedControlFlow] ───
   Could not find label 'someLabel' for 'break' statement.
@@ -136,6 +152,10 @@
        |
     35 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'on' statement is here:
+       |
+    32 | on here {
        |
 
 ─── error in controlFlow.chpl:36 [DisallowedControlFlow] ───
@@ -151,6 +171,10 @@
     39 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
+  The relevant 'begin' statement is here:
+       |
+    38 | begin {
+       |
 
 ─── error in controlFlow.chpl:40 [DisallowedControlFlow] ───
   Could not find label 'someLabel' for 'break' statement.
@@ -164,6 +188,10 @@
        |
     41 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'begin' statement is here:
+       |
+    38 | begin {
        |
 
 ─── error in controlFlow.chpl:42 [DisallowedControlFlow] ───
@@ -179,6 +207,10 @@
     45 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
+  The relevant 'sync' statement is here:
+       |
+    44 | sync {
+       |
 
 ─── error in controlFlow.chpl:46 [DisallowedControlFlow] ───
   Could not find label 'someLabel' for 'break' statement.
@@ -192,6 +224,10 @@
        |
     47 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'sync' statement is here:
+       |
+    44 | sync {
        |
 
 ─── error in controlFlow.chpl:48 [DisallowedControlFlow] ───
@@ -207,6 +243,10 @@
     51 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
+  The relevant 'cobegin' statement is here:
+       |
+    50 | cobegin {
+       |
 
 ─── error in controlFlow.chpl:52 [DisallowedControlFlow] ───
   Could not find label 'someLabel' for 'break' statement.
@@ -220,6 +260,10 @@
        |
     53 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'cobegin' statement is here:
+       |
+    50 | cobegin {
        |
 
 ─── error in controlFlow.chpl:54 [DisallowedControlFlow] ───
@@ -235,7 +279,10 @@
     59 |         break;
        |         ⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a procedure.
+  Cannot 'break' out of a procedure:
+       |
+    58 |     proc wrapper2() {
+       |
 
 ─── error in controlFlow.chpl:60 [DisallowedControlFlow] ───
   'break' to label 'actualLabel' outside of a procedure is not allowed.
@@ -243,7 +290,10 @@
     60 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a procedure.
+  Cannot 'break' out of a procedure:
+       |
+    58 |     proc wrapper2() {
+       |
 
 ─── error in controlFlow.chpl:61 [DisallowedControlFlow] ───
   'continue' is not allowed outside of a loop.
@@ -251,7 +301,10 @@
     61 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a procedure.
+  Cannot 'continue' out of a procedure:
+       |
+    58 |     proc wrapper2() {
+       |
 
 ─── error in controlFlow.chpl:62 [DisallowedControlFlow] ───
   'continue' to label 'actualLabel' outside of a procedure is not allowed.
@@ -259,13 +312,20 @@
     62 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a procedure.
+  Cannot 'continue' out of a procedure:
+       |
+    58 |     proc wrapper2() {
+       |
 
 ─── error in controlFlow.chpl:67 [DisallowedControlFlow] ───
   'break' is not allowed in a 'forall' statement.
        |
     67 |         break;
        |         ⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'forall' statement is here:
+       |
+    66 |     forall 1..10 {
        |
 
 ─── error in controlFlow.chpl:68 [DisallowedControlFlow] ───
@@ -274,7 +334,10 @@
     68 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'forall' statement.
+  Cannot 'break' out of a 'forall' statement:
+       |
+    66 |     forall 1..10 {
+       |
 
 ─── error in controlFlow.chpl:70 [DisallowedControlFlow] ───
   'continue' to label 'actualLabel' outside of a 'forall' statement is not allowed.
@@ -282,13 +345,20 @@
     70 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a 'forall' statement.
+  Cannot 'continue' out of a 'forall' statement:
+       |
+    66 |     forall 1..10 {
+       |
 
 ─── error in controlFlow.chpl:73 [DisallowedControlFlow] ───
   'break' is not allowed in a 'coforall' statement.
        |
     73 |         break;
        |         ⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'coforall' statement is here:
+       |
+    72 |     coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:74 [DisallowedControlFlow] ───
@@ -297,13 +367,20 @@
     74 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'coforall' statement.
+  Cannot 'break' out of a 'coforall' statement:
+       |
+    72 |     coforall 1..10 {
+       |
 
 ─── error in controlFlow.chpl:75 [DisallowedControlFlow] ───
   'continue' is not allowed in a 'coforall' statement.
        |
     75 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'coforall' statement is here:
+       |
+    72 |     coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:76 [DisallowedControlFlow] ───
@@ -312,13 +389,20 @@
     76 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a 'coforall' statement.
+  Cannot 'continue' out of a 'coforall' statement:
+       |
+    72 |     coforall 1..10 {
+       |
 
 ─── error in controlFlow.chpl:79 [DisallowedControlFlow] ───
   'break' is not allowed in an 'on' statement.
        |
     79 |         break;
        |         ⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'on' statement is here:
+       |
+    78 |     on here {
        |
 
 ─── error in controlFlow.chpl:80 [DisallowedControlFlow] ───
@@ -327,13 +411,20 @@
     80 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of an 'on' statement.
+  Cannot 'break' out of an 'on' statement:
+       |
+    78 |     on here {
+       |
 
 ─── error in controlFlow.chpl:81 [DisallowedControlFlow] ───
   'continue' is not allowed in an 'on' statement.
        |
     81 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'on' statement is here:
+       |
+    78 |     on here {
        |
 
 ─── error in controlFlow.chpl:82 [DisallowedControlFlow] ───
@@ -342,13 +433,20 @@
     82 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of an 'on' statement.
+  Cannot 'continue' out of an 'on' statement:
+       |
+    78 |     on here {
+       |
 
 ─── error in controlFlow.chpl:85 [DisallowedControlFlow] ───
   'break' is not allowed in a 'begin' statement.
        |
     85 |         break;
        |         ⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'begin' statement is here:
+       |
+    84 |     begin {
        |
 
 ─── error in controlFlow.chpl:86 [DisallowedControlFlow] ───
@@ -357,13 +455,20 @@
     86 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'begin' statement.
+  Cannot 'break' out of a 'begin' statement:
+       |
+    84 |     begin {
+       |
 
 ─── error in controlFlow.chpl:87 [DisallowedControlFlow] ───
   'continue' is not allowed in a 'begin' statement.
        |
     87 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'begin' statement is here:
+       |
+    84 |     begin {
        |
 
 ─── error in controlFlow.chpl:88 [DisallowedControlFlow] ───
@@ -372,13 +477,20 @@
     88 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a 'begin' statement.
+  Cannot 'continue' out of a 'begin' statement:
+       |
+    84 |     begin {
+       |
 
 ─── error in controlFlow.chpl:91 [DisallowedControlFlow] ───
   'break' is not allowed in a 'sync' statement.
        |
     91 |         break;
        |         ⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'sync' statement is here:
+       |
+    90 |     sync {
        |
 
 ─── error in controlFlow.chpl:92 [DisallowedControlFlow] ───
@@ -387,13 +499,20 @@
     92 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'sync' statement.
+  Cannot 'break' out of a 'sync' statement:
+       |
+    90 |     sync {
+       |
 
 ─── error in controlFlow.chpl:93 [DisallowedControlFlow] ───
   'continue' is not allowed in a 'sync' statement.
        |
     93 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'sync' statement is here:
+       |
+    90 |     sync {
        |
 
 ─── error in controlFlow.chpl:94 [DisallowedControlFlow] ───
@@ -402,13 +521,20 @@
     94 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a 'sync' statement.
+  Cannot 'continue' out of a 'sync' statement:
+       |
+    90 |     sync {
+       |
 
 ─── error in controlFlow.chpl:97 [DisallowedControlFlow] ───
   'break' is not allowed in a 'cobegin' statement.
        |
     97 |         break;
        |         ⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'cobegin' statement is here:
+       |
+    96 |     cobegin {
        |
 
 ─── error in controlFlow.chpl:98 [DisallowedControlFlow] ───
@@ -417,13 +543,20 @@
     98 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'cobegin' statement.
+  Cannot 'break' out of a 'cobegin' statement:
+       |
+    96 |     cobegin {
+       |
 
 ─── error in controlFlow.chpl:99 [DisallowedControlFlow] ───
   'continue' is not allowed in a 'cobegin' statement.
        |
     99 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'cobegin' statement is here:
+       |
+    96 |     cobegin {
        |
 
 ─── error in controlFlow.chpl:100 [DisallowedControlFlow] ───
@@ -432,5 +565,8 @@
     100 |         continue actualLabel;
         |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
         |
-  Cannot 'continue' out of a 'cobegin' statement.
+  Cannot 'continue' out of a 'cobegin' statement:
+       |
+    96 |     cobegin {
+       |
 

--- a/test/errors/scope-resolution/redefinition/redefinition-variables.1.good
+++ b/test/errors/scope-resolution/redefinition/redefinition-variables.1.good
@@ -1,3 +1,4 @@
 redefinition-variables.chpl:1: error: 'x' has multiple definitions
 redefinition-variables.chpl:3: note: redefined here
 redefinition-variables.chpl:4: note: redefined here
+redefinition-variables.chpl:6: note: redefined here

--- a/test/errors/scope-resolution/redefinition/redefinition-variables.2.good
+++ b/test/errors/scope-resolution/redefinition/redefinition-variables.2.good
@@ -4,8 +4,6 @@
       |
     1 | var x =
       |     ⎺⎺⎺⎺
-    2 |         1;
-      | ⎺⎺⎺⎺⎺⎺⎺⎺⎺
       |
   Redefined here:
       |
@@ -14,7 +12,12 @@
       |
   Redefined here:
       |
-    4 | var x = 3;
+    4 | var y = 1, x = 3;
+      |            ⎺⎺⎺⎺⎺
+      |
+  Redefined here:
+      |
+    6 |     x = 3;
       |     ⎺⎺⎺⎺⎺
       |
 

--- a/test/errors/scope-resolution/redefinition/redefinition-variables.chpl
+++ b/test/errors/scope-resolution/redefinition/redefinition-variables.chpl
@@ -1,4 +1,6 @@
 var x =
         1;
 var x = 2;
-var x = 3;
+var y = 1, x = 3;
+var z = 1,
+    x = 3;


### PR DESCRIPTION
Some detailed error messages have the flaw of printing out an entire definition/statement when code is printed. This is problematic in the cases of records and multi-line definitions, which can span multiple lines (records in particular can be very long). Thus, it's possible to accidentally print a huge chunk of the program as part of the error. This PR introduces a new wrapper struct, `JustOneLine`, which wraps a code location and ensures that only one line of code is printed. The PR also adds two helper methods to `ErrorWriter`, namely `codeForDef` and `codeForLocation`, which offer a more declarative and abstract way of printing code. These two methods use `JustOneLine`. Finally, this PR converts existing errors to using this functionality, thereby reducing the risk of printing too much code "in the wild" (and making printing code a viable option for some errors, namely the disallowed control flow ones).

Reviewed by @mppf and @benharsh -- thanks!

## Testing
- [x] full local