### PR TITLE
Reword "which now means" to "is a" in generic class error messages

### DIFF
--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1346,7 +1346,7 @@ module ChapelDomain {
         compilerWarning("creating an array with element type " +
                         eltType:string);
         if isClassType(eltType) && !isGenericType(eltType:borrowed) {
-          compilerWarning("which now means class type with generic management");
+          compilerWarning("which is a class type with generic management");
         }
         compilerError("array element type cannot currently be generic");
         // In the future we might support it if the array is not default-inited

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -57,7 +57,7 @@ module SortedMap {
       compilerWarning("creating a sortedMap with key type " +
                       keyType:string);
       if isClassType(keyType) && !isGenericType(keyType:borrowed) {
-        compilerWarning("which now means class type with generic management");
+        compilerWarning("which is a class type with generic management");
       }
       compilerError("sortedMap key type cannot currently be generic");
     }
@@ -69,7 +69,7 @@ module SortedMap {
       compilerWarning("creating a sortedMap with value type " +
                       valType:string);
       if isClassType(valType) && !isGenericType(valType:borrowed) {
-        compilerWarning("which now means class type with generic management");
+        compilerWarning("which is a class type with generic management");
       }
       compilerError("sortedMap value type cannot currently be generic");
     }

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -81,7 +81,7 @@ module Heap {
       compilerWarning("creating a heap with element type " +
                       eltType:string);
       if isClassType(eltType) && !isGenericType(eltType:borrowed) {
-        compilerWarning("which now means class type with generic management");
+        compilerWarning("which is a class type with generic management");
       }
       compilerError("heap element type cannot currently be generic");
       // In the future we might support it if the list is not default-inited

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -108,7 +108,7 @@ module List {
       compilerWarning("creating a list with element type " +
                       eltType:string);
       if isClassType(eltType) && !isGenericType(eltType:borrowed) {
-        compilerWarning("which now means class type with generic management");
+        compilerWarning("which is a class type with generic management");
       }
       compilerError("list element type cannot currently be generic");
       // In the future we might support it if the list is not default-inited

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -56,7 +56,7 @@ module Map {
     if isGenericType(K) {
       compilerWarning('creating a map with key type ', K:string, 2);
       if isClassType(K) && !isGenericType(K:borrowed) {
-        compilerWarning('which now means class type with generic ',
+        compilerWarning('which is a class type with generic ',
                         'management', 2);
       }
       compilerError('map key type cannot currently be generic', 2);
@@ -64,7 +64,7 @@ module Map {
     if isGenericType(V) {
       compilerWarning('creating a map with value type ', V:string, 2);
       if isClassType(V) && !isGenericType(V:borrowed) {
-        compilerWarning('which now means class type with generic ',
+        compilerWarning('which is a class type with generic ',
                         'management', 2);
       }
       compilerError('map value type cannot currently be generic', 2);

--- a/test/arrays/compilerErrors/array-of-generic-management.good
+++ b/test/arrays/compilerErrors/array-of-generic-management.good
@@ -1,3 +1,3 @@
 array-of-generic-management.chpl:2: warning: creating an array with element type MyClass
-array-of-generic-management.chpl:2: warning: which now means class type with generic management
+array-of-generic-management.chpl:2: warning: which is a class type with generic management
 array-of-generic-management.chpl:2: error: array element type cannot currently be generic

--- a/test/library/packages/SortedMap/init/testInitGenericError.good
+++ b/test/library/packages/SortedMap/init/testInitGenericError.good
@@ -1,5 +1,5 @@
 $CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: warning: creating a sortedMap with key type C
-$CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: warning: which now means class type with generic management
+$CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: warning: which is a class type with generic management
 $CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: error: sortedMap key type cannot currently be generic
   testInitGenericError.chpl:9: called as sortedMap.init(type keyType = C, type valType = int(64), param parSafe = false, comparator: DefaultComparator)

--- a/test/library/packages/SortedMap/init/testInitGenericError2.good
+++ b/test/library/packages/SortedMap/init/testInitGenericError2.good
@@ -1,5 +1,5 @@
 $CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: warning: creating a sortedMap with value type C
-$CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: warning: which now means class type with generic management
+$CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: warning: which is a class type with generic management
 $CHPL_HOME/modules/packages/SortedMap.chpl:nnnn: error: sortedMap value type cannot currently be generic
   testInitGenericError2.chpl:9: called as sortedMap.init(type keyType = int(64), type valType = C, param parSafe = false, comparator: DefaultComparator)

--- a/test/library/standard/List/init/listInitGenericError.good
+++ b/test/library/standard/List/init/listInitGenericError.good
@@ -1,5 +1,5 @@
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: creating a list with element type C
-$CHPL_HOME/modules/standard/List.chpl:nnnn: warning: which now means class type with generic management
+$CHPL_HOME/modules/standard/List.chpl:nnnn: warning: which is a class type with generic management
 $CHPL_HOME/modules/standard/List.chpl:nnnn: error: list element type cannot currently be generic
   listInitGenericError.chpl:nnnn: called as list.init(type eltType = C, param parSafe = false)

--- a/test/library/standard/Map/testInitGenericError.good
+++ b/test/library/standard/Map/testInitGenericError.good
@@ -1,3 +1,3 @@
 testInitGenericError.chpl:7: warning: creating a map with key type C
-testInitGenericError.chpl:7: warning: which now means class type with generic management
+testInitGenericError.chpl:7: warning: which is a class type with generic management
 testInitGenericError.chpl:7: error: map key type cannot currently be generic

--- a/test/library/standard/Map/testInitGenericError2.good
+++ b/test/library/standard/Map/testInitGenericError2.good
@@ -1,3 +1,3 @@
 testInitGenericError2.chpl:7: warning: creating a map with value type C
-testInitGenericError2.chpl:7: warning: which now means class type with generic management
+testInitGenericError2.chpl:7: warning: which is a class type with generic management
 testInitGenericError2.chpl:7: error: map value type cannot currently be generic


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/issues/21417, Michael pointed out that our error messages about generic management styles use the phrase "which now means" which made sense at the time that class definitions were changing, but now feels odd...  Here, I reword such cases to "is a" in hopes of making the error messages clearer.
