### PR TITLE
Use --fast in a GPU test that times out occasionally

### DIFF
--- a/test/gpu/native/largeLoop.compopts
+++ b/test/gpu/native/largeLoop.compopts
@@ -1,0 +1,4 @@
+# this test has a very long running loop that causes timeouts. Even though this
+# isn't a performance test, I am throwing `--fast` to make sure that test
+# finishes quickly.
+--fast

--- a/test/gpu/native/largeLoop.good
+++ b/test/gpu/native/largeLoop.good
@@ -1,1 +1,0 @@
-warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly


### PR DESCRIPTION
The "largeLoop" test times out occasionally. It is important to have a loop tripping enough times to overflow a 32-bit ints. So, I can't make the loop shorter. But luckily `--fast` improves the kernel performance significantly (`--no-checks` is already implied).

The test is about 2x faster with gasnet after this PR.