### PR TITLE
Add quotes in paratest.chapdl

### DIFF
--- a/util/test/paratest.chapdl
+++ b/util/test/paratest.chapdl
@@ -2,4 +2,4 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-CHPL_TEST_PARTITION=chapdl CHPL_TEST_NODEPARA=8 $CWD/paratest.chapcs $@
+CHPL_TEST_PARTITION=chapdl CHPL_TEST_NODEPARA=8 $CWD/paratest.chapcs "$@"


### PR DESCRIPTION
This allows passing space-containing args through to `paratest.server`.

Tested by calling paratest.chapdl with `-dirs "compflags/bradc/badflagdash compflags/bradc/badflagddash compflags/bradc/copyright"`
