### PR TITLE
Reorder GPU plots, fix two Y labels

### DIFF
--- a/test/GPU-GRAPHFILES
+++ b/test/GPU-GRAPHFILES
@@ -1,22 +1,23 @@
-gpu/native/studies/shoc/shoc-triad-bw-lg.graph
+gpu/native/studies/shoc/shoc-triad-bw-sm.graph
 gpu/native/studies/shoc/triad.graph
 gpu/native/studies/shoc/kernel.graph
-gpu/native/studies/shoc/kernel2.graph
+gpu/native/studies/shoc/shoc-triad-bw-lg.graph
 gpu/native/studies/shoc/triad2.graph
-gpu/native/studies/shoc/shoc-triad-bw-sm.graph
-gpu/native/studies/shoc/sort.graph
-
-gpu/native/streamPrototype/gpuStream.graph
-
-gpu/native/studies/compiler-performance/transform.graph
-gpu/native/studies/compiler-performance/end-to-end.graph
-
-gpu/native/studies/kernelLaunch/emptyKernelLaunch.graph
-
-gpu/native/studies/chop/chplGPU.graph
+gpu/native/studies/shoc/kernel2.graph
 
 gpu/native/array_on_device/studies/shoc/triadAodBw1.graph
 gpu/native/array_on_device/studies/shoc/triadAodBw2.graph
 
+gpu/native/studies/shoc/sort.graph
+
+gpu/native/streamPrototype/gpuStream.graph
+
+gpu/native/studies/kernelLaunch/emptyKernelLaunch.graph
+
 gpu/native/studies/transpose/transpose-throughput.graph
 gpu/native/studies/transpose/transpose-time.graph
+
+gpu/native/studies/chop/chplGPU.graph
+
+gpu/native/studies/compiler-performance/transform.graph
+gpu/native/studies/compiler-performance/end-to-end.graph

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodBw1.graph
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodBw1.graph
@@ -1,5 +1,5 @@
 perfkeys: BW block size 64 =, BW block size 64 =
 files: triadAOD.dat, triadAodAsync.dat
 graphkeys: Triad, Async comm
-ylabel: Time (s)
+ylabel: Bandwidth (GB/s)
 graphtitle: SHOC Triad (array on device) - Bandwidth - 64KB

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodBw2.graph
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodBw2.graph
@@ -1,5 +1,5 @@
 perfkeys: BW block size 16384 =, BW block size 16384 =
 files: triadAOD.dat, triadAodAsync.dat
 graphkeys: Triad, Async comm
-ylabel: Time (s)
+ylabel: Bandwidth (GB/s)
 graphtitle: SHOC Triad (array on device) - Bandwidth - 16384KB


### PR DESCRIPTION
The plots are reordered to make things slightly easier while comparing performance. We can reduce number of plots we have, but I am leaving that as a future work.

Also fixes Y axis labels on two plots that caused us to believe that they were regressions: https://github.com/Cray/chapel-private/issues/4426