### PR TITLE
Test `stringify` deprecation

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2091,7 +2091,7 @@ module ChapelArray {
   pragma "no doc"
   operator :(x: [], type t:string) {
     use IO;
-    return stringify(x);
+    return try! string.ioWrite(x);
   }
 
   pragma "no doc"

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2595,7 +2595,7 @@ module ChapelDomain {
         return val._value.doiToString();
       } else {
         use IO;
-        return stringify(val);
+        return try! string.ioWrite(val);
       }
     }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2177,11 +2177,11 @@ module DefaultRectangular {
   private proc complexTransferComm(A, B, stridelevels:int(32), dstStride, srcStride, count, AFirst, BFirst) {
     if debugDefaultDistBulkTransfer {
       chpl_debug_writeln("BulkTransferStride with values:\n",
-                         "\tLocale        = ", stringify(here.id), "\n",
-                         "\tStride levels = ", stringify(stridelevels), "\n",
-                         "\tdstStride     = ", stringify(dstStride), "\n",
-                         "\tsrcStride     = ", stringify(srcStride), "\n",
-                         "\tcount         = ", stringify(count));
+                         "\tLocale        = ", try! string.ioWrite(here.id), "\n",
+                         "\tStride levels = ", try! string.ioWrite(stridelevels), "\n",
+                         "\tdstStride     = ", try! string.ioWrite(dstStride), "\n",
+                         "\tsrcStride     = ", try! string.ioWrite(srcStride), "\n",
+                         "\tcount         = ", try! string.ioWrite(count));
     }
 
     const AO = A.getDataIndex(AFirst, getShifted = false);

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -397,7 +397,7 @@ module UnitTest {
         }
         var shorterLength = min(len1, len2);
         tmpString = seq_type_name+"s differ: ";
-        tmpString += "'"+stringify(seq1)+"' != '"+stringify(seq2)+"'" ;
+        tmpString += "'" + string.ioWrite(seq1) + "' != '"+ string.ioWrite(seq2) + "'" ;
         for i in 0..#shorterLength {
           if seq1[i] != seq2[i] {
             tmpString += "\nFirst differing element at index "+i:string +":\n'"+seq1[i]:string+"'\n'"+seq2[i]:string+"'\n";
@@ -425,8 +425,8 @@ module UnitTest {
       array2: The second array to compare.
     */
     proc assertArrayEqual(array1: [], array2: []) throws {
-      const genericErrorMsg = "assert failed -\n'" + stringify(array1) +
-                              "'\nand\n'"+stringify(array2) + "'\n";
+      const genericErrorMsg = "assert failed -\n'" + string.ioWrite(array1) +
+                              "'\nand\n'"+string.ioWrite(array2) + "'\n";
 
       // Compare array types, size, and shape
       if array1.rank != array2.rank {
@@ -446,8 +446,8 @@ module UnitTest {
         // Compare array values
         const arraysEqual = && reduce (array1 == array2);
         if !arraysEqual {
-          const errorMsg = "assert failed -\n'" + stringify(array1) +
-                           "'\n!=\n'"+stringify(array2)+"'";
+          const errorMsg = "assert failed -\n'" + string.ioWrite(array1) +
+                           "'\n!=\n'"+string.ioWrite(array2)+"'";
           throw new owned AssertionError(errorMsg);
         }
       }
@@ -467,7 +467,7 @@ module UnitTest {
         assertSequenceEqual(tuple1,tuple2,"tuple("+firstType: string+")");
       }
       else {
-        var tmpString = "assert failed - '" + stringify(tuple1) +"' and '"+stringify(tuple2) + "' are not of same type";
+        var tmpString = "assert failed - '" + string.ioWrite(tuple1) +"' and '"+string.ioWrite(tuple2) + "' are not of same type";
         throw new owned AssertionError(tmpString);
       }
     }
@@ -499,12 +499,12 @@ module UnitTest {
     proc __baseAssertEqual(first, second) throws {
       if canResolve("!=",first,second) {
         if (first != second) {
-          var tmpString = "assert failed - '" + stringify(first) +"' != '"+stringify(second)+"'";
+          var tmpString = "assert failed - '" + string.ioWrite(first) +"' != '"+string.ioWrite(second)+"'";
           throw new owned AssertionError(tmpString);
         }
       }
       else {
-        var tmpString = "assert failed - '" + stringify(first) +"' and '"+stringify(second) + "' are not of same type";
+        var tmpString = "assert failed - '" + string.ioWrite(first) +"' and '"+string.ioWrite(second) + "' are not of same type";
         throw new owned AssertionError(tmpString);
       }
     }
@@ -552,7 +552,7 @@ module UnitTest {
     proc assertNotEqual(first, second) throws {
       if canResolve("!=",first, second) {
         if !checkAssertInequality(first,second) {
-          var tmpString = "assert failed -\n'" + stringify(first) +"'\n==\n'"+stringify(second)+"'";
+          var tmpString = "assert failed -\n'" + string.ioWrite(first) +"'\n==\n'"+string.ioWrite(second)+"'";
           throw new owned AssertionError(tmpString);
         }
       }
@@ -661,7 +661,7 @@ module UnitTest {
           }
         }
         else {
-          tmpString += "'"+stringify(seq1)+"'"+symbol+"'"+stringify(seq2)+"'" ;
+          tmpString += "'"+string.ioWrite(seq1)+"'"+symbol+"'"+string.ioWrite(seq2)+"'" ;
         }
         tmpString+=tmplarge;
       }
@@ -682,13 +682,13 @@ module UnitTest {
           }
           else { // can be reimplemented using `reduce`
             if all(array1 <= array2) {
-              var tmpString = "assert failed -\n'" + stringify(array1) +"'\n<=\n'"+stringify(array2)+"'";
+              var tmpString = "assert failed -\n'" + string.ioWrite(array1) +"'\n<=\n'"+string.ioWrite(array2)+"'";
               throw new owned AssertionError(tmpString);
             }
         }
         }
         else {
-          var tmpString = "assert failed - First element is of shape " + stringify(array1.shape) +" and Second is of shape "+stringify(array2.shape);
+          var tmpString = "assert failed - First element is of shape " + string.ioWrite(array1.shape) +" and Second is of shape "+string.ioWrite(array2.shape);
           throw new owned AssertionError(tmpString);
         }
       }
@@ -755,7 +755,7 @@ module UnitTest {
     /*The default assertGreater implementation, not type specific.*/
     proc __baseAssertGreater(first, second) throws {
       if all(first <= second) {
-        var tmpString = "assert failed - '" + stringify(first) +"' <= '"+stringify(second)+"'";
+        var tmpString = "assert failed - '" + string.ioWrite(first) +"' <= '"+string.ioWrite(second)+"'";
         throw new owned AssertionError(tmpString);
       }
     }
@@ -863,7 +863,7 @@ module UnitTest {
           }
         }
         else {
-          tmpString += "'"+stringify(seq1)+"'"+symbol+"'"+stringify(seq2)+"'" ;
+          tmpString += "'"+string.ioWrite(seq1)+"'"+symbol+"'"+string.ioWrite(seq2)+"'" ;
         }
         tmpString+=tmplarge;
       }
@@ -884,13 +884,13 @@ module UnitTest {
           }
           else {
             if all(array1 >= array2) {
-              var tmpString = "assert failed - \n'" + stringify(array1) +"'\n>=\n'"+stringify(array2)+"'";
+              var tmpString = "assert failed - \n'" + string.ioWrite(array1) +"'\n>=\n'"+string.ioWrite(array2)+"'";
               throw new owned AssertionError(tmpString);
             }
         }
         }
         else {
-          var tmpString = "assert failed - First element is of shape " + stringify(array1.shape) +" and Second is of shape "+stringify(array2.shape);
+          var tmpString = "assert failed - First element is of shape " + string.ioWrite(array1.shape) +" and Second is of shape "+string.ioWrite(array2.shape);
           throw new owned AssertionError(tmpString);
         }
       }
@@ -957,7 +957,7 @@ module UnitTest {
     /*The default assertGreater implementation, not type specific.*/
     proc __baseAssertLess(first, second) throws {
       if all(first >= second) {
-        var tmpString = "assert failed - '" + stringify(first) +"'>='"+stringify(second)+"'";
+        var tmpString = "assert failed - '" + string.ioWrite(first) +"'>='"+string.ioWrite(second)+"'";
         throw new owned AssertionError(tmpString);
       }
     }

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -878,8 +878,8 @@ module ChapelIO {
 
   pragma "no doc"
   proc chpl_stringify_wrapper(const args ...):string {
-    use IO only stringify;
-    return stringify((...args));
+    use IO only ioWrite;
+    return try! string.ioWrite((...args));
   }
 
   //
@@ -895,6 +895,6 @@ module ChapelIO {
   pragma "no doc"
   pragma "last resort"
   operator :(x, type t:string) where !isPrimitiveType(x.type) {
-    return stringify(x);
+    return try! string.ioWrite(x);
   }
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5883,7 +5883,7 @@ public use ChapelIOStringifyHelper;
     Writes each argument, possibly using a `writeThis` method,
     to a string and returns the result.
   */
-@deprecated("stringify is depredated; please use string.ioWrite instead")
+@deprecated("stringify is deprecated; please use string.ioWrite instead")
 proc stringify(const args ...?k):string {
   if _can_stringify_direct(args) {
     return stringify_simple((...args));
@@ -5926,8 +5926,8 @@ proc stringify(const args ...?k):string {
 
   :returns: A string containing the result of writing the arguments.
 
-  :throws SystemError: Thrown if an internal error occured (more information
-                       :ref:`here reason<io-general-sys-error>`).
+  :throws SystemError: Thrown if an error occured writing the string (more
+                       information :ref:`here<io-general-sys-error>`).
 */
 proc type string.ioWrite(const args ...?k):string throws {
   if _can_stringify_direct(args) {

--- a/test/distributions/robust/associative/basic/array_write.chpl
+++ b/test/distributions/robust/associative/basic/array_write.chpl
@@ -8,7 +8,7 @@ for i in D {
   DomIntType += myIdx;
   DomUintType += myIdx:uintType;
   DomRealType += myIdx:realType;
-  DomStringType += stringify(myIdx);
+  DomStringType += string.ioWrite(myIdx);
 }
 
 forall ai in DomIntType do


### PR DESCRIPTION
This PR deprecates `stringify` in favor of `IO.string.ioWrite` in order to test the implications of replacing `stringify` with a type method on `string`.