### PR TITLE
Add a missing comm-none.good file

### DIFF
--- a/test/gpu/native/stringBytesConfig/bytesConfigIssue20276.comm-none.good
+++ b/test/gpu/native/stringBytesConfig/bytesConfigIssue20276.comm-none.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+b2
+b2


### PR DESCRIPTION
The test was added in https://github.com/chapel-lang/chapel/pull/21976. I forgot to check-in a good file. This PR fixes that.