### PR TITLE
fix type mismatch in yaml package

### DIFF
--- a/modules/packages/YAML.chpl
+++ b/modules/packages/YAML.chpl
@@ -1573,7 +1573,7 @@ module YAML {
         then throw new YamlEmitterError("Failed to initialize emitter");
 
       var p = path, w = "w";
-      var f = fopen(c_ptrTo(p), c_ptrTo(w));
+      var f = fopen(p.c_str(), w.c_str());
       this.file = f;
 
       yaml_emitter_set_output_file(c_ptrTo(this.emitter), this.file);


### PR DESCRIPTION
This PR fixes a type mismatch when calling `fopen` after merging https://github.com/chapel-lang/chapel/pull/22622. 

Testing:

- [x] all tests in `test/library/packages/Yaml` pass