### PR TITLE
Deprecate/rename the intIdxType queries on ranges, domains and arrays

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -964,6 +964,7 @@ module ChapelArray {
        :proc:`rank` * :proc:`idxType`. */
     proc fullIdxType type do return this.domain.fullIdxType;
 
+    @deprecated("'.intIdxType' on arrays is deprecated; please let us know if you're relying on it")
     proc intIdxType type do return chpl__idxTypeToIntIdxType(_value.idxType);
 
     pragma "no copy return"
@@ -2772,7 +2773,7 @@ module ChapelArray {
   lifetime a < b {
 
       type idxType = a.domain.idxType,
-           strType = chpl__signedType(a.domain.intIdxType);
+           strType = chpl__signedType(a.domain.chpl_intIdxType);
 
       const stride = a.domain.dim(a.rank-rank).stride,
       start = a.domain.dim(a.rank-rank).firstAsInt;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2773,7 +2773,7 @@ module ChapelArray {
   lifetime a < b {
 
       type idxType = a.domain.idxType,
-           strType = chpl__signedType(a.domain.chpl_intIdxType);
+           strType = chpl__signedType(a.domain.chpl_integralIdxType);
 
       const stride = a.domain.dim(a.rank-rank).stride,
       start = a.domain.dim(a.rank-rank).firstAsInt;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -3377,7 +3377,7 @@ module ChapelBase {
     if zippered && isTuple(iterable) then
       return chpl_boundedCoforallSize(iterable[0], zippered=false);
     else if isRange(iterable) || isDomain(iterable) || isArray(iterable) then
-      return iterable.sizeAs(iterable.intIdxType);
+      return iterable.size;
     else
       compilerError("Called chpl_boundedCoforallSize on an unsupported type");
   }

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1192,7 +1192,12 @@ module ChapelDomain {
     /* The ``idxType`` as represented by an integer type.  When
        ``idxType`` is an enum type, this evaluates to ``int``.
        Otherwise, it evaluates to ``idxType``. */
+    @deprecated("'domain.intIdxType' is deprecated; please let us know if you are relying on it")
     proc intIdxType type {
+      return chpl_intIdxType;
+    }
+
+    proc chpl_intIdxType type {
       return chpl__idxTypeToIntIdxType(_value.idxType);
     }
 
@@ -2260,7 +2265,7 @@ module ChapelDomain {
 
     @chpldoc.nodoc
     proc position(i) {
-      var ind = _makeIndexTuple(rank, i, "index"), pos: rank*intIdxType;
+      var ind = _makeIndexTuple(rank, i, "index"), pos: rank*chpl_intIdxType;
       for d in 0..rank-1 do
         pos(d) = _value.dsiDim(d).indexOrder(ind(d));
       return pos;
@@ -2470,7 +2475,7 @@ module ChapelDomain {
     // intended for internal use only:
     //
     proc chpl__unTranslate(off: integral ...rank) do return chpl__unTranslate(off);
-    proc chpl__unTranslate(off: rank*intIdxType) {
+    proc chpl__unTranslate(off: rank*chpl_intIdxType) {
       var ranges = dims();
       for i in 0..rank-1 do
         ranges(i) = dim(i).chpl__unTranslate(off(i));

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1194,10 +1194,10 @@ module ChapelDomain {
        Otherwise, it evaluates to ``idxType``. */
     @deprecated("'domain.intIdxType' is deprecated; please let us know if you are relying on it")
     proc intIdxType type {
-      return chpl_intIdxType;
+      return chpl_integralIdxType;
     }
 
-    proc chpl_intIdxType type {
+    proc chpl_integralIdxType type {
       return chpl__idxTypeToIntIdxType(_value.idxType);
     }
 
@@ -2265,7 +2265,7 @@ module ChapelDomain {
 
     @chpldoc.nodoc
     proc position(i) {
-      var ind = _makeIndexTuple(rank, i, "index"), pos: rank*chpl_intIdxType;
+      var ind = _makeIndexTuple(rank, i, "index"), pos: rank*chpl_integralIdxType;
       for d in 0..rank-1 do
         pos(d) = _value.dsiDim(d).indexOrder(ind(d));
       return pos;
@@ -2475,7 +2475,7 @@ module ChapelDomain {
     // intended for internal use only:
     //
     proc chpl__unTranslate(off: integral ...rank) do return chpl__unTranslate(off);
-    proc chpl__unTranslate(off: rank*chpl_intIdxType) {
+    proc chpl__unTranslate(off: rank*chpl_integralIdxType) {
       var ranges = dims();
       for i in 0..rank-1 do
         ranges(i) = dim(i).chpl__unTranslate(off(i));

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1192,7 +1192,7 @@ module ChapelDomain {
     /* The ``idxType`` as represented by an integer type.  When
        ``idxType`` is an enum type, this evaluates to ``int``.
        Otherwise, it evaluates to ``idxType``. */
-    @deprecated("'domain.intIdxType' is deprecated; please let us know if you are relying on it")
+    @deprecated("'.intIdxType' on domains is deprecated; please let us know if you're relying on it")
     proc intIdxType type {
       return chpl_integralIdxType;
     }

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -155,7 +155,7 @@ module ChapelRange {
      be more of an implementation detail than a user-facing
      feature. */
   @chpldoc.nodoc
-  proc range.intIdxType type {
+  proc range.chpl_intIdxType type {
     return chpl__idxTypeToIntIdxType(idxType);
   }
 
@@ -329,7 +329,7 @@ module ChapelRange {
                            " from a range with strideKind.", s:string);
 
     param isEnumBool = isFiniteIdxType(idxType);
-    type bt = other.intIdxType;
+    type bt = other.chpl_intIdxType;
     const low  = if isEnumBool && !other.hasLowBound()
                  then finiteIdxTypeLow(idxType):bt
                  else other._low;
@@ -989,8 +989,8 @@ module ChapelRange {
   // for low/high of a pre-allocated enum range, ex., in range/domain followers
 
   inline proc ref range.chpl_setFields(low, high, stride) {
-    this._low  = chpl__idxToInt(low):  this.intIdxType;
-    this._high = chpl__idxToInt(high): this.intIdxType;
+    this._low  = chpl__idxToInt(low):  this.chpl_intIdxType;
+    this._high = chpl__idxToInt(high): this.chpl_intIdxType;
     if this.hasParamStrideAltvalAld() {
       if boundsChecking then verifyAppropriateStide(this.strides, stride);
     } else {
@@ -1003,8 +1003,8 @@ module ChapelRange {
 
   inline proc ref range.chpl_setFields(low, high) {
     compilerAssert(this.hasParamStride()); // otherwise stride = ?
-    this._low  = chpl__idxToInt(low):  this.intIdxType;
-    this._high = chpl__idxToInt(high): this.intIdxType;
+    this._low  = chpl__idxToInt(low):  this.chpl_intIdxType;
+    this._high = chpl__idxToInt(high): this.chpl_intIdxType;
   }
 
   /* Returns the range's aligned low bound. If this bound is
@@ -1421,7 +1421,7 @@ module ChapelRange {
     }
     if ! hasPosNegUnitStride()
     {
-      var s = abs(_stride):intIdxType;
+      var s = abs(_stride):chpl_intIdxType;
       if chpl__diffMod(i, _alignment, s) != 0
         then return false;
     }
@@ -1597,12 +1597,12 @@ proc range.safeCast(type t: range(?)) {
   if ! tmp.hasParamStrideAltvalAld() {
     tmp._stride = this.stride.safeCast(tmp.strType);
     tmp._alignment = if isNothingValue(this._alignment) then 0
-                     else this._alignment.safeCast(intIdxType);
+                     else this._alignment.safeCast(chpl_intIdxType);
     tmp._aligned = this.aligned;
   }
 
-  tmp._low = if this.hasLowBound() then chpl__idxToInt(this.lowBound.safeCast(tmp.idxType)) else this._low.safeCast(tmp.intIdxType);
-  tmp._high = if this.hasHighBound() then chpl__idxToInt(this.highBound.safeCast(tmp.idxType)) else this._high.safeCast(tmp.intIdxType);
+  tmp._low = if this.hasLowBound() then chpl__idxToInt(this.lowBound.safeCast(tmp.idxType)) else this._low.safeCast(tmp.chpl_intIdxType);
+  tmp._high = if this.hasHighBound() then chpl__idxToInt(this.highBound.safeCast(tmp.idxType)) else this._high.safeCast(tmp.chpl_intIdxType);
 
   return tmp;
 }
@@ -1657,12 +1657,12 @@ private inline proc rangeCastHelper(r, type t) throws {
   if ! tmp.hasParamStrideAltvalAld() {
     tmp._stride = r.stride: tmp._stride.type;
     tmp._alignment = if isNothingValue(r._alignment) then 0
-                     else r._alignment: tmp.intIdxType;
+                     else r._alignment: tmp.chpl_intIdxType;
     tmp._aligned = r.aligned;
   }
 
-  tmp._low = (if r.hasLowBound() then chpl__idxToInt(r.lowBound:dstType) else r._low): tmp.intIdxType;
-  tmp._high = (if r.hasHighBound() then chpl__idxToInt(r.highBound:dstType) else r._high): tmp.intIdxType;
+  tmp._low = (if r.hasLowBound() then chpl__idxToInt(r.lowBound:dstType) else r._low): tmp.chpl_intIdxType;
+  tmp._high = (if r.hasHighBound() then chpl__idxToInt(r.highBound:dstType) else r._high): tmp.chpl_intIdxType;
 
   return tmp;
 }
@@ -1758,7 +1758,7 @@ private inline proc rangeCastHelper(r, type t) throws {
     if boundsChecking && this.isAmbiguous() then
       HaltWrappers.boundsCheckHalt("indexOrder -- Undefined on a range with ambiguous alignment.");
 
-    if ! contains(ind) then return (-1):intIdxType;
+    if ! contains(ind) then return (-1):chpl_intIdxType;
     if strides.isOne() {
       if this.hasLowBound() then
         return chpl__idxToInt(ind) - _low;
@@ -1767,9 +1767,9 @@ private inline proc rangeCastHelper(r, type t) throws {
         return _high - chpl__idxToInt(ind);
     } else {
       if this.hasFirst() then
-        return ((chpl__idxToInt(ind):strType - chpl__idxToInt(this.first):strType) / _stride):intIdxType;
+        return ((chpl__idxToInt(ind):strType - chpl__idxToInt(this.first):strType) / _stride):chpl_intIdxType;
     }
-    return (-1):intIdxType;
+    return (-1):chpl_intIdxType;
   }
 
   /* Returns the zero-based ``ord``-th element of this range's represented
@@ -1877,7 +1877,7 @@ private inline proc rangeCastHelper(r, type t) throws {
   */
   proc range.expand(offset: integral)
   {
-    const i = offset.safeCast(chpl__signedType(intIdxType));
+    const i = offset.safeCast(chpl__signedType(chpl_intIdxType));
     return new range(idxType, bounds, strides,
                      _low-i,
                      _high+i,
@@ -1901,7 +1901,7 @@ private inline proc rangeCastHelper(r, type t) throws {
 
   @chpldoc.nodoc
   proc range._effAlmt() param  where  hasParamAlignmentVal()
-    do return 0: intIdxType;
+    do return 0: chpl_intIdxType;
 
   // Return an interior portion of this range.
   pragma "last resort"
@@ -1946,7 +1946,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       if abs(offset):uint > this.sizeAs(uint) then
         HaltWrappers.boundsCheckHalt("can't compute the interior " + offset:string + " elements of a range with size " + this.sizeAs(uint):string);
 
-    const i = (abs(offset)).safeCast(intIdxType);
+    const i = (abs(offset)).safeCast(chpl_intIdxType);
     if offset < 0 then
       return new range(idxType, bounds, strides,
                        _low, _low - 1 + i,
@@ -1994,7 +1994,7 @@ private inline proc rangeCastHelper(r, type t) throws {
    */
   proc range.exterior(offset: integral)
   {
-    const i = (abs(offset)).safeCast(intIdxType);
+    const i = (abs(offset)).safeCast(chpl_intIdxType);
     if offset < 0 then
       return new range(idxType, bounds, strides,
                        _low - i,
@@ -2038,8 +2038,8 @@ private inline proc rangeCastHelper(r, type t) throws {
       compilerError("assigning to a range with strideKind.", r1.strides:string,
                            " from a range with strideKind.", r2.strides:string,
                            " without an explicit cast");
-    r1._low = r2._low: r1.intIdxType;
-    r1._high = r2._high: r1.intIdxType;
+    r1._low = r2._low: r1.chpl_intIdxType;
+    r1._high = r2._high: r1.chpl_intIdxType;
 
     if ! r1.hasParamStrideAltvalAld() {
       r1._stride = r2.stride;
@@ -2058,7 +2058,7 @@ private inline proc rangeCastHelper(r, type t) throws {
   @chpldoc.nodoc
   inline operator +(r: range(?e, ?b, ?s), offset: integral)
   {
-    const i = offset:r.intIdxType;
+    const i = offset:r.chpl_intIdxType;
     type strType = chpl__rangeStrideType(e);
 
     return new range(e, b, s,
@@ -2157,7 +2157,7 @@ private inline proc rangeCastHelper(r, type t) throws {
           then (true, r.chpl_alignedHighAsIntForIter)
         else
           if ! r.hasPosNegUnitStride() then (r.aligned, r._alignment)
-                                       else (false, 0:r.intIdxType);
+                                       else (false, 0:r.chpl_intIdxType);
 
     return new range(i, b, newStrides, lw, hh, st, alt, ald);
   }
@@ -2227,7 +2227,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       compilerError("can't apply '.offset()' to a range whose 'idxType' only has one value");
     }
 
-    var offs = offset.safeCast(intIdxType);
+    var offs = offset.safeCast(chpl_intIdxType);
     if hasUnitStride() {
       if !this.hasLowBound() then
         compilerError("can't invoke 'offset' on an unstrided range with no low bound");
@@ -2259,7 +2259,7 @@ private inline proc rangeCastHelper(r, type t) throws {
     if this.isAmbiguous() then
       HaltWrappers.unimplementedFeatureHalt("slicing of an unaligned range");
 
-    // the new idxType, intIdxType, strType are inherited from `this`
+    // the new idxType, chpl_intIdxType, strType are inherited from `this`
 
     /////////// Step 1: intersect the unaligned spans ///////////
 
@@ -2288,7 +2288,7 @@ private inline proc rangeCastHelper(r, type t) throws {
 
     // If the result type is unsigned, don't let the low bound go negative.
     // This is a kludge.  We should really obey type coercion rules. (hilde)
-    if (isUintType(intIdxType)) { if (lo1 < 0) then lo1 = 0; }
+    if (isUintType(chpl_intIdxType)) { if (lo1 < 0) then lo1 = 0; }
 
     //
     // These are mixed int/uint min/max functions that return a value
@@ -2370,8 +2370,8 @@ private inline proc rangeCastHelper(r, type t) throws {
 
 
     emptyIntersection = false;
-    var newlo = myMax(lo1, lo2):intIdxType;
-    var newhi = myMin(hi1, hi2):intIdxType;
+    var newlo = myMax(lo1, lo2):chpl_intIdxType;
+    var newhi = myMin(hi1, hi2):chpl_intIdxType;
 
     if (emptyIntersection) {
       newlo = chpl__defaultLowBound(idxType, newBoundKind);
@@ -2448,15 +2448,15 @@ private inline proc rangeCastHelper(r, type t) throws {
     /////////// allocate the result ///////////
 
     var result = new range(idxType, newBoundKind, newStrideKind,
-                           newlo, newhi, newStride, 0:intIdxType, true, false);
+                           newlo, newhi, newStride, 0:chpl_intIdxType, true, false);
 
     /////////// Step 3: choose the alignment ///////////
 
     // We require that `this` be unambiguous. The result will always be, too.
 
     if ! newStrideKind.isPosNegOne() && newAbsStride > 1 {
-      var al1 = (chpl__idxToInt(this.alignment) % st1:intIdxType):int;
-      var al2 = (chpl__idxToInt(other.alignment) % st2:other.intIdxType):int;
+      var al1 = (chpl__idxToInt(this.alignment) % st1:chpl_intIdxType):int;
+      var al2 = (chpl__idxToInt(other.alignment) % st2:other.chpl_intIdxType):int;
       var newAlignmentIsInAl2 = false;
 
       if other.isAmbiguous() {
@@ -2490,7 +2490,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       if newAlignmentIsInAl2 then
       {
         if al2 < 0 then al2 += newAbsStride;
-        result._alignment = al2: intIdxType;
+        result._alignment = al2: chpl_intIdxType;
       } else
       if (al2 - al1) % g != 0 then
       {
@@ -2500,7 +2500,7 @@ private inline proc rangeCastHelper(r, type t) throws {
         result._low = chpl__defaultLowBound(idxType, newBoundKind);
         result._high = chpl__defaultHighBound(idxType, newBoundKind);
         result._alignment = if this.hasPositiveStride()
-                            then 1:intIdxType else 0:intIdxType;
+                            then 1:chpl_intIdxType else 0:chpl_intIdxType;
         // todo: what should be the alignment of an empty range?
         // _alignment == _low, so it won't print.
       }
@@ -2512,8 +2512,8 @@ private inline proc rangeCastHelper(r, type t) throws {
         // offset is in the range [-(lcm-1), lcm-1]
         // not needed: if offset < 0 then offset += lcm;
 
-        // Now offset can be safely cast to intIdxType.
-        result._alignment = al1:intIdxType + offset:intIdxType * st1:intIdxType / g:intIdxType;
+        // Now offset can be safely cast to chpl_intIdxType.
+        result._alignment = al1:chpl_intIdxType + offset:chpl_intIdxType * st1:chpl_intIdxType / g:chpl_intIdxType;
 
         if result._alignment:int < 0 {
           result._alignment += newAbsStride;
@@ -2551,7 +2551,7 @@ private inline proc rangeCastHelper(r, type t) throws {
     if boundsChecking && r.isAmbiguous() then
       boundsCheckHalt("count -- Cannot count off elements from a range which is ambiguously aligned.");
 
-    type resultType = r.intIdxType;
+    type resultType = r.chpl_intIdxType;
     type strType = chpl__rangeStrideType(resultType);
 
     proc absSameType() {
@@ -2743,7 +2743,7 @@ private inline proc rangeCastHelper(r, type t) throws {
   proc range.checkIfIterWillOverflow(shouldHalt=true) {
     if isFiniteIdxType(idxType) then
       return false;
-    return chpl_checkIfRangeIterWillOverflow(this.intIdxType, this._low, this._high,
+    return chpl_checkIfRangeIterWillOverflow(this.chpl_intIdxType, this._low, this._high,
         this.stride, this.chpl_firstAsIntForIter, this.chpl_lastAsIntForIter, shouldHalt);
   }
 
@@ -3179,14 +3179,14 @@ private inline proc rangeCastHelper(r, type t) throws {
     // stride like the bounded iterators. However, all that gets you is the
     // ability to use .low over .first. The additional code isn't
     // worth it just for that.
-    var i: intIdxType;
+    var i: chpl_intIdxType;
     const start = chpl__idxToInt(this.first);
-    const end = max(intIdxType) - stride: intIdxType;
+    const end = max(chpl_intIdxType) - stride: chpl_intIdxType;
 
     while __primitive("C for loop",
                       __primitive( "=", i, start),
                       __primitive("<=", i, end),
-                      __primitive("+=", i, stride: intIdxType)) {
+                      __primitive("+=", i, stride: chpl_intIdxType)) {
       yield chpl_intToIdx(i);
     }
     if i > end {
@@ -3215,13 +3215,13 @@ private inline proc rangeCastHelper(r, type t) throws {
     // Apart from the computation of 'end' and the comparison used to
     // terminate the C for loop, this iterator follows the bounded-low
     // case above.  See it for additional comments.
-    var i: intIdxType;
+    var i: chpl_intIdxType;
     const start = chpl__idxToInt(this.first);
-    const end = min(intIdxType) - stride: intIdxType;
+    const end = min(chpl_intIdxType) - stride: chpl_intIdxType;
     while __primitive("C for loop",
                       __primitive( "=", i, start),
                       __primitive(">=", i, end),
-                      __primitive("+=", i, stride: intIdxType)) {
+                      __primitive("+=", i, stride: chpl_intIdxType)) {
       yield chpl_intToIdx(i);
     }
     if i < end {
@@ -3249,14 +3249,14 @@ private inline proc rangeCastHelper(r, type t) throws {
       // must use first/last since we have no knowledge of stride
       // must check if low > high (something like 10..1) because of the !=
       // relational operator. Such ranges are supposed to iterate 0 times
-      var i: intIdxType;
+      var i: chpl_intIdxType;
       const start = chpl_firstAsIntForIter;
-      const end: intIdxType = if this._low > this._high then start
-                              else chpl_lastAsIntForIter + stride: intIdxType;
+      const end: chpl_intIdxType = if this._low > this._high then start
+                              else chpl_lastAsIntForIter + stride: chpl_intIdxType;
       while __primitive("C for loop",
                         __primitive( "=", i, start),
                         __primitive("!=", i, end),
-                        __primitive("+=", i, stride: intIdxType)) {
+                        __primitive("+=", i, stride: chpl_intIdxType)) {
         yield chpl_intToIdx(i);
       }
     } else {
@@ -3278,7 +3278,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       // don't need to check if isAmbiguous since stride is one
 
       // can use low/high instead of first/last since stride is one
-      var i: intIdxType;
+      var i: chpl_intIdxType;
       const start = chpl__idxToInt(lowBoundForIter(this));
       const end = chpl__idxToInt(highBoundForIter(this));
 
@@ -3286,14 +3286,14 @@ private inline proc rangeCastHelper(r, type t) throws {
       while __primitive("C for loop",
                         __primitive( "=", i, start),
                         __primitive("<=", i, end),
-                        __primitive("+=", i, 1: intIdxType)) {
+                        __primitive("+=", i, 1: chpl_intIdxType)) {
         yield chpl_intToIdx(i);
       }
      else // stride == -1
       while __primitive("C for loop",
                         __primitive( "=", i, end),
                         __primitive(">=", i, start),
-                        __primitive("-=", i, 1: intIdxType)) {
+                        __primitive("-=", i, 1: chpl_intIdxType)) {
         yield chpl_intToIdx(i);
       }
     } else {
@@ -3323,14 +3323,14 @@ private inline proc rangeCastHelper(r, type t) throws {
     if boundsChecking && hasAmbiguousAlignmentForIter(this) then
       HaltWrappers.boundsCheckHalt("these -- Attempt to iterate over a range with ambiguous alignment.");
 
-    var i: intIdxType;
+    var i: chpl_intIdxType;
     const start = this.first;
     const end = if this._low > this._high then start else this.last;
 
     while __primitive("C for loop",
                       __primitive( "=", i, start),
                       __primitive(">=", highBoundForIter(this), lowBoundForIter(this)),  // execute at least once?
-                      __primitive("+=", i, stride: intIdxType)) {
+                      __primitive("+=", i, stride: chpl_intIdxType)) {
       yield i;
       if i == end then break;
     }
@@ -3354,7 +3354,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       chpl_debug_writeln("*** In range standalone iterator:");
     }
 
-    const len = this.sizeAs(intIdxType);
+    const len = this.sizeAs(chpl_intIdxType);
     const numChunks = if __primitive("task_get_serial") then
                       1 else _computeNumChunks(len);
 
@@ -3398,7 +3398,7 @@ private inline proc rangeCastHelper(r, type t) throws {
     const numSublocs = here._getChildCount();
 
     if localeModelPartitionsIterationOnSublocales && numSublocs != 0 {
-      const len = this.sizeAs(intIdxType);
+      const len = this.sizeAs(chpl_intIdxType);
       const tasksPerLocale = dataParTasksPerLocale;
       const ignoreRunning = dataParIgnoreRunningTasks;
       const minIndicesPerTask = dataParMinGranularity;
@@ -3435,7 +3435,7 @@ private inline proc rangeCastHelper(r, type t) throws {
           }
           const (lo,hi) = _computeBlock(len, numChunks, chunk, len-1);
           const locRange = lo..hi;
-          const locLen = locRange.sizeAs(intIdxType);
+          const locLen = locRange.sizeAs(chpl_intIdxType);
           // Divide the locale's tasks approximately evenly
           // among the sublocales
           const numSublocTasks = (if chunk < dptpl % numChunks
@@ -3457,7 +3457,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       }
 
     } else {
-      var v = this.chpl_sizeAsForIter(intIdxType);
+      var v = this.chpl_sizeAsForIter(chpl_intIdxType);
       const numChunks = if __primitive("task_get_serial") then
                         1 else _computeNumChunks(v);
 
@@ -3521,7 +3521,7 @@ private inline proc rangeCastHelper(r, type t) throws {
         myFollowThis.hasPosNegUnitStride()     ) ||
        myFollowThis.hasLast()
     {
-      const flwlen = myFollowThis.sizeAs(myFollowThis.intIdxType);
+      const flwlen = myFollowThis.sizeAs(myFollowThis.chpl_intIdxType);
       if boundsChecking {
         if this.hasLast() {
           // this check is for typechecking only
@@ -3706,7 +3706,7 @@ private inline proc rangeCastHelper(r, type t) throws {
   }
 
   // Get the simple expression 'start + stride*count' to typecheck.
-  // Use example: low + i:intIdxType * stride.
+  // Use example: low + i:chpl_intIdxType * stride.
   // Use explicit conversions, no other additional runtime work.
   proc chpl__addRangeStrides(start, stride, count): start.type {
     proc convert(a,b) param do

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -155,7 +155,7 @@ module ChapelRange {
      be more of an implementation detail than a user-facing
      feature. */
   @chpldoc.nodoc
-  proc range.chpl_intIdxType type {
+  proc range.chpl_integralIdxType type {
     return chpl__idxTypeToIntIdxType(idxType);
   }
 
@@ -329,7 +329,7 @@ module ChapelRange {
                            " from a range with strideKind.", s:string);
 
     param isEnumBool = isFiniteIdxType(idxType);
-    type bt = other.chpl_intIdxType;
+    type bt = other.chpl_integralIdxType;
     const low  = if isEnumBool && !other.hasLowBound()
                  then finiteIdxTypeLow(idxType):bt
                  else other._low;
@@ -989,8 +989,8 @@ module ChapelRange {
   // for low/high of a pre-allocated enum range, ex., in range/domain followers
 
   inline proc ref range.chpl_setFields(low, high, stride) {
-    this._low  = chpl__idxToInt(low):  this.chpl_intIdxType;
-    this._high = chpl__idxToInt(high): this.chpl_intIdxType;
+    this._low  = chpl__idxToInt(low):  this.chpl_integralIdxType;
+    this._high = chpl__idxToInt(high): this.chpl_integralIdxType;
     if this.hasParamStrideAltvalAld() {
       if boundsChecking then verifyAppropriateStide(this.strides, stride);
     } else {
@@ -1003,8 +1003,8 @@ module ChapelRange {
 
   inline proc ref range.chpl_setFields(low, high) {
     compilerAssert(this.hasParamStride()); // otherwise stride = ?
-    this._low  = chpl__idxToInt(low):  this.chpl_intIdxType;
-    this._high = chpl__idxToInt(high): this.chpl_intIdxType;
+    this._low  = chpl__idxToInt(low):  this.chpl_integralIdxType;
+    this._high = chpl__idxToInt(high): this.chpl_integralIdxType;
   }
 
   /* Returns the range's aligned low bound. If this bound is
@@ -1421,7 +1421,7 @@ module ChapelRange {
     }
     if ! hasPosNegUnitStride()
     {
-      var s = abs(_stride):chpl_intIdxType;
+      var s = abs(_stride):chpl_integralIdxType;
       if chpl__diffMod(i, _alignment, s) != 0
         then return false;
     }
@@ -1597,12 +1597,12 @@ proc range.safeCast(type t: range(?)) {
   if ! tmp.hasParamStrideAltvalAld() {
     tmp._stride = this.stride.safeCast(tmp.strType);
     tmp._alignment = if isNothingValue(this._alignment) then 0
-                     else this._alignment.safeCast(chpl_intIdxType);
+                     else this._alignment.safeCast(chpl_integralIdxType);
     tmp._aligned = this.aligned;
   }
 
-  tmp._low = if this.hasLowBound() then chpl__idxToInt(this.lowBound.safeCast(tmp.idxType)) else this._low.safeCast(tmp.chpl_intIdxType);
-  tmp._high = if this.hasHighBound() then chpl__idxToInt(this.highBound.safeCast(tmp.idxType)) else this._high.safeCast(tmp.chpl_intIdxType);
+  tmp._low = if this.hasLowBound() then chpl__idxToInt(this.lowBound.safeCast(tmp.idxType)) else this._low.safeCast(tmp.chpl_integralIdxType);
+  tmp._high = if this.hasHighBound() then chpl__idxToInt(this.highBound.safeCast(tmp.idxType)) else this._high.safeCast(tmp.chpl_integralIdxType);
 
   return tmp;
 }
@@ -1657,12 +1657,12 @@ private inline proc rangeCastHelper(r, type t) throws {
   if ! tmp.hasParamStrideAltvalAld() {
     tmp._stride = r.stride: tmp._stride.type;
     tmp._alignment = if isNothingValue(r._alignment) then 0
-                     else r._alignment: tmp.chpl_intIdxType;
+                     else r._alignment: tmp.chpl_integralIdxType;
     tmp._aligned = r.aligned;
   }
 
-  tmp._low = (if r.hasLowBound() then chpl__idxToInt(r.lowBound:dstType) else r._low): tmp.chpl_intIdxType;
-  tmp._high = (if r.hasHighBound() then chpl__idxToInt(r.highBound:dstType) else r._high): tmp.chpl_intIdxType;
+  tmp._low = (if r.hasLowBound() then chpl__idxToInt(r.lowBound:dstType) else r._low): tmp.chpl_integralIdxType;
+  tmp._high = (if r.hasHighBound() then chpl__idxToInt(r.highBound:dstType) else r._high): tmp.chpl_integralIdxType;
 
   return tmp;
 }
@@ -1758,7 +1758,7 @@ private inline proc rangeCastHelper(r, type t) throws {
     if boundsChecking && this.isAmbiguous() then
       HaltWrappers.boundsCheckHalt("indexOrder -- Undefined on a range with ambiguous alignment.");
 
-    if ! contains(ind) then return (-1):chpl_intIdxType;
+    if ! contains(ind) then return (-1):chpl_integralIdxType;
     if strides.isOne() {
       if this.hasLowBound() then
         return chpl__idxToInt(ind) - _low;
@@ -1767,9 +1767,9 @@ private inline proc rangeCastHelper(r, type t) throws {
         return _high - chpl__idxToInt(ind);
     } else {
       if this.hasFirst() then
-        return ((chpl__idxToInt(ind):strType - chpl__idxToInt(this.first):strType) / _stride):chpl_intIdxType;
+        return ((chpl__idxToInt(ind):strType - chpl__idxToInt(this.first):strType) / _stride):chpl_integralIdxType;
     }
-    return (-1):chpl_intIdxType;
+    return (-1):chpl_integralIdxType;
   }
 
   /* Returns the zero-based ``ord``-th element of this range's represented
@@ -1877,7 +1877,7 @@ private inline proc rangeCastHelper(r, type t) throws {
   */
   proc range.expand(offset: integral)
   {
-    const i = offset.safeCast(chpl__signedType(chpl_intIdxType));
+    const i = offset.safeCast(chpl__signedType(chpl_integralIdxType));
     return new range(idxType, bounds, strides,
                      _low-i,
                      _high+i,
@@ -1901,7 +1901,7 @@ private inline proc rangeCastHelper(r, type t) throws {
 
   @chpldoc.nodoc
   proc range._effAlmt() param  where  hasParamAlignmentVal()
-    do return 0: chpl_intIdxType;
+    do return 0: chpl_integralIdxType;
 
   // Return an interior portion of this range.
   pragma "last resort"
@@ -1946,7 +1946,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       if abs(offset):uint > this.sizeAs(uint) then
         HaltWrappers.boundsCheckHalt("can't compute the interior " + offset:string + " elements of a range with size " + this.sizeAs(uint):string);
 
-    const i = (abs(offset)).safeCast(chpl_intIdxType);
+    const i = (abs(offset)).safeCast(chpl_integralIdxType);
     if offset < 0 then
       return new range(idxType, bounds, strides,
                        _low, _low - 1 + i,
@@ -1994,7 +1994,7 @@ private inline proc rangeCastHelper(r, type t) throws {
    */
   proc range.exterior(offset: integral)
   {
-    const i = (abs(offset)).safeCast(chpl_intIdxType);
+    const i = (abs(offset)).safeCast(chpl_integralIdxType);
     if offset < 0 then
       return new range(idxType, bounds, strides,
                        _low - i,
@@ -2038,8 +2038,8 @@ private inline proc rangeCastHelper(r, type t) throws {
       compilerError("assigning to a range with strideKind.", r1.strides:string,
                            " from a range with strideKind.", r2.strides:string,
                            " without an explicit cast");
-    r1._low = r2._low: r1.chpl_intIdxType;
-    r1._high = r2._high: r1.chpl_intIdxType;
+    r1._low = r2._low: r1.chpl_integralIdxType;
+    r1._high = r2._high: r1.chpl_integralIdxType;
 
     if ! r1.hasParamStrideAltvalAld() {
       r1._stride = r2.stride;
@@ -2058,7 +2058,7 @@ private inline proc rangeCastHelper(r, type t) throws {
   @chpldoc.nodoc
   inline operator +(r: range(?e, ?b, ?s), offset: integral)
   {
-    const i = offset:r.chpl_intIdxType;
+    const i = offset:r.chpl_integralIdxType;
     type strType = chpl__rangeStrideType(e);
 
     return new range(e, b, s,
@@ -2157,7 +2157,7 @@ private inline proc rangeCastHelper(r, type t) throws {
           then (true, r.chpl_alignedHighAsIntForIter)
         else
           if ! r.hasPosNegUnitStride() then (r.aligned, r._alignment)
-                                       else (false, 0:r.chpl_intIdxType);
+                                       else (false, 0:r.chpl_integralIdxType);
 
     return new range(i, b, newStrides, lw, hh, st, alt, ald);
   }
@@ -2227,7 +2227,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       compilerError("can't apply '.offset()' to a range whose 'idxType' only has one value");
     }
 
-    var offs = offset.safeCast(chpl_intIdxType);
+    var offs = offset.safeCast(chpl_integralIdxType);
     if hasUnitStride() {
       if !this.hasLowBound() then
         compilerError("can't invoke 'offset' on an unstrided range with no low bound");
@@ -2259,7 +2259,7 @@ private inline proc rangeCastHelper(r, type t) throws {
     if this.isAmbiguous() then
       HaltWrappers.unimplementedFeatureHalt("slicing of an unaligned range");
 
-    // the new idxType, chpl_intIdxType, strType are inherited from `this`
+    // the new idxType, chpl_integralIdxType, strType are inherited from `this`
 
     /////////// Step 1: intersect the unaligned spans ///////////
 
@@ -2288,7 +2288,7 @@ private inline proc rangeCastHelper(r, type t) throws {
 
     // If the result type is unsigned, don't let the low bound go negative.
     // This is a kludge.  We should really obey type coercion rules. (hilde)
-    if (isUintType(chpl_intIdxType)) { if (lo1 < 0) then lo1 = 0; }
+    if (isUintType(chpl_integralIdxType)) { if (lo1 < 0) then lo1 = 0; }
 
     //
     // These are mixed int/uint min/max functions that return a value
@@ -2370,8 +2370,8 @@ private inline proc rangeCastHelper(r, type t) throws {
 
 
     emptyIntersection = false;
-    var newlo = myMax(lo1, lo2):chpl_intIdxType;
-    var newhi = myMin(hi1, hi2):chpl_intIdxType;
+    var newlo = myMax(lo1, lo2):chpl_integralIdxType;
+    var newhi = myMin(hi1, hi2):chpl_integralIdxType;
 
     if (emptyIntersection) {
       newlo = chpl__defaultLowBound(idxType, newBoundKind);
@@ -2448,15 +2448,15 @@ private inline proc rangeCastHelper(r, type t) throws {
     /////////// allocate the result ///////////
 
     var result = new range(idxType, newBoundKind, newStrideKind,
-                           newlo, newhi, newStride, 0:chpl_intIdxType, true, false);
+                           newlo, newhi, newStride, 0:chpl_integralIdxType, true, false);
 
     /////////// Step 3: choose the alignment ///////////
 
     // We require that `this` be unambiguous. The result will always be, too.
 
     if ! newStrideKind.isPosNegOne() && newAbsStride > 1 {
-      var al1 = (chpl__idxToInt(this.alignment) % st1:chpl_intIdxType):int;
-      var al2 = (chpl__idxToInt(other.alignment) % st2:other.chpl_intIdxType):int;
+      var al1 = (chpl__idxToInt(this.alignment) % st1:chpl_integralIdxType):int;
+      var al2 = (chpl__idxToInt(other.alignment) % st2:other.chpl_integralIdxType):int;
       var newAlignmentIsInAl2 = false;
 
       if other.isAmbiguous() {
@@ -2490,7 +2490,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       if newAlignmentIsInAl2 then
       {
         if al2 < 0 then al2 += newAbsStride;
-        result._alignment = al2: chpl_intIdxType;
+        result._alignment = al2: chpl_integralIdxType;
       } else
       if (al2 - al1) % g != 0 then
       {
@@ -2500,7 +2500,7 @@ private inline proc rangeCastHelper(r, type t) throws {
         result._low = chpl__defaultLowBound(idxType, newBoundKind);
         result._high = chpl__defaultHighBound(idxType, newBoundKind);
         result._alignment = if this.hasPositiveStride()
-                            then 1:chpl_intIdxType else 0:chpl_intIdxType;
+                            then 1:chpl_integralIdxType else 0:chpl_integralIdxType;
         // todo: what should be the alignment of an empty range?
         // _alignment == _low, so it won't print.
       }
@@ -2512,8 +2512,8 @@ private inline proc rangeCastHelper(r, type t) throws {
         // offset is in the range [-(lcm-1), lcm-1]
         // not needed: if offset < 0 then offset += lcm;
 
-        // Now offset can be safely cast to chpl_intIdxType.
-        result._alignment = al1:chpl_intIdxType + offset:chpl_intIdxType * st1:chpl_intIdxType / g:chpl_intIdxType;
+        // Now offset can be safely cast to chpl_integralIdxType.
+        result._alignment = al1:chpl_integralIdxType + offset:chpl_integralIdxType * st1:chpl_integralIdxType / g:chpl_integralIdxType;
 
         if result._alignment:int < 0 {
           result._alignment += newAbsStride;
@@ -2551,7 +2551,7 @@ private inline proc rangeCastHelper(r, type t) throws {
     if boundsChecking && r.isAmbiguous() then
       boundsCheckHalt("count -- Cannot count off elements from a range which is ambiguously aligned.");
 
-    type resultType = r.chpl_intIdxType;
+    type resultType = r.chpl_integralIdxType;
     type strType = chpl__rangeStrideType(resultType);
 
     proc absSameType() {
@@ -2743,7 +2743,7 @@ private inline proc rangeCastHelper(r, type t) throws {
   proc range.checkIfIterWillOverflow(shouldHalt=true) {
     if isFiniteIdxType(idxType) then
       return false;
-    return chpl_checkIfRangeIterWillOverflow(this.chpl_intIdxType, this._low, this._high,
+    return chpl_checkIfRangeIterWillOverflow(this.chpl_integralIdxType, this._low, this._high,
         this.stride, this.chpl_firstAsIntForIter, this.chpl_lastAsIntForIter, shouldHalt);
   }
 
@@ -3179,14 +3179,14 @@ private inline proc rangeCastHelper(r, type t) throws {
     // stride like the bounded iterators. However, all that gets you is the
     // ability to use .low over .first. The additional code isn't
     // worth it just for that.
-    var i: chpl_intIdxType;
+    var i: chpl_integralIdxType;
     const start = chpl__idxToInt(this.first);
-    const end = max(chpl_intIdxType) - stride: chpl_intIdxType;
+    const end = max(chpl_integralIdxType) - stride: chpl_integralIdxType;
 
     while __primitive("C for loop",
                       __primitive( "=", i, start),
                       __primitive("<=", i, end),
-                      __primitive("+=", i, stride: chpl_intIdxType)) {
+                      __primitive("+=", i, stride: chpl_integralIdxType)) {
       yield chpl_intToIdx(i);
     }
     if i > end {
@@ -3215,13 +3215,13 @@ private inline proc rangeCastHelper(r, type t) throws {
     // Apart from the computation of 'end' and the comparison used to
     // terminate the C for loop, this iterator follows the bounded-low
     // case above.  See it for additional comments.
-    var i: chpl_intIdxType;
+    var i: chpl_integralIdxType;
     const start = chpl__idxToInt(this.first);
-    const end = min(chpl_intIdxType) - stride: chpl_intIdxType;
+    const end = min(chpl_integralIdxType) - stride: chpl_integralIdxType;
     while __primitive("C for loop",
                       __primitive( "=", i, start),
                       __primitive(">=", i, end),
-                      __primitive("+=", i, stride: chpl_intIdxType)) {
+                      __primitive("+=", i, stride: chpl_integralIdxType)) {
       yield chpl_intToIdx(i);
     }
     if i < end {
@@ -3249,14 +3249,14 @@ private inline proc rangeCastHelper(r, type t) throws {
       // must use first/last since we have no knowledge of stride
       // must check if low > high (something like 10..1) because of the !=
       // relational operator. Such ranges are supposed to iterate 0 times
-      var i: chpl_intIdxType;
+      var i: chpl_integralIdxType;
       const start = chpl_firstAsIntForIter;
-      const end: chpl_intIdxType = if this._low > this._high then start
-                              else chpl_lastAsIntForIter + stride: chpl_intIdxType;
+      const end: chpl_integralIdxType = if this._low > this._high then start
+                              else chpl_lastAsIntForIter + stride: chpl_integralIdxType;
       while __primitive("C for loop",
                         __primitive( "=", i, start),
                         __primitive("!=", i, end),
-                        __primitive("+=", i, stride: chpl_intIdxType)) {
+                        __primitive("+=", i, stride: chpl_integralIdxType)) {
         yield chpl_intToIdx(i);
       }
     } else {
@@ -3278,7 +3278,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       // don't need to check if isAmbiguous since stride is one
 
       // can use low/high instead of first/last since stride is one
-      var i: chpl_intIdxType;
+      var i: chpl_integralIdxType;
       const start = chpl__idxToInt(lowBoundForIter(this));
       const end = chpl__idxToInt(highBoundForIter(this));
 
@@ -3286,14 +3286,14 @@ private inline proc rangeCastHelper(r, type t) throws {
       while __primitive("C for loop",
                         __primitive( "=", i, start),
                         __primitive("<=", i, end),
-                        __primitive("+=", i, 1: chpl_intIdxType)) {
+                        __primitive("+=", i, 1: chpl_integralIdxType)) {
         yield chpl_intToIdx(i);
       }
      else // stride == -1
       while __primitive("C for loop",
                         __primitive( "=", i, end),
                         __primitive(">=", i, start),
-                        __primitive("-=", i, 1: chpl_intIdxType)) {
+                        __primitive("-=", i, 1: chpl_integralIdxType)) {
         yield chpl_intToIdx(i);
       }
     } else {
@@ -3323,14 +3323,14 @@ private inline proc rangeCastHelper(r, type t) throws {
     if boundsChecking && hasAmbiguousAlignmentForIter(this) then
       HaltWrappers.boundsCheckHalt("these -- Attempt to iterate over a range with ambiguous alignment.");
 
-    var i: chpl_intIdxType;
+    var i: chpl_integralIdxType;
     const start = this.first;
     const end = if this._low > this._high then start else this.last;
 
     while __primitive("C for loop",
                       __primitive( "=", i, start),
                       __primitive(">=", highBoundForIter(this), lowBoundForIter(this)),  // execute at least once?
-                      __primitive("+=", i, stride: chpl_intIdxType)) {
+                      __primitive("+=", i, stride: chpl_integralIdxType)) {
       yield i;
       if i == end then break;
     }
@@ -3354,7 +3354,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       chpl_debug_writeln("*** In range standalone iterator:");
     }
 
-    const len = this.sizeAs(chpl_intIdxType);
+    const len = this.sizeAs(chpl_integralIdxType);
     const numChunks = if __primitive("task_get_serial") then
                       1 else _computeNumChunks(len);
 
@@ -3398,7 +3398,7 @@ private inline proc rangeCastHelper(r, type t) throws {
     const numSublocs = here._getChildCount();
 
     if localeModelPartitionsIterationOnSublocales && numSublocs != 0 {
-      const len = this.sizeAs(chpl_intIdxType);
+      const len = this.sizeAs(chpl_integralIdxType);
       const tasksPerLocale = dataParTasksPerLocale;
       const ignoreRunning = dataParIgnoreRunningTasks;
       const minIndicesPerTask = dataParMinGranularity;
@@ -3435,7 +3435,7 @@ private inline proc rangeCastHelper(r, type t) throws {
           }
           const (lo,hi) = _computeBlock(len, numChunks, chunk, len-1);
           const locRange = lo..hi;
-          const locLen = locRange.sizeAs(chpl_intIdxType);
+          const locLen = locRange.sizeAs(chpl_integralIdxType);
           // Divide the locale's tasks approximately evenly
           // among the sublocales
           const numSublocTasks = (if chunk < dptpl % numChunks
@@ -3457,7 +3457,7 @@ private inline proc rangeCastHelper(r, type t) throws {
       }
 
     } else {
-      var v = this.chpl_sizeAsForIter(chpl_intIdxType);
+      var v = this.chpl_sizeAsForIter(chpl_integralIdxType);
       const numChunks = if __primitive("task_get_serial") then
                         1 else _computeNumChunks(v);
 
@@ -3521,7 +3521,7 @@ private inline proc rangeCastHelper(r, type t) throws {
         myFollowThis.hasPosNegUnitStride()     ) ||
        myFollowThis.hasLast()
     {
-      const flwlen = myFollowThis.sizeAs(myFollowThis.chpl_intIdxType);
+      const flwlen = myFollowThis.sizeAs(myFollowThis.chpl_integralIdxType);
       if boundsChecking {
         if this.hasLast() {
           // this check is for typechecking only
@@ -3706,7 +3706,7 @@ private inline proc rangeCastHelper(r, type t) throws {
   }
 
   // Get the simple expression 'start + stride*count' to typecheck.
-  // Use example: low + i:chpl_intIdxType * stride.
+  // Use example: low + i:chpl_integralIdxType * stride.
   // Use explicit conversions, no other additional runtime work.
   proc chpl__addRangeStrides(start, stride, count): start.type {
     proc convert(a,b) param do

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -167,7 +167,7 @@ module DefaultRectangular {
       this.dist = dist;
     }
 
-    proc chpl_intIdxType type {
+    proc chpl_integralIdxType type {
       return chpl__idxTypeToIntIdxType(idxType);
     }
 
@@ -279,7 +279,7 @@ module DefaultRectangular {
     iter these(tasksPerLocale = dataParTasksPerLocale,
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
-               offset=createTuple(rank, chpl_intIdxType, 0:chpl_intIdxType)) {
+               offset=createTuple(rank, chpl_integralIdxType, 0:chpl_integralIdxType)) {
       if rank == 1 {
         for i in ranges(0) do
           yield i;
@@ -293,7 +293,7 @@ module DefaultRectangular {
                tasksPerLocale = dataParTasksPerLocale,
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
-               offset=createTuple(rank, chpl_intIdxType, 0:chpl_intIdxType))
+               offset=createTuple(rank, chpl_integralIdxType, 0:chpl_integralIdxType))
       where tag == iterKind.standalone {
       if chpl__testParFlag then
         chpl__testPar("default rectangular domain standalone invoked on ", ranges);
@@ -356,7 +356,7 @@ module DefaultRectangular {
                tasksPerLocale = dataParTasksPerLocale,
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
-               offset=createTuple(rank, chpl_intIdxType, 0:chpl_intIdxType))
+               offset=createTuple(rank, chpl_integralIdxType, 0:chpl_integralIdxType))
       where tag == iterKind.leader {
 
       const numSublocs = here._getChildCount();
@@ -399,11 +399,11 @@ module DefaultRectangular {
             const numSublocTasks = (if chunk < dptpl % numChunks
                                     then dptpl / numChunks + 1
                                     else dptpl / numChunks);
-            var locBlock: rank*range(chpl_intIdxType);
+            var locBlock: rank*range(chpl_integralIdxType);
             for param i in 0..rank-1 do
-              locBlock(i) = offset(i)..#(ranges(i).sizeAs(chpl_intIdxType));
-            var followMe: rank*range(chpl_intIdxType) = locBlock;
-            const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(chpl_intIdxType),
+              locBlock(i) = offset(i)..#(ranges(i).sizeAs(chpl_integralIdxType));
+            var followMe: rank*range(chpl_integralIdxType) = locBlock;
+            const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(chpl_integralIdxType),
                                           numChunks, chunk,
                                           locBlock(parDim)._high,
                                           locBlock(parDim)._low,
@@ -414,13 +414,13 @@ module DefaultRectangular {
                                                              minIndicesPerTask,
                                                              followMe);
             coforall chunk2 in 0..#numChunks2 {
-              var locBlock2: rank*range(chpl_intIdxType);
+              var locBlock2: rank*range(chpl_integralIdxType);
               for param i in 0..rank-1 do
                 locBlock2(i) = followMe(i).lowBound..followMe(i).highBound;
-              var followMe2: rank*range(chpl_intIdxType) = locBlock2;
+              var followMe2: rank*range(chpl_integralIdxType) = locBlock2;
               const low  = locBlock2(parDim2)._low,
                 high = locBlock2(parDim2)._high;
-              const (lo,hi) = _computeBlock(locBlock2(parDim2).sizeAs(chpl_intIdxType),
+              const (lo,hi) = _computeBlock(locBlock2(parDim2).sizeAs(chpl_integralIdxType),
                                             numChunks2, chunk2,
                                             high, low, low);
               followMe2(parDim2) = lo..hi;
@@ -461,14 +461,14 @@ module DefaultRectangular {
                   "### nranges = ", ranges);
         }
 
-        var locBlock: rank*range(chpl_intIdxType);
+        var locBlock: rank*range(chpl_integralIdxType);
         for param i in 0..rank-1 do
-          locBlock(i) = offset(i)..#(ranges(i).sizeAs(chpl_intIdxType));
+          locBlock(i) = offset(i)..#(ranges(i).sizeAs(chpl_integralIdxType));
         if debugDefaultDist then
           chpl_debug_writeln("*** DI: locBlock = ", locBlock);
         coforall chunk in 0..#numChunks {
-          var followMe: rank*range(chpl_intIdxType) = locBlock;
-          const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(chpl_intIdxType),
+          var followMe: rank*range(chpl_integralIdxType) = locBlock;
+          const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(chpl_integralIdxType),
                                         numChunks, chunk,
                                         locBlock(parDim)._high,
                                         locBlock(parDim)._low,
@@ -485,7 +485,7 @@ module DefaultRectangular {
                tasksPerLocale = dataParTasksPerLocale,
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
-               offset=createTuple(rank, chpl_intIdxType, 0:chpl_intIdxType))
+               offset=createTuple(rank, chpl_integralIdxType, 0:chpl_integralIdxType))
       where tag == iterKind.follower {
 
       if followThis.size != this.rank then
@@ -501,27 +501,27 @@ module DefaultRectangular {
       param newStrides = chpl_strideProduct(this.strides,
                                             chpl_strideUnion(followThis));
 
-      var block: rank*range(idxType=chpl_intIdxType, strides=newStrides);
+      var block: rank*range(idxType=chpl_integralIdxType, strides=newStrides);
       if boundsChecking then
         for param i in 0..rank-1 do
           if followThis(i).highBound >= ranges(i).sizeAs(uint) then
             HaltWrappers.boundsCheckHalt("size mismatch in zippered iteration (dimension " + i:string + ")");
 
       if ! newStrides.isPosNegOne() {
-        type strType = chpl__signedType(chpl_intIdxType);
+        type strType = chpl__signedType(chpl_integralIdxType);
         for param i in 0..rank-1 {
           const rStride = ranges(i).stride;
           const rSignedStride = rStride:strType,
                 fSignedStride = followThis(i).stride:strType;
           if ranges(i).hasPositiveStride() {
-            const riStride = rStride:chpl_intIdxType;
+            const riStride = rStride:chpl_integralIdxType;
             const low = ranges(i).alignedLowAsInt + followThis(i).lowBound*riStride,
                   high = ranges(i).alignedLowAsInt + followThis(i).highBound*riStride,
                   stride = (rSignedStride * fSignedStride):strType;
             block(i).chpl_setFields(low, high, stride);
 
           } else {
-            const irStride = (-rStride):chpl_intIdxType;
+            const irStride = (-rStride):chpl_integralIdxType;
             const low = ranges(i).alignedHighAsInt - followThis(i).highBound*irStride,
                   high = ranges(i).alignedHighAsInt - followThis(i).lowBound*irStride,
                   stride = (rSignedStride * fSignedStride):strType;
@@ -530,20 +530,20 @@ module DefaultRectangular {
         }
       } else {
         // else-branch duplicates then-branch, except here strides are params
-        type strType = chpl__signedType(chpl_intIdxType);
+        type strType = chpl__signedType(chpl_integralIdxType);
         for param i in 0..rank-1 {
           param rStride = ranges(i).stride;
           param rSignedStride = rStride:strType,
                 fSignedStride = followThis(i).stride:strType;
           if ranges(i).hasPositiveStride() {
-            param riStride = rStride:chpl_intIdxType;
+            param riStride = rStride:chpl_integralIdxType;
             const low = ranges(i).alignedLowAsInt + followThis(i).lowBound*riStride,
                   high = ranges(i).alignedLowAsInt + followThis(i).highBound*riStride;
             param stride = (rSignedStride * fSignedStride):strType;
             block(i).chpl_setFields(low, high);
 
           } else {
-            param irStride = (-rStride):chpl_intIdxType;
+            param irStride = (-rStride):chpl_integralIdxType;
             const low = ranges(i).alignedHighAsInt - followThis(i).highBound*irStride,
                   high = ranges(i).alignedHighAsInt - followThis(i).lowBound*irStride;
             param stride = (rSignedStride * fSignedStride):strType;
@@ -576,7 +576,7 @@ module DefaultRectangular {
       for param d in 0..rank-1 by -1 {
         const orderD = ranges(d).indexOrder(ind(d));
         // NOTE: This follows from the implementation of indexOrder()
-        if (orderD == (-1):chpl_intIdxType) then return orderD;
+        if (orderD == (-1):chpl_integralIdxType) then return orderD;
         totOrder += orderD * blk;
         blk *= ranges(d).sizeAs(int);
       }
@@ -652,7 +652,7 @@ module DefaultRectangular {
       if rank == 1 {
         return ranges(0).stride;
       } else {
-        var result: rank*chpl__signedType(chpl_intIdxType);
+        var result: rank*chpl__signedType(chpl_integralIdxType);
         for param i in 0..rank-1 do
           result(i) = ranges(i).stride;
         return result;
@@ -942,8 +942,8 @@ module DefaultRectangular {
   //
   proc _remoteAccessData.toRankChange(newDom, cd, idx) {
     compilerAssert(this.rank == idx.size && this.rank != newDom.rank);
-    type chpl_intIdxType = newDom.chpl_intIdxType;
-    type idxSignedType = chpl__signedType(chpl_intIdxType);
+    type chpl_integralIdxType = newDom.chpl_integralIdxType;
+    type idxSignedType = chpl__signedType(chpl_integralIdxType);
 
     // Unconditionally sets 'blkChanged'
     //
@@ -1078,7 +1078,7 @@ module DefaultRectangular {
       this.setupFieldsAndAllocate(initElts);
     }
 
-    proc chpl_intIdxType type {
+    proc chpl_integralIdxType type {
       return chpl__idxTypeToIntIdxType(idxType);
     }
 
@@ -2039,7 +2039,7 @@ module DefaultRectangular {
     for param i in 0..rank-1 do
       Blo(i) = Bdims(i).first;
 
-    const len = aView.sizeAs(aView.chpl_intIdxType).safeCast(c_size_t);
+    const len = aView.sizeAs(aView.chpl_integralIdxType).safeCast(c_size_t);
 
     if len == 0 then return;
 
@@ -2169,7 +2169,7 @@ module DefaultRectangular {
   private proc complexTransferCore(LHS, LViewDom, RHS, RViewDom) {
     param minRank = min(LHS.rank, RHS.rank);
     type  idxType = LHS.idxType;
-    type  chpl_intIdxType = LHS.chpl_intIdxType;
+    type  chpl_integralIdxType = LHS.chpl_integralIdxType;
 
     if debugDefaultDistBulkTransfer {
       writeln("Transferring views :", LViewDom, " <-- ", RViewDom);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -167,7 +167,7 @@ module DefaultRectangular {
       this.dist = dist;
     }
 
-    proc intIdxType type {
+    proc chpl_intIdxType type {
       return chpl__idxTypeToIntIdxType(idxType);
     }
 
@@ -279,7 +279,7 @@ module DefaultRectangular {
     iter these(tasksPerLocale = dataParTasksPerLocale,
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
-               offset=createTuple(rank, intIdxType, 0:intIdxType)) {
+               offset=createTuple(rank, chpl_intIdxType, 0:chpl_intIdxType)) {
       if rank == 1 {
         for i in ranges(0) do
           yield i;
@@ -293,7 +293,7 @@ module DefaultRectangular {
                tasksPerLocale = dataParTasksPerLocale,
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
-               offset=createTuple(rank, intIdxType, 0:intIdxType))
+               offset=createTuple(rank, chpl_intIdxType, 0:chpl_intIdxType))
       where tag == iterKind.standalone {
       if chpl__testParFlag then
         chpl__testPar("default rectangular domain standalone invoked on ", ranges);
@@ -356,7 +356,7 @@ module DefaultRectangular {
                tasksPerLocale = dataParTasksPerLocale,
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
-               offset=createTuple(rank, intIdxType, 0:intIdxType))
+               offset=createTuple(rank, chpl_intIdxType, 0:chpl_intIdxType))
       where tag == iterKind.leader {
 
       const numSublocs = here._getChildCount();
@@ -399,11 +399,11 @@ module DefaultRectangular {
             const numSublocTasks = (if chunk < dptpl % numChunks
                                     then dptpl / numChunks + 1
                                     else dptpl / numChunks);
-            var locBlock: rank*range(intIdxType);
+            var locBlock: rank*range(chpl_intIdxType);
             for param i in 0..rank-1 do
-              locBlock(i) = offset(i)..#(ranges(i).sizeAs(intIdxType));
-            var followMe: rank*range(intIdxType) = locBlock;
-            const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(intIdxType),
+              locBlock(i) = offset(i)..#(ranges(i).sizeAs(chpl_intIdxType));
+            var followMe: rank*range(chpl_intIdxType) = locBlock;
+            const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(chpl_intIdxType),
                                           numChunks, chunk,
                                           locBlock(parDim)._high,
                                           locBlock(parDim)._low,
@@ -414,13 +414,13 @@ module DefaultRectangular {
                                                              minIndicesPerTask,
                                                              followMe);
             coforall chunk2 in 0..#numChunks2 {
-              var locBlock2: rank*range(intIdxType);
+              var locBlock2: rank*range(chpl_intIdxType);
               for param i in 0..rank-1 do
                 locBlock2(i) = followMe(i).lowBound..followMe(i).highBound;
-              var followMe2: rank*range(intIdxType) = locBlock2;
+              var followMe2: rank*range(chpl_intIdxType) = locBlock2;
               const low  = locBlock2(parDim2)._low,
                 high = locBlock2(parDim2)._high;
-              const (lo,hi) = _computeBlock(locBlock2(parDim2).sizeAs(intIdxType),
+              const (lo,hi) = _computeBlock(locBlock2(parDim2).sizeAs(chpl_intIdxType),
                                             numChunks2, chunk2,
                                             high, low, low);
               followMe2(parDim2) = lo..hi;
@@ -461,14 +461,14 @@ module DefaultRectangular {
                   "### nranges = ", ranges);
         }
 
-        var locBlock: rank*range(intIdxType);
+        var locBlock: rank*range(chpl_intIdxType);
         for param i in 0..rank-1 do
-          locBlock(i) = offset(i)..#(ranges(i).sizeAs(intIdxType));
+          locBlock(i) = offset(i)..#(ranges(i).sizeAs(chpl_intIdxType));
         if debugDefaultDist then
           chpl_debug_writeln("*** DI: locBlock = ", locBlock);
         coforall chunk in 0..#numChunks {
-          var followMe: rank*range(intIdxType) = locBlock;
-          const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(intIdxType),
+          var followMe: rank*range(chpl_intIdxType) = locBlock;
+          const (lo,hi) = _computeBlock(locBlock(parDim).sizeAs(chpl_intIdxType),
                                         numChunks, chunk,
                                         locBlock(parDim)._high,
                                         locBlock(parDim)._low,
@@ -485,7 +485,7 @@ module DefaultRectangular {
                tasksPerLocale = dataParTasksPerLocale,
                ignoreRunning = dataParIgnoreRunningTasks,
                minIndicesPerTask = dataParMinGranularity,
-               offset=createTuple(rank, intIdxType, 0:intIdxType))
+               offset=createTuple(rank, chpl_intIdxType, 0:chpl_intIdxType))
       where tag == iterKind.follower {
 
       if followThis.size != this.rank then
@@ -501,27 +501,27 @@ module DefaultRectangular {
       param newStrides = chpl_strideProduct(this.strides,
                                             chpl_strideUnion(followThis));
 
-      var block: rank*range(idxType=intIdxType, strides=newStrides);
+      var block: rank*range(idxType=chpl_intIdxType, strides=newStrides);
       if boundsChecking then
         for param i in 0..rank-1 do
           if followThis(i).highBound >= ranges(i).sizeAs(uint) then
             HaltWrappers.boundsCheckHalt("size mismatch in zippered iteration (dimension " + i:string + ")");
 
       if ! newStrides.isPosNegOne() {
-        type strType = chpl__signedType(intIdxType);
+        type strType = chpl__signedType(chpl_intIdxType);
         for param i in 0..rank-1 {
           const rStride = ranges(i).stride;
           const rSignedStride = rStride:strType,
                 fSignedStride = followThis(i).stride:strType;
           if ranges(i).hasPositiveStride() {
-            const riStride = rStride:intIdxType;
+            const riStride = rStride:chpl_intIdxType;
             const low = ranges(i).alignedLowAsInt + followThis(i).lowBound*riStride,
                   high = ranges(i).alignedLowAsInt + followThis(i).highBound*riStride,
                   stride = (rSignedStride * fSignedStride):strType;
             block(i).chpl_setFields(low, high, stride);
 
           } else {
-            const irStride = (-rStride):intIdxType;
+            const irStride = (-rStride):chpl_intIdxType;
             const low = ranges(i).alignedHighAsInt - followThis(i).highBound*irStride,
                   high = ranges(i).alignedHighAsInt - followThis(i).lowBound*irStride,
                   stride = (rSignedStride * fSignedStride):strType;
@@ -530,20 +530,20 @@ module DefaultRectangular {
         }
       } else {
         // else-branch duplicates then-branch, except here strides are params
-        type strType = chpl__signedType(intIdxType);
+        type strType = chpl__signedType(chpl_intIdxType);
         for param i in 0..rank-1 {
           param rStride = ranges(i).stride;
           param rSignedStride = rStride:strType,
                 fSignedStride = followThis(i).stride:strType;
           if ranges(i).hasPositiveStride() {
-            param riStride = rStride:intIdxType;
+            param riStride = rStride:chpl_intIdxType;
             const low = ranges(i).alignedLowAsInt + followThis(i).lowBound*riStride,
                   high = ranges(i).alignedLowAsInt + followThis(i).highBound*riStride;
             param stride = (rSignedStride * fSignedStride):strType;
             block(i).chpl_setFields(low, high);
 
           } else {
-            param irStride = (-rStride):intIdxType;
+            param irStride = (-rStride):chpl_intIdxType;
             const low = ranges(i).alignedHighAsInt - followThis(i).highBound*irStride,
                   high = ranges(i).alignedHighAsInt - followThis(i).lowBound*irStride;
             param stride = (rSignedStride * fSignedStride):strType;
@@ -576,7 +576,7 @@ module DefaultRectangular {
       for param d in 0..rank-1 by -1 {
         const orderD = ranges(d).indexOrder(ind(d));
         // NOTE: This follows from the implementation of indexOrder()
-        if (orderD == (-1):intIdxType) then return orderD;
+        if (orderD == (-1):chpl_intIdxType) then return orderD;
         totOrder += orderD * blk;
         blk *= ranges(d).sizeAs(int);
       }
@@ -652,7 +652,7 @@ module DefaultRectangular {
       if rank == 1 {
         return ranges(0).stride;
       } else {
-        var result: rank*chpl__signedType(intIdxType);
+        var result: rank*chpl__signedType(chpl_intIdxType);
         for param i in 0..rank-1 do
           result(i) = ranges(i).stride;
         return result;
@@ -942,8 +942,8 @@ module DefaultRectangular {
   //
   proc _remoteAccessData.toRankChange(newDom, cd, idx) {
     compilerAssert(this.rank == idx.size && this.rank != newDom.rank);
-    type intIdxType = newDom.intIdxType;
-    type idxSignedType = chpl__signedType(intIdxType);
+    type chpl_intIdxType = newDom.chpl_intIdxType;
+    type idxSignedType = chpl__signedType(chpl_intIdxType);
 
     // Unconditionally sets 'blkChanged'
     //
@@ -1078,7 +1078,7 @@ module DefaultRectangular {
       this.setupFieldsAndAllocate(initElts);
     }
 
-    proc intIdxType type {
+    proc chpl_intIdxType type {
       return chpl__idxTypeToIntIdxType(idxType);
     }
 
@@ -2039,7 +2039,7 @@ module DefaultRectangular {
     for param i in 0..rank-1 do
       Blo(i) = Bdims(i).first;
 
-    const len = aView.sizeAs(aView.intIdxType).safeCast(c_size_t);
+    const len = aView.sizeAs(aView.chpl_intIdxType).safeCast(c_size_t);
 
     if len == 0 then return;
 
@@ -2169,7 +2169,7 @@ module DefaultRectangular {
   private proc complexTransferCore(LHS, LViewDom, RHS, RViewDom) {
     param minRank = min(LHS.rank, RHS.rank);
     type  idxType = LHS.idxType;
-    type  intIdxType = LHS.intIdxType;
+    type  chpl_intIdxType = LHS.chpl_intIdxType;
 
     if debugDefaultDistBulkTransfer {
       writeln("Transferring views :", LViewDom, " <-- ", RViewDom);

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -840,7 +840,7 @@ module ChapelIO {
     }
 
     if f.matchLiteral(" align ") {
-      const alignVal = f.read(intIdxType);
+      const alignVal = f.read(chpl_intIdxType);
       if hasParamStrideAltvalAld() {
         // It is valid to align this range. We do not store its alignment
         // at runtime because the alignment always normalizes to 0.

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -840,7 +840,7 @@ module ChapelIO {
     }
 
     if f.matchLiteral(" align ") {
-      const alignVal = f.read(chpl_intIdxType);
+      const alignVal = f.read(chpl_integralIdxType);
       if hasParamStrideAltvalAld() {
         // It is valid to align this range. We do not store its alignment
         // at runtime because the alignment always normalizes to 0.

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -100,9 +100,9 @@ where tag == iterKind.leader
   // int(64).  Then we can call divceilpos() with it and any chunkSize
   // type, since then we know at least one arg is signed.
   if c.idxType == uint(64) then
-    numChunks = divceil(c.size, chunkSize:uint(64)): int;
+    numChunks = divceil(c.sizeAs(uint(64)), chunkSize:uint(64)): int;
   else
-    numChunks = divceilpos(c.size, chunkSize): int;
+    numChunks = divceilpos(c.sizeAs(int), chunkSize): int;
 
   // Check if the number of tasks is 0, in that case it returns a default value
   const nTasks = min(numChunks, defaultNumTasks(numTasks));

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -100,9 +100,9 @@ where tag == iterKind.leader
   // int(64).  Then we can call divceilpos() with it and any chunkSize
   // type, since then we know at least one arg is signed.
   if c.idxType == uint(64) then
-    numChunks = divceil(c.sizeAs(uint(64)), chunkSize:uint(64)): int;
+    numChunks = divceil(c.size, chunkSize:uint(64)): int;
   else
-    numChunks = divceilpos(c.sizeAs(int), chunkSize): int;
+    numChunks = divceilpos(c.size, chunkSize): int;
 
   // Check if the number of tasks is 0, in that case it returns a default value
   const nTasks = min(numChunks, defaultNumTasks(numTasks));
@@ -291,7 +291,7 @@ iter guided(param tag:iterKind, c:range(?), numTasks:int=0)
 where tag == iterKind.leader
 {
   // Check if the number of tasks is 0, in that case it returns a default value
-  const nTasks=min(c.sizeAs(c.intIdxType), defaultNumTasks(numTasks));
+  const nTasks=min(c.size, defaultNumTasks(numTasks));
   type rType=c.type;
   var remain:rType = densify(c,c);
   // If the number of tasks is insufficient, yield in serial
@@ -494,7 +494,7 @@ where tag == iterKind.leader
     compilerError("methodStealing value must be between 0 and 2");*/
 
   // Check if the number of tasks is 0, in that case it returns a default value
-  const nTasks=min(c.sizeAs(c.intIdxType), defaultNumTasks(numTasks));
+  const nTasks=min(c.size, defaultNumTasks(numTasks));
   type rType=c.type;
 
   // If the number of tasks is insufficient, yield in serial
@@ -525,10 +525,10 @@ where tag == iterKind.leader
       // Step 1: Initial range per Thread/Task
 
       // Initial Local range in localWork[tid]
-      const chunkSize = c.sizeAs(c.intIdxType)/nTasks;
+      const chunkSize = c.size/nTasks;
       localWork[tid]=
       if tid==nTasks-1 then
-        r#(chunkSize*(nTasks-1)-r.sizeAs(r.intIdxType))
+        r#(chunkSize*(nTasks-1)-r.size)
       else
         (r+tid*chunkSize)#chunkSize;
       barrier.add(1);
@@ -545,7 +545,7 @@ where tag == iterKind.leader
         // There is local work
         // The current range we get after splitting locally
         const zeroBasedIters:rType=adaptSplit(localWork[tid], factorSteal, moreLocalWork[tid], locks[tid]);
-        if zeroBasedIters.sizeAs(zeroBasedIters.intIdxType) !=0 then {
+        if zeroBasedIters.size !=0 then {
           if debugDynamicIters then
             writeln("Parallel adaptive Iterator. Working locally at tid ", tid, " with range yielded as ", zeroBasedIters);
           yield (zeroBasedIters,);
@@ -568,7 +568,7 @@ where tag == iterKind.leader
           if moreLocalWork[victim] then {
             // There is work in victim
             const zeroBasedIters2:rType=adaptSplit(localWork[victim], factorSteal, moreLocalWork[victim], locks[victim]);
-            if zeroBasedIters2.sizeAs(zeroBasedIters2.intIdxType) !=0 then {
+            if zeroBasedIters2.size !=0 then {
               if debugDynamicIters then
                 writeln("Range stolen at victim ", victim," yielded as ", zeroBasedIters2," by tid ", tid);
               yield (zeroBasedIters2,);
@@ -581,7 +581,7 @@ where tag == iterKind.leader
             // There is work in victim
             const zeroBasedIters2:rType=adaptSplit(localWork[victim], factorSteal, moreLocalWork[victim], locks[victim], methodStealing==Method.WholeTail);
                                           //after splitting from a victim range
-            if zeroBasedIters2.sizeAs(zeroBasedIters2.intIdxType) !=0 then {
+            if zeroBasedIters2.size !=0 then {
               if debugDynamicIters then
                 writeln("Range stolen at victim ", victim," yielded as ", zeroBasedIters2," by tid ", tid);
               yield (zeroBasedIters2,);
@@ -727,12 +727,11 @@ private proc defaultNumTasks(nTasks:int)
 private proc adaptSplit(ref rangeToSplit:range(?), splitFactor:int, ref itLeft, lock:chpl_LocalSpinlock, splitTail:bool=false)
 {
   type rType=rangeToSplit.type;
-  type lenType=rangeToSplit.sizeAs(rangeToSplit.intIdxType).type;
-  var totLen, size:lenType;
+  var totLen, size:int;
   const profThreshold=1;
 
   lock.lock();
-  totLen=rangeToSplit.sizeAs(rangeToSplit.intIdxType);
+  totLen=rangeToSplit.size;
   if totLen > profThreshold then
     size=max(totLen/splitFactor, profThreshold);
   else {

--- a/test/deprecated/intIdxType.chpl
+++ b/test/deprecated/intIdxType.chpl
@@ -1,0 +1,5 @@
+var D = {1..10};
+var A: [D] real;
+
+writeln(D.intIdxType:string);
+writeln(A.intIdxType:string);

--- a/test/deprecated/intIdxType.good
+++ b/test/deprecated/intIdxType.good
@@ -1,0 +1,4 @@
+intIdxType.chpl:4: warning: 'domain.intIdxType' is deprecated; please let us know if you are relying on it
+intIdxType.chpl:5: warning: '.intIdxType' on arrays is deprecated; please let us know if you're relying on it
+int(64)
+int(64)

--- a/test/deprecated/intIdxType.good
+++ b/test/deprecated/intIdxType.good
@@ -1,4 +1,4 @@
-intIdxType.chpl:4: warning: 'domain.intIdxType' is deprecated; please let us know if you are relying on it
+intIdxType.chpl:4: warning: '.intIdxType' on domains is deprecated; please let us know if you're relying on it
 intIdxType.chpl:5: warning: '.intIdxType' on arrays is deprecated; please let us know if you're relying on it
 int(64)
 int(64)

--- a/test/expressions/if-expr/unexpected-AST.chpl
+++ b/test/expressions/if-expr/unexpected-AST.chpl
@@ -50,7 +50,7 @@ iter DefaultRectangularDom.myIter(param tag) {
           yield i;
         }
       } else {
-        var locBlock: rank*range(intIdxType);
+        var locBlock: rank*range(idxType);
         for param i in 1..rank {
           locBlock(i) = offset(i)..#(ranges(i).size);
         }
@@ -58,7 +58,7 @@ iter DefaultRectangularDom.myIter(param tag) {
           chpl_debug_writeln("*** DI: locBlock = ", locBlock);
         }
         coforall chunk in 0..#numChunks {
-          var followMe: rank*range(intIdxType) = locBlock;
+          var followMe: rank*range(idxType) = locBlock;
           const (lo,hi) = _computeBlock(locBlock(parDim).size,
                                         numChunks, chunk,
                                         locBlock(parDim)._high,
@@ -68,9 +68,9 @@ iter DefaultRectangularDom.myIter(param tag) {
           if debugDefaultDist {
             chpl_debug_writeln("*** DI[", chunk, "]: followMe = ", followMe);
           }
-          var block: rank*range(idxType=intIdxType, stridable=stridable);
+          var block: rank*range(idxType=idxType, stridable=stridable);
           if stridable {
-            type strType = chpl__signedType(intIdxType);
+            type strType = chpl__signedType(idxType);
             for param i in 1..rank {
               // Note that a range.stride is signed, even if the range is not
               const rStride = ranges(i).stride;
@@ -78,14 +78,14 @@ iter DefaultRectangularDom.myIter(param tag) {
               if rStride > 0 {
                 // Since stride is positive, the following line results
                 // in a positive number, so casting it to e.g. uint is OK
-                const riStride = rStride:intIdxType;
+                const riStride = rStride:idxType;
                 const low = ranges(i).alignedLowAsInt + followMe(i).low*riStride,
                       high = ranges(i).alignedLowAsInt + followMe(i).high*riStride,
                       stride = rSignedStride;
                 block(i) = low..high by stride;
               } else {
                 // Stride is negative, so the following number is positive.
-                const riStride = (-rStride):intIdxType;
+                const riStride = (-rStride):idxType;
                 const low = ranges(i).alignedHighAsInt - followMe(i).high*riStride,
                       high = ranges(i).alignedHighAsInt - followMe(i).low*riStride,
                       stride = rSignedStride;
@@ -94,7 +94,7 @@ iter DefaultRectangularDom.myIter(param tag) {
             }
           } else {
             for  param i in 1..rank do
-              block(i) = ranges(i)._low+followMe(i).low:intIdxType..ranges(i)._low+followMe(i).high:intIdxType;
+              block(i) = ranges(i)._low+followMe(i).low:idxType..ranges(i)._low+followMe(i).high:idxType;
           }
           for i in these_help(1, block) {
             yield chpl_intToIdx(i);


### PR DESCRIPTION
Since our reviews of the domain and range modules... last year?... I've owned a task to look at the uses of intIdxType, which I believe I introduced without much discussion or review, to see whether I thought it should be part of the stable interface of ranges, domains, and arrays for Chapel 2.0.  Checking the code validated my sense that it's not really used outside of our internal modules (which is what I'd expected/hoped), which makes it seem like an obvious candidate for deprecation and replacement with an internal method.

To that end, I've deprecated the methods that were documented (on domains and arrays) and renamed the versions on ranges and domains for our own continued use (the range version was already @nodoc'd, so didn't really need deprecation; and the array's version wasn't actually used).

The two cases outside of our internal modules were:
* the dynamicIters using intIdxType in order to make `sizeAs(someRange.intIdxType)` calls, where I just changed these to `.size` on the assumption that the likelihood of someone creating something whose size was bigger than `max(int)` is ... very unlikely.
* a test that appears to be a snapshot of some internal module code, and didn't seem likely to matter whether it's using `sizeAs(someRange.intIdxType)` or simply `size`.

Resolves #17129.