### PR TITLE
Unstable-ize CHPL_* params in ChplConfig

### DIFF
--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -35,6 +35,7 @@ module ChplConfig {
   private use ChapelStandard;
 
   /* See :ref:`readme-chplenv.CHPL_HOME` for more information. */
+  @unstable("'ChplConfig.CHPL_HOME' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_HOME:string;
   CHPL_HOME = __primitive("get compiler variable", "CHPL_HOME");
 
@@ -47,112 +48,139 @@ module ChplConfig {
   }
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_PLATFORM` for more information. */
+  @unstable("'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_TARGET_PLATFORM:string;
   CHPL_TARGET_PLATFORM = __primitive("get compiler variable", "CHPL_TARGET_PLATFORM");
 
   /* See :ref:`readme-chplenv.CHPL_HOST_PLATFORM` for more information. */
+  @unstable("'ChplConfig.CHPL_HOST_PLATFORM' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_HOST_PLATFORM:string;
   CHPL_HOST_PLATFORM = __primitive("get compiler variable", "CHPL_HOST_PLATFORM");
 
   /* See :ref:`readme-chplenv.CHPL_HOST_ARCH` for more information. */
+  @unstable("'ChplConfig.CHPL_HOST_ARCH' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_HOST_ARCH:string;
   CHPL_HOST_ARCH = __primitive("get compiler variable", "CHPL_HOST_ARCH");
 
   /* See :ref:`readme-chplenv.CHPL_COMPILER` for more information. */
+  @unstable("'ChplConfig.CHPL_HOST_COMPILER' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_HOST_COMPILER:string;
   CHPL_HOST_COMPILER = __primitive("get compiler variable", "CHPL_HOST_COMPILER");
 
   /* See :ref:`readme-chplenv.CHPL_COMPILER` for more information. */
+  @unstable("'ChplConfig.CHPL_TARGET_COMPILER' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_TARGET_COMPILER:string;
   CHPL_TARGET_COMPILER = __primitive("get compiler variable", "CHPL_TARGET_COMPILER");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_ARCH` for more information. */
+  @unstable("'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_TARGET_ARCH:string;
   CHPL_TARGET_ARCH = __primitive("get compiler variable", "CHPL_TARGET_ARCH");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_CPU` for more information. */
+  @unstable("'ChplConfig.CHPL_TARGET_CPU' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_TARGET_CPU:string;
   CHPL_TARGET_CPU = __primitive("get compiler variable", "CHPL_TARGET_CPU");
 
   /* See :ref:`readme-chplenv.CHPL_LOCALE_MODEL` for more information. */
+  @unstable("'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_LOCALE_MODEL:string;
   CHPL_LOCALE_MODEL = __primitive("get compiler variable", "CHPL_LOCALE_MODEL");
 
   /* See :ref:`readme-chplenv.CHPL_COMM` for more information. */
+  @unstable("'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_COMM:string;
   CHPL_COMM = __primitive("get compiler variable", "CHPL_COMM");
 
   /* See :ref:`readme-launcher` for more information. */
+  @unstable("'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_COMM_SUBSTRATE:string;
   CHPL_COMM_SUBSTRATE = __primitive("get compiler variable", "CHPL_COMM_SUBSTRATE");
 
   /* See :ref:`readme-multilocale` for more information. */
+  @unstable("'ChplConfig.CHPL_GASNET_SEGMENT' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_GASNET_SEGMENT:string;
   CHPL_GASNET_SEGMENT = __primitive("get compiler variable", "CHPL_GASNET_SEGMENT");
 
   @chpldoc.nodoc
+  @unstable("'ChplConfig.CHPL_LIBFABRIC' is unstable and may be replaced with a different way to access this information in the future");
   /* See :ref:`readme-chplenv.CHPL_LIBFABRIC` for more information. */
   param CHPL_LIBFABRIC:string;
   CHPL_LIBFABRIC = __primitive("get compiler variable", "CHPL_LIBFABRIC");
 
   /* See :ref:`readme-chplenv.CHPL_TASKS` for more information. */
+  @unstable("'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_TASKS:string;
   CHPL_TASKS = __primitive("get compiler variable", "CHPL_TASKS");
 
   /* See :ref:`readme-chplenv.CHPL_LAUNCHER` for more information. */
+  @unstable("'ChplConfig.CHPL_LAUNCHER' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_LAUNCHER:string;
   CHPL_LAUNCHER = __primitive("get compiler variable", "CHPL_LAUNCHER");
 
   /* See :ref:`readme-chplenv.CHPL_TIMERS` for more information. */
+  @unstable("'ChplConfig.CHPL_TIMERS' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_TIMERS:string;
   CHPL_TIMERS = __primitive("get compiler variable", "CHPL_TIMERS");
 
   /* See :ref:`readme-chplenv.CHPL_UNWIND` for more information. */
+  @unstable("'ChplConfig.CHPL_UNWIND' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_UNWIND:string;
   CHPL_UNWIND = __primitive("get compiler variable", "CHPL_UNWIND");
 
   /* See :ref:`readme-chplenv.CHPL_MEM` for more information. */
+  @unstable("'ChplConfig.CHPL_MEM' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_MEM:string;
   CHPL_MEM = __primitive("get compiler variable", "CHPL_MEM");
 
   /* See :ref:`readme-chplenv.CHPL_MAKE` for more information. */
+  @unstable("'ChplConfig.CHPL_MAKE' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_MAKE:string;
   CHPL_MAKE = __primitive("get compiler variable", "CHPL_MAKE");
 
   /* See :ref:`readme-chplenv.CHPL_ATOMICS` for more information. */
+  @unstable("'ChplConfig.CHPL_ATOMICS' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_ATOMICS:string;
   CHPL_ATOMICS = __primitive("get compiler variable", "CHPL_ATOMICS");
 
   /* See :ref:`readme-atomics` for more information. */
+  @unstable("'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_NETWORK_ATOMICS:string;
   CHPL_NETWORK_ATOMICS = __primitive("get compiler variable", "CHPL_NETWORK_ATOMICS");
 
   /* See :ref:`readme-chplenv.CHPL_GMP` for more information. */
+  @unstable("'ChplConfig.CHPL_GMP' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_GMP:string;
   CHPL_GMP = __primitive("get compiler variable", "CHPL_GMP");
 
   /* See :ref:`readme-chplenv.CHPL_HWLOC` for more information. */
+  @unstable("'ChplConfig.CHPL_HWLOC' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_HWLOC:string;
   CHPL_HWLOC = __primitive("get compiler variable", "CHPL_HWLOC");
 
   @chpldoc.nodoc
+  @unstable("'ChplConfig.CHPL_JEMALLOC' is unstable and may be replaced with a different way to access this information in the future");
   /* See :ref:`readme-chplenv.CHPL_JEMALLOC` for more information. */
   param CHPL_JEMALLOC:string;
   CHPL_JEMALLOC = __primitive("get compiler variable", "CHPL_TARGET_JEMALLOC");
 
   /* See :ref:`readme-chplenv.CHPL_RE2` for more information. */
+  @unstable("'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_RE2:string;
   CHPL_RE2 = __primitive("get compiler variable", "CHPL_RE2");
 
   /* See :ref:`readme-chplenv.CHPL_LLVM` for more information. */
+  @unstable("'ChplConfig.CHPL_LLVM' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_LLVM:string;
   CHPL_LLVM = __primitive("get compiler variable", "CHPL_LLVM");
 
   @chpldoc.nodoc
+  @unstable("'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_GPU_MEM_STRATEGY:string;
   CHPL_GPU_MEM_STRATEGY = __primitive("get compiler variable", "CHPL_GPU_MEM_STRATEGY");
 
   @chpldoc.nodoc
+  @unstable("'ChplConfig.CHPL_GPU' is unstable and may be replaced with a different way to access this information in the future");
   param CHPL_GPU:string;
   CHPL_GPU = __primitive("get compiler variable", "CHPL_GPU");
 }

--- a/test/compflags/TestWarnUnstableSuppression.2.good
+++ b/test/compflags/TestWarnUnstableSuppression.2.good
@@ -4,8 +4,21 @@ $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/Atomics.chpl:nnnn: warning: 'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: In function 'supportsNativeSyncVar':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: warning: 'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:nnnn: In function '_allocateData':
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: In function 'localSpawn':
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: In function 'doSearchNoEnc':
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future

--- a/test/compflags/TestWarnUnstableSuppression.3.good
+++ b/test/compflags/TestWarnUnstableSuppression.3.good
@@ -5,6 +5,38 @@ $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unst
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: sparse domains are unstable, their behavior is likely to change in the future
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOME' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_ARCH' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_COMPILER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_COMPILER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_CPU' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GASNET_SEGMENT' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LIBFABRIC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LAUNCHER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TIMERS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_UNWIND' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_MEM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_MAKE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GMP' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HWLOC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_JEMALLOC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LLVM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/Regex.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/standard/Regex.chpl:nnnn: warning: 'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/packages/CopyAggregation.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/packages/CopyAggregation.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
@@ -16,6 +48,8 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'last':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
+$CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':

--- a/test/compflags/TestWarnUnstableSuppression.4.good
+++ b/test/compflags/TestWarnUnstableSuppression.4.good
@@ -6,8 +6,21 @@ $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is
 TestWarnUnstableSuppression.chpl:2: warning: chpl_unstableInternalSymbolForTesting is unstable
 TestWarnUnstableSuppression.chpl:3: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/Atomics.chpl:nnnn: warning: 'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: In function 'supportsNativeSyncVar':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: warning: 'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:nnnn: In function '_allocateData':
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: In function 'localSpawn':
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: In function 'doSearchNoEnc':
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future

--- a/test/compflags/TestWarnUnstableSuppression.5.good
+++ b/test/compflags/TestWarnUnstableSuppression.5.good
@@ -7,6 +7,38 @@ $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unst
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: sparse domains are unstable, their behavior is likely to change in the future
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOME' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_ARCH' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_COMPILER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_COMPILER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_CPU' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GASNET_SEGMENT' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LIBFABRIC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LAUNCHER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TIMERS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_UNWIND' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_MEM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_MAKE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GMP' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HWLOC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_JEMALLOC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LLVM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/Regex.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/standard/Regex.chpl:nnnn: warning: 'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/packages/CopyAggregation.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/packages/CopyAggregation.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
@@ -18,6 +50,8 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'last':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
+$CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':

--- a/test/compflags/TestWarnUnstableSuppression.6.good
+++ b/test/compflags/TestWarnUnstableSuppression.6.good
@@ -10,9 +10,54 @@ $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unst
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: sparse domains are unstable, their behavior is likely to change in the future
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/Atomics.chpl:nnnn: warning: 'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: In function 'supportsNativeSyncVar':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: warning: 'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:nnnn: In function '_allocateData':
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: In function 'localSpawn':
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOME' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_ARCH' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_COMPILER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_COMPILER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_CPU' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GASNET_SEGMENT' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LIBFABRIC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LAUNCHER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TIMERS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_UNWIND' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_MEM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_MAKE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GMP' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HWLOC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_JEMALLOC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LLVM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/Regex.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/standard/Regex.chpl:nnnn: warning: 'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/packages/CopyAggregation.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/packages/CopyAggregation.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
@@ -24,6 +69,8 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'last':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
+$CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':

--- a/test/compflags/TestWarnUnstableSuppression.7.good
+++ b/test/compflags/TestWarnUnstableSuppression.7.good
@@ -12,9 +12,54 @@ $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unst
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: sparse domains are unstable, their behavior is likely to change in the future
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/Atomics.chpl:nnnn: warning: 'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: In function 'supportsNativeSyncVar':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: warning: 'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:nnnn: In function '_allocateData':
+$CHPL_HOME/modules/internal/ChapelHashtable.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: In function 'localSpawn':
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOME' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_ARCH' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HOST_COMPILER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_COMPILER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_CPU' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GASNET_SEGMENT' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LIBFABRIC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LAUNCHER' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_TIMERS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_UNWIND' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_MEM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_MAKE' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GMP' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_HWLOC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_JEMALLOC' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_LLVM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/ChplConfig.chpl:nnnn: warning: 'ChplConfig.CHPL_GPU' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/standard/Regex.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/standard/Regex.chpl:nnnn: warning: 'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/packages/CopyAggregation.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
+$CHPL_HOME/modules/packages/CopyAggregation.chpl:nnnn: warning: 'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
@@ -26,6 +71,8 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'last':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
+$CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':


### PR DESCRIPTION
These configuration `param`s are made unstable to give us room to change how the information is accessed in the future.

Resolves https://github.com/Cray/chapel-private/issues/5018.

[reviewer info placeholder]

Testing:
- [x] local paratest
- [x] gasnet paratest