### PR TITLE
Add a limitation about nested loops with the cpu-as-device mode

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -254,6 +254,12 @@ tests where access to GPUs may be limited. In this mode:
   ``CHPL_RT_NUM_GPUS_PER_LOCALE`` can be set to control how many GPU sublocales
   will be created per locale.
 
+* Inner loops in loop nests that consist of GPU-eligible loops will be reported
+  as kernel launch whereas in regular GPU modes, such loops will not be launched
+  as a kernel as the execution will already be on the GPU. This may cause in
+  increased kernel launches reported by the :mod:`GpuDiagnostics` utilities with
+  loop nests and multidimensional loops.
+
 .. warning::
 
   This mode should not be used for performance studies. Application correctness


### PR DESCRIPTION
@stonea noticed this issue while working on https://github.com/chapel-lang/chapel/pull/22674. I am hopeful that we can solve this soon. But probably not very soon that I wanted to add a bullet in our technote. https://github.com/Cray/chapel-private/issues/5064 is the internal tracker for this effort.