### PR TITLE
Addition to distributed list docs

### DIFF
--- a/test/library/draft/DistributedList/DistributedList.chpl
+++ b/test/library/draft/DistributedList/DistributedList.chpl
@@ -1,4 +1,28 @@
+/*
 
+A prototype distributed list.
+
+Note: in the future, it is unlikely that we will add a distributed list data
+  structure to the standard library. Instead, we would likely add some more
+  constrained list-like data structures such as a distributed dequeue or stack.
+  This is for a couple of reasons:
+
+  - some of the methods on `list` are very inefficient to implement on a
+        distributed list. Namely, `remove`, `insert`, and `getAndRemove`.
+        With the below implementation in particular, supporting these methods
+        harms the performance of other methods because global locking is
+        required. Such methods would not be included in a distributed queue,
+        stack, or dequeue.
+  - one of the initial motivations for creating a distributed list was that
+       we'd eventually like to have a distributed version of all (or most) of
+       the collection types supported by the standard library. However, in some
+       discussions about the `list` data structure, we decided it would be
+       okay to keep list as a single-locale-only collection, and to add a queue
+       stack, and/or dequeue (along with their distributed versions) to the library.
+
+  (see: https://github.com/chapel-lang/chapel/issues/21933, for more discussion)
+
+*/
 module DistributedList {
 
     private use HaltWrappers;

--- a/test/library/draft/DistributedList/DistributedList.chpl
+++ b/test/library/draft/DistributedList/DistributedList.chpl
@@ -17,7 +17,7 @@ Note: in the future, it is unlikely that we will add a distributed list data
        we'd eventually like to have a distributed version of all (or most) of
        the collection types supported by the standard library. However, in some
        discussions about the `list` data structure, we decided it would be
-       okay to keep list as a single-locale-only collection, and to add a queue
+       okay to keep list as a single-locale-only collection, and to add a queue,
        stack, and/or dequeue (along with their distributed versions) to the library.
 
   (see: https://github.com/chapel-lang/chapel/issues/21933, for more discussion)


### PR DESCRIPTION
Following [this](https://github.com/chapel-lang/chapel/issues/21933#issuecomment-1563624603) decision, add a summary about how we plan to move forward with the distributed list data structure(s) to `/test/library/draft/DistributedList.chpl` so that we don't forget what we decided when it comes time to implement.