### PR TITLE
Stop generating GPU-related flags without the GPU locale model

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4611,8 +4611,10 @@ void makeBinaryLLVM(void) {
     cargs += clangInfo->clangCCArgs[i];
   }
 
-  std::string gpuArgs = generateClangGpuLangArgs();
-  gpuArgs += " -Wno-unknown-cuda-version";
+  std::string gpuArgs = "";
+  if (usingGpuLocaleModel()) {
+    gpuArgs = generateClangGpuLangArgs() + " -Wno-unknown-cuda-version";
+  }
 
   int filenum = 0;
   while (const char* inputFilename = nthFilename(filenum++)) {


### PR DESCRIPTION
Shortly after merging https://github.com/chapel-lang/chapel/pull/22089, I realized that it led to always adding `-Wno-unknown-cuda-version` while compiling `.c` files. However, this is only relevant when `CHPL_LOCALE_MODEL=gpu`. I suspect it may be a problem if a clang that doesn't support that is used with C interop.

Test:

- [x] test added in https://github.com/chapel-lang/chapel/pull/22089 passes