### PR TITLE
Update extern_kernel_launch.chpl test with a #define

### DIFF
--- a/test/gpu/native/rocmOnly/extern_kernel_launch.chpl
+++ b/test/gpu/native/rocmOnly/extern_kernel_launch.chpl
@@ -1,6 +1,7 @@
 // See the README for more info on this test
 
 extern {
+  #define __HIP_PLATFORM_AMD__
   #include <hip/hip_runtime.h>
   #include <hip/hip_runtime_api.h>
   #include <assert.h>


### PR DESCRIPTION
Follow-up to PR #21944.

Add `#define __HIP_PLATFORM_AMD__`. Somehow this was previously being communicated to clang when compiling the extern block but not so with the new current extern block logic.

Reviewed by @stonea - thanks!