### PR TITLE
Add a use of the Math module to avoid a deprecation warning in this test

### DIFF
--- a/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/PARACR-BC-bulk.chpl
+++ b/test/optimizations/bulkcomm/asenjo/redistBlockToCyclic/PARACR-BC-bulk.chpl
@@ -1,4 +1,4 @@
-use CTypes;
+use CTypes, Math;
 
 proc copyBtoC(A:[], B:[])
 {


### PR DESCRIPTION
This test relies on log2, which we are going to stop including in all user programs by default.  For the test to continue working in the future, we need a use of the Math module

Checking a fresh checkout with gasnet (where the test is run)