### PR TITLE
Update GPU technote with CUDA/ROCM version requirements

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -125,10 +125,11 @@ Requirements
 
   * If targeting NVIDIA GPUs, we require CUDA toolkit to be version 10.x or 11.x
     (inclusive). If using version 10.x you must set
-    ``CHPL_RT_NUM_THREADS_PER_LOCALE=1``. In some cases versions as early as
-    7.x or at or above 12.x may work but we have not tested these.
+    ``CHPL_RT_NUM_THREADS_PER_LOCALE=1``. Versions as early as 7.x may work,
+    although we have not tested this.
 
-  * If targeting AMD GPUs, we require a version of ROCM greater than 4.x.
+  * If targeting AMD GPUs, we require ROCM version 4.x; we suspect version 5.x
+    will work as well although we have not tested so.
 
 
 GPU-Related Environment Variables

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -121,12 +121,15 @@ Requirements
     version as the bundled version (currently 14). Older versions may
     work; however, we only make efforts to test GPU support with this version.
 
-* Either ``nvcc`` (for NVIDIA) or ``hipcc`` (for AMD) must be available; Chapel
-  uses libraries included in these packages and will automatically deduce the
-  path to these libraries based on the location of the ``nvcc``/``hipcc``
-  executable. Note that the automatically deduced paths may be overwritten by
-  manually setting the ``CHPL_CUDA_PATH`` or ``CHPL_ROCM_PATH`` environment
-  variables.
+* Either the CUDA toolkit (for NVIDIA), or ROCM (for AMD) must be installed.
+
+  * If targeting NVIDIA GPUs, we require CUDA toolkit to be version 10.x or 11.x
+    (inclusive). If using version 10.x you must set
+    ``CHPL_RT_NUM_THREADS_PER_LOCALE=1``. In some cases versions as early as
+    7.x or at or above 12.x may work but we have not tested these.
+
+  * If targeting AMD GPUs, we require a version of ROCM greater than 4.x.
+
 
 GPU-Related Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We should document what version of third-party dependencies for GPU support (e.g. cuda/rocm) are needed.

This PR adds that information to the GPU tech note.

Some other changes:

* I change the requirements section to talk about the CUDA Toolkit and ROCM rather than `nvcc` and `hipcc` as (apart from inferring a default for `CHPL_GPU_CODEGEN` we don't actually use these, rather we use APIs that are packaged as part of these toolkits).
* Since I no longer mention `nvcc` or `hipcc` in the requirements section, I removed the line about how we "automatically deduce the path to these libraries based on the location of the ``nvcc``/``hipcc`` executable." I think if we want to mention this the requirements section isn't the place to do it and in the "GPU Related Environment Variables" section we mention that we try and automatically deduce the value for `CHPL_GPU_CODEGEN` but don't go into details how; I think it's fine to leave the "how" for that out of the technote.

Some info:
* The machines we've tested on use various versions of CUDA 11.x and HIP 4.x. I'm basing that we might be able to use CUDA versions after 7.x on [this prerequisite in the clang documentation](https://llvm.org/docs/CompileCudaWithLLVM.html#:~:text=Clang%20currently%20supports%20CUDA%207.0,CUDA%20installation%20guide%20for%20details.)

--

Related issues: https://github.com/chapel-lang/chapel/issues/22085 and https://github.com/chapel-lang/chapel/issues/22087