### PR TITLE
Avoid spurious GCC 12 use-after-free error when compiling generated code

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -320,6 +320,7 @@ endif
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 12; echo "$$?"),0)
 RUNTIME_CFLAGS += -Wno-use-after-free
 WARN_CXXFLAGS += -Wno-use-after-free
+SQUASH_WARN_GEN_CFLAGS += -Wno-use-after-free
 endif
 
 #

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -229,7 +229,9 @@ endif
 # haven't seen problems in practice and run testing with asan, I'm
 # squashing as in the previous case.
 #
-ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -ge 13; echo "$$?"),0)
+# Also skip this warning for GCC 12 since we saw the issue there in
+# some configurations.
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -ge 12; echo "$$?"),0)
 SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overread
 endif
 


### PR DESCRIPTION
Follow-up to PR #22400 to avoid GCC 12's use-after-free error (which has false positives with `realloc`) when compiling the generated code. This PR just extends the `Wno-use-after-free` to apply to compiling the generated C code as well in order to fix problems in asan configurations.

This PR also extends `-Wno-stringop-overread` to GCC 12 since we saw problems with that in gasnet quickstart testing.

Reviewed by @lydia-duncan - thanks

- [x] full local testing