### PR TITLE
Update broken links related to gpu tests

### DIFF
--- a/test/gpu/native/studies/compiler-performance/math.chpl
+++ b/test/gpu/native/studies/compiler-performance/math.chpl
@@ -1,1 +1,1 @@
-../../math.chpl
+../../cudaOnly/math.chpl

--- a/test/gpu/native/studies/compiler-performance/math.good
+++ b/test/gpu/native/studies/compiler-performance/math.good
@@ -1,1 +1,1 @@
-../../math.good
+../../cudaOnly/math.good


### PR DESCRIPTION
In PR #21727 I moved some tests into a `cudaOnly/` directory.  We had tests under `studies/compiler-performance` that are symbolic links to other tests. The aforementioned PR accidentally broke a couple of these links.