### PR TITLE
Suppress gcc 13.1 warning

### DIFF
--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -171,6 +171,8 @@ void* chpl_memmove(void* dest, const void* src, size_t num)
 #if defined(HAS_GPU_LOCALE) && !defined(GPU_RUNTIME_CPU)
     return chpl_gpu_memmove(dest, src, num);
 #else
+// GCC 13.1 compplains about the following without this pragma...
+#pragma GCC diagnostic ignored "-Wstringop-overread"
     return memmove(dest, src, num);
 #endif
 }

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -171,9 +171,22 @@ void* chpl_memmove(void* dest, const void* src, size_t num)
 #if defined(HAS_GPU_LOCALE) && !defined(GPU_RUNTIME_CPU)
     return chpl_gpu_memmove(dest, src, num);
 #else
-// GCC 13.1 compplains about the following without this pragma...
+    // GCC 13.1 compplains about the following memmove() without this
+    // pragma to squash it...
+    //
+    // I was unable to convince myself the warning was reasonable or
+    // that GCC could even determine that the memmove() was
+    // unreasonable from the callchains I inspected, so chose to
+    // squash it and rely on our asan testing to keep us safe.  It may
+    // be that if we followed this path for a chpl_comm_get() that was
+    // local rather than remote we'd have a problem, and that our
+    // logic is guarding us in a way that GCC can't determine?
+    //
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overread"
     return memmove(dest, src, num);
+#pragma GCC diagnostic pop
+
 #endif
 }
 


### PR DESCRIPTION
The GASNet team pointed out that GCC 13.1 complained about a memmove() reached from `chpl_comm_get...()` calls was reading from a region of size 0 (#22337).  I spent some time looking through stack traces to see whether I believed that the memmove() was inherently problematic and was unable to convince myself that it was.  Moreover, I was unable to come up with any explanation for how GCC was able to think that it could be problematic—the expressions computing the addresses passed in are sufficiently gnarly that it seemed unlikely to me that it could be an actual problem, particularly given that we run asan testing with GASNet, which would presumably catch the issue if there was one.  My best guesses as to why it's complaining are:

* maybe the memmove() path would be problematic if we took it for a remote case, but since we only take it on a local get() case it's not?
* maybe GCC 13.1 has a bug or is being overly aggressive

In any case, in this PR I've taken the brute force solution of squashing the warning for the line in question which seems to quiet the warning, choosing to rely on our testing to inform of us of any true problems here.

Resolves #22337.