### PR TITLE
Switch bigint serialization to use `mpz_init_set` instead of assign

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4679,7 +4679,7 @@ module BigInteger {
   record __serializeHelper {
     var buff: mpz_t;
     var localeId: chpl_nodeID_t;
-    
+
     proc init(const ref otherBuff, const ref otherLocaleId) {
       this.complete();
       mpz_init_set(this.buff, otherBuff);

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4679,6 +4679,12 @@ module BigInteger {
   record __serializeHelper {
     var buff: mpz_t;
     var localeId: chpl_nodeID_t;
+    
+    proc init(const ref otherBuff, const ref otherLocaleId) {
+      this.complete();
+      mpz_init_set(this.buff, otherBuff);
+      this.localeId = otherLocaleId;
+    }
   }
 
   @chpldoc.nodoc


### PR DESCRIPTION
Previously, the bigint serialization routines were using plain assignment of the extern `mpz` field, which would result in bad memory accesses, since the `mpz` field had not been initialized. Switching to `mpz_init_set` does both the initialization and assignment.

This bug was revealed by https://github.com/Bears-R-Us/arkouda/pull/2437 and a test is added in https://github.com/chapel-lang/chapel/pull/22403 for the `+ scan` over a block distributed array that was triggering this.

- [x] paratest
- [x] paratest gasnet