### PR TITLE
Make c_ptrTo on class types return c_void_ptr

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -944,18 +944,17 @@ module CTypes {
   }
 
   /*
-   Like :proc:`c_ptrTo` for class types, but returns a :type:`c_ptrConst`
-   which disallows direct modification of the pointee.
+   Like :proc:`c_ptrTo` for class types, but also accepts ``const`` data.
    */
-  inline proc c_ptrToConst(const ref c: class): c_ptrConst(c.type)
+  inline proc c_ptrToConst(const ref c: class): c_void_ptr
     where cPtrToLogicalValue == true
   {
-    return c : c_void_ptr : c_ptrConst(c.type);
+    return c : c_void_ptr;
   }
-  inline proc c_ptrToConst(const ref c: class?): c_ptrConst(c.type)
+  inline proc c_ptrToConst(const ref c: class?): c_void_ptr
     where cPtrToLogicalValue == true
   {
-    return c : c_void_ptr : c_ptrConst(c.type);
+    return c : c_void_ptr;
   }
 
   @deprecated(notes="The c_ptrToConst(class) overload that returns a pointer to the class representation on the stack is deprecated. Default behavior will soon change to return a pointer to the heap instance. Please use 'c_addrOfConst' instead, or recompile with '-s cPtrToLogicalValue=true' to opt-in to the new behavior.")

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -913,21 +913,21 @@ module CTypes {
   }
 
   /*
-    Returns a :type:`c_ptr` to the heap instance of a class type.
+    Returns a :type:`c_void_ptr` to the heap instance of a class type.
 
-    Note that the existence of this ``c_ptr`` has no impact on the lifetime of
-    the instance.  The returned pointer will be invalid if the instance is
+    Note that the existence of this ``c_void_ptr`` has no impact on the lifetime
+    of the instance.  The returned pointer will be invalid if the instance is
     freed or even reallocated.
   */
-  inline proc c_ptrTo(ref c: class): c_ptr(c.type)
+  inline proc c_ptrTo(ref c: class): c_void_ptr
     where cPtrToLogicalValue == true
   {
-    return c : c_void_ptr : c_ptr(c.type);
+    return c : c_void_ptr;
   }
-  inline proc c_ptrTo(ref c: class?): c_ptr(c.type)
+  inline proc c_ptrTo(ref c: class?): c_void_ptr
     where cPtrToLogicalValue == true
   {
-    return c : c_void_ptr : c_ptr(c.type);
+    return c : c_void_ptr;
   }
 
   @deprecated(notes="The c_ptrTo(class) overload that returns a pointer to the class representation on the stack is deprecated. Default behavior will soon change to return a pointer to the heap instance. Please use 'c_addrOf' instead, or recompile with '-s cPtrToLogicalValue=true' to opt-in to the new behavior.")


### PR DESCRIPTION
Changes return type of `c_ptrTo` on a class type from `c_ptr(classType)` to `c_void_ptr`, and similarly for `c_ptrToConst`. This is more in line with the old behavior of casting a class type to `c_void_ptr`, allowing a user to take a class instance from Chapel->C->Chapel.

Follow up to #22367.

See #22478 for discussion of this change.

[reviewer info]

Testing:
- [x] paratest
- [x] gasnet paratest