### PR TITLE
Don't allow hugepage module to hijack morecore

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -84,11 +84,19 @@ void chpl_comm_preLaunch(int32_t numLocales) {
     //
     chpl_env_set("PMI_NO_PREINITIALIZE", "y", 1);
   }
-  //
-  // Don't map virtual hugepages to physical pages if we allocate a
-  // fixed heap.
-  //
   if (chpl_env_rt_get_bool("COMM_OFI_USE_HUGEPAGES", false)) {
+    //
+    // Don't map virtual hugepages to physical pages when allocating a
+    // fixed heap. We want to do it ourselves so we can stripe the heap
+    // across NUMA domains.
+    //
     chpl_env_set("HUGETLB_NO_RESERVE", "yes", 0);
+  } else {
+    //
+    // Don't allow morecore to use hugepages, otherwise we'll end up using
+    // hugepages when we allocate the fixed heap using memalign.
+    //
+    chpl_env_set("HUGETLB_MORECORE", "no", 1);
   }
+
 }


### PR DESCRIPTION
If `CHPL_RT_COMM_OFI_USE_HUGEPAGES=false` then we should not use hugepages to allocate the fixed heap. However, the various `craype-hugepages*` modules set `HUGETLB_MORECORE=yes`, which hijacks the `morecore` function to use hugepages. As a result, the call to `memalign` to allocate the heap from regular pages ends up allocating it from hugepages. The solution is to set `HUGETLB_MORECORE=no` if `CHPL_RT_COMM_OFI_USE_HUGEPAGES=false`.