### PR TITLE
Add documentation to mark owned/shared adopt and release as experimental

### DIFF
--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -156,6 +156,8 @@ module OwnedObject {
       of the argument. The result has the same type as the argument.
       If the argument is non-nilable, it must be recognized by the compiler
       as an expiring value.
+
+      Note: This is an experimental interface
     */
     inline proc type adopt(pragma "nil from arg" in obj : owned) {
       return obj;
@@ -168,6 +170,8 @@ module OwnedObject {
 
       It is an error to directly delete the class instance
       after passing it to `owned.adopt()`.
+
+      Note: This is an experimental interface
     */
     inline proc type adopt(pragma "nil from arg" in obj: unmanaged) {
       // 'result' may have a non-nilable type
@@ -181,6 +185,8 @@ module OwnedObject {
       return the instance previously managed by this owned object.
 
       If the argument is `nil` it returns `nil`.
+
+      Note: This is an experimental interface
     */
     inline proc type release(pragma "nil from arg" ref obj: owned) {
       var oldPtr = obj.chpl_p;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -158,9 +158,11 @@ module OwnedObject {
       as an expiring value.
 
       .. note::
-
-         This is part of an experimental interface, users should prefer
-         :proc:`owned.create`/:proc:`owned.retain`/:proc:`owned.clear` for now.
+         This is part of an new interface that will replace :proc:`owned.create`
+         and :proc:`owned.retain`. However, `adopt` is not as widely used as
+         `create` and `retain` yet, so there may be some bugs we have not
+         found yet. If you discover any bugs with `adopt`, please report them
+         to us and fall back on `create` and `retain`.
     */
     inline proc type adopt(pragma "nil from arg" in obj : owned) {
       return obj;
@@ -175,9 +177,11 @@ module OwnedObject {
       after passing it to `owned.adopt()`.
 
       .. note::
-
-         This is part of an experimental interface, users should prefer
-         :proc:`owned.create`/:proc:`owned.retain`/:proc:`owned.clear` for now.
+         This is part of an new interface that will replace :proc:`owned.create`
+         and :proc:`owned.retain`. However, `adopt` is not as widely used as
+         `create` and `retain` yet, so there may be some bugs we have not
+         found yet. If you discover any bugs with `adopt`, please report them
+         to us and fall back on `create` and `retain`.
     */
     inline proc type adopt(pragma "nil from arg" in obj: unmanaged) {
       // 'result' may have a non-nilable type
@@ -193,9 +197,9 @@ module OwnedObject {
       If the argument is `nil` it returns `nil`.
 
       .. note::
-
-         This is part of an experimental interface, users should prefer
-         :proc:`owned.create`/:proc:`owned.retain`/:proc:`owned.clear` for now.
+         This is part of an new interface that will replace :proc:`owned.clear`.However, `release` is not as widely used as `clear` yet, so there may
+         be some bugs we have not found yet. If you discover any bugs with
+         `release`, please report them to us and fall back on `clear`.
     */
     inline proc type release(pragma "nil from arg" ref obj: owned) {
       var oldPtr = obj.chpl_p;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -197,7 +197,8 @@ module OwnedObject {
       If the argument is `nil` it returns `nil`.
 
       .. note::
-         This is part of an new interface that will replace :proc:`owned.clear`.However, `release` is not as widely used as `clear` yet, so there may
+         This is part of an new interface that will replace :proc:`owned.clear`.
+         However, `release` is not as widely used as `clear` yet, so there may
          be some bugs we have not found yet. If you discover any bugs with
          `release`, please report them to us and fall back on `clear`.
     */

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -157,7 +157,10 @@ module OwnedObject {
       If the argument is non-nilable, it must be recognized by the compiler
       as an expiring value.
 
-      Note: This is an experimental interface
+      .. note::
+
+         This is part of an experimental interface, users should prefer
+         :proc:`owned.create`/:proc:`owned.retain`/:proc:`owned.clear` for now.
     */
     inline proc type adopt(pragma "nil from arg" in obj : owned) {
       return obj;
@@ -171,7 +174,10 @@ module OwnedObject {
       It is an error to directly delete the class instance
       after passing it to `owned.adopt()`.
 
-      Note: This is an experimental interface
+      .. note::
+
+         This is part of an experimental interface, users should prefer
+         :proc:`owned.create`/:proc:`owned.retain`/:proc:`owned.clear` for now.
     */
     inline proc type adopt(pragma "nil from arg" in obj: unmanaged) {
       // 'result' may have a non-nilable type
@@ -186,7 +192,10 @@ module OwnedObject {
 
       If the argument is `nil` it returns `nil`.
 
-      Note: This is an experimental interface
+      .. note::
+
+         This is part of an experimental interface, users should prefer
+         :proc:`owned.create`/:proc:`owned.retain`/:proc:`owned.clear` for now.
     */
     inline proc type release(pragma "nil from arg" ref obj: owned) {
       var oldPtr = obj.chpl_p;

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -355,9 +355,11 @@ module SharedObject {
       as an expiring value.
 
       .. note::
-
-         This is part of an experimental interface, users should prefer
-         :proc:`shared.create`/:proc:`shared.retain`/:proc:`shared.clear` for now.
+         This is part of an new interface that will replace :proc:`shared.create`
+         and :proc:`shared.retain`. However, `adopt` is not as widely used as
+         `create` and `retain` yet, so there may be some bugs we have not
+         found yet. If you discover any bugs with `adopt`, please report them
+         to us and fall back on `create` and `retain`.
     */
     inline proc type adopt(pragma "nil from arg" in obj: owned) {
       var ptr = owned.release(obj);
@@ -368,9 +370,11 @@ module SharedObject {
       The result has the same type as the argument.
 
       .. note::
-
-         This is part of an experimental interface, users should prefer
-         :proc:`shared.create`/:proc:`shared.retain`/:proc:`shared.clear` for now.
+         This is part of an new interface that will replace :proc:`shared.create`
+         and :proc:`shared.retain`. However, `adopt` is not as widely used as
+         `create` and `retain` yet, so there may be some bugs we have not
+         found yet. If you discover any bugs with `adopt`, please report them
+         to us and fall back on `create` and `retain`.
     */
     inline proc type adopt(pragma "nil from arg" in obj: shared) {
       return obj;
@@ -385,9 +389,11 @@ module SharedObject {
       after passing it to `shared.adopt()`.
 
       .. note::
-
-         This is part of an experimental interface, users should prefer
-         :proc:`shared.create`/:proc:`shared.retain`/:proc:`shared.clear` for now.
+         This is part of an new interface that will replace :proc:`shared.create`
+         and :proc:`shared.retain`. However, `adopt` is not as widely used as
+         `create` and `retain` yet, so there may be some bugs we have not
+         found yet. If you discover any bugs with `adopt`, please report them
+         to us and fall back on `create` and `retain`.
     */
     inline proc type adopt(pragma "nil from arg" in obj: unmanaged) {
       // 'result' may have a non-nilable type

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -353,6 +353,8 @@ module SharedObject {
       The result type preserves nilability of the argument type.
       If the argument is non-nilable, it must be recognized by the compiler
       as an expiring value.
+
+      Note: This is an experimental interface
     */
     inline proc type adopt(pragma "nil from arg" in obj: owned) {
       var ptr = owned.release(obj);
@@ -361,6 +363,8 @@ module SharedObject {
     /*
       Creates a new `shared` class reference to the argument.
       The result has the same type as the argument.
+
+      Note: This is an experimental interface
     */
     inline proc type adopt(pragma "nil from arg" in obj: shared) {
       return obj;
@@ -373,6 +377,8 @@ module SharedObject {
 
       It is an error to directly delete the class instance
       after passing it to `shared.adopt()`.
+
+      Note: This is an experimental interface
     */
     inline proc type adopt(pragma "nil from arg" in obj: unmanaged) {
       // 'result' may have a non-nilable type

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -354,7 +354,10 @@ module SharedObject {
       If the argument is non-nilable, it must be recognized by the compiler
       as an expiring value.
 
-      Note: This is an experimental interface
+      .. note::
+
+         This is part of an experimental interface, users should prefer
+         :proc:`shared.create`/:proc:`shared.retain`/:proc:`shared.clear` for now.
     */
     inline proc type adopt(pragma "nil from arg" in obj: owned) {
       var ptr = owned.release(obj);
@@ -364,7 +367,10 @@ module SharedObject {
       Creates a new `shared` class reference to the argument.
       The result has the same type as the argument.
 
-      Note: This is an experimental interface
+      .. note::
+
+         This is part of an experimental interface, users should prefer
+         :proc:`shared.create`/:proc:`shared.retain`/:proc:`shared.clear` for now.
     */
     inline proc type adopt(pragma "nil from arg" in obj: shared) {
       return obj;
@@ -378,7 +384,10 @@ module SharedObject {
       It is an error to directly delete the class instance
       after passing it to `shared.adopt()`.
 
-      Note: This is an experimental interface
+      .. note::
+
+         This is part of an experimental interface, users should prefer
+         :proc:`shared.create`/:proc:`shared.retain`/:proc:`shared.clear` for now.
     */
     inline proc type adopt(pragma "nil from arg" in obj: unmanaged) {
       // 'result' may have a non-nilable type


### PR DESCRIPTION
Add a note to mark the following functions as experimental.
- owned.adopt
- owned.release
- shared.adopt

After discussion offline, these functions will be kept in the release with appropriate notations in the documentation. These will eventually replace the owned and shared functions/methods `create`, `retain`, and `clear`, but the actual work to do the replacement is not done yet.

---

Tested docs for formatting