### PR TITLE
Fix a test with a missing .good

### DIFF
--- a/test/gpu/native/assertOnFailToGpuize.4.good
+++ b/test/gpu/native/assertOnFailToGpuize.4.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly


### PR DESCRIPTION
The 4th .good file for this test didn't get checked in. Add it now.