### PR TITLE
Use a raw_c_void_ptr for chpl_privateObject_t

### DIFF
--- a/modules/internal/ChapelPrivatization.chpl
+++ b/modules/internal/ChapelPrivatization.chpl
@@ -22,9 +22,12 @@ module ChapelPrivatization {
 
   private use CTypes;
 
+  // see the note in LocaleModelHelpMem for the use of raw_c_void_ptr
+  extern type raw_c_void_ptr = chpl__c_void_ptr;
+
   // the type of elements in chpl_privateObjects.
   extern record chpl_privateObject_t {
-    var obj:c_ptr(void);
+    var obj:raw_c_void_ptr;
   }
 
   extern var chpl_privateObjects:c_ptr(chpl_privateObject_t);

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -171,9 +171,6 @@ module LocaleModel {
     return chpl_mem_good_alloc_size(min_size.safeCast(c_size_t)).safeCast(min_size.type);
   }
 
-  // see the note in LocaleModelHelpMem for the use of raw_c_void_ptr
-  extern type raw_c_void_ptr = chpl__c_void_ptr;
-
   pragma "locale model free"
   pragma "always propagate line file info"
   proc chpl_here_free(ptr:raw_c_void_ptr): void {


### PR DESCRIPTION
Switch from `c_ptr(void)` to `raw_c_void_ptr` for the element type of a `chpl_privateObject_t` in the `ChapelPrivatization` internal module.

This is a band-aid solution to some yet-undiagnosed compiler behavior that caused a change in behavior here with the switch from an old `c_void_ptr` (`raw_c_void_ptr`) to a `c_ptr(void)`. This was causing GPU nightly test failures. It is also unknown why this only affected GPU configurations.

It should be possible to use a `c_ptr(void)` here with appropriate compiler changes, which is future work tracked in https://github.com/Cray/chapel-private/issues/5096. Along with that it is likely also possible to remove other usages of `raw_c_void_ptr` that remain as similar band-aid solutions.

Follow up to https://github.com/chapel-lang/chapel/pull/22637.

[reviewer info placeholder]

Testing:
- [x] local paratest
- [x] gasnet paratest
- [x] nvidia GPU testing run by Engin