### PR TITLE
mark replacement modules using compiler flags as internal/standard

### DIFF
--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -214,6 +214,33 @@ void setModuleSearchPath(Context* context,
                          std::vector<UniqueString> searchPath);
 
 /**
+  Return a list of paths to be prepended to the internal module path. This is
+  likely to be empty unless set using --prepend-internal-module-dir
+*/
+const std::vector<UniqueString>& prependedInternalModulePath(Context* context);
+
+/**
+  Set a list of paths to be prepended to the internal module path. This is
+  typically set using the compiler flag --prepend-internal-module-dir
+*/
+void setPrependedInternalModulePath(Context* context,
+                                    std::vector<UniqueString> paths);
+
+/**
+  Return a list of paths to be prepended to the standard module path. This is
+  likely to be empty unless set using --prepend-standard-module-dir
+*/
+const std::vector<UniqueString>& prependedStandardModulePath(Context* context);
+
+
+/**
+  Set a list of paths to be prepended to the standard module path. This is
+  typically set using the compiler flag --prepend-standard-module-dir
+*/
+void setPrependedStandardModulePath(Context* context,
+                                    std::vector<UniqueString> paths);
+
+/**
   Return the current internal module path, i.e. CHPL_HOME/modules/internal/
  */
 UniqueString internalModulePath(Context* context);

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -215,27 +215,29 @@ void setModuleSearchPath(Context* context,
 
 /**
   Return a list of paths to be prepended to the internal module path. This is
-  likely to be empty unless set using --prepend-internal-module-dir
+  likely to be empty unless using --prepend-internal-module-dir when compiling
 */
 const std::vector<UniqueString>& prependedInternalModulePath(Context* context);
 
 /**
   Set a list of paths to be prepended to the internal module path. This is
-  typically set using the compiler flag --prepend-internal-module-dir
+  typically set using the compiler flag --prepend-internal-module-dir and will
+  be called during setupModuleSearchPaths
 */
 void setPrependedInternalModulePath(Context* context,
                                     std::vector<UniqueString> paths);
 
 /**
   Return a list of paths to be prepended to the standard module path. This is
-  likely to be empty unless set using --prepend-standard-module-dir
+  likely to be empty unless using --prepend-standard-module-dir when compiling
 */
 const std::vector<UniqueString>& prependedStandardModulePath(Context* context);
 
 
 /**
   Set a list of paths to be prepended to the standard module path. This is
-  typically set using the compiler flag --prepend-standard-module-dir
+  typically set using the compiler flag --prepend-standard-module-dir and will
+  be called during setupModuleSearchPaths
 */
 void setPrependedStandardModulePath(Context* context,
                                     std::vector<UniqueString> paths);
@@ -334,6 +336,13 @@ bool idIsInBundledModule(Context* context, ID id);
  If the bundled module path is empty, this function returns false.
  */
 bool idIsInStandardModule(Context* context, ID id);
+
+
+bool
+filePathIsInInternalModule(Context* context, UniqueString filePath);
+
+bool
+filePathIsInStandardModule(Context* context, UniqueString filePath);
 
 /**
  This query parses a toplevel module by name. Returns nullptr

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -458,6 +458,45 @@ void setModuleSearchPath(Context* context,
   QUERY_STORE_INPUT_RESULT(moduleSearchPathQuery, context, searchPath);
 }
 
+static const std::vector<UniqueString>&
+prependedStandardModulePathQuery(Context* context) {
+  QUERY_BEGIN_INPUT(prependedStandardModulePathQuery, context);
+
+  // use empty string if wasn't already set by setPrependedStandardModulePath
+  std::vector<UniqueString> result;
+
+  return QUERY_END(result);
+}
+
+const std::vector<UniqueString>& prependedStandardModulePath(Context* context) {
+  return prependedStandardModulePathQuery(context);
+}
+
+void setPrependedStandardModulePath(Context* context,
+                                    std::vector<UniqueString> paths) {
+  QUERY_STORE_INPUT_RESULT(prependedStandardModulePathQuery, context, paths);
+}
+
+
+static const std::vector<UniqueString>&
+prependedInternalModulePathQuery(Context* context) {
+  QUERY_BEGIN_INPUT(prependedInternalModulePathQuery, context);
+
+  // use empty string if wasn't already set by setPrependedInternalModulePath
+  std::vector<UniqueString> result;
+
+  return QUERY_END(result);
+}
+
+const std::vector<UniqueString>& prependedInternalModulePath(Context* context) {
+  return prependedInternalModulePathQuery(context);
+}
+
+void setPrependedInternalModulePath(Context* context,
+                                    std::vector<UniqueString> paths) {
+  QUERY_STORE_INPUT_RESULT(prependedInternalModulePathQuery, context, paths);
+}
+
 
 static const UniqueString&
 internalModulePathQuery(Context* context) {
@@ -540,10 +579,16 @@ void setupModuleSearchPaths(
   setBundledModulePath(context, UniqueString::get(context, bundled));
 
   std::vector<std::string> searchPath;
+  std::vector<UniqueString> uPrependedInternalModulePaths;
+  std::vector<UniqueString> uPrependedStandardModulePaths;
 
   for (auto& path : prependInternalModulePaths) {
     searchPath.push_back(path);
+    UniqueString uPath = UniqueString::get(context, path);
+    uPrependedInternalModulePaths.push_back(uPath);
   }
+
+  setPrependedInternalModulePath(context, uPrependedInternalModulePaths);
 
   // TODO: Shouldn't these use the internal path we just set?
   searchPath.push_back(modRoot + "/internal/localeModels/" + chplLocaleModel);
@@ -557,8 +602,10 @@ void setupModuleSearchPaths(
 
   searchPath.push_back(modRoot + "/internal");
 
-  for (auto& path : prependInternalModulePaths) {
+  for (auto& path : prependStandardModulePaths) {
     searchPath.push_back(path);
+    UniqueString uPath = UniqueString::get(context, path);
+    uPrependedStandardModulePaths.push_back(uPath);
   }
 
   // TODO: Shouldn't these use the standard path we just set?
@@ -629,6 +676,13 @@ void setupModuleSearchPaths(Context* context,
 
 static bool
 filePathIsInInternalModule(Context* context, UniqueString filePath) {
+  // check for prepended internal module paths that may have come in from
+  // the command line flag --prepend-internal-module-dir
+  auto prependedPaths = prependedInternalModulePath(context);
+  for (auto& path : prependedPaths) {
+    if (filePath.startsWith(path)) return true;
+  }
+
   UniqueString prefix = internalModulePath(context);
   if (prefix.isEmpty()) return false;
   return filePath.startsWith(prefix);
@@ -643,6 +697,13 @@ filePathIsInBundledModule(Context* context, UniqueString filePath) {
 
 static bool
 filePathIsInStandardModule(Context* context, UniqueString filePath) {
+  // check for prepended standard module paths that may have come in from
+  // the command line flag --prepend-standard-module-dir
+  auto prependedPaths = prependedStandardModulePath(context);
+  for (auto& path : prependedPaths) {
+    if (filePath.startsWith(path)) return true;
+  }
+
   UniqueString prefix1 = bundledModulePath(context);
   if (prefix1.isEmpty()) return false;
   auto concat = prefix1.endsWith("/") ? "standard" : "/standard";

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -674,11 +674,11 @@ void setupModuleSearchPaths(Context* context,
                          inputFilenames);
 }
 
-static bool
+bool
 filePathIsInInternalModule(Context* context, UniqueString filePath) {
   // check for prepended internal module paths that may have come in from
   // the command line flag --prepend-internal-module-dir
-  auto prependedPaths = prependedInternalModulePath(context);
+  auto& prependedPaths = prependedInternalModulePath(context);
   for (auto& path : prependedPaths) {
     if (filePath.startsWith(path)) return true;
   }
@@ -695,11 +695,11 @@ filePathIsInBundledModule(Context* context, UniqueString filePath) {
   return filePath.startsWith(prefix);
 }
 
-static bool
+bool
 filePathIsInStandardModule(Context* context, UniqueString filePath) {
   // check for prepended standard module paths that may have come in from
   // the command line flag --prepend-standard-module-dir
-  auto prependedPaths = prependedStandardModulePath(context);
+  auto& prependedPaths = prependedStandardModulePath(context);
   for (auto& path : prependedPaths) {
     if (filePath.startsWith(path)) return true;
   }

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1317,6 +1317,18 @@ void Visitor::visit(const Continue* node) {
 bool Visitor::isUserFilePath(Context* context, UniqueString filepath) {
   UniqueString modules = chpl::parsing::bundledModulePath(context);
   if (modules.isEmpty()) return true;
+  // check for prepended internal module paths that may have come in from
+  // the command line flag --prepend-internal-module-dir
+  auto prependedIntPaths = chpl::parsing::prependedInternalModulePath(context);
+  for (auto& path : prependedIntPaths) {
+    if (filepath.startsWith(path)) return false;
+  }
+  // check for prepended standard module paths that may have come in from
+  // the command line flag --prepend-standard-module-dir
+  auto prependedStdPaths = chpl::parsing::prependedStandardModulePath(context);
+  for (auto& path : prependedStdPaths) {
+    if (filepath.startsWith(path)) return false;
+  }
   bool ret = !filepath.startsWith(modules);
   return ret;
 }

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1317,18 +1317,10 @@ void Visitor::visit(const Continue* node) {
 bool Visitor::isUserFilePath(Context* context, UniqueString filepath) {
   UniqueString modules = chpl::parsing::bundledModulePath(context);
   if (modules.isEmpty()) return true;
-  // check for prepended internal module paths that may have come in from
-  // the command line flag --prepend-internal-module-dir
-  auto prependedIntPaths = chpl::parsing::prependedInternalModulePath(context);
-  for (auto& path : prependedIntPaths) {
-    if (filepath.startsWith(path)) return false;
-  }
-  // check for prepended standard module paths that may have come in from
-  // the command line flag --prepend-standard-module-dir
-  auto prependedStdPaths = chpl::parsing::prependedStandardModulePath(context);
-  for (auto& path : prependedStdPaths) {
-    if (filepath.startsWith(path)) return false;
-  }
+  // check for internal module paths
+  if (parsing::filePathIsInInternalModule(context, filepath)) return false;
+  // check for standard module paths
+  if (parsing::filePathIsInStandardModule(context, filepath)) return false;
   bool ret = !filepath.startsWith(modules);
   return ret;
 }

--- a/test/modules/paths/int/ChapelNumLocales.chpl
+++ b/test/modules/paths/int/ChapelNumLocales.chpl
@@ -13,7 +13,7 @@ module ChapelNumLocales {
   //
   config const numLocales = chpl_comm_default_num_locales();
 
-  // this procedure is a helper for warnUnstableInt and warnUnstableBoth
+  // this procedure is a helper for tests warnUnstableInt and warnUnstableBoth
   // the pragma and unstable attribute would both trigger warnings if this
   // replacement module was not properly marked as internal by the compiler
   pragma "always RVF"

--- a/test/modules/paths/int/ChapelNumLocales.chpl
+++ b/test/modules/paths/int/ChapelNumLocales.chpl
@@ -7,9 +7,19 @@ module ChapelNumLocales {
 
   extern proc printf(x...);
   printf("In personal NumLocales module\n");
-  
+
   //
   // the number of locales on which to run the program
   //
   config const numLocales = chpl_comm_default_num_locales();
+
+  // this procedure is a helper for warnUnstableInt and warnUnstableBoth
+  // the pragma and unstable attribute would both trigger warnings if this
+  // replacement module was not properly marked as internal by the compiler
+  pragma "always RVF"
+  @unstable
+  proc testNumLocalsUnstableProc(doWrite:bool) {
+    if doWrite then
+      writeln("In my personal NumLocales - unstable proc");
+  }
 }

--- a/test/modules/paths/noWarnUnstableInt.good
+++ b/test/modules/paths/noWarnUnstableInt.good
@@ -1,0 +1,3 @@
+In personal NumLocales module
+inside M
+In my personal NumLocales - unstable proc

--- a/test/modules/paths/noWarnUnstableStd.good
+++ b/test/modules/paths/noWarnUnstableStd.good
@@ -1,0 +1,4 @@
+warning: Ambiguous module source file -- using std/Path.chpl over $CHPL_HOME/modules/standard/Path.chpl
+In my personal copy of Path
+inside M
+In personal Path - unstable proc

--- a/test/modules/paths/std/Path.chpl
+++ b/test/modules/paths/std/Path.chpl
@@ -2,7 +2,7 @@ module Path {
   extern proc printf(x...);
   printf("In my personal copy of Path\n");
 
-  // this procedure is a helper for warnUnstableStd and warnUnstableBoth
+  // this procedure is a helper for tests warnUnstableStd and warnUnstableBoth
   // the pragma and unstable attribute would both trigger warnings if this
   // replacement module was not properly marked as internal by the compiler
   pragma "always RVF"

--- a/test/modules/paths/std/Path.chpl
+++ b/test/modules/paths/std/Path.chpl
@@ -1,4 +1,14 @@
 module Path {
   extern proc printf(x...);
   printf("In my personal copy of Path\n");
+
+  // this procedure is a helper for warnUnstableStd and warnUnstableBoth
+  // the pragma and unstable attribute would both trigger warnings if this
+  // replacement module was not properly marked as internal by the compiler
+  pragma "always RVF"
+  @unstable
+  proc testPathUnstableProc(doWrite:bool) {
+    if doWrite then
+      writeln("In personal Path - unstable proc");
+  }
 }

--- a/test/modules/paths/warnUnstableBoth.chpl
+++ b/test/modules/paths/warnUnstableBoth.chpl
@@ -1,0 +1,10 @@
+module M {
+  use Path;
+  use ChapelNumLocales;
+
+  writeln("inside M");
+
+  testNumLocalsUnstableProc(true);
+  testPathUnstableProc(true);
+
+}

--- a/test/modules/paths/warnUnstableBoth.compopts
+++ b/test/modules/paths/warnUnstableBoth.compopts
@@ -1,0 +1,1 @@
+--prepend-standard-module-dir=std --prepend-internal-module-dir=int --warn-unstable

--- a/test/modules/paths/warnUnstableBoth.good
+++ b/test/modules/paths/warnUnstableBoth.good
@@ -1,0 +1,9 @@
+warning: Ambiguous module source file -- using std/Path.chpl over $CHPL_HOME/modules/standard/Path.chpl
+warnUnstableBoth.chpl:1: In module 'M':
+warnUnstableBoth.chpl:7: warning: testNumLocalsUnstableProc is unstable
+warnUnstableBoth.chpl:8: warning: testPathUnstableProc is unstable
+In personal NumLocales module
+In my personal copy of Path
+inside M
+In my personal NumLocales - unstable proc
+In personal Path - unstable proc

--- a/test/modules/paths/warnUnstableInt.chpl
+++ b/test/modules/paths/warnUnstableInt.chpl
@@ -1,0 +1,8 @@
+module M {
+  use ChapelNumLocales;
+
+  writeln("inside M");
+
+  testNumLocalsUnstableProc(true);
+}
+

--- a/test/modules/paths/warnUnstableInt.compopts
+++ b/test/modules/paths/warnUnstableInt.compopts
@@ -1,0 +1,2 @@
+--prepend-internal-module-dir=int  # noWarnUnstableInt.good
+--prepend-internal-module-dir=int --warn-unstable  # warnUnstableInt.good

--- a/test/modules/paths/warnUnstableInt.good
+++ b/test/modules/paths/warnUnstableInt.good
@@ -1,0 +1,5 @@
+warnUnstableInt.chpl:1: In module 'M':
+warnUnstableInt.chpl:6: warning: testNumLocalsUnstableProc is unstable
+In personal NumLocales module
+inside M
+In my personal NumLocales - unstable proc

--- a/test/modules/paths/warnUnstableStd.chpl
+++ b/test/modules/paths/warnUnstableStd.chpl
@@ -1,0 +1,8 @@
+module M {
+  use Path;
+
+  writeln("inside M");
+
+  testPathUnstableProc(true);
+
+}

--- a/test/modules/paths/warnUnstableStd.compopts
+++ b/test/modules/paths/warnUnstableStd.compopts
@@ -1,0 +1,2 @@
+--prepend-standard-module-dir=std  # noWarnUnstableStd.good
+--prepend-standard-module-dir=std --warn-unstable  # warnUnstableStd.good

--- a/test/modules/paths/warnUnstableStd.good
+++ b/test/modules/paths/warnUnstableStd.good
@@ -1,0 +1,6 @@
+warning: Ambiguous module source file -- using std/Path.chpl over $CHPL_HOME/modules/standard/Path.chpl
+warnUnstableStd.chpl:1: In module 'M':
+warnUnstableStd.chpl:6: warning: testPathUnstableProc is unstable
+In my personal copy of Path
+inside M
+In personal Path - unstable proc


### PR DESCRIPTION
This PR addresses an issue where modules that serve as replacements for standard or internal modules using the compiler flags `--prepend-internal-module-dir` and `--prepend-standard-module-dir` were not being marked as internal or standard like the modules they replaced. This caused some issues where adding the `--warn-unstable` flag would generate lots of messages from the usage of unstable features inside those replacement modules. 

To treat those modules appropriately, we now store a list of paths given through those compiler flags and treat modules found in those paths as either internal or standard. This will help keep the behavior similar when using replacement modules combined with the `--warn-unstable` flag.


TESTING:

- [x] paratest `[Summary: #Successes = 14793 | #Failures = 0 | #Futures = 907]`

reviewed by @dlongnecke-cray - thanks!