### PR TITLE
Added code to delete the cloned repository and .sif inside each linux folders

### DIFF
--- a/util/cron/test-apptainer.bash
+++ b/util/cron/test-apptainer.bash
@@ -11,14 +11,17 @@ log_info "Setting CHPL_HOME to: ${CHPL_HOME}"
 
 cd $CHPL_HOME/util/devel/test/apptainer
 
-./chapel-quickstart.sh
+./chapel-quickstart-delete.sh
 
 if [ $? -ne 0 ] 
    then
-     log_error "./chapel-quickstart.sh exited with error" 
+     log_error "./chapel-quickstart-delete.sh exited with error" 
+     log_info "cleaning before exiting"
+     ./chapel-delete.sh 
+     ./image-delete.sh
      exit 1
    else
-     log_info "./chapel-quickstart.sh succeeded"  
+     log_info "./chapel-quickstart-delete.sh succeeded"  
 fi 
 
 # Commented out to just test chapel-quickstart in Jenkins.

--- a/util/devel/test/apptainer/chapel-quickstart-delete.sh
+++ b/util/devel/test/apptainer/chapel-quickstart-delete.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Checks if a Quickstart build basses make check
+# Prints a summary at the end.
+
+./tryit-Jenkins.sh ../../provision-scripts/chapel-quickstart.sh

--- a/util/devel/test/apptainer/tryit-jenkins.sh
+++ b/util/devel/test/apptainer/tryit-jenkins.sh
@@ -67,10 +67,10 @@ do
       #exit 1
       ;;
     esac
-    rm -rF
-    cd "$DIR"
     rm -Rf chapel
     rm -Rf image.sif
+    cd "$DIR"
+   
     ((i++))
   fi
 done

--- a/util/devel/test/apptainer/tryit-jenkins.sh
+++ b/util/devel/test/apptainer/tryit-jenkins.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Runs a command (or series of commands) on all the images.
+# Prints a summary of the output at the end.
+# Saves all the command output in the file called log.
+
+LOG=log
+
+declare -a NAME
+declare -a RESULT
+
+echo > log
+echo > log2
+echo "Running command on images:" | tee -a log
+echo "$*" | tee -a log
+
+DIR=`pwd`
+
+i=0
+
+# compute longest length for padding
+maxlen=0
+for name in current/*
+do
+  if [ -f $name/image.def ]
+  then
+    if (( ${#name} > $maxlen ))
+    then
+      maxlen=${#name}
+    fi
+  fi
+done
+
+for name in current/*
+do
+  if [ -f $name/image.def ]
+  then
+    cd $name
+    display=`printf "%${maxlen}s" $name`
+    NAME[$i]=$display
+    echo
+    echo "     ---- $display ---- " | tee -a "$DIR"/log
+    if [ ! -e image.sif ]
+    then
+      echo $name/image.sif not present so building image
+      ( apptainer build --fakeroot image.sif image.def 2>&1 && echo >&3 ok || echo >&3 error exit $? ) 3> "$DIR"/log2 | tee -a "$DIR"/log
+    fi
+    ( apptainer exec image.sif "$@" 2>&1 && echo >&3 ok || echo >&3 error exit $? ) 3> "$DIR"/log2 | tee -a "$DIR"/log
+    case "$(tail -n 1 "$DIR"/log2)" in
+    ( ok )
+      echo
+      lastline=`tail -n 1 "$DIR"/log`
+      RESULT[$i]="  OK: $lastline"
+      ;;
+    ( error* )
+      lastline=`tail -n 1 "$DIR"/log`
+      RESULT[$i]="FAIL: $lastline"
+      echo "     FAIL:" $name
+      echo "     You might want to run:"
+      echo
+      echo "     cd" $name
+      echo "     apptainer shell image.sif"
+      echo "     " $*
+      echo
+      echo
+      #uncomment the below line to make errors fatal
+      #exit 1
+      ;;
+    esac
+    rm -rF
+    cd "$DIR"
+    rm -Rf chapel
+    rm -Rf image.sif
+    ((i++))
+  fi
+done
+
+# log2 is no longer needed so remove it
+rm log2
+
+echo "     -------- SUMMARY --------"
+
+i=0
+for name in current/*
+do
+  if [ -f $name/image.def ]
+  then
+    echo "${NAME[$i]}:${RESULT[$i]}"
+
+    ((i++))
+  fi
+done


### PR DESCRIPTION
Jenkins test run is causing the chapvm-build to crash with low disk space every time the test is executed.

Clean up each the images after testing each linux version.