### PR TITLE
Use pkg-config to get libzstd link args

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -778,15 +778,13 @@ def filter_llvm_link_flags(flags):
         # So, if we have '-lzstd', use pkg-config to get the link flags.
         if flag == '-lzstd':
           import third_party_utils
-          try:
-            link_bundled_args, link_system_args = (
-                third_party_utils.pkgconfig_get_system_link_args('libzstd'))
-          except:
-            link_system_args = None
-          if link_system_args:
-              # found something with pkg-config, so use that instead
-              ret.extend(link_system_args)
-              continue
+          if third_party_utils.has_pkgconfig():
+              link_bundled_args, link_system_args = (
+                  third_party_utils.pkgconfig_get_system_link_args('libzstd'))
+              if link_system_args:
+                  # found something with pkg-config, so use that instead
+                  ret.extend(link_system_args)
+                  continue
         # otherwise, append -lzstd as usual
 
         ret.append(flag)

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -776,10 +776,13 @@ def filter_llvm_link_flags(flags):
         # LLVM 15 detects libzstd on some systems but doesn't include
         # the -L path from pkg-config (this can happen in a Spack configuration)
         # So, if we have '-lzstd', use pkg-config to get the link flags.
-        if flag == '-lzstd' and sys.platform != "darwin":
+        if flag == '-lzstd':
           import third_party_utils
-          link_bundled_args, link_system_args = (
-              third_party_utils.pkgconfig_get_system_link_args('libzstd'))
+          try:
+            link_bundled_args, link_system_args = (
+                third_party_utils.pkgconfig_get_system_link_args('libzstd'))
+          except:
+            link_system_args = None
           if link_system_args:
               # found something with pkg-config, so use that instead
               ret.extend(link_system_args)

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -4,7 +4,7 @@ import re
 import chpl_cpu, chpl_arch, chpl_compiler
 import chpl_lib_pic, chpl_locale_model, chpl_platform
 from chpl_home_utils import get_chpl_home, get_chpl_third_party, using_chapel_module
-from utils import error, memoize, run_command, warning
+from utils import error, memoize, run_command, warning, try_run_command
 
 #
 # This is the default unique configuration path which
@@ -256,6 +256,14 @@ def pkgconfig_get_system_version(pkg):
   # run pkg-config to get the version
   version = run_command(['pkg-config', '--modversion', pkg])
   return version.strip()
+
+@memoize
+def has_pkgconfig():
+    (exists, code, _stdout, _stderr) = try_run_command(['pkg-config',
+                                                       '--version'])
+    if exists and code == 0:
+        return True
+    return False
 
 #
 # This returns the default link args for the given third-party package


### PR DESCRIPTION
Use `pkg-config` to get the link arguments for `libzstd`, if possible.

Resolves https://github.com/Cray/chapel-private/issues/4905.