### PR TITLE
Fix nightly GPU ChOP testing to not timeout on git clone

### DIFF
--- a/util/cron/test-perf.gpu-cuda.bash
+++ b/util/cron/test-perf.gpu-cuda.bash
@@ -13,7 +13,5 @@ export CHPL_TEST_PERF_CONFIG_NAME='gpu'
 source $CWD/common-perf.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-cuda"
 
-export CHOP_URL="git@github.com:tcarneirop/ChOp.git"
-
 nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5 -startdate 07/15/22"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Our nightly GPU ChOp test is timing out when trying to clone from GitHub. The fix is to simply use an https based URL. The script that checks this repos out defaults to using an `https` based URL unless it gets overwritten by an explicitly set by a `$CHOP_URL` environment variable. This is what our cron script for the nightly job was doing so I just removed it being explicitly set (there's no need to override it the https based default is what we want).