### PR TITLE
Fix nightly testing for new GPU 'savec' test

### DIFF
--- a/test/gpu/native/savec.good
+++ b/test/gpu/native/savec.good
@@ -1,5 +1,5 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 0 1 2 3 4 5 6 7 8 9
-savec_dir/chpl__gpu.s
 savec_dir/chpl__gpu.o
+savec_dir/chpl__gpu.s
 savec_dir/chpl__module.o

--- a/test/gpu/native/savec.prediff
+++ b/test/gpu/native/savec.prediff
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-find savec_dir -type f -name "*.o" -o -name "*.s" >> $2
+# Get list of all .o and .s files. Exclude 'savec.tmp_launcher.o' since we want this test
+# to pass regardless of whether a launcher is being used or not.
+find savec_dir -type f -name "*.o" -o -name "*.s" | grep -v "savec\.tmp_launcher\.o" | sort >> $2


### PR DESCRIPTION
This test locks down what `.s` and `.o` files get put in the generated directory when compiling with `chpl --savec`.

One of the files that might get added is `savec.tmp_launcher.o` but this is only added when chpl is configured to use a launcher (which we do for the nightly testing job but not for our paratest runs).

Anyway, I've updated the prediff to filter this out so it should now work regardless of whether a launcher is being used or not.