### PR TITLE
Generate GPU unstability warning in the compiler, reword the message

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1636,9 +1636,12 @@ static void setPrintCppLineno() {
 }
 
 static void setGPUFlags() {
-  bool isGpuCodegen = usingGpuLocaleModel();
-
-  if(isGpuCodegen) {
+  if(usingGpuLocaleModel()) {
+    if (fWarnUnstable) {
+      USR_WARN("GPU support is under active development. As such, the"
+               " interface is unstable and expected to change in the"
+               " forthcoming releases.");
+    }
     if (!fNoChecks) {
       USR_WARN("The prototype GPU support implies --no-checks."
                " This may impact debuggability. To suppress this warning,"

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -27,7 +27,7 @@
 // backward compatible with the architecture implicitly provided by
 // releases 1.6 and preceding.
 //
-@unstable("GPU support is a prototype in this version of Chapel. As such, the interface is unstable and expected to change in the forthcoming releases.")
+@unstable("The GPU locale interface is unstable and expected to change in the forthcoming releases")
 module LocaleModel {
 
   public use LocaleModelHelpGPU;

--- a/test/gpu/native/jacobi/flags-warn-unstable-internal.good
+++ b/test/gpu/native/jacobi/flags-warn-unstable-internal.good
@@ -1,0 +1,8 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+$CHPL_HOME/modules/internal/ChapelStandard.chpl:53: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:29: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
+$CHPL_HOME/modules/internal/ChapelBase.chpl:57: warning: chpl_unstableInternalSymbolForTesting is unstable
+on GPU:
+1.0 1.20906 2.19525 2.9034 3.5552 4.01125 4.21599 4.10448 3.62297 2.85669 1.60226 1.0
+on CPU:
+1.0 1.20906 2.19525 2.9034 3.5552 4.01125 4.21599 4.10448 3.62297 2.85669 1.60226 1.0

--- a/test/gpu/native/jacobi/flags-warn-unstable.good
+++ b/test/gpu/native/jacobi/flags-warn-unstable.good
@@ -1,7 +1,7 @@
+warning: GPU support is under active development. As such, the interface is unstable and expected to change in the forthcoming releases.
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-$CHPL_HOME/modules/internal/ChapelStandard.chpl:53: warning: GPU support is a prototype in this version of Chapel. As such, the interface is unstable and expected to change in the forthcoming releases.
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:29: warning: GPU support is a prototype in this version of Chapel. As such, the interface is unstable and expected to change in the forthcoming releases.
 flags.chpl:1: warning: The GpuDiagnostics module is unstable and its interface is subject to change in the future.
+flags.chpl:3: warning: The GPU module is unstable and its interface is subject to change in the future.
 on GPU:
 1.0 1.20906 2.19525 2.9034 3.5552 4.01125 4.21599 4.10448 3.62297 2.85669 1.60226 1.0
 on CPU:

--- a/test/gpu/native/jacobi/flags.compopts
+++ b/test/gpu/native/jacobi/flags.compopts
@@ -1,2 +1,3 @@
---no-checks      # flags-no-checks.good
---warn-unstable  # flags-warn-unstable.good
+--no-checks               # flags-no-checks.good
+--warn-unstable           # flags-warn-unstable.good
+--warn-unstable-internal  # flags-warn-unstable-internal.good

--- a/test/gpu/native/jacobi/jacobi.chpl
+++ b/test/gpu/native/jacobi/jacobi.chpl
@@ -1,5 +1,6 @@
 use GpuDiagnostics;
 use CTypes;
+use GPU; // just to check the unstability warning
 
 config const nSteps = 10;
 config const n = 10;


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/22033 changed how unstable warnings are generated and broke a test for `--warn-unstable`.

We were generating the unstability message through the GPU locale model, which is now suppressed without `--warn-unstable-internal`. This PR moves the message to the compiler, adjust the relevant test and rewords the message.

Test:
- [x] gpu/native/jacobi/flags
- [x] gpu/native/streamPrototype