### PR TITLE
Reorder computeNoAliasSets transform to be after GpuTransforms

### DIFF
--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -1263,14 +1263,7 @@ static void licmFn(FnSymbol* fn) {
   }
 }
 
-void loopInvariantCodeMotion(void) {
-
-  // compute array element alias sets
-  computeNoAliasSets();
-
-  // optimize certain statements in foralls to unordered
-  optimizeForallUnorderedOps();
-
+static void loopInvariantCodeMotionImpl(void) {
   if(fNoLoopInvariantCodeMotion) {
     return;
   }
@@ -1326,6 +1319,27 @@ void loopInvariantCodeMotion(void) {
   fclose(timingFile);
   fclose(maxTimeFile);
 #endif
+}
 
+void loopInvariantCodeMotion(void) {
+  // optimize certain statements in foralls to unordered
+  optimizeForallUnorderedOps();
+
+  loopInvariantCodeMotionImpl();
+
+  // We run gpuTransforms after LICM since we can benefit from invariant
+  // computations being removed from GUP kernels (that prior to this point are
+  // normal foreach loops).  Currently, we have gpuTransforms called here
+  // rather than in its own pass in order to avoid disruption/overhead of
+  // adding a new pass (though we may wish to change this at some point in the
+  // future).
   gpuTransforms();
+
+  // Compute array element alias sets.
+  //
+  // Any manipulations on the AST that removes a symbol within a function may
+  // invalidate the 'no alias set' primitives (that this transforms adds to the
+  // top of functions). GpuTransfroms is one such transform that does AST
+  // manipulations, so we run computeNoAliasSets after GPUTransforms.
+  computeNoAliasSets();
 }

--- a/test/analysis/alias/COMPOPTS
+++ b/test/analysis/alias/COMPOPTS
@@ -1,2 +1,2 @@
---fast --report-aliases
+--fast --report-aliasesA
 --no-loop-invariant-code-motion

--- a/test/analysis/alias/COMPOPTS
+++ b/test/analysis/alias/COMPOPTS
@@ -1,2 +1,2 @@
---fast --report-aliasesA
+--fast --report-aliases
 --no-loop-invariant-code-motion

--- a/test/analysis/alias/array-arguments-const-ref-refid.compgood
+++ b/test/analysis/alias/array-arguments-const-ref-refid.compgood
@@ -1,5 +1,5 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function refIdentity:
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-const-ref.compgood
+++ b/test/analysis/alias/array-arguments-const-ref.compgood
@@ -1,6 +1,6 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function test:
   a no ref alias b
   <array get pointer> no alias <array get pointer>
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-in.compgood
+++ b/test/analysis/alias/array-arguments-in.compgood
@@ -1,3 +1,5 @@
+LICM: may-alias report for a loop in function test:
+  Result may alias return argument
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function test:
@@ -5,5 +7,3 @@ noAliasSets: no-aliases for function test:
   a no ref alias return argument
   b no ref alias return argument
   <array get pointer> no alias <array get pointer>
-LICM: may-alias report for a loop in function test:
-  Result may alias return argument

--- a/test/analysis/alias/array-arguments-rank-change.compgood
+++ b/test/analysis/alias/array-arguments-rank-change.compgood
@@ -1,3 +1,3 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-ref-nested-inner-same.compgood
+++ b/test/analysis/alias/array-arguments-ref-nested-inner-same.compgood
@@ -1,6 +1,6 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function callTest:
   a no ref alias b
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-ref-nested-same.compgood
+++ b/test/analysis/alias/array-arguments-ref-nested-same.compgood
@@ -1,5 +1,5 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function callTest:
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-ref-nested.compgood
+++ b/test/analysis/alias/array-arguments-ref-nested.compgood
@@ -1,3 +1,4 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function callTest:
@@ -5,4 +6,3 @@ noAliasSets: no-aliases for function callTest:
 noAliasSets: no-aliases for function test:
   a no ref alias b
   <array get pointer> no alias <array get pointer>
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-ref-refid.compgood
+++ b/test/analysis/alias/array-arguments-ref-refid.compgood
@@ -1,5 +1,5 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function refIdentity:
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-ref.compgood
+++ b/test/analysis/alias/array-arguments-ref.compgood
@@ -1,6 +1,6 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function test:
   a no ref alias b
   <array get pointer> no alias <array get pointer>
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-refvar-same.compgood
+++ b/test/analysis/alias/array-arguments-refvar-same.compgood
@@ -1,3 +1,3 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-refvar.compgood
+++ b/test/analysis/alias/array-arguments-refvar.compgood
@@ -1,4 +1,4 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-reindex.compgood
+++ b/test/analysis/alias/array-arguments-reindex.compgood
@@ -1,4 +1,4 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
   a no ref alias b
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-same-nested.compgood
+++ b/test/analysis/alias/array-arguments-same-nested.compgood
@@ -1,4 +1,4 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function callTest:
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-same.compgood
+++ b/test/analysis/alias/array-arguments-same.compgood
@@ -1,3 +1,3 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments-slice.compgood
+++ b/test/analysis/alias/array-arguments-slice.compgood
@@ -1,4 +1,4 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
   a no ref alias b
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-arguments.compgood
+++ b/test/analysis/alias/array-arguments.compgood
@@ -1,6 +1,6 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function test:
   a no ref alias b
   <array get pointer> no alias <array get pointer>
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-in-class.compgood
+++ b/test/analysis/alias/array-in-class.compgood
@@ -1,8 +1,8 @@
+LICM: may-alias report for a loop in function arrayArgs:
+LICM: may-alias report for a loop in function innerArrayArgs:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function deinit:
 noAliasSets: no-aliases for function _new:
 noAliasSets: no-aliases for function arrayArgs:
 noAliasSets: no-aliases for function classArgs:
 noAliasSets: no-aliases for function innerArrayArgs:
-LICM: may-alias report for a loop in function arrayArgs:
-LICM: may-alias report for a loop in function innerArrayArgs:

--- a/test/analysis/alias/array-in-class2.compgood
+++ b/test/analysis/alias/array-in-class2.compgood
@@ -1,8 +1,8 @@
+LICM: may-alias report for a loop in function arrayArgs:
+LICM: may-alias report for a loop in function innerArrayArgs:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function deinit:
 noAliasSets: no-aliases for function _new:
 noAliasSets: no-aliases for function arrayArgs:
 noAliasSets: no-aliases for function classArgs:
 noAliasSets: no-aliases for function innerArrayArgs:
-LICM: may-alias report for a loop in function arrayArgs:
-LICM: may-alias report for a loop in function innerArrayArgs:

--- a/test/analysis/alias/array-of-arrays.compgood
+++ b/test/analysis/alias/array-of-arrays.compgood
@@ -1,3 +1,3 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/array-of-classes-variant.compgood
+++ b/test/analysis/alias/array-of-classes-variant.compgood
@@ -1,3 +1,7 @@
+LICM: may-alias report for a loop in function acceptsArrays:
+LICM: may-alias report for a loop in function acceptsClasses:
+LICM: may-alias report for a loop in function acceptsIntRefs:
+  a may alias b
 noAliasSets: no-aliases for function makeArray:
 noAliasSets: no-aliases for function main:
   A no alias B
@@ -9,7 +13,3 @@ noAliasSets: no-aliases for function acceptsArrays:
   <array get pointer> no alias <array get pointer>
 noAliasSets: no-aliases for function acceptsClasses:
 noAliasSets: no-aliases for function acceptsIntRefs:
-LICM: may-alias report for a loop in function acceptsArrays:
-LICM: may-alias report for a loop in function acceptsClasses:
-LICM: may-alias report for a loop in function acceptsIntRefs:
-  a may alias b

--- a/test/analysis/alias/array-of-classes.compgood
+++ b/test/analysis/alias/array-of-classes.compgood
@@ -1,3 +1,7 @@
+LICM: may-alias report for a loop in function acceptsArrays:
+LICM: may-alias report for a loop in function acceptsClasses:
+LICM: may-alias report for a loop in function acceptsIntRefs:
+  a may alias b
 noAliasSets: no-aliases for function main:
   A no alias B
 noAliasSets: no-aliases for function deinit:
@@ -8,7 +12,3 @@ noAliasSets: no-aliases for function acceptsArrays:
   <array get pointer> no alias <array get pointer>
 noAliasSets: no-aliases for function acceptsClasses:
 noAliasSets: no-aliases for function acceptsIntRefs:
-LICM: may-alias report for a loop in function acceptsArrays:
-LICM: may-alias report for a loop in function acceptsClasses:
-LICM: may-alias report for a loop in function acceptsIntRefs:
-  a may alias b

--- a/test/analysis/alias/future/ref-to-array-of-arrays.bad
+++ b/test/analysis/alias/future/ref-to-array-of-arrays.bad
@@ -1,3 +1,3 @@
+LICM: may-alias report for a loop in function kernel:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function kernel:
-LICM: may-alias report for a loop in function kernel:

--- a/test/analysis/alias/global-arrays-nested.compgood
+++ b/test/analysis/alias/global-arrays-nested.compgood
@@ -1,5 +1,5 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function callTest:
 noAliasSets: no-aliases for function test:
 noAliasSets: no-aliases for function chpl__deinit_global-arrays-nested:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/global-arrays-same.compgood
+++ b/test/analysis/alias/global-arrays-same.compgood
@@ -1,4 +1,4 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
 noAliasSets: no-aliases for function chpl__deinit_global-arrays-same:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/global-arrays.compgood
+++ b/test/analysis/alias/global-arrays.compgood
@@ -1,6 +1,6 @@
+LICM: may-alias report for a loop in function test:
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
   a no ref alias b
   <array get pointer> no alias <array get pointer>
 noAliasSets: no-aliases for function chpl__deinit_global-arrays:
-LICM: may-alias report for a loop in function test:

--- a/test/analysis/alias/integer-arguments-ref-same.compgood
+++ b/test/analysis/alias/integer-arguments-ref-same.compgood
@@ -1,4 +1,4 @@
-noAliasSets: no-aliases for function main:
-noAliasSets: no-aliases for function test:
 LICM: may-alias report for a loop in function test:
   a may alias b
+noAliasSets: no-aliases for function main:
+noAliasSets: no-aliases for function test:

--- a/test/analysis/alias/integer-arguments-ref.compgood
+++ b/test/analysis/alias/integer-arguments-ref.compgood
@@ -1,5 +1,5 @@
+LICM: may-alias report for a loop in function test:
+  a may alias b
 noAliasSets: no-aliases for function main:
 noAliasSets: no-aliases for function test:
   a no ref alias b
-LICM: may-alias report for a loop in function test:
-  a may alias b

--- a/test/analysis/alias/integer-arguments-same-global.compgood
+++ b/test/analysis/alias/integer-arguments-same-global.compgood
@@ -1,4 +1,4 @@
-noAliasSets: no-aliases for function main:
-noAliasSets: no-aliases for function test:
 LICM: may-alias report for a loop in function test:
   a may alias b
+noAliasSets: no-aliases for function main:
+noAliasSets: no-aliases for function test:


### PR DESCRIPTION
This PR should have no user facing impact but is a necessary step to ensure the correctness of a planned subsequent GPU-related PR (involving specializing GPU-locale bound functions in the aim of improving performance).

**More specifically:**

This PR reorders the `computeNoAliasSets` transform to be after GpuTransforms as doing so will resolve a correctness issue in an upcoming planned PR for GpuTransforms (that clones certain functions and replaces gpuizable loops with kernel calls).

**To give more context:**

The `computeNoAliasSets` transform computes information that is later used to populate LLVM alias.scope and noalias metadata. Although the information in this transform is not used by loop invariant code motion, it was called by LICM because:

1. Perhaps LICM could use the results of this transform, and
2. We didn't want to create a whole new pass for it.

This transform adds primitives to the tops of functions that refer to "no alias" sets of various symbols def'd within the function. However, in a planned upcoming modification to GpuTransforms we are adding some behavior that clones and function and then removes a gpuized loop from it and in the process removes the symbols to everything defined in that loop.  This can potentially lead to an invalid state where one of the "no alias" sets refered to by `computeNoAliasSets` now has a `SymExpr` with a pointer to a deleted `Symbol`.

In order to avoid this there a couple of things we could do:

1. Update GpuTransforms to keep the no alias information up-to-date, or
2. Move the transformation after GpuTransforms.

I'd rather avoid adding new responsibilities to GpuTransforms and it seems less likely that I'd introduce an inadvertent bug by moving, so I'm opting for 2: moving the transform to be after GpuTransforms.

**TODO:**

[ ] Paratests (no gasnet, flat locale model)