### PR TITLE
Include endpoint bound state in verbose output

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1106,23 +1106,25 @@ void chpl_comm_post_task_init(void) {
 
 static
 void init_ofi(void) {
+
+  init_ofiDoProviderChecks();
+  init_ofiEp();
+
   if (verbosity >= 2 || DBG_TEST_MASK(DBG_PROV)) {
     if ((chpl_nodeID == 0) || DBG_TEST_MASK(DBG_PROV)) {
       void* start;
       size_t size;
       chpl_comm_regMemHeapInfo(&start, &size);
       char buf[10];
-      printf("COMM=ofi: %s MCM mode, \"%s\" provider, \"%s\" device, %s fixed heap\n",
-             mcmModeNames[mcmMode], ofi_info->fabric_attr->prov_name,
-             ofi_info->domain_attr->name,
-             ((size == 0)
-              ? "no"
-              : chpl_snprintf_KMG_z(buf, sizeof(buf), size)));
+      printf("COMM=ofi: %s MCM mode, \"%s\" provider, \"%s\" device, "
+        "%s fixed heap, %s endpoints\n",
+        mcmModeNames[mcmMode], ofi_info->fabric_attr->prov_name,
+        ofi_info->domain_attr->name,
+        ((size == 0) ? "no": chpl_snprintf_KMG_z(buf, sizeof(buf), size)),
+        (tciTabBindTxCtxs ? "bound" : "unbound"));
     }
   }
 
-  init_ofiDoProviderChecks();
-  init_ofiEp();
   init_ofiExchangeAvInfo();
   init_ofiForMem();
   init_ofiForRma();


### PR DESCRIPTION
Include whether or not OFI endpoints are bound to threads in the verbose output.