### PR TITLE
Add owned.adopt() and owned.release()

### DIFF
--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -190,8 +190,8 @@ module OwnedObject {
 
       obj.chpl_p = nil;
 
-      return if _to_nilable(t) == t 
-                then _to_unmanaged(oldPtr) 
+      return if _to_nilable(t) == t
+                then _to_unmanaged(oldPtr)
                 else _to_unmanaged(oldPtr!);
     }
 

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -177,8 +177,8 @@ module OwnedObject {
     }
 
     /*
-      Empty obj of type :record:`owned` so that it manages `nil`.
-      Returns the instance previously managed by this :record:`owned`.
+      Empty `obj` so that it manages `nil` and
+      return the instance previously managed by this owned object.
     */
     inline proc type release(pragma "nil from arg" ref obj: owned) {
       var oldPtr = obj.chpl_p;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -179,6 +179,8 @@ module OwnedObject {
     /*
       Empty `obj` so that it manages `nil` and
       return the instance previously managed by this owned object.
+
+      If the argument is `nil` it returns `nil`.
     */
     inline proc type release(pragma "nil from arg" ref obj: owned) {
       var oldPtr = obj.chpl_p;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -176,10 +176,6 @@ module OwnedObject {
       return result;
     }
 
-    inline proc type adopt(arg:nil) {
-      return nil;
-    }
-
     /*
       Empty obj of type :record:`owned` so that it manages `nil`.
       Returns the instance previously managed by this :record:`owned`.

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -142,6 +142,61 @@ module OwnedObject {
       this.chpl_p = src.release();
     }
 
+
+
+
+    pragma "no doc"
+    proc type adopt(source) {
+      compilerError("cannot adopt a ", source.type:string);
+    }
+
+
+    /*
+      Creates a new `owned` class reference, taking over the ownership
+      of the argument. The result has the same type as the argument.
+      If the argument is non-nilable, it must be recognized by the compiler
+      as an expiring value.
+    */
+    inline proc type adopt(pragma "nil from arg" in obj : owned) {
+      return obj;
+    }
+
+    /*
+      Starts managing the argument class instance `obj`
+      using the `owned` memory management strategy.
+      The result type preserves nilability of the argument type.
+
+      It is an error to directly delete the class instance
+      after passing it to `owned.adopt()`.
+    */
+    inline proc type adopt(pragma "nil from arg" in obj: unmanaged) {
+      // 'result' may have a non-nilable type
+      var result: (obj.type : owned);
+      result = new _owned(obj);
+      return result;
+    }
+
+    inline proc type adopt(arg:nil) {
+      return nil;
+    }
+
+    /*
+      Empty obj of type :record:`owned` so that it manages `nil`.
+      Returns the instance previously managed by this :record:`owned`.
+    */
+    inline proc type release(pragma "nil from arg" ref obj: owned) {
+      var oldPtr = obj.chpl_p;
+      type t = obj.chpl_t;
+
+      obj.chpl_p = nil;
+
+      return if _to_nilable(t) == t 
+                then _to_unmanaged(oldPtr) 
+                else _to_unmanaged(oldPtr!);
+    }
+
+
+
     // Issue a compiler error for illegal uses.
     pragma "no doc"
     proc type create(source) {

--- a/test/classes/jade/owned/adopt-release.chpl
+++ b/test/classes/jade/owned/adopt-release.chpl
@@ -1,0 +1,46 @@
+
+
+class A {
+  var x: int;
+  var y: int;
+  proc init() {x=0;y=0;}
+  proc init(x:int,y:int) {this.x=x;this.y=y;}
+}
+
+{
+  writeln("test adopt of unmanaged");
+  var aHeapObj = new unmanaged A();
+  var a = owned.adopt(aHeapObj);
+}
+
+{
+  writeln("test release of owned");
+  var a = new A();
+  var aHeapObj = owned.release(a);
+  delete aHeapObj;
+}
+
+
+{
+  writeln("test adopt/release ownership transfer");
+  var un = new unmanaged A(16, 17);
+
+  var own: owned A = owned.adopt(un);
+  writeln("unmanaged obj: ", un, " and managed obj: ", own);
+  own.x += own.y;
+  writeln("unmanaged obj: ", un, " and managed obj: ", own);
+
+  var un2: unmanaged A = owned.release(own);
+  writeln("unmanaged obj: ", un2);
+  delete un2;
+
+}
+
+
+{
+  writeln("test adopt ownership transfer to owned object");
+  var own1 = new A(2, 3);
+  var own2 = owned.adopt(own1);
+  // own1 should now be invalid
+  writeln(own2);
+}

--- a/test/classes/jade/owned/adopt-release.chpl
+++ b/test/classes/jade/owned/adopt-release.chpl
@@ -39,8 +39,9 @@ class A {
 
 {
   writeln("test adopt ownership transfer to owned object");
-  var own1 = new A(2, 3);
+  var own1: A? = new A(2, 3);
   var own2 = owned.adopt(own1);
-  // own1 should now be invalid
+  // own1 should now be invalid/nil
+  writeln(own1);
   writeln(own2);
 }

--- a/test/classes/jade/owned/adopt-release.execopts
+++ b/test/classes/jade/owned/adopt-release.execopts
@@ -1,0 +1,1 @@
+--memLeaks

--- a/test/classes/jade/owned/adopt-release.execopts
+++ b/test/classes/jade/owned/adopt-release.execopts
@@ -1,1 +1,0 @@
---memLeaks

--- a/test/classes/jade/owned/adopt-release.good
+++ b/test/classes/jade/owned/adopt-release.good
@@ -1,0 +1,8 @@
+test adopt of unmanaged
+test release of owned
+test adopt/release ownership transfer
+unmanaged obj: {x = 16, y = 17} and managed obj: {x = 16, y = 17}
+unmanaged obj: {x = 33, y = 17} and managed obj: {x = 33, y = 17}
+unmanaged obj: {x = 33, y = 17}
+test adopt ownership transfer to owned object
+{x = 2, y = 3}

--- a/test/classes/jade/owned/adopt-release.good
+++ b/test/classes/jade/owned/adopt-release.good
@@ -5,4 +5,5 @@ unmanaged obj: {x = 16, y = 17} and managed obj: {x = 16, y = 17}
 unmanaged obj: {x = 33, y = 17} and managed obj: {x = 33, y = 17}
 unmanaged obj: {x = 33, y = 17}
 test adopt ownership transfer to owned object
+nil
 {x = 2, y = 3}


### PR DESCRIPTION
Implements owned.adopt() and owned.release() per #21372. They are not currently used anywhere other than the added tests. They will eventually replace owned.create, owned.retain, and owned.clear.

## Summary of changes
- implement `owned.adopt()` to create owned object from unmanaged
- implement `owned.adopt()` to create owned object from owned object (matching existing `owned.create()`)
- implement `owned.release()` to let go of its ownership of an object and return an unmanaged object

## New tests
- add test of adopt/release with memLeaks enabled

## Testing
- full paratest
- checked docs to ensure correct formatting


Closes cray/chapel-private#4435