### PR TITLE
Improved `file.lines` deprecation message

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3863,7 +3863,7 @@ config param useNewLinesRegionBounds = false;
 
    :throws SystemError: Thrown if an object could not be returned.
  */
-deprecated "`file.lines` is deprecated; please use `fileReader.lines` instead"
+deprecated "`file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`"
 proc file.lines(param locking:bool = true, region: range(?) = 0..,
                 hints = ioHintSet.empty) throws where (!region.hasHighBound() ||
                                                        useNewLinesRegionBounds) {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3863,7 +3863,7 @@ config param useNewLinesRegionBounds = false;
 
    :throws SystemError: Thrown if an object could not be returned.
  */
-deprecated "`file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`"
+deprecated "`file.lines` is deprecated; please use `file.reader().lines` instead"
 proc file.lines(param locking:bool = true, region: range(?) = 0..,
                 hints = ioHintSet.empty) throws where (!region.hasHighBound() ||
                                                        useNewLinesRegionBounds) {

--- a/test/deprecated/IO/fileLines.good
+++ b/test/deprecated/IO/fileLines.good
@@ -1,4 +1,4 @@
-fileLines.chpl:5: warning: `file.lines` is deprecated; please use `fileReader.lines` instead
+fileLines.chpl:5: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
 use IO;
 
 var f = open("fileLines.chpl", ioMode.r);

--- a/test/deprecated/IO/fileLines.good
+++ b/test/deprecated/IO/fileLines.good
@@ -1,4 +1,4 @@
-fileLines.chpl:5: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
+fileLines.chpl:5: warning: `file.lines` is deprecated; please use `file.reader().lines` instead
 use IO;
 
 var f = open("fileLines.chpl", ioMode.r);

--- a/test/library/standard/IO/linesBadRegion.good
+++ b/test/library/standard/IO/linesBadRegion.good
@@ -1,4 +1,4 @@
-linesBadRegion.chpl:6: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
+linesBadRegion.chpl:6: warning: `file.lines` is deprecated; please use `file.reader().lines` instead
 uncaught SystemError: Invalid argument (while reading string with path "linesLimited.txt" offset -1)
   linesBadRegion.chpl:6: thrown here
   linesBadRegion.chpl:6: uncaught here

--- a/test/library/standard/IO/linesBadRegion.good
+++ b/test/library/standard/IO/linesBadRegion.good
@@ -1,4 +1,4 @@
-linesBadRegion.chpl:6: warning: `file.lines` is deprecated; please use `fileReader.lines` instead
+linesBadRegion.chpl:6: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
 uncaught SystemError: Invalid argument (while reading string with path "linesLimited.txt" offset -1)
   linesBadRegion.chpl:6: thrown here
   linesBadRegion.chpl:6: uncaught here

--- a/test/library/standard/IO/linesLimited.good
+++ b/test/library/standard/IO/linesLimited.good
@@ -1,7 +1,7 @@
-linesLimited.chpl:6: warning: `file.lines` is deprecated; please use `fileReader.lines` instead
-linesLimited.chpl:10: warning: `file.lines` is deprecated; please use `fileReader.lines` instead
-linesLimited.chpl:14: warning: `file.lines` is deprecated; please use `fileReader.lines` instead
-linesLimited.chpl:18: warning: `file.lines` is deprecated; please use `fileReader.lines` instead
+linesLimited.chpl:6: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
+linesLimited.chpl:10: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
+linesLimited.chpl:14: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
+linesLimited.chpl:18: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
 doe, a deer, a female deer
 ray, a drop of golden sun
 me, a name, I call myself

--- a/test/library/standard/IO/linesLimited.good
+++ b/test/library/standard/IO/linesLimited.good
@@ -1,7 +1,7 @@
-linesLimited.chpl:6: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
-linesLimited.chpl:10: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
-linesLimited.chpl:14: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
-linesLimited.chpl:18: warning: `file.lines` is deprecated; please use `fileReader.lines` by calling `.reader().lines() on your `file`
+linesLimited.chpl:6: warning: `file.lines` is deprecated; please use `file.reader().lines` instead
+linesLimited.chpl:10: warning: `file.lines` is deprecated; please use `file.reader().lines` instead
+linesLimited.chpl:14: warning: `file.lines` is deprecated; please use `file.reader().lines` instead
+linesLimited.chpl:18: warning: `file.lines` is deprecated; please use `file.reader().lines` instead
 doe, a deer, a female deer
 ray, a drop of golden sun
 me, a name, I call myself


### PR DESCRIPTION
The old deprecation message for `file.lines` indicated that `fileReader.lines` should be used instead, but did not specify how to obtain one. This PR corrects that.

- [x] passing paratest