### PR TITLE
Use mempcy instead of strncpy, null-terminate manually in `--gpu-arch` handling

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1684,7 +1684,7 @@ static void setGPUFlags() {
     if (strlen(fGpuArch) > 0) {
       // using memcpy and setting the null byte to avoid errors from older GCCs
       memcpy(gpuArch, fGpuArch, gpuArchNameLen);
-      gpuArch[gpuArchNameLen-1] = 0;
+      gpuArch[gpuArchNameLen] = 0;
     }
     else {
       if (CHPL_GPU_ARCH != nullptr && strlen(CHPL_GPU_ARCH) == 0) {
@@ -1696,7 +1696,7 @@ static void setGPUFlags() {
         // using memcpy and setting the null byte to avoid errors from older
         // GCCs
         memcpy(gpuArch, CHPL_GPU_ARCH, gpuArchNameLen);
-        gpuArch[gpuArchNameLen-1] = 0;
+        gpuArch[gpuArchNameLen] = 0;
       }
     }
   }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1682,7 +1682,9 @@ static void setGPUFlags() {
     //
     // set up gpuArch
     if (strlen(fGpuArch) > 0) {
-      strncpy(gpuArch, fGpuArch, gpuArchNameLen);
+      // using memcpy and setting the null byte to avoid errors from older GCCs
+      memcpy(gpuArch, fGpuArch, gpuArchNameLen);
+      gpuArch[gpuArchNameLen-1] = 0;
     }
     else {
       if (CHPL_GPU_ARCH != nullptr && strlen(CHPL_GPU_ARCH) == 0) {
@@ -1691,7 +1693,10 @@ static void setGPUFlags() {
                   "for more information");
       }
       else {
-        strncpy(gpuArch, CHPL_GPU_ARCH, gpuArchNameLen);
+        // using memcpy and setting the null byte to avoid errors from older
+        // GCCs
+        memcpy(gpuArch, CHPL_GPU_ARCH, gpuArchNameLen);
+        gpuArch[gpuArchNameLen-1] = 0;
       }
     }
   }


### PR DESCRIPTION
String operations for handling `--gpu-arch` is still causing trouble with older GCCs. This PR uses `memcpy` and adds null-termination to hopefully avoid the issues. For some reason, I am unable to reproduce the issue, but I am hoping that this will fix.

Test:
- [x] gpu/native/jacobi/jacobi.chpl on NVIDIA