### PR TITLE
Make adjustments to spec grammar to reflect array type parsing changes

### DIFF
--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -35,11 +35,16 @@ by the following syntax:
 .. code-block:: syntax
 
    array-type:
-     [ domain-expression ] type-expression
+     [ domain-expression[OPT] ] type-expression[OPT]
 
-The ``domain-expression`` must specify a domain that the array can be
+The ``domain-expression`` may specify a domain that the array can be
 declared over. If the ``domain-expression`` is a rectangular domain
 literal, the curly braces around the literal may be omitted.
+
+The ``domain-expression`` and ``type-expression`` are optional, but
+can currently only be omitted when the array type is specified as
+one of: a formal type expression, a procedure return type, or an
+iterator yield type.
 
    *Example (decls.chpl)*.
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -140,14 +140,12 @@ Procedures are defined with the following syntax:
 
    formal-type:
      : type-expression
-     : ? identifier[OPT]
 
    default-expression:
      = expression
 
    variable-argument-expression:
      ... expression
-     ... ? identifier[OPT]
      ...
 
    formal-intent:

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -28,6 +28,7 @@ The syntax of a type is as follows:
      if-expression
      unary-expression
      binary-expression
+     expression
 
 Many expressions are syntactically allowed as a type; however not all
 expressions produce a type. For example, a call to a function is


### PR DESCRIPTION
In #21584 I adjusted the implementation grammar to parse array types
and bracket loops with a single production. This PR adjusts the spec
grammar to reflect those changes.

Apply `expression` from `type-expression`. This mirrors how the
production compiler has collapsed `type-expression` into `expression`,
but also keeps the category of things that are logically considered
"type expressions" separate from other expressions.

Remove redundant rules of the form `? identifier[OPT]` as those terms
are reachable by `query-expression`.

Adjust `array-type` to make the `domain-expression` and
`type-expression` optional. Add a sentence explaining that currently,
they may only be omitted in specific circumstances.

Reviewed by @benharsh. Thanks!