### PR TITLE
Fix failing tests after tail() deprecation

### DIFF
--- a/test/distributions/bharshbarg/constInIdxBlock.chpl
+++ b/test/distributions/bharshbarg/constInIdxBlock.chpl
@@ -14,7 +14,7 @@ proc main() {
   //
   // This relies on 'idx' being a wide reference once passed to dsiAccess.
   //
-  on Locales.tail() {
+  on Locales.last {
     assert(idx.locale != here);
     assert(A.localSubdomain().contains(idx) == false);
     A.dsiAccess(idx) = 100;

--- a/test/optimizations/remoteValueForwarding/serialization/destroyGlobals.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/destroyGlobals.chpl
@@ -30,7 +30,7 @@ record Foo {
 const f = new Foo(new unmanaged Helper((1,2,3)));
 
 proc main() {
-  on Locales.tail() {
+  on Locales.last {
     if f.h.x(1) > 100 then halt();
   }
 }

--- a/test/optimizations/remoteValueForwarding/serialization/domains.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/domains.chpl
@@ -7,7 +7,7 @@ proc main() {
   var changingDom = {1..5};
 
   writeln("===== on-stmt (variable domain) =====");
-  on Locales.tail() {
+  on Locales.last {
     startCommDiagnostics();
     const dims = changingDom.dims();
     if dims(0).high > 1000 then halt("foo");
@@ -24,7 +24,7 @@ proc main() {
   resetCommDiagnostics();
 
   writeln("===== on-stmt (const domain) =====");
-  on Locales.tail() {
+  on Locales.last {
     startCommDiagnostics();
     const dims = Offsets.dims();
     if dims(0).high > 1000 then halt("foo");

--- a/test/optimizations/remoteValueForwarding/serialization/missingDeserializer.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/missingDeserializer.chpl
@@ -27,7 +27,7 @@ proc main() {
   const ff = new Foo(new unmanaged Helper((1,2,3)));
 
   startCommDiagnostics();
-  on Locales.tail() {
+  on Locales.last {
     if ff.h.x(1) == 100 then halt();
   }
   stopCommDiagnostics();

--- a/test/optimizations/remoteValueForwarding/serialization/returnsClass.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/returnsClass.chpl
@@ -20,7 +20,7 @@ record Foo {
 proc main() {
   const f = new Foo();
 
-  on Locales.tail() {
+  on Locales.last {
     if f.x(1) == 100 then halt();
   }
 }

--- a/test/optimizations/remoteValueForwarding/serialization/strings.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/strings.chpl
@@ -18,7 +18,7 @@ proc print(const msg : string) {
 proc main() {
   const localStr = "loc " * n;
 
-  on Locales.tail() {
+  on Locales.last {
     startCommDiagnostics();
     for s in globalStr {
       if s == "z" then halt();
@@ -27,7 +27,7 @@ proc main() {
   }
   print("global const string");
 
-  on Locales.tail() {
+  on Locales.last {
     startCommDiagnostics();
     for s in localStr {
       if s == "z" then halt();
@@ -42,7 +42,7 @@ proc main() {
   // utilize a fixed-size buffer within the serialized data to avoid GET-ing
   // the remote buffer.
   startCommDiagnostics();
-  on Locales.tail() {
+  on Locales.last {
     for s in shortStr {
       if s == "z" then halt();
     }


### PR DESCRIPTION
These tests started failing in our gasnet job after https://github.com/chapel-lang/chapel/pull/21648 which deprecated `Array.tail()`. This PR updates the tests to use `Array.last`.