### PR TITLE
Adjust SKIPIF to avoid testing problematic config

### DIFF
--- a/test/llvm/abi/x86-64/SKIPIF
+++ b/test/llvm/abi/x86-64/SKIPIF
@@ -5,3 +5,5 @@ CHPL_LLVM_VERSION==13
 CHPL_LIB_PIC==pic
 CHPL_TARGET_ARCH!=x86_64
 COMPOPTS <= --baseline
+# skipping for --fast for now but issue #21856 needs to be addressed
+COMPOPTS <= --fast


### PR DESCRIPTION
This PR adjusts the SKIPIF for `export-vs-c.chpl ` to avoid the `--fast` testing configuration where that test is not currently working. This test was not tested in nightly configurations for a long time but PR #21832 fixed that and revealed an existing issue that was present in 1.29 and will take more time to fix. Issue #21856 describes the existing issue.

Test change only -- not reviewed.