### PR TITLE
Deprecate fileReader.flush instead of removing it

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8186,7 +8186,7 @@ proc fileWriter.writeln(const args ...?k, style:iostyle) throws {
   try this.writeHelper((...args), new ioNewline(), style=style);
 }
 
-@deprecated(notes="fileReader.flush is deprecated, it was a no-op")
+@deprecated(notes="fileReader.flush is deprecated; it has no replacement because 'flush' has no effect on 'fileReader'")
 proc fileReader.flush() throws {
   var err:errorCode = 0;
   on this._home {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8186,6 +8186,15 @@ proc fileWriter.writeln(const args ...?k, style:iostyle) throws {
   try this.writeHelper((...args), new ioNewline(), style=style);
 }
 
+@deprecated(notes="fileReader.flush is deprecated, it was a no-op")
+proc fileReader.flush() throws {
+  var err:errorCode = 0;
+  on this._home {
+    err = qio_channel_flush(locking, _channel_internal);
+  }
+  if err then try this._ch_ioerror(err, "in fileReader.flush");
+}
+
 /*
 
   Makes all writes to the fileWriter, if any, available to concurrent viewers of

--- a/test/deprecated/IO/fileReaderFlush.chpl
+++ b/test/deprecated/IO/fileReaderFlush.chpl
@@ -1,0 +1,5 @@
+use IO;
+
+var r = openReader("fileReaderFlush.txt");
+r.flush();
+r.close();

--- a/test/deprecated/IO/fileReaderFlush.good
+++ b/test/deprecated/IO/fileReaderFlush.good
@@ -1,1 +1,1 @@
-fileReaderFlush.chpl:4: warning: fileReader.flush is deprecated, it was a no-op
+fileReaderFlush.chpl:4: warning: fileReader.flush is deprecated; it has no replacement because 'flush' has no effect on 'fileReader'

--- a/test/deprecated/IO/fileReaderFlush.good
+++ b/test/deprecated/IO/fileReaderFlush.good
@@ -1,0 +1,1 @@
+fileReaderFlush.chpl:4: warning: fileReader.flush is deprecated, it was a no-op

--- a/test/deprecated/IO/fileReaderFlush.txt
+++ b/test/deprecated/IO/fileReaderFlush.txt
@@ -1,0 +1,2 @@
+It's a file
+


### PR DESCRIPTION
It's a no-op, but people might have thought they needed to
to call it on reading channels, so give them a gentler warning
instead of just removing the function.

Add a test locking in the deprecation message

Passed a full paratest with futures