### PR TITLE
CONTRIBUTORS.md for 1.30

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,12 +1,11 @@
 Chapel Contributors
 ===================
 
-The following people have contributed to the implementation of the
-most recent Chapel release:
+The following people have contributed to Chapel releases:
 
-Contributors to the Chapel 1.29.0 release
+Contributors to the Chapel 1.30.0 release
 -----------------------------------------
-* Gabriel Brown, individual contributor
+* Jade Abraham, [HPE]
 * Paul Cassella, [HPE]
 * [Brad Chamberlain], [HPE]
 * Soohoon Choi, [HPE]
@@ -27,7 +26,6 @@ Contributors to the Chapel 1.29.0 release
 * Elliot Ronaghan, [HPE]
 * Andy Stone, [HPE] (former [Cray Inc.] intern from [Colorado State University])
 * Michelle Mills Strout, [HPE]
-* Vivian Wang, individual contributor, [GHC] 2022 Open Source Day
 * Karlon West, [HPE]
 * Tim Zinsky, [HPE]
 
@@ -50,6 +48,7 @@ Contributors to previous releases
 * Robert Bocchino, [Cray Inc.] intern from [University of Illinois, Urbana-Champaign]
 * Dan Bonachea, [UC Berkeley]
 * Kyle Brady, [Cray Inc.]
+o Gabriel Brown, individual contributor
 * Daniel Buettner, [LTS]
 * John Byrne, [HPE]
 * Zixian Cai, individual contributor
@@ -191,6 +190,7 @@ Contributors to previous releases
 * Branch Vincent, individual contributor
 * Chris Wailes, [Indiana University]
 * Tony Wallace, [Cray Inc.]
+o Vivian Wang, individual contributor, [GHC] 2022 Open Source Day
 * Alvis Wong, [GSoC 2019] student from [University of Waterloo]
 * Wayne Wong, [Cray Inc.]
 * Tong Xu, individual contributor

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,7 @@ Contributors to the Chapel 1.30.0 release
 * Andy Stone, [HPE] (former [Cray Inc.] intern from [Colorado State University])
 * Michelle Mills Strout, [HPE]
 * Karlon West, [HPE]
+* Vanessa Zambrano, [HPE]
 * Tim Zinsky, [HPE]
 
 Contributors to previous releases

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@ Contributors to the Chapel 1.30.0 release
 * Ahmad Rezaii, [HPE]
 * Anna Rift, [HPE]
 * Elliot Ronaghan, [HPE]
+* Erik Schierboom, individual contributor
 * Andy Stone, [HPE] (former [Cray Inc.] intern from [Colorado State University])
 * Michelle Mills Strout, [HPE]
 * Karlon West, [HPE]


### PR DESCRIPTION
Update the contributors file to highlight those who have contributed to Chapel 1.30.  I also simplified the header line to make it shorter and suggest that it's speaking about the file's contents as a whole and not just the first section.