### PR TITLE
Don't allow default initialization for typeless fields

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13649,36 +13649,13 @@ static CallExpr* createGenericRecordVarDefaultInitCall(Symbol* val,
         }
       }
     } else if (isGenericField) {
-
-      bool hasCompilerGeneratedInitializer = root->wantsDefaultInitializer();
-
-      if (hasCompilerGeneratedInitializer && hasDefault == false) {
-        // Create a temporary to pass for typeless generic fields
-        // e.g. for
-        //   record R { var x; }
-        //   var myR: R(int);
-        // convert the  default initialization into
-        //   var default_field_tmp: int;
-        //   var myR = new R(x=default_field_tmp)
-        VarSymbol* temp = newTemp("default_field_temp", value->typeInfo());
-        CallExpr* tempCall = new CallExpr(PRIM_DEFAULT_INIT_VAR, temp, value);
-
-        call->insertBefore(new DefExpr(temp));
-        call->insertBefore(tempCall);
-        resolveExpr(tempCall->get(2));
-        resolveExpr(tempCall);
-        appendExpr = new SymExpr(temp);
-
-      } else {
-        USR_FATAL_CONT(call, "default initialization with type '%s' "
-                             "is not yet supported", toString(at));
-        USR_PRINT(field, "field '%s' is a generic value",
-                         field->name);
-        USR_PRINT(field, "consider separately declaring a type field for it "
-                         "or using a 'new' call");
-        USR_STOP();
-      }
-
+      USR_FATAL_CONT(call, "default initialization with type '%s' "
+                           "is not yet supported", toString(at));
+      USR_PRINT(field, "field '%s' is a generic value",
+                       field->name);
+      USR_PRINT(field, "consider separately declaring a type field for it "
+                       "or using a 'new' call");
+      USR_STOP();
     } else {
       INT_FATAL("Unhandled case for default-init");
     }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2287,6 +2287,17 @@ module TwoArrayPartitioning {
     var baseCaseSize:int = 16;
     var sequentialSizePerTask:int = 4096;
     var endbit:int = max(int);
+
+    proc init(in bucketizer,
+              baseCaseSize: int = 16,
+              sequentialSizePerTask: int = 4096,
+              endbit: int = max(int)) {
+      this.bucketizerType = bucketizer.type;
+      this.bucketizer = bucketizer;
+      this.baseCaseSize = baseCaseSize;
+      this.sequentialSizePerTask = sequentialSizePerTask;
+      this.endbit = endbit;
+    }
   }
 
   record TwoArrayDistributedBucketizerStatePerLocale {
@@ -3184,7 +3195,6 @@ module TwoArrayRadixSort {
 
     if Data._instance.isDefaultRectangular() {
       var state = new TwoArrayBucketizerSharedState(
-        bucketizerType=RadixBucketizer,
         bucketizer=new RadixBucketizer(),
         baseCaseSize=baseCaseSize,
         sequentialSizePerTask=sequentialSizePerTask,

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2257,7 +2257,8 @@ module TwoArrayPartitioning {
                       else here.maxTaskPar;
     var countsSize:int = nTasks*maxBuckets;
 
-    var bucketizer; // contains e.g. sample
+    type bucketizerType;
+    var bucketizer: bucketizerType; // contains e.g. sample
 
     // globalCounts stores counts like this:
     //   count for bin 0, task 0
@@ -3183,6 +3184,7 @@ module TwoArrayRadixSort {
 
     if Data._instance.isDefaultRectangular() {
       var state = new TwoArrayBucketizerSharedState(
+        bucketizerType=RadixBucketizer,
         bucketizer=new RadixBucketizer(),
         baseCaseSize=baseCaseSize,
         sequentialSizePerTask=sequentialSizePerTask,

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2288,6 +2288,10 @@ module TwoArrayPartitioning {
     var sequentialSizePerTask:int = 4096;
     var endbit:int = max(int);
 
+    proc init(type bucketizerType) {
+      this.bucketizerType = bucketizerType;
+    }
+
     proc init(in bucketizer,
               baseCaseSize: int = 16,
               sequentialSizePerTask: int = 4096,

--- a/test/classes/deitz/infer/infer_field10.good
+++ b/test/classes/deitz/infer/infer_field10.good
@@ -1,1 +1,3 @@
-(y = (x = 0))
+infer_field10.chpl:6: error: default initialization with type 'R(int(64))' is not yet supported
+infer_field10.chpl:2: note: field 'x' is a generic value
+infer_field10.chpl:2: note: consider separately declaring a type field for it or using a 'new' call

--- a/test/classes/deitz/infer/infer_field11.good
+++ b/test/classes/deitz/infer/infer_field11.good
@@ -1,2 +1,3 @@
-(y = (x = 0))
-(y = (x = 0.0))
+infer_field11.chpl:6: error: default initialization with type 'R(int(64))' is not yet supported
+infer_field11.chpl:2: note: field 'x' is a generic value
+infer_field11.chpl:2: note: consider separately declaring a type field for it or using a 'new' call

--- a/test/classes/delete-free/owned/owned-record-instantiation-types.chpl
+++ b/test/classes/delete-free/owned/owned-record-instantiation-types.chpl
@@ -25,19 +25,22 @@ record GenericCollection {
 }
 
 {
-  var a:GenericCollection(owned MyClass?);
+  var a:GenericCollection(owned MyClass?)
+        = new GenericCollection(nil: owned MyClass?);
   a.field = new owned MyClass();
   writeln("a ", a.type:string, " has field ", a.field.type:string);
 }
 
 {
-  var b:GenericCollection(owned MyClass?);
+  var b:GenericCollection(owned MyClass?)
+        = new GenericCollection(nil: owned MyClass?);
   b.field = new owned MyClass();
   writeln("b ", b.type:string, " has field ", b.field.type:string);
 }
 
 {
-  var c:GenericCollection(borrowed MyClass?);
+  var c:GenericCollection(borrowed MyClass?)
+        = new GenericCollection(nil: borrowed MyClass?);
   var other = new owned MyClass();
   c.field = other;
   writeln("(borrowed) c ", c.type:string, " has field ", c.field.type:string);

--- a/test/classes/delete-free/tests-from-design-overview/generic-collection-owned.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/generic-collection-owned.chpl
@@ -1,7 +1,15 @@
 class MyClass { var x:int; }
 
 record Collection {
-  var element: owned;
+  type eltType;
+  var element: eltType;
+  proc init(type eltType: owned) {
+    this.eltType = eltType;
+  }
+  proc init(in arg: owned) {
+    this.eltType = arg.type;
+    this.element = arg;
+  }
 }
 
 proc Collection.addElement(in arg: owned) {

--- a/test/classes/delete-free/tests-from-design-overview/generic-collection-unspecified.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/generic-collection-unspecified.chpl
@@ -1,7 +1,8 @@
 class MyClass { var x:int; }
 
 record Collection {
-  var element;
+  type eltType;
+  var element: eltType;
 }
 
 proc Collection.addElement(in arg: element.type) lifetime this < arg {

--- a/test/classes/ferguson/generic-field/generic-field-integral-not-inited-record.good
+++ b/test/classes/ferguson/generic-field/generic-field-integral-not-inited-record.good
@@ -1,1 +1,4 @@
-R(int(64)) (i = 0)
+generic-field-integral-not-inited-record.chpl:5: In function 'test':
+generic-field-integral-not-inited-record.chpl:6: error: default initialization with type 'R(int(64))' is not yet supported
+generic-field-integral-not-inited-record.chpl:2: note: field 'i' is a generic value
+generic-field-integral-not-inited-record.chpl:2: note: consider separately declaring a type field for it or using a 'new' call

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited.good
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited.good
@@ -1,1 +1,4 @@
-Wrapper(GenericRecord(int(64))) (f = (field = 0))
+generic-field-record-not-inited.chpl:9: In function 'test1':
+generic-field-record-not-inited.chpl:10: error: default initialization with type 'Wrapper(GenericRecord(int(64)))' is not yet supported
+generic-field-record-not-inited.chpl:6: note: field 'f' is a generic value
+generic-field-record-not-inited.chpl:6: note: consider separately declaring a type field for it or using a 'new' call

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited2.good
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited2.good
@@ -1,1 +1,5 @@
-Wrapper(GenericRecord(int(64))) (f = (field = (field = 0)))
+generic-field-record-not-inited2.chpl:8: In initializer:
+generic-field-record-not-inited2.chpl:8: error: default initialization with type 'GenericRecord(GenericRecord(int(64)))' is not yet supported
+generic-field-record-not-inited2.chpl:2: note: field 'field' is a generic value
+generic-field-record-not-inited2.chpl:2: note: consider separately declaring a type field for it or using a 'new' call
+  generic-field-record-not-inited2.chpl:16: called as Wrapper.init(type t = GenericRecord(int(64)))

--- a/test/classes/initializers/compilerGenerated/generics/issue-16508-default-ok.good
+++ b/test/classes/initializers/compilerGenerated/generics/issue-16508-default-ok.good
@@ -1,1 +1,3 @@
-0: int(64)
+issue-16508-default-ok.chpl:5: error: default initialization with type 'TypelessField(int(64))' is not yet supported
+issue-16508-default-ok.chpl:2: note: field 'field' is a generic value
+issue-16508-default-ok.chpl:2: note: consider separately declaring a type field for it or using a 'new' call

--- a/test/classes/initializers/compilerGenerated/generics_check_record.chpl
+++ b/test/classes/initializers/compilerGenerated/generics_check_record.chpl
@@ -12,8 +12,9 @@ proc main() {
   writeln(c1.type:string);
   writeln(c1);
 
-  var c2: GenericRecord(int, 2, bool);
-  writeln(c2.type:string);
+  // commented out because this case now results in compilation error
+  //var c2: GenericRecord(int, 2, bool);
+  //writeln(c2.type:string);
 
   var c3: GenericRecord(real, 5, real) = new GenericRecord(real, 5, 2.4, 8);
   writeln(c3.type:string);

--- a/test/classes/initializers/compilerGenerated/generics_check_record.good
+++ b/test/classes/initializers/compilerGenerated/generics_check_record.good
@@ -1,5 +1,4 @@
 GenericRecord(bool,5,real(64))
 (v = 3.0, nongeneric = 2)
-GenericRecord(int(64),2,bool)
 GenericRecord(real(64),5,real(64))
 (v = 2.4, nongeneric = 8)

--- a/test/classes/initializers/generics/copy-init-generic-field.chpl
+++ b/test/classes/initializers/generics/copy-init-generic-field.chpl
@@ -16,4 +16,7 @@ record R {
   var something = foobar(foo);
 }
 
-var r : R(int);
+var r = new R(0);
+var copy = r;
+writeln(r);
+writeln(copy);

--- a/test/classes/initializers/generics/copy-init-generic-field.good
+++ b/test/classes/initializers/generics/copy-init-generic-field.good
@@ -1,0 +1,2 @@
+(foo = 0, something = 0)
+(foo = 0, something = 0)

--- a/test/deprecated-keyword/handleField.chpl
+++ b/test/deprecated-keyword/handleField.chpl
@@ -219,7 +219,7 @@ proc main() {
   // Check various declarations of a record with the new field present
   var r13: ReplaceVarGeneric2(?) = new ReplaceVarGeneric2(10);
   var r14 = new ReplaceVarGeneric2(0);
-  var r15: ReplaceVarGeneric2(int);
+  var r15: ReplaceVarGeneric2(int) = new ReplaceVarGeneric2(0);
   // Check direct references
   writeln(r13.newName);
   writeln(r13.oldName); // Should warn, but show the same value
@@ -244,7 +244,7 @@ proc main() {
   // Check various declarations of a record with the new field present
   var r16: ReplaceConstGeneric2(?) = new ReplaceConstGeneric2(3);
   var r17 = new ReplaceConstGeneric2(17);
-  var r18: ReplaceConstGeneric2(int);
+  var r18: ReplaceConstGeneric2(int) = new ReplaceConstGeneric2(0);
   // Check direct references
   writeln(r16.newName);
   writeln(r16.oldName); // Should warn, but show the same value

--- a/test/functions/ferguson/partially-generic-overloads.chpl
+++ b/test/functions/ferguson/partially-generic-overloads.chpl
@@ -25,8 +25,10 @@ proc t1(A:[]) where true {
 t1(A);
 
 record R {
-  var x;
-  var y;
+  type xType;
+  type yType;
+  var x: xType;
+  var y: yType;
 }
 
 proc t2(r:R(int, ?)) {

--- a/test/functions/promotion/passPromotedToFunction.chpl
+++ b/test/functions/promotion/passPromotedToFunction.chpl
@@ -1,4 +1,4 @@
-record R { var x; }
+record R { type xType; var x: xType; }
 proc testit(ref r: R) { r.x += 1; }
 
 var A: [1..1] R(int);

--- a/test/library/standard/Types/copyable.chpl
+++ b/test/library/standard/Types/copyable.chpl
@@ -76,7 +76,9 @@ class C { var x: int; }
 record R { var y: int; }
 enum MyEnum { val }
 
-record GenericRecord { var x; }
+record GenericRecord { type xType; var x: xType; }
+
+record GenericRecordTypeless { var x; }
 
 record GenericRecordDefault { type t = int; var z: t; }
 
@@ -90,7 +92,8 @@ proc main() {
   var unmanagedCQ = new unmanaged C?();
 
   var at: atomic int;
-  var genericR = new GenericRecord(1);
+  var genericR = new GenericRecord(int, 1);
+  var genericRT = new GenericRecordTypeless(2);
   var genericRD: GenericRecordDefault;
 
   checkNormal(int, 1);
@@ -116,6 +119,7 @@ proc main() {
 
   checkNormal(atomic int, at);
   checkNormal(GenericRecord(int), genericR);
+  checkNormalNoDefault(GenericRecordTypeless(int), genericRT);
   checkNormal(GenericRecordDefault, genericRD);
 
   delete unmanagedCQ;

--- a/test/types/partial/partial-no-q-warning.chpl
+++ b/test/types/partial/partial-no-q-warning.chpl
@@ -20,7 +20,7 @@ record r3 {
 }
 
 type t3 = r3(real);
-var z: t3(int);
+//var z: t3(int); // currently an error
 
 
 record r4 {

--- a/test/types/records/generic/warn-field-generic-declared-type.chpl
+++ b/test/types/records/generic/warn-field-generic-declared-type.chpl
@@ -3,7 +3,7 @@ record R {
 }
 
 {
-  var rr: R(int);
+  var rr: R(int) = new R(0);
   writeln(rr);
 }
 
@@ -22,7 +22,7 @@ record B {
 }
 
 {
-  var bb: B(owned MyClass?);
+  var bb: B(owned MyClass?) = new B(nil: owned MyClass?);
   writeln(bb, " : ", bb.type:string);
 }
 

--- a/test/types/records/init/no-default-init-generic-var.chpl
+++ b/test/types/records/init/no-default-init-generic-var.chpl
@@ -1,5 +1,5 @@
 record R { var genericField: integral; }
 
-var x: R(int); // ok
+var x: R(int); // error
 writeln(x, " : ", x.type:string);
 

--- a/test/types/records/init/no-default-init-generic-var.chpl
+++ b/test/types/records/init/no-default-init-generic-var.chpl
@@ -1,0 +1,5 @@
+record R { var genericField: integral; }
+
+var x: R(int); // ok
+writeln(x, " : ", x.type:string);
+

--- a/test/types/records/init/no-default-init-generic-var.good
+++ b/test/types/records/init/no-default-init-generic-var.good
@@ -1,0 +1,3 @@
+no-default-init-generic-var.chpl:3: error: default initialization with type 'R(int(64))' is not yet supported
+no-default-init-generic-var.chpl:1: note: field 'genericField' is a generic value
+no-default-init-generic-var.chpl:1: note: consider separately declaring a type field for it or using a 'new' call

--- a/test/types/records/init/no-default-init-typeless.chpl
+++ b/test/types/records/init/no-default-init-typeless.chpl
@@ -1,0 +1,5 @@
+record R { var genericField; }
+
+var x: R(int); // ok
+writeln(x, " : ", x.type:string);
+

--- a/test/types/records/init/no-default-init-typeless.chpl
+++ b/test/types/records/init/no-default-init-typeless.chpl
@@ -1,5 +1,5 @@
 record R { var genericField; }
 
-var x: R(int); // ok
+var x: R(int); // error
 writeln(x, " : ", x.type:string);
 

--- a/test/types/records/init/no-default-init-typeless.good
+++ b/test/types/records/init/no-default-init-typeless.good
@@ -1,0 +1,3 @@
+no-default-init-typeless.chpl:3: error: default initialization with type 'R(int(64))' is not yet supported
+no-default-init-typeless.chpl:1: note: field 'genericField' is a generic value
+no-default-init-typeless.chpl:1: note: consider separately declaring a type field for it or using a 'new' call

--- a/test/types/records/with-runtime-types.bad
+++ b/test/types/records/with-runtime-types.bad
@@ -1,2 +1,5 @@
-(DDD = {1..3}, ARR = 5 5 5)
-with-runtime-types.chpl:11: error: default initialization of type containing array or domain type not yet implemented
+with-runtime-types.chpl:10: In function 'procp':
+with-runtime-types.chpl:11: error: default initialization with type 'RRR(domain(1,int(64),one))' is not yet supported
+with-runtime-types.chpl:6: note: field 'DDD' is a generic value
+with-runtime-types.chpl:6: note: consider separately declaring a type field for it or using a 'new' call
+  with-runtime-types.chpl:28: called as procp(type TTT = RRR(domain(1,int(64),one)))


### PR DESCRIPTION
For #16508.

This PR changes the behavior of examples like the below, when the type uses a compiler-generated default initializer:

``` chapel
record R { var genericField; }

var x: R(int); // was OK; now error

record U { var genericField: integral; }

var x: U(int); // was OK; now error
```

Historically, when faced with a default initialization like `var x: R(int)` above, the compiler would default initialize an `int` to pass as the value for `genericField`. However, it is worrying that this pattern default-initializes something without it being clear that the user has requested it. A further concern is that the default initializer should be possible for users to write, but this is a case where a user cannot write it. Additionally, a similar pattern was already producing a compilation error if the type has user-provided initializers. That makes sense, because it would be reasonable for a type author to assume that they could customize the default value of such a field, when in fact today, they cannot.

This PR changes the compiler to emit an error for default initialization of a record using the compiler-generated initializer a typeless or generic value field. The new error does not apply to `type` or `param` fields. Note that such patterns already generated an error when the type did not rely on the compiler-generated initializer. So, this PR makes this error apply also to the case of compiler-generated initializers.

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing