### PR TITLE
Dyno: Implement generic tuple type expressions

### DIFF
--- a/frontend/include/chpl/types/TupleType.h
+++ b/frontend/include/chpl/types/TupleType.h
@@ -55,6 +55,8 @@ class TupleType final : public CompositeType {
       if (elt.postOrderId() == -1) {
         isKnownSize_ = false;
       }
+    } else if (subs_.size() == 0) {
+      isKnownSize_ = false;
     }
     computeIsStarTuple();
     computeIsParamKnown();

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2937,7 +2937,8 @@ void Resolver::exit(const Call* call) {
                              /* raiseErrors */ true,
                              &actualAsts);
 
-  // With two exceptions (see below), don't try to resolve a call that accepts:
+  // With these exceptions (see below), don't try to resolve a call that
+  // accepts:
   //  * an unknown param
   //  * a type that is a generic type unless there are substitutions
   //  * a value of generic type
@@ -2946,9 +2947,11 @@ void Resolver::exit(const Call* call) {
   // the actual argument can have unknown / generic type if it
   // refers directly to a particular variable.
   // EXCEPT, type construction can work with unknown or generic types
+  // EXCEPT, tuple type construction also works with unknown/generic types
 
   bool skip = false;
-  if (!ci.calledType().isType()) {
+  if (!ci.calledType().isType() &&
+      !call->isTuple()) {
     int actualIdx = 0;
     for (const auto& actual : ci.actuals()) {
       ID toId; // does the actual refer directly to a particular variable?

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -818,6 +818,17 @@ CanPassResult CanPassResult::canInstantiate(Context* context,
   } else if (auto actualCt = actualT->toCompositeType()) {
     // check for instantiating records/unions/tuples
     if (auto formalCt = formalT->toCompositeType()) {
+      // Quick check to disallow passing tuples of mismatching sizes when the
+      // sizes are known.
+      if (actualCt->isTupleType() && formalCt->isTupleType()) {
+        auto at = actualCt->toTupleType();
+        auto ft = formalCt->toTupleType();
+        if (at->isKnownSize() && ft->isKnownSize() &&
+            at->numElements() != ft->numElements()) {
+          return fail();
+        }
+      }
+
       if (actualCt->isInstantiationOf(context, formalCt)) {
         return instantiate();
       }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -205,7 +205,15 @@ void CallInfo::prepareActuals(Context* context,
     auto actual = call->actual(i);
 
     if (isQuestionMark(actual)) {
-      if (questionArg == nullptr) {
+      if (call->isTuple()) {
+        // Expressions like (?,?,?)
+        UniqueString byName;
+        auto qt = QualifiedType(QualifiedType::TYPE, AnyType::get(context));
+        actuals.push_back(CallInfoActual(qt, byName));
+        if (actualAsts != nullptr) {
+          actualAsts->push_back(actual);
+        }
+      } else if (questionArg == nullptr) {
         questionArg = actual;
       } else {
         CHPL_REPORT(context, MultipleQuestionArgs, fnCall, questionArg, actual);

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -39,6 +39,8 @@ CompositeType::areSubsInstantiationOf(Context* context,
                                       const CompositeType* partial) const {
   // Check to see if the substitutions of `this` are all instantiations
   // of the field types of `partial`
+  //
+  // Note: Assumes 'this' and 'partial' share a root instantiation.
 
   const SubstitutionsMap& mySubs = substitutions();
   const SubstitutionsMap& pSubs = partial->substitutions();
@@ -62,6 +64,16 @@ CompositeType::areSubsInstantiationOf(Context* context,
         // it was not an instantiation
         return false;
       }
+    } else {
+      // If the ID isn't found, then that means the generic component doesn't
+      // exist in the other type, which means this cannot be an instantiation
+      // of the other type.
+      //
+      // Currently this check assumes that 'this' and 'partial' share a root
+      // instantiation, so how could we reach this condition? One path here
+      // involves passing a tuple to a tuple formal with a fewer number of
+      // elements. For example, passing "(1, 2, 3)" to "(int, ?)".
+      return false;
     }
   }
 

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -471,6 +471,86 @@ static void test17() {
   assert(tt->elementType(2).type()->isIntType());
 }
 
+static void argHelper(std::string formal, std::string actual,
+                           bool shouldResolve) {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    operator =(ref lhs: _tuple, const ref rhs: _tuple) {}
+
+    proc foo(arg: )""" + formal + R"""() {
+      return arg;
+    }
+
+    var actual = )""" + actual + R"""(;
+    var x = foo(actual);
+    )""";
+
+  auto m = parseModule(context, std::move(program));
+  auto x = findVariable(m, "x");
+  auto a = findVariable(m ,"actual");
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+  if (shouldResolve) {
+    // 'x' and 'actual' should have the same type
+    auto xt = rr.byAst(x).type();
+    auto at = rr.byAst(a).type();
+    assert(xt.isUnknown() == false);
+    assert(xt.isErroneousType() == false);
+    assert(xt.hasTypePtr());
+    assert(xt.type()->isTupleType());
+    assert(xt.type() == at.type());
+
+    auto t = xt.type()->toTupleType();
+    std::stringstream str;
+    t->stringify(str, chpl::StringifyKind::CHPL_SYNTAX);
+    printf("  success: passing %s to %s\n", str.str().c_str(), formal.c_str());
+  } else {
+    std::string msg = "Cannot resolve call to 'foo': no matching candidates";
+    assert(guard.numErrors() == 1);
+    assert(guard.error(0)->message() == msg);
+    guard.clearErrors();
+    printf("  success: cannot pass %s to %s\n", actual.c_str(), formal.c_str());
+  }
+}
+
+static void testTupleGeneric() {
+  printf("testTupleGeneric\n");
+
+  // Basic all-generic cases
+  argHelper("(?,)", "(5,)", true);
+  argHelper("(?,)", "('hello',)", true);
+  argHelper("(?,?)", "(5, 1.0)", true);
+  argHelper("(?,?)", "(5, 'hello')", true);
+  argHelper("(?,?,?)", "(5, 1.0,'hello')", true);
+
+  // Mixed concrete and generic, still expecting to pass
+  argHelper("(int, ?)", "(5, 1.0)", true);
+  argHelper("(int, ?)", "(5, 'hello')", true);
+  argHelper("(int, ?)", "('hello', 5)", false);
+
+  argHelper("(int, ?, string)", "(5, 42.0, 'hello')", true);
+  argHelper("(int, ?, string)", "(5, 5, 'hello')", true);
+  argHelper("(int, ?, string)", "(5, 'hi', 'hello')", true);
+  argHelper("(int, ?, string)", "('hi', 42.0, 'hello')", false);
+  argHelper("(int, ?, string)", "(5, 42.0, 5)", false);
+
+  // Passing a tuples of incorrect size
+  argHelper("(int, ?)", "(5,5,5)", false);
+  argHelper("(int, ?, ?)", "(5,5)", false);
+
+  // Some 'integral' and 'numeric' tests
+  argHelper("(integral, integral)", "(5, 5)", true);
+  argHelper("(integral, integral)", "(5, 'hello')", false);
+
+  argHelper("(numeric, numeric)", "(5, 5)", true);
+  argHelper("(numeric, numeric)", "(5, 42.0)", true);
+  argHelper("(numeric, numeric)", "(5, 'hi')", false);
+}
+
 int main() {
   test1();
   test2();
@@ -489,6 +569,8 @@ int main() {
   test15();
   test16();
   test17();
+
+  testTupleGeneric();
 
   return 0;
 }


### PR DESCRIPTION
This PR implements support for generic tuple type expressions like ``(int, ?)`` or ``(string, integral)``.

``CallInfo`` was updated to allow for multiple question marks in ``Tuple`` expressions, and improvements were made to ``canPass`` to correctly check instantiations of generic tuples. Tests involving generic tuple types have been added to the ``testTuples`` suite.

Testing:
- [x] make test-dyno