### PR TITLE
Patch ChOp with GPU diagnpstics change

### DIFF
--- a/test/gpu/native/studies/chop/chplGPU.skipif
+++ b/test/gpu/native/studies/chop/chplGPU.skipif
@@ -32,7 +32,7 @@ if ! git clone ${CHOP_URL} --branch=${CHOP_BRANCH} --depth=1 2>gitClone.out; the
 fi
 
 # Apply the GPU diagnostics patch, skipif that fails.
-if ! git -C ChOp apply ../patches/gpuDiagnostics.patch 2>gitPatch.out; then
+if ! (for p in patches/*patch; do git -C ChOp apply ../$p; done) 2>gitPatch.out; then
   echo "Patching failed; output:"
   cat gitPatch.out
   echo "True"

--- a/test/gpu/native/studies/chop/chplGPU.skipif
+++ b/test/gpu/native/studies/chop/chplGPU.skipif
@@ -31,4 +31,12 @@ if ! git clone ${CHOP_URL} --branch=${CHOP_BRANCH} --depth=1 2>gitClone.out; the
   exit
 fi
 
+# Apply the GPU diagnostics patch, skipif that fails.
+if ! git -C ChOp apply ../patches/gpuDiagnostics.patch 2>gitPatch.out; then
+  echo "Patching failed; output:"
+  cat gitPatch.out
+  echo "True"
+  exit
+fi
+
 echo "False"

--- a/test/gpu/native/studies/chop/patches/gpuDiagnostics.patch
+++ b/test/gpu/native/studies/chop/patches/gpuDiagnostics.patch
@@ -1,0 +1,30 @@
+diff --git a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+index e973ff5..ab4748b 100644
+--- a/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
++++ b/other_codes/chplGPU/modules/queens_GPU_call_device_search.chpl
+@@ -8,14 +8,14 @@ module queens_GPU_call_device_search{
+ 	use Math;
+ 	//use CPtr;
+ 	use Time;
+-  use GPUDiagnostics;
++  use GpuDiagnostics;
+ 
+ 	config const CPUGPUVerbose: bool = false;
+ 
+ 	proc queens_GPU_call_device_search(const num_gpus: c_int, const size: uint(16), const depthPreFixos: c_int,
+ 		ref local_active_set: [] queens_node, const initial_num_prefixes: uint(64)): (uint(64), uint(64)) {
+ 
+-    startVerboseGPU();
++    startVerboseGpu();
+ 
+ 		var vector_of_tree_size_h: [0..#initial_num_prefixes] c_ulonglong;
+ 		var sols_h: [0..#initial_num_prefixes] c_ulonglong;
+@@ -106,7 +106,7 @@ module queens_GPU_call_device_search{
+         }
+     }//end of gpu search
+ 
+-    stopVerboseGPU();
++    stopVerboseGpu();
+ 
+ 		var redTree = (+ reduce vector_of_tree_size_h):uint(64);
+ 		var redSol  = (+ reduce sols_h):uint(64);


### PR DESCRIPTION
ChOp uses the `GPUDiagnostics` module, which is now `GpuDiagnostics`. The Chapel release that brings this change isn't out yet, so we don't want to PR to ChOp just yet, but to get our testing working, we need to patch the code locally to work with the pre-release Chapel version.

Reviewed by @stonea - thanks!