### PR TITLE
Add missing skipif lines for llvm.assertVectorized tests

### DIFF
--- a/test/llvm/assertVectorize/SKIPIF
+++ b/test/llvm/assertVectorize/SKIPIF
@@ -2,6 +2,8 @@
 COMPOPTS <= --fast
 # throws off loop attributes
 COMPOPTS <= --baseline
+CHPL_TARGET_COMPILER != llvm
+CHPL_COMM != none
 # test only LLVM 14 or greater
 CHPL_LLVM_VERSION==11
 CHPL_LLVM_VERSION==12

--- a/test/llvm/attributes/ir-check/SKIPIF
+++ b/test/llvm/attributes/ir-check/SKIPIF
@@ -1,2 +1,3 @@
 # throws off loop attributes
 COMPOPTS <= --baseline
+CHPL_TARGET_COMPILER != llvm


### PR DESCRIPTION
Add skipifs to failing tests
[not reviewed - trivial test change]