### PR TITLE
prediff scripts for revcomp futures

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.verify.prediff
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.verify.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i '' -r "s/MAI-CHE-CKS-[0-9]+/MAI-CHE-CKS-nnnn/g" $2
+sed -i '' -r "s/chpl version .*/chpl version mmmm/g" $2
+perl -pi -e 'chomp if eof' $2

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug.prediff
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i '' -r "s/OPT-COP-ION-[0-9]+/OPT-COP-ION-nnnn/g" $2
+sed -i '' -r "s/chpl version .*/chpl version mmmm/g" $2
+perl -pi -e 'chomp if eof' $2


### PR DESCRIPTION
Adds a prediff script to 
- studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref.verify
- studies/shootout/reverse-complement/bradc/revcomp-blc-copyPropBug

that removes version specific information from the output. This should correct some failures to match against `.bad` files.

Affected tests passing:
- [x] quickstart config (mac)
- [x] quickstart config (linux)
- [x] CHPL_COMM=gasnet (linux)