### PR TITLE
Suppress reportGpu test if CHPL_COMM!=none

### DIFF
--- a/test/gpu/native/reportGpu.suppressif
+++ b/test/gpu/native/reportGpu.suppressif
@@ -1,0 +1,1 @@
+CHPL_COMM != none


### PR DESCRIPTION
This test fails in our nightly GPU+GASNET job because of a known failure mode (see https://github.com/chapel-lang/chapel/issues/20641).

This failure mode has nothing to do with GPU report generation itself, so arguably, I could just avoid this by removing the use global variable and the offending loop but I kind of like having this test demonstrating the various ways a loop might be made ineligible.