### PR TITLE
Make timezone awareness part of `dateTime`/`time`'s static type

### DIFF
--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -608,12 +608,12 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   /* A record representing a time */
   record time {
     var chpl_hour, chpl_minute, chpl_second, chpl_microsecond: int;
-    var chpl_tz: shared Timezone?;
 
     // Timezone awareness/naivety is part of the type so we can prohibit
     // comparison of an aware vs naive time at compile-time.
     @chpldoc.nodoc
     param tz_aware : bool = false;
+    var chpl_tz: if tz_aware then (shared Timezone) else nothing;
 
     /* The hour represented by this `time` value */
     proc hour {
@@ -637,6 +637,8 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
     /* The timezone represented by this `time` value */
     proc timezone {
+      if (!tz_aware) then
+        compilerError("Can't access timezone of a naive time");
       return chpl_tz;
     }
 
@@ -670,28 +672,6 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   }
 
   /* Initialize a new `time` value from the given `hour`, `minute`, `second`,
-     `microsecond`, and `timezone`.  All arguments are optional
-   */
-  @unstable("tz is unstable; its type may change in the future")
-  proc time.init(hour:int=0, minute:int=0, second:int=0, microsecond:int=0,
-                 in tz: shared Timezone?) {
-    if hour < 0 || hour >= 24 then
-      HaltWrappers.initHalt("hour out of range");
-    if minute < 0 || minute >= 60 then
-      HaltWrappers.initHalt("minute out of range");
-    if second < 0 || second >= 60 then
-      HaltWrappers.initHalt("second out of range");
-    if microsecond < 0 || microsecond >= 1000000 then
-      HaltWrappers.initHalt("microsecond out of range");
-    this.chpl_hour = hour;
-    this.chpl_minute = minute;
-    this.chpl_second = second;
-    this.chpl_microsecond = microsecond;
-    this.chpl_tz = tz;
-    this.tz_aware = true;
-  }
-
-  /* Initialize a new `time` value from the given `hour`, `minute`, `second`,
      `microsecond`.  All arguments are optional
    */
   proc time.init(hour:int=0, minute:int=0, second:int=0, microsecond:int=0) {
@@ -707,8 +687,29 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     this.chpl_minute = minute;
     this.chpl_second = second;
     this.chpl_microsecond = microsecond;
-    this.chpl_tz = nil;
     this.tz_aware = false;
+  }
+
+  /* Initialize a new `time` value from the given `hour`, `minute`, `second`,
+     `microsecond`, and `timezone`.  All arguments are optional
+   */
+  @unstable("tz is unstable; its type may change in the future")
+  proc time.init(hour:int=0, minute:int=0, second:int=0, microsecond:int=0,
+                 in tz: shared Timezone) {
+    if hour < 0 || hour >= 24 then
+      HaltWrappers.initHalt("hour out of range");
+    if minute < 0 || minute >= 60 then
+      HaltWrappers.initHalt("minute out of range");
+    if second < 0 || second >= 60 then
+      HaltWrappers.initHalt("second out of range");
+    if microsecond < 0 || microsecond >= 1000000 then
+      HaltWrappers.initHalt("microsecond out of range");
+    this.chpl_hour = hour;
+    this.chpl_minute = minute;
+    this.chpl_second = second;
+    this.chpl_microsecond = microsecond;
+    this.tz_aware = true;
+    this.chpl_tz = tz;
   }
 
   /* Initialize a new `time` value from the given `hour`, `minute`, `second`,
@@ -721,11 +722,22 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Methods on time values */
 
+  /* Get a new `time` with the same values as this one, but no timezone
+     awareness.
+   */
+  proc time.withoutTz() : time(tz_aware = false) {
+    if !tz_aware {
+      return this;
+    } else {
+      return new time(hour, minute, second, microsecond);
+    }
+  }
+
   /* Replace the `hour`, `minute`, `second`, `microsecond` in a
      `time` to create a new `time`. All arguments are optional.
    */
   proc time.replace(hour = -1, minute = -1, second = -1, microsecond = -1)
-      : time(tz_aware = false) {
+      : time(tz_aware = false) where !tz_aware {
     const newhour = if hour != -1 then hour else this.hour;
     const newminute = if minute != -1 then minute else this.minute;
     const newsecond = if second != -1 then second else this.second;
@@ -765,8 +777,8 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if microsecond != 0 {
       ret = ret + "." + makeNDigits(6, microsecond);
     }
-    var offset = utcOffset();
-    if timezone.borrow() != nil {
+    if tz_aware {
+      var offset = utcOffset();
       var sign: string;
       if offset.days < 0 {
         offset = -offset;
@@ -782,29 +794,21 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Return the offset from UTC */
   proc time.utcOffset() : timeDelta {
-    if timezone.borrow() == nil {
-      return new timeDelta();
-    } else {
-      return timezone!.utcOffset(dateTime.now());
-    }
+    if !tz_aware then compilerError("Can't get utcOffset of naive time");
+    return timezone!.utcOffset(dateTime.now());
   }
 
   /* Return the daylight saving time offset */
   proc time.dst() : timeDelta {
-    if timezone.borrow() == nil {
-      return new timeDelta();
-    } else {
-      return timezone!.dst(dateTime.now());
-    }
+    if !tz_aware then compilerError("Can't get dst offset of naive time");
+    return timezone!.dst(dateTime.now());
   }
 
   /* Return the name of the timezone for this `time` value */
   @unstable("'tzname' is unstable")
   proc time.tzname() {
-    if timezone.borrow() == nil then
-      return "";
-    else
-      return timezone!.tzname(new dateTime(1,1,1));
+    if !tz_aware then compilerError("Can't get tzname of naive time");
+    return timezone!.tzname(new dateTime(1,1,1));
   }
 
   /* Return a `string` matching the `format` argument for this `time` */
@@ -1072,6 +1076,8 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
     /* The timezone represented by this `dateTime` value */
     proc timezone {
+      if (!tz_aware) then
+        compilerError("Can't access timezone of a naive dateTime");
       return chpl_time.timezone;
     }
 
@@ -1100,7 +1106,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   @unstable("tz is unstable; its type may change in the future")
   proc dateTime.init(year:int, month:int, day:int,
                      hour:int=0, minute:int=0, second:int=0, microsecond:int=0,
-                     in tz) {
+                     in tz:shared Timezone) {
     chpl_date = new date(year, month, day);
     tz_aware = true;
     chpl_time = new time(hour, minute, second, microsecond, tz);
@@ -1136,23 +1142,13 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Return a `dateTime` value representing the current time and date, in the
      given timezone */
-  proc type dateTime.now(in tz: shared Timezone?) : dateTime(tz_aware=true) {
-    if tz.borrow() == nil {
-      const timeSinceEpoch = getTimeOfDay();
-      const lt = getLocalTime(timeSinceEpoch);
-      return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
-                          day=lt.tm_mday,       hour=lt.tm_hour,
-                          minute=lt.tm_min,     second=lt.tm_sec,
-                          microsecond=timeSinceEpoch(1),
-                          tz=nil);
-    } else {
-      const timeSinceEpoch = getTimeOfDay();
-      const td = new timeDelta(seconds=timeSinceEpoch(0),
-                               microseconds=timeSinceEpoch(1));
-      const utcNow = unixEpoch + td;
+  proc type dateTime.now(in tz: shared Timezone) : dateTime(tz_aware=true) {
+    const timeSinceEpoch = getTimeOfDay();
+    const td = new timeDelta(seconds=timeSinceEpoch(0),
+                             microseconds=timeSinceEpoch(1));
+    const utcNow = unixEpoch + td;
 
-      return (utcNow + tz!.utcOffset(utcNow)).replace(tz=tz);
-    }
+    return (utcNow + tz!.utcOffset(utcNow)).replace(tz=tz);
   }
 
   /* Return a `dateTime` value representing the current time and date in UTC */
@@ -1170,7 +1166,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   @deprecated(notes="'dateTime.fromTimestamp' is deprecated, please use 'dateTime.createFromTimestamp' instead")
   proc type dateTime.fromTimestamp(timestamp: real,
-                                   in tz: shared Timezone?) {
+                                   in tz: shared Timezone) {
     return dateTime.createFromTimestamp(timestamp, tz);
   }
 
@@ -1183,19 +1179,9 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   /* The `dateTime` that is `timestamp` seconds from the epoch */
   @unstable("tz is unstable; its type may change in the future")
   proc type dateTime.createFromTimestamp(timestamp: real,
-                                   in tz: shared Timezone?) : dateTime(tz_aware=true) {
-    if tz.borrow() == nil {
-      var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);
-      const lt = getLocalTime(t);
-      return new dateTime(year=lt.tm_year+1900, month=lt.tm_mon+1,
-                          day=lt.tm_mday,       hour=lt.tm_hour,
-                          minute=lt.tm_min,     second=lt.tm_sec,
-                          microsecond=t(1),
-                          tz=nil);
-    } else {
-      var dt = dateTime.createUtcFromTimestamp(timestamp);
-      return (dt + tz!.utcOffset(dt)).replace(tz=tz);
-    }
+                                   in tz: shared Timezone) : dateTime(tz_aware=true) {
+    var dt = dateTime.createUtcFromTimestamp(timestamp);
+    return (dt + tz!.utcOffset(dt)).replace(tz=tz);
   }
 
   @deprecated(notes="'dateTime.utcFromTimestamp' is deprecated, please use 'dateTime.createUtcFromTimestamp' instead")
@@ -1249,27 +1235,54 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Get the `time` portion of the `dateTime` value, with `tz` = nil */
   proc dateTime.getTime() : time(tz_aware=false) {
-    if chpl_time.tz_aware == false then
+    if !tz_aware then
       return chpl_time;
     else
-      return new time(hour=hour, minute=minute,
-                      second=second, microsecond=microsecond);
+      return time.withoutTz();
   }
 
   /* Get the `time` portion of the `dateTime` value including the
      `tz` field
    */
   proc dateTime.timetz() : time(tz_aware=true) {
+    if !tz_aware then compilerError("Can't get aware time from naive dateTime");
     return chpl_time;
+  }
+
+  proc dateTime.withoutTz() : dateTime(tz_aware=false) {
+    if !tz_aware {
+      return this;
+    } else {
+      return dateTime.combine(chpl_date, chpl_time.withoutTz());
+    }
+  }
+
+  /* Replace the `year`, `month`, `day`, `hour`, `minute`, `second`,
+     or `microsecond` to form a new `dateTime` object. All
+     arguments are optional.
+   */
+  proc dateTime.replace(year=-1, month=-1, day=-1,
+                        hour=-1, minute=-1, second=-1, microsecond=-1)
+                        : dateTime(tz_aware=false) where !this.tz_aware {
+    return dateTime.combine(
+      new date(if year == -1 then this.year else year,
+               if month == -1 then this.month else month,
+               if day == -1 then this.day else day),
+      new time(if hour == -1 then this.hour else hour,
+               if minute == -1 then this.minute else minute,
+               if second == -1 then this.second else second,
+               if microsecond == -1 then this.microsecond else microsecond));
   }
 
   /* Replace the `year`, `month`, `day`, `hour`, `minute`, `second`,
      `microsecond`, or `tz` to form a new `dateTime` object. All
      arguments are optional.
    */
+  @unstable("tz is unstable; its type may change in the future")
   proc dateTime.replace(year=-1, month=-1, day=-1,
                         hour=-1, minute=-1, second=-1, microsecond=-1,
-                        in tz=this.timezone) : dateTime(tz_aware=true) {
+                        in tz: shared Timezone)
+                        : dateTime(tz_aware=true) where !this.tz_aware {
     return dateTime.combine(
       new date(if year == -1 then this.year else year,
                if month == -1 then this.month else month,
@@ -1278,7 +1291,29 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
                if minute == -1 then this.minute else minute,
                if second == -1 then this.second else second,
                if microsecond == -1 then this.microsecond else microsecond,
-               tz));
+               tz)
+      );
+  }
+
+  /* Replace the `year`, `month`, `day`, `hour`, `minute`, `second`,
+     `microsecond`, or `tz` to form a new `dateTime` object. All
+     arguments are optional.
+   */
+  @unstable("tz is unstable; its type may change in the future")
+  proc dateTime.replace(year=-1, month=-1, day=-1,
+                        hour=-1, minute=-1, second=-1, microsecond=-1,
+                        in tz: shared Timezone = this.timezone)
+                        : dateTime(tz_aware=true) where this.tz_aware {
+    return dateTime.combine(
+      new date(if year == -1 then this.year else year,
+               if month == -1 then this.month else month,
+               if day == -1 then this.day else day),
+      new time(if hour == -1 then this.hour else hour,
+               if minute == -1 then this.minute else minute,
+               if second == -1 then this.second else second,
+               if microsecond == -1 then this.microsecond else microsecond,
+               tz)
+      );
   }
 
   /* Return the date and time converted into the timezone in the argument */
@@ -1293,25 +1328,20 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* Return the offset from UTC */
   proc dateTime.utcOffset() : timeDelta {
-    if timezone.borrow() == nil {
-      halt("utcOffset called on naive dateTime");
-    } else {
-      return timezone!.utcOffset(this);
-    }
+    if !tz_aware then compilerError("utcOffset called on naive dateTime");
+    return timezone.utcOffset(this);
   }
   /* Return the daylight saving time offset */
   proc dateTime.dst() : timeDelta {
-    if timezone.borrow() == nil then
-      halt("dst() called with nil timezone");
-    return timezone!.dst(this);
+    if !tz_aware then compilerError("dst called on naive dateTime");
+    return timezone.dst(this);
   }
 
   /* Return the name of the timezone for this `dateTime` value */
   @unstable("'tzname' is unstable")
   proc dateTime.tzname() : string {
-    if timezone.borrow() == nil then
-      return "";
-    return timezone!.tzname(this);
+    if !tz_aware then compilerError("tzname called on naive dateTime");
+    return timezone.tzname(this);
   }
 
   /* Return a filled record matching the C `struct tm` type for the given
@@ -1328,7 +1358,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     timeStruct.tm_wday = weekday(): int(32);
     timeStruct.tm_yday = (toOrdinal() - (new date(year, 1, 1)).toOrdinal() + 1): int(32);
 
-    if timezone.borrow() == nil {
+    if !tz_aware {
       timeStruct.tm_isdst = -1;
     } else if dst() == new timeDelta(0) {
       timeStruct.tm_isdst = 0;
@@ -1344,7 +1374,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
    */
   @unstable("'dateTime.utctimetuple' is unstable")
   proc dateTime.utctimetuple() {
-    if timezone.borrow() == nil {
+    if !tz_aware {
       var ret = timetuple();
       ret.tm_isdst = 0;
       return ret;
@@ -1405,7 +1435,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     }
     var micro = if microsecond > 0 then "." + zeroPad(6, microsecond) else "";
     var offset: string;
-    if timezone.borrow() != nil {
+    if tz_aware {
       var utcoff = utcOffset();
       var sign: string;
       if utcoff < new timeDelta(0) {
@@ -1457,7 +1487,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     timeStruct.tm_min = minute: int(32);
     timeStruct.tm_sec = second: int(32);
 
-    if timezone.borrow() != nil {
+    if tz_aware {
       timeStruct.tm_isdst = timezone!.dst(this).seconds: int(32);
       timeStruct.tm_gmtoff = timezone!.utcOffset(this).seconds: c_long;
       timeStruct.tm_zone = nil;
@@ -1471,9 +1501,15 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     timeStruct.tm_mon = (month-1): int(32);    // 0 based
     timeStruct.tm_mday = day: int(32);
     timeStruct.tm_wday = (weekday(): int(32) + 1) % 7; // shift Sunday to 0
-    timeStruct.tm_yday =
-      (this.replace(tz=nil) - (new dateTime(year, 1, 1, tz=nil))).days
-        : int(32);
+    if (tz_aware) {
+      timeStruct.tm_yday =
+        (this - (new dateTime(year, 1, 1, tz=this.timezone))).days
+          : int(32);
+    } else {
+      timeStruct.tm_yday =
+        (this - (new dateTime(year, 1, 1))).days
+          : int(32);
+    }
 
     // Iterate over format specifiers in strftime(), replacing %f with microseconds
     iter strftok(const ref s: string)
@@ -1658,19 +1694,19 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
     if (dt1.chpl_time.tz_aware != dt2.chpl_time.tz_aware) {
       compilerError("both dateTimes must both be either naive or aware");
     }
-    if dt1.timezone == dt2.timezone {
-      const newmicro = dt1.microsecond - dt2.microsecond,
-            newsec = dt1.second - dt2.second,
-            newmin = dt1.minute - dt2.minute,
-            newhour = dt1.hour - dt2.hour,
-            newday = dt1.toOrdinal() - dt2.toOrdinal();
-      return new timeDelta(days=newday, hours=newhour, minutes=newmin,
-                           seconds=newsec, microseconds=newmicro);
-    } else {
-      return dt1.replace(tz=nil) -
-                                dt2.replace(tz=nil) +
-                                dt2.utcOffset() - dt1.utcOffset();
+    if (dt1.tz_aware) {
+      if (dt1.timezone != dt2.timezone) {
+        return dt1.withoutTz() - dt2.withoutTz()
+                + dt2.utcOffset() - dt1.utcOffset();
+      }
     }
+    const newmicro = dt1.microsecond - dt2.microsecond,
+          newsec = dt1.second - dt2.second,
+          newmin = dt1.minute - dt2.minute,
+          newhour = dt1.hour - dt2.hour,
+          newday = dt1.toOrdinal() - dt2.toOrdinal();
+    return new timeDelta(days=newday, hours=newhour, minutes=newmin,
+                         seconds=newsec, microseconds=newmicro);
   }
 
   @chpldoc.nodoc

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -664,6 +664,10 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
 
   /* initializers/factories for time values */
 
+  @chpldoc.nodoc
+  proc time.init(tz_aware: bool) {
+  }
+
   /* Initialize a new `time` value from the given `hour`, `minute`, `second`,
      `microsecond`, and `timezone`.  All arguments are optional
    */
@@ -1080,7 +1084,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   /* initializers/factories for dateTime values */
 
   @chpldoc.nodoc
-  proc dateTime.init() {
+  proc dateTime.init(tz_aware: bool) {
   }
 
   /* Initialize a new `dateTime` value from the given `year`, `month`, `day`,

--- a/test/library/standard/DateTime/readWriteDatesTimes.good
+++ b/test/library/standard/DateTime/readWriteDatesTimes.good
@@ -1,3 +1,3 @@
-dateTime: true
+dateTime(false): true
 date: true
-time: true
+time(false): true

--- a/test/library/standard/DateTime/strptime2.bad
+++ b/test/library/standard/DateTime/strptime2.bad
@@ -1,5 +1,5 @@
 strptime2.chpl:4: In function 'test_microsecond':
-strptime2.chpl:7: error: unresolved call 'dateTime.strptime("12:59:59.008000", "%T.%f")'
+strptime2.chpl:7: error: unresolved call 'dateTime(false).strptime("12:59:59.008000", "%T.%f")'
 $CHPL_HOME/modules/standard/Time.chpl:1418: note: this candidate did not match: type dateTime.strptime(date_string: string, format: string)
 strptime2.chpl:7: note: because non-type method call receiver
 $CHPL_HOME/modules/standard/Time.chpl:1418: note: is passed to formal 'this: dateTime'

--- a/test/library/standard/DateTime/testDatetime.chpl
+++ b/test/library/standard/DateTime/testDatetime.chpl
@@ -220,7 +220,7 @@ proc test_combine() {
 
 proc test_replace() {
   var args = (1, 2, 3, 4, 5, 6, 7);
-  var base = new dateTime((...args));
+  var base = new dateTime((...args), tz=nil);
   var nilTZ:shared Timezone?;
 
   assert(base == base.replace(tz=nilTZ));
@@ -234,9 +234,9 @@ proc test_replace() {
                          ("second", 7),
                          ("microsecond", 8)) {
     var newargs = args;
-    var got: dateTime;
+    var got: dateTime(tz_aware=true);
     newargs[i] = newval;
-    var expected = new dateTime((...newargs));
+    var expected = new dateTime((...newargs), tz=nil);
 
     if name == "year" then
       got = base.replace(year = newval, tz=nilTZ);

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -15,16 +15,16 @@ class FixedOffset: Timezone {
     this.dstoffset = new timeDelta(minutes=dstoffset);
   }
 
-  override proc utcOffset(dt: dateTime) {
+  override proc utcOffset(dt: dateTime(?)) {
     return offset;
   }
-  override proc tzname(dt: dateTime) {
+  override proc tzname(dt: dateTime(?)) {
     return name;
   }
-  override proc dst(dt: dateTime) {
+  override proc dst(dt: dateTime(?)) {
     return dstoffset;
   }
-  override proc fromUtc(dt: dateTime) {
+  override proc fromUtc(dt: dateTime(?)) {
     var dtoff = dt.utcOffset();
     var dtdst = dt.dst();
     var delta = dtoff - dtdst;
@@ -244,7 +244,7 @@ proc test_tzinfo_fromtimestamp() {
 
   // Try to make sure tz= actually does some conversion.
   var timestamp = 1000000000;
-  var utcdateTime = dateTime.createUtcFromTimestamp(timestamp);
+  var utcdateTime = dateTime.createUtcFromTimestamp(timestamp).replace(tz=nil);
   // In POSIX (epoch 1970), that's 2001-09-09 01:46:40 UTC, give or take.
   // But on some flavor of Mac, it's nowhere near that.  So we can't have
   // any idea here what time that actually is, we can only test that
@@ -394,7 +394,7 @@ proc test_replace() {
     var newargs = args;
     newargs[i] = newval;
     var expected = new dateTime((...newargs), z100);
-    var got: dateTime;
+    var got: dateTime(tz_aware=true);
     if name == "year" then
       got = base.replace(year=newval, tz=z100);
     else if name == "month" then
@@ -463,7 +463,7 @@ proc test_aware_subtract() {
   // Ensure that utcoffset() is ignored when the operands have the
   // same tz member.
   class OperandDependentOffset: Timezone {
-    override proc utcOffset(dt: dateTime) {
+    override proc utcOffset(dt: dateTime(?)) {
       if dt.minute < 10 {
         // d0 and d1 equal after adjustment
         return new timeDelta(minutes=dt.minute);
@@ -487,7 +487,7 @@ proc test_aware_subtract() {
   }
   // OTOH, if the tz members are distinct, utcoffsets aren't
   // ignored.
-  base = new dateTime(8, 9, 10, 11, 12, 13, 14);
+  base = new dateTime(8, 9, 10, 11, 12, 13, 14, tz=nil);
   d0 = base.replace(minute=3, tz=new shared OperandDependentOffset());
   d1 = base.replace(minute=9, tz=new shared OperandDependentOffset());
   d2 = base.replace(minute=11, tz=new shared OperandDependentOffset());
@@ -511,8 +511,8 @@ proc test_aware_subtract() {
 }
 
 proc test_mixed_compare() {
-  var t1 = new dateTime(1, 2, 3, 4, 5, 6, 7);
-  var t2 = new dateTime(1, 2, 3, 4, 5, 6, 7);
+  var t1 = new dateTime(1, 2, 3, 4, 5, 6, 7, tz=nil);
+  var t2 = new dateTime(1, 2, 3, 4, 5, 6, 7, tz=nil);
   assert(t1 == t2);
   t2 = t2.replace(tz=nil);
   assert(t1 == t2);
@@ -524,7 +524,7 @@ proc test_mixed_compare() {
     proc init() {
       offset = new timeDelta(minutes=22);
     }
-    override proc utcOffset(dt: dateTime) {
+    override proc utcOffset(dt: dateTime(?)) {
       offset += new timeDelta(minutes=1);
       return offset;
     }

--- a/test/library/standard/DateTime/testTime.chpl
+++ b/test/library/standard/DateTime/testTime.chpl
@@ -96,7 +96,7 @@ proc test_resolution_info() {
 
 proc test_replace() {
   var args = (1, 2, 3, 4);
-  var base = new time((...args));
+  var base = new time((...args), tz=nil);
   assert(base == base.replace(tz=base.timezone));
 
   var i = 0;
@@ -106,8 +106,8 @@ proc test_replace() {
                          ("microsecond", 8)) {
     var newargs = args;
     newargs[i] = newval;
-    var expected = new time((...newargs));
-    var got: time;
+    var expected = new time((...newargs), tz=nil);
+    var got: time(tz_aware=true);
     if name == "hour" then
       got = base.replace(hour=newval, tz=base.timezone);
     else if name == "minute" then

--- a/test/library/standard/DateTime/testTimezone.chpl
+++ b/test/library/standard/DateTime/testTimezone.chpl
@@ -109,7 +109,7 @@ proc test_replace() {
     var newargs = args;
     newargs[i] = newval;
     var expected = new time((...newargs), z100);
-    var got: time;
+    var got: time(tz_aware=true);
     if name == "hour" then
       got = base.replace(hour=newval, tz=base.timezone);
     else if name == "minute" then
@@ -143,10 +143,8 @@ proc test_replace() {
 }
 
 proc test_mixed_compare() {
-  var t1 = new time(1, 2, 3);
-  var t2 = new time(1, 2, 3);
-  assert(t1 == t2);
-  t2 = t2.replace(tz=nil);
+  var t1 = new time(1, 2, 3, tz=nil);
+  var t2 = new time(1, 2, 3, tz=nil);
   assert(t1 == t2);
   t2 = t2.replace(tz=new shared FixedOffset(0, ""));
 
@@ -157,14 +155,14 @@ proc test_mixed_compare() {
     proc init() {
       offset = new timeDelta(minutes=22);
     }
-    override proc utcOffset(dt: dateTime) {
+    override proc utcOffset(dt: dateTime(?)) {
       offset += new timeDelta(minutes=1);
       return offset;
     }
-    override proc dst(dt: dateTime) {
+    override proc dst(dt: dateTime(?)) {
       return new timeDelta(0);
     }
-    override proc tzname(dt: dateTime) {
+    override proc tzname(dt: dateTime(?)) {
       return name;
     }
   }

--- a/test/library/standard/DateTime/timezoneAwarenessMismatch.1.good
+++ b/test/library/standard/DateTime/timezoneAwarenessMismatch.1.good
@@ -1,0 +1,1 @@
+timezoneAwarenessMismatch.chpl:46: error: both dateTimes must both be either naive or aware

--- a/test/library/standard/DateTime/timezoneAwarenessMismatch.2.good
+++ b/test/library/standard/DateTime/timezoneAwarenessMismatch.2.good
@@ -1,0 +1,1 @@
+timezoneAwarenessMismatch.chpl:47: error: both dateTimes must both be either naive or aware

--- a/test/library/standard/DateTime/timezoneAwarenessMismatch.3.good
+++ b/test/library/standard/DateTime/timezoneAwarenessMismatch.3.good
@@ -1,0 +1,1 @@
+timezoneAwarenessMismatch.chpl:48: error: both dateTimes must both be either naive or aware

--- a/test/library/standard/DateTime/timezoneAwarenessMismatch.4.good
+++ b/test/library/standard/DateTime/timezoneAwarenessMismatch.4.good
@@ -1,0 +1,1 @@
+timezoneAwarenessMismatch.chpl:49: error: both dateTimes must both be either naive or aware

--- a/test/library/standard/DateTime/timezoneAwarenessMismatch.5.good
+++ b/test/library/standard/DateTime/timezoneAwarenessMismatch.5.good
@@ -1,0 +1,1 @@
+timezoneAwarenessMismatch.chpl:50: error: both dateTimes must both be either naive or aware

--- a/test/library/standard/DateTime/timezoneAwarenessMismatch.6.good
+++ b/test/library/standard/DateTime/timezoneAwarenessMismatch.6.good
@@ -1,0 +1,1 @@
+timezoneAwarenessMismatch.chpl:51: error: both dateTimes must both be either naive or aware

--- a/test/library/standard/DateTime/timezoneAwarenessMismatch.chpl
+++ b/test/library/standard/DateTime/timezoneAwarenessMismatch.chpl
@@ -1,0 +1,54 @@
+use Time;
+
+class FixedOffset: Timezone {
+  var offset: timeDelta;
+  var name: string;
+  var dstoffset: timeDelta;
+  proc init(offset: timeDelta, name: string, dstoffset: timeDelta = new timeDelta(minutes=42)) {
+    this.offset = offset;
+    this.name = name;
+    this.dstoffset = dstoffset;
+  }
+  proc init(offset: int, name, dstoffset:int=42) {
+    this.offset = new timeDelta(minutes=offset);
+    this.name = name;
+    this.dstoffset = new timeDelta(minutes=dstoffset);
+  }
+
+  override proc utcOffset(dt: dateTime(?)) {
+    return offset;
+  }
+  override proc tzname(dt: dateTime(?)) {
+    return name;
+  }
+  override proc dst(dt: dateTime(?)) {
+    return dstoffset;
+  }
+  override proc fromUtc(dt: dateTime(?)) {
+    var dtoff = dt.utcOffset();
+    var dtdst = dt.dst();
+    var delta = dtoff - dtdst;
+    var dt2 = dt + delta;
+    dtdst = dt2.dst();
+    return dt2 + dtdst;
+  }
+}
+
+config param tzCompareOperation : string;
+
+const myTimezone = new shared FixedOffset(3, "MyTimezone");
+
+var naiveDt : dateTime(tz_aware=false) = dateTime.now();
+var awareDt : dateTime(tz_aware=true) = dateTime.now(myTimezone);
+
+// Each of these should cause a compiler error, so we can only test one
+// at a time, chosen via compiler flag.
+select tzCompareOperation {
+  when "lt" do writeln(naiveDt < awareDt);
+  when "gt" do writeln(naiveDt > awareDt);
+  when "leq" do writeln(naiveDt <= awareDt);
+  when "geq" do writeln(naiveDt >= awareDt);
+  when "eq" do writeln(naiveDt == awareDt);
+  when "neq" do writeln(naiveDt == awareDt);
+  otherwise do assert(false); // test invoked incorrectly
+}

--- a/test/library/standard/DateTime/timezoneAwarenessMismatch.compopts
+++ b/test/library/standard/DateTime/timezoneAwarenessMismatch.compopts
@@ -1,0 +1,6 @@
+-stzCompareOperation=\"lt\"
+-stzCompareOperation=\"gt\"
+-stzCompareOperation=\"leq\"
+-stzCompareOperation=\"geq\"
+-stzCompareOperation=\"eq\"
+-stzCompareOperation=\"neq\"


### PR DESCRIPTION
Adds a `param tz_aware` to `time` and `dateTime` so they have timezone awareness as part of their static type.

This enables us to error at compile-time when trying to compare `time`s/`dateTime`s with awareness/naivety differences, rather than the status quo of halting at runtime. This PR does so without deprecation as code encountering this compiler error would already have been illegal, just enforced at runtime.

As future work (likely post-2.0) it should be possible to avoid having to use or check for `nil` `Timezone`s entirely, just using `tz_aware`ness instead. This would let us move even more checking to compile-time, though this PR does remove all the halts we can[^1]. The commit history of this PR contains a reverted attempt at starting this.

[^1]: Halts for `dateTime.{utcOffset,dst}` are left intact because these methods are to be deprecated shortly.

Resolves https://github.com/chapel-lang/chapel/issues/9941, and implements part of the decisions from https://github.com/Cray/chapel-private/issues/5170.

[reviewer info placeholder]

Testing:
- [x] local paratest