### PR TITLE
Add a skipif for threadring on GPU locale model

### DIFF
--- a/test/release/examples/benchmarks/shootout/threadring.skipif
+++ b/test/release/examples/benchmarks/shootout/threadring.skipif
@@ -1,0 +1,3 @@
+# This test currently hangs at the end of main for the gpu locale model.
+
+CHPL_LOCALE_MODEL == gpu

--- a/test/release/examples/benchmarks/shootout/threadring.suppressif
+++ b/test/release/examples/benchmarks/shootout/threadring.suppressif
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-import os
-
-machine=os.uname()[1].split('.', 1)[0]
-print (machine == 'bradc-lnx')


### PR DESCRIPTION
This test hangs at the end of main for the GPU locale model. Add a .skipif to avoid timeouts for this configuration.

The only differences I see in the AST logs for flat vs. gpu are extra temp variables to store the domain when creating arrays and some extra wide references. I'm not sure how either of these cause it to hang on the program termination lock.