### PR TITLE
Fix linkage for C files with the GPU locale model

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2572,9 +2572,7 @@ void runClang(const char* just_parse_filename) {
 
     // Need to select CUDA/AMD mode in embedded clang to
     // activate the GPU target
-    //generateClangGpuLangArgs(clangOtherArgs);
     splitStringWhitespace(generateClangGpuLangArgs(), clangOtherArgs);
-    //clangOtherArgs.push_back(generateClangGpuLangArgs());
 
     std::string gpuArch = std::string("--offload-arch=") + CHPL_GPU_ARCH;
     clangOtherArgs.push_back(gpuArch);

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -303,6 +303,14 @@ improvements in the future.
   <../usingchapel/tasks.html#chpl-tasks-fifo>`_ is the
   default in only Cygwin and NetBSD.
 
+Using C Interoperability
+~~~~~~~~~~~~~~~~~~~~~~~~
+C interoperability on the host side is supported. However, GPU programming
+implies C++ linkage. To handle that, the Chapel compiler compiles the ``.c``
+files passed via the command line and/or ``require`` statements with ``clang -x
+[cuda|hip]``. This implies that some C features may fail to compile if they are
+not supported by the above ``clang`` compilation.
+
 Further Information
 -------------------
 * Please refer to issues with `GPU Support label

--- a/test/gpu/native/extern/extern_c_test.c
+++ b/test/gpu/native/extern/extern_c_test.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "./extern_c_test.h"
+
+void hello_world()
+{
+    printf("hello world from C");
+}

--- a/test/gpu/native/extern/extern_c_test.h
+++ b/test/gpu/native/extern/extern_c_test.h
@@ -1,0 +1,6 @@
+#ifndef __EXTERN_C_TEST_H_
+#define __EXTERN_C_TEST_H_
+
+void hello_world(void);
+
+#endif

--- a/test/gpu/native/extern/main.chpl
+++ b/test/gpu/native/extern/main.chpl
@@ -1,0 +1,18 @@
+module extern_c
+{
+  require "extern_c_test.c", "extern_c_test.h";
+  extern proc hello_world(): void;
+}
+
+module main
+{
+  use extern_c;
+
+  proc main(): int
+  {
+    writeln("hello world from chpl");
+    hello_world();
+
+    return 0;
+  }
+}

--- a/test/gpu/native/extern/main.good
+++ b/test/gpu/native/extern/main.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+hello world from chpl
+hello world from C


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/21905.

This PR changes how the Chapel compiler compiles `.c` files that are passed through the command line or the `require statement` with `CHPL_LOCALE_MODEL=gpu`. The main motivation for this change is that when you are compiling for GPU you have to use C++ linkage even if your files are `.c`.

I was hoping that this can also address https://github.com/chapel-lang/chapel/issues/21906, but that doesn't seem to be the case.

Test:
- [x] gpu/native with NVIDIA
- [x] gpu/native with AMD