### PR TITLE
Fix two deprecations that are exposed by `make mason`

### DIFF
--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -92,7 +92,7 @@ proc pkgSearch(args) throws {
     exit(0);
   }
 
-  const pattern = compile(pkgName, ignoreCase=true);
+  const pattern = new regex(pkgName, ignoreCase=true);
   const command = "pkg-config --list-all";
   const cmd = command.split();
   var sub = spawn(cmd, stdout=pipeStyle.pipe);

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -103,7 +103,7 @@ proc main(args: [] string) throws {
   var usedCmd:string;
   var cmdList:list(string);
   // identify which, if any, subcommand was used and collect its arguments
-  for (cmd, arg) in subCmds.items() {
+  for (cmd, arg) in zip(subCmds.keys(), subCmds.values()) {
     if arg.hasValue() {
       usedCmd = cmd;
       cmdList = new list(arg.values());


### PR DESCRIPTION
Apparently our testing suite doesn't check everything that `make mason` does, and that deprecation warnings from GitHub actions can go unnoticed.

This PR makes two fixes to mason to avoid deprecation warnings.

Test:
- [x] `make mason` builds without warnings
- [x] run mason tests