### PR TITLE
GPU: Add procedures wrapping `syncThreads` and `allocShared` primitives.

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -167,8 +167,6 @@ section; many of them will be addressed in upcoming editions.
   passing ``--gpu-block-size=size`` to the compiler or setting it with the
   ``CHPL_GPU_BLOCK_SIZE`` environment variable.
 
-* There is no user-level feature to allocate or access block shared memory.
-
 * The use of most ``extern`` functions within a GPU eligible loop is not supported
   (a limited set of functions used by Chapel's runtime library are supported). 
 

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -179,4 +179,16 @@ module GPU
   inline proc syncThreads() {
     __primitive("gpu syncThreads");
   }
+
+  /*
+    Allocate block shared memory, enough to allocate `size` elements of
+    `eltType`. Returns a `c_ptr` to the allocated array. Note that although
+    every thread in a block calls this procedure, the same shared array is
+    returned to all of them.
+   */
+  pragma "no doc"
+  inline proc createSharedArray(type eltType, param size): c_ptr(eltType) {
+    const voidPtr = __primitive("gpu allocShared", numBytes(eltType)*size);
+    return voidPtr : c_ptr(eltType);
+  }
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -192,4 +192,11 @@ module GPU
     const voidPtr = __primitive("gpu allocShared", numBytes(eltType)*size);
     return voidPtr : c_ptr(eltType);
   }
+
+  /*
+    Set the block size for kernels launched on the GPU.
+   */
+  inline proc setBlockSize(blockSize: int) {
+    __primitive("gpu set blockSize", blockSize);
+  }
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -175,18 +175,20 @@ module GPU
      Synchronize threads within a block using the underlying GPU's
      synchronization primitive.
    */
-  pragma "no doc"
   inline proc syncThreads() {
     __primitive("gpu syncThreads");
   }
 
   /*
-    Allocate block shared memory, enough to allocate `size` elements of
-    `eltType`. Returns a `c_ptr` to the allocated array. Note that although
-    every thread in a block calls this procedure, the same shared array is
-    returned to all of them.
+    Allocate block shared memory, enough to store ``size`` elements of
+    ``eltType``. Returns a :type:`CTypes.c_ptr` to the allocated array. Note that
+    although every thread in a block calls this procedure, the same shared array
+    is returned to all of them.
+
+    :arg eltType: the type of elements to allocate the array for.
+
+    :arg size: the number of elements to allocate the array for.
    */
-  pragma "no doc"
   inline proc createSharedArray(type eltType, param size): c_ptr(eltType) {
     const voidPtr = __primitive("gpu allocShared", numBytes(eltType)*size);
     return voidPtr : c_ptr(eltType);

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -172,8 +172,7 @@ module GPU
   }
 
   /*
-     Synchronize threads within a block using the underlying GPU's
-     synchronization primitive.
+     Synchronize threads within a GPU block.
    */
   inline proc syncThreads() {
     __primitive("gpu syncThreads");
@@ -187,7 +186,7 @@ module GPU
 
     :arg eltType: the type of elements to allocate the array for.
 
-    :arg size: the number of elements to allocate the array for.
+    :arg size: the number of elements in each GPU thread block's copy of the array.
    */
   inline proc createSharedArray(type eltType, param size): c_ptr(eltType) {
     const voidPtr = __primitive("gpu allocShared", numBytes(eltType)*size);

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -170,4 +170,13 @@ module GPU
 
     chpl_gpu_comm_wait(gpuHandle);
   }
+
+  /*
+     Synchronize threads within a block using the underlying GPU's
+     synchronization primitive.
+   */
+  pragma "no doc"
+  inline proc syncThreads() {
+    __primitive("gpu syncThreads");
+  }
 }

--- a/test/gpu/native/memory/sharedMemory.chpl
+++ b/test/gpu/native/memory/sharedMemory.chpl
@@ -1,4 +1,5 @@
 use CTypes;
+use GPU only syncThreads;
 
 config param N=16;
 config param BLOCK_SIZE;
@@ -14,7 +15,7 @@ on here.gpus[0] {
     // After the sync the array in shared memory will be:
     //   [100, 200, 300, 400, ...]
     dst_ptr_casted[i] = ((i+1) * 100) : uint;
-    __primitive("gpu syncThreads");
+    syncThreads();
 
     // Grab value in shared memory assigned by neighbor to your right and add
     // your id

--- a/test/gpu/native/memory/sharedMemory.chpl
+++ b/test/gpu/native/memory/sharedMemory.chpl
@@ -1,5 +1,5 @@
 use CTypes;
-use GPU only syncThreads;
+use GPU only syncThreads, createSharedArray;
 
 config param N=16;
 config param BLOCK_SIZE;
@@ -9,17 +9,16 @@ on here.gpus[0] {
 
   forall i in 0..<N {
     // Each thread independently assigns to shared memory
-    var dst_ptr = __primitive("gpu allocShared", N * numBytes(uint));
-    var dst_ptr_casted = dst_ptr : c_ptr(uint);
+    var dst_ptr = createSharedArray(uint, N);
 
     // After the sync the array in shared memory will be:
     //   [100, 200, 300, 400, ...]
-    dst_ptr_casted[i] = ((i+1) * 100) : uint;
+    dst_ptr[i] = ((i+1) * 100) : uint;
     syncThreads();
 
     // Grab value in shared memory assigned by neighbor to your right and add
     // your id
-    A[i] = dst_ptr_casted[(i + 1) % N] + i : uint;
+    A[i] = dst_ptr[(i + 1) % N] + i : uint;
   }
 
   // Print array, chunked by blocks. Note that each element is assigned by a

--- a/test/gpu/native/studies/shoc/sort.chpl
+++ b/test/gpu/native/studies/shoc/sort.chpl
@@ -10,7 +10,7 @@ use List;
 use CTypes;
 use ResultDB;
 use GpuDiagnostics;
-use GPU only syncThreads, createSharedArray;
+use GPU only syncThreads, createSharedArray, setBlockSize;
 
 config const noisy = false;
 config const gpuDiags = false;
@@ -329,7 +329,7 @@ proc radixSortBlocks(radixGlobalWorkSize, const nbits : uint(32), const startbit
 
     foreach i in 0..<radixGlobalWorkSize:uint(32) {
 
-        __primitive("gpu set blockSize", SORT_BLOCK_SIZE);
+        setBlockSize(SORT_BLOCK_SIZE);
 
         var sMem = createSharedArray(uint(32), 512);
 
@@ -429,7 +429,7 @@ proc findRadixOffsets(findGlobalWorkSize, ref keys : [] uint(32), ref counters :
 
     foreach i in 0..<findGlobalWorkSize:uint(32){
 
-        __primitive("gpu set blockSize", SCAN_BLOCK_SIZE);
+        setBlockSize(SCAN_BLOCK_SIZE);
 
         var sStartPointers = createSharedArray(uint(32), 16);
         var sRadix1 = createSharedArray(uint(32), 2*SCAN_BLOCK_SIZE);
@@ -494,7 +494,7 @@ proc reorderData (reorderGlobalWorkSize, startbit: uint(32),
         ref sizes : [] uint(32), totalBlocks : uint(32)) {
 
     foreach i in 0..<reorderGlobalWorkSize: uint(32){
-        __primitive("gpu set blockSize", SCAN_BLOCK_SIZE);
+        setBlockSize(SCAN_BLOCK_SIZE);
 
         const GROUP_SIZE = SCAN_BLOCK_SIZE : uint(32);
 
@@ -582,7 +582,7 @@ proc scanKernel(numBlocks : uint(32), ref g_odata: [] uint(32), ref g_idata: [] 
     var globalSize : uint(32) = numBlocks * SCAN_BLOCK_SIZE;
     foreach gid in 0..<globalSize : uint(32) {
 
-        __primitive("gpu set blockSize", SCAN_BLOCK_SIZE);
+        setBlockSize(SCAN_BLOCK_SIZE);
 
 
         var s_data = createSharedArray(uint(32), 512);
@@ -656,7 +656,7 @@ proc vectorAddUniform4(ref d_vector: [] uint(32), const ref d_uniforms : [] uint
     // = numElements / (4) = n/4
     foreach i in 0..<n/4 : uint(32) {
 
-        __primitive("gpu set blockSize", SCAN_BLOCK_SIZE);
+        setBlockSize(SCAN_BLOCK_SIZE);
 
         const blockId = i / SCAN_BLOCK_SIZE : uint(32);
         const threadId = i % SCAN_BLOCK_SIZE : uint(32);

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -17,8 +17,7 @@ pragma "always resolve function"
 export proc transposeMatrix(odata: c_ptr(dataType), idata: c_ptr(dataType), width: int, height: int) {
   // Allocate extra columns for the shared 2D array to avoid bank conflicts.
   param paddedBlockSize = blockSize + blockPadding;
-  var smVoidPtr = __primitive("gpu allocShared", numBytes(dataType)*paddedBlockSize*blockSize);
-  var smArrPtr = smVoidPtr : c_ptr(dataType);
+  var smArrPtr = createSharedArray(dataType, paddedBlockSize*blockSize);
 
   const blockIdxX = __primitive("gpu blockIdx x"),
         threadIdxX = __primitive("gpu threadIdx x"),

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -35,7 +35,7 @@ export proc transposeMatrix(odata: c_ptr(dataType), idata: c_ptr(dataType), widt
   }
 
   // synchronize the threads
-  __primitive("gpu syncThreads");
+  syncThreads();
 
   // Swap coordinates and write back out
   idxX = blockIdxY * blockSize + threadIdxX;


### PR DESCRIPTION
This simply provides user-facing wrappers for these primitives, since the features they provide are frequently used in GPU codes (see https://github.com/Cray/chapel-private/issues/4454).

Reviewed by @stonea - thanks!

## Testing
- [x] `test/gpu/native` with NVIDIA
- [x] `test/gpu/native` with AMD