### PR TITLE
Spack load LLVM for linux64-clang nightly test config

### DIFF
--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -5,6 +5,9 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
+# Load LLVM Spack install to get clang in PATH
+$CHPL_DEPS_SPACK_ROOT/bin/spack load llvm
+
 export CHPL_HOST_COMPILER=clang
 export CHPL_TARGET_COMPILER=clang
 

--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
 # Load LLVM Spack install to get clang in PATH
-$CHPL_DEPS_SPACK_ROOT/bin/spack load llvm
+eval `$CHPL_DEPS_SPACK_ROOT/bin/spack load --sh   llvm`
 
 export CHPL_HOST_COMPILER=clang
 export CHPL_TARGET_COMPILER=clang

--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -7,6 +7,8 @@ source $CWD/common.bash
 
 # Load LLVM Spack install to get clang in PATH
 eval `$CHPL_DEPS_SPACK_ROOT/bin/spack load --sh   llvm`
+unset CC
+unset CXX
 
 export CHPL_HOST_COMPILER=clang
 export CHPL_TARGET_COMPILER=clang


### PR DESCRIPTION
While we generally don't want to `spack load llvm` as it causes some unwanted changes to `CC/CXX` environment variables, it is needed for this test as we are using the `clang` provided by that LLVM install.

[reviewer info placeholder]

Nightly test change, cannot feasibly test besides waiting for tonight's run.