### PR TITLE
Handle computing CHPL_COMPILER=gnu from CC=gcc.exe

### DIFF
--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -271,11 +271,12 @@ COMPILERS = [('gnu', 'gcc', 'g++'),
 # and the C and C++ variants of that command
 def get_compiler_from_command(command):
     # the following adjustments are to handle a command like
-    #    /path/to/gcc-10 --some-option
+    #    /path/to/gcc.exe-10 --some-option
     # where we are looking for just the 'gcc' part.
     first = command.split()[0]
     basename = os.path.basename(first)
     name = basename.split('-')[0].strip()
+    name = name.split('.')[0].strip()
     for tup in COMPILERS:
         if name == tup[1] or name == tup[2]:
             return tup[0]

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -271,7 +271,7 @@ COMPILERS = [('gnu', 'gcc', 'g++'),
 # and the C and C++ variants of that command
 def get_compiler_from_command(command):
     # the following adjustments are to handle a command like
-    #    /path/to/gcc.exe-10 --some-option
+    #    /path/to/gcc-10.exe --some-option
     # where we are looking for just the 'gcc' part.
     first = command.split()[0]
     basename = os.path.basename(first)


### PR DESCRIPTION
Follow-up to #21985 to resolve a Cygwin configuration failure where `CHPL_HOST_CC` is set to `gcc.exe` and the compiler detection logic is unable to infer `CHPL_COMPILER=gnu` from that.

Reviewed by @arezaii - thanks!

- [x] `make && make check` succeeds on a Cygwin system
- [x] full comm=none testing