### PR TITLE
Add worksharingBasic.skipif for nightly AOD+AMD GPU testing config

### DIFF
--- a/test/gpu/native/multiGPU/worksharingBasic.skipif
+++ b/test/gpu/native/multiGPU/worksharingBasic.skipif
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+import os
+print(os.getenv('CHPL_GPU_MEM_STRATEGY') == 'array_on_device' and
+      os.getenv('CHPL_GPU') == 'amd')


### PR DESCRIPTION
Skip workSharingBasic nightly test (that is currently timing out) for GPU AMD+AOD

Looks like there's one more test that should have been added in https://github.com/chapel-lang/chapel/pull/22392 where we added `.skipif` files for several tests in the new GPU AMD+AOD testing configuration.

The missing test was `workSharingBasic.chpl` (in the previous PR we filtered out `worksharing.chpl` but didn't add this one too). I've noted this in https://github.com/Cray/chapel-private/issues/4885 (we need to followup and investigate why this is timing out but for now we want a clean nightly test job).
