### PR TITLE
Replace protobuf 'map.items' call with a zip over keys, values

### DIFF
--- a/modules/packages/ProtobufProtocolSupport.chpl
+++ b/modules/packages/ProtobufProtocolSupport.chpl
@@ -520,7 +520,7 @@ module ProtobufProtocolSupport {
 
     proc mapAppend(val, fieldNumber: int, param protoKeyType: string,
       param protoValueType: string, ch:writingChannel) throws {
-      for (key, value) in val.items() {
+      for (key, value) in zip(val.keys(), val.values()) {
         tagAppend(fieldNumber, lengthDelimited, ch);
         var initialOffset = ch.offset();
         ch.mark();


### PR DESCRIPTION
'map.items()' has been deprecated in favor of zipping over the keys and values, so this updates some protobuf code to follow that recommendation.