### PR TITLE
Fix default copy init for atomics

### DIFF
--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -56,11 +56,11 @@ module LocaleModelHelpSetup {
     }
     proc init=(other: chpl_root_locale_accum) {
       this.complete();
-      this.nPUsPhysAcc.init_helper(other.nPUsPhysAcc.read());
-      this.nPUsPhysAll.init_helper(other.nPUsPhysAll.read());
-      this.nPUsLogAcc.init_helper(other.nPUsLogAcc.read());
-      this.nPUsLogAll.init_helper(other.nPUsLogAll.read());
-      this.maxTaskPar.init_helper(other.maxTaskPar.read());
+      this.nPUsPhysAcc.write(other.nPUsPhysAcc.read());
+      this.nPUsPhysAll.write(other.nPUsPhysAll.read());
+      this.nPUsLogAcc.write(other.nPUsLogAcc.read());
+      this.nPUsLogAll.write(other.nPUsLogAll.read());
+      this.maxTaskPar.write(other.maxTaskPar.read());
     }
 
     proc accum(loc:locale) {


### PR DESCRIPTION
Fixes an issue which showed up in our nightly testing. `init_helper` would not be resolved in some configurations

Tested in failing configuration using OFI.

[Not Reviewed - trivial]