### PR TITLE
Don't specify --quiet if SLURM_DEBUG/SALLOC_DEBUG/SBATCH_DEBUG is set

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -99,10 +99,9 @@ static int getNumCoresPerLocale(void) {
   return numCores;
 }
 
-static chpl_bool getSlurmDebug(chpl_bool batch) {
+static chpl_bool getSlurmDebug(void) {
   chpl_bool result = false;
-  const char *varName = (batch) ? "SBATCH_DEBUG" : "SLURM_DEBUG";
-  char *debugString = getenv(varName);
+  char *debugString = getenv("SALLOC_DEBUG");
   if (debugString) {
     result = (atoi(debugString) != 0) ? true : false;
   }
@@ -281,7 +280,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     char iCom[2*FILENAME_MAX-10];
     int len = 0;
 
-    if (!getSlurmDebug(false)) {
+    if (!getSlurmDebug()) {
       len += snprintf(iCom+len, sizeof(iCom)-len, "--quiet ");
     }
     len += snprintf(iCom+len, sizeof(iCom)-len, "-J %s ", jobName);

--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -101,14 +101,10 @@ static int getNumCoresPerLocale(void) {
 
 static chpl_bool getSlurmDebug(chpl_bool batch) {
   chpl_bool result = false;
-  char *debugString = getenv("SLURM_DEBUG");
+  const char *varName = (batch) ? "SBATCH_DEBUG" : "SLURM_DEBUG";
+  char *debugString = getenv(varName);
   if (debugString) {
     result = (atoi(debugString) != 0) ? true : false;
-  } else if (batch) {
-    debugString = getenv("SBATCH_DEBUG");
-    if (debugString) {
-      result = (atoi(debugString) != 0) ? true : false;
-    }
   }
   return result;
 }

--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -99,6 +99,20 @@ static int getNumCoresPerLocale(void) {
   return numCores;
 }
 
+static chpl_bool getSlurmDebug(chpl_bool batch) {
+  chpl_bool result = false;
+  char *debugString = getenv("SLURM_DEBUG");
+  if (debugString) {
+    result = (atoi(debugString) != 0) ? true : false;
+  } else if (batch) {
+    debugString = getenv("SBATCH_DEBUG");
+    if (debugString) {
+      result = (atoi(debugString) != 0) ? true : false;
+    }
+  }
+  return result;
+}
+
 static void genNumLocalesOptions(FILE* slurmFile, sbatchVersion sbatch,
                                  int32_t numLocales,
                                  int32_t numCoresPerLocale) {
@@ -271,7 +285,9 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     char iCom[2*FILENAME_MAX-10];
     int len = 0;
 
-    len += snprintf(iCom+len, sizeof(iCom)-len, "--quiet ");
+    if (!getSlurmDebug(false)) {
+      len += snprintf(iCom+len, sizeof(iCom)-len, "--quiet ");
+    }
     len += snprintf(iCom+len, sizeof(iCom)-len, "-J %s ", jobName);
     len += snprintf(iCom+len, sizeof(iCom)-len, "-N %d ", numLocales);
     len += snprintf(iCom+len, sizeof(iCom)-len, "--ntasks-per-node=1 ");

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -310,7 +310,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // set the job name
     fprintf(slurmFile, "#SBATCH --job-name=%s\n", jobName);
 
-    if (!getSlurmDebug(true)) {
+    if (!getSlurmDebug(/*batch=*/true)) {
       // suppress informational messages, will still display errors
       fprintf(slurmFile, "#SBATCH --quiet\n");
     }
@@ -436,7 +436,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     // set the job name
     len += snprintf(iCom+len, sizeof(iCom)-len, "--job-name=%s ", jobName);
-    if(!getSlurmDebug(false)) {
+    if (!getSlurmDebug(/*batch=*/false)) {
       // suppress informational messages, will still display errors
       len += snprintf(iCom+len, sizeof(iCom)-len, "--quiet ");
     }

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -160,14 +160,10 @@ static int getCoresPerLocale(int nomultithread, int32_t localesPerNode) {
 
 static chpl_bool getSlurmDebug(chpl_bool batch) {
   chpl_bool result = false;
-  char *debugString = getenv("SLURM_DEBUG");
+  const char *varName = (batch) ? "SBATCH_DEBUG" : "SLURM_DEBUG";
+  char *debugString = getenv(varName);
   if (debugString) {
     result = (atoi(debugString) != 0) ? true : false;
-  } else if (batch) {
-    debugString = getenv("SBATCH_DEBUG");
-    if (debugString) {
-      result = (atoi(debugString) != 0) ? true : false;
-    }
   }
   return result;
 }

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -156,6 +156,23 @@ static int getCoresPerLocale(int nomultithread, int32_t localesPerNode) {
   }
   return numCores / localesPerNode;
 }
+
+
+static chpl_bool getSlurmDebug(chpl_bool batch) {
+  chpl_bool result = false;
+  char *debugString = getenv("SLURM_DEBUG");
+  if (debugString) {
+    result = (atoi(debugString) != 0) ? true : false;
+  } else if (batch) {
+    debugString = getenv("SBATCH_DEBUG");
+    if (debugString) {
+      result = (atoi(debugString) != 0) ? true : false;
+    }
+  }
+  return result;
+}
+
+
 #define MAX_COM_LEN (FILENAME_MAX + 128)
 // create the command that will actually launch the program and
 // create any files needed for the launch like the batch script
@@ -297,8 +314,10 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // set the job name
     fprintf(slurmFile, "#SBATCH --job-name=%s\n", jobName);
 
-    // suppress informational messages, will still display errors
-    fprintf(slurmFile, "#SBATCH --quiet\n");
+    if (!getSlurmDebug(true)) {
+      // suppress informational messages, will still display errors
+      fprintf(slurmFile, "#SBATCH --quiet\n");
+    }
 
     int32_t numNodes = (numLocales + localesPerNode - 1) / localesPerNode;
 
@@ -421,8 +440,10 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     // set the job name
     len += snprintf(iCom+len, sizeof(iCom)-len, "--job-name=%s ", jobName);
-    // suppress informational messages, will still display errors
-    len += snprintf(iCom+len, sizeof(iCom)-len, "--quiet ");
+    if(!getSlurmDebug(false)) {
+      // suppress informational messages, will still display errors
+      len += snprintf(iCom+len, sizeof(iCom)-len, "--quiet ");
+    }
 
     // request the number of locales, with 1 task per node, and number of cores
     // cpus-per-task. We probably don't need --nodes and --ntasks specified


### PR DESCRIPTION
Passing the `--quiet` argument to `srun`, `salloc`, or `sbatch` is incompatible with `SLURM_DEBUG`, `SALLOC_DEBUG` and `SBATCH_DEBUG`, respectively.