### PR TITLE
Update GPU test to not fail due to internal use of newly unstable 'allocate' function

### DIFF
--- a/test/gpu/native/jacobi/flags-warn-unstable-internal.good
+++ b/test/gpu/native/jacobi/flags-warn-unstable-internal.good
@@ -2,6 +2,9 @@ warning: The prototype GPU support implies --no-checks. This may impact debuggab
 $CHPL_HOME/modules/internal/ChapelStandard.chpl:53: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:29: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
 $CHPL_HOME/modules/internal/ChapelBase.chpl:57: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:669: In function 'warmupRuntime':
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:672: warning: 'allocate' is unstable, and may be renamed or moved
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:674: warning: 'deallocate' is unstable, and may be renamed or moved
 on GPU:
 1.0 1.20906 2.19525 2.9034 3.5552 4.01125 4.21599 4.10448 3.62297 2.85669 1.60226 1.0
 on CPU:


### PR DESCRIPTION
This PR (https://github.com/chapel-lang/chapel/pull/22358) updated the internal `ChapelLocale.chpl` file to use `allocate` in place of `c_malloc`. `allocate` is a new and unstable function.


With this change I now see our `gpu/native/jacobi/flags.chpl` test fails when using compopts: 3 (passing `--warn-unstable-internal`). Specifically I see:

> $CHPL_HOME/modules/internal/ChapelLocale.chpl:672: warning: 'allocate' is unstable, and may be renamed or moved
> $CHPL_HOME/modules/internal/ChapelLocale.chpl:674: warning: 'deallocate' is unstable, and may be renamed or moved

So in this PR I just update the `.good` file.

FYI: @riftEmber, can you take a quick look. I assume we don't have a stable alternative so updating the .good file should be the right thing to do. I'm going to submit this so it doesn't fail our nightly tests.
