### PR TITLE
Add dummy field to _serializeWrapper class

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2462,6 +2462,13 @@ private proc defaultSerializeVal(param writing : bool) {
 class _serializeWrapper {
   type T;
   var member: T;
+  // TODO: Needed to avoid a weird memory error in the following test in
+  // no-local configurations:
+  // - library/draft/DistributedMap/v2/use-distributed-map
+  //
+  // Cause of bug likely involves the case when 'T' is nothing, and this
+  // class has a zero-size allocation.
+  var __dummy: int;
 
   override proc serialize(writer, ref serializer) throws {
   }


### PR DESCRIPTION
There appears to be some kind of bug in no-local configurations involving a wrapper class around 'nothing', where the only 'var' member is 'none'. Adding the '__dummy' field here fixes some kind of memory error in the 'library/draft/DistributedMap/v2/use-distributed-map' test.

Future work: investigate and resolve the underlying bug

Testing:
- [x] full local
- [x] full gasnet