### PR TITLE
Fix bug causing us to use an invalid number of locales for multilocale gpu testing

### DIFF
--- a/test/gpu/native/multiLocale/NUMLOCALES
+++ b/test/gpu/native/multiLocale/NUMLOCALES
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-codegen=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_GPU | cut -d = -f 2-`
+codegen=`$CHPL_HOME/util/printchplenv --all --simple | grep ^CHPL_GPU= | cut -d = -f 2-`
 if [ "$codegen" = "amd" ]; then
   echo "2"
 else


### PR DESCRIPTION
For out nightly multilocale GPU testing, when using AMD, we want to set it to use 2 locales (this is what the machine we're testing this on has available, any more and things hang forever). We have a `NUMLOCALES` script to configured to do just that. This script works by looking at the value of `CHPL_GPU` and if that's "amd" returns 2 (otherwise it returns 4 for our nvidia testing).

The script extracts `CHPL_GPU` by running `printchplenv` and grepping for "CHPL_GPU", but that grep ends up being too broad and capturing other `CHPL_GPU` related variables. This PR fixes the regexp used to be more narrow and ensure we only capture `CHPL_GPU` and not something like `CHPL_GPU_MEM_STRATEGY`.