### PR TITLE
Remove extraneous debuggerBreakHere in Foreach::build

### DIFF
--- a/frontend/lib/uast/Foreach.cpp
+++ b/frontend/lib/uast/Foreach.cpp
@@ -43,7 +43,6 @@ owned<Foreach> Foreach::build(Builder* builder,
   int8_t withClauseChildNum = NO_CHILD;
   int attributeGroupChildNum = NO_CHILD;
 
-  debuggerBreakHere();
   if (attributeGroup.get() != nullptr) {
     attributeGroupChildNum = lst.size();
     lst.push_back(std::move(attributeGroup));


### PR DESCRIPTION
Remove an extraneous call to `debuggerBreakHere()` in `Foreach::build`

This appears to have been left in accidentally from https://github.com/chapel-lang/chapel/pull/22932 and causes a lot of unnecessary debugger breaks in parsing.

[trivial, not reviewed]