### PR TITLE
Fix GPU ROCM runtime calls for block size and idx

### DIFF
--- a/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
@@ -118,13 +118,13 @@ __device__ static inline uint32_t chpl_gpu_getThreadIdxX() { return __builtin_am
 __device__ static inline uint32_t chpl_gpu_getThreadIdxY() { return __builtin_amdgcn_workitem_id_y(); }
 __device__ static inline uint32_t chpl_gpu_getThreadIdxZ() { return __builtin_amdgcn_workitem_id_z(); }
 
-__device__ static inline uint32_t chpl_gpu_getBlockIdxX()  { return __builtin_amdgcn_workgroup_size_x(); }
-__device__ static inline uint32_t chpl_gpu_getBlockIdxY()  { return __builtin_amdgcn_workgroup_size_y(); }
-__device__ static inline uint32_t chpl_gpu_getBlockIdxZ()  { return __builtin_amdgcn_workgroup_size_z(); }
+__device__ static inline uint32_t chpl_gpu_getBlockIdxX()  { return __builtin_amdgcn_workgroup_id_x(); }
+__device__ static inline uint32_t chpl_gpu_getBlockIdxY()  { return __builtin_amdgcn_workgroup_id_y(); }
+__device__ static inline uint32_t chpl_gpu_getBlockIdxZ()  { return __builtin_amdgcn_workgroup_id_z(); }
 
-__device__ static inline uint32_t chpl_gpu_getBlockDimX()  { return __builtin_amdgcn_workgroup_id_x(); }
-__device__ static inline uint32_t chpl_gpu_getBlockDimY()  { return __builtin_amdgcn_workgroup_id_y(); }
-__device__ static inline uint32_t chpl_gpu_getBlockDimZ()  { return __builtin_amdgcn_workgroup_id_z(); }
+__device__ static inline uint32_t chpl_gpu_getBlockDimX()  { return __builtin_amdgcn_workgroup_size_x(); }
+__device__ static inline uint32_t chpl_gpu_getBlockDimY()  { return __builtin_amdgcn_workgroup_size_y(); }
+__device__ static inline uint32_t chpl_gpu_getBlockDimZ()  { return __builtin_amdgcn_workgroup_size_z(); }
 
 __device__ static inline uint32_t chpl_gpu_getGridDimX()   { return __builtin_amdgcn_grid_size_x(); }
 __device__ static inline uint32_t chpl_gpu_getGridDimY()   { return __builtin_amdgcn_grid_size_y(); }


### PR DESCRIPTION
These were accidentally reversed (the block size functions were calling the ROCM primitives for block index and vice versa).

With the approval of others I'm going to try and submit this now even though we're near our release deadline on the basis that:

- it's pretty small / innocuous in terms of complexity yet with major impact on correctness and
- it’s in GPU code, which at this point isn't heavily used and considered more prototypical (though getting less over time)
- the previous bullet is doubly the case for AMD