### PR TITLE
Fix line numbers in grandparentAccess.good

### DIFF
--- a/test/classes/initializers/phase1/grandparentAccess.good
+++ b/test/classes/initializers/phase1/grandparentAccess.good
@@ -1,2 +1,2 @@
 grandparentAccess.chpl:21: In initializer:
-grandparentAccess.chpl:22: error: cannot access parent field "a" before super.init() or this.init()
+grandparentAccess.chpl:24: error: cannot access parent field "a" before super.init() or this.init()


### PR DESCRIPTION
Follow-up to PR #22614 to fix test failures due to trivial line number differences.

Test change only - not reviewed.