### PR TITLE
Enable CHPL_LLVM=none builds with LLVM 16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,9 @@ endif()
 # set(DEBUG OFF CACHE BOOL "DEBUG flag from make") # CMake Debug?
 # set(PROFILE OFF CACHE BOOL "PROFILE flag from make")
 
+message(VERBOSE "Using C++ compile options ${CHPL_CXX_FLAGS}")
+message(VERBOSE "Using C++ link options ${CHPL_LD_FLAGS}")
+
 # TODO: replace this with above, get proper values depending on compiler/version
 #  see make/compiler/Makefile.gnu, make/compiler/Makefile.clang
 add_compile_options(SHELL:$<$<COMPILE_LANGUAGE:CXX>:${CHPL_CXX_FLAGS}>)

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -16,10 +16,13 @@
 # limitations under the License.
 
 
-# TODO: Determine when CMake looks for CC and CXX and set them to our
-# CHPL_HOST_CC and CHPL_HOST_CXX
-# request C++14
-set(CMAKE_CXX_STANDARD 14)
+# request C++14 -- or C++17 if using LLVM 16
+if (CHPL_LLVM_VERSION VERSION_LESS 16.0)
+  set(CMAKE_CXX_STANDARD 14)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # request C11

--- a/frontend/CMakeLists.txt
+++ b/frontend/CMakeLists.txt
@@ -77,8 +77,12 @@ configure_file(${CHPL_MAIN_INCLUDE_DIR}/chpl/config/config.h.cmake
                ${CHPL_INCLUDE_DIR}/chpl/config/config.h)
 
 
-# request C++14
-set(CMAKE_CXX_STANDARD 14)
+# request C++14 -- or C++17 if using LLVM 16
+if (CHPL_LLVM_VERSION VERSION_LESS 16.0)
+  set(CMAKE_CXX_STANDARD 14)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # request C11

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -380,7 +380,7 @@ class BorrowedIdsWithName {
   /**
     Iterator that skips invisible entries from the list of borrowed IDs.
    */
-  class BorrowedIdsWithNameIter : public std::iterator<ID, std::forward_iterator_tag> {
+  class BorrowedIdsWithNameIter {
     // To allow use of isIdVisible
     friend class BorrowedIdsWithName;
    private:
@@ -414,6 +414,13 @@ class BorrowedIdsWithName {
     }
     inline const ID& operator*() const { return currentIdv->id_; }
     inline const IdAndFlags& curIdAndFlags() const { return *currentIdv; }
+
+    // iterator traits
+    using difference_type = std::ptrdiff_t;
+    using value_type = ID;
+    using pointer = const ID*;
+    using reference = const ID&;
+    using iterator_category = std::forward_iterator_tag;
   };
 
  private:

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "llvm/ADT/None.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
@@ -456,7 +457,11 @@ class BorrowedIdsWithName {
       return BorrowedIdsWithName(std::move(idAndVis),
                                  filterFlags, std::move(excludeFlagSet));
     }
+#if LLVM_VERSION_MAJOR >= 16
+    return std::nullopt;
+#else
     return llvm::None;
+#endif
   }
 
   static BorrowedIdsWithName
@@ -470,8 +475,13 @@ class BorrowedIdsWithName {
     auto maybeIds = createWithSingleId(std::move(id), vis,
                                        isField, isMethod, isParenfulFunction,
                                        filterFlags, excludeFlagSet);
+#if LLVM_VERSION_MAJOR >= 16
+    CHPL_ASSERT(maybeIds.has_value());
+    return maybeIds.value();
+#else
     CHPL_ASSERT(maybeIds.hasValue());
     return maybeIds.getValue();
+#endif
   }
 
   static BorrowedIdsWithName

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2011,7 +2011,11 @@ bool Resolver::enter(const uast::Conditional* cond) {
       r.setType(CHPL_TYPE_ERROR(context, IncompatibleIfBranches, cond,
                                 returnTypes[0], returnTypes[1]));
     } else if (ifType) {
+#if LLVM_VERSION_MAJOR >= 16
+      r.setType(ifType.value());
+#else
       r.setType(ifType.getValue());
+#endif
     }
   }
   return false;
@@ -2632,7 +2636,11 @@ void Resolver::exit(const Range* range) {
                                  suppliedTypes[0], suppliedTypes[1]));
       return;
     } else {
+#if LLVM_VERSION_MAJOR >= 16
+      idxType = idxTypeResult.value();
+#else
       idxType = idxTypeResult.getValue();
+#endif
     }
   } else {
     // No bounds. Use default.

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1120,7 +1120,11 @@ commonType(Context* context,
   if (requiredKind) {
     // The caller enforces a particular kind on us. Make sure that the
     // computed properties line up with the kind.
+#if LLVM_VERSION_MAJOR >= 16
+    auto requiredProperties = KindProperties::fromKind(requiredKind.value());
+#else
     auto requiredProperties = KindProperties::fromKind(requiredKind.getValue());
+#endif
     requiredProperties.strictCombineWith(properties);
     properties = requiredProperties;
   }
@@ -1150,8 +1154,14 @@ commonType(Context* context,
     return commonType;
   }
 
+#if LLVM_VERSION_MAJOR >= 16
   bool paramRequired = requiredKind &&
-    requiredKind.getValue() == QualifiedType::PARAM;
+                       requiredKind.value() == QualifiedType::PARAM;
+#else
+  bool paramRequired = requiredKind &&
+                       requiredKind.getValue() == QualifiedType::PARAM;
+#endif
+
   if (bestKind == QualifiedType::PARAM && !paramRequired) {
     // We couldn't unify the types as params, but maybe if we downgrade
     // them to values, it'll work.

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2820,10 +2820,6 @@ gatherAndFilterCandidatesForwarding(Context* context,
                                     CandidatesVec& poiCandidates,
                                     ForwardingInfoVec& nonPoiForwardingTo,
                                     ForwardingInfoVec& poiForwardingTo) {
-  nonPoiCandidates.empty();
-  poiCandidates.empty();
-  nonPoiForwardingTo.empty();
-  poiForwardingTo.empty();
 
   const Type* receiverType = ci.actual(0).type().type();
 

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -297,7 +297,11 @@ QualifiedType ReturnTypeInferrer::returnedType() {
       context->error(astForErr, "could not determine return type for function");
       retType = QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
     }
+#if LLVM_VERSION_MAJOR >= 16
+    auto adjType = adjustForReturnIntent(returnIntent, retType.value());
+#else
     auto adjType = adjustForReturnIntent(returnIntent, retType.getValue());
+#endif
     return adjType;
   }
 }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -653,7 +653,11 @@ bool LookupHelper::doLookupInImportsAndUses(
             traceResult->push_back(std::move(t));
           }
 
+#if LLVM_VERSION_MAJOR >= 16
+          result.push_back(std::move(foundIds.value()));
+#else
           result.push_back(std::move(foundIds.getValue()));
+#endif
           found = true;
         }
       }
@@ -864,7 +868,11 @@ bool LookupHelper::doLookupInExternBlocks(const Scope* scope,
           t.visibleThrough.push_back(std::move(elt));
           traceResult->push_back(std::move(t));
         }
+#if LLVM_VERSION_MAJOR >= 16
+        result.push_back(std::move(foundIds.value()));
+#else
         result.push_back(std::move(foundIds.getValue()));
+#endif
       }
     }
   }

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -161,7 +161,11 @@ OwnedIdsWithName::borrow(IdAndFlags::Flags filterFlags,
   // Are all of the filter flags present in flagsOr?
   // If not, it is not possible for this to match.
   if ((flagsOr_ & filterFlags) != filterFlags) {
+#if LLVM_VERSION_MAJOR >= 16
+    return std::nullopt;
+#else
     return llvm::None;
+#endif
   }
 
   if (BorrowedIdsWithName::isIdVisible(idv_, filterFlags, excludeFlagSet)) {
@@ -169,7 +173,11 @@ OwnedIdsWithName::borrow(IdAndFlags::Flags filterFlags,
   }
   // The first ID isn't visible; are others?
   if (moreIdvs_.get() == nullptr) {
+#if LLVM_VERSION_MAJOR >= 16
+    return std::nullopt;
+#else
     return llvm::None;
+#endif
   }
 
   // Are all of the filter flags present in flagsAnd?
@@ -192,7 +200,11 @@ OwnedIdsWithName::borrow(IdAndFlags::Flags filterFlags,
   }
 
   // No ID was visible, so we can't borrow.
+#if LLVM_VERSION_MAJOR >= 16
+  return std::nullopt;
+#else
   return llvm::None;
+#endif
 }
 
 int BorrowedIdsWithName::countVisibleIds(IdAndFlags::Flags flagsAnd,
@@ -313,10 +325,17 @@ bool Scope::lookupInScope(UniqueString name,
     // There might not be any IDs that are visible to us, so borrow returns
     // an optional list.
     auto borrowedIds = search->second.borrow(filterFlags, excludeFlags);
+#if LLVM_VERSION_MAJOR >= 16
+    if (borrowedIds.has_value()) {
+      result.push_back(std::move(borrowedIds.value()));
+      return true;
+    }
+#else
     if (borrowedIds.hasValue()) {
       result.push_back(std::move(borrowedIds.getValue()));
       return true;
     }
+#endif
   }
   return false;
 }

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -115,11 +115,19 @@ void testProgram(const std::vector<ReturnVariant>& variants, F func,
     requiredKind = kind;
   }
   auto commonTypeResult = chpl::resolution::commonType(context, types, requiredKind);
+#if LLVM_VERSION_MAJOR >= 16
+  auto qt = commonTypeResult.value_or(QualifiedType());
+#else
   auto qt = commonTypeResult.getValueOr(QualifiedType());
+#endif
   std::cout << "return type:" << std::endl;
   qt.dump();
   std::cout << std::endl;
+#if LLVM_VERSION_MAJOR >= 16
+  func(commonTypeResult.has_value(), qt);
+#else
   func(commonTypeResult.hasValue(), qt);
+#endif
 }
 
 static void test1() {

--- a/frontend/test/resolution/testScopeTypes.cpp
+++ b/frontend/test/resolution/testScopeTypes.cpp
@@ -108,8 +108,13 @@ static void testBorrowIds() {
                          /* field */ false, /* method */ false, /* parenful */ false);
     assert(ids.numIds() == 1);
     auto foundIds = ids.borrow(0, FlagSet::empty());
+#if LLVM_VERSION_MAJOR >= 16
+    assert(foundIds.has_value());
+    auto b = foundIds.value();
+#else
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
+#endif
     assert(b.firstId() == x);
     assert(b.numIds() == 1);
     int count = 0;
@@ -127,7 +132,11 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = pub;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
+#if LLVM_VERSION_MAJOR >= 16
+    assert(!foundIds.has_value());
+#else
     assert(!foundIds.hasValue());
+#endif
   }
   {
     // check one id with filtering
@@ -136,7 +145,11 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(not_method);
     auto foundIds = ids.borrow(f, e);
+#if LLVM_VERSION_MAJOR >= 16
+    assert(!foundIds.has_value());
+#else
     assert(!foundIds.hasValue());
+#endif
   }
 
   {
@@ -149,8 +162,13 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = pub;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
+#if LLVM_VERSION_MAJOR >= 16
+    assert(foundIds.has_value());
+    auto b = foundIds.value();
+#else
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
+#endif
     assert(b.firstId() == y);
     assert(b.numIds() == 1);
     int count = 0;
@@ -170,8 +188,13 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = IdAndFlags::PUBLIC;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
+#if LLVM_VERSION_MAJOR >= 16
+    assert(foundIds.has_value());
+    auto b = foundIds.value();
+#else
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
+#endif
     assert(b.firstId() == y);
     assert(b.numIds() == 1);
     int count = 0;
@@ -191,8 +214,13 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
+#if LLVM_VERSION_MAJOR >= 16
+    assert(foundIds.has_value());
+    auto b = foundIds.value();
+#else
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
+#endif
     assert(b.firstId() == y);
     assert(b.numIds() == 2);
     int count = 0;
@@ -212,8 +240,13 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
+#if LLVM_VERSION_MAJOR >= 16
+    assert(foundIds.has_value());
+    auto b = foundIds.value();
+#else
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
+#endif
     assert(b.firstId() == x);
     assert(b.numIds() == 1);
     int count = 0;
@@ -233,8 +266,13 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
+#if LLVM_VERSION_MAJOR >= 16
+    assert(foundIds.has_value());
+    auto b = foundIds.value();
+#else
     assert(foundIds.hasValue());
     auto b = foundIds.getValue();
+#endif
     assert(b.firstId() == x);
     assert(b.numIds() == 1);
     int count = 0;
@@ -254,7 +292,11 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub);
     auto foundIds = ids.borrow(f, e);
+#if LLVM_VERSION_MAJOR >= 16
+    assert(!foundIds.has_value());
+#else
     assert(!foundIds.hasValue());
+#endif
   }
 }
 

--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -79,7 +79,13 @@ endif
 # Flags for compiler, runtime, and generated code
 #
 COMP_CFLAGS = $(C_STD) $(CPPFLAGS) $(FLAGS)
-COMP_CXXFLAGS = $(CXX14_STD) $(CPPFLAGS) $(CXXFLAGS)
+ifeq ($(CHPL_MAKE_LLVM_VERSION),16)
+# get the C++ standard flag from CMake
+COMP_CXXFLAGS = $(CPPFLAGS) $(CXXFLAGS)
+else
+COMP_CXXFLAGS += $(CXX14_STD) $(CPPFLAGS) $(CXXFLAGS)
+endif
+
 COMP_CXXFLAGS_NONCHPL = -Wno-error
 RUNTIME_CFLAGS = $(C_STD) $(CPPFLAGS) $(CFLAGS)
 RUNTIME_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -143,9 +143,9 @@ DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -
 C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
 CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 
-# CXX11_STD is the flag to select C++11, or "unknown" for compilers
-# we don't know how to do that with yet.
-# If a compiler uses C++11 or newer by default, CXX11_STD will be blank.
+# CXX11_STD is the flag to select C++11, blank for compilers that
+# don't know how to do that
+# Also, if a compiler uses C++11 or newer by default, CXX11_STD will be blank.
 CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 CXX14_STD := $(shell test $(DEF_CXX_VER) -lt 201402 && echo -std=gnu++14)
 
@@ -155,7 +155,11 @@ ifeq ($(GNU_GPP_MAJOR_VERSION),4)
 endif
 
 COMP_CFLAGS += $(C_STD)
+ifneq ($(CHPL_MAKE_LLVM_VERSION),16)
 COMP_CXXFLAGS += $(CXX14_STD)
+else
+# get the C++ standard flag from CMake
+endif
 RUNTIME_CFLAGS += $(C_STD)
 RUNTIME_CXXFLAGS += $(CXX_STD)
 GEN_CFLAGS += $(C_STD)


### PR DESCRIPTION
The focus of this PR is to enable `CHPL_LLVM=none` builds when using LLVM 16 to provide the LLVM Support library. That is slightly complicated for two reasons:
 * LLVM 16 requires C++17 and the LLVM 16 headers will not compile with just C++14
 * LLVM 16 deprecates `llvm::Optional` and replaces it with `std::optional`. However, it is not a clean deprecation, since some methods are spelled differently, and so causes errors in some cases (and not just warnings).

This PR:
 * updates build scripts to use C++17 when working with LLVM 16. LLVM 16 headers will not compile with C++14.
 * adds `#if` blocks to adjust for the different spelling of `optional` methods in LLVM 11 vs LLVM 16.
 * updates BorrowedIdsWithNameIter to avoid a C++ `std::iterator` template deprecated in C++17
 * removes some useless .empty calls in gatherAndFilterCandidatesForwarding.

Future Work:
 * Require C++17 for the Chapel C++ compiler source code and remove the ifdefs related to `llvm::Optional` changing behavior and just use `std::optional` in our code.

Reviewed by @DanilaFe - thanks!

- [x] compiler builds with LLVM 16 and CHPL_LLVM=none (to use the LLVM Support library only; note that this currently requires with patches to allow it & make warnings non-fatal) and Hello World runs in that configuration
- [x] comm=none testing with LLVM 14