### PR TITLE
Dyno: param-folding 'select' statements

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1135,6 +1135,7 @@ class AssociatedAction {
     NEW_INIT,
     REDUCE_SCAN,  // resolution of "generate" for a reduce/scan operation.
     INFER_TYPE,
+    COMPARE,      // == , e.g., for select-statements
   };
 
  private:

--- a/frontend/include/chpl/types/NothingType.h
+++ b/frontend/include/chpl/types/NothingType.h
@@ -50,6 +50,9 @@ class NothingType final : public Type {
   ~NothingType() = default;
 
   static const NothingType* get(Context* context);
+
+  virtual void stringify(std::ostream& ss,
+                         chpl::StringifyKind stringKind) const override;
 };
 
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2233,7 +2233,7 @@ bool Resolver::enter(const uast::Select* sel) {
     if (!scopeResolveOnly && allParamFalse) {
       // case will never be true, so do not resolve the statement
       continue;
-    } else {
+    } else if (when->numStmts() > 0) {
       // Otherwise, resolve the body.
       when->stmt(0)->traverse(*this);
     }
@@ -2252,7 +2252,10 @@ bool Resolver::enter(const uast::Select* sel) {
   // If one of the when-stmts is statically true, we should not resolve the
   // 'otherwise' statement, should one exist.
   if (foundParamTrue == false && otherwise != -1) {
-    sel->whenStmt(otherwise)->stmt(0)->traverse(*this);
+    auto other = sel->whenStmt(otherwise);
+    if (other->numStmts() > 0) {
+      other->stmt(0)->traverse(*this);
+    }
   }
 
   exitScope(sel);

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -469,6 +469,9 @@ struct Resolver {
   bool enter(const uast::Conditional* cond);
   void exit(const uast::Conditional* cond);
 
+  bool enter(const uast::Select* sel);
+  void exit(const uast::Select* sel);
+
   bool enter(const uast::Literal* literal);
   void exit(const uast::Literal* literal);
 

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -437,13 +437,20 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_STRING_SELECT:
 
     /* primitives that always return bool */
-    case PRIM_UNARY_LNOT:
     case PRIM_EQUAL:
+      if (ci.actual(0).type().isType() && ci.actual(1).type().isType()) {
+        bool isEqual = ci.actual(0).type().type() == ci.actual(1).type().type();
+        type = QualifiedType(QualifiedType::PARAM,
+                             BoolType::get(context, 0),
+                             BoolParam::get(context, isEqual));
+        break;
+      }
     case PRIM_NOTEQUAL:
     case PRIM_LESSOREQUAL:
     case PRIM_GREATEROREQUAL:
     case PRIM_LESS:
     case PRIM_GREATER:
+    case PRIM_UNARY_LNOT:
     case PRIM_TESTCID:
     case PRIM_LOGICAL_AND:
     case PRIM_LOGICAL_OR:

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -880,6 +880,8 @@ const char* AssociatedAction::kindToString(Action a) {
       return "reduce-scan";
     case INFER_TYPE:
       return "infer-type";
+    case COMPARE:
+      return "compare";
     // no default to get a warning if new Actions are added
   }
 

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -775,6 +775,12 @@ static bool helpComputeReturnType(Context* context,
     CHPL_ASSERT(fn);
 
     if (const AstNode* retType = fn->returnType()) {
+      // Cannot return the correct "return type" for something value-less like
+      // "param : int".
+      if (fn->returnIntent() == Function::ReturnIntent::PARAM) {
+        return false;
+      }
+
       // resolve the return type
       ResolutionResultByPostorderID resolutionById;
       auto visitor = Resolver::createForFunction(context, fn, poiScope, sig,

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -265,6 +265,7 @@ bool createsScope(asttags::AstTag tag) {
          || asttags::isCobegin(tag)
          || asttags::isConditional(tag)
          || asttags::isSelect(tag)
+         || asttags::isWhen(tag)
          || asttags::isTry(tag)
          || asttags::isCatch(tag)
          || asttags::isSync(tag);

--- a/frontend/lib/types/NothingType.cpp
+++ b/frontend/lib/types/NothingType.cpp
@@ -36,6 +36,11 @@ const NothingType* NothingType::get(Context* context) {
   return getNothingType(context).get();
 }
 
+void NothingType::stringify(std::ostream& ss,
+                            chpl::StringifyKind stringKind) const {
+  ss << "nothing";
+}
+
 
 } // end namespace types
 } // end namespace chpl


### PR DESCRIPTION
This PR implements param-folding for ``select`` statements in dyno. The ``Resolver`` will iterate through each ``when`` statement and resolve a ``==`` call between the ``select``'s expression and the case's expression. This ``==`` call will be added as an ``AssociatedAction`` of the kind ``COMPARE``, which is introduced in this PR. Chapel allows for the ``otherwise`` statement to appear anywhere in the ``select`` statement, but semantically resolves it last.

If a ``when`` statement's case comparisons all return as being param-false, then the ``Resolver`` will not attempt to resolve the body of that ``when`` statement. If any case comparison returns as param-true, then the ``Resolver`` will resolve the body of that ``when`` statement and will not resolve any of the remaining ``when`` statements (including ``otherwise``).

Return type inference is updated with similar logic.

A couple of minor changes:
- adds ``NothingType::stringify`` to print type as "nothing"
- implements "==" primitive between types
- defines ``When`` nodes as introducing scope (in accordance with the language specification)
- updates return type computation such that a ``param`` return intent must resolve the whole body

Testing:
- [x] test-dyno
- [x] full local paratest