### PR TITLE
Fix LLVM IR symbol name comparison in mismatch-ri-iv.bad

### DIFF
--- a/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
@@ -1,5 +1,5 @@
 Incorrect number of arguments passed to called function!
-  %4 = call i32 @returnIntFromIntArg() #0
+  %n = call i32 @returnIntFromIntArg() #0
 internal error: COD-CG--BOL-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler,

--- a/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.prediff
+++ b/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.prediff
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Ignore LLVM IR line number, as it is LLVM version-dependent
+
+TESTNAME=$1
+OUTFILE=$2
+
+TMPFILE="$outfile.prediff.tmp"
+mv $OUTFILE $TMPFILE
+sed -e 's/%[0-9]/%n/g' $TMPFILE > $OUTFILE
+rm $TMPFILE


### PR DESCRIPTION
Adds a `.prediff` stripping the symbol name on the offending line from the compiler output (and corresponding `.bad`), so additional symbols before the line do not affect the test.

In this case, this was necessary because moving to opaque pointers removes a bitcast that was previously required.

[trivial test change, not reviewed]

Testing:
- [x] .bad matches on LLVM 14 and 15 (with opaque pointers)