### PR TITLE
Change the file permission and fix formatting in apptainer test

### DIFF
--- a/util/cron/test-apptainer.bash
+++ b/util/cron/test-apptainer.bash
@@ -19,7 +19,8 @@ if [ $? -ne 0 ]
      exit 1
    else
      log_info "./chapel-quickstart.sh succeeded"  
-   fi 
+fi 
+
 # Commented out to just test chapel-quickstart in Jenkins.
 # Will add this once we know what configurations will fail(most/all of the non-llvm) have the logic to fail the test 
 # if [ $? -ne 0 ] 


### PR DESCRIPTION
To fix the failure in jenkins run, changing the file permission and formatting.