### PR TITLE
Fixing protobuf test failures per `list.append` deprecation

### DIFF
--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/enums/write.chpl
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/enums/write.chpl
@@ -10,12 +10,12 @@ messageObj.a = color.blue;
 
 messageObj.b = 564;
 
-messageObj.c.append(color.blue);
-messageObj.c.append(color.green);
+messageObj.c.pushBack(color.blue);
+messageObj.c.pushBack(color.green);
 
 messageObj.d = enumTest_fruit.orange;
 
-messageObj.e.append(enumTest_fruit.orange);
-messageObj.e.append(enumTest_fruit.apple);
+messageObj.e.pushBack(enumTest_fruit.orange);
+messageObj.e.pushBack(enumTest_fruit.apple);
 
 messageObj.serialize(writingChannel);

--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/messagefield/write.chpl
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/messagefield/write.chpl
@@ -13,18 +13,18 @@ var tmpObj1:messageC;
 var tmpObj2:messageC;
 tmpObj1.d = 26;
 tmpObj1.e = true;
-messageObj.f.append(tmpObj1);
+messageObj.f.pushBack(tmpObj1);
 tmpObj2.d = 36;
 tmpObj2.e = false;
-messageObj.f.append(tmpObj2);
+messageObj.f.pushBack(tmpObj2);
 
 messageObj.g.a = 76;
 
 var tmpObj3:messageA_messageD;
 var tmpObj4:messageA_messageD;
 tmpObj3.a = 26;
-messageObj.h.append(tmpObj3);
+messageObj.h.pushBack(tmpObj3);
 tmpObj4.a = 46;
-messageObj.h.append(tmpObj4);
+messageObj.h.pushBack(tmpObj4);
 
 messageObj.serialize(writingChannel);

--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/repeatedfield/read.chpl
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/repeatedfield/read.chpl
@@ -9,76 +9,76 @@ var readingChannel = file.reader();
 messageObj.deserialize(readingChannel);
 
 var lst1 = new list(uint(64));
-lst1.append(1);
-lst1.append(2445464);
+lst1.pushBack(1);
+lst1.pushBack(2445464);
 writeln(messageObj.ui64 == lst1);
 
 var lst2 = new list(uint(32));
-lst2.append(1);
-lst2.append(24454);
+lst2.pushBack(1);
+lst2.pushBack(24454);
 writeln(messageObj.ui32 == lst2);
 
 var lst3 = new list(int(64));
-lst3.append(-100);
-lst3.append(244540000000);
+lst3.pushBack(-100);
+lst3.pushBack(244540000000);
 writeln(messageObj.i64 == lst3);
 
 var lst4 = new list(int(32));
-lst4.append(-500);
-lst4.append(2445489);
+lst4.pushBack(-500);
+lst4.pushBack(2445489);
 writeln(messageObj.i32 == lst4);
 
 var lst5 = new list(bool);
-lst5.append(true);
-lst5.append(false);
+lst5.pushBack(true);
+lst5.pushBack(false);
 writeln(messageObj.bo == lst5);
 
 var lst6 = new list(int(64));
-lst6.append(-500);
-lst6.append(-24454890000);
+lst6.pushBack(-500);
+lst6.pushBack(-24454890000);
 writeln(messageObj.si64 == lst6);
 
 var lst7 = new list(int(32));
-lst7.append(-50);
-lst7.append(-2445489);
+lst7.pushBack(-50);
+lst7.pushBack(-2445489);
 writeln(messageObj.si32 == lst7);
 
 var lst8 = new list(uint(32));
-lst8.append(67);
-lst8.append(8907);
+lst8.pushBack(67);
+lst8.pushBack(8907);
 writeln(messageObj.fi32 == lst8);
 
 var lst9 = new list(uint(64));
-lst9.append(500);
-lst9.append(2445489000);
+lst9.pushBack(500);
+lst9.pushBack(2445489000);
 writeln(messageObj.fi64 == lst9);
 
 var lst10 = new list(real(32));
-lst10.append(4.12);
-lst10.append(4500.3);
+lst10.pushBack(4.12);
+lst10.pushBack(4500.3);
 writeln(messageObj.fl == lst10);
 
 var lst11 = new list(real(64));
-lst11.append(67.2345);
-lst11.append(8907980.5657);
+lst11.pushBack(67.2345);
+lst11.pushBack(8907980.5657);
 writeln(messageObj.db == lst11);
 
 var lst12 = new list(int(32));
-lst12.append(-500);
-lst12.append(-244548);
+lst12.pushBack(-500);
+lst12.pushBack(-244548);
 writeln(messageObj.sfi32 == lst12);
 
 var lst13 = new list(int(64));
-lst13.append(-45);
-lst13.append(-4500000000);
+lst13.pushBack(-45);
+lst13.pushBack(-4500000000);
 writeln(messageObj.sfi64 == lst13);
 
 var lst14 = new list(bytes);
-lst14.append(b"\x01\x87\x76");
-lst14.append(b"\x00\x01\x02\x03");
+lst14.pushBack(b"\x01\x87\x76");
+lst14.pushBack(b"\x00\x01\x02\x03");
 writeln(messageObj.byt == lst14);
 
 var lst15 = new list(string);
-lst15.append("aniket");
-lst15.append("String with spaces");
+lst15.pushBack("aniket");
+lst15.pushBack("String with spaces");
 writeln(messageObj.st == lst15);

--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/repeatedfield/write.chpl
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/repeatedfield/write.chpl
@@ -6,49 +6,49 @@ var writingChannel = file.writer();
 
 var messageObj = new repeatedField();
 
-messageObj.ui64.append(1);
-messageObj.ui64.append(2445464);
+messageObj.ui64.pushBack(1);
+messageObj.ui64.pushBack(2445464);
 
-messageObj.ui32.append(1);
-messageObj.ui32.append(24454);
+messageObj.ui32.pushBack(1);
+messageObj.ui32.pushBack(24454);
 
-messageObj.i64.append(-100);
-messageObj.i64.append(244540000000);
+messageObj.i64.pushBack(-100);
+messageObj.i64.pushBack(244540000000);
 
-messageObj.i32.append(-500);
-messageObj.i32.append(2445489);
+messageObj.i32.pushBack(-500);
+messageObj.i32.pushBack(2445489);
 
-messageObj.bo.append(true);
-messageObj.bo.append(false);
+messageObj.bo.pushBack(true);
+messageObj.bo.pushBack(false);
 
-messageObj.si64.append(-500);
-messageObj.si64.append(-24454890000);
+messageObj.si64.pushBack(-500);
+messageObj.si64.pushBack(-24454890000);
 
-messageObj.si32.append(-50);
-messageObj.si32.append(-2445489);
+messageObj.si32.pushBack(-50);
+messageObj.si32.pushBack(-2445489);
 
-messageObj.fi32.append(67);
-messageObj.fi32.append(8907);
+messageObj.fi32.pushBack(67);
+messageObj.fi32.pushBack(8907);
 
-messageObj.fi64.append(500);
-messageObj.fi64.append(2445489000);
+messageObj.fi64.pushBack(500);
+messageObj.fi64.pushBack(2445489000);
 
-messageObj.fl.append(4.12);
-messageObj.fl.append(4500.3);
+messageObj.fl.pushBack(4.12);
+messageObj.fl.pushBack(4500.3);
 
-messageObj.db.append(67.2345);
-messageObj.db.append(8907980.5657);
+messageObj.db.pushBack(67.2345);
+messageObj.db.pushBack(8907980.5657);
 
-messageObj.sfi32.append(-500);
-messageObj.sfi32.append(-244548);
+messageObj.sfi32.pushBack(-500);
+messageObj.sfi32.pushBack(-244548);
 
-messageObj.sfi64.append(-45);
-messageObj.sfi64.append(-4500000000);
+messageObj.sfi64.pushBack(-45);
+messageObj.sfi64.pushBack(-4500000000);
 
-messageObj.byt.append(b"\x01\x87\x76");
-messageObj.byt.append(b"\x00\x01\x02\x03");
+messageObj.byt.pushBack(b"\x01\x87\x76");
+messageObj.byt.pushBack(b"\x00\x01\x02\x03");
 
-messageObj.st.append("aniket");
-messageObj.st.append("String with spaces");
+messageObj.st.pushBack("aniket");
+messageObj.st.pushBack("String with spaces");
 
 messageObj.serialize(writingChannel);


### PR DESCRIPTION
Replaces the uses of `list.append` with `list.pushBack` in:
-  `library/packages/ProtobufProtocolSupport/enumsRunner`
- `library/packages/ProtobufProtocolSupport/messagefieldRunner`
- `library/packages/ProtobufProtocolSupport/repeatedfieldRunner`

