### PR TITLE
Avoid two spurious warnings with GCC 12

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -323,6 +323,15 @@ WARN_CXXFLAGS += -Wno-use-after-free
 endif
 
 #
+# Avoid a GCC bug when combining -fsanitize=address -Wmaybe-uninitialized
+#
+ifneq ($(CHPL_MAKE_SANITIZE), none)
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -ge 12; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-maybe-uninitialized
+endif
+endif
+
+#
 # 2016/03/28: Help to protect the Chapel compiler from a partially
 # characterized GCC optimizer regression when the compiler is being
 # compiled with gcc 5.X.

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -318,6 +318,7 @@ endif
 # that occur in GCC 12.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 12; echo "$$?"),0)
+RUNTIME_CFLAGS += -Wno-use-after-free
 WARN_CXXFLAGS += -Wno-use-after-free
 endif
 

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -324,6 +324,7 @@ endif
 
 #
 # Avoid a GCC bug when combining -fsanitize=address -Wmaybe-uninitialized
+# As of May 2023, GCC 12 and 13 both had this bug.
 #
 ifneq ($(CHPL_MAKE_SANITIZE), none)
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -ge 12; echo "$$?"),0)


### PR DESCRIPTION
This PR adjusts Makefile.gnu to avoid two spurious warnings with GCC 12.

First, use -Wno-use-after-free for GCC 12 when building the runtime. This is a a follow-up to PR #20199. When working with GCC 12.2, we are seeing spurious warnings-as-errors with realloc (similar to the case from PR #20199). We have already turned off use-after-free warnings from GCC for C++ compiler code due to this issue. This change turns it off for the runtime C code as well.

Second, avoid a GCC bug when combining certain warnings with `-fsanitize=address`. See also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105616 . At present it looks like GCC 13 also has this bug.

Note that these warnings are only in effect with a make command like `make WARNINGS=1` for example.

Reviewed by @lydia-duncan - thanks!

- [x] resolves problem with GCC 12
- [x] full comm=none testing