### PR TITLE
Add a use of the Math module to these tests

### DIFF
--- a/test/library/packages/LinearAlgebra/correctness/inv-test.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/inv-test.chpl
@@ -1,4 +1,5 @@
 use LinearAlgebra;
+use Math;
 
 config const n=10;
 config const thresh=1.0e-10;

--- a/test/library/packages/LinearAlgebra/correctness/testEigen.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/testEigen.chpl
@@ -1,4 +1,4 @@
-use LinearAlgebra, Random;
+use LinearAlgebra, Random, Math;
 
 config const epsilon = 0.0000000001;
 


### PR DESCRIPTION
inv-test.chpl relies on pi while testEigen.chpl relies on sqrt_2 and recipr_sqrt_2, all of which are no longer included by default.

Double checked that the solution worked