### PR TITLE
Filter out `-stdlib` flags when compiling for GCC

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -737,6 +737,7 @@ def filter_llvm_config_flags(flags):
 
     platform_val = chpl_platform.get('host')
     cygwin = platform_val.startswith('cygwin')
+    darwin = platform_val.startswith('darwin')
     gnu = chpl_compiler.get('host') == 'gnu'
 
     for flag in flags:
@@ -746,7 +747,7 @@ def filter_llvm_config_flags(flags):
             flag.startswith('-O') or
             flag == '-pedantic' or
             flag == '-Wno-class-memaccess' or
-            (gnu and flag.startswith('-stdlib=')) or
+            (darwin and gnu and flag.startswith('-stdlib=')) or
             (cygwin and flag == '-std=c++14')):
             continue # filter out these flags
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -737,6 +737,7 @@ def filter_llvm_config_flags(flags):
 
     platform_val = chpl_platform.get('host')
     cygwin = platform_val.startswith('cygwin')
+    gnu = chpl_compiler.get('host') == 'gnu'
 
     for flag in flags:
         if (flag == '-DNDEBUG' or
@@ -745,6 +746,7 @@ def filter_llvm_config_flags(flags):
             flag.startswith('-O') or
             flag == '-pedantic' or
             flag == '-Wno-class-memaccess' or
+            (gnu and flag.startswith('-stdlib=')) or
             (cygwin and flag == '-std=c++14')):
             continue # filter out these flags
 


### PR DESCRIPTION
When compiling on M1 macs with the following variables (the CXX/CC overrides are needed because Apple Clang poses as `gcc`/`g++` 😠 ):

```Bash
export CHPL_HOST_CXX=/opt/homebrew/Cellar/gcc/13.1.0/bin/g++-13
export CHPL_HOST_CC=/opt/homebrew/Cellar/gcc/13.1.0/bin/gcc-13
export CHPL_HOST_COMPILER=gnu
```

CMake immediately reports that the C++ compiler cannot create executables, reporting:
```
g++-13: error: unrecognized command-line option '-stdlib=libc++'
```

I tracked this down to an option being thrown by `llvm-config`, which is always invoked nowadays due to our use of the support library. This PR attempts to fix the issue by removing `-stdlib=libc++` from the `llvm-config` flags when the host compiler is `gnu`. 

Reviewed by @mppf -- thanks!

Tested locally with M1 mac, and on paratest machine with GNU compiler.