### PR TITLE
Update a few .precomp files for LLVM 15

### DIFF
--- a/test/extern/bradc/require/usefoobarbaz.precomp
+++ b/test/extern/bradc/require/usefoobarbaz.precomp
@@ -1,2 +1,3 @@
 #!/bin/bash
-gcc -c baz.c
+USE_CC=`${CHPL_HOME}/util/printchplenv --all --compiler --simple | grep CHPL_TARGET_CC | cut -d = -f 2-`
+${USE_CC} -c baz.c

--- a/test/interop/C/makefiles/commandLineLib.precomp
+++ b/test/interop/C/makefiles/commandLineLib.precomp
@@ -1,3 +1,3 @@
 #!/bin/bash
-
-gcc -c foo.c && ar -rc libfoo.a foo.o
+USE_CC=`${CHPL_HOME}/util/printchplenv --all --compiler --simple | grep CHPL_TARGET_CC | cut -d = -f 2-`
+${USE_CC} -c foo.c && ar -rc libfoo.a foo.o

--- a/test/interop/C/makefiles/requireStmt.precomp
+++ b/test/interop/C/makefiles/requireStmt.precomp
@@ -1,3 +1,3 @@
 #!/bin/bash
-
-gcc -c foo.c && ar -rc libfoo.a foo.o
+USE_CC=`${CHPL_HOME}/util/printchplenv --all --compiler --simple | grep CHPL_TARGET_CC | cut -d = -f 2-`
+${USE_CC} -c foo.c && ar -rc libfoo.a foo.o


### PR DESCRIPTION
This PR updates a few test precomp files that create .o files to use same C compiler / linker as Chapel.

On systems where 'gcc' defaults to a configuration that is not position-independent-executables, the clang-15 might be configured to be position-independent, leading to a linker error when a separately compiled .o file is linked with a Chapel program.

Note that this is very system dependent. It occurs on a SLES 15 but not on an Ubuntu 23.04 system.

To fix, just compile these .o files with the same compiler.

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14