### PR TITLE
Do a configure-like check for MLI skipifs

### DIFF
--- a/test/interop/C/multilocale.skipif
+++ b/test/interop/C/multilocale.skipif
@@ -2,25 +2,44 @@
 
 """
  Multilocale interoperability requires ZMQ
- Installation of the ZMQ library is detected with the find_library function,
- which looks for the appropriate dynamic library (e.g. libzmq.so).
- Note that if the dynamic library is found, this test assumes that the
- header and static library are available. Can be overridden with
- `CHPL_TEST_NO_ZMQ=True`
+ Initial installation probe of the ZMQ library is detected with the
+ find_library function, but that only checks for libzmq.so and not the headers
+ so do a configure-like compilation check for the headers.
+
+ Longer term want to just do pkg-config check, but that requires updating MLI
+ support: https://github.com/Cray/chapel-private/issues/4292
 """
 
 from ctypes.util import find_library
 import os
+import shlex
+import subprocess
+import tempfile
 
-# Is ZMQ available?
+# Is ZMQ shared object available?
 zmq_found = find_library('zmq') is not None
-user_no_zmq = os.getenv('CHPL_TEST_NO_ZMQ') is not None
+
+# Do a configure like check to ensure header is found too
+if zmq_found:
+    try:
+        chpl_home = os.getenv('CHPL_HOME')
+        compileline = os.path.join(chpl_home, 'util', 'config', 'compileline')
+        c_compiler = subprocess.check_output([compileline, '--compile']).decode()
+        c_compiler = shlex.split(c_compiler)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            c_test = os.path.join(tmp_dir, 'zmq-test.c')
+            with open(c_test, 'w') as fp:
+                fp.write('#include "zmq.h"\nint main (void) { return 0; }')
+            subprocess.run(c_compiler + [c_test, '-lzmq'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except:
+        zmq_found = False
 
 # Are we configured for multilocale?
 is_not_local = os.getenv('CHPL_COMM', 'none') != 'none'
 
 # OK contains the conditions that must be met to run the test
-OK = is_not_local and zmq_found and not user_no_zmq
+OK = is_not_local and zmq_found
 
 # Skip if not OK
 print(not OK)

--- a/test/interop/python/multilocale.skipif
+++ b/test/interop/python/multilocale.skipif
@@ -2,22 +2,41 @@
 
 """
  Multilocale interoperability requires ZMQ
- Installation of the ZMQ library is detected with the find_library function,
- which looks for the appropriate dynamic library (e.g. libzmq.so).
- Note that if the dynamic library is found, this test assumes that the
- header and static library are available. Can be overridden with
- `CHPL_TEST_NO_ZMQ=True`
+ Initial installation probe of the ZMQ library is detected with the
+ find_library function, but that only checks for libzmq.so and not the headers
+ so do a configure-like compilation check for the headers.
+
+ Longer term want to just do pkg-config check, but that requires updating MLI
+ support: https://github.com/Cray/chapel-private/issues/4292
 """
 
 from ctypes.util import find_library
 import os
+import shlex
+import subprocess
+import tempfile
 
-# Is ZMQ available?
+# Is ZMQ shared object available?
 zmq_found = find_library('zmq') is not None
-user_no_zmq = os.getenv('CHPL_TEST_NO_ZMQ') is not None
+
+# Do a configure like check to ensure header is found too
+if zmq_found:
+    try:
+        chpl_home = os.getenv('CHPL_HOME')
+        compileline = os.path.join(chpl_home, 'util', 'config', 'compileline')
+        c_compiler = subprocess.check_output([compileline, '--compile']).decode()
+        c_compiler = shlex.split(c_compiler)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            c_test = os.path.join(tmp_dir, 'zmq-test.c')
+            with open(c_test, 'w') as fp:
+                fp.write('#include "zmq.h"\nint main (void) { return 0; }')
+            subprocess.run(c_compiler + [c_test, '-lzmq'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except:
+        zmq_found = False
 
 # OK contains the conditions that must be met to run the test
-OK = zmq_found and not user_no_zmq
+OK = zmq_found
 
 # Skip if not OK
 print(not OK)


### PR DESCRIPTION
Multi-locale interop (MLI) requires ZMQ. Currently, it requires a true system install of ZMQ (we only provide `-lzmq` and don't have a way to provide non-default `-L`/`-I` paths.) Previously, the skipif was just checking for `libzmq.so` and assuming the headers would be available if the shared object was found, but this isn't true on SLES15 and some other systems.

For other ZMQ tests, we switched to using `pkg-config` for the skipifs and providing lib/include paths, but since we don't have a way to provide lib/include paths for MLI support that won't work here. Instead this does a "configure-like" check to compile a small zmq test program and skip based on whether that succeeded.

This isn't ideal, but is better than letting the tests fail on systems with libzmq.so, but without headers.

Part of Cray/chapel-private#4292