### PR TITLE
Fix NUMLOCALES script to use CHPL_GPU

### DIFF
--- a/test/gpu/native/multiLocale/NUMLOCALES
+++ b/test/gpu/native/multiLocale/NUMLOCALES
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
-codegen=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_GPU_CODEGEN | cut -d = -f 2-`
-if [ "$codegen" = "rocm" ]; then
+codegen=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_GPU | cut -d = -f 2-`
+if [ "$codegen" = "amd" ]; then
   echo "2"
 else
   echo "4"


### PR DESCRIPTION
We replaced using the $CHPL_GPU_CODEGEN environment variable with $CHPL_GPU. This PR updates a test configuration file (`NUMLOCALES`) that should have been updated to account for that.
