### PR TITLE
Add mode to avoid overhead of asking "are we on a GPU sublocale?" per kernel launch (with GPU-bound specializations)

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -263,6 +263,7 @@ extern int fGPUBlockSize;
 const int gpuArchNameLen = 16;
 extern char fGpuArch[gpuArchNameLen+1];
 extern bool fGpuPtxasEnforceOpt;
+extern bool fGpuSpecialization;
 extern const char* gGpuSdkPath;
 extern char gpuArch[gpuArchNameLen+1];
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1262,7 +1262,7 @@ static ArgumentDescription arg_desc[] = {
  {"gpu-block-size", ' ', "<block-size>", "Block size for GPU launches", "I", &fGPUBlockSize, "CHPL_GPU_BLOCK_SIZE", NULL},
  {"gpu-arch", ' ', "<cuda-architecture>", "CUDA architecture to use", "S16", &fGpuArch, "_CHPL_GPU_ARCH", setEnv},
  {"gpu-ptxas-enforce-optimization", ' ', NULL, "Modify generated .ptxas file to enable optimizations", "F", &fGpuPtxasEnforceOpt, NULL, NULL},
- {"gpu-specialization", ' ', NULL, "Enable [disable] an optimization that clones functions known to executed on a GPU locale", "N", &fGpuSpecialization, "CHPL_GPU_SPECIALIZATION", NULL},
+ {"gpu-specialization", ' ', NULL, "Enable [disable] an optimization that clones functions into copies assumed to run on a GPU locale.", "N", &fGpuSpecialization, "CHPL_GPU_SPECIALIZATION", NULL},
  {"library", ' ', NULL, "Generate a Chapel library file", "F", &fLibraryCompile, NULL, NULL},
  {"library-dir", ' ', "<directory>", "Save generated library helper files in directory", "P", libDir, "CHPL_LIB_SAVE_DIR", verifySaveLibDir},
  {"library-header", ' ', "<filename>", "Name generated header file", "P", libmodeHeadername, NULL, setLibmode},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -358,6 +358,7 @@ std::vector<std::string> gDynoPrependStandardModulePaths;
 int fGPUBlockSize = 0;
 char fGpuArch[gpuArchNameLen+1] = "";
 bool fGpuPtxasEnforceOpt;
+bool fGpuSpecialization = false;
 const char* gGpuSdkPath = NULL;
 char gpuArch[gpuArchNameLen+1] = "";
 
@@ -1261,6 +1262,7 @@ static ArgumentDescription arg_desc[] = {
  {"gpu-block-size", ' ', "<block-size>", "Block size for GPU launches", "I", &fGPUBlockSize, "CHPL_GPU_BLOCK_SIZE", NULL},
  {"gpu-arch", ' ', "<cuda-architecture>", "CUDA architecture to use", "S16", &fGpuArch, "_CHPL_GPU_ARCH", setEnv},
  {"gpu-ptxas-enforce-optimization", ' ', NULL, "Modify generated .ptxas file to enable optimizations", "F", &fGpuPtxasEnforceOpt, NULL, NULL},
+ {"gpu-specialization", ' ', NULL, "Enable [disable] an optimization that clones functions known to executed on a GPU locale", "N", &fGpuSpecialization, "CHPL_GPU_SPECIALIZATION", NULL},
  {"library", ' ', NULL, "Generate a Chapel library file", "F", &fLibraryCompile, NULL, NULL},
  {"library-dir", ' ', "<directory>", "Save generated library helper files in directory", "P", libDir, "CHPL_LIB_SAVE_DIR", verifySaveLibDir},
  {"library-header", ' ', "<filename>", "Name generated header file", "P", libmodeHeadername, NULL, setLibmode},

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <set>
 #include <queue>
+#include <list>
 #include "stmt.h"
 #include "stlUtil.h"
 #include "passes.h"
@@ -157,6 +158,169 @@ static bool isDegenerateOuterRef(Symbol* sym, CForLoop* loop) {
 }
 
 // ----------------------------------------------------------------------------
+// CreateGpuFunctionSpecializations
+// ----------------------------------------------------------------------------
+
+/**
+ * Performs a pass to find functions reachable from an `on` statement and clones
+ * them into functions flagged with FLAG_GPU_SPECIALIZATION. Rewrite the
+ * specializations to call to each other and rewrite the 'on block' to query
+ * whether or not the current sublocale is to a GPU and if so, call the GPU
+ * specialized clone (and if not, call the non-GPU specialized original).
+ *
+ * Effectively this sets things up so within a "GPU Specialized" function we can
+ * safely assume we're 'on' a GPU sublocale.
+ **/
+class CreateGpuFunctionSpecializations {
+  std::map<FnSymbol *, FnSymbol *> specMap_; // Map original functions to GPU specialized clones
+
+  FnSymbol* getGpuSpecializationOfFcn(FnSymbol *nonGpuFunction) const;
+  FnSymbol* createGpuSpecializationOfFn(FnSymbol* fn);
+  std::queue<FnSymbol*> findAndCloneOnFns();
+  void findAndCloneFnsReachableFromQueue(std::queue<FnSymbol*> &queue);
+  void rewriteCallToOnFnInOnBlock(CallExpr *call) const;
+  void rewriteOnBlock(FnSymbol *fn) const;
+  void findAndRewriteOnBlocks() const;
+  void rewriteSpecializationToCallOtherSpecializations(FnSymbol *fn) const;
+  void rewriteSpecializationsToCallOtherSpecializations() const;
+
+  public:
+
+  void doit();
+};
+
+FnSymbol* CreateGpuFunctionSpecializations::getGpuSpecializationOfFcn(FnSymbol *nonGpuFunction) const {
+  auto entry = specMap_.find(nonGpuFunction);
+  if(entry != specMap_.end()) {
+    return entry->second;
+  }
+  return nullptr;
+}
+
+FnSymbol* CreateGpuFunctionSpecializations::createGpuSpecializationOfFn(FnSymbol* fn) {
+  SET_LINENO(fn);
+  auto specMapFnIter = specMap_.find(fn);
+  if (FnSymbol *alreadySpecialized =
+      specMapFnIter != specMap_.end() ? specMapFnIter->first : nullptr)
+  {
+    (void)alreadySpecialized;
+    return nullptr;
+  } else if (!fn->hasFlag(FLAG_EXTERN)) {
+    FnSymbol* gpuSpecFn = fn->copy();
+    gpuSpecFn->addFlag(FLAG_GPU_SPECIALIZATION);
+    fn->defPoint->insertBefore(new DefExpr(gpuSpecFn));
+
+    specMap_[fn] = gpuSpecFn;
+    specMap_[gpuSpecFn] = gpuSpecFn; // to handle recursion
+
+    return gpuSpecFn;
+  }
+  return nullptr;
+}
+
+std::queue<FnSymbol*> CreateGpuFunctionSpecializations::findAndCloneOnFns() {
+  std::queue<FnSymbol*> queue;
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (fn->hasFlag(FLAG_ON)) {
+      SET_LINENO(fn);
+      if(FnSymbol *newSpec = createGpuSpecializationOfFn(fn)) {
+        queue.push(newSpec);
+      }
+    }
+  }
+  return queue;
+}
+
+void CreateGpuFunctionSpecializations::findAndCloneFnsReachableFromQueue(std::queue<FnSymbol*> &queue) {
+  while (queue.empty() == false) {
+    FnSymbol* gpuReachableFn = queue.front();
+    queue.pop();
+
+    std::vector<CallExpr*> calls;
+    collectCallExprs(gpuReachableFn, calls);
+    for_vector(CallExpr, call, calls) {
+      if (FnSymbol* fn = call->resolvedFunction()) {
+        FnSymbol* gpuFn = createGpuSpecializationOfFn(fn);
+        if(gpuFn) {
+          queue.push(gpuFn);
+        }
+      }
+    }
+  }
+}
+
+void CreateGpuFunctionSpecializations::rewriteCallToOnFnInOnBlock(CallExpr *call) const {
+  SET_LINENO(call);
+  BlockStmt* cpuBlock = new BlockStmt();
+  BlockStmt* gpuBlock = new BlockStmt();
+
+  // populate the gpu block
+  CallExpr* gpuCall = call->copy();
+  gpuCall->baseExpr = new SymExpr(getGpuSpecializationOfFcn(call->resolvedFunction()));
+  gpuBlock->insertAtTail(gpuCall);
+
+  CallExpr* condExpr = new CallExpr(PRIM_GREATEROREQUAL,
+                                    new CallExpr(PRIM_GET_REQUESTED_SUBLOC),
+                                    new_IntSymbol(0));
+
+  // we can't add elseStmt later on
+  CondStmt* cond = new CondStmt(condExpr, gpuBlock,
+                                isFullGpuCodegen() ? cpuBlock : NULL);
+
+  // first, make sure the conditional is in place
+  call->insertBefore(cond);
+
+  // then relocate the loop
+  cpuBlock->insertAtHead(call->remove());
+}
+
+void CreateGpuFunctionSpecializations::rewriteOnBlock(FnSymbol *fn) const {
+  std::vector<CallExpr*> calls;
+  collectCallExprs(fn, calls);
+  for_vector(CallExpr, call, calls) {
+    if (FnSymbol* fn = call->resolvedFunction()) {
+      if(fn->hasFlag(FLAG_ON)) {
+        rewriteCallToOnFnInOnBlock(call);
+      }
+    }
+  }
+}
+
+void CreateGpuFunctionSpecializations::findAndRewriteOnBlocks() const {
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (fn->hasFlag(FLAG_ON_BLOCK)) {
+      rewriteOnBlock(fn);
+    }
+  }
+}
+
+void CreateGpuFunctionSpecializations::rewriteSpecializationToCallOtherSpecializations(FnSymbol *fn) const {
+  std::vector<CallExpr*> calls;
+  collectCallExprs(fn, calls);
+  for_vector(CallExpr, call, calls) {
+    FnSymbol* callee = call->resolvedFunction();
+    if (FnSymbol* newFn = getGpuSpecializationOfFcn(callee)) {
+      SET_LINENO(call);
+      call->baseExpr->replace(new SymExpr(newFn));
+    }
+  }
+}
+
+void CreateGpuFunctionSpecializations::rewriteSpecializationsToCallOtherSpecializations() const {
+  for (const auto& entry : specMap_) {
+    rewriteSpecializationToCallOtherSpecializations(entry.second);
+  }
+}
+
+void CreateGpuFunctionSpecializations::doit() {
+  std::queue<FnSymbol*> queue = findAndCloneOnFns();
+  findAndCloneFnsReachableFromQueue(queue);
+  findAndRewriteOnBlocks();
+  rewriteSpecializationsToCallOtherSpecializations();
+}
+
+
+// ----------------------------------------------------------------------------
 // GpuizableLoop
 // ----------------------------------------------------------------------------
 
@@ -183,7 +347,6 @@ public:
     return std::find(loopIndices_.begin(), loopIndices_.end(), sym) !=
       loopIndices_.end();
   }
-
 
 private:
   bool determineIfShouldErrorIfNotGpuizable();
@@ -364,8 +527,6 @@ bool GpuizableLoop::callsInBodyAreGpuizableHelp(BlockStmt* blk,
   return true;
 }
 
-
-
 bool GpuizableLoop::attemptToExtractLoopInformation() {
   // Pattern match loop boundaries to determine lower
   // and upper bounds. If we fail to match exit early.
@@ -454,25 +615,21 @@ class GpuKernel {
   std::vector<Symbol*> kernelActuals_;
   SymbolMap copyMap_;
   bool lateGpuizationFailure_;
-  std::vector<CallExpr*> callExprsInBody_;
-
-  public:
   SymExpr* blockSize_;
 
+  public:
   GpuKernel(const GpuizableLoop &gpuLoop, DefExpr* insertionPoint);
+
   FnSymbol* fn() const { return fn_; }
   const std::vector<Symbol*>& kernelActuals() { return kernelActuals_; }
   bool lateGpuizationFailure() const { return lateGpuizationFailure_; }
+  SymExpr* blockSize() const {return blockSize_; }
 
   private:
   void buildStubOutlinedFunction(DefExpr* insertionPoint);
-  // Has a side effect of removing the block size primitive from the loop
-  // and the (future) outlined function.
-  void handleAndRemoveBlockSize(CForLoop *loop);
+  void determineBlockSize();
+  static bool isCallToPrimitiveWeShouldNotCopyIntoKernel(CallExpr *call);
   void populateBody(CForLoop *loop, FnSymbol *outlinedFunction);
-  // Has a side effect of modifying the original loop body, replacing
-  // calls to GPU-only primitives with dummy values and errors.
-  void replaceDisallowedPrimitives();
   void normalizeOutlinedFunction();
   void finalize();
 
@@ -490,9 +647,8 @@ GpuKernel::GpuKernel(const GpuizableLoop &gpuLoop, DefExpr* insertionPoint)
 {
   buildStubOutlinedFunction(insertionPoint);
   normalizeOutlinedFunction();
-  handleAndRemoveBlockSize(gpuLoop.loop());
+  determineBlockSize();
   populateBody(gpuLoop.loop(), fn_);
-  replaceDisallowedPrimitives();
   if(!lateGpuizationFailure_) {
     finalize();
   }
@@ -615,20 +771,26 @@ void GpuKernel::generateEarlyReturn() {
   fn_->insertAtTail(new CondStmt(new SymExpr(isOOB), thenBlock));
 }
 
-void GpuKernel::handleAndRemoveBlockSize(CForLoop *loop) {
-  for_alist(node, loop->body) {
-    collectCallExprs(node, callExprsInBody_);
+void GpuKernel::determineBlockSize() {
+  std::vector<CallExpr*> callExprsInBody;
+  for_alist(node, gpuLoop.loop()->body) {
+    collectCallExprs(node, callExprsInBody);
   }
 
-  for_vector(CallExpr, callExpr, callExprsInBody_) {
+  for_vector(CallExpr, callExpr, callExprsInBody) {
     if (callExpr->isPrimitive(PRIM_GPU_SET_BLOCKSIZE)) {
       if (blockSize_ != nullptr) {
         USR_FATAL(callExpr, "Can only set GPU block size once per GPU-eligible loop.");
       }
       blockSize_ = toSymExpr(callExpr->get(1));
-      callExpr->remove();
     }
   }
+}
+
+bool GpuKernel::isCallToPrimitiveWeShouldNotCopyIntoKernel(CallExpr *call) {
+  return call && 
+    (call->isPrimitive(PRIM_ASSERT_ON_GPU) ||
+     call->isPrimitive(PRIM_GPU_SET_BLOCKSIZE));
 }
 
 void GpuKernel::populateBody(CForLoop *loop, FnSymbol *outlinedFunction) {
@@ -643,12 +805,7 @@ void GpuKernel::populateBody(CForLoop *loop, FnSymbol *outlinedFunction) {
     collectDefExprs(node, defExprsInBody);
 
     CallExpr* call = toCallExpr(node);
-    if(call && call->isPrimitive(PRIM_ASSERT_ON_GPU)) {
-      // The outlined kernel can only be executed on the GPU so there's no need
-      // to copy it over. Note: not all device functions are kernels so this does
-      // not ensure that this assertion won't work its way into functions
-      // called from the kernel, but we remove it here anyway cause why not, it's
-      // a slight optimization.
+    if(isCallToPrimitiveWeShouldNotCopyIntoKernel(call)) {
       copyNode = false;
     }
     else if (DefExpr* def = toDefExpr(node)) {
@@ -746,40 +903,6 @@ void GpuKernel::populateBody(CForLoop *loop, FnSymbol *outlinedFunction) {
   update_symbols(outlinedFunction->body, &copyMap_);
 }
 
-static const std::unordered_map<PrimitiveTag, const char*>
-gpuPrimitivesDisallowedOnHost = {
-  { PRIM_GPU_BLOCKIDX_X, "getBlockIdxX" },
-  { PRIM_GPU_BLOCKIDX_Y, "getBlockIdxY" },
-  { PRIM_GPU_BLOCKIDX_Z, "getBlockIdxZ" },
-  { PRIM_GPU_BLOCKDIM_X, "getBlockDimX" },
-  { PRIM_GPU_BLOCKDIM_Y, "getBlockDimY" },
-  { PRIM_GPU_BLOCKDIM_Z, "getBlockDimZ" },
-  { PRIM_GPU_THREADIDX_X, "getThreadIdxX" },
-  { PRIM_GPU_THREADIDX_Y, "getThreadIdxY" },
-  { PRIM_GPU_THREADIDX_Z, "getThreadIdxZ" },
-  { PRIM_GPU_GRIDDIM_X, "getGridDimX" },
-  { PRIM_GPU_GRIDDIM_Y, "getGridDimY" },
-  { PRIM_GPU_GRIDDIM_Z, "getGridDimZ" },
-};
-
-void GpuKernel::replaceDisallowedPrimitives() {
-  for_vector(CallExpr, callExpr, callExprsInBody_) {
-    if (!callExpr->isPrimitive()) continue;
-    auto tagIt = gpuPrimitivesDisallowedOnHost.find(callExpr->primitive->tag);
-    if (tagIt == gpuPrimitivesDisallowedOnHost.end()) continue;
-
-    auto errorMsg = new_CStringSymbol(astr("operation not allowed outside of GPU: ",
-                                           tagIt->second));
-    // Expecting AST:
-    //   (move call_tmp (call 'gpu prim'))
-    // Want:
-    //   (call 'rt_error' c"Operation not allowed")
-    //   (move call_tmp 0)
-    callExpr->parentExpr->insertBefore(new CallExpr(PRIM_RT_ERROR, errorMsg));
-    callExpr->replace(new SymExpr(new_IntSymbol(0)));
-  }
-}
-
 
 void GpuKernel::normalizeOutlinedFunction() {
   normalize(fn_);
@@ -841,6 +964,89 @@ void GpuKernel::markGPUSubCalls(FnSymbol* fn) {
 }
 
 // ----------------------------------------------------------------------------
+// CpuBoundLoopCleanup 
+// ----------------------------------------------------------------------------
+
+// Post process a foreach loop after we have outlined it into a GPU kernel
+// or have it remain in a non-gpu specialization of a function
+class CpuBoundLoopCleanup {
+  // If these primitives are ever encountered in a loop (running on the CPU) then
+  // we should have a runtime error
+  static const std::unordered_map<PrimitiveTag, const char *>
+    gpuPrimitivesDisallowedOnHost;
+
+  // We will remove any calls to these primitives on host code 
+  static const std::unordered_set<PrimitiveTag> gpuPrimitivesStripOnHost;
+
+  static void replaceDisallowedPrimitiveWithError(CallExpr *callExpr) {
+    INT_ASSERT(callExpr->isPrimitive());
+    SET_LINENO(callExpr);
+
+    auto tagIt = gpuPrimitivesDisallowedOnHost.find(callExpr->primitive->tag);
+    if (tagIt == gpuPrimitivesDisallowedOnHost.end()) {
+        return;
+    }
+
+    auto errorMsg = new_CStringSymbol(
+        astr("operation not allowed outside of GPU: ", tagIt->second));
+    // Expecting AST:
+    //   (move call_tmp (call 'gpu prim'))
+    // Want:
+    //   (call 'rt_error' c"Operation not allowed")
+    //   (move call_tmp 0)
+    callExpr->parentExpr->insertBefore(new CallExpr(PRIM_RT_ERROR, errorMsg));
+    callExpr->replace(new SymExpr(new_IntSymbol(0)));
+  }
+
+  static void stripPrimitiveIfWeShouldStrip(CallExpr *callExpr) {
+    INT_ASSERT(callExpr->isPrimitive());
+    auto tagIt = gpuPrimitivesStripOnHost.find(callExpr->primitive->tag);
+    if (tagIt == gpuPrimitivesStripOnHost.end()) {
+        return;
+    }
+    callExpr->remove();
+  }
+
+  public:
+
+  static void doit(CForLoop *loop) {
+    std::vector<CallExpr*> callExprsInBody;
+    for_alist(node, loop->body) {
+      collectCallExprs(node, callExprsInBody);
+    }
+
+    for_vector(CallExpr, callExpr, callExprsInBody) {
+      if(callExpr->isPrimitive()) {
+        replaceDisallowedPrimitiveWithError(callExpr);
+        stripPrimitiveIfWeShouldStrip(callExpr);
+      }
+    }
+  }
+};
+
+const std::unordered_map<PrimitiveTag, const char *>
+  CpuBoundLoopCleanup::gpuPrimitivesDisallowedOnHost = {
+      {PRIM_GPU_BLOCKIDX_X, "getBlockIdxX"},
+      {PRIM_GPU_BLOCKIDX_Y, "getBlockIdxY"},
+      {PRIM_GPU_BLOCKIDX_Z, "getBlockIdxZ"},
+      {PRIM_GPU_BLOCKDIM_X, "getBlockDimX"},
+      {PRIM_GPU_BLOCKDIM_Y, "getBlockDimY"},
+      {PRIM_GPU_BLOCKDIM_Z, "getBlockDimZ"},
+      {PRIM_GPU_THREADIDX_X, "getThreadIdxX"},
+      {PRIM_GPU_THREADIDX_Y, "getThreadIdxY"},
+      {PRIM_GPU_THREADIDX_Z, "getThreadIdxZ"},
+      {PRIM_GPU_GRIDDIM_X, "getGridDimX"},
+      {PRIM_GPU_GRIDDIM_Y, "getGridDimY"},
+      {PRIM_GPU_GRIDDIM_Z, "getGridDimZ"},
+};
+
+// We will remove any calls to these primitives on host code 
+const std::unordered_set<PrimitiveTag>
+    CpuBoundLoopCleanup::gpuPrimitivesStripOnHost = {
+      PRIM_GPU_SET_BLOCKSIZE
+    };
+
+// ----------------------------------------------------------------------------
 // GPU Transforms
 // ----------------------------------------------------------------------------
 /**
@@ -883,9 +1089,9 @@ static CallExpr* generateGPUCall(GpuKernel& info, VarSymbol* numThreads) {
 
   call->insertAtTail(numThreads);  // total number of GPU threads
 
-  if (info.blockSize_) {
+  if (info.blockSize()) {
     // sets blockSize if specified with by "gpu set BlockSize" primitive
-    call->insertAtTail(info.blockSize_->copy());
+    call->insertAtTail(info.blockSize()->copy());
   } else {
     int blockSize = fGPUBlockSize != 0 ? fGPUBlockSize : 512;
     call->insertAtTail(new_IntSymbol(blockSize));
@@ -900,6 +1106,11 @@ static CallExpr* generateGPUCall(GpuKernel& info, VarSymbol* numThreads) {
 
 static void generateGpuAndNonGpuPaths(const GpuizableLoop &gpuLoop,
                                       GpuKernel &kernel) {
+  // If we're not creating AST specializations for functions where we can assume
+  // we're on a GPU sublocale, then every time, before doing a kernel launch, we
+  // need to check and see if we are on a GPU sublocale. The code to do this
+  // looks like this:
+  //
   // if (chpl_task_getRequestedSubloc() >= 0) {
   //   code to determine number of threads to launch kernel with
   //   call the generated GPU kernel
@@ -912,31 +1123,41 @@ static void generateGpuAndNonGpuPaths(const GpuizableLoop &gpuLoop,
   // will make sure that we call the runtime support as if there's a GPU, yet
   // still executing the loop always.
 
-  BlockStmt* cpuBlock = new BlockStmt();
-  BlockStmt* gpuBlock = new BlockStmt();
+  if(fGpuSpecialization) {
+    // If we are creating GPU specializations then we already know we're on a GPU
+    // sublocale and can just generate the kernel launch call
+    BlockStmt* gpuBlock = new BlockStmt();
+    VarSymbol *numThreads = generateNumThreads(gpuBlock, gpuLoop);
+    CallExpr* gpuCall = generateGPUCall(kernel, numThreads);
+    gpuBlock->insertAtTail(gpuCall);
+    gpuLoop.loop()->replace(gpuBlock);
+  } else {
+    BlockStmt* cpuBlock = new BlockStmt();
+    BlockStmt* gpuBlock = new BlockStmt();
 
-  // populate the gpu block
-  VarSymbol *numThreads = generateNumThreads(gpuBlock, gpuLoop);
-  CallExpr* gpuCall = generateGPUCall(kernel, numThreads);
-  gpuBlock->insertAtTail(gpuCall);
+    // populate the gpu block
+    VarSymbol *numThreads = generateNumThreads(gpuBlock, gpuLoop);
+    CallExpr* gpuCall = generateGPUCall(kernel, numThreads);
+    gpuBlock->insertAtTail(gpuCall);
 
-  CallExpr* condExpr = new CallExpr(PRIM_GREATEROREQUAL,
-                                    new CallExpr(PRIM_GET_REQUESTED_SUBLOC),
-                                    new_IntSymbol(0));
+    CallExpr* condExpr = new CallExpr(PRIM_GREATEROREQUAL,
+                                      new CallExpr(PRIM_GET_REQUESTED_SUBLOC),
+                                      new_IntSymbol(0));
 
-  // we can't add elseStmt later on
-  CondStmt* cond = new CondStmt(condExpr, gpuBlock,
-                                isFullGpuCodegen() ? cpuBlock : NULL);
+    // we can't add elseStmt later on
+    CondStmt* cond = new CondStmt(condExpr, gpuBlock,
+                                  isFullGpuCodegen() ? cpuBlock : NULL);
 
-  // first, make sure the conditional is in place
-  gpuLoop.loop()->insertBefore(cond);
+    // first, make sure the conditional is in place
+    gpuLoop.loop()->insertBefore(cond);
 
-  // then relocate the loop
-  cpuBlock->insertAtHead(gpuLoop.loop()->remove());
+    // then relocate the loop
+    cpuBlock->insertAtHead(gpuLoop.loop()->remove());
 
-  // if not doing GPU codegen, just add cpuBlock after the conditional
-  if (!isFullGpuCodegen()) {
-    cond->insertAfter(cpuBlock);
+    // if not doing GPU codegen, just add cpuBlock after the conditional
+    if (!isFullGpuCodegen()) {
+      cond->insertAfter(cpuBlock);
+    }
   }
 }
 
@@ -952,18 +1173,56 @@ static void outlineEligibleLoop(FnSymbol *fn, GpuizableLoop &gpuLoop) {
   }
 }
 
-static void outlineGPUKernels() {
-  forv_Vec(FnSymbol*, fn, gFnSymbols) {
-    std::vector<BaseAST*> asts;
-    collect_asts(fn, asts);
+static void outlineGpuKernelsInFn(FnSymbol *fn) {
+  std::vector<BaseAST*> asts;
+  collect_asts(fn, asts);
 
-    for_vector(BaseAST, ast, asts) {
-      if (CForLoop* loop = toCForLoop(ast)) {
-        GpuizableLoop gpuLoop(loop);
-        if (gpuLoop.isEligible()) {
-          outlineEligibleLoop(fn, gpuLoop);
-        }
+  for_vector(BaseAST, ast, asts) {
+    if (CForLoop* loop = toCForLoop(ast)) {
+      // In the case of a nested foreach loop we may end up replacing the
+      // outer loop with a kernel call and in doing so making the loop no
+      // longer in the tree.
+      if (!loop->inTree()) {
+        continue;
       }
+
+      GpuizableLoop gpuLoop(loop);
+      if (gpuLoop.isEligible()) {
+        outlineEligibleLoop(fn, gpuLoop);
+      }
+    }
+  }
+}
+
+// We need to strip any GPU specific primitives that remain i
+static void cleanupForeachLoopsGauranteedToRunOnCpu(FnSymbol *fn) {
+  std::vector<BaseAST*> asts;
+  collect_asts(fn, asts);
+  for_vector(BaseAST, ast, asts) {
+    if (CForLoop* loop = toCForLoop(ast)) {
+      CpuBoundLoopCleanup::doit(loop);
+    }
+  }
+}
+
+static void doGpuTransforms() {
+  if(fGpuSpecialization) {
+    CreateGpuFunctionSpecializations().doit();
+  }
+
+  // Outline all eligible loops; cleanup CPU bound loops
+  forv_Vec(FnSymbol*, fn, gFnSymbols) {
+    if(fGpuSpecialization && !fn->hasFlag(FLAG_GPU_SPECIALIZATION)) {
+      // By definition all foreach loops in a function without this flag
+      // will be run on the CPU:
+      cleanupForeachLoopsGauranteedToRunOnCpu(fn);
+    } else {
+      outlineGpuKernelsInFn(fn);
+
+      // All eligible loops in the function will have been outlined into
+      // kernels at this point so anything that remains is gauranteed to
+      // run on the CPU
+      cleanupForeachLoopsGauranteedToRunOnCpu(fn);
     }
   }
 }
@@ -985,6 +1244,8 @@ static void logGpuizableLoops() {
   }
 }
 
+// ----------------------------------------------------------------------------
+
 void gpuTransforms() {
   if (debugPrintGPUChecks) {
     logGpuizableLoops();
@@ -995,7 +1256,7 @@ void gpuTransforms() {
   if (usingGpuLocaleModel()) {
     if (fReportGpuTransformTime) gpuTransformTimer.start();
 
-    outlineGPUKernels();
+    doGpuTransforms();
 
     if (fReportGpuTransformTime) {
       gpuTransformTimer.stop();

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1018,7 +1018,7 @@ class CpuBoundLoopCleanup {
 
     for_vector(CallExpr, callExpr, callExprsInBody) {
       if(callExpr->isPrimitive()) {
-        replaceDisallowedPrimitiveWithError(callExpr) &&
+        replaceDisallowedPrimitiveWithError(callExpr) ||
         stripPrimitiveIfWeShouldStrip(callExpr);
       }
     }

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -269,6 +269,7 @@ PRAGMA(GLOBAL_VAR_BUILTIN, ypr, "global var builtin", "is accessible through a g
 PRAGMA(GPU_CODEGEN, ypr, "codegen for GPU", "generate GPU code and set function calling convention to kernel launch")
 PRAGMA(GPU_AND_CPU_CODEGEN, ypr, "codegen for CPU and GPU", "generate both GPU and CPU code")
 PRAGMA(ASSERT_ON_GPU, ypr, "assert on gpu", "triggers runtime assertion if not running on device")
+PRAGMA(GPU_SPECIALIZATION, npr, "gpu specialization", ncm)
 
 PRAGMA(HAS_POSTINIT, ypr, "has postinit", "type that has a postinit method")
 PRAGMA(HAS_RUNTIME_TYPE, ypr, "has runtime type", "type that has an associated runtime type")

--- a/test/GPU-GRAPHFILES
+++ b/test/GPU-GRAPHFILES
@@ -13,6 +13,7 @@ gpu/native/studies/shoc/sort.graph
 gpu/native/streamPrototype/gpuStream.graph
 
 gpu/native/studies/kernelLaunch/emptyKernelLaunch.graph
+gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.graph
 
 gpu/native/studies/transpose/transpose-throughput.graph
 gpu/native/studies/transpose/transpose-time.graph

--- a/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.chpl
+++ b/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.chpl
@@ -1,0 +1,46 @@
+use GpuDiagnostics;
+use Time;
+
+config const timeLimit = 5; //seconds
+config const validate = false;
+config const report = false;
+
+config const N = 30_000;
+config param M = 10;
+config const P = 100;
+
+// ----------------------------------------------------------------------------
+
+inline proc trial(ref A) {
+  for i in 0..N {
+    for param j in 0..<M {
+      foreach k in 0..<P { A[k] = i; }
+    }
+  }
+}
+
+var t = new stopwatch();
+
+if validate then startGpuDiagnostics();
+var numTrials = 0;
+
+var A : [0..<M] int;
+
+t.start();
+do {
+  trial(A);
+  numTrials += 1;
+} while t.elapsed() < timeLimit;
+t.stop();
+
+if validate {
+  stopGpuDiagnostics();
+  assert(getGpuDiagnostics()[0].kernel_launch == 0);
+}
+
+if report {
+  const perTrialTime = t.elapsed()/numTrials;
+  writeln("Total test time (s): ", t.elapsed());
+  writeln("Number of trials: ", numTrials);
+  writeln("Average time per trial (ms): ", perTrialTime*1_000);
+}

--- a/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.compopts
+++ b/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.compopts
@@ -1,0 +1,4 @@
+# This is primarily a performance test. We want to check its correctness under
+# performance configuration
+--fast
+--fast --gpu-specialization

--- a/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.execopts
+++ b/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.execopts
@@ -1,0 +1,1 @@
+--validate=true --report=false --timeLimit=10

--- a/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.gpu-compopts
+++ b/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.gpu-compopts
@@ -1,0 +1,4 @@
+# This is primarily a performance test. We want to check its correctness under
+# performance configuration
+--fast                      # tightLoopNotOnGpu-no-spec
+--fast --gpu-specialization # tightLoopNotOnGpu-with-spec

--- a/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.gpu-execopts
+++ b/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.gpu-execopts
@@ -1,0 +1,1 @@
+--validate=false --report=true --timeLimit=10

--- a/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.gpu-keys
+++ b/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.gpu-keys
@@ -1,0 +1,1 @@
+Average time per trial (ms):

--- a/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.graph
+++ b/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.graph
@@ -1,0 +1,5 @@
+perfkeys: Average time per trial (ms):, Average time per trial (ms):
+files: tightLoopNotOnGpu-no-spec.dat, tightLoopNotOnGpu-with-spec.dat
+graphkeys: Without specialization, With specialization
+ylabel: Time (ms)
+graphtitle: Gpuizable loops on CPU locale in a tight loop

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -82,6 +82,7 @@ _chpl ()
 --gpu-arch \
 --gpu-block-size \
 --gpu-ptxas-enforce-optimization \
+--gpu-specialization \
 --hdr-search-path \
 --help \
 --help-env \
@@ -189,6 +190,7 @@ _chpl ()
 --no-force-vectorize \
 --no-formal-domain-checks \
 --no-gen-ids \
+--no-gpu-specialization \
 --no-html-print-block-ids \
 --no-html-wrap-lines \
 --no-ieee-float \


### PR DESCRIPTION
This PR adds a new mode for GPU transforms that can be enabled by passing `--gpu-specialization` to `chpl`. In this mode we clone functions reachable from 'on' statements and then rewrite the 'on' statement to query if you're on a GPU sublocale. If so, we go to these cloned versions (and otherwise go to the originals). With this now being the case, we can safely assume that a user is "on" a GPU sublocale in all of these cloned versions, so we have kernel launches in these functions launch directly without checking. For more info see: https://github.com/Cray/chapel-private/issues/4566

**Notes to reviewers**:

- The bulk of work is in a new `CreateGpuFunctionSpecializations` class in `GpuTransforms`.
    - Start by reading the `CreateGpuFunctionSpecializations::doit` function and go from there.
  - When in this mode I have `generateGpuAndNonGpuPaths` fully replace GPU-eligible loop with a kernel call (no need to check if we're on a GPU sublocale)
- I factored out some work that deals with cleaning up primitives that remain in the CPU-bound version of a gpuizable loop.
  - Why: before we did this while processing the loop (rewriting it in the process). But when we're doing gpu specialization we only process the loop on the GPU-bound specialization but we need to have these cleanups done on the CPU-bound.
  - This cleanup code is now in a separate `CpuBoundLoopCleanup` class
- Adds a flag to `chpl`: `--gpu-specialization` (can also be set with the `CHPL_GPU_SPECIALIZATION` environment variable) to turn the feature on. By default it is off.
- Update Bash autocomplete script to include this new flag.
- Adds a nightly performance test for an artificial benchmark of a bunch of kernel launches in a tightly nested loop (run with and without this optimization in play).

TODO:
- [x] GPU Paratests (NVIDIA)
- [x] start_test of GPU tests with `CHPL_GPU_SPECIALIZATION=y` set (NVIDIA)
- [x] Flat locale model paratests