### PR TITLE
Fix tests needing 'do return' that slipped past me

### DIFF
--- a/test/functions/iterators/vass/const-ref-iterator-1.chpl
+++ b/test/functions/iterators/vass/const-ref-iterator-1.chpl
@@ -24,21 +24,21 @@ record QQ { type t; }  // a generic record
 var   v1 = 5, v2 = new RR(), v3 = new QQ(bool);
 const c1 = 6, c2 = new RR(), c3 = new QQ(bool);
 
-proc typ1() type return int;
-proc typ2() type return RR;
-proc typ3() type return QQ;
+proc typ1() type do return int;
+proc typ2() type do return RR;
+proc typ3() type do return QQ;
 
-proc ref1() ref return v1;
-proc ref2() ref return v2;
-proc ref3() ref return v3;
+proc ref1() ref do return v1;
+proc ref2() ref do return v2;
+proc ref3() ref do return v3;
 
-proc pcr1() const ref return v1;
-proc pcr2() const ref return v2;
-proc pcr3() const ref return v3;
+proc pcr1() const ref do return v1;
+proc pcr2() const ref do return v2;
+proc pcr3() const ref do return v3;
 
-proc nonr1() return v1;
-proc nonr2() return v2;
-proc nonr3() return v3;
+proc nonr1() do return v1;
+proc nonr2() do return v2;
+proc nonr3() do return v3;
 
 /////////// return type: not declared ///////////
 

--- a/test/functions/iterators/vass/const-ref-iterator-4.chpl
+++ b/test/functions/iterators/vass/const-ref-iterator-4.chpl
@@ -10,21 +10,21 @@ record QQ { type t; }  // a generic record
 var   v1 = 5, v2 = new RR(), v3 = new QQ(bool);
 const c1 = 6, c2 = new RR(), c3 = new QQ(bool);
 
-proc typ1() type return int;
-proc typ2() type return RR;
-proc typ3() type return QQ;
+proc typ1() type do return int;
+proc typ2() type do return RR;
+proc typ3() type do return QQ;
 
-proc ref1() ref return v1;
-proc ref2() ref return v2;
-proc ref3() ref return v3;
+proc ref1() ref do return v1;
+proc ref2() ref do return v2;
+proc ref3() ref do return v3;
 
-proc pcr1() const ref return v1;
-proc pcr2() const ref return v2;
-proc pcr3() const ref return v3;
+proc pcr1() const ref do return v1;
+proc pcr2() const ref do return v2;
+proc pcr3() const ref do return v3;
 
-proc nonr1() return v1;
-proc nonr2() return v2;
-proc nonr3() return v3;
+proc nonr1() do return v1;
+proc nonr2() do return v2;
+proc nonr3() do return v3;
 
 /////////// return type: not declared ///////////
 

--- a/test/multilocale/deitz/needMultiLocales/diagnostics/test_remote_value_forwarding1.chpl
+++ b/test/multilocale/deitz/needMultiLocales/diagnostics/test_remote_value_forwarding1.chpl
@@ -1,6 +1,6 @@
 use CommDiagnostics;
 
-proc foo(i: int): int
+proc foo(i: int): int do
   return if i > 1 then 1 + foo(i-1) else 1;
 
 proc main() {

--- a/test/multilocale/deitz/needMultiLocales/diagnostics/test_remote_value_forwarding2.chpl
+++ b/test/multilocale/deitz/needMultiLocales/diagnostics/test_remote_value_forwarding2.chpl
@@ -1,6 +1,6 @@
 use CommDiagnostics;
 
-proc foo(i: int): int
+proc foo(i: int): int do
   return if i > 1 then 1 + foo(i-1) else 1;
 
 proc main() {

--- a/test/optimizations/bulkcomm/asenjo/ptransDR/v1/ptrans.chpl
+++ b/test/optimizations/bulkcomm/asenjo/ptransDR/v1/ptrans.chpl
@@ -23,9 +23,9 @@ record localInfo {
   var B: [domB] elType;
 
   pragma "no copy return"
-  proc Acompute return A[domA];
+  proc Acompute do return A[domA];
   pragma "no copy return"
-  proc Bcompute return B[domB];
+  proc Bcompute do return B[domB];
 
   var localDelta: elType;
 }

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_assignment.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_assignment.chpl
@@ -341,7 +341,7 @@ proc bitReverse(val: ?valType, revBits = 64) {
 //
 // Compute the log base 4 of x
 //
-proc log4(x) return logBasePow2(x, 2);  
+proc log4(x) do return logBasePow2(x, 2);  
 
 	     //
 	     // verify that the results are correct by reapplying the dfft and then

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_bulk.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/FFT_bulk.chpl
@@ -480,7 +480,7 @@ proc bitReverse(val: ?valType, revBits = 64) {
 //
 // Compute the log base 4 of x
 //
-proc log4(x) return logBasePow2(x, 2);
+proc log4(x) do return logBasePow2(x, 2);
 
 	     //
 	     // verify that the results are correct by reapplying the dfft and then

--- a/test/optimizations/bulkcomm/asenjo/stencilDR/v1/stencil.chpl
+++ b/test/optimizations/bulkcomm/asenjo/stencilDR/v1/stencil.chpl
@@ -22,8 +22,8 @@ record localInfo {
 
   var A, B: [domAlloc] elType;
 
-  proc Acompute return A[domCompute];
-  proc Bcompute return B[domCompute];
+  proc Acompute do return A[domCompute];
+  proc Bcompute do return B[domCompute];
 
   var localDelta: elType;
 }

--- a/test/parallel/forall/vass/other/binary-tree-spawn.no-recurse.chpl
+++ b/test/parallel/forall/vass/other/binary-tree-spawn.no-recurse.chpl
@@ -11,7 +11,7 @@ proc main {
   writef("%064bi\n", result);
 }
 
-inline proc ln return 2**here.id;
+inline proc ln do return 2**here.id;
 
 iter AAA() {
   halt("do not invoke me");


### PR DESCRIPTION
One pair may have been modified concurrently since my last merge with main?  The others suggest I never checked gasnet testing before now.