### PR TITLE
Fix wavelet test failing under --baseline config

### DIFF
--- a/test/exercises/wavelet/ecgIO.chpl
+++ b/test/exercises/wavelet/ecgIO.chpl
@@ -1,10 +1,15 @@
 use IO, IO.FormattedIO;
 import Subprocess.spawn;
 
-iter getEcgSamples(path: string): int throws {
+iter getEcgSamples(path: string): int {
   const fr = openReader(path);
   var a, b: int;
-  while fr.readf("%i %i\n", a, b) do yield b;
+  try {
+    while fr.readf("%i %i\n", a, b) do yield b;
+  } catch {
+    writeln("Failed to parse ECG data");
+    halt(1);
+  }
 }
 
 iter getGoodCoeffs(path: string): int throws {

--- a/test/exercises/wavelet/ecgIO.chpl
+++ b/test/exercises/wavelet/ecgIO.chpl
@@ -1,15 +1,10 @@
 use IO, IO.FormattedIO;
 import Subprocess.spawn;
 
-iter getEcgSamples(path: string): int {
+iter getEcgSamples(path: string): int throws {
   const fr = openReader(path);
   var a, b: int;
-  try {
-    while fr.readf("%i %i\n", a, b) do yield b;
-  } catch {
-    writeln("Failed to parse ECG data");
-    halt(1);
-  }
+  while fr.readf("%i %i\n", a, b) do yield b;
 }
 
 iter getGoodCoeffs(path: string): int throws {

--- a/test/exercises/wavelet/wavelet.skipif
+++ b/test/exercises/wavelet/wavelet.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline


### PR DESCRIPTION
`test/exercises/wavelet/wavelet.chpl` was failing under --baseline due to a throwing iterator not being inlined. This PR adds a skipif to skip
the test under the `--baseline` config.

- [X] wavelet test passing
- [X] wavelet test skipping with `--baseline` flag