### PR TITLE
Make chpl_library_finalize() not exit; Make chpl_library_init() error on second call

### DIFF
--- a/runtime/include/chpl-init.h
+++ b/runtime/include/chpl-init.h
@@ -37,7 +37,6 @@ void deallocate_string_literals_buf(void);
 #endif // ifndef LAUNCHER
 
 void chpl_rt_init(int argc, char* argv[]);
-void chpl_rt_finalize(int return_value);
 
 void chpl_executable_init(void);
 void chpl_execute_module_deinit(c_fn_ptr deinitFun);

--- a/runtime/include/chplexit.h
+++ b/runtime/include/chplexit.h
@@ -27,6 +27,8 @@
 extern "C" {
 #endif
 
+void chpl_finalize(int status, int all);
+
 void cleanup_for_exit(void);    // must be exposed to avoid dead-code elim.
 
 void chpl_exit_all(int status);  // must be called by all threads

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -398,6 +398,13 @@ void chpl_libraryModuleLevelCleanup(void);
 // }
 //
 void chpl_library_init(int argc, char* argv[]) {
+  static bool inited = false;
+
+  if (inited) {
+    chpl_error("Can't call chpl_library_init() twice", 0, 0);
+  } else {
+    inited = true;
+  }
   chpl_rt_init(argc, argv);                     // Initialize the runtime
   chpl_task_callMain(chpl_std_module_init);     // Initialize std modules
   chpl_libraryModuleLevelSetup();
@@ -416,5 +423,4 @@ extern void chpl_deinitModules(void);
 void chpl_library_finalize(void) {
   chpl_libraryModuleLevelCleanup();
   chpl_deinitModules();
-  chpl_rt_finalize(0);
 }

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -423,4 +423,5 @@ extern void chpl_deinitModules(void);
 void chpl_library_finalize(void) {
   chpl_libraryModuleLevelCleanup();
   chpl_deinitModules();
+  chpl_finalize(0, 1);
 }

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -300,14 +300,6 @@ void chpl_rt_init(int argc, char* argv[]) {
 }
 
 //
-// Called by "main.c:main(...)" and "cphl-init.c:chpl_library_finalize()".
-//
-void chpl_rt_finalize(int return_value) {
-  //chpl_rt_postUserCodeHook();
-  chpl_exit_all(return_value);
-}
-
-//
 // Chapel standard module initialization.
 //
 // Factored out of "main.c:chpl_main(...)" this needs to be called from within the
@@ -418,7 +410,7 @@ void chpl_library_init(int argc, char* argv[]) {
 extern void chpl_deinitModules(void);
 
 //
-// A wrapper around chpl-init.c:chpl_rt_finalize(...), sole purpose is
+// A wrapper around chplexit.c:chpl_finalize(...), sole purpose is
 // to provide a "chpl_library_*" interface for the Chapel "library-user".
 void chpl_library_finalize(void) {
   chpl_libraryModuleLevelCleanup();

--- a/runtime/src/chplexit.c
+++ b/runtime/src/chplexit.c
@@ -37,6 +37,12 @@ static void chpl_exit_common(int status, int all) {
   if (status != 0) {
     gdbShouldBreakHere();
   }
+  chpl_finalize(status, all);
+  exit(status);
+}
+
+
+void chpl_finalize(int status, int all) {
   chpl_comm_pre_task_exit(all);
   if (all) {
     chpl_task_exit();
@@ -47,7 +53,6 @@ static void chpl_exit_common(int status, int all) {
     chpl_mem_exit();
     chpl_topo_exit();
   }
-  exit(status);
 }
 
 

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
 
   // have everyone exit, returning the value returned by the user written main
   // or 0 if it didn't return anything
-  chpl_rt_finalize(chpl_gen_main_arg.return_value);
+  chpl_exit_all(chpl_gen_main_arg.return_value);
 
   return 0; // should never get here
 }

--- a/test/interop/C/deinit/codeAfterFinalize.cleanfiles
+++ b/test/interop/C/deinit/codeAfterFinalize.cleanfiles
@@ -1,0 +1,2 @@
+lib/libfoo.a
+lib/foo.h

--- a/test/interop/C/deinit/codeAfterFinalize.good
+++ b/test/interop/C/deinit/codeAfterFinalize.good
@@ -1,0 +1,2 @@
+In foo
+After chpl_library_finalize()

--- a/test/interop/C/deinit/codeAfterFinalize.lastcompopts
+++ b/test/interop/C/deinit/codeAfterFinalize.lastcompopts
@@ -1,0 +1,1 @@
+-Llib/ -lfoo `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/deinit/codeAfterFinalize.precomp
+++ b/test/interop/C/deinit/codeAfterFinalize.precomp
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo Compiling foo.chpl
+$3 --library --static foo.chpl

--- a/test/interop/C/deinit/codeAfterFinalize.test.c
+++ b/test/interop/C/deinit/codeAfterFinalize.test.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include "lib/foo.h"
+
+// Test of calling an exported Chapel library.
+int main(int argc, char* argv[]) {
+  // Initialize the Chapel runtime and standard modules twice This is
+  // not legal/supported, so the second should result in an error.
+  chpl_library_init(argc, argv);
+
+  // Call the function
+  foo();
+
+  // Shutdown the Chapel runtime and standard modules
+  chpl_library_finalize();
+  printf("After chpl_library_finalize()\n");
+
+  return 0;
+}

--- a/test/interop/C/deinit/foo.chpl
+++ b/test/interop/C/deinit/foo.chpl
@@ -1,0 +1,3 @@
+export proc foo() {
+  writeln("In foo");
+}

--- a/test/interop/C/deinit/foo.notest
+++ b/test/interop/C/deinit/foo.notest
@@ -1,0 +1,1 @@
+This is just a helper for other tests

--- a/test/interop/C/errorMessage/foo.chpl
+++ b/test/interop/C/errorMessage/foo.chpl
@@ -1,0 +1,3 @@
+export proc foo() {
+  writeln("In foo");
+}

--- a/test/interop/C/errorMessage/foo.notest
+++ b/test/interop/C/errorMessage/foo.notest
@@ -1,0 +1,1 @@
+This is just a helper for other tests

--- a/test/interop/C/errorMessage/initTwice.cleanfiles
+++ b/test/interop/C/errorMessage/initTwice.cleanfiles
@@ -1,0 +1,2 @@
+lib/libdefaultValueWarning.a
+lib/defaultValueWarning.h

--- a/test/interop/C/errorMessage/initTwice.cleanfiles
+++ b/test/interop/C/errorMessage/initTwice.cleanfiles
@@ -1,2 +1,2 @@
-lib/libdefaultValueWarning.a
-lib/defaultValueWarning.h
+lib/libfoo.a
+lib/foo.h

--- a/test/interop/C/errorMessage/initTwice.good
+++ b/test/interop/C/errorMessage/initTwice.good
@@ -1,0 +1,1 @@
+error: Can't call chpl_library_init() twice

--- a/test/interop/C/errorMessage/initTwice.lastcompopts
+++ b/test/interop/C/errorMessage/initTwice.lastcompopts
@@ -1,0 +1,1 @@
+-Llib/ -ldefaultValueWarning `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/errorMessage/initTwice.lastcompopts
+++ b/test/interop/C/errorMessage/initTwice.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -ldefaultValueWarning `$CHPL_HOME/util/config/compileline --libraries`
+-Llib/ -lfoo `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/errorMessage/initTwice.precomp
+++ b/test/interop/C/errorMessage/initTwice.precomp
@@ -1,3 +1,3 @@
 #!/bin/bash
-echo Compiling defaultValueWarning.chpl
-$3 --library --static defaultValueWarning.chpl
+echo Compiling foo.chpl
+$3 --library --static foo.chpl

--- a/test/interop/C/errorMessage/initTwice.precomp
+++ b/test/interop/C/errorMessage/initTwice.precomp
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo Compiling defaultValueWarning.chpl
+$3 --library --static defaultValueWarning.chpl

--- a/test/interop/C/errorMessage/initTwice.test.c
+++ b/test/interop/C/errorMessage/initTwice.test.c
@@ -1,0 +1,16 @@
+#include "lib/defaultValueWarning.h"
+
+// Test of calling an exported Chapel library.
+int main(int argc, char* argv[]) {
+  // Initialize the Chapel runtime and standard modules twice
+  chpl_library_init(argc, argv);
+  chpl_library_init(argc, argv);
+
+  // Call the function
+  foo(3);
+
+  // Shutdown the Chapel runtime and standard modules
+  chpl_library_finalize();
+
+  return 0;
+}

--- a/test/interop/C/errorMessage/initTwice.test.c
+++ b/test/interop/C/errorMessage/initTwice.test.c
@@ -2,7 +2,7 @@
 
 // Test of calling an exported Chapel library.
 int main(int argc, char* argv[]) {
-  // Initialize the Chapel runtime and standard modules twice This is
+  // Initialize the Chapel runtime and standard modules twice. This is
   // not legal/supported, so the second should result in an error.
   chpl_library_init(argc, argv);
   chpl_library_init(argc, argv);

--- a/test/interop/C/errorMessage/initTwice.test.c
+++ b/test/interop/C/errorMessage/initTwice.test.c
@@ -1,13 +1,14 @@
-#include "lib/defaultValueWarning.h"
+#include "lib/foo.h"
 
 // Test of calling an exported Chapel library.
 int main(int argc, char* argv[]) {
-  // Initialize the Chapel runtime and standard modules twice
+  // Initialize the Chapel runtime and standard modules twice This is
+  // not legal/supported, so the second should result in an error.
   chpl_library_init(argc, argv);
   chpl_library_init(argc, argv);
 
   // Call the function
-  foo(3);
+  foo();
 
   // Shutdown the Chapel runtime and standard modules
   chpl_library_finalize();


### PR DESCRIPTION
This changes `chpl_library_finalize()` to not explicitly exit the Chapel program, permitting the user to do other computations or cleanup activities after finalizing the Chapel library, as requested in #22739 and as our docs already suggest is possible (by showing code following the finalize() call and not having finalize() take an exit status).  It adds a test of this in `test/interop/C/deinit/codeAfterFinalize.test.c` demonstrating it works.

It also adds an error if `chpl_library_init()` is called twice, in the event that a user tries to re-initialize the Chapel library after finalizing it (or simply tries to initialize it twice, which has never been supported—we just haven't guarded against it in the past).  It adds a test of this in `test/interop/C/errorMessage/initTwice.test.c`.

In implementing this, I did a bit of refactoring of the existing code:
* I split most of (the internal) `chpl_exit()` (routine) into a new (internal) `chpl_finalize()` routine that did the lion's share of the same actions other than calling the exit() itself, permitting `chpl_finalize()` to be used by `chpl_library_finalize()`
* I removed `chpl_rt_finalize()` which didn't really serve any purpose anymore since it was only called in one place and only wrapped one routine and had the remaining use in `main.c` just call that routine directly.

Elliot noted that GASNet's finalize() routine currently exits the program such that this doesn't resolve the original request for GASNet programs.  Since @twesterhout (who filed #22739) indicated that he was only interested in comm=none runs, I'm leaving that for future work and have created a separate issue for it in #22968.

Resolves #22739.