### PR TITLE
Git-clone only the current tree of champs

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -23,7 +23,8 @@ export CHAMPS_HOME=$CWD/champs
 rm -rf ${CHAMPS_HOME}
 
 # Clone CHAMPS 
-if ! git clone ${CHAMPS_URL} --branch=${CHAMPS_BRANCH} ; then
+git_clone_opts="--branch=${CHAMPS_BRANCH} --single-branch --depth=1"
+if ! git clone ${CHAMPS_URL} $git_clone_opts ; then
   log_fatal_error "cloning CHAMPS"
 else
   echo "Cloned CHAMPS successfully"


### PR DESCRIPTION
This modifies champs sub_test to clone only the current source tree without bringing in all branches and dev history. This is done in order to reduce the cloning time and the size of the cloned tree. As of this writing, this change reduced the tree size from 499Mb to 7.4Mb.

The tree cloned the fast way, using git clone options `--single-branch --depth=1`, is not suitable for development. If this presents hardship, we can reconsider.

Testing: I verified that the source trees cloned before and after this change are identical, except for the .git directory.