### PR TITLE
Update 'getCurrentTime' deprecation message

### DIFF
--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -1943,7 +1943,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
    :returns: The elapsed time since midnight, local time, in the units specified
    :rtype:   `real(64)`
  */
-@deprecated(notes="'getCurrentTime()' is deprecated please use 'timeSinceEpoch()' instead")
+@deprecated(notes="'getCurrentTime()' is deprecated please use 'timeSinceEpoch().totalSeconds()' instead")
 proc getCurrentTime(unit: TimeUnits = TimeUnits.seconds) : real(64) do
   return _convert_microseconds(unit, chpl_now_time());
 

--- a/test/deprecated/timeGetCurrentTime.good
+++ b/test/deprecated/timeGetCurrentTime.good
@@ -1,1 +1,1 @@
-timeGetCurrentTime.chpl:3: warning: 'getCurrentTime()' is deprecated please use 'timeSinceEpoch()' instead
+timeGetCurrentTime.chpl:3: warning: 'getCurrentTime()' is deprecated please use 'timeSinceEpoch().totalSeconds()' instead


### PR DESCRIPTION
The `getCurrentTime` deprecation message was previously only recommending to use `timeSinceEpoch()`, which is not an equivalent replacement by itself, so this PR updates it to instead recommend `timeSinceEpoch().totalSeconds()`, which can be put in place of old `getCurrentTime` calls by itself.

- [x] paratest