### PR TITLE
Apply a one-off fix for a UTF-8 decoding bug

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -238,6 +238,11 @@ def trim_output(output):
         new_output = output[:max_size//2]
         new_output += output[-max_size//2:]
         output = new_output
+
+    # Popen returns bytes if an invalid utf-8 character was present.
+    if isinstance(output, bytes):
+        output = str(output, encoding='utf-8', errors='surrogateescape')
+
     return ''.join(s if s in string.printable else "~" for s in output)
 
 


### PR DESCRIPTION
This is an alternative to #22831 that, instead of making sweeping changes to the way the script handles reading from subprocess' standard input, applies a point fix to the known bug, in which test producting a non-UTF-8 character crashes sub_test. The solution is to always encode the output of Popen as a string, even if surrogate pairs need to be used to make it work.