### PR TITLE
Unstabilize `dmap`

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -666,6 +666,7 @@ module ChapelArray {
   //
   pragma "syntactic distribution"
   @chpldoc.nodoc
+  @unstable("the type 'dmap' is unstable, instead please use distribution factory functions when available")
   record dmap { }
 
   proc chpl__buildDistType(type t) type where isSubtype(_to_borrowed(t), BaseDist) {

--- a/test/compflags/TestWarnUnstableSuppression.2.good
+++ b/test/compflags/TestWarnUnstableSuppression.2.good
@@ -1,15 +1,21 @@
+$CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: In function 'chpl__distributed':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: In function 'doSearchNoEnc':
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/String.chpl:nnnn: called as doSearchNoEnc(x: string, needle: string, region: range(byteIndex,low,one), param count = false, param fromLeft = true)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/String.chpl:nnnn: In method 'doSearchUTF8':
 $CHPL_HOME/modules/internal/String.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/String.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/String.chpl:nnnn: called as string.doSearchUTF8(pattern: string, indices: range(byteIndex,low,one), param count = false, param fromLeft = true)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: In function 'warmupRuntime':
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved

--- a/test/compflags/TestWarnUnstableSuppression.3.good
+++ b/test/compflags/TestWarnUnstableSuppression.3.good
@@ -1,18 +1,30 @@
+$CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: In method 'createDomain':
 $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
+$CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: In function 'newBlockDom':
 $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: sparse domains are unstable, their behavior is likely to change in the future
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_leave':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'first':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'last':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
+$CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function 'stringify':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
   $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: called as stringify(args(0): string, args(1): ArrayInit, args(2): string)

--- a/test/compflags/TestWarnUnstableSuppression.4.good
+++ b/test/compflags/TestWarnUnstableSuppression.4.good
@@ -1,3 +1,4 @@
+$CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: In function 'chpl__distributed':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
@@ -5,13 +6,18 @@ $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is
 TestWarnUnstableSuppression.chpl:2: warning: chpl_unstableInternalSymbolForTesting is unstable
 TestWarnUnstableSuppression.chpl:3: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: In function 'doSearchNoEnc':
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/String.chpl:nnnn: called as doSearchNoEnc(x: string, needle: string, region: range(byteIndex,low,one), param count = false, param fromLeft = true)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/String.chpl:nnnn: In method 'doSearchUTF8':
 $CHPL_HOME/modules/internal/String.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/String.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/String.chpl:nnnn: called as string.doSearchUTF8(pattern: string, indices: range(byteIndex,low,one), param count = false, param fromLeft = true)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: In function 'warmupRuntime':
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved

--- a/test/compflags/TestWarnUnstableSuppression.5.good
+++ b/test/compflags/TestWarnUnstableSuppression.5.good
@@ -1,20 +1,32 @@
 TestWarnUnstableSuppression.chpl:2: warning: chpl_unstableInternalSymbolForTesting is unstable
 TestWarnUnstableSuppression.chpl:3: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: In method 'createDomain':
 $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
+$CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: In function 'newBlockDom':
 $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: sparse domains are unstable, their behavior is likely to change in the future
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_leave':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'first':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'last':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
+$CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function 'stringify':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
   $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: called as stringify(args(0): string, args(1): ArrayInit, args(2): string)

--- a/test/compflags/TestWarnUnstableSuppression.6.good
+++ b/test/compflags/TestWarnUnstableSuppression.6.good
@@ -1,37 +1,55 @@
+$CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: In function 'chpl__distributed':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
+$CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: In method 'createDomain':
 $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
+$CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: In function 'newBlockDom':
 $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: sparse domains are unstable, their behavior is likely to change in the future
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_leave':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'first':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'last':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
+$CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
+$CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: In function 'doSearchNoEnc':
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/String.chpl:nnnn: called as doSearchNoEnc(x: string, needle: string, region: range(byteIndex,low,one), param count = false, param fromLeft = true)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/String.chpl:nnnn: In method 'doSearchUTF8':
 $CHPL_HOME/modules/internal/String.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/String.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/String.chpl:nnnn: called as string.doSearchUTF8(pattern: string, indices: range(byteIndex,low,one), param count = false, param fromLeft = true)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function 'stringify':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
   $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: called as stringify(args(0): string, args(1): ArrayInit, args(2): string)
   within internal functions (use --print-callstack-on-error to see)
   $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: called as halt(args(0): string, args(1): ArrayInit, args(2): string)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: In function 'warmupRuntime':
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.7.good
+++ b/test/compflags/TestWarnUnstableSuppression.7.good
@@ -1,39 +1,57 @@
+$CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: In function 'chpl__distributed':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 TestWarnUnstableSuppression.chpl:2: warning: chpl_unstableInternalSymbolForTesting is unstable
 TestWarnUnstableSuppression.chpl:3: warning: chpl_unstableStandardSymbolForTesting is unstable
+$CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: In method 'createDomain':
 $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
+$CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: In function 'newBlockDom':
 $CHPL_HOME/modules/dists/BlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: sparse domains are unstable, their behavior is likely to change in the future
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: warning: chpl_unstableInternalSymbolForTesting is unstable
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/internal/DefaultRectangular.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 $CHPL_HOME/modules/standard/Reflection.chpl:nnnn: warning: chpl_unstableStandardSymbolForTesting is unstable
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_leave':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'first':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method 'last':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
+$CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
+$CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
+$CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: In function 'doSearchNoEnc':
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/String.chpl:nnnn: called as doSearchNoEnc(x: string, needle: string, region: range(byteIndex,low,one), param count = false, param fromLeft = true)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/String.chpl:nnnn: In method 'doSearchUTF8':
 $CHPL_HOME/modules/internal/String.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
 $CHPL_HOME/modules/internal/String.chpl:nnnn: warning: range.orderToIndex() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/String.chpl:nnnn: called as string.doSearchUTF8(pattern: string, indices: range(byteIndex,low,one), param count = false, param fromLeft = true)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In function 'stringify':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
   $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: called as stringify(args(0): string, args(1): ArrayInit, args(2): string)
   within internal functions (use --print-callstack-on-error to see)
   $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: called as halt(args(0): string, args(1): ArrayInit, args(2): string)
   within internal functions (use --print-callstack-on-error to see)
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: In function 'warmupRuntime':
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: 'allocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: 'deallocate' is unstable, and may be renamed or moved
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In initializer:

--- a/test/compflags/TestWarnUnstableSuppression.prediff
+++ b/test/compflags/TestWarnUnstableSuppression.prediff
@@ -5,12 +5,5 @@
 # There and in many other prediffs, the match pattern is /:[0-9:]*:/
 # Here we drop : inside [] because it is not needed.
 
-# As of this writing, the file names in the "In function 'xyz':" lines
-# do not get their CHPL_HOME path replaced with the string '$CHPL_HOME'.
-# So we filter them out to ensure .good matches.
-# See test/unstable-keyword/in-function.future.
-
-sed -e '/CHPL_HOME\/modules/s/:[0-9]*:/:nnnn:/' \
-    -e "/: In function '/d; /: In method '/d" $2 > $2.tmp
-
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
 mv $2.tmp $2

--- a/test/distributions/block/redistBlock.comm-none.good
+++ b/test/distributions/block/redistBlock.comm-none.good
@@ -1,4 +1,6 @@
 redistBlock.chpl:5: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
+redistBlock.chpl:4: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+redistBlock.chpl:41: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 redistBlock.chpl:15: warning: 'Block.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
 redistBlock.chpl:34: warning: 'Block.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
 redistBlock.chpl:41: warning: assignment between distributions is currently unstable due to lack of testing

--- a/test/distributions/block/redistBlock.good
+++ b/test/distributions/block/redistBlock.good
@@ -1,4 +1,6 @@
 redistBlock.chpl:5: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
+redistBlock.chpl:4: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+redistBlock.chpl:41: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 redistBlock.chpl:15: warning: 'Block.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
 redistBlock.chpl:34: warning: 'Block.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
 redistBlock.chpl:41: warning: assignment between distributions is currently unstable due to lack of testing

--- a/test/unstable-keyword/in-function.prediff
+++ b/test/unstable-keyword/in-function.prediff
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-sed '/CHPL_HOME/!s@^.*/test/@USER PATH/test/@' $2 > $2.tmp
-mv $2.tmp $2

--- a/test/unstable/dmapped-sparse.chpl
+++ b/test/unstable/dmapped-sparse.chpl
@@ -7,4 +7,16 @@ writeln(SD);
 var DD = D dmapped DefaultDist();   // warning: 'dmapped' is unstable
 writeln(DD);
 
-compilerError("done");
+var dm = new dmap(new DefaultDist());
+testit(dm);
+
+proc testit(arg: _distribution) {
+  compilerError("done");
+}
+
+// NB this overload does not match the above call testit(dm)
+// because by resolution time dm's dmap has been converted to '_distribution'
+// while this overload's dmap is still 'dmap'.
+proc testit(arg: dmap) {
+  compilerError("arg: dmap");
+}

--- a/test/unstable/dmapped-sparse.good
+++ b/test/unstable/dmapped-sparse.good
@@ -1,3 +1,6 @@
 dmapped-sparse.chpl:4: warning: sparse domains are unstable, their behavior is likely to change in the future
 dmapped-sparse.chpl:7: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
-dmapped-sparse.chpl:10: error: done
+dmapped-sparse.chpl:10: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+dmapped-sparse.chpl:20: In function 'testit':
+dmapped-sparse.chpl:20: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+dmapped-sparse.chpl:11: error: done


### PR DESCRIPTION
This marks the type `dmap` as unstable, as discussed in a design subteam on May 30.

While there, simplify test/compflags/TestWarnUnstableSuppression.prediff and remove test/unstable-keyword/in-function.prediff, thanks to #22757.

Testing: standard+gasnet paratests; distribution robustness suite.