### PR TITLE
Migrate llvm-global-to-wide testing to opaque pointers

### DIFF
--- a/compiler/llvm/llvm-global-to-wide/CMakeLists.txt
+++ b/compiler/llvm/llvm-global-to-wide/CMakeLists.txt
@@ -1,67 +1,36 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.20.0)
+project(llvm-pgas)
 
+# assumes LLVM 15 is installed system-wide
+find_package(LLVM 15 REQUIRED)
 
-# Detect LLVM
-# The user is supposed to set this to a valid llvm 3.7 install root
-set(LLVM_ROOT "" CACHE PATH "Root of LLVM install.")
-# and source tree
-# (we use lit.py from the LLVM source tree)
-set(LLVM_SRC "" CACHE PATH "Root of LLVM source tree.")
-
-set(LLVM_LIT "${LLVM_SRC}/utils/lit/lit.py")
-
-# sanity check LLVM install path
-if(NOT EXISTS "${LLVM_ROOT}/include/llvm" )
-    message(FATAL_ERROR
-            "LLVM_ROOT (${LLVM_ROOT}) is invalid")
+if(LLVM_VERSION VERSION_LESS 15)
+  message(FATAL_ERROR "Did not find LLVM 15 -- found ${LLVM_VERSION}")
 endif()
 
-
-# sanity check LLVM src path
-if(NOT EXISTS "${LLVM_SRC}/lib/Transforms" )
-    message(FATAL_ERROR
-            "LLVM_SRC (${LLVM_SRC}) is invalid")
-endif()
+# assumes ~/llvm-project has an LLVM 15 source checkout
+set(LLVM_LIT "~/llvm-project/llvm/utils/lit/lit.py")
 
 # find Python
 find_package(PythonInterp)
 
-#
-#set( LLVM_DIR "${LLVM_ROOT}/share/llvm/cmake" )
-#set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${LLVM_DIR} )
-#find_package(LLVM)
-#include(AddLLVM)
-#add_definitions(${LLVM_DEFINITIONS})
-#include_directories(${LLVM_INCLUDE_DIRS})
-#link_directories(${LLVM_LIBRARY_DIRS})
-# Load various LLVM config stuff,
-# see http://llvm.org/docs/CMake.html#developing-llvm-passes-out-of-source
-
-# Load LLVM CMake config
-#list(APPEND CMAKE_PREFIX_PATH "${LLVM_ROOT}/share/llvm/cmake")
-#set( LLVM_DIR "${LLVM_ROOT}/share/llvm/cmake" )
-#set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${LLVM_DIR} )
-find_package(LLVM REQUIRED CONFIG)
-
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-include(HandleLLVMOptions) # load additional config
-include(AddLLVM) # used to add our own modules
 
-# propagate LLVM-specific variables to this project
-add_definitions(${LLVM_DEFINITIONS} -DHAVE_LLVM)
+include(LLVM-Config)
+include(HandleLLVMOptions)
+include(AddLLVM)
+
 include_directories(${LLVM_INCLUDE_DIRS})
-# See commit r197394, needed by add_llvm_module in llvm/CMakeLists.txt
-set(LLVM_RUNTIME_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/bin/${CMAKE_CFG_INT_DIR}")
-set(LLVM_LIBRARY_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/lib/${CMAKE_CFG_INT_DIR}")
 
-set(SOURCES
-      llvmAggregateGlobalOps.cpp
-      llvmGlobalToWide.cpp
-      llvmUtil.cpp
-   )
+# no interesting code unless we define this
+add_definitions(-DHAVE_LLVM)
 
-add_llvm_loadable_module( llvm-pgas ${SOURCES} )
-#set_target_properties( llvm-pgas PROPERTIES COMPILE_FLAGS "-fno-rtti" )
+add_llvm_pass_plugin(llvm-pgas MODULE
+    llvmAggregateGlobalOps.cpp
+    llvmGlobalToWide.cpp
+    llvmPgasPlugin.cpp
+    llvmUtil.cpp
+)
 
 # set various configuration settings in the test suite
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/test/lit.cfg.in" "${CMAKE_CURRENT_BINARY_DIR}/test/lit.cfg")
@@ -75,14 +44,14 @@ foreach( test_file ${test_files} )
     "${CMAKE_CURRENT_BINARY_DIR}/${test_file}" COPYONLY)
 endforeach( test_file )
 
-if(NOT EXISTS ${LLVM_ROOT}/bin/FileCheck)
-    message(FATAL_ERROR "need FileCheck installed to run tests; configure LLVM with -DLLVM_INSTALL_UTILS")
-endif()
+#if(NOT EXISTS ${LLVM_ROOT}/bin/FileCheck)
+#    message(FATAL_ERROR "need FileCheck installed to run tests; configure LLVM with -DLLVM_INSTALL_UTILS")
+#endif()
+
 
 # support make check with the LLVM tester lit in the tests directory
 add_custom_target(check
     COMMAND ${PYTHON_EXECUTABLE} ${LLVM_LIT}
             "${CMAKE_CURRENT_BINARY_DIR}/test/" -v
-            DEPENDS llvm-pgas
-)
+            DEPENDS llvm-pgas )
 

--- a/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
+++ b/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
@@ -1,7 +1,5 @@
 #!/bin/sh
-#./configure --with-llvmsrc=../../../third-party/llvm/llvm/ --with-llvmobj=../../../third-party/llvm/build/linux64-gnu/ --enable-shared
-#autoconf
-#./configure
+
 ln -s ../llvmGlobalToWide.cpp llvmGlobalToWide.cpp
 ln -s ../llvmUtil.cpp llvmUtil.cpp
 ln -s ../llvmAggregateGlobalOps.cpp llvmAggregateGlobalOps.cpp
@@ -11,6 +9,6 @@ ln -s ../../include/llvmAggregateGlobalOps.h llvmAggregateGlobalOps.h
 ln -s ../../include/llvmVer.h llvmVer.h
 mkdir -p build
 cd build
-#export CMAKE_PREFIX_PATH=$CHPL_HOME/third-party/llvm/install/linux64-x86_64-gnu/
-#cmake .. -DLLVM_ROOT=~/llvm-project/llvm -DLLVM_SRC=~/llvm-project/llvm -DCMAKE_BUILD_TYPE=Debug
+
+# Note: assumes a relevant version of LLVM is installed system-wide
 cmake .. -DCMAKE_BUILD_TYPE=Debug

--- a/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
+++ b/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
@@ -11,5 +11,6 @@ ln -s ../../include/llvmAggregateGlobalOps.h llvmAggregateGlobalOps.h
 ln -s ../../include/llvmVer.h llvmVer.h
 mkdir -p build
 cd build
-export CMAKE_PREFIX_PATH=$CHPL_HOME/third-party/llvm/install/linux64-x86_64-gnu/
-cmake .. -DLLVM_ROOT=$CHPL_HOME/third-party/llvm/install/linux64-x86_64-gnu/ -DLLVM_SRC=$CHPL_HOME/third-party/llvm/llvm -DCMAKE_BUILD_TYPE=Debug
+#export CMAKE_PREFIX_PATH=$CHPL_HOME/third-party/llvm/install/linux64-x86_64-gnu/
+#cmake .. -DLLVM_ROOT=~/llvm-project/llvm -DLLVM_SRC=~/llvm-project/llvm -DCMAKE_BUILD_TYPE=Debug
+cmake .. -DCMAKE_BUILD_TYPE=Debug

--- a/compiler/llvm/llvm-global-to-wide/llvmPgasPlugin.cpp
+++ b/compiler/llvm/llvm-global-to-wide/llvmPgasPlugin.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "llvmGlobalToWide.h"
+#include "llvmAggregateGlobalOps.h"
+
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+
+#ifdef HAVE_LLVM
+
+using namespace llvm;
+
+/* New PM Registration */
+llvm::PassPluginLibraryInfo getLlvmPgasPluginInfo() {
+  printf("In getLlvmPgasPluginInfo\n");
+  return {LLVM_PLUGIN_API_VERSION, "llvm-pgas", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            printf("In callback RegisterPassBuilderCallbacks\n");
+
+            /*
+            PB.registerVectorizerStartEPCallback(
+                [](llvm::FunctionPassManager &PM, OptimizationLevel Level) {
+                  printf("In VectorizerStartEPCallback\n");
+                });
+            PB.registerScalarOptimizerLateEPCallback(
+                [](llvm::FunctionPassManager &PM, OptimizationLevel Level) {
+                  printf("In registerScalarOptimizerLateEPCallback\n");
+                  fflush(stdout);
+                  PM.addPass(AggregateGlobalOpsOptPass());
+                });*/
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, llvm::FunctionPassManager &FPM,
+                   ArrayRef<llvm::PassBuilder::PipelineElement> Pipeline) {
+                  printf("In PipelineParsingCallback FPM Considering Pass Name '%s'\n", Name.str().c_str());
+                  if (!Pipeline.empty()) {
+                    printf("Pipeline.front().Name '%s'\n", Pipeline.front().Name.str().c_str());
+                  }
+                  fflush(stdout);
+                  if (Name == "aggregate-global-ops") {
+                    FPM.addPass(AggregateGlobalOpsOptPass());
+                    return true;
+                  }
+                  return false;
+                });
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, llvm::ModulePassManager &MPM,
+                   ArrayRef<llvm::PassBuilder::PipelineElement> Pipeline) {
+                  printf("In PipelineParsingCallback MPM Considering Pass Name '%s'\n", Name.str().c_str());
+                  if (!Pipeline.empty()) {
+                    printf("Pipeline.front().Name '%s'\n", Pipeline.front().Name.str().c_str());
+                  }
+                  fflush(stdout);
+                  if (Name == "global-to-wide") {
+                    MPM.addPass(GlobalToWidePass());
+                    return true;
+                  }
+                  return false;
+                });
+
+            PB.registerParseTopLevelPipelineCallback(
+               [](ModulePassManager &MPM,
+                   ArrayRef<llvm::PassBuilder::PipelineElement> Pipeline) {
+                  printf("In ParseTopLevelPipelineCallback\n");
+                  if (!Pipeline.empty()) {
+                    printf("Pipeline.front().Name '%s'\n", Pipeline.front().Name.str().c_str());
+                  }
+                  fflush(stdout);
+                  if (!Pipeline.empty() && Pipeline.front().Name == "aggregate-global-ops") {
+                    //MPM.addPass(AggregateGlobalOpsOptPass());
+                    return true;
+                  }
+                  return false;
+                });
+            printf("Done callback RegisterPassBuilderCallbacks\n");
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getLlvmPgasPluginInfo();
+}
+
+#endif

--- a/compiler/llvm/llvm-global-to-wide/test/a.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/a.ll
@@ -1,4 +1,4 @@
-; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT} -global-to-wide -S < %s | FileCheck %s
+; RUN: opt-15 --load-pass-plugin=%bindir/llvm-pgas.so -S --passes=global-to-wide < %s | FileCheck-15 %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 

--- a/compiler/llvm/llvm-global-to-wide/test/a.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/a.ll
@@ -3,12 +3,12 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 
 ; Note after LLVM 7 memcpy will no longer take an alignment argument
-declare void @llvm.memcpy.p0i8.p100i8.i64(i8* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
-declare void @llvm.memcpy.p100i8.p0i8.i64(i8 addrspace(100)* nocapture, i8* nocapture, i64, i32, i1)
-declare void @llvm.memcpy.p100i8.p100i8.i64(i8 addrspace(100)* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p0i8.p100i8.i64(ptr nocapture, ptr addrspace(100) nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p100i8.p0i8.i64(ptr addrspace(100) nocapture, ptr nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p100i8.p100i8.i64(ptr addrspace(100) nocapture, ptr addrspace(100) nocapture, i64, i32, i1)
 
-define void @teststore(i64 addrspace(100)* %storeme) {
-; CHECK: @teststore({ %struct.c_localeid_t, i64* } %
+define void @teststore(ptr addrspace(100) %storeme) {
+; CHECK: @teststore({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @memcpy
 ; CHECK: put
@@ -16,16 +16,14 @@ define void @teststore(i64 addrspace(100)* %storeme) {
 ; CHECK: ret
 entry:
   %a = alloca i64
-  store i64 7, i64 * %a
-  %storeme.cast = bitcast i64 addrspace(100)* %storeme to i8 addrspace(100)*
-  %a.cast = bitcast i64 * %a to i8 *
-  call void @llvm.memcpy.p100i8.p0i8.i64(i8 addrspace(100)* %storeme.cast, i8* %a.cast, i64 8, i32 1, i1 true)
+  store i64 7, ptr %a
+  call void @llvm.memcpy.p100i8.p0i8.i64(ptr addrspace(100) %storeme, ptr %a, i64 8, i32 1, i1 true)
   ret void
 }
 
 
-define i64 @testload(i64 addrspace(100)* %loadme) {
-; CHECK: @testload({ %struct.c_localeid_t, i64* } %
+define i64 @testload(ptr addrspace(100) %loadme) {
+; CHECK: @testload({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @memcpy
 ; CHECK: get
@@ -33,48 +31,43 @@ define i64 @testload(i64 addrspace(100)* %loadme) {
 ; CHECK: ret
 entry:
   %a = alloca i64
-  %loadme.cast = bitcast i64 addrspace(100)* %loadme to i8 addrspace(100)*
-  %a.cast = bitcast i64 * %a to i8 *
-  call void @llvm.memcpy.p0i8.p100i8.i64(i8* %a.cast, i8 addrspace(100)* %loadme.cast, i64 8, i32 1, i1 true)
+  call void @llvm.memcpy.p0i8.p100i8.i64(ptr %a, ptr addrspace(100) %loadme, i64 8, i32 1, i1 true)
   %ret = load i64, i64 * %a
   ret i64 %ret
 }
 
-define void @testcopy(i64 addrspace(100)* %dst, i64 addrspace(100)* %src) {
-; CHECK: @testcopy({ %struct.c_localeid_t, i64* } %
+define void @testcopy(ptr addrspace(100) %dst, ptr addrspace(100) %src) {
+; CHECK: @testcopy({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @memcpy
 ; CHECK: getput
 ; CHECK-NOT: @memcpy
 ; CHECK: ret
 entry:
-  %dst.cast = bitcast i64 addrspace(100)* %dst to i8 addrspace(100)*
-  %src.cast = bitcast i64 addrspace(100)* %src to i8 addrspace(100)*
-  call void @llvm.memcpy.p100i8.p100i8.i64(i8 addrspace(100)* %dst.cast, i8 addrspace(100)* %src.cast, i64 8, i32 1, i1 true)
+  call void @llvm.memcpy.p100i8.p100i8.i64(ptr addrspace(100) %dst, ptr addrspace(100) %src, i64 8, i32 1, i1 true)
   ret void
 }
 
-define i64 @read_int(i64 addrspace(100)* %src) {
-; CHECK: i64 @read_int({ %struct.c_localeid_t, i64* } %
+define i64 @read_int(ptr addrspace(100) %src) {
+; CHECK: i64 @read_int({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
 ; CHECK: get
 ; CHECK-NOT: @.gf
 ; CHECK: ret i64
 entry:
-  %ret = load i64, i64 addrspace(100)* %src
+  %ret = load i64, ptr addrspace(100) %src
   ret i64 %ret
 }
 
-define void @write_int(i64 addrspace(100)* %dst, i64 %v) {
-; CHECK: void @write_int({ %struct.c_localeid_t, i64* } %
+define void @write_int(ptr addrspace(100) %dst, i64 %v) {
+; CHECK: void @write_int({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
 ; CHECK: put
 ; CHECK-NOT: @.gf
 ; CHECK: ret void
 entry:
-  store i64 %v, i64 addrspace(100)* %dst
+  store i64 %v, ptr addrspace(100) %dst
   ret void
 }
-

--- a/compiler/llvm/llvm-global-to-wide/test/aggregate.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/aggregate.ll
@@ -2,30 +2,30 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 
 ; Note after LLVM 7 memcpy will no longer take an alignment argument
-declare void @llvm.memcpy.p0i8.p100i8.i64(i8* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
-declare void @llvm.memcpy.p100i8.p0i8.i64(i8 addrspace(100)* nocapture, i8* nocapture, i64, i32, i1)
-declare void @llvm.memcpy.p100i8.p100i8.i64(i8 addrspace(100)* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p0i8.p100i8.i64(ptr nocapture, ptr addrspace(100) nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p100i8.p0i8.i64(ptr addrspace(100) nocapture, ptr nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p100i8.p100i8.i64(ptr addrspace(100) nocapture, ptr addrspace(100) nocapture, i64, i32, i1)
 
 
-define void @teststore1(i64 addrspace(100)* %base) {
+define void @teststore1(ptr addrspace(100) %base) {
 ; CHECK: @teststore1(
 ; )
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 1
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
 ; CHECK: store i64 1
 ; CHECK: store i64 2
 ; CHECK: store i64 3
 ; CHECK: memcpy
 ; CHECK: ret
-  store i64 1, i64 addrspace(100)* %p0, align 8
-  store i64 2, i64 addrspace(100)* %p1, align 8
-  store i64 3, i64 addrspace(100)* %p2, align 8
+  store i64 1, ptr addrspace(100) %p0, align 8
+  store i64 2, ptr addrspace(100) %p1, align 8
+  store i64 3, ptr addrspace(100) %p2, align 8
   ret void
 }
 
-define void @teststore2(i64 addrspace(100)* %base) {
+define void @teststore2(ptr addrspace(100) %base) {
 ; CHECK: @teststore2(
 ; )
 entry:
@@ -34,40 +34,40 @@ entry:
 ; CHECK: store i64 3
 ; CHECK: memcpy
 ; CHECK: ret
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
-  store i64 1, i64 addrspace(100)* %p0, align 8
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
-  store i64 2, i64 addrspace(100)* %p1, align 8
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
-  store i64 3, i64 addrspace(100)* %p2, align 8
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
+  store i64 1, ptr addrspace(100) %p0, align 8
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 1
+  store i64 2, ptr addrspace(100) %p1, align 8
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
+  store i64 3, ptr addrspace(100) %p2, align 8
   ret void
 }
 
-define void @teststore3(i64 addrspace(100)* %base) {
+define void @teststore3(ptr addrspace(100) %base) {
 ; CHECK: @teststore3(
 ; )
 entry:
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 1
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
 ; CHECK: store i64 3
 ; CHECK: store i64 2
 ; CHECK: store i64 1
 ; CHECK: memcpy
 ; CHECK: ret
-  store i64 3, i64 addrspace(100)* %p2, align 8
-  store i64 2, i64 addrspace(100)* %p1, align 8
-  store i64 1, i64 addrspace(100)* %p0, align 8
+  store i64 3, ptr addrspace(100) %p2, align 8
+  store i64 2, ptr addrspace(100) %p1, align 8
+  store i64 1, ptr addrspace(100) %p0, align 8
   ret void
 }
 
-define void @teststore4(i64 addrspace(100)* %base) {
+define void @teststore4(ptr addrspace(100) %base) {
 ; CHECK: @teststore4(
 ; )
 entry:
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
-  %p01 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
+  %p01 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
 ; CHECK: store i64 3
 ; CHECK: store i64 2
 ; CHECK: store i64 1
@@ -80,7 +80,7 @@ entry:
 }
 
 
-define i64 @testload1(i64 addrspace(100)* %base) {
+define i64 @testload1(ptr addrspace(100) %base) {
 ; CHECK: @testload1(
 ; )
 ; CHECK: memcpy
@@ -89,18 +89,18 @@ define i64 @testload1(i64 addrspace(100)* %base) {
 ; CHECK: load
 ; CHECK: ret
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
-  %v1 = load i64, i64 addrspace(100)* %p0, align 8
-  %v2 = load i64, i64 addrspace(100)* %p1, align 8
-  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 1
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
+  %v1 = load i64, ptr addrspace(100) %p0, align 8
+  %v2 = load i64, ptr addrspace(100) %p1, align 8
+  %v3 = load i64, ptr addrspace(100) %p2, align 8
   %sum1 = add i64 %v1, %v2
   %sum2 = add i64 %sum1, %v3
   ret i64 %sum2
 }
 
-define i64 @testload2(i64 addrspace(100)* %base) {
+define i64 @testload2(ptr addrspace(100) %base) {
 ; CHECK: @testload2(
 ; )
 ; CHECK: memcpy
@@ -109,18 +109,18 @@ define i64 @testload2(i64 addrspace(100)* %base) {
 ; CHECK: load
 ; CHECK: ret
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
-  %v1 = load i64, i64 addrspace(100)* %p0, align 8
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
-  %v2 = load i64, i64 addrspace(100)* %p1, align 8
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
-  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
+  %v1 = load i64, ptr addrspace(100) %p0, align 8
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 1
+  %v2 = load i64, ptr addrspace(100) %p1, align 8
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
+  %v3 = load i64, ptr addrspace(100) %p2, align 8
   %sum1 = add i64 %v1, %v2
   %sum2 = add i64 %sum1, %v3
   ret i64 %sum2
 }
 
-define i64 @testload3(i64 addrspace(100)* %base) {
+define i64 @testload3(ptr addrspace(100) %base) {
 ; CHECK: @testload3(
 ; )
 ; CHECK: memcpy
@@ -129,18 +129,18 @@ define i64 @testload3(i64 addrspace(100)* %base) {
 ; CHECK: load
 ; CHECK: ret
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
-  %v1 = load i64, i64 addrspace(100)* %p0, align 8
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 4
-  %v2 = load i64, i64 addrspace(100)* %p1, align 8
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 8
-  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
+  %v1 = load i64, ptr addrspace(100) %p0, align 8
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 4
+  %v2 = load i64, ptr addrspace(100) %p1, align 8
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 8
+  %v3 = load i64, ptr addrspace(100) %p2, align 8
   %sum1 = add i64 %v1, %v2
   %sum2 = add i64 %sum1, %v3
   ret i64 %sum2
 }
 
-define i64 @testload4(i64 addrspace(100)* %base) {
+define i64 @testload4(ptr addrspace(100) %base) {
 ; CHECK: @testload4(
 ; )
 ; CHECK: memcpy
@@ -149,18 +149,18 @@ define i64 @testload4(i64 addrspace(100)* %base) {
 ; CHECK: load
 ; CHECK: ret
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
-  %v1 = load i64, i64 addrspace(100)* %p0, align 8
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 4
-  %v2 = load i64, i64 addrspace(100)* %p1, align 8
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
+  %v1 = load i64, ptr addrspace(100) %p0, align 8
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 4
+  %v2 = load i64, ptr addrspace(100) %p1, align 8
   %sum1 = add i64 %v1, %v2
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 8
-  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 8
+  %v3 = load i64, ptr addrspace(100) %p2, align 8
   %sum2 = add i64 %sum1, %v3
   ret i64 %sum2
 }
 
-define i64 @testload5(i64 addrspace(100)* %base) {
+define i64 @testload5(ptr addrspace(100) %base) {
 ; CHECK: @testload5(
 ; )
 ; CHECK: memcpy
@@ -169,18 +169,18 @@ define i64 @testload5(i64 addrspace(100)* %base) {
 ; CHECK: load
 ; CHECK: ret
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 3
-  %v1 = load i64, i64 addrspace(100)* %p0, align 8
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
-  %v2 = load i64, i64 addrspace(100)* %p1, align 8
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 3
+  %v1 = load i64, ptr addrspace(100) %p0, align 8
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 1
+  %v2 = load i64, ptr addrspace(100) %p1, align 8
   %sum1 = add i64 %v1, %v2
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
-  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
+  %v3 = load i64, ptr addrspace(100) %p2, align 8
   %sum2 = add i64 %sum1, %v3
   ret i64 %sum2
 }
 
-define i64 @testload6(i64 addrspace(100)* %base, i64 addrspace(100)* %other) {
+define i64 @testload6(ptr addrspace(100) %base, ptr addrspace(100) %other) {
 ; CHECK: @testload6(
 ; )
 ; CHECK: getelementptr
@@ -193,18 +193,18 @@ define i64 @testload6(i64 addrspace(100)* %base, i64 addrspace(100)* %other) {
 ; CHECK: add
 ; CHECK: ret
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 3
-  %v1 = load i64, i64 addrspace(100)* %p0, align 8
-  %o1 = getelementptr inbounds i64, i64 addrspace(100)* %other, i32 1
-  %vo = load i64, i64 addrspace(100)* %o1, align 8
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 3
+  %v1 = load i64, ptr addrspace(100) %p0, align 8
+  %o1 = getelementptr inbounds i64, ptr addrspace(100) %other, i32 1
+  %vo = load i64, ptr addrspace(100) %o1, align 8
   %sum1 = add i64 %v1, %vo
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
-  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
+  %v3 = load i64, ptr addrspace(100) %p2, align 8
   %sum2 = add i64 %sum1, %v3
   ret i64 %sum2
 }
 
-define i64 @testload7(i64 addrspace(100)* %base, i64 addrspace(100)* %other) {
+define i64 @testload7(ptr addrspace(100) %base, ptr addrspace(100) %other) {
 ; CHECK: @testload7(
 ; )
 ; CHECK: getelementptr
@@ -218,37 +218,35 @@ define i64 @testload7(i64 addrspace(100)* %base, i64 addrspace(100)* %other) {
 ; CHECK: add
 ; CHECK: ret
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 3
-  %v1 = load i64, i64 addrspace(100)* %p0, align 8
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 3
+  %v1 = load i64, ptr addrspace(100) %p0, align 8
   %sum0 = add i64 %v1, %v1
-  %o1 = getelementptr inbounds i64, i64 addrspace(100)* %other, i32 1
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
-  %v2 = load i64, i64 addrspace(100)* %p1, align 8
-  %vo = load i64, i64 addrspace(100)* %o1, align 8
+  %o1 = getelementptr inbounds i64, ptr addrspace(100) %other, i32 1
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 1
+  %v2 = load i64, ptr addrspace(100) %p1, align 8
+  %vo = load i64, ptr addrspace(100) %o1, align 8
   %sum1 = add i64 %sum0, %vo
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
-  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
+  %v3 = load i64, ptr addrspace(100) %p2, align 8
   %sum2 = add i64 %sum1, %v3
   ret i64 %sum2
 }
 
 
 
-define void @teststoreatomic(i64 addrspace(100)* %base) {
+define void @teststoreatomic(ptr addrspace(100) %base) {
 ; CHECK: @teststoreatomic(
 ; )
 entry:
-  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
-  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
-  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
+  %p0 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 0
+  %p1 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 1
+  %p2 = getelementptr inbounds i64, ptr addrspace(100) %base, i32 2
 ; CHECK: store atomic i64 1
 ; CHECK: store atomic i64 2
 ; CHECK: store atomic i64 3
 ; CHECK: ret
-  store atomic i64 1, i64 addrspace(100)* %p0 unordered, align 8
-  store atomic i64 2, i64 addrspace(100)* %p1 unordered, align 8
-  store atomic i64 3, i64 addrspace(100)* %p2 unordered, align 8
+  store atomic i64 1, ptr addrspace(100) %p0 unordered, align 8
+  store atomic i64 2, ptr addrspace(100) %p1 unordered, align 8
+  store atomic i64 3, ptr addrspace(100) %p2 unordered, align 8
   ret void
 }
-
-

--- a/compiler/llvm/llvm-global-to-wide/test/aggregate.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/aggregate.ll
@@ -1,5 +1,4 @@
-; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT} -aggregate-global-ops -S < %s | FileCheck %s
-
+; RUN: opt-15 --load-pass-plugin=%bindir/llvm-pgas.so -S --passes=aggregate-global-ops < %s | FileCheck-15 %s
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 
 ; Note after LLVM 7 memcpy will no longer take an alignment argument

--- a/compiler/llvm/llvm-global-to-wide/test/b.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/b.ll
@@ -1,4 +1,4 @@
-; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT} -global-to-wide -S < %s | FileCheck %s
+; RUN: opt-15 --load-pass-plugin=%bindir/llvm-pgas.so -S --passes=global-to-wide < %s | FileCheck-15 %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 

--- a/compiler/llvm/llvm-global-to-wide/test/b.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/b.ll
@@ -5,59 +5,58 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ; Check wide pointer manipulation functions.
 %struct.c_localeid_t = type { i32, i32 }
 
-declare i64* @.gf.addr.1(i64 addrspace(100)*) readnone
-declare i32 @.gf.node.1(i64 addrspace(100)*) readnone
-declare %struct.c_localeid_t @.gf.loc.1(i64 addrspace(100)*) readnone
-declare i64 addrspace(100)* @.gf.make.1(%struct.c_localeid_t, i64*) readnone
+declare ptr @.gf.addr.1(ptr addrspace(100)) readnone
+declare i32 @.gf.node.1(ptr addrspace(100)) readnone
+declare %struct.c_localeid_t @.gf.loc.1(ptr addrspace(100)) readnone
+declare ptr addrspace(100) @.gf.make.1(%struct.c_localeid_t, ptr) readnone
 
-define i64* @testaddr(i64 addrspace(100)* %w) {
-; CHECK: @testaddr({ %struct.c_localeid_t, i64* } %
+define ptr @testaddr(ptr addrspace(100) %w) {
+; CHECK: @testaddr({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
-; CHECK: %ret = extractvalue { %struct.c_localeid_t, i64* } %w, 1
+; CHECK: %ret = extractvalue { %struct.c_localeid_t, ptr } %w, 1
 ; CHECK-NOT: @.gf
-; CHECK: ret i64* %ret
+; CHECK: ret ptr %ret
 entry:
-  %ret = call i64* @.gf.addr.1(i64 addrspace(100)* %w)
-  ret i64* %ret
+  %ret = call ptr @.gf.addr.1(ptr addrspace(100) %w)
+  ret ptr %ret
 }
 
-define i32 @testnode(i64 addrspace(100)* %w) {
-; CHECK: @testnode({ %struct.c_localeid_t, i64* } %
+define i32 @testnode(ptr addrspace(100) %w) {
+; CHECK: @testnode({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
-; CHECK: extractvalue { %struct.c_localeid_t, i64* } %w, 0, 0
+; CHECK: extractvalue { %struct.c_localeid_t, ptr } %w, 0, 0
 ; CHECK-NOT: @.gf
 ; CHECK: ret i32 %ret
 entry:
-  %ret = call i32 @.gf.node.1(i64 addrspace(100)* %w)
+  %ret = call i32 @.gf.node.1(ptr addrspace(100) %w)
   ret i32 %ret
 }
 
-define %struct.c_localeid_t @testloc(i64 addrspace(100)* %w) {
-; CHECK: @testloc({ %struct.c_localeid_t, i64* } %
+define %struct.c_localeid_t @testloc(ptr addrspace(100) %w) {
+; CHECK: @testloc({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
-; CHECK: %ret = extractvalue { %struct.c_localeid_t, i64* } %w, 0
+; CHECK: %ret = extractvalue { %struct.c_localeid_t, ptr } %w, 0
 ; CHECK-NOT: @.gf
 ; CHECK: ret %struct.c_localeid_t %ret
 entry:
-  %ret = call %struct.c_localeid_t @.gf.loc.1(i64 addrspace(100)* %w)
+  %ret = call %struct.c_localeid_t @.gf.loc.1(ptr addrspace(100) %w)
   ret %struct.c_localeid_t %ret
 }
 
-define i64 addrspace(100)* @testmake(%struct.c_localeid_t %loc, i64* %addr) {
-; CHECK: { %struct.c_localeid_t, i64* } @testmake(
+define ptr addrspace(100) @testmake(%struct.c_localeid_t %loc, i64* %addr) {
+; CHECK: { %struct.c_localeid_t, ptr } @testmake(
 ; )
 ; CHECK-NOT: @.gf
-; CHECK: insertvalue { %struct.c_localeid_t, i64* }
+; CHECK: insertvalue { %struct.c_localeid_t, ptr }
 ; CHECK: %struct.c_localeid_t %loc, 0
-; CHECK: insertvalue { %struct.c_localeid_t, i64* }
-; CHECK: i64* %addr
+; CHECK: insertvalue { %struct.c_localeid_t, ptr }
+; CHECK: ptr %addr
 ; CHECK-NOT: @.gf
-; CHECK: ret { %struct.c_localeid_t, i64* }
+; CHECK: ret { %struct.c_localeid_t, ptr }
 entry:
-  %ret = call i64 addrspace(100)* @.gf.make.1(%struct.c_localeid_t %loc, i64* %addr)
-  ret i64 addrspace(100)* %ret
+  %ret = call ptr addrspace(100) @.gf.make.1(%struct.c_localeid_t %loc, ptr %addr)
+  ret ptr addrspace(100) %ret
 }
-

--- a/compiler/llvm/llvm-global-to-wide/test/c.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/c.ll
@@ -1,4 +1,4 @@
-; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT} -global-to-wide -S < %s | FileCheck %s
+; RUN: opt-15 --load-pass-plugin=%bindir/llvm-pgas.so -S --passes=global-to-wide < %s | FileCheck-15 %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 

--- a/compiler/llvm/llvm-global-to-wide/test/c.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/c.ll
@@ -6,76 +6,78 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 %struct.c_localeid_t = type { i32, i32 }
 
 
-declare i64* @.gf.addr.1(i64 addrspace(100)*) readnone
-declare i32 @.gf.node.1(i64 addrspace(100)*) readnone
-declare %struct.c_localeid_t @.gf.loc.1(i64 addrspace(100)*) readnone
-declare i64 addrspace(100)* @.gf.make.1(%struct.c_localeid_t, i64*) readnone
+declare ptr @.gf.addr.1(ptr addrspace(100)) readnone
+declare i32 @.gf.node.1(ptr addrspace(100)) readnone
+declare %struct.c_localeid_t @.gf.loc.1(ptr addrspace(100)) readnone
+declare ptr addrspace(100) @.gf.make.1(%struct.c_localeid_t, ptr) readnone
 
-%mystruct = type { i64 addrspace(100)*, i64 addrspace(100)*, i32 *}
-; CHECK: %mystruct = type { { %struct.c_localeid_t, i64* }, { %struct.c_localeid_t, i64* }, i32* }
+; mystruct has opaque pointers but with typed pointers it is
+; %mystruct = type { i64 addrspace(100)*, i64 addrspace(100)*, i32 *}
 
-declare %mystruct* @.gf.addr.2(%mystruct addrspace(100)*) readnone
-declare i32 @.gf.node.2(%mystruct addrspace(100)*) readnone
-declare %struct.c_localeid_t @.gf.loc.2(%mystruct addrspace(100)*) readnone
-declare %mystruct addrspace(100)* @.gf.make.2(%struct.c_localeid_t, %mystruct*) readnone
+%mystruct = type { ptr addrspace(100), ptr addrspace(100), ptr }
+; CHECK: %mystruct = type { { %struct.c_localeid_t, ptr }, { %struct.c_localeid_t, ptr }, ptr }
+
+declare ptr @.gf.addr.2(ptr addrspace(100)) readnone
+declare i32 @.gf.node.2(ptr addrspace(100)) readnone
+declare %struct.c_localeid_t @.gf.loc.2(ptr addrspace(100)) readnone
+declare ptr addrspace(100) @.gf.make.2(%struct.c_localeid_t, ptr) readnone
 
 
-define i64 addrspace(100)* @get_one(%mystruct addrspace(100)* %s) {
-; CHECK: { %struct.c_localeid_t, i64* } @get_one({ %struct.c_localeid_t, %mystruct* } %
+define ptr addrspace(100) @get_one(ptr addrspace(100) %s) {
+; CHECK: { %struct.c_localeid_t, ptr } @get_one({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
-; CHECK: ret { %struct.c_localeid_t, i64* }
+; CHECK: ret { %struct.c_localeid_t, ptr }
 entry:
-  %gep = getelementptr inbounds %mystruct, %mystruct addrspace(100)* %s, i32 0, i32 0
-  %ptr = load i64 addrspace(100)*, i64 addrspace(100)* addrspace(100)* %gep
-  ret i64 addrspace(100)* %ptr
+  %gep = getelementptr inbounds %mystruct, ptr addrspace(100) %s, i32 0, i32 0
+  %ptr = load ptr addrspace(100), ptr addrspace(100) %gep
+  ret ptr addrspace(100) %ptr
 }
-define i64 addrspace(100)* @get_two(%mystruct addrspace(100)* %s) {
-; CHECK: { %struct.c_localeid_t, i64* } @get_two({ %struct.c_localeid_t, %mystruct* }
+define ptr addrspace(100) @get_two(ptr addrspace(100) %s) {
+; CHECK: { %struct.c_localeid_t, ptr } @get_two({ %struct.c_localeid_t, ptr }
 ; )
 ; CHECK-NOT: @.gf
-; CHECK: ret { %struct.c_localeid_t, i64* }
+; CHECK: ret { %struct.c_localeid_t, ptr }
 entry:
-  %gep = getelementptr inbounds %mystruct, %mystruct addrspace(100)* %s, i32 0, i32 1
-  %ptr = load i64 addrspace(100)*, i64 addrspace(100)* addrspace(100)* %gep
-  ret i64 addrspace(100)* %ptr
+  %gep = getelementptr inbounds %mystruct, ptr addrspace(100) %s, i32 0, i32 1
+  %ptr = load ptr addrspace(100), ptr addrspace(100) %gep
+  ret ptr addrspace(100) %ptr
 }
-define i32* @get_three(%mystruct addrspace(100)* %s) {
-; CHECK: i32* @get_three({ %struct.c_localeid_t, %mystruct* } %
+define ptr @get_three(ptr addrspace(100) %s) {
+; CHECK: ptr @get_three({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
-; CHECK: ret i32*
+; CHECK: ret ptr
 entry:
-  %gep = getelementptr inbounds %mystruct, %mystruct addrspace(100)* %s, i32 0, i32 2
-  %ptr = load i32*, i32* addrspace(100)* %gep
-  ret i32* %ptr
+  %gep = getelementptr inbounds %mystruct, ptr addrspace(100) %s, i32 0, i32 2
+  %ptr = load i32*, ptr addrspace(100) %gep
+  ret ptr %ptr
 }
 
-define i64 @read_int(%mystruct addrspace(100)* %s) {
-; CHECK: i64 @read_int({ %struct.c_localeid_t, %mystruct* } %
+define i64 @read_int(ptr addrspace(100) %s) {
+; CHECK: i64 @read_int({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
 ; CHECK: get
 ; CHECK-NOT: @.gf
 ; CHECK: ret i64
 entry:
-  %gep = getelementptr inbounds %mystruct, %mystruct addrspace(100)* %s, i32 0, i32 0
-  %ptr = load i64 addrspace(100)*, i64 addrspace(100)* addrspace(100)* %gep
-  %ret = load i64, i64 addrspace(100)* %ptr
+  %gep = getelementptr inbounds %mystruct, ptr addrspace(100) %s, i32 0, i32 0
+  %ptr = load ptr addrspace(100), ptr addrspace(100) %gep
+  %ret = load i64, ptr addrspace(100) %ptr
   ret i64 %ret
 }
 
-define void @write_int(%mystruct addrspace(100)* %s, i64 %v) {
-; CHECK: void @write_int({ %struct.c_localeid_t, %mystruct* } %
+define void @write_int(ptr addrspace(100) %s, i64 %v) {
+; CHECK: void @write_int({ %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK-NOT: @.gf
 ; CHECK: put
 ; CHECK-NOT: @.gf
 ; CHECK: ret void
 entry:
-  %gep = getelementptr inbounds %mystruct, %mystruct addrspace(100)* %s, i32 0, i32 0
-  %ptr = load i64 addrspace(100)*, i64 addrspace(100)* addrspace(100)* %gep
-  store i64 %v, i64 addrspace(100)* %ptr
+  %gep = getelementptr inbounds %mystruct, ptr addrspace(100) %s, i32 0, i32 0
+  %ptr = load ptr addrspace(100), ptr addrspace(100) %gep
+  store i64 %v, ptr addrspace(100) %ptr
   ret void
 }
-

--- a/compiler/llvm/llvm-global-to-wide/test/d.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/d.ll
@@ -1,4 +1,4 @@
-; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT} -global-to-wide -S < %s | FileCheck %s
+; RUN: opt-15 --load-pass-plugin=%bindir/llvm-pgas.so -S --passes=global-to-wide < %s | FileCheck-15 %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 

--- a/compiler/llvm/llvm-global-to-wide/test/d.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/d.ll
@@ -9,12 +9,17 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ;%type_one = type opaque
 ;%type_two = type opaque
 
-%recurs = type { %recurs addrspace(100)* }
-; CHECK: %recurs = type { { %struct.c_localeid_t, %recurs* } }
-%type_one = type { %type_two addrspace(100)* }
-; CHECK: %type_one = type { { %struct.c_localeid_t, %type_two* } }
-%type_two = type { %type_one addrspace(100)* }
-; CHECK: %type_two = type { { %struct.c_localeid_t, %type_one* } }
+; these types are defined with opaque pointers but with typed ptrs they are:
+; %recurs = type { %recurs addrspace(100)* }
+; %type_one = type { %type_two addrspace(100)* }
+; %type_two = type { %type_one addrspace(100)* }
+
+%recurs = type { ptr addrspace(100) }
+; CHECK: %recurs = type { { %struct.c_localeid_t, ptr } }
+%type_one = type { ptr addrspace(100) }
+; CHECK: %type_one = type { { %struct.c_localeid_t, ptr } }
+%type_two = type { ptr addrspace(100) }
+; CHECK: %type_two = type { { %struct.c_localeid_t, ptr } }
 
 ; A function to keep those types from dissapearing
 define void @test(%recurs %a, %type_one %b, %type_two %c) {

--- a/compiler/llvm/llvm-global-to-wide/test/e.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/e.ll
@@ -1,4 +1,4 @@
-; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT}  -global-to-wide -S < %s | FileCheck %s
+; RUN: opt-15 --load-pass-plugin=%bindir/llvm-pgas.so -S --passes=global-to-wide < %s | FileCheck-15 %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 

--- a/compiler/llvm/llvm-global-to-wide/test/e.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/e.ll
@@ -6,18 +6,21 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 %struct.c_localeid_t = type { i32, i32 }
 
 
-declare i64* @.gf.addr.1(i64 addrspace(100)*) readnone
-declare i32 @.gf.node.1(i64 addrspace(100)*) readnone
-declare %struct.c_localeid_t @.gf.loc.1(i64 addrspace(100)*) readnone
-declare i64 addrspace(100)* @.gf.make.1(%struct.c_localeid_t, i64*) readnone
+declare ptr @.gf.addr.1(ptr addrspace(100)) readnone
+declare i32 @.gf.node.1(ptr addrspace(100)) readnone
+declare %struct.c_localeid_t @.gf.loc.1(ptr addrspace(100)) readnone
+declare ptr addrspace(100) @.gf.make.1(%struct.c_localeid_t, ptr) readnone
 
-%mystruct = type { i64 addrspace(100)*, i64 addrspace(100)*, i32 *}
-; CHECK: %mystruct = type { { %struct.c_localeid_t, i64* }, { %struct.c_localeid_t, i64* }, i32* }
+; mystruct uses opaque pointers but with typed ptrs it would be:
+; %mystruct = type { i64 addrspace(100)*, i64 addrspace(100)*, i32 *}
 
-declare %mystruct* @.gf.addr.2(%mystruct addrspace(100)*) readnone
-declare i32 @.gf.node.2(%mystruct addrspace(100)*) readnone
-declare %struct.c_localeid_t @.gf.loc.2(%mystruct addrspace(100)*) readnone
-declare %mystruct addrspace(100)* @.gf.make.2(%struct.c_localeid_t, %mystruct*) readnone
+%mystruct = type { ptr addrspace(100), ptr addrspace(100), ptr }
+; CHECK: %mystruct = type { { %struct.c_localeid_t, ptr }, { %struct.c_localeid_t, ptr }, ptr }
+
+declare ptr @.gf.addr.2(ptr addrspace(100)) readnone
+declare i32 @.gf.node.2(ptr addrspace(100)) readnone
+declare %struct.c_localeid_t @.gf.loc.2(ptr addrspace(100)) readnone
+declare ptr addrspace(100) @.gf.make.2(%struct.c_localeid_t, ptr) readnone
 
 ; A function to keep those types from dissapearing
 define void @test(%mystruct %a) {
@@ -50,15 +53,13 @@ E_end:
 
 
 
-define void @G(i1 %a, %mystruct addrspace(100)* %s) {
+define void @G(i1 %a, ptr addrspace(100) %s) {
 entry:
   br label %G_loop
 G_loop:
-  %in = phi %mystruct addrspace(100)* [ %s, %entry ], [ %ptr, %G_loop ]
-  %ptr = getelementptr inbounds %mystruct, %mystruct addrspace(100)* %in, i32 1
+  %in = phi ptr addrspace(100) [ %s, %entry ], [ %ptr, %G_loop ]
+  %ptr = getelementptr inbounds %mystruct, ptr addrspace(100) %in, i32 1
   br i1 %a, label %G_loop, label %G_end
 G_end:
   ret void
 }
-
-

--- a/compiler/llvm/llvm-global-to-wide/test/f.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/f.ll
@@ -1,4 +1,4 @@
-; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT} -global-to-wide -S < %s | FileCheck %s
+; RUN: opt-15 --load-pass-plugin=%bindir/llvm-pgas.so -S --passes=global-to-wide < %s | FileCheck-15 %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 

--- a/compiler/llvm/llvm-global-to-wide/test/f.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/f.ll
@@ -6,18 +6,21 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 %struct.c_localeid_t = type { i32, i32 }
 
 
-declare i64* @.gf.addr.1(i64 addrspace(100)*) readnone
-declare i32 @.gf.node.1(i64 addrspace(100)*) readnone
-declare %struct.c_localeid_t @.gf.loc.1(i64 addrspace(100)*) readnone
-declare i64 addrspace(100)* @.gf.make.1(%struct.c_localeid_t, i64*) readnone
+declare ptr @.gf.addr.1(ptr addrspace(100)) readnone
+declare i32 @.gf.node.1(ptr addrspace(100)) readnone
+declare %struct.c_localeid_t @.gf.loc.1(ptr addrspace(100)) readnone
+declare ptr addrspace(100) @.gf.make.1(%struct.c_localeid_t, ptr) readnone
 
-%mystruct = type { i64 addrspace(100)*, i64 addrspace(100)*, i32 *}
-; CHECK: %mystruct = type { { %struct.c_localeid_t, i64* }, { %struct.c_localeid_t, i64* }, i32* }
+; mystruct uses opaque pointers but with typed pointers it would be:
+; %mystruct = type { i64 addrspace(100)*, i64 addrspace(100)*, i32 *}
 
-declare %mystruct* @.gf.addr.2(%mystruct addrspace(100)*) readnone
-declare i32 @.gf.node.2(%mystruct addrspace(100)*) readnone
-declare %struct.c_localeid_t @.gf.loc.2(%mystruct addrspace(100)*) readnone
-declare %mystruct addrspace(100)* @.gf.make.2(%struct.c_localeid_t, %mystruct*) readnone
+%mystruct = type { ptr addrspace(100), ptr addrspace(100), ptr }
+; CHECK: %mystruct = type { { %struct.c_localeid_t, ptr }, { %struct.c_localeid_t, ptr }, ptr }
+
+declare ptr @.gf.addr.2(ptr addrspace(100)) readnone
+declare i32 @.gf.node.2(ptr addrspace(100)) readnone
+declare %struct.c_localeid_t @.gf.loc.2(ptr addrspace(100)) readnone
+declare ptr addrspace(100) @.gf.make.2(%struct.c_localeid_t, ptr) readnone
 
 ; A function to keep those types from dissapearing
 define void @test(%mystruct %a) {
@@ -30,7 +33,7 @@ define void @F() {
 entry:
   br label %F_cond
 F_cond:
-  %tmp = phi %mystruct addrspace(100)* [ undef, %entry ], [ undef, %F_body_five ]
+  %tmp = phi ptr addrspace(100) [ undef, %entry ], [ undef, %F_body_five ]
   br i1 undef, label %F_body_three, label %F_end
 F_body_three:
   br i1 undef, label %F_body_five, label %F_body_six
@@ -41,5 +44,3 @@ F_body_six:
 F_end:
   unreachable
 }
-
-

--- a/compiler/llvm/llvm-global-to-wide/test/g.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/g.ll
@@ -1,4 +1,4 @@
-; RUN: opt --load %bindir/lib/llvm-pgas${MOD_EXT} -global-to-wide -S < %s | FileCheck %s
+; RUN: opt-15 --load-pass-plugin=%bindir/llvm-pgas.so -S --passes=global-to-wide < %s | FileCheck-15 %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 

--- a/compiler/llvm/llvm-global-to-wide/test/g.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/g.ll
@@ -3,36 +3,32 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 
 ; Note after LLVM 7 memcpy will no longer take an alignment argument
-declare void @llvm.memcpy.p0i8.p100i8.i64(i8* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
-declare void @llvm.memcpy.p100i8.p0i8.i64(i8 addrspace(100)* nocapture, i8* nocapture, i64, i32, i1)
-declare void @llvm.memcpy.p100i8.p100i8.i64(i8 addrspace(100)* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p0i8.p100i8.i64(ptr nocapture, ptr addrspace(100) nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p100i8.p0i8.i64(ptr addrspace(100) nocapture, ptr nocapture, i64, i32, i1)
+declare void @llvm.memcpy.p100i8.p100i8.i64(ptr addrspace(100) nocapture, ptr addrspace(100) nocapture, i64, i32, i1)
 
-define i128 @testptrtoint(double addrspace(100)* %ptr) {
+define i128 @testptrtoint(ptr addrspace(100) %ptr) {
 ; CHECK: i128 @testptrtoint(
-; CHECK: { %struct.c_localeid_t, double* } %
+; CHECK: { %struct.c_localeid_t, ptr } %
 ; )
 ; CHECK: alloca i128
-; CHECK: bitcast i128* %
-; CHECK: to { %struct.c_localeid_t, double* }*
-; CHECK: store { %struct.c_localeid_t, double* } %ptr
-; CHECK: load i128, i128* %
+; CHECK: store { %struct.c_localeid_t, ptr } %ptr
+; CHECK: load i128, ptr %
 ; CHECK: ret i128
 entry:
-  %ret = ptrtoint double addrspace(100)* %ptr to i128
+  %ret = ptrtoint ptr addrspace(100) %ptr to i128
   ret i128 %ret
 }
 
 
-define double addrspace(100)* @testinttoptr(i128 %i) {
-; CHECK: { %struct.c_localeid_t, double* } @testinttoptr(i128 %
+define ptr addrspace(100) @testinttoptr(i128 %i) {
+; CHECK: { %struct.c_localeid_t, ptr } @testinttoptr(i128 %
 ; )
-; CHECK: alloca { %struct.c_localeid_t, double* }
-; CHECK: bitcast { %struct.c_localeid_t, double* }* %
-; CHECK: to i128*
+; CHECK: alloca { %struct.c_localeid_t, ptr }
 ; CHECK: store i128 %
-; CHECK: load { %struct.c_localeid_t, double* }, { %struct.c_localeid_t, double* }*
-; CHECK: ret { %struct.c_localeid_t, double* }
+; CHECK: load { %struct.c_localeid_t, ptr },
+; CHECK: ret { %struct.c_localeid_t, ptr }
 entry:
-  %ret = inttoptr i128 %i to double addrspace(100)*
-  ret double addrspace(100)* %ret
+  %ret = inttoptr i128 %i to ptr addrspace(100)
+  ret ptr addrspace(100) %ret
 }

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -875,8 +875,6 @@ bool AggregateGlobalOpsOpt::run(Function &F) {
   bool ChangedFn = false;
   bool DebugThis = DEBUG;
 
-  printf("In AggregateGlobalOpsOpt::run\n");
-
   if( debugThisFn[0] && F.getName() == debugThisFn ) {
     DebugThis = true;
   }

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -875,6 +875,8 @@ bool AggregateGlobalOpsOpt::run(Function &F) {
   bool ChangedFn = false;
   bool DebugThis = DEBUG;
 
+  printf("In AggregateGlobalOpsOpt::run\n");
+
   if( debugThisFn[0] && F.getName() == debugThisFn ) {
     DebugThis = true;
   }
@@ -937,6 +939,5 @@ bool AggregateGlobalOpsOpt::run(Function &F) {
   //MD = 0;
   return ChangedFn;
 }
-
 
 #endif


### PR DESCRIPTION
In trying to debug a problem with `--llvm-wide-opt` with opaque pointers enabled, I sought to run the LLVM lit-style tests that exist for that pass with opaque pointers. I had trouble running these tests due to changes in the build process but I got them working eventually (on my system, anyway).

This PR:
 * updates the compiler/llvm/llvm-global-to-wide test directory to be able to build and test the passes with LLVM 15
 * updates the tests themselves to have opaque pointer input and output

Note that these tests do not run in any nightly testing configuration. The TODO of adding such testing is covered in issue #11192.

Test change only.

Reviewed by @riftEmber - thanks!

- [x] these tests pass on Ubuntu 23.04 with a system-wide install of LLVM 15.