### PR TITLE
Update some boolean logic to avoid gcc warnings about pointless comparisons

### DIFF
--- a/test/types/range/rangeSafeCasts.chpl
+++ b/test/types/range/rangeSafeCasts.chpl
@@ -24,9 +24,9 @@ proc tryCasts(r) {
 proc safe(r, type t) {
   if t == bool && ((r.low != 0 && r.low != 1) || (r.high != 0 && r.high != 1)) then
     return false;
-  if isUintType(t) && r.low < 0 || r.high < 0 then
+  if isUintType(t) && isIntType(r.idxType) &&  (r.low < 0 || r.high < 0) then
     return false;
-  if isIntType(t) && r.low > max(t) || r.high > max(t) then
+  if isIntegralType(t) && r.idxType != bool && (r.low > max(t) || r.high > max(t)) then
     return false;
   return true;
 }


### PR DESCRIPTION
I'd only tested this test with the clang C back-end, and gcc is better at warning about pointless bool comparisons, so did.