### PR TITLE
Replace internal error with error message when setting config variables

### DIFF
--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -531,12 +531,10 @@ Builder::parseDummyNodeForInitExpr(Variable* var, std::string value) {
     initNode = std::move(mod->children_[0]->children_.back());
     // clean out the nullptr
     mod->children_[0]->children_.pop_back();
-  }
-  else if (mod->stmt(0)->isErroneousExpression()) {
+  } else if (mod->stmt(0)->isErroneousExpression()) {
     auto loc = Location();
     context()->error(loc, "Error while trying to set config '%s'", var->name().c_str());
-  }
-  else {
+  } else {
     CHPL_ASSERT(false && "should only be an assignment or type initializer");
   }
   return initNode;

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -493,12 +493,14 @@ AstNode* Builder::updateConfig(Variable* var, std::string configName,
   CHPL_ASSERT(!configName.empty());
   // TODO: how to handle nested module configs e.g., -sFoo.Baz.bar=10
   owned<AstNode> initNode = parseDummyNodeForInitExpr(var, configVal);
-  ret = initNode.get();
-  // create a last column value, add 1 for the initial column and 1 for the `=`
-  int lastColumn = configName.length() + configVal.length() + 2;
-  auto loc = Location(ret->id().symbolPath(), 1,1,1,lastColumn);
-  noteChildrenLocations(ret, loc);
-  addOrReplaceInitExpr(var->toVariable(), std::move(initNode));
+  if (initNode) {
+    ret = initNode.get();
+    // create a last column value, add 1 for the initial column and 1 for the `=`
+    int lastColumn = configName.length() + configVal.length() + 2;
+    auto loc = Location(ret->id().symbolPath(), 1,1,1,lastColumn);
+    noteChildrenLocations(ret, loc);
+    addOrReplaceInitExpr(var->toVariable(), std::move(initNode));
+  }
   return ret;
 }
 
@@ -529,7 +531,12 @@ Builder::parseDummyNodeForInitExpr(Variable* var, std::string value) {
     initNode = std::move(mod->children_[0]->children_.back());
     // clean out the nullptr
     mod->children_[0]->children_.pop_back();
-  } else {
+  }
+  else if (mod->stmt(0)->isErroneousExpression()) {
+    auto loc = Location();
+    context()->error(loc, "Error while trying to set config '%s'", var->name().c_str());
+  }
+  else {
     CHPL_ASSERT(false && "should only be an assignment or type initializer");
   }
   return initNode;

--- a/test/compflags/configs/stringWithSpace.chpl
+++ b/test/compflags/configs/stringWithSpace.chpl
@@ -1,0 +1,2 @@
+config var x: string = "hello";
+config var y: int = 10;

--- a/test/compflags/configs/stringWithSpace.compopts
+++ b/test/compflags/configs/stringWithSpace.compopts
@@ -1,0 +1,1 @@
+-sx="hello world"

--- a/test/compflags/configs/stringWithSpace.good
+++ b/test/compflags/configs/stringWithSpace.good
@@ -1,0 +1,2 @@
+Command-line arg (x):1: syntax error: near 'world'
+error: Error while trying to set config 'x'


### PR DESCRIPTION
When setting a `config var` string from the command line at compile time, the compiler was expecting it to compile correctly. When this was not the case, it would abort with an internal error.

Specifically, passing `-sx="hello world"` would fail, since the quotes would be eaten by the shell and the compiler would then see `-sx=hello world`, which would incorrectly be parsed and compiled.

## Summary of changes
- adds a check to `Builder::parseDummyNodeForInitExpr` which checks for an `ErroneousExpression`

## New Tests
- `test/compflags/configs/stringWithSpace.chpl`

## Testing
- paratest

[Reviewed by @mppf]