### PR TITLE
Warn for variables/fields declared with generic type without `?`

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1881,8 +1881,7 @@ AggregateType* AggregateType::getNewInstantiation(Symbol* sym, Type* symType, Ex
 
   instantiations.push_back(retval);
 
-  checkSurprisingGenericDecls(field, field->defPoint->exprType,
-                              /* isField */ true);
+  checkSurprisingGenericDecls(field, field->defPoint->exprType, this);
 
   return retval;
 }

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1888,7 +1888,8 @@ AggregateType* AggregateType::getNewInstantiation(Symbol* sym, Type* symType, Ex
 
   instantiations.push_back(retval);
 
-  checkSurprisingGenericDecls(field->defPoint, /* isField */ true);
+  checkSurprisingGenericDecls(field, field->defPoint->exprType,
+                              /* isField */ true);
 
   return retval;
 }

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -319,18 +319,11 @@ static bool isFieldTypeExprGeneric(Expr* typeExpr,
   }
 
   // Partial generic expressions with '?'
-  if (CallExpr* call = toCallExpr(typeExpr)) {
-    if (SymExpr* se = toSymExpr(call->baseExpr)) {
-      if (se->symbol()->type->symbol->hasFlag(FLAG_GENERIC)) {
-        for_actuals(actual, call) {
-          if (SymExpr* act = toSymExpr(actual)) {
-            if (act->symbol() == gUninstantiated) {
-              return true;
-            }
-          }
-        }
-      }
-    }
+  if (findSymExprFor(typeExpr, gUninstantiated)) {
+    // Note: this assumes that ? used in a nested call makes the type generic.
+    // That's not strictly true, but is close enough until
+    // we can use the dyno resolver to handle this in a more principled way.
+    return true;
   }
 
   if (UnresolvedSymExpr* urse = toUnresolvedSymExpr(typeExpr)) {

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -577,12 +577,14 @@ void update_symbols(BaseAST* ast, SymbolMap* map) {
         // BENHARSH TODO 2019-06-20: I think we need to do this because in
         // some cases the SymbolMap contains a mapping from the generic 'T' to
         // an instantiation of 'T'. Is that mapping necessary?
-        CallExpr* call = toCallExpr(sym_expr->parentExpr);
-        if (call != NULL && call->baseExpr == sym_expr) {
-          if (y->getValType()->symbol->hasFlag(FLAG_TUPLE) == false &&
-              y->getValType() != dtUnknown &&
-              sym_expr->symbol()->hasFlag(FLAG_TYPE_VARIABLE)) {
-            skip = true;
+        if (isTypeSymbol(sym_expr->parentSymbol)) {
+          CallExpr* call = toCallExpr(sym_expr->parentExpr);
+          if (call != NULL && call->baseExpr == sym_expr) {
+            if (y->getValType()->symbol->hasFlag(FLAG_TUPLE) == false &&
+                y->getValType() != dtUnknown &&
+                sym_expr->symbol()->hasFlag(FLAG_TYPE_VARIABLE)) {
+              skip = true;
+            }
           }
         }
 

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -391,7 +391,7 @@ void checkDuplicateDecorators(Type* decorator, Type* decorated, Expr* ctx);
 // emit a warning for
 //   var x: domain;
 // as a field or variable (it should be, var x: domain(?)).
-void checkSurprisingGenericDecls(DefExpr* def, bool isField);
+void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr, bool isField);
 
 // These enable resolution for functions that don't really match
 // according to the language definition in order to get more errors

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -391,7 +391,8 @@ void checkDuplicateDecorators(Type* decorator, Type* decorated, Expr* ctx);
 // emit a warning for
 //   var x: domain;
 // as a field or variable (it should be, var x: domain(?)).
-void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr, bool isField);
+void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
+                                 bool definitelyField);
 
 // These enable resolution for functions that don't really match
 // according to the language definition in order to get more errors

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -392,7 +392,7 @@ void checkDuplicateDecorators(Type* decorator, Type* decorated, Expr* ctx);
 //   var x: domain;
 // as a field or variable (it should be, var x: domain(?)).
 void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
-                                 bool definitelyField);
+                                 AggregateType* forFieldInHere);
 
 // These enable resolution for functions that don't really match
 // according to the language definition in order to get more errors

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13874,6 +13874,14 @@ void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
       if (sym->hasFlag(FLAG_FORMAL_TEMP))
         return;
 
+
+      // supress the warning for fields within owned/shared
+      // themselves (better to see the warning at uses of owned/shared
+      // that create generic owned/shared).
+      if (TypeSymbol* ts = toTypeSymbol(sym->defPoint->parentSymbol))
+        if (ts->hasFlag(FLAG_MANAGED_POINTER))
+          return;
+
       bool hasQuestionArg = sym->hasFlag(FLAG_MARKED_GENERIC);
 
       // Inspect the AST to decide if there was a question mark arg

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13862,6 +13862,11 @@ void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
         return;
       }
 
+      // suppress the warning for formal temps e.g.
+      // proc f(out arg: R) for a generic record R
+      if (sym->hasFlag(FLAG_FORMAL_TEMP))
+        return;
+
       bool hasQuestionArg = sym->hasFlag(FLAG_MARKED_GENERIC);
 
       // Inspect the AST to decide if there was a question mark arg

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13791,6 +13791,7 @@ static bool isBuiltinGenericType(Type* t) {
 }
 
 std::set<Symbol*> gAlreadyWarnedSurprisingGenericSyms;
+std::set<Symbol*> gAlreadyWarnedSurprisingGenericManagementSyms;
 
 void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
                                  AggregateType* forFieldInHere) {
@@ -13844,6 +13845,12 @@ void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
       if (isClassLikeOrManaged(declType)) {
         auto dec = classTypeDecorator(declType);
         if (isField && isDecoratorUnknownManagement(dec)) {
+          auto pair = gAlreadyWarnedSurprisingGenericManagementSyms.insert(sym);
+          if (!pair.second) {
+            // don't warn twice for the same field
+            return;
+          }
+
           USR_WARN(sym, "field is declared with generic memory management");
           USR_PRINT("consider adding 'owned', 'shared', or 'borrowed'");
           USR_PRINT("if generic memory management is desired, "

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13861,12 +13861,12 @@ void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
         return;
       }
 
-      bool hasQuestionArg = false;
+      bool hasQuestionArg = sym->hasFlag(FLAG_MARKED_GENERIC);
 
-      // If it is a variable, the type would end up in a type-expr-temp,
-      // so find our way through that, checking for question mark args
-      // such as 'R(?)', which will prevent the warning.
-      while (true) {
+      // Inspect the AST to decide if there was a question mark arg
+      // (such as 'R(?)'). This is particularly important for variable
+      // declarations with the current AST.
+      while (hasQuestionArg == false) {
         if (SymExpr* se = toSymExpr(typeExpr)) {
           if (se->symbol()->hasFlag(FLAG_MARKED_GENERIC)) {
             hasQuestionArg = true;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13786,7 +13786,8 @@ static bool isBuiltinGenericType(Type* t) {
          t == dtNumeric || t == dtIntegral ||
          t == dtIteratorRecord || t == dtIteratorClass ||
          t == dtAnyPOD ||
-         t == dtOwned || t == dtShared;
+         t == dtOwned || t == dtShared ||
+         t == dtAnyRecord;
 }
 
 std::set<Symbol*> gAlreadyWarnedSurprisingGenericSyms;

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -126,6 +126,25 @@ Expr* postFold(Expr* expr) {
 
         if (doFoldAway) {
           retval = se->copy();
+          // if call is RHS of a PRIM_MOVE setting a temporary,
+          // record existence of ? argument by setting FLAG_MARKED_GENERIC.
+          if (CallExpr* parentCall = toCallExpr(call->parentExpr)) {
+            if (parentCall->isPrimitive(PRIM_MOVE)) {
+              if (SymExpr* lhsSe = toSymExpr(parentCall->get(1))) {
+                bool hasQuestionArg = false;
+                for_actuals(actual, call) {
+                  if (SymExpr* act = toSymExpr(actual)) {
+                    if (act->symbol() == gUninstantiated) {
+                      hasQuestionArg = true;
+                    }
+                  }
+                }
+                if (hasQuestionArg && lhsSe->symbol()->hasFlag(FLAG_TEMP)) {
+                  lhsSe->symbol()->addFlag(FLAG_MARKED_GENERIC);
+                }
+              }
+            }
+          }
           call->replace(retval);
         }
       }

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -139,6 +139,8 @@ Expr* postFold(Expr* expr) {
                     }
                   }
                 }
+                // TODO: Is this still necessary? The normalizer probably
+                // covers this case now.
                 if (hasQuestionArg && lhsSe->symbol()->hasFlag(FLAG_TEMP)) {
                   lhsSe->symbol()->addFlag(FLAG_MARKED_GENERIC);
                 }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -204,6 +204,8 @@ static FnSymbol* getInstantiatedFunction(FnSymbol* pfn,
 
   if (_thisAt->isGeneric() == true) {
     subs.put(_this, ct->symbol);
+  } else {
+    INT_ASSERT(!_thisAt->symbol->hasFlag(FLAG_GENERIC));
   }
 
   for (int i = 3; i <= cfn->numFormals(); i++) {

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -626,7 +626,7 @@ module ChapelDistribution {
 
   record SparseIndexBuffer {
     param rank: int;
-    var obj: borrowed BaseSparseDom;
+    var obj: borrowed BaseSparseDom(?);
 
     type idxType = if rank==1 then int else rank*int;
     var bufDom = domain(1);

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -36,7 +36,7 @@ module DefaultAssociative {
 
   // helps to move around array elements when rehashing the domain
   class DefaultAssociativeDomRehashHelper : chpl__rehashHelpers {
-    var dom: unmanaged DefaultAssociativeDom;
+    var dom: unmanaged DefaultAssociativeDom(?);
     override proc startRehash(newSize: int) {
       for arr in dom._arrs {
         arr._startRehash(newSize);

--- a/modules/packages/Channel.chpl
+++ b/modules/packages/Channel.chpl
@@ -276,8 +276,8 @@ module Channel {
     var recvIdx = 0;
     var count = 0;
     var closed = false;
-    var sendWaiters : owned WaiterQueue;
-    var recvWaiters : owned WaiterQueue;
+    var sendWaiters : owned WaiterQueue(eltType);
+    var recvWaiters : owned WaiterQueue(eltType);
     var lock$ = new _LockWrapper();
 
     proc init(type elt, size = 0) {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -273,7 +273,7 @@ defaultComparator = new DefaultComparator();
    default sort order.
 
  */
-const reverseComparator: ReverseComparator;
+const reverseComparator: ReverseComparator(DefaultComparator);
 reverseComparator = new ReverseComparator();
 
 /* Private methods */

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -104,8 +104,8 @@ module SortedMap {
 
     /* The underlying implementation */
     @chpldoc.nodoc
-    var _set: sortedSet;
-
+    var _set: sortedSet(_eltType, parSafe=false,
+                        _keyComparator(comparator.type));
 
     //TODO: Maybe we should use the lock from the underlying implementation
     @chpldoc.nodoc

--- a/test/classes/bradc/paramInClass/weirdParamInit3.chpl
+++ b/test/classes/bradc/paramInClass/weirdParamInit3.chpl
@@ -4,7 +4,7 @@ class C {
 
 class D {
   var cc = new owned C(2);
-  var c: borrowed C = cc.borrow();
+  var c: borrowed C(?) = cc.borrow();
   param y: int = c.x;
 }
 

--- a/test/classes/bradc/paramInClass/weirdParamInit3a.chpl
+++ b/test/classes/bradc/paramInClass/weirdParamInit3a.chpl
@@ -3,7 +3,7 @@ class C {
 }
 
 class D {
-  var c: unmanaged C = new unmanaged C(2);
+  var c: unmanaged C(?) = new unmanaged C(2);
   param y: int = c.x;
 }
 

--- a/test/classes/bradc/paramInClass/weirdParamInit4.chpl
+++ b/test/classes/bradc/paramInClass/weirdParamInit4.chpl
@@ -3,7 +3,7 @@ class C {
 }
 
 class D {
-  var c: borrowed C;
+  var c: borrowed C(?);
   param y: int = c.x;
 }
 

--- a/test/classes/delete-free/undecorated-generic/generic-management-field-multiple.good
+++ b/test/classes/delete-free/undecorated-generic/generic-management-field-multiple.good
@@ -1,15 +1,6 @@
 generic-management-field-multiple.chpl:10: warning: field is declared with generic memory management
 note: consider adding 'owned', 'shared', or 'borrowed'
 note: if generic memory management is desired, use a 'type' field to store the class type
-generic-management-field-multiple.chpl:10: warning: field is declared with generic memory management
-note: consider adding 'owned', 'shared', or 'borrowed'
-note: if generic memory management is desired, use a 'type' field to store the class type
-generic-management-field-multiple.chpl:10: warning: field is declared with generic memory management
-note: consider adding 'owned', 'shared', or 'borrowed'
-note: if generic memory management is desired, use a 'type' field to store the class type
-generic-management-field-multiple.chpl:10: warning: field is declared with generic memory management
-note: consider adding 'owned', 'shared', or 'borrowed'
-note: if generic memory management is desired, use a 'type' field to store the class type
 {x = 1}
 (f = {x = 1})
 {x = 2}

--- a/test/classes/ferguson/delete-free/unmanaged-generic.chpl
+++ b/test/classes/ferguson/delete-free/unmanaged-generic.chpl
@@ -8,7 +8,7 @@ proc f(arg: unmanaged C) {
   writeln(arg.type:string, " ", arg);
 }
 
-var myC: unmanaged C = new unmanaged C(int, 1);
+var myC: unmanaged C(?) = new unmanaged C(int, 1);
 writeln(myC.type:string, " ", myC);
 f(myC);
 delete myC;

--- a/test/classes/ferguson/generic-field/generic-field-default-init.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-default-init.chpl
@@ -3,7 +3,7 @@ record GenericRecord {
 }
 
 class GenericClass {
-  var f:GenericRecord;
+  var f:GenericRecord(?);
 }
 
 proc test() {

--- a/test/classes/ferguson/generic-field/generic-field-default-init.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-default-init.chpl
@@ -10,7 +10,7 @@ proc test() {
   var ownX = new owned GenericClass(new GenericRecord(1));
   var x = ownX.borrow();
   var ownY = new owned GenericClass(new GenericRecord(1));
-  var y:borrowed GenericClass = ownY.borrow();
+  var y:borrowed GenericClass(?) = ownY.borrow();
   var ownZ = new owned GenericClass(new GenericRecord(1));
   var z:borrowed GenericClass(GenericRecord(int)) = ownZ.borrow();
 

--- a/test/classes/ferguson/generic-field/generic-field-integral.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-integral.chpl
@@ -10,7 +10,7 @@ proc test() {
   var ownX = new owned GenericClass(1);
   var x = ownX.borrow();
   var ownY = new owned GenericClass(2);
-  var y:borrowed GenericClass = ownY.borrow();
+  var y:borrowed GenericClass(?) = ownY.borrow();
   var ownZ = new owned GenericClass(2);
   var z:borrowed GenericClass(int) = ownZ.borrow();
 

--- a/test/classes/ferguson/generic-field/generic-field-new-owned.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-new-owned.chpl
@@ -3,7 +3,7 @@ record GenericRecord {
 }
 
 class GenericClass {
-  var f:GenericRecord;
+  var f:GenericRecord(?);
   proc init(arg:GenericRecord) {
     this.f = arg;
   }

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited.chpl
@@ -3,7 +3,7 @@ record GenericRecord {
 }
 
 record Wrapper {
-  var f:GenericRecord;
+  var f:GenericRecord(?);
 }
 
 proc test1() {

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited3.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited3.chpl
@@ -3,7 +3,7 @@ record GenericRecord {
 }
 
 record Wrapper {
-  var f:GenericRecord;
+  var f:GenericRecord(?);
   proc init(f : GenericRecord) {
     this.f = f;
   }

--- a/test/classes/ferguson/generic-field/generic-field-record.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-record.chpl
@@ -3,7 +3,7 @@ record GenericRecord {
 }
 
 record Wrapper {
-  var f:GenericRecord;
+  var f:GenericRecord(?);
   proc init(arg:GenericRecord) {
     this.f = arg;
   }

--- a/test/classes/ferguson/generic-field/generic-field-record.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-record.chpl
@@ -11,7 +11,7 @@ record Wrapper {
 
 proc test1() {
   var x = new Wrapper(new GenericRecord(1));
-  var y:Wrapper = new Wrapper(new GenericRecord(1));
+  var y:Wrapper(?) = new Wrapper(new GenericRecord(1));
   var z:Wrapper(GenericRecord(int)) = new Wrapper(new GenericRecord(1));
 
   writeln(x.type:string, " ", x);

--- a/test/classes/ferguson/generic-field/generic-field-unmanaged-borrowed.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-unmanaged-borrowed.chpl
@@ -27,7 +27,7 @@ proc test1a() {
   var ownX = new owned GenericClassUnmanaged(a);
   var x = ownX.borrow();
   var ownY = new owned GenericClassUnmanaged(b);
-  var y:borrowed GenericClassUnmanaged = ownY.borrow();
+  var y:borrowed GenericClassUnmanaged(?) = ownY.borrow();
   var ownZ = new owned GenericClassUnmanaged(c);
   var z:borrowed GenericClassUnmanaged(unmanaged ClassA) = ownZ.borrow();
 
@@ -48,7 +48,7 @@ proc test1b() {
   var c = new unmanaged ClassB(3);
   var x = new owned GenericClassUnmanaged(a);
   var myOwnedY = new owned GenericClassUnmanaged(b);
-  var y:borrowed GenericClassUnmanaged = myOwnedY;
+  var y:borrowed GenericClassUnmanaged(?) = myOwnedY;
   var myOwnedZ = new owned GenericClassUnmanaged(c);
   var z:borrowed GenericClassUnmanaged(unmanaged ClassB) = myOwnedZ;
 
@@ -73,7 +73,7 @@ proc test2a() {
   var c = ownC.borrow();
   var x = new unmanaged GenericClassBorrowed(a);
   var ownY = new owned GenericClassBorrowed(b);
-  var y:borrowed GenericClassBorrowed = ownY.borrow();
+  var y:borrowed GenericClassBorrowed(?) = ownY.borrow();
   var ownZ = new owned GenericClassBorrowed(c);
   var z:borrowed GenericClassBorrowed(borrowed ClassA) = ownZ.borrow();
 
@@ -97,7 +97,7 @@ proc test2b() {
   var ownX = new owned GenericClassBorrowed(a);
   var x = ownX.borrow();
   var myOwnedY = new owned GenericClassBorrowed(b);
-  var y:borrowed GenericClassBorrowed = myOwnedY;
+  var y:borrowed GenericClassBorrowed(?) = myOwnedY;
   var myOwnedZ = new owned GenericClassBorrowed(c);
   var z:borrowed GenericClassBorrowed(borrowed ClassB) = myOwnedZ;
 

--- a/test/classes/ferguson/generic-field/generic-field.chpl
+++ b/test/classes/ferguson/generic-field/generic-field.chpl
@@ -3,7 +3,7 @@ record GenericRecord {
 }
 
 class GenericClass {
-  var f:GenericRecord;
+  var f:GenericRecord(?);
   proc init(arg:GenericRecord) {
     this.f = arg;
   }

--- a/test/classes/ferguson/generic-field/generic-field.chpl
+++ b/test/classes/ferguson/generic-field/generic-field.chpl
@@ -14,7 +14,7 @@ proc test() {
   var ownX = new owned GenericClass(new GenericRecord(1));
   var x = ownX.borrow();
   var ownY = new owned GenericClass(new GenericRecord(1));
-  var y:borrowed GenericClass = ownY.borrow();
+  var y:borrowed GenericClass(?) = ownY.borrow();
   var ownZ = new owned GenericClass(new GenericRecord(1));
   var z:borrowed GenericClass(GenericRecord(int)) = ownZ.borrow();
 

--- a/test/classes/ferguson/recursive/waiter-bug.good
+++ b/test/classes/ferguson/recursive/waiter-bug.good
@@ -1,7 +1,7 @@
-waiter-bug.chpl:8: warning: please use '?' when declaring a field with generic type
-waiter-bug.chpl:8: note: for example with 'Waiter(?)'
-waiter-bug.chpl:8: warning: please use '?' when declaring a field with generic type
-waiter-bug.chpl:8: note: for example with 'Waiter(?)'
+waiter-bug.chpl:5: warning: please use '?' when declaring a field with generic type
+waiter-bug.chpl:5: note: for example with 'Waiter(?)'
+waiter-bug.chpl:6: warning: please use '?' when declaring a field with generic type
+waiter-bug.chpl:6: note: for example with 'Waiter(?)'
 waiter-bug.chpl:8: In initializer:
 waiter-bug.chpl:8: error: Cannot default-initialize a variable with generic type
 waiter-bug.chpl:8: note: 'prev' has generic type 'unmanaged Waiter?'

--- a/test/classes/ferguson/recursive/waiter-bug.good
+++ b/test/classes/ferguson/recursive/waiter-bug.good
@@ -1,3 +1,7 @@
+waiter-bug.chpl:8: warning: please use '?' when declaring a field with generic type
+waiter-bug.chpl:8: note: for example with 'Waiter(?)'
+waiter-bug.chpl:8: warning: please use '?' when declaring a field with generic type
+waiter-bug.chpl:8: note: for example with 'Waiter(?)'
 waiter-bug.chpl:8: In initializer:
 waiter-bug.chpl:8: error: Cannot default-initialize a variable with generic type
 waiter-bug.chpl:8: note: 'prev' has generic type 'unmanaged Waiter?'

--- a/test/classes/generic/varOverBadGeneric.chpl
+++ b/test/classes/generic/varOverBadGeneric.chpl
@@ -3,6 +3,6 @@ class C {
   var x: t;
 }
 
-var myC: borrowed C;
+var myC: borrowed C(?);
 myC = (new owned C()).borrow();
 writeln(myC);

--- a/test/classes/generic/varOverGeneric.chpl
+++ b/test/classes/generic/varOverGeneric.chpl
@@ -4,5 +4,5 @@ class C {
 }
 
 var ownC = new owned C(int, 1);
-var myC: borrowed C = ownC.borrow();
+var myC: borrowed C(?) = ownC.borrow();
 writeln(myC);

--- a/test/classes/initializers/initequals/changing-param-field.chpl
+++ b/test/classes/initializers/initequals/changing-param-field.chpl
@@ -49,7 +49,7 @@ proc main() {
   var c = start; // inferred type
   writeln(c.type:string, " ", c);
   
-  var d:R = start; // specified generic type
+  var d:R(?) = start; // specified generic type
   writeln(d.type:string, " ", d);
 
   var e:R(true, ?) = start; // specified partial type

--- a/test/classes/jade/error-messages/generic-field-nil.good
+++ b/test/classes/jade/error-messages/generic-field-nil.good
@@ -1,4 +1,6 @@
 generic-field-nil.chpl:n: warning: field is declared with generic memory management
 note: consider adding 'owned', 'shared', or 'borrowed'
 note: if generic memory management is desired, use a 'type' field to store the class type
+generic-field-nil.chpl:n: warning: please use '?' when declaring a field with generic type
+generic-field-nil.chpl:n: note: for example with 'A(?)'
 generic-field-nil.chpl:n: error: could not coerce a value of type 'nil' to type '_formal_type'

--- a/test/classes/jade/owned/assign-op.chpl
+++ b/test/classes/jade/owned/assign-op.chpl
@@ -3,7 +3,7 @@ class A {
 }
 
 {
-  var z: owned A? = new A(7);
+  var z: owned A(?)? = new A(7);
   var x: owned A(?)?;
   x = new A(8);
   x = z;

--- a/test/classes/jade/owned/assign-op.chpl
+++ b/test/classes/jade/owned/assign-op.chpl
@@ -4,7 +4,7 @@ class A {
 
 {
   var z: owned A? = new A(7);
-  var x: owned A?;
+  var x: owned A(?)?;
   x = new A(8);
   x = z;
   writeln(x!.x);

--- a/test/classes/jade/shared/assign-op.chpl
+++ b/test/classes/jade/shared/assign-op.chpl
@@ -3,8 +3,8 @@ class A {
 }
 
 {
-  var z: shared A? = new shared A(7);
-  var x: shared A?;
+  var z: shared A(?)? = new shared A(7);
+  var x: shared A(?)?;
   x = new shared A(8);
   x = z;
   writeln(z!.x);

--- a/test/classes/nilability/cycle-generic.bad
+++ b/test/classes/nilability/cycle-generic.bad
@@ -1,5 +1,7 @@
 cycle-generic.chpl:2: warning: field is declared with generic memory management
 note: consider adding 'owned', 'shared', or 'borrowed'
 note: if generic memory management is desired, use a 'type' field to store the class type
+cycle-generic.chpl:2: warning: please use '?' when declaring a field with generic type
+cycle-generic.chpl:2: note: for example with 'Node(?)'
 cycle-generic.chpl:1: In module 'cycle':
 cycle-generic.chpl:3: error: initialization requires an argument for next

--- a/test/classes/nilability/cycle-generic.good
+++ b/test/classes/nilability/cycle-generic.good
@@ -1,7 +1,1 @@
-cycle-generic.chpl:2: warning: field is declared with generic memory management
-note: consider adding 'owned', 'shared', or 'borrowed'
-note: if generic memory management is desired, use a 'type' field to store the class type
-cycle-generic.chpl:2: warning: please use '?' when declaring a field with generic type
-cycle-generic.chpl:2: note: for example with 'Node(?)'
-cycle-generic.chpl:1: In module 'cycle':
-cycle-generic.chpl:3: error: initialization requires an argument for next
+cycle-generic.chpl:2 error: instantiating generic type without type argument

--- a/test/classes/nilability/cycle-generic.good
+++ b/test/classes/nilability/cycle-generic.good
@@ -1,1 +1,7 @@
-cycle-generic.chpl:2 error: instantiating generic type without type argument
+cycle-generic.chpl:2: warning: field is declared with generic memory management
+note: consider adding 'owned', 'shared', or 'borrowed'
+note: if generic memory management is desired, use a 'type' field to store the class type
+cycle-generic.chpl:2: warning: please use '?' when declaring a field with generic type
+cycle-generic.chpl:2: note: for example with 'Node(?)'
+cycle-generic.chpl:1: In module 'cycle':
+cycle-generic.chpl:3: error: initialization requires an argument for next

--- a/test/deprecated-keyword/handleField.chpl
+++ b/test/deprecated-keyword/handleField.chpl
@@ -139,7 +139,7 @@ proc main() {
   writeln(r3.oldName); // Should warn, but show the same value
 
   // Check various declarations of a class with the new field present
-  var c4: ReplaceType = new ReplaceType(uint);
+  var c4: ReplaceType(?) = new ReplaceType(uint);
   var c5: ReplaceType(int) = new ReplaceType(int);
   // Check direct references
   writeln(c4.newName: string);
@@ -148,7 +148,7 @@ proc main() {
   writeln(c5.oldName: string); // Should warn, but show the same value
 
   // Check various declarations of a record with the new field present
-  var r4: ReplaceType2 = new ReplaceType2(uint);
+  var r4: ReplaceType2(?) = new ReplaceType2(uint);
   var r5 = new ReplaceType2(int);
   var r6: ReplaceType2(bool);
   // Check direct references
@@ -160,7 +160,7 @@ proc main() {
   writeln(r6.oldName: string); // Should warn, but show the same value
 
   // Check various declarations of a class with the new field present
-  var c7: ReplaceParam = new ReplaceParam(4);
+  var c7: ReplaceParam(?) = new ReplaceParam(4);
   var c8: ReplaceParam(2) = new ReplaceParam(2);
   // Check direct references
   writeln(c7.newName);
@@ -169,7 +169,7 @@ proc main() {
   writeln(c8.oldName); // Should warn, but show the same value
 
   // Check various declarations of a record with the new field present
-  var r7: ReplaceParam2 = new ReplaceParam2(4);
+  var r7: ReplaceParam2(?) = new ReplaceParam2(4);
   var r8 = new ReplaceParam2(2);
   var r9: ReplaceParam2(1);
   // Check direct references
@@ -202,7 +202,7 @@ proc main() {
   writeln(r12.oldName); // Should warn, but show the same value
 
   // Check various declarations of a class with the new field present
-  var c13: ReplaceVarGeneric = new ReplaceVarGeneric(10);
+  var c13: ReplaceVarGeneric(?) = new ReplaceVarGeneric(10);
   var c14 = new ReplaceVarGeneric(0);
   // Check direct references
   writeln(c13.newName);
@@ -217,7 +217,7 @@ proc main() {
   writeln(c14.oldName); // Should warn, but show the same value
 
   // Check various declarations of a record with the new field present
-  var r13: ReplaceVarGeneric2 = new ReplaceVarGeneric2(10);
+  var r13: ReplaceVarGeneric2(?) = new ReplaceVarGeneric2(10);
   var r14 = new ReplaceVarGeneric2(0);
   var r15: ReplaceVarGeneric2(int);
   // Check direct references
@@ -233,7 +233,7 @@ proc main() {
   writeln(r15.oldName); // Should warn, but show the same value
 
   // Check various declarations of a class with the new field present
-  var c16: ReplaceConstGeneric = new ReplaceConstGeneric(3);
+  var c16: ReplaceConstGeneric(?) = new ReplaceConstGeneric(3);
   var c17 = new ReplaceConstGeneric(17);
   // Check direct references
   writeln(c16.newName);
@@ -242,7 +242,7 @@ proc main() {
   writeln(c17.oldName); // Should warn, but show the same value
 
   // Check various declarations of a record with the new field present
-  var r16: ReplaceConstGeneric2 = new ReplaceConstGeneric2(3);
+  var r16: ReplaceConstGeneric2(?) = new ReplaceConstGeneric2(3);
   var r17 = new ReplaceConstGeneric2(17);
   var r18: ReplaceConstGeneric2(int);
   // Check direct references

--- a/test/deprecated/classes/owned-create-clear-retain-release.chpl
+++ b/test/deprecated/classes/owned-create-clear-retain-release.chpl
@@ -20,7 +20,7 @@ class A {
 
 {
   var a = new unmanaged A(7);
-  var o: owned A? = new A(0);
+  var o: owned A(?)? = new A(0);
   o.retain(a);
 }
 

--- a/test/domains/compilerErrors/initDomainWithNonDomain.chpl
+++ b/test/domains/compilerErrors/initDomainWithNonDomain.chpl
@@ -1,7 +1,7 @@
 config param version = 1;
 config const N = 10;
 
-var aDom: domain = if version == 1 then 5.67 else 0..#N;
+var aDom: domain(?) = if version == 1 then 5.67 else 0..#N;
 writeln(aDom, ": ", aDom.type:string);
 aDom = {0..#2*N};
 writeln(aDom, ": ", aDom.type:string);

--- a/test/functions/generic/genericChannelInInit2.good
+++ b/test/functions/generic/genericChannelInInit2.good
@@ -1,3 +1,5 @@
+genericChannelInInit2.chpl:7: warning: please use '?' when declaring a field with generic type
+genericChannelInInit2.chpl:7: note: for example with 'fileWriter(?)'
 genericChannelInInit2.chpl:9: In initializer:
 genericChannelInInit2.chpl:9: error: Cannot default-initialize a variable with generic type
 genericChannelInInit2.chpl:9: note: 'C_chnl' has generic type 'fileWriter'

--- a/test/functions/intents/out/out-generic-type-set-assign.chpl
+++ b/test/functions/intents/out/out-generic-type-set-assign.chpl
@@ -8,7 +8,7 @@ proc outFn(input, out output: R) {
 }
 
 proc test1() {
-  var x: R; // generic type!
+  var x: R(?); // generic type!
   outFn(1, x); // sets type of x! 
   writeln("x has type ", x.type:string, " and value ", x);
 }

--- a/test/functions/intents/out/out-generic-type-set-out.chpl
+++ b/test/functions/intents/out/out-generic-type-set-out.chpl
@@ -13,7 +13,7 @@ proc outFn(input, out output: R) {
 }
 
 proc test1() {
-  var x: R; // generic type!
+  var x: R(?); // generic type!
   outFn(1, x); // sets type of x! 
   writeln("x has type ", x.type:string, " and value ", x);
 }

--- a/test/library/standard/List/initEquals/list-init-eq-many.chpl
+++ b/test/library/standard/List/initEquals/list-init-eq-many.chpl
@@ -34,7 +34,7 @@ proc initCopyFromList() {
   x.pushBack(1); x.pushBack(2);
   writeln("x:", x.type:string, " = ", x);
 
-  var a: list = x;
+  var a: list(?) = x;
   writeln("a:", a.type:string, " = ", a);
   var b: list(parSafe=false, ?) = x;
   writeln("b:", b.type:string, " = ", b);
@@ -45,7 +45,7 @@ proc initCopyFromList() {
   y.pushBack(1); y.pushBack(2);
   writeln("y:", y.type:string, " = ", y);
 
-  var d: list = y;
+  var d: list(?) = y;
   writeln("d:", d.type:string, " = ", d);
   var e: list(parSafe=false, ?) = y;
   writeln("e:", e.type:string, " = ", e);
@@ -93,7 +93,7 @@ proc initCopyFromArray() {
   var x:[1..2] int = 1..2;
   writeln("x:", x.type:string, " = ", x);
 
-  var a: list = x;
+  var a: list(?) = x;
   writeln("a:", a.type:string, " = ", a);
   var b: list(parSafe=false, ?) = x;
   writeln("b:", b.type:string, " = ", b);
@@ -133,7 +133,7 @@ proc initCopyFromRange() {
   var x = 1..2;
   writeln("x:", x.type:string, " = ", x);
 
-  var a: list = x;
+  var a: list(?) = x;
   writeln("a:", a.type:string, " = ", a);
   var b: list(parSafe=false, ?) = x;
   writeln("b:", b.type:string, " = ", b);
@@ -177,11 +177,11 @@ newCopyFromIter();
 
 proc initCopyFromIter() {
   writeln("initCopyFromIter");
-  var a:list = for i in 1..2 do i;
+  var a:list(?) = for i in 1..2 do i;
   writeln("a:", a.type:string, " = ", a);
-  var b:list = myIter();
+  var b:list(?) = myIter();
   writeln("b:", b.type:string, " = ", b);
-  var c:list = (1..2).these();
+  var c:list(?) = (1..2).these();
   writeln("c:", c.type:string, " = ", c);
   var d:list(parSafe=false, ?) = [i in 1..2] i;
   writeln("d:", d.type:string, " = ", d);

--- a/test/localeModels/nspark/loc-in-locales.good
+++ b/test/localeModels/nspark/loc-in-locales.good
@@ -1,2 +1,4 @@
+loc-in-locales.chpl:5: warning: please use '?' when declaring a variable with generic type
+loc-in-locales.chpl:5: note: for example with 'fileReader(?)'
 loc-in-locales.chpl:5: error: Cannot default-initialize a variable with generic type
 loc-in-locales.chpl:5: note: 'c' has generic type 'fileReader'

--- a/test/studies/adventOfCode/2021/bradc/futures/day18-bug.bad
+++ b/test/studies/adventOfCode/2021/bradc/futures/day18-bug.bad
@@ -1,3 +1,7 @@
+day18-bug.chpl:26: warning: please use '?' when declaring a variable with generic type
+day18-bug.chpl:26: note: for example with 'Node(?)'
+day18-bug.chpl:26: warning: please use '?' when declaring a variable with generic type
+day18-bug.chpl:26: note: for example with 'Node(?)'
 day18-bug.chpl:23: In function 'lineToTree':
 day18-bug.chpl:28: error: cannot default-initialize a variable with generic type
 day18-bug.chpl:28: note: '<temporary>' has generic type 'Node'

--- a/test/studies/adventOfCode/2021/bradc/futures/day18-bug2.bad
+++ b/test/studies/adventOfCode/2021/bradc/futures/day18-bug2.bad
@@ -1,7 +1,5 @@
 day18-bug2.chpl:26: warning: please use '?' when declaring a variable with generic type
 day18-bug2.chpl:26: note: for example with 'Node(?)'
-$CHPL_HOME/modules/internal/OwnedObject.chpl:41: warning: please use '?' when declaring a field with generic type
-$CHPL_HOME/modules/internal/OwnedObject.chpl:41: note: for example with 'Node(?)'
 $CHPL_HOME/modules/internal/OwnedObject.chpl:50: In initializer:
 $CHPL_HOME/modules/internal/OwnedObject.chpl:55: error: Could not coerce 'nil' to 'borrowed Node?' in initialization
   $CHPL_HOME/modules/internal/OwnedObject.chpl:130: called as owned.init(type chpl_t = borrowed Node?)

--- a/test/studies/adventOfCode/2021/bradc/futures/day18-bug2.bad
+++ b/test/studies/adventOfCode/2021/bradc/futures/day18-bug2.bad
@@ -1,5 +1,9 @@
-$CHPL_HOME/modules/internal/OwnedObject.chpl:167: In initializer:
-$CHPL_HOME/modules/internal/OwnedObject.chpl:172: error: Could not coerce 'nil' to 'borrowed Node?' in initialization
-  $CHPL_HOME/modules/internal/OwnedObject.chpl:247: called as owned.init(type chpl_t = borrowed Node?)
+day18-bug2.chpl:26: warning: please use '?' when declaring a variable with generic type
+day18-bug2.chpl:26: note: for example with 'Node(?)'
+$CHPL_HOME/modules/internal/OwnedObject.chpl:41: warning: please use '?' when declaring a field with generic type
+$CHPL_HOME/modules/internal/OwnedObject.chpl:41: note: for example with 'Node(?)'
+$CHPL_HOME/modules/internal/OwnedObject.chpl:50: In initializer:
+$CHPL_HOME/modules/internal/OwnedObject.chpl:55: error: Could not coerce 'nil' to 'borrowed Node?' in initialization
+  $CHPL_HOME/modules/internal/OwnedObject.chpl:130: called as owned.init(type chpl_t = borrowed Node?)
   within internal functions (use --print-callstack-on-error to see)
   day18-bug2.chpl:20: called as lineToTree(line: string, pos: int(64))

--- a/test/studies/ssca2/main/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/main/SSCA2_Modules/SSCA2_kernels.chpl
@@ -499,7 +499,7 @@ module SSCA2_kernels
           const tpv = tpvElem!;
           var al = tpv.Active_Level;
           coforall loc in Locales do on loc {
-            var level: unmanaged Level_Set? = al[here.id];
+            var level: unmanaged Level_Set(?)? = al[here.id];
             var prev = level!.previous;
             while prev != nil {
               var p2 = prev!.previous;

--- a/test/types/partial/default-init-generic1.good
+++ b/test/types/partial/default-init-generic1.good
@@ -1,3 +1,5 @@
+default-init-generic1.chpl:22: warning: please use '?' when declaring a variable with generic type
+default-init-generic1.chpl:22: note: for example with 'S(?)'
 default-init-generic1.chpl:21: In function 'main':
 default-init-generic1.chpl:22: error: cannot default-initialize a variable with generic type
 default-init-generic1.chpl:22: note: 'D' has generic type 'S'

--- a/test/types/partial/initeq.chpl
+++ b/test/types/partial/initeq.chpl
@@ -41,9 +41,9 @@ proc main() {
   }
 
   {
-    var a : W = "hello";
+    var a : W(?) = "hello";
     writeln(a);
-    var b : W = 1234;
+    var b : W(?) = 1234;
     writeln(b);
   }
   {

--- a/test/types/partial/initeq.chpl
+++ b/test/types/partial/initeq.chpl
@@ -29,7 +29,7 @@ proc W.init=(other : ?T) where isSubtype(T, W) == false {
 }
 
 proc helper(type T, val) {
-  var x : T = val;
+  var x : T(?) = val;
   writeln("initialized '", T:string, "' from '", val.type:string, "' resulting in '", x.type:string, "'");
 }
 

--- a/test/types/partial/owned-shared.chpl
+++ b/test/types/partial/owned-shared.chpl
@@ -18,24 +18,24 @@ proc print(x) {
 }
 
 proc testOwned() {
-  var a : owned Parent = new owned Parent(int, 3);
+  var a : owned Parent(?) = new owned Parent(int, 3);
   print(a);
   var b : owned Parent(int, ?) = new owned Parent(int, 3);
   print(b);
 
-  var c : owned Parent = new owned Child(int, 3, U=real);
+  var c : owned Parent(?) = new owned Child(int, 3, U=real);
   print(c);
   var d : owned Child(int, ?) = new owned Child(int, 3 , U=real);
   print(d);
 }
 
 proc testShared() {
-  var a : shared Parent = new shared Parent(int, 3);
+  var a : shared Parent(?) = new shared Parent(int, 3);
   print(a);
   var b : shared Parent(int, ?) = new shared Parent(int, 3);
   print(b);
 
-  var c : shared Parent = new shared Child(int, 3, U=real);
+  var c : shared Parent(?) = new shared Child(int, 3, U=real);
   print(c);
   var d : shared Child(int, ?) = new shared Child(int, 3 , U=real);
   print(d);

--- a/test/types/records/bad-change-type/init-uses-default.chpl
+++ b/test/types/records/bad-change-type/init-uses-default.chpl
@@ -8,5 +8,5 @@ proc R.init(type t=real) {
   field = 1.0;
 }
 
-var xx: R;
+var xx: R(?);
 writeln(xx.type:string, " ", xx);

--- a/test/types/records/ferguson/init-leak-check/init-leak-check-defaultinit-generic.chpl
+++ b/test/types/records/ferguson/init-leak-check/init-leak-check-defaultinit-generic.chpl
@@ -9,7 +9,7 @@ proc test1() {
 test1();
 
 proc test2() {
-  var r:MyRecord = new MyRecord("Hello"*3);
+  var r:MyRecord(?) = new MyRecord("Hello"*3);
   writeln(r);
 }
 test2();

--- a/test/types/records/ferguson/init-leak-check/init-leak-check-init-generic.chpl
+++ b/test/types/records/ferguson/init-leak-check/init-leak-check-init-generic.chpl
@@ -15,7 +15,7 @@ proc test1() {
 test1();
 
 proc test2() {
-  var r:MyRecord = new MyRecord("Hello"*3);
+  var r:MyRecord(?) = new MyRecord("Hello"*3);
   writeln(r);
 }
 test2();

--- a/test/types/records/generic/genericFieldDecl-used.bad
+++ b/test/types/records/generic/genericFieldDecl-used.bad
@@ -1,3 +1,5 @@
+genericFieldDecl-used.chpl:9: warning: please use '?' when declaring a variable with generic type
+genericFieldDecl-used.chpl:9: note: for example with 'One(?)'
 genericFieldDecl-used.chpl:9: error: default initialization with type 'One' is not yet supported
 genericFieldDecl-used.chpl:2: note: field 'x' is a generic value
 genericFieldDecl-used.chpl:2: note: consider separately declaring a type field for it or using a 'new' call

--- a/test/types/records/generic/noGenericsDefaulted.chpl
+++ b/test/types/records/generic/noGenericsDefaulted.chpl
@@ -10,7 +10,7 @@ proc foo(r: R) {
   writeln("In foo, r is: ", r);
 }
 
-var ri2: R = new R(int, 2);
+var ri2: R(?) = new R(int, 2);
 var rr2: R(real, 2);
 var ri3: R(int, 3);
 
@@ -18,4 +18,3 @@ foo(ri2);
 foo(rr2);
 foo(ri3);
 writeln();
-

--- a/test/types/records/generic/someGenericsDefaulted.chpl
+++ b/test/types/records/generic/someGenericsDefaulted.chpl
@@ -13,7 +13,7 @@ proc foo(r: R) {
 var ri2: R(rank=2);
 var rr2: R(real, 2);
 var ri3: R(int, 3);
-var rr3: R = new R(real, 3);
+var rr3: R(?) = new R(real, 3);
 
 foo(ri2);
 foo(rr2);

--- a/test/types/records/generic/someGenericsDefaulted2.chpl
+++ b/test/types/records/generic/someGenericsDefaulted2.chpl
@@ -13,7 +13,7 @@ proc foo(r: R) {
 var ri2: R(int);
 var rr2: R(real, 2);
 var ri3: R(int, 3);
-var rr3: R = new R(real, 3);
+var rr3: R(?) = new R(real, 3);
 
 foo(ri2);
 foo(rr2);

--- a/test/types/records/generic/warn-field-generic-declared-type.good
+++ b/test/types/records/generic/warn-field-generic-declared-type.good
@@ -7,6 +7,8 @@ note: if generic memory management is desired, use a 'type' field to store the c
 warn-field-generic-declared-type.chpl:30: warning: field is declared with generic memory management
 note: consider adding 'owned', 'shared', or 'borrowed'
 note: if generic memory management is desired, use a 'type' field to store the class type
+warn-field-generic-declared-type.chpl:56: warning: please use '?' when declaring a field with generic type
+warn-field-generic-declared-type.chpl:56: note: for example with 'GR(?)'
 warn-field-generic-declared-type.chpl:96: warning: please use 'domain(?)' for the type of a generic field storing any domain
 (myfield = 0)
 (myfield = {}) : A(owned MyClass?)

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.chpl
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.chpl
@@ -10,9 +10,17 @@ record R2 {
   var genericFieldY: foo();
 }
 
+record R3 {
+  var genericFieldX: GR;
+  proc init() {
+    this.genericFieldX = new GR(int, 0);
+  }
+}
+
 proc main() {
   var x = new R1(new GR(int, 0));
   var y = new R2(new GR(int, 0));
+  var z = new R3();
 
   var myvar1: GR;
   var myvar2: GR(?);
@@ -22,6 +30,9 @@ proc main() {
   myvar2 = new GR(int, 2);
   myvar3 = new GR(int, 3);
   myvar4 = new GR(int, 4);
+
+  var myvar5: GR = new GR(int, 5);
+  var myvar6: GR(?) = new GR(int, 6);
 
   genericFn(GR);
 

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.chpl
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.chpl
@@ -22,5 +22,13 @@ proc main() {
   myvar2 = new GR(int, 2);
   myvar3 = new GR(int, 3);
   myvar4 = new GR(int, 4);
+
+  genericFn(GR);
+
   compilerError("done");
+}
+
+proc genericFn(type t) {
+  var x: t;
+  x = new GR(int, 5);
 }

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.chpl
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.chpl
@@ -1,0 +1,26 @@
+record GR { type t; var field: t; }
+
+proc foo() type { return GR; }
+
+record R1 {
+  var genericFieldX: GR;
+}
+
+record R2 {
+  var genericFieldY: foo();
+}
+
+proc main() {
+  var x = new R1(new GR(int, 0));
+  var y = new R2(new GR(int, 0));
+
+  var myvar1: GR;
+  var myvar2: GR(?);
+  var myvar3: foo();
+  var myvar4: foo()(?);
+  myvar1 = new GR(int, 1);
+  myvar2 = new GR(int, 2);
+  myvar3 = new GR(int, 3);
+  myvar4 = new GR(int, 4);
+  compilerError("done");
+}

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.good
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.good
@@ -2,10 +2,14 @@ warn-generic-var-field-no-q.chpl:6: warning: please use '?' when declaring a fie
 warn-generic-var-field-no-q.chpl:6: note: for example with 'GR(?)'
 warn-generic-var-field-no-q.chpl:10: warning: please use '?' when declaring a field with generic type
 warn-generic-var-field-no-q.chpl:10: note: for example with 'GR(?)'
-warn-generic-var-field-no-q.chpl:17: warning: please use '?' when declaring a variable with generic type
-warn-generic-var-field-no-q.chpl:17: note: for example with 'GR(?)'
-warn-generic-var-field-no-q.chpl:19: warning: please use '?' when declaring a variable with generic type
-warn-generic-var-field-no-q.chpl:19: note: for example with 'GR(?)'
-warn-generic-var-field-no-q.chpl:32: warning: please use '?' when declaring a variable with generic type
-warn-generic-var-field-no-q.chpl:32: note: for example with 'GR(?)'
-warn-generic-var-field-no-q.chpl:13: error: done
+warn-generic-var-field-no-q.chpl:14: warning: please use '?' when declaring a field with generic type
+warn-generic-var-field-no-q.chpl:14: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:25: warning: please use '?' when declaring a variable with generic type
+warn-generic-var-field-no-q.chpl:25: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:27: warning: please use '?' when declaring a variable with generic type
+warn-generic-var-field-no-q.chpl:27: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:34: warning: please use '?' when declaring a variable with generic type
+warn-generic-var-field-no-q.chpl:34: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:43: warning: please use '?' when declaring a variable with generic type
+warn-generic-var-field-no-q.chpl:43: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:20: error: done

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.good
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.good
@@ -1,0 +1,9 @@
+warn-generic-var-field-no-q.chpl:6: warning: please use '?' when declaring a field with generic type
+warn-generic-var-field-no-q.chpl:6: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:10: warning: please use '?' when declaring a field with generic type
+warn-generic-var-field-no-q.chpl:10: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:17: warning: please use '?' when declaring a variable with generic type
+warn-generic-var-field-no-q.chpl:17: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:19: warning: please use '?' when declaring a variable with generic type
+warn-generic-var-field-no-q.chpl:19: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:13: error: done

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.good
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.good
@@ -6,4 +6,6 @@ warn-generic-var-field-no-q.chpl:17: warning: please use '?' when declaring a va
 warn-generic-var-field-no-q.chpl:17: note: for example with 'GR(?)'
 warn-generic-var-field-no-q.chpl:19: warning: please use '?' when declaring a variable with generic type
 warn-generic-var-field-no-q.chpl:19: note: for example with 'GR(?)'
+warn-generic-var-field-no-q.chpl:32: warning: please use '?' when declaring a variable with generic type
+warn-generic-var-field-no-q.chpl:32: note: for example with 'GR(?)'
 warn-generic-var-field-no-q.chpl:13: error: done


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/5032

This PR adds a warning for these cases:
* `var x: someGenericType` for fields and variables (need `someGenericType(?)`)
* `proc foo(type t) { var x: t; }` -- similarly to `var x: someGenericType`
* `var x: f();` where `f()` returns a generic type, for fields and variables

In the above, `someGenericType` includes `domain` or user records/classes that are generic. Note that PR #22697 added a warning for fields declared with type `domain` or fields of class type with generic management.

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing

Future work
* warn for `class C : SomeGenericType` -- PR #22784
