### PR TITLE
chplenv: try and get CUDA/HIP version from nvcc and/or hipcc

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -188,6 +188,14 @@ def _validate_cuda_version_impl():
         match = re.search(r'\d+\.\d+\.\d+', txt)
         if match:
             cudaVersion = match.group()
+    if cudaVersion is None:
+        exists, returncode, my_stdout, my_stderr = utils.try_run_command(
+            ["nvcc", "--version"])
+        if exists and returncode == 0:
+            pattern = r"Cuda compilation tools, release ([\d\.]+)"
+            match = re.search(pattern, my_stdout)
+            if match:
+                cudaVersion = match.group(1)
 
     if cudaVersion is None:
         _reportMissingGpuReq("Unable to determine CUDA version.")

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -227,11 +227,20 @@ def _validate_rocm_version_impl():
            version_filename = fname
            break
 
-    if version_filename is None:
+    rocmVersion = None
+    if version_filename is not None:
+        rocmVersion = open(version_filename).read()
+    else:
+        exists, returncode, my_stdout, my_stderr = utils.try_run_command(
+            ["hipcc", "--version"])
+        if exists and returncode == 0:
+            match = re.search(r"rocm?-([\d\.]+)", my_stdout)
+            if match:
+                rocmVersion = match.group(1)
+
+    if rocmVersion is None:
         _reportMissingGpuReq("Unable to determine ROCm version.")
         return False
-
-    rocmVersion = open(version_filename).read()
 
     if not is_ver_in_range(rocmVersion, MIN_REQ_VERSION, MAX_REQ_VERSION):
         _reportMissingGpuReq(


### PR DESCRIPTION
I found another install of CUDA that doesn't have either `version.json` or `version.txt` so I've added in yet another way of trying to extract the CUDA version: using `nvcc --version`, which is perhaps what I have should have done from the start.
I'm thinking maybe the `version.json` and `version.txt` files are put there by the package manager rather than something officially added by NVIDIA.

I figured while I was at it I should add a similar fallback for ROCm using `hipcc`.

Annoyingly enough for ROCm the version returned by `hipcc --version` is not the same as the ROCm version.  On my system for `hipcc --version` I got output like this:

```
$ hipcc --version
HIP version: 4.4.21432-f9dccde4
AMD clang version 13.0.0 (https://github.com/RadeonOpenCompute/llvm-project roc-4.5.2 21432 9bbd96fd1936641cd47defd8022edafd063019d5)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/rocm-4.5.2/llvm/bin
```

Where note the "ROCM" version and the "HIP Version" do not match. Nevertheless the ROCm version does appear in their twice though somewhat more brittely based on the install path and I think what is the branch name for LLVM? Either way I can still try and extract it.