### PR TITLE
Fix a GPU performance test's .graph file

### DIFF
--- a/test/gpu/native/studies/gpuArrayOps/gpuArrayOps.graph
+++ b/test/gpu/native/studies/gpuArrayOps/gpuArrayOps.graph
@@ -1,13 +1,13 @@
 perfkeys: Cpu Array Init (s):, Gpu Array Init (s):
-files: arrayOps-d2h-from-h, arrayOps-d2h-from-h
+files: gpuArrayOps-d2h-from-h.dat, gpuArrayOps-d2h-from-h.dat
 graphkeys: Cpu Array Init, Gpu Array Init
 ylabel: Time (s)
 graphtitle: Array Initialization (100M ints)
 
 
 perfkeys: host to device copy (GB/s):, device to host copy (GB/s):, device to host copy (GB/s):
-files: gpuArrayOps-d2h-from-h, gpuArrayOps-d2h-from-h, gpuArrayOps-d2h-from-d
-graphkeys: Host-to-Device, Device-to-Host (host touch last), Device-to-Host (device touch last),
+files: gpuArrayOps-d2h-from-h.dat, gpuArrayOps-d2h-from-h.dat, gpuArrayOps-d2h-from-d.dat
+graphkeys: Host-to-Device, Device-to-Host (host touch last), Device-to-Host (device touch last)
 ylabel: Bandwidth (GiB/s)
 graphtitle: Data Copy Between Host and Device (100M ints)
 


### PR DESCRIPTION
Fixes a graph file for a test that is not rendering correctly:

https://chapel-lang.org/perf/gpu/?graphs=arrayinitialization100mints,datacopybetweenhostanddevice100mints

The issue was with the mismatch in dat file names. I confirmed this by seeing nulls vs actual values in the generated json file. I also confirmed that we have been collecting data for these tests since they were added. We were just not able to generate the plot correctly.