### PR TITLE
Transitionally, disable opaque pointers in LLVM 15

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2827,6 +2827,11 @@ GenInfo::GenInfo()
              clangInfo(nullptr)
 #endif
 {
+#ifdef LLVM_NO_OPAQUE_POINTERS
+#if HAVE_LLVM_VER >= 150 && HAVE_LLVM_VER < 160
+  llvmContext.setOpaquePointers(false);
+#endif
+#endif
 }
 
 std::string numToString(int64_t num)

--- a/compiler/include/llvmVer.h
+++ b/compiler/include/llvmVer.h
@@ -27,9 +27,12 @@
 
 #define HAVE_LLVM_VER (LLVM_VERSION_MAJOR*10 + LLVM_VERSION_MINOR)
 
-#if HAVE_LLVM_VER < 60
+#if HAVE_LLVM_VER < 110
 #error LLVM version is too old for this version of Chapel
 #endif
+
+// TODO: remove this transitional aid
+#define LLVM_NO_OPAQUE_POINTERS 1
 
 #endif //HAVE_LLVM
 


### PR DESCRIPTION
This PR updates the Chapel compiler to request typed pointers from LLVM 15 instead of opaque pointers. This is a transitional strategy while we are migrating to LLVM 15 and the opaque pointers. Using typed pointers with LLVM 15 allows us to update calls to get the pointer element type in another way, and then existing LLVM assertions check that the type we provided is consistent with the pointer type. This mode can be disabled or removed once we have completely migrated to LLVM 15 and removed the reliance on pointer element types.

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14