### PR TITLE
Add llvmMoved GPU test

### DIFF
--- a/test/gpu/native/llvmMoved.chpl
+++ b/test/gpu/native/llvmMoved.chpl
@@ -54,7 +54,7 @@
 
 // After addressing the checklist items (or creating a GH issue to do so)
 // modify the following const so that this test no longer fails.
-const EXPECTED_LLVM_VERSION = 14;
+const EXPECTED_LLVM_VERSION = 15;
 
 //-----------------------------------------------------------------------------
 

--- a/test/gpu/native/llvmMoved.chpl
+++ b/test/gpu/native/llvmMoved.chpl
@@ -29,7 +29,7 @@
               version.
 
         - [ ] Look at util/chplenv/chpl_gpu.py, in here we have code that
-              checks to see if youre using a compatible version of CUDA/ROCm
+              checks to see if you're using a compatible version of CUDA/ROCm
               (as of writing this comment this is in the
               `_validate_cuda_version_impl` and `_validate_rocm_version_impl`
               functions).  Update this code.

--- a/test/gpu/native/llvmMoved.chpl
+++ b/test/gpu/native/llvmMoved.chpl
@@ -1,0 +1,69 @@
+/*
+  /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+  /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+
+  ATTENTION:
+
+      If this test fails it means we're running a new version of LLVM.  Before
+      updating the test so it no longer fails, use the following checklist to
+      see if there are other changes we need to make.
+
+      If you don't want to address all these items yourself, create a GH issue
+      about addressing them and assign that to someone who's familiar with GPU
+      support and who will follow through on it.
+
+  /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+  /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+
+  CHECKLIST:
+
+    - [ ] In the technote search for any mentions of the previous version of
+          LLVM and replace them with the newer version. 
+
+    - [ ] Check to see what version of CUDA and ROCm this version of LLVM
+          supports for its NVPTX and AMDGPU backend.  If (compared to our
+          prior supported version) things have changed.  Determine if we want to
+          have Chapel support this newer version of CUDA/ROCm.  If so then:
+
+        - [ ] Make sure we have nightly testing set up to work with this newer
+              version.
+
+        - [ ] Look at util/chplenv/chpl_gpu.py, in here we have code that
+              checks to see if youre using a compatible version of CUDA/ROCm
+              (as of writing this comment this is in the
+              `_validate_cuda_version_impl` and `_validate_rocm_version_impl`
+              functions).  Update this code.
+
+        - [ ] Check to see if there are any mentions of these version
+              requirements in the tech note and update as needed.
+
+        - [ ] Check public issue #22085, we believe this should be resolved
+              once LLVM adds support for CUDA 12. If LLVM has added support for
+              CUDA 12 and it's resolved remove this checklist item.  If LLVM
+              added support for CUDA 12 and it's not resolved reopen the issue
+              so we can discuss what to do next.
+
+    - [ ] Take a moment to think if there are other items that should belong on
+          this checklist and add them if appropriate.
+
+    - [ ] Update the EXPECTED_LLVM_VERSION constant so this test no longer
+          fails.
+*/
+
+//-----------------------------------------------------------------------------
+
+// After addressing the checklist items (or creating a GH issue to do so)
+// modify the following const so that this test no longer fails.
+const EXPECTED_LLVM_VERSION = 14;
+
+//-----------------------------------------------------------------------------
+
+config const actualLlvmVersion : int; // Passed in by .execopts
+
+if actualLlvmVersion > EXPECTED_LLVM_VERSION {
+  writef("For GPU support, Chapel officially supports using LLVM %s but " +
+    "found version %s, so this test has failed. ",
+    EXPECTED_LLVM_VERSION, actualLlvmVersion);
+  writef("Look at this test and its included checklist to see how to update" +
+         "GPU support for a newer version of LLVM.");
+}

--- a/test/gpu/native/llvmMoved.execopts
+++ b/test/gpu/native/llvmMoved.execopts
@@ -1,0 +1,3 @@
+#!/bin/bash
+LLVM_VERSION=`${CHPL_HOME}/util/printchplenv --all --simple | grep CHPL_LLVM_VERSION | cut -d = -f 2-`
+echo --actualLlvmVersion=$LLVM_VERSION

--- a/test/gpu/native/llvmMoved.good
+++ b/test/gpu/native/llvmMoved.good
@@ -1,0 +1,1 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly

--- a/third-party/llvm/README
+++ b/third-party/llvm/README
@@ -85,3 +85,7 @@ follows, assuming CWD is $CHPL_HOME/third-party/llvm/:
 16. update this README file
 17. commit the docs and chplenv changes
 18. PR, test, merge, etc.
+
+Updating LLVM versions may also have impacts on GPU support.  See the test
+$CHPL_HOME/test/gpu/native/llvmMoved.chpl for a description of these
+considerations.

--- a/third-party/llvm/README
+++ b/third-party/llvm/README
@@ -88,4 +88,4 @@ follows, assuming CWD is $CHPL_HOME/third-party/llvm/:
 
 Updating LLVM versions may also have impacts on GPU support.  See the test
 $CHPL_HOME/test/gpu/native/llvmMoved.chpl for a description of these
-considerations.
+impacts.


### PR DESCRIPTION
Somewhat in response to comments on <https://github.com/chapel-lang/chapel/issues/22085>.

I think it would be good if we had some kind of alert whenever LLVM updates to ensure that we update GPU support in kind.  This test hard codes the version of LLVM we expect to use for our nightly tests and if we run it on a job with a newer LLVM it will fail.

The test includes a checklist of things to consider regarding GPU support and an LLVM update and gives instructions on how to update.