### PR TITLE
Mark the log functions as unstable when uint and int arguments are provided

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -598,6 +598,38 @@ module Math {
 
      It is an error if `x` is less than or equal to zero.
   */
+  @chpldoc.nodoc
+  @unstable("The version of 'ln' that takes an int argument is unstable and may change its return type in the future")
+  inline proc ln(x: int(?w)) {
+    if (w < 32) {
+      // These were coerced to real(32) prior to the existence of this overload,
+      // so maintain that behavior for now.
+      return ln(x: real(32));
+    } else {
+      return ln(x: real(w));
+    }
+  }
+
+  /* Returns the natural logarithm of the argument `x`.
+
+     It is an error if `x` is equal to zero.
+  */
+  @chpldoc.nodoc
+  @unstable("The version of 'ln' that takes an uint argument is unstable and may change its return type in the future")
+  inline proc ln(x: uint(?w)) {
+    if (w < 32) {
+      // These were coerced to real(32) prior to the existence of this overload,
+      // so maintain that behavior for now.
+      return ln(x: real(32));
+    } else {
+      return ln(x: real(w));
+    }
+  }
+
+  /* Returns the natural logarithm of the argument `x`.
+
+     It is an error if `x` is less than or equal to zero.
+  */
   inline proc log(x: real(64)): real(64) {
     return chpl_log(x);
   }
@@ -620,6 +652,38 @@ module Math {
     return chpl_log(x);
   }
 
+  /* Returns the natural logarithm of the argument `x`.
+
+     It is an error if `x` is less than or equal to zero.
+  */
+  @chpldoc.nodoc
+  @unstable("The version of 'log' that takes an int argument is unstable and may change its return type in the future")
+  inline proc log(x: int(?w)) {
+    if (w < 32) {
+      // These were coerced to real(32) prior to the existence of this overload,
+      // so maintain that behavior for now.
+      return log(x: real(32));
+    } else {
+      return log(x: real(w));
+    }
+  }
+
+  /* Returns the natural logarithm of the argument `x`.
+
+     It is an error if `x` is equal to zero.
+  */
+  @chpldoc.nodoc
+  @unstable("The version of 'log' that takes an uint argument is unstable and may change its return type in the future")
+  inline proc log(x: uint(?w)) {
+    if (w < 32) {
+      // These were coerced to real(32) prior to the existence of this overload,
+      // so maintain that behavior for now.
+      return log(x: real(32));
+    } else {
+      return log(x: real(w));
+    }
+  }
+
   /* Returns the base 10 logarithm of the argument `x`.
 
      It is an error if `x` is less than or equal to zero.
@@ -636,6 +700,38 @@ module Math {
     return chpl_log10(x);
   }
 
+  /* Returns the base 10 logarithm of the argument `x`.
+
+     It is an error if `x` is less than or equal to zero.
+  */
+  @chpldoc.nodoc
+  @unstable("The version of 'log10' that takes an int argument is unstable and may change its return type in the future")
+  inline proc log10(x: int(?w)) {
+    if (w < 32) {
+      // These were coerced to real(32) prior to the existence of this overload,
+      // so maintain that behavior for now.
+      return log10(x: real(32));
+    } else {
+      return log10(x: real(w));
+    }
+  }
+
+  /* Returns the base 10 logarithm of the argument `x`.
+
+     It is an error if `x` is equal to zero.
+  */
+  @chpldoc.nodoc
+  @unstable("The version of 'log10' that takes an uint argument is unstable and may change its return type in the future")
+  inline proc log10(x: uint(?w)) {
+    if (w < 32) {
+      // These were coerced to real(32) prior to the existence of this overload,
+      // so maintain that behavior for now.
+      return log10(x: real(32));
+    } else {
+      return log10(x: real(w));
+    }
+  }
+
   /* Returns the natural logarithm of `x` + 1.
 
      It is an error if `x` is less than or equal to -1.
@@ -650,6 +746,36 @@ module Math {
   */
   inline proc log1p(x : real(32)): real(32) {
     return chpl_log1p(x);
+  }
+
+  /* Returns the natural logarithm of `x` + 1.
+
+     It is an error if `x` is less than or equal to -1.
+  */
+  @chpldoc.nodoc
+  @unstable("The version of 'log1p' that takes an int argument is unstable and may change its return type in the future")
+  inline proc log1p(x: int(?w)) {
+    if (w < 32) {
+      // These were coerced to real(32) prior to the existence of this overload,
+      // so maintain that behavior for now.
+      return log1p(x: real(32));
+    } else {
+      return log1p(x: real(w));
+    }
+  }
+
+  /* Returns the natural logarithm of `x` + 1.
+  */
+  @chpldoc.nodoc
+  @unstable("The version of 'log1p' that takes an uint argument is unstable and may change its return type in the future")
+  inline proc log1p(x: uint(?w)) {
+    if (w < 32) {
+      // These were coerced to real(32) prior to the existence of this overload,
+      // so maintain that behavior for now.
+      return log1p(x: real(32));
+    } else {
+      return log1p(x: real(w));
+    }
   }
 
   /* Returns the log to the base `2**exp` of the given `x` value.
@@ -725,6 +851,7 @@ module Math {
 
      It is an error if `x` is less than or equal to zero.
   */
+  @unstable("The version of 'log2' that takes an int argument is unstable")
   inline proc log2(x: int(?w)) {
     return chpl_log2(x);
   }
@@ -734,8 +861,9 @@ module Math {
 
      :rtype: `int`
 
-     It is an error if `x` is less than or equal to zero.
+     It is an error if `x` is equal to zero.
   */
+  @unstable("The version of 'log2' that takes an uint argument is unstable")
   inline proc log2(x: uint(?w)) {
     return chpl_log2(x);
   }

--- a/test/unstable/Math/unstableLogs.chpl
+++ b/test/unstable/Math/unstableLogs.chpl
@@ -1,0 +1,42 @@
+use Math;
+
+// log2
+var log2Int = log2(4);
+writeln(log2Int.type: string);
+writeln(log2Int);
+var log2UInt = log2(4: uint);
+writeln(log2UInt.type: string);
+writeln(log2UInt);
+
+// ln
+var lnInt = ln(e: int);
+writeln(lnInt.type: string);
+writeln(lnInt);
+var lnUInt = ln(e: uint);
+writeln(lnUInt.type: string);
+writeln(lnUInt);
+
+writeln("-- log --");
+// log
+var logInt = log(e: int(16));
+writeln(logInt.type: string);
+writeln(logInt);
+var logUInt = log(e: uint(8));
+writeln(logUInt.type: string);
+writeln(logUInt);
+
+writeln("-- log10 --");
+var log10Int = log10(100);
+writeln(log10Int.type: string);
+writeln(log10Int);
+var log10UInt = log10(1000: uint);
+writeln(log10UInt.type: string);
+writeln(log10UInt);
+
+writeln("-- log1p --");
+var log1pInt = log1p(e: int(16));
+writeln(log1pInt.type: string);
+writeln(log1pInt);
+var log1pUInt = log1p(e: uint(8));
+writeln(log1pUInt.type: string);
+writeln(log1pUInt);

--- a/test/unstable/Math/unstableLogs.good
+++ b/test/unstable/Math/unstableLogs.good
@@ -1,0 +1,33 @@
+unstableLogs.chpl:4: warning: The version of 'log2' that takes an int argument is unstable
+unstableLogs.chpl:7: warning: The version of 'log2' that takes an uint argument is unstable
+unstableLogs.chpl:12: warning: The version of 'ln' that takes an int argument is unstable and may change its return type in the future
+unstableLogs.chpl:15: warning: The version of 'ln' that takes an uint argument is unstable and may change its return type in the future
+unstableLogs.chpl:21: warning: The version of 'log' that takes an int argument is unstable and may change its return type in the future
+unstableLogs.chpl:24: warning: The version of 'log' that takes an uint argument is unstable and may change its return type in the future
+unstableLogs.chpl:29: warning: The version of 'log10' that takes an int argument is unstable and may change its return type in the future
+unstableLogs.chpl:32: warning: The version of 'log10' that takes an uint argument is unstable and may change its return type in the future
+unstableLogs.chpl:37: warning: The version of 'log1p' that takes an int argument is unstable and may change its return type in the future
+unstableLogs.chpl:40: warning: The version of 'log1p' that takes an uint argument is unstable and may change its return type in the future
+int(64)
+2
+int(64)
+2
+real(64)
+0.693147
+real(64)
+0.693147
+-- log --
+real(32)
+0.693147
+real(32)
+0.693147
+-- log10 --
+real(64)
+2.0
+real(64)
+3.0
+-- log1p --
+real(32)
+1.09861
+real(32)
+1.09861


### PR DESCRIPTION
(except logBasePow2, which is already unstable)

log2 had explicit overloads to allow calls with `int` and `uint` arguments,
which would return ints.  This was not consistent with the behavior of the other
log functions, which did not have explicit overloads and so coerced such
arguments to reals of the nearest size, thus returning reals.

W.r.t. 2.0, the plan is to mark all such calls as unstable.  This may mean that
the log2 overloads return reals in the future, or it may mean that log, ln,
log10, and log1p will change their return type when provided int or uint
arguments in the future.  We are short on time before the 2.0 release, though,
so will not make that decision yet.

Though "new" overloads are added, they are not included in the generated
documentation.  This will enable users that are accidentally relying on the
behavior to get notified without cluttering the module documentation until
we're ready to stabilize the log functions' behavior.

Discussed in #10292 

Add a test locking in the unstable warning for the various log versions.

Passed a full paratest with futures.