### PR TITLE
Fixing linear algebra test failures per `list.append` deprecation

### DIFF
--- a/test/library/packages/LinearAlgebra/correctness/testElementwise.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/testElementwise.chpl
@@ -10,7 +10,7 @@ proc getSparse(d, stride) {
   var sdom: sparse subdomain(d);
   var indices: list(2*d.idxType);
   for (i,j) in d by stride {
-    indices.append((i,j));
+    indices.pushBack((i,j));
   }
   sdom += indices.toArray();
   return sdom;
@@ -55,4 +55,3 @@ print_sparsearr(A.times(B));
 writeln();
 print_sparsearr(A.elementDiv(B));
 writeln();
-

--- a/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
+++ b/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
@@ -178,7 +178,7 @@ record _SPA {
     if this.b[pos] == 0 {
       this.w[pos] = value;
       this.b[pos] = true;
-      this.ls.append(pos);
+      this.ls.pushBack(pos);
     } else {
       this.w[pos] += value;
     }


### PR DESCRIPTION
Replaces the uses of `list.append` with `list.pushBack` in:
- library/packages/LinearAlgebra/correctness/testElementwise
- library/packages/LinearAlgebra/performance/SPA-perf
