### PR TITLE
Remove deprecated `bigint.fits_*` methods

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -3294,61 +3294,6 @@ module BigInteger {
     return fits_into(t_.mpz, t);
   }
 
-  @deprecated(notes="`fits_ulong_p` is deprecated -  please use `bigint.fitsInto(c_ulong)` instead")
-  proc bigint.fits_ulong_p() : int {
-    var t_ = this.localize();
-    var ret: c_int;
-
-    ret = mpz_fits_ulong_p(t_.mpz);
-    return ret.safeCast(int);
-  }
-
-  @deprecated(notes="`fits_slong_p` is deprecated -  please use `bigint.fitsInto(c_long)` instead")
-  proc bigint.fits_slong_p() : int {
-    var t_ = this.localize();
-    var ret: c_int;
-
-    ret = mpz_fits_slong_p(t_.mpz);
-    return ret.safeCast(int);
-  }
-
-  @deprecated(notes="`fits_uint_p` is deprecated -  please use `bigint.fitsInto(c_uint)` instead")
-  proc bigint.fits_uint_p() : int {
-    var t_ = this.localize();
-    var ret: c_int;
-
-    ret = mpz_fits_uint_p(t_.mpz);
-
-    return ret.safeCast(int);
-  }
-
-  @deprecated(notes="`fits_sint_p` is deprecated -  please use `bigint.fitsInto(c_int)` instead")
-  proc bigint.fits_sint_p() : int {
-    var t_ = this.localize();
-    var ret: c_int;
-
-    ret = mpz_fits_sint_p(t_.mpz);
-    return ret.safeCast(int);
-  }
-
-  @deprecated(notes="`fits_ushort_p` is deprecated -  please use `bigint.fitsInto(c_ushort)` instead")
-  proc bigint.fits_ushort_p() : int {
-    var t_ = this.localize();
-    var ret: c_int;
-
-    ret = mpz_fits_ushort_p(t_.mpz);
-    return ret.safeCast(int);
-  }
-
-  @deprecated(notes="`fits_sshort_p` is deprecated -  please use `bigint.fitsInto(c_short)` instead")
-  proc bigint.fits_sshort_p() : int {
-    var t_ = this.localize();
-    var ret: c_int;
-
-    ret = mpz_fits_sshort_p(t_.mpz);
-    return ret.safeCast(int);
-  }
-
   /*
     .. warning::
 

--- a/test/deprecated/BigInteger/deprecateFitsMethods.chpl
+++ b/test/deprecated/BigInteger/deprecateFitsMethods.chpl
@@ -1,4 +1,0 @@
-use BigInteger;
-
-const a = new bigint(5);
-writeln(a.fits_ulong_p() & a.fits_slong_p() & a.fits_uint_p() & a.fits_sint_p() & a.fits_ushort_p() & a.fits_sshort_p());

--- a/test/deprecated/BigInteger/deprecateFitsMethods.good
+++ b/test/deprecated/BigInteger/deprecateFitsMethods.good
@@ -1,7 +1,0 @@
-deprecateFitsMethods.chpl:4: warning: `fits_ulong_p` is deprecated -  please use `bigint.fitsInto(c_ulong)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_slong_p` is deprecated -  please use `bigint.fitsInto(c_long)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_uint_p` is deprecated -  please use `bigint.fitsInto(c_uint)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_sint_p` is deprecated -  please use `bigint.fitsInto(c_int)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_ushort_p` is deprecated -  please use `bigint.fitsInto(c_ushort)` instead
-deprecateFitsMethods.chpl:4: warning: `fits_sshort_p` is deprecated -  please use `bigint.fitsInto(c_short)` instead
-1


### PR DESCRIPTION
Remove the `biting.fits_*` methods, deprecated in [this PR](https://github.com/chapel-lang/chapel/pull/20039). These symbols have been deprecated for multiple releases.

- [x] inspected docs
- [x] paratest