### PR TITLE
Fix issues which were causing chpldef to break release smoke-tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,13 @@ message(STATUS "Using Python: ${CHPL_CMAKE_PYTHON}")
 add_subdirectory(compiler)
 add_subdirectory(frontend)
 add_subdirectory(tools/chpldoc)
-add_subdirectory(tools/chpldef)
+
+# We are not ready to include 'chpldef' in an official release just yet.
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+  if (EXISTS tools/chpldef)
+    add_subdirectory(tools/chpldef)
+  endif()
+endif()
 
 # Adjust the install rpath for chpl and chpldoc
 if (INSTALLATION_MODE STREQUAL "prefix")

--- a/tools/chpldef/misc.cpp
+++ b/tools/chpldef/misc.cpp
@@ -45,4 +45,14 @@ std::string jsonToString(const JsonValue& json, bool pretty) {
   return ret;
 }
 
+bool cast(std::string str, int& out) noexcept {
+  char* end = nullptr;
+  const char* cstr = str.c_str();
+  errno = 0;
+  int x = std::strtol(cstr, &end, 10);
+  if (errno == ERANGE || end == cstr) return false;
+  out = x;
+  return true;
+}
+
 } // end namespace 'chpldef'

--- a/tools/chpldef/misc.h
+++ b/tools/chpldef/misc.h
@@ -85,13 +85,7 @@ template <typename T>
 inline opt<T> option(const T& t) { return opt<T>(t); }
 
 /** Cast a string to an integer, return 'false' if there was an error. */
-inline bool cast(std::string str, int& out) {
-  try {
-    out = std::stoi(str);
-    return true;
-  } catch (const std::exception& ex) { std::ignore = ex; }
-  return false;
-}
+bool cast(std::string str, int& out) noexcept;
 
 /** Print a JSON value's tag as a string. */
 const char* jsonTagStr(const JsonValue& json);


### PR DESCRIPTION
Adjust a call to a throwing function to be a call to a `noexcept`
function instead to silence GNU compiler errors. Adjust the top-level
`CMakeLists.txt` to only build `chpldef` if the files exist and we
are not in release mode.

Reviewed by @e-kayrakli. Thanks!