### PR TITLE
list parsing bug fix for JsonDeserializer

### DIFF
--- a/modules/packages/JSON.chpl
+++ b/modules/packages/JSON.chpl
@@ -537,11 +537,27 @@ module JSON {
       if !_firstThing then reader._readLiteral(",");
       else _firstThing = false;
 
-      return reader.read(eltType);
+      // preemptively check if a list will end with the next byte
+      //  to avoid an uncaught BadFormatError in eltType's
+      //  deserializing initializer
+      if this.peekListEnd(reader)
+        then throw new BadFormatError();
+        else return reader.read(eltType);
     }
     @chpldoc.nodoc
     proc endList(reader: _readerType) throws {
       reader._readLiteral("]");
+    }
+    @chpldoc.nodoc
+    proc peekListEnd(reader: _readerType): bool throws {
+      reader.mark();
+      if reader.matchLiteral("]") {
+        reader.revert();
+        return true;
+      } else {
+        reader.commit(); // doesn't do anything
+        return false;
+      }
     }
 
     // Array helpers

--- a/test/io/ferguson/json-basic.chpl
+++ b/test/io/ferguson/json-basic.chpl
@@ -1,13 +1,15 @@
 
-use IO;
+use IO, JSON;
 
 record MyRecord {
   var a: int;
   var b: int;
 }
 
-writef("testing default stdout: %t\n", new MyRecord(1,2));
-writef("testing json stdout: %jt\n", new MyRecord(1,2));
+writef("testing default stdout: %?\n", new MyRecord(1,2));
+stdout
+  .withSerializer(JsonSerializer)
+  .writef("testing json stdout: %?\n", new MyRecord(1,2));
 
 var f = openTempFile();
 
@@ -20,11 +22,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  var got = reader.readf("%jt", r);
+  var got = reader.readf("%?", r);
 
   writeln("got is ", got);
   writeln("Read: ", r);
@@ -41,11 +43,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  var got = reader.readf("%jt", r);
+  var got = reader.readf("%?", r);
 
   writeln("got is ", got);
   writeln("Read: ", r);
@@ -63,15 +65,15 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
   var got: bool;
 
   try! {
-    got = reader.readf("%~jt", r);
-  } catch e: BadFormatError {
-    writeln("bad format error");
+    got = reader.readf("%?", r);
+  } catch e: IllegalArgumentError {
+    writeln("illegal argument error");
   }
   writeln("got is ", got);
   writeln("Read: ", r);
@@ -88,11 +90,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -108,11 +110,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -129,11 +131,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -150,11 +152,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%~jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -170,11 +172,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%~jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -192,11 +194,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%~jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -213,11 +215,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%~jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -233,11 +235,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%~jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -253,11 +255,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%~jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 
@@ -273,11 +275,11 @@ var f = openTempFile();
 }
 
 {
-  var reader = f.reader();
+  var reader = f.reader(deserializer = new JsonDeserializer());
 
   var r:MyRecord;
 
-  reader.readf("%~jt", r);
+  reader.readf("%?", r);
 
   writeln("Read: ", r);
 

--- a/test/io/ferguson/json-basic.good
+++ b/test/io/ferguson/json-basic.good
@@ -7,7 +7,7 @@ Writing JSON:
 got is false
 Read: (a = 0, b = 0)
 Writing JSON: {"c":3}
-bad format error
+illegal argument error
 got is false
 Read: (a = 0, b = 0)
 Writing JSON: {"a":1, "b":2}

--- a/test/io/ferguson/json-basic.notest
+++ b/test/io/ferguson/json-basic.notest
@@ -1,1 +1,0 @@
-will remove .notest after a skip-field option is added to JsonDeserializer to replace '%~jt'

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -187,13 +187,15 @@ proc process_json(logfile:fileReader, fname:string, ref Pairs) {
   var nlines = 0;
   var max_id = 0;
 
+  var jsonReader = logfile.withDeserializer(JsonDeserializer);
+
   if progress then
     writeln(fname, " : processing");
 
   while true {
     try! {
       try {
-        got = logfile.readf("%~jt", tweet);
+        got = jsonReader.read(tweet);
       } catch e: BadFormatError {
         if verbose {
             try! logfile.lock();
@@ -204,7 +206,7 @@ proc process_json(logfile:fileReader, fname:string, ref Pairs) {
         }
 
         // read over something else
-        got = logfile.readf("%~jt", empty);
+        got = logfile.read(empty);
       }
     } catch e: SystemError {
       try! logfile.lock();
@@ -218,7 +220,7 @@ proc process_json(logfile:fileReader, fname:string, ref Pairs) {
     } // halt on truly unknown error
 
     if got {
-      if verbose then stdout.withSerializer(JsonSerializer).writef("%?\n", tweet);
+      if verbose then stdout.withSerializer(JsonSerializer).write(tweet);
       var id = tweet.user.id;
       if max_id < id then max_id = id;
       for mentions in tweet.entities.user_mentions {

--- a/test/studies/labelprop/labelprop-tweets.notest
+++ b/test/studies/labelprop/labelprop-tweets.notest
@@ -1,1 +1,0 @@
-will remove .notest after a skip-field option is added to JsonDeserializer to replace '%~jt'


### PR DESCRIPTION
Fixes a bug where the `JsonDeserializer` could fail to parse a list if the element type's deserializing initializer threw an error.

Also removes some `notest` files from two Json IO tests that are now working. 

- [x] local paratest
- [x] gasnet paratest