### PR TITLE
Dyno: Implement forwarding to methods

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1646,6 +1646,12 @@ class ResolvedFields {
     forwarding_.push_back(ForwardingDetail(forwardingId, receiverType));
   }
 
+  void addForwarding(const ResolvedFields& other) {
+    for (int i = 0; i < other.numForwards(); i++) {
+      addForwarding(other.forwardingStmt(i), other.forwardingToType(i));
+    }
+  }
+
   void finalizeFields(Context* context);
 
   /** Returns true if this is a generic type */

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2440,7 +2440,18 @@ void Resolver::resolveIdentifier(const Identifier* ident,
     } else if (id.isEmpty()) {
       type = typeForBuiltin(context, ident->name());
       result.setIsBuiltin(true);
-      result.setToId(id);
+
+      // Some builtin types have a more useful ID than an empty ID
+      ID builtinId = id;
+      if (type.hasTypePtr()) {
+        if (auto cl = type.type()->toClassType()) {
+          builtinId = cl->basicClassType()->id();
+        } else if (auto ct = type.type()->toCompositeType()) {
+          builtinId = ct->id();
+        }
+      }
+      result.setToId(builtinId);
+
       result.setType(type);
       return;
     }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -418,6 +418,10 @@ gatherParentClassScopesForScopeResolving(Context* context, ID classDeclId) {
         if (const AstNode* parentClassExpr = c->parentClass()) {
           // Resolve the parent class type expression
           ResolutionResultByPostorderID r;
+          // TODO: Seems like we should just be able to call
+          // 'resolveIdentifier' here. As-is, going through normal traversal is
+          // a bit muddled by the parentClassExpr technically being a child of
+          // 'c'.
           auto visitor =
             Resolver::createForParentClassScopeResolve(context, c, r);
           parentClassExpr->traverse(visitor);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -344,9 +344,10 @@ Resolver::createForParentClassScopeResolve(Context* context,
                                            const AggregateDecl* decl,
                                            ResolutionResultByPostorderID& byId)
 {
-  auto ret = Resolver(context, decl, byId, /* poiScope */ nullptr);
+  auto parent = parsing::parentAst(context, decl);
+  auto ret = Resolver(context, parent, byId, /* poiScope */ nullptr);
   ret.defaultsPolicy = DefaultsPolicy::USE_DEFAULTS;
-  ret.byPostorder.setupForSymbol(decl);
+  ret.byPostorder.setupForSymbol(parent);
   ret.scopeResolveOnly = true;
   return ret;
 }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2252,7 +2252,7 @@ Resolver::lookupIdentifier(const Identifier* ident,
       if (isPotentialSuper(ident)) {
         // We found a single ID, and it's just 'super'.
         return { BorrowedIdsWithName::createWithBuiltinId() };
-      } else {
+      } else if (!resolvingCalledIdent) {
         auto pair = namesWithErrorsEmitted.insert(ident->name());
         if (pair.second) {
           // insertion took place so emit the error

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2450,7 +2450,9 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       ID builtinId = id;
       if (type.hasTypePtr()) {
         if (auto cl = type.type()->toClassType()) {
-          builtinId = cl->basicClassType()->id();
+          if (auto basic = cl->basicClassType()) {
+            builtinId = basic->id();
+          }
         } else if (auto ct = type.type()->toCompositeType()) {
           builtinId = ct->id();
         }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -344,7 +344,8 @@ Resolver::createForParentClassScopeResolve(Context* context,
                                            const AggregateDecl* decl,
                                            ResolutionResultByPostorderID& byId)
 {
-  auto parent = parsing::parentAst(context, decl);
+  auto parentId = decl->id().parentSymbolId(context);
+  auto parent = parsing::idToAst(context, parentId);
   auto ret = Resolver(context, parent, byId, /* poiScope */ nullptr);
   ret.defaultsPolicy = DefaultsPolicy::USE_DEFAULTS;
   ret.byPostorder.setupForSymbol(parent);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -654,12 +654,7 @@ const ResolvedFields& fieldsForTypeDeclQuery(Context* context,
                           resolvedFields.fieldDeclId(i),
                           resolvedFields.fieldType(i));
         }
-        // Copy resolved forwarding statements into the result
-        n = resolvedFields.numForwards();
-        for (int i = 0; i < n; i++) {
-          result.addForwarding(resolvedFields.forwardingStmt(i),
-                               resolvedFields.forwardingToType(i));
-        }
+        result.addForwarding(resolvedFields);
       }
     }
 
@@ -734,12 +729,7 @@ const ResolvedFields& resolveForwardingExprs(Context* context,
           !child->toForwardingDecl()->expr()->isDecl()) {
         const ResolvedFields& resolvedFields =
           resolveFieldDecl(context, ct, child->id(), DefaultsPolicy::USE_DEFAULTS);
-        // Copy resolved forwarding statements into the result
-        int n = resolvedFields.numForwards();
-        for (int i = 0; i < n; i++) {
-          result.addForwarding(resolvedFields.forwardingStmt(i),
-                               resolvedFields.forwardingToType(i));
-        }
+        result.addForwarding(resolvedFields);
       }
     }
   }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -638,10 +638,12 @@ const ResolvedFields& fieldsForTypeDeclQuery(Context* context,
 
     for (auto child: ad->children()) {
       // Ignore everything other than VarLikeDecl, MultiDecl, TupleDecl
+      bool isForwardingField = child->isForwardingDecl() &&
+                               child->toForwardingDecl()->expr()->isDecl();
       if (child->isVarLikeDecl() ||
           child->isMultiDecl() ||
           child->isTupleDecl() ||
-          child->isForwardingDecl()) {
+          isForwardingField) {
         const ResolvedFields& resolvedFields =
           resolveFieldDecl(context, ct, child->id(), defaultsPolicy);
         // Copy resolvedFields into result

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3060,6 +3060,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
   }
 }
 
+// TODO: Could/should this be a parsing query?
 static bool isInsideForwarding(Context* context, const Call* call) {
   bool insideForwarding = false;
   if (call != nullptr) {

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -432,7 +432,7 @@ static void forwardForwardHelper(std::string stmt, bool isVar = false) {
   auto qt = resolveQualifiedTypeOfX(context, contents);
   assert(qt.type()->isErroneousType());
 
-  int numExpected = isVar ? 3 : 2;
+  unsigned int numExpected = isVar ? 3 : 2;
   assert(guard.numErrors() == numExpected);
 
   auto first = "Cannot resolve call to 'bar': no matching candidates";


### PR DESCRIPTION
This PR implements forwarding to methods expressions in a class or record, which is a recurring pattern in our internal/standard modules.

Previously, we were resolving forwarding statements at the same time we were resolving fields. The core of this PR is to separate the resolution of forwarding statements involving expressions, like "forwarding foo()", and resolve them later during ``gatherAndFilterCandidatesForwarding``. To allow for resolving this kind of forwarding statement the ``Resolver`` implementation was updated to more broadly infer a potential method receiver type.

Other changes to account for newly exposed issues were:
- Fixing ``createForParentClassScopeResolve`` to start scope resolving at the parent symbol, not the class itself
- Attempting to set the correct ID for builtin types during identifier resolution

Finally, a new overload of ``ResolvedFields::addForwarding`` is introduced to support bulk-adding forwarding from another ``ResolvedFields`` instance.

Testing:
- [x] make test-dyno
- [x] full local