### PR TITLE
dyno: Add 'enum' to regex that sanitizes Sphinx markup from warning messages

### DIFF
--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1317,7 +1317,7 @@ removeSphinxMarkupFromWarningMessage(const std::string msg) {
   // hyperlinks (and having only target show up in sanitized message).
   // TODO: Prefixing content with ! (and filtering it out)
   // TODO: Prefixing content with ~ (and displaying only the last component)
-  static const auto re = R"(\B\:(mod|proc|iter|data|const|var|param)"
+  static const auto re = R"(\B\:(mod|proc|iter|data|const|var|param|enum)"
                          R"(|type|class|record|attr)\:`([!$\w\$\.]+)`\B)";
   auto ret = std::regex_replace(msg, std::regex(re), "$2");
   return ret;
@@ -1396,6 +1396,8 @@ unstableWarningForIdImpl(Context* context, ID idMention, ID idTarget) {
   std::string msg = storedMsg.isEmpty()
       ? createDefaultUnstableMessage(context, targetNamedDecl)
       : storedMsg.c_str();
+
+  msg = removeSphinxMarkupFromWarningMessage(msg);
 
   CHPL_ASSERT(msg.size() > 0);
   CHPL_REPORT(context, Unstable, msg, mention, targetNamedDecl);


### PR DESCRIPTION
Some tests weren't having their Sphinx markup sanitized for warning
messages because the markup was linking to an `enum`. Fix that, and
also perform the sanitation for unstable messages as well.

TESTING

- [x] `linux64` `--dyno` fixes 3 test failures

Reviewed by @DanilaFe. Thanks!