### PR TITLE
Add prediff for test that has a new error message under 'dyno'

### DIFF
--- a/test/modules/implicit/parseTwice/main.prediff
+++ b/test/modules/implicit/parseTwice/main.prediff
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+"""
+Strip excess '././' from file names in error messages.
+"""
+
+import os.path as path
+import shutil
+import sys
+
+fname = sys.argv[2]
+
+with open(fname, 'r+') as fp:
+  out = str()
+  for line in fp:
+    sp = line.split(':', 1)
+    if len(sp) != 2: continue
+    sp[0] = path.normpath(sp[0])
+    out += ':'.join(sp)
+  fp.seek(0)
+  fp.truncate()
+  fp.write(out)

--- a/test/modules/implicit/parseTwice/main.prediff
+++ b/test/modules/implicit/parseTwice/main.prediff
@@ -5,7 +5,6 @@ Strip excess '././' from file names in error messages.
 """
 
 import os.path as path
-import shutil
 import sys
 
 fname = sys.argv[2]


### PR DESCRIPTION
Adjust a test that produces variable output under dyno to use a
prediff.

The test `'modules/implicit/parseTwice/main.chpl` takes a bunch of
files on the command line that use paths like `././SomeLibrary.chpl`.

The dyno frontend produces an additional error that mentions
`././SomeLibrary.chpl`, which means a prediff is required to avoid
introducing 9 different `.good` files.

Both dyno and production display paths exactly as they are input to
the compiler. We could consider having the compiler produce absolute
paths or performing a `normpath` operation on paths to avoid this
sort of prediff in the future.

Reviewed by @DanilaFe. Thanks!