### PR TITLE
Remove a .suppressif file for a test that no longer needs it

### DIFF
--- a/test/library/standard/FileSystem/nonUTF8/basic.suppressif
+++ b/test/library/standard/FileSystem/nonUTF8/basic.suppressif
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# Fails when run in the nightly test directory for cygwin64, see issue #4097
-
-if test "$OS" = Windows_NT; then
-  echo 1
-else
-  echo 0
-fi


### PR DESCRIPTION
This test was updated in #21769 in a way that makes it pass in the suppressed configuration. Remove the .suppressif file.