### PR TITLE
Avoid relying on typed LLVM pointers in cg-symbol.cpp

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2658,13 +2658,8 @@ void FnSymbol::codegenDef() {
               // consume the next LLVM argument
               llvm::Value* val = &*ai++;
               // store it into the addr
-#if HAVE_LLVM_VER >= 130
-              llvm::Type* eltTy = llvm::cast<llvm::PointerType>(storeAdr->getType()->getScalarType())->getPointerElementType();
               llvm::Value* eltPtr =
-                irBuilder->CreateStructGEP(eltTy, storeAdr, i);
-#else
-              llvm::Value* eltPtr = irBuilder->CreateStructGEP(storeAdr, i);
-#endif
+                irBuilder->CreateStructGEP(sTy, storeAdr, i);
               irBuilder->CreateStore(val, eltPtr);
             }
 


### PR DESCRIPTION
This PR is focused on removing cases where cg-symbol.cpp was relying on typed pointers (since LLVM 15 and future versions use opaque pointers). For the most part, it relied on using that information available in a different way from LLVM (from a GlobalVariable or a relevant StructType).

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14