### PR TITLE
Add future for compiler segfault when overriding method gives default value to arg which didn't have one in base class

### DIFF
--- a/test/classes/override/override-making-arg-default.bad
+++ b/test/classes/override/override-making-arg-default.bad
@@ -1,0 +1,8 @@
+override-making-arg-default.chpl:9: internal error: UTI-MIS-1041 chpl version 1.31.0 pre-release (5d33cfdd5a)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler,
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/classes/override/override-making-arg-default.chpl
+++ b/test/classes/override/override-making-arg-default.chpl
@@ -1,0 +1,22 @@
+var five = 5;
+var six = 6;
+
+class C {
+  proc foo(x: int = five) { writeln("C.foo: ", x); }
+}
+
+class D : C {
+  override proc foo(x: int) { writeln("D.foo: ", x); }
+}
+
+var c = new C();
+c.foo();
+c.foo(1);
+
+var d = new D();
+d.foo();
+d.foo(2);
+
+var d2: C = new D();
+d2.foo();
+d2.foo(3);

--- a/test/classes/override/override-making-arg-default.future
+++ b/test/classes/override/override-making-arg-default.future
@@ -1,0 +1,5 @@
+bug: compiler segfault when overriding method gives default value to arg which didn't have one in base class
+#17679, #22517
+
+In #17679, there was some agreement that this shouldn't compile.
+As of #22517, it now gives a compiler segfault.

--- a/test/classes/override/override-making-arg-default.good
+++ b/test/classes/override/override-making-arg-default.good
@@ -1,0 +1,1 @@
+override-making-arg-default.chpl:9: error: D.foo override keyword present but no superclass method matches signature to override due to default value of x


### PR DESCRIPTION
Add a future for #17679 and #22517.