### PR TITLE
Avoid relying on typed LLVM pointers in cg-expr.cpp

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -811,9 +811,9 @@ initPrimitive() {
 
   // new keyword
   prim_def(PRIM_NEW, "new", returnInfoFirst);
-  // get complex real component
+  // given a complex value, produce get a reference to the real component
   prim_def(PRIM_GET_REAL, "complex_get_real", returnInfoComplexField);
-  // get complex imag component
+  // given a complex value, produce get a reference to the imag component
   prim_def(PRIM_GET_IMAG, "complex_get_imag", returnInfoComplexField);
   // query expression primitive
   prim_def(PRIM_QUERY, "query", returnInfoUnknown);

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -811,9 +811,9 @@ initPrimitive() {
 
   // new keyword
   prim_def(PRIM_NEW, "new", returnInfoFirst);
-  // given a complex value, produce get a reference to the real component
+  // given a complex value, produce a reference to the real component
   prim_def(PRIM_GET_REAL, "complex_get_real", returnInfoComplexField);
-  // given a complex value, produce get a reference to the imag component
+  // given a complex value, produce a reference to the imag component
   prim_def(PRIM_GET_IMAG, "complex_get_imag", returnInfoComplexField);
   // query expression primitive
   prim_def(PRIM_QUERY, "query", returnInfoUnknown);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5946,7 +5946,7 @@ DEFINE_PRIM(VIRTUAL_METHOD_CALL) {
     INT_ASSERT(fn);
 
     {
-      GenRet  i           = codegenValue(call->get(2));    // the cid
+      GenRet  i          = codegenValue(call->get(2));    // the cid
       int64_t fnId       = virtualMethodMap.get(fn);
       GenRet j           = new_IntSymbol(fnId,    INT_SIZE_64);
       GenRet maxVMTConst = new_IntSymbol(gMaxVMT, INT_SIZE_64);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4176,11 +4176,15 @@ DEFINE_PRIM(ARRAY_SHIFT_BASE_POINTER) {
     GenRet addr    = call->get(2);
     GenRet shifted = codegenElementPtr(addr, call->get(3), true);
 
-    if (rv.isLVPtr != GEN_WIDE_PTR) {
-      codegenAssign(rv, codegenAddrOf(shifted));
-    } else {
-      codegenWideAddrWithAddr(rv, shifted, ret.chplType);
+    // used to have code to handle this case but it was wrong
+    INT_ASSERT(rv.isLVPtr != GEN_WIDE_PTR);
+
+    // not useful to get a reference type in this case
+    GenRet shiftedAddr = codegenAddrOf(shifted);
+    if (shiftedAddr.chplType) {
+      shiftedAddr.chplType = shiftedAddr.chplType->getValType();
     }
+    codegenAssign(rv, shiftedAddr);
 }
 
 DEFINE_PRIM(NOOP) {

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2266,8 +2266,8 @@ GenRet codegenGlobalArrayElement(const char* table_name,
 
     auto global = llvm::cast<llvm::GlobalVariable>(table.val);
     INT_ASSERT(global);
-    //GenRet eltTy = codegenTypeByName(eltTypeName);
-    //INT_ASSERT(eltTy.type);
+    GenRet eltTy = codegenTypeByName(eltTypeName);
+    INT_ASSERT(eltTy.type);
 
     llvm::Value* GEPLocs[2];
     GEPLocs[0] = llvm::Constant::getNullValue(
@@ -2279,7 +2279,7 @@ GenRet codegenGlobalArrayElement(const char* table_name,
 
 #if HAVE_LLVM_VER >= 130
     llvm::Instruction* element =
-      info->irBuilder->CreateLoad(elementPtr->getType()->getPointerElementType(), elementPtr);
+      info->irBuilder->CreateLoad(eltTy.type, elementPtr);
 #else
     llvm::Instruction* element = info->irBuilder->CreateLoad(elementPtr);
 #endif

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -1815,9 +1815,15 @@ GenRet codegenAdd(GenRet a, GenRet b)
 
       unsigned AS = ptr->val->getType()->getPointerAddressSpace();
 
+      INT_ASSERT(ptr->chplType &&
+                 ptr->chplType->symbol->hasFlag(FLAG_DATA_CLASS));
+      TypeSymbol* eltTypeSym = getDataClassType(ptr->chplType->symbol);
+      GenRet genEltType = eltTypeSym->type;
+      INT_ASSERT(genEltType.type);
       // Emit a GEP instruction to do the addition.
       ret.isUnsigned = true; // returning a pointer, consider them unsigned
-      ret.val = createInBoundsGEPCompat(ptr->val, extendToPointerSize(*i, AS));
+      ret.val = createInBoundsGEP(genEltType.type, ptr->val,
+                                  extendToPointerSize(*i, AS));
     } else {
       PromotedPair values =
         convertValuesToLarger(av.val, bv.val, a_signed, b_signed);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2787,11 +2787,10 @@ static GenRet codegenCallExprInner(GenRet function,
                 for (unsigned i = 0; i < nElts; i++) {
                   // load to produce the next LLVM argument
 #if HAVE_LLVM_VER >= 130
-                  llvm::Type* ty = llvm::cast<llvm::PointerType>(ptr->getType()->getScalarType())->getPointerElementType();
                   llvm::Value* eltPtr =
-                    irBuilder->CreateStructGEP(ty, ptr, i);
+                    irBuilder->CreateStructGEP(sTy, ptr, i);
                   llvm::Value* loaded =
-                    irBuilder->CreateLoad(eltPtr->getType()->getPointerElementType(), eltPtr);
+                    irBuilder->CreateLoad(sTy->getElementType(i), eltPtr);
 #else
                   llvm::Value* eltPtr = irBuilder->CreateStructGEP(ptr, i);
                   llvm::Value* loaded = irBuilder->CreateLoad(eltPtr);
@@ -2833,9 +2832,9 @@ static GenRet codegenCallExprInner(GenRet function,
               // load to produce the next LLVM argument
 #if HAVE_LLVM_VER >= 130
               llvm::Value* eltPtr =
-                irBuilder->CreateStructGEP(ptr->getType(), ptr, i);
+                irBuilder->CreateStructGEP(sTy, ptr, i);
               llvm::Value* loaded =
-                irBuilder->CreateLoad(eltPtr->getType()->getPointerElementType(), eltPtr);
+                irBuilder->CreateLoad(ty, eltPtr);
 #else
               llvm::Value* eltPtr = irBuilder->CreateStructGEP(ptr, i);
               llvm::Value* loaded = irBuilder->CreateLoad(eltPtr);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -655,9 +655,11 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
   GenInfo* info = gGenInfo;
 
   INT_ASSERT(valType);
+  GenRet loadValType = valType;
+  INT_ASSERT(loadValType.type);
 
 #if HAVE_LLVM_VER >= 130
-  llvm::LoadInst* ret = info->irBuilder->CreateLoad(ptr->getType()->getPointerElementType(), ptr);
+  llvm::LoadInst* ret = info->irBuilder->CreateLoad(loadValType.type, ptr);
 #else
   llvm::LoadInst* ret = info->irBuilder->CreateLoad(ptr);
 #endif

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -6015,8 +6015,7 @@ DEFINE_PRIM(INVARIANT_START) {
 #ifdef HAVE_LLVM
     GenRet ptr = codegenValue(call->get(1));
     llvm::Value* val = ptr.val;
-    llvm::Type* ty = val->getType()->getPointerElementType();
-    codegenInvariantStart(ty, val);
+    codegenInvariantStart(nullptr, val);
 #endif
   }
 }

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -1091,17 +1091,13 @@ GenRet doCodegenFieldPtr(
   AggregateType* ct = NULL;
   Type* castType = NULL;
 
-  if( special == field_normal ) {
-    INT_ASSERT(baseType);
-  }
+  INT_ASSERT(baseType);
 
-  if( baseType ) {
-    // Reduce the Chapel reference or wide reference cases
-    // to GEN_PTR or GEN_WIDE_PTR cases.
-    if (baseType->symbol->hasEitherFlag(FLAG_REF,FLAG_WIDE_REF)) {
-      base = codegenDeref(base);
-      return doCodegenFieldPtr(base, c_field_name, chpl_field_name, special);
-    }
+  // Reduce the Chapel reference or wide reference cases
+  // to GEN_PTR or GEN_WIDE_PTR cases.
+  if (baseType->symbol->hasEitherFlag(FLAG_REF,FLAG_WIDE_REF)) {
+    base = codegenDeref(base);
+    return doCodegenFieldPtr(base, c_field_name, chpl_field_name, special);
   }
 
   if( ! fLLVMWideOpt ) {
@@ -1117,27 +1113,25 @@ GenRet doCodegenFieldPtr(
     }
   }
 
-  if( baseType ) {
-    // At this point, baseType should be a record, union, class, or wide class
-    // All of these types are in the AggregateType AST node.
-    ct = toAggregateType(baseType);
-    INT_ASSERT(ct);
+  // At this point, baseType should be a record, union, class, or wide class
+  // All of these types are in the AggregateType AST node.
+  ct = toAggregateType(baseType);
+  INT_ASSERT(ct);
 
-    if ( isClass(ct) ) {
-      // ok, we have a class type. We should codegenValue
-      // to make sure we have no extra indirection.
-      base = codegenValue(base);
-    } else if ( baseType->symbol->hasFlag(FLAG_WIDE_CLASS)) {
-      // Get the local version of the class (because it has the fields)
-      base = codegenValue(base);
-      baseType = baseType->getField("addr")->typeInfo();
-      ct = toAggregateType(baseType);
-    } else {
-      // Must be a record or union type, and we must have an
-      // lvalue-ptr to one of them.
-      INT_ASSERT(isRecord(ct) || isUnion(ct));
-      INT_ASSERT( base.isLVPtr != GEN_VAL );
-    }
+  if ( isClass(ct) ) {
+    // ok, we have a class type. We should codegenValue
+    // to make sure we have no extra indirection.
+    base = codegenValue(base);
+  } else if ( baseType->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+    // Get the local version of the class (because it has the fields)
+    base = codegenValue(base);
+    baseType = baseType->getField("addr")->typeInfo();
+    ct = toAggregateType(baseType);
+  } else {
+    // Must be a record or union type, and we must have an
+    // lvalue-ptr to one of them.
+    INT_ASSERT(isRecord(ct) || isUnion(ct));
+    INT_ASSERT( base.isLVPtr != GEN_VAL );
   }
 
   // No Chapel field name? it must be special.
@@ -1209,7 +1203,7 @@ GenRet doCodegenFieldPtr(
     INT_ASSERT(ret.chplType);
     GenRet retType = ret.chplType;
 
-    if( isUnion(ct) && !ct->symbol->hasFlag(FLAG_EXTERN) && !special ) {
+    if (isUnion(ct) && !ct->symbol->hasFlag(FLAG_EXTERN) && !special) {
       // Get a pointer to the union data then cast it to the right type
       bool unused;
       llvm::Type* eltTy = nullptr;

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -1250,7 +1250,10 @@ GenRet doCodegenFieldPtr(
         llvm::Type* retTy = genEltType.type;
         INT_ASSERT(retTy);
         ret.val = info->irBuilder->CreateStructGEP(baseTy, baseValue, fieldno);
-        ret.val = info->irBuilder->CreateStructGEP(retTy, ret.val, 0);
+        llvm::StructType* sTy = llvm::cast<llvm::StructType>(baseTy);
+        INT_ASSERT(sTy);
+        llvm::Type* eltTy = sTy->getElementType(fieldno);
+        ret.val = info->irBuilder->CreateStructGEP(eltTy, ret.val, 0);
         ret.isLVPtr = GEN_VAL;
       } else {
         ret.val = info->irBuilder->CreateStructGEP(baseTy, baseValue, fieldno);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -643,7 +643,7 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
 // appropriate metadata based upon the Chapel type of ptr.
 static
 llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
-                                Type* valType = NULL,
+                                Type* valType,
                                 Type* surroundingStruct = NULL,
                                 uint64_t fieldOffset = 0,
                                 llvm::MDNode* fieldTbaaTypeDescriptor = NULL,
@@ -653,6 +653,9 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
                                 bool isLoadOfLocalVar = true)
 {
   GenInfo* info = gGenInfo;
+
+  INT_ASSERT(valType);
+
 #if HAVE_LLVM_VER >= 130
   llvm::LoadInst* ret = info->irBuilder->CreateLoad(ptr->getType()->getPointerElementType(), ptr);
 #else

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5851,7 +5851,8 @@ DEFINE_PRIM(FTABLE_CALL) {
 
       GEPLocs[0] = llvm::Constant::getNullValue(llvm::IntegerType::getInt64Ty(gGenInfo->module->getContext()));
       GEPLocs[1] = index.val;
-      fnPtrPtr   = createInBoundsGEPCompat(ftable.val, GEPLocs);
+      fnPtrPtr   = createInBoundsGEP(global->getValueType(),
+                                     ftable.val, GEPLocs);
 #if HAVE_LLVM_VER >= 130
       fnPtr      = gGenInfo->irBuilder->CreateLoad(genericFnPtr, fnPtrPtr);
 #else

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -4049,7 +4049,18 @@ static GenRet codegenCallStaticAddress(CallExpr* call) {
             INT_ASSERT(ptr);
             llvm::Type* ptrTy = ptr->getType();
             INT_ASSERT(ptrTy && ptrTy->isPointerTy());
-            llvm::Type* eltTy = ptrTy->getPointerElementType();
+
+            llvm::Type* eltTy = nullptr;
+            llvm::AllocaInst* locVar = llvm::dyn_cast<llvm::AllocaInst>(ptr);
+            llvm::GlobalValue* globVar = llvm::dyn_cast<llvm::GlobalValue>(ptr);
+            if (locVar) {
+              eltTy = locVar->getAllocatedType();
+            }
+            if (globVar) {
+              eltTy = globVar->getValueType();
+            }
+            INT_ASSERT(eltTy);
+
             codegenInvariantStart(eltTy, ptr);
           }
         }

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1403,7 +1403,7 @@ void TypeSymbol::codegenDef() {
       USR_FATAL(this, "Could not find C type for %s", cname);
     }
 
-    llvmImplType = type;
+    if (llvmImplType == nullptr) llvmImplType = type;
     if(debug_info) debug_info->get_type(this->type);
 #endif
   }

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -427,6 +427,7 @@ void AggregateType::codegenDef() {
         for_fields(field, this) {
           if (field->type != dtNothing && field->type != dtVoid) {
             nonVoidFields++;
+            break;
           }
         }
 
@@ -558,7 +559,7 @@ void AggregateType::codegenPrototype() {
 
       llvm::PointerType* pt = llvm::PointerType::getUnqual(st);
       info->lvt->addGlobalType(symbol->cname, pt, false);
-      symbol->llvmImplType = pt;
+      symbol->llvmImplType = st;
 #endif
     }
   }

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -529,7 +529,6 @@ genSubclassArray(bool isHeader) {
 
 // Returns the type, in .c or .type field, for the passed name.
 // The type_name typically refers to something defined in the runtime.
-static
 GenRet codegenTypeByName(const char* type_name)
 {
   GenInfo* info = gGenInfo;

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -177,6 +177,7 @@ GenRet codegenCallExpr(const char* fnName, GenRet a1);
 GenRet codegenCallExpr(const char* fnName, GenRet a1, GenRet a2);
 Type* getNamedTypeDuringCodegen(const char* name);
 void gatherTypesForCodegen(void);
+GenRet codegenTypeByName(const char* type_name);
 
 void registerPrimitiveCodegens();
 

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -86,6 +86,12 @@ extern GenRet baseASTCodegenString(const char* str);
    BaseAST* (code generate some Chapel thing)
    const char* (generate a string)
    int (generate an int)
+     TODO: stop change these to explicit ->codegen() calls
+
+   In a GenRet value, there is also a .chplType field that stores the relevant
+   Chapel type. In the case that isLVPtr is some sort of pointer (GEN_PTR or
+   GEN_WIDE_PTR), then the value is expected to be a pointer (or wide
+   pointer/wide reference) and .chplType is the element type of that pointer.
 
  */
 class GenRet {

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -86,7 +86,8 @@ extern GenRet baseASTCodegenString(const char* str);
    BaseAST* (code generate some Chapel thing)
    const char* (generate a string)
    int (generate an int)
-     TODO: stop change these to explicit ->codegen() calls
+     TODO: change these to explicit ->codegen() calls and remove the
+           implicit conversion
 
    In a GenRet value, there is also a .chplType field that stores the relevant
    Chapel type. In the case that isLVPtr is some sort of pointer (GEN_PTR or

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -80,5 +80,7 @@ void llvmAddAttr(llvm::LLVMContext& ctx, llvm::AttributeList& attrs,
 
 void llvmAttachStructRetAttr(llvm::AttrBuilder& b, llvm::Type* returnTy);
 
+bool isOpaquePointer(llvm::Type* ty);
+
 #endif //HAVE_LLVM
 #endif //LLVMUTIL_H

--- a/compiler/include/llvmVer.h
+++ b/compiler/include/llvmVer.h
@@ -31,8 +31,29 @@
 #error LLVM version is too old for this version of Chapel
 #endif
 
-// TODO: remove this transitional aid
+// TODO: this is transitional -- stop setting LLVM_NO_OPAQUE_POINTERS when ready
 #define LLVM_NO_OPAQUE_POINTERS 1
+
+// define HAVE_LLVM_TYPED_POINTERS if the LLVM version / configuration
+// allows typed pointers (and leave it undefined if only opaque pointers
+// are available).
+#if HAVE_LLVM_VER < 150
+// always use typed pointers for LLVM 11, 12, 13, 14
+#define HAVE_LLVM_TYPED_POINTERS 1
+#else
+// HAVE_LLVM_VER >= 150
+
+#if HAVE_LLVM_VER >= 160
+// LLVM 16 has untested typed pointer support
+// LLVM 17 and newer have no typed pointer support
+#else
+// for LLVM 15, we can opt into typed pointers with LLVM_NO_OPAQUE_POINTERS
+#ifdef LLVM_NO_OPAQUE_POINTERS
+#define HAVE_LLVM_TYPED_POINTERS 1
+#endif // LLVM_NO_OPAQUE_POINTERS
+#endif // else (HAVE_LLVM_VER<160)
+
+#endif // else (HAVE_LLVM_VER>=150)
 
 #endif //HAVE_LLVM
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3054,6 +3054,7 @@ void LayeredValueTable::addGlobalValue(
   store.u.value = value;
   store.isLVPtr = isLVPtr;
   store.isUnsigned = isUnsigned;
+  store.chplType = type;
   (layers.back())[name] = store;
 }
 

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -626,5 +626,13 @@ void llvmAttachStructRetAttr(llvm::AttrBuilder& b, llvm::Type* returnTy) {
   #endif
 }
 
+bool isOpaquePointer(llvm::Type* ty) {
+#if HAVE_LLVM_VER >= 140
+  return ty->isOpaquePointerTy();
+#else
+  return false; // older LLVMs did not have opaque pointers
+#endif
+}
+
 #endif
 


### PR DESCRIPTION
This PR is focused on removing cases where cg-expr.cpp was relying on typed pointers (since LLVM 15 and future versions use opaque pointers). Generally speaking, it accomplished that by separately computing the relevant type. In some cases, I relied on computing the value type for a GlobalVariable or AllocaInst, since the types are available in those cases as well and that case is relatively common.

This PR also fixes some problems with `getLLVMStructureType` where it was still storing the pointer type in some cases (follow-up to PR #21376), and it updates the ternary expression computation to keep class types as pointers (follow-up to PR #21394 -- AFAIK the use of `getLLVMStructureType` was still returning the pointer type for classes before this PR).

Future Work:
 * The LLVM backend includes a lot of implicit conversion code that makes this kind of effort more challenging. Historically speaking, these were enabled in order to have the LLVM backend match the C backend in terms of capabilities. It would be much nicer if the implicit conversions were all handled at the Chapel AST level before code generation begins -- or, if they are artifacts of LLVM it could be handled at the time something is generated with an odd type (e.g. LLVM comparisons produce `i1` but when code generating a comparison we could convert that to `i8` to match the `bool` type).

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14
- [x] comm=gasnet testing with LLVM 14