### PR TITLE
Run addr2line from the PATH in stack trace handling

### DIFF
--- a/runtime/src/error.c
+++ b/runtime/src/error.c
@@ -69,11 +69,11 @@ static int chpl_unwind_getLineNum(void *addr){
   // We use a little shell script for avoiding the case in which
   // addr2line isn't present
   const char* scriptPreArgs =
-    "if test -x /usr/bin/addr2line; then /usr/bin/addr2line -e ";
+    "if command -v addr2line > /dev/null 2>&1; then addr2line -e ";
   // then the path
   // then space
   // then the address
-  // then
+  // then below to close the 'if'
   const char* scriptPostArgs = "; fi";
 
   // Start the buffer out with the script


### PR DESCRIPTION
This resolves a problem in a nightly testing configuration where /usr/bin/addr2line is too old as compared to the compiler in use (in particular it was giving errors about not supporting dwarf 5). This PR solves the problem by finding `addr2line` from the PATH since in the nightly testing spack configuration, that `addr2line` came with `gcc` and has the required dwarf 5 support.

Reviewed by @jhh67 - thanks!

- [x] addresses failure with test/runtime/stacktrace/stacktrace.chpl on the affected configuration
- [x] full local testing