### PR TITLE
Refactor `where` clauses for `IO.chpl` to improve documentation

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6386,6 +6386,9 @@ proc fileReader.readline(arg: [] uint(8), out numRead : int, start = arg.domain.
   return false;
 }
 
+// TODO: a.hasUnitStride() (or even a.strides.isOne() ) vs
+// a.strides == strideKind.one is more readable, but currently undocumented
+
 /*
   Read a line into an array of bytes.
 
@@ -6415,8 +6418,8 @@ proc fileReader.readline(arg: [] uint(8), out numRead : int, start = arg.domain.
  */
 proc fileReader.readLine(ref a: [] ?t, maxSize=a.size,
                          stripNewline=false): int throws
-      where (t == uint(8) || t == int(8)) && a.rank == 1 &&
-            a.isRectangular() && a.hasUnitStride()
+      where a.rank == 1 && a.isRectangular() && a.strides == strideKind.one &&
+            (t == uint(8) || t == int(8))
 {
   if maxSize > a.size
     then throw new IllegalArgumentError("'maxSize' argument exceeds size of array in readLine");
@@ -7230,8 +7233,8 @@ proc fileReader.readAll(ref b: bytes): int throws {
                        due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileReader.readAll(ref a: [?d] ?t): int throws
-  where (t == uint(8) || t == int(8)) && a.rank == 1 &&
-        a.isRectangular() && a.hasUnitStride()
+  where a.rank == 1 && a.isRectangular() && a.strides == strideKind.one &&
+        (t == uint(8) || t == int(8))
 {
   var i = d.low;
 
@@ -7965,7 +7968,7 @@ proc fileWriter.writeBinary(b: bytes, size: int = b.size) throws {
                        due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioendian.native) throws
-  where d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+  where d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0;
@@ -8016,7 +8019,7 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
                        due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileWriter.writeBinary(const ref data: [?d] ?t, endian:ioendian) throws
-  where d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+  where d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   select (endian) {
@@ -8226,7 +8229,7 @@ config param ReadBinaryArrayReturnInt = false;
 @deprecated(notes="The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant")
 proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): bool throws
   where ReadBinaryArrayReturnInt == false &&
-    d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0,
@@ -8286,7 +8289,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): b
 */
 proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): int throws
   where ReadBinaryArrayReturnInt == true &&
-    d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0,
@@ -8350,7 +8353,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
 @deprecated(notes="The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant")
 proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):bool throws
   where ReadBinaryArrayReturnInt == false &&
-    d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var rv: bool = false;
@@ -8390,7 +8393,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):bool throws
 */
 proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):int throws
   where ReadBinaryArrayReturnInt == true &&
-    d.rank == 1 && d.isRectangular() && d.hasUnitStride() && (
+    d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var nr: int = 0;
@@ -8910,8 +8913,9 @@ proc read(type t ...?numTypes) throws {
 
 /* Equivalent to ``stdin.readLine``.  See :proc:`fileReader.readLine` */
 proc readLine(ref a: [] ?t, maxSize=a.size, stripNewline=false): int throws
-      where (t == uint(8) || t == int(8)) && a.rank == 1 &&
-            a.isRectangular() && a.hasUnitStride() {
+  where a.rank == 1 && a.isRectangular() && a.strides == strideKind.one &&
+        (t == uint(8) || t == int(8))
+{
   return stdin.readLine(a, maxSize, stripNewline);
 }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -7968,7 +7968,7 @@ proc fileWriter.writeBinary(b: bytes, size: int = b.size) throws {
                        due to a :ref:`system error<io-general-sys-error>`.
 */
 proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioendian.native) throws
-  where d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
+  where data.rank == 1 && data.isRectangular() && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0;
@@ -8018,8 +8018,8 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
   :throws SystemError: Thrown if data could not be written to the ``fileWriter``
                        due to a :ref:`system error<io-general-sys-error>`.
 */
-proc fileWriter.writeBinary(const ref data: [?d] ?t, endian:ioendian) throws
-  where d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
+proc fileWriter.writeBinary(const ref data: [] ?t, endian:ioendian) throws
+  where data.rank == 1 && data.isRectangular() && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   select (endian) {
@@ -8227,9 +8227,9 @@ config param ReadBinaryArrayReturnInt = false;
                                values are read.
 */
 @deprecated(notes="The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant")
-proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): bool throws
+proc fileReader.readBinary(ref data: [] ?t, param endian = ioendian.native): bool throws
   where ReadBinaryArrayReturnInt == false &&
-    d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
+    data.rank == 1 && data.isRectangular() && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0,
@@ -8289,7 +8289,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): b
 */
 proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): int throws
   where ReadBinaryArrayReturnInt == true &&
-    d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
+    data.rank == 1 && data.isRectangular() && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0,
@@ -8351,9 +8351,9 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
                                ``data.size`` values are read.
 */
 @deprecated(notes="The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant")
-proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):bool throws
+proc fileReader.readBinary(ref data: [] ?t, endian: ioendian):bool throws
   where ReadBinaryArrayReturnInt == false &&
-    d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
+    data.rank == 1 && data.isRectangular() && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var rv: bool = false;
@@ -8391,9 +8391,9 @@ proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):bool throws
    :throws SystemError: Thrown if data could not be read from the ``fileReader``
                         due to a :ref:`system error<io-general-sys-error>`.
 */
-proc fileReader.readBinary(ref data: [?d] ?t, endian: ioendian):int throws
+proc fileReader.readBinary(ref data: [] ?t, endian: ioendian):int throws
   where ReadBinaryArrayReturnInt == true &&
-    d.rank == 1 && d.isRectangular() && d.strides == strideKind.one && (
+    data.rank == 1 && data.isRectangular() && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var nr: int = 0;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6386,9 +6386,6 @@ proc fileReader.readline(arg: [] uint(8), out numRead : int, start = arg.domain.
   return false;
 }
 
-// TODO: a.hasUnitStride() (or even a.strides.isOne() ) vs
-// a.strides == strideKind.one is more readable, but currently undocumented
-
 /*
   Read a line into an array of bytes.
 


### PR DESCRIPTION
Rearranges the `where` clauses for some IO functions to be more readable in the generated documentation. 

## Summary of changes
- move the check for `t` equal to `int(8)` or `uint(8)` to the end of the statement which makes the docs slightly better.
- manually inlined `hasUnitStride`, I think this actually makes the `where` clause more verbose and potentially harder to immediately understand, but the function is currently marked `nodoc`.
- For `where` clauses which accept an array and check `.rank` (or others), modified the ones which refer to the domain to just use the array.

## testing
- paratest
- built and checked docs

[Reviewed by @bradcray and @nikkirad]