### PR TITLE
Improve `Math` module doc

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -504,19 +504,19 @@ module Math {
   }
 
   /* Returns the value of the Napierian `e` raised to the power of the
-     argument. */
+     argument `x`. */
   inline proc exp(x : real(32)): real(32) {
     return chpl_exp(x);
   }
 
   /* Returns the value of the Napierian `e` raised to the power of the
-     argument. */
+     argument `x`. */
   inline proc exp(x: complex(64)): complex(64) {
     return chpl_exp(x);
   }
 
   /* Returns the value of the Napierian `e` raised to the power of the
-     argument. */
+     argument `x`. */
   inline proc exp(x: complex(128)): complex(128) {
     return chpl_exp(x);
   }
@@ -543,13 +543,14 @@ module Math {
     return chpl_expm1(x);
   }
 
-  /* Multiply by an integer power of 2.
-     Returns x * 2**n.
-     */
+  /* Returns the value of the argument `x` multiplied by the number 2 raised to
+    the argument `n` power. */
   inline proc ldexp(x:real(64), n:int(32)):real(64) {
     return chpl_ldexp(x, n);
   }
 
+  /* Returns the value of the argument `x` multiplied by the number 2 raised to
+    the argument `n` power. */
   inline proc ldexp(x:real(32), n:int(32)):real(32) {
     return chpl_ldexp(x, n);
   }
@@ -1031,37 +1032,37 @@ module Math {
   }
 
   /* Returns the Bessel function of the second kind of order `0` of `x`, where
-     `x` must be greater than 0 */
+     `x` must be greater than 0. */
   inline proc y0(x: real(32)): real(32) {
     return chpl_y0(x);
   }
 
   /* Returns the Bessel function of the second kind of order `0` of `x`,
-     where `x` must be greater than 0 */
+     where `x` must be greater than 0. */
   inline proc y0(x: real(64)): real(64) {
     return chpl_y0(x);
   }
 
   /* Returns the Bessel function of the second kind of order `1` of `x`,
-     where `x` must be greater than 0 */
+     where `x` must be greater than 0. */
   inline proc y1(x: real(32)): real(32) {
     return chpl_y1(x);
   }
 
   /* Returns the Bessel function of the second kind of order `1` of `x`,
-     where `x` must be greater than 0 */
+     where `x` must be greater than 0. */
   inline proc y1(x: real(64)): real(64) {
     return chpl_y1(x);
   }
 
   /* Returns the Bessel function of the second kind of order `n` of `x`,
-     where `x` must be greater than 0 */
+     where `x` must be greater than 0. */
   inline proc yn(n: int, x: real(32)): real(32) {
     return chpl_yn(n, x);
   }
 
   /* Returns the Bessel function of the second kind of order `n` of `x`,
-     where `x` must be greater than 0 */
+     where `x` must be greater than 0. */
   inline proc yn(n: int, x: real(64)): real(64) {
     return chpl_yn(n, x);
   }

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -473,24 +473,28 @@ module Math {
     return chpl_divfloorpos(x, y);
   }
 
-  /* Returns the error function of the argument `x`. */
+  /* Returns the error function of the argument `x`. This is equivalent to the
+     integral of :proc:`twiceReciprSqrtPi`\ * :proc:`exp`\(`-t**2`)dt from 0
+     to `x`. */
   inline proc erf(x: real(64)): real(64) {
     return chpl_erf(x);
   }
 
-  /* Returns the error function of the argument `x`. */
+  /* Returns the error function of the argument `x`. This is equivalent to the
+     integral of :proc:`twiceReciprSqrtPi`\ * :proc:`exp`\(`-t**2`)dt from 0
+     to `x`. */
   inline proc erf(x : real(32)): real(32) {
     return chpl_erf(x);
   }
 
-  /* Returns the complementary error function of the argument.
+  /* Returns the complementary error function of the argument `x`.
      This is equivalent to 1.0 - :proc:`erf`\(`x`).
   */
   inline proc erfc(x: real(64)): real(64) {
     return chpl_erfc(x);
   }
 
-  /* Returns the complementary error function of the argument.
+  /* Returns the complementary error function of the argument `x`.
      This is equivalent to 1.0 - :proc:`erf`\(`x`).
   */
   inline proc erfc(x : real(32)): real(32) {

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -346,7 +346,7 @@ module Math {
     return chpl_atan2(y, x);
   }
 
-  /* Returns the arc tangent of the two arguments.
+  /* Returns the arc tangent of the ratio of the two arguments.
 
      This is equivalent to
      the arc tangent of `y` / `x` except that the signs of `y`
@@ -546,13 +546,13 @@ module Math {
   }
 
   /* Returns the value of the argument `x` multiplied by 2 raised to the
-     argument `n` power, i.e. x * 2**n. */
+     argument `n` power, i.e., x * 2**n. */
   inline proc ldexp(x:real(64), n:int(32)):real(64) {
     return chpl_ldexp(x, n);
   }
 
   /* Returns the value of the argument `x` multiplied by 2 raised to the
-     argument `n` power, i.e. x * 2**n. */
+     argument `n` power, i.e., x * 2**n. */
   inline proc ldexp(x:real(32), n:int(32)):real(32) {
     return chpl_ldexp(x, n);
   }
@@ -997,7 +997,7 @@ module Math {
     return chpl_tgamma(x);
   }
 
-  /* Returns the greatest common divisor of the integer argument `x` and
+  /* Returns the greatest common divisor of the integer arguments `x` and
      `y`. */
   proc gcd(in x: int,in y: int): int {
     return chpl_gcd(x, y);

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -473,16 +473,14 @@ module Math {
     return chpl_divfloorpos(x, y);
   }
 
-  /* Returns the error function of the argument `x`. This is equivalent to the
-     integral of :proc:`twiceReciprSqrtPi`\ * :proc:`exp`\(`-t**2`)dt from 0
-     to `x`. */
+  /* Returns the error function of the argument `x`. This is equivalent to
+     2/sqrt(pi) * the integral of exp(-t**2)dt from 0 to `x`. */
   inline proc erf(x: real(64)): real(64) {
     return chpl_erf(x);
   }
 
-  /* Returns the error function of the argument `x`. This is equivalent to the
-     integral of :proc:`twiceReciprSqrtPi`\ * :proc:`exp`\(`-t**2`)dt from 0
-     to `x`. */
+  /* Returns the error function of the argument `x`. This is equivalent to
+     2/sqrt(pi) * the integral of exp(-t**2)dt from 0 to `x`. */
   inline proc erf(x : real(32)): real(32) {
     return chpl_erf(x);
   }
@@ -547,14 +545,14 @@ module Math {
     return chpl_expm1(x);
   }
 
-  /* Returns the value of the argument `x` multiplied by the number 2 raised to
-    the argument `n` power. */
+  /* Returns the value of the argument `x` multiplied by 2 raised to the
+     argument `n` power, i.e. x * 2**n. */
   inline proc ldexp(x:real(64), n:int(32)):real(64) {
     return chpl_ldexp(x, n);
   }
 
-  /* Returns the value of the argument `x` multiplied by the number 2 raised to
-    the argument `n` power. */
+  /* Returns the value of the argument `x` multiplied by 2 raised to the
+     argument `n` power, i.e. x * 2**n. */
   inline proc ldexp(x:real(32), n:int(32)):real(32) {
     return chpl_ldexp(x, n);
   }

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -474,13 +474,13 @@ module Math {
   }
 
   /* Returns the error function of the argument `x`. This is equivalent to
-     2/sqrt(pi) * the integral of exp(-t**2)dt from 0 to `x`. */
+     ``2/sqrt(pi)`` * the integral of ``exp(-t**2)dt`` from 0 to `x`. */
   inline proc erf(x: real(64)): real(64) {
     return chpl_erf(x);
   }
 
   /* Returns the error function of the argument `x`. This is equivalent to
-     2/sqrt(pi) * the integral of exp(-t**2)dt from 0 to `x`. */
+     ``2/sqrt(pi)`` * the integral of ``exp(-t**2)dt`` from 0 to `x`. */
   inline proc erf(x : real(32)): real(32) {
     return chpl_erf(x);
   }
@@ -546,13 +546,13 @@ module Math {
   }
 
   /* Returns the value of the argument `x` multiplied by 2 raised to the
-     argument `n` power, i.e., x * 2**n. */
+     argument `n` power, i.e., ``x * 2**n``. */
   inline proc ldexp(x:real(64), n:int(32)):real(64) {
     return chpl_ldexp(x, n);
   }
 
   /* Returns the value of the argument `x` multiplied by 2 raised to the
-     argument `n` power, i.e., x * 2**n. */
+     argument `n` power, i.e., ``x * 2**n``. */
   inline proc ldexp(x:real(32), n:int(32)):real(32) {
     return chpl_ldexp(x, n);
   }


### PR DESCRIPTION
This PR proposes some minor improvements in the `Math` module documentation:

- add an extended doc for `erf`, as suggested by #18997;
- modify the doc of `inline proc ldexp(x:real(64), n:int(32)):real(64)` to better fit the standard (i.e. "Returns ...");
- add the missing doc of `inline proc ldexp(x:real(32), n:int(32)):real(32)`;
- add some missing argument names;
- add some missing end points;
- fix some typos.

Issue #18997 also asks for an extended doc for `erfc`, but in my opinion it is meaningful enough given the new `erf` doc.

Resolves #18997