### PR TITLE
Add ref where needed in linear algebra tests

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -2006,7 +2006,7 @@ proc cholesky(A: [] ?t, lower = true)
       compiler error if ``lapackImpl`` is ``off``.
 
 */
-proc eigvalsh(A: [] ?t, lower=true, param overwrite=false) throws where (A.domain.rank == 2) && (usingLAPACK) {
+proc eigvalsh(ref A: [] ?t, lower=true, param overwrite=false) throws where (A.domain.rank == 2) && (usingLAPACK) {
   if isDistributed(A) then
     compilerError("eigvalsh does not support distributed vectors/matrices");
   return eigh(A, lower=lower, overwrite=overwrite, eigvalsOnly=true);
@@ -2036,7 +2036,7 @@ proc eigvalsh(A: [] ?t, lower=true, param overwrite=false) throws where (A.domai
       compiler error if ``lapackImpl`` is ``off``.
 
 */
-proc eigh(A: [] ?t, lower=true, param eigvalsOnly=false, param overwrite=false) throws where (A.domain.rank == 2) && (usingLAPACK) {
+proc eigh(ref A: [] ?t, lower=true, param eigvalsOnly=false, param overwrite=false) throws where (A.domain.rank == 2) && (usingLAPACK) {
   if isDistributed(A) then
     compilerError("eigh does not support distributed vectors/matrices");
 

--- a/test/library/packages/LAPACK/LAPACK_Matrix_test.chpl
+++ b/test/library/packages/LAPACK/LAPACK_Matrix_test.chpl
@@ -2,7 +2,7 @@ use TestHelpers;
 
 config var verbose_test: bool;
 
-proc putInto2D( arrayOfArrays: [?D1] ?t, twoArray: [?D2] ?o): void{
+proc putInto2D( arrayOfArrays: [?D1] ?t, ref twoArray: [?D2] ?o): void{
   // no check. Cannot have ragged array literals
   assert( D1.rank == 1 && D2.rank == 2  );
   var formed: domain(2) = {D1.dim(0), arrayOfArrays[D1.dim(0).low].domain.dim(0)};
@@ -16,7 +16,7 @@ proc putInto2D( arrayOfArrays: [?D1] ?t, twoArray: [?D2] ?o): void{
 }
 
 writeln( "1D row input => row" );
-var input_1_row: [1..4] real = 
+var input_1_row: [1..4] real =
   [ 3.0, 1.0, 
     4.0, 2.0 ];
 var A_1_row = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_1_row  ); 


### PR DESCRIPTION
Fixes issue in tests with LinearAlgebra.chpl where `ref` is missing due to ref-maybe-const deprecation. When modifying array formals, the `ref` intent is now required.

[Not Reviewed - trivial test change]