### PR TITLE
Fix erroneous deprecation message on `sys_getenv`

### DIFF
--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -554,7 +554,7 @@ module Sys {
     :returns: 1 if ``name`` is defined and 0 if not
     :rtype: `c_int`
    */
-  @deprecated(notes="'Sys.sys_getenv' is deprecated; please use 'OS.sys_getenv' instead")
+  @deprecated(notes="'Sys.sys_getenv' is deprecated")
   extern proc sys_getenv(name:c_string, ref string_out:c_string):c_int;
 
   /* The type corresponding to C's mode_t */


### PR DESCRIPTION
`Sys.sys_getenv` was deprecated without replacement in https://github.com/chapel-lang/chapel/pull/20126; however, the deprecation message said to find a replacement in the OS module. This PR corrects the deprecation message.

- [X] paratest
