### PR TITLE
Remove calls to codegenInvariantStart

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -199,7 +199,6 @@ GenRet SymExpr::codegen() {
     }
 #endif
   }
-  ret.canBeMarkedAsConstAfterStore = var->isConstValWillNotChange();
   return ret;
 }
 
@@ -582,7 +581,6 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
                                   llvm::MDNode* fieldTbaaTypeDescriptor = NULL,
                                   llvm::MDNode* aliasScope = NULL,
                                   llvm::MDNode* noalias = NULL,
-                                  bool addInvariantStart = false,
                                   bool isStoreOfLocalVar = true)
 {
   GenInfo *info = gGenInfo;
@@ -612,9 +610,6 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
     if (loopData.markMemoryOps)
       ret->setMetadata("llvm.access.group", loopData.accessGroup);
   }
-
-  if(addInvariantStart)
-    codegenInvariantStart(val->getType(), ptr);
 
   return ret;
 }
@@ -646,13 +641,10 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
     val.val = v;
   }
 
-  INT_ASSERT(!(ptr.alreadyStored && ptr.canBeMarkedAsConstAfterStore));
-  ptr.alreadyStored = true;
   return codegenStoreLLVM(val.val, ptr.val, valType, ptr.surroundingStruct,
                           ptr.fieldOffset, ptr.fieldTbaaTypeDescriptor,
                           ptr.aliasScope,
                           ptr.noalias,
-                          ptr.canBeMarkedAsConstAfterStore,
                           !ptr.mustPointOutsideOrderIndependentLoop);
 }
 // Create an LLVM load instruction possibly adding
@@ -4078,25 +4070,6 @@ static GenRet codegenCallStaticAddress(CallExpr* call) {
     }
 
     ret = codegenCallExprWithArgs(base, args, fn->cname, fn, nullptr, true);
-
-    #ifdef HAVE_LLVM
-    // Handle setting LLVM invariant on const records after
-    // they are initialized
-    if (fn && (fn->isInitializer() || fn->isCopyInit())) {
-      if (typeNeedsCopyInitDeinit(call->get(1)->typeInfo())) {
-        if (SymExpr* initedSe = toSymExpr(call->get(1))) {
-          if (initedSe->symbol()->isConstValWillNotChange()) {
-            GenRet genSe = args[0];
-            llvm::Value* ptr = genSe.val;
-            INT_ASSERT(ptr);
-            llvm::Type* ptrTy = ptr->getType();
-            INT_ASSERT(ptrTy && ptrTy->isPointerTy());
-            codegenInvariantStart(nullptr, ptr);
-          }
-        }
-      }
-    }
-    #endif
   }
 
   return ret;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2938,9 +2938,6 @@ void nprint_view(GenRet& gen) {
     printf("\n");
   }
 #endif
-  printf("canBeMarkedAsConstAfterStore=%i\n",
-         (int) gen.canBeMarkedAsConstAfterStore);
-  printf("alreadyStored %i\n", (int) gen.alreadyStored);
   if (gen.chplType) {
     TypeSymbol* ts = gen.chplType->symbol;
     printf("chplType=%s (%i)\n", ts->name, ts->id);

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -121,15 +121,6 @@ public:
   void* noalias;
 #endif
 
-  // Used to mark variables as const after they are stored
-  // Specifically: use "llvm.invariant.start"
-  bool canBeMarkedAsConstAfterStore;
-
-  // Mark pointers we already stored to, used to assert
-  // the assumption that store to const memory
-  // is the only store to that memory
-  bool alreadyStored;
-
   // Used for generating LLVM parallel_loop_accesses metadata.
   // Loads/stores to/from loop local stack variables should not be considered
   // for this, so this variable tracks if a pointer must point to something
@@ -161,7 +152,6 @@ public:
   GenRet() : c(), val(NULL), type(NULL), surroundingStruct(NULL),
              fieldOffset(0), fieldTbaaTypeDescriptor(NULL),
              aliasScope(NULL), noalias(NULL),
-             canBeMarkedAsConstAfterStore(false), alreadyStored(false),
              mustPointOutsideOrderIndependentLoop(false),
              chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
 

--- a/test/llvm/dbg-intrinsics/dbg-proc.chpl
+++ b/test/llvm/dbg-intrinsics/dbg-proc.chpl
@@ -1,6 +1,8 @@
+proc foo(const ref x) { }
 proc dbg_proc() {
     // CHECK: call void @llvm.dbg.declare{{.*}}
     const x = 42.42;
+    foo(x);
     var b = 42;
     writeln(x);
     writeln(b);

--- a/test/llvm/with-opaque-ptrs/llvm-invariant/NOTEST
+++ b/test/llvm/with-opaque-ptrs/llvm-invariant/NOTEST
@@ -1,0 +1,1 @@
+Skipping this directory since llvm.invariant.start is disabled

--- a/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-multi-blocks.chpl
+++ b/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-multi-blocks.chpl
@@ -20,9 +20,6 @@ proc mytest_multi_blocks() {
   // CHECK: %test1_chpl = alloca double
   // CHECK-NEXT: %[[REG5:[0-9]+]] = bitcast double* %test1_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG5]])
-  // CHECK: %{{[0-9]+}} = bitcast double* %a_chpl to i8*
-  // CHECK: %{{[0-9]+}} = bitcast double* %b_chpl to i8*
-  // CHECK: %{{[0-9]+}} = bitcast double* %test1_chpl to i8*
   var a = 1.09;
   refidentity(a);
   var b = 11.11;

--- a/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-multi-return.chpl
+++ b/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-multi-return.chpl
@@ -17,7 +17,6 @@ proc mytest_multi_return() {
   // CHECK: %z_chpl = alloca double
   // CHECK-NEXT: %[[REG4:[0-9]+]] = bitcast double* %z_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG4]])
-  // CHECK: %{{[0-9]+}} = bitcast double* %a_chpl to i8*
   const x = 1.09;
   refidentity(x);
   const a = 1.22;

--- a/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-no-return.chpl
+++ b/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-no-return.chpl
@@ -14,7 +14,6 @@ proc mytest_no_return() {
   // CHECK: %c_chpl = alloca double
   // CHECK-NEXT: %[[REG3:[0-9]+]] = bitcast double* %c_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG3]])
-  // CHECK: {{[0-9]+}} = bitcast i64* %a_chpl to i8*
   const a : int = 32;
   refidentity(a);
   var b : real = 3.99;

--- a/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-record.chpl
+++ b/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-record.chpl
@@ -11,7 +11,6 @@ proc mytest_record() {
   // CHECK: %r_chpl = alloca %R_chpl
   // CHECK-NEXT: %[[REG1:[0-9]+]] = bitcast %R_chpl* %r_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 4, i8* %[[REG1]])
-  // CHECK: %{{[0-9]+}} = bitcast %R_chpl* %r_chpl to i8*
   refidentity(r);
   // CHECK: %[[REG2:[0-9]+]] = bitcast %R_chpl* %r_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 4, i8* %[[REG2]])

--- a/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-temporaries.chpl
+++ b/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-temporaries.chpl
@@ -8,7 +8,6 @@ proc mytest_temporaries() {
   // CHECK: %[[TMP:[a-zA-Z0-9_]+]] = alloca i64
   // CHECK: %[[REG1:[0-9]+]] = bitcast i64* %[[TMP]] to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG1]])
-  // CHECK: %{{[0-9]+}} = bitcast i64* %[[TMP]] to i8*
   // CHECK: %[[REG2:[0-9]+]] = bitcast i64* %[[TMP]] to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 8, i8* %[[REG2]])
   return x + y;

--- a/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-throws.chpl
+++ b/test/llvm/with-typed-ptrs/lifetime-intrinsics/lifetime-throws.chpl
@@ -19,8 +19,6 @@ proc mytest_throws(f: string) throws {
   // CHECK-NEXT: %[[REG2:[0-9]+]] = bitcast i64* %b_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG2]])
   refidentity(b);
-  // CHECK: %{{[0-9]+}} = bitcast i64* %a_chpl to i8*
-  // CHECK: %{{[0-9]+}} = bitcast i64* %b_chpl to i8*
   if f.isEmpty() then
     throw new owned EmptyStringError();
   if b != 42 * 2 {

--- a/test/llvm/with-typed-ptrs/llvm-invariant/NOTEST
+++ b/test/llvm/with-typed-ptrs/llvm-invariant/NOTEST
@@ -1,0 +1,1 @@
+Skipping for now since llvm.invariant.start is currently disabled.


### PR DESCRIPTION
This PR adjusts the Chapel code generator to not generate calls to `llvm.invariant.start`. The reason for doing that is that we are seeing test failures for some tests with `--fast` after upgrading to LLVM 15. Generation of `llvm.invariant.start` was initially added in PR #6706. I'd like to fix the problems with these in a better way than just not generating `llvm.invariant.start`, but removing it for now is the short-term solution in case I cannot come up with a fix in a reasonable amount of time. Note that it is still possible to generate a call to one of these with `PRIM_INVARIANT_START` but that is not done in any modules or tests.

Reviewed by @riftEmber - thanks!

- [x] full comm=none --fast testing with a system LLVM 14
- [x] full comm=none --fast testing with a system LLVM 15
- [x] full comm=none testing with a system LLVM 14
- [x] full comm=none testing with a system LLVM 15

<details>

Reproducer:

``` chapel
use Sort;

var d : domain(string);
var A:[0..10] string;


d.add("two");
d.add("zero");

{
  for elem in sorted(d) {
    writeln(elem);
  }
}

writelnSorted(d);

writeln(A);

proc writelnSorted(dom: domain) {
  var first = true;
  writeln(sorted(dom));
  var i = 0;
  for elem in sorted(dom) {
    A[i] = elem;
    if first then {
      first = false;
    } else {
      write(" ");
    }
    i += 1;
  }
  //writeln(" ");
}
```

Fails with -O2 but passes with -O1. I used opt-bisect to narrow down the optimization problem.

```
chpl repro.chpl --fast -o repro1 --mllvm -opt-bisect-limit=-1 --savec=tmp-bad && ./repro1
```

(and doing binary search on bisect pass numbers until finding the boundary of the failure; then I made then make tmp-bad and tmp-good and inspect the disassembled .bc files for differences.)

It's within writelnSorted when a LICM occurs. The LICM'd load is loading the string length from the 1st string. I think that's the problem.

Why is it LICM'd? I *think* that what is happening is that we have a loop that initializes a stack local variable. We emit an llvm.invariant.start after initializing. But, we never emit an llvm.invariant.end after the end of the loop body, even though the stack local variable is used across different loop iterations.

</details>