### PR TITLE
Special case `isCopyableType` to avoid warning

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -278,9 +278,10 @@ static void setRecordCopyableFlags(AggregateType* at) {
         ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
       }
       if (initEq != NULL) {
-        if (initEq->hasFlag(FLAG_COMPILER_GENERATED) &&
-            !recordContainsNonNilableOwned(at)) {
-          if (recordContainsOwned(at))
+        if (initEq->hasFlag(FLAG_COMPILER_GENERATED)) {
+          if (recordContainsNonNilableOwned(at))
+            ; // do nothing for this case
+          else if (recordContainsOwned(at))
             ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF);
           else
             ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
@@ -326,9 +327,10 @@ static void setRecordAssignableFlags(AggregateType* at) {
       FnSymbol* assign = findAssignFn(at);
       if (assign != NULL) {
         
-        if (assign->hasFlag(FLAG_COMPILER_GENERATED) &&
-            !recordContainsNonNilableOwned(at)) {
-          if (recordContainsOwned(at))
+        if (assign->hasFlag(FLAG_COMPILER_GENERATED)) {
+          if (recordContainsNonNilableOwned(at))
+            ; // do nothing for this case
+          else if (recordContainsOwned(at))
             ts->addFlag(FLAG_TYPE_ASSIGN_FROM_REF);
           else
             ts->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -267,7 +267,7 @@ static void setRecordCopyableFlags(AggregateType* at) {
       }
 
     } else {
-      // TODO Jade:
+      // TODO Jade 6/27/23:
       // special case since while implicit reads of sync/single are not yet removed
       // with their removal, the init= that throws a warning will be gone
       FnSymbol* initEq = NULL;

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -267,9 +267,15 @@ static void setRecordCopyableFlags(AggregateType* at) {
       }
 
     } else {
-      // Try resolving a test init= to set the flags
-      const char* err = NULL;
-      FnSymbol* initEq = findCopyInitFn(at, err);
+      // TODO Jade:
+      // special case since while implicit reads of sync/single are not yet removed
+      // with their removal, the init= that throws a warning will be gone
+      FnSymbol* initEq = NULL;
+      if(!ts->hasFlag(FLAG_SYNC) && !ts->hasFlag(FLAG_SINGLE)) {
+        // Try resolving a test init= to set the flags
+        const char* err = NULL;
+        initEq = findCopyInitFn(at, err);
+      }
       if (initEq == NULL) {
         ts->addFlag(FLAG_TYPE_INIT_EQUAL_MISSING);
       } else if (initEq->hasFlag(FLAG_COMPILER_GENERATED)) {

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -247,12 +247,10 @@ static bool isNonNilableOwned(Type* t) {
 static void setRecordCopyableFlags(AggregateType* at) {
   TypeSymbol* ts = at->symbol;
   if (!ts->hasFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST) &&
-      !ts->hasFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF) &&
-      !ts->hasFlag(FLAG_TYPE_INIT_EQUAL_MISSING)) {
+      !ts->hasFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF)) {
 
     if (isNonNilableOwned(at)) {
-      ts->addFlag(FLAG_TYPE_INIT_EQUAL_MISSING);
-
+      // do nothing for this case
     } else if (Type* eltType = arrayElementType(at)) {
       if (AggregateType* eltTypeAt = toAggregateType(eltType)) {
         setRecordCopyableFlags(eltTypeAt);
@@ -260,8 +258,6 @@ static void setRecordCopyableFlags(AggregateType* at) {
           at->symbol->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
         else if (eltType->symbol->hasFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF))
           at->symbol->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF);
-        else if (eltType->symbol->hasFlag(FLAG_TYPE_INIT_EQUAL_MISSING))
-          at->symbol->addFlag(FLAG_TYPE_INIT_EQUAL_MISSING);
       } else {
         at->symbol->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
       }
@@ -276,26 +272,25 @@ static void setRecordCopyableFlags(AggregateType* at) {
         const char* err = NULL;
         initEq = findCopyInitFn(at, err);
       }
-      if (initEq == NULL) {
-        ts->addFlag(FLAG_TYPE_INIT_EQUAL_MISSING);
-      } else if (initEq->hasFlag(FLAG_COMPILER_GENERATED)) {
-        if (recordContainsNonNilableOwned(at))
-          ts->addFlag(FLAG_TYPE_INIT_EQUAL_MISSING);
-        else if (recordContainsOwned(at))
-          ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF);
-        else
-          ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
-      } else {
-        // formals are mt, this, other
-        ArgSymbol* other = initEq->getFormal(3);
-        IntentTag intent = concreteIntentForArg(other);
-        if (intent == INTENT_IN ||
-            intent == INTENT_CONST_IN ||
-            intent == INTENT_CONST_REF) {
-          ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
+      if (initEq != NULL) {
+        if (initEq->hasFlag(FLAG_COMPILER_GENERATED) &&
+            !recordContainsNonNilableOwned(at)) {
+          if (recordContainsOwned(at))
+            ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF);
+          else
+            ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
         } else {
-          // this case includes INTENT_REF_MAYBE_CONST
-          ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF);
+          // formals are mt, this, other
+          ArgSymbol* other = initEq->getFormal(3);
+          IntentTag intent = concreteIntentForArg(other);
+          if (intent == INTENT_IN ||
+              intent == INTENT_CONST_IN ||
+              intent == INTENT_CONST_REF) {
+            ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
+          } else {
+            // this case includes INTENT_REF_MAYBE_CONST
+            ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_REF);
+          }
         }
       }
     }
@@ -305,12 +300,10 @@ static void setRecordCopyableFlags(AggregateType* at) {
 static void setRecordAssignableFlags(AggregateType* at) {
   TypeSymbol* ts = at->symbol;
   if (!ts->hasFlag(FLAG_TYPE_ASSIGN_FROM_CONST) &&
-      !ts->hasFlag(FLAG_TYPE_ASSIGN_FROM_REF) &&
-      !ts->hasFlag(FLAG_TYPE_ASSIGN_MISSING)) {
+      !ts->hasFlag(FLAG_TYPE_ASSIGN_FROM_REF)) {
 
     if (isNonNilableOwned(at)) {
-      ts->addFlag(FLAG_TYPE_ASSIGN_MISSING);
-
+      // do nothing for this case
     } else if (Type* eltType = arrayElementType(at)) {
 
       if (AggregateType* eltTypeAt = toAggregateType(eltType)) {
@@ -320,8 +313,6 @@ static void setRecordAssignableFlags(AggregateType* at) {
           at->symbol->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);
         else if (eltType->symbol->hasFlag(FLAG_TYPE_ASSIGN_FROM_REF))
           at->symbol->addFlag(FLAG_TYPE_ASSIGN_FROM_REF);
-        else if (eltType->symbol->hasFlag(FLAG_TYPE_ASSIGN_MISSING))
-          at->symbol->addFlag(FLAG_TYPE_ASSIGN_MISSING);
       } else {
         at->symbol->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);
       }
@@ -329,33 +320,33 @@ static void setRecordAssignableFlags(AggregateType* at) {
     } else {
       // Try resolving a test = to set the flags
       FnSymbol* assign = findAssignFn(at);
-      if (assign == NULL) {
-        ts->addFlag(FLAG_TYPE_ASSIGN_MISSING);
-      } else if (assign->hasFlag(FLAG_COMPILER_GENERATED)) {
-        if (recordContainsNonNilableOwned(at))
-          ts->addFlag(FLAG_TYPE_ASSIGN_MISSING);
-        else if (recordContainsOwned(at))
-          ts->addFlag(FLAG_TYPE_ASSIGN_FROM_REF);
-        else
-          ts->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);
-      } else {
-        // formals are lhs, rhs
-        int rhsNum = 2;
-        if (assign->hasFlag(FLAG_OPERATOR) && assign->hasFlag(FLAG_METHOD)) {
-          // Sometimes operators are defined as operator methods, in which case
-          // there are an extra two arguments and we need to adjust where we
-          // look for the rhs
-          rhsNum += 2;
-        }
-        ArgSymbol* rhs = assign->getFormal(rhsNum);
-        IntentTag intent = concreteIntentForArg(rhs);
-        if (intent == INTENT_IN ||
-            intent == INTENT_CONST_IN ||
-            intent == INTENT_CONST_REF) {
-          ts->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);
+      if (assign != NULL) {
+        
+        if (assign->hasFlag(FLAG_COMPILER_GENERATED) &&
+            !recordContainsNonNilableOwned(at)) {
+          if (recordContainsOwned(at))
+            ts->addFlag(FLAG_TYPE_ASSIGN_FROM_REF);
+          else
+            ts->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);
         } else {
-          // this case includes INTENT_REF_MAYBE_CONST
-          ts->addFlag(FLAG_TYPE_ASSIGN_FROM_REF);
+          // formals are lhs, rhs
+          int rhsNum = 2;
+          if (assign->hasFlag(FLAG_OPERATOR) && assign->hasFlag(FLAG_METHOD)) {
+            // Sometimes operators are defined as operator methods, in which case
+            // there are an extra two arguments and we need to adjust where we
+            // look for the rhs
+            rhsNum += 2;
+          }
+          ArgSymbol* rhs = assign->getFormal(rhsNum);
+          IntentTag intent = concreteIntentForArg(rhs);
+          if (intent == INTENT_IN ||
+              intent == INTENT_CONST_IN ||
+              intent == INTENT_CONST_REF) {
+            ts->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);
+          } else {
+            // this case includes INTENT_REF_MAYBE_CONST
+            ts->addFlag(FLAG_TYPE_ASSIGN_FROM_REF);
+          }
         }
       }
     }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -272,6 +272,11 @@ static void setRecordCopyableFlags(AggregateType* at) {
         const char* err = NULL;
         initEq = findCopyInitFn(at, err);
       }
+      else {
+        // sync/single variables are technically copyable until after the
+        // deprecation is removed, mark then as such
+        ts->addFlag(FLAG_TYPE_INIT_EQUAL_FROM_CONST);
+      }
       if (initEq != NULL) {
         if (initEq->hasFlag(FLAG_COMPILER_GENERATED) &&
             !recordContainsNonNilableOwned(at)) {
@@ -316,7 +321,6 @@ static void setRecordAssignableFlags(AggregateType* at) {
       } else {
         at->symbol->addFlag(FLAG_TYPE_ASSIGN_FROM_CONST);
       }
-
     } else {
       // Try resolving a test = to set the flags
       FnSymbol* assign = findAssignFn(at);

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -326,7 +326,7 @@ static void setRecordAssignableFlags(AggregateType* at) {
       // Try resolving a test = to set the flags
       FnSymbol* assign = findAssignFn(at);
       if (assign != NULL) {
-        
+
         if (assign->hasFlag(FLAG_COMPILER_GENERATED)) {
           if (recordContainsNonNilableOwned(at))
             ; // do nothing for this case

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -573,10 +573,8 @@ PRAGMA(STAR_TUPLE_ACCESSOR, ypr, "star tuple accessor", "this function for star 
 
 PRAGMA(TYPE_ASSIGN_FROM_CONST, npr, "type has = from const", "type supports assignment from a const rhs")
 PRAGMA(TYPE_ASSIGN_FROM_REF, npr, "type has = from ref", "type supports assignment from a potentially non-const rhs")
-PRAGMA(TYPE_ASSIGN_MISSING, npr, "type has no =", "type has no assign overload")
 PRAGMA(TYPE_INIT_EQUAL_FROM_CONST,  npr, "type has init= from const", "type supports init= with const other")
 PRAGMA(TYPE_INIT_EQUAL_FROM_REF,  npr, "type has init= from ref", "type supports init= from a potentially non-const other argument")
-PRAGMA(TYPE_INIT_EQUAL_MISSING, npr, "type has no init=", "type has no init=")
 PRAGMA(TYPE_DEFAULT_VALUE, npr, "type has default value", "type has a default value")
 PRAGMA(TYPE_NO_DEFAULT_VALUE, npr, "type has no default value", "type has no default value")
 

--- a/test/library/standard/Types/copyable-sync-single-string.chpl
+++ b/test/library/standard/Types/copyable-sync-single-string.chpl
@@ -1,7 +1,7 @@
 var x: sync string;
 param p = isCopyableType(x.type);
-compilerWarning("isCopyableType(sync string) = " + p:string);
+writeln("isCopyableType(sync string) = " + p:string);
 var y: sync string;
 param p2 = isCopyableType(y.type);
-compilerWarning("isCopyableType(single string) = " + p2:string);
+writeln("isCopyableType(single string) = " + p2:string);
 

--- a/test/library/standard/Types/copyable-sync-single-string.chpl
+++ b/test/library/standard/Types/copyable-sync-single-string.chpl
@@ -1,0 +1,7 @@
+var x: sync string;
+param p = isCopyableType(x.type);
+compilerWarning("isCopyableType(sync string) = " + p:string);
+var y: sync string;
+param p2 = isCopyableType(y.type);
+compilerWarning("isCopyableType(single string) = " + p2:string);
+

--- a/test/library/standard/Types/copyable-sync-single-string.good
+++ b/test/library/standard/Types/copyable-sync-single-string.good
@@ -1,2 +1,2 @@
-isCopyableType(sync string) = false
-isCopyableType(single string) = false
+isCopyableType(sync string) = true
+isCopyableType(single string) = true

--- a/test/library/standard/Types/copyable-sync-single-string.good
+++ b/test/library/standard/Types/copyable-sync-single-string.good
@@ -1,0 +1,2 @@
+copyable-sync-single-string.chpl:3: warning: isCopyableType(sync string) = false
+copyable-sync-single-string.chpl:6: warning: isCopyableType(single string) = false

--- a/test/library/standard/Types/copyable-sync-single-string.good
+++ b/test/library/standard/Types/copyable-sync-single-string.good
@@ -1,2 +1,2 @@
-copyable-sync-single-string.chpl:3: warning: isCopyableType(sync string) = false
-copyable-sync-single-string.chpl:6: warning: isCopyableType(single string) = false
+isCopyableType(sync string) = false
+isCopyableType(single string) = false

--- a/test/library/standard/Types/copyable-sync-string.bad
+++ b/test/library/standard/Types/copyable-sync-string.bad
@@ -1,2 +1,0 @@
-$CHPL_HOME/modules/standard/Types.chpl:250: warning: Initializing a type-inferred variable from a 'sync' is deprecated; apply a 'read??()' method to the right-hand side
-copyable-sync-string.chpl:3: error: isCopyableType(sync string) = true

--- a/test/library/standard/Types/copyable-sync-string.chpl
+++ b/test/library/standard/Types/copyable-sync-string.chpl
@@ -1,3 +1,0 @@
-var x: sync string;
-param p = isCopyableType(x.type);
-compilerError("isCopyableType(sync string) = " + p:string);

--- a/test/library/standard/Types/copyable-sync-string.future
+++ b/test/library/standard/Types/copyable-sync-string.future
@@ -1,2 +1,0 @@
-bug: sync type argument to isCopyableType triggers deprecation warning
-#20984

--- a/test/library/standard/Types/copyable-sync-string.good
+++ b/test/library/standard/Types/copyable-sync-string.good
@@ -1,1 +1,0 @@
-copyable-sync-string.chpl:3: error: isCopyableType(sync string) = true

--- a/test/types/sync/lydia/arrayOfArrayOfSyncsInField.bad
+++ b/test/types/sync/lydia/arrayOfArrayOfSyncsInField.bad
@@ -1,2 +1,0 @@
-$CHPL_HOME/modules/standard/Types.chpl:nnnn: warning: Initializing a type-inferred variable from a 'sync' is deprecated; apply a 'read??()' method to the right-hand side
-3

--- a/test/types/sync/lydia/arrayOfArrayOfSyncsInField.future
+++ b/test/types/sync/lydia/arrayOfArrayOfSyncsInField.future
@@ -1,2 +1,0 @@
-bug: fields of array of array of syncs trigger a sync deprecation warning
-#20984

--- a/test/types/sync/lydia/arrayOfArrayOfSyncsInField.prediff
+++ b/test/types/sync/lydia/arrayOfArrayOfSyncsInField.prediff
@@ -1,1 +1,0 @@
-../../../../util/test/prediff-obscure-module-linenos


### PR DESCRIPTION
With the `sync`/`single` implicit reads/writes deprecation, the `init=` for the implementing records were marked as deprecated. This causes `isCopyableType` to throw a deprecation warning when it trys to resolve the `init=` while checking if a type is copyable (bug reported in #20984). This behavior should go away when the deprecation is removed, but until then users may get unintended deprecation warnings. This is resolved in the short term by special casing the check to not try to resolve `init=` for `sync`/`single`. In the long term, this special case can be removed when the deprecated `init=` is removed.

## Summary of changes
- add a check for a `sync` or `single` before trying to resolve `init=` in `setRecordCopyableFlags`
- explicitly set `FLAG_TYPE_INIT_EQUAL_FROM_CONST` for `sync`/`single` to maintain deprecated behavior, for now
- removed `FLAG_TYPE_INIT_EQUAL_MISSING` and `FLAG_TYPE_ASSIGN_MISSING`
  - both were only used locally in their respective functions and are not needed for correctness

## Tests
- convert the two futures in #20984 into normal tests

## testing
- paratest
- paratest + gasnet

[Reviewed by @lydia-duncan]
closes #20984