### PR TITLE
Flag to report GPU eligible and ineligible loops (--report-gpu flag). Also avoid duplicate output by flushing stdout before forking compiler.

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -102,6 +102,12 @@ void collectForallStmts(BaseAST* ast, std::vector<ForallStmt*>& forallStmts) {
     forallStmts.push_back(forall);
 }
 
+void collectCForLoopStmts(BaseAST* ast, std::vector<CForLoop*>& cforloopStmts) {
+  AST_CHILDREN_CALL(ast, collectCForLoopStmts, cforloopStmts);
+  if (CForLoop* cforloop = toCForLoop(ast))
+    cforloopStmts.push_back(cforloop);
+}
+
 void collectCallExprs(BaseAST* ast, std::vector<CallExpr*>& callExprs) {
   AST_CHILDREN_CALL(ast, collectCallExprs, callExprs);
   if (CallExpr* callExpr = toCallExpr(ast))

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2703,8 +2703,6 @@ static void codegenPartTwo() {
   {
     fprintf(stderr, "Statements emitted: %d\n", gStmtCount);
   }
-
-
 }
 
 void codegen() {
@@ -2718,6 +2716,9 @@ void codegen() {
     // We need to generate the name for the temp directory before we do the fork (since this
     // name uses the PID).
     ensureTmpDirExists();
+    
+    // flush stdout before forking process so buffered output doesn't get copied over
+    fflush(stdout);
 
     pid_t pid = fork();
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2716,7 +2716,7 @@ void codegen() {
     // We need to generate the name for the temp directory before we do the fork (since this
     // name uses the PID).
     ensureTmpDirExists();
-    
+
     // flush stdout before forking process so buffered output doesn't get copied over
     fflush(stdout);
 

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -70,6 +70,7 @@ void collect_stmts(BaseAST* ast, std::vector<Expr*>& stmts);
 void collectDefExprs(BaseAST* ast, std::vector<DefExpr*>& defExprs);
 void collectDefExprs(BaseAST* ast, llvm::SmallVectorImpl<DefExpr*>& defExprs);
 void collectForallStmts(BaseAST* ast, std::vector<ForallStmt*>& forallStmts);
+void collectCForLoopStmts(BaseAST* ast, std::vector<CForLoop*>& cforloopStmts);
 void collectCallExprs(BaseAST* ast, std::vector<CallExpr*>& callExprs);
 void collectMyCallExprs(BaseAST* ast,
                         std::vector<CallExpr*>& callExprs,

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -242,6 +242,7 @@ extern bool fReportVectorizedLoops;
 extern bool fReportOptimizedOn;
 extern bool fReportPromotion;
 extern bool fReportScalarReplace;
+extern bool fReportGpu;
 extern bool fReportDeadBlocks;
 extern bool fReportDeadModules;
 extern bool fReportGpuTransformTime;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -279,6 +279,7 @@ bool fReportOptimizedOn = false;
 bool fReportOptimizeForallUnordered = false;
 bool fReportPromotion = false;
 bool fReportScalarReplace = false;
+bool fReportGpu = false;
 bool fReportDeadBlocks = false;
 bool fReportDeadModules = false;
 bool fReportGpuTransformTime = false;
@@ -1233,6 +1234,7 @@ static ArgumentDescription arg_desc[] = {
  {"report-optimized-forall-unordered-ops", ' ', NULL, "Show which statements in foralls have been converted to unordered operations", "F", &fReportOptimizeForallUnordered, NULL, NULL},
  {"report-promotion", ' ', NULL, "Print information about scalar promotion", "F", &fReportPromotion, NULL, NULL},
  {"report-scalar-replace", ' ', NULL, "Print scalar replacement stats", "F", &fReportScalarReplace, NULL, NULL},
+ {"report-gpu", ' ', NULL, "Print information about what loops are and are not GPU eligible", "F", &fReportGpu, NULL, NULL},
 
  {"", ' ', NULL, "Developer Flags -- Miscellaneous", NULL, NULL, NULL, NULL},
  {"allow-noinit-array-not-pod", ' ', NULL, "Allow noinit for arrays of records", "N", &fAllowNoinitArrayNotPod, "CHPL_BREAK_ON_CODEGEN", NULL},

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1019,7 +1019,7 @@ static void logGpuizableLoops() {
   printf("\n");
 
   printf("GPU ELIGIBLE LOOPS:\n");
-  printf("------------------\n");
+  printf("-------------------\n");
   for (const auto& loop : eligibleLoops) {
     printf("%s\n", loop->stringLoc());
   }

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -224,7 +224,7 @@ GpuizableLoop::GpuizableLoop(BlockStmt *blk) {
   }
 }
 
-// Given --report-gpu we don't want to report on all 'for' loops just those
+// Given --report-gpu we don't want to report on all 'for' loops, just those
 // that are from forall/foreach that aren't already within GPU kernels
 bool GpuizableLoop::isReportWorthy() {
   CForLoop *cfl = this->loop_;

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -242,7 +242,7 @@ bool GpuizableLoop::isReportWorthy() {
   if(isAlreadyInGpuKernel()) {
     return false;
   }
-  
+
   return true;
 }
 

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -993,19 +993,17 @@ static void logGpuizableLoops() {
   std::set<CForLoop*, LocationComparator> ineligibleLoops;
 
   forv_Vec(FnSymbol*, fn, gFnSymbols) {
-    std::vector<BaseAST*> asts;
-    collect_asts(fn, asts);
+    std::vector<CForLoop*> loops;
+    collectCForLoopStmts(fn, loops);
 
-    for_vector(BaseAST, ast, asts) {
-      if (CForLoop* loop = toCForLoop(ast)) {
-        GpuizableLoop gpuLoop(loop);
-        bool isInModuleWeShouldReportOn = developer || loop->getModule()->modTag == MOD_USER;
-        if (gpuLoop.isReportWorthy() && isInModuleWeShouldReportOn) {
-          if(gpuLoop.isEligible()) {
-            eligibleLoops.insert(loop);
-          } else {
-            ineligibleLoops.insert(loop);
-          }
+    for_vector(CForLoop, loop, loops) {
+      GpuizableLoop gpuLoop(loop);
+      bool isInModuleWeShouldReportOn = developer || loop->getModule()->modTag == MOD_USER;
+      if (gpuLoop.isReportWorthy() && isInModuleWeShouldReportOn) {
+        if(gpuLoop.isEligible()) {
+          eligibleLoops.insert(loop);
+        } else {
+          ineligibleLoops.insert(loop);
         }
       }
     }

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -174,6 +174,8 @@ class GpuizableLoop {
 public:
   GpuizableLoop(BlockStmt* blk);
 
+  bool isReportWorthy();
+
   CForLoop* loop() const { return loop_; }
   bool isEligible() const { return isEligible_; }
   Symbol* upperBound() const { return upperBound_; }
@@ -222,6 +224,28 @@ GpuizableLoop::GpuizableLoop(BlockStmt *blk) {
   }
 }
 
+// Given --report-gpu we don't want to report on all 'for' loops just those
+// that are from forall/foreach that aren't already within GPU kernels
+bool GpuizableLoop::isReportWorthy() {
+  CForLoop *cfl = this->loop_;
+  INT_ASSERT(cfl);
+
+  if (!cfl->inTree())
+    return false;
+
+  if (!cfl->isOrderIndependent())
+    return false;
+
+  // We currently don't support launching kernels from kernels. So if
+  // the loop is within a function already marked for use on the GPU,
+  // don't GPUize.
+  if(isAlreadyInGpuKernel()) {
+    return false;
+  }
+  
+  return true;
+}
+
 bool GpuizableLoop::determineIfShouldErrorIfNotGpuizable() {
   CForLoop *cfl = this->loop_;
   INT_ASSERT(cfl);
@@ -248,23 +272,8 @@ bool GpuizableLoop::isAlreadyInGpuKernel() {
 }
 
 bool GpuizableLoop::evaluateLoop() {
-  CForLoop *cfl = this->loop_;
-  INT_ASSERT(cfl);
-
-  if (!cfl->inTree())
-    return false;
-
-  if (!cfl->isOrderIndependent())
-    return false;
-
-  // We currently don't support launching kernels from kernels. So if
-  // the loop is within a function already marked for use on the GPU,
-  // don't GPUize.
-  if(isAlreadyInGpuKernel()) {
-    return false;
-  }
-
-  return parentFnAllowsGpuization() &&
+  return isReportWorthy() &&
+         parentFnAllowsGpuization() &&
          callsInBodyAreGpuizable() &&
          attemptToExtractLoopInformation();
 }
@@ -969,24 +978,55 @@ static void outlineGPUKernels() {
 }
 
 static void logGpuizableLoops() {
-  forv_Vec(BlockStmt, block, gBlockStmts) {
-    if (ForLoop* forLoop = toForLoop(block)) {
-      if (forLoop->isOrderIndependent())
-        if (GpuizableLoop(forLoop).isEligible())
-          if (debugPrintGPUChecks)
-            printf("Found viable forLoop %s:%d[%d]\n",
-                   forLoop->fname(), forLoop->linenum(), forLoop->id);
-    } else if (CForLoop* forLoop = toCForLoop(block)) {
-      if (GpuizableLoop(forLoop).isEligible())
-        if (debugPrintGPUChecks)
-          printf("Found viable CForLoop %s:%d[%d]\n",
-                 forLoop->fname(), forLoop->linenum(), forLoop->id);
+  struct LocationComparator {
+    bool operator()(const CForLoop* item1, const CForLoop* item2) const {
+      const char* s1 = item1->fname();
+      const char* s2 = item2->fname();
+      int result = strcmp(s1, s2);
+      if (result != 0) {
+        return result < 0;
+      }
+      return item1->linenum() < item2->linenum();
     }
+  };
+  std::set<CForLoop*, LocationComparator> eligibleLoops;
+  std::set<CForLoop*, LocationComparator> ineligibleLoops;
+
+  forv_Vec(FnSymbol*, fn, gFnSymbols) {
+    std::vector<BaseAST*> asts;
+    collect_asts(fn, asts);
+
+    for_vector(BaseAST, ast, asts) {
+      if (CForLoop* loop = toCForLoop(ast)) {
+        GpuizableLoop gpuLoop(loop);
+        bool isInModuleWeShouldReportOn = developer || loop->getModule()->modTag == MOD_USER;
+        if (gpuLoop.isReportWorthy() && isInModuleWeShouldReportOn) {
+          if(gpuLoop.isEligible()) {
+            eligibleLoops.insert(loop);
+          } else {
+            ineligibleLoops.insert(loop);
+          }
+        }
+      }
+    }
+  }
+
+  printf("GPU INELIGIBLE LOOPS:\n");
+  printf("---------------------\n");
+  for (const auto& loop : ineligibleLoops) {
+    printf("%s\n", loop->stringLoc());
+  }
+  printf("\n");
+
+  printf("GPU ELIGIBLE LOOPS:\n");
+  printf("------------------\n");
+  for (const auto& loop : eligibleLoops) {
+    printf("%s\n", loop->stringLoc());
   }
 }
 
 void gpuTransforms() {
-  if (debugPrintGPUChecks) {
+  if (fReportGpu) {
     logGpuizableLoops();
   }
 

--- a/test/gpu/native/reportGpu.chpl
+++ b/test/gpu/native/reportGpu.chpl
@@ -1,0 +1,100 @@
+foreach i in 0..10 { callSomeExtern(); }  // [*]
+// [*] We want an ineligible loop on line 1, 5, 10, and 100 
+//     In order to verify that we're sorting by line number correctly and not just by
+//     using string comparison (e.g. foo.chpl:5 should be sorted before foo.chpl:10 )
+foreach i in 0..10 { callSomeExtern(); } // [*]
+
+extern { static void gpuIneligibleExtern(void) { }; }
+proc callSomeExtern() { gpuIneligibleExtern(); }
+
+foreach i in 0..10 { callSomeExtern(); }  // [*]
+use GPU;
+
+var globalVar = 0;
+
+proc directlyRecursiveFunc(i:int) { if i > 0 then directlyRecursiveFunc(i-1); }
+proc indirectlyRecursiveFunc(i:int) { if i > 0 then indirectlyRecursiveFunc2(i-1); }
+proc indirectlyRecursiveFunc2(i:int) { if i > 0 then indirectlyRecursiveFunc(i-1); }
+proc usesOutsideVar() { return globalVar; }
+
+pragma "no gpu codegen"
+proc funcMarkedNotGpuizableThatTriesToGpuize() {
+  foreach i in 0..10 {
+  }
+}
+
+pragma "no gpu codegen"
+proc funcMarkedNotGpuizable() { }
+
+on here.gpus[0] {
+  funcMarkedNotGpuizableThatTriesToGpuize();
+
+  foreach i in 0..10 {
+    funcMarkedNotGpuizable();
+  }
+
+  foreach i in 0..10 {
+    usesOutsideVar();
+  }
+
+  // calling a recursive function is allowed now
+  foreach i in 0..10 {
+    directlyRecursiveFunc(i);
+  }
+
+  foreach i in 0..10 {
+    indirectlyRecursiveFunc(i);
+  }
+
+  // I want to ensure this works
+  // with forall loops as well:
+  forall i in 0..10 {
+    directlyRecursiveFunc(i);
+  }
+
+  // And loops of a multidimensional array:
+  {
+    var A: [1..10, 1..10] int;
+    foreach a in A {
+      directlyRecursiveFunc(5);
+    }
+  }
+
+  foreach i in 0..10 { }
+  forall i in 0..10 { }
+  var A: [1..10, 1..10] int;
+  foreach a in A { }
+  foreach idx in {0..10, 0..10} { }
+  forall a in A { }
+  forall idx in {0..10, 0..10} { }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+foreach i in 0..10 { callSomeExtern(); }  // [*]

--- a/test/gpu/native/reportGpu.compopts
+++ b/test/gpu/native/reportGpu.compopts
@@ -1,0 +1,1 @@
+--report-gpu

--- a/test/gpu/native/reportGpu.good
+++ b/test/gpu/native/reportGpu.good
@@ -1,0 +1,23 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+GPU INELIGIBLE LOOPS:
+---------------------
+reportGpu.chpl:1
+reportGpu.chpl:5
+reportGpu.chpl:10
+reportGpu.chpl:22
+reportGpu.chpl:32
+reportGpu.chpl:36
+reportGpu.chpl:100
+
+GPU ELIGIBLE LOOPS:
+------------------
+reportGpu.chpl:41
+reportGpu.chpl:45
+reportGpu.chpl:51
+reportGpu.chpl:58
+reportGpu.chpl:63
+reportGpu.chpl:64
+reportGpu.chpl:66
+reportGpu.chpl:67
+reportGpu.chpl:68
+reportGpu.chpl:69

--- a/test/gpu/native/reportGpu.good
+++ b/test/gpu/native/reportGpu.good
@@ -10,7 +10,7 @@ reportGpu.chpl:36
 reportGpu.chpl:100
 
 GPU ELIGIBLE LOOPS:
-------------------
+-------------------
 reportGpu.chpl:41
 reportGpu.chpl:45
 reportGpu.chpl:51

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -329,6 +329,7 @@ _chpl ()
 --report-blocking \
 --report-dead-blocks \
 --report-dead-modules \
+--report-gpu \
 --report-gpu-transform-time \
 --report-inlined-iterators \
 --report-inlining \


### PR DESCRIPTION
This PR adds a flag to `chpl` (`--report-gpu`) that when run will produce a report like this:

```
GPU INELIGIBLE LOOPS:
---------------------
reportGpu.chpl:1
reportGpu.chpl:5
reportGpu.chpl:10
reportGpu.chpl:22
reportGpu.chpl:32
reportGpu.chpl:36
reportGpu.chpl:100

GPU ELIGIBLE LOOPS:
-------------------
reportGpu.chpl:41
reportGpu.chpl:45
reportGpu.chpl:51
reportGpu.chpl:58
reportGpu.chpl:63
reportGpu.chpl:64
reportGpu.chpl:66
reportGpu.chpl:67
reportGpu.chpl:68
reportGpu.chpl:69
```

Where each entry is a file/linenum to an order-independent loop. Output in each category is sorted by filename and line number.

If run with `--developer` we'll print information for all modules, if not we only print instances in user code.

While I'm here I also add a flush to stdout before we fork the compiler for the GPU pass.  In the absence of this if stdout is being redirected to a pipe (so we don't use line buffering) you can end up in a situation where the output buffer gets copied into the forked process and that copy gets flushed.  This ended up causing me metaphorical headaches while trying to understand why `start_test` kept complaining about my test having duplicate output but being unable to reproduce it when running `chpl` manually.

**TODO:**
* [x] gpu paratest (NVIDIA)
* [x] non gpu paratest