### PR TITLE
Remove uneeded non-zero exit codes from performance tests

### DIFF
--- a/test/studies/colostate/Jacobi1D-DiamondByHand-OMP_dyn.test.c
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-OMP_dyn.test.c
@@ -169,9 +169,6 @@ int main( int argc, char* argv[] ) {
       fprintf(stderr,"SUCCESS\n");
     }
   }
-  return 1;
+  return 0;
     
 }
-
-
-

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-OMP_static.test.c
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-OMP_static.test.c
@@ -169,9 +169,6 @@ int main( int argc, char* argv[] ) {
       fprintf(stderr,"SUCCESS\n");
     }
   }
-  return 1;
+  return 0;
     
 }
-
-
-

--- a/test/studies/colostate/cfd-mini-c.test.c
+++ b/test/studies/colostate/cfd-mini-c.test.c
@@ -140,8 +140,7 @@ int main(int argc, char **argv) {
   // Step 2: Call the function to do the work
   cfd_mini(numCell, numBox, kernel); 
 
-
-  return 1;
+  return 0;
 }
 
 #undef GET_VAL_PTR


### PR DESCRIPTION
After the testing infra change in https://github.com/chapel-lang/chapel/pull/22611, some performance tests are failing because they emit non-zero exit codes.

The following C tests are updated to `reaturn 0` from `main` instead of `1` to avoid these failures:
- studies/colostate/Jacobi1D-DiamondByHand-OMP_dyn
- studies/colostate/Jacobi1D-DiamondByHand-OMP_static
- studies/colostate/cfd-mini-c