### PR TITLE
Revert change to `%t` default precision

### DIFF
--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -5013,7 +5013,7 @@ qioerr qio_conv_parse(c_string fmt,
     } else if( specifier == 't' ) {
       style_out->base = 10;
       style_out->pad_char = ' ';
-      style_out->realfmt = 0;
+      style_out->realfmt = 2;
       style_out->string_format = QIO_STRING_FORMAT_CHPL;
 
       // Handle precision

--- a/test/compflags/TestWarnUnstableSuppression.3.good
+++ b/test/compflags/TestWarnUnstableSuppression.3.good
@@ -57,6 +57,17 @@ $CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_enter':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_leave':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method 'extend':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_warnForParSafeIndexing':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':

--- a/test/compflags/TestWarnUnstableSuppression.5.good
+++ b/test/compflags/TestWarnUnstableSuppression.5.good
@@ -59,6 +59,17 @@ $CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_enter':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_leave':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method 'extend':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_warnForParSafeIndexing':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/standard/Errors.chpl:nnnn: In method 'deinit':

--- a/test/compflags/TestWarnUnstableSuppression.6.good
+++ b/test/compflags/TestWarnUnstableSuppression.6.good
@@ -78,6 +78,17 @@ $CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_enter':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_leave':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method 'extend':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_warnForParSafeIndexing':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: In function 'doSearchNoEnc':

--- a/test/compflags/TestWarnUnstableSuppression.7.good
+++ b/test/compflags/TestWarnUnstableSuppression.7.good
@@ -80,6 +80,17 @@ $CHPL_HOME/modules/standard/Time.chpl:nnnn: In function 'tm_zoneType':
 $CHPL_HOME/modules/standard/Time.chpl:nnnn: warning: 'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: In function 'getDefaultSparseDist':
 $CHPL_HOME/modules/dists/SparseBlockDist.chpl:nnnn: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_enter':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_leave':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method 'extend':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method '_warnForParSafeIndexing':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In initializer:
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In function '_modestring':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: append mode is unstable
 $CHPL_HOME/modules/internal/BytesStringCommon.chpl:nnnn: In function 'doSearchNoEnc':


### PR DESCRIPTION
The default floating point precision style for `%t` was accidentally changed in https://github.com/chapel-lang/chapel/pull/22766. This PR reverts that change.

Also fixes .good files for compflags/TestWarnUnstableSuppression, which was failing on main.

- [x] paratest