### PR TITLE
Fix some good files that include --help output

### DIFF
--- a/test/execflags/configs/privateconfigs-help-set.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help-set.comm-none.good
@@ -20,6 +20,7 @@ Built-in config vars:
                       memLeaksLog: string
                    memLeaksByDesc: string
                          debugGpu: bool
+              gpuNoCpuModeWarning: bool
                      enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)

--- a/test/execflags/configs/privateconfigs-help-set.good
+++ b/test/execflags/configs/privateconfigs-help-set.good
@@ -20,6 +20,7 @@ Built-in config vars:
                       memLeaksLog: string
                    memLeaksByDesc: string
                          debugGpu: bool
+              gpuNoCpuModeWarning: bool
                      enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64) (configured to 1)

--- a/test/execflags/configs/privateconfigs-help.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help.comm-none.good
@@ -20,6 +20,7 @@ Built-in config vars:
                       memLeaksLog: string
                    memLeaksByDesc: string
                          debugGpu: bool
+              gpuNoCpuModeWarning: bool
                      enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)

--- a/test/execflags/configs/privateconfigs-help.good
+++ b/test/execflags/configs/privateconfigs-help.good
@@ -20,6 +20,7 @@ Built-in config vars:
                       memLeaksLog: string
                    memLeaksByDesc: string
                          debugGpu: bool
+              gpuNoCpuModeWarning: bool
                      enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64) (configured to 1)

--- a/test/execflags/ferguson/help2.good
+++ b/test/execflags/ferguson/help2.good
@@ -32,6 +32,7 @@ CONFIG VARS:
                       memLeaksLog: string
                    memLeaksByDesc: string
                          debugGpu: bool
+              gpuNoCpuModeWarning: bool
                      enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)

--- a/test/execflags/shannon/configs/help/basehelp.txt
+++ b/test/execflags/shannon/configs/help/basehelp.txt
@@ -21,6 +21,7 @@ Built-in config vars:
                      memLeaksLog: string
                   memLeaksByDesc: string
                         debugGpu: bool 
+             gpuNoCpuModeWarning: bool
                     enableGpuP2P: bool 
  defaultHashTableResizeThreshold: real(64) 
                       numLocales: int(64)

--- a/test/execflags/shannon/help.good
+++ b/test/execflags/shannon/help.good
@@ -19,6 +19,7 @@ CONFIG VARS:
                       memLeaksLog: string
                    memLeaksByDesc: string
                          debugGpu: bool
+              gpuNoCpuModeWarning: bool
                      enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)


### PR DESCRIPTION
Add the new GPU related config to some good files that test `--help` output.

Tests pass with local and gasnet configs.