### PR TITLE
Validate installed CUDA and ROCM version

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -57,6 +57,8 @@
 
 #ifdef HAVE_LLVM
 #include "llvm/Config/llvm-config.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/TargetSelect.h"
 #endif
 
 
@@ -1330,6 +1332,15 @@ static void printStuff(const char* argv0) {
 
 #ifdef HAVE_LLVM
     fprintf(stdout, "  built with LLVM version %s\n", LLVM_VERSION_STRING);
+    llvm::InitializeAllTargets();
+    std::string availableTargets;
+    bool first = true;
+    for (auto target : llvm::TargetRegistry::targets()) {
+      if(!first) { availableTargets += ", "; }
+      first = false;
+      availableTargets += target.getName();
+    }
+    fprintf(stdout, "  available LLVM targets: %s\n", availableTargets.c_str());
 #endif
 
     fPrintCopyright  = true;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -57,7 +57,11 @@
 
 #ifdef HAVE_LLVM
 #include "llvm/Config/llvm-config.h"
+#if HAVE_LLVM_VER >= 140
 #include "llvm/MC/TargetRegistry.h"
+#else
+#include "llvm/Support/TargetRegistry.h"
+#endif
 #include "llvm/Support/TargetSelect.h"
 #endif
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -27,15 +27,15 @@ GPU_TYPES = {
 
 def _reportMissingGpuReq(msg, allowExempt=True, suggestNone=True):
     if suggestNone:
-        msg += " You can use the 'none' GPU layer by setting "
-        msg += "'CHPL_GPU_CODEGEN=none'."
+        msg += " To avoid this issue, you can have GPU code run on the CPU "
+        msg += "by setting 'CHPL_GPU_CODEGEN=none'."
 
     if allowExempt and os.environ.get('CHPLENV_GPU_REQ_ERRS_AS_WARNINGS'):
         warning(msg)
         return
 
     if allowExempt:
-        msg += " You can turn this error into a warning by setting "
+        msg += " To turn this error into a warning set "
         msg += "CHPLENV_GPU_REQ_ERRS_AS_WARNINGS."
     error(msg)
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -1,9 +1,16 @@
 import utils
 import os
 import glob
+import json
 import chpl_locale_model
 import chpl_llvm
-from utils import error, memoize, run_command, which
+from utils import error, memoize, run_command, which, is_ver_in_range
+
+def _validate_cuda_version():
+    return _validate_cuda_version_impl()
+
+def _validate_rocm_version():
+    return _validate_rocm_version_impl()
 
 # Format:
 #   SDK path environment variable
@@ -12,9 +19,26 @@ from utils import error, memoize, run_command, which
 #   Default GPU architecure for the vendor
 #   LLVM target
 GPU_TYPES = {
-    "cuda": ("CHPL_CUDA_PATH", "nvcc",  2,"sm_60",  "NVPTX"),
-    "rocm": ("CHPL_ROCM_PATH", "hipcc", 3,"gfx906", "AMDGPU")
+    "cuda": ("CHPL_CUDA_PATH", "nvcc",  2,"sm_60",  "NVPTX",
+             _validate_cuda_version),
+    "rocm": ("CHPL_ROCM_PATH", "hipcc", 3,"gfx906", "AMDGPU",
+             _validate_rocm_version)
 }
+
+def _reportMissingGpuReq(msg, allowExempt=True, suggestNone=True):
+    if suggestNone:
+        msg += " You can use the 'none' GPU layer by setting "
+        msg += "'CHPL_GPU_CODEGEN=none'."
+
+    if allowExempt and os.environ.get('CHPLENV_GPU_REQ_ERRS_AS_WARNINGS'):
+        warning(msg)
+        return
+
+    if allowExempt:
+        msg += " You can turn this error into a warning by setting "
+        msg += "CHPLENV_GPU_REQ_ERRS_AS_WARNINGS."
+    error(msg)
+
 
 def determineGpuType():
     typesFound = [gpuType for gpuType in GPU_TYPES.keys() if which(GPU_TYPES[gpuType][1])]
@@ -54,7 +78,7 @@ def get_arch():
         return arch
 
     # Return vendor-specific default architecture
-    _, _, _, gpu_default_arch, _ = GPU_TYPES[gpu_type]
+    _, _, _, gpu_default_arch, _, _ = GPU_TYPES[gpu_type]
     return gpu_default_arch
 
 @memoize
@@ -66,7 +90,7 @@ def get_sdk_path(for_gpu):
         return ''
 
     # Check vendor-specific environment variable for SDK path
-    gpu_variable, gpu_program, gpu_bin_depth, _, _ = GPU_TYPES[for_gpu]
+    gpu_variable, gpu_program, gpu_bin_depth, _, _, _ = GPU_TYPES[for_gpu]
     chpl_sdk_path = os.environ.get(gpu_variable)
     if chpl_sdk_path:
         return chpl_sdk_path
@@ -80,7 +104,7 @@ def get_sdk_path(for_gpu):
         chpl_sdk_path = "/".join(real_path.split("/")[:-gpu_bin_depth])
         return chpl_sdk_path
     elif gpu_type == for_gpu:
-        error("Can't find {}".format(get()))
+        _reportMissingGpuReq("Can't find {} toolkit.".format(get()))
     else:
         return ''
 
@@ -106,7 +130,7 @@ def get_cuda_libdevice_path():
         # to be sure here.
         libdevices = glob.glob(chpl_cuda_path+"/nvvm/libdevice/libdevice*.bc")
         if len(libdevices) == 0:
-            error("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
+            _reportMissingGpuReq("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
                   "set such that CHPL_CUDA_PATH/nvmm/libdevice/libdevice*.bc exists.")
         else:
             return libdevices[0]
@@ -143,13 +167,67 @@ def validateLlvmBuiltForTgt(expectedTgt):
     return expectedTgt in targets
 
 
+def _validate_cuda_version_impl():
+    """Check that the installed CUDA version is >= MIN_REQ_VERSION and <
+       MAX_REQ_VERSION"""
+    MIN_REQ_VERSION = "7"
+    MAX_REQ_VERSION = "12"
+
+    chpl_cuda_path = get_sdk_path('cuda')
+    version_file = '%s/version.json' % chpl_cuda_path
+    if not os.path.exists(version_file):
+      _reportMissingGpuReq("Unable to find file %s." % version_file)
+      return False
+
+    f = open(version_file)
+    version_json = json.load(f)
+    f.close()
+    cudaVersion = version_json["cuda"]["version"]
+
+    if not is_ver_in_range(cudaVersion, MIN_REQ_VERSION, MAX_REQ_VERSION):
+      _reportMissingGpuReq(
+            "Chapel requires a CUDA version between %s and %s, "
+            "detected version %s on system." %
+            (MIN_REQ_VERSION, MAX_REQ_VERSION, cudaVersion))
+      return False
+
+    return True
+
+
+def _validate_rocm_version_impl():
+    """Check that the installed CUDA version is >= MIN_REQ_VERSION and <
+       MAX_REQ_VERSION"""
+    MIN_REQ_VERSION = "4"
+    MAX_REQ_VERSION = "6"
+
+    chpl_rocm_path = get_sdk_path('rocm')
+    version_file = '%s/.info/version-hiprt' % chpl_rocm_path
+    if not os.path.exists(version_file):
+      _reportMissingGpuReq("Unable to find file %s.")
+      return False
+
+    rocmVersion = open(version_file).read()
+
+    if not is_ver_in_range(rocmVersion, MIN_REQ_VERSION, MAX_REQ_VERSION):
+        _reportMissingGpuReq(
+            "Chapel requires ROCm to be a version between %s and %s, "
+            "detected version %s on system." %
+            (MIN_REQ_VERSION, MAX_REQ_VERSION, rocmVersion))
+        return False
+
+    return True
+
 @memoize
 def validate(chplLocaleModel, chplComm):
     if chplLocaleModel != "gpu":
         return True
 
+    # Run function to validate that we have a satisfactory version of our SDK
+    # (e.g. cuda or rocm)
+    GPU_TYPES[get()][5]()
+
     llvmTgt = GPU_TYPES[get()][4]
     if not validateLlvmBuiltForTgt(llvmTgt):
-        error("LLVM not built for %s, consider setting CHPL_LLVM to 'bundled'" % llvmTgt)
+        _reportMissingGpuReq("LLVM not built for %s, consider setting CHPL_LLVM to 'bundled'." % llvmTgt, allowExempt=False)
 
     return True

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -46,6 +46,7 @@ from collections import namedtuple
 from functools import partial
 import optparse
 import os
+import unittest
 from sys import stdout, path
 
 from chplenv import *
@@ -482,6 +483,9 @@ def parse_args():
     parser.add_option('--cmake',  action='store_const', dest='format', const='cmake')
     parser.add_option('--path',   action='store_const', dest='format', const='path')
 
+    #[hidden]
+    parser.add_option('--unit-tests', action='store_true', dest='do_unit_tests')
+
     # Hijack the help message to use the module docstring
     # optparse is not robust enough to support help msg sections for args.
     parser.print_help = lambda: stdout.write(__doc__)
@@ -491,6 +495,16 @@ def parse_args():
 
 def main():
     (options, args) = parse_args()
+
+    # If passed hidden --unit-tests flag, perform all PyUnit tests that can we
+    # can find and exit.
+    if options.do_unit_tests:
+      this_dir = os.path.realpath(os.path.dirname(__file__))
+      test_loader = unittest.TestLoader()
+      test_suite = test_loader.discover(this_dir, pattern="*.py")
+      test_runner = unittest.TextTestRunner()
+      test_runner.run(test_suite)
+      exit(1)
 
     # Handle --all flag
     if options.all:

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+import unittest
 
 try:
     # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12
@@ -107,3 +108,78 @@ def run_live_command(command):
 
     if returncode != 0:
         error("command failed: {0}".format(command), CommandError)
+
+
+def _split_ver_str(ver_str):
+    """Split a version string into an array of integers"""
+
+    # Semantic versioning strings can have prelease information
+    # after a hypen and/or build metadata after a plus. For
+    # the purpose of our versioning checks we strip these
+    ver_str = ver_str.rsplit('-',1)[0]
+    ver_str = ver_str.rsplit('+',1)[0]
+
+    return [int(x) for x in ver_str.split('.')]
+
+
+def is_ver_in_range(versionStr, minimumStr, maximumStr):
+    """Assume that version, minimum, and maximum are version strings consisting
+    of integers separated by spaces. Ensure that version is withint the
+    (inclusive) bounds: [minimumStr, maximumStr]."""
+
+    version = _split_ver_str(versionStr)
+    minimum = _split_ver_str(minimumStr)
+    maximum = _split_ver_str(maximumStr)
+
+    # Pad version, minimum, and maximum with zeros so they're the same length
+    max_len = max(len(version), len(minimum), len(maximum))
+    version = version + [0] * (max_len - len(version))
+    minimum = minimum + [0] * (max_len - len(minimum))
+    maximum = maximum + [0] * (max_len - len(maximum))
+
+    for i in range(max_len):
+        if version[i] < minimum[i]:
+            return False
+        elif version[i] > minimum[i]:
+            break
+
+    for i in range(max_len):
+        if version[i] < maximum[i]:
+            return True
+        elif version[i] > maximum[i]:
+            return False
+
+    return False
+
+
+class _UtilsTests(unittest.TestCase):
+    def test_is_ver_in_range(self):
+        # Various tests for versions in range: [2, 4)
+        for min_ver in ["2", "2.0", "2.0.0"]:
+          for max_ver in ["4", "4.0", "4.0.0"]:
+            # Versions too low
+            for ver in ["0", "0.0", "1", "1.0", "1.0-alpha"]:
+                self.assertFalse(is_ver_in_range(ver, min_ver, max_ver))
+
+            # Versions in bound
+            for ver in ["2", "2.0", "2.5", "3", "3-alpha", "3.1", "3.1.1", "3.9", "3.9.9.9.9"]:
+              self.assertTrue(is_ver_in_range(ver, min_ver, max_ver))
+
+            # Versions too high
+            for ver in ["4", "4.0", "4.1", "4.0.1", "5", "5-alpha"]:
+              self.assertFalse(is_ver_in_range(ver, min_ver, max_ver))
+
+        # Various tests for versions in range: [2.5, 4.5)
+        for min_ver in ["2.5", "2.5.0"]:
+          for max_ver in ["4.5", "4.5.0"]:
+            # Versions too low
+            for ver in ["2", "2.4", "2.4.0", "2.4.0.0", "2.4.9.9.9.9"]:
+              self.assertFalse(is_ver_in_range(ver, min_ver, max_ver))
+
+            # Versions in bound
+            for ver in ["2.5", "2.5.0", "2.6", "4.4", "4.4.0", "4.4.9"]:
+              self.assertTrue(is_ver_in_range(ver, min_ver, max_ver))
+
+            # Versions too high
+            for ver in ["4.5", "4.5.0", "4.5.9", "4.6", "5", "5.0"]:
+              self.assertFalse(is_ver_in_range(ver, min_ver, max_ver))

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -124,8 +124,8 @@ def _split_ver_str(ver_str):
 
 def is_ver_in_range(versionStr, minimumStr, maximumStr):
     """Assume that version, minimum, and maximum are version strings consisting
-    of integers separated by spaces. Ensure that version is withint the
-    (inclusive) bounds: [minimumStr, maximumStr]."""
+    of integers separated by periods. Ensure that version is within the
+    bounds: [minimumStr, maximumStr); non upper-bound is non inclusive."""
 
     version = _split_ver_str(versionStr)
     minimum = _split_ver_str(minimumStr)


### PR DESCRIPTION
This PR also adds a check for the requirement that when configured to target NVIDIA GPUs we have an installed version of the CUDA API >= 11.0 and < 12 and when configured to target AMD we have an installed version of the HIP API >= 4 and < 6.

In https://github.com/chapel-lang/chapel/issues/22087 we had discussions about whether this and a few associated requirements should be done as part of the build for the compiler and/or runtime but ultimately decided to have it as part of the compiler build on the basis that:

- Although some of these requirements are not needed of `chpl` does not get to the codegen some are needed at build time for `chpl`.
- If the user doesn't care about getting to the codegen pass an easy workaround is to use the new 'none' GPU layer. I add this as a suggestion in the error messages we produce to inform users of this.
- If the user does want to try using an unofficially supported version of the CUDA toolkit (for example) I've added a check for an environment variable that can be used to turn all these errors into warnings (`CHPLENV_GPU_REQ_ERRS_AS_WARNINGS`).

In that issue @bradcray also mentioned that after the LLVM backend was added to Chapel, we have had `chpl` report what version of LLVM is being using invoking `chpl --version`.  In that sense, it also seems relevant to include what targets LLVM was built to support (e.g. NVPTX, AMDGPU, etc.) and so I now have that information also be displayed when we pass `--version`.

Here's example of what this might look like:

```
chpl version 1.31.0 pre-release (844b2c7ff7)
  built with LLVM version 14.0.6
  available LLVM targets: amdgcn, r600, nvptx64, nvptx, x86-64, x86
Copyright 2020-2023 Hewlett Packard Enterprise Development LP
Copyright 2004-2019 Cray Inc.
(See LICENSE file for more details)
``` 

Here are how some error messages appear now ---

If we can't find nvcc:
```
Can't find cuda toolkit. You can use the 'none' GPU layer by setting 'CHPL_GPU_CODEGEN=none'. You can turn this error into a warning by setting CHPLENV_GPU_REQ_ERRS_AS_WARNINGS.
```

If you have nvcc installed but it's at the wrong version:
```
Chapel requires a CUDA version between 7 and 12, detected version 13.0.0 on system. You can use the 'none' GPU layer by setting 'CHPL_GPU_CODEGEN=none'. You can turn this error into a warning by setting CHPLENV_GPU_REQ_ERRS_AS_WARNINGS.
```

If we can't find libdevice:

```
Can't find libdevice. Please make sure your CHPL_CUDA_PATH is set such that CHPL_CUDA_PATH/nvmm/libdevice/libdevice*.bc exists. You can use the 'none' GPU layer by setting 'CHPL_GPU_CODEGEN=none'. You can turn this error into a warning by setting CHPLENV_GPU_REQ_ERRS_AS_WARNINGS.
```

If LLVM was not built for NVPTX target:
```
LLVM not built for NVPTX, consider setting CHPL_LLVM to 'bundled'. You can use the 'none' GPU layer by setting 'CHPL_GPU_CODEGEN=none'.
```

There's also some other things to note in this PR:

- While developing, I wanted to test my version checking code so I wrote a pyunit test for it. I could throw this code out but why should I? Instead I added a hidden `--unit-tests` flags that can be passed to printchplenv that will run any pyunit tests found within the chplenv scripts. This sets up the framework for future unit testing if we want it.
- I'm probably (poorly) reinventing the wheel with my version checking code. Semantic versioning libraries exist for Python but aren't packaged with Python by default and do we want to add a dependency (beyond Python itself) to printchplenv? Do we have any precedent of doing that?