### PR TITLE
Improvements to the Standard Module Style Guide

### DIFF
--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -118,12 +118,12 @@ Accessors
 +++++++++
 
 Accessor methods are methods intended to return a distinct piece of information
-about the type on which they are defined.  Typically, such methods are defined
-without parentheses, allowing them to appear similar to a field access.
-However, there is no requirement that the contents of the accessor be similarly
-simple - whether the information returned is calculated based on the internal
-fields of the type or whether it is actually a field is an implementation
-detail.
+about the type on which they are defined.  This piece of information could be
+reasonably implemented as a field.  Typically, such methods are defined without
+parentheses, allowing them to appear similar to a field access.  However, there
+is no requirement that the contents of the accessor be similarly simple -
+whether the information returned is calculated based on the internal fields of
+the type or whether it is actually a field is an implementation detail.
 
 Accessor methods will avoid using "get" in their name.  E.g., instead of
 ``array.getIdxType``, the accessor is named ``array.idxType``.

--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -114,7 +114,23 @@ could have:
  * ``createStringWithBorrowedBuffer`` or
  * ``string.createWithBorrowedBuffer``.
 
+Accessors
++++++++++
+
+Accessor methods are methods intended to return a distinct piece of information
+about the type on which they are defined.  Typically, such methods are defined
+without parentheses, allowing them to appear similar to a field access.
+However, there is no requirement that the contents of the accessor be similarly
+simple - whether the information returned is calculated based on the internal
+fields of the type or whether it is actually a field is an implementation
+detail.
+
+Accessor methods will avoid using "get" in their name.  E.g., instead of
+``array.getIdxType``, the accessor is named ``array.idxType``.
+
+Methods that are not accessors are still allowed to use "get" in their name.
+
 Other Identifiers
 -----------------
 
-Variables, fields, and argument names should be camelCase or CamelCase.
+Variables, fields, and argument names should be camelCase or PascalCase.


### PR DESCRIPTION
Resolves Cray/chapel-private#4451
Resolves #21691

This change is mostly focused on adding the guidance we
decided on for accessor method naming.  It also corrects
an incorrect use of "CamelCase" to "PascalCase", which
is the proper term.

Built the docs locally.