### PR TITLE
Fix problem running 'make' with CC and CXX set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,13 +284,18 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E env
                 OUTPUT_STRIP_TRAILING_WHITESPACE
                 )
 
+if(CHPLENV_RETURNCODE AND NOT CHPLENV_RETURNCODE EQUAL 0)
+  message(FATAL_ERROR "CHPL_LLVM_GCC_PREFIX=${CHPL_LLVM_GCC_PREFIX} CHPL_DEVELOPER=${CHPL_DEVELOPER} CHPL_HOST_CC=${CMAKE_C_COMPILER} CHPL_HOST_CXX=${CMAKE_CXX_COMPILER} printchplenv failed")
+else()
+  message(VERBOSE "printchplenv ran successfully")
+endif()
+
 message(VERBOSE "Updating build configuration with results from printchplenv:\n${CHPLENV_OUTPUT}")
 
 # This is a workaround for CMake not having any in-built way to
 # split a string into a list.  It's not perfect, but it works for this purpose
 STRING(REGEX REPLACE ";" "\\\\;" CHPLENV_OUTPUT "${CHPLENV_OUTPUT}")
 STRING(REGEX REPLACE "\n" ";" CHPLENV_OUTPUT "${CHPLENV_OUTPUT}")
-# message(DEBUG "printchplenv returned ${CHPLENV_RETURNCODE}")
 # set all the chplenv values from printchplenv
 foreach (CHPLENV_LINE IN LISTS CHPLENV_OUTPUT)
   # Split the line into the parts we want, variable name and value

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -56,18 +56,31 @@ def get_prgenv_compiler():
 # if we would like to default to LLVM.
 @memoize
 def should_consider_cc_cxx(flag):
+    return (should_consider_inferring_compiler(flag) and
+            overrides.get('CHPL_HOST_CC') is None and
+            overrides.get('CHPL_HOST_CXX') is None and
+            overrides.get('CHPL_TARGET_CC') is None and
+            overrides.get('CHPL_TARGET_CXX') is None)
+
+# Don't use CHPL_HOST_CC / CHPL_HOST_CXX to set CHPL_HOST_COMPILER
+# if CHPL_HOST_COMPILER is already set
+#
+#
+# Don't use CHPL_TARGET_CC / CHPL_TARGET_CXX to set CHPL_TARGET_COMPILER
+# if CHPL_TARGET_COMPILER is already set or if there is a PrgEnv
+# compiler or if we are using the LLVM backend.
+@memoize
+def should_consider_inferring_compiler(flag):
     default_llvm = default_to_llvm(flag)
     if default_llvm:
         return False
 
-    if (overrides.get('CHPL_HOST_COMPILER') is not None or
-        overrides.get('CHPL_HOST_CC') is not None or
-        overrides.get('CHPL_HOST_CXX') is not None or
-        overrides.get('CHPL_TARGET_COMPILER') is not None or
-        overrides.get('CHPL_TARGET_CC') is not None or
-        overrides.get('CHPL_TARGET_CXX') is not None):
-        # A compilation configuration setting was adjusted,
-        # so require CHPL_HOST_CC etc rather than using CC
+    if (flag == 'host' and
+        overrides.get('CHPL_HOST_COMPILER') is not None):
+        return False
+
+    if (flag == 'target' and
+        overrides.get('CHPL_TARGET_COMPILER') is not None):
         return False
 
     if flag == 'target' and get_prgenv_compiler() != 'none':
@@ -78,17 +91,18 @@ def should_consider_cc_cxx(flag):
     return True
 
 
-# Figures out the compiler family (e.g. gnu) from the CC/CXX enviro vars
+# Figures out the compiler family (e.g. gnu) from the provided enviro
+# vars (which are e.g. CC/CXX or CHPL_HOST_CC,CHPL_HOST_CXX etc).
 # Returns '' if CC / CXX are not set and 'unknown' if they are set
 # to something too complex.
 @memoize
-def get_compiler_from_cc_cxx():
+def get_compiler_from_cc_cxx(ccVarName, cxxVarName):
     cc_compiler = 'unknown'
     cxx_compiler = 'unknown'
-    warn = False
+    fail = False
     compiler_val = 'unknown'
-    cc_val = overrides.get('CC', '')
-    cxx_val = overrides.get('CXX', '')
+    cc_val = overrides.get(ccVarName, '')
+    cxx_val = overrides.get(cxxVarName, '')
 
     if cc_val == '' and cxx_val == '':
         return ''
@@ -102,35 +116,38 @@ def get_compiler_from_cc_cxx():
         if cc_compiler == cxx_compiler:
             compiler_val = cc_compiler
         else:
-            error("Conflicting compiler families for CC and CXX settings\n"
-                  "  {0} -> {1}\n"
+            error("Conflicting compiler families for {0} and {1} settings\n"
                   "  {2} -> {3}\n"
+                  "  {4} -> {5}\n"
                   "Set CHPL_HOST_COMPILER and CHPL_TARGET_COMPILER to the "
-                  "desired compiler family".format(cc_val, cc_compiler,
+                  "desired compiler family".format(ccVarName, cxxVarName,
+                                                   cc_val, cc_compiler,
                                                    cxx_val, cxx_compiler))
             compiler_val = 'unknown'
 
     else:
         # if we get here, CC or CXX is provided, but not both.
-        # Usually we warn in that case.
+        # Usually we fail in that case.
         # Check to see if the command name matches the default
         # for the compiler family.
-        # In that event, omit the warning.
+        # In that event, omit the error.
         if cc_val:
             compiler_val = cc_compiler
-            warn = (get_compiler_name_c(compiler_val) != cc_val)
+            fail = (get_compiler_name_c(compiler_val) != cc_val)
         if cxx_val:
             compiler_val = cxx_compiler
-            warn = (get_compiler_name_cxx(compiler_val) != cxx_val)
+            fail = (get_compiler_name_cxx(compiler_val) != cxx_val)
 
     if compiler_val == 'unknown':
         error("Could not infer CHPL_TARGET_COMPILER from "
-              "CC={0} CXX={1}".format(cc_val, cxx_val))
+              "{0}={1} {2}={3}".format(ccVarName, cc_val, cxxVarName, cxx_val))
     else:
-        if warn and cc_val:
-            error('CC is set but not CXX -- please set both\n')
-        if warn and cxx_val:
-            error('CXX is set but not CC -- please set both\n')
+        if fail and cc_val:
+            error('{0} is set but not {1} -- please set both\n'.format(
+                  ccVarName, cxxVarName))
+        if fail and cxx_val:
+            error('{0} is set but not {1} -- please set both\n'.format(
+                  cxxVarName, ccVarName))
 
     return compiler_val
 
@@ -164,9 +181,23 @@ def get(flag='host'):
     if not compiler_val:
         default_llvm = default_to_llvm(flag)
 
-        # If allowable, look at CC/CXX
-        if should_consider_cc_cxx(flag):
-            compiler_val = get_compiler_from_cc_cxx()
+        # If allowable, infer compiler family from CC / CHPL_HOST_CC / etc.
+        if should_consider_inferring_compiler(flag):
+
+            # consider CHPL_HOST_CC / CHPL_HOST_CXX
+            if flag == 'host':
+                compiler_val = get_compiler_from_cc_cxx('CHPL_HOST_CC',
+                                                        'CHPL_HOST_CXX')
+            # consider CHPL_TARGET_CC / CHPL_TARGET_CXX
+            if flag == 'target':
+                compiler_val = get_compiler_from_cc_cxx('CHPL_TARGET_CC',
+                                                        'CHPL_TARGET_CXX')
+
+            # if the compiler family was not set by the above,
+            # and none of CHPL_HOST_CC ... CHPL_TARGET_CXX are set,
+            # consider CC and CXX
+            if should_consider_cc_cxx(flag) and not compiler_val:
+                compiler_val = get_compiler_from_cc_cxx('CC', 'CXX')
 
     if compiler_val:
         validate_compiler(compiler_val, flag)


### PR DESCRIPTION
This PR is intended to resolve the build issue discussed in https://chapel.discourse.group/t/1-30-configuration-and-link-errors-when-building-on-system-where-1-29-previously-worked/20733/6

When building Chapel with something like `CC=clang CXX=clang++ make`, several things were going wrong:
 1. There was an error from printchplenv
 2. That error did not stop the build & later there were linker errors

Why was there an error at all? it was this sequence of events:
 * the Makefile invoking cmake set `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` based on CHPL_MAKE_HOST_CC etc to communicate this setting to cmake (so cmake does not infer it based upon CC or use its favorite compiler)
 * the cmake script invoked printchplenv while setting `CHPL_HOST_CC` and `CHPL_HOST_CXX` in the environment (so that printchplenv will be considering the same configuration that cmake is using)
 * printchplenv supports inferring `CHPL_HOST_COMPILER` from `CC` and `CXX` but not from `CHPL_HOST_CC` and `CHPL_HOST_CXX`. So, it failed, because the default value `CHPL_HOST_COMPILER=gnu` was inconsistent with `CHPL_HOST_CC=clang` / `CHPL_HOST_CXX=clang++`.


This PR:
 * It adjusts the cmake script to check for the return code from printchplenv and fail with an error if it is nonzero.
 * Enables inferring `CHPL_HOST_COMPILER` from `CHPL_HOST_CC` / `CHPL_HOST_CXX`
 * Enables inferring `CHPL_TARGET_COMPILER` from `CHPL_TARGET_CC` / `CHPL_TARGET_CXX` (but this does not happen when LLVM would be the default or when using a PrgEnv).

An alternative solution to the issue of inferring `CHPL_HOST_COMPILER` would be to pass it as an environment variable from `make` to `cmake` and from `cmake` to `printchplenv`.