### PR TITLE
Add missing compopts file for GPU math perf test

### DIFF
--- a/test/gpu/native/studies/compiler-performance/math.gpu-compopts
+++ b/test/gpu/native/studies/compiler-performance/math.gpu-compopts
@@ -1,0 +1,1 @@
+math.compopts


### PR DESCRIPTION
For `gpu/native/studies/compiler-performance` we have a `.compopts` file, however since we run GPU perf tests with `-perflabel gpu-` so if we want to use the compiler options we need a `.gpu-compopts` file. This PR creates the file and links it to the non-perf test version.