### PR TITLE
Add an ArrayOOMError for throwing array allocation interface

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1593,7 +1593,7 @@ module ChapelBase {
     ret = _ddata_allocate_noinit(eltType, size, callPostAlloc, subloc, false);
 
     if ret == nil then
-      throw new ArrayOOMError();
+      throw new ArrayOomError();
 
     init_elts(ret, size, eltType);
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1593,7 +1593,7 @@ module ChapelBase {
     ret = _ddata_allocate_noinit(eltType, size, callPostAlloc, subloc, false);
 
     if ret == nil then
-      throw new Error("Could not allocate memory");
+      throw new ArrayOOMError();
 
     init_elts(ret, size, eltType);
 

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1540,7 +1540,7 @@ module ChapelDomain {
       This method can be called on all domains that implement a
       'doiTryCreateArray' method.
 
-      Throws a `ArrayOOMError` when out of memory allocating elements.
+      Throws an `ArrayOomError` when out of memory allocating elements.
     */
     pragma "no copy return"
     @unstable("tryCreateArray() is subject to change in the future.")

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1539,6 +1539,8 @@ module ChapelDomain {
 
       This method can be called on all domains that implement a
       'doiTryCreateArray' method.
+
+      Throws a `ArrayOOMError` when out of memory allocating elements.
     */
     pragma "no copy return"
     @unstable("tryCreateArray() is subject to change in the future.")

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -703,7 +703,7 @@ module DefaultRectangular {
     proc doiTryCreateArray(type eltType) throws {
       // TODO: Update to support higher dimension (not needed in Arkouda)
       if rank != 1 then
-        throw new Error("'tryBuildArray' is only supported on domains of rank 1");
+        throw new Error("'tryCreateArray' is only supported on domains of rank 1");
 
       var data = _try_ddata_allocate(eltType, ranges(0).size);
       return new unmanaged DefaultRectangularArr(eltType=eltType, rank=rank,

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -158,7 +158,8 @@ module Errors {
     }
   }
 
-  class ArrayOOMError: Error {
+  @unstable("`ArrayOomError` is unstable; expect this error to change in the future.")
+  class ArrayOomError: Error {
     @chpldoc.nodoc
     override proc message() {
       return "out of memory allocating array elements";

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -158,6 +158,13 @@ module Errors {
     }
   }
 
+  class ArrayOOMError: Error {
+    @chpldoc.nodoc
+    override proc message() {
+      return "out of memory allocating array elements";
+    }
+  }
+
   @deprecated(notes=":class:`CodepointSplittingError` is deprecated; please use :class:`CodepointSplitError` instead")
   type CodepointSplittingError = CodepointSplitError;
 


### PR DESCRIPTION
The Arkouda devs have requested that the throwing array allocation
interface have a specific type of error message thrown so that it
can be handled uniquely. This PR adds an `ArrayOOMError` for when
an array allocation fails.

Related PR: https://github.com/chapel-lang/chapel/pull/22786

- [x] paratest