### PR TITLE
Fix unstable warning for assertVectorized

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1273,7 +1273,7 @@ void Visitor::checkAttributeNameRecognizedOrToolSpaced(const Attribute* node) {
 void Visitor::checkAttributeUnstable(const Attribute* node) {
   if (shouldEmitUnstableWarning(node)) {
     if(node->name() == UniqueString::get(context_, "llvm.metadata") ||
-       node->name() == UniqueString::get(context_, "llvm.metadata")) {
+       node->name() == UniqueString::get(context_, "llvm.assertVectorized")) {
       warn(node, "'%s' is an unstable attribute", node->name());
     }
   }

--- a/test/unstable/llvmMetadata.good
+++ b/test/unstable/llvmMetadata.good
@@ -1,6 +1,6 @@
 llvmMetadata.chpl:2: In function 'saxpy':
 llvmMetadata.chpl:10: warning: Unknown attribute tool name 'llvm'
+llvmMetadata.chpl:10: warning: 'llvm.assertVectorized' is an unstable attribute
 llvmMetadata.chpl:11: warning: Unknown attribute tool name 'llvm'
 llvmMetadata.chpl:11: warning: 'llvm.metadata' is an unstable attribute
-llvmMetadata.chpl:10: warning: 'llvm.assertVectorized' is an unstable attribute
 3.0 6.0 9.0 12.0 15.0 18.0 21.0 24.0 27.0 30.0 33.0 36.0 39.0 42.0 45.0 48.0


### PR DESCRIPTION
Fixes unstable warning for assertVectorized not being thrown.

[not reviewed - trivial]