### PR TITLE
Inline definiton of `faux_c_string` to prevent symbol error

### DIFF
--- a/modules/minimal/internal/ChapelTaskTable.chpl
+++ b/modules/minimal/internal/ChapelTaskTable.chpl
@@ -22,13 +22,12 @@
 //
 
 module ChapelTaskTable {
-  extern type faux_c_string = chpl__c_void_ptr; // in place of deprecated c_string
   proc chpldev_taskTable_init() {
   }
 
   export proc chpldev_taskTable_add(taskID   : chpl_taskID_t,
                                     lineno   : uint(32),
-                                    filename : faux_c_string,
+                                    filename : chpl__c_void_ptr,
                                     tl_info  : uint(64))
   {
   }

--- a/modules/minimal/internal/MemTracking.chpl
+++ b/modules/minimal/internal/MemTracking.chpl
@@ -28,7 +28,6 @@ module MemTracking
   // config consts to the runtime code that actually implements the
   // memory tracking.
   //
-  extern type faux_c_string = chpl__c_void_ptr;
   export
   proc chpl_memTracking_returnConfigVals(ref ret_memTrack: bool,
                                          ref ret_memStats: bool,
@@ -36,8 +35,8 @@ module MemTracking
                                          ref ret_memLeaksTable: bool,
                                          ref ret_memMax: uint(64),       // **
                                          ref ret_memThreshold: uint(64), // **
-                                         ref ret_memLog: faux_c_string,
-                                         ref ret_memLeaksLog: faux_c_string) {
+                                         ref ret_memLog: chpl__c_void_ptr,
+                                         ref ret_memLeaksLog: chpl__c_void_ptr) {
 
     // ** In minimal-modules mode, I've hard-coded these c_size_t
     // arguments to uint(64) rather than using the c_size_t aliases

--- a/test/trivial/diten/printvisibleOptFalse.good
+++ b/test/trivial/diten/printvisibleOptFalse.good
@@ -7,14 +7,13 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/ChapelLocale.chpl:61: chpl_taskRunningCntReset
   modules/minimal/internal/ChapelTaskData.chpl:24: chpl_task_setCommDiagsTemporarilyDisabled
   modules/minimal/internal/ChapelTaskData.chpl:28: chpl_task_getCommDiagsTemporarilyDisabled
-  modules/minimal/internal/ChapelTaskTable.chpl:25: faux_c_string
-  modules/minimal/internal/ChapelTaskTable.chpl:26: chpldev_taskTable_init
-  modules/minimal/internal/ChapelTaskTable.chpl:29: chpldev_taskTable_add
-  modules/minimal/internal/ChapelTaskTable.chpl:36: chpldev_taskTable_remove
-  modules/minimal/internal/ChapelTaskTable.chpl:40: chpldev_taskTable_set_active
-  modules/minimal/internal/ChapelTaskTable.chpl:44: chpldev_taskTable_set_suspended
-  modules/minimal/internal/ChapelTaskTable.chpl:48: chpldev_taskTable_get_tl_info
-  modules/minimal/internal/ChapelTaskTable.chpl:52: chpldev_taskTable_print
+  modules/minimal/internal/ChapelTaskTable.chpl:25: chpldev_taskTable_init
+  modules/minimal/internal/ChapelTaskTable.chpl:28: chpldev_taskTable_add
+  modules/minimal/internal/ChapelTaskTable.chpl:35: chpldev_taskTable_remove
+  modules/minimal/internal/ChapelTaskTable.chpl:39: chpldev_taskTable_set_active
+  modules/minimal/internal/ChapelTaskTable.chpl:43: chpldev_taskTable_set_suspended
+  modules/minimal/internal/ChapelTaskTable.chpl:47: chpldev_taskTable_get_tl_info
+  modules/minimal/internal/ChapelTaskTable.chpl:51: chpldev_taskTable_print
   modules/minimal/internal/ChapelUtil.chpl:28: chpl_main_argument
   modules/minimal/internal/ChapelUtil.chpl:35: chpl_rt_preUserCodeHook
   modules/minimal/internal/ChapelUtil.chpl:36: chpl_rt_postUserCodeHook
@@ -34,5 +33,5 @@ printvisibleOptFalse.chpl:3: Printing symbols visible from here:
   modules/minimal/internal/IO.chpl:49: chpl_qio_get_chunk
   modules/minimal/internal/IO.chpl:52: chpl_qio_get_locales_for_region
   modules/minimal/internal/IO.chpl:55: chpl_qio_file_close
-  modules/minimal/internal/MemTracking.chpl:33: chpl_memTracking_returnConfigVals
+  modules/minimal/internal/MemTracking.chpl:32: chpl_memTracking_returnConfigVals
   printvisibleOptFalse.chpl:1: xyzSymbol


### PR DESCRIPTION
Inline the type expression for `faux_c_string` added by #22940 to prevent warning "Could not find extern def of type faux_c_string"

tested with paratest and asan

[Reviewed by @arezaii]