### PR TITLE
Update tests to prepare for clang 15

### DIFF
--- a/test/extern/ExternBlockClangError.chpl
+++ b/test/extern/ExternBlockClangError.chpl
@@ -1,8 +1,9 @@
 extern {
-  extern void foo();
-  void bar() {
+  extern void foo(void);
+  void bar(void) {
     foo();
   }
+  void baz(a) { }
 }
 
 var globalArr : [1..1] real;

--- a/test/extern/ExternBlockClangError.chpl
+++ b/test/extern/ExternBlockClangError.chpl
@@ -3,7 +3,6 @@ extern {
   void bar(void) {
     foo();
   }
-  void baz(a) { }
 }
 
 var globalArr : [1..1] real;

--- a/test/extern/ExternBlockClangError.good
+++ b/test/extern/ExternBlockClangError.good
@@ -1,16 +1,22 @@
-ExternBlockClangError.chpl:2:18: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
-  extern void foo();
-                 ^
-                  void
 ExternBlockClangError.chpl:3:8: error: no previous prototype for function 'bar' [-Werror,-Wmissing-prototypes]
-  void bar() {
+  void bar(void) {
        ^
 ExternBlockClangError.chpl:3:3: note: declare 'static' if the function is not intended to be used outside of this translation unit
-  void bar() {
+  void bar(void) {
   ^
   static 
-ExternBlockClangError.chpl:3:11: error: this old-style function definition is not preceded by a prototype [-Werror,-Wstrict-prototypes]
-  void bar() {
-          ^
-3 errors generated.
+ExternBlockClangError.chpl:6:12: error: parameter 'a' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Werror,-Wimplicit-int]
+  void baz(a) { }
+           ^
+ExternBlockClangError.chpl:6:8: error: no previous prototype for function 'baz' [-Werror,-Wmissing-prototypes]
+  void baz(a) { }
+       ^
+ExternBlockClangError.chpl:6:3: note: declare 'static' if the function is not intended to be used outside of this translation unit
+  void baz(a) { }
+  ^
+  static 
+ExternBlockClangError.chpl:6:8: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
+  void baz(a) { }
+       ^
+4 errors generated.
 ExternBlockClangError.chpl:1: error: error running clang on extern block

--- a/test/extern/ExternBlockClangError.good
+++ b/test/extern/ExternBlockClangError.good
@@ -5,18 +5,5 @@ ExternBlockClangError.chpl:3:3: note: declare 'static' if the function is not in
   void bar(void) {
   ^
   static 
-ExternBlockClangError.chpl:6:12: error: parameter 'a' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Werror,-Wimplicit-int]
-  void baz(a) { }
-           ^
-ExternBlockClangError.chpl:6:8: error: no previous prototype for function 'baz' [-Werror,-Wmissing-prototypes]
-  void baz(a) { }
-       ^
-ExternBlockClangError.chpl:6:3: note: declare 'static' if the function is not intended to be used outside of this translation unit
-  void baz(a) { }
-  ^
-  static 
-ExternBlockClangError.chpl:6:8: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
-  void baz(a) { }
-       ^
-4 errors generated.
+1 error generated.
 ExternBlockClangError.chpl:1: error: error running clang on extern block

--- a/test/extern/bradc/externClock.c
+++ b/test/extern/bradc/externClock.c
@@ -1,6 +1,6 @@
 #include "externClock.h"
 
-clock_t get_CLOCKS_PER_SEC() {
+clock_t get_CLOCKS_PER_SEC(void) {
   return CLOCKS_PER_SEC;
 }
 

--- a/test/release/examples/primers/cHelper.c
+++ b/test/release/examples/primers/cHelper.c
@@ -3,7 +3,7 @@
 int x = 14;
 uint32_t y = 3;
 
-int baz() {
+int baz(void) {
   return x;
 }
 

--- a/test/release/examples/primers/fact.c
+++ b/test/release/examples/primers/fact.c
@@ -13,7 +13,7 @@ int fact(int x){
 
 
 
-data* getNewData(){
+data* getNewData(void){
     data *d = malloc(sizeof(data));
     d->x = 5;
     return d;
@@ -33,7 +33,7 @@ data* fact_d(data *d){
     return f;
 }
 
-data* getDataStructPtr(){
+data* getDataStructPtr(void){
     data *d = malloc(sizeof(data));
     d->x = 10;
     return d;

--- a/test/visibility/require/helperFiles/baz.c
+++ b/test/visibility/require/helperFiles/baz.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include "baz.h"
 
-void baz() {
+void baz(void) {
   printf("In baz()\n");
 }

--- a/test/visibility/require/helperFiles/foo.c
+++ b/test/visibility/require/helperFiles/foo.c
@@ -1,5 +1,5 @@
 #include "foo.h"
 
-int bar() {
+int bar(void) {
   return 2;
 }


### PR DESCRIPTION
Clang 15 gives a new warning (or error with `-Werror`) for code like `int foo(void); int foo() { }`. The `int foo()` is declaring something other than a 0-argument function and the warning has to do with that. So, this PR updates tests with C code using this pattern to avoid it in order to ease transition to LLVM 15.

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14
