### PR TITLE
Fix some missing cases that relied on the single-statement return exception

### DIFF
--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -212,7 +212,7 @@ module LocaleModel {
   class GPULocale : AbstractLocaleModel {
     const sid: chpl_sublocID_t;
 
-    override proc chpl_id() return try! (parent._value:LocaleModel)._node_id; // top-level node id
+    override proc chpl_id() do return try! (parent._value:LocaleModel)._node_id; // top-level node id
     override proc chpl_localeid() {
       return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
                                 sid);
@@ -331,17 +331,17 @@ module LocaleModel {
     }
 
     // top-level locale (node) number
-    override proc chpl_id() return _node_id;
+    override proc chpl_id() do return _node_id;
 
     override proc chpl_localeid() {
       return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_none);
     }
-    override proc chpl_name() return local_name;
+    override proc chpl_name() do return local_name;
 
-    proc getChildSpace() return childSpace;
+    proc getChildSpace() do return childSpace;
 
-    override proc getChildCount() return numSublocales;
-    override proc _getChildCount() return numSublocales;
+    override proc getChildCount() do return numSublocales;
+    override proc _getChildCount() do return numSublocales;
 
     iter getChildIndices() : int {
       for idx in {0..#numSublocales} do // chpl_emptyLocaleSpace do
@@ -417,37 +417,37 @@ module LocaleModel {
     // We return numLocales for now, since we expect nodes to be
     // numbered less than this.
     // -1 is used in the abstract locale class to specify an invalid node ID.
-    override proc chpl_id() return numLocales;
+    override proc chpl_id() do return numLocales;
     override proc chpl_localeid() {
       return chpl_buildLocaleID(numLocales:chpl_nodeID_t, c_sublocid_none);
     }
-    override proc chpl_name() return local_name();
-    proc local_name() return "rootLocale";
+    override proc chpl_name() do return local_name();
+    proc local_name() do return "rootLocale";
 
     override proc writeThis(f) throws {
       f.write(name);
     }
 
-    override proc getChildCount() return this.myLocaleSpace.size;
-    override proc _getChildCount() return this.myLocaleSpace.size;
+    override proc getChildCount() do return this.myLocaleSpace.size;
+    override proc _getChildCount() do return this.myLocaleSpace.size;
 
-    proc getChildSpace() return this.myLocaleSpace;
+    proc getChildSpace() do return this.myLocaleSpace;
 
     iter getChildIndices() : int {
       for idx in this.myLocaleSpace do
         yield idx;
     }
 
-    override proc getChild(idx:int) return this.myLocales[idx];
-    override proc _getChild(idx:int) return this.myLocales[idx];
+    override proc getChild(idx:int) do return this.myLocales[idx];
+    override proc _getChild(idx:int) do return this.myLocales[idx];
 
     iter getChildren() : locale  {
       for loc in this.myLocales do
         yield loc;
     }
 
-    override proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
-    override proc getDefaultLocaleArray() const ref return myLocales;
+    override proc getDefaultLocaleSpace() const ref do return this.myLocaleSpace;
+    override proc getDefaultLocaleArray() const ref do return myLocales;
 
     override proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);

--- a/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
+++ b/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
@@ -149,11 +149,11 @@ proc SPAdot(A: [?Adom], B: [?Bdom]) where isCSArr(A) && isCSArr(B) {
   return C;
 
   /* Cleaner startIdx accessor */
-  proc _array.IR ref return this._value.dom.startIdx;
+  proc _array.IR ref do return this._value.dom.startIdx;
   /* Cleaner idx accessor */
-  proc _array.JC ref return this._value.dom.idx;
+  proc _array.JC ref do return this._value.dom.idx;
   /* Cleaner data accessor */
-  proc _array.NUM ref return this._value.data;
+  proc _array.NUM ref do return this._value.data;
 
 }
 


### PR DESCRIPTION
This addresses a few cases that didn't show up in my paratesting, but did show up in then nightlies, the first of which was a fairly obvious oversight, in retrospect:
* 16 cases in the gpu Locale Model, which I'd failed to check or test
* 1 case only enabled in LinearAlgebra testing on XCs
