### PR TITLE
Update regexp to determineOclcVersionLib based on CHPL_GPU_ARCH

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3904,7 +3904,7 @@ static std::string determineOclcVersionLib(std::string libPath) {
 
   // Extract version number from CHPL_GPU_ARCH string (e.g. extract
   // the 908 from "gfx908")
-  std::regex pattern("gfx(\\d+)");
+  std::regex pattern("[[:alpha:]]+([[:digit:]]+[[:alpha:]]?)");
   std::cmatch match;
   if (std::regex_search(CHPL_GPU_ARCH, match, pattern)) {
     result = libPath + "/oclc_isa_version_" + std::string(match[1]) + ".bc";
@@ -4228,7 +4228,8 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
                       "/llvm/bin/lld -flavor gnu" +
                        " --no-undefined -shared" +
                        " -plugin-opt=-amdgpu-internalize-symbols" +
-                       " -plugin-opt=mcpu=gfx906 -plugin-opt=O3" +
+                       " -plugin-opt=mcpu=" + CHPL_GPU_ARCH +
+                       " -plugin-opt=O3" +
                        " -plugin-opt=-amdgpu-early-inline-all=true" +
                        " -plugin-opt=-amdgpu-function-calls=false -o " +
                        outFilename + " " + artifactFilename;


### PR DESCRIPTION
This PR updates the regexp that determines what version of a `oclc_isa_version` file to use based on the value of `CHPL_GPU_ARCH`.  There's some question in my head about if merely updating the regexp is the right thing to do, I go into more detail about that in the underlying issue: <https://github.com/chapel-lang/chapel/issues/21964>.  But this PR is an improvement over what we currently have.
