### PR TITLE
Add test locking in conversion from unmanaged class to c_void_ptr and back

### DIFF
--- a/test/classes/cast/castClassPtr.chpl
+++ b/test/classes/cast/castClassPtr.chpl
@@ -1,0 +1,33 @@
+use CTypes;
+
+class Func {
+  var x: int;
+
+  proc postinit() {
+    writeln("created");
+  }
+
+  proc this() const {
+    writeln("invoked");
+    return x;
+  }
+}
+
+proc main() {
+  var c = new unmanaged Func(42);
+  writeln(c);
+
+  var p: c_void_ptr = c_ptrTo(c);
+  var c2: unmanaged Func = (p: unmanaged Func?)!;
+  writeln(c2);
+  writeln(c2());
+  assert(c_ptrTo(c) == c_ptrTo(c2));
+  writeln("Addresses match!");
+
+  var p2: c_void_ptr = c:c_void_ptr;
+  var c3: unmanaged Func = (p2: unmanaged Func?)!;
+  writeln(c3);
+  writeln(c3());
+  assert(c_ptrTo(c) == c_ptrTo(c3));
+  writeln("Addresses match!");
+}

--- a/test/classes/cast/castClassPtr.compopts
+++ b/test/classes/cast/castClassPtr.compopts
@@ -1,0 +1,1 @@
+-scPtrToLogicalValue

--- a/test/classes/cast/castClassPtr.good
+++ b/test/classes/cast/castClassPtr.good
@@ -1,0 +1,10 @@
+created
+{x = 42}
+{x = 42}
+invoked
+42
+Addresses match!
+{x = 42}
+invoked
+42
+Addresses match!


### PR DESCRIPTION
We've been talking recently about ways to convert from classes to pointers and back, and this was a test I wrote up to convince myself we could, in two ways currently at least.  Whether or not we should keep both of them relates to #22341.