### PR TITLE
Remove CHPL_COMM=none out of test-gpu-rocm.gasnet.bash

### DIFF
--- a/util/cron/test-gpu-rocm.gasnet.bash
+++ b/util/cron/test-gpu-rocm.gasnet.bash
@@ -6,7 +6,6 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 
 export CHPL_LLVM=bundled
-export CHPL_COMM=none
 export CHPL_GPU_CODEGEN=rocm
 export CHPL_LAUNCHER_PARTITION=amdMI60
 module load rocm


### PR DESCRIPTION
This PR added `util/cron/test-gpu-rocm.gasnet.bash` but I realize I had a line `CHPL_COMM=none` in there, which we definitely wouldn't want for nightly gasnet testing.

This PR fixes that.