### PR TITLE
Mark atomic `compareAndSwap` as unstable

### DIFF
--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -370,6 +370,7 @@ module Atomics {
        Stores `desired` as the new value, if and only if the original value is
        equal to `expected`. Returns `true` if `desired` was stored.
     */
+    @unstable("'compareAndSwap' is unstable")
     inline proc compareAndSwap(expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
       pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("compare_exchange_strong", bool)
@@ -565,6 +566,7 @@ module Atomics {
        Stores `desired` as the new value, if and only if the original value is
        equal to `expected`. Returns `true` if `desired` was stored.
     */
+    @unstable("'compareAndSwap' is unstable")
     inline proc compareAndSwap(expected:valType, desired:valType, param order: memoryOrder = memoryOrder.seqCst): bool {
       pragma "local fn" pragma "fast-on safe extern function"
       extern externFunc("compare_exchange_strong", valType)

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -103,6 +103,7 @@ module NetworkAtomics {
       return this.compareExchange(expected, desired, success, failure);
     }
 
+    @unstable("'compareAndSwap' is unstable")
     inline proc compareAndSwap(expected:bool, desired:bool, param order: memoryOrder = memoryOrder.seqCst): bool {
       pragma "insert line file info" extern externFunc("cmpxchg", int(64))
         proc atomic_cmpxchg(ref expected:int(64), ref desired:int(64), l:int(32), obj:c_ptr(void), ref result:uint(32), succ:memory_order, fail:memory_order): void;
@@ -215,6 +216,7 @@ module NetworkAtomics {
       return this.compareExchange(expected, desired, success, failure);
     }
 
+    @unstable("'compareAndSwap' is unstable")
     inline proc compareAndSwap(expected:valType, desired:valType, param order: memoryOrder = memoryOrder.seqCst): bool {
       pragma "insert line file info" extern externFunc("cmpxchg", valType)
         proc atomic_cmpxchg(ref expected:valType, ref desired:valType, l:int(32), obj:c_ptr(void), ref result:uint(32), succ:memory_order, fail:memory_order): void;

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -388,9 +388,8 @@ module DistributedDeque {
           on queueSize {
             var readSize = queueSize!.read();
             // Attempt to fix, but yield to reduce potential contention and CPU hogging.
-            while readSize < 0 && !queueSize!.compareAndSwap(readSize, 0) {
+            while readSize < 0 && !queueSize!.compareExchangeWeak(readSize, 0) {
               chpl_task_yield();
-              readSize = queueSize!.read();
             }
           }
 
@@ -433,9 +432,8 @@ module DistributedDeque {
             on queueSize {
               var readSize = queueSize!.read();
               // Attempt to fix, but yield to reduce potential contention and CPU hogging.
-              while readSize > this.cap && !queueSize!.compareAndSwap(readSize, this.cap) {
+              while readSize > this.cap && !queueSize!.compareExchangeWeak(readSize, this.cap) {
                 chpl_task_yield();
-                readSize = queueSize!.read();
               }
             }
 

--- a/test/exercises/boundedBuffer/solutions/boundedBuffer-atomic.chpl
+++ b/test/exercises/boundedBuffer/solutions/boundedBuffer-atomic.chpl
@@ -168,11 +168,10 @@ class BoundedBuffer {
   // a simple helper function for advancing the head or tail position.
   //
   inline proc advance(ref pos: atomic int) {
-    var prevPos: int;
+    var prevPos = pos.read();
     do {
-      prevPos = pos.read();
       const nextPos = (prevPos + 1) % capacity;
-    } while (!pos.compareAndSwap(prevPos, nextPos));
+    } while (!pos.compareExchangeWeak(prevPos, nextPos));
 
     return prevPos;
   }

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -247,12 +247,10 @@ proc process_json(logfile:fileReader, fname:string, ref Pairs) {
   total_tweets_processed.add(ntweets);
   total_lines_processed.add(nlines);
 
-  while true {
-    var got = max_user_id.read();
-    var id = if got > max_id then got else max_id;
-    var success = max_user_id.compareAndSwap(got, id);
-    if success then break;
-  }
+  var old_id = max_user_id.read();
+  do {
+    var id = if old_id > max_id then old_id else max_id;
+  } while(!max_user_id.compareExchangeWeak(old_id, id));
 }
 
 proc process_json(fname: string, ref Pairs)

--- a/test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-iter.chpl
+++ b/test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-iter.chpl
@@ -111,6 +111,5 @@ proc fannkuch(idxMin:int, idxMax:int) {
   checks.add(checkSum);
 
   var curMax = flips.read();
-  while curMax < maxFlips && !flips.compareAndSwap(curMax, maxFlips) do
-    curMax = flips.read();
+  while curMax < maxFlips && !flips.compareExchangeWeak(curMax, maxFlips) { }
 }

--- a/test/studies/uts/uts_deq.chpl
+++ b/test/studies/uts/uts_deq.chpl
@@ -166,14 +166,12 @@ class TreeNode {
 /* Compute atomically:  this = max(this, other) */
 proc AtomicT.max(other: int) {
   var curMax = this.read();
-  while curMax < other && !this.compareAndSwap(curMax, other) do
-    curMax = this.read();
+  while curMax < other && !this.compareExchangeWeak(curMax, other) { }
 }
 
 proc RAtomicT.max(other: int) {
   var curMax = this.read();
-  while curMax < other && !this.compareAndSwap(curMax, other) do
-    curMax = this.read();
+  while curMax < other && !this.compareExchangeWeak(curMax, other) { }
 }
 
 

--- a/test/unstable/Synchronization/COMPOPTS
+++ b/test/unstable/Synchronization/COMPOPTS
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/unstable/Synchronization/compareAndSwap.chpl
+++ b/test/unstable/Synchronization/compareAndSwap.chpl
@@ -1,0 +1,8 @@
+var ab: atomic bool;
+var ai: atomic int;
+
+ab.compareAndSwap(false, true);
+ai.compareAndSwap(0, 1);
+
+writeln(ab);
+writeln(ai);

--- a/test/unstable/Synchronization/compareAndSwap.good
+++ b/test/unstable/Synchronization/compareAndSwap.good
@@ -1,0 +1,4 @@
+compareAndSwap.chpl:4: warning: 'compareAndSwap' is unstable
+compareAndSwap.chpl:5: warning: 'compareAndSwap' is unstable
+true
+1


### PR DESCRIPTION
We currently have similar atomic `compareAndSwap` and `compareExchange` methods:

```chpl
proc  compareAndSwap(    expected: valType, desired: valType): bool
proc compareExchange(ref expected: valType, desired: valType): bool
```

Where the difference is that `compareExchange` takes `expected` by ref and updates it on failure. This is more efficient when you want to update expected since it avoids having to do another read to get the current value. 

`compareExchange` aligns with the C/C++ `compare_exchange_strong` API, but is more cumbersome when you don't want to modify expected or you're using non-mutable values. It can also be confusing/surprising that `expected` gets updated, even for C/C++ users. We decided to stick with the name/behavior to match the C/C++ interface since we based the rest of our atomics off them so we want to stabilize that, but also want a version that doesn't update `expected`. Currently, that's `compareAndSwap`, but it's not obvious just from the name which version does what since `compareAndSwap` and `compareExchange` are often used interchangeably. For that reason mark it unstable until we find a better name or decide it's good enough as-is.

As part of this effort, convert tests that updated `expected` on failure to use `compareExchange`. Most of these cases were implementing atomic max, which I think we'll want to provide by default anyways in the future, but for now just update them to use the more efficient `compareExchange`.

Part of https://github.com/Cray/chapel-private/issues/3730