### PR TITLE
Add warmup loop to measureGpuCycles.chpl test

### DIFF
--- a/test/gpu/native/measureGpuCycles.chpl
+++ b/test/gpu/native/measureGpuCycles.chpl
@@ -10,6 +10,13 @@ on here.gpus[0] {
   foreach i in 0..0 {
     var dblFactor = 1;
     var start, stop : uint;
+
+    // Warm up loop to pull "A" onto the GPU if using
+    // unified memory
+    for k in 0..1024 * dblFactor {
+      A[k % 1024] = A[k % 1024] * k;
+    }
+
     for j in 0..<howManyResults {
       start = gpuClock();
       for k in 0..1024 * dblFactor {


### PR DESCRIPTION
For some reason we're seeing this test now fails our nightly tests for AMD.

The test works by running three successively longer loops, measures each, and errors out if our GPU clocks don’t say each loop takes longer than the last. These loops read/write from an array. I think what’s happening is with unified memory the first loop ends up taking a long time because it has to “pull” that data from the host.

So it makes sense this would fail. It's not obvious to me why it's not failing for NVIDIA and why this would regress.

Nevertheless, it seems like the right thing to do is update the test to have a warmup loop to ensure the array is on the device before we do any timing runs.

