### PR TITLE
Rename `enterThis`/`leaveThis` to `enterContext`/`exitContext`

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1927,7 +1927,7 @@ BlockStmt* buildConditionalLocalStmt(Expr* condExpr, Expr *stmt) {
     // Insertion point for next manager or user block.
   } catch chpl_tmp_err {
     errorCaught = true;
-    manager.leaveThis(chpl_tmp_err);
+    manager.exitContext(chpl_tmp_err);
   }
 
 */
@@ -1944,8 +1944,8 @@ static TryStmt* buildTryCatchForManagerBlock(VarSymbol* managerHandle,
   auto errorCaughtToTrue = new CallExpr(PRIM_MOVE, seErrorCaught, seTrue);
   catchBlock->insertAtTail(errorCaughtToTrue);
 
-  // BUILD: manager.leaveThis(chpl_tmp_err);
-  auto leave = new CallExpr("leaveThis",
+  // BUILD: manager.exitContext(chpl_tmp_err);
+  auto leave = new CallExpr("exitContext",
                             gMethodToken,
                             new SymExpr(managerHandle),
                             new UnresolvedSymExpr(errName));
@@ -1968,17 +1968,17 @@ static TryStmt* buildTryCatchForManagerBlock(VarSymbol* managerHandle,
 
   {
     TEMP ref manager = PRIM_ADDR_OF(myManager());
-    USER [var/ref/const] myResource = manager.enterThis();
+    USER [var/ref/const] myResource = manager.enterContext();
     TEMP errorCaught = false;
 
     try {
       // Insertion point for next manager or user block.
     } catch chpl_temp_err {
       errorCaught = true;
-      manager.leaveThis(chpl_tmp_err);
+      manager.exitContext(chpl_tmp_err);
     }
 
-    if !errorCaught then manager.leaveThis(nil);
+    if !errorCaught then manager.exitContext(nil);
   }
 
 */
@@ -1997,11 +1997,11 @@ BlockStmt* buildManagerBlock(Expr* managerExpr, std::set<Flag>* flags,
   auto moveIntoHandle = new CallExpr(PRIM_MOVE, managerHandle, addrOfExpr);
   ret->insertAtTail(moveIntoHandle);
 
-  // Build call to 'enterThis()', but don't insert into the tree yet.
+  // Build call to 'enterContext()', but don't insert into the tree yet.
   auto seManager = new SymExpr(managerHandle);
-  auto enterThis = new CallExpr("enterThis", gMethodToken, seManager);
+  auto enterContext = new CallExpr("enterContext", gMethodToken, seManager);
 
-  // BUILD: [var/ref/const ref] myResource = manager.enterThis();
+  // BUILD: [var/ref/const ref] myResource = manager.enterContext();
   if (resourceName != nullptr) {
     const bool isResourceStorageKindInferred = (flags == nullptr);
     auto resource = new VarSymbol(resourceName);
@@ -2014,12 +2014,12 @@ BlockStmt* buildManagerBlock(Expr* managerExpr, std::set<Flag>* flags,
       flags = nullptr;
     }
 
-    ret->insertAtTail(new DefExpr(resource, enterThis));
+    ret->insertAtTail(new DefExpr(resource, enterContext));
 
   } else {
 
-    // Otherwise, just make the call to 'enterThis()'.
-    ret->insertAtTail(enterThis);
+    // Otherwise, just make the call to 'enterContext()'.
+    ret->insertAtTail(enterContext);
   }
 
   // BUILD: TEMP var errorCaught = false;
@@ -2030,9 +2030,9 @@ BlockStmt* buildManagerBlock(Expr* managerExpr, std::set<Flag>* flags,
   auto tryCatch = buildTryCatchForManagerBlock(managerHandle, errorCaught);
   ret->insertAtTail(tryCatch);
 
-  // BUILD: if !errorCaught then manager.leaveThis(nil);
+  // BUILD: if !errorCaught then manager.exitContext(nil);
   auto ifCond = new CallExpr(PRIM_UNARY_LNOT, new SymExpr(errorCaught));
-  auto ifBranch = new CallExpr("leaveThis",
+  auto ifBranch = new CallExpr("exitContext",
                                gMethodToken,
                                new SymExpr(managerHandle),
                                gNil);
@@ -2044,11 +2044,11 @@ BlockStmt* buildManagerBlock(Expr* managerExpr, std::set<Flag>* flags,
 
 /*
   Each manager block declares some temporary variables, and then calls the
-  'enterThis()' method on the manager before executing the next block.
+  'enterContext()' method on the manager before executing the next block.
   Managers are nested from left to right, and the final innermost scope is
   the block containing user code.
 
-  Managers call 'leaveThis()' and are deinitialized in the reverse order of
+  Managers call 'exitContext()' and are deinitialized in the reverse order of
   their initialization.
 
   TODO (dlongnecke-cray): In cleanup, recursively lift up the manager out of

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -526,7 +526,7 @@ static Expr* preFoldPrimInitVarForManagerResource(CallExpr* call) {
       //
       //    manage man as res do ...;
       //
-      // It means that multiple candidates were found for 'man.enterThis()'.
+      // It means that multiple candidates were found for 'man.enterContext()'.
       // We currently don't specify a disambiguation order in this case,
       // which means we have no way to determine the storage of 'res'.
       //
@@ -592,12 +592,12 @@ static Expr* preFoldPrimInitVarForManagerResource(CallExpr* call) {
       // case multiple overloads either do not exist, or if they do there
       // is no ambiguity at the callsite.
       } else {
-        auto enterThisCall = toCallExpr(moveIntoTemp->get(2));
+        auto enterContextCall = toCallExpr(moveIntoTemp->get(2));
 
-        INT_ASSERT(enterThisCall);
+        INT_ASSERT(enterContextCall);
 
         // If this doesn't fire, then there was already a resolution error.
-        if (FnSymbol* fn = enterThisCall->resolvedFunction()) {
+        if (FnSymbol* fn = enterContextCall->resolvedFunction()) {
           bool isTagConstRef = fn->retTag == RET_CONST_REF;
           bool isTagRef = fn->retTag == RET_REF;
 

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -992,13 +992,13 @@ in a manage statement.
         var x: int;
       }
 
-      proc IntWrapper.enterThis() ref: int {
+      proc IntWrapper.enterContext() ref: int {
         writeln('entering');
         writeln(this);
         return this.x;
       }
 
-      proc IntWrapper.leaveThis(in error: owned Error?) throws {
+      proc IntWrapper.exitContext(in error: owned Error?) throws {
         if error then throw error;
         writeln('leaving');
         writeln(this);
@@ -1019,21 +1019,21 @@ in a manage statement.
       leaving
       (x = 8)
 
-The ``enterThis()`` special method is called on the manager expression
+The ``enterContext()`` special method is called on the manager expression
 before executing the managed block (in the above example the manager
 expression is ``wrapper``). The method may return a type or value, or
 it may return ``void``.
 
-The resource returned by ``enterThis()`` can be captured by name so
+The resource returned by ``enterContext()`` can be captured by name so
 that it can be referred to within the scope of the managed block
 (in the above example the captured resource is ``val``).
 
 Capturing a returned resource is optional, and the syntax may be
 omitted. It is an error to try to capture a resource if
-``enterThis()`` returns ``void``.
+``enterContext()`` returns ``void``.
 
 The storage of a captured resource may also be omitted, in which
-case it will be inferred from the return intent of the ``enterThis()``
+case it will be inferred from the return intent of the ``enterContext()``
 method (in the above example the storage of ``val`` is inferred
 to be ``ref``).
 
@@ -1049,13 +1049,13 @@ Resource storage may also be specified explicitly.
         var x: int;
       }
 
-      proc IntWrapper.enterThis() ref: int {
+      proc IntWrapper.enterContext() ref: int {
         writeln('entering');
         writeln(this);
         return this.x;
       }
 
-      proc IntWrapper.leaveThis(in error: owned Error?) throws {
+      proc IntWrapper.exitContext(in error: owned Error?) throws {
         if error then throw error;
         writeln('leaving');
         writeln(this);
@@ -1081,26 +1081,26 @@ Resource storage may also be specified explicitly.
       (x = 0)
 
 Because the storage of ``val`` was specified as ``var``, the integer
-field of ``wrapper`` was not modified even though ``enterThis()``
+field of ``wrapper`` was not modified even though ``enterContext()``
 returns by ``ref``.
 
 .. note::
 
   *Open issue:*
 
-    The ``enterThis()`` special method does not currently support the
+    The ``enterContext()`` special method does not currently support the
     use of return intent overloading (see :ref:`Return_Intent_Overloads`)
     when the storage of a resource is omitted. Adding such support would
     require additional disambiguation rules, and the value of doing so
     is unclear at this time.
 
-Participating types must also define the ``leaveThis()`` method,
+Participating types must also define the ``exitContext()`` method,
 which is called implicitly when the scope of the managed block
 is exited.
 
-The ``leaveThis()`` method takes an ``Error?`` by ``in`` intent. If
+The ``exitContext()`` method takes an ``Error?`` by ``in`` intent. If
 the error is not ``nil``,  it may be handled within the method. It
-can also be propagated by annotating ``leaveThis()`` with the
+can also be propagated by annotating ``exitContext()`` with the
 ``throws`` tag and throwing the error.
 
 Multiple manager expressions may be present in a single manage
@@ -1116,13 +1116,13 @@ statement.
         var x: int;
       }
 
-      proc IntWrapper.enterThis() ref: int {
+      proc IntWrapper.enterContext() ref: int {
         writeln('entering');
         writeln(this);
         return this.x;
       }
 
-      proc IntWrapper.leaveThis(in error: owned Error?) throws {
+      proc IntWrapper.exitContext(in error: owned Error?) throws {
         if error then throw error;
         writeln('leaving');
         writeln(this);
@@ -1154,7 +1154,7 @@ statement.
       (x = -1)
 
 Before executing the code in the body of the manage statement, the
-``enterThis()`` method is called on each manager from left to right.
-Upon exiting the managed scope, the ``leaveThis()`` method is called
+``enterContext()`` method is called on each manager from left to right.
+Upon exiting the managed scope, the ``exitContext()`` method is called
 on each manager from right to left.
 

--- a/doc/rst/technotes/manage.rst
+++ b/doc/rst/technotes/manage.rst
@@ -25,22 +25,22 @@ The manager may optionally return a `resource`. If a developer wants
 to make use of the resource, they may capture it after the manager
 expression (the `myResource` declaration in the above example).
 The resource may be of any type, and is the value returned by the
-special method called ``enterThis()``.
+special method called ``enterContext()``.
 
 Any aggregate type may be used as a manager as long as it defines
-two special methods called ``enterThis()`` and ``leaveThis()``:
+two special methods called ``enterContext()`` and ``exitContext()``:
 
 .. code-block:: chapel
 
    record myManager {
      var x: int = 0;
 
-     proc enterThis() ref: int {
+     proc enterContext() ref: int {
        writeln('x is: ', x);
        return x;
      }
 
-     proc leaveThis(in err: owned Error?) {
+     proc exitContext(in err: owned Error?) {
        if err then halt(err:string);
        writeln('x is: ', x);
      }
@@ -53,8 +53,8 @@ two special methods called ``enterThis()`` and ``leaveThis()``:
      // Prints '8'
    }
 
-The ``enterThis()`` method is called on the manager before entering
-the managed block. The ``leaveThis()`` method is called on the
+The ``enterContext()`` method is called on the manager before entering
+the managed block. The ``exitContext()`` method is called on the
 manager before leaving the block. It accepts a nilable
 ``owned Error?`` by ``in`` intent in order to take ownership of it.
 The type author may decide to rethrow the error or suppress it.
@@ -65,7 +65,7 @@ Status and Future Work
 The behavior of several aspects of the ``manage`` statement have yet
 to be formalized, such as:
 
-- If multiple overloads of ``enterThis()`` exist that have different
+- If multiple overloads of ``enterContext()`` exist that have different
   return intents, it is unclear what the disambiguation order used
   to select an overload should be.
 - It is uncertain whether or not the storage kind (e.g. ``var``) of
@@ -79,9 +79,9 @@ to be formalized, such as:
   Should explicit declaration of the ``var`` storage kind for `bar`
   be allowed?
 
-- It is unclear how the ``leaveThis()`` method of a manager should
-  interact with errors beyond guaranteeing that ``leaveThis()``
+- It is unclear how the ``exitContext()`` method of a manager should
+  interact with errors beyond guaranteeing that ``exitContext()``
   is called even if an error is thrown from within a managed block.
-- The names of the special methods ``enterThis()`` and ``leaveThis()``
+- The names of the special methods ``enterContext()`` and ``exitContext()``
   are unstable and subject to change.
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1802,14 +1802,14 @@ module ChapelBase {
   record endCountDiagsManager {
     var taskInfo: c_ptr(chpl_task_infoChapel_t);
     var prevDiagsDisabledVal: bool;
-    inline proc enterThis() : void {
+    inline proc enterContext() : void {
       if !commDiagsTrackEndCounts {
         taskInfo = chpl_task_getInfoChapel();
         prevDiagsDisabledVal = chpl_task_data_setCommDiagsTemporarilyDisabled(taskInfo, true);
       }
     }
 
-    inline proc leaveThis(in unused: owned Error?) {
+    inline proc exitContext(in unused: owned Error?) {
       if !commDiagsTrackEndCounts {
         chpl_task_data_setCommDiagsTemporarilyDisabled(taskInfo, prevDiagsDisabledVal);
       }

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1856,7 +1856,7 @@ module ChapelDomain {
       }
 
       @chpldoc.nodoc
-      proc enterThis() ref {
+      proc enterContext() ref {
 
         // TODO: Is it possible to nest unsafe assignments? Future work...
         if _isActiveManager {
@@ -1910,7 +1910,7 @@ module ChapelDomain {
       }
 
       @chpldoc.nodoc
-      proc leaveThis(in err: owned Error?) throws {
+      proc exitContext(in err: owned Error?) throws {
         _ensureNoLongerManagingThis();
         if err then throw err;
       }

--- a/test/library/draft/DistributedMap/DistributedMap.chpl
+++ b/test/library/draft/DistributedMap/DistributedMap.chpl
@@ -200,7 +200,7 @@ record distributedMapManager {
     this.key    = k;
   }
 
-  proc enterThis() ref {
+  proc enterContext() ref {
     // todo: optimize remote accesses here
     client = client.getPrivatizedThisOn(client.targetLocales[locIdx]);
     ref map = client.localMaps[mapIdx];
@@ -208,7 +208,7 @@ record distributedMapManager {
     return map.thisInternal(key);
   }
 
-  proc leaveThis(in err: owned Error?) throws {
+  proc exitContext(in err: owned Error?) throws {
     on client {
       client.localMaps[mapIdx]._leave();
     }

--- a/test/library/draft/DistributedMap/v3/DistributedMap.chpl
+++ b/test/library/draft/DistributedMap/v3/DistributedMap.chpl
@@ -364,12 +364,12 @@ module DistributedMap {
             this.dm = dm;
         }
 
-        proc ref enterThis() ref: dmType {
+        proc ref enterContext() ref: dmType {
             this.dm._incrementStaticCounts();
             return this.dm;
         }
 
-        proc ref leaveThis(in err: owned Error?) {
+        proc ref exitContext(in err: owned Error?) {
             this.dm._decrementStaticCounts();
             this.dm._maybeResizeAndBallance();
             if err then try! { throw err; }

--- a/test/statements/manage/ContextManagerSyntax.chpl
+++ b/test/statements/manage/ContextManagerSyntax.chpl
@@ -4,11 +4,11 @@
 
 use TrackingRecord;
 
-proc r.enterThis() {
+proc r.enterContext() {
   writeln('entering');
 }
 
-proc r.leaveThis(in err: owned Error?) {
+proc r.exitContext(in err: owned Error?) {
   writeln('leaving');
   if err then try! { throw err; }
 }
@@ -21,27 +21,27 @@ record res {
 
 var globalRes = new res();
 
-// Multiple overloads of 'enterThis()' can exist, that just means that the
+// Multiple overloads of 'enterContext()' can exist, that just means that the
 // resource storage cannot be inferred.
 record man {
   var x = new r();
 
-  proc enterThis() ref {
-    writeln('proc man.enterThis() ref: res');
+  proc enterContext() ref {
+    writeln('proc man.enterContext() ref: res');
     return globalRes;
   }
 
-  proc enterThis() const ref {
-    writeln('proc man.enterThis() const ref: res');
+  proc enterContext() const ref {
+    writeln('proc man.enterContext() const ref: res');
     return globalRes;
   }
 
-  proc enterThis() {
-    writeln('proc man.enterThis(): res');
+  proc enterContext() {
+    writeln('proc man.enterContext(): res');
     return globalRes;
   }
 
-  proc leaveThis(in err: owned Error?) {
+  proc exitContext(in err: owned Error?) {
     writeln('leaving');
     if err then try! { throw err; }
   }
@@ -53,14 +53,14 @@ proc doSomething() {
 
 proc test1() {
   writeln('T1');
-  // Calls the value overload of 'enterThis'.
+  // Calls the value overload of 'enterContext'.
   manage new man() do doSomething();
 }
 test1(); writeln();
 
 proc test2() {
   writeln('T2');
-  // Calls the value overload of 'enterThis'.
+  // Calls the value overload of 'enterContext'.
   manage new man() {
     doSomething();
   }

--- a/test/statements/manage/ContextManagerSyntax.good
+++ b/test/statements/manage/ContextManagerSyntax.good
@@ -1,29 +1,29 @@
 T1
 default-init (ptr = {x = 0})
-proc man.enterThis(): res
+proc man.enterContext(): res
 doing something
 leaving
 deinit (ptr = {x = 0})
 
 T2
 default-init (ptr = {x = 1})
-proc man.enterThis(): res
+proc man.enterContext(): res
 doing something
 leaving
 deinit (ptr = {x = 1})
 
 T3
 default-init (ptr = {x = 2})
-proc man.enterThis(): res
+proc man.enterContext(): res
 doing something
 leaving
 deinit (ptr = {x = 2})
 
 T4
 default-init (ptr = {x = 3})
-proc man.enterThis(): res
+proc man.enterContext(): res
 default-init (ptr = {x = 4})
-proc man.enterThis(): res
+proc man.enterContext(): res
 doing something
 leaving
 deinit (ptr = {x = 4})
@@ -33,8 +33,8 @@ deinit (ptr = {x = 3})
 T5
 default-init (ptr = {x = 5})
 default-init (ptr = {x = 6})
-proc man.enterThis(): res
-proc man.enterThis(): res
+proc man.enterContext(): res
+proc man.enterContext(): res
 doing something
 leaving
 leaving
@@ -43,53 +43,53 @@ deinit (ptr = {x = 5})
 
 T6: resource is explicitly var
 default-init (ptr = {x = 7})
-proc man.enterThis(): res
+proc man.enterContext(): res
 doing something with resource
 leaving
 deinit (ptr = {x = 7})
 
 T7: resource is explicitly ref
 default-init (ptr = {x = 8})
-proc man.enterThis() ref: res
+proc man.enterContext() ref: res
 doing something with resource
 leaving
 deinit (ptr = {x = 8})
 
 T8: resource is explicitly const ref
 default-init (ptr = {x = 9})
-proc man.enterThis() const ref: res
+proc man.enterContext() const ref: res
 doing something with resource
 leaving
 deinit (ptr = {x = 9})
 
 T9: resource is explicitly var
 default-init (ptr = {x = 10})
-proc man.enterThis(): res
+proc man.enterContext(): res
 doing something with resource
 leaving
 deinit (ptr = {x = 10})
 
 T10: resource is explicitly ref
 default-init (ptr = {x = 11})
-proc man.enterThis() ref: res
+proc man.enterContext() ref: res
 doing something with resource
 leaving
 deinit (ptr = {x = 11})
 
 T11: resource is explicitly const ref
 default-init (ptr = {x = 12})
-proc man.enterThis() const ref: res
+proc man.enterContext() const ref: res
 doing something with resource
 leaving
 deinit (ptr = {x = 12})
 
 T12: nested managers, mixed resource storage types
 default-init (ptr = {x = 13})
-proc man.enterThis(): res
+proc man.enterContext(): res
 default-init (ptr = {x = 14})
-proc man.enterThis() ref: res
+proc man.enterContext() ref: res
 default-init (ptr = {x = 15})
-proc man.enterThis() const ref: res
+proc man.enterContext() const ref: res
 doing something with resource
 doing something with resource
 doing something with resource
@@ -104,9 +104,9 @@ T13: nested managers, mixed resource storage types
 default-init (ptr = {x = 16})
 default-init (ptr = {x = 17})
 default-init (ptr = {x = 18})
-proc man.enterThis(): res
-proc man.enterThis() ref: res
-proc man.enterThis() const ref: res
+proc man.enterContext(): res
+proc man.enterContext() ref: res
+proc man.enterContext() const ref: res
 doing something with resource
 doing something with resource
 doing something with resource
@@ -119,9 +119,9 @@ deinit (ptr = {x = 16})
 
 T14: same manager nested, mixed resource storage types
 default-init (ptr = {x = 19})
-proc man.enterThis(): res
-proc man.enterThis() ref: res
-proc man.enterThis() const ref: res
+proc man.enterContext(): res
+proc man.enterContext() ref: res
+proc man.enterContext() const ref: res
 doing something with resource
 doing something with resource
 doing something with resource

--- a/test/statements/manage/ExplicitConstRefResourceMutation.chpl
+++ b/test/statements/manage/ExplicitConstRefResourceMutation.chpl
@@ -1,16 +1,16 @@
 record man1 {
   var x = 0;
-  proc enterThis() const ref: int { return x; }
-  proc leaveThis(in err: owned Error?) {
+  proc enterContext() const ref: int { return x; }
+  proc exitContext(in err: owned Error?) {
     if err then halt();
   }
 }
 
 record man2 {
   var x = 0;
-  proc enterThis(): int { return x; }
-  proc enterThis() const ref: int { return x; }
-  proc leaveThis(in err: owned Error?) {
+  proc enterContext(): int { return x; }
+  proc enterContext() const ref: int { return x; }
+  proc exitContext(in err: owned Error?) {
     if err then halt();
   }
 }
@@ -28,7 +28,7 @@ proc test2() {
   var myManager = new man1();
   writeln(myManager);
 
-  // This is OK, we can infer 'man1.enterThis()' due to no overloads.
+  // This is OK, we can infer 'man1.enterContext()' due to no overloads.
   manage myManager as myResource do
     myResource += 1;
 }

--- a/test/statements/manage/InferredConstRefResourceMutation.chpl
+++ b/test/statements/manage/InferredConstRefResourceMutation.chpl
@@ -1,13 +1,13 @@
 record man {
   var x = 0;
-  proc enterThis(): int { return x; }
-  proc enterThis() const ref: int { return x; }
-  proc leaveThis(in err: owned Error?) {
+  proc enterContext(): int { return x; }
+  proc enterContext() const ref: int { return x; }
+  proc exitContext(in err: owned Error?) {
     if err then halt();
   }
 }
 
-// Emit an error because there are two overloads of 'enterThis()'.
+// Emit an error because there are two overloads of 'enterContext()'.
 proc test1() {
   var myManager = new man();
   writeln(myManager);

--- a/test/statements/manage/InferredConstRefResourceMutation.good
+++ b/test/statements/manage/InferredConstRefResourceMutation.good
@@ -1,6 +1,6 @@
-InferredConstRefResourceMutation.chpl:14: error: cannot determine storage for 'myResource' due to multiple return intents for 'man.enterThis()'
+InferredConstRefResourceMutation.chpl:14: error: cannot determine storage for 'myResource' due to multiple return intents for 'man.enterContext()'
 InferredConstRefResourceMutation.chpl:14: note: specify an explicit storage (e.g., 'const ref') to disambiguate
 InferredConstRefResourceMutation.chpl:4: note: return by 'const ref' defined here
 InferredConstRefResourceMutation.chpl:3: note: return by 'value' defined here
-InferredConstRefResourceMutation.chpl:21: error: cannot determine storage for 'myResource' due to multiple return intents for 'man.enterThis()'
+InferredConstRefResourceMutation.chpl:21: error: cannot determine storage for 'myResource' due to multiple return intents for 'man.enterContext()'
 InferredConstRefResourceMutation.chpl:21: note: specify an explicit storage (e.g., 'const ref') to disambiguate

--- a/test/statements/manage/InferredRefResourceMutation.chpl
+++ b/test/statements/manage/InferredRefResourceMutation.chpl
@@ -1,7 +1,7 @@
 record man {
   var x = 0;
-  proc enterThis() ref: int { return x; }
-  proc leaveThis(in err: owned Error?) {
+  proc enterContext() ref: int { return x; }
+  proc exitContext(in err: owned Error?) {
     if err then halt();
   }
 }

--- a/test/statements/manage/InferredResourceMultipleReturnIntents1.chpl
+++ b/test/statements/manage/InferredResourceMultipleReturnIntents1.chpl
@@ -1,10 +1,10 @@
 use TrackingRecord;
 
-proc r.enterThis() {
+proc r.enterContext() {
   writeln('entering');
 }
 
-proc r.leaveThis(in err: owned Error?) {
+proc r.exitContext(in err: owned Error?) {
   writeln('leaving');
   if err then try! { throw err; }
 }
@@ -20,22 +20,22 @@ var globalRes = new res();
 record man {
   var x = new r();
 
-  proc enterThis() ref {
-    writeln('proc man.enterThis() ref: res');
+  proc enterContext() ref {
+    writeln('proc man.enterContext() ref: res');
     return globalRes;
   }
 
-  proc enterThis() const ref {
-    writeln('proc man.enterThis() const ref: res');
+  proc enterContext() const ref {
+    writeln('proc man.enterContext() const ref: res');
     return globalRes;
   }
 
-  proc enterThis() {
-    writeln('proc man.enterThis(): res');
+  proc enterContext() {
+    writeln('proc man.enterContext(): res');
     return globalRes;
   }
 
-  proc leaveThis(in err: owned Error?) {
+  proc exitContext(in err: owned Error?) {
     writeln('leaving');
     if err then try! { throw err; }
   }

--- a/test/statements/manage/InferredResourceMultipleReturnIntents1.good
+++ b/test/statements/manage/InferredResourceMultipleReturnIntents1.good
@@ -1,7 +1,7 @@
-InferredResourceMultipleReturnIntents1.chpl:48: error: cannot determine storage for 'myResource' due to multiple return intents for 'man.enterThis()'
+InferredResourceMultipleReturnIntents1.chpl:48: error: cannot determine storage for 'myResource' due to multiple return intents for 'man.enterContext()'
 InferredResourceMultipleReturnIntents1.chpl:48: note: specify an explicit storage (e.g., 'ref') to disambiguate
 InferredResourceMultipleReturnIntents1.chpl:23: note: return by 'ref' defined here
 InferredResourceMultipleReturnIntents1.chpl:28: note: return by 'const ref' defined here
 InferredResourceMultipleReturnIntents1.chpl:33: note: return by 'value' defined here
-InferredResourceMultipleReturnIntents1.chpl:56: error: cannot determine storage for 'myResource' due to multiple return intents for 'man.enterThis()'
+InferredResourceMultipleReturnIntents1.chpl:56: error: cannot determine storage for 'myResource' due to multiple return intents for 'man.enterContext()'
 InferredResourceMultipleReturnIntents1.chpl:56: note: specify an explicit storage (e.g., 'ref') to disambiguate

--- a/test/statements/manage/InferredResourceStorage.chpl
+++ b/test/statements/manage/InferredResourceStorage.chpl
@@ -14,30 +14,30 @@ var globalRes = new res();
 
 record man1 {
   var x = new r();
-  proc enterThis(): res {
-    writeln('proc man1.enterThis(): res'); return new res();
+  proc enterContext(): res {
+    writeln('proc man1.enterContext(): res'); return new res();
   }
-  proc leaveThis(in err: owned Error?) {
+  proc exitContext(in err: owned Error?) {
     if err then try! { throw err; } writeln('leaving');
   }
 }
 
 record man2 {
   var x = new r();
-  proc enterThis() ref: res {
-    writeln('proc man2.enterThis() ref: res'); return globalRes;
+  proc enterContext() ref: res {
+    writeln('proc man2.enterContext() ref: res'); return globalRes;
   }
-  proc leaveThis(in err: owned Error?) {
+  proc exitContext(in err: owned Error?) {
     if err then try! { throw err; } writeln('leaving');
   }
 }
 
 record man3 {
   var x = new r();
-  proc enterThis() const ref: res {
-    writeln('proc man3.enterThis() const ref: res'); return globalRes;
+  proc enterContext() const ref: res {
+    writeln('proc man3.enterContext() const ref: res'); return globalRes;
   }
-  proc leaveThis(in err: owned Error?) {
+  proc exitContext(in err: owned Error?) {
     if err then try! { throw err; } writeln('leaving');
   }
 }

--- a/test/statements/manage/InferredResourceStorage.good
+++ b/test/statements/manage/InferredResourceStorage.good
@@ -1,27 +1,27 @@
 T1A: only VALUE overload with NO mutation
 default-init (ptr = {x = 0})
-proc man1.enterThis(): res
+proc man1.enterContext(): res
 const action with resource
 leaving
 deinit (ptr = {x = 0})
 
 T1B: only VALUE overload with mutation
 default-init (ptr = {x = 1})
-proc man1.enterThis(): res
+proc man1.enterContext(): res
 mutating resource
 leaving
 deinit (ptr = {x = 1})
 
 T2: only REF overload with mutation
 default-init (ptr = {x = 2})
-proc man2.enterThis() ref: res
+proc man2.enterContext() ref: res
 mutating resource
 leaving
 deinit (ptr = {x = 2})
 
 T3: only CONST-REF overload with NO mutation
 default-init (ptr = {x = 3})
-proc man3.enterThis() const ref: res
+proc man3.enterContext() const ref: res
 const action with resource
 leaving
 deinit (ptr = {x = 3})

--- a/test/statements/manage/SpinlockGuard.chpl
+++ b/test/statements/manage/SpinlockGuard.chpl
@@ -15,12 +15,12 @@ record spinlock {
     this._resource = resource;
   }
 
-  proc ref enterThis() ref: T {
+  proc ref enterContext() ref: T {
     _lock.lock();
     return _resource;
   }
 
-  proc ref leaveThis(in err: owned Error?) {
+  proc ref exitContext(in err: owned Error?) {
     defer _lock.unlock();
     if err then try! { throw err; }
   }

--- a/test/statements/manage/UseSpinlockGuardBadTaskIntent.good
+++ b/test/statements/manage/UseSpinlockGuardBadTaskIntent.good
@@ -1,10 +1,10 @@
 UseSpinlockGuardBadTaskIntent.chpl:3: In function 'test1':
-UseSpinlockGuardBadTaskIntent.chpl:13: error: const actual is passed to 'ref' formal 'this' of enterThis()
+UseSpinlockGuardBadTaskIntent.chpl:13: error: const actual is passed to 'ref' formal 'this' of enterContext()
 SpinlockGuard.chpl:4: note: to formal of type spinlock(int(64))
 SpinlockGuard.chpl:18: note: to ref formal here
-UseSpinlockGuardBadTaskIntent.chpl:13: error: const actual is passed to 'ref' formal 'this' of leaveThis()
+UseSpinlockGuardBadTaskIntent.chpl:13: error: const actual is passed to 'ref' formal 'this' of exitContext()
 SpinlockGuard.chpl:4: note: to formal of type spinlock(int(64))
 SpinlockGuard.chpl:23: note: to ref formal here
-UseSpinlockGuardBadTaskIntent.chpl:13: error: const actual is passed to 'ref' formal 'this' of leaveThis()
+UseSpinlockGuardBadTaskIntent.chpl:13: error: const actual is passed to 'ref' formal 'this' of exitContext()
 SpinlockGuard.chpl:4: note: to formal of type spinlock(int(64))
 SpinlockGuard.chpl:23: note: to ref formal here

--- a/test/statements/manage/WarnUnstable.chpl
+++ b/test/statements/manage/WarnUnstable.chpl
@@ -1,6 +1,6 @@
 record man {
-  proc enterThis(): int { return 0; }
-  proc leaveThis(in err: owned Error?) {
+  proc enterContext(): int { return 0; }
+  proc exitContext(in err: owned Error?) {
     if err then try! { throw err; }
   }
 }


### PR DESCRIPTION
Due to the discussion in https://github.com/chapel-lang/chapel/issues/22618, the decision was made to rename `enterThis`/`leaveThis` to `enterContext` and `exitContext`.

- [x] paratest