### PR TITLE
Rename openreader/openwriter

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3458,27 +3458,27 @@ config param useNewOpenReaderRegionBounds = false;
 
 /*
 
-Open a file at a particular path and return a reading channel for it.
+Open a file at a particular path and return a :record:`fileReader` for it.
 This function is equivalent to calling :proc:`open` and then
 :proc:`file.reader` on the resulting file.
 
 :arg path: which file to open (for example, "some/file.txt").
 :arg kind: :type:`iokind` compile-time argument to determine the
-            corresponding parameter of the :record:`channel` type. Defaults
+            corresponding parameter of the :record:`fileReader` type. Defaults
             to ``iokind.dynamic``, meaning that the associated
             :record:`iostyle` controls the formatting choices.
 :arg locking: compile-time argument to determine whether or not the
-              channel should use locking; sets the
-              corresponding parameter of the :record:`channel` type.
+              fileReader should use locking; sets the
+              corresponding parameter of the :record:`fileReader` type.
               Defaults to true, but when safe, setting it to false
               can improve performance.
 :arg region: zero-based byte offset indicating where in the file the
-            channel should start and stop reading. Defaults to
+            fileReader should start and stop reading. Defaults to
             ``0..``, meaning from the start of the file to no specified end
             point.
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :record:`ioHintSet`.
-:returns: an open reading channel to the requested resource.
+:returns: an open fileReader to the requested resource.
 
 .. warning::
 
@@ -3489,7 +3489,7 @@ This function is equivalent to calling :proc:`open` and then
                          permissions
 :throws NotADirectoryError: Thrown if part of the provided path was expected to
                             be a directory but was not
-:throws SystemError: Thrown if a reading channel could not be returned.
+:throws SystemError: Thrown if a fileReader could not be returned.
 :throws IllegalArgumentError: Thrown if trying to read explicitly prior to byte
                               0.
  */
@@ -3505,27 +3505,27 @@ proc openreader(path:string,
 
 /*
 
-Open a file at a particular path and return a reading channel for it.
+Open a file at a particular path and return a :record:`fileReader` for it.
 This function is equivalent to calling :proc:`open` and then
 :proc:`file.reader` on the resulting file.
 
 :arg path: which file to open (for example, "some/file.txt").
 :arg kind: :type:`iokind` compile-time argument to determine the
-            corresponding parameter of the :record:`channel` type. Defaults
+            corresponding parameter of the :record:`fileReader` type. Defaults
             to ``iokind.dynamic``, meaning that the associated
             :record:`iostyle` controls the formatting choices.
 :arg locking: compile-time argument to determine whether or not the
-              channel should use locking; sets the
-              corresponding parameter of the :record:`channel` type.
+              fileReader should use locking; sets the
+              corresponding parameter of the :record:`fileReader` type.
               Defaults to true, but when safe, setting it to false
               can improve performance.
 :arg region: zero-based byte offset indicating where in the file the
-            channel should start and stop reading. Defaults to
+            fileReader should start and stop reading. Defaults to
             ``0..``, meaning from the start of the file to no specified end
             point.
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :record:`ioHintSet`.
-:returns: an open reading channel to the requested resource.
+:returns: an open fileReader to the requested resource.
 
 .. warning::
 
@@ -3536,7 +3536,7 @@ This function is equivalent to calling :proc:`open` and then
                          permissions
 :throws NotADirectoryError: Thrown if part of the provided path was expected to
                             be a directory but was not
-:throws SystemError: Thrown if a reading channel could not be returned.
+:throws SystemError: Thrown if a fileReader could not be returned.
 :throws IllegalArgumentError: Thrown if trying to read explicitly prior to byte
                               0.
  */
@@ -3602,30 +3602,30 @@ proc openWriter(path:string,
 
 /*
 
-Open a file at a particular path and return a writing channel for it.
+Open a file at a particular path and return a :record:`fileWriter` for it.
 This function is equivalent to calling :proc:`open` with ``ioMode.cwr`` and then
 :proc:`file.writer` on the resulting file.
 
 :arg path: which file to open (for example, "some/file.txt").
 :arg kind: :type:`iokind` compile-time argument to determine the
-           corresponding parameter of the :record:`channel` type. Defaults
+           corresponding parameter of the :record:`fileWriter` type. Defaults
            to ``iokind.dynamic``, meaning that the associated
            :record:`iostyle` controls the formatting choices.
 :arg locking: compile-time argument to determine whether or not the
-              channel should use locking; sets the
-              corresponding parameter of the :record:`channel` type.
+              fileWriter should use locking; sets the
+              corresponding parameter of the :record:`fileWriter` type.
               Defaults to true, but when safe, setting it to false
               can improve performance.
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :record:`ioHintSet`.
-:returns: an open writing channel to the requested resource.
+:returns: an open fileWriter to the requested resource.
 
 :throws FileNotFoundError: Thrown if part of the provided path did not exist
 :throws PermissionError: Thrown if part of the provided path had inappropriate
                          permissions
 :throws NotADirectoryError: Thrown if part of the provided path was expected to
                             be a directory but was not
-:throws SystemError: Thrown if a writing channel could not be returned.
+:throws SystemError: Thrown if a fileWriter could not be returned.
 :throws IllegalArgumentError: Thrown if trying to write explicitly prior to byte
                               0.
 */
@@ -3639,30 +3639,30 @@ proc openwriter(path:string,
 
 /*
 
-Open a file at a particular path and return a writing channel for it.
+Open a file at a particular path and return a :record:`fileWriter` for it.
 This function is equivalent to calling :proc:`open` with ``ioMode.cwr`` and then
 :proc:`file.writer` on the resulting file.
 
 :arg path: which file to open (for example, "some/file.txt").
 :arg kind: :type:`iokind` compile-time argument to determine the
-           corresponding parameter of the :record:`channel` type. Defaults
+           corresponding parameter of the :record:`fileWriter` type. Defaults
            to ``iokind.dynamic``, meaning that the associated
            :record:`iostyle` controls the formatting choices.
 :arg locking: compile-time argument to determine whether or not the
-              channel should use locking; sets the
-              corresponding parameter of the :record:`channel` type.
+              fileWriter should use locking; sets the
+              corresponding parameter of the :record:`fileWriter` type.
               Defaults to true, but when safe, setting it to false
               can improve performance.
 :arg hints: optional argument to specify any hints to the I/O system about
             this file. See :record:`ioHintSet`.
-:returns: an open writing channel to the requested resource.
+:returns: an open fileWriter to the requested resource.
 
 :throws FileNotFoundError: Thrown if part of the provided path did not exist
 :throws PermissionError: Thrown if part of the provided path had inappropriate
                          permissions
 :throws NotADirectoryError: Thrown if part of the provided path was expected to
                             be a directory but was not
-:throws SystemError: Thrown if a writing channel could not be returned.
+:throws SystemError: Thrown if a fileWriter could not be returned.
 :throws IllegalArgumentError: Thrown if trying to write explicitly prior to byte
                               0.
 */

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3626,6 +3626,8 @@ This function is equivalent to calling :proc:`open` with ``ioMode.cwr`` and then
 :throws NotADirectoryError: Thrown if part of the provided path was expected to
                             be a directory but was not
 :throws SystemError: Thrown if a writing channel could not be returned.
+:throws IllegalArgumentError: Thrown if trying to write explicitly prior to byte
+                              0.
 */
 deprecated "openwriter is deprecated - please use :proc:`openWriter` instead"
 proc openwriter(path:string,
@@ -3661,6 +3663,8 @@ This function is equivalent to calling :proc:`open` with ``ioMode.cwr`` and then
 :throws NotADirectoryError: Thrown if part of the provided path was expected to
                             be a directory but was not
 :throws SystemError: Thrown if a writing channel could not be returned.
+:throws IllegalArgumentError: Thrown if trying to write explicitly prior to byte
+                              0.
 */
 proc openWriter(path:string,
                 param kind=iokind.dynamic, param locking=true,

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3422,18 +3422,29 @@ proc _channel.filePlugin() : borrowed QioPluginFile? {
   return vptr:borrowed QioPluginFile?;
 }
 
-@unstable "openreader with a style argument is unstable"
+deprecated "openreader is deprecated - please use :proc:`openReader` instead"
 proc openreader(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints=ioHintSet.empty,
                 style:iostyle)
     : fileReader(kind, locking) throws {
-  return openreaderHelper(path, kind, locking, start..end, hints,
+  return openReader(path, kind, locking, start, end, hints, style);
+}
+
+
+@unstable "openReader with a style argument is unstable"
+proc openReader(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                start:int(64) = 0, end:int(64) = max(int(64)),
+                hints=ioHintSet.empty,
+                style:iostyle)
+    : fileReader(kind, locking) throws {
+  return openReaderHelper(path, kind, locking, start..end, hints,
                           style: iostyleInternal);
 }
 
-/* Used to control the behavior of the region argument for :proc:`openreader`.
+/* Used to control the behavior of the region argument for :proc:`openReader`.
    When set to ``true``, the region argument will fully specify the bounds of
    the :type:`fileReader`.  When set to ``false``, the region argument will
    exclude the high bound.  Defaults to ``false``, the original behavior.
@@ -3482,24 +3493,80 @@ This function is equivalent to calling :proc:`open` and then
 :throws IllegalArgumentError: Thrown if trying to read explicitly prior to byte
                               0.
  */
+deprecated "openreader is deprecated - please use :proc:`openReader` instead"
 proc openreader(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 region: range(?) = 0.., hints=ioHintSet.empty)
     : fileReader(kind, locking) throws where (!region.hasHighBound() ||
                                               useNewOpenReaderRegionBounds) {
-  return openreaderHelper(path, kind, locking, region, hints);
+  return openReader(path, kind, locking, region, hints);
 }
 
-deprecated "Currently the region argument's high bound specifies the first location in the file that is not included.  This behavior is deprecated, please compile your program with `-suseNewOpenReaderRegionBounds=true` to have the region argument specify the entire segment of the file covered, inclusive."
+
+/*
+
+Open a file at a particular path and return a reading channel for it.
+This function is equivalent to calling :proc:`open` and then
+:proc:`file.reader` on the resulting file.
+
+:arg path: which file to open (for example, "some/file.txt").
+:arg kind: :type:`iokind` compile-time argument to determine the
+            corresponding parameter of the :record:`channel` type. Defaults
+            to ``iokind.dynamic``, meaning that the associated
+            :record:`iostyle` controls the formatting choices.
+:arg locking: compile-time argument to determine whether or not the
+              channel should use locking; sets the
+              corresponding parameter of the :record:`channel` type.
+              Defaults to true, but when safe, setting it to false
+              can improve performance.
+:arg region: zero-based byte offset indicating where in the file the
+            channel should start and stop reading. Defaults to
+            ``0..``, meaning from the start of the file to no specified end
+            point.
+:arg hints: optional argument to specify any hints to the I/O system about
+            this file. See :record:`ioHintSet`.
+:returns: an open reading channel to the requested resource.
+
+.. warning::
+
+   The region argument will ignore any specified stride other than 1.
+
+:throws FileNotFoundError: Thrown if part of the provided path did not exist
+:throws PermissionError: Thrown if part of the provided path had inappropriate
+                         permissions
+:throws NotADirectoryError: Thrown if part of the provided path was expected to
+                            be a directory but was not
+:throws SystemError: Thrown if a reading channel could not be returned.
+:throws IllegalArgumentError: Thrown if trying to read explicitly prior to byte
+                              0.
+ */
+proc openReader(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                region: range(?) = 0.., hints=ioHintSet.empty)
+    : fileReader(kind, locking) throws where (!region.hasHighBound() ||
+                                              useNewOpenReaderRegionBounds) {
+  return openReaderHelper(path, kind, locking, region, hints);
+}
+
+deprecated "openreader is deprecated - please use :proc:`openReader` instead"
 proc openreader(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 region: range(?) = 0.., hints=ioHintSet.empty)
     : fileReader(kind, locking) throws where (region.hasHighBound() &&
                                               !useNewOpenReaderRegionBounds) {
-  return openreaderHelper(path, kind, locking, region, hints);
+  return openReader(path, kind, locking, region, hints);
 }
 
-private proc openreaderHelper(path:string,
+deprecated "Currently the region argument's high bound specifies the first location in the file that is not included.  This behavior is deprecated, please compile your program with `-suseNewOpenReaderRegionBounds=true` to have the region argument specify the entire segment of the file covered, inclusive."
+proc openReader(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                region: range(?) = 0.., hints=ioHintSet.empty)
+    : fileReader(kind, locking) throws where (region.hasHighBound() &&
+                                              !useNewOpenReaderRegionBounds) {
+  return openReaderHelper(path, kind, locking, region, hints);
+}
+
+private proc openReaderHelper(path:string,
                               param kind=iokind.dynamic, param locking=true,
                               region: range(?) = 0..,
                               hints=ioHintSet.empty,
@@ -3511,15 +3578,61 @@ private proc openreaderHelper(path:string,
                              fromOpenReader=true);
 }
 
-@unstable "openwriter with a style argument is unstable"
+deprecated "openwriter is deprecated - please use :proc:`openWriter` instead"
 proc openwriter(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints=ioHintSet.empty,
                 style:iostyle)
     : fileWriter(kind, locking) throws {
-  return openwriterHelper(path, kind, locking, start, end, hints,
+  return openWriter(path, kind, locking, start, end, hints, style);
+}
+
+@unstable "openWriter with a style argument is unstable"
+proc openWriter(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                start:int(64) = 0, end:int(64) = max(int(64)),
+                hints=ioHintSet.empty,
+                style:iostyle)
+    : fileWriter(kind, locking) throws {
+  return openWriterHelper(path, kind, locking, start, end, hints,
                     style: iostyleInternal);
+}
+
+
+/*
+
+Open a file at a particular path and return a writing channel for it.
+This function is equivalent to calling :proc:`open` with ``ioMode.cwr`` and then
+:proc:`file.writer` on the resulting file.
+
+:arg path: which file to open (for example, "some/file.txt").
+:arg kind: :type:`iokind` compile-time argument to determine the
+           corresponding parameter of the :record:`channel` type. Defaults
+           to ``iokind.dynamic``, meaning that the associated
+           :record:`iostyle` controls the formatting choices.
+:arg locking: compile-time argument to determine whether or not the
+              channel should use locking; sets the
+              corresponding parameter of the :record:`channel` type.
+              Defaults to true, but when safe, setting it to false
+              can improve performance.
+:arg hints: optional argument to specify any hints to the I/O system about
+            this file. See :record:`ioHintSet`.
+:returns: an open writing channel to the requested resource.
+
+:throws FileNotFoundError: Thrown if part of the provided path did not exist
+:throws PermissionError: Thrown if part of the provided path had inappropriate
+                         permissions
+:throws NotADirectoryError: Thrown if part of the provided path was expected to
+                            be a directory but was not
+:throws SystemError: Thrown if a writing channel could not be returned.
+*/
+deprecated "openwriter is deprecated - please use :proc:`openWriter` instead"
+proc openwriter(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                hints = ioHintSet.empty)
+    : fileWriter(kind, locking) throws {
+  return openWriter(path, kind, locking, hints);
 }
 
 /*
@@ -3549,14 +3662,14 @@ This function is equivalent to calling :proc:`open` with ``ioMode.cwr`` and then
                             be a directory but was not
 :throws SystemError: Thrown if a writing channel could not be returned.
 */
-proc openwriter(path:string,
+proc openWriter(path:string,
                 param kind=iokind.dynamic, param locking=true,
                 hints = ioHintSet.empty)
     : fileWriter(kind, locking) throws {
-  return openwriterHelper(path, kind, locking, hints=hints);
+  return openWriterHelper(path, kind, locking, hints=hints);
 }
 
-private proc openwriterHelper(path:string,
+private proc openWriterHelper(path:string,
                               param kind=iokind.dynamic, param locking=true,
                               start:int(64) = 0, end:int(64) = max(int(64)),
                               hints = ioHintSet.empty,
@@ -3663,11 +3776,11 @@ proc file.readerHelper(param kind=iokind.dynamic, param locking=true,
     if (region.hasLowBound() && region.hasHighBound()) {
       // This is to ensure the user sees consistent behavior and can control it.
       // - All calls from `openUrlReader` should use the new behavior.
-      // - Only calls from `openreader` that are compiled with the flag that
+      // - Only calls from `openReader` that are compiled with the flag that
       //   controls its region argument should affect its behavior.
       // - Only calls from `file.reader` that are compiled with the flag that
       //   controls its region argument should affect its behavior.
-      // Calls from `openreader` should not be impacted by `file.reader`'s flag
+      // Calls from `openReader` should not be impacted by `file.reader`'s flag
       // and vice versa.
       if ((fromOpenReader && useNewOpenReaderRegionBounds) ||
           fromOpenUrlReader ||
@@ -3686,11 +3799,11 @@ proc file.readerHelper(param kind=iokind.dynamic, param locking=true,
     } else if (region.hasHighBound()) {
       // This is to ensure the user sees consistent behavior and can control it.
       // - All calls from `openUrlReader` should use the new behavior.
-      // - Only calls from `openreader` that are compiled with the flag that
+      // - Only calls from `openReader` that are compiled with the flag that
       //   controls its region argument should affect its behavior.
       // - Only calls from `file.reader` that are compiled with the flag that
       //   controls its region argument should affect its behavior.
-      // Calls from `openreader` should not be impacted by `file.reader`'s flag
+      // Calls from `openReader` should not be impacted by `file.reader`'s flag
       // and vice versa.
       if ((fromOpenReader && useNewOpenReaderRegionBounds) ||
           fromOpenUrlReader ||

--- a/test/deprecated/IO/internalWriteBytes.chpl
+++ b/test/deprecated/IO/internalWriteBytes.chpl
@@ -4,5 +4,5 @@ use CTypes;
 var a = [1,2,3,4] : uint(8);
 var ap = c_ptrTo(a);
 
-var f = openwriter("wb.txt");
+var f = openWriter("wb.txt");
 f.writeBytes(ap, 4);

--- a/test/deprecated/IO/openreaderHigh.chpl
+++ b/test/deprecated/IO/openreaderHigh.chpl
@@ -2,12 +2,12 @@ use IO;
 
 var filename = "seek.txt";
 var readRes: string;
-var readChEnd = openreader(filename, region=..5);
+var readChEnd = openReader(filename, region=..5);
 readChEnd.readLine(readRes);
 writeln(readRes);
 readChEnd.close();
 
-var readChStartAndEnd = openreader(filename, region=3..5);
+var readChStartAndEnd = openReader(filename, region=3..5);
 readChStartAndEnd.readLine(readRes);
 writeln(readRes);
 readChStartAndEnd.close();

--- a/test/deprecated/IO/openreaderwriter.chpl
+++ b/test/deprecated/IO/openreaderwriter.chpl
@@ -1,0 +1,16 @@
+use IO;
+use FileSystem;
+
+config var testfile = "test.txt";
+
+{
+  var w = openwriter(testfile);
+  w.writeln("writing text");
+}
+{
+  var r = openreader(testfile);
+  var got = r.readLine(stripNewline=true);
+  writeln(got);
+}
+
+FileSystem.remove(testfile);

--- a/test/deprecated/IO/openreaderwriter.good
+++ b/test/deprecated/IO/openreaderwriter.good
@@ -1,0 +1,3 @@
+openreaderwriter.chpl:7: warning: openwriter is deprecated - please use openWriter instead
+openreaderwriter.chpl:11: warning: openreader is deprecated - please use openReader instead
+writing text

--- a/test/deprecated/IO/readBinaryArray.chpl
+++ b/test/deprecated/IO/readBinaryArray.chpl
@@ -4,25 +4,25 @@ use IO;
 
 // try reading after fileReader is at EOF, should return false:
 var a : [0..<8] uint(8),
-    r = openreader("./readBinaryArrayInput.bin"),
+    r = openReader("./readBinaryArrayInput.bin"),
     f = r.readAll();
 writeln(r.readBinary(a));
 writeln(a);
 
 // read part of the file, should return 'true':
 var b : [0..<4] uint(8);
-writeln(openreader("./readBinaryArrayInput.bin").readBinary(b));
+writeln(openReader("./readBinaryArrayInput.bin").readBinary(b));
 writeln(b);
 
 // read the whole file, should return 'true':
 var c : [0..<8] uint(8);
-writeln(openreader("./readBinaryArrayInput.bin").readBinary(c));
+writeln(openReader("./readBinaryArrayInput.bin").readBinary(c));
 writeln(c);
 
 // ask for more than 8 bytes, should throw:
 var d : [0..<10] uint(8);
 try {
-    openreader("./readBinaryArrayInput.bin").readBinary(d);
+    openReader("./readBinaryArrayInput.bin").readBinary(d);
 } catch e : UnexpectedEofError {
     writeln("caught: ", e);
 } catch {

--- a/test/deprecated/IO/readbytes.chpl
+++ b/test/deprecated/IO/readbytes.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var r = openreader("f.txt");
+var r = openReader("f.txt");
 var b = b"";
 r.readbytes(b);
 write(b);

--- a/test/deprecated/IO/readstring.chpl
+++ b/test/deprecated/IO/readstring.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var r = openreader("f.txt");
+var r = openReader("f.txt");
 var s = "";
 r.readstring(s);
 write(s);

--- a/test/deprecated/IO/seekHigh.chpl
+++ b/test/deprecated/IO/seekHigh.chpl
@@ -1,5 +1,5 @@
 use IO;
 
-var ch = openreader("seek.txt", locking=false);
+var ch = openReader("seek.txt", locking=false);
 ch.seek(3..8);
 writeln(ch.readLine());

--- a/test/library/draft/DistributedMap/v2/checkRead.chpl
+++ b/test/library/draft/DistributedMap/v2/checkRead.chpl
@@ -2,7 +2,7 @@ use DistributedMap, IO;
 
 var m = new distributedMap(int, int);
 
-var ch = openreader("checkRead.txt");
+var ch = openReader("checkRead.txt");
 ch.read(m);
 
 writeln(m.size); // Should be 4

--- a/test/library/draft/DistributedMap/v2/use-distributed-map.chpl
+++ b/test/library/draft/DistributedMap/v2/use-distributed-map.chpl
@@ -15,7 +15,7 @@ forall key in inputArr with
 
 // agg.flush(); // agg doesn't live outside the forall so can't flush here
 
-var ch = openwriter("mapOutput.txt");
+var ch = openWriter("mapOutput.txt");
 
 var first = true;
 for key in dm1.keys() { // won't be great perf but that's okay for now

--- a/test/library/packages/MatrixMarket/complexspwtst.chpl
+++ b/test/library/packages/MatrixMarket/complexspwtst.chpl
@@ -6,5 +6,5 @@ var o = mmreadsp(complex, filename);
 
 mmwrite("complextest.mtx", o);
 
-var r = openreader("complextest.mtx");
+var r = openReader("complextest.mtx");
 for l in r.lines() { writeln(l); }

--- a/test/library/packages/MatrixMarket/complextst.chpl
+++ b/test/library/packages/MatrixMarket/complextst.chpl
@@ -6,5 +6,5 @@ writeln(o);
 
 mmwrite("cmplx.mtx", o);
 
-var r = openreader("cmplx.mtx");
+var r = openReader("cmplx.mtx");
 for l in r.lines() { writeln(l); }

--- a/test/library/packages/MatrixMarket/mm-dense4x3-write.chpl
+++ b/test/library/packages/MatrixMarket/mm-dense4x3-write.chpl
@@ -23,7 +23,7 @@ writeln(A);
 
 mmwrite("dense-4x3-write.mtx", A);
 
-var r = openreader("dense-4x3-write.mtx");
+var r = openReader("dense-4x3-write.mtx");
 var lines = new list(string);
 var i=1;
 for l in r.lines() {

--- a/test/library/packages/TOML/BurntSushi/Passing.chpl
+++ b/test/library/packages/TOML/BurntSushi/Passing.chpl
@@ -9,11 +9,11 @@ use TOML, IO;
 config const f = 'bool.toml';
 
 proc main() {
-  var tomlChannel = openreader(f);
+  var tomlChannel = openReader(f);
   var tomlData = parseToml(tomlChannel);
 
   const j = f.replace('.toml', '.json.out');
-  var jsonChannel = openwriter(j);
+  var jsonChannel = openWriter(j);
 
   tomlData.writeJSON(jsonChannel);
 

--- a/test/library/packages/TOML/BurntSushi/TomlTest.chpl
+++ b/test/library/packages/TOML/BurntSushi/TomlTest.chpl
@@ -9,11 +9,11 @@ use TOML, IO;
 config const f = 'bool.toml';
 
 proc main() {
-  var tomlChannel = openreader(f);
+  var tomlChannel = openReader(f);
   var tomlData = parseToml(tomlChannel);
 
   const j = f.replace('.toml', '.json.out');
-  var jsonChannel = openwriter(j);
+  var jsonChannel = openWriter(j);
 
   tomlData.writeJSON(jsonChannel);
 

--- a/test/library/packages/TOML/specification/TomlTest.chpl
+++ b/test/library/packages/TOML/specification/TomlTest.chpl
@@ -10,7 +10,7 @@ use IO;
 config const f = 'example.good';
 
 proc main() {
-  var tomlChannel = openreader(f);
+  var tomlChannel = openReader(f);
   var tomlData = parseToml(tomlChannel);
   writeln(tomlData);
   tomlChannel.close();

--- a/test/library/packages/TOML/test/TomlTest.chpl
+++ b/test/library/packages/TOML/test/TomlTest.chpl
@@ -3,7 +3,7 @@ use IO, TOML;
 config const f: string;
 
 proc main() {
-  var tomlChannel = openreader(f);
+  var tomlChannel = openReader(f);
   var tomlData = parseToml(tomlChannel);
   writeln(tomlData);
   tomlChannel.close();

--- a/test/library/packages/TOML/test/UTomlTest.chpl
+++ b/test/library/packages/TOML/test/UTomlTest.chpl
@@ -3,7 +3,7 @@ use IO, TOML;
 config const f: string;
 
 proc main() {
-  var tomlChannel = openreader(f);
+  var tomlChannel = openReader(f);
   var tomlData = parseToml(tomlChannel);
   writeln("Before Mutation:", tomlData);
 

--- a/test/library/packages/TOML/test/arrayoftbl.chpl
+++ b/test/library/packages/TOML/test/arrayoftbl.chpl
@@ -3,7 +3,7 @@ use IO, TOML;
 config const f: string;
 
 proc main() {
-  var tomlChannel = openreader(f);
+  var tomlChannel = openReader(f);
   var tomlData = parseToml(tomlChannel);
   writeln(tomlData);
 

--- a/test/library/packages/TOML/test/quoteKeyPeriod.chpl
+++ b/test/library/packages/TOML/test/quoteKeyPeriod.chpl
@@ -3,7 +3,7 @@ use TOML;
 config const f: string;
 
 proc main() {
-  var tomlChannel = openreader(f);
+  var tomlChannel = openReader(f);
   var tomlData = parseToml(tomlChannel);
   writeln(tomlData);
 

--- a/test/library/packages/csv/CSVtest.chpl
+++ b/test/library/packages/csv/CSVtest.chpl
@@ -10,8 +10,8 @@ module CSVtest {
     try {
       // read and write using a tuple. The type arguments to `read` define
       // the types in each row.
-      var myReader = if infile == "" then stdin else openreader(infile);
-      var myWriter = if outfile == "" then stdout else openwriter(outfile);
+      var myReader = if infile == "" then stdin else openReader(infile);
+      var myWriter = if outfile == "" then stdout else openWriter(outfile);
       var r = new CSVIO(myReader, hasHeader=false);
       var w = new CSVIO(myWriter);
       var myData = r.read((...(4*real)), string);
@@ -32,8 +32,8 @@ module CSVtest {
         var seriesLabel: string;
       }
 
-      var myReader = if infile == "" then stdin else openreader(infile);
-      var myWriter = if outfile == "" then stdout else openwriter(outfile);
+      var myReader = if infile == "" then stdin else openReader(infile);
+      var myWriter = if outfile == "" then stdout else openWriter(outfile);
       var r = new CSVIO(myReader, hasHeader=false);
       var w = new CSVIO(myWriter);
 
@@ -50,8 +50,8 @@ module CSVtest {
     try {
       // read the data into tuples like before, then copy it
       // into a 2D array and 1D array of labels
-      var myReader = if infile == "" then stdin else openreader(infile);
-      var myWriter = if outfile == "" then stdout else openwriter(outfile);
+      var myReader = if infile == "" then stdin else openReader(infile);
+      var myWriter = if outfile == "" then stdout else openWriter(outfile);
       var r = new CSVIO(myReader, hasHeader=false);
       var w = new CSVIO(myWriter);
 
@@ -77,8 +77,8 @@ module CSVtest {
       // read and write using a tuple. The type arguments to `read` define
       // the types in each row.
       type t = ((...(4*real)), string);
-      var myReader = if infile == "" then stdin else openreader(infile);
-      var myWriter = if outfile == "" then stdout else openwriter(outfile);
+      var myReader = if infile == "" then stdin else openReader(infile);
+      var myWriter = if outfile == "" then stdout else openWriter(outfile);
       var r = new CSVIO(myReader, hasHeader=false);
       var w = new CSVIO(myWriter);
       var myData = r.read(t);

--- a/test/library/packages/csv/readStrings.chpl
+++ b/test/library/packages/csv/readStrings.chpl
@@ -2,7 +2,7 @@ use CSV, IO;
 
 config const filename = "strings.csv";
 
-var reader = openreader(filename);
+var reader = openReader(filename);
 var r = new CSVIO(reader, sep=" ");
 
 var A = r.read(string);

--- a/test/library/packages/csv/readStringsSkipHeader.chpl
+++ b/test/library/packages/csv/readStringsSkipHeader.chpl
@@ -2,7 +2,7 @@ use CSV, IO;
 
 config const filename = "strings.csv";
 
-var reader = openreader(filename);
+var reader = openReader(filename);
 var r = new CSVIO(reader, sep=" ", hasHeader=true);
 
 var A = r.read(string);

--- a/test/library/standard/IO/channel/lines.chpl
+++ b/test/library/standard/IO/channel/lines.chpl
@@ -3,7 +3,7 @@ use IO;
 config param locking=true,
              ioKind=iokind.dynamic;
 
-var c = openreader('lines.good', kind=ioKind, locking=locking);
+var c = openReader('lines.good', kind=ioKind, locking=locking);
 
 for line in c.lines() {
   write(line);

--- a/test/library/standard/IO/open/checkPermissions.chpl
+++ b/test/library/standard/IO/open/checkPermissions.chpl
@@ -2,7 +2,7 @@ use IO, OS.POSIX, FileSystem;
 
 var filename = "readOnly.txt";
 
-var w = openwriter(filename);
+var w = openWriter(filename);
 w.writeln("something");
 w.close();
 

--- a/test/library/standard/IO/openreader/checkFileNotFound.chpl
+++ b/test/library/standard/IO/openreader/checkFileNotFound.chpl
@@ -3,7 +3,7 @@ use OS.POSIX;
 
 var filename = "doesNotExist.txt";
 try {
-  var f = openreader(filename);
+  var f = openReader(filename);
   writeln("Uh oh, didn't trigger error");
 
 } catch e: FileNotFoundError {

--- a/test/library/standard/IO/openreader/checkNotADir.chpl
+++ b/test/library/standard/IO/openreader/checkNotADir.chpl
@@ -3,7 +3,7 @@ use IO, OS.POSIX;
 var filename = "secretlyNotADir/foo.txt";
 
 try {
-  var f = openreader(filename);
+  var f = openReader(filename);
   writeln("uh oh, no error");
 } catch e: NotADirectoryError {
   writeln(e.message());

--- a/test/library/standard/IO/openreader/checkPermissions.chpl
+++ b/test/library/standard/IO/openreader/checkPermissions.chpl
@@ -3,7 +3,7 @@ use IO, OS.POSIX, FileSystem;
 var filename = "writeOnly.txt";
 
 try {
-  var f = openreader(filename);
+  var f = openReader(filename);
   writeln("Uh oh, didn't trigger an error");
 } catch e: PermissionError {
   writeln(e.message());

--- a/test/library/standard/IO/openreaderBadRegion.chpl
+++ b/test/library/standard/IO/openreaderBadRegion.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 var filename = "openreaderLimited.txt";
-var readCh = openreader(filename, region=-5..);
+var readCh = openReader(filename, region=-5..);
 var readRes: string;
 readCh.readLine(readRes, stripNewline=true);
 writeln(readRes);

--- a/test/library/standard/IO/openreaderBadRegion2.chpl
+++ b/test/library/standard/IO/openreaderBadRegion2.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 var filename = "openreaderLimited.txt";
-var readCh = openreader(filename, region=3..0);
+var readCh = openReader(filename, region=3..0);
 var readRes: string;
 readCh.readLine(readRes, stripNewline=true);
 writeln(readRes);

--- a/test/library/standard/IO/openreaderLimited.chpl
+++ b/test/library/standard/IO/openreaderLimited.chpl
@@ -1,23 +1,23 @@
 use IO;
 
 var filename = "openreaderLimited.txt";
-var readCh = openreader(filename);
+var readCh = openReader(filename);
 var readRes: string;
 readCh.readLine(readRes, stripNewline=true);
 writeln(readRes);
 readCh.close();
 
-var readChStart = openreader(filename, region=3..);
+var readChStart = openReader(filename, region=3..);
 readChStart.readLine(readRes, stripNewline=true);
 writeln(readRes);
 readChStart.close();
 
-var readChEnd = openreader(filename, region=..4);
+var readChEnd = openReader(filename, region=..4);
 readChEnd.readLine(readRes);
 writeln(readRes);
 readChEnd.close();
 
-var readChStartAndEnd = openreader(filename, region=3..4);
+var readChStartAndEnd = openReader(filename, region=3..4);
 readChStartAndEnd.readLine(readRes);
 writeln(readRes);
 readChStartAndEnd.close();

--- a/test/library/standard/IO/openwriter/checkFileNotFound.chpl
+++ b/test/library/standard/IO/openwriter/checkFileNotFound.chpl
@@ -3,7 +3,7 @@ use OS.POSIX;
 
 var filename = "doesNotExistDir/doesNotExist.txt";
 try {
-  var f = openwriter(filename);
+  var f = openWriter(filename);
   writeln("Uh oh, didn't trigger error");
 
 } catch e: FileNotFoundError {

--- a/test/library/standard/IO/openwriter/checkNotADir.chpl
+++ b/test/library/standard/IO/openwriter/checkNotADir.chpl
@@ -3,7 +3,7 @@ use IO, OS.POSIX;
 var filename = "secretlyNotADir/foo.txt";
 
 try {
-  var f = openwriter(filename);
+  var f = openWriter(filename);
   writeln("uh oh, no error");
 } catch e: NotADirectoryError {
   writeln(e.message());

--- a/test/library/standard/IO/openwriter/checkPermissions.chpl
+++ b/test/library/standard/IO/openwriter/checkPermissions.chpl
@@ -2,14 +2,14 @@ use IO, OS.POSIX, FileSystem;
 
 var filename = "readOnly.txt";
 
-var w = openwriter(filename);
+var w = openWriter(filename);
 w.writeln("something");
 w.close();
 
 chmod(filename.c_str(), 0o0400: mode_t); // set it to read only now that it has contents
 
 try {
-  var f = openwriter(filename);
+  var f = openWriter(filename);
   writeln("Uh oh, didn't trigger an error");
 } catch e: PermissionError {
   writeln(e.message());

--- a/test/library/standard/IO/readAll/readBytes.chpl
+++ b/test/library/standard/IO/readAll/readBytes.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 // the entire channel is read, and the number of bytes is counted correctly:
-var ch = openreader("./jab.txt");
+var ch = openReader("./jab.txt");
 var b = b"yep\n";
 const num_b = ch.readAll(b);
 

--- a/test/library/standard/IO/readAll/readBytesArray.chpl
+++ b/test/library/standard/IO/readAll/readBytesArray.chpl
@@ -3,7 +3,7 @@ use CTypes;
 
 // the correct unsigned bytes are read:
 var a_unsigned : [0..<1032] uint(8);
-var ch = openreader("./jab.txt");
+var ch = openReader("./jab.txt");
 const num_b_us = ch.readAll(a_unsigned);
 ch.close();
 
@@ -12,7 +12,7 @@ writeBytesArray(a_unsigned, num_b_us);
 
 // the correct signed bytes are read:
 var a_signed: [0..<1032] int(8);
-ch = openreader("./jab.txt");
+ch = openReader("./jab.txt");
 const num_b_s = ch.readAll(a_signed);
 ch.close();
 

--- a/test/library/standard/IO/readAll/readBytesArrayInsufficientCapacity.chpl
+++ b/test/library/standard/IO/readAll/readBytesArrayInsufficientCapacity.chpl
@@ -27,5 +27,5 @@ proc testInsuffCapError(ch: fileReader) {
     writeln(s_from_array + s_remaining);
 }
 
-testInsuffCapError(openreader("./jab.txt"));
-testInsuffCapError(openreader("./jab.txt", region=..1032));
+testInsuffCapError(openReader("./jab.txt"));
+testInsuffCapError(openReader("./jab.txt", region=..1032));

--- a/test/library/standard/IO/readAll/readBytesArrayLeaveExcessAlone.chpl
+++ b/test/library/standard/IO/readAll/readBytesArrayLeaveExcessAlone.chpl
@@ -5,7 +5,7 @@ const NUMBYTES = 1032;
 
 // array is larger than necessary to fit the whole file...
 var a : [0..<1100] uint(8) = 0;
-var ch = openreader("./jab.txt");
+var ch = openReader("./jab.txt");
 const num_b = ch.readAll(a);
 ch.close();
 

--- a/test/library/standard/IO/readAll/readBytesType.chpl
+++ b/test/library/standard/IO/readAll/readBytesType.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var ch = openreader("./jab.txt");
+var ch = openReader("./jab.txt");
 const b = ch.readAll(bytes);
 ch.close();
 

--- a/test/library/standard/IO/readAll/readRemainingBytes.chpl
+++ b/test/library/standard/IO/readAll/readRemainingBytes.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 // readAll can pick up where other byte-reader methods left off:
-var ch = openreader("./jab.txt");
+var ch = openReader("./jab.txt");
 const line1 = ch.readLine(bytes);
 const line2 = ch.readLine(bytes);
 const remaining = ch.readAll(bytes);

--- a/test/library/standard/IO/readAll/readRemainingString.chpl
+++ b/test/library/standard/IO/readAll/readRemainingString.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 // readAll can pick up where other string-reader methods left off:
-var ch = openreader("./jab.txt");
+var ch = openReader("./jab.txt");
 const line1 = ch.readLine(string);
 const line2 = ch.readLine(string);
 const remaining = ch.readAll(string);

--- a/test/library/standard/IO/readAll/readString.chpl
+++ b/test/library/standard/IO/readAll/readString.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 // the entire channel is read, and the number of code-points is counted correctly:
-var ch = openreader("./jab.txt");
+var ch = openReader("./jab.txt");
 var s = "yep\n";
 const num_cp = ch.readAll(s);
 

--- a/test/library/standard/IO/readAll/readStringType.chpl
+++ b/test/library/standard/IO/readAll/readStringType.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var ch = openreader("./jab.txt");
+var ch = openReader("./jab.txt");
 const s = ch.readAll(string);
 ch.close();
 

--- a/test/library/standard/IO/readBinary/arrayOfValues.chpl
+++ b/test/library/standard/IO/readBinary/arrayOfValues.chpl
@@ -24,7 +24,7 @@ testBinaryRead("./input/ti32le.bin", makeSignedArray(32), ioendian.little);
 testBinaryRead("./input/ti64le.bin", makeSignedArray(64), ioendian.little);
 
 proc testBinaryRead(path: string, expected_values, endian: ioendian = ioendian.native) {
-    var reader = openreader(path);
+    var reader = openReader(path);
     var values : expected_values.type;
 
     try {

--- a/test/library/standard/IO/readBinary/arrayReadSome.chpl
+++ b/test/library/standard/IO/readBinary/arrayReadSome.chpl
@@ -2,7 +2,7 @@
 
 use IO;
 
-var r = openreader("./input/tu8.bin");
+var r = openReader("./input/tu8.bin");
 
 var partial: [0..#3] uint(8),
     larger: [0..#10] uint(8) = 1,

--- a/test/library/standard/IO/readBinary/multiloc/binaryArray.chpl
+++ b/test/library/standard/IO/readBinary/multiloc/binaryArray.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 on Locales[0] {
-    var reader = openreader("../input/tu8.bin");
+    var reader = openReader("../input/tu8.bin");
 
     on Locales[1] {
         const a_expected = [1, 2, 4, 8, 16, 32, 64, 128] : uint(8);

--- a/test/library/standard/IO/readBinary/multiloc/binaryBytes.chpl
+++ b/test/library/standard/IO/readBinary/multiloc/binaryBytes.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 on Locales[0] {
-    var reader = openreader("./input.bin");
+    var reader = openReader("./input.bin");
 
     on Locales[1] {
         var b: bytes = createBytesWithNewBuffer(b"");

--- a/test/library/standard/IO/readBinary/multiloc/binaryString.chpl
+++ b/test/library/standard/IO/readBinary/multiloc/binaryString.chpl
@@ -1,7 +1,7 @@
 use IO;
 
 on Locales[0] {
-    var reader = openreader("./input.bin");
+    var reader = openReader("./input.bin");
 
     on Locales[1] {
         var s: string = createStringWithNewBuffer("");

--- a/test/library/standard/IO/readBinary/read_c_ptr.chpl
+++ b/test/library/standard/IO/readBinary/read_c_ptr.chpl
@@ -1,10 +1,10 @@
 use IO;
 use CTypes;
 
-readCptrTest(openreader("./c_ptr_input/cptr8.bin"), 8);
-readCptrTest(openreader("./c_ptr_input/cptr16.bin"), 16);
-readCptrTest(openreader("./c_ptr_input/cptr32.bin"), 32);
-readCptrTest(openreader("./c_ptr_input/cptr64.bin"), 64);
+readCptrTest(openReader("./c_ptr_input/cptr8.bin"), 8);
+readCptrTest(openReader("./c_ptr_input/cptr16.bin"), 16);
+readCptrTest(openReader("./c_ptr_input/cptr32.bin"), 32);
+readCptrTest(openReader("./c_ptr_input/cptr64.bin"), 64);
 
 // read 0..9 from the given file, expecting the given integer size,
 //  and ensure that the correct values were read
@@ -18,10 +18,10 @@ proc readCptrTest(reader, param isize: int) {
 }
 
 
-readCptrTestTooMany(openreader("./c_ptr_input/cptr8.bin"), 8);
-readCptrTestTooMany(openreader("./c_ptr_input/cptr16.bin"), 16);
-readCptrTestTooMany(openreader("./c_ptr_input/cptr32.bin"), 32);
-readCptrTestTooMany(openreader("./c_ptr_input/cptr64.bin"), 64);
+readCptrTestTooMany(openReader("./c_ptr_input/cptr8.bin"), 8);
+readCptrTestTooMany(openReader("./c_ptr_input/cptr16.bin"), 16);
+readCptrTestTooMany(openReader("./c_ptr_input/cptr32.bin"), 32);
+readCptrTestTooMany(openReader("./c_ptr_input/cptr64.bin"), 64);
 
 // try expecting a larger number of values than are present in the file.
 //  ensure that the first 10 values were read correctly, and that 'num_read' is correct

--- a/test/library/standard/IO/readBinary/read_c_void_ptr.chpl
+++ b/test/library/standard/IO/readBinary/read_c_void_ptr.chpl
@@ -1,10 +1,10 @@
 use IO;
 use CTypes;
 
-readCptrTest(openreader("./c_ptr_input/cptr8.bin"), 8);
-readCptrTest(openreader("./c_ptr_input/cptr16.bin"), 16);
-readCptrTest(openreader("./c_ptr_input/cptr32.bin"), 32);
-readCptrTest(openreader("./c_ptr_input/cptr64.bin"), 64);
+readCptrTest(openReader("./c_ptr_input/cptr8.bin"), 8);
+readCptrTest(openReader("./c_ptr_input/cptr16.bin"), 16);
+readCptrTest(openReader("./c_ptr_input/cptr32.bin"), 32);
+readCptrTest(openReader("./c_ptr_input/cptr64.bin"), 64);
 
 // read 0..9 from the given file, expecting the given integer size,
 //  and ensure that the correct values were read
@@ -18,10 +18,10 @@ proc readCptrTest(reader, param isize: int) {
     c_free(cm);
 }
 
-readCptrTestTooMany(openreader("./c_ptr_input/cptr8.bin"), 8);
-readCptrTestTooMany(openreader("./c_ptr_input/cptr16.bin"), 16);
-readCptrTestTooMany(openreader("./c_ptr_input/cptr32.bin"), 32);
-readCptrTestTooMany(openreader("./c_ptr_input/cptr64.bin"), 64);
+readCptrTestTooMany(openReader("./c_ptr_input/cptr8.bin"), 8);
+readCptrTestTooMany(openReader("./c_ptr_input/cptr16.bin"), 16);
+readCptrTestTooMany(openReader("./c_ptr_input/cptr32.bin"), 32);
+readCptrTestTooMany(openReader("./c_ptr_input/cptr64.bin"), 64);
 
 // try expecting a larger number of values than are present in the file.
 //  ensure that the first 10 values were read correctly, and that 'num_read' is correct

--- a/test/library/standard/IO/readStringAndBytes/readBytes.chpl
+++ b/test/library/standard/IO/readStringAndBytes/readBytes.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = openreader("./inputData.txt");
+var f = openReader("./inputData.txt");
 
 // check that both interfaces work:
 const first_line = f.readBytes(23);

--- a/test/library/standard/IO/readStringAndBytes/readString.chpl
+++ b/test/library/standard/IO/readStringAndBytes/readString.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var f = openreader("./inputData.txt");
+var f = openReader("./inputData.txt");
 
 // check that both interfaces work:
 const first_line = f.readString(23);

--- a/test/library/standard/IO/seekLowerBound.chpl
+++ b/test/library/standard/IO/seekLowerBound.chpl
@@ -1,4 +1,4 @@
 use IO;
 
-var ch = openreader("openreaderLimited.txt", locking=false);
+var ch = openReader("openreaderLimited.txt", locking=false);
 ch.seek(..15);

--- a/test/library/standard/IO/seekUpperBound.chpl
+++ b/test/library/standard/IO/seekUpperBound.chpl
@@ -1,5 +1,5 @@
 use IO;
 
-var ch = openreader("seek.txt", locking=false);
+var ch = openReader("seek.txt", locking=false);
 ch.seek(3..8);
 writeln(ch.readLine());  // Should include the space after "mi"

--- a/test/library/standard/IO/writeBinary/writeArray.chpl
+++ b/test/library/standard/IO/writeBinary/writeArray.chpl
@@ -21,7 +21,7 @@ testBinaryWrite("I64_LE", makeSignedArray(64), ioendian.little);
 
 
 proc testBinaryWrite(testName, values, endian: ioendian = ioendian.native) {
-    var w = openwriter(testName + ".bin");
+    var w = openWriter(testName + ".bin");
     w.writeBinary(values, endian);
 }
 

--- a/test/library/standard/IO/writeBinary/write_c_ptr.chpl
+++ b/test/library/standard/IO/writeBinary/write_c_ptr.chpl
@@ -1,10 +1,10 @@
 use IO;
 use CTypes;
 
-testCptrToArray(openwriter("./c_ptr_out/cptr8.bin"), 8);
-testCptrToArray(openwriter("./c_ptr_out/cptr16.bin"), 16);
-testCptrToArray(openwriter("./c_ptr_out/cptr32.bin"), 32);
-testCptrToArray(openwriter("./c_ptr_out/cptr64.bin"), 64);
+testCptrToArray(openWriter("./c_ptr_out/cptr8.bin"), 8);
+testCptrToArray(openWriter("./c_ptr_out/cptr16.bin"), 16);
+testCptrToArray(openWriter("./c_ptr_out/cptr32.bin"), 32);
+testCptrToArray(openWriter("./c_ptr_out/cptr64.bin"), 64);
 
 proc testCptrToArray(writer, param isize: int) {
     var a = [0,1,2,3,4,5,6,7,8,9] : uint(isize);

--- a/test/library/standard/IO/writeBinary/write_c_void_ptr.chpl
+++ b/test/library/standard/IO/writeBinary/write_c_void_ptr.chpl
@@ -1,10 +1,10 @@
 use IO;
 use CTypes;
 
-testCptrToArray(openwriter("./c_ptr_out/cvoidptr8.bin"), 8);
-testCptrToArray(openwriter("./c_ptr_out/cvoidptr16.bin"), 16);
-testCptrToArray(openwriter("./c_ptr_out/cvoidptr32.bin"), 32);
-testCptrToArray(openwriter("./c_ptr_out/cvoidptr64.bin"), 64);
+testCptrToArray(openWriter("./c_ptr_out/cvoidptr8.bin"), 8);
+testCptrToArray(openWriter("./c_ptr_out/cvoidptr16.bin"), 16);
+testCptrToArray(openWriter("./c_ptr_out/cvoidptr32.bin"), 32);
+testCptrToArray(openWriter("./c_ptr_out/cvoidptr64.bin"), 64);
 
 proc testCptrToArray(writer, param isize: int) {
     var a = [0,1,2,3,4,5,6,7,8,9] : uint(isize);

--- a/test/library/standard/IO/writeStringAndBytes/writeBytes.chpl
+++ b/test/library/standard/IO/writeStringAndBytes/writeBytes.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var w = openwriter("bfile.txt");
+var w = openWriter("bfile.txt");
 var b = b"negates itself when prepended to itself \xE2\xAC\x85\xEf\xB8\x8F negates itself when prepended to itself";
 
 // default size:

--- a/test/library/standard/IO/writeStringAndBytes/writeString.chpl
+++ b/test/library/standard/IO/writeStringAndBytes/writeString.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var w = openwriter("sfile.txt");
+var w = openWriter("sfile.txt");
 var s = "negates itself when prepended to itself ⬅️ negates itself when prepended to itself";
 
 // default size:

--- a/test/mason/chplVersion/mason-chpl-version-new.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-new.chpl
@@ -12,7 +12,7 @@ proc main() {
   masonNew(args);
 
   assert(isDir("newTest") == true);
-  const fr = openreader("newTest/Mason.toml");
+  const fr = openReader("newTest/Mason.toml");
   for line in fr.lines() do write(line);
   fr.close();
 

--- a/test/mason/chplVersion/mason-chpl-version-update.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-update.chpl
@@ -15,7 +15,7 @@ proc main() {
   if exists("Mason.lock") {
     writeln("----- lock file -----");
 
-    const fr = openreader("Mason.lock");
+    const fr = openReader("Mason.lock");
     for line in fr.lines() {
       write(line);
     }

--- a/test/mason/mason-update-toml-error/mason-chpl-version-update.chpl
+++ b/test/mason/mason-update-toml-error/mason-chpl-version-update.chpl
@@ -14,7 +14,7 @@ proc main() {
   if exists("Mason.lock") {
     writeln("----- lock file -----");
 
-    const fr = openreader("Mason.lock");
+    const fr = openReader("Mason.lock");
     for line in fr.lines() {
       write(line);
     }

--- a/test/mason/masonUpdateTest.chpl
+++ b/test/mason/masonUpdateTest.chpl
@@ -21,7 +21,7 @@ proc main() {
   var temp = open(lf, ioMode.cw);
   {
     var w = temp.writer();
-    for line in openreader(goodLock).lines() do
+    for line in openReader(goodLock).lines() do
       w.write(line.replace('CHPL_CUR_FULL', currentVersion));
     w.close();
   }

--- a/test/mason/pkgconfig-tests/pcTest.chpl
+++ b/test/mason/pkgconfig-tests/pcTest.chpl
@@ -17,7 +17,7 @@ proc test(goodLock: string, tf: string) {
   var temp = open(lf, ioMode.cw);
   {
     var w = temp.writer();
-    for line in openreader(goodLock).lines() do
+    for line in openReader(goodLock).lines() do
       w.write(line.replace('CHPL_CUR_FULL', currentVersion));
     w.close();
   }

--- a/test/regex/ferguson/bug-16891.chpl
+++ b/test/regex/ferguson/bug-16891.chpl
@@ -3,7 +3,7 @@ use IO.FormattedIO;
 
 config const useRegex=false;
 
-var ff=openreader("bug-16891.txt");
+var ff=openReader("bug-16891.txt");
 var got=true;
 var ss : string;
 while (got) {

--- a/test/regex/ferguson/readfinf.chpl
+++ b/test/regex/ferguson/readfinf.chpl
@@ -3,7 +3,7 @@
 
 use Regex, IO;
 
-var ch = openreader("readfinf.chpl");
+var ch = openReader("readfinf.chpl");
 
 for i in 1..4 {
   const ok = ch.readf("%//");

--- a/test/release/examples/primers/specialMethods.chpl
+++ b/test/release/examples/primers/specialMethods.chpl
@@ -184,13 +184,13 @@ proc R.readThis(ch: fileReader) throws {
 }
 
 {
-  var chW = openwriter(filename);
+  var chW = openWriter(filename);
   chW.writeln(r);
   chW.flush();
 
   writeln(r);
   var r2 = new R();
-  var chR = openreader(filename);
+  var chR = openReader(filename);
   chR.readln(r2);
   assert(r == r2);
 }

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -255,7 +255,7 @@ proc process_json(fname: string, ref Pairs)
     var sub = spawn(["gunzip", "-c", fname], stdout=pipeStyle.pipe);
     process_json(sub.stdout, fname, Pairs);
   } else {
-    var logfile = openreader(fname);
+    var logfile = openReader(fname);
     process_json(logfile, fname, Pairs);
   }
 }

--- a/test/unstable/iostyle/openReaderWriter.chpl
+++ b/test/unstable/iostyle/openReaderWriter.chpl
@@ -2,7 +2,7 @@ use IO;
 
 var filename = "blah3.txt";
 var style = defaultIOStyleInternal();
-var chW = openwriter(filename, style=style);
+var chW = openWriter(filename, style=style);
 chW.close();
-var chR = openreader(filename, style=style);
+var chR = openReader(filename, style=style);
 chR.close();

--- a/test/unstable/iostyle/openReaderWriter.good
+++ b/test/unstable/iostyle/openReaderWriter.good
@@ -1,2 +1,2 @@
-openReaderWriter.chpl:5: warning: openwriter with a style argument is unstable
-openReaderWriter.chpl:7: warning: openreader with a style argument is unstable
+openReaderWriter.chpl:5: warning: openWriter with a style argument is unstable
+openReaderWriter.chpl:7: warning: openReader with a style argument is unstable

--- a/test/users/npadmana/bugs/null_in_formattedio/bug.chpl
+++ b/test/users/npadmana/bugs/null_in_formattedio/bug.chpl
@@ -1,6 +1,6 @@
 use IO;
 
-var ff = openwriter("test.dat");
+var ff = openWriter("test.dat");
 var m,x,y,z,vx,vy,vz : real;
 m=0;
 x=0;y=0;z=0;

--- a/test/users/npadmana/twopt/do_smu_aos.chpl
+++ b/test/users/npadmana/twopt/do_smu_aos.chpl
@@ -54,7 +54,7 @@ proc generateRandom(pp : []WeightedParticle3D) {
 
 
 proc countLines(fn : string) : int {
-  var fr = openreader(fn);
+  var fr = openReader(fn);
   var ipart = 0;
   for iff in fr.lines() do ipart +=1;
   fr.close();
@@ -64,7 +64,7 @@ proc countLines(fn : string) : int {
 proc readFile(fn : string, pp : []WeightedParticle3D)  {
   const maxcols=25;
 
-  var fr = openreader(fn);
+  var fr = openReader(fn);
   var cols : [1.. #maxcols] real;
   var icol=1;
   var ipart = 0;
@@ -298,7 +298,7 @@ proc doPairs() {
     smuAccumulate(hh, soa1,soa2, soa1.Dpart, soa2.Dpart, 1.0);
     tt.stop();
     writef("Time to brute force paircount : %r \n", tt.elapsed());
-    var ff1 = openwriter("%s.brute".format(pairfn));
+    var ff1 = openWriter("%s.brute".format(pairfn));
     writeHist(ff1,hh);
     ff1.close();
   }
@@ -312,7 +312,7 @@ proc doPairs() {
   if (!isTest) {
     writef("Time to tree paircount : %r \n", tt.elapsed());
     if !isPerf {
-      var ff = openwriter("%s.tree".format(pairfn));
+      var ff = openWriter("%s.tree".format(pairfn));
       writeHist(ff,hh);
       ff.close();
     }

--- a/test/users/npadmana/twopt/do_smu_soa-error.chpl
+++ b/test/users/npadmana/twopt/do_smu_soa-error.chpl
@@ -114,7 +114,7 @@ class Particle3D {
 
 
 proc countLines(fn : string) : int {
-  var fr = openreader(fn);
+  var fr = openReader(fn);
   var ipart = 0;
   for iff in fr.lines() do ipart +=1;
   fr.close();
@@ -125,7 +125,7 @@ proc readFile(fn : string) : owned Particle3D  {
   var npart = countLines(fn);
   var pp = new owned Particle3D(npart);
 
-  var ff = openreader(fn);
+  var ff = openReader(fn);
   var ipart = 0;
   var x,y,z,w,r2 : real;
   while (ff.read(x,y,z,w)) {
@@ -346,7 +346,7 @@ proc initialPP12() {
   if (!isTest) {
     writef("Time to tree paircount : %r \n", tt.elapsed());
     if !isPerf {
-      var ff = openwriter("%s.tree".format(pairfn));
+      var ff = openWriter("%s.tree".format(pairfn));
       writeHist(ff,hh);
       ff.close();
     }

--- a/test/users/npadmana/twopt/do_smu_soa.chpl
+++ b/test/users/npadmana/twopt/do_smu_soa.chpl
@@ -114,7 +114,7 @@ class Particle3D {
 
 
 proc countLines(fn : string) : int {
-  var fr = openreader(fn);
+  var fr = openReader(fn);
   var ipart = 0;
   for iff in fr.lines() do ipart +=1;
   fr.close();
@@ -125,7 +125,7 @@ proc readFile(fn : string) : owned Particle3D  {
   var npart = countLines(fn);
   var pp = new owned Particle3D(npart);
 
-  var ff = openreader(fn);
+  var ff = openReader(fn);
   var ipart = 0;
   var x,y,z,w,r2 : real;
   while (ff.read(x,y,z,w)) {
@@ -344,7 +344,7 @@ proc initialPP(fn) {
   if (!isTest) {
     writef("Time to tree paircount : %r \n", tt.elapsed());
     if !isPerf {
-      var ff = openwriter("%s.tree".format(pairfn));
+      var ff = openWriter("%s.tree".format(pairfn));
       writeHist(ff,hh);
       ff.close();
     }

--- a/test/visibility/only/weirdWritefInteraction.chpl
+++ b/test/visibility/only/weirdWritefInteraction.chpl
@@ -11,7 +11,7 @@ proc main()
     var a = (new owned Mytype()).borrow();
     writeln( a );
 
-    var file = openwriter( "test.dat" );
+    var file = openWriter( "test.dat" );
 
     file.writef( "%10.3dr\n", 1.23 );
     // file.writeln( 1.23 );

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -64,7 +64,7 @@ proc modifyToml(add: bool, spec: string, external: bool, system: bool,
                 skipCheck: bool, projectHome: string, tf="Mason.toml") throws {
 
   const tomlPath = '/'.join(projectHome, tf);
-  const openFile = openreader(tomlPath);
+  const openFile = openReader(tomlPath);
   const toml = parseToml(openFile);
   var newToml: shared Toml?;
 

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -149,7 +149,7 @@ proc printPkgPc(args) throws {
       //
       var pcDir = "".join(getPkgVariable(pkgName, "--variable=pcfiledir").these()).strip();
       var pcFile = joinPath(pcDir, pkgName + ".pc");
-      var pc = openreader(pcFile);
+      var pc = openReader(pcFile);
       writeln("\n------- " + pkgName + ".pc -------\n");
       for line in pc.lines() {
         write(line);

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -74,7 +74,7 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock", show=true) {
     const projectHome = getProjectHome(cwd, tf);
     const tomlPath = projectHome + "/" + Path.relPath(tf);
     const lockPath = projectHome + "/" + Path.relPath(lf);
-    const openFile = openreader(tomlPath);
+    const openFile = openReader(tomlPath);
     const TomlFile = parseToml(openFile);
     var updated = false;
     if isFile(tomlPath) {

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -568,7 +568,7 @@ proc getDepToml(depName: string, depVersion: string) throws {
 
   if results.size > 0 {
     const brickPath = '/'.join(registries[0], 'Bricks', packages[0], versions[0]) + '.toml';
-    const openFile = openreader(brickPath);
+    const openFile = openReader(brickPath);
     const toml = parseToml(openFile);
 
     return toml;
@@ -598,7 +598,7 @@ proc findLatest(packageDir: string): VersionInfo {
     // Skip packages that are out of version bounds
     const chplVersion = getChapelVersionInfo();
 
-    const manifestReader = openreader(packageDir + '/' + manifest);
+    const manifestReader = openReader(packageDir + '/' + manifest);
     const manifestToml = parseToml(manifestReader);
     const brick = manifestToml['brick'];
     var (low, high) = parseChplVersion(brick);
@@ -722,7 +722,7 @@ proc splitNameVersion(ref package: string, original: bool) {
 
 /* Print a TOML file. Expects full path. */
 proc showToml(tomlFile : string) {
-  const openFile = openreader(tomlFile);
+  const openFile = openReader(tomlFile);
   const toml = parseToml(openFile);
   writeln(toml);
   openFile.close();


### PR DESCRIPTION
Based on discussion in #20150, renames `proc openreader` to `proc openReader` and `proc openwriter` to `proc openWriter`.

# Summary of changes
- deprecate openreader, new function signature is
```chapel
proc openReader(path:string,
                param kind=iokind.dynamic, param locking=true,
                region: range(?) = 0.., hints=ioHintSet.empty)
    : fileReader(kind, locking) throws
```
- deprecate openwriter, new function signature is
```chapel
proc openWriter(path:string,
                param kind=iokind.dynamic, param locking=true,
                hints = ioHintSet.empty)
    : fileWriter(kind, locking) throws
```
- change existing modules/tests using old names to new names

> **NOTE: ** the original issue for this mentioned explicitly checking for the case that `region.low < 0`. This is already implemented in the internal helper methods which `openReader` and `openWriter` both call.

# New Tests
- new deprecation test for openreader/openwriter

# Testing 
- full paratest
- built docs and check formatting

# Closes
closes #20150 
closes cray/chapel-private#4420