### PR TITLE
Add AMD GPU performance test

### DIFF
--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -8,5 +8,4 @@ source $CWD/common-slurm-gasnet-cray-cs.bash
 export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_TEST_GPU=true
-export CHPL_LAUNCHER_PARTITION=stormP100
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"

--- a/util/cron/test-perf.gpu-cuda.aod.bash
+++ b/util/cron/test-perf.gpu-cuda.aod.bash
@@ -8,6 +8,8 @@ source $CWD/common-native-gpu.bash
 module load cudatoolkit
 
 export CHPL_GPU=nvidia
+export CHPL_LAUNCHER_PARTITION=stormP100
+
 export CHPL_COMM=none
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/array_on_device"
 export CHPL_GPU_MEM_STRATEGY=array_on_device

--- a/util/cron/test-perf.gpu-cuda.bash
+++ b/util/cron/test-perf.gpu-cuda.bash
@@ -7,6 +7,8 @@ source $CWD/common-native-gpu.bash
 module load cudatoolkit
 
 export CHPL_GPU=nvidia
+export CHPL_LAUNCHER_PARTITION=stormP100
+
 export CHPL_COMM=none
 
 export CHPL_TEST_PERF_CONFIG_NAME='gpu'

--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -1,0 +1,22 @@
+#;!/usr/bin/env bash
+#
+# Run GPU performance tests
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common-native-gpu.bash
+module load rocm
+
+export CHPL_GPU=amd
+export CHPL_GPU_ARCH=gfx906
+export CHPL_GPU_MEM_STRATEGY=array_on_device
+export CHPL_LAUNCHER_PARTITION=amdMI60
+
+export CHPL_COMM=none
+export CHPL_LLVM=bundled
+
+export CHPL_TEST_PERF_CONFIG_NAME='gpu-rocm'
+source $CWD/common-perf.bash
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-rocm"
+
+nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5 -startdate 07/20/23"
+$CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -2,7 +2,7 @@
 #
 # Run GPU performance tests
 
-CWD=$(cd $(dirname $0) ; pwd)
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 
 export CHPL_GPU=amd

--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -1,4 +1,4 @@
-#;!/usr/bin/env bash
+#!/usr/bin/env bash
 #
 # Run GPU performance tests
 

--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -4,15 +4,15 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-native-gpu.bash
-module load rocm
 
 export CHPL_GPU=amd
 export CHPL_GPU_ARCH=gfx906
-export CHPL_GPU_MEM_STRATEGY=array_on_device
-export CHPL_LAUNCHER_PARTITION=amdMI60
-
-export CHPL_COMM=none
 export CHPL_LLVM=bundled
+export CHPL_COMM=none
+export CHPL_LAUNCHER_PARTITION=amdMI60
+export CHPL_GPU_MEM_STRATEGY=array_on_device
+module load rocm
+
 
 export CHPL_TEST_PERF_CONFIG_NAME='gpu-rocm'
 source $CWD/common-perf.bash


### PR DESCRIPTION
Makes some adjustments to one of the common scripts and adds a new one for AMD GPU performance testing.

Uses `rocm` as the distinguishing name as opposed to `amd` (we went with vector names in the recent runtime overhaul, we may want to do the same in the test names, but there are other changes coming up w.r.t GPU testing in the medium-term).

Leaves the current performance test as just `gpu`, although we probably need to suffix that with `nvidia`.