### PR TITLE
Fix ROCm and CUDA build

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -84,7 +84,7 @@ static hipModule_t *chpl_gpu_rocm_modules;
 static int *deviceClockRates;
 
 
-static void chpl_gpu_ensure_context() {
+static void chpl_gpu_ensure_context(void) {
   // Some hipCtx* functions are deprecated so we're using `hipSetDevice`
   // in its place
   ROCM_CALL(hipSetDevice(chpl_task_getRequestedSubloc()));
@@ -157,7 +157,7 @@ void chpl_gpu_impl_init(int* num_devices) {
 
 static bool chpl_gpu_device_alloc = false;
 
-void chpl_gpu_impl_support_module_finished_initializing() {
+void chpl_gpu_impl_support_module_finished_initializing(void) {
   chpl_gpu_device_alloc = true;
 }
 

--- a/runtime/src/gpu/nvidia/gpu-nvidia.c
+++ b/runtime/src/gpu/nvidia/gpu-nvidia.c
@@ -51,7 +51,7 @@ static CUmodule *chpl_gpu_cuda_modules;
 static int *deviceClockRates;
 
 
-static bool chpl_gpu_has_context() {
+static bool chpl_gpu_has_context(void) {
   CUcontext cuda_context = NULL;
 
   CUresult ret = cuCtxGetCurrent(&cuda_context);
@@ -97,7 +97,7 @@ static void chpl_gpu_impl_set_globals(CUmodule module) {
   chpl_gpu_impl_copy_host_to_device((void*)ptr, &chpl_nodeID, glob_size);
 }
 
-static void chpl_gpu_ensure_context() {
+static void chpl_gpu_ensure_context(void) {
   chpl_gpu_switch_context(chpl_task_getRequestedSubloc());
 }
 


### PR DESCRIPTION
Apparently the compiler now warns about the functions in `gpu-amd.c` and `gpu-nvidia.c`  that don't have arguments but also don't include `(void)` in their argument list. This PR fixes that.

Trivial; I'm going to merge without review.

## Testing
- [x] code compiles on Osprey