### PR TITLE
Stabilize atomic formal and type names

### DIFF
--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -24,15 +24,18 @@ module NetworkAtomics {
   private use MemConsistency;
   private use CTypes;
 
-  private proc externFunc(param s: string, type T) param {
-    if isInt(T)  then return "chpl_comm_atomic_" + s + "_int"  + numBits(T):string;
-    if isUint(T) then return "chpl_comm_atomic_" + s + "_uint" + numBits(T):string;
-    if isReal(T) then return "chpl_comm_atomic_" + s + "_real" + numBits(T):string;
+  private proc externFunc(param s: string, type valType) param {
+    if isInt(valType)  then return "chpl_comm_atomic_" + s + "_int"  + numBits(valType):string;
+    if isUint(valType) then return "chpl_comm_atomic_" + s + "_uint" + numBits(valType):string;
+    if isReal(valType) then return "chpl_comm_atomic_" + s + "_real" + numBits(valType):string;
   }
 
   pragma "atomic type"
   pragma "ignore noinit"
   record RAtomicBool {
+    proc type valType type { return bool; }
+    proc valType type { return bool; }
+
     var _v: int(64);
 
     proc init=(other:RAtomicBool) {
@@ -60,20 +63,20 @@ module NetworkAtomics {
       return ret:bool;
     }
 
-    inline proc write(value:bool, param order: memoryOrder = memoryOrder.seqCst): void {
+    inline proc write(val:bool, param order: memoryOrder = memoryOrder.seqCst): void {
       pragma "insert line file info" extern externFunc("write", int(64))
         proc atomic_write(ref desired:int(64), l:int(32), obj:c_ptr(void), order:memory_order): void;
 
-      var v = value:int(64);
+      var v = val:int(64);
       atomic_write(v, _localeid(), _addr(), c_memory_order(order));
     }
 
-    inline proc exchange(value:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
+    inline proc exchange(val:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
       pragma "insert line file info" extern externFunc("xchg", int(64))
         proc atomic_xchg(ref desired:int(64), l:int(32), obj:c_ptr(void), ref result:int(64), order:memory_order): void;
 
       var ret:int(64);
-      var v = value:int(64);
+      var v = val:int(64);
       atomic_xchg(v, _localeid(), _addr(), ret, c_memory_order(order));
       return ret:bool;
     }
@@ -119,9 +122,9 @@ module NetworkAtomics {
       this.write(false, order);
     }
 
-    inline proc const waitFor(value:bool, param order: memoryOrder = memoryOrder.seqCst): void {
+    inline proc const waitFor(val:bool, param order: memoryOrder = memoryOrder.seqCst): void {
       on this {
-        while (this.read(order=memoryOrder.relaxed) != value) {
+        while (this.read(order=memoryOrder.relaxed) != val) {
           chpl_task_yield();
         }
         chpl_atomic_thread_fence(c_memory_order(order));
@@ -142,16 +145,16 @@ module NetworkAtomics {
   pragma "atomic type"
   pragma "ignore noinit"
   record RAtomicT {
-    type T;
-    var _v: T;
+    type valType;
+    var _v: valType;
 
     proc init=(other:this.type) {
-      this.T = other.T;
+      this.valType = other.valType;
       this._v = other.read();
     }
 
-    proc init=(other:this.type.T) {
-      this.T = other.type;
+    proc init=(other:this.type.valType) {
+      this.valType = other.type;
       this._v = other;
     }
 
@@ -163,39 +166,39 @@ module NetworkAtomics {
       return __primitive("_wide_get_addr", _v);
     }
 
-    inline proc const read(param order: memoryOrder = memoryOrder.seqCst): T {
-      pragma "insert line file info" extern externFunc("read", T)
-        proc atomic_read(ref result:T, l:int(32), const obj:c_ptr(void), order:memory_order): void;
+    inline proc const read(param order: memoryOrder = memoryOrder.seqCst): valType {
+      pragma "insert line file info" extern externFunc("read", valType)
+        proc atomic_read(ref result:valType, l:int(32), const obj:c_ptr(void), order:memory_order): void;
 
-      var ret:T;
+      var ret:valType;
       atomic_read(ret, _localeid(), _addr(), c_memory_order(order));
       return ret;
     }
 
-    inline proc write(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
-      pragma "insert line file info" extern externFunc("write", T)
-        proc atomic_write(ref desired:T, l:int(32), obj:c_ptr(void), order:memory_order): void;
+    inline proc write(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
+      pragma "insert line file info" extern externFunc("write", valType)
+        proc atomic_write(ref desired:valType, l:int(32), obj:c_ptr(void), order:memory_order): void;
 
-      var v = value;
+      var v = val;
       atomic_write(v, _localeid(), _addr(), c_memory_order(order));
     }
 
-    inline proc exchange(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
-      pragma "insert line file info" extern externFunc("xchg", T)
-        proc atomic_xchg(ref desired:T, l:int(32), obj:c_ptr(void), ref result:T, order:memory_order): void;
+    inline proc exchange(val:valType, param order: memoryOrder = memoryOrder.seqCst): valType {
+      pragma "insert line file info" extern externFunc("xchg", valType)
+        proc atomic_xchg(ref desired:valType, l:int(32), obj:c_ptr(void), ref result:valType, order:memory_order): void;
 
-      var ret:T;
-      var v = value;
+      var ret:valType;
+      var v = val;
       atomic_xchg(v, _localeid(), _addr(), ret, c_memory_order(order));
       return ret;
     }
 
-    inline proc compareExchange(ref expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
+    inline proc compareExchange(ref expected:valType, desired:valType, param order: memoryOrder = memoryOrder.seqCst): bool {
       return this.compareExchange(expected, desired, order, readableOrder(order));
     }
-    inline proc compareExchange(ref expected:T, desired:T, param success: memoryOrder, param failure: memoryOrder): bool {
-      pragma "insert line file info" extern externFunc("cmpxchg", T)
-        proc atomic_cmpxchg(ref expected:T, ref desired:T, l:int(32), obj:c_ptr(void), ref result:uint(32), succ:memory_order, fail:memory_order): void;
+    inline proc compareExchange(ref expected:valType, desired:valType, param success: memoryOrder, param failure: memoryOrder): bool {
+      pragma "insert line file info" extern externFunc("cmpxchg", valType)
+        proc atomic_cmpxchg(ref expected:valType, ref desired:valType, l:int(32), obj:c_ptr(void), ref result:uint(32), succ:memory_order, fail:memory_order): void;
 
       var te = expected;
       var ret:uint(32);
@@ -205,16 +208,16 @@ module NetworkAtomics {
       return ret:bool;
     }
 
-    inline proc compareExchangeWeak(ref expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
+    inline proc compareExchangeWeak(ref expected:valType, desired:valType, param order: memoryOrder = memoryOrder.seqCst): bool {
       return this.compareExchange(expected, desired, order);
     }
-    inline proc compareExchangeWeak(ref expected:T, desired:T, param success: memoryOrder, param failure: memoryOrder): bool {
+    inline proc compareExchangeWeak(ref expected:valType, desired:valType, param success: memoryOrder, param failure: memoryOrder): bool {
       return this.compareExchange(expected, desired, success, failure);
     }
 
-    inline proc compareAndSwap(expected:T, desired:T, param order: memoryOrder = memoryOrder.seqCst): bool {
-      pragma "insert line file info" extern externFunc("cmpxchg", T)
-        proc atomic_cmpxchg(ref expected:T, ref desired:T, l:int(32), obj:c_ptr(void), ref result:uint(32), succ:memory_order, fail:memory_order): void;
+    inline proc compareAndSwap(expected:valType, desired:valType, param order: memoryOrder = memoryOrder.seqCst): bool {
+      pragma "insert line file info" extern externFunc("cmpxchg", valType)
+        proc atomic_cmpxchg(ref expected:valType, ref desired:valType, l:int(32), obj:c_ptr(void), ref result:uint(32), succ:memory_order, fail:memory_order): void;
 
       var ret:uint(32);
       var te = expected;
@@ -223,105 +226,105 @@ module NetworkAtomics {
       return ret:bool;
     }
 
-    inline proc fetchAdd(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
-      pragma "insert line file info" extern externFunc("fetch_add", T)
-        proc atomic_fetch_add(ref op:T, l:int(32), obj:c_ptr(void), ref result:T, order:memory_order): void;
+    inline proc fetchAdd(val:valType, param order: memoryOrder = memoryOrder.seqCst): valType {
+      pragma "insert line file info" extern externFunc("fetch_add", valType)
+        proc atomic_fetch_add(ref op:valType, l:int(32), obj:c_ptr(void), ref result:valType, order:memory_order): void;
 
-      var ret:T;
-      var v = value;
+      var ret:valType;
+      var v = val;
       atomic_fetch_add(v, _localeid(), _addr(), ret, c_memory_order(order));
       return ret;
     }
 
-    inline proc add(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
-      pragma "insert line file info" extern externFunc("add", T)
-        proc atomic_add(ref op:T, l:int(32), obj:c_ptr(void), order:memory_order): void;
+    inline proc add(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
+      pragma "insert line file info" extern externFunc("add", valType)
+        proc atomic_add(ref op:valType, l:int(32), obj:c_ptr(void), order:memory_order): void;
 
-      var v = value;
+      var v = val;
       atomic_add(v, _localeid(), _addr(), c_memory_order(order));
     }
 
-    inline proc fetchSub(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
-      pragma "insert line file info" extern externFunc("fetch_sub", T)
-        proc atomic_fetch_sub(ref op:T, l:int(32), obj:c_ptr(void), ref result:T, order:memory_order): void;
+    inline proc fetchSub(val:valType, param order: memoryOrder = memoryOrder.seqCst): valType {
+      pragma "insert line file info" extern externFunc("fetch_sub", valType)
+        proc atomic_fetch_sub(ref op:valType, l:int(32), obj:c_ptr(void), ref result:valType, order:memory_order): void;
 
-      var ret:T;
-      var v = value;
+      var ret:valType;
+      var v = val;
       atomic_fetch_sub(v, _localeid(), _addr(), ret, c_memory_order(order));
       return ret;
     }
 
-    inline proc sub(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
-      pragma "insert line file info" extern externFunc("sub", T)
-        proc atomic_sub(ref op:T, l:int(32), obj:c_ptr(void), order:memory_order): void;
+    inline proc sub(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
+      pragma "insert line file info" extern externFunc("sub", valType)
+        proc atomic_sub(ref op:valType, l:int(32), obj:c_ptr(void), order:memory_order): void;
 
-      var v = value;
+      var v = val;
       atomic_sub(v, _localeid(), _addr(), c_memory_order(order));
     }
 
-    inline proc fetchOr(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
-      if !isIntegral(T) then compilerError("fetchOr is only defined for integer atomic types");
-      pragma "insert line file info" extern externFunc("fetch_or", T)
-        proc atomic_fetch_or(ref op:T, l:int(32), obj:c_ptr(void), ref result:T, order:memory_order): void;
+    inline proc fetchOr(val:valType, param order: memoryOrder = memoryOrder.seqCst): valType {
+      if !isIntegral(valType) then compilerError("fetchOr is only defined for integer atomic types");
+      pragma "insert line file info" extern externFunc("fetch_or", valType)
+        proc atomic_fetch_or(ref op:valType, l:int(32), obj:c_ptr(void), ref result:valType, order:memory_order): void;
 
-      var ret:T;
-      var v = value;
+      var ret:valType;
+      var v = val;
       atomic_fetch_or(v, _localeid(), _addr(), ret, c_memory_order(order));
       return ret;
     }
 
-    inline proc or(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
-      if !isIntegral(T) then compilerError("or is only defined for integer atomic types");
-      pragma "insert line file info" extern externFunc("or", T)
-        proc atomic_or(ref op:T, l:int(32), obj:c_ptr(void), order:memory_order): void;
+    inline proc or(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
+      if !isIntegral(valType) then compilerError("or is only defined for integer atomic types");
+      pragma "insert line file info" extern externFunc("or", valType)
+        proc atomic_or(ref op:valType, l:int(32), obj:c_ptr(void), order:memory_order): void;
 
-      var v = value;
+      var v = val;
       atomic_or(v, _localeid(), _addr(), c_memory_order(order));
     }
 
-    inline proc fetchAnd(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
-      if !isIntegral(T) then compilerError("fetchAnd is only defined for integer atomic types");
-      pragma "insert line file info" extern externFunc("fetch_and", T)
-        proc atomic_fetch_and(ref op:T, l:int(32), obj:c_ptr(void), ref result:T, order:memory_order): void;
+    inline proc fetchAnd(val:valType, param order: memoryOrder = memoryOrder.seqCst): valType {
+      if !isIntegral(valType) then compilerError("fetchAnd is only defined for integer atomic types");
+      pragma "insert line file info" extern externFunc("fetch_and", valType)
+        proc atomic_fetch_and(ref op:valType, l:int(32), obj:c_ptr(void), ref result:valType, order:memory_order): void;
 
-      var ret:T;
-      var v = value;
+      var ret:valType;
+      var v = val;
       atomic_fetch_and(v, _localeid(), _addr(), ret, c_memory_order(order));
       return ret;
     }
 
-    inline proc and(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
-      if !isIntegral(T) then compilerError("and is only defined for integer atomic types");
-      pragma "insert line file info" extern externFunc("and", T)
-        proc atomic_and(ref op:T, l:int(32), obj:c_ptr(void), order:memory_order): void;
+    inline proc and(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
+      if !isIntegral(valType) then compilerError("and is only defined for integer atomic types");
+      pragma "insert line file info" extern externFunc("and", valType)
+        proc atomic_and(ref op:valType, l:int(32), obj:c_ptr(void), order:memory_order): void;
 
-      var v = value;
+      var v = val;
       atomic_and(v, _localeid(), _addr(), c_memory_order(order));
     }
 
-    inline proc fetchXor(value:T, param order: memoryOrder = memoryOrder.seqCst): T {
-      if !isIntegral(T) then compilerError("fetchXor is only defined for integer atomic types");
-      pragma "insert line file info" extern externFunc("fetch_xor", T)
-        proc atomic_fetch_xor(ref op:T, l:int(32), obj:c_ptr(void), ref result:T, order:memory_order): void;
+    inline proc fetchXor(val:valType, param order: memoryOrder = memoryOrder.seqCst): valType {
+      if !isIntegral(valType) then compilerError("fetchXor is only defined for integer atomic types");
+      pragma "insert line file info" extern externFunc("fetch_xor", valType)
+        proc atomic_fetch_xor(ref op:valType, l:int(32), obj:c_ptr(void), ref result:valType, order:memory_order): void;
 
-      var ret:T;
-      var v = value;
+      var ret:valType;
+      var v = val;
       atomic_fetch_xor(v, _localeid(), _addr(), ret, c_memory_order(order));
       return ret;
     }
 
-    inline proc xor(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
-      if !isIntegral(T) then compilerError("xor is only defined for integer atomic types");
-      pragma "insert line file info" extern externFunc("xor", T)
-        proc atomic_xor(ref op:T, l:int(32), obj:c_ptr(void), order:memory_order): void;
+    inline proc xor(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
+      if !isIntegral(valType) then compilerError("xor is only defined for integer atomic types");
+      pragma "insert line file info" extern externFunc("xor", valType)
+        proc atomic_xor(ref op:valType, l:int(32), obj:c_ptr(void), order:memory_order): void;
 
-      var v = value;
+      var v = val;
       atomic_xor(v, _localeid(), _addr(), c_memory_order(order));
     }
 
-    inline proc const waitFor(value:T, param order: memoryOrder = memoryOrder.seqCst): void {
+    inline proc const waitFor(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
       on this {
-        while (this.read(order=memoryOrder.relaxed) != value) {
+        while (this.read(order=memoryOrder.relaxed) != val) {
           chpl_task_yield();
         }
         chpl_atomic_thread_fence(c_memory_order(order));
@@ -335,7 +338,7 @@ module NetworkAtomics {
   }
 
   operator :(rhs, type t:RAtomicT)
-  where rhs.type == t.T {
+  where rhs.type == t.valType {
     var lhs: t = rhs; // use init=
     return lhs;
   }

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -195,7 +195,7 @@ file="./Atomics.rst"
 removePrefixFunctions $file
 
 replace "record:: AtomicBool" "type:: atomic \(bool\)" $file
-replace "record:: AtomicT"    "type:: atomic \(T\)" $file
+replace "record:: AtomicT"    "type:: atomic \(valType\)" $file
 
 removeTitle $file
 removeUsage $file

--- a/modules/packages/PeekPoke.chpl
+++ b/modules/packages/PeekPoke.chpl
@@ -56,37 +56,37 @@ module PeekPoke {
   }
 
   /*
-     Non-atomically writes `value`.
+     Non-atomically writes `val`.
   */
-  inline proc AtomicBool.poke(value:bool): void {
-    this.write(value, order=memoryOrder.relaxed);
+  inline proc AtomicBool.poke(val:bool): void {
+    this.write(val, order=memoryOrder.relaxed);
   }
   @chpldoc.nodoc
-  inline proc RAtomicBool.poke(value:bool): void {
-    _v = value:int(64);
+  inline proc RAtomicBool.poke(val:bool): void {
+    _v = val:int(64);
   }
 
 
   /*
      Non-atomically reads the stored value.
   */
-  inline proc const AtomicT.peek(): T {
+  inline proc const AtomicT.peek(): valType {
     return this.read(order=memoryOrder.relaxed);
   }
   @chpldoc.nodoc
-  inline proc const RAtomicT.peek(): T {
+  inline proc const RAtomicT.peek(): valType {
     return _v;
   }
 
 
   /*
-     Non-atomically writes `value`.
+     Non-atomically writes `val`.
   */
-  inline proc AtomicT.poke(value:T): void {
-    this.write(value, order=memoryOrder.relaxed);
+  inline proc AtomicT.poke(val:valType): void {
+    this.write(val, order=memoryOrder.relaxed);
   }
   @chpldoc.nodoc
-  inline proc RAtomicT.poke(value:T): void {
-    _v = value;
+  inline proc RAtomicT.poke(val:valType): void {
+    _v = val;
   }
 }

--- a/modules/packages/UnorderedAtomics.chpl
+++ b/modules/packages/UnorderedAtomics.chpl
@@ -79,77 +79,77 @@
  */
 module UnorderedAtomics {
 
-  private proc externFunc(param s: string, type T) param {
-    if isInt(T)  then return "chpl_comm_atomic_" + s + "_int"  + numBits(T):string;
-    if isUint(T) then return "chpl_comm_atomic_" + s + "_uint" + numBits(T):string;
-    if isReal(T) then return "chpl_comm_atomic_" + s + "_real" + numBits(T):string;
+  private proc externFunc(param s: string, type valType) param {
+    if isInt(valType)  then return "chpl_comm_atomic_" + s + "_int"  + numBits(valType):string;
+    if isUint(valType) then return "chpl_comm_atomic_" + s + "_uint" + numBits(valType):string;
+    if isReal(valType) then return "chpl_comm_atomic_" + s + "_real" + numBits(valType):string;
   }
 
   /* Unordered atomic add. */
-  inline proc AtomicT.unorderedAdd(value:T): void {
-    this.add(value);
+  inline proc AtomicT.unorderedAdd(val:valType): void {
+    this.add(val);
   }
   @chpldoc.nodoc
-  inline proc RAtomicT.unorderedAdd(value:T): void {
-    pragma "insert line file info" extern externFunc("add_unordered", T)
-      proc atomic_add_unordered(ref op:T, l:int(32), obj:c_ptr(void)): void;
+  inline proc RAtomicT.unorderedAdd(val:valType): void {
+    pragma "insert line file info" extern externFunc("add_unordered", valType)
+      proc atomic_add_unordered(ref op:valType, l:int(32), obj:c_ptr(void)): void;
 
-    var v = value;
+    var v = val;
     atomic_add_unordered(v, _localeid(), _addr());
   }
 
   /* Unordered atomic sub. */
-  inline proc AtomicT.unorderedSub(value:T): void {
-    this.sub(value);
+  inline proc AtomicT.unorderedSub(val:valType): void {
+    this.sub(val);
   }
   @chpldoc.nodoc
-  inline proc RAtomicT.unorderedSub(value:T): void {
-    pragma "insert line file info" extern externFunc("sub_unordered", T)
-      proc atomic_sub_unordered(ref op:T, l:int(32), obj:c_ptr(void)): void;
+  inline proc RAtomicT.unorderedSub(val:valType): void {
+    pragma "insert line file info" extern externFunc("sub_unordered", valType)
+      proc atomic_sub_unordered(ref op:valType, l:int(32), obj:c_ptr(void)): void;
 
-    var v = value;
+    var v = val;
     atomic_sub_unordered(v, _localeid(), _addr());
   }
 
   /* Unordered atomic or. */
-  inline proc AtomicT.unorderedOr(value:T): void {
-    this.or(value);
+  inline proc AtomicT.unorderedOr(val:valType): void {
+    this.or(val);
   }
   @chpldoc.nodoc
-  inline proc RAtomicT.unorderedOr(value:T): void {
-    if !isIntegral(T) then compilerError("or is only defined for integer atomic types");
-    pragma "insert line file info" extern externFunc("or_unordered", T)
-      proc atomic_or_unordered(ref op:T, l:int(32), obj:c_ptr(void)): void;
+  inline proc RAtomicT.unorderedOr(val:valType): void {
+    if !isIntegral(valType) then compilerError("or is only defined for integer atomic types");
+    pragma "insert line file info" extern externFunc("or_unordered", valType)
+      proc atomic_or_unordered(ref op:valType, l:int(32), obj:c_ptr(void)): void;
 
-    var v = value;
+    var v = val;
     atomic_or_unordered(v, _localeid(), _addr());
   }
 
   /* Unordered atomic and. */
-  inline proc AtomicT.unorderedAnd(value:T): void {
-    this.and(value);
+  inline proc AtomicT.unorderedAnd(val:valType): void {
+    this.and(val);
   }
   @chpldoc.nodoc
-  inline proc RAtomicT.unorderedAnd(value:T): void {
-    if !isIntegral(T) then compilerError("and is only defined for integer atomic types");
-    pragma "insert line file info" extern externFunc("and_unordered", T)
-      proc atomic_and_unordered(ref op:T, l:int(32), obj:c_ptr(void)): void;
+  inline proc RAtomicT.unorderedAnd(val:valType): void {
+    if !isIntegral(valType) then compilerError("and is only defined for integer atomic types");
+    pragma "insert line file info" extern externFunc("and_unordered", valType)
+      proc atomic_and_unordered(ref op:valType, l:int(32), obj:c_ptr(void)): void;
 
-    var v = value;
+    var v = val;
     atomic_and_unordered(v, _localeid(), _addr());
   }
 
   /* Unordered atomic xor. */
-  inline proc AtomicT.unorderedXor(value:T): void {
-    this.xor(value);
+  inline proc AtomicT.unorderedXor(val:valType): void {
+    this.xor(val);
   }
   @chpldoc.nodoc
-  inline proc RAtomicT.unorderedXor(value:T): void {
-    if !isIntegral(T) then compilerError("xor is only defined for integer atomic types");
-    pragma "insert line file info" extern externFunc("xor_unordered", T)
-      proc atomic_xor_unordered(ref op:T, l:int(32), obj:c_ptr(void)): void;
+  inline proc RAtomicT.unorderedXor(val:valType): void {
+    if !isIntegral(valType) then compilerError("xor is only defined for integer atomic types");
+    pragma "insert line file info" extern externFunc("xor_unordered", valType)
+      proc atomic_xor_unordered(ref op:valType, l:int(32), obj:c_ptr(void)): void;
 
-    var v = value;
+    var v = val;
     atomic_xor_unordered(v, _localeid(), _addr());
   }
 

--- a/test/compflags/vass/callstack-internal-modules.d+s+.good
+++ b/test/compflags/vass/callstack-internal-modules.d+s+.good
@@ -1,5 +1,5 @@
 $CHPL_HOME/modules/internal/Atomics.chpl:nnnn: In function 'chpl__atomicType':
 $CHPL_HOME/modules/internal/Atomics.chpl:nnnn: error: Unsupported atomic type: string
-  callstack-internal-modules.chpl:28: called as chpl__atomicType(type T = string) from function 'foo'
+  callstack-internal-modules.chpl:28: called as chpl__atomicType(type valType = string) from function 'foo'
   callstack-internal-modules.chpl:24: called as foo() from function 'bar'
   callstack-internal-modules.chpl:20: called as bar() from function 'main'

--- a/test/runtime/configMatters/comm/AtomicsAPI.chpl
+++ b/test/runtime/configMatters/comm/AtomicsAPI.chpl
@@ -20,12 +20,14 @@ proc asyncSet(a) { begin { a.write(true); } }
 proc testAtomicBool(a, ref i, ref b) {
   param t = true, f = false;
 
-  writeln("Testing 'atomic bool':");
+  writeln("Testing '", a.type:string, "':");
                                                                 writea  ("init    ", a);
                 var initval : a.type = true;                    writeai ("init=   ", a, initval);
                 var initval2 : a.type = initval;                writeai ("init=(v)", a, initval2);
                 var initval3 = initval;                         writeai ("init=(v)", a, initval3);
                 assert(initval3.type == atomic bool);
+                assert(a.valType == bool);
+                assert(a.type.valType == bool);
                 i = a.read();                                   writeai ("read    ", a, i);
                     a.write(t);                                 writea  ("write   ", a);
                 i = a.exchange(f);                              writeai ("xchg    ", a, i);
@@ -45,12 +47,14 @@ proc testAtomicBool(a, ref i, ref b) {
 proc testOrderAtomicBool(a, ref i, ref b, param o: memoryOrder) {
   param t = true, f = false;
 
-  writeln("Testing 'atomic bool' with order '", o, "':");
+  writeln("Testing '", a.type:string, "' with order '", o, "':");
                                                                      writea  ("init    ", a);
                 var initval : a.type = true;                         writeai ("init=   ", a, initval);
                 var initval2 : a.type = initval;                     writeai ("init=(v)", a, initval2);
                 var initval3 = initval;                              writeai ("init=(v)", a, initval3);
                 assert(initval3.type == atomic bool);
+                assert(a.valType == bool);
+                assert(a.type.valType == bool);
                 i = a.read(o);                                       writeai ("read    ", a, i);
                     a.write(t, o);                                   writea  ("write   ", a);
                 i = a.exchange(f, o);                                writeai ("xchg    ", a, i);
@@ -72,22 +76,26 @@ proc testOrderAtomicBool(a, ref i, ref b, param o: memoryOrder) {
 }
 
 proc asyncAdd(a) { begin { a.add(1); } }
-proc testAtomicT(a, ref i, ref b, type basetype) {
-  param isInt = isIntegral(basetype);
-  type xType = if isArray(a) then [a.domain] basetype else basetype;
+proc testAtomicT(a, ref i, ref b) {
+  type eltType = if isArray(a) then a.eltType else a.type;
+  type valType = eltType.valType;
+  param isInt = isIntegral(valType);
+  type xType = if isArray(a) then [a.domain] valType else valType;
 
-  writeln("Testing 'atomic ", basetype:string, "':");
+  writeln("Testing '", eltType:string, "':");
                                                                 writea  ("init    ", a);
                 if isArray(a) == false {
                   var initval : a.type = 1;                     writeai ("init=   ", a, initval);
                   var initval2 : a.type = initval;              writeai ("init=(v)", a, initval2);
                   var initval3 = initval;                       writeai ("init=(v)", a, initval3);
-                  assert(initval3.type == atomic basetype);     
+                  assert(initval3.type == atomic valType);
+                  assert(a.valType == valType);
+                  assert(a.type.valType == valType);
                 }
                 i = a.read();                                   writeai ("read    ", a, i);
                     a.write(1);                                 writea  ("write   ", a);
                 i = a.exchange(2);                              writeai ("xchg    ", a, i);
-                var x: xType = 3:basetype;                      writex  ("expected", x);
+                var x: xType = 3:valType;                       writex  ("expected", x);
                 b = a.compareExchange(x, 4);                    writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchange(x, 4);                    writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchangeWeak(x, 2);                writeabx("cmpxchgW", a, b, x);
@@ -108,22 +116,26 @@ proc testAtomicT(a, ref i, ref b, type basetype) {
   writeln();
 }
 
-proc testOrderAtomicT(a, ref i, ref b, type basetype, param o: memoryOrder) {
-  param isInt = isIntegral(basetype);
-  type xType = if isArray(a) then [a.domain] basetype else basetype;
+proc testOrderAtomicT(a, ref i, ref b, param o: memoryOrder) {
+  type eltType = if isArray(a) then a.eltType else a.type;
+  type valType = eltType.valType;
+  param isInt = isIntegral(valType);
+  type xType = if isArray(a) then [a.domain] valType else valType;
 
-  writeln("Testing 'atomic ", basetype:string, "' with order '", o, "':");
+  writeln("Testing '", eltType:string, "' with order '", o, "':");
                                                                      writea  ("init    ", a);
                 if isArray(a) == false {
                   var initval : a.type = 1;                          writeai ("init=   ", a, initval);
                   var initval2 : a.type = initval;                   writeai ("init=(v)", a, initval2);
                   var initval3 = initval;                            writeai ("init=(v)", a, initval3);
-                  assert(initval3.type == atomic basetype);     
+                  assert(initval3.type == atomic valType);
+                  assert(a.valType == valType);
+                  assert(a.type.valType == valType);
                 }
                 i = a.read(o);                                       writeai ("read    ", a, i);
                     a.write(1, o);                                   writea  ("write   ", a);
                 i = a.exchange(2, o);                                writeai ("xchg    ", a, i);
-                var x: xType = 3:basetype;                           writex  ("expected", x);
+                var x: xType = 3:valType;                            writex  ("expected", x);
                 b = a.compareExchange(x, 4, o);                      writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchange(x, 4, o);                      writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchange(x, 2, o, o);                   writeabx("cmpxchg ", a, b, x);
@@ -148,12 +160,14 @@ proc testOrderAtomicT(a, ref i, ref b, type basetype, param o: memoryOrder) {
   writeln();
 }
 
-proc testUnorderedAtomicT(a, ref i, ref b, type basetype) {
+proc testUnorderedAtomicT(a, ref i, ref b) {
+  type eltType = if isArray(a) then a.eltType else a.type;
+  type valType = eltType.valType;
   use UnorderedAtomics;
   inline proc fence() { unorderedAtomicTaskFence(); }
-  param isInt = isIntegral(basetype);
+  param isInt = isIntegral(valType);
 
-  writeln("Testing 'atomic ", basetype:string, "':");
+  writeln("Testing '", eltType:string, "':");
                                                     writea ("init    ", a);
                     a.unorderedAdd(8); fence();     writea ("add     ", a);
                     a.unorderedSub(1); fence();     writea ("sub     ", a);

--- a/test/runtime/configMatters/comm/atomic-stress.chpl
+++ b/test/runtime/configMatters/comm/atomic-stress.chpl
@@ -30,33 +30,33 @@ proc testAddSub(type t) {
 }
 
 enum ExchangeType {cmpxchg, cmpxchgW, cas};
-inline proc AtomicT.loopAdd(value: T, param exchangeType: ExchangeType) {
+inline proc AtomicT.loopAdd(val: valType, param exchangeType: ExchangeType) {
   var oldValue = this.read();
   select (exchangeType) {
     when ExchangeType.cmpxchgW {
-      while !this.compareExchangeWeak(oldValue, oldValue + value) { }
+      while !this.compareExchangeWeak(oldValue, oldValue + val) { }
     }
     when ExchangeType.cmpxchg {
-      while !this.compareExchange(oldValue, oldValue + value) { }
+      while !this.compareExchange(oldValue, oldValue + val) { }
     }
     when ExchangeType.cas {
-      while !this.compareAndSwap(oldValue, oldValue + value) {
+      while !this.compareAndSwap(oldValue, oldValue + val) {
         oldValue = this.read();
       }
     }
   }
 }
-inline proc RAtomicT.loopAdd(value: T, param exchangeType: ExchangeType) {
+inline proc RAtomicT.loopAdd(val: valType, param exchangeType: ExchangeType) {
   var oldValue = this.read();
   select (exchangeType) {
     when ExchangeType.cmpxchgW {
-      while !this.compareExchangeWeak(oldValue, oldValue + value) { }
+      while !this.compareExchangeWeak(oldValue, oldValue + val) { }
     }
     when ExchangeType.cmpxchg {
-      while !this.compareExchange(oldValue, oldValue + value) { }
+      while !this.compareExchange(oldValue, oldValue + val) { }
     }
     when ExchangeType.cas {
-      while !this.compareAndSwap(oldValue, oldValue + value) {
+      while !this.compareAndSwap(oldValue, oldValue + val) {
         oldValue = this.read();
       }
     }

--- a/test/runtime/configMatters/comm/atomics-api-on.chpl
+++ b/test/runtime/configMatters/comm/atomics-api-on.chpl
@@ -13,13 +13,13 @@ proc declareAndTestAtomicBool() {
   }
 }
 
-proc declareAndTestAtomicT(type basetype) {
-  var a, a2: atomic basetype;
-  var i: basetype;
+proc declareAndTestAtomicT(type valType) {
+  var a, a2: atomic valType;
+  var i: valType;
   var b: bool;
   on Locales[onLocale] {
-    testAtomicT(a, i, b, basetype);
-    testOrderAtomicT(a2, i, b, basetype, memoryOrder.seqCst);
+    testAtomicT(a, i, b);
+    testOrderAtomicT(a2, i, b, memoryOrder.seqCst);
   }
 }
 
@@ -48,7 +48,7 @@ var IInt: [1..3] int;
 var BInt: [1..3] bool;
 on Locales[onLocale] {
   write("Promotion -- ");
-  testAtomicT(AInt, IInt, BInt, int);
-  testOrderAtomicT(AInt2, IInt, BInt, int, memoryOrder.seqCst);
+  testAtomicT(AInt, IInt, BInt);
+  testOrderAtomicT(AInt2, IInt, BInt, memoryOrder.seqCst);
 }
 

--- a/test/runtime/configMatters/comm/atomics-api.chpl
+++ b/test/runtime/configMatters/comm/atomics-api.chpl
@@ -8,12 +8,12 @@ proc declareAndTestAtomicBool() {
   testOrderAtomicBool(a2, i, b, memoryOrder.seqCst);
 }
 
-proc declareAndTestAtomicT(type basetype) {
-  var a, a2: atomic basetype;
-  var i: basetype;
+proc declareAndTestAtomicT(type valType) {
+  var a, a2: atomic valType;
+  var i: valType;
   var b: bool;
-  testAtomicT(a, i, b, basetype);
-  testOrderAtomicT(a2, i, b, basetype, memoryOrder.seqCst);
+  testAtomicT(a, i, b);
+  testOrderAtomicT(a2, i, b, memoryOrder.seqCst);
 }
 
 /* Test full API for all types */
@@ -40,5 +40,5 @@ var AInt, AInt2: [1..3] atomic int;
 var IInt: [1..3] int;
 var BInt: [1..3] bool;
 write("Promotion -- ");
-testAtomicT(AInt, IInt, BInt, int);
-testOrderAtomicT(AInt2, IInt, BInt, int, memoryOrder.seqCst);
+testAtomicT(AInt, IInt, BInt);
+testOrderAtomicT(AInt2, IInt, BInt, memoryOrder.seqCst);

--- a/test/runtime/configMatters/comm/unordered/unorderedAtomicsApiOn.chpl
+++ b/test/runtime/configMatters/comm/unordered/unorderedAtomicsApiOn.chpl
@@ -3,12 +3,12 @@ use AtomicsAPI;
 config const lastLocale = false;
 const onLocale = if lastLocale then numLocales-1 else 0;
 
-proc declareAndTestAtomicT(type basetype) {
-  var a: atomic basetype;
-  var i: basetype;
+proc declareAndTestAtomicT(type valType) {
+  var a: atomic valType;
+  var i: valType;
   var b: bool;
   on Locales[onLocale] {
-    testUnorderedAtomicT(a, i, b, basetype);
+    testUnorderedAtomicT(a, i, b);
   }
 }
 
@@ -35,5 +35,5 @@ var IInt: [1..3] int;
 var BInt: [1..3] bool;
 on Locales[onLocale] {
   write("Promotion -- ");
-  testUnorderedAtomicT(AInt, IInt, BInt, int);
+  testUnorderedAtomicT(AInt, IInt, BInt);
 }


### PR DESCRIPTION
Switch the atomic formal `value` to `val` and change the value type from `T` to `valType`. `valType` was chosen to match syncs and be similar to `eltType` on arrays and `idxType`. The formal name `val` was then used to match `valType` and so we could distinguish the stored "value" in the atomic and the name of the formal more easily. The `value`->`val` formal renaming is being done without deprecation since we believe named args are never used with atomics and if we had a way to disable named args we may have just used that.

Part of Cray/chapel-private#3730
Resolves https://github.com/chapel-lang/chapel/issues/20182