### PR TITLE
Prepend CRAY_LD_LIBRARY_PATH to LD_LIBRARY_PATH for Cray whitebox testing

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -150,5 +150,9 @@ module load cray-fftw
 log_info "Current loaded modules:"
 module list
 
+log_info "Updating LD_LIBRARY_PATH to include CRAY_LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+echo $LD_LIBRARY_PATH
+
 log_info "Chapel environment:"
 $CHPL_HOME/util/printchplenv --all --no-tidy


### PR DESCRIPTION
The goal of this is to make our environment more robust on heterogeneous Cray systems.  HPE developers can see https://github.hpe.com/hpe/hpc-chapel-code/pull/574 for more information.
