### PR TITLE
Fix python interop with ref-maybe-const

### DIFF
--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -120,14 +120,14 @@ module ExternalArray {
     return ret;
   }
 
-  proc convertStringOrBytes(arr: []): chpl_external_array
+  proc convertStringOrBytes(ref arr: []): chpl_external_array
     where arr.eltType == string || arr.eltType == bytes {
 
     var wrapper: [arr.domain] chpl_byte_buffer;
 
     // Move existing string buffers over to a new shell.
     for i in 0..#arr.size {
-      const ref item = arr[i];
+      ref item = arr[i];
 
       // This call assumes ownership of the string's buffer.
       var val = chpl__exportRetStringOrBytes(item);

--- a/test/interop/python/arrayOpaquePointer_block.chpl
+++ b/test/interop/python/arrayOpaquePointer_block.chpl
@@ -21,6 +21,6 @@ export proc printBlock(x: [D] int) {
   writeln(output);
 }
 
-export proc addEltBlock(x: [D] int, idx: int, val: int) {
+export proc addEltBlock(ref x: [D] int, idx: int, val: int) {
   x[idx] = val;
 }

--- a/test/interop/python/arrayOpaquePointer_block_with.chpl
+++ b/test/interop/python/arrayOpaquePointer_block_with.chpl
@@ -21,6 +21,6 @@ export proc printBlock(x: [D] int) {
   writeln(output);
 }
 
-export proc addEltBlock(x: [D] int, idx: int, val: int) {
+export proc addEltBlock(ref x: [D] int, idx: int, val: int) {
   x[idx] = val;
 }


### PR DESCRIPTION
Fix issues missed with ref-maybe-const deprecation (https://github.com/chapel-lang/chapel/pull/22958). We now require `ref` to be used when modifying an array

Added `ref` where needed in python interop tests

[Not reviewed - trivial test change]