### PR TITLE
Fix array reversal in guru-interface-example.chpl

### DIFF
--- a/test/library/packages/FFTW/guru-interface-example.chpl
+++ b/test/library/packages/FFTW/guru-interface-example.chpl
@@ -24,7 +24,7 @@ var a1,b1,a2,b2: [D]complex;
 
 
 fillRandom(a1); // Original array
-a2 = reshape(a1, D by -1);   // neg-stride temp array created by reshape()
+a2 = [idx in D by -1] a1[idx];
 
 if verbose {
   writeln("The original array :");

--- a/test/library/packages/FFTW/guru-interface-example.good
+++ b/test/library/packages/FFTW/guru-interface-example.good
@@ -1,2 +1,1 @@
 SUCCESS
-guru-interface-example.chpl:27: warning: arrays and array slices with negatively-strided dimensions are currently unsupported and may lead to unexpected behavior; compile with -snoNegativeStrideWarnings to suppress this warning; the dimension(s) are: (0..99 by -1, 0..23 by -1)


### PR DESCRIPTION
This fixes the testing failure in FFTW/guru-interface-example.chpl

The test behavior changed due to #21760. The assignment `Array1 = Array2;` traversed the elements of Array1/Array2 in a different order before that change than after that change when one of Array1's or Array2's domains has dimension(s) with negative stride(s). With #21760, the array assignment iterates over the same set of pairs of array elements as a zippered iteration over `zip(Array1,Array2)`.

Therefore this PR makes this change:

```chpl
// replace this code that no longer reverses the array
a2 = reshape(a1, D by -1);  // where a1.domain == a2.domain == D

// with this code, suggested by @dlongnecke-cray
a2 = [idx in D by -1] a1[idx];

// another way of doing the same:
forall (i2,i1) in zip(D, D by -1) do a2[i2] = a1[i1];
```

As a side effect of this PR, this test no longer causes reshape() to create an array with negative strides. So it no longer triggers the "negative stride" warning.