### PR TITLE
Fix failing test case due to use of `AutoMath.log`

### DIFF
--- a/test/users/npadmana/gsl_demonstration/gsl_demo.chpl
+++ b/test/users/npadmana/gsl_demonstration/gsl_demo.chpl
@@ -1,4 +1,5 @@
 use CTypes;
+use Math;
 require '-lgsl','-lgslcblas';
 
 /* Put in the usual GSL includes here */


### PR DESCRIPTION
PR #22284 deprecated including `log` by default, this test was missed while fixing deprecation messages.

---

[Not reviewed - trivial]