### PR TITLE
Update these tests to use `conj` instead of `conjg`

### DIFF
--- a/test/library/packages/BLAS/test_blas1.chpl
+++ b/test/library/packages/BLAS/test_blas1.chpl
@@ -492,7 +492,7 @@ proc test_dotc_helper(type t) {
     var X: [D] t = [1: t, 2: t, 3: t],
         Y: [D] t = [3: t, 2: t, 1: t];
 
-    var prod = conjg(X)*Y;
+    var prod = conj(X)*Y;
     var red = + reduce prod;
 
     var res = dotc(X, Y);

--- a/test/library/packages/BLAS/test_blas2.chpl
+++ b/test/library/packages/BLAS/test_blas2.chpl
@@ -334,7 +334,7 @@ proc test_gemv_helper(type t){
 
     // Compute Result vector
     for i in R.domain do
-      R[i] = beta*Y[i] + alpha*(+ reduce (conjg(A[..,i])*X[..]));
+      R[i] = beta*Y[i] + alpha*(+ reduce (conj(A[..,i])*X[..]));
 
     gemv(A, X, Y, alpha, beta, opA=Op.H);
 
@@ -476,7 +476,7 @@ proc test_gerc_helper(type t){
     var alpha = rng.getNext();
 
     // Precompute result
-    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conjg(Y[j]) + A[i, j];
+    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conj(Y[j]) + A[i, j];
 
     gerc(A, X, Y, alpha);
 
@@ -508,7 +508,7 @@ proc test_gerc_helper(type t){
     var alpha = rng.getNext();
 
     // Precompute result
-    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conjg(Y[j]) + A[i, j];
+    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conj(Y[j]) + A[i, j];
 
     gerc(A[.., 0.. #n], X, Y, alpha);
 
@@ -736,7 +736,7 @@ proc test_her_helper(type t){
     makeHerm(A);
 
     // Precompute result
-    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conjg(X[j]) + A[i, j];
+    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conj(X[j]) + A[i, j];
 
     // Resulting 'A' is only stored in upper triangular array
     zeroTri(A);
@@ -767,7 +767,7 @@ proc test_her_helper(type t){
     makeHerm(A);
 
     // Precompute result
-    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conjg(X[j]) + A[i, j];
+    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conj(X[j]) + A[i, j];
 
     // Resulting 'A' is only stored in upper triangular array
     zeroTri(A, uplo=Uplo.Lower);
@@ -799,7 +799,7 @@ proc test_her_helper(type t){
     makeHerm(A[.., 0..#m]);
 
     // Precompute result
-    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conjg(X[j]) + A[i, j];
+    for (i,j) in R.domain do R[i, j] = alpha*X[i]*conj(X[j]) + A[i, j];
 
     // Resulting 'A' is only stored in upper triangular array
     zeroTri(A[.., 0..#m]);
@@ -840,7 +840,7 @@ proc test_her2_helper(type t){
 
     // Precompute result
     for (i, j) in R.domain do
-      R[i, j] = alpha*X[i]*conjg(Y[j]) + conjg(alpha)*Y[i]*conjg(Y[j]) + A[i, j];
+      R[i, j] = alpha*X[i]*conj(Y[j]) + conj(alpha)*Y[i]*conj(Y[j]) + A[i, j];
 
     // A result is only stored in upper triangular array
     zeroTri(A);
@@ -872,7 +872,7 @@ proc test_her2_helper(type t){
 
     // Precompute result
     for (i, j) in R.domain do
-      R[i, j] = alpha*X[i]*conjg(Y[j]) + conjg(alpha)*Y[i]*conjg(Y[j]) + A[i, j];
+      R[i, j] = alpha*X[i]*conj(Y[j]) + conj(alpha)*Y[i]*conj(Y[j]) + A[i, j];
 
     // A result is only stored in upper triangular array
     zeroTri(A, uplo=Uplo.Lower);
@@ -905,7 +905,7 @@ proc test_her2_helper(type t){
 
     // Precompute result
     for (i, j) in R.domain do
-      R[i, j] = alpha*X[i]*conjg(Y[j]) + conjg(alpha)*Y[i]*conjg(Y[j]) + A[i, j];
+      R[i, j] = alpha*X[i]*conj(Y[j]) + conj(alpha)*Y[i]*conj(Y[j]) + A[i, j];
 
     // A result is only stored in upper triangular array
     zeroTri(A[.., 0..#m]);
@@ -1153,7 +1153,7 @@ proc test_syr_helper(type t){
 
     makeSymm(A);
 
-    for (i, j) in R.domain do R[i, j] = alpha*X[i]*conjg(X[j]) + A[i, j];
+    for (i, j) in R.domain do R[i, j] = alpha*X[i]*conj(X[j]) + A[i, j];
 
     // A result is only stored in upper triangular array
     zeroTri(R);
@@ -1183,7 +1183,7 @@ proc test_syr_helper(type t){
 
     makeSymm(A);
 
-    for (i, j) in R.domain do R[i, j] = alpha*X[i]*conjg(X[j]) + A[i, j];
+    for (i, j) in R.domain do R[i, j] = alpha*X[i]*conj(X[j]) + A[i, j];
 
     // A result is only stored in upper triangular array
     zeroTri(R, Uplo.Lower);
@@ -1214,7 +1214,7 @@ proc test_syr_helper(type t){
 
     makeSymm(A[.., 0..#m]);
 
-    for (i, j) in R.domain do R[i, j] = alpha*X[i]*conjg(X[j]) + A[i, j];
+    for (i, j) in R.domain do R[i, j] = alpha*X[i]*conj(X[j]) + A[i, j];
 
     // A result is only stored in upper triangular array
     zeroTri(R);
@@ -1256,7 +1256,7 @@ proc test_syr2_helper(type t){
     makeSymm(A);
 
     for (i, j) in R.domain do
-        R[i, j] = alpha*X[i]*conjg(Y[j]) + conjg(alpha)*Y[i]*conjg(X[j]) + A[i,j];
+        R[i, j] = alpha*X[i]*conj(Y[j]) + conj(alpha)*Y[i]*conj(X[j]) + A[i,j];
 
     // A result is only stored in upper triangular array
     zeroTri(R);
@@ -1289,7 +1289,7 @@ proc test_syr2_helper(type t){
     makeSymm(A);
 
     for (i, j) in R.domain do
-        R[i, j] = alpha*X[i]*conjg(Y[j]) + conjg(alpha)*Y[i]*conjg(X[j]) + A[i,j];
+        R[i, j] = alpha*X[i]*conj(Y[j]) + conj(alpha)*Y[i]*conj(X[j]) + A[i,j];
 
     // A result is only stored in upper triangular array
     zeroTri(R, Uplo.Lower);
@@ -1323,7 +1323,7 @@ proc test_syr2_helper(type t){
     makeSymm(A[.., 0..#m]);
 
     for (i, j) in R.domain do
-        R[i, j] = alpha*X[i]*conjg(Y[j]) + conjg(alpha)*Y[i]*conjg(X[j]) + A[i,j];
+        R[i, j] = alpha*X[i]*conj(Y[j]) + conj(alpha)*Y[i]*conj(X[j]) + A[i,j];
 
     // A result is only stored in upper triangular array
     zeroTri(R);

--- a/test/library/packages/LinearAlgebra/correctness/dependencies/testEigen.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/dependencies/testEigen.chpl
@@ -82,7 +82,7 @@ var cplxA: [1..10, 1..10] complex = A;
   // Where k and u are corresponding eigenvalues and left eigenvectors
   // and ^H means conjugate transpose.
   for (k, i) in zip(eigenvalues, left.domain.dim(1)) {
-    var eigVec:[left.domain.dim(0)] complex = conjg(left[.., i]);
+    var eigVec:[left.domain.dim(0)] complex = conj(left[.., i]);
     var Av = dot(eigVec, cplxA);
     var ku = dot(k, eigVec);
 
@@ -121,7 +121,7 @@ var cplxA: [1..10, 1..10] complex = A;
 
   // u^H * A = k * u^H
   for (k, i) in zip(eigenvalues, left.domain.dim(1)) {
-    var eigVec:[left.domain.dim(0)] complex = conjg(left[.., i]);
+    var eigVec:[left.domain.dim(0)] complex = conj(left[.., i]);
     var Av = dot(eigVec, cplxA);
     var ku = dot(k, eigVec);
 
@@ -208,7 +208,7 @@ fillRandom(B);
   // Where k and u are corresponding eigenvalues and left eigenvectors
   // and ^H means conjugate transpose.
   for (k, i) in zip(eigenvalues, left.domain.dim(1)) {
-    var eigVec:[1..10] complex = conjg(left[.., i]);
+    var eigVec:[1..10] complex = conj(left[.., i]);
     var Bv = dot(eigVec, B);
     var ku = dot(k, eigVec);
 
@@ -247,7 +247,7 @@ fillRandom(B);
 
   // u^H * B = k * u^H
   for (k, i) in zip(eigenvalues, left.domain.dim(1)) {
-    var eigVec:[1..10] complex = conjg(left[.., i]);
+    var eigVec:[1..10] complex = conj(left[.., i]);
     var Bv = dot(eigVec, B);
     var ku = dot(k, eigVec);
 
@@ -365,7 +365,7 @@ proc testEigenvalHerm1(type t) {
                     [+0.49754108324625095552 + 0.10391036719974609152i,
                      +0.40096763363066469802 + 0.24510208283104556075i,
                      +0.72166850550863686527 + 0.0i], eltType=t);
-  var eig0h = conjg(eig0);
+  var eig0h = conj(eig0);
   
   testEighHelper(mat0, true0, eig0h);
 }

--- a/test/library/packages/LinearAlgebra/correctness/dependencies/testLeastSquares.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/dependencies/testLeastSquares.chpl
@@ -82,7 +82,7 @@ use TestUtils;
 /* Compute least squares solution via solve() */
 proc directLeastSquares(a: [], b: [], cmplx=false) {
   var at = a.T;
-  if cmplx then at = conjg(at);
+  if cmplx then at = conj(at);
   var a1 = dot(at, a),
       b1 = dot(at, b);
   return solve(a1, b1);


### PR DESCRIPTION
Avoids the deprecation warning for the old function name
