### PR TITLE
Report GPU Stream performance in GiB/s

### DIFF
--- a/test/gpu/native/streamPrototype/gpuStream.graph
+++ b/test/gpu/native/streamPrototype/gpuStream.graph
@@ -1,5 +1,5 @@
-perfkeys: Performance (GiB/s) =
+perfkeys: Performance (GB/s) =
 files: stream.dat
-graphkeys: Performance (GiB/s)
-ylabel: Performance (GiB/s)
-graphtitle: STREAM Performance (GiB/s)
+graphkeys: Performance (GB/s)
+ylabel: Performance (GB/s)
+graphtitle: STREAM Performance (GB/s; GB = 10^9 bytes)

--- a/test/gpu/native/streamPrototype/gpuStream.graph
+++ b/test/gpu/native/streamPrototype/gpuStream.graph
@@ -1,5 +1,5 @@
-perfkeys: Performance (GB/s) =
+perfkeys: Performance (GiB/s) =
 files: stream.dat
-graphkeys: Performance (GB/s)
-ylabel: Performance (GB/s)
-graphtitle: STREAM Performance (GB/s)
+graphkeys: Performance (GiB/s)
+ylabel: Performance (GiB/s)
+graphtitle: STREAM Performance (GiB/s)

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -200,7 +200,7 @@ proc verifyResults(A, B, C) {
 }
 
 //
-// Print out success/failure, the timings, and the GiB/s value
+// Print out success/failure, the timings, and the throughput
 //
 proc printResults(successful, execTimes) {
   writeln("Validation: ", if successful then "SUCCESS" else "FAILURE");

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -200,7 +200,7 @@ proc verifyResults(A, B, C) {
 }
 
 //
-// Print out success/failure, the timings, and the GB/s value
+// Print out success/failure, the timings, and the GiB/s value
 //
 proc printResults(successful, execTimes) {
   writeln("Validation: ", if successful then "SUCCESS" else "FAILURE");
@@ -227,7 +227,7 @@ proc printResults(successful, execTimes) {
     writeln("  avg = ", avgTime);
     writeln("  min = ", minTime);
 
-    const GBPerSec = numVectors * numBytes(elemType) * (m / minTime) * 1e-9;
-    writeln("Performance (GB/s) = ", GBPerSec);
+    const GiBPerSec = numVectors * numBytes(elemType) * (m / minTime) / (1<<30):real;
+    writeln("Performance (GiB/s) = ", GiBPerSec);
   }
 }

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -20,8 +20,8 @@ proc verifyLaunches() {
 }
 
 config param useForeach = true;
-
 config const useGpuDiags = true;
+config const SI = true;
 
 //
 // The number of vectors and element type of those vectors
@@ -227,7 +227,14 @@ proc printResults(successful, execTimes) {
     writeln("  avg = ", avgTime);
     writeln("  min = ", minTime);
 
-    const GiBPerSec = numVectors * numBytes(elemType) * (m / minTime) / (1<<30):real;
-    writeln("Performance (GiB/s) = ", GiBPerSec);
+    if SI {
+      const GBPerSec =
+        numVectors * numBytes(elemType) * (m / minTime) * 1e-9;
+      writeln("Performance (GB/s) = ", GBPerSec);
+    } else {
+      const GiBPerSec =
+        numVectors * numBytes(elemType) * (m / minTime) / (1<<30):real;
+      writeln("Performance (GiB/s) = ", GiBPerSec);
+    }
   }
 }

--- a/test/gpu/native/streamPrototype/stream.gpu-keys
+++ b/test/gpu/native/streamPrototype/stream.gpu-keys
@@ -1,1 +1,1 @@
-Performance (GB/s) =
+Performance (GiB/s) =

--- a/test/gpu/native/streamPrototype/stream.gpu-keys
+++ b/test/gpu/native/streamPrototype/stream.gpu-keys
@@ -1,1 +1,1 @@
-Performance (GiB/s) =
+Performance (GB/s) =


### PR DESCRIPTION
As opposed to GB/s. That is: use units that are powers of 2 rather than powers of 10.