### PR TITLE
Fix tests minimal module tests broken in asan and valgrind configurations

### DIFF
--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -158,7 +158,7 @@ module ChapelTaskTable {
 
   export proc chpldev_taskTable_print()
   {
-    use IO;
+    use IO, CTypes;
     extern proc chpl_lookupFilename(idx: int(32)): c_ptrConst(c_char);
 
     if (chpldev_taskTable == nil) then return;

--- a/modules/minimal/internal/ChapelTaskTable.chpl
+++ b/modules/minimal/internal/ChapelTaskTable.chpl
@@ -22,10 +22,16 @@
 //
 
 module ChapelTaskTable {
-
+  extern type faux_c_string = chpl__c_void_ptr; // in place of deprecated c_string
   proc chpldev_taskTable_init() {
   }
 
+  export proc chpldev_taskTable_add(taskID   : chpl_taskID_t,
+                                    lineno   : uint(32),
+                                    filename : faux_c_string,
+                                    tl_info  : uint(64))
+  {
+  }
 
   export proc chpldev_taskTable_remove(taskID : chpl_taskID_t)
   {

--- a/modules/minimal/internal/MemTracking.chpl
+++ b/modules/minimal/internal/MemTracking.chpl
@@ -28,7 +28,7 @@ module MemTracking
   // config consts to the runtime code that actually implements the
   // memory tracking.
   //
-  extern type raw_c_void_ptr = chpl__c_void_ptr;
+  extern type faux_c_string = chpl__c_void_ptr;
   export
   proc chpl_memTracking_returnConfigVals(ref ret_memTrack: bool,
                                          ref ret_memStats: bool,
@@ -36,8 +36,8 @@ module MemTracking
                                          ref ret_memLeaksTable: bool,
                                          ref ret_memMax: uint(64),       // **
                                          ref ret_memThreshold: uint(64), // **
-                                         ref ret_memLog: raw_c_void_ptr,
-                                         ref ret_memLeaksLog: raw_c_void_ptr) {
+                                         ref ret_memLog: faux_c_string,
+                                         ref ret_memLeaksLog: faux_c_string) {
 
     // ** In minimal-modules mode, I've hard-coded these c_size_t
     // arguments to uint(64) rather than using the c_size_t aliases

--- a/test/trivial/diten/printvisibleOptFalse.good
+++ b/test/trivial/diten/printvisibleOptFalse.good
@@ -7,12 +7,14 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/ChapelLocale.chpl:61: chpl_taskRunningCntReset
   modules/minimal/internal/ChapelTaskData.chpl:24: chpl_task_setCommDiagsTemporarilyDisabled
   modules/minimal/internal/ChapelTaskData.chpl:28: chpl_task_getCommDiagsTemporarilyDisabled
+  modules/minimal/internal/ChapelTaskTable.chpl:25: faux_c_string
   modules/minimal/internal/ChapelTaskTable.chpl:26: chpldev_taskTable_init
-  modules/minimal/internal/ChapelTaskTable.chpl:30: chpldev_taskTable_remove
-  modules/minimal/internal/ChapelTaskTable.chpl:34: chpldev_taskTable_set_active
-  modules/minimal/internal/ChapelTaskTable.chpl:38: chpldev_taskTable_set_suspended
-  modules/minimal/internal/ChapelTaskTable.chpl:42: chpldev_taskTable_get_tl_info
-  modules/minimal/internal/ChapelTaskTable.chpl:46: chpldev_taskTable_print
+  modules/minimal/internal/ChapelTaskTable.chpl:29: chpldev_taskTable_add
+  modules/minimal/internal/ChapelTaskTable.chpl:36: chpldev_taskTable_remove
+  modules/minimal/internal/ChapelTaskTable.chpl:40: chpldev_taskTable_set_active
+  modules/minimal/internal/ChapelTaskTable.chpl:44: chpldev_taskTable_set_suspended
+  modules/minimal/internal/ChapelTaskTable.chpl:48: chpldev_taskTable_get_tl_info
+  modules/minimal/internal/ChapelTaskTable.chpl:52: chpldev_taskTable_print
   modules/minimal/internal/ChapelUtil.chpl:28: chpl_main_argument
   modules/minimal/internal/ChapelUtil.chpl:35: chpl_rt_preUserCodeHook
   modules/minimal/internal/ChapelUtil.chpl:36: chpl_rt_postUserCodeHook
@@ -22,6 +24,7 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/ChapelUtil.chpl:48: chpl_deinitModules
   modules/minimal/internal/IO.chpl:23: errorCode
   modules/minimal/internal/IO.chpl:24: qio_channel_ptr_t
+  modules/minimal/internal/IO.chpl:29: raw_c_void_ptr
   modules/minimal/internal/IO.chpl:31: chpl_qio_setup_plugin_channel
   modules/minimal/internal/IO.chpl:34: chpl_qio_read_atleast
   modules/minimal/internal/IO.chpl:37: chpl_qio_write
@@ -31,6 +34,5 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/IO.chpl:49: chpl_qio_get_chunk
   modules/minimal/internal/IO.chpl:52: chpl_qio_get_locales_for_region
   modules/minimal/internal/IO.chpl:55: chpl_qio_file_close
-  modules/minimal/internal/MemTracking.chpl:31: raw_c_void_ptr
   modules/minimal/internal/MemTracking.chpl:33: chpl_memTracking_returnConfigVals
   printvisibleOptFalse.chpl:1: xyzSymbol


### PR DESCRIPTION
This PR should correct some broken tests in asan and valgrind test configurations. In the process of deprecating `c_string` in https://github.com/chapel-lang/chapel/pull/22622, I removed some signatures from `minimal` modules that included `c_string` as a formal. While it worked in all the regular paratest configurations I ran, it failed in asan and valgrind configurations. This PR corrects those failures by adding the missing signature back in, and updating the formal type to a void pointer type.

TESTING:

- [x] local asan testing of the failing tests

[reviewed by @mppf - thank you!]