### PR TITLE
Fix bug causing printchplenv to error with "Command not found" when LLVM not installed

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -845,6 +845,11 @@ def compute_host_link_settings():
     llvm_support_val = get_llvm_support()
     llvm_config = get_llvm_config()
 
+    # If llvm_config is not discoverable (e.g. we're configured to use a system
+    # LLVM and LLVM is not installed or we have an incompatible version
+    # installed) return a dummy value. If necessary, elsewhere in printchplenv
+    # (validate_llvm_config) we will recognize this and present an error to the
+    # user.
     if llvm_config == "" or llvm_config is None:
         return ('', '', None)
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -844,6 +844,10 @@ def compute_host_link_settings():
     llvm_val = get()
     llvm_support_val = get_llvm_support()
     llvm_config = get_llvm_config()
+
+    if llvm_config == "" or llvm_config is None:
+        return ('', '', None)
+
     clang_static_libs = ['-lclangFrontend',
                          '-lclangSerialization',
                          '-lclangDriver',


### PR DESCRIPTION
Currently on my mac if I don't have LLVM installed or I have LLVM 16 installed by homebrew, I get this error message:

```
OSError: command not found:
```

What appears to be happening is that printchplenv tries to compute defaults for various `CHPL_` variables and while trying to compute `CHPL_LLVM_STATIC_DYNAMIC` it calls out to `compute_host_link_settings`, which then tries to determine the path for `llvm-config` and uses that.  If `llvm-config` is not found it errors with that "command not found" error. 

In this PR I have `compute_host_link_settings` exit early and return dummy values if it can't find `llvm-config`. This appears to work and later on I'll get an error like this:

```
Exception: CHPL_LLVM=system but could not find an installed LLVM with one of the supported versions: 15, 14, 13, 12, 11
```

**To reviewers**
I'm not super confident this is the best place to "fix" the problem. It seems like we may have a whack-a-mole sort of issue trying to find all the uses of `chpl-config` and ensuring we handle the "null" value for it, so maybe we should error out when we try and find its path? OTOH, maybe we to avoid erroring out until after we've computed the defaults for all `CHPL_` variables and have some kind of validation step at the end? Arguably, invoking `printchplenv` directly should never error out and we should only be presented with error when trying to run `make` for the compiler or runtime or running `chpl` itself.
