### PR TITLE
Deprecate including lgamma and tgamma by default

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -902,17 +902,37 @@ module AutoMath {
     return ldexpf(x, n);
   }
 
-  /* Returns the natural logarithm of the absolute value
-     of the gamma function of the argument `x`.
-  */
-  pragma "fn synchronization free"
-  pragma "codegen for CPU and GPU"
-  extern proc lgamma(x: real(64)): real(64);
+  // When removing this deprecated function, be sure to remove chpl_lgamma and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @deprecated(notes="In an upcoming release 'lgamma' will no longer be included by default, please 'use' or 'import' the :mod:`Math` module to call it")
+  inline proc lgamma(x: real(64)): real(64) {
+    return chpl_lgamma(x);
+  }
 
-  /* Returns the natural logarithm of the absolute value
-     of the gamma function of the argument `x`.
-  */
+  @chpldoc.nodoc
+  inline proc chpl_lgamma(x: real(64)): real(64) {
+    // Note: this extern proc was originally free standing.  It might be
+    // reasonable to make it that way again when the deprecated version is
+    // removed
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc lgamma(x: real(64)): real(64);
+    return lgamma(x);
+  }
+
+  // When removing this deprecated function, be sure to remove chpl_lgamma and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @deprecated(notes="In an upcoming release 'lgamma' will no longer be included by default, please 'use' or 'import' the :mod:`Math` module to call it")
   inline proc lgamma(x : real(32)): real(32) {
+    return chpl_lgamma(x);
+  }
+
+  @chpldoc.nodoc
+  inline proc chpl_lgamma(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc lgammaf(x: real(32)): real(32);
@@ -1481,15 +1501,37 @@ module AutoMath {
     return ctanh(z);
   }
 
+  // When removing this deprecated function, be sure to remove chpl_tgamma and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @deprecated(notes="In an upcoming release 'tgamma' will no longer be included by default, please 'use' or 'import' the :mod:`Math` module to call it")
+  inline proc tgamma(x: real(64)): real(64) {
+    return chpl_tgamma(x);
+  }
 
+  @chpldoc.nodoc
+  inline proc chpl_tgamma(x: real(64)): real(64) {
+    // Note: this extern proc was originally free standing.  It might be
+    // reasonable to make it that way again when the deprecated version is
+    // removed
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc tgamma(x: real(64)): real(64);
+    return tgamma(x);
+  }
 
-  /* Returns the absolute value of the gamma function of the argument `x`. */
-  pragma "fn synchronization free"
-  pragma "codegen for CPU and GPU"
-  extern proc tgamma(x: real(64)): real(64);
-
-  /* Returns the absolute value of the gamma function of the argument `x`. */
+  // When removing this deprecated function, be sure to remove chpl_tgamma and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
+  pragma "last resort"
+  @deprecated(notes="In an upcoming release 'tgamma' will no longer be included by default, please 'use' or 'import' the :mod:`Math` module to call it")
   inline proc tgamma(x : real(32)): real(32) {
+    return chpl_tgamma(x);
+  }
+
+  @chpldoc.nodoc
+  inline proc chpl_tgamma(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc tgammaf(x: real(32)): real(32);

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -112,6 +112,19 @@ module Math {
     return chpl_ldexp(x, n);
   }
 
+  /* Returns the natural logarithm of the absolute value
+     of the gamma function of the argument `x`.
+  */
+  inline proc lgamma(x: real(64)): real(64) {
+    return chpl_lgamma(x);
+  }
+
+  /* Returns the natural logarithm of the absolute value
+     of the gamma function of the argument `x`.
+  */
+  inline proc lgamma(x : real(32)): real(32) {
+    return chpl_lgamma(x);
+  }
 
   /* Returns the natural logarithm of `x` + 1.
 
@@ -149,6 +162,16 @@ module Math {
   */
   inline proc logBasePow2(val: uint(?w), baseLog2) {
     return chpl_logBasePow2(val, baseLog2);
+  }
+
+  /* Returns the absolute value of the gamma function of the argument `x`. */
+  inline proc tgamma(x: real(64)): real(64) {
+    return chpl_tgamma(x);
+  }
+
+  /* Returns the absolute value of the gamma function of the argument `x`. */
+  inline proc tgamma(x : real(32)): real(32) {
+    return chpl_tgamma(x);
   }
 
   /* Returns the Bessel function of the first kind of order `0` of `x`. */

--- a/test/deprecated/Math/gammas.chpl
+++ b/test/deprecated/Math/gammas.chpl
@@ -1,0 +1,12 @@
+var a: real(64) = 7.0;
+var b: real(32) = 7.0;
+
+var checkL64 = lgamma(a);
+var checkL32 = lgamma(b);
+writeln(6.0 < checkL64 && checkL64 < 7.0);
+writeln(6.0 < checkL32 && checkL32 < 7.0);
+
+var checkT64 = tgamma(a);
+var checkT32 = tgamma(b);
+writeln(719.0 < checkT64 && checkT64 < 721.0);
+writeln(719.0 < checkT32 && checkT32 < 721.0);

--- a/test/deprecated/Math/gammas.good
+++ b/test/deprecated/Math/gammas.good
@@ -1,0 +1,8 @@
+gammas.chpl:4: warning: In an upcoming release 'lgamma' will no longer be included by default, please 'use' or 'import' the Math module to call it
+gammas.chpl:5: warning: In an upcoming release 'lgamma' will no longer be included by default, please 'use' or 'import' the Math module to call it
+gammas.chpl:9: warning: In an upcoming release 'tgamma' will no longer be included by default, please 'use' or 'import' the Math module to call it
+gammas.chpl:10: warning: In an upcoming release 'tgamma' will no longer be included by default, please 'use' or 'import' the Math module to call it
+true
+true
+true
+true

--- a/test/library/standard/Math/bradc/math32bits-more.chpl
+++ b/test/library/standard/Math/bradc/math32bits-more.chpl
@@ -1,3 +1,5 @@
+use Math;
+
 var x = 0.333: real(32);
 
 var o = exp2(x);

--- a/test/library/standard/Math/lgamma.chpl
+++ b/test/library/standard/Math/lgamma.chpl
@@ -1,3 +1,5 @@
+use Math;
+
 var a: real = 1;
 var b: real = 5;
 var c: real = 10;


### PR DESCRIPTION
In an earlier discussion of which Math symbols should be included
in all programs by default, we decided to stop including `lgamma`
and `tgamma`.  Move them to the Math module.

<details>

The commit for this ends up looking a little odd so that we don't
accidentally build the Math module by default as well - make an
undocumented version that Math and the deprecated version
can call, so that Math depends on AutoMath and the two versions
stay in sync until the deprecated version is removed. This strategy
was previously followed for other symbols in the Math module. 

</details>

Adds a use of the Math module to two tests to enable them to
continue to pass without deprecation warnings.

Adds a new test to lock in the deprecation warnings.

Passed a full paratest with futures