### PR TITLE
Unstable warning for 'const' return intent

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -124,6 +124,7 @@ struct Visitor {
   void checkFormalsForTypeOrParamProcs(const Function* node);
   void checkNoReceiverClauseOnPrimaryMethod(const Function* node);
   void checkLambdaReturnIntent(const Function* node);
+  void checkConstReturnIntent(const Function* node);
   void checkProcTypeFormalsAreAnnotated(const FunctionSignature* node);
   void checkProcDefFormalsAreNamed(const Function* node);
   void checkGenericArrayTypeUsage(const BracketLoop* node);
@@ -795,7 +796,7 @@ void Visitor::checkLambdaReturnIntent(const Function* node) {
   switch (node->returnIntent()) {
     case Function::CONST_REF:
     case Function::REF:
-      disallowedReturnType = "ref";
+      disallowedReturnType = "[const] ref";
       break;
     case Function::PARAM:
       disallowedReturnType = "param";
@@ -807,9 +808,16 @@ void Visitor::checkLambdaReturnIntent(const Function* node) {
       break;
   }
   if (disallowedReturnType) {
-    error(node, "'%s' return types are not allowed in lambdas.",
+    error(node, "'%s' return intent is not allowed in lambdas.",
           disallowedReturnType);
   }
+}
+
+void Visitor::checkConstReturnIntent(const Function* node) {
+  if (node->returnIntent() != Function::CONST) return;
+  if (!shouldEmitUnstableWarning(node)) return;
+  warn(node, "'const' return intent is unstable and may work differently"
+             " in the future");
 }
 
 void
@@ -1128,7 +1136,7 @@ void Visitor::checkUserModuleHasPragma(const AttributeGroup* node) {
     }
   }
   // don't check if warn_unstable isn't set
-  if (!isFlagSet(CompilerFlags::WARN_UNSTABLE)) return;
+  if (!shouldEmitUnstableWarning(node)) return;
 
   // don't warn if the only pragma is 'no doc', which is deprecated
   bool noDocIsOnlyPragma = (pragmaNoDocFound && pragmaCount == 1);
@@ -1233,6 +1241,7 @@ void Visitor::visit(const Function* node) {
   checkNoReceiverClauseOnPrimaryMethod(node);
   checkLambdaDeprecated(node);
   checkLambdaReturnIntent(node);
+  checkConstReturnIntent(node);
   checkProcDefFormalsAreNamed(node);
 }
 

--- a/test/classes/weakPointers/passiveCache.good
+++ b/test/classes/weakPointers/passiveCache.good
@@ -1,3 +1,11 @@
+$CHPL_HOME/modules/standard/Map.chpl:503: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:528: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:544: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:636: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:503: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:528: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:544: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:636: warning: 'const' return intent is unstable and may work differently in the future
 passiveCache.chpl:46: In method 'buildAndSave':
 passiveCache.chpl:48: warning: The `weak` type is experimental; expect this API to change in the future.
   passiveCache.chpl:38: called as (PassiveCache(basicClass)).buildAndSave(key: int(64)) from method 'getOrBuild'

--- a/test/functions/resolution/parenless-call-segfault.bad
+++ b/test/functions/resolution/parenless-call-segfault.bad
@@ -1,4 +1,0 @@
-parenless-call-segfault.chpl:9: In function 'main':
-parenless-call-segfault.chpl:12: error: This appears to be a first class function reference created using qualified access
-note: First class functions created using qualified access are not supported
-note: If this is not intended as a first class function, please report it to the Chapel team

--- a/test/functions/resolution/parenless-call-segfault.chpl
+++ b/test/functions/resolution/parenless-call-segfault.chpl
@@ -1,3 +1,6 @@
+// This was a .future test for #16128
+// unimplemented feature: creating a fcf using qualified access
+
 module M {
   proc y() {
     writeln("Executing y");
@@ -8,10 +11,9 @@ module M {
 module N {
   proc main() {
     use M;
-    if false then
-      M.y;
-    else
-      M.y();
+    var fcf = M.y;
+    writeln(fcf());
+    M.y();
     writeln("Success");
   }
 }

--- a/test/functions/resolution/parenless-call-segfault.future
+++ b/test/functions/resolution/parenless-call-segfault.future
@@ -1,2 +1,0 @@
-unimplemented feature: creating a fcf using qualified access
-#16128

--- a/test/functions/resolution/parenless-call-segfault.good
+++ b/test/functions/resolution/parenless-call-segfault.good
@@ -1,2 +1,4 @@
 Executing y
+33
+Executing y
 Success

--- a/test/unstable/Map/parSafe.good
+++ b/test/unstable/Map/parSafe.good
@@ -1,3 +1,11 @@
+$CHPL_HOME/modules/standard/Map.chpl:503: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:528: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:544: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:636: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:503: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:528: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:544: warning: 'const' return intent is unstable and may work differently in the future
+$CHPL_HOME/modules/standard/Map.chpl:636: warning: 'const' return intent is unstable and may work differently in the future
 parSafe.chpl:4: warning: 'Map.parSafe' is unstable
 parSafe.chpl:5: warning: 'Map.parSafe' is unstable
 parSafe.chpl:12: warning: 'Map.parSafe' is unstable

--- a/test/unstable/const-return-intent.chpl
+++ b/test/unstable/const-return-intent.chpl
@@ -1,0 +1,22 @@
+// 'const' return and yield intents are unstable, see:
+// https://github.com/chapel-lang/chapel/issues/21888#issuecomment-1563535855
+
+
+proc f1(len) {
+  var a: [1..len] int;
+  return a;
+}
+
+proc f2() const {
+  return f1(4);
+}
+
+iter i3() const {
+  for size in 1..3 do
+    yield f1(size);
+}
+
+writeln(f1(2));
+writeln(f2());
+for arr in i3() do
+  writeln(arr);

--- a/test/unstable/const-return-intent.good
+++ b/test/unstable/const-return-intent.good
@@ -1,0 +1,7 @@
+const-return-intent.chpl:10: warning: 'const' return intent is unstable and may work differently in the future
+const-return-intent.chpl:14: warning: 'const' return intent is unstable and may work differently in the future
+0 0
+0 0 0 0
+0
+0 0
+0 0 0


### PR DESCRIPTION
With this PR, the compiler generates unstable warnings for uses of `const` return/yield intent. This is in preparation for the future work discussed in https://github.com/chapel-lang/chapel/issues/21888#issuecomment-1563535855 .

Testing highlights four methods in our standard Map that use `const` return/yield intent:
```chpl
proc get(k: keyType, const sentinel: valType) const
iter values() const where isNonNilableClass(valType)
// two more 'const' methods are deprecated
```

I updated .good files for two tests that have --warn-unstable compopts and call these methods.

With this PR, the future test `test/functions/resolution/parenless-call-segfault.chpl` passes, for an unknown reason. I de-futurized it, we will see how it behaves in nightly. I made a note on its issue, #16128 .
