### PR TITLE
Application-level optimizations for the Coral Image Analysis code

### DIFF
--- a/test/gpu/native/studies/coral/coral.chpl
+++ b/test/gpu/native/studies/coral/coral.chpl
@@ -29,8 +29,8 @@ config const verbose_gpu = false;
 
 proc convolve_and_calculate(Array: [] real(32), centerPoints : ?, locL : ?, locC : ?, locR : ?, Output: [] real(64), t: stopwatch) : [] {
 
-  var bs = 1;
-  var be = 5;
+  param bs = 1;
+  param be = 5;
 
   var first_point = centerPoints.first[1];
   var last_point = centerPoints.last[1];

--- a/test/gpu/native/studies/coral/coral.chpl
+++ b/test/gpu/native/studies/coral/coral.chpl
@@ -57,7 +57,7 @@ proc convolve_and_calculate(Array: [] real(32), centerPoints : ?, locL : ?, locC
     calc_distance(Array, locC, locR, tmpCR, bs, be, i, first_point);
     calc_distance(Array, locR, locR, tmpRR, bs, be, i, first_point);
 
-    Output.localAccess[i,first_point] = (tmpLL + tmpCC + tmpRR + 2*(tmpLC + tmpLR + tmpCR)); // / (Mask_Size**2);
+    Output.localAccess[first_point,i] = (tmpLL + tmpCC + tmpRR + 2*(tmpLC + tmpLR + tmpCR)); // / (Mask_Size**2);
 
     //var Output = (tmpLL + tmpCC + tmpRR + 2*(tmpLC + tmpLR + tmpCR));
     var prev = tmpCC + tmpRR + 2*tmpCR;
@@ -78,7 +78,7 @@ proc convolve_and_calculate(Array: [] real(32), centerPoints : ?, locL : ?, locC
 
       /* Global GPU memory access causing ~20% slowdown? */
       var current = tmpRR + 2*(tmpLR + tmpCR);
-      Output.localAccess[i,j] = (prev + current); // / (Mask_Size**2);
+      Output.localAccess[j,i] = (prev + current); // / (Mask_Size**2);
 
       //Output = prev + current;
       prev = prev + current - tmpLL - 2*(tmpLC + tmpLR);
@@ -128,7 +128,7 @@ proc main(args: [] string) {
         x = 1000;
         y = 1000;
       }
-      const ImageSpace = {0..#x, 0..#y};
+      const ImageSpace = {0..#y, 0..#x};
 
 
       var Array : [1..5,1..y,1..x] real(32);

--- a/test/gpu/native/studies/coral/coral.chpl
+++ b/test/gpu/native/studies/coral/coral.chpl
@@ -96,7 +96,7 @@ proc main(args: [] string) {
   t.start();
 
   const radius = (sqrt(window_size) / 2) : int;
-  const nx = (radius / dx) : int;
+  const nx = (radius / dx) : int(16);
   writeln("Distance circle has a radius of ", nx, " points.");
   writeln("inputSize = ", inputSize);
 
@@ -112,7 +112,7 @@ proc main(args: [] string) {
     on here.gpus[0] {
 
       const radius = (sqrt(window_size) / 2) : int;
-      const nx = (radius / dx) : int;
+      const nx = (radius / dx) : int(16);
       writeln("Distance circle has a radius of ", nx, " points.");
 
       var x, y: int;

--- a/test/gpu/native/studies/coral/coral.gpu-compopts
+++ b/test/gpu/native/studies/coral/coral.gpu-compopts
@@ -1,1 +1,1 @@
--M modules
+-M modules --gpu-block-size=64

--- a/test/gpu/native/studies/coral/modules/distance_iter.chpl
+++ b/test/gpu/native/studies/coral/modules/distance_iter.chpl
@@ -8,7 +8,7 @@ inline proc calc_distance(Array : [] real(32), Mask1 : ?, Mask2 : ?,
 
       var tmp : real(32) = 0;
       for p in bs..be {
-        tmp += (Array[p,i+k,j+l]-Array[p,i+m,j+n])**2;
+        tmp += (Array[p,j+l,i+k]-Array[p,j+n,i+m])**2;
       }
 
       Output_tmp += sqrt(tmp);

--- a/test/gpu/native/studies/coral/modules/distance_iter.chpl
+++ b/test/gpu/native/studies/coral/modules/distance_iter.chpl
@@ -1,13 +1,13 @@
 inline proc calc_distance(Array : [] real(32), Mask1 : ?, Mask2 : ?,
-                          inout Output_tmp : real(64), bs : int, be : int,
-                          i : int, j : int) {
+                          inout Output_tmp : real(64), param bs : int,
+                          param be : int, i : int, j : int) {
   for (k,l) in Mask1 {
     for (m,n) in Mask2 {
 
       var dist : real(32) = 0;
 
       var tmp : real(32) = 0;
-      for p in bs..be {
+      for param p in bs..be {
         tmp += (Array[p,j+l,i+k]-Array[p,j+n,i+m])**2;
       }
 

--- a/test/gpu/native/studies/coral/modules/distance_mask.chpl
+++ b/test/gpu/native/studies/coral/modules/distance_mask.chpl
@@ -1,8 +1,8 @@
 module distance_mask {
 
-proc create_distance_mask(radius : real, dx : real, nx : int) {
+proc create_distance_mask(radius : real, dx : real, nx : int(16)) {
 
-  const D : domain(2, int) = {-nx..nx, -nx..nx};
+  const D : domain(2, int(16)) = {-nx..nx, -nx..nx};
   var D_center : sparse subdomain(D);
   var D_left : sparse subdomain(D);
   var D_right : sparse subdomain(D);


### PR DESCRIPTION
This PR patches the Coral Image Analysis GPU performance test to have some of the application level optimizations that I had developed in the past. https://github.com/Cray/chapel-private/issues/4827 has the detailed discussion on those optimizations. But the summary is:

(All performance results are with 8000x8000 input with windowSize 100. V100 was the GPU used)

1. Reduce block size to 64: The kernel is relatively large and requires a lot of registers. If you have a lot of threads within a block (threads in the same block share the same physical memory for registers and L1), you end up thrashing registers a lot. (~3.2x improvement over base)
2. Transpose input array: Without transposing the input, GPU threads read sequential data individually, which is intuitive for CPUs. But you want to coalesce memory accesses by making consecutive threads read consecutive data. Note that there's no thread divergence in GPUs, so if two neighbor threads read two cache lines, that's a stall. (~2.8x improvement over (1))
3. Param unroll inner loop: this loop is guaranteed to trip 5 times. There *may* be changes down the road, but the trip count is inherent to the application (known at compile time) and will surely remain in single digits. (~1.1x improvement over (2))
4. Use smaller indices for the mask: The mask is a 2D sparse domain. For any astronomically high but realistic window size, 16-bit should be enough. This reduces the memory usage by simply storing less data. Probably leads to better cache utilization. (~1.1x improvement over (3))

The test passes both correctness and performance testing on nvidia.