### PR TITLE
Allow passing numeric param values (e.g. 1) to const ref

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -700,18 +700,10 @@ isLegalLvalueActualArg(ArgSymbol* formal, Expr* actual,
 
 
 // Is this a legal actual argument for a 'const ref' formal?
-// At present, params cannot be passed to 'const ref'.
+// At present, anything can be passed to 'const ref'
 static bool
 isLegalConstRefActualArg(ArgSymbol* formal, Expr* actual) {
-  bool retval = true;
-
-  if (SymExpr* se = toSymExpr(actual))
-    if (se->symbol()->isParameter()                   ==  true &&
-        isString(se->symbol())                        == false &&
-        isBytes(se->symbol())                         == false)
-      retval = false;
-
-  return retval;
+  return true;
 }
 
 /* If we have a generic parent, e.g.:

--- a/test/functions/sungeun/const_ref_arg_default_value.future
+++ b/test/functions/sungeun/const_ref_arg_default_value.future
@@ -1,1 +1,0 @@
-bug: Const ref args to functions should be allowed to have default values.

--- a/test/functions/vass/const-ref-lvalue-error.chpl
+++ b/test/functions/vass/const-ref-lvalue-error.chpl
@@ -6,7 +6,7 @@ proc with_inout_arg(inout x_inout) { writeln(x_inout); }
 
 const xxx = 3;
 with_constref_arg(xxx); //OK
-with_constref_arg(5); // currently an error
+with_constref_arg(5); // OK
 with_inout_arg(xxx);
 with_inout_arg(5);
 

--- a/test/functions/vass/const-ref-lvalue-error.good
+++ b/test/functions/vass/const-ref-lvalue-error.good
@@ -1,4 +1,3 @@
-const-ref-lvalue-error.chpl:9: error: non-lvalue actual is passed to 'const ref' formal 'x_constref' of with_constref_arg()
 const-ref-lvalue-error.chpl:10: error: const actual is passed to 'inout' formal 'x_inout' of with_inout_arg()
 const-ref-lvalue-error.chpl:11: error: const actual is passed to 'inout' formal 'x_inout' of with_inout_arg()
 const-ref-lvalue-error.chpl:15: error: cannot assign to const variable

--- a/test/performance/vectorization/vectorizeOnly/nonIterableErrorMessage/nonVectorizeOnlyInvalidIterable.good
+++ b/test/performance/vectorization/vectorizeOnly/nonIterableErrorMessage/nonVectorizeOnlyInvalidIterable.good
@@ -1,2 +1,1 @@
-nonVectorizeOnlyInvalidIterable.chpl:4: error: non-lvalue actual is passed to a 'const ref' formal of _getIterator()
 nonVectorizeOnlyInvalidIterable.chpl:4: error: cannot iterate over values of type int(64)

--- a/test/performance/vectorization/vectorizeOnly/nonIterableErrorMessage/vectorizeOnlyInvalidIterable.good
+++ b/test/performance/vectorization/vectorizeOnly/nonIterableErrorMessage/vectorizeOnlyInvalidIterable.good
@@ -1,2 +1,1 @@
-vectorizeOnlyInvalidIterable.chpl:4: error: non-lvalue actual is passed to a 'const ref' formal of _getIterator()
 vectorizeOnlyInvalidIterable.chpl:4: error: cannot iterate over values of type int(64)


### PR DESCRIPTION
This PR enables passing numeric param values to `const ref` formals. Note that this was already allowed for `const` values and for bytes/string param values.

For example:

``` chapel
proc f(const ref arg) { writeln(arg); }

f(1); // previously, lvalue error. Now, OK
```

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing