### PR TITLE
Skip `CodepointSplittingError` deprecation test in asan config

### DIFF
--- a/test/deprecated/cpSplittingError.skipif
+++ b/test/deprecated/cpSplittingError.skipif
@@ -1,0 +1,1 @@
+CHPL_SANITIZE == address # https://github.com/chapel-lang/chapel/issues/22720


### PR DESCRIPTION
The deprecation test for `CodepointSplittingError` introduced in https://github.com/chapel-lang/chapel/pull/22678 is failing in the address sanitization config due to a potential bug summarized here: https://github.com/chapel-lang/chapel/issues/22720.

This PR updates the test to be skipped for `CHPL_SANITIZE=address` until the failure can be investigated more thoroughly.