### PR TITLE
Fix assertVectorized tests

### DIFF
--- a/test/llvm/assertVectorize/SKIPIF
+++ b/test/llvm/assertVectorize/SKIPIF
@@ -2,9 +2,14 @@
 COMPOPTS <= --fast
 # throws off loop attributes
 COMPOPTS <= --baseline
-CHPL_TARGET_COMPILER != llvm
+# mem libcalls throw off opt
+EXECOPTS <= --memLeaks
+# COMM throws off opt
 CHPL_COMM != none
+COMPOPTS <= --no-local
+
 # test only LLVM 14 or greater
+CHPL_TARGET_COMPILER != llvm
 CHPL_LLVM_VERSION==11
 CHPL_LLVM_VERSION==12
 CHPL_LLVM_VERSION==13

--- a/test/llvm/assertVectorize/SKIPIF
+++ b/test/llvm/assertVectorize/SKIPIF
@@ -2,6 +2,8 @@
 COMPOPTS <= --fast
 # throws off loop attributes
 COMPOPTS <= --baseline
+# verify should not affect opt, but test fails with it
+COMPOPTS <= --verify
 # mem libcalls throw off opt
 EXECOPTS <= --memLeaks
 # COMM throws off opt

--- a/test/llvm/assertVectorize/SUPPRESSIF
+++ b/test/llvm/assertVectorize/SUPPRESSIF
@@ -1,0 +1,2 @@
+# verify should not affect opt, but test fails with it
+COMPOPTS <= --verify

--- a/test/llvm/assertVectorize/SUPPRESSIF
+++ b/test/llvm/assertVectorize/SUPPRESSIF
@@ -1,2 +1,0 @@
-# verify should not affect opt, but test fails with it
-COMPOPTS <= --verify

--- a/test/llvm/assertVectorize/assertVectorized.compopts
+++ b/test/llvm/assertVectorize/assertVectorized.compopts
@@ -1,4 +1,4 @@
  # assertVectorized-baseline.good
---fast --no-ieee-float
+--fast --no-ieee-float --mllvm -fno-math-errno
 -g # assertVectorized-debug.good
--g --fast --no-ieee-float
+-g --fast --no-ieee-float --mllvm -fno-math-errno

--- a/test/llvm/assertVectorize/assertVectorized.compopts
+++ b/test/llvm/assertVectorize/assertVectorized.compopts
@@ -1,4 +1,4 @@
  # assertVectorized-baseline.good
---fast --no-ieee-float --mllvm -fno-math-errno
+--fast --no-ieee-float --ccflags -fno-math-errno
 -g # assertVectorized-debug.good
--g --fast --no-ieee-float --mllvm -fno-math-errno
+-g --fast --no-ieee-float --ccflags -fno-math-errno


### PR DESCRIPTION
Add compopts and skipif to assertVectorized test to resolve nightly test issues

[not reviewed - trivial test change]