### PR TITLE
Nightly ChOp test was silently skipifing; correct this

### DIFF
--- a/test/gpu/native/studies/chop/chplGPU.skipif
+++ b/test/gpu/native/studies/chop/chplGPU.skipif
@@ -6,17 +6,6 @@ if [ -z "$CHPL_TEST_PERF" ]; then
   exit
 fi
 
-# Skip this test if we cannot connect to github, which is required to
-# run the test.
-ping -c 1 github.com &> /dev/null
-status=$?
-if ! [ $status -eq 0 ]; then
-  echo "True"
-  # exit 0 as we want test to be considered a success as to not fail nightly
-  # Jenkins job.
-  exit 0  
-fi
-
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 CHOP_BRANCH=main
 CHOP_URL=${CHOP_URL:-https://github.com/tcarneirop/ChOp.git}
@@ -25,16 +14,16 @@ CHOP_BRANCH=${CHOP_BRANCH:-main}
 # Clone ChOp, skipif clone failed, add extra output to fail nightly job
 rm -rf ChOp
 if ! git clone ${CHOP_URL} --branch=${CHOP_BRANCH} --depth=1 2>gitClone.out; then
-  echo "git clone failed; output:"
-  cat gitClone.out
+  echo "git clone failed; output:" >&2
+  cat gitClone.out >&2
   echo "True"
   exit
 fi
 
 # Apply patches, if any
 if ! (for p in $(find patches -name "*patch"); do git -C ChOp apply ../$p; done) 2>gitPatch.out; then
-  echo "Patching failed; output:"
-  cat gitPatch.out
+  echo "Patching failed; output:" >&2
+  cat gitPatch.out >&2
   echo "True"
   exit
 fi


### PR DESCRIPTION
Our nightly GPU + ChOP test clones the ChOp repos from GitHub. It does this via a `.skipif` script and this script has a step that pings GitHub to see if it's available and skips the test if it isn't. 

This test hasn't been running recently because of changes in our test configuration environment that would cause it to always fail when pinging GitHub. However, this isn't due to actual network connectivity issues and the subsequent `git clone` in the script would have worked had we let it.

It also turns out any output from a `.skipif` script that isn't directed to stderr will get swallowed by `start_tests` so we won't see it in any of our log files.

This PR removes that initial check and redirects error output from that `.skipif` for this test to `stderr` so it will get logged.