### PR TITLE
Change some c_ptrTo() calls to c_addrOf() in CopyAggregation.chpl

### DIFF
--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -337,8 +337,8 @@ module CopyAggregation {
       myRSrcVals.GET(myLSrcVals, myBufferIdx);
 
       // Assign the srcVal to the dstAddrs
-      var dstAddrPtr = c_ptrTo(dstAddrs[loc][0]);
-      var srcValPtr = c_ptrTo(myLSrcVals[0]);
+      var dstAddrPtr = c_addrOf(dstAddrs[loc][0]);
+      var srcValPtr = c_addrOf(myLSrcVals[0]);
       for i in 0..<myBufferIdx {
         dstAddrPtr[i].deref() = srcValPtr[i];
       }


### PR DESCRIPTION
This addresses some failures in `test/optimizations/autoAggregation/arrTypes.chpl` that were seemingly introduced in #22165 (which introduced `c_addrOf()` and changed some behaviors of `c_ptrTo()`).

I can't currently explain why the changes are necessary and haven't tried to spend the time to get my head around them, but stumbled across the failures while doing some post-merge sanity checking of my own PR, so am filing this in hopes of reducing testing noise tonight.