### PR TITLE
Change reservation.py test to parse `printenv` by NUL

### DIFF
--- a/test/runtime/configMatters/launch/jhh/reservation/reservation.py
+++ b/test/runtime/configMatters/launch/jhh/reservation/reservation.py
@@ -34,8 +34,10 @@ def skipif():
         if key == 'CHPL_LAUNCHER' and value != 'slurm-srun':
             skipReason = "CHPL_LAUNCHER != slurm-srun"
     # Verify environment variables
-    output = runCmd("printenv")
-    for line in output.splitlines():
+    output = runCmd("printenv -0")
+    for line in output.split("\0"):
+        if len(line) == 0:
+            continue
         (key, value) = line.split('=',1)
         if key == 'CHPL_RT_LOCALES_PER_NODE' and value != 1:
             skipReason = "CHPL_RT_LOCALES_PER_NODE != 1"


### PR DESCRIPTION
Fixes an issue where `test/runtime/configMatters/launch/jhh/reservation/reservation.py` parses the output of `printenv` by newline. This does not work when `SHELL` is `bash`, because exported functions (and any environment variable really) may contain newlines. This breaks the parsing as each `line` is no longer a complete environment variable.

The fix is to use `-0` with `printenv` to delimit by NUL not newline.