### PR TITLE
Use CHPL_LLVM=none for nightly configs testing specific GCC versions

### DIFF
--- a/util/cron/test-linux64-gcc101.bash
+++ b/util/cron/test-linux64-gcc101.bash
@@ -5,6 +5,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
+export CHPL_LLVM=none
+
 source /data/cf/chapel/setup_gcc101.bash     # host-specific setup for target compiler
 
 gcc_version=$(gcc -dumpversion)

--- a/util/cron/test-linux64-gcc112.bash
+++ b/util/cron/test-linux64-gcc112.bash
@@ -5,6 +5,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
+export CHPL_LLVM=none
+
 source /data/cf/chapel/setup_gcc112.bash     # host-specific setup for target compiler
 
 gcc_version=$(gcc -dumpversion)

--- a/util/cron/test-linux64-gcc54.bash
+++ b/util/cron/test-linux64-gcc54.bash
@@ -5,6 +5,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
+export CHPL_LLVM=none
+
 source /data/cf/chapel/setup_gcc54.bash     # host-specific setup for target compiler
 
 gcc_version=$(gcc -dumpversion)

--- a/util/cron/test-linux64-gcc63.bash
+++ b/util/cron/test-linux64-gcc63.bash
@@ -5,6 +5,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
+export CHPL_LLVM=none
+
 source /data/cf/chapel/setup_gcc63.bash     # host-specific setup for target compiler
 
 gcc_version=$(gcc -dumpversion)

--- a/util/cron/test-linux64-gcc73.bash
+++ b/util/cron/test-linux64-gcc73.bash
@@ -5,6 +5,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
+export CHPL_LLVM=none
+
 source /data/cf/chapel/setup_gcc73.bash     # host-specific setup for target compiler
 
 gcc_version=$(gcc -dumpversion)

--- a/util/cron/test-linux64-gcc91.bash
+++ b/util/cron/test-linux64-gcc91.bash
@@ -5,6 +5,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
+export CHPL_LLVM=none
+
 source /data/cf/chapel/setup_gcc91.bash     # host-specific setup for target compiler
 
 gcc_version=$(gcc -dumpversion)


### PR DESCRIPTION
We are in the process of moving all nightly testing dependencies to a Spack install, in which all dependencies (including updated LLVM 15) are built with GCC 12. This is likely to cause failures for the test configs that pin a specific old GCC version, so this PR updates those configs to use `CHPL_LLVM=none`.

In the long term it would be valuable for these configs to run in an environment where their specific GCC version is the system GCC, i.e. in a container/VM. For now, this keeps these configs testing something valuable while being less likely to break due to dependency version changes.

[reviewer info placeholder]

This is a nightly test config change and is not feasible to test manually before tonight's nightly test runs.