### PR TITLE
Fix quoting for args passed to paratest.chapdl

### DIFF
--- a/util/test/paratest.chapdl
+++ b/util/test/paratest.chapdl
@@ -2,4 +2,4 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-CHPL_TEST_PARTITION=chapdl CHPL_TEST_NODEPARA=8 $CWD/paratest.chapcs $@
+CHPL_TEST_PARTITION=chapdl CHPL_TEST_NODEPARA=8 $CWD/paratest.chapcs "$@"


### PR DESCRIPTION
Not quoting striped quotes from args that were passed in so things like `-env 'GASNET_SPAWNFN=L GASNET_QUIET=yes'` wouldn't work correctly.