### PR TITLE
First series of fixes to the scope resolver to work without production

### DIFF
--- a/compiler/AST/CatchStmt.cpp
+++ b/compiler/AST/CatchStmt.cpp
@@ -273,7 +273,7 @@ void CatchStmt::cleanup()
 
   if (catchall) {
     Expr* nonNilC = new CallExpr(PRIM_TO_NON_NILABLE_CLASS, casted);
-    Expr* toOwned = new CallExpr(PRIM_NEW, new CallExpr("_owned", nonNilC));
+    Expr* toOwned = new CallExpr(PRIM_NEW, new CallExpr(new SymExpr(dtOwned->symbol), nonNilC));
 
     errorDef->init = toOwned;
 
@@ -289,7 +289,7 @@ void CatchStmt::cleanup()
     castedDef->insertAfter(cond);
 
     Expr* nonNilC = new CallExpr(PRIM_TO_NON_NILABLE_CLASS, casted);
-    Expr* toOwned = new CallExpr(PRIM_NEW, new CallExpr("_owned", nonNilC));
+    Expr* toOwned = new CallExpr(PRIM_NEW, new CallExpr(new SymExpr(dtOwned->symbol), nonNilC));
 
     errorDef->init = toOwned;
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -272,7 +272,8 @@ static void processGenericFields() {
 // to handle chpl__Program with little or no special casing.
 
 static void addToSymbolTable() {
-  rootScope = ResolveScope::getRootModule();
+  rootScope = ResolveScope::getScopeFor(theProgram->block);
+  if (!rootScope) rootScope = ResolveScope::getRootModule();
 
   // Extend the rootScope with every top-level definition
   for_alist(stmt, theProgram->block->body) {

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1181,6 +1181,8 @@ class ResolvedExpression {
   // For simple (non-function Identifier) cases,
   // the ID of a NamedDecl it refers to
   ID toId_;
+  // Is this a reference to a compiler-created primitive?
+  bool isPrimitive_ = false;
 
   // For a function call, what is the most specific candidate,
   // or when using return intent overloading, what are the most specific
@@ -1210,6 +1212,9 @@ class ResolvedExpression {
    * refers to */
   ID toId() const { return toId_; }
 
+  /** check whether this resolution result refers to a compiler primitive like `bool`. */
+  bool isPrimitive() const { return isPrimitive_; }
+
   /** For a function call, what is the most specific candidate, or when using
    * return intent overloading, what are the most specific candidates? The
    * choice between these needs to happen later than the main function
@@ -1226,6 +1231,9 @@ class ResolvedExpression {
   const ResolvedParamLoop* paramLoop() const {
     return paramLoop_;
   }
+
+  /** set the isPrimitive flag */
+  void setIsPrimitive(bool isPrimitive) { isPrimitive_ = isPrimitive; }
 
   /** set the toId */
   void setToId(ID toId) { toId_ = toId; }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2344,13 +2344,21 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       } else {
         // Possibly a "compatibility hack" with production: we haven't checked
         // whether the call is valid, but the production scope resolver doesn't
-        // care and assumes `ident` points to this parenless function.
-        r.setToId(id);
+        // care and assumes `ident` points to this parenless function. Setting
+        // the toId also helps determine if this is a method call and should
+        // have `this` inserted, as well as wehther or not to turn this
+        // into a parenless call.
+        validateAndSetToId(r, ident, id);
       }
       return;
     } else if (scopeResolveOnly &&
                type.kind() == QualifiedType::FUNCTION) {
-      return;
+      // Possibly a "compatibility hack" with production: we haven't checked
+      // whether the call is valid, but the production scope resolver doesn't
+      // care and assumes `ident` points to this function. Setting
+      // the toId also helps determine if this is a method call
+
+      // Fall through to validateAndSetToId
     }
 
     validateAndSetToId(result, ident, id);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2289,6 +2289,7 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       return;
     } else if (id.isEmpty()) {
       type = typeForBuiltin(context, ident->name());
+      result.setIsPrimitive(true);
       result.setToId(id);
       result.setType(type);
       return;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2350,13 +2350,6 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       return;
     } else if (scopeResolveOnly &&
                type.kind() == QualifiedType::FUNCTION) {
-      if (scopeResolveOnly) {
-        // Possibly a "compatibility hack" with production: we haven't checked
-        // whether the call is valid, but the production scope resolver doesn't
-        // care and assumes `ident` points to this function.
-        ResolvedExpression& r = byPostorder.byAst(ident);
-        r.setToId(id);
-      }
       return;
     }
 

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -63,7 +63,7 @@ areOverloadsPresentInDefiningScope(Context* context, const Type* type,
   if (!scopeForReceiverType) return false;
 
   // do not look outside the defining module
-  const LookupConfig config = LOOKUP_DECLS | LOOKUP_PARENTS;
+  const LookupConfig config = LOOKUP_DECLS | LOOKUP_PARENTS | LOOKUP_METHODS;
 
   auto vec = lookupNameInScope(context, scopeForReceiverType,
                                /* receiver scopes */ {},

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -714,8 +714,10 @@ computeIsMoreVisible(Context* context,
 
   // TODO: This might be over-simplified -- see issue #19167
 
-  LookupConfig onlyDecls = LOOKUP_DECLS;
-  LookupConfig importAndUse = LOOKUP_IMPORT_AND_USE;
+  // In both cases, include methods since they're considered for candidate
+  // search.
+  LookupConfig onlyDecls = LOOKUP_DECLS | LOOKUP_METHODS;
+  LookupConfig importAndUse = LOOKUP_IMPORT_AND_USE | LOOKUP_METHODS;
 
   // Go up scopes to figure out which of the two IDs is
   // declared first / innermost
@@ -842,6 +844,10 @@ static void testArgMapping(const DisambiguationContext& dctx,
   if (f1Type.kind() == QualifiedType::OUT ||
       f2Type.kind() == QualifiedType::OUT) {
     return;
+  }
+
+  if (candidate1.fn->id().symbolPath() == "broken.R") {
+    debuggerBreakHere();
   }
 
   // Initializer work-around: Skip 'this' for generic initializers

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -39,6 +39,9 @@ std::string IdAndFlags::flagsToString(Flags flags) {
   if ((flags & PARENFUL_FUNCTION) != 0)     ret += "parenful-fn ";
   if ((flags & NOT_PARENFUL_FUNCTION) != 0) ret += "!parenful-fn ";
 
+  if ((flags & METHOD) != 0)     ret += "method ";
+  if ((flags & NOT_METHOD) != 0) ret += "!method ";
+
   return ret;
 }
 
@@ -184,6 +187,7 @@ void Scope::addBuiltin(UniqueString name) {
                     OwnedIdsWithName(ID(),
                                      uast::Decl::PUBLIC,
                                      /*isMethodOrField*/ false,
+                                     /*isMethod*/ false,
                                      /*isParenfulFunction*/ false));
 }
 

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -717,12 +717,13 @@ static void testExample5a() {
                   proc r.foo { }
                   foo; // is this referring to the int or the parenless method?
                        // 1.29 refers to the local variable
+                       // Should it be ambiguous?
                 }
               }
            )"""",
            "M.test",
            "M.test@4",
-           "" /* ambiguity */);
+           "M.test@3" /* match 1.29 behavior */);
 }
 
 static void testExample6() {
@@ -1049,12 +1050,13 @@ static void testExample20() {
                   foo; // does it call the method or non-method?
                        // 1.29 calls A.r.method.foo
                        // (the non-method)
+                       // Should it be ambiguous?
                 }
               }
            )"""",
            "A.test",
            "A.test@2",
-           "" /* ambiguity error */);
+           "A.test.foo#1" /* match 1.29 behavior */);
 }
 
 int main() {

--- a/frontend/test/resolution/testScopeTypes.cpp
+++ b/frontend/test/resolution/testScopeTypes.cpp
@@ -68,7 +68,7 @@ static void testBorrowIds() {
   {
     // check one id with no filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     assert(ids.numIds() == 1);
     auto foundIds = ids.borrow(0, 0);
     assert(foundIds.hasValue());
@@ -86,7 +86,7 @@ static void testBorrowIds() {
   {
     // check one id with filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = pub;
     IdAndFlags::Flags e = 0;
     auto foundIds = ids.borrow(f, e);
@@ -95,7 +95,7 @@ static void testBorrowIds() {
   {
     // check one id with filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     IdAndFlags::Flags e = not_method;
     auto foundIds = ids.borrow(f, e);
@@ -105,9 +105,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out the 1st
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     ids.appendIdAndFlags(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     assert(ids.numIds() == 2);
     IdAndFlags::Flags f = pub;
     IdAndFlags::Flags e = 0;
@@ -127,9 +127,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out the 2nd
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = IdAndFlags::PUBLIC;
     IdAndFlags::Flags e = 0;
     auto foundIds = ids.borrow(f, e);
@@ -148,9 +148,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out neither
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     IdAndFlags::Flags e = 0;
     auto foundIds = ids.borrow(f, e);
@@ -169,9 +169,9 @@ static void testBorrowIds() {
   {
     // check two excluding one of them
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     IdAndFlags::Flags e = pub | method;
     auto foundIds = ids.borrow(f, e);
@@ -190,9 +190,9 @@ static void testBorrowIds() {
   {
     // check two different ones excluding one of them
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PUBLIC,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     IdAndFlags::Flags e = pub | method;
     auto foundIds = ids.borrow(f, e);
@@ -211,9 +211,9 @@ static void testBorrowIds() {
   {
     // check two excluding both
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PUBLIC,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     IdAndFlags::Flags e = pub;
     auto foundIds = ids.borrow(f, e);

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/badName-this.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/badName-this.good
@@ -1,1 +1,2 @@
-badName-this.chpl:5: error: Bad identifier, no known 'this' defined in 'Foo'
+badName-this.chpl:4: In module 'User':
+badName-this.chpl:5: error: cannot 'import' symbol 'this' as it is not defined in 'Foo'


### PR DESCRIPTION
The Dyno scope resolver, though on by default, relies on the production scope resolver to handle certain cases. Thus, we haven't _completely_ replaced the production scope resolution pass, only made it less authoritative. This PR takes a few steps towards replacing the production scope resolver altogether, by specially handling builtin primitives, avoiding used `_owned` as an `UnresolvedSymExpr`, and properly translating forwarding declarations.

## Testing
- [ ] full local