### PR TITLE
Check CUDA/HIP version before building runtime

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -30,7 +30,7 @@ CHPL_ENV_HEADER_TEMPLATE=$(CHPL_MAKE_HOME)/runtime/etc/chpl-env-gen-template.h
 CHPL_ENV_HEADER_DIR=$(RUNTIME_OBJDIR)/include/
 CHPL_ENV_HEADER=$(CHPL_ENV_HEADER_DIR)/chpl-env-gen.h
 
-all: $(CHPL_ENV_HEADER) third-party-pkgs all.helpme
+all: reqchecks $(CHPL_ENV_HEADER) third-party-pkgs all.helpme
 
 depend:
 
@@ -51,6 +51,11 @@ ifneq ($(CHPL_MAKE_LAUNCHER),none)
 	@$(MAKE) -f Makefile.help MAKE_LAUNCHER=1 CHPL_MAKE_RULE=$* $*
 endif
 
+# Tell printchplenv to perform any dependnecy checks that should be met before
+# building the runtime.
+reqchecks:
+	@$(CHPL_MAKE_HOME)/util/printchplenv --runtime --no-tidy --anonymize --runtime-req-checks
+	
 # save output of printchplenv into #defines but munge away
 # characters that can't be in #defines
 $(CHPL_ENV_HEADER): $(CHPL_MAKE_HOME)/util/printchplenv $(CHPL_MAKE_HOME)/util/chplenv/*

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -60,12 +60,14 @@ def get_runtime_includes_and_defines():
         sdk_path = chpl_gpu.get_sdk_path(gpu_type)
 
         bundled.append("-I" + os.path.join(incl, "gpu", chpl_gpu.get()))
-        if gpu_type == "cuda":
-            system.append("-I" + os.path.join(sdk_path, "include"))
-        elif gpu_type == "rocm":
-            # -isystem instead of -I silences warnings from inside these includes.
-            system.append("-isystem" + os.path.join(sdk_path, "hip", "include"))
-            system.append("-isystem" + os.path.join(sdk_path, "hsa", "include"))
+
+        if sdk_path is not None:
+            if gpu_type == "cuda":
+                system.append("-I" + os.path.join(sdk_path, "include"))
+            elif gpu_type == "rocm":
+                # -isystem instead of -I silences warnings from inside these includes.
+                system.append("-isystem" + os.path.join(sdk_path, "hip", "include"))
+                system.append("-isystem" + os.path.join(sdk_path, "hsa", "include"))
 
     if mem == "jemalloc":
         # set -DCHPL_JEMALLOC_PREFIX=chpl_je_
@@ -92,16 +94,18 @@ def get_runtime_link_args(runtime_subdir):
         # and add cuda libraries
         gpu_type = chpl_gpu.get()
         sdk_path = chpl_gpu.get_sdk_path(gpu_type)
-        if gpu_type == "cuda":
-            system.append("-L" + os.path.join(sdk_path, "lib64"))
-            system.append("-lcuda")
-            system.append("-lcudart")
-        elif gpu_type == "rocm":
-            lib_path = os.path.join(sdk_path, "lib")
-            system.append("-L" + lib_path)
-            system.append("-Wl,-rpath," + lib_path)
-            system.append("-lamdhip64")
-            system.append("-lhsa-runtime64")
+
+        if sdk_path is not None:
+            if gpu_type == "cuda":
+                system.append("-L" + os.path.join(sdk_path, "lib64"))
+                system.append("-lcuda")
+                system.append("-lcudart")
+            elif gpu_type == "rocm":
+                lib_path = os.path.join(sdk_path, "lib")
+                system.append("-L" + lib_path)
+                system.append("-Wl,-rpath," + lib_path)
+                system.append("-lamdhip64")
+                system.append("-lhsa-runtime64")
 
     # always link with the math library
     system.append("-lm")

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import unittest
 
 try:
     # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
@@ -12,6 +13,10 @@ except ImportError:
     # Backport for pre Python 3.2
     from distutils.spawn import find_executable as which
 
+# Set to True if you want to error out if a requirement for building the
+# runtime library (under the current configuration) is not met. If building the
+# compiler (or just using printchplenv directly) print nothing.
+err_if_runtime_reqs_unmet = False
 
 def warning(msg):
     if not os.environ.get('CHPLENV_SUPPRESS_WARNINGS'):
@@ -30,6 +35,19 @@ def error(msg, exception=Exception):
         sys.stderr.write(msg)
         sys.stderr.write('\n')
         sys.exit(1)
+
+
+def report_unmet_runtime_req(msg):
+  """Report that a runtime requirement is not met; should error out if
+  printchplenv is invoked with a hidden --runtimeReqChecks flag and do nothing
+  otherwise."""
+  global err_if_runtime_reqs_unmet
+  if err_if_runtime_reqs_unmet:
+      if not os.environ.get('CHPLENV_RUNTIME_REQ_ERRS_AS_WARNINGS'):
+          error("%s To turn this error into a warning set the "
+              "CHPLENV_RUNTIME_REQ_ERRS_AS_WARNINGS environment variable." % msg)
+      else:
+          warning(msg)
 
 
 def memoize(func):
@@ -107,3 +125,79 @@ def run_live_command(command):
 
     if returncode != 0:
         error("command failed: {0}".format(command), CommandError)
+
+
+def _split_ver_str(ver_str):
+    """Split a version string into an array of integers"""
+
+    # Semantic versioning strings can have prelease information
+    # after a hypen and/or build metadata after a plus. For
+    # the purpose of our versioning checks we strip these
+    ver_str = ver_str.rsplit('-',1)[0]
+    ver_str = ver_str.rsplit('+',1)[0]
+
+    return [int(x) for x in ver_str.split('.')]
+
+
+def is_ver_in_range(versionStr, minimumStr, maximumStr):
+    """Assume that version, minimum, and maximum are version strings consisting
+    of integers separated by spaces. Ensure that version is withint the
+    (inclusive) bounds: [minimumStr, maximumStr]."""
+
+    version = _split_ver_str(versionStr)
+    minimum = _split_ver_str(minimumStr)
+    maximum = _split_ver_str(maximumStr)
+
+    # Pad version, minimum, and maximum with zeros so they're the same length
+    max_len = max(len(version), len(minimum), len(maximum))
+    version = version + [0] * (max_len - len(version))
+    minimum = minimum + [0] * (max_len - len(minimum))
+    maximum = maximum + [0] * (max_len - len(maximum))
+
+    for i in range(max_len):
+        if version[i] < minimum[i]:
+            return False
+        elif version[i] > minimum[i]:
+            break
+
+    for i in range(max_len):
+        if version[i] < maximum[i]:
+            return True
+        elif version[i] > maximum[i]:
+            return False
+
+    return False
+
+
+class _UtilsTests(unittest.TestCase):
+    def test_is_ver_in_range(self):
+        # Various tests for versions in range: [2, 4)
+        for min_ver in ["2", "2.0", "2.0.0"]:
+          for max_ver in ["4", "4.0", "4.0.0"]:
+            # Versions too low
+            for ver in ["0", "0.0", "1", "1.0", "1.0-alpha"]:
+                self.assertFalse(is_ver_in_range(ver, min_ver, max_ver))
+
+            # Versions in bound
+            for ver in ["2", "2.0", "2.5", "3", "3-alpha", "3.1", "3.1.1", "3.9", "3.9.9.9.9"]:
+              self.assertTrue(is_ver_in_range(ver, min_ver, max_ver))
+
+            # Versions too high
+            for ver in ["4", "4.0", "4.1", "4.0.1", "5", "5-alpha"]:
+              self.assertFalse(is_ver_in_range(ver, min_ver, max_ver))
+
+        # Various tests for versions in range: [2.5, 4.5)
+        for min_ver in ["2.5", "2.5.0"]:
+          for max_ver in ["4.5", "4.5.0"]:
+            # Versions too low
+            for ver in ["2", "2.4", "2.4.0", "2.4.0.0", "2.4.9.9.9.9"]:
+              self.assertFalse(is_ver_in_range(ver, min_ver, max_ver))
+
+            # Versions in bound
+            for ver in ["2.5", "2.5.0", "2.6", "4.4", "4.4.0", "4.4.9"]:
+              self.assertTrue(is_ver_in_range(ver, min_ver, max_ver))
+
+            # Versions too high
+            for ver in ["4.5", "4.5.0", "4.5.9", "4.6", "5", "5.0"]:
+              self.assertFalse(is_ver_in_range(ver, min_ver, max_ver))
+


### PR DESCRIPTION
As [discussed here](https://github.com/chapel-lang/chapel/issues/22087#issuecomment-1507895779) it seems like a good idea to not have `printchplenv` indiscrimently error out if there's an unmet requirement for the runtime; it would be better to only error as a check before building the runtime library. There are current checks in `chpl_gpu` that break this philosophy and I want to add another one to check CUDA/HIP version.

This draft PR tries to resolve this by adding a pass to the runtime build that invokes `printchplenv` with a special hidden `--runtime-req-checks` argument.  When `printchplenv` is passed this, we do  runtime-library-dependency checks and error out if they're unmet.  If users want to proceed despite these unmet dependencies, they can be turned to warnings by setting a `CHPLENV_RUNTIME_REQ_ERRS_AS_WARNINGS` environment variable.

This PR also adds a check for the requirement that when configured to target NVIDIA GPUs we have an installed version of the CUDA API >= 11.0 and < 12 and when configured to target AMD we have an installed version of the HIP API >= 4 and < 6. 

There are a few things that make me a litle unsatisfied with the solution; I think this is a step in the right direction, but I think I need feedback from someone more familiar with these scripts and our Makefiles.

Here's some thoughts:

- I'm unsure if some (maybe all) of these existing checks should really be thought of as runtime requirements.  They truly are requirements of the `chpl` compiler and not the runtime, they're just requirements that don't necessarily matter at `chpl` build time and don't even really matter at `chpl` runtime until/unless you get to the codegen pass.
  - Maybe I should have some similar flag / mode to tell chplenv to do "codegen time checks"? I suppose I could also just move these checks into our C++ code for the compiler but I'd rather not.
- I was thinking of having these checks warn when not passed `--runtime-req-checks` but we call `printchplenv` multiple times when doing the build and seeing these first as warnings and then as errors is inelegant (especially if there isn't a bunch of output inbetween).
- When invoking `printchplenv` without `--runtime-req-checks` we still end up doing all the checks/validation, but some (all) of this work ends up being useless work.
- I'm adding yet another invocation of `printchplenv`
- Maybe we should separate these checks into a separate script or have `printchplenv` only do the checks and nothing else when passed  `--runtime-req-checks` but:
  - These validation checks sometimes need access to all a user-unset `CHPL_` variable that's been filled in with a defaults (figuring out that default is what `printchplenv` does).
  - I don't think it's currently the case, but in the future there may be cases where setting the default value for something depends on whether one of these checks passes or not. So, at least sometime, the validation code will  need to be redundantly run by `printchplenv`.

There's also some other thoughts I have about my version checking code:

- While developing, I wanted to test my version checking code so I wrote a pyunit test for it. I could throw this code out but why should I?  Instead I added a hidden `--unit-tests` flags that can be passed to `printchplenv` that will run any pyunit tests found within the `chplenv` scripts. This sets up the framework for future unit testing if we want it.
- I'm probably (poorly) reinventing the wheel with my version checking code. Semantic versioning libraries exist for Python but aren't packaged with Python by default and do we want to add a dependency (beyond Python itself) to `printchplenv`? Do we have any precedent of doing that?