### PR TITLE
Avoid deleting the temp dir in the GPU subprocess

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -54,9 +54,7 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname=NULL,
 void ensureDirExists(const char* /* dirname */, const char* /* explanation */);
 const char* getCwd();
 void ensureTmpDirExists();
-const char* makeTempDir(const char* dirPrefix);
 void deleteDir(const char* dirname);
-void deleteTmpDir();
 const char* objectFileForCFile(const char* cfile);
 
 const char* genIntermediateFilename(const char* filename);

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1889,7 +1889,9 @@ static void dynoConfigureContext(std::string chpl_module_path) {
   config.toolName = "chpl";
 
   // Replace the current gContext with one using the new configuration.
-  gContext = new chpl::Context(*gContext, std::move(config));
+  auto oldContext = gContext;
+  gContext = new chpl::Context(*oldContext, std::move(config));
+  delete oldContext;
 
   // set up the clang arguments
 #ifdef HAVE_LLVM

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -42,7 +42,6 @@
 #include "mysystem.h"
 #include "stlUtil.h"
 #include "stringutil.h"
-#include "tmpdirname.h"
 
 #include <pwd.h>
 #include <unistd.h>
@@ -117,7 +116,7 @@ void ensureDirExists(const char* dirname, const char* explanation) {
   }
 }
 
-const char* makeTempDir(const char* dirPrefix) {
+static const char* makeTempDir() {
  std::string tmpDirPath = gContext->tmpDir();
  ensureDirExists(tmpDirPath.c_str(), "ensuring tmp sub-directory exists");
 
@@ -126,14 +125,17 @@ const char* makeTempDir(const char* dirPrefix) {
 
 void ensureTmpDirExists() {
   if (saveCDir[0] == '\0') {
-    if (tmpdirname == NULL) {
-      tmpdirname = makeTempDir("chpl-");
-      intDirName = tmpdirname;
+    if (intDirName == NULL) {
+      intDirName = makeTempDir();
     }
   } else {
     if (intDirName != saveCDir) {
       intDirName = saveCDir;
       ensureDirExists(saveCDir, "ensuring --savec directory exists");
+      if (0 != strcmp(makeTempDir(), saveCDir)) {
+        // expected gContext to have been constructed with saveCDir
+        INT_FATAL("misconfiguration with temp dir");
+      }
     }
   }
 }

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -183,15 +183,6 @@ static const char* cleanCompilerFilename(const char* name) {
 static void cleanup_for_exit() {
   closeCodegenFiles();
 
-  // Currently, gpu code generation is done in on forked process. This
-  // forked process produces some files in the tmp directory that are
-  // later read by the main process, so we want the main process
-  // to clean up the temp dir and not the forked process.
-  if (!gCodegenGPU) {
-    if (gContext) {
-      gContext->cleanupTmpDirIfNeeded();
-    }
-  }
   stopCatchingSignals();
 }
 

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -349,6 +349,10 @@ class Context {
 
   ~Context();
 
+  /** Return the Configuration used by this Context */
+  const Configuration& configuration() const { return config_; }
+
+  /** Return the configured CHPL_HOME directory */
   const std::string& chplHome() const;
 
   /** Return a temporary directory that can be used by this process.
@@ -370,6 +374,8 @@ class Context {
       can be called during program exit. */
   void cleanupTmpDirIfNeeded();
 
+  /** Change whether or not this Context is configured for detailed
+      error/warning output (vs brief output). */
   void setDetailedErrorOutput(bool useDetailed);
 
   /**

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -122,6 +122,10 @@ Context::Context(Context& consumeContext, Configuration newConfig) {
   // swap all fields in to place from consumeContext
   this->swap(consumeContext);
 
+  // set consumeContext not to delete the temp dir when it is deleted
+  // since this context will do so if that is needed.
+  consumeContext.config_.keepTmpDir = true;
+
   // now set the new configuration information
   config_.swap(newConfig);
 }


### PR DESCRIPTION
Follow-up to PR #21944

When compiling for GPU, the compiler `fork()`s and the child process needs to use the same temp dir. But, after PR #21944, the child process was deleting the temp dir. This PR fixes that problem. While there, it cleans up a memory leak when reconfiguring the Context and it adds documentation for a few Context methods.

Future Work:
 * remove `tmpdirname.h` and `tmpdirname.cpp` from the compiler. These are currently built but unused.
 * Consider renaming `Context::Configuration` to `Context::InitConfiguration` or something like that to indicate it is only the initial context of the configuration.
 * Adjust the 2-argument Context constructor to handle the case that the temp dir was generated in the old context but the new configuration specifies a different temp dir.
 * Consider using a helper object to track the responsibility of deleting the temp dir (e.g. it could be an RAII pattern with an object representing the temp dir that is moved around).

Reviewed by @DanilaFe - thanks!

- [x] full local testing