### PR TITLE
Fix slurm-srun reservation tests

### DIFF
--- a/test/runtime/configMatters/launch/jhh/reservation/SKIPIF
+++ b/test/runtime/configMatters/launch/jhh/reservation/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_TEST_PERF == on

--- a/test/runtime/configMatters/launch/jhh/reservation/sub_test
+++ b/test/runtime/configMatters/launch/jhh/reservation/sub_test
@@ -10,4 +10,4 @@ pushd $CHPL_HOME
 source util/setchplenv.bash
 popd
 
-python3 reservation.py --verbose
+python3 reservation.py $@ --verbose


### PR DESCRIPTION
Added `SKIPIF` to indicate that these are not performance tests. Also made file paths in the output conform to those produced by `sub_test.py`.