### PR TITLE
Add (no doc'd) functions to enable P2P GPU access

### DIFF
--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -26,7 +26,7 @@ module ChapelGpuSupport {
   config const debugGpu = false;
 
   /* If true, upon startup, enables peer-to-peer access between all pairs of
-     GPUs */
+     GPUs that are eligible for peer-to-peer access within each locale. */
   pragma "no doc"
   config const enableGpuP2P = false;
 

--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -20,6 +20,7 @@
 
 module ChapelGpuSupport {
   use ChapelBase;
+  use ChplConfig;
 
   extern var chpl_gpu_debug : bool;
 
@@ -33,11 +34,12 @@ module ChapelGpuSupport {
   // by virtue of module initialization:
   chpl_gpu_debug = debugGpu;
 
-  if(enableGpuP2P) {
-    use GPU;
-    for loc in Locales do on loc do
-      for gpu1 in here.gpus do
-        for gpu2 in here.gpus do
-          if canAccessPeer(gpu1,gpu2) then setPeerAccess(gpu1,gpu2,true);
-  }
+  if CHPL_LOCALE_MODEL == 'gpu' then
+    if(enableGpuP2P) {
+      use GPU;
+      for loc in Locales do on loc do
+        for gpu1 in here.gpus do
+          for gpu2 in here.gpus do
+            if canAccessPeer(gpu1,gpu2) then setPeerAccess(gpu1,gpu2,true);
+    }
 }

--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -25,6 +25,19 @@ module ChapelGpuSupport {
 
   config const debugGpu = false;
 
+  /* If true, upon startup, enables peer-to-peer access between all pairs of
+     GPUs */
+  pragma "no doc"
+  config const enableGpuP2P = false;
+
   // by virtue of module initialization:
   chpl_gpu_debug = debugGpu;
+
+  if(enableGpuP2P) {
+    use GPU;
+    for loc in Locales do on loc do
+      for gpu1 in here.gpus do
+        for gpu2 in here.gpus do
+          if canAccessPeer(gpu1,gpu2) then setPeerAccess(gpu1,gpu2,true);
+  }
 }

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -28,7 +28,6 @@ module LocaleModelHelpGPU {
   pragma "no doc"
   config param debugGPULocale = false;
 
-
   //////////////////////////////////////////
   //
   // utilities

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -28,6 +28,7 @@ module LocaleModelHelpGPU {
   pragma "no doc"
   config param debugGPULocale = false;
 
+
   //////////////////////////////////////////
   //
   // utilities

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -214,8 +214,8 @@ module LocaleModel {
 
     override proc chpl_id() do return try! (parent._value:LocaleModel)._node_id; // top-level node id
     override proc chpl_localeid() {
-      return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
-                                sid);
+      return try! chpl_buildLocaleID((parent._value:LocaleModel)._node_id:chpl_nodeID_t,
+                                     sid);
     }
     override proc chpl_name() {
       return try! (parent._value:LocaleModel).local_name + "-GPU" + sid:string;

--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -151,4 +151,8 @@ module ChplConfig {
   pragma "no doc"
   param CHPL_GPU_MEM_STRATEGY:string;
   CHPL_GPU_MEM_STRATEGY = __primitive("get compiler variable", "CHPL_GPU_MEM_STRATEGY");
+
+  pragma "no doc"
+  param CHPL_GPU_CODEGEN:string;
+  CHPL_GPU_CODEGEN = __primitive("get compiler variable", "CHPL_GPU_CODEGEN");
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -199,4 +199,29 @@ module GPU
   inline proc setBlockSize(blockSize: int) {
     __primitive("gpu set blockSize", blockSize);
   }
+
+  pragma "no doc"
+  proc canAccessPeer(loc1 : locale, loc2 : locale) : bool {
+    extern proc chpl_gpu_can_access_peer(i : c_int, j : c_int) : bool;
+
+    if(!loc1.isGpu() || !loc2.isGpu()) then
+      halt("Non GPU locale passed to 'canAccessPeer'");
+    const ref loc1Gpu = try! loc1._instance : unmanaged GPULocale;
+    const ref loc2Gpu = try! loc2._instance : unmanaged GPULocale;
+
+    return chpl_gpu_can_access_peer(loc1Gpu.sid, loc2Gpu.sid);
+  }
+
+  pragma "no doc"
+  proc setPeerAccess(loc1 : locale, loc2 : locale, shouldEnable : bool) {
+    extern proc chpl_gpu_set_peer_access(
+      i : c_int, j : c_int, shouldEnable : bool) : void;
+
+    if(!loc1.isGpu() || !loc2.isGpu()) then
+      halt("Non GPU locale passed to 'canAccessPeer'");
+    const ref loc1Gpu = try! loc1._instance : unmanaged GPULocale;
+    const ref loc2Gpu = try! loc2._instance : unmanaged GPULocale;
+
+    chpl_gpu_set_peer_access(loc1Gpu.sid, loc2Gpu.sid, shouldEnable);
+  }
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -206,10 +206,10 @@ module GPU
 
     if(!loc1.isGpu() || !loc2.isGpu()) then
       halt("Non GPU locale passed to 'canAccessPeer'");
-    const ref loc1Gpu = try! loc1._instance : unmanaged GPULocale;
-    const ref loc2Gpu = try! loc2._instance : unmanaged GPULocale;
+    const loc1Sid = chpl_sublocFromLocaleID(loc1.chpl_localeid());
+    const loc2Sid = chpl_sublocFromLocaleID(loc2.chpl_localeid());
 
-    return chpl_gpu_can_access_peer(loc1Gpu.sid, loc2Gpu.sid);
+    return chpl_gpu_can_access_peer(loc1Sid, loc2Sid);
   }
 
   pragma "no doc"
@@ -219,9 +219,9 @@ module GPU
 
     if(!loc1.isGpu() || !loc2.isGpu()) then
       halt("Non GPU locale passed to 'canAccessPeer'");
-    const ref loc1Gpu = try! loc1._instance : unmanaged GPULocale;
-    const ref loc2Gpu = try! loc2._instance : unmanaged GPULocale;
+    const loc1Sid = chpl_sublocFromLocaleID(loc1.chpl_localeid());
+    const loc2Sid = chpl_sublocFromLocaleID(loc2.chpl_localeid());
 
-    chpl_gpu_set_peer_access(loc1Gpu.sid, loc2Gpu.sid, shouldEnable);
+    chpl_gpu_set_peer_access(loc1Sid, loc2Sid, shouldEnable);
   }
 }

--- a/runtime/include/chpl-gpu-impl.h
+++ b/runtime/include/chpl-gpu-impl.h
@@ -61,6 +61,9 @@ bool chpl_gpu_impl_is_host_ptr(const void* ptr);
 // TODO do we really need to expose this?
 size_t chpl_gpu_impl_get_alloc_size(void* ptr);
 
+bool chpl_gpu_impl_can_access_peer(int dev1, int dev2);
+void chpl_gpu_impl_set_peer_access(int dev1, int dev2, bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -122,6 +122,10 @@ unsigned int chpl_gpu_device_clock_rate(int32_t devNum);
 
 // TODO do we really need to expose this?
 size_t chpl_gpu_get_alloc_size(void* ptr);
+
+bool chpl_gpu_can_access_peer(int dev1, int dev2);
+void chpl_gpu_set_peer_access(int dev1, int dev2, bool enable);
+
 #endif // HAS_GPU_LOCALE
 
 #ifdef __cplusplus

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -294,4 +294,12 @@ bool chpl_gpu_is_host_ptr(const void* ptr) {
   return chpl_gpu_impl_is_host_ptr(ptr);
 }
 
+bool chpl_gpu_can_access_peer(int dev1, int dev2) {
+  return chpl_gpu_impl_can_access_peer(dev1, dev2);
+}
+
+void chpl_gpu_set_peer_access(int dev1, int dev2, bool enable) {
+  chpl_gpu_impl_set_peer_access(dev1, dev2, enable);
+}
+
 #endif

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -489,18 +489,19 @@ unsigned int chpl_gpu_device_clock_rate(int32_t devNum) {
   return (unsigned int)deviceClockRates[devNum];
 }
 
-bool chpl_gpu_can_access_peer(int dev1, int dev2) {
+bool chpl_gpu_impl_can_access_peer(int dev1, int dev2) {
   int p2p;
-  cuDeviceCanAccessPeer(&p2p, chpl_gpu_devices[dev1], chpl_gpu_devices[dev2]);
+  CUDA_CALL(cuDeviceCanAccessPeer(&p2p, chpl_gpu_devices[dev1],
+    chpl_gpu_devices[dev2]));
   return p2p != 0;
 }
 
-void chpl_gpu_set_peer_access(int dev1, int dev2, bool enable) {
+void chpl_gpu_impl_set_peer_access(int dev1, int dev2, bool enable) {
   chpl_gpu_switch_context(dev1);
   if(enable) {
-    cuCtxEnablePeerAccess(chpl_gpu_primary_ctx[dev2], 0);
+    CUDA_CALL(cuCtxEnablePeerAccess(chpl_gpu_primary_ctx[dev2], 0));
   } else {
-    cuCtxDisablePeerAccess(chpl_gpu_primary_ctx[dev2]);
+    CUDA_CALL(cuCtxDisablePeerAccess(chpl_gpu_primary_ctx[dev2]));
   }
 }
 

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -43,6 +43,7 @@
 extern const char* chpl_gpuBinary;
 
 static CUcontext *chpl_gpu_primary_ctx;
+static CUdevice  *chpl_gpu_devices;
 
 // array indexed by device ID (we load the same module once for each GPU).
 static CUmodule *chpl_gpu_cuda_modules;
@@ -63,8 +64,8 @@ static bool chpl_gpu_has_context() {
   }
 }
 
-static void chpl_gpu_ensure_context() {
-  CUcontext next_context = chpl_gpu_primary_ctx[chpl_task_getRequestedSubloc()];
+static void chpl_gpu_switch_context(int deviceId) {
+  CUcontext next_context = chpl_gpu_primary_ctx[deviceId];
 
   if (!chpl_gpu_has_context()) {
     CUDA_CALL(cuCtxPushCurrent(next_context));
@@ -96,6 +97,10 @@ static void chpl_gpu_impl_set_globals(CUmodule module) {
   chpl_gpu_impl_copy_host_to_device((void*)ptr, &chpl_nodeID, glob_size);
 }
 
+static void chpl_gpu_ensure_context() {
+  chpl_gpu_switch_context(chpl_task_getRequestedSubloc());
+}
+
 void chpl_gpu_impl_init() {
   int         num_devices;
 
@@ -105,6 +110,7 @@ void chpl_gpu_impl_init() {
   CUDA_CALL(cuDeviceGetCount(&num_devices));
 
   chpl_gpu_primary_ctx = chpl_malloc(sizeof(CUcontext)*num_devices);
+  chpl_gpu_devices = chpl_malloc(sizeof(CUdevice)*num_devices);
   chpl_gpu_cuda_modules = chpl_malloc(sizeof(CUmodule)*num_devices);
   deviceClockRates = chpl_malloc(sizeof(int)*num_devices);
 
@@ -126,6 +132,7 @@ void chpl_gpu_impl_init() {
 
     cuDeviceGetAttribute(&deviceClockRates[i], CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device);
 
+    chpl_gpu_devices[i] = device;
     chpl_gpu_primary_ctx[i] = context;
 
     // TODO can we refactor some of this to chpl-gpu to avoid duplication
@@ -480,6 +487,21 @@ size_t chpl_gpu_impl_get_alloc_size(void* ptr) {
 
 unsigned int chpl_gpu_device_clock_rate(int32_t devNum) {
   return (unsigned int)deviceClockRates[devNum];
+}
+
+bool chpl_gpu_can_access_peer(int dev1, int dev2) {
+  int p2p;
+  cuDeviceCanAccessPeer(&p2p, chpl_gpu_devices[dev1], chpl_gpu_devices[dev2]);
+  return p2p != 0;
+}
+
+void chpl_gpu_set_peer_access(int dev1, int dev2, bool enable) {
+  chpl_gpu_switch_context(dev1);
+  if(enable) {
+    cuCtxEnablePeerAccess(chpl_gpu_primary_ctx[dev2], 0);
+  } else {
+    cuCtxDisablePeerAccess(chpl_gpu_primary_ctx[dev2]);
+  }
 }
 
 #endif // HAS_GPU_LOCALE

--- a/runtime/src/gpu/rocm/gpu-rocm.c
+++ b/runtime/src/gpu/rocm/gpu-rocm.c
@@ -553,4 +553,20 @@ unsigned int chpl_gpu_device_clock_rate(int32_t devNum) {
   return (unsigned int)deviceClockRates[devNum];
 }
 
+bool chpl_gpu_can_access_peer(int dev1, int dev2) {
+  int p2p;
+  hipDeviceCanAccessPeer(&p2p, dev1, dev2);
+  return p2p != 0;
+}
+
+void chpl_gpu_set_peer_access(int dev1, int dev2, bool enable) {
+  ROCM_CALL(hipSetDevice(dev1));
+  if(enable) {
+    hipDeviceEnablePeerAccess(dev2, 0);
+  } else {
+    hipDeviceDisablePeerAccess(dev2);
+  }
+}
+
+
 #endif // HAS_GPU_LOCALE

--- a/runtime/src/gpu/rocm/gpu-rocm.c
+++ b/runtime/src/gpu/rocm/gpu-rocm.c
@@ -553,20 +553,19 @@ unsigned int chpl_gpu_device_clock_rate(int32_t devNum) {
   return (unsigned int)deviceClockRates[devNum];
 }
 
-bool chpl_gpu_can_access_peer(int dev1, int dev2) {
+bool chpl_gpu_impl_can_access_peer(int dev1, int dev2) {
   int p2p;
-  hipDeviceCanAccessPeer(&p2p, dev1, dev2);
+  ROCM_CALL(hipDeviceCanAccessPeer(&p2p, dev1, dev2));
   return p2p != 0;
 }
 
-void chpl_gpu_set_peer_access(int dev1, int dev2, bool enable) {
+void chpl_gpu_impl_set_peer_access(int dev1, int dev2, bool enable) {
   ROCM_CALL(hipSetDevice(dev1));
   if(enable) {
-    hipDeviceEnablePeerAccess(dev2, 0);
+    ROCM_CALL(hipDeviceEnablePeerAccess(dev2, 0));
   } else {
-    hipDeviceDisablePeerAccess(dev2);
+    ROCM_CALL(hipDeviceDisablePeerAccess(dev2));
   }
 }
-
 
 #endif // HAS_GPU_LOCALE

--- a/test/gpu/native/nvlink.chpl
+++ b/test/gpu/native/nvlink.chpl
@@ -127,7 +127,7 @@ proc checkNumAccessEnabled(valFromChpl) {
   select ChplConfig.CHPL_GPU_CODEGEN {
     when "cuda" do checkNumAccessEnabled_cuda(valFromChpl);
     when "rocm" do checkNumAccessEnabled_rocm(valFromChpl);
-    otherwise do assertFalse("Update test to check for new runtime lib");
+    otherwise do compilerError("Update test to check for new runtime lib");
   }
 }
 

--- a/test/gpu/native/nvlink.chpl
+++ b/test/gpu/native/nvlink.chpl
@@ -1,0 +1,144 @@
+use CTypes, IO, Time, Sort, Subprocess, ChplConfig;
+
+config const N = 1024 * 1024 * 1024; // Setting to 8 GB causes an error?
+config const NUM_TRIALS = 3;         // Setting to 16 causes an error?
+config const p2p = true;
+config const verbose = false;
+config const runChecksForTest = false;
+config const printTimes = true;
+const gNumDevs = here.gpus.size;
+const gGpuRange = 0..<here.gpus.size;
+
+proc bw(time) { return (N : real) / (time * (1.0 * (1 << 30))); }
+
+proc measureP2P(dev1 : integral, dev2 : integral) {
+  var timer : stopwatch;
+
+  const locDev1 = here.gpus[dev1];
+  on here.gpus[dev2] {
+    var dev2Buf : [0..<N] uint(8);
+    on locDev1 {
+      var dev1Buf : [0..<N] uint(8);
+      timer.start();
+      dev2Buf = dev1Buf;
+      timer.stop();
+    }
+  }
+  return timer.elapsed();
+}
+
+proc medianTime(times, i, j) {
+  var arr = times[i, j, ..];
+  const n = arr.size;
+  sort(arr);
+  if (n % 2 == 0) {
+    return (arr[n/2-1] + arr[n/2]) / 2.0;
+  } else {
+    return arr[n/2];
+  }
+}
+
+proc doPrintTimes(times) {
+  writef("Times (GiB/s):\n");
+
+  write(b"┏");      for i in 0..< gNumDevs * 9 + 5 do write(b"━");        write(b"┓\n");
+  write(b"┃    │"); for i in 0..< gNumDevs         do writef("%-8i ", i); write(b"┃\n");
+  write(b"┃━━━━│"); for i in 0..< gNumDevs * 9     do write(b"━");        write(b"┃\n");
+
+  for i in gGpuRange {
+    writef(b"┃ %2i │", i);
+    for j in gGpuRange {
+      writef("%8.1dr ", bw(medianTime(times, i, j)));
+    }
+    write("┃\n");
+  }
+
+  write("┗"); for i in 0..<gNumDevs * 9 + 5 do write("━"); write("┛\n");
+}
+
+proc turnOnPeerAccess() {
+  extern proc chpl_gpu_can_access_peer(i : c_int, j : c_int) : bool;
+  extern proc chpl_gpu_set_peer_access(
+    i : c_int, j : c_int, shouldEnable : bool) : bool;
+  var n = 0;
+
+  for (i,j) in {gGpuRange, gGpuRange} {
+    if chpl_gpu_can_access_peer(i : c_int, j : c_int) {
+      n += 1;
+      if verbose then writef("ENABLE ACCESS: %i -> %i\n", i, j);
+      chpl_gpu_set_peer_access(i : c_int, j : c_int, true);
+    }
+  }
+  return n;
+}
+
+proc measureTimes(ref times) {
+  for i in gGpuRange {
+    for j in gGpuRange {
+      if verbose then stderr.writef("%i -> %i: ", i, j);
+      for k in 0..<NUM_TRIALS {
+        if verbose { stderr.write("."); stderr.flush(); }
+        times[i,j,k] = measureP2P(i,j);
+      }
+      if verbose then stderr.writeln();
+    }
+  }
+}
+
+proc checkNumAccessEnabled_cuda(valFromChpl) {
+  // The "nvidia-smi topo -p2p w" command will print a table showing what pairs
+  // of GPUs can enable peer access, each pair is marked with "OK" so we could
+  // the number of "OKs" output by the command. 
+  var sub = spawn(["nvidia-smi", "topo", "-p2p", "w"], stdout=pipeStyle.pipe);
+  var line : string;
+  var count = 0;
+  while sub.stdout.readLine(line) do
+    count += line.count("OK");
+  count -= 1; // Remove one for "OK" in legend
+
+  assert(count == valFromChpl,
+    "peer accesses enabled by Chapel does not match number possible ",
+    "according to nvidia-smi");
+}
+
+proc checkNumAccessEnabled_rocm(valFromChpl) {
+  // The "rocm-smi --showtopotype" command will print a table showing how pairs
+  // of GPUs are connected to one another.   The behavior I've seen with ROCM
+  // is that GPUs connected by PCIe can have peer access enabled.  It's very
+  // likely that this test will have to be updated to account for other link
+  // types in the future. Unfortunatly, I'm not aware of a subcommand in
+  // `rocm-smi` that would let me directly see which GPUs can enable peer
+  // access.  
+  var sub = spawn(["rocm-smi", "--showtopotype"], stdout=pipeStyle.pipe);
+  var line : string;
+  var count = 0;
+  while sub.stdout.readLine(line) do
+    count += line.count("PCIE");
+
+  assert(count == valFromChpl,
+    "peer accesses enabled by Chapel does not match number of PCIE ",
+    "connections found uising rocm-smi");
+}
+
+proc checkNumAccessEnabled(valFromChpl) {
+  // For the time being I'm going to run this as a CUDA only test as we I
+  // believe `rocm-smi --showtopotype` could be used to detect pairs of AMD
+  // GPUs that can have peer access enabled but I have not yet explored this.
+  select ChplConfig.CHPL_GPU_CODEGEN {
+    when "cuda" do checkNumAccessEnabled_cuda(valFromChpl);
+    when "rocm" do checkNumAccessEnabled_rocm(valFromChpl);
+    otherwise do assertFalse("Update test to check for new runtime lib");
+  }
+}
+
+proc main() {
+  var times : [gGpuRange, gGpuRange, 0..<NUM_TRIALS] real;
+  var numAccessEnabled = 0;
+  if p2p then numAccessEnabled = turnOnPeerAccess();
+  measureTimes(times);
+  if printTimes then doPrintTimes(times);
+
+  if(runChecksForTest) {
+    checkNumAccessEnabled(numAccessEnabled);
+  }
+}

--- a/test/gpu/native/nvlink.execopts
+++ b/test/gpu/native/nvlink.execopts
@@ -1,0 +1,1 @@
+--runChecksForTest=true --printTimes=false --N=1024

--- a/test/gpu/native/nvlink.good
+++ b/test/gpu/native/nvlink.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly


### PR DESCRIPTION
This PR has some initial work for getting Chapel to work with nvlink.  The punchline seems to be: I think all we need to do this is call `cuCtxEnablePeerAccess` between all pairs of GPUs that support it.  So I've added some no doc'd functions to the GPU module to query/enable this as well as a no doc'd enableGpuP2P config constant that will enable peer-to-peer access wherever its possible on startup.

More specifically, this PR:

* Adds the aforementioned `enableGpuP2P` config constant (which lives in the `ChapelGpuSupport` internal module)
* Adds no doc'd `canAccessPeer` and `setPeerAccess` to `GPU` module, that call out to:
  * Added `chpl_gpu_can_access_peer` and `chpl_gpu_set_peer_access` in runtime (CUDA and ROCM versions)
* Adds `CHPL_GPU_CODEGEN` as a no doc'd function to the `ChplConfig` module.  I want to have access to this for our own testing purposes. Perhaps this is a candidate of something that would nice to have in `ChplConfig` more globally?
* Adds a test
  * This can be run alone to experiment with and time GPU to GPU data transfers both with nvlink enabled and disabled; it displays it results in a table.
  * For test verification enable peer access and do the data transfers. I also compare how often I'm able to enable peer access and check that it matches what I would expect given output from `nvidia-smi` and `rocm-smi` about how GPUs connect to one another. This is a little wonky and doesn't really establish that I'm using nvlink but it is something. As future work I think we should find some benchmark that exhibits better performance when nvlink is enabled and then do nithgly performance testing with it (and then if things regress we'll see so on our nightly graph).

