### PR TITLE
Fix up distributions for Block-Sparse Domains/Arrays

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -473,6 +473,14 @@ record Block {
       return newRectangularDom(rank, idxType, strides, ranges, definedConst);
     }
 
+    proc newSparseDom(param rank: int, type idxType, dom: domain) {
+      var x = _value.dsiNewSparseDom(rank, idxType, dom);
+      if x.linksDistribution() {
+        _value.add_dom(x);
+      }
+      return x;
+    }
+
     proc idxToLocale(ind) do return _value.dsiIndexToLocale(ind);
 
     proc writeThis(f) throws {

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -603,6 +603,13 @@ class LocSparseBlockArr {
   }
 }
 
+proc SparseBlockDom.dsiGetDist() {
+  if _isPrivatized(dist) then
+    return new Block(dist.pid, dist, _unowned=true);
+  else
+    return new Block(nullPid, dist, _unonwned=true);
+}
+
 /*
 
 Some old code that might be useful to draw from as this

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -103,7 +103,7 @@ module ChapelDomain {
   }
 
   pragma "runtime type init fn"
-  proc chpl__buildSparseDomainRuntimeType(dist: _distribution,
+  proc chpl__buildSparseDomainRuntimeType(dist,
                                           parentDom: domain) type {
     if ! isUltimatelyRectangularParent(parentDom) then
       compilerError("sparse subdomains are currently supported only for " +
@@ -1189,7 +1189,7 @@ module ChapelDomain {
     }
 
     @deprecated("domain.dist is deprecated, please use domain.distribution instead")
-    proc dist do return _getDistribution(_value.dist);
+    proc dist do return this.distribution;
 
     /* Return the number of dimensions in this domain */
     proc rank param {
@@ -2658,7 +2658,7 @@ module ChapelDomain {
       // could add e.g. dsiDefaultSparseDist to the DSI interface
       // and have this function use _value.dsiDefaultSparseDist()
       // (or perhaps _value.dist.dsiDefaultSparseDist() ).
-      return _getDistribution(_value.dist);
+      return this.distribution;
     }
 
     // returns a default rectangular domain

--- a/test/distributions/sparseBlock/distTypeTest.chpl
+++ b/test/distributions/sparseBlock/distTypeTest.chpl
@@ -1,0 +1,48 @@
+use BlockDist, Reflection;
+
+var Dist = new Block({1..10});
+var Dom = {1..10} dmapped Dist;
+var A: [Dom] real;
+
+var SpsDom: sparse subdomain(Dom);
+var SpsArr: [SpsDom] real;
+
+var SpsDom2: sparse subdomain(A.domain);
+var SpsArr2: [SpsDom2] real;
+
+var B = Block.createArray({1..10}, int);
+var SpsDom3: sparse subdomain(B.domain);
+var SpsArr3: [SpsDom3] real;
+
+writeln(A.domain.type:string);
+writeln(A.domain.distribution.type:string);
+writeln(isBlockDist(A.domain.distribution));
+writeln();
+
+writeln(SpsArr.domain.type:string);
+writeln(SpsArr.domain.distribution.type:string);
+writeln(isBlockDist(SpsArr.domain.distribution));
+writeln();
+
+writeln(SpsArr2.domain.type:string);
+writeln(SpsArr2.domain.distribution.type:string);
+writeln(isBlockDist(SpsArr2.domain.distribution));
+writeln();
+
+writeln(B.domain.type:string);
+writeln(B.domain.distribution.type:string);
+writeln(isBlockDist(B.domain.distribution));
+writeln();
+
+writeln(SpsArr3.domain.type:string);
+writeln(SpsArr3.domain.distribution.type:string);
+writeln(isBlockDist(SpsArr3.domain.distribution));
+writeln();
+
+proc isBlockDist(x: Block(?)) param {
+  return true;
+}
+
+proc isBlockDist(x) param {
+  return false;
+}

--- a/test/distributions/sparseBlock/distTypeTest.good
+++ b/test/distributions/sparseBlock/distTypeTest.good
@@ -1,0 +1,20 @@
+BlockDom(1,int(64),one,unmanaged DefaultDist)
+Block(1,int(64),unmanaged DefaultDist)
+true
+
+SparseBlockDom(1,int(64),BlockDom(1,int(64),one,unmanaged DefaultDist),unmanaged DefaultDist,one)
+Block(1,int(64),unmanaged DefaultDist)
+true
+
+SparseBlockDom(1,int(64),BlockDom(1,int(64),one,unmanaged DefaultDist),unmanaged DefaultDist,one)
+Block(1,int(64),unmanaged DefaultDist)
+true
+
+BlockDom(1,int(64),one,unmanaged DefaultDist)
+Block(1,int(64),unmanaged DefaultDist)
+true
+
+SparseBlockDom(1,int(64),BlockDom(1,int(64),one,unmanaged DefaultDist),unmanaged DefaultDist,one)
+Block(1,int(64),unmanaged DefaultDist)
+true
+


### PR DESCRIPTION
I'd failed to anticipate that if someone made a `.distribution` query on a sparse block-distributed domain that we'd get an old `_distribution()` object back, wrapping a `BlockImpl` class, rather than the new `Block` record type that we'd expect.  It turns out that this tripped up some of the logic in the LinearAlgebra module that was trying to reason about whether a given matrix was distributed or not.  This PR fixes that by adding the new dsiGetDist() call to the SparseBlockDom class, similar to the BlockDom class.

Though that change got the `.distribution` query working properly, it then led to an internal error for some code patterns, which turned out to be due to a code path in 'defaultSparseDist()' that was expecting all domain values to have a `.dist` field that they could use directly and call with `_getDistribution()` (the old / manual / internal way of getting a new `_distribution` object).  Converting this to a call to the new '.distribution' query, which maintains backwards compatibility for the old distribution types while treating Block properly fixed that internal error.

This led me to also notice that the deprecated '.dist' query would also only do the old thing, where we'd want it to also use the same new '.distribution' logic, so I updated it to make that call instead (this was due to bad/lazy merging on my behalf when updating my branch to include the PR that deprecated '.dist', though arguably that PR should've had the deprecated routine call the new routine rather than duplicating its logic).

Added a test that locks in these behaviors somewhere more directly than in the depths of the LinearAlgebra module.