### PR TITLE
Exempt bundled llvm from GPU targets check

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -126,6 +126,13 @@ def get_runtime():
     return get()
 
 def validateLlvmBuiltForTgt(expectedTgt):
+    # If we're using the bundled LLVM, llvm-config may not have been built
+    # before we call chplenv. It seems safe to assume the bundled LLVM has been
+    # built with whatever requirements we have for Chapel so we just return
+    # that it's been validated.
+    if chpl_llvm.get() == 'bundled':
+        return True
+
     exists, returncode, my_stdout, my_stderr = utils.try_run_command(
         [chpl_llvm.get_llvm_config(), "--targets-built"])
 


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/21800 I add a check to ensure
that LLVM was built with the AMD or NVPTX target when using rocm/cuda.  This
check relies on calling out to `llvm-config` a tool that's packaged with LLVM.
This has a problem when calling `printchplenv` when using CHPL_LLVM=`bundled`
before the bundled LLVM has been built (namely that `llvm-config` itself won't
have been built yet.

As a workaround I exempt this check when using `CHPL_LLVM=bundled`. I think
it's safe to assume our bundled LLVM has the appropriate targets built.
