### PR TITLE
Improve start_test to find .good files with directory-wide COMPOPTS

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1782,15 +1782,18 @@ for testname in testsrc:
 
             # find the compiler .good file to compare against. The compiler
             # .good file can be of the form testname.<configuration>.good or
-            # explicitname.<configuration>.good. It's not currently setup to
-            # handle testname.<configuration>.<compoptsnum>.good, but that
-            # would be easy to add. 
+            # explicitname.<configuration>.good or
+            # testname.<configuration>.<compoptsnum>.good.
             basename = test_filename 
             if len(clist) != 0:
                 explicitcompgoodfile = clist[0].split('#')[1].strip()
                 basename = explicitcompgoodfile.replace('.good', '')
 
-            goodfile = FindGoodFile(basename)
+            compOptNum = ['']
+            if len(compoptslist) > 1:
+                compOptNum.insert(0,'.'+str(compoptsnum))
+
+            goodfile = FindGoodFile(basename, compOptNum)
             # sys.stdout.write('default goodfile=%s\n'%(goodfile))
             error_msg = filter_compiler_errors(origoutput)
             if error_msg != '':


### PR DESCRIPTION
This PR enables `start_test` to find `.good` files along the lines of `testname.<configuration>.<compoptsnum>.good` when there is a directory-wide COMPOPTS or when the .compopts file does not specify the .good files.

In the `test/errors` directory, we want to easily test brief and detailed error messages. The easiest way to do that is with a directory-wide COMPOPTS file, but the current implementation of `sub_test.py` didn't know how to look for `.good` files like `testname.1.good` and `testname.2.good` when compilation failed with an error. This PR fixes that by adjusting `sub_test.py` to support this case. It works along the same lines as the compopts + execopts logic.

Reviewed by @jhh67 - thanks!

- [x] full local futures testing