### PR TITLE
Clean up how environment variables are deleted

### DIFF
--- a/test/runtime/configMatters/launch/jhh/reservation/reservation.py
+++ b/test/runtime/configMatters/launch/jhh/reservation/reservation.py
@@ -65,11 +65,9 @@ class SrunTests(unittest.TestCase):
         if skipReason is not None:
             self.skipTest(skipReason)
         self.env = os.environ.copy()
-        try:
-            del self.env['CHPL_LAUNCHER_PARTITION']
-            del self.env['CHPL_LAUNCHER_USE_SBATCH']
-        except:
-            pass
+        self.env.pop('CHPL_LAUNCHER_PARTITION', None)
+        self.env.pop('CHPL_LAUNCHER_CORES_PER_LOCALE', None)
+        self.env.pop('CHPL_LAUNCHER_USE_SBATCH', None)
 
     def runCmd(self, cmd):
         output = runCmd(cmd, self.env);


### PR DESCRIPTION
Use the `pop` method to avoid exceptions when deleting a non-existent key from a dictionary. This way is a lot cleaner than using `try`.