### PR TITLE
Make dyno scope resolver work better without production

### DIFF
--- a/compiler/AST/CatchStmt.cpp
+++ b/compiler/AST/CatchStmt.cpp
@@ -273,7 +273,7 @@ void CatchStmt::cleanup()
 
   if (catchall) {
     Expr* nonNilC = new CallExpr(PRIM_TO_NON_NILABLE_CLASS, casted);
-    Expr* toOwned = new CallExpr(PRIM_NEW, new CallExpr("_owned", nonNilC));
+    Expr* toOwned = new CallExpr(PRIM_NEW, new CallExpr(new SymExpr(dtOwned->symbol), nonNilC));
 
     errorDef->init = toOwned;
 
@@ -289,7 +289,7 @@ void CatchStmt::cleanup()
     castedDef->insertAfter(cond);
 
     Expr* nonNilC = new CallExpr(PRIM_TO_NON_NILABLE_CLASS, casted);
-    Expr* toOwned = new CallExpr(PRIM_NEW, new CallExpr("_owned", nonNilC));
+    Expr* toOwned = new CallExpr(PRIM_NEW, new CallExpr(new SymExpr(dtOwned->symbol), nonNilC));
 
     errorDef->init = toOwned;
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -434,7 +434,7 @@ struct Converter {
           auto nameExpr = new_CStringSymbol(node->name().c_str());
           CallExpr* ret = new CallExpr(".", thisExpr, nameExpr);
           return ret;
-        } else if (rr->isPrimitive()) {
+        } else if (rr->isBuiltin()) {
           auto scope = ResolveScope::getScopeFor(theProgram->block);
           if (!scope) scope = ResolveScope::getRootModule();
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -272,7 +272,8 @@ static void processGenericFields() {
 // to handle chpl__Program with little or no special casing.
 
 static void addToSymbolTable() {
-  rootScope = ResolveScope::getRootModule();
+  rootScope = ResolveScope::getScopeFor(theProgram->block);
+  if (!rootScope) rootScope = ResolveScope::getRootModule();
 
   // Extend the rootScope with every top-level definition
   for_alist(stmt, theProgram->block->body) {

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1181,6 +1181,8 @@ class ResolvedExpression {
   // For simple (non-function Identifier) cases,
   // the ID of a NamedDecl it refers to
   ID toId_;
+  // Is this a reference to a compiler-created primitive?
+  bool isPrimitive_ = false;
 
   // For a function call, what is the most specific candidate,
   // or when using return intent overloading, what are the most specific
@@ -1210,6 +1212,9 @@ class ResolvedExpression {
    * refers to */
   ID toId() const { return toId_; }
 
+  /** check whether this resolution result refers to a compiler primitive like `bool`. */
+  bool isPrimitive() const { return isPrimitive_; }
+
   /** For a function call, what is the most specific candidate, or when using
    * return intent overloading, what are the most specific candidates? The
    * choice between these needs to happen later than the main function
@@ -1226,6 +1231,9 @@ class ResolvedExpression {
   const ResolvedParamLoop* paramLoop() const {
     return paramLoop_;
   }
+
+  /** set the isPrimitive flag */
+  void setIsPrimitive(bool isPrimitive) { isPrimitive_ = isPrimitive; }
 
   /** set the toId */
   void setToId(ID toId) { toId_ = toId; }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1261,6 +1261,7 @@ class ResolvedExpression {
   bool operator==(const ResolvedExpression& other) const {
     return type_ == other.type_ &&
            toId_ == other.toId_ &&
+           isPrimitive_ == other.isPrimitive_ &&
            mostSpecific_ == other.mostSpecific_ &&
            poiScope_ == other.poiScope_ &&
            associatedActions_ == other.associatedActions_ &&
@@ -1272,6 +1273,7 @@ class ResolvedExpression {
   void swap(ResolvedExpression& other) {
     type_.swap(other.type_);
     toId_.swap(other.toId_);
+    std::swap(isPrimitive_, other.isPrimitive_);
     mostSpecific_.swap(other.mostSpecific_);
     std::swap(poiScope_, other.poiScope_);
     std::swap(associatedActions_, other.associatedActions_);

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1182,7 +1182,7 @@ class ResolvedExpression {
   // the ID of a NamedDecl it refers to
   ID toId_;
   // Is this a reference to a compiler-created primitive?
-  bool isPrimitive_ = false;
+  bool isBuiltin_ = false;
 
   // For a function call, what is the most specific candidate,
   // or when using return intent overloading, what are the most specific
@@ -1212,8 +1212,8 @@ class ResolvedExpression {
    * refers to */
   ID toId() const { return toId_; }
 
-  /** check whether this resolution result refers to a compiler primitive like `bool`. */
-  bool isPrimitive() const { return isPrimitive_; }
+  /** check whether this resolution result refers to a compiler builtin like `bool`. */
+  bool isBuiltin() const { return isBuiltin_; }
 
   /** For a function call, what is the most specific candidate, or when using
    * return intent overloading, what are the most specific candidates? The
@@ -1233,7 +1233,7 @@ class ResolvedExpression {
   }
 
   /** set the isPrimitive flag */
-  void setIsPrimitive(bool isPrimitive) { isPrimitive_ = isPrimitive; }
+  void setIsPrimitive(bool isPrimitive) { isBuiltin_ = isPrimitive; }
 
   /** set the toId */
   void setToId(ID toId) { toId_ = toId; }
@@ -1261,7 +1261,7 @@ class ResolvedExpression {
   bool operator==(const ResolvedExpression& other) const {
     return type_ == other.type_ &&
            toId_ == other.toId_ &&
-           isPrimitive_ == other.isPrimitive_ &&
+           isBuiltin_ == other.isBuiltin_ &&
            mostSpecific_ == other.mostSpecific_ &&
            poiScope_ == other.poiScope_ &&
            associatedActions_ == other.associatedActions_ &&
@@ -1273,7 +1273,7 @@ class ResolvedExpression {
   void swap(ResolvedExpression& other) {
     type_.swap(other.type_);
     toId_.swap(other.toId_);
-    std::swap(isPrimitive_, other.isPrimitive_);
+    std::swap(isBuiltin_, other.isBuiltin_);
     mostSpecific_.swap(other.mostSpecific_);
     std::swap(poiScope_, other.poiScope_);
     std::swap(associatedActions_, other.associatedActions_);

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -57,6 +57,11 @@ class IdAndFlags {
     /** A non-function or a function without parentheses */
     NOT_PARENFUL_FUNCTION = 32,
     // note: if adding something here, also update flagsToString
+    /** A method declaration */
+    METHOD = 64,
+    /** Something other than a method declaration */
+    NOT_METHOD = 128,
+    // note: if adding something here, also update flagsToString
   };
   /**
     A bit-set of the flags defined in the above enum.
@@ -141,7 +146,7 @@ class IdAndFlags {
 
  public:
   IdAndFlags(ID id, uast::Decl::Visibility vis,
-             bool isMethodOrField, bool isParenfulFunction)
+             bool isMethodOrField, bool isMethod, bool isParenfulFunction)
     : id_(std::move(id)) {
     // setup the flags
     Flags flags = 0;
@@ -159,6 +164,13 @@ class IdAndFlags {
       flags |= METHOD_FIELD;
     } else {
       flags |= NOT_METHOD_FIELD;
+      flags |= NOT_METHOD;
+    }
+    if (isMethod) {
+      flags |= METHOD;
+      flags |= METHOD_FIELD;
+    } else {
+      flags |= NOT_METHOD;
     }
     if (isParenfulFunction) {
       flags |= PARENFUL_FUNCTION;
@@ -193,6 +205,9 @@ class IdAndFlags {
   }
   bool isMethodOrField() const {
     return (flags_ & METHOD_FIELD) != 0;
+  }
+  bool isMethod() const {
+    return (flags_ & METHOD) != 0;
   }
   bool isParenfulFunction() const {
     return (flags_ & PARENFUL_FUNCTION) != 0;
@@ -234,15 +249,15 @@ class OwnedIdsWithName {
  public:
   /** Construct an OwnedIdsWithName containing one ID. */
   OwnedIdsWithName(ID id, uast::Decl::Visibility vis,
-                   bool isMethodOrField, bool isParenfulFunction)
-    : idv_(IdAndFlags(std::move(id), vis, isMethodOrField, isParenfulFunction)),
+                   bool isMethodOrField, bool isMethod, bool isParenfulFunction)
+    : idv_(IdAndFlags(std::move(id), vis, isMethodOrField, isMethod, isParenfulFunction)),
       flagsAnd_(idv_.flags_), flagsOr_(idv_.flags_),
       moreIdvs_(nullptr)
   { }
 
   /** Append an ID to an OwnedIdsWithName. */
   void appendIdAndFlags(ID id, uast::Decl::Visibility vis,
-                        bool isMethodOrField, bool isParenfulFunction) {
+                        bool isMethodOrField, bool isMethod, bool isParenfulFunction) {
     if (moreIdvs_.get() == nullptr) {
       // create the vector and add the single existing id to it
       moreIdvs_ = toOwned(new std::vector<IdAndFlags>());
@@ -251,7 +266,7 @@ class OwnedIdsWithName {
       // from idv_.
     }
     auto idv = IdAndFlags(std::move(id), vis,
-                          isMethodOrField, isParenfulFunction);
+                          isMethodOrField, isMethod, isParenfulFunction);
     // add the id passed
     moreIdvs_->push_back(std::move(idv));
     // update the flags
@@ -435,10 +450,10 @@ class BorrowedIdsWithName {
 
   static llvm::Optional<BorrowedIdsWithName>
   createWithSingleId(ID id, uast::Decl::Visibility vis,
-                     bool isMethodOrField, bool isParenfulFunction,
+                     bool isMethodOrField, bool isMethod, bool isParenfulFunction,
                      IdAndFlags::Flags filterFlags,
                      IdAndFlags::FlagSet excludeFlagSet) {
-    auto idAndVis = IdAndFlags(id, vis, isMethodOrField, isParenfulFunction);
+    auto idAndVis = IdAndFlags(id, vis, isMethodOrField, isMethod, isParenfulFunction);
     if (isIdVisible(idAndVis, filterFlags, excludeFlagSet)) {
       return BorrowedIdsWithName(std::move(idAndVis),
                                  filterFlags, std::move(excludeFlagSet));
@@ -450,11 +465,12 @@ class BorrowedIdsWithName {
   createWithToplevelModuleId(ID id) {
     auto vis = uast::Decl::Visibility::PUBLIC;
     bool isMethodOrField = false;
+    bool isMethod = false;
     bool isParenfulFunction = false;
     IdAndFlags::Flags filterFlags = 0;
     IdAndFlags::FlagSet excludeFlagSet;
     auto maybeIds = createWithSingleId(std::move(id), vis,
-                                       isMethodOrField, isParenfulFunction,
+                                       isMethodOrField, isMethod, isParenfulFunction,
                                        filterFlags, excludeFlagSet);
     CHPL_ASSERT(maybeIds.hasValue());
     return maybeIds.getValue();
@@ -1020,6 +1036,11 @@ enum {
     Skip shadow scopes (for private use)
    */
   LOOKUP_SKIP_SHADOW_SCOPES = 1024,
+
+  /**
+    Include methods in the search results (they are excluded by default).
+   */
+  LOOKUP_METHODS = 2048,
 };
 
 /** LookupConfig is a bit-set of the LOOKUP_ flags defined above */

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2344,13 +2344,21 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       } else {
         // Possibly a "compatibility hack" with production: we haven't checked
         // whether the call is valid, but the production scope resolver doesn't
-        // care and assumes `ident` points to this parenless function.
-        r.setToId(id);
+        // care and assumes `ident` points to this parenless function. Setting
+        // the toId also helps determine if this is a method call and should
+        // have `this` inserted, as well as wehther or not to turn this
+        // into a parenless call.
+        validateAndSetToId(r, ident, id);
       }
       return;
     } else if (scopeResolveOnly &&
                type.kind() == QualifiedType::FUNCTION) {
-      return;
+      // Possibly a "compatibility hack" with production: we haven't checked
+      // whether the call is valid, but the production scope resolver doesn't
+      // care and assumes `ident` points to this function. Setting
+      // the toId also helps determine if this is a method call
+
+      // Fall through to validateAndSetToId
     }
 
     validateAndSetToId(result, ident, id);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2289,6 +2289,7 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       return;
     } else if (id.isEmpty()) {
       type = typeForBuiltin(context, ident->name());
+      result.setIsPrimitive(true);
       result.setToId(id);
       result.setType(type);
       return;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2350,13 +2350,6 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       return;
     } else if (scopeResolveOnly &&
                type.kind() == QualifiedType::FUNCTION) {
-      if (scopeResolveOnly) {
-        // Possibly a "compatibility hack" with production: we haven't checked
-        // whether the call is valid, but the production scope resolver doesn't
-        // care and assumes `ident` points to this function.
-        ResolvedExpression& r = byPostorder.byAst(ident);
-        r.setToId(id);
-      }
       return;
     }
 

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -63,7 +63,7 @@ areOverloadsPresentInDefiningScope(Context* context, const Type* type,
   if (!scopeForReceiverType) return false;
 
   // do not look outside the defining module
-  const LookupConfig config = LOOKUP_DECLS | LOOKUP_PARENTS;
+  const LookupConfig config = LOOKUP_DECLS | LOOKUP_PARENTS | LOOKUP_METHODS;
 
   auto vec = lookupNameInScope(context, scopeForReceiverType,
                                /* receiver scopes */ {},

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -714,8 +714,10 @@ computeIsMoreVisible(Context* context,
 
   // TODO: This might be over-simplified -- see issue #19167
 
-  LookupConfig onlyDecls = LOOKUP_DECLS;
-  LookupConfig importAndUse = LOOKUP_IMPORT_AND_USE;
+  // In both cases, include methods since they're considered for candidate
+  // search.
+  LookupConfig onlyDecls = LOOKUP_DECLS | LOOKUP_METHODS;
+  LookupConfig importAndUse = LOOKUP_IMPORT_AND_USE | LOOKUP_METHODS;
 
   // Go up scopes to figure out which of the two IDs is
   // declared first / innermost

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -222,7 +222,12 @@ const QualifiedType& typeForModuleLevelSymbol(Context* context, ID id) {
   int postOrderId = id.postOrderId();
   if (postOrderId >= 0) {
     const auto& resolvedStmt = resolveModuleStmt(context, id);
-    result = resolvedStmt.byId(id).type();
+    if (resolvedStmt.hasId(id)) {
+      result = resolvedStmt.byId(id).type();
+    } else {
+      // fall back to default value
+      result = QualifiedType();
+    }
   } else {
     QualifiedType::Kind kind = QualifiedType::UNKNOWN;
     const Type* t = nullptr;
@@ -2773,6 +2778,10 @@ lookupCalledExpr(Context* context,
 
   if (ci.isMethodCall()) {
     config |= LOOKUP_ONLY_METHODS_FIELDS;
+  }
+
+  if (ci.isOpCall()) {
+    config |= LOOKUP_METHODS;
   }
 
   UniqueString name = ci.name();

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -75,6 +75,16 @@ static bool isMethodOrField(const AstNode* d, bool atFieldLevel) {
   return false;
 }
 
+static bool isMethod(const AstNode* d, bool atFieldLevel) {
+  if (d != nullptr) {
+    if (auto fn = d->toFunction()) {
+      return atFieldLevel || fn->isMethod();
+    }
+  }
+
+  return false;
+}
+
 static bool isParenfulFunction(const AstNode* d) {
   if (d != nullptr) {
     if (auto fn = d->toFunction()) {
@@ -100,12 +110,14 @@ static void gather(DeclMap& declared,
                           name,
                           OwnedIdsWithName(d->id(), visibility,
                                            isMethodOrField(d, atFieldLevel),
+                                           isMethod(d, atFieldLevel),
                                            isParenfulFunction(d)));
   } else {
     // found an entry, so add to it
     OwnedIdsWithName& val = search->second;
     val.appendIdAndFlags(d->id(), visibility,
                          isMethodOrField(d, atFieldLevel),
+                         isMethod(d, atFieldLevel),
                          isParenfulFunction(d));
   }
 }
@@ -458,7 +470,8 @@ struct LookupHelper {
                              UniqueString name,
                              bool onlyInnermost,
                              bool skipPrivateVisibilities,
-                             bool onlyMethodsFields);
+                             bool onlyMethodsFields,
+                             bool includeMethods);
 
   bool doLookupInToplevelModules(const Scope* scope, UniqueString name);
 
@@ -526,6 +539,7 @@ bool LookupHelper::doLookupInImportsAndUses(
   bool onlyMethodsFields = (config & LOOKUP_ONLY_METHODS_FIELDS) != 0;
   bool checkExternBlocks = (config & LOOKUP_EXTERN_BLOCKS) != 0;
   bool skipPrivateUseImport = (config & LOOKUP_SKIP_PRIVATE_USE_IMPORT) != 0;
+  bool includeMethods = (config & LOOKUP_METHODS) != 0;
   bool trace = (traceCurPath != nullptr && traceResult != nullptr);
   bool found = false;
 
@@ -576,6 +590,9 @@ bool LookupHelper::doLookupInImportsAndUses(
         if (onlyMethodsFields) {
           newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
         }
+        if (includeMethods) {
+          newConfig |= LOOKUP_METHODS;
+        }
         if (checkExternBlocks) {
           newConfig |= LOOKUP_EXTERN_BLOCKS;
         }
@@ -612,11 +629,13 @@ bool LookupHelper::doLookupInImportsAndUses(
         auto scopeAst = parsing::idToAst(context, is.scope()->id());
         auto visibility = scopeAst->toDecl()->visibility();
         bool isMethodOrField = false; // target must be module/enum, not method
+        bool isMethod = false; // target must be module/enum, not method
         bool isParenfulFunction = false;
         auto foundIds =
           BorrowedIdsWithName::createWithSingleId(is.scope()->id(),
                                                   visibility,
                                                   isMethodOrField,
+                                                  isMethod,
                                                   isParenfulFunction,
                                                   filterFlags,
                                                   excludeFilter);
@@ -651,7 +670,8 @@ bool LookupHelper::doLookupInAutoModules(const Scope* scope,
                                          UniqueString name,
                                          bool onlyInnermost,
                                          bool skipPrivateVisibilities,
-                                         bool onlyMethodsFields) {
+                                         bool onlyMethodsFields,
+                                         bool includeMethods) {
   bool trace = (traceCurPath != nullptr && traceResult != nullptr);
   bool found = false;
 
@@ -668,6 +688,10 @@ bool LookupHelper::doLookupInAutoModules(const Scope* scope,
 
       if (onlyMethodsFields) {
         newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
+      }
+
+      if (includeMethods) {
+        newConfig |= LOOKUP_METHODS;
       }
 
       if (trace) {
@@ -818,6 +842,7 @@ bool LookupHelper::doLookupInExternBlocks(const Scope* scope,
     if (externBlockContainsName(context, exbId, name)) {
       // note that this extern block can match 'name'
       bool isMethodOrField = false; // not possible in an extern block
+      bool isMethod = false; // not possible in an extern block
       bool isParenfulFunction = false; // might be a lie. TODO does it matter?
       IdAndFlags::Flags filterFlags = 0;
       IdAndFlags::FlagSet excludeFlagSet;
@@ -829,6 +854,7 @@ bool LookupHelper::doLookupInExternBlocks(const Scope* scope,
         BorrowedIdsWithName::createWithSingleId(newId,
                                                 Decl::PUBLIC,
                                                 isMethodOrField,
+                                                isMethod,
                                                 isParenfulFunction,
                                                 filterFlags,
                                                 excludeFlagSet);
@@ -885,6 +911,7 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
   bool onlyMethodsFields = (config & LOOKUP_ONLY_METHODS_FIELDS) != 0;
   bool checkExternBlocks = (config & LOOKUP_EXTERN_BLOCKS) != 0;
   bool skipShadowScopes = (config & LOOKUP_SKIP_SHADOW_SCOPES) != 0;
+  bool includeMethods = (config & LOOKUP_METHODS) != 0;
   bool trace = (traceCurPath != nullptr && traceResult != nullptr);
 
   IdAndFlags::Flags curFilter = 0;
@@ -894,6 +921,8 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
   }
   if (onlyMethodsFields) {
     curFilter |= IdAndFlags::METHOD_FIELD;
+  } else if (!includeMethods && receiverScopes.empty()) {
+    curFilter |= IdAndFlags::NOT_METHOD;
   }
   // note: setting excludeFilter in some way other than the
   // handling below with checkedScopes will require other adjustments.
@@ -988,7 +1017,8 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
     got |= doLookupInAutoModules(scope, name,
                                  onlyInnermost,
                                  skipPrivateVisibilities,
-                                 onlyMethodsFields);
+                                 onlyMethodsFields,
+                                 includeMethods);
     if (onlyInnermost && got) return true;
   }
 

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -135,7 +135,7 @@ struct GatherDecls {
   bool atFieldLevel = false;
 
   GatherDecls(const AstNode* parentAst) {
-    if (parentAst && parentAst->isAggregateDecl()) {
+    if (parentAst && (parentAst->isAggregateDecl() || parentAst->isInterface())) {
       atFieldLevel = true;
     }
   }

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -39,6 +39,9 @@ std::string IdAndFlags::flagsToString(Flags flags) {
   if ((flags & PARENFUL_FUNCTION) != 0)     ret += "parenful-fn ";
   if ((flags & NOT_PARENFUL_FUNCTION) != 0) ret += "!parenful-fn ";
 
+  if ((flags & METHOD) != 0)     ret += "method ";
+  if ((flags & NOT_METHOD) != 0) ret += "!method ";
+
   return ret;
 }
 
@@ -281,6 +284,7 @@ void Scope::addBuiltin(UniqueString name) {
                     OwnedIdsWithName(ID(),
                                      uast::Decl::PUBLIC,
                                      /*isMethodOrField*/ false,
+                                     /*isMethod*/ false,
                                      /*isParenfulFunction*/ false));
 }
 

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -283,7 +283,7 @@ void Scope::addBuiltin(UniqueString name) {
   declared_.emplace(name,
                     OwnedIdsWithName(ID(),
                                      uast::Decl::PUBLIC,
-                                     /*isMethodOrField*/ false,
+                                     /*isField*/ false,
                                      /*isMethod*/ false,
                                      /*isParenfulFunction*/ false));
 }

--- a/frontend/test/resolution/testScopeTypes.cpp
+++ b/frontend/test/resolution/testScopeTypes.cpp
@@ -105,7 +105,7 @@ static void testBorrowIds() {
   {
     // check one id with no filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     assert(ids.numIds() == 1);
     auto foundIds = ids.borrow(0, FlagSet::empty());
     assert(foundIds.hasValue());
@@ -123,7 +123,7 @@ static void testBorrowIds() {
   {
     // check one id with filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = pub;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
@@ -132,7 +132,7 @@ static void testBorrowIds() {
   {
     // check one id with filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(not_method);
     auto foundIds = ids.borrow(f, e);
@@ -142,9 +142,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out the 1st
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     ids.appendIdAndFlags(y, Decl::PUBLIC,
-                         /* method or field */ true, /* method */ true, /* parenful */ false);
+                         /* field */ false, /* method */ true, /* parenful */ false);
     assert(ids.numIds() == 2);
     IdAndFlags::Flags f = pub;
     auto e = FlagSet::empty();
@@ -164,9 +164,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out the 2nd
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method or field */ true, /* method */ true, /* parenful */ false);
+                         /* field */ false, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = IdAndFlags::PUBLIC;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
@@ -185,9 +185,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out neither
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method or field */ true, /* method */ true, /* parenful */ false);
+                         /* field */ false, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
@@ -206,9 +206,9 @@ static void testBorrowIds() {
   {
     // check two excluding one of them
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method or field */ true, /* method */ true, /* parenful */ false);
+                         /* field */ false, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
@@ -227,9 +227,9 @@ static void testBorrowIds() {
   {
     // check two different ones excluding one of them
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method or field */ true, /* method */ true, /* parenful */ false);
+                         /* field */ false, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PUBLIC,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
@@ -248,9 +248,9 @@ static void testBorrowIds() {
   {
     // check two excluding both
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method or field */ true, /* method */ true, /* parenful */ false);
+                         /* field */ false, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PUBLIC,
-                         /* method or field */ false, /* method */ false, /* parenful */ false);
+                         /* field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub);
     auto foundIds = ids.borrow(f, e);

--- a/frontend/test/resolution/testScopeTypes.cpp
+++ b/frontend/test/resolution/testScopeTypes.cpp
@@ -105,7 +105,7 @@ static void testBorrowIds() {
   {
     // check one id with no filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     assert(ids.numIds() == 1);
     auto foundIds = ids.borrow(0, FlagSet::empty());
     assert(foundIds.hasValue());
@@ -123,7 +123,7 @@ static void testBorrowIds() {
   {
     // check one id with filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = pub;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
@@ -132,7 +132,7 @@ static void testBorrowIds() {
   {
     // check one id with filtering
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(not_method);
     auto foundIds = ids.borrow(f, e);
@@ -142,9 +142,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out the 1st
     OwnedIdsWithName ids(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     ids.appendIdAndFlags(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     assert(ids.numIds() == 2);
     IdAndFlags::Flags f = pub;
     auto e = FlagSet::empty();
@@ -164,9 +164,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out the 2nd
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = IdAndFlags::PUBLIC;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
@@ -185,9 +185,9 @@ static void testBorrowIds() {
   {
     // check two ids with filtering out neither
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
@@ -206,9 +206,9 @@ static void testBorrowIds() {
   {
     // check two excluding one of them
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PRIVATE,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
@@ -227,9 +227,9 @@ static void testBorrowIds() {
   {
     // check two different ones excluding one of them
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PUBLIC,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
@@ -248,9 +248,9 @@ static void testBorrowIds() {
   {
     // check two excluding both
     OwnedIdsWithName ids(y, Decl::PUBLIC,
-                         /* method */ true, /* parenful */ false);
+                         /* method or field */ true, /* method */ true, /* parenful */ false);
     ids.appendIdAndFlags(x, Decl::PUBLIC,
-                         /* method */ false, /* parenful */ false);
+                         /* method or field */ false, /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub);
     auto foundIds = ids.borrow(f, e);

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/badName-this.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/badName-this.good
@@ -1,1 +1,2 @@
-badName-this.chpl:5: error: Bad identifier, no known 'this' defined in 'Foo'
+badName-this.chpl:4: In module 'User':
+badName-this.chpl:5: error: cannot 'import' symbol 'this' as it is not defined in 'Foo'


### PR DESCRIPTION
On main, running
```Bash
chpl hello.chpl --dyno --dyno-scope-bundled --no-dyno-scope-production &>errors.txt
```
produces a file that's 1054 lines long. This is because the Dyno scope resolver doesn't yet handle all the functionality that the production scope resolver takes on. This PR attempts to start bridging the gap, though it still doesn't quite get hello world compiling. It does, however, produce a file with far fewer error lines (476). It does so by:

* Fixing up the Dyno conversion for forwarding declarations
* Adding support for properly converting (parenless) methods 
* Hiding methods from Dyno identifier lookups by default (to match the fact that the production scope only returns methods in some situations)
* Directly refering to the _owned and _shared types instead of relying on the production scope resolver to resolve their names.
* Looking up primitives like `int` in the global scope.

I'm not sure about the `{NOT_,}METHOD` flag, because it's unclear to me if our current include-exclude flag pairing will work properly with that change. However, I haven't run into problems yet. As of #22220, though, this is not an issue.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest