### PR TITLE
Add uses of the Math module to these two tests to avoid deprecation warnings

### DIFF
--- a/test/optimizations/sungeun/bulk_transfer/assignMultiloc.chpl
+++ b/test/optimizations/sungeun/bulk_transfer/assignMultiloc.chpl
@@ -18,7 +18,7 @@ config const printTiming = false;
 
 const shift = (123, 456, 789);
 
-use Random, Time;
+use Random, Time, Math;
 
 if numLocales < 3 then halt("numLocales must be >= 3");
 var declLocale = Locales(numLocales-1);

--- a/test/studies/hpcc/HPL/vass/bl.md.chpl
+++ b/test/studies/hpcc/HPL/vass/bl.md.chpl
@@ -12,7 +12,7 @@ use DimensionalDist2D;
 use ReplicatedDim;
 use BlockDim;
 //use BlockCycDim; //MBC //BC
-use Time, Random;
+use Time, Random, Math;
 
 config param reproducible = false;
 config var verbose = true;


### PR DESCRIPTION
divceilpos and divfloorpos will soon no longer be included by default, so these tests need a use of the Math module to continue working

Checked a fresh checkout of the tests