### PR TITLE
Fix use of SysBasic and c_alloc/c_free in allocators technote

### DIFF
--- a/doc/rst/technotes/allocators.rst
+++ b/doc/rst/technotes/allocators.rst
@@ -109,21 +109,20 @@ allocation functions:
     }
   }
 
-  // SysBasic provides c_calloc and c_free to call the Chapel allocator
+  // CTypes provides allocate and deallocate to call the Chapel allocator
   // directly for C interoperability purposes
-  use SysBasic;
+  use CTypes;
 
   // Allocate using the system allocator (malloc)
   var x = mymalloc();
 
   writeln(x.deref());
 
-  // Free using the Chapel allocator - c_free calls the Chapel free function
-  // directly. It's named c_free because it's meant to be used for C
-  // interoperability purposes.
+  // Free using the Chapel allocator - deallocate calls the Chapel free function
+  // directly.
   // This will generally cause a core dump unless:
   //   * you have configured Chapel to use the system allocator, or
   //   * you link this program with -lchplmalloc
-  c_free(x);
+  deallocate(x);
 
 


### PR DESCRIPTION
This PR makes a small update to the `allocators.rst` technote (titled "Using the Chapel Allocator from C"), which was referring to `c_alloc` and `c_free` in `SysBasic`. These functions have long since been moved to `CTypes` and replaced with `allocate` and `deallocate` respectively.

[trivial, not reviewed]