### PR TITLE
Dyno: only resolve relevant initializer signatures

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -368,9 +368,11 @@ bool InitResolver::implicitlyResolveFieldType(ID id) {
   if (!state || !state->initPointId.isEmpty()) return false;
 
   if (state->qt.isParam()) {
-    CHPL_ASSERT(0 == "Not handled yet!");
+    // TODO: not yet implemented
+    state->qt = QualifiedType(QualifiedType::PARAM, ErroneousType::get(ctx_));
   } else if (state->qt.isType()) {
-    CHPL_ASSERT(0 == "Not handled yet!");
+    // TODO: not yet implemented
+    state->qt = QualifiedType(QualifiedType::TYPE, ErroneousType::get(ctx_));
   } else {
     auto ct = typeToCompType(currentRecvType_);
     auto& rf = resolveFieldDecl(ctx_, ct, id, DefaultsPolicy::USE_DEFAULTS);

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -472,8 +472,16 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
         actuals.push_back(CallInfoActual(qt, fname));
       }
     }
+
+    // Get the 'root' instantiation
+    const CompositeType* calledCT = compositeType;
+    while (auto insn = calledCT->instantiatedFromCompositeType()) {
+      calledCT = insn;
+    }
+    auto calledType = QualifiedType(QualifiedType::VAR, calledCT);
+
     auto ci = CallInfo (/* name */ USTR("init"),
-                        /* calledType */ QualifiedType(),
+                        /* calledType */ calledType,
                         /* isMethodCall */ true,
                         /* hasQuestionArg */ false,
                         /* isParenless */ false,

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -28,6 +28,8 @@
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
 
+#include "Resolver.h"
+
 namespace chpl {
 namespace resolution {
 
@@ -83,11 +85,11 @@ areOverloadsPresentInDefiningScope(Context* context, const Type* type,
       if (auto fn = node->toFunction()) {
         if (!fn->isMethod()) continue;
 
-        auto ufs = UntypedFnSignature::get(context, fn->id());
-
         // TODO: way to just compute formal type instead of whole TFS?
-        auto tfs = typedSignatureInitial(context, ufs);
-        auto receiverQualType = tfs->formalType(0);
+        ResolutionResultByPostorderID r;
+        auto vis = Resolver::createForInitialSignature(context, fn, r);
+        fn->thisFormal()->traverse(vis);
+        auto receiverQualType = vis.byPostorder.byAst(fn->thisFormal()).type();
 
         // return true if the receiver type matches or
         // if the receiver type is a generic type and we have

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -85,7 +85,6 @@ areOverloadsPresentInDefiningScope(Context* context, const Type* type,
       if (auto fn = node->toFunction()) {
         if (!fn->isMethod()) continue;
 
-        // TODO: way to just compute formal type instead of whole TFS?
         ResolutionResultByPostorderID r;
         auto vis = Resolver::createForInitialSignature(context, fn, r);
         fn->thisFormal()->traverse(vis);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2212,6 +2212,8 @@ doIsCandidateApplicableInitial(Context* context,
     }
   }
 
+  CHPL_ASSERT(isFunction(tag) && "expected fn case only by this point");
+
   if (ci.isMethodCall() && ci.name() == "init") {
     // TODO: test when record has defaults for type/param fields
     auto recv = ci.calledType();
@@ -2227,7 +2229,6 @@ doIsCandidateApplicableInitial(Context* context,
     }
   }
 
-  CHPL_ASSERT(isFunction(tag) && "expected fn case only by this point");
   auto ufs = UntypedFnSignature::get(context, candidateId);
   auto faMap = FormalActualMap(ufs, ci);
   auto ret = typedSignatureInitial(context, ufs);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2212,6 +2212,21 @@ doIsCandidateApplicableInitial(Context* context,
     }
   }
 
+  if (ci.isMethodCall() && ci.name() == "init") {
+    // TODO: test when record has defaults for type/param fields
+    auto recv = ci.calledType();
+    auto fn = parsing::idToAst(context, candidateId)->toFunction();
+    ResolutionResultByPostorderID r;
+    auto vis = Resolver::createForInitialSignature(context, fn, r);
+    fn->thisFormal()->traverse(vis);
+    auto res = vis.byPostorder.byAst(fn->thisFormal());
+
+    auto got = canPass(context, recv, res.type());
+    if (!got.passes()) {
+      return nullptr;
+    }
+  }
+
   CHPL_ASSERT(isFunction(tag) && "expected fn case only by this point");
   auto ufs = UntypedFnSignature::get(context, candidateId);
   auto faMap = FormalActualMap(ufs, ci);


### PR DESCRIPTION
This PR replicates some of the behavior from #9004, which prevents the compiler from trying to resolve the signatures of initializers on types other than the type being initialized. In this PR, we selectively resolve the "this" formal on candidates and use ``canPass`` to check whether it is an initializer on the desired type. Without this change we could easily encounter recursive query errors whenever a class or record was initialized in an initializer's signature:

```chpl
proc MyType.init(x = new X(5))
```

Testing:
- [x] make test-dyno