### PR TITLE
Simplify common.bash and avoid sourcing .bashrc

### DIFF
--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -7,15 +7,23 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/functions.bash
 
 if [ -f /data/cf/chapel/chpl-deps/setup_chpl_deps.bash ] ; then
-  # just load all dependencies via spack
+  # for chapcs/chapvm, just load all dependencies via spack
   source /data/cf/chapel/chpl-deps/setup_chpl_deps.bash
 else
+  # For our internal testing, this is necessary to get the latest version of gcc
+  # on the system.
+  if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then
+      source ~/.bashrc
+      export CHPL_SOURCED_BASHRC=true
+  fi
+
   # load llvm
   if [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
     source /cray/css/users/chapelu/setup_system_llvm.bash
   elif [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
     source /cy/users/chapelu/setup_system_llvm.bash
   fi
+
   # load cmake
   if [ -f /cray/css/users/chapelu/setup_cmake_nightly.bash ] ; then
     source /cray/css/users/chapelu/setup_cmake_nightly.bash

--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -6,27 +6,22 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/functions.bash
 
-# For our internal testing, this is necessary to get the latest version of gcc
-# on the system.
-if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then
-    source ~/.bashrc
-    export CHPL_SOURCED_BASHRC=true
-fi
-
-if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
-  source /data/cf/chapel/setup_system_llvm.bash
-elif [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
-  source /cray/css/users/chapelu/setup_system_llvm.bash
-elif [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
-  source /cy/users/chapelu/setup_system_llvm.bash
-fi
-
-if [ -f /data/cf/chapel/setup_cmake_nightly.bash ] ; then
-  source /data/cf/chapel/setup_cmake_nightly.bash
-elif [ -f /cray/css/users/chapelu/setup_cmake_nightly.bash ] ; then
-  source /cray/css/users/chapelu/setup_cmake_nightly.bash
-elif [ -f /cy/users/chapelu/setup_cmake_nightly.bash ] ; then
-  source /cy/users/chapelu/setup_cmake_nightly.bash
+if [ -f /data/cf/chapel/chpl-deps/setup_chpl_deps.bash ] ; then
+  # just load all dependencies via spack
+  source /data/cf/chapel/chpl-deps/setup_chpl_deps.bash
+else
+  # load llvm
+  if [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
+    source /cray/css/users/chapelu/setup_system_llvm.bash
+  elif [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
+    source /cy/users/chapelu/setup_system_llvm.bash
+  fi
+  # load cmake
+  if [ -f /cray/css/users/chapelu/setup_cmake_nightly.bash ] ; then
+    source /cray/css/users/chapelu/setup_cmake_nightly.bash
+  elif [ -f /cy/users/chapelu/setup_cmake_nightly.bash ] ; then
+    source /cy/users/chapelu/setup_cmake_nightly.bash
+  fi
 fi
 
 log_info "gcc version: $(which gcc)"


### PR DESCRIPTION
For chapcs/chapvm systems, just `source` `setup_chpl_deps.bash` for all dependencies, including avoiding sourcing `.bashrc`.

Once this is merged we should remove the source of `setup_chpl_deps.bash` from the chapelu `.bashrc` on chapcs.

[reviewer info]