### PR TITLE
Fix broken tests for new cpu-as-device nightly test

### DIFF
--- a/test/gpu/native/noGpu/basicMem.prediff
+++ b/test/gpu/native/noGpu/basicMem.prediff
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 sed -i -e 's/0x.*/0xPREDIFFED/' $2
+sed -i -e '/<internal>/d' $2

--- a/test/gpu/native/studies/transpose/transpose.skipif
+++ b/test/gpu/native/studies/transpose/transpose.skipif
@@ -1,1 +1,4 @@
 CHPL_GPU_MEM_STRATEGY==array_on_device
+# This test makes direct calls to gpu primitives that we don't support with
+# cpu-as-device mode
+CHPL_GPU==cpu


### PR DESCRIPTION
We have a couple of failures in our new nightly test job for cpu-as-device for GPU support.

This PR modifies these tests so that they will no longer fail in this job.

transpose.chpl: is something we should be .skip'ifing for this job (I'll submit a followup PR to do that).

basicMem.chpl: It looks like we have some non-deterministic allocations in internal module code. This isn't really what the test is trying to lock down so it seems like we should just filter these messages out.