### PR TITLE
Rename bigint's setbit, tstbit, combit, and clrbit methods

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2894,8 +2894,18 @@ module BigInteger {
 
 
   // Set/Clr bit
-  proc bigint.setbit(bit_index: integral) {
-    const bi_ = bit_index.safeCast(c_ulong);
+  @deprecated("bigint.setbit is deprecated - please use :proc:`bigint.setBit`")
+  proc bigint.setbit(bit_index: integral) do this.setBit(bit_index);
+
+  /*  Set the bit at ``idx`` of ``this``.
+
+      Utilizes the GMP function `mpz_setbit <https://gmplib.org/manual/Integer-Logic-and-Bit-Fiddling>`_
+
+      :arg idx: the index of the bit to be set
+      :type idx: ``integral``
+  */
+  proc bigint.setBit(idx: integral) {
+    const bi_ = idx.safeCast(c_ulong);
 
     if _local {
       mpz_setbit(this.mpz, bi_);
@@ -2912,8 +2922,18 @@ module BigInteger {
     }
   }
 
-  proc bigint.clrbit(bit_index: integral) {
-    const bi_ = bit_index.safeCast(c_ulong);
+  @deprecated("bigint.clrbit is deprecated - please use :proc:`bigint.clearBit`")
+  proc bigint.clrbit(bit_index: integral) do this.clearBit(bit_index);
+
+  /*  Clear the bit at ``idx`` of ``this``.
+
+      Utilizes the GMP function `mpz_clrbit <https://gmplib.org/manual/Integer-Logic-and-Bit-Fiddling>`_
+
+      :arg idx: the index of the bit to be cleared
+      :type idx: ``integral``
+  */
+  proc bigint.clearBit(idx: integral) {
+    const bi_ = idx.safeCast(c_ulong);
 
     if _local {
       mpz_clrbit(this.mpz, bi_);
@@ -2930,8 +2950,19 @@ module BigInteger {
     }
   }
 
-  proc bigint.combit(bit_index: integral) {
-    const bi_ = bit_index.safeCast(c_ulong);
+  @deprecated("bigint.combit is deprecated - please use :proc:`bigint.toggleBit`")
+  proc bigint.combit(bit_index: integral) do this.toggleBit(bit_index);
+
+  /*  Toggle the bit at ``idx`` of ``this``. If the bit was 1, set it to 0. If
+      the bit was 0, set it to 1.
+
+      Utilizes the GMP function `mpz_combit <https://gmplib.org/manual/Integer-Logic-and-Bit-Fiddling>`_
+
+      :arg idx: the index of the bit to be toggled
+      :type idx: ``integral``
+  */
+  proc bigint.toggleBit(idx: integral) {
+    const bi_ = idx.safeCast(c_ulong);
 
     if _local {
       mpz_combit(this.mpz, bi_);
@@ -2948,9 +2979,22 @@ module BigInteger {
     }
   }
 
-  proc bigint.tstbit(bit_index: integral) : int {
+  @deprecated("bigint.tstbit is deprecated - please use :proc:`bigint.getBit`")
+  proc bigint.tstbit(bit_index: integral): int do return this.getBit(bit_index);
+
+  /*  Get the bit at ``idx`` of ``this``.
+
+      Utilizes the GMP function `mpz_tstbit <https://gmplib.org/manual/Integer-Logic-and-Bit-Fiddling>`_
+
+      :arg idx: the index of the bit to be returned
+      :type idx: ``integral``
+
+      :returns: the bit at index ``idx``
+      :rtype: ``int``
+  */
+  proc bigint.getBit(idx: integral): int {
     var t_ = this.localize();
-    const bi_ = bit_index.safeCast(c_ulong);
+    const bi_ = idx.safeCast(c_ulong);
     var  ret: c_int;
 
     ret = mpz_tstbit(t_.mpz, bi_);

--- a/test/deprecated/BigInteger/deprecateBitFunctions.chpl
+++ b/test/deprecated/BigInteger/deprecateBitFunctions.chpl
@@ -1,0 +1,18 @@
+// deprecated in 1.32 by Jade
+use BigInteger;
+use IO.FormattedIO;
+
+var x: bigint = 0xFF;
+writef("0x%xu\n", x:int);
+
+x.clrbit(0);
+writef("0x%xu\n", x:int);
+
+x.combit(2);
+writef("0x%xu\n", x:int);
+
+x.setbit(9);
+writef("0x%xu\n", x:int);
+
+var i = x.tstbit(8);
+writeln(i);

--- a/test/deprecated/BigInteger/deprecateBitFunctions.good
+++ b/test/deprecated/BigInteger/deprecateBitFunctions.good
@@ -1,0 +1,9 @@
+deprecateBitFunctions.chpl:8: warning: bigint.clrbit is deprecated - please use bigint.clearBit
+deprecateBitFunctions.chpl:11: warning: bigint.combit is deprecated - please use bigint.toggleBit
+deprecateBitFunctions.chpl:14: warning: bigint.setbit is deprecated - please use bigint.setBit
+deprecateBitFunctions.chpl:17: warning: bigint.tstbit is deprecated - please use bigint.getBit
+0xff
+0xfe
+0xfa
+0x2fa
+0

--- a/test/library/standard/GMP/ldelaney/gmp_Bigint_logic_bit.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_Bigint_logic_bit.chpl
@@ -32,12 +32,12 @@ writeln(a, "'s first 0 bit is in position ", a.scan0(0));
 a.set(96);
 writeln(a, "'s first 1 bit is in position ", a.scan1(0));
 
-a.setbit(2);  // set bit 2 (if not set, adds 2^2)
+a.setBit(2);  // set bit 2 (if not set, adds 2^2)
 writeln(a);
 
-a.clrbit(6);  // clear bit 6 (if set, subtracts 2^6)
+a.clearBit(6);  // clear bit 6 (if set, subtracts 2^6)
 writeln(a);
 
-a.combit(3);  // flip the bit signifying 2^3 (adds or subtracts 2^3)
+a.toggleBit(3);  // flip the bit signifying 2^3 (adds or subtracts 2^3)
 writeln(a);
-writeln("bit 3 of a is ", a.tstbit(3));
+writeln("bit 3 of a is ", a.getBit(3));


### PR DESCRIPTION
Renames both the procedure name and the argument name to `bigint`'s *bit methods (#17735 and #22008)

## Summary of changes
- rename `setbit(bit_index: integral)` to `setBit(idx: integral)`
- rename `clrbit(bit_index: integral)` to `clearBit(idx: integral)`
- rename `tstbit(bit_index: integral)` to `getBit(idx: integral)`
- rename `combit(bit_index: integral)` to `toggleBit(idx: integral)`
- add documentation for these 4 functions
  - includes links to the underlying GMP function's documentation
- updated tests as needed

## New tests
- adds `test/deprecated/BigInteger/deprecateBitFunctions.chpl`

## Testing
- paratest with futures
- paratest + gasnet
- built and checked docs

[Reviewed by @bmcdonald3]

closes #17735
closes #22008
closes cray/chapel-private#5095