### PR TITLE
Add a CHPL_AUTO_MAKE_TARGETS Makefile var and 'checkwhitespace' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ export CHPL_MAKE_PYTHON := $(shell $(CHPL_MAKE_HOME)/util/config/find-python.sh)
 
 default: all
 
-all: comprt
+all: $(CHPL_AUTO_MAKE_TARGETS) comprt
 	@test -r Makefile.devel && $(MAKE) develall || echo ""
 
 comprt: FORCE

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -74,6 +74,13 @@ run-frontend-linters: FORCE
 
 run-dyno-linters: run-frontend-linters FORCE
 
+checkwhitespace:
+	@if [ `./util/devel/lookForTrailingSpaces | wc -l` -gt 0 ]; then \
+		echo "Found lines with trailing spaces :-("; \
+		./util/devel/lookForTrailingSpaces; \
+		exit 1; \
+	fi
+
 SPECTEST_DIR = ./test/release/examples/spec
 spectests: FORCE
 	rm -rf $(SPECTEST_DIR)


### PR DESCRIPTION
This adds a CHPL_AUTO_MAKE_TARGETS Makefile variable that can be used to create a given target (or targets?) to be made every time you do a `make all` or `make`.  By setting the variable in your environment or command-line, you can force every make to run some command.

I also added a 'checkwhitespace' target to Makefile.devel that runs the same script as our CI process does.  The combination of the two permits a developer to set CHPL_AUTO_MAKE_TARGETS=checkwhitespace in order to get a whitespace check on every build (if set in environment, or every build that sets it on the command-line otherwise).

---
Signed-off-by: Brad Chamberlain <bradcray@users.noreply.github.com>