### PR TITLE
Remove old, unused checkNoUnresolveds function

### DIFF
--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -76,21 +76,6 @@ void checkArgsAndLocals()
   }
 }
 
-// Check that no unresolved symbols remain in the tree.
-// This one is pretty cheap, so can be run after every pass (following
-// resolution).
-void checkNoUnresolveds()
-{
-  // BHARSH INIT TODO: Can this be '0' now that the tuple constructor is gone?
-  //
-  // TODO: This value should really be cranked down to 0.
-  // But in some cases _construct__tuple remains unresolved after
-  // resolution ... .
-  if (gUnresolvedSymExprs.n > 1)
-    INT_FATAL("Structural error: "
-      "At this point, the AST should not contain any unresolved symbols.");
-}
-
 // Ensures that primitives are used only where they are expected.
 void checkPrimitives()
 {

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -86,7 +86,6 @@ void verify();
 void checkInvariants(char log_tag);
 void checkPrimitives();                 // constrains primitive use
 void checkPostResolution();
-void checkNoUnresolveds();
 // These checks can be applied after any pass.
 void checkForDuplicateUses();
 void checkArgsAndLocals();

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -498,9 +498,6 @@ static void check_afterResolution()
     checkResolveRemovedPrims();
 // Disabled for now because user warnings should not be logged multiple times:
 //    checkResolved();
-// Disabled for now because it does not hold when named externs are present.
-// See test/extern/hilde/namedExtern.chpl.
-//    checkNoUnresolveds();
     checkFormalActualBaseTypesMatch();
     checkRetTypeMatchesRetVarType();
     checkAutoCopyMap();
@@ -566,9 +563,6 @@ static void check_afterCallDestructors()
   {
 // Disabled for now because user warnings should not be logged multiple times:
 //    checkResolved();
-// Disabled for now because it does not hold when named externs are present.
-// See test/extern/hilde/namedExtern.chpl.
-//    checkNoUnresolveds();
     checkFormalActualTypesMatch();
   }
 }


### PR DESCRIPTION
Calls to the "checkNoUnresolveds" check have been commented out for quite a long time. I spent a small amount of time investigating what it might take to re-enable, but the internal state of the compiler has changed so much since this test was disabled that it's probably not worth trying to get working again.

Since we've lived without this check for so long, this PR removes the check so that we don't have to think about maintaining it anymore.