### PR TITLE
Remove warning for change in behavior for zip() being led by unbounded range

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -2526,13 +2526,6 @@ expandForLoop(ForLoop* forLoop) {
       // are in a zippered context, we'll set it up based on this
       // iterator which is presumably the first.
       if (testBlock == NULL) {
-        if (!isBoundedIterator(iterFn) && iterators.n > 1) {
-          USR_WARN(forLoop, "The behavior of zippered serial loops driven by "
-                   "unbounded ranges has been fixed in this release to act "
-                   "as though they were conceptually infinite; to maintain "
-                   "the previous behavior, swap a bounded iterand into the "
-                   "first expression of the 'zip(...)'.");
-        }
         if (isNotDynIter) {
           // note that we have found the first test
           testBlock = buildIteratorCall(NULL, HASMORE, iterators.v[i], children);

--- a/test/deprecated/zipUnbounded.chpl
+++ b/test/deprecated/zipUnbounded.chpl
@@ -1,3 +1,0 @@
-for (i,j) in zip(0.., 1..3) do
-  writeln(i,j);
-

--- a/test/deprecated/zipUnbounded.good
+++ b/test/deprecated/zipUnbounded.good
@@ -1,5 +1,0 @@
-zipUnbounded.chpl:1: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-01
-12
-23
-zipUnbounded.chpl:1: error: zippered iterations have non-equal lengths

--- a/test/deprecated/zipUnbounded.skipif
+++ b/test/deprecated/zipUnbounded.skipif
@@ -1,2 +1,0 @@
-COMPOPTS <= --fast
-COMPOPTS <= --no-checks

--- a/test/types/range/unbounded/test_indefinite1.good
+++ b/test/types/range/unbounded/test_indefinite1.good
@@ -1,5 +1,3 @@
-test_indefinite1.chpl:1: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-test_indefinite1.chpl:11: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
 (2, 1)
 (3, 2)
 (4, 3)

--- a/test/types/range/unbounded/unboundedBoolEnum3.good
+++ b/test/types/range/unbounded/unboundedBoolEnum3.good
@@ -1,5 +1,3 @@
-unboundedBoolEnum3.chpl:12: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-unboundedBoolEnum3.chpl:28: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
 color 2 = red
 color 3 = orange
 color 4 = yellow

--- a/test/types/range/unbounded/zipMismatch-case2-baseline.good
+++ b/test/types/range/unbounded/zipMismatch-case2-baseline.good
@@ -1,6 +1,3 @@
-zipMismatch.chpl:4: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:8: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:12: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
 (250, 1)
 (251, 2)
 (252, 3)

--- a/test/types/range/unbounded/zipMismatch-case2.good
+++ b/test/types/range/unbounded/zipMismatch-case2.good
@@ -1,6 +1,3 @@
-zipMismatch.chpl:4: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:8: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:12: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
 (250, 1)
 (251, 2)
 (252, 3)

--- a/test/types/range/unbounded/zipMismatch-case3-fast.good
+++ b/test/types/range/unbounded/zipMismatch-case3-fast.good
@@ -1,6 +1,3 @@
-zipMismatch.chpl:4: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:8: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:12: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
 (250, 1)
 (251, 2)
 (252, 3)

--- a/test/types/range/unbounded/zipMismatch-case3.good
+++ b/test/types/range/unbounded/zipMismatch-case3.good
@@ -1,6 +1,3 @@
-zipMismatch.chpl:4: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:8: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:12: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
 (250, 1)
 (251, 2)
 zipMismatch.chpl:12: error: zippered iterations have non-equal lengths

--- a/test/types/range/unbounded/zipMismatch.good
+++ b/test/types/range/unbounded/zipMismatch.good
@@ -1,6 +1,3 @@
-zipMismatch.chpl:4: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:8: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
-zipMismatch.chpl:12: warning: The behavior of zippered serial loops driven by unbounded ranges has been fixed in this release to act as though they were conceptually infinite; to maintain the previous behavior, swap a bounded iterand into the first expression of the 'zip(...)'.
 (250, 1)
 (251, 2)
 (252, 3)


### PR DESCRIPTION
This removes the warning that the behavior for serial zippered loops led by unbounded ranges has changed now that the warning has been on for the past two releases.