### PR TITLE
Fix dumb typo

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -607,7 +607,7 @@ proc SparseBlockDom.dsiGetDist() {
   if _isPrivatized(dist) then
     return new Block(dist.pid, dist, _unowned=true);
   else
-    return new Block(nullPid, dist, _unonwned=true);
+    return new Block(nullPid, dist, _unowned=true);
 }
 
 /*


### PR DESCRIPTION
I'd mistakenly only tested #22893 with CHPL_COMM=gasnet, thinking that the change was so multi-locale specific that passing there would ensure passing for CHPL_COMM=none.  A post-merge check pointed out I was wrong due to a branch of a param conditional containing a typo.  This fixes that typo.