### PR TITLE
Restrict the kernel naming test to only work on the current file.

### DIFF
--- a/test/gpu/native/loopNaming.good
+++ b/test/gpu/native/loopNaming.good
@@ -12,5 +12,3 @@
 	Kernel: chpl_gpu_kernel_loopNaming_line_24
 	Kernel: chpl_gpu_kernel_loopNaming_line_25
 	Kernel: chpl_gpu_kernel_loopNaming_line_25
-	Kernel: chpl_gpu_kernel_ChapelArray_line_3307
-	Kernel: chpl_gpu_kernel_ChapelArray_line_3307

--- a/test/gpu/native/loopNaming.prediff
+++ b/test/gpu/native/loopNaming.prediff
@@ -1,2 +1,2 @@
 #! /bin/sh
-grep 'Kernel:' $2 > $2.temp && mv $2.temp $2
+grep 'Kernel:.\+loopNaming' $2 > $2.temp && mv $2.temp $2


### PR DESCRIPTION
The loop naming GPU test was sensitive to loops being moved around in the standard library. To avoid that, I'm switching the test to only display kernel names for the `loopName.chpl` file, and not the standard library.

Reviewed by @e-kayrakli -- thanks!

## Testing
- [x] test now passes locally