### PR TITLE
Fix free errors in fini_ofi

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -150,17 +150,17 @@ endpoint. ofi_rxAv refers to ofi_av if AVs can be shared, otherwise it
 refers to its own AV.
 */
 
-static struct fid_av*   ofi_av = NULL;   // shared address vector
-static fi_addr_t*       ofi_addrs;       // remote endpoint addresses
-
-static struct fid_ep*   ofi_rxEp;       // receive endpoint
-static struct fid_cq*   ofi_rxCQ;       // receive endpoint CQ
-static struct fid_cntr* ofi_rxCntr;     // receive endpoint counter
-static uint64_t         ofi_rxCount;    // # messages already received.
-static void*            ofi_rxBuffer;   // receive buffer for new messages
-static void*            ofi_rxEnd;      // first byte after buffer
-static struct fid_av*   ofi_rxAv;       // address vector
-static fi_addr_t*       ofi_rxAddrs;    // table of remote endpoint addresses
+static struct fid_av*   ofi_av = NULL;      // shared address vector
+static fi_addr_t*       ofi_addrs = NULL;   // remote endpoint addresses
+static struct fid_ep*   ofi_rxEp;           // receive endpoint
+static struct fid_cq*   ofi_rxCQ;           // receive endpoint CQ
+static struct fid_cntr* ofi_rxCntr;         // receive endpoint counter
+static uint64_t         ofi_rxCount;        // # messages already received.
+static void*            ofi_rxBuffer;       // receive buffer for new messages
+static void*            ofi_rxEnd;          // first byte after buffer
+static struct fid_av*   ofi_rxAv;           // address vector
+static fi_addr_t*       ofi_rxAddrs = NULL; // table of remote endpoint
+                                            // addresses
 
 #define rxAddr(tcip, n) (tcip->addrs[n])
 
@@ -3263,11 +3263,6 @@ void fini_ofi(void) {
     CHPL_FREE(memTabMap);
   }
 
-  CHPL_FREE(amLZs[1]);
-  CHPL_FREE(amLZs[0]);
-
-  CHPL_FREE(ofi_rxAddrs);
-
   if (ofi_amhPollSet != NULL) {
     OFI_CHK(fi_poll_del(ofi_amhPollSet, tciTab[tciTabLen - 1].txCmplFid, 0));
     OFI_CHK(fi_poll_del(ofi_amhPollSet, &ofi_rxCQ->fid, 0));
@@ -3305,14 +3300,18 @@ void fini_ofi(void) {
 
   if (ofi_rxAv != ofi_av) {
     OFI_CHK(fi_close(&ofi_rxAv->fid));
+  }
+
+  if (ofi_rxAddrs != NULL) {
     CHPL_FREE(ofi_rxAddrs);
   }
 
   if (ofi_av != NULL) {
     OFI_CHK(fi_close(&ofi_av->fid));
+  }
+  if (ofi_addrs != NULL) {
     CHPL_FREE(ofi_addrs);
   }
-
   if (ofi_amhPollSet != NULL) {
     OFI_CHK(fi_close(&ofi_amhWaitSet->fid));
     OFI_CHK(fi_close(&ofi_amhPollSet->fid));
@@ -3322,6 +3321,10 @@ void fini_ofi(void) {
   OFI_CHK(fi_close(&ofi_fabric->fid));
 
   fi_freeinfo(ofi_info);
+
+  CHPL_FREE(amLZs[1]);
+  CHPL_FREE(amLZs[0]);
+
 }
 
 


### PR DESCRIPTION
Remove double free of `ofi_rxAddr`, and free landing zones after everything else has been torn down to avoid use-after-free errors.