### PR TITLE
Apply patch to build compiler with LLVM 15

### DIFF
--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -343,7 +343,13 @@ struct MemOpRanges { // from MemsetRanges in MemCpyOptimizer
                        // element in a structure.
 
     addRange(OffsetFromFirst, StoreSize, Slack,
-             SI->getPointerOperand(), SI->getAlignment(), SI);
+             SI->getPointerOperand(),
+#if HAVE_LLVM_VER >= 150
+             SI->getAlign().value(),
+#else
+             SI->getAlignment(),
+#endif
+             SI);
   }
   // CUSTOM because MemsetRanges doesn't work with LoadInsts.
   void addLoad(int64_t OffsetFromFirst, LoadInst *LI) {
@@ -351,7 +357,13 @@ struct MemOpRanges { // from MemsetRanges in MemCpyOptimizer
     int64_t Slack =  GET_EXTRA; // Pretend loads use more space...
 
     addRange(OffsetFromFirst, LoadSize, Slack,
-             LI->getPointerOperand(), LI->getAlignment(), LI);
+             LI->getPointerOperand(),
+#if HAVE_LLVM_VER >= 150
+             LI->getAlign().value(),
+#else
+             LI->getAlignment(),
+#endif
+             LI);
   }
   // CUSTOM adds Slack
   void addRange(int64_t Start, int64_t Size, int64_t Slack, Value *Ptr,

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -241,8 +241,13 @@ namespace {
                                           "", insertBefore);
 
     Constant* undef = UndefValue::get(widePtrType);
+#if HAVE_LLVM_VER >= 150
+    IRBuilder<> irBuilder(insertBefore);
+    Value* undefLocPtr = irBuilder.CreateExtractValue(undef, wideAddrGEP);
+#else
     Constant* undefLocPtr = ConstantExpr::getExtractValue(undef,
                                                           wideAddrGEP);
+#endif
     // get the local address space pointer.
     Value* cast = CastInst::CreatePointerCast(ptr, undefLocPtr->getType(),
                                               "", insertBefore);

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -15,7 +15,7 @@ def llvm_versions():
     # Which major release - only need one number for that with current
     # llvm (since LLVM 4.0).
     # These will be tried in order.
-    return ('14','13','12','11',)
+    return ('15','14','13','12','11',)
 
 @memoize
 def get_uniq_cfg_path_for(llvm_val, llvm_support_val):

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -15,7 +15,7 @@ def llvm_versions():
     # Which major release - only need one number for that with current
     # llvm (since LLVM 4.0).
     # These will be tried in order.
-    return ('15','14','13','12','11',)
+    return ('14','13','12','11',)
 
 @memoize
 def get_uniq_cfg_path_for(llvm_val, llvm_support_val):


### PR DESCRIPTION
This PR just applies the remainder of @daviditen 's work on building the compiler with LLVM 15, and is all his work. See https://github.com/Cray/chapel-private/issues/4028, particularly [this comment](https://github.com/Cray/chapel-private/issues/4028#issuecomment-1401237911) describing the status of the work as he left it off.

With this patch applied, all the remaining build failures with LLVM 15 are from usages of typed pointers.

The code in this PR is cherry picked from https://github.com/chapel-lang/chapel/commit/d93f2d34b361f0c50970a8432d6413f1cee2ca4c. The only modification is to remove LLVM 15 from the list of supported LLVM versions in `chpl_llvm.py`, as LLVM 15 support is not done and this would cause failures on systems where it is present.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] compiler builds and runs on my system with system and bundled LLVM 14
- [x] errors in LLVM 15 build are as expected