### PR TITLE
Adjust skipif for FCF pointer implementation to check target compiler

### DIFF
--- a/test/functions/fcf/pointers/SKIPIF
+++ b/test/functions/fcf/pointers/SKIPIF
@@ -1,1 +1,1 @@
-CHPL_LLVM == none
+CHPL_TARGET_COMPILER != llvm


### PR DESCRIPTION
Adjust the skipif for a test exercising the FCF pointer implementation
to ensure `CHPL_TARGET_COMPILER != llvm` rather than `CHPL_LLVM`.
Nightly confs will build with LLVM enabled but target Clang instead.