### PR TITLE
Update llvmGlobalToWide to build with LLVM 11, 12

### DIFF
--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1037,10 +1037,17 @@ namespace {
 
       if (newSrcTy != srcTy || newResTy != resTy) {
         // gather the indices
+#if HAVE_LLVM_VER >= 130
         SmallVector<Constant*> idxList;
         for (const auto& v : gepOp->indices()) {
           idxList.push_back(cast<Constant>(v));
         }
+#else
+        SmallVector<Constant*, 8> idxList;
+        for (auto it = gepOp->idx_begin(); it != gepOp->idx_end(); ++it) {
+          idxList.push_back(cast<Constant>(*it));
+        }
+#endif
         // Create a new GetElementPtrConstantExpr while changing the types
         auto C1 = ConstantExpr::getGetElementPtr(
                      newSrcTy,

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -15,7 +15,7 @@ def llvm_versions():
     # Which major release - only need one number for that with current
     # llvm (since LLVM 4.0).
     # These will be tried in order.
-    return ('14','13','12','11',)
+    return ('15', '14','13','12','11',)
 
 @memoize
 def get_uniq_cfg_path_for(llvm_val, llvm_support_val):


### PR DESCRIPTION
Follow-up to PR #22266 to fix build errors with LLVM 11 and 12.

Reviewed by @riftEmber - thanks!

- [x] full comm=gasnet testing