### PR TITLE
Add another workaround for LLVM_NODISCARD for intel compilers

### DIFF
--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -128,7 +128,7 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 #  174 : warns about expressions that have no effect
 #  177 : warns about unused variable declarations
 
-WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599 -diag-warning 3924
+WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599 -diag-warning 1292,3924
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177


### PR DESCRIPTION
This is a follow-on to #20426 that changes another warning to a diagnostic around LLVM_NODISCARD for the Intel Classic Compiler 2023.1.0 release.  Without it, the GASNet team was seeing:

```
/path/to/chpl-home/third-party/llvm/install/support-only-linux64-x86_64/include/llvm/ADT/StringRef.h(781): error #1292: unknown attribute "clang::warn_unused_result"
      LLVM_NODISCARD
      ^
```

in a developer build (with WARNINGS=1 on).  Note that this is a subtle shift from the previous warning that didn't seem to recognize the namespace rather than the attribute itself.

I have not tested this, but the GASNet team did test the equivalent (made the same change to their sources) and saw that it let the build go through, though in a noisy manner due to the diagnostic messages.

I did not do any research to see whether it was surprising / unexpected that we would get this warning, nor much thinking about the implications on using the attribute apart from posing the question on https://github.com/chapel-lang/chapel/pull/20426#issuecomment-1496474984.