### PR TITLE
Prototype for `ioMode.a`supporting one `fileWriter`

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -590,7 +590,7 @@ enum ioMode {
   cw = 2,
   rw = 3,
   cwr = 4,
-  @unstable("append mode for :record:`fileWriter`s is unstable")
+  @unstable("append mode for is unstable")
   a = 5,
 }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -590,7 +590,7 @@ enum ioMode {
   cw = 2,
   rw = 3,
   cwr = 4,
-  @unstable("append mode for is unstable")
+  @unstable("append mode is unstable")
   a = 5,
 }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -563,11 +563,11 @@ constants have the same meaning as the following strings passed to ``fopen()`` i
    * - ``ioMode.cwr``
      - ``"w+"``
      - same as ``ioMode.cw``, but reading from the file is also allowed.
-
-.. TODO: Support append / create-exclusive modes:
    * - ``ioMode.a``
      - ``"a"``
      - open a file for appending, creating it if it does not exist.
+
+.. TODO: Support append / create-exclusive modes:
    * - ``ioMode.ar``
      - ``"a+"``
      - same as ``ioMode.a``, but reading from the file is also allowed.
@@ -579,12 +579,19 @@ constants have the same meaning as the following strings passed to ``fopen()`` i
      - same as ``ioMode.cwx``, but reading from the file is also allowed.
 
 However, :proc:`open()` in Chapel does not necessarily invoke ``fopen()`` in C.
+
+.. warning::
+
+   ``ioMode.a`` is unstable and subject to change. It currently only supports
+   one :record:`fileWriter` at a time.
 */
 enum ioMode {
   r = 1,
   cw = 2,
   rw = 3,
   cwr = 4,
+  @unstable("append mode for :record:`fileWriter`s is unstable")
+  a = 5,
 }
 
 @deprecated(notes="enum iomode is deprecated - please use :enum:`ioMode` instead")
@@ -2075,6 +2082,7 @@ private param _r = "r";
 private param _rw  = "r+";
 private param _cw = "w";
 private param _cwr = "w+";
+private param _a = "a";
 
 @chpldoc.nodoc
 proc _modestring(mode:ioMode) {
@@ -2084,6 +2092,7 @@ proc _modestring(mode:ioMode) {
     when ioMode.rw do return _rw;
     when ioMode.cw do return _cw;
     when ioMode.cwr do return _cwr;
+    when ioMode.a do return _a;
     otherwise do HaltWrappers.exhaustiveSelectHalt("Invalid ioMode");
   }
 }

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -799,6 +799,11 @@ qioerr qio_file_init(qio_file_t** file_out, FILE* fp, fd_t fd, qio_hint_t iohint
   if( err ) {
     return err;
   } else {
+    // if append, set the initial position to be the length
+    if( rc & O_APPEND ) {
+      initial_pos = initial_length;
+    }
+
     rc &= O_ACCMODE;
     // When setting the file mode, we pretend no matter what
     // that stdin is read-only and stdout/stderr are write-only.

--- a/test/compflags/TestWarnUnstableSuppression.3.good
+++ b/test/compflags/TestWarnUnstableSuppression.3.good
@@ -1,4 +1,6 @@
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode for is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.3.good
+++ b/test/compflags/TestWarnUnstableSuppression.3.good
@@ -1,6 +1,6 @@
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode for is unstable
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.5.good
+++ b/test/compflags/TestWarnUnstableSuppression.5.good
@@ -2,7 +2,7 @@ TestWarnUnstableSuppression.chpl:2: warning: chpl_unstableInternalSymbolForTesti
 TestWarnUnstableSuppression.chpl:3: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode for is unstable
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.5.good
+++ b/test/compflags/TestWarnUnstableSuppression.5.good
@@ -1,6 +1,8 @@
 TestWarnUnstableSuppression.chpl:2: warning: chpl_unstableInternalSymbolForTesting is unstable
 TestWarnUnstableSuppression.chpl:3: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode for is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.6.good
+++ b/test/compflags/TestWarnUnstableSuppression.6.good
@@ -1,5 +1,7 @@
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode for is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.6.good
+++ b/test/compflags/TestWarnUnstableSuppression.6.good
@@ -1,7 +1,7 @@
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode for is unstable
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.7.good
+++ b/test/compflags/TestWarnUnstableSuppression.7.good
@@ -2,6 +2,8 @@ TestWarnUnstableSuppression.chpl:2: warning: chpl_unstableInternalSymbolForTesti
 TestWarnUnstableSuppression.chpl:3: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode for is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.7.good
+++ b/test/compflags/TestWarnUnstableSuppression.7.good
@@ -3,7 +3,7 @@ TestWarnUnstableSuppression.chpl:3: warning: chpl_unstableStandardSymbolForTesti
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode for is unstable
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/library/standard/IO/append/.gitignore
+++ b/test/library/standard/IO/append/.gitignore
@@ -1,0 +1,1 @@
+test.txt

--- a/test/library/standard/IO/append/append.chpl
+++ b/test/library/standard/IO/append/append.chpl
@@ -4,7 +4,7 @@ config var filename = "test.txt";
 
 {
   var f = open(filename, ioMode.cw);
-  var w = f.writer(locking=false);
+  var w = f.writer();
   w.writeln("hello world from writeln");
   w.writeln("hello world from writeln again");
   w.close();
@@ -12,11 +12,8 @@ config var filename = "test.txt";
 }
 
 {
-  writeln(ioHintSet.mmap(false)._internal);
-  // works with ioHintSet.fromFlag(QIO_METHOD_FREADFWRITE)
-  // ioHintSet.fromFlag(QIO_METHOD_FREADFWRITE)
-  var f = open(filename, ioMode.a); // open then close without a write is fine
-  var a = f.writer(); //region=f.size..
+  var f = open(filename, ioMode.a);
+  var a = f.writer();
   a.writeln("world hello");
   a.close();
   f.close();

--- a/test/library/standard/IO/append/append.chpl
+++ b/test/library/standard/IO/append/append.chpl
@@ -1,0 +1,32 @@
+use IO;
+
+config var filename = "test.txt";
+
+{
+  var f = open(filename, ioMode.cw);
+  var w = f.writer(locking=false);
+  w.writeln("hello world from writeln");
+  w.writeln("hello world from writeln again");
+  w.close();
+  f.close();
+}
+
+{
+  writeln(ioHintSet.mmap(false)._internal);
+  // works with ioHintSet.fromFlag(QIO_METHOD_FREADFWRITE)
+  // ioHintSet.fromFlag(QIO_METHOD_FREADFWRITE)
+  var f = open(filename, ioMode.a); // open then close without a write is fine
+  var a = f.writer(); //region=f.size..
+  a.writeln("world hello");
+  a.close();
+  f.close();
+}
+
+{
+  var r = openReader(filename);
+  var line: string;
+  while r.readLine(line) {
+    write(line);
+  }
+  r.close();
+}

--- a/test/library/standard/IO/append/append.cleanfiles
+++ b/test/library/standard/IO/append/append.cleanfiles
@@ -1,0 +1,1 @@
+test.txt

--- a/test/library/standard/IO/append/append.good
+++ b/test/library/standard/IO/append/append.good
@@ -1,0 +1,3 @@
+hello world from writeln
+hello world from writeln again
+world hello

--- a/test/library/standard/IO/append/multipleWriters.chpl
+++ b/test/library/standard/IO/append/multipleWriters.chpl
@@ -1,0 +1,53 @@
+use IO;
+
+config var filename = "test.txt";
+
+config var mode = ioMode.a;
+config var nWriters = 5;
+config param locking = true;
+
+{
+  var w = openWriter(filename);
+  for i in 1..100 {
+      w.writeln("original ", i);
+      w.flush();
+  }
+  w.close();
+}
+{
+  proc writeStrings(w: fileWriter, id: int) {
+    // w.lock();
+    for i in 1..100 {
+      // w.lock();
+      w.writeln("task ", id, " ", i);
+      w.flush();
+      // w.unlock();
+    }
+    // w.unlock();
+
+  }
+  var f = open(filename, mode);
+
+  var writers: [0..<nWriters] fileWriter(iokind.dynamic,locking,nothing);
+  for idx in 0..<nWriters {
+    writers[idx] = f.writer(locking=locking);
+  }
+  coforall idx in 0..<nWriters {
+    writeStrings(writers[idx], idx);
+  }
+
+  for idx in 0..<nWriters {
+    writers[idx].close();
+  }
+  f.close();
+}
+{
+  var r = openReader(filename);
+  var line: string;
+  while r.readLine(line) {
+    write(line);
+  }
+  r.close();
+}
+
+

--- a/test/library/standard/IO/append/multipleWriters.future
+++ b/test/library/standard/IO/append/multipleWriters.future
@@ -1,0 +1,2 @@
+feature request: currently append only works correctly with one fileWriter
+#9992

--- a/test/library/standard/IO/append/multipleWriters.noexec
+++ b/test/library/standard/IO/append/multipleWriters.noexec
@@ -1,0 +1,1 @@
+this code is really racy right now, it is not clear to me what correct output should be

--- a/test/library/standard/IO/append/multipleWriters.notest
+++ b/test/library/standard/IO/append/multipleWriters.notest
@@ -1,0 +1,1 @@
+this is racy code right now

--- a/test/library/standard/IO/append/multipleWriters.notest
+++ b/test/library/standard/IO/append/multipleWriters.notest
@@ -1,1 +1,0 @@
-this is racy code right now

--- a/test/unstable/ioModeAppend.chpl
+++ b/test/unstable/ioModeAppend.chpl
@@ -1,0 +1,12 @@
+use IO;
+
+config var filename = "test.txt";
+
+{
+  var f = open(filename, ioMode.a);
+  var w = f.writer();
+  w.writeln("hello world from writeln");
+  w.writeln("hello world from writeln again");
+  w.close();
+  f.close();
+}

--- a/test/unstable/ioModeAppend.cleanfiles
+++ b/test/unstable/ioModeAppend.cleanfiles
@@ -1,0 +1,1 @@
+test.txt

--- a/test/unstable/ioModeAppend.good
+++ b/test/unstable/ioModeAppend.good
@@ -1,0 +1,1 @@
+ioModeAppend.chpl:6: warning: append mode for is unstable

--- a/test/unstable/ioModeAppend.good
+++ b/test/unstable/ioModeAppend.good
@@ -1,1 +1,1 @@
-ioModeAppend.chpl:6: warning: append mode for is unstable
+ioModeAppend.chpl:6: warning: append mode is unstable


### PR DESCRIPTION
Implements a prototype implementation for appending to a file, discussed in #22084 and #9992. It only supports one `fileWriter` at a time, using more can cause races.

## Summary of changes
- enable ioMode.a in `IO.chpl` and `qio.c`

## New Tests
- `test/library/standard/IO/append/append.chpl`
- `test/library/standard/IO/append/multipleWriters.chpl`
  - marked as `notest`, but including as it exhibits the potential races
- `test/unstable/ioModeAppend.chpl`

## Testing
- [x] paratest LLVM backend
- [x] paratest C backend
- [x] paratest LLVM backend + gasnet

[Reviewed by @jeremiah-corrado]