### PR TITLE
Fix c2chapel-tester const pointer test

### DIFF
--- a/test/c2chapel/c2chapel-tester.good
+++ b/test/c2chapel/c2chapel-tester.good
@@ -6,6 +6,7 @@ anonymousStruct: OK
 arrayDecl: OK
 chapelKeywords: OK
 chapelVarargs: OK
+constPointer: OK
 cstrvoid: OK
 dashEye: OK
 enum: OK
@@ -28,6 +29,7 @@ anonymousStruct: OK
 arrayDecl: OK
 chapelKeywords: OK
 chapelVarargs: OK
+constPointer: OK
 cstrvoid: OK
 dashEye: OK
 enum: OK


### PR DESCRIPTION
Fixes `test/c2chapel/c2chapel-tester.good` for addition of const pointer test in https://github.com/chapel-lang/chapel/pull/21913.

The const pointer c2chapel test appears to be working properly, but I had neglected to update this `.good` to expect output from it.

[reviewer info placeholder]

Testing:
- [x] c2chapel tests locally
- [x] paratest (which appears not to cover this test?)