### PR TITLE
dyno: Further improve independence of Dyno scope resolver

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1806,6 +1806,11 @@ setupFunctionDecl(FnSymbol*   fn,
       for_alist(expr, optFnBody->body) {
         fn->body->insertAtTail(expr->remove());
       }
+
+      // Preserve the module references (which are not part of the body)
+      if (optFnBody->modRefs) {
+        fn->body->modRefsReplace(optFnBody->modRefs->copy());
+      }
     } else {
       fn->insertAtTail(optFnBody);
     }

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -676,14 +676,29 @@ BlockStmt::useListClear() {
 }
 
 void
-BlockStmt::modRefsAdd(ModuleSymbol* mod) {
+BlockStmt::modRefsEnsure() {
   if (modRefs == NULL) {
-    modRefs = new CallExpr(PRIM_REFERENCED_MODULES_LIST);
-
-    if (parentSymbol)
-      insert_help(modRefs, this, parentSymbol);
+    modRefsReplace(new CallExpr(PRIM_REFERENCED_MODULES_LIST));
   }
+}
 
+void
+BlockStmt::modRefsReplace(CallExpr* replacementRefs) {
+  modRefs = replacementRefs;
+
+  if (parentSymbol)
+    insert_help(modRefs, this, parentSymbol);
+}
+
+void
+BlockStmt::modRefsAdd(ModuleSymbol* mod) {
+  modRefsEnsure();
+  modRefs->insertAtTail(new SymExpr(mod));
+}
+
+void
+BlockStmt::modRefsAdd(TemporaryConversionSymbol* mod) {
+  modRefsEnsure();
   modRefs->insertAtTail(new SymExpr(mod));
 }
 

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -179,7 +179,10 @@ public:
   bool                useListRemove(ModuleSymbol* mod);
   void                useListClear();
 
+  void                modRefsEnsure();
+  void                modRefsReplace(CallExpr* replacementRefs);
   void                modRefsAdd(ModuleSymbol* mod);
+  void                modRefsAdd(TemporaryConversionSymbol* mod);
   bool                modRefsRemove(ModuleSymbol* mod);
   void                modRefsClear();
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -859,8 +859,11 @@ struct Converter {
     ID moduleId, targetId;
     types::QualifiedType targetType;
     if (!isDotOnModule(node, moduleId, targetId, targetType) ||
-        targetId.isEmpty() ||
-        targetId.isFabricatedId()) return nullptr;
+        targetId.isEmpty()) return nullptr;
+    if (targetId.isFabricatedId()) {
+      CHPL_ASSERT(targetId.fabricatedIdKind() == ID::ExternBlockElement);
+      return nullptr;
+    }
     storeReferencedMod(findConvertedSym(moduleId));
 
     // If it's just a variable, turn it into a direct reference to said
@@ -2077,7 +2080,10 @@ struct Converter {
     if (!dot || !isDotOnModule(dot, moduleId, targetId, targetType)) return nullptr;
 
     // Don't know how to convert fabricated IDs yet.
-    if (targetId.isFabricatedId()) return nullptr;
+    if (targetId.isFabricatedId()) {
+      CHPL_ASSERT(targetId.fabricatedIdKind() == ID::ExternBlockElement);
+      return nullptr;
+    }
 
     if (!targetId.isEmpty() && targetType.kind() != types::QualifiedType::FUNCTION) {
       // an empty ID indicates that it's an overloaded function or otherwise unknown,
@@ -3252,7 +3258,7 @@ struct Converter {
     // Note the module is converted so we can wire up SymExprs later
     noteConvertedSym(node, mod);
 
-    // Pop the module after converting children, and note the moduels used
+    // Pop the module after converting children, and note the modules used
     // within.
     INT_ASSERT(modStack.size() > 0 && modStack.back().mod == node);
     for (auto usedMod : modStack.back().usedModules) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -859,7 +859,8 @@ struct Converter {
     ID moduleId, targetId;
     types::QualifiedType targetType;
     if (!isDotOnModule(node, moduleId, targetId, targetType) ||
-        targetId.isEmpty()) return nullptr;
+        targetId.isEmpty() ||
+        targetId.isFabricatedId()) return nullptr;
     storeReferencedMod(findConvertedSym(moduleId));
 
     // If it's just a variable, turn it into a direct reference to said
@@ -2074,6 +2075,9 @@ struct Converter {
     types::QualifiedType targetType;
     auto dot = node->calledExpression()->toDot();
     if (!dot || !isDotOnModule(dot, moduleId, targetId, targetType)) return nullptr;
+
+    // Don't know how to convert fabricated IDs yet.
+    if (targetId.isFabricatedId()) return nullptr;
 
     if (!targetId.isEmpty() && targetType.kind() != types::QualifiedType::FUNCTION) {
       // an empty ID indicates that it's an overloaded function or otherwise unknown,

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -164,6 +164,13 @@ struct Converter {
      ForwardingDecls will add a method that does not exist in the uAST. */
   std::vector<Symbol*> methodThisStack;
 
+  /* Some actions in the production scope resolver (particularly using a module)
+     cause a search up the chain of scopes until they encounter a Block node.
+     Rather than implementing this search, just keep track of a stack of
+     scope-producing nodes. To properly keep track of them, code in the
+     converter that would normally call `new BlockExpr()`, creating a new
+     scope-producing block but not tracking it, would need to instead call
+     pushScopefulBlock, making the new block appear on this stack. */
   std::vector<BlockStmt*> blockStack;
 
 

--- a/frontend/include/chpl/resolution/resolution-error-classes-list.h
+++ b/frontend/include/chpl/resolution/resolution-error-classes-list.h
@@ -57,7 +57,7 @@ ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const u
 ERROR_CLASS(MultipleQuestionArgs, const uast::FnCall*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(NestedClassFieldRef, const uast::AggregateDecl*, const uast::AggregateDecl*, const uast::AstNode*, ID)
 ERROR_CLASS(NonIterable, const uast::AstNode*, const uast::AstNode*, types::QualifiedType)
-ERROR_CLASS(NotInModule, const uast::Dot*, ID, UniqueString, ID)
+ERROR_CLASS(NotInModule, const uast::Dot*, ID, UniqueString, ID, bool)
 ERROR_CLASS(PrivateToPublicInclude, const uast::Include*, const uast::Module*)
 ERROR_CLASS(ProcDefExplicitAnonFormal, const uast::Function*, const uast::Formal*)
 ERROR_CLASS(ProcTypeUnannotatedFormal, const uast::FunctionSignature*, const uast::AnonFormal*)

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1267,8 +1267,16 @@ void Resolver::issueErrorForFailedModuleDot(const Dot* dot,
     auto vec = lookupNameInScope(context, modScope,
                                  /* receiverScopes */ {},
                                  dot->field(), configWithPrivate);
-    if (!vec.empty()) {
-      thereButPrivate = true;
+    for (auto& bids : vec) {
+      for (auto& id : bids) {
+        // Only report "bla is private" if it's originally declared in the
+        // given module (i.e., don't do so if the found ID is imported from
+        // elsewhere)
+        auto modId = parsing::idToParentModule(context, id);
+        if (modId != moduleId) continue;
+
+        thereButPrivate = true;
+      }
     }
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2970,7 +2970,7 @@ void Resolver::exit(const Dot* dot) {
 
   bool resolvingCalledDot = (inLeafCall &&
                              dot == inLeafCall->calledExpression());
-  if (resolvingCalledDot) {
+  if (resolvingCalledDot && !scopeResolveOnly) {
     // we will handle it when resolving the FnCall
     return;
   }

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -325,7 +325,9 @@ struct Resolver {
                                          const CallResolutionResult& c);
 
   // issue error for M.x where x is not found in a module M
-  void issueErrorForFailedModuleDot(const uast::Dot* dot, ID moduleId);
+  void issueErrorForFailedModuleDot(const uast::Dot* dot,
+                                    ID moduleId,
+                                    LookupConfig failedConfig);
 
   // handle the result of one of the functions to resolve a call. Handles:
   //  * r.setMostSpecific

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -663,9 +663,15 @@ void ErrorNotInModule::write(ErrorWriterBase& wr) const {
   //ID moduleId = std::get<1>(info);
   UniqueString moduleName = std::get<2>(info);
   ID renameClauseId = std::get<3>(info);
+  bool thereButPrivate = std::get<bool>(info);
 
-  wr.heading(kind_, type_, dot,
-             "cannot find '", dot->field(), "' in module '", moduleName, "'");
+  if (thereButPrivate) {
+    wr.heading(kind_, type_, dot,
+               "cannot access '", dot->field(), "' as it is private to '", moduleName, "'.");
+  } else {
+    wr.heading(kind_, type_, dot,
+               "cannot find '", dot->field(), "' in module '", moduleName, "'.");
+  }
 
   wr.code(dot, { dot });
 
@@ -683,7 +689,7 @@ void ErrorNotInModule::write(ErrorWriterBase& wr) const {
     } else {
       wr.note(locationOnly(renameClauseId),
               "module '", moduleName, "' was renamed to"
-              " '", dotModName, "' here");
+              " '", dotModName, "' here:");
       wr.code<ID>(renameClauseId, { renameClauseId });
     }
   }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -215,7 +215,7 @@ struct GatherDecls {
 
   // consider 'include module' something that defines a name
   bool enter(const Include* d) {
-    gather(declared, d->name(), d, uast::Decl::PUBLIC, atFieldLevel);
+    gather(declared, d->name(), d, d->visibility(), atFieldLevel);
     return false;
   }
   void exit(const Include* d) { }

--- a/test/modules/deitz/test_module_access2.good
+++ b/test/modules/deitz/test_module_access2.good
@@ -1,2 +1,2 @@
 test_module_access2.chpl:1: In module 'OuterModule':
-test_module_access2.chpl:13: error: cannot access 'x' as it is private to 'M'
+test_module_access2.chpl:13: error: cannot find 'x' in module 'M'

--- a/test/modules/deitz/test_module_access2.good
+++ b/test/modules/deitz/test_module_access2.good
@@ -1,1 +1,2 @@
-test_module_access2.chpl:13: error: Symbol 'x' undeclared in module 'M'
+test_module_access2.chpl:1: In module 'OuterModule':
+test_module_access2.chpl:13: error: cannot access 'x' as it is private to 'M'

--- a/test/visibility/import/edgeCases/dontLeakSymbols1-proc.good
+++ b/test/visibility/import/edgeCases/dontLeakSymbols1-proc.good
@@ -1,2 +1,2 @@
 dontLeakSymbols1-proc.chpl:18: In function 'main':
-dontLeakSymbols1-proc.chpl:19: error: Symbol 'foo' undeclared in module 'C'
+dontLeakSymbols1-proc.chpl:19: error: cannot find 'foo' in module 'C'

--- a/test/visibility/import/edgeCases/dontLeakSymbols2-proc.good
+++ b/test/visibility/import/edgeCases/dontLeakSymbols2-proc.good
@@ -1,2 +1,2 @@
 dontLeakSymbols2-proc.chpl:19: In function 'main':
-dontLeakSymbols2-proc.chpl:20: error: cannot access 'foo' as it is private to 'C'
+dontLeakSymbols2-proc.chpl:20: error: cannot find 'foo' in module 'C'

--- a/test/visibility/import/edgeCases/dontLeakSymbols2-proc.good
+++ b/test/visibility/import/edgeCases/dontLeakSymbols2-proc.good
@@ -1,2 +1,2 @@
 dontLeakSymbols2-proc.chpl:19: In function 'main':
-dontLeakSymbols2-proc.chpl:20: error: Symbol 'foo' undeclared in module 'C'
+dontLeakSymbols2-proc.chpl:20: error: cannot access 'foo' as it is private to 'C'

--- a/test/visibility/import/edgeCases/dontLeakSymbols2.good
+++ b/test/visibility/import/edgeCases/dontLeakSymbols2.good
@@ -1,2 +1,2 @@
 dontLeakSymbols2.chpl:15: In function 'main':
-dontLeakSymbols2.chpl:16: error: cannot access 'x' as it is private to 'C'
+dontLeakSymbols2.chpl:16: error: cannot find 'x' in module 'C'

--- a/test/visibility/import/edgeCases/dontLeakSymbols2.good
+++ b/test/visibility/import/edgeCases/dontLeakSymbols2.good
@@ -1,2 +1,2 @@
 dontLeakSymbols2.chpl:15: In function 'main':
-dontLeakSymbols2.chpl:16: error: Symbol 'x' undeclared in module 'C'
+dontLeakSymbols2.chpl:16: error: cannot access 'x' as it is private to 'C'

--- a/test/visibility/import/submoduleCloser.bad
+++ b/test/visibility/import/submoduleCloser.bad
@@ -1,2 +1,2 @@
 submoduleCloser.chpl:11: In function 'main':
-submoduleCloser.chpl:15: error: Symbol 'do_my_impl' undeclared in module 'Details'
+submoduleCloser.chpl:15: error: cannot find 'do_my_impl' in module 'Details'

--- a/test/visibility/only/innerModuleSharesName-topLevel.good
+++ b/test/visibility/only/innerModuleSharesName-topLevel.good
@@ -1,1 +1,2 @@
-innerModuleSharesName-topLevel.chpl:11: error: Symbol 'whatev' undeclared in module 'M'
+innerModuleSharesName-topLevel.chpl:1: In module 'OuterModule':
+innerModuleSharesName-topLevel.chpl:11: error: cannot find 'whatev' in module 'M'

--- a/test/visibility/private/config/constants/accessSibling.good
+++ b/test/visibility/private/config/constants/accessSibling.good
@@ -1,2 +1,2 @@
 accessSibling.chpl:7: In function 'main':
-accessSibling.chpl:8: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessSibling.chpl:8: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/config/constants/accessesOther.good
+++ b/test/visibility/private/config/constants/accessesOther.good
@@ -1,1 +1,2 @@
-accessesOther.chpl:7: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessesOther.chpl:1: In module 'OuterModule':
+accessesOther.chpl:7: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/config/params/accessSibling.good
+++ b/test/visibility/private/config/params/accessSibling.good
@@ -1,2 +1,2 @@
 accessSibling.chpl:7: In function 'main':
-accessSibling.chpl:8: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessSibling.chpl:8: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/config/params/accessesOther.good
+++ b/test/visibility/private/config/params/accessesOther.good
@@ -1,1 +1,2 @@
-accessesOther.chpl:7: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessesOther.chpl:1: In module 'OuterModule':
+accessesOther.chpl:7: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/config/variables/accessSibling.good
+++ b/test/visibility/private/config/variables/accessSibling.good
@@ -1,2 +1,2 @@
 accessSibling.chpl:7: In function 'main':
-accessSibling.chpl:8: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessSibling.chpl:8: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/config/variables/accessesOther.good
+++ b/test/visibility/private/config/variables/accessesOther.good
@@ -1,1 +1,2 @@
-accessesOther.chpl:7: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessesOther.chpl:1: In module 'OuterModule':
+accessesOther.chpl:7: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/constants/accessSibling.good
+++ b/test/visibility/private/constants/accessSibling.good
@@ -1,2 +1,2 @@
 accessSibling.chpl:7: In function 'main':
-accessSibling.chpl:8: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessSibling.chpl:8: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/constants/accessesOther.good
+++ b/test/visibility/private/constants/accessesOther.good
@@ -1,1 +1,2 @@
-accessesOther.chpl:7: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessesOther.chpl:1: In module 'OuterModule':
+accessesOther.chpl:7: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/functions/accessSibling.good
+++ b/test/visibility/private/functions/accessSibling.good
@@ -1,2 +1,2 @@
 accessSibling.chpl:10: In function 'main':
-accessSibling.chpl:11: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessSibling.chpl:11: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/functions/accessesOther.good
+++ b/test/visibility/private/functions/accessesOther.good
@@ -1,1 +1,2 @@
-accessesOther.chpl:10: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessesOther.chpl:1: In module 'OuterModule':
+accessesOther.chpl:10: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/functions/overloaded4.good
+++ b/test/visibility/private/functions/overloaded4.good
@@ -1,2 +1,2 @@
 overloaded4.chpl:14: In function 'main':
-overloaded4.chpl:15: error: Cannot access 'aproc', 'aproc' is private to 'A'
+overloaded4.chpl:15: error: cannot access 'aproc' as it is private to 'A'

--- a/test/visibility/private/iters/accessSibling.good
+++ b/test/visibility/private/iters/accessSibling.good
@@ -1,2 +1,2 @@
 accessSibling.chpl:11: In function 'main':
-accessSibling.chpl:12: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessSibling.chpl:12: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/iters/accessesOther.good
+++ b/test/visibility/private/iters/accessesOther.good
@@ -1,1 +1,2 @@
-accessesOther.chpl:11: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessesOther.chpl:1: In module 'OuterModule':
+accessesOther.chpl:11: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/moduleSymbols/accessPrivateUsedNephew.good
+++ b/test/visibility/private/moduleSymbols/accessPrivateUsedNephew.good
@@ -1,2 +1,2 @@
 accessPrivateUsedNephew.chpl:17: In function 'main':
-accessPrivateUsedNephew.chpl:18: error: Cannot access 'child', 'child' is private to 'parent'
+accessPrivateUsedNephew.chpl:18: error: cannot access 'child' as it is private to 'parent'

--- a/test/visibility/private/params/accessSibling.good
+++ b/test/visibility/private/params/accessSibling.good
@@ -1,2 +1,2 @@
 accessSibling.chpl:7: In function 'main':
-accessSibling.chpl:8: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessSibling.chpl:8: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/params/accessesOther.good
+++ b/test/visibility/private/params/accessesOther.good
@@ -1,1 +1,2 @@
-accessesOther.chpl:7: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessesOther.chpl:1: In module 'OuterModule':
+accessesOther.chpl:7: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/variables/accessSibling.good
+++ b/test/visibility/private/variables/accessSibling.good
@@ -1,2 +1,2 @@
 accessSibling.chpl:7: In function 'main':
-accessSibling.chpl:8: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessSibling.chpl:8: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/private/variables/accessesOther.good
+++ b/test/visibility/private/variables/accessesOther.good
@@ -1,1 +1,2 @@
-accessesOther.chpl:7: error: Cannot access 'foo', 'foo' is private to 'M1'
+accessesOther.chpl:1: In module 'OuterModule':
+accessesOther.chpl:7: error: cannot access 'foo' as it is private to 'M1'

--- a/test/visibility/submodule-in-file/errors/test-PrivateIncludePublic.good
+++ b/test/visibility/submodule-in-file/errors/test-PrivateIncludePublic.good
@@ -1,1 +1,2 @@
-test-PrivateIncludePublic.chpl:3: error: Cannot access 'SubModule', 'SubModule' is private to 'PrivateIncludePublic'
+test-PrivateIncludePublic.chpl:3: error: cannot access 'SubModule' as it is private to 'PrivateIncludePublic'
+test-PrivateIncludePublic.chpl:4: error: cannot access 'SubModule' as it is private to 'PrivateIncludePublic'


### PR DESCRIPTION
This is a continuation of #22183. I am working towards reducing Dyno's reliance on the production scope resolver, and also fixing bugs in said scope resolver that surface due to this change. 

In this PR:
* Dyno takes on translating `M.x[12345]` into `x[12345]`, and `M.f` into `(call f mod M)` 
* By extension, Dyno now includes its own logic for tracking when modules were used in a particular scope and in a particular module.
* Because module-dot resolution now happens in Dyno, Dyno takes on some more error messages from the production scope resolver. To better match the behavior of the scope resolver, I modify some of the error message output to specifically mention "'x' can't be imported because it's private" instead of simply saying "'x' is not found".
* I fixed a bug in which `M.x` would be scope resolved to `x`, even if it's a private member of `M`. I did so by modifying the `Dot*` handling logic in the Resolver to check if the module being searched contains the current `Dot*`.
* I also fixed a bug in which `include private module` would make the symbols publicly available. We didn't know this was a problem until now because the only test that triggered this bug was a module reference `M.N`, and the previous bug didn't respect private fields.

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest