### PR TITLE
Unstabilize `list.sort`

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -38,7 +38,7 @@
       - remove
       - pop
       - clear
-      - sort (*unstable*)
+      - sort
 
   Additionally, all references to list elements are invalidated when the list
   is deinitialized.

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -36,9 +36,9 @@
 
       - insert
       - remove
-      - sort
       - pop
       - clear
+      - sort (*unstable*)
 
   Additionally, all references to list elements are invalidated when the list
   is deinitialized.
@@ -1563,6 +1563,7 @@ module List {
 
       :arg comparator: A comparator used to sort this list.
     */
+    @unstable("'list.sort' is unstable and may be replaced or modified in a future release")
     proc ref sort(comparator: ?rec=Sort.defaultComparator) {
       on this {
         _enter();

--- a/test/release/examples/primers/listOps.chpl
+++ b/test/release/examples/primers/listOps.chpl
@@ -61,7 +61,7 @@ coforall tid in 0..3 with (ref lst2) {
   order. The contents of ``lst2`` might be out of order even though our loop
   size is small (only 4 tasks).
 
-  We can call ``list.sort()`` (*unstable*) on our list to be on the safe side.
+  We can call :proc:`~List.list.sort()` on our list to be on the safe side.
 */
 
 if !quiet then

--- a/test/release/examples/primers/listOps.chpl
+++ b/test/release/examples/primers/listOps.chpl
@@ -61,7 +61,7 @@ coforall tid in 0..3 with (ref lst2) {
   order. The contents of ``lst2`` might be out of order even though our loop
   size is small (only 4 tasks).
 
-  We can call ``list.sort()`` on our list to be on the safe side.
+  We can call ``list.sort()`` (*unstable*) on our list to be on the safe side.
 */
 
 if !quiet then

--- a/test/unstable/listSort.chpl
+++ b/test/unstable/listSort.chpl
@@ -1,0 +1,5 @@
+use List;
+
+var l = new list([4, 8, 2, 1, 7, 3, 9, 6, 5]);
+l.sort();
+writeln(l);

--- a/test/unstable/listSort.good
+++ b/test/unstable/listSort.good
@@ -1,0 +1,2 @@
+listSort.chpl:4: warning: 'list.sort' is unstable and may be replaced or modified in a future release
+[1, 2, 3, 4, 5, 6, 7, 8, 9]


### PR DESCRIPTION
The sort method on list did not make it into 2.0 stability discussions. The symbol will be marked unstable for now.

See related discussion here: https://github.com/chapel-lang/chapel/issues/18100

- [x] paratest
- [x] inspected docs
