### PR TITLE
Add [safe]casts in module and test code for allocate size

### DIFF
--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -385,7 +385,7 @@ module AggregationPrimitives {
     // remote locales buffer
     proc cachedAlloc(): c_ptr(elemType) {
       if data == c_nil {
-        const rvf_size = size;
+        const rvf_size = size.safeCast(c_size_t);
         on Locales[loc] do {
           data = allocate(elemType, rvf_size);
         }

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -688,7 +688,7 @@ module DistributedBag {
         halt("DistributedBag Internal Error: Capacity is 0...");
       }
 
-      this.elems = allocate(eltType, capacity);
+      this.elems = allocate(eltType, capacity.safeCast(c_size_t));
       this.cap = capacity;
     }
 

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -478,7 +478,7 @@ module DistributedBag {
 
         // Allocate buffer, which holds the 'excess' elements for redistribution.
         // Then fill it.
-        var buffer = allocate(eltType, excess);
+        var buffer = allocate(eltType, excess.safeCast(c_size_t));
         var bufferOffset = 0;
         for loc in localThis.targetLocales do on loc {
           var average = avg;
@@ -596,7 +596,7 @@ module DistributedBag {
             // Create a snapshot...
             var block = segment.headBlock;
             var bufferSz = segment.nElems.read() : int;
-            var buffer = allocate(eltType, bufferSz);
+            var buffer = allocate(eltType, bufferSz.safeCast(c_size_t));
             var bufferOffset = 0;
 
             while block != nil {
@@ -1191,7 +1191,7 @@ module DistributedBag {
                                 var toSteal = max(distributedBagWorkStealingMinElems, min(mb / sizeof(eltType), targetSegment.nElems.read() * distributedBagWorkStealingRatio)) : int;
 
                                 // Allocate storage...
-                                on stolenWork do stolenWork[loc.id] = (toSteal, allocate(eltType, toSteal));
+                                on stolenWork do stolenWork[loc.id] = (toSteal, allocate(eltType, toSteal.safeCast(c_size_t)));
                                 var destPtr = stolenWork[here.id][1];
                                 targetSegment.transferElements(destPtr, toSteal, stolenWork.locale.id);
                                 targetSegment.releaseStatus();

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -11146,7 +11146,7 @@ private proc chpl_do_format(fmt:?t, args ...?k): t throws
     } catch { /* ignore deferred close error */ }
   }
 
-  var offset:c_size_t = 0;
+  var offset:int = 0;
   {
     var w = try f.writer(locking=false);
     defer {
@@ -11163,7 +11163,7 @@ private proc chpl_do_format(fmt:?t, args ...?k): t throws
     try w.close();
   }
 
-  var buf = allocate(uint(8), offset+1);
+  var buf = allocate(uint(8), (offset+1).safeCast(c_size_t));
   var r = try f.reader(locking=false);
   defer {
     try {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -11146,7 +11146,7 @@ private proc chpl_do_format(fmt:?t, args ...?k): t throws
     } catch { /* ignore deferred close error */ }
   }
 
-  var offset:int = 0;
+  var offset:c_size_t = 0;
   {
     var w = try f.writer(locking=false);
     defer {

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -916,7 +916,8 @@ record regex {
     var last:byteIndex;
     var localText = text.localize();
 
-    var matches = allocate(qio_regex_string_piece_t, nmatches);
+    var matches = allocate(qio_regex_string_piece_t,
+                           nmatches.safeCast(c_size_t));
     defer deallocate(matches);
 
     pos = 0;

--- a/test/arrays/elliot/arrayInitDeinitPerf.chpl
+++ b/test/arrays/elliot/arrayInitDeinitPerf.chpl
@@ -1,6 +1,6 @@
 use Time, CTypes;
 config const size = 40_000_000;
-config const innerSize = 40;
+config const innerSize : c_size_t = 40;
 
 config const printTiming = true;
 

--- a/test/deprecated/string-bytes-factoryFunctions.chpl
+++ b/test/deprecated/string-bytes-factoryFunctions.chpl
@@ -20,7 +20,7 @@ writeln("string factory functions");
   writeln(s_);
 }
 {
-  var ptr = allocate(uint(8), helloBytes.size);
+  var ptr = allocate(uint(8), helloBytes.size:c_size_t);
   for (idx, char) in zip(0..<helloBytes.size, helloBytes) do
     ptr[idx] = char;
   var s = ptr: c_string;
@@ -28,7 +28,7 @@ writeln("string factory functions");
   writeln(s_);
 }
 {
-  var ptr = allocate(uint(8), helloBytes.size);
+  var ptr = allocate(uint(8), helloBytes.size:c_size_t);
   for (idx, char) in zip(0..<helloBytes.size, helloBytes) do
     ptr[idx] = char;
   var s_ = createStringWithOwnedBuffer(ptr, length=helloBytes.size-1, size=helloBytes.size);
@@ -67,7 +67,7 @@ writeln("bytes factory functions");
   writeln(s_);
 }
 {
-  var ptr = allocate(uint(8), helloBytes.size);
+  var ptr = allocate(uint(8), helloBytes.size:c_size_t);
   for (idx, char) in zip(0..<helloBytes.size, helloBytes) do
     ptr[idx] = char;
   var s = ptr: c_string;
@@ -75,7 +75,7 @@ writeln("bytes factory functions");
   writeln(s_);
 }
 {
-  var ptr = allocate(uint(8), helloBytes.size);
+  var ptr = allocate(uint(8), helloBytes.size:c_size_t);
   for (idx, char) in zip(0..<helloBytes.size, helloBytes) do
     ptr[idx] = char;
   var s_ = createBytesWithOwnedBuffer(ptr, length=helloBytes.size-1, size=helloBytes.size);

--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -454,7 +454,7 @@ prototype module DistributedFFT {
     if plan.isValid {
       return plan;
     } else {
-      arr = allocate(arrType, dom.size);
+      arr = allocate(arrType, dom.size.safeCast(c_size_t));
       defer { deallocate(arr); }
       return new FFTWplan(ftType, rank, nnp, howmany, arr,
                           nnp, stride, idist,

--- a/test/runtime/configMatters/mem/align.chpl
+++ b/test/runtime/configMatters/mem/align.chpl
@@ -5,7 +5,7 @@ use CTypes;
 for i in 3..20 {
   const alignment = (1 << i) : uint;
   var ptr = allocate(uint(8), (2*alignment).safeCast(c_size_t),
-                     alignment=alignment);
+                     alignment=alignment.safeCast(c_size_t));
   writeln(alignment, " => ", ptr : c_uintptr : uint % alignment);
   deallocate(ptr);
 }
@@ -13,7 +13,7 @@ for i in 3..20 {
 // try with size = 1
 for i in 3..20 {
   const alignment = (1 << i) : uint;
-  var ptr = allocate(uint(8), 1, alignment=alignment);
+  var ptr = allocate(uint(8), 1, alignment=alignment.safeCast(c_size_t));
   writeln(alignment, " => ", ptr : c_uintptr : uint % alignment);
   deallocate(ptr);
 }

--- a/test/runtime/configMatters/mem/align.chpl
+++ b/test/runtime/configMatters/mem/align.chpl
@@ -4,7 +4,8 @@ use CTypes;
 // try with size = 2*alignment
 for i in 3..20 {
   const alignment = (1 << i) : uint;
-  var ptr = allocate(uint(8), 2*alignment, alignment=alignment);
+  var ptr = allocate(uint(8), (2*alignment).safeCast(c_size_t),
+                     alignment=alignment);
   writeln(alignment, " => ", ptr : c_uintptr : uint % alignment);
   deallocate(ptr);
 }

--- a/test/runtime/configMatters/mem/concurrent-alloc.chpl
+++ b/test/runtime/configMatters/mem/concurrent-alloc.chpl
@@ -1,6 +1,6 @@
 use CTypes, OS.POSIX;
 
-config const size = 256 * 1024 * 1024;
+config const size : c_size_t = 256 * 1024 * 1024;
 config const numTasks = max(here.maxTaskPar, max(int(8)));
 
 config const trials = 3;

--- a/test/runtime/configMatters/mem/testMemApi.chpl
+++ b/test/runtime/configMatters/mem/testMemApi.chpl
@@ -1,11 +1,12 @@
 use CTypes;
 
 // check a couple of sizes can be allocated and freed
-var sizes : 5*c_size_t = (0, 1, 16, 17, 1000);
+var sizes = (0, 1, 16, 17, 1000);
 for size in sizes {
-  var m = allocate(int, size);
-  var c = allocate(int, size, clear=true);
-  var a = allocate(int, size, alignment=8);
+  var sizeAsCSizeT : c_size_t = size.safeCast(c_size_t);
+  var m = allocate(int, sizeAsCSizeT);
+  var c = allocate(int, sizeAsCSizeT, clear=true);
+  var a = allocate(int, sizeAsCSizeT, alignment=8);
   deallocate(m);
   deallocate(a);
   deallocate(c);

--- a/test/runtime/configMatters/mem/testMemApi.chpl
+++ b/test/runtime/configMatters/mem/testMemApi.chpl
@@ -1,7 +1,7 @@
 use CTypes;
 
 // check a couple of sizes can be allocated and freed
-var sizes = (0, 1, 16, 17, 1000);
+var sizes : 5*c_size_t = (0, 1, 16, 17, 1000);
 for size in sizes {
   var m = allocate(int, size);
   var c = allocate(int, size, clear=true);

--- a/test/types/bytes/io/writeread-pattern.chpl
+++ b/test/types/bytes/io/writeread-pattern.chpl
@@ -7,7 +7,7 @@ proc test(byteRange) {
   const byteRange = 0..255;
   const reverseRange = byteRange by -byteRange.stride;
   const nBytes = (byteRange.size + reverseRange.size)*nRepeat;
-  var buf = allocate(uint(8), nBytes+1);
+  var buf = allocate(uint(8), (nBytes+1).safeCast(c_size_t));
 
   var i = 0;
   for r in 0..#nRepeat {

--- a/test/types/bytes/io/writeread-random.chpl
+++ b/test/types/bytes/io/writeread-random.chpl
@@ -1,7 +1,7 @@
 use CTypes;
 use Random, IO;
 
-config const nBytes = 1024;
+config const nBytes : c_size_t = 1024;
 
 // create bytes with random bytes
 var randomStream = createRandomStream(eltType=uint(8));

--- a/test/types/bytes/io/writeread-random.chpl
+++ b/test/types/bytes/io/writeread-random.chpl
@@ -1,11 +1,11 @@
 use CTypes;
 use Random, IO;
 
-config const nBytes : c_size_t = 1024;
+config const nBytes = 1024;
 
 // create bytes with random bytes
 var randomStream = createRandomStream(eltType=uint(8));
-var buf = allocate(uint(8), nBytes+1);
+var buf = allocate(uint(8), (nBytes+1).safeCast(c_size_t));
 for i in 0..#nBytes {
   buf[i] = randomStream.getNext();
 }

--- a/test/types/string/validation/randomByteEscape.chpl
+++ b/test/types/string/validation/randomByteEscape.chpl
@@ -1,14 +1,14 @@
 use CTypes;
 use Random;
 
-config const nBytes : c_size_t = 100000;
+config const nBytes = 100000;
 config const nIterations = 25;
 config const useFactory = false;
 
 var randomStream = createRandomStream(eltType=uint(8));
 for i in 1..nIterations {
   // create bytes with random bytes
-  var buf = allocate(uint(8), nBytes+1);
+  var buf = allocate(uint(8), (nBytes+1).safeCast(c_size_t));
   for i in 0..#nBytes {
     buf[i] = randomStream.getNext();
   }

--- a/test/types/string/validation/randomByteEscape.chpl
+++ b/test/types/string/validation/randomByteEscape.chpl
@@ -1,7 +1,7 @@
 use CTypes;
 use Random;
 
-config const nBytes = 100000;
+config const nBytes : c_size_t = 100000;
 config const nIterations = 25;
 config const useFactory = false;
 


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/22358, which replaced `c_*alloc`s (with `integral` sizes) with `allocate` (with `c_size_t` size). While on 64-bit systems our default `int` can implicitly convert to a `c_size_t`, on 32-bit systems it does not fit, causing a number of test failures. This PR adds casts and `safeCast`s to `c_size_t` as appropriate to fix this on 32-bit systems.

[trivial, not reviewed]

Testing:
- [x] 64-bit paratest
- [x] previously failing tests succeed on 32-bit system