### PR TITLE
Update measureGpuCycles test to be less brittle

### DIFF
--- a/test/gpu/native/measureGpuCycles.chpl
+++ b/test/gpu/native/measureGpuCycles.chpl
@@ -32,8 +32,9 @@ on here.gpus[0] {
     if showTimingResults then
       writeln("Diff is: ",
         (clockDiff[i] : real) / (gpuClocksPerSec(0) : real));
-    if clockDiff[i] < 0 {
-      writeln("Unexpected negative result, i= ", i,  " clockDiff[i]=", clockDiff[i]);
+    if clockDiff[i] <= 0 {
+      writeln("Unexpected negative or zero result: i= ", i,  " clockDiff[i]=",
+        clockDiff[i]);
     }
   }
 }

--- a/test/gpu/native/measureGpuCycles.chpl
+++ b/test/gpu/native/measureGpuCycles.chpl
@@ -28,16 +28,12 @@ on here.gpus[0] {
     }
   }
 
-  var isMonotonicallyIncreasing = true;
   for i in 0..<howManyResults {
     if showTimingResults then
       writeln("Diff is: ",
         (clockDiff[i] : real) / (gpuClocksPerSec(0) : real));
-    if i > 0 && clockDiff[i] < clockDiff[i-1] then
-      isMonotonicallyIncreasing = false;
+    if clockDiff[i] < 0 {
+      writeln("Unexpected negative result, i= ", i,  " clockDiff[i]=", clockDiff[i]);
+    }
   }
-
-  // Used as a crude correctness check. If this isn't true then we're likely
-  // doing something wrong.
-  writeln("Largers loops always took longer: ", isMonotonicallyIncreasing);
 }

--- a/test/gpu/native/measureGpuCycles.good
+++ b/test/gpu/native/measureGpuCycles.good
@@ -1,2 +1,1 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-Largers loops always took longer: true


### PR DESCRIPTION
The measureGpuCycles.chpl test does a verification test by running a series of progressively larger loops. It performs a correctness check to verify that the larger loops always run for a longer amount of time compared to the smaller loops.

Most of the times this works fine, but we've had this test fail sporadically. The `gpuClock` function is a pretty thin wrapper on the cuda `clock()` function and the vast majority of times things do run fine so I find it doubtful that this is due to any legitimate issue on our end and more likely due to noise in the system.

Nevertheless, (assuming these are false negatives), it's a bit annoying so I'm going to change the testing strategy to just assert that our clocked times for each loop is > 0 ms.

See this (internal) issue for more details: https://github.com/Cray/chapel-private/issues/4808