### PR TITLE
Deprecate owned.borrow() type method

### DIFF
--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -291,6 +291,7 @@ module OwnedObject {
       }
     }
 
+    @deprecated("calling `.borrow()` on a type is deprecated - please use a cast to `borrowed` instead")
     proc type borrow() type {
       if _to_nilable(chpl_t) == chpl_t {
         return chpl_t;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -291,7 +291,7 @@ module OwnedObject {
       }
     }
 
-    @deprecated("calling `.borrow()` on a type is deprecated - please use a cast to `borrowed` instead")
+    @deprecated("calling `.borrow()` on an `owned` type is deprecated - please use a cast to `borrowed` instead")
     proc type borrow() type {
       if _to_nilable(chpl_t) == chpl_t {
         return chpl_t;

--- a/test/deprecated/deprecateOwnedBorrow.chpl
+++ b/test/deprecated/deprecateOwnedBorrow.chpl
@@ -1,0 +1,8 @@
+
+class MyClass {
+
+}
+type t = owned MyClass;
+type t2 = t.borrow();
+type t3 = t:borrowed;
+writeln(t2 == t3);

--- a/test/deprecated/deprecateOwnedBorrow.good
+++ b/test/deprecated/deprecateOwnedBorrow.good
@@ -1,2 +1,2 @@
-deprecateOwnedBorrow.chpl:6: warning: calling `.borrow()` on a type is deprecated - please use a cast to `borrowed` instead
+deprecateOwnedBorrow.chpl:6: warning: calling `.borrow()` on an `owned` type is deprecated - please use a cast to `borrowed` instead
 true

--- a/test/deprecated/deprecateOwnedBorrow.good
+++ b/test/deprecated/deprecateOwnedBorrow.good
@@ -1,0 +1,2 @@
+deprecateOwnedBorrow.chpl:6: warning: calling `.borrow()` on a type is deprecated - please use a cast to `borrowed` instead
+true


### PR DESCRIPTION
Based on #22273, we are deprecating the `owned.borrow()` type method.

Tested with paratest + futures. Also built docs to check deprecation looks right

[reviewed by @riftEmber]

closes #22273