### PR TITLE
Avoid relying on typed LLVM pointers in cg-type.cpp

### DIFF
--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -465,14 +465,25 @@ void AggregateType::codegenDef() {
         Type* baseType = this->getField("addr")->type;
         llvm::Type* llBaseType = baseType->symbol->codegen().type;
         INT_ASSERT(llBaseType);
-        llvm::Type *globalPtrTy = NULL;
+        llvm::Type *globalPtrTy = nullptr;
 
-        // Remove one level of indirection since the addr field
-        // of a wide pointer is always a local address.
-        llBaseType = llBaseType->getPointerElementType();
-        INT_ASSERT(llBaseType);
+        if (isOpaquePointer(llBaseType)) {
+#if HAVE_LLVM_VER >= 140
+          // No need to compute the element type for an opaque pointer
+          globalPtrTy = llvm::PointerType::get(info->llvmContext,
+                                               globalAddressSpace);
+#endif
+        } else {
+#ifdef HAVE_LLVM_TYPED_POINTERS
+          // Remove one level of indirection since the addr field
+          // of a wide pointer is always a local address.
+          globalPtrTy =
+            llvm::PointerType::get(llBaseType->getPointerElementType(),
+                                   globalAddressSpace);
+#endif
+        }
 
-        globalPtrTy = llvm::PointerType::get(llBaseType, globalAddressSpace);
+        INT_ASSERT(globalPtrTy);
         type = globalPtrTy; // set to use alternative address space ptr
 
         if( fLLVMWideOpt ) {

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -477,9 +477,9 @@ void AggregateType::codegenDef() {
 #ifdef HAVE_LLVM_TYPED_POINTERS
           // Remove one level of indirection since the addr field
           // of a wide pointer is always a local address.
-          globalPtrTy =
-            llvm::PointerType::get(llBaseType->getPointerElementType(),
-                                   globalAddressSpace);
+          llvm::Type* eltType = llBaseType->getPointerElementType();
+          INT_ASSERT(eltType);
+          globalPtrTy = llvm::PointerType::get(eltType, globalAddressSpace);
 #endif
         }
 


### PR DESCRIPTION
This PR is focused on removing cases where cg-type.cpp was relying on typed pointers (since LLVM 15 and future versions use opaque pointers). The one case it updates was computing a global pointer type from a local pointer type, so if the pointer type is opaque, it can propagate that information.

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14
- [x] full comm=gasnet testing with LLVM 14