### PR TITLE
Fix array localization in `writeBinary(data: [])`

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -7568,7 +7568,7 @@ proc fileWriter.writeBinary(b: bytes, size: int = b.size) throws {
                                could be written.
 */
 proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioendian.native) throws
-  where (d.rank == 1 && d.stridable == false) && (
+  where (d.rank == 1 && d.stridable == false && !d.isSparse()) && (
           isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t))
 {
   var e : errorCode = 0;
@@ -7577,7 +7577,7 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
     try this.lock(); defer { this.unlock(); }
     const tSize = c_sizeof(t) : c_ssize_t;
 
-    if endian == ioendian.native && data.locale == this._home {
+    if endian == ioendian.native && data.locale == this._home && data.isDefaultRectangular() {
       e = try qio_channel_write_amt(false, this._channel_internal, data[0], data.size:c_ssize_t * tSize);
 
       if e == EEOF {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -7575,10 +7575,11 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
 
   on this._home {
     try this.lock(); defer { this.unlock(); }
-    const tSize = c_sizeof(t) : c_ssize_t;
+    const tSize = c_sizeof(t) : c_ssize_t,
+          dlocal = data;
 
     if endian == ioendian.native {
-      e = try qio_channel_write_amt(false, this._channel_internal, data[0], data.size:c_ssize_t * tSize);
+      e = try qio_channel_write_amt(false, this._channel_internal, dlocal[0], data.size:c_ssize_t * tSize);
 
       if e == EEOF {
         throw new owned UnexpectedEofError("Unable to write entire array of values in 'writeBinary'");
@@ -7586,7 +7587,7 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
         throw createSystemOrChplError(e);
       }
     } else {
-      for b in data {
+      for b in dlocal {
         select (endian) {
           when ioendian.native { }
           when ioendian.big {


### PR DESCRIPTION
This PR resolves a test failure introduced by https://github.com/chapel-lang/chapel/pull/21786, where `writeBinary` would pass a pointer to a remote array into an external C function.  This call is now only made if the array is local.

- [x] paratest
- [x] gasnet paratest