### PR TITLE
Align homebrew tests to align with homebrew CI.

### DIFF
--- a/util/packaging/docker/test/brew_install.bash
+++ b/util/packaging/docker/test/brew_install.bash
@@ -18,12 +18,12 @@ brew test-bot --only-setup
     fi
 
 # tests commands
-brew-test --only-cleanup-before
+brew test-bot --only-cleanup-before
 if [ $? -ne 0 ]; then
-      echo "brew-test --only-cleanup-before failed" 
+      echo "brew test-bot --only-cleanup-before failed" 
       exit 1
 else
-      echo "brew-test --only-cleanup-before succeeded"
+      echo "brew test-bot --only-cleanup-before succeeded"
 fi
 
 brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formula=chapel --added-formulae= --deleted-formulae=

--- a/util/packaging/docker/test/brew_install.bash
+++ b/util/packaging/docker/test/brew_install.bash
@@ -9,14 +9,6 @@ else
       echo "brew test-bot --only-tap-syntax succeeded"
 fi
 
-brew test-bot --only-setup
-    if [ $? -ne 0 ]; then
-      echo "brew test-bot --only-setup failed" 
-      exit 1
-      else
-      echo "brew test-bot --only-setup succeeded"
-    fi
-
 # tests commands
 brew test-bot --only-cleanup-before
 if [ $? -ne 0 ]; then
@@ -26,13 +18,13 @@ else
       echo "brew test-bot --only-cleanup-before succeeded"
 fi
 
-brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formula=chapel --added-formulae= --deleted-formulae=
-if [ $? -ne 0 ]; then
-      echo "brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formula=chapel --added-formulae= --deleted-formulae= failed" 
+brew test-bot --only-setup
+    if [ $? -ne 0 ]; then
+      echo "brew test-bot --only-setup failed" 
       exit 1
-else
-      echo "brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formula=chapel --added-formulae= --deleted-formulae= succeeded"
-fi
+      else
+      echo "brew test-bot --only-setup succeeded"
+    fi
 
 brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel
 if [ $? -ne 0 ]; then


### PR DESCRIPTION

Homebrew CI is updated with new set of test-bot commands.
Updating our homebrew-runs to align with the homebrew-CI (for ex https://github.com/Homebrew/homebrew-core/actions/runs/4598529663/jobs/8122829052).

Correct brew test bot command to test --cleanup-before
Remove the stale test-bot commands

https://github.com/Cray/chapel-private/issues/4642