### PR TITLE
Pass AMD library paths with rpath, too

### DIFF
--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -97,8 +97,9 @@ def get_runtime_link_args(runtime_subdir):
             system.append("-lcuda")
             system.append("-lcudart")
         elif gpu_type == "rocm":
-            system.append("-L" + os.path.join(sdk_path, "hip", "lib"))
-            system.append("-L" + os.path.join(sdk_path, "hsa", "lib"))
+            lib_path = os.path.join(sdk_path, "lib")
+            system.append("-L" + lib_path)
+            system.append("-Wl,-rpath," + lib_path)
             system.append("-lamdhip64")
             system.append("-lhsa-runtime64")
 


### PR DESCRIPTION
This PR passes AMD libraries' path to `rpath` while linking.

It looks like they are shared libraries that require rpath or LD_LIBRARY_PATH to be set.

While there, it also uses the parent directory for the path as that contains symlinks to both HSA and HIP libraries.

Test:
- [x] gpu/native with rocm on linux64