### PR TITLE
Build RE2 with -fPIE when using LLVM 15

### DIFF
--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -35,6 +35,13 @@ ifeq ($(CHPL_LIB_PIC),pic)
 CXXFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),llvm)
+# If we are using LLVM 15+, it defaults to -fPIE, so use that here as well
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -ge 15; echo "$$?"),0)
+CXXFLAGS += -fPIE
+endif
+endif
+
 CHPL_RE2_CFG_OPTIONS += $(CHPL_RE2_MORE_CFG_OPTIONS)
 
 # RE2 2017-04-01 uses C++11 features


### PR DESCRIPTION
Resolves linking errors when building chapel with `CHPL_RE2=bundled` using LLVM 15. Similar to the change made for third-party/gasnet here: https://github.com/chapel-lang/chapel/pull/22339

I noticed some linking errors along with this error:
```
$CHPL_HOME/third-party/re2/install/linux64-x86_64-native-llvm-none/lib/libre2.a(re2.o): relocation R_X86_64_32S against `.text' can not be used when making a PIE object; recompile with -fPIE
```
When building tests that also link with a system installed C-library.

<details>
<summary>printchplenv...</summary>

```
CHPL_TARGET_PLATFORM: linux64
CHPL_TARGET_COMPILER: llvm
CHPL_TARGET_ARCH: x86_64
CHPL_TARGET_CPU: native
CHPL_LOCALE_MODEL: flat
CHPL_COMM: none *
CHPL_TASKS: fifo *
CHPL_LAUNCHER: none
CHPL_TIMERS: generic
CHPL_UNWIND: none
CHPL_MEM: cstdlib *
CHPL_ATOMICS: cstdlib
CHPL_GMP: bundled *
CHPL_HWLOC: none
CHPL_RE2: bundled *
CHPL_LLVM: system *
CHPL_AUX_FILESYS: none
```
</details>

Testing:
- [ ] paratest
