### PR TITLE
Improve portability to Alpine 3.17 and to GCC 13

### DIFF
--- a/frontend/include/chpl/util/hash.h
+++ b/frontend/include/chpl/util/hash.h
@@ -21,6 +21,7 @@
 #define CHPL_UTIL_HASH_H
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <set>
 #include <string>

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -212,6 +212,8 @@ def find_system_llvm_config():
         paths.append("llvm-config-" + vers)
         # this format used by freebsd
         paths.append("llvm-config" + vers)
+        # this format is used by Alpine Linux
+        paths.append("llvm" + vers + "-config")
         if homebrew_prefix:
             # look for homebrew install of LLVM
             paths.append(homebrew_prefix +

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -374,18 +374,26 @@ def get_system_llvm_clang(lang):
         clang = os.path.join(bindir, clang_name)
 
         if not os.path.exists(clang):
-            # also try /usr/bin/clang since some OSes use that
-            # for the clang package
-            usr_bin = "/usr/bin"
-            clang2 = os.path.join(usr_bin, clang_name);
-            if os.path.exists(clang2):
-                llvm_config = find_system_llvm_config()
-                # check that clang --version matches llvm-config --version
-                clangv = run_command([clang2, '--version']).strip()
-                llvmv = run_command([llvm_config, '--version']).strip()
+            # try /usr/bin/clang-<version> or /usr/bin/clang
+            # since some OSes use that for the clang package
+            paths = [ ]
 
-                if llvmv in clangv:
-                    clang = clang2
+            usr_bin = "/usr/bin"
+            llvm_config = find_system_llvm_config()
+            llvm_version, ignored_err = check_llvm_config(llvm_config)
+
+            paths.append(os.path.join(usr_bin, clang_name + "-" + llvm_version))
+            paths.append(os.path.join(usr_bin, clang_name))
+
+            for clang2 in paths:
+                if os.path.exists(clang2):
+                    # check that clang --version matches llvm-config --version
+                    clangv = run_command([clang2, '--version']).strip()
+                    llvmv = run_command([llvm_config, '--version']).strip()
+
+                    if llvmv in clangv:
+                        clang = clang2
+                        break
 
     return clang
 


### PR DESCRIPTION
This PR takes a few steps to improve the portability of Chapel.

 * improves portability to Alpine Linux 3.17 by enabling the LLVM detection logic to find `llvm14-config`. That version of Alpine defaults to LLVM 15 but we don't support that yet. Along the same lines, added support for finding `/usr/bin/clang-14` which is the style that Alpine uses.
 * improves portability to GCC 13 by adding some `#include`s that GCC insists upon.

Reviewed by @stonea - thanks!

- [x] make check in default config works on Alpine 3.17
- [x] make check in quickstart config works in Fedora 38 (which uses GCC 13)
- [x] full local testing