### PR TITLE
Fix strict aliasing check for pointers-to-pointers

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -350,6 +350,10 @@ module CTypes {
     // if from and to are both pointer types themselves, recurse into their
     // respective pointee types (strip a layer of indirection)
     if (isAnyCPtr(from) && isAnyCPtr(to)) {
+      // allow casting to and from void pointer pointee type
+      if (from == c_void_ptr || to == c_void_ptr) {
+        return true;
+      }
       return pointeeCastStrictAliasingAllowed(from.eltType, to.eltType);
     }
     // allow identical types

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -347,6 +347,11 @@ module CTypes {
   pragma "no doc"
   inline proc pointeeCastStrictAliasingAllowed(type from, type to) param
       : bool {
+    // if from and to are both pointer types themselves, recurse into their
+    // respective pointee types (strip a layer of indirection)
+    if (isAnyCPtr(from) && isAnyCPtr(to)) {
+      return pointeeCastStrictAliasingAllowed(from.eltType, to.eltType);
+    }
     // allow identical types
     if (from == to) {
       return true;

--- a/test/types/cptr/cross_type_cast.chpl
+++ b/test/types/cptr/cross_type_cast.chpl
@@ -34,3 +34,13 @@ writeln(xpconst_char.deref());
 // should also warn from non-const to const and vice-versa
 var xpconst_float_from_nonconst = xp : c_ptrConst(c_float);
 var xp_float_from_const = xpconst : c_ptr(c_float);
+
+
+// double pointers should recursively check pointee types
+var xpp : c_ptr(c_ptr(c_int)) = c_ptrTo(xp);
+var xpp_char = xpp : c_ptr(c_ptr(c_int)); // acceptable to strict aliasing
+var xpp_float = xpp : c_ptr(c_ptr(c_float)); // unacceptable
+
+// casting to and from void pointer pointee type is ok
+var xpp_void = xpp : c_ptr(c_void_ptr);
+var xpp_void_int_again = xpp_void : c_ptr(c_ptr(c_int));

--- a/test/types/cptr/cross_type_cast.good
+++ b/test/types/cptr/cross_type_cast.good
@@ -4,5 +4,6 @@ cross_type_cast.chpl:28: warning: Casting c_ptrConst to a non-equivalent, non-ch
 cross_type_cast.chpl:29: warning: Casting c_ptrConst to a non-equivalent, non-char element type ('int(32)' -> 'real(64)') can cause undefined behavior.
 cross_type_cast.chpl:35: warning: Casting c_ptr to a non-equivalent, non-char element type ('int(32)' -> 'real(32)') can cause undefined behavior.
 cross_type_cast.chpl:36: warning: Casting c_ptrConst to a non-equivalent, non-char element type ('int(32)' -> 'real(32)') can cause undefined behavior.
+cross_type_cast.chpl:42: warning: Casting c_ptr to a non-equivalent, non-char element type ('c_ptr(int(32))' -> 'c_ptr(real(32))') can cause undefined behavior.
 1
 1


### PR DESCRIPTION
Fixes incorrect strict aliasing check behavior for casts between pointers-to-pointers, originally introduced in https://github.com/chapel-lang/chapel/pull/21934.

The check will now recurse into pointee types when both `from` and `to` pointee types are pointers types themselves. I experimentally verified with GCC that the warning for casts between double pointers appears to work recursively. Since we always allow casting a typed C pointer to and from a void C pointer, this is also allowed for pointees.

Should fix nightly failures for the following tests:
- `interop/fortran/FortranCallChapel/chapelProcs`
- `interop/fortran/genFortranInterface/chapelProcs`
Both of these tests cast a `c_ptr(c_string)` to `c_ptr(c_ptr(c_char))`, and the pointee type change from `c_string` to `c_ptr(c_char)` was incorrectly failing the strict aliasing check.

[reviewer info placeholder]

Testing:
- [x] paratest 