### PR TITLE
Untrack output files created by IO tests

### DIFF
--- a/test/deprecated/IO/.gitignore
+++ b/test/deprecated/IO/.gitignore
@@ -7,3 +7,4 @@ wrb.txt
 fileWriterHigh.txt
 wb.txt
 test.bin
+filePtrTest.txt

--- a/test/deprecated/IO/filePtrTest.txt
+++ b/test/deprecated/IO/filePtrTest.txt
@@ -1,1 +1,0 @@
-Hello, World!

--- a/test/library/standard/IO/.gitignore
+++ b/test/library/standard/IO/.gitignore
@@ -4,3 +4,4 @@ fileWriterLimited.txt
 fileWriterBadRegion.txt
 writeBinary/*.bin
 writeStringAndBytes/*.txt
+outOfRange.txt

--- a/test/library/standard/IO/outOfRange.txt
+++ b/test/library/standard/IO/outOfRange.txt
@@ -1,1 +1,0 @@
-blahblah


### PR DESCRIPTION
Remove some output files created by IO tests that don't need to be tracked:

- test/library/standard/IO/outOfRange.txt
- test/deprecated/IO/filePtrTest.txt

testing:
- [x] paratest