### PR TITLE
Add warning for deprecated implicit conversion to int(?w) etc

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4066,6 +4066,7 @@ static void cloneParameterizedPrimitive(FnSymbol* fn,
                                         int       width) {
   SymbolMap map;
   FnSymbol* newFn = fn->copy(&map);
+  ArgSymbol* newFormal = toArgSymbol(map.get(formal));
 
   if (DefExpr* def = toDefExpr(query)) {
     Symbol* newSym = map.get(def->sym);
@@ -4079,10 +4080,13 @@ static void cloneParameterizedPrimitive(FnSymbol* fn,
         se->setSymbol(new_IntSymbol(width));
     }
   } else {
-    ArgSymbol* newFormal = toArgSymbol(map.get(formal));
     CallExpr* typeSpecifier = toCallExpr(newFormal->typeExpr->body.tail);
     typeSpecifier->get(1)->replace(new SymExpr(new_IntSymbol(width)));
   }
+
+  // add a flag to the new formal created to cause a warning
+  // if implicit conversions are used when passing to it
+  newFormal->addFlag(FLAG_DEPRECATED_IMPLICIT_CONVERSION);
 
   fn->defPoint->insertAfter(new DefExpr(newFn));
 }

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -193,6 +193,9 @@ PRAGMA(DESTRUCTOR, npr,
 PRAGMA(DEPRECATED, npr,
        "deprecated",
        "applied to symbols that are deprecated")
+PRAGMA(DEPRECATED_IMPLICIT_CONVERSION, npr,
+       "deprecated impliict conversions",
+       "implicit conversions when passing to this formal are deprecated")
 PRAGMA(DISTRIBUTION, ypr, "distribution", ncm)
 PRAGMA(DOCS_ONLY, ypr,
        "docs only",

--- a/test/deprecated/implicit-numeric-to-int-qw-etc.chpl
+++ b/test/deprecated/implicit-numeric-to-int-qw-etc.chpl
@@ -1,0 +1,34 @@
+// test warning for deprecated implicit conversion
+
+// bool(?w) exists but is already deprecated
+
+proc intq(arg: int(?w)) {
+  writeln("in intq(", arg.type:string, ")");
+}
+proc uintq(arg: uint(?w)) {
+  writeln("in uintq(", arg.type:string, ")");
+}
+proc realq(arg: real(?w)) {
+  writeln("in realq(", arg.type:string, ")");
+}
+proc imagq(arg: imag(?w)) {
+  writeln("in imagq(", arg.type:string, ")");
+}
+proc complexq(arg: complex(?w)) {
+  writeln("in complexq(", arg.type:string, ")");
+}
+
+// not expecting warning for these cases
+var oneInt: int = 1;
+var oneUint: uint = 1;
+intq(oneInt);
+uintq(oneUint);
+realq(1.0);
+imagq(1.0i);
+complexq(1.0+1.0i);
+
+// expecting warning in these cases
+intq(true);
+uintq(true);
+realq(oneInt);
+complexq(oneInt);

--- a/test/deprecated/implicit-numeric-to-int-qw-etc.good
+++ b/test/deprecated/implicit-numeric-to-int-qw-etc.good
@@ -1,0 +1,25 @@
+implicit-numeric-to-int-qw-etc.chpl:31: warning: deprecated use of implicit conversion when passing to a generic formal
+implicit-numeric-to-int-qw-etc.chpl:31: note: actual with type 'bool'
+implicit-numeric-to-int-qw-etc.chpl:5: note: is passed to formal with type 'int(?w)'
+note: consider adding a cast to 'int(64)' or an overload to handle 'bool'
+implicit-numeric-to-int-qw-etc.chpl:32: warning: deprecated use of implicit conversion when passing to a generic formal
+implicit-numeric-to-int-qw-etc.chpl:32: note: actual with type 'bool'
+implicit-numeric-to-int-qw-etc.chpl:8: note: is passed to formal with type 'uint(?w)'
+note: consider adding a cast to 'uint(64)' or an overload to handle 'bool'
+implicit-numeric-to-int-qw-etc.chpl:33: warning: deprecated use of implicit conversion when passing to a generic formal
+implicit-numeric-to-int-qw-etc.chpl:33: note: actual with type 'int(64)'
+implicit-numeric-to-int-qw-etc.chpl:11: note: is passed to formal with type 'real(?w)'
+note: consider adding a cast to 'real(64)' or an overload to handle 'int(64)'
+implicit-numeric-to-int-qw-etc.chpl:34: warning: deprecated use of implicit conversion when passing to a generic formal
+implicit-numeric-to-int-qw-etc.chpl:34: note: actual with type 'int(64)'
+implicit-numeric-to-int-qw-etc.chpl:17: note: is passed to formal with type 'complex(?w)'
+note: consider adding a cast to 'complex(128)' or an overload to handle 'int(64)'
+in intq(int(64))
+in uintq(uint(64))
+in realq(real(64))
+in imagq(imag(64))
+in complexq(complex(128))
+in intq(int(64))
+in uintq(uint(64))
+in realq(real(64))
+in complexq(complex(128))

--- a/test/functions/bradc/resolution/smallIntBoolTests/boolInt-testenum.good
+++ b/test/functions/bradc/resolution/smallIntBoolTests/boolInt-testenum.good
@@ -1,16 +1,16 @@
-boolInt.chpl:35: error: unresolved call 'foo(mybool, int(8))'
-boolInt.chpl:11: note: this candidate did not match: foo(x: int(64), y: uint(64))
-boolInt.chpl:35: note: because actual argument #1 with type 'mybool'
-boolInt.chpl:11: note: is passed to formal 'x: int(64)'
-boolInt.chpl:35: note: other candidates are:
-boolInt.chpl:15: note:   foo(x: uint(64), y: int(64))
-boolInt.chpl:3: note:   foo(x: int(8), y: int(8))
+boolInt.chpl:53: error: unresolved call 'foo(mybool, int(8))'
+boolInt.chpl:3: note: this candidate did not match: foo(x: int(8), y: int(8))
+boolInt.chpl:53: note: because actual argument #1 with type 'mybool'
+boolInt.chpl:3: note: is passed to formal 'x: int(8)'
+boolInt.chpl:53: note: other candidates are:
+boolInt.chpl:6: note:   foo(x: int(16), y: int(16))
+boolInt.chpl:9: note:   foo(x: int(32), y: int(32))
 note: and 7 other candidates, use --print-all-candidates to see them
-boolInt.chpl:36: error: unresolved call 'foo(mybool, uint(8))'
-boolInt.chpl:11: note: this candidate did not match: foo(x: int(64), y: uint(64))
-boolInt.chpl:36: note: because actual argument #1 with type 'mybool'
-boolInt.chpl:11: note: is passed to formal 'x: int(64)'
-boolInt.chpl:36: note: other candidates are:
-boolInt.chpl:15: note:   foo(x: uint(64), y: int(64))
-boolInt.chpl:3: note:   foo(x: int(8), y: int(8))
+boolInt.chpl:54: error: unresolved call 'foo(mybool, uint(8))'
+boolInt.chpl:3: note: this candidate did not match: foo(x: int(8), y: int(8))
+boolInt.chpl:54: note: because actual argument #1 with type 'mybool'
+boolInt.chpl:3: note: is passed to formal 'x: int(8)'
+boolInt.chpl:54: note: other candidates are:
+boolInt.chpl:6: note:   foo(x: int(16), y: int(16))
+boolInt.chpl:9: note:   foo(x: int(32), y: int(32))
 note: and 7 other candidates, use --print-all-candidates to see them

--- a/test/functions/bradc/resolution/smallIntBoolTests/boolInt.chpl
+++ b/test/functions/bradc/resolution/smallIntBoolTests/boolInt.chpl
@@ -1,11 +1,29 @@
 config param testenum=false;
 
-proc foo(x: int(?w), y: int(w)) {
-  writeln("In int foo ", w);
+proc foo(x: int(8), y: int(8)) {
+  writeln("In int foo 8");
+}
+proc foo(x: int(16), y: int(16)) {
+  writeln("In int foo 16");
+}
+proc foo(x: int(32), y: int(32)) {
+  writeln("In int foo 32");
+}
+proc foo(x: int(64), y: int(64)) {
+  writeln("In int foo 64");
 }
 
-proc foo(x: uint(?w), y: uint(w)) {
-  writeln("In uint foo ", w);
+proc foo(x: uint(8), y: uint(8)) {
+  writeln("In uint foo 8");
+}
+proc foo(x: uint(16), y: uint(16)) {
+  writeln("In uint foo 16");
+}
+proc foo(x: uint(32), y: uint(32)) {
+  writeln("In uint foo 32");
+}
+proc foo(x: uint(64), y: uint(64)) {
+  writeln("In uint foo 64");
 }
 
 proc foo(x: int(64), y: uint(64)) {

--- a/test/functions/bradc/resolution/smallIntBoolTests/paramNon.chpl
+++ b/test/functions/bradc/resolution/smallIntBoolTests/paramNon.chpl
@@ -1,14 +1,42 @@
-proc plus(x: int(?w), y: int(w)) {
+proc plus(x: int(8), y: int(8)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(16), y: int(16)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(32), y: int(32)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(64), y: int(64)) {
   writeln("In int version");
   writeln(x+y);
 }
 
-proc plus(x: uint(?w), y: uint(w)) {
+proc plus(x: uint(8), y: uint(8)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(16), y: uint(16)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(32), y: uint(32)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(64), y: uint(64)) {
   writeln("In uint version");
   writeln(x+y);
 }
 
-proc plus(x: real(?w), y: real(w)) {
+proc plus(x: real(32), y: real(32)) {
+  writeln("In real version");
+  writeln(x+y);
+}
+proc plus(x: real(32), y: real(32)) {
   writeln("In real version");
   writeln(x+y);
 }

--- a/test/functions/bradc/resolution/smallIntBoolTests/paramNon2.chpl
+++ b/test/functions/bradc/resolution/smallIntBoolTests/paramNon2.chpl
@@ -1,14 +1,42 @@
-proc plus(x: int(?w), y: int(w)) {
+proc plus(x: int(8), y: int(8)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(16), y: int(16)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(32), y: int(32)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(64), y: int(64)) {
   writeln("In int version");
   writeln(x+y);
 }
 
-proc plus(x: uint(?w), y: uint(w)) {
+proc plus(x: uint(8), y: uint(8)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(16), y: uint(16)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(32), y: uint(32)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(64), y: uint(64)) {
   writeln("In uint version");
   writeln(x+y);
 }
 
-proc plus(x: real(?w), y: real(w)) {
+proc plus(x: real(32), y: real(32)) {
+  writeln("In real version");
+  writeln(x+y);
+}
+proc plus(x: real(32), y: real(32)) {
   writeln("In real version");
   writeln(x+y);
 }

--- a/test/functions/bradc/resolution/smallIntBoolTests/paramNon3.chpl
+++ b/test/functions/bradc/resolution/smallIntBoolTests/paramNon3.chpl
@@ -1,14 +1,42 @@
-proc plus(x: int(?w), y: int(w)) {
+proc plus(x: int(8), y: int(8)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(16), y: int(16)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(32), y: int(32)) {
+  writeln("In int version");
+  writeln(x+y);
+}
+proc plus(x: int(64), y: int(64)) {
   writeln("In int version");
   writeln(x+y);
 }
 
-proc plus(x: uint(?w), y: uint(w)) {
+proc plus(x: uint(8), y: uint(8)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(16), y: uint(16)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(32), y: uint(32)) {
+  writeln("In uint version");
+  writeln(x+y);
+}
+proc plus(x: uint(64), y: uint(64)) {
   writeln("In uint version");
   writeln(x+y);
 }
 
-proc plus(x: real(?w), y: real(w)) {
+proc plus(x: real(32), y: real(32)) {
+  writeln("In real version");
+  writeln(x+y);
+}
+proc plus(x: real(32), y: real(32)) {
   writeln("In real version");
   writeln(x+y);
 }

--- a/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.chpl
+++ b/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.chpl
@@ -53,15 +53,43 @@ proc check(msg:c_string, type expect, type t) {
   printf(c"%s expect %s, found %s\n", msg, typeToCString(expect), typeToCString(t));
 }
 
-proc foo(x:int(?w), y:int(w)) {
-  return 0:int(w);
+proc foo(x:int(8), y:int(8)) {
+  return 0:int(8);
 }
-proc foo(param x:int(?w), param y:int(w)) param {
-  return 0:int(w);
+proc foo(x:int(16), y:int(16)) {
+  return 0:int(16);
+}
+proc foo(x:int(32), y:int(32)) {
+  return 0:int(32);
+}
+proc foo(x:int(64), y:int(64)) {
+  return 0:int(64);
 }
 
-proc bar(x:int(?w), y:int(w)) {
-  return 0:int(w);
+proc foo(param x:int(8), param y:int(8)) param {
+  return 0:int(8);
+}
+proc foo(param x:int(16), param y:int(16)) param {
+  return 0:int(16);
+}
+proc foo(param x:int(32), param y:int(32)) param {
+  return 0:int(32);
+}
+proc foo(param x:int(64), param y:int(64)) param {
+  return 0:int(64);
+}
+
+proc bar(x:int(8), y:int(8)) {
+  return 0:int(8);
+}
+proc bar(x:int(16), y:int(16)) {
+  return 0:int(16);
+}
+proc bar(x:int(32), y:int(32)) {
+  return 0:int(32);
+}
+proc bar(x:int(64), y:int(64)) {
+  return 0:int(64);
 }
 
 proc baz(x:uint, y:int) {
@@ -79,13 +107,31 @@ proc boo(x:int(32)) {
   return 0:int(32);
 }
 
-proc bok(x:int(?w), y:int(w)) {
-  return 0:int(w);
+proc bok(x:int(8), y:int(8)) {
+  return 0:int(8);
 }
-proc bok(x:uint(?w), y:uint(w)) {
-  return 0:uint(w);
+proc bok(x:int(16), y:int(16)) {
+  return 0:int(16);
+}
+proc bok(x:int(32), y:int(32)) {
+  return 0:int(32);
+}
+proc bok(x:int(64), y:int(64)) {
+  return 0:int(64);
 }
 
+proc bok(x:uint(8), y:uint(8)) {
+  return 0:uint(8);
+}
+proc bok(x:uint(16), y:uint(16)) {
+  return 0:uint(16);
+}
+proc bok(x:uint(32), y:uint(32)) {
+  return 0:uint(32);
+}
+proc bok(x:uint(64), y:uint(64)) {
+  return 0:uint(64);
+}
 
 proc asSigned(type t) type where t == int(8) do return int(8);
 proc asSigned(type t) type where t == int(16) do return int(16);


### PR DESCRIPTION
Resolves #20011

This PR implements a warning to deprecate implicit conversion when passing to formal types such as `int(?w)`. Such formal types have historically been implemented by an early stamping-out process within the compiler, but we want to make them behave the same as generic formals. Since generic formals don't allow numeric implicit conversion, neither should these.

The implementation approach here is to add a flag to such formals that are stamped-out in `cloneParameterizedPrimitive` in normalize.cpp and then check for this flag in `handleCoercion` in wrappers.cpp.

The warning currently only applies to formals declared in user modules. I explored enabling the warning more broadly and observed 19 failures in full testing, primarily with lulesh implementations. It looks like these have to do with AutoMath functions that still use `int(?w)` etc. This PR leaves migrating those to separate overloads as future work in #22814.

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing