### PR TITLE
fix the branch date

### DIFF
--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -149,7 +149,7 @@ var branchInfo = [
                     "revision" : -1},
                   { "release": "1.30.0", 
                     "releaseDate": "2023-03-23",
-                    "branchDate" : "2022-03-17",
+                    "branchDate" : "2023-03-17",
                     "revision" : -1}
                     
                   ];


### PR DESCRIPTION
The perf graph has missing partition for 1.30 release.
Fix: Fix the branch date 