### PR TITLE
Avoid reductions with AMD+AOD in test

### DIFF
--- a/test/gpu/native/studies/multiGpuStream/multiGpuStream.chpl
+++ b/test/gpu/native/studies/multiGpuStream/multiGpuStream.chpl
@@ -1,5 +1,6 @@
 use Time;
 use Math;
+use ChplConfig;
 
 config type elemType = real(64);
 
@@ -79,7 +80,15 @@ coforall (gpu, id) in zip(here.gpus, here.gpus.domain) do on gpu {
 if printOutput then writeln(A);
 
 if validate {
-  const result = + reduce A;
+  var result = 0.0;
+  if CHPL_GPU=="amd" {
+    // reductions with AMD+AOD hangs see
+    // https://github.com/chapel-lang/chapel/issues/22736
+    for a in A do result += a;
+  }
+  else {
+    result = + reduce A;
+  }
   const expected = numElems*(1+alpha*2);
 
   assert(isclose(result, expected));


### PR DESCRIPTION
The new multi-gpu stream test was timing out on AMD with `array_on_device`. Looks like it is because the validation code uses reduction that seems to be problematic in this setup: https://github.com/chapel-lang/chapel/issues/22736. For now, do sequential and manual reduction on AMD to get the test running.

With this the test passes with NVIDIA and AMD.