### PR TITLE
Define new chpl::option data type to avoid some LLVM16 ifdefs

### DIFF
--- a/doc/rst/meta/compiler-internals-doxygen/base.rst
+++ b/doc/rst/meta/compiler-internals-doxygen/base.rst
@@ -71,6 +71,8 @@ namespace. The entries may not be exhaustive.
    :members:
    :undoc-members:
 
+.. doxygentypedef:: chpl::optional
+
 .. doxygentypedef:: chpl::owned
 
 .. doxygenenum:: chpl::StringifyKind

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -180,12 +180,12 @@ CanPassResult canPass(Context* context,
   commonType to serve the case of functions that enforce param, type,
   or const returns.
  */
-using KindRequirement = opt<chpl::types::QualifiedType::Kind>;
+using KindRequirement = optional<chpl::types::QualifiedType::Kind>;
 
 /**
   Given a (non-empty) list of types (e.g., the types of various return
   statements in a function), determine the type, if any, that can be used to
-  represent all of them. Returns an opt that contains the qualified
+  represent all of them. Returns an optional that contains the qualified
   type if one is found, or is empty otherwise.
 
   If useRequiredKind=true is specified, the requiredKind argument is treated
@@ -194,7 +194,7 @@ using KindRequirement = opt<chpl::types::QualifiedType::Kind>;
   result in failure to find a common type, even if the types can otherwise
   by unified.
  */
-opt<chpl::types::QualifiedType>
+optional<chpl::types::QualifiedType>
 commonType(Context* context,
            const std::vector<chpl::types::QualifiedType>& types,
            KindRequirement requiredKind = KindRequirement());

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -180,12 +180,12 @@ CanPassResult canPass(Context* context,
   commonType to serve the case of functions that enforce param, type,
   or const returns.
  */
-using KindRequirement = llvm::Optional<chpl::types::QualifiedType::Kind>;
+using KindRequirement = opt<chpl::types::QualifiedType::Kind>;
 
 /**
   Given a (non-empty) list of types (e.g., the types of various return
   statements in a function), determine the type, if any, that can be used to
-  represent all of them. Returns an llvm::Optional that contains the qualified
+  represent all of them. Returns an opt that contains the qualified
   type if one is found, or is empty otherwise.
 
   If useRequiredKind=true is specified, the requiredKind argument is treated
@@ -194,7 +194,7 @@ using KindRequirement = llvm::Optional<chpl::types::QualifiedType::Kind>;
   result in failure to find a common type, even if the types can otherwise
   by unified.
  */
-llvm::Optional<chpl::types::QualifiedType>
+opt<chpl::types::QualifiedType>
 commonType(Context* context,
            const std::vector<chpl::types::QualifiedType>& types,
            KindRequirement requiredKind = KindRequirement());

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -311,7 +311,7 @@ class OwnedIdsWithName {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
-  llvm::Optional<BorrowedIdsWithName>
+  opt<BorrowedIdsWithName>
   borrow(IdAndFlags::Flags filterFlags, const IdAndFlags::FlagSet& excludeFlagSet) const;
 
   /// \cond DO_NOT_DOCUMENT
@@ -454,7 +454,7 @@ class BorrowedIdsWithName {
   }
  public:
 
-  static llvm::Optional<BorrowedIdsWithName>
+  static opt<BorrowedIdsWithName>
   createWithSingleId(ID id, uast::Decl::Visibility vis,
                      bool isField, bool isMethod, bool isParenfulFunction,
                      IdAndFlags::Flags filterFlags,
@@ -464,11 +464,7 @@ class BorrowedIdsWithName {
       return BorrowedIdsWithName(std::move(idAndVis),
                                  filterFlags, std::move(excludeFlagSet));
     }
-#if LLVM_VERSION_MAJOR >= 16
-    return std::nullopt;
-#else
-    return llvm::None;
-#endif
+    return chpl::empty;
   }
 
   static BorrowedIdsWithName
@@ -482,13 +478,8 @@ class BorrowedIdsWithName {
     auto maybeIds = createWithSingleId(std::move(id), vis,
                                        isField, isMethod, isParenfulFunction,
                                        filterFlags, excludeFlagSet);
-#if LLVM_VERSION_MAJOR >= 16
-    CHPL_ASSERT(maybeIds.has_value());
-    return maybeIds.value();
-#else
-    CHPL_ASSERT(maybeIds.hasValue());
-    return maybeIds.getValue();
-#endif
+    CHPL_ASSERT(!!maybeIds);
+    return *maybeIds;
   }
 
   static BorrowedIdsWithName

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -311,7 +311,7 @@ class OwnedIdsWithName {
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
-  opt<BorrowedIdsWithName>
+  optional<BorrowedIdsWithName>
   borrow(IdAndFlags::Flags filterFlags, const IdAndFlags::FlagSet& excludeFlagSet) const;
 
   /// \cond DO_NOT_DOCUMENT
@@ -454,7 +454,7 @@ class BorrowedIdsWithName {
   }
  public:
 
-  static opt<BorrowedIdsWithName>
+  static optional<BorrowedIdsWithName>
   createWithSingleId(ID id, uast::Decl::Visibility vis,
                      bool isField, bool isMethod, bool isParenfulFunction,
                      IdAndFlags::Flags filterFlags,

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -478,7 +478,7 @@ class BorrowedIdsWithName {
     auto maybeIds = createWithSingleId(std::move(id), vis,
                                        isField, isMethod, isParenfulFunction,
                                        filterFlags, excludeFlagSet);
-    CHPL_ASSERT(!!maybeIds);
+    CHPL_ASSERT((bool) maybeIds);
     return *maybeIds;
   }
 

--- a/frontend/include/chpl/util/memory.h
+++ b/frontend/include/chpl/util/memory.h
@@ -21,8 +21,18 @@
 #define CHPL_UTIL_MEMORY_H
 
 #include <memory>
+#include "llvm/Option/Option.h"
 
 namespace chpl {
+
+template <typename T>
+#if LLVM_VERSION_MAJOR >= 16
+using opt = std::optional<T>;
+const auto empty = std::nulopt;
+#else
+using opt = llvm::Optional<T>;
+const auto empty = llvm::None;
+#endif
 
 /**
  owned<T> is just a synonym for 'std::unique_ptr<T>'.

--- a/frontend/include/chpl/util/memory.h
+++ b/frontend/include/chpl/util/memory.h
@@ -25,6 +25,15 @@
 
 namespace chpl {
 
+// Below, the underlying type of optional is selected based on the available
+// LLVM version (which implies an available C++ version, since LLVM16 requires
+// C++17). The two types (llvm::Optional and std::optional) don't have an
+// exactly equal API: the former has getValue while the latter has get_value,
+// and so on. To use either without knowing which implementation is in use, you
+// can instead use unary operator* (dereference) and operator bool (boolean
+// coercion). Thus, `o.getValue()` becomes `*o`, and `o.hasValue()` becomes
+// `(bool) o`, or even just `o` in some contexts like if conditions.
+
 template <typename T>
 #if LLVM_VERSION_MAJOR >= 16
 /**

--- a/frontend/include/chpl/util/memory.h
+++ b/frontend/include/chpl/util/memory.h
@@ -38,7 +38,7 @@ using optional = std::optional<T>;
 /**
   This is the "empty" value for the above optional<T> type.
  */
-const auto empty = std::nulopt;
+static const auto empty = std::nullopt;
 #else
 /**
  optional<T> is just a synonym for 'llvm::Optional<T>'.
@@ -51,7 +51,7 @@ using optional = llvm::Optional<T>;
 /**
   This is the "empty" value for the above optional<T> type.
  */
-const auto empty = llvm::None;
+static const auto empty = llvm::None;
 #endif
 
 /**

--- a/frontend/include/chpl/util/memory.h
+++ b/frontend/include/chpl/util/memory.h
@@ -27,10 +27,30 @@ namespace chpl {
 
 template <typename T>
 #if LLVM_VERSION_MAJOR >= 16
+/**
+ optional<T> is just a synonym for 'std::optional<T>'.
+
+ It allows for easy migration in the event that we switch
+ underlying optional types.
+ */
 using optional = std::optional<T>;
+
+/**
+  This is the "empty" value for the above optional<T> type.
+ */
 const auto empty = std::nulopt;
 #else
+/**
+ optional<T> is just a synonym for 'llvm::Optional<T>'.
+
+ It allows for easy migration in the event that we switch
+ underlying optional types.
+ */
 using optional = llvm::Optional<T>;
+
+/**
+  This is the "empty" value for the above optional<T> type.
+ */
 const auto empty = llvm::None;
 #endif
 

--- a/frontend/include/chpl/util/memory.h
+++ b/frontend/include/chpl/util/memory.h
@@ -27,10 +27,10 @@ namespace chpl {
 
 template <typename T>
 #if LLVM_VERSION_MAJOR >= 16
-using opt = std::optional<T>;
+using optional = std::optional<T>;
 const auto empty = std::nulopt;
 #else
-using opt = llvm::Optional<T>;
+using optional = llvm::Optional<T>;
 const auto empty = llvm::None;
 #endif
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2011,11 +2011,7 @@ bool Resolver::enter(const uast::Conditional* cond) {
       r.setType(CHPL_TYPE_ERROR(context, IncompatibleIfBranches, cond,
                                 returnTypes[0], returnTypes[1]));
     } else if (ifType) {
-#if LLVM_VERSION_MAJOR >= 16
-      r.setType(ifType.value());
-#else
-      r.setType(ifType.getValue());
-#endif
+      r.setType(*ifType);
     }
   }
   return false;
@@ -2636,11 +2632,7 @@ void Resolver::exit(const Range* range) {
                                  suppliedTypes[0], suppliedTypes[1]));
       return;
     } else {
-#if LLVM_VERSION_MAJOR >= 16
-      idxType = idxTypeResult.value();
-#else
-      idxType = idxTypeResult.getValue();
-#endif
+      idxType = *idxTypeResult;
     }
   } else {
     // No bounds. Use default.

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1080,7 +1080,7 @@ class KindProperties {
   bool valid() const { return isValid; }
 };
 
-static opt<QualifiedType>
+static optional<QualifiedType>
 findByPassing(Context* context,
               const std::vector<QualifiedType>& types) {
   for (auto& type : types) {
@@ -1098,7 +1098,7 @@ findByPassing(Context* context,
   return chpl::empty;
 }
 
-opt<QualifiedType>
+optional<QualifiedType>
 commonType(Context* context,
            const std::vector<QualifiedType>& types,
            KindRequirement requiredKind) {

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1080,7 +1080,7 @@ class KindProperties {
   bool valid() const { return isValid; }
 };
 
-static llvm::Optional<QualifiedType>
+static opt<QualifiedType>
 findByPassing(Context* context,
               const std::vector<QualifiedType>& types) {
   for (auto& type : types) {
@@ -1095,10 +1095,10 @@ findByPassing(Context* context,
     }
     if (fitsOthers) return type;
   }
-  return llvm::Optional<QualifiedType>();
+  return chpl::empty;
 }
 
-llvm::Optional<QualifiedType>
+opt<QualifiedType>
 commonType(Context* context,
            const std::vector<QualifiedType>& types,
            KindRequirement requiredKind) {
@@ -1120,17 +1120,13 @@ commonType(Context* context,
   if (requiredKind) {
     // The caller enforces a particular kind on us. Make sure that the
     // computed properties line up with the kind.
-#if LLVM_VERSION_MAJOR >= 16
-    auto requiredProperties = KindProperties::fromKind(requiredKind.value());
-#else
-    auto requiredProperties = KindProperties::fromKind(requiredKind.getValue());
-#endif
+    auto requiredProperties = KindProperties::fromKind(*requiredKind);
     requiredProperties.strictCombineWith(properties);
     properties = requiredProperties;
   }
 
   // We can't reconcile the intents. Return with error.
-  if (!properties.valid()) return llvm::Optional<QualifiedType>();
+  if (!properties.valid()) return chpl::empty;
   auto bestKind = properties.toKind();
 
   // Create a new list of types with their kinds adjusted.
@@ -1154,13 +1150,8 @@ commonType(Context* context,
     return commonType;
   }
 
-#if LLVM_VERSION_MAJOR >= 16
   bool paramRequired = requiredKind &&
-                       requiredKind.value() == QualifiedType::PARAM;
-#else
-  bool paramRequired = requiredKind &&
-                       requiredKind.getValue() == QualifiedType::PARAM;
-#endif
+                       *requiredKind == QualifiedType::PARAM;
 
   if (bestKind == QualifiedType::PARAM && !paramRequired) {
     // We couldn't unify the types as params, but maybe if we downgrade
@@ -1177,7 +1168,7 @@ commonType(Context* context,
       return commonType;
     }
   }
-  return llvm::Optional<QualifiedType>();
+  return chpl::empty;
 }
 
 } // end namespace resolution

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -297,11 +297,7 @@ QualifiedType ReturnTypeInferrer::returnedType() {
       context->error(astForErr, "could not determine return type for function");
       retType = QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
     }
-#if LLVM_VERSION_MAJOR >= 16
-    auto adjType = adjustForReturnIntent(returnIntent, retType.value());
-#else
-    auto adjType = adjustForReturnIntent(returnIntent, retType.getValue());
-#endif
+    auto adjType = adjustForReturnIntent(returnIntent, *retType);
     return adjType;
   }
 }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -653,11 +653,7 @@ bool LookupHelper::doLookupInImportsAndUses(
             traceResult->push_back(std::move(t));
           }
 
-#if LLVM_VERSION_MAJOR >= 16
-          result.push_back(std::move(foundIds.value()));
-#else
-          result.push_back(std::move(foundIds.getValue()));
-#endif
+          result.push_back(std::move(*foundIds));
           found = true;
         }
       }
@@ -868,11 +864,7 @@ bool LookupHelper::doLookupInExternBlocks(const Scope* scope,
           t.visibleThrough.push_back(std::move(elt));
           traceResult->push_back(std::move(t));
         }
-#if LLVM_VERSION_MAJOR >= 16
-        result.push_back(std::move(foundIds.value()));
-#else
-        result.push_back(std::move(foundIds.getValue()));
-#endif
+        result.push_back(std::move(*foundIds));
       }
     }
   }

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -155,7 +155,7 @@ void OwnedIdsWithName::stringify(std::ostream& ss,
   }
 }
 
-opt<BorrowedIdsWithName>
+optional<BorrowedIdsWithName>
 OwnedIdsWithName::borrow(IdAndFlags::Flags filterFlags,
                          const IdAndFlags::FlagSet& excludeFlagSet) const {
   // Are all of the filter flags present in flagsOr?

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -155,17 +155,13 @@ void OwnedIdsWithName::stringify(std::ostream& ss,
   }
 }
 
-llvm::Optional<BorrowedIdsWithName>
+opt<BorrowedIdsWithName>
 OwnedIdsWithName::borrow(IdAndFlags::Flags filterFlags,
                          const IdAndFlags::FlagSet& excludeFlagSet) const {
   // Are all of the filter flags present in flagsOr?
   // If not, it is not possible for this to match.
   if ((flagsOr_ & filterFlags) != filterFlags) {
-#if LLVM_VERSION_MAJOR >= 16
-    return std::nullopt;
-#else
-    return llvm::None;
-#endif
+    return chpl::empty;
   }
 
   if (BorrowedIdsWithName::isIdVisible(idv_, filterFlags, excludeFlagSet)) {
@@ -173,11 +169,7 @@ OwnedIdsWithName::borrow(IdAndFlags::Flags filterFlags,
   }
   // The first ID isn't visible; are others?
   if (moreIdvs_.get() == nullptr) {
-#if LLVM_VERSION_MAJOR >= 16
-    return std::nullopt;
-#else
-    return llvm::None;
-#endif
+    return chpl::empty;
   }
 
   // Are all of the filter flags present in flagsAnd?
@@ -200,11 +192,7 @@ OwnedIdsWithName::borrow(IdAndFlags::Flags filterFlags,
   }
 
   // No ID was visible, so we can't borrow.
-#if LLVM_VERSION_MAJOR >= 16
-  return std::nullopt;
-#else
-  return llvm::None;
-#endif
+  return chpl::empty;
 }
 
 int BorrowedIdsWithName::countVisibleIds(IdAndFlags::Flags flagsAnd,
@@ -325,17 +313,10 @@ bool Scope::lookupInScope(UniqueString name,
     // There might not be any IDs that are visible to us, so borrow returns
     // an optional list.
     auto borrowedIds = search->second.borrow(filterFlags, excludeFlags);
-#if LLVM_VERSION_MAJOR >= 16
-    if (borrowedIds.has_value()) {
-      result.push_back(std::move(borrowedIds.value()));
+    if (borrowedIds) {
+      result.push_back(std::move(*borrowedIds));
       return true;
     }
-#else
-    if (borrowedIds.hasValue()) {
-      result.push_back(std::move(borrowedIds.getValue()));
-      return true;
-    }
-#endif
   }
   return false;
 }

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -123,7 +123,7 @@ void testProgram(const std::vector<ReturnVariant>& variants, F func,
   std::cout << "return type:" << std::endl;
   qt.dump();
   std::cout << std::endl;
-  func(!!commonTypeResult, qt);
+  func((bool) commonTypeResult, qt);
 }
 
 static void test1() {

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -123,11 +123,7 @@ void testProgram(const std::vector<ReturnVariant>& variants, F func,
   std::cout << "return type:" << std::endl;
   qt.dump();
   std::cout << std::endl;
-#if LLVM_VERSION_MAJOR >= 16
-  func(commonTypeResult.has_value(), qt);
-#else
-  func(commonTypeResult.hasValue(), qt);
-#endif
+  func(!!commonTypeResult, qt);
 }
 
 static void test1() {

--- a/frontend/test/resolution/testScopeTypes.cpp
+++ b/frontend/test/resolution/testScopeTypes.cpp
@@ -108,13 +108,8 @@ static void testBorrowIds() {
                          /* field */ false, /* method */ false, /* parenful */ false);
     assert(ids.numIds() == 1);
     auto foundIds = ids.borrow(0, FlagSet::empty());
-#if LLVM_VERSION_MAJOR >= 16
-    assert(foundIds.has_value());
-    auto b = foundIds.value();
-#else
-    assert(foundIds.hasValue());
-    auto b = foundIds.getValue();
-#endif
+    assert(foundIds);
+    auto b = *foundIds;
     assert(b.firstId() == x);
     assert(b.numIds() == 1);
     int count = 0;
@@ -132,11 +127,7 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = pub;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
-#if LLVM_VERSION_MAJOR >= 16
-    assert(!foundIds.has_value());
-#else
-    assert(!foundIds.hasValue());
-#endif
+    assert(!foundIds);
   }
   {
     // check one id with filtering
@@ -145,11 +136,7 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(not_method);
     auto foundIds = ids.borrow(f, e);
-#if LLVM_VERSION_MAJOR >= 16
-    assert(!foundIds.has_value());
-#else
-    assert(!foundIds.hasValue());
-#endif
+    assert(!foundIds);
   }
 
   {
@@ -162,13 +149,8 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = pub;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
-#if LLVM_VERSION_MAJOR >= 16
-    assert(foundIds.has_value());
-    auto b = foundIds.value();
-#else
-    assert(foundIds.hasValue());
-    auto b = foundIds.getValue();
-#endif
+    assert(foundIds);
+    auto b = *foundIds;
     assert(b.firstId() == y);
     assert(b.numIds() == 1);
     int count = 0;
@@ -188,13 +170,8 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = IdAndFlags::PUBLIC;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
-#if LLVM_VERSION_MAJOR >= 16
-    assert(foundIds.has_value());
-    auto b = foundIds.value();
-#else
-    assert(foundIds.hasValue());
-    auto b = foundIds.getValue();
-#endif
+    assert(foundIds);
+    auto b = *foundIds;
     assert(b.firstId() == y);
     assert(b.numIds() == 1);
     int count = 0;
@@ -214,13 +191,8 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::empty();
     auto foundIds = ids.borrow(f, e);
-#if LLVM_VERSION_MAJOR >= 16
-    assert(foundIds.has_value());
-    auto b = foundIds.value();
-#else
-    assert(foundIds.hasValue());
-    auto b = foundIds.getValue();
-#endif
+    assert(foundIds);
+    auto b = *foundIds;
     assert(b.firstId() == y);
     assert(b.numIds() == 2);
     int count = 0;
@@ -240,13 +212,8 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
-#if LLVM_VERSION_MAJOR >= 16
-    assert(foundIds.has_value());
-    auto b = foundIds.value();
-#else
-    assert(foundIds.hasValue());
-    auto b = foundIds.getValue();
-#endif
+    assert(foundIds);
+    auto b = *foundIds;
     assert(b.firstId() == x);
     assert(b.numIds() == 1);
     int count = 0;
@@ -266,13 +233,8 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub | method);
     auto foundIds = ids.borrow(f, e);
-#if LLVM_VERSION_MAJOR >= 16
-    assert(foundIds.has_value());
-    auto b = foundIds.value();
-#else
-    assert(foundIds.hasValue());
-    auto b = foundIds.getValue();
-#endif
+    assert(foundIds);
+    auto b = *foundIds;
     assert(b.firstId() == x);
     assert(b.numIds() == 1);
     int count = 0;
@@ -292,11 +254,7 @@ static void testBorrowIds() {
     IdAndFlags::Flags f = 0;
     auto e = FlagSet::singleton(pub);
     auto foundIds = ids.borrow(f, e);
-#if LLVM_VERSION_MAJOR >= 16
-    assert(!foundIds.has_value());
-#else
-    assert(!foundIds.hasValue());
-#endif
+    assert(!foundIds);
   }
 }
 


### PR DESCRIPTION
We currently have a `chpl::owned<T>`. If we make a symmetric addition of `chpl::optional`, aliased (initially) to `llvm::Optional`, and later (via an `LLVM >= 16` check) to `std::optional` directly (in case LLVM eventually removes `llvm::Optional`), we can get rid of all the LLVM-specific ifdefs in the frontend. The last ingredient here (thanks, @dlongnecke-cray !) is the fact that although `has_value` and `hasValue` are not the same name, both data types support `operator bool` and `operator *`, and most of the code can be written in terms of those and work for either optional implementation.

Reviewed by @mppf -- thanks!

Michael says the following about LLVM16:

> I've verified that the latest revision builds successfully with LLVM 16 for the Support library (ie. with CHPL_LLVM=none). I checked `make test-dyno` and `make check` in that mode.

## Testing (LLVM14)
- [x] Paratest