### PR TITLE
Skip yield-by-value-4 future in non-standard configurations

### DIFF
--- a/test/functions/iterators/vass/yield-by-value-4.skipif
+++ b/test/functions/iterators/vass/yield-by-value-4.skipif
@@ -1,0 +1,6 @@
+# The leaked amounts are bigger for no-local compilations, so do not match .bad.
+# Remove this skipif once the leak is fixed.
+COMPOPTS <= --no-local
+CHPL_COMM != none
+# Something else is different causing .bad mismatch for --baseline compilations.
+COMPOPTS <= --baseline


### PR DESCRIPTION
The .bad file for this test expect certain amounts of leaked memory. The latter differs for baseline and no-local/gasnet testing. So, skip this test in those cases.

Once the leak is fixed, the skipif can be removed. Actually, the entire test should be folded into yield-by-value-2,3, for simplicity.

Trivial, not reviewed.