### PR TITLE
Remove typed pointer usages from llvmGlobalToWide

### DIFF
--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1228,30 +1228,18 @@ namespace {
         auto getFn = M.getOrInsertFunction("chpl_gen_comm_get_ctl_sym", voidTy,
                                            voidPtrTy, nodeTy, voidPtrTy,
                                            sizeTy, i64Ty);
-#if HAVE_LLVM_VER < 90
-        Type* getFnTy = getFn->getType();
-        info->getFn = getFn;
-        info->getFnType = NULL;
-#else
         FunctionType* getFnTy = getFn.getFunctionType();
         info->getFn = getFn.getCallee();
         info->getFnType = getFnTy;
-#endif
         checkFunctionExistAndHasArgs(info->getFn, getFnTy, 5);
 
 
         auto putFn = M.getOrInsertFunction("chpl_gen_comm_put_ctl_sym", voidTy,
                                            nodeTy, voidPtrTy, voidPtrTy,
                                            sizeTy, i64Ty);
-#if HAVE_LLVM_VER < 90
-        Type* putFnTy = putFn->getType();
-        info->putFn = putFn;
-        info->putFnType = NULL;
-#else
         FunctionType* putFnTy = putFn.getFunctionType();
         info->putFn = putFn.getCallee();
         info->putFnType = putFnTy;
-#endif
         checkFunctionExistAndHasArgs(info->putFn, putFnTy, 5);
 
 
@@ -1259,32 +1247,18 @@ namespace {
                                               nodeTy, voidPtrTy,
                                               nodeTy, voidPtrTy,
                                               sizeTy);
-
-#if HAVE_LLVM_VER < 90
-        Type* getPutFnTy = getPutFn->getType();
-        info->getPutFn = getPutFn;
-        info->getPutFnType = NULL;
-#else
         FunctionType* getPutFnTy = getPutFn.getFunctionType();
         info->getPutFn = getPutFn.getCallee();
         info->getPutFnType = getPutFnTy;
-#endif
         checkFunctionExistAndHasArgs(info->getPutFn, getPutFnTy, 5);
 
 
         auto memsetFn = M.getOrInsertFunction("chpl_gen_comm_memset_sym", voidTy,
                                               nodeTy, voidPtrTy,
                                               i8Ty, sizeTy);
-
-#if HAVE_LLVM_VER < 90
-        Type* memsetFnTy = memsetFn->getType();
-        info->memsetFn = memsetFn;
-        info->memsetFnType = NULL;
-#else
         FunctionType* memsetFnTy = memsetFn.getFunctionType();
         info->memsetFn = memsetFn.getCallee();
         info->memsetFnType = memsetFnTy;
-#endif
         checkFunctionExistAndHasArgs(info->memsetFn, memsetFnTy, 4);
 
 

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -2209,7 +2209,7 @@ Type* createWidePointerToType(Module* module, GlobalToWideInfo* i, Type* eltTy)
   // Get the wide pointer struct containing {locale, address}
   Type* fields[2];
   fields[0] = i->localeIdType;
-  llvm::PointerType* ptrTy;
+  llvm::PointerType* ptrTy = nullptr;
   if (eltTy) {
 #ifdef HAVE_LLVM_TYPED_POINTERS
     ptrTy = llvm::PointerType::getUnqual(eltTy);
@@ -2219,6 +2219,7 @@ Type* createWidePointerToType(Module* module, GlobalToWideInfo* i, Type* eltTy)
     ptrTy = llvm::PointerType::getUnqual(context);
 #endif
   }
+  assert(ptrTy);
   fields[1] = ptrTy;
 
   return StructType::get(context, fields, false);

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -2320,23 +2320,23 @@ Type* convertTypeGlobalToWide(Module* module, GlobalToWideInfo* info, Type* t)
   }
 
   if(t->isPointerTy()){
-  bool isOpaque = false;
-  Type* eltType = nullptr;
+    bool isOpaque = false;
+    Type* eltType = nullptr;
 #if HAVE_LLVM_VER < 170
 #if HAVE_LLVM_VER >= 140
-  isOpaque = t->isOpaquePointerTy();
+    isOpaque = t->isOpaquePointerTy();
 #endif
-  if (!isOpaque) {
-    // TODO: this code can be ifdef'd out for LLVM 15 once
-    // we fully migrate to opaque pointers with LLVM 15.
-    Type* eltType = t->getPointerElementType();
-    assert(t != t->getPointerElementType()); // detect simple recursion
-  }
+    if (!isOpaque) {
+      // TODO: this code can be ifdef'd out for LLVM 15 once
+      // we fully migrate to opaque pointers with LLVM 15.
+      Type* eltType = t->getPointerElementType();
+      assert(t != t->getPointerElementType());  // detect simple recursion
+    }
 #endif
     Type* wideEltType = convertTypeGlobalToWide(module, info, eltType);
 
-    if( t->getPointerAddressSpace() == info->globalSpace ||
-        t->getPointerAddressSpace() == info->wideSpace ) {
+    if (t->getPointerAddressSpace() == info->globalSpace ||
+        t->getPointerAddressSpace() == info->wideSpace) {
       // Replace the pointer with a struct containing {locale, address}
       return createWidePointerToType(module, info, wideEltType);
     } else {

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -2202,6 +2202,7 @@ llvm::Function* getWideToGlobalFn(llvm::Module *module, GlobalToWideInfo* info, 
   return r.wideToGlobalFn;
 }
 
+// Generates an opaque pointer if eltTy is nullptr, and typed pointer otherwise.
 static
 Type* createWidePointerToType(Module* module, GlobalToWideInfo* i, Type* eltTy)
 {


### PR DESCRIPTION
Removes usages of typed pointers (except with macro guards) from `llvmGlobalToWide.cpp` in preparation for the deprecation of typed pointers in LLVM 15.

Uses the `HAVE_LLVM_TYPED_POINTERS` macro from #22240 to use old typed pointer code when LLVM is supporting typed pointers.

[reviewer info]

Testing:
- [x] LLVM 14 paratest with COMM=none
- [x] LLVM 14 paratest with COMM=gasnet