### PR TITLE
Add skpif for global-var-type-mismatch

### DIFF
--- a/test/extern/ferguson/global-var-type-mismatch.skipif
+++ b/test/extern/ferguson/global-var-type-mismatch.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM==none


### PR DESCRIPTION
Follow-up to PR #22277.

The new error checking of `extern var` Chapel type vs C type only works with the LLVM backend, so skip the test of it for `CHPL_LLVM=none`.

Test change only - not reviewed.