### PR TITLE
Revert back to using GB/s in gpu performance tests

### DIFF
--- a/test/gpu/native/studies/gpuArrayOps/gpuArrayOps.chpl
+++ b/test/gpu/native/studies/gpuArrayOps/gpuArrayOps.chpl
@@ -20,7 +20,11 @@ proc stopTest(name, bandwidth=false) {
   if reportTime {
     t.stop();
     if bandwidth then
-      writeln(name, " (GiB/s): ", n*numBytes(int)/t.elapsed()/1e9);
+      // GiB/s is the precise metric here. However, GB/s can be used
+      // interchangably and that's how we started testing. Changing it confuses
+      // the test system.  Note that we report this as GiB/s in the relevant
+      // plot.
+      writeln(name, " (GB/s): ", n*numBytes(int)/t.elapsed()/1e9);
     else
       writeln(name, " (s): ", t.elapsed());
     t.clear();

--- a/test/gpu/native/studies/gpuArrayOps/gpuArrayOps.gpu-keys
+++ b/test/gpu/native/studies/gpuArrayOps/gpuArrayOps.gpu-keys
@@ -1,4 +1,4 @@
 Cpu Array Init (s): 
 Gpu Array Init (s):
-host to device copy (GiB/s):
-device to host copy (GiB/s):
+host to device copy (GB/s):
+device to host copy (GB/s):

--- a/test/gpu/native/studies/gpuArrayOps/gpuArrayOps.graph
+++ b/test/gpu/native/studies/gpuArrayOps/gpuArrayOps.graph
@@ -5,7 +5,7 @@ ylabel: Time (s)
 graphtitle: Array Initialization (100M ints)
 
 
-perfkeys: host to device copy (GiB/s):, device to host copy (GiB/s):, device to host copy (GiB/s):
+perfkeys: host to device copy (GB/s):, device to host copy (GB/s):, device to host copy (GB/s):
 files: gpuArrayOps-d2h-from-h, gpuArrayOps-d2h-from-h, gpuArrayOps-d2h-from-d
 graphkeys: Host-to-Device, Device-to-Host (host touch last), Device-to-Host (device touch last),
 ylabel: Bandwidth (GiB/s)

--- a/test/gpu/native/studies/transpose/transpose-throughput.graph
+++ b/test/gpu/native/studies/transpose/transpose-throughput.graph
@@ -1,4 +1,4 @@
-perfkeys: Performance (GiB/s):, Performance (GiB/s):, Performance (GiB/s):
+perfkeys: Performance (GB/s):, Performance (GB/s):, Performance (GB/s):
 files: transpose-lowlevel.dat, transpose-naive.dat, transpose-clever.dat
 graphkeys: Low Level, Naive, Clever
 ylabel: Throughput (GiB/s)

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -28,8 +28,6 @@ config param blockSize = 16;
 config param blockPadding = 1;
 config type dataType = real(32);
 
-config const SI = true;
-
 inline proc transposeNaive(original, output) {
   foreach (x,y) in original.domain {
     assertOnGpu();
@@ -154,17 +152,12 @@ var elapsed = timer.elapsed() / numTrials;
 if perftest {
 var sizeInBytes = originalHost.size * numBytes(dataType);
   writeln("Wall clock time (s): ", elapsed);
-  if SI {
-    var sizeInGib = sizeInBytes / (1000.0 * 1000.0 * 1000.0);
-    var gibPerSec = sizeInGib / elapsed;
-    writeln("Performance (GiB/s): ", gibPerSec);
-  }
-  else {
-    var sizeInGb = sizeInBytes / (1<<30):real;
-    var gbPerSec = sizeInGb / elapsed;
-    writeln("Performance (GB/s): ", gbPerSec);
-
-  }
+  var sizeInGb = sizeInBytes / (1000.0 * 1000.0 * 1000.0);
+  var gibPerSec = sizeInGb / elapsed;
+  // GiB/s is the precise metric here. However, GB/s can be used interchangably
+  // and that's how we started testing. Changing it confuses the test system.
+  // Note that we report this as GiB/s in the relevant plot.
+  writeln("Performance (GB/s): ", gibPerSec);
 }
 
 var passed = true;

--- a/test/gpu/native/studies/transpose/transpose.gpu-keys
+++ b/test/gpu/native/studies/transpose/transpose.gpu-keys
@@ -1,4 +1,4 @@
 Wall clock time (s): 
-Performance (GiB/s): 
+Performance (GB/s): 
 verify: Passed
 reject: Failed


### PR DESCRIPTION
Further fallout from test changes. I switched to reporting `GiB/s` instead of `GB/s` but we already have performance data with `GB/s`. This PR reverts back to GB/s while reporting. But the generated plot will have `GiB/s` in its y-axis label. I also add some comments about the units.

Tests pass under correctness and performance settings.