### PR TITLE
Remove opx provider

### DIFF
--- a/third-party/libfabric/Makefile
+++ b/third-party/libfabric/Makefile
@@ -17,7 +17,8 @@ endif
 CHPL_LIBFABRIC_CFG_OPTIONS += --enable-static \
                               --disable-shared \
                               --prefix=$(LIBFABRIC_INSTALL_DIR) \
-			      --enable-psm3=no
+			      --disable-psm3 \
+			      --disable-opx
 
 ifdef CHPL_COMM_DEBUG
 CHPL_LIBFABRIC_CFG_OPTIONS += --enable-debug


### PR DESCRIPTION
Don't build the `opx` provider as we don't need it and it creates a dependency on the NUMA library that isn't reflected in the `libfabric.pc` file.