### PR TITLE
dyno: Fix silenced errors reoccurring in new generations

### DIFF
--- a/frontend/include/chpl/framework/Context-detail.h
+++ b/frontend/include/chpl/framework/Context-detail.h
@@ -234,7 +234,10 @@ struct QueryDependency {
 };
 
 using QueryDependencyVec = std::vector<QueryDependency>;
-using QueryErrorVec = std::vector<owned<ErrorBase>>;
+// The first component is the error emitted by the query, while the second
+// component stores whether or not the error was silenced (i.e. not reported).
+// The query contains all errors, but only prints the non-silenced ones.
+using QueryErrorVec = std::vector<std::pair<owned<ErrorBase>, bool>>;
 
 class QueryMapResultBase {
  public:


### PR DESCRIPTION
The Dyno error silencing system currently ensures that _queries_ that produce errors while errors are being silenced are properly handled. However, if the an error occurs after silencing has started, but before a sub-query has been invoked, that error gets added to the current query's list of errors, and re-reported once the query result is re-used (which occurs when a new generation begins). This PR fixes this bug by tracking whether or not errors stored on a query result have themselves been silenced; this way, while results keep tracking all occurring errors, these errors are not accidentally re-emitted when they shouldn't be.

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest