### PR TITLE
Fix bug in sub_test causing performance tests to fail

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -810,7 +810,7 @@ def main():
     # Start of sub_test proper
     #
     global utildir, chpl_base, chpl_home, machine, envCompopts, platform
-    global chplcommstr, chplnastr, chpllmstr, chpltasksstr
+    global chplcommstr, chplnastr, chpllmstr, chpltasksstr, perflabel
 
     if len(sys.argv)!=2:
         print('usage: sub_test COMPILER')


### PR DESCRIPTION
A recent PR that made `sub_test.py` more modular (#22878) had to work around our constant use of global variables. To this end, it ended up using `global` declarations. However, `perflabel` slipped through as a non-global declaration, was never set to `gpu`, and perftests would try reading `.keys` files instead of `.perfkeys` files. This PR fixes this issue.

Reviewed by @jhh67 -- thanks!