### PR TITLE
Update the compiler to build with LLVM 16

### DIFF
--- a/compiler/codegen/cg-CForLoop.cpp
+++ b/compiler/codegen/cg-CForLoop.cpp
@@ -49,11 +49,7 @@ static llvm::MDNode* generateLoopMetadata(bool thisLoopParallelAccess,
 
   std::vector<llvm::Metadata*> args;
   // Resolve operand 0 for the loop id self reference
-#if HAVE_LLVM_VER >= 160
-  auto tmpNode        = llvm::MDNode::getTemporary(ctx, std::nullopt);
-#else
-  auto tmpNode        = llvm::MDNode::getTemporary(ctx, llvm::None);
-#endif
+  auto tmpNode        = llvm::MDNode::getTemporary(ctx, chpl::empty);
   args.push_back(tmpNode.get());
 
   // llvm.loop.vectorize.enable metadata is only used by LoopVectorizer to:

--- a/compiler/codegen/cg-CForLoop.cpp
+++ b/compiler/codegen/cg-CForLoop.cpp
@@ -49,7 +49,11 @@ static llvm::MDNode* generateLoopMetadata(bool thisLoopParallelAccess,
 
   std::vector<llvm::Metadata*> args;
   // Resolve operand 0 for the loop id self reference
+#if HAVE_LLVM_VER >= 160
+  auto tmpNode        = llvm::MDNode::getTemporary(ctx, std::nullopt);
+#else
   auto tmpNode        = llvm::MDNode::getTemporary(ctx, llvm::None);
+#endif
   args.push_back(tmpNode.get());
 
   // llvm.loop.vectorize.enable metadata is only used by LoopVectorizer to:

--- a/compiler/codegen/cg-CForLoop.cpp
+++ b/compiler/codegen/cg-CForLoop.cpp
@@ -25,6 +25,7 @@
 #include "build.h"
 #include "codegen.h"
 #include "driver.h"
+#include "llvmVer.h"
 #include "ForLoop.h"
 #include "LayeredValueTable.h"
 
@@ -212,7 +213,11 @@ GenRet CForLoop::codegen()
     // Create the init basic block
     blockStmtInit = llvm::BasicBlock::Create(info->module->getContext(), FNAME("blk_c_for_init"));
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtInit);
+#else
     func->getBasicBlockList().push_back(blockStmtInit);
+#endif
 
     // Insert an explicit branch from the current block to the init block
     info->irBuilder->CreateBr(blockStmtInit);
@@ -237,7 +242,11 @@ GenRet CForLoop::codegen()
     info->irBuilder->CreateCondBr(condValue0, blockStmtBody, blockStmtEnd);
 
     // Now add the body.
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtBody);
+#else
     func->getBasicBlockList().push_back(blockStmtBody);
+#endif
 
     info->irBuilder->SetInsertPoint(blockStmtBody);
     info->lvt->addLayer();
@@ -276,7 +285,11 @@ GenRet CForLoop::codegen()
     if(loopMetadata)
       addLoopMetadata(endLoopBranch, loopMetadata, accessGroup);
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtEnd);
+#else
     func->getBasicBlockList().push_back(blockStmtEnd);
+#endif
 
     info->irBuilder->SetInsertPoint(blockStmtEnd);
 

--- a/compiler/codegen/cg-DoWhileStmt.cpp
+++ b/compiler/codegen/cg-DoWhileStmt.cpp
@@ -23,6 +23,7 @@
 #include "AstVisitor.h"
 #include "build.h"
 #include "codegen.h"
+#include "llvmVer.h"
 #include "LayeredValueTable.h"
 
 #ifdef HAVE_LLVM
@@ -76,7 +77,11 @@ GenRet DoWhileStmt::codegen()
     info->irBuilder->CreateBr(blockStmtBody);
 
     // Now add the body.
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtBody);
+#else
     func->getBasicBlockList().push_back(blockStmtBody);
+#endif
 
     info->irBuilder->SetInsertPoint(blockStmtBody);
     info->lvt->addLayer();
@@ -88,7 +93,11 @@ GenRet DoWhileStmt::codegen()
     // Add the condition block.
     blockStmtEndCond = llvm::BasicBlock::Create(info->module->getContext(), FNAME("blk_end_cond"));
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtEndCond);
+#else
     func->getBasicBlockList().push_back(blockStmtEndCond);
+#endif
 
     // Insert an explicit branch from the body block to the loop condition.
     info->irBuilder->CreateBr(blockStmtEndCond);
@@ -108,7 +117,11 @@ GenRet DoWhileStmt::codegen()
 
     info->irBuilder->CreateCondBr(condValue, blockStmtBody, blockStmtEnd);
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtEnd);
+#else
     func->getBasicBlockList().push_back(blockStmtEnd);
+#endif
 
     info->irBuilder->SetInsertPoint(blockStmtEnd);
 

--- a/compiler/codegen/cg-WhileDoStmt.cpp
+++ b/compiler/codegen/cg-WhileDoStmt.cpp
@@ -24,6 +24,7 @@
 #include "build.h"
 #include "CForLoop.h"
 #include "codegen.h"
+#include "llvmVer.h"
 #include "LayeredValueTable.h"
 
 #ifdef HAVE_LLVM
@@ -83,7 +84,11 @@ GenRet WhileDoStmt::codegen()
     blockStmtEnd  = llvm::BasicBlock::Create(info->module->getContext(), FNAME("blk_end"));
     blockStmtCond = llvm::BasicBlock::Create(info->module->getContext(), FNAME("blk_cond"));
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtCond);
+#else
     func->getBasicBlockList().push_back(blockStmtCond);
+#endif
 
     // Insert an explicit branch from the current block to the loop start.
     info->irBuilder->CreateBr(blockStmtCond);
@@ -105,7 +110,11 @@ GenRet WhileDoStmt::codegen()
     info->irBuilder->CreateCondBr(condValue, blockStmtBody, blockStmtEnd);
 
     // Now add the body.
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtBody);
+#else
     func->getBasicBlockList().push_back(blockStmtBody);
+#endif
 
     info->irBuilder->SetInsertPoint(blockStmtBody);
     info->lvt->addLayer();
@@ -119,7 +128,11 @@ GenRet WhileDoStmt::codegen()
     else
       info->irBuilder->CreateBr(blockStmtEnd);
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtEnd);
+#else
     func->getBasicBlockList().push_back(blockStmtEnd);
+#endif
 
     info->irBuilder->SetInsertPoint(blockStmtEnd);
 

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -3391,7 +3391,11 @@ llvm::Constant* codegenSizeofLLVM(llvm::Type* type)
 
   INT_ASSERT(type->isSized());
   llvm::TypeSize ret = dl.getTypeAllocSize(type);
+#if HAVE_LLVM_VER >= 160
+  auto intValue = ret.getKnownMinValue();
+#else
   auto intValue = ret.getKnownMinSize();
+#endif
   llvm::Type* sizeTy = dl.getIntPtrType(ctx);
 
   return llvm::ConstantInt::get(sizeTy, intValue);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -1501,15 +1501,9 @@ GenRet createTempVar(Type* t)
 
     llvm::AllocaInst* alloca = createVarLLVM(llTy);
     llvm::MaybeAlign alignment = getAlignment(t);
-#if HAVE_LLVM_VER >= 160
-    if (alignment.has_value()) {
-      alloca->setAlignment(alignment.value());
+    if (alignment) {
+      alloca->setAlignment(*alignment);
     }
-#else
-    if (alignment.hasValue()) {
-      alloca->setAlignment(alignment.getValue());
-    }
-#endif
     ret.isLVPtr = GEN_PTR;
     ret.val = alloca;
 #endif
@@ -2748,15 +2742,9 @@ static GenRet codegenCallExprInner(GenRet function,
         // Create a temporary for holding the return value
         sret = createVarLLVM(chapelRetTy);
 
-#if HAVE_LLVM_VER >= 160
-        if (retAlignment.has_value()) {
-          sret->setAlignment(retAlignment.value());
+        if (retAlignment) {
+          sret->setAlignment(*retAlignment);
         }
-#else
-        if (retAlignment.hasValue()) {
-          sret->setAlignment(retAlignment.getValue());
-        }
-#endif
         llArgs.push_back(sret);
       }
     }
@@ -6059,11 +6047,7 @@ llvm::MDNode* createMetadataScope(llvm::LLVMContext& ctx,
                                     const char* name) {
 
   auto scopeName = llvm::MDString::get(ctx, name);
-#if HAVE_LLVM_VER >= 160
-  auto dummy = llvm::MDNode::getTemporary(ctx, std::nullopt);
-#else
-  auto dummy = llvm::MDNode::getTemporary(ctx, llvm::None);
-#endif
+  auto dummy = llvm::MDNode::getTemporary(ctx, chpl::empty);
   llvm::Metadata* Args[] = {dummy.get(), domain, scopeName};
   auto scope = llvm::MDNode::get(ctx, Args);
   // Remove the dummy and replace it with a self-reference.
@@ -6087,11 +6071,7 @@ DEFINE_PRIM(NO_ALIAS_SET) {
 
     if (info->noAliasDomain == NULL) {
       auto domainName = llvm::MDString::get(ctx, "Chapel no-alias");
-#if HAVE_LLVM_VER >= 160
-      auto dummy = llvm::MDNode::getTemporary(ctx, std::nullopt);
-#else
-      auto dummy = llvm::MDNode::getTemporary(ctx, llvm::None);
-#endif
+      auto dummy = llvm::MDNode::getTemporary(ctx, chpl::empty);
       llvm::Metadata* Args[] = {dummy.get(), domainName};
       info->noAliasDomain = llvm::MDNode::get(ctx, Args);
       // Remove the dummy and replace it with a self-reference.

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -245,7 +245,11 @@ GenRet DefExpr::codegen() {
 
       info->irBuilder->CreateBr(blockLabel);
 
+#if HAVE_LLVM_VER >= 160
+      func->insert(func->end(), blockLabel);
+#else
       func->getBasicBlockList().push_back(blockLabel);
+#endif
       info->irBuilder->SetInsertPoint(blockLabel);
     }
 #endif
@@ -2221,17 +2225,29 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
     info->irBuilder->CreateCondBr(
         codegenValue(cond).val, blockIfTrue, blockIfFalse);
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockIfTrue);
+#else
     func->getBasicBlockList().push_back(blockIfTrue);
+#endif
     info->irBuilder->SetInsertPoint(blockIfTrue);
     info->irBuilder->CreateStore(values.a, tmp);
     info->irBuilder->CreateBr(blockEnd);
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockIfFalse);
+#else
     func->getBasicBlockList().push_back(blockIfFalse);
+#endif
     info->irBuilder->SetInsertPoint(blockIfFalse);
     info->irBuilder->CreateStore(values.b, tmp);
     info->irBuilder->CreateBr(blockEnd);
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockEnd);
+#else
     func->getBasicBlockList().push_back(blockEnd);
+#endif
     info->irBuilder->SetInsertPoint(blockEnd);
     ret.val = info->irBuilder->CreateLoad(ifTrue.chplType->symbol->getLLVMType(), tmp);
 

--- a/compiler/codegen/cg-stmt.cpp
+++ b/compiler/codegen/cg-stmt.cpp
@@ -174,7 +174,11 @@ GenRet BlockStmt::codegen() {
     info->irBuilder->CreateBr(blockStmtBody);
 
     // Now add the body.
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), blockStmtBody);
+#else
     func->getBasicBlockList().push_back(blockStmtBody);
+#endif
 
     info->irBuilder->SetInsertPoint(blockStmtBody);
 
@@ -284,7 +288,11 @@ CondStmt::codegen() {
 
     info->irBuilder->CreateBr(condStmtIf);
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), condStmtIf);
+#else
     func->getBasicBlockList().push_back(condStmtIf);
+#endif
     info->irBuilder->SetInsertPoint(condStmtIf);
 
     GenRet condValueRet = codegenValue(condExpr);
@@ -304,7 +312,11 @@ CondStmt::codegen() {
         condStmtThen,
         (elseStmt) ? condStmtElse : condStmtEnd);
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), condStmtThen);
+#else
     func->getBasicBlockList().push_back(condStmtThen);
+#endif
     info->irBuilder->SetInsertPoint(condStmtThen);
 
     info->lvt->addLayer();
@@ -314,7 +326,11 @@ CondStmt::codegen() {
     info->lvt->removeLayer();
 
     if(elseStmt) {
+#if HAVE_LLVM_VER >= 160
+      func->insert(func->end(), condStmtElse);
+#else
       func->getBasicBlockList().push_back(condStmtElse);
+#endif
       info->irBuilder->SetInsertPoint(condStmtElse);
 
       info->lvt->addLayer();
@@ -323,7 +339,11 @@ CondStmt::codegen() {
       info->lvt->removeLayer();
     }
 
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), condStmtEnd);
+#else
     func->getBasicBlockList().push_back(condStmtEnd);
+#endif
     info->irBuilder->SetInsertPoint(condStmtEnd);
 
     info->lvt->removeLayer();
@@ -369,7 +389,11 @@ GenRet GotoStmt::codegen() {
 
     llvm::BasicBlock *afterGoto = llvm::BasicBlock::Create(
         info->module->getContext(), FNAME("afterGoto"));
+#if HAVE_LLVM_VER >= 160
+    func->insert(func->end(), afterGoto);
+#else
     func->getBasicBlockList().push_back(afterGoto);
+#endif
     info->irBuilder->SetInsertPoint(afterGoto);
 
 #endif

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -971,16 +971,9 @@ void VarSymbol::codegenDef() {
     llvm::AllocaInst *varAlloca = createVarLLVM(varType, cname);
 
     // Update the alignment if necessary
-#if HAVE_LLVM_VER >= 160
-    if (alignment.has_value()) {
-      varAlloca->setAlignment(alignment.value());
+    if (alignment) {
+      varAlloca->setAlignment(*alignment);
     }
-#else
-    if (alignment.hasValue()) {
-      varAlloca->setAlignment(alignment.getValue());
-    }
-#endif
-
 
     info->lvt->addValue(cname, varAlloca, GEN_PTR, ! is_signed(type));
 

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -971,13 +971,13 @@ void VarSymbol::codegenDef() {
     llvm::AllocaInst *varAlloca = createVarLLVM(varType, cname);
 
     // Update the alignment if necessary
-#if HAVE_LLVM_VER >= 100
-    if (alignment.hasValue()) {
-      varAlloca->setAlignment(alignment.getValue());
+#if HAVE_LLVM_VER >= 160
+    if (alignment.has_value()) {
+      varAlloca->setAlignment(alignment.value());
     }
 #else
-    if (alignment > 1) {
-      varAlloca->setAlignment(alignment);
+    if (alignment.hasValue()) {
+      varAlloca->setAlignment(alignment.getValue());
     }
 #endif
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1931,7 +1931,11 @@ static llvm::TargetOptions getTargetOptions(
       CodeGenOpts.UniqueBasicBlockSectionNames;
   Options.TLSSize = CodeGenOpts.TLSSize;
   Options.EmulatedTLS = CodeGenOpts.EmulatedTLS;
+#if HAVE_LLVM_VER >= 160
   Options.ExplicitEmulatedTLS = true;
+#else
+  Options.ExplicitEmulatedTLS = CodeGenOpts.ExplicitEmulatedTLS;
+#endif
   Options.DebuggerTuning = CodeGenOpts.getDebuggerTuning();
   Options.EmitStackSizeSection = CodeGenOpts.StackSizeSection;
 #if HAVE_LLVM_VER >= 130

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1831,7 +1831,7 @@ getCodeModel(const CodeGenOptions &CodeGenOpts) {
                            .Default(~0u);
   assert(CodeModel != ~0u && "invalid code model!");
   if (CodeModel == ~1u)
-    return None;
+    return chpl::empty;
   return static_cast<llvm::CodeModel::Model>(CodeModel);
 }
 

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -695,7 +695,11 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
         eltType = st->getValueOperand()->getType();
       }
       if (eltType) {
+#if HAVE_LLVM_VER >= 160
+        Alignment = DL->getABITypeAlign(eltType);
+#else
         Alignment = DL->getABITypeAlignment(eltType);
+#endif
       } else {
         assert(false && "expected eltType when computing natural alignment");
       }

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -54,6 +54,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/Statistic.h"
 

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -696,7 +696,7 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
       }
       if (eltType) {
 #if HAVE_LLVM_VER >= 160
-        Alignment = DL->getABITypeAlign(eltType);
+        Alignment = DL->getABITypeAlign(eltType).value();
 #else
         Alignment = DL->getABITypeAlignment(eltType);
 #endif

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -170,7 +170,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         get_type(type->getValType()),//it should return the pointee's DIType
         layout.getPointerSizeInBits(ty->getPointerAddressSpace()),
         0, /* alignment */
-        llvm::None,
+        chpl::empty,
         name);
 
       myTypeDescriptors[type] = N;
@@ -193,7 +193,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
             pteIntDIType,
             layout.getPointerSizeInBits(ty->getPointerAddressSpace()),
             0,
-            llvm::None,
+            chpl::empty,
             name);
 
           myTypeDescriptors[type] = N;
@@ -222,7 +222,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
             pteStrDIType,
             layout.getPointerSizeInBits(ty->getPointerAddressSpace()),
             0,
-            llvm::None,
+            chpl::empty,
             name);
 
           myTypeDescriptors[type] = N;
@@ -250,7 +250,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
               get_type(vt),
               layout.getPointerSizeInBits(ty->getPointerAddressSpace()),
               0,
-              llvm::None,
+              chpl::empty,
               name);
 
             myTypeDescriptors[type] = N;

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -211,7 +211,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
             layout.getTypeSizeInBits(PointeeTy):
             8), /* SizeInBits */
             (PointeeTy->isSized()?
-            8*layout.getABITypeAlignment(PointeeTy):
+            8*layout.getABITypeAlign(PointeeTy).value():
             8), /* AlignInBits */
             llvm::DINode::FlagZero, /* Flags */
             NULL, /* DerivedFrom */
@@ -272,7 +272,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
               defLine,
               0, // RuntimeLang
               layout.getTypeSizeInBits(ty),
-              8*layout.getABITypeAlignment(ty));
+              8*layout.getABITypeAlign(ty).value());
 
             //N is added to the map (early) so that element search below can find it,
             //so as to avoid infinite recursion for structs that contain pointers to
@@ -302,7 +302,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
                 get_file(fieldDefFile),
                 fieldDefLine,
                 layout.getTypeSizeInBits(fty),
-                8*layout.getABITypeAlignment(fty),
+                8*layout.getABITypeAlign(fty).value(),
                 slayout->getElementOffsetInBits(this_class->getMemberGEP(field->cname, unused)),
                 llvm::DINode::FlagZero,
                 fditype);
@@ -317,7 +317,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
               get_file(defFile), /* File */
               defLine, /* LineNumber */
               layout.getTypeSizeInBits(ty), /* SizeInBits */
-              8*layout.getABITypeAlignment(ty), /* AlignInBits */
+              8*layout.getABITypeAlign(ty).value(), /* AlignInBits */
               llvm::DINode::FlagZero, /* Flags */
               derivedFrom, /* DerivedFrom */
               this->dibuilder.getOrCreateArray(EltTys) /* Elements */
@@ -351,7 +351,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
       defLine,
       0, // RuntimeLang
       layout.getTypeSizeInBits(ty),
-      8*layout.getABITypeAlignment(ty));
+      8*layout.getABITypeAlign(ty).value());
 
     //N is added to the map (early) so that element search below can find it,
     //so as to avoid infinite recursion for structs that contain pointers to
@@ -382,7 +382,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         get_file(fieldDefFile),
         fieldDefLine,
         layout.getTypeSizeInBits(fty),
-        8*layout.getABITypeAlignment(fty),
+        8*layout.getABITypeAlign(fty).value(),
         slayout->getElementOffsetInBits(this_class->getMemberGEP(field->cname, unused)),
         llvm::DINode::FlagZero,
         fditype);
@@ -397,7 +397,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         get_file(defFile),
         defLine,
         layout.getTypeSizeInBits(ty),
-        8*layout.getABITypeAlignment(ty),
+        8*layout.getABITypeAlign(ty).value(),
         llvm::DINode::FlagZero,
         derivedFrom,
         this->dibuilder.getOrCreateArray(EltTys));
@@ -412,7 +412,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         get_file(defFile),
         defLine,
         layout.getTypeSizeInBits(ty),
-        8*layout.getABITypeAlignment(ty),
+        8*layout.getABITypeAlign(ty).value(),
         llvm::DINode::FlagZero,
         derivedFrom,
         this->dibuilder.getOrCreateArray(EltTys));
@@ -427,7 +427,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         get_file(defFile),
         defLine,
         layout.getTypeSizeInBits(ty),
-        8*layout.getABITypeAlignment(ty),
+        8*layout.getABITypeAlign(ty).value(),
         llvm::DINode::FlagZero,
         this->dibuilder.getOrCreateArray(EltTys));
 
@@ -449,7 +449,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
     if (get_type(eleType) == NULL) return NULL;
     N = this->dibuilder.createArrayType(
       Asize,
-      8*layout.getABITypeAlignment(ty),
+      8*layout.getABITypeAlign(ty).value(),
       get_type(eleType),
       this->dibuilder.getOrCreateArray(Subscripts));
 

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1649,7 +1649,11 @@ bool GlobalToWide::run(Module &M) {
                 Instruction *New;
                 New = fixer.callGlobalToWideFn(RI->getReturnValue(), RI);
                 New = ReturnInst::Create(M.getContext(), New, RI);
+#if HAVE_LLVM_VER >= 160
+                RI->eraseFromParent();
+#else
                 BB->getInstList().erase(RI);
+#endif
               }
             }
           }

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1604,8 +1604,11 @@ bool GlobalToWide::run(Module &M) {
           // fix up functions that have bodies
           // also skip "special" functions like wideToGlobal
           // (since they have no body)
-
+#if HAVE_LLVM_VER >= 160
+          NF->splice(NF->begin(), F);
+#else
           NF->getBasicBlockList().splice(NF->begin(), F->getBasicBlockList());
+#endif
 
           // Loop over the argument list, transferring uses of the old arguments
           // over to the new arguments, also transferring over the names as

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -404,8 +404,8 @@ bool isTypeEquivalent(const llvm::DataLayout& layout, llvm::Type* a, llvm::Type*
   }
 
 
-  alignA = layout.getPrefTypeAlignment(a);
-  alignB = layout.getPrefTypeAlignment(b);
+  alignA = layout.getPrefTypeAlign(a).value();
+  alignB = layout.getPrefTypeAlign(b).value();
   sizeA = layout.getTypeStoreSize(a);
   sizeB = layout.getTypeStoreSize(b);
 

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -170,7 +170,7 @@ GEN_CFLAGS += $(C_STD)
 # On Ubuntu, gcc complains about multiline comments in some versions
 # of Clang header files.
 #
-WARN_COMMONFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing
+WARN_COMMONFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing -Wno-error=missing-braces
 WARN_CXXFLAGS = $(WARN_COMMONFLAGS) -Wno-comment -Wmissing-braces
 WARN_CFLAGS = $(WARN_COMMONFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)


### PR DESCRIPTION
This PR updates the compiler to build with LLVM 16. It continues the effort from PRs #22260 #22282 #22300 to add compiler support for LLVM 16.

Note that this PR adds `-Wno-error=missing-braces` to the GCC flags because I am seeing it from within the LLVM headers (which we do not control). As far as I know, this works with old GCCs.

With these changes, as well as enabling LLVM 16 in chplenv, I'm able to build `chpl` and compile and run Hello World with LLVM 16.

Reviewed by @riftEmber - thanks!

- [x] full comm=none testing with LLVM 14