### PR TITLE
fix incorrect int64 cast for 32-bit system

### DIFF
--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -711,7 +711,7 @@ module Curl {
 
     private proc startsWith(haystack:c_ptrConst(c_char), needle:c_ptrConst(c_char)) {
       extern proc strncmp(s1: c_ptrConst(c_char), s2: c_ptrConst(c_char), n:c_size_t):c_int;
-      const len = strLen(needle):uint(64);
+      const len = strLen(needle):c_size_t;
       return strncmp(haystack, needle, len) == 0;
     }
 


### PR DESCRIPTION
This PR corrects a bad cast to a 64 bit sized int that caused tests to fail on 32-bit systems. This was introduced in https://github.com/chapel-lang/chapel/pull/22622.

The fix is just to change the cast to a `c_size_t`, which will always be the correct size for the receiver since it also expects a `c_size_t`.

TESTING:

- [x] paratest

[trivial change - not reviewed]