### PR TITLE
Add cplxOperators.prediff handling negative vs positive zero for Valgrind

### DIFF
--- a/test/types/complex/diten/cplxOperators.prediff
+++ b/test/types/complex/diten/cplxOperators.prediff
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Normalize all instances of "- 0.0i" to "+ 0.0i" as mathematically equivalent.
+# This is due to an unknown quirk in which direct execution gives a positive
+# zero and execution with Valgrind memcheck gives a negative zero.
+
+#TESTNAME=$1
+OUTFILE=$2
+
+TMPFILE="$outfile.prediff.tmp"
+mv $OUTFILE $TMPFILE
+sed -e 's/- 0.0i/+ 0.0i/g' $TMPFILE > $OUTFILE
+rm $TMPFILE


### PR DESCRIPTION
With the upgrade to GCC 12.2.0 on `chapcs`, and corresponding newer install of Valgrind, we are seeing `test/types/complex/diten/cplxOperators.chpl` output a `+0.0i` for the imaginary part of a quotient when executed directly, and a `-0.0i` when run in Valgrind. This does not occur when using the new install of Valgrind but compiling Chapel with GCC 8.3.

I am chalking this up to a quirk of Valgrind or GCC floating-point handling, and adding a `cplxOperators.prediff` that replaces negative zeros with positive zeros.

[reviewer info]

Testing:
- [x] test passes without Valgrind
- [x] manual testing with Valgrind and executing prediff gives expected result