### PR TITLE
Suppress pointer cast strict aliasing warning in cuBLAS test

### DIFF
--- a/test/gpu/interop/cuBLAS/cuBLAS.chpl
+++ b/test/gpu/interop/cuBLAS/cuBLAS.chpl
@@ -27,7 +27,7 @@ module cuBLAS {
   proc cpu_to_gpu(src_ptr: c_ptr(?t), size: c_size_t){
     require "c_cublas.h", "c_cublas.o";
     var gpu_ptr: DevicePtr(t);
-    gpu_ptr.val = to_gpu(src_ptr, size): c_ptr(t);
+    gpu_ptr.val = to_gpu(src_ptr, size):c_void_ptr:c_ptr(t);
     return gpu_ptr;
   }
 


### PR DESCRIPTION
Suppresses a warning for casting between incompatible pointee types in the `cpu_to_gpu` function in GPU `cuBLAS` test, by casting through `c_void_ptr`.

[reviewer info placeholder]

Testing:
- [x] warnings disappear for GPU testing `gpu/interop/cuBLAS/level1/test_cublas1`