### PR TITLE
Remove useless 'const' on return values

### DIFF
--- a/frontend/include/chpl/types/ArrayType.h
+++ b/frontend/include/chpl/types/ArrayType.h
@@ -72,7 +72,7 @@ class ArrayType final : public CompositeType {
                                        const QualifiedType& domainType,
                                        const QualifiedType& eltType);
 
-  const QualifiedType domainType() const {
+  QualifiedType domainType() const {
     auto it = subs_.find(domainId);
     if (it != subs_.end()) {
       return it->second;
@@ -81,7 +81,7 @@ class ArrayType final : public CompositeType {
     }
   }
 
-  const QualifiedType eltType() const {
+  QualifiedType eltType() const {
     auto it = subs_.find(eltTypeId);
     if (it != subs_.end()) {
       return it->second;

--- a/frontend/include/chpl/types/DomainType.h
+++ b/frontend/include/chpl/types/DomainType.h
@@ -100,7 +100,7 @@ class DomainType final : public CompositeType {
                                               const QualifiedType& idxType,
                                               const QualifiedType& parSafe);
 
-  const Kind kind() const {
+  Kind kind() const {
     return kind_;
   }
 


### PR DESCRIPTION
Follow-up to PRs #22096 and #22097.

This PR just removes some useless `const` modifiers on return values. These cause warnings with some Intel compilers.

Reviewed by @benharsh - thanks!

- [x] full local testing