### PR TITLE
Deprecate dereference in put/get primitives

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5413,7 +5413,10 @@ static void codegenPutGet(CallExpr* call, GenRet &ret) {
 
       // c_ptr/ddata are already addresses, so dereference one level.
       if (dt->hasFlag(FLAG_DATA_CLASS)) {
-        USR_WARN(call, "fixme to not do dereference");
+        USR_WARN(call,
+                "put/get primitive special behavior for "
+                "c_ptr/_ddata will be removed -- please pass a ref "
+                "to the primitive");
         localAddr = codegenValue(localAddr);
       }
     }
@@ -5463,7 +5466,10 @@ static void codegenPutGet(CallExpr* call, GenRet &ret) {
       remoteAddr = codegenRaddr(remoteAddr);
 
     } else if (t->hasFlag(FLAG_DATA_CLASS) == true)  {
-      USR_WARN(call, "fixme to not do dereference");
+      USR_WARN(call,
+                "put/get primitive special behavior for "
+                "c_ptr/_ddata will be removed -- please pass a ref "
+                "to the primitive");
       remoteAddr = codegenValue(remoteAddr);
 
     } else if (curArg->isRef()        == false) {

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5413,6 +5413,7 @@ static void codegenPutGet(CallExpr* call, GenRet &ret) {
 
       // c_ptr/ddata are already addresses, so dereference one level.
       if (dt->hasFlag(FLAG_DATA_CLASS)) {
+        USR_WARN(call, "fixme to not do dereference");
         localAddr = codegenValue(localAddr);
       }
     }
@@ -5462,6 +5463,7 @@ static void codegenPutGet(CallExpr* call, GenRet &ret) {
       remoteAddr = codegenRaddr(remoteAddr);
 
     } else if (t->hasFlag(FLAG_DATA_CLASS) == true)  {
+      USR_WARN(call, "fixme to not do dereference");
       remoteAddr = codegenValue(remoteAddr);
 
     } else if (curArg->isRef()        == false) {

--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -80,8 +80,12 @@ module ChapelGpuSupport {
     on __primitive("chpl_on_locale_num",
                    chpl_buildLocaleID(src_node, src_subloc)) {
 
-      __primitive("chpl_comm_put", raddr:c_ptr(uint(8)), dst_node,
-                  dst_subloc, addr:c_ptr(uint(8)), size);
+      // communicate to the primitive using a reference rather than a ptr
+      // the primitive will copy data using these references
+      const ref addrRef = (addr:c_ptr(uint(8))).deref();
+      ref raddrRef = (raddr:c_ptr(uint(8))).deref();
+      __primitive("chpl_comm_put", raddrRef, dst_node,
+                  dst_subloc, addrRef, size);
 
     }
   }
@@ -99,8 +103,12 @@ module ChapelGpuSupport {
     on __primitive("chpl_on_locale_num",
                    chpl_buildLocaleID(dst_node, dst_subloc)) {
 
-      __primitive("chpl_comm_get", raddr:c_ptr(uint(8)), src_node,
-                  src_subloc, addr:c_ptr(uint(8)), size);
+      // communicate to the primitive using a reference rather than a ptr
+      // the primitive will copy data using these references
+      ref addrRef = (addr:c_ptr(uint(8))).deref();
+      const ref raddrRef = (raddr:c_ptr(uint(8))).deref();
+      __primitive("chpl_comm_get", raddrRef, src_node,
+                  src_subloc, addrRef, size);
 
     }
   }

--- a/modules/standard/Communication.chpl
+++ b/modules/standard/Communication.chpl
@@ -58,8 +58,11 @@ module Communication {
       }
     }
 
-    __primitive("chpl_comm_get", dest:c_ptr(uint(8)), srcLocID,
-                src:c_ptr(uint(8)), numBytes);
+    // communicate to the primitive using a reference rather than a ptr
+    // the primitive will copy data using these references
+    ref destRef = (dest:c_ptr(uint(8))).deref();
+    const ref srcRef = (src:c_ptr(uint(8))).deref();
+    __primitive("chpl_comm_get", destRef, srcLocID, srcRef, numBytes);
   }
 
   /*
@@ -84,7 +87,11 @@ module Communication {
              ") for Communication.put is negative.");
       }
     }
-    __primitive("chpl_comm_put", src:c_ptr(uint(8)), destLocID,
-                dest:c_ptr(uint(8)), numBytes);
+
+    // communicate to the primitive using a reference rather than a ptr
+    // the primitive will copy data using these references
+    const ref srcRef = (src:c_ptr(uint(8))).deref();
+    ref destRef = (dest:c_ptr(uint(8))).deref();
+    __primitive("chpl_comm_put", srcRef, destLocID, destRef, numBytes);
   }
 }


### PR DESCRIPTION
PR #2884 added a dereference in code that is now `codegenPutGet`, so that `chpl_string_comm_get` could use the primitive to move data from one `c_ptr` to another.

However, efforts to replace `c_string` with `c_ptrConst(c_char)` in #22622 have run into challenges due to this change. In particular, since `c_string` used to be a primitive type (meaning it did not have `FLAG_DATA_CLASS`, but its replacement does have that flag, we were seeing problems in an HDF5 test related to this logic, when trying to bulk transfer arrays of `c_string` / `c_ptrConst(c_char)`. But, the array bulk transfer logic shouldn't be dereferencing `c_ptr` elements, so this seems to be a latent bug.

The fix here is to change the primitive to always expect references and to adjust the Chapel code invoking it to create references from the `c_ptr`s when working with `c_ptr`s. This PR also adds a warning to the code generator case that should be removed in the future. That way, we can find and fix any cases that are revealed in nightly testing before fully removing it. We will need to remove those blocks to address the problem that #22622 faces in this area.

Reviewed by @dlongnecke-cray - thanks!

- [x] full comm=gasnet testing
- [x] full comm=none testing