### PR TITLE
Update global-var-type-mismatch.skipif

### DIFF
--- a/test/extern/ferguson/global-var-type-mismatch.skipif
+++ b/test/extern/ferguson/global-var-type-mismatch.skipif
@@ -1,1 +1,1 @@
-CHPL_LLVM==none
+CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
Follow-up to PR #22277 and take 2 on PR #22303.

It was not skipping correctly for CHPL_LLVM=system CHPL_TARGET_COMPILER=gnu.

Test change only - not reviewed.