### PR TITLE
Reduce the number of copies of a 'Block' record made in common code patterns

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -691,7 +691,7 @@ module ChapelArray {
   proc chpl__buildDistValue(in x:owned) where isSubtype(x.borrow().type, BaseDist) {
     return new _distribution(owned.release(x));
   }
-  proc chpl__buildDistValue(x:record) {
+  proc chpl__buildDistValue(ref x:record) ref {
     return x;
   }
 
@@ -699,7 +699,7 @@ module ChapelArray {
     compilerError("illegal domain map value specifier - must be a subclass of BaseDist");
   }
 
-  proc chpl__buildDistDMapValue(x: record) {
+  proc chpl__buildDistDMapValue(ref x: record) ref {
     compilerWarning("The use of 'dmap' is deprecated for this distribution; please replace 'new dmap(new <DistName>(<args>))' with 'new <DistName>(<args>)'");
     return chpl__buildDistValue(x);
   }


### PR DESCRIPTION
In refactoring 'Block' to be a record, I inadvertently added an extra copy of the 'Block' record when creating a new distribution for many common code patterns.  This PR removes the extra copy by updating the 'chpl__buildDistValue() routine (which is intended to just be a pass-through for the case of a record-based distribution) from:

  ```chapel
  proc chpl__buildDistValue(x:record) {
    return x;
  }
  ```

to:

  ```chapel
  proc chpl__buildDistValue(ref x:record) ref {
    return x;
  }
  ```

I'd naively assumed/hoped that with the default intents, copy elision would simply have done this for me automatically, but no such luck.

I then had to do a similar update to the version of chpl__buildDistDMapValue() that takes records for
backwards-compatibility.

This extra copy was only detected by one of our GPU tests because the new copy of 'Block' resulted in an additional array assignment, which resulted in an additional kernel launch.  But since the extra copy of 'Block' results in an extra coforall+on to set up all of the 'LocBlock' classes, I'm surprised that we didn't see any changes in our correctness tests that do communication counts.

TODO:

- [x] look into that last question of "Why didn't other things catch this?" a bit more (Done: See #22898)
