### PR TITLE
Remove test for returning sync by value

### DIFF
--- a/test/parallel/sync/diten/returnSync.chpl
+++ b/test/parallel/sync/diten/returnSync.chpl
@@ -1,9 +1,0 @@
-proc retSync(x: ?t): sync t {
-  var xx: sync t = x;
-  return xx;
-}
-
-var x = retSync(3).readFE();
-var y: sync int = retSync(4);
-
-writeln(x.type:string, ", ", y.type:string);

--- a/test/parallel/sync/diten/returnSync.good
+++ b/test/parallel/sync/diten/returnSync.good
@@ -1,1 +1,0 @@
-int(64), sync int(64)

--- a/test/parallel/sync/diten/returnSync.skipif
+++ b/test/parallel/sync/diten/returnSync.skipif
@@ -1,4 +1,0 @@
-# The most interesting error message occurs with CHPL_TASKS=fifo.
-# Please run with valgrind, and with qthreads when this error is resolved
-CHPL_TASKS != fifo
-CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Removes `test/parallel/sync/diten/returnSync.chpl`, as the feature is deprecated and will be removed.

tested locally

[not reviewed - trivial test change]