### PR TITLE
Fix auto-use modules being preferred to used modules

### DIFF
--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -455,7 +455,8 @@ struct LookupHelper {
   bool doLookupInAutoModules(const Scope* scope,
                              UniqueString name,
                              bool onlyInnermost,
-                             bool skipPrivateVisibilities);
+                             bool skipPrivateVisibilities,
+                             bool onlyMethodsFields);
 
   bool doLookupInToplevelModules(const Scope* scope, UniqueString name);
 
@@ -643,7 +644,8 @@ bool LookupHelper::doLookupInImportsAndUses(
 bool LookupHelper::doLookupInAutoModules(const Scope* scope,
                                          UniqueString name,
                                          bool onlyInnermost,
-                                         bool skipPrivateVisibilities) {
+                                         bool skipPrivateVisibilities,
+                                         bool onlyMethodsFields) {
   bool trace = (traceCurPath != nullptr && traceResult != nullptr);
   bool found = false;
 
@@ -656,6 +658,10 @@ bool LookupHelper::doLookupInAutoModules(const Scope* scope,
 
       if (onlyInnermost) {
         newConfig |= LOOKUP_INNERMOST;
+      }
+
+      if (onlyMethodsFields) {
+        newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
       }
 
       if (trace) {
@@ -968,7 +974,9 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
 
     // treat the auto-used modules as if they were 'private use'd
     got |= doLookupInAutoModules(scope, name,
-                                 onlyInnermost, skipPrivateVisibilities);
+                                 onlyInnermost,
+                                 skipPrivateVisibilities,
+                                 onlyMethodsFields);
     if (onlyInnermost && got) return true;
   }
 


### PR DESCRIPTION
This fixes a bug in Dyno in which despite the presence of `use Math`, `pi` would resolve to `AutoMath.pi` instead of `Math.pi`, but only from methods. This was caused by the fact that, when searching receiver scopes, Dyno sets the lookup configuration to only consider methods and fields. However, this configuration option is not forwarded to `doLookupAutoModules`. Thus, Dyno would first consider `use Math` via a method receiver, and rule it out due to `onlyMethodsFields`. But then, it would consider `private use AutoMath`, and not rule out the `pi` decalred there, thereby finding the wrong `pi`. This bug surfaced because `AutoMath`'s `pi` is deprecated, whereas `Math`'s is not.