### PR TITLE
Skip nightly testing for GPU AMD+AOD tests that are timing out

### DIFF
--- a/test/gpu/native/multiGPU/worksharing.skipif
+++ b/test/gpu/native/multiGPU/worksharing.skipif
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+import os
+print(os.getenv('CHPL_GPU_MEM_STRATEGY') == 'array_on_device' and
+      os.getenv('CHPL_GPU') == 'amd')

--- a/test/gpu/native/studies/shoc/triadchpl.skipif
+++ b/test/gpu/native/studies/shoc/triadchpl.skipif
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+import os
+print(os.getenv('CHPL_GPU_MEM_STRATEGY') == 'array_on_device' and
+      os.getenv('CHPL_GPU') == 'amd')


### PR DESCRIPTION
We have a new test configuration for AMD+AOD testing so it's not unexpected that we have some failing tests.  I want to get things in a stable state where the job is expected to pass and any failure represents a regression.

So for the short-term I'm adding skipif files for these tests.

I'll fork another GH issue to investigate why these tests are failing and decided what our next steps ought to be. (edit see: https://github.com/Cray/chapel-private/issues/4885)