### PR TITLE
Have paratest.server test futures by default and add a -no-futures flag

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -39,7 +39,7 @@ $client_script = "$pwd/../util/test/paratest.client";
 $venv_check = "$pwd/../util/test/run-in-test-venv.bash python3 -c 'print(\"OK\")'";
 $summary_len = 2;
 $sleep_time = 1;                       # polling time (sec) to distribute work
-$futures_mode = 0;
+$futures_mode = 1;
 $filedist = 0;
 $dirs = "";
 $node_para = 1;                        # the number of tasks to run on each node
@@ -606,6 +606,8 @@ sub main {
             $futures_mode = 2;
         } elsif (/^-futures$/) {
             $futures_mode = 1;
+        } elsif (/^-no-futures$/) {
+            $futures_mode = 0;
         } elsif (/^-logfile$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {


### PR DESCRIPTION
This changes paratest.server to test futures by default in hopes of cutting down on the number of PRs that go in cleanly except for some .bad mismatches on futures.  Though this adds testing time by default on legacy systems, for modern/fast ones, the additional overhead should be negligible.

Also added here is a -no-futures flag that permits someone who's not ready to run futures or wants to shave a bit of time off their runs to opt back out of testing them by default.
