### PR TITLE
Fix warnings when building compiler with GCC 13

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -238,7 +238,7 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
   std::string libraries = getCompilelineOption("libraries");
   std::string libname = getLibname(name);
 
-  std::string requires = getRequireLibraries();
+  std::string requires_ = getRequireLibraries();
 
   fprintf(makefile.fptr, "CHPL_LDFLAGS = -L%s %s",
           libDir,
@@ -256,8 +256,8 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
     fprintf(makefile.fptr, " %s", deps.c_str());
   }
 
-  if (requires != "") {
-    fprintf(makefile.fptr, "%s", requires.c_str());
+  if (requires_ != "") {
+    fprintf(makefile.fptr, "%s", requires_.c_str());
   }
 
   //
@@ -315,7 +315,7 @@ static void printCMakeListsLibraries(fileinfo cmakelists, std::string name) {
   std::string libraries = getCompilelineOption("libraries");
   std::string libname = getLibname(name);
 
-  std::string requires = getRequireLibraries();
+  std::string requires_ = getRequireLibraries();
 
   varValue += "-L${CMAKE_CURRENT_LIST_DIR}";
   varValue += " ";
@@ -334,9 +334,9 @@ static void printCMakeListsLibraries(fileinfo cmakelists, std::string name) {
     varValue += deps;
   }
 
-  if (requires != "") {
+  if (requires_ != "") {
     varValue += " ";
-    varValue += requires;
+    varValue += requires_;
   }
 
   //

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1702,6 +1702,8 @@ resolveFunctionByPoisQuery(Context* context,
   return QUERY_END(result);
 }
 
+// this wrapper around resolveFunctionByPoisQuery helps to avoid
+// 'possibly dangling reference to a temporary' warnings from GCC 13.
 static const owned<ResolvedFunction>&
 resolveFunctionByPoisQueryWrapper(Context* context,
                                   const TypedFnSignature* sig,
@@ -2261,13 +2263,14 @@ filterCandidatesInitial(Context* context,
 
   return QUERY_END(result);
 }
+
+// this wrapper around filterCandidatesInitial helps to avoid
+// 'possibly dangling reference to a temporary' warnings from GCC 13.
 static const std::vector<const TypedFnSignature*>&
 filterCandidatesInitialWrapper(Context* context,
                                std::vector<BorrowedIdsWithName>&& lst,
                                const CallInfo& call) {
-  auto lstMove = std::move(lst);
-  auto callCopy = call;
-  return filterCandidatesInitial(context, lstMove, callCopy);
+  return filterCandidatesInitial(context, std::move(lst), call);
 }
 
 void

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1702,6 +1702,18 @@ resolveFunctionByPoisQuery(Context* context,
   return QUERY_END(result);
 }
 
+static const owned<ResolvedFunction>&
+resolveFunctionByPoisQueryWrapper(Context* context,
+                                  const TypedFnSignature* sig,
+                                  const PoiInfo& poiInfo) {
+  auto poiFnIdsUsedCopy = poiInfo.poiFnIdsUsed();
+  auto recursiveFnsUsedCopy = poiInfo.recursiveFnsUsed();
+
+  return resolveFunctionByPoisQuery(context, sig,
+                                    std::move(poiFnIdsUsedCopy),
+                                    std::move(recursiveFnsUsedCopy));
+}
+
 static const ResolvedFunction* const&
 resolveFunctionByInfoQuery(Context* context,
                            const TypedFnSignature* sig,
@@ -1760,9 +1772,8 @@ resolveFunctionByInfoQuery(Context* context,
                          resolvedPoiInfo.poiFnIdsUsed(),
                          resolvedPoiInfo.recursiveFnsUsed());
       auto& saved =
-        resolveFunctionByPoisQuery(context, newTfsForInitializer,
-                                   resolvedPoiInfo.poiFnIdsUsed(),
-                                   resolvedPoiInfo.recursiveFnsUsed());
+        resolveFunctionByPoisQueryWrapper(context, newTfsForInitializer,
+                                          resolvedPoiInfo);
       const ResolvedFunction* resultInit = saved.get();
       QUERY_STORE_RESULT(resolveFunctionByInfoQuery,
                          context,
@@ -1840,9 +1851,7 @@ resolveFunctionByInfoQuery(Context* context,
 
   // Return the unique result from the query (that might have been saved above)
   const owned<ResolvedFunction>& resolved =
-    resolveFunctionByPoisQuery(context, sig,
-                               resolvedPoiInfo.poiFnIdsUsed(),
-                               resolvedPoiInfo.recursiveFnsUsed());
+    resolveFunctionByPoisQueryWrapper(context, sig, resolvedPoiInfo);
 
   const ResolvedFunction* result = resolved.get();
 
@@ -2251,6 +2260,14 @@ filterCandidatesInitial(Context* context,
   }
 
   return QUERY_END(result);
+}
+static const std::vector<const TypedFnSignature*>&
+filterCandidatesInitialWrapper(Context* context,
+                               std::vector<BorrowedIdsWithName>&& lst,
+                               const CallInfo& call) {
+  auto lstMove = std::move(lst);
+  auto callCopy = call;
+  return filterCandidatesInitial(context, lstMove, callCopy);
 }
 
 void
@@ -2878,7 +2895,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
 
         // filter without instantiating yet
         const auto& initialCandidates =
-          filterCandidatesInitial(context, v, fci);
+          filterCandidatesInitialWrapper(context, std::move(v), fci);
 
         // find candidates, doing instantiation if necessary
         filterCandidatesInstantiating(context,
@@ -2914,7 +2931,8 @@ gatherAndFilterCandidatesForwarding(Context* context,
         auto v = lookupCalledExpr(context, curPoi->inScope(), fci, visited[i]);
 
         // filter without instantiating yet
-        auto& initialCandidates = filterCandidatesInitial(context, v, fci);
+        auto& initialCandidates =
+          filterCandidatesInitialWrapper(context, std::move(v), fci);
 
         // find candidates, doing instantiation if necessary
         filterCandidatesInstantiating(context,
@@ -2988,7 +3006,8 @@ gatherAndFilterCandidates(Context* context,
     auto v = lookupCalledExpr(context, inScope, ci, visited);
 
     // filter without instantiating yet
-    const auto& initialCandidates = filterCandidatesInitial(context, v, ci);
+    const auto& initialCandidates =
+      filterCandidatesInitialWrapper(context, std::move(v), ci);
 
     // find candidates, doing instantiation if necessary
     filterCandidatesInstantiating(context,
@@ -3014,7 +3033,8 @@ gatherAndFilterCandidates(Context* context,
     auto v = lookupCalledExpr(context, curPoi->inScope(), ci, visited);
 
     // filter without instantiating yet
-    const auto& initialCandidates = filterCandidatesInitial(context, v, ci);
+    const auto& initialCandidates =
+      filterCandidatesInitialWrapper(context, std::move(v), ci);
 
     // find candidates, doing instantiation if necessary
     filterCandidatesInstantiating(context,


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/4782

This PR fixes two warnings from GCC 13 (note that some build configurations use `-Werror` so these can also be fatal build errors)

* Renames some local variables from `requires` since that is a keyword in C++ 20
* Adds wrapper functions to avoid false-positive 'possibly dangling reference to a temporary' warnings. See also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108165 which seems to indicate such false positives will not be fixed. If this approach turns out to be unweildy, alternatives include disabling this warning or using a GCC-specific pragma.

Reviewed by @DanilaFe - thanks!

- [x] full local testing