### PR TITLE
Fix commcount regressions from #22441

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -1191,13 +1191,14 @@ module ChapelDistribution {
 
   // domain assignment helpers
 
-  private proc doCastIndices(from, type idxType, param strides) {
-    type resultType = range(idxType, boundKind.both, strides);
+  private proc castIndices(from, lhs) {
+    param rank = lhs.rank;
+    compilerAssert(rank == from.size);
+
+    type resultType = range(lhs.idxType, boundKind.both, lhs.strides);
     if from(0).type == resultType then
       return from;
 
-    // set result = inds with some error checking
-    param rank = from.size;
     var result: rank * resultType;
     for param i in 0..rank-1 do
       result(i) = from(i).safeCast(resultType);
@@ -1213,25 +1214,22 @@ module ChapelDistribution {
   proc chpl_assignDomainWithGetSetIndices(lhs:?t, rhs: domain)
     where isSubtype(_to_borrowed(t),BaseRectangularDom)
   {
+    const rhsInds = rhs.getIndices();
     type arrType = lhs.getBaseArrType();
-    param rank = lhs.rank;
-    type idxType = lhs.idxType;
-    param strides = lhs.strides;
-    compilerAssert(rank == rhs.rank);
 
-    const castIndices = doCastIndices(rhs.getIndices(), idxType, strides);
     for e in lhs._arrs do {
       on e {
         if const eCast = e:arrType? then
-          eCast.dsiReallocate(castIndices);
+          eCast.dsiReallocate(castIndices(rhsInds, lhs));
+          // castIndices() is not hoisted because 'lhs' may not have any arrays
         else
           halt("internal error: ", t:string,
                " contains a bad array type ", arrType:string);
       }
     }
 
-    // todo: why we cast indices for dsiReallocate and not for dsiSetIndices?
-    lhs.dsiSetIndices(rhs.getIndices());
+    // todo: should we cast indices for dsiSetIndices like for dsiReallocate?
+    lhs.dsiSetIndices(rhsInds);
 
     for e in lhs._arrs do {
       var eCastQ = e:arrType?;


### PR DESCRIPTION
#22441 resulted in added `get` communications for the call `rhs.getIndices()` that it hoisted out from the loop `for e in lhs._arrs` in chpl_assignDomainWithGetSetIndices(). While hoisting helps in many cases, here it was detrimental because this loop had no iterations at all.

Given that chpl_assignDomainWithGetSetIndices already invokes `rhs.getIndices()` outside of the loop, I changed the code to invoke it just once and reuse its result whenever necessary.

I also moved the call to castIndices(), which #22441 also hoisted out of the loop, back into the loop. However it probably does not matter because it will be no-op in most cases, otherwise have low overhead.

Testing: standard+gasnet paratests; distribution robustness suites for block, cyclic, replicated.