### PR TITLE
Several minor type resolution fixes for dyno

### DIFF
--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -216,6 +216,9 @@ class CompositeType : public Type {
   /** Get the bytes type */
   static const RecordType* getBytesType(Context* context);
 
+  /** Get the locale type */
+  static const RecordType* getLocaleType(Context* context);
+
   /** When compiling without a standard library (for testing purposes),
       the compiler code needs to work around the fact that there
       is no definition available for the bundled types needed

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -670,6 +670,9 @@ bool InitResolver::handleResolvingFieldAccess(const Dot* node) {
         re.setType(qt);
         return false;
       }
+    } else {
+      // Otherwise, proceed normally.
+      return false;
     }
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2990,6 +2990,15 @@ void Resolver::exit(const Call* call) {
 
     // handle type inference for variables split-inited by 'out' formals
     adjustTypesForOutFormals(ci, actualAsts, c.mostSpecific());
+  } else {
+    // For practical development/debugging, set the ResolvedExpression for
+    // this call in case resolution proceeds to the point where some other
+    // part of resolution assumes there is an entry for this call.
+    //
+    // Otherwise we would run into out_of_range exceptions when accessing
+    // the resolution result.
+    ResolvedExpression& r = byPostorder.byAst(call);
+    r.setType(QualifiedType());
   }
 
   inLeafCall = nullptr;

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -292,9 +292,15 @@ CallResolutionResult resolvePrimCall(Context* context,
 
   // handle param folding
   auto prim = call->prim();
-  if (Param::isParamOpFoldable(prim) && allParam && ci.numActuals() == 2) {
+  if (Param::isParamOpFoldable(prim) && allParam) {
+    if (ci.numActuals() == 2) {
       type = Param::fold(context, prim, ci.actual(0).type(), ci.actual(1).type());
-      return CallResolutionResult(candidates, type, poi);
+    } else if (ci.numActuals() == 1) {
+      type = Param::fold(context, prim, ci.actual(0).type(), QualifiedType());
+    } else {
+      CHPL_ASSERT(false && "unsupported param folding");
+    }
+    return CallResolutionResult(candidates, type, poi);
   }
 
   // otherwise, handle each primitive individually

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -132,6 +132,15 @@ const RecordType* CompositeType::getBytesType(Context* context) {
                          SubstitutionsMap());
 }
 
+const RecordType* CompositeType::getLocaleType(Context* context) {
+  auto symbolPath = UniqueString::get(context, "ChapelLocale._locale");
+  auto name = UniqueString::get(context, "locale");
+  auto id = ID(symbolPath, -1, 0);
+  return RecordType::get(context, id, name,
+                         /* instantiatedFrom */ nullptr,
+                         SubstitutionsMap());
+}
+
 bool CompositeType::isMissingBundledType(Context* context, ID id) {
   return isMissingBundledClassType(context, id) ||
          isMissingBundledRecordType(context, id);

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -326,11 +326,8 @@ QualifiedType Param::fold(Context* context,
                           QualifiedType a,
                           QualifiedType b) {
   CHPL_ASSERT(a.hasTypePtr() && a.hasParamPtr());
-  CHPL_ASSERT(b.hasTypePtr() && b.hasParamPtr());
-
   // convert Param to Immediate
   Immediate aImm = paramToImmediate(a.param(), a.type());
-  Immediate bImm = paramToImmediate(b.param(), b.type());
   Immediate result;
 
   // fold
@@ -340,7 +337,14 @@ QualifiedType Param::fold(Context* context,
     CHPL_ASSERT(false && "param primitive op not foldable");
   }
 
-  fold_constant(context, immOp, &aImm, &bImm, &result);
+  if (b.isUnknown()) {
+    fold_constant(context, immOp, &aImm, nullptr, &result);
+  } else {
+    CHPL_ASSERT(b.hasTypePtr() && b.hasParamPtr());
+
+    Immediate bImm = paramToImmediate(b.param(), b.type());
+    fold_constant(context, immOp, &aImm, &bImm, &result);
+  }
 
   // convert from Immediate
   std::pair<const Param*, const Type*> pair = immediateToParam(context, result);

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -115,6 +115,9 @@ void Type::gatherBuiltins(Context* context,
   auto stringType = CompositeType::getStringType(context);
   gatherType(context, map, "string", stringType);
   gatherType(context, map, "_string", stringType);
+  auto localeType = CompositeType::getLocaleType(context);
+  gatherType(context, map, "locale", localeType);
+  gatherType(context, map, "_locale", localeType);
 
   gatherType(context, map, "Error", CompositeType::getErrorType(context));
 

--- a/frontend/test/resolution/testParamFolding.cpp
+++ b/frontend/test/resolution/testParamFolding.cpp
@@ -143,6 +143,30 @@ static void test10() {
   guard.realizeErrors();
 }
 
+static void testUnary() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    param val = false;
+
+    record R {
+      proc type foo(x:int) {
+        return x;
+      }
+    }
+
+    if __primitive("u!", val) {
+      var x = R.foo(5);
+    } else {
+      var x = R.foo("hello");
+    })""";
+
+  auto m = parseModule(context, program);
+  std::ignore = resolveModule(context, m->id());
+}
+
 int main() {
   test1();
   test2();
@@ -154,6 +178,8 @@ int main() {
   test8();
   test9();
   test10();
+
+  testUnary();
 
   return 0;
 }

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -115,7 +115,7 @@ void testProgram(const std::vector<ReturnVariant>& variants, F func,
     requiredKind = kind;
   }
   auto commonTypeResult = chpl::resolution::commonType(context, types, requiredKind);
-#if LLVM_VERSION_MAJOR >= 16
+#if LLVM_VERSION_MAJOR >= 15
   auto qt = commonTypeResult.value_or(QualifiedType());
 #else
   auto qt = commonTypeResult.getValueOr(QualifiedType());


### PR DESCRIPTION
This PR includes a few bundled improvements for type-resolving in dyno:
- Updates ``handleResolvingFieldAccess`` to ignore ``Dot`` expressions that don't start with "this"
- Enables param folding for unary operators
- Adds support for mapping the "locale" type to the "_locale" implementation
- Adds workaround for potential ``out_of_range`` exception in the cased of skipped calls
- Updates test to use ``value_or`` on llvm's ``Optional`` type if LLVM 15 is available
  - since the other method was deprecated in version 15

Testing:
- [x] test-dyno