### PR TITLE
Gpu atomics

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -37,21 +37,21 @@ module GPU
   use CTypes;
   use ChplConfig;
 
-  pragma "no doc"
   pragma "codegen for CPU and GPU"
+  @chpldoc.nodoc
   extern proc chpl_gpu_write(const str : c_string) : void;
 
-  pragma "no doc"
   pragma "codegen for CPU and GPU"
+  @chpldoc.nodoc
   extern proc chpl_gpu_clock() : uint;
 
-  pragma "no doc"
   pragma "codegen for CPU and GPU"
+  @chpldoc.nodoc
   extern proc chpl_gpu_printTimeDelta(
     msg : c_string, start : uint, stop : uint) : void;
 
-  pragma "no doc"
   pragma "codegen for CPU and GPU"
+  @chpldoc.nodoc
   extern proc chpl_gpu_device_clock_rate(devNum : int(32)) : uint;
 
   /*
@@ -123,7 +123,7 @@ module GPU
     print the time elapsed between subsequent calls to 'gpuClock()'.
     To convert to seconds divide by 'gpuClocksPerSec()'
   */
-  pragma "no doc"
+  @chpldoc.nodoc
   proc gpuPrintTimeDelta(msg : c_string, start : uint, stop : uint) : void {
     chpl_gpu_printTimeDelta(msg, start, stop);
   }
@@ -136,7 +136,7 @@ module GPU
     return chpl_gpu_device_clock_rate(devNum : int(32));
   }
 
-  pragma "no doc"
+  @chpldoc.nodoc
   type GpuAsyncCommHandle = c_void_ptr;
 
   /*
@@ -146,7 +146,7 @@ module GPU
     Returns a handle that can be passed to `waitGpuComm` to pause execution
     until completion of this asynchronous transfer
   */
-  pragma "no doc"
+  @chpldoc.nodoc
   proc asyncGpuComm(dstArr : ?t1, srcArr : ?t2) : GpuAsyncCommHandle
     where isArrayType(t1) && isArrayType(t2)
   {
@@ -165,7 +165,7 @@ module GPU
      Wait for communication to complete, the handle passed in should be from the return
      value of a previous call to `asyncGpuComm`.
   */
-  pragma "no doc"
+  @chpldoc.nodoc
   proc gpuCommWait(gpuHandle : GpuAsyncCommHandle) {
     extern proc chpl_gpu_comm_wait(stream : c_void_ptr);
 
@@ -201,7 +201,7 @@ module GPU
     __primitive("gpu set blockSize", blockSize);
   }
 
-  pragma "no doc"
+  @chpldoc.nodoc
   proc canAccessPeer(loc1 : locale, loc2 : locale) : bool {
     extern proc chpl_gpu_can_access_peer(i : c_int, j : c_int) : bool;
 
@@ -213,7 +213,7 @@ module GPU
     return chpl_gpu_can_access_peer(loc1Sid, loc2Sid);
   }
 
-  pragma "no doc"
+  @chpldoc.nodoc
   proc setPeerAccess(loc1 : locale, loc2 : locale, shouldEnable : bool) {
     extern proc chpl_gpu_set_peer_access(
       i : c_int, j : c_int, shouldEnable : bool) : void;
@@ -341,17 +341,26 @@ module GPU
     chpl_atomicTernOp(c_ptrTo(x), cmp, val);
   }
 
-  // I think to get any of this to work I'll need
-  // https://github.com/chapel-lang/chapel/issues/22114 to be resolved.
-  proc gpuAtomicAdd(  ref x : ?T, val : T) : void { gpuAtomicBinOp("add", x, val); }
-  proc gpuAtomicSub(  ref x : ?T, val : T) : void { gpuAtomicBinOp("sub", x, val); }
-  proc gpuAtomicExch( ref x : ?T, val : T) : void { gpuAtomicBinOp("exch", x, val); }
-  proc gpuAtomicMin(  ref x : ?T, val : T) : void { gpuAtomicBinOp("min", x, val); }
-  proc gpuAtomicMax(  ref x : ?T, val : T) : void { gpuAtomicBinOp("max", x, val); }
-  proc gpuAtomicInc(  ref x : ?T, val : T) : void { gpuAtomicBinOp("inc", x, val); }
-  proc gpuAtomicDec(  ref x : ?T, val : T) : void { gpuAtomicBinOp("dec", x, val); }
-  proc gpuAtomicAnd(  ref x : ?T, val : T) : void { gpuAtomicBinOp("and", x, val); }
-  proc gpuAtomicOr(   ref x : ?T, val : T) : void { gpuAtomicBinOp("or", x, val); }
-  proc gpuAtomicXor(  ref x : ?T, val : T) : void { gpuAtomicBinOp("xor", x, val); }
-  proc gpuAtomicCAS(  ref x : ?T, cmp : T, val : T) : void { gpuAtomicTernOp("CAS", x, cmp, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicAdd(  ref x : ?T, val : T) : void { gpuAtomicBinOp("add", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicSub(  ref x : ?T, val : T) : void { gpuAtomicBinOp("sub", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicExch( ref x : ?T, val : T) : void { gpuAtomicBinOp("exch", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicMin(  ref x : ?T, val : T) : void { gpuAtomicBinOp("min", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicMax(  ref x : ?T, val : T) : void { gpuAtomicBinOp("max", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicInc(  ref x : ?T, val : T) : void { gpuAtomicBinOp("inc", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicDec(  ref x : ?T, val : T) : void { gpuAtomicBinOp("dec", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicAnd(  ref x : ?T, val : T) : void { gpuAtomicBinOp("and", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicOr(   ref x : ?T, val : T) : void { gpuAtomicBinOp("or", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicXor(  ref x : ?T, val : T) : void { gpuAtomicBinOp("xor", x, val); }
+  @chpldoc.nodoc
+  inline proc gpuAtomicCAS(  ref x : ?T, cmp : T, val : T) : void { gpuAtomicTernOp("CAS", x, cmp, val); }
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -313,7 +313,7 @@ module GPU
   private proc checkValidGpuAtomicOp(param opName, param rtFuncName, type T) param {
     if CHPL_GPU_CODEGEN == "rocm" && invalidGpuAtomicOpForRocm(rtFuncName) then
       compilerError("Chapel does not support atomic ", opName, " operation on type ", T : string,
-        " when using the rocm runtime.");
+        " when using 'CHPL_GPU=amd'.");
 
     if(!validGpuAtomicOp(rtFuncName)) then
       compilerError("Chapel does not support atomic ", opName, " operation on type ", T : string, ".");

--- a/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cuda/chpl-gpu-gen-includes.h
@@ -138,6 +138,70 @@ __device__ static inline uint32_t chpl_gpu_getGridDimX()   { return __nvvm_read_
 __device__ static inline uint32_t chpl_gpu_getGridDimY()   { return __nvvm_read_ptx_sreg_nctaid_y(); }
 __device__ static inline uint32_t chpl_gpu_getGridDimZ()   { return __nvvm_read_ptx_sreg_nctaid_z(); }
 
+// =================
+// Atomic Operations
+// =================
+
+#define GPU_2OP_ATOMIC(T, runtime_name, cuda_name)           \
+  __device__ static inline void runtime_name(T *x, T val) {  \
+    cuda_name(x, val);                                       \
+  }                                                          \
+  __host__ static inline void runtime_name(T *x, T val) {}
+
+#define GPU_3OP_ATOMIC(T, runtime_name, cuda_name)                   \
+  __device__ static inline void runtime_name(T *x, T val1, T val2) { \
+    cuda_name(x, val1, val2);                                        \
+  }                                                                  \
+  __host__ static inline void runtime_name(T *x, T val1, T val2) {}
+
+GPU_2OP_ATOMIC(int,                chpl_gpu_atomic_add_int,       atomicAdd);
+GPU_2OP_ATOMIC(unsigned int,       chpl_gpu_atomic_add_uint,      atomicAdd);
+GPU_2OP_ATOMIC(unsigned long long, chpl_gpu_atomic_add_ulonglong, atomicAdd);
+GPU_2OP_ATOMIC(float,              chpl_gpu_atomic_add_float,     atomicAdd);
+GPU_2OP_ATOMIC(double,             chpl_gpu_atomic_add_double,    atomicAdd);
+
+GPU_2OP_ATOMIC(int,          chpl_gpu_atomic_sub_int,  atomicSub);
+GPU_2OP_ATOMIC(unsigned int, chpl_gpu_atomic_sub_uint, atomicSub);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_exch_int,       atomicExch);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_exch_uint,      atomicExch);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_exch_ulonglong, atomicExch);
+GPU_2OP_ATOMIC(float,                  chpl_gpu_atomic_exch_float,     atomicExch);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_min_int,       atomicMin);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_min_uint,      atomicMin);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_min_ulonglong, atomicMin);
+GPU_2OP_ATOMIC(long long int,          chpl_gpu_atomic_min_longlong,  atomicMin);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_max_int,       atomicMax);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_max_uint,      atomicMax);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_max_ulonglong, atomicMax);
+GPU_2OP_ATOMIC(long long int,          chpl_gpu_atomic_max_longlong,  atomicMax);
+
+GPU_2OP_ATOMIC(unsigned int, chpl_gpu_atomic_inc_uint, atomicInc);
+
+GPU_2OP_ATOMIC(unsigned int, chpl_gpu_atomic_dec_uint, atomicDec);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_and_int,       atomicAnd);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_and_uint,      atomicAnd);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_and_ulonglong, atomicAnd);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_or_int,       atomicOr);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_or_uint,      atomicOr);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_or_ulonglong, atomicOr);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_xor_int,       atomicXor);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_xor_uint,      atomicXor);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_xor_ulonglong, atomicXor);
+
+GPU_3OP_ATOMIC(int,                    chpl_gpu_atomic_CAS_int,       atomicCAS);
+GPU_3OP_ATOMIC(unsigned int,           chpl_gpu_atomic_CAS_uint,      atomicCAS);
+GPU_3OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_CAS_ulonglong, atomicCAS);
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700)
+GPU_3OP_ATOMIC(unsigned short int,     chpl_gpu_atomic_CAS_ushort, atomicCAS);
+#endif
+
 #endif // HAS_GPU_LOCALE
 
 #endif // _CHPL_GPU_GEN_INCLUDES_H

--- a/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/rocm/chpl-gpu-gen-includes.h
@@ -139,6 +139,71 @@ __device__ static inline uint32_t chpl_gpu_getGridDimZ()   {
   return __builtin_amdgcn_grid_size_z() / chpl_gpu_getBlockDimZ();
 }
 
+// =================
+// Atomic Operations
+// =================
+
+#define GPU_2OP_ATOMIC(T, runtime_name, rocm_name)           \
+  __device__ static inline void runtime_name(T *x, T val) {  \
+    rocm_name(x, val);                                       \
+  }                                                          \
+  __host__ static inline void runtime_name(T *x, T val) {}
+
+#define GPU_3OP_ATOMIC(T, runtime_name, rocm_name)                   \
+  __device__ static inline void runtime_name(T *x, T val1, T val2) { \
+    rocm_name(x, val1, val2);                                        \
+  }                                                                  \
+  __host__ static inline void runtime_name(T *x, T val1, T val2) {}
+
+// Some atomic operations are only supported in CUDA while others are only
+// supported in ROCM. We mark the operations that are unsupported for this
+// header's SDK with [*]:
+
+GPU_2OP_ATOMIC(int,                chpl_gpu_atomic_add_int,       atomicAdd);
+GPU_2OP_ATOMIC(unsigned int,       chpl_gpu_atomic_add_uint,      atomicAdd);
+GPU_2OP_ATOMIC(unsigned long long, chpl_gpu_atomic_add_ulonglong, atomicAdd);
+GPU_2OP_ATOMIC(float,              chpl_gpu_atomic_add_float,     atomicAdd);
+GPU_2OP_ATOMIC(double,             chpl_gpu_atomic_add_double,    atomicAdd);
+
+GPU_2OP_ATOMIC(int,          chpl_gpu_atomic_sub_int,  atomicSub);
+GPU_2OP_ATOMIC(unsigned int, chpl_gpu_atomic_sub_uint, atomicSub);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_exch_int,       atomicExch);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_exch_uint,      atomicExch);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_exch_ulonglong, atomicExch);
+GPU_2OP_ATOMIC(float,                  chpl_gpu_atomic_exch_float,     atomicExch);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_min_int,       atomicMin);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_min_uint,      atomicMin);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_min_ulonglong, atomicMin);
+// [*] GPU_2OP_ATOMIC(long long int,          chpl_gpu_atomic_min_longlong,  atomicMin);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_max_int,       atomicMax);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_max_uint,      atomicMax);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_max_ulonglong, atomicMax);
+// [*] GPU_2OP_ATOMIC(long long int,          chpl_gpu_atomic_max_longlong,  atomicMax);
+
+GPU_2OP_ATOMIC(unsigned int, chpl_gpu_atomic_inc_uint, atomicInc);
+
+GPU_2OP_ATOMIC(unsigned int, chpl_gpu_atomic_dec_uint, atomicDec);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_and_int,       atomicAnd);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_and_uint,      atomicAnd);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_and_ulonglong, atomicAnd);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_or_int,       atomicOr);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_or_uint,      atomicOr);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_or_ulonglong, atomicOr);
+
+GPU_2OP_ATOMIC(int,                    chpl_gpu_atomic_xor_int,       atomicXor);
+GPU_2OP_ATOMIC(unsigned int,           chpl_gpu_atomic_xor_uint,      atomicXor);
+GPU_2OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_xor_ulonglong, atomicXor);
+
+GPU_3OP_ATOMIC(int,                    chpl_gpu_atomic_CAS_int,       atomicCAS);
+GPU_3OP_ATOMIC(unsigned int,           chpl_gpu_atomic_CAS_uint,      atomicCAS);
+GPU_3OP_ATOMIC(unsigned long long int, chpl_gpu_atomic_CAS_ulonglong, atomicCAS);
+// [*] GPU_3OP_ATOMIC(unsigned short int,     chpl_gpu_atomic_CAS_ushort, atomicCAS);
+
 #endif // HAS_GPU_LOCALE
 
 #endif // _CHPL_GPU_GEN_INCLUDES_H

--- a/test/gpu/native/atomics.chpl
+++ b/test/gpu/native/atomics.chpl
@@ -28,7 +28,7 @@ proc check(orig, gpuRes, cpuRes, s) {
     writeln(s + " resulted in kernel launch");
 
   // To get this to work we'll need to resolve https://github.com/chapel-lang/chapel/issues/22114
-  /*var isCorrect = true;
+  var isCorrect = true;
   for (x,y) in zip(gpuRes,cpuRes) do isCorrect &= isclose(x,y);
   var printVals = false;
   if !isCorrect {
@@ -42,20 +42,27 @@ proc check(orig, gpuRes, cpuRes, s) {
     writeln("input values: ", orig);
     writeln("gpu result: ", gpuRes);
     writeln("cpu result: ", cpuRes);
-  }*/
+  }
 
   resetGpuDiagnostics();
   startGpuDiagnostics();
 }
 
 proc runTest(param op : string, type T) {
-  var origVals : 3*T;
-  var gpuVals  : 3*T;
-  var cpuVals  : 3*T;
+  stopGpuDiagnostics();
+
+  var origVals : [0..2] T;
+  var gpuVals  : [0..2] T;
+  var cpuVals  : [0..2] T;
   var rng = createRandomStream(eltType=T, parSafe=false);
-  for i in 0..2 do origVals[i] = rng.getNext();
-  gpuVals = origVals;
-  cpuVals = origVals;
+  for i in 0..2 {
+    origVals[i] = rng.getNext();
+    gpuVals[i] = origVals[i];
+    cpuVals[i] = origVals[i];
+  }
+
+  resetGpuDiagnostics();
+  startGpuDiagnostics();
 
   // It would be better if we could pass 'runTest' the gpu and cpu functions
   // that we want to test as first class functions instead of having this

--- a/test/gpu/native/atomics.chpl
+++ b/test/gpu/native/atomics.chpl
@@ -1,0 +1,147 @@
+use GPU, CTypes, GpuDiagnostics, Types, Random;
+
+config const verbose = false;
+
+// CPU versions of associated GPU functions. These aren't actually atomic but
+// just used for test verification:
+proc cpuAtomicAdd (ref x : ?T, val : T) : void { x += val; }
+proc cpuAtomicSub (ref x : ?T, val : T) : void { x -= val; }
+proc cpuAtomicExch(ref x : ?T, val : T) : void { x = val; }
+proc cpuAtomicMin (ref x : ?T, val : T) : void { x = min(x, val); }
+proc cpuAtomicMax (ref x : ?T, val : T) : void { x = max(x, val); }
+proc cpuAtomicInc (ref x : ?T, val : T) : void { x = if x >= val then 0:T else x + 1; }
+proc cpuAtomicDec (ref x : ?T, val : T) : void { x = if x == 0:T || x > val then val else x-1; }
+proc cpuAtomicAnd (ref x : ?T, val : T) : void { x &= val; }
+proc cpuAtomicOr  (ref x : ?T, val : T) : void { x |= val; }
+proc cpuAtomicXor (ref x : ?T, val : T) : void { x ^= val; }
+proc cpuAtomicCAS (ref x : ?T, cmp : T, val : T) : void { x = if x == cmp then val else x; }
+
+proc check(orig, gpuRes, cpuRes, s) {
+  stopGpuDiagnostics();
+  const nLaunch = getGpuDiagnostics()[0].kernel_launch;
+
+  if nLaunch !=1 then
+    writeln(s + " didn't result in correct number of kernel launches. " +
+            nLaunch:string + " launches detected.");
+  else if verbose then
+    writeln(s + " resulted in kernel launch");
+
+  // To get this to work we'll need to resolve https://github.com/chapel-lang/chapel/issues/22114
+  /*var isCorrect = true;
+  for (x,y) in zip(gpuRes,cpuRes) do isCorrect &= isclose(x,y);
+  var printVals = false;
+  if !isCorrect {
+    writeln(s + " computed wrong result. ");
+    printVals = true;
+  } else if verbose {
+    writeln(s + " computed right result. ");
+    printVals = true;
+  }
+  if(printVals) {
+    writeln("input values: ", orig);
+    writeln("gpu result: ", gpuRes);
+    writeln("cpu result: ", cpuRes);
+  }*/
+
+  resetGpuDiagnostics();
+  startGpuDiagnostics();
+}
+
+proc runTest(param op : string, type T) {
+  var origVals : 3*T;
+  var gpuVals  : 3*T;
+  var cpuVals  : 3*T;
+  var rng = createRandomStream(eltType=T, parSafe=false);
+  for i in 0..2 do origVals[i] = rng.getNext();
+  gpuVals = origVals;
+  cpuVals = origVals;
+
+  // It would be better if we could pass 'runTest' the gpu and cpu functions
+  // that we want to test as first class functions instead of having this
+  // repetitive switchyard. Alas, those functions are generic so (as of today)
+  // can not be captured as FCF.
+  select(op) {
+    when "add" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicAdd(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicAdd(cpuVals[0],  cpuVals[1]);
+    }
+    when "sub" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicSub(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicSub(cpuVals[0],  cpuVals[1]);
+    }
+    when "exch" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicExch(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicExch(cpuVals[0],  cpuVals[1]);
+    }
+    when "min" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicMin(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicMin(cpuVals[0],  cpuVals[1]);
+    }
+    when "max" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicMax(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicMax(cpuVals[0],  cpuVals[1]);
+    }
+    when "inc" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicInc(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicInc(cpuVals[0],  cpuVals[1]);
+    }
+    when "dec" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicDec(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicDec(cpuVals[0],  cpuVals[1]);
+    }
+    when "and" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicAnd(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicAnd(cpuVals[0],  cpuVals[1]);
+    }
+    when "or" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicOr(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicOr(cpuVals[0],  cpuVals[1]);
+    }
+    when "xor" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicXor(gpuVals[0],  gpuVals[1]); }
+      cpuAtomicXor(cpuVals[0],  cpuVals[1]);
+    }
+    when "CAS" {
+      foreach n in 0..0 { assertOnGpu(); gpuAtomicCAS(gpuVals[0],  gpuVals[1], gpuVals[2]); }
+      cpuAtomicCAS(cpuVals[0],  cpuVals[1], cpuVals[2]);
+    }
+  }
+  check(origVals, gpuVals, cpuVals, op);
+}
+
+proc main() {
+  on here.gpus[0] {
+    startGpuDiagnostics();
+
+    runTest("add", c_int);   runTest("add", c_uint);  runTest("add", c_ulonglong);
+    runTest("add", c_float); runTest("add", c_double);
+
+    runTest("sub", c_int); runTest("sub", c_uint);
+
+    runTest("exch", c_int); runTest("exch", c_uint); runTest("exch", c_ulonglong);
+    runTest("exch", c_float);
+
+    runTest("min", c_int); runTest("min", c_uint); runTest("min", c_ulonglong);
+    runTest("min", c_longlong);
+
+    runTest("max", c_int); runTest("max", c_uint); runTest("max", c_ulonglong);
+    runTest("max", c_longlong);
+
+    runTest("inc", c_uint);
+
+    runTest("dec", c_uint);
+
+    runTest("and", c_int); runTest("and", c_uint); runTest("and", c_ulonglong);
+
+    runTest("or", c_int); runTest("or", c_uint); runTest("or", c_ulonglong);
+
+    runTest("xor", c_int); runTest("xor", c_uint); runTest("xor", c_ulonglong);
+
+    runTest("CAS", c_int); runTest("CAS", c_uint); runTest("CAS", c_ulonglong);
+
+    // Before adding support for this I would want better capabilities
+    // to process CHPL_GPU (this is only supported when compiling for
+    // CUDA with CC >= 7.0
+    // runTest("CAS", c_ushort); 
+  }
+}

--- a/test/gpu/native/atomics.chpl
+++ b/test/gpu/native/atomics.chpl
@@ -1,9 +1,10 @@
 use GPU, CTypes, GpuDiagnostics, Types, Random;
 
 config const verbose = false;
+config param excludeForRocm;
 
 // CPU versions of associated GPU functions. These aren't actually atomic but
-// just used for test verification:
+// are used for test verification:
 proc cpuAtomicAdd (ref x : ?T, val : T) : void { x += val; }
 proc cpuAtomicSub (ref x : ?T, val : T) : void { x -= val; }
 proc cpuAtomicExch(ref x : ?T, val : T) : void { x = val; }
@@ -113,35 +114,46 @@ proc main() {
   on here.gpus[0] {
     startGpuDiagnostics();
 
-    runTest("add", c_int);   runTest("add", c_uint);  runTest("add", c_ulonglong);
-    runTest("add", c_float); runTest("add", c_double);
+    runTest("add", c_int);  runTest("add", c_uint);  runTest("add", c_float);
+    if(!excludeForRocm) {
+      runTest("add", c_ulonglong);  runTest("add", c_double);
+    }
 
-    runTest("sub", c_int); runTest("sub", c_uint);
+    runTest("sub", c_int);  runTest("sub", c_uint);
 
-    runTest("exch", c_int); runTest("exch", c_uint); runTest("exch", c_ulonglong);
-    runTest("exch", c_float);
+    runTest("exch", c_int);  runTest("exch", c_uint);  runTest("exch", c_float);
+    /*if !excludeForRocm then */runTest("exch", c_ulonglong);
 
-    runTest("min", c_int); runTest("min", c_uint); runTest("min", c_ulonglong);
-    runTest("min", c_longlong);
+    runTest("min", c_int);  runTest("min", c_uint);
+    if !excludeForRocm then runTest("min", c_ulonglong);
+    // This is not listed as supported in the ROCM (5.5) documentation:
+    if(!excludeForRocm) then runTest("min", c_longlong);
 
-    runTest("max", c_int); runTest("max", c_uint); runTest("max", c_ulonglong);
-    runTest("max", c_longlong);
+    runTest("max", c_int); runTest("max", c_uint);
+    if !excludeForRocm then runTest("max", c_ulonglong);
+    // This is not listed as supported in the ROCM (5.5) documentation:
+    if !excludeForRocm then runTest("max", c_longlong);
 
     runTest("inc", c_uint);
 
     runTest("dec", c_uint);
 
-    runTest("and", c_int); runTest("and", c_uint); runTest("and", c_ulonglong);
+    runTest("and", c_int); runTest("and", c_uint);
+    if !excludeForRocm then runTest("and", c_ulonglong);
 
-    runTest("or", c_int); runTest("or", c_uint); runTest("or", c_ulonglong);
+    runTest("or", c_int); runTest("or", c_uint);
+    if !excludeForRocm then runTest("or", c_ulonglong);
 
-    runTest("xor", c_int); runTest("xor", c_uint); runTest("xor", c_ulonglong);
+    runTest("xor", c_int); runTest("xor", c_uint);
+    if !excludeForRocm then runTest("xor", c_ulonglong);
 
-    runTest("CAS", c_int); runTest("CAS", c_uint); runTest("CAS", c_ulonglong);
+    runTest("CAS", c_int); runTest("CAS", c_uint);
+    if !excludeForRocm then runTest("CAS", c_ulonglong);
 
     // Before adding support for this I would want better capabilities
     // to process CHPL_GPU (this is only supported when compiling for
-    // CUDA with CC >= 7.0
-    // runTest("CAS", c_ushort); 
+    // CUDA with CC >= 7.0. This is also not listed as something supported
+    // by the ROCM (5.5) documentation
+    // if !excludeForRocm then runTest("CAS", c_ushort);
   }
 }

--- a/test/gpu/native/atomics.chpl
+++ b/test/gpu/native/atomics.chpl
@@ -60,50 +60,50 @@ proc runTest(param op : string, type T) {
   // It would be better if we could pass 'runTest' the gpu and cpu functions
   // that we want to test as first class functions instead of having this
   // repetitive switchyard. Alas, those functions are generic so (as of today)
-  // can not be captured as FCF.
+  // can not be captured as a FCF.
   select(op) {
     when "add" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicAdd(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicAdd(gpuVals[0],  gpuVals[1]);
       cpuAtomicAdd(cpuVals[0],  cpuVals[1]);
     }
     when "sub" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicSub(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicSub(gpuVals[0],  gpuVals[1]);
       cpuAtomicSub(cpuVals[0],  cpuVals[1]);
     }
     when "exch" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicExch(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicExch(gpuVals[0],  gpuVals[1]);
       cpuAtomicExch(cpuVals[0],  cpuVals[1]);
     }
     when "min" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicMin(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicMin(gpuVals[0],  gpuVals[1]);
       cpuAtomicMin(cpuVals[0],  cpuVals[1]);
     }
     when "max" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicMax(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicMax(gpuVals[0],  gpuVals[1]);
       cpuAtomicMax(cpuVals[0],  cpuVals[1]);
     }
     when "inc" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicInc(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicInc(gpuVals[0],  gpuVals[1]);
       cpuAtomicInc(cpuVals[0],  cpuVals[1]);
     }
     when "dec" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicDec(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicDec(gpuVals[0],  gpuVals[1]);
       cpuAtomicDec(cpuVals[0],  cpuVals[1]);
     }
     when "and" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicAnd(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicAnd(gpuVals[0],  gpuVals[1]);
       cpuAtomicAnd(cpuVals[0],  cpuVals[1]);
     }
     when "or" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicOr(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicOr(gpuVals[0],  gpuVals[1]);
       cpuAtomicOr(cpuVals[0],  cpuVals[1]);
     }
     when "xor" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicXor(gpuVals[0],  gpuVals[1]); }
+      foreach n in 0..0 do gpuAtomicXor(gpuVals[0],  gpuVals[1]);
       cpuAtomicXor(cpuVals[0],  cpuVals[1]);
     }
     when "CAS" {
-      foreach n in 0..0 { assertOnGpu(); gpuAtomicCAS(gpuVals[0],  gpuVals[1], gpuVals[2]); }
+      foreach n in 0..0 do gpuAtomicCAS(gpuVals[0],  gpuVals[1], gpuVals[2]);
       cpuAtomicCAS(cpuVals[0],  cpuVals[1], cpuVals[2]);
     }
   }

--- a/test/gpu/native/atomics.compopts
+++ b/test/gpu/native/atomics.compopts
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+if [ $CHPL_GPU_CODEGEN == "rocm" ]; then
+  echo -sexcludeForRocm=true
+else
+  echo -sexcludeForRocm=false
+fi

--- a/test/gpu/native/atomics.good
+++ b/test/gpu/native/atomics.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly


### PR DESCRIPTION
This PR adds various undocumented gpuAtomic procedures to the GPU module.  These correspond to various `atomic` functions in the CUDA/HIP APIs. Note that I only write (or have implementations for) the corresponding GPU bound (i.e. `__device__`) implementation for these procedures.  In the GPU module I have these procs call `assertOnGpu` so attempting to use them in CPU code should fail.  In theory I could imagine these falling back to calling the CPU-bound functions we have in our runtime library for atomics but I imagine eventually we'll want the normal Chapel `atomic` datatypes to call out to these undcoumented APIs, in which case I think we would want the code in `Atomics.chpl` to be responsible for dispatching as appropriate rather than code in the GPU module.  So IOW: I don't think it's worth worrying about CPU-bound code in the GPU module for these subroutines.

Here is the list of the new APIs in the GPU module:

```chpl
  proc gpuAtomicAdd(  ref x : ?T, val : T) : void
  proc gpuAtomicSub(  ref x : ?T, val : T) : void
  proc gpuAtomicExch( ref x : ?T, val : T) : void
  proc gpuAtomicMin(  ref x : ?T, val : T) : void
  proc gpuAtomicMax(  ref x : ?T, val : T) : void
  proc gpuAtomicInc(  ref x : ?T, val : T) : void
  proc gpuAtomicDec(  ref x : ?T, val : T) : void
  proc gpuAtomicAnd(  ref x : ?T, val : T) : void
  proc gpuAtomicOr(   ref x : ?T, val : T) : void
  proc gpuAtomicXor(  ref x : ?T, val : T) : void
  proc gpuAtomicCAS(  ref x : ?T, cmp : T, val : T) : void
```

Some other notes:

- I suppose it's redundant to add a bunch of functions in the "GPU" module that are prefix with "gpu" (although I guess we already do that with `gpuWriteln`, `gpuClock`, etc.) though I feel most users will just `use` the GPU module wholly and it would be too easy to confuse their with more generic implementations. For many of these my hope is that eventually we'll have the more generic API for these (e.g. `writeln`, `clock`) call out to the GPU specific version, which we'd then make undocumented functions for internal use only.

- It's a bit disappointing that CUDA/HIP defines these in terms of the standard "minimum width" C numeric data types rather than fixed width types.  Since (apart from the varous `c_` types everything in Chapel is fixed width) so when you use one of the `gpuAtomic` functions it has to figure out which of the various overloads of the CUDA/HIP to call based on the number of bits in your Chapel type and looking at `numBits` for `c_int`, etc.
  - For info on CUDA see: https://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions
  - For info on ROCm see table 7 under: https://docs.amd.com/bundle/HIP-Programming-Guide-v5.5/page/Programming_with_HIP.html#d278e2278

- There's also a strange thing where certain atomic functions are supported for a larger set of types than others.  For example, in CUDA, `atomicAdd` works for `int`, `unsigned int`, `unsinged long long`, `float` and `double` while `atomicSub` is only supported for `int` and `unsigned int`.  In CUDA (but not HIP) `atomicMin` and `atomicMax` support `long long int` but no other atomic operation does.  So it's kind of confusing to get a grasp of what's supported and what's not and why.  I've added some compiler errors that will trigger if my "try and match your Chapel type to the closest C type" code chooses something that there isn't a valid CUDA/HIP function for but it's a bit disconcerting that this means we'll lose portability: there may be an atomic operation that works for some particular numeric Chapel type that works fine on one machine that has a particular width for `c_int` but may fail on another machine where `c_int` is a different width.

- Again 'long long int' works for `atomicMax` and `atomicMin` for CUDA but not ROCm (and it's not documented as working in Table 7 here: <https://docs.amd.com/bundle/HIP-Programming-Guide-v5.5/page/Programming_with_HIP.html>. I've added a compiletime check that will error out if you attempt to use these when `CHPL_GPU_CODEGEN=rocm` but maybe we should just not support these at all (or figure out some backup strategy) in the name of vendor portability? 

- For whatever reason if I use ROCm on my test it will error out if I do various atomic operations on `c_double` or `c_ulonglong` so for the time being I've excluded these from running on the test when using ROCm. I wonder if the root cause of this issue is the same thing that we're running into with the math functions that are failing.  For the atomics I'll get this error at runtime if I try and do these with ROCm: `:0:rocdevice.cpp            :2589: 9014384876703 us: Device::callbackQueue aborting with error : HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION: The agent attempted to access memory beyond the largest legal address. code: 0x29`

### TODO:

* [x] start_test on gpu/native with CHPL_GPU=nvidia
* [x] start_test on gpu/native with CHPL_GPU=rocm