### PR TITLE
CHPL_RT_COMM_OFI_EP_COUNT overrides maximum number of endpoints

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1607,10 +1607,11 @@ chpl_bool canBindTxCtxs(struct fi_info* info) {
   // we'll use bound tx contexts with this provider.
   //
   const struct fi_domain_attr* dom_attr = info->domain_attr;
+  int epCount = chpl_env_rt_get_int("COMM_OFI_EP_COUNT", dom_attr->ep_cnt);
   int numWorkerTxCtxs = ((envPreferScalableTxEp
                           && dom_attr->max_ep_tx_ctx > 1)
                          ? dom_attr->max_ep_tx_ctx
-                         : dom_attr->ep_cnt)
+                         : epCount)
                         - 1
                         - numAmHandlers;
   if (envCommConcurrency > 0 && envCommConcurrency < numWorkerTxCtxs) {


### PR DESCRIPTION
The `CHPL_RT_COMM_OFI_EP_COUNT` environment variable overrides the maximum number of endpoints reported by the `ofi` provider in the `ep_cnt` field of the domain attributes. Some providers report an incorrect maximum that is too low to allow one endpoint per thread. As a result, endpoints are not bound to threads and the runtime cannot make use of endpoint ordering properties.