### PR TITLE
Remove usage of sprintf

### DIFF
--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -494,8 +494,7 @@ static void maybeIssueRefMaybeConstWarning(ArgSymbol* arg) {
     const char* argName = nullptr;
     char argBuffer[64];
     if (isTaskIntent && arg->hasFlag(FLAG_FIELD_ACCESSOR)) {
-      sprintf(argBuffer, "this");
-      argName = argBuffer;
+      argName = "this";
     } else if (arg->hasFlag(FLAG_EXPANDED_VARARGS)) {
       int varArgNum;
       int ret = sscanf(arg->name, "_e%d_%63s", &varArgNum, argBuffer);


### PR DESCRIPTION
Fixes issue introduced with #23049 which uses `sprintf`, which causes the compiler to fail to compile with certain versions of the C++ compiler.

[Reviewed by @benharsh]