### PR TITLE
Stop emitting const qualifiers in generated C code

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -2263,11 +2263,3 @@ void
 setDataClassType(TypeSymbol* ts, TypeSymbol* ets) {
   ts->type->setSubstitutionWithName(astr("eltType"), ets);
 }
-
-const char* getConstnessSpecifierForDataClass(TypeSymbol* ts) {
-  const char* constness = "";
-  if (ts->hasFlag(FLAG_C_PTRCONST_CLASS)) {
-    constness = "const ";
-  }
-  return constness;
-}

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1023,9 +1023,9 @@ transformTypeForPointer(Type* type) {
     return referenced->codegen().c + " *";
 
   } else if (type->symbol->hasFlag(FLAG_C_PTR_CLASS)) {
-    const char* constness = getConstnessSpecifierForDataClass(type->symbol);
+    // TODO: add const qualifier for const pointers?
     Type* pointedTo = getDataClassType(type->symbol)->typeInfo();
-    return constness + pointedTo->codegen().c + " *";
+    return pointedTo->codegen().c + " *";
   }
   std::string typeName = type->codegen().c;
   return typeName;

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -312,11 +312,12 @@ void AggregateType::codegenDef() {
   } else if (symbol->hasFlag(FLAG_DATA_CLASS)) {
     TypeSymbol* base = getDataClassType(symbol);
     const char* baseType = base->cname;
-    const char* constness = getConstnessSpecifierForDataClass(symbol);
     if( outfile ) {
-      fprintf(outfile, "typedef %s%s *%s;\n",
-              constness, baseType,
-              symbol->cname);
+      // TODO: add const qualifier for const pointers
+      // This would require properly using const qualifiers throughout generated C
+      // code, which we currently do not have. Otherwise we get warnings about
+      // discarding const qualification. Anna, 04-19-2023
+      fprintf(outfile, "typedef %s *%s;\n", baseType, symbol->cname);
     } else {
 #ifdef HAVE_LLVM
       llvm::Type* llBaseType;

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -669,7 +669,6 @@ bool isNumericParamDefaultType(Type* type);
 
 TypeSymbol* getDataClassType(TypeSymbol* ts);
 void setDataClassType(TypeSymbol* ts, TypeSymbol* ets);
-const char* getConstnessSpecifierForDataClass(TypeSymbol* ts);
 
 // defined in codegen.cpp
 GenRet codegenImmediate(Immediate* i);


### PR DESCRIPTION
Removes generation of `const` qualifiers for const C pointers in C backend, which was originally added in https://github.com/chapel-lang/chapel/pull/21913.

This was causing some nightly test failures because we do not currently consistently emit `const` qualifiers in our C backend. For example, one particular failure was occurring because `writeln` is codegen'd to take non-const, even though its arguments are a const varargs in Chapel. This causes some C compilers to (rightly) warn that we are discarding a `const` qualifier.

I have replaced the places where the `const` qualifier would be printed with TODOs, including an explanation of why we can't do it now.

This does remove some functionality that we would in theory like to have, however there is a lot of work to do with emitting `const` qualifiers in generated C code besides just for `c_ptrConst`. I tried it out and observed our generated C code does not even `const` variables that are `const` in Chapel, let alone things like `const` argument intents.

[reviewer info placeholder]

Testing:
- [x] paratest