### PR TITLE
Support building Chapel in a Nix shell 

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import itertools
 import optparse
 import os
 import sys

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -377,7 +377,10 @@ def get_possible_clang_installation_directories():
     bindir = get_system_llvm_config_bindir()
     if bindir:
         paths.append(bindir)
-    return paths + os.environ["PATH"].split(":")
+    for p in os.environ["PATH"].split(":"):
+        if os.path.isdir(p):
+            paths.append(p)
+    return paths
 
 def get_possible_clang_executables(lang, llvm_version):
     clang_name = get_llvm_clang_command_name(lang)


### PR DESCRIPTION
This PR includes the patches that were necessary to build the Chapel compiler under Nix as tested in this project https://github.com/twesterhout/nix-chapel .
The code should be self-explanatory, but let me know if you feel that additional explanations/justifications are needed.

One thing to note is that, for now, we skip some checks when we're in Nix environments. That means that if you add `llvmPackages.clang` to your build inputs, but forget `llvmPackages.libclang.dev`, the build system won't print a pretty error message saying that we're missing libclang; rather, the compilation will just fail with a missing include file. This should be fixed, but probably in a later PR.

Pinging @mppf since we discussed this patch at length yesterday. 