### PR TITLE
Add PRETEST script logic for multi-locale

### DIFF
--- a/test/classes/casts/generated-cast-tests/argumentCoerce_Const/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_Const/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentConst" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentConst" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_Const/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_Const/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentConst" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentConst" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_ConstIn/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_ConstIn/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentConstIn" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentConstIn" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_ConstIn/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_ConstIn/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentConstIn" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentConstIn" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_ConstRef/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_ConstRef/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentConstRef" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentConstRef" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_ConstRef/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_ConstRef/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentConstRef" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentConstRef" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_In/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_In/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentIn" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentIn" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_In/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_In/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentIn" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentIn" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_Inout/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_Inout/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentInout" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentInout" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_Inout/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_Inout/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentInout" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentInout" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_Out/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_Out/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentOut" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentOut" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_Out/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_Out/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentOut" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentOut" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_Ref/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_Ref/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentRef" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentRef" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/argumentCoerce_Ref/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/argumentCoerce_Ref/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="argumentRef" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="argumentRef" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/coerceAssign/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/coerceAssign/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="coerceAssign" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="coerceAssign" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/coerceAssign/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/coerceAssign/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="coerceAssign" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="coerceAssign" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/coerceInitAssign/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/coerceInitAssign/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="coerceInit" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="coerceInit" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/coerceInitAssign/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/coerceInitAssign/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="coerceInit" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="coerceInit" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/explicitCasts/error/PRETEST
+++ b/test/classes/casts/generated-cast-tests/explicitCasts/error/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="explicitCasts" --generateErrorCases=true
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="explicitCasts" --generateErrorCases=true
+rm -rf generate-tests generate-tests_real

--- a/test/classes/casts/generated-cast-tests/explicitCasts/noerror/PRETEST
+++ b/test/classes/casts/generated-cast-tests/explicitCasts/noerror/PRETEST
@@ -1,5 +1,5 @@
 #!/bin/bash
 CHPL=$1
 $CHPL ../../generate-tests.chpl -o generate-tests && \
-  ./generate-tests --generateSuite="explicitCasts" --generateErrorCases=false
-rm -rf generate-tests
+  ./generate-tests -nl 1 --generateSuite="explicitCasts" --generateErrorCases=false
+rm -rf generate-tests generate-tests_real


### PR DESCRIPTION
When `chpl` has been compiled for multi-locale, generating and running tests for `test/classes/casts/generated-cast-tests/generate-tests.chpl` did not work properly

tested with paratest with comm=none and comm=gasnet

Note: all of the changes in separate files are the same

[Reviewed by @vasslitvinov]