### PR TITLE
Stop including gcd by default

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -2354,9 +2354,19 @@ module AutoMath {
     return truncf(x);
   }
 
+  // When removing this deprecated function, be sure to remove chpl_gcd and
+  // move its contents into Math.chpl to reduce the symbols living in this
+  // module.
   /* Returns the greatest common divisor of the integer argument `a` and
      `b`. */
+  pragma "last resort"
+  @deprecated(notes="In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the :mod:`Math` module to call it")
   proc gcd(in a: int,in b: int): int {
+    return chpl_gcd(a, b);
+  }
+
+  @chpldoc.nodoc
+  proc chpl_gcd(in a: int,in b: int): int {
      a = abs(a);
      b = abs(b);
      var r: int;

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -580,6 +580,12 @@ module Math {
     return chpl_tgamma(x);
   }
 
+  /* Returns the greatest common divisor of the integer argument `a` and
+     `b`. */
+  proc gcd(in a: int,in b: int): int {
+    return chpl_gcd(a, b);
+  }
+
   /* Returns the Bessel function of the first kind of order `0` of `x`. */
   inline proc j0(x: real(32)): real(32) {
     return chpl_j0(x);

--- a/test/deprecated/Math/depGcd.chpl
+++ b/test/deprecated/Math/depGcd.chpl
@@ -1,0 +1,17 @@
+writeln(gcd(4,8));
+
+writeln(gcd(2,8));
+
+writeln(gcd(3,8));
+
+writeln(gcd(5,11));
+
+writeln(gcd(4,-8));
+
+writeln(gcd(-4,-8));
+
+writeln(gcd(0,8));
+
+writeln(gcd(4,0));
+
+writeln(gcd(0,0));

--- a/test/deprecated/Math/depGcd.good
+++ b/test/deprecated/Math/depGcd.good
@@ -1,0 +1,18 @@
+depGcd.chpl:1: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depGcd.chpl:3: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depGcd.chpl:5: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depGcd.chpl:7: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depGcd.chpl:9: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depGcd.chpl:11: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depGcd.chpl:13: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depGcd.chpl:15: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+depGcd.chpl:17: warning: In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the Math module to call it
+4
+2
+1
+1
+4
+4
+8
+4
+0

--- a/test/library/standard/Math/testcases_gcd.chpl
+++ b/test/library/standard/Math/testcases_gcd.chpl
@@ -1,3 +1,5 @@
+use Math;
+
 writeln(gcd(4,8));
 
 writeln(gcd(2,8));


### PR DESCRIPTION
In a recent discussion on which symbols in the AutoMath
module should continue being included by default, we
decided to stop including `gcd`.  This change implements
that decision.

<details>

Similar to the previous deprecations along these lines, add
a hidden helper function that both the deprecated version
and the new version can call to maintain their unity. This
version will be removed and its contents migrated into the
new version once the deprecations have been removed.
We did this to avoid causing `AutoMath` to rely on `Math`. 

</details>

Updates one test to use the Math module so that it
continues to work.

Add a new test locking in the deprecation message.

Passed a full paratest with futures