### PR TITLE
Fix some 32-bit failures related to `readBinary(arr)`

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -7963,7 +7963,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
           isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t))
 {
   var e : errorCode = 0,
-      numRead = 0;
+      numRead : c_ssize_t = 0;
 
   on this._home {
     try this.lock(); defer { this.unlock(); }
@@ -7997,7 +7997,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
     }
   }
 
-  return numRead;
+  return numRead : int;
 }
 
 /*


### PR DESCRIPTION
A few IO tests failed in 32-bit testing because of a missing cast to `c_ssize_t` in `readBinary`. This PR corrects those failures.

- [X] re-ran failing tests on 32-bit system
- [x] full paratest