### PR TITLE
Bundle protobuff support into the release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ clobber: FORCE
 	cd tools/chplvis && $(MAKE) clobber
 	cd tools/c2chapel && $(MAKE) clobber
 	cd tools/mason && $(MAKE) clobber
-	cd tools/protoc-gen-chpl && $(MAKE) clobber
+	-cd tools/protoc-gen-chpl && $(MAKE) clobber
 	cd tools/chpldoc && $(MAKE) clobber
 	if [ -e doc/Makefile ]; then cd doc && $(MAKE) clobber; fi
 	rm -rf bin

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -167,7 +167,8 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     "tools/chpldoc",
     "tools/chplvis",
     "tools/c2chapel",
-    "tools/mason"
+    "tools/mason",
+    "tools/protoc-gen-chpl"
 );
 
 

--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -76,6 +76,14 @@ if ($tmpstatus != 0) then
     exit($tmpstatus)
 endif
 
+$mymake protoc-gen-chpl
+set tmpstatus = $status
+if ($tmpstatus != 0) then
+    echo "ERROR: make protoc-gen-chpl failed"
+    exit($tmpstatus)
+endif
+
+
 
 # Calculate expected version string from CMakeLists.txt
 set major=`cat CMakeLists.txt | grep 'set(CHPL_MAJOR_VERSION' | cut -f2 -d' ' | sed 's/)//g'`


### PR DESCRIPTION
The release documentation has instructions for using protobuff with Chapel that haven't worked since it was introduced because we didn't actually bundle the code into the release.  This PR does so and also adds a testRelease step to make sure it builds OK.  

In reviewing this PR, Michael pointed out that this check requires a particular version of protobuff to be available on the system doing the test.  Since we only run these tests in a small number of Jenkins configs, the plan is to merge, see if any of those break, and comment out the checks if they do.  If this check causes issues in the future, we can consider satisfying the dependence, beefing up the code to check for it, or commenting out the check then.

While here, I made the `make clobber` step for protobuff ignore failures out of a slight sense of paranoia (given that users have been bitten by it and reported it) and not seeing any real downside.  This is a little more paranoid than I usually like to be in my coding, and if someone wanted to remove it in the future, that would be fine with me.

Resolves #22136.
