### PR TITLE
Build amudprun-host with host values of CC/CXX

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -77,9 +77,7 @@ endif
 # built for the target platform. Note that this uses an "unofficial" target
 # that the gasnet team has provided for us.
 ifeq ($(CHPL_MAKE_LAUNCHER),amudprun)
-HOST_CC=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host make -f $(CHPL_MAKE_HOME)/make/Makefile.base printQ-CC)
-HOST_CXX=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host make -f $(CHPL_MAKE_HOME)/make/Makefile.base printQ-CXX)
-XTRA_POST_BUILD_COMMAND=cd $(GASNET_BUILD_DIR)/other/amudp && $(MAKE) CC='$(HOST_CC)' CXX='$(HOST_CXX)' amudprun-host && mv amudprun-host amudprun
+XTRA_POST_BUILD_COMMAND=cd $(GASNET_BUILD_DIR)/other/amudp && $(MAKE) CC='$(CHPL_MAKE_HOST_CC)' CXX='$(CHPL_MAKE_HOST_CXX)' amudprun-host && mv amudprun-host amudprun
 endif
 
 

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -77,7 +77,9 @@ endif
 # built for the target platform. Note that this uses an "unofficial" target
 # that the gasnet team has provided for us.
 ifeq ($(CHPL_MAKE_LAUNCHER),amudprun)
-XTRA_POST_BUILD_COMMAND=cd $(GASNET_BUILD_DIR)/other/amudp && $(MAKE) amudprun-host && mv amudprun-host amudprun
+HOST_CC=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host make -f $(CHPL_MAKE_HOME)/make/Makefile.base printQ-CC)
+HOST_CXX=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host make -f $(CHPL_MAKE_HOME)/make/Makefile.base printQ-CXX)
+XTRA_POST_BUILD_COMMAND=cd $(GASNET_BUILD_DIR)/other/amudp && $(MAKE) CC='$(HOST_CC)' CXX='$(HOST_CXX)' amudprun-host && mv amudprun-host amudprun
 endif
 
 

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -5,10 +5,6 @@ endif
 CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
-# Get the host compiler (some build-time programs are compiled and run to
-# generate host-specific data table, and these run on the host/build node)
-HOST_CC=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host make -f $(CHPL_MAKE_HOME)/make/Makefile.base printQ-CC)
-
 #
 # Cray builds are cross-compilations
 #
@@ -71,7 +67,7 @@ $(GMP_BUILD_SUBDIR):
 $(GMP_H_FILE): $(GMP_BUILD_SUBDIR)
 	touch $(GMP_SUBDIR)/doc/gmp.info*
 	touch $(GMP_SUBDIR)/demos/calc/calc*.c
-	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC_FOR_BUILD='$(HOST_CC)' CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
+	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC_FOR_BUILD='$(CHPL_MAKE_HOST_CC)' CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
 	cd $(GMP_BUILD_DIR) && $(MAKE)
 ifeq ($(GMP_CROSS_COMPILED),no)
 	cd $(GMP_BUILD_DIR) && $(MAKE) check


### PR DESCRIPTION
For some time, we have relied on a GASNet target that was introduced for our sake, `amudprun-host`, which builds `amudprun` in a way that permits it to be run on the host rather than target in a cross-compiling setting.  It seems that, since forever, that target has relied on default values of `CC=gcc` and `CXX=g++` which work in most places, but of course wouldn't work on a system that didn't have such compilers available.  This changes our invocation of the build line to pass along our own predetermined values for HOST_CC and HOST_CXX for use instead.

While here, I also updated third-party/gmp/Makefile to use the same Makefile variables rather than an explicit `shell` command (which is how my first draft of this change was also written until I found myself thinking "surely there must be a cheaper way"—it very well may be that there wasn't a cheaper way when that Makefile was added).