### PR TITLE
Follow up for GPU compilation: add another missing (void) to fix a failing test

### DIFF
--- a/test/gpu/native/extern/extern_c_test.c
+++ b/test/gpu/native/extern/extern_c_test.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "./extern_c_test.h"
 
-void hello_world()
+void hello_world(void)
 {
     printf("hello world from C");
 }


### PR DESCRIPTION
Turns out one of the tests in ROCm CI also used C code, and used it without that `(void)` argument list! This PR fixes that.

Reviewed by @e-kayrakli -- thanks!

## Testing
- [x] test passes on osprey, where it didn't pass on main