### PR TITLE
Remove %= on reals

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2077,10 +2077,6 @@ module ChapelBase {
         halt("Attempt to compute a modulus by zero");
     __primitive("%=", lhs, rhs);
   }
-  @deprecated(notes="'%=' is deprecated for 'real' values for the time being because it does not work")
-  inline operator %=(ref lhs:real(?w), rhs:real(w)) {
-    __primitive("%=", lhs, rhs);
-  }
   inline operator %=(ref lhs, rhs)
   where !(isIntegralOrRealType(lhs.type) && isIntegralOrRealType(rhs.type)) {
     lhs = lhs % rhs;

--- a/test/deprecated/modOnReal.chpl
+++ b/test/deprecated/modOnReal.chpl
@@ -1,3 +1,0 @@
-var a, b: real = 2.0;
-a %= b;
-writeln(a);

--- a/test/deprecated/modOnReal.compopts
+++ b/test/deprecated/modOnReal.compopts
@@ -1,1 +1,0 @@
---no-codegen

--- a/test/deprecated/modOnReal.good
+++ b/test/deprecated/modOnReal.good
@@ -1,1 +1,0 @@
-modOnReal.chpl:2: warning: '%=' is deprecated for 'real' values for the time being because it does not work

--- a/test/deprecated/modOnReal.noexec
+++ b/test/deprecated/modOnReal.noexec
@@ -1,1 +1,0 @@
-We're not codegen-ing, so don't execute either


### PR DESCRIPTION
This removes the support for `%=` on reals, which has been deprecated for two releases now and doesn't work anyway (so in retrospect, probably it could've been removed without deprecation...).
