### PR TITLE
Add note to new warnings about being an error in the future

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -262,6 +262,9 @@ static void checkClass(AggregateType* ct) {
         if (!ct->symbol->hasFlag(FLAG_SUPERCLASS_MARKED_GENERIC) &&
             parent->isGeneric() && !parent->isGenericWithDefaults()) {
           USR_WARN(ct->symbol, "missing '(?)' after a generic parent class");
+          if (fWarnUnstable) {
+            USR_PRINT("this warning may be an error in the future");
+          }
         }
         if (ct->symbol->hasFlag(FLAG_SUPERCLASS_MARKED_GENERIC) &&
             !parent->isGeneric()) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13861,6 +13861,9 @@ void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
           USR_PRINT("consider adding 'owned', 'shared', or 'borrowed'");
           USR_PRINT("if generic memory management is desired, "
                     "use a 'type' field to store the class type");
+          if (fWarnUnstable) {
+            USR_PRINT("this warning may be an error in the future");
+          }
         }
 
         // consider the class type ignoring management for
@@ -13948,6 +13951,9 @@ void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
           USR_WARN(sym, "please use '?' when declaring a %s with generic type",
                    fieldOrVar);
           USR_PRINT(sym, "for example with '%s'", s.c_str());
+        }
+        if (fWarnUnstable) {
+          USR_PRINT("this warning may be an error in the future");
         }
       }
     }

--- a/test/classes/ferguson/inherit-generic-q.compopts
+++ b/test/classes/ferguson/inherit-generic-q.compopts
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/classes/ferguson/inherit-generic-q.good
+++ b/test/classes/ferguson/inherit-generic-q.good
@@ -1,2 +1,3 @@
 inherit-generic-q.chpl:4: warning: missing '(?)' after a generic parent class
+note: this warning may be an error in the future
 inherit-generic-q.chpl:8: error: '(?)' after a concrete parent class

--- a/test/types/records/generic/warn-field-generic-declared-type.compopts
+++ b/test/types/records/generic/warn-field-generic-declared-type.compopts
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/types/records/generic/warn-field-generic-declared-type.good
+++ b/test/types/records/generic/warn-field-generic-declared-type.good
@@ -1,15 +1,20 @@
 warn-field-generic-declared-type.chpl:12: warning: field is declared with generic memory management
 note: consider adding 'owned', 'shared', or 'borrowed'
 note: if generic memory management is desired, use a 'type' field to store the class type
+note: this warning may be an error in the future
 warn-field-generic-declared-type.chpl:21: warning: field is declared with generic memory management
 note: consider adding 'owned', 'shared', or 'borrowed'
 note: if generic memory management is desired, use a 'type' field to store the class type
+note: this warning may be an error in the future
 warn-field-generic-declared-type.chpl:30: warning: field is declared with generic memory management
 note: consider adding 'owned', 'shared', or 'borrowed'
 note: if generic memory management is desired, use a 'type' field to store the class type
+note: this warning may be an error in the future
 warn-field-generic-declared-type.chpl:56: warning: please use '?' when declaring a field with generic type
 warn-field-generic-declared-type.chpl:56: note: for example with 'GR(?)'
+note: this warning may be an error in the future
 warn-field-generic-declared-type.chpl:96: warning: please use 'domain(?)' for the type of a generic field storing any domain
+note: this warning may be an error in the future
 (myfield = 0)
 (myfield = {}) : A(owned MyClass?)
 (myfield = nil) : B(owned MyClass?)

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.compopts
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.compopts
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.good
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.good
@@ -1,15 +1,22 @@
 warn-generic-var-field-no-q.chpl:6: warning: please use '?' when declaring a field with generic type
 warn-generic-var-field-no-q.chpl:6: note: for example with 'GR(?)'
+note: this warning may be an error in the future
 warn-generic-var-field-no-q.chpl:10: warning: please use '?' when declaring a field with generic type
 warn-generic-var-field-no-q.chpl:10: note: for example with 'GR(?)'
+note: this warning may be an error in the future
 warn-generic-var-field-no-q.chpl:14: warning: please use '?' when declaring a field with generic type
 warn-generic-var-field-no-q.chpl:14: note: for example with 'GR(?)'
+note: this warning may be an error in the future
 warn-generic-var-field-no-q.chpl:25: warning: please use '?' when declaring a variable with generic type
 warn-generic-var-field-no-q.chpl:25: note: for example with 'GR(?)'
+note: this warning may be an error in the future
 warn-generic-var-field-no-q.chpl:27: warning: please use '?' when declaring a variable with generic type
 warn-generic-var-field-no-q.chpl:27: note: for example with 'GR(?)'
+note: this warning may be an error in the future
 warn-generic-var-field-no-q.chpl:34: warning: please use '?' when declaring a variable with generic type
 warn-generic-var-field-no-q.chpl:34: note: for example with 'GR(?)'
+note: this warning may be an error in the future
 warn-generic-var-field-no-q.chpl:43: warning: please use '?' when declaring a variable with generic type
 warn-generic-var-field-no-q.chpl:43: note: for example with 'GR(?)'
+note: this warning may be an error in the future
 warn-generic-var-field-no-q.chpl:20: error: done


### PR DESCRIPTION
Adjusts the warnings from PRs #22697 #22745 and #22784 to include a note about the warning possibly being an error in the future when compiling with `--warn-unstable`.

- [ ] full comm=none testing