### PR TITLE
Add a specialized error for 'c_ptr()' types whose arguments are generic

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3487,10 +3487,15 @@ static void warnForPartialInstantiationNoQ(CallExpr* call, Type* t) {
       if (!foundQuestionMarkArg) {
         Type* tt = canonicalClassType(t);
         if (tt && tt->symbol->hasFlag(FLAG_GENERIC)) {
-          // print out which field
-          USR_WARN(checkCall, "partial instantiation without '?' argument");
-          USR_PRINT(checkCall, "opt in to partial instantiation explicitly with a trailing '?' argument");
-          USR_PRINT(checkCall, "or, add arguments to instantiate the following fields in generic type '%s':", tt->symbol->name);
+          if (tt->symbol->hasFlag(FLAG_C_PTR_CLASS)) {
+            USR_FATAL(checkCall, "the c_ptr() type requires a concrete type argument, but its argument is generic");
+            return;
+          } else {
+            // print out which field
+            USR_WARN(checkCall, "partial instantiation without '?' argument");
+            USR_PRINT(checkCall, "opt in to partial instantiation explicitly with a trailing '?' argument");
+            USR_PRINT(checkCall, "or, add arguments to instantiate the following fields in generic type '%s':", tt->symbol->name);
+          }
           // which field names are generic?
           if (AggregateType* at = toAggregateType(tt)) {
             bool printedAnyFields = false;


### PR DESCRIPTION
As I understand it, the 'c_ptr()' type is designed to only take concrete types.  Currently, if given a generic type, we get the partial instantiation without '?' warning, though:

(1) I don't think we really want to encourage 'c_ptr()' instantiations with generics (do we?)

(2) It seems as though the place we'd add a '?' to quiet the warning is odd...  (see https://github.com/chapel-lang/chapel/issues/22011#issuecomment-1492765079 for details)

More broadly, this relates to a more general question I've (we've?) been asking recently, which is whether something that takes a type argument should accept generic types, at least by default.

TODO:

- [ ] File future from #22011 or wait for Daniel to and resolve
- [ ] File future for issue comment noted above
- [ ] Verify that c_ptr shouldn't take a generic type
- [ ] File an issue (after verifying we don't have one?) asking whether `type` argument should only accept concrete types
