### PR TITLE
Resolve a problem using system clang on Alpine linux

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -480,6 +480,10 @@ def get_system_llvm_clang(lang):
             clang_path = clang_name + suffix
             if prefix is not None:
                 clang_path = os.path.join(prefix, clang_path)
+            # Use the full path to clang. For some reason, this is important
+            # on Alpine Linux for clang to find its own standard lib headers.
+            if '/' not in clang_path:
+                clang_path = which(clang_path)
             if is_system_clang_version_ok(clang_path):
                 return clang_path
     return ''


### PR DESCRIPTION
We were seeing errors along the lines of

    fatal error: 'stdatomic.h' file not found

These appeared after PR #22454 which changed the printchplenv logic to compute CHPL_LLVM_CLANG_C etc as 'clang' rather than '/usr/bin/clang' on this platform. For some reason, using clang as a library without the full path causes it to miss adding a system include path. So, this PR just adjusts the clang search process to run 'which' if it doesn't already have a directory component.

Reviewed by @DanilaFe - thanks!

- [x] full comm=none testing