### PR TITLE
GPU: Fix running AMD runtime with CHPL_DEVELOPER set.

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -110,7 +110,11 @@ static void chpl_gpu_impl_set_globals(c_sublocid_t dev_id, hipModule_t module) {
   ROCM_CALL(err);
 
   assert(glob_size == sizeof(c_nodeid_t));
-  chpl_gpu_impl_copy_host_to_device((void*)ptr, &chpl_nodeID, glob_size);
+  // chpl_gpu_impl_copy_host_to_device performs a validation using
+  // hipPointerGetAttributes. However, apparently, that's not something you
+  // should call on pointers returned from hipModuleGetGlobal. Just perform
+  // the copy directly.
+  ROCM_CALL(hipMemcpyHtoD(ptr, (void*)&chpl_nodeID, glob_size));
 }
 
 


### PR DESCRIPTION
Today on `main`, we get an error while running any GPU program built for AMD when the runtime was compiled with `CHPL_DEVELOPER=1`. This error is triggered by a `ROCM_CALL` to `hipPointerGetAttributes` inside of an assertion that gets compiled out in release mode. 

The error message is as follows:
```
> start_test test/gpu/native/jacobi/jacobi.chpl 
...
internal error: gpu-amd.c:156: Error calling HIP function: hipErrorInvalidDevice (Code: 101)
```

It appears that the warning is triggered by calling our `host_to_device` copy using a pointer returned from `hipModuleGetGlobal`. Apparently, `hipModuleGetGlobal`'s return value, even though it's a device pointer, is not a valid argument to `hipPointerGetAttributes`. I have verified this by applying the following patch to [the HIP test for `hipModuleGetGlobal`](https://github.com/ROCm-Developer-Tools/HIP/blob/develop/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp):

```diff
diff --git a/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp b/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
index 6d643776..c82d0039 100644
--- a/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
+++ b/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
@@ -75,7 +75,9 @@ int main() {
     float myDeviceGlobal_h = 42.0;
     hipDeviceptr_t deviceGlobal;
     size_t deviceGlobalSize;
+    hipPointerAttribute_t attrs;
     HIP_CHECK(hipModuleGetGlobal(&deviceGlobal, &deviceGlobalSize, Module, "myDeviceGlobal"));
+    HIP_CHECK(hipPointerGetAttributes(&attrs, &deviceGlobal));
     HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(deviceGlobal), &myDeviceGlobal_h, deviceGlobalSize));
 #define ARRAY_SIZE 16
     float myDeviceGlobalArray_h[ARRAY_SIZE];
```

This change made the tests fail on multiple AMD GPU machines I've tested with. 

To address the bug, I simply directly performed the `hipMemcpyHtoD` call, circumventing `impl_copy_host_to_device` and thus the `hipPointerGetAttributes` call.

Reviewed by @ShreyasKhandekar and @stonea -- thanks!

## Testing
- [x] `test/gpu/native` test on AMD.