### PR TITLE
dyno: Perform some control flow checking to skip unused return statements

### DIFF
--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -396,7 +396,7 @@ void ReturnTypeInferrer::exitScope(const uast::AstNode* node) {
       }
     }
 
-    if (auto tryNode = poppingFrame->scopeAst->toTry()) {
+    if (poppingFrame->scopeAst->isTry()) {
       // The sub-frames of try/catch nodes are just the catches, but they
       // aren't the only thing that needs to return: the try itself
       // should return too.

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -126,6 +126,47 @@ void testProgram(const std::vector<ReturnVariant>& variants, F func,
   func((bool) commonTypeResult, qt);
 }
 
+static std::string buildControlFlowProgram(std::string controlFlow) {
+  std::string program = "";
+  program += "proc f() {\n  // Inserted control flow\n";
+  program += controlFlow;
+  program += "\n  // End inserted control flow\n  return \"hello\";\n}";
+  program += "\nvar x = f();";
+  return program;
+}
+
+enum class ControlFlowResult {
+  AllPathsReturn,
+  SomePathsReturn,
+  FallsThrough,
+};
+
+static void testControlFlow(std::string controlFlow, ControlFlowResult expectedResult) {
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+  auto program = buildControlFlowProgram(controlFlow);
+  std::cout << "--- test program ---" << std::endl;
+  std::cout << program.c_str() << std::endl;
+
+  auto returnType = resolveTypeOfXInit(context, program,
+                                       /* requireTypeKnown */ expectedResult != ControlFlowResult::SomePathsReturn);
+
+  if (expectedResult == ControlFlowResult::AllPathsReturn) {
+    // No errors should be emitted.
+    // Error guard will emit any unexpected errors when we go out of scope.
+    assert(returnType.type());
+    assert(returnType.type()->isIntType());
+  } else if (expectedResult == ControlFlowResult::FallsThrough) {
+    // No errors should be emitted.
+    // Error guard will emit any unexpected errors when we go out of scope.
+    assert(returnType.type());
+    assert(returnType.type()->isStringType());
+  } else {
+    assert(guard.realizeErrors() > 0);
+  }
+}
+
 static void test1() {
   // test returning a single value from value-returning function
   testProgram({
@@ -359,6 +400,202 @@ static void test18() {
   }, QualifiedType::UNKNOWN);
 }
 
+// Subsequent tests execute some control flow before running `return "hello"`.
+// The purpose of the tests is to ensure that we correctly identify instances
+// where all paths return, and subsequent return statements (like the one
+// with "hello") are ignored.
+
+static void testControlFlow0() {
+  testControlFlow(
+      R"""(
+      )"""
+  , ControlFlowResult::FallsThrough);
+}
+
+static void testControlFlow1() {
+  testControlFlow(
+      R"""(
+      return 1;
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow2() {
+  testControlFlow(
+      R"""(
+      var x = true;
+      if (x) {
+          return 1;
+      }
+      )"""
+  , ControlFlowResult::SomePathsReturn);
+}
+
+static void testControlFlow3() {
+  testControlFlow(
+      R"""(
+      var x = true;
+      if (x) {
+          return 1;
+      } else {
+          return 2;
+      }
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow4() {
+  testControlFlow(
+      R"""(
+      var x, y = true;
+      if (x) {
+          if (y) {
+              return 1;
+          } else {
+
+          }
+      } else {
+          return 3;
+      }
+      )"""
+  , ControlFlowResult::SomePathsReturn);
+}
+
+static void testControlFlow5() {
+  testControlFlow(
+      R"""(
+      var x, y = true;
+      if (x) {
+          if (y) {
+              return 1;
+          } else {
+              return 2;
+          }
+      } else {
+          return 3;
+      }
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow6() {
+  testControlFlow(
+      R"""(
+      try! {
+          return 1;
+      }
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow7() {
+  testControlFlow(
+      R"""(
+      try {
+          return 1;
+      } catch {
+
+      }
+      )"""
+  , ControlFlowResult::SomePathsReturn);
+}
+
+static void testControlFlow8() {
+  testControlFlow(
+      R"""(
+      try {
+          return 1;
+      } catch {
+          return 2;
+      }
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow9() {
+  testControlFlow(
+      R"""(
+      class MyError: Error {}
+      try {
+          return 1;
+      } catch e : MyError {
+          return 2;
+      } catch {
+
+      }
+      )"""
+  , ControlFlowResult::SomePathsReturn);
+}
+
+static void testControlFlow10() {
+  testControlFlow(
+      R"""(
+      class MyError: Error {}
+      try {
+          return 1;
+      } catch e : MyError {
+          return 2;
+      } catch {
+          return 3;
+      }
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow11() {
+  testControlFlow(
+      R"""(
+      while false {
+          return 1;
+      }
+      )"""
+  , ControlFlowResult::SomePathsReturn);
+}
+
+static void testControlFlow12() {
+  testControlFlow(
+      R"""(
+      if true {
+        return 1;
+      }
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow13() {
+  testControlFlow(
+      R"""(
+      if false {
+        return "hello";
+      } else {
+        return 1;
+      }
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow14() {
+  testControlFlow(
+      R"""(
+      if false {
+        return 1;
+      }
+      )"""
+  , ControlFlowResult::FallsThrough);
+}
+
+static void testControlFlow15() {
+  testControlFlow(
+      R"""(
+      if true {
+
+      } else {
+        return 1;
+      }
+      )"""
+  , ControlFlowResult::FallsThrough);
+}
+
 // TODO: test param coercion (param int(32) = 1 and param int(64) = 2)
 // looks like canPass doesn't handle this very well.
 
@@ -381,5 +618,22 @@ int main() {
   test16();
   test17();
   test18();
+
+  testControlFlow0();
+  testControlFlow1();
+  testControlFlow2();
+  testControlFlow3();
+  testControlFlow4();
+  testControlFlow5();
+  testControlFlow6();
+  testControlFlow7();
+  testControlFlow8();
+  testControlFlow9();
+  testControlFlow10();
+  testControlFlow11();
+  testControlFlow12();
+  testControlFlow13();
+  testControlFlow14();
+  testControlFlow15();
   return 0;
 }


### PR DESCRIPTION
The production module code occasionally has a pattern like the following:

```Chapel
if someParam then return 1;

return "hello";
```

Since the `param` is known at compile time, this shouldn't be an error, as the `return "hello"` shouldn't be considered. This PR adds some control flow analysis to Dyno to properly handle cases like this.

## Future Work
It might be nice to throw a warning in some situations where multiple returns like `return x; return y`; are used, but I didn't do so in this PR.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest