### PR TITLE
Revert submitted benchmarks and update good files

### DIFF
--- a/test/studies/shootout/submitted/knucleotide3.chpl
+++ b/test/studies/shootout/submitted/knucleotide3.chpl
@@ -54,7 +54,7 @@ proc writeFreqs(data, param nclSize) {
   const freqs = calculate(data, nclSize);
 
   // create an array of (frequency, sequence) tuples
-  var arr = for (s,f) in zip(freqs.keys(), freqs.values()) do (f,s);
+  var arr = for (s,f) in freqs.items() do (f,s);
 
   // print the array, sorted by decreasing frequency
   for (f, s) in arr.sorted(reverseComparator) do
@@ -85,7 +85,7 @@ proc calculate(data, param nclSize) {
       myFreqs[hash(data, i, nclSize)] += 1;
 
     lock.readFE();      // acquire lock
-    for (k,v) in zip(myFreqs.keys(), myFreqs.values()) do
+    for (k,v) in myFreqs.items() do
       freqs[k] += v;
     lock.writeEF(true); // release lock
   }

--- a/test/studies/shootout/submitted/knucleotide3.good
+++ b/test/studies/shootout/submitted/knucleotide3.good
@@ -4,12 +4,42 @@ knucleotide3.chpl:25: warning: channel.readline is deprecated. Use channel.readL
 knucleotide3.chpl:25: warning: channel.readline is deprecated. Use channel.readLine instead
 knucleotide3.chpl:33: warning: channel.readline is deprecated. Use channel.readLine instead
 knucleotide3.chpl:33: warning: channel.readline is deprecated. Use channel.readLine instead
-knucleotide3.chpl:53: In function 'writeFreqs':
-knucleotide3.chpl:60: warning: 'Array.sorted' is deprecated - use Sort.sort instead
+knucleotide3.chpl:76: In function 'calculate':
+knucleotide3.chpl:88: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide3.chpl:54: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 1) from function 'writeFreqs'
   knucleotide3.chpl:43: called as writeFreqs(data: [domain(1,int(64),false)] uint(8), param nclSize = 1) from function 'main'
 knucleotide3.chpl:53: In function 'writeFreqs':
+knucleotide3.chpl:57: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+knucleotide3.chpl:60: warning: 'Array.sorted' is deprecated - use Sort.sort instead
+  knucleotide3.chpl:43: called as writeFreqs(data: [domain(1,int(64),false)] uint(8), param nclSize = 1) from function 'main'
+knucleotide3.chpl:76: In function 'calculate':
+knucleotide3.chpl:88: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide3.chpl:54: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 2) from function 'writeFreqs'
+  knucleotide3.chpl:44: called as writeFreqs(data: [domain(1,int(64),false)] uint(8), param nclSize = 2) from function 'main'
+knucleotide3.chpl:53: In function 'writeFreqs':
+knucleotide3.chpl:57: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
 knucleotide3.chpl:60: warning: 'Array.sorted' is deprecated - use Sort.sort instead
   knucleotide3.chpl:44: called as writeFreqs(data: [domain(1,int(64),false)] uint(8), param nclSize = 2) from function 'main'
+knucleotide3.chpl:76: In function 'calculate':
+knucleotide3.chpl:88: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide3.chpl:69: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 3) from function 'writeCount'
+  knucleotide3.chpl:45: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGT") from function 'main'
+knucleotide3.chpl:76: In function 'calculate':
+knucleotide3.chpl:88: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide3.chpl:69: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 4) from function 'writeCount'
+  knucleotide3.chpl:46: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGTA") from function 'main'
+knucleotide3.chpl:76: In function 'calculate':
+knucleotide3.chpl:88: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide3.chpl:69: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 6) from function 'writeCount'
+  knucleotide3.chpl:47: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGTATT") from function 'main'
+knucleotide3.chpl:76: In function 'calculate':
+knucleotide3.chpl:88: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide3.chpl:69: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 12) from function 'writeCount'
+  knucleotide3.chpl:48: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGTATTTTAATT") from function 'main'
+knucleotide3.chpl:76: In function 'calculate':
+knucleotide3.chpl:88: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide3.chpl:69: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 18) from function 'writeCount'
+  knucleotide3.chpl:49: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGTATTTTAATTTATAGT") from function 'main'
 A 30.279
 T 30.113
 G 19.835

--- a/test/studies/shootout/submitted/knucleotide4.chpl
+++ b/test/studies/shootout/submitted/knucleotide4.chpl
@@ -53,7 +53,7 @@ proc writeFreqs(data, param nclSize) {
   const freqs = calculate(data, nclSize);
 
   // create an array of (frequency, sequence) tuples
-  var arr = for (s,f) in zip(freqs.keys(), freqs.values()) do (f,s.val);
+  var arr = for (s,f) in freqs.items() do (f,s.val);
 
   // print the array, sorted by decreasing frequency
   for (f, s) in arr.sorted(reverseComparator) do
@@ -84,7 +84,7 @@ proc calculate(data, param nclSize) {
       myFreqs[hash(data, i, nclSize)] += 1;
 
     lock.readFE();      // acquire lock
-    for (k,v) in zip(myFreqs.keys(), myFreqs.values()) do
+    for (k,v) in myFreqs.items() do
       freqs[k] += v;
     lock.writeEF(true); // release lock
   }

--- a/test/studies/shootout/submitted/knucleotide4.good
+++ b/test/studies/shootout/submitted/knucleotide4.good
@@ -4,12 +4,42 @@ knucleotide4.chpl:24: warning: channel.readline is deprecated. Use channel.readL
 knucleotide4.chpl:24: warning: channel.readline is deprecated. Use channel.readLine instead
 knucleotide4.chpl:32: warning: channel.readline is deprecated. Use channel.readLine instead
 knucleotide4.chpl:32: warning: channel.readline is deprecated. Use channel.readLine instead
-knucleotide4.chpl:52: In function 'writeFreqs':
-knucleotide4.chpl:59: warning: 'Array.sorted' is deprecated - use Sort.sort instead
+knucleotide4.chpl:75: In function 'calculate':
+knucleotide4.chpl:87: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide4.chpl:53: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 1) from function 'writeFreqs'
   knucleotide4.chpl:42: called as writeFreqs(data: [domain(1,int(64),false)] uint(8), param nclSize = 1) from function 'main'
 knucleotide4.chpl:52: In function 'writeFreqs':
+knucleotide4.chpl:56: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+knucleotide4.chpl:59: warning: 'Array.sorted' is deprecated - use Sort.sort instead
+  knucleotide4.chpl:42: called as writeFreqs(data: [domain(1,int(64),false)] uint(8), param nclSize = 1) from function 'main'
+knucleotide4.chpl:75: In function 'calculate':
+knucleotide4.chpl:87: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide4.chpl:53: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 2) from function 'writeFreqs'
+  knucleotide4.chpl:43: called as writeFreqs(data: [domain(1,int(64),false)] uint(8), param nclSize = 2) from function 'main'
+knucleotide4.chpl:52: In function 'writeFreqs':
+knucleotide4.chpl:56: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
 knucleotide4.chpl:59: warning: 'Array.sorted' is deprecated - use Sort.sort instead
   knucleotide4.chpl:43: called as writeFreqs(data: [domain(1,int(64),false)] uint(8), param nclSize = 2) from function 'main'
+knucleotide4.chpl:75: In function 'calculate':
+knucleotide4.chpl:87: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide4.chpl:68: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 3) from function 'writeCount'
+  knucleotide4.chpl:44: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGT") from function 'main'
+knucleotide4.chpl:75: In function 'calculate':
+knucleotide4.chpl:87: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide4.chpl:68: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 4) from function 'writeCount'
+  knucleotide4.chpl:45: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGTA") from function 'main'
+knucleotide4.chpl:75: In function 'calculate':
+knucleotide4.chpl:87: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide4.chpl:68: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 6) from function 'writeCount'
+  knucleotide4.chpl:46: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGTATT") from function 'main'
+knucleotide4.chpl:75: In function 'calculate':
+knucleotide4.chpl:87: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide4.chpl:68: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 12) from function 'writeCount'
+  knucleotide4.chpl:47: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGTATTTTAATT") from function 'main'
+knucleotide4.chpl:75: In function 'calculate':
+knucleotide4.chpl:87: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+  knucleotide4.chpl:68: called as calculate(data: [domain(1,int(64),false)] uint(8), param nclSize = 18) from function 'writeCount'
+  knucleotide4.chpl:48: called as writeCount(data: [domain(1,int(64),false)] uint(8), param str = "GGTATTTTAATTTATAGT") from function 'main'
 A 30.279
 T 30.113
 G 19.835


### PR DESCRIPTION
In #21733, I had updated submitted benchmarks rather than updating their good files so that we remember to go and update the submitted files. This PR undoes the changes that were made and updates the good files to reflect the deprecations.