### PR TITLE
Remove CHPL_RT_COMM_OFI_EP_COUNT

### DIFF
--- a/doc/rst/platforms/libfabric.rst
+++ b/doc/rst/platforms/libfabric.rst
@@ -262,19 +262,3 @@ slurm job, however.
 
 .. _Homebrew: https://github.com/Homebrew/brew
 
-.. _bound-endpoints:
-
-Bound Endpoints
-_______________________
-
-For best performance endpoints should be "bound" to cores, so that
-each core has a dedicated transmit endpoint. Unfortunately, some
-providers incorrectly report that they support too few endpoints to bind
-each core to an endpoint. You can override the number of endpoints reported
-by the provider by setting ``CHPL_RT_COMM_OFI_EP_COUNT``. Note that
-endpoint creation will fail if you set this variable to a value higher
-than the number of endpoints that the provider can support. You
-may verify whether or not endpoints are bound by specifying the
-the ``-v`` option on the command line and looking at the line in the output
-that starts with ``COMM=``.
-

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1609,8 +1609,11 @@ chpl_bool canBindTxCtxs(struct fi_info* info) {
   // we'll use bound tx contexts with this provider.
   //
   const struct fi_domain_attr* dom_attr = info->domain_attr;
-  int epCount = chpl_env_rt_get_int("COMM_OFI_EP_COUNT", dom_attr->ep_cnt);
-  int numWorkerTxCtxs = ((envPreferScalableTxEp
+  // The cxi provider has a bug in which it reports a maximum of only 128
+  // endpoints. Until that is fixed, assume it can create as many endpoints
+  // as we need.
+  size_t epCount = isInProvider("cxi", info) ? SIZE_MAX : dom_attr->ep_cnt;
+  size_t numWorkerTxCtxs = ((envPreferScalableTxEp
                           && dom_attr->max_ep_tx_ctx > 1)
                          ? dom_attr->max_ep_tx_ctx
                          : epCount)


### PR DESCRIPTION
The `CHPL_RT_COMM_OFI_EP_COUNT` environment variable was added as an expedient workaround to the erroneous `ep_cnt` value returned by the `cxi` provider. However, it requires documentation and relies on the user to specify a large enough value to bind all cores to endpoints. Instead, until the `cxi` bug is fixed, simply assume the `cxi` provider can create as many endpoints as we need.

Resolves https://github.com/Cray/chapel-private/issues/5025 and resolves https://github.com/Cray/chapel-private/issues/4968.