### PR TITLE
Adjust FCF test to call tests manually instead of walking array

### DIFF
--- a/test/functions/fcf/Motivators.chpl
+++ b/test/functions/fcf/Motivators.chpl
@@ -165,6 +165,8 @@ proc test9() {
 }
 
 proc main() {
+  // TODO: Can trigger hard to reproduce bug where FCF name does not print.
+  /*
   const tests = [test0, test1, test2a, test2b, test3, test4, test5, test6,
                  test7, test8, test9];
   type T = proc(): void;
@@ -173,5 +175,29 @@ proc main() {
     writeln("--- ", test:string, " ---");
     test();
   }
+  */
+
+  writeln("--- ", "test0()", " ---");
+  test0();
+  writeln("--- ", "test1()", " ---");
+  test1();
+  writeln("--- ", "test2a()", " ---");
+  test2a();
+  writeln("--- ", "test2b()", " ---");
+  test2b();
+  writeln("--- ", "test3()", " ---");
+  test3();
+  writeln("--- ", "test4()", " ---");
+  test4();
+  writeln("--- ", "test5()", " ---");
+  test5();
+  writeln("--- ", "test6()", " ---");
+  test6();
+  writeln("--- ", "test7()", " ---");
+  test7();
+  writeln("--- ", "test8()", " ---");
+  test8();
+  writeln("--- ", "test9()", " ---");
+  test9();
 }
 


### PR DESCRIPTION
Adjust a FCF test to invoke each test manually instead of walking
over an array of tests in a loop. This should fix a sporadic bug
where test names would not print correctly.

The test `test/functions/fcf/Motivators.chpl` has been failing off
and on with a fairly consistent failure mode. All the tests in the
module are stored in an array (an array of FCFs), and then that
array is iterated over and the tests run sequentually. Before each
test is run, its name is printed out.

The bug is that sometimes the test name will not display - nothing
appears when something like "test2a" should be showing. I am not
sure what is causing this bug, but it is flakey and hard for me to
pin down. I was able to see the bug locally on `df14e4`, but after
making some environment changes, it seems to have vanished.

Adjust this test until I can pin down what is going on.