### PR TITLE
Update GPU AMD runtime to not call HIP deprecated `hipHostAlloc` function (and a few other testing updates)

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -176,11 +176,7 @@ bool chpl_gpu_impl_is_device_ptr(const void* ptr) {
     }
   }
 
-  #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
-    return res.memoryType == hipMemoryTypeDevice;
-  #else
-    return true;
-  #endif
+  return true;
 }
 
 bool chpl_gpu_impl_is_host_ptr(const void* ptr) {
@@ -447,22 +443,12 @@ void* chpl_gpu_mem_array_alloc(size_t size, chpl_mem_descInt_t description,
   return (void*)ptr;
 }
 
-
 void* chpl_gpu_impl_mem_alloc(size_t size) {
-  // This line is a workaround since currently it looks like
-  // `chpl_gpu_ensure_context()` fails in our ROCM runtime when there are
-  // multiple devices. This function (`chpl_gpu_mem_array_alloc`) is called
-  // when initializing the Chapel module for the GPU locale module
-  // (chpl_gpu_device_alloc == true during this time), in this case the intent
-  // is just to return host memory anyway so there's no need to switch
-  // contexts.
-  if(!chpl_gpu_device_alloc) { return chpl_malloc(size); }
-
   chpl_gpu_ensure_context();
 
 #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
   void* ptr = 0;
-  ROCM_CALL(hipHostAlloc(&ptr, size, 0));
+  ROCM_CALL(hipHostMalloc(&ptr, size, 0));
 #else
   hipDeviceptr_t ptr = 0;
   ROCM_CALL(hipMallocManaged(&ptr, size, hipMemAttachGlobal));

--- a/test/gpu/native/atomics.skipif
+++ b/test/gpu/native/atomics.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU_ARCH==gfx908

--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
@@ -20,7 +20,7 @@ extern {
 
   extern char* chpl_gpuBinary;
 
-  static double launchKernel(){
+  static double launchKernel(void){
     CUdevice    device;
     CUmodule    cudaModule;
     CUfunction  function;

--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums_primitive.chpl
@@ -8,7 +8,7 @@ extern {
     assert(err == CUDA_SUCCESS);
   }
 
-  static CUdeviceptr getDeviceBufferPointer(){
+  static CUdeviceptr getDeviceBufferPointer(void){
     double X;
     CUdeviceptr devBufferX;
 


### PR DESCRIPTION
Currently, our AMD version of the GPU runtime library is calling a deprecated function. This generates a warning and causes our nightly test job to fail. The warning message suggests using `hipHostMalloc` instead of `hipHostAlloc`.  However, if I just this change I'll get several test failures.  I noticed while debugging this that for some reason, this changes also changes our result for `chpl_gpu_is_device_ptr`.

If I just change `chpl_gpu_is_device_ptr` to return `true` when using array_on_device mode all the gpu tests pass (for AMD). But I'm not quite sure this is really the right thing to do. We differ the implementation of this function quite a bit between our NVIDIA and AMD implementations of the library as our NVIDIA implementation calls out to several CUDA functions that don't have equivalents in HIP 4.0 (they exist in 5.0 but some our systems use HIP 4.0).

Really, I'm not sure what `chpl_gpu_impl_is_device_ptr` is asking. Is something in unified/managed memory a device pointer?  What about if it's in page-locked memory and accessible by the device? I think this function is really asking is, is this pointer something that can be accessed by the device rather than is this something that's allocated on the device. But I'm not totally sure.  @e-kayrakli, can you take a look at this and comment?

While there I also removed some code from `chpl_gpu_impl_mem_alloc` that I think is no longer necessary (the one about needing a workaround for chpl_gpu_ensure_context, which I think is no longer needed as of https://github.com/chapel-lang/chapel/pull/22258.

And also while there I added a `.skipif` for `atomics.chpl` when `CHPL_GPU_ARCH==gfx908`. This test is triggering a kernel panic on one of our test machines that happens to have that as a GPU. We need to investigate why this is but in the meantime it'd be best to avoid running it there.

And finally while I'm at it, it looks like with the newest LLVM we'll get an "error: a function declaration without a prototype is deprecated in all versions of C" message if you have a function prototype that doesn't take any arguments when what you really want is `void` (e.g. something like `void foo()` instead of `void foo(void)`. This causes our addNums test to fail so I've updated it.

* [ ] Paratest GPU NVIDIA AOD
* [ ] Paratest GPU AMD AOD
* [ ] Paratest GPU NVIDIA
* [ ] Paratest GPU AMD