### PR TITLE
Add a prediff to filter out line numbers in a test

### DIFF
--- a/test/gpu/native/noGpu/assertOnGpu-do-assert.good
+++ b/test/gpu/native/noGpu/assertOnGpu-do-assert.good
@@ -1,3 +1,3 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-assertOnGpu.chpl:9: error: Loop is marked with @assertOnGpu but is not eligible for execution on a GPU
-assertOnGpu.chpl:14: note: call has outer var access
+assertOnGpu.chpl:X: error: Loop is marked with @assertOnGpu but is not eligible for execution on a GPU
+assertOnGpu.chpl:X: note: call has outer var access

--- a/test/gpu/native/noGpu/assertOnGpu-dont-assert.good
+++ b/test/gpu/native/noGpu/assertOnGpu-dont-assert.good
@@ -1,23 +1,23 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 LOCALE0-GPU0 1 2 3 4 5 6 7 8 9 10
 LOCALE0-GPU1 1 2 3 4 5 6 7 8 9 10
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
-assertOnGpu.chpl:10: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu
+assertOnGpu.chpl:X: warning: assertOnGpu() is ignored with CHPL_GPU=cpu

--- a/test/gpu/native/noGpu/assertOnGpu.prediff
+++ b/test/gpu/native/noGpu/assertOnGpu.prediff
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sed -i -e 's/chpl:[[:digit:]]\+:/chpl:X:/' $2
+


### PR DESCRIPTION
An `assertOnGpu` test failed recently with line number changes. This PR adds a prediff for that test to filter out line numbers.

The test passes with `CHPL_GPU=cpu` with this PR.