### PR TITLE
Add a 'bigint.localize' for functions that allocate

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -765,54 +765,27 @@ module BigInteger {
   operator bigint.+(const ref a: bigint, const ref b: bigint): bigint {
     var c = new bigint();
 
-    if _local {
-      mpz_add(c.mpz, a.mpz, b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_add(c.mpz, a.mpz, b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      mpz_add(c.mpz, a_.mpz, b_.mpz);
-    }
+    const a_ = a.localize();
+    const b_ = b.localize();
+    
+    mpz_add(c.mpz, a_.mpz, b_.mpz);
 
     return c;
   }
 
   operator bigint.+(const ref a: bigint, b: int): bigint {
     var c = new bigint();
+    const a_ = a.localize();
 
     if b >= 0 {
       const b_ = b.safeCast(c_ulong);
 
-      if _local {
-        mpz_add_ui(c.mpz, a.mpz,  b_);
-
-      } else if a.localeId == chpl_nodeID {
-        mpz_add_ui(c.mpz, a.mpz,  b_);
-
-      } else {
-        const a_ = a;
-
-        mpz_add_ui(c.mpz, a_.mpz, b_);
-      }
+      mpz_add_ui(c.mpz, a_.mpz,  b_);
 
     } else {
       const b_ = (0 - b).safeCast(c_ulong);
 
-      if _local {
-        mpz_sub_ui(c.mpz, a.mpz, b_);
-
-      } else if a.localeId == chpl_nodeID {
-        mpz_sub_ui(c.mpz, a.mpz, b_);
-
-      } else {
-        const a_ = a;
-
-        mpz_sub_ui(c.mpz, a_.mpz, b_);
-      }
+      mpz_sub_ui(c.mpz, a_.mpz, b_);
     }
 
     return c;
@@ -820,75 +793,38 @@ module BigInteger {
 
   operator bigint.+(a: int, const ref b: bigint): bigint {
     var c = new bigint();
+    const b_ = b.localize();
 
     if a >= 0 {
       const a_ = a.safeCast(c_ulong);
 
-      if _local {
-        mpz_add_ui(c.mpz, b.mpz,  a_);
-
-      } else if b.localeId == chpl_nodeID {
-        mpz_add_ui(c.mpz, b.mpz,  a_);
-
-      } else {
-        const b_ = b;
-
-        mpz_add_ui(c.mpz, b_.mpz, a_);
-      }
+      mpz_add_ui(c.mpz, b.mpz,  a_);
 
     } else {
       const a_ = (0 - a).safeCast(c_ulong);
 
-      if _local {
-        mpz_sub_ui(c.mpz, b.mpz,  a_);
-
-      } else if b.localeId == chpl_nodeID {
-        mpz_sub_ui(c.mpz, b.mpz,  a_);
-
-      } else {
-        const b_ = b;
-
-        mpz_sub_ui(c.mpz, b_.mpz, a_);
-      }
+      mpz_sub_ui(c.mpz, b_.mpz, a_);
     }
 
     return c;
   }
 
   operator bigint.+(const ref a: bigint, b: uint): bigint {
+    const a_ = a.localize();
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
-    if _local {
-      mpz_add_ui(c.mpz, a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      mpz_add_ui(c.mpz, a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      mpz_add_ui(c.mpz, a_.mpz, b_);
-    }
+    mpz_add_ui(c.mpz, a_.mpz, b_);
 
     return c;
   }
 
   operator bigint.+(a: uint, const ref b: bigint): bigint {
     const a_ = a.safeCast(c_ulong);
+    const b_ = b.localize();
     var   c  = new bigint();
 
-    if _local {
-      mpz_add_ui(c.mpz, b.mpz,  a_);
-
-    } else if b.localeId == chpl_nodeID {
-      mpz_add_ui(c.mpz, b.mpz,  a_);
-
-    } else {
-      const b_ = b;
-
-      mpz_add_ui(c.mpz, b_.mpz, a_);
-    }
+    mpz_add_ui(c.mpz, b_.mpz, a_);
 
     return c;
   }
@@ -897,17 +833,26 @@ module BigInteger {
 
   // Subtraction
   operator bigint.-(const ref a: bigint, const ref b: bigint): bigint {
+    const a_ = a.localize();
+    const b_ = b.localize();
     var c = new bigint();
 
-    if _local {
-      mpz_sub(c.mpz, a.mpz,  b.mpz);
+    mpz_sub(c.mpz, a_.mpz, b_.mpz);
 
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_sub(c.mpz, a.mpz,  b.mpz);
+    return c;
+  }
+
+  operator bigint.-(const ref a: bigint, b: int): bigint {
+    const a_ = a.localize();
+    var c = new bigint();
+
+    if b >= 0 {
+      const b_ = b.safeCast(c_ulong);
+
+      mpz_sub_ui(c.mpz, a_.mpz, b_);
 
     } else {
-      const a_ = a;
-      const b_ = b;
+      const b_ = b:bigint;
 
       mpz_sub(c.mpz, a_.mpz, b_.mpz);
     }
@@ -915,114 +860,40 @@ module BigInteger {
     return c;
   }
 
-  operator bigint.-(const ref a: bigint, b: int): bigint {
-    var c = new bigint();
-
-    if b >= 0 {
-      const b_ = b.safeCast(c_ulong);
-
-      if _local {
-        mpz_sub_ui(c.mpz, a.mpz,  b_);
-
-      } else if a.localeId == chpl_nodeID {
-        mpz_sub_ui(c.mpz, a.mpz,  b_);
-
-      } else {
-        const a_ = a;
-
-        mpz_sub_ui(c.mpz, a_.mpz, b_);
-      }
-
-    } else {
-      const b_ = b:bigint;
-
-      if _local {
-        mpz_sub(c.mpz, a.mpz, b_.mpz);
-
-      } else if a.localeId == chpl_nodeID {
-        mpz_sub(c.mpz, a.mpz, b_.mpz);
-
-      } else {
-        const a_ = a;
-
-        mpz_sub(c.mpz, a_.mpz, b_.mpz);
-      }
-    }
-
-    return c;
-  }
-
   operator bigint.-(a: int, const ref b: bigint): bigint {
+    const b_ = b.localize();
     var c = new bigint();
 
     if a >= 0 {
       const a_ = a.safeCast(c_ulong);
 
-      if _local {
-        mpz_ui_sub(c.mpz, a_, b.mpz);
-
-      } else if b.localeId == chpl_nodeID {
-        mpz_ui_sub(c.mpz, a_, b.mpz);
-
-      } else {
-        const b_ = b;
-
-        mpz_ui_sub(c.mpz, a_, b_.mpz);
-      }
+      mpz_ui_sub(c.mpz, a_, b_.mpz);
 
     } else {
       const a_ = a:bigint;
 
-      if _local {
-        mpz_sub(c.mpz, a_.mpz, b.mpz);
-
-      } else if b.localeId == chpl_nodeID {
-        mpz_sub(c.mpz, a_.mpz, b.mpz);
-
-      } else {
-        const b_ = b;
-
-        mpz_sub(c.mpz, a_.mpz, b.mpz);
-      }
+      mpz_sub(c.mpz, a_.mpz, b.mpz);
     }
 
     return c;
   }
 
   operator bigint.-(const ref a: bigint, b: uint): bigint {
+    const a_ = a.localize();
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
-    if _local {
-      mpz_sub_ui(c.mpz, a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      mpz_sub_ui(c.mpz, a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      mpz_sub_ui(c.mpz, a_.mpz, b_);
-    }
+    mpz_sub_ui(c.mpz, a_.mpz, b_);
 
     return c;
   }
 
   operator bigint.-(a: uint, const ref b: bigint): bigint {
     const a_ = a.safeCast(c_ulong);
+    const b_ = b.localize();
     var   c  = new bigint();
 
-    if _local {
-      mpz_ui_sub(c.mpz, a_, b.mpz);
-
-    } else if b.localeId == chpl_nodeID {
-      mpz_ui_sub(c.mpz, a_, b.mpz);
-
-    } else {
-      const b_ = b;
-
-      mpz_ui_sub(c.mpz, a_, b_.mpz);
-    }
+    mpz_ui_sub(c.mpz, a_, b_.mpz);
 
     return c;
   }
@@ -1030,96 +901,51 @@ module BigInteger {
 
   // Multiplication
   operator bigint.*(const ref a: bigint, const ref b: bigint): bigint {
+    const a_ = a.localize();
+    const b_ = b.localize();
     var c = new bigint();
 
-    if _local {
-      mpz_mul(c.mpz, a.mpz, b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_mul(c.mpz, a.mpz, b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      mpz_mul(c.mpz, a_.mpz, b_.mpz);
-    }
+    mpz_mul(c.mpz, a_.mpz, b_.mpz);
 
     return c;
   }
 
   operator bigint.*(const ref a: bigint, b: int): bigint {
+    const a_ = a.localize();
     const b_ = b.safeCast(c_long);
     var   c  = new bigint();
 
-    if _local {
-      mpz_mul_si(c.mpz, a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      mpz_mul_si(c.mpz, a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      mpz_mul_si(c.mpz, a_.mpz, b_);
-    }
+    mpz_mul_si(c.mpz, a_.mpz, b_);
 
     return c;
   }
 
   operator bigint.*(a: int, const ref b: bigint): bigint {
     const a_ = a.safeCast(c_long);
+    const b_ = b.localize();
     var   c  = new bigint();
 
-    if _local {
-      mpz_mul_si(c.mpz, b.mpz,  a_);
-
-    } else if b.localeId == chpl_nodeID {
-      mpz_mul_si(c.mpz, b.mpz,  a_);
-
-    } else {
-      const b_ = b;
-
-      mpz_mul_si(c.mpz, b_.mpz, a_);
-    }
+    mpz_mul_si(c.mpz, b_.mpz, a_);
 
     return c;
   }
 
   operator bigint.*(const ref a: bigint, b: uint): bigint {
+    const a_ = a.localize();
     const b_ = b.safeCast(c_ulong);
     var   c  = new bigint();
 
-    if _local {
-      mpz_mul_ui(c.mpz, a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      mpz_mul_ui(c.mpz, a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      mpz_mul_ui(c.mpz, a_.mpz, b_);
-    }
+    mpz_mul_ui(c.mpz, a_.mpz, b_);
 
     return c;
   }
 
   operator bigint.*(a: uint, const ref b: bigint): bigint {
     const a_ = a.safeCast(c_ulong);
+    const b_ = b.localize();
     var   c  = new bigint();
 
-    if _local {
-      mpz_mul_ui(c.mpz, b.mpz,  a_);
-
-    } else if b.localeId == chpl_nodeID {
-      mpz_mul_ui(c.mpz, b.mpz,  a_);
-
-    } else {
-      const b_ = b;
-
-      mpz_mul_ui(c.mpz, b_.mpz, a_);
-    }
+    mpz_mul_ui(c.mpz, b_.mpz, a_);
 
     return c;
   }
@@ -1199,17 +1025,11 @@ module BigInteger {
      It is an error if `b` == 0.
   */
   operator bigint.%(const ref a: bigint, const ref b: bigint): bigint {
+    const a_ = a.localize();
+    const b_ = b.localize();
     var c = new bigint();
 
-    if _local {
-      mpz_tdiv_r(c.mpz, a.mpz, b.mpz);
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_tdiv_r(c.mpz, a.mpz, b.mpz);
-    } else {
-      const a_ = a;
-      const b_ = b;
-      mpz_tdiv_r(c.mpz, a_.mpz, b_.mpz);
-    }
+    mpz_tdiv_r(c.mpz, a_.mpz, b_.mpz);
 
     return c;
   }
@@ -1222,6 +1042,7 @@ module BigInteger {
   */
   operator bigint.%(const ref a: bigint, b: int): bigint {
     var c = new bigint();
+    const a_ = a.localize();
     var b_ : c_ulong;
 
     if b >= 0 then
@@ -1229,14 +1050,7 @@ module BigInteger {
     else
       b_ = (0 - b).safeCast(c_ulong);
 
-    if _local {
-      mpz_tdiv_r_ui(c.mpz, a.mpz, b_);
-    } else if a.localeId == chpl_nodeID {
-      mpz_tdiv_r_ui(c.mpz, a.mpz, b_);
-    } else {
-      const a_ = a;
-      mpz_tdiv_r_ui(c.mpz, a_.mpz, b_);
-    }
+    mpz_tdiv_r_ui(c.mpz, a_.mpz, b_);
 
     return c;
   }
@@ -1248,20 +1062,11 @@ module BigInteger {
      It is an error if `b` == 0.
   */
   operator bigint.%(const ref a: bigint, b: uint): bigint {
-    var   c  = new bigint();
+    const a_ = a.localize();
     const b_ = b.safeCast(c_ulong);
+    var   c  = new bigint();
 
-    if _local {
-      mpz_tdiv_r_ui(c.mpz, a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      mpz_tdiv_r_ui(c.mpz, a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      mpz_tdiv_r_ui(c.mpz, a_.mpz, b_);
-    }
+    mpz_tdiv_r_ui(c.mpz, a_.mpz, b_);
 
     return c;
   }
@@ -1270,57 +1075,29 @@ module BigInteger {
 
   // Bit-shift left
   operator bigint.<<(const ref a: bigint, b: int): bigint {
+    const a_ = a.localize();
     var c = new bigint();
 
     if b >= 0 {
       const b_ = b.safeCast(mp_bitcnt_t);
 
-      if _local {
-        mpz_mul_2exp(c.mpz, a.mpz,  b_);
-
-      } else if a.localeId == chpl_nodeID {
-        mpz_mul_2exp(c.mpz, a.mpz,  b_);
-
-      } else {
-        const a_ = a;
-
-        mpz_mul_2exp(c.mpz, a_.mpz, b_);
-      }
+      mpz_mul_2exp(c.mpz, a_.mpz, b_);
 
     } else {
       const b_ = (0 - b).safeCast(mp_bitcnt_t);
 
-      if _local {
-        mpz_tdiv_q_2exp(c.mpz, a.mpz,  b_);
-
-      } else if a.localeId == chpl_nodeID {
-        mpz_tdiv_q_2exp(c.mpz, a.mpz,  b_);
-
-      } else {
-        const a_ = a;
-
-        mpz_tdiv_q_2exp(c.mpz, a_.mpz, b_);
-      }
+      mpz_tdiv_q_2exp(c.mpz, a_.mpz, b_);
     }
 
     return c;
   }
 
   operator bigint.<<(const ref a: bigint, b: uint): bigint {
+    const a_ = a.localize();
     const b_ = b.safeCast(mp_bitcnt_t);
     var   c  = new bigint();
 
-    if _local {
-      mpz_mul_2exp(c.mpz, a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      mpz_mul_2exp(c.mpz, a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      mpz_mul_2exp(c.mpz, a_.mpz, b_);
-    }
+    mpz_mul_2exp(c.mpz, a_.mpz, b_);
 
     return c;
   }
@@ -1329,57 +1106,29 @@ module BigInteger {
 
   // Bit-shift right
   operator bigint.>>(const ref a: bigint, b: int): bigint {
+    const a_ = a.localize();
     var c = new bigint();
 
     if b >= 0 {
       const b_ = b.safeCast(mp_bitcnt_t);
 
-      if _local {
-        mpz_tdiv_q_2exp(c.mpz, a.mpz,  b_);
-
-      } else if a.localeId == chpl_nodeID {
-        mpz_tdiv_q_2exp(c.mpz, a.mpz,  b_);
-
-      } else {
-        const a_ = a;
-
-        mpz_tdiv_q_2exp(c.mpz, a_.mpz, b_);
-      }
+      mpz_tdiv_q_2exp(c.mpz, a_.mpz, b_);
 
     } else {
       const b_ = (0 - b).safeCast(mp_bitcnt_t);
 
-      if _local {
-        mpz_mul_2exp(c.mpz, a.mpz,  b_);
-
-      } else if a.localeId == chpl_nodeID {
-        mpz_mul_2exp(c.mpz, a.mpz,  b_);
-
-      } else {
-        const a_ = a;
-
-        mpz_mul_2exp(c.mpz, a_.mpz, b_);
-      }
+      mpz_mul_2exp(c.mpz, a_.mpz, b_);
     }
 
     return c;
   }
 
   operator bigint.>>(const ref a: bigint, b: uint): bigint {
+    const a_ = a.localize();
     const b_ = b.safeCast(mp_bitcnt_t);
     var   c  = new bigint();
 
-    if _local {
-      mpz_tdiv_q_2exp(c.mpz, a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      mpz_tdiv_q_2exp(c.mpz, a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      mpz_tdiv_q_2exp(c.mpz, a_.mpz, b_);
-    }
+    mpz_tdiv_q_2exp(c.mpz, a_.mpz, b_);
 
     return c;
   }
@@ -1388,20 +1137,11 @@ module BigInteger {
 
   // Bitwise and
   operator bigint.&(const ref a: bigint, const ref b: bigint): bigint {
+    const a_ = a.localize();
+    const b_ = b.localize();
     var c = new bigint();
 
-    if _local {
-      mpz_and(c.mpz, a.mpz, b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_and(c.mpz, a.mpz, b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      mpz_and(c.mpz, a_.mpz, b_.mpz);
-    }
+    mpz_and(c.mpz, a_.mpz, b_.mpz);
 
     return c;
   }
@@ -1410,20 +1150,11 @@ module BigInteger {
 
   // Bitwise ior
   operator bigint.|(const ref a: bigint, const ref b: bigint): bigint {
+    const a_ = a.localize();
+    const b_ = b.localize();
     var c = new bigint();
 
-    if _local {
-      mpz_ior(c.mpz, a.mpz, b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_ior(c.mpz, a.mpz, b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      mpz_ior(c.mpz, a_.mpz, b_.mpz);
-    }
+    mpz_ior(c.mpz, a_.mpz, b_.mpz);
 
     return c;
   }
@@ -1432,20 +1163,11 @@ module BigInteger {
 
   // Bitwise xor
   operator bigint.^(const ref a: bigint, const ref b: bigint): bigint {
+    const a_ = a.localize();
+    const b_ = b.localize();
     var c = new bigint();
 
-    if _local {
-      mpz_xor(c.mpz, a.mpz, b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      mpz_xor(c.mpz, a.mpz, b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      mpz_xor(c.mpz, a_.mpz, b_.mpz);
-    }
+    mpz_xor(c.mpz, a_.mpz, b_.mpz);
 
     return c;
   }
@@ -1457,96 +1179,51 @@ module BigInteger {
   //
 
   private inline proc cmp(const ref a: bigint, const ref b: bigint) {
+    const a_ = a.localize();
+    const b_ = b.localize();
     var ret : c_int;
 
-    if _local {
-      ret = mpz_cmp(a.mpz,  b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      ret = mpz_cmp(a.mpz,  b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      ret = mpz_cmp(a_.mpz, b_.mpz);
-    }
+    ret = mpz_cmp(a_.mpz, b_.mpz);
 
     return ret;
   }
 
   private inline proc cmp(const ref a: bigint, b: int) {
+    const a_ = a.localize();
     const b_ = b.safeCast(c_long);
     var   ret : c_int;
 
-    if _local {
-      ret = mpz_cmp_si(a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      ret = mpz_cmp_si(a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      ret = mpz_cmp_si(a_.mpz, b_);
-    }
+    ret = mpz_cmp_si(a_.mpz, b_);
 
     return ret;
   }
 
   private inline proc cmp(a: int, const ref b: bigint) {
     const a_ = a.safeCast(c_long);
+    const b_ = b.localize();
     var   ret : c_int;
 
-    if _local {
-      ret = mpz_cmp_si(b.mpz,  a_);
-
-    } else if b.localeId == chpl_nodeID {
-      ret = mpz_cmp_si(b.mpz,  a_);
-
-    } else {
-      const b_ = b;
-
-      ret = mpz_cmp_si(b_.mpz, a_);
-    }
+    ret = mpz_cmp_si(b_.mpz, a_);
 
     return 0 - ret;
   }
 
   private inline proc cmp(const ref a: bigint, b: uint) {
+    const a_ = a.localize();
     const b_ = b.safeCast(c_ulong);
     var   ret : c_int;
 
-    if _local {
-      ret = mpz_cmp_ui(a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      ret = mpz_cmp_ui(a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      ret = mpz_cmp_ui(a_.mpz, b_);
-    }
+    ret = mpz_cmp_ui(a_.mpz, b_);
 
     return ret;
   }
 
   private inline proc cmp(a: uint, const ref b: bigint) {
     const a_ = a.safeCast(c_ulong);
+    const b_ = b.localize();
     var   ret : c_int;
 
-    if _local {
-      ret = mpz_cmp_ui(b.mpz,  a_);
-
-    } else if b.localeId == chpl_nodeID {
-      ret = mpz_cmp_ui(b.mpz,  a_);
-
-    } else {
-      const b_ = b;
-
-      ret = mpz_cmp_ui(b_.mpz, a_);
-    }
+    ret = mpz_cmp_ui(b_.mpz, a_);
 
     return 0 - ret;
   }
@@ -1925,33 +1602,17 @@ module BigInteger {
 
   // **=
   operator bigint.**=(ref base: bigint, const ref exp: bigint) {
-    if _local {
-      base = base ** exp;
+    const base_ = base.localize();
+    const exp_  = exp.localize();
 
-    } else if base.localeId == chpl_nodeID && exp.localeId == chpl_nodeID {
-      base = base ** exp;
-
-    } else {
-      const base_ = base;
-      const exp_  = exp;
-
-      base = base_ ** exp_;
-    }
+    base = base_ ** exp_;
   }
 
   operator bigint.**=(ref base: bigint, exp: int) {
-    if _local {
-      base.pow(base, exp);
+    const base_ = base.localize();
+    const exp_ = exp.localize();
 
-    } else if base.localeId == chpl_nodeID {
-      base.pow(base, exp);
-
-    } else {
-      const base_ = base;
-      const exp_ = exp;
-
-      base.pow(base_, exp_);
-    }
+    base.pow(base_, exp_);
   }
 
   operator bigint.**=(ref base: bigint, exp: uint) {
@@ -2252,20 +1913,11 @@ module BigInteger {
 
   // Special Operations
   proc jacobi(const ref a: bigint, const ref b: bigint) : int {
+    const a_ = a.localize();
+    const b_ = b.localize();
     var ret : c_int;
 
-    if _local {
-      ret = mpz_jacobi(a.mpz,  b.mpz);
-
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      ret = mpz_jacobi(a.mpz,  b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      ret = mpz_jacobi(a_.mpz, b_.mpz);
-    }
+    ret = mpz_jacobi(a_.mpz, b_.mpz);
 
     return ret.safeCast(int);
   }
@@ -2273,20 +1925,11 @@ module BigInteger {
 
 
   proc legendre(const ref a: bigint, const ref p: bigint) : int {
+    const a_ = a.localize();
+    const p_ = p.localize();
     var ret : c_int;
 
-    if _local {
-      ret = mpz_legendre(a.mpz,  p.mpz);
-
-    } else if a.localeId == chpl_nodeID && p.localeId == chpl_nodeID {
-      ret = mpz_legendre(a.mpz,  p.mpz);
-
-    } else {
-      const a_ = a;
-      const p_ = p;
-
-      ret = mpz_legendre(a_.mpz, p_.mpz);
-    }
+    ret = mpz_legendre(a_.mpz, p_.mpz);
 
     return ret.safeCast(int);
   }
@@ -2297,94 +1940,50 @@ module BigInteger {
   proc kronecker(const ref a: bigint, const ref b: bigint) : int {
     var ret : c_int;
 
-    if _local {
-      ret = mpz_kronecker(a.mpz,  b.mpz);
+    const a_ = a.localize();
+    const b_ = b.localize();
 
-    } else if a.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      ret = mpz_kronecker(a.mpz,  b.mpz);
-
-    } else {
-      const a_ = a;
-      const b_ = b;
-
-      ret = mpz_kronecker(a_.mpz, b_.mpz);
-    }
+    ret = mpz_kronecker(a_.mpz, b_.mpz);
 
     return ret.safeCast(int);
   }
 
   proc kronecker(const ref a: bigint, b: int) : int {
+    const a_ = a.localize();
     const b_ = b.safeCast(c_long);
     var  ret : c_int;
 
-    if _local {
-      ret = mpz_kronecker_si(a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      ret = mpz_kronecker_si(a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      ret = mpz_kronecker_si(a_.mpz, b_);
-    }
+    ret = mpz_kronecker_si(a_.mpz, b_);
 
     return ret.safeCast(int);
   }
 
   proc kronecker(a: int, const ref b: bigint) : int {
     const a_ = a.safeCast(c_long);
+    const b_ = b.localize();
     var  ret : c_int;
 
-    if _local {
-      ret = mpz_si_kronecker(a_, b.mpz);
-
-    } else if b.localeId == chpl_nodeID {
-      ret = mpz_si_kronecker(a_, b.mpz);
-
-    } else {
-      const b_ = b;
-
-      ret = mpz_si_kronecker(a_, b_.mpz);
-    }
+    ret = mpz_si_kronecker(a_, b_.mpz);
 
     return ret.safeCast(int);
   }
 
   proc kronecker(const ref a: bigint, b: uint) : int {
+    const a_ = a.localize();
     const b_ = b.safeCast(c_ulong);
     var  ret : c_int;
 
-    if _local {
-      ret = mpz_kronecker_ui(a.mpz,  b_);
-
-    } else if a.localeId == chpl_nodeID {
-      ret = mpz_kronecker_ui(a.mpz,  b_);
-
-    } else {
-      const a_ = a;
-
-      ret = mpz_kronecker_ui(a_.mpz, b_);
-    }
+    ret = mpz_kronecker_ui(a_.mpz, b_);
 
     return ret.safeCast(int);
   }
 
   proc kronecker(a: uint, const ref b: bigint) : int {
     const a_ = b.safeCast(c_ulong);
+    const b_ = b.localize();
     var  ret : c_int;
 
-    if _local {
-      ret = mpz_ui_kronecker(a_, a.mpz);
-
-    } else if b.localeId == chpl_nodeID {
-      ret = mpz_ui_kronecker(a_, a.mpz);
-
-    } else {
-      const b_ = b;
-
-      ret = mpz_ui_kronecker(a_, b_.mpz);
-    }
+    ret = mpz_ui_kronecker(a_, b_.mpz);
 
     return ret.safeCast(int);
   }
@@ -2500,20 +2099,11 @@ module BigInteger {
   // divisible_p
   // documented in uint version
   proc bigint.isDivisible(const ref div: bigint) : bool {
+    const t_ = this.localize();
+    const div_ = div.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_divisible_p(this.mpz, div.mpz);
-
-    } else if this.localeId == chpl_nodeID && div.localeId == chpl_nodeID {
-      ret = mpz_divisible_p(this.mpz, div.mpz);
-
-    } else {
-      const t_ = this;
-      const div_ = div;
-
-      ret = mpz_divisible_p(this.mpz, div.mpz);
-    }
+    ret = mpz_divisible_p(this.mpz, div.mpz);
 
     if ret then
       return true;
@@ -2523,6 +2113,7 @@ module BigInteger {
 
   // documented in uint version
   proc bigint.isDivisible(div: int) : bool {
+    const t_ = this.localize();
     var div_ = 0 : c_ulong;
     var ret: c_int;
 
@@ -2531,17 +2122,7 @@ module BigInteger {
     else
       div_ = (0 - div).safeCast(c_ulong);
 
-    if _local {
-      ret = mpz_divisible_ui_p(this.mpz, div_);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_divisible_ui_p(this.mpz, div_);
-
-    } else {
-      const t_ = this;
-
-      ret = mpz_divisible_ui_p(t_.mpz,   div_);
-    }
+    ret = mpz_divisible_ui_p(t_.mpz,   div_);
 
     if ret then
       return true;
@@ -2563,20 +2144,11 @@ module BigInteger {
     :rtype: ``bool``
    */
   proc bigint.isDivisible(div: uint) : bool {
+    const t_ = this.localize();
     const div_ = div.safeCast(c_ulong);
     var   ret: c_int;
 
-    if _local {
-      ret = mpz_divisible_ui_p(this.mpz, div_);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_divisible_ui_p(this.mpz, div_);
-
-    } else {
-      const t_ = this;
-
-      ret = mpz_divisible_ui_p(t_.mpz,   div_);
-    }
+    ret = mpz_divisible_ui_p(t_.mpz, div_);
 
     if ret then
       return true;
@@ -2608,20 +2180,11 @@ module BigInteger {
     :rtype: ``bool``
    */
   proc bigint.isDivisibleBy2Pow(exp: integral) : bool {
+    const t_ = this.localize();
     const exp_ = exp.safeCast(mp_bitcnt_t);
     var   ret: c_int;
 
-    if _local {
-      ret = mpz_divisible_2exp_p(this.mpz, exp_);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_divisible_2exp_p(this.mpz, exp_);
-
-    } else {
-      const t_ = this;
-
-      ret = mpz_divisible_2exp_p(t_.mpz,   exp_);
-    }
+    ret = mpz_divisible_2exp_p(t_.mpz,   exp_);
 
     if ret then
       return true;
@@ -2654,23 +2217,12 @@ module BigInteger {
   // congruent_p
   // documented in integral, integral version
   proc bigint.isCongruent(const ref con: bigint, const ref mod: bigint) : bool {
+    const t_ = this.localize();
+    const con_ = con.localize();
+    const mod_ = mod.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_congruent_p(this.mpz, con.mpz, mod.mpz);
-
-    } else if this.localeId == chpl_nodeID &&
-              con.localeId    == chpl_nodeID &&
-              mod.localeId    == chpl_nodeID {
-      ret = mpz_congruent_p(this.mpz, con.mpz, mod.mpz);
-
-    } else {
-      const t_ = this;
-      const con_ = con;
-      const mod_ = mod;
-
-      ret = mpz_congruent_p(t_.mpz, con_.mpz, mod_.mpz);
-    }
+    ret = mpz_congruent_p(t_.mpz, con_.mpz, mod_.mpz);
 
     if ret then
       return true;
@@ -2697,21 +2249,12 @@ module BigInteger {
     :rtype: ``bool``
    */
   proc bigint.isCongruent(con: integral, mod: integral) : bool {
+    const t_ = this.localize();
     const con_ = con.safeCast(c_ulong);
     const mod_ = mod.safeCast(c_ulong);
     var   ret: c_int;
 
-    if _local {
-      ret = mpz_congruent_ui_p(this.mpz, con_, mod_);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_congruent_ui_p(this.mpz, con_, mod_);
-
-    } else {
-      const t_ = this;
-
-      ret = mpz_congruent_ui_p(t_.mpz,   con_, mod_);
-    }
+    ret = mpz_congruent_ui_p(t_.mpz, con_, mod_);
 
     if ret then
       return true;
@@ -2748,22 +2291,12 @@ module BigInteger {
     :rtype: ``bool``
    */
   proc bigint.isCongruentBy2Pow(const ref con: bigint, modExp: integral) : bool {
+    const t_ = this.localize();
+    const con_ = con.localize();
     const modExp_ = modExp.safeCast(mp_bitcnt_t);
     var   ret: c_int;
 
-    if _local {
-      ret = mpz_congruent_2exp_p(this.mpz, con.mpz, modExp_);
-
-    } else if this.localeId == chpl_nodeID &&
-              con.localeId    == chpl_nodeID {
-      ret = mpz_congruent_2exp_p(this.mpz, con.mpz, modExp_);
-
-    } else {
-      const t_ = this;
-      const con_ = con;
-
-      ret = mpz_congruent_2exp_p(t_.mpz, con_.mpz, modExp_);
-    }
+    ret = mpz_congruent_2exp_p(t_.mpz, con_.mpz, modExp_);
 
     if ret then
       return true;
@@ -3146,16 +2679,10 @@ module BigInteger {
     :return: ``true`` if ``this`` is a perfect power, ``false`` otherwise.
    */
   proc bigint.isPerfectPower () : bool {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local || this.localeId == chpl_nodeID {
-      ret = mpz_perfect_power_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_perfect_power_p(t_.mpz);
-    }
+    ret = mpz_perfect_power_p(t_.mpz);
 
     if ret then
       return true;
@@ -3183,16 +2710,10 @@ module BigInteger {
     :rtype: ``bool``
    */
   proc bigint.isPerfectSquare() : bool {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local || this.localeId == chpl_nodeID {
-      ret = mpz_perfect_square_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_perfect_square_p(t_.mpz);
-    }
+    ret = mpz_perfect_square_p(t_.mpz);
 
     if ret then
       return true;
@@ -3250,17 +2771,12 @@ module BigInteger {
     :rtype: :enum:`primality`
    */
   proc bigint.probablyPrime(reps: int) : primality {
+    var t_ = this.localize();
     var reps_ = reps.safeCast(c_int);
     var ret: c_int;
 
-    if _local || this.localeId == chpl_nodeID {
-      ret = mpz_probab_prime_p(this.mpz, reps_);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_probab_prime_p(t_.mpz, reps_);
-    }
+    ret = mpz_probab_prime_p(t_.mpz, reps_);
+    
     use primality;
     if ret==0 then
       return notPrime;
@@ -3785,38 +3301,20 @@ module BigInteger {
 
   // Bit operations
   proc bigint.popcount() : uint {
+    const t_ = this.localize();
     var ret: c_ulong;
 
-    if _local {
-      ret = mpz_popcount(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_popcount(this.mpz);
-
-    } else {
-      const t_ = this;
-
-      ret = mpz_popcount(t_.mpz);
-    }
+    ret = mpz_popcount(t_.mpz);
 
     return ret.safeCast(uint);
   }
 
   proc bigint.hamdist(const ref b: bigint) : uint {
+    const t_ = this.localize();
+    const b_ = b.localize();
     var ret: c_ulong;
 
-    if _local {
-      ret = mpz_hamdist(this.mpz, b.mpz);
-
-    } else if this.localeId == chpl_nodeID && b.localeId == chpl_nodeID {
-      ret = mpz_hamdist(this.mpz, b.mpz);
-
-    } else {
-      const t_ = this;
-      const b_ = b;
-
-      ret = mpz_hamdist(t_.mpz, b_.mpz);
-    }
+    ret = mpz_hamdist(t_.mpz, b_.mpz);
 
     return ret.safeCast(uint);
   }
@@ -3842,20 +3340,11 @@ module BigInteger {
       :rtype: ``uint``
    */
   proc bigint.scan0(startBitIdx: integral): uint {
+    const t_ = this.localize();
     const sb_ = startBitIdx.safeCast(c_ulong);
     var   ret: c_ulong;
 
-    if _local {
-      ret = mpz_scan0(this.mpz, sb_);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_scan0(this.mpz, sb_);
-
-    } else {
-      const t_ = this;
-
-      ret = mpz_scan0(t_.mpz,   sb_);
-    }
+      ret = mpz_scan0(t_.mpz, sb_);
 
     return ret.safeCast(uint);
   }
@@ -3881,20 +3370,11 @@ module BigInteger {
       :rtype: ``uint``
    */
   proc bigint.scan1(startBitIdx: integral): uint {
+    const t_ = this.localize();
     const sb_ = startBitIdx.safeCast(c_ulong);
     var   ret: c_ulong;
 
-    if _local {
-      ret = mpz_scan1(this.mpz, sb_);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_scan1(this.mpz, sb_);
-
-    } else {
-      const t_ = this;
-
-      ret = mpz_scan1(t_.mpz,   sb_);
-    }
+    ret = mpz_scan1(t_.mpz,   sb_);
 
     return ret.safeCast(uint);
   }
@@ -3957,20 +3437,11 @@ module BigInteger {
   }
 
   proc bigint.tstbit(bit_index: integral) : int {
+    var t_ = this.localize();
     const bi_ = bit_index.safeCast(c_ulong);
     var  ret: c_int;
 
-    if _local {
-      ret = mpz_tstbit(this.mpz, bi_);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_tstbit(this.mpz, bi_);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_tstbit(t_.mpz, bi_);
-    }
+    ret = mpz_tstbit(t_.mpz, bi_);
 
     return ret.safeCast(int);
   }
@@ -4005,128 +3476,62 @@ module BigInteger {
     :type t: `integral`
   */
   proc bigint.fitsInto(type t: integral): bool {
-    if _local {
-      return fits_into(this.mpz, t);
-    } else if this.localeId == chpl_nodeID {
-      return fits_into(this.mpz, t);
-    } else {
-      var t_ = this;
-
-      return fits_into(t_.mpz, t);
-    }
+    var t_ = this.localize();
+    return fits_into(t_.mpz, t);
   }
 
   deprecated "`fits_ulong_p` is deprecated -  please use `bigint.fitsInto(c_ulong)` instead"
   proc bigint.fits_ulong_p() : int {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_fits_ulong_p(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_fits_ulong_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_fits_ulong_p(t_.mpz);
-    }
-
+    ret = mpz_fits_ulong_p(t_.mpz);
     return ret.safeCast(int);
   }
 
   deprecated "`fits_slong_p` is deprecated -  please use `bigint.fitsInto(c_long)` instead"
   proc bigint.fits_slong_p() : int {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_fits_slong_p(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_fits_slong_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_fits_slong_p(t_.mpz);
-    }
-
+    ret = mpz_fits_slong_p(t_.mpz);
     return ret.safeCast(int);
   }
 
   deprecated "`fits_uint_p` is deprecated -  please use `bigint.fitsInto(c_uint)` instead"
   proc bigint.fits_uint_p() : int {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_fits_uint_p(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_fits_uint_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_fits_uint_p(t_.mpz);
-    }
+    ret = mpz_fits_uint_p(t_.mpz);
 
     return ret.safeCast(int);
   }
 
   deprecated "`fits_sint_p` is deprecated -  please use `bigint.fitsInto(c_int)` instead"
   proc bigint.fits_sint_p() : int {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_fits_sint_p(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_fits_sint_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_fits_sint_p(t_.mpz);
-    }
-
+    ret = mpz_fits_sint_p(t_.mpz);
     return ret.safeCast(int);
   }
 
   deprecated "`fits_ushort_p` is deprecated -  please use `bigint.fitsInto(c_ushort)` instead"
   proc bigint.fits_ushort_p() : int {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_fits_ushort_p(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_fits_ushort_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_fits_ushort_p(t_.mpz);
-    }
-
+    ret = mpz_fits_ushort_p(t_.mpz);
     return ret.safeCast(int);
   }
 
   deprecated "`fits_sshort_p` is deprecated -  please use `bigint.fitsInto(c_short)` instead"
   proc bigint.fits_sshort_p() : int {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_fits_sshort_p(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_fits_sshort_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_fits_sshort_p(t_.mpz);
-    }
-
+    ret = mpz_fits_sshort_p(t_.mpz);
     return ret.safeCast(int);
   }
 
@@ -4145,19 +3550,10 @@ module BigInteger {
     Returns ``true`` if ``this`` is an even number, ``false`` otherwise.
    */
   proc bigint.isEven() : bool {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_even_p(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_even_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_even_p(t_.mpz);
-    }
+    ret = mpz_even_p(t_.mpz);
 
     if ret then
       return true;
@@ -4180,19 +3576,10 @@ module BigInteger {
     Returns ``true`` if ``this`` is an odd number, ``false`` otherwise.
    */
   proc bigint.isOdd() : bool {
+    var t_ = this.localize();
     var ret: c_int;
 
-    if _local {
-      ret = mpz_odd_p(this.mpz);
-
-    } else if this.localeId == chpl_nodeID {
-      ret = mpz_odd_p(this.mpz);
-
-    } else {
-      var t_ = this;
-
-      ret = mpz_odd_p(t_.mpz);
-    }
+    ret = mpz_odd_p(t_.mpz);
 
     if ret then
       return true;
@@ -5655,6 +5042,41 @@ module BigInteger {
 
         mpz_set(this.mpz, tmp.mpz);
       }
+    }
+  }
+
+  record bigintWrapper {
+    var mpz: mpz_t;
+    var isOwned: bool;
+    proc init(a: mpz_t) {
+      mpz = a;
+      isOwned = false;
+    }
+
+    proc init(a: bigint) {
+      this.complete();
+      var mpz_struct = a.getImpl();
+      mpz_init(this.mpz);
+      chpl_gmp_get_mpz(this.mpz, a.localeId, mpz_struct);
+      isOwned = true;
+    }
+
+    proc deinit() {
+      if isOwned then
+        mpz_clear(this.mpz);
+    }
+  }
+  
+  inline proc bigint.localize() {
+    if _local {
+      const ret = new bigintWrapper(this.mpz);
+      return ret;
+    } else if this.localeId == chpl_nodeID {
+      const ret = new bigintWrapper(this.mpz);
+      return ret;
+    } else {
+      const ret = new bigintWrapper(this);
+      return ret;
     }
   }
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -1602,17 +1602,11 @@ module BigInteger {
 
   // **=
   operator bigint.**=(ref base: bigint, const ref exp: bigint) {
-    const base_ = base.localize();
-    const exp_  = exp.localize();
-
-    base = base_ ** exp_;
+    base = base ** exp;
   }
 
   operator bigint.**=(ref base: bigint, exp: int) {
-    const base_ = base.localize();
-    const exp_ = exp.localize();
-
-    base.pow(base_, exp_);
+    base.pow(base, exp);
   }
 
   operator bigint.**=(ref base: bigint, exp: uint) {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -798,7 +798,7 @@ module BigInteger {
     if a >= 0 {
       const a_ = a.safeCast(c_ulong);
 
-      mpz_add_ui(c.mpz, b.mpz,  a_);
+      mpz_add_ui(c.mpz, b_.mpz,  a_);
 
     } else {
       const a_ = (0 - a).safeCast(c_ulong);
@@ -5025,7 +5025,9 @@ module BigInteger {
     }
   }
 
+  pragma "no doc"
   record bigintWrapper {
+    pragma "no init"
     var mpz: mpz_t;
     var isOwned: bool;
     proc init(a: mpz_t) {
@@ -5047,6 +5049,7 @@ module BigInteger {
     }
   }
 
+  pragma "no doc"
   inline proc bigint.localize() {
     if _local {
       const ret = new bigintWrapper(this.mpz);

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -767,7 +767,7 @@ module BigInteger {
 
     const a_ = a.localize();
     const b_ = b.localize();
-    
+
     mpz_add(c.mpz, a_.mpz, b_.mpz);
 
     return c;
@@ -1610,21 +1610,7 @@ module BigInteger {
   }
 
   operator bigint.**=(ref base: bigint, exp: uint) {
-    const exp_ = exp.safeCast(c_ulong);
-
-    if _local {
-      base.pow(base, exp_);
-
-    } else if base.localeId == chpl_nodeID {
-      base.pow(base, exp_);
-
-    } else {
-      const baseLoc = chpl_buildLocaleID(base.localeId, c_sublocid_any);
-
-      on __primitive("chpl_on_locale_num", baseLoc) {
-        base.pow(base, exp_);
-      }
-    }
+    base.pow(base, exp);
   }
 
 
@@ -2770,7 +2756,7 @@ module BigInteger {
     var ret: c_int;
 
     ret = mpz_probab_prime_p(t_.mpz, reps_);
-    
+
     use primality;
     if ret==0 then
       return notPrime;
@@ -3338,7 +3324,7 @@ module BigInteger {
     const sb_ = startBitIdx.safeCast(c_ulong);
     var   ret: c_ulong;
 
-      ret = mpz_scan0(t_.mpz, sb_);
+    ret = mpz_scan0(t_.mpz, sb_);
 
     return ret.safeCast(uint);
   }
@@ -5060,7 +5046,7 @@ module BigInteger {
         mpz_clear(this.mpz);
     }
   }
-  
+
   inline proc bigint.localize() {
     if _local {
       const ret = new bigintWrapper(this.mpz);


### PR DESCRIPTION
For bigint functions that allocate today, there are 3 branches that check for locality and decide how to handle that case for each function. This results in a great deal of duplicated code, obfuscating the code and making bugs difficult to spot.

This PR adds a `bigintWrapper` record and a
`bigint.localize()` method to get rid of the need to have the branching in every function call.

Impacts:
 - about 600 lines removed from bigint
 - about 60s saved on Arkouda gasnet compilation
 - about 5% reduction in raw performance for operations that allocate for both operands (such as `bigint+bigint`)

Backing issue: https://github.com/Cray/chapel-private/issues/4146
Follow up issue for performance regression: https://github.com/Cray/chapel-private/issues/4449