### PR TITLE
Add missing symlink to math.compopts

### DIFF
--- a/test/gpu/native/studies/compiler-performance/math.compopts
+++ b/test/gpu/native/studies/compiler-performance/math.compopts
@@ -1,0 +1,1 @@
+../../math.compopts


### PR DESCRIPTION
This is another thing I need to fix a nightly test failure for one of our GPU tests (see https://github.com/chapel-lang/chapel/pull/21794)