### PR TITLE
Drop default arch for AMD, wire `--gpu-arch` flag correctly

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -263,6 +263,7 @@ extern int fGPUBlockSize;
 extern char fGpuArch[16];
 extern bool fGpuPtxasEnforceOpt;
 extern const char* gGpuSdkPath;
+extern char gpuArch[16];
 
 extern char stopAfterPass[128];
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -359,6 +359,7 @@ int fGPUBlockSize = 0;
 char fGpuArch[16];
 bool fGpuPtxasEnforceOpt;
 const char* gGpuSdkPath = NULL;
+char gpuArch[16];
 
 chpl::Context* gContext = nullptr;
 std::vector<std::pair<std::string, std::string>> gDynoParams;
@@ -1677,6 +1678,21 @@ static void setGPUFlags() {
       fNoStackChecks  = true;
       fNoCastChecks = true;
       fNoDivZeroChecks = true;
+    }
+  }
+
+  // set up gpuArch
+  if (strlen(fGpuArch) > 0) {
+    strncpy(gpuArch, fGpuArch, 16);
+  }
+  else {
+    if (strlen(CHPL_GPU_ARCH) == 0) {
+      USR_FATAL("CHPL_GPU_ARCH must be set. See "
+                "https://chapel-lang.org/docs/technotes/gpu.html "
+                "for more information");
+    }
+    else {
+      strncpy(gpuArch, CHPL_GPU_ARCH, 16);
     }
   }
 }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1679,22 +1679,23 @@ static void setGPUFlags() {
       fNoCastChecks = true;
       fNoDivZeroChecks = true;
     }
-  }
-
-  // set up gpuArch
-  if (strlen(fGpuArch) > 0) {
-    strncpy(gpuArch, fGpuArch, 16);
-  }
-  else {
-    if (strlen(CHPL_GPU_ARCH) == 0) {
-      USR_FATAL("CHPL_GPU_ARCH must be set. See "
-                "https://chapel-lang.org/docs/technotes/gpu.html "
-                "for more information");
+    //
+    // set up gpuArch
+    if (strlen(fGpuArch) > 0) {
+      strncpy(gpuArch, fGpuArch, 16);
     }
     else {
-      strncpy(gpuArch, CHPL_GPU_ARCH, 16);
+      if (CHPL_GPU_ARCH != nullptr && strlen(CHPL_GPU_ARCH) == 0) {
+        USR_FATAL("CHPL_GPU_ARCH must be set. See "
+                  "https://chapel-lang.org/docs/technotes/gpu.html "
+                  "for more information");
+      }
+      else {
+        strncpy(gpuArch, CHPL_GPU_ARCH, 16);
+      }
     }
   }
+
 }
 
 static void checkLLVMCodeGen() {

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -147,13 +147,14 @@ detected (or you would like to use a different installation) you may set
 ``CHPL_CUDA_PATH`` and/or ``CHPL_ROCM_PATH``.
 
 ``CHPL_GPU_ARCH`` environment variable can be set to control the desired GPU
-architecture to compile for.  The default value is ``sm_60`` for
-``CHPL_GPU=nvidia`` and ``gfx906`` for ``CHPL_GPU=amd``. You may also use the
-``--gpu-arch`` compiler flag to set GPU architecture. For a list of possible
-values please refer to `CUDA Programming Guide
+architecture to compile for. For ``CHPL_GPU=nvidia``, this defaults to
+``sm_60``. For ``CHPL_GPU=amd`` it needs to be set explicitly. The environment
+setting can be overridden by the ``--gpu-arch`` compiler flag.  For a list of
+possible values please refer to "processor" values in `this table in the LLVM
+documentation <https://llvm.org/docs/AMDGPUUsage.html#processors>`_ for AMD or
+the `CUDA Programming Guide
 <https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications>`_
-for NVIDIA or "processor" values in `this table in the LLVM documentation
-<https://llvm.org/docs/AMDGPUUsage.html#processors>`_ for AMD.
+for NVIDIA.
 
 ``CHPL_RT_NUM_GPUS_PER_LOCALE`` can be used to control the number of GPU
 sublocales created. For example, in a system where 8 physical GPUs per node,

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -110,7 +110,7 @@ def get_arch():
     arch = GPU_TYPES[gpu_type].default_arch
     if arch != "":
         return arch
-    else
+    else:
         error("CHPL_GPU={} requires also setting CHPL_GPU_ARCH. "
               "Please check the GPU programming technote "
               "<https://chapel-lang.org/docs/technotes/gpu.html> "

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -40,7 +40,7 @@ GPU_TYPES = {
     "amd": gpu_type(sdk_path_env="CHPL_ROCM_PATH",
                     compiler="hipcc",
                     bin_depth=3,
-                    default_arch="gfx908",
+                    default_arch="",
                     llvm_target="AMDGPU",
                     runtime_impl="rocm",
                     version_validator=_validate_rocm_version),
@@ -107,7 +107,14 @@ def get_arch():
         return arch
 
     # Return vendor-specific default architecture
-    return GPU_TYPES[gpu_type].default_arch
+    arch = GPU_TYPES[gpu_type].default_arch
+    if arch != "":
+        return arch
+    else
+        error("CHPL_GPU={} requires also setting CHPL_GPU_ARCH. "
+              "Please check the GPU programming technote "
+              "<https://chapel-lang.org/docs/technotes/gpu.html> "
+              "for more information.".format(gpu_type))
 
 @memoize
 def get_sdk_path(for_gpu):


### PR DESCRIPTION
With this PR:

- we no longer have a default `CHPL_GPU_ARCH` for AMD. It needs to be set by the user: This is because we currently don't have an AMD architecture compatibility story.
- fix `--gpu-arch` that was largely going unused

Test:
- [x] jacobi.chpl on NVIDIA
- [x] jacobi.chpl on AMD