### PR TITLE
Fix BigInteger issue with a result parameter used as an argument

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -1965,12 +1965,12 @@ module BigInteger {
       if _local {
         powNegativeExpHelper(result, base, exp);
       } else if result.localeId == chpl_nodeID {
-        const base_ = base.localize();
+        const base_ = base;
         powNegativeExpHelper(result, base_, exp);
       } else {
         const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
         on __primitive("chpl_on_locale_num", resultLoc) {
-          const base_ = base.localize();
+          const base_ = base;
           powNegativeExpHelper(result, base_, exp);
         }
       }
@@ -1989,12 +1989,12 @@ module BigInteger {
     if _local {
       mpz_pow_ui(result.mpz, base.mpz, exp_);
     } else if result.localeId == chpl_nodeID {
-      const base_ = base.localize();
+      const base_ = base;
       mpz_pow_ui(result.mpz, base_.mpz, exp_);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const base_ = base.localize();
+        const base_ = base;
         mpz_pow_ui(result.mpz, base_.mpz, exp_);
       }
     }
@@ -2294,12 +2294,12 @@ module BigInteger {
     if _local {
       mpz_nextprime(result.mpz, a.mpz);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_nextprime(result.mpz, a_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_nextprime(result.mpz, a_.mpz);
       }
     }
@@ -2459,14 +2459,14 @@ module BigInteger {
     if _local {
       mpz_lcm(result.mpz, a.mpz, b.mpz);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
-      const b_ = b.localize();
+      const a_ = a;
+      const b_ = b;
       mpz_lcm(result.mpz, a_.mpz, b_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
-        const b_ = b.localize();
+        const a_ = a;
+        const b_ = b;
         mpz_lcm(result.mpz, a_.mpz, b_.mpz);
       }
     }
@@ -2495,12 +2495,12 @@ module BigInteger {
     if _local {
       mpz_lcm_ui(result.mpz, a.mpz, b_);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_lcm_ui(result.mpz, a_.mpz, b_);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_lcm_ui(result.mpz, a_.mpz, b_);
       }
     }
@@ -2548,14 +2548,14 @@ module BigInteger {
     if _local {
       ret = mpz_invert(result.mpz, a.mpz, b.mpz);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
-      const b_ = b.localize();
+      const a_ = a;
+      const b_ = b;
       ret = mpz_invert(result.mpz, a_.mpz, b_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
-        const b_ = b.localize();
+        const a_ = a;
+        const b_ = b;
         ret = mpz_invert(result.mpz, a_.mpz, b_.mpz);
       }
     }
@@ -3129,14 +3129,14 @@ module BigInteger {
       mpz_add(result.mpz, a.mpz, b.mpz);
     }
     else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
-      const b_ = b.localize();
+      const a_ = a;
+      const b_ = b;
       mpz_add(result.mpz, a_.mpz, b_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
-        const b_ = b.localize();
+        const a_ = a;
+        const b_ = b;
         mpz_add(result.mpz, a_.mpz, b_.mpz);
       }
     }
@@ -3158,13 +3158,13 @@ module BigInteger {
         mpz_sub_ui(result.mpz, a.mpz, b_);
       }
       else if result.localeId == chpl_nodeID {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_sub_ui(result.mpz, a_.mpz, b_);
       }
       else {
         const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
         on __primitive("chpl_on_locale_num", resultLoc) {
-          const a_ = a.localize();
+          const a_ = a;
           mpz_sub_ui(result.mpz, a_.mpz, b_);
         }
       }
@@ -3182,13 +3182,13 @@ module BigInteger {
       mpz_add_ui(result.mpz, a.mpz, b_);
     }
     else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_add_ui(result.mpz, a_.mpz, b_);
     }
     else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_add_ui(result.mpz, a_.mpz, b_);
       }
     }
@@ -3203,14 +3203,14 @@ module BigInteger {
     if _local {
       mpz_sub(result.mpz, a.mpz, b.mpz);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
-      const b_ = b.localize();
+      const a_ = a;
+      const b_ = b;
       mpz_sub(result.mpz, a_.mpz, b_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
-        const b_ = b.localize();
+        const a_ = a;
+        const b_ = b;
         mpz_sub(result.mpz, a_.mpz, b_.mpz);
       }
     }
@@ -3240,12 +3240,12 @@ module BigInteger {
     if _local {
       mpz_sub_ui(result.mpz, a.mpz, b_);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_sub_ui(result.mpz, a_.mpz, b_);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_sub_ui(result.mpz, a_.mpz, b_);
       }
     }
@@ -3266,13 +3266,13 @@ module BigInteger {
         mpz_add_ui(result.mpz, b.mpz, a_);
         mpz_neg(result.mpz, result.mpz);
       } else if result.localeId == chpl_nodeID {
-        const b_ = b.localize();
+        const b_ = b;
         mpz_add_ui(result.mpz, b_.mpz, a_);
         mpz_neg(result.mpz, result.mpz);
       } else {
         const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
         on __primitive("chpl_on_locale_num", resultLoc) {
-          const b_ = b.localize();
+          const b_ = b;
           mpz_add_ui(result.mpz, b_.mpz, a_);
           mpz_neg(result.mpz, result.mpz);
         }
@@ -3311,8 +3311,8 @@ module BigInteger {
     if _local {
       mpz_mul(result.mpz, a.mpz, b.mpz);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
-      const b_ = b.localize();
+      const a_ = a;
+      const b_ = b;
       mpz_mul(result.mpz, a_.mpz, b_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
@@ -3335,12 +3335,12 @@ module BigInteger {
     if _local {
       mpz_mul_si(result.mpz, a.mpz, b_);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_mul_si(result.mpz, a_.mpz, b_);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_mul_si(result.mpz, a_.mpz, b_);
       }
     }
@@ -3357,12 +3357,12 @@ module BigInteger {
     if _local {
       mpz_mul_ui(result.mpz, a.mpz, b_);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_mul_ui(result.mpz, a_.mpz, b_);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_mul_ui(result.mpz, a_.mpz, b_);
       }
     }
@@ -3377,14 +3377,14 @@ module BigInteger {
     if _local {
       mpz_addmul(result.mpz, a.mpz, b.mpz);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
-      const b_ = b.localize();
+      const a_ = a;
+      const b_ = b;
       mpz_addmul(result.mpz, a_.mpz, b_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
-        const b_ = b.localize();
+        const a_ = a;
+        const b_ = b;
         mpz_addmul(result.mpz, a_.mpz, b_.mpz);
       }
     }
@@ -3435,14 +3435,14 @@ module BigInteger {
     if _local {
       mpz_submul(result.mpz, a.mpz, b.mpz);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
-      const b_ = b.localize();
+      const a_ = a;
+      const b_ = b;
       mpz_submul(result.mpz, a_.mpz, b_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
-        const b_ = b.localize();
+        const a_ = a;
+        const b_ = b;
         mpz_submul(result.mpz, a_.mpz, b_.mpz);
       }
     }
@@ -3472,12 +3472,12 @@ module BigInteger {
     if _local {
       mpz_submul_ui(result.mpz, a.mpz, b_);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_submul_ui(result.mpz, a_.mpz, b_);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_submul_ui(result.mpz, a_.mpz, b_);
       }
     }
@@ -3494,12 +3494,12 @@ module BigInteger {
     if _local {
       mpz_mul_2exp(result.mpz, a.mpz, b_);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_mul_2exp(result.mpz, a_.mpz, b_);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_mul_2exp(result.mpz, a_.mpz, b_);
       }
     }
@@ -4519,12 +4519,12 @@ module BigInteger {
     if _local {
       mpz_com(result.mpz, a.mpz);
     } else if result.localeId == chpl_nodeID {
-      const a_ = a.localize();
+      const a_ = a;
       mpz_com(result.mpz, a_.mpz);
     } else {
       const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
       on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a.localize();
+        const a_ = a;
         mpz_com(result.mpz, a_.mpz);
       }
     }

--- a/test/library/standard/BigInteger/resultAsArgument.chpl
+++ b/test/library/standard/BigInteger/resultAsArgument.chpl
@@ -1,0 +1,476 @@
+use BigInteger;
+
+{
+  write("divexact ");
+  var a = new bigint(12);
+  var b = new bigint(6);
+  divexact(a, a, b);
+  writeln(a);
+}
+{
+  write("divexact ");
+  var a = new bigint(12);
+  divexact(a, a, 6);
+  writeln(a);
+}
+{
+  write("powMod ");
+  var a = new bigint(4);
+  var b = new bigint(2);
+  var c = new bigint(5);
+  powMod(a, a, b, c);
+  writeln(a);
+}
+{
+  write("powMod ");
+  var a = new bigint(4);
+  var b = new bigint(2);
+  var c = new bigint(5);
+  powMod(b, a, b, c);
+  writeln(b);
+}
+{
+  write("powMod ");
+  var a = new bigint(4);
+  var b = new bigint(2);
+  var c = new bigint(5);
+  powMod(c, a, b, c);
+  writeln(c);
+}
+{
+  write("powMod ");
+  var a = new bigint(4);
+  var b = new bigint(5);
+  powMod(a, a, 2:uint, b);
+  writeln(a);
+}
+{
+  write("powMod ");
+  var a = new bigint(4);
+  var b = new bigint(5);
+  powMod(b, a, 2:uint, b);
+  writeln(b);
+}
+{
+  write("pow ");
+  var a = new bigint(4);
+  pow(a, a, -2);
+  writeln(a);
+}
+{
+  write("pow ");
+  var a = new bigint(4);
+  pow(a, a, 2:uint);
+  writeln(a);
+}
+{
+  write("root ");
+  var a = new bigint(4);
+  root(a, a, 2:uint);
+  writeln(a);
+}
+{
+  write("rootrem ");
+  var a = new bigint(5);
+  var b: bigint;
+  rootrem(a, b, a, 2:uint);
+  writeln(a, " ", b);
+}
+{
+  write("rootrem ");
+  var a = new bigint(5);
+  var b: bigint;
+  rootrem(b, a, a, 2:uint);
+  writeln(b, " ", a);
+}
+{
+  write("sqrt ");
+  var a = new bigint(9);
+  sqrt(a, a);
+  writeln(a);
+}
+{
+  write("sqrtrem ");
+  var a = new bigint(10);
+  var b: bigint;
+  sqrtrem(a, b, a);
+  writeln(a, " ", b);
+}
+{
+  write("sqrtrem ");
+  var a = new bigint(10);
+  var b: bigint;
+  sqrtrem(b, a, a);
+  writeln(b, " ", a);
+}
+{
+  write("nextprime ");
+  var a = new bigint(16);
+  nextprime(a, a);
+  writeln(a);
+}
+{
+  write("gcd ");
+  var a = new bigint(8);
+  var b = new bigint(12);
+  gcd(a, a, b);
+  writeln(a);
+}
+{
+  write("gcd ");
+  var a = new bigint(8);
+  var b = new bigint(12);
+  gcd(b, a, b);
+  writeln(b);
+}
+{
+  write("gcd ");
+  var a = new bigint(8);
+  gcd(a, a, 12:uint);
+  writeln(a);
+}
+{
+  write("gcd ");
+  var a = new bigint(8);
+  var b = new bigint(12);
+  var c: bigint;
+  var d: bigint;
+  gcd(a, a, b, c, d);
+  writeln(a, " ", c, " ", d);
+}
+{
+  write("gcd ");
+  var a = new bigint(8);
+  var b = new bigint(12);
+  var c: bigint;
+  var d: bigint;
+  gcd(b, a, b, c, d);
+  writeln(b, " ", c, " ", d);
+}
+{
+  write("gcd ");
+  var a = new bigint(8);
+  var b = new bigint(12);
+  var c: bigint;
+  gcd(c, a, b, a, b);
+  writeln(c, " ", a, " ", b);
+}
+{
+  write("lcm ");
+  var a = new bigint(4);
+  var b = new bigint(6);
+  lcm(a, a, b);
+  writeln(a);
+}
+{
+  write("lcm ");
+  var a = new bigint(4);
+  var b = new bigint(6);
+  lcm(b, a, b);
+  writeln(b);
+}
+{
+  write("lcm ");
+  var a = new bigint(4);
+  lcm(a, a, 6:uint);
+  writeln(a);
+}
+{
+  write("invert ");
+  var a = new bigint(5);
+  var b = new bigint(13);
+  invert(a, a, b);
+  writeln(a);
+}
+{
+  write("invert ");
+  var a = new bigint(5);
+  var b = new bigint(13);
+  invert(b, a, b);
+  writeln(b);
+}
+{
+  write("removeFactor ");
+  var a = new bigint(5);
+  var b = new bigint(13);
+  removeFactor(a, a, b);
+  writeln(a);
+}
+{
+  write("removeFactor ");
+  var a = new bigint(5);
+  var b = new bigint(13);
+  removeFactor(b, a, b);
+  writeln(b);
+}
+{
+  write("bin ");
+  var a = new bigint(2);
+  bin(a, a, 1);
+  writeln(a);
+}
+{
+  write("add ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  add(a, a, b);
+  writeln(a);
+}
+{
+  write("add ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  add(b, a, b);
+  writeln(b);
+}
+{
+  write("add ");
+  var a = new bigint(5);
+  add(a, a, 6:uint);
+  writeln(a);
+}
+{
+  write("add ");
+  var a = new bigint(5);
+  add(a, a, -6);
+  writeln(a);
+}
+{
+  write("sub ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  sub(a, a, b);
+  writeln(a);
+}
+{
+  write("sub ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  sub(b, a, b);
+  writeln(b);
+}
+{
+  write("sub ");
+  var a = new bigint(5);
+  sub(a, a, 6:uint);
+  writeln(a);
+}
+{
+  write("sub ");
+  var a = new bigint(5);
+  sub(a, -6, a);
+  writeln(a);
+}
+{
+  write("sub ");
+  var a = new bigint(5);
+  sub(a, 6:uint, a);
+  writeln(a);
+}
+{
+  write("mul ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  mul(a, a, b);
+  writeln(a);
+}
+{
+  write("mul ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  mul(b, a, b);
+  writeln(b);
+}
+{
+  write("mul ");
+  var a = new bigint(5);
+  mul(a, a, 6:int);
+  writeln(a);
+}
+{
+  write("mul ");
+  var a = new bigint(5);
+  mul(a, a, 6:uint);
+  writeln(a);
+}
+{
+  write("addmul ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  addmul(a, a, b);
+  writeln(a);
+}
+{
+  write("addmul ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  addmul(b, a, b);
+  writeln(b);
+}
+{
+  write("addmul ");
+  var a = new bigint(5);
+  addmul(a, a, 6:uint);
+  writeln(a);
+}
+{
+  write("submul ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  submul(a, a, b);
+  writeln(a);
+}
+{
+  write("submul ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  submul(b, a, b);
+  writeln(b);
+}
+{
+  write("submul ");
+  var a = new bigint(5);
+  submul(a, a, 6:uint);
+  writeln(a);
+}
+{
+  write("mul_2exp ");
+  var a = new bigint(5);
+  mul_2exp(a, a, 2);
+  writeln(a);
+}
+{
+  write("neg ");
+  var a = new bigint(5);
+  neg(a, a);
+  writeln(a);
+}
+{
+  write("abs ");
+  var a = new bigint(-5);
+  abs(a, a);
+  writeln(a);
+}
+{
+  write("divQ ");
+  var a = new bigint(10);
+  var b = new bigint(2);
+  divQ(a, a, b);
+  writeln(a);
+}
+{
+  write("divQ ");
+  var a = new bigint(10);
+  var b = new bigint(2);
+  divQ(b, a, b);
+  writeln(b);
+}
+
+{
+  write("divR ");
+  var a = new bigint(10);
+  var b = new bigint(2);
+  divR(a, a, b);
+  writeln(a);
+}
+{
+  write("divR ");
+  var a = new bigint(10);
+  var b = new bigint(2);
+  divR(b, a, b);
+  writeln(b);
+}
+{
+  write("divQR ");
+  var a = new bigint(10);
+  var b = new bigint(2);
+  divQR(a, b, a, b);
+  writeln(a, " ", b);
+}
+{
+  write("divQR ");
+  var a = new bigint(10);
+  var b = new bigint(2);
+  divQR(b, a, a, b);
+  writeln(b, " ", a);
+}
+{
+  write("divQ2Exp ");
+  var a = new bigint(3);
+  divQ2Exp(a, a, 1);
+  writeln(a);
+}
+{
+  write("divR2Exp ");
+  var a = new bigint(3);
+  divR2Exp(a, a, 1);
+  writeln(a);
+}
+{
+  write("mod ");
+  var a = new bigint(10);
+  var b = new bigint(3);
+  mod(a, a, b);
+  writeln(a);
+}
+{
+  write("mod ");
+  var a = new bigint(10);
+  var b = new bigint(3);
+  mod(b, a, b);
+  writeln(b);
+}
+{
+  write("mod ");
+  var a = new bigint(10);
+  mod(a, a, 3);
+  writeln(a);
+}
+{
+  write("and ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  and(a, a, b);
+  writeln(a);
+}
+{
+  write("and ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  and(b, a, b);
+  writeln(b);
+}
+{
+  write("ior ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  ior(a, a, b);
+  writeln(a);
+}
+{
+  write("ior ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  ior(b, a, b);
+  writeln(b);
+}
+{
+  write("xor ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  xor(a, a, b);
+  writeln(a);
+}
+{
+  write("xor ");
+  var a = new bigint(5);
+  var b = new bigint(6);
+  xor(b, a, b);
+  writeln(b);
+}
+{
+  write("com ");
+  var a = new bigint(5);
+  com(a, a);
+  writeln(a);
+}

--- a/test/library/standard/BigInteger/resultAsArgument.good
+++ b/test/library/standard/BigInteger/resultAsArgument.good
@@ -1,0 +1,70 @@
+divexact 2
+divexact 2
+powMod 1
+powMod 1
+powMod 1
+powMod 1
+powMod 1
+pow 0
+pow 16
+root 2
+rootrem 2 1
+rootrem 2 1
+sqrt 3
+sqrtrem 3 1
+sqrtrem 3 1
+nextprime 17
+gcd 4
+gcd 4
+gcd 4
+gcd 4 -1 1
+gcd 4 -1 1
+gcd 4 -1 1
+lcm 12
+lcm 12
+lcm 12
+invert 8
+invert 8
+removeFactor 5
+removeFactor 5
+bin 2
+add 11
+add 11
+add 11
+add -1
+sub -1
+sub -1
+sub -1
+sub -11
+sub 1
+mul 30
+mul 30
+mul 30
+mul 30
+addmul 35
+addmul 36
+addmul 35
+submul -25
+submul -24
+submul -25
+mul_2exp 20
+neg -5
+abs 5
+divQ 5
+divQ 5
+divR 0
+divR 0
+divQR 5 0
+divQR 5 0
+divQ2Exp 1
+divR2Exp 1
+mod 1
+mod 1
+mod 1
+and 4
+and 4
+ior 7
+ior 7
+xor 3
+xor 3
+com -6


### PR DESCRIPTION
Several BigInteger functions which have `ref result` and some `const ref arg` can fail when the same argument is passed to both of these, but only when asan is enabled with `CHPL_COMM!=none`. This issue is not caused by the same argument being passed, but seems to be related to an underlying issue within gmp. For example, `mul` is affected in all cases, but `powMod` is not affected at all and `sub` is only affected in certain combinations. 

Example
```
var a = new bigint(5);
var b = new bigint(6);
mul(a, a, b); // a now contains garbage
```

## Summary of changes
- remove `.localize()` for affected functions
- list of affected functions
  ```chapel
  proc pow(ref result: bigint, const ref base: bigint, exp: int)
  proc pow(ref result: bigint, const ref base: bigint, exp: uint) 

  proc nextprime(ref result: bigint, const ref a: bigint)

  proc lcm(ref result: bigint, const ref a: bigint, const ref b: bigint)
  proc lcm(ref result: bigint, const ref a: bigint, b: uint)

  proc invert(ref result: bigint, const ref a: bigint, const ref b: bigint) throws 

  proc add(ref result: bigint, const ref a: bigint, const ref b: bigint) 
  proc add(ref result: bigint, const ref a: bigint, b: int) 
  proc add(ref result: bigint, const ref a: bigint, b: uint) 

  proc sub(ref result: bigint, const ref a: bigint, const ref b: bigint)
  proc sub(ref result:bigint, const ref a: bigint, b: uint)
  proc sub(ref result: bigint, a: int, const ref b: bigint)

  proc mul(ref result: bigint, const ref a: bigint, const ref b: bigint) 
  proc mul(ref result: bigint, const ref a: bigint, b: int)
  proc mul(ref result: bigint, const ref a: bigint, b: uint)

  proc addmul(ref result: bigint, const ref a: bigint, const ref b: bigint)

  proc submul(ref result: bigint, const ref a: bigint, const ref b: bigint)
  proc submul(ref result: bigint, const ref a: bigint, b: uint)

  proc mul_2exp(ref result: bigint, const ref a: bigint, b: integral)

  proc com(ref result: bigint, const ref a: bigint)
  ```  

## New Tests
- new test for functions with the result parameter used as an argument as well

## Testing
- paratest
- paratest with asan
- paratest with gasnet
- paratest with gasnet and asan

---

[Reviewed by @bmcdonald3 ]