### PR TITLE
User flags to inspect LLVM optimizations

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2616,11 +2616,11 @@ static llvm::Error setupRemarks(llvm::LLVMContext &Context,
 
   return llvm::Error::success();
 }
-#endif
 
 static bool shouldShowLLVMRemarks() {
   return *llvmRemarksFilters != '\0' || !llvmRemarksFunctionsToShow.empty();
 }
+#endif
 
 // Do this for GPU and then do for CPU
 static void codegenPartTwo() {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2526,7 +2526,7 @@ struct ChapelRemarkSerializer : public llvm::remarks::RemarkSerializer {
 
     // if not developer, skip all non user functions
     if (!developer) {
-      auto funcName = Remark.FunctionName; 
+      auto funcName = Remark.FunctionName;
       auto funcIt = gGenInfo->functionCNameAstrToSymbol.find(astr(funcName.str()));
       if (funcIt != gGenInfo->functionCNameAstrToSymbol.end()) {
         auto mod = funcIt->second->getModule();

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2621,7 +2621,7 @@ static llvm::Error setupRemarks(llvm::LLVMContext& Context,
 }
 
 static bool shouldShowLLVMRemarks() {
-  return *llvmRemarksFilters != '\0' || !llvmRemarksFunctionsToShow.empty();
+  return !llvmRemarksFilters.empty() || !llvmRemarksFunctionsToShow.empty();
 }
 #endif
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2538,7 +2538,7 @@ struct ChapelRemarkSerializer : public llvm::remarks::RemarkSerializer {
     // couldn't get from map, do the slow way with a loop through the FnSymbols
     if(fn == nullptr) {
       for_alive_in_Vec(FnSymbol, gFn, gFnSymbols) {
-        const char* cname = astr(gFn->cname);
+        const char* cname = gFn->cname;
         if(astr_funcCName == cname) {
           fn = gFn;
           break;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2535,16 +2535,10 @@ struct ChapelRemarkSerializer : public llvm::remarks::RemarkSerializer {
       fn = funcIt->second;
     }
 
-    // couldn't get from map, do the slow way with a loop through the FnSymbols
-    if(fn == nullptr) {
-      for_alive_in_Vec(FnSymbol, gFn, gFnSymbols) {
-        const char* cname = gFn->cname;
-        if(astr_funcCName == cname) {
-          fn = gFn;
-          break;
-        }
-      }
-    }
+    // TODO: if the function was not in `functionCNameAstrToSymbol`, then `fn`
+    // could still be a nullptr. In non-developer runs this will get filtered
+    // out, but in a developer run it would be nice to be able to get better
+    // source information for these functions
 
     // if fn is still nullptr and not developer, skip it
     if(fn == nullptr && !developer) return;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2568,7 +2568,7 @@ struct ChapelRemarkSerializer : public llvm::remarks::RemarkSerializer {
       const char* filename = fn ? cleanFilename(fn->fname()) : nullptr;
       int linenum = fn ? fn->linenum() : 0;
       if(filename) OS << filename << ":" << linenum << ":0";
-      else OS << fn->cname;
+      else OS << Remark.FunctionName;
     }
     OS << ": opt " << typeToString(Remark.RemarkType);
     OS << " for '" << Remark.PassName << "'";

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -289,6 +289,7 @@ extern bool fIncrementalCompilation;
 
 // LLVM flags (-mllvm)
 extern std::string llvmFlags;
+extern char llvmRemarksFilters[128];
 
 extern bool fPrintAdditionalErrors;
 

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -290,6 +290,7 @@ extern bool fIncrementalCompilation;
 // LLVM flags (-mllvm)
 extern std::string llvmFlags;
 extern char llvmRemarksFilters[128];
+extern std::vector<std::string> llvmRemarksFunctionsToShow;
 
 extern bool fPrintAdditionalErrors;
 

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -289,7 +289,7 @@ extern bool fIncrementalCompilation;
 
 // LLVM flags (-mllvm)
 extern std::string llvmFlags;
-extern char llvmRemarksFilters[128];
+extern std::string llvmRemarksFilters;
 extern std::vector<std::string> llvmRemarksFunctionsToShow;
 
 extern bool fPrintAdditionalErrors;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -275,7 +275,6 @@ bool fReportBlocking = false;
 bool fReportOptimizedLoopIterators = false;
 bool fReportInlinedIterators = false;
 bool fReportVectorizedLoops = false;
-bool fReportMissedVectorization = false;
 bool fReportOptimizedOn = false;
 bool fReportOptimizeForallUnordered = false;
 bool fReportPromotion = false;
@@ -737,21 +736,6 @@ static void setLLVMRemarksFunctions(const ArgumentDescription* desc, const char*
     llvmRemarksFunctionsToShow.push_back(n);
   }
 }
-
-// static void setLLVMRemarks(const ArgumentDescription* desc, const char* arg) {
-//   // Append arg to the end of llvmFlags.
-
-//   // add a space if there are already arguments here
-//   std::cout << std::string(arg) << "\n";
-// }
-
-// static void setLLVMRemarksFilter(const ArgumentDescription* desc, const char* arg) {
-//   // Append arg to the end of llvmFlags.
-
-//   // add a space if there are already arguments here
-//   std::cout << std::string(arg) << "\n";
-// }
-
 
 static void handleLibrary(const ArgumentDescription* desc, const char* arg_unused) {
  addLibFile(libraryFilename);

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1155,8 +1155,6 @@ static ArgumentDescription arg_desc[] = {
  {"llvm", ' ', NULL, "[Don't] use the LLVM code generator", "N", &fYesLlvmCodegen, "CHPL_LLVM_CODEGEN", setLlvmCodegen},
  {"llvm-wide-opt", ' ', NULL, "Enable [disable] LLVM wide pointer optimizations", "N", &fLLVMWideOpt, "CHPL_LLVM_WIDE_OPTS", NULL},
  {"mllvm", ' ', "<flags>", "LLVM flags (can be specified multiple times)", "S", NULL, "CHPL_MLLVM", setLLVMFlags},
- {"llvm-remarks", ' ', "<regex>", "Print LLVM optimization remarks", "S", NULL, NULL, &setLLVMRemarksFilters},
- {"llvm-remarks-function", ' ', "<name>", "Print LLVM optimization remarks only for these functions", "S", NULL, NULL, &setLLVMRemarksFunctions},
 
  {"", ' ', NULL, "Compilation Trace Options", NULL, NULL, NULL, NULL},
  {"print-commands", ' ', NULL, "[Don't] print system commands", "N", &printSystemCommands, "CHPL_PRINT_COMMANDS", NULL},
@@ -1226,6 +1224,8 @@ static ArgumentDescription arg_desc[] = {
 // {"log-symbol", ' ', "<symbol-name>", "Restrict IR dump to the named symbol(s)", "S256", log_symbol, "CHPL_LOG_SYMBOL", NULL}, // This doesn't work yet.
  {"llvm-print-ir", ' ', "<name>", "Dump LLVM Intermediate Representation of given function to stdout", "S", NULL, "CHPL_LLVM_PRINT_IR", &setPrintIr},
  {"llvm-print-ir-stage", ' ', "<stage>", "Specifies from which LLVM optimization stage to print function: none, basic, full", "S", NULL, "CHPL_LLVM_PRINT_IR_STAGE", &verifyStageAndSetStageNum},
+ {"llvm-remarks", ' ', "<regex>", "Print LLVM optimization remarks", "S", NULL, NULL, &setLLVMRemarksFilters},
+ {"llvm-remarks-function", ' ', "<name>", "Print LLVM optimization remarks only for these functions", "S", NULL, NULL, &setLLVMRemarksFunctions},
  {"verify", ' ', NULL, "Run consistency checks during compilation", "N", &fVerify, "CHPL_VERIFY", NULL},
  {"parse-only", ' ', NULL, "Stop compiling after 'parse' pass for syntax checking", "N", &fParseOnly, NULL, NULL},
  {"parser-debug", ' ', NULL, "Set parser debug level", "+", &debugParserLevel, "CHPL_PARSER_DEBUG", NULL},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -331,6 +331,7 @@ static bool fPrintChplHome = false;
 
 std::string llvmFlags;
 char llvmRemarksFilters[128];
+std::vector<std::string> llvmRemarksFunctionsToShow;
 
 bool fPrintAdditionalErrors;
 
@@ -728,6 +729,13 @@ static void setLLVMFlags(const ArgumentDescription* desc, const char* arg) {
     llvmFlags += ' ';
 
   llvmFlags += arg;
+}
+static void setLLVMRemarksFunctions(const ArgumentDescription* desc, const char* arg) {
+  std::vector<std::string> fNames;
+  splitString(std::string(arg), fNames, ",");
+  for(auto n: fNames) {
+    llvmRemarksFunctionsToShow.push_back(n);
+  }
 }
 
 // static void setLLVMRemarks(const ArgumentDescription* desc, const char* arg) {
@@ -1159,6 +1167,7 @@ static ArgumentDescription arg_desc[] = {
  {"llvm-wide-opt", ' ', NULL, "Enable [disable] LLVM wide pointer optimizations", "N", &fLLVMWideOpt, "CHPL_LLVM_WIDE_OPTS", NULL},
  {"mllvm", ' ', "<flags>", "LLVM flags (can be specified multiple times)", "S", NULL, "CHPL_MLLVM", setLLVMFlags},
  {"llvm-remarks", ' ', "<regex>", "Print LLVM optimization remarks", "S128", &llvmRemarksFilters, NULL, NULL},
+ {"llvm-remarks-function", ' ', "<name>", "Print LLVM optimization remarks only for these functions", "S", NULL, NULL, &setLLVMRemarksFunctions},
 
  {"", ' ', NULL, "Compilation Trace Options", NULL, NULL, NULL, NULL},
  {"print-commands", ' ', NULL, "[Don't] print system commands", "N", &printSystemCommands, "CHPL_PRINT_COMMANDS", NULL},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -329,7 +329,7 @@ static bool fPrintVersion = false;
 static bool fPrintChplHome = false;
 
 std::string llvmFlags;
-char llvmRemarksFilters[128];
+std::string llvmRemarksFilters;
 std::vector<std::string> llvmRemarksFunctionsToShow;
 
 bool fPrintAdditionalErrors;
@@ -729,6 +729,11 @@ static void setLLVMFlags(const ArgumentDescription* desc, const char* arg) {
 
   llvmFlags += arg;
 }
+
+static void setLLVMRemarksFilters(const ArgumentDescription* desc, const char* arg) {
+  llvmRemarksFilters = std::string(arg);
+}
+
 static void setLLVMRemarksFunctions(const ArgumentDescription* desc, const char* arg) {
   std::vector<std::string> fNames;
   splitString(std::string(arg), fNames, ",");
@@ -1150,7 +1155,7 @@ static ArgumentDescription arg_desc[] = {
  {"llvm", ' ', NULL, "[Don't] use the LLVM code generator", "N", &fYesLlvmCodegen, "CHPL_LLVM_CODEGEN", setLlvmCodegen},
  {"llvm-wide-opt", ' ', NULL, "Enable [disable] LLVM wide pointer optimizations", "N", &fLLVMWideOpt, "CHPL_LLVM_WIDE_OPTS", NULL},
  {"mllvm", ' ', "<flags>", "LLVM flags (can be specified multiple times)", "S", NULL, "CHPL_MLLVM", setLLVMFlags},
- {"llvm-remarks", ' ', "<regex>", "Print LLVM optimization remarks", "S128", &llvmRemarksFilters, NULL, NULL},
+ {"llvm-remarks", ' ', "<regex>", "Print LLVM optimization remarks", "S", NULL, NULL, &setLLVMRemarksFilters},
  {"llvm-remarks-function", ' ', "<name>", "Print LLVM optimization remarks only for these functions", "S", NULL, NULL, &setLLVMRemarksFunctions},
 
  {"", ' ', NULL, "Compilation Trace Options", NULL, NULL, NULL, NULL},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -275,6 +275,7 @@ bool fReportBlocking = false;
 bool fReportOptimizedLoopIterators = false;
 bool fReportInlinedIterators = false;
 bool fReportVectorizedLoops = false;
+bool fReportMissedVectorization = false;
 bool fReportOptimizedOn = false;
 bool fReportOptimizeForallUnordered = false;
 bool fReportPromotion = false;
@@ -329,6 +330,7 @@ static bool fPrintVersion = false;
 static bool fPrintChplHome = false;
 
 std::string llvmFlags;
+char llvmRemarksFilters[128];
 
 bool fPrintAdditionalErrors;
 
@@ -727,6 +729,20 @@ static void setLLVMFlags(const ArgumentDescription* desc, const char* arg) {
 
   llvmFlags += arg;
 }
+
+// static void setLLVMRemarks(const ArgumentDescription* desc, const char* arg) {
+//   // Append arg to the end of llvmFlags.
+
+//   // add a space if there are already arguments here
+//   std::cout << std::string(arg) << "\n";
+// }
+
+// static void setLLVMRemarksFilter(const ArgumentDescription* desc, const char* arg) {
+//   // Append arg to the end of llvmFlags.
+
+//   // add a space if there are already arguments here
+//   std::cout << std::string(arg) << "\n";
+// }
 
 
 static void handleLibrary(const ArgumentDescription* desc, const char* arg_unused) {
@@ -1142,6 +1158,7 @@ static ArgumentDescription arg_desc[] = {
  {"llvm", ' ', NULL, "[Don't] use the LLVM code generator", "N", &fYesLlvmCodegen, "CHPL_LLVM_CODEGEN", setLlvmCodegen},
  {"llvm-wide-opt", ' ', NULL, "Enable [disable] LLVM wide pointer optimizations", "N", &fLLVMWideOpt, "CHPL_LLVM_WIDE_OPTS", NULL},
  {"mllvm", ' ', "<flags>", "LLVM flags (can be specified multiple times)", "S", NULL, "CHPL_MLLVM", setLLVMFlags},
+ {"llvm-remarks", ' ', "<regex>", "Print LLVM optimization remarks", "S128", &llvmRemarksFilters, NULL, NULL},
 
  {"", ' ', NULL, "Compilation Trace Options", NULL, NULL, NULL, NULL},
  {"print-commands", ' ', NULL, "[Don't] print system commands", "N", &printSystemCommands, "CHPL_PRINT_COMMANDS", NULL},

--- a/doc/rst/technotes/llvm.rst
+++ b/doc/rst/technotes/llvm.rst
@@ -137,3 +137,37 @@ After the usual LLVM optimization passes run, two Chapel LLVM passes run:
 
 
 .. _LLVM-based Communication Optimizations for PGAS Programs: http://ahayashi.blogs.rice.edu/files/2013/07/Chapel_LLVM_camera_ready-q6usv4.pdf
+
+-----------------------------
+Inspecting LLVM Optimizations
+-----------------------------
+
+It may be useful to determine if specific LLVM optimizations ran and what the
+results were. LLVM remarks allow optimization passes to report what happened.
+
+To request optimization remarks, use the experimental ``--llvm-remarks`` and
+``--llvm-remarks-function`` flags.
+
+ * ``--llvm-remarks`` accepts a regular expression which matches and filters
+   optimization pass names.
+
+   * ``'.''`` -- shows remarks for all optimization passes
+   * ``inline`` -- shows remarks for any optimization pass which matches
+     '``inline``'
+   * ``(slp|loop)-vectorize`` -- shows remarks for any optimization pass which
+     matches '``slp-vectorize``' or '``loop-vectorize``'
+
+ * ``--llvm-remarks-function`` accepts a comma-separated list of function names
+   to show. Not passing this flag will show all functions
+
+These flags are also affected by if ``-g`` is set or not and whether
+``CHPL_DEVELOPER`` / ``--[no]-devel`` is set or not. Without ``-g``, the
+ability of LLVM to map remarks back to Chapel source code is limited. The
+compiler makes a best effort attempt to get Chapel source code information. If
+the compiler is run in developer mode and no function filters are set, it will
+output remarks for all code including standard and internal modules. Otherwise
+remarks will be limited to user modules only.
+
+
+.. note::
+   Introducing debug symbols with ``-g`` or changing the state of ``CHPL_DEVELOPER`` may change what optimizations can be done.

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -498,16 +498,6 @@ OPTIONS
     Pass an option to the LLVM optimization and transformation passes.
     This option can be specified multiple times.
 
-**\--llvm-remarks <filter>**
-
-    Enable printing LLVM optimization remarks with given regular expression
-    filter. Can be combined with **\--llvm-remarks-function**.
-
-**\--llvm-remarks-function <function names>**
-    
-    Enable printing LLVM optimization remarks for specific functions. Functions
-    are listed as a comma separated string. Can be combined with
-    **\--llvm-remarks**.
 
 *Compilation Trace Options*
 

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -498,6 +498,16 @@ OPTIONS
     Pass an option to the LLVM optimization and transformation passes.
     This option can be specified multiple times.
 
+**\--llvm-remarks <filter>**
+
+    Enable printing LLVM optimization remarks with given regular expression
+    filter. Can be combined with **\--llvm-remarks-function**.
+
+**\--llvm-remarks-function <function names>**
+    
+    Enable printing LLVM optimization remarks for specific functions. Functions
+    are listed as a comma separated string. Can be combined with
+    **\--llvm-remarks**.
 
 *Compilation Trace Options*
 

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -126,9 +126,6 @@ LLVM Code Generation Options:
                                       optimizations
       --mllvm <flags>                 LLVM flags (can be specified multiple
                                       times)
-      --llvm-remarks <regex>          Print LLVM optimization remarks
-      --llvm-remarks-function <name>  Print LLVM optimization remarks only for
-                                      these functions
 
 Compilation Trace Options:
       --[no-]print-commands           [Don't] print system commands

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -126,6 +126,9 @@ LLVM Code Generation Options:
                                       optimizations
       --mllvm <flags>                 LLVM flags (can be specified multiple
                                       times)
+      --llvm-remarks <regex>          Print LLVM optimization remarks
+      --llvm-remarks-function <name>  Print LLVM optimization remarks only for
+                                      these functions
 
 Compilation Trace Options:
       --[no-]print-commands           [Don't] print system commands

--- a/test/llvm/llvmOptRemarks/shouldBeInlined-optFailed.good
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined-optFailed.good
@@ -1,0 +1,1 @@
+shouldBeInlined.chpl:n:0: opt missed for 'inline' - 'foo_chpl' not inlined into 'chpl_user_main' because it should never be inlined (cost=never): no alwaysinline attribute

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.chpl
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.chpl
@@ -1,0 +1,9 @@
+// note: this test is pretty fragile based on whether or not LLVM chooses to optimize something
+config var x = 10;
+proc foo() {
+  return 1 + x;
+}
+proc main() {
+  var x = foo();
+  writeln(x);
+}

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.compopts
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.compopts
@@ -1,0 +1,5 @@
+--llvm-remarks='inline' # shouldBeInlined-optFailed.good
+--llvm-remarks-function='main' # shouldBeInlined-optFailed.good
+--fast --llvm-remarks='inline'
+--fast --llvm-remarks-function='main'
+--fast --llvm-remarks-function='foo' # nothing.good

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.good
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.good
@@ -1,0 +1,1 @@
+shouldBeInlined.chpl:n:0: opt passed for 'inline' - 'foo_chpl' inlined into 'chpl_user_main' with (cost=-15020, threshold=375)

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.noexec
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.noexec
@@ -1,0 +1,9 @@
+// note: thi
+config var x = 10;
+proc foo() {
+  return 1 + x;
+}
+proc main() {
+  var x = foo();
+  writeln(x);
+}

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.noexec
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.noexec
@@ -1,9 +1,0 @@
-// note: thi
-config var x = 10;
-proc foo() {
-  return 1 + x;
-}
-proc main() {
-  var x = foo();
-  writeln(x);
-}

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.prediff
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.prediff
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+TESTNAME=$1
+OUTFILE=$2
+TMPFILE=$OUTFILE.prediff.tmp
+
+# filter out line numbers
+sed -E 's/\.chpl:[0-9]*:/\.chpl:n:/' < $OUTFILE > $TMPFILE
+cat $TMPFILE > $OUTFILE
+
+# filter out any line that doesn't refer to 'foo_chpl'
+grep 'foo_chpl' < $OUTFILE > $TMPFILE
+cat $TMPFILE > $OUTFILE
+
+rm $TMPFILE

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.skipif
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.skipif
@@ -1,0 +1,4 @@
+# test will fail some cases if used in a --fast configuration
+COMPOPTS <= --fast
+# test only does something if LLVM is the backed
+CHPL_TARGET_COMPILER != llvm

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -134,6 +134,8 @@ _chpl ()
 --llvm \
 --llvm-print-ir \
 --llvm-print-ir-stage \
+--llvm-remarks \
+--llvm-remarks-function \
 --llvm-wide-opt \
 --local \
 --local-checks \
@@ -438,6 +440,8 @@ _chpl ()
 --license \
 --live-analysis \
 --llvm \
+--llvm-remarks \
+--llvm-remarks-function \
 --llvm-wide-opt \
 --local \
 --local-checks \

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -440,8 +440,6 @@ _chpl ()
 --license \
 --live-analysis \
 --llvm \
---llvm-remarks \
---llvm-remarks-function \
 --llvm-wide-opt \
 --local \
 --local-checks \


### PR DESCRIPTION
Adds flags to report LLVM optimization remarks, which allows inspecting which optimizations did/did not occur without inspecting the assembly. This is a general tool which should resolve #22596.

This adds two new flags, `--llvm-remarks` and `--llvm-remarks-function`. Use of either causes remarks to be emitted or they can be combined for filtering of which optimization remarks are emitted.
- `--llvm-remarks`: regex filtering based on the optimization pass name
- `--llvm-remarks-function`: comma separated list of function names to filter for

## Summary of changes
- Implement new flags, `--llvm-remarks` is passed directly to LLVM
- Add documentation to the LLVM technote 

## New Tests
- `test/llvm/llvmOptRemarks/shouldBeInlined.chpl`

## Testing
- [x] paratest with LLVM backend
- [x] paratest with C backend

[Reviewed by @mppf]