### PR TITLE
Replace ":throws: Error:" with ":throws Error: "

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -766,8 +766,8 @@ module Bytes {
                   - `decodePolicy.escape` escapes each illegal byte with
                     private use codepoints
 
-    :throws: `DecodeError` if `decodePolicy.strict` is passed to the `policy`
-              argument and the :type:`bytes` contains non-UTF-8 characters.
+    :throws DecodeError: if `decodePolicy.strict` is passed to the `policy`
+            argument and the :type:`bytes` contains non-UTF-8 characters.
 
     :returns: A UTF-8 string.
   */

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -416,7 +416,7 @@ module String {
                  terminating null byte.
     :type length: `int`
 
-    :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+    :throws DecodeError: if `x` contains non-UTF-8 characters.
 
     :returns: A new `string`
   */
@@ -463,7 +463,7 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+     :throws DecodeError: if `x` contains non-UTF-8 characters.
 
      :returns: A new `string`
   */
@@ -496,7 +496,7 @@ module String {
                  terminating null byte.
     :type length: `int`
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+     :throws DecodeError: if `x` contains non-UTF-8 characters.
 
     :returns: A new `string`
   */
@@ -520,7 +520,7 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+     :throws DecodeError: if `x` contains non-UTF-8 characters.
 
      :returns: A new `string`
   */
@@ -569,8 +569,8 @@ module String {
                  - `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-    :throws: `DecodeError` if `decodePolicy.strict` is passed to the `policy`
-             argument and `x` contains non-UTF-8 characters.
+    :throws DecodeError: if `decodePolicy.strict` is passed to the `policy`
+            argument and `x` contains non-UTF-8 characters.
 
     :returns: A new `string`
   */
@@ -600,7 +600,7 @@ module String {
                    `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+     :throws DecodeError: if `x` contains non-UTF-8 characters.
 
      :returns: A new `string`
   */
@@ -1452,8 +1452,8 @@ module String {
 
     :arg r: range of the indices the new string should be made from
 
-    :throws: `CodepointSplittingError` if slicing results in splitting a
-             multi-byte codepoint.
+    :throws CodepointSplittingError: if slicing results in splitting a
+            multi-byte codepoint.
 
     :returns: a new string that is a substring within ``0..<string.size``. If
               the length of `r` is zero, an empty string is returned.

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -1046,7 +1046,7 @@ module ArgumentParser {
 
     :returns: a shared `Argument` where parsed values will be placed
 
-    :throws: ArgumentError in any of the following conditions:
+    :throws: `ArgumentError` in any of the following conditions:
 
              * `name` is already defined for this parser
              * `defaultValue` is something other than a string, array or list
@@ -1103,7 +1103,7 @@ module ArgumentParser {
 
     :returns: a shared `Argument` where parsed values will be placed
 
-    :throws: ArgumentError in any of the following conditions:
+    :throws: `ArgumentError` in any of the following conditions:
 
              * `name` is already defined for this parser
              * `defaultValue` is something other than a string, array or list
@@ -1189,7 +1189,7 @@ module ArgumentParser {
 
     :returns: a shared `Argument` where parsed values will be placed
 
-    :throws: ArgumentError in any of the following conditions:
+    :throws: `ArgumentError` in any of the following conditions:
 
              * `name` or `opts` are already defined for this parser
              * values in `opts` do not begin with a dash ``-``
@@ -1265,7 +1265,7 @@ module ArgumentParser {
 
     :returns: a shared `Argument` where parsed values will be placed
 
-    :throws: ArgumentError in any of the following conditions:
+    :throws: `ArgumentError` in any of the following conditions:
 
              * `name` or `opts` are already defined for this parser
              * values in `opts` do not begin with a dash ``-``
@@ -1361,7 +1361,7 @@ module ArgumentParser {
 
     :returns: a shared `Argument` where parsed values will be placed
 
-    :throws: ArgumentError in any of the following conditions:
+    :throws: `ArgumentError` in any of the following conditions:
 
               * `name` or `opts` are already defined for this parser
               * `numArgs` > 1
@@ -1444,7 +1444,7 @@ module ArgumentParser {
 
     :returns: a shared `Argument` where parsed values will be placed
 
-    :throws: ArgumentError in any of the following conditions:
+    :throws: `ArgumentError` in any of the following conditions:
 
              * `name` or `opts` are already defined for this parser
              * `numArgs` high-bound > 1
@@ -1541,7 +1541,7 @@ module ArgumentParser {
 
     :returns: a shared `Argument` where parsed values will be placed
 
-    :throws: ArgumentError if `cmd` is already defined for this parser
+    :throws: `ArgumentError` if `cmd` is already defined for this parser
 
     */
     proc addSubCommand(cmd:string, help="",
@@ -1575,7 +1575,7 @@ module ArgumentParser {
     :returns: a shared `Argument` where collected values will be placed for use
               by the developer
 
-    :throws: ArgumentError if `delimiter` is already defined for this parser
+    :throws: `ArgumentError` if `delimiter` is already defined for this parser
 
     */
     proc addPassThrough(delimiter="--") : shared Argument throws {
@@ -1623,9 +1623,9 @@ module ArgumentParser {
 
     :arg arguments: The array of values passed from the command line to `main(args:[]string)`
 
-    :throws: If argumentParser initialized with exitOnError=false,
-             then an ArgumentError is raised if invalid or undefined command
-             line arguments found in `arguments`
+    :throws: `ArgumentError` if argumentParser is initialized with
+             `exitOnError=false`, and invalid or undefined command line
+             arguments are found in `arguments`.
     */
     proc parseArgs(arguments:[?argsD] string) throws {
       // normal operation is to catch parsing error, write help message,

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3632,7 +3632,7 @@ private inline proc markHelper(fileRW) throws {
     memory space requirements.
 
   :returns: The offset that was marked
-  :throws: SystemError: if marking the fileReader failed
+  :throws SystemError: if marking the fileReader failed
  */
 proc fileReader.mark() throws do return markHelper(this);
 
@@ -3670,7 +3670,7 @@ proc fileReader.mark() throws do return markHelper(this);
     memory space requirements.
 
   :returns: The offset that was marked
-  :throws: SystemError: if marking the fileWriter failed
+  :throws SystemError: if marking the fileWriter failed
  */
 proc fileWriter.mark() throws do return markHelper(this);
 
@@ -3896,7 +3896,7 @@ proc fileWriter._offset():int(64) {
    discipline.
 
   :returns: The offset that was marked
-  :throws: SystemError: if marking the fileReader failed
+  :throws SystemError: if marking the fileReader failed
  */
 @deprecated(notes="fileReader._mark is deprecated - please use :proc:`fileReader.mark` instead")
 proc fileReader._mark() throws {
@@ -3915,7 +3915,7 @@ proc fileReader._mark() throws {
    discipline.
 
   :returns: The offset that was marked
-  :throws: SystemError: if marking the fileWriter failed
+  :throws SystemError: if marking the fileWriter failed
  */
 @deprecated(notes="fileWriter._mark is deprecated - please use :proc:`fileWriter.mark` instead")
 proc fileWriter._mark() throws {


### PR DESCRIPTION
This seems to be the form chpldoc is expecting that all the other modules but these use consistently, and formats the `Error` specially in the docs.