### PR TITLE
Improve createSharedArray error if argument type doesn't have a known size.

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -190,7 +190,14 @@ module GPU
     :arg size: the number of elements in each GPU thread block's copy of the array.
    */
   inline proc createSharedArray(type eltType, param size): c_ptr(eltType) {
-    if CHPL_GPU != "cpu" {
+    if !__primitive("call and fn resolves", "numBits", eltType) {
+      compilerError("attempting to allocate a shared array of '",
+                    eltType : string,
+                    "', which does not have a known size. Is 'numBits(",
+                    eltType : string,
+                    ")' supported?");
+    }
+    else if CHPL_GPU != "cpu" {
       const voidPtr = __primitive("gpu allocShared", numBytes(eltType)*size);
       return voidPtr : c_ptr(eltType);
     }

--- a/test/gpu/native/createSharedArrayError.chpl
+++ b/test/gpu/native/createSharedArrayError.chpl
@@ -1,0 +1,17 @@
+module Test {
+  use GPU;
+
+  record myRecord {
+    var x: real(32);
+    var y: real(32);
+  }
+
+  proc main() {
+    on here.gpus[0] {
+      foreach i in 0..<1024 {
+        ref A = createSharedArray(myRecord, 16);
+        A[i].x = A[i].y;
+      }
+    }
+  }
+}

--- a/test/gpu/native/createSharedArrayError.good
+++ b/test/gpu/native/createSharedArrayError.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+createSharedArrayError.chpl:9: In function 'main':
+createSharedArrayError.chpl:12: error: attempting to allocate a shared array of 'myRecord', which does not have a known size. Is 'numBits(myRecord)' supported?


### PR DESCRIPTION
This is intended to close #22309.

Reviewed by @stonea -- thanks!

## Testing
- [x] GPU test:
   `[Summary: #Successes = 71 | #Failures = 0 | #Futures = 0 | #Warnings = 0 ]`