### PR TITLE
Fix testInteractive code to not assert the existence of resolve results

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1456,6 +1456,9 @@ class ResolvedFunction {
   const ResolvedExpression& byAst(const uast::AstNode* ast) const {
     return resolutionById_.byAst(ast);
   }
+  const ResolvedExpression* byAstOrNull(const uast::AstNode* ast) const {
+    return resolutionById_.byAstOrNull(ast);
+  }
 
   const ID& id() const {
     return signature_->id();

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -66,25 +66,25 @@ resolvedExpressionForAstInteractive(Context* context, const AstNode* ast,
         if (parentAst->isModule()) {
           if (scopeResolveOnly) {
             const auto& byId = scopeResolveModule(context, parentAst->id());
-            return &byId.byAst(ast);
+            return byId.byAstOrNull(ast);
           } else {
             const auto& byId = resolveModule(context, parentAst->id());
-            return &byId.byAst(ast);
+            return byId.byAstOrNull(ast);
           }
         } else if (auto parentFn = parentAst->toFunction()) {
           auto untyped = UntypedFnSignature::get(context, parentFn);
           // use inFn if it matches
           if (inFn && inFn->signature()->untyped() == untyped) {
-            return &inFn->resolutionById().byAst(ast);
+            return inFn->byAstOrNull(ast);
           } else {
             if (scopeResolveOnly) {
               auto rFn = scopeResolveFunction(context, parentFn->id());
-              return &rFn->resolutionById().byAst(ast);
+              return rFn->byAstOrNull(ast);
             } else {
               auto typed = typedSignatureInitial(context, untyped);
               if (!typed->needsInstantiation()) {
                 auto rFn = resolveFunction(context, typed, nullptr);
-                return &rFn->resolutionById().byAst(ast);
+                return rFn->byAstOrNull(ast);
               }
             }
           }
@@ -100,9 +100,8 @@ resolvedExpressionForAstInteractive(Context* context, const AstNode* ast,
     return nullptr;
   }
 
-  if (inFn != nullptr && inFn->id() != ast->id() &&
-      inFn->id().contains(ast->id())) {
-    return &inFn->byAst(ast);
+  if (inFn != nullptr && inFn->id() != ast->id()) {
+    return inFn->byAstOrNull(ast);
   }
   return nullptr;
 }


### PR DESCRIPTION
Previously, this code in `testInteractive` used `ID::contains` to check if it was safe to access the function's resolution results. This worked because the resolution results always had a vector big enough to contain all the IDs in the function. However, recent changes (https://github.com/chapel-lang/chapel/pull/21765), switched this from a vector to a map, which is only filled on-demand. In a const-access, it's possible that calls to `byAst` will not find an `ID` in the map when previously it would be found in the vector. This PR fixes such issues in `testInteractive` by using `byAstOrNull` instead of the (possibly-throwing) `byAst`.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] full local