### PR TITLE
Add two tests using `continue` in a kernel

### DIFF
--- a/test/gpu/native/continue/contFromLoop.chpl
+++ b/test/gpu/native/continue/contFromLoop.chpl
@@ -1,0 +1,12 @@
+use GPU;
+
+on here.gpus[0] {
+  var A : [0..10] real(32);
+  foreach i in 0..10 {
+    assertOnGpu();
+    if i == 3 then continue;
+    A[i] = i;
+  }
+  writeln(A);
+}
+

--- a/test/gpu/native/continue/contFromLoop.good
+++ b/test/gpu/native/continue/contFromLoop.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+0.0 1.0 2.0 0.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0

--- a/test/gpu/native/continue/contFromLoop2.chpl
+++ b/test/gpu/native/continue/contFromLoop2.chpl
@@ -1,0 +1,14 @@
+use GPU;
+
+on here.gpus[0] {
+  var A : [0..10] real(32);
+  foreach i in 0..10 {
+    assertOnGpu();
+    for j in 1..3 {
+      if j == 3 then continue;
+      A[i] += i;
+    }
+  }
+  writeln(A);
+}
+

--- a/test/gpu/native/continue/contFromLoop2.good
+++ b/test/gpu/native/continue/contFromLoop2.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+0.0 2.0 4.0 6.0 8.0 10.0 12.0 14.0 16.0 18.0 20.0


### PR DESCRIPTION
This PR adds two tests that I was planning to add in https://github.com/chapel-lang/chapel/pull/21620.

These tests lock the behavior discuss/reported in https://github.com/chapel-lang/chapel/issues/21924