### PR TITLE
Fix BigInteger test fitsIntoMethod32

### DIFF
--- a/test/library/standard/BigInteger/fitsIntoMethod32.chpl
+++ b/test/library/standard/BigInteger/fitsIntoMethod32.chpl
@@ -32,5 +32,5 @@ check_bounds(2, c_short);
 check_bounds(3, c_ushort);
 check_bounds(4, c_int);
 check_bounds(5, c_uint);
-check_bounds(4, c_long);
-check_bounds(5, c_ulong);
+check_bounds(6, c_long);
+check_bounds(7, c_ulong);

--- a/test/library/standard/BigInteger/fitsIntoMethod32.compopts
+++ b/test/library/standard/BigInteger/fitsIntoMethod32.compopts
@@ -1,0 +1,1 @@
+-sbigintInitThrows=true


### PR DESCRIPTION
fitsIntoMethod32 was failing due to a deprecation warning being thrown. This looks like it got missed because it isn't run in nightly due to its skipif.

## summary of changes
- add missing compopts file
- fix typo in test case

## testing
- local testing of this test

---
> Note: we should probably make sure this test is being run in nightly

[Reviewed by @]
