### PR TITLE
Update portability testing 1.31

### DIFF
--- a/util/devel/test/apptainer/chapel-branch.sh
+++ b/util/devel/test/apptainer/chapel-branch.sh
@@ -16,4 +16,4 @@ fi
 
 echo "Checking out github branch $GITHUB_USER/$GITHUB_BRANCH"
 
-./tryit.sh ../../provision-scripts/chapel-branch.sh "$GITHUB_USER" "$GITHUB_BRANCH"
+./tryit.py ../../provision-scripts/chapel-branch.sh "$GITHUB_USER" "$GITHUB_BRANCH"

--- a/util/devel/test/apptainer/chapel-default.sh
+++ b/util/devel/test/apptainer/chapel-default.sh
@@ -3,4 +3,8 @@
 # Checks if a default build basses make check
 # Prints a summary at the end.
 
-./tryit.sh ../../provision-scripts/chapel-default.sh
+# apptainer forwards env vars to container by default, so unset
+# CHPL_DEVELOPER b/c it can change warning behavior
+unset CHPL_DEVELOPER
+
+./tryit.py --skip-nollvm ../../provision-scripts/chapel-default.sh

--- a/util/devel/test/apptainer/chapel-quickstart-delete.sh
+++ b/util/devel/test/apptainer/chapel-quickstart-delete.sh
@@ -3,4 +3,8 @@
 # Checks if a Quickstart build basses make check
 # Prints a summary at the end.
 
-./tryit-jenkins.sh ../../provision-scripts/chapel-quickstart.sh
+# apptainer forwards env vars to container by default, so unset
+# CHPL_DEVELOPER b/c it can change warning behavior
+unset CHPL_DEVELOPER
+
+./tryit.py --cleanup ../../provision-scripts/chapel-quickstart.sh

--- a/util/devel/test/apptainer/chapel-quickstart.sh
+++ b/util/devel/test/apptainer/chapel-quickstart.sh
@@ -3,4 +3,8 @@
 # Checks if a Quickstart build basses make check
 # Prints a summary at the end.
 
-./tryit.sh ../../provision-scripts/chapel-quickstart.sh
+# apptainer forwards env vars to container by default, so unset
+# CHPL_DEVELOPER b/c it can change warning behavior
+unset CHPL_DEVELOPER
+
+./tryit.py ../../provision-scripts/chapel-quickstart.sh

--- a/util/devel/test/apptainer/chapel-showcommit.sh
+++ b/util/devel/test/apptainer/chapel-showcommit.sh
@@ -2,4 +2,4 @@
 
 # Shows the commit on each image.
 
-./tryit.sh ../../provision-scripts/chapel-showcommit.sh
+./tryit.py ../../provision-scripts/chapel-showcommit.sh

--- a/util/devel/test/apptainer/chapel-update.sh
+++ b/util/devel/test/apptainer/chapel-update.sh
@@ -3,4 +3,4 @@
 # Updates the chapel checkout to be 'main' (makes sure it exists)
 # Prints a summary at the end.
 
-./tryit.sh ../../provision-scripts/chapel-update.sh
+./tryit.py ../../provision-scripts/chapel-update.sh

--- a/util/devel/test/apptainer/current/almalinux-8-nollvm/image.def
+++ b/util/devel/test/apptainer/current/almalinux-8-nollvm/image.def
@@ -8,4 +8,4 @@ From: almalinux:8
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/almalinux-8/image.def
+++ b/util/devel/test/apptainer/current/almalinux-8/image.def
@@ -9,4 +9,4 @@ From: almalinux:8
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/almalinux-9.0-nollvm/image.def
+++ b/util/devel/test/apptainer/current/almalinux-9.0-nollvm/image.def
@@ -8,4 +8,4 @@ From: almalinux:9.0
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/almalinux-9.0/image.def
+++ b/util/devel/test/apptainer/current/almalinux-9.0/image.def
@@ -9,4 +9,4 @@ From: almalinux:9.0
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/almalinux-9.1-nollvm/image.def
+++ b/util/devel/test/apptainer/current/almalinux-9.1-nollvm/image.def
@@ -8,4 +8,4 @@ From: almalinux:9.1
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/almalinux-9.1/image.def
+++ b/util/devel/test/apptainer/current/almalinux-9.1/image.def
@@ -9,4 +9,4 @@ From: almalinux:9.1
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/almalinux-9.2-nollvm/image.def
+++ b/util/devel/test/apptainer/current/almalinux-9.2-nollvm/image.def
@@ -1,0 +1,11 @@
+BootStrap: docker
+From: almalinux:9.2
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/dnf-deps.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/almalinux-9.2/image.def
+++ b/util/devel/test/apptainer/current/almalinux-9.2/image.def
@@ -1,0 +1,13 @@
+BootStrap: docker
+From: almalinux:9.2
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/dnf-deps.sh
+    # installs llvm/clang 15
+    /provision-scripts/dnf-llvm.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/alpine-3.15-nollvm/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.15-nollvm/image.def
@@ -8,4 +8,4 @@ From: alpine:3.15
     /provision-scripts/apk-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/alpine-3.15/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.15/image.def
@@ -10,4 +10,4 @@ From: alpine:3.15
     /provision-scripts/apk-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/alpine-3.17-nollvm/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.17-nollvm/image.def
@@ -8,4 +8,4 @@ From: alpine:3.17
     /provision-scripts/apk-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/alpine-3.17/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.17/image.def
@@ -10,4 +10,4 @@ From: alpine:3.17
     /provision-scripts/apk-llvm14.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/alpine-3.17/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.17/image.def
@@ -7,7 +7,7 @@ From: alpine:3.17
 %post
     /provision-scripts/apk-deps.sh
     # default llvm/clang version is 15
-    /provision-scripts/apk-llvm14.sh
+    /provision-scripts/apk-llvm.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/alpine-3.18-nollvm/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.18-nollvm/image.def
@@ -1,0 +1,11 @@
+BootStrap: docker
+From: alpine:3.17
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/apk-deps.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/alpine-3.18/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.18/image.def
@@ -1,0 +1,13 @@
+BootStrap: docker
+From: alpine:3.18
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/apk-deps.sh
+    # default llvm/clang version is 16
+    /provision-scripts/apk-llvm15.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/amazonlinux-2-nollvm/image.def
+++ b/util/devel/test/apptainer/current/amazonlinux-2-nollvm/image.def
@@ -9,4 +9,4 @@ From: amazonlinux:2
     /provision-scripts/yum-deps-amazonlinux-2.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/amazonlinux-2/image.def
+++ b/util/devel/test/apptainer/current/amazonlinux-2/image.def
@@ -11,4 +11,4 @@ From: amazonlinux:2
     yum -y install llvm-devel clang clang-devel
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/amazonlinux-2023-nollvm/image.def
+++ b/util/devel/test/apptainer/current/amazonlinux-2023-nollvm/image.def
@@ -9,4 +9,4 @@ From: amazonlinux:2023
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/amazonlinux-2023/image.def
+++ b/util/devel/test/apptainer/current/amazonlinux-2023/image.def
@@ -11,4 +11,4 @@ From: amazonlinux:2023
     dnf -y install clang clang-devel llvm-devel
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/arch-nollvm/image.def
+++ b/util/devel/test/apptainer/current/arch-nollvm/image.def
@@ -8,4 +8,4 @@ From: archlinux:base-devel
     /provision-scripts/pacman-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/arch/image.def
+++ b/util/devel/test/apptainer/current/arch/image.def
@@ -9,4 +9,4 @@ From: archlinux:base-devel
     /provision-scripts/pacman-llvm14.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/centos-stream-8-nollvm/image.def
+++ b/util/devel/test/apptainer/current/centos-stream-8-nollvm/image.def
@@ -8,4 +8,4 @@ From: quay.io/centos/centos:stream8
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/centos-stream-8/image.def
+++ b/util/devel/test/apptainer/current/centos-stream-8/image.def
@@ -6,8 +6,8 @@ From: quay.io/centos/centos:stream8
 
 %post
     /provision-scripts/dnf-deps.sh
-    # installing llvm-devel installs LLVM 15 so opt in to 14
-    /provision-scripts/dnf-llvm-14.sh
+    # installing llvm-devel installs LLVM 15
+    /provision-scripts/dnf-llvm.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/centos-stream-8/image.def
+++ b/util/devel/test/apptainer/current/centos-stream-8/image.def
@@ -10,4 +10,4 @@ From: quay.io/centos/centos:stream8
     /provision-scripts/dnf-llvm-14.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/centos-stream-9-nollvm/image.def
+++ b/util/devel/test/apptainer/current/centos-stream-9-nollvm/image.def
@@ -8,4 +8,4 @@ From: quay.io/centos/centos:stream9
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/centos-stream-9/image.def
+++ b/util/devel/test/apptainer/current/centos-stream-9/image.def
@@ -6,9 +6,8 @@ From: quay.io/centos/centos:stream9
 
 %post
     /provision-scripts/dnf-deps.sh
-    # installing llvm-devel installs LLVM 15
-    # opt in to LLVM 14 until that is supported.
-    /provision-scripts/dnf-llvm-14.sh
+    # installing llvm-devel installs LLVM 16
+    /provision-scripts/dnf-llvm-15.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/centos-stream-9/image.def
+++ b/util/devel/test/apptainer/current/centos-stream-9/image.def
@@ -11,4 +11,4 @@ From: quay.io/centos/centos:stream9
     /provision-scripts/dnf-llvm-14.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/debian-bookworm-nollvm/image.def
+++ b/util/devel/test/apptainer/current/debian-bookworm-nollvm/image.def
@@ -10,4 +10,4 @@ From: debian:bookworm
     /provision-scripts/apt-get-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/debian-bookworm-nollvm/image.def
+++ b/util/devel/test/apptainer/current/debian-bookworm-nollvm/image.def
@@ -6,8 +6,6 @@ From: debian:bookworm
 
 %post
     /provision-scripts/apt-get-deps.sh
-    # installs LLVM 11 and llvm-11-tools
-    /provision-scripts/apt-get-llvm.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/debian-bookworm/image.def
+++ b/util/devel/test/apptainer/current/debian-bookworm/image.def
@@ -6,7 +6,7 @@ From: debian:bookworm
 
 %post
     /provision-scripts/apt-get-deps.sh
-    # installs LLVM 11 and llvm-11-tools
+    # installs LLVM 14
     /provision-scripts/apt-get-llvm.sh
 
 %runscript

--- a/util/devel/test/apptainer/current/debian-bookworm/image.def
+++ b/util/devel/test/apptainer/current/debian-bookworm/image.def
@@ -10,4 +10,4 @@ From: debian:bookworm
     /provision-scripts/apt-get-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/debian-bullseye-nollvm/image.def
+++ b/util/devel/test/apptainer/current/debian-bullseye-nollvm/image.def
@@ -8,4 +8,4 @@ From: debian:bullseye
     /provision-scripts/apt-get-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/debian-bullseye/image.def
+++ b/util/devel/test/apptainer/current/debian-bullseye/image.def
@@ -10,4 +10,4 @@ From: debian:bullseye
     /provision-scripts/apt-get-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/debian-buster-nollvm/image.def
+++ b/util/devel/test/apptainer/current/debian-buster-nollvm/image.def
@@ -8,4 +8,4 @@ From: debian:buster
     /provision-scripts/apt-get-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/debian-buster/image.def
+++ b/util/devel/test/apptainer/current/debian-buster/image.def
@@ -6,7 +6,7 @@ From: debian:buster
 
 %post
     /provision-scripts/apt-get-deps.sh
-    /provision-scripts/apt-get-llvm-11.sh
+    /provision-scripts/apt-get-llvm-13.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/debian-buster/image.def
+++ b/util/devel/test/apptainer/current/debian-buster/image.def
@@ -9,4 +9,4 @@ From: debian:buster
     /provision-scripts/apt-get-llvm-11.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-34-nollvm/image.def
+++ b/util/devel/test/apptainer/current/fedora-34-nollvm/image.def
@@ -8,4 +8,4 @@ From: fedora:34
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-34/image.def
+++ b/util/devel/test/apptainer/current/fedora-34/image.def
@@ -10,4 +10,4 @@ From: fedora:34
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-35-nollvm/image.def
+++ b/util/devel/test/apptainer/current/fedora-35-nollvm/image.def
@@ -8,4 +8,4 @@ From: fedora:35
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-35/image.def
+++ b/util/devel/test/apptainer/current/fedora-35/image.def
@@ -10,4 +10,4 @@ From: fedora:35
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-36-nollvm/image.def
+++ b/util/devel/test/apptainer/current/fedora-36-nollvm/image.def
@@ -8,4 +8,4 @@ From: fedora:36
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-36/image.def
+++ b/util/devel/test/apptainer/current/fedora-36/image.def
@@ -10,4 +10,4 @@ From: fedora:36
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-37-nollvm/image.def
+++ b/util/devel/test/apptainer/current/fedora-37-nollvm/image.def
@@ -8,4 +8,4 @@ From: fedora:37
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-37/image.def
+++ b/util/devel/test/apptainer/current/fedora-37/image.def
@@ -11,4 +11,4 @@ From: fedora:37
     # though there are llvm14-devel and clang14-devel
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-37/image.def
+++ b/util/devel/test/apptainer/current/fedora-37/image.def
@@ -6,9 +6,8 @@ From: fedora:37
 
 %post
     /provision-scripts/dnf-deps.sh
-    # installing llvm-devel installs LLVM 15,
-    # clang14 package seems to be missing even
-    # though there are llvm14-devel and clang14-devel
+    # installing llvm-devel installs LLVM 15
+    /provision-scripts/dnf-llvm.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-38-nollvm/image.def
+++ b/util/devel/test/apptainer/current/fedora-38-nollvm/image.def
@@ -11,4 +11,4 @@ From: fedora:38
     # though there are llvm14 etc
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-38/image.def
+++ b/util/devel/test/apptainer/current/fedora-38/image.def
@@ -11,4 +11,4 @@ From: fedora:38
     # though there are llvm14 etc
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-38/image.def
+++ b/util/devel/test/apptainer/current/fedora-38/image.def
@@ -6,9 +6,9 @@ From: fedora:38
 
 %post
     /provision-scripts/dnf-deps.sh
-    # installing llvm-devel installs LLVM 15,
-    # clang14 package seems to be missing even
-    # though there are llvm14 etc
+    # installing llvm-devel installs LLVM 16
+    # and I dont see how to install clang 15
+    #/provision-scripts/dnf-llvm15.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-39-nollvm/image.def
+++ b/util/devel/test/apptainer/current/fedora-39-nollvm/image.def
@@ -1,0 +1,14 @@
+BootStrap: docker
+From: quay.io/fedora/fedora:39
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/dnf-deps.sh
+    # installing llvm-devel installs LLVM 15,
+    # clang14 package seems to be missing even
+    # though there are llvm14 etc
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-39/image.def
+++ b/util/devel/test/apptainer/current/fedora-39/image.def
@@ -1,0 +1,14 @@
+BootStrap: docker
+From: quay.io/fedora/fedora:39
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/dnf-deps.sh
+    # installing llvm-devel installs LLVM 15,
+    # clang14 package seems to be missing even
+    # though there are llvm14 etc
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-39/image.def
+++ b/util/devel/test/apptainer/current/fedora-39/image.def
@@ -6,9 +6,9 @@ From: quay.io/fedora/fedora:39
 
 %post
     /provision-scripts/dnf-deps.sh
-    # installing llvm-devel installs LLVM 15,
-    # clang14 package seems to be missing even
-    # though there are llvm14 etc
+    # installing llvm-devel installs LLVM 16
+    # and I dont see how to install clang 15
+    #/provision-scripts/dnf-llvm.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/opensuse-leap-15.3-nollvm/image.def
+++ b/util/devel/test/apptainer/current/opensuse-leap-15.3-nollvm/image.def
@@ -8,4 +8,4 @@ From: opensuse/leap:15.3
     /provision-scripts/zypper-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/opensuse-leap-15.3/image.def
+++ b/util/devel/test/apptainer/current/opensuse-leap-15.3/image.def
@@ -10,4 +10,4 @@ From: opensuse/leap:15.3
     /provision-scripts/zypper-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/opensuse-leap-15.4-nollvm/image.def
+++ b/util/devel/test/apptainer/current/opensuse-leap-15.4-nollvm/image.def
@@ -8,4 +8,4 @@ From: opensuse/leap:15.4
     /provision-scripts/zypper-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/opensuse-leap-15.4/image.def
+++ b/util/devel/test/apptainer/current/opensuse-leap-15.4/image.def
@@ -10,4 +10,4 @@ From: opensuse/leap:15.4
     /provision-scripts/zypper-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/opensuse-leap-15.5-nollvm/image.def
+++ b/util/devel/test/apptainer/current/opensuse-leap-15.5-nollvm/image.def
@@ -1,0 +1,11 @@
+BootStrap: docker
+From: opensuse/leap:15.5
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/zypper-deps.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/opensuse-leap-15.5/image.def
+++ b/util/devel/test/apptainer/current/opensuse-leap-15.5/image.def
@@ -1,0 +1,13 @@
+BootStrap: docker
+From: opensuse/leap:15.5
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/zypper-deps.sh
+    # leap 15.5 defaults to LLVM/clang 15
+    /provision-scripts/zypper-llvm.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/rockylinux-8-nollvm/image.def
+++ b/util/devel/test/apptainer/current/rockylinux-8-nollvm/image.def
@@ -8,4 +8,4 @@ From: rockylinux:8
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/rockylinux-8/image.def
+++ b/util/devel/test/apptainer/current/rockylinux-8/image.def
@@ -9,4 +9,4 @@ From: rockylinux:8
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/rockylinux-9.0-nollvm/image.def
+++ b/util/devel/test/apptainer/current/rockylinux-9.0-nollvm/image.def
@@ -8,4 +8,4 @@ From: rockylinux:9.0
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/rockylinux-9.0/image.def
+++ b/util/devel/test/apptainer/current/rockylinux-9.0/image.def
@@ -9,4 +9,4 @@ From: rockylinux:9.0
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/rockylinux-9.1-nollvm/image.def
+++ b/util/devel/test/apptainer/current/rockylinux-9.1-nollvm/image.def
@@ -8,4 +8,4 @@ From: rockylinux:9.1
     /provision-scripts/dnf-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/rockylinux-9.1/image.def
+++ b/util/devel/test/apptainer/current/rockylinux-9.1/image.def
@@ -9,4 +9,4 @@ From: rockylinux:9.1
     /provision-scripts/dnf-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/rockylinux-9.2-nollvm/image.def
+++ b/util/devel/test/apptainer/current/rockylinux-9.2-nollvm/image.def
@@ -1,0 +1,11 @@
+BootStrap: docker
+From: rockylinux:9.2
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/dnf-deps.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/rockylinux-9.2/image.def
+++ b/util/devel/test/apptainer/current/rockylinux-9.2/image.def
@@ -1,0 +1,13 @@
+BootStrap: docker
+From: rockylinux:9.2
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/dnf-deps.sh
+    # installs LLVM / clang 15
+    /provision-scripts/dnf-llvm.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/ubuntu-focal-nollvm/image.def
+++ b/util/devel/test/apptainer/current/ubuntu-focal-nollvm/image.def
@@ -13,4 +13,4 @@ From: ubuntu:focal
     /provision-scripts/apt-get-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/ubuntu-focal/image.def
+++ b/util/devel/test/apptainer/current/ubuntu-focal/image.def
@@ -14,4 +14,4 @@ From: ubuntu:focal
     /provision-scripts/apt-get-llvm-12.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/ubuntu-jammy-nollvm/image.def
+++ b/util/devel/test/apptainer/current/ubuntu-jammy-nollvm/image.def
@@ -8,4 +8,4 @@ From: ubuntu:jammy
     /provision-scripts/apt-get-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/ubuntu-jammy/image.def
+++ b/util/devel/test/apptainer/current/ubuntu-jammy/image.def
@@ -10,4 +10,4 @@ From: ubuntu:jammy
     /provision-scripts/apt-get-llvm.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/ubuntu-kinetic-nollvm/image.def
+++ b/util/devel/test/apptainer/current/ubuntu-kinetic-nollvm/image.def
@@ -8,4 +8,4 @@ From: ubuntu:kinetic
     /provision-scripts/apt-get-deps.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/ubuntu-kinetic/image.def
+++ b/util/devel/test/apptainer/current/ubuntu-kinetic/image.def
@@ -10,4 +10,4 @@ From: ubuntu:kinetic
     /provision-scripts/apt-get-llvm-14.sh
 
 %runscript
-    ../../provision-scripts/run.sh
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/extract-docs.py
+++ b/util/devel/test/apptainer/extract-docs.py
@@ -140,9 +140,11 @@ for d in directories:
         if "homebrew" in subpath:
             continue # skip these configurations
                      # (not sure how useful this is)
+        if "nix" in subpath:
+            continue # skip these configurations
+                     # (not sure how useful this is)
         if ("fedora-38" in subpath or
-            "fedora-37" in subpath or
-            "amazonlinux-2023" in subpath):
+            "fedora-39" in subpath):
             continue # skip due to not having working LLVM dependency right now
         if "generic-x32-debian11" in subpath:
             continue # skip this one, redudant with other debian ones

--- a/util/devel/test/apptainer/tryit.py
+++ b/util/devel/test/apptainer/tryit.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+""" Runs a command (or series of commands) on all the images.
+    Prints a summary of the output at the end.
+    Saves all of the command output in a file called 'log'. """
+
+import argparse, glob, os, subprocess, shutil
+
+def gatherDirs():
+    dirs = [ ]
+    for d in glob.glob('current/*'):
+        if os.path.exists(os.path.join(d, 'image.def')):
+            dirs.append(d)
+    dirs.sort()
+    return dirs
+
+def dirNameToConfigName(d):
+    return os.path.basename(d.rstrip('/'))
+
+def printAndLog(log, s):
+    print(s)
+    print(s, file=log)
+
+# Returns a tuple consisting of (exit code, last line)
+def runAndLog(log, command):
+    printAndLog(log, "Running command: {}\n".format(" ".join(command)))
+    try:
+        p = subprocess.Popen(command,
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                             encoding='utf-8')
+        lastline = ""
+        while p.poll() is None:
+            line = p.stdout.readline()
+            if line:
+                line = line.strip()
+                printAndLog(log, line)
+                if line and not line.startswith("INFO"):
+                    lastline = line
+        return (p.returncode, lastline)
+    except OSError:
+        return (-1, "")
+
+def main():
+    parser = argparse.ArgumentParser(
+            description='Run a command on all the images.')
+    parser.add_argument('--cleanup', dest='cleanup', action='store_true',
+                        help='delete each image and checkout after using it')
+    parser.add_argument('--rebuild', dest='rebuild', action='store_true',
+                        help='rebuild each image before running it')
+    parser.add_argument('--only', dest='only', action='store',
+                        help='only run one configuration')
+    parser.add_argument('command', nargs='+', help='command to run')
+
+    args = parser.parse_args()
+
+    logpath = 'log'
+
+    startDir = os.getcwd()
+
+    status = { }
+
+    with open(logpath, 'w', encoding="utf-8") as log:
+        dirs = gatherDirs()
+        if args.only != None:
+            dirs = [ args.only ]
+
+        # compute the longest length for padding
+        maxNameLen = 0
+        for d in dirs:
+            name = dirNameToConfigName(d)
+            if len(name) > maxNameLen:
+                maxNameLen = len(name)
+
+        for d in dirs:
+            name = dirNameToConfigName(d)
+
+            os.chdir(d)
+            printAndLog(log,
+                        "     ---- " + name + " ---- ")
+
+            statusline = ""
+            ok = True
+            # Build/rebuild image.sif if needed
+            if os.path.exists("image.sif") and args.rebuild:
+                printAndLog(log, "Removing {}/image.sif".format(d));
+                os.remove("image.sif")
+            if not os.path.exists("image.sif"):
+                e,r = runAndLog(log, ["apptainer", "build", "--fakeroot",
+                                "image.sif", "image.def"])
+                if e != 0 or not os.path.exists("image.sif"):
+                    statusline = "IMAGE BUILD FAILURE: " + r
+                    ok = False
+                    print("    Image build failure: you might want to run\n" +
+                          "        cd " + d + "\n" +
+                          "        apptainer build --fakeroot image.sif image.def\n")
+
+
+            # Run the command in the image
+            if ok:
+                e,r = runAndLog(log,
+                                ["apptainer", "run", "image.sif"] +
+                                args.command)
+                if e == 0:
+                    statusline = "OK: " + r
+                else:
+                    statusline = "FAIL: " + r
+                    ok = False
+                    print("    Failure: you might want to run\n" +
+                          "        cd " + d + "\n" +
+                          "        apptainer shell image.sif\n" +
+                          "        " + " ".join(args.command))
+
+            status[name] = statusline
+
+            if args.cleanup:
+                printAndLog(log, "Removing {}/image.sif".format(d));
+                os.remove("image.sif")
+                printAndLog(log, "Removing {}/chapel".format(d));
+                shutil.rmtree("chapel")
+
+            printAndLog(log, "")
+            os.chdir(startDir)
+
+        # Print out the status summary.
+        printAndLog(log, "     -------- SUMMARY --------")
+
+        for d in dirs:
+            name = dirNameToConfigName(d)
+            paddedName = name.rjust(maxNameLen)
+            printAndLog(log, paddedName + ": " + status[name])
+
+
+if __name__ == '__main__':
+    main()

--- a/util/devel/test/apptainer/x_problems/nix-os/image.def
+++ b/util/devel/test/apptainer/x_problems/nix-os/image.def
@@ -1,0 +1,20 @@
+BootStrap: docker
+From: nixos/nix:2.16.1
+
+# This tests the latest version of Nix and packages
+# We could lock it down to a NixOS release above and
+# use a lock file below if we want to control when
+# the dependencies are updated.
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    echo "updating /etc/nix/nix.conf"
+    echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf
+
+    mkdir /chpl-nix-deps
+    cd /chpl-nix-deps
+    cp /provision-scripts/chpl-nix-deps.nix flake.nix
+
+    nix print-dev-env --accept-flake-config < /dev/null > activate.sh

--- a/util/devel/test/vagrant/README-distro-timelines.txt
+++ b/util/devel/test/vagrant/README-distro-timelines.txt
@@ -138,7 +138,7 @@ x 18.10 "Cosmic Cuttlefish" EOL July 2019
 x 19.04 "Disco Dingo"       EOL Jan 2020
 x 19.10 "Eoan Ermine"       EOL July 2020
 x 20.10 "Groovy Gorilla"    EOL July 2021
-x 21.04 "Hirsute Hippo"     EOL January 2022
+x 21.04 "Hirsute Hippo"     EOL Jan 2022
 x 21.10 "Impish Indri"      EOL July 2022
   22.10 "Kinetic Kudu"      EOL July 2023
-  23.04 "Lunar Lobster"     expected release in April 2023
+  23.04 "Lunar Lobster"     EOL Jan 2024

--- a/util/devel/test/vagrant/README-distro-timelines.txt
+++ b/util/devel/test/vagrant/README-distro-timelines.txt
@@ -7,19 +7,22 @@ Alpine Linux -- see https://www.alpinelinux.org/releases/
   3.15  EOL 2023-11-01
   3.16  EOL 2024-05-23
   3.17  EOL 2024-11-22
+  3.18  EOL 2025-05-09
 
 Alma Linux -- see https://en.wikipedia.org/wiki/AlmaLinux
+           -- EOL dates probably match Rocky linux
   8   - EOL May 2029
   9   - EOL 2032?
   9.0 - EOL May 2032
   9.1 - EOL ?
+  9.2 - EOL ?
 
 Amazon Linux
        -- see https://docs.aws.amazon.com/linux/al2022/ug/release-cadence.html
        -- which has 2 years of standard support, 3 of maintenance
   2    EOL June 30, 2025
   2022 was renamed to 2023 in March 2023
-  2023 to be released in 2023 ?
+  2023 released March 2023
 
 CentOS -- see https://wiki.centos.org/About/Product
 x 5 full updates until Jan 2014, maintenance until Mar 2017
@@ -51,7 +54,7 @@ x 8 "jessie"   long-term support until May 2020
 x 9 "stretch"  long-term support until Jun 2022
  10 "buster"   long-term support until Jun 2024
  11 "bullseye" long-term support until Jun 2026
- 12 "bookworm" expected release June 2023
+ 12 "bookworm" released June 2023
  13 "trixie"   expected release ?
  14 "forky"    expected release ?
 
@@ -75,7 +78,7 @@ x 35 EOL Dec 2022
   36 EOL May 2023
   37 EOL Nov 2023
   38 EOL May 2024
-  39 EOL Nov 2024
+  39 to be released Oct 2023 -- EOL Nov 2024
 
 FreeBSD -- see https://www.freebsd.org/security/unsupported.html
         -- and https://app.vagrantup.com/freebsd
@@ -96,7 +99,7 @@ x 12.3 EOL Mar 2023
   12.4 EOL Dec 2023
 x 13.0 EOL Aug 2022
   13.1
-  13.2 not released yet
+  13.2
   14.0 not released yet
 
 OpenSuse -- see https://en.opensuse.org/Lifetime
@@ -111,11 +114,14 @@ x 15.1 EOL Nov 2020
 x 15.2 EOL Dec 2021
 x 15.3 EOL Nov 2022
   15.4 EOL Nov 2023
+  15.5 EOL Nov 2024
 
-Rocky Linux
+Rocky Linux -- see https://wiki.rockylinux.org/rocky/version/
   8   - EOL May 2029
-  9.0 - EOL May 2032
-  9.1 - EOL May 2032
+  9   - EOL May 2032
+  9.0 - EOL Nov 2022
+  9.1 - EOL May 2023
+  9.2 - EOL Nov 2023
 
 Ubuntu -- see https://wiki.ubuntu.com/Releases
        -- and https://app.vagrantup.com/ubuntu

--- a/util/devel/test/vagrant/current/freebsd-FreeBSD-13.2-STABLE/Vagrantfile
+++ b/util/devel/test/vagrant/current/freebsd-FreeBSD-13.2-STABLE/Vagrantfile
@@ -1,0 +1,35 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "freebsd/FreeBSD-13.2-STABLE"
+
+  # needs more disk space
+  # have to use this for it to work:
+  # export VAGRANT_EXPERIMENTAL="disks"
+  config.vm.disk :disk, size: "12GB", primary: true
+
+  config.vm.provision "shell",
+    path: "../../provision-scripts/freebsd-pkg-deps.sh"
+
+  # It comes with clang 15 and pkg install llvm installs 15,
+  # but 11 - 16 are available.
+  config.vm.provision "shell",
+    path: "../../provision-scripts/freebsd-pkg-llvm.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../../provision-scripts/gmake-chapel-quick.sh"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 4096
+    #vb.cpus = 2
+  end
+
+end

--- a/util/devel/test/vagrant/current/ubuntu-jammy-nix/Vagrantfile
+++ b/util/devel/test/vagrant/current/ubuntu-jammy-nix/Vagrantfile
@@ -1,0 +1,32 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/jammy64"
+
+  config.vm.provision "file",
+    source: "../../provision-scripts/chpl-nix-deps.nix",
+    destination: "chpl-nix-deps.nix"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../../provision-scripts/apt-get-and-nix-install-1.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../../provision-scripts/apt-get-and-nix-install-2.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../../provision-scripts/git-clone-chapel.sh"
+
+  config.vm.provision "shell", privileged: false,
+    path: "../../provision-scripts/make-chapel-quick.sh"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 8192
+    vb.cpus = 4
+  end
+
+end

--- a/util/devel/test/vagrant/provision-scripts/apk-llvm.sh
+++ b/util/devel/test/vagrant/provision-scripts/apk-llvm.sh
@@ -2,5 +2,6 @@
 
 # and LLVM stuff
 # llvm 12 is the newest available on 3.15
+# llvm 15 is the newest available on 3.17
 # llvm-static / clang-static are here to work around a cmake issue
 apk add llvm-dev clang-dev clang-static llvm-static

--- a/util/devel/test/vagrant/provision-scripts/apk-llvm14.sh
+++ b/util/devel/test/vagrant/provision-scripts/apk-llvm14.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-apk add llvm14-dev clang14-dev

--- a/util/devel/test/vagrant/provision-scripts/apk-llvm15.sh
+++ b/util/devel/test/vagrant/provision-scripts/apk-llvm15.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# static packages avoid a problem with cmaking
+apk add llvm15-dev clang15-dev llvm15-static clang15-static

--- a/util/devel/test/vagrant/provision-scripts/apt-get-and-nix-install-1.sh
+++ b/util/devel/test/vagrant/provision-scripts/apt-get-and-nix-install-1.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Note, this is not run all as root, so use sudo where needed
+
+sudo apt-get update
+
+sh <(curl -L https://nixos.org/nix/install) --daemon --yes
+
+sudo bash -c "echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf"

--- a/util/devel/test/vagrant/provision-scripts/apt-get-and-nix-install-2.sh
+++ b/util/devel/test/vagrant/provision-scripts/apt-get-and-nix-install-2.sh
@@ -6,7 +6,14 @@
 mkdir chpl-nix-deps
 cp chpl-nix-deps.nix chpl-nix-deps/flake.nix
 cd chpl-nix-deps
-bash -c 'nix print-dev-env --accept-flake-config < /dev/null >> activate.sh'
+bash -c 'nix print-dev-env --accept-flake-config < /dev/null > activate.sh'
+
+# add code to append includes to compiler command
+# these includes are necessary to avoid problems not finding sys/types.h
+# which is actually defined by clang itself.
+# TODO: is there a better way to handle this on nix?
+echo 'export CHPL_TARGET_CC="$CHPL_TARGET_CC $CHPL_CLANG_INCLUDES"' >> activate.sh
+echo 'export CHPL_TARGET_CXX="$CHPL_TARGET_CXX $CHPL_CLANG_INCLUDES"' >> activate.sh
 
 # make it available to future logins
 echo 'source chpl-nix-deps/activate.sh' >> /home/vagrant/.bash_profile

--- a/util/devel/test/vagrant/provision-scripts/apt-get-and-nix-install-2.sh
+++ b/util/devel/test/vagrant/provision-scripts/apt-get-and-nix-install-2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Note, this is not run all as root, so use sudo where needed
+
+# gather the build dependencies environment
+mkdir chpl-nix-deps
+cp chpl-nix-deps.nix chpl-nix-deps/flake.nix
+cd chpl-nix-deps
+bash -c 'nix print-dev-env --accept-flake-config < /dev/null >> activate.sh'
+
+# make it available to future logins
+echo 'source chpl-nix-deps/activate.sh' >> /home/vagrant/.bash_profile

--- a/util/devel/test/vagrant/provision-scripts/apt-get-llvm-13.sh
+++ b/util/devel/test/vagrant/provision-scripts/apt-get-llvm-13.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# install LLVM
+apt-get install -y llvm-13-dev llvm-13 llvm-13-tools clang-13 libclang-13-dev libclang-cpp13-dev libedit-dev

--- a/util/devel/test/vagrant/provision-scripts/chapel-default.sh
+++ b/util/devel/test/vagrant/provision-scripts/chapel-default.sh
@@ -7,5 +7,5 @@ fi
 
 source ../../provision-scripts/chapel-setmakej.sh
 
-echo cd chapel && source util/setchplenv.bash && make $MAKEJ && make check
+echo "cd chapel && source util/setchplenv.bash && make $MAKEJ && make check"
 cd chapel && source util/setchplenv.bash && make $MAKEJ && make check

--- a/util/devel/test/vagrant/provision-scripts/chapel-update.sh
+++ b/util/devel/test/vagrant/provision-scripts/chapel-update.sh
@@ -3,7 +3,7 @@
 if [ -d chapel ]
 then
   echo chapel directory already exists - updating
-  cd chapel && git checkout main && git pull && cd .. && echo UPDATED
+  cd chapel && git checkout main && git pull --ff-only && cd .. && echo UPDATED
 else
   echo cloning chapel
   git clone https://github.com/chapel-lang/chapel && echo CLONED

--- a/util/devel/test/vagrant/provision-scripts/chpl-nix-deps.nix
+++ b/util/devel/test/vagrant/provision-scripts/chpl-nix-deps.nix
@@ -23,6 +23,7 @@
     {
       devShells.default = (pkgs.mkShell.override { stdenv = pkgs.llvmPackages_14.stdenv; }) {
         nativeBuildInputs = with pkgs; [
+          automake
           bash
           cmake
           file
@@ -42,21 +43,15 @@
           which
         ];
         shellHook = with pkgs; ''
-          #export CC=${llvmPackages_14.clang}/bin/cc
-          #export CXX=${llvmPackages_14.clang}/bin/c++
-          #export CHPL_LLVM=system
-          #export CHPL_LLVM_CONFIG=${llvmPackages_14.llvm.dev}/bin/llvm-config
-          #export CHPL_HOST_COMPILER=llvm
-          #export CHPL_HOST_CC=${llvmPackages_14.clang}/bin/clang
-          #export CHPL_HOST_CXX=${llvmPackages_14.clang}/bin/clang++
-          #export CHPL_TARGET_CPU=none
-          #export CHPL_TARGET_CC=${llvmPackages_14.clang}/bin/clang
-          #export CHPL_TARGET_CXX=${llvmPackages_14.clang}/bin/clang++
-          #export CHPL_GMP=system
-          #export CHPL_RE2=bundled
-          #export CHPL_UNWIND=system
+          export CHPL_LLVM=system
+          export CHPL_LLVM_CONFIG=${llvmPackages_14.llvm.dev}/bin/llvm-config
+          export CHPL_HOST_COMPILER=llvm
+          export CHPL_HOST_CC=${llvmPackages_14.clang}/bin/clang
+          export CHPL_HOST_CXX=${llvmPackages_14.clang}/bin/clang++
+          export CHPL_TARGET_CC=${llvmPackages_14.clang}/bin/clang
+          export CHPL_TARGET_CXX=${llvmPackages_14.clang}/bin/clang++
+          export CHPL_CLANG_INCLUDES="-I ${llvmPackages_15.bintools.libc.dev}/include -I ${llvmPackages_15.clang-unwrapped.lib}/lib/clang/${llvmPackages_15.clang.version}/include"
         '';
       };
     });
 }
-

--- a/util/devel/test/vagrant/provision-scripts/chpl-nix-deps.nix
+++ b/util/devel/test/vagrant/provision-scripts/chpl-nix-deps.nix
@@ -1,0 +1,62 @@
+{
+  description = "Chapel Dependencies in Nix";
+
+  nixConfig = {
+    extra-experimental-features = "nix-command flakes";
+  };
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    #nix-filter.url = "github:numtide/nix-filter";
+    #flake-compat = {
+    #  url = "github:edolstra/flake-compat";
+    #  flake = false;
+    #};
+  };
+
+  outputs = inputs: inputs.flake-utils.lib.eachDefaultSystem (system:
+    with builtins;
+    let
+      pkgs = import inputs.nixpkgs { inherit system; };
+    in
+    {
+      devShells.default = (pkgs.mkShell.override { stdenv = pkgs.llvmPackages_14.stdenv; }) {
+        nativeBuildInputs = with pkgs; [
+          bash
+          cmake
+          file
+          gmp
+          gnum4
+          gnumake
+          gnused
+          libunwind
+          llvmPackages_14.clang
+          llvmPackages_14.libclang.dev
+          llvmPackages_14.llvm
+          llvmPackages_14.llvm.dev
+          makeWrapper
+          perl
+          pkg-config
+          python39
+          which
+        ];
+        shellHook = with pkgs; ''
+          #export CC=${llvmPackages_14.clang}/bin/cc
+          #export CXX=${llvmPackages_14.clang}/bin/c++
+          #export CHPL_LLVM=system
+          #export CHPL_LLVM_CONFIG=${llvmPackages_14.llvm.dev}/bin/llvm-config
+          #export CHPL_HOST_COMPILER=llvm
+          #export CHPL_HOST_CC=${llvmPackages_14.clang}/bin/clang
+          #export CHPL_HOST_CXX=${llvmPackages_14.clang}/bin/clang++
+          #export CHPL_TARGET_CPU=none
+          #export CHPL_TARGET_CC=${llvmPackages_14.clang}/bin/clang
+          #export CHPL_TARGET_CXX=${llvmPackages_14.clang}/bin/clang++
+          #export CHPL_GMP=system
+          #export CHPL_RE2=bundled
+          #export CHPL_UNWIND=system
+        '';
+      };
+    });
+}
+

--- a/util/devel/test/vagrant/provision-scripts/dnf-llvm-14.sh
+++ b/util/devel/test/vagrant/provision-scripts/dnf-llvm-14.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# what version to put here? try e.g.
-# dnf --showduplicates list llvm
-
-# Unclear to me why clang-14 or clang14 does not work
-dnf -y install llvm-devel-14.0.6 clang-14.0.6 clang-devel-14.0.6

--- a/util/devel/test/vagrant/provision-scripts/dnf-llvm-15.sh
+++ b/util/devel/test/vagrant/provision-scripts/dnf-llvm-15.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# what version to put here? try e.g.
+# dnf --showduplicates list llvm
+
+# Unclear to me why clang-15 or clang15 does not work
+dnf -y install llvm-devel-15.0.7 clang-15.0.7 clang-devel-15.0.7

--- a/util/devel/test/vagrant/provision-scripts/dnf-llvm15.sh
+++ b/util/devel/test/vagrant/provision-scripts/dnf-llvm15.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dnf -y install llvm15-devel clang15 clang15-devel 

--- a/util/devel/test/vagrant/provision-scripts/freebsd-pkg-llvm.sh
+++ b/util/devel/test/vagrant/provision-scripts/freebsd-pkg-llvm.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pkg install --yes llvm

--- a/util/devel/test/vagrant/provision-scripts/run.sh
+++ b/util/devel/test/vagrant/provision-scripts/run.sh
@@ -1,18 +1,5 @@
 #!/usr/bin/env bash
 
-# script for singularity image 'run' command
-
-if [ -d chapel ]
-then
-  echo chapel directory already exists - updating
-  git checkout main
-  git pull
-else
-  echo cloning chapel
-  git clone https://github.com/chapel-lang/chapel
-fi
-
-cd chapel
-source util/quickstart/setchplenv.bash
-make -j4
-make check
+# Just run the provided command in the current shell.
+echo "Running command in image: ${@@Q}"
+"$@"

--- a/util/devel/test/vagrant/provision-scripts/run.sh
+++ b/util/devel/test/vagrant/provision-scripts/run.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
 # Just run the provided command in the current shell.
-echo "Running command in image: ${@@Q}"
 "$@"

--- a/util/devel/test/vagrant/tryit.sh
+++ b/util/devel/test/vagrant/tryit.sh
@@ -10,6 +10,9 @@ LOG=log
 declare -a NAME
 declare -a RESULT
 
+# enable resizing for FreeBSD images
+export VAGRANT_EXPERIMENTAL="disks"
+
 echo > log
 echo > log2
 echo "Running command on images:" | tee -a log


### PR DESCRIPTION
This PR updates the portability testing scripts to test current platforms and to use LLVM 15 in some places since it is supported now in 1.31.

* rewrites Apptainer scripting `tryit.sh` to Python `tryit.py`. This makes it easier to add special logic with command line arguments and will hopefully also enable outputting portability test results in a way that Jenkins understands.
  * `tryit.py` already supports `--cleanup` `--rebuild` `--only someConfig` `--start someConfig` and `--skip-nollvm` options which have been useful to be in the process of running these tests
* updates various apptainer test scripts to use `tryit.py` and to `unset CHPL_DEVELOPER` since apptainer forwards environment variables and having `CHPL_DEVELOPER` set impacts how warnings behave
* updates the apptainer images to have a runscript that just runs a command. I did that on the idea we'd be able to use it for Nix testing but it's not currently very important. However the Python `tryit.py` is set up to use it.
* adds test configurations for Alma Linux 9.2, Alpine 3.18, Fedora 39 (pre-release), OpenSUSE Leap 15.5, Rocky Linux 9.2, FreeBSD 13.2
* adds prototype NixOS testing as a container (which does not work due to permission issues) and as a Vagrant VM (which passes quickstart testing but currently runs into problems building hwloc).
* updates a number of test configurations to use a newer LLVM / clang version
* updates the Vagrant tryit.sh to `export VAGRANT_EXPERIMENTAL="disks"` to avoid a hidden gotcha with the FreeBSD VMs.

Test changes only.

Reviewed by @bhavanijayakumaran - thanks!