### PR TITLE
Fix regression in BigInteger operators with bools and promotion

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -962,7 +962,9 @@ module BigInteger {
   }
 
   // Bit-shift left
-  operator bigint.<<(const ref a: bigint, b: integral): bigint {
+  operator bigint.<<(const ref a: bigint, b): bigint
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     var c = new bigint();
     BigInteger.shiftLeft(c, a, b);
     return c;
@@ -982,7 +984,9 @@ module BigInteger {
 
 
   // Bit-shift right
-  operator bigint.>>(const ref a: bigint, b: integral): bigint {
+  operator bigint.>>(const ref a: bigint, b): bigint
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     var c = new bigint();
     BigInteger.shiftRight(c, a, b);
     return c;
@@ -1023,11 +1027,15 @@ module BigInteger {
     return a.cmp(b);
   }
 
-  private inline proc cmp(const ref a: bigint, b: integral) {
+  private inline proc cmp(const ref a: bigint, b)
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     return a.cmp(b);
   }
 
-  private inline proc cmp(a: integral, const ref b: bigint) {
+  private inline proc cmp(a, const ref b: bigint)
+  where isIntegralType(a.type) || isBoolType(a.type)
+  {
     const ret = b.cmp(a);
     return 0 - ret;
   }
@@ -1038,11 +1046,15 @@ module BigInteger {
     return BigInteger.cmp(a, b) == 0;
   }
 
-  operator bigint.==(const ref a: bigint, b: integral): bool {
+  operator bigint.==(const ref a: bigint, b): bool
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     return BigInteger.cmp(a, b) == 0;
   }
 
-  operator bigint.==(a: integral, const ref b: bigint): bool {
+  operator bigint.==(a, const ref b: bigint): bool
+  where isIntegralType(a.type) || isBoolType(a.type)
+  {
     return BigInteger.cmp(a, b) == 0;
   }
 
@@ -1053,11 +1065,15 @@ module BigInteger {
     return BigInteger.cmp(a, b) != 0;
   }
 
-  operator bigint.!=(const ref a: bigint, b: integral): bool {
+  operator bigint.!=(const ref a: bigint, b): bool
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     return BigInteger.cmp(a, b) != 0;
   }
 
-  operator bigint.!=(a: integral, const ref b: bigint): bool {
+  operator bigint.!=(a, const ref b: bigint): bool
+  where isIntegralType(a.type) || isBoolType(a.type)
+  {
     return BigInteger.cmp(a, b) != 0;
   }
 
@@ -1067,11 +1083,15 @@ module BigInteger {
     return BigInteger.cmp(a, b) > 0;
   }
 
-  operator bigint.>(const ref a: bigint, b: integral): bool {
+  operator bigint.>(const ref a: bigint, b): bool
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     return BigInteger.cmp(a, b) > 0;
   }
 
-  operator bigint.>(a: integral, const ref b: bigint): bool {
+  operator bigint.>(a, const ref b: bigint): bool
+  where isIntegralType(a.type) || isBoolType(a.type)
+  {
     return BigInteger.cmp(a, b) > 0;
   }
 
@@ -1082,11 +1102,15 @@ module BigInteger {
     return BigInteger.cmp(a, b) < 0;
   }
 
-  operator bigint.<(const ref a: bigint, b: integral): bool {
+  operator bigint.<(const ref a: bigint, b): bool
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     return BigInteger.cmp(a, b) < 0;
   }
 
-  operator bigint.<(a: integral, const ref b: bigint): bool {
+  operator bigint.<(a, const ref b: bigint): bool
+  where isIntegralType(a.type) || isBoolType(a.type)
+  {
     return BigInteger.cmp(a, b) < 0;
   }
 
@@ -1096,11 +1120,15 @@ module BigInteger {
     return BigInteger.cmp(a, b) >= 0;
   }
 
-  operator bigint.>=(const ref a: bigint, b: integral): bool {
+  operator bigint.>=(const ref a: bigint, b): bool
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     return BigInteger.cmp(a, b) >= 0;
   }
 
-  operator bigint.>=(a: integral, const ref b: bigint): bool {
+  operator bigint.>=(a, const ref b: bigint): bool
+  where isIntegralType(a.type) || isBoolType(a.type)
+  {
     return BigInteger.cmp(a, b) >= 0;
   }
 
@@ -1110,11 +1138,15 @@ module BigInteger {
     return BigInteger.cmp(a, b) <= 0;
   }
 
-  operator bigint.<=(const ref a: bigint, b: integral): bool {
+  operator bigint.<=(const ref a: bigint, b): bool
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     return BigInteger.cmp(a, b) <= 0;
   }
 
-  operator bigint.<=(a: integral, const ref b: bigint): bool {
+  operator bigint.<=(a, const ref b: bigint): bool
+    where isIntegralType(a.type) || isBoolType(a.type)
+  {
     return BigInteger.cmp(a, b) <= 0;
   }
 
@@ -1130,7 +1162,9 @@ module BigInteger {
     BigInteger.add(a, a, b);
   }
 
-  operator bigint.+=(ref a: bigint, b: integral) {
+  operator bigint.+=(ref a: bigint, b)
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     BigInteger.add(a, a, b);
   }
 
@@ -1141,7 +1175,9 @@ module BigInteger {
     BigInteger.sub(a, a, b);
   }
 
-  operator bigint.-=(ref a: bigint, b: integral) {
+  operator bigint.-=(ref a: bigint, b)
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     BigInteger.sub(a, a, b);
   }
 
@@ -1152,7 +1188,9 @@ module BigInteger {
     BigInteger.mul(a, a, b);
   }
 
-  operator bigint.*=(ref a: bigint, b: integral) {
+  operator bigint.*=(ref a: bigint, b)
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     BigInteger.mul(a, a, b);
   }
 
@@ -1278,14 +1316,18 @@ module BigInteger {
 
 
   // <<=
-  operator bigint.<<=(ref a: bigint, b: integral) {
+  operator bigint.<<=(ref a: bigint, b)
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     BigInteger.shiftLeft(a, a, b);
   }
 
 
 
   // >>=
-  operator bigint.>>=(ref a: bigint, b: integral) {
+  operator bigint.>>=(ref a: bigint, b)
+  where isIntegralType(b.type) || isBoolType(b.type)
+  {
     BigInteger.shiftRight(a, a, b);
   }
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -765,17 +765,23 @@ module BigInteger {
     return c;
   }
 
-  operator bigint.+(const ref a: bigint, b): bigint
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
+  operator bigint.+(const ref a: bigint, b: int): bigint {
+    var c = new bigint();
+    BigInteger.add(c, a, b);
+    return c;
+  }
+  operator bigint.+(const ref a: bigint, b: uint): bigint {
     var c = new bigint();
     BigInteger.add(c, a, b);
     return c;
   }
 
-  operator bigint.+(a, const ref b: bigint): bigint
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
+  operator bigint.+(a: int, const ref b: bigint): bigint {
+    var c = new bigint();
+    BigInteger.add(c, b, a);
+    return c;
+  }
+  operator bigint.+(a: uint, const ref b: bigint): bigint {
     var c = new bigint();
     BigInteger.add(c, b, a);
     return c;
@@ -790,17 +796,23 @@ module BigInteger {
     return c;
   }
 
-  operator bigint.-(const ref a: bigint, b): bigint
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
+  operator bigint.-(const ref a: bigint, b: int): bigint {
+    var c = new bigint();
+    BigInteger.sub(c, a, b);
+    return c;
+  }
+  operator bigint.-(const ref a: bigint, b: uint): bigint {
     var c = new bigint();
     BigInteger.sub(c, a, b);
     return c;
   }
 
-  operator bigint.-(a, const ref b: bigint): bigint
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
+  operator bigint.-(a: int, const ref b: bigint): bigint {
+    var c = new bigint();
+    BigInteger.sub(c, a, b);
+    return c;
+  }
+  operator bigint.-(a: uint, const ref b: bigint): bigint {
     var c = new bigint();
     BigInteger.sub(c, a, b);
     return c;
@@ -813,17 +825,23 @@ module BigInteger {
     return c;
   }
 
-  operator bigint.*(const ref a: bigint, b): bigint
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
+  operator bigint.*(const ref a: bigint, b: int): bigint {
+    var c = new bigint();
+    BigInteger.mul(c, a, b);
+    return c;
+  }
+  operator bigint.*(const ref a: bigint, b: uint): bigint {
     var c = new bigint();
     BigInteger.mul(c, a, b);
     return c;
   }
 
-  operator bigint.*(a, const ref b: bigint): bigint
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
+  operator bigint.*(a: int, const ref b: bigint): bigint {
+    var c = new bigint();
+    BigInteger.mul(c, b, a);
+    return c;
+  }
+  operator bigint.*(a: uint, const ref b: bigint): bigint {
     var c = new bigint();
     BigInteger.mul(c, b, a);
     return c;
@@ -962,9 +980,12 @@ module BigInteger {
   }
 
   // Bit-shift left
-  operator bigint.<<(const ref a: bigint, b): bigint
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
+  operator bigint.<<(const ref a: bigint, b: int): bigint {
+    var c = new bigint();
+    BigInteger.shiftLeft(c, a, b);
+    return c;
+  }
+  operator bigint.<<(const ref a: bigint, b: uint): bigint {
     var c = new bigint();
     BigInteger.shiftLeft(c, a, b);
     return c;
@@ -984,9 +1005,12 @@ module BigInteger {
 
 
   // Bit-shift right
-  operator bigint.>>(const ref a: bigint, b): bigint
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
+  operator bigint.>>(const ref a: bigint, b: int): bigint {
+    var c = new bigint();
+    BigInteger.shiftRight(c, a, b);
+    return c;
+  }
+  operator bigint.>>(const ref a: bigint, b: uint): bigint {
     var c = new bigint();
     BigInteger.shiftRight(c, a, b);
     return c;
@@ -1023,134 +1047,108 @@ module BigInteger {
   // Comparison Operations
   //
 
-  private inline proc cmp(const ref a: bigint, const ref b: bigint) {
-    return a.cmp(b);
-  }
+  private inline proc cmp(const ref a: bigint, const ref b: bigint)
+    do return a.cmp(b);
 
-  private inline proc cmp(const ref a: bigint, b)
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    return a.cmp(b);
-  }
+  private inline proc cmp(const ref a: bigint, b: int)
+    do return a.cmp(b);
+  private inline proc cmp(const ref a: bigint, b: uint)
+    do return a.cmp(b);
 
-  private inline proc cmp(a, const ref b: bigint)
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
-    const ret = b.cmp(a);
-    return 0 - ret;
-  }
+  private inline proc cmp(a: int, const ref b: bigint)
+    do return 0 - (b.cmp(a));
+  private inline proc cmp(a: uint, const ref b: bigint)
+    do return 0 - (b.cmp(a));
 
 
   // Equality
-  operator bigint.==(const ref a: bigint, const ref b: bigint): bool {
-    return BigInteger.cmp(a, b) == 0;
-  }
+  operator bigint.==(const ref a: bigint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) == 0;
 
-  operator bigint.==(const ref a: bigint, b): bool
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    return BigInteger.cmp(a, b) == 0;
-  }
+  operator bigint.==(const ref a: bigint, b: int): bool
+    do return BigInteger.cmp(a, b) == 0;
+  operator bigint.==(const ref a: bigint, b: uint): bool
+    do return BigInteger.cmp(a, b) == 0;
 
-  operator bigint.==(a, const ref b: bigint): bool
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
-    return BigInteger.cmp(a, b) == 0;
-  }
-
+  operator bigint.==(a: int, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) == 0;
+  operator bigint.==(a: uint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) == 0;
 
 
   // Inequality
-  operator bigint.!=(const ref a: bigint, const ref b: bigint): bool {
-    return BigInteger.cmp(a, b) != 0;
-  }
+  operator bigint.!=(const ref a: bigint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) != 0;
 
-  operator bigint.!=(const ref a: bigint, b): bool
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    return BigInteger.cmp(a, b) != 0;
-  }
+  operator bigint.!=(const ref a: bigint, b: int): bool
+    do return BigInteger.cmp(a, b) != 0;
+  operator bigint.!=(const ref a: bigint, b: uint): bool
+    do return BigInteger.cmp(a, b) != 0;
 
-  operator bigint.!=(a, const ref b: bigint): bool
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
-    return BigInteger.cmp(a, b) != 0;
-  }
+  operator bigint.!=(a: int, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) != 0;
+  operator bigint.!=(a: uint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) != 0;
 
 
   // Greater than
-  operator bigint.>(const ref a: bigint, const ref b: bigint): bool {
-    return BigInteger.cmp(a, b) > 0;
-  }
+  operator bigint.>(const ref a: bigint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) > 0;
 
-  operator bigint.>(const ref a: bigint, b): bool
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    return BigInteger.cmp(a, b) > 0;
-  }
+  operator bigint.>(const ref a: bigint, b: int): bool
+    do return BigInteger.cmp(a, b) > 0;
+  operator bigint.>(const ref a: bigint, b: uint): bool
+    do return BigInteger.cmp(a, b) > 0;
 
-  operator bigint.>(a, const ref b: bigint): bool
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
-    return BigInteger.cmp(a, b) > 0;
-  }
-
+  operator bigint.>(a: int, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) > 0;
+  operator bigint.>(a: uint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) > 0;
 
 
   // Less than
-  operator bigint.<(const ref a: bigint, const ref b: bigint): bool {
-    return BigInteger.cmp(a, b) < 0;
-  }
+  operator bigint.<(const ref a: bigint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) < 0;
 
-  operator bigint.<(const ref a: bigint, b): bool
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    return BigInteger.cmp(a, b) < 0;
-  }
+  operator bigint.<(const ref a: bigint, b: int): bool
+    do return BigInteger.cmp(a, b) < 0;
+  operator bigint.<(const ref a: bigint, b: uint): bool
+    do return BigInteger.cmp(a, b) < 0;
 
-  operator bigint.<(a, const ref b: bigint): bool
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
-    return BigInteger.cmp(a, b) < 0;
-  }
+  operator bigint.<(a: int, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) < 0;
+  operator bigint.<(a: uint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) < 0;
 
 
   // Greater than or equal
-  operator bigint.>=(const ref a: bigint, const ref b: bigint): bool {
-    return BigInteger.cmp(a, b) >= 0;
-  }
+  operator bigint.>=(const ref a: bigint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) >= 0;
 
-  operator bigint.>=(const ref a: bigint, b): bool
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    return BigInteger.cmp(a, b) >= 0;
-  }
+  operator bigint.>=(const ref a: bigint, b: int): bool
+    do return BigInteger.cmp(a, b) >= 0;
+  operator bigint.>=(const ref a: bigint, b: uint): bool
+    do return BigInteger.cmp(a, b) >= 0;
 
-  operator bigint.>=(a, const ref b: bigint): bool
-  where isIntegralType(a.type) || isBoolType(a.type)
-  {
-    return BigInteger.cmp(a, b) >= 0;
-  }
+  operator bigint.>=(a: int, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) >= 0;
+  operator bigint.>=(a: uint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) >= 0;
 
 
   // Less than or equal
-  operator bigint.<=(const ref a: bigint, const ref b: bigint): bool {
-    return BigInteger.cmp(a, b) <= 0;
-  }
+  operator bigint.<=(const ref a: bigint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) <= 0;
 
-  operator bigint.<=(const ref a: bigint, b): bool
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    return BigInteger.cmp(a, b) <= 0;
-  }
+  operator bigint.<=(const ref a: bigint, b: int): bool
+    do return BigInteger.cmp(a, b) <= 0;
+  operator bigint.<=(const ref a: bigint, b: uint): bool
+    do return BigInteger.cmp(a, b) <= 0;
 
-  operator bigint.<=(a, const ref b: bigint): bool
-    where isIntegralType(a.type) || isBoolType(a.type)
-  {
-    return BigInteger.cmp(a, b) <= 0;
-  }
-
-
+  operator bigint.<=(a: int, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) <= 0;
+  operator bigint.<=(a: uint, const ref b: bigint): bool
+    do return BigInteger.cmp(a, b) <= 0;
 
 
   //
@@ -1158,41 +1156,35 @@ module BigInteger {
   //
 
   // +=
-  operator bigint.+=(ref a: bigint, const ref b: bigint) {
-    BigInteger.add(a, a, b);
-  }
+  operator bigint.+=(ref a: bigint, const ref b: bigint)
+    do BigInteger.add(a, a, b);
 
-  operator bigint.+=(ref a: bigint, b)
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    BigInteger.add(a, a, b);
-  }
+  operator bigint.+=(ref a: bigint, b: int)
+    do BigInteger.add(a, a, b);
+  operator bigint.+=(ref a: bigint, b: uint)
+    do BigInteger.add(a, a, b);
 
 
 
   // -=
-  operator bigint.-=(ref a: bigint, const ref b: bigint) {
-    BigInteger.sub(a, a, b);
-  }
+  operator bigint.-=(ref a: bigint, const ref b: bigint)
+    do BigInteger.sub(a, a, b);
 
-  operator bigint.-=(ref a: bigint, b)
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    BigInteger.sub(a, a, b);
-  }
+  operator bigint.-=(ref a: bigint, b: int)
+    do BigInteger.sub(a, a, b);
+  operator bigint.-=(ref a: bigint, b: uint)
+    do BigInteger.sub(a, a, b);
 
 
 
   // *=
-  operator bigint.*=(ref a: bigint, const ref b: bigint) {
-    BigInteger.mul(a, a, b);
-  }
+  operator bigint.*=(ref a: bigint, const ref b: bigint)
+    do BigInteger.mul(a, a, b);
 
-  operator bigint.*=(ref a: bigint, b)
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    BigInteger.mul(a, a, b);
-  }
+  operator bigint.*=(ref a: bigint, b:  int)
+    do BigInteger.mul(a, a, b);
+  operator bigint.*=(ref a: bigint, b: uint)
+    do BigInteger.mul(a, a, b);
 
 
 
@@ -1316,20 +1308,18 @@ module BigInteger {
 
 
   // <<=
-  operator bigint.<<=(ref a: bigint, b)
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    BigInteger.shiftLeft(a, a, b);
-  }
+  operator bigint.<<=(ref a: bigint, b: int)
+    do BigInteger.shiftLeft(a, a, b);
+  operator bigint.<<=(ref a: bigint, b: uint)
+    do BigInteger.shiftLeft(a, a, b);
 
 
 
   // >>=
-  operator bigint.>>=(ref a: bigint, b)
-  where isIntegralType(b.type) || isBoolType(b.type)
-  {
-    BigInteger.shiftRight(a, a, b);
-  }
+  operator bigint.>>=(ref a: bigint, b:  int)
+    do BigInteger.shiftRight(a, a, b);
+  operator bigint.>>=(ref a: bigint, b: uint)
+    do BigInteger.shiftRight(a, a, b);
 
 
   // Swap

--- a/test/library/standard/BigInteger/apiTest.chpl
+++ b/test/library/standard/BigInteger/apiTest.chpl
@@ -87,6 +87,9 @@ on Locales[min(Locales.domain.high, executeLocale)] {
   s = a;
   s += 1:bigint;
   assert(s == b);
+  s = a;
+  s += (true);
+  assert(s == b);
 
   // Subtraction
 
@@ -126,7 +129,10 @@ on Locales[min(Locales.domain.high, executeLocale)] {
   s -= 1;
   assert(s == a);
   s = b;
-  s += -1:bigint;
+  s -= 1:bigint;
+  assert(s == a);
+  s = b;
+  s -= (true);
   assert(s == a);
 
   // Multiplication
@@ -168,6 +174,9 @@ on Locales[min(Locales.domain.high, executeLocale)] {
   s = a;
   s *= 1:bigint;
   assert(s == a);
+  s = a;
+  s *= true;
+  assert(s == a);
 
   assert(aa + bb == 327547);
   assert(aa + bb + cc == "3426495623485904783805894":bigint);
@@ -185,6 +194,8 @@ on Locales[min(Locales.domain.high, executeLocale)] {
   // Bit shifts
   assert(5:bigint  << 3   == 40);
   assert(5:bigint  >> 1   == 2);
+  assert(5:bigint  >> true== 2);
+  assert(5:bigint  << true== 10);
   assert(-5:bigint << 3   == -40);
   assert(-5:bigint >> 1   == -3);
   assert(5:bigint  >> -3  == 40);
@@ -203,6 +214,12 @@ on Locales[min(Locales.domain.high, executeLocale)] {
   assert(s == 10:bigint);
   s = 5:bigint;
   s >>= 1;
+  assert(s == 2:bigint);
+  s = 5:bigint;
+  s <<= (true);
+  assert(s == 10:bigint);
+  s = 5:bigint;
+  s >>= (true);
   assert(s == 2:bigint);
 
   // right shifting a negative value over its size will always result in -1,
@@ -300,6 +317,23 @@ on Locales[min(Locales.domain.high, executeLocale)] {
   assert(18:uint >  s);
   assert(18:uint >= s);
   assert(18:uint != s);
+
+  s = 1:bigint;
+  assert(s == (true));
+  assert(s >  (false));
+  assert(s >= (false));
+  s = 0:bigint;
+  assert(s <  (true));
+  assert(s <= (true));
+  assert(s != (true));
+  s = 1:bigint;
+  assert((true)  == s);
+  assert((false) <  s);
+  assert((false) <= s);
+  s = 0:bigint;
+  assert((true) >  s);
+  assert((true) >= s);
+  assert((true) != s);
 
 
 }

--- a/test/library/standard/BigInteger/apiTest.chpl
+++ b/test/library/standard/BigInteger/apiTest.chpl
@@ -335,5 +335,14 @@ on Locales[min(Locales.domain.high, executeLocale)] {
   assert((true) >= s);
   assert((true) != s);
 
+  // test comparison under promotion
+  var abc = [a, b, c];
+  assert(abc == [a, b, c]);
+  assert(abc > [1,2,3]);
+  assert(abc > 1);
+  assert(17:bigint > [1,2,3]);
+  var ss = [1:bigint, 2:bigint, 3:bigint];
+  assert(ss == [1,2,3]);
+
 
 }


### PR DESCRIPTION
Revert a change in #21986 where a number of BigInteger operators where changed from having an `int` version and a `uint` version to having an `integral` version (or a version type checked by a `where` clause). The `integral` version fails when passed a `bool` (see #20125 and #20011). The `where` clause version fails under promotion. 

## Summary of changes
- change methods previously changed to `integral`/`where` clause back to `int` and `uint`
- change some of these methods which are single lines to use `do` instead of `{}`.

## new tests
- add more tests for `bool` passed as integers to `apiTest.chpl`
- add a handful of operator promotion tests to `apiTest.chpl`

## testing
- local testing
- paratest
- build and run Arkouda tests

---

[Reviewed by @bmcdonald3 ]