### PR TITLE
Emit an error for extern blocks not a module scope

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -132,6 +132,7 @@ struct Visitor {
   void checkAttributeNameRecognizedOrToolSpaced(const Attribute* node);
   void checkAttributeUsedParens(const Attribute* node);
   void checkUserModuleHasPragma(const AttributeGroup* node);
+  void checkExternBlockAtModuleScope(const ExternBlock* node);
   /*
   TODO
   void checkProcedureFormalsAgainstRetType(const Function* node);
@@ -173,6 +174,7 @@ struct Visitor {
   void visit(const Yield* node);
   void visit(const Break* node);
   void visit(const Continue* node);
+  void visit(const ExternBlock* node);
 };
 
 /**
@@ -1309,6 +1311,17 @@ void Visitor::visit(const Continue* node) {
   if (!checkParentsForControlFlow(parents_, nodeAllowsContinue, node, blockingNode, allowingNode)) {
     CHPL_REPORT(context_, DisallowedControlFlow, node, blockingNode, allowingNode);
   }
+}
+
+void Visitor::checkExternBlockAtModuleScope(const ExternBlock* node) {
+  const AstNode* p = parent();
+  if (!p->isModule()) {
+    error(node, "extern blocks are currently only supported at module scope");
+  }
+}
+
+void Visitor::visit(const ExternBlock* node) {
+  checkExternBlockAtModuleScope(node);
 }
 
 // Duplicate the contents of 'idIsInBundledModule', while skipping the

--- a/test/functions/fcf/ExternBlock.bad
+++ b/test/functions/fcf/ExternBlock.bad
@@ -1,3 +1,3 @@
-ExternBlock.chpl:14: error: extern procedure argument types should be extern types - 'proc(x: int, y: int): int' is not
+ExternBlock.chpl:13: error: extern procedure argument types should be extern types - 'proc(x: int, y: int): int' is not
 ExternBlock.chpl:17: note: when instantiated from here
 ExternBlock.chpl:23: note: when instantiated from here

--- a/test/functions/fcf/ExternBlock.chpl
+++ b/test/functions/fcf/ExternBlock.chpl
@@ -1,18 +1,18 @@
 /***
 */
 module ExternBlock {
-  proc test5() {
-    extern {
-      #include <assert.h>
-      void foo(int64_t (*)(int64_t, int64_t));
-      void foo(int64_t (*fn)(int64_t, int64_t)) {
-        int n = fn(4, 4);
-        assert(n == 8);
-      }
+  extern {
+    #include <assert.h>
+    void foo(int64_t (*)(int64_t, int64_t));
+    void foo(int64_t (*fn)(int64_t, int64_t)) {
+      int n = fn(4, 4);
+      assert(n == 8);
     }
+  }
 
-    extern proc foo(fn: proc(_: int, _: int): int): void;
+  extern proc foo(fn: proc(_: int, _: int): int): void;
 
+  proc test5() {
     // Call 'foo' with our proc literal.
     foo(proc(x: int, y: int) {
       return x + y;


### PR DESCRIPTION
Resolves #22150

This PR adds a post-parse check to make sure that extern blocks only appear at module scope. We might relax that in the future but currently, having an extern block at non-module scope leads to strange behavior.

- [x] full local testing

Reviewed by @dlongnecke-cray - thanks!