### PR TITLE
Fix failure in anonymousRangeIter

### DIFF
--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -37,4 +37,4 @@ _ic__F#_i_chpl = INT#(#);
 for (_ic__F#_i_chpl = INT#(#),_ic__F#_i_chpl# = INT#(#); (tmp_chpl# = (_ic__F#_i_chpl <= INT#(#)),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT#(#),_ic__F#_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(-#),_ic__F#_i_chpl# = tmp_chpl#) {
 
 # var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
-for (_ic__F#_i_chpl# = INT#(#),_ic__F#_i_chpl# = tmp_chpl#; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(#),_ic__F#_i_chpl# = tmp_chpl#,tmp_chpl# = _ic__F#_this_chpl,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += (&tmp_chpl#)->_stride,_ic__F#_i_chpl# = tmp_chpl#) {
+for (_ic__F#_i_chpl# = INT#(#),_ic__F#_i_chpl# = call_tmp_chpl#; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(#),_ic__F#_i_chpl# = tmp_chpl#,tmp_chpl# = _ic__F#_this_chpl,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += (&tmp_chpl#)->_stride,_ic__F#_i_chpl# = tmp_chpl#) {


### PR DESCRIPTION
#22441 changed how some range bounds are calculated. As a result, the compiler now produces a temp called `call_tmp` where previously it was called `tmp`. Adjust the expectations that the test `anonymousRangeIter` makes about the generated code.

Trivial, not reviewed.