### PR TITLE
Add support for multi-arch GPU executables for Nvidia

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -261,12 +261,12 @@ extern int breakOnID;
 extern int breakOnRemoveID;
 
 extern int fGPUBlockSize;
-const int gpuArchNameLen = 16;
+const int gpuArchNameLen = 256;
 extern char fGpuArch[gpuArchNameLen+1];
 extern bool fGpuPtxasEnforceOpt;
 extern bool fGpuSpecialization;
 extern const char* gGpuSdkPath;
-extern char gpuArch[gpuArchNameLen+1];
+extern std::unordered_set<std::string> gpuArches;
 
 extern char stopAfterPass[128];
 

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -266,7 +266,7 @@ extern char fGpuArch[gpuArchNameLen+1];
 extern bool fGpuPtxasEnforceOpt;
 extern bool fGpuSpecialization;
 extern const char* gGpuSdkPath;
-extern std::unordered_set<std::string> gpuArches;
+extern std::set<std::string> gpuArches;
 
 extern char stopAfterPass[128];
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2831,9 +2831,6 @@ void runClang(const char* just_parse_filename) {
     // Need to select CUDA/AMD mode in embedded clang to
     // activate the GPU target
     splitStringWhitespace(generateClangGpuLangArgs(), clangOtherArgs);
-
-    std::string archFlag = std::string("--offload-arch=") + gpuArch;
-    clangOtherArgs.push_back(archFlag);
   }
 
   // Always include sys_basic because it might change the
@@ -4213,14 +4210,14 @@ static void linkBitCodeFile(const char *bitCodeFilePath) {
                             llvm::Linker::Flags::LinkOnlyNeeded);
 }
 
-static std::string determineOclcVersionLib(std::string libPath) {
+static std::string determineOclcVersionLib(std::string libPath, const std::string& gpuArch) {
   std::string result;
 
   // Extract version number from gpuArch string (e.g. extract
   // the 908 from "gfx908")
   std::regex pattern("[[:alpha:]]+([[:digit:]]+[[:alpha:]]?)");
   std::cmatch match;
-  if (std::regex_search(gpuArch, match, pattern)) {
+  if (std::regex_search(gpuArch.c_str(), match, pattern)) {
     result = libPath + "/oclc_isa_version_" + std::string(match[1]) + ".bc";
   } else {
     USR_FATAL("Unable to determine oclc version from gpuArch");
@@ -4266,7 +4263,9 @@ static void linkGpuDeviceLibraries() {
     linkBitCodeFile((libPath + "/oclc_finite_only_off.bc").c_str());
     linkBitCodeFile((libPath + "/oclc_correctly_rounded_sqrt_on.bc").c_str());
     linkBitCodeFile((libPath + "/oclc_wavefrontsize64_on.bc").c_str());
-    linkBitCodeFile(determineOclcVersionLib(libPath).c_str());
+    for (auto gpuArch : gpuArches) {
+      linkBitCodeFile(determineOclcVersionLib(libPath, gpuArch).c_str());
+    }
   }
 
   // internalize all functions that are not in `externals`
@@ -4546,27 +4545,36 @@ static void makeBinaryLLVMForCUDA(const std::string& artifactFilename,
   // avoid warning about not statically knowing the stack size when recursive
   // functions are called from the kernel
   ptxasFlags += " --suppress-stack-size-warning ";
-  std::string ptxCmd = std::string("ptxas -m64 --gpu-name ") + gpuArch +
-                       " " + ptxasFlags + " " +
-                       std::string(" --output-file ") +
-                       gpuObjectFilename.c_str() +
-                       " " + artifactFilename.c_str();
 
-  mysystem(ptxCmd.c_str(), "PTX to  object file");
+  // Run ptxas for each architecture
+  std::string profiles;
+  for (auto& gpuArch : gpuArches) {
+    // Figure out the corresponding compute capability and object name
+    if (strncmp(gpuArch.c_str(), "sm_", 3) != 0 || gpuArch.size() != 5) {
+      USR_FATAL("Unrecognized CUDA arch");
+    }
+    std::string computeCap = std::string("compute_") + gpuArch[3] + gpuArch[4];
+    std::string gpuObject = gpuObjectFilename + "_" + gpuArch + ".o";
 
-  if (strncmp(gpuArch, "sm_", 3) != 0 || strlen(gpuArch) != 5) {
-    USR_FATAL("Unrecognized CUDA arch");
+    // Execute the assembler for this architecture
+    std::string ptxCmd = std::string("ptxas -m64 --gpu-name ") + gpuArch +
+                         " " + ptxasFlags + " " +
+                         std::string(" --output-file ") +
+                         gpuObjectFilename.c_str() +
+                         " " + artifactFilename.c_str();
+    mysystem(ptxCmd.c_str(), "PTX to object file");
+
+    // Track the new object we created and the CC we enabled.
+    profiles += std::string(" --image=profile=") + computeCap +
+                ",file=" + artifactFilename;
+    profiles += std::string(" --image=profile=") + gpuArch +
+                ",file=" + gpuObject;
   }
 
-  std::string computeCap = std::string("compute_") + gpuArch[3] +
-                                                     gpuArch[4];
   std::string fatbinaryCmd = std::string("fatbinary -64 ") +
                              std::string("--create ") +
                              fatbinFilename.c_str() +
-                             std::string(" --image=profile=") + gpuArch +
-                             ",file=" + gpuObjectFilename.c_str() +
-                             std::string(" --image=profile=") + computeCap +
-                             ",file=" + artifactFilename.c_str();
+                             profiles;
   mysystem(fatbinaryCmd.c_str(), "object file to fatbinary");
 }
 
@@ -4575,30 +4583,42 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
                                  const std::string& outFilename,
                                  const std::string& fatbinFilename)
 {
-  std::string asmCmd = findSiblingClangToolPath("llvm-mc") + " " +
-                       "--filetype=obj " +
-                       "--triple=amdgcn-amd-amdhsa --mcpu=" + gpuArch + " " +
-                       artifactFilename + " " +
-                       "-o " + gpuObjFilename;
-  std::string lldCmd = std::string(gGpuSdkPath) +
-                      "/llvm/bin/lld -flavor gnu" +
-                       " --no-undefined -shared" +
-                       " -plugin-opt=-amdgpu-internalize-symbols" +
-                       " -plugin-opt=mcpu=" + gpuArch +
-                       " -plugin-opt=O3" +
-                       " -plugin-opt=-amdgpu-early-inline-all=true" +
-                       " -plugin-opt=-amdgpu-function-calls=false -o " +
-                       outFilename + " " + gpuObjFilename;
+  std::string targets;
+  std::string inputs;
+  for (auto& gpuArch : gpuArches) {
+    std::string gpuObject = gpuObjFilename + "_" + gpuArch + ".o";
+    std::string gpuOut = outFilename + "_" + gpuArch + ".out";
+
+    std::string asmCmd = findSiblingClangToolPath("llvm-mc") + " " +
+                         "--filetype=obj " +
+                         "--triple=amdgcn-amd-amdhsa --mcpu=" + gpuArch + " " +
+                         artifactFilename + " " +
+                         "-o " + gpuObject;
+    std::string lldCmd = std::string(gGpuSdkPath) +
+                        "/llvm/bin/lld -flavor gnu" +
+                         " --no-undefined -shared" +
+                         " -plugin-opt=-amdgpu-internalize-symbols" +
+                         " -plugin-opt=mcpu=" + gpuArch +
+                         " -plugin-opt=O3" +
+                         " -plugin-opt=-amdgpu-early-inline-all=true" +
+                         " -plugin-opt=-amdgpu-function-calls=false -o " +
+                         gpuOut + " " + gpuObject;
+    mysystem(asmCmd.c_str(), "Assembly to .o file");
+    mysystem(lldCmd.c_str(), "Device .o file to .out file");
+
+    targets += std::string(",hipv4-amdgcn-amd-amdhsa--") + gpuArch;
+    inputs += std::string(",") + gpuOut;
+
+  }
   std::string bundlerCmd = std::string(gGpuSdkPath) +
                           "/llvm/bin/clang-offload-bundler" +
                            " -type=o -bundle-align=4096" +
-                           " -targets=host-x86_64-unknown-linux," +
-                           "hipv4-amdgcn-amd-amdhsa--" + gpuArch +
-                           " -inputs=/dev/null," + outFilename +
+                           " -targets=host-x86_64-unknown-linux" +
+                           targets +
+                           " -inputs=/dev/null" +
+                           inputs +
                            " -outputs=" + fatbinFilename;
 
-  mysystem(asmCmd.c_str(), "Assembly to .o file");
-  mysystem(lldCmd.c_str(), "Device .o file to .out file");
   mysystem(bundlerCmd.c_str(), ".out file to fatbin file");
 }
 
@@ -4712,9 +4732,11 @@ void makeBinaryLLVM(void) {
     preOptFilename = genIntermediateFilename("chpl__gpu_module-nopt.bc");
     opt1Filename = genIntermediateFilename("chpl__gpu_module-opt1.bc");
     opt2Filename = genIntermediateFilename("chpl__gpu_module-opt2.bc");
-    gpuObjectFilename = genIntermediateFilename("chpl__gpu.o");
     fatbinFilename = genIntermediateFilename("chpl__gpu.fatbin");
-    outFilename = genIntermediateFilename("chpl__gpu.out");
+
+    outFilename = genIntermediateFilename("chpl__gpu");
+    gpuObjectFilename = genIntermediateFilename("chpl__gpu");
+    // no .o suffix on that last two because we might generate multiple
 
     // This switch may seem unnecessary, but in the past we wanted to use a
     // different "type" of intermediate file for different GPUs and we may want

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4560,7 +4560,7 @@ static void makeBinaryLLVMForCUDA(const std::string& artifactFilename,
     std::string ptxCmd = std::string("ptxas -m64 --gpu-name ") + gpuArch +
                          " " + ptxasFlags + " " +
                          std::string(" --output-file ") +
-                         gpuObjectFilename.c_str() +
+                         gpuObject.c_str() +
                          " " + artifactFilename.c_str();
     mysystem(ptxCmd.c_str(), "PTX to object file");
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2832,7 +2832,7 @@ void runClang(const char* just_parse_filename) {
     // activate the GPU target
     splitStringWhitespace(generateClangGpuLangArgs(), clangOtherArgs);
 
-    if (gpuArches.size() == 1) {
+    if (gpuArches.size() >= 1) {
       std::string archFlag = std::string("--offload-arch=") + *gpuArches.begin();
       clangOtherArgs.push_back(archFlag);
     }

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2831,6 +2831,11 @@ void runClang(const char* just_parse_filename) {
     // Need to select CUDA/AMD mode in embedded clang to
     // activate the GPU target
     splitStringWhitespace(generateClangGpuLangArgs(), clangOtherArgs);
+
+    if (gpuArches.size() == 1) {
+      std::string archFlag = std::string("--offload-arch=") + *gpuArches.begin();
+      clangOtherArgs.push_back(archFlag);
+    }
   }
 
   // Always include sys_basic because it might change the
@@ -4583,6 +4588,11 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
                                  const std::string& outFilename,
                                  const std::string& fatbinFilename)
 {
+  // Note: this is currently implemented as a loop over all the specified
+  // GPU architectures. However, at present, we don't have a good way to
+  // generate artifacts per-target to be fed to llvm-mc and clang-offload-bundler.
+  // So this loop should run exactly one iteration.
+
   std::string targets;
   std::string inputs;
   for (auto& gpuArch : gpuArches) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1507,9 +1507,13 @@ static void populateEnvMap() {
 
   // Call printchplenv and collect output into a map
   auto chplEnvResult = chpl::getChplEnv(envMap, CHPL_HOME);
-  if (auto err = chplEnvResult.getError()) {
-    USR_FATAL("failed to get output from printchplenv, error: %s",
-              err.message().c_str());
+  if (!chplEnvResult) {
+    if (auto err = chplEnvResult.getError()) {
+      USR_FATAL("failed to get output from printchplenv, error: %s",
+                err.message().c_str());
+    } else {
+      USR_FATAL("failed to get output from printchplenv");
+    }
   }
 
   // figure out if it's a Cray programing environment so we can infer

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1509,10 +1509,10 @@ static void populateEnvMap() {
   auto chplEnvResult = chpl::getChplEnv(envMap, CHPL_HOME);
   if (!chplEnvResult) {
     if (auto err = chplEnvResult.getError()) {
-      USR_FATAL("failed to get output from printchplenv, error: %s",
+      USR_FATAL("failed to get environment settings (error while running printchplenv: %s)",
                 err.message().c_str());
     } else {
-      USR_FATAL("failed to get output from printchplenv");
+      USR_FATAL("failed to get environment settings");
     }
   }
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1703,8 +1703,8 @@ static void populateGpuArches(const char* from) {
   buffer[gpuArchNameLen] = '\0';
 
   std::vector<std::string> into;
-  splitString(std::string(from), into, ",");
-  for (auto& str : into ){
+  splitString(std::string(buffer), into, ",");
+  for (auto& str : into){
     gpuArches.insert(str);
   }
 }
@@ -1742,7 +1742,7 @@ static void setGPUFlags() {
                   "for more information");
       }
       else {
-        populateGpuArches(fGpuArch);
+        populateGpuArches(CHPL_GPU_ARCH);
       }
     }
   }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -366,7 +366,7 @@ char fGpuArch[gpuArchNameLen+1] = "";
 bool fGpuPtxasEnforceOpt;
 bool fGpuSpecialization = false;
 const char* gGpuSdkPath = NULL;
-std::unordered_set<std::string> gpuArches;
+std::set<std::string> gpuArches;
 
 chpl::Context* gContext = nullptr;
 std::vector<std::pair<std::string, std::string>> gDynoParams;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -366,7 +366,7 @@ char fGpuArch[gpuArchNameLen+1] = "";
 bool fGpuPtxasEnforceOpt;
 bool fGpuSpecialization = false;
 const char* gGpuSdkPath = NULL;
-char gpuArch[gpuArchNameLen+1] = "";
+std::unordered_set<std::string> gpuArches;
 
 chpl::Context* gContext = nullptr;
 std::vector<std::pair<std::string, std::string>> gDynoParams;
@@ -1695,6 +1695,20 @@ static void setPrintCppLineno() {
   if (developer && !userSetCppLineno) printCppLineno = false;
 }
 
+static void populateGpuArches(const char* from) {
+  // using memcpy and setting the null byte to avoid errors from older
+  // GCCs
+  char buffer[gpuArchNameLen+1];
+  memcpy(buffer, from, gpuArchNameLen);
+  buffer[gpuArchNameLen] = '\0';
+
+  std::vector<std::string> into;
+  splitString(std::string(from), into, ",");
+  for (auto& str : into ){
+    gpuArches.insert(str);
+  }
+}
+
 static void setGPUFlags() {
   if(usingGpuLocaleModel()) {
     if (fWarnUnstable) {
@@ -1719,9 +1733,7 @@ static void setGPUFlags() {
     //
     // set up gpuArch
     if (strlen(fGpuArch) > 0) {
-      // using memcpy and setting the null byte to avoid errors from older GCCs
-      memcpy(gpuArch, fGpuArch, gpuArchNameLen);
-      gpuArch[gpuArchNameLen] = 0;
+      populateGpuArches(fGpuArch);
     }
     else {
       if (CHPL_GPU_ARCH != nullptr && strlen(CHPL_GPU_ARCH) == 0) {
@@ -1730,10 +1742,7 @@ static void setGPUFlags() {
                   "for more information");
       }
       else {
-        // using memcpy and setting the null byte to avoid errors from older
-        // GCCs
-        memcpy(gpuArch, CHPL_GPU_ARCH, gpuArchNameLen);
-        gpuArch[gpuArchNameLen] = 0;
+        populateGpuArches(fGpuArch);
       }
     }
   }

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -218,6 +218,12 @@ values (see the "processor" column). For NVIDIA, see the `CUDA Programming
 Guide
 <https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications>`_.
 
+For NVIDIA, the ``CHPL_GPU_ARCH`` variable can also be set to a comma-separated
+list. This causes the Chapel compiler to generate device code for each of the
+given compute capabilities, and to bundle the different versions in a single
+executable. When the program is executed, the compute capability best suited
+for the available GPU will be loaded by the CUDA runtime. Support for this
+feature for AMD GPUs is planned, but not currently available.
 
 CPU as Device Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -412,6 +418,9 @@ improvements in the future.
 * Intel GPUs are not supported, yet.
 
 * For AMD GPUs:
+
+    * It's not currently possible to compile for multiple AMD GPU architectures
+      at the same time.
 
     * Certain 64-bit math functions are unsupported. To see what does
       and doesn't work see `this test

--- a/frontend/lib/util/chplenv.cpp
+++ b/frontend/lib/util/chplenv.cpp
@@ -75,9 +75,9 @@ getChplEnvImpl(const InputMap& varMap,
   command += std::string(chplHome) + "/util/printchplenv --all --internal --no-tidy --simple";
 
   auto commandOutput = getCommandOutput(command);
-  if (auto err = commandOutput.getError()) {
+  if (!commandOutput) {
     // forward error code
-    return err;
+    return commandOutput.getError();
   }
   ChplEnvMap result;
   parseChplEnv(commandOutput.get(), result);

--- a/test/gpu/native/.gitignore
+++ b/test/gpu/native/.gitignore
@@ -1,0 +1,1 @@
+savec.good

--- a/test/gpu/native/savec.base.good
+++ b/test/gpu/native/savec.base.good
@@ -1,5 +1,4 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 0 1 2 3 4 5 6 7 8 9
-savec_dir/chpl__gpu.o
 savec_dir/chpl__gpu.s
 savec_dir/chpl__module.o

--- a/test/gpu/native/savec.precomp
+++ b/test/gpu/native/savec.precomp
@@ -1,0 +1,9 @@
+#!/bin/bash
+gpuArch=$($CHPL_HOME/util/printchplenv --all --internal --simple | grep CHPL_GPU_ARCH | cut -d '=' -f 2)
+cp $1.base.good $1.good
+rm -f $1.gen.good
+for arch in ${gpuArch//,/ }; do
+    echo "savec_dir/chpl__gpu_$arch.o" >> $1.gen.good
+done
+sort < $1.gen.good >> $1.good
+rm $1.gen.good

--- a/test/gpu/native/savec.prediff
+++ b/test/gpu/native/savec.prediff
@@ -2,4 +2,5 @@
 
 # Get list of all .o and .s files. Exclude 'savec.tmp_launcher.o' since we want this test
 # to pass regardless of whether a launcher is being used or not.
-find savec_dir -type f -name "*.o" -o -name "*.s" | grep -v "savec\.tmp_launcher\.o" | sort >> $2
+find savec_dir -type f -name "*.o" -o -name "*.s" | grep -v -e "savec\.tmp_launcher\.o" -e "chpl__gpu.\+\.o" | sort >> $2
+find savec_dir -type f -name "chpl__gpu_*.o" | sort >> $2

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -105,6 +105,11 @@ def get_arch():
     # Check if user is overriding the arch.
     arch = os.environ.get("CHPL_GPU_ARCH")
     if arch:
+        # arch might be specified in arch1,arch2 format, which is only supported
+        # on nvidia.
+        if len(arch.split(",")) > 1 and gpu_type != "nvidia":
+            error("Multi-target builds are only supported for the 'nvidia' GPU type.")
+
         return arch
 
     # Return vendor-specific default architecture


### PR DESCRIPTION
This PR allows the `CHPL_GPU_ARCH` variable to specify a comma-separated list, thereby allowing a user to request an executable to be built for multiple GPU architectures. It also modifies the clang driver code to support building multi-architecture objects, by invoking the assembler multiple times and giving more arguments to the platform-specific bundler.

However, thus approach currently relies on the ability to re-assemble a single file generated by clang (`.ptx` or `.S`) into multiple specialized object files for different architectures. Unfortunately, although this is possible for Nvidia, the assembly files generated by Clang for AMD (especially without a `--offload-arch` argument) are not compatible between different GPU architectures. It seems like the proper approach in this situation is to get Clang to generate multiple object / assembly files, one per device architecture; however, this has turned out to be very difficult due to some global state in the Chapel compiler and LLVM that I have not yet been able to track down. 

Therefore, although the code makes changes to support multi-device compilation on both AMD and NVIDIA (including changing the processing code for AMD into a loop over architectures), it explicitly constrains AMD builds to have only one target architecture. Thus, AMD support is not fleshed out, but if we were to at some point wrangle Clang into generating multiple assembly files, the code modified by this PR should work as is (and symmetric between AMD and NVIDIA). 

The code also slightly modifies `driver.cpp` to handle the case where `printchplenv` throws an error. Currently, the "AMD can only have one target architecture" invariant is checked by `printchplenv`, which means we need to gracefully forward that error to the output of `chpl`. 

Reviewed by @stonea -- thanks!

## Testing
- [x] builds AMD executables still
- [x] `test/gpu/native` with NVidia
- [x] paratest  