### PR TITLE
Fix commDiags.good

### DIFF
--- a/test/parallel/taskPar/sungeun/barrier/commDiags.good
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.good
@@ -1,15 +1,15 @@
 atomic remote test basic
 (execute_on_nb = 4)
-(get = 1, execute_on = 1)
-(get = 1, execute_on = 1)
-(get = 1, execute_on = 1)
-(get = 1, execute_on = 1)
+(get = 1, execute_on = 2)
+(get = 1, execute_on = 2)
+(get = 1, execute_on = 2)
+(get = N, execute_on = 3-N)
 atomic remote test split phase
 (execute_on_nb = 4)
-(get = 2, execute_on = 2)
-(get = 2, execute_on = 2)
-(get = 2, execute_on = 2)
-(get = 2, execute_on = 2)
+(get = 3, execute_on = 2)
+(get = 3, execute_on = 2)
+(get = 3, execute_on = 2)
+(get = 3, execute_on = 2)
 allLocalesBarrier test basic
 (execute_on_nb = 4)
 (<no communication>)


### PR DESCRIPTION
The atomic section of the `commDiags.good` file was inadvertently removed in commit `b84c8e1` instead of the sync section. This commit restores the atomic section and removes the sync section.