### PR TITLE
Make qthreads config-time check of hwloc linking configurable

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -37,6 +37,8 @@ ifneq ($(CHPL_MAKE_HWLOC),none)
     ifdef CHPL_HWLOC_PREFIX
       CHPL_QTHREAD_CFG_OPTIONS += --with-hwloc-symbol-prefix=$(CHPL_HWLOC_PREFIX)hwloc_
     endif
+    # don't bother checking if we can link against hwloc
+    CHPL_QTHREAD_CFG_OPTIONS += --disable-hwloc-configure-checks
   endif
 endif
 

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -30,9 +30,10 @@ as follows:
 
 * We modified the configuration to support the
   --with-hwloc-get-topology-function argument that specifies a function that
-    qthreads should call to get the hwloc topology, and several files to
-    support this behavior including the Makefile to pass this argument to
-    configure, and binders.c and hwloc.c to call the function.
+  qthreads should call to get the hwloc topology, and several files to
+  support this behavior including the Makefile to pass this argument to
+  configure, and binders.c and hwloc.c to call the function.
 
-* Added -lpciaccess to the list of libraries to try when linking against
-  hwloc.
+* We added --disable-hwloc-configure-checks to disable hwloc link checks,
+  and --disable-hwloc-has-distance to specify whether or not hwloc supports
+  distance information.

--- a/third-party/qthread/qthread-src/config/qthread_check_hwloc.m4
+++ b/third-party/qthread/qthread-src/config/qthread_check_hwloc.m4
@@ -34,7 +34,7 @@ AC_DEFUN([QTHREAD_CHECK_HWLOC], [
      LDFLAGS="-L$with_hwloc/lib $LDFLAGS"])
   AC_CHECK_HEADERS([hwloc.h],[],
              [qt_allgoodsofar=no])
-  
+
   # enable or disable distance support if specified
   AS_IF([test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = xyes],
         [AC_MSG_NOTICE([enabling hwloc distance support])
@@ -46,7 +46,7 @@ AC_DEFUN([QTHREAD_CHECK_HWLOC], [
     # do configuration checks
     [AS_IF([test "x$qt_allgoodsofar" = xyes],
             # check if we can link against hwloc
-  	    [AC_SEARCH_LIBS([${with_hwloc_symbol_prefix}topology_init], [hwloc "hwloc -lnuma" "hwloc -lnuma -lpciaccess" "hwloc -lpciaccess"], [],
+  	    [AC_SEARCH_LIBS([${with_hwloc_symbol_prefix}topology_init], [hwloc "hwloc -lnuma"], [],
   		                [qt_allgoodsofar=no])])
     # check if hwloc has distance support if it wasn't specified
     AS_IF([test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = x],
@@ -71,7 +71,7 @@ int main()
     [AC_MSG_NOTICE([skipping hwloc link checks])
     AC_DEFINE([QTHREAD_HAVE_HWLOC],[1],[if I can use the hwloc topology interface])
     # default to having distance if not specified
-    AS_IF([test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = x], 
+    AS_IF([test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = x],
         [AC_MSG_NOTICE([enabling hwloc distance support])
         AC_DEFINE([QTHREAD_HAVE_HWLOC_DISTS],[1],[hwloc has distances])])])
 

--- a/third-party/qthread/qthread-src/config/qthread_check_hwloc.m4
+++ b/third-party/qthread/qthread-src/config/qthread_check_hwloc.m4
@@ -9,15 +9,20 @@ AC_DEFUN([QTHREAD_CHECK_HWLOC], [
   qt_allgoodsofar=yes
   AC_ARG_WITH([hwloc],
               [AS_HELP_STRING([--with-hwloc=[[PATH]]],
-			                  [specify the path to the hwloc library; used for both the library and the include files])])
+			                  [Specify the path to the hwloc library; used for both the library and the include files])])
   AC_ARG_WITH([hwloc-symbol-prefix],
               [AS_HELP_STRING([--with-hwloc-symbol-prefix=[[prefix]]],
-                        [specify prefix for hwloc symbols @<:@default=hwloc_@:>@.])], [],
+                        [Specify prefix for hwloc symbols @<:@default=hwloc_@:>@.])], [],
                         [with_hwloc_symbol_prefix="hwloc_"])
-
   AC_ARG_WITH([hwloc-get-topology-function],
               [AS_HELP_STRING([--with-hwloc-get-topology-function=[[name]]],
-                        [specify function to get hwloc topology (otherwise uses hwloc_topology_init and hwloc_topology_load)])])
+                        [Specify function to get hwloc topology (otherwise uses hwloc_topology_init and hwloc_topology_load)])])
+  AC_ARG_ENABLE([hwloc-configure-checks],
+              [AS_HELP_STRING([--disable-hwloc-configure-checks],
+                        [Disable hwloc link checks during configuration])])
+  AC_ARG_ENABLE([hwloc-has-distance],
+              [AC_HELP_STRING([--disable-hwloc-has-distance],
+                          [Disable hwloc distance support])])
 
   AS_IF([test "x$with_hwloc_get_topology_function" != x],
     AC_DEFINE_UNQUOTED([HWLOC_GET_TOPOLOGY_FUNCTION],[$with_hwloc_get_topology_function],
@@ -26,16 +31,28 @@ AC_DEFUN([QTHREAD_CHECK_HWLOC], [
   hwloc_saved_LDFLAGS="$LDFLAGS"
   AS_IF([test "x$with_hwloc" != x],
         [CPPFLAGS="-I$with_hwloc/include $CPPFLAGS"
-		 LDFLAGS="-L$with_hwloc/lib $LDFLAGS"])
+     LDFLAGS="-L$with_hwloc/lib $LDFLAGS"])
   AC_CHECK_HEADERS([hwloc.h],[],
-  				   [qt_allgoodsofar=no])
-  AS_IF([test "x$qt_allgoodsofar" = xyes],
-	    [AC_SEARCH_LIBS([${with_hwloc_symbol_prefix}topology_init], [hwloc "hwloc -lnuma" "hwloc -lnuma -lpciaccess" "hwloc -lpciaccess"], [],
-		                [qt_allgoodsofar=no])])
-  AS_IF([test "x$qt_allgoodsofar" = xyes],
-        [AC_MSG_CHECKING([for distance support in hwloc])
-		 AC_LINK_IFELSE([AC_LANG_SOURCE([[
-#include <hwloc.h>
+             [qt_allgoodsofar=no])
+  
+  # enable or disable distance support if specified
+  AS_IF([test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = xyes],
+        [AC_MSG_NOTICE([enabling hwloc distance support])
+        AC_DEFINE([QTHREAD_HAVE_HWLOC_DISTS],[1],[hwloc has distances])])
+  AS_IF([test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = xno],
+        [AC_MSG_NOTICE([disabling hwloc distance support])])
+
+  AS_IF([test "x$enable_hwloc_configure_checks" != xno],
+    # do configuration checks
+    [AS_IF([test "x$qt_allgoodsofar" = xyes],
+            # check if we can link against hwloc
+  	    [AC_SEARCH_LIBS([${with_hwloc_symbol_prefix}topology_init], [hwloc "hwloc -lnuma" "hwloc -lnuma -lpciaccess" "hwloc -lpciaccess"], [],
+  		                [qt_allgoodsofar=no])])
+    # check if hwloc has distance support if it wasn't specified
+    AS_IF([test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = x],
+          [AC_MSG_CHECKING([for distance support in hwloc])
+  		 AC_LINK_IFELSE([AC_LANG_SOURCE([[
+  #include <hwloc.h>
 int main()
 {
   hwloc_topology_t topology;
@@ -43,14 +60,21 @@ int main()
   hwloc_topology_load(topology);
   return (NULL == hwloc_get_whole_distance_matrix_by_type(topology, 0));
 }]])],
-        [AC_MSG_RESULT(yes)
-		 AC_DEFINE([QTHREAD_HAVE_HWLOC_DISTS],[1],[Hwloc has distances])],
-		[AC_MSG_RESULT(no)])
-		])
-  AS_IF([test "x$qt_allgoodsofar" = xyes],
-	    [AC_DEFINE([QTHREAD_HAVE_HWLOC],[1],[if I can use the hwloc topology interface])
-		 $1],
-		[CPPFLAGS="$hwloc_saved_CPPFLAGS"
-		 LDFLAGS="$hwloc_saved_LDFLAGS"
-		 $2])
+          [AC_MSG_RESULT(yes)
+  		 AC_DEFINE([QTHREAD_HAVE_HWLOC_DISTS],[1],[hwloc has distances])],
+  		[AC_MSG_RESULT(no)])
+  		])
+    AS_IF([test "x$qt_allgoodsofar" = xyes],
+  	    [AC_DEFINE([QTHREAD_HAVE_HWLOC],[1],[if I can use the hwloc topology interface])
+  		 $1])],
+    # don't do configuration checks
+    [AC_MSG_NOTICE([skipping hwloc link checks])
+    AC_DEFINE([QTHREAD_HAVE_HWLOC],[1],[if I can use the hwloc topology interface])
+    # default to having distance if not specified
+    AS_IF([test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = x], 
+        [AC_MSG_NOTICE([enabling hwloc distance support])
+        AC_DEFINE([QTHREAD_HAVE_HWLOC_DISTS],[1],[hwloc has distances])])])
+
+  CPPFLAGS="$hwloc_saved_CPPFLAGS"
+  LDFLAGS="$hwloc_saved_LDFLAGS"
 ])

--- a/third-party/qthread/qthread-src/configure
+++ b/third-party/qthread/qthread-src/configure
@@ -900,6 +900,8 @@ enable_fastcontext
 with_hwloc
 with_hwloc_symbol_prefix
 with_hwloc_get_topology_function
+enable_hwloc_configure_checks
+enable_hwloc_has_distance
 with_portals4
 '
       ac_precious_vars='build_alias
@@ -1677,6 +1679,10 @@ Optional Features:
                           swapping mechanism that does not make system calls.
                           If you run into bugs, you can disable it on some
                           systems to use the slower libc-provided version.
+  --disable-hwloc-configure-checks
+                          Disable hwloc link checks during configuration
+  --disable-hwloc-has-distance
+                          Disable hwloc distance support
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -1734,12 +1740,12 @@ Optional Packages:
                           (e.g. for cross-compiles)
   --with-bsd-qsort_r      Force the assumption of a BSD-style qsort_r
                           implementation (for cross-compiling)
-  --with-hwloc=[PATH]     specify the path to the hwloc library; used for both
+  --with-hwloc=[PATH]     Specify the path to the hwloc library; used for both
                           the library and the include files
   --with-hwloc-symbol-prefix=[prefix]
-                          specify prefix for hwloc symbols [default=hwloc_].
+                          Specify prefix for hwloc symbols [default=hwloc_].
   --with-hwloc-get-topology-function=[name]
-                          specify function to get hwloc topology (otherwise
+                          Specify function to get hwloc topology (otherwise
                           uses hwloc_topology_init and hwloc_topology_load)
   --with-portals4[=DIR]   Build Portals4 support, with optional install prefix
                           DIR
@@ -26008,10 +26014,19 @@ else
 fi
 
 
-
 # Check whether --with-hwloc-get-topology-function was given.
 if test "${with_hwloc_get_topology_function+set}" = set; then :
   withval=$with_hwloc_get_topology_function;
+fi
+
+  # Check whether --enable-hwloc-configure-checks was given.
+if test "${enable_hwloc_configure_checks+set}" = set; then :
+  enableval=$enable_hwloc_configure_checks;
+fi
+
+  # Check whether --enable-hwloc-has-distance was given.
+if test "${enable_hwloc_has_distance+set}" = set; then :
+  enableval=$enable_hwloc_has_distance;
 fi
 
 
@@ -26026,7 +26041,7 @@ fi
   hwloc_saved_LDFLAGS="$LDFLAGS"
   if test "x$with_hwloc" != x; then :
   CPPFLAGS="-I$with_hwloc/include $CPPFLAGS"
-		 LDFLAGS="-L$with_hwloc/lib $LDFLAGS"
+     LDFLAGS="-L$with_hwloc/lib $LDFLAGS"
 fi
   for ac_header in hwloc.h
 do :
@@ -26042,8 +26057,25 @@ fi
 
 done
 
-  if test "x$qt_allgoodsofar" = xyes; then :
-  as_ac_Search=`$as_echo "ac_cv_search_${with_hwloc_symbol_prefix}topology_init" | $as_tr_sh`
+
+  # enable or disable distance support if specified
+  if test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = xyes; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: enabling hwloc distance support" >&5
+$as_echo "$as_me: enabling hwloc distance support" >&6;}
+
+$as_echo "#define QTHREAD_HAVE_HWLOC_DISTS 1" >>confdefs.h
+
+fi
+  if test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = xno; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: disabling hwloc distance support" >&5
+$as_echo "$as_me: disabling hwloc distance support" >&6;}
+fi
+
+  if test "x$enable_hwloc_configure_checks" != xno; then :
+  # do configuration checks
+    if test "x$qt_allgoodsofar" = xyes; then :
+  # check if we can link against hwloc
+  	    as_ac_Search=`$as_echo "ac_cv_search_${with_hwloc_symbol_prefix}topology_init" | $as_tr_sh`
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing ${with_hwloc_symbol_prefix}topology_init" >&5
 $as_echo_n "checking for library containing ${with_hwloc_symbol_prefix}topology_init... " >&6; }
 if eval \${$as_ac_Search+:} false; then :
@@ -26104,13 +26136,14 @@ else
 fi
 
 fi
-  if test "x$qt_allgoodsofar" = xyes; then :
+    # check if hwloc has distance support if it wasn't specified
+    if test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = x; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for distance support in hwloc" >&5
 $as_echo_n "checking for distance support in hwloc... " >&6; }
-		 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+  		 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <hwloc.h>
+  #include <hwloc.h>
 int main()
 {
   hwloc_topology_t topology;
@@ -26133,20 +26166,33 @@ rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
-  if test "x$qt_allgoodsofar" = xyes; then :
+    if test "x$qt_allgoodsofar" = xyes; then :
 
 $as_echo "#define QTHREAD_HAVE_HWLOC 1" >>confdefs.h
 
-		 if test "x$qthread_topo" != xhwloc -a "x$qthread_topo" != xhwloc_via_chapel -a "x$qthread_topo" != xhwloc_v2 -a "x$qthread_topo" != xbinders; then :
+  		 if test "x$qthread_topo" != xhwloc -a "x$qthread_topo" != xhwloc_via_chapel -a "x$qthread_topo" != xhwloc_v2 -a "x$qthread_topo" != xbinders; then :
   qthread_topo=hwloc
 fi
+fi
 else
+  # don't do configuration checks
+    { $as_echo "$as_me:${as_lineno-$LINENO}: skipping hwloc link checks" >&5
+$as_echo "$as_me: skipping hwloc link checks" >&6;}
+
+$as_echo "#define QTHREAD_HAVE_HWLOC 1" >>confdefs.h
+
+    # default to having distance if not specified
+    if test "x$qt_allgoodsofar" = xyes && test "x$enable_hwloc_has_distance" = x; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: enabling hwloc distance support" >&5
+$as_echo "$as_me: enabling hwloc distance support" >&6;}
+
+$as_echo "#define QTHREAD_HAVE_HWLOC_DISTS 1" >>confdefs.h
+
+fi
+fi
+
   CPPFLAGS="$hwloc_saved_CPPFLAGS"
-		 LDFLAGS="$hwloc_saved_LDFLAGS"
-		 if test "x$qthread_topo" != xno; then :
-  as_fn_error $? "Specified topology library ($qthread_topo) does not work." "$LINENO" 5
-fi
-fi
+  LDFLAGS="$hwloc_saved_LDFLAGS"
 
 fi
        # Second, check for the ones that will give me distance information

--- a/third-party/qthread/qthread-src/configure
+++ b/third-party/qthread/qthread-src/configure
@@ -26100,7 +26100,7 @@ return ${with_hwloc_symbol_prefix}topology_init ();
   return 0;
 }
 _ACEOF
-for ac_lib in '' hwloc "hwloc -lnuma" "hwloc -lnuma -lpciaccess" "hwloc -lpciaccess"; do
+for ac_lib in '' hwloc "hwloc -lnuma"; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else

--- a/third-party/qthread/qthread-src/include/config.h.in
+++ b/third-party/qthread/qthread-src/include/config.h.in
@@ -494,7 +494,7 @@
 /* if I can use the hwloc topology interface */
 #undef QTHREAD_HAVE_HWLOC
 
-/* Hwloc has distances */
+/* hwloc has distances */
 #undef QTHREAD_HAVE_HWLOC_DISTS
 
 /* if the machine has a Solaris-style liblgrp topology interface */


### PR DESCRIPTION
`Qthreads` configuration contained a static list of sets of potential link-time arguments needed to link against `hwloc`. The `configure` script would iterate through this list until a set of arguments was successful. This was problematic because it required keeping the list up-to-date with respect to `hwloc` changes. This commit makes the check configurable as it is only beneficial to Chapel developers as any problems with linking against `hwloc` will be found when compiling an app. It's not worth the cost of maintaining the list nor the complexity of adding support for `pkg-config`.  The `--disable-hwloc-configure-checks` argument to `configure` turns off the `hwloc` link check. The link check also tests whether or not `hwloc` supports distance information. If the link check is disabled, `configure` assumes that `hwloc` supports distance information. This may be changed by passing `--disable-hwloc-has-distance` to `configure`.

Resolves https://github.com/Cray/chapel-private/issues/4387 and closes https://github.com/Cray/chapel-private/issues/4595.