### PR TITLE
Add co-locale support to -nl argument

### DIFF
--- a/runtime/etc/src/mli/chpl-mli-client-runtime.c
+++ b/runtime/etc/src/mli/chpl-mli-client-runtime.c
@@ -102,9 +102,11 @@ char* chpl_mli_pull_connection(void) {
 //
 int chpl_mli_client_launch(int argc, char** argv) {
   int32_t execNumLocales;
+  int32_t execNumLocalesPerNode;
   pid_t pid;
 
-  if (chpl_launch_prep(&argc, argv, &execNumLocales)) {
+  if (chpl_launch_prep(&argc, argv, &execNumLocales,
+                       &execNumLocalesPerNode)) {
     return -1;
   }
 
@@ -114,7 +116,7 @@ int chpl_mli_client_launch(int argc, char** argv) {
     // TODO: Should parent wait here, or in `chpl_library_finalize`?
     if (pid == -1) { return - 1; }
   } else {
-    chpl_launch(argc, argv, execNumLocales);
+    chpl_launch(argc, argv, execNumLocales, execNumLocalesPerNode);
     chpl_mli_exit(0);
   }
 

--- a/runtime/include/arg.h
+++ b/runtime/include/arg.h
@@ -38,6 +38,7 @@ void parseNumLocales(const char* numPtr, int32_t lineno, int32_t filename);
 void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
                int* argc, char* argv[]);
 int32_t getArgNumLocales(void);
+int32_t getArgNumLocalesPerNode(void);
 int32_t chpl_baseUniqueLocaleID(int32_t r);
 int _runInGDB(void);
 int _runInLLDB(void);

--- a/runtime/include/chpl-comm-locales.h
+++ b/runtime/include/chpl-comm-locales.h
@@ -45,6 +45,12 @@ int64_t chpl_comm_default_num_locales(void);
 //
 void chpl_comm_verify_num_locales(int64_t proposedNumLocales);
 
+//
+// Generates an error if the comm layer does not support the specified
+// number of co-locales.
+//
+void chpl_comm_verify_supports_colocales(int64_t numColocales);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -63,15 +63,18 @@ char* chpl_get_enviro_keys(char sep);
 void chpl_compute_real_binary_name(const char* argv0);
 const char* chpl_get_real_binary_wrapper(void);
 const char* chpl_get_real_binary_name(void);
-int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales);
+int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales,
+                     int32_t *c_execNumLocalesPerNode);
 int chpl_launcher_main(int argc, char* argv[]);
 
 void chpl_launcher_get_job_name(char* baseName, char* jobName, int jobLen);
 
+void chpl_launcher_no_colocales_error(const char *name);
 //
 // Defined in launch_<CHPL_LAUNCHER>.c
 //
-int chpl_launch(int argc, char* argv[], int32_t numLocales);
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode);
 int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
                            int32_t lineno, int32_t filename);
 const argDescTuple_t* chpl_launch_get_help(void);

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -32,6 +32,7 @@
 #include "chpl-linefile-support.h"
 #include "config.h"
 #include "error.h"
+#include "chpl-comm-locales.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -241,19 +242,78 @@ void printHelpTable(void) {
 
 
 static int32_t _argNumLocales = 0;
+static int32_t _argNumLocalesPerNode = 1;
 
 void parseNumLocales(const char* numPtr, int32_t lineno, int32_t filename) {
   int invalid;
   char invalidChars[2] = "\0\0";
-  _argNumLocales = c_string_to_int32_t_precise(numPtr, &invalid, invalidChars);
-  if (invalid) {
-    char* message = chpl_glom_strings(3, "\"", numPtr,
-                                      "\" is not a valid number of locales");
-    chpl_error(message, lineno, filename);
+  char *expr = chpl_mem_alloc(strlen(numPtr)+1, CHPL_RT_MD_COMMAND_BUFFER,
+                              lineno, filename);
+  strcpy(expr, numPtr);
+  char *x = strchr(expr, 'x');
+  if (x != NULL) {
+    // parse locale expression of the form MxN where N is optional
+    *x = '\0';
+    char *lpn = x+1;
+    if (*lpn != '\0') {
+      // locales per node (N) was specified
+      _argNumLocalesPerNode = c_string_to_int32_t_precise(lpn, &invalid,
+                                                   invalidChars);
+      if (invalid) {
+        char *message = chpl_glom_strings(3, "\"", lpn,
+                              "\" is not a valid number of locales per node.");
+        chpl_error(message, lineno, filename);
+      }
+      if (_argNumLocalesPerNode < 1) {
+        chpl_error("Number of locales per node must be > 0.",
+                   lineno, filename);
+      }
+      if (_argNumLocalesPerNode > 1) {
+        chpl_env_set("CHPL_RT_LOCALES_PER_NODE", lpn, 1);
+      }
+    } else {
+
+      // N wasn't specified, determine the default from
+      // CHPL_RT_LOCALES_PER_NODE. It is an error if it is not set.
+
+      if (!chpl_env_rt_get("LOCALES_PER_NODE", NULL)) {
+        chpl_error("CHPL_RT_LOCALES_PER_NODE must be set.", lineno, filename);
+      }
+      _argNumLocalesPerNode = (int32_t) chpl_env_rt_get_int("LOCALES_PER_NODE", 1);
+      if (_argNumLocalesPerNode < 1) {
+        chpl_error("CHPL_RT_LOCALES_PER_NODE must be > 0.", lineno, filename);
+      }
+    }
+
+    int32_t numNodes = c_string_to_int32_t_precise(expr, &invalid,
+                                                   invalidChars);
+    if (invalid) {
+      char* message = chpl_glom_strings(3, "\"", expr,
+                                        "\" is not a valid number of nodes.");
+      chpl_error(message, lineno, filename);
+    }
+    if (numNodes < 1) {
+      chpl_error("Number of nodes must be > 0.",
+                 lineno, filename);
+    }
+    _argNumLocales = numNodes * _argNumLocalesPerNode;
+  } else {
+    // parse simple number of locales
+    _argNumLocales = c_string_to_int32_t_precise(expr, &invalid, invalidChars);
+    if (invalid) {
+      char* message = chpl_glom_strings(3, "\"", expr,
+                                        "\" is not a valid number of locales.");
+      chpl_error(message, lineno, filename);
+    }
+    if (_argNumLocales < 1) {
+      chpl_error("Number of locales must be > 0.", lineno, filename);
+    }
+    _argNumLocalesPerNode = (int32_t) chpl_env_rt_get_int("LOCALES_PER_NODE", 1);
+    if (_argNumLocalesPerNode < 1) {
+      chpl_error("CHPL_RT_LOCALES_PER_NODE must be > 0.", lineno, filename);
+    }
   }
-  if (_argNumLocales < 1) {
-    chpl_error("Number of locales must be greater than 0", lineno, filename);
-  }
+  chpl_mem_free(expr, lineno, filename);
 }
 
 int32_t getArgNumLocales(void) {
@@ -262,6 +322,10 @@ int32_t getArgNumLocales(void) {
     retval = _argNumLocales;
   }
   return retval;
+}
+
+int32_t getArgNumLocalesPerNode(void) {
+  return _argNumLocalesPerNode;
 }
 
 

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -757,12 +757,14 @@ void chpl_launcher_get_job_name(char *baseName, char *jobName, int jobLen) {
 }
 
 
-int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales) {
+int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales,
+                     int32_t* c_execNumLocalesPerNode) {
   //
   // This is a user invocation, so parse the arguments to determine
   // the number of locales.
   //
   int32_t execNumLocales;
+  int32_t execNumLocalesPerNode;
   int argc = *c_argc;
 
   // Set up main argument parsing.
@@ -790,6 +792,12 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales) {
   //
   chpl_comm_verify_num_locales(execNumLocales);
 
+  execNumLocalesPerNode = getArgNumLocalesPerNode();
+  if (execNumLocalesPerNode > 1) {
+    chpl_comm_verify_supports_colocales(execNumLocalesPerNode);
+  }
+
+
   //
   // Let the comm layer do any last-minute pre-launch activities it
   // needs to.
@@ -797,6 +805,7 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales) {
   CHPL_COMM_PRELAUNCH(execNumLocales);
 
   *c_execNumLocales = execNumLocales;
+  *c_execNumLocalesPerNode = execNumLocalesPerNode;
   *c_argc = argc;
 
   return 0;
@@ -805,13 +814,15 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales) {
 
 int chpl_launcher_main(int argc, char* argv[]) {
   int32_t execNumLocales;
+  int32_t execNumLocalesPerNode;
 
   //
   // The chpl_launch_prep function calls parseArgs, which modifies argc, so
   // so we need to make sure those changes are visible before calling
   // chpl_launch.
   //
-  if (chpl_launch_prep(&argc, argv, &execNumLocales)) {
+  if (chpl_launch_prep(&argc, argv, &execNumLocales,
+                       &execNumLocalesPerNode)) {
     return -1;
   }
 
@@ -819,7 +830,16 @@ int chpl_launcher_main(int argc, char* argv[]) {
   // Launch the program.
   // This may not return (e.g., if calling chpl_launch_using_exec()).
   //
-  int retval = chpl_launch(argc, argv, execNumLocales);
+  int retval = chpl_launch(argc, argv, execNumLocales, execNumLocalesPerNode);
   chpl_mem_free(chpl_real_binary_name, 0, 0);
   return retval;
+}
+
+void chpl_launcher_no_colocales_error(const char *name) {
+  char msg[100];
+  if (name == NULL) {
+    name = CHPL_LAUNCHER;
+  }
+  snprintf(msg, sizeof(msg), "'%s' launcher does not support co-locales.", name);
+  chpl_error(msg, 0, 0);
 }

--- a/runtime/src/comm/gasnet/comm-gasnet-locales.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-locales.c
@@ -32,5 +32,6 @@ int64_t chpl_comm_default_num_locales(void) {
 }
 
 
-void chpl_comm_verify_num_locales(int64_t proposedNumLocales) {
-}
+void chpl_comm_verify_num_locales(int64_t proposedNumLocales) { }
+
+void chpl_comm_verify_supports_colocales(int64_t numColocales) { }

--- a/runtime/src/comm/none/comm-none-locales.c
+++ b/runtime/src/comm/none/comm-none-locales.c
@@ -33,3 +33,7 @@ void chpl_comm_verify_num_locales(int64_t proposedNumLocales) {
                0, 0);
   }
 }
+
+void chpl_comm_verify_supports_colocales(int64_t numColocales) {
+  chpl_error("Co-locales are not supported by CHPL_COMM layer 'none'", 0, 0);
+}

--- a/runtime/src/comm/ofi/comm-ofi-locales.c
+++ b/runtime/src/comm/ofi/comm-ofi-locales.c
@@ -45,3 +45,7 @@ void chpl_comm_verify_num_locales(int64_t proposedNumLocales) {
   }
 #endif
 }
+
+
+void chpl_comm_verify_supports_colocales(int64_t numColocales) { }
+

--- a/runtime/src/comm/ugni/comm-ugni-locales.c
+++ b/runtime/src/comm/ugni/comm-ugni-locales.c
@@ -34,3 +34,8 @@ int64_t chpl_comm_default_num_locales(void) {
 
 void chpl_comm_verify_num_locales(int64_t proposedNumLocales) {
 }
+
+void chpl_comm_verify_supports_colocales(int64_t numColocales) {
+  chpl_error("Co-locales are not supported by CHPL_COMM layer 'ugni'", 0, 0);
+}
+

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -347,9 +347,13 @@ void initSetValue(const char* varName, const char* value,
     #endif
   }
   if (strcmp(varName, "numLocales") == 0) {
+    char buf[100];
     parseNumLocales(value, lineno, filename);
+    snprintf(buf, sizeof(buf), "%d", getArgNumLocales());
+    configVar->setValue = chpl_glom_strings(1, buf);
+  } else {
+    configVar->setValue = chpl_glom_strings(1, value);
   }
-  configVar->setValue = chpl_glom_strings(1, value);
 }
 
 

--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -98,7 +98,13 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
+
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
+
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("amudprun") + 2;
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   snprintf(cmd, len, "%s/%samudprun", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));

--- a/runtime/src/launch/aprun/launch-aprun.c
+++ b/runtime/src/launch/aprun/launch-aprun.c
@@ -36,7 +36,12 @@
 static const char *_ccArg = NULL;
 static const char* debug = NULL;
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
+
   debug = getenv("CHPL_LAUNCHER_DEBUG");
   return chpl_launch_using_exec("aprun",
                                 chpl_create_aprun_cmd(argc, argv,

--- a/runtime/src/launch/dummy/launch-dummy.c
+++ b/runtime/src/launch/dummy/launch-dummy.c
@@ -63,8 +63,13 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 }
 
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  return chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales),
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
+  return chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales,
+                                      numLocalesPerNode),
                                   argv[0]);
 }
 

--- a/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
+++ b/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
@@ -63,7 +63,11 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(GASNETRUN_LAUNCHER);
+  }
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen(GASNETRUN_LAUNCHER) + 2;
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   snprintf(cmd, len, "%s/%s%s", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), GASNETRUN_LAUNCHER);

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -75,10 +75,15 @@ static char** chpl_launch_create_argv(int argc, char* argv[],
 }
 
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
   chpl_env_set("BSUB_QUIET", "1", 0);
   return chpl_launch_using_exec("bsub",
-                                chpl_launch_create_argv(argc, argv, numLocales),
+                                chpl_launch_create_argv(argc, argv, numLocales,
+                                                        numLocalesPerNode),
                                 argv[0]);
 }
 

--- a/runtime/src/launch/mpirun/launch-mpirun.c
+++ b/runtime/src/launch/mpirun/launch-mpirun.c
@@ -61,8 +61,13 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
   const char *cmd = "mpirun";
+
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
 
   return chpl_launch_using_exec(cmd,
                                 chpl_launch_create_argv(cmd, argc, argv,

--- a/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
+++ b/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
@@ -62,7 +62,12 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 }
 
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
+
   const char *cmd = "mpirun";
   return chpl_launch_using_exec(cmd,
                                 chpl_launch_create_argv(cmd, argc, argv,

--- a/runtime/src/launch/pals/launch-pals.c
+++ b/runtime/src/launch/pals/launch-pals.c
@@ -32,7 +32,12 @@
 static const char *ccArg = NULL;
 
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
+
   char **launchCmd = chpl_create_pals_cmd(argc, argv, numLocales, ccArg);
   return chpl_launch_using_exec(launchCmd[0], launchCmd, argv[0]);
 }

--- a/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
+++ b/runtime/src/launch/pbs-aprun/launch-pbs-aprun.c
@@ -394,9 +394,14 @@ static void chpl_launch_cleanup(void) {
   }
 }
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
   int retcode;
   debug = getenv("CHPL_LAUNCHER_DEBUG");
+
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
 
   if (generate_qsub_script) {
     genQsubScript(argc, argv, numLocales);

--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -199,7 +199,6 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   } else {
       basenamePtr++;
   }
-
   chpl_launcher_get_job_name(basenamePtr, jobName, sizeof(jobName));
 
   chpl_compute_real_binary_name(argv[0]);
@@ -366,12 +365,18 @@ static void chpl_launch_cleanup(void) {
 }
 
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
   int retcode;
 
   debug = getenv("CHPL_LAUNCHER_DEBUG");
 
-  retcode = chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales),
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
+
+  retcode = chpl_launch_using_system(chpl_launch_create_command(argc, argv,
+                                          numLocales),
             argv[0]);
   chpl_launch_cleanup();
   return retcode;

--- a/runtime/src/launch/smp/launch-smp.c
+++ b/runtime/src/launch/smp/launch-smp.c
@@ -26,8 +26,13 @@
 
 // Simple launcher that just sets GASNET_PSHM_NODES and launchers the _real
 
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+int chpl_launch(int argc, char* argv[], int32_t numLocales,
+                int32_t numLocalesPerNode) {
   char baseCommand[4096];
+
+  if (numLocalesPerNode > 1) {
+    chpl_launcher_no_colocales_error(NULL);
+  }
 
   chpl_env_set_uint("GASNET_PSHM_NODES", numLocales, 1);
 

--- a/test/multilocale/numLocales/bradc/printNumLocalesNonIntArg.good
+++ b/test/multilocale/numLocales/bradc/printNumLocalesNonIntArg.good
@@ -1,1 +1,1 @@
-<command-line arg>:1: error: "1e" is not a valid number of locales
+<command-line arg>:1: error: "1e" is not a valid number of locales.

--- a/test/multilocale/numLocales/bradc/printNumLocalesZero.good
+++ b/test/multilocale/numLocales/bradc/printNumLocalesZero.good
@@ -1,1 +1,1 @@
-<command-line arg>:1: error: Number of locales must be greater than 0
+<command-line arg>:1: error: Number of locales must be > 0.

--- a/test/runtime/configMatters/launch/jhh/co-locales/README
+++ b/test/runtime/configMatters/launch/jhh/co-locales/README
@@ -1,0 +1,4 @@
+Tests co-locale functionality as specified by the the -nl argument, Note that
+the functionality of hello.chpl doesn't matter, it is invoked with --dry-run
+so that it doesn't actually run. The tests look for the proper launcher
+arguments in the output.

--- a/test/runtime/configMatters/launch/jhh/co-locales/SKIPIF
+++ b/test/runtime/configMatters/launch/jhh/co-locales/SKIPIF
@@ -1,0 +1,6 @@
+#! /usr/bin/env python3
+
+import os
+
+print(os.getenv('CHPL_TEST_PERF') == 'on' or not os.getenv('CHPL_LAUNCHER').startswith('slurm'))
+

--- a/test/runtime/configMatters/launch/jhh/co-locales/SKIPIF
+++ b/test/runtime/configMatters/launch/jhh/co-locales/SKIPIF
@@ -2,5 +2,5 @@
 
 import os
 
-print(os.getenv('CHPL_TEST_PERF') == 'on' or not os.getenv('CHPL_LAUNCHER').startswith('slurm'))
+print(os.getenv('CHPL_TEST_PERF') == 'on' or os.getenv('CHPL_LAUNCHER') != 'slurm-srun')
 

--- a/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
+++ b/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+"""
+Co-locales command-line argument test.
+Usage: ./co-locales.py.
+The -v flag prints verbose output, the -f flag will cause testing to stop when
+the first test fails.
+"""
+
+import unittest
+import subprocess
+import os
+import sys
+import operator
+from functools import reduce
+
+
+if not 'CHPL_HOME' in os.environ:
+    print('CHPL_HOME is not set')
+    sys.exit(1)
+
+sys.path.append(os.path.join(os.environ['CHPL_HOME'], 'util', 'chplenv'))
+import printchplenv
+
+verbose = False
+skipReason = None
+
+def runCmd(cmd, env=None):
+    if type(cmd) is str:
+        cmd = cmd.split()
+    if env is None:
+        proc = subprocess.run(cmd, text=True, check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    else:
+        proc = subprocess.run(cmd, text=True, check=True, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return proc.stdout
+
+def setup():
+    global skipReason
+    global launcher, comm
+
+    # Get the Chapel configuration
+    printchplenv.compute_all_values()
+    # strip the padding printchplenv puts on some of the keys
+    env = {k.strip():v for k,v in printchplenv.ENV_VALS.items()}
+
+    launcher = env.get('CHPL_LAUNCHER')
+    comm = env.get('CHPL_COMM')
+
+    # Verify Chapel configuration
+    # These tests only run on comm=ofi and slurm-srun
+    launchers = ['slurm-srun', 'slurm-gasnetrun_ibv']
+    if launcher not in launchers:
+        skipReason = "CHPL_LAUNCHER not one of " + str(launchers)
+        return
+    comms = ['ofi', 'gasnet']
+    if comm not in comms:
+        skipReason = "CHPL_COMM not one of " + str(comms)
+        return
+
+class ColocaleArgs(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        global numSockets
+        # Should not be set by default
+        if 'CHPL_RT_LOCALES_PER_NODE' in os.environ:
+            del os.environ['CHPL_RT_LOCALES_PER_NODE']
+
+        # Determine the number of sockets per node
+        cmd = ["sinfo", "--format=%X", "--noheader", "--exact"]
+        partition = os.environ.get('CHPL_LAUNCHER_PARTITION')
+        if partition is not None:
+            cmd += ["--partition", partition]
+            if verbose:
+                print("Partition: ", partition)
+
+        numSockets = int(runCmd(cmd))
+        if numSockets == 1:
+            self.skipTest("Node has only one socket.")
+
+    def setUp(self):
+        if skipReason is not None:
+            self.skipTest(skipReason)
+        self.env = os.environ.copy()
+
+    def runCmd(self, cmd):
+        output = runCmd(cmd, self.env);
+        return output
+
+    def test_00_base(self):
+        """One locale per node"""
+        output = self.runCmd("./hello -nl 4 -v --dry-run")
+        self.assertTrue('--nodes=4' in output or '-N 4' in output)
+        self.assertIn('--ntasks=4', output)
+
+    def test_01_1x1(self):
+        """Still one locale per node"""
+        output = self.runCmd("./hello -nl 1x1 -v --dry-run")
+        self.assertTrue('--nodes=1' in output or '-N 1' in output)
+        self.assertIn('--ntasks=1', output)
+
+    def test_02_3x2(self):
+        """Three nodes, two locales per node"""
+        output = self.runCmd("./hello -nl 3x2 -v --dry-run")
+        self.assertTrue('--nodes=3' in output or '-N 3' in output)
+        self.assertIn('--ntasks=6', output)
+
+    def test_03_1x(self):
+        """One node, locales-per-node defaults to 1"""
+        output = self.runCmd("./hello -nl 1x -v --dry-run")
+        self.assertTrue('--nodes=1' in output or '-N 1' in output)
+        self.assertIn('--ntasks=1', output)
+
+    def test_04_3x(self):
+        """Three nodes, locales-per-node defaults to 1"""
+        output = self.runCmd("./hello -nl 3x -v --dry-run")
+        self.assertTrue('--nodes=3' in output or '-N 3' in output)
+        self.assertIn('--ntasks=3', output)
+
+    def test_05_3x(self):
+        """Three nodes, locales-per-node defaults to 2"""
+        self.env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        output = self.runCmd("./hello -nl 3x -v --dry-run")
+        self.assertTrue('--nodes=3' in output or '-N 3' in output)
+        self.assertIn('--ntasks=6', output)
+
+
+# copied from sub_test.py
+# report an error message and exit
+def Fatal(message):
+    sys.stdout.write('[Error (sub_test): '+message+']\n')
+    magic_exit_code = reduce(operator.add, map(ord, 'CHAPEL')) % 256
+    sys.exit(magic_exit_code)
+
+def getDir(compiler):
+
+    # This code is copied from sub_test.py to ensure we print
+    # the path of the test in the same format so all paths look
+    # the same in the test outputs.
+
+    # Find the base installation
+    #compiler=argv[1]
+    if not os.access(compiler,os.R_OK|os.X_OK):
+        Fatal('Cannot execute compiler \''+compiler+'\'')
+
+    is_chpldoc = compiler.endswith('chpldoc')
+
+    path_to_compiler=os.path.abspath(os.path.dirname(compiler))
+    # Assume chpl binary is 2 directory levels down in the base installation
+    (chpl_base, tmp) = os.path.split(path_to_compiler)
+    (chpl_base, tmp) = os.path.split(chpl_base)
+    chpl_base=os.path.normpath(chpl_base)
+    # sys.stdout.write('CHPL_BASE='+chpl_base+'\n')
+
+    # If $CHPL_HOME is not set, use the base installation of the compiler
+
+    chpl_home=os.getenv('CHPL_HOME', chpl_base);
+    chpl_home=os.path.normpath(chpl_home)
+
+    # Find the test directory
+    testdir=chpl_home+'/test'
+    if os.path.isdir(testdir)==0:
+        testdir=chpl_home+'/examples'
+        if os.path.isdir(testdir)==0:
+            Fatal('Cannot find test directory '+chpl_home+'/test or '+testdir)
+    # Needed for MacOS mount points
+    testdir = os.path.realpath(testdir)
+    # sys.stdout.write('testdir='+testdir+'\n');
+
+    # If user specified a different test directory (e.g. with --test-root flag on
+    # start_test), use it instead.
+    test_root_dir = os.environ.get('CHPL_TEST_ROOT_DIR')
+    if test_root_dir is not None:
+        testdir = test_root_dir
+
+    # Get the current directory (normalize for MacOS case-sort-of-sensitivity)
+    localdir = os.path.normpath(os.getcwd()).replace(testdir, '.')
+    # sys.stdout.write('localdir=%s\n'%(localdir))
+
+    if localdir.find('./') == 0:
+        # strip off the leading './'
+        localdir = localdir.lstrip('.')
+        localdir = localdir.lstrip('/')
+    # sys.stdout.write('localdir=%s\n'%(localdir))
+
+    return localdir
+
+def main(argv):
+    global verbose
+    failfast = False
+    if "-f" in argv or "--force" in argv:
+        failfast = True
+        try:
+            argv.remove("-f")
+            argv.remove("--force")
+        except:
+            pass
+    if "-v" in argv or "--verbose" in argv:
+        verbose = True
+
+    setup()
+
+    if len(argv) < 2:
+        print('usage: sub_test COMPILER [options]')
+        sys.exit(0)
+
+    compiler = argv[1]
+    name = os.path.join(getDir(compiler), argv[0])
+    del argv[1]
+
+    # Add sbatch and srun to our path
+    path = os.environ['PATH']
+    os.environ['PATH'] = os.path.join(os.getcwd(), "bin") + ":" + path
+
+    if skipReason is None:
+        # Compile the test program
+        cmd = compiler + ' hello.chpl'
+        if verbose:
+            print("Compiling test program")
+            print(cmd)
+        runCmd(cmd)
+    if verbose:
+        print("Running tests")
+    prog = unittest.main(argv=argv, failfast=failfast, exit=False)
+
+    # Produce output that start_test can parse. To start_test this is a single
+    # test. Report report success if all tests succeeded, an error if any
+    # test failed, and nothing if all tests were skipped.
+
+    if len(prog.result.skipped) > 0:
+        print("Skipped %d tests in %s" % (len(prog.result.skipped), name))
+    if len(prog.result.skipped) != prog.result.testsRun:
+        if len(prog.result.errors) > 0 or len(prog.result.failures) > 0:
+            print("[Error running tests in %s]" % name)
+        else:
+            print("[Success matching tests in %s]" % name)
+
+if __name__ == '__main__':
+    main(sys.argv)
+

--- a/test/runtime/configMatters/launch/jhh/co-locales/hello.chpl
+++ b/test/runtime/configMatters/launch/jhh/co-locales/hello.chpl
@@ -1,0 +1,2 @@
+// Simple hello world
+writeln("Hello, world!");    // print 'Hello, world!' to the console

--- a/test/runtime/configMatters/launch/jhh/co-locales/sub_test
+++ b/test/runtime/configMatters/launch/jhh/co-locales/sub_test
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# This is a wrapper around the Python unittest framework to fit it
+# into the Chapel test infrastructure.
+
+# start_test removes directories under $CHPL_HOME from the path.
+# Put them back so we can compile the test program
+
+pushd $CHPL_HOME
+source util/setchplenv.bash
+popd
+
+python3 co-locales.py $@ --verbose

--- a/test/runtime/jhh/lps/lps_test.py
+++ b/test/runtime/jhh/lps/lps_test.py
@@ -134,7 +134,7 @@ class LocalePerSocket(unittest.TestCase):
         self.assertNotIn('--ntasks-per-node', output)
 
     def mrAllocatedRequired(self):
-        output = runCmd("fi_info -v")
+        output = runCmd("srun fi_info -v")
         for line in output.splitlines():
             if "mr_mode" in line:
                 if "FI_MR_ALLOCATED" in line:

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-
+#!/usr/bin/env python3dar
 import optparse
 import os
 import sys

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3dar
+#!/usr/bin/env python3
+
 import optparse
 import os
 import sys


### PR DESCRIPTION
Allow the `-nl `argument to be an expression of the form _MxN_, where _M_ is the number of nodes and _N_ is the number of locales per node. _N_ is optional, and if it is missing the number of locales per node is determined by heuristic, which currently is to use the value of `CHPL_RT_NUM_LOCALES_PER_NODE`. For example, "-nl 4x2" will run 2 locales on each of 4 nodes, for a total of 8 locales. 

This extended syntax is only supported for the `gasnet` and `ofi` comm layers, and the `slurm-srun` and `pbs-gasnetrun_ibv` launchers.

Closes https://github.com/Cray/chapel-private/issues/4845, resolves https://github.com/Cray/chapel-private/issues/4727, and resolves https://github.com/Cray/chapel-private/issues/4910.
