### PR TITLE
Silence unstable output in Beta_Diversity for now

### DIFF
--- a/test/users/bachman/Beta_Diversity/main.chpl
+++ b/test/users/bachman/Beta_Diversity/main.chpl
@@ -15,7 +15,7 @@ config const in_name : string;
 config const map_type : string;
 config const window_size : real(32);
 config const dx : real(32) = 5.0;
-
+config const printReduce = false;
 
 proc convolve_and_calculate(Image: [] int(8), centerPoints : ?, LeftMaskDomain : ?, CenterMaskDomain : ?, RightMaskDomain : ?, dissimilarity : [] real(32), Output: [] real(32), d_size : int, Mask_Size : int,  t: stopwatch) : [] {
 
@@ -200,7 +200,7 @@ proc main(args: [] string) {
   }
 
 //  WriteOutput(out_file, OutputArray, varid);
-  writeln("Sum reduce of OutputArray: ", (+ reduce OutputArray));
-
+  if printReduce then
+    writeln("Sum reduce of OutputArray: ", (+ reduce OutputArray));
 }
 

--- a/test/users/bachman/Beta_Diversity/main.good
+++ b/test/users/bachman/Beta_Diversity/main.good
@@ -1,3 +1,2 @@
 Distance circle has a radius of 3 points.
 Starting coforall loop.
-Sum reduce of OutputArray: -8.55289e+07


### PR DESCRIPTION
While running a paratest on a branch made from main today, I was seeing failures in the sum reduce output of the Beta_Diversity test that was added today, and then testing on my Mac saw a different value in the output.  This adds a config const for the time being that suppresses the output so that we'll still get the check that the code compiles and runs completely, but without any validation that the output is expected (the goal being to head off potentially getting a test mail for every configuration tonight if all of them similarly get different answers).
