### PR TITLE
Add deprecation warning to docs on classes

### DIFF
--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -718,6 +718,11 @@ a ``type-expression`` that results in a class type. Then:
 
             (new owned C()).borrow()
 
+  .. warning::
+
+    ``new borrowed C()`` has been deprecated - use ``(new owned C()).borrow()``
+    instead
+
 -  ``new unmanaged C()`` allocates and initializes an instance that must
    have ``delete`` called on it explicitly to avoid a memory leak. It
    results in something of type ``unmanaged C``.


### PR DESCRIPTION
PR #20589 added a deprecation for creating new classes as `new borrowed`, but our spec still suggests this as an option.

This PR adds a warning to the spec telling users this is deprecated.

Built docs locally and checked them

---

[Reviewed by @daviditen]