### PR TITLE
Some clean ups to the developer document on deprecation

### DIFF
--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -23,17 +23,14 @@ The deprecation message uses the following format:
 For compile-time messaging you can use ``compilerWarning()`` to do this, but
 when deprecating symbols the ``@deprecated`` attribute often works better because
 it can be applied to any symbol in a uniform way.  Look in the test/deprecated
-and test/deprecated-keyword directories for many examples.  Note that the
-``@deprecated`` attribute itself is likely to be replaced by different syntax in
-the future, though this may not affect its use in practice since deprecations
-typically only last for one release anyway.
+and test/deprecated-keyword directories for many examples.
 
 Currently, the ``@deprecated`` attribute optionally takes a string literal,
 which is used for the deprecated symbol's documentation and compiler warning
 message. If there is also a documentation comment applied to the symbol that
-comment will take precedence when producing documentation.  When we produce a
-compiler warning we filter it to remove any inline markup.
+comment will take precedence when producing documentation.
 
+When we produce a compiler warning we filter it to remove any inline markup.
 This means if your deprecation message points to the preferred feature using
 syntax like this: ``foo is deprecated - please use :proc:`bar```, then in the
 generated documentation "bar" will link to the documentation for the "bar"


### PR DESCRIPTION
- Removes wording about replacing the deprecated attribute with a different syntax.  That has now occurred
- Move "When we produce a compiler warning" sentence to the following paragraph, which references it.  This seemed better than making them all one paragraph, and will clarify what is being talked about in that paragraph

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>