### PR TITLE
Generate compile_commands.json for the whole project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ if (CMAKE_VERSION VERSION_LESS 3.20)
                   release. You have ${CMAKE_VERSION}")
 endif()
 
+# generate the compile_commands.json compilation database
+# tools like the fieldsUsed linter require this
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 ### BEGIN config.h value setting ###
 # Handle all (most?) the versioning information in one place
 # These values will be written to <build_dir>/frontend/include/chpl/config/config.h


### PR DESCRIPTION
This PR updates the root ``CMakeLists.txt`` file to generate ``compile_commands.json`` for the entire project. This will help to facilitate use of various tools in the future.