### PR TITLE
Include missing headers in gpuAddNums.chpl

### DIFF
--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
@@ -3,6 +3,8 @@
 extern {
   #include <cuda.h>
   #include <assert.h>
+  #include <stdio.h>
+  #include <stdbool.h>
 
   #define FATBIN_FILE "gpuAddNums_gpu_files/chpl__gpu.fatbin"
 


### PR DESCRIPTION
Follow-up to PR #21944 which makes extern blocks more strict about needing the relevant `#include`s. This PR updates a GPU test to have the extern block have the `#include`s for the features used.

Test change only - not reviewed.