### PR TITLE
Add a user facing task yield

### DIFF
--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -38,6 +38,10 @@ details task parallelism as follows:
 -  :ref:`Serial` describes the serial statement, a structured
    way to suppress parallelism.
 
+-  :ref:`Yield_Task_Execution` describes yielding the current tasks
+    execution.
+
+
 .. _Task_parallelism:
 
 Tasks and Task Parallelism
@@ -839,3 +843,12 @@ generates task according to normal Chapel rules.
 
    because the expression evaluated to determine whether to serialize
    always evaluates to true.
+
+.. _Yield_Task_Execution:
+
+Yielding Task Execution
+-----------------------
+
+Execution of the current task can be explicitly yielded with
+``currentTask.yieldExecution()``, providing an opportunity for other tasks to
+execute.

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -405,7 +405,7 @@ module Atomics {
     inline proc const waitFor(val:bool, param order: memoryOrder = memoryOrder.seqCst): void {
       on this {
         while (this.read(order=memoryOrder.relaxed) != val) {
-          chpl_task_yield();
+          currentTask.yieldExecution();
         }
         chpl_atomic_thread_fence(c_memory_order(order));
       }
@@ -745,7 +745,7 @@ module Atomics {
     inline proc const waitFor(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
       on this {
         while (this.read(order=memoryOrder.relaxed) != val) {
-          chpl_task_yield();
+          currentTask.yieldExecution();
         }
         chpl_atomic_thread_fence(c_memory_order(order));
       }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1764,6 +1764,12 @@ module ChapelBase {
     var _val;
   }
 
+  module currentTask {
+    inline proc yieldExecution() {
+      extern proc chpl_task_yield();
+      chpl_task_yield();
+    }
+  }
   //
   // data structures for naive implementation of end used for
   // sync statements and for joining coforall and cobegin tasks

--- a/modules/internal/ChapelLocks.chpl
+++ b/modules/internal/ChapelLocks.chpl
@@ -46,7 +46,7 @@ module ChapelLocks {
     inline proc lock() {
       on this do
         while l.read() || l.testAndSet(memoryOrder.acquire) do
-          chpl_task_yield();
+          currentTask.yieldExecution();
     }
 
     inline proc unlock() {

--- a/modules/internal/ChapelLocks.chpl
+++ b/modules/internal/ChapelLocks.chpl
@@ -44,9 +44,10 @@ module ChapelLocks {
     }
 
     inline proc lock() {
+      use ChapelBase.currentTask;
       on this do
         while l.read() || l.testAndSet(memoryOrder.acquire) do
-          currentTask.yieldExecution();
+          yieldExecution();
     }
 
     inline proc unlock() {

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -234,7 +234,7 @@ module ChapelSyncvar {
   */
   proc _syncvar.readXX() {
     // Yield to allow readXX in a loop to make progress
-    chpl_task_yield();
+    currentTask.yieldExecution();
     return wrapped.readXX();
   }
 
@@ -897,7 +897,7 @@ module ChapelSyncvar {
   */
   proc _singlevar.readXX() {
     // Yield to allow readXX in a loop to make progress
-    chpl_task_yield();
+    currentTask.yieldExecution();
     return wrapped.readXX();
   }
 

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -124,6 +124,7 @@ module LocaleModelHelpRuntime {
   extern proc chpl_task_addTask(fn: int,
                                 args: chpl_task_bundle_p, args_size: c_size_t,
                                 subloc_id: int);
+  @deprecated("'chpl_task_yield' is deprecated, please use 'currentTask.yieldExecution' instead")
   extern proc chpl_task_yield();
 
   //

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -126,7 +126,7 @@ module NetworkAtomics {
     inline proc const waitFor(val:bool, param order: memoryOrder = memoryOrder.seqCst): void {
       on this {
         while (this.read(order=memoryOrder.relaxed) != val) {
-          chpl_task_yield();
+          currentTask.yieldExecution();
         }
         chpl_atomic_thread_fence(c_memory_order(order));
       }
@@ -327,7 +327,7 @@ module NetworkAtomics {
     inline proc const waitFor(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
       on this {
         while (this.read(order=memoryOrder.relaxed) != val) {
-          chpl_task_yield();
+          currentTask.yieldExecution();
         }
         chpl_atomic_thread_fence(c_memory_order(order));
       }

--- a/modules/packages/ConcurrentMap.chpl
+++ b/modules/packages/ConcurrentMap.chpl
@@ -378,7 +378,7 @@ module ConcurrentMap {
           }
         }
 
-        if shouldYield then chpl_task_yield(); // If lock could not be acquired
+        if shouldYield then currentTask.yieldExecution(); // If lock could not be acquired
         shouldYield = true;
       }
       return nil;
@@ -457,7 +457,7 @@ module ConcurrentMap {
           }
         }
 
-        if shouldYield then chpl_task_yield(); // If lock could not be acquired
+        if shouldYield then currentTask.yieldExecution(); // If lock could not be acquired
         shouldYield = true;
       }
       return retNil;
@@ -549,7 +549,7 @@ module ConcurrentMap {
             }
 
             if (continueFlag == false && deferred != nil) {
-              chpl_task_yield();
+              currentTask.yieldExecution();
             } else if (deferred == nil) then break;
           }
         }
@@ -944,7 +944,7 @@ module ConcurrentMap {
             clearHelper(r, tok);
             increment = true;
           } else {
-            if shouldYield then chpl_task_yield(); // If lock could not be acquired
+            if shouldYield then currentTask.yieldExecution(); // If lock could not be acquired
             shouldYield = true;
           }
         } else {

--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -195,7 +195,7 @@ module CopyAggregation {
         _flushBuffer(loc, bufferIdx, freeData=false);
         opsUntilYield = yieldFrequency;
       } else if opsUntilYield == 0 {
-        chpl_task_yield();
+        currentTask.yieldExecution();
         opsUntilYield = yieldFrequency;
       } else {
         opsUntilYield -= 1;
@@ -297,7 +297,7 @@ module CopyAggregation {
         _flushBuffer(loc, bufferIdx, freeData=false);
         opsUntilYield = yieldFrequency;
       } else if opsUntilYield == 0 {
-        chpl_task_yield();
+        currentTask.yieldExecution();
         opsUntilYield = yieldFrequency;
       } else {
         opsUntilYield -= 1;

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -747,7 +747,7 @@ module DistributedBag {
           break;
         }
 
-        chpl_task_yield();
+        currentTask.yieldExecution();
       }
     }
 
@@ -763,7 +763,7 @@ module DistributedBag {
           }
         }
 
-        chpl_task_yield();
+        currentTask.yieldExecution();
       }
 
       return false;
@@ -1033,7 +1033,7 @@ module DistributedBag {
                   }
                 }
               }
-              chpl_task_yield();
+              currentTask.yieldExecution();
             }
           }
         }
@@ -1102,7 +1102,7 @@ module DistributedBag {
                 }
 
                 // Backoff
-                chpl_task_yield();
+                currentTask.yieldExecution();
               }
 
               iterations = iterations + 1;
@@ -1213,7 +1213,7 @@ module DistributedBag {
                               }
 
                               // Backoff...
-                              chpl_task_yield();
+                              currentTask.yieldExecution();
                             }
                           }
                         }
@@ -1224,7 +1224,7 @@ module DistributedBag {
                       ref recvSegment = segments[segmentIdx];
                       while true {
                         if recvSegment.currentStatus == STATUS_UNLOCKED && recvSegment.acquireWithStatus(STATUS_ADD) then break;
-                        chpl_task_yield();
+                        currentTask.yieldExecution();
                       }
 
                       // Add stolen elements to segment...
@@ -1256,7 +1256,7 @@ module DistributedBag {
               }
 
               // Backoff to maximum...
-              chpl_task_yield();
+              currentTask.yieldExecution();
             }
           }
 

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -389,7 +389,7 @@ module DistributedDeque {
             var readSize = queueSize!.read();
             // Attempt to fix, but yield to reduce potential contention and CPU hogging.
             while readSize < 0 && !queueSize!.compareExchangeWeak(readSize, 0) {
-              chpl_task_yield();
+              currentTask.yieldExecution();
             }
           }
 
@@ -433,7 +433,7 @@ module DistributedDeque {
               var readSize = queueSize!.read();
               // Attempt to fix, but yield to reduce potential contention and CPU hogging.
               while readSize > this.cap && !queueSize!.compareExchangeWeak(readSize, this.cap) {
-                chpl_task_yield();
+                currentTask.yieldExecution();
               }
             }
 
@@ -940,7 +940,7 @@ module DistributedDeque {
             // Check if there is an element for us...
             if size.read() == 0 {
               while size.read() == 0 {
-                chpl_task_yield();
+                currentTask.yieldExecution();
               }
             }
 
@@ -1017,7 +1017,7 @@ module DistributedDeque {
             // Check if there is an element for us...
             if size.read() == 0 {
               while size.read() == 0 {
-                chpl_task_yield();
+                currentTask.yieldExecution();
               }
             }
 

--- a/modules/packages/LockFreeQueue.chpl
+++ b/modules/packages/LockFreeQueue.chpl
@@ -161,7 +161,7 @@ module LockFreeQueue {
         else {
           _tail.compareAndSwap(curr_tail, next);
         }
-        chpl_task_yield();
+        currentTask.yieldExecution();
       }
       tok.unpin();
     }
@@ -189,7 +189,7 @@ module LockFreeQueue {
             return (true, ret_val);
           }
         }
-        chpl_task_yield();
+        currentTask.yieldExecution();
       }
 
       tok.unpin();

--- a/modules/packages/LockFreeStack.chpl
+++ b/modules/packages/LockFreeStack.chpl
@@ -149,7 +149,7 @@ module LockFreeStack {
       do {
         var oldTop = _top.read();
         n.next = oldTop;
-        if shouldYield then chpl_task_yield();
+        if shouldYield then currentTask.yieldExecution();
         shouldYield = true;
       } while (!_top.compareAndSwap(oldTop, n));
       tok.unpin();
@@ -167,7 +167,7 @@ module LockFreeStack {
           return (false, retval);
         }
         var newTop = oldTop!.next;
-        if shouldYield then chpl_task_yield();
+        if shouldYield then currentTask.yieldExecution();
         shouldYield = true;
       } while (!_top.compareAndSwap(oldTop, newTop));
       var retval = oldTop!.val;

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -363,7 +363,7 @@ module MPI {
     var flag, ret : c_int;
     ret = C_MPI.MPI_Test(request, flag, status);
     while (flag==0) {
-      chpl_task_yield();
+      currentTask.yieldExecution();
       ret = C_MPI.MPI_Test(request, flag, status);
     }
     return ret;

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -211,7 +211,7 @@ semantically-blocking call to :proc:`Socket.send()` allow other Chapel tasks
 to be scheduled on the OS thread as supported by the tasking layer.
 Internally, the ZMQ module uses non-blocking calls to ``zmq_send()`` and
 ``zmq_recv()`` to transfer data, and yields to the tasking layer via
-`chpl_task_yield()` when the call would otherwise block.
+`currentTask.yieldExecution()` when the call would otherwise block.
 
 Limitations and Future Work
 +++++++++++++++++++++++++++
@@ -904,7 +904,7 @@ module ZMQ {
         while(-1 == zmq_msg_send(msg, classRef.socket,
                                  (ZMQ_DONTWAIT | flags):c_int)) {
           if errno == EAGAIN then
-            chpl_task_yield();
+            currentTask.yieldExecution();
           else {
             try throw_socket_error(errno, "send");
           }
@@ -921,7 +921,7 @@ module ZMQ {
                               numBytes(T):c_size_t,
                               (ZMQ_DONTWAIT | flags):c_int)) {
           if errno == EAGAIN then
-            chpl_task_yield();
+            currentTask.yieldExecution();
           else {
             try throw_socket_error(errno, "send");
           }
@@ -981,7 +981,7 @@ module ZMQ {
         while (-1 == zmq_msg_recv(msg, classRef.socket,
                                   (ZMQ_DONTWAIT | flags):c_int)) {
           if errno == EAGAIN then
-            chpl_task_yield();
+            currentTask.yieldExecution();
           else {
             try throw_socket_error(errno, "recv");
           }
@@ -1021,7 +1021,7 @@ module ZMQ {
                               numBytes(T):c_size_t,
                               (ZMQ_DONTWAIT | flags):c_int)) {
           if errno == EAGAIN then
-            chpl_task_yield();
+            currentTask.yieldExecution();
           else {
             try throw_socket_error(errno, "recv");
           }

--- a/test/chplvis/benchmarks-hpcc/ra-vdb.chpl
+++ b/test/chplvis/benchmarks-hpcc/ra-vdb.chpl
@@ -258,7 +258,7 @@ record vlock {
     this.l = other.l.read();
   }
   proc lock() {
-    on this do while l.testAndSet() != false do chpl_task_yield();
+    on this do while l.testAndSet() != false do currentTask.yieldExecution();
   }
   proc unlock() {
     l.write(false);

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -46,6 +46,8 @@ OwnedObject
   from print-module-resolution.ChapelStandard.OwnedObject
 MemConsistency
   from print-module-resolution.ChapelStandard.SharedObject.Errors.ChapelLocks.Atomics.MemConsistency
+currentTask
+  from print-module-resolution.ChapelStandard.SharedObject.Errors.ChapelLocks.Atomics.currentTask
 Atomics
   from print-module-resolution.ChapelStandard.SharedObject.Errors.ChapelLocks.Atomics
 ChapelLocks

--- a/test/deprecated/taskYield.chpl
+++ b/test/deprecated/taskYield.chpl
@@ -1,0 +1,1 @@
+chpl_task_yield();

--- a/test/deprecated/taskYield.good
+++ b/test/deprecated/taskYield.good
@@ -1,0 +1,1 @@
+taskYield.chpl:1: warning: 'chpl_task_yield' is deprecated, please use 'currentTask.yieldExecution' instead

--- a/test/library/packages/Collection/CollectionNQueens.chpl
+++ b/test/library/packages/Collection/CollectionNQueens.chpl
@@ -166,7 +166,7 @@ coforall loc in Locales do on loc {
           halt("Spun: ", nSpins);
         }
 
-        chpl_task_yield();
+        currentTask.yieldExecution();
         continue;
       }
 

--- a/test/library/packages/Sort/RadixSort/ips4o-like.chpl
+++ b/test/library/packages/Sort/RadixSort/ips4o-like.chpl
@@ -1334,7 +1334,7 @@ proc parallelInPlacePartition(start_n: int, end_n: int,
             // Make sure no other task is currently reading this block
             on bp {
               while (bp.isReading()) {
-                chpl_task_yield();
+                currentTask.yieldExecution();
               }
             }
             // Write the block

--- a/test/modules/OS/POSIX/select.chpl
+++ b/test/modules/OS/POSIX/select.chpl
@@ -31,7 +31,7 @@ proc beReader(fds:[] c_int) {
   var fdset:fd_set;
   var timeout:struct_timeval;
   while numReceived < numXfers {
-    chpl_task_yield();
+    currentTask.yieldExecution();
     const (fdMin, fdMax) = fdsetSetup(c_ptrTo(fdset), fds);
     timeout.tv_sec = 0:time_t;             // timeout = 0.1 sec
     timeout.tv_usec = 100_000:suseconds_t;
@@ -81,7 +81,7 @@ proc beWriter(fds:[] c_int) {
   var timeout:struct_timeval;
   var numSent = 0;
   while numSent < numXfers {
-    chpl_task_yield();
+    currentTask.yieldExecution();
     const (fdMin, fdMax) = fdsetSetup(c_ptrTo(fdset), fds);
     timeout.tv_sec = 0:time_t;             // timeout = 0.1 sec
     timeout.tv_usec = 100_000:suseconds_t;

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -3,6 +3,7 @@ Initializing Modules:
     OwnedObject
     Atomics
      MemConsistency
+     currentTask
     ChapelThreads
     ChapelTuple
      DSIUtil

--- a/test/optimizations/forall-unordered-opt/compilation-tests/opt-unexpected.chpl
+++ b/test/optimizations/forall-unordered-opt/compilation-tests/opt-unexpected.chpl
@@ -208,7 +208,7 @@ proc mini_lock() {
   forall r in 1..M {
     // Acquire the lock
     while myLock.compareAndSwap(0, 1) {
-      //chpl_task_yield();
+      //currentTask.yieldExecution();
     }
     // do something meaningful
 
@@ -225,7 +225,7 @@ proc doCmpXchng(ref myLock: atomic int) {
 
 proc lock(ref myLock: atomic int) {
   while doCmpXchng(myLock) == false {
-    //chpl_task_yield();
+    //currentTask.yieldExecution();
   }
 }
 
@@ -251,7 +251,7 @@ proc mini_lock3() {
     var x = 1;
     while x < 10000 {
       while myLock.compareAndSwap(0, 1) {
-        //chpl_task_yield();
+        //currentTask.yieldExecution();
       }
       x += 1;
     }

--- a/test/parallel/sync/figueroa/ReadMethods.chpl
+++ b/test/parallel/sync/figueroa/ReadMethods.chpl
@@ -17,7 +17,7 @@ proc foo(type t, u: t, v: t, name) {
       done.writeEF(true);
       write  ("2: value has changed to ", s.readFF());
       writeln(" and it is ", if s.isFull then "full" else "empty");
-      chpl_task_yield();
+      currentTask.yieldExecution();
       writeln("2: after sleeping, value is still ", s.readXX());
       s.reset();
       writeln("2: value has been reset to ", s.readFE());

--- a/test/parallel/taskCompare/elliot/chpl-taskyield.chpl
+++ b/test/parallel/taskCompare/elliot/chpl-taskyield.chpl
@@ -21,7 +21,7 @@ proc taskYield(oversub) {
     var i: int;
     for 1..numTrials {
       i += 1;
-      chpl_task_yield();
+      currentTask.yieldExecution();
     }
     total.add(i);
   }

--- a/test/parallel/taskCount/runningTaskCount/moved-on.chpl
+++ b/test/parallel/taskCount/runningTaskCount/moved-on.chpl
@@ -18,7 +18,7 @@ proc main() {
       mytask();
 
       // wait for 2nd task to migrate (if it'll actually migrate)
-      if numLocales > 1 then while (here.runningTasks() != 2) { chpl_task_yield(); }
+      if numLocales > 1 then while (here.runningTasks() != 2) { currentTask.yieldExecution(); }
       writeln("\n", here.runningTasks());
       on Locales[1%numLocales] do setDoneSpinning();
       bar.barrier();

--- a/test/release/examples/benchmarks/hpcc/ra.chpl
+++ b/test/release/examples/benchmarks/hpcc/ra.chpl
@@ -250,7 +250,7 @@ record vlock {
     this.l = other.l.read();
   }
   proc lock() {
-    on this do while l.testAndSet() != false do chpl_task_yield();
+    on this do while l.testAndSet() != false do currentTask.yieldExecution();
   }
   proc unlock() {
     l.write(false);

--- a/test/release/examples/benchmarks/hpcc/variants/ra-cleanloop.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/ra-cleanloop.chpl
@@ -253,7 +253,7 @@ record vlock {
     this.l = other.l.read();
   }
   proc lock() {
-    on this do while l.testAndSet() != false do chpl_task_yield();
+    on this do while l.testAndSet() != false do currentTask.yieldExecution();
   }
   proc unlock() {
     l.write(false);

--- a/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
@@ -151,7 +151,7 @@ class Chameneos {
       if spinCount then
         spinCount -= 1;
       else
-        chpl_task_yield();
+        currentTask.yieldExecution();
     }
     meetingCompleted.write(false);
   }

--- a/test/release/examples/benchmarks/shootout/meteor-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/meteor-fast.chpl
@@ -353,7 +353,7 @@ record BackoffSpinLock {
       lockAttempts += 1;
       if (lockAttempts & maxLockAttempts) == 0 {
         maxLockAttempts >>= 1;
-        chpl_task_yield();
+        currentTask.yieldExecution();
       }
     }
   }

--- a/test/studies/bale/aggregation/AtomicAggregation.chpl
+++ b/test/studies/bale/aggregation/AtomicAggregation.chpl
@@ -59,7 +59,7 @@ module AtomicAggregation {
         _flushBuffer(loc, bufferIdx, freeData=false);
         opsUntilYield = yieldFrequency;
       } else if opsUntilYield == 0 {
-        chpl_task_yield();
+        currentTask.yieldExecution();
         opsUntilYield = yieldFrequency;
       } else {
         opsUntilYield -= 1;

--- a/test/studies/bale/toposort/toposort.chpl
+++ b/test/studies/bale/toposort/toposort.chpl
@@ -62,7 +62,7 @@ class AtomicLock {
   }
 
   proc lock(){
-    while lock$.testAndSet() do chpl_task_yield();
+    while lock$.testAndSet() do currentTask.yieldExecution();
   }
 
   proc unlock(){
@@ -202,7 +202,7 @@ class ParallelWorkQueue {
           yield work;
         }
       } else  {
-        chpl_task_yield();
+        currentTask.yieldExecution();
       }
 
       delete unlockedQueue;
@@ -369,7 +369,7 @@ class LocalDistributedWorkQueue {
             yield work;
           }
         } else  {
-          chpl_task_yield();
+          currentTask.yieldExecution();
         }
 
         delete unlockedQueue;

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -195,7 +195,7 @@ class LocAccumStencilArr {
   // not have an on statement around the while loop below (to avoid
   // the repeated on's from calling testAndSet()).
   inline proc lockLocRAD() {
-    while locRADLock.testAndSet() do chpl_task_yield();
+    while locRADLock.testAndSet() do currentTask.yieldExecution();
   }
 
   inline proc unlockLocRAD() {

--- a/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
@@ -861,7 +861,7 @@ proc bsIncorporateOthersPartSums(diaFrom, diaTo, locId1, locId2) {
       seenOther = false;
       // since incorporation in ihelper
       for l2 in 0..#tl2 do ihelper(partSums[l2], l2);
-      if !seenOther then chpl_task_yield();
+      if !seenOther then currentTask.yieldExecution();
     }
 
 }  // bsIncorporateOthersPartSums

--- a/test/studies/hpcc/HPL/vass/hpl.performance.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.performance.chpl
@@ -814,7 +814,7 @@ proc bsIncorporateOthersPartSums(diaFrom, diaTo, locId1, locId2) {
       seenOther = false;
       // since incorporation in ihelper
       for l2 in 0..#tl2 do ihelper(partSums[l2], l2);
-      if !seenOther then chpl_task_yield();
+      if !seenOther then currentTask.yieldExecution();
     }
   // We must have seen *something* the last time around.
   if checkBsub then assert(seenOther, "bsI-2");

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
@@ -169,7 +169,7 @@ class Chameneos {
       if spinCount then
         spinCount -= 1;
       else
-        chpl_task_yield();
+        currentTask.yieldExecution();
     }
     meetingCompleted.write(false);
   }

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -159,7 +159,7 @@ class Chameneos {
       if spinCount then
         spinCount -= 1;
       else
-        chpl_task_yield();
+        currentTask.yieldExecution();
     }
     meetingCompleted.write(false);
   }

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -165,7 +165,7 @@ class Chameneos {
       if spinCount then
         spinCount -= 1;
       else
-        chpl_task_yield();
+        currentTask.yieldExecution();
     }
     meetingCompleted.write(false);
   }

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
@@ -1,5 +1,3 @@
-extern proc chpl_task_yield();
-
 /*  - The Chameneos game is as follows:
       A population of n chameneos gathers at a common meeting place, where
       m meetings will take place (n and m may be distinct).  At any time, only
@@ -132,7 +130,7 @@ class Chameneos {
           meetingsWithSelf += is_same;
         } else {
           while (meetingCompleted.read() == 0) {
-            chpl_task_yield();
+            currentTask.yieldExecution();
           }
           meetingCompleted.write(0);
           stateTemp = meetingPlace.state.read();

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
@@ -1,5 +1,3 @@
-extern proc chpl_task_yield();
-
 /*  - The Chameneos game is as follows:
       A population of n chameneos gathers at a common meeting place, where
       m meetings will take place (n and m may be distinct).  At any time, only
@@ -158,7 +156,7 @@ class Chameneos {
       }
       if !completed {
         // not ready, yield the task
-        chpl_task_yield();
+        currentTask.yieldExecution();
       } else {
         // done
         break;

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
@@ -112,7 +112,7 @@ class Chameneos {
         } else {
           // Attend meeting
 
-          // This version uses waitFor instead of chpl_task_yield
+          // This version uses waitFor instead of currentTask.yieldExecution
           meetingCompleted.waitFor(true);
 
           meetingCompleted.write(false, memoryOrder.release);

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
@@ -1,5 +1,3 @@
-extern proc chpl_task_yield();
-
 /*  - The Chameneos game is as follows:
       A population of n chameneos gathers at a common meeting place, where
       m meetings will take place (n and m may be distinct).  At any time, only
@@ -116,7 +114,7 @@ class Chameneos {
 
           // Gives slightly better performance than waitFor, but is not "nicer"
           while (!meetingCompleted.read(memoryOrder.acquire)) {
-            chpl_task_yield();
+            currentTask.yieldExecution();
           }
 
           meetingCompleted.write(false, memoryOrder.release);

--- a/test/studies/shootout/submitted/archive/chameneosredux2.chpl
+++ b/test/studies/shootout/submitted/archive/chameneosredux2.chpl
@@ -146,7 +146,7 @@ class Chameneos {
       if spinCount then
         spinCount -= 1;
       else
-        chpl_task_yield();
+        currentTask.yieldExecution();
     }
     meetingCompleted.write(false);
   }

--- a/test/studies/shootout/submitted/archive/meteor2.chpl
+++ b/test/studies/shootout/submitted/archive/meteor2.chpl
@@ -360,7 +360,7 @@ record BackoffSpinLock {
       lockAttempts += 1;
       if (lockAttempts & maxLockAttempts) == 0 {
         maxLockAttempts >>= 1;
-        chpl_task_yield();
+        currentTask.yieldExecution();
       }
     }
   }

--- a/test/studies/ssca2/main/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/main/SSCA2_Modules/SSCA2_kernels.chpl
@@ -615,7 +615,7 @@ module SSCA2_kernels
     proc gettid() {
       const tid = this.currTPV.fetchAdd(1)%numTPVs;
       on this.TPV[tid] do
-        while this.TPV[tid]!.used.testAndSet() do chpl_task_yield();
+        while this.TPV[tid]!.used.testAndSet() do currentTask.yieldExecution();
       return tid;
     }
     proc getTPV(tid) {

--- a/test/studies/ssca2/rachels/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/rachels/SSCA2_kernels.chpl
@@ -608,7 +608,7 @@ module SSCA2_kernels
     proc gettid() {
       const tid = this.currTPV.fetchAdd(1)%numTPVs;
       on this.TPV[tid] do
-        while this.TPV[tid]!.used.testAndSet() do chpl_task_yield();
+        while this.TPV[tid]!.used.testAndSet() do currentTask.yieldExecution();
       return tid;
     }
     proc getTPV(tid) {

--- a/test/users/aroonsharma/CyclicZipOpt.chpl
+++ b/test/users/aroonsharma/CyclicZipOpt.chpl
@@ -1022,7 +1022,7 @@ class LocCyclicZipOptArr {
   // not have an on statement around the while loop below (to avoid
   // the repeated on's from calling testAndSet()).
   inline proc lockLocRAD() {
-    while locRADLock.testAndSet() do chpl_task_yield();
+    while locRADLock.testAndSet() do currentTask.yieldExecution();
   }
 
   inline proc unlockLocRAD() {


### PR DESCRIPTION
Explicitly yielding a task is important for avoiding deadlock in busy-loops and we also use it code like aggregators to give other task a chance to run and let remote tasks make progress sooner.  However, historically we have not had a user-facing mechanism and just relied on the runtime `chpl_task_yield()` function.

This adds a user-facing version `currentTask.yieldExecution()`. This is implemented as a `currentTask` namespace (similar to C++ `this_thread` and a `yieldExecution` function. Chapel tasks are anonymous, so this was done to make it clear you're only operating on the current task and it's not possible to capture. This namespace is also somewhere we can attach other task specific functions too in the future (e.g. `currentTask.id`).  We consider task yielding a core part of Chapel, so it's available by default.

Note that while `chpl_task_yield()` was never meant to be user-facing, it did end up in user codes. Because of this, I deprecated it instead of just making it unavailable.

Resolves #10977