### PR TITLE
Remove domain.makeIndexBuffer and IO.unicodeSupported

### DIFF
--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1941,9 +1941,6 @@ module ChapelDomain {
       return _value.dsiBulkAdd(inds, dataSorted, isUnique, preserveInds, addOn);
     }
 
-    @deprecated(notes="makeIndexBuffer has been renamed to createIndexBuffer")
-    inline proc makeIndexBuffer(size: int) { return createIndexBuffer(size); }
-
     /*
      Creates an index buffer which can be used for faster index addition.
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8943,14 +8943,6 @@ proc readln(type t ...?numTypes) throws {
   return stdin.readln((...t));
 }
 
-/*
-   :returns: `true` if this version of the Chapel runtime supports UTF-8 output.
- */
-@deprecated(notes="unicodeSupported is deprecated due to always returning true")
-proc unicodeSupported():bool {
-  return true;
-}
-
 
 /************** Distributed File Systems ***************/
 

--- a/test/deprecated/IO/unicodeSupported.chpl
+++ b/test/deprecated/IO/unicodeSupported.chpl
@@ -1,3 +1,0 @@
-use IO only unicodeSupported;
-
-writeln(unicodeSupported());

--- a/test/deprecated/IO/unicodeSupported.good
+++ b/test/deprecated/IO/unicodeSupported.good
@@ -1,3 +1,0 @@
-unicodeSupported.chpl:1: warning: unicodeSupported is deprecated due to always returning true
-unicodeSupported.chpl:3: warning: unicodeSupported is deprecated due to always returning true
-true

--- a/test/deprecated/domains/makeIndexBuffer.chpl
+++ b/test/deprecated/domains/makeIndexBuffer.chpl
@@ -1,4 +1,0 @@
-param N : int = 3;
-var parentDom : domain(N);
-var spsDom: sparse subdomain(parentDom);
-var idxBuf = spsDom.makeIndexBuffer(size=N);

--- a/test/deprecated/domains/makeIndexBuffer.good
+++ b/test/deprecated/domains/makeIndexBuffer.good
@@ -1,1 +1,0 @@
-makeIndexBuffer.chpl:4: warning: makeIndexBuffer has been renamed to createIndexBuffer


### PR DESCRIPTION
This PR removes two symbols deprecated in the 1.29 release for the 1.31 release:
- `domain.makeIndexBuffer` (deprecated and renamed to `domain.createIndexBuffer` in #21085)
- `IO.unicodeSupported` (deprecated in #21086)

[trivial, not reviewed]

Testing:
- [x] paratest