### PR TITLE
Add a `foreach`-based optimized transpose benchmark

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -468,8 +468,12 @@ class GpuKernel {
 
   private:
   void buildStubOutlinedFunction(DefExpr* insertionPoint);
+  // Has a side effect of removing the block size primitive from the loop
+  // and the (future) outlined function.
   void handleAndRemoveBlockSize(CForLoop *loop);
   void populateBody(CForLoop *loop, FnSymbol *outlinedFunction);
+  // Has a side effect of modifying the original loop body, replacing
+  // calls to GPU-only primitives with dummy values and errors.
   void replaceDisallowedPrimitives();
   void normalizeOutlinedFunction();
   void finalize();

--- a/test/gpu/native/studies/transpose/transpose-throughput.graph
+++ b/test/gpu/native/studies/transpose/transpose-throughput.graph
@@ -1,5 +1,5 @@
-perfkeys: Performance (GB/s):, Performance (GB/s):
-files: transpose-lowlevel.dat, transpose-naive.dat
-graphkeys: Low Level, Naive
+perfkeys: Performance (GB/s):, Performance (GB/s):, Performance (GB/s):
+files: transpose-lowlevel.dat, transpose-naive.dat, transpose-clever.dat
+graphkeys: Low Level, Naive, Clever
 ylabel: Throughput (GB/s)
 graphtitle: Matrix Transpose Throughput

--- a/test/gpu/native/studies/transpose/transpose-time.graph
+++ b/test/gpu/native/studies/transpose/transpose-time.graph
@@ -1,5 +1,5 @@
-perfkeys: Wall clock time (s):, Wall clock time (s):
-files: transpose-lowlevel.dat, transpose-naive.dat
-graphkeys: Low Level, Naive
+perfkeys: Wall clock time (s):, Wall clock time (s):, Wall clock time (s):
+files: transpose-lowlevel.dat, transpose-naive.dat, transpose-clever.dat
+graphkeys: Low Level, Naive, Clever
 ylabel: Wall Clock Time (s)
 graphtitle: Matrix Transpose Time

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -24,7 +24,7 @@ inline proc transposeNaive(original, output) {
 inline proc transposeClever(original, output) {
   foreach 0..<original.size {
     assertOnGpu();
-    // setBlockSize(blockSize * blockSize);
+    setBlockSize(blockSize * blockSize);
     param paddedBlockSize = blockSize + blockPadding;
     var smArrPtr = createSharedArray(dataType, paddedBlockSize*blockSize);
 

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -18,7 +18,10 @@ config param blockPadding = 1;
 config type dataType = real(32);
 
 inline proc transposeNaive(original, output) {
-  foreach (x,y) in original.domain do output[y,x] = original[x,y];
+  foreach (x,y) in original.domain {
+    assertOnGpu();
+    output[y,x] = original[x,y];
+  }
 }
 
 inline proc transposeClever(original, output) {
@@ -110,12 +113,10 @@ on here.gpus[0] {
   var timer: stopwatch;
   for 1..#numTrials {
     timer.start();
-    if impl == naive {
-      transposeNaive(original, output);
-    } else if impl == clever {
-      transposeClever(original, output);
-    } else if impl == lowlevel {
-      transposeLowLevel(original, output);
+    select impl {
+      when naive do transposeNaive(original, output);
+      when clever do transposeClever(original, output);
+      when lowlevel do transposeLowLevel(original, output);
     }
     timer.stop();
   }

--- a/test/gpu/native/studies/transpose/transpose.gpu-execopts
+++ b/test/gpu/native/studies/transpose/transpose.gpu-execopts
@@ -1,2 +1,3 @@
---useNaive=false # transpose-lowlevel
---useNaive=true  # transpose-naive
+--impl=naive    # transpose-naive
+--impl=clever   # transpose-clever
+--impl=lowlevel # transpose-lowlevel


### PR DESCRIPTION
This PR adds a memory coalesced benchmark that does not use our three-dimensional kernel launch primitive. To make this work, this version of the benchmark includes code to compute the intended two-dimensional coordinates of each thread and block given their one-dimensional indices. 

To make this benchmark work, I also fixed two issues in the compiler:
* The `set blockSize` primitive did not work in multidimensional loops (note that these loops still have one-dimensional _kernels_ -- the outer loop is turned into a kernel, the inner loop is run on the GPU). This was because the GPU transformations expected the primitive to be in the top-level block in the outer loop body, but a multidimensional for loop will have a `CForLoop` inside the outer `CForLoop`, wrapping the primitive. This PR addresses this issue by allowing a `set blockSize` primitive to occur anywhere in the loop body (as long as there's only one). Note that it would even get lifted out of user-written loops and if-expressions; users attempting to conditionally set block size would be in for a surprise. Since this is a compiler primitive, I'm not too worried about this.
* GPU primitives like `get blockIdx x` are left in the non-GPU copy of the loop body, and lead to "linking errors" -- the compiler is unable to find the function to wire them up to, because that function is `__device__`-only. To fix this, specify a blocklist of GPU primitives that are explicitly not allowed on the CPU, and replace calls to these primitives with calls to `chpl_error`. 

Reviewed by @stonea -- thanks!

## Testing
- [x] GPU tests in `test/gpu/native` passed under CUDA, with the exception of `gpu/native/stringBytesConfig/bytesConfigIssue20276`, which is failing on `main` at this time.