### PR TITLE
Fix io future test failure

### DIFF
--- a/test/io/ferguson/issue-16945.skipif
+++ b/test/io/ferguson/issue-16945.skipif
@@ -1,1 +1,6 @@
-CHPL_COMM != none
+#!/usr/bin/env python3
+
+import os
+
+# skip for --no-local or CHPL_COMM != none
+print(('--no-local' in os.getenv('COMPOPTS')) or (os.getenv('CHPL_COMM') != 'none'))


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/22766 introduced a future: `test/io/ferguson/issue-16945.chpl` which produces different output for `CHPL_COMM != none` or `--no-local`. This PR adds a check to the tests `skipif` for `--no-local` to avoid a test failure in that configuration.

- [x] test is skipped for `gasnet` or `--no-local`
- [x] test is passing in local config