### PR TITLE
Automatically set CHPL_GPU_CODEGEN if not already set

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -145,6 +145,6 @@ def validate(chplLocaleModel, chplComm):
 
     if get() == 'rocm':
         if not validateLlvmBuiltForRocm():
-            error("LLVM not built for AMDGPU Consider setting CHPL_LLVM to 'bundled'")
+            error("LLVM not built for AMDGPU, consider setting CHPL_LLVM to 'bundled'")
 
     return True

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -3,7 +3,6 @@ import os
 import glob
 import chpl_locale_model
 import chpl_llvm
-import shutil
 from utils import error, memoize, run_command, which
 
 # Format:
@@ -141,7 +140,11 @@ def validateLlvmBuiltForRocm():
 
 @memoize
 def validate(chplLocaleModel, chplComm):
+    if chplLocaleModel != "gpu":
+        return True
+
     if get() == 'rocm':
         if not validateLlvmBuiltForRocm():
             error("LLVM not built for AMDGPU Consider setting CHPL_LLVM to 'bundled'")
+
     return True

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -3,6 +3,7 @@ import os
 import glob
 import chpl_locale_model
 import chpl_llvm
+import shutil
 from utils import error, memoize, run_command
 
 # Format:
@@ -14,6 +15,16 @@ GPU_TYPES = {
     "cuda": ("CHPL_CUDA_PATH", "nvcc", 2, "sm_60"),
     "rocm": ("CHPL_ROCM_PATH", "hipcc", 3,"gfx906")
 }
+
+def determineGpuType():
+  nvccPath = shutil.which("nvcc")
+  hipccPath = shutil.which("hipcc")
+  if nvccPath and not hipccPath:
+    return('cuda')
+  if not nvccPath and hipccPath:
+    return('rocm')
+  error("Unable to determine GPU type, assign 'CHPL_GPU_CODEGEN' to one of {}".
+    format(GPU_TYPES.keys()))
 
 @memoize
 def get():
@@ -27,7 +38,7 @@ def get():
         else:
             return chpl_gpu_codegen
     else:
-        return 'cuda'
+        return determineGpuType();
 
 @memoize
 def get_arch():

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -10,23 +10,21 @@ from utils import error, memoize, run_command, which
 #   program to locate SDK folder
 #   depth of program within SDK folder
 #   Default GPU architecure for the vendor
+#   LLVM target
 GPU_TYPES = {
-    "cuda": ("CHPL_CUDA_PATH", "nvcc", 2, "sm_60"),
-    "rocm": ("CHPL_ROCM_PATH", "hipcc", 3,"gfx906")
+    "cuda": ("CHPL_CUDA_PATH", "nvcc",  2,"sm_60",  "NVPTX"),
+    "rocm": ("CHPL_ROCM_PATH", "hipcc", 3,"gfx906", "AMDGPU")
 }
 
 def determineGpuType():
-    gpuTypesFound = 0
-    typeFound = None
-    for gpuType in GPU_TYPES.keys():
-        if which(GPU_TYPES[gpuType][1]):
-            typeFound = gpuType
-            gpuTypesFound += 1
+    typesFound = [gpuType for gpuType in GPU_TYPES.keys() if which(GPU_TYPES[gpuType][1])]
+    if len(typesFound) == 1:
+      return typesFound[0]
 
-    if gpuTypesFound != 1:
-        error("Unable to determine GPU type, assign 'CHPL_GPU_CODEGEN' to one of {}".
-            format(GPU_TYPES.keys()))
-    return typeFound
+    error("Unable to determine GPU type%s, assign 'CHPL_GPU_CODEGEN' to one of: [%s]" %
+      ("" if len(typesFound) == 0 else " (detected: [%s])" %  ", ".join(typesFound),
+       ", ".join(GPU_TYPES.keys())))
+    return None;
 
 @memoize
 def get():
@@ -56,7 +54,7 @@ def get_arch():
         return arch
 
     # Return vendor-specific default architecture
-    _, _, _, gpu_default_arch = GPU_TYPES[gpu_type]
+    _, _, _, gpu_default_arch, _ = GPU_TYPES[gpu_type]
     return gpu_default_arch
 
 @memoize
@@ -68,7 +66,7 @@ def get_sdk_path(for_gpu):
         return ''
 
     # Check vendor-specific environment variable for SDK path
-    gpu_variable, gpu_program, gpu_bin_depth, _ = GPU_TYPES[for_gpu]
+    gpu_variable, gpu_program, gpu_bin_depth, _, _ = GPU_TYPES[for_gpu]
     chpl_sdk_path = os.environ.get(gpu_variable)
     if chpl_sdk_path:
         return chpl_sdk_path
@@ -127,7 +125,7 @@ def get_runtime():
             return chpl_gpu_runtime
     return get()
 
-def validateLlvmBuiltForRocm():
+def validateLlvmBuiltForTgt(expectedTgt):
     exists, returncode, my_stdout, my_stderr = utils.try_run_command(
         [chpl_llvm.get_llvm_config(), "--targets-built"])
 
@@ -135,7 +133,7 @@ def validateLlvmBuiltForRocm():
         return False
 
     targets = my_stdout.strip().split(" ")
-    return "AMDGPU" in targets
+    return expectedTgt in targets
 
 
 @memoize
@@ -143,8 +141,8 @@ def validate(chplLocaleModel, chplComm):
     if chplLocaleModel != "gpu":
         return True
 
-    if get() == 'rocm':
-        if not validateLlvmBuiltForRocm():
-            error("LLVM not built for AMDGPU, consider setting CHPL_LLVM to 'bundled'")
+    llvmTgt = GPU_TYPES[get()][4]
+    if not validateLlvmBuiltForTgt(llvmTgt):
+        error("LLVM not built for %s, consider setting CHPL_LLVM to 'bundled'" % llvmTgt)
 
     return True


### PR DESCRIPTION
This change automatically sets `CHPL_GPU_CODEGEN` to either `cuda` or `rocm` based on whether the user has `nvcc` or `hipcc` in their path. If they have both or neither then this variable must be set manually.

This PR also adds in some checks when `CHPL_GPU_CODEGEN=rocm` to check that the user's LLVM installation supports the AMDGPU target. If it can't validate this it suggests using the bundled llvm.