### PR TITLE
Switch to calling `write` instead of `writeIt` for FCFs

### DIFF
--- a/compiler/resolution/fcf-support.cpp
+++ b/compiler/resolution/fcf-support.cpp
@@ -678,7 +678,7 @@ attachChildWriteMethod(const SharedFcfSuperInfo info,
   ret->body->useListAdd(new UseStmt(ioModule, "", false));
   ret->getModule()->moduleUseAdd(ioModule);
   auto str = new_StringSymbol(astr(payload->name, "()"));
-  auto writeCall = new CallExpr(".", fileArg, new_StringSymbol("writeIt"),
+  auto writeCall = new CallExpr(".", fileArg, new_StringSymbol("write"),
                                 str);
   ret->insertAtTail(new CallExpr(writeCall));
   normalize(ret);


### PR DESCRIPTION
With the serializer implementation, FCFs were being printed in the JSON serializer without `"`s, which made it invalid JSON. This was caught while converting Arkouda to use the new serializers. This PR switches the compiler to call `write` instead of `writeIt` for FCFs.

- [x] paratest
- [x] arkouda testing