### PR TITLE
Switch DR.dsiAccess tuple arg to const ref

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1352,20 +1352,20 @@ module DefaultRectangular {
     where rank == 1 do
       return dsiAccess(ind);
 
-    inline proc dsiAccess(ind : rank*idxType) ref {
+    inline proc dsiAccess(const ref ind : rank*idxType) ref {
       // Note: bounds checking occurs in ChapelArray for this type.
       var dataInd = getDataIndex(ind);
       return theData(dataInd);
     }
 
-    inline proc dsiAccess(ind : rank*idxType)
+    inline proc dsiAccess(const ref ind : rank*idxType)
     where shouldReturnRvalueByValue(eltType) {
       // Note: bounds checking occurs in ChapelArray for this type.
       var dataInd = getDataIndex(ind);
       return theData(dataInd);
     }
 
-    inline proc dsiAccess(ind : rank*idxType) const ref {
+    inline proc dsiAccess(const ref ind : rank*idxType) const ref {
       // Note: bounds checking occurs in ChapelArray for this type.
       var dataInd = getDataIndex(ind);
       return theData(dataInd);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1352,20 +1352,20 @@ module DefaultRectangular {
     where rank == 1 do
       return dsiAccess(ind);
 
-    inline proc dsiAccess(const ref ind : rank*idxType) ref {
+    inline proc dsiAccess(const in ind : rank*idxType) ref {
       // Note: bounds checking occurs in ChapelArray for this type.
       var dataInd = getDataIndex(ind);
       return theData(dataInd);
     }
 
-    inline proc dsiAccess(const ref ind : rank*idxType)
+    inline proc dsiAccess(const in ind : rank*idxType)
     where shouldReturnRvalueByValue(eltType) {
       // Note: bounds checking occurs in ChapelArray for this type.
       var dataInd = getDataIndex(ind);
       return theData(dataInd);
     }
 
-    inline proc dsiAccess(const ref ind : rank*idxType) const ref {
+    inline proc dsiAccess(const in ind : rank*idxType) const ref {
       // Note: bounds checking occurs in ChapelArray for this type.
       var dataInd = getDataIndex(ind);
       return theData(dataInd);


### PR DESCRIPTION
This aims to fix the performance regressions we observe as a result of #21665.
No new tests are added or needed.

### Suspected cause for performance regression

First, array.this(idx) invokes DefaultRectangularArr.dsiAccess(idx).
This passes `idx` by the default intent, which triggers copying the tuple,
since #21665.

array.this() and dsiAccess() engage in return intent overloading.
Copying the tuple now occurs three times for each call to dsiAccess.

Copying involves creating call and return temps, so we now observe
three of these sitting in the AST for a call like `dsiAccess(dataIdx)`:
```
def val coerce_tmp: 2*int(64)
def val ret_tmp: 2*int(64)
call fn : (dataIdx, ret_tmp)
move coerce_tmp <-- ret_tmp
```

Second, consider this loop over two DefaultRectangular multi-D arrays:

```chpl
for (a,b) in zip(A,B) do
  a = b;
```

the serial iterator for A and B does some array indexing, so it gets
these additional temps and copying.

Finally, this iterator does not get inlined. So all those temps
end up in the iterator class during lowerIterators. Which comes
before copyPropagation so the temps and copies do not get optimized away.
Now the copying involves reading and updating the fields of heap-allocated
objects, so LLVM and C backends are not optimizing them away, either.

The following does not seem to affect performance, however results
in clutter in the generated code: a PRIM_ASSIGN between two tuples
is codegen-ed as a series of field assignments. This was done
in 557c09e995 because memcpy was not as fast back then. We may
want to switch to memcpy as we expect it to be better now.
See fNoTupleCopyOpt in cg-expr.cpp.

### Possible solutions

We could address each step in the above progression:

* Change the intent in dsiAccess() and similar to explicit `const in`.
  @dlongnecke-cray proposed this approach.
  Interestingly, `BlockArr.dsiAccess()` has const-in intent already.

* My first solution was to apply `const ref` intent,
  which fixed the performance regression in the above example loop.
  However, with `const in` intents my test runs of that loop
  showed better performance than I got with `const ref`.

* Avoid inserting tuple copying in more cases than #21665 already does.

* Run some cleanup before lowerIterators().

* Beef up copyPropagation to handle iterator classes.

This PR chooses the first of these for simplicity. However we may want
to make other changes as well in the future. 
