### PR TITLE
Make c_pointer_return_const return a non-const pointer

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -658,7 +658,11 @@ module CTypes {
   pragma "no doc"
   pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
-  extern proc c_pointer_return(const ref x:?t):c_ptr(t);
+  extern proc c_pointer_return(ref x:?t):c_ptr(t);
+  pragma "no doc"
+  pragma "fn synchronization free"
+  pragma "codegen for CPU and GPU"
+  extern proc c_pointer_return_const(const ref x:?t):c_ptrConst(t);
   pragma "no doc"
   pragma "fn synchronization free"
   extern proc c_pointer_diff(a:c_void_ptr, b:c_void_ptr,
@@ -713,7 +717,7 @@ module CTypes {
         halt("Can't create a C pointer for an array with 0 elements.");
     }
 
-    return c_pointer_return(arr[arr.domain.low]):c_ptrConst(arr.eltType);
+    return c_pointer_return_const(arr[arr.domain.low]);
   }
 
   /*
@@ -744,7 +748,7 @@ module CTypes {
     if isDomainType(t) then
       compilerError("c_ptrToConst domain type not supported", 2);
     // Other cases should be avoided, e.g. sync vars
-    return c_pointer_return(x):c_ptrConst(t);
+    return c_pointer_return_const(x);
   }
 
   pragma "no doc"

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -658,11 +658,7 @@ module CTypes {
   pragma "no doc"
   pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
-  extern proc c_pointer_return(ref x:?t):c_ptr(t);
-  pragma "no doc"
-  pragma "fn synchronization free"
-  pragma "codegen for CPU and GPU"
-  extern proc c_pointer_return_const(const ref x:?t):c_ptrConst(t);
+  extern proc c_pointer_return(const ref x:?t):c_ptr(t);
   pragma "no doc"
   pragma "fn synchronization free"
   extern proc c_pointer_diff(a:c_void_ptr, b:c_void_ptr,
@@ -717,7 +713,7 @@ module CTypes {
         halt("Can't create a C pointer for an array with 0 elements.");
     }
 
-    return c_pointer_return_const(arr[arr.domain.low]);
+    return c_pointer_return(arr[arr.domain.low]):c_ptrConst(arr.eltType);
   }
 
   /*
@@ -748,7 +744,7 @@ module CTypes {
     if isDomainType(t) then
       compilerError("c_ptrToConst domain type not supported", 2);
     // Other cases should be avoided, e.g. sync vars
-    return c_pointer_return_const(x);
+    return c_pointer_return(x):c_ptrConst(t);
   }
 
   pragma "no doc"

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -73,7 +73,8 @@ typedef _Bool chpl_bool;
 typedef bool chpl_bool;
 #endif
 
-static inline void* c_pointer_return(const void* x) { return (void*)x; }
+static inline void* c_pointer_return(void* x) { return x; }
+static inline void* c_pointer_return_const(const void* x) { return (void*)x; }
 static inline ptrdiff_t c_pointer_diff(void* a, void* b, ptrdiff_t eltSize) {
   return (((unsigned char*)a) - ((unsigned char*)b)) / eltSize;
 }

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -74,7 +74,7 @@ typedef bool chpl_bool;
 #endif
 
 static inline void* c_pointer_return(void* x) { return x; }
-static inline const void* c_pointer_return_const(const void* x) { return x; }
+static inline void* c_pointer_return_const(const void* x) { return (void*)x; }
 static inline ptrdiff_t c_pointer_diff(void* a, void* b, ptrdiff_t eltSize) {
   return (((unsigned char*)a) - ((unsigned char*)b)) / eltSize;
 }

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -74,6 +74,14 @@ typedef bool chpl_bool;
 #endif
 
 static inline void* c_pointer_return(void* x) { return x; }
+// TODO: Return a const void* and remove the const-discarding cast, here as well
+// as in the GPU runtime versions.
+// This is currently not possible as our C backend does not consistently respect
+// constness and would generate code that discards the const qualifier.
+// Constness is casted away here because we still need to accept a const
+// argument to get pointers to const Chapel variables; preventing mutation of
+// pointed-to const variables is enforced before this point.
+// Anna, April 2023.
 static inline void* c_pointer_return_const(const void* x) { return (void*)x; }
 static inline ptrdiff_t c_pointer_diff(void* a, void* b, ptrdiff_t eltSize) {
   return (((unsigned char*)a) - ((unsigned char*)b)) / eltSize;

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -73,8 +73,7 @@ typedef _Bool chpl_bool;
 typedef bool chpl_bool;
 #endif
 
-static inline void* c_pointer_return(void* x) { return x; }
-static inline void* c_pointer_return_const(const void* x) { return (void*)x; }
+static inline void* c_pointer_return(const void* x) { return (void*)x; }
 static inline ptrdiff_t c_pointer_diff(void* a, void* b, ptrdiff_t eltSize) {
   return (((unsigned char*)a) - ((unsigned char*)b)) / eltSize;
 }

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -59,8 +59,7 @@ __device__ static inline chpl_localeID_t chpl_gen_getLocaleID(void)
   return localeID;
 }
 
-__device__ static inline void* c_pointer_return(void* x) { return x; }
-__device__ static inline void* c_pointer_return_const(const void* x) {
+__device__ static inline void* c_pointer_return(const void* x) {
   return (void*)x;
 }
 

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -60,8 +60,8 @@ __device__ static inline chpl_localeID_t chpl_gen_getLocaleID(void)
 }
 
 __device__ static inline void* c_pointer_return(void* x) { return x; }
-__device__ static inline const void* c_pointer_return_const(const void* x) {
-  return x;
+__device__ static inline void* c_pointer_return_const(const void* x) {
+  return (void*)x;
 }
 
 __device__ static inline chpl_localeID_t chpl_rt_buildLocaleID(c_nodeid_t node,  c_sublocid_t subloc) {

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -59,7 +59,8 @@ __device__ static inline chpl_localeID_t chpl_gen_getLocaleID(void)
   return localeID;
 }
 
-__device__ static inline void* c_pointer_return(const void* x) {
+__device__ static inline void* c_pointer_return(void* x) { return x; }
+__device__ static inline void* c_pointer_return_const(const void* x) {
   return (void*)x;
 }
 

--- a/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
@@ -59,8 +59,7 @@ __device__ static inline chpl_localeID_t chpl_gen_getLocaleID(void)
   return localeID;
 }
 
-__device__ static inline void* c_pointer_return(void* x) { return x; }
-__device__ static inline void* c_pointer_return_const(const void* x) {
+__device__ static inline void* c_pointer_return(const void* x) {
   return (void*)x;
 }
 

--- a/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
@@ -60,8 +60,8 @@ __device__ static inline chpl_localeID_t chpl_gen_getLocaleID(void)
 }
 
 __device__ static inline void* c_pointer_return(void* x) { return x; }
-__device__ static inline const void* c_pointer_return_const(const void* x) {
-  return x;
+__device__ static inline void* c_pointer_return_const(const void* x) {
+  return (void*)x;
 }
 
 __device__ static inline chpl_localeID_t chpl_rt_buildLocaleID(c_nodeid_t node,  c_sublocid_t subloc) {

--- a/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
@@ -59,7 +59,8 @@ __device__ static inline chpl_localeID_t chpl_gen_getLocaleID(void)
   return localeID;
 }
 
-__device__ static inline void* c_pointer_return(const void* x) {
+__device__ static inline void* c_pointer_return(void* x) { return x; }
+__device__ static inline void* c_pointer_return_const(const void* x) {
   return (void*)x;
 }
 


### PR DESCRIPTION
This PR modifies the `c_pointer_return_const` runtime function added in https://github.com/chapel-lang/chapel/pull/21913 to return a `void*` instead of `const void*`, addressing nightly failures related to discarding this const qualifier in generated C code that uses it.

Previously, `c_pointer_return` took a `void*` and returned it as a `void*`, and `c_pointer_return_const` took a `const void*` and returned it as a `const void*`. Unfortunately, returning a `const void*` does not work as we get warnings in the C backend for discarding the `const` qualifier, as our C backend does not consistently use `const` qualification; `c_pointer_return_const` needs to return a `void*`.

This PR is a follow up to https://github.com/chapel-lang/chapel/pull/22122, which removed `const` qualifier in generated C for `c_ptrConst` variables. This caused some failing tests to start failing with different messages, due to shifting where the first instance of `const` being discarded was. With the changes of this new PR there should be no instances.

- [x] paratest
- [x] `c_ptrConst` tests (`test/types/cptr/const`) succeed with C backend