### PR TITLE
Fix mutable arrays on GPU

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -1747,7 +1747,7 @@ static void localizeCall(CallExpr* call) {
           }
           break;
         } else if (rhs->isPrimitive(PRIM_GET_UNION_ID)) {
-          if (rhs->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
+          if (rhs->get(1)->isWideRef()) {
             insertLocalTemp(rhs->get(1));
           }
           break;
@@ -1764,7 +1764,7 @@ static void localizeCall(CallExpr* call) {
           !call->get(2)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {
         break;
       }
-      if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF) &&
+      if (call->get(1)->isWideRef() &&
           !call->get(2)->isRefOrWideRef()) {
         insertLocalTemp(call->get(1));
       }
@@ -1786,7 +1786,7 @@ static void localizeCall(CallExpr* call) {
       }
       break;
     case PRIM_SET_UNION_ID:
-      if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_REF)) {
+      if (call->get(1)->isWideRef()) {
         insertLocalTemp(call->get(1));
       }
       break;
@@ -1860,7 +1860,7 @@ static void handleLocalBlocks() {
             queue.push(local->body);
             cache.put(fn, local);
             cache.put(local, local); // to handle recursion
-            if (local->retType->symbol->hasFlag(FLAG_WIDE_REF)) {
+            if (local->isWideRef()) {
               CallExpr* ret = toCallExpr(local->body->body.tail);
               INT_ASSERT(ret && ret->isPrimitive(PRIM_RETURN));
               // Capture the return expression in a local temp.

--- a/test/gpu/native/bug22114.chpl
+++ b/test/gpu/native/bug22114.chpl
@@ -1,0 +1,32 @@
+use GPU;
+use CTypes;
+
+param N = 16;
+
+proc main() {
+  on here.gpus[0] {
+    var A: [0..<N] real;
+
+    foreach i in 0..<N {
+	add1(A, i);
+	assertOnGpu();
+    }
+    writeln(A);
+
+    foreach i in 0..<N {
+        add2(A, i);
+        assertOnGpu();
+    }
+    writeln(A);
+  }
+}
+
+inline proc add1(ref A: [] real, idx: int) {
+  // gpuWrite(c"Setting a value on A!");
+  A[idx] = 59;
+}
+
+proc add2(ref A: [] real, idx: int) {
+  // gpuWrite(c"Setting a value on A!");
+  A[idx] = 61;
+}

--- a/test/gpu/native/bug22114.good
+++ b/test/gpu/native/bug22114.good
@@ -1,0 +1,3 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0 59.0
+61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0 61.0


### PR DESCRIPTION
This should fix #22114. It appears as though some of the code in `insertWideReferences` didn't insert local accesses of local variables in enough cases, including when accessing an array. This made GPU procedures that were turned into `local_` versions still have some communication. This, in turn, is unimplemented on the GPU device, so array assignment became a no-op.

@benharsh pointed out that we now have a different way of checking if something is a wide reference (which I believe also consults the `wide-ref` qualifier, and not just an expression's type symbol). Switching logic in `insertWideRefs` to using this check made it pick up and "localize" the array accesses. Thanks Ben!

Reviewed by @benharsh -- thanks!

## Testing
- [x] Added a new GPU test
- [x] `/test/gpu/native`
- [x] `CHPL_COMM=gasnet` paratest 