### PR TITLE
Fix compilation issue with Intel compiler for FFTW

### DIFF
--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -161,7 +161,7 @@ module FFTW {
     An opaque type used to store and reuse FFTW plans across multiple
     routines.
   */
-  extern type fftw_plan = c_ptr(opaque);
+  extern type fftw_plan = c_void_ptr;
 
   /*
     Type alias for FFTW flags


### PR DESCRIPTION
Fixes an issue where the opaque ptr type `fftw_plan` caused errors when compiling the generated C with an Intel compiler. Changing the type to `c_void_ptr` resolves the problem.

This issue cropped up in our nightly testing and this PR should resolve it.

Tested against all the FFTW tests I could find.

[Reviewed by @bradcray]