### PR TITLE
Change wording of multi-locale informational message

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -965,7 +965,7 @@ void chpl_comm_rollcall(void) {
   // Initialize diags
   chpl_comm_diags_init();
 
-  chpl_msg(2, "executing on node %d of %d node(s): %s\n", chpl_nodeID,
+  chpl_msg(2, "executing locale %d of %d on node '%s'\n", chpl_nodeID,
            chpl_numNodes, chpl_nodeName());
 }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3109,7 +3109,7 @@ void chpl_comm_rollcall(void) {
   // Initialize diags
   chpl_comm_diags_init();
 
-  chpl_msg(2, "executing on node %d of %d node(s): %s\n", chpl_nodeID,
+  chpl_msg(2, "executing locale %d of %d on node '%s'\n", chpl_nodeID,
            chpl_numNodes, chpl_nodeName());
 
   //

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3009,7 +3009,7 @@ void chpl_comm_rollcall(void)
   // Initialize diags
   chpl_comm_diags_init();
 
-  chpl_msg(2, "executing on node %d of %d node(s): %s\n", chpl_nodeID,
+  chpl_msg(2, "executing locale %d of %d on node '%s'\n", chpl_nodeID,
            chpl_numNodes, chpl_nodeName());
 
   if (chpl_numNodes == 1)

--- a/test/multilocale/numLocales/bradc/testVFlag.comm-gasnet.goodcont
+++ b/test/multilocale/numLocales/bradc/testVFlag.comm-gasnet.goodcont
@@ -1,1 +1,1 @@
-executing on node 0 of 1 node(s): UNAME
+executing locale 0 of 1 on node 'UNAME'

--- a/test/multilocale/numLocales/bradc/testVFlag.comm-ofi.goodcont
+++ b/test/multilocale/numLocales/bradc/testVFlag.comm-ofi.goodcont
@@ -1,1 +1,1 @@
-executing on node 0 of 1 node(s): UNAME
+executing locale 0 of 1 on node 'UNAME'

--- a/test/multilocale/numLocales/bradc/testVFlag.comm-ugni.goodcont
+++ b/test/multilocale/numLocales/bradc/testVFlag.comm-ugni.goodcont
@@ -1,1 +1,1 @@
-executing on node 0 of 1 node(s): UNAME
+executing locale 0 of 1 on node 'UNAME'

--- a/test/multilocale/numLocales/bradc/testVFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVFlag.prediff
@@ -43,7 +43,7 @@ fi
 # aren't meaningful.
 case $target in
   cray-cs|cray-x*|hpe-cray-ex)
-     sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
+     sed "s/\(executing locale 0 of 1 on node \).*/\1'$uname'/" \
          < $2 > $2.tmp &&
      mv $2.tmp $2;;
 esac

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.comm-gasnet.goodcont
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.comm-gasnet.goodcont
@@ -1,1 +1,1 @@
-executing on node 0 of 1 node(s): UNAME
+executing locale 0 of 1 on node 'UNAME'

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.comm-ofi.goodcont
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.comm-ofi.goodcont
@@ -1,1 +1,1 @@
-executing on node 0 of 1 node(s): UNAME
+executing locale 0 of 1 on node 'UNAME'

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.comm-ugni.goodcont
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.comm-ugni.goodcont
@@ -1,1 +1,1 @@
-executing on node 0 of 1 node(s): UNAME
+executing locale 0 of 1 on node 'UNAME'

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
@@ -43,7 +43,7 @@ fi
 # aren't meaningful.
 case $target in
   cray-cs|cray-x*|hpe-cray-ex)
-     sed "s/\(executing on node 0 of 1 node(s): \).*/\1$uname/" \
+     sed "s/\(executing locale 0 of 1 on node \).*/\1'$uname'/" \
          < $2 > $2.tmp &&
      mv $2.tmp $2;;
 esac


### PR DESCRIPTION
Change the wording of the multi-locale informational message from the form

    executing on node 8 of 10 node(s): amd-0005

to the form

    executing locale 8 of 10 on node 'amd-0005'

to make the distinction between locales and nodes clearer.

Resolves https://github.com/Cray/chapel-private/issues/4909.