### PR TITLE
Print `CHPL_GPU` by default and warn users when using `fifo` tasks with cpu-as-device

### DIFF
--- a/test/compflags/albrecht/chplenv/generateChplEnvFiles
+++ b/test/compflags/albrecht/chplenv/generateChplEnvFiles
@@ -7,7 +7,7 @@
 generateGood() {
     # Generate Good file from printchplenv variables
 
-    printchplenv=$(../../../../util/printchplenv --simple --no-tidy --anonymize | grep -v CHPL_TARGET_HAS_PRGENV | grep -v CHPL_AUX_FILESYS | grep -v SUBDIR)
+    printchplenv=$(../../../../util/printchplenv --simple --no-tidy --anonymize | grep -v CHPL_TARGET_HAS_PRGENV | grep -v CHPL_AUX_FILESYS | grep -v SUBDIR | grep -v CHPL_GPU=)
 
     good=""
     for var in ${printchplenv}; do

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -6,6 +6,7 @@ import chpl_locale_model
 import chpl_llvm
 import chpl_compiler
 import re
+import chpl_tasks
 from utils import error, warning, memoize, run_command, which, is_ver_in_range
 
 def _validate_cuda_version():
@@ -274,7 +275,7 @@ def _validate_rocm_version_impl():
     return True
 
 @memoize
-def validate(chplLocaleModel, chplComm):
+def validate(chplLocaleModel):
     if chplLocaleModel != "gpu":
         return True
 
@@ -285,6 +286,8 @@ def validate(chplLocaleModel, chplComm):
     gpu.validate_sdk_version()
 
     if get() == 'cpu':
+        if chpl_tasks.get() == 'fifo':
+            error("The 'fifo' tasking model is not supported with CPU-as-device mode")
         return True
 
     if chpl_compiler.get('target') != 'llvm':

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -92,7 +92,7 @@ CHPL_ENVS = [
     ChapelEnv('CHPL_TARGET_CPU_FLAG', INTERNAL),
     ChapelEnv('CHPL_TARGET_BACKEND_CPU', INTERNAL),
     ChapelEnv('CHPL_LOCALE_MODEL', RUNTIME | LAUNCHER | DEFAULT, 'loc'),
-    ChapelEnv('  CHPL_GPU', RUNTIME, 'gpu'),
+    ChapelEnv('  CHPL_GPU', RUNTIME | DEFAULT, 'gpu'),
     ChapelEnv('  CHPL_GPU_ARCH', INTERNAL),
     ChapelEnv('  CHPL_GPU_MEM_STRATEGY', RUNTIME , 'gpu_mem' ),
     ChapelEnv('  CHPL_CUDA_PATH', INTERNAL),
@@ -234,7 +234,7 @@ def compute_all_values():
     chpl_arch.validate('target')
     chpl_llvm.validate_llvm_config()
     chpl_compiler.validate_compiler_settings()
-    chpl_gpu.validate(ENV_VALS['CHPL_LOCALE_MODEL'], ENV_VALS['CHPL_COMM'])
+    chpl_gpu.validate(ENV_VALS['CHPL_LOCALE_MODEL'])
 
 
 """Compute '--internal' env var values and populate global dict, ENV_VALS"""


### PR DESCRIPTION
Makes the following changes:
1) `printchplenv` now prints `CHPL_GPU` by default (i.e. even without the `--all` flag)
   (Resolves #22894)
2) Adds validation to make `printchplenv` print a simple warning when
   using CPU-as -device mode in tandem with `CHPL_TASKS=fifo` since that
leads to issues with launching GPU kerneks (Resolves #22598)

Also removes an unused `chplComm` argument being passed to `validate()` in `chpl_gpu.py`