### PR TITLE
Fix an LLVM 11 compatability issue

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -686,12 +686,8 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
   GenInfo* info = gGenInfo;
 
   llvm::Type* loadType = computePointerElementType(ptr, valType);
-
-#if HAVE_LLVM_VER >= 130
   llvm::LoadInst* ret = info->irBuilder->CreateLoad(loadType, ptr);
-#else
-  llvm::LoadInst* ret = info->irBuilder->CreateLoad(ptr);
-#endif
+
   llvm::MDNode* tbaa = NULL;
   if (USE_TBAA && valType &&
       (isClass(valType) || !valType->symbol->llvmTbaaStructCopyNode)) {


### PR DESCRIPTION
Follow-up to PR #22240 to fix an unused variable when using LLVM 11. This PR just removes an ifdef that is unnecessary since LLVM 11 supports the newer form of CreateLoad.

Trivial and not reviewed.

- [x] fixes warning building cg-expr.cpp with LLVM 11
- [x] full comm=none testing with LLVM 14