### PR TITLE
Add return values for GPU Atomics

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -336,10 +336,10 @@ module GPU
     checkValidGpuAtomicOp(opName, rtName, T);
 
     pragma "codegen for GPU"
-    extern rtName proc chpl_atomicBinOp(x, val);
+    extern rtName proc chpl_atomicBinOp(x, val) : T;
 
     __primitive("chpl_assert_on_gpu", false);
-    chpl_atomicBinOp(c_ptrTo(x), val);
+    return chpl_atomicBinOp(c_ptrTo(x), val);
   }
 
   private inline proc gpuAtomicTernOp(param opName : string, ref x : ?T, cmp : T, val : T) {
@@ -347,39 +347,39 @@ module GPU
     checkValidGpuAtomicOp(opName, rtName, T);
 
     pragma "codegen for GPU"
-    extern rtName proc chpl_atomicTernOp(x, cmp, val);
+    extern rtName proc chpl_atomicTernOp(x, cmp, val) : T;
 
     __primitive("chpl_assert_on_gpu", false);
-    chpl_atomicTernOp(c_ptrTo(x), cmp, val);
+    return chpl_atomicTernOp(c_ptrTo(x), cmp, val);
   }
 
   /* When run on a GPU, atomically add 'val' to 'x' (result is stored in 'x'). */
-  inline proc gpuAtomicAdd(  ref x : ?T, val : T) : void { gpuAtomicBinOp("add", x, val); }
+  inline proc gpuAtomicAdd(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("add", x, val); }
   /* When run on a GPU, atomically subtract 'val' from 'x' (result is stored in 'x'). */
-  inline proc gpuAtomicSub(  ref x : ?T, val : T) : void { gpuAtomicBinOp("sub", x, val); }
+  inline proc gpuAtomicSub(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("sub", x, val); }
   @chpldoc.nodoc
-  inline proc gpuAtomicExch( ref x : ?T, val : T) : void { gpuAtomicBinOp("exch", x, val); }
+  inline proc gpuAtomicExch( ref x : ?T, val : T) : T { return gpuAtomicBinOp("exch", x, val); }
   /* When run on a GPU, atomically compare 'x' and 'val' and store the minimum in 'x'. */
-  inline proc gpuAtomicMin(  ref x : ?T, val : T) : void { gpuAtomicBinOp("min", x, val); }
+  inline proc gpuAtomicMin(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("min", x, val); }
   /* When run on a GPU, atomically compare 'x' and 'val' and store the maximum in 'x'. */
-  inline proc gpuAtomicMax(  ref x : ?T, val : T) : void { gpuAtomicBinOp("max", x, val); }
+  inline proc gpuAtomicMax(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("max", x, val); }
   /* When run on a GPU, atomically increments x if the original value of x is
      greater-than or equal to val, if so the result is stored in 'x'. */
-  inline proc gpuAtomicInc(  ref x : ?T, val : T) : void { gpuAtomicBinOp("inc", x, val); }
+  inline proc gpuAtomicInc(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("inc", x, val); }
   /* When run on a GPU, atomically determine if 'x' equals 0 or is greater than 'val'.
      If so store 'val' in 'x' otherwise decrement 'x' by 1. */
-  inline proc gpuAtomicDec(  ref x : ?T, val : T) : void { gpuAtomicBinOp("dec", x, val); }
+  inline proc gpuAtomicDec(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("dec", x, val); }
   /* When run on a GPU, atomically perform a bitwise 'and' operation on 'x' and 'val' and store
      the result in 'x'. */
-  inline proc gpuAtomicAnd(  ref x : ?T, val : T) : void { gpuAtomicBinOp("and", x, val); }
+  inline proc gpuAtomicAnd(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("and", x, val); }
   /* When run on a GPU, atomically perform a bitwise 'or' operation on 'x' and 'val' and store
      the result in 'x'.  */
-  inline proc gpuAtomicOr(   ref x : ?T, val : T) : void { gpuAtomicBinOp("or", x, val); }
+  inline proc gpuAtomicOr(   ref x : ?T, val : T) : T { return gpuAtomicBinOp("or", x, val); }
   /* When run on a GPU, atomically perform a bitwise 'xor' operation on 'x' and 'val' and store
      the result in 'x'. */
-  inline proc gpuAtomicXor(  ref x : ?T, val : T) : void { gpuAtomicBinOp("xor", x, val); }
+  inline proc gpuAtomicXor(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("xor", x, val); }
 
   /* When run on a GPU, atomically compare the value in 'x' and 'cmp', if they
      are equal store 'val' in 'x'.  */
-  inline proc gpuAtomicCAS(  ref x : ?T, cmp : T, val : T) : void { gpuAtomicTernOp("CAS", x, cmp, val); }
+  inline proc gpuAtomicCAS(  ref x : ?T, cmp : T, val : T) : T { return gpuAtomicTernOp("CAS", x, cmp, val); }
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -353,33 +353,40 @@ module GPU
     return chpl_atomicTernOp(c_ptrTo(x), cmp, val);
   }
 
-  /* When run on a GPU, atomically add 'val' to 'x' (result is stored in 'x'). */
+  /* When run on a GPU, atomically add 'val' to 'x' and store the result in 'x'.
+     The operation returns the old value of x. */
   inline proc gpuAtomicAdd(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("add", x, val); }
-  /* When run on a GPU, atomically subtract 'val' from 'x' (result is stored in 'x'). */
+  /* When run on a GPU, atomically subtract 'val' from 'x' and store the result in 'x'.
+     The operation returns the old value of x. */
   inline proc gpuAtomicSub(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("sub", x, val); }
-  @chpldoc.nodoc
+  /* When run on a GPU, atomically exchange the value stored in 'x' with 'val'.
+     The operation returns the old value of x. */
   inline proc gpuAtomicExch( ref x : ?T, val : T) : T { return gpuAtomicBinOp("exch", x, val); }
-  /* When run on a GPU, atomically compare 'x' and 'val' and store the minimum in 'x'. */
+  /* When run on a GPU, atomically compare 'x' and 'val' and store the minimum in 'x'.
+     The operation returns the old value of x. */
   inline proc gpuAtomicMin(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("min", x, val); }
-  /* When run on a GPU, atomically compare 'x' and 'val' and store the maximum in 'x'. */
+  /* When run on a GPU, atomically compare 'x' and 'val' and store the maximum in 'x'.
+     The operation returns the old value of x. */
   inline proc gpuAtomicMax(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("max", x, val); }
   /* When run on a GPU, atomically increments x if the original value of x is
-     greater-than or equal to val, if so the result is stored in 'x'. */
+     greater-than or equal to val, if so the result is stored in 'x'. Otherwise x is set to 0.
+     The operation returns the old value of x. */
   inline proc gpuAtomicInc(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("inc", x, val); }
   /* When run on a GPU, atomically determine if 'x' equals 0 or is greater than 'val'.
-     If so store 'val' in 'x' otherwise decrement 'x' by 1. */
+     If so store 'val' in 'x' otherwise decrement 'x' by 1. Otherwise x is set to val.
+     The operation returns the old value of x. */
   inline proc gpuAtomicDec(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("dec", x, val); }
   /* When run on a GPU, atomically perform a bitwise 'and' operation on 'x' and 'val' and store
-     the result in 'x'. */
+     the result in 'x'. The operation returns the old value of x. */
   inline proc gpuAtomicAnd(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("and", x, val); }
   /* When run on a GPU, atomically perform a bitwise 'or' operation on 'x' and 'val' and store
-     the result in 'x'.  */
+     the result in 'x'. The operation returns the old value of x. */
   inline proc gpuAtomicOr(   ref x : ?T, val : T) : T { return gpuAtomicBinOp("or", x, val); }
   /* When run on a GPU, atomically perform a bitwise 'xor' operation on 'x' and 'val' and store
-     the result in 'x'. */
+     the result in 'x'. The operation returns the old value of x. */
   inline proc gpuAtomicXor(  ref x : ?T, val : T) : T { return gpuAtomicBinOp("xor", x, val); }
 
   /* When run on a GPU, atomically compare the value in 'x' and 'cmp', if they
-     are equal store 'val' in 'x'.  */
+     are equal store 'val' in 'x'. The operation returns the old value of x. */
   inline proc gpuAtomicCAS(  ref x : ?T, cmp : T, val : T) : T { return gpuAtomicTernOp("CAS", x, cmp, val); }
 }

--- a/runtime/include/gpu/amd/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/amd/chpl-gpu-gen-includes.h
@@ -87,16 +87,16 @@ __device__ static inline uint32_t chpl_gpu_getGridDimZ()   {
 // =================
 
 #define GPU_2OP_ATOMIC(T, runtime_name, rocm_name)           \
-  __device__ static inline void runtime_name(T *x, T val) {  \
-    rocm_name(x, val);                                       \
+  __device__ static inline T runtime_name(T *x, T val) {     \
+    return rocm_name(x, val);                                \
   }                                                          \
-  __host__ static inline void runtime_name(T *x, T val) {}
+  __host__ static inline T runtime_name(T *x, T val) {return 0;}
 
 #define GPU_3OP_ATOMIC(T, runtime_name, rocm_name)                   \
-  __device__ static inline void runtime_name(T *x, T val1, T val2) { \
-    rocm_name(x, val1, val2);                                        \
+  __device__ static inline T runtime_name(T *x, T val1, T val2) {    \
+    return rocm_name(x, val1, val2);                                 \
   }                                                                  \
-  __host__ static inline void runtime_name(T *x, T val1, T val2) {}
+  __host__ static inline T runtime_name(T *x, T val1, T val2) {return 0;}
 
 // Some atomic operations are only supported in CUDA while others are only
 // supported in ROCM. We mark the operations that are unsupported for this

--- a/runtime/include/gpu/nvidia/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/nvidia/chpl-gpu-gen-includes.h
@@ -80,17 +80,17 @@ __device__ static inline uint32_t chpl_gpu_getGridDimZ()   { return __nvvm_read_
 // Atomic Operations
 // =================
 
-#define GPU_2OP_ATOMIC(T, runtime_name, cuda_name)           \
-  __device__ static inline void runtime_name(T *x, T val) {  \
-    cuda_name(x, val);                                       \
-  }                                                          \
-  __host__ static inline void runtime_name(T *x, T val) {}
+#define GPU_2OP_ATOMIC(T, runtime_name, cuda_name)            \
+  __device__ static inline T runtime_name(T *x, T val) {      \
+    return cuda_name(x, val);                                 \
+  }                                                           \
+  __host__ static inline T runtime_name(T *x, T val) {return 0;}
 
 #define GPU_3OP_ATOMIC(T, runtime_name, cuda_name)                   \
-  __device__ static inline void runtime_name(T *x, T val1, T val2) { \
-    cuda_name(x, val1, val2);                                        \
+  __device__ static inline T runtime_name(T *x, T val1, T val2) {    \
+    return cuda_name(x, val1, val2);                                 \
   }                                                                  \
-  __host__ static inline void runtime_name(T *x, T val1, T val2) {}
+  __host__ static inline T runtime_name(T *x, T val1, T val2) {return 0;}
 
 GPU_2OP_ATOMIC(int,                chpl_gpu_atomic_add_int,       atomicAdd);
 GPU_2OP_ATOMIC(unsigned int,       chpl_gpu_atomic_add_uint,      atomicAdd);

--- a/test/gpu/native/atomics.chpl
+++ b/test/gpu/native/atomics.chpl
@@ -5,17 +5,17 @@ config param excludeForRocm = (CHPL_GPU == "amd");
 
 // CPU versions of associated GPU functions. These aren't actually atomic but
 // are used for test verification:
-proc cpuAtomicAdd (ref x : ?T, val : T) : void { x += val; }
-proc cpuAtomicSub (ref x : ?T, val : T) : void { x -= val; }
-proc cpuAtomicExch(ref x : ?T, val : T) : void { x = val; }
-proc cpuAtomicMin (ref x : ?T, val : T) : void { x = min(x, val); }
-proc cpuAtomicMax (ref x : ?T, val : T) : void { x = max(x, val); }
-proc cpuAtomicInc (ref x : ?T, val : T) : void { x = if x >= val then 0:T else x + 1; }
-proc cpuAtomicDec (ref x : ?T, val : T) : void { x = if x == 0:T || x > val then val else x-1; }
-proc cpuAtomicAnd (ref x : ?T, val : T) : void { x &= val; }
-proc cpuAtomicOr  (ref x : ?T, val : T) : void { x |= val; }
-proc cpuAtomicXor (ref x : ?T, val : T) : void { x ^= val; }
-proc cpuAtomicCAS (ref x : ?T, cmp : T, val : T) : void { x = if x == cmp then val else x; }
+proc cpuAtomicAdd (ref x : ?T, val : T) : T { x += val; return x-val;}
+proc cpuAtomicSub (ref x : ?T, val : T) : T { x -= val; return x+val;}
+proc cpuAtomicExch(ref x : ?T, val : T) : T { const retval = x; x = val; return retval;}
+proc cpuAtomicMin (ref x : ?T, val : T) : T { const retval = x; x = min(x, val); return retval;}
+proc cpuAtomicMax (ref x : ?T, val : T) : T { const retval = x; x = max(x, val); return retval;}
+proc cpuAtomicInc (ref x : ?T, val : T) : T { const retval = x; x = if x >= val then 0:T else x + 1; return retval;}
+proc cpuAtomicDec (ref x : ?T, val : T) : T { const retval = x; x = if x == 0:T || x > val then val else x-1; return retval;}
+proc cpuAtomicAnd (ref x : ?T, val : T) : T { const retval = x; x &= val; return retval;}
+proc cpuAtomicOr  (ref x : ?T, val : T) : T { const retval = x; x |= val; return retval;}
+proc cpuAtomicXor (ref x : ?T, val : T) : T { const retval = x; x ^= val; return retval;}
+proc cpuAtomicCAS (ref x : ?T, cmp : T, val : T) : T { const retval = x; x = if x == cmp then val else x; return retval;}
 
 proc check(orig, gpuRes, cpuRes, s) {
   stopGpuDiagnostics();
@@ -58,8 +58,8 @@ proc runTest(param op : string, type T) {
   stopGpuDiagnostics();
 
   var origVals : [0..2] T;
-  var gpuVals  : [0..2] T;
-  var cpuVals  : [0..2] T;
+  var gpuVals  : [0..3] T;
+  var cpuVals  : [0..3] T;
   var rng = createRandomStream(eltType=T, parSafe=false);
   for i in 0..2 {
     origVals[i] = rng.getNext();
@@ -76,48 +76,48 @@ proc runTest(param op : string, type T) {
   // can not be captured as a FCF.
   select(op) {
     when "add" {
-      foreach n in 0..0 do gpuAtomicAdd(gpuVals[0],  gpuVals[1]);
-      cpuAtomicAdd(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicAdd(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicAdd(cpuVals[0],  cpuVals[1]);
     }
     when "sub" {
-      foreach n in 0..0 do gpuAtomicSub(gpuVals[0],  gpuVals[1]);
-      cpuAtomicSub(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicSub(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicSub(cpuVals[0],  cpuVals[1]);
     }
     when "exch" {
-      foreach n in 0..0 do gpuAtomicExch(gpuVals[0],  gpuVals[1]);
-      cpuAtomicExch(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicExch(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicExch(cpuVals[0],  cpuVals[1]);
     }
     when "min" {
-      foreach n in 0..0 do gpuAtomicMin(gpuVals[0],  gpuVals[1]);
-      cpuAtomicMin(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicMin(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicMin(cpuVals[0],  cpuVals[1]);
     }
     when "max" {
-      foreach n in 0..0 do gpuAtomicMax(gpuVals[0],  gpuVals[1]);
-      cpuAtomicMax(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicMax(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicMax(cpuVals[0],  cpuVals[1]);
     }
     when "inc" {
-      foreach n in 0..0 do gpuAtomicInc(gpuVals[0],  gpuVals[1]);
-      cpuAtomicInc(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicInc(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicInc(cpuVals[0],  cpuVals[1]);
     }
     when "dec" {
-      foreach n in 0..0 do gpuAtomicDec(gpuVals[0],  gpuVals[1]);
-      cpuAtomicDec(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicDec(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicDec(cpuVals[0],  cpuVals[1]);
     }
     when "and" {
-      foreach n in 0..0 do gpuAtomicAnd(gpuVals[0],  gpuVals[1]);
-      cpuAtomicAnd(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicAnd(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicAnd(cpuVals[0],  cpuVals[1]);
     }
     when "or" {
-      foreach n in 0..0 do gpuAtomicOr(gpuVals[0],  gpuVals[1]);
-      cpuAtomicOr(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicOr(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicOr(cpuVals[0],  cpuVals[1]);
     }
     when "xor" {
-      foreach n in 0..0 do gpuAtomicXor(gpuVals[0],  gpuVals[1]);
-      cpuAtomicXor(cpuVals[0],  cpuVals[1]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicXor(gpuVals[0],  gpuVals[1]);
+      cpuVals[3] = cpuAtomicXor(cpuVals[0],  cpuVals[1]);
     }
     when "CAS" {
-      foreach n in 0..0 do gpuAtomicCAS(gpuVals[0],  gpuVals[1], gpuVals[2]);
-      cpuAtomicCAS(cpuVals[0],  cpuVals[1], cpuVals[2]);
+      foreach n in 0..0 do gpuVals[3] = gpuAtomicCAS(gpuVals[0],  gpuVals[1], gpuVals[2]);
+      cpuVals[3] = cpuAtomicCAS(cpuVals[0],  cpuVals[1], cpuVals[2]);
     }
   }
   check(origVals, gpuVals, cpuVals, op);
@@ -127,7 +127,7 @@ proc main() {
   on here.gpus[0] {
     startGpuDiagnostics();
 
-    runTest("add", c_int);  runTest("add", c_uint);  runTest("add", c_float);
+    runTest("add", c_int); runTest("add", c_uint);  runTest("add", c_float);
     if(!excludeForRocm) {
       runTest("add", c_ulonglong);  runTest("add", c_double);
     }

--- a/test/gpu/native/atomics.chpl
+++ b/test/gpu/native/atomics.chpl
@@ -5,8 +5,8 @@ config param excludeForRocm = (CHPL_GPU == "amd");
 
 // CPU versions of associated GPU functions. These aren't actually atomic but
 // are used for test verification:
-proc cpuAtomicAdd (ref x : ?T, val : T) : T { x += val; return x-val;}
-proc cpuAtomicSub (ref x : ?T, val : T) : T { x -= val; return x+val;}
+proc cpuAtomicAdd (ref x : ?T, val : T) : T { const retval = x; x += val; return retval;}
+proc cpuAtomicSub (ref x : ?T, val : T) : T { const retval = x; x -= val; return retval;}
 proc cpuAtomicExch(ref x : ?T, val : T) : T { const retval = x; x = val; return retval;}
 proc cpuAtomicMin (ref x : ?T, val : T) : T { const retval = x; x = min(x, val); return retval;}
 proc cpuAtomicMax (ref x : ?T, val : T) : T { const retval = x; x = max(x, val); return retval;}


### PR DESCRIPTION
Make the GPU atomic functions return the appropriate old values. Currently these atomics are wrappers to nvidia or amd atomics, which do return the old values, we didn't pass it along earlier. Now we pass along the return value we get from the nvidia and AMD atomic functions so we can use them in Chapel code.


- [x] AMD GPU paratest
- [x] Nvidia GPU paratest