### PR TITLE
Number of GPU radix sort kernels by mem strategy

### DIFF
--- a/test/gpu/native/studies/sort/radixSortGpu.chpl
+++ b/test/gpu/native/studies/sort/radixSortGpu.chpl
@@ -274,13 +274,13 @@ module SortTest {
       if verboseGpu then
         stopVerboseGpu();
       if scanType == "hillisSteele" then
-        assertGpuDiags(kernel_launch=76, host_to_device=12,device_to_host=8,
+        assertGpuDiags(kernel_launch_aod=76, kernel_launch_um=72, host_to_device=12,device_to_host=8,
                                                       device_to_device=72);
       else if scanType == "blelloch" then
-        assertGpuDiags(kernel_launch=136, host_to_device=12,device_to_host=8,
+        assertGpuDiags(kernel_launch_aod=136, kernel_launch_um=132, host_to_device=12,device_to_host=8,
                                                       device_to_device=128);
       else if scanType == "serial" then
-        assertGpuDiags(kernel_launch=8, host_to_device=4,device_to_host=4,
+        assertGpuDiags(kernel_launch_aod=8, kernel_launch_um=4, host_to_device=4,device_to_host=4,
                                                       device_to_device=0);
 
     }


### PR DESCRIPTION
The number of kernels launched differs based on the memory strategy used in radix sort. Array on device has 4 more kernels used in bulk copies. Modified the assertGpuDiags so nightly testing works.

No other tests impacted.