### PR TITLE
dyno: Adjust when to skip emitting deprecation/unstable warnings

### DIFF
--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -288,11 +288,13 @@ void setupModuleSearchPaths(Context* context,
 
 /**
  Returns true if the ID corresponds to something in an internal module.
+ If the internal module path is empty, this function returns false.
  */
 bool idIsInInternalModule(Context* context, ID id);
 
 /**
  Returns true if the ID corresponds to something in a bundled module.
+ If the bundled module path is empty, this function returns false.
  */
 bool idIsInBundledModule(Context* context, ID id);
 

--- a/frontend/test/resolution/testFindDecl.cpp
+++ b/frontend/test/resolution/testFindDecl.cpp
@@ -302,7 +302,10 @@ static void test7() {
     mScope = scopeForId(context, m->id());
     assert(mScope);
     assert(mScope->id() == m->id() && mScope->numDeclared() == 1);
-    assert(mScope->containsUseImport() == false);
+    // TODO: contains use/import because it auto uses modules, should
+    // this change?
+    assert(mScope->containsUseImport() == true);
+    assert(mScope->autoUsesModules() == true);
     // scope contents changed so Scope pointer should change
     assert(mScope != oldMScope);
 
@@ -343,7 +346,10 @@ static void test7() {
     mScope = scopeForId(context, m->id());
     assert(mScope);
     assert(mScope->id() == m->id() && mScope->numDeclared() == 1);
-    assert(mScope->containsUseImport() == false);
+    // TODO: contains use/import because it auto uses modules, should
+    // this change?
+    assert(mScope->containsUseImport() == true);
+    assert(mScope->autoUsesModules() == true);
     // scope contents did not change so Scope pointer should be the same
     assert(mScope == oldMScope);
 


### PR DESCRIPTION
Adjust when dyno emits deprecation/unstable warnings to better match
the production compiler.

Specifically, deprecation warnings will not show in either:

  - A deprecated symbol
  - An unstable symbol
  - A symbol marked "compiler generated"

While unstable warnings are the same but will show in deprecated
symbols. The rationale for this is that unstable things will
likely stick around longer than deprecated things, so we want to
make sure that the unstable things stay up to date.

While here, adjust `idIsInInternalModule` and friends to return false
immediately if the `internalModulePath` is the empty string.

TESTING

- [x] `paratest -compopts --dyno`

Reviewed by @riftEmber. Thanks!