### PR TITLE
Fix import validity checking to allow importing methods

### DIFF
--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1440,7 +1440,8 @@ static void errorIfNameNotInScope(Context* context,
   LookupConfig config = LOOKUP_INNERMOST |
                         LOOKUP_DECLS |
                         LOOKUP_IMPORT_AND_USE |
-                        LOOKUP_EXTERN_BLOCKS;
+                        LOOKUP_EXTERN_BLOCKS |
+                        LOOKUP_METHODS;
 
   bool got = helpLookupInScope(context, scope, {}, resolving, name, config,
                                checkedScopes, result,

--- a/test/visibility/import/enablesUnqualified/multipleUnqualified/badName-this.good
+++ b/test/visibility/import/enablesUnqualified/multipleUnqualified/badName-this.good
@@ -1,2 +1,1 @@
-badName-this.chpl:4: In module 'User':
-badName-this.chpl:5: error: cannot 'import' symbol 'this' as it is not defined in 'Foo'
+badName-this.chpl:5: error: Bad identifier, no known 'this' defined in 'Foo'


### PR DESCRIPTION
Methods can be imported, but the search function for checking if an identifier is valid to be imported didn't check for modules, leading to errors. This tweaks that setting, making sure that modules can be imported.

I'll be adding regression tests for this tomorrow, don't want the build to be broken overnight.

Reviewed by @dlongnecke-cray -- thanks!!

## Testing
- [x] paratest