### PR TITLE
Fix nightly test scripts that use specific LLVM versions

### DIFF
--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -1,11 +1,9 @@
-# Use latest system LLVM, to use an earlier version pass version number as a
-# parameter to the script.
-source /cray/css/users/chapelu/setup_system_llvm.bash
-# Lie to prevent common.bash adding a newer llvm
-export OFFICIAL_SYSTEM_LLVM=true
-
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
+
+# Use latest system LLVM, to use an earlier version uncomment and pass version
+# number as a parameter to the script.
+# source /cray/css/users/chapelu/setup_system_llvm.bash
 
 export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu

--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -13,14 +13,12 @@ if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then
     export CHPL_SOURCED_BASHRC=true
 fi
 
-if [ -z "${OFFICIAL_SYSTEM_LLVM}" ] ; then
-  if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
-    source /data/cf/chapel/setup_system_llvm.bash
-  elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
-    source /cray/css/users/chapelu/setup_system_llvm.bash
-  elif [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
-    source /cy/users/chapelu/setup_system_llvm.bash
-  fi
+if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+  source /data/cf/chapel/setup_system_llvm.bash
+elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
+  source /cray/css/users/chapelu/setup_system_llvm.bash
+elif [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
+  source /cy/users/chapelu/setup_system_llvm.bash
 fi
 
 if [ -f /data/cf/chapel/setup_cmake_nightly.bash ] ; then

--- a/util/cron/test-linux64-llvm11.bash
+++ b/util/cron/test-linux64-llvm11.bash
@@ -2,11 +2,10 @@
 #
 # Test default configuration on examples only, on linux64, with llvm 11
 
-export OFFICIAL_SYSTEM_LLVM=true
-source /data/cf/chapel/setup_system_llvm.bash 11.0
-
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
+
+source /data/cf/chapel/setup_system_llvm.bash 11
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "11.0.1" ]; then

--- a/util/cron/test-linux64-llvm12.bash
+++ b/util/cron/test-linux64-llvm12.bash
@@ -2,11 +2,10 @@
 #
 # Test default configuration on examples only, on linux64, with llvm 12
 
-export OFFICIAL_SYSTEM_LLVM=true
-source /data/cf/chapel/setup_system_llvm.bash 12
-
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
+
+source /data/cf/chapel/setup_system_llvm.bash 12
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "12.0.1" ]; then

--- a/util/cron/test-linux64-llvm13.bash
+++ b/util/cron/test-linux64-llvm13.bash
@@ -2,11 +2,10 @@
 #
 # Test default configuration on examples only, on linux64, with llvm 13
 
-export OFFICIAL_SYSTEM_LLVM=true
-source /data/cf/chapel/setup_system_llvm.bash 13
-
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
+
+source /data/cf/chapel/setup_system_llvm.bash 13
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "13.0.0" ]; then

--- a/util/cron/test-linux64-llvm14.bash
+++ b/util/cron/test-linux64-llvm14.bash
@@ -2,11 +2,10 @@
 #
 # Test default configuration on examples only, on linux64, with llvm 14
 
-export OFFICIAL_SYSTEM_LLVM=true
-source /data/cf/chapel/setup_system_llvm.bash 14
-
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
+
+source /data/cf/chapel/setup_system_llvm.bash 14
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "14.0.0" ]; then

--- a/util/cron/test-linux64-llvm15.bash
+++ b/util/cron/test-linux64-llvm15.bash
@@ -2,11 +2,10 @@
 #
 # Test default configuration on examples only, on linux64, with llvm 15
 
-export OFFICIAL_SYSTEM_LLVM=true
-source /data/cf/chapel/setup_system_llvm.bash 15
-
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
+
+source /data/cf/chapel/setup_system_llvm.bash 15
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "15.0.0" ]; then

--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -2,15 +2,13 @@
 #
 # Test valgrind-compatible configuration on full suite with valgrind on linux64.
 
-# Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
-# and pretend it's a system llvm to avoid common.bash adding a newer one
-source /cray/css/users/chapelu/setup_system_llvm.bash 13
-export OFFICIAL_SYSTEM_LLVM=true
-
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-valgrind.bash
 source $CWD/common-localnode-paratest.bash
+
+# Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
+source /cray/css/users/chapelu/setup_system_llvm.bash 13
 
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES

--- a/util/cron/test-valgrindexe.bash
+++ b/util/cron/test-valgrindexe.bash
@@ -2,15 +2,13 @@
 #
 # Test valgrind-compatible configuration on full suite with valgrind on linux64.
 
-# Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
-# and pretend it's a system llvm to avoid common.bash adding a newer one
-source /cray/css/users/chapelu/setup_system_llvm.bash 13
-export OFFICIAL_SYSTEM_LLVM=true
-
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-valgrind.bash
 source $CWD/common-localnode-paratest.bash
+
+# Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
+source /cray/css/users/chapelu/setup_system_llvm.bash 13
 
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES


### PR DESCRIPTION
Currently our nightly tests that are locked to use LLVM 11-15 are actually all just using LLVM 15. This is because we first check `CHPL_LLVM_CONFIG` to find our LLVM, but only the script that initially sets the default LLVM (latest install) is actually setting that variable. System LLVM setup scripts have been adjusted to set this variable, including for the old LLVM installs. As the second component of the fix, this PR adjusts old LLVM version loading to happen after `common.bash` pulls in the default LLVM, and override it.

Also removes the `OFFICIAL_SYSTEM_LLVM` variable as it no longer has any use (and wasn't providing the desired effect after test server script changes anyways).

There are more improvements to be made to the `common.bash` script such as eliminating the need to `source ~/.bashrc` and independently load dependencies without the `setup_chpl_deps.bash` script, but I will leave those to a future PR to avoid the risk of breaking things in a second way with human error.

[reviewer info placeholder]