### PR TITLE
Skip a GPU test in cpu-as-device mode

### DIFF
--- a/test/gpu/native/largeLoop.skipif
+++ b/test/gpu/native/largeLoop.skipif
@@ -1,0 +1,5 @@
+# this test was added to make sure that we can outline loops whose bounds can't
+# fit into 32-bits. It takes too long to run such loops on CPU for testing
+# purposes. There's nothing special about this that we should test for
+# cpu-as-device. So, we're skipping it.
+CHPL_GPU==cpu


### PR DESCRIPTION
`test/gpu/native/largeLoop` was added to make sure that we can outline loops whose bounds can't fit into 32-bits. It takes too long to run such loops on CPU for testing purposes. There's nothing special about this that we should test for cpu-as-device. So, we're skipping it.

The test is skipped correctly with `start_test --respect-skipifs`