### PR TITLE
fix copy elision warning on mac

### DIFF
--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -192,13 +192,14 @@ owned<AttributeGroup> ParserContext::buildAttributeGroup(YYLTYPE locationOfDecl)
       ? *(attributeGroupParts.pragmas)
       : std::set<PragmaTag>();
 
+  auto attrList = consumeList(attributeGroupParts.attributeList);
   auto node = AttributeGroup::build(builder, convertLocation(locationOfDecl),
                                 std::move(pragmaCopy),
                                 attributeGroupParts.isDeprecated,
                                 attributeGroupParts.isUnstable,
                                 attributeGroupParts.deprecationMessage,
                                 attributeGroupParts.unstableMessage,
-                                std::move(consumeList(attributeGroupParts.attributeList)));
+                                std::move(attrList));
   return node;
 }
 


### PR DESCRIPTION
this PR fixes a build failure on mac after merging https://github.com/chapel-lang/chapel/pull/21425.
The failure is due to a copy elision warning that is promoted to an error and just requires assigning the value to a temporary local variable.

TESTING:

- [x] builds on mac
- [x] builds on linux