### PR TITLE
 Avoid relying on typed LLVM pointers in codegen.cpp

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -519,19 +519,6 @@ GenRet codegenWideAddrWithAddr(GenRet base, GenRet newAddr, Type* wideType = NUL
 #define USE_TBAA 1
 
 static
-llvm::Type* tryComputingPointerElementType(llvm::Value* ptr) {
-  llvm::Type* eltType = nullptr;
-  if (llvm::AllocaInst* locVar = llvm::dyn_cast<llvm::AllocaInst>(ptr)) {
-    eltType = locVar->getAllocatedType();
-  }
-  if (llvm::GlobalValue* globVar = llvm::dyn_cast<llvm::GlobalValue>(ptr)) {
-    eltType = globVar->getValueType();
-  }
-
-  return eltType;
-}
-
-static
 llvm::Type* computePointerElementType(llvm::Value* ptr, Type* chplType) {
   llvm::Type* eltTypeFromInsn = nullptr;
   llvm::Type* eltTypeFromChapelType = nullptr;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2114,11 +2114,9 @@ codegen_config() {
         std::vector<llvm::Value *> args (6);
         {
           GenRet gen = new_CStringSymbol(var->name)->codegen();
-#if HAVE_LLVM_VER >= 130
-          args[0] = info->irBuilder->CreateLoad(gen.val->getType()->getPointerElementType(), gen.val);
-#else
-          args[0] = info->irBuilder->CreateLoad(gen.val);
-#endif
+          llvm::Type* eltType = tryComputingPointerElementType(gen.val);
+          INT_ASSERT(eltType); // it should have been a global variable
+          args[0] = info->irBuilder->CreateLoad(eltType, gen.val);
         }
 
         Type* type = var->type;
@@ -2133,28 +2131,22 @@ codegen_config() {
         }
         {
           GenRet gen = new_CStringSymbol(type->symbol->name)->codegen();
-#if HAVE_LLVM_VER >= 130
-          args[1] = info->irBuilder->CreateLoad(gen.val->getType()->getPointerElementType(), gen.val);
-#else
-          args[1] = info->irBuilder->CreateLoad(gen.val);
-#endif
+          llvm::Type* eltType = tryComputingPointerElementType(gen.val);
+          INT_ASSERT(eltType); // it should have been a global variable
+          args[1] = info->irBuilder->CreateLoad(eltType, gen.val);
         }
 
         if (var->getModule()->modTag == MOD_INTERNAL) {
           GenRet gen = new_CStringSymbol("Built-in")->codegen();
-#if HAVE_LLVM_VER >= 130
-          args[2] = info->irBuilder->CreateLoad(gen.val->getType()->getPointerElementType(), gen.val);
-#else
-          args[2] = info->irBuilder->CreateLoad(gen.val);
-#endif
+          llvm::Type* eltType = tryComputingPointerElementType(gen.val);
+          INT_ASSERT(eltType); // it should have been a global variable
+          args[2] = info->irBuilder->CreateLoad(eltType, gen.val);
         }
         else {
           GenRet gen = new_CStringSymbol(var->getModule()->name)->codegen();
-#if HAVE_LLVM_VER >= 130
-          args[2] =info->irBuilder->CreateLoad(gen.val->getType()->getPointerElementType(), gen.val);
-#else
-          args[2] =info->irBuilder->CreateLoad(gen.val);
-#endif
+          llvm::Type* eltType = tryComputingPointerElementType(gen.val);
+          INT_ASSERT(eltType); // it should have been a global variable
+          args[2] = info->irBuilder->CreateLoad(eltType, gen.val);
         }
 
         args[3] = info->irBuilder->getInt32(var->hasFlag(FLAG_PRIVATE));
@@ -2162,11 +2154,9 @@ codegen_config() {
         args[4] = info->irBuilder->getInt32(var->hasFlag(FLAG_DEPRECATED));
         {
           GenRet gen = new_CStringSymbol(var->getDeprecationMsg())->codegen();
-#if HAVE_LLVM_VER >= 130
-          args[5] = info->irBuilder->CreateLoad(gen.val->getType()->getPointerElementType(), gen.val);
-#else
-          args[5] = info->irBuilder->CreateLoad(gen.val);
-#endif
+          llvm::Type* eltType = tryComputingPointerElementType(gen.val);
+          INT_ASSERT(eltType); // it should have been a global variable
+          args[5] = info->irBuilder->CreateLoad(eltType, gen.val);
         }
         info->irBuilder->CreateCall(installConfigFunc, args);
       }

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -82,5 +82,9 @@ void llvmAttachStructRetAttr(llvm::AttrBuilder& b, llvm::Type* returnTy);
 
 bool isOpaquePointer(llvm::Type* ty);
 
+// if ptr is an AllocaInst or GlobalValue, we can get the pointed-to type
+// from it. Otherwise, return nullptr.
+llvm::Type* tryComputingPointerElementType(llvm::Value* ptr);
+
 #endif //HAVE_LLVM
 #endif //LLVMUTIL_H

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -634,5 +634,16 @@ bool isOpaquePointer(llvm::Type* ty) {
 #endif
 }
 
-#endif
+llvm::Type* tryComputingPointerElementType(llvm::Value* ptr) {
+  llvm::Type* eltType = nullptr;
+  if (llvm::AllocaInst* locVar = llvm::dyn_cast<llvm::AllocaInst>(ptr)) {
+    eltType = locVar->getAllocatedType();
+  }
+  if (llvm::GlobalValue* globVar = llvm::dyn_cast<llvm::GlobalValue>(ptr)) {
+    eltType = globVar->getValueType();
+  }
 
+  return eltType;
+}
+
+#endif


### PR DESCRIPTION
This PR is focused on removing cases where codegen.cpp was relying on typed pointers (since LLVM 15 and future versions use opaque pointers). The one case it updates was computing the value to load from a GlobalVariable, so it moves `tryComputingPointerElementType` (used in earlier work to compute the value type of a GlobalVariable since these are always pointers in LLVM) to make it available here and uses it.

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14