### PR TITLE
Flip boolean logic in code that caches LLVM function types

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1206,7 +1206,7 @@ chapelFunctionTypeToLlvmFunctionType;
 
 bool llvmMapUnderlyingFunctionType(FunctionType* k, llvm::FunctionType* v) {
   auto it = chapelFunctionTypeToLlvmFunctionType.find(k);
-  if (it == chapelFunctionTypeToLlvmFunctionType.end()) return false;
+  if (it != chapelFunctionTypeToLlvmFunctionType.end()) return false;
   chapelFunctionTypeToLlvmFunctionType.emplace_hint(it, k, v);
   return true;
 }

--- a/test/functions/fcf/pointers/SKIPIF
+++ b/test/functions/fcf/pointers/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_LLVM == none


### PR DESCRIPTION
Fix an internal assertion in codegen for function types introduced by
#20991 by fixing a bug in a helper function that maps LLVM function
types to their Chapel equivalents.

Add a skipif to a FCF subdirectory intended to test the new pointer
implementation (under development).

Reviewed by @benharsh. Thanks!