### PR TITLE
Improve OFI landing zone sizing

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3001,7 +3001,7 @@ void init_ofiForAms(void) {
   // renewing.  We actually then split this in half and create 2 half-sized
   // buffers (see below), so reflect that here also.
   //
-  const char *ev = "COMM_OFI_LZ_SIZE";
+  const char *ev = "COMM_OFI_AM_LZ_SIZE";
   size_t amLZSize = (size_t) 64 << 20;
   const char *sizeStr = chpl_env_rt_get(ev, NULL);
   if (sizeStr != NULL) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3002,9 +3002,11 @@ void init_ofiForAms(void) {
   // buffers (see below), so reflect that here also.
   //
   const char *ev = "COMM_OFI_LZ_SIZE";
-  const size_t defaultSize = (size_t) 64 << 20;
-  const char *sizeStr = chpl_env_rt_get(ev, "64M");
-  size_t amLZSize = chpl_env_str_to_size(ev, sizeStr, defaultSize);
+  size_t amLZSize = (size_t) 64 << 20;
+  const char *sizeStr = chpl_env_rt_get(ev, NULL);
+  if (sizeStr != NULL) {
+    amLZSize = chpl_env_str_to_size(ev, sizeStr, amLZSize);
+  }
 
   char buf[10];
   DBG_PRINTF(DBG_AM_BUF, "AM LZ size %s (%#zx)",

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3001,13 +3001,8 @@ void init_ofiForAms(void) {
   // renewing.  We actually then split this in half and create 2 half-sized
   // buffers (see below), so reflect that here also.
   //
-  const char *ev = "COMM_OFI_AM_LZ_SIZE";
-  size_t amLZSize = (size_t) 64 << 20;
-  const char *sizeStr = chpl_env_rt_get(ev, NULL);
-  if (sizeStr != NULL) {
-    amLZSize = chpl_env_str_to_size(ev, sizeStr, amLZSize);
-  }
-
+  size_t amLZSize = chpl_env_rt_get_size("COMM_OFI_AM_LZ_SIZE",
+                                               (size_t) 64 << 20);
   char buf[10];
   DBG_PRINTF(DBG_AM_BUF, "AM LZ size %s (%#zx)",
              chpl_snprintf_KMG_z(buf, sizeof(buf), amLZSize), amLZSize);


### PR DESCRIPTION
OFI uses a "landing zone" into which incoming active messages are received. The landing zone is split into two buffers used in a double-buffered fashion -- messages are placed in one buffer until it is full as which point libfabric switches to the other buffer. Once the active message handler has finished processing the messages in a buffer it re-registers the now-empty buffer with libfabric. Previously, the landing zone was 40MB. This size was determined empirically on somewhat older hardware. Increase the default size to 64MB and make it configurable via the CHPL_RT_COMM_OFI_AM_LZ_SIZE environment variable.

Closes https://github.com/Cray/chapel-private/issues/5245.