### PR TITLE
Work around an LLVM assertion a failure with this test

### DIFF
--- a/test/llvm/dbg-intrinsics/dbg-proc.compopts
+++ b/test/llvm/dbg-intrinsics/dbg-proc.compopts
@@ -1,1 +1,1 @@
---ccflags -fno-discard-value-names --fast --debug --llvm-print-ir-stage none --llvm-print-ir dbg_proc
+--ccflags -fno-discard-value-names --fast --debug --llvm-print-ir-stage basic --llvm-print-ir dbg_proc


### PR DESCRIPTION
When LLVM 15 is built with assertions enabled, this test was running into an assertion failure along these lines:

chpl: /home/mppf/w/main/third-party/llvm/llvm-src/lib/Transforms/Utils/ValueMapper.cpp:807: llvm::Metadata* {anonymous}::MDNodeMapper::mapTopLevelUniquedNode(const llvm::MDNode&): Assertion `FirstN.isUniqued() && "Expected uniqued node"' failed.

The assertion is encountered when running cloneModule and the metadata node that is not uniqued is the function debug metadata. The cloneModule call is run as part of our code to print out the LLVM IR for a function (with --llvm-print-ir).

I do not understand if this is a bug in LLVM or not. It might be. It looks like the debug info metadata handling has been changed recently and is in some amount of flux. And, so far I have been unable to create a small reproducer.

For some reason, the assertion only appears if the function has not yet been optimized / simplified. So, changing the test to print out the IR after the function is simplified (with `--llvm-print-ir-stage basic`) works around the issue and it is just as good for the purposes of this test.

Test change only - not reviewed.