### PR TITLE
Remove deprecated isFloat functions

### DIFF
--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -73,14 +73,6 @@ Returns ``true`` if the type ``t`` is one the following types, of any width:
 proc isIntegralType(type t) param do return
   isIntType(t) || isUintType(t);
 
-/*
-Returns ``true`` if the type ``t`` is one the following types, of any width:
-``real``, ``imag``.
-*/
-@deprecated(notes="isFloatType is deprecated use `isRealType(t) || isImagType(t)` instead")
-proc isFloatType(type t) param do return
-  isRealType(t) || isImagType(t);
-
 /* Returns ``true`` if the type ``t`` is the ``nothing`` type. */
 proc isNothingType(type t) param do return t == nothing;
 
@@ -308,11 +300,6 @@ proc isNumericValue(e)   param do  return isNumericType(e.type);
 ``int``, ``uint``. */
 proc isIntegralValue(e)  param do  return isIntegralType(e.type);
 
-/* Returns ``true`` if the argument is a value of one the following types:
-``real``, ``imag``. */
-@deprecated(notes="isFloatValue is deprecated use `isRealValue(e) || isImagValue(e)` instead")
-proc isFloatValue(e)     param do  return isFloatType(e.type);
-
 /* Returns ``true`` if the argument is a ``nothing`` value (i.e., ``none``) */
 proc isNothingValue(e)   param do return isNothingType(e.type);
 
@@ -423,9 +410,6 @@ pragma "no doc"
 proc isNumeric(type t)   param do  return isNumericType(t);
 pragma "no doc"
 proc isIntegral(type t)  param do  return isIntegralType(t);
-pragma "no doc"
-@deprecated(notes="isFloat is deprecated use `isReal(t) || isImag(t)` instead")
-proc isFloat(type t)     param do  return isFloatType(t);
 
 pragma "no doc"
 proc isNothing(type t)  param do return isNothingType(t);
@@ -519,12 +503,6 @@ Returns ``true`` if the argument is one the following types, of any width:
 ``int``, ``uint``, or a value of such a type.
 */
 proc isIntegral(e)  param do  return isIntegralValue(e);
-/*
-Returns ``true`` if the argument is one the following types, of any width:
-``real``, ``imag``, or a value of such a type.
-*/
-@deprecated(notes="isFloat is deprecated use `isReal(e) || isImag(e)` instead")
-proc isFloat(e)     param do  return isFloatValue(e);
 
 /* Returns ``true`` if the argument is ``none`` or the ``nothing`` type.
  as defined by the language specification.*/

--- a/test/deprecated/typeQueryFuncs.chpl
+++ b/test/deprecated/typeQueryFuncs.chpl
@@ -30,15 +30,15 @@
 
 
 
+
+
+
+
+
+
+
+
 // end empty space
-
-// isFloat* functions are being deprecatd
-// (in favor of doing isReal(x) || isImag(x) instead)
-
-writeln("isFloat(1.2) returns ", isFloat(1.2));
-writeln("isFloat(real) returns ", isFloat(real));
-writeln("isFloatType(real) returns ", isFloatType(real));
-writeln("isFloatValue(1.2) returns ", isFloatValue(1.2));
 
 // Type subtype relations (use named functions instead of operators).
 

--- a/test/deprecated/typeQueryFuncs.good
+++ b/test/deprecated/typeQueryFuncs.good
@@ -1,7 +1,3 @@
-typeQueryFuncs.chpl:38: warning: isFloat is deprecated use `isReal(e) || isImag(e)` instead
-typeQueryFuncs.chpl:39: warning: isFloat is deprecated use `isReal(t) || isImag(t)` instead
-typeQueryFuncs.chpl:40: warning: isFloatType is deprecated use `isRealType(t) || isImagType(t)` instead
-typeQueryFuncs.chpl:41: warning: isFloatValue is deprecated use `isRealValue(e) || isImagValue(e)` instead
 typeQueryFuncs.chpl:46: warning: type comparison operators are deprecated; use isSubtype/isProperSubtype instead
 typeQueryFuncs.chpl:47: warning: type comparison operators are deprecated; use isSubtype/isProperSubtype instead
 typeQueryFuncs.chpl:48: warning: type comparison operators are deprecated; use isSubtype/isProperSubtype instead
@@ -14,10 +10,6 @@ typeQueryFuncs.chpl:61: warning: type comparison operators are deprecated; use i
 typeQueryFuncs.chpl:62: warning: type comparison operators are deprecated; use isSubtype/isProperSubtype instead
 typeQueryFuncs.chpl:63: warning: type comparison operators are deprecated; use isSubtype/isProperSubtype instead
 typeQueryFuncs.chpl:64: warning: type comparison operators are deprecated; use isSubtype/isProperSubtype instead
-isFloat(1.2) returns true
-isFloat(real) returns true
-isFloatType(real) returns true
-isFloatValue(1.2) returns true
 Compare 1.type op int
 op <= returns true
 op <  returns false

--- a/test/library/draft/DistributedMap/v2/use-distributed-map.bad
+++ b/test/library/draft/DistributedMap/v2/use-distributed-map.bad
@@ -1,5 +1,5 @@
 ./Aggregator.chpl:36: In initializer:
-$CHPL_HOME/modules/standard/Types.chpl:250: warning: Initializing a type-inferred variable from a 'sync' is deprecated; apply a 'read??()' method to the right-hand side
+$CHPL_HOME/modules/standard/Types.chpl:242: warning: Initializing a type-inferred variable from a 'sync' is deprecated; apply a 'read??()' method to the right-hand side
   ./DistributedMap.chpl:716: called as (aggregator(distributedMapImpl(string,int(64),nothing),proc(ref element: int))).init(clientInst: borrowed distributedMapImpl(string,int(64),nothing), updaterFcf: proc(ref element: int)) from method 'updateAggregator'
   use-distributed-map.chpl:12: called as (distributedMapImpl(string,int(64),nothing)).updateAggregator(updater: proc(ref element: int))
 Jacob=2


### PR DESCRIPTION
This PR remove deprecated isFloat* functions.

These functions were deprecated in 1.28: https://github.com/chapel-lang/chapel/pull/20548

The test for this (`typeQueryFuncs.chpl`) also includes use of subtype comparison operators. I don't remove those in this PR since those were deprecated in 1.29 (https://github.com/chapel-lang/chapel/pull/21108). FWIW, those changes also seem riskier to remove so we might consider keeping them around for longer than the normal 6 month cycle.