### PR TITLE
Stop including erf and erfc in all programs by default

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -727,18 +727,39 @@ module AutoMath {
     return erff(x);
   }
 
+  // When removing this deprecated function, be sure to remove chpl_erfc and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'erfc' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
+  inline proc erfc(x: real(64)): real(64) {
+    return chpl_erfc(x);
+  }
 
-  /* Returns the complementary error function of the argument.
-     This is equivalent to 1.0 - :proc:`erf`\(`x`).
-  */
-  pragma "fn synchronization free"
-  pragma "codegen for CPU and GPU"
-  extern proc erfc(x: real(64)): real(64);
+  @chpldoc.nodoc
+  inline proc chpl_erfc(x: real(64)): real(64) {
+    // Note: this extern proc was originally free standing.  It might be
+    // reasonable to make it that way again when the deprecated version is
+    // removed
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc erfc(x: real(64)): real(64);
+    return erfc(x);
+  }
 
-  /* Returns the complementary error function of the argument.
-     This is equivalent to 1.0 - :proc:`erf`\(`x`).
-  */
+  // When removing this deprecated function, be sure to remove chpl_erfc and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @chpldoc.nodoc
+  @deprecated(notes="In an upcoming release 'erfc' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc erfc(x : real(32)): real(32) {
+    return chpl_erfc(x);
+  }
+
+  @chpldoc.nodoc
+  inline proc chpl_erfc(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc erfcf(x: real(32)): real(32);

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -692,7 +692,6 @@ module AutoMath {
   // move its contents into Math.chpl to reduce the symbols living in this
   // module.
   pragma "last resort"
-  @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'erf' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc erf(x: real(64)): real(64) {
     return chpl_erf(x);
@@ -713,7 +712,6 @@ module AutoMath {
   // move its contents into Math.chpl to reduce the symbols living in this
   // module.
   pragma "last resort"
-  @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'erf' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc erf(x : real(32)): real(32) {
     return chpl_erf(x);
@@ -731,7 +729,6 @@ module AutoMath {
   // move its contents into Math.chpl to reduce the symbols living in this
   // module.
   pragma "last resort"
-  @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'erfc' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc erfc(x: real(64)): real(64) {
     return chpl_erfc(x);
@@ -752,7 +749,6 @@ module AutoMath {
   // move its contents into Math.chpl to reduce the symbols living in this
   // module.
   pragma "last resort"
-  @chpldoc.nodoc
   @deprecated(notes="In an upcoming release 'erfc' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc erfc(x : real(32)): real(32) {
     return chpl_erfc(x);

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -688,14 +688,39 @@ module AutoMath {
     return m / n;
   }
 
+  // When removing this deprecated function, be sure to remove chpl_erf and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @chpldoc.nodoc
+  @deprecated(notes="erf will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it")
+  inline proc erf(x: real(64)): real(64) {
+    return chpl_erf(x);
+  }
 
-  /* Returns the error function of the argument `x`. */
-  pragma "fn synchronization free"
-  pragma "codegen for CPU and GPU"
-  extern proc erf(x: real(64)): real(64);
+  @chpldoc.nodoc
+  inline proc chpl_erf(x: real(64)): real(64) {
+    // Note: this extern proc was originally free standing.  It might be
+    // reasonable to make it that way again when the deprecated version is
+    // removed
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc erf(x: real(64)): real(64);
+    return erf(x);
+  }
 
-  /* Returns the error function of the argument `x`. */
+  // When removing this deprecated function, be sure to remove chpl_erf and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @chpldoc.nodoc
+  @deprecated(notes="erf will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc erf(x : real(32)): real(32) {
+    return chpl_erf(x);
+  }
+
+  @chpldoc.nodoc
+  inline proc chpl_erf(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc erff(x: real(32)): real(32);

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -693,7 +693,7 @@ module AutoMath {
   // module.
   pragma "last resort"
   @chpldoc.nodoc
-  @deprecated(notes="erf will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it")
+  @deprecated(notes="In an upcoming release 'erf' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc erf(x: real(64)): real(64) {
     return chpl_erf(x);
   }
@@ -714,7 +714,7 @@ module AutoMath {
   // module.
   pragma "last resort"
   @chpldoc.nodoc
-  @deprecated(notes="erf will soon stop being included by default, please 'use' or 'import' the 'Math' module to call it")
+  @deprecated(notes="In an upcoming release 'erf' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc erf(x : real(32)): real(32) {
     return chpl_erf(x);
   }

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -99,6 +99,20 @@ module Math {
     return chpl_erf(x);
   }
 
+  /* Returns the complementary error function of the argument.
+     This is equivalent to 1.0 - :proc:`erf`\(`x`).
+  */
+  inline proc erfc(x: real(64)): real(64) {
+    return chpl_erfc(x);
+  }
+
+  /* Returns the complementary error function of the argument.
+     This is equivalent to 1.0 - :proc:`erf`\(`x`).
+  */
+  inline proc erfc(x : real(32)): real(32) {
+    return chpl_erfc(x);
+  }
+
   /* Returns the natural logarithm of `x` + 1.
 
      It is an error if `x` is less than or equal to -1.

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -89,6 +89,16 @@ module Math {
     return chpl_carg(z);
   }
 
+  /* Returns the error function of the argument `x`. */
+  inline proc erf(x: real(64)): real(64) {
+    return chpl_erf(x);
+  }
+
+  /* Returns the error function of the argument `x`. */
+  inline proc erf(x : real(32)): real(32) {
+    return chpl_erf(x);
+  }
+
   /* Returns the natural logarithm of `x` + 1.
 
      It is an error if `x` is less than or equal to -1.

--- a/test/deprecated/Math/erfErfc.chpl
+++ b/test/deprecated/Math/erfErfc.chpl
@@ -1,0 +1,6 @@
+var a: real = -100;
+writeln("a = ", a);
+writeln("erf(a) = ", erf(a)); // Should trigger the deprecation message
+
+writeln("a = ", a);
+writeln("erfc(a) = ", erfc(a)); // Should trigger the deprecation message

--- a/test/deprecated/Math/erfErfc.good
+++ b/test/deprecated/Math/erfErfc.good
@@ -1,0 +1,6 @@
+erfErfc.chpl:3: warning: In an upcoming release 'erf' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it
+erfErfc.chpl:6: warning: In an upcoming release 'erfc' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it
+a = -100.0
+erf(a) = -1.0
+a = -100.0
+erfc(a) = 2.0

--- a/test/library/standard/Math/erf.chpl
+++ b/test/library/standard/Math/erf.chpl
@@ -1,3 +1,5 @@
+use Math;
+
 var a: real = -100;
 var b: real = -0.05;
 var c: real = 0;

--- a/test/library/standard/Math/erfc.chpl
+++ b/test/library/standard/Math/erfc.chpl
@@ -1,3 +1,5 @@
+use Math;
+
 var a: real = -100;
 var b: real = -0.05;
 var c: real = 0;

--- a/test/release/examples/benchmarks/hpcc/ptrans.chpl
+++ b/test/release/examples/benchmarks/hpcc/ptrans.chpl
@@ -7,9 +7,10 @@
 
 
 //
-// Use standard Chapel modules for Block-Cyclic distributions and timings
+// Use standard Chapel modules for Block-Cyclic distributions, timings and math
+// functions that aren't included by default
 //
-use BlockCycDist, Time;
+use BlockCycDist, Time, Math;
 
 
 //

--- a/test/studies/hpcc/PTRANS/PTRANS.chpl
+++ b/test/studies/hpcc/PTRANS/PTRANS.chpl
@@ -21,6 +21,7 @@ module HPCC_PTRANS {
 
   use LinearAlgebra, 
       Time,
+      Math,
       BlockDist;
 
   proc main () {

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.chpl
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.chpl
@@ -22,6 +22,7 @@ module HPCC_PTRANS {
 
   use LinearAlgebra, 
       Time,
+      Math,
       BlockCycDist;
  
 

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.chpl
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.chpl
@@ -22,6 +22,7 @@ module HPCC_PTRANS {
 
   use LinearAlgebra, 
       Time,
+      Math,
       BlockDist;
  
 


### PR DESCRIPTION
In earlier discussions on which Math symbols should be included
in all programs by default, we decided to stop including `erf` and
`erfc`.

<details>
The commit for this ends up looking a little odd so that we don't accidentally
build the Math module by default as well - make an undocumented version that
Math and the deprecated version can call, so that Math depends on AutoMath and
the two versions stay in sync until the deprecated version is removed. This
strategy was previously followed for other symbols in the Math module.
</details>

Adds a test locking in the deprecation warning.

Adds a use of the Math module to tests that were relying on these functions
being included by default

Passed a full paratest with futures