### PR TITLE
Fix problems with extern block improvement PR.

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1896,6 +1896,12 @@ static void dynoConfigureContext(std::string chpl_module_path) {
   {
     std::vector<std::string> clangCCArgs;
     computeClangArgs(clangCCArgs);
+    if (developer && printSystemCommands) {
+      printf("computed clang arguments:\n");
+      for (const auto& arg : clangCCArgs) {
+        printf("  %s\n", arg.c_str());
+      }
+    }
     chpl::util::setClangFlags(gContext, clangCCArgs);
   }
 #endif

--- a/frontend/include/chpl/util/clang-integration.h
+++ b/frontend/include/chpl/util/clang-integration.h
@@ -33,16 +33,19 @@ class TemporaryFileResult;
 namespace util {
 
 
-/** Return the currently set clang flags */
+/** Return the currently set clang flags.
+    The first vector element is the clang to run (like argv[0]). */
 const std::vector<std::string>& clangFlags(Context* context);
 
-/** Set the clang flags for this revision if they have not been set already */
+/** Set the clang flags for this revision if they have not been set already.
+    The first vector element should be the clang to run (like argv[0]). */
 void setClangFlags(Context* context, std::vector<std::string> clangFlags);
 
 /** Initialize all LLVM targets */
 void initializeLlvmTargets();
 
-/** Given arguments to 'clang', convert them into arguments for 'cc1' */
+/** Given arguments to 'clang', convert them into arguments for 'cc1'.
+    The first element of 'arg' should be which clang to use (like argv[0]). */
 const std::vector<std::string>& getCC1Arguments(Context* context,
                                                 std::vector<std::string> args,
                                                 bool forGpuCodegen);

--- a/frontend/include/chpl/util/filesystem.h
+++ b/frontend/include/chpl/util/filesystem.h
@@ -20,6 +20,8 @@
 #ifndef CHPL_UTIL_FILESYSTEM_H
 #define CHPL_UTIL_FILESYSTEM_H
 
+#include "llvm/Config/llvm-config.h"
+
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -109,10 +111,16 @@ std::string getExecutablePath(const char* argv0, void* MainExecAddr);
 */
 bool isSameFile(const llvm::Twine& path1, const llvm::Twine& path2);
 
+
+#if LLVM_VERSION_MAJOR >= 13
 /**
  Non-error result type for hashFile.
  */
 using HashFileResult = std::array<uint8_t, 32>;
+#else
+// LLVM 12 and older don't have SHA256, so use the SHA1 size.
+using HashFileResult = std::array<uint8_t, 20>;
+#endif
 
 /**
   Convert a HashFileResult to a string storing its hex value

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -54,7 +54,7 @@ namespace util {
 const std::vector<std::string>& clangFlags(Context* context) {
   QUERY_BEGIN_INPUT(clangFlags, context);
   std::vector<std::string> ret;
-  ret.push_back("clang"); // dummy argv[0]
+  ret.push_back("clang"); // dummy argv[0] to make this callable in C++ tests
   return QUERY_END(ret);
 }
 
@@ -136,7 +136,7 @@ const std::vector<std::string>& getCC1Arguments(Context* context,
   clang::driver::Command* job = nullptr;
 
   if (usingGpuLocaleModel(context) == false) {
-    if (C->getJobs().begin() != C->getJobs().end()) {
+    if (!C->getJobs().empty()) {
       // Not a CPU+GPU compilation, so just use first job.
       job = &*C->getJobs().begin();
     }

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -150,8 +150,10 @@ const std::vector<std::string>& getCC1Arguments(Context* context,
   clang::driver::Command* job = nullptr;
 
   if (usingGpuLocaleModel(context) == false) {
-    // Not a CPU+GPU compilation, so just use first job.
-    job = &*C->getJobs().begin();
+    if (C->getJobs().begin() != C->getJobs().end()) {
+      // Not a CPU+GPU compilation, so just use first job.
+      job = &*C->getJobs().begin();
+    }
   } else {
     // CPU+GPU compilation
     //  1st cc1 command is for the GPU

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -54,6 +54,7 @@ namespace util {
 const std::vector<std::string>& clangFlags(Context* context) {
   QUERY_BEGIN_INPUT(clangFlags, context);
   std::vector<std::string> ret;
+  ret.push_back("clang"); // dummy argv[0]
   return QUERY_END(ret);
 }
 
@@ -76,19 +77,6 @@ void initializeLlvmTargets() {
 }
 
 #ifdef HAVE_LLVM
-// Get the current clang executable path from printchplenv
-static std::string getClangExe(Context* context) {
-  std::string clangExe = "clang";
-  auto chplEnv = context->getChplEnv();
-  if (chplEnv) {
-    auto it = chplEnv->find("CHPL_LLVM_CLANG_C");
-    if (it != chplEnv->end()) {
-      clangExe = it->second;
-    }
-  }
-  return clangExe;
-}
-
 static std::string getChplLocaleModel(Context* context) {
   std::string result = "flat";
   auto chplEnv = context->getChplEnv();
@@ -115,14 +103,12 @@ const std::vector<std::string>& getCC1Arguments(Context* context,
   std::vector<std::string> result;
 
 #ifdef HAVE_LLVM
-  std::string clangExe = getClangExe(context);
-  std::vector<const char*> argsCstrs;
+  CHPL_ASSERT(args.size() > 0 && "clang to use should be arg 0");
 
-  argsCstrs.push_back(clangExe.c_str());
+  std::vector<const char*> argsCstrs;
   for (const auto& arg : args) {
     argsCstrs.push_back(arg.c_str());
   }
-
 
 
   // TODO: use a different triple when cross compiling
@@ -143,7 +129,7 @@ const std::vector<std::string>& getCC1Arguments(Context* context,
   auto diags = new clang::DiagnosticsEngine(diagID, &*diagOptions, diagClient);
 
   // takes ownership of all of the above
-  clang::driver::Driver D(clangExe, triple, *diags);
+  clang::driver::Driver D(argsCstrs[0], triple, *diags);
 
   std::unique_ptr<clang::driver::Compilation> C(D.BuildCompilation(argsCstrs));
 
@@ -232,21 +218,20 @@ createClangPrecompiledHeader(Context* context, ID externBlockId) {
     clang::CompilerInstance* Clang = new clang::CompilerInstance();
 
     // gather args to clang
-    const std::vector<std::string>& clFlags = clangFlags(context);
-    std::vector<std::string> args = clFlags;
+    std::vector<std::string> clFlags = clangFlags(context);
     // disable storing timestamps in precompiled headers
-    args.push_back("-Xclang");
-    args.push_back("-fno-pch-timestamp");
+    clFlags.push_back("-Xclang");
+    clFlags.push_back("-fno-pch-timestamp");
     // ask to generate a precompiled header
-    args.push_back("-x");
-    args.push_back("c-header");
+    clFlags.push_back("-x");
+    clFlags.push_back("c-header");
     // specify input
-    args.push_back(tmpInput);
+    clFlags.push_back(tmpInput);
     // specify output
-    args.push_back("-o");
-    args.push_back(tmpOutput);
+    clFlags.push_back("-o");
+    clFlags.push_back(tmpOutput);
     const std::vector<std::string>& cc1args =
-        getCC1Arguments(context, args, /* forGpuCodegen */ false);
+        getCC1Arguments(context, clFlags, /* forGpuCodegen */ false);
     std::vector<const char*> cc1argsCstrs;
     for (const auto& arg : cc1args) {
       cc1argsCstrs.push_back(arg.c_str());

--- a/frontend/lib/util/filesystem.cpp
+++ b/frontend/lib/util/filesystem.cpp
@@ -28,7 +28,13 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Process.h"
+
+// LLVM 13 introduced SHA256. Use that if it is available.
+#if LLVM_VERSION_MAJOR >= 13
 #include "llvm/Support/SHA256.h"
+#else
+#include "llvm/Support/SHA1.h"
+#endif
 
 #include <cerrno>
 
@@ -255,7 +261,11 @@ llvm::ErrorOr<HashFileResult> hashFile(const llvm::Twine& path) {
     return errorCodeFromCError(errno);
   }
 
+#if LLVM_VERSION_MAJOR >= 13
   llvm::SHA256 hasher;
+#else
+  llvm::SHA1 hasher;
+#endif
 
   uint8_t buf[256];
   while (true) {

--- a/frontend/test/clang/testClangCC1Args.cpp
+++ b/frontend/test/clang/testClangCC1Args.cpp
@@ -28,6 +28,8 @@ int main(int argc, char** argv) {
   std::string chpl_home;
   std::vector<std::string> clangArgs;
 
+  clangArgs.push_back("clang");
+
   for (int i = 1; i < argc; i++) {
     clangArgs.push_back(argv[i]);
   }

--- a/frontend/test/clang/testClangCC1Args.cpp
+++ b/frontend/test/clang/testClangCC1Args.cpp
@@ -32,6 +32,10 @@ int main(int argc, char** argv) {
     clangArgs.push_back(argv[i]);
   }
 
+  if (clangArgs.empty()) {
+    clangArgs.push_back("test.c");
+  }
+
   if (const char* chpl_home_env  = getenv("CHPL_HOME")) {
     chpl_home = chpl_home_env;
     printf("CHPL_HOME was set\n");


### PR DESCRIPTION
Follow-up to PR #21944

PR #21944 improved extern block in the dyno scope resolver by adding integration with clang. However, there were some problems with computing the correct clang arguments, especially when `CHPL_LLVM_GCC_PREFIX` is used. Additionally, there were problems with LLVM 11 and 12 since SHA256 was added to the LLVM Support library in LLVM 13. This PR fixes these problems.-

Reviewed by @riftEmber - thanks!

- [x] full local testing