### PR TITLE
Fix `Reflection.getField` on wrapper classes

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -979,7 +979,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
 
   case PRIM_FIELD_BY_NUM: {
     // if call->get(1) is a reference type, dereference it
-    Type*          t          = canonicalDecoratedClassType(call->get(1)->getValType());
+    Type*          t          = canonicalClassType(call->get(1)->getValType());
     AggregateType* classType  = toAggregateType(t);
 
     VarSymbol*     var        = toVarSymbol(toSymExpr(call->get(2))->symbol());
@@ -1005,9 +1005,25 @@ static Expr* preFoldPrimOp(CallExpr* call) {
                 toString(classType));
     }
 
-    retval = new CallExpr(PRIM_GET_MEMBER,
-                          call->get(1)->copy(),
-                          new_CStringSymbol(name));
+    if(isManagedPtrType(call->get(1)->getValType())) {
+      // Extract the 'chpl_p' field.
+      Symbol* pField = toAggregateType(call->get(1)->getValType())->getField("chpl_p");
+      VarSymbol* pTemp = newTempConst(pField->type);
+      call->getStmtExpr()->insertBefore(new DefExpr(pTemp));
+      call->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE,
+                            pTemp,
+                            new CallExpr(PRIM_GET_MEMBER,
+                                call->get(1)->copy(),
+                                pField)));
+
+      retval = new CallExpr(PRIM_GET_MEMBER,
+                            new SymExpr(pTemp),
+                            new_CStringSymbol(name));
+    } else {
+      retval = new CallExpr(PRIM_GET_MEMBER,
+                            call->get(1)->copy(),
+                            new_CStringSymbol(name));
+    }
 
     call->replace(retval);
 

--- a/test/library/standard/Reflection/getField-managed.chpl
+++ b/test/library/standard/Reflection/getField-managed.chpl
@@ -1,9 +1,10 @@
 use Reflection;
-proc test(const ref obj) {
+proc test(in obj) {
   writeln("===== ", obj.type:string);
   writeln("  numFields       ", numFields(obj.type)            :string);
   writeln("  getFieldName    ", getFieldName(obj.type, 5)             );
-  writeln("  getField        ", getField(obj, 5)         :string);
+  writeln("  getField        ", getField(obj, 5)               :string);
+  writeln("  getFieldRef     ", getFieldRef(obj, 5)             :string);
   writeln("  hasField        ", hasField(obj.type, "f6")       :string);
   writeln("  getFieldIndex   ", getFieldIndex(obj.type, "f6")  :string);
   writeln("  isFieldBound 5  ", isFieldBound(obj.type, 5)      :string);

--- a/test/library/standard/Reflection/getField-managed.chpl
+++ b/test/library/standard/Reflection/getField-managed.chpl
@@ -24,6 +24,10 @@ test((new owned CCon()).borrow());
 test(((new owned CCon()):owned class?).borrow());
 test(new unmanaged CCon());
 test((new unmanaged CCon()):unmanaged class?);
+var a = new CCon();
+test(a.borrow());
+var b = new CCon():class?;
+test(b.borrow());
 
 record RCon {
   var f1, f2, f3, f4, f5: int;

--- a/test/library/standard/Reflection/getField-managed.chpl
+++ b/test/library/standard/Reflection/getField-managed.chpl
@@ -1,0 +1,32 @@
+use Reflection;
+proc test(const ref obj) {
+  writeln("===== ", obj.type:string);
+  writeln("  numFields       ", numFields(obj.type)            :string);
+  writeln("  getFieldName    ", getFieldName(obj.type, 5)             );
+  writeln("  getField        ", getField(obj, 5)         :string);
+  writeln("  hasField        ", hasField(obj.type, "f6")       :string);
+  writeln("  getFieldIndex   ", getFieldIndex(obj.type, "f6")  :string);
+  writeln("  isFieldBound 5  ", isFieldBound(obj.type, 5)      :string);
+  writeln("  isFieldBound f6 ", isFieldBound(obj.type, "f6")   :string);
+}
+
+class CCon {
+  var f1, f2, f3, f4, f5: int;
+  var f6:int = 17;
+}
+
+test(new owned CCon());
+test((new owned CCon()):owned class?);
+test(new shared CCon());
+test((new shared CCon()):shared class?);
+test((new owned CCon()).borrow());
+test(((new owned CCon()):owned class?).borrow());
+test(new unmanaged CCon());
+test((new unmanaged CCon()):unmanaged class?);
+
+record RCon {
+  var f1, f2, f3, f4, f5: int;
+  var f6:int = 17;
+}
+
+test(new RCon());

--- a/test/library/standard/Reflection/getField-managed.good
+++ b/test/library/standard/Reflection/getField-managed.good
@@ -70,6 +70,24 @@
   getFieldIndex   5
   isFieldBound 5  true
   isFieldBound f6 true
+===== borrowed CCon
+  numFields       6
+  getFieldName    f6
+  getField        17
+  getFieldRef     17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== borrowed CCon?
+  numFields       6
+  getFieldName    f6
+  getField        17
+  getFieldRef     17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
 ===== RCon
   numFields       6
   getFieldName    f6

--- a/test/library/standard/Reflection/getField-managed.good
+++ b/test/library/standard/Reflection/getField-managed.good
@@ -1,0 +1,72 @@
+===== owned CCon
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== owned CCon?
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== shared CCon
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== shared CCon?
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== borrowed CCon
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== borrowed CCon?
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== unmanaged CCon
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== unmanaged CCon?
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true
+===== RCon
+  numFields       6
+  getFieldName    f6
+  getField        17
+  hasField        true
+  getFieldIndex   5
+  isFieldBound 5  true
+  isFieldBound f6 true

--- a/test/library/standard/Reflection/getField-managed.good
+++ b/test/library/standard/Reflection/getField-managed.good
@@ -2,6 +2,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true
@@ -10,6 +11,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true
@@ -18,6 +20,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true
@@ -26,6 +29,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true
@@ -34,6 +38,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true
@@ -42,6 +47,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true
@@ -50,6 +56,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true
@@ -58,6 +65,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true
@@ -66,6 +74,7 @@
   numFields       6
   getFieldName    f6
   getField        17
+  getFieldRef     17
   hasField        true
   getFieldIndex   5
   isFieldBound 5  true


### PR DESCRIPTION
Implements a fix for the bugs described in #14154 and #20491 where `getField` and `getFieldRef` get wrapper class fields instead of the actual class. This does not match the behavior of other `Reflection` methods such as `getFieldName` and `numFields`.

## Summary of changes
- add a check to `PRIM_FIELD_BY_NUM` for managed ptrs and look through the `chpl_p` pointer.

## New tests
- add a new test that checks `getField` and `getField` on classes

## testing
- paratest
- paratest + gasnet

---

[reviewed by @dlongnecke-cray ]

closes #14154
closes #20491
closes Cray/chapel-private#4677