### PR TITLE
Dyno: switch CheckedScopes to using a list of past filters instead of a single Flags filter 

### DIFF
--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -86,86 +86,27 @@ class IdAndFlags {
     FlagSet& operator=(FlagSet&& other) = default;
 
     /** Create a FlagSet consisting of only one combination of Flags. */
-    static FlagSet singleton(Flags flags) {
-      FlagSet toReturn;
-      toReturn.insert(flags);
-      return toReturn;
-    }
+    static FlagSet singleton(Flags flags);
 
     /** Create a FlagSet consisting of no flag combinations; such a set
         matches any entry. */
-    static FlagSet empty() {
-      return FlagSet();
-    }
+    static FlagSet empty();
 
     /** Add a new disjunct to the set of flag combinations. Automatically
         performs some deduplication and packing to avoid growing the set
         if possible. */
-    void insert(Flags excludeFlags) {
-      // booleans, like all lattices, follow the absorption law:
-      //
-      //     a /\ (a \/ b) = a   and   a \/ (a /\ b) = a
-      //
-      // Since Flags elements represent conjunction, if a & b = a,
-      // we know that b has all of flags in a, and maybe more. Thus,
-      // logically, b = a /\ b', where b' is the "more". But then, by the
-      // absorption law,
-      //
-      //     a \/ b = a \/ (a /\ b') = a
-      //
-      // In other words, if a & b = a, then only a needs to be in the
-      // FlagSet (which is a disjunction of flags). First try finding such a pair,
-      // so that we can keep the size of the set small.
-      for (auto& otherFlags : flagVec) {
-        if ((otherFlags & excludeFlags) == otherFlags) {
-          // excludeFlags is subsumed, we're done.
-          return;
-        }
-        if ((excludeFlags & otherFlags) == excludeFlags) {
-          // Existing entry is subsumed.
-          otherFlags = excludeFlags;
-          return;
-        }
-      }
-
-      // We didn't find a pair eligible for merging, so just insert.
-      flagVec.push_back(excludeFlags);
-    }
+    void insert(Flags excludeFlags);
 
     /* Checks if any flag combinations in the set already subsume
        the given flag combination. */
-    bool subsumes(Flags mightBeSubsumed) {
-      for (auto& otherFlags : flagVec) {
-        if ((otherFlags & mightBeSubsumed) == otherFlags) {
-          // excludeFlags is subsumed, we're done.
-          return true;
-        }
-      }
-      return false;
-    }
+    bool subsumes(Flags mightBeSubsumed) const;
 
     /** Checks that none of the or'ed flag combinations match the given flags. */
-    bool noneMatch(Flags match) const {
-      return std::all_of(flagVec.begin(), flagVec.end(), [&](auto excludeFlags) {
-        return (match & excludeFlags) != excludeFlags;
-      });
-    }
+    bool noneMatch(Flags match) const;
 
-    bool operator==(const FlagSet& other) const {
-      return flagVec == other.flagVec;
-    }
-
-    bool operator!=(const FlagSet& other) const {
-      return !(*this == other);
-    }
-
-    size_t hash() const {
-      size_t ret = 0;
-      for (auto excludeFlags : flagVec) {
-        ret = hash_combine(ret, chpl::hash(excludeFlags));
-      }
-      return ret;
-    }
+    bool operator==(const FlagSet& other) const;
+    bool operator!=(const FlagSet& other) const;
+    size_t hash() const;
   };
 
  private:

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -66,6 +66,7 @@ class IdAndFlags {
       * just IdAndFlags::METHOD_FIELD -- only methods/fields
       * IdAndFlags::PUBLIC | IdAndFlags::METHOD_FIELD --
         only public symbols that are methods/fields
+      * Empty Flags -- match everything
    */
   using Flags = uint16_t;
 
@@ -83,7 +84,7 @@ class IdAndFlags {
       That is, either any public symbol, or a private method or field.
 
       Other examples:
-        * [] (empty FlagSet) -- matches everything.
+        * [] (empty FlagSet) -- matches nothing.
         * [IdAndFlags::PUBLIC | IdAndFlags::METHOD_FIELD] --
           only public symbols that are methods / fields.
         * More generally, [f] (singleton set) --
@@ -108,7 +109,7 @@ class IdAndFlags {
     static FlagSet singleton(Flags flags);
 
     /** Create a FlagSet consisting of no flag combinations; such a set
-        matches any entry. */
+        matches nothing (the base case of OR is false). */
     static FlagSet empty();
 
     /** Add a new disjunct to the set of flag combinations. Automatically

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -114,7 +114,7 @@ class IdAndFlags {
     /** Add a new disjunct to the set of flag combinations. Automatically
         performs some deduplication and packing to avoid growing the set
         if possible. */
-    void insert(Flags excludeFlags);
+    void addDisjunction(Flags excludeFlags);
 
     /* Checks if any flag combinations in the set already subsume
        the given flag combination. */

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -107,6 +107,7 @@ class IdAndFlags {
     bool operator==(const FlagSet& other) const;
     bool operator!=(const FlagSet& other) const;
     size_t hash() const;
+    void mark(Context* context) const;
   };
 
  private:
@@ -512,6 +513,7 @@ class BorrowedIdsWithName {
     for (auto const& elt : *moreIdvs_) {
       context->markPointer(&elt.id_);
     }
+    excludeFlagSet_.mark(context);
   }
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -936,7 +936,7 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
     // Update checkedScopes to record that a search has occurred for
     // curFilter. This means subsequent searches will not look at symbols
     // that match curFilter, because those symbols would've already been found.
-    flagsInMap.insert(curFilter);
+    flagsInMap.addDisjunction(curFilter);
   }
 
   // if the scope has an extern block, note that fact.

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -895,11 +895,11 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
   if (onlyMethodsFields) {
     curFilter |= IdAndFlags::METHOD_FIELD;
   }
-  // Note: curFilter can only represent combinations of positive flags;
-  // if it extended, it might no longer be possible to represent
-  // the combinedFilter below as a single bitset.
-  // Also note: setting excludeFilter in some way other than the
+  // note: setting excludeFilter in some way other than the
   // handling below with checkedScopes will require other adjustments.
+  // This is because the updated filter in checkedScopes will be assumed to
+  // contain all the past search information, but would be missing any
+  // additional information from modifying excludeFilter manually.
 
   // goPastModules should imply checkParents; otherwise, why would we proceed
   // through module boundaries if we aren't traversing the scope chain?
@@ -933,17 +933,9 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
     // ok, we can search for curFilter but exclude what was already found
     excludeFilter = flagsInMap;
 
-    // Update checkedScopes to remove filter bits that weren't present
-    // in foundFilter (because we are going to update results
-    // with matches for the now-not-filtered-out cases).
-    // This is an approximation.
-    // Since we are storing only a single bit set, we cannot represent
-    // all combinations, e.g.:
-    //   if we had input foundFilter={PUBLIC} and curFilter={METHODS_OR_FIELDS},
-    //   we will search now for {PRIVATE,METHODS_OR_FIELDS},
-    //   but then we will have no way of recording that we have
-    //   searched {PUBLIC} U {PRIVATE,METHODS_OR_FIELDS}, which means
-    //   that a future search for {PRIVATE,NOT_METHODS_OR_FIELDS} won't work.
+    // Update checkedScopes to record that a search has occurred for
+    // curFilter. This means subsequent searches will not look at symbols
+    // that match curFilter, because those symbols would've already been found.
     flagsInMap.insert(curFilter);
   }
 

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -118,6 +118,10 @@ size_t FlagSet::hash() const {
   return ret;
 }
 
+void FlagSet::mark(Context* context) const {
+  // nothing, because flags don't need to be marked.
+}
+
 void OwnedIdsWithName::stringify(std::ostream& ss,
                                  chpl::StringifyKind stringKind) const {
   if (auto ptr = moreIdvs_.get()) {

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -58,14 +58,14 @@ FlagSet FlagSet::empty() {
 void FlagSet::insert(Flags excludeFlags) {
   // booleans, like all lattices, follow the absorption law:
   //
-  //     a /\ (a \/ b) = a   and   a \/ (a /\ b) = a
+  //     a ∧ (a ∨ b) = a   and   a ∨ (a ∧ b) = a
   //
   // Since Flags elements represent conjunction, if a & b = a,
   // we know that b has all of flags in a, and maybe more. Thus,
-  // logically, b = a /\ b', where b' is the "more". But then, by the
+  // logically, b = a ∧ b', where b' is the "more". But then, by the
   // absorption law,
   //
-  //     a \/ b = a \/ (a /\ b') = a
+  //     a ∨ b = a ∨ (a ∧ b') = a
   //
   // In other words, if a & b = a, then only a needs to be in the
   // FlagSet (which is a disjunction of flags). First try finding such a pair,

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -47,7 +47,7 @@ using FlagSet = IdAndFlags::FlagSet;
 
 FlagSet FlagSet::singleton(Flags flags) {
   FlagSet toReturn;
-  toReturn.insert(flags);
+  toReturn.addDisjunction(flags);
   return toReturn;
 }
 
@@ -55,7 +55,7 @@ FlagSet FlagSet::empty() {
   return FlagSet();
 }
 
-void FlagSet::insert(Flags excludeFlags) {
+void FlagSet::addDisjunction(Flags excludeFlags) {
   // booleans, like all lattices, follow the absorption law:
   //
   //     a ∧ (a ∨ b) = a   and   a ∨ (a ∧ b) = a

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -82,6 +82,23 @@ void FlagSet::addDisjunction(Flags excludeFlags) {
     }
   }
 
+  // Performance: another possible optimization is the detection of two disjuncts
+  // being logical negations of each other (particularly if each disjunct is
+  // a single flag). For instance, if we have
+  //
+  //    IdAndFlags::METHOD_FIELD ∨ ...
+  //
+  // And we add IdAndFlags::NOT_METHOD_FIELD. In that case, we get:
+  //
+  //    IdAndFlags::METHOD_FIELD ∨ IdAndFlags::NOT_METHOD_FIELD ∨ ...
+  //
+  // Which is logically equivalent to:
+  //
+  //    True ∨ ... = True
+  //
+  // This means we can replace the whole disjunction with a single term,
+  // True, aka the empty Flags value 0.
+
   // We didn't find a pair eligible for merging, so just insert.
   flagVec.push_back(excludeFlags);
 }

--- a/frontend/test/resolution/testScopeTypes.cpp
+++ b/frontend/test/resolution/testScopeTypes.cpp
@@ -26,35 +26,37 @@ const IdAndFlags::Flags not_pub = IdAndFlags::NOT_PUBLIC;
 const IdAndFlags::Flags method = IdAndFlags::METHOD_FIELD;
 const IdAndFlags::Flags not_method = IdAndFlags::NOT_METHOD_FIELD;
 
+using FlagSet = IdAndFlags::FlagSet;
+
 // test IdAndFlags::matchFilter
 static void testMatchFilter() {
   // no filter provided -> it matches
-  assert(IdAndFlags::matchFilter(pub, 0, 0));
-  assert(IdAndFlags::matchFilter(not_pub, 0, 0));
+  assert(IdAndFlags::matchFilter(pub, 0, FlagSet::empty()));
+  assert(IdAndFlags::matchFilter(not_pub, 0, FlagSet::empty()));
 
   // same filter as what we have -> it matches
-  assert(IdAndFlags::matchFilter(pub, pub, 0));
-  assert(IdAndFlags::matchFilter(not_pub, not_pub, 0));
+  assert(IdAndFlags::matchFilter(pub, pub, FlagSet::empty()));
+  assert(IdAndFlags::matchFilter(not_pub, not_pub, FlagSet::empty()));
 
   // no filter provided but it is excluded -> it does not match
-  assert(!IdAndFlags::matchFilter(pub, 0, pub));
-  assert(!IdAndFlags::matchFilter(not_pub, 0, not_pub));
+  assert(!IdAndFlags::matchFilter(pub, 0, FlagSet::singleton(pub)));
+  assert(!IdAndFlags::matchFilter(not_pub, 0, FlagSet::singleton(not_pub)));
 
   // test some multi-bit situations
   IdAndFlags::Flags pm = pub | method;
   IdAndFlags::Flags pf = pub | not_method;
 
-  assert(IdAndFlags::matchFilter(pm, 0, 0));
-  assert(IdAndFlags::matchFilter(pm, pub, 0));
-  assert(IdAndFlags::matchFilter(pm, method, 0));
+  assert(IdAndFlags::matchFilter(pm, 0, FlagSet::empty()));
+  assert(IdAndFlags::matchFilter(pm, pub, FlagSet::empty()));
+  assert(IdAndFlags::matchFilter(pm, method, FlagSet::empty()));
 
-  assert(!IdAndFlags::matchFilter(pm, not_pub, 0));
-  assert(!IdAndFlags::matchFilter(pm, not_method, 0));
-  assert(!IdAndFlags::matchFilter(pm, pm, pm));
-  assert(!IdAndFlags::matchFilter(pm, pm, pub));
-  assert(!IdAndFlags::matchFilter(pm, pm, method));
+  assert(!IdAndFlags::matchFilter(pm, not_pub, FlagSet::empty()));
+  assert(!IdAndFlags::matchFilter(pm, not_method, FlagSet::empty()));
+  assert(!IdAndFlags::matchFilter(pm, pm, FlagSet::singleton(pm)));
+  assert(!IdAndFlags::matchFilter(pm, pm, FlagSet::singleton(pub)));
+  assert(!IdAndFlags::matchFilter(pm, pm, FlagSet::singleton(method)));
 
-  assert(IdAndFlags::matchFilter(pm, pm, pf));
+  assert(IdAndFlags::matchFilter(pm, pm, FlagSet::singleton(pf)));
 }
 
 // test OwnedIdsWithName::borrow
@@ -70,7 +72,7 @@ static void testBorrowIds() {
     OwnedIdsWithName ids(x, Decl::PRIVATE,
                          /* method */ false, /* parenful */ false);
     assert(ids.numIds() == 1);
-    auto foundIds = ids.borrow(0, 0);
+    auto foundIds = ids.borrow(0, FlagSet::empty());
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
     assert(b.firstId() == x);
@@ -88,7 +90,7 @@ static void testBorrowIds() {
     OwnedIdsWithName ids(x, Decl::PRIVATE,
                          /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = pub;
-    IdAndFlags::Flags e = 0;
+    auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
     assert(!foundIds.hasValue());
   }
@@ -97,7 +99,7 @@ static void testBorrowIds() {
     OwnedIdsWithName ids(x, Decl::PRIVATE,
                          /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
-    IdAndFlags::Flags e = not_method;
+    auto e = FlagSet::singleton(not_method);
     auto foundIds = ids.borrow(f, e);
     assert(!foundIds.hasValue());
   }
@@ -110,7 +112,7 @@ static void testBorrowIds() {
                          /* method */ true, /* parenful */ false);
     assert(ids.numIds() == 2);
     IdAndFlags::Flags f = pub;
-    IdAndFlags::Flags e = 0;
+    auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
@@ -131,7 +133,7 @@ static void testBorrowIds() {
     ids.appendIdAndFlags(x, Decl::PRIVATE,
                          /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = IdAndFlags::PUBLIC;
-    IdAndFlags::Flags e = 0;
+    auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
@@ -152,7 +154,7 @@ static void testBorrowIds() {
     ids.appendIdAndFlags(x, Decl::PRIVATE,
                          /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
-    IdAndFlags::Flags e = 0;
+    auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
@@ -173,7 +175,7 @@ static void testBorrowIds() {
     ids.appendIdAndFlags(x, Decl::PRIVATE,
                          /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
-    IdAndFlags::Flags e = pub | method;
+    auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
@@ -194,7 +196,7 @@ static void testBorrowIds() {
     ids.appendIdAndFlags(x, Decl::PUBLIC,
                          /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
-    IdAndFlags::Flags e = pub | method;
+    auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
@@ -215,7 +217,7 @@ static void testBorrowIds() {
     ids.appendIdAndFlags(x, Decl::PUBLIC,
                          /* method */ false, /* parenful */ false);
     IdAndFlags::Flags f = 0;
-    IdAndFlags::Flags e = pub;
+    auto e = FlagSet::singleton(pub);
     auto foundIds = ids.borrow(f, e);
     assert(!foundIds.hasValue());
   }


### PR DESCRIPTION
This fixes the issue presented in https://github.com/chapel-lang/chapel/issues/22217. By using an arbitrary-length list of checked conditions, we don't have to worry about not being able to represent a particular combinations of checks.

To support the change, this introduces a new struct `FlagSet` that contains a list, and represents their logical disjunction. Combined with the fact that individual `Flags` values represent logical _conjunctions_ of their set fields, this means that `FlagSet` effectively represents a sum-of-products representation of what has been checked so far (or should be excluded).

I used an LLVM `SmallVector` to represent the list of Flags, in the hope of reducing the memory footprint. Since this PR replaces a single `int16_t` with a whole set, it does cause an increase in the sizes of `BorrowedIdsWithName` and others. It might be time to do a performance investigation.

Reviewed by @mppf -- thanks!

## Testing
- [x] full local