### PR TITLE
Drop memory leaks graphs from performance tracking suite

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -91,7 +91,6 @@ studies/rbc/tvandoren/RBC.graph
 exercises/c-ray/old/c-ray.graph
 users/npadmana/twopt/twopt-buildtrees.graph
 users/npadmana/twopt/twopt-paircount.graph
-memleaksfull.graph
 studies/jacobi/jacobi.graph
 library/standard/List/perf/listBenchmark1.graph
 # suite: HPC Challenge


### PR DESCRIPTION
In the performance meeting, we decided that it didn't make sense to be tracking the memory leaks in the performance suite now that memory leaks send out a test failure and we are handling those as a part of regular triage. Based on this, we are dropping memory leaks from the performance tracking suite.