### PR TITLE
Fix a memory leak in c_ptr_class_type test

### DIFF
--- a/test/types/cptr/c_ptr_class_type.chpl
+++ b/test/types/cptr/c_ptr_class_type.chpl
@@ -36,3 +36,4 @@ writeln(c_ptrTo(mynilableunmanaged):string == (mynilableunmanaged:c_void_ptr):st
 
 
 delete myunmanaged;
+delete mynilableunmanaged;


### PR DESCRIPTION
Fixes a memory leak due to an `unmanaged` not being `delete`'d. Test with memory leak added in #22367.

[trivial test change, not reviewed]