### PR TITLE
Update the spec and primers for range and const changes

### DIFF
--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -769,16 +769,18 @@ expression or a type expression.
 Explicit Range Conversions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An expression of stridable range type can be explicitly converted to an
-unstridable range type, changing the stride to 1 in the process.
+An expression of a range type with ``strides=strideKind.any``
+can be explicitly converted to a range type with ``strides=strideKind.one``,
+changing the stride to 1 in the process.
 
 .. _Explicit_Domain_Conversions:
 
 Explicit Domain Conversions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An expression of stridable domain type can be explicitly converted to an
-unstridable domain type, changing all strides to 1 in the process.
+An expression of a domain type with ``strides=strideKind.any``
+can be explicitly converted to a domain type with ``strides=strideKind.one``,
+changing all strides to 1 in the process.
 
 .. _Explicit_String_to_Bytes_Conversions:
 

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -170,15 +170,13 @@ tuple type ``rank*idxType``. If unspecified, ``idxType`` defaults to
 
 The syntax of a rectangular domain type is summarized as follows:
 
-
 .. code-block:: syntax
 
    rectangular-domain-type:
      'domain' ( named-expression-list )
 
-where ``named-expression-list`` permits the values of ``rank``,
-``idxType``, and ``strides`` to be specified using standard type
-signature.
+where ``named-expression-list`` allows specifying the values of ``rank``,
+``idxType``, and ``strides``.
 
    *Example (typeFunctionDomain.chpl)*.
 
@@ -244,8 +242,8 @@ The type of a rectangular domain literal is defined as follows:
 
 -  ``idxType`` = the type of the range expressions;
 
--  ``strides`` = the most specific value that accepts all the strides
-   that are accepted by the ``strides`` parameters of the range expressions.
+-  ``strides`` = the most narrow :enum:`strideKind` that can represent
+   all ``strides`` parameters of the range expressions.
 
 If the index types in the ranges differ and all of them can be promoted
 to the same type, then that type is used as the ``idxType``. Otherwise,
@@ -395,7 +393,6 @@ the indices does not match a compiler error will be issued.
       var D : domain(string) = {"bar", "foo"};
       writeln(D);
 
-
    produces the output 
 
    .. code-block:: printoutput
@@ -446,7 +443,6 @@ Simple Subdomain Types
 ~~~~~~~~~~~~~~~~~~~~~~
 
 A simple subdomain type is specified using the following syntax:
-
 
 .. code-block:: syntax
 
@@ -744,9 +740,9 @@ integral tuple whose size matches the domain’s rank.
      domain-expression 'by' expression
 
 The type of the resulting domain is the same as the original domain,
-with the ``strides`` parameter adjusted to accept all the strides
-that are accepted by the ``strides`` parameters of the resulting
-domain's ranges.
+with the ``strides`` parameter adjusted to the most narrow
+:enum:`strideKind` that can represent all ``strides`` parameters
+of the resulting domain's ranges.
 The resulting domain's range in each dimension is obtained
 by applying the ``by`` operator to the corresponding dimension
 of the operand domain and the stride value if it is an integer,
@@ -902,7 +898,6 @@ set manipulations.  The supported set operators are:
   \-       Difference
   ^        Symmetric Difference
   =======  ====================
-
 
 Predefined Routines on Domains
 ------------------------------

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -31,7 +31,6 @@ The syntax to declare an iterator is given by:
      identifier
 
    yield-intent:
-     'const'
      'const ref'
      'ref'
      'param'

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -160,7 +160,6 @@ Procedures are defined with the following syntax:
      'type'
 
    return-intent:
-     'const'
      'const ref'
      'ref'
      'param'
@@ -845,13 +844,6 @@ When no ``return-intent`` is specified explicitly, the function returns
 a value that cannot be used as an lvalue. This value is obtained
 by copy-initialization from the returned expression,
 see :ref:`Copy_and_Move_Initialization`.
-
-.. _Const_Return_Intent:
-
-The Const Return Intent
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``const`` return intent is identical to the default return intent.
 
 .. _Ref_Return_Intent:
 
@@ -1613,7 +1605,7 @@ The compiler can choose between overloads differing in return intent
 when:
 
 -  there are zero or one best functions for each of ``ref``,
-   ``const ref``, ``const``, or the default (blank) return intent
+   ``const ref``, or the default (blank) return intent
 
 -  at least two of the above return intents have a best function.
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -615,7 +615,7 @@ range, with the ``strides`` parameter updated according to the step.
 For example:
 
 - If the base range has ``strides=strideKind.one`` and the step is
-  the literal ``-2``, the result has ``strides=strideKind.positive``.
+  the literal ``-2``, the result has ``strides=strideKind.negative``.
 
 - If the base range has ``strides=strideKind.one`` and the step has
   the type ``uint``, the result has ``strides=strideKind.positive``.

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -62,6 +62,8 @@ follows.
    ambiguous alignment means that the represented sequence is undefined.
    In such a case, certain operations discussed later result in an
    error.
+   The alignment is always between zero and :math:`|stride|-1`,
+   inclusively.
 
 More formally, the represented sequence for the range
 :math:`(low, high, stride, alignmt)` contains all indices :math:`ix`
@@ -167,13 +169,12 @@ The type of a range is characterized by three properties:
 
 -  ``bounds`` indicates which of the range’s bounds are not
    :math:`\infty`. ``bounds`` is an enumeration constant of the
-   type ``BoundedRangeType``. It is discussed further below.
+   type ``boundKind``. It is discussed further below.
 
--  ``stridable`` is a boolean that determines whether the range’s stride
-   can take on values other than 1. ``stridable`` is ``false`` by
-   default. A range is called *stridable* if its type’s ``stridable``
-   field is ``true``.
-
+-  ``strides`` indicates what values of ``stride`` are allowed
+   for this type. ``strides`` is an enumeration constant of the
+   type ``strideKind``. It is discussed further below.
+   
 ``bounds`` is one of the constants of the following enumeration:
 
 .. enum::  enum boundKind { both, low, high, neither };
@@ -194,14 +195,33 @@ corresponding direction(s)) as follows:
 
 ``bounds`` is ``boundKind.both`` by default. 
 
-The parameters ``idxType``, ``bounds``, and ``stridable`` affect
+``strides`` is one of the constants of the following enumeration:
+
+.. enum::   enum strideKind { one, negOne, positive, negative, any };
+
+The value of ``strides`` determines what values of ``stride`` this
+range can have as follows:
+
+-  ``one``: ``stride`` must be :math:`1`.
+
+- ``negOne``: ``stride`` must be :math:`-1`.
+
+- ``positive``: ``stride`` must be positive.
+
+- ``negative``: ``stride`` must be negative.
+
+- ``any``: ``stride`` can take on any value other than zero.
+
+``strides`` is ``strideKind.one`` by default. 
+
+The parameters ``idxType``, ``bounds``, and ``strides`` affect
 all values of the corresponding range type. For example, the range’s low
 bound is -:math:`\infty` if and only if the ``bounds`` of that
 range’s type is either ``high`` or ``neither``.
 
    *Rationale*.
 
-   Providing ``bounds`` and ``stridable`` in a range’s type
+   Providing ``bounds`` and ``strides`` in a range’s type
    allows the compiler to identify and optimize the common cases where
    the range is bounded in both directions and/or its stride is 1.
 
@@ -218,13 +238,13 @@ header:
 
 .. code-block:: chapel
 
-     proc range(type idxType = int,
-                param bounds = boundKind.both,
-                param stridable = false) type
+     proc range(type idxType  = int,
+                param bounds  = boundKind.both,
+                param strides = strideKind.one) type
 
 As a special case, the keyword ``range`` without a parenthesized
 argument list refers to the range type with the default values of all
-its parameters, i.e., ``range(int, boundKind.both, false)``.
+its parameters, i.e., ``range(int, boundKind.both, strideKind.one)``.
 
    *Example (rangeVariable.chpl)*.
 
@@ -310,7 +330,7 @@ The type of a range literal is a range with the following parameters:
 
    -  ``neither``, if neither bound expression is given.
 
--  ``stridable`` is ``false``.
+-  ``strides`` is ``strideKind.one``.
 
 The value of a range literal is as follows:
 
@@ -403,8 +423,8 @@ Range assignment is legal when:
 
 -  the two range types have the same ``bounds``, and
 
--  either the destination range is stridable or the source range is not
-   stridable.
+-  the ``strides`` parameter of the destination range is the same
+   or more permissive than that of the source range.
 
 .. _Range_Comparisons:
 
@@ -591,7 +611,17 @@ values are interpreted as 0 or 1, respectively.  It is an error for
 the step to be zero.
 
 The type of the result of the ``by`` operator is the type of the base
-range, but with the ``stridable`` parameter set to ``true``.
+range, with the ``strides`` parameter updated according to the step.
+For example:
+
+- If the base range has ``strides=strideKind.one`` and the step is
+  the literal ``-2``, the result has ``strides=strideKind.positive``.
+
+- If the base range has ``strides=strideKind.one`` and the step has
+  the type ``uint``, the result has ``strides=strideKind.positive``.
+
+- If the step has the type ``int`` and is not a ``param``,
+  the result has ``strides=strideKind.any``.
 
 Formally, the result of the ``by`` operator is a range with the
 following primary properties:
@@ -652,8 +682,9 @@ following primary properties:
 Align Operator
 ~~~~~~~~~~~~~~
 
-The ``align`` operator can be applied to any range, and creates a new
-range with the given alignment.
+The ``align`` operator takes a base range and an alignment operand.
+It produces a copy of the base range with alignment set
+to the alignment argument, taken mod :math:`{|stride|}`.
 
 The syntax for the ``align`` operator is: 
 
@@ -663,12 +694,11 @@ The syntax for the ``align`` operator is:
      range-expression 'align' expression
 
 The type of the resulting range expression is the same as that of the
-range appearing as the left operand, but with the ``stridable``
-parameter set to ``true``. An implicit conversion from the type of the
-right operand to the index type of the operand range must be allowed.
+base range. An implicit conversion from the type of the
+alignment operand to the index type of the base range must be allowed.
 The resulting range has the same low and high bounds and stride as the
-source range. The alignment equals the ``align`` operator’s right
-operand and therefore is not ambiguous.
+base range. The alignment equals the alignment operand mod :math:`{|stride|}`
+and therefore is not ambiguous.
 
    *Example (alignedStride.chpl)*.
 
@@ -726,8 +756,8 @@ When the stride is negative, the same indices are printed in reverse:
       | 9 6 3 0
       | 10 7 4 1
 
-To create a range aligned relative to its ``first`` index, see
-``range.offset`` below.
+To set the alignment relative to the range's ``first`` index,
+use the method :proc:`~ChapelRange.range.offset`.
 
 .. _Count_Operator:
 
@@ -831,8 +861,6 @@ Arithmetic Operators
 The following arithmetic operators are defined on ranges and integral
 types:
 
-
-
 .. code-block:: chapel
 
    proc +(r: range, s: integral): range
@@ -844,7 +872,7 @@ range’s low and high bounds, producing a shifted version of the range.
 If the operand range is unbounded above or below, the missing bounds are
 ignored. The index type of the resulting range is the type of the value
 that would result from an addition between the scalar value and a value
-with the range’s index type. The ``bounds`` and ``stridable`` parameters for
+with the range’s index type. The ``bounds`` and ``strides`` parameters for
 the result range are the same as for the input range.
 
 The stride of the resulting range is the same as the stride of the
@@ -855,12 +883,12 @@ resulting range is also ambiguously aligned.
 
    *Example (rangeAdd.chpl)*.
 
-   The following code creates a bounded, non-stridable range ``r`` which
-   has an index type of ``int`` representing the indices
+   The following code creates a range ``r`` which
+   has an index type of ``int`` and represents the indices
    :math:`{0, 1, 2, 3}`. It then uses the ``+`` operator to create a
    second range ``r2`` representing the indices :math:`{1, 2, 3, 4}`.
-   The ``r2`` range is bounded, non-stridable, and is represented by
-   indices of type ``int``. 
+   Like ``r``, the range ``r2`` is bounded, its ``stride`` is 1 and
+   cannot be changed, and its indices have the type ``int``. 
 
    .. code-block:: chapel
 
@@ -952,25 +980,19 @@ Predefined Routines on Ranges
 Range Type Queries
 ~~~~~~~~~~~~~~~~~~
 
-
-
 .. function:: proc range.idxType type
 
    Returns the type of the range's indices (its ``idxType``).
 
-
-
-.. function:: proc range.bounds param : BoundedRangeType
+.. function:: proc range.bounds param : boundKind
 
    Returns which bounds the range explicitly represents
-   (its ``bounds`` value).
+   (its ``bounds`` parameter).
 
+.. function:: proc range.strides param : strideKind
 
-
-.. function:: proc range.stridable param : bool
-
-   Returns whether or not the range can have non-unit strides (its
-   ``stridable`` value).
+   Returns what strides the range can have
+   (its ``strides`` parameter).
 
 
 .. include:: ../../builtins/ChapelRange.rst

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -735,7 +735,7 @@ Value tuples include:
 
 - tuple variables
 - formal arguments with ``in`` intent that have a tuple type
-- tuples returned from functions with the default or ``const`` return intent
+- tuples returned from functions with the default return intent
 
 A *referential tuple* stores its components by value or by reference,
 as determined by the default argument intent of the component's type:
@@ -961,7 +961,7 @@ tuple depending on its argument intent.
 Tuple Return Behavior
 ---------------------
 
-Procedures with the default or ``const`` return intent always return
+Procedures with the default return intent always return
 a value tuple. If an expression returned by such a procedure is
 a referential tuple, it will be implicitly converted to a value tuple.
 
@@ -1017,7 +1017,7 @@ the procedure's scope. Otherwise there is a compilation error.
 Tuple Yield Behavior
 --------------------
 
-Iterators with the default or ``const`` return intent always yield
+Iterators with the default return intent always yield
 a value tuple. If an expression yielded by such an iterator is
 a referential tuple, it will be implicitly converted to a value tuple.
 

--- a/doc/rst/technotes/dsi.rst
+++ b/doc/rst/technotes/dsi.rst
@@ -175,15 +175,13 @@ class ``GlobalDomain``
 
   .. code-block:: chapel
 
-    class GlobalDomain ... {
-      param rank: int;
-      type idxType;
-      param stridable: bool;
+    class GlobalDomain: BaseRectangularDom {
       var dist;
       ...
     }
 
-  The fields ``rank``, ``idxType``, ``stridable`` are the attributes
+  The fields ``rank``, ``idxType``, ``strides``, inherited from
+  the class BaseRectangularDom, are the attributes
   of the corresponding Chapel domain. (They could be replaced with
   parentheses-less functions of the same names and param/type intents.)
 
@@ -202,24 +200,24 @@ class ``GlobalDomain``
   Returns this domain's domain map. This procedure should be provided as shown.
   (Exception: see ``dsiLinksDistribution()``.)
 
-.. method:: proc GlobalDistribution.dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) : GlobalDomain(rank, idxType, stridable)
+.. method:: proc GlobalDistribution.dsiNewRectangularDom(param rank: int, type idxType, param strides: strideKind, inds) : GlobalDomain(rank, idxType, strides)
 
   This method is invoked when the Chapel program is creating a domain
-  value of the type domain(rank, idxType, stridable) mapped using the
+  value of the type domain(rank, idxType, strides) mapped using the
   domain map `this` with initial indices `inds`.
 
   This method returns a new ``GlobalDomain`` instance that will correspond to
   that Chapel domain value, i.e., be that value's runtime representation.
   The field ``dist`` of the returned ``GlobalDomain`` must point to `this`.
 
-.. method:: proc GlobalDomain.dsiGetIndices(): rank * range(idxType, BoundedRangeType.bounded, stridable)
+.. method:: proc GlobalDomain.dsiGetIndices(): rank * range(idxType, boundKind.both, strides)
 
   Returns a tuple of ranges describing the dimensions of this domain.
 
   ``dsiDims()`` and ``dsiGetIndices()`` have the same specification
   and so may be implemented in terms of one another.
 
-.. method:: proc GlobalDomain.dsiSetIndices(dom: domain(rank, idxType, stridable)): void
+.. method:: proc GlobalDomain.dsiSetIndices(dom: domain(rank, idxType, strides)): void
 
   Updates the internal representation of `this`
   to match the index set of ``dom``.
@@ -522,15 +520,12 @@ class ``GlobalArray``
 
     class GlobalDomain : BaseRectangularDom {
       // required
-      param rank: int;
-      type idxType;
-      param stridable: bool;
       const dist;
       // for example, store indices as a single Chapel domain
-      var myIndices: domain(rank, idxType, stridable);
+      var myIndices: domain(rank, idxType, strides);
     }
 
-    proc GlobalDomain.dsiSetIndices(dom: domain(rank,idxType,stridable)): void
+    proc GlobalDomain.dsiSetIndices(dom: domain(rank, idxType, strides)): void
     { myIndices = dom; }
 
     class GlobalArray : BaseArr {
@@ -600,9 +595,9 @@ as an indication of what procedure(s) need to be defined.
   The domain map implementer is allowed to restrict the type of ``indexx``
   that this method accepts.
 
-.. method:: proc GlobalDomain.dsiDim(dim: int): range(idxType, BoundedRangeType.bounded, stridable)
+.. method:: proc GlobalDomain.dsiDim(dim: int): range(idxType, boundKind.both, strides)
 
-.. method:: proc GlobalDomain.dsiDims(): rank * range(idxType, BoundedRangeType.bounded, stridable)
+.. method:: proc GlobalDomain.dsiDims(): rank * range(idxType, boundKind.both, strides)
 
 .. method:: proc GlobalDomain.dsiLow
 

--- a/test/release/examples/primers/LinearAlgebralib.chpl
+++ b/test/release/examples/primers/LinearAlgebralib.chpl
@@ -94,8 +94,8 @@ a.shape; // (3, 5)
 writeln(a.eltType: string); // real(64)
 
 // Array type in format of:
-//   ``[domain(rank, index-type, stridable)] element-type``
-writeln(a.type: string); // [domain(2,int(64),false)] real(64)
+//   ``[domain(rank, index-type, strides)] element-type``
+writeln(a.type: string); // [domain(2,int(64),one)] real(64)
 
 // Element-wise addition (and subtraction)
 a = a + 1; // or, a += 1

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -325,7 +325,7 @@ var reverse2to10by2 = 2..10 by -2; // 10, 8, 6, 4, 2
 var trapRange = 10..1 by -1; // Do not be fooled, this is still an empty range
 writeln("Size of range '", trapRange, "' = ", trapRange.size);
 
-// Note: ``range(bounds= ...)`` and ``range(stridable= ...)`` are necessary
+// Note: ``range(bounds= ...)`` and ``range(strides= ...)`` are necessary
 // only if we give the variable a type explicitly.
 
 // The end point of a range can be computed by specifying the total size
@@ -338,7 +338,7 @@ writeln(rangeCountBy);
 
 // Properties of the range can be queried.
 // In this example, printing the first index, last index, number of indices,
-// stride, and if 2 is include in the range.
+// stride, and if 2 is included in the range.
 writeln((rangeCountBy.first, rangeCountBy.last, rangeCountBy.size,
            rangeCountBy.stride, rangeCountBy.contains(2)));
 

--- a/test/release/examples/primers/ranges.chpl
+++ b/test/release/examples/primers/ranges.chpl
@@ -201,11 +201,6 @@ writeRange(..5 # -3);         // 3, 4, 5
 writeln();
 
 //
-// The ``by`` and ``align`` operators are used to create `strided
-// ranges` representing non-consecutive, evenly spaced values.
-//
-
-//
 // The ``by`` operator applies a stride to a range, selecting a
 // subsequence of its original values.  If the range was already
 // strided, the effect is multiplicative.  If the stride is negative,
@@ -262,7 +257,7 @@ writeln();
 //
 // The alignment is always taken modulo the stride, so one could also
 // declare 'allEvens' using `.. by 2 align 0`, `.. by 2 align 12`, or
-// any other even number as the alignment.:
+// any other even number as the alignment.
 //
 
 
@@ -352,7 +347,7 @@ writeln();
 //
 // * ``idxType``: The type of the range's values (defaults to ``int``)
 // * ``bounds``: A :enum:`boundKind` value indicating which bounds the range stores (defaults to ``boundKind.both``)
-// * ``stridable``: A ``bool`` indicating whether or not the range can have a stride other than 1 (defaults to ``false``)
+// * ``strides``: A :enum:`strideKind` value indicating what values the range's ``strides`` is allowed to store (defaults to ``strideKind.one``)
 //
 // Like other variables, range types can be inferred by the compiler
 // from the initializing expression for simplicity, as in the previous
@@ -369,7 +364,7 @@ const rt: range(int) = 1..10,
 // More importantly, range types can be used to make a range variable
 // more flexible than its initializer permits.  For example, this
 // range's initializer has a unit stride, but because its type is
-// declared with ``stridable=true``, it can later be assigned a range
+// declared with ``strideKind.any``, it can later be assigned a range
 // value with a stride.
 
 var rangeVar: range(int, strides=strideKind.any) = 1..10;


### PR DESCRIPTION
Update the Ranges and Domains and Coercions chapters of the spec and the comments in the ranges and other primers for the change `range.stridable` --> `strides: strideKind` in #22441, with follow-ons #22486 and #22508.

Also remove the remaining occurrences of `BoundedRangeType` from the spec and primers -- it is deprecated as of #22059.

Remove the `const` return and yield intent in the Procedures, Iterators, and Tuples sections of the spec -- it is unstable as of #22515. I did not see any need to update the primers for this change.

While there, I did some rephrasing and restructuring of the text for better readability or precision.

Testing: visual examination of the generated docs; a standard paratest.

Post-merge: update the Chapel Evolution document.