### PR TITLE
Fix issue preventing nightly cpu-as-device testing

### DIFF
--- a/test/gpu/native.skipif
+++ b/test/gpu/native.skipif
@@ -4,9 +4,10 @@ import os
 import shutil
 
 # Native GPU tests require nvcc/hipcc, llvm, and the gpu locale model
+missing_gpucc = False
 if os.getenv('CHPL_GPU') == 'amd':
   missing_gpucc = shutil.which("hipcc") is None
-else:
+elif os.getenv('CHPL_GPU') == 'nvidia':
   missing_gpucc = shutil.which("nvcc") is None
 
 no_llvm = os.getenv('CHPL_TARGET_COMPILER') != 'llvm'


### PR DESCRIPTION
Our native.skipif file was inadvertedly skipping the native/ tests even when `CHPL_GPU=cpu`. This commit fixes it.