### PR TITLE
"range generic" prototype

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,7 @@
+The branch `rd2` is my experiment of making ranges undefaulted generics.
+
+Also introducing:
+
+    type boundedRange = range(bounds = boundedKind.both, ?);
+    type simpleRange = range(int, boundedKind.both, strideKind.unit);
+

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -352,7 +352,7 @@ proc BlockCyclic.getStarts(inds, locid) {
   // TODO: Does using David's detupling trick work here?
   //
   var D: domain(rank, idxType, stridable=true);
-  var R: rank*range(idxType, stridable=true);
+  var R: rank*range(idxType, boundKind.both, stridable=true);
   for i in 0..rank-1 {
     var lo, hi: idxType;
     const domlo = inds.dim(i).lowBound,
@@ -533,13 +533,13 @@ iter BlockCyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
     // passed through nested loops correctly (or at all).
     for follow in locDom.myStarts.these(iterKind.leader, maxTasks, ignoreRunning, minSize) {
       for i in locDom.myStarts.these(iterKind.follower, follow, maxTasks, ignoreRunning, minSize) {
-        var retblock: rank*range(idxType);
+        var retblock: rank*range(idxType, boundKind.both, false);
         for param j in 0..rank-1 {
           const lo     = if rank == 1 then i else i(j);
           const dim    = whole.dim(j);
           const dimLow = dim.lowBound;
 
-          var temp : range(idxType, stridable=stridable);
+          var temp : range(idxType, boundKind.both, stridable=stridable);
           temp = max(lo, dimLow)..
                      min(lo + dist.blocksize(j):idxType-1, dim.highBound);
           temp     = dim[temp];
@@ -567,7 +567,7 @@ iter BlockCyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
 // stencil communication will be done on a per-locale basis.
 //
 iter BlockCyclicDom.these(param tag: iterKind, followThis) where tag == iterKind.follower {
-  var t: rank*range(idxType, stridable=stridable);
+  var t: rank*range(idxType, boundKind.both, stridable=stridable);
 
   for param i in 0..rank-1 {
     const curFollow = followThis(i);
@@ -995,7 +995,7 @@ iter BlockCyclicArr.these(param tag: iterKind) where tag == iterKind.leader {
 }
 
 iter BlockCyclicArr.these(param tag: iterKind, followThis) ref where tag == iterKind.follower {
-  var myFollowThis: rank*range(idxType=idxType, stridable=stridable);
+  var myFollowThis: rank*range(idxType=idxType, boundKind.both, stridable=stridable);
 
   for param i in 0..rank-1 {
     const curFollow = followThis(i);
@@ -1059,7 +1059,7 @@ iter do_dsiLocalSubdomains(indexDom) {
   const blockSizes = indexDom.globDom.dist.blocksize;
   const globDims = indexDom.globDom.whole.dims();
   foreach i in indexDom.myStarts {
-    var temp : rank*range(idxType);
+    var temp : rank*range(idxType, boundKind.both, false);
     for param j in 0..rank-1 {
       var lo: idxType;
       if rank == 1 then lo = i;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -714,7 +714,7 @@ iter Block.activeTargetLocales(const space : domain = boundingBox) {
   const locSpace = {(...space.dims())}; // make a local domain in case 'space' is distributed
   const low  = chpl__tuplify(targetLocsIdx(locSpace.low));
   const high = chpl__tuplify(targetLocsIdx(locSpace.high));
-  var dims : rank*range(low(0).type);
+  var dims : rank*range(low(0).type, boundKind.both, false);
   for param i in 0..rank-1 {
     dims(i) = low(i)..high(i);
   }
@@ -761,7 +761,7 @@ proc chpl__computeBlock(locid, targetLocBox:domain, boundingBox:domain,
                         boundingBoxDims /* boundingBox.dims() */) {
   param rank = targetLocBox.rank;
   type idxType = boundingBox.idxType;
-  var inds: rank*range(idxType);
+  var inds: rank*range(idxType, boundKind.both, false);
   for param i in 0..rank-1 {
     const lo = boundingBoxDims(i).lowBound;
     const hi = boundingBoxDims(i).highBound;
@@ -899,7 +899,8 @@ iter BlockDom.these(param tag: iterKind, followThis) where tag == iterKind.follo
   if chpl__testParFlag then
     chpl__testParWriteln("Block domain follower invoked on ", followThis);
 
-  var t: rank*range(idxType, stridable=stridable||anyStridable(followThis));
+  var t: rank*range(idxType, boundKind.both,
+                    stridable=stridable||anyStridable(followThis));
   for param i in 0..rank-1 {
     const wholeDim  = whole.dim(i);
     const followDim = followThis(i);
@@ -1224,7 +1225,7 @@ iter BlockArr.these(param tag: iterKind, followThis, param fast: bool = false) r
   if testFastFollowerOptimization then
     writeln((if fast then "fast" else "regular") + " follower invoked for Block array");
 
-  var myFollowThis: rank*range(idxType=idxType, stridable=stridable || anyStridable(followThis));
+  var myFollowThis: rank*range(idxType=idxType, boundKind.both, stridable=stridable || anyStridable(followThis));
   var lowIdx: rank*idxType;
 
   for param i in 0..rank-1 {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -441,7 +441,7 @@ proc Cyclic.dsiIndexToLocale(i: rank*idxType) {
 proc chpl__computeCyclic(type idxType, locid, targetLocBox, startIdx) {
     type strType = chpl__signedType(idxType);
     param rank = targetLocBox.size;
-    var inds: rank*range(idxType, stridable=true);
+    var inds: rank*range(idxType, boundKind.both, stridable=true);
     for param i in 0..rank-1 {
       // NOTE: Not bothering to check to see if these can fit into idxType
       const lo = chpl__tuplify(startIdx)(i): idxType;
@@ -473,7 +473,7 @@ class LocCyclic {
     else
       for param i in 0..rank-1 do locidx(i) = locid(i):idxType;
 
-    var inds: rank*range(idxType, stridable=true);
+    var inds: rank*range(idxType, boundKind.both, stridable=true);
 
     inds = chpl__computeCyclic(idxType, locid, distLocDims, startIdx);
     myChunk = {(...inds)};
@@ -646,7 +646,7 @@ iter CyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
       // distribution (at least, I couldn't figure out a way to not go
       // back and forth without breaking tests)
       const zeroShift = {(...newFollowThis)}.chpl__unTranslate(wholeLow);
-      var result: rank*range(idxType=idxType, stridable=true);
+      var result: rank*range(idxType=idxType, boundKind.both, stridable=true);
       type strType = chpl__signedType(idxType);
       for param i in 0..rank-1 {
         const wholestride = chpl__tuplify(wholeStride)(i);
@@ -662,7 +662,7 @@ iter CyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
 // of 'whole'
 private proc chpl__followThisToOrig(type idxType, followThis, whole) {
   param rank = followThis.size;
-  var t: rank*range(idxType, stridable=true);
+  var t: rank*range(idxType, boundKind.both, stridable=true);
   if debugCyclicDist then
     writeln(here.id, ": follower whole is: ", whole,
                      " follower is: ", followThis);
@@ -964,7 +964,7 @@ iter CyclicArr.these(param tag: iterKind, followThis, param fast: bool = false) 
   if testFastFollowerOptimization then
     writeln((if fast then "fast" else "regular") + " follower invoked for Cyclic array");
 
-  var t: rank*range(idxType=idxType, stridable=true);
+  var t: rank*range(idxType=idxType, boundKind.both, stridable=true);
   for param i in 0..rank-1 {
     type strType = chpl__signedType(idxType);
     const wholestride = dom.whole.dim(i).stride:chpl__signedType(idxType);
@@ -1142,7 +1142,7 @@ where canDoAnyToCyclic(this, destDom, Src, srcDom) {
         const end = bulkCommConvertCoordinate(regionDest.last, destDom, srcDom);
         const sb  = chpl__tuplify(regionSrc.stride);
 
-        var r1,r2: rank * range(idxType = el,stridable = true);
+        var r1,r2: rank * range(idxType = el, boundKind.both, stridable = true);
         r2 = regionDest.dims();
         //In the case that the number of elements in dimension t for r1 and r2
         //were different, we need to calculate the correct stride in r1
@@ -1184,7 +1184,7 @@ where useBulkTransferDist {
 
         //r2 is the domain to refer the elements of A in locale j
         //r1 is the domain to refer the corresponding elements of Dest
-        var r1,r2: rank * range(idxType = el,stridable = true);
+        var r1,r2: rank * range(idxType = el, boundKind.both, stridable = true);
         r2 = inters.dims();
 
         //In the case that the number of elements in dimension t for r1 and r2
@@ -1226,7 +1226,7 @@ where useBulkTransferDist {
         const end = bulkCommConvertCoordinate(inters.last, destDom, srcDom);
         const sb  = chpl__tuplify(srcDom.stride);
 
-        var r1,r2: rank * range(idxType = el,stridable = true);
+        var r1,r2: rank * range(idxType = el, boundKind.both, stridable = true);
         r2 = inters.dims();
         //In the case that the number of elements in dimension t for r1 and r2
         //were different, we need to calculate the correct stride in r1

--- a/modules/dists/DSIUtil.chpl
+++ b/modules/dists/DSIUtil.chpl
@@ -498,7 +498,7 @@ proc setupTargetLocalesArray(ref targetLocDom, targetLocArr, specifiedLocArr) {
   param rank = targetLocDom.rank;
   if rank != 1 && specifiedLocArr.rank == 1 {
     const factors = _factor(rank, specifiedLocArr.size);
-    var ranges: rank*range;
+    var ranges: rank*simpleRange;
     for param i in 0..rank-1 do
       ranges(i) = 0..#factors(i);
     targetLocDom = {(...ranges)};
@@ -506,7 +506,7 @@ proc setupTargetLocalesArray(ref targetLocDom, targetLocArr, specifiedLocArr) {
   } else {
     if specifiedLocArr.rank != rank then
       compilerError("specified target array of locales must equal 1 or distribution rank");
-    var ranges: rank*range;
+    var ranges: rank*simpleRange;
     for param i in 0..rank-1 do
       ranges(i) = 0..#specifiedLocArr.domain.dim(i).sizeAs(int);
     targetLocDom = {(...ranges)};
@@ -515,7 +515,7 @@ proc setupTargetLocalesArray(ref targetLocDom, targetLocArr, specifiedLocArr) {
 }
 
 proc setupTargetLocRanges(param rank, specifiedLocArr) {
-  var ranges: rank*range;
+  var ranges: rank*simpleRange;
 
   if rank != 1 && specifiedLocArr.rank == 1 {
     const factors = _factor(rank, specifiedLocArr.size);
@@ -612,7 +612,7 @@ proc bulkCommTranslateDomain(srcSlice : domain, srcDom : domain, targetDom : dom
   // {1..20 by 4} in {1..20} to {101..120} = {101..120 by 4}
   param needsStridable = targetDom.stridable || srcSlice.stridable;
   var rngs = targetDom.dims() :
-             (targetDom.rank*range(targetDom.idxType,stridable=needsStridable));
+             (targetDom.rank*range(targetDom.idxType, boundKind.both, stridable=needsStridable));
 
   for i in 0..inferredRank-1 {
     const SD    = SrcActives(i);

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -320,7 +320,7 @@ class DimensionalDom : BaseRectangularDom {
 
   // replace this with 'this.stridable' for simplicity?
   proc stoStridable param do  return stoStridableDom(stoIndexT, dom1, dom2);
-  proc stoRangeT type do  return range(stoIndexT, stridable = stoStridable);
+  proc stoRangeT type do  return range(stoIndexT, boundKind.both, stoStridable);
   proc stoDomainT type do  return domain(rank, stoIndexT, stoStridable);
 
   // convenience - our instantiation of LocDimensionalDom

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -100,9 +100,7 @@ class PrivateDom: BaseRectangularDom {
 
   iter these(param tag: iterKind) where tag == iterKind.leader {
     coforall loc in Locales do on loc {
-      var t: 1*range(idxType);
-      t(0) = here.id..here.id;
-      yield t;
+      yield ((here.id..here.id): range(idxType, boundKind.both, false), );  //1*range
     }
   }
 
@@ -295,9 +293,7 @@ iter PrivateArr.these() ref {
 
 iter PrivateArr.these(param tag: iterKind) where tag == iterKind.leader {
   coforall loc in Locales do on loc {
-    var t: 1*range(idxType);
-    t(0) = here.id..here.id;
-    yield t;
+    yield ((here.id..here.id): range(idxType, boundKind.both, false), );  //1*range
   }
 }
 

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -183,7 +183,7 @@ class SparseBlockDom: BaseSparseDomImpl {
 
     if !dataSorted then sort(inds, comparator=comp);
 
-    var localeRanges: [dist.targetLocDom] range;
+    var localeRanges: [dist.targetLocDom] simpleRange;
     on inds {
       for l in dist.targetLocDom {
         const blockval = locDoms[l]!.mySparseBlock._value;

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -646,7 +646,7 @@ iter Stencil.activeTargetLocales(const space : domain = boundingBox) {
   const locSpace = {(...space.dims())}; // make a local domain in case 'space' is distributed
   const low = chpl__tuplify(targetLocsIdx(locSpace.first));
   const high = chpl__tuplify(targetLocsIdx(locSpace.last));
-  var dims : rank*range(low(0).type);
+  var dims : rank*range(low(0).type, boundKind.both, false);
   for param i in 0..rank-1 {
     dims(i) = low(i)..high(i);
   }
@@ -674,7 +674,7 @@ iter Stencil.activeTargetLocales(const space : domain = boundingBox) {
 proc chpl__computeBlock(locid, targetLocBox, boundingBox) {
   param rank = targetLocBox.rank;
   type idxType = chpl__tuplify(boundingBox)(0).idxType;
-  var inds: rank*range(idxType);
+  var inds: rank*range(idxType, boundKind.both, false);
   for param i in 0..rank-1 {
     const lo = boundingBox.dim(i).lowBound;
     const hi = boundingBox.dim(i).highBound;
@@ -803,7 +803,8 @@ iter StencilDom.these(param tag: iterKind, followThis) where tag == iterKind.fol
   if chpl__testParFlag then
     chpl__testPar("Stencil domain follower invoked on ", followThis);
 
-  var t: rank*range(idxType, stridable=stridable||anyStridable(followThis));
+  var t: rank*range(idxType, boundKind.both,
+                    stridable=stridable||anyStridable(followThis));
   for param i in 0..rank-1 {
     const wholeDim  = whole.dim(i);
     const followDim = followThis(i);
@@ -928,7 +929,7 @@ proc StencilDom.dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
 
 // Create a domain that points to the nearest neighboring locales
 private proc nearestDom(param rank) {
-  var nearest : rank*range;
+  var nearest : rank*simpleRange;
   for param i in 0..rank-1 do nearest(i) = -1..1;
   const ND : domain(rank) = nearest;
   return ND;
@@ -1313,7 +1314,7 @@ iter StencilArr.these(param tag: iterKind, followThis, param fast: bool = false)
   if testFastFollowerOptimization then
     writeln((if fast then "fast" else "regular") + " follower invoked for Stencil array");
 
-  var myFollowThis: rank*range(idxType=idxType, stridable=stridable || anyStridable(followThis));
+  var myFollowThis: rank*range(idxType=idxType, boundKind.both, stridable=stridable || anyStridable(followThis));
   var lowIdx: rank*idxType;
 
   for param i in 0..rank-1 {

--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -422,7 +422,7 @@ inline proc BlockCyclic1dom._dsiStorageIdx(ind: idxType) do
 // oblivious of 'wholeR'
 inline proc BlockCyclic1dom._dsiIndicesOnCycLoc(cycNo: idxType, locNo: locIdT,
                                                 param zerobased)
-  : range(idxType)
+  : range(idxType, boundKind.both, false)
 {
   const startCycle = mulP2(cycNo, cycleSizePos) -
     // cycNo*cycleSize may be <adjLowIdx, subtraction would wrap for unsigned
@@ -568,7 +568,7 @@ inline proc BlockCyclic1dom._dsiStorageHigh(locId: locIdT): stoIndexT {
   return hiCycNo * storagePerCycle:stoIndexT + hiIdxAdj;
 }
 
-proc BlockCyclic1locdom.dsiSetLocalIndices1d(globDD, locId: locIdT): range(stoIndexT) {
+proc BlockCyclic1locdom.dsiSetLocalIndices1d(globDD, locId: locIdT): range(stoIndexT, boundKind.both, false) {
   const stoLow = globDD._dsiStorageLow(locId);
   const stoHigh = globDD._dsiStorageHigh(locId);
 
@@ -692,7 +692,7 @@ proc BlockCyclic1locdom.dsiMyDensifiedRangeForTaskID1d(globDD, taskid:int, numTa
   type resultIdxType = globDD.idxType;
   // Ensure it is the same as dsiMyDensifiedRangeType1d(globDD).idxType.
   // Have to do it a bit indirectly.
-  compilerAssert(range(idxType=resultIdxType, stridable=globDD.stridable)
+  compilerAssert(range(idxType=resultIdxType, boundKind.both, stridable=globDD.stridable)
                  == dsiMyDensifiedRangeType1d(globDD));
 
   // Assume 2*numLocales always fits in 31 bits, so we can skip this check
@@ -723,7 +723,7 @@ proc BlockCyclic1locdom.dsiMyDensifiedRangeForTaskID1d(globDD, taskid:int, numTa
 }
 
 proc BlockCyclic1locdom.dsiMyDensifiedRangeType1d(globDD) type do
-  return range(idxType=globDD.idxType, stridable=globDD.stridable);
+  return range(idxType=globDD.idxType, boundKind.both, stridable=globDD.stridable);
 
 proc BlockCyclic1locdom.dsiLocalSliceStorageIndices1d(globDD, sliceRange)
   : range(stoIndexT, sliceRange.bounds, false)

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -186,7 +186,7 @@ proc BlockDim.dsiNewRectangularDom1d(type idxType, param stridable: bool,
 proc Block1dom.dsiIsReplicated1d() param do return false;
 
 proc Block1dom.dsiNewLocalDom1d(type stoIndexT, locId: locIdT) {
-  var defaultVal: range(stoIndexT, stridable=this.stridable);
+  var defaultVal: range(stoIndexT, boundKind.both, this.stridable);
   return new Block1locdom(myRange = defaultVal);
 }
 
@@ -251,7 +251,7 @@ proc Block1dom.dsiAccess1d(indexx: idxType): (locIdT, idxType) {
 
 iter Block1locdom.dsiMyDensifiedRangeForSingleTask1d(globDD) {
   const locRange = densify(myRange, globDD.wholeR, userErrors=false);
-  yield locRange: range(globDD.idxType);
+  yield locRange: range(globDD.idxType, boundKind.both, false);
 }
 
 proc Block1dom.dsiSingleTaskPerLocaleOnly1d() param do return false;
@@ -268,7 +268,7 @@ proc Block1locdom.dsiMyDensifiedRangeForTaskID1d(globDD, taskid:int, numTasks:in
 }
 
 proc Block1locdom.dsiMyDensifiedRangeType1d(globDD) type do
-  return range(globDD.idxType);
+  return range(globDD.idxType, boundKind.both, false);
 
 iter Block1dom.dsiSerialArrayIterator1d() {
   // The Block distribution assigns indices to locales contiguously and

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -85,7 +85,7 @@ record Replicated1locdom {
   type stoIndexT;
   param stridable;
   // our copy of wholeR
-  var locWholeR: range(stoIndexT, stridable=stridable);
+  var locWholeR: range(stoIndexT, boundKind.both, stridable=stridable);
 }
 
 
@@ -300,7 +300,7 @@ proc Replicated1locdom.dsiMyDensifiedRangeForTaskID1d(globDD, taskid:int, numTas
 // REQ the range type returned/yielded by dsiMyDensifiedRangeForSingleTask1d()
 // and (if applicable) by dsiMyDensifiedRangeForTaskID1d().
 proc Replicated1locdom.dsiMyDensifiedRangeType1d(globDD) type do
-  return range(globDD.idxType);
+  return range(globDD.idxType, boundKind.both, false);
 
 // REQ-2 if !dsiStorageUsesUserIndices
 // Returns a range of storage indices corresponding to the user indices

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -771,7 +771,7 @@ module ArrayViewReindex {
       compilerError("Called chpl_reindexConvertDomMaybeSlice with incorrect rank. Got " + dims.size:string + ", expecting " + updom.rank:string);
     }
 
-    var ranges : downdom.rank * range(downdom.idxType, stridable=downdom.stridable || dims(0).stridable);
+    var ranges : downdom.rank * range(downdom.idxType, boundKind.both, stridable=downdom.stridable || dims(0).stridable);
     var actualLow, actualHigh: downdom.rank*downdom.idxType;
     for param d in 0..dims.size-1 {
       if (dims(d).sizeAs(int) == 0) {

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -362,7 +362,7 @@ module Bytes {
     :returns: The indices that can be used to index into the bytes
               (i.e., the range ``0..<this.size``)
   */
-  proc bytes.indices : range do return 0..<size;
+  proc bytes.indices : simpleRange do return 0..<size;
 
   /*
     :returns: The number of bytes in the :type:`bytes`.

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2491,7 +2491,7 @@ module ChapelDomain {
         for param dim in 0..inds.size-1 {
           if inds(dim).stride != 1 then
             halt("non-stridable domain assigned non-unit stride in dimension ", dim);
-          unstridableInds(dim) = inds(dim).safeCast(range(tmpD.idxType,
+          unstridableInds(dim) = inds(dim).safeCast(range(tmpD.idxType, boundKind.both,
                                                           stridable=false));
         }
         tmpD.setIndices(unstridableInds);

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1223,7 +1223,7 @@ module ChapelDomain {
       var idx: rank*idxType;
       param uprank = chpl__countRanges((...args));
       param upstridable = this.stridable || chpl__anyRankChangeStridable(args);
-      var upranges: uprank*range(idxType=_value.idxType,
+      var upranges: uprank*range(idxType=_value.idxType, boundKind.both,
                                  stridable=upstridable);
       var updim = 0;
 
@@ -2486,7 +2486,7 @@ module ChapelDomain {
         return this;
       else if !tmpD.stridable && this.stridable {
         const inds = this.getIndices();
-        var unstridableInds: rank*range(tmpD.idxType, stridable=false);
+        var unstridableInds: rank*range(tmpD.idxType, boundKind.both, stridable=false);
 
         for param dim in 0..inds.size-1 {
           if inds(dim).stride != 1 then
@@ -2575,10 +2575,10 @@ module ChapelDomain {
         return d;
       else if !tmpD.stridable && d.stridable {
         var inds = d.getIndices();
-        var unstridableInds: d.rank*range(tmpD.idxType, stridable=false);
+        var unstridableInds: d.rank*range(tmpD.idxType, boundKind.both, stridable=false);
 
         for param i in 0..tmpD.rank-1 {
-          unstridableInds(i) = inds(i):range(tmpD.idxType, stridable=false);
+          unstridableInds(i) = inds(i):range(tmpD.idxType, boundKind.both, stridable=false);
         }
         tmpD.setIndices(unstridableInds);
         return tmpD;

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -102,9 +102,9 @@ module ChapelRange {
   pragma "range"
   record range
   {
-    type idxType = int;                            // element type
-    param bounds: boundKind = boundKind.both;      // lower/upper bounds
-    param stridable: bool = false;                 // range can be strided
+    type idxType;                 // element type
+    param bounds: boundKind;      // lower/upper bounds
+    param stridable: bool;        // range can be strided
 
     // deprecated by Vass in 1.31 to implement #17126
     @deprecated("range.boundedType is deprecated; please use '.bounds' instead")
@@ -122,6 +122,10 @@ module ChapelRange {
       return idxType;
     }
   }
+
+  // convenience aliases
+  type boundedRange = range(bounds = boundKind.both, ?);
+  type simpleRange = range(int, boundKind.both, false);
 
   /* The ``idxType`` as represented by an integer type.  When
      ``idxType`` is an enum type, this evaluates to ``int``.
@@ -204,6 +208,7 @@ module ChapelRange {
   proc range.init(type idxType, low: idxType, high: idxType) {
     this.idxType = idxType;
     this.bounds = boundKind.both;
+    this.stridable = false;
     this._low = chpl__idxToInt(low);
     this._high = chpl__idxToInt(high);
   }
@@ -214,6 +219,7 @@ module ChapelRange {
   proc range.init(low: ?t) {
     this.idxType = t;
     this.bounds = boundKind.low;
+    this.stridable = false;
     this._low = chpl__idxToInt(low);
     this.complete();
     if isFiniteIdxType(idxType) {
@@ -227,6 +233,7 @@ module ChapelRange {
   proc range.init(high: ?t) {
     this.idxType = t;
     this.bounds = boundKind.high;
+    this.stridable = false;
     this._high = chpl__idxToInt(high);
     this.complete();
     if isFiniteIdxType(idxType) {
@@ -240,6 +247,7 @@ module ChapelRange {
   proc range.init() {
     this.idxType = int;
     this.bounds = boundKind.neither;
+    this.stridable = false;
     this.complete();
     if isFiniteIdxType(idxType) {
       this._low = finiteIdxTypeLow(idxType);
@@ -2980,7 +2988,7 @@ operator :(r: range(?), type t: range(?)) {
       }
 
       if this.stridable || myFollowThis.stridable {
-        var r: range(idxType, stridable=true);
+        var r: range(idxType, boundKind.both, stridable=true);
 
         if flwlen != 0 {
           const stride = this.stride * myFollowThis.stride;
@@ -2999,7 +3007,7 @@ operator :(r: range(?), type t: range(?)) {
           yield i;
 
       } else {
-        var r:range(idxType);
+        var r:range(idxType, boundKind.both, false);
 
         if flwlen != 0 {
           const low = this.orderToIndex(myFollowThis.first);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -400,10 +400,10 @@ module DefaultRectangular {
             const numSublocTasks = (if chunk < dptpl % numChunks
                                     then dptpl / numChunks + 1
                                     else dptpl / numChunks);
-            var locBlock: rank*range(intIdxType);
+            var locBlock: rank*range(intIdxType, boundKind.both, false);
             for param i in 0..rank-1 do
               locBlock(i) = offset(i)..#(ranges(i).sizeAs(intIdxType));
-            var followMe: rank*range(intIdxType) = locBlock;
+            var followMe = locBlock;
             const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(intIdxType),
                                           numChunks, chunk,
                                           locBlock(parDim)._high,
@@ -415,13 +415,10 @@ module DefaultRectangular {
                                                              minIndicesPerTask,
                                                              followMe);
             coforall chunk2 in 0..#numChunks2 {
-              var locBlock2: rank*range(intIdxType);
-              for param i in 0..rank-1 do
-                locBlock2(i) = followMe(i).lowBound..followMe(i).highBound;
-              var followMe2: rank*range(intIdxType) = locBlock2;
-              const low  = locBlock2(parDim2)._low,
-                high = locBlock2(parDim2)._high;
-              const (lo,hi) = _computeBlock(locBlock2(parDim2).sizeAs(intIdxType),
+              var followMe2 = followMe;
+              const low  = followMe(parDim2)._low,
+                high = followMe(parDim2)._high;
+              const (lo,hi) = _computeBlock(followMe(parDim2).sizeAs(intIdxType),
                                             numChunks2, chunk2,
                                             high, low, low);
               followMe2(parDim2) = lo..hi;
@@ -462,13 +459,13 @@ module DefaultRectangular {
                   "### nranges = ", ranges);
         }
 
-        var locBlock: rank*range(intIdxType);
+        var locBlock: rank*range(intIdxType, boundKind.both, false);
         for param i in 0..rank-1 do
           locBlock(i) = offset(i)..#(ranges(i).sizeAs(intIdxType));
         if debugDefaultDist then
           chpl_debug_writeln("*** DI: locBlock = ", locBlock);
         coforall chunk in 0..#numChunks {
-          var followMe: rank*range(intIdxType) = locBlock;
+          var followMe = locBlock;
           const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(intIdxType),
                                         numChunks, chunk,
                                         locBlock(parDim)._high,
@@ -504,7 +501,7 @@ module DefaultRectangular {
         chpl_debug_writeln("In domain follower code: Following ", followThis);
 
       param stridable = this.stridable || anyStridable(followThis);
-      var block: rank*range(idxType=intIdxType, stridable=stridable);
+      var block: rank*range(idxType=intIdxType, boundKind.both, stridable=stridable);
       if boundsChecking then
         for param i in 0..rank-1 do
           if followThis(i).highBound >= ranges(i).sizeAs(uint) then
@@ -685,7 +682,7 @@ module DefaultRectangular {
 
     proc dsiBuildArrayWith(type eltType, data:_ddata(eltType), allocSize:int) {
 
-      var allocRange:range(idxType) = (ranges(0).lowBound)..#allocSize;
+      var allocRange:range(idxType,?) = (ranges(0).lowBound)..#allocSize;
       return new unmanaged DefaultRectangularArr(eltType=eltType,
                                        rank=rank,
                                        idxType=idxType,

--- a/modules/internal/ISO_Fortran_binding.chpl
+++ b/modules/internal/ISO_Fortran_binding.chpl
@@ -193,7 +193,7 @@ module ISO_Fortran_binding {
       cumulativeLength *= FA.dim[i-1].extent;
     }
 
-    var dims: rank*range;
+    var dims: rank*simpleRange;
     for param i in 0..<rank {
       assert(FA.dim[i].lower_bound == 0);
       dims[i] = 1..#FA.dim[i].extent;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1068,7 +1068,7 @@ module String {
     :returns: The indices that can be used to index into the string
               (i.e., the range ``0..<this.size``)
   */
-  inline proc string.indices : range do return 0..<size;
+  inline proc string.indices : simpleRange do return 0..<size;
 
   /*
     :returns: The number of bytes in the string.
@@ -1507,7 +1507,7 @@ module String {
    */
 
   inline proc string.find(pattern: string,
-                          indices: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
+                          indices: range(?) = this.byteIndices:range(byteIndex, boundKind.both, false)) : byteIndex {
     if this.isASCII() then
       return doSearchNoEnc(this, pattern, indices, count=false): byteIndex;
     else
@@ -1524,7 +1524,7 @@ module String {
               within a string, or -1 if the `pattern` is not in the string.
    */
   inline proc string.rfind(pattern: string,
-                           indices: range(?) = this.byteIndices:range(byteIndex)) : byteIndex {
+                           indices: range(?) = this.byteIndices:range(byteIndex, boundKind.both, false)) : byteIndex {
     if this.isASCII() then
       return doSearchNoEnc(this, pattern, indices,
                            count=false, fromLeft=false): byteIndex;

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -111,8 +111,8 @@ class CSDom: BaseSparseDomImpl {
   param stridable;
   var dist: unmanaged CS(compressRows,sortedIndices);
 
-  var rowRange: range(idxType, stridable=stridable);
-  var colRange: range(idxType, stridable=stridable);
+  var rowRange: range(idxType, boundKind.both, stridable=stridable);
+  var colRange: range(idxType, boundKind.both, stridable=stridable);
 
   /* (row|col) startIdxDom */
   var startIdxDom: domain(1, idxType);

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -1999,8 +1999,8 @@ module ArgumentParser {
 
   // helper to prepare numArgs ranges for use
   pragma "no doc"
-  proc _prepareRange(rIn: range(?)) : range throws {
-    var nArgs:range;
+  proc _prepareRange(rIn: range(?)) : simpleRange throws { // bug: should be able to have the generic 'range' for the ret. type 
+    var nArgs:simpleRange;
     if rIn.hasLowBound() && !rIn.hasHighBound() {
       nArgs = rIn.low..max(int);
     } else if !rIn.hasLowBound() {

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -1999,7 +1999,7 @@ module ArgumentParser {
 
   // helper to prepare numArgs ranges for use
   pragma "no doc"
-  proc _prepareRange(rIn: range(?)) : simpleRange throws { // bug: should be able to have the generic 'range' for the ret. type 
+  proc _prepareRange(rIn: range(?)) : simpleRange throws { // bug: should be able to have the generic 'range' for the ret. type
     var nArgs:simpleRange;
     if rIn.hasLowBound() && !rIn.hasHighBound() {
       nArgs = rIn.low..max(int);

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3573,7 +3573,7 @@ module HDF5 {
       var data: [0..# (* reduce dims)] eltType;
       readHDF5Dataset(file_id, dsetName, data);
 
-      var rngTup: rank*range;
+      var rngTup: rank*simpleRange;
       for param i in 0..rank-1 do rngTup[i] = 1..dims[i]:int;
 
       const D = {(...rngTup)};

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3832,7 +3832,7 @@ module HDF5 {
         // using 1-based domains for the yielded arrays.
         //
         //var positionalRangeTup: outRank * range,
-        var rangeTup: outRank * range;
+        var rangeTup: outRank * simpleRange;
 
         var inOffsetArr, inCountArr,
             outOffsetArr, outCountArr: [0..#outRank] C_HDF5.hsize_t;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1475,7 +1475,7 @@ module SampleSortHelp {
       return numBuckets * (1 + equalBuckets:int);
     }
     proc getBinsToRecursivelySort() {
-      var r:range(stridable=true);
+      var r:range(int, boundKind.both, true);
       if equalBuckets {
         // odd bins will be equality buckets
         r = (0..(getNumBuckets()-1)) by 2;

--- a/modules/packages/UnrolledLinkedList.chpl
+++ b/modules/packages/UnrolledLinkedList.chpl
@@ -447,7 +447,7 @@ module UnrolledLinkedList {
       :rtype: `range`
     */
     proc ref append(other: list(eltType, ?p)) lifetime this < other {
-      var ret: range;
+      var ret: simpleRange;
       on this {
         _enter();
         ret = _appendGeneric(other);
@@ -468,7 +468,7 @@ module UnrolledLinkedList {
       :rtype: `range`
     */
     proc ref append(other: unrolledLinkedList(eltType, ?p)) lifetime this < other {
-      var ret: range;
+      var ret: simpleRange;
       on this {
         _enter();
         ret = _appendGeneric(other);
@@ -489,7 +489,7 @@ module UnrolledLinkedList {
       :rtype: `range`
     */
     proc ref append(other: [?d] eltType) lifetime this < other {
-      var ret: range;
+      var ret: simpleRange;
       on this {
         _enter();
         ret = _appendGeneric(other);
@@ -521,7 +521,7 @@ module UnrolledLinkedList {
         compilerError(msg);
       }
 
-      var ret: range;
+      var ret: simpleRange;
       on this {
         _enter();
         ret = _appendGeneric(other);

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -749,7 +749,7 @@ module List {
       :rtype: `range`
     */
     proc ref append(other: list(eltType, ?p)) lifetime this < other {
-      var ret: range;
+      var ret: simpleRange;
       on this {
         _enter();
         ret = _appendGeneric(other);
@@ -771,7 +771,7 @@ module List {
       :rtype: `range`
     */
     proc ref append(other: [?d] eltType) lifetime this < other {
-      var ret: range;
+      var ret: simpleRange;
       on this {
         _enter();
         ret = _appendGeneric(other);
@@ -801,7 +801,7 @@ module List {
         param msg = "Cannot extend " + e + " with unbounded " + f;
         compilerError(msg);
       }
-      var ret: range;
+      var ret: simpleRange;
       on this {
         _enter();
         ret = _appendGeneric(other);

--- a/test/arrays/deitz/part7/test_error_stride_range.chpl
+++ b/test/arrays/deitz/part7/test_error_stride_range.chpl
@@ -1,4 +1,4 @@
-var r : range;
+var r : simpleRange; /*autofix*/
 r = 1..5;
 for i in r do writeln(i);
 r = 1..5 by 2;

--- a/test/associative/bharshbarg/domains/rangeBad.chpl
+++ b/test/associative/bharshbarg/domains/rangeBad.chpl
@@ -1,3 +1,3 @@
 
-var D : domain(range);
+var D : domain(simpleRange);
 var A : [D] int;

--- a/test/associative/bharshbarg/domains/recordWithRange.chpl
+++ b/test/associative/bharshbarg/domains/recordWithRange.chpl
@@ -3,7 +3,7 @@ use List;
 config const n = 100;
 
 record R {
-  var x : range;
+  var x : simpleRange;
 }
 
 operator R.<(x:R, y:R) {

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
@@ -1,5 +1,5 @@
 record R {
-  var isRange: range;
+  var isRange: simpleRange; /*autofix*/
 
   var boundedRange = 1..10;
   var lowBoundedRange = 1..;

--- a/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
+++ b/test/chpldoc/types/fields/rangesAndDomains.doc.chpl
@@ -1,5 +1,5 @@
 record R {
-  var isRange: simpleRange; /*autofix*/
+  var isRange: range;  // should be simpleRange
 
   var boundedRange = 1..10;
   var lowBoundedRange = 1..;

--- a/test/classes/bradc/overloadMethods/v2NoReturnValueButType.chpl
+++ b/test/classes/bradc/overloadMethods/v2NoReturnValueButType.chpl
@@ -1,5 +1,5 @@
 class C {
-  proc bbox(x: int): range {
+  proc bbox(x: int): simpleRange {
     halt("bbox() not implemented for this class");
   }
 }

--- a/test/classes/forwarding/forwardIterator.chpl
+++ b/test/classes/forwarding/forwardIterator.chpl
@@ -8,7 +8,7 @@ record Foo {
 }
 
 class Bar {
-  var r: range;
+  var r: simpleRange; /*autofix*/
 
   proc init(num: int) {
     r = 0..#num;

--- a/test/classes/initializers/generics/overloading.chpl
+++ b/test/classes/initializers/generics/overloading.chpl
@@ -1,5 +1,5 @@
 class C {
-  proc bbox(x: int): range {
+  proc bbox(x: int): simpleRange {  // get an error if return type is generic
     halt("bbox() not implemented for this class");
   }
 }

--- a/test/classes/initializers/records/const-record.chpl
+++ b/test/classes/initializers/records/const-record.chpl
@@ -1,6 +1,6 @@
 
 record Foo {
-  var x : 3*range;
+  var x : 3*simpleRange; // could be generic if we fix implementation
 
   proc init() {
     x = (1..1, 1..2, 1..3);

--- a/test/classes/vass/generic-method-with-param-arg-1.chpl
+++ b/test/classes/vass/generic-method-with-param-arg-1.chpl
@@ -1,21 +1,21 @@
-override proc DefaultRectangularArr.getAllocationDomainForDefaultRectangularArray3(): 3 * range(int(64), stridable=true)
+override proc DefaultRectangularArr.getAllocationDomainForDefaultRectangularArray3(): 3 * range(int(64), boundKind.both, stridable=true)  // could be generic if we fix implementation
 {
   param rank = 3;
   if this.dom.dsiNumIndices == 1000000 {
     return (this:BaseArr).getAllocationDomainForDefaultRectangularArray3();
   } else {
-    var p:rank * range(int(64), stridable=true);
+    var p:rank * range(int(64), boundKind.both, stridable=true);
     for i in 0..#rank do
       p(i)=dom.ranges(i);
     return p;
   }
 }
 
-proc BaseArr.getAllocationDomainForDefaultRectangularArray3(): 3 * range(int(64), stridable=true)
+proc BaseArr.getAllocationDomainForDefaultRectangularArray3(): 3 * range(int(64), boundKind.both, stridable=true)  // could be generic if we fix implementation
 {
   param rank = 3;
    halt("getAllocationDomainForDefaultRectangularArray:non-DefaultRectangular array encountered");
-   var dummy: rank * range(int(64), stridable=true);
+   var dummy: rank * range(int(64), boundKind.both, stridable=true);
    return dummy;
 }
 

--- a/test/classes/vass/generic-method-with-param-arg-4.chpl
+++ b/test/classes/vass/generic-method-with-param-arg-4.chpl
@@ -1,13 +1,13 @@
 class C {
-  proc a(param rank): rank * range(int(64), stridable=true) {
-    var dummy: rank * range(int(64), stridable=true);
+  proc a(param rank): rank * range(int(64), boundKind.both, stridable=true) {  // could be generic if we fix implementation
+    var dummy: rank * range(int(64), boundKind.both, stridable=true);
     return dummy;
   }
 }
 
 class D: C {
-  override proc a(param rank): rank * range(int(64), stridable=true) {
-    var dummy: rank * range(int(64), stridable=true);
+  override proc a(param rank): rank * range(int(64), boundKind.both, stridable=true) {  // could be generic if we fix implementation
+    var dummy: rank * range(int(64), boundKind.both, stridable=true);
     return dummy;
   }
 }

--- a/test/deprecated/boundedRangeType.chpl
+++ b/test/deprecated/boundedRangeType.chpl
@@ -13,8 +13,8 @@ writeln(brt);
 
 // NB deprecating `range(boundedType=...)` required changing AggregateType.cpp
 var r: range(boundedType =              // d: boundedType
-  BoundedRangeType.boundedHigh);        // d: BoundedRangeType, boundedHigh
-
+  BoundedRangeType.boundedHigh,         // d: BoundedRangeType, boundedHigh
+  int, false);
 compilerWarning(r.boundedType:string);  // d: boundedType
 
 // NB deprecating `range(boundedType=?B)` required changing preFold.cpp

--- a/test/distributions/bharshbarg/blockCyclic/indexing.chpl
+++ b/test/distributions/bharshbarg/blockCyclic/indexing.chpl
@@ -41,7 +41,7 @@ iter blockIter(param r : int) {
 proc main() {
   if n < 1 then halt("config 'n' must be >= 1.");
 
-  var dims : rank*range;
+  var dims : rank*simpleRange;
   for param i in 0..rank-1 {
     dims(i) = 1..n;
   }

--- a/test/distributions/bharshbarg/stencil/util.chpl
+++ b/test/distributions/bharshbarg/stencil/util.chpl
@@ -6,7 +6,7 @@ proc verifyStencil(A : [?dom], debug = false) {
   assert(dom._value.periodic);
   var Neighs : domain(rank);
   {
-    var n : rank*range;
+    var n : rank*simpleRange;
     for i in 0..#rank do n(i) = -1..1;
     Neighs = {(...n)};
   }

--- a/test/distributions/bradc/wrongDomForDist/DummyArithDist.chpl
+++ b/test/distributions/bradc/wrongDomForDist/DummyArithDist.chpl
@@ -16,7 +16,7 @@ class MyDom : BaseRectangularDom {
   const dist: unmanaged MyDist?;
 
   proc dsiGetIndices() {
-    var r: range;
+    var r: simpleRange; /*autofix*/
     return r;
   }
 

--- a/test/distributions/bradc/wrongDomForDist/DummyAssocDist.chpl
+++ b/test/distributions/bradc/wrongDomForDist/DummyAssocDist.chpl
@@ -13,7 +13,7 @@ class MyDom : BaseAssociativeDom {
   const dist: unmanaged MyDist?;
 
   proc dsiGetIndices() {
-    var r: range;
+    var r: simpleRange; /*autofix*/
     return r;
   }
 

--- a/test/distributions/diten/Dimensional.chpl
+++ b/test/distributions/diten/Dimensional.chpl
@@ -60,7 +60,7 @@ class Dimensional {
   // mapped to that locale for that dimension within the range
   // min(idxType)..max(idxType)
   proc getLocRanges(loc: nDims*int) {
-    var ranges: nDims*range(stridable=true);
+    var ranges: nDims*range(int, boundKind.both, stridable=true);
     for param dim in 0..nDims-1 {
       ranges(dim) = dimensionDistributors(dim).localPart(localeDomain, loc, idxType);
     }

--- a/test/distributions/diten/blockCyclicDist.chpl
+++ b/test/distributions/diten/blockCyclicDist.chpl
@@ -74,7 +74,7 @@ class BlockCyclicDom {
         }
       }
       on dist.locales(pos) {
-        var locRanges: nDims*range(idxType, boundKind.both);
+        var locRanges: nDims*range(idxType, boundKind.both, false);
         for i in 0..#nDims {
           locRanges(i) = 1..locSize(i);
         }
@@ -101,7 +101,7 @@ class LocBlockCyclicDom {
   param nDims: int;
   type idxType;
   const whole: unmanaged BlockCyclicDom(nDims, idxType);
-  const locRanges: nDims*range(idxType, boundKind.both);
+  const locRanges: nDims*range(idxType, boundKind.both, false);
   const locDom: domain(nDims);
   proc postinit() {
     locDom.setIndices(locRanges);

--- a/test/domains/claridge/multiplicationSyntaxCheck.chpl
+++ b/test/domains/claridge/multiplicationSyntaxCheck.chpl
@@ -3,7 +3,7 @@ operator *(D1: domain, D2: domain)
   param stridable = D1.stridable || D2.stridable;
   param rank = D1.rank + D2.rank;
 
-  var ranges: rank*range(stridable=stridable);
+  var ranges: rank*range(int, boundKind.both, stridable);
   for i in 0..#D1.rank do
     ranges(i) = D1.dim(i);
   for i in 0..#D2.rank do

--- a/test/domains/sungeun/rect/equality/equality_basic.chpl
+++ b/test/domains/sungeun/rect/equality/equality_basic.chpl
@@ -13,7 +13,7 @@ proc checkit(d1, d2) {
 }
 
 {
-  var init_range: rank*range;
+  var init_range: rank*simpleRange;
   for param i in 0..rank-1 do
     init_range(i) = 1..n*i;
   const D1: domain(rank) = init_range;

--- a/test/domains/sungeun/rect/equality/equality_basic.chpl
+++ b/test/domains/sungeun/rect/equality/equality_basic.chpl
@@ -26,7 +26,7 @@ proc checkit(d1, d2) {
 }
 
 {
-  var init_range: rank*range(stridable=true);
+  var init_range: rank*range(int, boundKind.both, true);
   for param i in 0..rank-1 do
     init_range(i) = 1..n*i by s;
   const D1: domain(rank, stridable=true) = init_range;
@@ -39,7 +39,7 @@ proc checkit(d1, d2) {
 }
 
 {
-  var init_range: rank*range(stridable=true);
+  var init_range: rank*range(int, boundKind.both, true) /*autofix*/;
   for param i in 0..rank-1 do
     init_range(i) = 1..n*i by -s;
   const D1: domain(rank, stridable=true) = init_range;

--- a/test/domains/sungeun/rect/equality/equality_stridable.chpl
+++ b/test/domains/sungeun/rect/equality/equality_stridable.chpl
@@ -13,7 +13,7 @@ proc checkit(d1, d2) {
 }
 
 {
-  var init_range: rank*range;
+  var init_range: rank*simpleRange; /*autofix*/
   for param i in 0..rank-1 do
     init_range(i) = 1..n*i;
   const D1: domain(rank, stridable=true) = init_range;

--- a/test/domains/sungeun/rect/equality/equality_strided.chpl
+++ b/test/domains/sungeun/rect/equality/equality_strided.chpl
@@ -13,7 +13,7 @@ proc checkit(d1, d2) {
 }
 
 {
-  var init_range: rank*range(stridable=true);
+  var init_range: rank*range(int, boundKind.both, true) /*autofix*/;
   for param i in 1..rank do
     init_range(i) = 1..n*i by s;
   const D1: domain(rank, stridable=true) = init_range;
@@ -24,7 +24,7 @@ proc checkit(d1, d2) {
 }
 
 {
-  var init_range: rank*range(stridable=true);
+  var init_range: rank*range(int, boundKind.both, true) /*autofix*/;
   for param i in 1..rank do
     init_range(i) = 1..n*i by -s;
   const D1: domain(rank, stridable=true) = init_range;
@@ -36,7 +36,7 @@ proc checkit(d1, d2) {
 
 
 {
-  var init_range: rank*range(stridable=true);
+  var init_range: rank*range(int, boundKind.both, true) /*autofix*/;
   for param i in 1..rank do
     init_range(i) = 1..n*i by s;
   const D1: domain(rank, stridable=true) = init_range;

--- a/test/domains/sungeun/sparse/equality.chpl
+++ b/test/domains/sungeun/sparse/equality.chpl
@@ -11,7 +11,7 @@ proc checkit(d1, d2) {
   writeln(d1!=d2);
 }
 
-var init_range: rank*range;
+var init_range: rank*simpleRange; /*autofix*/
 var myIdx: [0..rank-1] rank*int;
 for param i in 0..rank-1 {
   init_range(i) = 1..n*(i+1);

--- a/test/expressions/noinit/usedWithRange.chpl
+++ b/test/expressions/noinit/usedWithRange.chpl
@@ -1,3 +1,3 @@
-var r: range(int) = noinit;
+var r: simpleRange = noinit;
 r = 1..5;
 writeln(r);

--- a/test/functions/deitz/iterators/leader_follower/test_recursive_leader.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_recursive_leader.chpl
@@ -3,7 +3,7 @@ iter foo(n: int) {
     yield i;
 }
 
-iter foo(param tag: iterKind, n: int):range where tag == iterKind.leader {
+iter foo(param tag: iterKind, n: int):simpleRange where tag == iterKind.leader {
   if n == 1 then
     yield 1..1;
   else {

--- a/test/functions/iterators/angeles/distAdaptativeWS.chpl
+++ b/test/functions/iterators/angeles/distAdaptativeWS.chpl
@@ -50,7 +50,7 @@ proc CheckCorrectness(grainsize:string)
   var t: stopwatch;
   var delay:uint;
   var n,m,chunk:int;
-  var r:range;
+  var r:simpleRange; /*autofix*/
   const mW, mS:string="BS";
  
   select grainsize {

--- a/test/functions/iterators/angeles/distAdaptativeWSv1.chpl
+++ b/test/functions/iterators/angeles/distAdaptativeWSv1.chpl
@@ -52,7 +52,7 @@ proc CheckCorrectness(grainsize:string)
   var t: stopwatch;
   var delay:uint;
   var n,m,chunk:int;
-  var r:range;
+  var r:simpleRange; /*autofix*/
   const mW, mS:string="BS";
 
   select grainsize {

--- a/test/functions/iterators/angeles/distAdaptativeWSv2.chpl
+++ b/test/functions/iterators/angeles/distAdaptativeWSv2.chpl
@@ -50,7 +50,7 @@ proc CheckCorrectness(grainsize:string)
   var t: stopwatch;
   var delay:uint;
   var n,m,chunk:int;
-  var r:range;
+  var r:simpleRange; /*autofix*/
   const mW, mS:string="BS";
   
  

--- a/test/functions/iterators/angeles/dynamic.chpl
+++ b/test/functions/iterators/angeles/dynamic.chpl
@@ -49,7 +49,7 @@ proc CheckCorrectness(grainsize:string)
   var t: stopwatch;
   var delay:uint;
   var n,m, chunk:int;
-  var r:range;
+  var r:simpleRange; /*autofix*/
  
 
   select grainsize {

--- a/test/functions/iterators/angeles/guided.chpl
+++ b/test/functions/iterators/angeles/guided.chpl
@@ -49,7 +49,7 @@ proc CheckCorrectness(grainsize:string)
   var t: stopwatch;
   var delay:uint;
   var n,m, chunk:int;
-  var r:range;
+  var r:simpleRange; /*autofix*/
 
  select grainsize {
     when "fine" do {

--- a/test/functions/iterators/vass/const-ref-iterator-3.chpl
+++ b/test/functions/iterators/vass/const-ref-iterator-3.chpl
@@ -3,7 +3,7 @@
 
 var globInt:    int;
 var globString: string;
-var globRange:  range;
+var globRange:  simpleRange;
 var globDomain: domain(1);
 var globArray:  [globDomain] int;
 

--- a/test/library/draft/Vector/Vector.chpl
+++ b/test/library/draft/Vector/Vector.chpl
@@ -1003,7 +1003,7 @@ module Vector {
       :type other: `list(eltType)`
     */
     proc ref append(other: vector(eltType, ?p)) lifetime this < other {
-      var ret: range;
+      var ret: simpleRange; /*autofix*/
       on this {
         _enter();
         _requestCapacity(_size + other.size);
@@ -1022,7 +1022,7 @@ module Vector {
       :type other: `[?d] eltType`
     */
     proc ref append(other: [?d] eltType) lifetime this < other {
-      var ret: range;
+      var ret: simpleRange; /*autofix*/
       on this {
         _enter();
         _requestCapacity(_size + d.size);
@@ -1052,7 +1052,7 @@ module Vector {
         compilerError(msg);
       }
 
-      var ret: range;
+      var ret: simpleRange; /*autofix*/
       on this {
         _enter();
         _requestCapacity(_size + other.size);

--- a/test/library/packages/BLAS/blas_helpers.chpl
+++ b/test/library/packages/BLAS/blas_helpers.chpl
@@ -167,7 +167,7 @@ proc bandArrayTriangular(A: [?Dom] ?eltType, k, uplo=Uplo.Upper, order=Order.Row
   var a: [{0..#(k+1), 0..#n}] eltType;
 
   var m = 0;
-  var irange: range;
+  var irange: simpleRange; /*autofix*/
 
   if order == order.Col {
     for j in 0..#n {

--- a/test/library/standard/LinkedLists/deitz/test_range.chpl
+++ b/test/library/standard/LinkedLists/deitz/test_range.chpl
@@ -1,7 +1,7 @@
 var r: range = 1..5;
 writeln(r);
 
-var ur: range(uint) = 2:uint..6;
+var ur: boundedRange(uint,false) = 2:uint..6;
 writeln(ur);
 
 for i in r do

--- a/test/multilocale/deitz/needMultiLocales/privateLimitedDistributedArrayClass1.chpl
+++ b/test/multilocale/deitz/needMultiLocales/privateLimitedDistributedArrayClass1.chpl
@@ -5,7 +5,7 @@ if n < numLocales || n % numLocales != 0 then
   halt("the number of locales, ", numLocales, ", does not evenly divide n,", n);
 
 class DistributedArray {
-  var ndata: range(int);
+  var ndata: simpleRange;
   var data: [ndata] int;
   var others: [0..numLocales-1] unmanaged DistributedArray?;
 }

--- a/test/multilocale/deitz/needMultiLocales/privateLimitedDistributedArrayClass2.chpl
+++ b/test/multilocale/deitz/needMultiLocales/privateLimitedDistributedArrayClass2.chpl
@@ -5,7 +5,7 @@ if n < numLocales || n % numLocales != 0 then
   halt("the number of locales, ", numLocales, ", does not evenly divide n,", n);
 
 class DistributedArray {
-  var ndata: range(int);
+  var ndata: simpleRange;
   var data: [ndata] int;
   var others: [0..numLocales-1] unmanaged DistributedArray?;
   var otherBases: [0..numLocales-1] _ddata(int);

--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -372,7 +372,7 @@ prototype module DistributedFFT {
   pragma "default intent is ref"
   record BatchedFFTWplan {
     param ftType : FFTtype;
-    const parRange: range;
+    const parRange: simpleRange; /*autofix*/
     const numTasks: int;
     const batchSizeSm, batchSizeLg: int;
     var planSm, planLg: FFTWplan(ftType);

--- a/test/optimizations/autoAggregation/removeAggCondInFastFollowers.chpl
+++ b/test/optimizations/autoAggregation/removeAggCondInFastFollowers.chpl
@@ -19,7 +19,7 @@ class Arr {
 // fine.
 
 proc sliceIndexMsg(): string throws {
-  var slice: range(stridable=true) = 1..10;
+  var slice: range(int, boundKind.both, true) /*autofix*/ = 1..10;
 
   proc sliceHelper(type t) throws {
       var e = new Arr(int);

--- a/test/optimizations/bulkcomm/bharshbarg/rankChange.chpl
+++ b/test/optimizations/bulkcomm/bharshbarg/rankChange.chpl
@@ -42,7 +42,7 @@ iter variations(in template, param rank = template.size) {
 for param rank in 2..maxDims {
   var dom : domain(rank, stridable=true);
   {
-    var r : rank*range(stridable=true);
+    var r : rank*range(int, boundKind.both, true) /*autofix*/;
     for i in 0..#rank do r(i) = 1..10;
     var temp : domain(rank, stridable=true) = r;
     dom = temp;
@@ -52,7 +52,7 @@ for param rank in 2..maxDims {
 
   var smaller : domain(rank-1, stridable=true);
   {
-    var r : (rank-1)*range(stridable=true);
+    var r : (rank-1)*range(int, boundKind.both, true) /*autofix*/;
     for i in 0..#(rank-1) do r(i) = 1..10;
     var temp : domain(rank-1, stridable = true) = r;
     smaller = temp;

--- a/test/optimizations/bulkcomm/bharshbarg/reindexNoStride.chpl
+++ b/test/optimizations/bulkcomm/bharshbarg/reindexNoStride.chpl
@@ -2,7 +2,7 @@
 use util;
 
 iter halves(dom) {
-  var ret : dom.rank*range;
+  var ret : dom.rank*simpleRange; /*autofix*/
   for i in 0..#2**dom.rank {
     for j in 0..#dom.rank {
       const r = dom.dim(j);
@@ -23,7 +23,7 @@ proc assignHalves(left, right) {
 }
 
 proc testDim(param rank : int) {
-  var ones, zeroes : rank*range;
+  var ones, zeroes : rank*simpleRange; /*autofix*/
   for param i in 0..rank-1 {
     ones(i) = 1..8;
     zeroes(i) = 0..7;

--- a/test/optimizations/bulkcomm/bharshbarg/stridedAssignDR.chpl
+++ b/test/optimizations/bulkcomm/bharshbarg/stridedAssignDR.chpl
@@ -36,7 +36,7 @@ proc buildSlices(param rank : int, Orig : domain(rank, stridable=true)) {
   var ret = new list(domain(rank, stridable=true));
 
   var innerDom = {1..0};
-  var perDim : [1..rank] [innerDom] range(stridable=true);
+  var perDim : [1..rank] [innerDom] range(int, boundKind.both, true) /*autofix*/;
 
   for i in 0..#rank {
     const cur = Orig.dim(i);
@@ -47,7 +47,7 @@ proc buildSlices(param rank : int, Orig : domain(rank, stridable=true)) {
     const quart = size/4;
     const str = Orig.dim(i).stride;
 
-    var mine : list(range(stridable=true));
+    var mine : list(range(int, boundKind.both, true) /*autofix*/);
 
     if cur.size == 1 {
       mine.append(cur by str);
@@ -150,7 +150,7 @@ proc testReindex(param rank : int, Dom) {
 }
 
 proc makeDom(param rank : int, low : int, str = 1) {
-  var r : rank*range(stridable=true);
+  var r : rank*range(int, boundKind.both, true) /*autofix*/;
   for param i in 0..rank-1 do r(i) = low.. by str # n;
   return r;
 }

--- a/test/optimizations/bulkcomm/block/blockToBlock.chpl
+++ b/test/optimizations/bulkcomm/block/blockToBlock.chpl
@@ -104,7 +104,7 @@ proc testDim(param rank : int, DestLocales : [], SrcLocales : []) {
   const len = if rank <= 2 then n else n/3;
   for i in 0..#rank do denseRanges(i) = 1..len;
 
-  var stridedRanges : rank*range(stridable=true);
+  var stridedRanges : rank*range(int, boundKind.both, true) /*autofix*/;
   for i in 0..#rank do stridedRanges(i) = 1.. by (i + 2) # len;
 
   const Dense = {(...denseRanges)};

--- a/test/optimizations/bulkcomm/block/blockToBlock.chpl
+++ b/test/optimizations/bulkcomm/block/blockToBlock.chpl
@@ -100,7 +100,7 @@ proc testCore(DestDom : domain, DestLocales : [],
 
 proc testDim(param rank : int, DestLocales : [], SrcLocales : []) {
   printDebug("  ----- rank=", rank:string, " -----");
-  var denseRanges : rank*range;
+  var denseRanges : rank*simpleRange; /*autofix*/
   const len = if rank <= 2 then n else n/3;
   for i in 0..#rank do denseRanges(i) = 1..len;
 

--- a/test/optimizations/bulkcomm/block/toFromDR.chpl
+++ b/test/optimizations/bulkcomm/block/toFromDR.chpl
@@ -108,7 +108,7 @@ proc testCore(DestDom : domain, SrcDom  : domain, param useDist : bool) {
 
 proc testDim(param rank : int, param useDist : bool) {
   printDebug("  ----- rank=", rank:string, " -----");
-  var denseRanges : rank*range;
+  var denseRanges : rank*simpleRange; /*autofix*/
   for i in 0..#rank do denseRanges(i) = 1..n;
 
   var stridedRanges : rank*range(stridable=true);

--- a/test/optimizations/bulkcomm/block/toFromDR.chpl
+++ b/test/optimizations/bulkcomm/block/toFromDR.chpl
@@ -111,7 +111,7 @@ proc testDim(param rank : int, param useDist : bool) {
   var denseRanges : rank*simpleRange; /*autofix*/
   for i in 0..#rank do denseRanges(i) = 1..n;
 
-  var stridedRanges : rank*range(stridable=true);
+  var stridedRanges : rank*range(int, boundKind.both, true) /*autofix*/;
   for i in 0..#rank do stridedRanges(i) = 1.. by (i + 2) # n;
 
   const Dense = {(...denseRanges)};

--- a/test/optimizations/remoteValueForwarding/serialization/globals.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/globals.chpl
@@ -3,7 +3,7 @@ use CommDiagnostics, Map;
 config const n = 10;
 
 class Helper {
-  var x : 3*range;
+  var x : 3*simpleRange; /*autofix*/
 }
 
 record Foo {

--- a/test/optimizations/remoteValueForwarding/serialization/staticSize.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/staticSize.chpl
@@ -3,7 +3,7 @@ use CommDiagnostics, Map;
 config const n = 10;
 
 class Helper {
-  var x : 3*range;
+  var x : 3*simpleRange; /*autofix*/
 }
 
 record Foo {

--- a/test/optimizations/sungeun/RADOpt/access.chpl
+++ b/test/optimizations/sungeun/RADOpt/access.chpl
@@ -17,7 +17,7 @@ use DSIUtil;
 
 // Stole this from the setupTargetLocalesArray()
 const factors = _factor(rank, numLocales);
-var ranges: rank*range;
+var ranges: rank*simpleRange; /*autofix*/
 for param i in 0..rank-1 do
   ranges(i) = 0..#factors(i);
 const D = {(...ranges)};

--- a/test/parallel/forall/checks/const-indices-vass.chpl
+++ b/test/parallel/forall/checks/const-indices-vass.chpl
@@ -1,7 +1,7 @@
 
 var globInt:    int;
 var globString: string;
-var globRange:  range;
+var globRange:  simpleRange;
 var globDomain: domain(1);
 var globArray:  [globDomain] int;
 

--- a/test/parallel/sync/bradc/syncArrInit.chpl
+++ b/test/parallel/sync/bradc/syncArrInit.chpl
@@ -1,5 +1,5 @@
 class C {
-  const irng: range;
+  const irng: simpleRange; /*autofix*/
 
   proc init(v1: int) {
     irng = v1..v1;

--- a/test/parallel/sync/bradc/testSyncSingleTypes.compopts
+++ b/test/parallel/sync/bradc/testSyncSingleTypes.compopts
@@ -1,13 +1,13 @@
 -st=complex(64)                         # testSyncSingleTypes-ok
 -st=complex(128)                        # testSyncSingleTypes-ok
--st=range                               # testSyncSingleTypes-ok
+-st=simpleRange                         # testSyncSingleTypes-ok
 -st=R                                   # testSyncSingleTypes-ok
 -st='[0..127] int'                      # testSyncSingleTypes-arr
 -st='[1..5] sync int'                   # testSyncSingleTypes-arr2
 -st='sync int'                          # testSyncSingleTypes-sync
 -st=complex(64) -stestSingle=true       # testSyncSingleTypes-ok
 -st=complex(128) -stestSingle=true      # testSyncSingleTypes-ok
--st=range -stestSingle=true             # testSyncSingleTypes-ok
+-st=simpleRange -stestSingle=true       # testSyncSingleTypes-ok
 -st=R -stestSingle=true                 # testSyncSingleTypes-ok
 -st='[0..127] int' -stestSingle=true    # testSyncSingleTypes-arr
 -st='[1..5] sync int' -stestSingle=true # testSyncSingleTypes-arr2

--- a/test/param/errors/checkParamTypes.compopts
+++ b/test/param/errors/checkParamTypes.compopts
@@ -22,7 +22,7 @@
 -st=R             # checkParamTypes-error.good
 -st='borrowed C'  # checkParamTypes-error.good
 -st=U             # checkParamTypes-error.good
--st=range         # checkParamTypes-error.good
+-st=simpleRange   # checkParamTypes-error.good
 -st=domain(1)     # checkParamTypes-error.good
 -st='[1..3] real' # checkParamTypes-error.good
 -st='sync int'    # checkParamTypes-error.good

--- a/test/reductions/partial/DRtest.chpl
+++ b/test/reductions/partial/DRtest.chpl
@@ -25,7 +25,7 @@ proc setup3(A3) {
 }
 
 proc d2d(DIMS) {
-  var ranges: DIMS.size * range;
+  var ranges: DIMS.size * simpleRange;
   for param dim in 0..DIMS.size-1 do
     ranges(dim) = 
       if isRange(DIMS(dim)) then DIMS(dim)

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -315,11 +315,11 @@ var rangeThisToThat: range = thisInt..thatInt; // using variables
 var rangeEmpty: range = 100..-100; // this is valid but contains no indices
 
 // Ranges can be unbounded.
-var range1toInf: range(bounds=boundKind.low) = 1.. ; // 1, 2, 3, 4, 5, ...
+var range1toInf: range(bounds=boundKind.low, ?) = 1.. ; // 1, 2, 3, 4, 5, ...  // now it is generic
 var rangeNegInfTo1 = ..1; // ..., -4, -3, -2, -1, 0, 1
 
 // Ranges can be strided (and reversed) using the ``by`` operator.
-var range2to10by2: range(stridable=true) = 2..10 by 2; // 2, 4, 6, 8, 10
+var range2to10by2: range(stridable=true, ?) = 2..10 by 2; // 2, 4, 6, 8, 10    // now it is generic
 var reverse2to10by2 = 2..10 by -2; // 10, 8, 6, 4, 2
 
 var trapRange = 10..1 by -1; // Do not be fooled, this is still an empty range
@@ -333,7 +333,7 @@ writeln("Size of range '", trapRange, "' = ", trapRange.size);
 var rangeCount: range = -5..#12; // range from -5 to 6
 
 // Operators can be mixed.
-var rangeCountBy: range(stridable=true) = -5..#12 by 2; // -5, -3, -1, 1, 3, 5
+var rangeCountBy: range(stridable=true, ?) = -5..#12 by 2; // -5, -3, -1, 1, 3, 5
 writeln(rangeCountBy);
 
 // Properties of the range can be queried.

--- a/test/release/examples/primers/ranges.chpl
+++ b/test/release/examples/primers/ranges.chpl
@@ -359,12 +359,12 @@ writeln();
 // examples.  However, they can also be specified if desired.  Here
 // are some examples that are equivalent to ones we've seen before:
 //
-const rt: range(int) = 1..10,
+const rt: range(int, ?) = 1..10,
       rt2: range(int, bounds=boundKind.both, stridable=false)
          = 1..10,
-      rte: range(color) = color.orange..color.green,
-      rts: range(stridable=true) = 1..10 by 2,
-      rtub: range(bounds=boundKind.low) = 1..;
+      rte: range(color, ?) = color.orange..color.green,
+      rts: range(stridable=true, ?) = 1..10 by 2,
+      rtub: range(bounds=boundKind.low, ?) = 1..;
 
 // More importantly, range types can be used to make a range variable
 // more flexible than its initializer permits.  For example, this
@@ -372,13 +372,13 @@ const rt: range(int) = 1..10,
 // declared with ``stridable=true``, it can later be assigned a range
 // value with a stride.
 
-var rangeVar: range(int, stridable=true) = 1..10;
+var rangeVar: range(int, boundKind.both, stridable=true) = 1..10;
 
 // Range types are also valuable in declaring formal arguments of a
 // procedure in which you want to leave certain aspects of the range
 // constrained or unconstrained.
 
-proc acceptsNonStridedIntRangesOnly(r: range(int)) { }
+proc acceptsNonStridedIntRangesOnly(r: range(int, boundKind.both, false)) { }
 proc acceptsAnyRange(r: range(?)) { }
 
 acceptsNonStridedIntRangesOnly(1..10);

--- a/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
+++ b/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
@@ -368,7 +368,7 @@ proc AMRHierarchy.buildRefinedLevel ( i_refining: int )
 
     for cell in cells do
       if flags(cell) {
-        var ranges: dimension*range(stridable=true);
+        var ranges: dimension*range(int, boundKind.both, true) /*autofix*/;
         for d in dimensions do ranges(d) = cell(d)-2 .. cell(d)+2 by 2;
         var neighborhood: domain(dimension,stridable=true) = ranges;
         for nbr in cells(neighborhood) do

--- a/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
+++ b/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
@@ -206,7 +206,7 @@ class CandidateDomain {
 proc CandidateDomain.trim()
 {    
   //===> Find bounds of trimmed domain ===>
-  var trimmed_ranges:      rank*range(stridable=true);
+  var trimmed_ranges:      rank*range(int, boundKind.both, true) /*autofix*/;
   var trim_low, trim_high: int;
   
   for d in 0..rank-1 {
@@ -311,7 +311,7 @@ proc CandidateDomain.removeHole()
   var D1, D2: domain(rank, stridable=true);
   D1 = D;
 
-  var ranges:      rank*range(stridable=true);
+  var ranges:      rank*range(int, boundKind.both, true) /*autofix*/;
   var hole_low:    int;
   var hole_high:   int;
   var low_active:  bool;
@@ -416,7 +416,7 @@ proc CandidateDomain.removeHole()
 proc CandidateDomain.inflectionCut ()
 {
 
-  var ranges: rank*range(stridable=true);
+  var ranges: rank*range(int, boundKind.both, true) /*autofix*/;
 
   var D1, D2: domain(rank, stridable=true);
   D1 = D;

--- a/test/studies/amr/lib/cfboundary/CFUtilities.chpl
+++ b/test/studies/amr/lib/cfboundary/CFUtilities.chpl
@@ -74,7 +74,7 @@ proc refine (
 
 
   //==== Set and return new domain ====
-  var ranges: dimension*range(stridable=true);
+  var ranges: dimension*range(int, boundKind.both, true) /*autofix*/;
 
   for d in dimensions do
     ranges(d) = fine_cells_low(d) .. fine_cells_high(d) by 2;
@@ -105,7 +105,7 @@ proc refine (
 
 
   //==== Set and return new domain ====
-  var ranges: dimension*range(stridable=true);
+  var ranges: dimension*range(int, boundKind.both, true) /*autofix*/;
 
   for d in dimensions do
     ranges(d) = fine_cells_low(d) .. fine_cells_high(d) by 2;
@@ -166,7 +166,7 @@ proc coarsen (
   
 
   //==== Set and return new domain ====
-  var ranges: dimension*range(stridable=true);
+  var ranges: dimension*range(int, boundKind.both, true) /*autofix*/;
   for d in dimensions do
     ranges(d) = low_coarse(d) .. high_coarse(d) by 2;
 

--- a/test/studies/amr/lib/grid/GridVariable_def.chpl
+++ b/test/studies/amr/lib/grid/GridVariable_def.chpl
@@ -206,7 +206,7 @@ proc GridVariable.writeData (
     // Transpose cells; iterating over the transpose in row major
     // order achieves column major order on the original domain.
     //------------------------------------------------------------
-    var range_tuple: dimension*range(stridable=true);
+    var range_tuple: dimension*range(int, boundKind.both, true) /*autofix*/;
     [d in dimensions with (ref range_tuple)] // could also be 'for param d'
       range_tuple(d) = grid.cells.dim(dimension - (d+1));
 

--- a/test/studies/amr/lib/grid/Grid_def.chpl
+++ b/test/studies/amr/lib/grid/Grid_def.chpl
@@ -75,7 +75,7 @@ class Grid {
       i_high(d) = i_low(d) + 2*n_cells(d);
 
     //==== Physical cells ====
-    var ranges: dimension*range(stridable = true);
+    var ranges: dimension*range(int, boundKind.both, true);
     for d in dimensions
     {
       ranges(d) = (i_low(d)+1 .. by 2) #n_cells(d);

--- a/test/studies/amr/lib/level/Level_def.chpl
+++ b/test/studies/amr/lib/level/Level_def.chpl
@@ -79,7 +79,7 @@ class Level {
 
 
     //---- Possible cells ----
-    var ranges: dimension*range(stridable = true);
+    var ranges: dimension*range(int, boundKind.both, true);
     for d in dimensions do ranges(d) = 1 .. 2*n_cells(d)-1 by 2;
     possible_cells = ranges;
 

--- a/test/studies/amr/lib/misc/LanguageExtensions.chpl
+++ b/test/studies/amr/lib/misc/LanguageExtensions.chpl
@@ -140,7 +140,7 @@ operator *(R: range(stridable=?s), D: domain)
 {
   param stridable = s || D.stridable;
 
-  var ranges: (D.rank+1)*range(stridable=stridable);
+  var ranges: (D.rank+1)*range(int, boundKind.both, stridable);
   ranges(0) = R;
   for i in 1..D.rank do ranges(i) = D.dim(i);
 
@@ -153,7 +153,7 @@ operator *(D: domain, R: range(stridable=?s))
 {
   param stridable = s || D.stridable;
 
-  var ranges: (D.rank+1)*range(stridable=stridable);
+  var ranges: (D.rank+1)*range(int, boundKind.both, stridable);
   for i in 0..#D.rank-1 do ranges(i) = D.dim(i);
   ranges(D.rank) = R;
 
@@ -167,7 +167,7 @@ operator *(D1: domain, D2: domain)
   param stridable = D1.stridable || D2.stridable;
   param rank = D1.rank + D2.rank;
 
-  var ranges: rank*range(stridable=stridable);
+  var ranges: rank*range(int, boundKind.both, stridable);
   for i in 0..#D1.rank do
     ranges(i) = D1.dim(i);
   for i in 0..#D2.rank do

--- a/test/studies/amr/lib/misc/MultiDomain_def.chpl
+++ b/test/studies/amr/lib/misc/MultiDomain_def.chpl
@@ -573,7 +573,7 @@ class MDNode
   {
     assert( bisect_dim>0, "Error: Called MDNode.createLeft with bisect_dim<=0.");
     
-    var subranges: rank*range(stridable=stridable);
+    var subranges: rank*range(int, boundKind.both, stridable);
     
     for d in 0..rank-1          do subranges(d) = Domain.dim(d);
     for d in bisect_dim..rank-1 do subranges(d) = Domain.dim(d);    
@@ -592,7 +592,7 @@ class MDNode
   {
     assert( bisect_dim>0, "Error: Called MDNode.createRight with bisect_dim<=0.");
     
-    var subranges: rank*range(stridable=stridable);
+    var subranges: rank*range(int, boundKind.both, stridable);
     
     for d in 0..rank-1          do subranges(d) = Domain.dim(d);
     for d in bisect_dim..rank-1 do subranges(d) = Domain.dim(d);
@@ -678,7 +678,7 @@ proc MDNode.extendToContain( D: domain(rank,stridable=stridable) ) : unmanaged M
     var parent:  unmanaged MDNode(rank,stridable)?;
     // var sibling: MDNode(rank,stridable);
     
-    var subranges: rank*range(stridable=stridable);
+    var subranges: rank*range(int, boundKind.both, stridable);
     var D_temp:    domain(rank,stridable=stridable);
     
     for d in 0..ext_d-1    do subranges(d) = Domain.dim(d);  

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -533,8 +533,8 @@ proc AccumStencil.dsiCreateReindexDist(newSpace, oldSpace) {
 proc LocAccumStencil.init(param rank: int,
                           type idxType,
                           locid, // the locale index from the target domain
-                          boundingBox: rank*range(idxType),
-                          targetLocBox: rank*range) {
+                          boundingBox: rank*range(idxType, boundKind.both, false),
+                          targetLocBox: rank*simpleRange) {
   this.rank = rank;
   this.idxType = idxType;
   if rank == 1 {
@@ -546,7 +546,7 @@ proc LocAccumStencil.init(param rank: int,
                                      max(idxType), min(idxType), lo);
     myChunk = {blo..bhi};
   } else {
-    var inds: rank*range(idxType);
+    var inds: rank*range(idxType, boundKind.both, false);
     for param i in 0..rank-1 {
       const lo = boundingBox(i).low;
       const hi = boundingBox(i).high;
@@ -669,7 +669,7 @@ iter AccumStencilDom.these(param tag: iterKind, followThis) where tag == iterKin
   if chpl__testParFlag then
     chpl__testPar("AccumStencil domain follower invoked on ", followThis);
 
-  var t: rank*range(idxType, stridable=stridable||anyStridable(followThis));
+  var t: rank*range(idxType, boundKind.both, stridable||anyStridable(followThis));
   type strType = chpl__signedType(idxType);
   for param i in 0..rank-1 {
     var stride = whole.dim(i).stride: strType;
@@ -1074,7 +1074,7 @@ iter AccumStencilArr.these(param tag: iterKind, followThis, param fast: bool = f
   if testFastFollowerOptimization then
     writeln((if fast then "fast" else "regular") + " follower invoked for AccumStencil array");
 
-  var myFollowThis: rank*range(idxType=idxType, stridable=stridable || anyStridable(followThis));
+  var myFollowThis: rank*range(idxType=idxType, bounds=boundKind.both, stridable=stridable || anyStridable(followThis));
   var lowIdx: rank*idxType;
 
   for param i in 0..rank-1 {

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -1265,7 +1265,7 @@ iter AccumStencilArr.dsiBoundaries() {
       return {(...r)};
     }
 
-    var ndr : rank*range;
+    var ndr : rank*simpleRange; /*autofix*/
     for i in 0..rank-1 do ndr(i) = -1..1;
     const ND = {(...ndr)};
 
@@ -1319,7 +1319,7 @@ iter AccumStencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.s
       return {(...r)};
     }
 
-    var ndr : rank*range;
+    var ndr : rank*simpleRange; /*autofix*/
     for i in 0..rank-1 do ndr(i) = -1..1;
     const ND = {(...ndr)};
 

--- a/test/studies/compOcean/compOcean.chpl
+++ b/test/studies/compOcean/compOcean.chpl
@@ -36,7 +36,7 @@ proc readData(param dims: int, dataname: string) {
 
   cdfError(nc_inq_vardimid(ncid, varid, dimids[0]));
   extern proc nc_inq_dimlen_WAR(ncid:c_int, dimid: c_int, ref dimlens): c_int;
-  var dimranges: dims*range;
+  var dimranges: dims*simpleRange; /*autofix*/
   for i in 0..#ndims {
     cdfError(nc_inq_dimlen_WAR(ncid, dimids[i], dimlens[i]));
     dimranges(i+1) = 0..#dimlens[i];

--- a/test/studies/lu/marybeth/nopivlublock-alias.chpl
+++ b/test/studies/lu/marybeth/nopivlublock-alias.chpl
@@ -20,7 +20,7 @@ var A: [A2D] real;
 
 // The variable slice is used to implement D(k+1..),
 // where D would be a subdomain (but is currently a range).
-var slice: range;
+var slice: simpleRange; /*autofix*/
 
 initA(A,'Adata.dat');
 

--- a/test/studies/lu/marybeth/pivlublock-alias.chpl
+++ b/test/studies/lu/marybeth/pivlublock-alias.chpl
@@ -19,7 +19,7 @@ param n = 10;
 param blk = 5;
 
 var A1D = 1..n;
-var slice0, slice1, slice2: range;
+var slice0, slice1, slice2: simpleRange; /*autofix*/
 const A2D = {A1D,A1D}; 
 var A: [A2D] real;
 var piv: [A1D] int;

--- a/test/types/range/align/rangeAlignTest2.chpl
+++ b/test/types/range/align/rangeAlignTest2.chpl
@@ -1,5 +1,5 @@
-var r1: range(int);
+var r1: range(int, boundKind.both, stridable=false);
 writeln(r1.aligned);
 
-var r2: range(int, stridable=true);
+var r2: range(int, boundKind.both, stridable=true);
 writeln(r2.aligned);

--- a/test/types/range/contains.chpl
+++ b/test/types/range/contains.chpl
@@ -1,5 +1,5 @@
-var r: range;
-var r2: range;
+var r: simpleRange; /*autofix*/
+var r2: simpleRange; /*autofix*/
 
 
 writeln(r.contains(r2));

--- a/test/types/range/diten/castAwayStridableRange.chpl
+++ b/test/types/range/diten/castAwayStridableRange.chpl
@@ -10,10 +10,10 @@ unstridableRange = stridableRange: simpleRange; /*autofix*/
 writeln("after cast/assign unstridableRange=", unstridableRange); // {1..20}
 writeln("after cast/assign stridableRange=", stridableRange); // {1..20 by 2}
 
-unstridableRange = stridableRangeUnit.safeCast(range);
+unstridableRange = stridableRangeUnit.safeCast(simpleRange);
 
 writeln("after safeCast/assign unstridableRange=", unstridableRange); // {1..20}
 writeln("after safeCast/assign stridableRangeUnit=", stridableRangeUnit); // {1..20}
 
 // halt reached - non-stridable range assigned non-unit stride
-unstridableRange = stridableRange.safeCast(range);
+unstridableRange = stridableRange.safeCast(simpleRange);

--- a/test/types/range/diten/castAwayStridableRange.chpl
+++ b/test/types/range/diten/castAwayStridableRange.chpl
@@ -5,7 +5,7 @@ var unstridableRange = 1..10;
 writeln("before cast/assign unstridableRange=", unstridableRange); // {1..10}
 writeln("before cast/assign stridableRange=", stridableRange); // {1..20 by 2}
 
-unstridableRange = stridableRange: range;
+unstridableRange = stridableRange: simpleRange; /*autofix*/
 
 writeln("after cast/assign unstridableRange=", unstridableRange); // {1..20}
 writeln("after cast/assign stridableRange=", stridableRange); // {1..20 by 2}

--- a/test/types/range/enum/castEnumRange.chpl
+++ b/test/types/range/enum/castEnumRange.chpl
@@ -1,6 +1,6 @@
 enum color { red=1, green=2, blue=3 };
 {
   var r = color.red..color.blue;
-  var r2 = r: range(int);
+  var r2 = r: simpleRange;
   writeln(r2);
 }

--- a/test/types/range/enum/castEnumRange2.chpl
+++ b/test/types/range/enum/castEnumRange2.chpl
@@ -1,5 +1,5 @@
 enum color { red, green, blue };
 
 var r = color.red..color.blue;
-var r2 = r: range(int);
+var r2 = r: simpleRange;
 writeln(r2);

--- a/test/types/range/enum/castEnumRange3.chpl
+++ b/test/types/range/enum/castEnumRange3.chpl
@@ -1,6 +1,6 @@
 enum color { red=100, green=200, blue=300 };
 {
   var r = color.red..color.blue;
-  var r2 = r: range(int);
+  var r2 = r: simpleRange;
   writeln(r2);
 }

--- a/test/types/range/enum/singleValEnum.chpl
+++ b/test/types/range/enum/singleValEnum.chpl
@@ -1,3 +1,3 @@
 enum E {A};
-const r: range(idxType=E);
+const r: range(idxType=E, boundKind.both, false);
 writeln(r);

--- a/test/types/range/enum/singleValEnum3.chpl
+++ b/test/types/range/enum/singleValEnum3.chpl
@@ -44,5 +44,5 @@ forall c in C do
   writeln(c);
 
 
-var r2: range(color);
+var r2: range(color, boundKind.both, false);
 writeln(r2);

--- a/test/types/range/enum/singleValEnum4.chpl
+++ b/test/types/range/enum/singleValEnum4.chpl
@@ -6,14 +6,14 @@ enum color { red };
   testit(r);
 
   writeln("overwritten:");
-  var r2: range(color);
+  var r2: range(color, boundKind.both, false);
   r = r2;
   testit(r);
 }
 
 {
   writeln("default initialized");
-  var r: range(color);
+  var r: range(color, boundKind.both, false);
   testit(r);
 
   writeln("overwritten:");
@@ -23,7 +23,7 @@ enum color { red };
 
 {
   writeln("implicit strided");
-  var r: range(color, stridable=true);
+  var r: range(color, boundKind.both, true);
   testit(r);
 
   writeln("overwritten:");

--- a/test/types/range/enum/strideSingleValEnum.chpl
+++ b/test/types/range/enum/strideSingleValEnum.chpl
@@ -1,6 +1,6 @@
 enum color { red };
 use color;
-var r: range(color);
+var r: range(color, boundKind.both, false);
 writeln(r);
 writeln(r by 1);
 writeln(r by 2);

--- a/test/types/range/ferguson/cast-to-stridable.chpl
+++ b/test/types/range/ferguson/cast-to-stridable.chpl
@@ -1,4 +1,4 @@
-var a:range(int, stridable=false) = 1..10;
-var b = a:range(int, stridable=true);
+var a:range(int, boundKind.both, stridable=false) = 1..10;
+var b = a:range(int, boundKind.both, stridable=true);
 writeln(a);
 writeln(b);

--- a/test/types/range/ferguson/range-generic-default1.chpl
+++ b/test/types/range/ferguson/range-generic-default1.chpl
@@ -1,6 +1,6 @@
 record MyRecord {
   param p: int;
-  var r: range;
+  var r: simpleRange; /*autofix*/
 
   proc init(param p:int, r) {
     this.p = p;

--- a/test/types/range/ferguson/range-generic-default2.chpl
+++ b/test/types/range/ferguson/range-generic-default2.chpl
@@ -1,6 +1,6 @@
 record MyRecord {
   param p: int;
-  var r: range;
+  var r: simpleRange; /*autofix*/
 
   proc init(param p:int, r) {
     this.p = p;

--- a/test/types/range/ferguson/range-split-inits.chpl
+++ b/test/types/range/ferguson/range-split-inits.chpl
@@ -1,6 +1,6 @@
 proc test1() {
   writeln("test1");
-  var a:range;
+  var a:simpleRange; /*autofix*/
   writeln(a.type:string, " ", a);
 
   var b;
@@ -11,7 +11,7 @@ proc test1() {
   c = 2..20 by 2;
   writeln(c.type:string, " ", c);
   
-  var d:range;
+  var d:simpleRange; /*autofix*/
   d = 3..30;
   writeln(d.type:string, " ", d);
 }

--- a/test/types/range/unbounded/compareEnumBool.chpl
+++ b/test/types/range/unbounded/compareEnumBool.chpl
@@ -4,7 +4,7 @@ use color;
 var rgb = red..blue;
 var rdd = red..;
 var ddb = ..blue;
-var dd: range(color, boundKind.neither) = ..;
+var dd: range(color, boundKind.neither, false) = ..;
 
 writeln(rgb == rdd);
 writeln(rgb == ddb);
@@ -20,7 +20,7 @@ writeln(ddb == dd);
 var ft = false..true;
 var fdd = false..;
 var ddt = ..true;
-var dd: range(bool, boundKind.neither);
+var dd: range(bool, boundKind.neither, false);
 
 writeln(ft == fdd);
 writeln(ft == ddt);

--- a/test/types/range/unbounded/unboundedBool.chpl
+++ b/test/types/range/unbounded/unboundedBool.chpl
@@ -1,11 +1,11 @@
-var empty: range(bool, boundKind.neither);
+var empty: range(bool, boundKind.neither, false);
 
 writeln(empty.low);
 writeln(empty.high);
 writeln(empty._low);
 writeln(empty._high);
 
-var empty2: range(bool, boundKind.neither);
+var empty2: range(bool, boundKind.neither, false);
 
 writeln(empty2.low);
 writeln(empty2.high);

--- a/test/types/range/unbounded/unboundedBoolEnum2.chpl
+++ b/test/types/range/unbounded/unboundedBoolEnum2.chpl
@@ -51,8 +51,8 @@ for i in true.. by -1 do
 
 writeln("---");
 
-var re: range(color, boundKind.neither) = ..;
-var rb: range(bool, boundKind.neither) = ..;
+var re: range(color, ?) = ..;
+var rb: range(bool, ?) = ..;
 
 for i in re do
   writeln(i);

--- a/test/types/range/unbounded/unboundedBoolEnum2a.chpl
+++ b/test/types/range/unbounded/unboundedBoolEnum2a.chpl
@@ -51,8 +51,8 @@ for i in true.. by -3 do
 
 writeln("---");
 
-var re: range(color, boundKind.neither) = ..;
-var rb: range(bool, boundKind.neither) = ..;
+var re: range(color, boundKind.neither, ?) = ..;
+var rb: range(bool, boundKind.neither, ?) = ..;
 
 for i in re do
   writeln(i);

--- a/test/types/range/userAPI/singleEnumAPITest.chpl
+++ b/test/types/range/userAPI/singleEnumAPITest.chpl
@@ -5,11 +5,11 @@ use color;
 
 testRangeAPI("trivial enum range", red..red, red, red..red, 0, 1);
 
-var r: range(color);
+var r: range(color, boundKind.both, false);
 testRangeAPI("default trivial enum range", r, red, r, 0, 0);
 
 testRangeAPI("trivial strided enum range", red..red by 1, red, red..red, 0, 1);
 
-var r2: range(color, stridable=true);
+var r2: range(color, boundKind.both, true);
 testRangeAPI("default trivial strided enum range", r2, red, r, 0, 0);
 

--- a/test/types/range/vass/equalities-misc-32bits.chpl
+++ b/test/types/range/vass/equalities-misc-32bits.chpl
@@ -1,6 +1,6 @@
 // should be oblivious of idxType
-var r1: range(int(32)) = 0..1:int(32);
-var r2: range(uint(32))= 0..1:uint(32);
+var r1: range(int(32), ?) = 0..1:int(32);
+var r2: range(uint(32), ?)= 0..1:uint(32);
 writeln(r1==r2);
 writeln(r1!=r2);
 

--- a/test/types/range/vass/equalities-misc.chpl
+++ b/test/types/range/vass/equalities-misc.chpl
@@ -1,6 +1,6 @@
 // should be oblivious of idxType
-var r1: range(int) = 0..1;
-var r2: range(uint)= 0..1:uint;
+var r1: range(int, ?) = 0..1;
+var r2: range(uint, ?)= 0..1:uint;
 writeln(r1==r2);
 writeln(r1!=r2);
 

--- a/test/types/range/vass/explicit-conversion-index-type.chpl
+++ b/test/types/range/vass/explicit-conversion-index-type.chpl
@@ -1,3 +1,3 @@
-var r64: range(int(64)) = 7..9;
-var r32 = r64 : range(int(32));
+var r64: range(int(64), boundKind.both, false) = 7..9;
+var r32 = r64 : range(int(32), boundKind.both, false);
 writeln(r32);

--- a/test/types/range/vass/offset-1.chpl
+++ b/test/types/range/vass/offset-1.chpl
@@ -23,7 +23,7 @@ proc suite(r:range(?)) {
     test(r, i);
 }
 
-proc supersuite(r:range) {
+proc supersuite(r:range) {   // now generic
   const steps = (1, 2, -1, -2);
   suite(r);
   for param i in 0..steps.size-1 do suite(r by steps(i));

--- a/test/types/range/vass/offset-1.good
+++ b/test/types/range/vass/offset-1.good
@@ -1,7 +1,8 @@
 offset-1.chpl:10: In function 'test':
 offset-1.chpl:12: warning: invoking 'offset' on an unstrided range has no effect.
   offset-1.chpl:23: called as test(r: range(int(64),both,false), offs: int(64)) from function 'suite'
-  offset-1.chpl:28: called as suite(r: range(int(64),both,false))
+  offset-1.chpl:28: called as suite(r: range(int(64),both,false)) from function 'supersuite'
+  offset-1.chpl:33: called as supersuite(r: range(int(64),both,false))
 3..3  offs -4  3..3
 3..3  offs -2  3..3
 3..3  offs 0  3..3

--- a/test/types/range/vass/promotion-of-actuals-idxType.chpl
+++ b/test/types/range/vass/promotion-of-actuals-idxType.chpl
@@ -1,6 +1,6 @@
-var r1: range(int) = 0..1;
-var r2: range(uint) = 0:uint..1;
-var r64: range(int(64)) = 0..1;
+var r1: range(int,?) = 0..1;
+var r2: range(uint,?) = 0:uint..1;
+var r64: range(int(64),?) = 0..1;
 
 proc test1(i1:range(?IT,?,?), i2:range(IT,?,?)) {
   writeln((i1,i2));

--- a/test/types/range/vass/promotion-of-actuals-unstrided-to-strided.chpl
+++ b/test/types/range/vass/promotion-of-actuals-unstrided-to-strided.chpl
@@ -1,7 +1,7 @@
-var r:range(stridable=false);
+var r:range(int, boundKind.both, false);
 writeln(r);
 
-proc test(arg:range(stridable=true)) {
+proc test(arg:range(int, boundKind.both, true)) {
   writeln(arg);
 }
 

--- a/test/types/records/bad-change-type/range-init1.chpl
+++ b/test/types/records/bad-change-type/range-init1.chpl
@@ -1,6 +1,6 @@
 proc test() {
   var ok: range(?) = 1..10 by 2;
 
-  var err: range = 1..10 by 2;
+  var err: range(stridable=false, ?) = 1..10 by 2;
 }
 test();

--- a/test/types/records/bad-change-type/range-init2.chpl
+++ b/test/types/records/bad-change-type/range-init2.chpl
@@ -2,7 +2,7 @@ proc test() {
   var ok: range(?);
   ok = 1..10 by 2;
 
-  var err: range;
+  var err: simpleRange; /*autofix*/
   err = 1..10 by 2;
 }
 test();

--- a/test/types/tuple/ranges/tupleOfRanges.chpl
+++ b/test/types/tuple/ranges/tupleOfRanges.chpl
@@ -1,6 +1,6 @@
 {
-  var r: range(int, stridable=false) = 1..3;
-  var rngs: 1*range(int, stridable=true);
+  var r: range(int, boundKind.both, false) = 1..3;
+  var rngs: 1*range(int, boundKind.both, true);
   // this conditional is a trick to fool split init
   if (true) {
     rngs = (r,);
@@ -9,7 +9,7 @@
 }
 
 {
-  var r: range(int, stridable=false) = 1..3;
-  var rngs: 1*range(int, stridable=true) = (r,);
+  var r: range(int, boundKind.both, false) = 1..3;
+  var rngs: 1*range(int, boundKind.both, true) = (r,);
   writeln(rngs, ": ", rngs.type:string);
 }

--- a/test/users/aroonsharma/CyclicZipOpt.chpl
+++ b/test/users/aroonsharma/CyclicZipOpt.chpl
@@ -238,7 +238,7 @@ proc _CyclicZipOpt_matchArgsShape(type rangeType, type scalarType, args) type {
 
 proc CyclicZipOpt.dsiCreateRankChangeDist(param newRank: int, args) {
   var collapsedDimInds: rank*idxType;
-  var collapsedLocs: _cyclic_matchArgsShape(range(int), int, args);
+  var collapsedLocs: _cyclic_matchArgsShape(simpleRange, int, args);
   var newLow: newRank*idxType;
 
   var j: int = 1;

--- a/test/users/aroonsharma/CyclicZipOpt.chpl
+++ b/test/users/aroonsharma/CyclicZipOpt.chpl
@@ -60,7 +60,7 @@ class CyclicZipOpt: BaseDist {
       targetLocs = targetLocales;
     } else if targetLocales.rank == 1 {
       const factors = _factor(rank, targetLocales.size);
-      var ranges: rank*range;
+      var ranges: rank*simpleRange; /*autofix*/
       for param i in 1..rank {
         ranges(i) = 0..#factors(i);
       }
@@ -71,7 +71,7 @@ class CyclicZipOpt: BaseDist {
     } else {
       if targetLocales.rank != rank then
         compilerError("locales array rank must be one or match distribution rank");
-      var ranges: rank*range;
+      var ranges: rank*simpleRange; /*autofix*/
       for param i in 1..rank do {
         var thisRange = targetLocales.domain.dim(i);
         ranges(i) = 0..#thisRange.size; 

--- a/test/users/aroonsharma/MyBlockCyclic.chpl
+++ b/test/users/aroonsharma/MyBlockCyclic.chpl
@@ -103,7 +103,7 @@ class MyBlockCyclic : BaseDist {
       // BLC: Common code, factor out
 
       const factors = _factor(rank, targetLocales.size);
-      var ranges: rank*range;
+      var ranges: rank*simpleRange; /*autofix*/
       for param i in 1..rank do
         ranges(i) = 0..factors(i)-1;
       targetLocDom = {(...ranges)};
@@ -117,7 +117,7 @@ class MyBlockCyclic : BaseDist {
       if targetLocales.rank != rank then
     compilerError("locales array rank must be one or match distribution rank");
 
-      var ranges: rank*range;
+      var ranges: rank*simpleRange; /*autofix*/
       for param i in 1..rank do {
     var thisRange = targetLocales.domain.dim(i);
     ranges(i) = 0..#thisRange.size; 

--- a/test/users/dealmeidav/classWithRange-blc.chpl
+++ b/test/users/dealmeidav/classWithRange-blc.chpl
@@ -1,6 +1,6 @@
 class A
 {
-  var rng: range(int);
+  var rng: range(int, boundKind.both, false);
 }
 
 proc main()

--- a/test/users/dealmeidav/classWithRange.chpl
+++ b/test/users/dealmeidav/classWithRange.chpl
@@ -1,5 +1,5 @@
 class A {
-  var rng: range;
+  var rng: simpleRange; /*autofix*/
 }
 
 proc main() {

--- a/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
+++ b/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
@@ -158,7 +158,7 @@ iter DefaultSparseDom.dsiPartialThese(param onlyDim: int, otherIdx,
   const numTasks = if tasksPerLocale==0 then here.maxTaskPar else
     tasksPerLocale;
 
-  var rowRange: range;
+  var rowRange: simpleRange; /*autofix*/
   if onlyDim==rank-1 then rowRange = __private_findRowRange(otherIdxTup);
 
   const l = if onlyDim!=rank-1 then nnzDom.low else rowRange.low;
@@ -203,7 +203,7 @@ iter DefaultSparseDom.dsiPartialThese(param onlyDim: int, otherIdx,
 
   const otherIdxTup = chpl__tuplify(otherIdx);
 
-  var rowRange: range;
+  var rowRange: simpleRange; /*autofix*/
   if onlyDim==rank-1 then rowRange = __private_findRowRange(otherIdxTup);
 
   const l = if onlyDim!=rank-1 then _indices.domain.low else rowRange.low;

--- a/test/users/engin/partial_reduction_support/modules/utilities.chpl
+++ b/test/users/engin/partial_reduction_support/modules/utilities.chpl
@@ -83,9 +83,9 @@ proc faceSliceMask(dom, param exceptDim) {
   compilerAssert(numUbRangesPre + numUbRangesPost == dom.rank-1);
 
   const ubRangesPre = createTuple(if numUbRangesPre > 0 then numUbRangesPre
-      else 1, range(bounds=boundKind.neither), ..);
+      else 1, (..).type, ..);
   const ubRangesPost = createTuple(if numUbRangesPost > 0 then numUbRangesPost
-      else 1, range(bounds=boundKind.neither), ..);
+      else 1, (..).type, ..);
 
   if numUbRangesPre > 0 && numUbRangesPost > 0 {
     return ((...ubRangesPre),0,(...ubRangesPost));

--- a/test/users/npadmana/twopt/Histogram.chpl
+++ b/test/users/npadmana/twopt/Histogram.chpl
@@ -15,7 +15,7 @@ module Histogram {
     proc init(param dim : int, nbins : dim*int, limits : dim*(real,real)) {
       this.dim = dim;
       this.complete();
-      var dd : dim*range;
+      var dd : dim*simpleRange; /*autofix*/
       this.nbins = nbins;
       for param ii in 0..dim-1 {
         lo[ii] = limits(ii)(0);

--- a/test/users/shetag/fock/blockindices-blc.chpl
+++ b/test/users/shetag/fock/blockindices-blc.chpl
@@ -2,7 +2,7 @@ module blockindices {
 use fock;
 
 class blockIndices {
-  const is, js, ks, ls: range(int);
+  const is, js, ks, ls: simpleRange;
 
   proc init(iat, jat, kat, lat) {
     is = bas_info(iat);

--- a/test/users/shetag/fock/fock-3-blc.chpl
+++ b/test/users/shetag/fock/fock-3-blc.chpl
@@ -4,7 +4,7 @@ use blockindices, taskpool;
 type elemType = real(64);
 
 config const natom = 5;
-const bas_info : [1..natom] range = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
+const bas_info : [1..natom] simpleRange = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
 
 const n = (natom/2)*10 + ((natom+1)/2)*5;
 const matD : domain(2) = {1..n, 1..n}; 

--- a/test/users/shetag/fock/fock-dyn-prog-cntr.chpl
+++ b/test/users/shetag/fock/fock-dyn-prog-cntr.chpl
@@ -4,7 +4,7 @@ use blockindices;
 type elemType = real(64);
 
 config const natom = 5;
-const bas_info : [1..natom] range = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
+const bas_info : [1..natom] simpleRange = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
 
 const n = (natom/2)*10 + ((natom+1)/2)*5;
 const matD : domain(2) = {1..n, 1..n}; 

--- a/test/users/shetag/fock/fock-dyn-prog-pool.chpl
+++ b/test/users/shetag/fock/fock-dyn-prog-pool.chpl
@@ -4,7 +4,7 @@ use blockindices, taskpool;
 type elemType = real(64);
 
 config const natom = 5;
-const bas_info : [1..natom] range = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
+const bas_info : [1..natom] simpleRange = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
 
 const n = (natom/2)*10 + ((natom+1)/2)*5;
 const matD : domain(2) = {1..n, 1..n}; 

--- a/test/users/shetag/fock/fock-stc-1.chpl
+++ b/test/users/shetag/fock/fock-stc-1.chpl
@@ -5,7 +5,7 @@ use blockindices;
 type elemType = real(64);
 
 config const natom = 5;
-const bas_info : [1..natom] range = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
+const bas_info : [1..natom] simpleRange = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
 
 const n = (natom/2)*10 + ((natom+1)/2)*5;
 const matD : domain(2) = {1..n, 1..n}; 

--- a/test/users/shetag/fock/fock-stc.chpl
+++ b/test/users/shetag/fock/fock-stc.chpl
@@ -4,7 +4,7 @@ use blockindices;
 type elemType = real(64);
 
 config const natom = 5;
-const bas_info : [1..natom] range = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
+const bas_info : [1..natom] simpleRange = [i in 1..natom] (1..10/(i%2+1)) + 5*(i/2) + 10*((i-1)/2);
 
 const n = (natom/2)*10 + ((natom+1)/2)*5;
 const matD : domain(2) = {1..n, 1..n}; 

--- a/test/users/thom/passStrRngToNonstrRng.chpl
+++ b/test/users/thom/passStrRngToNonstrRng.chpl
@@ -1,4 +1,4 @@
-proc foo(x: range) {
+proc foo(x: simpleRange) {
   writeln("x is: ", x);
 }
 

--- a/test/users/thom/passStrRngToNonstrRng.good
+++ b/test/users/thom/passStrRngToNonstrRng.good
@@ -1,4 +1,4 @@
 passStrRngToNonstrRng.chpl:5: error: unresolved call 'foo(range(int(64),both,true))'
-passStrRngToNonstrRng.chpl:1: note: this candidate did not match: foo(x: range)
+passStrRngToNonstrRng.chpl:1: note: this candidate did not match: foo(x: simpleRange)
 passStrRngToNonstrRng.chpl:5: note: because actual argument #1 with type 'range(int(64),both,true)'
 passStrRngToNonstrRng.chpl:1: note: is passed to formal 'x: range(int(64),both,false)'

--- a/test/users/vass/isX/isX.byBlankArgs-compWarns.chpl
+++ b/test/users/vass/isX/isX.byBlankArgs-compWarns.chpl
@@ -87,7 +87,7 @@ var cls:  borrowed ClassType = (new owned ClassType()).borrow();
 var rec1: RecordSmall;
 var unn:  UnionType;
 
-var rng1: range;
+var rng1: simpleRange; /*autofix*/
 var rng2: range(uint(8), boundKind.neither, true);
 var dmp = defaultDist;
 var dom1: DomType1;

--- a/test/users/vass/isX/isX.module-writeln.chpl
+++ b/test/users/vass/isX/isX.module-writeln.chpl
@@ -87,7 +87,7 @@ var cls:  borrowed ClassType = (new owned ClassType()).borrow();
 var rec1: RecordSmall;
 var unn:  UnionType;
 
-var rng1: range;
+var rng1: simpleRange; /*autofix*/
 var rng2: range(uint(8), boundKind.neither, true);
 var dmp = defaultDist;
 var dom1: DomType1;

--- a/test/users/vass/type-tests.chpl
+++ b/test/users/vass/type-tests.chpl
@@ -20,7 +20,7 @@ var dm1 = new unmanaged Block(LocaleSpace); test("dist", dm1);
 var dm2 = new dmap(dm1); test("dmap", dm2);
 var dom: domain(1);      test("domain", dom);
 var arr: [dom] int;      test("array", arr);
-var rng: range(int);     test("range", rng);
+var rng = 1..0;          test("range", rng);
 var tu1 = (1,);          test("tuple-1", tu1);
 var tu2 = (1,2);         test("tuple-2", tu2);
 var tu3 = (1,2,3);       test("tuple-3", tu3);

--- a/test/users/wmikanik/domain64-badworkaround.chpl
+++ b/test/users/wmikanik/domain64-badworkaround.chpl
@@ -5,6 +5,6 @@ var A4 : [1 : int(64) .. 10: int(64), 1 : int(64) .. 10: int(64)] int;
 writeln (A4(1,1));
 
 //this line generates the error message
-const allInt64Inds: range(int(64)) = ..;
+const allInt64Inds: simpleRange = ..;
 writeln (A4(1, allInt64Inds));
 writeln(allInt64Inds);

--- a/test/users/wmikanik/domain64-workaround.chpl
+++ b/test/users/wmikanik/domain64-workaround.chpl
@@ -5,5 +5,5 @@ var A4 : [1 : int(64) .. 10: int(64), 1 : int(64) .. 10: int(64)] int;
 writeln (A4(1,1));
 
 //this line generates the error message
-const allInt64Inds: range(int(64), boundKind.neither);
+const allInt64Inds: range(int(64), boundKind.neither, false);
 writeln (A4(1, allInt64Inds));


### PR DESCRIPTION
This changes `range` to be generic without any defaults and adjusts our Chapel code to pass testing: standard and gasnet paratests with future. It introduces an alias `simpleRange` for range(int, boundKind.both, false).

Here are my notes about the changes I needed (or did not need) to make:

Arkouda compiles on my branch without changes.

CHAMPS needs 3 changes `range` -> `simpleRange` where it is used as the element type of map and array. Two formals have `range` as argument type, which did not need to be changed: addBodyRange, addWakeRange.

<details><summary>the CHAMPS patch</summary>

```diff
--- champs/potential/src/potentialSystem.chpl
+++ champs/potential/src/potentialSystem.chpl
@@ -43,13 +43,13 @@
     /** Zone indices corresponding to Bodies **/
     var bodyIndices_ : [bodyIndicesDomain_] int;
     /** Zone indices corresponding to Wakes **/
     var wakeIndices_ : [wakeIndicesDomain_] int;
     /** Range of global element indices per bodies **/
-    var elementsSubDomain_ = new map(int,range);
+    var elementsSubDomain_ = new map(int,simpleRange);
     /** Range of global element indices per wakes **/
-    var wakeElementsSubDomain_ = new map(int,range);
+    var wakeElementsSubDomain_ = new map(int,simpleRange);
     /** Record containing the grid references (cRef, Sref...) :record:`GridReferences_r <commonInputs.GridReferences_r>` **/
     var gridReferences_ : GridReferences_r = new GridReferences_r();
     /** Record containing the flow conditions (Mach, alpha...) :record:`FlowConditions_r <flowInputs.FlowConditions_r>` **/
     var flowConditions_ : FlowConditions_r;
     /** Potential flow solver **/
@@ -167,19 +167,19 @@
     }

     /**
         This procedure adds a range of global element indices to `elementsSubDomain_`
     **/
-    proc addBodyRange(zoneID : int, rg : range)
+    proc addBodyRange(zoneID : int, rg : range /*now generic*/)
     {
         elementsSubDomain_[zoneID] = rg;
     }

     /**
         This procedure adds a range of global element indices to `wakeElementsSubDomain_`
     **/
-    proc addWakeRange(zoneID : int, rg : range)
+    proc addWakeRange(zoneID : int, rg : range /*now generic*/)
     {
         wakeElementsSubDomain_[zoneID] = rg;
     }

     /**
--- champs/potential/src/spanwiseSections.chpl
+++ champs/potential/src/spanwiseSections.chpl
@@ -15,11 +15,11 @@
     /** Number of spanwise sections **/
     const numSection_ : int;
     /** The domain of sections **/
     const sectionDomain_ : domain(1) = {0..#numSection_};
     /** Range of elements forming a section **/
-    var elements_ : [sectionDomain_] range;
+    var elements_ : [sectionDomain_] simpleRange;
     /** Range of elements forming a section **/
     var facets_ : [sectionDomain_] list(int) = [sectionDomain_] new list(int);
     /** Local axis system for each section **/
     var localAxes_ : [sectionDomain_] owned Axis_c = [sectionDomain_] new owned Axis_c();
     /** The freestream angle-of-attack in the local frame of reference **/
```

</details>

There are ~50 occurrences of `range` not followed by parentheses in proc&iter declarations in modules and tests and ~30 occurrences in var&field decls, all in tests. This confirms our expectation that the declared types of formals' and vars will not need adjustments in many cases.

<details>

I used these greps for procs (similar greps for iters) and for vars:
```
grepmodules/greptests 'proc .*\brange[^(a-zA-Z0-9_.]' |
  egrep -v '[ (]range : (string|c_char)[,)]' |
  sed 's@proc range\.@procrange @' | grep -w range

grepmodules/greptests 'var .*:.*\brange[^(a-zA-Z0-9_.]'
```

I got this output:
```
# proc matches in modules.
modules/internal/String.chpl:813:    inline proc substring(r: range) {
modules/packages/ArgumentParser.chpl:576:    proc init(name:string, numOpts:int, opts:[?argsD] string, numArgs:range,
modules/packages/LinearAlgebra.chpl:492:proc Vector(space: range, type eltType=real) {
modules/packages/LinearAlgebra.chpl:554:proc Matrix(space: range, type eltType=real) {
modules/packages/LinearAlgebra.chpl:560:proc Matrix(rowSpace: range, colSpace: range, type eltType=real) {
modules/packages/LinearAlgebra.chpl:2695:  proc CSRDomain(space: range) {
modules/packages/LinearAlgebra.chpl:2701:  proc CSRDomain(rowSpace: range, colSpace: range) {
modules/packages/Buffers.chpl:364:  proc buffer.flatten(range:buffer_range) throws {

# proc matches in tests
test/classes/initializers/records/generics/siblingCall-moreComplex.chpl:4:  proc init(type idxType, space: range) {
test/functions/bradc/resolution/rangeVsPromotion.chpl:5:proc f(x: range, y) {
test/functions/ferguson/retrange.chpl:1:proc retrange(x):range {
test/functions/iterators/angeles/distAdaptativeWS.chpl:223:proc writeRange(r: range) 
test/functions/iterators/angeles/distAdaptativeWSv1.chpl:229:proc writeRange(r: range) 
test/functions/iterators/angeles/distAdaptativeWSv2.chpl:225:proc writeRange(r: range) 
test/release/examples/primers/parIters.chpl:475:proc computeChunk(r: range, myChunk, numChunks) where r.stridable == false {
test/studies/champs/champs/potential/src/potentialSystem.chpl:172:    proc addBodyRange(zoneID : int, rg : range)
test/studies/champs/champs/potential/src/potentialSystem.chpl:180:    proc addWakeRange(zoneID : int, rg : range)
test/types/range/vass/offset-1.chpl:26:proc supersuite(r:range) {   // now generic
test/constrained-generics/hashtable/MyHashtable.chpl:455:    proc chpl_Hashtable._ifcAllSlots(size: int): range do return 0..#size;
test/constrained-generics/hashtable/MyHashtable.chpl:456:    proc chpl_Hashtable.ifcAllSlots(): range do return _ifcAllSlots(this.tableSize);
test/library/packages/HDF5/readDistribMultipleFiles/distribReader.chpl:80:proc createFile(name: string, size: int, dataRange: range) {
test/library/packages/LAPACK/TestHelpers.chpl:145:    proc rowRange : range {
test/library/packages/LAPACK/TestHelpers.chpl:149:    proc columnRange : range {

# iterators matched only in tests:
test/functions/deitz/iterators/leader_follower/test_leader_followers.chpl:25:iter bar(param tag: iterKind, followThis: range, n: int) where tag == iterKind.follower {
test/functions/diten/parallel_iterator.chpl:6:iter singleLocaleIterator(param iterator: IteratorType, iterRange:range) {
test/functions/iterators/bradc/recursiveStandalone.chpl:1:iter myiter(r: range): int {
test/functions/iterators/bradc/recursiveStandalone.chpl:7:iter myiter(r: range, param tag: iterKind): int 
test/functions/iterators/diten/recursiveLeader.chpl:1:iter myiter(r:range): int {
test/functions/iterators/diten/recursiveLeader.chpl:7:iter myiter(r:range, param tag: iterKind): int
test/functions/iterators/diten/recursiveLeader.chpl:14:iter myiter(r:range, followThis, param tag: iterKind): int
test/functions/iterators/diten/standaloneParallelIter.chpl:17:iter myiter(param tag:iterKind, followThis: range) where tag == iterKind.follower {
test/functions/iterators/errors/badArgs.chpl:1:iter myiter(r: range) {
test/functions/iterators/errors/badArgs.chpl:6:iter myiter(param tag: iterKind, r: range) {
test/functions/iterators/vass/standaloneForallIntents.chpl:53:iter myiter(param tag:iterKind, followThis: range) where tag == iterKind.follower {
test/npb/ft/npadmana/DistributedFFT.chpl:343:  iter offset(r: range) { halt("Serial offset not implemented"); }
test/npb/ft/npadmana/DistributedFFT.chpl:346:  iter offset(param tag: iterKind, r: range) where (tag==iterKind.standalone) {
test/parallel/forall/vass/other/fi-prototype.chpl:137:iter ITR(numIters:int, param tag: iterKind, followThis: range)
test/performance/vectorization/vectorPragmas/zipIterInFollowerNoVector.chpl:3:  iter nonInlinableIter(r: range) {
test/performance/vectorization/vectorPragmas/zipIterInFollowerNoVectorForeach.chpl:3:  iter nonInlinableIter(r: range) {
test/release/examples/primers/slices.chpl:117:iter blockIter(vec:range,blk) {
test/studies/590o/blucia/img_proc.chpl:26:iter aawindow(W:range,H:range,filter_width:int,filter_height:int){
test/studies/cholesky/marybeth/blockChol.chpl:91:iter IterateByBlocks(D:range,blksize) {
test/studies/cholesky/marybeth/blockCholChoice.chpl:120:iter IterateByBlocks(D:range,blksize) {
test/studies/cholesky/marybeth/blockCholesky.chpl:115:iter Block(D:range,blksize,upper) {
test/studies/lu/marybeth/nopivlublock-alias.chpl:82:iter IterateByBlocks(D:range,blksize) {
test/studies/lu/marybeth/pivlublock-alias.chpl:112:iter IterateByBlocks(D:range,blksize) {
test/studies/matrixlib/MatrixOps.chpl:258:iter GenerateCholBlocks(D:range,blksize) {

# var matched only in tests:
test/chpldoc/types/fields/rangesAndDomains.doc.chpl:2:  var isRange: range;  // should be simpleRange
test/expressions/if-expr/if-loop-const.chpl:5:  var r : range = 1..10;
test/expressions/if-expr/if-loop-param.chpl:5:  var r : range = 1..10;
test/functions/iterators/angeles/checkAdvancedIters/checkAdaptiveWSIter.chpl:6:var rng:range=1..n;              // The ranges
test/functions/iterators/angeles/checkAdvancedIters/checkDynamicIter.chpl:7:var rng:range=1..n;             // The ranges
test/functions/iterators/angeles/checkAdvancedIters/checkGuidedIter.chpl:6:var rng:range=1..n;          // The ranges
grep: test/gpu/native/studies/chop/chplGPU.chpl: No such file or directory
test/npb/is/mcahir/intsort.mtml.chpl:119:var key:      [keyDom] int;    // random numbers between 0 and range -1
test/npb/is/mcahir/intsort.mtml.chpl:226:      var ibucket: int = k >> (log2range-log2nbuckets);  // this is equivalent to (key(i)/range)*nbuckets
test/release/examples/primers/learnChapelInYMinutes.chpl:312:var range1to10: range = 1..10;  // 1, 2, 3, ..., 10
test/release/examples/primers/learnChapelInYMinutes.chpl:314:var rangeThisToThat: range = thisInt..thatInt; // using variables
test/release/examples/primers/learnChapelInYMinutes.chpl:315:var rangeEmpty: range = 100..-100; // this is valid but contains no indices
test/release/examples/primers/learnChapelInYMinutes.chpl:333:var rangeCount: range = -5..#12; // range from -5 to 6
test/release/examples/primers/learnChapelInYMinutes.chpl:353:var thirdDim: range = 1..16;
test/release/examples/primers/learnChapelInYMinutes.chpl:354:var threeDims: domain(3) = {thirdDim, 1..10, 5..10}; // using a range variable
test/studies/590o/alexco/AverageFiles.chpl:92:        var image = readArray( filename + "_" +1:string +".txt" );  //image values ideal range = 0-1, single channel
test/studies/lu/marybeth/nopivlublock-alias.chpl:17:var A1D: range = 1..n;
test/studies/champs/champs/EXT_LIBS/src/CGNSextern.chpl:2670:    var charRange : range = 0..#charSize;
test/studies/champs/champs/common/src/preconditioner.chpl:166:                var nVarRange : range = 0..#nVariables;
test/studies/champs/champs/geo/src/geoFluxesHandles.chpl:525:        var nVarRange : range = 0..#nVariables;
test/studies/champs/champs/geo/src/geoFluxesHandles.chpl:681:        var nVarRange : range = 0..#nVariables;
test/studies/champs/champs/meshTool/src/hyperbolicGrid.chpl:2183:            var gridInterfaceElemsRange : range =  numSurfaceElements..#numSurfInterfaceHalos;
test/studies/champs/champs/potential/src/spanwiseSections.chpl:20:    var elements_ : [sectionDomain_] range;
test/studies/champs/champs/turb/src/SAFluxesHandles.chpl:47:            var nVarRange : range = 0..#nVariables;
test/studies/champs/champs/turb/src/SAFluxesHandles.chpl:1117:            var nVarRange : range = 0..#nVariables;
test/types/range/sungeun/length.chpl:6:  var r1: range = (lo..hi);
test/types/range/sungeun/length_broken.chpl:6:  var r1: range = (lo..hi);
test/library/packages/DistributedIters/checkBadInput-dynamic.chpl:7:var rng:range=1..10;
test/library/packages/DistributedIters/checkBadInput-guided.chpl:7:var rng:range=1..10;
test/library/packages/DistributedIters/checkGoodInput.chpl:10:var rng:range=0..n;
test/library/packages/DistributedIters/checkGoodInput.chpl:37:var testRange:range=0..n;
test/library/packages/LAPACK/TestHelpers.chpl:106:        var arrayRange: range = dimensions[0];
test/library/standard/LinkedLists/deitz/test_range.chpl:1:var r: range = 1..5;
```

</details>

There are ~100 cases where I replaced `range` with `simpleRange`, many (most?) of which were necessary, some were stylistic where the code's intention was to provide a concrete range type.

There are perhaps another ~100 cases I modified `range(...)` in one way or another. Some of them are to add `?` where required to indicate partially-generic types. Many others were to add `boundKind.both` to keep it a concrete type.

We have a lot of tuples of ranges. I made them concrete using `simpleRange` or by specifying boundKind.both and stridable as needed. We could potentially leave them generic, e.g., `rank * range(int, stridable=true)`, however they are usually initialized in a param forall loop, so today's compiler would not be able to infer the concrete type for those.

A few tests use `range(int)` to emphasize idxType=int to contrast with another idxType. I changed those either to simpleRange or to range(int, boundKind.both, false).

There were ~25-30 occurrences in tests of 'range(stridable=true)'

 - most in var (and/or field?) decls as the component type of homog. tuple
   - incl. 10 in AMR, ex.: `var ranges: dimension*range(stridable=true);`
 - 1 each as the element type of array and list
 - 2 as a formal type in a test in test/types/range/vass/

There are cases where `range` is used as the return/yield type. This causes trouble only if it is a recursive proc/iter. In one case it caused trouble even when returning a simpleRange (bug?).

Some tests cast to range types that would be generic with this change so I had to change those. Instead we could allow casting to generic range types, which would preserve the unspecified aspects from the source range.

Some notable examples:

```chpl
// range primer uses several `range(someFeature=..., ?)`

// ~8 occurrences of `range(stridable=?)` as fn args, ex.:
// test/errhandling/codePathCoverage/ifOrThrow2.chpl:5
proc testit(r: range(stridable=?)) throws

// learnChapelInYMinutes and range primers
var rangeCountBy: range(stridable=true, ?) = -5..#12 by 2;

// test/types/range/unbounded/unboundedBoolEnum2.chpl
var re: range(color, boundKind.neither) = ..;

// test/types/range/vass/equalities-misc.chpl
var r2: range(uint(32))= 0..1:uint(32);

// test/users/thom/passStrRngToNonstrRng.chpl
// no longer generates a compilation error
// when an any-stride range is passed to `range`
```

This prototype defines `type boundedRange = range(bounds = boundedKind.both, ?);` However I did not see any opportunities to use it, perhaps because of mental and code legacy.
