### PR TITLE
Rename Memory.Diagnostics to MemDiagnostics

### DIFF
--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -42,7 +42,7 @@ Diagnostics
 
    CommDiagnostics <standard/CommDiagnostics>
    GpuDiagnostics <standard/GpuDiagnostics>
-   Memory <standard/Memory>
+   MemDiagnostics <standard/MemDiagnostics>
 
 
 Files/IO

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -43,6 +43,7 @@ Diagnostics
    CommDiagnostics <standard/CommDiagnostics>
    GpuDiagnostics <standard/GpuDiagnostics>
    MemDiagnostics <standard/MemDiagnostics>
+   Memory <standard/Memory>
 
 
 Files/IO

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -188,10 +188,10 @@ an error if one of the aforementioned requirements is not met.  This check
 might also occur if :proc:`~GPU.assertOnGpu()` is placed elsewhere in the loop
 depending on the presence of control flow.
 
-Utilities in :mod:`MemDiagnostics <Diagnostics>` module can be used to
+Utilities in the :mod:`MemDiagnostics` module can be used to
 monitor GPU memory allocations and detect memory leaks. For example,
-:proc:`startVerboseMem() <Diagnostics.startVerboseMem()>` and
-:proc:`stopVerboseMem() <Diagnostics.stopVerboseMem()>` can be used to enable
+:proc:`startVerboseMem() <MemDiagnostics.startVerboseMem()>` and
+:proc:`stopVerboseMem() <MemDiagnostics.stopVerboseMem()>` can be used to enable
 and disable output from memory allocations and deallocations. GPU-based
 operations will be marked in the generated output.
 

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -188,7 +188,7 @@ an error if one of the aforementioned requirements is not met.  This check
 might also occur if :proc:`~GPU.assertOnGpu()` is placed elsewhere in the loop
 depending on the presence of control flow.
 
-Utilities in :mod:`Memory.Diagnostics <Diagnostics>` module can be used to
+Utilities in :mod:`MemDiagnostics <Diagnostics>` module can be used to
 monitor GPU memory allocations and detect memory leaks. For example,
 :proc:`startVerboseMem() <Diagnostics.startVerboseMem()>` and
 :proc:`stopVerboseMem() <Diagnostics.stopVerboseMem()>` can be used to enable

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -92,6 +92,7 @@ MODULES_TO_DOCUMENT = \
 	standard/Math.chpl \
 	standard/MemMove.chpl \
 	standard/Memory.chpl \
+	standard/MemDiagnostics.chpl \
 	standard/Memory/Diagnostics.chpl \
 	standard/Memory/Initialization.chpl \
 	standard/OS.chpl \

--- a/modules/standard/MemDiagnostics.chpl
+++ b/modules/standard/MemDiagnostics.chpl
@@ -20,7 +20,7 @@
 
 /* Provides routines for reasoning about memory usage.
 
-  The :mod:`Diagnostics` module provides procedures which report information
+  The :mod:`MemDiagnostics` module provides procedures which report information
   about memory usage.  With one exception, to use these procedures you
   must enable memory tracking.  Do this by setting one or more of the
   config vars below, using appropriate ``--configVarName=value`` or
@@ -91,8 +91,9 @@
     to its own file, with a dot ('.') and the locale ID appended to
     this path.
  */
-@deprecated("The Memory.Diagnostics module is deprecated - please use the :mod:`MemDiagnostics` instead")
-module Diagnostics {
+
+@unstable("The 'MemDiagnostics' module is unstable")
+module MemDiagnostics {
 
 pragma "insert line file info"
 private extern proc chpl_memoryUsed(): uint(64);
@@ -113,11 +114,11 @@ enum MemUnits {Bytes, KB, MB, GB};
 
   .. note::
 
-    Unlike the other procedures in the :mod:`Diagnostics` module, this
+    Unlike the other procedures in the :mod:`MemDiagnostics` module, this
     one does not require memory tracking to be enabled.
 
   :arg unit: Units in which the returned value is to be expressed.
-  :type unit: :type:`~Diagnostics.MemUnits`
+  :type unit: :type:`~MemDiagnostics.MemUnits`
   :arg retType: Type of the returned value.  Defaults to `int(64)`.
   :type retType: `type`
   :returns: Size of physical memory on the locale where the call is made.

--- a/modules/standard/Memory.chpl
+++ b/modules/standard/Memory.chpl
@@ -21,7 +21,9 @@
 /* Support for operations related to memory usage and initialization.
 
 .. warning:: The "Memory.Initialization" module is deprecated.
+.. warning:: The "Memory.Diagnostics" module is deprecated.
 */
+@deprecated("The Memory module is deprecated")
 module Memory {
 
 include module Diagnostics;

--- a/modules/standard/Memory.chpl
+++ b/modules/standard/Memory.chpl
@@ -20,8 +20,7 @@
 
 /* Support for operations related to memory usage and initialization.
 
-.. warning:: The "Memory.Initialization" module is deprecated.
-.. warning:: The "Memory.Diagnostics" module is deprecated.
+.. warning:: The "Memory" module and all submodules are deprecated
 */
 @deprecated("The Memory module is deprecated")
 module Memory {

--- a/modules/standard/Memory/Diagnostics.chpl
+++ b/modules/standard/Memory/Diagnostics.chpl
@@ -91,7 +91,7 @@
     to its own file, with a dot ('.') and the locale ID appended to
     this path.
  */
-@deprecated("The Memory.Diagnostics module is deprecated - please use the :mod:`MemDiagnostics` instead")
+@deprecated("The Memory.Diagnostics module is deprecated - please use :mod:`MemDiagnostics` instead")
 module Diagnostics {
 
 pragma "insert line file info"

--- a/test/arrays/deitz/part7/test_descriptor_frees.chpl
+++ b/test/arrays/deitz/part7/test_descriptor_frees.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config const serially = true;
 

--- a/test/arrays/ferguson/block-array-mem.chpl
+++ b/test/arrays/ferguson/block-array-mem.chpl
@@ -1,5 +1,5 @@
 use BlockDist;
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config const numTasks = 4;
 config const n = 100_000_000;

--- a/test/chplvis/benchmarks-hpcc/HPCCProblemSize.chpl
+++ b/test/chplvis/benchmarks-hpcc/HPCCProblemSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use Memory.Diagnostics, Types;
+  use MemDiagnostics, Types;
 
   //
   // The main routine for computing the problem size

--- a/test/classes/dinan/array_passed_to_constructor.chpl
+++ b/test/classes/dinan/array_passed_to_constructor.chpl
@@ -3,7 +3,7 @@
  **   reference?  At present, it is copied.
  **/
  
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 param M = 2048;
 

--- a/test/classes/initializers/array_passed_to_initializer.chpl
+++ b/test/classes/initializers/array_passed_to_initializer.chpl
@@ -6,7 +6,7 @@
  **   reference?  At present, it is copied.
  **/
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 param M = 2048;
 

--- a/test/deprecated/memMoveModule.good
+++ b/test/deprecated/memMoveModule.good
@@ -1,3 +1,4 @@
+memMoveModule.chpl:1: warning: The Memory module is deprecated
 memMoveModule.chpl:1: warning: The Memory.Initialization module has been deprecated; please use the 'MemMove' module instead
 memMoveModule.chpl:11: In function 'main':
 memMoveModule.chpl:14: warning: The Memory.Initialization module has been deprecated; please use the 'MemMove' module instead

--- a/test/deprecated/memoryDiagnostics.chpl
+++ b/test/deprecated/memoryDiagnostics.chpl
@@ -1,1 +1,2 @@
 use Memory.Diagnostics;
+// deprecated by Jade in 1.31

--- a/test/deprecated/memoryDiagnostics.chpl
+++ b/test/deprecated/memoryDiagnostics.chpl
@@ -1,0 +1,1 @@
+use Memory.Diagnostics;

--- a/test/deprecated/memoryDiagnostics.good
+++ b/test/deprecated/memoryDiagnostics.good
@@ -1,0 +1,2 @@
+memoryDiagnostics.chpl:1: warning: The Memory module is deprecated
+memoryDiagnostics.chpl:1: warning: The Memory.Diagnostics module is deprecated - please use MemDiagnostics instead

--- a/test/deprecated/memoryModule.chpl
+++ b/test/deprecated/memoryModule.chpl
@@ -1,0 +1,1 @@
+use Memory;

--- a/test/deprecated/memoryModule.chpl
+++ b/test/deprecated/memoryModule.chpl
@@ -1,1 +1,2 @@
 use Memory;
+// deprecated by Jade in 1.31

--- a/test/deprecated/memoryModule.good
+++ b/test/deprecated/memoryModule.good
@@ -1,0 +1,1 @@
+memoryModule.chpl:1: warning: The Memory module is deprecated

--- a/test/distributions/robust/arithmetic/kernels/HPCCProblemSize.chpl
+++ b/test/distributions/robust/arithmetic/kernels/HPCCProblemSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use Memory.Diagnostics, Types;
+  use MemDiagnostics, Types;
 
   //
   // The main routine for computing the problem size

--- a/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.chpl
+++ b/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 use driver;
 
 writeln("start");

--- a/test/distributions/robust/associative/performance/array_iter.chpl
+++ b/test/distributions/robust/associative/performance/array_iter.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics, Types, Time, Sort;
+use MemDiagnostics, Types, Time, Sort;
 
 config const printTiming = false;
 config const verify = true;

--- a/test/distributions/robust/associative/performance/domain_iter.chpl
+++ b/test/distributions/robust/associative/performance/domain_iter.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics, Types, Time, Sort;
+use MemDiagnostics, Types, Time, Sort;
 
 config const printTiming = false;
 config const verify = true;

--- a/test/gpu/native/array_on_device/studies/shoc/triadAOD.chpl
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAOD.chpl
@@ -2,7 +2,7 @@ use Time;
 use ResultDB;
 use IO.FormattedIO;
 use GpuDiagnostics;
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config const passes = 1; //10;
 config const alpha = 1.75: real(32);

--- a/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.chpl
+++ b/test/gpu/native/array_on_device/studies/shoc/triadAodAsync.chpl
@@ -2,7 +2,7 @@ use Time;
 use ResultDB;
 use IO.FormattedIO;
 use GpuDiagnostics;
-use Memory.Diagnostics;
+use MemDiagnostics;
 use GPU;
 
 config const passes = 1; //10;

--- a/test/gpu/native/diags.chpl
+++ b/test/gpu/native/diags.chpl
@@ -1,5 +1,5 @@
 use GpuDiagnostics;
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 writeln("Start");
 

--- a/test/gpu/native/multiGPU/worksharing.chpl
+++ b/test/gpu/native/multiGPU/worksharing.chpl
@@ -1,6 +1,6 @@
 use Time;
 use GpuDiagnostics;
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config const validate = true;
 config const printStats = false;

--- a/test/gpu/native/studies/shoc/triad.chpl
+++ b/test/gpu/native/studies/shoc/triad.chpl
@@ -2,7 +2,7 @@ use Time;
 use ResultDB;
 use IO.FormattedIO;
 use GpuDiagnostics;
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config const passes = 10;
 config const alpha = 1.75: real(32);

--- a/test/gpu/sidelnik/hpcc/probSize.chpl
+++ b/test/gpu/sidelnik/hpcc/probSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use Memory, Types;
+  use MemDiagnostics, Types;
 
   //
   // The main routine for computing the problem size

--- a/test/library/packages/Sort/performance/dist-performance.chpl
+++ b/test/library/packages/Sort/performance/dist-performance.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 use CommDiagnostics;
-use Memory.Diagnostics;
+use MemDiagnostics;
 use Random;
 use Sort;
 use Time;

--- a/test/library/standard/LinkedLists/checkListFreed.chpl
+++ b/test/library/standard/LinkedLists/checkListFreed.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 use LinkedLists;
 
 var mem : uint;

--- a/test/library/standard/Memory/Diagnostics/countMemory/countMemory.chpl
+++ b/test/library/standard/Memory/Diagnostics/countMemory/countMemory.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 proc output(type retType) {
   const mem = Locales(0).physicalMemory(retType = retType),

--- a/test/library/standard/machine/machine.chpl
+++ b/test/library/standard/machine/machine.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;  // This should not be necessary, but currently I cannot
+use MemDiagnostics;  // This should not be necessary, but currently I cannot
              // put the definition of the Locales array into
              // _chpl_machine.chpl without breaking reallocation of
              // 1D uint arrays.

--- a/test/memory/deitz/test_leaked_array.chpl
+++ b/test/memory/deitz/test_leaked_array.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config var n: int = 10;
 

--- a/test/memory/deitz/test_leaked_array_in_record.chpl
+++ b/test/memory/deitz/test_leaked_array_in_record.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config var n: int = 10;
 

--- a/test/memory/diten/freeNil.chpl
+++ b/test/memory/diten/freeNil.chpl
@@ -1,5 +1,5 @@
 proc main {
-  use MemAlloc, Memory.Diagnostics;
+  use MemAlloc, MemDiagnostics;
   var m1, m2: uint(64);
   var o: opaque;
   m1 = memoryUsed();

--- a/test/memory/diten/reallocNil.chpl
+++ b/test/memory/diten/reallocNil.chpl
@@ -1,5 +1,5 @@
 proc main {
-  use MemAlloc, Memory.Diagnostics;
+  use MemAlloc, MemDiagnostics;
   var m1, m2, m3: uint(64);
   var o: opaque;
   m1 = memoryUsed();

--- a/test/memory/diten/reallocToZero.chpl
+++ b/test/memory/diten/reallocToZero.chpl
@@ -1,5 +1,5 @@
 proc main {
-  use MemAlloc, Memory.Diagnostics;
+  use MemAlloc, MemDiagnostics;
   var m1, m2, m3:uint(64);
   m1 = memoryUsed();
   var o: opaque = chpl_mem_allocMany(1, 100, 0, 0, 0);

--- a/test/memory/figueroa/LeakedMemory1.chpl
+++ b/test/memory/figueroa/LeakedMemory1.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 class C1 {
   var x: int;

--- a/test/memory/figueroa/LeakedMemory2.chpl
+++ b/test/memory/figueroa/LeakedMemory2.chpl
@@ -1,7 +1,7 @@
 // find out how much memory is leaked when a function with a local array
 // is called
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 const N = 5;
 

--- a/test/memory/figueroa/LeakedMemory3.chpl
+++ b/test/memory/figueroa/LeakedMemory3.chpl
@@ -1,7 +1,7 @@
 // find out how much memory is leaked when a slice
 // is passed in to another function
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 const N = 5;
 var A: [1..N] int;

--- a/test/memory/figueroa/LeakedMemory5.chpl
+++ b/test/memory/figueroa/LeakedMemory5.chpl
@@ -1,7 +1,7 @@
 // find out how much memory is leaked when a function with a local array
 // is called, and than array's domain is changed
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 const N = 5;
 var D = {2..N};

--- a/test/memory/figueroa/LeakedMemory6.chpl
+++ b/test/memory/figueroa/LeakedMemory6.chpl
@@ -1,7 +1,7 @@
 // find out how much memory is leaked when a function with a local array
 // is called, and than array's domain is changed
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 const N = 5;
 var D = {2..N};

--- a/test/memory/figueroa/LeakedMemoryArrayOfClasses.chpl
+++ b/test/memory/figueroa/LeakedMemoryArrayOfClasses.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 class C {
   var x: int;

--- a/test/memory/figueroa/StringLeaks1.chpl
+++ b/test/memory/figueroa/StringLeaks1.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics, IO;
+use MemDiagnostics, IO;
 
 config const n = 1;
 

--- a/test/memory/figueroa/StringLeaks2.chpl
+++ b/test/memory/figueroa/StringLeaks2.chpl
@@ -1,7 +1,7 @@
 // This test case shows that there is a memory leak due to the second assignment
 // to s.  s should be freed, but only if it was assigned to twice.
 
-use Memory.Diagnostics, IO;
+use MemDiagnostics, IO;
 
 config const n = 1;
 

--- a/test/memory/figueroa/StringLeaks3.chpl
+++ b/test/memory/figueroa/StringLeaks3.chpl
@@ -1,7 +1,7 @@
 // This test case shows that there is a memory leak due to the second assignment
 // to s.  s should be freed just before it is assigned to again.
 
-use Memory.Diagnostics, IO;
+use MemDiagnostics, IO;
 
 config const n = 1;
 

--- a/test/memory/gbt/test-memLog.chpl
+++ b/test/memory/gbt/test-memLog.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 class C {
   var i: int;

--- a/test/memory/shannon/freedMalloc.chpl
+++ b/test/memory/shannon/freedMalloc.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 extern proc chpl_mem_allocMany(number, size, description, lineno=-1, filename=0): opaque;
 extern proc chpl_mem_free(ptr, lineno=-1, filename=0);

--- a/test/memory/shannon/memstatFlag.chpl
+++ b/test/memory/shannon/memstatFlag.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 var m = 5;
 var n = 2;

--- a/test/memory/shannon/memstatPrint.chpl
+++ b/test/memory/shannon/memstatPrint.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 extern proc chpl_mem_allocMany(number, size, description, lineno=-1, filename=0): opaque;
 

--- a/test/memory/shannon/printMemAllocs.chpl
+++ b/test/memory/shannon/printMemAllocs.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config var n : int = 20;
 config var epsilon : real = 0.00001;

--- a/test/memory/shannon/printMemAllocs2.chpl
+++ b/test/memory/shannon/printMemAllocs2.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 class C {
   var a: [1..320] int(64);

--- a/test/memory/shannon/reallocZeroSize.chpl
+++ b/test/memory/shannon/reallocZeroSize.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 extern proc chpl_mem_allocMany(number, size, description, lineno=-1, filename=0): opaque;
 extern proc chpl_mem_realloc(ptr, size, description, lineno=-1, filename=0): opaque;

--- a/test/memory/sungeun/refCount/arrays-rankchange.chpl
+++ b/test/memory/sungeun/refCount/arrays-rankchange.chpl
@@ -18,7 +18,7 @@ proc return_rankchange(A: []) {
   return A[.., 3];
 }
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 proc main() {
   var A: [1..9, 1..9] int;
 

--- a/test/memory/sungeun/refCount/arrays.chpl
+++ b/test/memory/sungeun/refCount/arrays.chpl
@@ -40,7 +40,7 @@ proc return_reindex(A: []) {
   return A.reindex(3..6);
 }
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 proc main() {
   writeln("Calling create_literal():");
   var m1 = memoryUsed();

--- a/test/memory/sungeun/refCount/arraysAndDomains.chpl
+++ b/test/memory/sungeun/refCount/arraysAndDomains.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config const n = 4;
 config const printProgress = false;

--- a/test/memory/sungeun/refCount/domainMaps.chpl
+++ b/test/memory/sungeun/refCount/domainMaps.chpl
@@ -27,7 +27,7 @@ proc privatizedUsed():int {
   return total;
 }
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 proc return_domain_map(param dmType: DMType) {
   return myDM(dmType);

--- a/test/memory/sungeun/refCount/domains.chpl
+++ b/test/memory/sungeun/refCount/domains.chpl
@@ -50,7 +50,7 @@ proc create_translate(D: domain(1)) {
   D.translate(1);
 }
 
-use Memory.Diagnostics;
+use MemDiagnostics;
 proc main() {
   writeln("Calling create_literal():");
   var m1 = memoryUsed();

--- a/test/memory/vass/assign-to-memTrack.chpl
+++ b/test/memory/vass/assign-to-memTrack.chpl
@@ -1,3 +1,3 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 memTrack = true;
 writeln(memoryUsed());

--- a/test/multilocale/bradc/locales/queryLocaleStats.chpl
+++ b/test/multilocale/bradc/locales/queryLocaleStats.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 writeln("Locales.numPUs() = ", Locales.numPUs());
 writeln("Locales.physicalMemory = ", Locales.physicalMemory());

--- a/test/multilocale/deitz/needMultiLocales/streamCommCheck.chpl
+++ b/test/multilocale/deitz/needMultiLocales/streamCommCheck.chpl
@@ -1,4 +1,4 @@
-use BlockDist, Time, Memory, Types, Random;
+use BlockDist, Time, MemDiagnostics, Types, Random;
 private use CommDiagnostics;
 
 type elemType = real(64);

--- a/test/multilocale/numLocales/bradc/numLocales2.chpl
+++ b/test/multilocale/numLocales/bradc/numLocales2.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 writeln("numLocales = ", numLocales);
 writeln("LocaleSpace = ", LocaleSpace);

--- a/test/multilocale/numLocales/bradc/numLocales2Space.chpl
+++ b/test/multilocale/numLocales/bradc/numLocales2Space.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 writeln("numLocales = ", numLocales);
 writeln("LocaleSpace = ", LocaleSpace);

--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/HPCCProblemSize.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/HPCCProblemSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use Memory.Diagnostics, Types;
+  use MemDiagnostics, Types;
 
   //
   // The main routine for computing the problem size

--- a/test/parallel/forall/vass/performance/memleaks1-minimal.chpl
+++ b/test/parallel/forall/vass/performance/memleaks1-minimal.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 const RELOC = Locales[0];
 
 proc useMe(arg: int) { }

--- a/test/parallel/forall/vass/performance/memleaks2-BlockDist.chpl
+++ b/test/parallel/forall/vass/performance/memleaks2-BlockDist.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 use BlockDist;
 
 const SPACE = {1..2, 1..2};

--- a/test/performance/array/distCreate.chpl
+++ b/test/performance/array/distCreate.chpl
@@ -1,5 +1,5 @@
 use Time;
-use Memory.Diagnostics;
+use MemDiagnostics;
 use CommDiagnostics;
 
 use BlockDist;

--- a/test/performance/bharshbarg/arr-forall.chpl
+++ b/test/performance/bharshbarg/arr-forall.chpl
@@ -2,7 +2,7 @@
 // Measures both array iteration and array access time
 //
 
-use Memory.Diagnostics, Time, Types;
+use MemDiagnostics, Time, Types;
 
 config const zipIter = false;
 config const memFraction = 1000;

--- a/test/performance/bharshbarg/views-forall.chpl
+++ b/test/performance/bharshbarg/views-forall.chpl
@@ -2,7 +2,7 @@
 // Measures both array iteration and array access time
 //
 
-use Memory.Diagnostics, Time, Types;
+use MemDiagnostics, Time, Types;
 
 config const memFraction = 1000;
 config const printPerf = false;

--- a/test/performance/comm/low-level/arrayTransfer.chpl
+++ b/test/performance/comm/low-level/arrayTransfer.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics, Time, CTypes;
+use MemDiagnostics, Time, CTypes;
 
 enum op_t {
   opGet,

--- a/test/performance/compiler/bradc/probSize.chpl
+++ b/test/performance/compiler/bradc/probSize.chpl
@@ -1,5 +1,5 @@
 module HPCCProblemSize {
-  use Memory.Diagnostics, Types;
+  use MemDiagnostics, Types;
 
   config const memRatio = 4;
 

--- a/test/reductions/vass/reductions-perf.chpl
+++ b/test/reductions/vass/reductions-perf.chpl
@@ -6,7 +6,7 @@ See runTest() calls for what the number of reps and
 the arrays' domains being measured.
 */
 
-use BlockDist, Time, Memory.Diagnostics, ChplConfig;
+use BlockDist, Time, MemDiagnostics, ChplConfig;
 
 config param useBlockDist = CHPL_COMM != "none";
 config const perf = false; // performance or --fast mode

--- a/test/regex/allocationCounts.chpl
+++ b/test/regex/allocationCounts.chpl
@@ -1,5 +1,5 @@
 use Regex;
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 config type t = string;
 

--- a/test/release/examples/benchmarks/hpcc/HPCCProblemSize.chpl
+++ b/test/release/examples/benchmarks/hpcc/HPCCProblemSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use MemDiagnostics;
+  use MemDiagnostics, Types;
 
   //
   // The main routine for computing the problem size

--- a/test/release/examples/benchmarks/hpcc/HPCCProblemSize.chpl
+++ b/test/release/examples/benchmarks/hpcc/HPCCProblemSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use MemDiagnosticspes;
+  use MemDiagnostics;
 
   //
   // The main routine for computing the problem size

--- a/test/release/examples/benchmarks/hpcc/HPCCProblemSize.chpl
+++ b/test/release/examples/benchmarks/hpcc/HPCCProblemSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use Memory.Diagnostics, Types;
+  use MemDiagnosticspes;
 
   //
   // The main routine for computing the problem size

--- a/test/release/examples/primers/locales.chpl
+++ b/test/release/examples/primers/locales.chpl
@@ -112,7 +112,7 @@ writeln();
    on the locale
 */
 
-use MemDiagnostics/ for physicalMemory()
+use MemDiagnostics; // for physicalMemory()
 config const printLocaleInfo = true;  // permit testing to turn this off
 
 if printLocaleInfo then

--- a/test/release/examples/primers/locales.chpl
+++ b/test/release/examples/primers/locales.chpl
@@ -112,7 +112,7 @@ writeln();
    on the locale
 */
 
-use Memory.Diagnostics;  // for physicalMemory()
+use MemDiagnostics/ for physicalMemory()
 config const printLocaleInfo = true;  // permit testing to turn this off
 
 if printLocaleInfo then

--- a/test/runtime/configMatters/comm/bigTransfer.chpl
+++ b/test/runtime/configMatters/comm/bigTransfer.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics, Time, CTypes;
+use MemDiagnostics, Time, CTypes;
 
 type elemType = int;
 

--- a/test/runtime/configMatters/comm/oversubscribedArrayAlloc.chpl
+++ b/test/runtime/configMatters/comm/oversubscribedArrayAlloc.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics, Time, CTypes;
+use MemDiagnostics, Time, CTypes;
 
 config const oversubscription = 4;
 const desiredTasks = oversubscription * here.maxTaskPar;

--- a/test/runtime/configMatters/mem/fragmentation/MemUtil.chpl
+++ b/test/runtime/configMatters/mem/fragmentation/MemUtil.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 
 // Estimate for how much memory we can allocate. Based on
 // chpl_comm_regMemHeapInfo if using a fixed heap, otherwise physical memory

--- a/test/scan/scanPerf.chpl
+++ b/test/scan/scanPerf.chpl
@@ -1,4 +1,4 @@
-use Time, Memory.Diagnostics, BlockDist, ChplConfig;
+use Time, MemDiagnostics, BlockDist, ChplConfig;
 
 // compute a target problem size if one is not specified; assume homogeneity
 config const memFraction = 0;

--- a/test/studies/hpcc/HPL/bradc/HPCCProblemSize.chpl
+++ b/test/studies/hpcc/HPL/bradc/HPCCProblemSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use Memory.Diagnostics, Types;
+  use MemDiagnostics, Types;
 
   //
   // The main routine for computing the problem size

--- a/test/studies/hpcc/HPL/vass/schurComplement.chpl
+++ b/test/studies/hpcc/HPL/vass/schurComplement.chpl
@@ -1,7 +1,7 @@
 use DimensionalDist2D;
 use ReplicatedDim;
 use BlockCycDim;
-use Memory.Diagnostics, Time, Random;
+use MemDiagnostics, Time, Random;
 
 
 /////////// configuration ///////////

--- a/test/studies/hpcc/RA/diten/probSize.chpl
+++ b/test/studies/hpcc/RA/diten/probSize.chpl
@@ -6,7 +6,7 @@ module HPCCProblemSize {
   //
   // Use the standard modules for reasoning about Memory and Types
   //
-  use Memory.Diagnostics, Types;
+  use MemDiagnostics, Types;
 
   //
   // The main routine for computing the problem size

--- a/test/studies/hpcc/common/probSize-hpcc06.chpl
+++ b/test/studies/hpcc/common/probSize-hpcc06.chpl
@@ -1,5 +1,5 @@
 module HPCCProblemSize {
-  use Memory.Diagnostics;
+  use MemDiagnostics;
   use Types;
 
   config const memRatio = 4;

--- a/test/studies/hpcc/common/probSize.chpl
+++ b/test/studies/hpcc/common/probSize.chpl
@@ -1,5 +1,5 @@
 module HPCCProblemSize {
-  use Memory.Diagnostics, Types;
+  use MemDiagnostics, Types;
 
   proc computeProblemSize(
     type elemType, numArrays, returnLog2 = false, memRatio=4)

--- a/test/studies/hpcc/common/testProbSize.prediff
+++ b/test/studies/hpcc/common/testProbSize.prediff
@@ -2,7 +2,7 @@
 
 $hostname = `hostname -s`; chomp($hostname);
 
-$countMemoryDir="../../../library/standard/Memory/Diagnostics/countMemory";
+$countMemoryDir="../../../library/standard/MemDiagnostics/countMemory";
 $countMemoryFile="$countMemoryDir/countMemory.$hostname.good";
 
 system("cd $countMemoryDir && ./countMemory.prediff");

--- a/test/studies/hpcc/common/testProbSize.prediff
+++ b/test/studies/hpcc/common/testProbSize.prediff
@@ -2,7 +2,7 @@
 
 $hostname = `hostname -s`; chomp($hostname);
 
-$countMemoryDir="../../../library/standard/MemDiagnostics/countMemory";
+$countMemoryDir="../../../library/standard/Memory/Diagnostics/countMemory";
 $countMemoryFile="$countMemoryDir/countMemory.$hostname.good";
 
 system("cd $countMemoryDir && ./countMemory.prediff");

--- a/test/studies/twitter/survey.chpl
+++ b/test/studies/twitter/survey.chpl
@@ -1,3 +1,3 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 for l in Locales do
   writeln(l.name, ": ", l.physicalMemory(MemUnits.GB, real), "GB, ", l.numPUs(), " cores");

--- a/test/types/enum/enumIterMemCheck.chpl
+++ b/test/types/enum/enumIterMemCheck.chpl
@@ -1,4 +1,4 @@
-use Memory.Diagnostics;
+use MemDiagnostics;
 enum color { red, green, blue };
 startVerboseMem();
 for c in color {}

--- a/test/types/string/StringImpl/common/memTrackSupport.chpl
+++ b/test/types/string/StringImpl/common/memTrackSupport.chpl
@@ -2,7 +2,7 @@ config const doMemLeaksTest = true;
 config const verboseMem = false;
 config const verboseMemLeaks = false;
 
-public use Memory.Diagnostics;
+public use MemDiagnostics;
 private use ChplConfig;
 
 var totalMemLeaked = 0:uint(64);

--- a/test/unstable/memDiagnosticsModule.chpl
+++ b/test/unstable/memDiagnosticsModule.chpl
@@ -1,0 +1,1 @@
+use MemDiagnostics;

--- a/test/unstable/memDiagnosticsModule.good
+++ b/test/unstable/memDiagnosticsModule.good
@@ -1,0 +1,1 @@
+memDiagnosticsModule.chpl:1: warning: The 'MemDiagnostics' module is unstable


### PR DESCRIPTION
Based on discussion in #21205, we will move the Memory.Diagnostics module to be an unstable top level module name MemDiagnostics. This leaves the Memory module empty, and so it will also be deprecated.

## Summary of changes
- Rename Memory.Diagnostics to MemDiagnostics
- Mark MemDiagnostics as unstable
- Deprecate Memory
- Fixup module and test code that uses these

## New Tests
- `test/deprecated/memoryModule.chpl`
- `test/deprecated/memoryDiagnostics.chpl`
- `test/unstable/memDiagnosticsModule.chpl`

## Testing
- paratest+futures
- paratest+gasnet
- built and checked docs

---

[Reviewed by @benharsh]

closes #21205
closes cray/chapel-private#4751
