### PR TITLE
Load LLVM 14 when testing Arkouda against 1.30 release

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -53,12 +53,13 @@ if [ -f "$SETUP_PYTHON" ]; then
   source $SETUP_PYTHON
 fi
 
-# test against Chapel release (checking our current test/cron directories)
+export CHPL_WHICH_RELEASE_FOR_ARKOUDA="1.30.0"
+# test against Chapel release (checking out current test/cron directories)
 function test_release() {
   export CHPL_TEST_PERF_DESCRIPTION=release
   export CHPL_TEST_PERF_CONFIGS="release:v,nightly"
   currentSha=`git rev-parse HEAD`
-  git checkout 1.30.0
+  git checkout $CHPL_WHICH_RELEASE_FOR_ARKOUDA
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
   git checkout $currentSha -- $CHPL_HOME/util/test/perf/

--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -8,5 +8,24 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.arkouda.release"
 source $CWD/common-arkouda.bash
 
+if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
+  # Note: Add more cases to the following 'if' whenever we need to test a
+  # release that does not support our latest available LLVM. Cases can be
+  # removed when we no longer care about testing against that release.
+  if [ "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" = "1.30.0" ]; then
+    # use LLVM 14, latest supported by 1.30.0
+    if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+      source /data/cf/chapel/setup_system_llvm.bash 14
+    fi
+  else
+    # Default to using latest LLVM.
+    # (Shouldn't need to set it here, we are already able to access default LLVM)
+    :
+  fi
+else
+  echo "CHPL_WHICH_RELEASE_FOR_ARKOUDA not set, cannot run Arkouda release test!"
+  exit 1
+fi
+
 test_release
 sync_graphs


### PR DESCRIPTION
`test-perf.chapcs.arkouda.release.bash` tests Arkouda against the latest Chapel release at time of writing (1.30.0), which does not support our now-default LLVM 15. This PR loads LLVM 14 specifically for when we are using this version of Chapel, and does nothing otherwise.

Although it's slightly overdoing it for the task at hand, this also introduces a `CHPL_WHICH_RELEASE_FOR_ARKOUDA` in `common-arkouda.bash` that one would have to modify to test Arkouda against a different Chapel release, to ensure that we do not leave this config permanently testing against LLVM 14 even as new Chapel versions come out.

[reviewer info placeholder]