### PR TITLE
Check LLVM 15 version using llvm-config

### DIFF
--- a/util/cron/test-linux64-llvm15.bash
+++ b/util/cron/test-linux64-llvm15.bash
@@ -7,12 +7,22 @@ source $CWD/common.bash
 
 source /data/cf/chapel/setup_system_llvm.bash 15
 
-clang_version=$(clang -dumpversion)
-if [ "$clang_version" != "15.0.0" ]; then
-  echo "Wrong clang version"
-  echo "Expected Version: 15.0.0 Actual Version: $clang_version"
+# Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
+llvm_version=$($CHPL_LLVM_CONFIG --version)
+if [ "$llvm_version" != "15.0.4" ]; then
+  echo "Wrong LLVM version"
+  echo "Expected Version: 15.0.4 Actual Version: $llvm_version"
   exit 2
 fi
+
+# This version check no longer works as we do not have clang in the path by
+# default.
+# clang_version=$(clang -dumpversion)
+# if [ "$clang_version" != "15.0.0" ]; then
+#   echo "Wrong clang version"
+#   echo "Expected Version: 15.0.0 Actual Version: $clang_version"
+#   exit 2
+# fi
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm15"
 


### PR DESCRIPTION
Replaces a check using clang, which is not in the path for our Spack install by default. It now uses `llvm-config` as retrieved from `CHPL_LLVM_CONFIG` after sourcing `setup_system_llvm.bash`.

Also changes checked version from `15.0.0` to `15.0.4` since that's what we actually have as latest LLVM 15.

[trivial, not reviewed]