### PR TITLE
Stop removing paths in #line directives

### DIFF
--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -188,7 +188,7 @@ void beautify(fileinfo* origfile) {
   int zline;
   char zname[1024];
   int old_depth;
-  char* znptr;
+  //  char* znptr;
   fileinfo* tmpfile;
 
   zline = -1;
@@ -212,6 +212,7 @@ void beautify(fileinfo* origfile) {
       /* record zpl/c source line map info */
       if (!strncmp(cp, ZLINEINPUT, ZLINEINPUTLEN)) {
         sscanf(cp, ZLINEINPUTFORMAT, &zline, zname);
+        /*
         znptr = strrchr(zname,'/');
         if (znptr != NULL) {
           // We can't use strcpy here because the source
@@ -221,6 +222,7 @@ void beautify(fileinfo* origfile) {
           size_t len = strlen(src) + 1; // also copy null
           memmove(dst, src, len);
         }
+        */
         continue;
       }
     }

--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -188,7 +188,6 @@ void beautify(fileinfo* origfile) {
   int zline;
   char zname[1024];
   int old_depth;
-  //  char* znptr;
   fileinfo* tmpfile;
 
   zline = -1;
@@ -212,17 +211,6 @@ void beautify(fileinfo* origfile) {
       /* record zpl/c source line map info */
       if (!strncmp(cp, ZLINEINPUT, ZLINEINPUTLEN)) {
         sscanf(cp, ZLINEINPUTFORMAT, &zline, zname);
-        /*
-        znptr = strrchr(zname,'/');
-        if (znptr != NULL) {
-          // We can't use strcpy here because the source
-          // and destination strings can overlap.
-          char *src = znptr+1;
-          char *dst = zname;
-          size_t len = strlen(src) + 1; // also copy null
-          memmove(dst, src, len);
-        }
-        */
         continue;
       }
     }


### PR DESCRIPTION
[conceived of by @jabraham17, typed in by me]

This PR updates the beautify pass that we take on our generated code to insert `#line` directives in order to stop removing paths to files.  Doing so made debugging harder when the source file was not in the CWD because that's where the debugger would look for it.

Resolves #22589 