### PR TITLE
Update spec w.r.t. single-statement 'do'; lack of 'return' special case

### DIFF
--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -1122,7 +1122,7 @@ The function ``isTrue`` is predefined over bool type as follows:
 
 .. code-block:: chapel
 
-   proc isTrue(a:bool) return a; 
+   proc isTrue(a:bool) do return a;
 
 Overloading the logical and operator over other types is accomplished by
 overloading the ``isTrue`` function over other types.

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -25,7 +25,7 @@ The syntax to declare an iterator is given by:
 
    iterator-declaration-statement:
      privacy-specifier[OPT] 'iter' iterator-name argument-list[OPT] yield-intent[OPT] yield-type[OPT] where-clause[OPT]
-     iterator-body
+     function-body
 
    iterator-name:
      identifier
@@ -39,10 +39,6 @@ The syntax to declare an iterator is given by:
 
    yield-type:
      : type-expression
-
-   iterator-body:
-     block-statement
-     yield-statement
 
 The syntax of an iterator declaration is similar to a procedure
 declaration, with some key differences:

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -175,8 +175,8 @@ Procedures are defined with the following syntax:
      'where' expression
 
    function-body:
+     'do' statement
      block-statement
-     return-statement
 
 Functions do not require parentheses if they have no arguments. Such
 functions are described in :ref:`Functions_without_Parentheses`.

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -214,6 +214,10 @@ type.
 The ``where-clause`` is optional and is discussed
 in :ref:`Where_Clauses`.
 
+The ``function-body`` defines the function's behavior and is defined
+in :ref:`The_Function_Body`.  Function bodies may contain return
+statements (see :ref:`The_Return_Statement`).
+
 Function and operator overloading is supported in Chapel and is
 discussed in :ref:`Function_Overloading`. Operator overloading
 is supported on the operators listed above (see ``operator-name``).
@@ -1055,14 +1059,29 @@ with a conditional expression that is not a parameter.
    ``numBits`` is a param procedure defined in the standard Types
    module.
 
+
+.. _The_Function_Body:
+
+Function Bodies
+---------------
+
+The body of a procedure or iterator is made up of one or more
+statements that are executed when a call to the function is made.
+Function bodies can always be specified using a compound or _block_
+statement (:ref:`Blocks`), set off by curly brackets.  When a
+function's body is just a single statement, the `do` keyword can be
+used as a shorthand for defining the body instead, similar to other
+forms of control flow.
+
+
 .. _The_Return_Statement:
 
 The Return Statement
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
-The return statement can only appear in a function. It causes control to
-exit that function, returning it to the point at which that function was
-called.
+The return statement can only appear in a function body. It causes
+control to exit that function, returning it to the point at which that
+function was called.
 
 A procedure can return a value by executing a return statement that
 includes an expression. If it does, that expression’s value becomes the

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -409,9 +409,9 @@ follows:
 
    .. code-block:: chapel
 
-      proc readXX(x: sync) return x.readXX();
-      proc readXX(x: single) return x.readXX();
-      proc readXX(x) return x;
+      proc readXX(x: sync) do return x.readXX();
+      proc readXX(x: single) do return x.readXX();
+      proc readXX(x) do return x;
 
    Note that the use of the helper function ``readXX()`` in this code
    fragment is solely for the purposes of illustration. It is not


### PR DESCRIPTION
This updates the spec's syntax diagrams to add support for single-statement 'do' subroutine bodies and to remove the previous exception for single-statement returns.  It also makes the iterator's syntax diagrams use the `function-body` rule from the procedures chapter, as the previous definition was incorrect (had a single-statement yield exception that the implementation doesn't support) and it doesn't require its own case.

While here, we were surprised to find that there was no text talking about procedure bodies, so I added a new short section about that, mentioning the single-statement `do` form, and moved the return statement section into it as a subsection.

It also udpates a few examples that I ran into while looking for other places that might need changing; apparently these are among the examples that have not been converted to running tests.
