### PR TITLE
chore(docs): update sphinxcontrib-chapeldomain version

### DIFF
--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -86,7 +86,7 @@ Changing A Function's Return Type
 When nothing about a function except its return type needs to change, it can
 be tricky for a user to opt in to the new behavior.
 
-.. code-block:: text
+.. code-block:: chapel
 
    @deprecated("foo returning 'int' is deprecated")
    proc foo(): int { ... }
@@ -98,7 +98,7 @@ be tricky for a user to opt in to the new behavior.
 In this situation, we recommend adding a ``config param`` and a ``where`` clause
 that responds to it to the deprecated function and its replacement:
 
-.. code-block:: text
+.. code-block:: chapel
 
    // The default state should result in the deprecated behavior, so users can
    // adjust their code at their leisure
@@ -115,7 +115,7 @@ that responds to it to the deprecated function and its replacement:
 When the deprecated function is removed, the flag should also be deprecated (and
 removed from the new function to avoid generating noise for the user):
 
-.. code-block:: text
+.. code-block:: chapel
 
    @deprecated("'fooReturnsBool' is deprecated and no longer has an effect")
    config param fooReturnsBool = false;
@@ -136,7 +136,7 @@ When only the name of a function argument needs to change and not its type, a
 new overload will encounter conflicts when a user relies solely on positional
 ordering:
 
-.. code-block:: text
+.. code-block:: chapel
 
    @deprecated("argument name 'a' is deprecated, use 'b' instead")
    proc foo(a: int) { ... }
@@ -159,7 +159,7 @@ resort"`` - this will avoid conflicts in the positional ordering case while
 still keeping the old argument name available to generate the deprecation
 warning:
 
-.. code-block:: text
+.. code-block:: chapel
 
    pragma "last resort"
    @deprecated("argument name 'a' is deprecated, use 'b' instead")
@@ -240,7 +240,7 @@ support for opting in to maintaining the default initializer (which is planned
 but not currently implemented), this will also require the addition of an
 equivalent replacement for the default initializer, which is a burden.
 
-.. code-block:: text
+.. code-block:: chapel
 
    record Foo {
      var newName: int;

--- a/doc/rst/technotes/attributes.rst
+++ b/doc/rst/technotes/attributes.rst
@@ -27,7 +27,7 @@ ability to specify a tool name for an attribute.
 
 Here are examples of what an attribute might look like:
 
-.. code-block:: text
+.. code-block:: chapel
 
     // example of an attribute without a tool name
     @attributeName(arg1="value", arg2=1, arg3=1.0, arg4=true, arg5=1..10)
@@ -105,7 +105,7 @@ Stability Attributes
     in a future release.
 
 
-.. code-block:: text
+.. code-block:: chapel
 
     // ways to use @deprecated
     @deprecated
@@ -153,7 +153,7 @@ using ``pragma "no doc"`` to suppress documentation for a symbol.
 When converting existing code, note that ``@chpldoc.nodoc`` must be placed `after`
 any remaining pragmas assigned to the symbol.
 
-.. code-block:: text
+.. code-block:: chapel
 
     // prevent the entire module from being documented
     @chpldoc.nodoc

--- a/doc/rst/tools/chpldoc/chpldoc.rst
+++ b/doc/rst/tools/chpldoc/chpldoc.rst
@@ -224,7 +224,7 @@ Stifling documentation
 To mark a particular symbol to not be output as part of the documentation,
 preface the symbol with the attribute ``@chpldoc.nodoc``. For example:
 
-.. code-block:: text
+.. code-block:: chapel
 
    @chpldoc.nodoc
    proc foo() { ... }

--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 sphinx-rtd-theme==1.0.0
-sphinxcontrib-chapeldomain==0.0.24
+sphinxcontrib-chapeldomain==0.0.25
 breathe==4.31.0


### PR DESCRIPTION
This PR updates the requirements file for docs to use the latest release of `sphinxcontrib-chapeldomain` (`0.0.25`). The 0.0.25 release adds support for Attribute syntax.

It also changes code blocks that were labeled as text to be correctly labeled as chapel code in the attributes tech note and `chpldoc` docs

TESTING:

- [x] build docs locally and inspect attribute code blocks for colorization