### PR TITLE
add note about privileges to `chown` docs

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -219,6 +219,12 @@ proc chmod(name: string, mode: int) throws {
    to the specified values.  If `uid` or `gid` are -1, the value in question
    will remain unchanged.
 
+   .. note::
+
+      Changing the owner typically requires root or elevated privileges.
+      Changing the group typically requires being the owner and a member of the
+      group, or having elevated privileges.
+
    :arg name: The name of the file to be changed.
    :type name: `string`
    :arg uid: The intended new owner(user) id, or -1 if it should remain the


### PR DESCRIPTION
This PR adds a note to the documentation on `FileSystem.chown` to indicate that the operations typically require elevated privileges or a combination of file ownership and group membership.

The addition was motivated by discussion summarized in https://github.com/Cray/chapel-private/issues/5015, with the goal of being explicit about the limitations of the operation. 

Testing:

- [x] manually review built html docs

[reviewed by @lydia-duncan - thank you!]