### PR TITLE
Remove range._aligned field

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -842,11 +842,10 @@ module ChapelIO {
     if f.matchLiteral(" align ") {
       const alignVal = f.read(chpl_integralIdxType);
       if hasParamStrideAltvalAld() {
-        // It is valid to align this range. We do not store its alignment
-        // at runtime because the alignment always normalizes to 0.
+        // It is valid to align any range. In this case we do not store
+        // the alignment at runtime because it always normalizes to 0.
       } else {
         _alignment = chpl__mod(alignVal, _stride);
-        _aligned = true;
       }
     }
   }

--- a/test/types/range/align/rangeAlignTest.chpl
+++ b/test/types/range/align/rangeAlignTest.chpl
@@ -38,10 +38,10 @@ var r12 = ..10;
 writeln(r12.alignment);
 
 var r13 = .. align 1 by 2;
-writeln(r13.alignment);
+writeln(r13.aligned);
 
 var r14 = ..10 align 1 by 2;
-writeln(r14.alignment);
+writeln(r14.aligned);
 
 var r15 = 1.. by 2;
 writeln(r15.alignment);
@@ -50,7 +50,7 @@ var r16 = 1.. align 2 by 2;
 writeln(r16.alignment);
 
 var r17 = .. by 2;
-writeln(r17.alignment);
+writeln(r17.aligned);
 
 var r18 = .. by 2 align 2;
 writeln(r18.alignment);

--- a/test/types/range/align/rangeAlignTest.good
+++ b/test/types/range/align/rangeAlignTest.good
@@ -11,10 +11,10 @@
 0
 0
 0
-0
-0
+false
+false
 1
 1
-0
+false
 0
 1

--- a/test/types/range/enum/rangeCastsWithEnum.good
+++ b/test/types/range/enum/rangeCastsWithEnum.good
@@ -43,21 +43,6 @@ rangeCastsWithEnum.chpl:47: warning: Casts between ranges involving 'enum' indic
 rangeCastsWithEnum.chpl:55: warning: Casts between ranges involving 'enum' indices are currently unstable (see issue #22406); consider performing the conversion manually
   rangeCastsWithEnum.chpl:29: called as tryCast(r: range(size,both,one), type t = uint(64)) from function 'tryCasts'
   rangeCastsWithEnum.chpl:22: called as tryCasts(r: range(size,both,one))
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: In initializer:
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: warning: int->uint implicit conversion is unstable
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: note: add a cast :uint(64) to avoid this warning
-  $CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: called as range.init(type idxType = uint(64), param bounds = boundKind.both, param strides = strideKind.any, _low: uint(64), _high: uint(64), _stride: int(64), _alignment: uint(64), _aligned: bool, param normalizeAlignment = true)
-  within internal functions (use --print-callstack-on-error to see)
-  rangeCastsWithEnum.chpl:29: called as tryCast(r: range(size,both,one), type t = uint(64)) from function 'tryCasts'
-  rangeCastsWithEnum.chpl:22: called as tryCasts(r: range(size,both,one))
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: In function 'helpAlignLow':
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: warning: int->uint implicit conversion is unstable
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: note: add a cast :uint(64) to avoid this warning
-  $CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: called as helpAlignLow(l: uint(64), a: uint(64), s: int(64))
-  within internal functions (use --print-callstack-on-error to see)
-  rangeCastsWithEnum.chpl:56: called as printRange(r: range(uint(64),both,any)) from function 'tryCast'
-  rangeCastsWithEnum.chpl:29: called as tryCast(r: range(size,both,one), type t = uint(64)) from function 'tryCasts'
-  rangeCastsWithEnum.chpl:22: called as tryCasts(r: range(size,both,one))
 rangeCastsWithEnum.chpl:32: In function 'tryCast':
 rangeCastsWithEnum.chpl:47: warning: Casts between ranges involving 'enum' indices are currently unstable (see issue #22406); consider performing the conversion manually
 rangeCastsWithEnum.chpl:55: warning: Casts between ranges involving 'enum' indices are currently unstable (see issue #22406); consider performing the conversion manually
@@ -66,21 +51,6 @@ rangeCastsWithEnum.chpl:55: warning: Casts between ranges involving 'enum' indic
 rangeCastsWithEnum.chpl:32: In function 'tryCast':
 rangeCastsWithEnum.chpl:47: warning: Casts between ranges involving 'enum' indices are currently unstable (see issue #22406); consider performing the conversion manually
 rangeCastsWithEnum.chpl:55: warning: Casts between ranges involving 'enum' indices are currently unstable (see issue #22406); consider performing the conversion manually
-  rangeCastsWithEnum.chpl:29: called as tryCast(r: range(size,both,one), type t = uint(8)) from function 'tryCasts'
-  rangeCastsWithEnum.chpl:22: called as tryCasts(r: range(size,both,one))
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: In initializer:
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: warning: int->uint implicit conversion is unstable
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: note: add a cast :uint(8) to avoid this warning
-  $CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: called as range.init(type idxType = uint(8), param bounds = boundKind.both, param strides = strideKind.any, _low: uint(8), _high: uint(8), _stride: int(8), _alignment: uint(8), _aligned: bool, param normalizeAlignment = true)
-  within internal functions (use --print-callstack-on-error to see)
-  rangeCastsWithEnum.chpl:29: called as tryCast(r: range(size,both,one), type t = uint(8)) from function 'tryCasts'
-  rangeCastsWithEnum.chpl:22: called as tryCasts(r: range(size,both,one))
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: In function 'helpAlignLow':
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: warning: int->uint implicit conversion is unstable
-$CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: note: add a cast :uint(8) to avoid this warning
-  $CHPL_HOME/modules/internal/ChapelRange.chpl:nnnn: called as helpAlignLow(l: uint(8), a: uint(8), s: int(8))
-  within internal functions (use --print-callstack-on-error to see)
-  rangeCastsWithEnum.chpl:56: called as printRange(r: range(uint(8),both,any)) from function 'tryCast'
   rangeCastsWithEnum.chpl:29: called as tryCast(r: range(size,both,one), type t = uint(8)) from function 'tryCasts'
   rangeCastsWithEnum.chpl:22: called as tryCasts(r: range(size,both,one))
 rangeCastsWithEnum.chpl:32: In function 'tryCast':


### PR DESCRIPTION
This PR makes no user-facing changes. The key implementation changes are:

(1) Remove `range._aligned`.  An unaligned range is indicated by storing -1 in its field `range._alignment`.

(2) Switch the type of `range._alignment` from `chpl_integralIdxType`, formerly `intIdxType`, to `strType`. This allows this field to store -1 for a range with an unsigned idxType. Since the alignment is stored normalized as of #22225, the value of `range._alignment` will never overflow `strType`.

"While there" implementation changes: rename `hasParamAlignmentVal()` to `hasParamAlignmentField()` (this is not a user-facing function); slightly reorganize some code so it looks better; simplify some code where the "aligned" property does not need to be passed separately; change some casts between integer types. The latter reduced the number of unstable warnings generated upon stable range operations, ex. see the change to rangeCastsWithEnum.good.

Dev history 137bf7e3d5..5752d0b095

Testing: standard, --fast, gasnet paratests