### PR TITLE
Don't insert too many line numbers

### DIFF
--- a/compiler/include/pass-manager-passes.h
+++ b/compiler/include/pass-manager-passes.h
@@ -276,6 +276,7 @@ class InsertLineNumbers : public PassTU<FnSymbol*, CallExpr*> {
   LineAndFile getLineAndFileForFn(FnSymbol *fn);
 
   std::unordered_map<FnSymbol*, LineAndFile> lineAndFilenameMap;
+  std::unordered_set<CallExpr*> fixedCalls;
 };
 
 #endif

--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -380,6 +380,12 @@ void InsertLineNumbers::process(FnSymbol *fn) {
 // pack), which is determined by `shouldPreferASTLine`
 //
 void InsertLineNumbers::process(FnSymbol *fn, CallExpr* call) {
+  auto pair = fixedCalls.insert(call);
+  if (!pair.second) {
+    // we already visited this call, so stop
+    return;
+  }
+
   if (shouldPreferASTLine(fn)) {
     insertLineNumber(call, makeASTLine(call));
 


### PR DESCRIPTION
I observed a problem (when developing another PR) where insertLineNumbers added 9 line numbers to the calls to `message` in the `Errors` module. Note that this only happens with `CHPL_DEVELOPER` unset (because of the logic in insertLineNumbers).

This PR fixes it by updating the insertLineNumbers pass to track the CallExprs that it has modified in a set and not to modify them twice. Note that PR #19260 added the pass structure to insertLineNumbers. I chose the simplest solution I could imagine here but we might want a different solution as insertLineNumbers / the pass manager evolve. A reasonable alternative would be to check that the call and the called function have matching numbers of arguments.

Reviewed by @riftEmber - thanks!

- [x] full local testing