### PR TITLE
Further adjustments to the IO documentation example codes

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -71,10 +71,10 @@ For example, the following program opens a file and writes an integer to it:
     // 17
 
   } catch e: Error {
-    // These functions will throw errors under specific circumstances.  The
-    // possible errors vary depending on arguments used and the current state of
-    // the file system.  See the documentation for the individual functions and
-    // the spec chapter on Error Handling for more information.
+    // Generally speaking, the I/O functions throw errors.  Handling these
+    // errors is application-dependent and is left out of this example for
+    // brevity.  Please see the documentation for individual functions for more
+    // details about errors that they can throw.
   }
 
 Then, the following program can be used to read the integer:
@@ -103,10 +103,10 @@ Then, the following program can be used to read the integer:
     // Read integer 17
 
   } catch e: Error {
-    // These functions will throw errors under specific circumstances.  The
-    // possible errors vary depending on arguments used and the current state of
-    // the file system.  See the documentation for the individual functions and
-    // the spec chapter on Error Handling for more information.
+    // Generally speaking, the I/O functions throw errors.  Handling these
+    // errors is application-dependent and is left out of this example for
+    // brevity.  Please see the documentation for individual functions for more
+    // details about errors that they can throw.
   }
 
 The :proc:`~IO.read` functions allow one to read values into variables as

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -51,47 +51,63 @@ For example, the following program opens a file and writes an integer to it:
 
 .. code-block:: chapel
 
-  // open the file "test-file.txt" for writing, creating it if
-  // it does not exist yet.
-  var myFile = try! open("test-file.txt", ioMode.cw);
+  try {
+    // open the file "test-file.txt" for writing, creating it if
+    // it does not exist yet.
+    var myFile = open("test-file.txt", ioMode.cw);
 
-  // create a fileWriter starting at file offset 0
-  // (start and end offsets can be specified when creating the
-  // fileWriter)
-  var myFileWriter = try! myFile.writer();
+    // create a fileWriter starting at file offset 0
+    // (start and end offsets can be specified when creating the
+    // fileWriter)
+    var myFileWriter = myFile.writer();
 
-  var x: int = 17;
+    var x: int = 17;
 
-  // This function will write the human-readable text version of x;
-  // binary I/O is also possible.
-  try! myFileWriter.write(x);
+    // This function will write the human-readable text version of x;
+    // binary I/O is also possible.
+    myFileWriter.write(x);
 
-  // Now test-file.txt contains:
-  // 17
+    // Now test-file.txt contains:
+    // 17
+
+  } catch e: Error {
+    // These functions will throw errors under specific circumstances.  The
+    // possible errors vary depending on arguments used and the current state of
+    // the file system.  See the documentation for the individual functions and
+    // the spec chapter on Error Handling for more information.
+  }
 
 Then, the following program can be used to read the integer:
 
 .. code-block:: chapel
 
-  // open the file "test-file.txt" for reading only
-  var myFile = try! open("test-file.txt", ioMode.r);
+  try {
+    // open the file "test-file.txt" for reading only
+    var myFile = open("test-file.txt", ioMode.r);
 
-  // create a fileReader starting at file offset 0
-  // (start and end offsets can be specified when creating the
-  // fileReader)
-  var myFileReader = try! myFile.reader();
+    // create a fileReader starting at file offset 0
+    // (start and end offsets can be specified when creating the
+    // fileReader)
+    var myFileReader = myFile.reader();
 
-  var x: int;
+    var x: int;
 
-  // Now read a textual integer. Note that the
-  // fileReader.read function returns a bool to indicate
-  // if it read something or if the end of the file
-  // was reached before something could be read.
-  var readSomething = try! myFileReader.read(x);
+    // Now read a textual integer. Note that the
+    // fileReader.read function returns a bool to indicate
+    // if it read something or if the end of the file
+    // was reached before something could be read.
+    var readSomething = myFileReader.read(x);
 
-  writeln("Read integer ", x);
-  // prints out:
-  // Read integer 17
+    writeln("Read integer ", x);
+    // prints out:
+    // Read integer 17
+
+  } catch e: Error {
+    // These functions will throw errors under specific circumstances.  The
+    // possible errors vary depending on arguments used and the current state of
+    // the file system.  See the documentation for the individual functions and
+    // the spec chapter on Error Handling for more information.
+  }
 
 The :proc:`~IO.read` functions allow one to read values into variables as
 the following example demonstrates. It shows three ways to read values into


### PR DESCRIPTION
Instead of using `try!` on the calls that throw errors, surround them in `try` / `catch` blocks with a note to look up the individual errors thrown.

This avoids recommending that users always halt on errors and points them to places where they can find more information

Built the docs locally without issue