### PR TITLE
Make gpu SDK version checking code more robust

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -188,7 +188,7 @@ def _validate_cuda_version_impl():
         match = re.search(r'\d+\.\d+\.\d+', txt)
         if match:
             cudaVersion = match.group()
-    
+
     if cudaVersion is None:
         _reportMissingGpuReq("Unable to determine CUDA version.")
         return False

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -5,7 +5,7 @@ import json
 import chpl_locale_model
 import chpl_llvm
 import re
-from utils import error, memoize, run_command, which, is_ver_in_range
+from utils import error, warning, memoize, run_command, which, is_ver_in_range
 
 def _validate_cuda_version():
     return _validate_cuda_version_impl()
@@ -188,9 +188,9 @@ def _validate_cuda_version_impl():
         match = re.search(r'\d+\.\d+\.\d+', txt)
         if match:
             cudaVersion = match.group()
-
+    cudaVersion = None
     if cudaVersion is None:
-        _reportMissingGpuReq("Unable to determine CUDA version")
+        _reportMissingGpuReq("Unable to determine CUDA version.")
         return False
 
     if not is_ver_in_range(cudaVersion, MIN_REQ_VERSION, MAX_REQ_VERSION):
@@ -212,15 +212,15 @@ def _validate_rocm_version_impl():
     chpl_rocm_path = get_sdk_path('rocm')
     files_to_try = ['%s/.info/version-hiprt' % chpl_rocm_path,
         '%s/.info/version-libs' % chpl_rocm_path]
+
     version_filename = None
     for fname in files_to_try:
-       print(fname)
        if os.path.exists(fname):
            version_filename = fname
            break
 
     if version_filename is None:
-        _reportMissingGpuReq("Unable to determine ROCm version")
+        _reportMissingGpuReq("Unable to determine ROCm version.")
         return False
 
     rocmVersion = open(version_filename).read()

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -188,7 +188,7 @@ def _validate_cuda_version_impl():
         match = re.search(r'\d+\.\d+\.\d+', txt)
         if match:
             cudaVersion = match.group()
-    cudaVersion = None
+    
     if cudaVersion is None:
         _reportMissingGpuReq("Unable to determine CUDA version.")
         return False


### PR DESCRIPTION
This PR (https://github.com/chapel-lang/chapel/pull/22170) introduced code that validates the installed version of a GPU SDK (i.e. CUDA or ROCm). My validation code works by looking for a certain file that contains the version; unfortunately it looks like the name of this file is different for different versions of both CUDA and ROCm. This PR updates to look for other known names/formats.

Since this is failing our nightly tests I plan to merge this quickly but we may want to consider if this is robust enough to handle future versions or deal with versions that we say we're supporting but haven't explicitly tested.  Some thoughts:

- We could compile a small program using CUDA/ROCm that calls the API to report the version and use that. This seems awfully heavy-handed to me.
- We could also consider not erroring if we can't find the file. IOW we only error if we can prove the user has a version we know not to work rather than erroring that we can't validate that they have a working version.

Also note that the error we produce today looks like this:

```
Error: Unable to determine CUDA version. To avoid this issue, you can have GPU code run on the CPU by setting 'CHPL_GPU_CODEGEN=none'. To turn this error into a warning set CHPLENV_GPU_REQ_ERRS_AS_WARNINGS.
```

which, gives a workaround (set `CHPLENV_GPU_REQ_ERRS_AS_WARNINGS`) so if this regresses there is a workaround presented.