### PR TITLE
Fix clang integration warning handling

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -111,6 +111,7 @@
 #include "llvmVer.h"
 
 #include "../../frontend/lib/immediates/prim_data.h"
+#include "chpl/util/clang-integration.h"
 
 #include "global-ast-vecs.h"
 
@@ -1640,7 +1641,7 @@ void setupClang(GenInfo* info, std::string mainFile)
   // Create a compiler instance to handle the actual work.
   CompilerInstance* Clang = new CompilerInstance();
   auto diagOptions =
-    clang::CreateAndPopulateDiagOpts(clangInfo->driverArgsCStrings);
+    chpl::util::wrapCreateAndPopulateDiagOpts(clangInfo->driverArgsCStrings);
   auto diagClient = new clang::TextDiagnosticPrinter(llvm::errs(),
                                                      &*diagOptions);
   auto clangDiags =

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -183,10 +183,6 @@ struct ClangInfo {
   std::vector<const char*> driverArgsCStrings;
 
   clang::CodeGenOptions codegenOptions;
-  llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagOptions;
-  clang::TextDiagnosticPrinter* DiagClient;
-  llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> DiagID;
-  llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine> Diags;
 
   clang::CompilerInstance *Clang;
 
@@ -232,10 +228,7 @@ ClangInfo::ClangInfo(
          clangCCArgs(std::move(clangCCArgsIn)),
          clangOtherArgs(std::move(clangOtherArgsIn)),
          clangLDArgs(std::move(clangLDArgsIn)),
-         codegenOptions(), diagOptions(nullptr),
-         DiagClient(nullptr),
-         DiagID(nullptr),
-         Diags(nullptr),
+         codegenOptions(),
          Clang(nullptr),
          Ctx(nullptr),
          cCodeGen(nullptr), cCodeGenAction(nullptr),
@@ -1325,7 +1318,7 @@ class CCodeGenConsumer final : public ASTConsumer {
     CCodeGenConsumer()
       : ASTConsumer(),
         info(gGenInfo),
-        Diags(info->clangInfo->Diags.get()),
+        Diags(&info->clangInfo->Clang->getDiagnostics()),
         Builder(NULL),
         parseOnly(info->clangInfo->parseOnly),
         savedCtx(NULL)
@@ -1562,8 +1555,6 @@ static void finishClang(ClangInfo* clangInfo){
     // This should call Builder->Release()
     clangInfo->cCodeGen->HandleTranslationUnit(*clangInfo->Ctx);
   }
-  clangInfo->Diags.reset();
-  clangInfo->DiagID.reset();
 }
 
 static void deleteClang(ClangInfo* clangInfo){
@@ -1642,31 +1633,32 @@ void setupClang(GenInfo* info, std::string mainFile)
   initializeLlvmTargets();
   std::string triple = getConfiguredTargetTriple();
 
-  // Create a compiler instance to handle the actual work.
-  CompilerInstance* Clang = new CompilerInstance();
-  Clang->createDiagnostics();
-
-  clangInfo->diagOptions = new DiagnosticOptions();
-  clangInfo->DiagClient= new TextDiagnosticPrinter(errs(),&*clangInfo->diagOptions);
-  clangInfo->DiagID = new DiagnosticIDs();
-  DiagnosticsEngine* Diags = NULL;
-  Diags = new DiagnosticsEngine(
-      clangInfo->DiagID, &*clangInfo->diagOptions, clangInfo->DiagClient);
-  if (usingGpuLocaleModel()) {
-    Diags->setSeverityForGroup(diag::Flavor::WarningOrError,
-                               "unknown-cuda-version",
-                               diag::Severity::Ignored);
-  }
-  clangInfo->Diags = Diags;
-  clangInfo->Clang = Clang;
-
-  clang::driver::Driver TheDriver(clangInfo->clangexe, triple, *Diags);
-
-  //   SetInstallDir(argv, TheDriver);
-
   for (auto & arg : clangInfo->driverArgs) {
     clangInfo->driverArgsCStrings.push_back(arg.c_str());
   }
+
+  // Create a compiler instance to handle the actual work.
+  CompilerInstance* Clang = new CompilerInstance();
+  auto diagOptions =
+    clang::CreateAndPopulateDiagOpts(clangInfo->driverArgsCStrings);
+  auto diagClient = new clang::TextDiagnosticPrinter(llvm::errs(),
+                                                     &*diagOptions);
+  auto clangDiags =
+    clang::CompilerInstance::createDiagnostics(diagOptions.release(),
+                                               diagClient,
+                                               /* owned */ true);
+  Clang->setDiagnostics(&*clangDiags);
+
+  if (usingGpuLocaleModel()) {
+    clangDiags->setSeverityForGroup(diag::Flavor::WarningOrError,
+                                    "unknown-cuda-version",
+                                    diag::Severity::Ignored);
+  }
+  clangInfo->Clang = Clang;
+
+  clang::driver::Driver TheDriver(clangInfo->clangexe, triple, *clangDiags);
+
+  //   SetInstallDir(argv, TheDriver);
 
   std::unique_ptr<clang::driver::Compilation> C(
       TheDriver.BuildCompilation(clangInfo->driverArgsCStrings));
@@ -1723,12 +1715,12 @@ void setupClang(GenInfo* info, std::string mainFile)
   bool success = CompilerInvocation::CreateFromArgs(
             Clang->getInvocation(),
             job->getArguments(),
-            *Diags);
+            *clangDiags);
 #else
   bool success = CompilerInvocation::CreateFromArgs(
             Clang->getInvocation(),
             &job->getArguments().front(), (&job->getArguments().back())+1,
-            *Diags);
+            *clangDiags);
 #endif
 
   CompilerInvocation* CI = &Clang->getInvocation();

--- a/frontend/include/chpl/util/clang-integration.h
+++ b/frontend/include/chpl/util/clang-integration.h
@@ -23,8 +23,16 @@
 #include "chpl/framework/ID.h"
 #include "chpl/util/memory.h"
 
+#include "llvm/ADT/ArrayRef.h"
+
 #include <string>
 #include <vector>
+
+#ifdef HAVE_LLVM
+namespace clang {
+  class DiagnosticOptions;
+}
+#endif
 
 namespace chpl {
 class Context;
@@ -43,6 +51,13 @@ void setClangFlags(Context* context, std::vector<std::string> clangFlags);
 
 /** Initialize all LLVM targets */
 void initializeLlvmTargets();
+
+#ifdef HAVE_LLVM
+/** Wrapper for CreateAndPopulateDiagOpts to support LLVM 11.
+    This can be removed after the minimum LLVM version is > 13. */
+std::unique_ptr<clang::DiagnosticOptions>
+wrapCreateAndPopulateDiagOpts(llvm::ArrayRef<const char *> Argv);
+#endif
 
 /** Given arguments to 'clang', convert them into arguments for 'cc1'.
     The first element of 'arg' should be which clang to use (like argv[0]). */

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -320,18 +320,18 @@ precompiledHeaderContainsNameQuery(Context* context,
     }
 
     clang::CompilerInstance* Clang = new clang::CompilerInstance();
-
-    auto diagOptions = new clang::DiagnosticOptions();
+    auto diagOptions = clang::CreateAndPopulateDiagOpts(cc1argsCstrs);
     auto diagClient = new clang::TextDiagnosticPrinter(llvm::errs(),
                                                        &*diagOptions);
-    auto diagID = new clang::DiagnosticIDs();
-    auto diags = new clang::DiagnosticsEngine(diagID, &*diagOptions, diagClient);
-
-    Clang->setDiagnostics(diags);
+    auto clangDiags =
+      clang::CompilerInstance::createDiagnostics(diagOptions.release(),
+                                                 diagClient,
+                                                 /* owned */ true);
+    Clang->setDiagnostics(&*clangDiags);
 
     bool success =
       clang::CompilerInvocation::CreateFromArgs(Clang->getInvocation(),
-                                                cc1argsCstrs, *diags);
+                                                cc1argsCstrs, *clangDiags);
     CHPL_ASSERT(success);
 
     Clang->setTarget(clang::TargetInfo::CreateTargetInfo(Clang->getDiagnostics(), Clang->getInvocation().TargetOpts));

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -255,16 +255,8 @@ createClangPrecompiledHeader(Context* context, ID externBlockId) {
 
     CHPL_ASSERT(Clang->getFrontendOpts().IncludeTimestamps == false);
 
-    //Clang->setTarget(clang::TargetInfo::CreateTargetInfo(Clang->getDiagnostics(), Clang->getInvocation().TargetOpts));
-    //Clang->createFileManager();
-    //Clang->createSourceManager(Clang->getFileManager());
-    //Clang->createPreprocessor(clang::TU_Complete);
-
     // create GeneratePCHAction
     clang::GeneratePCHAction* genPchAction = new clang::GeneratePCHAction();
-    //std::string outputFileNameFromClang;
-    //genPchAction->CreateOutputFile(*Clang, tmpInput, outputFileNameFromClang);
-
     // run action and capture results
     if (!Clang->ExecuteAction(*genPchAction)) {
       context->error(externBlockId, "error running clang on extern block");

--- a/test/extern/ExternBlockClangError.good
+++ b/test/extern/ExternBlockClangError.good
@@ -1,4 +1,3 @@
-In file included from <built-in>:2:
 ExternBlockClangError.chpl:2:18: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
   extern void foo();
                  ^
@@ -14,4 +13,4 @@ ExternBlockClangError.chpl:3:11: error: this old-style function definition is no
   void bar() {
           ^
 3 errors generated.
-error: error running clang on extern block
+ExternBlockClangError.chpl:1: error: error running clang on extern block


### PR DESCRIPTION
Follow-up to PR #21944.

This PR fixes a problem in warning option handling for the clang invocation in the new extern block handling. The warning options were not being handled correctly. Clang configures warnings through diagnostics options & these were being constructed with default settings. With this PR, the diagnostic options are computed from the clang command line. This PR switches two other clang integration points to use the pattern that handles the warning options correctly.

This PR is meant to resolve failures with the gsl_demo.chpl test.

- [x] full local testing (but with [Error matching program output for c2chapel/c2chapel-tester] which fails on main currently, this PR does not change the situation)

Reviewed by @riftEmber - thanks!