### PR TITLE
Fix gpu-specializations bug (and fix to work in cpu-in-device mode)

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -364,7 +364,7 @@ std::vector<std::string> gDynoPrependStandardModulePaths;
 int fGPUBlockSize = 0;
 char fGpuArch[gpuArchNameLen+1] = "";
 bool fGpuPtxasEnforceOpt;
-bool fGpuSpecialization = false;
+bool fGpuSpecialization = true;
 const char* gGpuSdkPath = NULL;
 char gpuArch[gpuArchNameLen+1] = "";
 


### PR DESCRIPTION
See https://github.com/Cray/chapel-private/issues/5227 for information about a bug (that we saw in the coral code) that exists when there are nested `on` statements that can go from a gpu locale to a cpu locale.

This PR fixes this bug and also makes some changes needed to get "gpu specializations" mode to work well in tandem with "cpu-as-device" mode.

Specifically, this PR:

- Prevents specializing `wrap_on` functions since (somewhat by definition) we don't want to rewrite the calls in these to only go to gpu functions.
- When using cpu-as-device mode we should sill dispatch to the gpu specific specialization
- When using cpu-as-device mode with gpu specializations keep the cpu-bound loop in the gpu-based specialization (in addition to generating the launch call to the runtime so that we record the psuedo-launch).


**EDIT**: I've also updated this PR to turn on gpu specializations by default.