### PR TITLE
Improve BigInteger documentation

### DIFF
--- a/frontend/lib/util/filtering.cpp
+++ b/frontend/lib/util/filtering.cpp
@@ -52,7 +52,7 @@ namespace {
     std::string reContent = "(?:(?:" + reCntType1 + ")|(?:" + reCntType2 + ")|(?:" + reCntType3 + ")|(?:" + reCntType4 +  + "))";
 
     // Various roles; put into a (?...) group so we don't "capture" it
-    std::string reRole = R"#((?:mod|proc|iter|data|const|var|param|type|class|record|attr|enum))#";
+    std::string reRole = R"#((?:mod|proc|iter|data|const|var|param|type|class|record|attr|enum|enumconstant))#";
 
     // Regexp to match :role:`content`; note \B is used on either end to indicate markup is separated by word boundaries
     std::string reSphinxMrkp = R"#(\B\:)#" + reRole + R"#(\:`)#" + reContent + R"#(`\B)#";

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -185,7 +185,7 @@ module BigInteger {
     var localeId : chpl_nodeID_t;      // The locale id for the GMP state
 
     /*
-      Initializes a :record:`bigint` to an initial value of 0.
+      Initializes a :record:`bigint` to an initial value of ``0``.
     */
     proc init() {
       this.complete();
@@ -276,36 +276,15 @@ module BigInteger {
 
     pragma "last resort"
     @deprecated("the argument name 'num' is deprecated - please use 'x' instead")
-    proc init(const ref num: bigint) {
-      this.complete();
-      if compiledForSingleLocale() || num.localeId == chpl_nodeID {
-        mpz_init_set(this.mpz, num.mpz);
-      } else {
-        var mpz_struct = num.getImpl();
+    proc init(const ref num: bigint) do this.init(num);
 
-        mpz_init(this.mpz);
-
-        chpl_gmp_get_mpz(this.mpz, num.localeId, mpz_struct);
-      }
-
-      this.localeId = chpl_nodeID;
-    }
     pragma "last resort"
     @deprecated("the argument name 'num' is deprecated - please use 'x' instead")
-    proc init(num: int) {
-      this.complete();
-      mpz_init_set_si(this.mpz, num.safeCast(c_long));
+    proc init(num: int) do this.init(num);
 
-      this.localeId = chpl_nodeID;
-    }
     pragma "last resort"
     @deprecated("the argument name 'num' is deprecated - please use 'x' instead")
-    proc init(num: uint) {
-      this.complete();
-      mpz_init_set_ui(this.mpz, num.safeCast(c_ulong));
-
-      this.localeId = chpl_nodeID;
-    }
+    proc init(num: uint) do this.init(num);
 
     /* Initialize a :record:`bigint` from a string and optionally a provided base
        to use with the string.  If the string is not a correct base ``base``
@@ -328,19 +307,8 @@ module BigInteger {
      */
     pragma "last resort"
     @deprecated("the argument name 'str' is deprecated - please use 'x' instead")
-    proc init(str: string, base: int = 0) throws where bigintInitThrows == true {
-      this.complete();
-      const ref str_ = str.localize().c_str();
-      const base_ = base.safeCast(c_int);
-
-      if mpz_init_set_str(this.mpz, str_, base_) != 0 {
-        mpz_clear(this.mpz);
-
-        throwingInitWorkaround();
-      }
-
-      this.localeId = chpl_nodeID;
-    }
+    proc init(str: string, base: int = 0) throws where bigintInitThrows == true
+      do this.init(num);
 
     @deprecated(notes="bigint initializers that halt are deprecated, please set the config param :param:`bigintInitThrows` to 'true' to opt in to using the new initializer that throws")
     proc init(str: string, base: int = 0) where bigintInitThrows == false {
@@ -388,7 +356,6 @@ module BigInteger {
         mpz_clear(this.mpz);
       }
     }
-
 
     /* Determine the size of ``this`` measured in number of digits in the given
        ``base``.  The sign of ``this`` is ignored, only the absolute value is

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2200,23 +2200,25 @@ module BigInteger {
 
   // Number Theoretic Functions
 
-  /* An enumeration of the different possibilities of a number being prime, for use with e.g.
-     :proc:`~bigint.probablyPrime` to determine if a number is prime or not.
-
-     - ``primality.notPrime`` indicates that the number is not a prime.
-     - ``primality.maybePrime`` indicates that the number may or may not be a prime.
-     - ``primality.isPrime`` indicates that the number is a prime.
+  /*
+    An enumeration of the different possibilities of a number being prime, for
+    use with e.g. :proc:`~bigint.probablyPrime` to determine if a number is
+    prime or not.
    */
   enum primality {
+    /* Indicates that the number is not a prime. */
     notPrime=0,
+    /* Indicates that the number may or may not be a prime. */
     maybePrime,
+    /* Indicates that the number is a prime. */
     isPrime
   };
 
   /*
     Determine whether ``this`` is prime.  Returns one of the :enum:`primality`
-    constants - ``primality.isPrime``, ``primality.maybePrime``, or
-    ``primality.notPrime``.
+    constants - :enumconstant:`~primality.isPrime`,
+    :enumconstant:`~primality.maybePrime`, or
+    :enumconstant:`~primality.notPrime`.
 
     Performs some trial divisions, a Baillie-PSW probable prime test, and
     reps-24 Miller-Rabin probabilistic primality tests.  A higher ``reps`` value
@@ -2228,12 +2230,14 @@ module BigInteger {
     Utilizes the GMP function `mpz_probab_prime_p
     <https://gmplib.org/manual/Number-Theoretic-Functions>`_.
 
-    :arg reps: number of attempts before returning ``primality.maybePrime`` if
-               a definitive answer can't be found before then.
+    :arg reps: number of attempts before returning
+               :enumconstant:`~primality.maybePrime` if a definitive answer
+               can't be found before then.
     :type reps: ``int``
 
-    :returns: ``primality.isPrime``, ``primality.maybePrime`` or
-              ``primality.notPrime``.
+    :returns: :enumconstant:`~primality.isPrime`,
+              :enumconstant:`~primality.maybePrime`, or
+              :enumconstant:`~primality.notPrime`.
     :rtype: :enum:`primality`
    */
   @unstable("bigint.probablyPrime is unstable and may change in the future")

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -485,11 +485,6 @@ module BigInteger {
       return (dbl: real, exp.safeCast(uint(32)));
     }
 
-    /*
-      .. warning::
-
-         bigint.size() is @deprecated
-    */
     @deprecated(notes="bigint.size() is deprecated")
     proc size() : c_size_t {
       var ret: c_size_t;
@@ -511,11 +506,6 @@ module BigInteger {
       return ret;
     }
 
-    /*
-      .. warning::
-
-         bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
-    */
     @deprecated
     ("bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead")
     proc sizeinbase(base: int) : uint {
@@ -1712,11 +1702,6 @@ module BigInteger {
       return false;
   }
 
-  /*
-    .. warning::
-
-       bigint.powm is deprecated, use bigint.powMod instead
-  */
   @deprecated
   ("bigint.powm is deprecated, use bigint.powMod instead")
   proc bigint.powm(const ref base: bigint,
@@ -1725,11 +1710,6 @@ module BigInteger {
     BigInteger.powMod(this, base, exp, mod);
   }
 
-  /*
-    .. warning::
-
-       bigint.powm is deprecated, use bigint.powMod instead
-  */
   @deprecated
   ("bigint.powm is deprecated, use bigint.powMod instead")
   proc bigint.powm(const ref base: bigint,
@@ -1738,11 +1718,6 @@ module BigInteger {
     BigInteger.powMod(this, base, exp, mod);
   }
 
-  /*
-    .. warning::
-
-       bigint.powm is deprecated, use bigint.powMod instead
-  */
   @deprecated
   ("bigint.powm is deprecated, use bigint.powMod instead")
   proc bigint.powm(const ref base: bigint,
@@ -2174,11 +2149,6 @@ module BigInteger {
   proc bigint.sqrtrem(ref rem: bigint, const ref a: bigint)
     do BigInteger.sqrtRem(this, rem, a);
 
-  /*
-    .. warning::
-
-       bigint.perfect_power_p is deprecated, use bigint.isPerfectPower instead
-  */
   @deprecated
   ("bigint.perfect_power_p is deprecated, use bigint.isPerfectPower instead")
   proc bigint.perfect_power_p() : int {
@@ -2206,11 +2176,6 @@ module BigInteger {
       return false;
   }
 
-  /*
-    .. warning::
-
-       bigint.perfect_square_p is deprecated, use bigint.isPerfectSquare instead
-  */
   @deprecated
   ("bigint.perfect_square_p is deprecated, use bigint.isPerfectSquare instead")
   proc bigint.perfect_square_p() : int {
@@ -2658,12 +2623,6 @@ module BigInteger {
     BigInteger.invert(this, a, b);
   }
 
-  // remove
-    /*
-    .. warning::
-
-       bigint.remove is deprecated, use bigint.removeFactor instead
-  */
   @deprecated
   ("bigint.remove is deprecated, use bigint.removeFactor instead")
   proc bigint.remove(const ref a: bigint, const ref f: bigint) : uint {
@@ -3254,11 +3213,6 @@ module BigInteger {
       return false;
   }
 
-  /*
-    .. warning::
-
-       bigint.odd_p is deprecated, use bigint.isOdd instead
-  */
   @deprecated
   ("bigint.odd_p is deprecated, use bigint.isOdd instead")
   proc bigint.odd_p() : int {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -395,13 +395,11 @@ module BigInteger {
       return ret.safeCast(int);
     }
 
-    /* Return the underlying implementation of :record:`bigint`.  Currently,
-       the type returned is ``__mpz_struct``.
-
-       .. warning::
-          This method is provided as a convenience but its result may change in
-          the future.
+    /*
+      Return the underlying implementation of :record:`bigint`.  Currently,
+      the type returned is ``__mpz_struct``.
     */
+    @unstable("getImpl is provided as a convenience but its result may change in the future")
     proc getImpl(): __mpz_struct {
       var ret: __mpz_struct;
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -153,83 +153,10 @@ module BigInteger {
   use OS;
   use ChplConfig only compiledForSingleLocale;
 
-
   /*
    Local copy of IO.EFORMAT as it is being phased out and is private in IO
    */
   private extern proc chpl_macro_int_EFORMAT():c_int;
-
-  @deprecated(notes="The enum Round is deprecated, please use the enum :enum:`roundingMode` instead")
-  enum Round {
-    DOWN = -1,
-    ZERO =  0,
-    UP   =  1
-  }
-
-  /* An enumeration of the different rounding strategies, for use with e.g.
-     :proc:`~BigInteger.divQ` to determine how to round the quotient when performing
-     the computation.
-   */
-  @deprecated(notes="enum round is deprecated - please use enum :enum:`roundingMode` instead")
-  enum round {
-    /*
-      Indicates that the quotient should be rounded down towards -infinity and
-      any remainder should have the same sign as the denominator.
-    */
-    down = -1,
-    /*
-      Indicates that the quotient should be rounded towards zero and any
-      remainder should have the same sign as the numerator.
-    */
-    zero = 0,
-    /*
-      Indicates that the quotient should be rounded up towards +infinity and any
-      remainder should have the opposite sign as the denominator.
-    */
-    up = 1
-  }
-
-
-  /* An enumeration of the different rounding strategies, for use with e.g.
-     :proc:`~BigInteger.div` to determine how to round the quotient when performing
-     the computation.
-   */
-  enum roundingMode {
-    /*
-      Indicates that the quotient should be rounded down towards -infinity and
-      any remainder should have the same sign as the denominator.
-    */
-    down = -1,
-    /*
-      Indicates that the quotient should be rounded towards zero and any
-      remainder should have the same sign as the numerator.
-    */
-    zero = 0,
-    /*
-      Indicates that the quotient should be rounded up towards +infinity and any
-      remainder should have the opposite sign as the denominator.
-    */
-    up = 1
-  }
-
-  proc chpl_roundToRoundingMode(param r) param : roundingMode {
-    use BigInteger.round;
-    if r == down then return roundingMode.down;
-    if r == zero then return roundingMode.zero;
-    if r == up then return roundingMode.up;
-    compilerError("unknown bigint rounding mode");
-  }
-
-  /* A compile-time parameter to control the behavior of bigint initializers
-     that take a string argument.
-
-     When ``false``, the deprecated behavior is used (i.e., errors will trigger
-     a halt at execution.)
-
-     When ``true``, the new behavior is used (i.e., errors will cause a
-     :type:`~OS.BadFormatError` to be thrown)
-  */
-  config param bigintInitThrows = false;
 
   // TODO: remove when initializers can throw in their body
   private proc throwingInitWorkaround() throws {
@@ -620,6 +547,77 @@ module BigInteger {
       s = this.getStr();
       writer.write(s);
     }
+  }
+
+  /* A compile-time parameter to control the behavior of bigint initializers
+     that take a string argument.
+
+     When ``false``, the deprecated behavior is used (i.e., errors will trigger
+     a halt at execution.)
+
+     When ``true``, the new behavior is used (i.e., errors will cause a
+     :type:`~OS.BadFormatError` to be thrown)
+  */
+  config param bigintInitThrows = false;
+
+  /* An enumeration of the different rounding strategies, for use with e.g.
+     :proc:`~BigInteger.div` to determine how to round the quotient when performing
+     the computation.
+   */
+  enum roundingMode {
+    /*
+      Indicates that the quotient should be rounded down towards -infinity and
+      any remainder should have the same sign as the denominator.
+    */
+    down = -1,
+    /*
+      Indicates that the quotient should be rounded towards zero and any
+      remainder should have the same sign as the numerator.
+    */
+    zero = 0,
+    /*
+      Indicates that the quotient should be rounded up towards +infinity and any
+      remainder should have the opposite sign as the denominator.
+    */
+    up = 1
+  }
+
+  proc chpl_roundToRoundingMode(param r) param : roundingMode {
+    use BigInteger.round;
+    if r == down then return roundingMode.down;
+    if r == zero then return roundingMode.zero;
+    if r == up then return roundingMode.up;
+    compilerError("unknown bigint rounding mode");
+  }
+
+  @deprecated(notes="The enum Round is deprecated, please use the enum :enum:`roundingMode` instead")
+  enum Round {
+    DOWN = -1,
+    ZERO =  0,
+    UP   =  1
+  }
+
+  /* An enumeration of the different rounding strategies, for use with e.g.
+     :proc:`~BigInteger.divQ` to determine how to round the quotient when performing
+     the computation.
+   */
+  @deprecated(notes="enum round is deprecated - please use enum :enum:`roundingMode` instead")
+  enum round {
+    /*
+      Indicates that the quotient should be rounded down towards -infinity and
+      any remainder should have the same sign as the denominator.
+    */
+    down = -1,
+    /*
+      Indicates that the quotient should be rounded towards zero and any
+      remainder should have the same sign as the numerator.
+    */
+    zero = 0,
+    /*
+      Indicates that the quotient should be rounded up towards +infinity and any
+      remainder should have the opposite sign as the denominator.
+    */
+    up = 1
   }
 
   //

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -1753,7 +1753,7 @@ module BigInteger {
 
 
   /*
-    Set ``result`` to the result of (``base`` raised to ``exp``) modulo ``mod``.
+    Set ``result`` to the result of ``(base**exp) modulo mod``.
 
     :arg result: Where the result is stored
     :type result: :record:`bigint`
@@ -1768,8 +1768,12 @@ module BigInteger {
     :type mod: :record:`bigint`
 
     .. warning::
-        The program behavior is undefined if ``exp`` is negative and the inverse
-        (1/``base``) modulo ``mod`` does not exist.
+       The program behavior is undefined if ``exp`` is negative and the inverse
+       ``(1/base) modulo mod`` does not exist.
+
+    .. seealso::
+       :proc:`GMP.mpz_powm` and
+       `mpz_powm <https://gmplib.org/manual/Integer-Exponentiation#index-mpz_005fpowm>`_.
   */
   proc powMod(ref result: bigint,
               const ref base: bigint,
@@ -1891,7 +1895,20 @@ module BigInteger {
     }
   }
 
-  // Documented in uint, uint version
+  /*
+    Set ``result`` to the result of ``base`` raised to ``exp``.
+
+    :arg result: Where the result is stored
+    :type result: :record:`bigint`
+    :arg base: The value to be raised to the power of ``exp``.
+    :type base: :record:`bigint`, ``int`` or ``uint``
+    :arg exp: The exponent to raise ``base`` to the power of.
+    :type exp: ``int`` or ``uint``
+
+    .. seealso::
+       :proc:`GMP.mpz_pow_ui` and
+       `mpz_pow_ui <https://gmplib.org/manual/Integer-Exponentiation#index-mpz_005fpow_005fui>`_.
+  */
   proc pow(ref result: bigint, const ref base: bigint, exp: int) {
     if exp >= 0 {
       BigInteger.pow(result, base, exp : uint);
@@ -1911,13 +1928,7 @@ module BigInteger {
     }
   }
 
-  // Documented in uint, uint version
-  @deprecated(notes="bigint.pow method is deprecated - please use the standalone function :proc:`~BigInteger.pow`")
-  proc bigint.pow(const ref base: bigint, exp: int) {
-    BigInteger.pow(this, base, exp);
-  }
-
-  // Documented in uint, uint version
+  /* See :proc:`~BigInteger.pow` */
   proc pow(ref result: bigint, const ref base: bigint, exp: uint) {
     const exp_ = exp.safeCast(c_ulong);
     if compiledForSingleLocale() {
@@ -1934,13 +1945,7 @@ module BigInteger {
     }
   }
 
-  // Documented in uint, uint version
-  @deprecated(notes="bigint.pow method is deprecated - please use the standalone function :proc:`~BigInteger.pow`")
-  proc bigint.pow(const ref base: bigint, exp: uint) {
-    BigInteger.pow(this, base, exp);
-  }
-
-  // Documented in uint, uint version
+  /* See :proc:`~BigInteger.pow` */
   proc pow(ref result: bigint, base: int, exp: int) {
     if base >= 0 && exp >= 0 {
       BigInteger.pow(result, base : uint, exp : uint);
@@ -1955,23 +1960,7 @@ module BigInteger {
     }
   }
 
-  // Documented in uint, uint version
-  @deprecated(notes="bigint.pow method is deprecated - please use the standalone function :proc:`~BigInteger.pow`")
-  proc bigint.pow(base: int, exp: int) {
-    BigInteger.pow(this, base, exp);
-  }
-
-  /* Set ``result`` to the result of ``base`` raised to ``exp``.
-
-     :arg result: Where the result is stored
-     :type result: :record:`bigint`
-
-     :arg base: The value to be raised to the power of ``exp``.
-     :type base: :record:`bigint`, ``int`` or ``uint``
-
-     :arg exp: The exponent to raise ``base`` to the power of.
-     :type exp: ``int`` or ``uint``
-   */
+  /* See :proc:`~BigInteger.pow` */
   proc pow(ref result: bigint, base: uint, exp: uint) {
     const base_ = base.safeCast(c_ulong);
     const exp_  = exp.safeCast(c_ulong);
@@ -1986,6 +1975,24 @@ module BigInteger {
         mpz_ui_pow_ui(result.mpz, base_, exp_);
       }
     }
+  }
+
+  // Documented in uint, uint version
+  @deprecated(notes="bigint.pow method is deprecated - please use the standalone function :proc:`~BigInteger.pow`")
+  proc bigint.pow(const ref base: bigint, exp: int) {
+    BigInteger.pow(this, base, exp);
+  }
+
+  // Documented in uint, uint version
+  @deprecated(notes="bigint.pow method is deprecated - please use the standalone function :proc:`~BigInteger.pow`")
+  proc bigint.pow(const ref base: bigint, exp: uint) {
+    BigInteger.pow(this, base, exp);
+  }
+
+  // Documented in uint, uint version
+  @deprecated(notes="bigint.pow method is deprecated - please use the standalone function :proc:`~BigInteger.pow`")
+  proc bigint.pow(base: int, exp: int) {
+    BigInteger.pow(this, base, exp);
   }
 
   /* Set ``this`` to the result of ``base`` raised to ``exp``.

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -169,19 +169,23 @@ module BigInteger {
   /* An enumeration of the different rounding strategies, for use with e.g.
      :proc:`~BigInteger.divQ` to determine how to round the quotient when performing
      the computation.
-
-     - ``round.down`` indicates that the quotient should be rounded down towards
-       -infinity and any remainder should have the same sign as the denominator.
-     - ``round.zero`` indicates that the quotient should be rounded towards zero
-       and any remainder should have the same sign as the numerator.
-     - ``round.up`` indicates that the quotient should be rounded up towards
-       +infinity and any remainder should have the opposite sign as the
-       denominator.
    */
   @deprecated(notes="enum round is deprecated - please use enum :enum:`roundingMode` instead")
   enum round {
+    /*
+      Indicates that the quotient should be rounded down towards -infinity and
+      any remainder should have the same sign as the denominator.
+    */
     down = -1,
+    /*
+      Indicates that the quotient should be rounded towards zero and any
+      remainder should have the same sign as the numerator.
+    */
     zero = 0,
+    /*
+      Indicates that the quotient should be rounded up towards +infinity and any
+      remainder should have the opposite sign as the denominator.
+    */
     up = 1
   }
 
@@ -189,20 +193,22 @@ module BigInteger {
   /* An enumeration of the different rounding strategies, for use with e.g.
      :proc:`~BigInteger.div` to determine how to round the quotient when performing
      the computation.
-
-     - ``roundingMode.down`` indicates that the quotient should be rounded down
-       towards -infinity and any remainder should have the same sign as the
-       denominator.
-     - ``roundingMode.zero`` indicates that the quotient should be rounded
-       towards zero and any remainder should have the same sign as the
-       numerator.
-     - ``roundingMode.up`` indicates that the quotient should be rounded up
-       towards +infinity and any remainder should have the opposite sign as the
-       denominator.
    */
   enum roundingMode {
+    /*
+      Indicates that the quotient should be rounded down towards -infinity and
+      any remainder should have the same sign as the denominator.
+    */
     down = -1,
+    /*
+      Indicates that the quotient should be rounded towards zero and any
+      remainder should have the same sign as the numerator.
+    */
     zero = 0,
+    /*
+      Indicates that the quotient should be rounded up towards +infinity and any
+      remainder should have the opposite sign as the denominator.
+    */
     up = 1
   }
 
@@ -4066,7 +4072,7 @@ module BigInteger {
      :type denom: :record:`bigint`, ``integral``
      :arg rounding: The rounding style to use, see :enum:`roundingMode` for a
                     description of what the rounding styles entail.  Defaults to
-                    ``zero`` if unspecified
+                    :enumconstant:`~roundingMode.zero` if unspecified
      :type rounding: :enum:`roundingMode`
 
      .. warning::
@@ -4194,15 +4200,15 @@ module BigInteger {
      :type denom: :record:`bigint`, ``integral``
      :arg rounding: The rounding style to use, see :enum:`roundingMode` for a
                     description of what the rounding styles entail.  Defaults to
-                    ``zero`` if unspecified
+                    :enumconstant:`~roundingMode.zero` if unspecified
      :type rounding: :enum:`roundingMode`
 
      .. warning::
         If the denominator is zero, the program behavior is undefined.
 
      .. note::
-        When ``rounding == roundingMode.down``, this procedure is equivalent to
-        :proc:`~BigInteger.mod`.
+        When ``rounding`` is :enumconstant:`~roundingMode.down`, this procedure
+        is equivalent to :proc:`~BigInteger.mod`.
 
      .. seealso::
         :proc:`GMP.mpz_cdiv_r`,
@@ -4270,7 +4276,7 @@ module BigInteger {
      :type denom: :record:`bigint`, ``integral``
      :arg rounding: The rounding style to use, see :enum:`roundingMode` for a
                     description of what the rounding styles entail.  Defaults to
-                    ``zero`` if unspecified
+                    :enumconstant:`~roundingMode.zero` if unspecified
      :type rounding: :enum:`roundingMode`
 
      .. warning::
@@ -4446,7 +4452,7 @@ module BigInteger {
      ``result``.
 
      This is the same as performing a right bit shift of ``numer`` by ``exp``
-     bits when ``rounding==roundingMode.down``.
+     bits when ``rounding`` is :enumconstant:`~roundingMode.down`.
 
      :arg result: Where the result is stored
      :type result: :record:`bigint`
@@ -4457,7 +4463,7 @@ module BigInteger {
      :type exp: ``integral``
      :arg rounding: The rounding style to use, see :enum:`roundingMode` for a
                     description of what the rounding styles entail.  Defaults to
-                    ``zero`` if unspecified
+                    :enumconstant:`~roundingMode.zero` if unspecified
      :type rounding: :enum:`roundingMode`
 
      .. seealso::
@@ -4553,7 +4559,7 @@ module BigInteger {
      :type exp: ``integral``
      :arg rounding: The rounding style to use, see :enum:`roundingMode` for a
                     description of what the rounding styles entail.  Defaults to
-                    ``zero`` if unspecified
+                    :enumconstant:`~roundingMode.zero` if unspecified
      :type rounding: :enum:`roundingMode`
 
      .. seealso::

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -2191,6 +2191,11 @@ module BigInteger {
     Negative values can only be odd perfect powers.
 
     :return: ``true`` if ``this`` is a perfect power, ``false`` otherwise.
+    :rtype: ``bool``
+
+    .. seealso::
+       :proc:`GMP.mpz_perfect_power_p` and
+       `mpz_perfect_power_p <https://gmplib.org/manual/Integer-Roots#index-mpz_005fperfect_005fpower_005fp>`_.
   */
   proc bigint.isPerfectPower () : bool {
     var t_ = this.localize();
@@ -2211,11 +2216,16 @@ module BigInteger {
 
   /*
     Return ``true`` if ``this`` is a perfect square, i.e., if the square root of
-    ``this`` is an integer.  Under this definition both ``0`` and ``1`` are
-    considered to be perfect squares.
+    ``this`` is an integer.
+
+    Under this definition both ``0`` and ``1`` are considered to be perfect squares.
 
     :return: ``true`` if ``this`` is a perfect square, ``false`` otherwise.
     :rtype: ``bool``
+
+    .. seealso::
+       :proc:`GMP.mpz_perfect_square_p` and
+       `mpz_perfect_square_p <https://gmplib.org/manual/Integer-Roots#index-mpz_005fperfect_005fsquare_005fp>`_.
   */
   proc bigint.isPerfectSquare() : bool {
     var t_ = this.localize();
@@ -3001,7 +3011,7 @@ module BigInteger {
 
     :arg x: value to compare ``this`` against
     :type x: :record:`bigint`
-    :returns: the number of bits that differ
+    :returns: The number of bits that differ
     :rtype: ``uint``
 
     .. seealso::
@@ -3026,9 +3036,9 @@ module BigInteger {
 
     If the bit at ``startBitIdx`` is ``0``, will return ``startBitIdx``.
 
-    :arg startBitIdx: the index of the first bit to start searching for a ``0``
+    :arg startBitIdx: The index of the first bit to start searching for a ``0``
     :type startBitIdx: ``integral``
-    :returns: the index of the first ``0`` bit after ``startBitIdx``, inclusive
+    :returns: The index of the first ``0`` bit after ``startBitIdx``, inclusive
     :rtype: ``uint``
   */
   @deprecated("scan0 is deprecated - please use :proc:`bigint.findNext0` instead")
@@ -3042,9 +3052,9 @@ module BigInteger {
 
     If the bit at ``startBitIdx`` is ``1``, will return ``startBitIdx``.
 
-    :arg startBitIdx: the index of the first bit to start searching for a ``1``
+    :arg startBitIdx: The index of the first bit to start searching for a ``1``
     :type startBitIdx: ``integral``
-    :returns: the index of the first ``1`` bit after ``startBitIdx``, inclusive
+    :returns: The index of the first ``1`` bit after ``startBitIdx``, inclusive
     :rtype: ``uint``
   */
   @deprecated("scan1 is deprecated - please use :proc:`bigint.findNext1` instead")
@@ -3057,9 +3067,9 @@ module BigInteger {
 
     If the bit at ``startBitIdx`` is ``1``, will return ``startBitIdx``.
 
-    :arg startBitIdx: the index of the first bit to start searching for a ``0``
+    :arg startBitIdx: The index of the first bit to start searching for a ``0``
     :type startBitIdx: ``integral``
-    :returns: the index of the first ``0`` bit after ``startBitIdx``, inclusive
+    :returns: The index of the first ``0`` bit after ``startBitIdx``, inclusive
     :rtype: ``uint``
 
     .. seealso::
@@ -3082,9 +3092,9 @@ module BigInteger {
 
     If the bit at ``startBitIdx`` is ``1``, will return ``startBitIdx``.
 
-    :arg startBitIdx: the index of the first bit to start searching for a ``1``
+    :arg startBitIdx: The index of the first bit to start searching for a ``1``
     :type startBitIdx: ``integral``
-    :returns: the index of the first ``1`` bit after ``startBitIdx``, inclusive
+    :returns: The index of the first ``1`` bit after ``startBitIdx``, inclusive
     :rtype: ``uint``
 
     .. seealso::
@@ -3108,7 +3118,7 @@ module BigInteger {
   /*
     Set the bit at ``idx`` of ``this``.
 
-    :arg idx: the index of the bit to be set
+    :arg idx: The index of the bit to be set
     :type idx: ``integral``
 
     .. seealso::
@@ -3135,7 +3145,7 @@ module BigInteger {
   /*
     Clear the bit at ``idx`` of ``this``.
 
-    :arg idx: the index of the bit to be cleared
+    :arg idx: The index of the bit to be cleared
     :type idx: ``integral``
 
     .. seealso::
@@ -3163,7 +3173,7 @@ module BigInteger {
     Toggle the bit at ``idx`` of ``this``. If the bit was 1, set it to 0. If
     the bit was 0, set it to 1.
 
-    :arg idx: the index of the bit to be toggled
+    :arg idx: The index of the bit to be toggled
     :type idx: ``integral``
 
     .. seealso::
@@ -3190,9 +3200,9 @@ module BigInteger {
   /*
     Get the bit at ``idx`` of ``this``.
 
-    :arg idx: the index of the bit to be returned
+    :arg idx: The index of the bit to be returned
     :type idx: ``integral``
-    :returns: the bit at index ``idx``
+    :returns: The bit at index ``idx``
     :rtype: ``int``
 
     .. seealso::

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -158,6 +158,17 @@ module BigInteger {
    */
   private extern proc chpl_macro_int_EFORMAT():c_int;
 
+  /* A compile-time parameter to control the behavior of bigint initializers
+     that take a string argument.
+
+     When ``false``, the deprecated behavior is used (i.e., errors will trigger
+     a halt at execution.)
+
+     When ``true``, the new behavior is used (i.e., errors will cause a
+     :type:`~OS.BadFormatError` to be thrown)
+  */
+  config param bigintInitThrows = false;
+
   // TODO: remove when initializers can throw in their body
   private proc throwingInitWorkaround() throws {
     throw new BadFormatError("Error initializing big integer");
@@ -552,17 +563,6 @@ module BigInteger {
       writer.write(s);
     }
   }
-
-  /* A compile-time parameter to control the behavior of bigint initializers
-     that take a string argument.
-
-     When ``false``, the deprecated behavior is used (i.e., errors will trigger
-     a halt at execution.)
-
-     When ``true``, the new behavior is used (i.e., errors will cause a
-     :type:`~OS.BadFormatError` to be thrown)
-  */
-  config param bigintInitThrows = false;
 
   /* An enumeration of the different rounding strategies, for use with e.g.
      :proc:`~BigInteger.div` to determine how to round the quotient when performing

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -506,8 +506,7 @@ module BigInteger {
       return ret;
     }
 
-    @deprecated
-    ("bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead")
+    @deprecated("bigint.sizeinbase is deprecated, use :proc:`bigint.sizeInBase` instead")
     proc sizeinbase(base: int) : uint {
       return sizeInBase(base).safeCast(uint);
     }
@@ -1702,24 +1701,21 @@ module BigInteger {
       return false;
   }
 
-  @deprecated
-  ("bigint.powm is deprecated, use bigint.powMod instead")
+  @deprecated("bigint.powm method is deprecated, please use the standalone function :proc:`~BigInteger.powMod` instead")
   proc bigint.powm(const ref base: bigint,
                    const ref exp:  bigint,
                    const ref mod:  bigint) {
     BigInteger.powMod(this, base, exp, mod);
   }
 
-  @deprecated
-  ("bigint.powm is deprecated, use bigint.powMod instead")
+  @deprecated("bigint.powm method is deprecated, please use the standalone function :proc:`~BigInteger.powMod` instead")
   proc bigint.powm(const ref base: bigint,
                              exp:  int,
                    const ref mod:  bigint) {
     BigInteger.powMod(this, base, exp, mod);
   }
 
-  @deprecated
-  ("bigint.powm is deprecated, use bigint.powMod instead")
+  @deprecated("bigint.powm method is deprecated, please use the standalone function :proc:`~BigInteger.powMod` instead")
   proc bigint.powm(const ref base: bigint,
                              exp:  uint,
                    const ref mod:  bigint) {
@@ -2149,8 +2145,7 @@ module BigInteger {
   proc bigint.sqrtrem(ref rem: bigint, const ref a: bigint)
     do BigInteger.sqrtRem(this, rem, a);
 
-  @deprecated
-  ("bigint.perfect_power_p is deprecated, use bigint.isPerfectPower instead")
+  @deprecated("bigint.perfect_power_p is deprecated, use :proc:`bigint.isPerfectPower` instead")
   proc bigint.perfect_power_p() : int {
     return this.isPerfectPower();
   }
@@ -2176,8 +2171,7 @@ module BigInteger {
       return false;
   }
 
-  @deprecated
-  ("bigint.perfect_square_p is deprecated, use bigint.isPerfectSquare instead")
+  @deprecated("bigint.perfect_square_p is deprecated, use :proc:`bigint.isPerfectSquare` instead")
   proc bigint.perfect_square_p() : int {
     return this.isPerfectSquare();
   }
@@ -2623,8 +2617,7 @@ module BigInteger {
     BigInteger.invert(this, a, b);
   }
 
-  @deprecated
-  ("bigint.remove is deprecated, use bigint.removeFactor instead")
+  @deprecated("bigint.remove is deprecated, use :proc:`bigint.removeFactor` instead")
   proc bigint.remove(const ref a: bigint, const ref f: bigint) : uint {
     return BigInteger.removeFactor(this, a,f);
   }
@@ -3213,8 +3206,7 @@ module BigInteger {
       return false;
   }
 
-  @deprecated
-  ("bigint.odd_p is deprecated, use bigint.isOdd instead")
+  @deprecated("bigint.odd_p is deprecated, use :proc:`bigint.isOdd` instead")
   proc bigint.odd_p() : int {
     return this.isOdd();
   }
@@ -3865,8 +3857,7 @@ module BigInteger {
     }
   }
 
-  @deprecated
-  ("bigint.div_q using Round is deprecated, use the standalone function :proc:`~BigInteger.div` with :enum:`roundingMode` instead")
+  @deprecated("bigint.div_q using Round is deprecated, use the standalone function :proc:`~BigInteger.div` with :enum:`roundingMode` instead")
   proc bigint.div_q(const ref n: bigint,
                               d: integral,
                     param     rounding = Round.ZERO) {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -702,7 +702,7 @@ module BigInteger {
     rounding towards zero).
 
     .. warning::
-       If the resulting expoenent from the conversion is too big, the result is
+       If the resulting exponent from the conversion is too big, the result is
        system dependant. If supported, an infinity may be returned. A hardware
        overflow trap may also occur.
 
@@ -1337,7 +1337,7 @@ module BigInteger {
 
 
   /*
-    Returns the Jacobi symbol ``a/b``, which is definied only when ``b`` is odd.
+    Returns the Jacobi symbol ``a/b``, which is defined only when ``b`` is odd.
 
     :rtype: ``int``
 
@@ -1359,7 +1359,7 @@ module BigInteger {
 
 
   /*
-    Returns the Legendre symbol ``a/p``, which is definied only when ``p`` is
+    Returns the Legendre symbol ``a/p``, which is defined only when ``p`` is
     an odd positive prime number.
 
     :rtype: ``int``
@@ -1561,7 +1561,6 @@ module BigInteger {
 
     :arg div: number to check if ``this`` is divisible by
     :type div: :record:`bigint`, ``int`` or ``uint``
-
     :return: ``true`` if ``this`` is exactly divisible by ``div``, ``false``
              otherwise
     :rtype: ``bool``
@@ -1630,7 +1629,7 @@ module BigInteger {
 
     .. seealso::
        :proc:`GMP.mpz_divisible_2exp_p` and
-       `mpz_divisible_2exp_p <hhttps://gmplib.org/manual/Integer-Division#index-mpz_005fdivisible_005f2exp_005fp>`_.
+       `mpz_divisible_2exp_p <https://gmplib.org/manual/Integer-Division#index-mpz_005fdivisible_005f2exp_005fp>`_.
    */
   proc bigint.isDivisibleBy2Pow(exp: integral) : bool {
     const t_ = this.localize();
@@ -2291,8 +2290,8 @@ module BigInteger {
   /* Set ``result`` to the next prime number greater than ``x``.
 
      .. note::
-        This is probablistic function and in an unlikely case may set
-        ``result`` to a compositie number.
+        This is a probabilistic function and in an unlikely case may set
+        ``result`` to a composite number.
 
      :arg result: return value that will contain the next prime number
      :type result: :record:`bigint`
@@ -3252,7 +3251,7 @@ module BigInteger {
 
     .. seealso::
        :proc:`GMP.mpz_even_p` and
-       `mpz_even_p <hhttps://gmplib.org/manual/Miscellaneous-Integer-Functions#index-mpz_005feven_005fp>`_.
+       `mpz_even_p <https://gmplib.org/manual/Miscellaneous-Integer-Functions#index-mpz_005feven_005fp>`_.
   */
   proc bigint.isEven() : bool {
     var t_ = this.localize();
@@ -3278,7 +3277,7 @@ module BigInteger {
 
     .. seealso::
        :proc:`GMP.mpz_odd_p` and
-       `mpz_odd_p <hhttps://gmplib.org/manual/Miscellaneous-Integer-Functions#index-mpz_005fodd_005fp>`_.
+       `mpz_odd_p <https://gmplib.org/manual/Miscellaneous-Integer-Functions#index-mpz_005fodd_005fp>`_.
   */
   proc bigint.isOdd() : bool {
     var t_ = this.localize();
@@ -3880,7 +3879,7 @@ module BigInteger {
 
      :arg result: Where the result is stored
      :type result: :record:`bigint`
-     :arg x: The number to take the absoulte value of
+     :arg x: The number to take the absolute value of
      :type x: :record:`bigint`
 
      .. seealso::

--- a/test/deprecated-keyword/messageFiltering.chpl
+++ b/test/deprecated-keyword/messageFiltering.chpl
@@ -56,12 +56,14 @@ var x3010 = 3010;
 var x3011 = 3011;
 @deprecated(notes="Lorem ipsum :enum:`test` dolor sit amet")
 var x3012 = 3012;
-@deprecated(notes="Lorem :mod:`abc` ipsum :proc:`def` dolor :iter:`ghi` sit :data:`jkl` amet")
+@deprecated(notes="Lorem ipsum :enumconstant:`test.constant` dolor sit amet")
 var x3013 = 3013;
-@deprecated(notes="Lorem :const:`abc` ipsum :var:`def` dolor :param:`ghi` sit :type:`jkl` amet")
+@deprecated(notes="Lorem :mod:`abc` ipsum :proc:`def` dolor :iter:`ghi` sit :data:`jkl` amet")
 var x3014 = 3014;
-@deprecated(notes="Lorem :class:`abc` ipsum :record:`def` dolor :attr:`ghi` sit amet")
+@deprecated(notes="Lorem :const:`abc` ipsum :var:`def` dolor :param:`ghi` sit :type:`jkl` amet")
 var x3015 = 3015;
+@deprecated(notes="Lorem :class:`abc` ipsum :record:`def` dolor :attr:`ghi` sit amet")
+var x3016 = 3016;
 
 // Test different text in ::s (all should not filter)
 @deprecated(notes="--- Test different text in ::s (all should not filter) ---")
@@ -228,6 +230,7 @@ writeln(x3012);
 writeln(x3013);
 writeln(x3014);
 writeln(x3015);
+writeln(x3016);
 
 writeln(x4000);
 writeln(x4001);

--- a/test/deprecated-keyword/messageFiltering.good
+++ b/test/deprecated-keyword/messageFiltering.good
@@ -23,6 +23,7 @@ messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
 messageFiltering.chpl:n: warning: Lorem ipsum test dolor sit amet
+messageFiltering.chpl:n: warning: Lorem ipsum test.constant dolor sit amet
 messageFiltering.chpl:n: warning: Lorem abc ipsum def dolor ghi sit jkl amet
 messageFiltering.chpl:n: warning: Lorem abc ipsum def dolor ghi sit jkl amet
 messageFiltering.chpl:n: warning: Lorem abc ipsum def dolor ghi sit amet
@@ -110,6 +111,7 @@ messageFiltering.chpl:n: warning: Lorem ipsum :proc:`abc <def.ghi>` dolor sit am
 3013
 3014
 3015
+3016
 4000
 4001
 4002

--- a/test/deprecated/BigInteger/deprecatePowm.good
+++ b/test/deprecated/BigInteger/deprecatePowm.good
@@ -1,4 +1,4 @@
-deprecatePowm.chpl:11: warning: bigint.powm method is deprecated, use the standalone function powMod instead
-deprecatePowm.chpl:15: warning: bigint.powm method is deprecated, use the standalone function powMod instead
+deprecatePowm.chpl:11: warning: bigint.powm method is deprecated, please use the standalone function powMod instead
+deprecatePowm.chpl:15: warning: bigint.powm method is deprecated, please use the standalone function powMod instead
 2^4 mod 10 = 6
 2^3 mod 10 = 8

--- a/test/deprecated/BigInteger/deprecatePowm.good
+++ b/test/deprecated/BigInteger/deprecatePowm.good
@@ -1,4 +1,4 @@
-deprecatePowm.chpl:11: warning: bigint.powm is deprecated, use bigint.powMod instead
-deprecatePowm.chpl:15: warning: bigint.powm is deprecated, use bigint.powMod instead
+deprecatePowm.chpl:11: warning: bigint.powm method is deprecated, use the standalone function powMod instead
+deprecatePowm.chpl:15: warning: bigint.powm method is deprecated, use the standalone function powMod instead
 2^4 mod 10 = 6
 2^3 mod 10 = 8

--- a/test/deprecated/BigInteger/deprecateSizeinbase.good
+++ b/test/deprecated/BigInteger/deprecateSizeinbase.good
@@ -1,7 +1,7 @@
-deprecateSizeinbase.chpl:7: warning: bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
-deprecateSizeinbase.chpl:8: warning: bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
-deprecateSizeinbase.chpl:9: warning: bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
-deprecateSizeinbase.chpl:10: warning: bigint.sizeinbase() is deprecated, use bigint.sizeInBase() instead
+deprecateSizeinbase.chpl:7: warning: bigint.sizeinbase is deprecated, use bigint.sizeInBase instead
+deprecateSizeinbase.chpl:8: warning: bigint.sizeinbase is deprecated, use bigint.sizeInBase instead
+deprecateSizeinbase.chpl:9: warning: bigint.sizeinbase is deprecated, use bigint.sizeInBase instead
+deprecateSizeinbase.chpl:10: warning: bigint.sizeinbase is deprecated, use bigint.sizeInBase instead
 -65536 is 6 digits in base 10
 -65536 is 17 digits in base 2
 129 is 3 digits in base 10


### PR DESCRIPTION
Improves BigInteger documentation by adding it where missing and trying to make the existing docs feel unified.

As a part of this PR, added filtering support for `enumconstant` to `frontend/lib/util/filtering.cpp`. I also tried to reduce the code duplication to reduce the maintenance burden 

## Summary of changes
- added docs to functions missing it 
  - for some functions, just needed to augment the existing documentation with types, links, etc 
- added docs for operators and exposed cast operators in docs
- update rounding enum definitions and move to the bottom of the file
  - this change makes the first thing you see on the BigInteger docs page be `bigint`, not a deprecated `enum ROUND` 
- cleanup some old deprecation messages
- refactor some more functions to use `.localize()` where applicable
- refactor some common code patterns
   ```chapel
   if compiledForSingleLocale() {}
   else if "on my locale" {}
   else {}
   ``` 
   to
   ```chapel
   if compiledForSingleLocale() || "on my locale" {}
   else {}
   ``` 
   if the cases were the same. This should save some maintenance burden and have the same performance due to param folding.

closes #17738
closes cray/chapel-private#5101
implements comment from: https://github.com/chapel-lang/chapel/issues/17735#issuecomment-1629214588

[Reviewed by @bmcdonald3]