### PR TITLE
Fix COMPOPTS for Socket package tests

### DIFF
--- a/test/library/packages/Socket.precomp
+++ b/test/library/packages/Socket.precomp
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-pkg-config --libs --cflags libevent > $CHPL_HOME/test/library/packages/Socket.compopts

--- a/test/library/packages/Socket/COMPOPTS
+++ b/test/library/packages/Socket/COMPOPTS
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+ccflags=$(pkg-config --cflags libevent)
+ldflags=$(pkg-config --libs libevent)
+
+echo "${ccflags:+--ccflags '$ccflags'} ${ldflags:+--ldflags '$ldflags'}"


### PR DESCRIPTION
Fixes passing `--ccflags` and `--ldflags` to `chpl` for `library/packages/Socket` tests requiring `libevent`.

This appears to have not passed the flags to `chpl` previously, which was not causing problems until the new `libevent` install in Spack. To fix it I copied what the sibling `ZMQ` tests are doing.

[trivial, not reviewed]