### PR TITLE
Remove compiler checking for hazards on BitOps functions

### DIFF
--- a/modules/internal/ChapelHashing.chpl
+++ b/modules/internal/ChapelHashing.chpl
@@ -56,6 +56,8 @@ module ChapelHashing {
   }
 
   inline proc chpl__defaultHashCombine(a:uint, b:uint, fieldnum:int): uint {
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
     extern proc chpl_bitops_rotl_64(x: uint(64), n: uint(64)) : uint(64);
     var n:uint = (17 + fieldnum):uint;
     return _gen_key(a ^ chpl_bitops_rotl_64(b, n));

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -1661,8 +1661,10 @@ module AutoMath {
 
   private inline proc _logBasePow2Help(in val, baseLog2) {
     // These are used here to avoid including BitOps by default.
+    pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc chpl_bitops_clz_32(x: c_uint) : uint(32);
+    pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
     extern proc chpl_bitops_clz_64(x: c_ulonglong) : uint(64);
 

--- a/modules/standard/BitOps.chpl
+++ b/modules/standard/BitOps.chpl
@@ -171,41 +171,57 @@ module BitOps {
  */
 private module BitOps_internal {
   private use CTypes;
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_popcount_32(x: c_uint) : uint(32);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_popcount_64(x: c_ulonglong) : uint(64);
 
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_clz_32(x: c_uint) : uint(32);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_clz_64(x: c_ulonglong) : uint(64);
 
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_ctz_32(x: c_uint) : uint(32);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_ctz_64(x: c_ulonglong) : uint(64);
 
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_parity_32(x: c_uint) : uint(32);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_parity_64(x: c_ulonglong) : uint(64);
 
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_rotl_8(x: uint(8), n: uint(8)) : uint(8);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_rotl_16(x: uint(16), n: uint(16)) : uint(16);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_rotl_32(x: uint(32), n: uint(32)) : uint(32);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_rotl_64(x: uint(64), n: uint(64)) : uint(64);
 
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_rotr_8(x: uint(8), n: uint(8)) : uint(8);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_rotr_16(x: uint(16), n: uint(16)) : uint(16);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_rotr_32(x: uint(32), n: uint(32)) : uint(32);
+  pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
   extern proc chpl_bitops_rotr_64(x: uint(64), n: uint(64)) : uint(64);
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1858,6 +1858,8 @@ module Random {
     proc pcg_rotr_32(value:uint(32), rot:uint(32)):uint(32)
     {
       // having trouble using BitOps...
+      pragma "fn synchronization free"
+      pragma "codegen for CPU and GPU"
       extern proc chpl_bitops_rotr_32(x: uint(32), n: uint(32)) : uint(32);
 
       var ret = chpl_bitops_rotr_32(value, rot);

--- a/test/constrained-generics/random/MyRandom.chpl
+++ b/test/constrained-generics/random/MyRandom.chpl
@@ -1713,6 +1713,8 @@ module MyRandom {
     proc pcg_rotr_32(value:uint(32), rot:uint(32)):uint(32)
     {
       // having trouble using BitOps...
+      pragma "fn synchronization free"
+      pragma "codegen for CPU and GPU"
       extern proc chpl_bitops_rotr_32(x: uint(32), n: uint(32)) : uint(32);
 
       var ret = chpl_bitops_rotr_32(value, rot);


### PR DESCRIPTION
Adds `pragma "fn synchronization free"` to all of the `extern proc` functions in `BitOps.chpl`. This should allow the compiler to infer that these functions do not cause hazards during optimization.

## Summary of changes
- Add `pragma "fn synchronization free"` to all 16 `extern proc`s in BitOps
- Add `pragma` to other uses of the BitOps `extern proc`s
  - These really should just use BitOps, but there are other considerations (not importing standard modules in internal modules?)

## Testing
- local testing of BitOps functions

---

[Reviewed by @mppf]