### PR TITLE
Fix test print formatting issue

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8820,8 +8820,8 @@ Chapel format specifiers.
 ========  ===========  ==========================================
 C         Chapel       Meaning
 ========  ===========  ==========================================
-%i        %i           an integer in decimal
-%d        %i           an integer in decimal
+%i        %i           a signed integer in decimal
+%d        %i           a signed integer in decimal
 %u        %u           an unsigned integer in decimal
 %x        %xu          an unsigned integer in hexadecimal
 %g        %r           real number in exponential or decimal (if compact)

--- a/test/types/range/minMaxStrides.chpl
+++ b/test/types/range/minMaxStrides.chpl
@@ -8,7 +8,12 @@ proc test(type t) {
   for by_ in (Types.min(ST), Types.max(ST), Types.max(ST):UT) {
     for align_ in (Types.min(ST), Types.max(ST), Types.max(UT)) {
       var r = (0:align_.type)..(100:align_.type) by by_ align align_;
-      writef("by_=%20i:%-10s; align_=%20i:%-10s; range=%t\n", by_, by_.type:string, align_, align_.type:string, r);
+      writef("by_=%22n:%-10s; align_=%22n:%-10s; range=", 
+        by_,
+        by_.type:string,
+        align_,
+        align_.type:string);
+      writeln(r);
     }
   }
 }

--- a/test/types/range/minMaxStrides.good
+++ b/test/types/range/minMaxStrides.good
@@ -1,3 +1,4 @@
+Testing signed int(8) and unsigned uint(8)
 by_=                -128:int(8)    ; align_=                -128:int(8)    ; range=0..100 by -128 align 0
 by_=                -128:int(8)    ; align_=                 127:int(8)    ; range=0..100 by -128 align 0
 by_=                -128:int(8)    ; align_=                  -1:uint(8)   ; range=0..100 by -128 align 1

--- a/test/types/range/minMaxStrides.good
+++ b/test/types/range/minMaxStrides.good
@@ -1,40 +1,40 @@
 Testing signed int(8) and unsigned uint(8)
-by_=                -128:int(8)    ; align_=                -128:int(8)    ; range=0..100 by -128 align 0
-by_=                -128:int(8)    ; align_=                 127:int(8)    ; range=0..100 by -128 align 0
-by_=                -128:int(8)    ; align_=                  -1:uint(8)   ; range=0..100 by -128 align 1
-by_=                 127:int(8)    ; align_=                -128:int(8)    ; range=0..100 by 127 align 1
-by_=                 127:int(8)    ; align_=                 127:int(8)    ; range=0..100 by 127
-by_=                 127:int(8)    ; align_=                  -1:uint(8)   ; range=0..100 by 127 align 1
-by_=                 127:uint(8)   ; align_=                -128:int(8)    ; range=0..100 by 127 align 1
-by_=                 127:uint(8)   ; align_=                 127:int(8)    ; range=0..100 by 127
-by_=                 127:uint(8)   ; align_=                  -1:uint(8)   ; range=0..100 by 127 align 1
+by_=                  -128:int(8)    ; align_=                  -128:int(8)    ; range=0..100 by -128 align 0
+by_=                  -128:int(8)    ; align_=                   127:int(8)    ; range=0..100 by -128 align 127
+by_=                  -128:int(8)    ; align_=                   255:uint(8)   ; range=0..100 by -128 align 127
+by_=                   127:int(8)    ; align_=                  -128:int(8)    ; range=0..100 by 127 align 126
+by_=                   127:int(8)    ; align_=                   127:int(8)    ; range=0..100 by 127
+by_=                   127:int(8)    ; align_=                   255:uint(8)   ; range=0..100 by 127 align 1
+by_=                   127:uint(8)   ; align_=                  -128:int(8)    ; range=0..100 by 127 align 126
+by_=                   127:uint(8)   ; align_=                   127:int(8)    ; range=0..100 by 127
+by_=                   127:uint(8)   ; align_=                   255:uint(8)   ; range=0..100 by 127 align 1
 Testing signed int(16) and unsigned uint(16)
-by_=              -32768:int(16)   ; align_=              -32768:int(16)   ; range=0..100 by -32768 align 1
-by_=              -32768:int(16)   ; align_=               32767:int(16)   ; range=0..100 by -32768 align 1
-by_=              -32768:int(16)   ; align_=                  -1:uint(16)  ; range=0..100 by -32768 align 1
-by_=               32767:int(16)   ; align_=              -32768:int(16)   ; range=0..100 by 32767 align 1
-by_=               32767:int(16)   ; align_=               32767:int(16)   ; range=0..100 by 32767 align 1
-by_=               32767:int(16)   ; align_=                  -1:uint(16)  ; range=0..100 by 32767 align 1
-by_=               32767:uint(16)  ; align_=              -32768:int(16)   ; range=0..100 by 32767 align 1
-by_=               32767:uint(16)  ; align_=               32767:int(16)   ; range=0..100 by 32767 align 1
-by_=               32767:uint(16)  ; align_=                  -1:uint(16)  ; range=0..100 by 32767 align 1
+by_=                -32768:int(16)   ; align_=                -32768:int(16)   ; range=0..100 by -32768 align 0
+by_=                -32768:int(16)   ; align_=                 32767:int(16)   ; range=0..100 by -32768 align 32767
+by_=                -32768:int(16)   ; align_=                 65535:uint(16)  ; range=0..100 by -32768 align 32767
+by_=                 32767:int(16)   ; align_=                -32768:int(16)   ; range=0..100 by 32767 align 32766
+by_=                 32767:int(16)   ; align_=                 32767:int(16)   ; range=0..100 by 32767
+by_=                 32767:int(16)   ; align_=                 65535:uint(16)  ; range=0..100 by 32767 align 1
+by_=                 32767:uint(16)  ; align_=                -32768:int(16)   ; range=0..100 by 32767 align 32766
+by_=                 32767:uint(16)  ; align_=                 32767:int(16)   ; range=0..100 by 32767
+by_=                 32767:uint(16)  ; align_=                 65535:uint(16)  ; range=0..100 by 32767 align 1
 Testing signed int(32) and unsigned uint(32)
-by_=         -2147483648:int(32)   ; align_=         -2147483648:int(32)   ; range=0..100 by -2147483648 align 0
-by_=         -2147483648:int(32)   ; align_=          2147483647:int(32)   ; range=0..100 by -2147483648 align 2147483647
-by_=         -2147483648:int(32)   ; align_=                  -1:uint(32)  ; range=0..100 by -2147483648 align 2147483647
-by_=          2147483647:int(32)   ; align_=         -2147483648:int(32)   ; range=0..100 by 2147483647 align 2147483646
-by_=          2147483647:int(32)   ; align_=          2147483647:int(32)   ; range=0..100 by 2147483647
-by_=          2147483647:int(32)   ; align_=                  -1:uint(32)  ; range=0..100 by 2147483647 align 1
-by_=          2147483647:uint(32)  ; align_=         -2147483648:int(32)   ; range=0..100 by 2147483647 align 2147483646
-by_=          2147483647:uint(32)  ; align_=          2147483647:int(32)   ; range=0..100 by 2147483647
-by_=          2147483647:uint(32)  ; align_=                  -1:uint(32)  ; range=0..100 by 2147483647 align 1
+by_=           -2147483648:int(32)   ; align_=           -2147483648:int(32)   ; range=0..100 by -2147483648 align 0
+by_=           -2147483648:int(32)   ; align_=            2147483647:int(32)   ; range=0..100 by -2147483648 align 2147483647
+by_=           -2147483648:int(32)   ; align_=            4294967295:uint(32)  ; range=0..100 by -2147483648 align 2147483647
+by_=            2147483647:int(32)   ; align_=           -2147483648:int(32)   ; range=0..100 by 2147483647 align 2147483646
+by_=            2147483647:int(32)   ; align_=            2147483647:int(32)   ; range=0..100 by 2147483647
+by_=            2147483647:int(32)   ; align_=            4294967295:uint(32)  ; range=0..100 by 2147483647 align 1
+by_=            2147483647:uint(32)  ; align_=           -2147483648:int(32)   ; range=0..100 by 2147483647 align 2147483646
+by_=            2147483647:uint(32)  ; align_=            2147483647:int(32)   ; range=0..100 by 2147483647
+by_=            2147483647:uint(32)  ; align_=            4294967295:uint(32)  ; range=0..100 by 2147483647 align 1
 Testing signed int(64) and unsigned uint(64)
-by_=-9223372036854775808:int(64)   ; align_=-9223372036854775808:int(64)   ; range=0..100 by -9223372036854775808 align 0
-by_=-9223372036854775808:int(64)   ; align_= 9223372036854775807:int(64)   ; range=0..100 by -9223372036854775808 align 9223372036854775807
-by_=-9223372036854775808:int(64)   ; align_=                  -1:uint(64)  ; range=0..100 by -9223372036854775808 align 9223372036854775807
-by_= 9223372036854775807:int(64)   ; align_=-9223372036854775808:int(64)   ; range=0..100 by 9223372036854775807 align 9223372036854775806
-by_= 9223372036854775807:int(64)   ; align_= 9223372036854775807:int(64)   ; range=0..100 by 9223372036854775807
-by_= 9223372036854775807:int(64)   ; align_=                  -1:uint(64)  ; range=0..100 by 9223372036854775807 align 1
-by_= 9223372036854775807:uint(64)  ; align_=-9223372036854775808:int(64)   ; range=0..100 by 9223372036854775807 align 9223372036854775806
-by_= 9223372036854775807:uint(64)  ; align_= 9223372036854775807:int(64)   ; range=0..100 by 9223372036854775807
-by_= 9223372036854775807:uint(64)  ; align_=                  -1:uint(64)  ; range=0..100 by 9223372036854775807 align 1
+by_=  -9223372036854775808:int(64)   ; align_=  -9223372036854775808:int(64)   ; range=0..100 by -9223372036854775808 align 0
+by_=  -9223372036854775808:int(64)   ; align_=   9223372036854775807:int(64)   ; range=0..100 by -9223372036854775808 align 9223372036854775807
+by_=  -9223372036854775808:int(64)   ; align_=  18446744073709551615:uint(64)  ; range=0..100 by -9223372036854775808 align 9223372036854775807
+by_=   9223372036854775807:int(64)   ; align_=  -9223372036854775808:int(64)   ; range=0..100 by 9223372036854775807 align 9223372036854775806
+by_=   9223372036854775807:int(64)   ; align_=   9223372036854775807:int(64)   ; range=0..100 by 9223372036854775807
+by_=   9223372036854775807:int(64)   ; align_=  18446744073709551615:uint(64)  ; range=0..100 by 9223372036854775807 align 1
+by_=   9223372036854775807:uint(64)  ; align_=  -9223372036854775808:int(64)   ; range=0..100 by 9223372036854775807 align 9223372036854775806
+by_=   9223372036854775807:uint(64)  ; align_=   9223372036854775807:int(64)   ; range=0..100 by 9223372036854775807
+by_=   9223372036854775807:uint(64)  ; align_=  18446744073709551615:uint(64)  ; range=0..100 by 9223372036854775807 align 1


### PR DESCRIPTION
Fixes an issue introduced in PR #22225 which inconsistently printed on different platforms, due to an incorrect format string.

From @vasslitvinov: Also added a change to the IO docs to clarify '%i'

Ran full paratest

[Reviewed by @vasslitvinov]