### PR TITLE
Improve error message for `c_FILE` pointer deprecation

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -68,7 +68,7 @@ module CTypes {
   /* Chapel type alias for a C ``FILE`` */
   proc c_FILE type {
     if cFileTypeHasPointer {
-      compilerWarning("in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.");
+      compilerWarning("in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Wrap instances of 'c_FILE' with 'c_ptr()' and recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.");
       return chpl_cFilePtr;
     } else {
       return chpl_cFile;

--- a/test/deprecated/IO/cFileWithPtr.good
+++ b/test/deprecated/IO/cFileWithPtr.good
@@ -1,7 +1,7 @@
 cFileWithPtr.chpl:3: In function 'fopen':
-cFileWithPtr.chpl:3: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
+cFileWithPtr.chpl:3: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Wrap instances of 'c_FILE' with 'c_ptr()' and recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
 cFileWithPtr.chpl:4: In function 'fwrite':
-cFileWithPtr.chpl:4: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
+cFileWithPtr.chpl:4: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Wrap instances of 'c_FILE' with 'c_ptr()' and recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
 cFileWithPtr.chpl:5: In function 'fclose':
-cFileWithPtr.chpl:5: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
+cFileWithPtr.chpl:5: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Wrap instances of 'c_FILE' with 'c_ptr()' and recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
 Hello, World!


### PR DESCRIPTION
This PR improves the error message for the `c_FILE` behavior deprecation s.t. users will be less likely to run into the error described here: https://github.com/chapel-lang/chapel/issues/22492 when transitioning to the new behavior.

Specifically, it indicates that instances of `c_FILE` will need to be wrapped in `c_ptr` with the new behavior in order to correctly represent a `FILE*`.

- [x] paratest

