### PR TITLE
dyno: Change compiler global impl to match the compiler flags impl

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -46,6 +46,8 @@
 
 #include "global-ast-vecs.h"
 
+#include "chpl/framework/compiler-configuration.h"
+
 #include <cmath>
 
 static bool isDerivedType(Type* type, Flag flag);
@@ -1358,9 +1360,9 @@ VarSymbol* createCompilerGlobalParam<bool>(const char* name, bool value) {
 }
 
 void initCompilerGlobals() {
-  auto& compilationGlobals = gContext->configuration().compilationGlobals;
+  auto& compilerGlobals = chpl::compilerGlobals(gContext);
   #define COMPILER_GLOBAL(TYPE__, NAME__, FIELD__) \
-    gCompilerGlobalParams.push_back(createCompilerGlobalParam<TYPE__>(NAME__, compilationGlobals.FIELD__));
+    gCompilerGlobalParams.push_back(createCompilerGlobalParam<TYPE__>(NAME__, compilerGlobals.FIELD__));
   #include "chpl/uast/compiler-globals-list.h"
   #undef COMPILER_GLOBAL
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1914,7 +1914,7 @@ static void validateSettings() {
   checkRuntimeBuilt();
 }
 
-static chpl::CompilationGlobals dynoBuildCompilationGlobals() {
+static chpl::CompilerGlobals dynoBuildCompilationGlobals() {
   return {
     .boundsChecking = !fNoBoundsChecks,
     .castChecking = !fNoCastChecks,

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1914,7 +1914,7 @@ static void validateSettings() {
   checkRuntimeBuilt();
 }
 
-static chpl::Context::CompilationGlobals dynoBuildCompilationGlobals() {
+static chpl::CompilationGlobals dynoBuildCompilationGlobals() {
   return {
     .boundsChecking = !fNoBoundsChecks,
     .castChecking = !fNoCastChecks,
@@ -1943,7 +1943,6 @@ static void dynoConfigureContext(std::string chpl_module_path) {
     config.keepTmpDir = true;
   }
   config.toolName = "chpl";
-  config.compilationGlobals = dynoBuildCompilationGlobals();
 
   // Replace the current gContext with one using the new configuration.
   auto oldContext = gContext;
@@ -2010,6 +2009,9 @@ static void dynoConfigureContext(std::string chpl_module_path) {
 
   // Set the compilation flags all at once using a query.
   chpl::setCompilerFlags(gContext, flags);
+
+  // Set the compilation globals all at once using a query.
+  chpl::setCompilerGlobals(gContext, dynoBuildCompilationGlobals());
 }
 
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1914,7 +1914,7 @@ static void validateSettings() {
   checkRuntimeBuilt();
 }
 
-static chpl::CompilerGlobals dynoBuildCompilationGlobals() {
+static chpl::CompilerGlobals dynoBuildCompilerGlobals() {
   return {
     .boundsChecking = !fNoBoundsChecks,
     .castChecking = !fNoCastChecks,
@@ -2011,7 +2011,7 @@ static void dynoConfigureContext(std::string chpl_module_path) {
   chpl::setCompilerFlags(gContext, flags);
 
   // Set the compilation globals all at once using a query.
-  chpl::setCompilerGlobals(gContext, dynoBuildCompilationGlobals());
+  chpl::setCompilerGlobals(gContext, dynoBuildCompilerGlobals());
 }
 
 

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -83,21 +83,11 @@ class Context {
     virtual void report(Context* context, const ErrorBase* err) = 0;
   };
 
-  /** Information about the program's compilation state that's available to
-      the programs themselves via global variables. */
-  struct CompilationGlobals {
-    #define COMPILER_GLOBAL(TYPE__, IDENT__, NAME__) TYPE__ NAME__;
-    #include "chpl/uast/compiler-globals-list.h"
-    #undef COMPILER_GLOBAL
-  };
-
   /** This struct stores configuration information to use when
       constructing a Context. */
   struct Configuration {
     /** Used for determining Chapel environment variables */
     std::string chplHome;
-
-    CompilationGlobals compilationGlobals;
 
     std::unordered_map<std::string, std::string> chplEnvOverrides;
 

--- a/frontend/include/chpl/framework/compiler-configuration.h
+++ b/frontend/include/chpl/framework/compiler-configuration.h
@@ -24,6 +24,30 @@
 
 namespace chpl {
 
+  /** Information about the program's compilation state that's available to
+      the programs themselves via global variables. */
+  struct CompilationGlobals {
+    #define COMPILER_GLOBAL(TYPE__, IDENT__, NAME__) TYPE__ NAME__;
+    #include "chpl/uast/compiler-globals-list.h"
+    #undef COMPILER_GLOBAL
+
+    static bool update(CompilationGlobals& keep, CompilationGlobals& addin);
+
+    void mark(Context* context) const {}
+    void swap(CompilationGlobals& other);
+    bool operator==(const CompilationGlobals& other) const;
+    bool operator!=(const CompilationGlobals& other) const;
+  };
+
+  /** Get the values of compiler-provided global variables. Variables here
+      are intended to be those influenced by command-line flags.
+   */
+  const CompilationGlobals& compilerGlobals(Context* context);
+
+  /**
+    Set the values of the various compiler global variables.
+   */
+  void setCompilerGlobals(Context* Context, CompilationGlobals newValue);
 
   /**
     Get the flags for the current session. The class returned by this

--- a/frontend/include/chpl/framework/compiler-configuration.h
+++ b/frontend/include/chpl/framework/compiler-configuration.h
@@ -26,28 +26,28 @@ namespace chpl {
 
   /** Information about the program's compilation state that's available to
       the programs themselves via global variables. */
-  struct CompilationGlobals {
+  struct CompilerGlobals {
     #define COMPILER_GLOBAL(TYPE__, IDENT__, NAME__) TYPE__ NAME__;
     #include "chpl/uast/compiler-globals-list.h"
     #undef COMPILER_GLOBAL
 
-    static bool update(CompilationGlobals& keep, CompilationGlobals& addin);
+    static bool update(CompilerGlobals& keep, CompilerGlobals& addin);
 
     void mark(Context* context) const {}
-    void swap(CompilationGlobals& other);
-    bool operator==(const CompilationGlobals& other) const;
-    bool operator!=(const CompilationGlobals& other) const;
+    void swap(CompilerGlobals& other);
+    bool operator==(const CompilerGlobals& other) const;
+    bool operator!=(const CompilerGlobals& other) const;
   };
 
   /** Get the values of compiler-provided global variables. Variables here
       are intended to be those influenced by command-line flags.
    */
-  const CompilationGlobals& compilerGlobals(Context* context);
+  const CompilerGlobals& compilerGlobals(Context* context);
 
   /**
     Set the values of the various compiler global variables.
    */
-  void setCompilerGlobals(Context* Context, CompilationGlobals newValue);
+  void setCompilerGlobals(Context* Context, CompilerGlobals newValue);
 
   /**
     Get the flags for the current session. The class returned by this

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -61,7 +61,6 @@ using namespace chpl::querydetail;
 
 void Context::Configuration::swap(Context::Configuration& other) {
   std::swap(chplHome, other.chplHome);
-  std::swap(compilationGlobals, other.compilationGlobals);
   std::swap(chplEnvOverrides, other.chplEnvOverrides);
   std::swap(tmpDir, other.tmpDir);
   std::swap(keepTmpDir, other.keepTmpDir);

--- a/frontend/lib/framework/compiler-configuration.cpp
+++ b/frontend/lib/framework/compiler-configuration.cpp
@@ -49,7 +49,7 @@ bool CompilerGlobals::operator!=(const CompilerGlobals& other) const {
 
 const CompilerGlobals& compilerGlobals(Context* context) {
   QUERY_BEGIN_INPUT(compilerGlobals, context);
-  CompilerGlobals ret;
+  CompilerGlobals ret{};
   return QUERY_END(ret);
 }
 

--- a/frontend/lib/framework/compiler-configuration.cpp
+++ b/frontend/lib/framework/compiler-configuration.cpp
@@ -23,18 +23,18 @@
 
 namespace chpl {
 
-bool CompilationGlobals::update(CompilationGlobals& keep, CompilationGlobals& addin) {
+bool CompilerGlobals::update(CompilerGlobals& keep, CompilerGlobals& addin) {
   return defaultUpdate(keep, addin);
 }
 
-void CompilationGlobals::swap(CompilationGlobals& other) {
+void CompilerGlobals::swap(CompilerGlobals& other) {
   #define COMPILER_GLOBAL(TYPE__, NAME__, FIELD__) \
     std::swap(this->FIELD__, other.FIELD__);
   #include "chpl/uast/compiler-globals-list.h"
   #undef COMPILER_GLOBAL
 }
 
-bool CompilationGlobals::operator==(const CompilationGlobals& other) const {
+bool CompilerGlobals::operator==(const CompilerGlobals& other) const {
   #define COMPILER_GLOBAL(TYPE__, NAME__, FIELD__) \
     this->FIELD__ == other.FIELD__&&
   return
@@ -43,17 +43,17 @@ bool CompilationGlobals::operator==(const CompilationGlobals& other) const {
     true;
 }
 
-bool CompilationGlobals::operator!=(const CompilationGlobals& other) const {
+bool CompilerGlobals::operator!=(const CompilerGlobals& other) const {
   return !(*this==other);
 }
 
-const CompilationGlobals& compilerGlobals(Context* context) {
+const CompilerGlobals& compilerGlobals(Context* context) {
   QUERY_BEGIN_INPUT(compilerGlobals, context);
-  CompilationGlobals ret;
+  CompilerGlobals ret;
   return QUERY_END(ret);
 }
 
-void setCompilerGlobals(Context* context, CompilationGlobals newValue) {
+void setCompilerGlobals(Context* context, CompilerGlobals newValue) {
   QUERY_STORE_INPUT_RESULT(compilerGlobals, context, newValue);
 }
 

--- a/frontend/lib/framework/compiler-configuration.cpp
+++ b/frontend/lib/framework/compiler-configuration.cpp
@@ -23,6 +23,39 @@
 
 namespace chpl {
 
+bool CompilationGlobals::update(CompilationGlobals& keep, CompilationGlobals& addin) {
+  return defaultUpdate(keep, addin);
+}
+
+void CompilationGlobals::swap(CompilationGlobals& other) {
+  #define COMPILER_GLOBAL(TYPE__, NAME__, FIELD__) \
+    std::swap(this->FIELD__, other.FIELD__);
+  #include "chpl/uast/compiler-globals-list.h"
+  #undef COMPILER_GLOBAL
+}
+
+bool CompilationGlobals::operator==(const CompilationGlobals& other) const {
+  #define COMPILER_GLOBAL(TYPE__, NAME__, FIELD__) \
+    this->FIELD__ == other.FIELD__&&
+  return
+  #include "chpl/uast/compiler-globals-list.h"
+  #undef COMPILER_GLOBAL
+    true;
+}
+
+bool CompilationGlobals::operator!=(const CompilationGlobals& other) const {
+  return !(*this==other);
+}
+
+const CompilationGlobals& compilerGlobals(Context* context) {
+  QUERY_BEGIN_INPUT(compilerGlobals, context);
+  CompilationGlobals ret;
+  return QUERY_END(ret);
+}
+
+void setCompilerGlobals(Context* context, CompilationGlobals newValue) {
+  QUERY_STORE_INPUT_RESULT(compilerGlobals, context, newValue);
+}
 
 const CompilerFlags& compilerFlags(Context* context) {
   QUERY_BEGIN_INPUT(compilerFlags, context);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -20,6 +20,7 @@
 #include "chpl/resolution/resolution-queries.h"
 
 #include "chpl/parsing/parsing-queries.h"
+#include "chpl/framework/compiler-configuration.h"
 #include "chpl/framework/ErrorMessage.h"
 #include "chpl/framework/UniqueString.h"
 #include "chpl/framework/global-strings.h"
@@ -3595,11 +3596,11 @@ const std::unordered_map<UniqueString, QualifiedType>&
 getCompilerGeneratedGlobals(Context* context) {
   QUERY_BEGIN(getCompilerGeneratedGlobals, context);
 
+  auto& globals = compilerGlobals(context);
   std::unordered_map<UniqueString, QualifiedType> result;
   #define COMPILER_GLOBAL(TYPE__, IDENT__, NAME__)\
     result[UniqueString::get(context, IDENT__)] = \
-      paramTypeFromValue<TYPE__>(context, \
-                                 context->configuration().compilationGlobals.NAME__);
+      paramTypeFromValue<TYPE__>(context, globals.NAME__);
   #include "chpl/uast/compiler-globals-list.h"
   #undef COMPILER_GLOBAL
 

--- a/frontend/test/resolution/testCompilationGlobals.cpp
+++ b/frontend/test/resolution/testCompilationGlobals.cpp
@@ -45,8 +45,8 @@ static std::unordered_map<std::string, QualifiedType> compilationGlobalTypes(Con
   return resolveTypesOfVariables(context, allGlobalsProgram, variables);
 }
 
-static Context::CompilationGlobals defaultGlobals() {
-  Context::CompilationGlobals globals;
+static CompilationGlobals defaultGlobals() {
+  CompilationGlobals globals;
   // For the time being, all globals are bools so just set them to false.
   #define COMPILER_GLOBAL(TYPE__, NAME__, FIELD__) globals.FIELD__ = false;
   #include "chpl/uast/compiler-globals-list.h"
@@ -65,15 +65,14 @@ void verifyGlobal<bool>(const QualifiedType& type, bool expected) {
 
 template <typename F>
 void verifyCompilerGlobals(F&& function) {
-  // Configure the globals (including running user code to set them)
-  Context::CompilationGlobals myGlobals = defaultGlobals();
-  function(myGlobals);
-  Context::Configuration config;
-  config.compilationGlobals = myGlobals;
-
   // Create the context
-  Context ctx(std::move(config));
+  Context ctx;
   Context* context = &ctx;
+
+  // Configure the globals (including running user code to set them)
+  CompilationGlobals myGlobals = defaultGlobals();
+  function(myGlobals);
+  setCompilerGlobals(context, myGlobals);
 
   std::cout << "--- verifying globals ---" << std::endl;
 
@@ -93,13 +92,13 @@ void verifyCompilerGlobals(F&& function) {
 static void test1() {
   // Default configuration, everything is false.
 
-  verifyCompilerGlobals([](Context::CompilationGlobals& globals) {
+  verifyCompilerGlobals([](CompilationGlobals& globals) {
     // Do not change the globals; all should be false.
   });
 }
 
 static void test2() {
-  verifyCompilerGlobals([](Context::CompilationGlobals& globals) {
+  verifyCompilerGlobals([](CompilationGlobals& globals) {
     globals.boundsChecking = true;
   });
 }
@@ -107,7 +106,7 @@ static void test2() {
 static void test3() {
   // Default configuration, everything is false.
 
-  verifyCompilerGlobals([](Context::CompilationGlobals& globals) {
+  verifyCompilerGlobals([](CompilationGlobals& globals) {
     globals.boundsChecking = true;
     globals.cacheRemote = true;
   });

--- a/frontend/test/resolution/testCompilationGlobals.cpp
+++ b/frontend/test/resolution/testCompilationGlobals.cpp
@@ -45,8 +45,8 @@ static std::unordered_map<std::string, QualifiedType> compilationGlobalTypes(Con
   return resolveTypesOfVariables(context, allGlobalsProgram, variables);
 }
 
-static CompilationGlobals defaultGlobals() {
-  CompilationGlobals globals;
+static CompilerGlobals defaultGlobals() {
+  CompilerGlobals globals;
   // For the time being, all globals are bools so just set them to false.
   #define COMPILER_GLOBAL(TYPE__, NAME__, FIELD__) globals.FIELD__ = false;
   #include "chpl/uast/compiler-globals-list.h"
@@ -70,7 +70,7 @@ void verifyCompilerGlobals(F&& function) {
   Context* context = &ctx;
 
   // Configure the globals (including running user code to set them)
-  CompilationGlobals myGlobals = defaultGlobals();
+  CompilerGlobals myGlobals = defaultGlobals();
   function(myGlobals);
   setCompilerGlobals(context, myGlobals);
 
@@ -92,13 +92,13 @@ void verifyCompilerGlobals(F&& function) {
 static void test1() {
   // Default configuration, everything is false.
 
-  verifyCompilerGlobals([](CompilationGlobals& globals) {
+  verifyCompilerGlobals([](CompilerGlobals& globals) {
     // Do not change the globals; all should be false.
   });
 }
 
 static void test2() {
-  verifyCompilerGlobals([](CompilationGlobals& globals) {
+  verifyCompilerGlobals([](CompilerGlobals& globals) {
     globals.boundsChecking = true;
   });
 }
@@ -106,7 +106,7 @@ static void test2() {
 static void test3() {
   // Default configuration, everything is false.
 
-  verifyCompilerGlobals([](CompilationGlobals& globals) {
+  verifyCompilerGlobals([](CompilerGlobals& globals) {
     globals.boundsChecking = true;
     globals.cacheRemote = true;
   });


### PR DESCRIPTION
I noticed that the compiler flags are implemented as an input query that must be set by the user of the Dyno library. I think that the compiler globals are very similar (_and_ in production they are also set from the variables in `driver.cpp). This PR makes compiler globals be implemented in the same way that compiler flags are.

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] paratest