### PR TITLE
Update GPU performance tests to not count launches in perf mode

### DIFF
--- a/test/gpu/native/array_on_device/studies/shoc/triadAOD.chpl
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAOD.chpl
@@ -24,7 +24,7 @@ proc main() {
 
     var hos: [0..#numMaxFloats] real(32);
     //startVerboseMem();
-    startGpuDiagnostics();
+    if !perftest then startGpuDiagnostics();
 
     var flopsDB = new ResultDatabase("TriadFlops", "GFLOP/s");
     var bdwthDB = new ResultDatabase("TriadBdwth", "GB/s");
@@ -233,7 +233,8 @@ proc main() {
       writeln("BW block size 64 = ", bwBlockSize64, " GB/s");
       writeln("BW block size 16384 = ", bwBlockSize16384, " GB/s");
     }
-
-    stopGpuDiagnostics();
-    writeln(getGpuDiagnostics());
+    else {
+      stopGpuDiagnostics();
+      writeln(getGpuDiagnostics());
+    }
 }

--- a/test/gpu/native/array_on_device/studies/shoc/triadAOD.gpu-keys
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAOD.gpu-keys
@@ -1,3 +1,2 @@
 BW block size 64 =
 BW block size 16384 =
-verify:-1: (kernel_launch = 1291)

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.chpl
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.chpl
@@ -26,7 +26,7 @@ proc main() {
 
     var hos: [0..#numMaxFloats] real(32);
     //startVerboseMem();
-    startGpuDiagnostics();
+    if !perftest then startGpuDiagnostics();
 
     var flopsDB = new ResultDatabase("TriadFlops", "GFLOP/s");
     var bdwthDB = new ResultDatabase("TriadBdwth", "GB/s");
@@ -203,7 +203,8 @@ proc main() {
       writeln("BW block size 64 = ", bwBlockSize64, " GB/s");
       writeln("BW block size 16384 = ", bwBlockSize16384, " GB/s");
     }
-
-    stopGpuDiagnostics();
-    writeln(getGpuDiagnostics());
+    else {
+      stopGpuDiagnostics();
+      writeln(getGpuDiagnostics());
+    }
 }

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.gpu-keys
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.gpu-keys
@@ -1,3 +1,2 @@
 BW block size 64 =
 BW block size 16384 =
-verify:-1: (kernel_launch = 1351)

--- a/test/gpu/native/studies/shoc/triad.chpl
+++ b/test/gpu/native/studies/shoc/triad.chpl
@@ -29,7 +29,7 @@ proc main(){
     var kernelDB = new ResultDatabase("Kernel Time", "sec");
 
     //startVerboseMem();
-    startGpuDiagnostics();
+    if !perftest then startGpuDiagnostics();
     on here.gpus[0] {
         var kernelLaunches = 0;
 
@@ -217,6 +217,8 @@ proc main(){
       triadDB.printPerfStats();
       kernelDB.printPerfStats();
     }
-    stopGpuDiagnostics();
-    writeln(getGpuDiagnostics());
+    else {
+      stopGpuDiagnostics();
+      writeln(getGpuDiagnostics());
+    }
 }

--- a/test/gpu/native/studies/shoc/triad.gpu-keys
+++ b/test/gpu/native/studies/shoc/triad.gpu-keys
@@ -4,4 +4,3 @@ Triad Time BlckSz:    64KB Median:
 Triad Time BlckSz: 16384KB Median:
 Kernel Time BlckSz:    64KB Median:
 Kernel Time BlckSz: 16384KB Median:
-verify:-1: (kernel_launch = 1291)

--- a/test/gpu/native/studies/shoc/triadalt1.chpl
+++ b/test/gpu/native/studies/shoc/triadalt1.chpl
@@ -38,7 +38,7 @@ proc main(){
     var kernelDB = new ResultDatabase("Kernel Time", "sec");
 
     var hos: [0..#numMaxFloats] real(32);
-    startGpuDiagnostics();
+    if !perftest then startGpuDiagnostics();
     on here.gpus[0] {
         var kernelLaunches = 0;
         for pass in 0..#passes{
@@ -208,8 +208,6 @@ proc main(){
             }
         }
     }
-    stopGpuDiagnostics();
-    verifyLaunches();
 
     if(output) {
       flopsDB.printDatabaseStats();
@@ -221,5 +219,9 @@ proc main(){
       bdwthDB.printPerfStats();
       triadDB.printPerfStats();
       kernelDB.printPerfStats();
+    }
+    else {
+      stopGpuDiagnostics();
+      verifyLaunches();
     }
 }

--- a/test/gpu/native/studies/shoc/triadalt1.gpu-keys
+++ b/test/gpu/native/studies/shoc/triadalt1.gpu-keys
@@ -4,4 +4,3 @@ Triad Time BlckSz:    64KB Median:
 Triad Time BlckSz: 16384KB Median:
 Kernel Time BlckSz:    64KB Median:
 Kernel Time BlckSz: 16384KB Median:
-verify:-1: (kernel_launch = 1305)

--- a/test/gpu/native/studies/shoc/triadalt2.chpl
+++ b/test/gpu/native/studies/shoc/triadalt2.chpl
@@ -37,7 +37,7 @@ proc main(){
     var kernelDB = new ResultDatabase("Kernel Time", "sec");
 
     var hos: [0..#numMaxFloats] real(32);
-    startGpuDiagnostics();
+    if !perftest then startGpuDiagnostics();
     on here.gpus[0] {
         var kernelLaunches = 0;
         for pass in 0..#passes{
@@ -158,8 +158,6 @@ proc main(){
             }
         }
     }
-    stopGpuDiagnostics();
-    verifyLaunches();
     if(output) {
       flopsDB.printDatabaseStats();
       bdwthDB.printDatabaseStats();
@@ -171,4 +169,9 @@ proc main(){
       triadDB.printPerfStats();
       kernelDB.printPerfStats();
     }
+    else {
+      stopGpuDiagnostics();
+      verifyLaunches();
+    }
 }
+

--- a/test/gpu/native/studies/shoc/triadalt2.gpu-keys
+++ b/test/gpu/native/studies/shoc/triadalt2.gpu-keys
@@ -4,4 +4,3 @@ Triad Time BlckSz:    64KB Median:
 Triad Time BlckSz: 16384KB Median:
 Kernel Time BlckSz:    64KB Median:
 Kernel Time BlckSz: 16384KB Median:
-verify:-1: (kernel_launch = 1305)

--- a/test/gpu/native/studies/shoc/triadchpl.chpl
+++ b/test/gpu/native/studies/shoc/triadchpl.chpl
@@ -14,7 +14,7 @@ proc main(){
     var bdwthDB = new ResultDatabase("TriadBdwth", "GB/s");
     var triadDB = new ResultDatabase("Triad Time", "sec");
     var kernelDB = new ResultDatabase("Kernel Time", "sec");
-    startGpuDiagnostics();
+    if !perftest then startGpuDiagnostics();
     on here.gpus[0] {
         var timer: stopwatch;
         var kernelTimer: stopwatch;
@@ -118,8 +118,6 @@ proc main(){
             }
         }
     }
-    stopGpuDiagnostics();
-    writeln(getGpuDiagnostics());
     if(output) {
       flopsDB.printDatabaseStats();
       bdwthDB.printDatabaseStats();
@@ -128,5 +126,9 @@ proc main(){
     if(perftest){
       bdwthDB.printPerfStats();
       triadDB.printPerfStats();
+    }
+    else {
+      stopGpuDiagnostics();
+      writeln(getGpuDiagnostics());
     }
 }

--- a/test/gpu/native/studies/shoc/triadchpl.gpu-keys
+++ b/test/gpu/native/studies/shoc/triadchpl.gpu-keys
@@ -1,3 +1,2 @@
 TriadBdwth BlckSz: 16384KB Median:
 Triad Time BlckSz: 16384KB Median:
-verify:-1: (kernel_launch = 8)


### PR DESCRIPTION
This updates SHOC perf studies to not count kernel launches if `--perftest` is thrown in.

We've recently seen perf test failures mostly due to the line number of the output and sometimes because of changes in number of kernel launches due to https://github.com/chapel-lang/chapel/pull/21753.

In any case, performance tests shouldn't count kernel launches as it is an atomic increment that can have noticeable effects in short-running and/or launch-heavy tests.

Test:
- [x] `start_test -perflabel gpu- test/gpu/native` (with approproate mem strategies)
- [x] changed tests pass (with appropriate mem strategies) 