### PR TITLE
Deprecate IO module's `_mark`, `_revert`, `_commit`, and `_offset`

### DIFF
--- a/modules/packages/MatrixMarket.chpl
+++ b/modules/packages/MatrixMarket.chpl
@@ -218,7 +218,7 @@ class MMReader {
      var pctflag = false;
      while !pctflag {
        var percentfound:string;
-       var offset = fin.offset();
+       var offset = fin.chpl_offset();
        fin.readLine(percentfound);
 
        // didn't find a percentage, rewind channel by length of read string...

--- a/modules/packages/MatrixMarket.chpl
+++ b/modules/packages/MatrixMarket.chpl
@@ -218,7 +218,7 @@ class MMReader {
      var pctflag = false;
      while !pctflag {
        var percentfound:string;
-       var offset = fin._offset();
+       var offset = fin.offset();
        fin.readLine(percentfound);
 
        // didn't find a percentage, rewind channel by length of read string...

--- a/modules/packages/ProtobufProtocolSupport.chpl
+++ b/modules/packages/ProtobufProtocolSupport.chpl
@@ -277,10 +277,10 @@ module ProtobufProtocolSupport {
     }
 
     proc messageAppendBase(val, ch:writingChannel) throws {
-     var initialOffset = ch.offset();
+     var initialOffset = ch.chpl_offset();
      ch.mark();
      val._serialize(ch);
-     var currentOffset = ch.offset();
+     var currentOffset = ch.chpl_offset();
      ch.revert();
      unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
      val._serialize(ch);
@@ -522,11 +522,11 @@ module ProtobufProtocolSupport {
       param protoValueType: string, ch:writingChannel) throws {
       for (key, value) in zip(val.keys(), val.values()) {
         tagAppend(fieldNumber, lengthDelimited, ch);
-        var initialOffset = ch.offset();
+        var initialOffset = ch.chpl_offset();
         ch.mark();
         protoFieldAppendHelper(key, 1, protoKeyType, ch);
         protoFieldAppendHelper(value, 2, protoValueType, ch);
-        var currentOffset = ch.offset();
+        var currentOffset = ch.chpl_offset();
         ch.revert();
         unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
         protoFieldAppendHelper(key, 1, protoKeyType, ch);
@@ -738,12 +738,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
       ch.mark();
       for val in valList {
         uint64AppendBase(val, ch);
       }
-      var currentOffset = ch.offset();
+      var currentOffset = ch.chpl_offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -753,11 +753,11 @@ module ProtobufProtocolSupport {
 
     proc uint64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(uint(64));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = uint64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -768,12 +768,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
       ch.mark();
       for val in valList {
         uint32AppendBase(val, ch);
       }
-      var currentOffset = ch.offset();
+      var currentOffset = ch.chpl_offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -783,11 +783,11 @@ module ProtobufProtocolSupport {
 
     proc uint32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(uint(32));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = uint32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -798,12 +798,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
       ch.mark();
       for val in valList {
         int64AppendBase(val, ch);
       }
-      var currentOffset = ch.offset();
+      var currentOffset = ch.chpl_offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -813,11 +813,11 @@ module ProtobufProtocolSupport {
 
     proc int64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(int(64));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = int64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -828,12 +828,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
       ch.mark();
       for val in valList {
         int32AppendBase(val, ch);
       }
-      var currentOffset = ch.offset();
+      var currentOffset = ch.chpl_offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -843,11 +843,11 @@ module ProtobufProtocolSupport {
 
     proc int32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(int(32));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = int32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -867,11 +867,11 @@ module ProtobufProtocolSupport {
 
     proc boolRepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(bool);
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = boolConsumeBase(ch);
         returnList.append(val);
       }
@@ -882,12 +882,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
       ch.mark();
       for val in valList {
         sint64AppendBase(val, ch);
       }
-      var currentOffset = ch.offset();
+      var currentOffset = ch.chpl_offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -897,11 +897,11 @@ module ProtobufProtocolSupport {
 
     proc sint64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(int(64));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = sint64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -912,12 +912,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
       ch.mark();
       for val in valList {
         sint32AppendBase(val, ch);
       }
-      var currentOffset = ch.offset();
+      var currentOffset = ch.chpl_offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -927,11 +927,11 @@ module ProtobufProtocolSupport {
 
     proc sint32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(int(32));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = sint32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -981,11 +981,11 @@ module ProtobufProtocolSupport {
 
     proc fixed32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(uint(32));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = fixed32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -1005,11 +1005,11 @@ module ProtobufProtocolSupport {
 
     proc fixed64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(uint(64));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = fixed64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -1029,11 +1029,11 @@ module ProtobufProtocolSupport {
 
     proc floatRepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(real(32));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = floatConsumeBase(ch);
         returnList.append(val);
       }
@@ -1053,11 +1053,11 @@ module ProtobufProtocolSupport {
 
     proc doubleRepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(real(64));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = doubleConsumeBase(ch);
         returnList.append(val);
       }
@@ -1077,11 +1077,11 @@ module ProtobufProtocolSupport {
 
     proc sfixed64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(int(64));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = sfixed64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -1101,11 +1101,11 @@ module ProtobufProtocolSupport {
 
     proc sfixed32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(int(32));
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = sfixed32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -1116,12 +1116,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
       ch.mark();
       for val in valList {
         enumAppendBase(val:uint, ch);
       }
-      var currentOffset = ch.offset();
+      var currentOffset = ch.chpl_offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -1131,11 +1131,11 @@ module ProtobufProtocolSupport {
 
     proc enumRepeatedConsume(ch: readingChannel, type enumType) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.offset();
+      var initialOffset = ch.chpl_offset();
 
       var returnList: list(enumType);
       while true {
-        if (ch.offset() - initialOffset) >= payloadLength then break;
+        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
         var val = enumConsumeBase(ch);
         returnList.append(val:enumType);
       }

--- a/modules/packages/ProtobufProtocolSupport.chpl
+++ b/modules/packages/ProtobufProtocolSupport.chpl
@@ -277,10 +277,10 @@ module ProtobufProtocolSupport {
     }
 
     proc messageAppendBase(val, ch:writingChannel) throws {
-     var initialOffset = ch.chpl_offset();
+     var initialOffset = ch.offset();
      ch.mark();
      val._serialize(ch);
-     var currentOffset = ch.chpl_offset();
+     var currentOffset = ch.offset();
      ch.revert();
      unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
      val._serialize(ch);
@@ -522,11 +522,11 @@ module ProtobufProtocolSupport {
       param protoValueType: string, ch:writingChannel) throws {
       for (key, value) in zip(val.keys(), val.values()) {
         tagAppend(fieldNumber, lengthDelimited, ch);
-        var initialOffset = ch.chpl_offset();
+        var initialOffset = ch.offset();
         ch.mark();
         protoFieldAppendHelper(key, 1, protoKeyType, ch);
         protoFieldAppendHelper(value, 2, protoValueType, ch);
-        var currentOffset = ch.chpl_offset();
+        var currentOffset = ch.offset();
         ch.revert();
         unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
         protoFieldAppendHelper(key, 1, protoKeyType, ch);
@@ -738,12 +738,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
       ch.mark();
       for val in valList {
         uint64AppendBase(val, ch);
       }
-      var currentOffset = ch.chpl_offset();
+      var currentOffset = ch.offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -753,11 +753,11 @@ module ProtobufProtocolSupport {
 
     proc uint64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(uint(64));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = uint64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -768,12 +768,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
       ch.mark();
       for val in valList {
         uint32AppendBase(val, ch);
       }
-      var currentOffset = ch.chpl_offset();
+      var currentOffset = ch.offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -783,11 +783,11 @@ module ProtobufProtocolSupport {
 
     proc uint32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(uint(32));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = uint32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -798,12 +798,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
       ch.mark();
       for val in valList {
         int64AppendBase(val, ch);
       }
-      var currentOffset = ch.chpl_offset();
+      var currentOffset = ch.offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -813,11 +813,11 @@ module ProtobufProtocolSupport {
 
     proc int64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(int(64));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = int64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -828,12 +828,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
       ch.mark();
       for val in valList {
         int32AppendBase(val, ch);
       }
-      var currentOffset = ch.chpl_offset();
+      var currentOffset = ch.offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -843,11 +843,11 @@ module ProtobufProtocolSupport {
 
     proc int32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(int(32));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = int32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -867,11 +867,11 @@ module ProtobufProtocolSupport {
 
     proc boolRepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(bool);
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = boolConsumeBase(ch);
         returnList.append(val);
       }
@@ -882,12 +882,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
       ch.mark();
       for val in valList {
         sint64AppendBase(val, ch);
       }
-      var currentOffset = ch.chpl_offset();
+      var currentOffset = ch.offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -897,11 +897,11 @@ module ProtobufProtocolSupport {
 
     proc sint64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(int(64));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = sint64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -912,12 +912,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
       ch.mark();
       for val in valList {
         sint32AppendBase(val, ch);
       }
-      var currentOffset = ch.chpl_offset();
+      var currentOffset = ch.offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -927,11 +927,11 @@ module ProtobufProtocolSupport {
 
     proc sint32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(int(32));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = sint32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -981,11 +981,11 @@ module ProtobufProtocolSupport {
 
     proc fixed32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(uint(32));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = fixed32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -1005,11 +1005,11 @@ module ProtobufProtocolSupport {
 
     proc fixed64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(uint(64));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = fixed64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -1029,11 +1029,11 @@ module ProtobufProtocolSupport {
 
     proc floatRepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(real(32));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = floatConsumeBase(ch);
         returnList.append(val);
       }
@@ -1053,11 +1053,11 @@ module ProtobufProtocolSupport {
 
     proc doubleRepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(real(64));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = doubleConsumeBase(ch);
         returnList.append(val);
       }
@@ -1077,11 +1077,11 @@ module ProtobufProtocolSupport {
 
     proc sfixed64RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(int(64));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = sfixed64ConsumeBase(ch);
         returnList.append(val);
       }
@@ -1101,11 +1101,11 @@ module ProtobufProtocolSupport {
 
     proc sfixed32RepeatedConsume(ch: readingChannel) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(int(32));
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = sfixed32ConsumeBase(ch);
         returnList.append(val);
       }
@@ -1116,12 +1116,12 @@ module ProtobufProtocolSupport {
       if valList.isEmpty() then return;
 
       tagAppend(fieldNumber, lengthDelimited, ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
       ch.mark();
       for val in valList {
         enumAppendBase(val:uint, ch);
       }
-      var currentOffset = ch.chpl_offset();
+      var currentOffset = ch.offset();
       ch.revert();
       unsignedVarintAppend((currentOffset-initialOffset):uint, ch);
       for val in valList {
@@ -1131,11 +1131,11 @@ module ProtobufProtocolSupport {
 
     proc enumRepeatedConsume(ch: readingChannel, type enumType) throws {
       var (payloadLength, _) = unsignedVarintConsume(ch);
-      var initialOffset = ch.chpl_offset();
+      var initialOffset = ch.offset();
 
       var returnList: list(enumType);
       while true {
-        if (ch.chpl_offset() - initialOffset) >= payloadLength then break;
+        if (ch.offset() - initialOffset) >= payloadLength then break;
         var val = enumConsumeBase(ch);
         returnList.append(val:enumType);
       }

--- a/modules/packages/RecordParser.chpl
+++ b/modules/packages/RecordParser.chpl
@@ -182,7 +182,10 @@ class RecordReader {
       do {
         var (rec, once) = _get_internal(offst, len);
         if (once == true) {
-          if (myReader.offset() >= offst+len) { // rec.end >= start + len
+          try! myReader.lock();
+          var o = myReader.chpl_offset();
+          myReader.unlock();
+          if (o >= offst+len) { // rec.end >= start + len
             // So yield and break
             yield rec;
             break;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3318,11 +3318,15 @@ inline proc fileWriter.unlock() {
 }
 
 /*
-  A compile-time parameter to control the behavior of :proc:`fileReader.offset` and :proc:`fileWriter.offset`
+  A compile-time parameter to control the behavior of :proc:`fileReader.offset`
+  and :proc:`fileWriter.offset` when :param:`fileReader.locking` or
+  :param:`fileWriting.locking` is true.
 
-  When 'false', the deprecated behavior is used (i.e., calling 'lock'/'unlock' before getting the offset)
+  When 'false', the deprecated behavior is used (i.e., calling
+  ``lock``/``unlock`` before getting the offset)
 
-  When 'true', the new behavior is used (i.e., no lock is automatically aquired)
+  When 'true', the new behavior is used (i.e., no lock is automatically
+  aquired)
 */
 config param fileOffsetWithoutLocking = false;
 
@@ -3346,7 +3350,9 @@ private inline proc offsetHelper(fileRW, param doDeprecatedLocking: bool) {
    :returns: the current offset of the fileReader
  */
 @deprecated(notes="The variant of :proc:`fileReader.offset` that automatically aquires a lock before getting the offset is deprecated; please compile with `-sfileOffsetWithoutLocking=true` and wrap :proc:`fileReader.offset` with the apprioatiate locking calls where necessary to opt in to the new behavior")
-proc fileReader.offset():int(64) where !fileOffsetWithoutLocking do return offsetHelper(this, true);
+proc fileReader.offset():int(64) 
+  where this.locking == true && !fileOffsetWithoutLocking 
+  do return offsetHelper(this, true);
 
 /*
    Return the current offset of a fileReader.
@@ -3359,7 +3365,10 @@ proc fileReader.offset():int(64) where !fileOffsetWithoutLocking do return offse
 
    :returns: the current offset of the fileReader
  */
-proc fileReader.offset():int(64) where fileOffsetWithoutLocking do return offsetHelper(this, false);
+proc fileReader.offset():int(64)
+  where this.locking == false || 
+        (this.locking == true && fileOffsetWithoutLocking)
+  do return offsetHelper(this, false);
 
 // remove and replace calls to this with 'offset' when 'fileOffsetWithoutLocking' is removed
 @chpldoc.nodoc
@@ -3374,7 +3383,9 @@ proc fileReader.chpl_offset():int(64) do return offsetHelper(this, false);
    :returns: the current offset of the fileWriter
  */
 @deprecated(notes="The variant of :proc:`fileWriter.offset` that automatically aquires a lock before getting the offset is deprecated; please compile with `-sfileOffsetWithoutLocking=true` and wrap :proc:`fileWriter.offset` with the apprioatiate locking calls where necessary to opt in to the new behavior")
-proc fileWriter.offset():int(64) where !fileOffsetWithoutLocking do return offsetHelper(this, true);
+proc fileWriter.offset():int(64)
+  where this.locking == true && !fileOffsetWithoutLocking
+  do return offsetHelper(this, true);
 
 /*
    Return the current offset of a fileWriter.
@@ -3387,7 +3398,10 @@ proc fileWriter.offset():int(64) where !fileOffsetWithoutLocking do return offse
 
    :returns: the current offset of the fileWriter
  */
-proc fileWriter.offset():int(64) where fileOffsetWithoutLocking do return offsetHelper(this, false);
+proc fileWriter.offset():int(64)
+  where this.locking == false || 
+        (this.locking == true && fileOffsetWithoutLocking)
+  do return offsetHelper(this, false);
 
 // remove and replace calls to this with 'offset' when 'fileOffsetWithoutLocking' is removed
 @chpldoc.nodoc

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3322,9 +3322,9 @@ inline proc fileWriter.unlock() {
 private inline proc offsetHelper(fileRW) {
   var ret:int(64);
   on fileRW._home {
-    if fileRW.locking then try! fileRW.lock();
+    if !fileRW.locking then try! fileRW.lock();
     ret = qio_channel_offset_unlocked(fileRW._channel_internal);
-    if fileRW.locking then try! fileRW.unlock();
+    if !fileRW.locking then fileRW.unlock();
   }
   return ret;
 }
@@ -3332,13 +3332,14 @@ private inline proc offsetHelper(fileRW) {
 /*
    Return the current offset of a fileReader.
 
-   .. warning::
+   If ``locking==false``, the fileReader will call :proc:`fileReader.lock`
+   before getting the offset and call :proc:`fileReader.unlock` after.
 
-      If the fileReader can be used by multiple tasks, take care
-      when doing operations that rely on the fileReader's current offset.
-      To prevent race conditions, first lock the fileReader with
-      :proc:`fileReader.lock`, do the operations with :proc:`fileReader._offset`
-      instead, then unlock it with :proc:`fileReader.unlock`.
+   If ``locking==true`` and the fileReader can be used by multiple tasks, take
+   care when doing operations that rely on the fileReader's current offset. To
+   prevent race conditions, lock the fileReader with :proc:`fileReader.lock`
+   before calling :proc:`fileReader.offset`, then unlock it afterwards with
+   :proc:`fileReader.unlock`.
 
    :returns: the current offset of the fileReader
  */
@@ -3346,14 +3347,15 @@ proc fileReader.offset():int(64) do return offsetHelper(this);
 
 /*
    Return the current offset of a fileWriter.
+   
+   If ``locking==false``, the fileWriter will call :proc:`fileWriter.lock`
+   before getting the offset and call :proc:`fileWriter.unlock` after.
 
-   .. warning::
-
-      If the fileWriter can be used by multiple tasks, take care
-      when doing operations that rely on the fileWriter's current offset.
-      To prevent race conditions, first lock the fileWriter with
-      :proc:`fileWriter.lock`, do the operations with :proc:`fileWriter._offset`
-      instead, then unlock it with :proc:`fileWriter.unlock`.
+   If ``locking==true`` and the fileWriter can be used by multiple tasks, take
+   care when doing operations that rely on the fileWriter's current offset. To
+   prevent race conditions, lock the fileWriter with :proc:`fileWriter.lock`
+   before calling :proc:`fileWriter.offset`, then unlock it afterwards with
+   :proc:`fileWriter.unlock`.
 
    :returns: the current offset of the fileWriter
  */

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3319,7 +3319,7 @@ inline proc fileWriter.unlock() {
 }
 
 @chpldoc.nodoc
-private inline proc offsetHelper(ref fileRW) {
+private inline proc offsetHelper(fileRW) {
   var ret:int(64);
   on fileRW._home {
     if fileRW.locking then try! fileRW.lock();
@@ -3540,7 +3540,7 @@ proc fileReader.advanceTo(separator: ?t) throws where t==string || t==bytes {
 }
 
 @chpldoc.nodoc
-private inline proc markHelper(ref fileRW) throws {
+private inline proc markHelper(fileRW) throws {
   const offset = fileRW.offset();
   const err = qio_channel_mark(false, fileRW._channel_internal);
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3322,8 +3322,8 @@ inline proc fileWriter.unlock() {
   and :proc:`fileWriter.offset` when :param:`fileReader.locking` or
   :param:`fileWriter.locking` is true.
 
-  When 'false', the deprecated behavior is used (i.e., calling
-  ``lock``/``unlock`` before getting the offset)
+  When 'false', the deprecated behavior is used (i.e., the method acquires a
+  lock internally before getting the offset)
 
   When 'true', the new behavior is used (i.e., no lock is automatically
   aquired)

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -263,12 +263,11 @@ is possible to disable the lock (for performance reasons) by passing
 methods - in particular those beginning with the underscore - should only be
 called on locked fileReaders or fileWriters.  With these methods, it is possible
 to get or set the fileReader or fileWriter style, or perform I/O "transactions"
-(see :proc:`fileWriter.mark` and :proc:`fileWriter._mark`, e.g.). To use these
-methods, e.g., first lock the fileWriter with :proc:`fileWriter.lock`, call the
-methods you need, then unlock the fileWriter with :proc:`fileWriter.unlock`.
-Note that in the future, we may move to alternative ways of calling these
-functions that guarantee that they are not called on a fileReader or fileWriter
-without the appropriate locking.
+(see :proc:`fileWriter.mark`, e.g.). To use these methods, e.g., first lock the
+fileWriter with :proc:`fileWriter.lock`, call the methods you need, then unlock
+the fileWriter with :proc:`fileWriter.unlock`. Note that in the future, we may
+move to alternative ways of calling these functions that guarantee that they
+are not called on a fileReader or fileWriter without the appropriate locking.
 
 Besides data races that can occur if locking is not used in fileWriters when it
 should be, it is also possible for there to be data races on file data that is
@@ -3347,7 +3346,7 @@ proc fileReader.offset():int(64) do return offsetHelper(this);
 
 /*
    Return the current offset of a fileWriter.
-   
+
    If ``locking==false``, the fileWriter will call :proc:`fileWriter.lock`
    before getting the offset and call :proc:`fileWriter.unlock` after.
 
@@ -3385,8 +3384,8 @@ proc fileReader.advance(amount:int(64)) throws {
    Move a fileWriter offset forward.
 
    This function will write ``amount`` zeros - or some other data if it is
-   stored in the fileWriter's buffer, for example with :proc:`fileWriter._mark`
-   and :proc:`fileWriter._revert`.
+   stored in the fileWriter's buffer, for example with :proc:`fileWriter.mark`
+   and :proc:`fileWriter.revert`.
 
    :throws EofError: If EOF is reached before the offset can be advanced by the
                       requested number of bytes.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3320,7 +3320,7 @@ inline proc fileWriter.unlock() {
 /*
   A compile-time parameter to control the behavior of :proc:`fileReader.offset`
   and :proc:`fileWriter.offset` when :param:`fileReader.locking` or
-  :param:`fileWriting.locking` is true.
+  :param:`fileWriter.locking` is true.
 
   When 'false', the deprecated behavior is used (i.e., calling
   ``lock``/``unlock`` before getting the offset)
@@ -3350,8 +3350,8 @@ private inline proc offsetHelper(fileRW, param doDeprecatedLocking: bool) {
    :returns: the current offset of the fileReader
  */
 @deprecated(notes="The variant of :proc:`fileReader.offset` that automatically aquires a lock before getting the offset is deprecated; please compile with `-sfileOffsetWithoutLocking=true` and wrap :proc:`fileReader.offset` with the apprioatiate locking calls where necessary to opt in to the new behavior")
-proc fileReader.offset():int(64) 
-  where this.locking == true && !fileOffsetWithoutLocking 
+proc fileReader.offset():int(64)
+  where this.locking == true && !fileOffsetWithoutLocking
   do return offsetHelper(this, true);
 
 /*
@@ -3366,7 +3366,7 @@ proc fileReader.offset():int(64)
    :returns: the current offset of the fileReader
  */
 proc fileReader.offset():int(64)
-  where this.locking == false || 
+  where this.locking == false ||
         (this.locking == true && fileOffsetWithoutLocking)
   do return offsetHelper(this, false);
 
@@ -3399,7 +3399,7 @@ proc fileWriter.offset():int(64)
    :returns: the current offset of the fileWriter
  */
 proc fileWriter.offset():int(64)
-  where this.locking == false || 
+  where this.locking == false ||
         (this.locking == true && fileOffsetWithoutLocking)
   do return offsetHelper(this, false);
 

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1670,7 +1670,7 @@ private proc _findSeparator(separator: regex(?t), maxBytes=-1, ch) : (errorCode,
   use Regex.RegexIoSupport;
 
   // look for a match with the provided regex
-  ch._mark();
+  ch.mark();
   const maxNumBytes = if maxBytes < 0 then max(int) else maxBytes,
         nm = 1;
 
@@ -1688,7 +1688,7 @@ private proc _findSeparator(separator: regex(?t), maxBytes=-1, ch) : (errorCode,
 
   // return if there was an error other than a no-match error
   if err != 0 && err != EEOF && err != EFORMAT {
-    ch._revert();
+    ch.revert();
     return (err, false, 0, separatorMatch);
   }
 
@@ -1698,14 +1698,14 @@ private proc _findSeparator(separator: regex(?t), maxBytes=-1, ch) : (errorCode,
   // extract a string from the match
   ch._extractMatch(m, separatorMatch, err);
   if err != 0 && err != EEOF && err != EFORMAT {
-    ch._revert();
+    ch.revert();
     return (err, false, 0, separatorMatch);
   }
 
   // move back to the starting offset and compute the total number of bytes read
-  const endOffset = ch._offset();
-  ch._revert(); // A
-  const numBytesRead: int = endOffset - ch._offset();
+  const endOffset = ch.offset();
+  ch.revert(); // A
+  const numBytesRead: int = endOffset - ch.offset();
 
   _ddata_free(matches, nm);
 

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -1703,9 +1703,9 @@ private proc _findSeparator(separator: regex(?t), maxBytes=-1, ch) : (errorCode,
   }
 
   // move back to the starting offset and compute the total number of bytes read
-  const endOffset = ch.offset();
+  const endOffset = ch.chpl_offset();
   ch.revert(); // A
-  const numBytesRead: int = endOffset - ch.offset();
+  const numBytesRead: int = endOffset - ch.chpl_offset();
 
   _ddata_free(matches, nm);
 

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -247,7 +247,7 @@ module Subprocess {
     pragma "no doc"
     proc _stop_stdin_buffering() {
       if this.stdin_buffering && this.stdin_pipe {
-        this.stdin_channel._commit();
+        this.stdin_channel.commit();
         this.stdin_buffering = false; // Don't commit again on close again
       }
     }
@@ -580,7 +580,7 @@ module Subprocess {
         // mark stdin so that we don't actually send any data
         // until communicate() is called.
 
-        err = ret.stdin_channel._mark();
+        err = ret.stdin_channel.mark();
         if err {
           ret.spawn_error = err; return ret;
         }

--- a/test/deprecated/IO/offsetWithLocking-deprecated.good
+++ b/test/deprecated/IO/offsetWithLocking-deprecated.good
@@ -1,0 +1,10 @@
+offsetWithLocking.chpl:11: warning: The variant of fileWriter.offset that automatically aquires a lock before getting the offset is deprecated; please compile with `-sfileOffsetWithoutLocking=true` and wrap fileWriter.offset with the apprioatiate locking calls where necessary to opt in to the new behavior
+offsetWithLocking.chpl:14: warning: The variant of fileWriter.offset that automatically aquires a lock before getting the offset is deprecated; please compile with `-sfileOffsetWithoutLocking=true` and wrap fileWriter.offset with the apprioatiate locking calls where necessary to opt in to the new behavior
+offsetWithLocking.chpl:21: warning: The variant of fileReader.offset that automatically aquires a lock before getting the offset is deprecated; please compile with `-sfileOffsetWithoutLocking=true` and wrap fileReader.offset with the apprioatiate locking calls where necessary to opt in to the new behavior
+offsetWithLocking.chpl:25: warning: The variant of fileReader.offset that automatically aquires a lock before getting the offset is deprecated; please compile with `-sfileOffsetWithoutLocking=true` and wrap fileReader.offset with the apprioatiate locking calls where necessary to opt in to the new behavior
+writing
+0
+12
+reading
+0
+12

--- a/test/deprecated/IO/offsetWithLocking.chpl
+++ b/test/deprecated/IO/offsetWithLocking.chpl
@@ -1,0 +1,27 @@
+// deprecated by jade in 1.31
+use IO;
+config var filename = "test.txt";
+config param useLocking = true;
+
+var f = open(filename, ioMode.cwr);
+
+{
+  writeln("writing");
+  var w = f.writer(locking=useLocking);
+  var off = w.offset();
+  writeln(off);
+  w.writeln("hello world");
+  off = w.offset();
+  writeln(off);
+}
+
+{
+  writeln("reading");
+  var r = f.reader(locking=useLocking);
+  var off = r.offset();
+  writeln(off);
+  var line = r.readLine(stripNewline=true);
+  assert(line == "hello world");
+  off = r.offset();
+  writeln(off);
+}

--- a/test/deprecated/IO/offsetWithLocking.compopts
+++ b/test/deprecated/IO/offsetWithLocking.compopts
@@ -1,0 +1,4 @@
+-suseLocking=true -sfileOffsetWithoutLocking=true
+-suseLocking=true -sfileOffsetWithoutLocking=false # offsetWithLocking-deprecated.good
+-suseLocking=false -sfileOffsetWithoutLocking=true
+-suseLocking=false -sfileOffsetWithoutLocking=false

--- a/test/deprecated/IO/offsetWithLocking.good
+++ b/test/deprecated/IO/offsetWithLocking.good
@@ -1,0 +1,6 @@
+writing
+0
+12
+reading
+0
+12

--- a/test/deprecated/IO/underscoreMethods.chpl
+++ b/test/deprecated/IO/underscoreMethods.chpl
@@ -1,0 +1,49 @@
+use IO;
+config var filename = "test.txt";
+
+var f = open(filename, ioMode.cwr);
+
+{
+  writeln("writing");
+  var w = f.writer(locking=true);
+  w.lock();
+
+  w._mark();
+  w.writeln("hello world");
+  w._revert();
+
+  var off = w._offset();
+  writeln(off);
+
+  w._mark();
+  w.writeln("world hello");
+  w._commit();
+
+  off = w._offset();
+  writeln(off);
+
+  w.unlock();
+}
+// use to put a space in .good to make more readable
+compilerWarning("");
+{
+  writeln("reading");
+  var r = f.reader(locking=true);
+  r.lock();
+
+  r._mark();
+  var line = r.readLine(stripNewline=true);
+  if line != "hello world" then r._revert();
+
+  var off = r._offset();
+  writeln(off);
+
+  r._mark();
+  line = r.readLine(stripNewline=true);
+  if line == "world hello" then r._commit();
+
+  off = r._offset();
+  writeln(off);
+
+  r.unlock();
+}

--- a/test/deprecated/IO/underscoreMethods.chpl
+++ b/test/deprecated/IO/underscoreMethods.chpl
@@ -1,3 +1,4 @@
+// deprecated by jade in 1.31
 use IO;
 config var filename = "test.txt";
 

--- a/test/deprecated/IO/underscoreMethods.cleanfiles
+++ b/test/deprecated/IO/underscoreMethods.cleanfiles
@@ -1,0 +1,1 @@
+test.txt

--- a/test/deprecated/IO/underscoreMethods.good
+++ b/test/deprecated/IO/underscoreMethods.good
@@ -1,0 +1,19 @@
+underscoreMethods.chpl:11: warning: fileWriter._mark is deprecated - please use fileWriter.mark instead
+underscoreMethods.chpl:13: warning: fileWriter._revert is deprecated - please use fileWriter.revert instead
+underscoreMethods.chpl:15: warning: fileWriter._offset is deprecated - please use fileWriter.offset instead
+underscoreMethods.chpl:18: warning: fileWriter._mark is deprecated - please use fileWriter.mark instead
+underscoreMethods.chpl:20: warning: fileWriter._commit is deprecated - please use fileWriter.commit instead
+underscoreMethods.chpl:23: warning: fileWriter._offset is deprecated - please use fileWriter.offset instead
+underscoreMethods.chpl:28: warning:
+underscoreMethods.chpl:34: warning: fileReader._mark is deprecated - please use fileReader.mark instead
+underscoreMethods.chpl:36: warning: fileReader._revert is deprecated - please use fileReader.revert instead
+underscoreMethods.chpl:38: warning: fileReader._offset is deprecated - please use fileReader.offset instead
+underscoreMethods.chpl:41: warning: fileReader._mark is deprecated - please use fileReader.mark instead
+underscoreMethods.chpl:43: warning: fileReader._commit is deprecated - please use fileReader.commit instead
+underscoreMethods.chpl:45: warning: fileReader._offset is deprecated - please use fileReader.offset instead
+writing
+0
+12
+reading
+0
+12

--- a/test/deprecated/IO/underscoreMethods.good
+++ b/test/deprecated/IO/underscoreMethods.good
@@ -1,16 +1,16 @@
-underscoreMethods.chpl:11: warning: fileWriter._mark is deprecated - please use fileWriter.mark instead
-underscoreMethods.chpl:13: warning: fileWriter._revert is deprecated - please use fileWriter.revert instead
-underscoreMethods.chpl:15: warning: fileWriter._offset is deprecated - please use fileWriter.offset instead
-underscoreMethods.chpl:18: warning: fileWriter._mark is deprecated - please use fileWriter.mark instead
-underscoreMethods.chpl:20: warning: fileWriter._commit is deprecated - please use fileWriter.commit instead
+underscoreMethods.chpl:12: warning: fileWriter._mark is deprecated - please use fileWriter.mark instead
+underscoreMethods.chpl:14: warning: fileWriter._revert is deprecated - please use fileWriter.revert instead
+underscoreMethods.chpl:16: warning: fileWriter._offset is deprecated - please use fileWriter.offset instead
+underscoreMethods.chpl:19: warning: fileWriter._mark is deprecated - please use fileWriter.mark instead
+underscoreMethods.chpl:21: warning: fileWriter._commit is deprecated - please use fileWriter.commit instead
 underscoreMethods.chpl:23: warning: fileWriter._offset is deprecated - please use fileWriter.offset instead
-underscoreMethods.chpl:28: warning:
-underscoreMethods.chpl:34: warning: fileReader._mark is deprecated - please use fileReader.mark instead
-underscoreMethods.chpl:36: warning: fileReader._revert is deprecated - please use fileReader.revert instead
-underscoreMethods.chpl:38: warning: fileReader._offset is deprecated - please use fileReader.offset instead
-underscoreMethods.chpl:41: warning: fileReader._mark is deprecated - please use fileReader.mark instead
-underscoreMethods.chpl:43: warning: fileReader._commit is deprecated - please use fileReader.commit instead
-underscoreMethods.chpl:45: warning: fileReader._offset is deprecated - please use fileReader.offset instead
+underscoreMethods.chpl:29: warning: 
+underscoreMethods.chpl:35: warning: fileReader._mark is deprecated - please use fileReader.mark instead
+underscoreMethods.chpl:37: warning: fileReader._revert is deprecated - please use fileReader.revert instead
+underscoreMethods.chpl:39: warning: fileReader._offset is deprecated - please use fileReader.offset instead
+underscoreMethods.chpl:42: warning: fileReader._mark is deprecated - please use fileReader.mark instead
+underscoreMethods.chpl:44: warning: fileReader._commit is deprecated - please use fileReader.commit instead
+underscoreMethods.chpl:46: warning: fileReader._offset is deprecated - please use fileReader.offset instead
 writing
 0
 12

--- a/test/io/literals/match-literal.compopts
+++ b/test/io/literals/match-literal.compopts
@@ -1,2 +1,2 @@
--suseStrings=true
--suseStrings=false
+-suseStrings=true -sfileOffsetWithoutLocking=true
+-suseStrings=false -sfileOffsetWithoutLocking=true

--- a/test/io/literals/read-literal.compopts
+++ b/test/io/literals/read-literal.compopts
@@ -1,2 +1,2 @@
--suseStrings=true
--suseStrings=false
+-suseStrings=true -sfileOffsetWithoutLocking=true
+-suseStrings=false -sfileOffsetWithoutLocking=true

--- a/test/library/packages/canCompileNoLink/HDFStest.compopts
+++ b/test/library/packages/canCompileNoLink/HDFStest.compopts
@@ -1,0 +1,1 @@
+-sfileOffsetWithoutLocking=true

--- a/test/regex/empty-channel-matches.compopts
+++ b/test/regex/empty-channel-matches.compopts
@@ -1,0 +1,1 @@
+-sfileOffsetWithoutLocking=true

--- a/test/regex/ferguson/readfinf.compopts
+++ b/test/regex/ferguson/readfinf.compopts
@@ -1,0 +1,1 @@
+-sfileOffsetWithoutLocking=true

--- a/test/regex/ferguson/readfre.compopts
+++ b/test/regex/ferguson/readfre.compopts
@@ -1,2 +1,2 @@
--st=string
--st=bytes
+-st=string -sfileOffsetWithoutLocking=true
+-st=bytes -sfileOffsetWithoutLocking=true

--- a/test/regex/ferguson/rechan.compopts
+++ b/test/regex/ferguson/rechan.compopts
@@ -1,0 +1,1 @@
+-sfileOffsetWithoutLocking=true

--- a/test/regex/regex-and-channel-todos.compopts
+++ b/test/regex/regex-and-channel-todos.compopts
@@ -1,0 +1,1 @@
+-sfileOffsetWithoutLocking=true

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -194,16 +194,23 @@ proc process_json(logfile:fileReader, fname:string, ref Pairs) {
       try {
         got = logfile.readf("%~jt", tweet);
       } catch e: BadFormatError {
-        if verbose then
+        if verbose {
+            try! logfile.lock();
+            var off = logfile.offset();
+            logfile.unlock();
             stdout.writeln("error reading tweets ", fname, " offset ",
-              logfile.offset(), " : ", e._msg);
+              off, " : ", e._msg);
+        }
 
         // read over something else
         got = logfile.readf("%~jt", empty);
       }
     } catch e: SystemError {
+      try! logfile.lock();
+      var off = logfile.offset();
+      logfile.unlock();
       stderr.writeln("severe error reading tweets ", fname, " offset ",
-          logfile.offset(), " : ", errorToString(e.err));
+          off, " : ", errorToString(e.err));
 
       // advance to the next line.
       logfile.readln();

--- a/test/studies/labelprop/labelprop-tweets.compopts
+++ b/test/studies/labelprop/labelprop-tweets.compopts
@@ -1,0 +1,1 @@
+-sfileOffsetWithoutLocking=true

--- a/test/studies/shootout/mandelbrot/ferguson/mandelbrot-opt2.compopts
+++ b/test/studies/shootout/mandelbrot/ferguson/mandelbrot-opt2.compopts
@@ -1,1 +1,1 @@
--suseNewFileWriterRegionBounds=true
+-suseNewFileWriterRegionBounds=true -sfileOffsetWithoutLocking=true

--- a/test/studies/shootout/mandelbrot/ferguson/mandelbrot2-opt.compopts
+++ b/test/studies/shootout/mandelbrot/ferguson/mandelbrot2-opt.compopts
@@ -1,0 +1,1 @@
+-sfileOffsetWithoutLocking=true


### PR DESCRIPTION
In discussion on #19827, the decision was made to remove `_mark` on `fileReaders` and `fileWriters`. `_mark` has the same implementation as `mark`, so it was decided to relax the restriction on `mark` and update the documentation to explain the locking behavior.

In an offline discussion, similar consensus was reached about `_revert`, `_commit`, and `_offset`

## Summary of changes
- deprecate `fileReader._mark` and `fileWriter._mark`
  - extract `mark` implementation to a helper, as it is the same for `fileReader` and `fileWriter`
- deprecate `fileReader._revert` and `fileWriter._revert`
- deprecate `fileReader._commit` and `fileWriter._commit`
- deprecate `fileReader._offset` and `fileWriter._offset`
  - extract `offset` implementation to a helper, as it is the same for `fileReader` and `fileWriter`
  - remove automatic locking on `offset` and deprecate this behavior with a compile time parameter
- update modules which use underscore methods
  - for `_mark`,  `_revert`, and `_commit`: remove underscore
  - for `_offset`: replace with `chpl_offset`, a nodoc method to avoid warning about locking
- update tests which use underscore methods
  - for `_mark`,  `_revert`, and `_commit`: remove underscore
  - for `_offset`: remove underscore, and add compile flag or locking (or both) where appropriate


## New tests
- deprecation test for all 8 functions deprecated - `test/deprecated/IO/underscoreMethods.chpl`
- deprecation test for `offset` without locking config flag - `test/deprecated/IO/offsetWithLocking.chpl`

## testing
- paratest with futures
- paratest with gasnet
- built and checked docs

---

[Reviewed by @jeremiah-corrado]

closes #19827
closes Cray/chapel-private#4735