### PR TITLE
Fix memory leak in gpu runtime

### DIFF
--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -96,10 +96,12 @@ extern "C" {
   m(GETS_PUTS_STRIDES,    "put_strd/get_strd array of strides",       true ), \
   m(MLI_DATA,             "multilocale interop data",                 true ), \
   m(GPU_DATA,             "user data allocation on gpu",              true ), \
-  m(GPU_KERNEL_ARG,       "kernel data allocation on gpu",            false), \
+  m(GPU_KERNEL_ARG,       "kernel data allocation on gpu",            true ), \
   m(GPU_UTIL,             "gpu layer utility space",                  false), \
-  m(NUM,                  "*** this must be the last entry ***",      true )
-
+  m(GPU_KERNEL_PARAM,      "pointer to a kernel arg",                 true ), \
+  m(GPU_KERNEL_PARAM_BUFF, "array of pointers to kernel args",        true ), \
+  m(GPU_KERNEL_PARAM_META, "metadata about kernel parameters",        true ), \
+  m(NUM,                   "*** this must be the last entry ***",     true )
 
 //
 // Define the enumeration constants for the memory descriptors.

--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -96,7 +96,7 @@ extern "C" {
   m(GETS_PUTS_STRIDES,    "put_strd/get_strd array of strides",       true ), \
   m(MLI_DATA,             "multilocale interop data",                 true ), \
   m(GPU_DATA,             "user data allocation on gpu",              true ), \
-  m(GPU_KERNEL_ARG,       "kernel data allocation on gpu",            true ), \
+  m(GPU_KERNEL_ARG,       "kernel data allocation on gpu",            false), \
   m(GPU_UTIL,             "gpu layer utility space",                  false), \
   m(GPU_KERNEL_PARAM,      "pointer to a kernel arg",                 true ), \
   m(GPU_KERNEL_PARAM_BUFF, "array of pointers to kernel args",        true ), \

--- a/runtime/src/gpu/nvidia/gpu-nvidia.c
+++ b/runtime/src/gpu/nvidia/gpu-nvidia.c
@@ -189,8 +189,8 @@ static void chpl_gpu_launch_kernel_help(int ln,
   CHPL_GPU_STOP_TIMER(load_time);
   CHPL_GPU_START_TIMER(prep_time);
 
-  // TODO: this should use chpl_mem_alloc
-  void*** kernel_params = chpl_malloc(nargs*sizeof(void**));
+  void ***kernel_params = chpl_mem_alloc(
+      nargs * sizeof(void **), CHPL_RT_MD_GPU_KERNEL_PARAM_BUFF, ln, fn);
 
   assert(function);
   assert(kernel_params);
@@ -202,8 +202,8 @@ static void chpl_gpu_launch_kernel_help(int ln,
 
   // Keep track of kernel parameters we dynamically allocate memory for so
   // later on we know what we need to free.
-  bool* was_memory_dynamically_allocated_for_kernel_param =
-    chpl_malloc(nargs*sizeof(bool));
+  bool *was_memory_dynamically_allocated_for_kernel_param = chpl_mem_alloc(
+      nargs * sizeof(bool), CHPL_RT_MD_GPU_KERNEL_PARAM_META, ln, fn);
 
   for (int i=0 ; i<nargs ; i++) {
     void* cur_arg = va_arg(args, void*);
@@ -212,8 +212,8 @@ static void chpl_gpu_launch_kernel_help(int ln,
     if (cur_arg_size > 0) {
       was_memory_dynamically_allocated_for_kernel_param[i] = true;
 
-      // TODO this allocation needs to use `chpl_mem_alloc` with a proper desc
-      kernel_params[i] = chpl_malloc(1*sizeof(CUdeviceptr));
+      kernel_params[i] = chpl_mem_alloc(1 * sizeof(CUdeviceptr),
+                                        CHPL_RT_MD_GPU_KERNEL_PARAM, ln, fn);
 
       // TODO this doesn't work on EX, why?
       // *kernel_params[i] = chpl_gpu_impl_mem_array_alloc(cur_arg_size, stream);
@@ -261,11 +261,12 @@ static void chpl_gpu_launch_kernel_help(int ln,
   for (int i=0 ; i<nargs ; i++) {
     if (was_memory_dynamically_allocated_for_kernel_param[i]) {
       chpl_gpu_mem_free(*kernel_params[i], ln, fn);
+      chpl_mem_free(kernel_params[i], ln, fn);
     }
   }
 
-  // TODO: this should use chpl_mem_free
-  chpl_free(kernel_params);
+  chpl_mem_free(kernel_params, ln, fn);
+  chpl_mem_free(was_memory_dynamically_allocated_for_kernel_param, ln, fn);
 
   CHPL_GPU_STOP_TIMER(teardown_time);
   CHPL_GPU_PRINT_TIMERS("<%20s> Load: %Lf, "

--- a/test/gpu/native/diags.good
+++ b/test/gpu/native/diags.good
@@ -7,6 +7,10 @@ Start
 0 (cpu): diags.chpl:nn: free xxB of _EndCount(atomic int(64),int(64)) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:nn: allocate xxB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:nn: allocate xxB of array elements at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: allocate xxB of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: allocate xxB of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: free xxB of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: free xxB of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): diags.chpl:nn: free xxB of array elements at 0xPREDIFFED
 0 (gpu 0): diags.chpl:nn: free xxB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 2 2 2 2 2 2 2 2 2 2


### PR DESCRIPTION
Fix of (relatively minor) memory leak in our runtime lib as described here (https://github.com/chapel-lang/chapel/issues/21689).

Along the way, since I saw this TODO comment:

`TODO: this should use chpl_mem_free`

I changed the free to use of `chpl_free` there to use `chpl_mem_Free` as well.  I'm not sure why this wasn't just done. I'm running things through paratests now, maybe I'll find out?

- [x] Paratest NVIDIA GPU
- [x] Paratest AMD GPU