### PR TITLE
Use modules and CHPL_GPU in test scripts individually

### DIFF
--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -7,7 +7,6 @@ export OFFICIAL_SYSTEM_LLVM=true
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 
-module load cudatoolkit
 export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_TEST_GPU=true

--- a/util/cron/test-gpu-cuda.aod.bash
+++ b/util/cron/test-gpu-cuda.aod.bash
@@ -4,6 +4,10 @@
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
+
+module load cudatoolkit
+
+export CHPL_GPU=nvidia
 export CHPL_COMM=none
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/array_on_device"
 export CHPL_GPU_MEM_STRATEGY=array_on_device

--- a/util/cron/test-gpu-cuda.bash
+++ b/util/cron/test-gpu-cuda.bash
@@ -4,6 +4,10 @@
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
+
+module load cudatoolkit
+
+export CHPL_GPU=nvidia
 export CHPL_COMM=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda"

--- a/util/cron/test-gpu-cuda.gasnet.bash
+++ b/util/cron/test-gpu-cuda.gasnet.bash
@@ -8,6 +8,7 @@ source $CWD/common-native-gpu.bash
 module load cudatoolkit
 
 export CHPL_GPU=nvidia
+export CHPL_COMM=gasnet
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda.gasnet"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-cuda.gasnet.bash
+++ b/util/cron/test-gpu-cuda.gasnet.bash
@@ -5,5 +5,9 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 
+module load cudatoolkit
+
+export CHPL_GPU=nvidia
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda.gasnet"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-rocm.bash
+++ b/util/cron/test-gpu-rocm.bash
@@ -5,6 +5,7 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 
+export CHPL_GPU=amd
 export CHPL_LLVM=bundled
 export CHPL_COMM=none
 export CHPL_LAUNCHER_PARTITION=amdMI60

--- a/util/cron/test-gpu-rocm.gasnet.bash
+++ b/util/cron/test-gpu-rocm.gasnet.bash
@@ -5,6 +5,7 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 
+export CHPL_GPU=amd
 export CHPL_LLVM=bundled
 export CHPL_GPU_CODEGEN=rocm
 export CHPL_LAUNCHER_PARTITION=amdMI60

--- a/util/cron/test-gpu-rocm.gasnet.bash
+++ b/util/cron/test-gpu-rocm.gasnet.bash
@@ -7,7 +7,7 @@ source $CWD/common-native-gpu.bash
 
 export CHPL_GPU=amd
 export CHPL_LLVM=bundled
-export CHPL_GPU_CODEGEN=rocm
+export CHPL_COMM=gasnet
 export CHPL_LAUNCHER_PARTITION=amdMI60
 module load rocm
 


### PR DESCRIPTION
We have `module load cudatoolkit` in the common cron script. This causes problems when you also load `rocm` without specifying `CHPL_GPU`. This PR:

- removes that top level `module load`
- explicitly sets `CHPL_GPU` in GPU test scripts
- while there, also sets `CHPL_COMM` explicitly because it took me a while to understand that it gets set automatically on CS.