### PR TITLE
Rename Time factory functions

### DIFF
--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -348,16 +348,26 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return unixEpoch.getDate() + td;
   }
 
-  /* The date that is `timestamp` seconds from the epoch */
+  @deprecated(notes="'date.fromTimestamp' is deprecated, please use 'date.createFromTimestamp' instead")
   proc type date.fromTimestamp(timestamp) {
+    return date.createFromTimestamp(timestamp);
+  }
+
+  /* The date that is `timestamp` seconds from the epoch */
+  proc type date.createFromTimestamp(timestamp) {
     const sec = timestamp: int;
     const us = ((timestamp-sec) * 1000000 + 0.5): int;
     const td = new timeDelta(seconds=sec, microseconds=us);
     return unixEpoch.getDate() + td;
   }
 
-  /* The `date` that is `ord` days from 1-1-0001 */
+  @deprecated(notes="'date.fromOrdinal' is deprecated, please use 'date.createFromOrdinal' instead")
   proc type date.fromOrdinal(ord) {
+    return date.createFromOrdinal(ord);
+  }
+
+  /* The `date` that is `ord` days from 1-1-0001 */
+  proc type date.createFromOrdinal(ord) {
     if ord < 0 || ord > 1+date.max.toOrdinal() then
       halt("ordinal (", ord, ") out of range");
     const (y,m,d) = ordToYmd(ord);
@@ -554,7 +564,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   /* Operators on date values */
   pragma "no doc"
   operator date.+(d: date, t: timeDelta): date {
-    return date.fromOrdinal(d.toOrdinal() + t.days);
+    return date.createFromOrdinal(d.toOrdinal() + t.days);
   }
 
   pragma "no doc"
@@ -564,7 +574,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   pragma "no doc"
   operator date.-(d: date, t: timeDelta): date {
-    return date.fromOrdinal(d.toOrdinal() - t.days);
+    return date.createFromOrdinal(d.toOrdinal() - t.days);
   }
 
   pragma "no doc"
@@ -1129,14 +1139,25 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return unixEpoch + td;
   }
 
-  /* The `dateTime` that is `timestamp` seconds from the epoch */
+  @deprecated(notes="'dateTime.fromTimestamp' is deprecated, please use 'dateTime.createFromTimestamp' instead")
   proc type dateTime.fromTimestamp(timestamp: real) {
-    return dateTime.fromTimestamp(timestamp, nil);
+    return dateTime.createFromTimestamp(timestamp, nil);
+  }
+
+  @deprecated(notes="'dateTime.fromTimestamp' is deprecated, please use 'dateTime.createFromTimestamp' instead")
+  proc type dateTime.fromTimestamp(timestamp: real,
+                                   in tz: shared Timezone?) {
+    return dateTime.createFromTimestamp(timestamp, tz);
+  }
+
+  /* The `dateTime` that is `timestamp` seconds from the epoch */
+  proc type dateTime.createFromTimestamp(timestamp: real) {
+    return dateTime.createFromTimestamp(timestamp, nil);
   }
 
   /* The `dateTime` that is `timestamp` seconds from the epoch */
   @unstable("tz is unstable; its type may change in the future")
-  proc type dateTime.fromTimestamp(timestamp: real,
+  proc type dateTime.createFromTimestamp(timestamp: real,
                                    in tz: shared Timezone?) {
     if tz.borrow() == nil {
       var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);
@@ -1146,19 +1167,29 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                           minute=lt.tm_min,     second=lt.tm_sec,
                           microsecond=t(1));
     } else {
-      var dt = dateTime.utcFromTimestamp(timestamp);
+      var dt = dateTime.createUtcFromTimestamp(timestamp);
       return (dt + tz!.utcOffset(dt)).replace(tz=tz);
     }
   }
 
-  /* The `dateTime` that is `timestamp` seconds from the epoch in UTC */
+  @deprecated(notes="'dateTime.utcFromTimestamp' is deprecated, please use 'dateTime.createUtcFromTimestamp' instead")
   proc type dateTime.utcFromTimestamp(timestamp) {
+    return dateTime.createUtcFromTimestamp(timestamp);
+  }
+
+  /* The `dateTime` that is `timestamp` seconds from the epoch in UTC */
+  proc type dateTime.createUtcFromTimestamp(timestamp) {
     return unixEpoch + new timeDelta(seconds=timestamp: int, microseconds=((timestamp-timestamp: int)*1000000): int);
   }
 
-  /* The `dateTime` that is `ordinal` days from 1-1-0001 */
+  @deprecated(notes="'dateTime.fromOrdinal' is deprecated, please use 'dateTime.createFromOrdinal' instead")
   proc type dateTime.fromOrdinal(ordinal) {
-    return dateTime.combine(date.fromOrdinal(ordinal), new time());
+    return dateTime.createFromOrdinal(ordinal);
+  }
+
+  /* The `dateTime` that is `ordinal` days from 1-1-0001 */
+  proc type dateTime.createFromOrdinal(ordinal) {
+    return dateTime.combine(date.createFromOrdinal(ordinal), new time());
   }
 
   /* Form a `dateTime` value from a given `date` and `time` */
@@ -1521,7 +1552,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     var adddays = td.days + newhour / 24;
     newhour %= 24;
 
-    return dateTime.combine(date.fromOrdinal(dt.getDate().toOrdinal()+adddays),
+    return dateTime.combine(date.createFromOrdinal(dt.getDate().toOrdinal()+adddays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tz=dt.timezone));
@@ -1562,7 +1593,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
       subDays += 1;
       newhour += 24;
     }
-    return dateTime.combine(date.fromOrdinal(dt.getDate().toOrdinal()-subDays),
+    return dateTime.combine(date.createFromOrdinal(dt.getDate().toOrdinal()-subDays),
                             new time(hour=newhour, minute=newmin,
                                      second=newsec, microsecond=newmicro,
                                      tz=dt.timezone));

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -368,9 +368,9 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* The `date` that is `ordinal` days from 1-1-0001 */
   proc type date.createFromOrdinal(ordinal: int) {
-    if ord < 0 || ord > 1+date.max.toOrdinal() then
-      halt("ordinal (", ord, ") out of range");
-    const (y,m,d) = ordToYmd(ord);
+    if ordinal < 0 || ordinal > 1+date.max.toOrdinal() then
+      halt("ordinal (", ordinal, ") out of range");
+    const (y,m,d) = ordToYmd(ordinal);
     return new date(y,m,d);
   }
 

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -354,7 +354,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* The date that is `timestamp` seconds from the epoch */
-  proc type date.createFromTimestamp(timestamp) {
+  proc type date.createFromTimestamp(timestamp: real) {
     const sec = timestamp: int;
     const us = ((timestamp-sec) * 1000000 + 0.5): int;
     const td = new timeDelta(seconds=sec, microseconds=us);
@@ -366,8 +366,8 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     return date.createFromOrdinal(ord);
   }
 
-  /* The `date` that is `ord` days from 1-1-0001 */
-  proc type date.createFromOrdinal(ord) {
+  /* The `date` that is `ordinal` days from 1-1-0001 */
+  proc type date.createFromOrdinal(ordinal: int) {
     if ord < 0 || ord > 1+date.max.toOrdinal() then
       halt("ordinal (", ord, ") out of range");
     const (y,m,d) = ordToYmd(ord);
@@ -1188,7 +1188,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* The `dateTime` that is `ordinal` days from 1-1-0001 */
-  proc type dateTime.createFromOrdinal(ordinal) {
+  proc type dateTime.createFromOrdinal(ordinal: int) {
     return dateTime.combine(date.createFromOrdinal(ordinal), new time());
   }
 

--- a/test/deprecated/timeFactoryFunctions.chpl
+++ b/test/deprecated/timeFactoryFunctions.chpl
@@ -1,0 +1,7 @@
+use Time;
+
+var d1 = date.fromTimestamp(100.99);
+var d2 = date.fromOrdinal(100);
+var dt1 = dateTime.fromTimestamp(100.99);
+var dt2 = dateTime.fromOrdinal(100);
+var utcDt = dateTime.utcFromTimestamp(100.99);

--- a/test/deprecated/timeFactoryFunctions.good
+++ b/test/deprecated/timeFactoryFunctions.good
@@ -1,0 +1,5 @@
+timeFactoryFunctions.chpl:3: warning: 'date.fromTimestamp' is deprecated, please use 'date.createFromTimestamp' instead
+timeFactoryFunctions.chpl:4: warning: 'date.fromOrdinal' is deprecated, please use 'date.createFromOrdinal' instead
+timeFactoryFunctions.chpl:5: warning: 'dateTime.fromTimestamp' is deprecated, please use 'dateTime.createFromTimestamp' instead
+timeFactoryFunctions.chpl:6: warning: 'dateTime.fromOrdinal' is deprecated, please use 'dateTime.createFromOrdinal' instead
+timeFactoryFunctions.chpl:7: warning: 'dateTime.utcFromTimestamp' is deprecated, please use 'dateTime.createUtcFromTimestamp' instead

--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -51,7 +51,7 @@ module CheckHttpSetOpt {
     curl_easy_getinfo(getCurlHandle(urlreader), CURLINFO_FILETIME,
 		      c_ptrTo(time));
 
-    writeln("Remote Time ", dateTime.utcFromTimestamp(time));
+    writeln("Remote Time ", dateTime.createUtcFromTimestamp(time));
 
     stderr.flush();
     stdout.flush();

--- a/test/library/standard/DateTime/fromTimestampComm.chpl
+++ b/test/library/standard/DateTime/fromTimestampComm.chpl
@@ -5,7 +5,7 @@ config const n = 100;
 startCommDiagnostics();
 on Locales[numLocales-1] {
   for i in 1..n {
-    date.fromTimestamp(i);
+    date.createFromTimestamp(i);
   }
 }
 stopCommDiagnostics();

--- a/test/library/standard/DateTime/testDate.chpl
+++ b/test/library/standard/DateTime/testDate.chpl
@@ -41,18 +41,18 @@ proc test_date_ordinal_conversions() {
                     (1945,11,12,710347)] {
     var d1 = new date(y, m, d);
     assert(n == d1.toOrdinal());
-    var fromord = date.fromOrdinal(n);
+    var fromord = date.createFromOrdinal(n);
     assert(d1 == fromord);
   }
 
   for year in MINYEAR..MAXYEAR by 7 {
     var d = new date(year, 1, 1);
     var n = d.toOrdinal();
-    var d2 = date.fromOrdinal(n);
+    var d2 = date.createFromOrdinal(n);
     assert(d == d2);
 
     if year > 1 {
-      d = date.fromOrdinal(n-1);
+      d = date.createFromOrdinal(n-1);
       d2 = new date(year-1, 12, 31);
       assert(d == d2);
       assert(d2.toOrdinal() == n-1);
@@ -69,7 +69,7 @@ proc test_date_ordinal_conversions() {
       for day in 1..md {
         var d = new date(year, month, day);
         assert(d.toOrdinal() == n);
-        assert(d == date.fromOrdinal(n));
+        assert(d == date.createFromOrdinal(n));
         n += 1;
       }
     }
@@ -79,21 +79,21 @@ proc test_date_ordinal_conversions() {
 proc test_date_extreme_ordinals() {
   var a = date.min;
   var aord = a.toOrdinal();
-  var b = date.fromOrdinal(aord);
+  var b = date.createFromOrdinal(aord);
   assert(a == b);
 
   b = a + new timeDelta(days=1);
   assert(b.toOrdinal() == aord + 1);
-  assert(b == date.fromOrdinal(aord+1));
+  assert(b == date.createFromOrdinal(aord+1));
 
   a = date.max;
   aord = a.toOrdinal();
-  b = date.fromOrdinal(aord);
+  b = date.createFromOrdinal(aord);
   assert(a == b);
 
   b = a - new timeDelta(days=1);
   assert(b.toOrdinal() == aord - 1);
-  assert(b == date.fromOrdinal(aord - 1));
+  assert(b == date.createFromOrdinal(aord - 1));
 }
 
 proc test_date_computations() {
@@ -133,7 +133,7 @@ proc test_date_fromtimestamp() {
   var delta = d1 - unixEpoch.getDate();
   var ts = delta.days * 60 * 60 * 24 + delta.seconds;
 
-  var d = date.fromTimestamp(ts);
+  var d = date.createFromTimestamp(ts);
   assert(d.year == year);
   assert(d.month == month);
   assert(d.day == day);
@@ -145,7 +145,7 @@ proc test_date_today() {
     tday = date.today();
     var delta = tday - unixEpoch.getDate();
     var ts = delta.days * 60 * 60 * 24 + delta.seconds;
-    tdayAgain = date.fromTimestamp(ts);
+    tdayAgain = date.createFromTimestamp(ts);
     if tday == tdayAgain then
       break;
   }

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -234,17 +234,17 @@ proc test_tzinfo_fromtimestamp() {
 
   var ts = getTimeOfDay()(1);
   // Ensure it doesn't require tz (i.e., that this doesn't blow up).
-  var base = dateTime.fromTimestamp(ts);
+  var base = dateTime.createFromTimestamp(ts);
   // Try with and without naming the keyword.
   var off42 = new shared FixedOffset(42, "42");
-  var another = dateTime.fromTimestamp(ts, off42);
-  var again = dateTime.fromTimestamp(ts, tz=off42);
+  var another = dateTime.createFromTimestamp(ts, off42);
+  var again = dateTime.createFromTimestamp(ts, tz=off42);
   assert(another.timezone == again.timezone);
   assert(another.utcOffset() == new timeDelta(minutes=42));
 
   // Try to make sure tz= actually does some conversion.
   var timestamp = 1000000000;
-  var utcdateTime = dateTime.utcFromTimestamp(timestamp);
+  var utcdateTime = dateTime.createUtcFromTimestamp(timestamp);
   // In POSIX (epoch 1970), that's 2001-09-09 01:46:40 UTC, give or take.
   // But on some flavor of Mac, it's nowhere near that.  So we can't have
   // any idea here what time that actually is, we can only test that
@@ -252,7 +252,7 @@ proc test_tzinfo_fromtimestamp() {
   var utcoffset = new timeDelta(hours=-15, minutes=39); // arbitrary, but not zero
   var tz = new shared FixedOffset(utcoffset, "tz", new timeDelta());
   var expected = utcdateTime + utcoffset;
-  var got = dateTime.fromTimestamp(timestamp, tz);
+  var got = dateTime.createFromTimestamp(timestamp, tz);
   assert(expected == got.replace(tz=nil));
 }
 


### PR DESCRIPTION
Rename factory functions in the Time module to start with 'create'. Add
deprecated versions of the old names and update other uses of them in the
Time module. Add a test/deprecated/ test for them.

Update a few tests to use the new names.