### PR TITLE
Specify environment to Spack load LLVM from

### DIFF
--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
 # Load LLVM Spack install to get clang in PATH
-eval `$CHPL_DEPS_SPACK_ROOT/bin/spack load --sh   llvm`
+eval `$CHPL_DEPS_SPACK_ROOT/bin/spack --env chpl-base-deps load --sh llvm`
 unset CC
 unset CXX
 

--- a/util/cron/test-perf.chapcs.clang.bash
+++ b/util/cron/test-perf.chapcs.clang.bash
@@ -8,7 +8,7 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 source $CWD/common-perf.bash
 
 # Load LLVM Spack install to get clang in PATH
-eval `$CHPL_DEPS_SPACK_ROOT/bin/spack load --sh   llvm`
+eval `$CHPL_DEPS_SPACK_ROOT/bin/spack --env chpl-base-deps load --sh llvm`
 unset CC
 unset CXX
 


### PR DESCRIPTION
This is to allow selecting our latest LLVM which is in the environment, while others not in the environment are ignored. This will fix our `clang`-specific testing configurations which began failing when I installed other older versions of LLVM we are not yet using in Spack.

[trivial, not reviewed]