### PR TITLE
Improve post-parse checks for generic array types

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -125,7 +125,7 @@ struct Visitor {
   void checkLambdaReturnIntent(const Function* node);
   void checkProcTypeFormalsAreAnnotated(const FunctionSignature* node);
   void checkProcDefFormalsAreNamed(const Function* node);
-  void checkForUnadornedArrayType(const BracketLoop* node);
+  void checkGenericArrayTypeUsage(const BracketLoop* node);
   void checkVisibilityClauseValid(const AstNode* parentNode,
                                   const VisibilityClause* clause);
 
@@ -813,28 +813,48 @@ void Visitor::checkProcDefFormalsAreNamed(const Function* node) {
   }
 }
 
-static bool isUnadornedArrayType(const BracketLoop* node) {
-  auto block = node->body();
-  if (block->numStmts() != 0) return false;
+// While normally, a particular bracket loop could be either a runnable
+// loop or an array type (and we won't know until we have type info), in
+// this particular case the expression '[]' can only appear in array types.
+static bool isBracketLoopDomainExpressionEmpty(const BracketLoop* node) {
   auto dom = node->iterand()->toDomain();
   if (!dom || dom->numExprs() != 0) return false;
   if (dom->usedCurlyBraces()) return false;
   return true;
 }
 
+static bool isBracketLoopBodyEmpty(const BracketLoop* node) {
+  auto block = node->body();
+  return block->numStmts() == 0;
+}
+
 // TODO: Might need to do some more fine-grained pattern matching.
-void Visitor::checkForUnadornedArrayType(const BracketLoop* node) {
+void Visitor::checkGenericArrayTypeUsage(const BracketLoop* node) {
   if (!parent(0)) return;
 
-  if (!isUnadornedArrayType(node)) return;
+  // TODO: These are treated the same right now, but in the future we might
+  // like to allow things like '[]' in type expressions, while
+  // default initialized variables such as 'var x: [] bytes;' would need
+  // a domain expression. 
+  bool isDomainEmpty = isBracketLoopDomainExpressionEmpty(node);
+  bool isBodyEmpty = isBracketLoopBodyEmpty(node); 
+
+  // Expression is fully adorned, so nothing to do.
+  if (!isDomainEmpty && !isBodyEmpty) return;
 
   bool doEmitError = true;
   const AstNode* last = nullptr;
   auto decl = searchParentsForDecl(node, &last);
+  bool isInTypeExpression = false;
+  bool isField = false;
 
   // Formal type expression is OK.
-  if (auto formal = decl->toFormal()) {
-    if (last == formal->typeExpression()) doEmitError = false;
+  if (auto varLike = decl->toVarLikeDecl()) {
+    if (auto var = varLike->toVariable()) isField = var->isField();
+    if (last == varLike->typeExpression()) {
+      isInTypeExpression = true;
+      doEmitError = !varLike->isFormal();
+    }
   }
 
   // Function return type is OK.
@@ -848,7 +868,12 @@ void Visitor::checkForUnadornedArrayType(const BracketLoop* node) {
   }
 
   if (doEmitError) {
-    error(node, "generic array types are unsupported in this context");
+    if (isInTypeExpression) {
+      auto str = isField ? "fields" : "variables";
+      error(node, "%s cannot specify generic array types", str);
+    } else {
+      error(node, "generic array types are unsupported in this context");
+    }
   }
 }
 
@@ -1062,7 +1087,7 @@ void Visitor::visit(const Array* node) {
 }
 
 void Visitor::visit(const BracketLoop* node) {
-  checkForUnadornedArrayType(node);
+  checkGenericArrayTypeUsage(node);
 }
   
 void Visitor::visit(const FnCall* node) {

--- a/frontend/test/parsing/testParseChecks.cpp
+++ b/frontend/test/parsing/testParseChecks.cpp
@@ -553,7 +553,38 @@ static void test17(void) {
   guard.clearErrors();
 }
 
+// Limit where empty '[]' domain type expressions can appear.
+static void test18(void) {
+  Context context;
+  Context* ctx = &context;
+  ErrorGuard guard(ctx);
+  std::string text =
+    R""""(
+      var w: [] bytes;
+      var x: [] int, y, z: [] real;
+      record r { var x: [] string; }
+      type T = [] string;
+    )"""";
 
+  auto path = UniqueString::get(ctx, "test18.chpl");
+  setFileText(ctx, path, text);
+
+  parseFileToBuilderResultAndCheck(ctx, path, UniqueString());
+
+  assert(guard.numErrors() == 5);
+  displayErrors(ctx, guard);
+  assertErrorMatches(ctx, guard, 0, "test18.chpl", 2,
+                     "variables cannot specify generic array types");
+  assertErrorMatches(ctx, guard, 1, "test18.chpl", 3,
+                     "variables cannot specify generic array types");
+  assertErrorMatches(ctx, guard, 2, "test18.chpl", 3,
+                     "variables cannot specify generic array types");
+  assertErrorMatches(ctx, guard, 3, "test18.chpl", 4,
+                     "fields cannot specify generic array types");
+  assertErrorMatches(ctx, guard, 4, "test18.chpl", 5,
+                     "generic array types are unsupported in this context");
+  assert(guard.realizeErrors());
+}
 
 int main() {
   test0();
@@ -574,6 +605,7 @@ int main() {
   test15();
   test16();
   test17();
+  test18();
 
   return 0;
 }

--- a/test/parsing/issue-21710.chpl
+++ b/test/parsing/issue-21710.chpl
@@ -1,0 +1,24 @@
+module my_freader {
+use IO;
+    class P {
+            var size: int = 0;
+            var buffer : [] bytes;
+
+            proc init() {
+                    var f = open("freader.chpl",ioMode.r);
+                    var ch = f.reader();
+
+                    size = f.size;
+                    buffer = new bytes[size];
+
+                    ch.read( buffer, size );
+
+                    writeln( buffer:string, size );
+            }
+
+    }
+
+    proc main() {
+            var p: P;
+    }
+}

--- a/test/parsing/issue-21710.good
+++ b/test/parsing/issue-21710.good
@@ -1,0 +1,2 @@
+issue-21710.chpl:1: In module 'my_freader':
+issue-21710.chpl:5: error: fields cannot specify generic array types


### PR DESCRIPTION
The post-parse checks I added to search for generic array types were
only firing for the expression `[]`. Expand them to also fire when
a variable specifies something like `var x: [] bytes`, and specialize
the error message a little bit.

Resolves #21710.

TESTING

- [x] `linux64`, `standard`, `-futures`

Reviewed by @bradcray, @arezaii. Thanks!