### PR TITLE
Deprecate fileReader.skipField

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -399,7 +399,7 @@ module ChapelIO {
         // Skip an unknown JSON field.
 
 
-        try reader.skipField();
+        try reader._skipField();
         needsComma = true;
       }
     }
@@ -515,7 +515,7 @@ module ChapelIO {
           // Try skipping fields if we're JSON and allowed to do so.
           if !hasReadFieldName then
             if isSkipUnknown && isJson {
-              try reader.skipField();
+              try reader._skipField();
               needsComma = true;
             } else {
               throw new owned

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -11806,7 +11806,13 @@ proc readf(fmt:string):bool throws {
    :throws UnexpectedEofError: Thrown if EOF encountered skipping field.
    :throws SystemError: Thrown if the field could not be skipped.
  */
+@deprecated("skipField is deprecated, please use JsonDeserializer instead.")
 proc fileReader.skipField() throws {
+  this._skipField();
+}
+
+@chpldoc.nodoc
+proc fileReader._skipField() throws {
   var err:errorCode = 0;
   on this._home {
     try this.lock(); defer { this.unlock(); }

--- a/test/deprecated/IO/skipField.chpl
+++ b/test/deprecated/IO/skipField.chpl
@@ -1,0 +1,44 @@
+
+use IO;
+
+proc main() {
+  var obj = """
+  {
+    "x": 5,
+    "y": 42.0,
+    "skipMe":false,
+    "z": "hello"
+  }
+  """;
+
+  var f = openMemFile();
+  f.writer().write(obj);
+
+  var r = f.reader();
+  var st = r._styleInternal();
+  var orig = st; defer { r._set_styleInternal(orig); }
+  st.realfmt = 2;
+  st.string_format = iostringformatInternal.json:uint(8);
+  st.aggregate_style = QIO_AGGREGATE_FORMAT_JSON:uint(8);
+  st.array_style = QIO_ARRAY_FORMAT_JSON:uint(8);
+  st.tuple_style = QIO_TUPLE_FORMAT_JSON:uint(8);
+  r._set_styleInternal(st);
+
+  r.readLiteral("{");
+
+  r.readLiteral("\"x\":");
+  assert(r.read(int) == 5);
+  r.readLiteral(",");
+
+  r.readLiteral("\"y\":");
+  assert(r.read(real) == 42.0);
+  r.readLiteral(",");
+
+  r.skipField();
+  r.readLiteral(",");
+
+  r.readLiteral("\"z\":");
+  assert(r.read(string) == "hello");
+
+  r.readLiteral("}");
+}

--- a/test/deprecated/IO/skipField.good
+++ b/test/deprecated/IO/skipField.good
@@ -1,0 +1,2 @@
+skipField.chpl:4: In function 'main':
+skipField.chpl:37: warning: skipField is deprecated, please use JsonDeserializer instead.


### PR DESCRIPTION
Deprecates the ``skipField`` method on ``fileReader`` and adds a deprecation test to make sure the feature continues working until it is removed.

Testing:
- [x] local paratest