### PR TITLE
Load LLVM 11 for Arkouda 1.30.0 release test on Raptor

### DIFF
--- a/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.cray-cs-hdr.arkouda.release.bash
@@ -18,6 +18,26 @@ source $CWD/common-cray-cs.bash
 export CHPL_LAUNCHER_PARTITION=rome64Share
 export CHPL_TARGET_CPU=none
 
+if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
+  # Note: Add more cases to the following 'if' whenever we need to test a
+  # release that does not support our latest available LLVM. Cases can be
+  # removed when we no longer care about testing against that release.
+  if [ "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" = "1.30.0" ]; then
+    # use LLVM 11, latest install on /cy/users before 15, which would be too
+    # new for Chapel 1.30.0
+    if [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
+      source /cy/users/chapelu/setup_system_llvm.bash 11
+    fi
+  else
+    # Default to using latest LLVM.
+    # (Shouldn't need to set it here, we are already able to access default LLVM)
+    :
+  fi
+else
+  echo "CHPL_WHICH_RELEASE_FOR_ARKOUDA not set, cannot run Arkouda release test!"
+  exit 1
+fi
+
 module list
 
 export GASNET_PHYSMEM_MAX="9/10"


### PR DESCRIPTION
Arkouda release tests on `raptor` are using the latest LLVM version, 15, which Chapel 1.30.0 does not support. This change makes the test use LLVM 11 (the latest installed LLVM before 15) for that release. Similar to what #22416 did for `chapcs`.

Note this can't be handled in `common-arkouda.bash` as it has to be loaded after `common-cray-cs.bash` purges and re-loads base deps.

[trivial, not reviewed]

Testing
- [x] `test-perf.cray-cs-hdr.arkouda.release.bash` no longer errors loading LLVM