### PR TITLE
Add 'inline' on .borrow()

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -676,7 +676,7 @@ proc Block.getChunk(inds, locid) {
   // Vass 2023-03: the chunk should really be computed as:
   //   const chunk = inds[locDist(locid).myChunk];
   // because we are looking for a subset of 'inds'.
-  // I did not make this change because it slightly bumps comm counts in:
+  // I did not make this change because it would slightly bump comm counts in:
   //   distributions/robust/arithmetic/performance/multilocale/assignReindex
   //
   const chunk = locDist(locid).myChunk((...inds.getIndices()));

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -609,6 +609,7 @@ proc Stencil.getChunk(inds, locid) {
   // TODO: Should this be able to be written as myChunk[inds] ???
   //
   // TODO: Does using David's detupling trick work here?
+  // see Block.getChunk
   //
   const chunk = locDist(locid).myChunk((...inds.getIndices()));
   if sanityCheckDistribution then

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -285,7 +285,7 @@ module OwnedObject {
        In some cases such errors are caught at compile-time.
      */
     pragma "nil from this"
-    inline proc /*const*/ borrow() {
+    proc /*const*/ borrow() {
       if _to_nilable(chpl_t) == chpl_t {
         return chpl_p;
       } else {

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -285,19 +285,11 @@ module OwnedObject {
        In some cases such errors are caught at compile-time.
      */
     pragma "nil from this"
-    proc /*const*/ borrow() {
+    inline proc /*const*/ borrow() {
       if _to_nilable(chpl_t) == chpl_t {
         return chpl_p;
       } else {
         return chpl_p!;
-      }
-    }
-
-    proc type borrow() type {
-      if _to_nilable(chpl_t) == chpl_t {
-        return chpl_t;
-      } else {
-        return _to_nonnil(chpl_t);
       }
     }
   }

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -490,7 +490,7 @@ module SharedObject {
        In some cases such errors are caught at compile-time.
      */
     pragma "nil from this"
-    inline proc /*const*/ borrow() {
+    proc /*const*/ borrow() {
       if _to_nilable(chpl_t) == chpl_t {
         return chpl_p;
       } else {

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -490,7 +490,7 @@ module SharedObject {
        In some cases such errors are caught at compile-time.
      */
     pragma "nil from this"
-    proc /*const*/ borrow() {
+    inline proc /*const*/ borrow() {
       if _to_nilable(chpl_t) == chpl_t {
         return chpl_p;
       } else {

--- a/test/library/packages/Search/correctness.chpl
+++ b/test/library/packages/Search/correctness.chpl
@@ -18,7 +18,7 @@ proc main() {
      revAbsA = [ -4, 3, 2, -1],
         strA = ['Brad', 'anthony', 'ben', 'david'],
     strideA : [strideD] int = [-4, -1, 2, 3],
-    revStrideA : [revStrideD] int = [-4, -1, 2, 3];  // neg-stride revStrideA[10]=3 etc.
+    revStrideA : [revStrideD] int = [-4, -1, 2, 3];  // neg-stride revStrideA[0]=3 etc.
 
   // Comparators
   const absKey = new AbsKeyCmp(),


### PR DESCRIPTION
This removes 'proc type borrow()'. It is not used and would not work even if it were, because it accesses a field on 'this'. Also touches up a couple of comments.