### PR TITLE
Spack load LLVM in perf.chapcs.clang nightly test config

### DIFF
--- a/util/cron/test-perf.chapcs.clang.bash
+++ b/util/cron/test-perf.chapcs.clang.bash
@@ -7,6 +7,11 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $CWD/common-perf.bash
 
+# Load LLVM Spack install to get clang in PATH
+eval `$CHPL_DEPS_SPACK_ROOT/bin/spack load --sh   llvm`
+unset CC
+unset CXX
+
 export CHPL_HOST_COMPILER=clang
 export CHPL_TARGET_COMPILER=clang
 


### PR DESCRIPTION
Similarly to #22393, this test config needs the `clang` provided by the default LLVM install to be available in the `PATH`. This is accomplished by adding a `spack load` for the LLVM install. As in the previous PR, the extraneous `CC` and `CXX` the `load` sets are then `unset`.

[reviewer info placeholder]