### PR TITLE
Include additional dependencies to build with LLVM/clang 15

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -842,6 +842,7 @@ def compute_host_link_settings():
                          '-lclangAST',
                          '-lclangLex',
                          '-lclangBasic']
+
     llvm_components = ['bitreader',
                        'bitwriter',
                        'ipo',
@@ -853,6 +854,13 @@ def compute_host_link_settings():
                        'coverage',
                        'coroutines',
                        'lto']
+
+    if llvm_val == 'system' or llvm_val == 'bundled':
+        llvm_version = get_llvm_version()
+        # Starting with clang 15, clang needs additional libraries
+        if llvm_version not in ('11', '12', '13', '14'):
+            clang_static_libs.append('-lclangSupport')
+            llvm_components.append('windowsdriver')
 
     # quit early if the llvm value is unset
     if llvm_val == 'unset':


### PR DESCRIPTION
This PR addresses problems with linker errors when using static libraries for LLVM and clang version 15. LLVM 15 support is not yet complete so & it requires other patches (not in this PR) to build. These additional libraries are not needed when using dynamic LLVM and clang libraries.

Reviewed by @riftEmber - thanks!

- [x] compiler builds with LLVM 15 (with other patches) with a static library
- [x] compiler builds with LLVM 15 (with other patches) with a dynamic library
- [x] full comm=none testing with LLVM 14