### PR TITLE
Improvements to diffusion tests

### DIFF
--- a/test/studies/diffusion/heat_2d.chpl
+++ b/test/studies/diffusion/heat_2d.chpl
@@ -22,7 +22,7 @@ const indices = {0..<nx, 0..<ny},
 var u : [indices] real;
 
 // setup initial conditions
-u = 1;
+u = 1.0;
 u[
   (0.5 / dx):int..<(1.0 / dx + 1):int,
   (0.5 / dy):int..<(1.0 / dy + 1):int

--- a/test/studies/diffusion/heat_2d.chpl
+++ b/test/studies/diffusion/heat_2d.chpl
@@ -1,4 +1,4 @@
-// ---- setup simulation parameters ------
+// ---- set up simulation parameters ------
 // declare configurable parameters with default values
 config const xLen = 2.0,    // length of the domain in x
              yLen = 2.0,    // length of the domain in y
@@ -13,7 +13,7 @@ const dx : real = xLen / (nx - 1),       // grid spacing in x
       dy : real = yLen / (ny - 1),       // grid spacing in y
       dt : real = sigma * dx * dy / nu;  // time step size
 
-// ---- setup the grid ------
+// ---- set up the grid ------
 // define a 2D domain and subdomain to describe the grid and its interior
 const indices = {0..<nx, 0..<ny},
       indicesInner = {1..<nx-1, 1..<ny-1};
@@ -21,7 +21,7 @@ const indices = {0..<nx, 0..<ny},
 // define a 2D array over the above domain
 var u : [indices] real;
 
-// setup initial conditions
+// set up initial conditions
 u = 1.0;
 u[
   (0.5 / dx):int..<(1.0 / dx + 1):int,

--- a/test/studies/diffusion/heat_2d.chpl
+++ b/test/studies/diffusion/heat_2d.chpl
@@ -1,22 +1,25 @@
-// setup simulation parameters
-config const xLen : real = 2,
-             yLen : real = 2,
-             nx = 31,
-             ny = 31,
-             nt = 50,
-             sigma = 0.25,
-             nu = 0.05;
+// ---- setup simulation parameters ------
+// declare configurable parameters with default values
+config const xLen = 2.0,    // length of the domain in x
+             yLen = 2.0,    // length of the domain in y
+             nx = 31,       // number of grid points in x
+             ny = 31,       // number of grid points in y
+             nt = 50,       // number of time steps
+             sigma = 0.25,  // CFL condition
+             nu = 0.05;     // viscosity
 
-const dx : real = xLen / (nx - 1),
-      dy : real = yLen / (ny - 1),
-      dt : real = sigma * dx * dy / nu;
+// declare non-configurable parameters
+const dx : real = xLen / (nx - 1),       // grid spacing in x
+      dy : real = yLen / (ny - 1),       // grid spacing in y
+      dt : real = sigma * dx * dy / nu;  // time step size
 
-// define a 2D domain and subdomain
-const dom = {0..<nx, 0..<ny},
-      domInner : subdomain(dom) = dom.expand(-1);
+// ---- setup the grid ------
+// define a 2D domain and subdomain to describe the grid and its interior
+const indices = {0..<nx, 0..<ny},
+      indicesInner = {1..<nx-1, 1..<ny-1};
 
-// define an array to hold the solution
-var u : [dom] real;
+// define a 2D array over the above domain
+var u : [indices] real;
 
 // setup initial conditions
 u = 1;
@@ -25,11 +28,18 @@ u[
   (0.5 / dy):int..<(1.0 / dy + 1):int
 ] = 2;
 
-// run finite difference computation
+// ---- run the finite difference computation ------
+// create a temporary copy of 'u' to store the previous time step
 var un = u;
-for n in 0..#nt {
+
+// iterate for 'nt' time steps
+for 1..nt {
+
+  // swap the arrays to prepare for the next time step
   u <=> un;
-  forall (i, j) in domInner {
+
+  // update the solution over the interior of the domain in parallel
+  forall (i, j) in indicesInner {
     u[i, j] = un[i, j] +
               nu * dt / dy**2 *
                 (un[i-1, j] - 2 * un[i, j] + un[i+1, j]) +
@@ -38,7 +48,7 @@ for n in 0..#nt {
   }
 }
 
-// print the standard deviation of the solution
+// ---- print final results ------
 const mean = (+ reduce u) / u.size,
       stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
 

--- a/test/studies/diffusion/heat_2d.chpl
+++ b/test/studies/diffusion/heat_2d.chpl
@@ -9,9 +9,9 @@ config const xLen = 2.0,    // length of the domain in x
              nu = 0.05;     // viscosity
 
 // declare non-configurable parameters
-const dx : real = xLen / (nx - 1),       // grid spacing in x
-      dy : real = yLen / (ny - 1),       // grid spacing in y
-      dt : real = sigma * dx * dy / nu;  // time step size
+const dx: real = xLen / (nx - 1),       // grid spacing in x
+      dy: real = yLen / (ny - 1),       // grid spacing in y
+      dt: real = sigma * dx * dy / nu;  // time step size
 
 // ---- set up the grid ------
 // define a 2D domain and subdomain to describe the grid and its interior
@@ -19,7 +19,7 @@ const indices = {0..<nx, 0..<ny},
       indicesInner = {1..<nx-1, 1..<ny-1};
 
 // define a 2D array over the above domain
-var u : [indices] real;
+var u: [indices] real;
 
 // set up initial conditions
 u = 1.0;

--- a/test/studies/diffusion/heat_2d_dist.chpl
+++ b/test/studies/diffusion/heat_2d_dist.chpl
@@ -24,7 +24,7 @@ const indices = {0..<nx, 0..<ny} dmapped Stencil({1..<nx-1, 1..<ny-1}, fluff=(1,
 var u : [indices] real;
 
 // setup initial conditions
-u = 1;
+u = 1.0;
 u[
   (0.5 / dx):int..<(1.0 / dx + 1):int,
   (0.5 / dy):int..<(1.0 / dy + 1):int

--- a/test/studies/diffusion/heat_2d_dist.chpl
+++ b/test/studies/diffusion/heat_2d_dist.chpl
@@ -11,9 +11,9 @@ config const xLen = 2.0,    // length of the domain in x
              nu = 0.05;     // viscosity
 
 // declare non-configurable parameters
-const dx : real = xLen / (nx - 1),       // grid spacing in x
-      dy : real = yLen / (ny - 1),       // grid spacing in y
-      dt : real = sigma * dx * dy / nu;  // time step size
+const dx: real = xLen / (nx - 1),       // grid spacing in x
+      dy: real = yLen / (ny - 1),       // grid spacing in y
+      dt: real = sigma * dx * dy / nu;  // time step size
 
 // ---- set up the grid ------
 // define a distributed 2D domain and subdomain to describe the grid and its interior
@@ -21,7 +21,7 @@ const indices = {0..<nx, 0..<ny} dmapped Stencil({1..<nx-1, 1..<ny-1}, fluff=(1,
       indicesInner = indices[{1..<nx-1, 1..<ny-1}];
 
 // define a distributed 2D array over the above domain
-var u : [indices] real;
+var u: [indices] real;
 
 // set up initial conditions
 u = 1.0;

--- a/test/studies/diffusion/heat_2d_dist.chpl
+++ b/test/studies/diffusion/heat_2d_dist.chpl
@@ -1,26 +1,27 @@
 use StencilDist;
 
-// setup simulation parameters
-config const xLen : real = 2,
-             yLen : real = 2,
-             nx = 31,
-             ny = 31,
-             nt = 50,
-             sigma = 0.25,
-             nu = 0.05;
+// ---- setup simulation parameters ------
+// declare configurable parameters with default values
+config const xLen = 2.0,    // length of the domain in x
+             yLen = 2.0,    // length of the domain in y
+             nx = 31,       // number of grid points in x
+             ny = 31,       // number of grid points in y
+             nt = 50,       // number of time steps
+             sigma = 0.25,  // CFL condition
+             nu = 0.05;     // viscosity
 
-const dx : real = xLen / (nx - 1),
-      dy : real = yLen / (ny - 1),
-      dt : real = sigma * dx * dy / nu;
+// declare non-configurable parameters
+const dx : real = xLen / (nx - 1),       // grid spacing in x
+      dy : real = yLen / (ny - 1),       // grid spacing in y
+      dt : real = sigma * dx * dy / nu;  // time step size
 
-// define a 2D domain and subdomain
-const dom = {0..<nx, 0..<ny},
-      domInner = dom.expand(-1),
-      DOM = dom dmapped Stencil(domInner, fluff=(1, 1)),
-      DOMINNER : subdomain(DOM) = DOM[domInner];
+// ---- setup the grid ------
+// define a distributed 2D domain and subdomain to describe the grid and its interior
+const indices = {0..<nx, 0..<ny} dmapped Stencil({1..<nx-1, 1..<ny-1}, fluff=(1,1)),
+      indicesInner = indices[{1..<nx-1, 1..<ny-1}];
 
-// define a distributed array to hold the solution
-var u : [DOM] real;
+// define a distributed 2D array over the above domain
+var u : [indices] real;
 
 // setup initial conditions
 u = 1;
@@ -29,13 +30,21 @@ u[
   (0.5 / dy):int..<(1.0 / dy + 1):int
 ] = 2;
 
-// run finite difference computation
+// ---- run the finite difference computation ------
+// create a temporary copy of 'u' to store the previous time step
 var un = u;
-for n in 0..#nt {
+
+// iterate for 'nt' time steps
+for 1..nt {
+
+  // swap the arrays to prepare for the next time step
   u <=> un;
+
+  // swap halo regions between neighboring compute nodes
   un.updateFluff();
 
-  forall (i, j) in DOMINNER {
+  // update the solution over the interior of the domain in parallel
+  forall (i, j) in indicesInner {
     u[i, j] = un[i, j] +
               nu * dt / dy**2 *
                 (un[i-1, j] - 2 * un[i, j] + un[i+1, j]) +
@@ -44,7 +53,7 @@ for n in 0..#nt {
   }
 }
 
-// print the standard deviation of the solution
+// ---- print final results ------
 const mean = (+ reduce u) / u.size,
       stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
 

--- a/test/studies/diffusion/heat_2d_dist.chpl
+++ b/test/studies/diffusion/heat_2d_dist.chpl
@@ -1,6 +1,6 @@
 use StencilDist;
 
-// ---- setup simulation parameters ------
+// ---- set up simulation parameters ------
 // declare configurable parameters with default values
 config const xLen = 2.0,    // length of the domain in x
              yLen = 2.0,    // length of the domain in y
@@ -15,7 +15,7 @@ const dx : real = xLen / (nx - 1),       // grid spacing in x
       dy : real = yLen / (ny - 1),       // grid spacing in y
       dt : real = sigma * dx * dy / nu;  // time step size
 
-// ---- setup the grid ------
+// ---- set up the grid ------
 // define a distributed 2D domain and subdomain to describe the grid and its interior
 const indices = {0..<nx, 0..<ny} dmapped Stencil({1..<nx-1, 1..<ny-1}, fluff=(1,1)),
       indicesInner = indices[{1..<nx-1, 1..<ny-1}];
@@ -23,7 +23,7 @@ const indices = {0..<nx, 0..<ny} dmapped Stencil({1..<nx-1, 1..<ny-1}, fluff=(1,
 // define a distributed 2D array over the above domain
 var u : [indices] real;
 
-// setup initial conditions
+// set up initial conditions
 u = 1.0;
 u[
   (0.5 / dx):int..<(1.0 / dx + 1):int,

--- a/test/studies/diffusion/heat_2d_dist.skipif
+++ b/test/studies/diffusion/heat_2d_dist.skipif
@@ -1,1 +1,0 @@
-CHPL_COMM==none


### PR DESCRIPTION
Improvements to heat equation FD solvers (under `test/studies/diffusion`) based on Brad's post-merge feedback here: https://github.com/chapel-lang/chapel/pull/22105

These changes are mostly stylistic. I also removed the `.skipif` on the distributed version s.t. it also runs for `CHPL_COMM=none`.

- [X] reran tests in `gasnet` and `none` comm configurations