### PR TITLE
Rename remaining Math constants and mark them unstable

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -51,13 +51,13 @@ Constants
 :param:`ln2`
 :param:`ln10`
 :param:`pi`
-:param:`half_pi`
-:param:`quarter_pi`
-:param:`recipr_pi`
-:param:`twice_recipr_pi`
-:param:`twice_recipr_sqrt_pi`
-:param:`sqrt_2`
-:param:`recipr_sqrt_2`
+:param:`halfPi`
+:param:`quarterPi`
+:param:`reciprPi`
+:param:`twiceReciprPi`
+:param:`twiceReciprSqrtPi`
+:param:`sqrt2`
+:param:`reciprSqrt2`
 
 .. _math-trigonometry:
 
@@ -177,18 +177,46 @@ module Math {
   /* pi - the circumference/the diameter of a circle */
   param pi = 3.14159265358979323846;
   /* pi/2 */
+  @unstable("'halfPi' is unstable due to questions about its utility.  If you are seeing negative performance impacts from using 'pi/2' instead of this 'param', please let us know!")
+  param halfPi = 1.57079632679489661923;
+  /* pi/2 */
+  @deprecated(notes="'half_pi' is deprecated, please use :param:`halfPi` or 'pi/2' instead")
   param half_pi = 1.57079632679489661923;
   /* pi/4 */
+  @unstable("'quarterPi' is unstable due to questions about its utility.  If you are seeing negative performance impacts from using 'pi/4' instead of this 'param', please let us know!")
+  param quarterPi = 0.78539816339744830962;
+  /* pi/4 */
+  @deprecated(notes="'quarter_pi' is deprecated, please use :param:`quarterPi` or 'pi/4' instead")
   param quarter_pi = 0.78539816339744830962;
   /* 1/pi */
+  @unstable("'reciprPi' is unstable due to questions about its utility.  If you are seeing negative performance impacts from using '1/pi' instead of this 'param', please let us know!")
+  param reciprPi = 0.31830988618379067154;
+  /* 1/pi */
+  @deprecated(notes="'recipr_pi' is deprecated, please use :param:`reciprPi` or '1/pi' instead")
   param recipr_pi = 0.31830988618379067154;
   /* 2/pi */
+  @unstable("'twiceReciprPi' is unstable due to questions about its utility.  If you are seeing negative performance impacts from using '2/pi' instead of this 'param', please let us know!")
+  param twiceReciprPi = 0.63661977236758134308;
+  /* 2/pi */
+  @deprecated(notes="'twice_recipr_pi' is deprecated, please use :param:`twiceReciprPi` or '2/pi' instead")
   param twice_recipr_pi = 0.63661977236758134308;
   /* 2/sqrt(pi) */
+  @unstable("'twiceReciprSqrtPi' is unstable due to questions about its utility.  If you are using this symbol, please let us know!")
+  param twiceReciprSqrtPi = 1.12837916709551257390;
+  /* 2/sqrt(pi) */
+  @deprecated(notes="'twice_recipr_sqrt_pi' is deprecated, please use :param:`twiceReciprSqrtPi` or '2/sqrt(pi)' instead")
   param twice_recipr_sqrt_pi = 1.12837916709551257390;
   /* sqrt(2) */
+  @unstable("'sqrt2' is unstable due to questions about its utility.  If you are using this symbol, please let us know!")
+  param sqrt2 = 1.41421356237309504880;
+  /* sqrt(2) */
+  @deprecated(notes="'sqrt_2' is deprecated, please use :param:`sqrt2` or 'sqrt(2)' instead")
   param sqrt_2 = 1.41421356237309504880;
   /* 1/sqrt(2) */
+  @unstable("'reciprSqrt2' is unstable due to questions about its utility.  If you are using this symbol, please let us know!")
+  param reciprSqrt2 = 0.70710678118654752440;
+  /* 1/sqrt(2) */
+  @deprecated(notes="'recipr_sqrt_2' is deprecated, please use :param:`reciprSqrt2` or '1/sqrt(2)' instead")
   param recipr_sqrt_2 = 0.70710678118654752440;
 
   /* Returns the arc cosine of the argument `x`.

--- a/test/deprecated/Math/mathConstantsRenamed.chpl
+++ b/test/deprecated/Math/mathConstantsRenamed.chpl
@@ -4,3 +4,12 @@ writeln(isClose(log2_e, log2(e))); // Should trigger for log2_e
 writeln(isClose(log10_e, log10(e))); // Should trigger for log10_e
 writeln(isClose(ln_2, log(2)));      // Should trigger for ln_2
 writeln(isClose(ln_10, log(10)));    // Should trigger for ln_10
+writeln(isClose(half_pi, pi/2));     // Should trigger for half_pi
+writeln(isClose(quarter_pi, pi/4));  // Should trigger for quarter_pi
+writeln(isClose(recipr_pi, 1/pi));   // Should trigger for recipr_pi
+// Should trigger for twice_recipr_pi
+writeln(isClose(twice_recipr_pi, 2/pi));
+// Should trigger for twice_recipr_sqrt_pi
+writeln(isClose(twice_recipr_sqrt_pi, 2/sqrt(pi)));
+writeln(isClose(sqrt_2, sqrt(2)));   // Should trigger for sqrt_2
+writeln(isClose(recipr_sqrt_2, 1/sqrt(2))); // Should trigger for recipr_sqrt_2

--- a/test/deprecated/Math/mathConstantsRenamed.good
+++ b/test/deprecated/Math/mathConstantsRenamed.good
@@ -2,6 +2,20 @@ mathConstantsRenamed.chpl:3: warning: 'log2_e' is deprecated, please use log2E i
 mathConstantsRenamed.chpl:4: warning: 'log10_e' is deprecated, please use log10E instead
 mathConstantsRenamed.chpl:5: warning: 'ln_2' is deprecated, please use ln2 instead
 mathConstantsRenamed.chpl:6: warning: 'ln_10' is deprecated, please use ln10 instead
+mathConstantsRenamed.chpl:7: warning: 'half_pi' is deprecated, please use halfPi or 'pi/2' instead
+mathConstantsRenamed.chpl:8: warning: 'quarter_pi' is deprecated, please use quarterPi or 'pi/4' instead
+mathConstantsRenamed.chpl:9: warning: 'recipr_pi' is deprecated, please use reciprPi or '1/pi' instead
+mathConstantsRenamed.chpl:11: warning: 'twice_recipr_pi' is deprecated, please use twiceReciprPi or '2/pi' instead
+mathConstantsRenamed.chpl:13: warning: 'twice_recipr_sqrt_pi' is deprecated, please use twiceReciprSqrtPi or '2/sqrt(pi)' instead
+mathConstantsRenamed.chpl:14: warning: 'sqrt_2' is deprecated, please use sqrt2 or 'sqrt(2)' instead
+mathConstantsRenamed.chpl:15: warning: 'recipr_sqrt_2' is deprecated, please use reciprSqrt2 or '1/sqrt(2)' instead
+true
+true
+true
+true
+true
+true
+true
 true
 true
 true

--- a/test/exercises/c-ray/c-ray.chpl
+++ b/test/exercises/c-ray/c-ray.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/c-ray.chpl
+++ b/test/exercises/c-ray/c-ray.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/old/c-ray.chpl
+++ b/test/exercises/c-ray/old/c-ray.chpl
@@ -27,7 +27,7 @@ use Image;    // use helper module related to writing out images
 use IO;       // allows access to stderr, stdin, ioMode
 use List;
 use ChplConfig;
-import Math.quarterPi;
+import Math.pi;
 
 //
 // Configuration constants
@@ -40,7 +40,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/old/c-ray.chpl
+++ b/test/exercises/c-ray/old/c-ray.chpl
@@ -27,7 +27,7 @@ use Image;    // use helper module related to writing out images
 use IO;       // allows access to stderr, stdin, ioMode
 use List;
 use ChplConfig;
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // Configuration constants
@@ -40,7 +40,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-1.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-1.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-1.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-1.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-1a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-1a.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-1a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-1a.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-2.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-2.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-2.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-2.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-2a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-2a.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-2a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-2a.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-3.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-3.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-3.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-3.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-3a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-3a.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-3a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-3a.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-4.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-4.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-4.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-4.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-4a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-4a.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-4a.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-4a.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-5.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-5.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-5.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-5.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-6.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-6.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-6.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-6.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-7.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-7.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-7.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-7.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-8.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-8.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarterPi;
+import Math.pi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarterPi,     // field of view in radians
+             fieldOfView = pi/4,          // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/exercises/c-ray/solutions/c-ray-8.chpl
+++ b/test/exercises/c-ray/solutions/c-ray-8.chpl
@@ -27,7 +27,7 @@
 use Image;    // use helper module related to writing out images
 use List;
 use IO;       // allow use of stderr, stdin, ioMode
-import Math.quarter_pi;
+import Math.quarterPi;
 
 //
 // =================================================
@@ -46,7 +46,7 @@ config const size = "800x600",            // size of output image
              imgType = extToFmt(image),   // the image file format
              usage = false,               // print usage message?
 
-             fieldOfView = quarter_pi,    // field of view in radians
+             fieldOfView = quarterPi,     // field of view in radians
              maxRayDepth = 5,             // raytrace recursion limit
              rayMagnitude = 1000.0,       // trace rays of this magnitude
              errorMargin = 1e-6,          // margin to avoid surface acne

--- a/test/library/standard/Math/constants.chpl
+++ b/test/library/standard/Math/constants.chpl
@@ -18,11 +18,11 @@ check(ln2, log(2));
 check(ln10, log(10));
 assert(pi:int == 3);
 check(sin(pi), 0.0);
-check(half_pi, pi/2.0);
-check(quarter_pi, pi/4.0);
-check(recipr_pi, 1.0/pi);
-check(twice_recipr_pi, 2.0/pi);
-check(twice_recipr_sqrt_pi, 2.0/sqrt(pi));
-check(sqrt_2, sqrt(2));
-check(recipr_sqrt_2, 1/sqrt(2));
+check(halfPi, pi/2.0);
+check(quarterPi, pi/4.0);
+check(reciprPi, 1.0/pi);
+check(twiceReciprPi, 2.0/pi);
+check(twiceReciprSqrtPi, 2.0/sqrt(pi));
+check(sqrt2, sqrt(2));
+check(reciprSqrt2, 1/sqrt(2));
 

--- a/test/unstable/Math/unstableConstants.chpl
+++ b/test/unstable/Math/unstableConstants.chpl
@@ -1,0 +1,11 @@
+use Math;
+
+writeln(isClose(halfPi, pi/2));     // Should trigger for halfPi
+writeln(isClose(quarterPi, pi/4));  // Should trigger for quarterPi
+writeln(isClose(reciprPi, 1/pi));   // Should trigger for reciprPi
+// Should trigger for twiceReciprPi
+writeln(isClose(twiceReciprPi, 2/pi));
+// Should trigger for twiceReciprSqrtPi
+writeln(isClose(twiceReciprSqrtPi, 2/sqrt(pi)));
+writeln(isClose(sqrt2, sqrt(2)));   // Should trigger for sqrt2
+writeln(isClose(reciprSqrt2, 1/sqrt(2))); // Should trigger for reciprSqrt2

--- a/test/unstable/Math/unstableConstants.good
+++ b/test/unstable/Math/unstableConstants.good
@@ -1,0 +1,14 @@
+unstableConstants.chpl:3: warning: 'halfPi' is unstable due to questions about its utility.  If you are seeing negative performance impacts from using 'pi/2' instead of this 'param', please let us know!
+unstableConstants.chpl:4: warning: 'quarterPi' is unstable due to questions about its utility.  If you are seeing negative performance impacts from using 'pi/4' instead of this 'param', please let us know!
+unstableConstants.chpl:5: warning: 'reciprPi' is unstable due to questions about its utility.  If you are seeing negative performance impacts from using '1/pi' instead of this 'param', please let us know!
+unstableConstants.chpl:7: warning: 'twiceReciprPi' is unstable due to questions about its utility.  If you are seeing negative performance impacts from using '2/pi' instead of this 'param', please let us know!
+unstableConstants.chpl:9: warning: 'twiceReciprSqrtPi' is unstable due to questions about its utility.  If you are using this symbol, please let us know!
+unstableConstants.chpl:10: warning: 'sqrt2' is unstable due to questions about its utility.  If you are using this symbol, please let us know!
+unstableConstants.chpl:11: warning: 'reciprSqrt2' is unstable due to questions about its utility.  If you are using this symbol, please let us know!
+true
+true
+true
+true
+true
+true
+true


### PR DESCRIPTION
Resolves #19000 

In that issue, we decided to perform the following renamings:
- half_pi is renamed to halfPi
- quarter_pi is renamed to quarterPi
- recipr_pi is renamed to reciprPi
- twice_recipr_pi is renamed to twiceReciprPi
- twice_recipr_sqrt_pi is renamed to twice_recipr_sqrt_pi
- sqrt_2 is renamed to sqrt2
- recipr_sqrt_2 is renamed to reciprSqrt2

The new versions are are marked unstable because we don't think they're used
much in practice and some of them shouldn't be necessary any more due to
improvements to the compiler's handling of param computations.

Ensures that the deprecation warnings are tested by adding them to the already-
existing renaming test.  Ensures that the unstable warnings are tested by making
a new test.  Updates the old test of the math constants functionality and the c-ray
tests to use the new, not-deprecated names.

Passed a full paratest with futures