### PR TITLE
Remove chpl_typeMoveWarning helper from CTypes

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -42,14 +42,6 @@ module CTypes {
   use HaltWrappers;
   public use ChapelSysCTypes;
 
-  @chpldoc.nodoc
-  proc chpl_typeMoveWarning(param name: string, param mod: string,
-                            param newmod: string = "CTypes") {
-    compilerWarning("type '" + name + "' has moved from '" + mod +
-                    "' to '" + newmod + "'; please update your " +
-                    "'use'/'import' statements accordingly.", errorDepth=2);
-  }
-
   /* The Chapel type corresponding to the C 'float' type */
   extern type c_float = real(32);
 
@@ -58,8 +50,6 @@ module CTypes {
 
   /* The Chapel type corresponding to the C 'FILE*' type defined in <stdio.h> */
   extern "_cfile" type c_FILE;
-
-  // Former CPtr contents start here
 
   /*
 


### PR DESCRIPTION
This helper was introduced in https://github.com/chapel-lang/chapel/pull/19262 to make it easier to add a large number of compiler warnings about moved types, but those warnings have all been phased out by now and it is unlikely to see use again. This PR removes the helper, as well as a comment about "former CPtr contents" as it has been over a year since CPtr's contents were moved into CTypes.

[reviewer info placeholder]

Testing:
- [x] paratest