### PR TITLE
Fix typos

### DIFF
--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -174,7 +174,7 @@ static void checkRangeDeprecations(ResolveScope* scope, UseStmt* use,
       USR_FATAL(use,
         "BoundedRangeType is deprecated; please use 'boundKind' instead");
     }
-    // Given the implentation below, it is hard to issue warnings
+    // Given the implementation below, it is hard to issue warnings
     // for individual naked uses of BoundedRangeType's enum constants.
     // Instead, issue a blanket warning here.
     // Note: the scope resolver has already warned about BoundedRangeType.

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -534,7 +534,7 @@ llvm::Type* computePointerElementType(llvm::Value* ptr, Type* chplType) {
   }
 
   // otherwise, try to compute it from the pointer element type.
-  // Note that while this works in simple cases, it is innaccurate for
+  // Note that while this works in simple cases, it is inaccurate for
   // more complex cases like e.g. a GEP of the 1st element in a global
   // of struct type -- that can return the global since the opaque pointer
   // value is the same as an opaque pointer pointing to the 1st field.

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -126,7 +126,7 @@ shouldPropagateOuterArg(Symbol* sym, FnSymbol* parentFn, FnSymbol* calledFn) {
 
   if (sym->hasFlag(FLAG_TYPE_VARIABLE) &&
       !sym->hasFlag(FLAG_HAS_RUNTIME_TYPE))
-    // don't propogate type variables
+    // don't propagate type variables
     return false;
 
   if (shouldAddArgForAlwaysRvf(sym, parentFn))

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -97,7 +97,7 @@ class IdAndFlags {
           equivalent to the single contained Flags value f.
 
       Inserting into the FlagSet automatically tries to perform basic
-      simplificaton to avoid growing the size. */
+      simplification to avoid growing the size. */
   class FlagSet {
    private:
      llvm::SmallVector<Flags, 4> flagVec;

--- a/frontend/lib/framework/TemporaryFileResult.cpp
+++ b/frontend/lib/framework/TemporaryFileResult.cpp
@@ -108,7 +108,7 @@ bool TemporaryFileResult::update(owned<TemporaryFileResult>& keep,
   if (const TemporaryFileResult* t = addin.get()) {
     if (!t->path_.empty()) {
       // 'complete' should be called on a TemporaryFileResult after the
-      // data is stored within the file. If it is forgetten, the query
+      // data is stored within the file. If it is forgotten, the query
       // framework will not correctly handle incremental changes. So,
       // check here in the update function (which will be called when
       // the TemporaryFileResult is the result of a query) that the data

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2458,7 +2458,7 @@ void Resolver::resolveIdentifier(const Identifier* ident,
         // whether the call is valid, but the production scope resolver doesn't
         // care and assumes `ident` points to this parenless function. Setting
         // the toId also helps determine if this is a method call and should
-        // have `this` inserted, as well as wehther or not to turn this
+        // have `this` inserted, as well as whether or not to turn this
         // into a parenless call.
         validateAndSetToId(r, ident, id);
       }

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -148,7 +148,7 @@ static QualifiedType primFieldNumToName(Context* context, const CallInfo& ci) {
   return type;
 }
 
-static QualifiedType primFieldNametoNum(Context* context, const CallInfo& ci) {
+static QualifiedType primFieldNameToNum(Context* context, const CallInfo& ci) {
   auto type = QualifiedType();
   if (ci.numActuals() != 2) return type;
 
@@ -327,7 +327,7 @@ CallResolutionResult resolvePrimCall(Context* context,
       break;
 
     case PRIM_FIELD_NAME_TO_NUM:
-      type = primFieldNametoNum(context, ci);
+      type = primFieldNameToNum(context, ci);
       break;
 
     case PRIM_FIELD_BY_NUM:

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -3080,8 +3080,8 @@ operator :(r: range(?), type t: range(?)) {
   {
     type t = modulus.type;
     var m = modulus;
-    // The extra check for `m != min(t)` is requird to avoid an optimizer
-    // (specially LLVM) determin that `-min(t)` is undefined and inserting
+    // The extra check for `m != min(t)` is required to avoid an optimizer
+    // (especially LLVM) determining that `-min(t)` is undefined and inserting
     // `poison`.
     if isIntType(t) && m < 0 && m != min(t) then m = -m;
 

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1212,7 +1212,7 @@ module CTypes {
 
 
   // since isAnyCPtr is used internally, renaming to chpl_isAnyCPtr this way
-  // the deprecated warning is not propogated across our internal modules by
+  // the deprecated warning is not propagated across our internal modules by
   // using the internal name.
   // After the deprecated function is removed, we can remove the extra
   // definition and just have `isAnyCPtr` as a private nodoc function

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3326,7 +3326,7 @@ inline proc fileWriter.unlock() {
   lock internally before getting the offset)
 
   When 'true', the new behavior is used (i.e., no lock is automatically
-  aquired)
+  acquired)
 */
 config param fileOffsetWithoutLocking = false;
 
@@ -11394,7 +11394,7 @@ proc fileReader.search(re:regex(?)):regexMatch throws
 
 /*  Search for an offset in the fileReader from the current offset matching the
     passed regular expression, possibly pulling out capture groups. If there is
-    a match, leaves the fileReader offset at the begininng of the match. If
+    a match, leaves the fileReader offset at the beginning of the match. If
     there is no match, the fileReader offset will be advanced to the end of the
     fileReader (or end of the file).
 
@@ -11509,7 +11509,7 @@ iter fileReader.matches(re:regex(?), param captures=0,
   }
   commit();
   if i < maxmatches {
-    // we stopped becasuse eof, move to end
+    // we stopped because eof, move to end
     // TODO: is there a better way to get to the end?
     // seeking on an unbounded reader doesn't work
     error = qio_channel_advance_past_byte(false, _channel_internal, 0, /* consume */ false);

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -2834,7 +2834,7 @@ qioerr _qio_buffered_read(qio_channel_t* ch, void* ptr, ssize_t len, ssize_t* am
       err = qbuffer_copyout(&ch->buf, start, end, ptr, gotlen);
       if( err ) return err;
 
-      // advance the ptr, start of aviliabe data, etc.
+      // advance the ptr, start of available data, etc.
       ptr = qio_ptr_add(ptr, gotlen);
       _set_right_mark_start(ch, end.offset);
       ch->cached_cur = qio_ptr_add(ch->cached_cur, gotlen);


### PR DESCRIPTION
Fix typos in

UseStmt.cpp, cg-expr.cpp, flattenFunctions.cpp, prims.cpp,
scope-types.h, TemporaryFileResult.cpp, Resolver.cpp,
ChapelRange.chpl, CTypes.chpl, IO.chpl,
qio.c