### PR TITLE
Deprecate and rename the Barriers module and Barrier type

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -70,8 +70,6 @@ static bool        includesParameterizedPrimitive(FnSymbol* fn);
 static void        replaceFunctionWithInstantiationsOfPrimitive(FnSymbol* fn);
 static void        fixupQueryFormals(FnSymbol* fn);
 
-static bool        isConstructor(FnSymbol* fn);
-
 static void        updateInitMethod (FnSymbol* fn);
 
 static void        checkUseBeforeDefs();
@@ -119,8 +117,6 @@ static void        updateVariableAutoDestroy(DefExpr* defExpr);
 
 static TypeSymbol* expandTypeAlias(SymExpr* se);
 
-static bool        firstConstructorWarning = true;
-
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
@@ -165,15 +161,7 @@ void normalize() {
     } else {
       fixupQueryFormals(fn);
 
-      if (isConstructor(fn) == true) {
-        Type* ct = fn->_this->getValType();
-        if (firstConstructorWarning) {
-          USR_PRINT(fn, "Constructors have been deprecated as of Chapel 1.18. Please use initializers instead.");
-          firstConstructorWarning = false;
-        }
-        USR_FATAL_CONT(fn, "Type '%s' defines a constructor here", ct->symbol->name);
-
-      } else if (fn->isInitializer() || fn->isCopyInit()) {
+      if (fn->isInitializer() || fn->isCopyInit()) {
         updateInitMethod(fn);
       }
     }
@@ -4530,18 +4518,6 @@ static void addToWhereClause(FnSymbol*  fn,
 *                                                                             *
 *                                                                             *
 ************************************** | *************************************/
-
-static bool isConstructor(FnSymbol* fn) {
-  bool retval = false;
-
-  if (fn->numFormals()       >= 2 &&
-      fn->getFormal(1)->type == dtMethodToken) {
-
-    retval = strcmp(fn->name, fn->getFormal(2)->type->symbol->name) == 0;
-  }
-
-  return retval;
-}
 
 static void updateInitMethod(FnSymbol* fn) {
   Type* thisType = fn->_this->type;

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -87,6 +87,7 @@ Parallelism/Distributed Computing
    :maxdepth: 1
 
    Barriers <standard/Barriers>
+   Collectives <standard/Collectives>
    Communication <standard/Communication>
    DynamicIters <standard/DynamicIters>
    GPU <standard/GPU>

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -74,6 +74,7 @@ MODULES_TO_DOCUMENT = \
 	standard/BitOps.chpl \
 	standard/ChapelIO.chpl \
 	standard/ChplConfig.chpl \
+	standard/Collectives.chpl \
 	standard/CommDiagnostics.chpl \
 	standard/Communication.chpl \
 	standard/GPUDiagnostics.chpl \

--- a/modules/packages/AllLocalesBarriers.chpl
+++ b/modules/packages/AllLocalesBarriers.chpl
@@ -25,11 +25,12 @@
    per locale.
 
    The :var:`allLocalesBarrier` barrier only supports the
-   :proc:`~Barriers.Barrier.barrier()` and :proc:`~Barriers.Barrier.reset()`
-   methods of the :attr:`~Barriers.Barrier` interface. By default it can be
+   :proc:`~Collectives.barrier.barrier()` and
+   :proc:`~Collectives.barrier.reset()` methods of the
+   :attr:`~Collectives.barrier` interface. By default it can be
    used as a barrier between 1 task on each locale. The
-   :proc:`~Barriers.Barrier.reset()` method can be used change how many tasks
-   per locale will participate in each barrier.
+   :proc:`~Collectives.barrier.reset()` method can be used change how
+   many tasks per locale will participate in each barrier.
 
    Use of this barrier is similar to ``shmem_barrier_all()`` or
    ``MPI_Barrier(MPI_COMM_WORLD)``, except that it's possible for multiple
@@ -65,7 +66,7 @@
    barrier that's optimized for the network will be used.
 */
 module AllLocalesBarriers {
-  use BlockDist, Barriers;
+  use BlockDist, Collectives;
 
   private const BarrierSpace = LocaleSpace dmapped Block(LocaleSpace);
   private var globalBarrier = [b in BarrierSpace] new unmanaged aBarrier(1, reusable=true, procAtomics=true, hackIntoCommBarrier=true);

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -58,9 +58,11 @@
    this barrier implementation is optimized and as the task-team concept is
    implemented and optimized.
 */
+deprecated "The 'Barriers' module is deprecated, please use 'Collectives' instead"
 module Barriers {
   import HaltWrappers;
   import ChplConfig;
+  import Collectives.{BarrierBaseType, aBarrier, sBarrier};
 
   /* An enumeration of the different barrier implementations.  Used to choose
      the implementation to use when constructing a new barrier object.
@@ -72,6 +74,7 @@ module Barriers {
   enum BarrierType {Atomic, Sync}
 
   /* A barrier that will cause `numTasks` to wait before proceeding. */
+  deprecated "The 'Barrier' type is deprecated, please use 'Collectives.barrier' instead"
   record Barrier {
     pragma "no doc"
     var bar: unmanaged BarrierBaseType;
@@ -187,256 +190,6 @@ module Barriers {
     }
   }
 
-  /* The BarrierBaseType class provides an abstract base type for barriers
-   */
-  pragma "no doc"
-  class BarrierBaseType {
-    pragma "no doc"
-    proc barrier() {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
-    pragma "no doc"
-    proc notify() {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
-    pragma "no doc"
-    proc wait() {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
-    pragma "no doc"
-    proc check(): bool {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
-    pragma "no doc"
-    proc reset(nTasks: int) {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-  }
-
-/* A task barrier implemented using atomics. Can be used as a simple barrier
-   or as a split-phase barrier.
- */
-  pragma "no doc" class aBarrier: BarrierBaseType {
-    /* If true the barrier can be used multiple times.  When using this as a
-       split-phase barrier this causes :proc:`wait` to block until all tasks
-       have reached the wait */
-    param reusable = true;
-
-    pragma "no doc"
-    var n: int;
-    pragma "no doc"
-    param procAtomics = if ChplConfig.CHPL_NETWORK_ATOMICS == "none" then true else false;
-    pragma "no doc"
-    var count: if procAtomics then chpl__processorAtomicType(int) else atomic int;
-    pragma "no doc"
-    var done: if procAtomics then chpl__processorAtomicType(bool) else atomic bool;
-
-    // Hack for AllLocalesBarrier
-    pragma "no doc"
-    param hackIntoCommBarrier = false;
-
-    /* Construct a new Barrier object.
-
-       :arg n: The number of tasks involved in this barrier
-     */
-    proc init(n: int, param reusable: bool) {
-      this.reusable = reusable;
-      this.complete();
-      reset(n);
-    }
-
-    // Hack for AllLocalesBarrier
-    pragma "no doc"
-    proc init(n: int, param reusable: bool, param procAtomics: bool, param hackIntoCommBarrier: bool) {
-      this.reusable = reusable;
-      this.procAtomics = procAtomics;
-      this.hackIntoCommBarrier = hackIntoCommBarrier;
-      this.complete();
-      reset(n);
-    }
-
-    pragma "no doc"
-    /* inline */ override proc reset(nTasks: int) {
-      inline proc innerReset() {
-        n = nTasks;
-        count.write(n);
-        done.write(false);
-      }
-      if procAtomics then on this do innerReset(); else innerReset();
-    }
-
-    /* Block until n tasks have called this method.  If `reusable` is true,
-       reset the barrier to be used again.
-     */
-    /* inline */ override proc barrier() {
-      inline proc innerBarrier() {
-        const myc = count.fetchSub(1);
-        if myc<=1 {
-          if hackIntoCommBarrier {
-            extern proc chpl_comm_barrier(msg: c_string);
-            chpl_comm_barrier(c"local barrier call");
-          }
-          const alreadySet = done.testAndSet();
-          if boundsChecking && alreadySet {
-            HaltWrappers.boundsCheckHalt("Too many callers to barrier()");
-          }
-          if reusable {
-            count.waitFor(n-1);
-            count.add(1);
-            done.clear();
-          }
-        } else {
-          done.waitFor(true);
-          if reusable {
-            count.add(1);
-            done.waitFor(false);
-          }
-        }
-      }
-      if procAtomics then on this do innerBarrier(); else innerBarrier();
-    }
-
-    /* Notify the barrier that this task has reached this point. */
-    /* inline */ override proc notify() {
-      inline proc innerNotify() {
-        const myc = count.fetchSub(1);
-        if myc<=1 {
-          const alreadySet = done.testAndSet();
-          if boundsChecking && alreadySet {
-            HaltWrappers.boundsCheckHalt("Too many callers to notify()");
-          }
-        }
-      }
-      if procAtomics then on this do innerNotify(); else innerNotify();
-    }
-
-    /* Wait until `n` tasks have called :proc:`notify`.  If `reusable` is true,
-       reset the barrier to be used again.  Note: if `reusable` is true
-       :proc:`wait` will block until `n` tasks have called it after calling
-       :proc:`notify`.
-     */
-    /* inline */ override proc wait() {
-      inline proc innerWait() {
-        done.waitFor(true);
-        if reusable {
-          const myc = count.fetchAdd(1);
-          if myc == n-1 then
-            done.clear();
-          done.waitFor(false);
-        }
-      }
-      if procAtomics then on this do innerWait(); else innerWait();
-    }
-
-    /* Return `true` if `n` tasks have called :proc:`notify`
-     */
-    /* inline */ override proc check(): bool {
-      return done.read();
-    }
-  }
-
-  /* A task barrier implemented using sync and single variables. Can be used
-     as a simple barrier or as a split-phase barrier.
-   */
- pragma "no doc" class sBarrier: BarrierBaseType {
-    /* If true the barrier can be used multiple times.  When using this as a
-       split-phase barrier this causes :proc:`wait` to block until all tasks
-       have reached the wait */
-    param reusable = true;
-
-    pragma "no doc"
-    var inGate: sync int;
-    pragma "no doc"
-    var outGate: sync int;
-    pragma "no doc"
-    var blockers: chpl__processorAtomicType(int);
-    pragma "no doc"
-    var maxBlockers: int;
-
-    /* Construct a new `n` task Barrier.
-       :arg n: The number of tasks that will be involved in the barrier.
-     */
-    proc init(n: int, param reusable: bool) {
-      this.reusable = reusable;
-      this.complete();
-      reset(n);
-    }
-
-    /* inline */ override proc reset(nTasks: int) {
-      maxBlockers = nTasks;
-      blockers.write(0);
-      outGate.reset();
-      inGate.writeXF(0);
-    }
-
-    /* Block until `n` tasks have called this method.
-     */
-    /* inline */ override proc barrier() {
-      on this {
-        if boundsChecking && blockers.read() >= maxBlockers {
-          HaltWrappers.boundsCheckHalt("Too many callers to barrier()");
-        }
-        inGate.readFF();
-        var waiters = blockers.fetchAdd(1) + 1;
-
-        if waiters == maxBlockers {
-          inGate.reset();
-          outGate.writeXF(0);
-        } else {
-          outGate.readFF();
-        }
-
-        if reusable {
-          waiters = blockers.fetchSub(1) - 1;
-          if waiters == 0 {
-            outGate.reset();
-            inGate.writeXF(0);
-          }
-        }
-      }
-    }
-
-    /* Notify the barrier that this task has reached this point. */
-    /* inline */ override proc notify() {
-      on this {
-        if boundsChecking && blockers.read() >= maxBlockers {
-          HaltWrappers.boundsCheckHalt("Too many callers to notify()");
-        }
-
-        inGate.readFF();
-        var waiters = blockers.fetchAdd(1) + 1;
-        if waiters == maxBlockers {
-          inGate.reset();
-          outGate.writeXF(0);
-        }
-      }
-    }
-
-    /* Wait until `n` tasks have called :proc:`notify`. */
-    /* inline */ override proc wait() {
-      on this {
-        outGate.readFF();
-        if reusable {
-          var waiters = blockers.fetchSub(1) - 1;
-          if waiters == 0 {
-            outGate.reset();
-            inGate.writeXF(0);
-          }
-        }
-      }
-    }
-
-    /* Return `true` if `n` tasks have called :proc:`notify`
-     */
-    /* inline */ override proc check(): bool {
-      return outGate.isFull;
-    }
-  }
-
   pragma "no doc"
   operator Barrier.=(ref lhs: Barrier, rhs: Barrier) {
     if lhs.isowned {
@@ -447,4 +200,3 @@ module Barriers {
   }
 
 }
-

--- a/modules/standard/Collectives.chpl
+++ b/modules/standard/Collectives.chpl
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Support for barriers between tasks.
+
+   The barrier type provided in this module can be used to prevent tasks
+   from proceeding until all other related tasks have also reached the
+   barrier.
+
+   In the following example, all of the tasks created by the coforall loop
+   will print their "entering the barrier" messages in an unspecified order,
+   then all of the tasks will print their "past the barrier" messages, also
+   in an unspecified order.  Because of the barrier, all of the
+   "entering the barrier" messages will be printed before any of the
+   "past the barrier" messages.
+
+   .. code-block:: chapel
+
+     use Collectives;
+
+     config const numTasks = here.maxTaskPar;
+     var b = new barrier(numTasks);
+
+     coforall tid in 1..numTasks {
+       writeln("Task ", tid, " is entering the barrier");
+       b.barrier();
+       writeln("Task ", tid, " is past the barrier");
+     }
+
+   Note: When a barrier instance goes out of scope it is automatically deleted.
+   After it is deleted, any copies of the barrier that remain are invalid.
+
+   Future direction
+   ----------------
+   In the future, we expect to add more language-level support for a
+   "task-team" concept.  A task-team will more directly support collective
+   operations such as barriers between the tasks within a team.
+
+   The current implementation is designed for correctness, but is not expected
+   to perform well at scale.  We expect performance at scale to improve as
+   this barrier implementation is optimized and as the task-team concept is
+   implemented and optimized.
+*/
+module Collectives {
+  import HaltWrappers;
+  import ChplConfig;
+
+  /* An enumeration of the different barrier implementations.  Used to choose
+     the implementation to use when constructing a new barrier object.
+
+     * `BarrierType.Atomic` uses Chapel atomic variables to control the barrier.
+     * `BarrierType.Sync` uses Chapel sync variables to control the barrier.
+  */
+  deprecated "BarrierType is deprecated, please use the default barrier implementation"
+  enum BarrierType {Atomic, Sync}
+
+  /* A barrier that will cause `numTasks` to wait before proceeding. */
+  record barrier {
+    pragma "no doc"
+    var bar: unmanaged BarrierBaseType;
+    pragma "no doc"
+    var isowned: bool = false;
+
+    /* Construct a new barrier object.
+
+       :arg numTasks: The number of tasks that will use this barrier
+       :arg barrierType: The barrier implementation to use
+       :arg reusable: Incur some extra overhead to allow reuse of this barrier?
+
+    */
+    proc init(numTasks: int, reusable: bool = true) {
+      if reusable {
+        bar = new unmanaged aBarrier(numTasks, reusable=true);
+      } else {
+        bar = new unmanaged aBarrier(numTasks, reusable=false);
+      }
+      isowned = true;
+    }
+
+    /* Construct a new barrier object.
+
+       :arg numTasks: The number of tasks that will use this barrier
+       :arg barrierType: The barrier implementation to use
+       :arg reusable: Incur some extra overhead to allow reuse of this barrier?
+
+    */
+    deprecated "choosing a barrier type is deprecated, please remove the 'barrierType' argument"
+    proc init(numTasks: int,
+              barrierType: BarrierType,
+              reusable: bool = true) {
+      select barrierType {
+        when BarrierType.Atomic {
+          if reusable {
+            bar = new unmanaged aBarrier(numTasks, reusable=true);
+          } else {
+            bar = new unmanaged aBarrier(numTasks, reusable=false);
+          }
+        }
+        when BarrierType.Sync {
+          if reusable {
+            bar = new unmanaged sBarrier(numTasks, reusable=true);
+          } else {
+            bar = new unmanaged sBarrier(numTasks, reusable=false);
+          }
+        }
+        otherwise {
+          HaltWrappers.exhaustiveSelectHalt("unknown barrier type");
+          bar = new unmanaged BarrierBaseType(); // dummy
+        }
+      }
+      isowned = true;
+    }
+
+    pragma "no doc"
+    proc init() {
+      this.init(0);
+    }
+
+    /* copy initializer */
+    pragma "no doc"
+    proc init=(b: barrier) {
+      this.bar = b.bar;
+      this.isowned = false;
+    }
+
+    pragma "no doc"
+    proc deinit() {
+      if isowned && bar != nil {
+        delete bar;
+      }
+    }
+
+    /* Block until all related tasks have called this method.  If `reusable`
+       is true, reset the barrier to be used again.
+     */
+    inline proc barrier() {
+      bar.barrier();
+    }
+
+    /* Notify the barrier that this task has reached this point. */
+    inline proc notify() {
+      bar.notify();
+    }
+
+    /* Wait until `n` tasks have called :proc:`notify`.  If `reusable` is true,
+       reset the barrier to be used again.
+
+       Note: if `reusable` is true the tasks will wait until all `n` tasks
+       have called both :proc:`notify` and :proc:`wait` at which point the
+       barrier will automatically be reset for the next use.  If `reusable`
+       is false, each task calling :proc:`wait` can return as soon as all
+       `n` tasks have called :proc:`notify`.
+     */
+    inline proc wait() {
+      bar.wait();
+    }
+
+    /* Return `true` if `n` tasks have called :proc:`notify`
+     */
+    inline proc check(): bool {
+      return bar.check();
+    }
+
+    /* Reset the barrier, setting it to work with `nTasks` tasks.  If some
+       (but not all) tasks had already called :proc:`barrier` or :proc:`check`
+       when :proc:`reset` is called, the behavior is undefined.
+     */
+    inline proc reset(nTasks: int) {
+      bar.reset(nTasks);
+    }
+  }
+
+  /* The BarrierBaseType class provides an abstract base type for barriers
+   */
+  pragma "no doc"
+  class BarrierBaseType {
+    pragma "no doc"
+    proc barrier() {
+      HaltWrappers.pureVirtualMethodHalt();
+    }
+
+    pragma "no doc"
+    proc notify() {
+      HaltWrappers.pureVirtualMethodHalt();
+    }
+
+    pragma "no doc"
+    proc wait() {
+      HaltWrappers.pureVirtualMethodHalt();
+    }
+
+    pragma "no doc"
+    proc check(): bool {
+      HaltWrappers.pureVirtualMethodHalt();
+    }
+
+    pragma "no doc"
+    proc reset(nTasks: int) {
+      HaltWrappers.pureVirtualMethodHalt();
+    }
+  }
+
+/* A task barrier implemented using atomics. Can be used as a simple barrier
+   or as a split-phase barrier.
+ */
+  pragma "no doc" class aBarrier: BarrierBaseType {
+    /* If true the barrier can be used multiple times.  When using this as a
+       split-phase barrier this causes :proc:`wait` to block until all tasks
+       have reached the wait */
+    param reusable = true;
+
+    pragma "no doc"
+    var n: int;
+    pragma "no doc"
+    param procAtomics = if ChplConfig.CHPL_NETWORK_ATOMICS == "none" then true else false;
+    pragma "no doc"
+    var count: if procAtomics then chpl__processorAtomicType(int) else atomic int;
+    pragma "no doc"
+    var done: if procAtomics then chpl__processorAtomicType(bool) else atomic bool;
+
+    // Hack for AllLocalesBarrier
+    pragma "no doc"
+    param hackIntoCommBarrier = false;
+
+    /* Construct a new Barrier object.
+
+       :arg n: The number of tasks involved in this barrier
+     */
+    proc init(n: int, param reusable: bool) {
+      this.reusable = reusable;
+      this.complete();
+      reset(n);
+    }
+
+    // Hack for AllLocalesBarrier
+    pragma "no doc"
+    proc init(n: int, param reusable: bool, param procAtomics: bool, param hackIntoCommBarrier: bool) {
+      this.reusable = reusable;
+      this.procAtomics = procAtomics;
+      this.hackIntoCommBarrier = hackIntoCommBarrier;
+      this.complete();
+      reset(n);
+    }
+
+    pragma "no doc"
+    /* inline */ override proc reset(nTasks: int) {
+      inline proc innerReset() {
+        n = nTasks;
+        count.write(n);
+        done.write(false);
+      }
+      if procAtomics then on this do innerReset(); else innerReset();
+    }
+
+    /* Block until n tasks have called this method.  If `reusable` is true,
+       reset the barrier to be used again.
+     */
+    /* inline */ override proc barrier() {
+      inline proc innerBarrier() {
+        const myc = count.fetchSub(1);
+        if myc<=1 {
+          if hackIntoCommBarrier {
+            extern proc chpl_comm_barrier(msg: c_string);
+            chpl_comm_barrier(c"local barrier call");
+          }
+          const alreadySet = done.testAndSet();
+          if boundsChecking && alreadySet {
+            HaltWrappers.boundsCheckHalt("Too many callers to barrier()");
+          }
+          if reusable {
+            count.waitFor(n-1);
+            count.add(1);
+            done.clear();
+          }
+        } else {
+          done.waitFor(true);
+          if reusable {
+            count.add(1);
+            done.waitFor(false);
+          }
+        }
+      }
+      if procAtomics then on this do innerBarrier(); else innerBarrier();
+    }
+
+    /* Notify the barrier that this task has reached this point. */
+    /* inline */ override proc notify() {
+      inline proc innerNotify() {
+        const myc = count.fetchSub(1);
+        if myc<=1 {
+          const alreadySet = done.testAndSet();
+          if boundsChecking && alreadySet {
+            HaltWrappers.boundsCheckHalt("Too many callers to notify()");
+          }
+        }
+      }
+      if procAtomics then on this do innerNotify(); else innerNotify();
+    }
+
+    /* Wait until `n` tasks have called :proc:`notify`.  If `reusable` is true,
+       reset the barrier to be used again.  Note: if `reusable` is true
+       :proc:`wait` will block until `n` tasks have called it after calling
+       :proc:`notify`.
+     */
+    /* inline */ override proc wait() {
+      inline proc innerWait() {
+        done.waitFor(true);
+        if reusable {
+          const myc = count.fetchAdd(1);
+          if myc == n-1 then
+            done.clear();
+          done.waitFor(false);
+        }
+      }
+      if procAtomics then on this do innerWait(); else innerWait();
+    }
+
+    /* Return `true` if `n` tasks have called :proc:`notify`
+     */
+    /* inline */ override proc check(): bool {
+      return done.read();
+    }
+  }
+
+  /* A task barrier implemented using sync and single variables. Can be used
+     as a simple barrier or as a split-phase barrier.
+   */
+ pragma "no doc" class sBarrier: BarrierBaseType {
+    /* If true the barrier can be used multiple times.  When using this as a
+       split-phase barrier this causes :proc:`wait` to block until all tasks
+       have reached the wait */
+    param reusable = true;
+
+    pragma "no doc"
+    var inGate: sync int;
+    pragma "no doc"
+    var outGate: sync int;
+    pragma "no doc"
+    var blockers: chpl__processorAtomicType(int);
+    pragma "no doc"
+    var maxBlockers: int;
+
+    /* Construct a new `n` task Barrier.
+       :arg n: The number of tasks that will be involved in the barrier.
+     */
+    proc init(n: int, param reusable: bool) {
+      this.reusable = reusable;
+      this.complete();
+      reset(n);
+    }
+
+    /* inline */ override proc reset(nTasks: int) {
+      maxBlockers = nTasks;
+      blockers.write(0);
+      outGate.reset();
+      inGate.writeXF(0);
+    }
+
+    /* Block until `n` tasks have called this method.
+     */
+    /* inline */ override proc barrier() {
+      on this {
+        if boundsChecking && blockers.read() >= maxBlockers {
+          HaltWrappers.boundsCheckHalt("Too many callers to barrier()");
+        }
+        inGate.readFF();
+        var waiters = blockers.fetchAdd(1) + 1;
+
+        if waiters == maxBlockers {
+          inGate.reset();
+          outGate.writeXF(0);
+        } else {
+          outGate.readFF();
+        }
+
+        if reusable {
+          waiters = blockers.fetchSub(1) - 1;
+          if waiters == 0 {
+            outGate.reset();
+            inGate.writeXF(0);
+          }
+        }
+      }
+    }
+
+    /* Notify the barrier that this task has reached this point. */
+    /* inline */ override proc notify() {
+      on this {
+        if boundsChecking && blockers.read() >= maxBlockers {
+          HaltWrappers.boundsCheckHalt("Too many callers to notify()");
+        }
+
+        inGate.readFF();
+        var waiters = blockers.fetchAdd(1) + 1;
+        if waiters == maxBlockers {
+          inGate.reset();
+          outGate.writeXF(0);
+        }
+      }
+    }
+
+    /* Wait until `n` tasks have called :proc:`notify`. */
+    /* inline */ override proc wait() {
+      on this {
+        outGate.readFF();
+        if reusable {
+          var waiters = blockers.fetchSub(1) - 1;
+          if waiters == 0 {
+            outGate.reset();
+            inGate.writeXF(0);
+          }
+        }
+      }
+    }
+
+    /* Return `true` if `n` tasks have called :proc:`notify`
+     */
+    /* inline */ override proc check(): bool {
+      return outGate.isFull;
+    }
+  }
+
+  pragma "no doc"
+  operator barrier.=(ref lhs: barrier, rhs: barrier) {
+    if lhs.isowned {
+      delete lhs.bar;
+    }
+    lhs.bar = rhs.bar;
+    lhs.isowned = false;
+  }
+
+}
+

--- a/test/classes/constructors/warnConstructors.chpl
+++ b/test/classes/constructors/warnConstructors.chpl
@@ -18,6 +18,6 @@ class D {
   }
 }
 
-var c = new owned C(1.5);
+var c = new owned C(2);
 
 var d = new owned D(1.5);

--- a/test/classes/constructors/warnConstructors.good
+++ b/test/classes/constructors/warnConstructors.good
@@ -1,4 +1,0 @@
-warnConstructors.chpl:4: note: Constructors have been deprecated as of Chapel 1.18. Please use initializers instead.
-warnConstructors.chpl:4: error: Type 'C' defines a constructor here
-warnConstructors.chpl:9: error: Type 'C' defines a constructor here
-warnConstructors.chpl:16: error: Type 'D' defines a constructor here

--- a/test/classes/initializers/oldAndNew.chpl
+++ b/test/classes/initializers/oldAndNew.chpl
@@ -9,7 +9,6 @@ class badClass {
     writeln("in old constructor");
   }
 }
-
-var c: badClass = new badClass(); // Should fail
-// Can't distinguish between the two initializer styles.
+// 'proc badClass' is a regular method, this uses 'init'.
+var c: badClass = new badClass();
 writeln(c);

--- a/test/classes/initializers/oldAndNew.good
+++ b/test/classes/initializers/oldAndNew.good
@@ -1,2 +1,2 @@
-oldAndNew.chpl:8: note: Constructors have been deprecated as of Chapel 1.18. Please use initializers instead.
-oldAndNew.chpl:8: error: Type 'badClass' defines a constructor here
+in new initializer
+{i = 10}

--- a/test/classes/initializers/oldAndNew2.chpl
+++ b/test/classes/initializers/oldAndNew2.chpl
@@ -11,8 +11,6 @@ class badClass {
   }
 }
 
-var c: badClass = new badClass(); // Should fail
-// Can't distinguish between the two initializer styles.
+// 'proc badClass' is a regular method, not a constructor
+var c: badClass = new badClass();
 writeln(c);
-// Variation on oldAndNew.chpl with constructor taking a different argument list
-// than the initializer

--- a/test/classes/initializers/oldAndNew2.good
+++ b/test/classes/initializers/oldAndNew2.good
@@ -1,2 +1,2 @@
-oldAndNew2.chpl:8: note: Constructors have been deprecated as of Chapel 1.18. Please use initializers instead.
-oldAndNew2.chpl:8: error: Type 'badClass' defines a constructor here
+in new initializer
+{i = 10}

--- a/test/classes/initializers/oldAndNew3.chpl
+++ b/test/classes/initializers/oldAndNew3.chpl
@@ -11,8 +11,6 @@ class badClass {
   }
 }
 
+// 'proc badClass' is a regular method, not a constructor
 var c: badClass = new badClass(); // Should fail
-// Can't distinguish between the two initializer styles.
 writeln(c);
-// Variation on oldAndNew2.chpl with the constructor occurring before the
-// initializer in code.

--- a/test/classes/initializers/oldAndNew3.good
+++ b/test/classes/initializers/oldAndNew3.good
@@ -1,2 +1,2 @@
-oldAndNew3.chpl:4: note: Constructors have been deprecated as of Chapel 1.18. Please use initializers instead.
-oldAndNew3.chpl:4: error: Type 'badClass' defines a constructor here
+in new initializer
+{i = 10}

--- a/test/classes/weakPointers/concurrentUpgrades.chpl
+++ b/test/classes/weakPointers/concurrentUpgrades.chpl
@@ -1,6 +1,6 @@
 
 use WeakPointer;
-use Barriers;
+use Collectives;
 
 class basicClass {
     var x :int;
@@ -12,7 +12,7 @@ proc concurrentlyUpgrade(s) {
     const wp = new weakPointer(s);
     var correct: atomic bool = true;
 
-    var b = new Barrier(n);
+    var b = new barrier(n);
 
     coforall tid in 0..<n {
         var my_weak = wp;

--- a/test/classes/weakPointers/passiveCache.chpl
+++ b/test/classes/weakPointers/passiveCache.chpl
@@ -3,7 +3,7 @@ import Map.map;
 import ChapelLocks;
 import Random;
 use WeakPointer;
-use Barriers;
+use Collectives;
 
 class PassiveCache {
     type dataType; // assuming this type has a an initializer that takes an int
@@ -76,7 +76,7 @@ proc main() {
 
         // concurrently construct or upgrade the 'basicClass' associated with each 'tid'
         //  and ensure that the strong count is correct
-        var b = new Barrier(num_task_ids);
+        var b = new barrier(num_task_ids);
         coforall tid in task_ids {
             var shared_tid : shared basicClass = pc.getOrBuild(tid:int);
             correct.write(correct.read() && shared_tid.x == tid);

--- a/test/deprecated/BarriersModule.chpl
+++ b/test/deprecated/BarriersModule.chpl
@@ -1,0 +1,3 @@
+use Barriers;
+
+var bar = new Barrier(10);

--- a/test/deprecated/BarriersModule.good
+++ b/test/deprecated/BarriersModule.good
@@ -1,0 +1,2 @@
+BarriersModule.chpl:1: warning: The 'Barriers' module is deprecated, please use 'Collectives' instead
+BarriersModule.chpl:3: warning: The 'Barrier' type is deprecated, please use 'Collectives.barrier' instead

--- a/test/deprecated/syncBarrier.chpl
+++ b/test/deprecated/syncBarrier.chpl
@@ -1,3 +1,3 @@
-use Barriers;
+use Collectives;
 
-var sb = new Barrier(10, BarrierType.Sync);
+var sb = new barrier(10, BarrierType.Sync);

--- a/test/library/packages/Collection/CollectionCounter.chpl
+++ b/test/library/packages/Collection/CollectionCounter.chpl
@@ -1,4 +1,4 @@
-use Barriers;
+use Collectives;
 use DistributedDeque;
 use DistributedBag;
 
@@ -47,13 +47,13 @@ assert(c.getSize() == nElems);
 // Empty collection. Make sure all tasks start around same time...
 if isBag then c.balance();
 concurrentActual.write(0);
-var barrier = new Barrier(here.maxTaskPar * numLocales);
+var bar = new barrier(here.maxTaskPar * numLocales);
 coforall loc in Locales do on loc {
   var perLocaleActual : atomic int;
   const _c = c;
 
   coforall tid in 0..#here.maxTaskPar {
-    barrier.barrier();
+    bar.barrier();
     // BUG: Moving this declaration above the loop results in an incorrect
     // compiler warning: 'A while loop with a constant condition'
     var (hasElem, elt) : (bool, int) = (true, 0);

--- a/test/library/packages/Collection/CollectionNQueens.chpl
+++ b/test/library/packages/Collection/CollectionNQueens.chpl
@@ -1,4 +1,4 @@
-use Barriers;
+use Collectives;
 use DistributedBag;
 use DistributedDeque;
 
@@ -151,10 +151,10 @@ var c = (
 c.add(_defaultOf(boardType));
 
 // Begin concurrent NQueens...
-var barrier = new Barrier(here.maxTaskPar * numLocales);
+var bar = new barrier(here.maxTaskPar * numLocales);
 coforall loc in Locales do on loc {
   coforall tid in 0 .. #here.maxTaskPar {
-    barrier.barrier();
+    bar.barrier();
     var nSpins : int;
     while found.read() < totalSolutions {
       var (exists, myBoard) = c.remove();

--- a/test/library/packages/Collection/DequeParity.chpl
+++ b/test/library/packages/Collection/DequeParity.chpl
@@ -1,4 +1,4 @@
-use Barriers;
+use Collectives;
 use DistributedDeque;
 
 // For the parity test, we separate even and odd numbers on each side of the Deque.
@@ -20,12 +20,12 @@ if isBounded {
 }
 
 var deque = new DistDeque(int, cap=cap);
-var barrier = new Barrier(numLocales * here.maxTaskPar);
+var bar = new barrier(numLocales * here.maxTaskPar);
 
 // Concurrent add... Ensure they all start around same time...
 coforall loc in Locales do on loc {
   coforall tid in 0..#here.maxTaskPar {
-    barrier.barrier();
+    bar.barrier();
     for i in 1 .. nElemsPerTask {
       // Even...
       if i % 2 == 0 {

--- a/test/library/packages/Sort/RadixSort/ips4o-like.chpl
+++ b/test/library/packages/Sort/RadixSort/ips4o-like.chpl
@@ -2,7 +2,7 @@ use Random;
 use Sort;
 //use BlockDist;
 use Time;
-use Barriers;
+use Collectives;
 use PeekPoke;
 
 config const seed = SeedGenerator.oddCurrentTime;
@@ -718,7 +718,7 @@ proc parallelInPlacePartition(start_n: int, end_n: int,
   // TODO: For Block distribution
   //   - Block per-locale chunk size should be a multiple of blockSize
   //   - Need to find starting index
-  var barrier = new Barrier(nTasks);
+  var barrier = new barrier(nTasks);
 
   // Overflow block
   var overflow:[0..#blockSize] eltType;

--- a/test/optimizations/bulkcomm/block/exchange.chpl
+++ b/test/optimizations/bulkcomm/block/exchange.chpl
@@ -1,6 +1,6 @@
 
 use BlockDist;
-use Barriers;
+use Collectives;
 use CommDiagnostics;
 use Time;
 
@@ -24,7 +24,7 @@ proc main() {
 
   var A : [D] int;
 
-  var b = new Barrier(numLocales);
+  var b = new barrier(numLocales);
 
   if !time then resetCommDiagnostics();
   else tmr.start();

--- a/test/parallel/taskCount/runningTaskCount/innerCoforall.chpl
+++ b/test/parallel/taskCount/runningTaskCount/innerCoforall.chpl
@@ -1,16 +1,16 @@
-use Barriers;
+use Collectives;
 
 config const tasksPerLoc = 4;
 var taskCounts: [0..#numLocales, 0..#tasksPerLoc] (int, int);
 
 proc main() {
   for loc in Locales do on loc {
-    var barrier = new Barrier(tasksPerLoc);
+    var bar = new barrier(tasksPerLoc);
     coforall tid in 0..#tasksPerLoc {
-      barrier.barrier();
+      bar.barrier();
       const taskID = (loc.id * tasksPerLoc) + tid;
       const rt = here.runningTasks();
-      barrier.barrier();
+      bar.barrier();
       taskCounts[loc.id, tid] = (taskID, rt);
     }
   }

--- a/test/parallel/taskCount/runningTaskCount/innerOuterCoforall.chpl
+++ b/test/parallel/taskCount/runningTaskCount/innerOuterCoforall.chpl
@@ -1,16 +1,16 @@
-use Barriers;
+use Collectives;
 
 config const tasksPerLoc = 4;
 var taskCounts: [0..#numLocales, 0..#tasksPerLoc] (int, int);
 
 proc main() {
   coforall loc in Locales do on loc {
-    var barrier = new Barrier(tasksPerLoc);
+    var bar = new barrier(tasksPerLoc);
     coforall tid in 0..#tasksPerLoc {
-      barrier.barrier();
+      bar.barrier();
       const taskID = (loc.id * tasksPerLoc) + tid;
       const rt = here.runningTaskCounter.read();
-      barrier.barrier();
+      bar.barrier();
       taskCounts[loc.id, tid] = (taskID, rt);
     }
   }

--- a/test/parallel/taskCount/runningTaskCount/moved-on.chpl
+++ b/test/parallel/taskCount/runningTaskCount/moved-on.chpl
@@ -1,4 +1,4 @@
-use Barriers;
+use Collectives;
 
 // Semi-hacky locale private var so that we don't have to wait on something
 // that lives on locale 0 since that would create an additional task. Note that
@@ -10,7 +10,7 @@ proc setDoneSpinning() { doneSpinning.write(true); }
 proc spin() { doneSpinning.waitFor(true); }
 
 proc main() {
-  var barrier = new Barrier(3);
+  var bar = new barrier(3);
 
   // show that a task moved via an on-stmt will decrement the local runningTask counter
   sync {
@@ -21,24 +21,24 @@ proc main() {
       if numLocales > 1 then while (here.runningTasks() != 2) { chpl_task_yield(); }
       writeln("\n", here.runningTasks());
       on Locales[1%numLocales] do setDoneSpinning();
-      barrier.barrier();
+      bar.barrier();
     }
     begin {
       mytask();
 
       on Locales [1%numLocales] do spin();
-      barrier.barrier();
+      bar.barrier();
     }
 
     mytask();
-    barrier.barrier();
+    bar.barrier();
   }
 
 
 
   proc mytask() {
-    barrier.barrier();
+    bar.barrier();
     writeln(here.runningTasks());
-    barrier.barrier();
+    bar.barrier();
   }
 }

--- a/test/parallel/taskCount/runningTaskCount/single-locale/begin.chpl
+++ b/test/parallel/taskCount/runningTaskCount/single-locale/begin.chpl
@@ -1,7 +1,7 @@
-use Barriers;
+use Collectives; 
 
 proc main() {
-  var barrier = new Barrier(4);
+  var bar = new barrier(4);
 
   // simple begin
   sync {
@@ -12,8 +12,8 @@ proc main() {
   }
 
   proc mytask() {
-    barrier.barrier();
+    bar.barrier();
     writeln(here.runningTasks());
-    barrier.barrier();
+    bar.barrier();
   }
 }

--- a/test/parallel/taskCount/runningTaskCount/single-locale/cobegin.chpl
+++ b/test/parallel/taskCount/runningTaskCount/single-locale/cobegin.chpl
@@ -1,7 +1,7 @@
-use Barriers;
+use Collectives;
 
 proc main() {
-  var barrier = new Barrier(4);
+  var bar = new barrier(4);
 
   // simple cobegin
   cobegin {
@@ -28,8 +28,8 @@ proc main() {
 
 
   proc mytask() {
-    barrier.barrier();
+    bar.barrier();
     writeln(here.runningTasks());
-    barrier.barrier();
+    bar.barrier();
   }
 }

--- a/test/parallel/taskCount/runningTaskCount/single-locale/coforall.chpl
+++ b/test/parallel/taskCount/runningTaskCount/single-locale/coforall.chpl
@@ -1,31 +1,31 @@
-use Barriers;
+use Collectives;
 
 config const tasksPerLoc = 4;
 
 proc main() {
-  var barrier = new Barrier(tasksPerLoc);
+  var bar = new barrier(tasksPerLoc);
 
   // simple coforall
   coforall 1..tasksPerLoc {
-    barrier.barrier();
+    bar.barrier();
     writeln(here.runningTasks());
-    barrier.barrier();
+    bar.barrier();
   }
   writeln();
 
 
   // "unbounded" coforall
   coforall unknownTasksWrapperIter() {
-    barrier.barrier();
+    bar.barrier();
     // lame hack to ensure waitEndCount has been called by the main task
     while (here.runningTasks() != tasksPerLoc) { }
     writeln(here.runningTasks());
-    barrier.barrier();
+    bar.barrier();
   }
   writeln();
 
 
-  var nestedBarrier = new Barrier(tasksPerLoc*tasksPerLoc);
+  var nestedBarrier = new barrier(tasksPerLoc*tasksPerLoc);
   // nested coforall
   coforall 1..tasksPerLoc {
     coforall 1..tasksPerLoc {

--- a/test/parallel/taskCount/runningTaskCount/single-locale/combined.chpl
+++ b/test/parallel/taskCount/runningTaskCount/single-locale/combined.chpl
@@ -1,11 +1,11 @@
-use Barriers;
+use Collectives;
 
 config const tasksPerLoc = 4;
 
 proc main() {
   // 2 cobegins spawn coforalls that spawn tasksPerLoc tasks, each of which
   // spawn an additional task:
-  var barrier = new Barrier(2 * (tasksPerLoc * 2));
+  var bar = new barrier(2 * (tasksPerLoc * 2));
 
   cobegin {
     {
@@ -29,9 +29,9 @@ proc main() {
 
 
   proc mytask() {
-    barrier.barrier();
+    bar.barrier();
     writeln(here.runningTasks());
-    barrier.barrier();
+    bar.barrier();
   }
 }
 

--- a/test/parallel/taskPar/diten/barrierCheck.chpl
+++ b/test/parallel/taskPar/diten/barrierCheck.chpl
@@ -1,9 +1,9 @@
-use Barriers;
+use Collectives;
 
 config const nTasks = 4;
 config const printSpinCount = false;
 
-proc check(b: Barrier) {
+proc check(b: barrier) {
   coforall i in 1..nTasks {
     if i < nTasks {
       b.notify();
@@ -24,6 +24,6 @@ proc check(b: Barrier) {
   }
 }
 
-var b = new Barrier(nTasks);
+var b = new barrier(nTasks);
 
 check(b);

--- a/test/parallel/taskPar/diten/copyBarrier.chpl
+++ b/test/parallel/taskPar/diten/copyBarrier.chpl
@@ -1,15 +1,15 @@
-use Barriers;
+use Collectives;
 
 config const nTasks = 4;
 
-proc copyInBar(in bar: Barrier) {
+proc copyInBar(in bar: barrier) {
   coforall tid in 1..nTasks {
     bar.barrier();
   }
   writeln("first coforall done!");
 }
 
-var bar = new Barrier(nTasks);
+var bar = new barrier(nTasks);
 
 copyInBar(bar);
 
@@ -19,7 +19,7 @@ coforall tid in 1..nTasks {
 
 writeln("second coforall done!");
 
-proc varCopyBar(bar: Barrier) {
+proc varCopyBar(bar: barrier) {
   var x = bar;
   coforall tid in 1..nTasks {
     if tid % 2 == 0 then

--- a/test/parallel/taskPar/elliot/barrier/array-of-barriers.chpl
+++ b/test/parallel/taskPar/elliot/barrier/array-of-barriers.chpl
@@ -1,12 +1,12 @@
-use Barriers;
+use Collectives;
 
-var bar: Barrier;
-bar = new Barrier(1);
+var bar: barrier;
+bar = new barrier(1);
 bar.barrier();
 
-var barArr: [1..1] Barrier;
-barArr[1] = new Barrier(1);
+var barArr: [1..1] barrier;
+barArr[1] = new barrier(1);
 barArr[1].barrier();
 
-var barArr2: [1..10] Barrier = new Barrier(1);
+var barArr2: [1..10] barrier = new barrier(1);
 for bar2 in barArr2 do bar2.barrier();

--- a/test/parallel/taskPar/sungeun/barrier/basic.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/basic.chpl
@@ -1,10 +1,10 @@
-use Barriers;
+use Collectives;
 use BlockDist;
 
 config const numTasks = 31;
 config const numRemoteTasks = numLocales*11;
 
-proc localTest(b: Barrier, numTasks) {
+proc localTest(b: barrier, numTasks) {
   const barSpace = 0..#numTasks;
   var A: [barSpace] int = -1;
   coforall t in barSpace do {
@@ -14,7 +14,7 @@ proc localTest(b: Barrier, numTasks) {
   }
 }
 
-proc remoteTest(b: Barrier, numRemoteTasks) {
+proc remoteTest(b: barrier, numRemoteTasks) {
   const barSpace = 0..#numRemoteTasks;
   var A: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = barSpace;
   var B: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = -1;
@@ -25,7 +25,7 @@ proc remoteTest(b: Barrier, numRemoteTasks) {
   }
 }
 
-var b: Barrier = new Barrier(numTasks);
+var b: barrier = new barrier(numTasks);
 localTest(b, numTasks);
 
 b.reset(numRemoteTasks);

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
@@ -1,4 +1,4 @@
-use Barriers;
+use Collectives;
 use AllLocalesBarriers;
 use BlockDist;
 use CommDiagnostics;
@@ -27,7 +27,7 @@ proc remoteTestBasic(b, numRemoteTasks) {
   }
 }
 
-proc remoteTestSplitPhase(b: Barrier, numRemoteTasks) {
+proc remoteTestSplitPhase(b: barrier, numRemoteTasks) {
   const barSpace = 0..#numRemoteTasks;
   const hi = barSpace.high;
   var A: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = barSpace;
@@ -60,7 +60,7 @@ proc remoteTestSplitPhase(b: Barrier, numRemoteTasks) {
   }
 }
 
-var b = new Barrier(numRemoteTasks);
+var b = new barrier(numRemoteTasks);
 writeln("atomic remote test basic");
 remoteTestBasic(b, numRemoteTasks);
 

--- a/test/parallel/taskPar/sungeun/barrier/reuse.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/reuse.chpl
@@ -1,11 +1,11 @@
-use Barriers;
+use Collectives;
 use BlockDist;
 
 config const printResults = false;
 config const numTasks = 31;
 config const numRemoteTasks = numLocales*11;
 
-proc localTest(b: Barrier, numTasks) {
+proc localTest(b: barrier, numTasks) {
   const barSpace = 0..#numTasks;
   var A: [barSpace] int = -1;
   coforall t in barSpace do {
@@ -22,7 +22,7 @@ proc localTest(b: Barrier, numTasks) {
   }
 }
 
-proc remoteTest(b: Barrier, numRemoteTasks) {
+proc remoteTest(b: barrier, numRemoteTasks) {
   const barSpace = 0..#numRemoteTasks;
   var A: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = barSpace;
   var B: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = -1;
@@ -41,7 +41,7 @@ proc remoteTest(b: Barrier, numRemoteTasks) {
 }
 
 
-var b = new Barrier(numTasks);
+var b = new barrier(numTasks);
 localTest(b, numTasks);
 
 b.reset(numRemoteTasks);

--- a/test/parallel/taskPar/sungeun/barrier/split-phase.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/split-phase.chpl
@@ -1,10 +1,10 @@
-use Barriers;
+use Collectives;
 use BlockDist;
 
 config const numTasks = 31;
 config const numRemoteTasks = numLocales*11;
 
-proc localTest(b: Barrier, numTasks) {
+proc localTest(b: barrier, numTasks) {
   const barSpace = 0..#numTasks;
   var A: [barSpace] int = -1;
   coforall t in barSpace do {
@@ -19,7 +19,7 @@ proc localTest(b: Barrier, numTasks) {
   }
 }
 
-proc remoteTest(b: Barrier, numRemoteTasks) {
+proc remoteTest(b: barrier, numRemoteTasks) {
   const barSpace = 0..#numRemoteTasks;
   var A: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = barSpace;
   var B: [{barSpace} dmapped new dmap(new Block({barSpace}))] int = -1;
@@ -36,7 +36,7 @@ proc remoteTest(b: Barrier, numRemoteTasks) {
 }
 
 
-var b = new Barrier(numTasks);
+var b = new barrier(numTasks);
 localTest(b, numTasks);
 
 b.reset(numRemoteTasks);

--- a/test/performance/comm/barrier/empty-chpl-barrier.chpl
+++ b/test/performance/comm/barrier/empty-chpl-barrier.chpl
@@ -1,5 +1,5 @@
 use Time;
-use Barriers;
+use Collectives;
 use AllLocalesBarriers;
 
 config const numTrials = 100;
@@ -32,11 +32,11 @@ proc main() {
 }
 
 proc LocalBarrierBarrier() {
-  var barrier = new Barrier(numTasks);
+  var bar = new barrier(numTasks);
   coforall loc in Locales do on loc do
     coforall 1..numTasksPerLocale do
       for 1..numTrials do
-        barrier.barrier();
+        bar.barrier();
 }
 
 proc GlobalAllLocalesBarrierBarrier() {

--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -15,9 +15,9 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barriers), and timers (Time).
+// synchronization (Collectives), and timers (Time).
 //
-use BlockDist, Barriers, Time;
+use BlockDist, Collectives, Time;
 
 //
 // The type of key to use when sorting.
@@ -147,7 +147,7 @@ var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, countKeysTime: [DistTaskSpace] [1..numTrials] real;
 var verifyKeyCount: atomic int;
 
-var barrier = new Barrier(numTasks);
+var bar = new barrier(numTasks);
 
 // should result in one loop iteration per task
 proc main() {
@@ -221,7 +221,7 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
   }
   
   exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys);
-  barrier.barrier();
+  bar.barrier();
 
   if subtime {
     exchangeKeysTime.localAccess[taskID][trial] = subTimer.elapsed();
@@ -246,7 +246,7 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
   // reset the receive offsets for the next iteration
   //
   recvOffset[taskID].write(0);
-  barrier.barrier();
+  bar.barrier();
 }
 
 
@@ -329,7 +329,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
   //
   //
   verifyKeyCount.add(myBucketSize);
-  barrier.barrier();
+  bar.barrier();
   if verifyKeyCount.read() != totalKeys then
     halt("total key count mismatch: ", verifyKeyCount.read(), " != ", totalKeys);
 

--- a/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
@@ -6,7 +6,7 @@ module RunSPMDRawLoops {
    */
 
   use LCALSDataTypes;
-  use Timer, Barriers, RangeChunk;
+  use Timer, Collectives, RangeChunk;
 
   proc runSPMDRawLoops(loop_stats:[] shared LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
@@ -46,7 +46,7 @@ module RunSPMDRawLoops {
             const eosvmax = loop_data.RealArray_scalars[3];
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -101,7 +101,7 @@ module RunSPMDRawLoops {
             const q_cut = loop_data.RealArray_scalars[3];
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -219,7 +219,7 @@ module RunSPMDRawLoops {
             const vnormq = 0.083333333333333333;
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -319,7 +319,7 @@ module RunSPMDRawLoops {
             const half = 0.5;
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -380,7 +380,7 @@ module RunSPMDRawLoops {
             const ireal = 0.0 + 1.0i;
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -451,7 +451,7 @@ module RunSPMDRawLoops {
             var val = 0;
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -483,7 +483,7 @@ module RunSPMDRawLoops {
             ref in2  = loop_data.RealArray_1D[4];
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -512,7 +512,7 @@ module RunSPMDRawLoops {
             ref in2  = loop_data.RealArray_1D[4];
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -540,7 +540,7 @@ module RunSPMDRawLoops {
             ref x2 = loop_data.RealArray_1D[4];
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -582,7 +582,7 @@ module RunSPMDRawLoops {
             var val = 0.0;
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();
@@ -619,7 +619,7 @@ module RunSPMDRawLoops {
             var atomicH: [0..#64, 0..#64] atomic real;
 
             const nTasks = here.maxTaskPar;
-            var bar = new Barrier(nTasks);
+            var bar = new barrier(nTasks);
             var isamp = 0;
 
             ltimer.start();

--- a/test/studies/adventOfCode/2022/day11/bradc/day11.chpl
+++ b/test/studies/adventOfCode/2022/day11/bradc/day11.chpl
@@ -1,4 +1,4 @@
-use IO, List, Barriers;
+use IO, List, Collectives;
 
 config const numRounds = 20;
 
@@ -39,7 +39,7 @@ var canFinishTurn: sync int = 0;
 
 
 // Our main parallel simulation loop for the monkeys
-var bar = new Barrier(numMonkeys);
+var bar = new barrier(numMonkeys);
 coforall monkey in Monkeys {
   for 1..numRounds {
     // Process any items that are in our list of current items

--- a/test/studies/adventOfCode/2022/day11/bradc/day11a.chpl
+++ b/test/studies/adventOfCode/2022/day11/bradc/day11a.chpl
@@ -1,4 +1,4 @@
-use IO, List, Barriers;
+use IO, List, Collectives;
 
 config const numRounds = 10_000;
 
@@ -39,7 +39,7 @@ var canFinishTurn: sync int = 0;
 
 
 // Our main parallel simulation loop for the monkeys
-var bar = new Barrier(numMonkeys);
+var bar = new barrier(numMonkeys);
 coforall monkey in Monkeys {
   for 1..numRounds {
     // Process any items that are in our list of current items

--- a/test/studies/cholesky/jglewis/version2/elemental/block_distribution/elemental_cholesky_symmetric_index_ranges_block.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/block_distribution/elemental_cholesky_symmetric_index_ranges_block.chpl
@@ -56,7 +56,7 @@ module elemental_cholesky_symmetric_index_ranges_block {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barriers
+  // execution model more closely.  Barriers are implemented in the Collectives
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -70,7 +70,7 @@ module elemental_cholesky_symmetric_index_ranges_block {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use BlockDist, Barriers;
+  use BlockDist, Collectives;
 
   use elemental_schur_complement, 
       locality_info, 
@@ -103,7 +103,7 @@ module elemental_cholesky_symmetric_index_ranges_block {
     assert ( A (A.domain.low).locale.id == 0 );
 	     
     // initialize a tasking barrier
-    var bar = new Barrier(n_processors);
+    var bar = new barrier(n_processors);
  
     // ------------------------------------------------
     // SPMD -- launch a separate task on each processor

--- a/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_symmetric_index_ranges {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barriers
+  // execution model more closely.  Barriers are implemented in the Collectives
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_symmetric_index_ranges {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barriers;
+  use CyclicDist, Collectives;
 
   use elemental_schur_complement, 
       locality_info, 
@@ -100,7 +100,7 @@ module elemental_cholesky_symmetric_index_ranges {
     assert ( A (A.domain.low).locale.id == 0 );
 	     
     // initialize a tasking barrier
-    var bar = new Barrier(n_processors);
+    var bar = new barrier(n_processors);
       
     // ------------------------------------------------
     // SPMD -- launch a separate task on each processor

--- a/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges_alt.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges_alt.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_symmetric_index_ranges_alt {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barriers
+  // execution model more closely.  Barriers are implemented in the Collectives
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_symmetric_index_ranges_alt {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barriers;
+  use CyclicDist, Collectives;
 
   use elemental_schur_complement, 
       local_reduced_matrix_cyclic_partition_alt,
@@ -101,7 +101,7 @@ module elemental_cholesky_symmetric_index_ranges_alt {
     const n_processors  = r * c;
 
     // initialize a tasking barrier
-    var bar = new Barrier(n_processors);
+    var bar = new barrier(n_processors);
  
     // ------------------------------------------------
     // SPMD -- launch a separate task on each processor

--- a/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/elemental_cholesky_fully_blocked.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/elemental_cholesky_fully_blocked.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_fully_blocked {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barriers
+  // execution model more closely.  Barriers are implemented in the Collectives
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_fully_blocked {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barriers;
+  use CyclicDist, Collectives;
 
   use blocked_elemental_schur_complement, 
       locality_info, 
@@ -100,7 +100,7 @@ module elemental_cholesky_fully_blocked {
     assert ( A (A.domain.low).locale.id == 0 );
 	     
     // initialize a tasking barrier
-    var bar = new Barrier(n_processors);
+    var bar = new barrier(n_processors);
 
     // ------------------------------------------------
     // SPMD -- launch a separate task on each processor

--- a/test/studies/cholesky/jglewis/version2/elemental/strided/elemental_cholesky_symmetric_strided.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/strided/elemental_cholesky_symmetric_strided.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_symmetric_strided {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barriers
+  // execution model more closely.  Barriers are implemented in the Collectives
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_symmetric_strided {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barriers;
+  use CyclicDist, Collectives;
 
   use elemental_schur_complement,
       locality_info_strided, 
@@ -103,7 +103,7 @@ module elemental_cholesky_symmetric_strided {
     assert ( A (A.domain.lowBound).locale.id == 0 );
 	     
     // initialize a tasking barrier
-    var bar = new Barrier(n_processors);
+    var bar = new barrier(n_processors);
 
     // ------------------------------------------------
     // SPMD -- launch a separate task on each processor

--- a/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/elemental_cholesky_unsymmetric_index_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/elemental_cholesky_unsymmetric_index_ranges.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_unsymmetric_index_ranges {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barriers
+  // execution model more closely.  Barriers are implemented in the Collectives
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_unsymmetric_index_ranges {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barriers;
+  use CyclicDist, Collectives;
 
   use elemental_gen_schur_complement, 
       locality_info, 
@@ -93,7 +93,7 @@ module elemental_cholesky_unsymmetric_index_ranges {
     assert ( A (A.domain.low).locale.id == 0 );
 	     
     // initialize a tasking barrier
-    var bar = new Barrier(n_processors);
+    var bar = new barrier(n_processors);
 
     // ------------------------------------------------
     // SPMD -- launch a separate task on each processor

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -15,7 +15,7 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barriers), and timers (Time).
+// synchronization (AllLocalesBarriers), and timers (Time).
 //
 use BlockDist, AllLocalesBarriers, Time;
 

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -12,9 +12,9 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barriers), and timers (Time).
+// synchronization (Collectives), and timers (Time).
 //
-use BlockDist, Barriers, Time;
+use BlockDist, Collectives, Time;
 
 //
 // The type of key to use when sorting.
@@ -141,7 +141,7 @@ var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, countKeysTime: [BucketSpace] [1..numTrials] real;
 var verifyKeyCount: atomic int;
 
-var barrier = new Barrier(numBuckets);
+var bar = new barrier(numBuckets);
 
 proc main() {
   coforall bucketID in BucketSpace do
@@ -217,7 +217,7 @@ proc bucketSort(bucketID, trial: int, time = false, verify = false) {
   }
   
   exchangeKeys(bucketID, sendOffsets, bucketSizes, myBucketedKeys);
-  barrier.barrier();
+  bar.barrier();
 
   if subtime {
     exchangeKeysTime.localAccess[here.id][trial] = subTimer.elapsed();
@@ -242,7 +242,7 @@ proc bucketSort(bucketID, trial: int, time = false, verify = false) {
   // reset the receive offsets for the next iteration
   //
   recvOffset[bucketID].write(0);
-  barrier.barrier();
+  bar.barrier();
 }
 
 
@@ -321,7 +321,7 @@ proc verifyResults(bucketID, myBucketSize, myLocalKeyCounts) {
   //
   //
   verifyKeyCount.add(myBucketSize);
-  barrier.barrier();
+  bar.barrier();
   if verifyKeyCount.read() != totalKeys then
     halt("total key count mismatch: " + verifyKeyCount.read():string + " != " + totalKeys:string);
 

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -15,9 +15,9 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barriers), and timers (Time).
+// synchronization (Collectives), and timers (Time).
 //
-use BlockDist, Barriers, Time;
+use BlockDist, Collectives, Time;
 
 //
 // The type of key to use when sorting.
@@ -147,7 +147,7 @@ var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, countKeysTime: [DistTaskSpace] [1..numTrials] real;
 var verifyKeyCount: atomic int;
 
-var barrier = new Barrier(numTasks);
+var bar = new barrier(numTasks);
 
 // should result in one loop iteration per task
 proc main() {
@@ -218,7 +218,7 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
   }
   
   exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys);
-  barrier.barrier();
+  bar.barrier();
 
   if subtime {
     exchangeKeysTime.localAccess[taskID][trial] = subTimer.elapsed();
@@ -241,7 +241,7 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
   // reset the receive offsets for the next iteration
   //
   recvOffset[taskID].write(0);
-  barrier.barrier();
+  bar.barrier();
 }
 
 
@@ -335,7 +335,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
   //
   //
   verifyKeyCount.add(myBucketSize);
-  barrier.barrier();
+  bar.barrier();
   if verifyKeyCount.read() != totalKeys then
     halt("total key count mismatch: ", verifyKeyCount.read(), " != ", totalKeys);
 

--- a/test/studies/ssca2/rachels/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/rachels/SSCA2_kernels.chpl
@@ -15,7 +15,7 @@ module SSCA2_kernels
 //  +==========================================================================+
 
 { 
-  use SSCA2_compilation_config_params, Time, Barriers, DSIUtil;
+  use SSCA2_compilation_config_params, Time, Collectives, DSIUtil;
 
   var sw : stopwatch;
 
@@ -331,7 +331,7 @@ module SSCA2_kernels
             BCaux[s].path_count$.writeXF(1.0);
         }
 
-        var barrier = new Barrier(numLocales);
+        var barrier = new barrier(numLocales);
 
         coforall loc in Locales with (ref remaining, ref barrier) do on loc {
           var ALhere = Active_Level[here.id]!;

--- a/test/studies/stencil9/stencil9-explicit.chpl
+++ b/test/studies/stencil9/stencil9-explicit.chpl
@@ -1,4 +1,4 @@
-use BlockDist, Barriers;
+use BlockDist, Collectives;
 
 config const n = 10;
 
@@ -80,7 +80,7 @@ var LocalDomArrs: [LocaleGridDom] unmanaged DomArr?;
 var numIters: atomic int;
 
 
-var b = new Barrier(LocaleGridDom.size);
+var b = new barrier(LocaleGridDom.size);
 
 coforall (lr,lc) in LocaleGridDom {
   on LocaleGrid[lr,lc] {

--- a/test/users/npadmana/mpi/ring.chpl
+++ b/test/users/npadmana/mpi/ring.chpl
@@ -1,7 +1,7 @@
 use MPI;
 use C_MPI;
 use Time;
-use Barriers;
+use Collectives;
 
 enum BarrierType {None, Chapel, MPI};
 
@@ -20,7 +20,7 @@ proc main() {
 }
 
 proc send() {
-  var sendBarrier = new Barrier(numLocales);
+  var sendBarrier = new barrier(numLocales);
   coforall loc in Locales do on loc {
     var rank = here.id : c_int,
     size = numLocales : c_int;
@@ -42,7 +42,7 @@ proc send() {
 }
 
 proc recv() {
-  var recvBarrier = new Barrier(numLocales);
+  var recvBarrier = new barrier(numLocales);
   coforall loc in Locales do on loc {
     var rank = here.id : c_int,
     size = numLocales : c_int;


### PR DESCRIPTION
The 'Barriers' module is deprecated and renamed to 'Collectives' and the
'Barrier' type is deprecated and renamed to 'barrier'.

Add a deprecated test that generates the two new deprecation warnings.

Add Collections to the module documentation.

Now that the type is named 'barrier' the 'barrier.barrier()' function looks
like a constructor. The compiler had an error saying to use initializers
instead of constructors for methods named the same as their parent type.
The error has been around for long enough that nobody should have constructors
anymore, so remove the error and allow it as a regular method.

Update tests to use the Collectives module instead of the deprecated Barriers
module, and to use the 'barrier' type instead of 'Barrier'. Change variable
names from 'barrier' to 'bar'.

Closes https://github.com/Cray/chapel-private/issues/4303
Closes https://github.com/chapel-lang/chapel/issues/18861