### PR TITLE
Update prereqs per current portability testing

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -114,6 +114,7 @@ We have used the following commands to install the above prerequisites:
 
   * Amazon Linux 2023::
 
+      # Note: CHPL_LLVM=system is not working yet on Amazon Linux 2023
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
       sudo dnf install which diffutils
       sudo dnf install clang clang-devel llvm-devel
@@ -168,6 +169,7 @@ We have used the following commands to install the above prerequisites:
 
   * Fedora 37, 38::
 
+      # Note: CHPL_LLVM=system is not working yet on Fedora 37, 38
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
       sudo dnf install which diffutils
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -112,14 +112,6 @@ We have used the following commands to install the above prerequisites:
       sudo yum install llvm-devel clang clang-devel
 
 
-  * Amazon Linux 2023::
-
-      # Note: CHPL_LLVM=system is not working yet on Amazon Linux 2023
-      sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
-      sudo dnf install which diffutils
-      sudo dnf install clang clang-devel llvm-devel
-
-
   * Arch::
 
       sudo pacman -Syu
@@ -167,22 +159,10 @@ We have used the following commands to install the above prerequisites:
       sudo dnf install llvm-devel clang clang-devel
 
 
-  * Fedora 37, 38::
-
-      # Note: CHPL_LLVM=system is not working yet on Fedora 37, 38
-      sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
-      sudo dnf install which diffutils
-
-
   * FreeBSD 12.2, 12.4, 13.1::
 
       sudo pkg install gcc m4 perl5 python3 bash gmake gawk git pkgconf cmake
       sudo pkg install llvm13
-
-
-  * Homebrew::
-
-      brew install cmake python gmp llvm@14
 
 
   * OpenSuse Leap 15.3, 15.4::

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -78,7 +78,8 @@ Installation
 
 We have used the following commands to install the above prerequisites:
 
-  * Alma Linux 8, 9.0::
+
+  * Alma Linux 8, 9.0, 9.1::
 
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
       sudo dnf install which diffutils
@@ -88,10 +89,30 @@ We have used the following commands to install the above prerequisites:
   * Alpine 3.15::
 
       sudo apk add gcc g++ m4 perl python3 python3-dev bash make gawk git cmake
-      sudo apk add llvm-dev clang-dev
+      sudo apk add llvm-dev clang-dev clang-static llvm-static
 
 
-  * Amazon Linux 2022::
+  * Alpine 3.17::
+
+      sudo apk add gcc g++ m4 perl python3 python3-dev bash make gawk git cmake
+      sudo apk add llvm14-dev clang14-dev
+
+
+  * Amazon Linux 2::
+
+      sudo yum install git gcc gcc-c++ m4 perl python tcsh bash gcc gcc-c++ perl python python-devel python-setuptools bash make gawk python3 which
+      sudo yum install wget tar openssl-devel
+      wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1.tar.gz
+      tar xvzf cmake-3.25.1.tar.gz
+      cd cmake-3.25.1
+      ./bootstrap
+      make
+      sudo make install
+      sudo update-alternatives --install /usr/bin/cmake cmake /usr/local/bin/cmake 1
+      sudo yum install llvm-devel clang clang-devel
+
+
+  * Amazon Linux 2023::
 
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
       sudo dnf install which diffutils
@@ -103,7 +124,7 @@ We have used the following commands to install the above prerequisites:
       sudo pacman -Syu
       sudo pacman -S base-devel
       sudo pacman -S cmake git python
-      sudo pacman -S llvm clang
+      sudo pacman -S llvm14 clang14
 
 
   * CentOS 7 Devtoolset 11::
@@ -117,14 +138,7 @@ We have used the following commands to install the above prerequisites:
       sudo echo export CMAKE=cmake3 >> ~/.bashrc
 
 
-  * CentOS Stream 8::
-
-      sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
-      sudo dnf install which diffutils
-      sudo dnf install llvm-devel clang clang-devel
-
-
-  * CentOS Stream 9::
+  * CentOS Stream 8, 9::
 
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
       sudo dnf install which diffutils
@@ -138,7 +152,7 @@ We have used the following commands to install the above prerequisites:
       sudo apt-get install llvm-11-dev llvm-11 llvm-11-tools clang-11 libclang-11-dev libclang-cpp11-dev libedit-dev
 
 
-  * Debian 11 "Bullseye"::
+  * Debian 12 "Bookworm", 11 "Bullseye"::
 
       sudo apt-get update
       sudo apt-get install gcc g++ m4 perl python3 python3-dev bash make mawk git pkg-config cmake
@@ -152,10 +166,21 @@ We have used the following commands to install the above prerequisites:
       sudo dnf install llvm-devel clang clang-devel
 
 
-  * FreeBSD 12.2, 12.3, 13.1::
+  * Fedora 37, 38::
+
+      sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
+      sudo dnf install which diffutils
+
+
+  * FreeBSD 12.2, 12.4, 13.1::
 
       sudo pkg install gcc m4 perl5 python3 bash gmake gawk git pkgconf cmake
       sudo pkg install llvm13
+
+
+  * Homebrew::
+
+      brew install cmake python gmp llvm@14
 
 
   * OpenSuse Leap 15.3, 15.4::
@@ -164,7 +189,7 @@ We have used the following commands to install the above prerequisites:
       sudo zypper install llvm-devel clang-devel clang
 
 
-  * Rocky Linux 8, 9.0::
+  * Rocky Linux 8, 9.0, 9.1::
 
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
       sudo dnf install which diffutils


### PR DESCRIPTION
This PR updates prereqs.rst according to the current output of `extract-docs.py`.

(Note that PR #21829 includes the portability testing changes that were used to generate this documentation change).

Reviewed by @tzinsky and @lydia-duncan - thanks!