### PR TITLE
Improve dyno scope resolution within methods

### DIFF
--- a/doc/util/nitpick_ignore
+++ b/doc/util/nitpick_ignore
@@ -34,7 +34,12 @@ cpp:identifier detail
 cpp:identifier detail::PODUniqueString
 cpp:identifier AstList::const_iterator::difference_type
 cpp:identifier uint64_t
+cpp:identifier uint32_t
+cpp:identifier uint16_t
+cpp:identifier uint8_t
 cpp:identifier int64_t
+cpp:identifier int32_t
+cpp:identifier int16_t
 cpp:identifier int8_t
 cpp:identifier va_list
 # TODO: Expand macros before generating docs to remove these.

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -274,6 +274,11 @@ uast::AstTag idToTag(Context* context, ID id);
 bool idIsParenlessFunction(Context* context, ID id);
 
 /**
+ Returns true if the ID is a method.
+ */
+bool idIsMethod(Context* context, ID id);
+
+/**
  If the ID represents a field in a record/class/union, returns
  the name of that field. Otherwise, returns the empty string.
  */

--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -23,13 +23,9 @@
 #include "chpl/resolution/scope-types.h"
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallPtrSet.h"
 
 namespace chpl {
 namespace resolution {
-
-  using ScopeSet = llvm::SmallPtrSet<const Scope*, 5>;
-  using NamedScopeSet = std::unordered_set<std::pair<UniqueString, const Scope*>>;
 
   /**
     Returns true if this AST type can create a scope.
@@ -91,7 +87,7 @@ namespace resolution {
                            const llvm::ArrayRef<const Scope*> receiverScopes,
                            UniqueString name,
                            LookupConfig config,
-                           NamedScopeSet& visited);
+                           CheckedScopes& visited);
 
   /**
     Returns true if all of checkScope is visible from fromScope

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -875,6 +875,11 @@ enum {
     Lookup in extern blocks
    */
   LOOKUP_EXTERN_BLOCKS = 256,
+
+  /**
+    Skip private use/import
+   */
+  LOOKUP_SKIP_PRIVATE_USE_IMPORT = 512,
 };
 
 /** LookupConfig is a bit-set of the LOOKUP_ flags defined above */

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -316,14 +316,8 @@ class BorrowedIdsWithName {
  public:
 
   static llvm::Optional<BorrowedIdsWithName>
-  createWithSingleId(ID id, uast::Decl::Visibility vis,
-                     bool isMethodOrField,
-                     bool arePrivateIdsIgnored,
-                     bool onlyMethodsFields) {
-    IdAndVis::SymbolTypeFlags filterFlags = 0;
-    if (arePrivateIdsIgnored) { filterFlags |= IdAndVis::PUBLIC; }
-    if (onlyMethodsFields) { filterFlags |= IdAndVis::METHOD_OR_FIELD; }
-
+  createWithSingleId(ID id, uast::Decl::Visibility vis, bool isMethodOrField,
+                     IdAndVis::SymbolTypeFlags filterFlags) {
     auto idAndVis = IdAndVis(id, vis, isMethodOrField);
     if (isIdVisible(idAndVis, filterFlags)) {
       return BorrowedIdsWithName(std::move(idAndVis), filterFlags);
@@ -335,14 +329,10 @@ class BorrowedIdsWithName {
   createWithToplevelModuleId(ID id) {
     auto vis = uast::Decl::Visibility::PUBLIC;
     bool isMethodOrField = false;
-    bool arePrivateIdsIgnored = true;
-    bool onlyMethodsFields = false;
-    auto maybeIds = createWithSingleId(std::move(id),
-                                       vis,
-                                       isMethodOrField,
-                                       arePrivateIdsIgnored,
-                                       onlyMethodsFields);
-    assert(maybeIds);
+    IdAndVis::SymbolTypeFlags filterFlags = 0;
+    auto maybeIds = createWithSingleId(std::move(id), vis, isMethodOrField,
+                                       filterFlags);
+    CHPL_ASSERT(maybeIds.hasValue());
     return maybeIds.getValue();
   }
 

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -190,8 +190,8 @@ class OwnedIdsWithName {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
-  llvm::Optional<BorrowedIdsWithName> borrow(bool arePrivateIdsIgnored,
-                                             bool onlyMethodsFields) const;
+  llvm::Optional<BorrowedIdsWithName>
+  borrow(IdAndVis::SymbolTypeFlags filterFlags) const;
 
   /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -300,12 +300,8 @@ class BorrowedIdsWithName {
       This BorrowedIdsWithName assumes that the OwnedIdsWithName
       will continue to exist. */
   BorrowedIdsWithName(IdAndVis idv, const std::vector<IdAndVis>* moreIdvs,
-                      bool arePrivateIdsIgnored, bool onlyMethodsFields)
-    : idv_(idv), moreIdvs_(moreIdvs) {
-    IdAndVis::SymbolTypeFlags filterFlags = 0;
-    if (arePrivateIdsIgnored) { filterFlags |= IdAndVis::PUBLIC; }
-    if (onlyMethodsFields) { filterFlags |= IdAndVis::METHOD_OR_FIELD; }
-    filterFlags_ = filterFlags;
+                      IdAndVis::SymbolTypeFlags filterFlags)
+    : filterFlags_(filterFlags), idv_(idv), moreIdvs_(moreIdvs) {
     numVisibleIds_ = countVisibleIds();
   }
 
@@ -313,14 +309,8 @@ class BorrowedIdsWithName {
       that the ID will not be filtered out according to the passed
       settings arePrivateIdsIgnored and onlyMethodsFields.
     */
-  BorrowedIdsWithName(IdAndVis idv,
-                      bool arePrivateIdsIgnored,
-                      bool onlyMethodsFields)
-    : numVisibleIds_(1), idv_(std::move(idv)) {
-    IdAndVis::SymbolTypeFlags filterFlags = 0;
-    if (arePrivateIdsIgnored) { filterFlags |= IdAndVis::PUBLIC; }
-    if (onlyMethodsFields) { filterFlags |= IdAndVis::METHOD_OR_FIELD; }
-    filterFlags_ = filterFlags;
+  BorrowedIdsWithName(IdAndVis idv, IdAndVis::SymbolTypeFlags filterFlags)
+    : filterFlags_(filterFlags), numVisibleIds_(1), idv_(std::move(idv)) {
     assert(isIdVisible(idv_, filterFlags_));
   }
  public:
@@ -336,9 +326,7 @@ class BorrowedIdsWithName {
 
     auto idAndVis = IdAndVis(id, vis, isMethodOrField);
     if (isIdVisible(idAndVis, filterFlags)) {
-      return BorrowedIdsWithName(std::move(idAndVis),
-                                 arePrivateIdsIgnored,
-                                 onlyMethodsFields);
+      return BorrowedIdsWithName(std::move(idAndVis), filterFlags);
     }
     return llvm::None;
   }

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -71,8 +71,10 @@ class IdAndVis {
       case uast::Decl::DEFAULT_VISIBILITY:
       case uast::Decl::PUBLIC:
         flags |= PUBLIC;
+        break;
       case uast::Decl::PRIVATE:
         flags |= PRIVATE;
+        break;
       // no defaut for compilation error if more are added
     }
     if (isMethodOrField) {
@@ -854,7 +856,7 @@ enum {
 
   /**
     Lookup only methods, fields, and class/record/union declarations
-    directly nested within a class/record/union
+    directly nested within a class/record/union.
    */
   LOOKUP_ONLY_METHODS_FIELDS = 128,
 

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -293,16 +293,17 @@ class BorrowedIdsWithName {
 
  private:
 
-  int countVisibleIds();
+  int countVisibleIds(IdAndVis::SymbolTypeFlags flagsAnd);
 
   /** Construct a BorrowedIdsWithName referring to the same IDs
       as the passed OwnedIdsWithName.
       This BorrowedIdsWithName assumes that the OwnedIdsWithName
       will continue to exist. */
-  BorrowedIdsWithName(IdAndVis idv, const std::vector<IdAndVis>* moreIdvs,
+  BorrowedIdsWithName(const OwnedIdsWithName& ownedIds,
                       IdAndVis::SymbolTypeFlags filterFlags)
-    : filterFlags_(filterFlags), idv_(idv), moreIdvs_(moreIdvs) {
-    numVisibleIds_ = countVisibleIds();
+    : filterFlags_(filterFlags),
+      idv_(ownedIds.idv_), moreIdvs_(ownedIds.moreIdvs_.get()) {
+    numVisibleIds_ = countVisibleIds(ownedIds.flagsAnd_);
   }
 
   /** Construct a BorrowedIdsWithName referring to one ID. Requires

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -513,8 +513,7 @@ class Scope {
       Returns true if something was appended. */
   bool lookupInScope(UniqueString name,
                      std::vector<BorrowedIdsWithName>& result,
-                     bool arePrivateIdsIgnored,
-                     bool onlyMethodsFields) const;
+                     IdAndVis::SymbolTypeFlags filterFlags) const;
 
   /** Check to see if the scope contains IDs with the provided name. */
   bool contains(UniqueString name) const;

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -312,9 +312,10 @@ class BorrowedIdsWithName {
       This BorrowedIdsWithName assumes that the OwnedIdsWithName
       will continue to exist. */
   BorrowedIdsWithName(const OwnedIdsWithName& ownedIds,
+                      const IdAndVis& firstMatch,
                       IdAndVis::SymbolTypeFlags filterFlags)
     : filterFlags_(filterFlags),
-      idv_(ownedIds.idv_), moreIdvs_(ownedIds.moreIdvs_.get()) {
+      idv_(firstMatch), moreIdvs_(ownedIds.moreIdvs_.get()) {
     numVisibleIds_ = countVisibleIds(ownedIds.flagsAnd_);
     CHPL_ASSERT(isIdVisible(idv_, filterFlags));
   }

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -161,9 +161,8 @@ class OwnedIdsWithName {
       // create the vector and add the single existing id to it
       moreIdvs_ = toOwned(new std::vector<IdAndVis>());
       moreIdvs_->push_back(idv_);
-      // set bitwise & and | of the flags to the initial idv
-      flagsAnd_ = idv_.flags_;
-      flagsOr_ = idv_.flags_;
+      // flagsAnd_ and flagsOr_ will have already been set in constructor
+      // from idv_.
     }
     auto idv = IdAndVis(std::move(id), vis, isMethodOrField);
     // add the id passed
@@ -317,6 +316,7 @@ class BorrowedIdsWithName {
     : filterFlags_(filterFlags),
       idv_(ownedIds.idv_), moreIdvs_(ownedIds.moreIdvs_.get()) {
     numVisibleIds_ = countVisibleIds(ownedIds.flagsAnd_);
+    CHPL_ASSERT(isIdVisible(idv_, filterFlags));
   }
 
   /** Construct a BorrowedIdsWithName referring to one ID. Requires
@@ -325,7 +325,7 @@ class BorrowedIdsWithName {
     */
   BorrowedIdsWithName(IdAndVis idv, IdAndVis::SymbolTypeFlags filterFlags)
     : filterFlags_(filterFlags), numVisibleIds_(1), idv_(std::move(idv)) {
-    assert(isIdVisible(idv_, filterFlags_));
+    CHPL_ASSERT(isIdVisible(idv_, filterFlags));
   }
  public:
 

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -111,7 +111,7 @@ class IdAndVis {
     return (flags_ & PUBLIC) != 0;
   }
   bool isPrivate() const {
-    return !isPublic();
+    return (flags_ & PRIVATE) != 0;
   }
   bool isMethodOrField() const {
     return (flags_ & METHOD_OR_FIELD) != 0;

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -666,6 +666,28 @@ bool idIsParenlessFunction(Context* context, ID id) {
   return idIsParenlessFunctionQuery(context, id);
 }
 
+static const bool& idIsMethodQuery(Context* context, ID id) {
+  QUERY_BEGIN(idIsMethodQuery, context, id);
+
+  bool result = false;
+
+  AstTag tag = idToTag(context, id);
+  if (asttags::isFunction(tag)) {
+    const AstNode* ast = astForIDQuery(context, id);
+    if (ast != nullptr) {
+      if (auto fn = ast->toFunction()) {
+        result = fn->isMethod();
+      }
+    }
+  }
+
+  return QUERY_END(result);
+}
+
+bool idIsMethod(Context* context, ID id) {
+  return idIsMethodQuery(context, id);
+}
+
 static const UniqueString& fieldIdToNameQuery(Context* context, ID id) {
   QUERY_BEGIN(fieldIdToNameQuery, context, id);
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2661,7 +2661,7 @@ static std::vector<BorrowedIdsWithName>
 lookupCalledExpr(Context* context,
                  const Scope* scope,
                  const CallInfo& ci,
-                 NamedScopeSet& visited) {
+                 CheckedScopes& visited) {
 
   Resolver::ReceiverScopesVec receiverScopes;
 
@@ -2790,7 +2790,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
     //   equally as sources of candidates
     // * do not consider forwarding (since we are considering it now!)
 
-    std::vector<NamedScopeSet> visited;
+    std::vector<CheckedScopes> visited;
     visited.resize(numForwards);
 
     for (const auto& fci : forwardingCis) {
@@ -2905,7 +2905,7 @@ gatherAndFilterCandidates(Context* context,
                           size_t& firstPoiCandidate,
                           ForwardingInfoVec& forwardingInfo) {
   CandidatesVec candidates;
-  NamedScopeSet visited;
+  CheckedScopes visited;
   firstPoiCandidate = 0;
 
   // inject compiler-generated candidates in a manner similar to below

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2666,8 +2666,12 @@ lookupCalledExpr(Context* context,
     }
   }
 
-  const LookupConfig config =
-      LOOKUP_DECLS | LOOKUP_IMPORT_AND_USE | LOOKUP_PARENTS;
+  LookupConfig config = LOOKUP_DECLS | LOOKUP_IMPORT_AND_USE | LOOKUP_PARENTS;
+
+  // For parenless non-method calls, only find the innermost match
+  if (ci.isParenless() && !ci.isMethodCall()) {
+    config |= LOOKUP_INNERMOST;
+  }
 
   UniqueString name = ci.name();
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2685,6 +2685,10 @@ lookupCalledExpr(Context* context,
     config |= LOOKUP_INNERMOST;
   }
 
+  if (ci.isMethodCall()) {
+    config |= LOOKUP_ONLY_METHODS_FIELDS;
+  }
+
   UniqueString name = ci.name();
 
   auto ret = lookupNameInScopeWithSet(context, scope, receiverScopes, name,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2115,6 +2115,18 @@ doIsCandidateApplicableInitial(Context* context,
     tag = parsing::idToTag(context, candidateId);
   }
 
+  // if it's a paren-less call, only consider parenless routines
+  // (including field accessors) but not types/outer variables/
+  // calls with parens.
+  if (ci.isParenless()) {
+    if (parsing::idIsParenlessFunction(context, candidateId) ||
+        parsing::idIsField(context, candidateId)) {
+      // OK
+    } else {
+      return nullptr;
+    }
+  }
+
   if (isTypeDecl(tag)) {
     // calling a type - i.e. type construction
     const Type* t = initialTypeForTypeDecl(context, candidateId);

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -847,9 +847,13 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
   auto p = checkedScopes.insert(std::make_pair(CheckedScope(name, scope),
                                 curFilter));
   if (p.second == false) {
+    // insertion did not occur because there was already an entry.
+    // Set flagsInMap to refer to the flags of the existing element
+    IdAndVis::SymbolTypeFlags& flagsInMap = p.first->second;
+
     // the insert did not succeed: there was already something in the map.
     // decide what to do about it.
-    IdAndVis::SymbolTypeFlags foundFilter = p.first->second;
+    IdAndVis::SymbolTypeFlags foundFilter = flagsInMap;
     if ((curFilter & foundFilter) == foundFilter) {
       // if the flags we found are equal to foundFilter,
       // or if curFilter is a superset of foundFilter
@@ -867,7 +871,7 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
     // in foundFilter (because we are going to update results
     // with matches for the now-not-filtered-out cases)
     IdAndVis::SymbolTypeFlags combinedFilter = foundFilter & ~onlyInFound;
-    checkedScopes[CheckedScope(name, scope)] = combinedFilter;
+    flagsInMap = combinedFilter;
   }
 
   // if the scope has an extern block, note that fact.

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -748,6 +748,9 @@ bool LookupHelper::doLookupInReceiverParentScopes(
       // stop if we aren't looking at parents or if we reach a module
       if (isModule(cur->tag()) && !goPastModules)
         break;
+      // stop if we reach an outer class / record
+      if (cur != rcvScope && isAggregateDecl(cur->tag()))
+        break;
       if (!checkParents)
         break;
     }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -686,7 +686,7 @@ bool LookupHelper::doLookupInReceiverScopes(
   newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
 
   bool got = false;
-  for (const auto& currentScope : receiverScopes) {
+  for (auto currentScope : receiverScopes) {
     if (trace) {
       VisibilityTraceElt elt;
       elt.methodReceiverScope = currentScope;
@@ -719,7 +719,7 @@ bool LookupHelper::doLookupInReceiverParentScopes(
 
   bool got = false;
 
-  for (const auto& rcvScope : receiverScopes) {
+  for (auto rcvScope : receiverScopes) {
     if (trace) {
       VisibilityTraceElt elt;
       elt.methodReceiverScope = rcvScope;

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -867,8 +867,10 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
   {
     bool got = false;
     if (checkDecls) {
-      got |= scope->lookupInScope(name, result,
-                                  skipPrivateVisibilities, onlyMethodsFields);
+      IdAndVis::SymbolTypeFlags filterFlags = 0;
+      if (skipPrivateVisibilities) { filterFlags |= IdAndVis::PUBLIC; }
+      if (onlyMethodsFields) { filterFlags |= IdAndVis::METHOD_OR_FIELD; }
+      got |= scope->lookupInScope(name, result, filterFlags);
       if (got && trace) {
         for (size_t i = startSize; i < result.size(); i++) {
           ResultVisibilityTrace t;
@@ -1976,9 +1978,8 @@ doWarnHiddenFormal(Context* context,
   // find the Formal*
   const Formal* formal = nullptr;
   std::vector<BorrowedIdsWithName> ids;
-  functionScope->lookupInScope(formalName, ids,
-                               /* ignore private */ false,
-                               /* only methods/fields */ false);
+  IdAndVis::SymbolTypeFlags filterFlags = 0;
+  functionScope->lookupInScope(formalName, ids, filterFlags);
   for (const auto& b : ids) {
     for (const auto& id : b) {
       auto formalAst = parsing::idToAst(context, id);

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -860,15 +860,13 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
     }
 
     // otherwise, compute the new filter to use
-    IdAndVis::SymbolTypeFlags onlyInFound = 0;
-    onlyInFound = foundFilter & ~curFilter;
+    IdAndVis::SymbolTypeFlags onlyInFound = foundFilter & ~curFilter;
     curFilter = IdAndVis::reverseFlags(onlyInFound);
 
     // update checkedScopes to remove filter bits that weren't present
     // in foundFilter (because we are going to update results
     // with matches for the now-not-filtered-out cases)
-    IdAndVis::SymbolTypeFlags combinedFilter = 0;
-    combinedFilter = foundFilter & ~onlyInFound;
+    IdAndVis::SymbolTypeFlags combinedFilter = foundFilter & ~onlyInFound;
     checkedScopes[CheckedScope(name, scope)] = combinedFilter;
   }
 

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -571,13 +571,15 @@ bool LookupHelper::doLookupInImportsAndUses(
         auto scopeAst = parsing::idToAst(context, is.scope()->id());
         auto visibility = scopeAst->toDecl()->visibility();
         bool isMethodOrField = false;
-        bool onlyMethodsFields = false;
+        IdAndVis::SymbolTypeFlags filterFlags = 0;
+        if (skipPrivateVisibilities) {
+          filterFlags |= IdAndVis::PUBLIC;
+        }
         auto foundIds =
           BorrowedIdsWithName::createWithSingleId(is.scope()->id(),
                                                   visibility,
                                                   isMethodOrField,
-                                                  skipPrivateVisibilities,
-                                                  onlyMethodsFields);
+                                                  filterFlags);
         if (foundIds) {
           if (trace) {
             ResultVisibilityTrace t;
@@ -767,15 +769,13 @@ bool LookupHelper::doLookupInExternBlock(const Scope* scope,
   auto ast = parsing::idToAst(context, scope->id());
   for (auto child : ast->children()) {
     if (child->isExternBlock()) {
-      bool isMethodOrField = false;
-      bool arePrivateIdsIgnored = false;
-      bool onlyMethodsFields = false;
+      bool isMethodOrField = false; // not possible in an extern block
+      IdAndVis::SymbolTypeFlags filterFlags = 0;
       auto foundIds =
         BorrowedIdsWithName::createWithSingleId(child->id(),
                                                 Decl::PUBLIC,
                                                 isMethodOrField,
-                                                arePrivateIdsIgnored,
-                                                onlyMethodsFields);
+                                                filterFlags);
       if (foundIds) {
         if (traceCurPath && traceResult) {
           ResultVisibilityTrace t;

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -44,9 +44,11 @@ void OwnedIdsWithName::stringify(std::ostream& ss,
 llvm::Optional<BorrowedIdsWithName>
 OwnedIdsWithName::borrow(bool skipPrivateVisibilities,
                          bool onlyMethodsFields) const {
-  if (BorrowedIdsWithName::isIdVisible(idv_,
-                                       skipPrivateVisibilities,
-                                       onlyMethodsFields)) {
+  IdAndVis::SymbolTypeFlags filterFlags = 0;
+  if (skipPrivateVisibilities) { filterFlags |= IdAndVis::PUBLIC; }
+  if (onlyMethodsFields) { filterFlags |= IdAndVis::METHOD_OR_FIELD; }
+
+  if (BorrowedIdsWithName::isIdVisible(idv_, filterFlags)) {
     return BorrowedIdsWithName(idv_, moreIdvs_.get(),
                                skipPrivateVisibilities, onlyMethodsFields);
   }
@@ -56,12 +58,10 @@ OwnedIdsWithName::borrow(bool skipPrivateVisibilities,
   }
 
   for (auto& idv : *moreIdvs_) {
-    if (!BorrowedIdsWithName::isIdVisible(idv,
-                                          skipPrivateVisibilities,
-                                          onlyMethodsFields))
+    if (!BorrowedIdsWithName::isIdVisible(idv, filterFlags))
       continue;
 
-    // Found a visible ID!
+    // Found a visible ID! Return a BorrowedIds referring to the whole thing
     return BorrowedIdsWithName(idv, moreIdvs_.get(),
                                skipPrivateVisibilities, onlyMethodsFields);
   }

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -57,6 +57,15 @@ OwnedIdsWithName::borrow(IdAndVis::SymbolTypeFlags filterFlags) const {
     return llvm::None;
   }
 
+  // Are all of the filter flags present in flagsAnd?
+  // If so, return the borrow
+  if ((flagsAnd_ & filterFlags) == filterFlags) {
+    // filter does not rule out anything in the OwnedIds,
+    // so we can return a match.
+    return BorrowedIdsWithName(*this, filterFlags);
+  }
+
+  // Otherwise, use a loop to decide if we can borrow
   for (auto& idv : *moreIdvs_) {
     if (!BorrowedIdsWithName::isIdVisible(idv, filterFlags))
       continue;

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -176,12 +176,7 @@ const Scope* Scope::parentModuleScope() const {
 
 bool Scope::lookupInScope(UniqueString name,
                           std::vector<BorrowedIdsWithName>& result,
-                          bool arePrivateIdsIgnored,
-                          bool onlyMethodsFields) const {
-  IdAndVis::SymbolTypeFlags filterFlags = 0;
-  if (arePrivateIdsIgnored) { filterFlags |= IdAndVis::PUBLIC; }
-  if (onlyMethodsFields) { filterFlags |= IdAndVis::METHOD_OR_FIELD; }
-
+                          IdAndVis::SymbolTypeFlags filterFlags) const {
   auto search = declared_.find(name);
   if (search != declared_.end()) {
     // There might not be any IDs that are visible to us, so borrow returns

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -28,6 +28,18 @@ namespace chpl {
 namespace resolution {
 
 
+IdAndVis::SymbolTypeFlags IdAndVis::reverseFlags(SymbolTypeFlags flags) {
+  SymbolTypeFlags ret = 0;
+
+  if ((flags & PUBLIC) != 0)               ret |= PRIVATE;
+  if ((flags & PRIVATE) != 0)              ret |= PUBLIC;
+
+  if ((flags & METHOD_OR_FIELD) != 0)      ret |= NOT_METHOD_NOT_FIELD;
+  if ((flags & NOT_METHOD_NOT_FIELD) != 0) ret |= METHOD_OR_FIELD;
+
+  return ret;
+}
+
 void OwnedIdsWithName::stringify(std::ostream& ss,
                                  chpl::StringifyKind stringKind) const {
   if (auto ptr = moreIdvs_.get()) {

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -112,20 +112,33 @@ void BorrowedIdsWithName::stringify(std::ostream& ss,
 
 Scope::Scope(const uast::AstNode* ast, const Scope* parentScope,
              bool autoUsesModules) {
+  bool containsUseImport = false;
+  bool containsFunctionDecls = false;
+  bool containsExternBlock = false;
+  bool isMethodScope = false;
+
   parentScope_ = parentScope;
   tag_ = ast->tag();
-  autoUsesModules_ = autoUsesModules;
   id_ = ast->id();
   if (auto decl = ast->toNamedDecl()) {
     name_ = decl->name();
   }
   if (auto fn = ast->toFunction()) {
-    methodScope_ = fn->isMethod();
+    isMethodScope = fn->isMethod();
   }
   gatherDeclsWithin(ast, declared_,
-                    containsUseImport_,
-                    containsFunctionDecls_,
-                    containsExternBlock_);
+                    containsUseImport,
+                    containsFunctionDecls,
+                    containsExternBlock);
+
+  // compute the flags storing a few settings
+  ScopeFlags flags = 0;
+  if (containsFunctionDecls) { flags |= CONTAINS_FUNCTION_DECLS; }
+  if (containsUseImport) {     flags |= CONTAINS_USE_IMPORT; }
+  if (autoUsesModules) {       flags |= AUTO_USES_MODULES; }
+  if (isMethodScope) {         flags |= METHOD_SCOPE; }
+  if (containsExternBlock) {   flags |= CONTAINS_EXTERN_BLOCK; }
+  flags_ = flags;
 }
 
 void Scope::addBuiltin(UniqueString name) {

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -62,7 +62,7 @@ OwnedIdsWithName::borrow(IdAndVis::SymbolTypeFlags filterFlags) const {
   }
 
   if (BorrowedIdsWithName::isIdVisible(idv_, filterFlags)) {
-    return BorrowedIdsWithName(*this, filterFlags);
+    return BorrowedIdsWithName(*this, idv_, filterFlags);
   }
   // The first ID isn't visible; are others?
   if (moreIdvs_.get() == nullptr) {
@@ -74,7 +74,7 @@ OwnedIdsWithName::borrow(IdAndVis::SymbolTypeFlags filterFlags) const {
   if ((flagsAnd_ & filterFlags) == filterFlags) {
     // filter does not rule out anything in the OwnedIds,
     // so we can return a match.
-    return BorrowedIdsWithName(*this, filterFlags);
+    return BorrowedIdsWithName(*this, idv_, filterFlags);
   }
 
   // Otherwise, use a loop to decide if we can borrow
@@ -83,7 +83,7 @@ OwnedIdsWithName::borrow(IdAndVis::SymbolTypeFlags filterFlags) const {
       continue;
 
     // Found a visible ID! Return a BorrowedIds referring to the whole thing
-    return BorrowedIdsWithName(*this, filterFlags);
+    return BorrowedIdsWithName(*this, idv, filterFlags);
   }
 
   // No ID was visible, so we can't borrow.

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -49,8 +49,7 @@ OwnedIdsWithName::borrow(bool skipPrivateVisibilities,
   if (onlyMethodsFields) { filterFlags |= IdAndVis::METHOD_OR_FIELD; }
 
   if (BorrowedIdsWithName::isIdVisible(idv_, filterFlags)) {
-    return BorrowedIdsWithName(idv_, moreIdvs_.get(),
-                               skipPrivateVisibilities, onlyMethodsFields);
+    return BorrowedIdsWithName(idv_, moreIdvs_.get(), filterFlags);
   }
   // The first ID isn't visible; are others?
   if (moreIdvs_.get() == nullptr) {
@@ -62,8 +61,7 @@ OwnedIdsWithName::borrow(bool skipPrivateVisibilities,
       continue;
 
     // Found a visible ID! Return a BorrowedIds referring to the whole thing
-    return BorrowedIdsWithName(idv, moreIdvs_.get(),
-                               skipPrivateVisibilities, onlyMethodsFields);
+    return BorrowedIdsWithName(idv, moreIdvs_.get(), filterFlags);
   }
 
   // No ID was visible, so we can't borrow.

--- a/frontend/test/resolution/testScopeResolve.cpp
+++ b/frontend/test/resolution/testScopeResolve.cpp
@@ -1106,7 +1106,7 @@ static void test29() {
 
   const ResolvedFunction* rfn = scopeResolveFunction(context, fn->id());
   const ResolvedExpression& reY = rfn->byAst(y->initExpression());
-  assert(reY.toId() == x->id());
+  assert(reY.toId().isEmpty());
 }
 
 

--- a/frontend/test/resolution/testScopeResolve.cpp
+++ b/frontend/test/resolution/testScopeResolve.cpp
@@ -601,7 +601,7 @@ static void test14() {
 
 
 // Make sure that the dot-expression handling of "this" works in addition
-// to the idenifier-expression handling of "this". Technically this is
+// to the identifier-expression handling of "this". Technically this is
 // redundant, but our goal is to issue a warning, not fail to resolve in
 // this case.
 static void test15() {
@@ -966,6 +966,150 @@ static void test25() {
   guard.clearErrors();
 }
 
+// check a more nested module example with privacy
+static void test26() {
+  printf("test26\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module M {
+        private var x : int;
+        module Sub {
+          use M;
+
+          var y = x; // access to 'x' should be OK
+        }
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* y = findVariable(vec, "y");
+  assert(y);
+
+  const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
+  assert(reY.toId() == x->id());
+}
+// this version matches the privateToParent test
+static void test27() {
+  printf("test27\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module M {
+        private var x : int;
+        module Sub {
+          proc main() {
+            use M;
+            var y = x; // access to 'x' should be OK
+          }
+        }
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* y = findVariable(vec, "y");
+  assert(y);
+
+  ID fnId = y->id().parentSymbolId(context);
+  auto fn = idToAst(context, fnId);
+  assert(fn && fn->isFunction());
+
+  const ResolvedFunction* rfn = scopeResolveFunction(context, fn->id());
+  const ResolvedExpression& reY = rfn->byAst(y->initExpression());
+  assert(reY.toId() == x->id());
+}
+// this version has two paths to 'x' and the public-only is processed first
+static void test28() {
+  printf("test28\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module Other {
+        public use M;
+      }
+      module M {
+        private var x : int;
+        module Sub {
+          use M;
+          proc main() {
+            use Other;
+
+            var y = x; // access to 'x' should be OK
+          }
+        }
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* y = findVariable(vec, "y");
+  assert(y);
+
+  ID fnId = y->id().parentSymbolId(context);
+  auto fn = idToAst(context, fnId);
+  assert(fn && fn->isFunction());
+
+  const ResolvedFunction* rfn = scopeResolveFunction(context, fn->id());
+  const ResolvedExpression& reY = rfn->byAst(y->initExpression());
+  assert(reY.toId() == x->id());
+}
+// this one tests if a 'private use' is visible within a submodule
+static void test29() {
+  printf("test29\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "input.chpl");
+  std::string contents = R""""(
+      module Other {
+        var x;
+      }
+      module M {
+        private use Other;
+        module Sub {
+          proc main() {
+            use M;
+            var y = x; // access to 'x' should be OK
+          }
+        }
+      }
+   )"""";
+  setFileText(context, path, contents);
+
+  const ModuleVec& vec = parseToplevel(context, path);
+
+  const Variable* x = findVariable(vec, "x");
+  assert(x);
+  const Variable* y = findVariable(vec, "y");
+  assert(y);
+
+  ID fnId = y->id().parentSymbolId(context);
+  auto fn = idToAst(context, fnId);
+  assert(fn && fn->isFunction());
+
+  const ResolvedFunction* rfn = scopeResolveFunction(context, fn->id());
+  const ResolvedExpression& reY = rfn->byAst(y->initExpression());
+  assert(reY.toId() == x->id());
+}
+
+
 int main() {
   test1();
   test2();
@@ -992,6 +1136,10 @@ int main() {
   test23();
   test24();
   test25();
+  test26();
+  test27();
+  test28();
+  test29();
 
   return 0;
 }


### PR DESCRIPTION
This PR improves name lookup within methods for the dyno scope resolver to better handle preferring local variables and formals to fields/methods and fields/methods to outer variables. This PR is motivated by getting cases from #21668 working. It adds the tests from that issue to testMethodFieldAccess.cpp but not all of them are working yet.

For the most part, this PR is motivated by this draft rule from #21668:

> When looking for symbols with a particular name, the compiler will search upwards in enclosing scopes. When a method scope is reached in that process, the compiler will search the method definition point for visible fields and methods. Then, it will proceed to the enclosing scope. In other words, the method definition point counts as a kind of shadow scope just outside the method scope.

That means that, when `doLookupInScope` is working with a method scope, it needs to consider the method receiver scope (and the parent scopes / use'd scopes of that) before considering the regular parent scopes. However, that was challenging to implement in a straightforward way in `doLookupInScope` because we have only one set of checked scopes. In particular, if the receiver scope has a parent scope that is also a parent scope to the current scope, the implementation was relying on checking the receiver scopes after the regular scopes, so that the restricted case (checking only methods and fields) would only be run if the general case wasn't needed.

To update `doLookupInScope` to consider the parents of the receiver scope along with the receiver scope, this PR adjusts it to potentially check such a parent scope twice: once filtering only for methods/fields and a second time finding only things that aren't methods/fields. In order to allow such checking, this PR generalizes the filtering that already existed for `OwnedIdsWithName::borrow` and within `BorrowedIdsWithName` from using particular `bool` formals/fields to using an integer representing a set. This set is built from enum values in `IdAndVis`, and there is a bit dedicated to each as well as its opposite (so, we have `PUBLIC`, `PRIVATE`, `METHOD_OR_FIELD`, and `NOT_METHOD_OR_FIELD`). The reason to have `PRIVATE` and `NOT_METHOD_OR_FIELD` (instead of just relying on the absence of a bit) is that it allows us to express all filters through set bits, where 0 bits mean "don't care". Since `0` bits mean "don't care", we can optimize `OwnedIdsWithName::borrow`. First, `OwnedIdsWithName` tracks the bitwise `&` and bitwise `|` of all of the contained `IdAndVis`. Then, within `OwnedIdsWithName::borrow`, we can easily detect two common cases: 1) the filter matches all Ids and 2) the filter matches no Ids. This keeps the process of borrowing O(1) in more cases. Note that a filter with bits set for `PUBLIC` and `METHOD_OR_FIELD` is requesting only Ids that meet both constraints (ie. only ids that are both public and are methods/fields).

More details:
 * added the different int/uint widths to doc/util/nitpick_ignore
 * added a parsing query `idIsMethod` (currently unused, but I am expecting that further work towards implementing the draft rules in #21668 will rely on it)
 * scope-types.h / scope-types.cpp:
   * added `IdAndVis::SymbolTypeFlags` that is a unsigned integer bitset backed by an enum; replaced `vis_` and `flags_` fields with a new `flags_` field; adjusted the constructor to set the flags appropriately. Removes `IdAndVis::vis()` which was unused. Added a `reverseFlags` helper.
   * added `IdAndVis::SymbolTypeFlags` fields to `OwnedIdsWithName` that represent the bitwise `&` and the bitwise `|` of all of the contained IdAndVis elements.
   * replaced `BorrowedIdsWithName` fields `arePrivateIdsIgnored_` and `onlyMethodsFields_` with a new `IdAndVis::SymbolTypeFlags filterFlags_` field. Adjusted the `isIdVisible` calculation to work with these bit sets. 
   * similarly, replaced several `bool` fields in `class Scope` with a bit set to better optimize memory usage and simplify the implementation of `==` on the type.
   * added `LOOKUP_SKIP_PRIVATE_USE_IMPORT` as a `LookupConfig` flag (to allow matching the production compiler with issue #21723).
   * migrated `ScopeSet` to this file from `scope-queries.h`
   * replaced `NamedScopeSet` with `CheckedScopes` which tracks the filter used when checking that scope
 * in resolution-queries.cpp
   * adjusted `doIsCandidateApplicableInitial` to allow resolving a parenless call to ignore declarations that are not parenless calls.
   * adjusted `lookupCalledExpr` to only find the innermost match for parenless non-method calls (to treat parenless non-methods more similarly to variable declarations) & to only gather visible fields/methods when considering a method call (since nothing else could be a candidate).
 * in scope-queries.cpp
   * merged doLookupInReceiverParentScopes with doLookupInReceiverScopes
   * adjusted several lookup calls to compute a filter instead of passing `bool`s
   * adjusted `doLookupInScope` to include logic that handles the possibility that we checked a scope with a restrictive filter but now are checking it again with no filter (or a less restrictive filter). In particular, this includes considering the possibility that we checked a scope only for methods&fields and now need to gather other kinds of symbols. This logic applies only to a specific scope, which should be OK because the other lookup helper functions (e.g. checkedScopesMethodsFields) already rely on `doLookupInScope` to handle these visited sets.
   * adjusted `helpLookupInScope` to check the receiver scopes after the other lookups in case they have not been checked yet in order to support scope resolving something like `myobject.x`.
 * in scope-types.cpp
   * optimized `OwnedIdsWithName::borrow` through checking `flagsOr_` and `flagsAnd_` and similarly optimized `BorrowedIdsWithName::countVisibleIds`.
   * adjusted scope functions to compute the bit set that replaces several bool flags

Future Work:
 * get all of the tests in testMethodFieldAccess.cpp working
 * adjust the dyno resolver / scope resolver to handle finding candidates differently if the innermost candidate is a variable / parenless non-method
 * create test cases for expressions like `myobject.x` referring to a field vs an outer method & analyze what the production compiler does in such cases.
 * resolve open language design questions in #21723 and update the dyno scope resolver to follow whatever is decided. At present, this PR uses additional logic to disallow access to private `use` statements from a parent module.

Reviewed by @DanilaFe - thanks!

- [x] full local testing
- [x] no new failures with `--dyno`