### PR TITLE
Un-future type-alias-method.chpl

### DIFF
--- a/test/users/ferguson/type-alias-method.future
+++ b/test/users/ferguson/type-alias-method.future
@@ -1,1 +1,0 @@
-bug: method on type alias


### PR DESCRIPTION
This test was added in PR #3072 and is now working as expected after PR #22622 made some minor improvements to it while updating it for the `c_string` deprecation.

Test change only - not reviewed.