### PR TITLE
Added code to create email.txt

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -880,7 +880,7 @@ if ($runtests == 0) {
 # FIXME: Pass correct args here!
      `$chplhomedir/util/cron/nightly_email.pl $status "$rawsummary" "$sortedsummary" "$prevsummary" "$mailer" "$nochangerecipient" "$recipient" "$subjectid" "$config_name" "$revision" "$rawlog" "$starttime" "$endtime" "$crontab" "$testdirs" $debug`;
      # Write the test results to the summary log.
-     $passed=writeFile($status, "$rawsummary", "$sortedsummary", "$prevsummary", "$mailer", "$nochangerecipient", "$recipient", "$subjectid", "$config_name", "$revision", "$rawlog", "$starttime", "$endtime", "$crontab", "$testdirs", $debug);
+     writeFile($status, "$rawsummary", "$sortedsummary", "$prevsummary", "$mailer", "$nochangerecipient", "$recipient", "$subjectid", "$config_name", "$revision", "$rawlog", "$starttime", "$endtime", "$crontab", "$testdirs", $debug);
 #
 # analyze memory leaks tests
 #
@@ -907,4 +907,4 @@ if ($runtests == 0) {
 }
 print "\n nightly status $passed \n";
 exit 0;
-#exit $passed;
+

--- a/util/cron/nightly_email.pm
+++ b/util/cron/nightly_email.pm
@@ -48,7 +48,7 @@ ensureSummaryExists($prevsummary);
 # status 2 means tests passed and there were some failures.
 # that shouldn't change the format of the email, so we collapse
 # the cases here.
-$passed=0;
+$email=1;
 if ($status == 2) {
   $status = 0;
 }
@@ -75,7 +75,7 @@ if ($status == 0) {
     $summary = "Tests run: $cursucc Successes ($delsucc), $curfail Failures ($delfail)";
 } else {
     $summary = "Tests run: failed new failures";
-    $passed = 1;
+    
 }
 
 
@@ -89,15 +89,6 @@ if ($status == 0) {
     $numtestssummary = "unknown number of Tests";
     $knownumtests = 0;
 }
-writeSummary ($revision,
-     $starttime,
-     $endtime ,
-     $crontab ,
-     $testdirs ,
-     $numtestssummary ,
-     $summary ,
-     $prevsummary ,
-     $sortedsummary );
 
 #
 # send mail
@@ -118,22 +109,21 @@ if ($status == 0) {
 
 if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0) {
     print "Mailing to minimal group\n";
-    $passed = 0;
+    $email=0;
     $recipient = $nochangerecipient;
 
 } else {
-    $passed = 1;
     print "Mailing to everyone\n";
 }
 
-# Persist the test summary to a (summary.txt) in the jenkins workspace.
-# Summary.txt will be used by Jenkins to send emails in case of a failure.
+# Persist the test summary to a (email.txt) in the jenkins workspace.
+# email.txt will be used by Jenkins to send emails in case of a failure.
 
 
 if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
-    # Send email only if there are new failures. Set the passed flag to 1
-    $passed = 1;
-    writeSummary ($revision,
+  print "\n Email:$email \n status:$status \n";
+    if ($email == 1){
+    writeEmail ($revision,
      $starttime,
      $endtime ,
      $crontab ,
@@ -142,7 +132,7 @@ if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$
      $summary ,
      $prevsummary ,
      $sortedsummary );
-  
+    }
 } else {
     print "CHPL_TEST_NOMAIL: No $mailcommand\n";
 }
@@ -156,7 +146,7 @@ if ($debug == 0) {
     }
 }
 
-return $status;
+return(0);
 
 }
 return(1);

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -9,7 +9,8 @@ use Sys::Hostname;
 
 $cwd = abs_path(dirname(__FILE__));
 $chplhomedir = abs_path("$cwd/../..");
-
+$file = "$chplhomedir/email.txt";
+unlink($file);
 
 sub mysystem {
     $command = $_[0];
@@ -141,7 +142,7 @@ sub endMailChplenv {
 
     $mystr;
 }
-sub writeSummary {
+sub writeEmail {
     my $revision = $_[0];
     my $starttime = $_[1];
     my $endtime = $_[2];
@@ -152,8 +153,8 @@ sub writeSummary {
     my $prevsummary = $_[7];
     my $sortedsummary = $_[8];
     print 
-    #Create a file "summary.log" in the chapel homedir. This file will be used by Jenkins to attach the test results in the email body
-    my $filename = "$chplhomedir/summary.log";
+    #Create a file "email.txt" in the chapel homedir. This file will be used by Jenkins to attach the test results in the email body
+    my $filename = "$chplhomedir/email.txt";
     open(my $SF, '>', $filename) or die "Could not open file '$filename' $!";
     print "Writing Test results summary... \n";
     print "filename ... $filename \n";

--- a/util/cron/test-email.bash
+++ b/util/cron/test-email.bash
@@ -9,4 +9,4 @@ export CHPL_HOST_MEM="jemalloc"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="test-email"
 
 $CWD/nightly -cron -hellos ${nightly_args}
-exit $?  
+ 


### PR DESCRIPTION
This PR will add code to create email.txt file in the Jenkins workspace.
Email.txt will be used by Jenkins to send emails in case of build/test failures and success.

https://github.com/Cray/chapel-private/issues/5144