### PR TITLE
Pin the version of urllib3

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -2,5 +2,6 @@
 Jinja2==3.1.2
 Pygments==2.12.0
 Sphinx==4.5.0
+urllib3<1.27,>=1.21.1
 docutils==0.16.0
 babel==2.10.3


### PR DESCRIPTION
Pin the version of urllib3 used so that nightly tests stop breaking
when running sphinx. Special thanks to @lydia-duncan for walking me
through how to pin the version of a Python module.