### PR TITLE
Fix chpl_here_free by using raw_c_void_ptr instead

### DIFF
--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -171,9 +171,12 @@ module LocaleModel {
     return chpl_mem_good_alloc_size(min_size.safeCast(c_size_t)).safeCast(min_size.type);
   }
 
+  // see the note in LocaleModelHelpMem for the use of raw_c_void_ptr
+  extern type raw_c_void_ptr = chpl__c_void_ptr;
+
   pragma "locale model free"
   pragma "always propagate line file info"
-  proc chpl_here_free(ptr:c_ptr(void)): void {
+  proc chpl_here_free(ptr:raw_c_void_ptr): void {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc chpl_mem_free(ptr:c_ptr(void)) : void;


### PR DESCRIPTION
Follow on to https://github.com/chapel-lang/chapel/pull/22637.

That PR missed the GPU locale model's `chpl_here_free` which was subject to the weird issue that was worked around with `raw_c_void_ptr` in that PR. This PR makes that particular `chpl_here_free` to also take a `raw_c_void_ptr` argument.

I expect all GPU testing to fail without this PR.

Test:
- [x] nvidia (with some failures)