### PR TITLE
add a technote about Attributes

### DIFF
--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -23,7 +23,7 @@ Base Language Features
    Module Search Paths <module_search>
    Operator Methods <operatorMethods>
    The 'manage' Statement <manage>
-
+   Attributes <attributes>
 
 Initializers and Generic Programming
 ------------------------------------


### PR DESCRIPTION
This PR adds some documentation about Attributes in general, and some specifics about the stability and chpldoc attributes. It also indicates the current state of support for attributes and details some future work plans.

For the 1.30 release, we are too close to release to issue an update to the `sphinxcontrib-chapeldomain` repo as `chpldoc` uses that package to build docs and could be affected. For now, the examples in this document update are labeled as `text` rather than `chapel`. Once https://github.com/chapel-lang/sphinxcontrib-chapeldomain/pull/70 can be merged, the docs can be updated to indicate the code blocks are Chapel and highlighting will resume. 

TESTING:

- [x] built docs locally and manually inspected attributes page and links

reviewed by @DanilaFe - thank you!