### PR TITLE
Deep copy for bigint values RVFed locally

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4687,7 +4687,7 @@ module BigInteger {
   proc type bigint.chpl__deserialize(data) {
     var ret: bigint;
     if data.localeId == chpl_nodeID {
-      ret.mpz = data.buff;
+      mpz_set(ret.mpz, data.buff);
     } else {
       chpl_gmp_get_mpz(ret.mpz, data.localeId, data.buff[0]);
     }


### PR DESCRIPTION
In #22000, when a bigint was RVFed locally, the RVFed record would do a shallow copy of the `mpz_t` field. This meant that the `mpz_t` field was being freed twice, once by the RVFed record and once by the original record. Doing a deep copy in this PR will fix this issue.