### PR TITLE
Replace vector with map in ResolutionResultByPostorderID

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1113,13 +1113,12 @@ struct Converter {
         noteConvertedSym(expr, svs);
         addForallIntent(ret, svs);
       } else {
-        auto r = symStack.back().resolved;
-        if (r != nullptr) {
-          const resolution::ResolvedExpression* rr = r->byAstOrNull(expr);
-          if (rr != nullptr) {
-            if (isTaskVarDecl) {
-              noteConvertedSym(expr, svs);
-            } else {
+        if (isTaskVarDecl) {
+          noteConvertedSym(expr, svs);
+        } else {
+          auto r = symStack.back().resolved;
+          if (r != nullptr) {
+            if (auto rr = r->byAstOrNull(expr)) {
               noteConvertedSym(expr, findConvertedSym(rr->toId()));
             }
           }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1311,15 +1311,15 @@ class ResolutionResultByPostorderID {
   /** prepare to resolve the body of a For loop */
   void setupForParamLoop(const uast::For* loop, ResolutionResultByPostorderID& parent);
 
-  ResolvedExpression& byIdExpanding(const ID& id) {
-    auto postorder = id.postOrderId();
-    CHPL_ASSERT(id.symbolPath() == symbolId.symbolPath());
-    CHPL_ASSERT(0 <= postorder);
-    return map[postorder];
-  }
-  ResolvedExpression& byAstExpanding(const uast::AstNode* ast) {
-    return byIdExpanding(ast->id());
-  }
+  /* ResolvedExpression& byIdExpanding(const ID& id) { */
+  /*   auto postorder = id.postOrderId(); */
+  /*   CHPL_ASSERT(id.symbolPath() == symbolId.symbolPath()); */
+  /*   CHPL_ASSERT(0 <= postorder); */
+  /*   return map[postorder]; */
+  /* } */
+  /* ResolvedExpression& byAstExpanding(const uast::AstNode* ast) { */
+  /*   return byIdExpanding(ast->id()); */
+  /* } */
 
   bool hasId(const ID& id) const {
     auto postorder = id.postOrderId();
@@ -1334,7 +1334,6 @@ class ResolutionResultByPostorderID {
   }
 
   ResolvedExpression& byId(const ID& id) {
-    CHPL_ASSERT(hasId(id));
     auto postorder = id.postOrderId();
     return map[postorder];
   }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1315,7 +1315,7 @@ class ResolutionResultByPostorderID {
   bool hasId(const ID& id) const {
     auto postorder = id.postOrderId();
     if (id.symbolPath() == symbolId.symbolPath() &&
-        0 <= postorder && map.count(postorder))
+        0 <= postorder && (map.count(postorder) > 0))
       return true;
 
     return false;
@@ -1330,9 +1330,9 @@ class ResolutionResultByPostorderID {
     return map.at(postorder);
   }
   const ResolvedExpression* byIdOrNull(const ID& id) const {
-    if (hasId(id)) {
-      auto postorder = id.postOrderId();
-      return &map.at(postorder);
+    auto found = map.find(id.postOrderId());
+    if (found != map.end()) {
+      return &found->second;
     }
     return nullptr;
   }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1297,8 +1297,8 @@ class ResolutionResultByPostorderID {
  private:
   ID symbolId;
   // This map is generally accessed with operator[] to default-construct a new
-  // ResolvedExpression if none exists for an ID. In other cases at() is used
-  // instead for const-ness.
+  // ResolvedExpression if none exists for an ID. at() is used instead only
+  // when const-ness is required.
   std::unordered_map<int, ResolvedExpression> map;
 
  public:
@@ -1311,16 +1311,7 @@ class ResolutionResultByPostorderID {
   /** prepare to resolve the body of a For loop */
   void setupForParamLoop(const uast::For* loop, ResolutionResultByPostorderID& parent);
 
-  /* ResolvedExpression& byIdExpanding(const ID& id) { */
-  /*   auto postorder = id.postOrderId(); */
-  /*   CHPL_ASSERT(id.symbolPath() == symbolId.symbolPath()); */
-  /*   CHPL_ASSERT(0 <= postorder); */
-  /*   return map[postorder]; */
-  /* } */
-  /* ResolvedExpression& byAstExpanding(const uast::AstNode* ast) { */
-  /*   return byIdExpanding(ast->id()); */
-  /* } */
-
+  /* ID query functions */
   bool hasId(const ID& id) const {
     auto postorder = id.postOrderId();
     if (id.symbolPath() == symbolId.symbolPath() &&
@@ -1329,10 +1320,6 @@ class ResolutionResultByPostorderID {
 
     return false;
   }
-  bool hasAst(const uast::AstNode* ast) const {
-    return ast != nullptr && hasId(ast->id());
-  }
-
   ResolvedExpression& byId(const ID& id) {
     auto postorder = id.postOrderId();
     return map[postorder];
@@ -1342,19 +1329,6 @@ class ResolutionResultByPostorderID {
     auto postorder = id.postOrderId();
     return map.at(postorder);
   }
-  ResolvedExpression& byAst(const uast::AstNode* ast) {
-    return byId(ast->id());
-  }
-  const ResolvedExpression& byAst(const uast::AstNode* ast) const {
-    return byId(ast->id());
-  }
-  ResolvedExpression* byIdOrNull(const ID& id) {
-    if (hasId(id)) {
-      auto postorder = id.postOrderId();
-      return &map[postorder];
-    }
-    return nullptr;
-  }
   const ResolvedExpression* byIdOrNull(const ID& id) const {
     if (hasId(id)) {
       auto postorder = id.postOrderId();
@@ -1362,8 +1336,16 @@ class ResolutionResultByPostorderID {
     }
     return nullptr;
   }
-  ResolvedExpression* byAstOrNull(const uast::AstNode* ast) {
-    return byIdOrNull(ast->id());
+
+  /* AST query functions */
+  bool hasAst(const uast::AstNode* ast) const {
+    return ast != nullptr && hasId(ast->id());
+  }
+  ResolvedExpression& byAst(const uast::AstNode* ast) {
+    return byId(ast->id());
+  }
+  const ResolvedExpression& byAst(const uast::AstNode* ast) const {
+    return byId(ast->id());
   }
   const ResolvedExpression* byAstOrNull(const uast::AstNode* ast) const {
     return byIdOrNull(ast->id());

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1330,9 +1330,9 @@ class ResolutionResultByPostorderID {
     return map.at(postorder);
   }
   const ResolvedExpression* byIdOrNull(const ID& id) const {
-    auto found = map.find(id.postOrderId());
-    if (found != map.end()) {
-      return &found->second;
+    if (hasId(id)) {
+      auto postorder = id.postOrderId();
+      return &map.at(postorder);
     }
     return nullptr;
   }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3532,7 +3532,7 @@ bool Resolver::enter(const Catch* node) {
       // default to Error placeholder
       const ClassType* errorType = CompositeType::getErrorType(context);
       auto qt = QualifiedType(QualifiedType::VAR, errorType);
-      ResolvedExpression& re = byPostorder.byAstExpanding(errVar);
+      ResolvedExpression& re = byPostorder.byAst(errVar);
       re.setType(qt);
     } else {
       errVar->traverse(*this);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -144,7 +144,12 @@ const ResolutionResultByPostorderID& resolveModule(Context* context, ID id) {
           int lastId = firstId + stmtId.numContainedChildren();
           for (int i = firstId; i <= lastId; i++) {
             ID exprId(stmtId.symbolPath(), i, 0);
-            result.byIdExpanding(exprId) = resolved.byId(exprId);
+            const ResolvedExpression* reToCopy = resolved.byIdOrNull(exprId);
+            if (reToCopy) {
+              result.byId(exprId) = *reToCopy;
+            } else {
+              result.byId(exprId);
+            }
           }
         }
       }
@@ -193,7 +198,12 @@ scopeResolveModule(Context* context, ID id) {
           int lastId = firstId + stmtId.numContainedChildren();
           for (int i = firstId; i <= lastId; i++) {
             ID exprId(stmtId.symbolPath(), i, 0);
-            result.byIdExpanding(exprId) = resolved.byId(exprId);
+            const ResolvedExpression* reToCopy = resolved.byIdOrNull(exprId);
+            if (reToCopy) {
+              result.byId(exprId) = *reToCopy;
+            } else {
+              result.byId(exprId);
+            }
           }
         }
       }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -144,11 +144,9 @@ const ResolutionResultByPostorderID& resolveModule(Context* context, ID id) {
           int lastId = firstId + stmtId.numContainedChildren();
           for (int i = firstId; i <= lastId; i++) {
             ID exprId(stmtId.symbolPath(), i, 0);
-            const ResolvedExpression* reToCopy = resolved.byIdOrNull(exprId);
-            if (reToCopy) {
-              result.byId(exprId) = *reToCopy;
-            } else {
-              result.byId(exprId);
+            ResolvedExpression& re = result.byId(exprId);
+            if (auto reToCopy = resolved.byIdOrNull(exprId)) {
+              re = *reToCopy;
             }
           }
         }
@@ -198,11 +196,9 @@ scopeResolveModule(Context* context, ID id) {
           int lastId = firstId + stmtId.numContainedChildren();
           for (int i = firstId; i <= lastId; i++) {
             ID exprId(stmtId.symbolPath(), i, 0);
-            const ResolvedExpression* reToCopy = resolved.byIdOrNull(exprId);
-            if (reToCopy) {
-              result.byId(exprId) = *reToCopy;
-            } else {
-              result.byId(exprId);
+            ResolvedExpression& re = result.byId(exprId);
+            if (auto reToCopy = resolved.byIdOrNull(exprId)) {
+              re = *reToCopy;
             }
           }
         }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -392,26 +392,14 @@ CallInfo CallInfo::createWithReceiver(const CallInfo& ci,
 
 void ResolutionResultByPostorderID::setupForSymbol(const AstNode* ast) {
   CHPL_ASSERT(Builder::astTagIndicatesNewIdScope(ast->tag()));
-  /* vec.resize(ast->id().numContainedChildren()); */
 
   symbolId = ast->id();
 }
 void ResolutionResultByPostorderID::setupForSignature(const Function* func) {
-  /* int maxPostorderId = 0; */
-  /* if (func && func->numChildren() > 0) */
-  /*   maxPostorderId = func->child(func->numChildren() - 1)->id().postOrderId(); */
-  /* CHPL_ASSERT(0 <= maxPostorderId); */
-  /* vec.resize(maxPostorderId + 1); */
-
   symbolId = func->id();
 }
-void ResolutionResultByPostorderID::setupForParamLoop(const For* loop, ResolutionResultByPostorderID& parent) {
-  /* int bodyPostorder = 0; */
-  /* if (loop && loop->body()) */
-  /*   bodyPostorder = loop->body()->id().postOrderId(); */
-  /* CHPL_ASSERT(0 <= bodyPostorder); */
-  /* vec.resize(bodyPostorder); */
-
+void ResolutionResultByPostorderID::setupForParamLoop(
+    const For* loop, ResolutionResultByPostorderID& parent) {
   this->symbolId = parent.symbolId;
 }
 void ResolutionResultByPostorderID::setupForFunction(const Function* func) {

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -389,13 +389,26 @@ CallInfo CallInfo::createWithReceiver(const CallInfo& ci,
 
 void ResolutionResultByPostorderID::setupForSymbol(const AstNode* ast) {
   CHPL_ASSERT(Builder::astTagIndicatesNewIdScope(ast->tag()));
+  /* vec.resize(ast->id().numContainedChildren()); */
 
   symbolId = ast->id();
 }
 void ResolutionResultByPostorderID::setupForSignature(const Function* func) {
+  /* int maxPostorderId = 0; */
+  /* if (func && func->numChildren() > 0) */
+  /*   maxPostorderId = func->child(func->numChildren() - 1)->id().postOrderId(); */
+  /* CHPL_ASSERT(0 <= maxPostorderId); */
+  /* vec.resize(maxPostorderId + 1); */
+
   symbolId = func->id();
 }
 void ResolutionResultByPostorderID::setupForParamLoop(const For* loop, ResolutionResultByPostorderID& parent) {
+  /* int bodyPostorder = 0; */
+  /* if (loop && loop->body()) */
+  /*   bodyPostorder = loop->body()->id().postOrderId(); */
+  /* CHPL_ASSERT(0 <= bodyPostorder); */
+  /* vec.resize(bodyPostorder); */
+
   this->symbolId = parent.symbolId;
 }
 void ResolutionResultByPostorderID::setupForFunction(const Function* func) {

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -389,26 +389,13 @@ CallInfo CallInfo::createWithReceiver(const CallInfo& ci,
 
 void ResolutionResultByPostorderID::setupForSymbol(const AstNode* ast) {
   CHPL_ASSERT(Builder::astTagIndicatesNewIdScope(ast->tag()));
-  vec.resize(ast->id().numContainedChildren());
 
   symbolId = ast->id();
 }
 void ResolutionResultByPostorderID::setupForSignature(const Function* func) {
-  int maxPostorderId = 0;
-  if (func && func->numChildren() > 0)
-    maxPostorderId = func->child(func->numChildren() - 1)->id().postOrderId();
-  CHPL_ASSERT(0 <= maxPostorderId);
-  vec.resize(maxPostorderId + 1);
-
   symbolId = func->id();
 }
 void ResolutionResultByPostorderID::setupForParamLoop(const For* loop, ResolutionResultByPostorderID& parent) {
-  int bodyPostorder = 0;
-  if (loop && loop->body())
-    bodyPostorder = loop->body()->id().postOrderId();
-  CHPL_ASSERT(0 <= bodyPostorder);
-  vec.resize(bodyPostorder);
-
   this->symbolId = parent.symbolId;
 }
 void ResolutionResultByPostorderID::setupForFunction(const Function* func) {

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -212,8 +212,11 @@ void CallInfo::prepareActuals(Context* context,
         // Keep questionArg pointing at the first question argument we found
       }
     } else {
-      const ResolvedExpression& r = byPostorder.byAst(actual);
-      QualifiedType actualType = r.type();
+      QualifiedType actualType;
+      // replace default value with resolved if available
+      if (const ResolvedExpression* r = byPostorder.byAstOrNull(actual)) {
+        actualType = r->type();
+      }
       UniqueString byName;
       if (fnCall && fnCall->isNamedActual(i)) {
         byName = fnCall->actualName(i);


### PR DESCRIPTION
Replaces the vector used in ResolutionResultByPostorderID with a hash map to avoid wasting memory.

Previously ResolutionResultByPostorderID stored a `std::vector` of `ResolvedExpression`s with indexes corresponding to IDs. This is replaced with a `std:unordered_map` with IDs as keys and `ResolvedExpression`s as values. This saves memory because we often store IDs that do not start at 0 and/or are non-consecutive. For example, storing IDs `10`, `11`, `15` would previously allocate 16 "slots", vector indices 0-15, with only 3 being used. With a map, we do not rely on empty placeholder slots to keep track of IDs, so we can allocate only slots that are being used.

I conducted testing to ensure this change had no negative impact on performance, detailed in https://github.com/Cray/chapel-private/issues/4512#issuecomment-1462468902.

An alternate solution considered was still using a vector, but storing an ID offset so that vector index 0 corresponds to the first ID we need to store. This could potentially be more performant but does not help in the case of non-consecutive IDs and was less intuitive in my opinion. Since the performance of the map turned out to be fine this solution was not implemented.

With this change, the ResolutionResultByPostorderID will now contain no entry in some cases where it previously would have contained an empty entry. Code that depended on the previous behavior has been adjusted in this PR.

Resolves https://github.com/Cray/chapel-private/issues/4393.

Testing:
- [x] performance test described above
- [x] dyno tests
- [x] paratest