### PR TITLE
Add some basic JSON IO support to standard Map and List

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1737,7 +1737,7 @@ module List {
       _leave();
     }
 
-    pragma "no doc"
+    @chpldoc.nodoc
     proc _writeJson(ch: fileWriter) throws {
       _enter();
 
@@ -1827,6 +1827,7 @@ module List {
       _leave();
     }
 
+    @chpldoc.nodoc
     proc _readJson(ch: fileReader) throws {
       var isFirst = true;
       var hasReadEnd = false;

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1704,6 +1704,12 @@ module List {
     */
     proc writeThis(ch: fileWriter) throws {
       var isBinary = ch.binary();
+      const isJson = ch.styleElement(QIO_STYLE_ELEMENT_AGGREGATE) == QIO_AGGREGATE_FORMAT_JSON;
+
+      if isJson {
+        _writeJson(ch);
+        return;
+      }
 
       _enter();
 
@@ -1731,6 +1737,25 @@ module List {
       _leave();
     }
 
+    pragma "no doc"
+    proc _writeJson(ch: fileWriter) throws {
+      _enter();
+
+      ch._writeLiteral("[");
+
+      for i in 0..(_size - 2) {
+        ch.writef("%jt", _getRef(i));
+        ch._writeLiteral(", ");
+      }
+
+      if _size > 0 then
+        ch.writef("%jt", _getRef(_size-1));
+
+      ch._writeLiteral("]");
+
+      _leave();
+    }
+
     /*
      Read the contents of this list from a channel.
 
@@ -1742,6 +1767,11 @@ module List {
       // size.
       //
       const isBinary = ch.binary();
+      const isJson = ch.styleElement(QIO_STYLE_ELEMENT_AGGREGATE) == QIO_AGGREGATE_FORMAT_JSON;
+      if isJson then {
+        _readJson(ch);
+        return;
+      }
 
       _enter();
 
@@ -1792,6 +1822,32 @@ module List {
         if !hasReadEnd {
           ch._readLiteral("]");
         }
+      }
+
+      _leave();
+    }
+
+    proc _readJson(ch: fileReader) throws {
+      var isFirst = true;
+      var hasReadEnd = false;
+
+      _enter();
+      _clearLocked();
+
+      ch._readLiteral("[");
+
+      while !ch.matchLiteral("]") {
+        if isFirst {
+          isFirst = false;
+        } else {
+          ch._readLiteral(",");
+        }
+
+        // read an element
+        pragma "no auto destroy"
+        var elt: eltType;
+        ch.readf("%jt", elt);
+        _appendByRef(elt);
       }
 
       _leave();

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -652,7 +652,33 @@ module Map {
       :arg ch: A channel to read from.
     */
     proc readThis(ch: fileReader) throws {
-      _readWriteHelper(ch);
+      const isJson = ch.styleElement(QIO_STYLE_ELEMENT_AGGREGATE) == QIO_AGGREGATE_FORMAT_JSON;
+      if isJson then
+        _readJson(ch);
+      else
+        _readWriteHelper(ch);
+    }
+
+    pragma "no doc"
+    proc _readJson(ch: fileReader) throws {
+      _enter(); defer _leave();
+      var first = true;
+
+      ch._readLiteral("{");
+
+      while !ch.matchLiteral("}") {
+        if first {
+          first = false;
+        } else {
+          ch._readLiteral(",");
+        }
+        var k : keyType;
+        ch.readf("%jt", k);
+        ch._readLiteral(":");
+        var v : valType;
+        ch.readf("%jt", v);
+        add(k, v);
+      }
     }
 
     //
@@ -681,7 +707,37 @@ module Map {
       :arg ch: A channel to write to.
     */
     proc writeThis(ch: fileWriter) throws {
-      _readWriteHelper(ch);
+      const isJson = ch.styleElement(QIO_STYLE_ELEMENT_AGGREGATE) == QIO_AGGREGATE_FORMAT_JSON;
+      if isJson then
+        _writeJson(ch);
+      else
+        _readWriteHelper(ch);
+    }
+
+    pragma "no doc"
+    proc _writeJson(ch: fileWriter) throws {
+      _enter(); defer _leave();
+      var first = true;
+
+      ch._writeLiteral("{");
+
+      for slot in table.allSlots() {
+        if table.isSlotFull(slot) {
+          if first {
+            first = false;
+          } else {
+            ch._writeLiteral(", ");
+          }
+          ref tabEntry = table.table[slot];
+          ref key = tabEntry.key;
+          ref val = tabEntry.val;
+          ch.writef("%jt", key);
+          ch._writeLiteral(": ");
+          ch.writef("%jt", val);
+        }
+      }
+
+      ch._writeLiteral("}");
     }
 
     pragma "no doc"

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -659,7 +659,7 @@ module Map {
         _readWriteHelper(ch);
     }
 
-    pragma "no doc"
+    @chpldoc.nodoc
     proc _readJson(ch: fileReader) throws {
       _enter(); defer _leave();
       var first = true;
@@ -714,7 +714,7 @@ module Map {
         _readWriteHelper(ch);
     }
 
-    pragma "no doc"
+    @chpldoc.nodoc
     proc _writeJson(ch: fileWriter) throws {
       _enter(); defer _leave();
       var first = true;

--- a/test/library/standard/List/testJson.chpl
+++ b/test/library/standard/List/testJson.chpl
@@ -1,0 +1,66 @@
+
+use IO;
+use List;
+
+record R {
+  var x : int;
+  var y : real;
+}
+
+record Z {
+  var z : string;
+  var r : R;
+}
+
+proc testList(orig: list(?)) {
+  const header = "--- " + orig.type:string + " ---";
+  writeln(header);
+  var f = openMemFile();
+  {
+    f.writer().writef("%jt", orig);
+    writeln("Writing list: ");
+    writeln(orig);
+    writeln();
+    writeln("Wrote JSON: ");
+    writef("%jt\n", orig);
+    writeln();
+  }
+  {
+    var r = f.reader();
+    var li : orig.type;
+    r.readf("%jt", li);
+    writeln("Read ", li.type:string, ": ");
+    writeln(li);
+    writeln("Equals original: ", li == orig);
+  }
+  writeln("-"*header.size);
+}
+
+proc main() {
+  {
+    var li : list(int);
+    for i in 1..4 do li.append(i);
+    testList(li);
+  }
+  {
+    var li : list(string);
+    for i in 1..4 do li.append("val" + i:string);
+    testList(li);
+  }
+  {
+    var li : list(R);
+  }
+  {
+    var li : list(R);
+    li.append(new R(5, 42.0));
+    li.append(new R(9, 9.9));
+    li.append(new R(3, 3.3));
+    testList(li);
+  }
+  {
+    var li : list(Z);
+    li.append(new Z("red", new R(1, 0.31)));
+    li.append(new Z("yellow", new R(0, 0.68)));
+    testList(li);
+  }
+}

--- a/test/library/standard/List/testJson.chpl
+++ b/test/library/standard/List/testJson.chpl
@@ -63,4 +63,12 @@ proc main() {
     li.append(new Z("yellow", new R(0, 0.68)));
     testList(li);
   }
+  {
+    var li : list(list(int));
+    var x : list(int) = [1, 2, 3];
+    var y : list(int) = [4, 5, 6];
+    li.append(x);
+    li.append(y);
+    testList(li);
+  }
 }

--- a/test/library/standard/List/testJson.chpl
+++ b/test/library/standard/List/testJson.chpl
@@ -1,6 +1,7 @@
 
 use IO;
 use List;
+use Map;
 
 record R {
   var x : int;
@@ -67,6 +68,21 @@ proc main() {
     var li : list(list(int));
     var x : list(int) = [1, 2, 3];
     var y : list(int) = [4, 5, 6];
+    li.append(x);
+    li.append(y);
+    testList(li);
+  }
+  {
+    var li : list(map(string, int));
+
+    var x : map(string,int);
+    x.add("A", 1);
+    x.add("B", 2);
+
+    var y : map(string,int);
+    y.add("X", 3);
+    y.add("Y", 4);
+
     li.append(x);
     li.append(y);
     testList(li);

--- a/test/library/standard/List/testJson.good
+++ b/test/library/standard/List/testJson.good
@@ -1,0 +1,44 @@
+--- list(int(64),false) ---
+Writing list: 
+[1, 2, 3, 4]
+
+Wrote JSON: 
+[1, 2, 3, 4]
+
+Read list(int(64),false): 
+[1, 2, 3, 4]
+Equals original: true
+---------------------------
+--- list(string,false) ---
+Writing list: 
+[val1, val2, val3, val4]
+
+Wrote JSON: 
+["val1", "val2", "val3", "val4"]
+
+Read list(string,false): 
+[val1, val2, val3, val4]
+Equals original: true
+--------------------------
+--- list(R,false) ---
+Writing list: 
+[(x = 5, y = 42.0), (x = 9, y = 9.9), (x = 3, y = 3.3)]
+
+Wrote JSON: 
+[{"x":5, "y":4.200000e+01}, {"x":9, "y":9.900000e+00}, {"x":3, "y":3.300000e+00}]
+
+Read list(R,false): 
+[(x = 5, y = 42.0), (x = 9, y = 9.9), (x = 3, y = 3.3)]
+Equals original: true
+---------------------
+--- list(Z,false) ---
+Writing list: 
+[(z = red, r = (x = 1, y = 0.31)), (z = yellow, r = (x = 0, y = 0.68))]
+
+Wrote JSON: 
+[{"z":"red", "r":{"x":1, "y":3.100000e-01}}, {"z":"yellow", "r":{"x":0, "y":6.800000e-01}}]
+
+Read list(Z,false): 
+[(z = red, r = (x = 1, y = 0.31)), (z = yellow, r = (x = 0, y = 0.68))]
+Equals original: true
+---------------------

--- a/test/library/standard/List/testJson.good
+++ b/test/library/standard/List/testJson.good
@@ -42,3 +42,14 @@ Read list(Z,false):
 [(z = red, r = (x = 1, y = 0.31)), (z = yellow, r = (x = 0, y = 0.68))]
 Equals original: true
 ---------------------
+--- list(list(int(64),false),false) ---
+Writing list: 
+[[1, 2, 3], [4, 5, 6]]
+
+Wrote JSON: 
+[[1, 2, 3], [4, 5, 6]]
+
+Read list(list(int(64),false),false): 
+[[1, 2, 3], [4, 5, 6]]
+Equals original: true
+---------------------------------------

--- a/test/library/standard/List/testJson.good
+++ b/test/library/standard/List/testJson.good
@@ -53,3 +53,14 @@ Read list(list(int(64),false),false):
 [[1, 2, 3], [4, 5, 6]]
 Equals original: true
 ---------------------------------------
+--- list(map(string,int(64),false),false) ---
+Writing list: 
+[{A: 1, B: 2}, {Y: 4, X: 3}]
+
+Wrote JSON: 
+[{"A": 1, "B": 2}, {"Y": 4, "X": 3}]
+
+Read list(map(string,int(64),false),false): 
+[{A: 1, B: 2}, {Y: 4, X: 3}]
+Equals original: true
+---------------------------------------------

--- a/test/library/standard/Map/testJson.chpl
+++ b/test/library/standard/Map/testJson.chpl
@@ -1,0 +1,59 @@
+
+use IO;
+use Map;
+
+record R {
+  var x : int;
+  var y : real;
+}
+
+record Z {
+  var z : string;
+  var r : R;
+}
+
+proc testMap(orig: map(?)) {
+  const header = "--- " + orig.type:string + " ---";
+  writeln(header);
+  var f = openMemFile();
+  {
+    f.writer().writef("%jt", orig);
+    writeln("Writing map: ");
+    writeln(orig);
+    writeln();
+    writeln("Wrote JSON: ");
+    writef("%jt\n", orig);
+    writeln();
+  }
+  {
+    var r = f.reader();
+    var m : orig.type;
+    r.readf("%jt", m);
+    writeln("Read ", m.type:string, ": ");
+    writeln(m);
+    writeln("Equals original: ", m == orig);
+  }
+  writeln("-"*header.size);
+}
+
+proc main() {
+  {
+    var m : map(string,string);
+    m.add("key1", "val1");
+    m.add("key2", "val2");
+    testMap(m);
+  }
+  {
+    var stringR : map(string, R);
+    stringR.add("red", new R(5, 42.0));
+    stringR.add("blue", new R(9, 9.9));
+    stringR.add("green", new R(3, 3.3));
+    testMap(stringR);
+  }
+  {
+    var m : map(string, Z);
+    m.add("apple", new Z("red", new R(1, 0.31)));
+    m.add("banana", new Z("yellow", new R(0, 0.68)));
+    testMap(m);
+  }
+}

--- a/test/library/standard/Map/testJson.chpl
+++ b/test/library/standard/Map/testJson.chpl
@@ -1,6 +1,7 @@
 
 use IO;
 use Map;
+use List;
 
 record R {
   var x : int;
@@ -69,6 +70,14 @@ proc main() {
     m.add("x", x);
     m.add("y", y);
 
+    testMap(m);
+  }
+  {
+    var m : map(string, list(int));
+    var x : list(int) = [1, 2, 3];
+    var y : list(int) = [4, 5, 6];
+    m.add("x", x);
+    m.add("y", y);
     testMap(m);
   }
 }

--- a/test/library/standard/Map/testJson.chpl
+++ b/test/library/standard/Map/testJson.chpl
@@ -56,4 +56,19 @@ proc main() {
     m.add("banana", new Z("yellow", new R(0, 0.68)));
     testMap(m);
   }
+  {
+    var x : map(string, int);
+    x.add("A", 5);
+    x.add("B", 42);
+
+    var y : map(string, int);
+    y.add("R", 99);
+    y.add("S", 33);
+
+    var m : map(string, map(string, int));
+    m.add("x", x);
+    m.add("y", y);
+
+    testMap(m);
+  }
 }

--- a/test/library/standard/Map/testJson.good
+++ b/test/library/standard/Map/testJson.good
@@ -31,3 +31,14 @@ Read map(string,Z,false):
 {banana: (z = yellow, r = (x = 0, y = 0.68)), apple: (z = red, r = (x = 1, y = 0.31))}
 Equals original: true
 ---------------------------
+--- map(string,map(string,int(64),false),false) ---
+Writing map: 
+{y: {S: 33, R: 99}, x: {A: 5, B: 42}}
+
+Wrote JSON: 
+{"y": {"S": 33, "R": 99}, "x": {"A": 5, "B": 42}}
+
+Read map(string,map(string,int(64),false),false): 
+{y: {S: 33, R: 99}, x: {A: 5, B: 42}}
+Equals original: true
+---------------------------------------------------

--- a/test/library/standard/Map/testJson.good
+++ b/test/library/standard/Map/testJson.good
@@ -1,0 +1,33 @@
+--- map(string,string,false) ---
+Writing map: 
+{key2: val2, key1: val1}
+
+Wrote JSON: 
+{"key2": "val2", "key1": "val1"}
+
+Read map(string,string,false): 
+{key2: val2, key1: val1}
+Equals original: true
+--------------------------------
+--- map(string,R,false) ---
+Writing map: 
+{red: (x = 5, y = 42.0), blue: (x = 9, y = 9.9), green: (x = 3, y = 3.3)}
+
+Wrote JSON: 
+{"red": {"x":5, "y":4.200000e+01}, "blue": {"x":9, "y":9.900000e+00}, "green": {"x":3, "y":3.300000e+00}}
+
+Read map(string,R,false): 
+{red: (x = 5, y = 42.0), blue: (x = 9, y = 9.9), green: (x = 3, y = 3.3)}
+Equals original: true
+---------------------------
+--- map(string,Z,false) ---
+Writing map: 
+{banana: (z = yellow, r = (x = 0, y = 0.68)), apple: (z = red, r = (x = 1, y = 0.31))}
+
+Wrote JSON: 
+{"banana": {"z":"yellow", "r":{"x":0, "y":6.800000e-01}}, "apple": {"z":"red", "r":{"x":1, "y":3.100000e-01}}}
+
+Read map(string,Z,false): 
+{banana: (z = yellow, r = (x = 0, y = 0.68)), apple: (z = red, r = (x = 1, y = 0.31))}
+Equals original: true
+---------------------------

--- a/test/library/standard/Map/testJson.good
+++ b/test/library/standard/Map/testJson.good
@@ -42,3 +42,14 @@ Read map(string,map(string,int(64),false),false):
 {y: {S: 33, R: 99}, x: {A: 5, B: 42}}
 Equals original: true
 ---------------------------------------------------
+--- map(string,list(int(64),false),false) ---
+Writing map: 
+{y: [4, 5, 6], x: [1, 2, 3]}
+
+Wrote JSON: 
+{"y": [4, 5, 6], "x": [1, 2, 3]}
+
+Read map(string,list(int(64),false),false): 
+{y: [4, 5, 6], x: [1, 2, 3]}
+Equals original: true
+---------------------------------------------


### PR DESCRIPTION
This PR adds some basic support for reading and writing standard ``map``s and ``list``s with the ``%jt`` formatting option.

Testing:
- [x] full local