### PR TITLE
Readme for GPU extern only tests

### DIFF
--- a/test/gpu/native/cudaOnly/gpuAddNums/README
+++ b/test/gpu/native/cudaOnly/gpuAddNums/README
@@ -1,0 +1,11 @@
+These test was used in the early days to prototype GPU support.  I think
+keeping this test around is a "nice to have" sort of thing because:
+
+- it demonstrates at a very basic level what our runtime library does
+- it's good to have as a template to work off of if we end up wanting to add
+  support for a new vendor
+- it provides test coverage for some important primitives
+
+On the other hand if there's a large maintenance burdon involved with this test
+keeping this test around it you want to consider just removing it; we've
+discussed that here: <https://github.com/Cray/chapel-private/issues/3195>.

--- a/test/gpu/native/cudaOnly/gpuAddNums/README
+++ b/test/gpu/native/cudaOnly/gpuAddNums/README
@@ -6,6 +6,6 @@ keeping this test around is a "nice to have" sort of thing because:
   support for a new vendor
 - it provides test coverage for some important primitives
 
-On the other hand if there's a large maintenance burdon involved with this test
+On the other hand if there's a large maintenance burden involved with this test
 keeping this test around it you want to consider just removing it; we've
 discussed that here: <https://github.com/Cray/chapel-private/issues/3195>.

--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
@@ -1,3 +1,5 @@
+// See the README file for more information about this test.
+
 extern {
   #include <cuda.h>
   #include <assert.h>

--- a/test/gpu/native/rocmOnly/README
+++ b/test/gpu/native/rocmOnly/README
@@ -2,5 +2,5 @@ For extern_kernel_launch.chpl:
 
 This like the equivalent test under `gpu/native/cudaOnly` was used in the early
 days of adding AMD support. I think it's nice to keep this around but if
-there's a large maintenance burdon involved we might want to remove it, see
+there's a large maintenance burden involved we might want to remove it, see
 this for more info: https://github.com/Cray/chapel-private/issues/3195

--- a/test/gpu/native/rocmOnly/README
+++ b/test/gpu/native/rocmOnly/README
@@ -1,0 +1,6 @@
+For extern_kernel_launch.chpl:
+
+This like the equivalent test under `gpu/native/cudaOnly` was used in the early
+days of adding AMD support. I think it's nice to keep this around but if
+there's a large maintenance burdon involved we might want to remove it, see
+this for more info: https://github.com/Cray/chapel-private/issues/3195

--- a/test/gpu/native/rocmOnly/extern_kernel_launch.chpl
+++ b/test/gpu/native/rocmOnly/extern_kernel_launch.chpl
@@ -1,3 +1,5 @@
+// See the README for more info on this test
+
 extern {
   #include <hip/hip_runtime.h>
   #include <hip/hip_runtime_api.h>


### PR DESCRIPTION
We have some tests in our GPU suite that call out to CUDA/ROCM externs. On the one hand keeping these tests around might have some value, on the other if the maintenance cost is anything but trivial we should probably just get rid of them. This PR adds a README to explain that.

This is in response to this issue:

https://github.com/Cray/chapel-private/issues/3195