### PR TITLE
fix(chpldoc): add LLVM as a build step for chpldoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ third-party-c2chapel-venv: FORCE
 test-venv: third-party-test-venv
 
 chpldoc: third-party-chpldoc-venv
+	@cd third-party && $(MAKE) llvm
 	cd compiler && $(MAKE) chpldoc
 	@cd modules && $(MAKE)
 	@test -r Makefile.devel && $(MAKE) man-chpldoc || echo ""


### PR DESCRIPTION
This PR fixes build failures introduced with PR #21876 for `chpldoc` when `chpl` was not built first. It adds a step to the top-level `Makefile` for the `chpldoc` target to also build LLVM, which is necessary when `CHPL_LLVM` is set to `none` or `bundled` 

reviewed by @vasslitvinov - thanks!