### PR TITLE
Add error when passing empty array to `c_ptrTo`

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -496,6 +496,11 @@ module CTypes {
     if (arr._value.locale != here) then
       halt("c_ptrTo() can only be applied to an array from the locale on which it lives (array is on locale " + arr._value.locale.id:string + ", call was made on locale " + here.id:string + ")");
 
+    if boundsChecking {
+      if (arr.size == 0) then
+        halt("Can’t take a C pointer to an array with 0 elements.");
+    }
+
     return c_pointer_return(arr[arr.domain.low]);
   }
 

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -498,7 +498,7 @@ module CTypes {
 
     if boundsChecking {
       if (arr.size == 0) then
-        halt("Can’t take a C pointer to an array with 0 elements.");
+        halt("Can't create a C pointer for an array with 0 elements.");
     }
 
     return c_pointer_return(arr[arr.domain.low]);

--- a/test/extern/PointerToEmpty.chpl
+++ b/test/extern/PointerToEmpty.chpl
@@ -1,0 +1,7 @@
+use CTypes;
+var a: [0..1] int;
+
+var locDom: domain(1) = {2..1};
+
+writeln(a[locDom]);          
+writeln(c_ptrTo(a[locDom]));

--- a/test/extern/PointerToEmpty.compopts
+++ b/test/extern/PointerToEmpty.compopts
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/extern/PointerToEmpty.good
+++ b/test/extern/PointerToEmpty.good
@@ -1,2 +1,2 @@
 
-PointerToEmpty.chpl:7: error: halt reached - Can’t take a C pointer to an array with 0 elements.
+PointerToEmpty.chpl:7: error: halt reached - Can't create a C pointer for an array with 0 elements.

--- a/test/extern/PointerToEmpty.good
+++ b/test/extern/PointerToEmpty.good
@@ -1,0 +1,2 @@
+
+PointerToEmpty.chpl:7: error: halt reached - Can’t take a C pointer to an array with 0 elements.


### PR DESCRIPTION
When `c_ptrTo` is passed an empty array, today we will get a halt for OOB, but that error message can be confusing, so this PR adds an explicit check for that in `c_ptrTo` that provides a more helpful error message.