### PR TITLE
mark umask unstable, add doc example for octals

### DIFF
--- a/doc/rst/users-guide/base/basicValues.rst
+++ b/doc/rst/users-guide/base/basicValues.rst
@@ -22,9 +22,11 @@ values:
   :language: chapel
   :lines: 1,4,6
 
+.. _Integral literal values:
+
 Integral Values
 ---------------
-            
+
 Literal values for ``int`` types are typically written as a sequence
 of decimal digits:
 
@@ -67,7 +69,7 @@ To represent a smaller integral value as a ``uint``, type conversions
 (:ref:`casts <ug-casts>` or coercions) must be used.
 
 .. TODO: hyperlink coercions above once that text is written
-   
+
 
 Floating Point Values
 ---------------------
@@ -85,7 +87,7 @@ where these literals correspond to the values:
 .. literalinclude:: examples/users-guide/base/floatValues.good
   :language: text
   :lines: 3-4
-          
+
 In the decimal form, a ``.`` must be used to distinguish the value
 from an integral literal.  Note that ``10.`` is not a valid floating
 point literal value in Chapel due to a syntactic ambiguity with making
@@ -123,7 +125,7 @@ assignments demonstrate imaginary literals:
 .. literalinclude:: examples/users-guide/base/floatValues.chpl
   :language: chapel
   :lines: 26,29,31,33,35
-     
+
 Note that whether using the ``int`` or ``real`` form, imaginary values
 are stored using a floating point representation.  Thus, these
 expressions correspond to the values:
@@ -169,4 +171,4 @@ Subsequent sections will cover strings in more detail.
 .. TODO: write such a section and hyperlink it
 
 
-   
+

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1439,22 +1439,17 @@ proc symlink(oldName: string, newName: string) throws {
    :rtype: `int`
 */
 proc locale.umask(mask: int): int where (CHPL_LOCALE_MODEL == "flat") {
-  import OS.POSIX.mode_t;
-  extern proc chpl_fs_umask(mask: mode_t): mode_t;
-  extern proc chpl_int_to_mode(mode: c_int): mode_t;
-  extern proc chpl_mode_to_int(mode: mode_t): c_int;
-
-  var result: int;
-  on this {
-    var callRes = chpl_fs_umask(chpl_int_to_mode(mask.safeCast(c_int)));
-    result = chpl_mode_to_int(callRes);
-  }
-  return result.safeCast(int);
+  return umaskHelper(mask);
 }
 
 @chpldoc.nodoc
 @unstable("'umask' is unstable on locale models other than 'flat'")
 proc locale.umask(mask: int): int where (CHPL_LOCALE_MODEL != "flat") {
+  return umaskHelper(mask);
+}
+
+@chpldoc.nodoc
+proc locale.umaskHelper(mask: int): int {
   import OS.POSIX.mode_t;
   extern proc chpl_fs_umask(mask: mode_t): mode_t;
   extern proc chpl_int_to_mode(mode: c_int): mode_t;

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -95,6 +95,7 @@ module FileSystem {
   use CTypes;
   use IO;
   use OS.POSIX;
+  use ChplConfig;
 
 /* S_IRUSR and the following constants are values of the form
    S_I[R | W | X][USR | GRP | OTH], S_IRWX[U | G | O], S_ISUID, S_ISGID, or
@@ -1427,14 +1428,17 @@ proc symlink(oldName: string, newName: string) throws {
       This is not safe within a parallel context.  A umask call in one task
       will affect the umask of all tasks for that locale.
 
+   .. warning::
 
-   :arg mask: The file creation mask to use now.
+      'umask' is unstable on locale models other than the flat locale model.
+
+   :arg mask: The file creation mask to use now. Octal literals may be specified, e.g., ``0o777``
    :type mask: `int`
 
    :return: The previous file creation mask
    :rtype: `int`
 */
-proc locale.umask(mask: int): int {
+proc locale.umask(mask: int): int where (CHPL_LOCALE_MODEL == "flat") {
   import OS.POSIX.mode_t;
   extern proc chpl_fs_umask(mask: mode_t): mode_t;
   extern proc chpl_int_to_mode(mode: c_int): mode_t;
@@ -1448,6 +1452,11 @@ proc locale.umask(mask: int): int {
   return result.safeCast(int);
 }
 
+@chpldoc.nodoc
+@unstable("'umask' is unstable on locale models other than 'flat'")
+proc locale.umask(mask: int): int where (CHPL_LOCALE_MODEL != "flat") {
+  return this.umask(mask);
+}
 
 @deprecated(notes="walkdirs is deprecated; please use walkDirs instead")
 iter walkdirs(path: string = ".", topdown: bool = true, depth: int = max(int),

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1432,7 +1432,7 @@ proc symlink(oldName: string, newName: string) throws {
 
       'umask' is unstable on locale models other than the flat locale model.
 
-   :arg mask: The file creation mask to use now. Octal literals may be specified, e.g., ``0o777``
+   :arg mask: The file creation mask to use now. Octal literals may be specified, e.g., ``0o777``. See :ref:`Integral literal values <Integral literal values>`.
    :type mask: `int`
 
    :return: The previous file creation mask

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1455,7 +1455,17 @@ proc locale.umask(mask: int): int where (CHPL_LOCALE_MODEL == "flat") {
 @chpldoc.nodoc
 @unstable("'umask' is unstable on locale models other than 'flat'")
 proc locale.umask(mask: int): int where (CHPL_LOCALE_MODEL != "flat") {
-  return this.umask(mask);
+  import OS.POSIX.mode_t;
+  extern proc chpl_fs_umask(mask: mode_t): mode_t;
+  extern proc chpl_int_to_mode(mode: c_int): mode_t;
+  extern proc chpl_mode_to_int(mode: mode_t): c_int;
+
+  var result: int;
+  on this {
+    var callRes = chpl_fs_umask(chpl_int_to_mode(mask.safeCast(c_int)));
+    result = chpl_mode_to_int(callRes);
+  }
+  return result.safeCast(int);
 }
 
 @deprecated(notes="walkdirs is deprecated; please use walkDirs instead")

--- a/test/unstable/changeMaskFlat.chpl
+++ b/test/unstable/changeMaskFlat.chpl
@@ -1,0 +1,12 @@
+use FileSystem;
+
+var newMask = 0o777;
+var oldMask = here.umask(newMask);
+var shouldMatchFirst = here.umask(oldMask);
+
+if newMask != shouldMatchFirst {
+  writeln("Uh oh, I didn't get the right umask back!");
+  writef("Expected umask %oi but got %oi\n", newMask, shouldMatchFirst);
+} else {
+  writeln("Phew, the returned umask value matched what I sent it!");
+}

--- a/test/unstable/changeMaskFlat.good
+++ b/test/unstable/changeMaskFlat.good
@@ -1,0 +1,1 @@
+Phew, the returned umask value matched what I sent it!

--- a/test/unstable/changeMaskFlat.skipif
+++ b/test/unstable/changeMaskFlat.skipif
@@ -1,0 +1,1 @@
+CHPL_LOCALE_MODEL!=flat

--- a/test/unstable/changeMaskNotFlat.chpl
+++ b/test/unstable/changeMaskNotFlat.chpl
@@ -1,0 +1,12 @@
+use FileSystem;
+
+var newMask = 0o777;
+var oldMask = here.umask(newMask);
+var shouldMatchFirst = here.umask(oldMask);
+
+if newMask != shouldMatchFirst {
+  writeln("Uh oh, I didn't get the right umask back!");
+  writef("Expected umask %oi but got %oi\n", newMask, shouldMatchFirst);
+} else {
+  writeln("Phew, the returned umask value matched what I sent it!");
+}

--- a/test/unstable/changeMaskNotFlat.good
+++ b/test/unstable/changeMaskNotFlat.good
@@ -1,0 +1,3 @@
+changeMaskNotFlat.chpl:4: warning: 'umask' is unstable on locale models other than 'flat'
+changeMaskNotFlat.chpl:5: warning: 'umask' is unstable on locale models other than 'flat'
+Phew, the returned umask value matched what I sent it!

--- a/test/unstable/changeMaskNotFlat.prediff
+++ b/test/unstable/changeMaskNotFlat.prediff
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mv $2  $1.orig.tmp
+pattern1="^warning: GPU support is under active development. As such, the interface is unstable and expected to change in the forthcoming releases."
+pattern2="^warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly"
+
+grep -vE "$pattern1|$pattern2" "$1.orig.tmp" > "$2"

--- a/test/unstable/changeMaskNotFlat.skipif
+++ b/test/unstable/changeMaskNotFlat.skipif
@@ -1,0 +1,1 @@
+CHPL_LOCALE_MODEL==flat


### PR DESCRIPTION
This PR marks `locale.umask` in the `FileSystem` module as unstable for locale models that are not `flat`. It also adds some text to the `mask` argument description indicating it can be assigned an octal literal.

This was motivated by design discussions on changing the location, return type or argument types for `umask`, where the major consideration for was how `umask` should behave on locale models with sub-locales. The summary issue can be found here https://github.com/Cray/chapel-private/issues/4988.

The unstable warning is written directly into the docs so that it shows up without double documenting the `umask` procedure.

TESTING:

- [x] paratest `[Summary: #Successes = 16784 | #Failures = 0 | #Futures = 916]`
- [x] gasnet paratest `[Summary: #Successes = 16965 | #Failures = 0 | #Futures = 925]`
- [x] manually review `locale.umask` docs

[reviewed by @jabraham17 - thanks!]