### PR TITLE
Simplify printing of range alignment and restore borrow()

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -3042,8 +3042,7 @@ operator :(r: range(?), type t: range(?)) {
       if x.stride != -1 && x.aligned && ! x.isNaturallyAligned() then
       // Write out the alignment only if it differs from natural alignment.
       // We take alignment modulo the stride for consistency.
-       ret += " align " + x.chpl_intToIdx(
-                  chpl__mod(chpl__idxToInt(x.alignment), x.stride)):string;
+       ret += " align " + x.alignment:string;
     }
     return ret;
   }

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -292,6 +292,14 @@ module OwnedObject {
         return chpl_p!;
       }
     }
+
+    proc type borrow() type {
+      if _to_nilable(chpl_t) == chpl_t {
+        return chpl_t;
+      } else {
+        return _to_nonnil(chpl_t);
+      }
+    }
   }
 
   /*

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -754,7 +754,7 @@ module ChapelIO {
     // Write out the alignment only if it differs from natural alignment.
     // We take alignment modulo the stride for consistency.
       f._writeLiteral(" align ");
-      f.write(chpl_intToIdx(chpl__mod(chpl__idxToInt(alignment), stride)));
+      f.write(alignment);
       }
     }
   }


### PR DESCRIPTION
Print range alignment without normalizing it, since it should be stored already normalized since #22225.

Restore the type proc `owned.borrow()`, which was mistakenly removed in #22038.

Trivial, not reviewed.