### PR TITLE
Allow raw_c_void_ptr/c_ptr(void) mismatch in formal/actual checks

### DIFF
--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -955,6 +955,17 @@ checkFormalActualTypesMatch()
             continue;
         }
 
+        // Allow raw_c_void_ptr/c_ptr(void) mismatch. Although implicit
+        // conversion between the two is allowed, the compiler currently inserts
+        // function such as chpl_here_free using raw_c_void_ptr after
+        // resolution.
+        // TODO: Remove this once we are using c_ptr(void) everywhere in the
+        // compiler and no longer have raw_c_void_ptr (dtCVoidPtr) sticking
+        // around.
+        if (isCVoidPtr(actual->typeInfo()) && isCVoidPtr(formal->type)) {
+          continue;
+        }
+
         if (formal->getValType() != actual->getValType()) {
           INT_FATAL(call,
                     "actual formal type mismatch for %s: %s != %s",


### PR DESCRIPTION
Add an exception to formal/actual type match checking to allow a mismatch between a `raw_c_void_ptr` and `c_ptr(void)`.

This exception is needed until we are able to replace `raw_c_void_ptr` with `c_ptr(void)` in all compiler-inserted code, likely when `c_ptr` becomes a primitive or compiler well-known type. A TODO comment on the code implementing the exception notes it can be removed once this is done. However, this isn't feasible to do in the production compiler at the moment due to 2.0 time pressure, as well as potentially being obviated soon by the Dyno resolver being brought into production.

The case specifically worked around by this is `chpl_here_free` calls inserted by `lowerIterators`, which are passed a `raw_c_void_ptr` argument. (There are likely more instances with the same problem which would be hit after this.) Since `lowerIterators` is post-resolution, the compiler would need to have `c_ptr(void)`'s `AggregateType` stored somewhere already to use it here instead of the raw version. Additionally, although we allow implicit conversion from `raw_c_void_ptr` to `c_ptr(void)`, this code being inserted post-resolution means it happens after the compiler accounts for implicit conversion.

This PR should resolve the errors encountered in nightly testing with `--verify`, which were introduced in https://github.com/chapel-lang/chapel/pull/22871.

Follow up to https://github.com/chapel-lang/chapel/pull/22871.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] paratest with `--verify`