### PR TITLE
Fix llvm.assertVectorized tests

### DIFF
--- a/test/llvm/assertVectorize/SKIPIF
+++ b/test/llvm/assertVectorize/SKIPIF
@@ -1,7 +1,8 @@
 # skip explicit fast
 COMPOPTS <= --fast
-# test only LLVM 15 or greater
+# throws off loop attributes
+COMPOPTS <= --baseline
+# test only LLVM 14 or greater
 CHPL_LLVM_VERSION==11
 CHPL_LLVM_VERSION==12
 CHPL_LLVM_VERSION==13
-CHPL_LLVM_VERSION==14

--- a/test/llvm/assertVectorize/assertVectorized-baseline.good
+++ b/test/llvm/assertVectorize/assertVectorized-baseline.good
@@ -1,8 +1,10 @@
-assertVectorized.chpl:2: In function 'doSum':
-assertVectorized.chpl:4: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:12: In function 'doSum2':
-assertVectorized.chpl:14: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:2: warning: loop was marked 'assertVectorized' but did not vectorize
-assertVectorized.chpl:12: warning: loop was marked 'assertVectorized' but did not vectorize
+assertVectorized.chpl:5: In function 'doSum':
+assertVectorized.chpl:7: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:8: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:16: In function 'doSum2':
+assertVectorized.chpl:18: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:19: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:5: warning: loop was marked 'assertVectorized' but did not vectorize
+assertVectorized.chpl:16: warning: loop was marked 'assertVectorized' but did not vectorize
 result 131328
 result 7734.6

--- a/test/llvm/assertVectorize/assertVectorized-debug.good
+++ b/test/llvm/assertVectorize/assertVectorized-debug.good
@@ -1,8 +1,10 @@
-assertVectorized.chpl:2: In function 'doSum':
-assertVectorized.chpl:4: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:12: In function 'doSum2':
-assertVectorized.chpl:14: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:2: warning: loop on line 5 was marked 'assertVectorized' but did not vectorize
-assertVectorized.chpl:12: warning: loop on line 15 was marked 'assertVectorized' but did not vectorize
+assertVectorized.chpl:5: In function 'doSum':
+assertVectorized.chpl:7: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:8: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:16: In function 'doSum2':
+assertVectorized.chpl:18: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:19: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:5: warning: loop on line 9 was marked 'assertVectorized' but did not vectorize
+assertVectorized.chpl:16: warning: loop on line 20 was marked 'assertVectorized' but did not vectorize
 result 131328
 result 7734.6

--- a/test/llvm/assertVectorize/assertVectorized.chpl
+++ b/test/llvm/assertVectorize/assertVectorized.chpl
@@ -1,7 +1,11 @@
 
+// to ensure that when `--fast` is thrown we actually do vectorize
+// use llvm.metadata to force vectorization
+
 proc doSum(A) {
   var sum: A.eltType = 0;
   @llvm.assertVectorized()
+  @llvm.metadata(("llvm.loop.vectorize.enable", true), ("llvm.loop.vectorize.width", 4), ("llvm.loop.interleave.count", 1))
   foreach i in A.domain {
     const ref a = A[i];
     sum += a;
@@ -12,6 +16,7 @@ proc doSum(A) {
 proc doSum2(A) {
   var sum: A.eltType = 0;
   @llvm.assertVectorized()
+  @llvm.metadata(("llvm.loop.vectorize.enable", true), ("llvm.loop.vectorize.width", 4), ("llvm.loop.interleave.count", 1))
   foreach a in A {
     sum += sqrt(a);
   }

--- a/test/llvm/assertVectorize/assertVectorized.compopts
+++ b/test/llvm/assertVectorize/assertVectorized.compopts
@@ -1,4 +1,4 @@
  # assertVectorized-baseline.good
---fast
+--fast --no-ieee-float
 -g # assertVectorized-debug.good
--g --fast
+-g --fast --no-ieee-float

--- a/test/llvm/assertVectorize/assertVectorized.good
+++ b/test/llvm/assertVectorize/assertVectorized.good
@@ -1,6 +1,8 @@
-assertVectorized.chpl:2: In function 'doSum':
-assertVectorized.chpl:4: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:12: In function 'doSum2':
-assertVectorized.chpl:14: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:5: In function 'doSum':
+assertVectorized.chpl:7: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:8: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:16: In function 'doSum2':
+assertVectorized.chpl:18: warning: Unknown attribute tool name 'llvm'
+assertVectorized.chpl:19: warning: Unknown attribute tool name 'llvm'
 result 131328
 result 7734.6

--- a/test/llvm/attributes/ir-check/SKIPIF
+++ b/test/llvm/attributes/ir-check/SKIPIF
@@ -1,0 +1,2 @@
+# throws off loop attributes
+COMPOPTS <= --baseline


### PR DESCRIPTION
Makes llvm.assertVectorized tests less fragile by forcing vectorization.

[not reviewed - trivial test change]