### PR TITLE
Skip tests that use a really small stack size under baseline

### DIFF
--- a/test/domains/sungeun/assoc/stress.numthr.skipif
+++ b/test/domains/sungeun/assoc/stress.numthr.skipif
@@ -1,3 +1,6 @@
 # Valgrind is exhibiting non-fair scheduling even though it uses fifo.
 # Disable
 CHPL_TEST_VGRND_EXE == on
+
+# The small stack size can be exceeded with baseline
+COMPOPTS <= --baseline

--- a/test/domains/sungeun/assoc/stress.skipif
+++ b/test/domains/sungeun/assoc/stress.skipif
@@ -1,3 +1,6 @@
 # Valgrind is exhibiting non-fair scheduling even though it uses fifo.
 # Disable
 CHPL_TEST_VGRND_EXE == on
+
+# The small stack size can be exceeded with baseline
+COMPOPTS <= --baseline

--- a/test/exercises/RandomNumber6.skipif
+++ b/test/exercises/RandomNumber6.skipif
@@ -1,0 +1,2 @@
+# The small stack size can be exceeded with baseline
+COMPOPTS <= --baseline

--- a/test/parallel/cobegin/deitz/test_many_threads.skipif
+++ b/test/parallel/cobegin/deitz/test_many_threads.skipif
@@ -1,3 +1,6 @@
 # To work as expected, this test requires a tasking layer in which sync
 # var blocks result in task switching.  fifo cannot do this.
 CHPL_TASKS == fifo
+
+# The small stack size can be exceeded with baseline
+COMPOPTS <= --baseline


### PR DESCRIPTION
Some tests that create a lot of concurrent tasks lower the stack size to run on systems with limited memory. This was causing issues for a few tests under baseline since we were exceeded a 128k stack size. This is an unusual situation (small stack size and baseline) so just skip all tests using less than 256K stacks under baseline.