### PR TITLE
Spec updates for range slicing and tuples

### DIFF
--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -12,7 +12,7 @@ values (consecutively or in parallel) via its yield statements.
    *Open issue*.
 
    The parallel iterator story is under development. It is expected that
-   the specification will be expanded regarding parallel iterators soon.
+   the specification will be expanded regarding parallel iterators.
 
 .. _Iterator_Function_Definitions:
 
@@ -84,6 +84,13 @@ execution continues from the point immediately following the ``yield``
 statement. A yield statement in an iterator that yields references must
 yield an lvalue expression.
 
+The iterator's ``yield-intent`` determines how each value is yielded.
+The rules for yielding are the same as the rules for returning values
+from procedures, see :ref:`Return_Intent`, except an iterator with
+the ``ref`` or ``const ref`` yield intent is allowed to yield an lvalue
+that is local to the iterator's scope.
+The rules for yielding a tuple are specified in :ref:`Tuple_Yield_Behavior`.
+
 When a ``return`` is encountered, the iterator finishes without yielding
 another index value. The ``return`` statements appearing in an iterator
 are not permitted to have a return expression. An iterator also
@@ -117,7 +124,8 @@ Iterators in For and Forall Loops
 
 When an iterator is accessed via a for or forall loop, the iterator is
 evaluated alongside the loop body in an interleaved manner. For each
-iteration, the iterator yields a value and the body is executed.
+iteration, the iterator yields a value or a reference
+and the loop body is executed.
 
 .. _Iterators_as_Arrays:
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -444,8 +444,8 @@ The In Intent
 
 When ``in`` is specified as the intent, the formal argument represents a
 variable that is initialized from the value of the actual argument.
-This initialization will be copy-initialization or move-initialization
-according to :ref:`Copy_and_Move_Initialization`.
+This initialization will be copy-initialization and may be changed to
+move-initialization according to :ref:`Copy_Elision`.
 
 For example, for integer arguments, the formal argument will store a copy
 of the actual argument.
@@ -546,8 +546,8 @@ The Const Ref Intent
 
 The ``const ref`` intent is identical to the ``ref`` intent, except that
 modifications to the formal argument are prohibited within the dynamic
-scope of the function. Note that concurrent tasks may modify the actual
-argument while the function is executing and that these modifications
+scope of the function. Note that the same or concurrent tasks may modify the
+actual argument while the function is executing and that these modifications
 may be visible to reads of the formal argument within the function’s
 dynamic scope (subject to the memory consistency model).
 
@@ -607,8 +607,8 @@ by default.  Exceptions are made for types where modification is
 considered part of their nature, such as types used for synchronization
 (like ``atomic``) and arrays.
 
-Default argument passing for tuples generally matches the default
-argument passing strategy that would be applied if each tuple element
+Default argument passing for tuples applies the default
+argument passing strategy to each tuple component as if it
 was passed as a separate argument. See :ref:`Tuple_Argument_Intents`.
 
 The :ref:`Abstract_Intents_Table` that follows defines the default
@@ -833,10 +833,27 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
 Return Intents
 --------------
 
-The ``return-intent`` specifies how the value is returned from a
-function, and in what contexts that function is allowed to be used. By
-default, or if the ``return-intent`` is ``const``, the function returns
-a value that cannot be used as an lvalue.
+The ``return-intent`` determines how the value is returned from a
+function and in what contexts that function is allowed to be used.
+The rules for returning tuples are specified in :ref:`Tuple_Return_Behavior`.
+
+.. _Default_Return_Intent:
+
+The Default Return Intent
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When no ``return-intent`` is specified explicitly, the function returns
+a value that cannot be used as an lvalue. This value is obtained
+by copy-initialization from the returned expression.
+This copy-initialization may be changed to move-initialization
+according to :ref:`Copy_Elision`.
+
+.. _Const_Return_Intent:
+
+The Const Return Intent
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``const`` return intent is identical to the default return intent.
 
 .. _Ref_Return_Intent:
 
@@ -848,7 +865,8 @@ When using a ``ref`` return intent, the function call is an lvalue
 variable for an iterator).
 
 The ``ref`` return intent is specified by following the argument list
-with the ``ref`` keyword. The function must return or yield an lvalue.
+with the ``ref`` keyword. The function must return an lvalue that
+exists outside of the function's scope.
 
    *Example (ref-return-intent.chpl)*.
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -443,9 +443,8 @@ The In Intent
 ^^^^^^^^^^^^^
 
 When ``in`` is specified as the intent, the formal argument represents a
-variable that is initialized from the value of the actual argument.
-This initialization will be copy-initialization and may be changed to
-move-initialization according to :ref:`Copy_Elision`.
+variable that is copy-initialized from the value of the actual argument,
+see :ref:`Copy_and_Move_Initialization`.
 
 For example, for integer arguments, the formal argument will store a copy
 of the actual argument.
@@ -844,9 +843,8 @@ The Default Return Intent
 
 When no ``return-intent`` is specified explicitly, the function returns
 a value that cannot be used as an lvalue. This value is obtained
-by copy-initialization from the returned expression.
-This copy-initialization may be changed to move-initialization
-according to :ref:`Copy_Elision`.
+by copy-initialization from the returned expression,
+see :ref:`Copy_and_Move_Initialization`.
 
 .. _Const_Return_Intent:
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -885,8 +885,10 @@ Ranges can be *sliced* using other ranges to create new sub-ranges. The
 resulting range represents the intersection between the two ranges’
 represented sequences. The stride, alignment, and bounds of the
 resulting range are adjusted as needed to make this true. ``idxType``
-of the result is determined by the first operand. The sign of the stride
-of the result is the product of the operand strides' signs.
+of the result is determined by the first operand.
+The stride of the result is of the same sign as the stride
+of the first operand if the second operand's stride is positive,
+and of the opposite sign otherwise.
 
 Range slicing is specified by the syntax: 
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -176,8 +176,6 @@ The type of a range is characterized by three properties:
 
 ``boundedType`` is one of the constants of the following enumeration:
 
-
-
 .. enum::   enum BoundedRangeType { bounded, boundedLow, boundedHigh, boundedNone };
 
 The value of ``boundedType`` determines which bounds of the range are
@@ -219,8 +217,6 @@ That is, a range type is obtained as if by invoking the range type
 constructor (:ref:`Type_Constructors`) that has the following
 header:
 
-
-
 .. code-block:: chapel
 
      proc range(type idxType = int,
@@ -236,13 +232,10 @@ its parameters, i.e., ``range(int, BoundedRangeType.bounded, false)``.
    The following declaration declares a variable ``r`` that can
    represent ranges of 32-bit integers, with both low and high bounds
    specified, and the ability to have a stride other than 1.
-   
 
    .. code-block:: chapel
 
       var r: range(int(32), BoundedRangeType.bounded, stridable=true);
-
-   
 
    .. BLOCK-test-chapelpost
 
@@ -250,8 +243,6 @@ its parameters, i.e., ``range(int, BoundedRangeType.bounded, false)``.
       var i32: int(32) = 3;
       r = i32..13 by 3 align 1;
       writeln(r);
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -273,8 +264,6 @@ Range Literals
 ~~~~~~~~~~~~~~
 
 Range literals are specified with the following syntax.
-
-
 
 .. code-block:: syntax
 
@@ -425,8 +414,6 @@ Range Comparisons
 
 Ranges can be compared using equality and inequality.
 
-
-
 .. function:: operator ==(r1: range(?), r2: range(?)): bool
 
    Returns ``true`` if the two ranges have the same represented sequence or
@@ -436,7 +423,7 @@ Ranges can be compared using equality and inequality.
 
    Returns ``false`` if the two ranges have the same represented sequence or
    the same four primary properties, and ``true`` otherwise.
-   
+
 .. _Iterating_over_Ranges:
 
 Iterating over Ranges
@@ -498,8 +485,6 @@ many indices as are needed to match its leader iterand.
       for i in zip(1..5, 3..) do
         write(i, "; ");
 
-   
-
    .. BLOCK-test-chapelpost
 
       writeln();
@@ -531,8 +516,6 @@ scalar function as described in :ref:`Promotion`.
    its actual argument, which will result in the function being
    invoked for each value in the range in a data-parallel manner.
 
-   
-
    .. code-block:: chapel
 
       proc addOne(x: int) {
@@ -541,13 +524,9 @@ scalar function as described in :ref:`Promotion`.
       var A: [1..10] int;
       A = addOne(1..10);
 
-   
-
    .. BLOCK-test-chapelpost
 
       writeln(A);
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -570,8 +549,6 @@ described in this section: stride (``by``), alignment (``align``), count
 (``#``) and slicing (``()`` or ``[]``). Chapel also defines a set
 of functions that operate on ranges. They are described in
 :ref:`Predefined_Range_Functions`.
-
-
 
 .. code-block:: syntax
 
@@ -649,14 +626,10 @@ following primary properties:
       var r1 = 1..20 by 2;
       var r2 = r1 by 2;
 
-   
-
    .. BLOCK-test-chapelpost
 
       writeln(r1);
       writeln(r2);
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -700,7 +673,6 @@ operand and therefore is not ambiguous.
 
    *Example (alignedStride.chpl)*.
 
-   
    .. BLOCK-test-chapelnoprint
       write("|");
 
@@ -730,7 +702,6 @@ When the stride is negative, the same indices are printed in reverse:
 
    *Example (alignedNegStride.chpl)*.
 
-   
    .. BLOCK-test-chapelnoprint
       write("|");
 
@@ -840,14 +811,10 @@ It is an error if the count is greater than the ``size`` of the range.
       var r3 = -6..6 by -2 # 3;
       var r4 = 1..#6 by -2;
 
-   
-
    .. BLOCK-test-chapelpost
 
       writeln(r1 == r2 && r2 == r3 && r3 == r4);
       writeln((r1, r2, r3, r4));
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -901,13 +868,9 @@ resulting range is also ambiguously aligned.
       var r = 0..3;
       var r2 = r + 1;    // 1..4
 
-   
-
    .. BLOCK-test-chapelpost
 
       writeln((r, r2));
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -920,9 +883,10 @@ Range Slicing
 
 Ranges can be *sliced* using other ranges to create new sub-ranges. The
 resulting range represents the intersection between the two ranges’
-represented sequences. The stride and alignment of the resulting range
-are adjusted as needed to make this true. ``idxType`` and the sign of
-the stride of the result are determined by the first operand.
+represented sequences. The stride, alignment, and bounds of the
+resulting range are adjusted as needed to make this true. ``idxType``
+of the result is determined by the first operand. The sign of the stride
+of the result is the product of the operand strides' signs.
 
 Range slicing is specified by the syntax: 
 
@@ -932,30 +896,7 @@ Range slicing is specified by the syntax:
      range-expression ( range-expression )
      range-expression [ range-expression ]
 
-If either of the operand ranges is ambiguously aligned, then the
-resulting range is also ambiguously aligned. In this case, the result is
-valid only if the strides of the operand ranges are relatively prime.
-Otherwise, an error is generated at run time.
-
-   *Rationale*.
-
-   If the strides of the two operand ranges are relatively prime, then
-   they are guaranteed to have some elements in their intersection,
-   regardless whether their relative alignment can be determined. In
-   that case, the bounds and stride in the resulting range are valid
-   with respect to the given inputs. The alignment can be supplied later
-   to create a valid range.
-
-   If the strides are not relatively prime, then the result of the
-   slicing operation would be completely ambiguous. The only reasonable
-   action for the implementation is to generate an error.
-
-If the resulting sequence cannot be expressed as a range of the original
-type, the slice expression evaluates to the empty range ``1..0``. This
-can happen, for example, when the operands represent all odd and all
-even numbers, or when the first operand is an unbounded range with
-unsigned ``idxType`` and the second operand represents only negative
-numbers.
+..
 
    *Example (rangeSlicing.chpl)*.
 
@@ -972,17 +913,33 @@ numbers.
       var r3 = r[1.. by 2];
       var r4 = r3[0.. by 3];
 
-   
-
    .. BLOCK-test-chapelpost
 
       writeln((r, r2, r3, r4));
 
-   
-
    .. BLOCK-test-chapeloutput
 
       (1..20, 3..20, 1..20 by 2, 1..20 by 6 align 3)
+
+It is an error for the first operand to be ambiguously aligned.
+If the second operand is ambiguously aligned, it is replaced
+with a range that is identical except it is given an alignment
+in such a way that that the intersection of the two ranges'
+represented sequences is non-empty, if possible.
+How this substitute alignment is chosen when multiple possibilities
+are availble is implementation-dependent.
+
+If the resulting sequence cannot be expressed as a range with the
+original ``idxType``, the slice expression evaluates to the empty
+range. This can happen, for example, when the first operand is an
+unbounded range with unsigned ``idxType`` and the second operand
+represents only negative numbers.
+
+If the resulting sequence is empty, the bounds, stride, and alignment
+of the resulting range are implementation-dependent.
+If the resulting sequence is empty and both operands are unbounded
+in the same direction, it is an error.
+
 
 .. _Predefined_Range_Functions:
 

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -726,9 +726,9 @@ Value Tuples and Referential Tuples
 -----------------------------------
 
 The terms referential tuple and value tuple describe two different ways
-that tuples capture their elements.
+that tuples capture their components.
 
-A *value tuple* stores all its elements by value and may store elements
+A *value tuple* stores all its components by value and may store components
 copy-initialized from another tuple. A value tuple is analogous to
 a group of formal arguments that each have the ``in`` intent.
 Value tuples include:
@@ -737,15 +737,11 @@ Value tuples include:
 - formal arguments with ``in`` intent that have a tuple type
 - tuples returned from functions with the default or ``const`` return intent
 
-A *referential tuple* stores its elements by value or by reference,
-as determined by the default argument intent of the element's type:
-
--  If the default intent is ``const ref`` or ``ref``,
-   the referential tuple's component is a reference.
-
--  Otherwise, the tuple's component stores a value of the component's type.
-
-Referential tuples are analogous to a group of function arguments
+A *referential tuple* stores its components by value or by reference,
+as determined by the default argument intent of the component's type:
+if it is ``const ref`` or ``ref``, the component is a reference,
+otherwise the component is stored by value, as though it had the ``in``
+intent. A referential tuple is analogous to a group of formal arguments
 that each have the default argument intent.
 Referential tuples include:
 
@@ -770,7 +766,7 @@ Referential tuples include:
    capture the value by reference in order to avoid a potentially
    expensive copy operation.
 
-In short, some or all of the elements of a referential tuple may be
+In short, some or all of the components of a referential tuple may be
 references, while a value tuple will never contain a reference.
 
    *Example (tuple-expression-behavior.chpl)*.
@@ -834,12 +830,11 @@ references, while a value tuple will never contain a reference.
 
       (0, 0, (x = 0))
 
-   Initialization of the tuple variable ``tup`` will make a copy of the
-   array ``a``, the record ``r``, and the integer ``i``. Because ``tup`` stores
-   a copy of these three variables, changes made to them are not visible
-   in ``tup`` when it is written to standard output.
-   Copy-initialization of the tuple's record component would be changed
-   to move-initialization if the record ``r`` were not used later.
+   Initialization of the tuple variable ``tup`` will copy-initialize
+   its components from the array ``a``, the record ``r``, and
+   the integer ``i``, see :ref:`Copy_and_Move_Initialization`.
+   Because ``tup`` stores a copy of these three variables, changes made
+   to them are not visible in ``tup`` when it is written to standard output.
 
 .. _Tuple_Argument_Intents:
 
@@ -850,7 +845,7 @@ A formal argument of a tuple type may be either a referential tuple or a value
 tuple depending on its argument intent.
 
 - If the tuple argument has the default argument intent, then it is a 
-  referential tuple and some of its elements may be captured by ``ref``
+  referential tuple and some of its components may be captured by ``ref``
   depending on their default argument intent.
   If a value tuple (such as a tuple variable) is passed to it, the value tuple
   will be implicitly converted into a referential tuple. The resulting
@@ -864,11 +859,12 @@ tuple depending on its argument intent.
 
 ..
 
-- If the tuple argument has the ``in`` or ``const in`` intent, then it is a
-  value tuple. Each of its components is copy-initialized or move-initialized
-  from the corresponding component of the actual argument as if it is passed
-  to an ``in`` intent argument, including the case where the actual argument
-  is a referential tuple.
+- If the tuple argument has the ``in`` or ``const in`` intent, then
+  it is a value tuple. Each of its components is copy-initialized
+  from the corresponding component of the actual argument as if it is
+  passed to an ``in`` intent formal argument. When the actual argument is
+  a referential tuple and the component is a reference,
+  the source of copy initialization is the variable being referenced.
   All components of a ``const in`` argument are considered to be ``const``
   and cannot be modified.
 

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -73,8 +73,6 @@ an integral parameter (a compile-time constant integer) and a type.
 
       writeln((x1,x2,x3));
 
-   
-
    .. BLOCK-test-chapeloutput
 
       ((, 0.0), (0, 0, 0), (0, 0, 0))
@@ -147,8 +145,6 @@ An underscore can be used to omit components when splitting a tuple
 
       writeln((x1,x2,x3));
 
-   
-
    .. BLOCK-test-chapeloutput
 
       ((hello, 3.14), (1, 2, 3), (4, 5, 6))
@@ -166,13 +162,10 @@ To specify a 1-tuple, use the form with the trailing comma ``(1,)``.
       var x: 1*int = (7,);
 
    creates a 1-tuple of integers storing the value 7.
-   
 
    .. BLOCK-test-chapelpost
 
-      writeln(x); 
-
-   
+      writeln(x);
 
    .. BLOCK-test-chapeloutput
 
@@ -207,7 +200,6 @@ compile-time constant) as if the tuple were an array. Indexing is
         writeln(myTuple(i));
 
    uses a param loop to output the components of a tuple.
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -372,8 +364,6 @@ is evaluated in component order.
 
       writeln((a, b, c));
 
-   
-
    .. BLOCK-test-chapeloutput
 
       (1, 2, 3)
@@ -397,7 +387,6 @@ is evaluated in component order.
    is created with array aliases (like a function call), the assignment
    to the second component uses the values just overwritten in the
    assignment to the first component. Line 4 outputs ``3 4 3 4``.
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -425,13 +414,10 @@ evaluated, but the omitted values will not be assigned to anything.
    variable ``x``, calls the function, assigns the first component in
    the returned tuple to ``x``, and ignores the other component in the
    returned tuple. The value of ``x`` becomes ``1``.
-   
 
    .. BLOCK-test-chapelpost
 
       writeln(x);
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -467,8 +453,6 @@ in :ref:`Variable_Declarations`.
 
       writeln((a, b, c));
 
-   
-
    .. BLOCK-test-chapeloutput
 
       (1, 2, 3)
@@ -490,8 +474,6 @@ parentheses.
    .. BLOCK-test-chapelpost
 
       writeln(a);
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -517,13 +499,10 @@ defined for the omitted components.
    declares and initializes variable ``x`` to the first component in the
    returned tuple, and ignores the other component in the returned
    tuple. The value of ``x`` is initialized to ``1``.
-   
 
    .. BLOCK-test-chapelpost
 
       writeln(x);
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -563,8 +542,8 @@ tuple must equal the size of the tuple returned by the iterator.
       4
 
 When a tuple is split across an index tuple, indices in the index tuple
-(left-hand side) may be omitted. In this case, no indices are defined
-for the omitted components.
+(left-hand side) may be omitted using underscores. In this case,
+no indices are defined for the omitted components.
 
 However even when indices are omitted, the iterator is evaluated as if
 an index were defined. Execution proceeds as if the omitted indices are
@@ -636,14 +615,11 @@ them.
       }
 
    except without the definition of the argument name ``t``.
-   
 
    .. BLOCK-test-chapelpost
 
       f((1, (2, 3)));
       g((1, (2, 3)));
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -662,7 +638,6 @@ destructured by enclosing a single formal argument in parentheses.
       proc f((x)) { }
 
    accepts a 1-tuple actual with any component type.
-   
 
    .. BLOCK-test-chapelpost
 
@@ -712,8 +687,6 @@ where a comma-separated list of components is valid.
 
       writeln(x3);
 
-   
-
    .. BLOCK-test-chapeloutput
 
       (1, 2.0, three, four)
@@ -737,14 +710,10 @@ where a comma-separated list of components is valid.
         return helper((...t));
       }
 
-   
-
    .. BLOCK-test-chapelpost
 
       writeln(first((1, 2, 3)));
       writeln(rest((1, 2, 3)));
-
-   
 
    .. BLOCK-test-chapeloutput
 
@@ -756,42 +725,57 @@ where a comma-separated list of components is valid.
 Value Tuples and Referential Tuples
 -----------------------------------
 
-Throughout the next few sections, the terms referential tuple and value
-tuple are used frequently to describe two different ways that tuples can
-capture elements.
+The terms referential tuple and value tuple describe two different ways
+that tuples capture their elements.
 
-Tuple expressions or tuple arguments with default argument intent are two
-examples of referential tuples. They store elements by reference where it
-makes sense to do so. Referential tuples may be viewed as analogous to a
-group of function arguments that each have default argument intent.
+A *value tuple* stores all its elements by value and may store elements
+copy-initialized from another tuple. A value tuple is analogous to
+a group of formal arguments that each have the ``in`` intent.
+Value tuples include:
 
-Tuple variables or tuple arguments with ``in`` intent are two examples of
-value tuples. They store all elements by value and may store elements copy
-initialized from another tuple. Value tuples may be viewed as analogous to
-a group of function arguments that each have the ``in`` intent.
+- tuple variables
+- formal arguments with ``in`` intent that have a tuple type
+- tuples returned from functions with the default or ``const`` return intent
+
+A *referential tuple* stores its elements by value or by reference,
+as determined by the default argument intent of the element's type:
+
+-  If the default intent is ``const ref`` or ``ref``,
+   the referential tuple's component is a reference.
+
+-  Otherwise, the tuple's component stores a value of the component's type.
+
+Referential tuples are analogous to a group of function arguments
+that each have the default argument intent.
+Referential tuples include:
+
+- tuple expressions
+- formal arguments with the default or ``const`` argument intent
+  that have a tuple type
+
+..
+
+   *Rationale*
+
+   Tuple expressions and other forms of referential tuple are designed to act
+   like a light-weight bundle of arguments. They behave similarly to the
+   individual arguments of a function call.
+
+   It would be prohibitively expensive for some argument types (such as
+   arrays) to be copied by default when passed as an argument to a
+   function call.
+
+   The same logic applies to tuple expressions. When the default argument
+   intent of a value's type is some form of ``ref``, a tuple expression will
+   capture the value by reference in order to avoid a potentially
+   expensive copy operation.
 
 In short, some or all of the elements of a referential tuple may be
 references, while a value tuple will never contain a reference.
 
-.. _Tuple_Expression_Behavior:
-
-Tuple Expression Behavior
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Tuple expressions are a form of referential tuple. Like most other
-referential tuples, tuple expressions capture each element based on the
-default argument intent of the element's type.
-
-More specifically:
-
--  If the default argument intent of the element's type is a variation of
-   ``ref``, then the tuple expression will refer to the element instead of
-   capturing it by value.
--  Otherwise, the tuple expression will capture the element by value.
-
-Consider the following example:
-
    *Example (tuple-expression-behavior.chpl)*.
+
+   In the following example:
 
    .. code-block:: chapel
 
@@ -821,34 +805,12 @@ Consider the following example:
 
       (1, 0, (x = 3))
 
-The tuple expression ``(a, i, r)`` will capture the array ``a`` and the
-record ``r`` by ``ref``, but will create a copy of the integer ``i``.
-
-   *Rationale*
-
-   Tuple expressions and other forms of referential tuple are designed to act
-   like a light-weight bundle of arguments. They behave similarly to the
-   individual arguments of a function call.
-
-   It would be prohibitively expensive for some argument types (such as
-   arrays) to be copied by default when passed as an argument to a
-   function call.
-
-   The same logic applies to tuple expressions. When the default argument
-   intent of a value's type is some form of ``ref``, a tuple expression will
-   capture the value by reference in order to avoid a potentially
-   expensive copy operation.
-
-Tuple Variable Behavior
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Tuple variables are a form of value tuple. Like other value tuples, tuple
-variables will copy elements in a manner similar to passing the element
-to an ``in`` intent argument.
-
-For example, in this code:
+   The tuple expression ``(a, i, r)`` will capture the array ``a`` and the
+   record ``r`` by reference, but will create a copy of the integer ``i``.
 
    *Example (tuple-variable-behavior.chpl)*.
+
+   In the following example:
 
    .. code-block:: chapel
 
@@ -872,47 +834,54 @@ For example, in this code:
 
       (0, 0, (x = 0))
 
-Initialization of the tuple variable ``tup`` will make a copy of the
-array ``a``, the record ``r``, and the integer ``i``. Because ``tup`` stores
-a copy of these three variables, changes made to them are not visible
-in ``tup`` when it is written to standard output.
+   Initialization of the tuple variable ``tup`` will make a copy of the
+   array ``a``, the record ``r``, and the integer ``i``. Because ``tup`` stores
+   a copy of these three variables, changes made to them are not visible
+   in ``tup`` when it is written to standard output.
+   Copy-initialization of the tuple's record component would be changed
+   to move-initialization if the record ``r`` were not used later.
 
 .. _Tuple_Argument_Intents:
 
 Tuple Argument Intents
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
-A tuple argument to a function may be either a referential tuple or a value
+A formal argument of a tuple type may be either a referential tuple or a value
 tuple depending on its argument intent.
 
-If the tuple argument has the default argument intent, then it is a 
-referential tuple and some of its elements may be captured by ``ref``
-depending on their default argument intent.
+- If the tuple argument has the default argument intent, then it is a 
+  referential tuple and some of its elements may be captured by ``ref``
+  depending on their default argument intent.
+  If a value tuple (such as a tuple variable) is passed to it, the value tuple
+  will be implicitly converted into a referential tuple. The resulting
+  referential tuple may refer to components from the original value tuple.
 
-A tuple argument declared with ``const`` intent will work similarly to one
-with a default intent, except that all the elements of the tuple are
-considered to be ``const`` and cannot be modified.
+..
 
-If the tuple argument has the ``in`` or ``const in`` intent, then it is a
-value tuple. All of its elements are captured by value as though each
-element is passed to an ``in`` intent argument.
+- A tuple argument declared with ``const`` intent works similarly to one
+  with a default intent, except that all the components of the tuple are
+  considered to be ``const`` and cannot be modified.
 
-.. _Tuple_Argument_Behavior:
+..
 
-Tuple Argument Behavior
-~~~~~~~~~~~~~~~~~~~~~~~
+- If the tuple argument has the ``in`` or ``const in`` intent, then it is a
+  value tuple. Each of its components is copy-initialized or move-initialized
+  from the corresponding component of the actual argument as if it is passed
+  to an ``in`` intent argument, including the case where the actual argument
+  is a referential tuple.
+  All components of a ``const in`` argument are considered to be ``const``
+  and cannot be modified.
 
-If a function argument is a tuple with the default argument intent and a
-value tuple (such as a tuple variable) is passed to it, the value tuple
-will be implicitly converted into a referential tuple. The resulting
-referential tuple may refer to elements from the original value tuple.
+..
 
-A conversion from referential tuple to value tuple also occurs when a
-referential tuple (such as a tuple expression) is passed to a tuple argument
-that has the ``in`` intent. The referential tuple will be converted to
-a value tuple by copy initializing each element.
+- If the tuple argument has the ``ref`` or ``const ref`` intent, then it is
+  a reference to a tuple from the call site.
+  The actual argument must be a value tuple (such as a tuple variable).
+  The formal argument will be a single reference to to that value tuple.
+  All components of a ``const ref`` argument are considered to be ``const``
+  and cannot be modified.
 
-Consider the following example:
+..
 
    *Example (tuple-argument-behavior.chpl)*.
 
@@ -964,11 +933,6 @@ Consider the following example:
       (0, (x = 6))
       (0, (x = 6))
 
-Tuple arguments with the ``ref`` intent are references to value tuples.
-Actual arguments are restricted to value tuples (a tuple variable or a
-returned tuple). Since the argument itself is passed by ``ref``, the
-entire tuple will refer to a tuple from the call site.
-
    *Example (tuple-argument-ref-intent.chpl)*.
 
    .. code-block:: chapel
@@ -999,16 +963,16 @@ entire tuple will refer to a tuple from the call site.
 .. _Tuple_Return_Behavior:
 
 Tuple Return Behavior
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
-When a tuple is returned from a function with ``ref`` or ``const ref`` return
-intent, it must refer to some form of value tuple that exists outside of
-the current scope. Otherwise there is a compilation error.
+Procedures with the default or ``const`` return intent always return
+a value tuple. If an expression returned by such a procedure is
+a referential tuple, it will be implicitly converted to a value tuple.
+
+When a tuple is returned from a procedure with ``ref`` or ``const ref`` 
+return intent, it must be a value tuple that exists outside of
+the procedure's scope. Otherwise there is a compilation error.
   
-Functions that return by value always return a value tuple. If an expression
-returned by such a function is a referential tuple, it will be implicitly
-converted to a value tuple.
-
    *Example (tuple-return-behavior.chpl)*.
 
    .. code-block:: chapel
@@ -1051,6 +1015,30 @@ converted to a value tuple.
    .. BLOCK-test-chapeloutput
 
       (0, 0, (x = 0))
+
+.. _Tuple_Yield_Behavior:
+
+Tuple Yield Behavior
+--------------------
+
+Iterators with the default or ``const`` return intent always yield
+a value tuple. If an expression yielded by such an iterator is
+a referential tuple, it will be implicitly converted to a value tuple.
+
+A tuple yielded from an iterator with ``ref`` or ``const ref``
+return intent must be a value tuple.
+
+   *Rationale*
+
+   Tuple yield behavior matches tuple return behavior, except
+   yielding a local tuple is allowed. This is because the iterator
+   will generally continue executing after the yield statement completes.
+
+..
+
+   *Open issue*.
+
+   We also need to provide a mechanism to yield referential tuples.
 
 .. _Tuple_Operators:
 

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -815,14 +815,15 @@ for records. In is also relevant for non-nilable ``owned`` class types
 since copies of those types will not be allowed by the compiler.
 
 After a *copy*, both the new variable and the initial variable exist
-separately. Generally speaking, they can both be modified.  However, they
-should generally refer to different storage. In particular, changing a
+separately. Generally speaking, they refer to different storage and
+can be modified independently.  For example, changing a
 field in the new record variable should not change the corresponding
 field in the initial record variable.
 
-A *move* is when a variable changes storage location. It is similar to a
+A *move* is when the value changes its storage location from the initial
+to the new variable. It is similar to a
 *copy initialization* but it represents a transfer rather than
-duplication. In particular, the initial record is no longer available
+duplication. In particular, the initial record variable is no longer available
 after the *move*.  A *move* can be thought of as an optimized form a
 *copy* followed by destruction of the initial record.  After a *move*,
 there is only one record variable - where after a *copy* there are two.

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -806,13 +806,18 @@ Copy and Move Initialization
 
 This section uses the terminology *copy* and *move*. These terms
 describe how a Chapel program initializes a variable based upon an
-existing variable. Both *copy* and *move* create a new variable
+existing variable. Both *copy* and *move* initialize a new variable
 from an initial variable.
+The compiler may change *copy initialization* to *move initialization*
+with :ref:`Copy_Elision`.
 
 Since records can use ``init=`` and ``deinit`` methods to adjust the
 behavior of copy initialization, this section is particularly relevant
 for records. In is also relevant for non-nilable ``owned`` class types
-since copies of those types will not be allowed by the compiler.
+since copies of those types will not be allowed by the compiler,
+and to strings, arrays, and domains that have record-like behavior
+in this regard. For records and other types that behave like
+"plain old data", *copy* and *move* are indistinguishable.
 
 After a *copy*, both the new variable and the initial variable exist
 separately. Generally speaking, they refer to different storage and
@@ -824,7 +829,7 @@ A *move* is when the value changes its storage location from the initial
 to the new variable. It is similar to a
 *copy initialization* but it represents a transfer rather than
 duplication. In particular, the initial record variable is no longer available
-after the *move*.  A *move* can be thought of as an optimized form a
+after the *move*.  A *move* can be thought of as an optimized form of a
 *copy* followed by destruction of the initial record.  After a *move*,
 there is only one record variable - where after a *copy* there are two.
 
@@ -894,7 +899,7 @@ local var last mention
   again - see :ref:`Copy_Elision` for further details
 
 local var mentioned again
-  means a use of a function-local variable which is mentioned again
+  means a use of a function-local variable which is mentioned again later
 
 outer/ref
   means a use of a module-scope variable, a variable in an outer


### PR DESCRIPTION
This updates the spec for the changes in:

* rules for range slicing #21760
* implementation of yielding tuples #21789

While there, clarify yielding by value (not just the tuples), reorg/tidy up the sections on value/referential tuples and tuple arg intents, and do some minor cleanups/updates.

Testing: local build of the docs.