### PR TITLE
Suppress deprecation test in broken configuration

### DIFF
--- a/test/deprecated/atomic/return-by-ref-array.suppressif
+++ b/test/deprecated/atomic/return-by-ref-array.suppressif
@@ -1,2 +1,3 @@
 # returning an array type by ref causes an internal error, #22685
 CHPL_COMM!=none
+COMPOPTS <= --no-local

--- a/test/deprecated/single/return-by-ref-array.suppressif
+++ b/test/deprecated/single/return-by-ref-array.suppressif
@@ -1,2 +1,3 @@
 # returning an array type by ref causes an internal error, #22685
 CHPL_COMM!=none
+COMPOPTS <= --no-local

--- a/test/deprecated/sync/return-by-ref-array.suppressif
+++ b/test/deprecated/sync/return-by-ref-array.suppressif
@@ -1,2 +1,3 @@
 # returning an array type by ref causes an internal error, #22685
 CHPL_COMM!=none
+COMPOPTS <= --no-local


### PR DESCRIPTION
Running `test/deprecated/[sync/single/atomic]/return-by-ref-array.chpl` in a non-local config causes the test to fail due to a bug

Bug: https://github.com/chapel-lang/chapel/issues/22685

[Not reviewed - trivial test change]