### PR TITLE
squash icc warning about "type X assinged to entity of type Y"

### DIFF
--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -1,15 +1,15 @@
 # Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 # Copyright 2004-2019 Cray Inc.
 # Other additional copyright holders may be indicated within.
-# 
+#
 # The entirety of this work is licensed under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -73,7 +73,7 @@ COMP_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
 COMP_CXXFLAGS_NONCHPL = -wr111,193,1418,1419,2215,2259,170 -Wno-error
 RUNTIME_CFLAGS = $(C_STD) $(CPPFLAGS) $(CFLAGS) -wr181,188
 RUNTIME_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
-GEN_CFLAGS = $(C_STD) -wr592 
+GEN_CFLAGS = $(C_STD) -wr592
 # NOTE: These are only supported for Linux
 GEN_STATIC_FLAG = -static-intel -static-libgcc -static
 GEN_DYNAMIC_FLAG = -Bdynamic
@@ -127,11 +127,12 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 #  167 : warns about incompatible parameter type (https://github.com/chapel-lang/chapel/issues/7983)
 #  174 : warns about expressions that have no effect
 #  177 : warns about unused variable declarations
+#  556 : warns about type X being assigned to entity of type Y
 
 WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599 -diag-warning 1292,3924
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
-SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177
+SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177,556
 
 #
 # Don't warn for signed pointer issues (ex. c_ptr(c_char) )


### PR DESCRIPTION
This PR should fix Intel compiler test failures that started happening after deprecating `c_string` in https://github.com/chapel-lang/chapel/pull/22622.

The PR squashes the warning emitted from the Intel compiler about "value of type X being assigned to entity of type Y" in our generated code as below:

```
error #556: a value of type "const char **" cannot be assigned to an entity of type "c_ptr_c_ptrConst_int8_t_chpl={c_ptrConst_int8_t_chpl={int8_t={__int8_t={signed char}} *} *}"
>   call_tmp_chpl37 = qio_spawn_allocate_ptrvec(((uint64_t)(nenv_chpl)));
```

This should be in alignment with changes to the `Makefile.gnu` in #22622 that suppressed warnings for discarding of `const` qualifiers.

TESTING:
- [x] change suppresses warning from icc
- [x] paratest `[Summary: #Successes = 16755 | #Failures = 0 | #Futures = 909]`
- [x] gasnet paratest `[Summary: #Successes = 16934 | #Failures = 0 | #Futures = 917]` 
- [x] cray-xc-module correctness tests passed w/intel compiler, comm=none, locale_model=flat `[Summary: #Successes = 30 | #Failures = 0 | #Futures = 0 | #Warnings = 0 ]
[Summary: #Passing Suppressions = 0 | #Passing Futures = 0 ]`

[reviewed by @ronawho - thanks!]
