### PR TITLE
Suppress `chpldoc` documentation for symbols with `chpl_` prefix

### DIFF
--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -114,7 +114,7 @@ PRAGMA(CHPL__ITER, npr,
 // Marks chpl__iter things created for ForallStmt.
 PRAGMA(CHPL__ITER_NEWSTYLE, npr, "chpl__iter_newstyle", ncm)
 // TODO: Remove this pragma once we have an attribute or otherwise remove/rename
-// or nodoc the chpl_ prefix on symbols in the GMP module
+// or nodoc the chpl_ prefix on symbols we want documented
 PRAGMA(CHPLDOC_IGNORE_CHPL_PREFIX, ypr,
        "chpldoc ignore chpl prefix",
        "generate chpldoc documentation for this symbol even though it starts with chpl_")

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -113,6 +113,11 @@ PRAGMA(CHPL__ITER, npr,
        "used as a marker to implement forall intents")
 // Marks chpl__iter things created for ForallStmt.
 PRAGMA(CHPL__ITER_NEWSTYLE, npr, "chpl__iter_newstyle", ncm)
+// TODO: Remove this pragma once we have an attribute or otherwise remove/rename
+// or nodoc the chpl_ prefix on symbols in the GMP module
+PRAGMA(CHPLDOC_IGNORE_CHPL_PREFIX, ypr,
+       "chpldoc ignore chpl prefix",
+       "generate chpldoc documentation for this symbol even though it starts with chpl_")
 PRAGMA(COBEGIN_OR_COFORALL, npr, "cobegin or coforall", ncm)
 PRAGMA(COBEGIN_OR_COFORALL_BLOCK, npr, "cobegin or coforall block", ncm)
 PRAGMA(COERCE_TEMP, npr,

--- a/frontend/test/parsing/testParse.cpp
+++ b/frontend/test/parsing/testParse.cpp
@@ -1133,7 +1133,7 @@ static void testAttribute3NamedArgs(Parser* parser) {
     proc foo() { }
   )"""";
 
-  auto parseResult = parseStringAndReportErrors(parser, "test9.chpl", program);
+  auto parseResult = parseStringAndReportErrors(parser, "testAttribute3NamedArgs.chpl", program);
   assert(guard.realizeErrors());
   auto mod = parseResult.singleModule();
   assert(mod);
@@ -1155,6 +1155,30 @@ static void testAttribute3NamedArgs(Parser* parser) {
   assert(attr1->isNamedActual(2));
   assert(attr1->actualName(2) == UniqueString::get(parser->context(), "issue"));
   assert(attr1->actual(2)->isIntLiteral());
+}
+
+/* a test of the pragma chpldoc ignore chpl prefix*/
+static void testPragmaChpldocIgnoreChplPrefix(Parser* parser) {
+  ErrorGuard guard(parser->context());
+  auto program = R""""(
+    module M {
+      pragma "chpldoc ignore chpl prefix"
+      proc chpl_foo() { }
+    }
+  )"""";
+
+  auto parseResult = parseStringAndReportErrors(parser, "testPragmaChpldocIgnoreChplPrefix.chpl", program);
+
+  auto mod = parseResult.singleModule();
+  assert(guard.numErrors()==0);
+  assert(mod);
+  assert(mod->numStmts() == 1);
+  auto p = mod->stmt(0)->toFunction();
+  assert(p);
+  auto attr = p->attributeGroup();
+  assert(attr);
+  assert(attr->numAttributes() == 0);
+  assert(attr->hasPragma(PragmaTag::PRAGMA_CHPLDOC_IGNORE_CHPL_PREFIX));
 }
 
 int main() {
@@ -1223,6 +1247,7 @@ int main() {
   testAttributeNamedArgs(p);
   testAttributeMixedNamedArgs(p);
   testAttribute3NamedArgs(p);
+  testPragmaChpldocIgnoreChplPrefix(p);
 
   return 0;
 }

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -198,7 +198,6 @@ class ReplicatedDom : BaseRectangularDom {
   //
   // helper function to get the local domain safely
   //
-  @chpldoc.nodoc
   proc chpl_myLocDom() {
     if boundsChecking then
       if (!dist.targetLocDom.contains(here.id)) then
@@ -400,7 +399,6 @@ class ReplicatedArr : AbsBaseArr {
   //
   // helper function to get the local array safely
   //
-  @chpldoc.nodoc
   proc chpl_myLocArr() {
     if boundsChecking then
       if (!dom.dist.targetLocDom.contains(here.id)) then

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -144,7 +144,6 @@ module Atomics {
   public use MemConsistency;  // OK: to get and propagate memoryOrder
 
   pragma "local fn" pragma "fast-on safe extern function"
-  @chpldoc.nodoc
   extern proc chpl_atomic_thread_fence(order:memory_order);
 
   // non user-facing fence that is called by the compiler
@@ -213,7 +212,6 @@ module Atomics {
                 else return "atomic_" + s + "_"          + externTString(T);
   }
 
-  @chpldoc.nodoc
   proc chpl__processorAtomicType(type T) type {
     if T == bool           then return AtomicBool;
     else if isSupported(T) then return AtomicT(T);
@@ -221,7 +219,6 @@ module Atomics {
   }
 
   // Parser hook
-  @chpldoc.nodoc
   proc chpl__atomicType(type T) type {
     use ChplConfig;
     if CHPL_NETWORK_ATOMICS == "none" {

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -103,7 +103,6 @@ module Bytes {
                                        size=length+1);
   }
 
-  @chpldoc.nodoc
   proc chpl_createBytesWithLiteral(buffer: c_string,
                                    offset: int,
                                    x: c_string,

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -617,6 +617,7 @@ module Bytes {
 
     :yields: uint(8)
   */
+  pragma "chpldoc ignore chpl prefix"
   iter bytes.chpl_bytes(): uint(8) {
     foreach i in this.indices do
       yield this.byte(i);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -924,7 +924,6 @@ module ChapelArray {
     }
 
     pragma "no copy return"
-    @chpldoc.nodoc
     proc type chpl__deserialize(data) {
       var arrinst = _to_borrowed(__primitive("static field type", this, "_instance")).chpl__deserialize(data);
       return new _array(nullPid, arrinst, _unowned=true);
@@ -3680,7 +3679,6 @@ module ChapelArray {
   //   var A: [1..3] real;
   //   foo(A);
   // 'castToVoidStar' says whether we should cast the result to c_void_ptr
-  @chpldoc.nodoc
   proc chpl_arrayToPtr(arr: [], param castToVoidStar: bool = false) {
     if (!arr.isRectangular() || !domainDistIsLayout(arr.domain)) then
       compilerError("Only single-locale rectangular arrays can be passed to an external routine argument with array type", errorDepth=2);

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1508,10 +1508,8 @@ module ChapelBase {
   // chpl_mem_descInt_t is really a well known compiler type since the compiler
   // emits calls for the chpl_mem_descs table. Maybe the compiler should just
   // create the type and export it to the runtime?
-  @chpldoc.nodoc
   extern type chpl_mem_descInt_t = int(16);
 
-  @chpldoc.nodoc
   enum chpl_ddataResizePolicy { normalInit, skipInit, skipInitButClearMem }
 
   // dynamic data block class

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -61,22 +61,17 @@ module ChapelDebugPrint {
   // (chpl__testParFlag and related code is here to avoid order
   //  of resolution issues.)
 
-  @chpldoc.nodoc
   config param chpl__testParFlag = false;
-  @chpldoc.nodoc
   var chpl__testParOn = false;
 
-  @chpldoc.nodoc
   proc chpl__testParStart() {
     chpl__testParOn = true;
   }
 
-  @chpldoc.nodoc
   proc chpl__testParStop() {
     chpl__testParOn = false;
   }
 
-  @chpldoc.nodoc
   proc chpl__testPar(args...) {
     if chpl__testParFlag && chpl__testParOn {
       // This function is written this way because it is called
@@ -95,7 +90,6 @@ module ChapelDebugPrint {
       printf("CHPL TEST PAR (%s:%i): %s\n", file_cs, line:c_int, str.c_str());
     }
   }
-  @chpldoc.nodoc
   proc chpl__testParWriteln(args...) {
     if chpl__testParFlag && chpl__testParOn {
       const file_cs : c_string = __primitive("chpl_lookupFilename",

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -218,7 +218,6 @@ module ChapelDomain {
     return d;
   }
 
-  @chpldoc.nodoc
   private proc chpl__setDomainConst(dom: domain) {
     dom._value.definedConst = true;
   }
@@ -1114,7 +1113,6 @@ module ChapelDomain {
 
     forwarding _value except chpl__serialize, chpl__deserialize;
 
-    @chpldoc.nodoc
     proc chpl__serialize()
       where this._value.isDefaultRectangular() {
       return this._value.chpl__serialize();
@@ -1123,7 +1121,6 @@ module ChapelDomain {
     // TODO: we *SHOULD* be allowed to query the type of '_instance' directly
     // This function may not use any run-time type information passed to it
     // in the form of the 'this' argument. Static/param information is OK.
-    @chpldoc.nodoc
     proc type chpl__deserialize(data) {
       type valueType = __primitive("static field type", this, "_instance");
       return new _domain(_to_borrowed(valueType).chpl__deserialize(data));

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -123,7 +123,6 @@ module ChapelIteratorSupport {
   //
   // This function IS executed at runtime - and 'x' is advanced once -
   // because the returned type is an array and so has a runtime component.
-  @chpldoc.nodoc
   proc chpl_elemTypeForReducingIterables(x) type {
 
     // Part 1 - get the first element yielded by 'x'

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -38,9 +38,7 @@ module ChapelLocale {
   //
   // Node and sublocale types and special sublocale values.
   //
-  @chpldoc.nodoc
   type chpl_nodeID_t = int(32);
-  @chpldoc.nodoc
   type chpl_sublocID_t = int(32);
 
   @chpldoc.nodoc
@@ -50,7 +48,6 @@ module ChapelLocale {
   @chpldoc.nodoc
   extern const c_sublocid_all: chpl_sublocID_t;
 
-  @chpldoc.nodoc
   inline proc chpl_isActualSublocID(subloc: chpl_sublocID_t) do
     return (subloc != c_sublocid_none
             && subloc != c_sublocid_any
@@ -415,19 +412,16 @@ module ChapelLocale {
 
     // These are dynamically dispatched, so they can be overridden in
     // concrete classes.
-    @chpldoc.nodoc
     proc chpl_id() : int {
       HaltWrappers.pureVirtualMethodHalt();
       return -1;
     }
 
-    @chpldoc.nodoc
     proc chpl_localeid() : chpl_localeID_t {
       HaltWrappers.pureVirtualMethodHalt();
       return chpl_buildLocaleID(-1:chpl_nodeID_t, c_sublocid_none);
     }
 
-    @chpldoc.nodoc
     proc chpl_name() : string {
       HaltWrappers.pureVirtualMethodHalt();
       return "";
@@ -540,7 +534,6 @@ module ChapelLocale {
   // (such as DefaultRectangular) to help the targetLocales call return
   // by 'const ref' without requiring the array/domain implementation
   // to store another array.
-  @chpldoc.nodoc
   proc chpl_getSingletonLocaleArray(arg: locale) const ref
   lifetime return c_sublocid_none // indicate return has global lifetime
   {
@@ -682,7 +675,6 @@ module ChapelLocale {
   // The init() function must use the chpl_initOnLocales() iterator above
   // to iterate in parallel over the locales to set up the LocaleModel
   // object.
-  @chpldoc.nodoc
   proc chpl_init_rootLocale() {
     if numLocales > 1 && _local then
       halt("Cannot run a program compiled with --local in more than 1 locale");
@@ -695,7 +687,6 @@ module ChapelLocale {
   // origRootLocale and resets the Locales array to point to the local
   // copy on all but locale 0 (which is done in LocalesArray.chpl as
   // part of the declaration).
-  @chpldoc.nodoc
   proc chpl_rootLocaleInitPrivate(locIdx) {
     // Even when not replicating the rootLocale, we must temporarily
     // set the rootLocale to the original version on locale 0, because
@@ -732,14 +723,12 @@ module ChapelLocale {
     rootLocaleInitialized = true;
   }
 
-  @chpldoc.nodoc
   proc chpl_defaultLocaleInitPrivate() {
     pragma "no copy" pragma "no auto destroy"
     const ref rl = (rootLocale._instance:borrowed RootLocale?)!.getDefaultLocaleArray();
     defaultLocale._instance = rl[0]._instance;
   }
 
-  @chpldoc.nodoc
   proc chpl_singletonCurrentLocaleInitPrivateSublocs(arg: locale) {
     for i in 0..#arg._getChildCount() {
       var subloc = arg._getChild(i);
@@ -753,7 +742,6 @@ module ChapelLocale {
       chpl_singletonCurrentLocaleInitPrivateSublocs(subloc);
     }
   }
-  @chpldoc.nodoc
   proc chpl_singletonCurrentLocaleInitPrivate(locIdx) {
     pragma "no copy" pragma "no auto destroy"
     const ref rl = (rootLocale._instance:borrowed RootLocale?)!.getDefaultLocaleArray();
@@ -768,11 +756,9 @@ module ChapelLocale {
 
   pragma "fn synchronization free"
   pragma "codegen for CPU and GPU"
-  @chpldoc.nodoc
   extern proc chpl_task_getRequestedSubloc(): chpl_sublocID_t;
 
   pragma "insert line file info"
-  @chpldoc.nodoc
   export
   proc chpl_getLocaleID(ref localeID: chpl_localeID_t) {
     localeID = here_id;
@@ -789,7 +775,6 @@ module ChapelLocale {
 
   // Returns a wide pointer to the locale with the given id.
   pragma "fn returns infinite lifetime"
-  @chpldoc.nodoc
   proc chpl_localeID_to_locale(id : chpl_localeID_t) : locale {
     if rootLocale._instance != nil then
       return (rootLocale._instance:borrowed AbstractRootLocale?)!.localeIDtoLocale(id);
@@ -817,7 +802,6 @@ module ChapelLocale {
   //
   pragma "insert line file info"
   pragma "inc running task"
-  @chpldoc.nodoc
   export
   proc chpl_taskRunningCntInc() {
     if rootLocaleInitialized {
@@ -827,7 +811,6 @@ module ChapelLocale {
 
   pragma "insert line file info"
   pragma "dec running task"
-  @chpldoc.nodoc
   export
   proc chpl_taskRunningCntDec() {
     if rootLocaleInitialized {
@@ -836,7 +819,6 @@ module ChapelLocale {
   }
 
   pragma "insert line file info"
-  @chpldoc.nodoc
   export
   proc chpl_taskRunningCntReset() {
     here.runningTaskCntSet(0);

--- a/modules/internal/ChapelPrivatization.chpl
+++ b/modules/internal/ChapelPrivatization.chpl
@@ -23,12 +23,10 @@ module ChapelPrivatization {
   private use CTypes;
 
   // the type of elements in chpl_privateObjects.
-  @chpldoc.nodoc
   extern record chpl_privateObject_t {
     var obj:c_void_ptr;
   }
 
-  @chpldoc.nodoc
   extern var chpl_privateObjects:c_ptr(chpl_privateObject_t);
 
   pragma "fn returns infinite lifetime"

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -980,7 +980,7 @@ module ChapelRange {
   // to work around casting limitations in code that calculates the ordinals
   // for low/high of a pre-allocated enum range, ex., in range/domain followers
 
-  @chpldoc.nodoc inline proc ref range.chpl_setFields(low, high, stride) {
+  inline proc ref range.chpl_setFields(low, high, stride) {
     this._low  = chpl__idxToInt(low):  this.intIdxType;
     this._high = chpl__idxToInt(high): this.intIdxType;
     if this.hasParamStrideAltvalAld() {
@@ -993,7 +993,7 @@ module ChapelRange {
     }
   }
 
-  @chpldoc.nodoc inline proc ref range.chpl_setFields(low, high) {
+  inline proc ref range.chpl_setFields(low, high) {
     compilerAssert(this.hasParamStride()); // otherwise stride = ?
     this._low  = chpl__idxToInt(low):  this.intIdxType;
     this._high = chpl__idxToInt(high): this.intIdxType;
@@ -1047,7 +1047,6 @@ module ChapelRange {
       return helpAlignLow(_low, _alignment, stride);
   }
 
-  @chpldoc.nodoc
   inline proc range.chpl_alignedLowAsIntForIter {
     if !hasUnitStride() && !hasLowBound() && isFiniteIndexType() {
       return helpAlignLow(chpl__idxToInt(lowBoundForIter(this)), _alignment, stride);
@@ -1143,7 +1142,6 @@ module ChapelRange {
       return helpAlignHigh(_high, _alignment, stride);
   }
 
-  @chpldoc.nodoc
   inline proc range.chpl_alignedHighAsIntForIter {
     if !hasUnitStride() && !hasHighBound() && isFiniteIdxType(idxType) {
       return helpAlignHigh(chpl__idxToInt(highBoundForIter(this)), _alignment, stride);
@@ -1263,7 +1261,6 @@ module ChapelRange {
     return lenAsUint: t;
   }
 
-  @chpldoc.nodoc
   proc range.chpl_sizeAsForIter(type t: integral): t {
     if chpl__singleValIdxType(idxType) {
       if _low > _high then return 0;
@@ -1316,7 +1313,6 @@ module ChapelRange {
                                   else this.alignedHighAsInt;
   }
 
-  @chpldoc.nodoc
   inline proc range.chpl_firstAsIntForIter {
     if this.bounds == boundKind.both {
       return this.firstAsInt;
@@ -1371,7 +1367,6 @@ module ChapelRange {
                                   else this.alignedLowAsInt;
   }
 
-  @chpldoc.nodoc
   inline proc range.chpl_lastAsIntForIter {
     if bounds == boundKind.both {
       return this.lastAsInt;
@@ -3620,7 +3615,6 @@ private inline proc rangeCastHelper(r, type t) throws {
   //# Internal helper functions.
   //#
 
-  @chpldoc.nodoc
   inline proc range.chpl__unTranslate(i) do
     return this - i;
 
@@ -3773,7 +3767,6 @@ private inline proc rangeCastHelper(r, type t) throws {
     }
   }
 
-  @chpldoc.nodoc
   proc chpl__idxTypeToIntIdxType(type idxType) type {
     if isIntegralType(idxType) {
       // integer idxTypes are their own integer idxType
@@ -3789,7 +3782,6 @@ private inline proc rangeCastHelper(r, type t) throws {
   // a single underscore where the standalone versions use double
   // underscores.  Reason: otherwise, the calls in range.init() try
   // to call the method version, which isn't currently legal.
-  @chpldoc.nodoc
   inline proc range.chpl_intToIdx(i) {
     return chpl__intToIdx(this.idxType, i);
   }

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -106,7 +106,6 @@ module ChapelSyncvar {
     return ret;
   }
 
-  @chpldoc.nodoc
   proc chpl__readXX(x) do return x;
 
   /************************************ | *************************************
@@ -395,7 +394,6 @@ module ChapelSyncvar {
   }
 
   pragma "auto copy fn"
-  @chpldoc.nodoc
   proc chpl__autoCopy(const ref rhs : _syncvar, definedConst: bool) {
     // Does it make sense to have a const sync? If so, can we make use of that
     // information here?
@@ -411,7 +409,6 @@ module ChapelSyncvar {
       delete x.wrapped;
   }
 
-  @chpldoc.nodoc
   proc chpl__readXX(const ref x : _syncvar(?)) do return x.readXX();
 
   @chpldoc.nodoc
@@ -960,7 +957,6 @@ module ChapelSyncvar {
   }
 
   pragma "auto copy fn"
-  @chpldoc.nodoc
   proc chpl__autoCopy(const ref rhs : _singlevar, definedConst: bool) {
     return new _singlevar(rhs);
   }
@@ -974,7 +970,6 @@ module ChapelSyncvar {
       delete x.wrapped;
   }
 
-  @chpldoc.nodoc
   proc chpl__readXX(const ref x : _singlevar(?)) do return x.readXX();
 
   /************************************ | *************************************

--- a/modules/internal/MemConsistency.chpl
+++ b/modules/internal/MemConsistency.chpl
@@ -108,15 +108,12 @@ module MemConsistency {
 
   pragma "insert line file info"
   pragma "compiler added remote fence"
-  @chpldoc.nodoc
   extern proc chpl_rmem_consist_release();
   pragma "insert line file info"
   pragma "compiler added remote fence"
-  @chpldoc.nodoc
   extern proc chpl_rmem_consist_acquire();
   pragma "insert line file info"
   pragma "compiler added remote fence"
-  @chpldoc.nodoc
   extern proc chpl_rmem_consist_maybe_release(order:memory_order);
   pragma "compiler added remote fence"
   proc chpl_rmem_consist_maybe_release(param order:memoryOrder) {
@@ -124,7 +121,6 @@ module MemConsistency {
   }
   pragma "insert line file info"
   pragma "compiler added remote fence"
-  @chpldoc.nodoc
   extern proc chpl_rmem_consist_maybe_acquire(order:memory_order);
   pragma "compiler added remote fence"
   proc chpl_rmem_consist_maybe_acquire(param order:memoryOrder) {
@@ -133,7 +129,6 @@ module MemConsistency {
 
   // This one can be used in module code.
   pragma "insert line file info"
-  @chpldoc.nodoc
   extern proc chpl_rmem_consist_fence(order:memory_order);
   proc chpl_rmem_consist_fence(param order:memoryOrder) {
     chpl_rmem_consist_fence(c_memory_order(order));

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -33,13 +33,11 @@ module OwnedObject {
   pragma "copy mutates"
   pragma "managed pointer"
   record _owned {
-    @chpldoc.nodoc
     type chpl_t;                // contained type (class type)
 
     // contained pointer (class type)
     // uses primitive as a workaround for compiler issues
     pragma "owned"
-    @chpldoc.nodoc
     var chpl_p:__primitive("to nilable class", chpl_t);
 
     // Note that the compiler also allows coercion to the borrow type.
@@ -355,7 +353,6 @@ module OwnedObject {
   // initCopy is defined explicitly as a workaround
   // for problems with initializers in this case
   pragma "init copy fn"
-  @chpldoc.nodoc
   proc chpl__initCopy(pragma "leaves arg nil" pragma "nil from arg"
                       ref src: _owned,
                       definedConst: bool) {
@@ -366,7 +363,6 @@ module OwnedObject {
   // autoCopy is defined explicitly as a workaround
   // for problems with initializers in this case
   pragma "auto copy fn"
-  @chpldoc.nodoc
   proc chpl__autoCopy(pragma "leaves arg nil" pragma "nil from arg"
                       ref src: _owned,
                       definedConst: bool) {
@@ -376,7 +372,6 @@ module OwnedObject {
   // This is a workaround - compiler was resolving
   // chpl__autoDestroy(x:object) from internal coercions.
   pragma "auto destroy fn"
-  @chpldoc.nodoc
   proc chpl__autoDestroy(ref x: _owned) {
     __primitive("call destructor", __primitive("deref", x));
   }

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -113,20 +113,17 @@ module SharedObject {
    */
   pragma "managed pointer"
   record _shared {
-    @chpldoc.nodoc
     type chpl_t;         // contained type (class type)
 
     // contained pointer (class type)
     // uses primitive as a workaround for compiler issues
     pragma "owned"
-    @chpldoc.nodoc
     var chpl_p:__primitive("to nilable class", chpl_t);
 
     // Note that compiler also allows coercion to the borrow type.
     forwarding borrow();
 
     pragma "owned"
-    @chpldoc.nodoc
     var chpl_pn:unmanaged ReferenceCount?; // reference counter
 
     /*
@@ -534,7 +531,6 @@ module SharedObject {
 
   // This is a workaround
   pragma "auto destroy fn"
-  @chpldoc.nodoc
   proc chpl__autoDestroy(ref x: _shared) {
     __primitive("call destructor", __primitive("deref", x));
   }
@@ -743,11 +739,9 @@ module WeakPointer {
     type classType;
 
     pragma "owned"
-    @chpldoc.nodoc
     var chpl_p: __primitive("to nilable class", _to_unmanaged(classType)); // instance pointer
 
     pragma "owned"
-    @chpldoc.nodoc
     var chpl_pn: unmanaged ReferenceCount?; // reference counter
 
     // ---------------- Initializers ----------------

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -119,64 +119,48 @@ module String {
 }
 
   // Helper routines in support of being able to use ranges of indices
-  @chpldoc.nodoc
   proc chpl_build_bounded_range(low: byteIndex, high: byteIndex) do
     return new range(byteIndex, low=low, high=high);
-  @chpldoc.nodoc
   proc chpl_build_bounded_range(low: codepointIndex, high: codepointIndex) do
     return new range(codepointIndex, low=low, high=high);
 
-  @chpldoc.nodoc
   proc chpl_build_low_bounded_range(low: byteIndex) do
     return new range(low=low);
-  @chpldoc.nodoc
   proc chpl_build_low_bounded_range(low: codepointIndex) do
     return new range(low=low);
 
-  @chpldoc.nodoc
   proc chpl_build_high_bounded_range(high: byteIndex) do
     return new range(high=high);
-  @chpldoc.nodoc
   proc chpl_build_high_bounded_range(high: codepointIndex) do
     return new range(high=high);
 
 
-  @chpldoc.nodoc
   proc chpl__rangeStrideType(type idxType: byteIndex) type do
     return int;
 
-  @chpldoc.nodoc
   proc chpl__rangeStrideType(type idxType: codepointIndex) type do
     return int;
 
-  @chpldoc.nodoc
   proc chpl__rangeUnsignedType(type idxType: byteIndex) type do
     return uint;
 
-  @chpldoc.nodoc
   proc chpl__rangeUnsignedType(type idxType: codepointIndex) type do
     return uint;
 
-  @chpldoc.nodoc
   inline proc chpl__idxToInt(i: byteIndex) do
     return i:int;
-  @chpldoc.nodoc
   inline proc chpl__idxToInt(i: codepointIndex) do
     return i:int;
 
-  @chpldoc.nodoc
   inline proc chpl__intToIdx(type idxType: byteIndex, i: int) do
     return i: byteIndex;
 
-  @chpldoc.nodoc
   inline proc chpl__intToIdx(type idxType: codepointIndex, i: int) do
     return i: codepointIndex;
 
-  @chpldoc.nodoc
   proc chpl__idxTypeToIntIdxType(type idxType: byteIndex) type do
     return int;
 
-  @chpldoc.nodoc
   proc chpl__idxTypeToIntIdxType(type idxType: codepointIndex) type do
     return int;
 
@@ -466,7 +450,6 @@ module String {
                                         size=length+1);
   }
 
-  @chpldoc.nodoc
   proc chpl_createStringWithLiteral(buffer: c_string,
                                     offset: int,
                                     x: c_string,

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1438,6 +1438,7 @@ module String {
   /*
     Iterates over the string byte by byte.
   */
+  pragma "chpldoc ignore chpl prefix"
   iter string.chpl_bytes() : uint(8) {
     var localThis: string = this.localize();
 

--- a/modules/minimal/internal/ChapelLocale.chpl
+++ b/modules/minimal/internal/ChapelLocale.chpl
@@ -23,7 +23,6 @@
 module ChapelLocale {
   use ChapelBase;
 
-  @chpldoc.nodoc
   type chpl_sublocID_t = int(32);
 
   //

--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -247,7 +247,6 @@ prototype module AtomicObjects {
   @chpldoc.nodoc
   extern type c_nodeid_t;
 
-  @chpldoc.nodoc
   extern proc chpl_return_wide_ptr_node(c_nodeid_t, c_void_ptr) : wide_ptr_t;
 
   if numLocales >= 2**16 {

--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -248,14 +248,12 @@ module Futures {
   } // record Future
 
   pragma "init copy fn"
-  @chpldoc.nodoc
   proc chpl__initCopy(x: Future, definedConst: bool) {
     x.acquire();
     return x;
   }
 
   pragma "auto copy fn"
-  @chpldoc.nodoc
   proc chpl__autoCopy(x: Future, definedConst: bool) {
     x.acquire();
     return x;

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -607,7 +607,6 @@ proc Matrix(A: [?Dom] ?Atype, type eltType=Atype)
   return M;
 }
 
-@chpldoc.nodoc
 proc chpl_varargsOKForMatrix(Arrays) param {
   if isHomogeneousTuple(Arrays) {
     return isArray(Arrays(0)) && Arrays(0).rank == 1;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -321,7 +321,6 @@ proc compareByPart(a:?t, b:t, comparator:?rec) {
      a > b : returns value > 0
      a == b: returns 0
 */
-@chpldoc.nodoc
 inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
   // TODO -- In cases where values are larger than keys, it may be faster to
   //         key data once and sort the keyed data, mirroring swaps in data.
@@ -341,7 +340,6 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
 
 
 pragma "unsafe" // due to 'data' default-initialized to nil for class types
-@chpldoc.nodoc
 /*
     Check if a comparator was passed and confirm that it will work, otherwise
     throw a compile-time error.

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -251,7 +251,6 @@ module AutoMath {
     return chpl_acos(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_acos(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -275,7 +274,6 @@ module AutoMath {
     return chpl_acos(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_acos(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -293,7 +291,6 @@ module AutoMath {
     return chpl_acos(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_acos(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -311,7 +308,6 @@ module AutoMath {
     return chpl_acos(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_acos(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -333,7 +329,6 @@ module AutoMath {
     return chpl_acosh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_acosh(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -357,7 +352,6 @@ module AutoMath {
     return chpl_acosh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_acosh(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -375,7 +369,6 @@ module AutoMath {
     return chpl_acosh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_acosh(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -393,7 +386,6 @@ module AutoMath {
     return chpl_acosh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_acosh(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -415,7 +407,6 @@ module AutoMath {
     return chpl_asin(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_asin(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -439,7 +430,6 @@ module AutoMath {
     return chpl_asin(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_asin(x: real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -457,7 +447,6 @@ module AutoMath {
     return chpl_asin(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_asin(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -475,7 +464,6 @@ module AutoMath {
     return chpl_asin(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_asin(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -494,7 +482,6 @@ module AutoMath {
     return chpl_asinh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_asinh(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -515,7 +502,6 @@ module AutoMath {
     return chpl_asinh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_asinh(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -533,7 +519,6 @@ module AutoMath {
     return chpl_asinh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_asinh(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -551,7 +536,6 @@ module AutoMath {
     return chpl_asinh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_asinh(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -571,7 +555,6 @@ module AutoMath {
     return chpl_atan(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atan(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -592,7 +575,6 @@ module AutoMath {
     return chpl_atan(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atan(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -610,7 +592,6 @@ module AutoMath {
     return chpl_atan(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atan(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -628,7 +609,6 @@ module AutoMath {
     return chpl_atan(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atan(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -651,7 +631,6 @@ module AutoMath {
     return chpl_atan2(y, x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atan2(y: real(64), x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -676,7 +655,6 @@ module AutoMath {
     return chpl_atan2(y, x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atan2(y : real(32), x: real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -697,7 +675,6 @@ module AutoMath {
     return chpl_atanh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atanh(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -720,7 +697,6 @@ module AutoMath {
     return chpl_atanh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atanh(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -738,7 +714,6 @@ module AutoMath {
     return chpl_atanh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atanh(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -756,7 +731,6 @@ module AutoMath {
     return chpl_atanh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_atanh(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -859,7 +833,6 @@ module AutoMath {
     return chpl_cos(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_cos(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -880,7 +853,6 @@ module AutoMath {
     return chpl_cos(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_cos(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -898,7 +870,6 @@ module AutoMath {
     return chpl_cos(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_cos(z : complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -916,7 +887,6 @@ module AutoMath {
     return chpl_cos(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_cos(z : complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -935,7 +905,6 @@ module AutoMath {
     return chpl_cosh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_cosh(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -956,7 +925,6 @@ module AutoMath {
     return chpl_cosh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_cosh(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -974,7 +942,6 @@ module AutoMath {
     return chpl_cosh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_cosh(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -992,7 +959,6 @@ module AutoMath {
     return chpl_cosh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_cosh(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1089,7 +1055,6 @@ module AutoMath {
     return chpl_erf(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_erf(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1109,7 +1074,6 @@ module AutoMath {
     return chpl_erf(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_erf(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1126,7 +1090,6 @@ module AutoMath {
     return chpl_erfc(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_erfc(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1146,7 +1109,6 @@ module AutoMath {
     return chpl_erfc(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_erfc(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1166,7 +1128,6 @@ module AutoMath {
     return chpl_exp(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_exp(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1188,7 +1149,6 @@ module AutoMath {
     return chpl_exp(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_exp(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1207,7 +1167,6 @@ module AutoMath {
     return chpl_exp(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_exp(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1226,7 +1185,6 @@ module AutoMath {
     return chpl_exp(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_exp(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1245,7 +1203,6 @@ module AutoMath {
     return chpl_exp2(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_exp2(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1266,7 +1223,6 @@ module AutoMath {
     return chpl_exp2(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_exp2(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1286,7 +1242,6 @@ module AutoMath {
     return chpl_expm1(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_expm1(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1308,7 +1263,6 @@ module AutoMath {
     return chpl_expm1(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_expm1(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1370,7 +1324,6 @@ module AutoMath {
     return chpl_ldexp(x, n);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_ldexp(x:real(64), n:int(32)):real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1390,7 +1343,6 @@ module AutoMath {
     return chpl_ldexp(x, n);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_ldexp(x:real(32), n:int(32)):real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1407,7 +1359,6 @@ module AutoMath {
     return chpl_lgamma(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_lgamma(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1427,7 +1378,6 @@ module AutoMath {
     return chpl_lgamma(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_lgamma(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1449,7 +1399,6 @@ module AutoMath {
     return chpl_log(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1473,7 +1422,6 @@ module AutoMath {
     return chpl_log(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1491,7 +1439,6 @@ module AutoMath {
     return chpl_log(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1509,7 +1456,6 @@ module AutoMath {
     return chpl_log(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1531,7 +1477,6 @@ module AutoMath {
     return chpl_log10(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log10(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1555,7 +1500,6 @@ module AutoMath {
     return chpl_log10(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log10(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1565,7 +1509,6 @@ module AutoMath {
 
   // To prevent this auto-included module from using a non-auto-included module
   // (Math)
-  @chpldoc.nodoc
   inline proc chpl_log1p(x: real(64)): real(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1575,7 +1518,6 @@ module AutoMath {
 
   // To prevent this auto-included module from using a non-auto-included module
   // (Math)
-  @chpldoc.nodoc
   inline proc chpl_log1p(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1627,7 +1569,6 @@ module AutoMath {
     return chpl_log2(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log2(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -1651,7 +1592,6 @@ module AutoMath {
     return chpl_log2(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log2(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -1683,7 +1623,6 @@ module AutoMath {
     return lg2 / baseLog2;
   }
 
-  @chpldoc.nodoc
   inline proc chpl_logBasePow2(val: int(?w), baseLog2) {
     if (val < 1) {
       halt("Can't take the log() of a non-positive integer");
@@ -1691,7 +1630,6 @@ module AutoMath {
     return _logBasePow2Help(val, baseLog2);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_logBasePow2(val: uint(?w), baseLog2) {
     return _logBasePow2Help(val, baseLog2);
   }
@@ -1712,7 +1650,6 @@ module AutoMath {
     return chpl_log2(val);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log2(val: int(?w)) {
     return chpl_logBasePow2(val, 1);
   }
@@ -1733,7 +1670,6 @@ module AutoMath {
     return chpl_log2(val);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_log2(val: uint(?w)) {
     return chpl_logBasePow2(val, 1);
   }
@@ -2038,7 +1974,6 @@ module AutoMath {
     return chpl_sin(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_sin(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -2059,7 +1994,6 @@ module AutoMath {
     return chpl_sin(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_sin(x: real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2077,7 +2011,6 @@ module AutoMath {
     return chpl_sin(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_sin(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2095,7 +2028,6 @@ module AutoMath {
     return chpl_sin(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_sin(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2114,7 +2046,6 @@ module AutoMath {
     return chpl_sinh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_sinh(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -2135,7 +2066,6 @@ module AutoMath {
     return chpl_sinh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_sinh(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2153,7 +2083,6 @@ module AutoMath {
     return chpl_sinh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_sinh(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2171,7 +2100,6 @@ module AutoMath {
     return chpl_sinh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_sinh(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2226,7 +2154,6 @@ module AutoMath {
     return chpl_tan(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tan(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -2247,7 +2174,6 @@ module AutoMath {
     return chpl_tan(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tan(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2265,7 +2191,6 @@ module AutoMath {
     return chpl_tan(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tan(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2283,7 +2208,6 @@ module AutoMath {
     return chpl_tan(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tan(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2302,7 +2226,6 @@ module AutoMath {
     return chpl_tanh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tanh(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -2323,7 +2246,6 @@ module AutoMath {
     return chpl_tanh(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tanh(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2341,7 +2263,6 @@ module AutoMath {
     return chpl_tanh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tanh(z: complex(64)): complex(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2359,7 +2280,6 @@ module AutoMath {
     return chpl_tanh(z);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tanh(z: complex(128)): complex(128) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2376,7 +2296,6 @@ module AutoMath {
     return chpl_tgamma(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tgamma(x: real(64)): real(64) {
     // Note: this extern proc was originally free standing.  It might be
     // reasonable to make it that way again when the deprecated version is
@@ -2396,7 +2315,6 @@ module AutoMath {
     return chpl_tgamma(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_tgamma(x : real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2431,7 +2349,6 @@ module AutoMath {
     return chpl_gcd(a, b);
   }
 
-  @chpldoc.nodoc
   proc chpl_gcd(in a: int,in b: int): int {
      a = abs(a);
      b = abs(b);
@@ -2454,7 +2371,6 @@ module AutoMath {
     return ( (diff<=abs(rtol*y)) || (diff<=abs(rtol*x)) || (diff<=atol) );
   }
 
-  @chpldoc.nodoc
   inline proc chpl_j0(x: real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2462,7 +2378,6 @@ module AutoMath {
     return chpl_float_j0(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_j0(x: real(64)): real(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2490,7 +2405,6 @@ module AutoMath {
     return chpl_j0(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_j1(x: real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2498,7 +2412,6 @@ module AutoMath {
     return chpl_float_j1(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_j1(x: real(64)): real(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2526,7 +2439,6 @@ module AutoMath {
     return chpl_j1(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_jn(n: int, x: real(32)): real(32) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2534,7 +2446,6 @@ module AutoMath {
     return chpl_float_jn(n.safeCast(c_int), x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_jn(n: int, x: real(64)): real(64) {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2562,7 +2473,6 @@ module AutoMath {
     return chpl_jn(n, x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_y0(x: real(32)): real(32) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for y0() must be non-negative");
@@ -2573,7 +2483,6 @@ module AutoMath {
     return chpl_float_y0(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_y0(x: real(64)): real(64) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for y0() must be non-negative");
@@ -2604,7 +2513,6 @@ module AutoMath {
     return chpl_y0(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_y1(x: real(32)): real(32) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for y1() must be non-negative");
@@ -2615,7 +2523,6 @@ module AutoMath {
     return chpl_float_y1(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_y1(x: real(64)): real(64) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for y1() must be non-negative");
@@ -2646,7 +2553,6 @@ module AutoMath {
     return chpl_y1(x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_yn(n: int, x: real(32)): real(32) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for yn() must be non-negative");
@@ -2657,7 +2563,6 @@ module AutoMath {
     return chpl_float_yn(n.safeCast(c_int), x);
   }
 
-  @chpldoc.nodoc
   inline proc chpl_yn(n: int, x: real(64)): real(64) {
     if boundsChecking && x < 0 then
       HaltWrappers.boundsCheckHalt("Input value for yn() must be non-negative");

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4655,12 +4655,10 @@ module BigInteger {
     var localeId: chpl_nodeID_t;
   }
 
-  @chpldoc.nodoc
   proc bigint.chpl__serialize() {
     return new __serializeHelper(this.mpz, this.localeId);
   }
 
-  @chpldoc.nodoc
   proc type bigint.chpl__deserialize(data) {
     var ret: bigint;
     if data.localeId == chpl_nodeID {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -409,32 +409,6 @@ module BigInteger {
       return ret.safeCast(int);
     }
 
-    @deprecated(notes="This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_nlimbs` on the mpz field instead")
-    proc numLimbs : uint {
-      return chpl_gmp_mpz_nlimbs(this.mpz);
-    }
-
-    @deprecated(notes="This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_getlimbn` on the mpz field instead")
-    proc get_limbn(n: integral) : uint {
-      var   ret: uint;
-
-      if _local {
-        ret = chpl_gmp_mpz_getlimbn(this.mpz, n);
-
-      } else if this.localeId == chpl_nodeID {
-        ret = chpl_gmp_mpz_getlimbn(this.mpz, n);
-
-      } else {
-        const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
-
-        on __primitive("chpl_on_locale_num", thisLoc) {
-          ret = chpl_gmp_mpz_getlimbn(this.mpz, n);
-        }
-      }
-
-      return ret;
-    }
-
     @deprecated(notes="mpzStruct is deprecated, please use :proc:`getImpl` instead")
     proc mpzStruct() : __mpz_struct {
       return getImpl();

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -48,9 +48,7 @@ module CTypes {
   /* The Chapel type corresponding to the C 'double' type */
   extern type c_double = real(64);
 
-  @chpldoc.nodoc
   extern "_cfile" type chpl_cFilePtr; // can be removed when deprecation is complete
-  @chpldoc.nodoc
   extern "_cfiletype" type chpl_cFile; // direct uses of this type in the IO module
                                       // can be replaced with c_FILE when deprecation is complete
 
@@ -1293,13 +1291,9 @@ module CTypes {
   // using the internal name.
   // After the deprecated function is removed, we can remove the extra
   // definition and just have `isAnyCPtr` as a private nodoc function
-  @chpldoc.nodoc
   proc chpl_isAnyCPtr(type t:c_ptr) param do return true;
-  @chpldoc.nodoc
   proc chpl_isAnyCPtr(type t:c_ptrConst) param do return true;
-  @chpldoc.nodoc
   proc chpl_isAnyCPtr(type t:c_void_ptr) param do return true;
-  @chpldoc.nodoc
   proc chpl_isAnyCPtr(type t) param do return false;
 
   /*

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -663,19 +663,15 @@ module ChapelIO {
   @chpldoc.nodoc
   proc _ddata.serialize(writer, ref serializer) throws { writeThis(writer); }
 
-  @chpldoc.nodoc
   proc chpl_taskID_t.writeThis(f) throws {
     f.write(this : uint(64));
   }
-  @chpldoc.nodoc
   proc chpl_taskID_t.serialize(writer, ref serializer) throws { writeThis(writer); }
 
-  @chpldoc.nodoc
   proc chpl_taskID_t.readThis(f) throws {
     this = f.read(uint(64)) : chpl_taskID_t;
   }
 
-  @chpldoc.nodoc
   proc type chpl_taskID_t.deserializeFrom(reader, ref deserializer) throws {
     var ret : chpl_taskID_t;
     ret.readThis(reader);
@@ -913,7 +909,6 @@ module ChapelIO {
     try! { stdout.writef(fmt); }
   }
 
-  @chpldoc.nodoc
   proc chpl_stringify_wrapper(const args ...):string {
     use IO only stringify;
     return stringify((...args));

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -208,6 +208,7 @@ module CommDiagnostics
      and forth between the two.  This first definition duplicates the
      one in the comm layer(s).
    */
+  pragma "chpldoc ignore chpl prefix"
   extern record chpl_commDiagnostics {
     /*
       blocking GETs, in which initiator waits for completion

--- a/modules/standard/Communication.chpl
+++ b/modules/standard/Communication.chpl
@@ -34,7 +34,6 @@ module Communication {
 
   // This module may be used from internal modules that are resolved before
   // Locale-related modules. So, we can't use `numLocales` or `Locales` here.
-  @chpldoc.nodoc
   private extern const chpl_numNodes: int(32);
 
   /*

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -155,7 +155,6 @@ module Errors {
   // will be read from this after all tasks that can add
   // errors have completed; at that point it no longer needs
   // to be parallel-safe.
-  @chpldoc.nodoc
   record chpl_TaskErrors {
     var _head: unmanaged Error? = nil;
     var _errorsLock: chpl_LocalSpinlock;
@@ -401,7 +400,6 @@ module Errors {
     }
   }
 
-  @chpldoc.nodoc
   proc chpl_error_type_name(err: borrowed Error) : string {
     var cid =  __primitive("getcid", err);
     var nameC: c_string = __primitive("class name by id", cid);
@@ -411,7 +409,6 @@ module Errors {
     }
     return nameS;
   }
-  @chpldoc.nodoc
   proc chpl_describe_error(err: borrowed Error) : string {
     var nameS = chpl_error_type_name(err);
 
@@ -422,7 +419,6 @@ module Errors {
 
   pragma "insert line file info"
   pragma "always propagate line file info"
-  @chpldoc.nodoc
   proc chpl_do_fix_thrown_error(err: unmanaged Error?): unmanaged Error {
 
     var fixErr: unmanaged Error? = err;
@@ -448,7 +444,6 @@ module Errors {
   pragma "insert line file info"
   pragma "always propagate line file info"
   pragma "ignore in global analysis"
-  @chpldoc.nodoc
   proc chpl_fix_thrown_error(in err: owned Error?): unmanaged Error {
     return chpl_do_fix_thrown_error(owned.release(err));
   }
@@ -457,20 +452,17 @@ module Errors {
   pragma "always propagate line file info"
   pragma "ignore transfer errors"
   pragma "ignore in global analysis"
-  @chpldoc.nodoc
   proc chpl_fix_thrown_error(in err: owned Error): unmanaged Error {
     return chpl_do_fix_thrown_error(owned.release(err));
   }
 
   pragma "insert line file info"
   pragma "always propagate line file info"
-  @chpldoc.nodoc
   proc chpl_fix_thrown_error(err: _nilType) {
     return chpl_do_fix_thrown_error(nil);
   }
 
   pragma "last resort"
-  @chpldoc.nodoc
   proc chpl_fix_thrown_error(err) {
     type t = err.type;
     if isCoercible(t, borrowed Error?) {
@@ -487,19 +479,16 @@ module Errors {
   }
 
   pragma "last resort"
-  @chpldoc.nodoc
   proc chpl_fix_thrown_error(type errType) {
     compilerError("Cannot throw a type: '", errType:string, "'. Did you forget the keyword 'new'?");
   }
 
-  @chpldoc.nodoc
   proc chpl_delete_error(err: unmanaged Error?) {
     if err != nil then delete err;
   }
   pragma "function terminates program"
   pragma "insert line file info"
   pragma "always propagate line file info"
-  @chpldoc.nodoc
   proc chpl_uncaught_error(err: unmanaged Error) {
     extern proc chpl_error_preformatted(c_string);
 
@@ -529,7 +518,6 @@ module Errors {
   // should be replaced by goto-error-handling.
   pragma "insert line file info"
   pragma "always propagate line file info"
-  @chpldoc.nodoc
   proc chpl_propagate_error(err: unmanaged Error) {
     chpl_uncaught_error(err);
   }
@@ -537,7 +525,6 @@ module Errors {
   // from a forall loop, so that it is always TaskErrors
   // (since the author of the forall loop shouldn't need to know
   //  how many tasks were run in that loop).
-  @chpldoc.nodoc
   proc chpl_forall_error(err: unmanaged Error) : unmanaged Error {
     if err:unmanaged TaskErrors? then
       return err;
@@ -549,7 +536,6 @@ module Errors {
   // function helps the compiler throw errors from those generated casts.
   pragma "insert line file info"
   pragma "always propagate line file info"
-  @chpldoc.nodoc
   proc chpl_enum_cast_error(casted: string, enumName: string) throws {
     if casted.isEmpty() then
       throw new owned IllegalArgumentError("bad cast from empty string to enum '" + enumName + "'");
@@ -559,14 +545,12 @@ module Errors {
 
   pragma "insert line file info"
   pragma "always propagate line file info"
-  @chpldoc.nodoc
   proc chpl_enum_cast_error(casted: integral, enumName: string) throws {
     throw new owned IllegalArgumentError("bad cast from int '" + casted:string + "' to enum '" + enumName, "'");
   }
 
   pragma "insert line file info"
   pragma "always propagate line file info"
-  @chpldoc.nodoc
   proc chpl_enum_cast_error_no_int(enumName: string, constName: string) throws {
     throw new owned IllegalArgumentError("bad cast: enum '" + enumName + "." +
                                           constName + "' has no integer value");
@@ -578,7 +562,6 @@ module Errors {
   // function helps the compiler throw errors from those generated casts.
   pragma "insert line file info"
   pragma "always propagate line file info"
-  @chpldoc.nodoc
   proc chpl_enum_cast_error(casted: bytes, enumName: string) throws {
     if casted.isEmpty() then
       throw new owned IllegalArgumentError("bad cast from empty bytes to enum '" + enumName + "'");

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -114,6 +114,7 @@ module GMP {
 
   require "GMPHelper/chplgmp.h";
 
+  pragma "chpldoc ignore chpl prefix"
   proc chpl_gmp_alloc(size:c_size_t) : c_void_ptr {
     pragma "insert line file info"
     extern proc chpl_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_void_ptr;
@@ -121,6 +122,7 @@ module GMP {
     return chpl_mem_alloc(size, CHPL_RT_MD_GMP);
   }
 
+  pragma "chpldoc ignore chpl prefix"
   proc chpl_gmp_realloc(ptr:c_void_ptr,
                                old_size:c_size_t, new_size:c_size_t) : c_void_ptr {
     pragma "insert line file info"
@@ -129,15 +131,18 @@ module GMP {
     return chpl_mem_realloc(ptr, new_size, CHPL_RT_MD_GMP);
   }
 
+  pragma "chpldoc ignore chpl prefix"
   proc chpl_gmp_free(ptr:c_void_ptr, old_size:c_size_t) {
     pragma "insert line file info"
       extern proc chpl_mem_free(ptr:c_void_ptr) : void;
     chpl_mem_free(ptr);
   }
 
+
   //
   // Initialize GMP to use Chapel's allocator
   //
+  pragma "chpldoc ignore chpl prefix"
   proc chpl_gmp_init() {
     extern proc chpl_gmp_mp_set_memory_functions(alloc:c_fn_ptr,
                                                  realloc:c_fn_ptr,
@@ -1127,6 +1132,7 @@ module GMP {
 
 
   /* Get an MPZ value stored on another locale */
+  pragma "chpldoc ignore chpl prefix"
   proc chpl_gmp_get_mpz(ref ret: mpz_t,
                         src_locale: int,
                         in from: __mpz_struct,
@@ -1164,12 +1170,14 @@ module GMP {
   }
 
   /* Return the number of limbs used in the number */
+  pragma "chpldoc ignore chpl prefix"
   proc chpl_gmp_mpz_nlimbs(const ref from: mpz_t) : uint(64) {
     var x = chpl_gmp_mpz_struct_sign_size(from[0]);
     return (abs(x)):uint(64);
   }
 
   /* Return the i'th limb used in the number (counting from 0) */
+  pragma "chpldoc ignore chpl prefix"
   proc chpl_gmp_mpz_getlimbn(const ref from: mpz_t, n:integral) : uint(64) {
     var i = n.safeCast(mp_size_t);
     // OK to cast result to maximal uint for two reasons:
@@ -1204,6 +1212,7 @@ module GMP {
   chpl_gmp_randstate_same_algorithm(a:gmp_randstate_t, b:gmp_randstate_t):c_int;
 
   /* Get an mpz_t as a string */
+  pragma "chpldoc ignore chpl prefix"
   extern proc chpl_gmp_mpz_get_str(base: c_int, const ref x: mpz_t) : c_string;
 
   class GMPRandom {

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -38,20 +38,16 @@ module GPU
   use ChplConfig;
 
   pragma "codegen for CPU and GPU"
-  @chpldoc.nodoc
   extern proc chpl_gpu_write(const str : c_string) : void;
 
   pragma "codegen for CPU and GPU"
-  @chpldoc.nodoc
   extern proc chpl_gpu_clock() : uint;
 
   pragma "codegen for CPU and GPU"
-  @chpldoc.nodoc
   extern proc chpl_gpu_printTimeDelta(
     msg : c_string, start : uint, stop : uint) : void;
 
   pragma "codegen for CPU and GPU"
-  @chpldoc.nodoc
   extern proc chpl_gpu_device_clock_rate(devNum : int(32)) : uint;
 
   /*

--- a/modules/standard/GpuDiagnostics.chpl
+++ b/modules/standard/GpuDiagnostics.chpl
@@ -48,6 +48,7 @@ module GpuDiagnostics
   /*
      Aggregated GPU operation counts.
    */
+  pragma "chpldoc ignore chpl prefix"
   extern record chpl_gpuDiagnostics {
     var kernel_launch: uint(64);
   };

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1131,7 +1131,6 @@ class QioPluginChannel {
 
 // These functions let the C QIO code call the plugins
 // TODO: Move more of the QIO code to be pure Chapel
-@chpldoc.nodoc
 export proc chpl_qio_setup_plugin_channel(file:c_void_ptr, ref plugin_ch:c_void_ptr, start:int(64), end:int(64), qio_ch:qio_channel_ptr_t):errorCode {
   var f=(file:unmanaged QioPluginFile?)!;
   var pluginChannel:unmanaged QioPluginChannel? = nil;
@@ -1140,17 +1139,14 @@ export proc chpl_qio_setup_plugin_channel(file:c_void_ptr, ref plugin_ch:c_void_
   return ret;
 }
 
-@chpldoc.nodoc
 export proc chpl_qio_read_atleast(ch_plugin:c_void_ptr, amt:int(64)) {
   var c=(ch_plugin:unmanaged QioPluginChannel?)!;
   return c.readAtLeast(amt);
 }
-@chpldoc.nodoc
 export proc chpl_qio_write(ch_plugin:c_void_ptr, amt:int(64)) {
   var c=(ch_plugin:unmanaged QioPluginChannel?)!;
   return c.write(amt);
 }
-@chpldoc.nodoc
 export proc chpl_qio_channel_close(ch:c_void_ptr):errorCode {
   var c=(ch:unmanaged QioPluginChannel?)!;
   var err = c.close();
@@ -1158,27 +1154,22 @@ export proc chpl_qio_channel_close(ch:c_void_ptr):errorCode {
   return err;
 }
 
-@chpldoc.nodoc
 export proc chpl_qio_filelength(file:c_void_ptr, ref length:int(64)):errorCode {
   var f=(file:unmanaged QioPluginFile?)!;
   return f.filelength(length);
 }
-@chpldoc.nodoc
 export proc chpl_qio_getpath(file:c_void_ptr, ref str:c_string, ref len:int(64)):errorCode {
   var f=(file:unmanaged QioPluginFile?)!;
   return f.getpath(str, len);
 }
-@chpldoc.nodoc
 export proc chpl_qio_fsync(file:c_void_ptr):errorCode {
   var f=(file:unmanaged QioPluginFile?)!;
   return f.fsync();
 }
-@chpldoc.nodoc
 export proc chpl_qio_get_chunk(file:c_void_ptr, ref length:int(64)):errorCode {
   var f=(file:unmanaged QioPluginFile?)!;
   return f.getChunk(length);
 }
-@chpldoc.nodoc
 export proc chpl_qio_get_locales_for_region(file:c_void_ptr, start:int(64),
     end:int(64), ref localeNames:c_void_ptr, ref nLocales:int(64)):errorCode {
   var strPtr:c_ptr(c_string);
@@ -1187,7 +1178,6 @@ export proc chpl_qio_get_locales_for_region(file:c_void_ptr, start:int(64),
   localeNames = strPtr:c_void_ptr;
   return ret;
 }
-@chpldoc.nodoc
 export proc chpl_qio_file_close(file:c_void_ptr):errorCode {
   var f = (file:unmanaged QioPluginFile?)!;
   var err = f.close();
@@ -3614,7 +3604,6 @@ proc fileReader.offset():int(64)
   do return offsetHelper(this, false);
 
 // remove and replace calls to this with 'offset' when 'fileOffsetWithoutLocking' is removed
-@chpldoc.nodoc
 proc fileReader.chpl_offset():int(64) do return offsetHelper(this, false);
 
 /*
@@ -3647,7 +3636,6 @@ proc fileWriter.offset():int(64)
   do return offsetHelper(this, false);
 
 // remove and replace calls to this with 'offset' when 'fileOffsetWithoutLocking' is removed
-@chpldoc.nodoc
 proc fileWriter.chpl_offset():int(64) do return offsetHelper(this, false);
 
 /*
@@ -5180,7 +5168,6 @@ private proc _write_text_internal(_channel_internal:qio_channel_ptr_t, x:?t):err
   return EINVAL;
 }
 
-@chpldoc.nodoc
 config param chpl_testReadBinaryInternalEIO = false;
 
 private proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, ref x:?t):errorCode where _isIoPrimitiveType(t) {
@@ -5282,7 +5269,6 @@ private proc _read_binary_internal(_channel_internal:qio_channel_ptr_t, param by
   return EINVAL;
 }
 
-@chpldoc.nodoc
 config param chpl_testWriteBinaryInternalEIO = false;
 
 private proc _write_binary_internal(_channel_internal:qio_channel_ptr_t, param byteorder:iokind, x:?t):errorCode where _isIoPrimitiveType(t) {
@@ -8857,14 +8843,12 @@ record itemReaderInternal {
 const stdin:fileReader(iokind.dynamic, true);
 stdin = try! (new file(0)).reader();
 
-@chpldoc.nodoc
 extern proc chpl_cstdout():chpl_cFilePtr;
 /* standard output, otherwise known as file descriptor 1 */
 const stdout:fileWriter(iokind.dynamic, true);
 stdout = try! (new file(chpl_cstdout())).writer();
 
 
-@chpldoc.nodoc
 extern proc chpl_cstderr():chpl_cFilePtr;
 /* standard error, otherwise known as file descriptor 2 */
 const stderr:fileWriter(iokind.dynamic, true);

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1078,7 +1078,6 @@ module OS {
   inline operator errorCode.!=(a: int(64), b: errorCode) do return !(a == b);
   @chpldoc.nodoc
   inline operator errorCode.!(a: errorCode) do return (qio_err_iserr(a) == 0:c_int);
-  @chpldoc.nodoc
   inline proc errorCode.chpl_cond_test_method() do return (qio_err_iserr(this) != 0:c_int);
   @chpldoc.nodoc
   inline operator :(x: errorCode, type t: int(32)) do return qio_err_to_int(x);

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -39,7 +39,6 @@
 module Reflection {
 
 // Used to test "--warn-unstable-standard", ignore.
-@chpldoc.nodoc
 @unstable
 var chpl_unstableStandardSymbolForTesting: int;
 chpl_unstableStandardSymbolForTesting;

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -511,7 +511,6 @@ proc _to_regexMatch(ref p:qio_regex_string_piece_t):regexMatch {
 @chpldoc.nodoc
 inline operator regexMatch.!(m: regexMatch) do return !m.matched;
 
-@chpldoc.nodoc
 inline proc regexMatch.chpl_cond_test_method() do return this.matched;
 
 /*  This function extracts the part of a string matching a regular
@@ -548,7 +547,6 @@ private proc serializedType(type exprType) type {
 /* We hold a copy of pattern string/bytes in its serialized form inside
  * this record.
  */
-@chpldoc.nodoc
 record chpl_serializeHelper {
   type exprType;
   var pattern:serializedType(exprType);
@@ -719,12 +717,10 @@ record regex {
                              this._regex);
   }
 
-  @chpldoc.nodoc
   proc chpl__serialize() {
     return _serialize();
   }
 
-  @chpldoc.nodoc
   proc type chpl__deserialize(data) {
     var ret:regex(exprType);
     ret._deserialize(data);

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -274,7 +274,6 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
 /* A record representing a date */
   record date {
-    @chpldoc.nodoc
     var chpl_year, chpl_month, chpl_day: int;
 
     /* The year represented by this `date` value */
@@ -605,9 +604,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* A record representing a time */
   record time {
-    @chpldoc.nodoc
     var chpl_hour, chpl_minute, chpl_second, chpl_microsecond: int;
-    @chpldoc.nodoc
     var chpl_tz: shared Timezone?;
 
     /* The hour represented by this `time` value */
@@ -1001,9 +998,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* A record representing a combined `date` and `time` */
   record dateTime {
-    @chpldoc.nodoc
     var chpl_date: date;
-    @chpldoc.nodoc
     var chpl_time: time;
 
     /* The minimum representable `date` and `time` */
@@ -1731,13 +1726,10 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
      It is an overflow error if `days` is outside the given range.
    */
   record timeDelta {
-    @chpldoc.nodoc
     var chpl_days: int;
 
-    @chpldoc.nodoc
     var chpl_seconds: int;
 
-    @chpldoc.nodoc
     var chpl_microseconds: int;
 
     /* The number of days this `timeDelta` represents */

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -259,7 +259,6 @@ proc isDefaultInitializableType(type t) param {
 }
 
 // Returns the unsigned equivalent of the input type.
-@chpldoc.nodoc
 proc chpl__unsignedType(type t) type
 {
   return uint(numBits(t));
@@ -267,13 +266,11 @@ proc chpl__unsignedType(type t) type
 
 
 // Returns the signed equivalent of the input type.
-@chpldoc.nodoc
 proc chpl__signedType(type t) type
 {
   return int(numBits(t));
 }
 
-@chpldoc.nodoc
 proc chpl__maxIntTypeSameSign(type t) type {
   if ! isIntegralType(t) then
     compilerError("type t is non-integral: ", t:string);
@@ -644,7 +641,6 @@ proc isDefaultInitializable(e) param do return isDefaultInitializableValue(e);
 
 
 // for internal use until we have a better name
-@chpldoc.nodoc
 proc chpl_isSyncSingleAtomic(e: ?t) param do return
   isSyncType(t) ||
   isSingleType(t) ||
@@ -653,7 +649,6 @@ proc chpl_isSyncSingleAtomic(e: ?t) param do return
 // isSubtype(), isProperSubtype() are now directly handled by compiler
 
 // Returns true if it is legal to coerce t1 to t2, false otherwise.
-@chpldoc.nodoc
 proc chpl__legalIntCoerce(type t1, type t2) param
 {
   if (isIntType(t2)) {
@@ -870,7 +865,6 @@ private proc chpl_enum_minbits(type t: enum) param {
 }
 // TODO - maybe this function can be useful for the user, for C interop?
 // If so, give it a different name.
-@chpldoc.nodoc
 proc chpl_enum_mintype(type t: enum) type {
   return uint(chpl_enum_minbits(t));
 }

--- a/test/chpldoc/nodoc/pragmaIgnoreChpl_.doc.catfiles
+++ b/test/chpldoc/nodoc/pragmaIgnoreChpl_.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/M.rst

--- a/test/chpldoc/nodoc/pragmaIgnoreChpl_.doc.chpl
+++ b/test/chpldoc/nodoc/pragmaIgnoreChpl_.doc.chpl
@@ -30,4 +30,17 @@ module M {
   proc chpl_proc(x: real) {
     writeln("chpl_proc(x: real)");
   }
+
+  /* this type is not documented by default*/
+  record chpl_someType {
+    var x: int;
+    var y: int;
+  }
+
+  /* this proc on chpl_someType is not documented by default */
+  proc chpl_someType.someProc() {
+    writeln("chpl_someType.someProc()");
+  }
+
+
 }

--- a/test/chpldoc/nodoc/pragmaIgnoreChpl_.doc.chpl
+++ b/test/chpldoc/nodoc/pragmaIgnoreChpl_.doc.chpl
@@ -1,0 +1,33 @@
+module M {
+
+  pragma "chpldoc ignore chpl prefix"
+  proc chpl_proc() {
+    // this chplproc is documented without a comment
+    writeln("chpl_proc");
+  }
+
+
+  /* this chpl_proc is documented with a comment*/
+  pragma "chpldoc ignore chpl prefix"
+  proc chpl_proc(msg: string) {
+    writeln("chpl_proc(msg: string)");
+  }
+
+  pragma "chpldoc ignore chpl prefix"
+  /* this chpl_proc is documented with a comment*/
+  proc chpl_proc(msgs : [] string) {
+    writeln("chpl_proc(msgs: [] string)");
+  }
+
+  /* this chpl_proc is not documented */
+  proc chpl_proc(x: int) {
+    writeln("chpl_proc(x: int)");
+  }
+
+  /* this chpl_proc is not documented */
+  pragma "chpldoc ignore chpl prefix"
+  @chpldoc.nodoc
+  proc chpl_proc(x: real) {
+    writeln("chpl_proc(x: real)");
+  }
+}

--- a/test/chpldoc/nodoc/pragmaIgnoreChpl_.doc.good
+++ b/test/chpldoc/nodoc/pragmaIgnoreChpl_.doc.good
@@ -1,0 +1,29 @@
+.. default-domain:: chpl
+
+.. module:: M
+
+M
+=
+**Usage**
+
+.. code-block:: chapel
+
+   use M;
+
+
+or
+
+.. code-block:: chapel
+
+   import M;
+
+.. function:: proc chpl_proc()
+
+.. function:: proc chpl_proc(msg: string)
+
+   this chpl_proc is documented with a comment
+
+.. function:: proc chpl_proc(msgs: [] string)
+
+   this chpl_proc is documented with a comment
+

--- a/test/deprecated/BigInteger/bigint_getlimbs.chpl
+++ b/test/deprecated/BigInteger/bigint_getlimbs.chpl
@@ -10,7 +10,7 @@ config const debug = false;
 var x:bigint;
 fac(x, 100);
 
-const n = x.numLimbs;
+const n = chpl_gmp_mpz_nlimbs(x.mpz);
 if debug then writeln("numLimbs is ", n);
 
 var checkn = mpz_size(x.mpz);
@@ -18,7 +18,7 @@ assert(n == checkn);
 
 var A:[0..#n] uint;
 for i in 0..#n {
-  var limb = x.get_limbn(i:uint);
+  var limb = chpl_gmp_mpz_getlimbn(x.mpz, i:uint);
   if debug then writeln("limb ", i, " is ", limb);
   A[i] = limb;
 }
@@ -30,12 +30,12 @@ var C:[0..#n] uint;
 
 on Locales[numLocales-1] {
   // Check getting size from other locale
-  var checkn = x.numLimbs;
+  var checkn = chpl_gmp_mpz_nlimbs(x.mpz);
   assert(n == checkn);
 
   // Read each limb from the other locale
   for i in 0..#n {
-    var limb = x.get_limbn(i:uint);
+    var limb = chpl_gmp_mpz_getlimbn(x.mpz, i:uint);
     if debug then writeln("limb ", i, " is ", limb);
     B[i] = limb;
   }
@@ -44,14 +44,14 @@ on Locales[numLocales-1] {
 on Locales[numLocales-1] {
   // Copy the entire number to the current locale.
   var local_x = x;
-  
+
   // Check getting size from copy
-  var checkn = local_x.numLimbs;
+  var checkn = chpl_gmp_mpz_nlimbs(local_x.mpz);
   assert(n == checkn);
 
   // Read each limb from the local copy
   for i in 0..#n {
-    var limb = local_x.get_limbn(i:uint);
+    var limb = chpl_gmp_mpz_getlimbn(local_x.mpz, i:uint);
     if debug then writeln("limb ", i, " is ", limb);
     C[i] = limb;
   }

--- a/test/deprecated/BigInteger/bigint_getlimbs.good
+++ b/test/deprecated/BigInteger/bigint_getlimbs.good
@@ -1,6 +1,0 @@
-bigint_getlimbs.chpl:13: warning: This method is deprecated, please use GMP.chpl_gmp_mpz_nlimbs on the mpz field instead
-bigint_getlimbs.chpl:21: warning: This method is deprecated, please use GMP.chpl_gmp_mpz_getlimbn on the mpz field instead
-bigint_getlimbs.chpl:33: warning: This method is deprecated, please use GMP.chpl_gmp_mpz_nlimbs on the mpz field instead
-bigint_getlimbs.chpl:38: warning: This method is deprecated, please use GMP.chpl_gmp_mpz_getlimbn on the mpz field instead
-bigint_getlimbs.chpl:49: warning: This method is deprecated, please use GMP.chpl_gmp_mpz_nlimbs on the mpz field instead
-bigint_getlimbs.chpl:54: warning: This method is deprecated, please use GMP.chpl_gmp_mpz_getlimbn on the mpz field instead

--- a/test/deprecated/Map/mapIterators.good
+++ b/test/deprecated/Map/mapIterators.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:392: In function '_getIterator':
-$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:393: warning: 'Map.these' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
+$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:391: In function '_getIterator':
+$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:392: warning: 'Map.these' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
   mapIterators.chpl:6: called as _getIterator(x: map(int(64),int(64),false))
 mapIterators.chpl:9: warning: 'Map.items' is deprecated. Consider 'Map.keys' to iterate over keys or 'Map.values' to iterate over values.
 0

--- a/test/trivial/diten/printvisibleOptFalse.good
+++ b/test/trivial/diten/printvisibleOptFalse.good
@@ -1,10 +1,10 @@
 printvisibleOptFalse.chpl:3: Printing symbols visible from here:
-  modules/minimal/internal/ChapelLocale.chpl:27: chpl_sublocID_t
-  modules/minimal/internal/ChapelLocale.chpl:35: chpl_localeModel_sublocToExecutionSubloc
-  modules/minimal/internal/ChapelLocale.chpl:41: chpl_localeModel_sublocMerge
-  modules/minimal/internal/ChapelLocale.chpl:53: chpl_taskRunningCntInc
-  modules/minimal/internal/ChapelLocale.chpl:58: chpl_taskRunningCntDec
-  modules/minimal/internal/ChapelLocale.chpl:62: chpl_taskRunningCntReset
+  modules/minimal/internal/ChapelLocale.chpl:26: chpl_sublocID_t
+  modules/minimal/internal/ChapelLocale.chpl:34: chpl_localeModel_sublocToExecutionSubloc
+  modules/minimal/internal/ChapelLocale.chpl:40: chpl_localeModel_sublocMerge
+  modules/minimal/internal/ChapelLocale.chpl:52: chpl_taskRunningCntInc
+  modules/minimal/internal/ChapelLocale.chpl:57: chpl_taskRunningCntDec
+  modules/minimal/internal/ChapelLocale.chpl:61: chpl_taskRunningCntReset
   modules/minimal/internal/ChapelTaskData.chpl:24: chpl_task_setCommDiagsTemporarilyDisabled
   modules/minimal/internal/ChapelTaskData.chpl:28: chpl_task_getCommDiagsTemporarilyDisabled
   modules/minimal/internal/ChapelTaskTable.chpl:26: chpldev_taskTable_init

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -295,11 +295,20 @@ static void checkKnownAttributes(const AttributeGroup* attrs) {
 }
 
 static bool isNoDoc(const Decl* e) {
-  if (auto attrs = parsing::astToAttributeGroup(gContext, e)) {
+  auto attrs = parsing::astToAttributeGroup(gContext, e);
+  if (attrs) {
     auto attr = attrs->getAttributeNamed(UniqueString::get(gContext,
                                                            "chpldoc.nodoc"));
     if (attr || attrs->hasPragma(pragmatags::PRAGMA_NO_DOC)) {
       return true;
+    }
+  }
+  if (auto namedDecl = e->toNamedDecl()) {
+    if (namedDecl->name().startsWith(UniqueString::get(gContext, "chpl_"))) {
+      // TODO: Remove this check and the pragma once we have an attribute that
+      // can be used to document chpl_ symbols or otherwise remove the
+      // chpl_ prefix from symbols in the GMP module we want documented
+      return !(attrs && attrs->hasPragma(PragmaTag::PRAGMA_CHPLDOC_IGNORE_CHPL_PREFIX));
     }
   }
   return false;

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -303,13 +303,12 @@ static bool isNoDoc(const Decl* e) {
       return true;
     }
   }
-  if (auto namedDecl = e->toNamedDecl()) {
-    if (namedDecl->name().startsWith(UniqueString::get(gContext, "chpl_"))) {
-      // TODO: Remove this check and the pragma once we have an attribute that
-      // can be used to document chpl_ symbols or otherwise remove the
-      // chpl_ prefix from symbols in the GMP module we want documented
-      return !(attrs && attrs->hasPragma(PragmaTag::PRAGMA_CHPLDOC_IGNORE_CHPL_PREFIX));
-    }
+  if (symbolNameBeginsWithChpl(e)) {
+    // TODO: Remove this check and the pragma once we have an attribute that
+    // can be used to document chpl_ symbols or otherwise remove the
+    // chpl_ prefix from symbols we want documented
+    return !(attrs &&
+             attrs->hasPragma(PragmaTag::PRAGMA_CHPLDOC_IGNORE_CHPL_PREFIX));
   }
   return false;
 }


### PR DESCRIPTION
This PR adds checking in `chpldoc` for items whose name begins with `chpl_` and treats them as being "no doc'd". This may suppress some items we mean to document, so a pragma is included which can override the behavior. The original request/backing issue is https://github.com/chapel-lang/chapel/issues/22081

The additional pragma (`pragma "chpldoc ignore chpl prefix"`) will instruct `chpldoc` to document the symbol even though it begins with `chpl_`. However, if an item with a name like `chpl_someProc` has the `@chpldoc.nodoc` attribute AND the `pragma "chpldoc ignore chpl prefix"`, we will respect the attribute `@chpldoc.nodoc` and ignore the pragma. 

This PR also removes two deprecated procedures from the `BigInteger` module: 
- `proc numLimbs : uint` 
- `proc get_limbn(n: integral) : uint`

Since this PR effectively makes the `@chpldoc.nodoc` attribute redundant on things with names that start with `chpl_`, it also removes that attribute from decls where it would be redundant.

TESTING:

- [x] paratest `[Summary: #Successes = 16433 | #Failures = 0 | #Futures = 909]`
- [x] gasnet paratest `[Summary: #Successes = 15086 | #Failures = 0 | #Futures = 917]`
- [x] diff .rst files in docs before and after change 

reviewed by @DanilaFe - thank you!

details of items removed from docs with this PR:
```
 https://chapel-lang.org/docs/main/language/spec/ranges.html#ChapelRange.range.chpl_slice
 doc-main/rst/builtins/ChapelRange.rst
	.. method:: proc range.chpl_slice(other: range(?), param forceNewRule: bool)
 
 https://chapel-lang.org/docs/main/modules/standard/BigInteger.html#BigInteger.bigint.numLimbs
 https://chapel-lang.org/docs/main/modules/standard/BigInteger.html#BigInteger.bigint.get_limbn
 doc-main/rst/modules/standard/BigInteger.rst
	.. method:: proc numLimbs: uint

      .. warning::

         This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_nlimbs` on the mpz field instead

   .. method:: proc get_limbn(n: integral): uint

      .. warning::

         This method is deprecated, please use :proc:`GMP.chpl_gmp_mpz_getlimbn` on the mpz field instead



https://chapel-lang.org/docs/main/modules/standard/ChapelIO.html#ChapelIO.chpl__isFileReader	
 doc-main/rst/modules/standard/ChapelIO.rst
	.. function:: proc chpl__isFileReader(type T) param: bool

```