### PR TITLE
Disallow break, return and continues with labels in foreach loops

### DIFF
--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -300,6 +300,8 @@ void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
     // Nothing
   } else if (blockingAst->isForall()) {
     blockingName = "'forall' statement";
+  } else if (blockingAst->isForeach()) {
+    blockingName = "'foreach' statement";
   } else if (blockingAst->isCoforall()) {
     blockingName = "'coforall' statement";
   } else if (blockingAst->isOn()) {

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -195,8 +195,9 @@ enum class ControlFlowModifier {
   BLOCKS,
 };
 
-// The six node types that most mess with control flow are:
+// The seven node types that most mess with control flow are:
 //   * "forall statement"
+//   * "foreach statement"
 //   * "coforall statement"
 //   * "on statement"
 //   * "begin statement"
@@ -206,8 +207,8 @@ enum class ControlFlowModifier {
 static ControlFlowModifier nodeAllowsReturn(const AstNode* node,
                                             const Return* ctrl) {
   if (node->isFunction()) return ControlFlowModifier::ALLOWS;
-  if (node->isForall() || node->isCoforall() || node->isOn() ||
-      node->isBegin() || node->isSync() || node->isCobegin()) {
+  if (node->isForall() || node->isForeach() || node->isCoforall() ||
+      node->isOn() || node->isBegin() || node->isSync() || node->isCobegin()) {
     return ControlFlowModifier::BLOCKS;
   }
   return ControlFlowModifier::NONE;
@@ -225,8 +226,8 @@ static ControlFlowModifier nodeAllowsYield(const AstNode* node,
 static ControlFlowModifier nodeAllowsBreak(const AstNode* node,
                                            const Break* ctrl) {
   if (node->isFunction() || // functions block break
-      node->isForall() || node->isCoforall() || node->isOn() ||
-      node->isBegin() || node->isSync() || node->isCobegin()) {
+      node->isForall() || node->isForeach() || node->isCoforall() ||
+      node->isOn() || node->isBegin() || node->isSync() || node->isCobegin()) {
     return ControlFlowModifier::BLOCKS;
   }
   if (auto target = ctrl->target()) {

--- a/test/errors/parsing/controlFlow.1.good
+++ b/test/errors/parsing/controlFlow.1.good
@@ -13,67 +13,73 @@ controlFlow.chpl:16: error: 'continue' is not allowed outside of a loop
 controlFlow.chpl:21: error: 'break' is not allowed in a 'forall' statement
 controlFlow.chpl:22: error: could not find label 'someLabel' for 'break' statement
 controlFlow.chpl:24: error: could not find label 'someLabel' for 'continue' statement
-controlFlow.chpl:27: error: 'break' is not allowed in a 'coforall' statement
+controlFlow.chpl:27: error: 'break' is not allowed in a 'foreach' statement
 controlFlow.chpl:28: error: could not find label 'someLabel' for 'break' statement
-controlFlow.chpl:29: error: 'continue' is not allowed in a 'coforall' statement
 controlFlow.chpl:30: error: could not find label 'someLabel' for 'continue' statement
-controlFlow.chpl:33: error: 'break' is not allowed in an 'on' statement
+controlFlow.chpl:33: error: 'break' is not allowed in a 'coforall' statement
 controlFlow.chpl:34: error: could not find label 'someLabel' for 'break' statement
-controlFlow.chpl:35: error: 'continue' is not allowed in an 'on' statement
+controlFlow.chpl:35: error: 'continue' is not allowed in a 'coforall' statement
 controlFlow.chpl:36: error: could not find label 'someLabel' for 'continue' statement
-controlFlow.chpl:39: error: 'break' is not allowed in a 'begin' statement
+controlFlow.chpl:39: error: 'break' is not allowed in an 'on' statement
 controlFlow.chpl:40: error: could not find label 'someLabel' for 'break' statement
-controlFlow.chpl:41: error: 'continue' is not allowed in a 'begin' statement
+controlFlow.chpl:41: error: 'continue' is not allowed in an 'on' statement
 controlFlow.chpl:42: error: could not find label 'someLabel' for 'continue' statement
-controlFlow.chpl:45: error: 'break' is not allowed in a 'sync' statement
+controlFlow.chpl:45: error: 'break' is not allowed in a 'begin' statement
 controlFlow.chpl:46: error: could not find label 'someLabel' for 'break' statement
-controlFlow.chpl:47: error: 'continue' is not allowed in a 'sync' statement
+controlFlow.chpl:47: error: 'continue' is not allowed in a 'begin' statement
 controlFlow.chpl:48: error: could not find label 'someLabel' for 'continue' statement
-controlFlow.chpl:51: error: 'break' is not allowed in a 'cobegin' statement
+controlFlow.chpl:51: error: 'break' is not allowed in a 'sync' statement
 controlFlow.chpl:52: error: could not find label 'someLabel' for 'break' statement
-controlFlow.chpl:53: error: 'continue' is not allowed in a 'cobegin' statement
+controlFlow.chpl:53: error: 'continue' is not allowed in a 'sync' statement
 controlFlow.chpl:54: error: could not find label 'someLabel' for 'continue' statement
-controlFlow.chpl:58: In function 'wrapper2':
-controlFlow.chpl:59: error: 'break' is not allowed outside of a loop
-controlFlow.chpl:58: note: cannot 'break' out of a procedure
-controlFlow.chpl:60: error: 'break' to label 'actualLabel' outside of a procedure is not allowed
-controlFlow.chpl:58: note: cannot 'break' out of a procedure
-controlFlow.chpl:61: error: 'continue' is not allowed outside of a loop
-controlFlow.chpl:58: note: cannot 'continue' out of a procedure
-controlFlow.chpl:62: error: 'continue' to label 'actualLabel' outside of a procedure is not allowed
-controlFlow.chpl:58: note: cannot 'continue' out of a procedure
-controlFlow.chpl:67: error: 'break' is not allowed in a 'forall' statement
-controlFlow.chpl:68: error: 'break' to label 'actualLabel' outside of a 'forall' statement is not allowed
-controlFlow.chpl:66: note: cannot 'break' out of a 'forall' statement
-controlFlow.chpl:70: error: 'continue' to label 'actualLabel' outside of a 'forall' statement is not allowed
-controlFlow.chpl:66: note: cannot 'continue' out of a 'forall' statement
-controlFlow.chpl:73: error: 'break' is not allowed in a 'coforall' statement
-controlFlow.chpl:74: error: 'break' to label 'actualLabel' outside of a 'coforall' statement is not allowed
-controlFlow.chpl:72: note: cannot 'break' out of a 'coforall' statement
-controlFlow.chpl:75: error: 'continue' is not allowed in a 'coforall' statement
-controlFlow.chpl:76: error: 'continue' to label 'actualLabel' outside of a 'coforall' statement is not allowed
-controlFlow.chpl:72: note: cannot 'continue' out of a 'coforall' statement
-controlFlow.chpl:79: error: 'break' is not allowed in an 'on' statement
-controlFlow.chpl:80: error: 'break' to label 'actualLabel' outside of an 'on' statement is not allowed
-controlFlow.chpl:78: note: cannot 'break' out of an 'on' statement
-controlFlow.chpl:81: error: 'continue' is not allowed in an 'on' statement
-controlFlow.chpl:82: error: 'continue' to label 'actualLabel' outside of an 'on' statement is not allowed
-controlFlow.chpl:78: note: cannot 'continue' out of an 'on' statement
-controlFlow.chpl:85: error: 'break' is not allowed in a 'begin' statement
-controlFlow.chpl:86: error: 'break' to label 'actualLabel' outside of a 'begin' statement is not allowed
-controlFlow.chpl:84: note: cannot 'break' out of a 'begin' statement
-controlFlow.chpl:87: error: 'continue' is not allowed in a 'begin' statement
-controlFlow.chpl:88: error: 'continue' to label 'actualLabel' outside of a 'begin' statement is not allowed
-controlFlow.chpl:84: note: cannot 'continue' out of a 'begin' statement
-controlFlow.chpl:91: error: 'break' is not allowed in a 'sync' statement
-controlFlow.chpl:92: error: 'break' to label 'actualLabel' outside of a 'sync' statement is not allowed
-controlFlow.chpl:90: note: cannot 'break' out of a 'sync' statement
-controlFlow.chpl:93: error: 'continue' is not allowed in a 'sync' statement
-controlFlow.chpl:94: error: 'continue' to label 'actualLabel' outside of a 'sync' statement is not allowed
-controlFlow.chpl:90: note: cannot 'continue' out of a 'sync' statement
-controlFlow.chpl:97: error: 'break' is not allowed in a 'cobegin' statement
-controlFlow.chpl:98: error: 'break' to label 'actualLabel' outside of a 'cobegin' statement is not allowed
-controlFlow.chpl:96: note: cannot 'break' out of a 'cobegin' statement
-controlFlow.chpl:99: error: 'continue' is not allowed in a 'cobegin' statement
-controlFlow.chpl:100: error: 'continue' to label 'actualLabel' outside of a 'cobegin' statement is not allowed
-controlFlow.chpl:96: note: cannot 'continue' out of a 'cobegin' statement
+controlFlow.chpl:57: error: 'break' is not allowed in a 'cobegin' statement
+controlFlow.chpl:58: error: could not find label 'someLabel' for 'break' statement
+controlFlow.chpl:59: error: 'continue' is not allowed in a 'cobegin' statement
+controlFlow.chpl:60: error: could not find label 'someLabel' for 'continue' statement
+controlFlow.chpl:64: In function 'wrapper2':
+controlFlow.chpl:65: error: 'break' is not allowed outside of a loop
+controlFlow.chpl:64: note: cannot 'break' out of a procedure
+controlFlow.chpl:66: error: 'break' to label 'actualLabel' outside of a procedure is not allowed
+controlFlow.chpl:64: note: cannot 'break' out of a procedure
+controlFlow.chpl:67: error: 'continue' is not allowed outside of a loop
+controlFlow.chpl:64: note: cannot 'continue' out of a procedure
+controlFlow.chpl:68: error: 'continue' to label 'actualLabel' outside of a procedure is not allowed
+controlFlow.chpl:64: note: cannot 'continue' out of a procedure
+controlFlow.chpl:73: error: 'break' is not allowed in a 'forall' statement
+controlFlow.chpl:74: error: 'break' to label 'actualLabel' outside of a 'forall' statement is not allowed
+controlFlow.chpl:72: note: cannot 'break' out of a 'forall' statement
+controlFlow.chpl:76: error: 'continue' to label 'actualLabel' outside of a 'forall' statement is not allowed
+controlFlow.chpl:72: note: cannot 'continue' out of a 'forall' statement
+controlFlow.chpl:79: error: 'break' is not allowed in a 'foreach' statement
+controlFlow.chpl:80: error: 'break' to label 'actualLabel' outside of a 'foreach' statement is not allowed
+controlFlow.chpl:78: note: cannot 'break' out of a 'foreach' statement
+controlFlow.chpl:85: error: 'break' is not allowed in a 'coforall' statement
+controlFlow.chpl:86: error: 'break' to label 'actualLabel' outside of a 'coforall' statement is not allowed
+controlFlow.chpl:84: note: cannot 'break' out of a 'coforall' statement
+controlFlow.chpl:87: error: 'continue' is not allowed in a 'coforall' statement
+controlFlow.chpl:88: error: 'continue' to label 'actualLabel' outside of a 'coforall' statement is not allowed
+controlFlow.chpl:84: note: cannot 'continue' out of a 'coforall' statement
+controlFlow.chpl:91: error: 'break' is not allowed in an 'on' statement
+controlFlow.chpl:92: error: 'break' to label 'actualLabel' outside of an 'on' statement is not allowed
+controlFlow.chpl:90: note: cannot 'break' out of an 'on' statement
+controlFlow.chpl:93: error: 'continue' is not allowed in an 'on' statement
+controlFlow.chpl:94: error: 'continue' to label 'actualLabel' outside of an 'on' statement is not allowed
+controlFlow.chpl:90: note: cannot 'continue' out of an 'on' statement
+controlFlow.chpl:97: error: 'break' is not allowed in a 'begin' statement
+controlFlow.chpl:98: error: 'break' to label 'actualLabel' outside of a 'begin' statement is not allowed
+controlFlow.chpl:96: note: cannot 'break' out of a 'begin' statement
+controlFlow.chpl:99: error: 'continue' is not allowed in a 'begin' statement
+controlFlow.chpl:100: error: 'continue' to label 'actualLabel' outside of a 'begin' statement is not allowed
+controlFlow.chpl:96: note: cannot 'continue' out of a 'begin' statement
+controlFlow.chpl:103: error: 'break' is not allowed in a 'sync' statement
+controlFlow.chpl:104: error: 'break' to label 'actualLabel' outside of a 'sync' statement is not allowed
+controlFlow.chpl:102: note: cannot 'break' out of a 'sync' statement
+controlFlow.chpl:105: error: 'continue' is not allowed in a 'sync' statement
+controlFlow.chpl:106: error: 'continue' to label 'actualLabel' outside of a 'sync' statement is not allowed
+controlFlow.chpl:102: note: cannot 'continue' out of a 'sync' statement
+controlFlow.chpl:109: error: 'break' is not allowed in a 'cobegin' statement
+controlFlow.chpl:110: error: 'break' to label 'actualLabel' outside of a 'cobegin' statement is not allowed
+controlFlow.chpl:108: note: cannot 'break' out of a 'cobegin' statement
+controlFlow.chpl:111: error: 'continue' is not allowed in a 'cobegin' statement
+controlFlow.chpl:112: error: 'continue' to label 'actualLabel' outside of a 'cobegin' statement is not allowed
+controlFlow.chpl:108: note: cannot 'continue' out of a 'cobegin' statement

--- a/test/errors/parsing/controlFlow.2.good
+++ b/test/errors/parsing/controlFlow.2.good
@@ -94,14 +94,14 @@
        |
 
 ─── error in controlFlow.chpl:27 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'coforall' statement.
+  'break' is not allowed in a 'foreach' statement.
        |
     27 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'coforall' statement is here:
+  The relevant 'foreach' statement is here:
        |
-    26 | coforall 1..10 {
+    26 | foreach 1..10 {
        |
 
 ─── error in controlFlow.chpl:28 [DisallowedControlFlow] ───
@@ -109,17 +109,6 @@
        |
     28 |     break someLabel;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
-       |
-
-─── error in controlFlow.chpl:29 [DisallowedControlFlow] ───
-  'continue' is not allowed in a 'coforall' statement.
-       |
-    29 |     continue;
-       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
-       |
-  The relevant 'coforall' statement is here:
-       |
-    26 | coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:30 [DisallowedControlFlow] ───
@@ -130,14 +119,14 @@
        |
 
 ─── error in controlFlow.chpl:33 [DisallowedControlFlow] ───
-  'break' is not allowed in an 'on' statement.
+  'break' is not allowed in a 'coforall' statement.
        |
     33 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'on' statement is here:
+  The relevant 'coforall' statement is here:
        |
-    32 | on here {
+    32 | coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:34 [DisallowedControlFlow] ───
@@ -148,14 +137,14 @@
        |
 
 ─── error in controlFlow.chpl:35 [DisallowedControlFlow] ───
-  'continue' is not allowed in an 'on' statement.
+  'continue' is not allowed in a 'coforall' statement.
        |
     35 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'on' statement is here:
+  The relevant 'coforall' statement is here:
        |
-    32 | on here {
+    32 | coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:36 [DisallowedControlFlow] ───
@@ -166,14 +155,14 @@
        |
 
 ─── error in controlFlow.chpl:39 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'begin' statement.
+  'break' is not allowed in an 'on' statement.
        |
     39 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'begin' statement is here:
+  The relevant 'on' statement is here:
        |
-    38 | begin {
+    38 | on here {
        |
 
 ─── error in controlFlow.chpl:40 [DisallowedControlFlow] ───
@@ -184,14 +173,14 @@
        |
 
 ─── error in controlFlow.chpl:41 [DisallowedControlFlow] ───
-  'continue' is not allowed in a 'begin' statement.
+  'continue' is not allowed in an 'on' statement.
        |
     41 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'begin' statement is here:
+  The relevant 'on' statement is here:
        |
-    38 | begin {
+    38 | on here {
        |
 
 ─── error in controlFlow.chpl:42 [DisallowedControlFlow] ───
@@ -202,14 +191,14 @@
        |
 
 ─── error in controlFlow.chpl:45 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'sync' statement.
+  'break' is not allowed in a 'begin' statement.
        |
     45 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'sync' statement is here:
+  The relevant 'begin' statement is here:
        |
-    44 | sync {
+    44 | begin {
        |
 
 ─── error in controlFlow.chpl:46 [DisallowedControlFlow] ───
@@ -220,14 +209,14 @@
        |
 
 ─── error in controlFlow.chpl:47 [DisallowedControlFlow] ───
-  'continue' is not allowed in a 'sync' statement.
+  'continue' is not allowed in a 'begin' statement.
        |
     47 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'sync' statement is here:
+  The relevant 'begin' statement is here:
        |
-    44 | sync {
+    44 | begin {
        |
 
 ─── error in controlFlow.chpl:48 [DisallowedControlFlow] ───
@@ -238,14 +227,14 @@
        |
 
 ─── error in controlFlow.chpl:51 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'cobegin' statement.
+  'break' is not allowed in a 'sync' statement.
        |
     51 |     break;
        |     ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'cobegin' statement is here:
+  The relevant 'sync' statement is here:
        |
-    50 | cobegin {
+    50 | sync {
        |
 
 ─── error in controlFlow.chpl:52 [DisallowedControlFlow] ───
@@ -256,14 +245,14 @@
        |
 
 ─── error in controlFlow.chpl:53 [DisallowedControlFlow] ───
-  'continue' is not allowed in a 'cobegin' statement.
+  'continue' is not allowed in a 'sync' statement.
        |
     53 |     continue;
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'cobegin' statement is here:
+  The relevant 'sync' statement is here:
        |
-    50 | cobegin {
+    50 | sync {
        |
 
 ─── error in controlFlow.chpl:54 [DisallowedControlFlow] ───
@@ -273,300 +262,358 @@
        |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
 
+─── error in controlFlow.chpl:57 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'cobegin' statement.
+       |
+    57 |     break;
+       |     ⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'cobegin' statement is here:
+       |
+    56 | cobegin {
+       |
+
+─── error in controlFlow.chpl:58 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'break' statement.
+       |
+    58 |     break someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
 ─── error in controlFlow.chpl:59 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'cobegin' statement.
+       |
+    59 |     continue;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+  The relevant 'cobegin' statement is here:
+       |
+    56 | cobegin {
+       |
+
+─── error in controlFlow.chpl:60 [DisallowedControlFlow] ───
+  Could not find label 'someLabel' for 'continue' statement.
+       |
+    60 |     continue someLabel;
+       |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
+
+─── error in controlFlow.chpl:65 [DisallowedControlFlow] ───
   'break' is not allowed outside of a loop.
        |
-    59 |         break;
+    65 |         break;
        |         ⎺⎺⎺⎺⎺⎺
        |
   Cannot 'break' out of a procedure:
        |
-    58 |     proc wrapper2() {
+    64 |     proc wrapper2() {
        |
 
-─── error in controlFlow.chpl:60 [DisallowedControlFlow] ───
+─── error in controlFlow.chpl:66 [DisallowedControlFlow] ───
   'break' to label 'actualLabel' outside of a procedure is not allowed.
        |
-    60 |         break actualLabel;
+    66 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
   Cannot 'break' out of a procedure:
        |
-    58 |     proc wrapper2() {
+    64 |     proc wrapper2() {
        |
 
-─── error in controlFlow.chpl:61 [DisallowedControlFlow] ───
+─── error in controlFlow.chpl:67 [DisallowedControlFlow] ───
   'continue' is not allowed outside of a loop.
        |
-    61 |         continue;
+    67 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
   Cannot 'continue' out of a procedure:
        |
-    58 |     proc wrapper2() {
+    64 |     proc wrapper2() {
        |
 
-─── error in controlFlow.chpl:62 [DisallowedControlFlow] ───
+─── error in controlFlow.chpl:68 [DisallowedControlFlow] ───
   'continue' to label 'actualLabel' outside of a procedure is not allowed.
        |
-    62 |         continue actualLabel;
+    68 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
   Cannot 'continue' out of a procedure:
        |
-    58 |     proc wrapper2() {
-       |
-
-─── error in controlFlow.chpl:67 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'forall' statement.
-       |
-    67 |         break;
-       |         ⎺⎺⎺⎺⎺⎺
-       |
-  The relevant 'forall' statement is here:
-       |
-    66 |     forall 1..10 {
-       |
-
-─── error in controlFlow.chpl:68 [DisallowedControlFlow] ───
-  'break' to label 'actualLabel' outside of a 'forall' statement is not allowed.
-       |
-    68 |         break actualLabel;
-       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
-       |
-  Cannot 'break' out of a 'forall' statement:
-       |
-    66 |     forall 1..10 {
-       |
-
-─── error in controlFlow.chpl:70 [DisallowedControlFlow] ───
-  'continue' to label 'actualLabel' outside of a 'forall' statement is not allowed.
-       |
-    70 |         continue actualLabel;
-       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
-       |
-  Cannot 'continue' out of a 'forall' statement:
-       |
-    66 |     forall 1..10 {
+    64 |     proc wrapper2() {
        |
 
 ─── error in controlFlow.chpl:73 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'coforall' statement.
+  'break' is not allowed in a 'forall' statement.
        |
     73 |         break;
        |         ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'coforall' statement is here:
+  The relevant 'forall' statement is here:
        |
-    72 |     coforall 1..10 {
+    72 |     forall 1..10 {
        |
 
 ─── error in controlFlow.chpl:74 [DisallowedControlFlow] ───
-  'break' to label 'actualLabel' outside of a 'coforall' statement is not allowed.
+  'break' to label 'actualLabel' outside of a 'forall' statement is not allowed.
        |
     74 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'coforall' statement:
+  Cannot 'break' out of a 'forall' statement:
        |
-    72 |     coforall 1..10 {
-       |
-
-─── error in controlFlow.chpl:75 [DisallowedControlFlow] ───
-  'continue' is not allowed in a 'coforall' statement.
-       |
-    75 |         continue;
-       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
-       |
-  The relevant 'coforall' statement is here:
-       |
-    72 |     coforall 1..10 {
+    72 |     forall 1..10 {
        |
 
 ─── error in controlFlow.chpl:76 [DisallowedControlFlow] ───
-  'continue' to label 'actualLabel' outside of a 'coforall' statement is not allowed.
+  'continue' to label 'actualLabel' outside of a 'forall' statement is not allowed.
        |
     76 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a 'coforall' statement:
+  Cannot 'continue' out of a 'forall' statement:
        |
-    72 |     coforall 1..10 {
+    72 |     forall 1..10 {
        |
 
 ─── error in controlFlow.chpl:79 [DisallowedControlFlow] ───
-  'break' is not allowed in an 'on' statement.
+  'break' is not allowed in a 'foreach' statement.
        |
     79 |         break;
        |         ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'on' statement is here:
+  The relevant 'foreach' statement is here:
        |
-    78 |     on here {
+    78 |     foreach 1..10 {
        |
 
 ─── error in controlFlow.chpl:80 [DisallowedControlFlow] ───
-  'break' to label 'actualLabel' outside of an 'on' statement is not allowed.
+  'break' to label 'actualLabel' outside of a 'foreach' statement is not allowed.
        |
     80 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of an 'on' statement:
+  Cannot 'break' out of a 'foreach' statement:
        |
-    78 |     on here {
-       |
-
-─── error in controlFlow.chpl:81 [DisallowedControlFlow] ───
-  'continue' is not allowed in an 'on' statement.
-       |
-    81 |         continue;
-       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
-       |
-  The relevant 'on' statement is here:
-       |
-    78 |     on here {
-       |
-
-─── error in controlFlow.chpl:82 [DisallowedControlFlow] ───
-  'continue' to label 'actualLabel' outside of an 'on' statement is not allowed.
-       |
-    82 |         continue actualLabel;
-       |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
-       |
-  Cannot 'continue' out of an 'on' statement:
-       |
-    78 |     on here {
+    78 |     foreach 1..10 {
        |
 
 ─── error in controlFlow.chpl:85 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'begin' statement.
+  'break' is not allowed in a 'coforall' statement.
        |
     85 |         break;
        |         ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'begin' statement is here:
+  The relevant 'coforall' statement is here:
        |
-    84 |     begin {
+    84 |     coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:86 [DisallowedControlFlow] ───
-  'break' to label 'actualLabel' outside of a 'begin' statement is not allowed.
+  'break' to label 'actualLabel' outside of a 'coforall' statement is not allowed.
        |
     86 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'begin' statement:
+  Cannot 'break' out of a 'coforall' statement:
        |
-    84 |     begin {
+    84 |     coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:87 [DisallowedControlFlow] ───
-  'continue' is not allowed in a 'begin' statement.
+  'continue' is not allowed in a 'coforall' statement.
        |
     87 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'begin' statement is here:
+  The relevant 'coforall' statement is here:
        |
-    84 |     begin {
+    84 |     coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:88 [DisallowedControlFlow] ───
-  'continue' to label 'actualLabel' outside of a 'begin' statement is not allowed.
+  'continue' to label 'actualLabel' outside of a 'coforall' statement is not allowed.
        |
     88 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a 'begin' statement:
+  Cannot 'continue' out of a 'coforall' statement:
        |
-    84 |     begin {
+    84 |     coforall 1..10 {
        |
 
 ─── error in controlFlow.chpl:91 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'sync' statement.
+  'break' is not allowed in an 'on' statement.
        |
     91 |         break;
        |         ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'sync' statement is here:
+  The relevant 'on' statement is here:
        |
-    90 |     sync {
+    90 |     on here {
        |
 
 ─── error in controlFlow.chpl:92 [DisallowedControlFlow] ───
-  'break' to label 'actualLabel' outside of a 'sync' statement is not allowed.
+  'break' to label 'actualLabel' outside of an 'on' statement is not allowed.
        |
     92 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'sync' statement:
+  Cannot 'break' out of an 'on' statement:
        |
-    90 |     sync {
+    90 |     on here {
        |
 
 ─── error in controlFlow.chpl:93 [DisallowedControlFlow] ───
-  'continue' is not allowed in a 'sync' statement.
+  'continue' is not allowed in an 'on' statement.
        |
     93 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'sync' statement is here:
+  The relevant 'on' statement is here:
        |
-    90 |     sync {
+    90 |     on here {
        |
 
 ─── error in controlFlow.chpl:94 [DisallowedControlFlow] ───
-  'continue' to label 'actualLabel' outside of a 'sync' statement is not allowed.
+  'continue' to label 'actualLabel' outside of an 'on' statement is not allowed.
        |
     94 |         continue actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'continue' out of a 'sync' statement:
+  Cannot 'continue' out of an 'on' statement:
        |
-    90 |     sync {
+    90 |     on here {
        |
 
 ─── error in controlFlow.chpl:97 [DisallowedControlFlow] ───
-  'break' is not allowed in a 'cobegin' statement.
+  'break' is not allowed in a 'begin' statement.
        |
     97 |         break;
        |         ⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'cobegin' statement is here:
+  The relevant 'begin' statement is here:
        |
-    96 |     cobegin {
+    96 |     begin {
        |
 
 ─── error in controlFlow.chpl:98 [DisallowedControlFlow] ───
-  'break' to label 'actualLabel' outside of a 'cobegin' statement is not allowed.
+  'break' to label 'actualLabel' outside of a 'begin' statement is not allowed.
        |
     98 |         break actualLabel;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  Cannot 'break' out of a 'cobegin' statement:
+  Cannot 'break' out of a 'begin' statement:
        |
-    96 |     cobegin {
+    96 |     begin {
        |
 
 ─── error in controlFlow.chpl:99 [DisallowedControlFlow] ───
-  'continue' is not allowed in a 'cobegin' statement.
+  'continue' is not allowed in a 'begin' statement.
        |
     99 |         continue;
        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
-  The relevant 'cobegin' statement is here:
+  The relevant 'begin' statement is here:
        |
-    96 |     cobegin {
+    96 |     begin {
        |
 
 ─── error in controlFlow.chpl:100 [DisallowedControlFlow] ───
-  'continue' to label 'actualLabel' outside of a 'cobegin' statement is not allowed.
+  'continue' to label 'actualLabel' outside of a 'begin' statement is not allowed.
         |
     100 |         continue actualLabel;
         |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
         |
+  Cannot 'continue' out of a 'begin' statement:
+       |
+    96 |     begin {
+       |
+
+─── error in controlFlow.chpl:103 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'sync' statement.
+        |
+    103 |         break;
+        |         ⎺⎺⎺⎺⎺⎺
+        |
+  The relevant 'sync' statement is here:
+        |
+    102 |     sync {
+        |
+
+─── error in controlFlow.chpl:104 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of a 'sync' statement is not allowed.
+        |
+    104 |         break actualLabel;
+        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+        |
+  Cannot 'break' out of a 'sync' statement:
+        |
+    102 |     sync {
+        |
+
+─── error in controlFlow.chpl:105 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'sync' statement.
+        |
+    105 |         continue;
+        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+        |
+  The relevant 'sync' statement is here:
+        |
+    102 |     sync {
+        |
+
+─── error in controlFlow.chpl:106 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of a 'sync' statement is not allowed.
+        |
+    106 |         continue actualLabel;
+        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+        |
+  Cannot 'continue' out of a 'sync' statement:
+        |
+    102 |     sync {
+        |
+
+─── error in controlFlow.chpl:109 [DisallowedControlFlow] ───
+  'break' is not allowed in a 'cobegin' statement.
+        |
+    109 |         break;
+        |         ⎺⎺⎺⎺⎺⎺
+        |
+  The relevant 'cobegin' statement is here:
+        |
+    108 |     cobegin {
+        |
+
+─── error in controlFlow.chpl:110 [DisallowedControlFlow] ───
+  'break' to label 'actualLabel' outside of a 'cobegin' statement is not allowed.
+        |
+    110 |         break actualLabel;
+        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+        |
+  Cannot 'break' out of a 'cobegin' statement:
+        |
+    108 |     cobegin {
+        |
+
+─── error in controlFlow.chpl:111 [DisallowedControlFlow] ───
+  'continue' is not allowed in a 'cobegin' statement.
+        |
+    111 |         continue;
+        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+        |
+  The relevant 'cobegin' statement is here:
+        |
+    108 |     cobegin {
+        |
+
+─── error in controlFlow.chpl:112 [DisallowedControlFlow] ───
+  'continue' to label 'actualLabel' outside of a 'cobegin' statement is not allowed.
+        |
+    112 |         continue actualLabel;
+        |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+        |
   Cannot 'continue' out of a 'cobegin' statement:
-       |
-    96 |     cobegin {
-       |
+        |
+    108 |     cobegin {
+        |
 

--- a/test/errors/parsing/controlFlow.chpl
+++ b/test/errors/parsing/controlFlow.chpl
@@ -23,6 +23,12 @@ forall 1..10 {
     continue;
     continue someLabel;
 }
+foreach 1..10 {
+    break;
+    break someLabel;
+    continue;
+    continue someLabel;
+}
 coforall 1..10 {
     break;
     break someLabel;
@@ -64,6 +70,12 @@ label actualLabel for 1..10 {
 
     // Each of the following block continues and returns.
     forall 1..10 {
+        break;
+        break actualLabel;
+        continue;
+        continue actualLabel;
+    }
+    foreach 1..10 {
         break;
         break actualLabel;
         continue;

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.chpl
@@ -254,10 +254,9 @@ proc findSeqStart(buff, inds, ref ltLoc) {
     foreach i in inds {
       if buff[i] == '>'.toByte() {
         ltLoc = i;
-        return true;
       }
     }
-    return false;
+    return ltLoc != max(int);
   } else if searchAlg == For {
     for i in inds {
       if buff[i] == '>'.toByte() {


### PR DESCRIPTION
This came up in https://github.com/chapel-lang/chapel/issues/21924

We might be able to support these statements in `foreach` statements (as well as `forall`). However, for `foreach`es we don't do anything special for them at the moment. Until we do, we should disallow to make them more aligned with `forall` loops.

This only required one test change.

Test:
- [x] linux64

