### PR TITLE
Tighten up string operations around setting

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -260,10 +260,11 @@ extern int breakOnID;
 extern int breakOnRemoveID;
 
 extern int fGPUBlockSize;
-extern char fGpuArch[16];
+const int gpuArchNameLen = 16;
+extern char fGpuArch[gpuArchNameLen+1];
 extern bool fGpuPtxasEnforceOpt;
 extern const char* gGpuSdkPath;
-extern char gpuArch[16];
+extern char gpuArch[gpuArchNameLen+1];
 
 extern char stopAfterPass[128];
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -356,10 +356,10 @@ std::vector<std::string> gDynoPrependInternalModulePaths;
 std::vector<std::string> gDynoPrependStandardModulePaths;
 
 int fGPUBlockSize = 0;
-char fGpuArch[16];
+char fGpuArch[gpuArchNameLen+1] = "";
 bool fGpuPtxasEnforceOpt;
 const char* gGpuSdkPath = NULL;
-char gpuArch[16];
+char gpuArch[gpuArchNameLen+1] = "";
 
 chpl::Context* gContext = nullptr;
 std::vector<std::pair<std::string, std::string>> gDynoParams;
@@ -1682,7 +1682,7 @@ static void setGPUFlags() {
     //
     // set up gpuArch
     if (strlen(fGpuArch) > 0) {
-      strncpy(gpuArch, fGpuArch, 16);
+      strncpy(gpuArch, fGpuArch, gpuArchNameLen);
     }
     else {
       if (CHPL_GPU_ARCH != nullptr && strlen(CHPL_GPU_ARCH) == 0) {
@@ -1691,7 +1691,7 @@ static void setGPUFlags() {
                   "for more information");
       }
       else {
-        strncpy(gpuArch, CHPL_GPU_ARCH, 16);
+        strncpy(gpuArch, CHPL_GPU_ARCH, gpuArchNameLen);
       }
     }
   }


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/22322.

My string operations were a bit haphazard that triggered warnings/errors with clang 15. This PR adjusts the string handling for `--gpu-arch` flag in the compiler.

Test:
- [x] gpu/native on NVIDIA

