### PR TITLE
docs(chpldoc): replace pragma 'no doc' with attribute

### DIFF
--- a/doc/rst/tools/chpldoc/chpldoc.rst
+++ b/doc/rst/tools/chpldoc/chpldoc.rst
@@ -222,11 +222,11 @@ Stifling documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 
 To mark a particular symbol to not be output as part of the documentation,
-preface the symbol with the pragma "no doc". For example:
+preface the symbol with the attribute ``@chpldoc.nodoc``. For example:
 
-.. code-block:: chapel
+.. code-block:: text
 
-   pragma "no doc"
+   @chpldoc.nodoc
    proc foo() { ... }
 
 Private symbols are not documented by default.


### PR DESCRIPTION
This PR updates the `chpldoc` documentation to change the method for suppressing generated documentation from `pragma "no doc"` to `@chpldoc.nodoc`.


This required changing the code block style from Chapel to plain text as the sphinxcontrib-chapeldomain and pygments packages both require updates to parse attributes.

Future work will change these back to Chapel blocks once those updated packages are available.

TESTING:

- [x] build docs locally and inspect `chpldoc` page

reviewed by @lydia-duncan - thanks!