### PR TITLE
Improve filtering for LLVM opt test

### DIFF
--- a/test/llvm/llvmOptRemarks/shouldBeInlined.good
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.good
@@ -1,1 +1,1 @@
-shouldBeInlined.chpl:n:0: opt passed for 'inline' - 'foo_chpl' inlined into 'chpl_user_main' with (cost=-15020, threshold=375)
+shouldBeInlined.chpl:n:0: opt passed for 'inline' - 'foo_chpl' inlined into 'chpl_user_main' with (cost=N, threshold=N)

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.prediff
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.prediff
@@ -12,4 +12,12 @@ cat $TMPFILE > $OUTFILE
 grep 'foo_chpl' < $OUTFILE > $TMPFILE
 cat $TMPFILE > $OUTFILE
 
+# filter out any line that doesn't refer to 'chpl_user_main'
+grep 'chpl_user_main' < $OUTFILE > $TMPFILE
+cat $TMPFILE > $OUTFILE
+
+# filter 'cost=...' and 'threshold=...'
+sed -E 's/(cost|threshold)=-?[0-9]+/\1=N/g' < $OUTFILE > $TMPFILE
+cat $TMPFILE > $OUTFILE
+
 rm $TMPFILE

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.skipif
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.skipif
@@ -3,4 +3,7 @@ COMPOPTS <= --fast
 # test only does something if LLVM is the backed
 CHPL_TARGET_COMPILER != llvm
 # test only LLVM 15 or greater
-CHPL_LLVM_VERSION>=15
+CHPL_LLVM_VERSION==11
+CHPL_LLVM_VERSION==12
+CHPL_LLVM_VERSION==13
+CHPL_LLVM_VERSION==14

--- a/test/llvm/llvmOptRemarks/shouldBeInlined.skipif
+++ b/test/llvm/llvmOptRemarks/shouldBeInlined.skipif
@@ -2,3 +2,5 @@
 COMPOPTS <= --fast
 # test only does something if LLVM is the backed
 CHPL_TARGET_COMPILER != llvm
+# test only LLVM 15 or greater
+CHPL_LLVM_VERSION>=15


### PR DESCRIPTION
A recently added test is susceptible to both the configuration (gasnet, valgrind, etc) and llvm version, this PR improves both the `.skipif` and the `.prediff` for the test to resolve this.

Test: `test/llvm/llvmOptRemarks/shouldBeInlined.chpl`

[Reviewed by @mppf]