### PR TITLE
Add enum constant Documentation

### DIFF
--- a/test/chpldoc/enum.doc.good
+++ b/test/chpldoc/enum.doc.good
@@ -21,7 +21,6 @@ or
 
    This is a color enum. 
 
-
    .. enumconstant:: enum constant Red
 
    .. enumconstant:: enum constant Yellow
@@ -31,7 +30,6 @@ or
 .. enum:: enum Months { January = 1, February, March, April, May, June, July, August, September, October, November, December }
 
    Another enum with inline comments for constants. 
-
 
    .. enumconstant:: enum constant January = 1
 

--- a/test/chpldoc/enum.doc.good
+++ b/test/chpldoc/enum.doc.good
@@ -22,8 +22,42 @@ or
    This is a color enum. 
 
 
+   .. enumconstant:: enum constant Red
+
+   .. enumconstant:: enum constant Yellow
+
+   .. enumconstant:: enum constant Blue
+
 .. enum:: enum Months { January = 1, February, March, April, May, June, July, August, September, October, November, December }
 
    Another enum with inline comments for constants. 
 
+
+   .. enumconstant:: enum constant January = 1
+
+   .. enumconstant:: enum constant February
+
+      month two! 
+
+   .. enumconstant:: enum constant March
+
+      the ides of 
+
+   .. enumconstant:: enum constant April
+
+   .. enumconstant:: enum constant May
+
+   .. enumconstant:: enum constant June
+
+   .. enumconstant:: enum constant July
+
+   .. enumconstant:: enum constant August
+
+   .. enumconstant:: enum constant September
+
+   .. enumconstant:: enum constant October
+
+   .. enumconstant:: enum constant November
+
+   .. enumconstant:: enum constant December
 

--- a/test/chpldoc/enum/deprecatedEnum.doc.good
+++ b/test/chpldoc/enum/deprecatedEnum.doc.good
@@ -55,7 +55,6 @@ or
 
    There was documentation of this symbol 
 
-
    .. warning::
 
       atomicSymbols is deprecated
@@ -69,7 +68,6 @@ or
 .. enum:: enum monsters { vampire, werewolf, ghost }
 
    This symbol also was documented 
-
 
    .. warning::
 
@@ -85,7 +83,6 @@ or
 
    Truncated Frankenstein's monster 
 
-
    .. enumconstant:: enum constant Frankenstein
 
    .. enumconstant:: enum constant Wolfman
@@ -97,7 +94,6 @@ or
 .. enum:: enum directions { north, south, east, west }
 
    This symbol is deprecated 
-
 
    .. enumconstant:: enum constant north
 
@@ -111,7 +107,6 @@ or
 
    This symbol is also deprecated, please use bones instead 
 
-
    .. enumconstant:: enum constant head
 
    .. enumconstant:: enum constant shoulders
@@ -123,7 +118,6 @@ or
 .. enum:: enum bones { tibia, fibia, skull, rib, kneecap }
 
    Replaces the deprecated bodyParts 
-
 
    .. enumconstant:: enum constant tibia
 

--- a/test/chpldoc/enum/deprecatedEnum.doc.good
+++ b/test/chpldoc/enum/deprecatedEnum.doc.good
@@ -23,13 +23,33 @@ or
 
       colors is deprecated
 
+   .. enumconstant:: enum constant red
+
+   .. enumconstant:: enum constant green
+
+   .. enumconstant:: enum constant blue
+
 .. enum:: enum stooges { curly, moe, larry }
 
    .. warning::
 
       stooges is deprecated, use marx instead
 
+   .. enumconstant:: enum constant curly
+
+   .. enumconstant:: enum constant moe
+
+   .. enumconstant:: enum constant larry
+
 .. enum:: enum marx { harpo, groucho, chico, zeppo }
+
+   .. enumconstant:: enum constant harpo
+
+   .. enumconstant:: enum constant groucho
+
+   .. enumconstant:: enum constant chico
+
+   .. enumconstant:: enum constant zeppo
 
 .. enum:: enum atomicSymbols { proton, electron, neutron }
 
@@ -40,6 +60,12 @@ or
 
       atomicSymbols is deprecated
 
+   .. enumconstant:: enum constant proton
+
+   .. enumconstant:: enum constant electron
+
+   .. enumconstant:: enum constant neutron
+
 .. enum:: enum monsters { vampire, werewolf, ghost }
 
    This symbol also was documented 
@@ -49,23 +75,63 @@ or
 
       monsters is deprecated, use monsterMash instead
 
+   .. enumconstant:: enum constant vampire
+
+   .. enumconstant:: enum constant werewolf
+
+   .. enumconstant:: enum constant ghost
+
 .. enum:: enum monsterMash { Frankenstein, Wolfman, Dracula, Casper }
 
    Truncated Frankenstein's monster 
 
+
+   .. enumconstant:: enum constant Frankenstein
+
+   .. enumconstant:: enum constant Wolfman
+
+   .. enumconstant:: enum constant Dracula
+
+   .. enumconstant:: enum constant Casper
 
 .. enum:: enum directions { north, south, east, west }
 
    This symbol is deprecated 
 
 
+   .. enumconstant:: enum constant north
+
+   .. enumconstant:: enum constant south
+
+   .. enumconstant:: enum constant east
+
+   .. enumconstant:: enum constant west
+
 .. enum:: enum bodyParts { head, shoulders, knees, toes }
 
    This symbol is also deprecated, please use bones instead 
 
 
+   .. enumconstant:: enum constant head
+
+   .. enumconstant:: enum constant shoulders
+
+   .. enumconstant:: enum constant knees
+
+   .. enumconstant:: enum constant toes
+
 .. enum:: enum bones { tibia, fibia, skull, rib, kneecap }
 
    Replaces the deprecated bodyParts 
 
+
+   .. enumconstant:: enum constant tibia
+
+   .. enumconstant:: enum constant fibia
+
+   .. enumconstant:: enum constant skull
+
+   .. enumconstant:: enum constant rib
+
+   .. enumconstant:: enum constant kneecap
 

--- a/test/chpldoc/enum/docConstants.doc.good
+++ b/test/chpldoc/enum/docConstants.doc.good
@@ -21,7 +21,6 @@ or
 
    enum documentation 
 
-
    .. enumconstant:: enum constant Red
 
       first constant doc 

--- a/test/chpldoc/enum/docConstants.doc.good
+++ b/test/chpldoc/enum/docConstants.doc.good
@@ -22,3 +22,9 @@ or
    enum documentation 
 
 
+   .. enumconstant:: enum constant Red
+
+      first constant doc 
+
+   .. enumconstant:: enum constant Yellow
+

--- a/test/chpldoc/globals/enums.doc.good
+++ b/test/chpldoc/globals/enums.doc.good
@@ -21,7 +21,6 @@ or
 
    This is a color enum. 
 
-
    .. enumconstant:: enum constant Red
 
    .. enumconstant:: enum constant Yellow

--- a/test/chpldoc/globals/enums.doc.good
+++ b/test/chpldoc/globals/enums.doc.good
@@ -22,6 +22,12 @@ or
    This is a color enum. 
 
 
+   .. enumconstant:: enum constant Red
+
+   .. enumconstant:: enum constant Yellow
+
+   .. enumconstant:: enum constant Blue
+
 .. data:: var typed: Color
 
    This variable is of type Color 

--- a/test/chpldoc/types/arguments/enums.doc.good
+++ b/test/chpldoc/types/arguments/enums.doc.good
@@ -21,7 +21,6 @@ or
 
    This is a color enum. 
 
-
    .. enumconstant:: enum constant Red
 
    .. enumconstant:: enum constant Yellow

--- a/test/chpldoc/types/arguments/enums.doc.good
+++ b/test/chpldoc/types/arguments/enums.doc.good
@@ -22,6 +22,12 @@ or
    This is a color enum. 
 
 
+   .. enumconstant:: enum constant Red
+
+   .. enumconstant:: enum constant Yellow
+
+   .. enumconstant:: enum constant Blue
+
 .. function:: proc gimmeAColor(c: Color)
 
    This function takes an enum as an argument 

--- a/test/chpldoc/types/fields/enums.doc.good
+++ b/test/chpldoc/types/fields/enums.doc.good
@@ -21,7 +21,6 @@ or
 
    This is a color enum. 
 
-
    .. enumconstant:: enum constant Red
 
    .. enumconstant:: enum constant Yellow

--- a/test/chpldoc/types/fields/enums.doc.good
+++ b/test/chpldoc/types/fields/enums.doc.good
@@ -22,6 +22,12 @@ or
    This is a color enum. 
 
 
+   .. enumconstant:: enum constant Red
+
+   .. enumconstant:: enum constant Yellow
+
+   .. enumconstant:: enum constant Blue
+
 .. class:: colorCup
 
    This class holds many different colors 

--- a/test/chpldoc/types/returns/enums.doc.good
+++ b/test/chpldoc/types/returns/enums.doc.good
@@ -21,7 +21,6 @@ or
 
    This is a color enum. 
 
-
    .. enumconstant:: enum constant Red
 
    .. enumconstant:: enum constant Yellow

--- a/test/chpldoc/types/returns/enums.doc.good
+++ b/test/chpldoc/types/returns/enums.doc.good
@@ -22,6 +22,12 @@ or
    This is a color enum. 
 
 
+   .. enumconstant:: enum constant Red
+
+   .. enumconstant:: enum constant Yellow
+
+   .. enumconstant:: enum constant Blue
+
 .. function:: proc gimmeAColor(): Color
 
    This function returns an enum 

--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 sphinx-rtd-theme==1.0.0
-sphinxcontrib-chapeldomain==0.0.26
+sphinxcontrib-chapeldomain==0.0.27
 breathe==4.31.0

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1411,7 +1411,7 @@ struct RstResultBuilder {
     RstSignatureVisitor ppv{os_};
 
     if (node->isEnumElement()) {
-      os_ << "enum element ";
+      os_ << "enum constant ";
     }
     
     node->traverse(ppv);
@@ -1528,7 +1528,7 @@ struct RstResultBuilder {
   owned<RstResult> visit(const EnumElement* e) {
     if (isNoDoc(e)) return {};
     indentDepth_++;
-    show("enumelement", e);
+    show("enumconstant", e);
     return getResult();
   }
 

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1409,8 +1409,14 @@ struct RstResultBuilder {
 
     if (!textOnly_) os_ << ".. " << kind << ":: ";
     RstSignatureVisitor ppv{os_};
+
+    if (node->isEnumElement()) {
+      os_ << "enum element ";
+    }
+    
     node->traverse(ppv);
     if (!textOnly_) os_ << "\n";
+
     bool commentShown = showComment(node, indentComment);
     // TODO: Fix all this because why are we checking for specific node types
     //  just to add a newline?
@@ -1520,10 +1526,9 @@ struct RstResultBuilder {
   }
 
   owned<RstResult> visit(const EnumElement* e) {
-    debuggerBreakHere();
     if (isNoDoc(e)) return {};
     indentDepth_++;
-    show("enum element", e);
+    show("enumelement", e);
     return getResult();
   }
 

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1413,7 +1413,7 @@ struct RstResultBuilder {
     if (node->isEnumElement()) {
       os_ << "enum constant ";
     }
-    
+
     node->traverse(ppv);
     if (!textOnly_) os_ << "\n";
 

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1420,8 +1420,7 @@ struct RstResultBuilder {
     bool commentShown = showComment(node, indentComment);
     // TODO: Fix all this because why are we checking for specific node types
     //  just to add a newline?
-    if (commentShown && !textOnly_ && (node->isEnum() ||
-                                       node->isClass() ||
+    if (commentShown && !textOnly_ && (node->isClass() ||
                                        node->isRecord() ||
                                        node->isModule())) {
       os_ << "\n";

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1515,6 +1515,15 @@ struct RstResultBuilder {
   owned<RstResult> visit(const Enum* e) {
     if (isNoDoc(e)) return {};
     show("enum", e);
+    visitChildren(e);
+    return getResult(true);
+  }
+
+  owned<RstResult> visit(const EnumElement* e) {
+    debuggerBreakHere();
+    if (isNoDoc(e)) return {};
+    indentDepth_++;
+    show("enum element", e);
     return getResult();
   }
 
@@ -1881,6 +1890,7 @@ struct CommentVisitor {
 
   DEF_ENTER(Module, true)
   DEF_ENTER(TypeDecl, true)
+  DEF_ENTER(EnumElement, false)
   DEF_ENTER(Function, false)
   DEF_ENTER(Variable, false)
 


### PR DESCRIPTION
This PR, along with [sphinxcontrib-chapeldomain PR #74](https://github.com/chapel-lang/sphinxcontrib-chapeldomain/pull/74), contains changes made to `chpldoc.cpp` to generate documentation for each enum constant rather than only for the enum. Solution to #5022.

Previously, documentation for enum constants have been either nonexistent, or written in different ways (such as a table) in order to be shown. Since this form of documentation is already available for other types that contain inner content (i.e. records), it is intuitive for enum constant documentation to exist as well.

These changes allow chpldoc to recognize enum constants (written as `EnumElement` in the AST) as enum's children. However, only prefix comments will be recognized and documented. There is intent to allow suffix comments to be recognized and documented in the future.

third-party/chpl-venv/Makefile and make_doc errors should be resolved after merging [this PR](https://github.com/chapel-lang/sphinxcontrib-chapeldomain/pull/74)