### PR TITLE
Selectively use 64-bit ints for GPU kernel index computation 

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -552,28 +552,30 @@ void GpuKernel::generateIndexComputation() {
     Symbol* loopIndex  = gpuLoop.loopIndices()[i];
     Symbol* lowerBound = gpuLoop.lowerBounds()[i];
 
+    // we want some of these variables to be 64-bits to be able to avoid
+    // overflows in number of threads.
     VarSymbol *varBlockIdxX = generateAssignmentToPrimitive(fn_, "blockIdxX",
-      PRIM_GPU_BLOCKIDX_X, dtInt[INT_SIZE_32]);
+      PRIM_GPU_BLOCKIDX_X, dtInt[INT_SIZE_64]);
     VarSymbol *varBlockDimX = generateAssignmentToPrimitive(fn_, "blockDimX",
       PRIM_GPU_BLOCKDIM_X, dtInt[INT_SIZE_32]);
     VarSymbol *varThreadIdxX = generateAssignmentToPrimitive(fn_, "threadIdxX",
       PRIM_GPU_THREADIDX_X, dtInt[INT_SIZE_32]);
 
     VarSymbol *tempVar = insertNewVarAndDef(fn_->body, "t0",
-      dtInt[INT_SIZE_32]);
+      dtInt[INT_SIZE_64]);
     CallExpr *c1 = new CallExpr(PRIM_MOVE, tempVar, new CallExpr(
       PRIM_MULT, varBlockIdxX, varBlockDimX));
     fn_->insertAtTail(c1);
 
     VarSymbol *tempVar1 = insertNewVarAndDef(fn_->body, "t1",
-      dtInt[INT_SIZE_32]);
+      dtInt[INT_SIZE_64]);
     CallExpr *c2 = new CallExpr(PRIM_MOVE, tempVar1, new CallExpr(
       PRIM_ADD, tempVar, varThreadIdxX));
     fn_->insertAtTail(c2);
 
     Symbol* startOffset = addKernelArgument(lowerBound);
     VarSymbol* index = insertNewVarAndDef(fn_->body, "chpl_simt_index",
-                                          dtInt[INT_SIZE_32]);
+                                          dtInt[INT_SIZE_64]);
     fn_->insertAtTail(new CallExpr(PRIM_MOVE, index, new CallExpr(
       PRIM_ADD, tempVar1, startOffset)));
 
@@ -852,10 +854,10 @@ static VarSymbol* generateNumThreads(BlockStmt* gpuLaunchBlock,
 
   VarSymbol *varBoundDelta = insertNewVarAndDef(gpuLaunchBlock,
                                                 "chpl_block_delta",
-                                                dtInt[INT_SIZE_DEFAULT]);
+                                                dtInt[INT_SIZE_64]);
   VarSymbol *numThreads = insertNewVarAndDef(gpuLaunchBlock,
                                              "chpl_num_gpu_threads",
-                                             dtInt[INT_SIZE_DEFAULT]);
+                                             dtInt[INT_SIZE_64]);
 
   CallExpr *c1 = new CallExpr(PRIM_ASSIGN, varBoundDelta,
                               new CallExpr(PRIM_SUBTRACT,

--- a/runtime/include/chpl-gpu-impl.h
+++ b/runtime/include/chpl-gpu-impl.h
@@ -35,7 +35,7 @@ void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
                                  int nargs, va_list args);
 void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
                                  const char* name,
-                                 int num_threads, int blk_dim,
+                                 int64_t num_threads, int blk_dim,
                                  int nargs, va_list args);
 
 void* chpl_gpu_impl_mem_alloc(size_t size);

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -89,7 +89,7 @@ void chpl_gpu_launch_kernel(int ln, int32_t fn,
                             int nargs, ...);
 void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
                                  const char* name,
-                                 int num_threads, int blk_dim,
+                                 int64_t num_threads, int blk_dim,
                                  int nargs, ...);
 
 void* chpl_gpu_mem_array_alloc(size_t size, chpl_mem_descInt_t description,

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -126,11 +126,13 @@ inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
 }
 
 void* chpl_gpu_memmove(void* dst, const void* src, size_t n) {
-  CHPL_GPU_DEBUG("Doing GPU memmove of %zu bytes from %p to %p.\n", n, src, dst);
+  // CHPL_GPU_DEBUG output here is too much. So, I'm commenting for now.
+
+  // CHPL_GPU_DEBUG("Doing GPU memmove of %zu bytes from %p to %p.\n", n, src, dst);
 
   void* ret = chpl_gpu_impl_memmove(dst, src, n);
 
-  CHPL_GPU_DEBUG("chpl_gpu_memmove successful\n");
+  // CHPL_GPU_DEBUG("chpl_gpu_memmove successful\n");
   return ret;
 }
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -94,15 +94,17 @@ inline void chpl_gpu_launch_kernel(int ln, int32_t fn,
 
 inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
                                         const char* name,
-                                        int num_threads, int blk_dim, int nargs,
+                                        int64_t num_threads, int blk_dim, int nargs,
                                         ...) {
 
   CHPL_GPU_DEBUG("Kernel launcher called. (subloc %d)\n"
                  "\tKernel: %s\n"
-                 "\tNumArgs: %d\n",
+                 "\tNumArgs: %d\n"
+                 "\tNumThreads: %lld\n",
                  chpl_task_getRequestedSubloc(),
                  name,
-                 nargs);
+                 nargs,
+                 num_threads);
 
   va_list args;
   va_start(args, nargs);

--- a/runtime/src/gpu/cuda/gpu-cuda.c
+++ b/runtime/src/gpu/cuda/gpu-cuda.c
@@ -232,6 +232,9 @@ static void chpl_gpu_launch_kernel_help(int ln,
   assert(kernel_params);
 
   CHPL_GPU_DEBUG("Creating kernel parameters\n");
+  CHPL_GPU_DEBUG("\tgridDims=(%d, %d, %d), blockDims(%d, %d, %d)\n",
+                 grd_dim_x, grd_dim_y, grd_dim_z,
+                 blk_dim_x, blk_dim_y, blk_dim_z);
 
   // Keep track of kernel parameters we dynamically allocate memory for so
   // later on we know what we need to free.
@@ -321,7 +324,7 @@ inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
 
 inline void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
                                              const char* name,
-                                             int num_threads,
+                                             int64_t num_threads,
                                              int blk_dim,
                                              int nargs,
                                              va_list args) {
@@ -406,7 +409,7 @@ void* chpl_gpu_mem_array_alloc(size_t size, chpl_mem_descInt_t description,
                                int32_t lineno, int32_t filename) {
   chpl_gpu_ensure_context();
 
-  CHPL_GPU_DEBUG("chpl_gpu_mem_array_alloc called. Size:%d file:%s line:%d\n", size,
+  CHPL_GPU_DEBUG("chpl_gpu_mem_array_alloc called. Size:%zu file:%s line:%d\n", size,
                chpl_lookupFilename(filename), lineno);
 
   CUdeviceptr ptr = 0;

--- a/runtime/src/gpu/rocm/gpu-rocm.c
+++ b/runtime/src/gpu/rocm/gpu-rocm.c
@@ -268,6 +268,9 @@ static void chpl_gpu_launch_kernel_help(int ln,
   assert(kernel_params);
 
   CHPL_GPU_DEBUG("Creating kernel parameters\n");
+  CHPL_GPU_DEBUG("\tgridDims=(%d, %d, %d), blockDims(%d, %d, %d)\n",
+                 grd_dim_x, grd_dim_y, grd_dim_z,
+                 blk_dim_x, blk_dim_y, blk_dim_z);
 
   // Keep track of kernel parameters we dynamically allocate memory for so
   // later on we know what we need to free.
@@ -357,7 +360,7 @@ inline void chpl_gpu_impl_launch_kernel(int ln, int32_t fn,
 
 inline void chpl_gpu_impl_launch_kernel_flat(int ln, int32_t fn,
                                              const char* name,
-                                             int num_threads,
+                                             int64_t num_threads,
                                              int blk_dim,
                                              int nargs,
                                              va_list args) {
@@ -455,7 +458,7 @@ void* chpl_gpu_mem_array_alloc(size_t size, chpl_mem_descInt_t description,
 
   chpl_gpu_ensure_context();
 
-  CHPL_GPU_DEBUG("chpl_gpu_mem_array_alloc called. Size:%d file:%s line:%d\n", size,
+  CHPL_GPU_DEBUG("chpl_gpu_mem_array_alloc called. Size:%zu file:%s line:%d\n", size,
                chpl_lookupFilename(filename), lineno);
 
   hipDeviceptr_t ptr = 0;

--- a/test/gpu/native/largeLoop.chpl
+++ b/test/gpu/native/largeLoop.chpl
@@ -1,0 +1,30 @@
+use GPU;
+use GpuDiagnostics;
+
+config const n = max(int(32))+1;
+config const printArr = false;
+config const printChecksum = false;
+
+var AHost: [0..<n] uint(8);
+
+on here.gpus[0] {
+  var A: [0..<n] uint(8);
+  foreach i in 0..<n {
+    assertOnGpu();
+    A[i] = 1;
+  }
+  AHost = A;
+}
+
+// reduction doesn't work on host either?
+var sum = 0;
+for a in AHost do sum += a;
+
+assert(sum == n);
+
+if printChecksum {
+  writeln(n);
+  writeln(sum);
+}
+
+if printArr then writeln(AHost);

--- a/test/gpu/native/largeLoop.good
+++ b/test/gpu/native/largeLoop.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly


### PR DESCRIPTION
This addresses a bug reported in https://chapel.discourse.group/t/gpu-forall-over-large-range-doesnt-enqueue-enough-gpu-threads/21659.

It looks like we have been using `int`s in the runtime for `num_threads`, and similarly `dtInt[INT_SIZE_32]` while generating index computation code within GPU kernels. Both of these limited us to run GPU kernels on loops with bounds that can fit in 32-bit ints. This is an arbitrary limitation as GPUs can run more than 2**32 threads. This PR fixes that.

While there improves `--debugGpu` output in the following ways:
- adds grid dimensions to the output. Ideally, we should move this computation from the `chpl-gpu-impl` layer to `chpl-gpu` layer and print the info out with `startVerboseGpu` output. But that's more than I am willing to do in this bug fix PR
- fixes an output that printed out a `size_t` with `%d` instead of `%zu`
- comments out the output for `chpl_gpu_memmove`, which generates a ton of output making `debugGpu` useless.

Test:
- [x] gpu/native with NVIDIA
- [x] gpu/native with AMD