### PR TITLE
Enable use of hugepages on the hpe-cray-ex platform

### DIFF
--- a/runtime/src/comm/ofi/Makefile.share
+++ b/runtime/src/comm/ofi/Makefile.share
@@ -48,9 +48,10 @@ ifneq (, $(findstring pmi2, $(COMM_SRCS)))
 endif
 
 #
-# Use hugepages only on Cray XC systems.
+# Use hugepages on Cray XC and HPE Cray EX systems.
 #
-ifneq (, $(findstring cray-x,$(CHPL_MAKE_TARGET_PLATFORM)))
+
+ifneq (, $(findstring $(CHPL_MAKE_TARGET_PLATFORM), cray-xc hpe-cray-ex))
   COMM_SRCS += comm-ofi-hugepages.c
 else
   COMM_SRCS += comm-ofi-no-hugepages.c

--- a/runtime/src/comm/ofi/Makefile.share
+++ b/runtime/src/comm/ofi/Makefile.share
@@ -47,11 +47,12 @@ ifneq (, $(findstring pmi2, $(COMM_SRCS)))
   endif
 endif
 
+
 #
-# Use hugepages on Cray XC and HPE Cray EX systems.
+# Use hugepages if requested.
 #
 
-ifneq (, $(findstring $(CHPL_MAKE_TARGET_PLATFORM), cray-xc hpe-cray-ex))
+ifneq (, $(call isTrue, $(CHPL_COMM_OFI_USE_HUGEPAGES)))
   COMM_SRCS += comm-ofi-hugepages.c
 else
   COMM_SRCS += comm-ofi-no-hugepages.c

--- a/runtime/src/comm/ofi/comm-ofi-hugepages.c
+++ b/runtime/src/comm/ofi/comm-ofi-hugepages.c
@@ -39,3 +39,7 @@ void* chpl_comm_ofi_hp_get_huge_pages(size_t size) {
 size_t chpl_comm_ofi_hp_gethugepagesize(void) {
   return gethugepagesize();
 }
+
+chpl_bool chpl_comm_ofi_hp_supported(void) {
+  return true;
+}

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -290,6 +290,7 @@ int  chpl_comm_ofi_oob_locales_on_node(int *localRank);
 
 void* chpl_comm_ofi_hp_get_huge_pages(size_t);
 size_t chpl_comm_ofi_hp_gethugepagesize(void);
+chpl_bool chpl_comm_ofi_hp_supported(void);
 
 
 //

--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -84,4 +84,9 @@ void chpl_comm_preLaunch(int32_t numLocales) {
     //
     chpl_env_set("PMI_NO_PREINITIALIZE", "y", 1);
   }
+  //
+  // Don't map virtual hugepages to physical pages if we allocate a
+  // fixed heap.
+  //
+  chpl_env_set("HUGETLB_NO_RESERVE", "yes", 0);
 }

--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -88,5 +88,7 @@ void chpl_comm_preLaunch(int32_t numLocales) {
   // Don't map virtual hugepages to physical pages if we allocate a
   // fixed heap.
   //
-  chpl_env_set("HUGETLB_NO_RESERVE", "yes", 0);
+  if (chpl_env_rt_get_bool("COMM_OFI_USE_HUGEPAGES", false)) {
+    chpl_env_set("HUGETLB_NO_RESERVE", "yes", 0);
+  }
 }

--- a/runtime/src/comm/ofi/comm-ofi-no-hugepages.c
+++ b/runtime/src/comm/ofi/comm-ofi-no-hugepages.c
@@ -33,3 +33,5 @@ void* chpl_comm_ofi_hp_get_huge_pages(size_t size) { return NULL; }
 
 
 size_t chpl_comm_ofi_hp_gethugepagesize(void) { return 0; }
+
+chpl_bool chpl_comm_ofi_hp_supported(void) { return false; }


### PR DESCRIPTION
Enable use of hugepages on the hpe-cray-ex platform. Due to limitations in the hugepage interface, the runtime will not size the heap dynamically based on available physical memory, but will instead use the default heap size or the size specified by `CHPL_RT_MAX_HEAP_SIZE`. The program may fail with an out-of-memory error if there is insufficient physical memory for the heap.

The `CHPL_RT_COMM_OFI_USE_HUGEPAGES` environment variable controls whether or not hugepage support is included in the Chapel runtime. The `CHPL_RT_COMM_OFI_USE_HUGEPAGES` variable controls whether or not hugepages are used at runtime.

Resolves #https://github.com/Cray/chapel-private/issues/4844 and resolved https://github.com/Cray/chapel-private/issues/3141.