### PR TITLE
Allow fast math flags in gpu codegen

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2458,9 +2458,7 @@ void prepareCodegenLLVM()
     // --ieee-float
     FM.setAllowContract(true);
   }
-  if (gCodegenGPU == false) {
-    info->irBuilder->setFastMathFlags(FM);
-  }
+  info->irBuilder->setFastMathFlags(FM);
 
   checkAdjustedDataLayout();
 


### PR DESCRIPTION
I found code in the compiler that looks like it disables fast math on GPU codegen. That code dates back to #17116, which was one of the earliest steps for GPU support. I am guessing that we avoided fast math just to be on the safe side. Checking with @mppf offline, he seemed to agree. This PR removes the conditional that avoids fast math on GPUs.

In a quick study with miniBUDE, I see some changes in the generated PTX, though can't easily tell whether they should improve performance. Nor I can see any performance change. But nonetheless we should remove that `if`.

Test:
- [x] gpu/native with NVIDIA