### PR TITLE
New `ioHintSet.mmap` interface

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1426,8 +1426,6 @@ private const IOHINTS_PREFETCH:    c_int = QIO_HINT_CACHED;
 private const IOHINTS_MMAP:        c_int = QIO_METHOD_MMAP;
 private const IOHINTS_NOMMAP:      c_int = QIO_METHOD_PREADPWRITE;
 
-config param newMmmap = true;
-
 /* A value of the :record:`ioHintSet` type defines a set of hints about
   the I/O that the file or channel will perform.  These hints may be used
   by the implementation to select optimized versions of the I/O operations.
@@ -1475,8 +1473,8 @@ record ioHintSet {
   /*
     Suggests whether or not 'mmap' should be used to access the file contents.
 
-     * when ``useMmap`` is ``true``, suggests that mmap should be used
-     * when ``useMmap`` is ``false``, suggests that mmap should not be used
+     * when ``useMmap`` is ``true``, suggests that 'mmap' should be used
+     * when ``useMmap`` is ``false``, suggests that 'mmap' should not be used and 'pread'/'pwrite' should be used instead
 
   */
   proc type mmap(useMmap = true) where newMmmap==true {
@@ -1495,25 +1493,25 @@ record ioHintSet {
   proc type fromFlag(flag: c_int) { return new ioHintSet(flag); }
 }
 
-/* Compute the union of two ``ioHintSet`` s
+/* Compute the union of two hint sets
 */
 operator ioHintSet.|(lhs: ioHintSet, rhs: ioHintSet) {
   return new ioHintSet(lhs._internal | rhs._internal);
 }
 
-/* Compute the intersection of two ``ioHintSet`` s
+/* Compute the intersection of two hint sets
 */
 operator ioHintSet.&(lhs: ioHintSet, rhs: ioHintSet) {
   return new ioHintSet(lhs._internal & rhs._internal);
 }
 
-/* Compare two ``ioHintSet`` s for equality
+/* Compare two hint sets for equality
 */
 operator ioHintSet.==(lhs: ioHintSet, rhs: ioHintSet) {
   return lhs._internal == rhs._internal;
 }
 
-/* Compare two ``ioHintSet`` s for inequality
+/* Compare two hint sets for inequality
 */
 operator ioHintSet.!=(lhs: ioHintSet, rhs: ioHintSet) {
   return !(lhs == rhs);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1475,8 +1475,8 @@ record ioHintSet {
   /*
     Suggests whether or not 'mmap' should be used to access the file contents.
 
-     * when the argument is ``true``, suggests that mmap should be used
-     * when the argument is ``false``, suggests that mmap should not be used
+     * when ``useMmap`` is ``true``, suggests that mmap should be used
+     * when ``useMmap`` is ``false``, suggests that mmap should not be used
 
   */
   // pragma "last resort"
@@ -1484,14 +1484,6 @@ record ioHintSet {
     return if useMmap
       then new ioHintSet(IOHINTS_MMAP)
       else new ioHintSet(IOHINTS_NOMMAP);
-  }
-
-  /* Suggests that 'mmap' should be used to access the file contents.
-  */
-  // pragma "last resort"
-  deprecated "`ioHintSet.mmap` is deprecated; please use `ioHintSet.mmap(true)` instead"
-  proc type mmap where newMmmap==false {
-    return new ioHintSet(IOHINTS_MMAP);
   }
 
   /* Suggests that 'mmap' should not be used to access the file contents.
@@ -1502,36 +1494,27 @@ record ioHintSet {
 
   pragma "no doc"
   proc type fromFlag(flag: c_int) { return new ioHintSet(flag); }
-
-  // pragma "no doc"
-  // pragma "last resort"
-  // proc this(useMmap: bool = true) {
-  //   compilerWarning("hello!");
-  //   // return if useMmap
-  //   //   then new ioHintSet(IOHINTS_MMAP)
-  //   //   else new ioHintSet(IOHINTS_NOMMAP);
-  // }
 }
 
-/* Compute the union of two ioHintSets
+/* Compute the union of two ``ioHintSet``s
 */
 operator ioHintSet.|(lhs: ioHintSet, rhs: ioHintSet) {
   return new ioHintSet(lhs._internal | rhs._internal);
 }
 
-/* Compute the intersection of two ioHintSets
+/* Compute the intersection of two ``ioHintSet``s
 */
 operator ioHintSet.&(lhs: ioHintSet, rhs: ioHintSet) {
   return new ioHintSet(lhs._internal & rhs._internal);
 }
 
-/* Compare two ioHintSets for equality
+/* Compare two ``ioHintSet``s for equality
 */
 operator ioHintSet.==(lhs: ioHintSet, rhs: ioHintSet) {
   return lhs._internal == rhs._internal;
 }
 
-/* Compare two ioHintSets for inequality
+/* Compare two ``ioHintSet``s for inequality
 */
 operator ioHintSet.!=(lhs: ioHintSet, rhs: ioHintSet) {
   return !(lhs == rhs);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1477,7 +1477,7 @@ record ioHintSet {
      * when ``useMmap`` is ``false``, suggests that 'mmap' should not be used and 'pread'/'pwrite' should be used instead
 
   */
-  proc type mmap(useMmap = true) where newMmmap==true {
+  proc type mmap(useMmap = true) {
     return if useMmap
       then new ioHintSet(IOHINTS_MMAP)
       else new ioHintSet(IOHINTS_NOMMAP);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1479,7 +1479,6 @@ record ioHintSet {
      * when ``useMmap`` is ``false``, suggests that mmap should not be used
 
   */
-  // pragma "last resort"
   proc type mmap(useMmap = true) where newMmmap==true {
     return if useMmap
       then new ioHintSet(IOHINTS_MMAP)
@@ -1496,25 +1495,25 @@ record ioHintSet {
   proc type fromFlag(flag: c_int) { return new ioHintSet(flag); }
 }
 
-/* Compute the union of two ``ioHintSet``s
+/* Compute the union of two ``ioHintSet`` s
 */
 operator ioHintSet.|(lhs: ioHintSet, rhs: ioHintSet) {
   return new ioHintSet(lhs._internal | rhs._internal);
 }
 
-/* Compute the intersection of two ``ioHintSet``s
+/* Compute the intersection of two ``ioHintSet`` s
 */
 operator ioHintSet.&(lhs: ioHintSet, rhs: ioHintSet) {
   return new ioHintSet(lhs._internal & rhs._internal);
 }
 
-/* Compare two ``ioHintSet``s for equality
+/* Compare two ``ioHintSet`` s for equality
 */
 operator ioHintSet.==(lhs: ioHintSet, rhs: ioHintSet) {
   return lhs._internal == rhs._internal;
 }
 
-/* Compare two ``ioHintSet``s for inequality
+/* Compare two ``ioHintSet`` s for inequality
 */
 operator ioHintSet.!=(lhs: ioHintSet, rhs: ioHintSet) {
   return !(lhs == rhs);

--- a/test/deprecated/IO/mmapParenless.chpl
+++ b/test/deprecated/IO/mmapParenless.chpl
@@ -1,12 +1,3 @@
 use IO;
 
-// const doMmapOld = ioHintSet.mmap,
-//       noMmapOld = ioHintSet.noMmap;
-//     //   doMmap = ioHintSet.mmap(true),
-//     //   noMmap = ioHintSet.mmap(false);
-
-// writeln(doMmapOld);
-// writeln(noMmapOld);
-
-const mm = ioHintSet.mmap;
-writeln(mm);
+writeln(ioHintSet.noMmap == ioHintSet.mmap(false));

--- a/test/deprecated/IO/mmapParenless.chpl
+++ b/test/deprecated/IO/mmapParenless.chpl
@@ -1,0 +1,12 @@
+use IO;
+
+// const doMmapOld = ioHintSet.mmap,
+//       noMmapOld = ioHintSet.noMmap;
+//     //   doMmap = ioHintSet.mmap(true),
+//     //   noMmap = ioHintSet.mmap(false);
+
+// writeln(doMmapOld);
+// writeln(noMmapOld);
+
+const mm = ioHintSet.mmap;
+writeln(mm);

--- a/test/deprecated/IO/mmapParenless.good
+++ b/test/deprecated/IO/mmapParenless.good
@@ -1,0 +1,2 @@
+true
+true

--- a/test/deprecated/IO/mmapParenless.good
+++ b/test/deprecated/IO/mmapParenless.good
@@ -1,2 +1,2 @@
-true
+mmapParenless.chpl:3: warning: `ioHintSet.noMmap` is deprecated; please use `ioHintset.mmap(false)` instead
 true

--- a/test/io/tzakian/recordReader/test.chpl
+++ b/test/io/tzakian/recordReader/test.chpl
@@ -5,7 +5,7 @@ use RecordParser, IO;
 config const no_mmap=false;
 var hints=ioHintSet.empty;
 if no_mmap {
-  hints = ioHintSet.noMmap;
+  hints = ioHintSet.mmap(false);
 }
 
 var f = open("input1.txt", ioMode.rw);

--- a/test/library/standard/IO/ioHintSetOperations.chpl
+++ b/test/library/standard/IO/ioHintSetOperations.chpl
@@ -6,8 +6,8 @@ const empty = ioHintSet.empty;
 const seq = ioHintSet.sequential;
 const rand = ioHintSet.random;
 const pref = ioHintSet.prefetch;
-const mmap = ioHintSet.mmap;
-const nommap = ioHintSet.noMmap;
+const mmap = ioHintSet.mmap(true);
+const nommap = ioHintSet.mmap(false);
 
 // equality and inequality
 writeln(seq != rand);

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -11,7 +11,7 @@ const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
 proc main(args: [] string) {
   const stdin = new file(0),
         input = stdin.reader(iokind.native, locking=false,
-                             hints=ioHintSet.mmap),
+                             hints=ioHintSet.mmap(true)),
         len = stdin.size;
   var data: [0..#len] uint(8);
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -13,7 +13,7 @@ config const readSize = 16 * 1024;
 proc main(args: [] string) {
   const stdin = new file(0);
   var input = stdin.reader(iokind.native, locking=false,
-                           hints=ioHintSet.mmap);
+                           hints=ioHintSet.mmap(true));
   var len = stdin.size;
   var data : [0..#len] uint(8);
   


### PR DESCRIPTION
Implements the change proposed in this issue: https://github.com/chapel-lang/chapel/issues/21508.

`ioHintSet.mmap` and `ioHintSet.noMmap` are deprecated in favor of `ioHintSet.mmap(useMmap: bool)`, so that the single type method can be used to select either hint.

Adds a deprecation test and changes other tests as needed.

- [x] passing paratest
- [x] inspected docs