### PR TITLE
remove `c_string` literals and calls to `.c_str()` in GPU module and tests

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -91,7 +91,7 @@ module GPU
      Pass arguments to :proc:`gpuWrite` and follow with a newline.
   */
   proc gpuWriteln(const args ...?k) {
-    gpuWrite((...args), "\n".c_str());
+    gpuWrite((...args), "\n":c_ptrConst(c_char));
   }
 
   /*

--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums_primitive.chpl
@@ -16,7 +16,7 @@ extern {
 
     srand(0);
     X = rand() % 100;
-    
+
     checkCudaErrors(cuMemcpyHtoD(devBufferX, &X, sizeof(double)));
 
     return devBufferX;
@@ -55,7 +55,9 @@ on here.gpus[0] {
 
   var deviceBuffer = getDeviceBufferPointer();
   // arguments are: fatbin path, function name, grid size, block size, arguments
-  __primitive("gpu kernel launch flat", c"add_nums", 1, 1, deviceBuffer);
+  __primitive("gpu kernel launch flat",
+               "add_nums":chpl_c_string,
+               1, 1, deviceBuffer);
   output = getDataFromDevice(deviceBuffer);
 }
 

--- a/test/gpu/native/gpuWritelnAndAssertOnGpu.chpl
+++ b/test/gpu/native/gpuWritelnAndAssertOnGpu.chpl
@@ -1,8 +1,8 @@
-use GPU;
+use GPU, CTypes;
 
 proc subFunc() {
-  gpuWriteln("hello from function called by GPU!".c_str());
-  gpuWriteln("hello again from ".c_str(), " function called by GPU!".c_str());
+  gpuWriteln("hello from function called by GPU!":c_ptrConst(c_char));
+  gpuWriteln("hello again from ":c_ptrConst(c_char), " function called by GPU!":c_ptrConst(c_char));
 }
 
 writeln("Writeln from CPU");
@@ -12,8 +12,8 @@ on here.gpus[0] {
     A[i] = i;
     assertOnGpu();
     if(i == 0) {
-      gpuWriteln("hello from the GPU!".c_str());
-      gpuWriteln("hello from the GPU ".c_str(), "again!".c_str());
+      gpuWriteln("hello from the GPU!":c_ptrConst(c_char));
+      gpuWriteln("hello from the GPU ":c_ptrConst(c_char), "again!":c_ptrConst(c_char));
       subFunc();
     }
   }

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -110,7 +110,7 @@ export proc transposeMatrix(odata: c_ptr(dataType), idata: c_ptr(dataType), widt
 
 inline proc transposeLowLevel(original, output) {
   __primitive("gpu kernel launch",
-          c"transposeMatrix",
+          "transposeMatrix":chpl_c_string,
           /* grid size */  sizeX / blockSize, sizeY / blockSize, 1,
           /* block size */ blockSize, blockSize, 1,
           /* kernel args */ c_ptrTo(output), c_ptrTo(original), sizeX, sizeY);

--- a/test/gpu/native/threadBlockAndGridPrimitives.chpl
+++ b/test/gpu/native/threadBlockAndGridPrimitives.chpl
@@ -48,9 +48,9 @@ proc runExample(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ) {
   writeln("Block size: ", bdimX, " x ", bdimY, " x ", bdimZ);
 
   const N = gdimX * gdimY * gdimZ * bdimX * bdimY * bdimZ * VALS_PER_THREAD;
-  
+
   var X : [0..<N] real(32);
-  __primitive("gpu kernel launch", c"add_nums",
+  __primitive("gpu kernel launch", "add_nums":chpl_c_string,
               gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ,
               c_ptrTo(X));
 


### PR DESCRIPTION
This PR removes calls to the unstable `.c_str()` in `GPU` and tests, and replaces those calls with a cast to `c_ptrConst(c_char)`. 

This should resolve test failures for GPU tests affected by the deprecation of `c_string` in https://github.com/chapel-lang/chapel/pull/22622.

TESTING:

- [x] all GPU tests on `chapdl-nvidia` `[Summary: #Successes = 82 | #Failures = 0 | #Futures = 0]` 
- [x] all GPU tests on `chapdl-amd` `[Summary: #Successes = 80 | #Failures = 0 | #Futures = 0]`

[reviewed by @e-kayrakli - thanks!]