### PR TITLE
Tune the aggregation buffer size for Slingshot-11

### DIFF
--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -91,7 +91,11 @@ module CopyAggregation {
 
   private config param verboseAggregation = false;
 
-  private param defaultBuffSize = if CHPL_COMM == "ugni" then 4096 else 8192;
+  private param defaultBuffSize =
+    if CHPL_TARGET_PLATFORM == "hpe-cray-ex" then 1024
+    else if CHPL_COMM == "ugni" then 4096
+    else 8192;
+
   private const yieldFrequency = getEnvInt("CHPL_AGGREGATION_YIELD_FREQUENCY", 1024);
   private const dstBuffSize = getEnvInt("CHPL_AGGREGATION_DST_BUFF_SIZE", defaultBuffSize);
   private const srcBuffSize = getEnvInt("CHPL_AGGREGATION_SRC_BUFF_SIZE", defaultBuffSize);


### PR DESCRIPTION
Aggregation performance on Slingshot-11 benefits from smaller buffer sizes. Similar to ugni/Aries, we can reach peak bandwidth rates at a smaller message size so we don't lose out on bandwidth and sending messages sooner allow us to progress remote work faster.

Here's some 256 node indexgather results:

| Buffer size | Performamance  |
| ----------: | -------------: |
|  512        | 6.69 GB/s/node |
| 1024        | 9.68 GB/s/node |
| 2048        | 9.86 GB/s/node |
| 4096        | 9.77 GB/s/node |
| 8192        | 9.14 GB/s/node |

Where 2K performs "best", but 1K isn't far off and I thought the additional savings in memory pressure was worth the tradeoff. We can always continue to tune more in the future, but for now this default is still better than the old 8K default.