### PR TITLE
Fix memory leaks in `readAll` tests

### DIFF
--- a/test/library/standard/IO/readAll/readBytesType.chpl
+++ b/test/library/standard/IO/readAll/readBytesType.chpl
@@ -2,7 +2,6 @@ use IO;
 
 var ch = openReader("./jab.txt");
 const b = ch.readAll(bytes);
-ch.close();
 
 writeln(b);
 writeln(b.type == bytes);
@@ -13,3 +12,5 @@ try {
 } catch e {
     writeln(e);
 }
+
+ch.close();

--- a/test/library/standard/IO/readAll/readStringType.chpl
+++ b/test/library/standard/IO/readAll/readStringType.chpl
@@ -2,7 +2,6 @@ use IO;
 
 var ch = openReader("./jab.txt");
 const s = ch.readAll(string);
-ch.close();
 
 writeln(s);
 writeln(s.type == string);
@@ -13,3 +12,5 @@ try {
 } catch e {
     writeln(e);
 }
+
+ch.close();


### PR DESCRIPTION
Fixes a memory leak in a couple of `readAll` tests caused by writing to the channel after calling `close()` on it.

- [x] reran tests with `--memleaks` config