### PR TITLE
Invalid warning when compiling frontend with gcc 13

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1725,8 +1725,8 @@ resolveFunctionByPoisQuery(Context* context,
   return QUERY_END(result);
 }
 
-// this wrapper around resolveFunctionByPoisQuery helps to avoid
-// 'possibly dangling reference to a temporary' warnings from GCC 13.
+// TODO: remove this workaround now that the build uses
+// -Wno-dangling-reference
 static const owned<ResolvedFunction>&
 resolveFunctionByPoisQueryWrapper(Context* context,
                                   const TypedFnSignature* sig,
@@ -2306,8 +2306,8 @@ filterCandidatesInitial(Context* context,
   return QUERY_END(result);
 }
 
-// this wrapper around filterCandidatesInitial helps to avoid
-// 'possibly dangling reference to a temporary' warnings from GCC 13.
+// TODO: remove this workaround now that the build uses
+// -Wno-dangling-reference
 static const std::vector<const TypedFnSignature*>&
 filterCandidatesInitialWrapper(Context* context,
                                std::vector<BorrowedIdsWithName>&& lst,

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -249,7 +249,7 @@ createClangPrecompiledHeader(Context* context, ID externBlockId) {
     // specify output
     clFlags.push_back("-o");
     clFlags.push_back(tmpOutput);
-    const std::vector<std::string> cc1args =
+    const std::vector<std::string>& cc1args =
         getCC1Arguments(context, clFlags, /* forGpuCodegen */ false);
 
     std::vector<const char*> cc1argsCstrs;
@@ -327,7 +327,7 @@ precompiledHeaderContainsNameQuery(Context* context,
     std::string dummyFile = context->chplHome() + "/runtime/etc/rtmain.c";
     clFlags.push_back(dummyFile);
 
-    const std::vector<std::string> cc1args =
+    const std::vector<std::string>& cc1args =
       getCC1Arguments(context, clFlags, /* forGpuCodegen */ false);
 
     std::vector<const char*> cc1argsCstrs;

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -249,7 +249,7 @@ createClangPrecompiledHeader(Context* context, ID externBlockId) {
     // specify output
     clFlags.push_back("-o");
     clFlags.push_back(tmpOutput);
-    const std::vector<std::string>& cc1args =
+    const std::vector<std::string> cc1args =
         getCC1Arguments(context, clFlags, /* forGpuCodegen */ false);
 
     std::vector<const char*> cc1argsCstrs;
@@ -327,7 +327,7 @@ precompiledHeaderContainsNameQuery(Context* context,
     std::string dummyFile = context->chplHome() + "/runtime/etc/rtmain.c";
     clFlags.push_back(dummyFile);
 
-    const std::vector<std::string>& cc1args =
+    const std::vector<std::string> cc1args =
       getCC1Arguments(context, clFlags, /* forGpuCodegen */ false);
 
     std::vector<const char*> cc1argsCstrs;

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -336,6 +336,15 @@ endif
 endif
 
 #
+# Avoid a spurious warning in gcc 13, about a "possibly dangling reference"
+# when a function returns a reference to something on the heap. For more info
+# see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108165
+#
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -ge 13; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-dangling-reference
+endif
+
+#
 # 2016/03/28: Help to protect the Chapel compiler from a partially
 # characterized GCC optimizer regression when the compiler is being
 # compiled with gcc 5.X.

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -337,8 +337,9 @@ endif
 
 #
 # Avoid a spurious warning in gcc 13, about a "possibly dangling reference"
-# when a function returns a reference to something on the heap. For more info
-# see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108165
+# when a function returns a reference (even though it's something gauranteed to
+# be allocated on the heap). For more info see
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108165
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -ge 13; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-dangling-reference

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -337,7 +337,7 @@ endif
 
 #
 # Avoid a spurious warning in gcc 13, about a "possibly dangling reference"
-# when a function returns a reference (even though it's something gauranteed to
+# when a function returns a reference (even though it's something guaranteed to
 # be allocated on the heap). For more info see
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108165
 #


### PR DESCRIPTION
Recently on my desktop machine I updated to gcc 13.1.1, ever since then I get these error when compiling Chapel:

```
[  0%] Building CXX object frontend/lib/CMakeFiles/ChplFrontend-obj.dir/util/clang-integration.cpp.o
/home/stonea/chapel/frontend/lib/util/clang-integration.cpp: In function ‘chpl::owned<chpl::TemporaryFileResult>& chpl::util::createClangPrecompiledHeader(chpl::Context*, chpl::ID)’:
/home/stonea/chapel/frontend/lib/util/clang-integration.cpp:252:37: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  252 |     const std::vector<std::string>& cc1args =
      |                                     ^~~~~~~
/home/stonea/chapel/frontend/lib/util/clang-integration.cpp:253:24: note: the temporary was destroyed at the end of the full expression ‘chpl::util::getCC1Arguments(context, std::vector<std::__cxx11::basic_string<char> >(clFlags), 0)’
  253 |         getCC1Arguments(context, clFlags, /* forGpuCodegen */ false);
      |         ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/stonea/chapel/frontend/lib/util/clang-integration.cpp: In function ‘const bool& chpl::util::precompiledHeaderContainsNameQuery(chpl::Context*, const chpl::TemporaryFileResult*, chpl::UniqueString)’:
/home/stonea/chapel/frontend/lib/util/clang-integration.cpp:330:37: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  330 |     const std::vector<std::string>& cc1args =
      |                                     ^~~~~~~
/home/stonea/chapel/frontend/lib/util/clang-integration.cpp:331:22: note: the temporary was destroyed at the end of the full expression ‘chpl::util::getCC1Arguments(context, std::vector<std::__cxx11::basic_string<char> >(clFlags), 0)’
  331 |       getCC1Arguments(context, clFlags, /* forGpuCodegen */ false);
      |       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[6]: *** [frontend/lib/CMakeFiles/ChplFrontend-obj.dir/build.make:2596: frontend/lib/CMakeFiles/ChplFrontend-obj.dir/util/clang-integration.cpp.o] Error 1
make[5]: *** [CMakeFiles/Makefile2:819: frontend/lib/CMakeFiles/ChplFrontend-obj.dir/all] Error 2
make[4]: *** [CMakeFiles/Makefile2:774: compiler/CMakeFiles/chpl.dir/rule] Error 2
make[3]: *** [Makefile:169: chpl] Error 2
make[2]: *** [Makefile:197: /home/stonea/chapel/bin/linux64-x86_64/chpl] Error 2
make[1]: *** [Makefile:82: compiler] Error 2
make: *** [Makefile:59: comprt] Error 2
```

What's happening is for whatever reason this function returns a reference to a vector:

```
const std::vector<std::string>& getCC1Arguments(...)
```

And when we call it we do something like this:

```
const std::vector<std::string>& cc1args = getCC1Arguments(...)
```

~~[Looking internally into `getCC1Arguments`](https://github.com/chapel-lang/chapel/blob/827df4f0d2281c44a4bffe2cb866a7503d9a92cf/frontend/lib/util/clang-integration.cpp#L198) I think? it's returning a variable on its stack (`result`), so it's true that the thing being referenced to is going to get destroyed after finishing the call.  I can get the issue to go away by just having the call site not assign to a reference.  Maybe I'm misunderstanding something, but I think with the move construction and/or copy elision there shouldn't be any unnecessary copies happening anyway.~~

**Edit**: In this case `getCC1Arguments` will indeed return a reference to heap allocated data so the warning is spurious.

TODO:
- [x] Normal paratests