### PR TITLE
Deprecate including cproj by default and move it to the Math module

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -496,8 +496,18 @@ module AutoMath {
     return z;
   }
 
-  /* Returns the projection of `z` on a Riemann sphere. */
+  // When removing this deprecated function, be sure to remove chpl_carg and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @chpldoc.nodoc
+  @deprecated(notes="cproj will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc cproj(z: complex(?w)): complex(w) {
+    return chpl_cproj(z);
+  }
+
+  @chpldoc.nodoc
+  inline proc chpl_cproj(z: complex(?w)): complex(w) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc cprojf(z: complex(64)): complex(64);

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -501,7 +501,7 @@ module AutoMath {
   // module.
   pragma "last resort"
   @chpldoc.nodoc
-  @deprecated(notes="cproj will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it")
+  @deprecated(notes="In an upcoming release 'cproj' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc cproj(z: complex(?w)): complex(w) {
     return chpl_cproj(z);
   }

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -496,7 +496,7 @@ module AutoMath {
     return z;
   }
 
-  // When removing this deprecated function, be sure to remove chpl_carg and
+  // When removing this deprecated function, be sure to remove chpl_cproj and
   // move its contents into Math.chpl to reduce the symbols living in this
   // module.
   pragma "last resort"

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -58,6 +58,11 @@ module Math {
     return chpl_carg(z);
   }
 
+  /* Returns the projection of `z` on a Riemann sphere. */
+  inline proc cproj(z: complex(?w)): complex(w) {
+    return chpl_cproj(z);
+  }
+
   /* Returns the natural logarithm of `x` + 1.
 
      It is an error if `x` is less than or equal to -1.

--- a/test/deprecated/Math/cprojDep.chpl
+++ b/test/deprecated/Math/cprojDep.chpl
@@ -1,0 +1,14 @@
+// Copied and reduced from test/types/complex/diten/cplxMathFnTypes.chpl
+
+proc testType(x: complex(?w)) {
+  const res4 = cproj(x); // Should trigger the deprecation warning
+  assert(res4.type == complex(w));
+}
+
+var c64 = 1.0:real(32) + 2.0i:imag(32);
+var c128 = 1.0: real(64) + 2.0i: imag(64);
+
+// Both calls cause this deprecation message because they result in different
+// instantiations
+testType(c64);
+testType(c128);

--- a/test/deprecated/Math/cprojDep.good
+++ b/test/deprecated/Math/cprojDep.good
@@ -1,4 +1,4 @@
 cprojDep.chpl:3: In function 'testType':
-cprojDep.chpl:4: warning: cproj will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it
+cprojDep.chpl:4: warning: In an upcoming release 'cproj' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it
 cprojDep.chpl:3: In function 'testType':
-cprojDep.chpl:4: warning: cproj will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it
+cprojDep.chpl:4: warning: In an upcoming release 'cproj' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it

--- a/test/deprecated/Math/cprojDep.good
+++ b/test/deprecated/Math/cprojDep.good
@@ -1,0 +1,4 @@
+cprojDep.chpl:3: In function 'testType':
+cprojDep.chpl:4: warning: cproj will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it
+cprojDep.chpl:3: In function 'testType':
+cprojDep.chpl:4: warning: cproj will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it


### PR DESCRIPTION
We don't want to include this function in all programs.

<details>
The commit for this ends up looking a little odd so that we don't accidentally
build the Math module by default as well - make an undocumented version that
Math and the deprecated version can call, so that Math depends on AutoMath and
the two versions stay in sync until the deprecated version is removed. This
strategy was previously followed for other symbols in the Math module.
</details>

Adds a test locking in the deprecation warning.

Note that this does not modify any tests because the test that uses it already
has a use of the Math module (due to #21950)

Passed a full paratest with futures