### PR TITLE
Fix strict aliasing check for c_string pointee casts

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -358,6 +358,8 @@ module CTypes {
     } else if (from == c_string) {
       // a c_string can be interpreted as a pointer to c_char for these purposes
       return pointeeCastStrictAliasingAllowed(c_char, to.eltType);
+    } else if (to == c_string) {
+      return pointeeCastStrictAliasingAllowed(from.eltType, c_char);
     }
     // allow identical types
     if (from == to) {

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -355,6 +355,9 @@ module CTypes {
         return true;
       }
       return pointeeCastStrictAliasingAllowed(from.eltType, to.eltType);
+    } else if (from == c_string) {
+      // a c_string can be interpreted as a pointer to c_char for these purposes
+      return pointeeCastStrictAliasingAllowed(c_char, to.eltType);
     }
     // allow identical types
     if (from == to) {

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -347,19 +347,21 @@ module CTypes {
   pragma "no doc"
   inline proc pointeeCastStrictAliasingAllowed(type from, type to) param
       : bool {
-    // if from and to are both pointer types themselves, recurse into their
-    // respective pointee types (strip a layer of indirection)
-    if (isAnyCPtr(from) && isAnyCPtr(to)) {
+    // special checking when either to or from is a pointer
+    if (isAnyCPtr(from) || isAnyCPtr(to)) {
       // allow casting to and from void pointer pointee type
       if (from == c_void_ptr || to == c_void_ptr) {
         return true;
+      } else if (isAnyCPtr(from) && isAnyCPtr(to)) {
+        // if from and to are both pointer types themselves, recurse into their
+        // respective pointee types (strip a layer of indirection)
+        return pointeeCastStrictAliasingAllowed(from.eltType, to.eltType);
+      } else if (from == c_string) {
+        // a c_string can be interpreted as a pointer to c_char for this purpose
+        return pointeeCastStrictAliasingAllowed(c_char, to.eltType);
+      } else if (to == c_string) {
+        return pointeeCastStrictAliasingAllowed(from.eltType, c_char);
       }
-      return pointeeCastStrictAliasingAllowed(from.eltType, to.eltType);
-    } else if (from == c_string) {
-      // a c_string can be interpreted as a pointer to c_char for these purposes
-      return pointeeCastStrictAliasingAllowed(c_char, to.eltType);
-    } else if (to == c_string) {
-      return pointeeCastStrictAliasingAllowed(from.eltType, c_char);
     }
     // allow identical types
     if (from == to) {

--- a/test/types/cptr/c_ptr_c_string.chpl
+++ b/test/types/cptr/c_ptr_c_string.chpl
@@ -11,6 +11,7 @@ proc main() {
   var x:string = "hello";
 
   var cstr = x.c_str();
+  var cstr_p : c_ptr(c_string) = c_ptrTo(cstr);
   var p1 = cstr:c_void_ptr;
   var p2 = cstr:c_ptr(c_char);
   var p3 = cstr:c_ptr(int(8));
@@ -18,6 +19,7 @@ proc main() {
   var p5 = cstr:c_ptrConst(c_char);
   var p6 = cstr:c_ptrConst(int(8));
   var p7 = cstr:c_ptrConst(uint(8));
+  var p8 = cstr_p:c_ptr(c_ptr(uint(8)));
 
   var c1 = p1:c_string;
   var c2 = p2:c_string;
@@ -26,6 +28,7 @@ proc main() {
   var c5 = p5:c_string;
   var c6 = p6:c_string;
   var c7 = p7:c_string;
+  var c8 = p8:c_ptr(c_string);
 
   printit(c1);
   printit(c2);

--- a/test/types/cptr/c_ptr_c_string.chpl
+++ b/test/types/cptr/c_ptr_c_string.chpl
@@ -19,7 +19,10 @@ proc main() {
   var p5 = cstr:c_ptrConst(c_char);
   var p6 = cstr:c_ptrConst(int(8));
   var p7 = cstr:c_ptrConst(uint(8));
+
   var p8 = cstr_p:c_ptr(c_ptr(uint(8)));
+  var p9 = cstr_p:c_ptr(c_void_ptr);
+  var p10 = cstr_p:c_ptrConst(c_ptr(uint(8)));
 
   var c1 = p1:c_string;
   var c2 = p2:c_string;
@@ -28,7 +31,10 @@ proc main() {
   var c5 = p5:c_string;
   var c6 = p6:c_string;
   var c7 = p7:c_string;
+
   var c8 = p8:c_ptr(c_string);
+  var c9 = p9:c_ptr(c_string);
+  var c10 = p10:c_ptrConst(c_string);
 
   printit(c1);
   printit(c2);
@@ -37,4 +43,8 @@ proc main() {
   printit(c5);
   printit(c6);
   printit(c7);
+
+  printit(c8.deref());
+  printit(c9.deref());
+  printit(c10.deref());
 }

--- a/test/types/cptr/c_ptr_c_string.good
+++ b/test/types/cptr/c_ptr_c_string.good
@@ -5,3 +5,6 @@ hello
 hello
 hello
 hello
+hello
+hello
+hello


### PR DESCRIPTION
This is a second attempt at fixing an incorrect strict aliasing warning when casting from a `c_ptr(c_string)` to a `c_ptr(c_ptr(c_char))`, which is causing nightly test failures.

This is a follow up to the first attempt in https://github.com/chapel-lang/chapel/pull/22116 which fixed part of the issue. Although comparing pointee types is fixed, the strict aliasing check was incorrectly warning on the cast from the contained pointee types `c_string` to `c_ptr(c_char)`. This is not tripped for a direct cast from a `c_string` to `c_ptr(c_char)` as that is separately implemented, and not handled via the cptr-to-cptr that has a strict aliasing check.

This PR causes the check to treat a `c_string` as a pointer to `c_char` for the purpose of aliasing. It works for casting either to or from a c_string pointee, and adds testing for both.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] locally testing `interop/fortran/FortranCallChapel/chapelProcs` and `interop/fortran/genFortranInterface/chapelProcs` (can't run the fortran, but aliasing warning is observed before this PR anyways)