### PR TITLE
Provide a std::hash implementation for PrimitiveTag

### DIFF
--- a/frontend/include/chpl/uast/PrimOp.h
+++ b/frontend/include/chpl/uast/PrimOp.h
@@ -54,4 +54,12 @@ DECLARE_SERDE_ENUM(uast::PrimitiveTag, uint16_t);
 
 } // end namespace chpl
 
+namespace std {
+  template <> struct hash<chpl::uast::PrimitiveTag> {
+    size_t operator()(const chpl::uast::PrimitiveTag& tag) const {
+      return (size_t) tag;
+    }
+  };
+} // end namespace std
+
 #endif


### PR DESCRIPTION
It turns out not all compilers provide a default `std::hash` implementation for enums. This caused failures in the build after I merged #22022, where I was using an `unordered_map` with enum keys. This PR fixes the build failures by adding a template specialization for `std::hash` and the specific enum that was used as a map key.

Reviewed by @benharsh -- thanks!

## Testing
- [x] Compiled using `cron` scripts on `chapcs`, which didn't work before.