### PR TITLE
Add missing skip for --no-local for ref_nonnul

### DIFF
--- a/test/llvm/with-opaque-ptrs/function-args/ref_nonnull.skipif
+++ b/test/llvm/with-opaque-ptrs/function-args/ref_nonnull.skipif
@@ -1,1 +1,2 @@
 CHPL_COMM!=none
+COMPOPTS <= --no-local

--- a/test/llvm/with-typed-ptrs/function-args/ref_nonnull.skipif
+++ b/test/llvm/with-typed-ptrs/function-args/ref_nonnull.skipif
@@ -1,1 +1,2 @@
 CHPL_COMM!=none
+COMPOPTS <= --no-local


### PR DESCRIPTION
Follow-up to PR #22275. Before that PR, this directory had a directory-wide skipif containing 'COMPOPTS <= --no-local'. Since the other test seems to be passing, this PR just adds that constraint to ref_nonnul.skipif.

Test change only - not reviewed.