### PR TITLE
Update DateTime symbols for camelCasing

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -365,7 +365,7 @@ module TomlParser {
         }
         // DateTime
         else if dt.match(val) {
-          var date = datetime.strptime(getToken(source), "%Y-%m-%dT%H:%M:%SZ");
+          var date = dateTime.strptime(getToken(source), "%Y-%m-%dT%H:%M:%SZ");
           return new shared Toml(date);
         }
         // Date
@@ -530,7 +530,7 @@ pragma "no doc"
  }
 
  pragma "no doc"
- operator Toml.=(ref t: shared Toml, dt: datetime) {
+ operator Toml.=(ref t: shared Toml, dt: dateTime) {
    compilerWarning("= overloads for Toml are deprecated");
    if t == nil {
      t = new shared Toml(dt);
@@ -589,7 +589,7 @@ used to recursively hold tables and respective values
       s: string,
       ld: date,
       ti: time,
-      dt: datetime,
+      dt: dateTime,
       dom: domain(1),
       arr: [dom] shared Toml?,
       A: map(string, shared Toml?, false),
@@ -633,7 +633,7 @@ used to recursively hold tables and respective values
     }
 
     // Datetime
-    proc init(dt: datetime) {
+    proc init(dt: dateTime) {
       this.dt = dt;
       this.tag = fieldDateTime;
     }
@@ -812,7 +812,7 @@ used to recursively hold tables and respective values
         t!.ti = ti;
       }
     }
-    proc set(tbl: string, dt: datetime) {
+    proc set(tbl: string, dt: dateTime) {
       ref t = this(tbl);
       if t == nil {
         t = new shared Toml(dt);

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -73,8 +73,10 @@ private extern proc chpl_timevalue_parts(t:           _timevalue,
 @deprecated(notes="The 'TimeUnits' type is deprecated. Please specify times in seconds in this module.")
 enum TimeUnits { microseconds, milliseconds, seconds, minutes, hours }
 
-/* Specifies the day of the week */
+@deprecated(notes="enum 'Day' is deprecated. Please use 'day' instead")
 enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturday }
+/* Specifies the day of the week */
+enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturday }
   /* Days in the week, starting with `Monday` = 0 */
   enum dayOfWeek {
     Monday =    0,
@@ -116,7 +118,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   private const DAYS_BEFORE_MONTH = init_days_before_month();
 
   /* The Unix Epoch date and time */
-  const unixEpoch = new datetime(1970, 1, 1);
+  const unixEpoch = new dateTime(1970, 1, 1);
 
   private const DI400Y = daysBeforeYear(401);
   private const DI100Y = daysBeforeYear(101);
@@ -145,10 +147,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Get the `time` since Unix Epoch in seconds
   */
-  proc timeSinceEpoch(): timedelta {
+  proc timeSinceEpoch(): timeDelta {
     var (seconds,microseconds):(real,real) = getTimeOfDay();
     microseconds = microseconds/1000000.0;
-    return new timedelta(seconds + microseconds);
+    return new timeDelta(seconds + microseconds);
   }
 
   pragma "no doc"
@@ -302,7 +304,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
     /* The minimum non-zero difference between two dates */
     proc type resolution {
-      return new timedelta(days=1);
+      return new timeDelta(days=1);
     }
   }
 
@@ -340,18 +342,18 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   /* A `date` object representing the current day */
   proc type date.today() {
     const timeSinceEpoch = getTimeOfDay();
-    const td = new timedelta(seconds=timeSinceEpoch(0),
+    const td = new timeDelta(seconds=timeSinceEpoch(0),
                              microseconds=timeSinceEpoch(1));
 
-    return unixEpoch.getdate() + td;
+    return unixEpoch.getDate() + td;
   }
 
   /* The date that is `timestamp` seconds from the epoch */
   proc type date.fromTimestamp(timestamp) {
     const sec = timestamp: int;
     const us = ((timestamp-sec) * 1000000 + 0.5): int;
-    const td = new timedelta(seconds=sec, microseconds=us);
-    return unixEpoch.getdate() + td;
+    const td = new timeDelta(seconds=sec, microseconds=us);
+    return unixEpoch.getDate() + td;
   }
 
   /* The `date` that is `ord` days from 1-1-0001 */
@@ -416,7 +418,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   proc date.isoCalendar() {
     proc findThursday(d: date) {
       var wd = d.weekday();
-      return d + new timedelta(days = (dayOfWeek.Thursday:int - wd:int));
+      return d + new timeDelta(days = (dayOfWeek.Thursday:int - wd:int));
     }
 
     proc findyear(d: date) {
@@ -426,9 +428,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     proc findFirstDayOfYear(year) {
       var thu = findThursday((new date(year, 1, 1)));
       if thu.year < year {
-        return thu + new timedelta(days=4);
+        return thu + new timeDelta(days=4);
       } else { // thu.year == year
-        return thu + new timedelta(days=-3);
+        return thu + new timeDelta(days=-3);
       }
     }
 
@@ -513,7 +515,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     f.write(isoFormat());
   }
 
-  // Exists to support some common functionality for `datetime.readThis`
+  // Exists to support some common functionality for `dateTime.readThis`
   pragma "no doc"
   proc date._readCore(f) throws {
     const dash = "-";
@@ -551,23 +553,23 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Operators on date values */
   pragma "no doc"
-  operator date.+(d: date, t: timedelta): date {
+  operator date.+(d: date, t: timeDelta): date {
     return date.fromOrdinal(d.toOrdinal() + t.days);
   }
 
   pragma "no doc"
-  operator date.+(t: timedelta, d: date): date {
+  operator date.+(t: timeDelta, d: date): date {
     return d + t;
   }
 
   pragma "no doc"
-  operator date.-(d: date, t: timedelta): date {
+  operator date.-(d: date, t: timeDelta): date {
     return date.fromOrdinal(d.toOrdinal() - t.days);
   }
 
   pragma "no doc"
-  operator date.-(d1: date, d2: date): timedelta {
-    return new timedelta(days=d1.toOrdinal() - d2.toOrdinal());
+  operator date.-(d1: date, d2: date): timeDelta {
+    return new timeDelta(days=d1.toOrdinal() - d2.toOrdinal());
   }
 
   pragma "no doc"
@@ -641,7 +643,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
     /* The minimum non-zero difference between two times */
     proc type resolution {
-      return new timedelta(microseconds=1);
+      return new timeDelta(microseconds=1);
     }
   }
 
@@ -758,27 +760,28 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   /* Return the offset from UTC */
   proc time.utcOffset() {
     if timezone.borrow() == nil {
-      return new timedelta();
+      return new timeDelta();
     } else {
-      return timezone!.utcOffset(datetime.now());
+      return timezone!.utcOffset(dateTime.now());
     }
   }
 
   /* Return the daylight saving time offset */
   proc time.dst() {
     if timezone.borrow() == nil {
-      return new timedelta();
+      return new timeDelta();
     } else {
-      return timezone!.dst(datetime.now());
+      return timezone!.dst(dateTime.now());
     }
   }
 
   /* Return the name of the timezone for this `time` value */
+  @unstable("'tzname' is unstable")
   proc time.tzname() {
     if timezone.borrow() == nil then
       return "";
     else
-      return timezone!.tzname(new datetime(1,1,1));
+      return timezone!.tzname(new dateTime(1,1,1));
   }
 
   /* Return a `string` matching the `format` argument for this `time` */
@@ -823,7 +826,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     f.write(isoFormat());
   }
 
-  // Exists to support some common functionality for `datetime.readThis`
+  // Exists to support some common functionality for `dateTime.readThis`
   pragma "no doc"
   proc time._readCore(f) throws {
     const colon = ":";
@@ -866,8 +869,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   pragma "no doc"
   operator time.==(t1: time, t2: time): bool {
-    var dt1 = datetime.combine(d=new date(2000, 1, 1), t=t1);
-    var dt2 = datetime.combine(d=new date(2000, 1, 1), t=t2);
+    var dt1 = dateTime.combine(d=new date(2000, 1, 1), t=t1);
+    var dt2 = dateTime.combine(d=new date(2000, 1, 1), t=t2);
     return dt1 == dt2;
   }
 
@@ -880,7 +883,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.<(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -893,21 +896,21 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      // As far as I can tell, python's datetime.time() comparisons don't
+      // As far as I can tell, python's dateTime.time() comparisons don't
       // pay attention to the timezones.
       // >>> central = pytz.timezone("US/Central")
       // >>> pacific = pytz.timezone("US/Pacific")
-      // >>> datetime.time(12,3,4,5,tz=central) >
-      //     datetime.time(12,3,4,5,tz=pacific)
+      // >>> dateTime.time(12,3,4,5,tz=central) >
+      //     dateTime.time(12,3,4,5,tz=pacific)
       // False
-      // >>> datetime.time(12,3,4,6,tz=central) >
-      //     datetime.time(12,3,4,5,tz=pacific)
+      // >>> dateTime.time(12,3,4,6,tz=central) >
+      //     dateTime.time(12,3,4,5,tz=pacific)
       // True
       //
       // This compares the time on a specific date, and factors in the
       // time zones.
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 < dt2;
       //return (t1.replace(tz=nil) - t1.utcOffset()) <
       //       (t2.replace(tz=nil) - t2.utcOffset());
@@ -918,7 +921,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.<=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -931,8 +934,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 <= dt2;
     }
   }
@@ -941,7 +944,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.>(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -954,8 +957,8 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 > dt2;
     }
   }
@@ -964,7 +967,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   operator time.>=(t1: time, t2: time): bool {
     if (t1.timezone.borrow() != nil && t2.timezone.borrow() == nil) ||
         (t1.timezone.borrow() == nil && t2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if t1.timezone == t2.timezone {
       const sec1 = t1.hour*3600 + t1.minute*60 + t1.second;
       const usec1 = t1.microsecond;
@@ -977,14 +980,17 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       else
         return false;
     } else {
-      const dt1 = datetime.combine(new date(1900, 1, 1), t1);
-      const dt2 = datetime.combine(new date(1900, 1, 1), t2);
+      const dt1 = dateTime.combine(new date(1900, 1, 1), t1);
+      const dt2 = dateTime.combine(new date(1900, 1, 1), t2);
       return dt1 >= dt2;
     }
   }
 
+  @deprecated(notes="'datetime' is deprecated, please use 'dateTime' instead")
+  type datetime = dateTime;
+
   /* A record representing a combined `date` and `time` */
-  record datetime {
+  record dateTime {
     pragma "no doc"
     var chpl_date: date;
     pragma "no doc"
@@ -1000,47 +1006,47 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       return this.combine(date.max, time.max);
     }
 
-    /* The minimum non-zero difference between two datetimes */
+    /* The minimum non-zero difference between two dateTimes */
     proc type resolution {
-      return new timedelta(microseconds=1);
+      return new timeDelta(microseconds=1);
     }
 
-    /* The year represented by this `datetime` value */
+    /* The year represented by this `dateTime` value */
     proc year {
       return chpl_date.year;
     }
 
-    /* The month represented by this `datetime` value */
+    /* The month represented by this `dateTime` value */
     proc month {
       return chpl_date.month;
     }
 
-    /* The day represented by this `datetime` value */
+    /* The day represented by this `dateTime` value */
     proc day {
       return chpl_date.day;
     }
 
-    /* The hour represented by this `datetime` value */
+    /* The hour represented by this `dateTime` value */
     proc hour {
       return chpl_time.hour;
     }
 
-    /* The minute represented by this `datetime` value */
+    /* The minute represented by this `dateTime` value */
     proc minute {
       return chpl_time.minute;
     }
 
-    /* The second represented by this `datetime` value */
+    /* The second represented by this `dateTime` value */
     proc second {
       return chpl_time.second;
     }
 
-    /* The microsecond represented by this `datetime` value */
+    /* The microsecond represented by this `dateTime` value */
     proc microsecond {
       return chpl_time.microsecond;
     }
 
-    /* The timezone represented by this `datetime` value */
+    /* The timezone represented by this `dateTime` value */
     proc timezone {
       return chpl_time.timezone;
     }
@@ -1052,62 +1058,62 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* initializers/factories for datetime values */
+  /* initializers/factories for dateTime values */
 
   pragma "no doc"
-  proc datetime.init() {
+  proc dateTime.init() {
   }
 
-  /* Initialize a new `datetime` value from the given `year`, `month`, `day`,
+  /* Initialize a new `dateTime` value from the given `year`, `month`, `day`,
      `hour`, `minute`, `second`, `microsecond` and timezone.  The `year`,
      `month`, and `day` arguments are required, the rest are optional.
    */
   @unstable("tz is unstable; its type may change in the future")
-  proc datetime.init(year:int, month:int, day:int,
+  proc dateTime.init(year:int, month:int, day:int,
                      hour:int=0, minute:int=0, second:int=0, microsecond:int=0,
                      in tz) {
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond, tz);
   }
 
-  /* Initialize a new `datetime` value from the given `year`, `month`, `day`,
+  /* Initialize a new `dateTime` value from the given `year`, `month`, `day`,
      `hour`, `minute`, `second`, `microsecond` and timezone.  The `year`,
      `month`, and `day` arguments are required, the rest are optional.
    */
-  proc datetime.init(year:int, month:int, day:int,
+  proc dateTime.init(year:int, month:int, day:int,
                      hour:int=0, minute:int=0, second:int=0, microsecond:int=0) {
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond);
   }
 
-  /* Initialize a new `datetime` value from the given `date` and `time` */
-  proc datetime.init(d: date, t: time) {
+  /* Initialize a new `dateTime` value from the given `date` and `time` */
+  proc dateTime.init(d: date, t: time) {
     chpl_date = d;
     chpl_time = t;
   }
 
-  /* Return a `datetime` value representing the current time and date */
-  proc type datetime.now() {
+  /* Return a `dateTime` value representing the current time and date */
+  proc type dateTime.now() {
     const timeSinceEpoch = getTimeOfDay();
     const lt = getLocalTime(timeSinceEpoch);
-    return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+    return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                         day=lt.tm_mday,       hour=lt.tm_hour,
                         minute=lt.tm_min,     second=lt.tm_sec,
                         microsecond=timeSinceEpoch(1));
   }
 
-  /* Return a `datetime` value representing the current time and date */
-  proc type datetime.now(in tz: shared Timezone?) {
+  /* Return a `dateTime` value representing the current time and date */
+  proc type dateTime.now(in tz: shared Timezone?) {
     if tz.borrow() == nil {
       const timeSinceEpoch = getTimeOfDay();
       const lt = getLocalTime(timeSinceEpoch);
-      return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+      return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                           day=lt.tm_mday,       hour=lt.tm_hour,
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=timeSinceEpoch(1));
     } else {
       const timeSinceEpoch = getTimeOfDay();
-      const td = new timedelta(seconds=timeSinceEpoch(0),
+      const td = new timeDelta(seconds=timeSinceEpoch(0),
                                microseconds=timeSinceEpoch(1));
       const utcNow = unixEpoch + td;
 
@@ -1115,61 +1121,66 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* Return a `datetime` value representing the current time and date in UTC */
-  proc type datetime.utcNow() {
+  /* Return a `dateTime` value representing the current time and date in UTC */
+  proc type dateTime.utcNow() {
     const timeSinceEpoch = getTimeOfDay();
-    const td = new timedelta(seconds=timeSinceEpoch(0),
+    const td = new timeDelta(seconds=timeSinceEpoch(0),
                              microseconds=timeSinceEpoch(1));
     return unixEpoch + td;
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch */
-  proc type datetime.fromTimestamp(timestamp: real) {
-    return datetime.fromTimestamp(timestamp, nil);
+  /* The `dateTime` that is `timestamp` seconds from the epoch */
+  proc type dateTime.fromTimestamp(timestamp: real) {
+    return dateTime.fromTimestamp(timestamp, nil);
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch */
+  /* The `dateTime` that is `timestamp` seconds from the epoch */
   @unstable("tz is unstable; its type may change in the future")
-  proc type datetime.fromTimestamp(timestamp: real,
+  proc type dateTime.fromTimestamp(timestamp: real,
                                    in tz: shared Timezone?) {
     if tz.borrow() == nil {
       var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);
       const lt = getLocalTime(t);
-      return new datetime(year=lt.tm_year+1900, month=lt.tm_mon+1,
+      return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
                           day=lt.tm_mday,       hour=lt.tm_hour,
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=t(1));
     } else {
-      var dt = datetime.utcFromTimestamp(timestamp);
+      var dt = dateTime.utcFromTimestamp(timestamp);
       return (dt + tz!.utcOffset(dt)).replace(tz=tz);
     }
   }
 
-  /* The `datetime` that is `timestamp` seconds from the epoch in UTC */
-  proc type datetime.utcFromTimestamp(timestamp) {
-    return unixEpoch + new timedelta(seconds=timestamp: int, microseconds=((timestamp-timestamp: int)*1000000): int);
+  /* The `dateTime` that is `timestamp` seconds from the epoch in UTC */
+  proc type dateTime.utcFromTimestamp(timestamp) {
+    return unixEpoch + new timeDelta(seconds=timestamp: int, microseconds=((timestamp-timestamp: int)*1000000): int);
   }
 
-  /* The `datetime` that is `ordinal` days from 1-1-0001 */
-  proc type datetime.fromOrdinal(ordinal) {
-    return datetime.combine(date.fromOrdinal(ordinal), new time());
+  /* The `dateTime` that is `ordinal` days from 1-1-0001 */
+  proc type dateTime.fromOrdinal(ordinal) {
+    return dateTime.combine(date.fromOrdinal(ordinal), new time());
   }
 
-  /* Form a `datetime` value from a given `date` and `time` */
-  proc type datetime.combine(d: date, t: time) {
-    return new datetime(d.year, d.month, d.day,
+  /* Form a `dateTime` value from a given `date` and `time` */
+  proc type dateTime.combine(d: date, t: time) {
+    return new dateTime(d.year, d.month, d.day,
                         t.hour, t.minute, t.second, t.microsecond, t.timezone);
   }
 
-  /* Methods on datetime values */
+  /* Methods on dateTime values */
 
-  /* Get the `date` portion of the `datetime` value */
-  proc datetime.getdate() {
+  @deprecated(notes="'dateTime.getdate' is deprecated. Please use 'dateTime.getDate' instead")
+  proc dateTime.getdate() {
     return chpl_date;
   }
 
-  /* Get the `time` portion of the `datetime` value, with `tz` = nil */
-  proc datetime.gettime() {
+  /* Get the `date` portion of the `dateTime` value */
+  proc dateTime.getDate() {
+    return chpl_date;
+  }
+
+  @deprecated(notes="'dateTime.gettime' is deprecated. Please use 'dateTime.getTime' instead")
+  proc dateTime.gettime() {
     if chpl_time.timezone.borrow() == nil then
       return chpl_time;
     else
@@ -1177,21 +1188,30 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                       second=second, microsecond=microsecond);
   }
 
-  /* Get the `time` portion of the `datetime` value including the
+  /* Get the `time` portion of the `dateTime` value, with `tz` = nil */
+  proc dateTime.getTime() {
+    if chpl_time.timezone.borrow() == nil then
+      return chpl_time;
+    else
+      return new time(hour=hour, minute=minute,
+                      second=second, microsecond=microsecond);
+  }
+
+  /* Get the `time` portion of the `dateTime` value including the
      `tz` field
    */
-  proc datetime.timetz() {
+  proc dateTime.timetz() {
     return chpl_time;
   }
 
   /* Replace the `year`, `month`, `day`, `hour`, `minute`, `second`,
-     `microsecond`, or `tz` to form a new `datetime` object. All
+     `microsecond`, or `tz` to form a new `dateTime` object. All
      arguments are optional.
    */
-  proc datetime.replace(year=-1, month=-1, day=-1,
+  proc dateTime.replace(year=-1, month=-1, day=-1,
                         hour=-1, minute=-1, second=-1, microsecond=-1,
                         in tz=this.timezone) {
-    return datetime.combine(
+    return dateTime.combine(
       new date(if year == -1 then this.year else year,
                if month == -1 then this.month else month,
                if day == -1 then this.day else day),
@@ -1204,7 +1224,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Return the date and time converted into the timezone in the argument */
   @unstable("tz is unstable; its type may change in the future")
-  proc datetime.astimezone(in tz: shared Timezone) {
+  proc dateTime.astimezone(in tz: shared Timezone) {
     if timezone == tz {
       return this;
     }
@@ -1213,31 +1233,32 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* Return the offset from UTC */
-  proc datetime.utcOffset() {
+  proc dateTime.utcOffset() {
     if timezone.borrow() == nil {
-      halt("utcOffset called on naive datetime");
+      halt("utcOffset called on naive dateTime");
     } else {
       return timezone!.utcOffset(this);
     }
   }
   /* Return the daylight saving time offset */
-  proc datetime.dst() {
+  proc dateTime.dst() {
     if timezone.borrow() == nil then
       halt("dst() called with nil timezone");
     return timezone!.dst(this);
   }
 
-  /* Return the name of the timezone for this `datetime` value */
-  proc datetime.tzname() {
+  /* Return the name of the timezone for this `dateTime` value */
+  @unstable("'tzname' is unstable")
+  proc dateTime.tzname() {
     if timezone.borrow() == nil then
       return "";
     return timezone!.tzname(this);
   }
 
   /* Return a filled record matching the C `struct tm` type for the given
-     `datetime` */
-  @unstable("'datetime.timetuple' is unstable")
-  proc datetime.timetuple() {
+     `dateTime` */
+  @unstable("'dateTime.timetuple' is unstable")
+  proc dateTime.timetuple() {
     var timeStruct: tm;
     timeStruct.tm_sec = second: int(32);
     timeStruct.tm_min = minute: int(32);
@@ -1250,7 +1271,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
     if timezone.borrow() == nil {
       timeStruct.tm_isdst = -1;
-    } else if dst() == new timedelta(0) {
+    } else if dst() == new timeDelta(0) {
       timeStruct.tm_isdst = 0;
     } else {
       timeStruct.tm_isdst = 1;
@@ -1260,10 +1281,10 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* Return a filled record matching the C `struct tm` type for the given
-     `datetime` in UTC
+     `dateTime` in UTC
    */
-  @unstable("'datetime.utctimetuple' is unstable")
-  proc datetime.utctimetuple() {
+  @unstable("'dateTime.utctimetuple' is unstable")
+  proc dateTime.utctimetuple() {
     if timezone.borrow() == nil {
       var ret = timetuple();
       ret.tm_isdst = 0;
@@ -1276,46 +1297,46 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  /* Return the number of days since 1-1-0001 this `datetime` represents */
-  proc datetime.toOrdinal() {
-    return getdate().toOrdinal();
+  /* Return the number of days since 1-1-0001 this `dateTime` represents */
+  proc dateTime.toOrdinal() {
+    return getDate().toOrdinal();
   }
 
   /* Return the day of the week as a `dayOfWeek`.
      `Monday` == 0, `Sunday` == 6
    */
-  proc datetime.weekday() {
-    return getdate().weekday();
+  proc dateTime.weekday() {
+    return getDate().weekday();
   }
 
   /* Return the day of the week as an `isoDayOfWeek`.
      `Monday` == 1, `Sunday` == 7
    */
-  proc datetime.isoWeekday() {
-    return getdate().isoWeekday();
+  proc dateTime.isoWeekday() {
+    return getDate().isoWeekday();
   }
 
   pragma "no doc"
   @deprecated(notes="'isoweekday' is deprecated, please use 'isoWeekday' instead")
-  proc datetime.isoweekday() {
+  proc dateTime.isoweekday() {
     return isoWeekday();
   }
 
   /* Return the ISO date as a tuple containing the ISO year, ISO week number,
      and ISO day of the week
    */
-  proc datetime.isoCalendar() {
-    return getdate().isoCalendar();
+  proc dateTime.isoCalendar() {
+    return getDate().isoCalendar();
   }
 
   pragma "no doc"
   @deprecated(notes="'isocalendar' is deprecated, please use 'isoCalendar' instead")
-  proc datetime.isocalendar() {
-    return getdate().isoCalendar();
+  proc dateTime.isocalendar() {
+    return getDate().isoCalendar();
   }
 
-  /* Return the `datetime` as a `string` in ISO format */
-  proc datetime.isoFormat(sep="T") {
+  /* Return the `dateTime` as a `string` in ISO format */
+  proc dateTime.isoFormat(sep="T") {
     proc zeroPad(nDigits: int, i: int) {
       var numStr = i: string;
       for i in 1..nDigits-numStr.size {
@@ -1328,7 +1349,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if timezone.borrow() != nil {
       var utcoff = utcOffset();
       var sign: string;
-      if utcoff < new timedelta(0) {
+      if utcoff < new timeDelta(0) {
         sign = '-';
         utcoff = abs(utcoff);
       } else {
@@ -1348,16 +1369,16 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return strftime(year + "-%m-%d" + sep + "%H:%M:%S" + micro + offset);
   }
 
-  /* Create a `datetime` as described by the `date_string` and
+  /* Create a `dateTime` as described by the `date_string` and
      `format` string.  Note that this routine currently only supports
      the format strings of C's strptime().
   */
-  @unstable("'datetime.strptime' is unstable")
-  proc type datetime.strptime(date_string: string, format: string) {
+  @unstable("'dateTime.strptime' is unstable")
+  proc type dateTime.strptime(date_string: string, format: string) {
     extern proc strptime(buf: c_string, format: c_string, ref ts: tm);
     var timeStruct: tm;
     strptime(date_string.c_str(), format.c_str(), timeStruct);
-    return new datetime(timeStruct.tm_year + 1900,
+    return new dateTime(timeStruct.tm_year + 1900,
                         timeStruct.tm_mon + 1,
                         timeStruct.tm_mday,
                         timeStruct.tm_hour,
@@ -1365,9 +1386,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                         timeStruct.tm_sec);
   }
 
-  /* Create a `string` from a `datetime` matching the `format` string */
-  @unstable("'datetime.strftime' is unstable")
-  proc datetime.strftime(fmt: string) {
+  /* Create a `string` from a `dateTime` matching the `format` string */
+  @unstable("'dateTime.strftime' is unstable")
+  proc dateTime.strftime(fmt: string) {
     extern proc strftime(s: c_void_ptr, size: c_size_t, format: c_string, ref timeStruct: tm);
     const bufLen: c_size_t = 100;
     var buf: [1..bufLen] c_char;
@@ -1391,7 +1412,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     timeStruct.tm_mon = (month-1): int(32);    // 0 based
     timeStruct.tm_mday = day: int(32);
     timeStruct.tm_wday = (weekday(): int(32) + 1) % 7; // shift Sunday to 0
-    timeStruct.tm_yday = (this.replace(tz=nil) - new datetime(year, 1, 1)).days: int(32);
+    timeStruct.tm_yday = (this.replace(tz=nil) - new dateTime(year, 1, 1)).days: int(32);
 
     // Iterate over format specifiers in strftime(), replacing %f with microseconds
     iter strftok(const ref s: string)
@@ -1436,21 +1457,21 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return str;
   }
 
-  /* Return a `string` from a `datetime` in the form:
+  /* Return a `string` from a `dateTime` in the form:
      Wed Dec  4 20:30:40 2002
   */
-  @unstable("'datetime.ctime' is unstable")
-  proc datetime.ctime() {
+  @unstable("'dateTime.ctime' is unstable")
+  proc dateTime.ctime() {
     return this.strftime("%a %b %e %T %Y");
   }
 
-  /* Writes this `datetime` in ISO format: YYYY-MM-DDThh:mm:ss.sss */
-  proc datetime.writeThis(f) throws {
+  /* Writes this `dateTime` in ISO format: YYYY-MM-DDThh:mm:ss.sss */
+  proc dateTime.writeThis(f) throws {
     f.write(isoFormat());
   }
 
-  /* Reads this `datetime` from ISO format: YYYY-MM-DDThh:mm:ss.sss */
-  proc datetime.readThis(f) throws {
+  /* Reads this `dateTime` from ISO format: YYYY-MM-DDThh:mm:ss.sss */
+  proc dateTime.readThis(f) throws {
     const binary = f.binary(),
           arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY),
           isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;
@@ -1470,18 +1491,18 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   // TODO: need to get this to work with the Json formatter
   //
   pragma "no doc"
-  proc datetime.init(f: fileReader) {
+  proc dateTime.init(f: fileReader) {
     this.init();
     readThis(f);
   }
 
 
-  // TODO: Add a datetime.timestamp() method
+  // TODO: Add a dateTime.timestamp() method
 
-  /* Operators on datetime values */
+  /* Operators on dateTime values */
 
   pragma "no doc"
-  operator datetime.+(td: timedelta, dt: datetime) {
+  operator dateTime.+(td: timeDelta, dt: dateTime) {
     var newmicro = dt.microsecond + td.microseconds;
     var newsec = dt.second + td.seconds;
     var newmin = dt.minute;
@@ -1500,7 +1521,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     var adddays = td.days + newhour / 24;
     newhour %= 24;
 
-    return datetime.combine(date.fromOrdinal(dt.getdate().toOrdinal()+adddays),
+    return dateTime.combine(date.fromOrdinal(dt.getDate().toOrdinal()+adddays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tz=dt.timezone));
@@ -1508,12 +1529,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.+(dt: datetime, td: timedelta) {
+  operator dateTime.+(dt: dateTime, td: timeDelta) {
     return td + dt;
   }
 
   pragma "no doc"
-  operator datetime.-(dt: datetime, td: timedelta) {
+  operator dateTime.-(dt: dateTime, td: timeDelta) {
     var deltasec  = td.seconds % 60;
     var deltamin  = (td.seconds / 60) % 60;
     var deltahour = td.seconds / (60*60);
@@ -1541,17 +1562,17 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       subDays += 1;
       newhour += 24;
     }
-    return datetime.combine(date.fromOrdinal(dt.getdate().toOrdinal()-subDays),
+    return dateTime.combine(date.fromOrdinal(dt.getDate().toOrdinal()-subDays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tz=dt.timezone));
   }
 
   pragma "no doc"
-  operator datetime.-(dt1: datetime, dt2: datetime): timedelta {
+  operator dateTime.-(dt1: dateTime, dt2: dateTime): timeDelta {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
        (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     }
     if dt1.timezone == dt2.timezone {
       const newmicro = dt1.microsecond - dt2.microsecond,
@@ -1559,7 +1580,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
             newmin = dt1.minute - dt2.minute,
             newhour = dt1.hour - dt2.hour,
             newday = dt1.toOrdinal() - dt2.toOrdinal();
-      return new timedelta(days=newday, hours=newhour, minutes=newmin,
+      return new timeDelta(days=newday, hours=newhour, minutes=newmin,
                            seconds=newsec, microseconds=newmicro);
     } else {
       return dt1.replace(tz=nil) -
@@ -1569,16 +1590,16 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.==(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.==(dt1: dateTime, dt2: dateTime): bool {
     if dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil ||
        dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil {
-      halt("Cannot compare naive datetime to aware datetime");
+      halt("Cannot compare naive dateTime to aware dateTime");
     } else if dt1.timezone == dt2.timezone {
       // just ignore timezone
-      var d1: date = dt1.replace(tz=nil).getdate(),
-          d2: date = dt2.replace(tz=nil).getdate();
-      var t1: time = dt1.replace(tz=nil).gettime(),
-          t2: time = dt2.replace(tz=nil).gettime();
+      var d1: date = dt1.replace(tz=nil).getDate(),
+          d2: date = dt2.replace(tz=nil).getDate();
+      var t1: time = dt1.replace(tz=nil).getTime(),
+          t2: time = dt2.replace(tz=nil).getTime();
 
       return d1.year == d2.year && d1.month == d2.month && d1.day == d2.day &&
                         t1.hour == t2.hour && t1.minute == t2.minute &&
@@ -1591,21 +1612,21 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.!=(dt1: datetime, dt2: datetime) {
+  operator dateTime.!=(dt1: dateTime, dt2: dateTime) {
     return !(dt1 == dt2);
   }
 
   pragma "no doc"
-  operator datetime.<(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.<(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
-      const date1 = dt1.getdate(),
-            date2 = dt2.getdate();
+      const date1 = dt1.getDate(),
+            date2 = dt2.getDate();
       if date1 < date2 then return true;
       else if date2 < date1 then return false;
-      else return dt1.gettime() < dt2.gettime();
+      else return dt1.getTime() < dt2.getTime();
     } else {
       return (dt1.replace(tz=nil) - dt1.utcOffset()) <
              (dt2.replace(tz=nil) - dt2.utcOffset());
@@ -1613,16 +1634,16 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.<=(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.<=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
-      const date1 = dt1.getdate(),
-            date2 = dt2.getdate();
+      const date1 = dt1.getDate(),
+            date2 = dt2.getDate();
       if date1 < date2 then return true;
       else if date2 < date1 then return false;
-      else return dt1.gettime() <= dt2.gettime();
+      else return dt1.getTime() <= dt2.getTime();
     } else {
       return (dt1.replace(tz=nil) - dt1.utcOffset()) <=
              (dt2.replace(tz=nil) - dt2.utcOffset());
@@ -1630,16 +1651,16 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.>(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.>(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
-      const date1 = dt1.getdate(),
-            date2 = dt2.getdate();
+      const date1 = dt1.getDate(),
+            date2 = dt2.getDate();
       if date1 > date2 then return true;
       else if date2 > date1 then return false;
-      else return dt1.gettime() > dt2.gettime();
+      else return dt1.getTime() > dt2.getTime();
     } else {
       return (dt1.replace(tz=nil) - dt1.utcOffset()) >
              (dt2.replace(tz=nil) - dt2.utcOffset());
@@ -1647,16 +1668,16 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator datetime.>=(dt1: datetime, dt2: datetime): bool {
+  operator dateTime.>=(dt1: dateTime, dt2: dateTime): bool {
     if (dt1.timezone.borrow() != nil && dt2.timezone.borrow() == nil) ||
         (dt1.timezone.borrow() == nil && dt2.timezone.borrow() != nil) {
-      halt("both datetimes must both be either naive or aware");
+      halt("both dateTimes must both be either naive or aware");
     } else if dt1.timezone == dt2.timezone {
-      const date1 = dt1.getdate(),
-            date2 = dt2.getdate();
+      const date1 = dt1.getDate(),
+            date2 = dt2.getDate();
       if date1 > date2 then return true;
       else if date2 > date1 then return false;
-      else return dt1.gettime() >= dt2.gettime();
+      else return dt1.getTime() >= dt2.getTime();
     } else {
       return (dt1.replace(tz=nil) - dt1.utcOffset()) >=
              (dt2.replace(tz=nil) - dt2.utcOffset());
@@ -1664,8 +1685,9 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
 
-
-  /* A record representing an amount of time.  A `timedelta` has fields
+  @deprecated(notes="'timedelta' is deprecated. Please use 'timeDelta' instead")
+  type timedelta = timeDelta;
+  /* A record representing an amount of time.  A `timeDelta` has fields
      representing days, seconds, and microseconds.  These fields are always
      kept within the following ranges:
 
@@ -1677,7 +1699,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
      It is an overflow error if `days` is outside the given range.
    */
-  record timedelta {
+  record timeDelta {
     pragma "no doc"
     var chpl_days: int;
 
@@ -1687,47 +1709,47 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     pragma "no doc"
     var chpl_microseconds: int;
 
-    /* The number of days this `timedelta` represents */
+    /* The number of days this `timeDelta` represents */
     proc days {
       return chpl_days;
     }
 
-    /* The number of seconds this `timedelta` represents */
+    /* The number of seconds this `timeDelta` represents */
     proc seconds {
       return chpl_seconds;
     }
 
-    /* The number of microseconds this `timedelta` represents */
+    /* The number of microseconds this `timeDelta` represents */
     proc microseconds {
       return chpl_microseconds;
     }
 
-    /* Return the minimum representable `timedelta` object. */
+    /* Return the minimum representable `timeDelta` object. */
     proc type min {
-      return new timedelta(days=-999999999);
+      return new timeDelta(days=-999999999);
     }
 
-    /* Return the maximum representable `timedelta` object. */
+    /* Return the maximum representable `timeDelta` object. */
     proc type max {
-      return new timedelta(days=999999999, hours=23, minutes=59,
+      return new timeDelta(days=999999999, hours=23, minutes=59,
                            seconds=59, microseconds=999999);
     }
 
-    /* Return the smallest positive value representable by a `timedelta`
+    /* Return the smallest positive value representable by a `timeDelta`
        object.
      */
     proc type resolution {
-      return new timedelta(microseconds=1);
+      return new timeDelta(microseconds=1);
     }
   }
 
-  /* initializers/factories for timedelta values */
+  /* initializers/factories for timeDelta values */
 
-  /* Initialize a `timedelta` object.  All arguments are optional and
+  /* Initialize a `timeDelta` object.  All arguments are optional and
      default to 0. Since only `days`, `seconds` and `microseconds` are
      stored, the other arguments are converted to days, seconds
      and microseconds. */
-  proc timedelta.init(days:int=0, seconds:int=0, microseconds:int=0,
+  proc timeDelta.init(days:int=0, seconds:int=0, microseconds:int=0,
                       milliseconds:int=0, minutes:int=0, hours:int=0, weeks:int=0) {
     param usps = 1000000,  // microseconds per second
           uspms = 1000,    // microseconds per millisecond
@@ -1763,34 +1785,34 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       HaltWrappers.initHalt("Overflow: days > 999999999");
   }
 
-  /* Create a `timedelta` from a given number of seconds */
-  proc timedelta.init(timestamp: real) {
+  /* Create a `timeDelta` from a given number of seconds */
+  proc timeDelta.init(timestamp: real) {
     this.init(seconds = timestamp: int, microseconds=((timestamp - timestamp: int)*1000000): int);
   }
 
 
-  /* Methods on timedelta values */
+  /* Methods on timeDelta values */
 
   /* Return the total number of seconds represented by this object */
-  proc timedelta.totalSeconds(): real {
+  proc timeDelta.totalSeconds(): real {
     return days*(24*60*60) + seconds + microseconds / 1000000.0;
   }
 
 
-  /* Operators on timedelta values */
+  /* Operators on timeDelta values */
 
   pragma "no doc"
-  operator timedelta.*(i: int, t: timedelta) {
-    return new timedelta(days=i*t.days, seconds=i*t.seconds, microseconds=i*t.microseconds);
+  operator timeDelta.*(i: int, t: timeDelta) {
+    return new timeDelta(days=i*t.days, seconds=i*t.seconds, microseconds=i*t.microseconds);
   }
 
   pragma "no doc"
-  operator timedelta.*(t: timedelta, i: int) {
-    return new timedelta(days=i*t.days, seconds=i*t.seconds, microseconds=i*t.microseconds);
+  operator timeDelta.*(t: timeDelta, i: int) {
+    return new timeDelta(days=i*t.days, seconds=i*t.seconds, microseconds=i*t.microseconds);
   }
 
   pragma "no doc"
-  operator timedelta./(t: timedelta, i: int) {
+  operator timeDelta./(t: timeDelta, i: int) {
     var day = t.days / i;
     var second = t.seconds + (t.days % i)*24*60*60;
     var microsecond = t.microseconds + (second % i)*1000000;
@@ -1801,35 +1823,35 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if us_remainder*2 >= i then
       microsecond += 1; // round up
 
-    return new timedelta(days=day, seconds=second, microseconds=microsecond);
+    return new timeDelta(days=day, seconds=second, microseconds=microsecond);
   }
 
   pragma "no doc"
-  operator timedelta.+(t: timedelta) {
+  operator timeDelta.+(t: timeDelta) {
     return t;
   }
 
   pragma "no doc"
-  operator timedelta.-(t: timedelta) {
-    return new timedelta(days=-t.days, seconds=-t.seconds, microseconds=-t.microseconds);
+  operator timeDelta.-(t: timeDelta) {
+    return new timeDelta(days=-t.days, seconds=-t.seconds, microseconds=-t.microseconds);
   }
 
   pragma "no doc"
-  operator timedelta.+(lhs: timedelta, rhs: timedelta) {
-    return new timedelta(days=lhs.days+rhs.days,
+  operator timeDelta.+(lhs: timeDelta, rhs: timeDelta) {
+    return new timeDelta(days=lhs.days+rhs.days,
                          seconds=lhs.seconds+rhs.seconds,
                          microseconds=lhs.microseconds+rhs.microseconds);
   }
 
   pragma "no doc"
-  operator timedelta.-(lhs: timedelta, rhs: timedelta) {
-    return new timedelta(days=lhs.days-rhs.days,
+  operator timeDelta.-(lhs: timeDelta, rhs: timeDelta) {
+    return new timeDelta(days=lhs.days-rhs.days,
                          seconds=lhs.seconds-rhs.seconds,
                          microseconds=lhs.microseconds-rhs.microseconds);
   }
 
   pragma "no doc"
-  operator timedelta.>(lhs: timedelta, rhs: timedelta) {
+  operator timeDelta.>(lhs: timeDelta, rhs: timeDelta) {
     const ls = (lhs.days*(24*60*60) + lhs.seconds);
     const rs = (rhs.days*(24*60*60) + rhs.seconds);
     if ls > rs then return true;
@@ -1838,12 +1860,12 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator timedelta.>=(lhs: timedelta, rhs: timedelta) {
+  operator timeDelta.>=(lhs: timeDelta, rhs: timeDelta) {
     return lhs > rhs || lhs == rhs;
   }
 
   pragma "no doc"
-  operator timedelta.<(lhs: timedelta, rhs: timedelta) {
+  operator timeDelta.<(lhs: timeDelta, rhs: timeDelta) {
     const ls = (lhs.days*(24*60*60) + lhs.seconds);
     const rs = (rhs.days*(24*60*60) + rhs.seconds);
     if ls < rs then return true;
@@ -1852,14 +1874,14 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator timedelta.<=(lhs: timedelta, rhs: timedelta) {
+  operator timeDelta.<=(lhs: timeDelta, rhs: timeDelta) {
     return lhs < rhs || lhs == rhs;
   }
 
   /* Return the absolute value of `t`.  If `t` is negative, then returns `-t`,
      else returns `t`.
    */
-  proc abs(t: timedelta) {
+  proc abs(t: timeDelta) {
     if t.days < 0 then
       return -t;
     else
@@ -1867,7 +1889,7 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   pragma "no doc"
-  operator :(t: timedelta, type s:string) {
+  operator :(t: timeDelta, type s:string) {
     var str: string;
     if t.days != 0 {
       str = t.days: string + " day";
@@ -1908,27 +1930,28 @@ enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
      derived from it. */
   class Timezone {
     /* The offset from UTC this class represents */
-    proc utcOffset(dt: datetime): timedelta {
+    proc utcOffset(dt: dateTime): timeDelta {
       HaltWrappers.pureVirtualMethodHalt();
-      return new timedelta();
+      return new timeDelta();
     }
 
-    /* The `timedelta` for daylight saving time */
-    proc dst(dt: datetime): timedelta {
+    /* The `timeDelta` for daylight saving time */
+    proc dst(dt: dateTime): timeDelta {
       HaltWrappers.pureVirtualMethodHalt();
-      return new timedelta();
+      return new timeDelta();
     }
 
     /* The name of this time zone */
-    proc tzname(dt: datetime): string {
+    @unstable("'tzname' is unstable")
+    proc tzname(dt: dateTime): string {
       HaltWrappers.pureVirtualMethodHalt();
       return "";
     }
 
     /* Convert a `time` in UTC to this time zone */
-    proc fromUtc(dt: datetime): datetime {
+    proc fromUtc(dt: dateTime): dateTime {
       HaltWrappers.pureVirtualMethodHalt();
-      return new datetime(0,0,0);
+      return new dateTime(0,0,0);
     }
 
   }
@@ -1967,14 +1990,14 @@ proc getCurrentDate() {
    :returns: The current day of the week
    :rtype:   :type:`Day`
  */
-proc getCurrentDayOfWeek() : Day {
+proc getCurrentDayOfWeek() : day {
   var now = chpl_now_timevalue();
 
   var seconds, minutes, hours, mday, month, year, wday, yday, isdst:int(32);
 
   chpl_timevalue_parts(now, seconds, minutes, hours, mday, month, year, wday, yday, isdst);
 
-  return try! wday : Day;
+  return try! wday : day;
 }
 
 /*

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -73,7 +73,7 @@ private extern proc chpl_timevalue_parts(t:           _timevalue,
 @deprecated(notes="The 'TimeUnits' type is deprecated. Please specify times in seconds in this module.")
 enum TimeUnits { microseconds, milliseconds, seconds, minutes, hours }
 
-@deprecated(notes="enum 'Day' is deprecated. Please use 'day' instead")
+@deprecated(notes="enum 'Day' is deprecated. Please use :enum:`day` instead")
 enum Day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturday }
 /* Specifies the day of the week */
 enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturday }
@@ -900,11 +900,11 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       // pay attention to the timezones.
       // >>> central = pytz.timezone("US/Central")
       // >>> pacific = pytz.timezone("US/Pacific")
-      // >>> dateTime.time(12,3,4,5,tz=central) >
-      //     dateTime.time(12,3,4,5,tz=pacific)
+      // >>> datetime.time(12,3,4,5,tz=central) >
+      //     datetime.time(12,3,4,5,tz=pacific)
       // False
-      // >>> dateTime.time(12,3,4,6,tz=central) >
-      //     dateTime.time(12,3,4,5,tz=pacific)
+      // >>> datetime.time(12,3,4,6,tz=central) >
+      //     datetime.time(12,3,4,5,tz=pacific)
       // True
       //
       // This compares the time on a specific date, and factors in the
@@ -986,7 +986,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
   }
 
-  @deprecated(notes="'datetime' is deprecated, please use 'dateTime' instead")
+  @deprecated(notes="'datetime' is deprecated, please use :record:`dateTime` instead")
   type datetime = dateTime;
 
   /* A record representing a combined `date` and `time` */
@@ -1169,7 +1169,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Methods on dateTime values */
 
-  @deprecated(notes="'dateTime.getdate' is deprecated. Please use 'dateTime.getDate' instead")
+  @deprecated(notes="'dateTime.getdate' is deprecated. Please use :proc:`dateTime.getDate` instead")
   proc dateTime.getdate() {
     return chpl_date;
   }
@@ -1179,7 +1179,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return chpl_date;
   }
 
-  @deprecated(notes="'dateTime.gettime' is deprecated. Please use 'dateTime.getTime' instead")
+  @deprecated(notes="'dateTime.gettime' is deprecated. Please use :proc:`dateTime.getTime` instead")
   proc dateTime.gettime() {
     if chpl_time.timezone.borrow() == nil then
       return chpl_time;
@@ -1685,7 +1685,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
 
-  @deprecated(notes="'timedelta' is deprecated. Please use 'timeDelta' instead")
+  @deprecated(notes="'timedelta' is deprecated. Please use :record:`timeDelta` instead")
   type timedelta = timeDelta;
   /* A record representing an amount of time.  A `timeDelta` has fields
      representing days, seconds, and microseconds.  These fields are always

--- a/test/classes/delete-free/shared/shared-default-arg-nil-ref.chpl
+++ b/test/classes/delete-free/shared/shared-default-arg-nil-ref.chpl
@@ -1,4 +1,4 @@
-// test inspired by datetime.init
+// test inspired by dateTime.init
 
 class MyClass {
   var x:int;

--- a/test/classes/delete-free/shared/shared-default-arg-nil.chpl
+++ b/test/classes/delete-free/shared/shared-default-arg-nil.chpl
@@ -1,4 +1,4 @@
-// test inspired by datetime.init
+// test inspired by dateTime.init
 
 class MyClass {
   var x:int;

--- a/test/deprecated/DateTimeSymbols.chpl
+++ b/test/deprecated/DateTimeSymbols.chpl
@@ -4,9 +4,9 @@ var t = new time();
 if t.tzinfo != nil then
   writeln("time Timezone!");
 
-var dt = datetime.now();
+var dt = dateTime.now();
 if dt.tzinfo != nil then
-  writeln("datetime Timezone!");
+  writeln("dateTime Timezone!");
 
 var wd = dt.isoweekday();
 var cal = dt.isocalendar();

--- a/test/deprecated/useDeprecatedDateTimeNames.chpl
+++ b/test/deprecated/useDeprecatedDateTimeNames.chpl
@@ -1,0 +1,9 @@
+use Time;
+
+var dt: datetime;
+var td: timedelta;
+
+var weekday: Day;
+
+var dtdate = dt.getdate();
+var dttime = dt.gettime();

--- a/test/deprecated/useDeprecatedDateTimeNames.good
+++ b/test/deprecated/useDeprecatedDateTimeNames.good
@@ -1,0 +1,5 @@
+useDeprecatedDateTimeNames.chpl:3: warning: 'datetime' is deprecated, please use 'dateTime' instead
+useDeprecatedDateTimeNames.chpl:4: warning: 'timedelta' is deprecated. Please use 'timeDelta' instead
+useDeprecatedDateTimeNames.chpl:6: warning: enum 'Day' is deprecated. Please use 'day' instead
+useDeprecatedDateTimeNames.chpl:8: warning: 'dateTime.getdate' is deprecated. Please use 'dateTime.getDate' instead
+useDeprecatedDateTimeNames.chpl:9: warning: 'dateTime.gettime' is deprecated. Please use 'dateTime.getTime' instead

--- a/test/deprecated/useDeprecatedDateTimeNames.good
+++ b/test/deprecated/useDeprecatedDateTimeNames.good
@@ -1,5 +1,5 @@
-useDeprecatedDateTimeNames.chpl:3: warning: 'datetime' is deprecated, please use 'dateTime' instead
-useDeprecatedDateTimeNames.chpl:4: warning: 'timedelta' is deprecated. Please use 'timeDelta' instead
-useDeprecatedDateTimeNames.chpl:6: warning: enum 'Day' is deprecated. Please use 'day' instead
-useDeprecatedDateTimeNames.chpl:8: warning: 'dateTime.getdate' is deprecated. Please use 'dateTime.getDate' instead
-useDeprecatedDateTimeNames.chpl:9: warning: 'dateTime.gettime' is deprecated. Please use 'dateTime.getTime' instead
+useDeprecatedDateTimeNames.chpl:3: warning: 'datetime' is deprecated, please use dateTime instead
+useDeprecatedDateTimeNames.chpl:4: warning: 'timedelta' is deprecated. Please use timeDelta instead
+useDeprecatedDateTimeNames.chpl:6: warning: enum 'Day' is deprecated. Please use day instead
+useDeprecatedDateTimeNames.chpl:8: warning: 'dateTime.getdate' is deprecated. Please use dateTime.getDate instead
+useDeprecatedDateTimeNames.chpl:9: warning: 'dateTime.gettime' is deprecated. Please use dateTime.getTime instead

--- a/test/library/draft/arrow/parquetHeaders.chpl
+++ b/test/library/draft/arrow/parquetHeaders.chpl
@@ -950,13 +950,13 @@ extern proc g_time_zone_get_identifier(ref tz : GTimeZone) : c_ptr(gchar);
 
 extern proc g_time_zone_get_identifier(tz : c_ptr(GTimeZone)) : c_ptr(gchar);
 
-extern proc g_date_time_unref(ref datetime : GDateTime) : void;
+extern proc g_date_time_unref(ref dateTime : GDateTime) : void;
 
-extern proc g_date_time_unref(datetime : c_ptr(GDateTime)) : void;
+extern proc g_date_time_unref(dateTime : c_ptr(GDateTime)) : void;
 
-extern proc g_date_time_ref(ref datetime : GDateTime) : c_ptr(GDateTime);
+extern proc g_date_time_ref(ref dateTime : GDateTime) : c_ptr(GDateTime);
 
-extern proc g_date_time_ref(datetime : c_ptr(GDateTime)) : c_ptr(GDateTime);
+extern proc g_date_time_ref(dateTime : c_ptr(GDateTime)) : c_ptr(GDateTime);
 
 extern proc g_date_time_new_now(ref tz : GTimeZone) : c_ptr(GDateTime);
 
@@ -990,41 +990,41 @@ extern proc g_date_time_new_local(year : gint, month : gint, day : gint, hour : 
 
 extern proc g_date_time_new_utc(year : gint, month : gint, day : gint, hour : gint, minute : gint, seconds : gdouble) : c_ptr(GDateTime);
 
-extern proc g_date_time_add(ref datetime : GDateTime, timespan : GTimeSpan) : c_ptr(GDateTime);
+extern proc g_date_time_add(ref dateTime : GDateTime, timespan : GTimeSpan) : c_ptr(GDateTime);
 
-extern proc g_date_time_add(datetime : c_ptr(GDateTime), timespan : GTimeSpan) : c_ptr(GDateTime);
+extern proc g_date_time_add(dateTime : c_ptr(GDateTime), timespan : GTimeSpan) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_years(ref datetime : GDateTime, years : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_years(ref dateTime : GDateTime, years : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_years(datetime : c_ptr(GDateTime), years : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_years(dateTime : c_ptr(GDateTime), years : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_months(ref datetime : GDateTime, months : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_months(ref dateTime : GDateTime, months : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_months(datetime : c_ptr(GDateTime), months : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_months(dateTime : c_ptr(GDateTime), months : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_weeks(ref datetime : GDateTime, weeks : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_weeks(ref dateTime : GDateTime, weeks : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_weeks(datetime : c_ptr(GDateTime), weeks : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_weeks(dateTime : c_ptr(GDateTime), weeks : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_days(ref datetime : GDateTime, days : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_days(ref dateTime : GDateTime, days : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_days(datetime : c_ptr(GDateTime), days : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_days(dateTime : c_ptr(GDateTime), days : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_hours(ref datetime : GDateTime, hours : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_hours(ref dateTime : GDateTime, hours : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_hours(datetime : c_ptr(GDateTime), hours : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_hours(dateTime : c_ptr(GDateTime), hours : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_minutes(ref datetime : GDateTime, minutes : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_minutes(ref dateTime : GDateTime, minutes : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_minutes(datetime : c_ptr(GDateTime), minutes : gint) : c_ptr(GDateTime);
+extern proc g_date_time_add_minutes(dateTime : c_ptr(GDateTime), minutes : gint) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_seconds(ref datetime : GDateTime, seconds : gdouble) : c_ptr(GDateTime);
+extern proc g_date_time_add_seconds(ref dateTime : GDateTime, seconds : gdouble) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_seconds(datetime : c_ptr(GDateTime), seconds : gdouble) : c_ptr(GDateTime);
+extern proc g_date_time_add_seconds(dateTime : c_ptr(GDateTime), seconds : gdouble) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_full(ref datetime : GDateTime, years : gint, months : gint, days : gint, hours : gint, minutes : gint, seconds : gdouble) : c_ptr(GDateTime);
+extern proc g_date_time_add_full(ref dateTime : GDateTime, years : gint, months : gint, days : gint, hours : gint, minutes : gint, seconds : gdouble) : c_ptr(GDateTime);
 
-extern proc g_date_time_add_full(datetime : c_ptr(GDateTime), years : gint, months : gint, days : gint, hours : gint, minutes : gint, seconds : gdouble) : c_ptr(GDateTime);
+extern proc g_date_time_add_full(dateTime : c_ptr(GDateTime), years : gint, months : gint, days : gint, hours : gint, minutes : gint, seconds : gdouble) : c_ptr(GDateTime);
 
 extern proc g_date_time_compare(dt1 : gconstpointer, dt2 : gconstpointer) : gint;
 
@@ -1032,105 +1032,105 @@ extern proc g_date_time_difference(ref end : GDateTime, ref begin_arg : GDateTim
 
 extern proc g_date_time_difference(end : c_ptr(GDateTime), begin_arg : c_ptr(GDateTime)) : GTimeSpan;
 
-extern proc g_date_time_hash(datetime : gconstpointer) : guint;
+extern proc g_date_time_hash(dateTime : gconstpointer) : guint;
 
 extern proc g_date_time_equal(dt1 : gconstpointer, dt2 : gconstpointer) : gboolean;
 
-extern proc g_date_time_get_ymd(ref datetime : GDateTime, ref year : gint, ref month : gint, ref day : gint) : void;
+extern proc g_date_time_get_ymd(ref dateTime : GDateTime, ref year : gint, ref month : gint, ref day : gint) : void;
 
-extern proc g_date_time_get_ymd(datetime : c_ptr(GDateTime), year : c_ptr(gint), month : c_ptr(gint), day : c_ptr(gint)) : void;
+extern proc g_date_time_get_ymd(dateTime : c_ptr(GDateTime), year : c_ptr(gint), month : c_ptr(gint), day : c_ptr(gint)) : void;
 
-extern proc g_date_time_get_year(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_year(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_year(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_year(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_month(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_month(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_month(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_month(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_day_of_month(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_day_of_month(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_day_of_month(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_day_of_month(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_week_numbering_year(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_week_numbering_year(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_week_numbering_year(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_week_numbering_year(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_week_of_year(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_week_of_year(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_week_of_year(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_week_of_year(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_day_of_week(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_day_of_week(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_day_of_week(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_day_of_week(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_day_of_year(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_day_of_year(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_day_of_year(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_day_of_year(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_hour(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_hour(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_hour(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_hour(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_minute(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_minute(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_minute(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_minute(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_second(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_second(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_second(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_second(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_microsecond(ref datetime : GDateTime) : gint;
+extern proc g_date_time_get_microsecond(ref dateTime : GDateTime) : gint;
 
-extern proc g_date_time_get_microsecond(datetime : c_ptr(GDateTime)) : gint;
+extern proc g_date_time_get_microsecond(dateTime : c_ptr(GDateTime)) : gint;
 
-extern proc g_date_time_get_seconds(ref datetime : GDateTime) : gdouble;
+extern proc g_date_time_get_seconds(ref dateTime : GDateTime) : gdouble;
 
-extern proc g_date_time_get_seconds(datetime : c_ptr(GDateTime)) : gdouble;
+extern proc g_date_time_get_seconds(dateTime : c_ptr(GDateTime)) : gdouble;
 
-extern proc g_date_time_to_unix(ref datetime : GDateTime) : gint64;
+extern proc g_date_time_to_unix(ref dateTime : GDateTime) : gint64;
 
-extern proc g_date_time_to_unix(datetime : c_ptr(GDateTime)) : gint64;
+extern proc g_date_time_to_unix(dateTime : c_ptr(GDateTime)) : gint64;
 
-extern proc g_date_time_to_timeval(ref datetime : GDateTime, ref tv : GTimeVal) : gboolean;
+extern proc g_date_time_to_timeval(ref dateTime : GDateTime, ref tv : GTimeVal) : gboolean;
 
-extern proc g_date_time_to_timeval(datetime : c_ptr(GDateTime), tv : c_ptr(GTimeVal)) : gboolean;
+extern proc g_date_time_to_timeval(dateTime : c_ptr(GDateTime), tv : c_ptr(GTimeVal)) : gboolean;
 
-extern proc g_date_time_get_utc_offset(ref datetime : GDateTime) : GTimeSpan;
+extern proc g_date_time_get_utc_offset(ref dateTime : GDateTime) : GTimeSpan;
 
-extern proc g_date_time_get_utc_offset(datetime : c_ptr(GDateTime)) : GTimeSpan;
+extern proc g_date_time_get_utc_offset(dateTime : c_ptr(GDateTime)) : GTimeSpan;
 
-extern proc g_date_time_get_timezone(ref datetime : GDateTime) : c_ptr(GTimeZone);
+extern proc g_date_time_get_timezone(ref dateTime : GDateTime) : c_ptr(GTimeZone);
 
-extern proc g_date_time_get_timezone(datetime : c_ptr(GDateTime)) : c_ptr(GTimeZone);
+extern proc g_date_time_get_timezone(dateTime : c_ptr(GDateTime)) : c_ptr(GTimeZone);
 
-extern proc g_date_time_get_timezone_abbreviation(ref datetime : GDateTime) : c_ptr(gchar);
+extern proc g_date_time_get_timezone_abbreviation(ref dateTime : GDateTime) : c_ptr(gchar);
 
-extern proc g_date_time_get_timezone_abbreviation(datetime : c_ptr(GDateTime)) : c_ptr(gchar);
+extern proc g_date_time_get_timezone_abbreviation(dateTime : c_ptr(GDateTime)) : c_ptr(gchar);
 
-extern proc g_date_time_is_daylight_savings(ref datetime : GDateTime) : gboolean;
+extern proc g_date_time_is_daylight_savings(ref dateTime : GDateTime) : gboolean;
 
-extern proc g_date_time_is_daylight_savings(datetime : c_ptr(GDateTime)) : gboolean;
+extern proc g_date_time_is_daylight_savings(dateTime : c_ptr(GDateTime)) : gboolean;
 
-extern proc g_date_time_to_timezone(ref datetime : GDateTime, ref tz : GTimeZone) : c_ptr(GDateTime);
+extern proc g_date_time_to_timezone(ref dateTime : GDateTime, ref tz : GTimeZone) : c_ptr(GDateTime);
 
-extern proc g_date_time_to_timezone(datetime : c_ptr(GDateTime), tz : c_ptr(GTimeZone)) : c_ptr(GDateTime);
+extern proc g_date_time_to_timezone(dateTime : c_ptr(GDateTime), tz : c_ptr(GTimeZone)) : c_ptr(GDateTime);
 
-extern proc g_date_time_to_local(ref datetime : GDateTime) : c_ptr(GDateTime);
+extern proc g_date_time_to_local(ref dateTime : GDateTime) : c_ptr(GDateTime);
 
-extern proc g_date_time_to_local(datetime : c_ptr(GDateTime)) : c_ptr(GDateTime);
+extern proc g_date_time_to_local(dateTime : c_ptr(GDateTime)) : c_ptr(GDateTime);
 
-extern proc g_date_time_to_utc(ref datetime : GDateTime) : c_ptr(GDateTime);
+extern proc g_date_time_to_utc(ref dateTime : GDateTime) : c_ptr(GDateTime);
 
-extern proc g_date_time_to_utc(datetime : c_ptr(GDateTime)) : c_ptr(GDateTime);
+extern proc g_date_time_to_utc(dateTime : c_ptr(GDateTime)) : c_ptr(GDateTime);
 
-extern proc g_date_time_format(ref datetime : GDateTime, ref format : gchar) : c_ptr(gchar);
+extern proc g_date_time_format(ref dateTime : GDateTime, ref format : gchar) : c_ptr(gchar);
 
-extern proc g_date_time_format(datetime : c_ptr(GDateTime), format : c_ptr(gchar)) : c_ptr(gchar);
+extern proc g_date_time_format(dateTime : c_ptr(GDateTime), format : c_ptr(gchar)) : c_ptr(gchar);
 
-extern proc g_date_time_format_iso8601(ref datetime : GDateTime) : c_ptr(gchar);
+extern proc g_date_time_format_iso8601(ref dateTime : GDateTime) : c_ptr(gchar);
 
-extern proc g_date_time_format_iso8601(datetime : c_ptr(GDateTime)) : c_ptr(gchar);
+extern proc g_date_time_format_iso8601(dateTime : c_ptr(GDateTime)) : c_ptr(gchar);
 
 extern proc g_bookmark_file_error_quark() : GQuark;
 
@@ -6579,7 +6579,7 @@ extern var g_thread_functions_for_glib_use : GThreadFunctions;
 
 extern var g_thread_use_default_impl : gboolean;
 
-extern var g_thread_gettime : c_ptr(c_fn_ptr);
+extern var g_thread_getTime : c_ptr(c_fn_ptr);
 
 extern proc g_thread_create(func : GThreadFunc, data : gpointer, joinable : gboolean, ref error : c_ptr(GError)) : c_ptr(GThread);
 

--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -51,7 +51,7 @@ module CheckHttpSetOpt {
     curl_easy_getinfo(getCurlHandle(urlreader), CURLINFO_FILETIME,
 		      c_ptrTo(time));
 
-    writeln("Remote Time ", datetime.utcFromTimestamp(time));
+    writeln("Remote Time ", dateTime.utcFromTimestamp(time));
 
     stderr.flush();
     stdout.flush();

--- a/test/library/standard/DateTime/datetimeInitWithDateAndTime.chpl
+++ b/test/library/standard/DateTime/datetimeInitWithDateAndTime.chpl
@@ -1,8 +1,8 @@
 use Time;
 
-const dt = datetime.now();
+const dt = dateTime.now();
 const d = date.today();
 
-// used to support datetime - date where date was promoted
-// to datetime with time == 0. This is the equivalent of that.
-const td = dt - new datetime(d, new time());
+// used to support dateTime - date where date was promoted
+// to dateTime with time == 0. This is the equivalent of that.
+const td = dt - new dateTime(d, new time());

--- a/test/library/standard/DateTime/readWriteDatesTimes.chpl
+++ b/test/library/standard/DateTime/readWriteDatesTimes.chpl
@@ -12,7 +12,7 @@ proc testReadWrite(dt) {
   writeln(dt.type:string, ": ", dt == dt2);
 }
 
-var dt = datetime.now();
+var dt = dateTime.now();
 testReadWrite(dt);
-testReadWrite(dt.getdate());
-testReadWrite(dt.gettime());
+testReadWrite(dt.getDate());
+testReadWrite(dt.getTime());

--- a/test/library/standard/DateTime/readWriteDatesTimes.good
+++ b/test/library/standard/DateTime/readWriteDatesTimes.good
@@ -1,3 +1,3 @@
-datetime: true
+dateTime: true
 date: true
 time: true

--- a/test/library/standard/DateTime/strptime.chpl
+++ b/test/library/standard/DateTime/strptime.chpl
@@ -2,35 +2,35 @@ use Time;
 use UnitTest;
 
 proc test_microsecond(test: borrowed Test) throws {
-  var dt : datetime = new datetime();
+  var dt : dateTime = new dateTime();
   try {
-    dt = datetime.strptime("12:59:59.008000", "%T.%f");
+    dt = dateTime.strptime("12:59:59.008000", "%T.%f");
   } catch e {}
   test.assertEqual(dt.microsecond,8000);
 }
 
 proc test_out_of_range_microseconds(test: borrowed Test) throws {
-  var dt : datetime = new datetime();
+  var dt : dateTime = new dateTime();
   try {
-    dt = datetime.strptime("12:59:59.1000001", "%T.%f");
+    dt = dateTime.strptime("12:59:59.1000001", "%T.%f");
   } catch e {
     test.assertEqual(e.message(),"Invalid Arguments Provided");
   }
 }
 
 proc test_negative_microseconds(test: borrowed Test) throws {
-  var dt : datetime = new datetime();
+  var dt : dateTime = new dateTime();
   try {
-    dt = datetime.strptime("12:59:59.-10", "%T.%f");
+    dt = dateTime.strptime("12:59:59.-10", "%T.%f");
   } catch e {
     test.assertEqual(e.message(),"Invalid Arguments Provided");
   }
 }
 
 proc test_no_microseconds(test: borrowed Test) throws {
-  var dt : datetime = new datetime();
+  var dt : dateTime = new dateTime();
   try {
-    dt = datetime.strptime("12:59:59", "%T.%f");
+    dt = dateTime.strptime("12:59:59", "%T.%f");
   } catch e {
     test.assertEqual(e.message(),"Invalid Arguments Provided");
   }

--- a/test/library/standard/DateTime/strptime2.bad
+++ b/test/library/standard/DateTime/strptime2.bad
@@ -1,5 +1,5 @@
 strptime2.chpl:4: In function 'test_microsecond':
-strptime2.chpl:7: error: unresolved call 'datetime.strptime("12:59:59.008000", "%T.%f")'
-$CHPL_HOME/modules/standard/Time.chpl:1418: note: this candidate did not match: type datetime.strptime(date_string: string, format: string)
+strptime2.chpl:7: error: unresolved call 'dateTime.strptime("12:59:59.008000", "%T.%f")'
+$CHPL_HOME/modules/standard/Time.chpl:1418: note: this candidate did not match: type dateTime.strptime(date_string: string, format: string)
 strptime2.chpl:7: note: because non-type method call receiver
-$CHPL_HOME/modules/standard/Time.chpl:1418: note: is passed to formal 'this: datetime'
+$CHPL_HOME/modules/standard/Time.chpl:1418: note: is passed to formal 'this: dateTime'

--- a/test/library/standard/DateTime/strptime2.chpl
+++ b/test/library/standard/DateTime/strptime2.chpl
@@ -2,7 +2,7 @@ use Time;
 use UnitTest;
 
 proc test_microsecond(test: borrowed Test) throws {
-  var dt : datetime = new datetime();
+  var dt : dateTime = new dateTime();
   try {
     dt.strptime("12:59:59.008000", "%T.%f");
   } catch e {}
@@ -10,7 +10,7 @@ proc test_microsecond(test: borrowed Test) throws {
 }
 
 proc test_out_of_range_microseconds(test: borrowed Test) throws {
-  var dt : datetime = new datetime();
+  var dt : dateTime = new dateTime();
   try {
     dt.strptime("12:59:59.1000001", "%T.%f");
   } catch e {
@@ -19,7 +19,7 @@ proc test_out_of_range_microseconds(test: borrowed Test) throws {
 }
 
 proc test_negative_microseconds(test: borrowed Test) throws {
-  var dt : datetime = new datetime();
+  var dt : dateTime = new dateTime();
   try {
     dt.strptime("12:59:59.-10", "%T.%f");
   } catch e {
@@ -28,7 +28,7 @@ proc test_negative_microseconds(test: borrowed Test) throws {
 }
 
 proc test_no_microseconds(test: borrowed Test) throws {
-  var dt : datetime = new datetime();
+  var dt : dateTime = new dateTime();
   try {
     dt.strptime("12:59:59", "%T.%f");
   } catch e {

--- a/test/library/standard/DateTime/testDate.chpl
+++ b/test/library/standard/DateTime/testDate.chpl
@@ -5,11 +5,11 @@ var today = date.today(); // workaround for problem with unused records
 
 proc test_date_delta_non_days_ignored() {
   var dt = new date(2000, 1, 2);
-  var delta = new timedelta(days=1, hours=2, minutes=3, seconds=4,
+  var delta = new timeDelta(days=1, hours=2, minutes=3, seconds=4,
                             microseconds=5);
 
-  var days = new timedelta(delta.days);
-  assert(days == new timedelta(1));
+  var days = new timeDelta(delta.days);
+  assert(days == new timeDelta(1));
 
   var dt2 = dt + delta;
   assert(dt2 == dt+days);
@@ -21,8 +21,8 @@ proc test_date_delta_non_days_ignored() {
   assert(dt2 == dt - days);
 
   delta = -delta;
-  days = new timedelta(delta.days);
-  assert(days == new timedelta(-2));
+  days = new timeDelta(delta.days);
+  assert(days == new timeDelta(-2));
 
   dt2 = dt + delta;
   assert(dt2 == dt + days);
@@ -82,7 +82,7 @@ proc test_date_extreme_ordinals() {
   var b = date.fromOrdinal(aord);
   assert(a == b);
 
-  b = a + new timedelta(days=1);
+  b = a + new timeDelta(days=1);
   assert(b.toOrdinal() == aord + 1);
   assert(b == date.fromOrdinal(aord+1));
 
@@ -91,7 +91,7 @@ proc test_date_extreme_ordinals() {
   b = date.fromOrdinal(aord);
   assert(a == b);
 
-  b = a - new timedelta(days=1);
+  b = a - new timeDelta(days=1);
   assert(b.toOrdinal() == aord - 1);
   assert(b == date.fromOrdinal(aord - 1));
 }
@@ -105,8 +105,8 @@ proc test_date_computations() {
   assert(diff.seconds == 0);
   assert(diff.microseconds == 0);
 
-  var day = new timedelta(1);
-  var week = new timedelta(7);
+  var day = new timeDelta(1);
+  var week = new timeDelta(7);
   a = new date(2002, 3, 2);
 
   assert(a + day == new date(2002, 3, 3));
@@ -130,7 +130,7 @@ proc test_date_computations() {
 proc test_date_fromtimestamp() {
   var (year, month, day) = (1999, 9, 19);
   var d1 = new date(year, month, day);
-  var delta = d1 - unixEpoch.getdate();
+  var delta = d1 - unixEpoch.getDate();
   var ts = delta.days * 60 * 60 * 24 + delta.seconds;
 
   var d = date.fromTimestamp(ts);
@@ -143,7 +143,7 @@ proc test_date_today() {
   var tday, tdayAgain: date;
   for 1..3 { // give it a few tries in case we cross midnight
     tday = date.today();
-    var delta = tday - unixEpoch.getdate();
+    var delta = tday - unixEpoch.getDate();
     var ts = delta.days * 60 * 60 * 24 + delta.seconds;
     tdayAgain = date.fromTimestamp(ts);
     if tday == tdayAgain then
@@ -165,13 +165,13 @@ proc test_date_isocalendar() {
   for i in 0..#7 {
     var d = new date(2003, 12, 22+i);
     assert(d.isoCalendar() == (2003, 52, i+1));
-    d = new date(2003, 12, 29) + new timedelta(i);
+    d = new date(2003, 12, 29) + new timeDelta(i);
     assert(d.isoCalendar() == (2004, 1, i+1));
     d = new date(2004, 1, 5+i);
     assert(d.isoCalendar() == (2004, 2, i+1));
     d = new date(2009, 12, 21+i);
     assert(d.isoCalendar() == (2009, 52, i+1));
-    d = new date(2009, 12, 28) + new timedelta(i);
+    d = new date(2009, 12, 28) + new timeDelta(i);
     assert(d.isoCalendar() == (2009, 53, i+1));
     d = new date(2010, 1, 4+i);
     assert(d.isoCalendar() == (2010, 1, i+1));
@@ -229,14 +229,14 @@ proc test_date_resolution_info() {
   proc isdate(type t, d) param do return false;
   assert(istype(date, date.min));
   assert(istype(date, date.max));
-  assert(istype(timedelta, date.resolution));
+  assert(istype(timeDelta, date.resolution));
   assert(date.max > date.min);
 }
 
-proc test_date_extreme_timedelta() {
+proc test_date_extreme_timeDelta() {
   var big = date.max - date.min;
   var n = (big.days*24*3600 + big.seconds)*1000000 + big.microseconds;
-  var justasbig = new timedelta(0, 0, n);
+  var justasbig = new timeDelta(0, 0, n);
 
   assert(big == justasbig);
   assert(date.min + big == date.max);
@@ -339,7 +339,7 @@ test_date_isoformat();
 test_date_ctime();
 test_date_strftime();
 test_date_resolution_info();
-test_date_extreme_timedelta();
+test_date_extreme_timeDelta();
 test_date_timetuple();
 test_date_compare();
 test_date_replace();

--- a/test/library/standard/DateTime/testDatetime.chpl
+++ b/test/library/standard/DateTime/testDatetime.chpl
@@ -1,7 +1,7 @@
 use Time;
 
 proc test_basic_attributes() {
-  var dt = new datetime(2002, 3, 1, 12, 0);
+  var dt = new dateTime(2002, 3, 1, 12, 0);
   assert(dt.year == 2002);
   assert(dt.month == 3);
   assert(dt.day == 1);
@@ -14,7 +14,7 @@ proc test_basic_attributes() {
 proc test_basic_attributes_nonzero() {
   // Make sure all attributes are non-zero so bugs in
   // bit-shifting access show up.
-  var dt = new datetime(2002, 3, 1, 12, 59, 59, 8000);
+  var dt = new dateTime(2002, 3, 1, 12, 59, 59, 8000);
   assert(dt.year == 2002);
   assert(dt.month == 3);
   assert(dt.day == 1);
@@ -25,14 +25,14 @@ proc test_basic_attributes_nonzero() {
 }
 
 proc test_isoformat() {
-  var t = new datetime(2, 3, 2, 4, 5, 1, 123);
+  var t = new dateTime(2, 3, 2, 4, 5, 1, 123);
   assert(t.isoFormat() == "0002-03-02T04:05:01.000123");
   assert(t.isoFormat('T') == "0002-03-02T04:05:01.000123");
   assert(t.isoFormat(' ') == "0002-03-02 04:05:01.000123");
   // str is ISO format with the separator forced to a blank.
   //assert(str(t) == "0002-03-02 04:05:01.000123");
 
-  t = new datetime(2, 3, 2);
+  t = new dateTime(2, 3, 2);
   assert(t.isoFormat() == "0002-03-02T00:00:00");
   assert(t.isoFormat('T') == "0002-03-02T00:00:00");
   assert(t.isoFormat(' ') == "0002-03-02 00:00:00");
@@ -42,15 +42,15 @@ proc test_isoformat() {
 
 proc test_more_ctime() {
   // Test fields that TestDate doesn't touch.
-  var t = new datetime(2002, 12, 4, 20, 30, 40);
+  var t = new dateTime(2002, 12, 4, 20, 30, 40);
   assert(t.ctime() == "Wed Dec  4 20:30:40 2002");
 
-  t = new datetime(2002, 3, 22, 18, 3, 5, 123);
+  t = new dateTime(2002, 3, 22, 18, 3, 5, 123);
   assert(t.ctime() == "Fri Mar 22 18:03:05 2002");
 /*
   import time;
 
-  var t = new datetime(2002, 3, 2, 18, 3, 5, 123);
+  var t = new dateTime(2002, 3, 2, 18, 3, 5, 123);
   assert(t.ctime() == "Sat Mar  2 18:03:05 2002");
   // Oops!  The next line fails on Win2K under MSVC 6, so it's commented
   // out.  The difference is that t.ctime() produces " 2" for the day,
@@ -59,15 +59,15 @@ proc test_more_ctime() {
   // self.assertEqual(t.ctime(), time.ctime(time.mktime(t.timetuple())))
 
   // So test a case where that difference doesn't matter.
-  t = new datetime(2002, 3, 22, 18, 3, 5, 123);
+  t = new dateTime(2002, 3, 22, 18, 3, 5, 123);
   assert(t.ctime() == time.ctime(time.mktime(t.timetuple())));
 */
 }
 
 proc test_tz_independent_comparing() {
-  var dt1 = new datetime(2002, 3, 1, 9, 0, 0);
-  var dt2 = new datetime(2002, 3, 1, 10, 0, 0);
-  var dt3 = new datetime(2002, 3, 1, 9, 0, 0);
+  var dt1 = new dateTime(2002, 3, 1, 9, 0, 0);
+  var dt2 = new dateTime(2002, 3, 1, 10, 0, 0);
+  var dt3 = new dateTime(2002, 3, 1, 9, 0, 0);
   assert(dt1 == dt3);
   assert(dt2 > dt3);
 
@@ -76,38 +76,38 @@ proc test_tz_independent_comparing() {
   // precision to span microsecond resolution across years 1 thru 9999,
   // so comparing via timestamp necessarily calls some distinct values
   // equal).
-  dt1 = new datetime(MAXYEAR, 12, 31, 23, 59, 59, 999998);
-  var us = new timedelta(microseconds=1);
+  dt1 = new dateTime(MAXYEAR, 12, 31, 23, 59, 59, 999998);
+  var us = new timeDelta(microseconds=1);
   dt2 = dt1 + us;
   assert(dt2 - dt1 == us);
   assert(dt1 < dt2);
 }
 
 proc test_computations() {
-  var a = new datetime(2002, 1, 31);
-  var b = new datetime(1956, 1, 31);
+  var a = new dateTime(2002, 1, 31);
+  var b = new dateTime(1956, 1, 31);
   var diff = a-b;
   assert(diff.days == 46*365 + (1956..2001 by 4).size);
   assert(diff.seconds == 0);
   assert(diff.microseconds == 0);
-  a = new datetime(2002, 3, 2, 17, 6);
-  var millisec = new timedelta(0, 0, 1000);
-  var hour = new timedelta(0, 3600);
-  var day = new timedelta(1);
-  var week = new timedelta(7);
-  assert(a + hour == new datetime(2002, 3, 2, 18, 6));
-  assert(hour + a == new datetime(2002, 3, 2, 18, 6));
-  assert(a + 10*hour == new datetime(2002, 3, 3, 3, 6));
-  assert(a - hour == new datetime(2002, 3, 2, 16, 6));
-  assert(-hour + a == new datetime(2002, 3, 2, 16, 6));
+  a = new dateTime(2002, 3, 2, 17, 6);
+  var millisec = new timeDelta(0, 0, 1000);
+  var hour = new timeDelta(0, 3600);
+  var day = new timeDelta(1);
+  var week = new timeDelta(7);
+  assert(a + hour == new dateTime(2002, 3, 2, 18, 6));
+  assert(hour + a == new dateTime(2002, 3, 2, 18, 6));
+  assert(a + 10*hour == new dateTime(2002, 3, 3, 3, 6));
+  assert(a - hour == new dateTime(2002, 3, 2, 16, 6));
+  assert(-hour + a == new dateTime(2002, 3, 2, 16, 6));
   assert(a - hour == a + -hour);
-  assert(a - 20*hour == new datetime(2002, 3, 1, 21, 6));
-  assert(a + day == new datetime(2002, 3, 3, 17, 6));
-  assert(a - day == new datetime(2002, 3, 1, 17, 6));
-  assert(a + week == new datetime(2002, 3, 9, 17, 6));
-  assert(a - week == new datetime(2002, 2, 23, 17, 6));
-  assert(a + 52*week == new datetime(2003, 3, 1, 17, 6));
-  assert(a - 52*week == new datetime(2001, 3, 3, 17, 6));
+  assert(a - 20*hour == new dateTime(2002, 3, 1, 21, 6));
+  assert(a + day == new dateTime(2002, 3, 3, 17, 6));
+  assert(a - day == new dateTime(2002, 3, 1, 17, 6));
+  assert(a + week == new dateTime(2002, 3, 9, 17, 6));
+  assert(a - week == new dateTime(2002, 2, 23, 17, 6));
+  assert(a + 52*week == new dateTime(2003, 3, 1, 17, 6));
+  assert(a - 52*week == new dateTime(2001, 3, 3, 17, 6));
   assert((a + week) - a == week);
   assert((a + day) - a == day);
   assert((a + hour) - a == hour);
@@ -125,19 +125,19 @@ proc test_computations() {
   assert(a - (a - hour) == hour);
   assert(a - (a - millisec) == millisec);
   assert(a + (week + day + hour + millisec) ==
-                   new datetime(2002, 3, 10, 18, 6, 0, 1000));
+                   new dateTime(2002, 3, 10, 18, 6, 0, 1000));
   assert(a + (week + day + hour + millisec) ==
                    (((a + week) + day) + hour) + millisec);
   assert(a - (week + day + hour + millisec) ==
-                   new datetime(2002, 2, 22, 16, 5, 59, 999000));
+                   new dateTime(2002, 2, 22, 16, 5, 59, 999000));
   assert(a - (week + day + hour + millisec) ==
                    (((a - week) - day) - hour) - millisec);
 }
 
 proc test_more_compare() {
   var args = (2000, 11, 29, 20, 58, 16, 999998);
-  var t1 = new datetime((...args));
-  var t2 = new datetime((...args));
+  var t1 = new dateTime((...args));
+  var t2 = new dateTime((...args));
   assert(t1 == t2);
   assert(t1 <= t2);
   assert(t1 >= t2);
@@ -150,7 +150,7 @@ proc test_more_compare() {
   for i in 0..#args.size {
     var newargs = args;
     newargs[i] = args[i] + 1;
-    t2 = new datetime((...newargs));   // this is larger than t1
+    t2 = new dateTime((...newargs));   // this is larger than t1
     assert(t1 < t2);
     assert(t2 > t1);
     assert(t1 <= t2);
@@ -169,7 +169,7 @@ proc test_more_compare() {
 }
 
 proc test_more_timetuple() {
-  var t = new datetime(2004, 12, 31, 6, 22, 33);
+  var t = new dateTime(2004, 12, 31, 6, 22, 33);
   var tt = t.timetuple();
   assert(tt.tm_year == t.year);
   assert(tt.tm_mon == t.month);
@@ -184,12 +184,12 @@ proc test_more_timetuple() {
 }
 
 proc test_more_strftime() {
-  var t = new datetime(2004, 12, 31, 6, 22, 33);
+  var t = new dateTime(2004, 12, 31, 6, 22, 33);
   assert(t.strftime("%m %d %y %S %M %H %j") == "12 31 04 33 22 06 366");
 }
 
 proc test_strftime() {
-  var t = new datetime(2004, 12, 31, 6, 22, 33, 61234);
+  var t = new dateTime(2004, 12, 31, 6, 22, 33, 61234);
   assert(t.strftime("%m %d %y %S %M %H %f %j") == "12 31 04 33 22 06 061234 366");
   assert(t.strftime("%m %d %y %S %M %H %0f %j") == "12 31 04 33 22 06 061234 366");
   assert(t.strftime("%m %d %y %S %M %H %%f %j") == "12 31 04 33 22 06 %f 366");
@@ -198,29 +198,29 @@ proc test_strftime() {
 }
 
 proc test_extract() {
-  var dt = new datetime(2002, 3, 4, 18, 45, 3, 1234);
-  assert(dt.getdate() == new date(2002, 3, 4));
-  assert(dt.gettime() == new time(18, 45, 3, 1234));
+  var dt = new dateTime(2002, 3, 4, 18, 45, 3, 1234);
+  assert(dt.getDate() == new date(2002, 3, 4));
+  assert(dt.getTime() == new time(18, 45, 3, 1234));
 }
 
 proc test_combine() {
   var d = new date(2002, 3, 4);
   var t = new time(18, 45, 3, 1234);
-  var expected = new datetime(2002, 3, 4, 18, 45, 3, 1234);
-  var dt = datetime.combine(d, t);
+  var expected = new dateTime(2002, 3, 4, 18, 45, 3, 1234);
+  var dt = dateTime.combine(d, t);
   assert(dt == expected);
 
-  dt = datetime.combine(t=t, d=d);
+  dt = dateTime.combine(t=t, d=d);
   assert(dt == expected);
 
-  assert(d == dt.getdate());
-  assert(t == dt.gettime());
-  assert(dt == datetime.combine(dt.getdate(), dt.gettime()));
+  assert(d == dt.getDate());
+  assert(t == dt.getTime());
+  assert(dt == dateTime.combine(dt.getDate(), dt.getTime()));
 }
 
 proc test_replace() {
   var args = (1, 2, 3, 4, 5, 6, 7);
-  var base = new datetime((...args));
+  var base = new dateTime((...args));
   var nilTZ:shared Timezone?;
 
   assert(base == base.replace(tz=nilTZ));
@@ -234,9 +234,9 @@ proc test_replace() {
                          ("second", 7),
                          ("microsecond", 8)) {
     var newargs = args;
-    var got: datetime;
+    var got: dateTime;
     newargs[i] = newval;
-    var expected = new datetime((...newargs));
+    var expected = new dateTime((...newargs));
 
     if name == "year" then
       got = base.replace(year = newval, tz=nilTZ);

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -1,30 +1,30 @@
 use Time;
 
 class FixedOffset: Timezone {
-  var offset: timedelta;
+  var offset: timeDelta;
   var name: string;
-  var dstoffset: timedelta;
-  proc init(offset: timedelta, name: string, dstoffset: timedelta = new timedelta(minutes=42)) {
+  var dstoffset: timeDelta;
+  proc init(offset: timeDelta, name: string, dstoffset: timeDelta = new timeDelta(minutes=42)) {
     this.offset = offset;
     this.name = name;
     this.dstoffset = dstoffset;
   }
   proc init(offset: int, name, dstoffset:int=42) {
-    this.offset = new timedelta(minutes=offset);
+    this.offset = new timeDelta(minutes=offset);
     this.name = name;
-    this.dstoffset = new timedelta(minutes=dstoffset);
+    this.dstoffset = new timeDelta(minutes=dstoffset);
   }
 
-  override proc utcOffset(dt: datetime) {
+  override proc utcOffset(dt: dateTime) {
     return offset;
   }
-  override proc tzname(dt: datetime) {
+  override proc tzname(dt: dateTime) {
     return name;
   }
-  override proc dst(dt: datetime) {
+  override proc dst(dt: dateTime) {
     return dstoffset;
   }
-  override proc fromUtc(dt: datetime) {
+  override proc fromUtc(dt: dateTime) {
     var dtoff = dt.utcOffset();
     var dtdst = dt.dst();
     var delta = dtoff - dtdst;
@@ -35,7 +35,7 @@ class FixedOffset: Timezone {
 }
 
 proc test_trivial() {
-  var dt = new datetime(1, 2, 3, 4, 5, 6, 7);
+  var dt = new dateTime(1, 2, 3, 4, 5, 6, 7);
   assert(dt.year == 1);
   assert(dt.month == 2);
   assert(dt.day == 3);
@@ -48,10 +48,10 @@ proc test_trivial() {
 
 proc test_even_more_compare() {
   // Smallest possible after UTC adjustment.
-  var t1 = new datetime(1, 1, 1,
+  var t1 = new dateTime(1, 1, 1,
                         tz=new shared FixedOffset(1439, ""));
   // Largest possible after UTC adjustment.
-  var t2 = new datetime(MAXYEAR, 12, 31, 23, 59, 59, 999999,
+  var t2 = new dateTime(MAXYEAR, 12, 31, 23, 59, 59, 999999,
                         tz=new shared FixedOffset(-1439, ""));
 
   // Make sure those compare correctly, and w/o overflow.
@@ -63,30 +63,30 @@ proc test_even_more_compare() {
   assert(t2 == t2);
 
   // Equal afer adjustment.
-  t1 = new datetime(1, 12, 31, 23, 59,
+  t1 = new dateTime(1, 12, 31, 23, 59,
                     tz=new shared FixedOffset(1, ""));
-  t2 = new datetime(2, 1, 1, 3, 13,
+  t2 = new dateTime(2, 1, 1, 3, 13,
                     tz=new shared FixedOffset(3*60+13+2, ""));
   assert(t1 == t2);
 
   // Change t1 not to subtract a minute, and t1 should be larger.
-  t1 = new datetime(1, 12, 31, 23, 59,
+  t1 = new dateTime(1, 12, 31, 23, 59,
                     tz=new shared FixedOffset(0, ""));
   assert(t1 > t2);
 
   // Change t1 to subtract 2 minutes, and t1 should be smaller.
-  t1 = new datetime(1, 12, 31, 23, 59,
+  t1 = new dateTime(1, 12, 31, 23, 59,
                     tz=new shared FixedOffset(2, ""));
   assert(t1 < t2);
 
   // Back to the original t1, but make seconds resolve it.
-  t1 = new datetime(1, 12, 31, 23, 59,
+  t1 = new dateTime(1, 12, 31, 23, 59,
                     tz=new shared FixedOffset(1, ""),
                     second=1);
   assert(t1 > t2);
 
   // Likewise, but make microseconds resolve it.
-  t1 = new datetime(1, 12, 31, 23, 59,
+  t1 = new dateTime(1, 12, 31, 23, 59,
                     tz=new shared FixedOffset(1, ""),
                     microsecond=1);
   assert(t1 > t2);
@@ -96,15 +96,15 @@ proc test_zones() {
   var est = new shared FixedOffset(-300, "EST");
   var utc = new shared FixedOffset(0, "UTC");
   var met = new shared FixedOffset(60, "MET");
-  var t1 = new datetime(2002, 3, 19,  7, 47, tz=est);
-  var t2 = new datetime(2002, 3, 19, 12, 47, tz=utc);
-  var t3 = new datetime(2002, 3, 19, 13, 47, tz=met);
+  var t1 = new dateTime(2002, 3, 19,  7, 47, tz=est);
+  var t2 = new dateTime(2002, 3, 19, 12, 47, tz=utc);
+  var t3 = new dateTime(2002, 3, 19, 13, 47, tz=met);
   assert(t1.timezone == est);
   assert(t2.timezone == utc);
   assert(t3.timezone == met);
-  assert(t1.utcOffset() == new timedelta(minutes=-300));
-  assert(t2.utcOffset() == new timedelta(minutes=0));
-  assert(t3.utcOffset() == new timedelta(minutes=60));
+  assert(t1.utcOffset() == new timeDelta(minutes=-300));
+  assert(t2.utcOffset() == new timeDelta(minutes=0));
+  assert(t3.utcOffset() == new timeDelta(minutes=60));
   assert(t1.tzname() == "EST");
   assert(t2.tzname() == "UTC");
   assert(t3.tzname() == "MET");
@@ -117,16 +117,16 @@ proc test_combine() {
   var met = new shared FixedOffset(60, "MET");
   var d = new date(2002, 3, 4);
   var tz = new time(18, 45, 3, 1234, tz=met);
-  var dt = datetime.combine(d, tz);
-  assert(dt == new datetime(2002, 3, 4, 18, 45, 3, 1234,
+  var dt = dateTime.combine(d, tz);
+  assert(dt == new dateTime(2002, 3, 4, 18, 45, 3, 1234,
                           tz=met));
 }
 
 proc test_extract() {
   var met = new shared FixedOffset(60, "MET");
-  var dt = new datetime(2002, 3, 4, 18, 45, 3, 1234, tz=met);
-  assert(dt.getdate() == new date(2002, 3, 4));
-  assert(dt.gettime() == new time(18, 45, 3, 1234));
+  var dt = new dateTime(2002, 3, 4, 18, 45, 3, 1234, tz=met);
+  assert(dt.getDate() == new date(2002, 3, 4));
+  assert(dt.getTime() == new time(18, 45, 3, 1234));
   assert(dt.timetz() == new time(18, 45, 3, 1234, tz=met));
 }
 
@@ -134,19 +134,19 @@ proc test_tz_aware_arithmetic() {
   use Random;
   var rng = createRandomStream(eltType=int);
 
-  var now = datetime.now();
+  var now = dateTime.now();
   var tz55 = new shared FixedOffset(-330, "west 5:30");
-  var timeaware = now.gettime().replace(tz=tz55);
-  var nowaware = datetime.combine(now.getdate(), timeaware);
+  var timeaware = now.getTime().replace(tz=tz55);
+  var nowaware = dateTime.combine(now.getDate(), timeaware);
   assert(nowaware.timezone == tz55);
   assert(nowaware.timetz() == timeaware);
 
   // Subtracting should yield 0.
-  assert(now - now == new timedelta(0));
-  assert(nowaware - nowaware == new timedelta(0));
+  assert(now - now == new timeDelta(0));
+  assert(nowaware - nowaware == new timeDelta(0));
 
   // Adding a delta should preserve tz.
-  var delta = new timedelta(weeks=1, minutes=12, microseconds=5678);
+  var delta = new timeDelta(weeks=1, minutes=12, microseconds=5678);
   var nowawareplus = nowaware + delta;
   assert(nowaware.timezone == tz55);
   var nowawareplus2 = delta + nowaware;
@@ -177,37 +177,37 @@ proc test_tz_aware_arithmetic() {
   assert(got == expected);
 
   // Try max possible difference.
-  var min = new datetime(1, 1, 1,
+  var min = new dateTime(1, 1, 1,
                          tz=new shared FixedOffset(1439, "min"));
-  var max = new datetime(MAXYEAR, 12, 31, 23, 59, 59, 999999,
+  var max = new dateTime(MAXYEAR, 12, 31, 23, 59, 59, 999999,
                       tz=new shared FixedOffset(-1439, "max"));
   var maxdiff = max - min;
-  assert(maxdiff == datetime.max - datetime.min +
-                    new timedelta(minutes=2*1439));
+  assert(maxdiff == dateTime.max - dateTime.min +
+                    new timeDelta(minutes=2*1439));
 }
 
 proc test_tzinfo_now() {
   // Ensure it doesn't require tz (i.e., that this doesn't blow up).
-  var base = datetime.now();
+  var base = dateTime.now();
   // Try with and without naming the keyword.
   var off42 = new shared FixedOffset(42, "42");
-  var another = datetime.now(off42);
-  var again = datetime.now(tz=off42);
+  var another = dateTime.now(off42);
+  var again = dateTime.now(tz=off42);
   assert(another.timezone == again.timezone);
-  assert(another.utcOffset() == new timedelta(minutes=42));
+  assert(another.utcOffset() == new timeDelta(minutes=42));
 
   // We don't know which time zone we're in, and don't have a tz
   // class to represent it, so seeing whether a tz argument actually
   // does a conversion is tricky.
-  var weirdtz = new shared FixedOffset(new timedelta(hours=15, minutes=58),
-                                           "weirdtz", new timedelta(0));
+  var weirdtz = new shared FixedOffset(new timeDelta(hours=15, minutes=58),
+                                           "weirdtz", new timeDelta(0));
   var utc = new shared FixedOffset(0, "utc", 0);
   for 0..2 {
-    var now = datetime.now(weirdtz);
+    var now = dateTime.now(weirdtz);
     assert(now.timezone == weirdtz);
-    var utcnow = datetime.utcNow().replace(tz=utc);
+    var utcnow = dateTime.utcNow().replace(tz=utc);
     var now2 = utcnow.astimezone(weirdtz);
-    if abs(now - now2) < new timedelta(seconds=30) {
+    if abs(now - now2) < new timeDelta(seconds=30) {
       break;
     // Else the code is broken, or more than 30 seconds passed between
     // calls; assuming the latter, just try again.
@@ -234,35 +234,35 @@ proc test_tzinfo_fromtimestamp() {
 
   var ts = getTimeOfDay()(1);
   // Ensure it doesn't require tz (i.e., that this doesn't blow up).
-  var base = datetime.fromTimestamp(ts);
+  var base = dateTime.fromTimestamp(ts);
   // Try with and without naming the keyword.
   var off42 = new shared FixedOffset(42, "42");
-  var another = datetime.fromTimestamp(ts, off42);
-  var again = datetime.fromTimestamp(ts, tz=off42);
+  var another = dateTime.fromTimestamp(ts, off42);
+  var again = dateTime.fromTimestamp(ts, tz=off42);
   assert(another.timezone == again.timezone);
-  assert(another.utcOffset() == new timedelta(minutes=42));
+  assert(another.utcOffset() == new timeDelta(minutes=42));
 
   // Try to make sure tz= actually does some conversion.
   var timestamp = 1000000000;
-  var utcdatetime = datetime.utcFromTimestamp(timestamp);
+  var utcdateTime = dateTime.utcFromTimestamp(timestamp);
   // In POSIX (epoch 1970), that's 2001-09-09 01:46:40 UTC, give or take.
   // But on some flavor of Mac, it's nowhere near that.  So we can't have
   // any idea here what time that actually is, we can only test that
   // relative changes match.
-  var utcoffset = new timedelta(hours=-15, minutes=39); // arbitrary, but not zero
-  var tz = new shared FixedOffset(utcoffset, "tz", new timedelta());
-  var expected = utcdatetime + utcoffset;
-  var got = datetime.fromTimestamp(timestamp, tz);
+  var utcoffset = new timeDelta(hours=-15, minutes=39); // arbitrary, but not zero
+  var tz = new shared FixedOffset(utcoffset, "tz", new timeDelta());
+  var expected = utcdateTime + utcoffset;
+  var got = dateTime.fromTimestamp(timestamp, tz);
   assert(expected == got.replace(tz=nil));
 }
 
 proc test_tzinfo_timetuple() {
-  // TestDateTime tested most of this.  datetime adds a twist to the
+  // TestDateTime tested most of this.  dateTime adds a twist to the
   // DST flag.
   class DST: Timezone {
-    var dstvalue: timedelta;
+    var dstvalue: timeDelta;
     proc init(i) {
-      dstvalue = new timedelta(minutes=i);
+      dstvalue = new timeDelta(minutes=i);
     }
     override proc dst(dt) {
       return dstvalue;
@@ -270,7 +270,7 @@ proc test_tzinfo_timetuple() {
   }
 
   for (dstvalue, flag) in ((-33, 1), (33, 1), (0, 0)) {
-    var d = new datetime(1, 1, 1, 10, 20, 30, 40,
+    var d = new dateTime(1, 1, 1, 10, 20, 30, 40,
                          tz=new shared DST(dstvalue));
     var t = d.timetuple();
     assert(1 == t.tm_year);
@@ -285,15 +285,15 @@ proc test_tzinfo_timetuple() {
   }
 
   // dst() at the edge.
-  assert((new datetime(1,1,1, tz=new shared DST(1439))).timetuple().tm_isdst == 1);
-  assert((new datetime(1,1,1, tz=new shared DST(-1439))).timetuple().tm_isdst == 1);
+  assert((new dateTime(1,1,1, tz=new shared DST(1439))).timetuple().tm_isdst == 1);
+  assert((new dateTime(1,1,1, tz=new shared DST(-1439))).timetuple().tm_isdst == 1);
 }
 
 proc test_utctimetuple() {
   class DST: Timezone {
-    var dstvalue: timedelta;
+    var dstvalue: timeDelta;
     proc init(dstvalue) {
-      this.dstvalue = new timedelta(minutes=dstvalue);
+      this.dstvalue = new timeDelta(minutes=dstvalue);
     }
     override proc dst(dt) {
       return dstvalue;
@@ -301,10 +301,10 @@ proc test_utctimetuple() {
   }
 
   class UOFS: DST {
-    var uofs: timedelta;
+    var uofs: timeDelta;
     proc init(uofs, dofs=0) {
       super.init(dofs);
-      this.uofs = new timedelta(minutes=uofs);
+      this.uofs = new timeDelta(minutes=uofs);
     }
     override proc utcOffset(dt) {
       return uofs;
@@ -314,7 +314,7 @@ proc test_utctimetuple() {
   // Ensure tm_isdst is 0 regardless of what dst() says:  DST is never
   // in effect for a UTC time.
   for dstvalue in (-33, 33, 0) {
-    var d = new datetime(1, 2, 3, 10, 20, 30, 40, tz=new shared UOFS(-53, dstvalue));
+    var d = new dateTime(1, 2, 3, 10, 20, 30, 40, tz=new shared UOFS(-53, dstvalue));
     var t = d.utctimetuple();
     assert(d.year == t.tm_year);
     assert(d.month == t.tm_mon);
@@ -328,9 +328,9 @@ proc test_utctimetuple() {
   }
 
   // At the edges, UTC adjustment can normalize into years out-of-range
-  // for a datetime object.  Ensure that a correct timetuple is
+  // for a dateTime object.  Ensure that a correct timetuple is
   // created anyway.
-  var tiny = new datetime(MINYEAR, 1, 1, 0, 0, 37, tz=new shared UOFS(1439));
+  var tiny = new dateTime(MINYEAR, 1, 1, 0, 0, 37, tz=new shared UOFS(1439));
   // That goes back 1 minute less than a full day.
   var t = tiny.utctimetuple();
   assert(t.tm_year == MINYEAR-1);
@@ -342,7 +342,7 @@ proc test_utctimetuple() {
   assert(t.tm_yday == 366);    // "year 0" is a leap year
   assert(t.tm_isdst == 0);
 
-  var huge = new datetime(MAXYEAR, 12, 31, 23, 59, 37, 999999, tz=new shared UOFS(-1439));
+  var huge = new dateTime(MAXYEAR, 12, 31, 23, 59, 37, 999999, tz=new shared UOFS(-1439));
   // That goes forward 1 minute less than a full day.
   t = huge.utctimetuple();
   assert(t.tm_year == MAXYEAR+1);
@@ -363,7 +363,7 @@ proc test_tzinfo_isoformat() {
   var datestr = '0001-02-03';
   for ofs in (zero, plus, minus) {
     for us in (0, 987001) {
-      var d = new datetime(1, 2, 3, 4, 5, 59, us, tz=ofs);
+      var d = new dateTime(1, 2, 3, 4, 5, 59, us, tz=ofs);
       var timestr = '04:05:59' + if us != 0 then '.987001' else '';
       var ofsstr = d.tzname();
       var tailstr = timestr + ofsstr;
@@ -378,9 +378,9 @@ proc test_tzinfo_isoformat() {
 
 proc test_replace() {
   var z100 = new shared FixedOffset(100, "+100");
-  var zm200 = new shared FixedOffset(new timedelta(minutes=-200), "-200");
+  var zm200 = new shared FixedOffset(new timeDelta(minutes=-200), "-200");
   var args = (1, 2, 3, 4, 5, 6, 7);
-  var base = new datetime((...args), z100);
+  var base = new dateTime((...args), z100);
   assert(base == base.replace(tz=base.timezone));
 
   var i = 0;
@@ -393,8 +393,8 @@ proc test_replace() {
                          ("microsecond", 8)) {
     var newargs = args;
     newargs[i] = newval;
-    var expected = new datetime((...newargs), z100);
-    var got: datetime;
+    var expected = new dateTime((...newargs), z100);
+    var got: dateTime;
     if name == "year" then
       got = base.replace(year=newval, tz=z100);
     else if name == "month" then
@@ -415,7 +415,7 @@ proc test_replace() {
 
   { // test replacing the timezone
     var newargs = args;
-    var expected = new datetime((...newargs), zm200);
+    var expected = new dateTime((...newargs), zm200);
     var got = base.replace(tz=zm200);
     assert(expected == got);
   }
@@ -434,26 +434,26 @@ proc test_replace() {
 proc test_more_astimezone() {
   // The inherited test_astimezone covered some trivial and error cases.
   var f44m = new shared FixedOffset(44, "44");
-  var fm5h = new shared FixedOffset(-(new timedelta(hours=5)), "m300");
+  var fm5h = new shared FixedOffset(-(new timeDelta(hours=5)), "m300");
 
-  var dt = datetime.now(tz=f44m);
+  var dt = dateTime.now(tz=f44m);
   assert(dt.timezone == f44m);
 
   // Replacing with same tz makes no change.
   var x = dt.astimezone(dt.timezone:shared Timezone);
   assert(x.timezone == f44m);
-  assert(x.getdate() == dt.getdate());
-  assert(x.gettime() == dt.gettime());
+  assert(x.getDate() == dt.getDate());
+  assert(x.getTime() == dt.getTime());
 
   // Replacing with different tz does adjust.
   var got = dt.astimezone(fm5h);
   assert(got.timezone == fm5h);
-  assert(got.utcOffset() == new timedelta(hours=-5));
+  assert(got.utcOffset() == new timeDelta(hours=-5));
   var expected = dt - dt.utcOffset();  // in effect, convert to UTC
   expected += fm5h.utcOffset(dt);  // and from there to local time
   expected = expected.replace(tz=fm5h); // and attach new tz
-  assert(got.getdate() == expected.getdate());
-  assert(got.gettime() == expected.gettime());
+  assert(got.getDate() == expected.getDate());
+  assert(got.getTime() == expected.getTime());
   assert(got.timetz() == expected.timetz());
   assert(got.timezone == expected.timezone);
   assert(got == expected);
@@ -463,47 +463,47 @@ proc test_aware_subtract() {
   // Ensure that utcoffset() is ignored when the operands have the
   // same tz member.
   class OperandDependentOffset: Timezone {
-    override proc utcOffset(dt: datetime) {
+    override proc utcOffset(dt: dateTime) {
       if dt.minute < 10 {
         // d0 and d1 equal after adjustment
-        return new timedelta(minutes=dt.minute);
+        return new timeDelta(minutes=dt.minute);
       } else {
         // d2 off in the weeds
-        return new timedelta(minutes=59);
+        return new timeDelta(minutes=59);
       }
     }
   }
 
-  var base = new datetime(8, 9, 10, 11, 12, 13, 14, tz=new shared OperandDependentOffset());
+  var base = new dateTime(8, 9, 10, 11, 12, 13, 14, tz=new shared OperandDependentOffset());
   var d0 = base.replace(minute=3, tz=base.timezone);
   var d1 = base.replace(minute=9, tz=base.timezone);
   var d2 = base.replace(minute=11, tz=base.timezone);
   for x in (d0, d1, d2) {
     for y in (d0, d1, d2) {
       var got = x - y;
-      var expected = new timedelta(minutes=x.minute - y.minute);
+      var expected = new timeDelta(minutes=x.minute - y.minute);
       assert(got == expected);
     }
   }
   // OTOH, if the tz members are distinct, utcoffsets aren't
   // ignored.
-  base = new datetime(8, 9, 10, 11, 12, 13, 14);
+  base = new dateTime(8, 9, 10, 11, 12, 13, 14);
   d0 = base.replace(minute=3, tz=new shared OperandDependentOffset());
   d1 = base.replace(minute=9, tz=new shared OperandDependentOffset());
   d2 = base.replace(minute=11, tz=new shared OperandDependentOffset());
   for x in (d0, d1, d2) {
     for y in (d0, d1, d2) {
       var got = x - y;
-      var expected: timedelta;
+      var expected: timeDelta;
       if (x == d0 || x == d1) && (y == d0 || y == d1) then
-        expected = new timedelta(0);
+        expected = new timeDelta(0);
       else if x == y && x == d2 then
-        expected = new timedelta(0);
+        expected = new timeDelta(0);
       else if x == d2 then
-        expected = new timedelta(minutes=(11-59)-0);
+        expected = new timeDelta(minutes=(11-59)-0);
       else {
         assert(y == d2);
-        expected = new timedelta(minutes=0-(11-59));
+        expected = new timeDelta(minutes=0-(11-59));
       }
       assert(got == expected);
     }
@@ -511,21 +511,21 @@ proc test_aware_subtract() {
 }
 
 proc test_mixed_compare() {
-  var t1 = new datetime(1, 2, 3, 4, 5, 6, 7);
-  var t2 = new datetime(1, 2, 3, 4, 5, 6, 7);
+  var t1 = new dateTime(1, 2, 3, 4, 5, 6, 7);
+  var t2 = new dateTime(1, 2, 3, 4, 5, 6, 7);
   assert(t1 == t2);
   t2 = t2.replace(tz=nil);
   assert(t1 == t2);
   t2 = t2.replace(tz=new shared FixedOffset(0, ""));
 
-  // In datetime w/ identical tz objects, utcoffset is ignored.
+  // In dateTime w/ identical tz objects, utcoffset is ignored.
   class Varies: Timezone {
-    var offset: timedelta;
+    var offset: timeDelta;
     proc init() {
-      offset = new timedelta(minutes=22);
+      offset = new timeDelta(minutes=22);
     }
-    override proc utcOffset(dt: datetime) {
-      offset += new timedelta(minutes=1);
+    override proc utcOffset(dt: dateTime) {
+      offset += new timeDelta(minutes=1);
       return offset;
     }
   }
@@ -533,8 +533,8 @@ proc test_mixed_compare() {
   var v = new shared Varies();
   t1 = t2.replace(tz=v);
   t2 = t2.replace(tz=v);
-  assert(t1.utcOffset() == new timedelta(minutes=23));
-  assert(t2.utcOffset() == new timedelta(minutes=24));
+  assert(t1.utcOffset() == new timeDelta(minutes=23));
+  assert(t2.utcOffset() == new timeDelta(minutes=24));
   assert(t1 == t2);
 
   // But if they're not identical, it isn't ignored.
@@ -545,7 +545,7 @@ proc test_mixed_compare() {
 proc first_sunday_on_or_after(in dt) {
   var days_to_go = 6 - dt.weekday():int;
   if days_to_go != 0 then
-    dt += new timedelta(days_to_go);
+    dt += new timeDelta(days_to_go);
   return dt;
 }
 

--- a/test/library/standard/DateTime/testNow.chpl
+++ b/test/library/standard/DateTime/testNow.chpl
@@ -1,10 +1,10 @@
 use Time;
 
-// Make sure datetime.now() is within a day of date.today(). They could be
+// Make sure dateTime.now() is within a day of date.today(). They could be
 // different if the time passes midnight betwen the two calls.
 
-var now = datetime.now();
+var now = dateTime.now();
 var today = date.today();
-var diff = now - new datetime(today.year, today.month, today.day);
+var diff = now - new dateTime(today.year, today.month, today.day);
 
 assert(diff.days == 0 || diff.days == -1);

--- a/test/library/standard/DateTime/testTime.chpl
+++ b/test/library/standard/DateTime/testTime.chpl
@@ -90,7 +90,7 @@ proc test_resolution_info() {
 
   assert(valIsType(time, time.min));
   assert(valIsType(time, time.max));
-  assert(valIsType(timedelta, time.resolution));
+  assert(valIsType(timeDelta, time.resolution));
   assert(time.max > time.min);
 }
 

--- a/test/library/standard/DateTime/testTimezone.chpl
+++ b/test/library/standard/DateTime/testTimezone.chpl
@@ -1,20 +1,20 @@
 use Time;
 
 class FixedOffset: Timezone {
-  var offset: timedelta;
+  var offset: timeDelta;
   var name: string;
-  var dstoffset: timedelta;
+  var dstoffset: timeDelta;
 
-  proc init(offset: timedelta, name: string, dstoffset: timedelta=new timedelta(42)) {
+  proc init(offset: timeDelta, name: string, dstoffset: timeDelta=new timeDelta(42)) {
     this.offset = offset;
     this.name = name;
     this.dstoffset = dstoffset;
   }
 
   proc init(offset: int, name, dstoffset:int=42) {
-    this.offset = new timedelta(minutes=offset);
+    this.offset = new timeDelta(minutes=offset);
     this.name = name;
-    this.dstoffset = new timedelta(minutes=dstoffset);
+    this.dstoffset = new timeDelta(minutes=dstoffset);
   }
 
   override proc utcOffset(dt) {
@@ -53,17 +53,17 @@ proc test_zones() {
   assert(t4.timezone.borrow() == nil);
   assert(t5.timezone == utc);
 
-  assert(t1.utcOffset() == new timedelta(minutes=-300));
-  assert(t2.utcOffset() == new timedelta(minutes=0));
-  assert(t3.utcOffset() == new timedelta(minutes=60));
+  assert(t1.utcOffset() == new timeDelta(minutes=-300));
+  assert(t2.utcOffset() == new timeDelta(minutes=0));
+  assert(t3.utcOffset() == new timeDelta(minutes=60));
 
   assert(t1.tzname() == "EST");
   assert(t2.tzname() == "UTC");
   assert(t3.tzname() == "MET");
 
-  assert(t1.dst() == new timedelta(minutes=1));
-  assert(t2.dst() == new timedelta(minutes=-2));
-  assert(t3.dst() == new timedelta(minutes=3));
+  assert(t1.dst() == new timeDelta(minutes=1));
+  assert(t2.dst() == new timeDelta(minutes=-2));
+  assert(t3.dst() == new timeDelta(minutes=3));
 
   assert(t1 == t2);
   assert(t1 == t3);
@@ -96,7 +96,7 @@ proc test_zones() {
 
 proc test_replace() {
   var z100 = new shared FixedOffset(100, "+100");
-  var zm200 = new shared FixedOffset(new timedelta(minutes=-200), "-200");
+  var zm200 = new shared FixedOffset(new timeDelta(minutes=-200), "-200");
   var args = (1, 2, 3, 4);
   var base = new time((...args), z100);
   assert(base == base.replace(tz=base.timezone));
@@ -152,19 +152,19 @@ proc test_mixed_compare() {
 
   // In time w/ identical tz objects, utcoffset is ignored.
   class Varies: Timezone {
-    var offset: timedelta;
+    var offset: timeDelta;
     var name = "Var";
     proc init() {
-      offset = new timedelta(minutes=22);
+      offset = new timeDelta(minutes=22);
     }
-    override proc utcOffset(dt: datetime) {
-      offset += new timedelta(minutes=1);
+    override proc utcOffset(dt: dateTime) {
+      offset += new timeDelta(minutes=1);
       return offset;
     }
-    override proc dst(dt: datetime) {
-      return new timedelta(0);
+    override proc dst(dt: dateTime) {
+      return new timeDelta(0);
     }
-    override proc tzname(dt: datetime) {
+    override proc tzname(dt: dateTime) {
       return name;
     }
   }
@@ -172,8 +172,8 @@ proc test_mixed_compare() {
   var v = new shared Varies();
   t1 = t2.replace(tz=v);
   t2 = t2.replace(tz=v);
-  assert(t1.utcOffset() == new timedelta(minutes=23));
-  assert(t2.utcOffset() == new timedelta(minutes=24));
+  assert(t1.utcOffset() == new timeDelta(minutes=23));
+  assert(t2.utcOffset() == new timeDelta(minutes=24));
   assert(t1 == t2);
 
   // But if they're not identical, it isn't ignored.

--- a/test/library/standard/DateTime/unstableTimezones.chpl
+++ b/test/library/standard/DateTime/unstableTimezones.chpl
@@ -2,23 +2,23 @@ use Time;
 
 class zone: Timezone {
   /* The offset from UTC this class represents */
-  proc utcoffset(dt: datetime): timedelta {
-    return new timedelta();
+  proc utcoffset(dt: dateTime): timeDelta {
+    return new timeDelta();
   }
 
-  /* The `timedelta` for daylight saving time */
-  proc dst(dt: datetime): timedelta {
-    return new timedelta();
+  /* The `timeDelta` for daylight saving time */
+  proc dst(dt: dateTime): timeDelta {
+    return new timeDelta();
   }
 
   /* The name of this time zone */
-  proc tzname(dt: datetime): string {
+  proc tzname(dt: dateTime): string {
     return "ZONE";
   }
 
   /* Convert a `time` in UTC to this time zone */
-  proc fromutc(dt: datetime): datetime {
-    return new datetime(0,0,0);
+  proc fromutc(dt: dateTime): dateTime {
+    return new dateTime(0,0,0);
   }
 }
 

--- a/test/library/standard/DateTime/writeDateTime.chpl
+++ b/test/library/standard/DateTime/writeDateTime.chpl
@@ -2,7 +2,7 @@ use Time;
 
 var t = new time(hour=3, minute=14, second=15, microsecond=926535);
 var d = new date(year=2718, month=2, day=8);
-var dt = new datetime(year=1618, month=03, day=3, hour=9, minute=8, second=8, microsecond=749894);
+var dt = new dateTime(year=1618, month=03, day=3, hour=9, minute=8, second=8, microsecond=749894);
 
 writeln(t);
 writeln(d);

--- a/test/library/standard/Time/stonea/getCurrentDayOfWeek.chpl
+++ b/test/library/standard/Time/stonea/getCurrentDayOfWeek.chpl
@@ -3,12 +3,12 @@ use Time;
 var day = getCurrentDayOfWeek():Day;
 
 select day {
-    when Day.sunday do writeln("Sunday");
-    when Day.monday do writeln("Monday");
-    when Day.tuesday do writeln("Tuesday");
-    when Day.wednesday do writeln("Wednesday");
-    when Day.thursday do writeln("Thursday");
-    when Day.friday do writeln("Friday");
-    when Day.saturday do writeln("Saturday");
+    when day.sunday do writeln("Sunday");
+    when day.monday do writeln("Monday");
+    when day.tuesday do writeln("Tuesday");
+    when day.wednesday do writeln("Wednesday");
+    when day.thursday do writeln("Thursday");
+    when day.friday do writeln("Friday");
+    when day.saturday do writeln("Saturday");
 }
 

--- a/test/library/standard/Time/stonea/getCurrentDayOfWeek.chpl
+++ b/test/library/standard/Time/stonea/getCurrentDayOfWeek.chpl
@@ -1,8 +1,8 @@
 use Time;
 
-var day = getCurrentDayOfWeek():Day;
+var weekday = getCurrentDayOfWeek():day;
 
-select day {
+select weekday {
     when day.sunday do writeln("Sunday");
     when day.monday do writeln("Monday");
     when day.tuesday do writeln("Tuesday");

--- a/test/studies/comd/elegant/arrayOfStructs/util/Util.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/Util.chpl
@@ -40,12 +40,12 @@ inline proc dot(A:vec3, B:vec3) {
 
 proc dateString() {
   use Time;
-  return datetime.now().strftime("%F, %T");
+  return dateTime.now().strftime("%F, %T");
 }
 
 proc timestampMessage(msg : string) {
   use Time;
-  const timeStr = datetime.now().ctime();
+  const timeStr = dateTime.now().ctime();
   writeln(timeStr, ": ", msg);
   writeln();
 }


### PR DESCRIPTION
Update 'datetime', 'timedelta', 'enum Day', 'getdate', 'gettime' to use our regular
capitalization rules. So the new names are 'dateTime', 'timeDelta', 'enum day',
'getDate', and 'getTime'.

Update modules that use dateTime. Update tests to use the new names.
Add a deprecated test for the old names.