### PR TITLE
Remove extra string cast from `map`

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -401,7 +401,7 @@ module Map {
 
       var (_, slot) = table.findAvailableSlot(k);
       if !table.isSlotFull(slot) {
-        throw new KeyNotFoundError(k:string);
+        throw new KeyNotFoundError(k);
       }
       ref result = table.table[slot].val;
       return result;


### PR DESCRIPTION
Removes the potential for a deprecation warning when accessing a map of a non-primitive key type.

The `Map` module's `KeyNotFoundError` uses `string.format` to create error message for keys of any type. However, one of map's `this` assessors was casting the key to string when creating a `KeyNotFoundError`, which can create a deprecation warning as of https://github.com/chapel-lang/chapel/pull/22068. This PR removes that cast.

- [ ] paratest