### PR TITLE
Implement stripNewline option for lines() on a fileReader

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5856,7 +5856,7 @@ iter fileReader.lines(stripNewline = false) {
   const saved_style: iostyleInternal = this._styleInternal();
   // Update iostyleInternal
   var newline_style: iostyleInternal = this._styleInternal();
-  
+
   param newlineChar = 0x0A; // '\n'
 
   newline_style.string_format = QIO_STRING_FORMAT_TOEND;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5844,10 +5844,11 @@ proc fileWriter._writeBytes(x, len:c_ssize_t) throws {
     performance if the current locale is not the same locale on which the
     fileReader was created.
 
-  :yields: lines ending in ``\n``
+  :arg stripNewline: Whether to strip the trailing ``\n`` from the line. Defaults to false
+  :yields: lines from the fileReader, by default with a trailing ``\n``
 
  */
-iter fileReader.lines() {
+iter fileReader.lines(stripNewline = false) {
 
   try! this.lock();
 
@@ -5855,15 +5856,23 @@ iter fileReader.lines() {
   const saved_style: iostyleInternal = this._styleInternal();
   // Update iostyleInternal
   var newline_style: iostyleInternal = this._styleInternal();
+  
+  param newlineChar = 0x0A; // '\n'
 
   newline_style.string_format = QIO_STRING_FORMAT_TOEND;
-  newline_style.string_end = 0x0a; // '\n'
+  newline_style.string_end = newlineChar;
   this._set_styleInternal(newline_style);
 
   // Iterate over lines
   var itemReader = new itemReaderInternal(string, kind, locking, fmtType, this);
   for line in itemReader {
-    yield line;
+    if !stripNewline then yield line;
+    else {
+      var lastCharIdx = line.size-1;
+      if !line.isEmpty() && line.byte(lastCharIdx) == newlineChar
+        then yield line[..<lastCharIdx];
+        else yield line;
+    }
   }
 
   // Set the iostyle back to original state

--- a/test/io/ferguson/io_test.chpl
+++ b/test/io/ferguson/io_test.chpl
@@ -51,7 +51,7 @@ proc testio(x)
   }
 }
 
-proc test_readlines()
+proc test_readlines(stripNewline = false)
 {
 
   var f = openTempFile();
@@ -80,13 +80,15 @@ proc test_readlines()
   }
 
 
-  if noisy then writeln("Testing readlines: fileReader.lines()");
+  if noisy then writeln("Testing readlines: fileReader.lines(stripNewline=", stripNewline, ")");
   {
-    for (line,i) in zip(f.reader().lines(),1..) {
+    proc getTestString(s) do return if stripNewline then s else s + "\n";
+
+    for (line,i) in zip(f.reader().lines(stripNewline),1..) {
       if i == 1 {
-        assert(line == "a b\n");
+        assert(line == getTestString("a b"));
       } else if i == 2 {
-        assert(line == "c d\n");
+        assert(line == getTestString("c d"));
       } else {
         assert(false);
       }
@@ -133,4 +135,5 @@ proc main() {
   testio(new ioLiteral("test"));
   
   test_readlines();
+  test_readlines(true);
 }

--- a/test/io/readLine/lines.chpl
+++ b/test/io/readLine/lines.chpl
@@ -1,0 +1,48 @@
+use IO;
+use List;
+
+proc testData(param testNum) {
+  var f = openTempFile();
+  var w = f.writer();
+  var data: list(string);
+  if testNum == 1 {
+    data.append("hello from line 1\n");
+    data.append("hello from line 2\n");
+    data.append("hello from line 3 which is the last line\n");
+  }
+  else if testNum == 2 {
+    // empty file
+  }
+  else if testNum == 3 {
+    // one line with a newline
+    data.append("hello world\n");
+  }
+  else if testNum == 4 {
+    // file ending without a newline
+    data.append("hello world");
+  }
+  for l in data do w.write(l);
+  w.close();
+  return (f, data);
+}
+
+proc test(param testNum, param stripNewline) {
+  var (f, data) = testData(testNum);
+
+  var r = f.reader();
+  var lines = r.lines(stripNewline);
+  assert(lines.size == data.size);
+  for (lineFromFile, originalLine) in zip(lines, data) {
+    var compareLine = if stripNewline then originalLine.strip() else originalLine;
+    assert(lineFromFile == compareLine);
+  }
+  r.close();
+  
+  f.close();
+}
+
+
+for param i in 1..4 {
+  test(i, true);
+  test(i, false);
+}


### PR DESCRIPTION
adds an option to the `lines()` iterator on `fileReader` to remove the trailing newline.

```chapel
iter fileReader.lines(stripNewline = false)
```

## Summary of changes
- implement `stripNewline`
- augment an existing `lines()` test to test new option

## new tests
- add a new test just for `fileReader.lines()` to test boundary conditions

## testing
- paratest

---

[Reviewed by @jeremiah-corrado]

closes #19547
closes cray/chapel-private#4734