### PR TITLE
Enable opaque pointers for LLVM 15

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1919,15 +1919,14 @@ static void codegen_header(std::set<const char*> & cnames,
           info->module->getNamedGlobal("chpl_globals_registry"))) {
       GVar->eraseFromParent();
     }
+    llvm::Type* globValType =
+      llvm::ArrayType::get(ptr_wide_ptr_t, globals_registry_static_size);
     llvm::GlobalVariable *chpl_globals_registryGVar =
       llvm::cast<llvm::GlobalVariable>(
           info->module->getOrInsertGlobal("chpl_globals_registry",
-            llvm::ArrayType::get(
-              ptr_wide_ptr_t,
-              globals_registry_static_size)));
+                                          globValType));
     chpl_globals_registryGVar->setInitializer(
-        llvm::Constant::getNullValue(
-          chpl_globals_registryGVar->getType()->getContainedType(0)));
+        llvm::Constant::getNullValue(globValType));
     info->lvt->addGlobalValue("chpl_globals_registry",
                               chpl_globals_registryGVar, GEN_PTR, true, /* chplType= */ nullptr);
 #endif

--- a/compiler/include/llvmVer.h
+++ b/compiler/include/llvmVer.h
@@ -31,8 +31,9 @@
 #error LLVM version is too old for this version of Chapel
 #endif
 
-// TODO: this is transitional -- stop setting LLVM_NO_OPAQUE_POINTERS when ready
-#define LLVM_NO_OPAQUE_POINTERS 1
+// LLVM 15 supports opaque pointers or typed pointers.
+// To select typed pointers, use
+//   #define LLVM_NO_OPAQUE_POINTERS 1
 
 // define HAVE_LLVM_TYPED_POINTERS if the LLVM version / configuration
 // allows typed pointers (and leave it undefined if only opaque pointers


### PR DESCRIPTION
This PR enables opaque pointers when using LLVM 15. Opaque pointers are the default in LLVM 15 and the alternative of typed pointers is not supported in future versions of LLVM.

Besides adjusting ifdefs to enable it, this PR fixes two problems uncovered in testing this mode:
 * Fixes a use of getContainedType in codegen.cpp that was computing a pointer element type.
 * Fixes a problem with llvmGlobalToWide.cpp where a Constant GetElementPointer would not have its types adjusted from the Global types (which can use address space 100) to the wide pointer versions. It seems to me to be something that LLVM's ValueMapper should do, but for now we fix it in llvmGlobalToWide. Since I was working on llvmGlobalToWide this PR also makes a a simplification to that pass that should not change its behavior.

Future Work: enable LLVM 15 in the chplenv scripts

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14
- [x] full comm=none testing with LLVM 15
- [x] full comm=gasnet testing with LLVM 14
- [x] full comm=gasnet testing with LLVM 15