### PR TITLE
Handle outer ref variables properly in GPU kernels

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5267,12 +5267,12 @@ static GenRet codegenGPUKernelLaunch(CallExpr* call, bool is3d) {
       Type* actualValType = actual->typeInfo()->getValType();
 
       // TODO can we use codegenArgForFormal instead of this logic?
-      if (isClass(actualValType) || !isAggregateType(actualValType)) {
+      if (isClass(actualValType) || (!actualSym->isRef() &&
+                                     !isAggregateType(actualValType))) {
         args.push_back(codegenAddrOf(codegenValuePtr(actual)));
         args.push_back(new_IntSymbol(0));
       }
       else if (actualSym->isRef()) {
-        INT_ASSERT(isAggregateType(actualValType));
         args.push_back(actual->codegen());
         args.push_back(codegenSizeof(actual->typeInfo()->getValType()));
       }

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -801,7 +801,8 @@ void GpuKernel::buildStubOutlinedFunction(DefExpr* insertionPoint) {
 
 Symbol* GpuKernel::addKernelArgument(Symbol* symInLoop) {
   Type* symType = symInLoop->typeInfo();
-  ArgSymbol* newFormal = new ArgSymbol(INTENT_IN, symInLoop->name, symType);
+  IntentTag intent = symInLoop->isRef() ? INTENT_REF : INTENT_IN;
+  ArgSymbol* newFormal = new ArgSymbol(intent, symInLoop->name, symType);
   fn_->insertFormalAtTail(newFormal);
 
   kernelActuals_.push_back(symInLoop);

--- a/test/gpu/native/basics/README
+++ b/test/gpu/native/basics/README
@@ -1,0 +1,4 @@
+This directory is to contain tests for fundamental operations like being able to
+launch kernels, pass arguments correctly and simple data movement. I am hoping
+that we can do a test rearrangement soon to move more of the existing tests into
+this directory.

--- a/test/gpu/native/basics/bug23045.chpl
+++ b/test/gpu/native/basics/bug23045.chpl
@@ -1,0 +1,30 @@
+// this code is from https://github.com/chapel-lang/chapel/issues/23045 verbatim
+// the bug reported will be resolved via
+// https://github.com/chapel-lang/chapel/pull/23048
+
+use GPU;
+use CTypes;
+
+extern {
+  static __device__ __host__ void printInt(int x) {
+    printf("%d\n", x);
+  }
+}
+
+pragma "codegen for GPU"
+pragma "always resolve function"
+extern proc printInt(x : c_int);
+
+proc testValue(){
+  var exp = 1234;
+
+  on here.gpus[0]{
+    @assertOnGpu
+    foreach i in 0 .. 0 {
+      printInt(exp:c_int); // prints garbage value
+    }
+  }
+  exp = exp + 1; // Without this line there's no error and the printInt function prints the right value
+}
+
+testValue();

--- a/test/gpu/native/basics/bug23045.good
+++ b/test/gpu/native/basics/bug23045.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+1234

--- a/test/gpu/native/basics/outerRef.chpl
+++ b/test/gpu/native/basics/outerRef.chpl
@@ -11,8 +11,9 @@ use GPU;
 
       writeln(A);
     }
-    exp = exp + 1; // Without this line there's no error, otherwise we used to get
-                   // garbage
+    exp = exp + 1; // Without this line there's no error because exp will be
+                   // RVFed, otherwise we used to get garbage because it is a
+                   // ref
   }
 
   testValue();
@@ -31,8 +32,9 @@ use GPU;
 
       writeln(A);
     }
-    exp = exp + 1; // Without this line there's no error, otherwise we used to get
-                   // garbage
+    exp = exp + 1; // Without this line there's no error because exp will be
+                   // RVFed, otherwise we used to get garbage because it is a
+                   // ref
   }
 
   testValue();
@@ -51,8 +53,9 @@ use GPU;
 
       writeln(A);
     }
-    exp = exp + 1; // Without this line there's no error, otherwise we used to get
-                   // garbage
+    exp = exp + 1; // Without this line there's no error because exp will be
+                   // RVFed, otherwise we used to get garbage because it is a
+                   // ref
   }
 
   testValue();

--- a/test/gpu/native/basics/outerRef.chpl
+++ b/test/gpu/native/basics/outerRef.chpl
@@ -1,0 +1,59 @@
+use GPU;
+
+{
+  proc testValue(){
+    var exp = 1234;
+
+    on here.gpus[0]{
+      var A: [0..0] int;
+      @assertOnGpu
+      foreach a in A do a = exp;
+
+      writeln(A);
+    }
+    exp = exp + 1; // Without this line there's no error, otherwise we used to get
+                   // garbage
+  }
+
+  testValue();
+}
+
+{
+  proc testValue(){
+    var exp = 1234;
+
+    ref rExp = exp;
+
+    on here.gpus[0]{
+      var A: [0..0] int;
+      @assertOnGpu
+      foreach a in A do a = rExp;
+
+      writeln(A);
+    }
+    exp = exp + 1; // Without this line there's no error, otherwise we used to get
+                   // garbage
+  }
+
+  testValue();
+}
+
+{
+  proc testValue(){
+    var exp = 1234;
+
+
+    on here.gpus[0]{
+      var A: [0..0] int;
+      ref rExp = exp;
+      @assertOnGpu
+      foreach a in A do a = rExp;
+
+      writeln(A);
+    }
+    exp = exp + 1; // Without this line there's no error, otherwise we used to get
+                   // garbage
+  }
+
+  testValue();
+}

--- a/test/gpu/native/basics/outerRef.good
+++ b/test/gpu/native/basics/outerRef.good
@@ -1,0 +1,4 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+1234
+1234
+1234

--- a/test/gpu/native/basics/outerRefFuture.bad
+++ b/test/gpu/native/basics/outerRefFuture.bad
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+10

--- a/test/gpu/native/basics/outerRefFuture.chpl
+++ b/test/gpu/native/basics/outerRefFuture.chpl
@@ -1,0 +1,16 @@
+config const n = 100;
+on here.gpus[0] {
+  var x = 10;
+  var A: [1..n] int = 2;
+
+  ref xRef = x;
+
+  // as of today, we don't have a good implementation for shadow
+  // variables/intents for foreach. But this test exposes a case where the
+  // behavior is wrong. We'd expect this code to change x to 2. But as we
+  // offload x and use a GPU-only ref in the kernel, you don't see any changes
+  // made to x.
+  foreach a in A do xRef = a;
+
+  writeln(x);
+}

--- a/test/gpu/native/basics/outerRefFuture.future
+++ b/test/gpu/native/basics/outerRefFuture.future
@@ -1,0 +1,4 @@
+bug: outer refs are not handled properly
+
+NOTE: we may decide not to support the code in this future, in which case it is
+safe to remove it.

--- a/test/gpu/native/basics/outerRefFuture.good
+++ b/test/gpu/native/basics/outerRefFuture.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+2


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/23045

This PR handles *some* `ref` variables outside of GPU kernels properly. Previously, all refs were falling into the same code path as class variables where the variable was not offloaded by the runtime. With this PR, refs of primitive types will no longer execute that codegen path, but instead will be passed with a non-zero size, which triggers the runtime to offload the variable to the GPU memory.

In effect, outer `ref`s will be copied onto the GPU memory and `ref`s will refer to that. Arguably, we should tighten the story when proper intents and shadow variables are implemented for `foreach` loops.

Tests:
- [x] nvidia
- [x] nvidia+gasnet
- [x] amd
