### PR TITLE
For clang, move `-W[missing|strict]-prototypes` to `WARN_CXXFLAGS` from `WARN_CFLAGS`

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -124,8 +124,8 @@ endif
 #
 # Flags for turning on warnings for C++/C code
 #
-WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing -Wmissing-declarations -Wmissing-braces
-WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
+WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wmissing-braces
+WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized
 


### PR DESCRIPTION
...so that they will apply to both C++ and C compiles.

The motivation for this is that our CI testing was catching things with g++ that we weren't catching as developers using clang++.  This should bring the clang++ warnings more in-line with what we're getting from g++.

It looks to me as though it's been this way since we first added support for clang, so putting them in both was either an oversight, or perhaps they weren't supported by clang++ back then.  I also get the sense (though I didn't look into it very carefully) that g++ and clang++ may have slightly different warnings associated with different flags in their C/C++ compilers.  In any case, my guess is that this will help any developers using warnings in recent versions of clang++, but please alert me if that's incorrect.