### PR TITLE
Fix up func_ptr_as_c_fn_ptr / func_ptr_as_void_ptr

### DIFF
--- a/test/types/cptr/func_ptr_as_c_fn_ptr.skipif
+++ b/test/types/cptr/func_ptr_as_c_fn_ptr.skipif
@@ -1,2 +1,9 @@
-COMPOPTS <= --baseline
-CHPL_TARGET_COMPILER == llvm
+#!/usr/bin/env python3
+
+from os import environ
+if 'llvm' == environ['CHPL_TARGET_COMPILER']:
+  print (True)
+elif '--baseline' in environ['COMPOPTS']:
+  print (False)
+else:
+  print (True)

--- a/test/types/cptr/func_ptr_as_void_ptr.chpl
+++ b/test/types/cptr/func_ptr_as_void_ptr.chpl
@@ -1,3 +1,5 @@
+use CTypes;
+
 extern record MyRec {
   var x: c_void_ptr;
 }

--- a/test/types/cptr/func_ptr_as_void_ptr.skipif
+++ b/test/types/cptr/func_ptr_as_void_ptr.skipif
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 from os import environ
-if '--baseline' in environ['COMPOPTS']:
+if 'llvm' == environ['CHPL_TARGET_COMPILER']:
+  print (True)
+elif '--baseline' in environ['COMPOPTS']:
   print (False)
 else:
   print (True)


### PR DESCRIPTION
This PR adjusts func_ptr_as_c_fn_ptr after PR #21894 caused it to start passing in non-baseline C backend configurations. That PR changed some of the temporaries for module-scope statements to not be module-scope but rather local variables. That allowed the denormalizer to be more effective and removed the expression that caused a problem. 

Meanwhile, based on the .future text, I think that perhaps func_ptr_as_c_fn_ptr was only ever intended to run in `--baseline` configurations and in fact it still fails there. So, this PR updates the .skipif to skip non-baseline configurations.

While there, I updated the skipif for func_ptr_as_void_ptr in a similar (that one was missing the part about skipping for the LLVM backend) and adjusted that test to resolve a compilation error due to a missing `use CTypes`.

Test change only - not reviewed.