### PR TITLE
Fix module code to avoid throwing "use shadows formal" warning

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1489,8 +1489,8 @@ iter walkDirs(path: string = ".", topdown: bool = true, depth: int = max(int),
   if (depth) {
     var subdirs = listDir(path, hidden=hidden, files=false, listlinks=followlinks);
     if (sort) {
-      use Sort /* only sort */;
-      sort(subdirs);
+      use Sort only sort as sortList;
+      sortList(subdirs);
     }
 
     for subdir in subdirs {


### PR DESCRIPTION
Dyno makes the "module use shadows formal" warning more strict, and detects cases such as those in our module code. The warning is accurate, so it seems to make the most sense to just fix the offending module code.

Reviewed by @arezaii -- thanks!

## Testing
- [x] paratest