### PR TITLE
Hack-ily hide c_ptr/c_array types with fixInternalDocs

### DIFF
--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -251,3 +251,13 @@ file=WeakPointer.rst
 replace "_shared" "shared" $file
 removeUsage $file
 ## End of WeakPointer ##
+
+# Bending the rules a little to modify CTypes, which is not an internal module.
+# This is a hack that won't be necessary after #issuenum.
+# Has to be at the end of the script due to the cd. (or cd back after)
+cd "${TEMPDIR}/source/modules/standard/"
+## CTypes ##
+file=CTypes.rst
+replace "class:: c_ptr" "type:: c_ptr" $file # also gets c_ptrConst
+replace "record:: c_array" "type:: c_array" $file
+## End of CTypes ##

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -253,7 +253,7 @@ removeUsage $file
 ## End of WeakPointer ##
 
 # Bending the rules a little to modify CTypes, which is not an internal module.
-# This is a hack that won't be necessary after #issuenum.
+# This is a hack that won't be necessary if #22461 is implemented.
 # Has to be at the end of the script due to the cd. (or cd back after)
 cd "${TEMPDIR}/source/modules/standard/"
 ## CTypes ##

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -189,8 +189,8 @@ module CTypes {
 
   // TODO: avoid redundant c_ptr pragma with c_ptrConst pragma
   /*
-    Like ``c_ptr``, but for a pointer to const data. In C, this is equivalent to
-    the type `const eltType*`.
+    Like :type:`c_ptr`, but for a pointer to const data. In C, this is
+    equivalent to the type `const eltType*`.
   */
   pragma "data class"
   pragma "no object"
@@ -843,8 +843,8 @@ module CTypes {
   }
 
   /*
-   Like ``c_ptrTo`` for :type:`~String.string`, but returns a :type:`c_ptrConst`
-   which disallows direct modification of the pointee.
+   Like :proc:`c_ptrTo` for :type:`~String.string`, but returns a
+   :type:`c_ptrConst` which disallows direct modification of the pointee.
    */
   inline proc c_ptrToConst(const ref s: string): c_ptrConst(c_uchar)
     where cPtrToStringBytesClassLogicalAddress == true
@@ -890,8 +890,8 @@ module CTypes {
   }
 
   /*
-   Like ``c_ptrTo`` for :type:`~Bytes.bytes`, but returns a :type:`c_ptrConst`
-   which disallows direct modification of the pointee.
+   Like :proc:`c_ptrTo` for :type:`~Bytes.bytes`, but returns a
+   :type:`c_ptrConst` which disallows direct modification of the pointee.
    */
   inline proc c_ptrToConst(const ref b: bytes): c_ptrConst(c_uchar)
     where cPtrToStringBytesClassLogicalAddress == true
@@ -942,7 +942,7 @@ module CTypes {
   }
 
   /*
-   Like ``c_ptrTo`` for class types, but returns a :type:`c_ptrConst`
+   Like :proc:`c_ptrTo` for class types, but returns a :type:`c_ptrConst`
    which disallows direct modification of the pointee.
    */
   inline proc c_ptrToConst(const ref c: class): c_ptrConst(c.type)

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -319,7 +319,7 @@ module CTypes {
     }
   }
 
-  /* Copy the elements from one ``c_array`` to another.
+  /* Copy the elements from one :type:`c_array` to another.
      Raises an error at compile time if the array sizes or
      element types do not match. */
   operator c_array.=(ref lhs:c_array, rhs:c_array) {
@@ -739,8 +739,8 @@ module CTypes {
     return c_pointer_return(arr[arr.domain.low]);
   }
   /*
-   Like c_ptrTo for arrays, but returns a :type:`c_ptrConst` which disallows
-   direct modification of the pointee.
+   Like :proc:`c_ptrTo` for arrays, but returns a :type:`c_ptrConst` which
+   disallows direct modification of the pointee.
    */
   inline proc c_ptrToConst(const arr: []): c_ptrConst(arr.eltType) {
     if (!arr.isRectangular() || !arr.domain.dist._value.dsiIsLayout()) then
@@ -949,7 +949,7 @@ module CTypes {
   }
 
   /*
-    Like c_ptrTo, but returns a :type:`c_ptrConst` which disallows direct
+    Like :proc:`c_ptrTo`, but returns a :type:`c_ptrConst` which disallows direct
     modification of the pointee.
   */
   inline proc c_ptrToConst(const ref x:?t): c_ptrConst(t) {
@@ -985,8 +985,8 @@ module CTypes {
   }
 
   /*
-   Like c_addrOf for arrays, but returns a :type:`c_ptrConst` which disallows
-   direct modification of the pointee.
+   Like :proc:`c_addrOf` for arrays, but returns a :type:`c_ptrConst` which
+   disallows direct modification of the pointee.
   */
   inline proc c_addrOfConst(arr: []) {
     if (!arr.isRectangular() || !arr.domain.dist._value.dsiIsLayout()) then
@@ -1014,8 +1014,8 @@ module CTypes {
   }
 
   /*
-    Like c_addrOf, but returns a :type:`c_ptrConst` which disallows direct
-    modification of the pointee.
+    Like :proc:`c_addrOf`, but returns a :type:`c_ptrConst` which disallows
+    direct modification of the pointee.
   */
   inline proc c_addrOfConst(const ref x: ?t): c_ptrConst(t) {
     if isDomainType(t) then

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -122,11 +122,10 @@ module CTypes {
   /*
 
     Represents a local C pointer for the purpose of C integration. This type
-    represents the equivalent to a C language pointer `eltType*`. Instances of
+    represents the equivalent to a C language pointer ``eltType*``. Instances of
     this type support assignment to other instances or ``nil``, ``==`` or ``!=``
-    comparison with a
-    ``c_void_ptr`` or with ``nil``, and casting to another ``c_ptr`` type or to
-    the ``c_void_ptr`` type.
+    comparison with a ``c_void_ptr`` or with ``nil``, and casting to another
+    ``c_ptr`` type or to the ``c_void_ptr`` type.
 
     Casting directly to a ``c_ptr`` of another pointee type is supported, but
     will emit a safety warning for casts that can lead to violation of C's
@@ -208,17 +207,18 @@ module CTypes {
   /*
   This type represents a C array with fixed size.  A variable of type
   ``c_array`` can coerce to a ``c_ptr`` with the same element type.  In that
-  event, the pointer will be equivalent to `c_ptrTo(array[0])`.  A ``c_array``
+  event, the pointer will be equivalent to ``c_ptrTo(array[0])``.  A ``c_array``
   behaves similarly to a homogeneous tuple except that its indices start at 0
   and it is guaranteed to be stored in contiguous memory.  A ``c_array``
-  variable has value semantics. Declaring one as a function local variable will
+  variable has value semantics. Declaring one as a function-local variable will
   create the array elements in the function's stack. Assigning or copy
   initializing will result in copying the elements (vs resulting in two pointers
   that refer to the same elements).  A ``nil`` ``c_array`` is not representable
   in Chapel.
   */
-  pragma "c_array record" pragma
-         "default intent is ref if modified" record c_array {
+  pragma "c_array record"
+  pragma "default intent is ref if modified"
+  record c_array {
     /* The array element type */
     type eltType;
     /* The fixed number of elements */

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -160,7 +160,14 @@ module CTypes {
     //   Similar to _ddata from ChapelBase, but differs
     //   from _ddata because it can never be wide.
 
-    /* The type that this pointer points to */
+    /*
+       The type that this pointer points to, which can be queried like so:
+
+       .. code-block:: chapel
+
+         var x: c_ptr = c_ptrTo(...);
+         if x.eltType == c_int then do writeln("x is an int pointer");
+    */
     type eltType;
     /* Retrieve the i'th element (zero based) from a pointer to an array.
       Does the equivalent of ptr[i] in C.
@@ -192,13 +199,30 @@ module CTypes {
   pragma "c_ptr class"
   pragma "c_ptrConst class"
   class c_ptrConst {
+    /*
+       The type that this pointer points to, which can be queried like so:
+
+       .. code-block:: chapel
+
+         var x: c_ptrConst = c_ptrToConst(...);
+         if x.eltType == c_int then do writeln("x is a const int pointer");
+    */
     type eltType;
+    /* Retrieve the i'th element (zero based) from a pointer to an array.
+       Does the equivalent of ptr[i] in C.
+       Provides a ``const ref`` which cannot be used to modify the element.
+    */
     inline proc this(i: integral) const ref {
       return __primitive("array_get", this, i);
     }
+    /* Get element pointed to directly by this pointer. If the pointer
+       refers to an array, this will return ptr[0].
+       Provides a ``const ref`` which cannot be used to modify the element.
+    */
     inline proc deref() const ref {
       return __primitive("array_get", this, 0);
     }
+    /* Print this pointer */
     inline proc writeThis(ch) throws {
       (this:c_void_ptr).writeThis(ch);
     }
@@ -219,9 +243,23 @@ module CTypes {
   pragma "c_array record"
   pragma "default intent is ref if modified"
   record c_array {
-    /* The array element type */
+    /*
+       The array element type, which can be queried like so:
+
+       .. code-block:: chapel
+
+         var x: c_array = c_ptrToConst(...);
+         if x.eltType == c_int then do writeln("x is an array of ints");
+    */
     type eltType;
-    /* The fixed number of elements */
+    /*
+       The fixed number of elements, which can be queried like so:
+
+       .. code-block:: chapel
+
+         var x: c_array = c_ptrToConst(...);
+         writeln("x has ", x.size, " elements.");
+    */
     param size;
 
     proc init(type eltType, param size) {

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -121,9 +121,10 @@ module CTypes {
 
   /*
 
-    Represents a local C pointer for the purpose of C integration. This class
-    represents the equivalent to a C language pointer. Instances of this class
-    support assignment to other instances or nil, == or != comparison with a
+    Represents a local C pointer for the purpose of C integration. This type
+    represents the equivalent to a C language pointer `eltType*`. Instances of
+    this type support assignment to other instances or ``nil``, ``==`` or ``!=``
+    comparison with a
     ``c_void_ptr`` or with ``nil``, and casting to another ``c_ptr`` type or to
     the ``c_void_ptr`` type.
 
@@ -205,19 +206,19 @@ module CTypes {
   }
 
   /*
-  This class represents a C array with fixed size.  A variable of type c_array
-  can coerce to a c_ptr with the same element type.  In that event, the
-  pointer will be equivalent to `c_ptrTo(array[0])`.  A c_array behaves
-  similarly to a homogeneous tuple except that its indices start at 0 and it is
-  guaranteed to be stored in contiguous memory.  A c_array variable has value
-  semantics. Declaring one as a function local variable will create the array
-  elements in the function's stack. Assigning or copy initializing will result
-  in copying the elements (vs resulting in two pointers that refer to the same
-  elements).  A `nil` c_array is not representable in Chapel.
+  This type represents a C array with fixed size.  A variable of type
+  ``c_array`` can coerce to a ``c_ptr`` with the same element type.  In that
+  event, the pointer will be equivalent to `c_ptrTo(array[0])`.  A ``c_array``
+  behaves similarly to a homogeneous tuple except that its indices start at 0
+  and it is guaranteed to be stored in contiguous memory.  A ``c_array``
+  variable has value semantics. Declaring one as a function local variable will
+  create the array elements in the function's stack. Assigning or copy
+  initializing will result in copying the elements (vs resulting in two pointers
+  that refer to the same elements).  A ``nil`` ``c_array`` is not representable
+  in Chapel.
   */
-  pragma "c_array record"
-  pragma "default intent is ref if modified"
-  record c_array {
+  pragma "c_array record" pragma
+         "default intent is ref if modified" record c_array {
     /* The array element type */
     type eltType;
     /* The fixed number of elements */
@@ -318,7 +319,7 @@ module CTypes {
     }
   }
 
-  /* Copy the elements from one c_array to another.
+  /* Copy the elements from one ``c_array`` to another.
      Raises an error at compile time if the array sizes or
      element types do not match. */
   operator c_array.=(ref lhs:c_array, rhs:c_array) {

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -187,11 +187,11 @@ module CTypes {
     }
   }
 
+  // TODO: avoid redundant c_ptr pragma with c_ptrConst pragma
   /*
     Like ``c_ptr``, but for a pointer to const data. In C, this is equivalent to
     the type `const eltType*`.
   */
-  // TODO: avoid redundant c_ptr pragma with c_ptrConst pragma
   pragma "data class"
   pragma "no object"
   pragma "no default functions"


### PR DESCRIPTION
This PR (mis)uses `fixInternalDocs.sh` to change the headers for `c_ptr`, `c_ptrConst`, and `c_array` to hide their underlying implementation types as classes (`c_ptr[Const]`) and records (`c_array`).

`CTypes` is not an internal module, so technically this would better belong in a `fixStandardDocs.sh`, but I view this as an acceptable temporary hack that would be obviated by https://github.com/chapel-lang/chapel/issues/22461.

Also includes some doc comment improvements for `c_ptr`, `c_ptrConst`, and `c_array`.

Resolves https://github.com/chapel-lang/chapel/issues/21385.

[reviewer info]

Testing:
- [x] locally generated docs look right