### PR TITLE
Fix failing gpu tests from ref-maybe-const deprecation

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -145,7 +145,7 @@ module GPU
     until completion of this asynchronous transfer
   */
   @chpldoc.nodoc
-  proc asyncGpuComm(dstArr : ?t1, srcArr : ?t2) : GpuAsyncCommHandle
+  proc asyncGpuComm(ref dstArr : ?t1, srcArr : ?t2) : GpuAsyncCommHandle
     where isArrayType(t1) && isArrayType(t2)
   {
     extern proc chpl_gpu_comm_async(dstArr : c_ptr(void), srcArr : c_ptr(void),
@@ -155,7 +155,7 @@ module GPU
       halt("Arrays passed to asyncGpuComm must have the same number of elements. ",
         "Sizes passed: ", dstArr.size, " and ", srcArr.size);
     }
-    return chpl_gpu_comm_async(c_ptrTo(dstArr), c_ptrTo(srcArr),
+    return chpl_gpu_comm_async(c_ptrTo(dstArr), c_ptrToConst(srcArr),
       dstArr.size * numBytes(dstArr.eltType));
   }
 

--- a/test/gpu/native/noGPUPragma.chpl
+++ b/test/gpu/native/noGPUPragma.chpl
@@ -2,7 +2,7 @@ use GpuDiagnostics;
 
 config param useForall = false;
 
-proc yepGPU(A) {
+proc yepGPU(ref A) {
   if useForall then
     forall a in A do a += 1;
   else
@@ -16,7 +16,7 @@ proc yepGPU(A) {
 // Another way to put it is that, this pragma only applies to order-independent
 // loops within this function's body.
 pragma "no gpu codegen"
-proc nopeGPU(A) {
+proc nopeGPU(ref A) {
   if useForall then
     forall a in A do a += 1;
   else

--- a/test/gpu/native/streamPrototype/stream.chpl
+++ b/test/gpu/native/streamPrototype/stream.chpl
@@ -131,7 +131,7 @@ proc printConfiguration() {
 // Initialize vectors B and C using a random stream of values and
 // optionally print them to the console
 //
-proc initVectors(B, C) {
+proc initVectors(ref B, ref C) {
   /*
 
   TODO: fillRandom has a `forall`. We either need dynamic check and this
@@ -155,7 +155,7 @@ proc initVectors(B, C) {
 //
 // Verify that the computation is correct
 //
-proc verifyResults(A, B, C) {
+proc verifyResults(A, ref B, C) {
   if (printArrays) then writeln("A is:     ", A, "\n");  // optionally print A
 
   //

--- a/test/gpu/native/studies/coral/coral.chpl
+++ b/test/gpu/native/studies/coral/coral.chpl
@@ -27,7 +27,7 @@ config const verbose_gpu = false;
 //var bs = 1;
 //var be = 5;
 
-proc convolve_and_calculate(Array: [] real(32), const in centerPoints : ?, locL : ?, locC : ?, locR : ?, Output: [] real(64), t: stopwatch) : [] {
+proc convolve_and_calculate(Array: [] real(32), const in centerPoints : ?, locL : ?, locC : ?, locR : ?, ref Output: [] real(64), t: stopwatch) : [] {
 
   param bs = 1;
   param be = 5;

--- a/test/gpu/native/studies/sort/radixSortGpu.chpl
+++ b/test/gpu/native/studies/sort/radixSortGpu.chpl
@@ -137,7 +137,7 @@ module RadixSort {
       writeln("Pf sum: ",count);
   }
 
-  proc radixSort(inputArr: [] uint){
+  proc radixSort(ref inputArr: [] uint){
     if (noisy){
         writeln("Bits at a time: ", bitsAtATime);
         writeln("Buckets: ", buckets);

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -28,14 +28,14 @@ config param blockSize = 16;
 config param blockPadding = 1;
 config type dataType = real(32);
 
-inline proc transposeNaive(original, output) {
+inline proc transposeNaive(original, ref output) {
   @assertOnGpu
   foreach (x,y) in original.domain {
     output[y,x] = original[x,y];
   }
 }
 
-inline proc transposeClever(original, output) {
+inline proc transposeClever(original, ref output) {
   @assertOnGpu
   foreach 0..<original.size {
     setBlockSize(blockSize * blockSize);
@@ -108,12 +108,12 @@ export proc transposeMatrix(odata: c_ptr(dataType), idata: c_ptr(dataType), widt
   }
 }
 
-inline proc transposeLowLevel(original, output) {
+inline proc transposeLowLevel(original, ref output) {
   __primitive("gpu kernel launch",
           "transposeMatrix":chpl_c_string,
           /* grid size */  sizeX / blockSize, sizeY / blockSize, 1,
           /* block size */ blockSize, blockSize, 1,
-          /* kernel args */ c_ptrTo(output), c_ptrTo(original), sizeX, sizeY);
+          /* kernel args */ c_ptrTo(output), c_ptrToConst(original), sizeX, sizeY);
 }
 
 var originalHost: [0..#sizeX, 0..#sizeY] dataType;


### PR DESCRIPTION
fixes failing tests by adding `ref` where needed in gpu tests.

ref-maybe-const was deprecated in #22958. Array formals can no longer be modified with the default intent, an explicit `ref` must now be supplied. This cascades to other functions that may require a `ref` like `c_ptrTo`.

Tested with `CHPL_GPU=cpu`

Note that `test/gpu/native/studies/sort/radixSortGpu` will not be fully fixed due to prior issue.

[Reviewed by @DanilaFe]
