### PR TITLE
Restrict cases when new --baseline future is run

### DIFF
--- a/test/parallel/forall/reduce-intents/ri-bool-baseline-bug.skipif
+++ b/test/parallel/forall/reduce-intents/ri-bool-baseline-bug.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local


### PR DESCRIPTION
It turns out that the bug I filed yesterday isn't problematic for --no-local compilations, so here, I've added a `.skipif` to skip over the future in the event that we're in a `CHPL_COMM!=none` or `--no-local` compilation.
