### PR TITLE
Add support for the `index(D)` operation to Dyno

### DIFF
--- a/frontend/include/chpl/resolution/resolution-error-classes-list.h
+++ b/frontend/include/chpl/resolution/resolution-error-classes-list.h
@@ -48,6 +48,7 @@ ERROR_CLASS(IncompatibleIfBranches, const uast::Conditional*, types::QualifiedTy
 ERROR_CLASS(IncompatibleKinds, types::QualifiedType::Kind, const uast::AstNode*, types::QualifiedType)
 ERROR_CLASS(IncompatibleRangeBounds, const uast::Range*, types::QualifiedType, types::QualifiedType)
 ERROR_CLASS(IncompatibleTypeAndInit, const uast::AstNode*, const uast::AstNode*, const uast::AstNode*, const types::Type*, const types::Type*)
+ERROR_CLASS(InvalidIndexCall, const uast::FnCall*, types::QualifiedType)
 ERROR_CLASS(InvalidNewTarget, const uast::New*, types::QualifiedType)
 ERROR_CLASS(InvalidSuper, const uast::Identifier*, types::QualifiedType)
 ERROR_CLASS(MemManagementNonClass, const uast::New*, const types::Type*)

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -418,7 +418,8 @@ class CallInfo {
                          const uast::Call* call,
                          const ResolutionResultByPostorderID& byPostorder,
                          bool raiseErrors = true,
-                         std::vector<const uast::AstNode*>* actualAsts=nullptr);
+                         std::vector<const uast::AstNode*>* actualAsts=nullptr,
+                         UniqueString rename = UniqueString());
 
   /** Construct a CallInfo by adding a method receiver argument to
       the passed CallInfo. */
@@ -1234,7 +1235,7 @@ class ResolvedExpression {
   }
 
   /** set the isPrimitive flag */
-  void setIsPrimitive(bool isPrimitive) { isBuiltin_ = isPrimitive; }
+  void setIsBuiltin(bool isBuiltin) { isBuiltin_ = isBuiltin; }
 
   /** set the toId */
   void setToId(ID toId) { toId_ = toId; }

--- a/frontend/include/chpl/types/DomainType.h
+++ b/frontend/include/chpl/types/DomainType.h
@@ -104,6 +104,12 @@ class DomainType final : public CompositeType {
     return kind_;
   }
 
+  // Returns the integer representing the rank of this domain. This is more
+  // general than `rank`, because `rank` returns the substitution
+  // corresponding to the rank, which only exists for rectangular domains.
+  // This method, however, works on associative domains, too.
+  int rankInt() const;
+
   const QualifiedType& rank() const {
     CHPL_ASSERT(kind_ == Kind::Rectangular);
     return subs_.at(ID(UniqueString(), 0, 0));

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -397,6 +397,9 @@ struct Resolver {
   // resolve a special op call such as tuple unpack assign
   bool resolveSpecialOpCall(const uast::Call* call);
 
+  // resolve a keyword call like index(D)
+  bool resolveSpecialKeywordCall(const uast::Call* call);
+
   // Resolve a || or && operation.
   types::QualifiedType typeForBooleanOp(const uast::OpCall* op);
 

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -486,6 +486,26 @@ void ErrorIncompatibleTypeAndInit::write(ErrorWriterBase& wr) const {
              "initial value has type '", initExprType, "'.");
 }
 
+void ErrorInvalidIndexCall::write(ErrorWriterBase& wr) const {
+  auto fnCall = std::get<const uast::FnCall*>(info);
+  auto& type = std::get<types::QualifiedType>(info);
+
+  wr.heading(kind_, type_, fnCall,
+             "invalid use of the 'index' keyword.");
+  wr.codeForLocation(fnCall);
+  wr.message("The 'index' keyword should be used with a domain: 'index(D)'.");
+
+  if (fnCall->numActuals() == 0) {
+    wr.message("However, 'index' here did not have any actuals.");
+  } else if (fnCall->numActuals() > 1) {
+    wr.message("However, 'index' here had more than one actual.");
+    wr.code(fnCall, { fnCall->actual(1) });
+  } else if (type.type() && !type.type()->isDomainType()) {
+    wr.message("However, 'index' here is not called with a domain argument, but with ", decayToValue(type), ".");
+    wr.code(fnCall, { fnCall->actual(0) });
+  }
+}
+
 void ErrorInvalidNewTarget::write(ErrorWriterBase& wr) const {
   auto newExpr = std::get<const uast::New*>(info);
   auto type = std::get<types::QualifiedType>(info);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -282,7 +282,8 @@ const QualifiedType& typeForBuiltin(Context* context,
 
     result = QualifiedType(QualifiedType::TYPE, t);
   } else {
-    CHPL_ASSERT(false && "Should not be reachable");
+    // Could be a non-type builtin like 'index'
+    result = QualifiedType();
   }
 
   return QUERY_END(result);

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -286,7 +286,8 @@ CallInfo CallInfo::create(Context* context,
                           const Call* call,
                           const ResolutionResultByPostorderID& byPostorder,
                           bool raiseErrors,
-                          std::vector<const uast::AstNode*>* actualAsts) {
+                          std::vector<const uast::AstNode*>* actualAsts,
+                          UniqueString rename) {
 
   // Pieces of the CallInfo we need to prepare.
   UniqueString name;
@@ -367,6 +368,13 @@ CallInfo CallInfo::create(Context* context,
 
   if (actualAsts != nullptr) {
     CHPL_ASSERT(actualAsts->size() == actuals.size());
+  }
+
+  if (!rename.isEmpty()) {
+    // Whatever we were calling was a value, and is now and actual. Can't
+    // rename an argument to a function...
+    CHPL_ASSERT(name != "this");
+    name = rename;
   }
 
   auto ret = CallInfo(name, calledType, isMethodCall,

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -664,7 +664,11 @@ static bool helpComputeReturnType(Context* context,
       if (untyped->name() == "idxType") {
         result = dt->idxType();
       } else if (untyped->name() == "rank") {
-        result = dt->rank();
+        // Can't use `RankType::rank` because `D.rank` is defined for associative
+        // domains, even though they don't have a matching substitution.
+        result = QualifiedType(QualifiedType::PARAM,
+                               IntType::get(context, 64),
+                               IntParam::get(context, dt->rankInt()));
       } else if (untyped->name() == "stridable") {
         result = dt->stridable();
       } else if (untyped->name() == "parSafe") {

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -305,6 +305,10 @@ isElseBlockOfConditionalWithIfVar(Context* context,
 
 static const Scope* const& scopeForIdQuery(Context* context, ID id);
 
+static void populateScopeWithBuiltinKeywords(Context* context, Scope* scope) {
+  scope->addBuiltin(UniqueString::get(context, "index"));
+}
+
 static void populateScopeWithBuiltins(Context* context, Scope* scope) {
   std::unordered_map<UniqueString,const Type*> map;
   Type::gatherBuiltins(context, map);
@@ -312,6 +316,8 @@ static void populateScopeWithBuiltins(Context* context, Scope* scope) {
   for (const auto& pair : map) {
     scope->addBuiltin(pair.first);
   }
+
+  populateScopeWithBuiltinKeywords(context, scope);
 }
 
 // This query always constructs a scope

--- a/frontend/lib/types/DomainType.cpp
+++ b/frontend/lib/types/DomainType.cpp
@@ -106,6 +106,16 @@ DomainType::getAssociativeType(Context* context,
                        DomainType::Kind::Associative).get();
 }
 
+int DomainType::rankInt() const {
+  if (kind_ == Kind::Rectangular) {
+    return rank().param()->toIntParam()->value();
+  } else if (kind_ == Kind::Associative) {
+    return 1;
+  }
+
+  // TODO: what's the rank of a generic domain type?
+  return 0;
+}
 
 } // end namespace types
 } // end namespace chpl

--- a/frontend/test/test-minimal-modules.h
+++ b/frontend/test/test-minimal-modules.h
@@ -84,6 +84,20 @@ module ChapelArray {
 
   // TODO: 'this' accessor can't work because accessing 'this.domain' in the
   // formal's type-expr is resolved as an ErroneousType
+
+  proc chpl__buildIndexType(param rank: int, type idxType) type where rank == 1 {
+    return idxType;
+  }
+
+  proc chpl__buildIndexType(param rank: int, type idxType) type where __primitive(">", rank, 1) {
+    return rank*idxType;
+  }
+
+  proc chpl__buildIndexType(param rank: int) type do
+    return chpl__buildIndexType(rank, int);
+
+  proc chpl__buildIndexType(d: domain) type do
+    return chpl__buildIndexType(d.rank, d.idxType);
 }
 )""";
 


### PR DESCRIPTION
Just like in the production compiler, this is implemented by invoking the standard library function `chpl__buildIndexType`. 

I also did the following:
* Fix up the `.rank` generated method on Domains to work with associative domains (it previously asserted that the domain should be rectangular)
* Fixed `setIsPrimitive` to be called `setIsBuiltin` (to match `isBuiltin` in `ResolvedExpression`)

Reviewed by @benharsh  -- thanks!

## Testing
- [x] paratest