### PR TITLE
Fix `readstring` deprecation in shootout benchmark

### DIFF
--- a/test/release/examples/benchmarks/shootout/regexdna.chpl
+++ b/test/release/examples/benchmarks/shootout/regexdna.chpl
@@ -28,7 +28,7 @@ proc main(args: [] string) {
   ];
 
   var data: string;
-  stdin.readstring(data); // read in the entire file
+  stdin.readAll(data); // read in the entire file
   const initLen = data.size;
 
   // remove newlines

--- a/test/release/examples/benchmarks/shootout/regexdna.good
+++ b/test/release/examples/benchmarks/shootout/regexdna.good
@@ -1,5 +1,3 @@
-regexdna.chpl:11: In function 'main':
-regexdna.chpl:31: warning: 'readstring' is deprecated; please use 'readString' instead
 agggtaaa|tttaccct 0
 [cgt]gggtaaa|tttaccc[acg] 3
 a[act]ggtaaa|tttacc[agt]t 9


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/21201 deprecated `readstring` in favor of `readString` and/or `readAll(string)`, but left the deprecated symbol in `test/release/examples/benchmarks/shootout/regexdna.chpl`. This PR corrects that error.