### PR TITLE
Remove some deprecated symbols from the Locale module

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -149,11 +149,6 @@ module ChapelLocale {
       return this._value._getChildCount();
     }
 
-    @deprecated(notes="'locale.getChildCount' is deprecated")
-    inline proc getChildCount() {
-      return this._value.getChildCount();
-    }
-
   } // end of record _locale
 
 
@@ -271,15 +266,6 @@ module ChapelLocale {
   }
 
   /*
-    ``callStackSize`` holds the size of a task stack on a given
-    locale.  Thus, ``here.callStackSize`` is the size of the call
-    stack for any task on the current locale, including the
-    caller.
-  */
-  @deprecated(notes="'locale.callStackSize' is deprecated.")
-  inline proc locale.callStackSize { return this._value.callStackSize; }
-
-  /*
     Get the number of tasks running on this locale.
 
     This method is intended to guide task creation during a parallel
@@ -338,8 +324,6 @@ module ChapelLocale {
              else if accessible then nPUsPhysAcc else nPUsPhysAll;
 
     var maxTaskPar: int;
-
-    var callStackSize: c_size_t;
 
     proc id : int do return chpl_nodeFromLocaleID(__primitive("_wide_get_locale", this));
 
@@ -439,13 +423,6 @@ module ChapelLocale {
       return 0;
     }
 
-    @chpldoc.nodoc
-    @deprecated(notes="'locale.getChildCount' is deprecated")
-    proc getChildCount() : int {
-      HaltWrappers.pureVirtualMethodHalt();
-      return 0;
-    }
-
 // Part of the required locale interface.
 // Commented out because presently iterators are statically bound.
 //    iter getChildIndices() : int {
@@ -461,12 +438,6 @@ module ChapelLocale {
 
     @chpldoc.nodoc
     proc _getChild(idx:int) : locale {
-      HaltWrappers.pureVirtualMethodHalt();
-    }
-
-    @chpldoc.nodoc
-    @deprecated(notes="'locale.getChild' is deprecated")
-    proc getChild(idx:int) : locale {
       HaltWrappers.pureVirtualMethodHalt();
     }
 
@@ -517,13 +488,7 @@ module ChapelLocale {
     override proc _getChildCount() : int {
       return 0;
     }
-    override proc getChildCount() : int {
-      return 0;
-    }
     override proc _getChild(idx:int) : locale {
-      return new locale(this);
-    }
-    override proc getChild(idx:int) : locale {
       return new locale(this);
     }
     override proc addChild(loc:locale)

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -158,9 +158,6 @@ module LocaleModelHelpSetup {
   proc helpSetupLocaleFlat(dst:borrowed LocaleModel, out local_name:string) {
     local_name = getNodeName();
 
-    extern proc chpl_task_getCallStackSize(): c_size_t;
-    dst.callStackSize = chpl_task_getCallStackSize();
-
     extern proc chpl_topo_getNumCPUsPhysical(accessible_only: bool): c_int;
     dst.nPUsPhysAcc = chpl_topo_getNumCPUsPhysical(true);
     dst.nPUsPhysAll = chpl_topo_getNumCPUsPhysical(false);

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -76,7 +76,6 @@ module LocaleModel {
       f.write('.'+name);
     }
 
-    override proc getChildCount(): int { return 0; }
     override proc _getChildCount(): int { return 0; }
 
     iter getChildIndices() : int {
@@ -85,10 +84,6 @@ module LocaleModel {
     }
     proc addChild(loc:locale) {
       halt("Cannot add children to this locale type.");
-    }
-    override proc getChild(idx:int) : locale {
-      halt("requesting a child from a CPULocale locale");
-      return new locale(this);
     }
     override proc _getChild(idx:int) : locale {
       halt("requesting a child from a CPULocale locale");
@@ -129,7 +124,6 @@ module LocaleModel {
       f.write('.'+name);
     }
 
-    override proc getChildCount(): int { return 0; }
     override proc _getChildCount(): int { return 0; }
     iter getChildIndices() : int {
       halt("No children to iterate over.");
@@ -137,10 +131,6 @@ module LocaleModel {
     }
     proc addChild(loc:locale) {
       halt("Cannot add children to this locale type.");
-    }
-    override proc getChild(idx:int) : locale {
-      halt("requesting a child from a GPULocale locale");
-      return new locale(this);
     }
     override proc _getChild(idx:int) : locale {
       halt("requesting a child from a GPULocale locale");
@@ -202,7 +192,6 @@ module LocaleModel {
       return {0..#numSublocales};
     }
 
-    override proc getChildCount() return 0;
     override proc _getChildCount() return 0;
 
     iter getChildIndices() : int {
@@ -210,12 +199,6 @@ module LocaleModel {
         yield idx;
     }
 
-    override proc getChild(idx:int) : locale {
-      if idx == 1
-        then return new locale(GPU!);
-      else
-        return new locale(CPU!);
-    }
     override proc _getChild(idx:int) : locale {
       if idx == 1
         then return new locale(GPU!);
@@ -300,7 +283,6 @@ module LocaleModel {
       f.write(name);
     }
 
-    override proc getChildCount() return this.myLocaleSpace.size;
     override proc _getChildCount() return this.myLocaleSpace.size;
 
     proc getChildSpace() return this.myLocaleSpace;
@@ -310,7 +292,6 @@ module LocaleModel {
         yield idx;
     }
 
-    override proc getChild(idx:int) return this.myLocales[idx];
     override proc _getChild(idx:int) return this.myLocales[idx];
 
     iter getChildren() : locale  {

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -102,19 +102,11 @@ module LocaleModel {
 
     proc getChildSpace() do return chpl_emptyLocaleSpace;
 
-    override proc getChildCount() do return 0;
     override proc _getChildCount() do return 0;
 
     iter getChildIndices() : int {
       for idx in chpl_emptyLocaleSpace do
         yield idx;
-    }
-
-    pragma "unsafe"
-    override proc getChild(idx:int) : locale {
-      halt("requesting a child from a flat LocaleModel locale");
-      var tmp:locale; // nil
-      return tmp;
     }
 
     pragma "unsafe"
@@ -186,7 +178,6 @@ module LocaleModel {
       f.write(name);
     }
 
-    override proc getChildCount() do return this.myLocaleSpace.size;
     override proc _getChildCount() do return this.myLocaleSpace.size;
 
     proc getChildSpace() do return this.myLocaleSpace;
@@ -196,7 +187,6 @@ module LocaleModel {
         yield idx;
     }
 
-    override proc getChild(idx:int) do return this.myLocales[idx];
     override proc _getChild(idx:int) do return this.myLocales[idx];
 
     iter getChildren() : locale  {

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -244,7 +244,6 @@ module LocaleModel {
       f.write("-GPU" + sid:string);
     }
 
-    override proc getChildCount(): int { return 0; }
     override proc _getChildCount(): int { return 0; }
 
     iter getChildIndices() : int {
@@ -253,10 +252,6 @@ module LocaleModel {
     }
     proc addChild(loc:locale) {
       halt("Cannot add children to this locale type.");
-    }
-    override proc getChild(idx:int) : locale {
-      halt("requesting a child from a GPULocale locale");
-      return new locale(this);
     }
     override proc _getChild(idx:int) : locale {
       halt("requesting a child from a GPULocale locale");
@@ -334,7 +329,6 @@ module LocaleModel {
 
     proc getChildSpace() do return childSpace;
 
-    override proc getChildCount() do return numSublocales;
     override proc _getChildCount() do return numSublocales;
 
     iter getChildIndices() : int {
@@ -342,12 +336,6 @@ module LocaleModel {
         yield idx;
     }
 
-    override proc getChild(idx:int) : locale {
-      if boundsChecking then
-        if (idx < 0) || (idx >= numSublocales) then
-          halt("sublocale child index out of bounds (",idx,")");
-      return new locale(childLocales[idx]);
-    }
     override proc _getChild(idx:int) : locale {
       if boundsChecking then
         if (idx < 0) || (idx >= numSublocales) then
@@ -422,7 +410,6 @@ module LocaleModel {
       f.write(name);
     }
 
-    override proc getChildCount() do return this.myLocaleSpace.size;
     override proc _getChildCount() do return this.myLocaleSpace.size;
 
     proc getChildSpace() do return this.myLocaleSpace;
@@ -432,7 +419,6 @@ module LocaleModel {
         yield idx;
     }
 
-    override proc getChild(idx:int) do return this.myLocales[idx];
     override proc _getChild(idx:int) do return this.myLocales[idx];
 
     iter getChildren() : locale  {

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -86,11 +86,6 @@ module LocaleModel {
       f.write('.'+ndName);
     }
 
-    override proc getChildCount(): int { return 0; }
-    iter getChildIndices() : int {
-      halt("No children to iterate over.");
-      yield -1;
-    }
     override proc _getChildCount(): int { return 0; }
     iter getChildIndices() : int {
       halt("No children to iterate over.");
@@ -101,12 +96,6 @@ module LocaleModel {
       halt("Cannot add children to this locale type.");
     }
 
-    pragma "unsafe"
-    override proc getChild(idx:int) : locale {
-      halt("Cannot getChild with this locale type");
-      var ret: locale; // default-initialize
-      return ret;
-    }
     pragma "unsafe"
     override proc _getChild(idx:int) : locale {
       halt("Cannot getChild with this locale type");
@@ -188,7 +177,6 @@ module LocaleModel {
 
     proc getChildSpace() return childSpace;
 
-    override proc getChildCount() return numSublocales;
     override proc _getChildCount() return numSublocales;
 
     iter getChildIndices() : int {
@@ -196,12 +184,6 @@ module LocaleModel {
         yield idx;
     }
 
-    override proc getChild(idx:int) : locale {
-      if boundsChecking then
-        if (idx < 0) || (idx >= numSublocales) then
-          halt("sublocale child index out of bounds (",idx,")");
-      return new locale(childLocales[idx]);
-    }
     override proc _getChild(idx:int) : locale {
       if boundsChecking then
         if (idx < 0) || (idx >= numSublocales) then
@@ -276,7 +258,6 @@ module LocaleModel {
       f.write(name);
     }
 
-    override proc getChildCount() return this.myLocaleSpace.size;
     override proc _getChildCount() return this.myLocaleSpace.size;
 
     proc getChildSpace() return this.myLocaleSpace;
@@ -286,7 +267,6 @@ module LocaleModel {
         yield idx;
     }
 
-    override proc getChild(idx:int) return this.myLocales[idx];
     override proc _getChild(idx:int) return this.myLocales[idx];
 
     iter getChildren() : locale  {

--- a/test/deprecated/locale-callStackSize.chpl
+++ b/test/deprecated/locale-callStackSize.chpl
@@ -1,1 +1,0 @@
-var css = here.callStackSize;

--- a/test/deprecated/locale-callStackSize.good
+++ b/test/deprecated/locale-callStackSize.good
@@ -1,1 +1,0 @@
-locale-callStackSize.chpl:1: warning: 'locale.callStackSize' is deprecated.

--- a/test/deprecated/localeGetChild.chpl
+++ b/test/deprecated/localeGetChild.chpl
@@ -1,1 +1,0 @@
-const cl = here.getChild(0);

--- a/test/deprecated/localeGetChild.good
+++ b/test/deprecated/localeGetChild.good
@@ -1,2 +1,0 @@
-localeGetChild.chpl:1: warning: 'locale.getChild' is deprecated
-localeGetChild.chpl:1: error: halt reached - requesting a child from a flat LocaleModel locale

--- a/test/deprecated/localeGetChild.skipif
+++ b/test/deprecated/localeGetChild.skipif
@@ -1,1 +1,0 @@
-CHPL_LOCALE_MODEL != flat

--- a/test/deprecated/localeGetChildCount.chpl
+++ b/test/deprecated/localeGetChildCount.chpl
@@ -1,1 +1,0 @@
-const clc = here.getChildCount();

--- a/test/deprecated/localeGetChildCount.good
+++ b/test/deprecated/localeGetChildCount.good
@@ -1,1 +1,0 @@
-localeGetChildCount.chpl:1: warning: 'locale.getChildCount' is deprecated

--- a/test/deprecated/localeGetChildCount.skipif
+++ b/test/deprecated/localeGetChildCount.skipif
@@ -1,1 +1,0 @@
-CHPL_LOCALE_MODEL != flat


### PR DESCRIPTION
Removes the following symbols which have been deprecated for over two releases:
- `locale.callStackSize`: deprecated in https://github.com/chapel-lang/chapel/pull/20317
- `locale.getChild()`: deprecated in https://github.com/chapel-lang/chapel/pull/20428
- `locale.getChildCount()`: deprecated in https://github.com/chapel-lang/chapel/pull/20428

Testing:
- [x] inspect Locale docs
- [x] paratest
- [x] gasnet paratest