### PR TITLE
 Add proxies to send_email.py for macs in Houston

### DIFF
--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -14,6 +14,8 @@ import os
 import smtplib
 import socket
 import sys
+import smtplib
+import socks
 
 try:
     basestring
@@ -25,7 +27,12 @@ def main():
     args = _parse_args()
     _setup_logging(args.verbose)
     body = sys.stdin.read()
-
+   # set proxy for macs in houston lab
+    if sys.platform.startswith('darwin'):
+        #socks.setdefaultproxy(TYPE, ADDR, PORT)
+        socks.setdefaultproxy(socks.HTTP, 'http://web-proxy.houston.hpecorp.net', 8080)
+        socks.setdefaultproxy(socks.HTTPS, 'http://web-proxy.houston.hpecorp.net', 8080)
+        socks.wrapmodule(smtplib)
     # Send the email!
     send_email(args.recipients, body, args.subject, args.header, args.sender, args.smtp_host,
         args.smtp_user, args.smtp_password, args.smtp_password_file)


### PR DESCRIPTION
To address:
https://github.com/Cray/chapel-private/issues/4478

Fix:
Check if the underlying OS is mac and add proxies for the tests running in macs in Houston.

- [x] Test the changes in Chapel Macs

Issue is resolved with the fix:
[Done with tests - 230307.105201]
[Log file: /var/folders/m0/pycx4cws2k9bgwygvs5l35l8000p12/T/day2-Tue-gasnet.fast.darwin.log.30935 ]

[Test Summary - 230307.105201]
[Summary: #Successes = 6 | #Failures = 0 | #Futures = 0 | #Warnings = 0 ]
[Summary: #Passing Suppressions = 0 | #Passing Futures = 0 ]
[END]

Moving the log and summary files

2023-03-07 10:52:02 [INFO] Finished running ./test-gasnet.fast.darwin.bash on C07N70Y6DY3H