### PR TITLE
Yield BigInt values by ref for block array scans

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1886,7 +1886,12 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
         }
 
         // Iterator that yields values instead of references (to enable RVF)
-        iter valIter(iterable) {
+        iter valIter(iterable) where isPOD(iterable.eltType) {
+          for elem in iterable do yield elem;
+        }
+
+        // BigInteger values are yielded by ref to disable RVF
+        iter valIter(iterable) ref where !isPOD(iterable.eltType) {
           for elem in iterable do yield elem;
         }
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4679,12 +4679,6 @@ module BigInteger {
   record __serializeHelper {
     var buff: mpz_t;
     var localeId: chpl_nodeID_t;
-
-    proc init(const ref otherBuff, const ref otherLocaleId) {
-      this.complete();
-      mpz_init_set(this.buff, otherBuff);
-      this.localeId = otherLocaleId;
-    }
   }
 
   @chpldoc.nodoc


### PR DESCRIPTION
BigInt values were being improperly remote value forwarded for block array scans (see https://github.com/Cray/chapel-private/issues/4925 for more information), so switching to yield BigInt values by ref in the scan, rather than creating copies to avoid what is believed to be stack memory corruption from values being cleaned up too early fixes this issue.

Closes https://github.com/Cray/chapel-private/issues/4925

- [x] paratest gasnet