### PR TITLE
Fix ASAN failures in negativeStrideWarnings

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1910,7 +1910,7 @@ module DefaultRectangular {
 
   private proc transferHelper(A, aView, B, bView) : bool {
     if A.rank == B.rank &&
-       aView.hasPosNegUnitStride() && (bView.strides == aView.strides) &&
+       aView.hasUnitStride() && bView.hasUnitStride() &&
        _canDoSimpleTransfer(A, aView, B, bView) {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("Performing simple DefaultRectangular transfer");


### PR DESCRIPTION
This PR updates the guard for invoking _simpleTransfer() in the implementation of chpl__bulkTransferArray() to require the viewing domains on both sides to have stride=1. Prior to this change it also accepted the case where the two domains both had stride=-1. However, the implementation was not intended to work in this latter case and so resulted in invalid memory accesses. This change avoids invoking _simpleTransfer() in such case.

Suggested by @benharsh, not reviewed.