### PR TITLE
Fixes shared.adopt() of an owned object

### DIFF
--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -356,7 +356,7 @@ module SharedObject {
     */
     inline proc type adopt(pragma "nil from arg" in obj: owned) {
       var ptr = owned.release(obj);
-      return owned.adopt(ptr);
+      return shared.adopt(ptr);
     }
     /*
       Creates a new `shared` class reference to the argument.

--- a/test/classes/jade/shared/adopt.chpl
+++ b/test/classes/jade/shared/adopt.chpl
@@ -11,13 +11,15 @@ class A {
   writeln("test adopt of unmanaged");
   var aHeapObj = new unmanaged A();
   var a = shared.adopt(aHeapObj);
+  writeln(a, " | ", a.type:string);
 }
 
 {
   writeln("test adopt of owned");
   var own: A? = new A();
   var a = shared.adopt(own);
-  writeln(own);
+  writeln(own, " | ", own.type:string);
+  writeln(a, " | ", a.type:string);
 }
 
 
@@ -27,11 +29,11 @@ class A {
   var shr1: A = shared.adopt(a);
   var shr2 = shared.adopt(shr1);
   // all should refer to the same object
-  writeln(a);
-  writeln(shr1);
-  writeln(shr2);
+  writeln(a, " | ", a.type:string);
+  writeln(shr1, " | ", shr1.type:string);
+  writeln(shr2, " | ", shr2.type:string);
   shr2.x += shr1.y;
-  writeln(a);
-  writeln(shr1);
-  writeln(shr2);
+  writeln(a, " | ", a.type:string);
+  writeln(shr1, " | ", shr1.type:string);
+  writeln(shr2, " | ", shr2.type:string);
 }

--- a/test/classes/jade/shared/adopt.good
+++ b/test/classes/jade/shared/adopt.good
@@ -1,10 +1,12 @@
 test adopt of unmanaged
+{x = 0, y = 0} | shared A
 test adopt of owned
-nil
+nil | owned A?
+{x = 0, y = 0} | shared A?
 test adopt ownership transfer to shared object
-{x = 2, y = 3}
-{x = 2, y = 3}
-{x = 2, y = 3}
-{x = 5, y = 3}
-{x = 5, y = 3}
-{x = 5, y = 3}
+{x = 2, y = 3} | unmanaged A
+{x = 2, y = 3} | shared A
+{x = 2, y = 3} | shared A
+{x = 5, y = 3} | unmanaged A
+{x = 5, y = 3} | shared A
+{x = 5, y = 3} | shared A


### PR DESCRIPTION
Fixes a one word typo in PR #21737 that causes `shared.adopt` to return `owned` instead of `shared`.

Also improved existing test for `shared.adopt()` to prevent this kind of error from occurring again.

Since no one is using `shared.adopt()` yet, change does not affect any existing tests.

## Summary of changes
- fix typo in shared.adopt()
- modify associated test to catch this error in the future

## New Tests
- no new tests, just added to existing

## Testing
- full paratest
- no documentation change