### PR TITLE
Use new pass manager with LLVM 16

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2840,7 +2840,7 @@ void FnSymbol::codegenDef() {
 
     // (note, in particular, the default pass manager's
     //  populateFunctionPassManager does not include vectorization)
-    info->FPM_postgen->run(*func);
+    simplifyFunction(func);
 #endif
   }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2811,9 +2811,7 @@ GenInfo::GenInfo()
              noAliasScopes(),
              noAliasScopeLists(),
              noAliasLists(),
-             globalToWideInfo(),
-             FPM_postgen(nullptr),
-             clangInfo(nullptr)
+             globalToWideInfo()
 #endif
 {
 #ifdef LLVM_NO_OPAQUE_POINTERS

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -132,6 +132,9 @@ void print_clang(const clang::ValueDecl* vd);
 
 const char* getGeneratedAnonTypeName(const clang::RecordType* structType);
 
+// simplify the function using the function simplification pipeline
+void simplifyFunction(llvm::Function* func);
+
 #endif // HAVE_LLVM
 
 #endif //CLANGUTIL_H

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -142,6 +142,7 @@ struct GenInfo {
   // (this one is only set for LLVM_USE_OLD_PASSES)
   llvm::legacy::FunctionPassManager* FPM_postgen = nullptr;
 
+  // Managers to optimize immediately after code-generating a fn
   // (these ones are used ifndef LLVM_USE_OLD_PASSES)
   llvm::LoopAnalysisManager* LAM = nullptr;
   llvm::FunctionAnalysisManager* FAM = nullptr;

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -46,8 +46,11 @@ namespace clang {
   }
 }
 
+#include "llvm/Analysis/LoopAnalysisManager.h"
+#include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/MDBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Target/TargetMachine.h"
 
 struct ClangInfo;
@@ -136,9 +139,18 @@ struct GenInfo {
   GlobalToWideInfo globalToWideInfo;
 
   // Optimizations to apply immediately after code-generating a fn
-  llvm::legacy::FunctionPassManager* FPM_postgen;
+  // (this one is only set for LLVM_USE_OLD_PASSES)
+  llvm::legacy::FunctionPassManager* FPM_postgen = nullptr;
 
-  ClangInfo* clangInfo;
+  // (these ones are used ifndef LLVM_USE_OLD_PASSES)
+  llvm::LoopAnalysisManager* LAM = nullptr;
+  llvm::FunctionAnalysisManager* FAM = nullptr;
+  llvm::CGSCCAnalysisManager* CGAM = nullptr;
+  llvm::ModuleAnalysisManager* MAM = nullptr;
+  llvm::FunctionPassManager* FunctionSimplificationPM = nullptr;
+
+  // pointer to clang support info
+  ClangInfo* clangInfo = nullptr;
 #endif
 
   GenInfo();

--- a/compiler/include/llvmDumpIR.h
+++ b/compiler/include/llvmDumpIR.h
@@ -26,6 +26,12 @@
 #include "llvmUtil.h"
 #include "symbol.h"
 
+namespace llvm {
+  class Loop;
+  class LPMUpdater;
+}
+
+#include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 
@@ -49,6 +55,10 @@ struct DumpIRPass : public llvm::PassInfoMixin<DumpIRPass> {
   explicit DumpIRPass(llvmStageNum_t stage) : pass(stage) { }
   llvm::PreservedAnalyses run(llvm::Function& function,
                               llvm::FunctionAnalysisManager& analysisManager);
+  llvm::PreservedAnalyses run(llvm::Loop& L,
+                              llvm::LoopAnalysisManager& AM,
+                              llvm::LoopStandardAnalysisResults& AR,
+                              llvm::LPMUpdater& U);
 };
 // old pass manager version
 struct LegacyDumpIRPass : public llvm::FunctionPass {

--- a/compiler/include/llvmVer.h
+++ b/compiler/include/llvmVer.h
@@ -56,7 +56,7 @@
 
 #endif // else (HAVE_LLVM_VER>=150)
 
-#if HAVE_LLVM_VER < 120
+#if HAVE_LLVM_VER < 160
 #define LLVM_USE_OLD_PASSES 1
 #endif
 

--- a/compiler/include/llvmVer.h
+++ b/compiler/include/llvmVer.h
@@ -56,6 +56,10 @@
 
 #endif // else (HAVE_LLVM_VER>=150)
 
+#if HAVE_LLVM_VER < 120
+#define LLVM_USE_OLD_PASSES 1
+#endif
+
 #endif //HAVE_LLVM
 
 #endif //LLVMVER_H

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -77,8 +77,10 @@
 #if HAVE_LLVM_VER >= 140
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Passes/OptimizationLevel.h"
+using LlvmOptimizationLevel = llvm::OptimizationLevel;
 #else
 #include "llvm/Support/TargetRegistry.h"
+using LlvmOptimizationLevel = llvm::PassBuilder::OptimizationLevel;
 #endif
 
 #if HAVE_LLVM_VER >= 90
@@ -2219,7 +2221,7 @@ void simplifyFunction(llvm::Function* func) {
 #ifndef LLVM_USE_OLD_PASSES
 // if optLevel is provided, use that; otherwise use the value
 // from clangInfo->codegenOptions.
-static llvm::OptimizationLevel translateOptLevel(int optLevel=-1) {
+static LlvmOptimizationLevel translateOptLevel(int optLevel=-1) {
   if (optLevel < 0) {
     ClangInfo* clangInfo = gGenInfo->clangInfo;
     INT_ASSERT(clangInfo);
@@ -2228,11 +2230,11 @@ static llvm::OptimizationLevel translateOptLevel(int optLevel=-1) {
   }
 
   switch (optLevel) {
-    case 0: return OptimizationLevel::O0;
-    case 1: return OptimizationLevel::O1;
-    case 2: return OptimizationLevel::O2;
-    case 3: return OptimizationLevel::O3;
-    default: return OptimizationLevel::O0;
+    case 0: return LlvmOptimizationLevel::O0;
+    case 1: return LlvmOptimizationLevel::O1;
+    case 2: return LlvmOptimizationLevel::O2;
+    case 3: return LlvmOptimizationLevel::O3;
+    default: return LlvmOptimizationLevel::O0;
   }
 }
 #endif
@@ -2374,7 +2376,7 @@ void prepareCodegenLLVM()
   PB.crossRegisterProxies(*info->LAM, *info->FAM, *info->CGAM, *info->MAM);
 
   auto lvl = translateOptLevel();
-  if (lvl != OptimizationLevel::O0) {
+  if (lvl != LlvmOptimizationLevel::O0) {
     info->FunctionSimplificationPM = new FunctionPassManager(
         PB.buildFunctionSimplificationPipeline(lvl, ThinOrFullLTOPhase::None));
   }

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2173,6 +2173,13 @@ static void registerRVPasses(const llvm::PassManagerBuilder &Builder,
 }
 #endif
 
+void simplifyFunction(llvm::Function* func) {
+  // Run per-function optimization / simplification
+  // to potentially keep the fn in cache while it is simplified.
+  // Big optimizations happen later.
+  gGenInfo->FPM_postgen->run(*func);
+}
+
 // This has code based on clang's EmitAssemblyHelper::CreatePasses
 // in BackendUtil.cpp.
 static

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2247,14 +2247,10 @@ static LlvmOptimizationLevel translateOptLevel(int optLevel=-1) {
 }
 
 static
-llvm::PipelineTuningOptions createPipelineOptions(bool forFunctionPasses,
-                                                  int optLevel = -1) {
+llvm::PipelineTuningOptions createPipelineOptions(bool forFunctionPasses) {
   ClangInfo* clangInfo = gGenInfo->clangInfo;
   INT_ASSERT(clangInfo);
   clang::CodeGenOptions &CodeGenOpts = clangInfo->codegenOptions;
-
-  if (optLevel < 0)
-    optLevel = CodeGenOpts.OptimizationLevel;
 
   // Based on clang's EmitAssemblyHelper::RunOptimizationPipeline
   PipelineTuningOptions PTO;
@@ -2469,7 +2465,7 @@ void prepareCodegenLLVM()
   info->LAM = new LoopAnalysisManager();
   info->FAM = new FunctionAnalysisManager();
   info->CGAM = new CGSCCAnalysisManager();
-  info->MAM = new ModuleAnalysisManager;
+  info->MAM = new ModuleAnalysisManager();
 
   info->FAM->registerPass([&] { return TargetLibraryAnalysis(TLII); });
 
@@ -4057,8 +4053,8 @@ static void registerDumpIrExtensions(PassBuilder& PB) {
         case llvmStageNum::ModuleOptimizerEarly:
           if (llvmPrintIrStageNum != llvmStageNum::EVERY) {
             // do nothing, don't see an equivalent
-            printf("Cannot use llvm-print-ir-stage module-optimizer-early "
-                   "with the new pass manager\n");
+            USR_FATAL("Cannot use llvm-print-ir-stage module-optimizer-early "
+                      "with the new pass manager\n");
           }
           break;
         case llvmStageNum::LoopOptimizerEnd:
@@ -4088,8 +4084,8 @@ static void registerDumpIrExtensions(PassBuilder& PB) {
         case llvmStageNum::EnabledOnOptLevel0:
           if (llvmPrintIrStageNum != llvmStageNum::EVERY) {
             // do nothing, don't see an equivalent
-            printf("Cannot use llvm-print-ir-stage module-optimizer-early "
-                   "with the new pass manager\n");
+            USR_FATAL("Cannot use llvm-print-ir-stage enabled-on-opt-level0 "
+                      "with the new pass manager\n");
           }
           break;
         case llvmStageNum::Peephole:

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -60,7 +60,6 @@
 #include "llvm/Linker/Linker.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/SubtargetFeature.h"
-#include "llvm/Passes/OptimizationLevel.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
@@ -77,6 +76,7 @@
 
 #if HAVE_LLVM_VER >= 140
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Passes/OptimizationLevel.h"
 #else
 #include "llvm/Support/TargetRegistry.h"
 #endif

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2130,19 +2130,15 @@ static void setupModule()
 static void cleanupFunctionOptManagers() {
   GenInfo* info = gGenInfo;
 
+  // note: the order of deleting these is important
   if (info->FunctionSimplificationPM) {
     delete info->FunctionSimplificationPM;
     info->FunctionSimplificationPM = nullptr;
   }
 
-  if (info->LAM) {
-    delete info->LAM;
-    info->LAM = nullptr;
-  }
-
-  if (info->FAM) {
-    delete info->FAM;
-    info->FAM = nullptr;
+  if (info->MAM) {
+    delete info->MAM;
+    info->MAM = nullptr;
   }
 
   if (info->CGAM) {
@@ -2150,9 +2146,14 @@ static void cleanupFunctionOptManagers() {
     info->CGAM = nullptr;
   }
 
-  if (info->MAM) {
-    delete info->MAM;
-    info->MAM = nullptr;
+  if (info->FAM) {
+    delete info->FAM;
+    info->FAM = nullptr;
+  }
+
+  if (info->LAM) {
+    delete info->LAM;
+    info->LAM = nullptr;
   }
 }
 

--- a/compiler/llvm/llvmDumpIR.cpp
+++ b/compiler/llvm/llvmDumpIR.cpp
@@ -28,9 +28,11 @@
 #ifdef HAVE_LLVM
 
 #include "llvm/ADT/Statistic.h"
+#include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/Function.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
+
 using namespace llvm;
 
 void DumpIR::run(Function &F) {
@@ -45,6 +47,18 @@ void DumpIR::run(Function &F) {
 PreservedAnalyses DumpIRPass::run(Function& function,
                                   FunctionAnalysisManager& analysisManager) {
   pass.run(function);
+  // We don't modify the program, so we preserve all analyses.
+  return llvm::PreservedAnalyses::all();
+}
+
+PreservedAnalyses DumpIRPass::run(Loop& L,
+                                  LoopAnalysisManager& AM,
+                                  LoopStandardAnalysisResults& AR,
+                                  LPMUpdater& U) {
+  llvm::BasicBlock* bb = L.getHeader();
+  assert(bb);
+  llvm::Function* function = bb->getParent();
+  pass.run(*function);
   // We don't modify the program, so we preserve all analyses.
   return llvm::PreservedAnalyses::all();
 }


### PR DESCRIPTION
Continuing PR #22282, this PR updates Chapel's use of LLVM optimization passes to work with the new Pass Manager instead of the legacy one. It is currently configured to only use the new pass manager with LLVM 16 and newer (and note that the compiler does not yet build with LLVM 16 but see PR #22335 for that).

LLVM has introduced a new pass manager and the old pass manager is deprecated for running the optimization pipeline as of LLVM 15. And, some features of optimization with the old pass manager are removed in LLVM 16. So, we are looking at migrating Chapel's LLVM passes to the new pass manager. (Some historical details: `clang` started to use the new pass manager in LLVM 12; the new pass manager existed in LLVM 11; and even as of LLVM 16, the LLVM IR to assembly code generators still use the old pass manager).

This PR adjust the compiler to run optimizations using the new pass manager for LLVM 16 and newer and continues to use the old pass manager for LLVM IR to assembly code generation (because these features are not yet available with the new pass manager).

Future Work:
 * understand performance differences from this change. I think I'm seeing some slowdown with k-nucleotide but there might be other tests that are easier to analyze in terms of performance changes.
 * figure out what is going wrong with scans, e.g. `reductions/deitz/test_scan1`, when using the new pass manager.

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14