### PR TITLE
Remove email capability from cron scripts

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -405,54 +405,7 @@ $testdir = "$chplhomedir/test";
 print "\$chplhomedir = $chplhomedir\n";
 
 
-#
-# set mail options. Default to util/test/send_email.py, if available and
-# working. If not available or not working, default to 'mail'.
-#
-$mailer = $ENV{'CHPL_MAILER'};
-if ($mailer eq "") {
-    $hostplatform = `$utildir/chplenv/chpl_platform.py --host`; chomp($hostplatform);
-    if ($hostplatform =~ "darwin") {
-     print "[ For Mac systems use the default Mail. Defaulting to 'mail'.]\n";
-     $mailer = "mail";
-    }
-    else {
-     $chplsendemail = "$chplhomedir/util/test/send_email.py";
-    `$chplsendemail --help >/dev/null 2>&1`;
-    if ($? == 0) {
-        $header = "";
-        if ($replymail ne "") {
-          $header = "Reply-To=$replymail,";
-        }
-        $header .= "Precedence=bulk";
-        $mailer = "$chplsendemail --header=$header";
-    } else {
-        print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
-        $mailer = "mail";
-    }
-    }
-}
-print "\$mailer = $mailer\n";
-
-
 $launchcmd = "$ENV{'CHPL_TEST_LAUNCHCMD'}";
-
-if ($debug == 1) {
-    $subjectid = "Debug";
-    $recipient = $debugmail;
-    $nochangerecipient = $debugmail;
-} else {
-    $subjectid = "Cron";
-
-    # "email", the mailer program used on cygwin platform, requires multiple
-    # recipient addresses to be comma delimited instead of space delimited.
-    if ($mailer eq "email") {
-        $recipient = "$failuremail";
-    } else {
-        $recipient = "$failuremail";
-    }
-    $nochangerecipient = $allmail;
-}
 
 #
 # test log filenames
@@ -553,23 +506,7 @@ if ($python2 == 0 && $pythonDep == 0) {
 }
 
 if ($buildruntime == 0) {
-    $endtime = localtime;
-
-    $mailsubject = "$subjectid $config_name";
-    $mailcommand = "| $mailer -s \"$mailsubject \" $nochangerecipient";
-
-    if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
-        print "Mailing to minimal group\n";
-        open(MAIL, $mailcommand);
-
-        print MAIL startMailHeader($revision, "<no logfile>", $starttime, $endtime, $crontab, "");
-        print MAIL "Built compiler but not runtime, and did not run tests\n";
-        print MAIL endMailHeader();
-        print MAIL endMailChplenv();
-        close(MAIL);
-    } else {
-        print "CHPL_TEST_NOMAIL: No $mailcommand\n";
-    }
+    print "Built compiler but not runtime, and did not run tests\n";
     exit 0;
 }
 
@@ -737,23 +674,7 @@ if (exists($ENV{"CHPL_START_TEST_ARGS"})) {
 
 
 if ($runtests == 0) {
-    $endtime = localtime;
-
-    $mailsubject = "$subjectid $config_name";
-    $mailcommand = "| $mailer -s \"$mailsubject \" $recipient";
-
-    if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
-        open(MAIL, $mailcommand);
-
-        print MAIL startMailHeader($revision, "<no logfile>", $starttime, $endtime, $crontab, "");
-        print MAIL "Built compiler and runtime but did not run tests\n";
-        print MAIL endMailHeader();
-        print MAIL endMailChplenv();
-
-        close(MAIL);
-    } else {
-        print "CHPL_TEST_NOMAIL: No $mailcommand\n";
-    }
+    print "Built compiler and runtime but did not run tests\n";
 
 } elsif ($python2 == 1 || $pythonDep == 1) {
 
@@ -880,7 +801,7 @@ if ($runtests == 0) {
 # FIXME: Pass correct args here!
      # `$chplhomedir/util/cron/nightly_email.pl $status "$rawsummary" "$sortedsummary" "$prevsummary" "$mailer" "$nochangerecipient" "$recipient" "$subjectid" "$config_name" "$revision" "$rawlog" "$starttime" "$endtime" "$crontab" "$testdirs" $debug`;
      # Write the test results to the summary log.
-     writeFile($status, "$rawsummary", "$sortedsummary", "$prevsummary", "$mailer", "$nochangerecipient", "$recipient", "$subjectid", "$config_name", "$revision", "$rawlog", "$starttime", "$endtime", "$crontab", "$testdirs", $debug);
+     writeFile($status, "$rawsummary", "$sortedsummary", "$prevsummary", "", "$nochangerecipient", "$recipient", "$subjectid", "$config_name", "$revision", "$rawlog", "$starttime", "$endtime", "$crontab", "$testdirs", $debug);
 #
 # analyze memory leaks tests
 #
@@ -905,6 +826,5 @@ if ($runtests == 0) {
         mysystem("cd $testdir && cp $memleaksdir/$memleakslog ./$memleaksmode.exec.out.tmp && $chplhomedir/util/test/computePerfStats $memleaksmode $memleaksdir", "memLeak computePerfStats", 1, 0, 0);
     }
 }
-print "\n nightly status $passed \n";
 exit 0;
 

--- a/util/cron/nightly_email.pm
+++ b/util/cron/nightly_email.pm
@@ -6,147 +6,139 @@ use lib "$FindBin::Bin";
 use nightlysubs;
 
 sub writeFile{
-$num_args = @_;
-print " \n  Number of arguments  $num_args \n ";
+    $num_args = @_;
 
-if ($num_args != 16) {
-    print "usage: nightly_email.pl \$status \$rawsummary \$sortedsummary \n";
-    print "         \$prevsummary \$mailer \$nochangerecipient \$recipient \n";
-    print "         \$subjectid \$config_name \$revision \$rawlog \$starttime \n";
-    print "         \$endtime \$crontab \$testdirs \$debug\n";
-    exit 1;
-}
-my ($status, $rawsummary, $sortedsummary, ,$prevsummary, $mailer, $nochangerecipient, $recipient, $subjectid, $config_name, $revision, $rawlog, $starttime, $endtime, $crontab, $testdirs, $debug)=@_;
-
-$status = $_[0];
-$rawsummary = $_[1];
-$sortedsummary = $_[2];
-$prevsummary = $_[3];
-$mailer = $_[4];
-$nochangerecipient = $_[5];
-$recipient = $_[6];
-$subjectid = $_[7];
-$config_name = $_[8];
-$revision = $_[9];
-$rawlog = $_[10];
-$starttime = $_[11];
-$endtime = $_[12];
-$crontab = $_[13];
-$testdirs = $_[14];
-$debug = $_[15];
-
-
-# Ensure the "previous" summary exists, e.g. if this is the first run of the
-# configuration they won't.
-ensureSummaryExists($prevsummary);
-
-
-#
-# sort output
-#
-
-# status 2 means tests passed and there were some failures.
-# that shouldn't change the format of the email, so we collapse
-# the cases here.
-$email=1;
-if ($status == 2) {
-  $status = 0;
-}
-
-if ($status == 0) {
-     print " \n status 0 \n";
-    `cat $rawsummary | grep -v "^.END" | grep -v "^.Test Summary" | LC_ALL=C sort > $sortedsummary`;
-
-    $oldsummary = `grep Summary: $prevsummary`; chomp($oldsummary);
-    $cursummary = `grep Summary: $sortedsummary`; chomp($cursummary);
-
-    $oldsucc = &numsuccesses($oldsummary);
-    $oldfail = &numfailures($oldsummary);
-    $oldfut  = &numfutures($oldsummary);
-
-    $cursucc = &numsuccesses($cursummary);
-    $curfail = &numfailures($cursummary);
-    $curfut  = &numfutures($cursummary);
-
-    $delsucc = &delta($oldsucc, $cursucc);
-    $delfail = &delta($oldfail, $curfail);
-    $delfut  = &delta($oldfut, $curfut);
-
-    $summary = "Tests run: $cursucc Successes ($delsucc), $curfail Failures ($delfail)";
-} else {
-    $summary = "Tests run: failed new failures";
-    
-}
-
-
-$knownumtests = 1;
-if ($status == 0) {
-    $oldnumtests = $oldsucc + $oldfail;
-    $curnumtests = $cursucc + $curfail;
-    $deltests = &delta($oldnumtests, $curnumtests);
-    $numtestssummary = "$curnumtests Tests ($deltests), $curfut Futures ($delfut)";
-} else {
-    $numtestssummary = "unknown number of Tests";
-    $knownumtests = 0;
-}
-
-#
-# send mail
-#
-$futuremarker = "^Future";
-$suppressmarker = "^Suppress";
-
-$newfailures = "???";
-if ($status == 0) {
-    $newfailures = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker" | wc -l`; chomp($newfailures);
-    $newresolved = `LC_ALL=C comm -23 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker" | wc -l`; chomp($newresolved);
-    $newpassingfutures = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Success" | wc -l`; chomp($newpassingfutures);
-    $passingfutures = `grep "$futuremarker" $sortedsummary | grep "\\[Success" | wc -l`; chomp($passingfutures);
-    $newpassingsuppress = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$suppressmarker" | grep "\\[Success" | wc -l`; chomp($newpassingsuppresss);
-    $passingsuppresss = `grep "$suppressmarker" $sortedsummary | grep "\\[Success" | wc -l`; chomp($passingsuppresss);
-    $newfailures += 0;
-}
-
-if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0) {
-    print "Mailing to minimal group\n";
-    $email=0;
-    $recipient = $nochangerecipient;
-
-} else {
-    print "Mailing to everyone\n";
-}
-
-# Persist the test summary to a (email.txt) in the jenkins workspace.
-# email.txt will be used by Jenkins to send emails in case of a failure.
-
-
-if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
-  print "\n Email:$email \n status:$status \n";
-    if ($email == 1){
-    writeEmail ($revision,
-     $starttime,
-     $endtime ,
-     $crontab ,
-     $testdirs ,
-     $numtestssummary ,
-     $summary ,
-     $prevsummary ,
-     $sortedsummary );
+    if ($num_args != 16) {
+        print "usage: nightly_email.pl \$status \$rawsummary \$sortedsummary \n";
+        print "         \$prevsummary \$mailer \$nochangerecipient \$recipient \n";
+        print "         \$subjectid \$config_name \$revision \$rawlog \$starttime \n";
+        print "         \$endtime \$crontab \$testdirs \$debug\n";
+        exit 1;
     }
-} else {
-    print "CHPL_TEST_NOMAIL: No $mailcommand\n";
-}
+    my ($status, $rawsummary, $sortedsummary, ,$prevsummary, $mailer, $nochangerecipient, $recipient, $subjectid, $config_name, $revision, $rawlog, $starttime, $endtime, $crontab, $testdirs, $debug)=@_;
 
-#
-# tuck this run's output away for comparison tomorrow
-#
-if ($debug == 0) {
+    $status = $_[0];
+    $rawsummary = $_[1];
+    $sortedsummary = $_[2];
+    $prevsummary = $_[3];
+    $mailer = $_[4];
+    $nochangerecipient = $_[5];
+    $recipient = $_[6];
+    $subjectid = $_[7];
+    $config_name = $_[8];
+    $revision = $_[9];
+    $rawlog = $_[10];
+    $starttime = $_[11];
+    $endtime = $_[12];
+    $crontab = $_[13];
+    $testdirs = $_[14];
+    $debug = $_[15];
+
+
+    # Ensure the "previous" summary exists, e.g. if this is the first run of the
+    # configuration they won't.
+    ensureSummaryExists($prevsummary);
+
+
+    #
+    # sort output
+    #
+
+    # status 2 means tests passed and there were some failures.
+    # that shouldn't change the format of the email, so we collapse
+    # the cases here.
+    $email=1;
+    if ($status == 2) {
+      $status = 0;
+    }
+
     if ($status == 0) {
-        system("cp -pv $sortedsummary $prevsummary");
+        `cat $rawsummary | grep -v "^.END" | grep -v "^.Test Summary" | LC_ALL=C sort > $sortedsummary`;
+
+        $oldsummary = `grep Summary: $prevsummary`; chomp($oldsummary);
+        $cursummary = `grep Summary: $sortedsummary`; chomp($cursummary);
+
+        $oldsucc = &numsuccesses($oldsummary);
+        $oldfail = &numfailures($oldsummary);
+        $oldfut  = &numfutures($oldsummary);
+
+        $cursucc = &numsuccesses($cursummary);
+        $curfail = &numfailures($cursummary);
+        $curfut  = &numfutures($cursummary);
+
+        $delsucc = &delta($oldsucc, $cursucc);
+        $delfail = &delta($oldfail, $curfail);
+        $delfut  = &delta($oldfut, $curfut);
+
+        $summary = "Tests run: $cursucc Successes ($delsucc), $curfail Failures ($delfail)";
+    } else {
+        $summary = "Tests run: failed new failures";
+
     }
-}
 
-return(0);
 
+    $knownumtests = 1;
+    if ($status == 0) {
+        $oldnumtests = $oldsucc + $oldfail;
+        $curnumtests = $cursucc + $curfail;
+        $deltests = &delta($oldnumtests, $curnumtests);
+        $numtestssummary = "$curnumtests Tests ($deltests), $curfut Futures ($delfut)";
+    } else {
+        $numtestssummary = "unknown number of Tests";
+        $knownumtests = 0;
+    }
+
+    #
+    # send mail
+    #
+    $futuremarker = "^Future";
+    $suppressmarker = "^Suppress";
+
+    $newfailures = "???";
+    if ($status == 0) {
+        $newfailures = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker" | wc -l`; chomp($newfailures);
+        $newresolved = `LC_ALL=C comm -23 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep -v "$futuremarker" | grep -v "$suppressmarker" | wc -l`; chomp($newresolved);
+        $newpassingfutures = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Success" | wc -l`; chomp($newpassingfutures);
+        $passingfutures = `grep "$futuremarker" $sortedsummary | grep "\\[Success" | wc -l`; chomp($passingfutures);
+        $newpassingsuppress = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$suppressmarker" | grep "\\[Success" | wc -l`; chomp($newpassingsuppresss);
+        $passingsuppresss = `grep "$suppressmarker" $sortedsummary | grep "\\[Success" | wc -l`; chomp($passingsuppresss);
+        $newfailures += 0;
+    }
+
+    if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0) {
+        $email=0;
+        $recipient = $nochangerecipient;
+    }
+
+    # Persist the test summary to a (email.txt) in the jenkins workspace.
+    # email.txt will be used by Jenkins to send emails in case of a failure.
+
+
+    if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
+        if ($email == 1){
+            writeEmail ($revision,
+             $starttime,
+             $endtime ,
+             $crontab ,
+             $testdirs ,
+             $numtestssummary ,
+             $summary ,
+             $prevsummary ,
+             $sortedsummary );
+        }
+    } else {
+        print "CHPL_TEST_NOMAIL: No $mailcommand\n";
+    }
+
+    #
+    # tuck this run's output away for comparison tomorrow
+    #
+    if ($debug == 0) {
+        if ($status == 0) {
+            system("cp -pv $sortedsummary $prevsummary");
+        }
+    }
+
+    return(0);
 }
 return(1);

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -26,27 +26,6 @@ sub mysystem {
         $somethingfailed = 1;
         if($status != -1) {$status = $status / 256; }
         print "Error $errorname: $status\n";
-
-        if ($mailmsg != 0) {
-            $mailsubject = "$subjectid $config_name Failure";
-            $mailcommand = "| $mailer -s \"$mailsubject \" $recipient";
-
-            if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
-                print "Trying to mail message... using $mailcommand\n";
-                open(MAIL, $mailcommand);
-                print MAIL startMailHeader($revision, $rawlog, $starttime, $endtime, $crontab, "");
-                print MAIL "ERROR $errorname: $status\n";
-                print MAIL "(workspace left at $tmpdir)\n";
-                print MAIL endMailHeader();
-                print MAIL endMailChplenv();
-                close(MAIL);
-                
-               
-            } else {
-                print "CHPL_TEST_NOMAIL: No $mailcommand\n";
-            }
-        }
-
         if ($fatal != 0) {
             exit 1;
         }
@@ -152,7 +131,6 @@ sub writeEmail {
     my $summary = $_[6];
     my $prevsummary = $_[7];
     my $sortedsummary = $_[8];
-    print 
     #Create a file "email.txt" in the chapel homedir. This file will be used by Jenkins to attach the test results in the email body
     my $filename = "$chplhomedir/email.txt";
     open(my $SF, '>', $filename) or die "Could not open file '$filename' $!";
@@ -193,7 +171,7 @@ sub writeEmail {
         print $SF "--- New Failing Future tests -----------------\n";
         print $SF `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Error"`;
         print $SF "\n";
-    print $SF      
+    print $SF;
     print $SF endMailChplenv();
     close($SF);
 }


### PR DESCRIPTION
Under some conditions the "cron" scripts such as "nightly" would send email directly, instead of relying on Jenkins to do it. Now the messages are written to the console where Jenkins will pick them up and email them if appropriate.