### PR TITLE
Fix a small spec typo on legal int->uint implicit conversions

### DIFF
--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -85,7 +85,7 @@ may result in a loss of precision.
    particularly given that floating point types are approximate by
    nature.
 
-Signed integral types ``int(s)`` can implicitly convert to ``uint(s)``
+Signed integral types ``int(s)`` can implicitly convert to ``uint(t)``
 where ``s <= t``.
 
    *Rationale*.


### PR DESCRIPTION
Fixes a small typo in the "Conversions" spec page.

Previous:
```
Signed integral types ``int(s)`` can implicitly convert to ``uint(s)`` where ``s <= t``.
```
Fixed (`uint(s)`->`uint(t)`):
```
Signed integral types ``int(s)`` can implicitly convert to ``uint(t)`` where ``s <= t``.
```

Checked correctness of the change against the table of legal numeric implicit conversions that follows this section.

[trivial, not reviewed]