### PR TITLE
Rename `list.pop` to `list.getAndRemove`

### DIFF
--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -1675,7 +1675,7 @@ module ArgumentParser {
           var elems = new list(arrElt.split("=", 1));
           // replace this opt=val with opt val
           var idx = argsList.find(arrElt);
-          argsList.pop(idx);
+          argsList.getAndRemove(idx);
           argsList.insert(idx, elems.toArray());
         }
       }

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -1277,7 +1277,7 @@ module TomlReader {
         }
         else {
           var ptrhold = currentLine;
-          tokenlist.pop(0);
+          tokenlist.getAndRemove(0);
           currentLine = tokenlist[0];
           delete ptrhold;
           return true;
@@ -1327,11 +1327,11 @@ module TomlReader {
     }
 
     proc skip() {
-      A.pop(0);
+      A.getAndRemove(0);
     }
 
     proc next() {
-      var toke = A.pop(0);
+      var toke = A.getAndRemove(0);
       return toke;
     }
 

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1237,7 +1237,7 @@ module List {
       return this.popBack();
     }
 
-    @deprecated(notes=":proc:`list.pop` is deprecated; please use :proc:`list.getAndRemove` instead.")
+    @deprecated(notes="list.pop(idx) is deprecated; please use :proc:`list.getAndRemove` instead.")
     proc ref pop(idx: int): eltType {
       return this.getAndRemove(idx);
     }

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1185,13 +1185,13 @@ module List {
       if boundsChecking && _size <= 0 {
         if unlockBeforeHalt then
           _leave();
-        boundsCheckHalt("Called \"list.pop\" on an empty list.");
+        boundsCheckHalt("Called \"list.getAndRemove\" on an empty list.");
       }
 
       if boundsChecking && !_withinBounds(idx) {
         if unlockBeforeHalt then
           _leave();
-        const msg = "Index for \"list.pop\" out of bounds: " + idx:string;
+        const msg = "Index for \"list.getAndRemove\" out of bounds: " + idx:string;
         boundsCheckHalt(msg);
       }
 
@@ -1237,6 +1237,11 @@ module List {
       return this.popBack();
     }
 
+    @deprecated(notes=":proc:`list.pop` is deprecated; please use :proc:`list.getAndRemove` instead.")
+    proc ref pop(idx: int): eltType {
+      return this.getAndRemove(idx);
+    }
+
     /*
       Remove the element at the index `idx` from this list and return it. The
       elements at indices after `idx` are shifted one to the left in memory,
@@ -1244,7 +1249,7 @@ module List {
 
       .. warning::
 
-        Popping an element from this list will invalidate any reference to
+        Removing an element from this list will invalidate any reference to
         the element taken while it was contained in this list.
 
       .. warning::
@@ -1259,7 +1264,7 @@ module List {
       :return: The element popped.
       :rtype: `eltType`
     */
-    proc ref pop(idx: int): eltType {
+    proc ref getAndRemove(idx: int): eltType {
       _enter();
       var result = _popAtIndex(idx);
       _leave();

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -239,10 +239,10 @@ proc commonPath(paths: string ...?n): string {
 
   if (flag == 1) {
     for i in pos..prefixList.size-1 by -1 do
-      try! prefixList.pop(i);
+      try! prefixList.getAndRemove(i);
   } else {
     for i in minPathLength..prefixList.size-1 by -1 do
-      try! prefixList.pop(i);
+      try! prefixList.getAndRemove(i);
     // in case all paths are subsets of the longest path thus pos was never
     // updated
   }
@@ -321,10 +321,10 @@ proc commonPath(paths: []): string {
 
   if (flag == 1) {
     for i in pos..prefixList.size-1 by -1 do
-      try! prefixList.pop(i);
+      try! prefixList.getAndRemove(i);
   } else {
     for i in minPathLength..prefixList.size-1 by -1 do
-      try! prefixList.pop(i);
+      try! prefixList.getAndRemove(i);
     // in case all paths are subsets of the longest path thus pos was never
     // updated
   }

--- a/test/deprecated/listPopIdx.chpl
+++ b/test/deprecated/listPopIdx.chpl
@@ -1,0 +1,4 @@
+use List;
+
+var l = new list(0..<10);
+writeln(l.pop(5));

--- a/test/deprecated/listPopIdx.good
+++ b/test/deprecated/listPopIdx.good
@@ -1,2 +1,2 @@
-listPopIdx.chpl:4: warning: list.pop is deprecated; please use list.getAndRemove instead.
+listPopIdx.chpl:4: warning: list.pop(idx) is deprecated; please use list.getAndRemove instead.
 5

--- a/test/deprecated/listPopIdx.good
+++ b/test/deprecated/listPopIdx.good
@@ -1,0 +1,2 @@
+listPopIdx.chpl:4: warning: list.pop is deprecated; please use list.getAndRemove instead.
+5

--- a/test/library/draft/Shlex/Shlex.chpl
+++ b/test/library/draft/Shlex/Shlex.chpl
@@ -155,7 +155,7 @@ module Shlex {
     */
     proc get_token(): string {
       if !this.pushback.isEmpty() {
-        var tok = this.pushback.pop(0);
+        var tok = this.pushback.getAndRemove(0);
         if this.debug >= 1 {
           writeln("shlex: popping token " + tok);
         }

--- a/test/library/standard/List/perf/listBenchmark1.chpl
+++ b/test/library/standard/List/perf/listBenchmark1.chpl
@@ -100,7 +100,7 @@ class PopFromFront: Test {
   // Use a smaller value for N because PopFront is O(n**2).
   override proc setup() { _lst = createList(n1); }
   override proc test() {
-    while !_lst.isEmpty() do _lst.pop(0);
+    while !_lst.isEmpty() do _lst.getAndRemove(0);
   }
 }
 

--- a/test/library/standard/List/pop/listAppendPopLeak.chpl
+++ b/test/library/standard/List/pop/listAppendPopLeak.chpl
@@ -10,10 +10,10 @@ proc main() {
   {
     var lines: list(string);
    
-    // Repeated push/pop of the same index should not leak.
+    // Repeated pushBack/getAndRemove of the same index should not leak.
     for i in 1..testIters {
       lines.pushBack(s);
-      lines.pop(0);
+      lines.getAndRemove(0);
     }
   }
 }

--- a/test/library/standard/List/pop/listAppendPopLeakClassInRecord.chpl
+++ b/test/library/standard/List/pop/listAppendPopLeakClassInRecord.chpl
@@ -49,6 +49,6 @@ proc main() {
 
     lines.pushBack(r);
 
-    const elem = lines.pop(0);
+    const elem = lines.getAndRemove(0);
   }
 }

--- a/test/library/standard/List/pop/listPopHaltEmpty.good
+++ b/test/library/standard/List/pop/listPopHaltEmpty.good
@@ -1,1 +1,1 @@
-listPopHaltEmpty.chpl:5: error: halt reached - Called "list.pop" on an empty list.
+listPopHaltEmpty.chpl:5: error: halt reached - Called "list.getAndRemove" on an empty list.

--- a/test/library/standard/List/pop/listPopIndex.chpl
+++ b/test/library/standard/List/pop/listPopIndex.chpl
@@ -8,6 +8,6 @@ for i in 1..testIters do
   lst.pushBack(i);
 
 for i in 1..testIters {
-  const elem = lst.pop(0);
+  const elem = lst.getAndRemove(0);
   assert(elem == i);
 }

--- a/test/library/standard/List/pop/listPopIndexHaltBadIndex.chpl
+++ b/test/library/standard/List/pop/listPopIndexHaltBadIndex.chpl
@@ -7,4 +7,4 @@ var lst: list(int);
 for i in 1..testIters do
   lst.pushBack(i);
 
-const elem = lst.pop(testIters + 1);
+const elem = lst.getAndRemove(testIters + 1);

--- a/test/library/standard/List/pop/listPopIndexHaltBadIndex.good
+++ b/test/library/standard/List/pop/listPopIndexHaltBadIndex.good
@@ -1,1 +1,1 @@
-listPopIndexHaltBadIndex.chpl:10: error: halt reached - Index for "list.pop" out of bounds: 9
+listPopIndexHaltBadIndex.chpl:10: error: halt reached - Index for "list.getAndRemove" out of bounds: 9

--- a/test/library/standard/List/pop/listPopIndexHaltEmpty.good
+++ b/test/library/standard/List/pop/listPopIndexHaltEmpty.good
@@ -1,1 +1,1 @@
-listPopIndexHaltEmpty.chpl:5: error: halt reached - Called "list.pop" on an empty list.
+listPopIndexHaltEmpty.chpl:5: error: halt reached - Called "list.getAndRemove" on an empty list.

--- a/test/library/standard/List/pop/listPopLeakClassInRecord.chpl
+++ b/test/library/standard/List/pop/listPopLeakClassInRecord.chpl
@@ -35,5 +35,5 @@ proc main() {
   for i in 1..testIters do L.pushBack(new R(i));
 
   // A copy of R(4) is leaked.
-  while !L.isEmpty() do L.pop(0);
+  while !L.isEmpty() do L.getAndRemove(0);
 }

--- a/test/release/examples/primers/listOps.chpl
+++ b/test/release/examples/primers/listOps.chpl
@@ -84,15 +84,15 @@ var lst3 = lst2;
 
   .. note::
 
-    The ``list.pop(idx)`` operation is O(n) worst case. If you pop a value
-    from the front of a list, all the other values after it have to be
+    The ``list.getAndRemove(idx)`` operation is O(n) worst case. If you remove
+    a value from the front of a list, all the other values after it have to be
     shifted one to the left.
 */
 
 var count = 0;
 
 while count < 16 {
-  const elem = lst2.pop(0);
+  const elem = lst2.getAndRemove(0);
   lst3.pushBack(elem);
   count += 1;
 }
@@ -231,8 +231,8 @@ for x in lst3 {
 
   .. note::
 
-    Similar to ``list.pop(idx)``, the ``list.insert()`` operation is O(n) in
-    the worst case.
+    Similar to ``list.getAndRemove(idx)``, the ``list.insert()`` operation
+    is O(n) in the worst case.
 
   .. warning::
 

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -499,7 +499,7 @@ proc getSpkgInfo(spec: string, ref dependencies: list(string)): shared Toml thro
         spkgInfo.set(name, getSpkgInfo(dep, depsOfDep));
 
         // remove dep for recursion
-        dependencies.pop(0);
+        dependencies.getAndRemove(0);
       }
       if depList.size > 0 {
         // Temporarily use toArray here to avoid supporting list.

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -318,7 +318,7 @@ private proc createDepTrees(depTree: Toml, ref deps: list(shared Toml), name: st
       var manifests = getManifests(subDeps);
       var dependency = createDepTrees(depTree, manifests, package);
     }
-    deps.pop(0);
+    deps.getAndRemove(0);
   }
   // Use toArray here to avoid making Toml aware of `list`, for now.
   if depList.size > 0 then

--- a/tools/mason/SpecParser.chpl
+++ b/tools/mason/SpecParser.chpl
@@ -134,7 +134,7 @@ private proc parseSpec(ref tokenList: list(string)): 4*string throws {
     throw new owned MasonError("Empty spec in Mason.toml");
   }
   while tokenList.size > 0 {
-    var toke = tokenList.pop(0);
+    var toke = tokenList.getAndRemove(0);
 
     // Package should be first token
     if package == '' {


### PR DESCRIPTION
Deprecates the `list.pop` method in favor of `list.getAndRemove` (see: https://github.com/chapel-lang/chapel/issues/21933#issuecomment-1563624603). Tests and module code are updated accordingly.

- [X] paratest
- [X] gasnet paratest
- [x] inspected built docs

