### PR TITLE
Fix bug in regex.match('$')

### DIFF
--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -300,7 +300,7 @@ qio_bool qio_regex_match(qio_regex_t* regex, const char* text, int64_t text_len,
       intptr_t diff = qio_ptr_diff((void*) spPtr[i].data(), (void*) textp.data());
       assert( diff >= startpos && diff <= endpos );
       int64_t length = spPtr[i].length();
-      
+
       submatch[i].offset = diff;
       submatch[i].len = length;
     }

--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -297,15 +297,10 @@ qio_bool qio_regex_match(qio_regex_t* regex, const char* text, int64_t text_len,
       submatch[i].offset = -1;
       submatch[i].len = 0;
     } else {
-      intptr_t diff = 0;
-      int64_t  length = 0;
-      if( spPtr[i].empty() ) {
-        diff = startpos;
-      } else {
-        diff = qio_ptr_diff((void*) spPtr[i].data(), (void*) textp.data());
-        assert( diff >= startpos && diff <= endpos );
-        length = spPtr[i].length();
-      }
+      intptr_t diff = qio_ptr_diff((void*) spPtr[i].data(), (void*) textp.data());
+      assert( diff >= startpos && diff <= endpos );
+      int64_t length = spPtr[i].length();
+      
       submatch[i].offset = diff;
       submatch[i].len = length;
     }

--- a/test/regex/empty-string-matches.chpl
+++ b/test/regex/empty-string-matches.chpl
@@ -3,10 +3,14 @@
 
 use Regex;
 
-var str = "";
+proc test(str: string) {
+  writeln((new regex("")).matches(str));
+  writeln((new regex("^")).matches(str));
+  writeln((new regex("$")).matches(str));
+  writeln((new regex("^$")).matches(str));
+  writeln((new regex(".*")).matches(str));
+}
 
-writeln((new regex("")).matches(str));
-writeln((new regex("^")).matches(str));
-writeln((new regex("$")).matches(str));
-writeln((new regex("^$")).matches(str));
-writeln((new regex(".*")).matches(str));
+test("");
+writeln();
+test("xy");

--- a/test/regex/empty-string-matches.good
+++ b/test/regex/empty-string-matches.good
@@ -3,3 +3,9 @@
 ((matched = true, byteOffset = 0, numBytes = 0),)
 ((matched = true, byteOffset = 0, numBytes = 0),)
 ((matched = true, byteOffset = 0, numBytes = 0),)
+
+((matched = true, byteOffset = 0, numBytes = 0),) ((matched = true, byteOffset = 1, numBytes = 0),) ((matched = true, byteOffset = 2, numBytes = 0),)
+((matched = true, byteOffset = 0, numBytes = 0),)
+((matched = true, byteOffset = 2, numBytes = 0),)
+
+((matched = true, byteOffset = 0, numBytes = 2),) ((matched = true, byteOffset = 2, numBytes = 0),)

--- a/test/regex/matchesOnlyEnd.chpl
+++ b/test/regex/matchesOnlyEnd.chpl
@@ -1,0 +1,16 @@
+// from https://github.com/chapel-lang/chapel/issues/20431
+module PlayingAround {
+  use Regex;
+  use IO.FormattedIO;
+
+  proc main () throws {
+    var s = 'i string i';
+    var pattern = '$';
+    var myRegex = new regex(pattern);
+    writeln("matches('%s')".format(pattern));
+    writeln(myRegex.matches(s));
+    writeln();
+    writeln("search('%s')".format(pattern));
+    writeln(myRegex.search(s));
+  }
+}

--- a/test/regex/matchesOnlyEnd.good
+++ b/test/regex/matchesOnlyEnd.good
@@ -1,0 +1,5 @@
+matches('$')
+((matched = true, byteOffset = 10, numBytes = 0),)
+
+search('$')
+(matched = true, byteOffset = 10, numBytes = 0)

--- a/test/regex/regex-and-channel-todos.bad
+++ b/test/regex/regex-and-channel-todos.bad
@@ -2,5 +2,3 @@
 [^]  ((matched = true, byteOffset = 1, numBytes = 0),) <> 2
 [^]  ((matched = true, byteOffset = 2, numBytes = 0),) <> 2
 [^]  done 2
-
-((matched = true, byteOffset = 2, numBytes = 0),)

--- a/test/regex/regex-and-channel-todos.bad
+++ b/test/regex/regex-and-channel-todos.bad
@@ -3,4 +3,4 @@
 [^]  ((matched = true, byteOffset = 2, numBytes = 0),) <> 2
 [^]  done 2
 
-((matched = true, byteOffset = 0, numBytes = 0),) ((matched = true, byteOffset = 1, numBytes = 0),) ((matched = true, byteOffset = 2, numBytes = 0),)
+((matched = true, byteOffset = 2, numBytes = 0),)

--- a/test/regex/regex-and-channel-todos.chpl
+++ b/test/regex/regex-and-channel-todos.chpl
@@ -20,10 +20,3 @@ proc testXY(re:string) {
 // What should be the ending position in the channel?
 // When this is fixed, merge it into empty-channel-matches.chpl
 testXY("^"); 
-
-writeln();
-
-// This should match once at the end of the string, with byteOffset = 2.
-// When this is fixed, merge it into empty-string-matches.chpl
-var re = new regex("$");
-writeln(re.matches("xy"));

--- a/test/regex/regex-and-channel-todos.good
+++ b/test/regex/regex-and-channel-todos.good
@@ -1,4 +1,2 @@
 [^]  ((matched = true, byteOffset = 0, numBytes = 0),) <> 0
 [^]  done 2
-
-((matched = true, byteOffset = 2, numBytes = 0),)


### PR DESCRIPTION
Resolves a bug where `regex.match('$')` would always return an offset equal to the start of the match. This was due to incorrectly copying the correct offset from RE2 in the runtime shim.

## Summary of changes
- remove check for an empty match in runtime shim for RE2

## New tests
- add #20431 as a test - `test/regex/matchesOnlyEnd.chpl`

## Testing
- paratest + futures
- paratest + gasnet

---

[Reviewed by @vasslitvinov]

resolves  #20431
Fixes some of the bugs in #20864, updated future accordingly