### PR TITLE
Remove opaque pointer usage in FileSystem.chpl

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1098,9 +1098,9 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
 */
 iter listDir(path: string = ".", hidden: bool = false, dirs: bool = true,
               files: bool = true, listlinks: bool = true): string {
-  extern record DIR {};
+  extern record DIR {}
   extern type DIRptr = c_ptr(DIR);
-  extern "struct dirent" record chpl_dirent {};
+  extern "struct dirent" record chpl_dirent {}
   extern type direntptr = c_ptr(chpl_dirent);
   extern proc opendir(name: c_string): DIRptr;
   extern proc readdir(dirp: DIRptr): direntptr;

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1098,8 +1098,10 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
 */
 iter listDir(path: string = ".", hidden: bool = false, dirs: bool = true,
               files: bool = true, listlinks: bool = true): string {
-  extern type DIRptr = c_ptr(opaque);
-  extern type direntptr = c_ptr(opaque);
+  extern record DIR {};
+  extern type DIRptr = c_ptr(DIR);
+  extern "struct dirent" record chpl_dirent {};
+  extern type direntptr = c_ptr(chpl_dirent);
   extern proc opendir(name: c_string): DIRptr;
   extern proc readdir(dirp: DIRptr): direntptr;
   extern proc closedir(dirp: DIRptr): c_int;


### PR DESCRIPTION
Changes a `c_ptr(opaque)` type definition to be a `c_ptr` to an actual concrete type in FileSystem.chpl. This resolves an issue that showed up in our nightly testing with the Intel compiler as the backend.

[Reviewed by @bradcray]