### PR TITLE
Remove a debug-related check that was executing always

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -125,12 +125,6 @@ inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
 
 void* chpl_gpu_memmove(void* dst, const void* src, size_t n) {
   CHPL_GPU_DEBUG("Doing GPU memmove of %zu bytes from %p to %p.\n", n, src, dst);
-  if (chpl_gpu_is_host_ptr(src)) {
-    CHPL_GPU_DEBUG("src is host ptr\n");
-  }
-  if (chpl_gpu_is_host_ptr(dst)) {
-    CHPL_GPU_DEBUG("dst is host ptr\n");
-  }
 
   void* ret = chpl_gpu_impl_memmove(dst, src, n);
 


### PR DESCRIPTION
My #21753 added debug-related conditionals that executes even without `--debugGpu` this really slows down execution of tests. This PR removes those conditionals.

Test:
- [x] gpu/native