### PR TITLE
Update docs menu for today's release

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -87,8 +87,8 @@ if (pagePath == "") {
   pagePath = "index";
 }
 function dropSetup() {
-  var currentRelease = "1.30"; // what does the public have?
-  var stagedRelease = "1.31";  // is there a release staged but not yet public?
+  var currentRelease = "1.31"; // what does the public have?
+  var stagedRelease = "1.32";  // is there a release staged but not yet public?
   var nextRelease = "1.32";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle


### PR DESCRIPTION
This is the standard day-of-release update of the docs menu to reflect that 1.31 is now the default.