### PR TITLE
Convert some new ioHintSet.noMmaps to ioHintset.mmap(false)

### DIFF
--- a/test/io/corrado/write_buffering_optimization/dynamic_buffering.chpl
+++ b/test/io/corrado/write_buffering_optimization/dynamic_buffering.chpl
@@ -11,7 +11,7 @@ qio_write_unbuffered_threshold = unbuffThreshold:c_ssize_t;
 qbytes_iobuf_size = iobuffSize:c_size_t;
 
 proc testDB(s: int): bool {
-  const w = openWriter("./db.bin", locking=false, hints = ioHintSet.noMmap);
+  const w = openWriter("./db.bin", locking=false, hints = ioHintSet.mmap(false));
 
   // put something small in the buffer to start with
   if smallWriteSize > 0 {

--- a/test/io/corrado/write_buffering_optimization/growing_buff_write.chpl
+++ b/test/io/corrado/write_buffering_optimization/growing_buff_write.chpl
@@ -12,7 +12,7 @@ var bufSize = 128,
     bufDom = {0..<bufSize},
     buf : [bufDom] uint(8);
 
-const fw = openWriter("gb.bin", locking=false, hints=ioHintSet.noMmap);
+const fw = openWriter("gb.bin", locking=false, hints=ioHintSet.mmap(false));
 
 var i : uint(8) = 1;
 while bufSize < maxBufSize {

--- a/test/io/corrado/write_buffering_optimization/large_write.chpl
+++ b/test/io/corrado/write_buffering_optimization/large_write.chpl
@@ -2,7 +2,7 @@ use IO, CTypes, FileSystem;
 
 config const size = 1024: int(64);
 
-const w = openWriter("./x.bin", locking=false, hints=ioHintSet.noMmap);
+const w = openWriter("./x.bin", locking=false, hints=ioHintSet.mmap(false));
 var a = [i in 0..<size] i;
 w.writeBinary(c_ptrTo(a), size*8);
 w.write("yep");


### PR DESCRIPTION
This fixes up a few tests that were added in #21786, presumably developed before noMmap was deprecated, but merged afterwards, in hopes of not having them fail tonight.