### PR TITLE
Deprecate including ldexp by default and move it to the Math module

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -865,13 +865,37 @@ module AutoMath {
      `false` otherwise. */
   inline proc isnan(x: real(32)): bool do return chpl_macro_float_isnan(x):bool;
 
-  /* Multiply by an integer power of 2.
-     Returns x * 2**n.
-     */
-  pragma "fn synchronization free"
-  pragma "codegen for CPU and GPU"
-  extern proc ldexp(x:real(64), n:int(32)):real(64);
+  // When removing this deprecated function, be sure to remove chpl_ldexp and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @deprecated(notes="In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
+  inline proc ldexp(x:real(64), n:int(32)):real(64) {
+    return chpl_ldexp(x, n);
+  }
+
+  @chpldoc.nodoc
+  inline proc chpl_ldexp(x:real(64), n:int(32)):real(64) {
+    // Note: this extern proc was originally free standing.  It might be
+    // reasonable to make it that way again when the deprecated version is
+    // removed
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc ldexp(x:real(64), n:int(32)):real(64);
+    return ldexp(x, n);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_ldexp and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @deprecated(notes="In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
   inline proc ldexp(x:real(32), n:int(32)):real(32) {
+    return chpl_ldexp(x, n);
+  }
+
+  @chpldoc.nodoc
+  inline proc chpl_ldexp(x:real(32), n:int(32)):real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc ldexpf(x:real(32), n:int(32)):real(32);

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -869,7 +869,7 @@ module AutoMath {
   // move its contents into Math.chpl to reduce the symbols living in this
   // module.
   pragma "last resort"
-  @deprecated(notes="In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
+  @deprecated(notes="In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the :mod:`Math` module to call it")
   inline proc ldexp(x:real(64), n:int(32)):real(64) {
     return chpl_ldexp(x, n);
   }
@@ -889,7 +889,7 @@ module AutoMath {
   // move its contents into Math.chpl to reduce the symbols living in this
   // module.
   pragma "last resort"
-  @deprecated(notes="In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it")
+  @deprecated(notes="In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the :mod:`Math` module to call it")
   inline proc ldexp(x:real(32), n:int(32)):real(32) {
     return chpl_ldexp(x, n);
   }

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -101,6 +101,18 @@ module Math {
     return chpl_erfc(x);
   }
 
+  /* Multiply by an integer power of 2.
+     Returns x * 2**n.
+     */
+  inline proc ldexp(x:real(64), n:int(32)):real(64) {
+    return chpl_ldexp(x, n);
+  }
+
+  inline proc ldexp(x:real(32), n:int(32)):real(32) {
+    return chpl_ldexp(x, n);
+  }
+
+
   /* Returns the natural logarithm of `x` + 1.
 
      It is an error if `x` is less than or equal to -1.

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -806,6 +806,7 @@ module Random {
 
     use super.RandomSupport;
     private use Random, IO;
+    private use Math only ldexp;
     private use PCGRandomLib;
     use ChapelLocks;
 

--- a/test/deprecated/Math/depLdexp.chpl
+++ b/test/deprecated/Math/depLdexp.chpl
@@ -1,0 +1,9 @@
+var a: real(64) = 4.0;
+var b: real(32) = 3.0;
+
+// Should be 16, but it's a real so there's variance
+var check1 = ldexp(a, 2);
+writeln(check1 < 17 && check1 > 15);
+// Should be 24, but it's a real so there's variance
+var check2 = ldexp(b, 3);
+writeln(check2 < 25 && check2 > 23);

--- a/test/deprecated/Math/depLdexp.good
+++ b/test/deprecated/Math/depLdexp.good
@@ -1,0 +1,4 @@
+depLdexp.chpl:5: warning: In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it
+depLdexp.chpl:8: warning: In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it
+true
+true

--- a/test/deprecated/Math/depLdexp.good
+++ b/test/deprecated/Math/depLdexp.good
@@ -1,4 +1,4 @@
-depLdexp.chpl:5: warning: In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it
-depLdexp.chpl:8: warning: In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the 'Math' module to call it
+depLdexp.chpl:5: warning: In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depLdexp.chpl:8: warning: In an upcoming release 'ldexp' will no longer be included by default, please 'use' or 'import' the Math module to call it
 true
 true

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -46,6 +46,7 @@ end of module search dirs
   $CHPL_HOME/modules/dists/BlockDist.chpl
   $CHPL_HOME/modules/standard/Set.chpl
   $CHPL_HOME/modules/standard/Time.chpl
+  $CHPL_HOME/modules/standard/Math.chpl
   $CHPL_HOME/modules/layouts/LayoutCS.chpl
   $CHPL_HOME/modules/dists/SparseBlockDist.chpl
 In bar

--- a/test/separate_compilation/serialization/testGenLib.MyMod.good
+++ b/test/separate_compilation/serialization/testGenLib.MyMod.good
@@ -85,6 +85,7 @@ b { fileTextQuery ("$CHPL_HOME/modules/packages/RangeChunk.chpl")
 2 { fileTextQuery ("$CHPL_HOME/modules/dists/BlockDist.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/standard/Set.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/standard/Time.chpl") 
+2 { fileTextQuery ("$CHPL_HOME/modules/standard/Math.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/layouts/LayoutCS.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/dists/SparseBlockDist.chpl") 
 MYPREFIX: doMyM-doMyM-doMyM

--- a/test/separate_compilation/serialization/testGenLib.OtherMod.good
+++ b/test/separate_compilation/serialization/testGenLib.OtherMod.good
@@ -85,6 +85,7 @@ b { fileTextQuery ("$CHPL_HOME/modules/packages/RangeChunk.chpl")
 2 { fileTextQuery ("$CHPL_HOME/modules/dists/BlockDist.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/standard/Set.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/standard/Time.chpl") 
+2 { fileTextQuery ("$CHPL_HOME/modules/standard/Math.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/layouts/LayoutCS.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/dists/SparseBlockDist.chpl") 
 MYPREFIX: MyMod MyMod MyMod

--- a/test/separate_compilation/serialization/testGenLib.both.good
+++ b/test/separate_compilation/serialization/testGenLib.both.good
@@ -84,6 +84,7 @@ b { fileTextQuery ("$CHPL_HOME/modules/packages/RangeChunk.chpl")
 2 { fileTextQuery ("$CHPL_HOME/modules/dists/BlockDist.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/standard/Set.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/standard/Time.chpl") 
+2 { fileTextQuery ("$CHPL_HOME/modules/standard/Math.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/layouts/LayoutCS.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/dists/SparseBlockDist.chpl") 
 MYPREFIX: doMyM-doMyM-doMyM


### PR DESCRIPTION
In earlier discussions of which Math symbols should be included
in all programs by default, we decided to stop including `ldexp`.

<details>
The commit for this ends up looking a little odd so that we don't
accidentally build the Math module by default as well - make an
undocumented version that Math and the deprecated version can
call, so that Math depends on AutoMath and the two versions stay
in sync until the deprecated version is removed. This strategy was
previously followed for other symbols in the Math module.

Note that, unlike previous PRs along these lines, this is not
sufficient to prevent Math.chpl's inclusion in some of our tests
that track which files are traversed (though it is still sufficient to
prevent it from being initialized, which I think means it is not
generated for the final binary for normal Chapel programs).  This
is because Random.chpl needs a use of the module to continue
to use `ldexp` in its submodule.
</details>

Adds a private use of the Math module to Random.chpl's
`PCGRandom` submodule.

Adds a test to lock in the deprecation message.

No tests needed to be updated because the ones that relied on
ldexp already had a use of the Math module.

Passed a full paratest with futures