### PR TITLE
Tweak chpl_gpu to not require GPU_ARCH for cpu runs.

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -98,7 +98,7 @@ def get_arch():
     gpu_type = get()
 
     # No arch if GPU is not being used.
-    if gpu_type == 'none':
+    if gpu_type == 'none' or gpu_type == 'cpu':
         return 'none'
 
     # Check if user is overriding the arch.


### PR DESCRIPTION
Currently, running `CHPL_GPU=cpu` on my M1 mac (without a GPU) gives the following beauty:

> Exception: CHPL_GPU=cpu requires also setting CHPL_GPU_ARCH. Please check the GPU programming technote <https://chapel-lang.org/docs/technotes/gpu.html> for more information.

This is not correct (why would a CPU-only implementation require GPU_ARCH?) and is driven by a tiny logic error in `chpl_gpu.py`. This PR fixes that, so you can use t`CHP_GPU=cpu` without setting the architecture.

Reviewed by @stonea -- thanks!