### PR TITLE
Cpu as device job

### DIFF
--- a/runtime/include/gpu/cpu/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cpu/chpl-gpu-gen-includes.h
@@ -47,7 +47,7 @@ static inline void chpl_gpu_printTimeDelta(
   printf("%s%u\n", msg, end - start);
 }
 
-static inline void chpl_gpu_force_sync() {
+static inline void chpl_gpu_force_sync(void) {
   if (!chpl_gpu_no_cpu_mode_warning) {
     chpl_warning("chpl_gpu_force_sync was called", 0, 0);
   }

--- a/test/gpu/native/array_on_device/README
+++ b/test/gpu/native/array_on_device/README
@@ -1,5 +1,5 @@
 This directory is for tests that can run with page-locked-memory
-(CHPL_CUDA_MEM_STRATEGY=array_data_on_device) at the time we are enabling it.
+(CHPL_GPU_MEM_STRATEGY=array_data_on_device) at the time we are enabling it.
 Down the road, as we have better support for GET/PUT and local data movement,
 we expect all tests to pass with that setting, and that setting to be the
 default.

--- a/test/gpu/native/atomics.skipif
+++ b/test/gpu/native/atomics.skipif
@@ -1,1 +1,2 @@
 CHPL_GPU_ARCH==gfx908
+CHPL_GPU==cpu

--- a/test/gpu/native/gpuWritelnAndAssertOnGpu.skipif
+++ b/test/gpu/native/gpuWritelnAndAssertOnGpu.skipif
@@ -1,1 +1,2 @@
-CHPL_GPU=cpu
+# This test covers features we don't support in cpu-as-device mode
+CHPL_GPU==cpu

--- a/test/gpu/native/gpuWritelnAndAssertOnGpu.skipif
+++ b/test/gpu/native/gpuWritelnAndAssertOnGpu.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU=cpu

--- a/test/gpu/native/memory/basic.skipif
+++ b/test/gpu/native/memory/basic.skipif
@@ -1,0 +1,4 @@
+# This test relies on making direct calls to the GPU runtime layer that in
+# practice (like chpl_gpu_copy_host_to_device) that won't be invoked when using
+# cpu-as-device mode.
+CHPL_GPU==cpu

--- a/test/gpu/native/memory/ops.skipif
+++ b/test/gpu/native/memory/ops.skipif
@@ -1,0 +1,4 @@
+# This test relies on making direct calls to the GPU runtime layer that in
+# practice (like chpl_gpu_copy_device_to_host) that won't be invoked when using
+# cpu-as-device mode.
+CHPL_GPU==cpu

--- a/test/gpu/native/memory/sharedMemory.skipif
+++ b/test/gpu/native/memory/sharedMemory.skipif
@@ -1,0 +1,2 @@
+# We don't support using shared memory when using cpu-as-device mode
+CHPL_GPU==cpu

--- a/test/gpu/native/nestedForall.suppressif
+++ b/test/gpu/native/nestedForall.suppressif
@@ -2,4 +2,7 @@
 # cpu-as-device mode.  Given that part of the purpose of using this mode is to
 # determine what the expected behavior would be with GPUs this is a little
 # disconcerting.
+#
+# TODO: Investigate this and report on
+# https://github.com/Cray/chapel-private/issues/5064
 CHPL_GPU==cpu

--- a/test/gpu/native/nestedForall.suppressif
+++ b/test/gpu/native/nestedForall.suppressif
@@ -1,0 +1,5 @@
+# This is currently failing to produce the same number of launches with using
+# cpu-as-device mode.  Given that part of the purpose of using this mode is to
+# determine what the expected behavior would be with GPUs this is a little
+# disconcerting.
+CHPL_GPU==cpu

--- a/test/gpu/native/nestedForeach.suppressif
+++ b/test/gpu/native/nestedForeach.suppressif
@@ -2,4 +2,7 @@
 # cpu-as-device mode.  Given that part of the purpose of using this mode is to
 # determine what the expected behavior would be with GPUs this is a little
 # disconcerting.
+#
+# TODO: Investigate this and report on
+# https://github.com/Cray/chapel-private/issues/5064
 CHPL_GPU==cpu

--- a/test/gpu/native/nestedForeach.suppressif
+++ b/test/gpu/native/nestedForeach.suppressif
@@ -1,0 +1,5 @@
+# This is currently failing to produce the same number of launches with using
+# cpu-as-device mode.  Given that part of the purpose of using this mode is to
+# determine what the expected behavior would be with GPUs this is a little
+# disconcerting.
+CHPL_GPU==cpu

--- a/test/gpu/native/noGpu/assertOnGpu.compopts
+++ b/test/gpu/native/noGpu/assertOnGpu.compopts
@@ -1,3 +1,3 @@
 -striggerAssert=true   #assertOnGpu-do-assert
--striggerAssert=false  #assertOnGpu-dont-assert
+-striggerAssert=false -sgpuNoCpuModeWarning=false #assertOnGpu-dont-assert
 -striggerAssert=false -sgpuNoCpuModeWarning #assertOnGpu-dont-assert-no-warn

--- a/test/gpu/native/nvlink.skipif
+++ b/test/gpu/native/nvlink.skipif
@@ -1,1 +1,2 @@
-CHPL_GPU=cpu
+# we don't support using nvlink with cpu-as-device mode
+CHPL_GPU==cpu

--- a/test/gpu/native/nvlink.skipif
+++ b/test/gpu/native/nvlink.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU=cpu

--- a/test/gpu/native/sharedMemory.skipif
+++ b/test/gpu/native/sharedMemory.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU=CPU

--- a/test/gpu/native/sharedMemory.skipif
+++ b/test/gpu/native/sharedMemory.skipif
@@ -1,1 +1,0 @@
-CHPL_GPU=CPU

--- a/test/gpu/native/studies/shoc/sort.skipif
+++ b/test/gpu/native/studies/shoc/sort.skipif
@@ -1,1 +1,4 @@
 CHPL_GPU_MEM_STRATEGY==array_on_device
+# 'sort' uses features like shared memory that we don't have support for in
+# cpu-as-device mode:
+CHPL_GPU==cpu

--- a/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.skipif
+++ b/test/gpu/native/studies/tightLoopNotOnGpu/tightLoopNotOnGpu.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU==cpu

--- a/test/gpu/native/threadBlockAndGridPrimitives.skipif
+++ b/test/gpu/native/threadBlockAndGridPrimitives.skipif
@@ -1,1 +1,3 @@
-CHPL_GPU=cpu
+# We don't expect to ever call the primitives this test is about directly when
+# using cpu-as-device mode.
+CHPL_GPU==cpu

--- a/test/gpu/native/threadBlockAndGridPrimitives.skipif
+++ b/test/gpu/native/threadBlockAndGridPrimitives.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU=cpu

--- a/util/cron/test-gpu-cpu.bash
+++ b/util/cron/test-gpu-cpu.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# GPU native testing using cpu-as-device mode on a Cray CS (using none for
+# CHPL_COMM)
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-native-gpu.bash
+
+export CHPL_GPU=cpu
+export CHPL_COMM=none
+export CHPL_GPU_NO_CPU_MODE_WARNING=y
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cpu"
+$CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
cpu-as-device is a (relatively) new mode for GPU support set by using `CHPL_GPU=cpu`.  This PR adds a script to conduct nightly testing in this mode and adds various `.skipif`/`.supressif` files to exempt portions of our GPU test suite that are expected (or currently don't) work in cpu-as-device mode.

The tests covered by `.suppressif` are things that I'm somewhat surprised don't currently work so we should do some followup investigation there. In the meantime though, I think locking down what currently works with nightly testing is valuable.

Somewhat tangentially: I also update a function declaration in `chpl-gpu-gen-includes.h` to avoid a compiletime warning due to the prototype having no arguments but instead of having an argument list like `foo(void)` we had it empty like: `foo()`.