### PR TITLE
Improve deprecation filtering for comments using '~' and '!'

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -37,6 +37,7 @@
 #include "type.h"
 #include "wellknown.h"
 #include "chpl/uast/OpCall.h"
+#include "chpl/util/filtering.h"
 
 #include "global-ast-vecs.h"
 
@@ -469,19 +470,7 @@ const char* Symbol::getUnstableMsg() const {
 // https://chapel-lang.org/docs/latest/tools/chpldoc/chpldoc.html#inline-markup-2
 // for information on the markup.
 const char* Symbol::getSanitizedMsg(std::string msg) const {
-  // TODO: Support explicit title and reference targets like in reST direct hyperlinks (and having only target
-  //       show up in sanitized message).
-  static const auto reStr = R"#(\B\:(?:mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`(?:([$\w\$\.]+)|(?:~([$\w\$]+\.?)+)|(?:!([$\w\$\.]+)))`\B)#";
-  std::smatch match;
-  while(std::regex_search(msg, match, std::regex(reStr))) {
-    for(auto i = 1; i < match.size(); i++) {
-      if(match[i].matched) {
-        msg = astr(match.prefix().str() + match[i].str() + match.suffix().str());
-        break;
-      }
-    }
-  }
-  return astr(msg);
+  return astr(chpl::removeSphinxMarkup(msg));
 }
 void Symbol::generateDeprecationWarning(Expr* context) {
   Symbol* contextParent = context->parentSymbol;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -471,10 +471,17 @@ const char* Symbol::getUnstableMsg() const {
 const char* Symbol::getSanitizedMsg(std::string msg) const {
   // TODO: Support explicit title and reference targets like in reST direct hyperlinks (and having only target
   //       show up in sanitized message).
-  // TODO: Allow prefixing content with ! (and filtering it out in the sanitized message)
-  static const auto reStr = R"(\B\:(mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`((?:[!$\w\$\.]+)|(?:~[$\w\$]+\.?))+`\B)";
-  msg = std::regex_replace(msg, std::regex(reStr), "$2");
-  return astr(msg.c_str());
+  static const auto reStr = R"#(\B\:(?:mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`(?:([$\w\$\.]+)|(?:~([$\w\$]+\.?)+)|(?:!([$\w\$\.]+)))`\B)#";
+  std::smatch match;
+  while(std::regex_search(msg, match, std::regex(reStr))) {
+    for(auto i = 1; i < match.size(); i++) {
+      if(match[i].matched) {
+        msg = astr(match.prefix().str() + match[i].str() + match.suffix().str());
+        break;
+      }
+    }
+  }
+  return astr(msg);
 }
 void Symbol::generateDeprecationWarning(Expr* context) {
   Symbol* contextParent = context->parentSymbol;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -472,12 +472,10 @@ const char* Symbol::getSanitizedMsg(std::string msg) const {
   // TODO: Support explicit title and reference targets like in reST direct hyperlinks (and having only target
   //       show up in sanitized message).
   // TODO: Allow prefixing content with ! (and filtering it out in the sanitized message)
-  // TODO: Allow prefixing content with ~ (and having it only display last component of target)
-  static const auto reStr = R"(\B\:(mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`([!$\w\$\.]+)`\B)";
+  static const auto reStr = R"(\B\:(mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`((?:[!$\w\$\.]+)|(?:~[$\w\$]+\.?))+`\B)";
   msg = std::regex_replace(msg, std::regex(reStr), "$2");
   return astr(msg.c_str());
 }
-
 void Symbol::generateDeprecationWarning(Expr* context) {
   Symbol* contextParent = context->parentSymbol;
   bool parentDeprecated = contextParent->hasFlag(FLAG_DEPRECATED);

--- a/frontend/include/chpl/util/filtering.h
+++ b/frontend/include/chpl/util/filtering.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_UTIL_FILTERING_H
+#define CHPL_UTIL_FILTERING_H
+
+#include <string>
+
+namespace chpl
+{
+
+/*
+  Removes the Sphinx inline markup for printing messages to the console.
+  See https://chapel-lang.org/docs/latest/tools/chpldoc/chpldoc.html#inline-markup-2
+*/
+std::string removeSphinxMarkup(const std::string& msg);
+
+} // namespace chpl
+
+
+#endif // CHPL_UTIL_FILTERING_H

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1329,9 +1329,9 @@ removeSphinxMarkupFromWarningMessage(const std::string msg) {
   // TODO: Support explicit title and reference targets like in reST direct
   // hyperlinks (and having only target show up in sanitized message).
   // TODO: Prefixing content with ! (and filtering it out)
-  // TODO: Prefixing content with ~ (and displaying only the last component)
   static const auto re = R"(\B\:(mod|proc|iter|data|const|var|param|enum)"
-                         R"(|type|class|record|attr)\:`([!$\w\$\.]+)`\B)";
+                         R"(|type|class|record|attr)\:"
+                         R"`((?:[!$\w\$\.]+)|(?:~[$\w\$]+\.?))+`\B)";
   auto ret = std::regex_replace(msg, std::regex(re), "$2");
   return ret;
 }

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1328,16 +1328,17 @@ removeSphinxMarkupFromWarningMessage(const std::string msg) {
   // TODO: Support explicit title and reference targets like in reST direct hyperlinks (and having only target
   //       show up in sanitized message).
   static const auto reStr = R"#(\B\:(?:mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`(?:([$\w\$\.]+)|(?:~([$\w\$]+\.?)+)|(?:!([$\w\$\.]+)))`\B)#";
+  std::string filteredMsg = msg;
   std::smatch match;
-  while(std::regex_search(msg, match, std::regex(reStr))) {
+  while(std::regex_search(filteredMsg, match, std::regex(reStr))) {
     for(auto i = 1; i < match.size(); i++) {
       if(match[i].matched) {
-        msg = astr(match.prefix().str() + match[i].str() + match.suffix().str());
+        filteredMsg = match.prefix().str() + match[i].str() + match.suffix().str();
         break;
       }
     }
   }
-  return astr(msg);
+  return filteredMsg;
 }
 
 static std::string

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1325,15 +1325,19 @@ static bool isAstFormal(Context* context, const AstNode* ast) {
 // https://chapel-lang.org/docs/latest/tools/chpldoc/chpldoc.html#inline-markup-2
 static std::string
 removeSphinxMarkupFromWarningMessage(const std::string msg) {
-
-  // TODO: Support explicit title and reference targets like in reST direct
-  // hyperlinks (and having only target show up in sanitized message).
-  // TODO: Prefixing content with ! (and filtering it out)
-  static const auto re = R"(\B\:(mod|proc|iter|data|const|var|param|enum)"
-                         R"(|type|class|record|attr)\:"
-                         R"`((?:[!$\w\$\.]+)|(?:~[$\w\$]+\.?))+`\B)";
-  auto ret = std::regex_replace(msg, std::regex(re), "$2");
-  return ret;
+  // TODO: Support explicit title and reference targets like in reST direct hyperlinks (and having only target
+  //       show up in sanitized message).
+  static const auto reStr = R"#(\B\:(?:mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`(?:([$\w\$\.]+)|(?:~([$\w\$]+\.?)+)|(?:!([$\w\$\.]+)))`\B)#";
+  std::smatch match;
+  while(std::regex_search(msg, match, std::regex(reStr))) {
+    for(auto i = 1; i < match.size(); i++) {
+      if(match[i].matched) {
+        msg = astr(match.prefix().str() + match[i].str() + match.suffix().str());
+        break;
+      }
+    }
+  }
+  return astr(msg);
 }
 
 static std::string

--- a/frontend/lib/util/CMakeLists.txt
+++ b/frontend/lib/util/CMakeLists.txt
@@ -36,4 +36,5 @@ target_sources(ChplFrontend-obj
                subprocess.cpp
                terminal.cpp
                version-info.cpp
+               filtering.cpp
               )

--- a/frontend/lib/util/filtering.cpp
+++ b/frontend/lib/util/filtering.cpp
@@ -40,12 +40,12 @@ namespace {
 
     // There are three "kinds" of content we consider, so we OR these together
     // Capture a normal Chapel identifier
-    std::string reCntType1 = R"#(([$\w\$\.]+))#";
+    std::string reCntType1 = R"#(([\w$.]+))#";
     // If it starts with ~, capture last identifier to the right of a '.'
     // Note in a repeated capture group (e.g. `(\w\.?)+` only the last iteration is captured
-    std::string reCntType2 = R"#(~([$\w\$]+\.?)+)#";
+    std::string reCntType2 = R"#(~([\w$]+\.?)+)#";
     // Starts with !, capture identifier to right of ! without capturing ! itself
-    std::string reCntType3 = R"#(!([$\w\$\.]+))#";
+    std::string reCntType3 = R"#(!([\w$.]+))#";
 
     // OR all the content types together, wrapping each in a non capturing group
     std::string reContent = "(?:(?:" + reCntType1 + ")|(?:" + reCntType2 + ")|(?:" + reCntType3 + "))";

--- a/frontend/lib/util/filtering.cpp
+++ b/frontend/lib/util/filtering.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/util/filtering.h"
+#include <regex>
+
+namespace chpl {
+
+std::string removeSphinxMarkup(const std::string& msg) {
+  // TODO: Support explicit title and reference targets like in reST direct hyperlinks (and having only target
+  //       show up in sanitized message).
+  static const auto reStr = R"#(\B\:(?:mod|proc|iter|data|const|var|param|type|class|record|attr|enum)\:`(?:([$\w\$\.]+)|(?:~([$\w\$]+\.?)+)|(?:!([$\w\$\.]+)))`\B)#";
+  std::string filteredMsg = msg;
+  std::smatch match;
+  while(std::regex_search(filteredMsg, match, std::regex(reStr))) {
+    for(size_t i = 1; i < match.size(); i++) {
+      if(match[i].matched) {
+        filteredMsg = match.prefix().str() + match[i].str() + match.suffix().str();
+        break;
+      }
+    }
+  }
+  return filteredMsg;
+}
+
+} // namespace chpl

--- a/test/deprecated-keyword/messageFiltering.chpl
+++ b/test/deprecated-keyword/messageFiltering.chpl
@@ -171,8 +171,8 @@ var x1101 = 1101;
 @deprecated(notes="Lorem ipsum :proc:`!abc` dolor sit amet")
 var x1102 = 1102;
 
-// Currently filters, but ideally wouldn't (see #18549):
-@deprecated(notes="--- Currently filters, but ideally wouldn't (see #18549) ---")
+// Prefixed with ~, should filter to just last component
+@deprecated(notes="--- Prefixed with ~, should filter to just last component ---")
 var x1200 = 1200;
 @deprecated(notes="Lorem ipsum :proc:`~abc.def` dolor sit amet")
 var x1201 = 1201;

--- a/test/deprecated-keyword/messageFiltering.chpl
+++ b/test/deprecated-keyword/messageFiltering.chpl
@@ -166,16 +166,20 @@ var x9003 = 9003;
 var x9004 = 9004;
 
 // Proc lead with ! (should filter)
-@deprecated(notes="--- Identifier is led with ! (should filter) ---")
+@deprecated(notes="--- Identifier is led with ! (should filter if well formed) ---")
 var x1101 = 1101;
 @deprecated(notes="Lorem ipsum :proc:`!abc` dolor sit amet")
 var x1102 = 1102;
+@deprecated(notes="Lorem ipsum :proc:`a!bc` dolor sit amet")
+var x1103 = 1103;
 
 // Prefixed with ~, should filter to just last component
-@deprecated(notes="--- Prefixed with ~, should filter to just last component ---")
+@deprecated(notes="--- Prefixed with ~, should filter to just last component if well formed ---")
 var x1200 = 1200;
 @deprecated(notes="Lorem ipsum :proc:`~abc.def` dolor sit amet")
 var x1201 = 1201;
+@deprecated(notes="Lorem ipsum :proc:`a~bc.def` dolor sit amet")
+var x1202 = 1202;
 
 // I purposefully access each variable on a separate line so the produced warning messages
 // will also have unique lines:
@@ -264,6 +268,8 @@ writeln(x9004);
 
 writeln(x1101);
 writeln(x1102);
+writeln(x1103);
 
 writeln(x1200);
 writeln(x1201);
+writeln(x1202);

--- a/test/deprecated-keyword/messageFiltering.good
+++ b/test/deprecated-keyword/messageFiltering.good
@@ -73,8 +73,8 @@ messageFiltering.chpl:n: warning: Lorem ipsum abc$def$ dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum abc$def$ghi dolor sit amet
 messageFiltering.chpl:n: warning: --- Identifier is led with ! (should filter) ---
 messageFiltering.chpl:n: warning: Lorem ipsum !abc dolor sit amet
-messageFiltering.chpl:n: warning: --- Currently filters, but ideally wouldn't (see #18549) ---
-messageFiltering.chpl:n: warning: Lorem ipsum :proc:`~abc.def` dolor sit amet
+messageFiltering.chpl:n: warning: --- Prefixed with ~, should filter to just last component ---
+messageFiltering.chpl:n: warning: Lorem ipsum def dolor sit amet
 1000
 1001
 1002

--- a/test/deprecated-keyword/messageFiltering.good
+++ b/test/deprecated-keyword/messageFiltering.good
@@ -71,10 +71,12 @@ messageFiltering.chpl:n: warning: Lorem ipsum abc$ dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum abc$def dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum abc$def$ dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum abc$def$ghi dolor sit amet
-messageFiltering.chpl:n: warning: --- Identifier is led with ! (should filter) ---
-messageFiltering.chpl:n: warning: Lorem ipsum !abc dolor sit amet
-messageFiltering.chpl:n: warning: --- Prefixed with ~, should filter to just last component ---
+messageFiltering.chpl:n: warning: --- Identifier is led with ! (should filter if well formed) ---
+messageFiltering.chpl:n: warning: Lorem ipsum abc dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`a!bc` dolor sit amet
+messageFiltering.chpl:n: warning: --- Prefixed with ~, should filter to just last component if well formed ---
 messageFiltering.chpl:n: warning: Lorem ipsum def dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`a~bc.def` dolor sit amet
 1000
 1001
 1002
@@ -150,5 +152,7 @@ messageFiltering.chpl:n: warning: Lorem ipsum def dolor sit amet
 9004
 1101
 1102
+1103
 1200
 1201
+1202

--- a/test/deprecated/HDFS/HDFS-open-iomode.good
+++ b/test/deprecated/HDFS/HDFS-open-iomode.good
@@ -1,6 +1,6 @@
 HDFS-open-iomode.chpl:6: In function 'main':
 HDFS-open-iomode.chpl:12: warning: enum iomode is deprecated - please use ioMode instead
 HDFS-open-iomode.chpl:20: warning: enum iomode is deprecated - please use ioMode instead
-HDFS-open-iomode.chpl:12: warning: open with an iomode argument is deprecated - please use ~IO.ioMode
-HDFS-open-iomode.chpl:20: warning: open with an iomode argument is deprecated - please use ~IO.ioMode
+HDFS-open-iomode.chpl:12: warning: open with an iomode argument is deprecated - please use ioMode
+HDFS-open-iomode.chpl:20: warning: open with an iomode argument is deprecated - please use ioMode
 Test file matches, OK


### PR DESCRIPTION
Inline markup filtering for deprecation messages was not filtering out a
'~'. This PR adds filtering for this, filtering out all components
except the last one.
This PR also implements better filtering for '!'

## Summary of changes
- The string ':proc:\`~abc.def\`' was filtered to '~abc.def', now it
filters to 'def'.
- The string ':proc:\`!abc.def\`' was filtered to '!abc.def', now it
filters to 'abc.def'.
- update tests to reflect new filtered string
- update the only usage of '~' in HDFS deprecations
- remove duplicated regular expression

## testing
- tested changes locally

---
Resolves some of the todo tasks mentioned in #18549

[Reviewed by @stonea]