### PR TITLE
Dyno: field type resolution using only type expression

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -287,6 +287,7 @@ Resolver::createForInitialFieldStmt(Context* context,
   ret.inCompositeType = compositeType;
   ret.defaultsPolicy = defaultsPolicy;
   ret.byPostorder.setupForSymbol(decl);
+  ret.fieldTypesOnly = true;
   return ret;
 }
 
@@ -305,6 +306,7 @@ Resolver::createForInstantiatedFieldStmt(Context* context,
   ret.substitutions = &compositeType->substitutions();
   ret.defaultsPolicy = defaultsPolicy;
   ret.byPostorder.setupForSymbol(decl);
+  ret.fieldTypesOnly = true;
   return ret;
 }
 
@@ -320,6 +322,7 @@ Resolver::createForInstantiatedSignatureFields(Context* context,
   ret.substitutions = &substitutions;
   ret.defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
   ret.byPostorder.setupForSymbol(decl);
+  ret.fieldTypesOnly = true;
   return ret;
 }
 
@@ -2629,7 +2632,26 @@ bool Resolver::enter(const NamedDecl* decl) {
 
   enterScope(decl);
 
-  return true;
+  // TODO: Initializers will need to check the compatibility of the type
+  // expression and initialization expression.
+  if (!scopeResolveOnly && fieldTypesOnly && decl == curStmt) {
+    auto field = decl->toVarLikeDecl();
+    if (field->typeExpression() != nullptr &&
+        field->storageKind() != Qualifier::TYPE &&
+        field->storageKind() != Qualifier::PARAM) {
+      field->typeExpression()->traverse(*this);
+      auto res = byPostorder.byAst(field->typeExpression());
+      auto g = getTypeGenericity(context, res.type().type());
+      if (g != Type::CONCRETE && field->initExpression() != nullptr) {
+        field->initExpression()->traverse(*this);
+      }
+      return false;
+    } else {
+      return true;
+    }
+  } else {
+    return true;
+  }
 }
 
 void Resolver::exit(const NamedDecl* decl) {

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -63,6 +63,7 @@ struct Resolver {
   bool signatureOnly = false;
   bool fieldOrFormalsComputed = false;
   bool scopeResolveOnly = false;
+  bool fieldTypesOnly = false;
   const uast::Block* fnBody = nullptr;
   std::set<ID> fieldOrFormals;
   std::set<ID> instantiatedFieldOrFormals;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2616,6 +2616,8 @@ convertClassTypeToNilable(Context* context, const Type* t) {
 static const Type* resolveFnCallSpecialType(Context* context,
                                             const AstNode* astForErr,
                                             const CallInfo& ci) {
+  // none of the special type function calls are methods; we can stop here.
+  if (ci.isMethodCall()) return nullptr;
 
   if (ci.name() == USTR("?")) {
     if (ci.numActuals() > 0) {


### PR DESCRIPTION
This PR resolves a bug in the dyno compiler where compilation could recurse through a field type's initialization expression, despite that field having a concrete type expression.

This PR adds a new field to ``Resolver`` named ``fieldTypesOnly``. This field is set in the cases where we are creating a ``Resolver`` for the purpose of resolving a type's fields. When this property is set, resolution of a ``NamedDecl`` will check if it is the field being resolved, and if so, will attempt to only use the field's type expression (if one is available). If the type expression is not a concrete type, then resolution will proceed to resolve the field's initialization expression.

This property does not apply to ``type`` or ``param`` fields since the initialization expression is necessary in those cases (if one exists).

A minor fix is included in this PR, in which we return from ``resolveFnCallSpecialType`` if the special call is trying to be resolved as a method call (which is not valid Chapel).

Future work involves updating the initializer implementation to take responsibility for checking the compatibility of field type expressions and initialization expressions (e.g. "var x : int = "hello";).

Testing:
- [x] test-dyno