### PR TITLE
Pull champs-nightly repos for nightly job

### DIFF
--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -8,6 +8,10 @@ COMMON_DIR=/cy/users/chapelu
 
 export CHAMPS_COMMON_DIR=$COMMON_DIR/champs-nightly
 
+pushd $CHAMPS_COMMON_DIR
+git pull
+popd
+
 # All CHAMPS testing is currently on a cray-cs
 module list
 


### PR DESCRIPTION
Our nightly CHAMPS test relies on a repos where we store various patches that need to be applied. Currently we rely on manually running 'git pull' on this repos anytime a new patch is submitted. This PR updates our nightly job to run 'git pull' automatically.

To resolve: https://github.com/Cray/chapel-private/issues/3030