### PR TITLE
Add divide by zero check to BigInteger mod

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -4157,20 +4157,7 @@ module BigInteger {
      It is an error if `b` == 0.
   */
   proc mod(ref result: bigint, const ref a: bigint, const ref b: bigint) {
-    if _local {
-      mpz_fdiv_r(result.mpz, a.mpz, b.mpz);
-    } else if result.localeId == chpl_nodeID {
-      const a_ = a;
-      const b_ = b;
-      mpz_fdiv_r(result.mpz, a_.mpz, b_.mpz);
-    } else {
-      const resultLoc = chpl_buildLocaleID(result.localeId, c_sublocid_any);
-      on __primitive("chpl_on_locale_num", resultLoc) {
-        const a_ = a;
-        const b_ = b;
-        mpz_fdiv_r(result.mpz, a_.mpz, b_.mpz);
-      }
-    }
+    BigInteger.divR(result, a, b, rounding=round.down);
   }
 
   /* Computes the mod operator on the two arguments, defined as
@@ -4198,6 +4185,10 @@ module BigInteger {
      It is an error if `b` == 0.
   */
   proc mod(ref result: bigint, const ref a: bigint, b: integral) : int {
+    if (chpl_checkDivByZero) then
+      if b == 0 then
+        halt("Attempt to divide by zero");
+
     var b_ : c_ulong;
     var rem: c_ulong;
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -910,13 +910,13 @@ module BigInteger {
 
       } else if res.localeId == chpl_nodeID {
         const x_ = x;
-        mpz_tdiv_r_ui(res.mpz, x_.mpz, y_);
+        mpz_tdiv_r_ui(res.mpz, x_.mpz, y);
 
       } else {
         const resLoc = chpl_buildLocaleID(res.localeId, c_sublocid_any);
         on __primitive("chpl_on_locale_num", resLoc) {
           const x_ = x;
-          mpz_tdiv_r_ui(res.mpz, x_.mpz, y_);
+          mpz_tdiv_r_ui(res.mpz, x_.mpz, y);
         }
       }
     }
@@ -4176,23 +4176,23 @@ module BigInteger {
       if b == 0 then
         halt("Attempt to divide by zero");
 
-    var b_ : c_ulong;
-    var rem: c_ulong;
-
     inline proc helper(ref res, ref rem, const ref a, b) {
       if _local {
-        rem = mpz_fdiv_r_ui(res.mpz, a.mpz, b_);
+        rem = mpz_fdiv_r_ui(res.mpz, a.mpz, b);
       } else if res.localeId == chpl_nodeID {
         const a_ = a;
-        rem = mpz_fdiv_r_ui(res.mpz, a_.mpz, b_);
+        rem = mpz_fdiv_r_ui(res.mpz, a_.mpz, b);
       } else {
         const resLoc = chpl_buildLocaleID(res.localeId, c_sublocid_any);
         on __primitive("chpl_on_locale_num", resLoc) {
           const a_ = a;
-          rem = mpz_fdiv_r_ui(res.mpz, a_.mpz, b_);
+          rem = mpz_fdiv_r_ui(res.mpz, a_.mpz, b);
         }
       }
     }
+
+    var b_ : c_ulong;
+    var rem: c_ulong;
 
     if isNonnegative(b) {
       b_ = b.safeCast(c_ulong);

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -891,7 +891,6 @@ module BigInteger {
     return c;
   }
 
-  // reimplemnt using divR?
   // helper for % and %=, which is different from `mod`
   private inline proc modTrunc(ref result: bigint,
                                const ref x: bigint,

--- a/test/deprecated/BigInteger/argumentNames.chpl
+++ b/test/deprecated/BigInteger/argumentNames.chpl
@@ -1,0 +1,24 @@
+// deprecated in 1.32 by Jade
+
+use BigInteger;
+
+
+{
+  compilerWarning("mod");
+  writeln("mod");
+  var a: bigint = 15;
+  var b: bigint = 6;
+  var res: bigint;
+  mod(res, a=a, b=b); // warn
+  writeln(res);
+  mod(res, a=a, b=3); // warn
+  writeln(res);
+  mod(res, x=a, y=b);
+  writeln(res);
+  mod(res, x=a, y=-4);
+  writeln(res);
+  mod(res, a, b);
+  writeln(res);
+  mod(res, a, 2);
+  writeln(res);
+}

--- a/test/deprecated/BigInteger/argumentNames.good
+++ b/test/deprecated/BigInteger/argumentNames.good
@@ -1,0 +1,10 @@
+argumentNames.chpl:7: warning: mod
+argumentNames.chpl:12: warning: mod with named formals `a` and `b` is deprecated, please use the version with `x` and `y` instead
+argumentNames.chpl:14: warning: mod with named formals `a` and `b` is deprecated, please use the version with `x` and `y` instead
+mod
+3
+0
+3
+-1
+3
+1

--- a/test/library/standard/BigInteger/modByZero.chpl
+++ b/test/library/standard/BigInteger/modByZero.chpl
@@ -1,0 +1,25 @@
+config var testnum = 1;
+use BigInteger;
+
+if(testnum == 1) {
+  var a: bigint = 15;
+  var b: int = 0;
+  var res: bigint = a % b;
+}
+else if(testnum == 2) {
+  var a: bigint = 15;
+  var b: bigint = 0;
+  var res: bigint = a % b;
+}
+else if(testnum == 3) {
+  var a: bigint = 15;
+  var b: uint = 0;
+  var res: bigint;
+  mod(res, a, b);
+}
+else if(testnum == 4) {
+  var a: bigint = 15;
+  var b: bigint = 0;
+  var res: bigint;
+  mod(res, a, b);
+}

--- a/test/library/standard/BigInteger/modByZero.chpl
+++ b/test/library/standard/BigInteger/modByZero.chpl
@@ -23,3 +23,13 @@ else if(testnum == 4) {
   var res: bigint;
   mod(res, a, b);
 }
+else if(testnum == 5) {
+  var a: bigint = 15;
+  var b: uint = 0;
+  a %= b;
+}
+else if(testnum == 6) {
+  var a: bigint = 15;
+  var b: bigint = 0;
+  a %= b;
+}

--- a/test/library/standard/BigInteger/modByZero.compopts
+++ b/test/library/standard/BigInteger/modByZero.compopts
@@ -1,0 +1,2 @@
+--checks
+--div-by-zero-checks

--- a/test/library/standard/BigInteger/modByZero.execopts
+++ b/test/library/standard/BigInteger/modByZero.execopts
@@ -1,0 +1,4 @@
+-stestnum=1
+-stestnum=2
+-stestnum=3
+-stestnum=4

--- a/test/library/standard/BigInteger/modByZero.execopts
+++ b/test/library/standard/BigInteger/modByZero.execopts
@@ -2,3 +2,5 @@
 -stestnum=2
 -stestnum=3
 -stestnum=4
+-stestnum=5
+-stestnum=6

--- a/test/library/standard/BigInteger/modByZero.good
+++ b/test/library/standard/BigInteger/modByZero.good
@@ -1,0 +1,1 @@
+modByZero.chpl:n: error: halt reached - Attempt to divide by zero

--- a/test/library/standard/BigInteger/modByZero.prediff
+++ b/test/library/standard/BigInteger/modByZero.prediff
@@ -1,0 +1,11 @@
+#!/bin/sh 
+
+TESTNAME=$1
+OUTFILE=$2
+TMPFILE=$OUTFILE.prediff.tmp
+
+# filter out line numbers
+sed -E 's/\.chpl:[0-9]*:/\.chpl:n:/' < $OUTFILE > $TMPFILE
+cat $TMPFILE > $OUTFILE
+
+rm $TMPFILE


### PR DESCRIPTION
Adds a divide by zero check to `BigInteger.mod`, `BigInteger.%` and `BigInteger.%=` to match the divide functions (#19384). While doing this work, implemented part of the change for argument names (https://github.com/chapel-lang/chapel/issues/19005#issuecomment-1634712958).

## Summary of changes
- add a divide by zero check to `mod`
- reimplement `mod` in terms of the `divR` with the proper rounding argument
- add helper methods for `modTrunc` by a `integral` to reduce code duplication
- deprecate argument names `a`/`b` on `mod` in favor of `x`/`y`

## New tests
- adds `test/library/standard/BigInteger/modByZero.chpl`
- adds `test/deprecated/BigInteger/argumentNames.chpl`

## Testing
- paratest with futures
- paratest + gasnet
- built and checked docs

[Reviewed by @bmcdonald3]

closes #19384
closes cray/chapel-private#5094