### PR TITLE
docs(generics): add test for MemberWidth example

### DIFF
--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -815,8 +815,18 @@ instead.
          writeln(r.type:string);
       }
 
-   Running this example with ``--sbig=true`` will print out ``R(64)``, and with
-   ``--sbig=false`` or no argument it will print out ``R(32)``.
+
+   .. BLOCK-test-chapelexecopts
+      -sbig=true
+
+
+   .. BLOCK-test-chapeloutput
+      R(64)
+
+
+
+   Running this example with ``-sbig=true`` will print out ``R(64)``, and with
+   ``-sbig=false`` or no argument it will print out ``R(32)``.
 
 .. _Fields_without_Types:
 


### PR DESCRIPTION
This PR fixes failing spectests that started after https://github.com/chapel-lang/chapel/pull/21902. This commit was supposed to be part of that PR, but didn't get pushed prior to it being merged due to user error (It was ME!)

The test was missing the command-line execopts and known good output to compare.

TESTING:

- [x] `make spectests` and test `MemberWidth.chpl`

reviewed by @mppf 