### PR TITLE
dyno: minor fixes to support domains and arrays

### DIFF
--- a/frontend/include/chpl/types/TupleType.h
+++ b/frontend/include/chpl/types/TupleType.h
@@ -87,12 +87,12 @@ class TupleType final : public CompositeType {
   getReferentialTuple(Context* context, std::vector<const Type*> eltTypes);
 
   static const TupleType*
-  getVarArgTuple(Context* context, std::vector<QualifiedType> eltTypes);
+  getQualifiedTuple(Context* context, std::vector<QualifiedType> eltTypes);
 
   static const TupleType*
-  getVarArgTuple(Context* context,
-                 QualifiedType paramSize,
-                 QualifiedType starEltType);
+  getStarTuple(Context* context,
+               QualifiedType paramSize,
+               QualifiedType starEltType);
 
   /** Return the generic tuple type `_tuple` */
   static const TupleType* getGenericTupleType(Context* context);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1129,8 +1129,10 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
           // if we aren't inferring from the init expr, clear initExprT
           // so it is not used below.
           initExprT = QualifiedType();
-          if (isTypeOrParam && isField) {
-            // a type or param field with initExpr is still generic, e.g.
+
+          if (isTypeOrParam && isFieldOrFormal && typeExprT == QualifiedType()) {
+            // a type or param field with initExpr is still generic, if
+            // it doesn't already have a type-expr, e.g.
             // record R { type t = int; }
             // if that behavior is requested with defaultsPolicy == IGNORE_DEFAULTS
             typeExprT = QualifiedType(QualifiedType::TYPE,

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -957,7 +957,7 @@ static const Type* computeVarArgTuple(Resolver& resolver,
       auto newKind = resolveIntent(QualifiedType(qtKind, typePtr),
                                    /* isThis */ false, /* isInit */ false);
       QualifiedType elt = QualifiedType(newKind, typePtr);
-      typePtr = TupleType::getVarArgTuple(context, paramSize, elt);
+      typePtr = TupleType::getStarTuple(context, paramSize, elt);
     }
   }
 

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -876,7 +876,8 @@ CanPassResult CanPassResult::canPass(Context* context,
     return fail();
   }
 
-  if (actualT == formalT) {
+  // Type-query Kinds should always pass
+  if (actualT == formalT || typeQueryActual) {
     if (formalQT.kind() == QualifiedType::PARAM &&
         formalQT.param() == nullptr) {
       // if the formal parameter value is unknown, we need to instantiate

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -884,6 +884,19 @@ CanPassResult CanPassResult::canPass(Context* context,
       return instantiate();
     }
 
+    // Passing in a type to another type requires instantiation.
+    // Note: we might encounter this situation for a type method on a
+    //   generic type. I.e., passing 'R(?)' to 'R(?)' for the 'this' formal.
+    //   This case should instantiate so that code looking for a substitution
+    //   will find one, rather than just seeing a generic type and guessing
+    //   that it wasn't instantiated.
+    //
+    // 'AnyType' has special meaning elsewhere, so it doesn't count as
+    // instantiation here.
+    if (formalQT.kind() == QualifiedType::TYPE && !formalT->isAnyType()) {
+      return instantiate();
+    }
+
     // otherwise we can pass as-is
     return passAsIs();
   }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1536,7 +1536,7 @@ const TypedFnSignature* instantiateSignature(Context* context,
     }
 
     if (instantiateVarArgs) {
-      const TupleType* t = TupleType::getVarArgTuple(context, varargsTypes);
+      const TupleType* t = TupleType::getQualifiedTuple(context, varargsTypes);
       auto formal = faMap.byFormalIdx(varArgIdx).formal()->toVarArgFormal();
       QualifiedType vat = QualifiedType(formal->storageKind(), t);
       substitutions.insert({formal->id(), vat});
@@ -2502,8 +2502,7 @@ static const Type* resolveFnCallSpecialType(Context* context,
     auto second = ci.actual(1).type();
     if (first.isParam() && first.type()->isIntType() &&
         second.isType()) {
-      // TODO: rename these methods...
-      return TupleType::getVarArgTuple(context, first, second);
+      return TupleType::getStarTuple(context, first, second);
     }
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2497,6 +2497,16 @@ static const Type* resolveFnCallSpecialType(Context* context,
     }
   }
 
+  if (ci.name() == USTR("*") && ci.numActuals() == 2) {
+    auto first = ci.actual(0).type();
+    auto second = ci.actual(1).type();
+    if (first.isParam() && first.type()->isIntType() &&
+        second.isType()) {
+      // TODO: rename these methods...
+      return TupleType::getVarArgTuple(context, first, second);
+    }
+  }
+
   if (auto t = getManagedClassType(context, astForErr, ci)) {
     return t;
   }

--- a/frontend/lib/types/TupleType.cpp
+++ b/frontend/lib/types/TupleType.cpp
@@ -161,8 +161,8 @@ TupleType::getGenericTupleType(Context* context) {
 }
 
 const TupleType*
-TupleType::getVarArgTuple(Context* context,
-                          std::vector<QualifiedType> eltTypes) {
+TupleType::getQualifiedTuple(Context* context,
+                             std::vector<QualifiedType> eltTypes) {
   SubstitutionsMap subs;
   int i = 0;
   for (const auto& t : eltTypes) {
@@ -178,16 +178,16 @@ TupleType::getVarArgTuple(Context* context,
 }
 
 const TupleType*
-TupleType::getVarArgTuple(Context* context,
-                          QualifiedType paramSize,
-                          QualifiedType varArgEltType) {
+TupleType::getStarTuple(Context* context,
+                        QualifiedType paramSize,
+                        QualifiedType varArgEltType) {
   CHPL_ASSERT(!varArgEltType.isUnknownKindOrType());
 
   if (!paramSize.isUnknown()) {
     // Fixed size, we can at least create a star tuple of AnyType
     int64_t numElements = paramSize.param()->toIntParam()->value();
     std::vector<QualifiedType> eltTypes(numElements, varArgEltType);
-    return getVarArgTuple(context, eltTypes);
+    return getQualifiedTuple(context, eltTypes);
   } else {
     // Size unknown, store the expected element type
     auto name = UniqueString::get(context, "_tuple");

--- a/frontend/test/resolution/testGenericDefaults.cpp
+++ b/frontend/test/resolution/testGenericDefaults.cpp
@@ -131,9 +131,37 @@ static void test3() {
   assert(subs.size() == 0);
 }
 
+static void test4() {
+  {
+    Context ctx;
+    auto context = &ctx;
+    QualifiedType qt =  resolveQualifiedTypeOfX(context,
+                           R""""(
+                           proc foo(type t = int) type do return t;
+
+                           var x : foo();
+                           )"""");
+    assert(qt.kind() == QualifiedType::VAR);
+    assert(qt.type()->isIntType());
+  }
+  {
+    Context ctx;
+    auto context = &ctx;
+    QualifiedType qt =  resolveQualifiedTypeOfX(context,
+                           R""""(
+                           proc foo(type t = int) type do return t;
+
+                           var x : foo(string);
+                           )"""");
+    assert(qt.kind() == QualifiedType::VAR);
+    assert(qt.type()->isStringType());
+  }
+}
+
 int main() {
   test1();
   test2();
   test3();
+  test4();
   return 0;
 }

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -341,6 +341,48 @@ static void test6() {
   assert(initType.type()->isIntType());
 }
 
+static void test7() {
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program =
+      R""""(
+        record R {
+          var x : int;
+
+          proc type factory() do return 1;
+        }
+
+        var x = R.factory();
+      )"""";
+
+    QualifiedType initType = resolveTypeOfXInit(context, program);
+    assert(initType.type()->isIntType());
+  }
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program =
+      R""""(
+        record R {
+          type T;
+          var x : int;
+
+          proc type factory() do return 1;
+        }
+
+        var x = R.factory();
+      )"""";
+
+    QualifiedType initType = resolveTypeOfXInit(context, program);
+    assert(initType.type()->isIntType());
+  }
+}
+
 
 int main() {
   test1();
@@ -349,6 +391,7 @@ int main() {
   test4();
   test5();
   test6();
+  test7();
 
   return 0;
 }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -450,6 +450,27 @@ static void test16() {
   assert(qt.type()->isRealType());
 }
 
+static void test17() {
+  printf("test17\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto qt = resolveQualifiedTypeOfX(context,
+                R""""(
+                  var x : 3*int;
+                )"""");
+
+  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.type()->isTupleType());
+  auto tt = qt.type()->toTupleType();
+
+  assert(tt->numElements() == 3);
+  assert(tt->isStarTuple());
+  assert(tt->elementType(0).type()->isIntType());
+  assert(tt->elementType(1).type()->isIntType());
+  assert(tt->elementType(2).type()->isIntType());
+}
+
 int main() {
   test1();
   test2();
@@ -467,6 +488,7 @@ int main() {
   test14();
   test15();
   test16();
+  test17();
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes a couple of bugs in our resolution of generic functions/methods and adds tests for code involving:
- optional type formals
- type methods on generic types

This PR also adds basic resolution for creating a tuple by multiplying a ``param int`` by a type.

This PR also renames some tuple-creating functions that were previously named in terms of variable arguments, but have broader usability in other contexts.

There were some other minor bugs exposed by existing testing:
- fix to 'canPass' so that a type query will always succeed
- bug where primitives could be resolved as method calls

Testing:
- [x] full local
- [x] make test-dyno