### PR TITLE
Improve `--mllvm --help`

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1794,7 +1794,9 @@ void setupClang(GenInfo* info, std::string mainFile)
     }
 
     std::vector<const char*> Args;
-    Args.push_back("chpl-llvm-opts");
+    Args.push_back("chpl --mllvm"); // pretend this is the name of the program
+                                    // so it shows 'chpl --mllvm --help'
+                                    // if the option was not recognized
     for (auto & i : vec) {
       Args.push_back(i.c_str());
     }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -57,6 +57,7 @@
 
 #ifdef HAVE_LLVM
 #include "llvm/Config/llvm-config.h"
+#include "llvm/Support/CommandLine.h"
 #if HAVE_LLVM_VER >= 140
 #include "llvm/MC/TargetRegistry.h"
 #else
@@ -723,11 +724,21 @@ static void setLDFlags(const ArgumentDescription* desc, const char* arg) {
 static void setLLVMFlags(const ArgumentDescription* desc, const char* arg) {
   // Append arg to the end of llvmFlags.
 
+#ifdef HAVE_LLVM
   // add a space if there are already arguments here
   if( llvmFlags.length() > 0 )
     llvmFlags += ' ';
 
   llvmFlags += arg;
+
+  if (0 == strcmp(arg, "--help")) {
+    std::vector<const char*> Args = {"chpl --mllvm", "--help", nullptr};
+    llvm::cl::ParseCommandLineOptions(Args.size()-1, &Args[0]);
+  }
+#else
+  printf("Cannot use '--mllvm': this 'chpl' was built without LLVM support\n");
+  clean_exit(1);
+#endif
 }
 
 static void setLLVMRemarksFilters(const ArgumentDescription* desc, const char* arg) {

--- a/test/compflags/ferguson/mllvm-badarg.chpl
+++ b/test/compflags/ferguson/mllvm-badarg.chpl
@@ -1,0 +1,1 @@
+writeln("hello world");

--- a/test/compflags/ferguson/mllvm-badarg.compopts
+++ b/test/compflags/ferguson/mllvm-badarg.compopts
@@ -1,0 +1,1 @@
+--mllvm --whelp

--- a/test/compflags/ferguson/mllvm-badarg.good
+++ b/test/compflags/ferguson/mllvm-badarg.good
@@ -1,0 +1,2 @@
+chpl --mllvm: Unknown command line argument '--whelp'.  Try: 'chpl --mllvm --help'
+chpl --mllvm: Did you mean '--help'?

--- a/test/compflags/ferguson/mllvm-badarg.skipif
+++ b/test/compflags/ferguson/mllvm-badarg.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM==none

--- a/test/compflags/ferguson/mllvm-help.chpl
+++ b/test/compflags/ferguson/mllvm-help.chpl
@@ -1,0 +1,1 @@
+writeln("hello world");

--- a/test/compflags/ferguson/mllvm-help.compopts
+++ b/test/compflags/ferguson/mllvm-help.compopts
@@ -1,0 +1,1 @@
+--mllvm --help

--- a/test/compflags/ferguson/mllvm-help.good
+++ b/test/compflags/ferguson/mllvm-help.good
@@ -1,0 +1,1 @@
+USAGE: chpl --mllvm [options]

--- a/test/compflags/ferguson/mllvm-help.prediff
+++ b/test/compflags/ferguson/mllvm-help.prediff
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TEST=$1
+LOG=$2
+# PREDIFF: Script to execute before diff'ing output (arguments: <test
+#    executable>, <log>, <compiler executable>)
+
+cat $LOG | head -n 1 > $LOG.tmp
+mv $LOG.tmp $LOG

--- a/test/compflags/ferguson/mllvm-help.skipif
+++ b/test/compflags/ferguson/mllvm-help.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM==none


### PR DESCRIPTION
Resolves #22702

This PR is intended to resolve the confusing user experience when passing a wrong argument to `--mllvm` e.g. `chpl --mllvm --whoops`. Previously, it would refer to a fictitious command. Now, output related to such a wrong argument refers to `chpl --mllvm` and prints out a suggestion to try `chpl --mllvm --help`. Additionally, this PR arranges for `chpl --mllvm --help` to output the help information for the LLVM flags.

Reviewed by @riftEmber - thanks!

- [x] full local testing