### PR TITLE
Update GPU technote for 1.31; doc atomic functions in GPU module

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -36,7 +36,7 @@ executing on a GPU sublocale.  Loops are eligible when:
 * They only make use of known compiler primitives that are fast and local. Here
   "fast" means "safe to run in a signal handler" and "local" means "doesn't
   cause any network communication".
-* The do not call out to ``extern`` functions (aside from those in an exempted
+* They do not call out to ``extern`` functions (aside from those in an exempted
   set of Chapel runtime functions).
 * They are free of any call to a function that fails to meet the above
   criteria or accesses outer variables.
@@ -148,16 +148,16 @@ code for and interacts with GPUs. These variables include:
   rebuilding Chapel. For more information, see the `Vendor Portability`_
   section.
 * ``CHPL_GPU_ARCH`` --- specifies GPU architecture to generate kernel code for.
-  If unset and targetting NVIDIA GPUs, will default to 'sm_60'. This may also
+  If unset and targeting NVIDIA GPUs, will default to 'sm_60'. This may also
   be set by passing the ``chpl`` compiler ``--gpu-arch=<architecture>``. For
   more information, see the `Vendor Portability`_ section.
 * ``CHPL_CUDA_PATH`` --- specifies path to CUDA toolkit.  If unset, Chapel tries
   to automatically determine this path based on the location of ``nvcc``. This
-  variable is unused if not targetting NVIDIA GPUs. For more information, see
+  variable is unused if not targeting NVIDIA GPUs. For more information, see
   the `Vendor Portability`_ section.
-* ``CHPL_ROCM_PATH`` --- specifiess path to ROCM library. If unset, Chapel tries
+* ``CHPL_ROCM_PATH`` --- specifies path to ROCm library. If unset, Chapel tries
   to automatically determine this path based on the location of ``hipcc``. This
-  variable is unused if not targetting AMD GPUs. For more information, see the
+  variable is unused if not targeting AMD GPUs. For more information, see the
   `Vendor Portability`_ section.
 * ``CHPL_RT_NUM_GPU_PER_LOCALE`` --- if using ``CHPL_GPU=cpu``, sets how many
   GPU sublocales to have per locale. For more information, see the `CPU as
@@ -196,21 +196,21 @@ Vendor Portability
 
 Chapel is able to generate code that will execute on either NVIDIA or AMD GPUs.
 Chapel’s build system will automatically try and deduce what type of GPU you
-have and where your installation of relevant runtime (e.g. CUDA or ROCM) are.
+have and where your installation of relevant runtime (e.g. CUDA or ROCm) are.
 If the type of GPU is not detected you may set the ``CHPL_GPU`` environment
 variable manually to either ``nvidia`` or ``amd``.  ``CHPL_GPU`` may also
 manually be set to ``cpu`` to use `CPU as Device mode`_.
 
-Based on the value of 'CHPL_GPU', Chapel's build system will also attempt to
+Based on the value of ``CHPL_GPU``, Chapel's build system will also attempt to
 automatically detect the path to the relevant runtime. If it is not
 automatically detected (or you would like to use a different installation) you
 may set ``CHPL_CUDA_PATH`` and/or ``CHPL_ROCM_PATH`` explicitly.
 
 The CHPL_GPU_ARCH environment variable can be set to control the desired GPU
-architecture to compile for. The default value is sm_60 for
-CHPL_GPU_CODEGEN=cuda. You may also use the --gpu-arch compiler flag to set GPU
-architecture. For a list of possible values please refer to "processor" values
-in `this table in the LLVM documentation
+architecture to compile for. The default value is ``sm_60`` for
+``CHPL_GPU_CODEGEN=cuda``. You may also use the ``--gpu-arch`` compiler flag to
+set GPU architecture. For a list of possible values please refer to "processor"
+values in `this table in the LLVM documentation
 <https://llvm.org/docs/AMDGPUUsage.html#processors>`_ for AMD or the `CUDA
 Programming Guide
 <https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications>`_

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -351,26 +351,33 @@ module GPU
     chpl_atomicTernOp(c_ptrTo(x), cmp, val);
   }
 
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically add 'val' to 'x' (result is stored in 'x'). */
   inline proc gpuAtomicAdd(  ref x : ?T, val : T) : void { gpuAtomicBinOp("add", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically subtract 'val' from 'x' (result is stored in 'x'). */
   inline proc gpuAtomicSub(  ref x : ?T, val : T) : void { gpuAtomicBinOp("sub", x, val); }
   @chpldoc.nodoc
   inline proc gpuAtomicExch( ref x : ?T, val : T) : void { gpuAtomicBinOp("exch", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically compare 'x' and 'val' and store the minimum in 'x'. */
   inline proc gpuAtomicMin(  ref x : ?T, val : T) : void { gpuAtomicBinOp("min", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically compare 'x' and 'val' and store the maximum in 'x'. */
   inline proc gpuAtomicMax(  ref x : ?T, val : T) : void { gpuAtomicBinOp("max", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically increments x if the original value of x is
+     greater-than or equal to val, if so the result is stored in 'x'. */
   inline proc gpuAtomicInc(  ref x : ?T, val : T) : void { gpuAtomicBinOp("inc", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically determine if 'x' equals 0 or is greater than 'val'.
+     If so store 'val' in 'x' otherwise decrement 'x' by 1. */
   inline proc gpuAtomicDec(  ref x : ?T, val : T) : void { gpuAtomicBinOp("dec", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically perform a bitwise 'and' operation on 'x' and 'val' and store
+     the result in 'x'. */
   inline proc gpuAtomicAnd(  ref x : ?T, val : T) : void { gpuAtomicBinOp("and", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically perform a bitwise 'or' operation on 'x' and 'val' and store
+     the result in 'x'.  */
   inline proc gpuAtomicOr(   ref x : ?T, val : T) : void { gpuAtomicBinOp("or", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically perform a bitwise 'xor' operation on 'x' and 'val' and store
+     the result in 'x'. */
   inline proc gpuAtomicXor(  ref x : ?T, val : T) : void { gpuAtomicBinOp("xor", x, val); }
-  @chpldoc.nodoc
+
+  /* When run on a GPU, atomically compare the value in 'x' and 'cmp', if they
+     are equal store 'val' in 'x'.  */
   inline proc gpuAtomicCAS(  ref x : ?T, cmp : T, val : T) : void { gpuAtomicTernOp("CAS", x, cmp, val); }
 }


### PR DESCRIPTION
Updates to  GPU tech note for 1.31:

- Add note about not calling certain extern functions to our definition of a GPU eligible loop at the top.  (This isn't a new limitation but something that seems notable and missing).
- Update supported LLVM version to 15.
- Reorganize the "GPU-Related Environment Variables" section to be a list of  environment variables with (shortish) descriptions. More details on each variable are given in relevant sections.
- Add Vendor Portability as a subsection of our "Features" section
- Move Engin's section on CPU as Device Mode to be after vendor portability (since I think the second can segue from the first).
- Add a sentence about `--report-gpu` to the "Diagnostics and Utilities" section
- Various other word tweaks and edits.

Updates to GPU module:

- I now have doc comments for the various atomic functions.  With the notable exception of `gpuAtomicExch`, which I don't think is one is too terribly useful unless it also returns the old value (which we don't do at the moment).


TODO:

- [x] Visually inspect resulting tech note
- [x] Visually inspect resulting doc for GPU module
- [x] Run through spell check a final time