### PR TITLE
Fix `init_ofiReserveCores` declaration

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2067,7 +2067,7 @@ void init_ofiFabricDomain(void) {
 // Reserve cores for the AM handler(s).
 //
 static
-void init_ofiReserveCores() {
+void init_ofiReserveCores(void) {
   for (int i = 0; i < numAmHandlers; i++) {
     reservedCPUs[i] = envUseDedicatedAmhCores ?
       chpl_topo_reserveCPUPhysical() : -1;


### PR DESCRIPTION
Change `init_ofiReserveCores()` to `init_ofiReserveCores(void)` to match the prototype. Caught by clang 15 upgrade, but was always incorrect.