### PR TITLE
Avoid lvalue error in inv-test.chpl

### DIFF
--- a/test/library/packages/LinearAlgebra/correctness/inv-test.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/inv-test.chpl
@@ -15,7 +15,8 @@ proc sinMatrix(n) {
   return A;
 }
 
-writeln(inv(sinMatrix(n)));
+var B = sinMatrix(n);
+writeln(inv(B));
 writeln();
 
 var A = sinMatrix(n);


### PR DESCRIPTION
Adjusts a test to adapt to the new error from PR #22816.

Test change only - not reviewed.