### PR TITLE
Fix `map.parSafe` references in set module

### DIFF
--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -189,7 +189,7 @@ module Set {
                                       initialCapacity);
     }
 
-    @unstable("'Map.parSafe' is unstable")
+    @unstable("'Set.parSafe' is unstable")
     proc init(type eltType, param parSafe,
               resizeThreshold=defaultHashTableResizeThreshold,
               initialCapacity=16) {
@@ -243,7 +243,7 @@ module Set {
       for elem in iterable do _addElem(elem);
     }
 
-    @unstable("'Map.parSafe' is unstable")
+    @unstable("'Set.parSafe' is unstable")
     proc init(type eltType, iterable, param parSafe,
               resizeThreshold=defaultHashTableResizeThreshold,
               initialCapacity=16)

--- a/test/unstable/Set/parSafe.good
+++ b/test/unstable/Set/parSafe.good
@@ -1,4 +1,4 @@
-parSafe.chpl:4: warning: 'Map.parSafe' is unstable
-parSafe.chpl:5: warning: 'Map.parSafe' is unstable
-parSafe.chpl:12: warning: 'Map.parSafe' is unstable
-parSafe.chpl:13: warning: 'Map.parSafe' is unstable
+parSafe.chpl:4: warning: 'Set.parSafe' is unstable
+parSafe.chpl:5: warning: 'Set.parSafe' is unstable
+parSafe.chpl:12: warning: 'Set.parSafe' is unstable
+parSafe.chpl:13: warning: 'Set.parSafe' is unstable


### PR DESCRIPTION
Vass pointed out the set module had some references to `Map.parSafe` due to a copy past error.