### PR TITLE
Add perf annotations for 2023-08-18

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -543,6 +543,16 @@ all:
   03/16/23:
     - text: Update GPU performance tests to not count launches in perf mode (#21891)
       config: gpu
+  05/26/23:
+    - text: Upgrade to llvm 15
+      config: chapcs
+  06/01/23:
+    - text: Remove calls to codegenInvariantStart (#22439)
+      config: chapcs
+  08/09/23:
+    - text: Deprecate c_string in user facing modules (#22622)
+      config: chapcs
+
 # End all
 
 allocate:
@@ -2346,7 +2356,17 @@ arkouda: &arkouda-base
     - Upgrade Arkouda release testing from 1.29 to 1.30 (#21969)
   03/30/23:
     - Bump bigint groupby benchmark problem size (Bears-R-Us/arkouda#2326)
-  07/05/23:
+  04/07/23:
+    - Fix BigInteger issue with a result parameter used as an argument (#22039)
+  04/08/23:
+    - Fix regression in BigInteger with ref arguments (#22075)
+  05/25/23:
+    - Revert SegArray to Client Side (Bears-R-Us/arkouda#2439)
+  07/22/23:
+    - new format specifier (#22766)
+  08/05/23:
+    - Resolve Arkouda deprecation warnings for 1.32 to date (Bears-R-Us/arkouda#2632)
+  07/06/23:
     - Upgrade Arkouda release testing from 1.30 to 1.31 (#22669)
 
 


### PR DESCRIPTION
Add annotations for recent changes and catch up on older ones:
 - llvm 15 upgrade
 - minor list regression from removing `codegenInvariantStart`
 - surprising list and rev-comp improvements from `c_string` deprecation
 - Arkouda:
   - Some bigint regressions from not reusing result as an arg
   - Regression to non-default dataframe display from segaray to client
   - Dataframe display regression from %j5 deprecation and later fix