### PR TITLE
Reduce the thread size to avoid jenkins error

### DIFF
--- a/util/devel/test/vagrant/provision-scripts/chapel-setmakej.sh
+++ b/util/devel/test/vagrant/provision-scripts/chapel-setmakej.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MAKEJ=${MAKEJ:=-j 16}
+MAKEJ=${MAKEJ:=-j 2}
 
 # could use $(chapel/util/buildRelease/chpl-make-cpu_count)}
 # but that doesn't currently incorporate the amount of RAM per thread


### PR DESCRIPTION
Jenkins executor is not able to handle concurrent IO write from the test.
hudson.remoting.SynchronousCommandTransport.run(SynchronousCommandTransport.java:77)
https://chapel-ci.us.cray.com/job/portability-apptainer/17/console
Reducing the thread count to see if the issue resolves.