### PR TITLE
Fix Spack deps getting 'module purge'd from common-cray-cs.bash

### DIFF
--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -20,6 +20,12 @@ function loadCSModule()
 if module avail craype- 2>&1 | grep -q craype- ; then
   export CHPL_HOST_PLATFORM=cray-cs
   export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
+  # Remove unwanted modules from environment, then re-load base dependencies
+  # that wipes out. In the future this should unload only the unwanted modules,
+  # making re-loading necessary.
+  module purge
+  source $CWD/load-base-deps.bash
+
   loadCSModule gcc/8.1.0
   loadCSModule cray-fftw
   export LD_LIBRARY_PATH="$FFTW_DIR:$LD_LIBRARY_PATH"

--- a/util/cron/common-cray-cs.bash
+++ b/util/cron/common-cray-cs.bash
@@ -20,7 +20,6 @@ function loadCSModule()
 if module avail craype- 2>&1 | grep -q craype- ; then
   export CHPL_HOST_PLATFORM=cray-cs
   export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
-  module purge
   loadCSModule gcc/8.1.0
   loadCSModule cray-fftw
   export LD_LIBRARY_PATH="$FFTW_DIR:$LD_LIBRARY_PATH"

--- a/util/cron/common.bash
+++ b/util/cron/common.bash
@@ -6,31 +6,7 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/functions.bash
 
-if [ -f /data/cf/chapel/chpl-deps/setup_chpl_deps.bash ] ; then
-  # for chapcs/chapvm, just load all dependencies via spack
-  source /data/cf/chapel/chpl-deps/setup_chpl_deps.bash
-else
-  # For our internal testing, this is necessary to get the latest version of gcc
-  # on the system.
-  if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then
-      source ~/.bashrc
-      export CHPL_SOURCED_BASHRC=true
-  fi
-
-  # load llvm
-  if [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
-    source /cray/css/users/chapelu/setup_system_llvm.bash
-  elif [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
-    source /cy/users/chapelu/setup_system_llvm.bash
-  fi
-
-  # load cmake
-  if [ -f /cray/css/users/chapelu/setup_cmake_nightly.bash ] ; then
-    source /cray/css/users/chapelu/setup_cmake_nightly.bash
-  elif [ -f /cy/users/chapelu/setup_cmake_nightly.bash ] ; then
-    source /cy/users/chapelu/setup_cmake_nightly.bash
-  fi
-fi
+source $CWD/load-base-deps.bash
 
 log_info "gcc version: $(which gcc)"
 gcc --version

--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Sources base dependencies required for all tests.
+# Eventually this should be loading everything via spack.
+
+if [ -f /data/cf/chapel/chpl-deps/setup_chpl_deps.bash ] ; then
+  # for chapcs/chapvm, just load all dependencies via spack
+  source /data/cf/chapel/chpl-deps/setup_chpl_deps.bash
+else
+  # For our internal testing, this is necessary to get the latest version of gcc
+  # on the system.
+  if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then
+      source ~/.bashrc
+      export CHPL_SOURCED_BASHRC=true
+  fi
+
+  # load llvm
+  if [ -f /cray/css/users/chapelu/setup_system_llvm.bash ] ; then
+    source /cray/css/users/chapelu/setup_system_llvm.bash
+  elif [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
+    source /cy/users/chapelu/setup_system_llvm.bash
+  fi
+
+  # load cmake
+  if [ -f /cray/css/users/chapelu/setup_cmake_nightly.bash ] ; then
+    source /cray/css/users/chapelu/setup_cmake_nightly.bash
+  elif [ -f /cy/users/chapelu/setup_cmake_nightly.bash ] ; then
+    source /cy/users/chapelu/setup_cmake_nightly.bash
+  fi
+fi


### PR DESCRIPTION
For our perf tests, after sourcing `common.bash`, `common-cray-cs.bash` wipes out all modules and loads new ones. This worked fine previously, but with the Spackification, `common.bash` sources `setup-chpl-deps.bash` which loads all our Spack dependences using the module system. Those are now getting purged shortly after being loaded.

Commit 3fb64c90463b68a9d1cefaa365bd180f9ac03cba provides the reason this `module purge` is necessary. In future we should probably change it to remove specifically the modules we are concerned about. For the moment, this PR re-loads all the base dependencies after the `module purge`. To make this possible, loading base dependencies is separated out from `common.bash` into its own `load-base-deps.bash` script, `source`d by `common.bash`.

[reviewer info placeholder]

Testing:
- [x] manual run of a test using this script succeeds