### PR TITLE
Remove a test bot formula that is not required in weekly testing

### DIFF
--- a/util/packaging/docker/test/brew_install.bash
+++ b/util/packaging/docker/test/brew_install.bash
@@ -9,14 +9,6 @@ else
       echo "brew test-bot --only-tap-syntax succeeded"
 fi
 
-brew test-bot --only-formulae-detect
-    if [ $? -ne 0 ]; then
-      echo "brew test-bot --only-formulae-detect failed" 
-      exit 1
-      else
-      echo "brew test-bot --only-formulae-detect succeeded"
-    fi
-
 brew test-bot --only-setup
     if [ $? -ne 0 ]; then
       echo "brew test-bot --only-setup failed" 


### PR DESCRIPTION
To fix a failure in homebrew, removing a brew test that is not required in the weekly run.