### PR TITLE
Ifdef out typed-pointer-dependent llvmDebug code

### DIFF
--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -172,6 +172,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
     }
     else {
       if(type->astTag == E_PrimitiveType) {
+#ifdef HAVE_LLVM_TYPED_POINTERS
         llvm::Type *PointeeTy = ty->getPointerElementType();
         // handle string, c_string, nil, opaque, c_void_ptr
         if(PointeeTy->isIntegerTy()) {
@@ -220,6 +221,9 @@ llvm::DIType* debug_data::construct_type(Type *type)
           myTypeDescriptors[type] = N;
           return llvm::cast_or_null<llvm::DIType>(N);
         }
+#else
+        return NULL;
+#endif
       }
       else if(type->astTag == E_AggregateType) {
         // dealing with classes

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -172,6 +172,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
     }
     else {
       if(type->astTag == E_PrimitiveType) {
+        // TODO: reimplement this properly within the Chapel type system
 #ifdef HAVE_LLVM_TYPED_POINTERS
         llvm::Type *PointeeTy = ty->getPointerElementType();
         // handle string, c_string, nil, opaque, c_void_ptr


### PR DESCRIPTION
Adds macro guards so the usage of a typed pointer only occurs if our LLVM has typed pointers enabled.

On Michael's recommendation I am ifdef'ing out this entire section of code that is relying on pointer element types. It is likely already not working properly, and does not seem to be tested beyond basic functionality.

[reviewer info]

Testing:
- [x] LLVM 14 paratest