### PR TITLE
chpldef: Implement core language server protocol lifecycle messages

### DIFF
--- a/tools/chpldef/Logger.cpp
+++ b/tools/chpldef/Logger.cpp
@@ -82,6 +82,17 @@ bool Logger::isLoggingToBuiltin() const {
   return output_ != Logger::FILEPATH;
 }
 
+const char* Logger::levelToString(Level level) {
+  switch (level) {
+    case Logger::OFF: return "off";
+    case Logger::MESSAGES: return "messages";
+    case Logger::VERBOSE: return "verbose";
+    case Logger::TRACE: return "trace";
+  }
+  CHPLDEF_IMPOSSIBLE();
+  return nullptr;
+}
+
 bool Logger::isLogging() const {
   if (isLoggingToBuiltin()) return true;
   return !filePath_.empty() && stream_.is_open();

--- a/tools/chpldef/Logger.h
+++ b/tools/chpldef/Logger.h
@@ -64,6 +64,8 @@ public:
   bool isLoggingToBuiltin() const;
   bool isLogging() const;
   inline Level level() const { return level_; }
+  static const char* levelToString(Level level);
+  inline const char* levelToString() const { return levelToString(level_); }
   inline Output output() const { return output_; }
   inline void setLevel(Level level) { this->level_ = level; }
   void setFlushImmediately(bool flushImmediately);

--- a/tools/chpldef/Message.cpp
+++ b/tools/chpldef/Message.cpp
@@ -315,13 +315,12 @@ const char* Message::errorToString(Error error) {
   return nullptr;
 }
 
-namespace {
 template <typename T, typename X>
 static bool doHandleMessage(Server* ctx, T* msg, X& x) {
   if (msg->status() == Message::PROGRESSING) CHPLDEF_TODO();
-  if (msg->status() != Message::PENDING) return true;
+  if (msg->status() != Message::PENDING) return false;
 
-  ctx->message("Handling request '%s' with ID '%s'\n",
+  ctx->message("Handling request '%s' with ID %s\n",
                msg->tagToString(),
                msg->idToString().c_str());
 
@@ -334,13 +333,9 @@ static bool doHandleMessage(Server* ctx, T* msg, X& x) {
     ctx->message("Request failed with code '%s'\n", cstr);
   }
 
-  if (ctx->logger().level() != Logger::OFF) {
-    auto str = x.result.toString();
-    ctx->message("Request completed with result %s\n", str.c_str());
-  }
+  ctx->message("Request '%s' complete...\n", msg->idToString().c_str());
 
-  return false;
-}
+  return true;
 }
 
 /** Call the request handler above and then mark completed or failed. */

--- a/tools/chpldef/Message.cpp
+++ b/tools/chpldef/Message.cpp
@@ -27,7 +27,9 @@
 namespace chpldef {
 
 bool Message::isIdValid(const JsonValue& id) {
-  return id.kind() == JsonValue::Number || id.kind() == JsonValue::String;
+  return id.kind() == JsonValue::Number ||
+         id.kind() == JsonValue::String ||
+         id.kind() == JsonValue::Null;
 }
 
 // TODO: Need to build an error message or record what went wrong. Create
@@ -36,10 +38,31 @@ bool Message::isIdValid(const JsonValue& id) {
 chpl::owned<BaseRequest> Message::request(Server* ctx, const JsonValue& j) {
   auto objPtr = j.getAsObject();
   if (!objPtr) {
-    ctx->verbose("Failed to unpack JSON object, found: %s\n",
-                 jsonTagStr(j));
+    ctx->verbose("Failed to unpack JSON object from %s\n",
+                 jsonKindToString(j));
     return nullptr;
   }
+
+  // Determine what method is to be called.
+  Message::Tag tag = Message::UNSET;
+  if (auto optMethod = objPtr->getString("method")) {
+    auto str = optMethod->str();
+
+    // Compare against RPC names in 'message-macro-list.h'.
+    tag = Message::jsonRpcMethodNameToTag(str);
+
+    // TODO: We can create an 'Invalid' request to represent this failure.
+    const bool hasTag = tag != Message::UNSET && tag != Message::INVALID;
+
+    if (!hasTag) {
+      CHPLDEF_FATAL(ctx, "Unrecognized method '%s'\n", str.c_str());
+      return nullptr;
+    }
+  }
+
+  CHPL_ASSERT(tag != Message::RESPONSE);
+
+  ctx->verbose("Constructing message with tag '%s'\n", tagToString(tag));
 
   // Get the ID as a JSON value.
   JsonValue id = nullptr;
@@ -48,41 +71,31 @@ chpl::owned<BaseRequest> Message::request(Server* ctx, const JsonValue& j) {
   }
 
   // Failed to get the ID.
-  if (id.kind() == JsonValue::Null) {
-    ctx->verbose("Failed to get message ID\n");
-    return nullptr;
-  }
-
-  // Determine what method is to be called.
-  Message::Tag tag = Message::UNSET;
-  if (auto optMethod = objPtr->getString("method")) {
-    tag = Message::jsonRpcMethodNameToTag(optMethod->str());
-
-    // TODO: We can create an 'Invalid' request to represent this failure.
-    bool hasTag = tag != Message::UNSET && tag != Message::INVALID;
-    if (!hasTag) {
-      CHPLDEF_TODO();
+  if (!Message::isIdValid(id)) {
+    auto k = id.kind();
+    if (k != JsonValue::Null || !isNotification(tag)) {
+      ctx->verbose("Invalid message ID type '%s'\n",
+                   jsonKindToString(k));
       return nullptr;
     }
   }
 
-  CHPL_ASSERT(tag != Message::RESPONSE);
-
   // Before building a specific request, get the params.
-  const JsonValue* params = nullptr;
+  const JsonValue params(nullptr);
+  const JsonValue* p = &params;
   if (auto ptr = objPtr->get("params")) {
     auto k = ptr->kind();
     if (k != JsonValue::Array && k != JsonValue::Object) {
       CHPLDEF_TODO();
       return nullptr;
     } else {
-      params = ptr;
+      p = ptr;
     }
   }
 
   switch (tag) {
     #define CHPLDEF_MESSAGE(name__, x1__, x2__, x3__) \
-      case name__: return name__::create(std::move(id), *params);
+      case name__: return name__::create(std::move(id), *p);
     #include "./message-macro-list.h"
     #undef CHPLDEF_MESSAGE
     default: break;
@@ -149,10 +162,10 @@ bool Message::isOutbound() const {
   return false;
 }
 
-bool Message::isNotification() const {
-  if (tag_ == Message::RESPONSE) return true;
+bool Message::isNotification(Tag tag) {
+  if (tag == Message::RESPONSE) return true;
   #define CHPLDEF_MESSAGE(name__, x1__, notification__, x3__) \
-    if (tag_ == Message::name__) return notification__;
+    if (tag == Message::name__) return notification__;
   #include "./message-macro-list.h"
   #undef CHPLDEF_MESSAGE
   return false;
@@ -190,6 +203,7 @@ Message::Tag Message::jsonRpcMethodNameToTag(std::string str) {
 std::string Message::idToString() const {
   if (auto optStr = id().getAsString()) return optStr->str();
   if (auto optInt = id().getAsInteger()) return std::to_string(*optInt);
+  if (id().kind() == JsonValue::Null) return "<>";
   CHPLDEF_IMPOSSIBLE();
   return {};
 }
@@ -316,7 +330,23 @@ const char* Message::errorToString(Error error) {
 }
 
 template <typename T, typename X>
-static bool doHandleMessage(Server* ctx, T* msg, X& x) {
+static bool doHandleNotification(Server* ctx, T* msg, X& x) {
+  if (msg->status() == Message::PROGRESSING) CHPLDEF_TODO();
+  if (msg->status() != Message::PENDING) return false;
+
+  ctx->message("Handling notification '%s'\n", msg->tagToString());
+
+  std::ignore = msg->compute(ctx);
+
+  if (x.isProgressingCallAgain) CHPLDEF_TODO();
+
+  ctx->message("Notification complete...\n");
+
+  return true;
+}
+
+template <typename T, typename X>
+static bool doHandleRequest(Server* ctx, T* msg, X& x) {
   if (msg->status() == Message::PROGRESSING) CHPLDEF_TODO();
   if (msg->status() != Message::PENDING) return false;
 
@@ -338,6 +368,12 @@ static bool doHandleMessage(Server* ctx, T* msg, X& x) {
   return true;
 }
 
+template <typename T, typename X>
+static bool doHandleMessage(Server* ctx, T* msg, X& x) {
+  if (msg->isNotification()) return doHandleNotification(ctx, msg, x);
+  return doHandleRequest(ctx, msg, x);
+}
+
 /** Call the request handler above and then mark completed or failed. */
 #define CHPLDEF_MESSAGE(name__, x1__, x2__, x3__) \
   void name__::handle(Server* ctx) { \
@@ -356,15 +392,11 @@ opt<Response> Message::handle(Server* ctx, Message* msg) {
   if (!ctx || !msg || msg->isResponse()) return {};
   if (msg->status() != Message::PENDING) return {};
 
-  // TODO: Notification will have empty 'Result' type.
-  if (msg->isNotification()) {
-    CHPLDEF_TODO();
-    return {};
-  }
-
   msg->handle(ctx);
 
-  if (msg->status() == Message::COMPLETED) {
+  CHPL_ASSERT(msg->status() != Message::PENDING);
+
+  if (!msg->isNotification() && msg->status() != Message::PROGRESSING) {
     if (auto ret = Message::response(ctx, msg)) {
       CHPL_ASSERT(ret->id() == msg->id());
       CHPL_ASSERT(ret->status() == Message::COMPLETED);

--- a/tools/chpldef/Message.h
+++ b/tools/chpldef/Message.h
@@ -299,13 +299,13 @@ protected:
                                std::string* note);
 
   /** Use in message handlers to return failure. */
-  inline ComputedResult fail(Error error=Message::ERR_REQUEST_FAILED,
-                             std::string note=std::string()) const {
+  static ComputedResult fail(Error error=Message::ERR_REQUEST_FAILED,
+                             std::string note=std::string()) {
     return { false, error, std::move(note), {} };
   }
 
   /** Use in message handlers to delay. */
-  inline ComputedResult delay() const {
+  static ComputedResult delay() {
     return { true, Message::OK, {}, {} };
   }
 
@@ -318,11 +318,11 @@ public:
       requests from server to client. */
   virtual JsonValue pack() const override;
 
-  /** Compute the answer to this request, doing meaningful work. */
-  virtual ComputedResult compute(Server* ctx) = 0;
-
   /** Compute results and save for later use. */
   virtual void handle(Server* ctx) override = 0;
+
+  /** Get the parameters of this request if they were deserialized. */
+  const Params* params() const;
 
   /** If computed, get the result of this request. */
   inline const Result* result() const {
@@ -362,7 +362,7 @@ public:
     static chpl::owned<BaseRequest> \
     create(JsonValue id, const JsonValue& j); \
     virtual void handle(Server* ctx) override; \
-    virtual ComputedResult compute(Server* ctx) override; \
+    static ComputedResult compute(Server* ctx, const Params& p); \
   };
 #include "./message-macro-list.h"
 #undef CHPLDEF_MESSAGE

--- a/tools/chpldef/Message.h
+++ b/tools/chpldef/Message.h
@@ -101,6 +101,7 @@ protected:
         error_(error),
         note_(std::move(note)) {
     CHPL_ASSERT(isIdValid(id_));
+    if (id.kind() == JsonValue::Null) CHPL_ASSERT(isNotification());
   }
 
   inline void markProgressing() { status_ = Message::PROGRESSING; }
@@ -142,7 +143,7 @@ public:
   static const char* errorToString(Error error);
 
   /** Print this message's error code as a string. */
-  inline const char* errorToString() const  { return errorToString(error_); }
+  inline const char* errorToString() const { return errorToString(error_); }
 
   /** Get the numeric value of an error code. */
   static inline int64_t errorToInt(Error e) {
@@ -167,8 +168,11 @@ public:
   /** If 'true', the server is sending this message to the client. */
   bool isOutbound() const;
 
+  /** If 'true', then the Tag 'tag' does not need a response. */
+  static bool isNotification(Tag tag);
+
   /** If 'true', then this message does not need a response. */
-  bool isNotification() const;
+  inline bool isNotification() const { return isNotification(tag_); }
 
   /** Returns the expected JSON-RPC method name for this message. */
   const char* jsonRpcMethodName() const;

--- a/tools/chpldef/Message.h
+++ b/tools/chpldef/Message.h
@@ -217,10 +217,7 @@ public:
 
     /** Default visitor body is trivial enough that we define it here. */
     #define CHPLDEF_MESSAGE(name__, x1__, x2__, x3__) \
-      virtual T visit(const class name__* req) { \
-        T ret; \
-        return ret; \
-      }
+      virtual T visit(const class name__* req) { T ret; return ret; }
     #include "./message-macro-list.h"
     #undef CHPLDEF_MESSAGE
 
@@ -232,8 +229,8 @@ public:
   };
 
   /** Dispatch a visitor using a message as the receiver. */
-  template <typename T, typename U>
-  inline T accept(Message::Visitor<U>& v) { return v.dispatch(*this); }
+  template <typename T>
+  inline T accept(Message::Visitor<T>& v) { return v.dispatch(*this); }
 
   /** Some messages can defer, but not sure which at this moment. */
   virtual bool defer() const { return false; }

--- a/tools/chpldef/Server.h
+++ b/tools/chpldef/Server.h
@@ -37,19 +37,39 @@
 
 namespace chpldef {
 
+class Initialize;
+class Initialized;
+class Shutdown;
+
 class Server {
 public:
+  enum State {
+    UNINIT,             /** Client has not sent 'Initialize' yet. */
+    INIT,               /** We have responded to 'Initialize'. */
+    READY,              /** Client has sent us 'Initialized'. */
+    SHUTDOWN            /** Client has sent us 'Shutdown'. */
+  };
+
   class Configuration {};
 
 private:
+  State state_ = UNINIT;
   Logger logger_;
   chpl::owned<chpl::Context> chplctx_ = nullptr;
   int revision_;
+
+protected:
+  friend class chpldef::Shutdown;
+  friend class chpldef::Initialize;
+  friend class chpldef::Initialized;
+
+  inline void setState(State state) { state_ = state; }
 
 public:
   Server();
  ~Server() = default;
 
+  inline State state() const { return state_; }
   inline int revision() const { return revision_; }
   inline const chpl::Context* chplctx() const { return chplctx_.get(); }
 

--- a/tools/chpldef/Transport.cpp
+++ b/tools/chpldef/Transport.cpp
@@ -97,7 +97,7 @@ bool Transport::sendJsonBlocking(Server* ctx, std::ostream& os,
                                  const JsonValue& json) {
   const bool pretty = false;
   std::string s = jsonToString(json, pretty);
-  os << std::move(s);
+  os << "Content-Length: " << s.size() << "\r\n\r\n" << std::move(s);
   os.flush();
   bool ret = !os.bad() && !os.fail();
   return ret;

--- a/tools/chpldef/Transport.cpp
+++ b/tools/chpldef/Transport.cpp
@@ -97,7 +97,7 @@ bool Transport::sendJsonBlocking(Server* ctx, std::ostream& os,
                                  const JsonValue& json) {
   const bool pretty = false;
   std::string s = jsonToString(json, pretty);
-  os << "Content-Length: " << s.size() << "\r\n\r\n" << std::move(s);
+  os << "Content-Length: " << s.size() << "\r\n\r\n" << s;
   os.flush();
   bool ret = !os.bad() && !os.fail();
   return ret;

--- a/tools/chpldef/chpldef.cpp
+++ b/tools/chpldef/chpldef.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
     CHPL_ASSERT(ok);
 
     if (logger.level() == Logger::TRACE) {
-      ctx->trace("Incoming JSON is: %s\n", jsonToString(json).c_str());
+      ctx->trace("Incoming JSON is %s\n", jsonToString(json).c_str());
     }
 
     // Create a message from the incoming JSON...
@@ -96,7 +96,7 @@ int main(int argc, char** argv) {
       auto pack = optRsp->pack();
       if (logger.level() == Logger::TRACE) {
         auto str = jsonToString(pack);
-        ctx->trace("Outgoing JSON is: %s\n", str.c_str());
+        ctx->trace("Outgoing JSON is %s\n", str.c_str());
       }
 
       ok = Transport::sendJsonBlocking(ctx, std::cout, std::move(pack));

--- a/tools/chpldef/chpldef.cpp
+++ b/tools/chpldef/chpldef.cpp
@@ -54,6 +54,8 @@ int main(int argc, char** argv) {
                logger.levelToString());
 
   int run = 1;
+  int ret = 0;
+
   while (run) {
     ctx->message("Server awaiting message...\n");
 
@@ -91,6 +93,11 @@ int main(int argc, char** argv) {
     CHPL_ASSERT(msg->status() == Message::PENDING);
     CHPL_ASSERT(!msg->isOutbound());
 
+    if (msg->tag() == Message::Exit) {
+      CHPL_ASSERT(ctx->state() == Server::SHUTDOWN);
+      run = 0;
+    }
+
     // We have an immediate response, so send it.
     if (auto optRsp = Message::handle(ctx, msg.get())) {
       auto pack = optRsp->pack();
@@ -113,5 +120,8 @@ int main(int argc, char** argv) {
     logger.flush();
   }
 
-  return 0;
+  ctx->message("Server exiting with code '%d'\n", ret);
+  logger.flush();
+
+  return ret;
 }

--- a/tools/chpldef/command-line-flags.cpp
+++ b/tools/chpldef/command-line-flags.cpp
@@ -30,14 +30,15 @@ Flag<std::string> logFile("log-file",
 
 Flag<Logger::Level> logLevel("log-level",
   llvm::cl::desc("Specify log verbosity level"),
-    llvm::cl::values(
-      clEnumValN(Logger::MESSAGES, "messages", "Log messages only"),
-      clEnumValN(Logger::VERBOSE, "verbose", "Messages and details"),
-      clEnumValN(Logger::TRACE, "trace", "Full trace of execution")));
+  llvm::cl::init(Logger::OFF),
+  llvm::cl::values(
+    clEnumValN(Logger::MESSAGES, "messages", "Log messages only"),
+    clEnumValN(Logger::VERBOSE, "verbose", "Messages and details"),
+    clEnumValN(Logger::TRACE, "trace", "Full trace of execution")));
 
 template <typename T>
-static bool isFlagEquivalent(const llvm::cl::opt<T>& f1,
-                             const llvm::cl::Option* f2) {
+static bool isSameMemoryLocation(const llvm::cl::opt<T>& f1,
+                                 const llvm::cl::Option* f2) {
   static_assert(std::is_base_of<llvm::cl::Option, llvm::cl::opt<T>>::value);
   auto ptr = static_cast<const llvm::cl::Option*>(&f1);
   return ptr == f2;
@@ -45,8 +46,8 @@ static bool isFlagEquivalent(const llvm::cl::opt<T>& f1,
 
 // TODO: Get these things in an array so we don't have O(n) code?
 static bool isChpldefRegisteredFlag(const llvm::cl::Option* f) {
-  if (isFlagEquivalent(logFile, f)) return true;
-  if (isFlagEquivalent(logLevel, f)) return true;
+  if (isSameMemoryLocation(logFile, f)) return true;
+  if (isSameMemoryLocation(logLevel, f)) return true;
   return false;
 }
 

--- a/tools/chpldef/message-compute.cpp
+++ b/tools/chpldef/message-compute.cpp
@@ -60,7 +60,8 @@ static ServerInfo configureServerInfo(Server* ctx) {
   return ret;
 }
 
-Initialize::ComputedResult Initialize::compute(Server* ctx) {
+Initialize::ComputedResult
+Initialize::compute(Server* ctx, const Params& p) {
 
   // Set the log verbosity level if it was requested.
   if (auto trace = p.trace) {
@@ -75,15 +76,36 @@ Initialize::ComputedResult Initialize::compute(Server* ctx) {
     }
   }
 
+  // Set the server to the 'INIT' state.
+  CHPL_ASSERT(ctx->state() == Server::UNINIT);
+  ctx->setState(Server::INIT);
+
   Result ret;
 
   doConfigureStaticCapabilities(ctx, ret.capabilities);
+
   ret.serverInfo = configureServerInfo(ctx);
 
   return ret;
 }
 
-Initialized::ComputedResult Initialized::compute(Server* ctx) {
+Initialized::ComputedResult
+Initialized::compute(Server* ctx, const Params& p) {
+  CHPL_ASSERT(ctx->state() == Server::INIT);
+  ctx->setState(Server::READY);
+  return {};
+}
+
+Shutdown::ComputedResult
+Shutdown::compute(Server* ctx, const Params& p) {
+  CHPL_ASSERT(ctx->state() == Server::READY);
+  ctx->setState(Server::SHUTDOWN);
+  return {};
+}
+
+Exit::ComputedResult
+Exit::compute(Server* ctx, const Params& p) {
+  CHPL_ASSERT(ctx->state() == Server::SHUTDOWN);
   return {};
 }
 

--- a/tools/chpldef/message-compute.cpp
+++ b/tools/chpldef/message-compute.cpp
@@ -83,4 +83,8 @@ Initialize::ComputedResult Initialize::compute(Server* ctx) {
   return ret;
 }
 
+Initialized::ComputedResult Initialized::compute(Server* ctx) {
+  return {};
+}
+
 } // end namespace 'chpldef'

--- a/tools/chpldef/message-compute.cpp
+++ b/tools/chpldef/message-compute.cpp
@@ -26,11 +26,60 @@
     source file with a name that matches the message name. */
 namespace chpldef {
 
-/** TODO: Fill in 'InitializeResult', turning most fields off. */
+static void
+doConfigureStaticCapabilities(Server* ctx, ServerCapabilities& x) {
+  x.positionEncoding = "utf-16";
+  x.hoverProvider = false;
+  x.declarationProvider = false;
+  x.definitionProvider = false;
+  x.typeDefinitionProvider = false;
+  x.implementationProvider = false;
+  x.referencesProvider = false;
+  x.documentHighlightProvider = false;
+  x.documentSymbolProvider = false;
+  x.codeActionProvider = false;
+  x.colorProvider = false;
+  x.documentFormattingProvider = false;
+  x.documentRangeFormattingProvider = false;
+  x.renameProvider = false;
+  x.foldingRangeProvider = false;
+  x.selectionRangeProvider = false;
+  x.linkEditingRangeProvider = false;
+  x.callHierarchyProvider = false;
+  x.monikerProvider = false;
+  x.typeHierarchyProvider = false;
+  x.inlineValueProvider = false;
+  x.inlayHintProvider = false;
+  x.workspaceSymbolProvider = false;
+}
+
+static ServerInfo configureServerInfo(Server* ctx) {
+  ServerInfo ret;
+  ret.name = "chpldef";
+  ret.version = "0.0.0";
+  return ret;
+}
+
 Initialize::ComputedResult Initialize::compute(Server* ctx) {
-  if (auto trace = p.trace) ctx->logger().setLevel(trace->level);
-  ctx->message("In the body of Initialize!\n");
+
+  // Set the log verbosity level if it was requested.
+  if (auto trace = p.trace) {
+    auto level = trace->level;
+    ctx->message("Client requested log level: '%s'\n",
+                 Logger::levelToString(level));
+    auto &logger = ctx->logger();
+    if (level < logger.level()) {
+      ctx->message("Ignoring as level is '%s'\n", logger.levelToString());
+    } else {
+      ctx->logger().setLevel(level);
+    }
+  }
+
   Result ret;
+
+  doConfigureStaticCapabilities(ctx, ret.capabilities);
+  ret.serverInfo = configureServerInfo(ctx);
+
   return ret;
 }
 

--- a/tools/chpldef/message-macro-list.h
+++ b/tools/chpldef/message-macro-list.h
@@ -27,14 +27,14 @@
 //
 
 CHPLDEF_MESSAGE(Initialize, 0, 0, initialize)
+CHPLDEF_MESSAGE(Initialized, 0, 1, initialized)
 
 /*
-CHPLDEF_MESSAGE(Initialized, initialized)
 CHPLDEF_MESSAGE(RegisterCapability, client/registerCapability)
 CHPLDEF_MESSAGE(UnregisterCapability, client/unregisterCapability)
 CHPLDEF_MESSAGE(SetTrace, $/setTrace)
 CHPLDEF_MESSAGE(LogTrace, $/logTrace)
-CHPLDEF_MESSAGE(Shutdown, shutdown)
+CHPLDEF_MESSAGE(Shutdown, 0, 0, shutdown)
 CHPLDEF_MESSAGE(Exit, exit)
 */
 

--- a/tools/chpldef/message-macro-list.h
+++ b/tools/chpldef/message-macro-list.h
@@ -28,14 +28,15 @@
 
 CHPLDEF_MESSAGE(Initialize, 0, 0, initialize)
 CHPLDEF_MESSAGE(Initialized, 0, 1, initialized)
+CHPLDEF_MESSAGE(Shutdown, 0, 0, shutdown)
+CHPLDEF_MESSAGE(Exit, 0, 1, exit)
 
 /*
 CHPLDEF_MESSAGE(RegisterCapability, client/registerCapability)
 CHPLDEF_MESSAGE(UnregisterCapability, client/unregisterCapability)
 CHPLDEF_MESSAGE(SetTrace, $/setTrace)
 CHPLDEF_MESSAGE(LogTrace, $/logTrace)
-CHPLDEF_MESSAGE(Shutdown, 0, 0, shutdown)
-CHPLDEF_MESSAGE(Exit, exit)
+
 */
 
 //

--- a/tools/chpldef/misc.cpp
+++ b/tools/chpldef/misc.cpp
@@ -23,8 +23,12 @@
 
 namespace chpldef {
 
-const char* jsonTagStr(const JsonValue& json) {
-  switch (json.kind()) {
+const char* jsonKindToString(const JsonValue& json) {
+  return jsonKindToString(json.kind());
+}
+
+const char* jsonKindToString(JsonValue::Kind kind) {
+  switch (kind) {
     case JsonValue::Null: return "null";
     case JsonValue::Boolean: return "boolean";
     case JsonValue::Number: return "number";

--- a/tools/chpldef/misc.h
+++ b/tools/chpldef/misc.h
@@ -88,8 +88,11 @@ inline opt<T> option(const T& t) { return opt<T>(t); }
 /** Cast a string to an integer, return 'false' if there was an error. */
 bool cast(std::string str, int& out) noexcept;
 
-/** Print a JSON value's tag as a string. */
-const char* jsonTagStr(const JsonValue& json);
+/** Print a JSON value's kind as a string. */
+const char* jsonKindToString(const JsonValue& json);
+
+/** Print a JSON value's kind as a string. */
+const char* jsonKindToString(JsonValue::Kind kind);
 
 /** Print a JSON value. */
 std::string jsonToString(const JsonValue& json, bool pretty=false);

--- a/tools/chpldef/misc.h
+++ b/tools/chpldef/misc.h
@@ -49,7 +49,8 @@
 
 #define CHPLDEF_FATAL(server__, ...) \
   do { \
-    server__->message("FATAL [%s:%d]...\n", __FUNCTION__, __LINE__); \
+    server__->message("FATAL [%s:%s:%d]...\n", \
+                      __FILE__, __FUNCTION__, __LINE__); \
     server__->message(__VA_ARGS__); \
     std::abort(); \
   } while (0)

--- a/tools/chpldef/protocol-types.cpp
+++ b/tools/chpldef/protocol-types.cpp
@@ -32,6 +32,15 @@ std::string ProtocolType::toString() const {
   return ret;
 }
 
+bool EmptyProtocolType::fromJson(const JsonValue& j, JsonPath p) {
+  return true;
+}
+
+JsonValue EmptyProtocolType::toJson() const {
+  JsonValue ret(nullptr);
+  return ret;
+}
+
 bool ClientInfo::fromJson(const JsonValue& j, JsonPath p) {
   JsonMapper m(j, p);
   if (!m) return false;

--- a/tools/chpldef/protocol-types.cpp
+++ b/tools/chpldef/protocol-types.cpp
@@ -22,6 +22,9 @@
 #include "./misc.h"
 #include "llvm/Support/JSON.h"
 
+/** Helper to make populating JSON object fields less painful. */
+#define FIELD_(name__) { #name__, name__ }
+
 namespace chpldef {
 
 std::string ProtocolType::toString() const {
@@ -87,8 +90,8 @@ bool InitializeResult::fromJson(const JsonValue& j, JsonPath p) {
 
 JsonValue InitializeResult::toJson() const {
   JsonObject ret {
-    { "capabilities", capabilities },
-    { "serverInfo", serverInfo }
+    FIELD_(capabilities),
+    FIELD_(serverInfo)
   };
   return ret;
 }
@@ -130,7 +133,7 @@ bool ServerInfo::fromJson(const JsonValue& j, JsonPath p) {
 }
 
 JsonValue ServerInfo::toJson() const {
-  JsonObject ret {{ "name", name }, { "version", version }};
+  JsonObject ret { FIELD_(name), FIELD_(version) };
   return ret;
 }
 
@@ -140,7 +143,43 @@ bool ServerCapabilities::fromJson(const JsonValue& j, JsonPath p) {
 }
 
 JsonValue ServerCapabilities::toJson() const {
-  JsonValue ret(nullptr);
+  JsonObject ret {
+    FIELD_(positionEncoding),
+    FIELD_(textDocumentSync),
+    FIELD_(notebookDocumentSync),
+    FIELD_(completionProvider),
+    FIELD_(hoverProvider),
+    FIELD_(signatureHelpProvider),
+    FIELD_(declarationProvider),
+    FIELD_(definitionProvider),
+    FIELD_(typeDefinitionProvider),
+    FIELD_(implementationProvider),
+    FIELD_(referencesProvider),
+    FIELD_(documentHighlightProvider),
+    FIELD_(documentSymbolProvider),
+    FIELD_(codeActionProvider),
+    FIELD_(codeLensProvider),
+    FIELD_(documentLinkProvider),
+    FIELD_(colorProvider),
+    FIELD_(documentFormattingProvider),
+    FIELD_(documentRangeFormattingProvider),
+    FIELD_(documentOnTypeFormattingProvider),
+    FIELD_(renameProvider),
+    FIELD_(foldingRangeProvider),
+    FIELD_(executeCommandProvider),
+    FIELD_(selectionRangeProvider),
+    FIELD_(linkEditingRangeProvider),
+    FIELD_(callHierarchyProvider),
+    FIELD_(semanticTokensProvider),
+    FIELD_(monikerProvider),
+    FIELD_(typeHierarchyProvider),
+    FIELD_(inlineValueProvider),
+    FIELD_(inlayHintProvider),
+    FIELD_(diagnosticProvider),
+    FIELD_(workspaceSymbolProvider),
+    FIELD_(workspace),
+    FIELD_(experimental)
+  };
   return ret;
 }
 

--- a/tools/chpldef/protocol-types.h
+++ b/tools/chpldef/protocol-types.h
@@ -30,6 +30,10 @@
   virtual bool fromJson(const JsonValue& j, JsonPath p) override;  \
   virtual JsonValue toJson() const override;
 
+/** Use this to declare protocol types that are empty. */
+#define CHPLDEF_PROTOCOL_EMPTY_TYPE(name__) \
+  struct name__ : EmptyProtocolType {}
+
 /** This header contains types which help form the Microsoft language server
     protocol. The types attempt to follow the specification as faithfully
     as possible, but liberty is taken in cases where definitions are too
@@ -50,6 +54,12 @@ struct ProtocolType {
   /** By default, convert to JSON and then print the JSON. */
   virtual std::string toString() const;
   virtual ~ProtocolType() = default;
+};
+
+struct EmptyProtocolType : ProtocolType {
+  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
+  virtual JsonValue toJson() const override;
+  virtual ~EmptyProtocolType() = default;
 };
 
 /** Information about the client. */
@@ -164,6 +174,9 @@ struct InitializeResult : ProtocolType {
   ServerCapabilities capabilities;
   opt<ServerInfo> serverInfo;
 };
+
+CHPLDEF_PROTOCOL_EMPTY_TYPE(InitializedParams);
+CHPLDEF_PROTOCOL_EMPTY_TYPE(InitializedResult);
 
 /** Instantiate only if 'T' is derived from 'ProtocolType'. */
 template <typename T>

--- a/tools/chpldef/protocol-types.h
+++ b/tools/chpldef/protocol-types.h
@@ -178,6 +178,12 @@ struct InitializeResult : ProtocolType {
 CHPLDEF_PROTOCOL_EMPTY_TYPE(InitializedParams);
 CHPLDEF_PROTOCOL_EMPTY_TYPE(InitializedResult);
 
+CHPLDEF_PROTOCOL_EMPTY_TYPE(ShutdownParams);
+CHPLDEF_PROTOCOL_EMPTY_TYPE(ShutdownResult);
+
+CHPLDEF_PROTOCOL_EMPTY_TYPE(ExitParams);
+CHPLDEF_PROTOCOL_EMPTY_TYPE(ExitResult);
+
 /** Instantiate only if 'T' is derived from 'ProtocolType'. */
 template <typename T>
 CHPLDEF_ENABLE_IF_DERIVED(T, ProtocolType, bool)

--- a/tools/chpldef/protocol-types.h
+++ b/tools/chpldef/protocol-types.h
@@ -41,6 +41,8 @@
 */
 namespace chpldef {
 
+using OPT_TODO_TYPE = opt<int>;
+
 struct ProtocolType {
   virtual bool fromJson(const JsonValue& j, JsonPath p) = 0;
   virtual JsonValue toJson() const = 0;
@@ -103,9 +105,50 @@ struct InitializeParams : ProtocolType {
   opt<std::vector<WorkspaceFolder>> workspaceFolders;
 };
 
-/** TODO: Build this up in conjunction with 'ClientCapabilities'. */
+struct TextDocumentSyncOptions : ProtocolType {
+  CHPLDEF_PROTOCOL_TYPE_OVERRIDES();
+};
+
+/** Some of the 'provider' queries have more advanced types we can swap
+    in to configure further -- see 'DeclarationRegistrationOptions'. */
 struct ServerCapabilities : ProtocolType {
   CHPLDEF_PROTOCOL_TYPE_OVERRIDES();
+
+  opt<std::string> positionEncoding;
+  OPT_TODO_TYPE textDocumentSync;
+  OPT_TODO_TYPE notebookDocumentSync;
+  OPT_TODO_TYPE completionProvider;
+  opt<bool> hoverProvider;
+  OPT_TODO_TYPE signatureHelpProvider;
+  opt<bool> declarationProvider;
+  opt<bool> definitionProvider;
+  opt<bool> typeDefinitionProvider;
+  opt<bool> implementationProvider;
+  opt<bool> referencesProvider;
+  opt<bool> documentHighlightProvider;
+  opt<bool> documentSymbolProvider;
+  opt<bool> codeActionProvider;
+  OPT_TODO_TYPE codeLensProvider;
+  OPT_TODO_TYPE documentLinkProvider;
+  opt<bool> colorProvider;
+  opt<bool> documentFormattingProvider;
+  opt<bool> documentRangeFormattingProvider;
+  OPT_TODO_TYPE documentOnTypeFormattingProvider;
+  opt<bool> renameProvider;
+  opt<bool> foldingRangeProvider;
+  OPT_TODO_TYPE executeCommandProvider;
+  opt<bool> selectionRangeProvider;
+  opt<bool> linkEditingRangeProvider;
+  opt<bool> callHierarchyProvider;
+  OPT_TODO_TYPE semanticTokensProvider;
+  opt<bool> monikerProvider;
+  opt<bool> typeHierarchyProvider;
+  opt<bool> inlineValueProvider;
+  opt<bool> inlayHintProvider;
+  OPT_TODO_TYPE diagnosticProvider;
+  opt<bool> workspaceSymbolProvider;
+  OPT_TODO_TYPE workspace;
+  OPT_TODO_TYPE experimental;
 };
 
 struct ServerInfo : ProtocolType {


### PR DESCRIPTION
Add initial support for responding to notifications. A notification
is like a request, but the server should not send a response back to
the client. Notifications do not have IDs. Implement the
`Initialized`, `Shutdown`, and `Exit` messages.

For now, the `ServerCapabilities` type turns all server capabilities
to false, so a lot of ugly "wiring-up" code that `clangd` has to
implement is avoided.

While unit testing is not set up yet, I can actually confirm via a
local `vscode` extension that the server does run to completion.
As soon as the client sees that we have no capabilities to offer, it
immediately asks us to shutdown (boy was that a blow to my pride -
I know `chpldef` can't do much yet, but _immediately_ sending the
`Shutdown` message? - oof).

Adjust the message `compute` method to be a static class function
instead. This will make it easy for unit tests to evaluate the
results of language queries without having to construct a `Message`
instance.

Reviewed by @DanilaFe. Thanks!