### PR TITLE
For Macs make the default Mailer the mail option to send email

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -411,7 +411,13 @@ print "\$chplhomedir = $chplhomedir\n";
 #
 $mailer = $ENV{'CHPL_MAILER'};
 if ($mailer eq "") {
-    $chplsendemail = "$chplhomedir/util/test/send_email.py";
+    $hostplatform = `$utildir/chplenv/chpl_platform.py --host`; chomp($hostplatform);
+    if ($hostplatform =~ "darwin") {
+     print "[ For Mac systems use the default Mail. Defaulting to 'mail'.]\n";
+     $mailer = "mail";
+    }
+    else {
+     $chplsendemail = "$chplhomedir/util/test/send_email.py";
     `$chplsendemail --help >/dev/null 2>&1`;
     if ($? == 0) {
         $header = "";
@@ -423,6 +429,7 @@ if ($mailer eq "") {
     } else {
         print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
         $mailer = "mail";
+    }
     }
 }
 print "\$mailer = $mailer\n";


### PR DESCRIPTION
Issue:
https://github.com/Cray/chapel-private/issues/4478

Fix:
In Nightly check if underlying platform is mac and set the mailer default to send emails.

- [ ] Tested on Osprey and ChapelMacs:
Mac:
$chplhomedir = /Users/chapelu/bhavani/chapel
[ For Mac systems use the default Mail. Defaulting to 'mail'.]
$mailer = mail

Osprey:
$chplhomedir = /lus/sonexion/jayakumb/chapel
$mailer = /lus/sonexion/jayakumb/chapel/util/test/send_email.py --header=Precedence=bulk