### PR TITLE
Use $CHPL_HOME in locations printed from frontend errors

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -885,8 +885,8 @@ static bool shouldPrintHeaderForDecl(chpl::ID declId) {
   return ret;
 }
 
-// Print out 'in function/module/initializer' etc...
-static void maybePrintErrorHeader(chpl::ID id) {
+// Print out 'In function/module/initializer' etc...
+static void maybePrintErrorHeader(chpl::Context* context, chpl::ID id) {
 
   // No ID associated with this error, so no UAST information.
   if (id.isEmpty()) return;
@@ -901,7 +901,7 @@ static void maybePrintErrorHeader(chpl::ID id) {
 
     auto& declLoc = chpl::parsing::locateId(gContext, declId);
     auto line = declLoc.firstLine();
-    auto path = declLoc.path();
+    auto path = context->adjustPathForErrorMsg(declLoc.path());
 
     fprintf(stderr, "%s:%d: In %s:\n", path.c_str(), line, declLabelStr);
 
@@ -929,7 +929,7 @@ static void dynoDisplayError(chpl::Context* context,
       fprintf(stderr, "\n");
     }
   } else {
-    maybePrintErrorHeader(id);
+    maybePrintErrorHeader(context, id);
 
     switch (err.kind()) {
       case chpl::ErrorMessage::NOTE:

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -503,6 +503,10 @@ class Context {
       error/warning output (vs brief output). */
   void setDetailedErrorOutput(bool useDetailed);
 
+  /** Normalize a path for output in an error message by replacing
+      any prefix with the value of CHPL_HOME with the string $CHPL_HOME */
+  UniqueString adjustPathForErrorMsg(UniqueString path);
+
   /**
     Run printchplenv, or return a cached result of doing so. To get output,
     CHPL_HOME must have been provided via the constructor; otherwise, the

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -241,6 +241,17 @@ void Context::setDetailedErrorOutput(bool detailedErrors) {
   this->detailedErrors = detailedErrors;
 }
 
+UniqueString Context::adjustPathForErrorMsg(UniqueString path) {
+  const std::string& chpl_home = this->chplHome();
+  size_t chpl_home_len = chpl_home.length();
+  if (chpl_home_len > 0 && path.startsWith(chpl_home)) {
+    // replace a prefix of the value of CHPL_HOME with $CHPL_HOME
+    return UniqueString::getConcat(this, "$CHPL_HOME",
+                                   path.c_str()+chpl_home_len);
+  }
+  return path;
+}
+
 llvm::ErrorOr<const ChplEnvMap&> Context::getChplEnv() {
   if (config_.chplHome.empty() || computedChplEnv) return chplEnv;
   auto chplEnvResult = ::chpl::getChplEnv(config_.chplEnvOverrides,

--- a/frontend/lib/framework/ErrorWriter.cpp
+++ b/frontend/lib/framework/ErrorWriter.cpp
@@ -104,8 +104,11 @@ static TermColorName kindColor(ErrorBase::Kind kind) {
   return CLEAR;
 }
 
-static void writeFile(std::ostream& oss, const Location& loc) {
-  auto pathUstr = loc.path();
+static void writeFile(Context* context,
+                      std::ostream& oss,
+                      const Location& loc) {
+  UniqueString pathUstr = loc.path();
+  if (context) pathUstr = context->adjustPathForErrorMsg(pathUstr);
   auto path = pathUstr.c_str();
   int lineno = loc.line();
   bool validPath = (path != nullptr && path[0] != '\0');
@@ -126,7 +129,7 @@ void ErrorWriter::writeHeading(ErrorBase::Kind kind, ErrorType type,
   oss_ << kindText(kind);
   setColor(CLEAR);
   oss_ << " in ";
-  writeFile(oss_, errordetail::locate(context, loc));
+  writeFile(context, oss_, errordetail::locate(context, loc));
   if (outputFormat_ == DETAILED) {
     // Second part of the error decoration
     const char* name = ErrorBase::getTypeName(type);
@@ -148,7 +151,7 @@ void ErrorWriter::writeNote(IdOrLocation loc, const std::string& str) {
   if (outputFormat_ == BRIEF) {
     // Indent notes in brief mode to make things easier to organize
     oss_ << "  note in ";
-    writeFile(oss_, errordetail::locate(context, loc));
+    writeFile(context, oss_, errordetail::locate(context, loc));
     oss_ << ": ";
   } else {
     // In detailed mode, the body is indented.

--- a/test/unstable-keyword/in-function.bad
+++ b/test/unstable-keyword/in-function.bad
@@ -1,3 +1,0 @@
-USER PATH/test/unstable-keyword/in-function.helper.chpl:2: In function 'main':
-$CHPL_HOME/test/unstable-keyword/in-function.helper.chpl:4: warning: sparse domains are unstable, their behavior is likely to change in the future
-$CHPL_HOME/test/unstable-keyword/in-function.helper.chpl:2: error: done

--- a/test/unstable-keyword/in-function.future
+++ b/test/unstable-keyword/in-function.future
@@ -1,2 +1,0 @@
-error message: $CHPL_HOME path is not replaced with '$CHPL_HOME' string
-#22752


### PR DESCRIPTION
Resolves #22752

This PR adjusts `frontend/` error message printing to use `$CHPL_HOME` as the start of the path instead of its value. This avoids inconsistencies depending on whether the error is coming from `frontend/` or the older production compiler code in `compiler/`.

Reviewed by @DanilaFe - thanks!

- [x] full comm=none testing