### PR TITLE
Avoid calling abs on at integer min in chpl__mod

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -3075,9 +3075,10 @@ operator :(r: range(?), type t: range(?)) {
   {
     type t = modulus.type;
     var m = modulus;
-    if isIntType(t) {
-      if modulus != min(t) then m = abs(modulus);
-    }
+    // The extra check for `m != min(t)` is requird to avoid an optimizer
+    // (specially LLVM) determin that `-min(t)` is undefined and inserting
+    // `poison`.
+    if isIntType(t) && m < 0 && m != min(t) then m = -m;
 
     var tmp = dividend % m;
     if isInt(dividend) then

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -3073,7 +3073,11 @@ operator :(r: range(?), type t: range(?)) {
   //
   proc chpl__mod(dividend:integral, modulus:integral)
   {
-    const m = abs(modulus);
+    type t = modulus.type;
+    var m = modulus;
+    if isIntType(t) {
+      if modulus != min(t) then m = abs(modulus);
+    }
 
     var tmp = dividend % m;
     if isInt(dividend) then


### PR DESCRIPTION
Adds a check to `chpl__mod` to only call `abs` on the `modulus` if it is well defined. 

`abs` is implemented as `if i < 0 then -i else i`. If this code is passed `min(int(?w))`, it will return the same value since there is no valid positive representation at that bit width. This is fine under normal codegen, but in optimized code an optimizer may decide this is invalid and insert `poison`.

This resolves an issue seen in our nightly testing

## Summary of changes
- add signed min check for `chpl__mod`, which could also insert poison values.

## testing
- paratest with futures
- paratest + gasnet

---

[Reviewed by @vasslitvinov]