### PR TITLE
Have AMD GPU codegen dump assembly

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4623,8 +4623,6 @@ void makeBinaryLLVM(void) {
 
     switch (getGpuCodegenType()) {
       case GpuCodegenType::GPU_CG_NVIDIA_CUDA:
-        artifactFilename = genIntermediateFilename("chpl__gpu_ptx.s");
-        break;
       case GpuCodegenType::GPU_CG_AMD_HIP:
         artifactFilename = genIntermediateFilename("chpl__gpu.s");
         break;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4567,7 +4567,7 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
 {
   std::string asmCmd = findSiblingClangToolPath("llvm-mc") + " " +
                        "--filetype=obj " +
-                       "--triple=amdgcn-amd-amdhsa --mcpu=gfx908 " +
+                       "--triple=amdgcn-amd-amdhsa --mcpu=" + gpuArch + " " +
                        artifactFilename + " " +
                        "-o " + gpuObjFilename;
   std::string lldCmd = std::string(gGpuSdkPath) +

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4649,7 +4649,7 @@ void makeBinaryLLVM(void) {
     outFilename = genIntermediateFilename("chpl__gpu.out");
 
     // This switch may seem unnecessary, but in the past we wanted to use a
-    // different "type" of intermedaite file for different GPUs and we may want
+    // different "type" of intermediate file for different GPUs and we may want
     // to do that again in the future. See the comment in getGpuCodegenType()
     // for more details about this history.
     switch (getGpuCodegenType()) {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4442,6 +4442,11 @@ static void moveGeneratedLibraryFile(const char* tmpbinname);
 static void moveResultFromTmp(const char* resultName, const char* tmpbinname);
 
 static llvm::CodeGenFileType getCodeGenFileType() {
+  // At one point, we returned CGFT_AssemblyFGile for NVIDIA and
+  // CGFT_ObjectFile for AMD (we since figured out how to assemble for AMD so
+  // no longer go directly to .o). Given that, this function may seem a little
+  // crufty, but we may want to return to doing different things for future
+  // GPUs.
   switch (getGpuCodegenType()) {
     case GpuCodegenType::GPU_CG_AMD_HIP:
     case GpuCodegenType::GPU_CG_NVIDIA_CUDA:
@@ -4643,6 +4648,10 @@ void makeBinaryLLVM(void) {
     fatbinFilename = genIntermediateFilename("chpl__gpu.fatbin");
     outFilename = genIntermediateFilename("chpl__gpu.out");
 
+    // This switch may seem unnecessary, but in the past we wanted to use a
+    // different "type" of intermedaite file for different GPUs and we may want
+    // to do that again in the future. See the comment in getGpuCodegenType()
+    // for more details about this history.
     switch (getGpuCodegenType()) {
       case GpuCodegenType::GPU_CG_NVIDIA_CUDA:
       case GpuCodegenType::GPU_CG_AMD_HIP:

--- a/test/gpu/native/savec.chpl
+++ b/test/gpu/native/savec.chpl
@@ -1,0 +1,8 @@
+config const N=10;
+
+on here.gpus[0] {
+  var A : [0..<N] int;
+  foreach i in 0..<N do
+    A[i] = i;
+  writeln(A);
+}

--- a/test/gpu/native/savec.cleanfiles
+++ b/test/gpu/native/savec.cleanfiles
@@ -1,0 +1,1 @@
+savec_dir

--- a/test/gpu/native/savec.compopts
+++ b/test/gpu/native/savec.compopts
@@ -1,0 +1,1 @@
+--savec savec_dir

--- a/test/gpu/native/savec.good
+++ b/test/gpu/native/savec.good
@@ -1,0 +1,5 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+0 1 2 3 4 5 6 7 8 9
+savec_dir/chpl__gpu.s
+savec_dir/chpl__gpu.o
+savec_dir/chpl__module.o

--- a/test/gpu/native/savec.prediff
+++ b/test/gpu/native/savec.prediff
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+find savec_dir -type f -name "*.o" -o -name "*.s" >> $2

--- a/test/gpu/native/savec.skipif
+++ b/test/gpu/native/savec.skipif
@@ -1,0 +1,4 @@
+# The purpose of this test is to ensure that we dump an assembly file for our
+# generated GPU kernels but we don't/can't do that when using cpu-as-device
+# mode.
+CHPL_GPU==cpu


### PR DESCRIPTION
This change modifies how we do code generation for AMD GPUs by dumping to an assembly (.s) file and then calling `llvm-mc` to assemble it into a .o file.  Previously we dumped to a .o file directly.

I think the prior way of doing things is undesirable because:
* It's not what we do for NVIDIA and the inconsistency might make it harder to maintain things, and
* (probably more importantly) when using `--savec` you'd have the assembly available to inspect for NVIDIA but not AMD

Notes to reviewers:

- To find `llvm-mc` I factored out some existing code we used to find llvmObj into a general `findSiblingClangToolPath` function (which I then call with `llvm-mc` and `llvm-objdump` as appropriate.
  - There's also a version of `llvm-mc` packaged with HIP but if we use one version of clang to generate the asssembly and another to assemble it we can run into issues.
- I added a test that passes `--savec` then examines the `.o` and `.s` files in the dumped directory locking down what we expect.
- In order to make the aforementioned test easier to write I changed things so the name of the dumped assembly file would be the same for NVIDIA and AMD. For NVIDIA this was previously `chpl__gpu_ptx.s`, it's now `chpl__gpu.s`. This doesn't change the content of the file (it's still PTX) just the name.
- Arguably, I should now get rid of `getCodeGenFileType` and the switch statement to generate `artifactFilename` in `makeBinaryLLVM` since we're now doing the same thing for NVIDIA/AMD. I'm tempted to leave it "as is" for now on the off chance that we would need to do something different for Intel.

# TODO:
- [x] paratest NVIDIA
- [x] paratest AMD
- [x] paratest cpu-as-device
