### PR TITLE
Deprecate non-reusable barriers and barrier.check in favor of barrier.pending

### DIFF
--- a/modules/standard/Collectives.chpl
+++ b/modules/standard/Collectives.chpl
@@ -189,7 +189,7 @@ module Collectives {
       return !bar.check();
     }
 
-    @deprecated(notes="'barrier.check()' is deprecated, please use 'barrier.pending()' instead")
+    @deprecated(notes="'barrier.check()' is deprecated, please use '!barrier.pending()' instead")
     inline proc check(): bool {
       return bar.check();
     }

--- a/modules/standard/Collectives.chpl
+++ b/modules/standard/Collectives.chpl
@@ -95,7 +95,7 @@ module Collectives {
        :arg reusable: Incur some extra overhead to allow reuse of this barrier?
 
     */
-    @deprecated(notes="non-reusable barriers are deprecated, please remove the 'reusable' argument from this initializer call") 
+    @deprecated(notes="non-reusable barriers are deprecated, please remove the 'reusable' argument from this initializer call")
     proc init(numTasks: int, reusable: bool) {
       if reusable {
         bar = new unmanaged aBarrier(numTasks, reusable=true);

--- a/modules/standard/Collectives.chpl
+++ b/modules/standard/Collectives.chpl
@@ -81,7 +81,6 @@ module Collectives {
     /* Construct a new barrier object.
 
        :arg numTasks: The number of tasks that will use this barrier
-       :arg reusable: Incur some extra overhead to allow reuse of this barrier?
 
     */
     proc init(numTasks: int) {
@@ -184,10 +183,10 @@ module Collectives {
       bar.wait();
     }
 
-    /* Return `true` if `n` tasks have called :proc:`notify`
+    /* Return `true` if fewer than `n` tasks have called :proc:`notify`
      */
     inline proc pending(): bool {
-      return bar.check();
+      return !bar.check();
     }
 
     @deprecated(notes="'barrier.check()' is deprecated, please use 'barrier.pending()' instead")

--- a/modules/standard/Collectives.chpl
+++ b/modules/standard/Collectives.chpl
@@ -81,11 +81,23 @@ module Collectives {
     /* Construct a new barrier object.
 
        :arg numTasks: The number of tasks that will use this barrier
-       :arg barrierType: The barrier implementation to use
        :arg reusable: Incur some extra overhead to allow reuse of this barrier?
 
     */
-    proc init(numTasks: int, reusable: bool = true) {
+    proc init(numTasks: int) {
+      bar = new unmanaged aBarrier(numTasks, reusable=true);
+      isowned = true;
+    }
+
+
+    /* Construct a new barrier object.
+
+       :arg numTasks: The number of tasks that will use this barrier
+       :arg reusable: Incur some extra overhead to allow reuse of this barrier?
+
+    */
+    @deprecated(notes="non-reusable barriers are deprecated, please remove the 'reusable' argument from this initializer call") 
+    proc init(numTasks: int, reusable: bool) {
       if reusable {
         bar = new unmanaged aBarrier(numTasks, reusable=true);
       } else {
@@ -174,6 +186,11 @@ module Collectives {
 
     /* Return `true` if `n` tasks have called :proc:`notify`
      */
+    inline proc pending(): bool {
+      return bar.check();
+    }
+
+    @deprecated(notes="'barrier.check()' is deprecated, please use 'barrier.pending()' instead")
     inline proc check(): bool {
       return bar.check();
     }

--- a/test/deprecated/barrierCheck.chpl
+++ b/test/deprecated/barrierCheck.chpl
@@ -1,0 +1,6 @@
+use Collectives;
+
+var b = new barrier(4);
+
+if b.check() then
+  writeln("check returned true?");

--- a/test/deprecated/barrierCheck.good
+++ b/test/deprecated/barrierCheck.good
@@ -1,0 +1,1 @@
+barrierCheck.chpl:5: warning: 'barrier.check()' is deprecated, please use 'barrier.pending()' instead

--- a/test/deprecated/barrierCheck.good
+++ b/test/deprecated/barrierCheck.good
@@ -1,1 +1,1 @@
-barrierCheck.chpl:5: warning: 'barrier.check()' is deprecated, please use 'barrier.pending()' instead
+barrierCheck.chpl:5: warning: 'barrier.check()' is deprecated, please use '!barrier.pending()' instead

--- a/test/deprecated/barrierReusable.chpl
+++ b/test/deprecated/barrierReusable.chpl
@@ -1,0 +1,3 @@
+use Collectives;
+
+var b = new barrier(4, true);

--- a/test/deprecated/barrierReusable.good
+++ b/test/deprecated/barrierReusable.good
@@ -1,0 +1,1 @@
+barrierReusable.chpl:3: warning: non-reusable barriers are deprecated, please remove the 'reusable' argument from this initializer call

--- a/test/parallel/taskPar/diten/barrierCheck.chpl
+++ b/test/parallel/taskPar/diten/barrierCheck.chpl
@@ -9,14 +9,14 @@ proc check(b: barrier) {
       b.notify();
     } else {
       var spinCount = 0;
-      writeln(b.check()); // false
+      writeln(!b.pending()); // false
       b.notify();
 
       /* wait until all tasks have notified */
-      while !b.check() {
+      while b.pending() {
         spinCount += 1;
       }
-      writeln(b.check()); // true
+      writeln(!b.pending());
       if printSpinCount then
         writeln(spinCount);
     }


### PR DESCRIPTION
Make changes agreed to by the barriers ad-hoc sub team. Deprecate non-reusable
barriers and replace the barrier.check function with barrier.pending.

Add tests for the new deprecation and update the one test that had a problem
with this.