### PR TITLE
Suppress printchplenv warnings in testEnv

### DIFF
--- a/util/test/testEnv
+++ b/util/test/testEnv
@@ -9,6 +9,7 @@ my $utildir = defined($ENV{"CHPL_TEST_UTIL_DIR"}) ? $ENV{"CHPL_TEST_UTIL_DIR"} :
 #
 # Set standard CHPL_* environment variables, if they are not already set.
 #
+$ENV{"CHPLENV_SUPPRESS_WARNINGS"} = "1";
 my $env = `$utildir/printchplenv --all --internal --simple --no-tidy`;
 my @lines = split(/\n/, $env);
 for my $line (@lines) {


### PR DESCRIPTION
`testEnv` should ignore `printchplenv` warnings because including them in its output causes problems with the programs that use `testEnv`, e.g., `sub_test.py` will not process executable `.skipif` files properly and will always conclude that the test should not be skipped.