### PR TITLE
Re-good flags-warn-unstable.good for unstable CHPL_GPU_MEM_STRATEGY

### DIFF
--- a/test/gpu/native/jacobi/flags-warn-unstable.good
+++ b/test/gpu/native/jacobi/flags-warn-unstable.good
@@ -2,6 +2,8 @@ warning: GPU support is under active development. As such, the interface is unst
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 flags.chpl:1: warning: The GpuDiagnostics module is unstable and its interface is subject to change in the future.
 flags.chpl:3: warning: The GPU module is unstable and its interface is subject to change in the future.
+flags.chpl:9: In function 'verifyLaunches':
+flags.chpl:16: warning: 'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future
 on GPU:
 1.0 1.20906 2.19525 2.9034 3.5552 4.01125 4.21599 4.10448 3.62297 2.85669 1.60226 1.0
 on CPU:


### PR DESCRIPTION
`test/gpu/native/jacobi/flags.chpl` uses `ChplConfig.CHPL_GPU_MEM_STRATEGY` which is unstable after https://github.com/chapel-lang/chapel/pull/22727. We see a warning for this when compiling with the `--warn-unstable` compopts set, so the `flags-warn-unstable.good` file is updated to include the warning.

Follow-up to https://github.com/chapel-lang/chapel/pull/22727.

[trivial test change, not reviewed]

Testing:
- [x] GPU tests