### PR TITLE
Disable hwloc readme generation

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -16,6 +16,7 @@ endif
 
 CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-shared \
+                          --disable-readme \
                           --disable-cairo \
                           --disable-libxml2 \
                           --disable-libudev \
@@ -71,15 +72,6 @@ hwloc-config: FORCE
 	sleep 1
 	cd $(HWLOC_SUBDIR) && touch configure
 	cd $(HWLOC_SUBDIR) && find . -name "*.in" | xargs touch
-#
-# For reasons not yet understood, our use of a separate build dir breaks
-# the doxygen doc rebuild step.  Ensuring that $(HWLOC_SUBDIR)/README is
-# newer than $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag prevents make from
-# trying to do that step.
-#
-	-touch -m -r  $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -d '+1 sec' $(HWLOC_SUBDIR)/README 2>/dev/null || \
-		touch -m -r $(HWLOC_SUBDIR)/doc/doxygen-doc/hwloc.tag -A '01' $(HWLOC_SUBDIR)/README 2>/dev/null || \
-		touch $(HWLOC_SUBDIR)/README
 #
 # Then configure
 #


### PR DESCRIPTION
We've historically had issues generating the hwloc README and did some file touching to try to trick the build system into not generating it. Hwloc 2.8 added a `--disable-readme` option, so now that we've upgraded to 2.9 we can use that option instead of touching specific files.

For more context see #19522 and open-mpi/hwloc#526