### PR TITLE
Add launcher partition back to cuda tests

### DIFF
--- a/util/cron/test-gpu-cuda.aod.bash
+++ b/util/cron/test-gpu-cuda.aod.bash
@@ -11,6 +11,7 @@ export CHPL_GPU=nvidia
 export CHPL_COMM=none
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/"
 export CHPL_GPU_MEM_STRATEGY=array_on_device
+export CHPL_LAUNCHER_PARTITION=stormP100
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda.aod"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-cuda.bash
+++ b/util/cron/test-gpu-cuda.bash
@@ -9,6 +9,7 @@ module load cudatoolkit
 
 export CHPL_GPU=nvidia
 export CHPL_COMM=none
+export CHPL_LAUNCHER_PARTITION=stormP100
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-cuda.gasnet.bash
+++ b/util/cron/test-gpu-cuda.gasnet.bash
@@ -9,6 +9,7 @@ module load cudatoolkit
 
 export CHPL_GPU=nvidia
 export CHPL_COMM=gasnet
+export CHPL_LAUNCHER_PARTITION=stormP100
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda.gasnet"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/22785, I made some changes that caused CUDA testing to use the default partition on the testing system. This PR makes sure that we have the correct partition used for CUDA testing.