### PR TITLE
Fix bugs with dyno scope resolution within methods

### DIFF
--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -407,7 +407,7 @@ class BorrowedIdsWithName {
     return idv_.id_;
   }
 
-  /** Returns the first IdAndVis in this list. */
+  /** Returns the first IdAndFlags in this list. */
   const IdAndFlags& firstIdAndFlags() const {
     return idv_;
   }

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -407,6 +407,11 @@ class BorrowedIdsWithName {
     return idv_.id_;
   }
 
+  /** Returns the first IdAndVis in this list. */
+  const IdAndFlags& firstIdAndFlags() const {
+    return idv_;
+  }
+
   /** Returns 'true' if the list contains only IDs that represent
       methods or fields. */
   bool containsOnlyMethodsOrFields() const;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1779,6 +1779,13 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
     return QualifiedType(QualifiedType::TYPE, t);
   }
 
+  if (asttags::isFunction(tag)) {
+    // TODO: use real function types
+    auto kind = qualifiedTypeKindForId(context, id);
+    const Type* type = nullptr;
+    return QualifiedType(kind, type);
+  }
+
   // Figure out what ID is contained within so we can use the
   // appropriate query.
   ID parentId = id.parentSymbolId(context);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2257,7 +2257,10 @@ void Resolver::resolveIdentifier(const Identifier* ident,
                             /* isParenless */ true,
                             actuals);
         auto inScope = scopeStack.back();
-        auto c = resolveGeneratedCall(context, ident, ci, inScope, poiScope);
+        auto c = resolveGeneratedCallInMethod(context, ident, ci,
+                                              inScope, poiScope,
+                                              methodReceiverType());
+
         // save the most specific candidates in the resolution result for the id
         ResolvedExpression& r = byPostorder.byAst(ident);
         handleResolvedCall(r, ident, ci, c);

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -190,8 +190,8 @@ class VarScopeVisitor {
   void enterAst(const uast::AstNode* ast);
   void exitAst(const uast::AstNode* ast);
 
-  bool enter(const VarLikeDecl* ast, RV& rv);
-  void exit(const VarLikeDecl* ast, RV& rv);
+  bool enter(const NamedDecl* ast, RV& rv);
+  void exit(const NamedDecl* ast, RV& rv);
 
   bool enter(const OpCall* ast, RV& rv);
   void exit(const OpCall* ast, RV& rv);

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -350,9 +350,9 @@ fieldAccessorQuery(Context* context,
     thisType = ClassType::get(context, bct, /*manager*/ nullptr, dec);
   }
 
-  // receiver is 'ref' to allow mutation
-  // TODO: indicate that its const-ness should vary with receiver const-ness
-  formalTypes.push_back(QualifiedType(QualifiedType::REF, thisType));
+  // receiver is ref-maybe-const to allow mutation
+  formalTypes.push_back(
+      QualifiedType(QualifiedType::REF_MAYBE_CONST, thisType));
 
   ID fieldId = parsing::fieldIdWithName(context, compType->id(), fieldName);
 

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -790,6 +790,12 @@ moreVisible(const DisambiguationContext& dctx,
   ID fn1Id = candidate1.fn->id();
   ID fn2Id = candidate2.fn->id();
 
+  // ignore more-visible for methods
+  if (candidate1.fn->untyped()->isMethod() &&
+      candidate2.fn->untyped()->isMethod()) {
+    return FOUND_BOTH;
+  }
+
   return moreVisibleQuery(dctx.context, callName,
                           dctx.callInScope, dctx.callInPoiScope,
                           fn1Id, fn2Id);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -600,9 +600,8 @@ const ResolvedFields& fieldsForTypeDeclQuery(Context* context,
   bool isMissingBundledType = false;
   if (auto bct = ct->toBasicClassType()) {
     isObjectType = bct->isObjectType();
-    auto id = bct->id();
-    isMissingBundledType = CompositeType::isMissingBundledType(context, id);
   }
+  isMissingBundledType = CompositeType::isMissingBundledType(context, ct->id());
 
   if (isObjectType || isMissingBundledType) {
     // no need to try to resolve the fields for the object type,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -597,11 +597,11 @@ const ResolvedFields& fieldsForTypeDeclQuery(Context* context,
   result.setType(ct);
 
   bool isObjectType = false;
-  bool isMissingBundledType = false;
   if (auto bct = ct->toBasicClassType()) {
     isObjectType = bct->isObjectType();
   }
-  isMissingBundledType = CompositeType::isMissingBundledType(context, ct->id());
+  bool isMissingBundledType =
+    CompositeType::isMissingBundledType(context, ct->id());
 
   if (isObjectType || isMissingBundledType) {
     // no need to try to resolve the fields for the object type,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2123,7 +2123,7 @@ doIsCandidateApplicableInitial(Context* context,
   }
 
   // if it's a paren-less call, only consider parenless routines
-  // (including field accessors) but not types/outer variables/
+  // (including generated field accessors) but not types/outer variables/
   // calls with parens.
   if (ci.isParenless()) {
     if (parsing::idIsParenlessFunction(context, candidateId) ||

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -93,6 +93,13 @@ resolvedExpressionForAstInteractive(Context* context, const AstNode* ast,
     }
   }
 
+  if (ast->id().postOrderId() < 0) {
+    // It's a symbol with a different path, e.g. a nested Function.
+    // Don't try to resolve it now in this
+    // traversal. Instead, resolve it separately.
+    return nullptr;
+  }
+
   if (inFn != nullptr && inFn->id() != ast->id() &&
       inFn->id().contains(ast->id())) {
     return &inFn->byAst(ast);

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -746,8 +746,6 @@ static void testExample4a() {
 }
 
 static void testExample5() {
-  // TODO: get this working
-#if 0
   testCall("example5.chpl",
            R""""(
               // Example 5
@@ -768,7 +766,6 @@ static void testExample5() {
            "B.test",
            "B.test@2",
            "A.foo" /* call the method; don't refer to the int */);
-#endif
 }
 
 static void testExample5a() {
@@ -794,7 +791,6 @@ static void testExample5a() {
 
 static void testExample6() {
   // TODO: currently getting "no matching candidates"
-#if 0
   testCall("example6.chpl",
            R""""(
               module A {
@@ -815,7 +811,6 @@ static void testExample6() {
            "B.test",
            "B.test@2",
            "A.foo" /* the method not the int */);
-#endif
 }
 
 static void testExample7() {
@@ -919,7 +914,6 @@ static void testExample10() {
 
 static void testExample11() {
   // TODO: no matching candidates
-#if 0
   testCall("example11.chpl",
            R""""(
               module A {
@@ -946,7 +940,6 @@ static void testExample11() {
            "C.test",
            "C.test@2",
            "C.foo" /* the method Child.foo */ );
-#endif
 }
 
 static void testExample12() {

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -517,9 +517,7 @@ static void test11p() {
          )"""",
          "M.rec.foo",
          "M.rec.foo@7",
-         "M.rec.foo@2" /* the local variable */,
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.rec.foo@2" /* the local variable */);
 }
 static void test11s() {
   testIt("test11s.chpl",
@@ -544,9 +542,7 @@ static void test11s() {
          )"""",
          "M.foo",
          "M.foo@8",
-         "M.foo@3" /* the local variable */,
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.foo@3" /* the local variable */);
 }
 
 // same as above but with a formal rather than a local variable
@@ -573,9 +569,7 @@ static void test12p() {
          )"""",
          "M.rec.foo",
          "M.rec.foo@9",
-         "M.rec.foo@2" /* the formal */,
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.rec.foo@2" /* the formal */);
 }
 static void test12s() {
   testIt("test12s.chpl",
@@ -600,9 +594,7 @@ static void test12s() {
          )"""",
          "M.foo",
          "M.foo@10",
-         "M.foo@3" /* the formal */,
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.foo@3" /* the formal */);
 }
 
 // field access vs parent module field
@@ -626,9 +618,7 @@ static void test13p() {
          )"""",
          "M.mat.foo",
          "M.mat.foo@5",
-         "M.mat@2" /* the field */,
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.mat@2" /* the field */);
 }
 static void test13s() {
   testIt("test13s.chpl",
@@ -651,9 +641,7 @@ static void test13s() {
          )"""",
          "M.foo",
          "M.foo@6",
-         "M.mat@2" /* the field */,
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.mat@2" /* the field */);
 }
 
 // The following series of tests is from issue #21668

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -1058,7 +1058,7 @@ static void testExample17() {
 }
 
 static void testExample18() {
-  // TODO: running into assertion failure
+  // TODO: this is calling M.main.r.x but we desire ambiguity
 #if 0
   testCall("example18.chpl",
            R""""(
@@ -1081,8 +1081,6 @@ static void testExample18() {
 }
 
 static void testExample19() {
-  // TODO: running into an internal assertion failure
-#if 0
   testCall("example19.chpl",
            R""""(
               module A {
@@ -1100,7 +1098,6 @@ static void testExample19() {
            "A.test",
            "A.test@2",
            "A.test.foo" /* the inner parenless non-method */);
-#endif
 }
 
 static void testExample20() {

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -118,7 +118,7 @@ static void testCall(const char* testName,
   assert(methodAst->isFunction());
   auto callAst = parsing::idToAst(context, callId);
   assert(callAst);
-  assert(callAst->isIdentifier() || callAst->isCall());
+  assert(callAst->isIdentifier() || callAst->isDot() || callAst->isCall());
   const AstNode* calledFnAst = nullptr;
   if (calledFnIdStr[0] != '\0') {
     calledFnAst = parsing::idToAst(context, calledFnId);
@@ -1058,8 +1058,6 @@ static void testExample17() {
 }
 
 static void testExample18() {
-  // TODO: this is calling M.main.r.x but we desire ambiguity
-#if 0
   testCall("example18.chpl",
            R""""(
               module M {
@@ -1077,7 +1075,6 @@ static void testExample18() {
            "M.main",
            "M.main@3",
            "" /* ambiguity */);
-#endif
 }
 
 static void testExample19() {

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -348,9 +348,7 @@ static void test6() {
          )"""",
          "M.Outer.Nested.bar",
          "M.Outer.Nested.bar@1",
-         "M.Base@1",
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.Base@1");
 }
 
 // test with an outer variable vs a parent class field
@@ -376,9 +374,7 @@ static void test7() {
          )"""",
          "M.secondary",
          "M.secondary@2",
-         "M.Base@1",
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.Base@1");
 }
 
 // test with a formal vs a parent class field
@@ -470,9 +466,7 @@ static void test10p() {
          )"""",
          "M.outerClass.foo",
          "M.outerClass.foo@1",
-         "M.outerClass.aClass" /* the nested class */,
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.outerClass.aClass" /* the nested class */);
 }
 // similar to test10, but with a secondary method
 static void test10s() {
@@ -496,9 +490,7 @@ static void test10s() {
          )"""",
          "M.foo",
          "M.foo@2",
-         "M.outerClass.aClass" /* the nested class */,
-         /* scope resolve only to avoid errors today */ true);
-  // TODO get the above case working with the full resolver
+         "M.outerClass.aClass" /* the nested class */);
 }
 
 // test with parent scopes that should find a local not a field

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -769,8 +769,6 @@ static void testExample5() {
 }
 
 static void testExample5a() {
-  // TODO: get this working (running into internal assertion)
-#if 0
   testCall("example5a.chpl",
            R""""(
               module M {
@@ -786,11 +784,9 @@ static void testExample5a() {
            "M.test",
            "M.test@4",
            "" /* ambiguity */);
-#endif
 }
 
 static void testExample6() {
-  // TODO: currently getting "no matching candidates"
   testCall("example6.chpl",
            R""""(
               module A {

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -662,8 +662,9 @@ static void testExample2() {
            "M.test",
            "M.test@6",
            "M.bar" /* the selected method */);
-  // TODO: thinking that this case should prefer the 'int' version
-  // because both should participate in disambiguation
+  // TODO: perhaps this case should prefer the 'int' version
+  // because both should participate in disambiguation.
+  // See issue #21668.
 }
 
 static void testExample3() {

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -830,8 +830,6 @@ static void testExample7() {
 }
 
 static void testExample8() {
-  // TODO: running into an internal assertion
-#if 0
   testCall("example8.chpl",
            R""""(
               module A {
@@ -849,12 +847,9 @@ static void testExample8() {
            "A.main.test",
            "A.main.test@2",
            "A.main.foo" /* the method */);
-#endif
 }
 
 static void testExample9() {
-  // TODO: running into an internal assertion
-#if 0
   testCall("example9.chpl",
            R""""(
               module A {
@@ -874,12 +869,9 @@ static void testExample9() {
            "A.main.test",
            "A.main.test@2",
            "A.main.foo" /* the method */);
-#endif
 }
 
 static void testExample10() {
-  // TODO: no matching candidates
-#if 0
   testCall("example10.chpl",
            R""""(
               module A {
@@ -905,11 +897,9 @@ static void testExample10() {
            "C.test",
            "C.test@2",
            "A.foo" /* the method */ );
-#endif
 }
 
 static void testExample11() {
-  // TODO: no matching candidates
   testCall("example11.chpl",
            R""""(
               module A {
@@ -1002,8 +992,6 @@ static void testExample14() {
 }
 
 static void testExample15() {
-  // TODO: running into an internal assertion failure
-#if 0
   testCall("example15.chpl",
            R""""(
               module M {
@@ -1021,12 +1009,9 @@ static void testExample15() {
            "M.test",
            "M.test@2",
            "" /* ambiguity error */);
-#endif
 }
 
 static void testExample16() {
-  // TODO: running into assertion failure
-#if 0
   testCall("example16.chpl",
            R""""(
               module M {
@@ -1045,7 +1030,6 @@ static void testExample16() {
            "M.main",
            "M.main@0",
            "M.main.foo" /* the innermost proc foo */);
-#endif
 }
 
 static void testExample17() {
@@ -1120,8 +1104,6 @@ static void testExample19() {
 }
 
 static void testExample20() {
-  // TODO: running into an internal assertion failure
-#if 0
   testCall("example20.chpl",
            R""""(
               module A {
@@ -1140,7 +1122,6 @@ static void testExample20() {
            "A.test",
            "A.test@2",
            "" /* ambiguity error */);
-#endif
 }
 
 


### PR DESCRIPTION
This PR continues #21715 and addresses some of the Future Work from that PR.

It is focused on fixing a variety of bugs in the dyno resolver that were interfering with a number of test cases in testMethodFieldAccess.cpp.

Future Work:
 * Implement disambiguation behavior for Example 2 in #21668 if that is desired
 * Come to a conclusion about what the programs in #21668 should do
 

Reviewed by @arezaii -- thanks!

- [x] full local testing
- [x] `--dyno` testing