### PR TITLE
Domain maps switch to range.strides

### DIFF
--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -974,9 +974,7 @@ iter CyclicArr.these(param tag: iterKind, followThis, param fast: bool = false) 
                       chpl_strideUnion(followThis), dom.whole.strides));
   for param i in 0..rank-1 {
     type strType = chpl__signedType(idxType);
-    const wholestride = dom.whole.dim(i).stride:chpl__signedType(idxType);
-//wass if this assertion holds, remove the cast in the previous line
-compilerAssert(dom.whole.dim(i).stride.type == chpl__signedType(idxType));//wass
+    const wholestride = dom.whole.dim(i).stride;
     if !dom.whole.strides.isPositive() && idxType != strType then
      if wholestride < 0 then
       halt("negative stride with unsigned idxType not supported");

--- a/modules/dists/DSIUtil.chpl
+++ b/modules/dists/DSIUtil.chpl
@@ -503,7 +503,7 @@ private proc asap1(arg) {
 // asapP1 = All Strides Are Positive - Param - 1 arg
 // returns true if all strides are known to be positive at compile time
 private proc asapP1(arg) param {
-  return !arg.stridable;
+  return arg.strides.isPositive();
 }
 
 private proc asapTuple(dims: _tuple) {

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -69,13 +69,13 @@ between locales.
 */
 class Private: BaseDist {
   override proc dsiNewRectangularDom(param rank: int, type idxType,
-                                     param stridable: bool, inds) {
+                                     param strides: strideKind, inds) {
     for i in inds do
       if i.size != 0 then
         halt("Tried to create a privateDom with a specific index set");
 
     return new unmanaged PrivateDom(rank=rank, idxType=idxType,
-                                    stridable=stridable,
+                                    strides=strides,
                                     dist=_to_unmanaged(this));
   }
 
@@ -116,7 +116,7 @@ class PrivateDom: BaseRectangularDom {
   proc dsiBuildArray(type eltType, param initElts:bool) {
     return new unmanaged PrivateArr(eltType=eltType, rank=rank,
                                     idxType=idxType,
-                                    stridable=stridable,
+                                    strides=strides,
                                     dom=_to_unmanaged(this),
                                     initElts=initElts);
   }
@@ -151,7 +151,7 @@ class PrivateDom: BaseRectangularDom {
 
   proc dsiPrivatize(privatizeData) {
     return new unmanaged PrivateDom(rank=rank, idxType=idxType,
-                                    stridable=stridable,
+                                    strides=strides,
                                     dist=dist);
   }
 
@@ -170,7 +170,7 @@ private proc checkCanMakeDefaultValue(type eltType) param {
 
 class PrivateArr: BaseRectangularArr {
 
-  var dom: unmanaged PrivateDom(rank, idxType, stridable);
+  var dom: unmanaged PrivateDom(rank, idxType, strides);
 
   // may be initialized separately
   // always destroyed explicitly (to control deiniting elts)
@@ -183,11 +183,11 @@ class PrivateArr: BaseRectangularArr {
   proc init(type eltType,
             param rank,
             type idxType,
-            param stridable,
-            dom: unmanaged PrivateDom(rank, idxType, stridable),
+            param strides,
+            dom: unmanaged PrivateDom(rank, idxType, strides),
             param initElts: bool) {
     super.init(eltType=eltType, rank=rank, idxType=idxType,
-               stridable=stridable);
+               strides=strides);
     this.dom = dom;
     // this.data not initialized
     this.isPrivatizedCopy = false;
@@ -204,7 +204,7 @@ class PrivateArr: BaseRectangularArr {
     var privdom = chpl_getPrivatizedCopy(toPrivatize.dom.type,
                                          toPrivatize.dom.pid);
     super.init(eltType=toPrivatize.eltType, rank=toPrivatize.rank,
-               idxType=toPrivatize.idxType, stridable=toPrivatize.stridable);
+               idxType=toPrivatize.idxType, strides=toPrivatize.strides);
     this.dom = privdom;
     // this.data not initialized
     this.isPrivatizedCopy = true;

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -186,11 +186,12 @@ class ReplicatedDom : BaseRectangularDom {
   const dist : unmanaged Replicated; // must be a Replicated
 
   // this is our index set; we store it here so we can get to it easily
-  var whole: domain(rank, idxType, stridable);
+  var whole: domain(rank, idxType, strides);
 
   // local domain objects
   // NOTE: if they ever change after the initializer - Reprivatize them
-  var localDoms: [dist.targetLocDom] unmanaged LocReplicatedDom(rank, idxType, stridable)?;
+  var localDoms: [dist.targetLocDom] unmanaged LocReplicatedDom(rank, idxType,
+                                                                strides)?;
 
   proc numReplicands do return localDoms.sizeAs(int);
 
@@ -214,10 +215,10 @@ class LocReplicatedDom {
   // copy from the global domain
   param rank: int;
   type idxType;
-  param stridable: bool;
+  param strides: strideKind;
 
   // our index set, copied from the global domain
-  var domLocalRep: domain(rank, idxType, stridable);
+  var domLocalRep: domain(rank, idxType, strides);
 }
 
 
@@ -245,7 +246,8 @@ proc ReplicatedDom.dsiPrivatize(privatizeData) {
   if traceReplicatedDist then writeln("ReplicatedDom.dsiPrivatize on ", here);
 
   var privdist = chpl_getPrivatizedCopy(this.dist.type, privatizeData.distpid);
-  return new unmanaged ReplicatedDom(rank=rank, idxType=idxType, stridable=stridable,
+  return new unmanaged ReplicatedDom(rank=rank, idxType=idxType,
+                           strides=strides,
                            dist = privdist,
                            whole = privatizeData.whole,
                            localDoms = privatizeData.localDoms);
@@ -258,7 +260,7 @@ proc ReplicatedDom.dsiGetReprivatizeData() {
 proc ReplicatedDom.dsiReprivatize(other, reprivatizeData): void {
   assert(this.rank == other.rank &&
          this.idxType == other.idxType &&
-         this.stridable == other.stridable);
+         this.strides == other.strides);
 
   this.whole = reprivatizeData;
 }
@@ -274,21 +276,21 @@ proc Replicated.dsiClone(): _to_unmanaged(this.type) {
 // create a new domain mapped with this distribution
 override proc Replicated.dsiNewRectangularDom(param rank: int,
                                          type idxType,
-                                         param stridable: bool,
+                                         param strides: strideKind,
                                          inds)
 {
   if traceReplicatedDist then writeln("Replicated.dsiNewRectangularDom ",
-                                      (rank, idxType:string, stridable, inds));
+                                      (rank, idxType:string, strides, inds));
 
   // Have to call the default initializer because we need to initialize 'dist'
   // prior to initializing 'localDoms' (which needs a non-nil value for 'dist'.
   var result = new unmanaged ReplicatedDom(rank=rank, idxType=idxType,
-                                 stridable=stridable, dist=_to_unmanaged(this));
+                                 strides=strides, dist=_to_unmanaged(this));
 
   // create local domain objects
   coforall (loc, locDom) in zip(targetLocales, result.localDoms) do
     on loc do
-      locDom = new unmanaged LocReplicatedDom(rank, idxType, stridable);
+      locDom = new unmanaged LocReplicatedDom(rank, idxType, strides);
   result.dsiSetIndices(inds);
 
   return result;
@@ -318,7 +320,7 @@ proc ReplicatedDom.dsiDims() do        return whole.dims();
 proc ReplicatedDom.dsiMember(i) do     return whole.contains(i);
 proc ReplicatedDom.doiToString() do    return whole:string;
 proc ReplicatedDom.dsiSerialWrite(x) { x.write(whole); }
-proc ReplicatedDom.dsiLocalSlice(param stridable, ranges) do return whole((...ranges));
+proc ReplicatedDom.dsiLocalSlice(param strides, ranges) do return whole((...ranges));
 override proc ReplicatedDom.dsiIndexOrder(i) do              return whole.indexOrder(i);
 override proc ReplicatedDom.dsiMyDist() do                   return dist;
 
@@ -341,7 +343,7 @@ proc ReplicatedDom.dsiSetIndices(domArg: domain): void {
 
 proc ReplicatedDom.dsiGetIndices(): rank * range(idxType,
                                                  boundKind.both,
-                                                 stridable) {
+                                                 strides) {
   if traceReplicatedDist then writeln("ReplicatedDom.dsiGetIndices");
   return whole.getIndices();
 }
@@ -393,7 +395,7 @@ class ReplicatedArr : AbsBaseArr {
   // the replicated arrays
   // NOTE: 'dom' must be initialized prior to initializing 'localArrs'
   var localArrs: [dom.dist.targetLocDom]
-              unmanaged LocReplicatedArr(eltType, dom.rank, dom.idxType, dom.stridable)?;
+     unmanaged LocReplicatedArr(eltType, dom.rank, dom.idxType, dom.strides)?;
 
   //
   // helper function to get the local array safely
@@ -435,9 +437,9 @@ class LocReplicatedArr {
   type eltType;
   param rank: int;
   type idxType;
-  param stridable: bool;
+  param strides: strideKind;
 
-  var myDom: unmanaged LocReplicatedDom(rank, idxType, stridable);
+  var myDom: unmanaged LocReplicatedDom(rank, idxType, strides);
   pragma "local field" pragma "unsafe" pragma "no auto destroy"
   // may be re-initialized separately
   // always destroyed explicitly (to control deiniting elts)
@@ -446,13 +448,13 @@ class LocReplicatedArr {
   proc init(type eltType,
             param rank: int,
             type idxType,
-            param stridable: bool,
-            myDom: unmanaged LocReplicatedDom(rank, idxType, stridable),
+            param strides: strideKind,
+            myDom: unmanaged LocReplicatedDom(rank, idxType, strides),
             param initElts: bool) {
     this.eltType = eltType;
     this.rank = rank;
     this.idxType = idxType;
-    this.stridable = stridable;
+    this.strides = strides;
     this.myDom = myDom;
 
     //
@@ -486,8 +488,8 @@ proc ReplicatedArr.init(type eltType, dom) {
   this.dom = dom;
 }
 
-proc ReplicatedArr.stridable param {
-  return dom.stridable;
+proc ReplicatedArr.strides param {
+  return dom.strides;
 }
 
 proc ReplicatedArr.idxType type {
@@ -558,12 +560,12 @@ proc ReplicatedDom.dsiBuildArray(type eltType, param initElts:bool)
     //
     if here == globalArrayLocale && !initElts {
       locArr = new unmanaged LocReplicatedArr(eltType, rank, idxType,
-                                              stridable,
+                                              strides,
                                               locDom!,
                                               initElts=false);
     } else {
       locArr = new unmanaged LocReplicatedArr(eltType, rank, idxType,
-                                              stridable,
+                                              strides,
                                               locDom!,
                                               initElts=true);
     }
@@ -678,7 +680,7 @@ proc ReplicatedDom.dsiLocalSubdomain(loc: locale) {
   if localDoms.domain.contains(loc.id) then
     return whole;
   else {
-    var d: domain(rank, idxType, stridable);
+    var d: domain(rank, idxType, strides);
     return d;
   }
 }
@@ -687,7 +689,7 @@ proc ReplicatedArr.dsiLocalSubdomain(loc: locale) {
   if localArrs.domain.contains(loc.id) then
     return dom.whole;
   else {
-    var d: domain(rank, idxType, stridable);
+    var d: domain(rank, idxType, strides);
     return d;
   }
 }

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -77,13 +77,13 @@ record BlockDim {
 
 record Block1dom {
   type idxType;
-  param stridable: bool;
+  param strides: strideKind;
 
   // convenience
-  proc rangeT type do  return range(idxType, boundKind.both, stridable);
+  proc rangeT type do  return range(idxType, boundKind.both, strides);
 
   // our range
-  var wholeR: range(idxType, boundKind.both, stridable);
+  var wholeR: range(idxType, boundKind.both, strides);
 
   // privatized distribution descriptor
   const pdist;
@@ -137,7 +137,7 @@ proc Block1dom.dsiGetPrivatizeData1d() {
 proc type Block1dom.dsiPrivatize1d(privDist, privatizeData) {
   assert(privDist.locale == here); // sanity check
   return new Block1dom(idxType   = this.idxType,
-                  stridable = this.stridable,
+                  strides   = this.strides,
                   wholeR    = privatizeData(0),
                   pdist     = privDist);
 }
@@ -172,7 +172,7 @@ proc BlockDim.init(numLocales, boundingBoxLow, boundingBoxHigh, type idxType = b
 proc BlockDim.toString() do
   return "BlockDim(" + numLocales:string + ", " + boundingBox:string + ")";
 
-proc BlockDim.dsiNewRectangularDom1d(type idxType, param stridable: bool,
+proc BlockDim.dsiNewRectangularDom1d(type idxType, param strides: strideKind,
                                      type stoIndexT)
 {
   // ignore stoIndexT - all we need is for other places to work out
@@ -180,13 +180,13 @@ proc BlockDim.dsiNewRectangularDom1d(type idxType, param stridable: bool,
     compilerError("The index type ", idxType:string,
                   " does not match the index type ",this.idxType:string,
                   " of the 'BlockDim' 1-d distribution");
-  return new Block1dom(idxType = idxType, stridable = stridable, pdist = this);
+  return new Block1dom(idxType = idxType, strides = strides, pdist = this);
 }
 
 proc Block1dom.dsiIsReplicated1d() param do return false;
 
 proc Block1dom.dsiNewLocalDom1d(type stoIndexT, locId: locIdT) {
-  var defaultVal: range(stoIndexT, stridable=this.stridable);
+  var defaultVal: range(stoIndexT, strides=this.strides);
   return new Block1locdom(myRange = defaultVal);
 }
 

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -64,14 +64,13 @@ record ReplicatedDim {
 record Replicated1dom {
   // REQ the parameters of our dimension of the domain being created
   type idxType;
-  param stridable: bool;
+  param strides: strideKind;
 
   // convenience
-  proc rangeT type do  return range(idxType, boundKind.both, stridable);
-//todo-remove?  proc domainT type return domain(1, idxType, stridable);
+  proc rangeT type do  return range(idxType, boundKind.both, strides);
 
   // our range
-  var wholeR: range(idxType, boundKind.both, stridable);
+  var wholeR: range(idxType, boundKind.both, strides);
 
   // locale ID in our dimension of the locale this instance is on
   var localLocID = invalidLocID;
@@ -83,9 +82,9 @@ record Replicated1dom {
 
 record Replicated1locdom {
   type stoIndexT;
-  param stridable;
+  param strides;
   // our copy of wholeR
-  var locWholeR: range(stoIndexT, stridable=stridable);
+  var locWholeR: range(stoIndexT, strides=strides);
 }
 
 
@@ -142,7 +141,7 @@ proc Replicated1dom.dsiGetPrivatizeData1d() {
 proc type Replicated1dom.dsiPrivatize1d(privDist, privatizeData) {
   assert(privDist.locale == here); // sanity check
   return new Replicated1dom(idxType   = this.idxType,
-                            stridable = this.stridable,
+                            strides   = this.strides,
                             wholeR    = privatizeData(0));
 }
 
@@ -197,13 +196,13 @@ proc Replicated1locdom.dsiStoreLocalDescToPrivatizedGlobalDesc1d(privGlobDesc) {
 
 
 // REQ create a 1-d global domain descriptor for dsiNewRectangularDom()
-// where our dimension is a range(idxType, bounded, stridable)
+// where our dimension is a range(idxType, bounded, strides)
 // stoIndexT is the same as in Replicated1dom.dsiNewLocalDom1d.
-proc ReplicatedDim.dsiNewRectangularDom1d(type idxType, param stridable: bool,
+proc ReplicatedDim.dsiNewRectangularDom1d(type idxType, param strides,
                                           type stoIndexT)
 {
   // ignore stoIndexT - all we need is for other places to work out
-  return new Replicated1dom(idxType, stridable);
+  return new Replicated1dom(idxType, strides);
 }
 
 // A nicety: produce a string showing the parameters.
@@ -221,7 +220,7 @@ proc Replicated1dom.dsiIsReplicated1d() param do return true;
 // stoIndexT must be the index type of the range returned by
 // dsiSetLocalIndices1d().
 proc Replicated1dom.dsiNewLocalDom1d(type stoIndexT, locId: locIdT) {
-  return new Replicated1locdom(stoIndexT, wholeR.stridable);
+  return new Replicated1locdom(stoIndexT, wholeR.strides);
 }
 
 // REQ given our dimension of the array index, on which locale is it located?

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -781,8 +781,8 @@ module ChapelArray {
                      rank, idxType, stridable, ranges2) {
 
         //RSDW: compilerWarning("the domain map '", _value.type:string,
-        // " needs to be updated from stridable: bool to strides: strideKind",
-        // " because 'stridable' is deprecated");
+        //  " needs to be updated from stridable: bool to strides: strideKind",
+        //  " because 'stridable' is deprecated");
 
         return _value.dsiNewRectangularDom(rank, idxType, stridable, ranges2);
       }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -781,8 +781,8 @@ module ChapelArray {
                      rank, idxType, stridable, ranges2) {
 
         //RSDW: compilerWarning("the domain map '", _value.type:string,
-        //  " needs to be updated from stridable: bool to strides: strideKind",
-        //  " because 'stridable' is deprecated");
+        // " needs to be updated from stridable: bool to strides: strideKind",
+        // " because 'stridable' is deprecated");
 
         return _value.dsiNewRectangularDom(rank, idxType, stridable, ranges2);
       }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -980,7 +980,7 @@ module ChapelDistribution {
     // deprecated by Vass in 1.31 to implement #17131
     //RSDW: @deprecated("[array].stridable is deprecated; use [array].strides instead")
     proc stridable param do return strides.toStridable();
-    //RSDW: @deprecated("domain.stridable is deprecated; use domain.strides instead")
+    //RSDW: @deprecated("[array].stridable is deprecated; use [array].strides instead")
     proc type stridable param do return strides.toStridable();
 
     @chpldoc.nodoc proc hasUnitStride() param do return strides.isOne();

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -166,7 +166,7 @@ module ChapelIteratorSupport {
   // RTT is **initialized**. Important: no accessing the uninitialized RTTs.
   //
   // It took some acrobatics to get the domain's distribution type,
-  // rank, idxType, stridable from 'domType', and the same plus
+  // rank, idxType, strides from 'domType', and the same plus
   // (even more acrobatics) eltType from 'arrType'.
   // Ideally we'd get them **directly** from domType/arrType.
   //
@@ -276,7 +276,7 @@ module ChapelIteratorSupport {
     // a BaseDist subclass. We use 'defaultDist' for that.
     // The other args are always compile-time only.
     return chpl__buildDomainRuntimeType(defaultDist, domInst.rank,
-                                        domInst.idxType, domInst.stridable);
+                                        domInst.idxType, domInst.strides);
   }
 
   // Other kinds of arrays/domains are not supported.

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1049,7 +1049,7 @@ module ChapelRange {
 
   @chpldoc.nodoc
   inline proc range.chpl_alignedLowAsIntForIter {
-    if stridable && !hasLowBound() && isFiniteIndexType() {
+    if !hasUnitStride() && !hasLowBound() && isFiniteIndexType() {
       return helpAlignLow(chpl__idxToInt(lowBoundForIter(this)), _alignment, stride);
     } else {
       return alignedLowAsInt;
@@ -1145,7 +1145,7 @@ module ChapelRange {
 
   @chpldoc.nodoc
   inline proc range.chpl_alignedHighAsIntForIter {
-    if stridable && !hasHighBound() && isFiniteIdxType(idxType) {
+    if !hasUnitStride() && !hasHighBound() && isFiniteIdxType(idxType) {
       return helpAlignHigh(chpl__idxToInt(highBoundForIter(this)), _alignment, stride);
     } else {
       return alignedHighAsInt;
@@ -2080,14 +2080,12 @@ private inline proc rangeCastHelper(r, type t) throws {
   @chpldoc.nodoc
   inline operator -(r: range(?e,?b,?s), i: integral)
   {
-    type strType = chpl__rangeStrideType(e);
-
     return new range(e, b, s,
                      r._low - i,
                      r._high - i,
-                     r.stride : strType,
+                     r._stride,
                      chpl__idxToInt(r.alignment)-i,
-                     r.aligned);
+                     r._aligned, false);
   }
 
   // TODO can this be removed?

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1003,10 +1003,11 @@ module DefaultRectangular {
       targetLocDom=newTargetLocDom;
     }
 
-    //RSDW remove this once Block, Cyclick, Stencil use 'strides'
+    //RSDW remove this once Block, Cyclic, Stencil use 'strides'
     pragma "dont disable remote value forwarding"
     proc init(type eltType, param rank: int, type idxType,
               param stridable: bool, newTargetLocDom: domain(rank)) {
+compilerWarning("vass1 - should not be invoked");
       this.init(eltType, rank, idxType, chpl_strideKind(stridable),
                 newTargetLocDom);
     }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1003,15 +1003,6 @@ module DefaultRectangular {
       targetLocDom=newTargetLocDom;
     }
 
-    //RSDW remove this once Block, Cyclic, Stencil use 'strides'
-    pragma "dont disable remote value forwarding"
-    proc init(type eltType, param rank: int, type idxType,
-              param stridable: bool, newTargetLocDom: domain(rank)) {
-compilerWarning("vass1 - should not be invoked");
-      this.init(eltType, rank, idxType, chpl_strideKind(stridable),
-                newTargetLocDom);
-    }
-
     inline proc lockRAD(rlocIdx) {
       RADLocks[rlocIdx].lock();
     }

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -49,9 +49,9 @@ module DefaultSparse {
       this.dist = dist;
     }
 
-    proc stridable param {
-      return parentDom.stridable;
-    }
+    // deprecated by Vass in 1.31 to implement #17131
+    @deprecated("domain.stridable is deprecated; use domain.strides instead")
+    proc stridable param do return parentDom.strides.toStridable();
 
     override proc getNNZ(): int{
       return _nnz;

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -84,7 +84,7 @@ class CS: BaseDist {
   param sortedIndices: bool = LayoutCSDefaultToSorted;
 
   override proc dsiNewSparseDom(param rank: int, type idxType, dom: domain) {
-    return new unmanaged CSDom(rank, idxType, this.compressRows, this.sortedIndices, dom.stridable, _to_unmanaged(this), dom);
+    return new unmanaged CSDom(rank, idxType, this.compressRows, this.sortedIndices, dom.strides, _to_unmanaged(this), dom);
   }
 
   proc dsiClone() {
@@ -108,11 +108,11 @@ class CS: BaseDist {
 class CSDom: BaseSparseDomImpl {
   param compressRows;
   param sortedIndices;
-  param stridable;
+  param strides;
   var dist: unmanaged CS(compressRows,sortedIndices);
 
-  var rowRange: range(idxType, stridable=stridable);
-  var colRange: range(idxType, stridable=stridable);
+  var rowRange: range(idxType, strides=strides);
+  var colRange: range(idxType, strides=strides);
 
   /* (row|col) startIdxDom */
   var startIdxDom: domain(1, idxType);
@@ -127,7 +127,7 @@ class CSDom: BaseSparseDomImpl {
   var idx: [nnzDom] idxType;      // would like index(parentDom.dim(0))
 
   /* Initializer */
-  proc init(param rank, type idxType, param compressRows, param sortedIndices, param stridable, dist: unmanaged CS(compressRows,sortedIndices), parentDom: domain) {
+  proc init(param rank, type idxType, param compressRows, param sortedIndices, param strides, dist: unmanaged CS(compressRows,sortedIndices), parentDom: domain) {
     if (rank != 2 || parentDom.rank != 2) then
       compilerError("Only 2D sparse domains are supported by the CS distribution");
     if parentDom.idxType != idxType then
@@ -137,7 +137,7 @@ class CSDom: BaseSparseDomImpl {
 
     this.compressRows = compressRows;
     this.sortedIndices = sortedIndices;
-    this.stridable = stridable;
+    this.strides      = strides;
 
     this.dist = dist;
     rowRange = parentDom.dim(0);

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1153,9 +1153,9 @@ proc _matmatMultHelper(ref AMat: [?Adom] ?eltType,
 
 @chpldoc.nodoc
 private inline proc hasNonStridedIndices(Adom : domain(2)) {
-  return (if Adom.stridable
+  return if !Adom.strides.isNegative()
           then Adom.dim(0).stride == 1 && Adom.dim(1).stride == 1
-          else true);
+          else false;
 }
 
 /*

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -108,18 +108,11 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.lo
 
  chpl_check_comparator(comparator, Data.eltType);
 
- const stride = if Dom.stridable then abs(Dom.stride) else 1;
- if Dom.stridable {
-   for i in lo..hi by stride {
-     if chpl_compare(Data[i], val, comparator=comparator) == 0 then
-       return (true, i);
-   }
- } else {
-   for i in lo..hi {
-     if chpl_compare(Data[i], val, comparator=comparator) == 0 then
-       return (true, i);
-   }
- }
+ const stride = abs(Dom.stride);
+
+ for i in lo..hi by if Dom.hasPosNegUnitStride() then 1 else stride:uint do
+   if chpl_compare(Data[i], val, comparator=comparator) == 0 then
+     return (true, i);
 
  return (false, hi+stride);
 }
@@ -160,8 +153,9 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.lo
  */
 proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high) {
   chpl_check_comparator(comparator, Data.eltType);
+  if Dom.rank != 1 then compilerError("binarySearch() requires 1-D array");
 
-  const stride = if Dom.stridable then abs(Dom.stride) else 1;
+  const stride = abs(Dom.stride);
 
   while (lo <= hi) {
     const size = (hi - lo) / stride,
@@ -183,8 +177,10 @@ proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom
 @chpldoc.nodoc
 /* Non-stridable binarySearch */
 proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high)
-  where !Dom.stridable {
+  where Dom.hasUnitStride()
+{
   chpl_check_comparator(comparator, Data.eltType);
+  if Dom.rank != 1 then compilerError("binarySearch() requires 1-D array");
 
   while (lo <= hi) {
     const mid = (hi - lo)/2 + lo;
@@ -198,11 +194,4 @@ proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom
   return (false, lo);
 }
 
-
-@chpldoc.nodoc
-/* Error message for multi-dimension arrays */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high)
-  where Dom.rank != 1 {
-    compilerError("binarySearch() requires 1-D array");
-}
 } // Search module

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1005,7 +1005,10 @@ module MergeSort {
       if depth & 1 {
         // At odd depths, we need to return the results in Scratch.
         // But if the test above is correct, we'll never reach this point.
-        Scratch[lo..hi by Dom.stride] = Data[lo..hi by Dom.stride];
+        if ! Dom.strides.isPosNegOne() then
+          Scratch[lo..hi by Dom.stride] = Data[lo..hi by Dom.stride];
+        else
+          Scratch[lo..hi] = Data[lo..hi];
       }
       return;
     }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6388,7 +6388,8 @@ proc fileReader.readline(arg: [] uint(8), out numRead : int, start = arg.domain.
  */
 proc fileReader.readLine(ref a: [] ?t, maxSize=a.size,
                          stripNewline=false): int throws
-      where (t == uint(8) || t == int(8)) && a.rank == 1 && a.isRectangular() && !a.stridable
+      where (t == uint(8) || t == int(8)) && a.rank == 1 &&
+            a.isRectangular() && a.hasUnitStride()
 {
   if maxSize > a.size
     then throw new IllegalArgumentError("'maxSize' argument exceeds size of array in readLine");
@@ -7202,7 +7203,8 @@ proc fileReader.readAll(ref b: bytes): int throws {
                        due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileReader.readAll(ref a: [?d] ?t): int throws
-  where (t == uint(8) || t == int(8)) && d.rank == 1 && d.stridable == false
+  where (t == uint(8) || t == int(8)) && a.rank == 1 &&
+        a.isRectangular() && a.hasUnitStride()
 {
   var i = d.low;
 
@@ -7936,8 +7938,8 @@ proc fileWriter.writeBinary(b: bytes, size: int = b.size) throws {
                        due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioendian.native) throws
-  where (d.rank == 1 && d.stridable == false && !d.isSparse()) && (
-          isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t))
+  where d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0;
 
@@ -7987,8 +7989,8 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
                        due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileWriter.writeBinary(const ref data: [?d] ?t, endian:ioendian) throws
-  where (d.rank == 1 && d.stridable == false) && (
-          isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t))
+  where d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   select (endian) {
     when ioendian.native {
@@ -8196,8 +8198,9 @@ config param ReadBinaryArrayReturnInt = false;
 */
 @deprecated(notes="The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant")
 proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): bool throws
-  where ReadBinaryArrayReturnInt == false && (d.rank == 1 && d.stridable == false) && (
-          isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t))
+  where ReadBinaryArrayReturnInt == false &&
+    d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0,
       readSomething = false;
@@ -8255,8 +8258,9 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): b
                        due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): int throws
-  where ReadBinaryArrayReturnInt == true && (d.rank == 1 && d.stridable == false && !d.isSparse()) && (
-          isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t))
+  where ReadBinaryArrayReturnInt == true &&
+    d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0,
       numRead : c_ssize_t = 0;
@@ -8318,8 +8322,9 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
 */
 @deprecated(notes="The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant")
 proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):bool throws
-  where ReadBinaryArrayReturnInt == false && (d.rank == 1 && d.stridable == false && !d.isSparse()) && (
-          isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t))
+  where ReadBinaryArrayReturnInt == false &&
+    d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var rv: bool = false;
 
@@ -8357,8 +8362,9 @@ proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):bool throws
                         due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):int throws
-  where ReadBinaryArrayReturnInt == true && (d.rank == 1 && d.stridable == false && !d.isSparse()) && (
-          isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t))
+  where ReadBinaryArrayReturnInt == true &&
+    d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var nr: int = 0;
 
@@ -8875,7 +8881,8 @@ proc read(type t ...?numTypes) throws {
 
 /* Equivalent to ``stdin.readLine``.  See :proc:`fileReader.readLine` */
 proc readLine(ref a: [] ?t, maxSize=a.size, stripNewline=false): int throws
-      where (t == uint(8) || t == int(8)) && a.rank == 1 && a.isRectangular() && ! a.stridable {
+      where (t == uint(8) || t == int(8)) && a.rank == 1 &&
+            a.isRectangular() && a.hasUnitStride() {
   return stdin.readLine(a, maxSize, stripNewline);
 }
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -658,7 +658,7 @@ module Random {
                                    if ``size < 1 || size.size < 1``,
                                    if ``replace=false`` and ``size > x.size || size.size > x.size``.
      */
-     proc choice(x: range(stridable=?), size:?sizeType=none, replace=true, prob:?probType=none) throws
+     proc choice(x: range(strides=?), size:?sizeType=none, replace=true, prob:?probType=none) throws
      {
        compilerError("RandomStreamInterface.choice called");
      }
@@ -1172,16 +1172,13 @@ module Random {
                                    if ``size < 1 || size.size < 1``,
                                    if ``replace=false`` and ``size > x.size || size.size > x.size``.
      */
-      proc choice(x: range(stridable=?), size:?sizeType=none, replace=true, prob:?probType=none)
+      proc choice(x: range(?), size:?sizeType=none, replace=true, prob:?probType=none)
         throws
       {
-        var dom: domain(1,stridable=true);
-
         if x.bounds != boundKind.both {
           compilerError('input range must be bounded');
-        } else {
-          dom = {x};
         }
+        var dom = {x};
         return _choice(this, dom, size=size, replace=replace, prob=prob);
       }
 
@@ -1682,7 +1679,7 @@ module Random {
           myStart += multiplier * ZD.indexOrder(((...outer), innerRange.lowBound)).safeCast(int(64));
         else
           myStart += multiplier * ZD.indexOrder(innerRange.lowBound).safeCast(int(64));
-        if !innerRange.stridable {
+        if innerRange.hasUnitStride() {
           var cursor = randlc_skipto(resultType, seed, myStart);
           for i in innerRange do
             yield randlc(resultType, cursor);
@@ -1735,7 +1732,7 @@ module Random {
           myStart += multiplier * ZD.indexOrder(((...outer), innerRange.lowBound)).safeCast(int(64));
         else
           myStart += multiplier * ZD.indexOrder(innerRange.lowBound).safeCast(int(64));
-        if !innerRange.stridable {
+        if innerRange.hasUnitStride() {
           var cursor = randlc_skipto(resultType, seed, myStart);
           var count = myStart;
           for i in innerRange {
@@ -2803,7 +2800,7 @@ module Random {
       }
 
       @chpldoc.nodoc
-      proc choice(x: range(stridable=?), size:?sizeType=none, replace=true, prob:?probType=none)
+      proc choice(x: range(?), size:?sizeType=none, replace=true, prob:?probType=none)
         throws
       {
         compilerError("NPBRandomStream.choice() is not supported.");
@@ -3012,7 +3009,7 @@ module Random {
           myStart += multiplier * ZD.indexOrder(((...outer), innerRange.lowBound)).safeCast(int(64));
         else
           myStart += multiplier * ZD.indexOrder(innerRange.lowBound).safeCast(int(64));
-        if !innerRange.stridable {
+        if innerRange.hasUnitStride() {
           cursor = randlc_skipto(seed, myStart);
           for i in innerRange do
             yield randlc(resultType, cursor);

--- a/test/distributions/private/PrivateDistNonNilableDefaultInit.good
+++ b/test/distributions/private/PrivateDistNonNilableDefaultInit.good
@@ -4,7 +4,7 @@ $CHPL_HOME/modules/dists/PrivateDist.chpl:nnnn: error: use here prevents split-i
 note: non-nilable class type 'borrowed C' does not support default initialization
 note: Consider using the type shared C? instead
 PrivateDistNonNilableDefaultInit.chpl:6: error: cannot default-initialize the array a because it has a non-nilable element type 'shared C'
-  $CHPL_HOME/modules/dists/PrivateDist.chpl:nnnn: called as PrivateArr.init(type eltType = shared C, param rank = 1, type idxType = int(64), param stridable = false, dom: unmanaged PrivateDom(1,int(64),one), param initElts = true) from method 'dsiBuildArray'
+  $CHPL_HOME/modules/dists/PrivateDist.chpl:nnnn: called as PrivateArr.init(type eltType = shared C, param rank = 1, type idxType = int(64), param strides = strideKind.one, dom: unmanaged PrivateDom(1,int(64),one), param initElts = true) from method 'dsiBuildArray'
   $CHPL_HOME/modules/internal/ChapelDomain.chpl:nnnn: called as (PrivateDom(1,int(64),one)).dsiBuildArray(type eltType = shared C, param initElts = true)
   within internal functions (use --print-callstack-on-error to see)
   PrivateDistNonNilableDefaultInit.chpl:9: called as test1()

--- a/test/distributions/robust/arithmetic/basics/test_domain_align.chpl
+++ b/test/distributions/robust/arithmetic/basics/test_domain_align.chpl
@@ -40,7 +40,7 @@ proc compare(D, R, a, s=2) {
 
 proc test(ref D) {
   D = rangeTuple(D.rank, 1..10);
-  var R : domain(D.rank, D.idxType, D.stridable);
+  var R : domain(D.rank, D.idxType, D.strides);
   R; R = D; // disable split init because warning text differs per dist
 
   compare(D, R, 0);

--- a/test/distributions/robust/arithmetic/trivial/test_dot_stridable.chpl
+++ b/test/distributions/robust/arithmetic/trivial/test_dot_stridable.chpl
@@ -1,19 +1,19 @@
 use driver_arrays;
 
-writeln(Dom1D.stridable);
-writeln(Dom2D.stridable);
-writeln(Dom3D.stridable);
-writeln(Dom4D.stridable);
-writeln(A1D.stridable);
-writeln(A2D.stridable);
-writeln(A3D.stridable);
-writeln(A4D.stridable);
+writeln(Dom1D.strides);
+writeln(Dom2D.strides);
+writeln(Dom3D.strides);
+writeln(Dom4D.strides);
+writeln(A1D.strides);
+writeln(A2D.strides);
+writeln(A3D.strides);
+writeln(A4D.strides);
 
-compilerWarning(Dom1D.stridable:string);
-compilerWarning(Dom2D.stridable:string);
-compilerWarning(Dom3D.stridable:string);
-compilerWarning(Dom4D.stridable:string);
-compilerWarning(A1D.stridable:string);
-compilerWarning(A2D.stridable:string);
-compilerWarning(A3D.stridable:string);
-compilerWarning(A4D.stridable:string);
+compilerWarning(Dom1D.strides:string);
+compilerWarning(Dom2D.strides:string);
+compilerWarning(Dom3D.strides:string);
+compilerWarning(Dom4D.strides:string);
+compilerWarning(A1D.strides:string);
+compilerWarning(A2D.strides:string);
+compilerWarning(A3D.strides:string);
+compilerWarning(A4D.strides:string);

--- a/test/distributions/robust/arithmetic/trivial/test_dot_stridable.good
+++ b/test/distributions/robust/arithmetic/trivial/test_dot_stridable.good
@@ -1,16 +1,16 @@
-test_dot_stridable.chpl:12: warning: false
-test_dot_stridable.chpl:13: warning: false
-test_dot_stridable.chpl:14: warning: false
-test_dot_stridable.chpl:15: warning: false
-test_dot_stridable.chpl:16: warning: false
-test_dot_stridable.chpl:17: warning: false
-test_dot_stridable.chpl:18: warning: false
-test_dot_stridable.chpl:19: warning: false
-false
-false
-false
-false
-false
-false
-false
-false
+test_dot_stridable.chpl:12: warning: one
+test_dot_stridable.chpl:13: warning: one
+test_dot_stridable.chpl:14: warning: one
+test_dot_stridable.chpl:15: warning: one
+test_dot_stridable.chpl:16: warning: one
+test_dot_stridable.chpl:17: warning: one
+test_dot_stridable.chpl:18: warning: one
+test_dot_stridable.chpl:19: warning: one
+one
+one
+one
+one
+one
+one
+one
+one

--- a/test/domains/compilerErrors/notsupportedRectOps-ok.good
+++ b/test/domains/compilerErrors/notsupportedRectOps-ok.good
@@ -22,7 +22,7 @@ DefaultSparseDom(1,int(64),domain(1,int(64),one))
 1
 2
 
-SparseBlockDom(1,int(64),BlockDom(1,int(64),one,unmanaged DefaultDist),unmanaged DefaultDist,false)
+SparseBlockDom(1,int(64),BlockDom(1,int(64),one,unmanaged DefaultDist),unmanaged DefaultDist,one)
 1
 3
 1

--- a/test/domains/diten/castAwayStridableDomain.good
+++ b/test/domains/diten/castAwayStridableDomain.good
@@ -4,4 +4,4 @@ after cast/assign unstridableDom={1..20}
 after cast/assign stridableDom={1..20 by 2}
 after safeCast/assign unstridableDom={1..20}
 after safeCast/assign stridableDomUnit={1..20}
-castAwayStridableDomain.chpl:19: error: halt reached - non-stridable domain assigned non-unit stride in dimension 0
+castAwayStridableDomain.chpl:19: error: halt reached - illegal safeCast from stride 2 to strideKind.one

--- a/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
+++ b/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
@@ -428,7 +428,7 @@ iter CSArr.dsiPartialThese(param onlyDim, otherIdx,
 // Block Distribution support
 //
 proc LocBlockArr.clone() {
-  return new unmanaged LocBlockArr(eltType,rank,idxType,stridable,locDom,
+  return new unmanaged LocBlockArr(eltType,rank,idxType,strides,locDom,
       locRAD, myElems, locRADLock);
 }
 
@@ -685,7 +685,7 @@ iter LocBlockCyclicDom.dsiPartialThese(param onlyDim, otherIdx,
 }
 
 proc LocBlockCyclicArr.clone() {
-  return new unmanaged LocBlockCyclicArr(eltType,rank,idxType,stridable,
+  return new unmanaged LocBlockCyclicArr(eltType,rank,idxType,strides,
       allocDom,indexDom);
 }
 


### PR DESCRIPTION
This updates the modules to the switch from range.stridable to range.strides in #22441.

Most of the changes are renamings from `stridable` to `strides` and replacing `anyStridable()` with `chpl_strideUnion()`. However occasionally I did some code reorg and simplification, such as merging two branches of an `if stridable` conditional into code not guarded by a condition. Notably:

* Added overloads of `domain.stride` and `domain.alignment` that return a `param` for 1-D rectangular and sparse domains.
* Simplified `range.readThis()` and `range.init(..., fileReader, serializer)`; the latter now "throws" (rightfully so).
* Removed an overload of binarySearch() that could result in an "ambiguous call" error, defeating its purpose of giving a user-friendly error message.
* Eliminated distracting differences in where-clauses of fileReader/fileWriter methods in IO.chpl

To do post-merge:
* [ ] enable the deprecation warnings that remain commented out since #22441
* [ ] create design issues related to uses of chpl_strideUnion et al., see review comments