### PR TITLE
dyno: Fix validateAndSetToID bug blocking bundled scope resolve

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2127,7 +2127,9 @@ void Resolver::validateAndSetToId(ResolvedExpression& r,
   auto scope = scopeForId(context, id);
   auto parentId = scope->id();
   auto parentTag = parsing::idToTag(context, parentId);
-  if (asttags::isAggregateDecl(parentTag) && parentId.contains(node->id())) {
+  if (asttags::isAggregateDecl(parentTag) &&
+      parentId.contains(node->id()) &&
+      parentId != id /* It's okay to refer to the record itself */) {
     // Referring to a field of a class that's surrounding the current node.
     // Loop upwards looking for a composite type.
     auto searchId = parsing::idToParentId(context, node->id());

--- a/frontend/test/resolution/testFieldAccess.cpp
+++ b/frontend/test/resolution/testFieldAccess.cpp
@@ -131,10 +131,49 @@ static void test3() {
   guard.realizeErrors();
 }
 
+static void test4() {
+  printf("test3\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto path = UniqueString::get(context, "test3.chpl");
+  std::string contents = R""""(
+    class Outer {
+        var outerField: int;
+        record Inner {
+            proc innerMethod() {
+                return new Outer();
+            }
+        }
+
+        var inner: Inner;
+        proc outerMethod() {
+            return inner.innerMethod();
+        }
+    }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+  assert(vec.size() == 1);
+
+  const Module* m = vec[0]->toModule();
+  assert(m);
+  assert(m->numStmts() == 1);
+
+  const AggregateDecl* outerAd = m->stmt(0)->toAggregateDecl();
+  const AggregateDecl* innerId = outerAd->declOrComment(1)->toAggregateDecl();
+  const Function* innerMethod = innerId->declOrComment(0)->toFunction();
+
+  scopeResolveFunction(context, innerMethod->id());
+}
+
 int main() {
   test1();
   test2();
   test3();
+  test4();
 
   return 0;
 }


### PR DESCRIPTION
The checking for "referring to field of outer type" did not consider the case where the "field" wasn't a field at all, but the outer type itself. This actually _is_ allowed, and used in particular in the standard library (the `_domain` record is referenced from a context manager class, which is defined inside `_domain`). This PR fixes the Dyno scope resolver to not error in this case.

## Testing
- [x] paratest
- [x] paratest with `--dyno` (no related failures; .good files need to be updated for unrelated tests though)

Reviewed by @mppf - thanks!