### PR TITLE
Make array.count stable

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1906,7 +1906,6 @@ module ChapelArray {
     }
 
     /* Return the number of times ``val`` occurs in the array. */
-    @unstable("'Array.count' is unstable")
     proc count(val: this.eltType): int {
       return + reduce (this == val);
     }

--- a/test/arrays/diten/arrayCount.chpl
+++ b/test/arrays/diten/arrayCount.chpl
@@ -1,6 +1,6 @@
 var A: [1..10] int = [i in 1..10] i;
-writeln(+ reduce (A == 3));
+writeln(A.count(3));
 
 A[7..9] = 3;
-writeln(+ reduce (A == 3));
-writeln(+ reduce (A == 11));
+writeln(A.count(3));
+writeln(A.count(11));

--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -80,6 +80,7 @@ proc testArrayAPI1D(lbl, X: [], sliceDom, reindexDom) {
   writeln("find last: ", X.find(X[X.domain.high]));
   var idx: X.fullIdxType;
   writeln("find last again: ", X.find(X[X.domain.high],idx), ": ", idx);
+  writeln("count last: ", X.count(X[X.domain.high]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));
   var Z = X + 0.1;
@@ -198,6 +199,7 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
     writeln("find last: ", X.find(X[X.domain.high]));
   var idx: X.fullIdxType;
   writeln("find last again: ", X.find(X[X.domain.high],idx), ": ", idx);
+  writeln("count last: ", X.count(X[X.domain.high]));
   var Y = X;
   writeln("equals same: ", X.equals(Y));
   var Z = X + 0.1;

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,3 +1,2 @@
-arrayAPItest.chpl:98: In function 'testArrayAPI2D':
-arrayAPItest.chpl:217: error: only sparse arrays have an IRV
-  arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))
+./arrayAPItest.chpl:101: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:223: error: only sparse arrays have an IRV

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,2 +1,3 @@
-./arrayAPItest.chpl:101: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:223: error: only sparse arrays have an IRV
+arrayAPItest.chpl:99: In function 'testArrayAPI2D':
+arrayAPItest.chpl:219: error: only sparse arrays have an IRV
+  arrayOps2D.chpl:5: called as testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D.good
+++ b/test/arrays/userAPI/arrayOps2D.good
@@ -79,6 +79,7 @@ local subdomains:
 is empty: false
 find last: (4, 4)
 find last again: true: (4, 4)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOps2D.comm-none.good
+++ b/test/arrays/userAPI/blockOps2D.comm-none.good
@@ -133,6 +133,7 @@ local subdomains:
 is empty: false
 find last: (10, 10)
 find last again: true: (10, 10)
+count last: 1
 equals same: true
 equals diff: false
 
@@ -354,6 +355,7 @@ local subdomains:
 is empty: false
 find last: (8, 8)
 find last again: true: (8, 8)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOps2D.good
+++ b/test/arrays/userAPI/blockOps2D.good
@@ -134,6 +134,7 @@ local subdomains:
 is empty: false
 find last: (10, 10)
 find last again: true: (10, 10)
+count last: 1
 equals same: true
 equals diff: false
 
@@ -356,6 +357,7 @@ local subdomains:
 is empty: false
 find last: (8, 8)
 find last again: true: (8, 8)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOpsRankChange.comm-none.good
+++ b/test/arrays/userAPI/blockOpsRankChange.comm-none.good
@@ -106,6 +106,7 @@ local subdomains:
 is empty: false
 find last: (7, 7)
 find last again: true: (7, 7)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOpsRankChange.good
+++ b/test/arrays/userAPI/blockOpsRankChange.good
@@ -110,6 +110,7 @@ local subdomains:
 is empty: false
 find last: (7, 7)
 find last again: true: (7, 7)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOpsReindex.comm-none.good
+++ b/test/arrays/userAPI/blockOpsReindex.comm-none.good
@@ -133,6 +133,7 @@ local subdomains:
 is empty: false
 find last: (9, 19)
 find last again: true: (9, 19)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/blockOpsReindex.good
+++ b/test/arrays/userAPI/blockOpsReindex.good
@@ -134,6 +134,7 @@ local subdomains:
 is empty: false
 find last: (9, 19)
 find last again: true: (9, 19)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/callExternArrTest.good
+++ b/test/arrays/userAPI/callExternArrTest.good
@@ -43,6 +43,7 @@ local subdomains:
 is empty: false
 find last: 4
 find last again: true: 4
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/enumArray.good
+++ b/test/arrays/userAPI/enumArray.good
@@ -87,6 +87,7 @@ local subdomains:
 
 is empty: false
 find last again: true: (blue, violet)
+count last: 1
 equals same: true
 equals diff: false
 
@@ -201,6 +202,7 @@ local subdomains:
 
 is empty: false
 find last again: true: (violet, violet)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/rankChangeOps3to2D.good
+++ b/test/arrays/userAPI/rankChangeOps3to2D.good
@@ -79,6 +79,7 @@ local subdomains:
 is empty: false
 find last: (4, 4)
 find last again: true: (4, 4)
+count last: 1
 equals same: true
 equals diff: false
 
@@ -185,6 +186,7 @@ local subdomains:
 is empty: false
 find last: (4, 4)
 find last again: true: (4, 4)
+count last: 1
 equals same: true
 equals diff: false
 
@@ -291,6 +293,7 @@ local subdomains:
 is empty: false
 find last: (4, 4)
 find last again: true: (4, 4)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/reindexOps2D.good
+++ b/test/arrays/userAPI/reindexOps2D.good
@@ -79,6 +79,7 @@ local subdomains:
 is empty: false
 find last: (3, 8)
 find last again: true: (3, 8)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/sliceOps2D.good
+++ b/test/arrays/userAPI/sliceOps2D.good
@@ -79,6 +79,7 @@ local subdomains:
 is empty: false
 find last: (4, 4)
 find last again: true: (4, 4)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/arrays/userAPI/unsignedOps.good
+++ b/test/arrays/userAPI/unsignedOps.good
@@ -79,6 +79,7 @@ local subdomains:
 is empty: false
 find last: (4, 4)
 find last again: true: (4, 4)
+count last: 1
 equals same: true
 equals diff: false
 
@@ -185,6 +186,7 @@ local subdomains:
 is empty: false
 find last: (4, 4)
 find last again: true: (4, 4)
+count last: 1
 equals same: true
 equals diff: false
 
@@ -291,6 +293,7 @@ local subdomains:
 is empty: false
 find last: (3, 8)
 find last again: true: (3, 8)
+count last: 1
 equals same: true
 equals diff: false
 
@@ -397,6 +400,7 @@ local subdomains:
 is empty: false
 find last: (4, 4)
 find last again: true: (4, 4)
+count last: 1
 equals same: true
 equals diff: false
 

--- a/test/unstable/arrayFuncs.chpl
+++ b/test/unstable/arrayFuncs.chpl
@@ -1,6 +1,0 @@
-// Marked unstable while we figure out if we want to change the interface to
-// make them more consistent with count and find on other datatypes like List,
-// Bytes, and String.
-
-var A = [1, 2, 1, 3, 1, 4, 1, 5];
-writeln("Count of 1's in A = ", A.count(1));

--- a/test/unstable/arrayFuncs.good
+++ b/test/unstable/arrayFuncs.good
@@ -1,2 +1,0 @@
-arrayFuncs.chpl:6: warning: 'Array.count' is unstable
-Count of 1's in A = 4


### PR DESCRIPTION
Previously, we marked `Array.count` as unstable due to the thought that we might want to change its interface to be more consistent with uses of counts in other datastructures. After further consideration it looks like the interface for `Array.count` is unlikely to change (at least not in a way that would break backwards compatibility).

This PR is for: https://github.com/chapel-lang/chapel/issues/21730
