### PR TITLE
fix failing `c_string` tests when compiled with `--verify`

### DIFF
--- a/test/types/string/sungeun/c_string/defaultExpr.chpl
+++ b/test/types/string/sungeun/c_string/defaultExpr.chpl
@@ -88,7 +88,7 @@ const s: string;
 
 // s should be c_ptrConst(c_char) for these
 {
-  proc f(s: c_ptrConst(c_char) = "hi") {
+  proc f(s: c_ptrConst(c_char) = "hi".c_str()) {
     checkType(c_ptrConst(c_char), s.type);
   }
 
@@ -98,7 +98,7 @@ const s: string;
 }
 
 {
-  proc f(type gtype, g, s: c_ptrConst(c_char) = "hi") {
+  proc f(type gtype, g, s: c_ptrConst(c_char) = "hi".c_str()) {
     checkType(gtype, g.type);
     checkType(c_ptrConst(c_char), s.type);
   }
@@ -109,7 +109,7 @@ const s: string;
 }
 
 {
-  proc f(s: c_ptrConst(c_char) = "hi", type gtype, g = 3.14) {
+  proc f(s: c_ptrConst(c_char) = "hi".c_str(), type gtype, g = 3.14) {
     checkType(gtype, g.type);
     checkType(c_ptrConst(c_char), s.type);
   }

--- a/test/types/string/sungeun/c_string/genericClassesAndRecord.chpl
+++ b/test/types/string/sungeun/c_string/genericClassesAndRecord.chpl
@@ -14,7 +14,7 @@ use checkType;
   var c1 = ownC1.borrow();
   checkType(c1.x.type);
 
-  const blah2: c_ptrConst(c_char) = "blah";
+  const blah2: c_ptrConst(c_char) = "blah".c_str();
   var ownC2 = new owned C(blah2);
   var c2 = ownC2.borrow();
   checkType(c_ptrConst(c_char), c2.x.type);
@@ -52,7 +52,7 @@ use checkType;
   var r1 = new R(blah1);
   checkType(r1.x.type);
 
-  const blah2: c_ptrConst(c_char) = "blah";
+  const blah2: c_ptrConst(c_char) = "blah".c_str();
   var r2 = new R(blah2);
   checkType(c_ptrConst(c_char), r2.x.type);
 

--- a/test/types/string/sungeun/c_string/initExpr.chpl
+++ b/test/types/string/sungeun/c_string/initExpr.chpl
@@ -32,7 +32,7 @@ checkType(A1.eltType);
   class C {
     var blah = "blah";
     var blah1: string = "blah";
-    var blah2: c_ptrConst(c_char) = "blah";
+    var blah2: c_ptrConst(c_char) = "blah".c_str();
     proc checkMe() {
       checkType(blah.type);
       checkType(blah1.type);


### PR DESCRIPTION
This PR fixes some `c_string` tests that assign default values or initialize args of type `c_ptrConst(c_char)`. The expectation is that a future PR will address the root cause of the failure, but this just gets the test working again by adding `.c_str()` calls on the literals where needed.

I  have opened https://github.com/Cray/chapel-private/issues/5231 to resolve the workaround in these tests.

TESTING:

- [x] local testing of failed `c_string` tests with `--verify`

[test file change only - not reviewed]
