### PR TITLE
Remove the deprecated config param 'alignedBoundsByDefault'

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -601,12 +601,6 @@ module ChapelRange {
   proc range.isBounded() param do
     return boundedType == BoundedRangeType.bounded;
 
-  /* This used to control whether or not the
-     :proc:`range.low`/:proc:`range.high` queries returned aligned
-     values by default. */
-  @deprecated(notes="``alignedBoundsByDefault`` is deprecated and no longer has any effect")
-  config param alignedBoundsByDefault = true;
-
   /* Returns ``true`` if this range's low bound is *not* -:math:`\infty`,
      and ``false`` otherwise. */
   proc range.hasLowBound() param do

--- a/test/deprecated/alignedBoundsByDefault.chpl
+++ b/test/deprecated/alignedBoundsByDefault.chpl
@@ -1,1 +1,0 @@
-writeln((1..10 by 2).high);

--- a/test/deprecated/alignedBoundsByDefault.compopts
+++ b/test/deprecated/alignedBoundsByDefault.compopts
@@ -1,1 +1,0 @@
--salignedBoundsByDefault=true

--- a/test/deprecated/alignedBoundsByDefault.good
+++ b/test/deprecated/alignedBoundsByDefault.good
@@ -1,3 +1,0 @@
-warning: ``alignedBoundsByDefault`` is deprecated and no longer has any effect
-note: 'alignedBoundsByDefault' was set via a compiler flag
-9


### PR DESCRIPTION
This was used to opt into the new range/domain.[low|high] behavior, but has been deprecated since 1.28 and no longer serves a purpose.
