### PR TITLE
Deprecate including these math constants by default

### DIFF
--- a/doc/rst/users-guide/base/constParam.rst
+++ b/doc/rst/users-guide/base/constParam.rst
@@ -45,7 +45,7 @@ value is 2 (as you'd hope):
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :caption:
   :language: chapel
-  :lines: 5
+  :lines: 6
 
 Unlike variables, attempting to assign to a constant after it has been
 initialized will result in a compile-time error.  For example, if we
@@ -53,7 +53,7 @@ later attempted to perform this assignment:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 8
+  :lines: 9
   :dedent: 2
 
 The compiler would report the following error:
@@ -68,7 +68,7 @@ will fill in any missing details:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 10-11
+  :lines: 11-12
 
 Of course, since constants cannot be re-assigned, in practice they
 typically do include an initialization expression.
@@ -79,7 +79,7 @@ shared:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 15-21
+  :lines: 16-22
 
 One of the main things that distinguishes ``const`` from ``param``
 declarations is that the initializing expression for a ``const`` need
@@ -89,13 +89,13 @@ from the console and then using that value to do some math:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 23-24
+  :lines: 24-25
 
 If we were to print their values as follows:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 26-27
+  :lines: 27-28
 
 And then typed '4' at the console after compiling and running the program,
 we'd see:
@@ -119,7 +119,7 @@ trivially be converted to ``param`` declarations as follows:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 30-36
+  :lines: 31-37
   :dedent: 2
 
 Attempting to initialize a ``param`` with a value not known to the
@@ -128,7 +128,7 @@ following initializers, which were legal in ``const`` declarations:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 39-40
+  :lines: 40-41
   :dedent: 4
 
 As ``param`` initializers, they result in the following error messages
@@ -145,7 +145,7 @@ initialized using expressions other than simple literal values:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 45-51
+  :lines: 46-52
 
 Specifically, procedures and operators that are declared to return
 ``param`` values are executed at compile-time and can be used to

--- a/doc/rst/users-guide/base/constParam.rst
+++ b/doc/rst/users-guide/base/constParam.rst
@@ -45,7 +45,7 @@ value is 2 (as you'd hope):
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :caption:
   :language: chapel
-  :lines: 6
+  :lines: 5
 
 Unlike variables, attempting to assign to a constant after it has been
 initialized will result in a compile-time error.  For example, if we
@@ -53,7 +53,7 @@ later attempted to perform this assignment:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 9
+  :lines: 8
   :dedent: 2
 
 The compiler would report the following error:
@@ -68,7 +68,7 @@ will fill in any missing details:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 11-12
+  :lines: 10-11
 
 Of course, since constants cannot be re-assigned, in practice they
 typically do include an initialization expression.
@@ -79,7 +79,7 @@ shared:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 16-22
+  :lines: 15-21
 
 One of the main things that distinguishes ``const`` from ``param``
 declarations is that the initializing expression for a ``const`` need
@@ -89,13 +89,13 @@ from the console and then using that value to do some math:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 24-25
+  :lines: 23-24
 
 If we were to print their values as follows:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 27-28
+  :lines: 26-27
 
 And then typed '4' at the console after compiling and running the program,
 we'd see:
@@ -119,7 +119,7 @@ trivially be converted to ``param`` declarations as follows:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 31-37
+  :lines: 30-36
   :dedent: 2
 
 Attempting to initialize a ``param`` with a value not known to the
@@ -128,7 +128,7 @@ following initializers, which were legal in ``const`` declarations:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 40-41
+  :lines: 39-40
   :dedent: 4
 
 As ``param`` initializers, they result in the following error messages
@@ -145,7 +145,7 @@ initialized using expressions other than simple literal values:
 
 .. literalinclude:: examples/users-guide/base/constParam.chpl
   :language: chapel
-  :lines: 46-52
+  :lines: 45-51
 
 Specifically, procedures and operators that are declared to return
 ``param`` values are executed at compile-time and can be used to

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -53,31 +53,56 @@ module AutoMath {
   // Constants (included in chpldocs)
   //
 
-  /* e - exp(1) or  the base of the natural logarithm */
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param e = 2.7182818284590452354;
-  /* log2(e) */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'log2_e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param log2_e = 1.4426950408889634074;
-  /* log10(e) */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'log10_e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param log10_e = 0.43429448190325182765;
-  /* log(2) (natural logarithm) */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'ln_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param ln_2 = 0.69314718055994530942;
-  /* log(10) (natural logarithm) */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'ln_10' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param ln_10 = 2.30258509299404568402;
-  /* pi - the circumference/the diameter of a circle */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param pi = 3.14159265358979323846;
-  /* pi/2 */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'half_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param half_pi = 1.57079632679489661923;
-  /* pi/4 */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'quarter_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param quarter_pi = 0.78539816339744830962;
-  /* 1/pi */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'recipr_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param recipr_pi = 0.31830988618379067154;
-  /* 2/pi */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'twice_recipr_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param twice_recipr_pi = 0.63661977236758134308;
-  /* 2/sqrt(pi) */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'twice_recipr_sqrt_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param twice_recipr_sqrt_pi = 1.12837916709551257390;
-  /* sqrt(2) */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'sqrt_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param sqrt_2 = 1.41421356237309504880;
-  /* 1/sqrt(2) */
+
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'recipr_sqrt_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param recipr_sqrt_2 = 0.70710678118654752440;
 
   //////////////////////////////////////////////////////////////////////////

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -53,54 +53,67 @@ module AutoMath {
   // Constants (included in chpldocs)
   //
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param e = 2.7182818284590452354;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'log2_e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param log2_e = 1.4426950408889634074;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'log10_e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param log10_e = 0.43429448190325182765;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'ln_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param ln_2 = 0.69314718055994530942;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'ln_10' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param ln_10 = 2.30258509299404568402;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param pi = 3.14159265358979323846;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'half_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param half_pi = 1.57079632679489661923;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'quarter_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param quarter_pi = 0.78539816339744830962;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'recipr_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param recipr_pi = 0.31830988618379067154;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'twice_recipr_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param twice_recipr_pi = 0.63661977236758134308;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'twice_recipr_sqrt_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param twice_recipr_sqrt_pi = 1.12837916709551257390;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'sqrt_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param sqrt_2 = 1.41421356237309504880;
 
+  pragma "last resort"
   @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'recipr_sqrt_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it")
   param recipr_sqrt_2 = 0.70710678118654752440;

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -46,6 +46,37 @@ module Math {
   private use CTypes;
   private use AutoMath;
 
+  //////////////////////////////////////////////////////////////////////////
+  // Constants (included in chpldocs)
+  //
+
+  /* e - exp(1) or  the base of the natural logarithm */
+  param e = 2.7182818284590452354;
+  /* log2(e) */
+  param log2_e = 1.4426950408889634074;
+  /* log10(e) */
+  param log10_e = 0.43429448190325182765;
+  /* log(2) (natural logarithm) */
+  param ln_2 = 0.69314718055994530942;
+  /* log(10) (natural logarithm) */
+  param ln_10 = 2.30258509299404568402;
+  /* pi - the circumference/the diameter of a circle */
+  param pi = 3.14159265358979323846;
+  /* pi/2 */
+  param half_pi = 1.57079632679489661923;
+  /* pi/4 */
+  param quarter_pi = 0.78539816339744830962;
+  /* 1/pi */
+  param recipr_pi = 0.31830988618379067154;
+  /* 2/pi */
+  param twice_recipr_pi = 0.63661977236758134308;
+  /* 2/sqrt(pi) */
+  param twice_recipr_sqrt_pi = 1.12837916709551257390;
+  /* sqrt(2) */
+  param sqrt_2 = 1.41421356237309504880;
+  /* 1/sqrt(2) */
+  param recipr_sqrt_2 = 0.70710678118654752440;
+
   /* Returns the phase (often called `argument`) of complex `z`, an angle (in
      radians).
 

--- a/test/classes/ferguson/forwarding/call-forwarded-omit-this.bad
+++ b/test/classes/ferguson/forwarding/call-forwarded-omit-this.bad
@@ -1,5 +1,5 @@
-call-forwarded-omit-this.chpl:27: In method 'bad':
-call-forwarded-omit-this.chpl:28: error: unresolved call 'area()'
-call-forwarded-omit-this.chpl:5: note: this candidate did not match: MyCircleImpl.area()
-call-forwarded-omit-this.chpl:28: note: because call is not written as a method call
-call-forwarded-omit-this.chpl:5: note: but candidate function is a method
+call-forwarded-omit-this.chpl:29: In method 'bad':
+call-forwarded-omit-this.chpl:30: error: unresolved call 'area()'
+call-forwarded-omit-this.chpl:7: note: this candidate did not match: MyCircleImpl.area()
+call-forwarded-omit-this.chpl:30: note: because call is not written as a method call
+call-forwarded-omit-this.chpl:7: note: but candidate function is a method

--- a/test/classes/ferguson/forwarding/call-forwarded-omit-this.chpl
+++ b/test/classes/ferguson/forwarding/call-forwarded-omit-this.chpl
@@ -1,3 +1,5 @@
+import Math.pi;
+
 class MyCircleImpl {
   var radius:real;
 

--- a/test/deprecated/Math/mathConstants.chpl
+++ b/test/deprecated/Math/mathConstants.chpl
@@ -1,0 +1,15 @@
+writeln(isclose(e, exp(1)));       // Should trigger for e
+writeln(isclose(log2_e, log2(e))); // Should trigger for log2_e and e
+writeln(isclose(log10_e, log10(e))); // Should trigger for log10_e and e
+writeln(isclose(ln_2, log(2)));      // Should trigger for ln_2
+writeln(isclose(ln_10, log(10)));    // Should trigger for ln_10
+writeln(isclose(pi, 3.141592653));   // Should trigger for pi
+writeln(isclose(half_pi, pi/2));     // Should trigger for half_pi, pi
+writeln(isclose(quarter_pi, pi/4));  // Should trigger for quarter_pi, pi
+writeln(isclose(recipr_pi, 1/pi));   // Should trigger for recipr_pi, pi
+// Should trigger for twice_recipr_pi, pi
+writeln(isclose(twice_recipr_pi, 2/pi));
+// Should trigger for twice_recipr_sqrt_pi, pi
+writeln(isclose(twice_recipr_sqrt_pi, 2/sqrt(pi)));
+writeln(isclose(sqrt_2, sqrt(2)));   // Should trigger for sqrt_2
+writeln(isclose(recipr_sqrt_2, 1/sqrt(2))); // Should trigger for recipr_sqrt_2

--- a/test/deprecated/Math/mathConstants.good
+++ b/test/deprecated/Math/mathConstants.good
@@ -1,0 +1,33 @@
+mathConstants.chpl:1: warning: In an upcoming release 'e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:2: warning: In an upcoming release 'log2_e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:2: warning: In an upcoming release 'e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:3: warning: In an upcoming release 'log10_e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:3: warning: In an upcoming release 'e' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:4: warning: In an upcoming release 'ln_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:5: warning: In an upcoming release 'ln_10' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:6: warning: In an upcoming release 'pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:7: warning: In an upcoming release 'half_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:7: warning: In an upcoming release 'pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:8: warning: In an upcoming release 'quarter_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:8: warning: In an upcoming release 'pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:9: warning: In an upcoming release 'recipr_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:9: warning: In an upcoming release 'pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:11: warning: In an upcoming release 'twice_recipr_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:11: warning: In an upcoming release 'pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:13: warning: In an upcoming release 'twice_recipr_sqrt_pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:13: warning: In an upcoming release 'pi' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:14: warning: In an upcoming release 'sqrt_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+mathConstants.chpl:15: warning: In an upcoming release 'recipr_sqrt_2' will no longer be included by default, please 'use' or 'import' the 'Math' module to access it
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/test/exercises/c-ray/c-ray.chpl
+++ b/test/exercises/c-ray/c-ray.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/old/c-ray.chpl
+++ b/test/exercises/c-ray/old/c-ray.chpl
@@ -27,6 +27,7 @@ use Image;    // use helper module related to writing out images
 use IO;       // allows access to stderr, stdin, ioMode
 use List;
 use ChplConfig;
+import Math.quarter_pi;
 
 //
 // Configuration constants

--- a/test/exercises/c-ray/solutions/c-ray-1.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-1.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-1a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-1a.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-2.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-2.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-2a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-2a.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-3.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-3.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-3a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-3a.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-4.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-4.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-4a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-4a.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-5.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-5.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-6.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-6.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-7.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-7.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/exercises/c-ray/solutions/c-ray-8.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-8.chpl
@@ -27,6 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
+import Math.quarter_pi;
 
 //
 // =================================================

--- a/test/modules/engin/pkg_module_res.chpl
+++ b/test/modules/engin/pkg_module_res.chpl
@@ -1,5 +1,5 @@
-use AutoMath; //doesn't make a difference -- works either way
-writeln(AutoMath.pi);
+use Math;
+writeln(Math.pi);
 writeln(pi);
 
 use LinearAlgebra;

--- a/test/npb/ft/npadmana/ft_transposed.chpl
+++ b/test/npb/ft/npadmana/ft_transposed.chpl
@@ -12,6 +12,7 @@
 */
 use DistributedFFT;
 use Time;
+import Math.pi;
 
 // Define the classes
 enum NPB {S,W,A,B,C,D,E,F};

--- a/test/release/examples/users-guide/base/constParam-error.good
+++ b/test/release/examples/users-guide/base/constParam-error.good
@@ -1,3 +1,3 @@
-constParam.chpl:9: error: cannot assign to const variable
-constParam.chpl:40: error: Initializing parameter 'n' to value not known at compile time
-constParam.chpl:41: error: Initializing parameter 'piOverN' to value not known at compile time
+constParam.chpl:8: error: cannot assign to const variable
+constParam.chpl:39: error: Initializing parameter 'n' to value not known at compile time
+constParam.chpl:40: error: Initializing parameter 'piOverN' to value not known at compile time

--- a/test/release/examples/users-guide/base/constParam-error.good
+++ b/test/release/examples/users-guide/base/constParam-error.good
@@ -1,3 +1,3 @@
-constParam.chpl:8: error: cannot assign to const variable
-constParam.chpl:39: error: Initializing parameter 'n' to value not known at compile time
-constParam.chpl:40: error: Initializing parameter 'piOverN' to value not known at compile time
+constParam.chpl:9: error: cannot assign to const variable
+constParam.chpl:40: error: Initializing parameter 'n' to value not known at compile time
+constParam.chpl:41: error: Initializing parameter 'piOverN' to value not known at compile time

--- a/test/release/examples/users-guide/base/constParam.chpl
+++ b/test/release/examples/users-guide/base/constParam.chpl
@@ -1,5 +1,4 @@
-use IO;
-import Math.pi;
+use IO, Math;
 
 config param testErrors = 0;
 

--- a/test/release/examples/users-guide/base/constParam.chpl
+++ b/test/release/examples/users-guide/base/constParam.chpl
@@ -1,4 +1,5 @@
 use IO;
+import Math.pi;
 
 config param testErrors = 0;
 

--- a/test/studies/prk/PIC/pic.chpl
+++ b/test/studies/prk/PIC/pic.chpl
@@ -6,6 +6,7 @@
 
 require "random_draw.h", "random_draw.c";
 use Time, CTypes;
+import Math.pi;
 
 // use random_draw library from PRK repo
 extern proc LCG_init();

--- a/test/types/real/transmute-toUint.chpl
+++ b/test/types/real/transmute-toUint.chpl
@@ -1,3 +1,5 @@
+import Math.pi;
+
 config param r: real = pi,
        r32: real(32) = r;
 

--- a/test/types/string/sungeun/c_string/concat.chpl
+++ b/test/types/string/sungeun/c_string/concat.chpl
@@ -33,7 +33,7 @@ checkType(string, (createStringWithNewBuffer(vcstr)+c:string).type);
 checkType(string, (c"8"+pe:string).type);
 checkType(string, ("8"+pe:string).type);
 checkType(string, (cstr+pe:string).type);
-checkType(string, (createStringWithNewBuffer(vcstr)+e:string).type);
+checkType(string, (createStringWithNewBuffer(vcstr)+pe:string).type);
 checkType(string, ("8"+ee:string).type);
 checkType(string, (createStringWithNewBuffer(cstr)+ee:string).type);
 checkType(string, (createStringWithNewBuffer(vcstr)+ee:string).type);

--- a/test/types/string/sungeun/c_string/decls.chpl
+++ b/test/types/string/sungeun/c_string/decls.chpl
@@ -26,6 +26,6 @@ param i = 4.0i;
 const ii = i;
 const c:complex = 4.0+4.0i;
 param pe = E.two;
-const ee = e;
+const ee = pe;
 param b = true;
 const bb = b;


### PR DESCRIPTION
The following constants will be no longer included in user programs
by default:
- `e`
- `log2_e`
- `log10_e`
- `ln_2`
- `ln_10`
- `pi`
- `half_pi`
- `quarter_pi`
- `recipr_pi`
- `twice_recipr_pi`
- `twice_recipr_sqrt_pi`
- `sqrt_2`
- `recipr_sqrt_2`

Adjusts line numbers in the user's guide document for the altered
test.

Adds a test locking in the deprecation messages.  Modifies tests in
the testing system to add explicit uses or imports of the Math module
where they now live, as appropriate.

Note: modified one test to stop using `e` period - I believe it was a typo
and the test author intended to refer to a different symbol in the test
instead instead based on how other parts of the test are written.  By
stopping including `e` by default, it should now be easier to notice when
these accidents happen.

Passed a full paratest with futures