### PR TITLE
Fix nightly tests accidentally broken from ROCM PR

### DIFF
--- a/test/gpu/native/cudaOnly.skipif
+++ b/test/gpu/native/cudaOnly.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU_CODEGEN == rocm

--- a/test/gpu/native/studies/compiler-performance/math.chpl
+++ b/test/gpu/native/studies/compiler-performance/math.chpl
@@ -1,1 +1,1 @@
-../../cudaOnly/math.chpl
+../../math.chpl

--- a/test/gpu/native/studies/compiler-performance/math.good
+++ b/test/gpu/native/studies/compiler-performance/math.good
@@ -1,1 +1,1 @@
-../../cudaOnly/math.good
+../../math.good


### PR DESCRIPTION
- Fix broken link for math test
- add skipif file for cudaOnly directory (accidentally removed)