### PR TITLE
Deprecate `IllegalArgumentError`'s two-argument intializer

### DIFF
--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -676,7 +676,7 @@ module BLAS {
         n = Bdom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("B", "Non-square array of dimensions %ix%i passed to trmm".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'B': Non-square array of dimensions %ix%i passed to trmm".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order),
@@ -737,7 +737,7 @@ module BLAS {
         n = Bdom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("B", "Non-square array of dimensions %ix%i passed to trsm".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'B': Non-square array of dimensions %ix%i passed to trsm".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order),
@@ -1027,7 +1027,7 @@ module BLAS {
         n = Adom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("A", "Non-square array of dimensions %ix%i passed to hemv".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'A': Non-square array of dimensions %ix%i passed to hemv".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order);
@@ -1062,7 +1062,7 @@ module BLAS {
         n = Adom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("A", "Non-square array of dimensions %ix%i passed to her".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'A': Non-square array of dimensions %ix%i passed to her".format(m, n));
 
     // TODO -- Assert alpha is real
 
@@ -1099,7 +1099,7 @@ module BLAS {
         n = Adom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("A", "Non-square array of dimensions %ix%i passed to her2".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'A': Non-square array of dimensions %ix%i passed to her2".format(m, n));
 
 
     // Set strides if necessary
@@ -1378,7 +1378,7 @@ module BLAS {
         n = Adom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("A", "Non-square array of dimensions %ix%i passed to symv".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'A': Non-square array of dimensions %ix%i passed to symv".format(m, n));
 
     var _ldA = getLeadingDim(A, order);
 
@@ -1415,7 +1415,7 @@ module BLAS {
         n = Adom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("A", "Non-square array of dimensions %ix%i passed to syr".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'A': Non-square array of dimensions %ix%i passed to syr".format(m, n));
 
     var _ldA = getLeadingDim(A, order);
 
@@ -1452,7 +1452,7 @@ module BLAS {
         n = Adom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("A", "Non-square array of dimensions %ix%i passed to syr2".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'A': Non-square array of dimensions %ix%i passed to syr2".format(m, n));
 
     var _ldA = getLeadingDim(A, order);
 
@@ -1675,7 +1675,7 @@ module BLAS {
         n = Adom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("A", "Non-square array of dimensions %ix%i passed to trmv".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'A': Non-square array of dimensions %ix%i passed to trmv".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order);
@@ -1721,7 +1721,7 @@ module BLAS {
         n = Adom.dim(1).size : c_int;
 
     if m != n then
-      throw new owned IllegalArgumentError("A", "Non-square array of dimensions %ix%i passed to trsv".format(m, n));
+      throw new owned IllegalArgumentError("illegal argument 'A': Non-square array of dimensions %ix%i passed to trsv".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order);
@@ -1841,7 +1841,7 @@ module BLAS {
     require header;
 
     if P.size != 5 then
-      throw new owned IllegalArgumentError("P", "must consist of 5 elements, passed to rotmg");
+      throw new owned IllegalArgumentError("illegal argument 'P': must consist of 5 elements, passed to rotmg");
 
     select eltType {
       when real(32) do{
@@ -1947,7 +1947,7 @@ module BLAS {
     require header;
 
     if P.size != 5 then
-      throw new owned IllegalArgumentError("P", "must consist of 5 elements, passed to rotm");
+      throw new owned IllegalArgumentError("illegal argument 'P': must consist of 5 elements, passed to rotm");
 
     const N = D.size: c_int;
 

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -860,11 +860,11 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       var ivLen = IV.getBuffSize();
       var keyLen = key.getBuffSize();
       if (ivLen != 8) {
-        throw new owned IllegalArgumentError("IV", "Blowfish cipher expects a size of 8 bytes.");
+        throw new owned IllegalArgumentError("illegal argument 'IV': Blowfish cipher expects a size of 8 bytes.");
       }
 
       if (keyLen < 10) {
-        throw new owned IllegalArgumentError("key", "Blowfish cipher expects a size greater than 10 bytes.");
+        throw new owned IllegalArgumentError("illegal argument 'key': Blowfish cipher expects a size greater than 10 bytes.");
       }
       var encryptedPlaintext = bfEncrypt(plaintext, key, IV, this.cipher);
       var encryptedPlaintextBuff = new owned CryptoBuffer(encryptedPlaintext);
@@ -938,7 +938,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     */
     proc getRandomBuffer(buffLen: int): owned CryptoBuffer throws {
       if (buffLen < 1) {
-        throw new owned IllegalArgumentError("buffLen", "Invalid random buffer length specified.");
+        throw new owned IllegalArgumentError("illegal argument 'buffLen': Invalid random buffer length specified.");
       }
       var randomizedBuff = try createRandomBuffer(buffLen);
       var randomizedCryptoBuff = new owned CryptoBuffer(randomizedBuff);
@@ -1101,7 +1101,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       }
 
       if (!openErrCode) {
-        throw new owned IllegalArgumentError("key", "The RSAKey is an invalid match.");
+        throw new owned IllegalArgumentError("illegal argument 'key': The RSAKey is an invalid match.");
       }
 
       var plaintextLen = ciphertext.size;

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -121,19 +121,27 @@ module Errors {
       super.init(msg);
     }
 
-    // This won't actually produce a deprecation message. It's here for documentation purposes only.
+    /*
+      .. warning::
+        ``new IllegalArgumentError(info=)`` is deprecated; please use the initializer that takes a formal ``msg`` instead.
+    */
     pragma "last resort"
     proc init(info: string) {
       compilerWarning("`new IllegalArgumentError(info=)` is deprecated; please use the initializer that takes a formal `msg` instead.");
       super.init(info);
     }
 
+    /*
+      .. warning::
+        IllegalArgumentError's two-argument initializer is deprecated; please use the single-arg initializer instead.
+    */
     proc init(formal: string, info: string) {
       compilerWarning("IllegalArgumentError's two-argument initializer is deprecated; please use the single-arg initializer instead.");
       var msg = "illegal argument '" + formal + "': " + info;
       super.init(msg);
     }
   }
+
 
   /*
     A ``CodepointSplitError`` is thrown when slicing a string with
@@ -550,7 +558,7 @@ module Errors {
   pragma "insert line file info"
   pragma "always propagate line file info"
   proc chpl_enum_cast_error(casted: integral, enumName: string) throws {
-    throw new owned IllegalArgumentError("bad cast from int '" + casted:string + "' to enum '" + enumName, "'");
+    throw new owned IllegalArgumentError("bad cast from int '" + casted:string + "' to enum '" + enumName + "'");
   }
 
   pragma "insert line file info"

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -123,12 +123,13 @@ module Errors {
 
     // This won't actually produce a deprecation message. It's here for documentation purposes only.
     pragma "last resort"
-    @deprecated(notes="`new IllegalArgumentError(info=)` is deprecated; please use the initializer that takes a formal `msg` instead.")
     proc init(info: string) {
+      compilerWarning("`new IllegalArgumentError(info=)` is deprecated; please use the initializer that takes a formal `msg` instead.");
       super.init(info);
     }
 
     proc init(formal: string, info: string) {
+      compilerWarning("IllegalArgumentError's two-argument initializer is deprecated; please use the single-arg initializer instead.");
       var msg = "illegal argument '" + formal + "': " + info;
       super.init(msg);
     }

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1227,7 +1227,7 @@ proc moveDir(src: string, dest: string) throws {
         // source and destination is to fail with a helpful error message.
         // Since this error code shouldn't occur otherwise, it signals to
         // the wrapper function what has happened.
-        throw new owned IllegalArgumentError("src", "Cannot move a directory \'" + src + "\' into itself \'" + dest + "\'.");
+        throw new owned IllegalArgumentError("illegal argument 'src': Cannot move a directory \'" + src + "\' into itself \'" + dest + "\'.");
       } else {
         // dest is a directory, we'll copy src inside it
         // NOT YET SUPPORTED.  Requires basename and joinPath

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4045,7 +4045,7 @@ proc fileReader.seek(region: range(?)) throws where (!region.hasHighBound() ||
     compilerError("Cannot seek on a locking fileReader");
 
   if (!region.hasLowBound()) {
-    throw new IllegalArgumentError("region", "must have a lower bound");
+    throw new IllegalArgumentError("illegal argument 'region': must have a lower bound");
 
   } else {
     if (region.hasHighBound()) {
@@ -4096,7 +4096,7 @@ proc fileWriter.seek(region: range(?)) throws where (!region.hasHighBound() ||
     compilerError("Cannot seek on a locking fileWriter");
 
   if (!region.hasLowBound()) {
-    throw new IllegalArgumentError("region", "must have a lower bound");
+    throw new IllegalArgumentError("illegal argument 'region': must have a lower bound");
 
   } else {
     if (region.hasHighBound()) {
@@ -4119,7 +4119,7 @@ proc fileWriter.seek(region: range(?)) throws where (!region.hasHighBound() ||
 proc fileReader.seek(region: range(?)) throws where (region.hasHighBound() &&
                                                      !useNewSeekRegionBounds) {
   if (!region.hasLowBound()) {
-    throw new IllegalArgumentError("region", "must have a lower bound");
+    throw new IllegalArgumentError("illegal argument 'region': must have a lower bound");
 
   } else {
     const err = qio_channel_seek(_channel_internal, region.low, region.high);
@@ -4133,7 +4133,7 @@ proc fileReader.seek(region: range(?)) throws where (region.hasHighBound() &&
 proc fileWriter.seek(region: range(?)) throws where (region.hasHighBound() &&
                                                      !useNewSeekRegionBounds) {
   if (!region.hasLowBound()) {
-    throw new IllegalArgumentError("region", "must have a lower bound");
+    throw new IllegalArgumentError("illegal argument 'region': must have a lower bound");
 
   } else {
     const err = qio_channel_seek(_channel_internal, region.low, region.high);
@@ -4792,7 +4792,7 @@ proc file.readerHelper(param kind=iokind.dynamic, param locking=true,
                        in deserializer: ?dt = defaultSerializeVal(false))
   : fileReader(kind, locking, dt) throws {
   if (region.hasLowBound() && region.low < 0) {
-    throw new IllegalArgumentError("region", "file region's lowest accepted bound is 0");
+    throw new IllegalArgumentError("illegal argument 'region': file region's lowest accepted bound is 0");
   }
 
   // It is the responsibility of the caller to release the returned fileReader
@@ -5034,7 +5034,7 @@ proc file.writerHelper(param kind=iokind.dynamic, param locking=true,
   fileWriter(kind,locking,st) throws {
 
   if (region.hasLowBound() && region.low < 0) {
-    throw new IllegalArgumentError("region", "file region's lowest accepted bound is 0");
+    throw new IllegalArgumentError("illegal argument 'region': file region's lowest accepted bound is 0");
   }
 
   // It is the responsibility of the caller to retain and release the returned
@@ -7522,11 +7522,11 @@ proc fileReader.readBits(ref x:integral, numBits:int):bool throws {
   if castChecking {
     // Error if reading more bits than fit into x
     if Types.numBits(x.type) < numBits then
-      throw new owned IllegalArgumentError("x, numBits", "readBits numBits=" + numBits:string +
+      throw new owned IllegalArgumentError("readBits numBits=" + numBits:string +
                                                  " > bits in x:" + x.type:string);
     // Error if reading negative number of bits
     if isIntType(numBits.type) && numBits < 0 then
-      throw new owned IllegalArgumentError("numBits", "readBits numBits=" + numBits:string + " < 0");
+      throw new owned IllegalArgumentError("readBits numBits=" + numBits:string + " < 0");
   }
 
   var tmp:_internalIoBits;
@@ -7580,13 +7580,12 @@ proc fileWriter.writeBits(x: integral, numBits: int) : void throws {
   if castChecking {
     // Error if writing more bits than fit into x
     if Types.numBits(x.type) < numBits then
-      throw new owned IllegalArgumentError("x, numBits",
-              "writeBits numBits=" + numBits:string +
-               " > bits in x:" + x.type:string);
+      throw new owned IllegalArgumentError("writeBits numBits=" +
+        numBits:string + " > bits in x:" + x.type:string);
     // Error if writing negative number of bits
     if isIntType(numBits.type) && numBits < 0 then
-      throw new owned IllegalArgumentError("numBits",
-              "writeBits numBits=" + numBits:string + " < 0");
+      throw new owned IllegalArgumentError("writeBits numBits=" +
+        numBits:string + " < 0");
   }
 
   try this.write(new _internalIoBits(x:uint(64), numBits:int(8)));
@@ -7892,7 +7891,7 @@ proc fileWriter.writeBinary(arg:numeric, endian:ioendian) throws {
 proc fileWriter.writeBinary(s: string, size: int = s.size) throws {
   // handle bad arguments
   if size > s.size then
-    throw new owned IllegalArgumentError("size", "cannot exceed length of provided string");
+    throw new owned IllegalArgumentError("illegal argument 'size': cannot exceed length of provided string");
   if s.hasEscapes then
     throw createSystemOrChplError(EILSEQ, "illegal use of escaped string characters in 'writeBinary'");
 
@@ -7940,7 +7939,7 @@ proc fileWriter.writeBinary(s: string, size: int = s.size) throws {
 proc fileWriter.writeBinary(b: bytes, size: int = b.size) throws {
   // handle bad arguments
   if size > b.size then
-    throw new owned IllegalArgumentError("size", "cannot exceed length of provided bytes");
+    throw new owned IllegalArgumentError("illegal argument 'size': cannot exceed length of provided bytes");
 
   on this._home {
     // write the first size bytes to the fileWriter
@@ -10920,8 +10919,9 @@ proc fileWriter._writefOne(fmtStr, ref arg, i: int,
         }
       } otherwise {
         // Unhandled argument type!
-        throw new owned IllegalArgumentError("args(" + i:string + ")",
-                                       "writef internal error " + argType(i):string);
+        throw new owned IllegalArgumentError(
+          "illegal argument 'args(" + i:string + ")': writef internal error " + argType(i):string
+        );
       }
     }
   }
@@ -11306,8 +11306,9 @@ proc fileReader.readf(fmtStr:?t, ref args ...?k): bool throws
                 }
               }
             } otherwise {
-              throw new owned IllegalArgumentError("args(" + i:string + ")",
-                                             "readf internal error " + argType(i):string);
+              throw new owned IllegalArgumentError(
+                "illegal argument 'args(" + i:string + ")': readf internal error " + argType(i):string
+              );
             }
           }
         }

--- a/modules/standard/MemMove.chpl
+++ b/modules/standard/MemMove.chpl
@@ -397,9 +397,9 @@ module MemMove {
     const srcGood = src.domain.contains(if isRange(srcRegion) then {srcRegion}
                                         else srcRegion);
     if !dstGood then
-      throw new IllegalArgumentError("dstRegion", "region contains invalid indices");
+      throw new IllegalArgumentError("illegal argument 'dstRegion': region contains invalid indices");
     if !srcGood then
-      throw new IllegalArgumentError("srcRegion", "region contains invalid indices");
+      throw new IllegalArgumentError("illegal argument 'srcRegion': region contains invalid indices");
 
     _testArrayAlias(dst, dstRegion, src, srcRegion);
   }

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -789,22 +789,22 @@ proc replaceExt(path: string, newExt: string): string throws {
 
     // Check for empty basename as extension can't be appended
     if  basename.isEmpty() {
-      throw new owned IllegalArgumentError(path, "has an empty basename");
+      throw new owned IllegalArgumentError("'" + path + "' has an empty basename");
     }
     // check if extension contains separator.
     else if newExt.find(pathSep) != -1 {
-      throw new owned IllegalArgumentError(newExt, "extension can't contain path separators");
+      throw new owned IllegalArgumentError("extension can't contain path separators");
     }
     // if extension is not blank then check it shouldn't end with ''.' and isn't just '.'
     else if newExt == "." || newExt.endsWith(".") {
-      throw new owned IllegalArgumentError(newExt, "extension can't end with '.'");
+      throw new owned IllegalArgumentError("extension can't end with '.'");
     }
     // remove leading '.' if any for uniform support to both
     const strippedExt = newExt.strip(".", leading=true);
     // check for presence of spaces in strippedExt
     for c in strippedExt {
       if c.isSpace() {
-        throw new owned IllegalArgumentError(newExt, "extension can't contain spaces");
+        throw new owned IllegalArgumentError("extension can't contain spaces");
       }
     }
     var updatedExt = strippedExt;

--- a/test/deprecated/illegalArgumentErrorInit.chpl
+++ b/test/deprecated/illegalArgumentErrorInit.chpl
@@ -5,3 +5,6 @@ const iae1 = new IllegalArgumentError(info="bad argument!"),
 writeln(iae1);
 writeln(iae2);
 writeln(iae3);
+
+const iae4 = new IllegalArgumentError("formal_name", "bad!");
+writeln(iae4);

--- a/test/deprecated/illegalArgumentErrorInit.good
+++ b/test/deprecated/illegalArgumentErrorInit.good
@@ -1,3 +1,6 @@
+$CHPL_HOME/modules/standard/Errors.chpl:553: warning: IllegalArgumentError's two-argument initializer is deprecated; please use the single-arg initializer instead.
+illegalArgumentErrorInit.chpl:1: warning: `new IllegalArgumentError(info=)` is deprecated; please use the initializer that takes a formal `msg` instead.
 IllegalArgumentError: bad argument!
 IllegalArgumentError: bad argument!
 IllegalArgumentError: bad argument!
+IllegalArgumentError: illegal argument 'formal_name': bad!

--- a/test/deprecated/illegalArgumentErrorInit.good
+++ b/test/deprecated/illegalArgumentErrorInit.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/Errors.chpl:553: warning: IllegalArgumentError's two-argument initializer is deprecated; please use the single-arg initializer instead.
 illegalArgumentErrorInit.chpl:1: warning: `new IllegalArgumentError(info=)` is deprecated; please use the initializer that takes a formal `msg` instead.
+illegalArgumentErrorInit.chpl:9: warning: IllegalArgumentError's two-argument initializer is deprecated; please use the single-arg initializer instead.
 IllegalArgumentError: bad argument!
 IllegalArgumentError: bad argument!
 IllegalArgumentError: bad argument!

--- a/test/errhandling/psahabu/coforall-try-bang.chpl
+++ b/test/errhandling/psahabu/coforall-try-bang.chpl
@@ -1,6 +1,6 @@
 module Test {
   proc throwme() throws {
-    throw new owned IllegalArgumentError("Bozos", "Sing");
+    throw new owned IllegalArgumentError("illegal argument 'Bozos': Sing");
   }
 
   proc test() {

--- a/test/expressions/casts/enumCastErrors-4.good
+++ b/test/expressions/casts/enumCastErrors-4.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'bad cast from int '7' to enum 'color': '
+uncaught IllegalArgumentError: bad cast from int '7' to enum 'color'
   enumCastErrors.chpl:25: thrown here
   enumCastErrors.chpl:25: uncaught here

--- a/test/expressions/casts/enumCastErrors-8.good
+++ b/test/expressions/casts/enumCastErrors-8.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'bad cast from int '1' to enum 'color2': '
+uncaught IllegalArgumentError: bad cast from int '1' to enum 'color2'
   enumCastErrors.chpl:41: thrown here
   enumCastErrors.chpl:41: uncaught here

--- a/test/io/ferguson/bits-errors.big-readbits.good
+++ b/test/io/ferguson/bits-errors.big-readbits.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'x, numBits': readBits numBits=9 > bits in x:uint(8)
+uncaught IllegalArgumentError: readBits numBits=9 > bits in x:uint(8)
   bits-errors.chpl:58: thrown here
   bits-errors.chpl:58: uncaught here

--- a/test/io/ferguson/bits-errors.big-writebits.good
+++ b/test/io/ferguson/bits-errors.big-writebits.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'x, numBits': writeBits numBits=9 > bits in x:uint(8)
+uncaught IllegalArgumentError: writeBits numBits=9 > bits in x:uint(8)
   bits-errors.chpl:35: thrown here
   bits-errors.chpl:35: uncaught here

--- a/test/io/ferguson/bits-errors.negative-readbits.good
+++ b/test/io/ferguson/bits-errors.negative-readbits.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'numBits': readBits numBits=-1 < 0
+uncaught IllegalArgumentError: readBits numBits=-1 < 0
   bits-errors.chpl:47: thrown here
   bits-errors.chpl:47: uncaught here

--- a/test/io/ferguson/bits-errors.negative-writebits.good
+++ b/test/io/ferguson/bits-errors.negative-writebits.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'numBits': writeBits numBits=-1 < 0
+uncaught IllegalArgumentError: writeBits numBits=-1 < 0
   bits-errors.chpl:24: thrown here
   bits-errors.chpl:24: uncaught here

--- a/test/io/jade/readBits-castchecking.good
+++ b/test/io/jade/readBits-castchecking.good
@@ -2,5 +2,5 @@ Correctly passes on 0 bits
 Correctly passes on 4 bits
 Correctly passes on 7 bits
 Correctly passes on 8 bits
-Correctly throws on 9 bits - IllegalArgumentError: illegal argument 'x, numBits': readBits numBits=9 > bits in x:uint(8)
-Correctly throws on -1 bits - IllegalArgumentError: illegal argument 'numBits': readBits numBits=-1 < 0
+Correctly throws on 9 bits - IllegalArgumentError: readBits numBits=9 > bits in x:uint(8)
+Correctly throws on -1 bits - IllegalArgumentError: readBits numBits=-1 < 0

--- a/test/library/standard/Path/king-11/replaceExt/cases.good
+++ b/test/library/standard/Path/king-11/replaceExt/cases.good
@@ -1,13 +1,13 @@
 foo.txt
 foo.txt
 foo.txt
-illegal argument 'foo/': has an empty basename
+'foo/' has an empty basename
 foo
-illegal argument '.chp/l': extension can't contain path separators
-illegal argument '.chpl       henlo': extension can't contain spaces
-illegal argument '': has an empty basename
+extension can't contain path separators
+extension can't contain spaces
+'' has an empty basename
 .bashrc.newext
 .exec.out.newext
 ./foo.newext
 /./foo.newext
-illegal argument '/./': has an empty basename
+'/./' has an empty basename

--- a/test/types/enum/diten/varEnumOutOfBounds.good
+++ b/test/types/enum/diten/varEnumOutOfBounds.good
@@ -2,6 +2,6 @@ A
 B
 C
 D
-uncaught IllegalArgumentError: illegal argument 'bad cast from int '4' to enum 'myEnum': '
+uncaught IllegalArgumentError: bad cast from int '4' to enum 'myEnum'
   varEnumOutOfBounds.chpl:10: thrown here
   varEnumOutOfBounds.chpl:10: uncaught here

--- a/test/types/range/enum/castEnumRange4a.good
+++ b/test/types/range/enum/castEnumRange4a.good
@@ -2,6 +2,6 @@ castEnumRange4a.chpl:3: warning: Casts between ranges involving 'enum' indices a
 castEnumRange4a.chpl:5: warning: Casts between ranges involving 'enum' indices are currently unstable (see issue #22406); consider performing the conversion manually
 42..56
 red..orange
-uncaught IllegalArgumentError: illegal argument 'bad cast from int '0' to enum 'color': '
+uncaught IllegalArgumentError: bad cast from int '0' to enum 'color'
   castEnumRange4a.chpl:7: thrown here
   castEnumRange4a.chpl:7: uncaught here

--- a/test/types/range/enum/rangeCastsWithEnum.good
+++ b/test/types/range/enum/rangeCastsWithEnum.good
@@ -110,16 +110,16 @@ casting 0..1 to stridable range of flavor:
   chocolate..vanilla: (chocolate, vanilla, 1, chocolate)
 
 casting 0..1 to range of size
-  caught Error: illegal argument 'bad cast from int '0' to enum 'size': '
+  caught Error: bad cast from int '0' to enum 'size'
 
 casting 0..1 to stridable range of size:
-  caught Error: illegal argument 'bad cast from int '0' to enum 'size': '
+  caught Error: bad cast from int '0' to enum 'size'
 
 casting 0..1 to range of polygon
-  caught Error: illegal argument 'bad cast from int '0' to enum 'polygon': '
+  caught Error: bad cast from int '0' to enum 'polygon'
 
 casting 0..1 to stridable range of polygon:
-  caught Error: illegal argument 'bad cast from int '0' to enum 'polygon': '
+  caught Error: bad cast from int '0' to enum 'polygon'
 
 casting 1..2 to range of flavor
   vanilla..strawberry: (vanilla, strawberry, 1, chocolate)
@@ -134,10 +134,10 @@ casting 1..2 to stridable range of size:
   small..medium: (small, medium, 1, small)
 
 casting 1..2 to range of polygon
-  caught Error: illegal argument 'bad cast from int '1' to enum 'polygon': '
+  caught Error: bad cast from int '1' to enum 'polygon'
 
 casting 1..2 to stridable range of polygon:
-  caught Error: illegal argument 'bad cast from int '1' to enum 'polygon': '
+  caught Error: bad cast from int '1' to enum 'polygon'
 
 casting 0..1 to range of flavor
   chocolate..vanilla: (chocolate, vanilla, 1, chocolate)
@@ -146,16 +146,16 @@ casting 0..1 to stridable range of flavor:
   chocolate..vanilla: (chocolate, vanilla, 1, chocolate)
 
 casting 0..1 to range of size
-  caught Error: illegal argument 'bad cast from int '0' to enum 'size': '
+  caught Error: bad cast from int '0' to enum 'size'
 
 casting 0..1 to stridable range of size:
-  caught Error: illegal argument 'bad cast from int '0' to enum 'size': '
+  caught Error: bad cast from int '0' to enum 'size'
 
 casting 0..1 to range of polygon
-  caught Error: illegal argument 'bad cast from int '0' to enum 'polygon': '
+  caught Error: bad cast from int '0' to enum 'polygon'
 
 casting 0..1 to stridable range of polygon:
-  caught Error: illegal argument 'bad cast from int '0' to enum 'polygon': '
+  caught Error: bad cast from int '0' to enum 'polygon'
 
 casting 1..2 to range of flavor
   vanilla..strawberry: (vanilla, strawberry, 1, chocolate)
@@ -170,10 +170,10 @@ casting 1..2 to stridable range of size:
   small..medium: (small, medium, 1, small)
 
 casting 1..2 to range of polygon
-  caught Error: illegal argument 'bad cast from int '1' to enum 'polygon': '
+  caught Error: bad cast from int '1' to enum 'polygon'
 
 casting 1..2 to stridable range of polygon:
-  caught Error: illegal argument 'bad cast from int '1' to enum 'polygon': '
+  caught Error: bad cast from int '1' to enum 'polygon'
 
 casting small..medium to range of bool
   true..true: (true, true, 1, false)


### PR DESCRIPTION
In discussion summarized here: https://github.com/chapel-lang/chapel/issues/19803#issuecomment-1638946105, we decided to deprecate `IllegalArgumentError`'s two-argument initializer in favor of its single-arg initializer. This PR makes that change and updates module code and tests accordingly.

- [x] paratest
- [x] inspected docs