### PR TITLE
Adjust anonymousRangeIter for trivial code generation difference

### DIFF
--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -29,7 +29,7 @@ _ic__F#_high_chpl# = INT#(#);
 for (i_chpl# = INT#(#); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {
 
 # for i in 2..#4 do write(i); writeln();
-_ic__F#_high_chpl# = tmp_chpl#;
+_ic__F#_high_chpl# = tmp_chpl;
 for (i_chpl# = INT#(#); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {
 
 # for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();


### PR DESCRIPTION
Follow-up to PR #21894 to address a failure with test/types/range/elliot/anonymousRangeIter working. This PR just updates the pattern to search for in the generated C to account for a trivial change in a temporary name.

Test change only - not reviewed.