### PR TITLE
Migrate Jira references in tests to github

### DIFF
--- a/test/compflags/ferguson/default-binary-name/sub_test
+++ b/test/compflags/ferguson/default-binary-name/sub_test
@@ -26,7 +26,7 @@ else:
     platform = myoutput
 
 
-# Skip this test on cygwin -- see JIRA 164
+# Skip this test on cygwin to avoid sporadic "Device or resource busy" errors
 if platform.startswith("cygwin"):
   sys.exit(0)
 

--- a/test/library/packages/FFTW/SKIPIF
+++ b/test/library/packages/FFTW/SKIPIF
@@ -1,15 +1,5 @@
 #!/usr/bin/env python3
 
-#
-# skip this test when FFTW_DIR is not set or we're using pgi (JIRA 195).
-#
-# See JIRA 195 for more info on why we skip with pgi:
-#    https://chapel.atlassian.net/browse/CHAPEL-195
-#
-
 import os
-
 missing_fftw_dir = 'FFTW_DIR' not in os.environ
-using_pgi = 'pgi' in os.getenv('CHPL_TARGET_COMPILER')
-
-print(missing_fftw_dir or using_pgi)
+print(missing_fftw_dir)

--- a/test/library/standard/FileSystem/fsouza/chown/permission_error.suppressif
+++ b/test/library/standard/FileSystem/fsouza/chown/permission_error.suppressif
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Fails when run as a windows service, see JIRA issue 81
+# Fails when run as a windows service, see
+# https://github.com/Cray/chapel-private/issues/4097
 
 if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
   echo 1

--- a/test/library/standard/IO/open/checkPermissions.suppressif
+++ b/test/library/standard/IO/open/checkPermissions.suppressif
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Fails when run as a windows service, see JIRA issue 81
+# Fails when run as a windows service, see
+# https://github.com/Cray/chapel-private/issues/4097
 
 if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
   echo 1

--- a/test/library/standard/IO/openreader/checkPermissions.suppressif
+++ b/test/library/standard/IO/openreader/checkPermissions.suppressif
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Fails when run as a windows service, see JIRA issue 81
+# Fails when run as a windows service, see
+# https://github.com/Cray/chapel-private/issues/4097
 
 if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
   echo 1

--- a/test/library/standard/IO/openwriter/checkPermissions.suppressif
+++ b/test/library/standard/IO/openwriter/checkPermissions.suppressif
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Fails when run as a windows service, see JIRA issue 81
+# Fails when run as a windows service, see
+# https://github.com/Cray/chapel-private/issues/4097
 
 if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
   echo 1

--- a/test/library/standard/OS/POSIX/chmod/chmod_noprivilege.suppressif
+++ b/test/library/standard/OS/POSIX/chmod/chmod_noprivilege.suppressif
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Fails when run as a windows service, see JIRA issue 81
+# Fails when run as a windows service, see
+# https://github.com/Cray/chapel-private/issues/4097
 
 if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
   echo 1

--- a/test/studies/cholesky/jglewis/version2/performance/test_cholesky_performance.suppressif
+++ b/test/studies/cholesky/jglewis/version2/performance/test_cholesky_performance.suppressif
@@ -1,4 +1,5 @@
-# cygwin leaks condition variables (see JIRA issue 74)
+# cygwin leaks condition variables (see
+# https://github.com/Cray/chapel-private/issues/4556)
 
 CHPL_TARGET_PLATFORM==cygwin32
 CHPL_TARGET_PLATFORM==cygwin64

--- a/test/studies/parboil/stencil/stencilSerial.skipif
+++ b/test/studies/parboil/stencil/stencilSerial.skipif
@@ -1,7 +1,4 @@
 # Floating point precision variations in some configs cause binary mismatch
-#
-# See JIRA 244 for more info: https://chapel.atlassian.net/browse/CHAPEL-244
 
 COMPOPTS <= --fast
 CHPL_TARGET_PLATFORM <= 32
-CHPL_TARGET_COMPILER <= pgi

--- a/test/testsystem.notest
+++ b/test/testsystem.notest
@@ -2,11 +2,8 @@ Some manual tests for debugging sub_test filters
 
 Usage & expected output:
 
-> start_test sub_test_filters/*.chpl
+> start_test test/testsystem/*.chpl
 
-[Error (possible private issue #398)  for chplenv/sub_test_filters/compiler-error]
-[Error (possible JIRA 287) matching program output for chplenv/sub_test_filters/compiler-warning]
-[Error (possible JIRA 274) matching program output for chplenv/sub_test_filters/runtime-error]
-
-
-
+[Error (private issue #398) for testsystem/compiler-error]
+[Error (private issue #482) matching program output for testsystem/compiler-warning]
+[Error (private issue #634) matching program output for testsystem/runtime-error]

--- a/test/testsystem/runtime-error.chpl
+++ b/test/testsystem/runtime-error.chpl
@@ -1,2 +1,2 @@
 // Test xSocket runtime error
-halt('Master got an xSocket: error in sendAll');
+halt('Slave got an xSocket: connection closed on recv');

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -645,7 +645,7 @@ def filter_compiler_errors(compiler_output):
     err_strings = ['could not checkout FLEXlm license']
     for s in err_strings:
         if re.search(s, compiler_output, re.IGNORECASE) != None:
-            error_msg = '(private issue #398) '
+            error_msg = '(private issue #398)'
             break
 
     return error_msg
@@ -691,7 +691,7 @@ def filter_errors(output_in, pre_exec_output, execgoodfile, execlog):
     for s in err_strings:
         if (re.search(s, output, re.IGNORECASE) != None or
             re.search(s, pre_exec_output, re.IGNORECASE) != None):
-            extra_msg = '(private issue #398) '
+            extra_msg = '(private issue #398)'
             break
 
     err_strings = ['=* Memory Leaks =*']


### PR DESCRIPTION
Migrate:
 - Cygwin suppressifs for Jira 74/81 to private issues 4556/4097
 - testsystem tests (manual tests to check sub_test filters)

Remove:
 - References to pgi specific issues since we don't test pgi anymore
 - Jira 164 for inline text since there wasn't much info to migrate

Part of Cray/chapel-private#4543