### PR TITLE
Document the meaning of CHPL_HOME for `make install` builds

### DIFF
--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -131,14 +131,15 @@ Specifically:
   ``/usr/local/`` or ``~/``.  Note that elevated privileges are likely
   to be required for any system-wide installation locations.
 
+  Please note that for any prefix-installed version of Chapel, the
+  meaning of ``$CHPL_HOME`` (e.g., as printed by compiler messages)
+  typically refers to ``/dir/for/install/share/chapel/x.yz`` where
+  ``x.yz`` is the Chapel version that was installed.
+  
 * ``--chpl-home=/dir/for/install`` copies key files and directories
   from the Chapel source tree into ``/dir/for/install``, preserving
   Chapel's traditional directory structure.
 
-* Please note that for any installed version of Chapel, the meaning of
-  ``$CHPL_HOME`` as printed by compiler messages refers to
-  ``/dir/for/install/share/chapel/x.yz`` where ``x.yz`` is the Chapel
-  version being installed.
 
 -----------------------------------------
 Switching Between Multiple Configurations

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -138,7 +138,8 @@ Specifically:
   
 * ``--chpl-home=/dir/for/install`` copies key files and directories
   from the Chapel source tree into ``/dir/for/install``, preserving
-  Chapel's traditional directory structure.
+  Chapel's traditional directory structure.  As you might expect, the
+  meaning of ``$CHPL_HOME`` for such installs is ``/dir/for/install``.
 
 
 -----------------------------------------

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -135,6 +135,10 @@ Specifically:
   from the Chapel source tree into ``/dir/for/install``, preserving
   Chapel's traditional directory structure.
 
+* Please note that for any installed version of Chapel, the meaning of
+  ``$CHPL_HOME`` as printed by compiler messages refers to
+  ``/dir/for/install/share/chapel/x.yz`` where ``x.yz`` is the Chapel
+  version being installed.
 
 -----------------------------------------
 Switching Between Multiple Configurations


### PR DESCRIPTION
In #21622, it was pointed out that CHPL_HOME is not documented for users of `make install` builds.  This updates the "Building Chapel" documentation to indicate that $CHPL_HOME is in the `share/chapel/x.yz/` directory under the prefix into which Chapel was installed.

This is not a perfect solution because someone may be using a version of Chapel installed by someone else and never read those instructions (and/or they may do the install themselves and never finish reading the instructions or forget about them).  Still, documenting it here seems like an obvious step forward.

Another thing we should consider doing in the near future is to promote the `--print-chpl-home` to a user flag (potentially calling it `--print-CHPL_HOME` to improve chances of finding it; or maybe we can just rely on the `--help` output to get people there).
