### PR TITLE
Test fixes from unstabilizing `set.parSafe` and `map.parSafe`

### DIFF
--- a/test/compflags/TestWarnUnstableSuppression.3.good
+++ b/test/compflags/TestWarnUnstableSuppression.3.good
@@ -49,7 +49,9 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable 
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_leave':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future

--- a/test/compflags/TestWarnUnstableSuppression.5.good
+++ b/test/compflags/TestWarnUnstableSuppression.5.good
@@ -51,7 +51,9 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable 
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_leave':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future

--- a/test/compflags/TestWarnUnstableSuppression.6.good
+++ b/test/compflags/TestWarnUnstableSuppression.6.good
@@ -70,9 +70,10 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable 
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_leave':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':

--- a/test/compflags/TestWarnUnstableSuppression.7.good
+++ b/test/compflags/TestWarnUnstableSuppression.7.good
@@ -72,7 +72,9 @@ $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable 
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_warnForParSafeIndexing':
 $CHPL_HOME/modules/standard/List.chpl:nnnn: warning: 'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_enter':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_leave':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future

--- a/test/types/chplhashtable/noHashForRecordWithEq.good
+++ b/test/types/chplhashtable/noHashForRecordWithEq.good
@@ -1,4 +1,4 @@
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_addElem':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: error: No hash function found for R
   $CHPL_HOME/modules/standard/Set.chpl:nnnn: called as (set(R,false))._addElem(elem: R) from method 'add'
-  noHashForRecordWithEq.chpl:28: called as (set(R,false)).add(element: R)
+  noHashForRecordWithEq.chpl:nnnn: called as (set(R,false)).add(element: R)

--- a/test/types/chplhashtable/noHashForRecordWithEq2.good
+++ b/test/types/chplhashtable/noHashForRecordWithEq2.good
@@ -1,4 +1,4 @@
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_addElem':
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: error: No hash function found for R
   $CHPL_HOME/modules/standard/Set.chpl:nnnn: called as (set(R,false))._addElem(elem: R) from method 'add'
-  noHashForRecordWithEq2.chpl:29: called as (set(R,false)).add(element: R)
+  noHashForRecordWithEq2.chpl:nnnn: called as (set(R,false)).add(element: R)


### PR DESCRIPTION
Fixes a few test failures from https://github.com/chapel-lang/chapel/pull/22772:

- `compflags/TestWarnUnstableSuppression`
- `types/chplhashtable/noHashForRecordWithEq`
- `types/chplhashtable/noHashForRecordWithEq2`

- [x] paratest