### PR TITLE
Fix bug in sub_test.py causing tests with CHPL_LAUNCHER_TIMEOUT to fail

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -811,6 +811,7 @@ def main():
     #
     global utildir, chpl_base, chpl_home, machine, envCompopts, platform
     global chplcommstr, chplnastr, chpllmstr, chpltasksstr, perflabel
+    global useLauncherTimeout
 
     if len(sys.argv)!=2:
         print('usage: sub_test COMPILER')


### PR DESCRIPTION
The function `LauncherTimeoutArgs` uses the global variable `useLauncherTimeout`, so it must be declared `global` in `main`.