### PR TITLE
Change 'Compiler Library'->'Frontend Library' in docs

### DIFF
--- a/doc/rst/developer/bestPractices/buildingdocs.rst
+++ b/doc/rst/developer/bestPractices/buildingdocs.rst
@@ -215,7 +215,7 @@ source files in the repository.
      - Doc name in Sidebar
      - Source file(s)
    * - COMPILING AND RUNNING CHAPEL
-     - Docs for Contributors--> Compiler Library API Docs
+     - Docs for Contributors--> Frontend Library API Docs
      - doc/rst/developer/compiler-internals/*
 
 

--- a/doc/rst/developer/bestPractices/index.rst
+++ b/doc/rst/developer/bestPractices/index.rst
@@ -48,7 +48,7 @@ developers.  A possible reading order is roughly as follows:
 
 `Compiler documentation`: 
   :ref:`compiler-internals-index`:
-    API documentation for the compiler library
+    API documentation for the frontend library
 
   The compiler overview document in 
 

--- a/doc/rst/meta/compiler-internals-doxygen/index.rst
+++ b/doc/rst/meta/compiler-internals-doxygen/index.rst
@@ -1,10 +1,10 @@
 .. _compiler-internals-index:
 
-Compiler Library API Docs
+Frontend Library API Docs
 =========================
 
 This section documents the various functions and types of the
-new compiler.
+new compiler frontend.
 
 .. toctree::
    :caption: Conceptual Guide

--- a/doc/rst/meta/compiler-internals-no-doxygen/index.rst
+++ b/doc/rst/meta/compiler-internals-no-doxygen/index.rst
@@ -1,6 +1,6 @@
 .. _compiler-internals-index:
 
-Compiler Library API Docs
+Frontend Library API Docs
 =========================
 
 This section is empty because doxygen was not available when the docs


### PR DESCRIPTION
This change is for consistency with how we refer to Dyno in code and other documentation.

Resolves https://github.com/Cray/chapel-private/issues/4143.

Testing:
- [x] docs build locally and look right