### PR TITLE
Fix an instance of memmove called with >uint32 size

### DIFF
--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -1106,7 +1106,7 @@ module ZMQ {
       const myOffset = tid*lenPerTask;
       const myLen = if tid == numTasks-1 then length:int-myOffset else lenPerTask;
 
-      memmove(dst+myOffset,x+myOffset,myLen);
+      memmove(dst+myOffset,x+myOffset,myLen.safeCast(c_size_t));
     }
 
     dst[length] = 0;


### PR DESCRIPTION
Fixes an instance of `memmove` being called with a size parameter that doesn't fit into `c_size_t` on 32-bit systems. This one was showing up weirdly in night tests so it was harder to catch (see https://github.com/Cray/chapel-private/issues/4928).

Follow up to https://github.com/chapel-lang/chapel/pull/22381.

[review info placeholder]

Testing:
- [x] 64-bit paratest
- [x] `library/packages/ZMQ` tests on 32-bit system