### PR TITLE
Remove `stringify` call from Yaml serializer

### DIFF
--- a/modules/packages/YAML.chpl
+++ b/modules/packages/YAML.chpl
@@ -1753,7 +1753,7 @@ module YAML {
       } else if (isClassType(t) && val == nil) || isNothingType(t) {
         return b"~";
       } else {
-        return stringify(val);
+        return try! "%?".format(val);
       }
     }
 


### PR DESCRIPTION
Fix a test failure following https://github.com/chapel-lang/chapel/pull/22068 by replacing a call to `stringify` with `"%?".format()` in the Yaml module.

- [x] yaml tests passing