### PR TITLE
Fix yaml basic-types test failure

### DIFF
--- a/modules/packages/Yaml.chpl
+++ b/modules/packages/Yaml.chpl
@@ -443,7 +443,13 @@ module Yaml {
     this.context.enter();
 
     if !this.context.inSuperClass {
-      var nb = if name.size > 0 then b"!" + name: bytes else b"";
+      // libyaml does not accept spaces in type names (e.g., "borrowed myClass")
+      var n = "";
+      if name.count(" ") > 0
+        then n = name.replace(" ", "_");
+        else n = name;
+
+      var nb = if n.size > 0 then b"!" + n: bytes else b"";
       this.emitter.startMapping(nb);
     }
   }
@@ -563,6 +569,7 @@ module Yaml {
   @chpldoc.nodoc
   proc YamlDeserializer._startMapping(reader: yamlReader, name: string) throws {
     // TODO: extract the type name from the document/mapping start and do type checking
+    //   (ensure that underscores in the type name are replaced with spaces before type-check)
 
     // start a document if we're in the base context
     if this.context.isBase

--- a/test/library/packages/Yaml/basic-types.good
+++ b/test/library/packages/Yaml/basic-types.good
@@ -138,7 +138,7 @@ SUCCESS
 ===== writing: =====
 {x = 5}
 --------------------
---- !Parent
+--- !borrowed_Parent
 x: 5
 
 ====================
@@ -152,7 +152,7 @@ SUCCESS
 ===== writing: =====
 {x = 5, y = 42.0}
 --------------------
---- !SimpleChild
+--- !borrowed_SimpleChild
 x: 5
 y: 42.0
 
@@ -167,7 +167,7 @@ SUCCESS
 ===== writing: =====
 {x = 1, y = 42.0, z = 5}
 --------------------
---- !ChildChild
+--- !borrowed_ChildChild
 x: 1
 y: 42.0
 z: 5
@@ -183,7 +183,7 @@ SUCCESS
 ===== writing: =====
 {x = 5}
 --------------------
---- !Parent
+--- !borrowed_Parent
 x: 5
 
 ====================
@@ -209,7 +209,7 @@ SUCCESS
 ===== writing: =====
 {x = 5}
 --------------------
---- !Parent
+--- !borrowed_Parent
 x: 5
 
 ====================

--- a/test/library/packages/Yaml/basic-types.notest
+++ b/test/library/packages/Yaml/basic-types.notest
@@ -1,2 +1,0 @@
-# Skip this test for tonight's testing as it seems to be failing and nobody
-# is around to help determine what ought to happen.


### PR DESCRIPTION
The `library/packages/yaml/basic-types` test was failing due to a change in the way type names are generated by the serializers api (see: https://github.com/chapel-lang/chapel/pull/22513). This failure was a post-merge interaction that was not caught in the original paratest. Specifically, the names of class types now include the management type, so output failed to match. This PR corrects the relevant `.good` file.

It is also the case that Yaml doesn't support multi word type names (like `borrowed myClass`), so the libyaml implementation was printing them out as `borrowed%20myClass`. This PR also changes the format to use an underscore instead (e.g.,`borrowed_myClass`).

- [X] yaml tests passing on local machine
- [x] paratest