### PR TITLE
Add new tag filter for :enum:

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -473,7 +473,7 @@ const char* Symbol::getSanitizedMsg(std::string msg) const {
   //       show up in sanitized message).
   // TODO: Allow prefixing content with ! (and filtering it out in the sanitized message)
   // TODO: Allow prefixing content with ~ (and having it only display last component of target)
-  static const auto reStr = R"(\B\:(mod|proc|iter|data|const|var|param|type|class|record|attr)\:`([!$\w\$\.]+)`\B)";
+  static const auto reStr = R"(\B\:(mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`([!$\w\$\.]+)`\B)";
   msg = std::regex_replace(msg, std::regex(reStr), "$2");
   return astr(msg.c_str());
 }

--- a/test/deprecated-keyword/messageFiltering.chpl
+++ b/test/deprecated-keyword/messageFiltering.chpl
@@ -54,12 +54,14 @@ deprecated "Lorem ipsum :record:`test` dolor sit amet"
 var x3010 = 3010;
 deprecated "Lorem ipsum :attr:`test` dolor sit amet"
 var x3011 = 3011;
-deprecated "Lorem :mod:`abc` ipsum :proc:`def` dolor :iter:`ghi` sit :data:`jkl` amet"
+deprecated "Lorem ipsum :enum:`test` dolor sit amet"
 var x3012 = 3012;
-deprecated "Lorem :const:`abc` ipsum :var:`def` dolor :param:`ghi` sit :type:`jkl` amet"
+deprecated "Lorem :mod:`abc` ipsum :proc:`def` dolor :iter:`ghi` sit :data:`jkl` amet"
 var x3013 = 3013;
-deprecated "Lorem :class:`abc` ipsum :record:`def` dolor :attr:`ghi` sit amet"
+deprecated "Lorem :const:`abc` ipsum :var:`def` dolor :param:`ghi` sit :type:`jkl` amet"
 var x3014 = 3014;
+deprecated "Lorem :class:`abc` ipsum :record:`def` dolor :attr:`ghi` sit amet"
+var x3015 = 3015;
 
 // Test different text in ::s (all should not filter)
 deprecated "--- Test different text in ::s (all should not filter) ---"
@@ -207,6 +209,7 @@ writeln(x3011);
 writeln(x3012);
 writeln(x3013);
 writeln(x3014);
+writeln(x3015);
 
 writeln(x4000);
 writeln(x4001);

--- a/test/deprecated-keyword/messageFiltering.good
+++ b/test/deprecated-keyword/messageFiltering.good
@@ -1,79 +1,80 @@
-messageFiltering.chpl:181: warning: --- No filtering should be applied: ---
-messageFiltering.chpl:182: warning: sample_message
-messageFiltering.chpl:183: warning: Lorem ipsum dolor sit amet
-messageFiltering.chpl:184: warning: Lorem_ipsum_dolor_sit_amet
-messageFiltering.chpl:185: warning: mod proc iter data const var param type class record
-messageFiltering.chpl:186: warning: :mod proc:`abc` :iter data:`def` :const var:`ghi`
-messageFiltering.chpl:187: warning: :param type:`jkl` :class record:`mno`
-messageFiltering.chpl:189: warning: --- Test filtering at start, middle, and end of msg (with and without content): ---
-messageFiltering.chpl:190: warning: abc Lorem ipsum dolor sit amet
-messageFiltering.chpl:191: warning: Lorem ipsum abc dolor sit amet
-messageFiltering.chpl:192: warning: Lorem ipsum dolor sit amet abc
-messageFiltering.chpl:193: warning: abc Lorem def ipsum dolor sit amet ghi
-messageFiltering.chpl:195: warning: --- Test different text in ::s (all should filter) ---
-messageFiltering.chpl:196: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:197: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:198: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:199: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:200: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:201: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:202: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:203: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:204: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:205: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:206: warning: Lorem ipsum test dolor sit amet
-messageFiltering.chpl:207: warning: Lorem abc ipsum def dolor ghi sit jkl amet
-messageFiltering.chpl:208: warning: Lorem abc ipsum def dolor ghi sit jkl amet
-messageFiltering.chpl:209: warning: Lorem abc ipsum def dolor ghi sit amet
-messageFiltering.chpl:211: warning: --- Test different text in ::s (all should not filter) ---
-messageFiltering.chpl:212: warning: Lorem ipsum ::`abc` dolor sit amet
-messageFiltering.chpl:213: warning: Lorem ipsum :a:`abc` dolor sit amet
-messageFiltering.chpl:214: warning: Lorem ipsum :abc123def:`abc` dolor sit amet
-messageFiltering.chpl:215: warning: Lorem ipsum :123abc123def:`abc` dolor sit amet
-messageFiltering.chpl:216: warning: Lorem ipsum :abc123def123:`abc` dolor sit amet
-messageFiltering.chpl:217: warning: Lorem ipsum :123abc123def123:`abc` dolor sit amet
-messageFiltering.chpl:218: warning: Lorem ipsum :abc_123_def:`abc` dolor sit amet
-messageFiltering.chpl:220: warning: --- Test different text in ``s ---
-messageFiltering.chpl:221: warning: Lorem ipsum :proc:`` dolor sit amet (should not filter)
-messageFiltering.chpl:222: warning: Lorem ipsum a dolor sit amet
-messageFiltering.chpl:223: warning: Lorem ipsum abc123def dolor sit amet
-messageFiltering.chpl:224: warning: Lorem ipsum abc_123_def dolor sit amet
-messageFiltering.chpl:225: warning: Lorem ipsum 123abc_123_def dolor sit amet
-messageFiltering.chpl:226: warning: Lorem ipsum abc_123_def123 dolor sit amet
-messageFiltering.chpl:227: warning: Lorem ipsum 123abc_123_def123 dolor sit amet
-messageFiltering.chpl:228: warning: Lorem ipsum _abc_123_def_ dolor sit amet
-messageFiltering.chpl:229: warning: Lorem ipsum :proc:`abc:def` dolor sit amet (should not filter)
-messageFiltering.chpl:230: warning: Lorem ipsum proc dolor sit amet
-messageFiltering.chpl:231: warning: Lorem ipsum :proc:`:proc:` dolor sit amet (should not filter)
-messageFiltering.chpl:232: warning: Lorem ipsum :proc:`:proc:abc` dolor sit amet (should not filter)
-messageFiltering.chpl:233: warning: Lorem ipsum :proc:`title target` dolor sit amet (should not filter)
-messageFiltering.chpl:234: warning: Lorem ipsum abc.def dolor sit amet
-messageFiltering.chpl:236: warning: --- Other :s in message: ---
-messageFiltering.chpl:237: warning: Instead of using foo(a: int, b: string) use bar.
-messageFiltering.chpl:238: warning: Instead of using foo(a:int,b:string) use bar.
-messageFiltering.chpl:239: warning: Instead of using foo(a:int):int use bar.
-messageFiltering.chpl:240: warning: Instead of using foo(proc: int, proc: string) use bar.
-messageFiltering.chpl:241: warning: Instead of using foo(proc:int,proc:string) use bar.
-messageFiltering.chpl:242: warning: Instead of using foo(proc:int):proc use bar.
-messageFiltering.chpl:243: warning: proc foo(x: int) is deprecated, use proc foo(x: real) instead
-messageFiltering.chpl:245: warning: --- Word boundaries (should filter) ---
-messageFiltering.chpl:246: warning: First (middle) end
-messageFiltering.chpl:247: warning: First, middle, end
-messageFiltering.chpl:248: warning: First,middle,end
-messageFiltering.chpl:250: warning: --- Word boundaries (should not filter) ---
-messageFiltering.chpl:251: warning: First:proc:`middle` end
-messageFiltering.chpl:252: warning: First :proc:`middle`end
-messageFiltering.chpl:253: warning: First:proc:`middle`end
-messageFiltering.chpl:254: warning: First:proc:`middle`:end
-messageFiltering.chpl:256: warning: --- Dollars in identifier (should filter) ---
-messageFiltering.chpl:257: warning: Lorem ipsum abc$ dolor sit amet
-messageFiltering.chpl:258: warning: Lorem ipsum abc$def dolor sit amet
-messageFiltering.chpl:259: warning: Lorem ipsum abc$def$ dolor sit amet
-messageFiltering.chpl:260: warning: Lorem ipsum abc$def$ghi dolor sit amet
-messageFiltering.chpl:262: warning: --- Identifier is led with ! (should filter) ---
-messageFiltering.chpl:263: warning: Lorem ipsum !abc dolor sit amet
-messageFiltering.chpl:265: warning: --- Currently filters, but ideally wouldn't (see #18549) ---
-messageFiltering.chpl:266: warning: Lorem ipsum :proc:`~abc.def` dolor sit amet
+messageFiltering.chpl:n: warning: --- No filtering should be applied: ---
+messageFiltering.chpl:n: warning: sample_message
+messageFiltering.chpl:n: warning: Lorem ipsum dolor sit amet
+messageFiltering.chpl:n: warning: Lorem_ipsum_dolor_sit_amet
+messageFiltering.chpl:n: warning: mod proc iter data const var param type class record
+messageFiltering.chpl:n: warning: :mod proc:`abc` :iter data:`def` :const var:`ghi`
+messageFiltering.chpl:n: warning: :param type:`jkl` :class record:`mno`
+messageFiltering.chpl:n: warning: --- Test filtering at start, middle, and end of msg (with and without content): ---
+messageFiltering.chpl:n: warning: abc Lorem ipsum dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum abc dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum dolor sit amet abc
+messageFiltering.chpl:n: warning: abc Lorem def ipsum dolor sit amet ghi
+messageFiltering.chpl:n: warning: --- Test different text in ::s (all should filter) ---
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem abc ipsum def dolor ghi sit jkl amet
+messageFiltering.chpl:n: warning: Lorem abc ipsum def dolor ghi sit jkl amet
+messageFiltering.chpl:n: warning: Lorem abc ipsum def dolor ghi sit amet
+messageFiltering.chpl:n: warning: --- Test different text in ::s (all should not filter) ---
+messageFiltering.chpl:n: warning: Lorem ipsum ::`abc` dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :a:`abc` dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :abc123def:`abc` dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :123abc123def:`abc` dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :abc123def123:`abc` dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :123abc123def123:`abc` dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :abc_123_def:`abc` dolor sit amet
+messageFiltering.chpl:n: warning: --- Test different text in ``s ---
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`` dolor sit amet (should not filter)
+messageFiltering.chpl:n: warning: Lorem ipsum a dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum abc123def dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum abc_123_def dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum 123abc_123_def dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum abc_123_def123 dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum 123abc_123_def123 dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum _abc_123_def_ dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`abc:def` dolor sit amet (should not filter)
+messageFiltering.chpl:n: warning: Lorem ipsum proc dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`:proc:` dolor sit amet (should not filter)
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`:proc:abc` dolor sit amet (should not filter)
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`title target` dolor sit amet (should not filter)
+messageFiltering.chpl:n: warning: Lorem ipsum abc.def dolor sit amet
+messageFiltering.chpl:n: warning: --- Other :s in message: ---
+messageFiltering.chpl:n: warning: Instead of using foo(a: int, b: string) use bar.
+messageFiltering.chpl:n: warning: Instead of using foo(a:int,b:string) use bar.
+messageFiltering.chpl:n: warning: Instead of using foo(a:int):int use bar.
+messageFiltering.chpl:n: warning: Instead of using foo(proc: int, proc: string) use bar.
+messageFiltering.chpl:n: warning: Instead of using foo(proc:int,proc:string) use bar.
+messageFiltering.chpl:n: warning: Instead of using foo(proc:int):proc use bar.
+messageFiltering.chpl:n: warning: proc foo(x: int) is deprecated, use proc foo(x: real) instead
+messageFiltering.chpl:n: warning: --- Word boundaries (should filter) ---
+messageFiltering.chpl:n: warning: First (middle) end
+messageFiltering.chpl:n: warning: First, middle, end
+messageFiltering.chpl:n: warning: First,middle,end
+messageFiltering.chpl:n: warning: --- Word boundaries (should not filter) ---
+messageFiltering.chpl:n: warning: First:proc:`middle` end
+messageFiltering.chpl:n: warning: First :proc:`middle`end
+messageFiltering.chpl:n: warning: First:proc:`middle`end
+messageFiltering.chpl:n: warning: First:proc:`middle`:end
+messageFiltering.chpl:n: warning: --- Dollars in identifier (should filter) ---
+messageFiltering.chpl:n: warning: Lorem ipsum abc$ dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum abc$def dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum abc$def$ dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum abc$def$ghi dolor sit amet
+messageFiltering.chpl:n: warning: --- Identifier is led with ! (should filter) ---
+messageFiltering.chpl:n: warning: Lorem ipsum !abc dolor sit amet
+messageFiltering.chpl:n: warning: --- Currently filters, but ideally wouldn't (see #18549) ---
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`~abc.def` dolor sit amet
 1000
 1001
 1002
@@ -101,6 +102,7 @@ messageFiltering.chpl:266: warning: Lorem ipsum :proc:`~abc.def` dolor sit amet
 3012
 3013
 3014
+3015
 4000
 4001
 4002

--- a/test/deprecated-keyword/messageFiltering.prediff
+++ b/test/deprecated-keyword/messageFiltering.prediff
@@ -1,0 +1,9 @@
+#!/bin/sh 
+
+# filter out line numbers
+TESTNAME=$1
+OUTFILE=$2
+TMPFILE=$OUTFILE.prediff.tmp
+sed -e 's/\.chpl:[0-9]*:/\.chpl:n:/' < $OUTFILE > $TMPFILE
+cat $TMPFILE > $OUTFILE
+rm $TMPFILE

--- a/test/deprecated/HDFS/HDFS-open-iomode.good
+++ b/test/deprecated/HDFS/HDFS-open-iomode.good
@@ -1,6 +1,6 @@
 HDFS-open-iomode.chpl:6: In function 'main':
-HDFS-open-iomode.chpl:12: warning: enum iomode is deprecated - please use :enum:`ioMode` instead
-HDFS-open-iomode.chpl:20: warning: enum iomode is deprecated - please use :enum:`ioMode` instead
-HDFS-open-iomode.chpl:12: warning: open with an iomode argument is deprecated - please use :enum:`~IO.ioMode`
-HDFS-open-iomode.chpl:20: warning: open with an iomode argument is deprecated - please use :enum:`~IO.ioMode`
+HDFS-open-iomode.chpl:12: warning: enum iomode is deprecated - please use ioMode instead
+HDFS-open-iomode.chpl:20: warning: enum iomode is deprecated - please use ioMode instead
+HDFS-open-iomode.chpl:12: warning: open with an iomode argument is deprecated - please use ~IO.ioMode
+HDFS-open-iomode.chpl:20: warning: open with an iomode argument is deprecated - please use ~IO.ioMode
 Test file matches, OK

--- a/test/deprecated/IO/iomodeDeprecation.good
+++ b/test/deprecated/IO/iomodeDeprecation.good
@@ -1,4 +1,4 @@
-iomodeDeprecation.chpl:7: warning: enum iomode is deprecated - please use :enum:`ioMode` instead
-iomodeDeprecation.chpl:4: warning: enum iomode is deprecated - please use :enum:`ioMode` instead
-iomodeDeprecation.chpl:7: warning: open with an iomode argument is deprecated - please use :enum:`ioMode`
-iomodeDeprecation.chpl:11: warning: open with an iomode argument is deprecated - please use :enum:`ioMode`
+iomodeDeprecation.chpl:7: warning: enum iomode is deprecated - please use ioMode instead
+iomodeDeprecation.chpl:4: warning: enum iomode is deprecated - please use ioMode instead
+iomodeDeprecation.chpl:7: warning: open with an iomode argument is deprecated - please use ioMode
+iomodeDeprecation.chpl:11: warning: open with an iomode argument is deprecated - please use ioMode


### PR DESCRIPTION
In comments on #21581, we realized that `:enum:` does not get filtered out of the command line deprecation warnings. Concluded to be an oversight, this PR fixes it

# Summary of changes
- add `enum` to the list of `:tags:` to filter in a deprecation message
- update deprecation filtering test to have `enum`
- update `ioMode` deprecation tests to match correct filtered output
  - currently `ioMode` was the only instance of this filtering issue

# Testing
- full paratest
- also ran nightly Hadoop tests, which were touched by `ioMode` changes

# Future work
- There is a note about supporting filtering `~` in `Symbol::getSanitizedMsg`. The `ioMode` deprecations for HDFS do use this and it would cleanup the output