### PR TITLE
Stop generating llvm.lifetime.start / llvm.lifetime.end

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -263,13 +263,9 @@ llvm::AllocaInst* createVarLLVM(llvm::Type* type, const char* name)
 {
   GenInfo* info = gGenInfo;
   llvm::IRBuilder<>* irBuilder = info->irBuilder;
-  const llvm::DataLayout& layout = info->module->getDataLayout();
-  llvm::LLVMContext &ctx = info->llvmContext;
   llvm::AllocaInst* val = NULL;
 
-  val = makeAllocaAndLifetimeStart(irBuilder, layout, ctx, type, name);
-  info->currentStackVariables.push_back(
-      std::pair<llvm::AllocaInst*, llvm::Type*>(val, type));
+  val = createAllocaInFunctionEntry(irBuilder, type, name);
 
   return val;
 }

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2511,8 +2511,6 @@ void FnSymbol::codegenDef() {
 
     llvm::IRBuilder<>* irBuilder = info->irBuilder;
     const llvm::DataLayout& layout = info->module->getDataLayout();
-    llvm::LLVMContext &ctx = info->llvmContext;
-
     unsigned int stackSpace = layout.getAllocaAddrSpace();
 
     func = getFunctionLLVM(cname);
@@ -2695,8 +2693,7 @@ void FnSymbol::codegenDef() {
             if (srcSize <= dstSize) {
               storeAdr = irBuilder->CreatePointerCast(ptr, coercePtrTy);
             } else {
-              storeAdr = makeAllocaAndLifetimeStart(irBuilder, layout, ctx,
-                                                    sTy, "coerce");
+              storeAdr = createAllocaInFunctionEntry(irBuilder, sTy, "coerce");
             }
 
             unsigned nElts = sTy->getNumElements();

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -103,22 +103,22 @@ public:
 
 #ifdef HAVE_LLVM
   // one of the following is set when generating LLVM
-  llvm::Value *val; // use val->getType() to obtain LLVM type
-  llvm::Type *type; // set when generating a type only
-  Type *surroundingStruct; // surrounding structure, if this is a field
-  uint64_t fieldOffset; // byte offset of this field within struct
-  llvm::MDNode *fieldTbaaTypeDescriptor;
-  llvm::MDNode *aliasScope;
-  llvm::MDNode *noalias;
+  llvm::Value *val=nullptr; // use val->getType() to obtain LLVM type
+  llvm::Type *type=nullptr; // set when generating a type only
+  Type *surroundingStruct=nullptr; // surrounding structure, if this is a field
+  uint64_t fieldOffset=0; // byte offset of this field within struct
+  llvm::MDNode *fieldTbaaTypeDescriptor=nullptr;
+  llvm::MDNode *aliasScope=nullptr;
+  llvm::MDNode *noalias=nullptr;
 #else
   // Keeping same layout for non-LLVM builds
-  void* val;
-  void* type;
-  void* surroundingStruct;
-  uint64_t fieldOffset;
-  void* fieldTbaaTypeDescriptor;
-  void* aliasScope;
-  void* noalias;
+  void* val=nullptr;
+  void* type=nullptr;
+  void* surroundingStruct=nullptr;
+  uint64_t fieldOffset=0;
+  void* fieldTbaaTypeDescriptor=nullptr;
+  void* aliasScope=nullptr;
+  void* noalias=nullptr;
 #endif
 
   // Used for generating LLVM parallel_loop_accesses metadata.
@@ -126,15 +126,16 @@ public:
   // for this, so this variable tracks if a pointer must point to something
   // other than a local variable (e.g. an array element, a class field);
   // or if it points to a value from outside any order independent loop.
-  bool mustPointOutsideOrderIndependentLoop;
+  bool mustPointOutsideOrderIndependentLoop = false;
 
   // always set if available
   // note that the chplType of a GenRet corresponds to the Chapel
   // type of the result of codegenValue on it - that is, chplType
   // corresponds to the case when isLVPtr == GEN_VAL, and does not change
   // if isLVPtr is GEN_PTR or GEN_WIDE_PTR.
-  Type *chplType;
-  uint8_t isLVPtr; // for some L-value expression, we set isLVPtr
+  Type *chplType = nullptr;
+  uint8_t isLVPtr = GEN_VAL;
+                   // for some L-value expression, we set isLVPtr
                    // if the generated expression is a possible lvalue
                    // If isLVPtr is set, the expression is the address
                    // of the e.g. variable we are referring to.
@@ -143,17 +144,13 @@ public:
                    //  isLVPtr = GEN_WIDE_PTR > 0. If it's a local pointer,
                    //  isLVPtr = GEN_PTR > 0.
 
-  bool isUnsigned; // Is this expression unsigned?
-                   // Needed for LLVM code generation in order to
-                   // properly coerce call arguments into the correct
-                   // called type, since LLVM native integer types do not
-                   // include signed-ness.
+  bool isUnsigned = false; // Is this expression unsigned?
+                           // Needed for LLVM code generation in order to
+                           // properly coerce call arguments into the correct
+                           // called type, since LLVM native integer types do
+                           // not include signed-ness.
 
-  GenRet() : c(), val(NULL), type(NULL), surroundingStruct(NULL),
-             fieldOffset(0), fieldTbaaTypeDescriptor(NULL),
-             aliasScope(NULL), noalias(NULL),
-             mustPointOutsideOrderIndependentLoop(false),
-             chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
+  GenRet() { }
 
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -41,9 +41,11 @@ struct PromotedPair {
 bool isArrayVecOrStruct(llvm::Type* t);
 
 // 0 means undefined alignment
+// creates an alloca instruction and inserts it before insertBefore
 llvm::AllocaInst* makeAlloca(llvm::Type* type, const char* name, llvm::Instruction* insertBefore, unsigned n=1, unsigned align=0);
 
-llvm::AllocaInst* createLLVMAlloca(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name);
+// creates an alloca instruction at the top of the function
+llvm::AllocaInst* createAllocaInFunctionEntry(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name);
 
 PromotedPair convertValuesToLarger(llvm::IRBuilder<> *irBuilder, llvm::Value *value1, llvm::Value *value2, bool isSigned1 = false, bool isSigned2 = false);
 llvm::Value *convertValueToType(llvm::IRBuilder<>* irBuilder,
@@ -57,12 +59,6 @@ void makeLifetimeStart(llvm::IRBuilder<>* irBuilder,
                        const llvm::DataLayout& layout,
                        llvm::LLVMContext &ctx,
                        llvm::Type *valType, llvm::Value *addr);
-
-// Returns an alloca
-llvm::AllocaInst* makeAllocaAndLifetimeStart(llvm::IRBuilder<>* irBuilder,
-                                        const llvm::DataLayout& layout,
-                                        llvm::LLVMContext &ctx,
-                                        llvm::Type* type, const char* name);
 
 int64_t getTypeSizeInBytes(const llvm::DataLayout& layout, llvm::Type* ty);
 bool isTypeSizeSmallerThan(const llvm::DataLayout& layout, llvm::Type* ty, uint64_t max_size_bytes);

--- a/test/llvm/with-opaque-ptrs/lifetime-intrinsics/NOTEST
+++ b/test/llvm/with-opaque-ptrs/lifetime-intrinsics/NOTEST
@@ -1,0 +1,1 @@
+Skipping for now since llvm.lifetime.start is currently disabled.

--- a/test/llvm/with-typed-ptrs/lifetime-intrinsics/NOTEST
+++ b/test/llvm/with-typed-ptrs/lifetime-intrinsics/NOTEST
@@ -1,0 +1,1 @@
+Skipping for now since llvm.lifetime.start is currently disabled.


### PR DESCRIPTION
This is sortof continuing PR #22439 which removed the generation of llvm.invariant.start (while llvm.invariant.end was not generated, leading to bugs). This PR entirely removes the llvm.lifetime.start / llvm.lifetime.end as well because I don't think that what we are doing today adds any value beyond what can be assumed of a function local variable (namely: the variable lifetime starts at the `alloca` and ends when the function returns).

I spent a while trying to get llvm.lifetime.start / llvm.invariant.start to work the way I think would be ideal, but that was more challenging than I anticipated. I observed several issues:
 * control flow is hard to analyze at code generation time (where do llvm.lifetime.end hints belong?). In particular for llvm.invariant.start / llvm.invariant.end, the start instruction must dominate the end instruction.
 * I looked at updating callDestructors to add primitives to indicate lifetime end & invariant start/end, but that seems to add a lot of noise to the AST and transformations can add variables & make variables `const` that were not before
 * llvm.invariant.start / llvm.invariant.end aren't very well documented. In particular, it's not clear what happens if the function returns when llvm.invariant.start is called but llvm.invariant.end is not.
 * my draft work did not restore the performance regression caused by PR #22439 in the one test that we observed it in (List Operations PopFront).
 
My abandoned work is here: https://github.com/chapel-lang/chapel/compare/main...mppf:chapel:llvm-lifetime-invariant

Reviewed by @ronawho - thanks!

- [x] full comm=none testing
- [x] full comm=none `--fast` testing
- [x] performance playground testing -- see https://chapel-lang.org/perf/chapcs/remove-llvm-lifetime/ -- no concerning performance differences