### PR TITLE
Don't use -Wall -Werror for clang processing extern blocks

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2630,17 +2630,16 @@ static void helpComputeClangArgs(std::string& clangCC,
   // when compiling the code in Chapel 'extern' blocks will play well
   // with our backend.
   const char* clangRequiredWarningFlags[] = {
-    "-Wall",
-    "-Werror",
-    "-Wpointer-arith",
-    "-Wwrite-strings",
-    "-Wno-strict-aliasing",
-    "-Wmissing-declarations",
-    "-Wmissing-prototypes",
-    "-Wstrict-prototypes",
-    "-Wmissing-format-attribute",
+    "-Werror=pointer-arith",
+    "-Werror=write-strings",
+    "-Werror=missing-declarations",
+    "-Werror=missing-prototypes",
+    "-Werror=strict-prototypes",
+    "-Werror=missing-format-attribute",
     // clang can't tell which functions we use
     "-Wno-unused-function",
+    // Chapel C backend normally throws this
+    "-Wno-strict-aliasing",
     NULL};
 
   const char* clang_debug = "-g";


### PR DESCRIPTION
Follow-up to PR #20904.

We were throwing `-Wall -Werror` for the clang parsing / compilation of extern blocks. But, that is not necessary, since we can use e.g. `-Werror=write-strings` to get warnings-as-errors for the warnings that are important to report to keep extern block code functioning within Chapel.

- [ ] full local testing