### PR TITLE
Add 'simple type name' primitive, for use in serialize/deserialize

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2504,7 +2504,7 @@ void AggregateType::buildReaderInitializer() {
 
         auto startKind = this->isClass() ? "startClass" : "startRecord";
         CallExpr* readStart = new CallExpr(startKind, gMethodToken, deser,
-                                           reader, new_StringSymbol(this->symbol->name));
+                                           reader, new CallExpr(PRIM_SIMPLE_TYPE_NAME, fn->_this));
         fn->insertAtHead(readStart);
 
         // Parent fields before child fields
@@ -2558,8 +2558,10 @@ void AggregateType::fieldToArg(FnSymbol*              fn,
                                ArgSymbol*             fileReader,
                                ArgSymbol*             formatter) {
   bool isReaderInit = (fileReader != nullptr);
+  int fieldNum = isClass() ? -1 : 0;
   for_fields(fieldDefExpr, this) {
     SET_LINENO(fieldDefExpr);
+    fieldNum += 1;
 
     if (VarSymbol* field = toVarSymbol(fieldDefExpr)) {
       if (field->hasFlag(FLAG_SUPER_CLASS) == false) {
@@ -2688,7 +2690,7 @@ void AggregateType::fieldToArg(FnSymbol*              fn,
           if (typeExpr != nullptr) {
             CallExpr* desField = new CallExpr("deserializeField", gMethodToken, formatter,
                                                fileReader,
-                                               new_StringSymbol(name),
+                                               new CallExpr(PRIM_FIELD_NUM_TO_NAME, fn->_this, new_IntSymbol(fieldNum)),
                                                typeExpr);
             fn->insertAtTail(new CallExpr("=",
                                           new CallExpr(".",

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -1116,6 +1116,7 @@ initPrimitive() {
 
   prim_def(PRIM_VIRTUAL_METHOD_CALL, "virtual method call", returnInfoVirtualMethodCall, true);
 
+  prim_def(PRIM_SIMPLE_TYPE_NAME, "simple type name", returnInfoString);
   prim_def(PRIM_NUM_FIELDS, "num fields", returnInfoInt32);
   prim_def(PRIM_FIELD_NUM_TO_NAME, "field num to name", returnInfoString);
   prim_def(PRIM_FIELD_NAME_TO_NUM, "field name to num", returnInfoInt32);

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -988,7 +988,7 @@ void ProcessThisUses::visitSymExpr(SymExpr* node) {
         }
       }
 
-      if (isClass(state->type())) {
+      if (isClass(state->type()) && call->isPrimitive() == false) {
         node->setSymbol(state->getThisAsParent());
       }
     }

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1947,8 +1947,7 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
         fn->insertAtTail(new CallExpr("serializeDefaultImpl",
                                       fileArg,
                                       serializer,
-                                      fn->_this,
-                                      new_StringSymbol(ct->symbol->name)));
+                                      fn->_this));
       }
     }
 
@@ -1992,8 +1991,7 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
       fn->insertAtTail(new CallExpr("deserializeDefaultImpl",
                                     fileArg,
                                     deserializer,
-                                    fn->_this,
-                                    new_StringSymbol(ct->symbol->name)));
+                                    fn->_this));
     }
 
     normalize(fn);

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1670,6 +1670,22 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     break;
   }
 
+  case PRIM_SIMPLE_TYPE_NAME: {
+    Type* t = call->get(1)->getValType();
+    if (AggregateType* at = toAggregateType(t)) {
+      const char* typeName = toString(at->getRootInstantiation());
+      retval = new SymExpr(new_StringSymbol(typeName));
+
+      call->replace(retval);
+    } else {
+      const char* typeName = toString(t);
+      retval = new SymExpr(new_StringSymbol(typeName));
+
+      call->replace(retval);
+    }
+    break;
+  }
+
   case PRIM_NUM_FIELDS: {
     Type*          t          = canonicalDecoratedClassType(call->get(1)->getValType());
     AggregateType* classType  = toAggregateType(t);

--- a/frontend/include/chpl/uast/prim-ops-list.h
+++ b/frontend/include/chpl/uast/prim-ops-list.h
@@ -296,6 +296,7 @@ PRIMITIVE_G(GET_SVEC_MEMBER_VALUE, "get svec member value")
 
 PRIMITIVE_G(VIRTUAL_METHOD_CALL, "virtual method call")
 
+PRIMITIVE_R(SIMPLE_TYPE_NAME, "simple type name")
 PRIMITIVE_R(NUM_FIELDS, "num fields")
 PRIMITIVE_R(FIELD_NUM_TO_NAME, "field num to name")
 PRIMITIVE_R(FIELD_NAME_TO_NUM, "field name to num")

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -324,6 +324,10 @@ CallResolutionResult resolvePrimCall(Context* context,
       CHPL_ASSERT(false && "not implemented yet");
       break;
 
+    case PRIM_SIMPLE_TYPE_NAME:
+      CHPL_ASSERT(false && "not implemented yet");
+      break;
+
     case PRIM_NUM_FIELDS:
       type = primNumFields(context, ci);
       break;

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -307,7 +307,8 @@ module ChapelIO {
     //
     @chpldoc.nodoc
     proc serializeDefaultImpl(writer:fileWriter, ref serializer,
-                              const x:?t, name: string) throws {
+                              const x:?t) throws {
+      const name = __primitive("simple type name", x);
       const numIO = __numIOFields(t);
       if isClassType(t) then
         serializer.startClass(writer, name, numIO);
@@ -315,7 +316,7 @@ module ChapelIO {
         serializer.startRecord(writer, name, numIO);
 
       if isClassType(t) && _to_borrowed(t) != borrowed object {
-        serializeDefaultImpl(writer, serializer, x.super, "super");
+        serializeDefaultImpl(writer, serializer, x.super);
       }
 
       param num_fields = __primitive("num fields", t);
@@ -335,7 +336,8 @@ module ChapelIO {
 
     @chpldoc.nodoc
     proc deserializeDefaultImpl(reader: fileReader, ref deserializer,
-                                ref x:?t, name:string) throws {
+                                ref x:?t) throws {
+      const name = __primitive("simple type name", x);
       if isClassType(t) then
         deserializer.startClass(reader, name);
       else


### PR DESCRIPTION
This PR introduces a "simple type name" primitive that returns the name of the type as it was declared, rather than including instantiation information (e.g. "R" vs. "R(int)"). The default implementations of ``serialize`` and ``deserialize`` methods are updated to use this new primitive instead of creating a string literal during ``buildDefaultFunctions``.

This change was motivated by a pair of mysterious baseline failures related to unused string literals in LLVM configurations. By only generating the string literal during resolution of the new primitive, we no longer leave the unused string literals around in the baseline configuration.

Testing:
- [x] full local
- [x] baseline
- [x] full gasnet
- [x] -suseIOSerializers