### PR TITLE
Add perf annotations for 2023-03-02

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -529,8 +529,9 @@ all:
   01/26/23:
     - text: Fix topo/comm initialization sequence (#21427)
       config: 16-node-xc, 16-node-cs-hdr
-
-
+  02/24/23:
+    - text:  Fix default and const argument intents on tuples (#21665)
+      config: chapcs, 1-node-xc
 # End all
 
 allocate:
@@ -542,12 +543,18 @@ allocate:
 allocation:
   11/10/22:
     - weakPointer prototype implementation (#20918)
+  02/28/23:
+    - Parallelize array deinitialization (#21670)
 
 arguments:
   03/10/17:
     - Three way refpair (#5561)
   09/20/17:
     - Adjust string pass/return test (#7360)
+
+arrayInitDeinitPerf:
+  02/28/23:
+    - Parallelize array deinitialization (#21670)
 
 arrayPerformance-1d:
   03/19/15:
@@ -732,7 +739,6 @@ create-views:
   10/02/20:
     - Only reference count a distribution's domains (#16528)
 
-
 cs-resize:
   03/05/19:
     - Add radix sort to Sort package module (#12452)
@@ -798,13 +804,10 @@ domainAssignment-similar: &domainAssign-base
 domainAssignment-dissimilar:
   <<: *domainAssign-base
 
-dgemm.128:
-  09/06/13:
-    - LICM bug fixes
+domEqualityPerf:
+  02/02/23:
+    - Deprecate Time.getCurrentTime (#21467)
 
-dgemm.64:
-  09/06/13:
-    - LICM bug fixes
 
 ep: &ep-base
   11/18/14:
@@ -1984,6 +1987,8 @@ testSerialReductions:
     - Merge ExternArr and friends into DefaultRectangular (#11893)
   07/15/20:
     - Enable parallel array init for all types (#16070)
+  02/28/23:
+    - Parallelize array deinitialization (#21670)
 
 thread-ring:
   03/19/15:


### PR DESCRIPTION
Add annotations for:
 - 2D array regressions
 - domain equality timer change
 - improvements and regressions from parallel array deinit

Also remove an old dgemm annotation (it wasn't alphabetized and when I went to fix that saw it's old enough that none of our current graphs include it anyways.)