### PR TITLE
Test failure corrections from new POSIX.mem* procs

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -128,7 +128,7 @@ module ByteBufferHelpers {
 
   inline proc bufferMemcpyLocal(dst: bufferType, src: bufferType, len: int,
                                 dst_off: int=0, src_off: int=0) {
-    memcpy(dst:bufferType+dst_off, src:bufferType+src_off, len:uint(64));
+    memcpy(dst:bufferType+dst_off, src:bufferType+src_off, len.safeCast(c_size_t));
   }
 
   inline proc bufferMemmoveLocal(dst: bufferType, src, len: int,

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1105,7 +1105,7 @@ module ChapelBase {
       if safeMul(numElems, elemWidthInBytes) {
         const numBytes = numElems * elemWidthInBytes;
         const shiftedPtr = _ddata_shift(eltType, ddata, lo);
-        memset(shiftedPtr:c_void_ptr, fill, numBytes);
+        memset(shiftedPtr:c_void_ptr, fill, numBytes.safeCast(c_size_t));
       } else {
         halt('internal error: Unsigned integer overflow during ' +
              'memset of dynamic block');
@@ -1531,7 +1531,7 @@ module ChapelBase {
     } else {
       var src = this,
           dst: uint(w);
-      memcpy(c_ptrTo(dst), c_ptrTo(src), numBytes(t));
+      memcpy(c_ptrTo(dst), c_ptrTo(src), numBytes(t).safeCast(c_size_t));
       return dst;
     }
   }
@@ -1569,7 +1569,7 @@ module ChapelBase {
     } else {
       var src = this,
           dst: real(w);
-      memcpy(c_ptrTo(dst), c_ptrTo(src), numBytes(t));
+      memcpy(c_ptrTo(dst), c_ptrTo(src), numBytes(t).safeCast(c_size_t));
       return dst;
     }
   }

--- a/modules/internal/ChapelHashtable.chpl
+++ b/modules/internal/ChapelHashtable.chpl
@@ -78,13 +78,13 @@ module ChapelHashtable {
       }
       when ArrayInit.serialInit {
         for slot in _allSlots(size) {
-          memset(ptrTo(ret[slot]), 0:uint(8), sizeofElement);
+          memset(ptrTo(ret[slot]), 0:uint(8), sizeofElement.safeCast(c_size_t));
         }
       }
       when ArrayInit.parallelInit {
         // This should match the 'these' iterator in terms of idx->task
         forall slot in _allSlots(size) {
-          memset(ptrTo(ret[slot]), 0:uint(8), sizeofElement);
+          memset(ptrTo(ret[slot]), 0:uint(8), sizeofElement.safeCast(c_size_t));
         }
       }
       when ArrayInit.gpuInit {

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -665,7 +665,7 @@ module Curl {
         var curbase = (ret.vec[ret.curr].iov_base):c_ptr(uint(8));
         var dst = curbase + ret.amt_read;
         var amt = ret.vec[ret.curr].iov_len - ret.amt_read;
-        memcpy(dst, ptr_data, amt);
+        memcpy(dst, ptr_data, amt.safeCast(c_size_t));
         ret.total_read += amt;
         realsize -= amt;
         ptr_data = ptr_data + amt;
@@ -729,7 +729,7 @@ module Curl {
         newbuf = allocate(uint(8), newsize, clear=true);
         if newbuf == nil then
           return 0;
-        memcpy(newbuf, buf.mem, oldsize);
+        memcpy(newbuf, buf.mem, oldsize.safeCast(c_size_t));
         deallocate(buf.mem);
         buf.mem = newbuf;
       }

--- a/test/interop/python/otherPointer.chpl
+++ b/test/interop/python/otherPointer.chpl
@@ -1,7 +1,8 @@
-use CTypes;
+use CTypes, OS.POSIX;
+
 export proc gimmePointer(x: c_ptr(real)) {
   var y = 4.0;
-  c_memcpy(x, c_ptrTo(y), c_sizeof(y.type));
+  memcpy(x, c_ptrTo(y), c_sizeof(y.type));
 }
 
 export proc writeReal(x: real) {

--- a/test/interop/python/otherPointer_int.chpl
+++ b/test/interop/python/otherPointer_int.chpl
@@ -1,7 +1,8 @@
-use CTypes;
+use CTypes, OS.POSIX;
+
 export proc gimmePointer(x: c_ptr(int(64))) {
   var y = 4;
-  c_memcpy(x, c_ptrTo(y), c_sizeof(y.type));
+  memcpy(x, c_ptrTo(y), c_sizeof(y.type));
 }
 
 export proc writeInt(x: int) {

--- a/test/interop/python/otherPointer_int32.chpl
+++ b/test/interop/python/otherPointer_int32.chpl
@@ -1,7 +1,8 @@
-use CTypes;
+use CTypes, OS.POSIX;
+
 export proc gimmePointer(x: c_ptr(int(32))) {
   var y: int(32) = 4;
-  c_memcpy(x, c_ptrTo(y), c_sizeof(y.type));
+  memcpy(x, c_ptrTo(y), c_sizeof(y.type));
 }
 
 export proc writeInt(x: int(32)) {

--- a/test/interop/python/stringAllocated.chpl
+++ b/test/interop/python/stringAllocated.chpl
@@ -1,10 +1,11 @@
-use CTypes;
+use CTypes, OS.POSIX;
+
 export proc g(size: int, ptr: c_ptr(uint(8))): int {
   var s = 'foo';
   if s.numBytes >= size {
     return -1;
   } else {
-    c_memcpy(ptr, s.c_str(): c_void_ptr, s.numBytes);
+    memcpy(ptr, s.c_str(): c_void_ptr, s.numBytes);
     return s.numBytes;
   }
 }

--- a/test/library/packages/Sort/RadixSort/ips4o-like.chpl
+++ b/test/library/packages/Sort/RadixSort/ips4o-like.chpl
@@ -4,6 +4,7 @@ use Sort;
 use Time;
 use Collectives;
 use PeekPoke;
+use CTypes, OS.POSIX;
 
 config const seed = SeedGenerator.oddCurrentTime;
 config const skew = false;
@@ -276,11 +277,11 @@ proc shallowCopy(ref A, dst, src, nElts) {
   //A[dst..#nElts] = A[src..#nElts];
 
     var size = (nElts:c_size_t)*c_sizeof(A.eltType);
-    c_memcpy(c_ptrTo(A[dst]), c_ptrTo(A[src]), size);
+    memcpy(c_ptrTo(A[dst]), c_ptrTo(A[src]), size.safeCast(c_size_t));
     /*
   if A._instance.isDefaultRectangular() {
     var size = (nElts:c_size_t)*c_sizeof(A.eltType);
-    c_memcpy(c_ptrTo(A[dst]), c_ptrTo(A[src]), size);
+    memcpy(c_ptrTo(A[dst]), c_ptrTo(A[src]), size.safeCast(c_size_t));
   } else {
     var ok = chpl__bulkTransferArray(/*dst*/ A._instance, {dst..#nElts},
                                      /*src*/ A._instance, {src..#nElts});
@@ -295,11 +296,11 @@ proc shallowCopy(ref DstA, dst, ref SrcA, src, nElts) {
   //DstA[dst..#nElts] = SrcA[src..#nElts];
 
     var size = (nElts:c_size_t)*c_sizeof(DstA.eltType);
-    c_memcpy(c_ptrTo(DstA[dst]), c_ptrTo(SrcA[src]), size);
+    memcpy(c_ptrTo(DstA[dst]), c_ptrTo(SrcA[src]), size.safeCast(c_size_t));
     /*
   if DstA._instance.isDefaultRectangular() && SrcA._instance.isDefaultRectangular() {
     var size = (nElts:c_size_t)*c_sizeof(DstA.eltType);
-    c_memcpy(c_ptrTo(DstA[dst]), c_ptrTo(SrcA[src]), size);
+    memcpy(c_ptrTo(DstA[dst]), c_ptrTo(SrcA[src]), size.safeCast(c_size_t));
   } else {
     var ok = chpl__bulkTransferArray(/*dst*/ DstA._instance, {dst..#nElts},
                                      /*src*/ SrcA._instance, {src..#nElts});

--- a/test/library/standard/Endian/Endian.chpl
+++ b/test/library/standard/Endian/Endian.chpl
@@ -28,7 +28,7 @@
     and big-endian formats.
  */
 module Endian {
-  use CTypes;
+  use CTypes, OS.POSIX;
 
   private extern proc htole16(x: uint(16)): uint(16);
   private extern proc le16toh(x: uint(16)): uint(16);
@@ -120,108 +120,108 @@ module Endian {
   private proc _hostToLittleEndian(x) where numBytes(x.type) == 2 {
     var a = x;
     var b: uint(16);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = htole16(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _littleEndianToHost(x) where numBytes(x.type) == 2 {
     var a = x;
     var b: uint(16);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = le16toh(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _hostToBigEndian(x) where numBytes(x.type) == 2 {
     var a = x;
     var b: uint(16);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = htobe16(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _bigEndianToHost(x) where numBytes(x.type) == 2 {
     var a = x;
     var b: uint(16);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = be16toh(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _hostToLittleEndian(x) where numBytes(x.type) == 4 {
     var a = x;
     var b: uint(32);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = htole32(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _littleEndianToHost(x) where numBytes(x.type) == 4 {
     var a = x;
     var b: uint(32);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = le32toh(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _hostToBigEndian(x) where numBytes(x.type) == 4 {
     var a = x;
     var b: uint(32);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = htobe32(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _bigEndianToHost(x) where numBytes(x.type) == 4 {
     var a = x;
     var b: uint(32);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = be32toh(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _hostToLittleEndian(x) where numBytes(x.type) == 8 {
     var a = x;
     var b: uint(64);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = htole64(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _littleEndianToHost(x) where numBytes(x.type) == 8 {
     var a = x;
     var b: uint(64);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = le64toh(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _hostToBigEndian(x) where numBytes(x.type) == 8 {
     var a = x;
     var b: uint(64);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = htobe64(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
 
   private proc _bigEndianToHost(x) where numBytes(x.type) == 8 {
     var a = x;
     var b: uint(64);
-    c_memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
+    memcpy(c_ptrTo(b), c_ptrTo(a), c_sizeof(b.type));
     var converted = be64toh(b);
-    c_memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
+    memcpy(c_ptrTo(a), c_ptrTo(converted), c_sizeof(a.type));
     return a;
   }
     

--- a/test/optimizations/parallelAssign/basicDR.chpl
+++ b/test/optimizations/parallelAssign/basicDR.chpl
@@ -37,7 +37,7 @@ select mode {
   }
   when testMode.serCopy {
     for i in 0..#nIter {
-      c_memcpy(c_ptrTo(B[1]), c_ptrTo(A[1]), n*numBytes(int));
+      memcpy(c_ptrTo(B[1]), c_ptrTo(A[1]), (n*numBytes(int)).safeCast(c_size_t));
     }
   }
   when testMode.parCopy {
@@ -45,7 +45,7 @@ select mode {
       const numTasks = here.maxTaskPar;
       coforall tid in 0..#numTasks {
         var c = chunk(1..n, numTasks, tid);
-        c_memcpy(c_ptrTo(B[c.first]), c_ptrTo(A[c.first]), c.size*numBytes(int));
+        memcpy(c_ptrTo(B[c.first]), c_ptrTo(A[c.first]), (c.size*numBytes(int)).safeCast(c_size_t));
       }
     }
   }

--- a/test/optimizations/parallelAssign/basicDR.chpl
+++ b/test/optimizations/parallelAssign/basicDR.chpl
@@ -1,4 +1,4 @@
-use CTypes;
+use CTypes, OS.POSIX;
 use Time;
 use RangeChunk;
 


### PR DESCRIPTION
This PR fixes some fallout from https://github.com/chapel-lang/chapel/pull/22381:

- Python interop tests now use the new `POSIX.memcpy` instead of the deprecated `c_memcpy`
- internal uses of new `mem*` procs now safecast the size argument to `c_size_t` to avoid compilation failures on 32-bit systems
- Endianness tests now use `POSIX.memcpy`

testing:
- [x] python interop tests passing
- [x] building on 32-bit system
- [x] release/examples/* tests passing on 32-bit
- [x] llvm paratest
- [x] gcc paratest
