### PR TITLE
Remove remaining usages of `raw_c_void_ptr` in modules

### DIFF
--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -569,6 +569,7 @@ TYPE_EXTERN PrimitiveType*    dtSyncVarAuxFields;
 TYPE_EXTERN PrimitiveType*    dtSingleVarAuxFields;
 
 TYPE_EXTERN PrimitiveType*    dtStringC; // the type of a C string (unowned)
+// TODO: replace raw dtCVoidPtr with a well-known AggregateType for c_ptr(void)
 TYPE_EXTERN PrimitiveType*    dtCVoidPtr; // the type of a C void* (unowned)
 TYPE_EXTERN PrimitiveType*    dtCFnPtr;   // a C function pointer (unowned)
 

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -227,9 +227,11 @@ scalarReplaceClass(AggregateType* ct, Symbol* sym) {
         return false;
 
       // The use must appear as the first argument in the containing
-      // expression.
-      if (se != call->get(1))
+      // expression, or second in a PRIM_CAST to c_ptr(void).
+      if (!(se == call->get(1) ||
+            (se == call->get(2) && call->isPrimitive(PRIM_CAST)))) {
         return false;
+      }
       // The use must be the first argument of one of the following
       // primitives or allocation functions.
       if (!(call->isPrimitive(PRIM_SET_MEMBER) ||
@@ -239,6 +241,9 @@ scalarReplaceClass(AggregateType* ct, Symbol* sym) {
             // As of r21945, compiler inserted calls to
             // chpl_here_free() have as its first argument a void *
             call->isPrimitive(PRIM_CAST_TO_VOID_STAR) ||
+            // Also support calls to chpl_here_free() with c_ptr(void) argument
+            (call->isPrimitive(PRIM_CAST) &&
+             isCVoidPtr(call->get(1)->qualType().type())) ||
             (call->isResolved() &&
              (call->resolvedFunction()->hasFlag(FLAG_ALLOCATOR) ||
               // TODO: don't know this is necessary as the arg to free
@@ -303,7 +308,8 @@ scalarReplaceClass(AggregateType* ct, Symbol* sym) {
         // class reference, we can remove the call to free it
         //
         call->remove();
-      } else if (call->isPrimitive(PRIM_CAST_TO_VOID_STAR)) {
+      } else if (call->isPrimitive(PRIM_CAST_TO_VOID_STAR) ||
+                 call->isPrimitive(PRIM_CAST)) {
         CallExpr* parent = toCallExpr(call->parentExpr);
         INT_ASSERT(parent);
         CallExpr* parentNext = toCallExpr(parent->next);

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -918,7 +918,8 @@ static void addKnownWides() {
     Symbol* defParent = var->defPoint->parentSymbol;
 
     if (usingGpuLocaleModel()) {
-      if (var->type->symbol->hasFlag(FLAG_DATA_CLASS)) {
+      if (var->type->symbol->hasFlag(FLAG_DATA_CLASS)
+          && !var->type->symbol->hasFlag(FLAG_C_PTR_CLASS)) {
         if (FnSymbol* fn = usedInOn(var)) {
           debug(var, "GPU variable used in on-statement\n");
           if (typeCanBeWide(var)) {

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -41,6 +41,7 @@ pragma "unsafe"
 module ChapelIteratorSupport {
   private use ChapelStandard;
   private use Reflection;
+  private use CTypes only c_ptr;
 
   //
   // module support for iterators
@@ -433,7 +434,7 @@ module ChapelIteratorSupport {
   }
 
   inline proc _freeIterator(ic: _iteratorClass) {
-    chpl_here_free(__primitive("cast_to_void_star", ic));
+    chpl_here_free(__primitive("cast", c_ptr(void), ic));
   }
 
   inline proc _freeIterator(x: _tuple) {

--- a/modules/internal/ChapelPrivatization.chpl
+++ b/modules/internal/ChapelPrivatization.chpl
@@ -27,7 +27,7 @@ module ChapelPrivatization {
 
   // the type of elements in chpl_privateObjects.
   extern record chpl_privateObject_t {
-    var obj:raw_c_void_ptr;
+    var obj:c_ptr(void);
   }
 
   extern var chpl_privateObjects:c_ptr(chpl_privateObject_t);

--- a/modules/internal/ChapelPrivatization.chpl
+++ b/modules/internal/ChapelPrivatization.chpl
@@ -22,9 +22,6 @@ module ChapelPrivatization {
 
   private use CTypes;
 
-  // see the note in LocaleModelHelpMem for the use of raw_c_void_ptr
-  extern type raw_c_void_ptr = chpl__c_void_ptr;
-
   // the type of elements in chpl_privateObjects.
   extern record chpl_privateObject_t {
     var obj:c_ptr(void);

--- a/modules/internal/LocaleModelHelpMem.chpl
+++ b/modules/internal/LocaleModelHelpMem.chpl
@@ -29,12 +29,6 @@
 // should feel free to reimplement them in some other way.
 module LocaleModelHelpMem {
   private use ChapelStandard, CTypes;
-  // TODO: use c_ptr(void) instead of raw_c_void_ptr. Currently, doing so
-  // causes a segfault in the compiled executable. This seems to be related to
-  // some quirk with how we invoke chpl_here_free with the result of a call to
-  // the cast_to_void_star primitive. See related private issue #5082.
-  // Anna, July 2023.
-  extern type raw_c_void_ptr = chpl__c_void_ptr;
 
   //////////////////////////////////////////
   //
@@ -98,11 +92,11 @@ module LocaleModelHelpMem {
 
   pragma "allocator"
   pragma "always propagate line file info"
-  proc chpl_here_realloc(ptr:raw_c_void_ptr, size:integral, md:chpl_mem_descInt_t): c_ptr(void) {
+  proc chpl_here_realloc(ptr:c_ptr(void), size:integral, md:chpl_mem_descInt_t): c_ptr(void) {
     pragma "fn synchronization free"
     pragma "insert line file info"
-      extern proc chpl_mem_realloc(ptr:raw_c_void_ptr, size:c_size_t, md:chpl_mem_descInt_t) : c_ptr(void);
-    return chpl_mem_realloc(ptr:raw_c_void_ptr, size.safeCast(c_size_t), md + chpl_memhook_md_num());
+      extern proc chpl_mem_realloc(ptr:c_ptr(void), size:c_size_t, md:chpl_mem_descInt_t) : c_ptr(void);
+    return chpl_mem_realloc(ptr:c_ptr(void), size.safeCast(c_size_t), md + chpl_memhook_md_num());
   }
 
   pragma "fn synchronization free"
@@ -116,10 +110,10 @@ module LocaleModelHelpMem {
 
   pragma "locale model free"
   pragma "always propagate line file info"
-  proc chpl_here_free(ptr:raw_c_void_ptr): void {
+  proc chpl_here_free(ptr:c_ptr(void)): void {
     pragma "fn synchronization free"
     pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:raw_c_void_ptr) : void;
-    chpl_mem_free(ptr:raw_c_void_ptr);
+      extern proc chpl_mem_free(ptr:c_ptr(void)) : void;
+    chpl_mem_free(ptr:c_ptr(void));
   }
 }

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -173,7 +173,7 @@ module LocaleModel {
 
   pragma "locale model free"
   pragma "always propagate line file info"
-  proc chpl_here_free(ptr:raw_c_void_ptr): void {
+  proc chpl_here_free(ptr:c_ptr(void)): void {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc chpl_mem_free(ptr:c_ptr(void)) : void;

--- a/modules/minimal/internal/CPtr.chpl
+++ b/modules/minimal/internal/CPtr.chpl
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module CPtr {
+  // barebones version of c_ptr for use as a formal type
+  pragma "data class"
+  pragma "no object"
+  pragma "no default functions"
+  pragma "no wide class"
+  pragma "c_ptr class"
+  class c_ptr {
+    type eltType;
+  }
+}

--- a/modules/minimal/internal/IO.chpl
+++ b/modules/minimal/internal/IO.chpl
@@ -23,36 +23,34 @@ module IO {
   extern "syserr" type errorCode;
   extern type qio_channel_ptr_t;
   private extern proc qio_int_to_err(a:int(32)):errorCode;
-  // Using raw_c_void_ptr as we can't access c_ptr(void) in minimal modules.
-  // TODO: Use c_ptr(void) instead, likely via compiler support for c_ptr, or
-  // by making it accessible in minimal modules if we don't do compiler support.
-  extern type raw_c_void_ptr = chpl__c_void_ptr;
 
-  export proc chpl_qio_setup_plugin_channel(file:raw_c_void_ptr, ref plugin_ch:raw_c_void_ptr, start:int(64), end:int(64), qio_ch:qio_channel_ptr_t):errorCode {
+  private use CPtr;
+
+  export proc chpl_qio_setup_plugin_channel(file:c_ptr(void), ref plugin_ch:c_ptr(void), start:int(64), end:int(64), qio_ch:qio_channel_ptr_t):errorCode {
     return qio_int_to_err(0);
   }
-  export proc chpl_qio_read_atleast(ch_plugin:raw_c_void_ptr, amt:int(64)) {
+  export proc chpl_qio_read_atleast(ch_plugin:c_ptr(void), amt:int(64)) {
     return qio_int_to_err(0);
   }
-  export proc chpl_qio_write(ch_plugin:raw_c_void_ptr, amt:int(64)) {
+  export proc chpl_qio_write(ch_plugin:c_ptr(void), amt:int(64)) {
     return qio_int_to_err(0);
   }
-  export proc chpl_qio_channel_close(ch:raw_c_void_ptr):errorCode {
+  export proc chpl_qio_channel_close(ch:c_ptr(void)):errorCode {
     return qio_int_to_err(0);
   }
-  export proc chpl_qio_filelength(file:raw_c_void_ptr, ref length:int(64)):errorCode {
+  export proc chpl_qio_filelength(file:c_ptr(void), ref length:int(64)):errorCode {
     return qio_int_to_err(0);
   }
-  export proc chpl_qio_fsync(file:raw_c_void_ptr):errorCode {
+  export proc chpl_qio_fsync(file:c_ptr(void)):errorCode {
     return qio_int_to_err(0);
   }
-  export proc chpl_qio_get_chunk(file:raw_c_void_ptr, ref length:int(64)):errorCode {
+  export proc chpl_qio_get_chunk(file:c_ptr(void), ref length:int(64)):errorCode {
     return qio_int_to_err(0);
   }
-  export proc chpl_qio_get_locales_for_region(file:raw_c_void_ptr, start:int(64), end:int(64), ref localeNames:raw_c_void_ptr, ref nLocales:int(64)):errorCode {
+  export proc chpl_qio_get_locales_for_region(file:c_ptr(void), start:int(64), end:int(64), ref localeNames:c_ptr(void), ref nLocales:int(64)):errorCode {
     return qio_int_to_err(0);
   }
-  export proc chpl_qio_file_close(file:raw_c_void_ptr):errorCode {
+  export proc chpl_qio_file_close(file:c_ptr(void)):errorCode {
     return qio_int_to_err(0);
   }
 }

--- a/test/deprecated/Map/mapIterators.good
+++ b/test/deprecated/Map/mapIterators.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:391: In function '_getIterator':
-$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:392: warning: 'map.these' is deprecated. Consider 'map.keys' to iterate over keys or 'map.values' to iterate over values.
+$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:392: In function '_getIterator':
+$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:393: warning: 'map.these' is deprecated. Consider 'map.keys' to iterate over keys or 'map.values' to iterate over values.
   mapIterators.chpl:6: called as _getIterator(x: map(int(64),int(64),false))
 mapIterators.chpl:9: warning: 'map.items' is deprecated. Consider 'map.keys' to iterate over keys or 'map.values' to iterate over values.
 0

--- a/test/trivial/diten/printvisibleOptFalse.good
+++ b/test/trivial/diten/printvisibleOptFalse.good
@@ -23,14 +23,14 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/ChapelUtil.chpl:48: chpl_deinitModules
   modules/minimal/internal/IO.chpl:23: errorCode
   modules/minimal/internal/IO.chpl:24: qio_channel_ptr_t
-  modules/minimal/internal/IO.chpl:31: chpl_qio_setup_plugin_channel
-  modules/minimal/internal/IO.chpl:34: chpl_qio_read_atleast
-  modules/minimal/internal/IO.chpl:37: chpl_qio_write
-  modules/minimal/internal/IO.chpl:40: chpl_qio_channel_close
-  modules/minimal/internal/IO.chpl:43: chpl_qio_filelength
-  modules/minimal/internal/IO.chpl:46: chpl_qio_fsync
-  modules/minimal/internal/IO.chpl:49: chpl_qio_get_chunk
-  modules/minimal/internal/IO.chpl:52: chpl_qio_get_locales_for_region
-  modules/minimal/internal/IO.chpl:55: chpl_qio_file_close
+  modules/minimal/internal/IO.chpl:29: chpl_qio_setup_plugin_channel
+  modules/minimal/internal/IO.chpl:32: chpl_qio_read_atleast
+  modules/minimal/internal/IO.chpl:35: chpl_qio_write
+  modules/minimal/internal/IO.chpl:38: chpl_qio_channel_close
+  modules/minimal/internal/IO.chpl:41: chpl_qio_filelength
+  modules/minimal/internal/IO.chpl:44: chpl_qio_fsync
+  modules/minimal/internal/IO.chpl:47: chpl_qio_get_chunk
+  modules/minimal/internal/IO.chpl:50: chpl_qio_get_locales_for_region
+  modules/minimal/internal/IO.chpl:53: chpl_qio_file_close
   modules/minimal/internal/MemTracking.chpl:32: chpl_memTracking_returnConfigVals
   printvisibleOptFalse.chpl:1: xyzSymbol

--- a/test/trivial/diten/printvisibleOptFalse.good
+++ b/test/trivial/diten/printvisibleOptFalse.good
@@ -23,7 +23,6 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/ChapelUtil.chpl:48: chpl_deinitModules
   modules/minimal/internal/IO.chpl:23: errorCode
   modules/minimal/internal/IO.chpl:24: qio_channel_ptr_t
-  modules/minimal/internal/IO.chpl:29: raw_c_void_ptr
   modules/minimal/internal/IO.chpl:31: chpl_qio_setup_plugin_channel
   modules/minimal/internal/IO.chpl:34: chpl_qio_read_atleast
   modules/minimal/internal/IO.chpl:37: chpl_qio_write


### PR DESCRIPTION
Removes all usages of `raw_c_void_ptr`, which maps to the `PrimitiveType` `dtCVoidPtr` like the old `c_void_ptr`, in favor of the non-primitive `c_ptr(void)`.

With this PR there are no more uses of `raw_c_void_ptr` in module code. However, `dtCVoidPtr` is still used in the compiler for some primitives and compiler-inserted calls. Eventually these usages can be replaced with a well-known `AggregateType` for `c_ptr(void)`, and this PR adds a TODO to do so. However, I think it's not worth doing so now as the work would be made redundant when we bring the Dyno resolver into production.

Follow up to https://github.com/chapel-lang/chapel/pull/22637.

[reviewer info placeholder]

Testing:
- [x] local paratest
- [x] gasnet paratest
- [x] C backend paratest