### PR TITLE
Link bitcode device libraries before the optimization pipeline

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4623,6 +4623,7 @@ void makeBinaryLLVM(void) {
       case GpuCodegenType::GPU_CG_CPU:
         break;
     }
+    linkGpuDeviceLibraries();
   }
 
   saveIrToBcFileIfNeeded(preOptFilename);
@@ -4836,8 +4837,6 @@ void makeBinaryLLVM(void) {
     } else {
 
       auto artifactFileType = getCodeGenFileType();
-
-      linkGpuDeviceLibraries();
 
       llvm::raw_fd_ostream outputArtifactFile(artifactFilename, error, flags);
 


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/22112.

This PR has to be merged after https://github.com/chapel-lang/chapel/pull/22840 as it resolves a bug that this bumps into.

Today, we link device bitcode library after the optimization pipeline is run. This means we are missing crucial optimization opportunities around functions in device libraries. At least for nvidia, these are math and bit operation functions. One of those optimization opportunities is inlining, and the fact that we were missing it was reported in #22112. Later on @milthorpe also confirmed that this had noticeable impact on miniBUDE performance on GPU.

This PR moves bitcode device library linking early in compilation to benefit from the optimizations in our standard optimization pipeline. I have some vague memories of trying this in the past and failing. I bet the issue resolved with #22840 was the blocker.

With this PR:


  | main (time) | PR (time) | improvement (x)
-- | -- | -- | --
miniBUDE (ms/iter) | 35.03 | 20.79 | 1.68
coral (after #22838) (s) | 1.91 | 1.56 | 1.22

Test:
- [x] nvidia
- [x] amd


