### PR TITLE
Filtering for rst direct hyperlinks to deprecations

### DIFF
--- a/frontend/lib/util/filtering.cpp
+++ b/frontend/lib/util/filtering.cpp
@@ -43,8 +43,10 @@ namespace {
     std::string reCntType2 = R"#(~([\w$]+\.?)+)#";
     // Starts with !, capture identifier to right of ! without capturing ! itself
     std::string reCntType3 = R"#(!([\w$.]+))#";
-    // support explicit title and reference target, capture the target
-    std::string reCntType4 = R"#((?:[\w$.]+)<([\w$.]+)>)#";
+    // support explicit title and reference target, captures the target
+    // note that Sphinx allows any character for the nice name of the title
+    // but does not allow a space directly before the '<'
+    std::string reCntType4 = R"#((?:[^<]+[^\s])<([\w$.]+)>)#";
 
     // OR all the content types together, wrapping each in a non capturing group
     std::string reContent = "(?:(?:" + reCntType1 + ")|(?:" + reCntType2 + ")|(?:" + reCntType3 + ")|(?:" + reCntType4 +  + "))";

--- a/frontend/lib/util/filtering.cpp
+++ b/frontend/lib/util/filtering.cpp
@@ -35,10 +35,7 @@ namespace {
     // We write the regexp so the relevant part of "content" will be captured by
     // std::smatch if we wish to use this to filter out the markup.
 
-    // TODO: Support explicit title and reference targets like in reST direct hyperlinks (and having only target
-    //       show up in sanitized message).
-
-    // There are three "kinds" of content we consider, so we OR these together
+    // There are four "kinds" of content we consider, so we OR these together
     // Capture a normal Chapel identifier
     std::string reCntType1 = R"#(([\w$.]+))#";
     // If it starts with ~, capture last identifier to the right of a '.'
@@ -46,9 +43,11 @@ namespace {
     std::string reCntType2 = R"#(~([\w$]+\.?)+)#";
     // Starts with !, capture identifier to right of ! without capturing ! itself
     std::string reCntType3 = R"#(!([\w$.]+))#";
+    // support explicit title and reference target, capture the target
+    std::string reCntType4 = R"#((?:[\w$.]+)<([\w$.]+)>)#";
 
     // OR all the content types together, wrapping each in a non capturing group
-    std::string reContent = "(?:(?:" + reCntType1 + ")|(?:" + reCntType2 + ")|(?:" + reCntType3 + "))";
+    std::string reContent = "(?:(?:" + reCntType1 + ")|(?:" + reCntType2 + ")|(?:" + reCntType3 + ")|(?:" + reCntType4 +  + "))";
 
     // Various roles; put into a (?...) group so we don't "capture" it
     std::string reRole = R"#((?:mod|proc|iter|data|const|var|param|type|class|record|attr|enum))#";

--- a/test/deprecated-keyword/messageFiltering.chpl
+++ b/test/deprecated-keyword/messageFiltering.chpl
@@ -187,6 +187,13 @@ var x1202 = 1202;
 var x1300 = 1300;
 @deprecated(notes="Lorem ipsum :proc:`abc<def.ghi>` dolor sit amet")
 var x1301 = 1301;
+@deprecated(notes="Lorem ipsum :proc:`abc with spaces<def.ghi>` dolor sit amet")
+var x1302 = 1302;
+@deprecated(notes="Lorem ipsum :proc:`a-b_c<def.ghi>` dolor sit amet")
+var x1303 = 1303;
+// this should not filter
+@deprecated(notes="Lorem ipsum :proc:`abc <def.ghi>` dolor sit amet")
+var x1304 = 1304;
 
 // I purposefully access each variable on a separate line so the produced warning messages
 // will also have unique lines:
@@ -283,3 +290,6 @@ writeln(x1202);
 
 writeln(x1300);
 writeln(x1301);
+writeln(x1302);
+writeln(x1303);
+writeln(x1304);

--- a/test/deprecated-keyword/messageFiltering.chpl
+++ b/test/deprecated-keyword/messageFiltering.chpl
@@ -181,6 +181,13 @@ var x1201 = 1201;
 @deprecated(notes="Lorem ipsum :proc:`a~bc.def` dolor sit amet")
 var x1202 = 1202;
 
+
+// Using rst hyperlink syntax
+@deprecated(notes="--- Text using the rst hyperlink syntax ---")
+var x1300 = 1300;
+@deprecated(notes="Lorem ipsum :proc:`abc<def.ghi>` dolor sit amet")
+var x1301 = 1301;
+
 // I purposefully access each variable on a separate line so the produced warning messages
 // will also have unique lines:
 
@@ -273,3 +280,6 @@ writeln(x1103);
 writeln(x1200);
 writeln(x1201);
 writeln(x1202);
+
+writeln(x1300);
+writeln(x1301);

--- a/test/deprecated-keyword/messageFiltering.good
+++ b/test/deprecated-keyword/messageFiltering.good
@@ -79,6 +79,9 @@ messageFiltering.chpl:n: warning: Lorem ipsum def dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum :proc:`a~bc.def` dolor sit amet
 messageFiltering.chpl:n: warning: --- Text using the rst hyperlink syntax ---
 messageFiltering.chpl:n: warning: Lorem ipsum def.ghi dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum def.ghi dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum def.ghi dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum :proc:`abc <def.ghi>` dolor sit amet
 1000
 1001
 1002
@@ -160,3 +163,6 @@ messageFiltering.chpl:n: warning: Lorem ipsum def.ghi dolor sit amet
 1202
 1300
 1301
+1302
+1303
+1304

--- a/test/deprecated-keyword/messageFiltering.good
+++ b/test/deprecated-keyword/messageFiltering.good
@@ -77,6 +77,8 @@ messageFiltering.chpl:n: warning: Lorem ipsum :proc:`a!bc` dolor sit amet
 messageFiltering.chpl:n: warning: --- Prefixed with ~, should filter to just last component if well formed ---
 messageFiltering.chpl:n: warning: Lorem ipsum def dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum :proc:`a~bc.def` dolor sit amet
+messageFiltering.chpl:n: warning: --- Text using the rst hyperlink syntax ---
+messageFiltering.chpl:n: warning: Lorem ipsum def.ghi dolor sit amet
 1000
 1001
 1002
@@ -156,3 +158,5 @@ messageFiltering.chpl:n: warning: Lorem ipsum :proc:`a~bc.def` dolor sit amet
 1200
 1201
 1202
+1300
+1301


### PR DESCRIPTION
Adds support for rst hyperlinks of the form `nicename<target>`. The filter will keep just `target`

# Summary of changes
- add regex for rst hyperlinks, captures only the target

# New tests
- added test for rst hyperlinks to existing deprecation filtering test

# Tested
- tested locally

---

Completes support for #18549, resolved

[Reviewed by @]