### PR TITLE
test(build): set flag to make nightly and CI builds more verbose

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   NIGHTLY_TEST_SETTINGS: true
+  CMAKE_VERBOSE_MAKEFILE: ON
 
 # NOTE: each job has to specify the container section in its entirety, which is
 # certainly repetetive, but the `defaults` section can't be applied and the `env`
@@ -39,7 +40,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v3 
+    - uses: actions/checkout@v3
     - name: make frontend-docs
       run: |
         make frontend-docs
@@ -109,7 +110,7 @@ jobs:
         fetch-depth: 100000
     - name: Set ownership
       run: |
-        chown -R $(id -u):$(id -g) $PWD   
+        chown -R $(id -u):$(id -g) $PWD
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls

--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -6,6 +6,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/functions.bash
 
+export CMAKE_VERBOSE_MAKEFILE=ON
+
 # For our internal testing, this is necessary to get the latest version of gcc
 # on the system.
 if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then


### PR DESCRIPTION
This PR sets the `CMAKE_VERBOSE_MAKEFILE` flag on for nightly builds (via the `util/cron/common.bash` script) and for CI checks (via `CI.yaml`).

The purpose is to capture the compiler commands with flags for each source file that is built using CMake in the logs, to aid in troubleshooting failed builds.