### PR TITLE
Fix typos

### DIFF
--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -269,7 +269,7 @@ void ParserContext::noteAttribute(YYLTYPE loc, AstNode* firstIdent,
   auto attr = buildAttribute(loc, ident, usedParens, toolspace, actuals);
   for (auto& attribute : *attrs) {
     if (attribute->toAttribute()->name() == attr->toAttribute()->name()) {
-      error(loc, "repteated attribute '%s'", attr->toAttribute()->name().c_str());
+      error(loc, "repeated attribute '%s'", attr->toAttribute()->name().c_str());
     }
   }
   attrs = appendList(attrs, attr.release());

--- a/frontend/test/parsing/testParseAttributes.cpp
+++ b/frontend/test/parsing/testParseAttributes.cpp
@@ -853,7 +853,7 @@ static void test15(Parser* parser) {
   auto parseResult = parseStringAndReportErrors(parser, "test15.chpl",
                                                 program.c_str());
   assert(guard.numErrors() == 1);
-  assert(guard.error(0)->message() == "repteated attribute 'chpldoc.nodoc'");
+  assert(guard.error(0)->message() == "repeated attribute 'chpldoc.nodoc'");
   assert(guard.error(0)->kind() == ErrorBase::Kind::ERROR);
   assert(guard.realizeErrors() == 1);
 }

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -128,7 +128,7 @@ OPTIONS
 
     [Don't] warn about attribute tool names that aren't recognized. Without this
     warning, attributes belonging to unknown tools will be silently ignored.
-    The default is to warn about all unkown tool names.
+    The default is to warn about all unknown tool names.
 
 **\--using-attribute-toolname <**\ *toolname*\ **>**
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5526,7 +5526,7 @@ proc fileReader._matchLiteralCommon(literal, ignore : bool) : bool throws {
 
   If the string is not matched exactly, then the fileReader's position is
   unchanged and this method will return ``false``. In other words, this
-  fileeReader will return ``false`` in the cases where
+  fileReader will return ``false`` in the cases where
   :proc:`fileReader.readLiteral` would throw a :class:`OS.BadFormatError` or an
   :class:`OS.EofError`.
 


### PR DESCRIPTION
Fix typos in ParserContextImpl.h, chpl.rst, and IO.chpl