### PR TITLE
fix deprecation warnings from c_string uses in python lib

### DIFF
--- a/test/interop/python/defaultValues.chpl
+++ b/test/interop/python/defaultValues.chpl
@@ -1,5 +1,6 @@
-export proc cstringDefault(in x: c_string = "blah") {
-  writeln(string.createCopyingBuffer(x));
+use CTypes;
+export proc cstringDefault(in x: chpl_c_string = "blah") {
+  writeln(string.createCopyingBuffer(x:c_ptrConst(c_char)));
 }
 
 export proc intDefault(x: int = 3) {

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.chpl
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.chpl
@@ -1,14 +1,13 @@
 
 
-export proc badFormalIntentNone(s: c_string) {}
+export proc badFormalIntentNone(s: chpl_c_string) {}
 
-export proc badFormalIntentConst(const s: c_string) {}
+export proc badFormalIntentConst(const s: chpl_c_string) {}
 
-export proc badFormalIntentOut(out s: c_string) {}
+export proc badFormalIntentOut(out s: chpl_c_string) {}
 
-export proc badFormalIntentInOut(inout s: c_string) {}
+export proc badFormalIntentInOut(inout s: chpl_c_string) {}
 
-export proc badFormalIntentRef(ref s: c_string) {}
+export proc badFormalIntentRef(ref s: chpl_c_string) {}
 
-export proc badFormalIntentConstRef(const ref s: c_string) {}
-
+export proc badFormalIntentConstRef(const ref s: chpl_c_string) {}

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.comm-none.good
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.comm-none.good
@@ -1,6 +1,6 @@
-badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
-badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
-badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
-badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
-badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
-badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries
+badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
+badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
+badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
+badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
+badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
+badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.good
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.good
@@ -1,6 +1,6 @@
-badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentNone' may not be passed by const ref in multilocale python libraries
-badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in multilocale python libraries
-badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in multilocale python libraries
-badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in multilocale python libraries
-badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in multilocale python libraries
-badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentNone' may not be passed by const ref in multilocale python libraries
+badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'chpl_c_string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in multilocale python libraries

--- a/test/interop/python/stringAllocated.chpl
+++ b/test/interop/python/stringAllocated.chpl
@@ -10,6 +10,6 @@ export proc g(size: int, ptr: c_ptr(uint(8))): int {
   }
 }
 
-export proc writeStr(in x: c_ptrConst(c_char)) {
-  writeln(string.createCopyingBuffer(x));
+export proc writeStr(in x: chpl_c_string) {
+  writeln(string.createCopyingBuffer(x:c_ptrConst(c_char)));
 }

--- a/test/interop/python/stringFunctions.chpl
+++ b/test/interop/python/stringFunctions.chpl
@@ -1,15 +1,16 @@
-/* Tests accepting a c_string */
-export proc takesString(in x: c_string) {
-  writeln(string.createCopyingBuffer(x));
+use CTypes;
+/* Tests accepting a chpl_c_string */
+export proc takesString(in x: chpl_c_string) {
+  writeln(string.createCopyingBuffer(x:c_ptrConst(c_char)));
 }
 
-/* Tests returning a c_string */
-export proc getString(): c_string {
-  var ret: c_string = "whee";
+/* Tests returning a chpl_c_string */
+export proc getString(): chpl_c_string {
+  var ret: chpl_c_string = "whee";
   return ret;
 }
 
-/* Tests taking and returning a c_string */
-export proc takeAndReturn(in x: c_string): c_string {
+/* Tests taking and returning a chpl_c_string */
+export proc takeAndReturn(in x: chpl_c_string): chpl_c_string {
   return x;
 }


### PR DESCRIPTION
This PR should fix some broken testing of the python library generation feature. For now, I have just updated the test code to remove the offending use of `c_string` and methods that accept `c_string`. A future task will be to handle code generation for `c_ptrConst(c_char)`. The initial attempt to treat it similarly to `c_string` did not work, so I'm putting this in to fix the tests while I work on the python interface generation changes. 

TESTING:

- [x] failing python module tests passing


failing tests addressed with this PR:
```
test/interop/python/defaultValues
test/interop/python/errorMessages/badFormalIntent-cstring
test/interop/python/stringAllocated
test/interop/python/stringFunctions
```

[reviewed by @lydia-duncan - thanks!]