### PR TITLE
Generate write method stubs for FCF superclass types

### DIFF
--- a/compiler/resolution/fcf-support.cpp
+++ b/compiler/resolution/fcf-support.cpp
@@ -174,14 +174,10 @@ static Expr* createLegacyClassInstance(FnSymbol* fn, Expr* use);
 *                                                                            *
 ************************************** | ************************************/
 
-
-
 static bool isIntentSameAsDefault(IntentTag tag, Type* t) {
   auto ret = concreteIntent(INTENT_BLANK, t) == concreteIntent(tag, t);
   return ret;
 }
-
-
 
 static Type* buildSharedWrapperType(AggregateType* super) {
   Type* ret = NULL;
@@ -322,7 +318,7 @@ buildWrapperSuperTypeAtProgram(const std::vector<FcfFormalInfo>& formals,
                                   throws);
   std::ignore = attachSuperWriteMethod(v->type, "writeThis");
   if (fUseIOFormatters) {
-    std::ignore = attachSuperWriteMethod(v->type, "writeThis");
+    std::ignore = attachSuperWriteMethod(v->type, "encodeTo");
   }
 
   if (isAnyFormalNamed) v->thisMethod->addFlag(FLAG_OVERRIDE);

--- a/compiler/resolution/fcf-support.cpp
+++ b/compiler/resolution/fcf-support.cpp
@@ -140,6 +140,9 @@ attachSuperThis(AggregateType* super,
                 Type* retType,
                 bool throws);
 
+static FnSymbol*
+attachSuperWriteMethod(AggregateType* super, const char* name);
+
 static AggregateType*
 insertChildWrapperAtPayload(const SharedFcfSuperInfo info,
                             FnSymbol* payload);
@@ -149,8 +152,9 @@ attachChildThis(const SharedFcfSuperInfo info, AggregateType* child,
                 FnSymbol* payload);
 
 static FnSymbol*
-attachChildWriteThis(const SharedFcfSuperInfo info, AggregateType* child,
-                     FnSymbol* payload, const char* name);
+attachChildWriteMethod(const SharedFcfSuperInfo info, AggregateType* child,
+                       FnSymbol* payload,
+                       const char* name);
 
 static FnSymbol*
 attachChildPayloadPtrGetter(const SharedFcfSuperInfo info,
@@ -316,6 +320,11 @@ buildWrapperSuperTypeAtProgram(const std::vector<FcfFormalInfo>& formals,
   v->thisMethod = attachSuperThis(v->type, formals, retTag,
                                   retType,
                                   throws);
+  std::ignore = attachSuperWriteMethod(v->type, "writeThis");
+  if (fUseIOFormatters) {
+    std::ignore = attachSuperWriteMethod(v->type, "writeThis");
+  }
+
   if (isAnyFormalNamed) v->thisMethod->addFlag(FLAG_OVERRIDE);
 
   // This ordering matters to prevent a circular dependency in 'toString'.
@@ -545,6 +554,15 @@ attachSuperThis(AggregateType* super,
   return ret;
 }
 
+static FnSymbol*
+attachSuperWriteMethod(AggregateType* super, const char* name) {
+  ArgSymbol* fileArg = nullptr;
+  auto ret = buildWriteThisFnSymbol(super, &fileArg, name);
+  ret->throwsErrorInit();
+  normalize(ret);
+  return ret;
+}
+
 static AggregateType*
 insertChildWrapperAtPayload(const SharedFcfSuperInfo info,
                             FnSymbol* payload) {
@@ -641,7 +659,7 @@ attachChildThis(const SharedFcfSuperInfo info, AggregateType* child,
 }
 
 static FnSymbol*
-attachChildWriteThis(const SharedFcfSuperInfo info,
+attachChildWriteMethod(const SharedFcfSuperInfo info,
                      AggregateType* child,
                      FnSymbol* payload,
                      const char* name) {
@@ -774,9 +792,9 @@ static Expr* createLegacyClassInstance(FnSymbol* fn, Expr* use) {
   auto child = insertChildWrapperAtPayload(info, fn);
   std::ignore = attachChildThis(info, child, fn);
 
-  std::ignore = attachChildWriteThis(info, child, fn, "writeThis");
+  std::ignore = attachChildWriteMethod(info, child, fn, "writeThis");
   if (fUseIOFormatters) {
-    std::ignore = attachChildWriteThis(info, child, fn, "encodeTo");
+    std::ignore = attachChildWriteMethod(info, child, fn, "encodeTo");
   }
 
   std::ignore = attachChildPayloadPtrGetter(info, child, fn);

--- a/test/functions/fcf/Motivators.chpl
+++ b/test/functions/fcf/Motivators.chpl
@@ -165,8 +165,6 @@ proc test9() {
 }
 
 proc main() {
-  // TODO: Can trigger hard to reproduce bug where FCF name does not print.
-  /*
   const tests = [test0, test1, test2a, test2b, test3, test4, test5, test6,
                  test7, test8, test9];
   type T = proc(): void;
@@ -175,32 +173,5 @@ proc main() {
     writeln("--- ", test:string, " ---");
     test();
   }
-  */
-
-  writeln("--- ", "test0()", " ---");
-  test0();
-  writeln("--- ", "test1()", " ---");
-  test1();
-  writeln("--- ", "test2a()", " ---");
-  test2a();
-  writeln("--- ", "test2b()", " ---");
-  test2b();
-  writeln("--- ", "test3()", " ---");
-  test3();
-  writeln("--- ", "test4()", " ---");
-  test4();
-  // TODO: Bug with printing fcf names that is difficult to pin down.
-  /*
-  writeln("--- ", "test5()", " ---");
-  test5();
-  */
-  writeln("--- ", "test6()", " ---");
-  test6();
-  writeln("--- ", "test7()", " ---");
-  test7();
-  writeln("--- ", "test8()", " ---");
-  test8();
-  writeln("--- ", "test9()", " ---");
-  test9();
 }
 

--- a/test/functions/fcf/Motivators.good
+++ b/test/functions/fcf/Motivators.good
@@ -23,6 +23,10 @@ proc(): int
 --- test4() ---
 Error: P1
 Error: P2
+--- test5() ---
+foo()
+foo()
+chpl_anon_proc_4()
 --- test6() ---
 --- test7() ---
 --- test8() ---


### PR DESCRIPTION
Fix a bug where FCF names were not displaying when printed with
`writeln()`. Generate `writeThis` and `encodeTo` method stubs
for FCF superclass types.

Special thanks to @lydia-duncan for sharing a backtrace of a run
that segfaulted.

TESTING

- [x] `linux64`, `standard`

Reviewed by @lydia-duncan. Thanks!