### PR TITLE
Fixing sporadic memory leak in `shared` deinitializer

### DIFF
--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -54,12 +54,12 @@ module SharedObject {
     }
 
     // decrement the strong reference count and return its new value
-    proc releaseStrong() {
+    inline proc releaseStrong() {
       return strongCount.fetchSub(1) - 1;
     }
 
     // decrement the total reference count and return its new value
-    proc releaseTotal() {
+    inline proc releaseTotal() {
       return totalCount.fetchSub(1) - 1;
     }
 

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -53,12 +53,15 @@ module SharedObject {
       totalCount.add(1);
     }
 
-    // decrement the strong reference count and return the new strong- and total-counts
-    proc release() {
-      var oldValue = strongCount.fetchSub(1);
-      return (oldValue - 1, totalCount.fetchSub(1) - 1);
+    // decrement the strong reference count and return its new value
+    proc releaseStrong() {
+      return strongCount.fetchSub(1) - 1;
     }
 
+    // decrement the total reference count and return its new value
+    proc releaseTotal() {
+      return totalCount.fetchSub(1) - 1;
+    }
 
     // ---------------- 'weak' interface ----------------
 
@@ -327,15 +330,13 @@ module SharedObject {
     @chpldoc.nodoc
     proc ref doClear() {
       if chpl_p != nil && chpl_pn != nil {
-        var (strongCount, totalCount) = chpl_pn!.release();
-        if strongCount == 0 {
-          // this is the last strong pointer, free the underlying class
+        const sc = chpl_pn!.releaseStrong();
+        if sc == 0 then
           delete _to_unmanaged(chpl_p);
-          if totalCount == 0 {
-            // There are no weak pointers, free the reference counter too
-            delete chpl_pn;
-          }
-        }
+
+        const tc = chpl_pn!.releaseTotal();
+        if tc == 0 then
+          delete chpl_pn;
       }
       chpl_p = nil;
       chpl_pn = nil;


### PR DESCRIPTION
Fixes a bug where concurrently deinitializing shared objects could result in the underlying `ReferenceCount` object being leaked.

This failure mode was difficult to reproduce, but came up in `test/types/records/copy-elision/copy-elision-default-behavior.chpl` which exhibits the following pattern:

```chapel
proc test() {
  var s: sync int;
  var x = new shared myClass();

  begin {
    var y = x;
    writeln(y);
    s.writeEF(1);
    // y deinitialized here
  }
  s.readFE();
  // x deinitialized here
}

sync { test(); }
```

Here, the two deinitializers can be executed concurrently, which was occasionally preventing the `ReferenceCount` object from being deleted.

- [X] reran failing test 10000 times with `-memleaks` checks
- [x] reran failing test with valgrind
- [x] paratest