### PR TITLE
More GPU test script fixes

### DIFF
--- a/util/cron/test-gpu-rocm.bash
+++ b/util/cron/test-gpu-rocm.bash
@@ -6,6 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 
 export CHPL_GPU=amd
+export CHPL_GPU_ARCH=gfx906
 export CHPL_LLVM=bundled
 export CHPL_COMM=none
 export CHPL_LAUNCHER_PARTITION=amdMI60

--- a/util/cron/test-gpu-rocm.gasnet.bash
+++ b/util/cron/test-gpu-rocm.gasnet.bash
@@ -6,6 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 
 export CHPL_GPU=amd
+export CHPL_GPU_ARCH=gfx906
 export CHPL_LLVM=bundled
 export CHPL_COMM=gasnet
 export CHPL_LAUNCHER_PARTITION=amdMI60

--- a/util/cron/test-perf.gpu-cuda.aod.bash
+++ b/util/cron/test-perf.gpu-cuda.aod.bash
@@ -4,9 +4,14 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-native-gpu.bash
+
+module load cudatoolkit
+
+export CHPL_GPU=nvidia
 export CHPL_COMM=none
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/array_on_device"
 export CHPL_GPU_MEM_STRATEGY=array_on_device
+
 
 export CHPL_TEST_PERF_CONFIG_NAME='gpu'
 source $CWD/common-perf.bash

--- a/util/cron/test-perf.gpu-cuda.bash
+++ b/util/cron/test-perf.gpu-cuda.bash
@@ -4,6 +4,9 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-native-gpu.bash
+module load cudatoolkit
+
+export CHPL_GPU=nvidia
 export CHPL_COMM=none
 
 export CHPL_TEST_PERF_CONFIG_NAME='gpu'


### PR DESCRIPTION
- Use the correct module and environment for GPU performance test scripts.
- Use `CHPL_GPU_ARCH` for AMD testing explicitly.

I missed these in https://github.com/chapel-lang/chapel/pull/22314