### PR TITLE
Fix missing change to fdiv and add negative right shift bigint test

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -1815,7 +1815,7 @@ module BigInteger {
         const aLoc = chpl_buildLocaleID(a.localeId, c_sublocid_any);
 
         on __primitive("chpl_on_locale_num", aLoc) {
-          mpz_tdiv_q_2exp(a.mpz, a.mpz, b_);
+          mpz_fdiv_q_2exp(a.mpz, a.mpz, b_);
         }
       }
 

--- a/test/library/standard/BigInteger/apiTest.chpl
+++ b/test/library/standard/BigInteger/apiTest.chpl
@@ -164,6 +164,14 @@ on Locales[min(Locales.domain.high, executeLocale)] {
   assert(-5:bigint << 3:uint  == -40);
   assert(-5:bigint >> 1:uint  == -3);
 
+  // right shifting a negative value over its size will always result in -1,
+  // not 0
+  var neg = -5:bigint;
+  neg >>= 64;
+  assert(neg == -1);
+  neg = -5; 
+  assert(neg >> 64 == -1);
+
   // Boolean ops
   assert(~123:bigint == -124);
   assert(123:bigint & 234:bigint == 106);


### PR DESCRIPTION
In #21784, I missed one of the changes from tdiv->fdiv and am also adding a test to lock in the behavior of over right shifting a negative value, which changed in #21784 (to be correct now). This change in behavior was caught in Arkouda (see https://github.com/Bears-R-Us/arkouda/pull/2204), where the old (incorrect) behavior was being relied upon.