### PR TITLE
Lock in error message for generically managed nilable fields

### DIFF
--- a/test/classes/jade/error-messages/generic-field-nil.chpl
+++ b/test/classes/jade/error-messages/generic-field-nil.chpl
@@ -1,0 +1,13 @@
+config param explicitNilable = false;
+if explicitNilable {
+  class A {
+    var x: A? = nil;
+  }
+  var a: owned A = new A();
+}
+else {
+  class A {
+    var x: A = nil;
+  }
+  var a: owned A = new A();
+}

--- a/test/classes/jade/error-messages/generic-field-nil.compopts
+++ b/test/classes/jade/error-messages/generic-field-nil.compopts
@@ -1,0 +1,2 @@
+-sexplicitNilable=true # generic-field-nil.good
+-sexplicitNilable=false # generic-field-nil.good

--- a/test/classes/jade/error-messages/generic-field-nil.good
+++ b/test/classes/jade/error-messages/generic-field-nil.good
@@ -1,0 +1,1 @@
+generic-field-nil.chpl:n: error: could not coerce a value of type 'nil' to type '_formal_type'

--- a/test/classes/jade/error-messages/generic-field-nil.prediff
+++ b/test/classes/jade/error-messages/generic-field-nil.prediff
@@ -1,0 +1,9 @@
+#!/bin/sh 
+
+# filter out line numbers
+TESTNAME=$1
+OUTFILE=$2
+TMPFILE=$OUTFILE.prediff.tmp
+sed -e 's/\.chpl:[0-9]*:/\.chpl:n:/' < $OUTFILE > $TMPFILE
+cat $TMPFILE > $OUTFILE
+rm $TMPFILE


### PR DESCRIPTION
Adds a test to lock in an error message for a generically managed nilable field.

Error message was added in #19709, merging this PR should allow closing of #19613 and #18923

## Summary of changes
- NA

## New tests
- `test/classes/jade/error-messages/generic-field-nil.chpl`

## Testing 
- local testing

---

Note: the error message is not the best, but is better than the previous issues of internal asserts and set faults. Issue discussing this captured here #22184

[Reviewed by @jeremiah-corrado]

closes #19613
closes #18923