### PR TITLE
fix fortran interop test failures due to deprecation messages

### DIFF
--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -572,14 +572,14 @@ this function itself.  The following should work after replacing
     export proc chpl_library_init_ftn() {
       // Make the runtime/library initialization function visible
       extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-      var filename = c"fake";
+      var filename = "fake":chpl_c_string;
       // Initialize the internal runtime/library
-      chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+      chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
       // Initialize the main user module
       chpl__init_MyModuleName();
     }
 
-A simple Fortran example using a function ``myChapelFunction`` from the 
+A simple Fortran example using a function ``myChapelFunction`` from the
 ``MyModuleName`` library is:
 
 .. code-block:: Fortran

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
@@ -6,8 +6,8 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = c"fake";
-  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  var filename = "fake":chpl_c_string;
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }
 

--- a/test/interop/fortran/fortArrayToDRAutomatic/chapelProcs.chpl
+++ b/test/interop/fortran/fortArrayToDRAutomatic/chapelProcs.chpl
@@ -3,8 +3,8 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = c"fake";
-  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  var filename = "fake":chpl_c_string;
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }
 

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
@@ -3,8 +3,8 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = c"fake";
-  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  var filename = "fake":chpl_c_string;
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }
 

--- a/test/interop/fortran/genFortranInterface/chapelProcs.chpl
+++ b/test/interop/fortran/genFortranInterface/chapelProcs.chpl
@@ -6,8 +6,8 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = c"fake";
-  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  var filename = "fake":chpl_c_string;
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }
 

--- a/test/interop/fortran/multidimArray/chapelProcs.chpl
+++ b/test/interop/fortran/multidimArray/chapelProcs.chpl
@@ -3,8 +3,8 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = c"fake";
-  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  var filename = "fake":chpl_c_string;
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }
 


### PR DESCRIPTION
This PR will fix test failures caused by deprecation messages related to `c_string` literals brought about by https://github.com/chapel-lang/chapel/pull/22622. For now we just cast these strings to the internal `chpl_c_string`. 

A future PR will identify and correct the failure to get a `c_ptr(c_ptr(c_char)`. 

TESTING:

- [x] local testing of previously failing tests, `chapelProcs.chpl`