### PR TITLE
Don't name dependent fields in partial instantiation warning

### DIFF
--- a/test/types/partial/partial-no-q-warning.chpl
+++ b/test/types/partial/partial-no-q-warning.chpl
@@ -1,23 +1,45 @@
-record r {
+record r1 {
   type t;
   type tt;
 }
 
-type t = r(int);
-var x: t(real);
+type t1 = r1(int);
+var x: t1(real);
 
 class C {
   param p1;
   param p2;
 }
 
-type tt = unmanaged C(1)?;
-var y: tt(2);
+type t2 = unmanaged C(1)?;
+var y: t2(2);
 
-record rr {
+record r3 {
   var x;
   var y;
 }
 
-type ttt = rr(real);
-var z: ttt(int);
+type t3 = r3(real);
+var z: t3(int);
+
+
+record r4 {
+  type tt;
+  param p;
+  type t;
+  var element: t;      // should not be included in warning
+  var otherElement: t; // should not be included in warning
+  var noType;
+  type t2;
+  param p2;
+}
+
+type t4 = r4(tt=int);
+
+record r5 {
+  type tt;
+  var x: integral;
+  var y: x.type;   // should not be included in warning
+}
+
+type t5 = r5(tt=int);

--- a/test/types/partial/partial-no-q-warning.good
+++ b/test/types/partial/partial-no-q-warning.good
@@ -1,6 +1,6 @@
 partial-no-q-warning.chpl:6: warning: partial instantiation without '?' argument
 partial-no-q-warning.chpl:6: note: opt in to partial instantiation explicitly with a trailing '?' argument
-partial-no-q-warning.chpl:6: note: or, add arguments to instantiate the following fields in generic type 'r(int(64))':
+partial-no-q-warning.chpl:6: note: or, add arguments to instantiate the following fields in generic type 'r1(int(64))':
 partial-no-q-warning.chpl:3: note:   generic type field 'tt'
 partial-no-q-warning.chpl:14: warning: partial instantiation without '?' argument
 partial-no-q-warning.chpl:14: note: opt in to partial instantiation explicitly with a trailing '?' argument
@@ -8,5 +8,17 @@ partial-no-q-warning.chpl:14: note: or, add arguments to instantiate the followi
 partial-no-q-warning.chpl:11: note:   generic param field 'p2'
 partial-no-q-warning.chpl:22: warning: partial instantiation without '?' argument
 partial-no-q-warning.chpl:22: note: opt in to partial instantiation explicitly with a trailing '?' argument
-partial-no-q-warning.chpl:22: note: or, add arguments to instantiate the following fields in generic type 'rr(real(64))':
+partial-no-q-warning.chpl:22: note: or, add arguments to instantiate the following fields in generic type 'r3(real(64))':
 partial-no-q-warning.chpl:19: note:   generic field 'y'
+partial-no-q-warning.chpl:37: warning: partial instantiation without '?' argument
+partial-no-q-warning.chpl:37: note: opt in to partial instantiation explicitly with a trailing '?' argument
+partial-no-q-warning.chpl:37: note: or, add arguments to instantiate the following fields in generic type 'r4(int(64))':
+partial-no-q-warning.chpl:28: note:   generic param field 'p'
+partial-no-q-warning.chpl:29: note:   generic type field 't'
+partial-no-q-warning.chpl:32: note:   generic field 'noType'
+partial-no-q-warning.chpl:33: note:   generic type field 't2'
+partial-no-q-warning.chpl:34: note:   generic param field 'p2'
+partial-no-q-warning.chpl:45: warning: partial instantiation without '?' argument
+partial-no-q-warning.chpl:45: note: opt in to partial instantiation explicitly with a trailing '?' argument
+partial-no-q-warning.chpl:45: note: or, add arguments to instantiate the following fields in generic type 'r5(int(64))':
+partial-no-q-warning.chpl:41: note:   generic field 'x'


### PR DESCRIPTION
Follow-up to PR #21410 to improve the `partial instantiation without '?' argument` warning.

The goal of this PR is to avoid listing fields that need to be instantiated when the field has a type that depends on an earlier field, for example, with `record R { param p; type eltType; var element: eltType; }`, the warning for `R(1)` should not include `element` since it's not really a generic field (just one that hasn't yet been instantiated).

See also https://github.com/chapel-lang/chapel/pull/21410#issuecomment-1463004071 which describes a situation in which this came up.

Instead of actually computing whether such a field is dependent or not, the approach here is to only report a non-type non-param field with a type expression if it is the first field. This is an approximation, but it is easy to implement. If it is wrong, users should see the next generic field once they add an argument for the reported generic fields.

Reviewed by @benharsh - thanks!

- [x] full local testing