### PR TITLE
Fix gasnet tests missing 'enableGpuP2P' in help message

### DIFF
--- a/test/execflags/configs/privateconfigs-help-set.good
+++ b/test/execflags/configs/privateconfigs-help-set.good
@@ -20,6 +20,7 @@ Built-in config vars:
                       memLeaksLog: string
                    memLeaksByDesc: string
                          debugGpu: bool
+                     enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64) (configured to 1)
 

--- a/test/execflags/configs/privateconfigs-help.good
+++ b/test/execflags/configs/privateconfigs-help.good
@@ -20,6 +20,7 @@ Built-in config vars:
                       memLeaksLog: string
                    memLeaksByDesc: string
                          debugGpu: bool
+                     enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64) (configured to 1)
 


### PR DESCRIPTION
More test updates needed for <https://github.com/chapel-lang/chapel/pull/22157> which adds an 'enableGpuP2P' flag. Tests that lock down the `--help` output need to be updated to account for this.