### PR TITLE
Build gasnet with -fPIE when working with LLVM 15

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -97,6 +97,13 @@ CHPL_GASNET_CFG_OPTIONS += --disable-hwloc
 # Disable IBV ODP due to https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4008
 CHPL_GASNET_CFG_OPTIONS += --disable-ibv-odp
 
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),llvm)
+# If we are using LLVM 15+, it defaults to -fPIE, so use that here as well
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -ge 15; echo "$$?"),0)
+GASNET_CFLAGS += -fPIE
+endif
+endif
+
 CHPL_GASNET_ENV_VARS:= CC='$(CC)' CXX='$(CXX)' MPI_CC='$(MPI_CC)' CFLAGS='$(GASNET_CFLAGS)' CXXFLAGS='$(GASNET_CFLAGS)'
 
 CHPL_GASNET_CFG_OPTIONS += $(CHPL_GASNET_MORE_CFG_OPTIONS)


### PR DESCRIPTION
This PR resolves link errors when using `chpl` to compile a program on Cray XC when using CHPL_COMM=gasnet after PR #22316. It does so by adding `-fPIE` to the GASNet build flags when using LLVM 15 or newer as the target compiler.

The issue stems from LLVM 15 making PIE (Position-Independent-Executable) the default. At the same time, on XC, we build GASNet with a different C compiler (other than `clang-15`). The result is link errors when the clang linker tries to link with `-pie` but the GASNet library is not built in a way to enable that.

Details about the LLVM 15 change to enable `-fPIE` by default (from https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html ):

> CMake -DCLANG_DEFAULT_PIE_ON_LINUX=ON is now the default. This is used by linux-gnu systems to decide whether -fPIE -pie is the default (instead of -fno-pic -no-pie). This matches GCC installations on many Linux distros. Note: linux-android and linux-musl always default to -fPIE -pie, ignoring this variable. -DCLANG_DEFAULT_PIE_ON_LINUX may be removed in the future. 

Future Work: Investigate performance differences with `-fPIE -pie` vs `-fno-pic -no-pie`. If there are large performance differences, look for a solution that disables clang's default `-fPIE` behavior instead of this adjustment.

Reviewed by @ronawho - thanks!

- [x] Hello World builds and runs on an XC when using GASNet and CHPL_LLVM=bundled
- [x] full comm=gasnet testing