### PR TITLE
Fix up some failures from #21633 and #21733

### DIFF
--- a/test/arrays/bradc/noelemtype.bad
+++ b/test/arrays/bradc/noelemtype.bad
@@ -1,2 +1,1 @@
-noelemtype.chpl:5: warning: single-element array literals without a trailing comma are deprecated; please rewrite as '[myElem, ]'
 noelemtype.chpl:5: error: cannot initialize [domain(1,int(64),false)] domain(1,int(64),false) from real(64)

--- a/test/arrays/dinan/no_element_type_error.bad
+++ b/test/arrays/dinan/no_element_type_error.bad
@@ -1,2 +1,2 @@
-no_element_type_error.chpl:2: warning: single-element array literals without a trailing comma are deprecated; please rewrite as '[myElem, ]'
+no_element_type_error.chpl:2: warning: please note that this is a 1-element array of ranges; if that was your intention, add a trailing comma or recompile with '--no-warn-array-of-range' to avoid this warning; if it wasn't, you may want to use a range instead
 no_element_type_error.chpl:2: error: cannot initialize [domain(1,int(64),false)] range(int(64),bounded,false) from [domain(1,int(64),false)] real(64)

--- a/test/arrays/errors/arrOfRanges.compopts
+++ b/test/arrays/errors/arrOfRanges.compopts
@@ -2,4 +2,4 @@
 --warn-array-of-range                # arrOfRanges.good
 --no-warn-array-of-range             # arrOfRanges-nowarning.good
 --no-warnings                        # arrOfRanges-nowarning.good
---no-warn-array-of-range --warn-array-of-range  # arrOfRanges.good
+--devel --no-warnings                # arrOfRanges-nowarning.good

--- a/test/library/draft/DistributedMap/v2/use-distributed-map.bad
+++ b/test/library/draft/DistributedMap/v2/use-distributed-map.bad
@@ -1,6 +1,6 @@
 ./Aggregator.chpl:36: In initializer:
 $CHPL_HOME/modules/standard/Types.chpl:250: warning: Initializing a type-inferred variable from a 'sync' is deprecated; apply a 'read??()' method to the right-hand side
-  ./DistributedMap.chpl:743: called as (aggregator(distributedMapImpl(string,int(64),nothing),proc(ref element: int))).init(clientInst: borrowed distributedMapImpl(string,int(64),nothing), updaterFcf: proc(ref element: int)) from method 'updateAggregator'
+  ./DistributedMap.chpl:716: called as (aggregator(distributedMapImpl(string,int(64),nothing),proc(ref element: int))).init(clientInst: borrowed distributedMapImpl(string,int(64),nothing), updaterFcf: proc(ref element: int)) from method 'updateAggregator'
   use-distributed-map.chpl:12: called as (distributedMapImpl(string,int(64),nothing)).updateAggregator(updater: proc(ref element: int))
 Jacob=2
 Jingleheimer=2

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -260,6 +260,7 @@ _chpl ()
 --no-use-io-formatters \
 --no-vectorize \
 --no-verify \
+--no-warn-array-of-range \
 --no-warn-const-loops \
 --no-warn-domain-literal \
 --no-warn-int-uint \
@@ -349,6 +350,7 @@ _chpl ()
 --vectorize \
 --verify \
 --version \
+--warn-array-of-range \
 --warn-const-loops \
 --warn-domain-literal \
 --warn-int-uint \


### PR DESCRIPTION
(watch out for those #21x33 PRs, kids!)

This fixes a few futures that I must've missed in my last paratest run (prior to paratest running futures by default!) as well as an obvious problem with the test of the bash autocompletion which I'm not sure how it slipped past me.

It also fixes an issue from Ben McDonald's #21733 which I happened to notice since he's likely out for the evening.

While here, I noticed that an erroneous condition that I'd noted earlier in #21652 has been resolved, probably by #21614 as Michael predicted, so I added a compopts line to lock that behavior in (and removed another that, in retrospect, felt overly paranoid).