### PR TITLE
Rename `CodepointSplittingError` to `CodepointSplitError`

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -895,8 +895,9 @@ module Bytes {
                   - `decodePolicy.escape` escapes each illegal byte with
                     private use codepoints
 
-    :throws DecodeError: if `decodePolicy.strict` is passed to the `policy`
-            argument and the :type:`bytes` contains non-UTF-8 characters.
+    :throws: Throws a :class:`~Errors.DecodeError` if `decodePolicy.strict` is
+      passed to the `policy` argument and the :type:`bytes` contains non-UTF-8
+      characters.
 
     :returns: A UTF-8 string.
   */

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -395,7 +395,7 @@ module BytesStringCommon {
         if r.hasLowBound() &&
            x.byteIndices.boundsCheck(r.lowBound:int) &&
            !isInitialByte(x.byte[r.lowBound:int]) {
-          throw new CodepointSplittingError(
+          throw new CodepointSplitError(
             "Byte-based string slice is not aligned to codepoint boundaries. " +
             "The byte at low boundary " + r.lowBound:string + " is not the first byte of a UTF-8 codepoint");
         }
@@ -404,7 +404,7 @@ module BytesStringCommon {
         if r.hasHighBound() &&
            x.byteIndices.boundsCheck(r.highBound:int+1) &&
            !isInitialByte(x.byte[r.highBound:int+1]) {
-          throw new CodepointSplittingError(
+          throw new CodepointSplitError(
             "Byte-based string slice is not aligned to codepoint boundaries. " +
             "The byte at high boundary " + r.highBound:string + " is not the first byte of a UTF-8 codepoint");
         }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -415,7 +415,8 @@ module String {
                  terminating null byte.
     :type length: `int`
 
-    :throws DecodeError: if `x` contains non-UTF-8 characters.
+    :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+      characters.
 
     :returns: A new `string`
   */
@@ -439,7 +440,8 @@ module String {
                  terminating null byte.
     :type length: `int`
 
-    :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+    :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+      characters.
 
     :returns: A new `string`
   */
@@ -488,7 +490,8 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws DecodeError: if `x` contains non-UTF-8 characters.
+     :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+      characters.
 
      :returns: A new `string`
   */
@@ -514,7 +517,8 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+     :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+      characters.
 
      :returns: A new `string`
   */
@@ -547,7 +551,8 @@ module String {
                  terminating null byte.
     :type length: `int`
 
-     :throws DecodeError: if `x` contains non-UTF-8 characters.
+    :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+      characters.
 
     :returns: A new `string`
   */
@@ -570,7 +575,8 @@ module String {
                  terminating null byte.
     :type length: `int`
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+    :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+      characters.
 
     :returns: A new `string`
   */
@@ -595,7 +601,8 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws DecodeError: if `x` contains non-UTF-8 characters.
+     :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+      characters.
 
      :returns: A new `string`
   */
@@ -620,7 +627,8 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+     :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+      characters.
 
      :returns: A new `string`
   */
@@ -670,8 +678,8 @@ module String {
                  - `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-    :throws DecodeError: if `decodePolicy.strict` is passed to the `policy`
-            argument and `x` contains non-UTF-8 characters.
+    :throws: Throws a :class:`~Errors.DecodeError`: if `decodePolicy.strict` is
+      passed to the `policy` argument and `x` contains non-UTF-8 characters.
 
     :returns: A new `string`
   */
@@ -698,8 +706,8 @@ module String {
                  - `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-    :throws: `DecodeError` if `decodePolicy.strict` is passed to the `policy`
-             argument and `x` contains non-UTF-8 characters.
+    :throws: Throws a :class:`~Errors.DecodeError`: if `decodePolicy.strict` is
+      passed to the `policy` argument and `x` contains non-UTF-8 characters.
 
     :returns: A new `string`
   */
@@ -733,7 +741,8 @@ module String {
                    `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-     :throws DecodeError: if `x` contains non-UTF-8 characters.
+     :throws: a :class:`~Errors.DecodeError` if `x` contains non-UTF-8
+       characters.
 
      :returns: A new `string`
   */
@@ -765,7 +774,8 @@ module String {
                    `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+     :throws: a :class:`~Errors.DecodeError` if `x` contains non-UTF-8
+       characters.
 
      :returns: A new `string`
   */
@@ -1619,8 +1629,8 @@ module String {
 
     :arg r: range of the indices the new string should be made from
 
-    :throws :class:`CodepointSplitError`: if slicing results in splitting a
-            multi-byte codepoint.
+    :throws: throws a :class:`~Errors.CodepointSplitError`: if slicing results
+      in splitting a multi-byte codepoint.
 
     :returns: a new string that is a substring within ``0..<string.size``. If
               the length of `r` is zero, an empty string is returned.

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1619,7 +1619,7 @@ module String {
 
     :arg r: range of the indices the new string should be made from
 
-    :throws CodepointSplittingError: if slicing results in splitting a
+    :throws :class:`CodepointSplitError`: if slicing results in splitting a
             multi-byte codepoint.
 
     :returns: a new string that is a substring within ``0..<string.size``. If

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -135,21 +135,11 @@ module Errors {
   }
 
   /*
-    A ``CodepointSplitError`` is a subclass of :class:`Error` thrown when
-    slicing a string with byteIndex-based ranges where the range
-    boundaries do not align with codepoint boundaries.
-
-    .. method:: proc init(info: string)
-
-    .. method:: override proc message()
+    A ``CodepointSplitError`` is thrown when slicing a string with
+    byteIndex-based ranges where the range boundaries do not align
+    with codepoint boundaries.
   */
-  type CodepointSplitError = chpl_CodepointSplitError;
-
-  @deprecated(notes=":class:`CodepointSplittingError` is deprecated; please use :class:`CodepointSplitError` instead")
-  type CodepointSplittingError = chpl_CodepointSplitError;
-
-  @chpldoc.nodoc
-  class chpl_CodepointSplitError: Error {
+  class CodepointSplitError: Error {
     proc init(info: string) {
       super.init(info);
     }
@@ -158,6 +148,9 @@ module Errors {
       return "Attempting to split a multi-byte codepoint. " + _msg;
     }
   }
+
+  @deprecated(notes=":class:`CodepointSplittingError` is deprecated; please use :class:`CodepointSplitError` instead")
+  type CodepointSplittingError = CodepointSplitError;
 
   // Used by the runtime to accumulate errors. This type
   // supports adding errors concurrently but need not support

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -135,10 +135,21 @@ module Errors {
   }
 
   /*
-   A `CodepointSplittingError` is thrown if an attempt to slice a string with
+   A `CodepointSplitError` is thrown if an attempt to slice a string with
    byteIndex-based ranges where the range boundaries does not align with
    codepoint boundaries.
    */
+  class CodepointSplitError: Error {
+    proc init(info: string) {
+      super.init(info);
+    }
+
+    override proc message() {
+      return "Attempting to split a multi-byte codepoint. " + _msg;
+    }
+  }
+
+  @deprecated(notes=":class:`CodepointSplittingError` is deprecated; please use :class:`CodepointSplitError` instead")
   class CodepointSplittingError: Error {
     proc init(info: string) {
       super.init(info);

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -138,19 +138,18 @@ module Errors {
    A `CodepointSplitError` is thrown if an attempt to slice a string with
    byteIndex-based ranges where the range boundaries does not align with
    codepoint boundaries.
-   */
-  class CodepointSplitError: Error {
-    proc init(info: string) {
-      super.init(info);
-    }
 
-    override proc message() {
-      return "Attempting to split a multi-byte codepoint. " + _msg;
-    }
-  }
+    .. method:: proc init(info: string)
+
+    .. method:: override proc message()
+  */
+  type CodepointSplitError = chpl_CodepointSplitError;
 
   @deprecated(notes=":class:`CodepointSplittingError` is deprecated; please use :class:`CodepointSplitError` instead")
-  class CodepointSplittingError: Error {
+  type CodepointSplittingError = chpl_CodepointSplitError;
+
+  @chpldoc.nodoc
+  class chpl_CodepointSplitError: Error {
     proc init(info: string) {
       super.init(info);
     }

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -135,9 +135,9 @@ module Errors {
   }
 
   /*
-   A `CodepointSplitError` is thrown if an attempt to slice a string with
-   byteIndex-based ranges where the range boundaries does not align with
-   codepoint boundaries.
+    A ``CodepointSplitError`` is a subclass of :class:`Error` thrown when
+    slicing a string with byteIndex-based ranges where the range
+    boundaries do not align with codepoint boundaries.
 
     .. method:: proc init(info: string)
 

--- a/test/deprecated/cpSplittingError.chpl
+++ b/test/deprecated/cpSplittingError.chpl
@@ -1,9 +1,7 @@
-var s = "you cannot split this pie: 🥧";
-
-try {
-  var x = s[(s.find(": ")+1)..];
-} catch e: CodepointSplittingError {
-  writeln(e.message());
-} catch e {
-  writeln("caught wrong error type!");
+proc splitString(s: string, needle: string) {
+  try {
+    return s[s.find(needle)];
+  } catch e:CodepointSplittingError {
+    return "";
+  }
 }

--- a/test/deprecated/cpSplittingError.chpl
+++ b/test/deprecated/cpSplittingError.chpl
@@ -1,7 +1,9 @@
-proc splitString(s: string, needle: string) {
-  try {
-    return s[s.find(needle)];
-  } catch e:CodepointSplittingError {
-    return "";
-  }
+var s = "you cannot split this pie:🥧";
+
+try {
+  var slice = s[(s.find(":")+2)..];
+} catch e: CodepointSplittingError {
+  writeln(e.message());
+} catch e {
+  writeln("caught wrong error type: ", e);
 }

--- a/test/deprecated/cpSplittingError.chpl
+++ b/test/deprecated/cpSplittingError.chpl
@@ -1,0 +1,9 @@
+var s = "you cannot split this pie: 🥧";
+
+try {
+  var x = s[(s.find(": ")+1)..];
+} catch e: CodepointSplittingError {
+  writeln(e.message());
+} catch e {
+  writeln("caught wrong error type!");
+}

--- a/test/deprecated/cpSplittingError.good
+++ b/test/deprecated/cpSplittingError.good
@@ -1,2 +1,2 @@
-cpSplittingError.chpl:1: In function 'splitString':
-cpSplittingError.chpl:4: warning: CodepointSplittingError is deprecated; please use CodepointSplitError instead
+cpSplittingError.chpl:5: warning: CodepointSplittingError is deprecated; please use CodepointSplitError instead
+Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 27 is not the first byte of a UTF-8 codepoint

--- a/test/deprecated/cpSplittingError.good
+++ b/test/deprecated/cpSplittingError.good
@@ -1,1 +1,2 @@
-cpSplittingError.chpl:5: warning: CodepointSplittingError is deprecated; please use CodepointSplitError instead
+cpSplittingError.chpl:1: In function 'splitString':
+cpSplittingError.chpl:4: warning: CodepointSplittingError is deprecated; please use CodepointSplitError instead

--- a/test/deprecated/cpSplittingError.good
+++ b/test/deprecated/cpSplittingError.good
@@ -1,0 +1,1 @@
+cpSplittingError.chpl:5: warning: CodepointSplittingError is deprecated; please use CodepointSplitError instead

--- a/test/types/string/ilseqByteSlice.good
+++ b/test/types/string/ilseqByteSlice.good
@@ -2,6 +2,6 @@ Türkçe
 6
 ürkçe
 5
-uncaught CodepointSplittingError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 2 is not the first byte of a UTF-8 codepoint
+uncaught CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 2 is not the first byte of a UTF-8 codepoint
   ilseqByteSlice.chpl:4: thrown here
   ilseqByteSlice.chpl:4: uncaught here

--- a/test/types/string/ilseqByteSlice.good
+++ b/test/types/string/ilseqByteSlice.good
@@ -2,6 +2,6 @@ Türkçe
 6
 ürkçe
 5
-uncaught chpl_CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 2 is not the first byte of a UTF-8 codepoint
+uncaught CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 2 is not the first byte of a UTF-8 codepoint
   ilseqByteSlice.chpl:4: thrown here
   ilseqByteSlice.chpl:4: uncaught here

--- a/test/types/string/ilseqByteSlice.good
+++ b/test/types/string/ilseqByteSlice.good
@@ -2,6 +2,6 @@ Türkçe
 6
 ürkçe
 5
-uncaught CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 2 is not the first byte of a UTF-8 codepoint
+uncaught chpl_CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 2 is not the first byte of a UTF-8 codepoint
   ilseqByteSlice.chpl:4: thrown here
   ilseqByteSlice.chpl:4: uncaught here

--- a/test/types/string/ilseqByteSlice2.good
+++ b/test/types/string/ilseqByteSlice2.good
@@ -1,3 +1,3 @@
-uncaught CodepointSplittingError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 4 is not the first byte of a UTF-8 codepoint
+uncaught CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 4 is not the first byte of a UTF-8 codepoint
   ilseqByteSlice2.chpl:4: thrown here
   ilseqByteSlice2.chpl:4: uncaught here

--- a/test/types/string/ilseqByteSlice2.good
+++ b/test/types/string/ilseqByteSlice2.good
@@ -1,3 +1,3 @@
-uncaught chpl_CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 4 is not the first byte of a UTF-8 codepoint
+uncaught CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 4 is not the first byte of a UTF-8 codepoint
   ilseqByteSlice2.chpl:4: thrown here
   ilseqByteSlice2.chpl:4: uncaught here

--- a/test/types/string/ilseqByteSlice2.good
+++ b/test/types/string/ilseqByteSlice2.good
@@ -1,3 +1,3 @@
-uncaught CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 4 is not the first byte of a UTF-8 codepoint
+uncaught chpl_CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 4 is not the first byte of a UTF-8 codepoint
   ilseqByteSlice2.chpl:4: thrown here
   ilseqByteSlice2.chpl:4: uncaught here


### PR DESCRIPTION
Per the discussion summarized [here](https://github.com/chapel-lang/chapel/issues/21069#issuecomment-1611857359), rename `CodepointSplittingError` to `CodepointSplitError`.

Also updates some `string` and `bytes` docs to link to `CodepointSplitError` and `DecodeError`.

- [x] inspected docs
- [x] paratest