### PR TITLE
Stop zero-initializing the mpz_t field for bigint

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -208,6 +208,7 @@ module BigInteger {
   record bigint {
     // The underlying GMP C structure
     pragma "no doc"
+    pragma "no init"
     var mpz      : mpz_t;              // A dynamic-vector of C integers
 
     pragma "no doc"


### PR DESCRIPTION
The bigint record has a field with an extern type of `mpz_t`, which is being zero initialized by default, adding a `memset` to the generated C code. This is not needed for bigint, since we are always calling a version of `mpz_init` when initializing a bigint record, which will handle the initialization, regardless of whether it has been zero initialized by Chapel.

Backing issue: https://github.com/Cray/chapel-private/issues/4146

- [x] paratest