### PR TITLE
Remove error for using FCF type constructor syntax in legacy mode

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10080,12 +10080,6 @@ static Expr* resolveFunctionTypeConstructor(DefExpr* def) {
     gdbShouldBreakHere();
   }
 
-  if (fcfs::useLegacyBehavior()) {
-    USR_FATAL(def, "syntax for constructing procedure types is not "
-                   "supported in legacy mode");
-    return def;
-  }
-
   bool isBodyResolved = fcfs::checkAndResolveSignature(fn, def);
 
   // Signature only, so no body to resolve.

--- a/test/functions/lambda/NewSyntaxInLegacyMode.chpl
+++ b/test/functions/lambda/NewSyntaxInLegacyMode.chpl
@@ -1,0 +1,22 @@
+// Make sure that, for the most part, you can use the new syntax
+// when compiling in legacy mode.
+
+type T1 = proc(x: int, y: int): int;
+type T2 = func(int, int, int);
+
+assert(T1 != T2);
+
+type T3 = proc(_: int, _: int): int;
+
+// TODO: These are not equal? Huh...
+writeln(T2:string);
+writeln(T3:string);
+
+const p1 = lambda(x: int, y: int): int { return x + y; };
+const p2 = proc(x: int, y: int): int { return x + y; };
+
+assert(p1.type == p2.type);
+
+writeln(p1(2, 2));
+writeln(p2(2, 2));
+

--- a/test/functions/lambda/NewSyntaxInLegacyMode.good
+++ b/test/functions/lambda/NewSyntaxInLegacyMode.good
@@ -1,0 +1,4 @@
+proc(int, int): int
+proc(_: int, _: int): int
+4
+4


### PR DESCRIPTION
An error message that fired when using the `proc()` procedure type
constructor in "legacy mode" is outdated and can be removed. Do so
to make it more convenient to try out new FCF syntax in 1.30.

TESTING

- [x] `linux64`, `standard`

Reviewed by @benharsh. Thanks!