### PR TITLE
Include ARCHIVE DESTINATION for ChplFrontend install

### DIFF
--- a/frontend/lib/CMakeLists.txt
+++ b/frontend/lib/CMakeLists.txt
@@ -141,9 +141,13 @@ set_target_properties(ChplFrontend PROPERTIES
 if (INSTALLATION_MODE STREQUAL "prefix")
   install(TARGETS ChplFrontend
           LIBRARY DESTINATION
+          "lib/chapel/${CHPL_MAJOR_VERSION}.${CHPL_MINOR_VERSION}/compiler"
+          ARCHIVE DESTINATION
           "lib/chapel/${CHPL_MAJOR_VERSION}.${CHPL_MINOR_VERSION}/compiler")
 else()
   install(TARGETS ChplFrontend
           LIBRARY DESTINATION
+          "lib/compiler/${CHPL_HOST_BIN_SUBDIR}"
+          ARCHIVE DESTINATION
           "lib/compiler/${CHPL_HOST_BIN_SUBDIR}")
 endif()


### PR DESCRIPTION
This PR is intended to resolve a portability problem with the quickstart configuration when running in Debian Buster with no system LLVM installed. In that mode, our build system will build the LLVM Support library as a static library, and also the ChplFrontend library as a static library (to avoid mixing static/dynamic between these two -- see 02795bcf9addef2fd1d2c55e5b64983990106ef5). At the same time, with CMake version 3.13, the `ARCHIVE DESTINATION` option is required to install a static library. This PR adds it and sets it to the same location as the `LIBRARY DESTINATION`.

Reviewed by @arezaii - thanks!

- [x] full comm=none testing