### PR TITLE
Make GPU "flags-warn-unstable-internal" test only consider the GPU module warnings

### DIFF
--- a/test/gpu/native/jacobi/flags-warn-unstable-internal.good
+++ b/test/gpu/native/jacobi/flags-warn-unstable-internal.good
@@ -1,11 +1,2 @@
-warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 $CHPL_HOME/modules/internal/ChapelStandard.chpl:53: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:29: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
-$CHPL_HOME/modules/internal/ChapelBase.chpl:57: warning: chpl_unstableInternalSymbolForTesting is unstable
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:669: In function 'warmupRuntime':
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:672: warning: 'allocate' is unstable, and may be renamed or moved
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:674: warning: 'deallocate' is unstable, and may be renamed or moved
-on GPU:
-1.0 1.20906 2.19525 2.9034 3.5552 4.01125 4.21599 4.10448 3.62297 2.85669 1.60226 1.0
-on CPU:
-1.0 1.20906 2.19525 2.9034 3.5552 4.01125 4.21599 4.10448 3.62297 2.85669 1.60226 1.0

--- a/test/gpu/native/jacobi/flags.prediff
+++ b/test/gpu/native/jacobi/flags.prediff
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+TESTNAME=$1
+OUTFILE=$2
+TMPFILE="$outfile.prediff.tmp"
+FILTER_TEXT="warning: The GPU locale interface is unstable"
+
+# If using --warn-unstable-internal only compare lines that have the GPU
+# specific warning.  (The intent of this test is to check for this warning and
+# we don't want to have to update the test if other unstable features are used
+# in our internal code).
+
+if [[ "$@" == *"--warn-unstable-internal"* ]]; then
+  mv $OUTFILE $TMPFILE
+  grep "$FILTER_TEXT" "$TMPFILE" > "$OUTFILE"
+  rm $TMPFILE
+fi


### PR DESCRIPTION
The `test/gpu/native/jacobi/flags.chpl` test has a compopt mode where it passes `--flags-warn-unstable-internal`.  

In a previous PR (https://github.com/chapel-lang/chapel/pull/22376) we update the test to account for `warning: 'allocate' is unstable, and may be renamed or moved` (which there is no stable alternative for).

The locations of these warnings has since changed and this test currently fails. Having to keep this test up-to-date with line changes and new internal warnings is a bit of a hassle and I believe the intent of this test is to lock down when/where the "GPU module is unstable" warnings occur internally.

So to avoid this in the future I've added a `.prediff` file that when run with `--flags-warn-unstable-internal` filters out all output except for the relevant warnings that we want to lock down.

FYI: @e-kayrakli 