### PR TITLE
Don't correctness-test foreach based revcomp variant as it times out

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.chpl
@@ -251,6 +251,9 @@ proc findSeqStart(buff, inds, ref ltLoc) {
     return ltLoc != max(int);
     
   } else if searchAlg == Foreach {
+    // this requires reduce intents. The solution here is potentially race-y.
+    // Making it use a `for` instead of `foreach` results lin what looks like an
+    // infinite loop. This mode is commented out in the compopts
     foreach i in inds {
       if buff[i] == '>'.toByte() {
         ltLoc = i;

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.chpl
@@ -252,7 +252,7 @@ proc findSeqStart(buff, inds, ref ltLoc) {
     
   } else if searchAlg == Foreach {
     // this requires reduce intents. The solution here is potentially race-y.
-    // Making it use a `for` instead of `foreach` results lin what looks like an
+    // Making it use a `for` instead of `foreach` results in what looks like an
     // infinite loop. This mode is commented out in the compopts
     foreach i in inds {
       if buff[i] == '>'.toByte() {

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.compopts
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.compopts
@@ -6,7 +6,7 @@
 -sshiftAlg=MemMove
 -ssearchAlg=Forall
 -ssearchAlg=OptForall
--ssearchAlg=Foreach
+#-ssearchAlg=Foreach
 -ssearchAlg=For
 -ssearchAlg=MemChr
 -ssearchAlg=Find -suseNewArrayFind


### PR DESCRIPTION
My changes to this test in https://github.com/chapel-lang/chapel/pull/22167 resulted time outs. The correct implementation requires foreach intents (https://github.com/chapel-lang/chapel/issues/18500). Strangely enough, changing `foreach` to `for` should work but results in what looks to be an infinite loop.

For now, add a comment in the source, and comment out the relevant compopt.

Test passes locally with this PR.