### PR TITLE
Adjust sub_test to no longer rely on Python 2's Popen behavior

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -2293,15 +2293,16 @@ for testname in testsrc:
 
                 # It's got surrogates, so encode it as bytes and write it as binary
                 mode = "w"
+                output_to_write, pre_exec_to_write = output, pre_exec_output
                 if re.search(r'[\uD800-\uDFFF]', output) or re.search(r'[\uD800-\uDFFF]', pre_exec_output):
-                    output = output.encode(errors="surrogateescape")
-                    pre_exec_output = pre_exec_output.encode(errors="surrogateescape")
+                    output_to_write = output.encode(errors="surrogateescape")
+                    pre_exec_to_write = pre_exec_output.encode(errors="surrogateescape")
                     mode = "wb"
 
                 # Sadly the scripts used below require an actual file
                 with open(execlog, mode) as execlogfile:
-                    execlogfile.write(pre_exec_output)
-                    execlogfile.write(output)
+                    execlogfile.write(pre_exec_to_write)
+                    execlogfile.write(output_to_write)
 
                 if not exectimeout and not launcher_error:
                     if systemPrediffs:

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -173,6 +173,13 @@ def elapsed_sub_test_time():
 import atexit
 atexit.register(elapsed_sub_test_time)
 
+def run_process(*args, **kwargs):
+    p = subprocess.Popen(*args, **kwargs)
+    (stdout, stderr) = p.communicate()
+    stdout_str = str(stdout, encoding='utf-8', errors='surrogateescape')
+    stderr_str = str(stderr, encoding='utf-8', errors='surrogateescape')
+    return (p.returncode, stdout_str, stderr_str)
+
 #
 # Time out class:  Read from a stream until time out
 #  A little ugly but sending SIGALRM (or any other signal) to Python
@@ -344,12 +351,12 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True, args=None):
 # diff 2 files
 def DiffFiles(f1, f2):
     sys.stdout.write('[Executing diff %s %s]\n'%(f1, f2))
-    p = py3_compat.Popen(['diff',f1,f2],
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
-    if p.returncode != 0:
+    (returncode, myoutput, _) = run_process(['diff',f1,f2],
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.PIPE)
+    if returncode != 0:
         sys.stdout.write(trim_output(myoutput))
-    return p.returncode
+    return returncode
 
 def DiffBinaryFiles(f1, f2):
     sys.stdout.write('[Executing binary diff %s %s]\n'%(f1, f2))

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -2291,8 +2291,15 @@ for testname in testsrc:
                                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
                     output += cat_output
 
+                # It's got surrogates, so encode it as bytes and write it as binary
+                mode = "w"
+                if re.search(r'[\uD800-\uDFFF]', output) or re.search(r'[\uD800-\uDFFF]', pre_exec_output):
+                    output = output.encode(errors="surrogateescape")
+                    pre_exec_output = pre_exec_output.encode(errors="surrogateescape")
+                    mode = "wb"
+
                 # Sadly the scripts used below require an actual file
-                with open(execlog, "w", errors='surrogatepass') as execlogfile:
+                with open(execlog, mode) as execlogfile:
                     execlogfile.write(pre_exec_output)
                     execlogfile.write(output)
 


### PR DESCRIPTION
At this time, sub_test expects `Popen` to behave the way it did in Python 2. That is, it expects Popen to convert the output and error streams to a string, unless it can't, in which case it keeps them as bytes. Python's new Popen uses bytes exclusively. Furthermore, a brief analysis of the sub_test code seems to indicate that it doesn't properly handle the bytes case, even assuming Python 2 behavior: it passes a bytes object to various string methods and `stdout.write`, both of which are string-only.

Motivated by all of this, this PR switches to using plain Python 3 Popen (instead of using the custom compatibility shim that preserved Python 2's behavior). It also makes the decision to immediately encode all outputs from Popen as strings, using surrogate pair encoding to avoid dropping values outside the UTF-8 range. It converts instances of py3_compat calls to their plain versions or wrappers around them. Ultimately, the intention is to do away with py3_compat altogether, since the sub_test script requires Python 3 already.

I followed a "poisoning" strategy for figuring out which values were and weren't possibly bytes. In particular, any time something was given to a `stdout.write` call (which throws a `TypeError` for `bytes` arguments), I assumed that this could be converted to a string-only variable without changing the behavior of the program. Most notably, this led to the deletion of some "isbytes" and "isstring" handling logic:


```Python
                p = py3_compat.Popen(['cat']+catfiles.split(),
                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                catoutput = p.communicate()[0]
                output += catoutput
                # If the python 3 compatible popen command to concatenate files
                # has given us a bytes back but the output up to this point was
                # all str, then we may not be able to translate the cat output
                # into a str and may have to go the other way
                if (isinstance(catoutput, bytes) and
                    not isinstance(output, bytes)):
                    try:
                        decodedcat = catoutput.decode('utf_8')
                        output += decodedcat
                    except UnicodeDecodeError:
                        dealWithBinary = True
                        output = output.encode('utf_8')
                        output += catoutput
                else:
                    output += catoutput

            with open(complog, 'w') as complogfile:
                complogfile.write('%s'%(output)) # <-- %s format here doesn't work with bytes!
````

I'm not sure how to test these changes beyond running a paratest. Please let me know if you have any ideas.

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest
- [x] the number of tests matches before/after this change
- [x] an `evil.chpl` file that writes a non-UTF-8 character is properly handled without exceptions.