### PR TITLE
Deprecate auto-included version of carg and move it to the Math module

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -174,9 +174,18 @@ module AutoMath {
       return cabs(z);
   }
 
-
-  /* Returns the real phase angle of complex argument `z`. */
+  // When removing this deprecated function, be sure to remove chpl_carg and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @chpldoc.nodoc
+  @deprecated(notes="carg will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc carg(z: complex(?w)): real(w/2) {
+    return chpl_carg(z);
+  }
+
+  @chpldoc.nodoc
+  inline proc chpl_carg(z: complex(?w)): real(w/2) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc cargf(z: complex(64)): real(32);

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -157,9 +157,12 @@ module AutoMath {
     return fabsf(_i2r(im));
   }
 
-  /* Returns the real magnitude of the complex argument `z`.
+  /* Returns the magnitude (often called modulus) of complex `z`.
 
-     :rtype: The type of the real component of the argument (== `w`/2).
+     In concert with the related :proc:`~Math.carg`, the phase (a.k.a. argument)
+     of `z`, it can be used to recompute `z`.
+
+     :rtype: ``real(w/2)`` when `z` has a type of ``complex(w)``.
   */
   inline proc abs(z : complex(?w)): real(w/2) {
     pragma "fn synchronization free"

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -182,7 +182,7 @@ module AutoMath {
   // module.
   pragma "last resort"
   @chpldoc.nodoc
-  @deprecated(notes="carg will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it")
+  @deprecated(notes="In an upcoming release 'carg' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc carg(z: complex(?w)): real(w/2) {
     return chpl_carg(z);
   }

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -46,6 +46,11 @@ module Math {
   private use CTypes;
   private use AutoMath;
 
+  /* Returns the real phase angle of complex argument `z`. */
+  inline proc carg(z: complex(?w)): real(w/2) {
+    return chpl_carg(z);
+  }
+
   /* Returns the natural logarithm of `x` + 1.
 
      It is an error if `x` is less than or equal to -1.

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -46,7 +46,14 @@ module Math {
   private use CTypes;
   private use AutoMath;
 
-  /* Returns the real phase angle of complex argument `z`. */
+  /* Returns the phase (often called `argument`) of complex `z`, an angle (in
+     radians).
+
+     In concert with the related :proc:`~AutoMath.abs`, the magnitude (a.k.a.
+     modulus) of `z`, it can be used to recompute `z`.
+
+     :rtype: ``real(w/2)`` when `z` has a type of ``complex(w)``.
+  */
   inline proc carg(z: complex(?w)): real(w/2) {
     return chpl_carg(z);
   }

--- a/test/deprecated/Math/cargDep.chpl
+++ b/test/deprecated/Math/cargDep.chpl
@@ -1,0 +1,14 @@
+// Copied and reduced from test/types/complex/diten/cplxMathFnTypes.chpl
+
+proc testType(x: complex(?w)) {
+  const res2 = carg(x); // Should trigger the deprecation warning
+  assert(res2.type == real(w/2));
+}
+
+var c64 = 1.0:real(32) + 2.0i:imag(32);
+var c128 = 1.0: real(64) + 2.0i: imag(64);
+
+// Both calls cause this deprecation message because they result in different
+// instantiations
+testType(c64);
+testType(c128);

--- a/test/deprecated/Math/cargDep.good
+++ b/test/deprecated/Math/cargDep.good
@@ -1,0 +1,4 @@
+cargDep.chpl:3: In function 'testType':
+cargDep.chpl:4: warning: carg will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it
+cargDep.chpl:3: In function 'testType':
+cargDep.chpl:4: warning: carg will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it

--- a/test/deprecated/Math/cargDep.good
+++ b/test/deprecated/Math/cargDep.good
@@ -1,4 +1,4 @@
 cargDep.chpl:3: In function 'testType':
-cargDep.chpl:4: warning: carg will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it
+cargDep.chpl:4: warning: In an upcoming release 'carg' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it
 cargDep.chpl:3: In function 'testType':
-cargDep.chpl:4: warning: carg will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it
+cargDep.chpl:4: warning: In an upcoming release 'carg' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it

--- a/test/types/complex/diten/cplxMathFnTypes.chpl
+++ b/test/types/complex/diten/cplxMathFnTypes.chpl
@@ -1,3 +1,5 @@
+use Math;
+
 proc testTypes(x: complex(?w)) {
   const res1 = abs(x);
   assert(res1.type == real(w/2));


### PR DESCRIPTION
We don't want to include this function in all programs.

<details>

The commit for this ends up looking a little odd so that we don't accidentally
build the Math module by default as well - make an undocumented version that
Math and the deprecated version can call, so that Math depends on AutoMath and
the two versions stay in sync until the deprecated version is removed.  This
strategy was previously followed for other symbols in the Math module.

</details>

While here, adjust the documentation for `carg` and the related version of `abs`.
`abs` of complex arguments is closely related to `carg`, so add documentation
links now that they are a little more separated.  Also, be more specific and
accurate when describing their functionality.  Documentation changes suggested
by Damian.

Adjusted a test that used `carg` to have a 'use' of the Math module to
avoid triggering the deprecation warning.  Add a test of the deprecation warning

Passed a full paratest