### PR TITLE
Fix typos

### DIFF
--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -448,7 +448,7 @@ class FunctionType final : public Type {
   buildUserFacingTypeString(Kind kind,
                             const std::vector<Formal>& formals,
                             RetTag returnIntent,
-                            Type* returntType,
+                            Type* returnType,
                             bool throws);
 
   FunctionType(Kind kind, std::vector<Formal> formals,

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1039,7 +1039,7 @@ static void insertUnrefForArrayOrTupleReturn(FnSymbol* fn) {
   Symbol* ret = fn->getReturnSymbol();
 
   // surely returning neither tuple nor array, so return
-  // TODO: the addition of this early return resulted in a subtantial reduction
+  // TODO: the addition of this early return resulted in a substantial reduction
   // of compilation time in some cases. We should investigate how to speed up
   // the remainder of this function.
   if (ret->type != dtUnknown                   &&

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -929,7 +929,7 @@ with a range that is identical except it is given an alignment
 in such a way that that the intersection of the two ranges'
 represented sequences is non-empty, if possible.
 How this substitute alignment is chosen when multiple possibilities
-are availble is implementation-dependent.
+are available is implementation-dependent.
 
 If the resulting sequence cannot be expressed as a range with the
 original ``idxType``, the slice expression evaluates to the empty

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -294,7 +294,7 @@ improvements in the future.
   supported).
 
 * Associative arrays cannot be used on GPU sublocales with
-  ``CHPL_GPU_MEM_STRAGETY=array_on_device``.
+  ``CHPL_GPU_MEM_STRATEGY=array_on_device``.
 
 * If using CUDA 10, single thread per locale can be used. i.e., you have to set
   ``CHPL_RT_NUM_THREADS_PER_LOCALE=1``.

--- a/frontend/include/chpl/framework/ErrorWriter.h
+++ b/frontend/include/chpl/framework/ErrorWriter.h
@@ -375,7 +375,7 @@ class ErrorWriterBase {
     Doesn't underline, but also doesn't print the whole thing. This
     is important, for instance, in the case that a record declaration
     is being printed. We don't want to dump all the fields / methods
-    as part of the errror.
+    as part of the error.
    */
   template <typename LocPlace>
   void codeForLocation(const LocPlace& place) {

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -83,7 +83,7 @@ class IdAndFlags {
       case uast::Decl::PRIVATE:
         flags |= NOT_PUBLIC;
         break;
-      // no defaut for compilation error if more are added
+      // no default for compilation error if more are added
     }
     if (isMethodOrField) {
       flags |= METHOD_FIELD;

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -80,7 +80,7 @@ static const char* allowedItems(resolution::VisibilityStmtKind kind) {
 // end with a space.
 //
 // 'encounteredAutoModule' is set to 'false' at the start of this function
-// but will be set to 'true' if the symbol came from an automaticly use'd
+// but will be set to 'true' if the symbol came from an automatically use'd
 // module
 //
 // 'from' is set to 'name' at the start of this function and will be
@@ -717,8 +717,8 @@ static bool firstIdFromDecls(
     const auto& t = trace[i];
     if (t.visibleThrough.size() == 0) {
       // TODO: find the first non-function ID?
-      // To do that, would use flags in BorrowedIdsWithIter
-      // to filter Idvs.
+      // To do that, would use flags in BorrowedIdsWithName
+      // to filter Ids.
       result = matches[i].firstId();
       return true;
     }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -422,7 +422,7 @@ const Scope* scopeForId(Context* context, ID id) {
 using VisibilityTraceElt = ResultVisibilityTrace::VisibilityTraceElt;
 
 // a struct to encapsulate arguments to doLookupIn...
-// so that the calls and function signatures do not get too unweildy.
+// so that the calls and function signatures do not get too unwieldy.
 struct LookupHelper {
   Context* context;
   const ResolvedVisibilityScope* resolving;

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -560,7 +560,7 @@ bool LookupHelper::doLookupInImportsAndUses(
         if (!allowPrivateAccess) {
           newConfig |= LOOKUP_SKIP_PRIVATE_VIS;
         } else {
-          // TODO: this disallowes nested modules from working  with
+          // TODO: this disallows nested modules from working  with
           // a private use/import in a parent module. But, that is
           // subject to discussion in issue #21723.
           // See the history of this comment for an implementation that
@@ -873,7 +873,7 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
     curFilter |= IdAndFlags::METHOD_FIELD;
   }
   // Note: curFilter can only represent combinations of positive flags;
-  // if it extended, it might no longer be possible to rerepresent
+  // if it extended, it might no longer be possible to represent
   // the combinedFilter below as a single bitset.
   // Also note: setting excludeFilter in some way other than the
   // handling below with checkedScopes will require other adjustments.
@@ -2300,7 +2300,7 @@ std::vector<ID> findUsedImportedModules(Context* context,
 static const std::map<ID, ID>&
 findAllModulesUsedImportedInTreeQuery(Context* context, ID id);
 
-// Pre-order depth first traveral of the entire module to gather use/import.
+// Pre-order depth first traversal of the entire module to gather use/import.
 // Key is ID of use/import, value is target module ID. We use a map here
 // because the C++ standard map maintains ordering, which should sort all
 // the use/import by their lexical order (via ID ordering).

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -64,7 +64,7 @@ module ChapelBase {
 
   enum iterKind {leader, follower, standalone};
 
-  // This is a compatability flag to maintain old behavior for applications
+  // This is a compatibility flag to maintain old behavior for applications
   // that rely on it (e.g., Arkouda). The tests for new features will run
   // with this set to FALSE. At a certain point the old behavior will be
   // deprecated, and this flag will be removed.

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -619,7 +619,7 @@ module ChapelRange {
 
   // More cases of hasPositiveStride() will become params
   // once we switch to an enum strideKind.
-  // Need design review to make this publically available.
+  // Need design review to make this publicly available.
   /* Returns whether this range's stride is positive,
      as a `param` when possible. */
  inline proc range.chpl_hasPositiveStride() where stridable do return _stride>0;

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -227,7 +227,7 @@ module ChapelSyncvar {
 
       * full: return a copy of the stored value.
       * empty: return either a new default-initialized value of the stored type
-        or, the last value stored (implementation dependant).
+        or, the last value stored (implementation dependent).
 
     :returns: The value of the ``sync`` variable.
   */
@@ -882,7 +882,7 @@ module ChapelSyncvar {
 
       * full: return a copy of the stored value.
       * empty: return either a new default-initialized value of the stored type
-        or, the last value stored (implementation dependant).
+        or, the last value stored (implementation dependent).
 
     :returns: The value of the ``single`` variable.
   */

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2398,7 +2398,7 @@ module BigInteger {
     if _local {
       mpz_gcdext(result.mpz, s.mpz, t.mpz, a.mpz, b.mpz);
     } else if result.localeId == chpl_nodeID {
-      // TODO: need to revist this in relation to Cray/chapel-private#4628
+      // TODO: need to revisit this in relation to Cray/chapel-private#4628
       var s_ : bigint;
       var t_ : bigint;
       const a_ = a.localize();
@@ -2765,7 +2765,7 @@ module BigInteger {
     if _local {
       mpz_fib2_ui(result.mpz, fnsub1.mpz, n_);
     } else if result.localeId == chpl_nodeID {
-        // TODO: need to revist this in relation to Cray/chapel-private#4628
+        // TODO: need to revisit this in relation to Cray/chapel-private#4628
         var fnsub1_ : bigint;
         mpz_fib2_ui(result.mpz, fnsub1_.mpz, n_);
         fnsub1 = fnsub1_;
@@ -2811,7 +2811,7 @@ module BigInteger {
     if _local {
       mpz_lucnum2_ui(result.mpz, fnsub1.mpz, n_);
     } else if result.localeId == chpl_nodeID {
-      // TODO: need to revist this in relation to Cray/chapel-private#4628
+      // TODO: need to revisit this in relation to Cray/chapel-private#4628
       var fnsub1_ : bigint;
       mpz_lucnum2_ui(result.mpz, fnsub1_.mpz, n_);
       fnsub1 = fnsub1_;
@@ -3888,7 +3888,7 @@ module BigInteger {
     if _local {
       helper(result, remain, numer, denom, rounding);
     } else if result.localeId == chpl_nodeID {
-      // TODO: need to revist this in relation to Cray/chapel-private#4628
+      // TODO: need to revisit this in relation to Cray/chapel-private#4628
       var   remain_ : bigint;
       const numer_ = numer.localize();
       const denom_ = denom.localize();

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1589,7 +1589,7 @@ record ioHintSet {
   /* Suggests that 'mmap' should not be used to access the file contents.
   Instead, pread/pwrite are used.
   */
-  @deprecated(notes="`ioHintSet.noMmap` is deprecated; please use `ioHintset.mmap(false)` instead")
+  @deprecated(notes="`ioHintSet.noMmap` is deprecated; please use `ioHintSet.mmap(false)` instead")
   proc type noMmap { return new ioHintSet(IOHINTS_NOMMAP); }
 
   pragma "no doc"
@@ -5951,7 +5951,7 @@ inline proc fileReader._readInner(ref args ...?k):void throws {
 
 /*
    Read one or more values from a ``fileReader``. The ``fileReader``'s lock
-   will be held while reading the values — this protects agianst interleaved
+   will be held while reading the values — this protects against interleaved
    reads.
 
    :arg args: a series of variables to read into. Basic types are handled
@@ -5960,7 +5960,7 @@ inline proc fileReader._readInner(ref args ...?k):void throws {
               in :ref:`readThis-writeThis`.
    :returns: `true` if the read succeeded, and `false` on end of file.
 
-   :throws UnexpectedEofError: Thrown if an EOF occured while reading an item.
+   :throws UnexpectedEofError: Thrown if an EOF occurred while reading an item.
    :throws SystemError: Thrown if data could not be read from the ``fileReader``
                         for :ref:`another reason<io-general-sys-error>`.
  */
@@ -8259,7 +8259,7 @@ proc fileReader.readln(type t ...?numTypes) throws where numTypes > 1 {
 
 /*
    Read values of passed types and return a tuple containing the read values.
-   The ``fileReader``'s lock will be held while reading — this protects agianst
+   The ``fileReader``'s lock will be held while reading — this protects against
    interleaved reads.
 
    :arg t: more than one type to read

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1657,7 +1657,7 @@ proc fileReader.readTo(separator: regex(bytes), ref b: bytes, maxSize=-1): bool 
   return b.size > 0;
 }
 
-/* helper for: readThrough(regex), readTo(regex) (and eventually andvanceTo, advanceThrough)
+/* helper for: readThrough(regex), readTo(regex) (and eventually advanceTo, advanceThrough)
 
   looks for a regex match in the next 'maxBytes' bytes in the channel
 

--- a/runtime/src/gpu/rocm/gpu-rocm.c
+++ b/runtime/src/gpu/rocm/gpu-rocm.c
@@ -90,7 +90,7 @@ static void chpl_gpu_ensure_context() {
   ROCM_CALL(hipSetDevice(chpl_task_getRequestedSubloc()));
 
   // The below is a direct "hipification" of the CUDA runtime
-  // but it's using depercated APIs
+  // but it's using deprecated APIs
   /*if (!chpl_gpu_has_context()) {
     ROCM_CALL(hipCtxPushCurrent(next_context));
   }

--- a/test/deprecated/IO/mmapParenless.good
+++ b/test/deprecated/IO/mmapParenless.good
@@ -1,2 +1,2 @@
-mmapParenless.chpl:3: warning: `ioHintSet.noMmap` is deprecated; please use `ioHintset.mmap(false)` instead
+mmapParenless.chpl:3: warning: `ioHintSet.noMmap` is deprecated; please use `ioHintSet.mmap(false)` instead
 true


### PR DESCRIPTION
Fix typos in

type.h, resolveFunction.cpp,
spec/ranges.rst, technotes/gpu.rst
ErrorWriter.h, scope-types.h
resolution-error-classes-list.cpp
scope-queries.cpp,
ChapelBase.chpl, ChapelSyncvar.chpl
Regex.chpl, IO.chpl
gpu-rocm.c
