### PR TITLE
Deprecate `fileReader.binary` and `fileWriter.binary`

### DIFF
--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -891,7 +891,7 @@ class UserMapAssocArr: AbsBaseArr(?) {
   proc dsiSerialWrite(f) {
     use IO;
 
-    var binary = f.binary();
+    var binary = f._binary();
     var arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
     var isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;
     var ischpl = arrayStyle == QIO_ARRAY_FORMAT_CHPL && !binary;

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1479,7 +1479,7 @@ iter StencilArr.these(param tag: iterKind, followThis, param fast: bool = false)
 //
 proc StencilArr.dsiSerialWrite(f) {
   type strType = chpl__signedType(idxType);
-  var binary = f.binary();
+  var binary = f._binary();
   if dom.dsiNumIndices == 0 then return;
   var i : rank*idxType;
   for dim in 0..rank-1 do

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1692,7 +1692,7 @@ module ChapelArray {
     @chpldoc.nodoc
     proc writeThis(f) throws {
       var arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
-      var ischpl = arrayStyle == QIO_ARRAY_FORMAT_CHPL && !f.binary();
+      var ischpl = arrayStyle == QIO_ARRAY_FORMAT_CHPL && !f._binary();
       if rank > 1 && ischpl {
         throw new owned IllegalArgumentError("Cannot perform Chapel write of multidimensional array.");
       }
@@ -1712,7 +1712,7 @@ module ChapelArray {
     @chpldoc.nodoc
     proc readThis(f) throws {
       var arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
-      var ischpl = arrayStyle == QIO_ARRAY_FORMAT_CHPL && !f.binary();
+      var ischpl = arrayStyle == QIO_ARRAY_FORMAT_CHPL && !f._binary();
       if rank > 1 && ischpl {
         throw new owned IllegalArgumentError("Cannot perform Chapel read of multidimensional array.");
       }

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -137,7 +137,7 @@ module DefaultAssociative {
     }
 
     proc dsiSerialWrite(f) throws {
-      const binary = f.binary();
+      const binary = f._binary();
 
       if binary {
         f.write(dsiNumIndices);
@@ -158,7 +158,7 @@ module DefaultAssociative {
       }
     }
     proc dsiSerialRead(f) throws {
-      const binary = f.binary();
+      const binary = f._binary();
 
       // Clear the domain so it only contains indices read in.
       dsiClear();
@@ -738,7 +738,7 @@ module DefaultAssociative {
     }
 
     proc dsiSerialReadWrite(f /*: channel*/, in printBraces=true, inout first = true) throws {
-      var binary = f.binary();
+      var binary = f._binary();
       var arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
       var isspace = arrayStyle == QIO_ARRAY_FORMAT_SPACE && !binary;
       var isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;
@@ -945,7 +945,7 @@ module DefaultAssociative {
   }
 
   proc chpl_serialReadWriteAssociativeHelper(f, arr, dom) throws {
-    var binary = f.binary();
+    var binary = f._binary();
     var arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
     var isspace = arrayStyle == QIO_ARRAY_FORMAT_SPACE && !binary;
     var isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1872,7 +1872,7 @@ module DefaultRectangular {
 
     proc recursiveArrayReaderWriter(in idx: rank*idxType, dim=0, in last=false) throws {
 
-      var binary = f.binary();
+      var binary = f._binary();
       var arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
       var isspace = arrayStyle == QIO_ARRAY_FORMAT_SPACE && !binary;
       var isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;
@@ -1931,7 +1931,7 @@ module DefaultRectangular {
     }
 
     if arr.isDefaultRectangular() && !chpl__isArrayView(arr) &&
-       _isSimpleIoType(arr.eltType) && f.binary() &&
+       _isSimpleIoType(arr.eltType) && f._binary() &&
        isNative && arr.isDataContiguous(dom) {
 
       // If we can, we would like to read/write the array as a single write op

--- a/modules/packages/LinkedLists.chpl
+++ b/modules/packages/LinkedLists.chpl
@@ -292,7 +292,7 @@ record LinkedList {
 
   @chpldoc.nodoc
   proc writeThis(f) throws {
-    var binary = f.binary();
+    var binary = f._binary();
     var arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
     var isspace = arrayStyle == QIO_ARRAY_FORMAT_SPACE && !binary;
     var isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;
@@ -343,7 +343,7 @@ record LinkedList {
     // Special handling for reading in order to handle reading an arbitrary
     // size.
     //
-    const isBinary = f.binary();
+    const isBinary = f._binary();
     const arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
     const isSpace = arrayStyle == QIO_ARRAY_FORMAT_SPACE && !isBinary;
     const isJson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !isBinary;

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -198,7 +198,7 @@ module ChapelIO {
     @chpldoc.nodoc
     proc writeThisFieldsDefaultImpl(writer, x:?t, inout first:bool) throws {
       param num_fields = __primitive("num fields", t);
-      var isBinary = writer.binary();
+      var isBinary = writer._binary();
 
       if (isClassType(t)) {
         if _to_borrowed(t) != borrowed RootClass {
@@ -261,7 +261,7 @@ module ChapelIO {
       const st = writer.styleElement(QIO_STYLE_ELEMENT_AGGREGATE);
       const isJson = st == QIO_AGGREGATE_FORMAT_JSON;
 
-      if !writer.binary() {
+      if !writer._binary() {
         const start = if isJson then "{"
                       else if st == QIO_AGGREGATE_FORMAT_CHPL
                       then "new " + t:string + "("
@@ -274,7 +274,7 @@ module ChapelIO {
 
       writeThisFieldsDefaultImpl(writer, x, first);
 
-      if !writer.binary() {
+      if !writer._binary() {
         const end = if isJson then "}"
                     else if st == QIO_AGGREGATE_FORMAT_CHPL then ")"
                     else if isClassType(t) then "}"
@@ -409,7 +409,7 @@ module ChapelIO {
         where !isUnionType(t) {
 
       param numFields = __primitive("num fields", t);
-      var isBinary = reader.binary();
+      var isBinary = reader._binary();
 
       if isClassType(t) && _to_borrowed(t) != borrowed RootClass {
 
@@ -541,7 +541,7 @@ module ChapelIO {
         where isUnionType(t) && !isExternUnionType(t) {
 
       param numFields = __primitive("num fields", t);
-      var isBinary = reader.binary();
+      var isBinary = reader._binary();
 
 
       if isBinary {
@@ -598,7 +598,7 @@ module ChapelIO {
     proc readThisDefaultImpl(reader, x:?t) throws where isClassType(t) {
       const st = reader.styleElement(QIO_STYLE_ELEMENT_AGGREGATE);
 
-      if !reader.binary() {
+      if !reader._binary() {
         const start = if st == QIO_AGGREGATE_FORMAT_CHPL
                       then "new " + t:string + "("
                       else "{";
@@ -614,7 +614,7 @@ module ChapelIO {
       try readThisFieldsDefaultImpl(reader, t, obj, needsComma);
       try skipFieldsAtEnd(reader, needsComma);
 
-      if !reader.binary() {
+      if !reader._binary() {
         const end = if st == QIO_AGGREGATE_FORMAT_CHPL then ")"
                     else "}";
 
@@ -627,7 +627,7 @@ module ChapelIO {
       const st = reader.styleElement(QIO_STYLE_ELEMENT_AGGREGATE);
       const isJson = st ==  QIO_AGGREGATE_FORMAT_JSON;
 
-      if !reader.binary() {
+      if !reader._binary() {
         const start = if st ==  QIO_AGGREGATE_FORMAT_CHPL
                       then "new " + t:string + "("
                       else if isJson then "{"
@@ -641,7 +641,7 @@ module ChapelIO {
       try readThisFieldsDefaultImpl(reader, t, x, needsComma);
       try skipFieldsAtEnd(reader, needsComma);
 
-      if !reader.binary() {
+      if !reader._binary() {
         const end = if isJson then "}"
                     else ")";
 
@@ -699,7 +699,7 @@ module ChapelIO {
   proc _tuple._readWriteHelper(f) throws {
     const st = f.styleElement(QIO_STYLE_ELEMENT_TUPLE);
     const isJson = st == QIO_TUPLE_FORMAT_JSON;
-    const binary = f.binary();
+    const binary = f._binary();
 
     // Returns a 4-tuple containing strings representing:
     // - start of a tuple

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6583,7 +6583,11 @@ inline proc fileWriter.readWriteNewline() throws
 
 /* Returns `true` if this fileReader is configured for binary I/O.
  */
-proc fileReader.binary():bool {
+@deprecated(notes="'fileReader.binary()' is deprecated; check whether the fileReader is configured with a binary deserializer instead")
+proc fileReader.binary(): bool do return this._binary();
+
+@chpldoc.nodoc
+proc fileReader._binary():bool {
   var ret:uint(8);
   on this._home {
     ret = qio_channel_binary(_channel_internal);
@@ -6593,7 +6597,11 @@ proc fileReader.binary():bool {
 
 /* Returns `true` if this fileWriter is configured for binary I/O.
  */
-proc fileWriter.binary():bool {
+@deprecated(notes="'fileWriter.binary()' is deprecated; check whether the fileWriter is configured with a binary serializer instead")
+proc fileWriter.binary(): bool do return this._binary();
+
+@chpldoc.nodoc
+proc fileWriter._binary():bool {
   var ret:uint(8);
   on this._home {
     ret = qio_channel_binary(_channel_internal);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6583,7 +6583,7 @@ inline proc fileWriter.readWriteNewline() throws
 
 /* Returns `true` if this fileReader is configured for binary I/O.
  */
-@deprecated(notes="'fileReader.binary()' is deprecated; check whether the fileReader is configured with a binary deserializer instead")
+@deprecated(notes="'fileReader.binary()' is deprecated; please use 'fileReader.deserializerType' to check for a binary deserializer instead")
 proc fileReader.binary(): bool do return this._binary();
 
 @chpldoc.nodoc
@@ -6597,7 +6597,7 @@ proc fileReader._binary():bool {
 
 /* Returns `true` if this fileWriter is configured for binary I/O.
  */
-@deprecated(notes="'fileWriter.binary()' is deprecated; check whether the fileWriter is configured with a binary serializer instead")
+@deprecated(notes="'fileWriter.binary()' is deprecated; please use 'fileWriter.serializerType' to check for a binary serializer instead")
 proc fileWriter.binary(): bool do return this._binary();
 
 @chpldoc.nodoc

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1854,7 +1854,7 @@ module List {
       :arg ch: A channel to write to.
     */
     proc writeThis(ch: fileWriter) throws {
-      var isBinary = ch.binary();
+      var isBinary = ch._binary();
       const isJson = ch.styleElement(QIO_STYLE_ELEMENT_AGGREGATE) == QIO_AGGREGATE_FORMAT_JSON;
 
       if isJson {
@@ -1929,7 +1929,7 @@ module List {
       // Special handling for reading in order to handle reading an arbitrary
       // size.
       //
-      const isBinary = ch.binary();
+      const isBinary = ch._binary();
       const isJson = ch.styleElement(QIO_STYLE_ELEMENT_AGGREGATE) == QIO_AGGREGATE_FORMAT_JSON;
       if isJson then {
         _readJson(ch);

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -540,7 +540,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   proc date.readThis(f) throws {
     import JSON.JsonDeserializer;
 
-    const binary = f.binary(),
+    const binary = f._binary(),
           arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY),
           isjson = (arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary) ||
             isSubtype(f.deserializerType, JsonDeserializer);
@@ -854,7 +854,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   proc time.readThis(f) throws {
     import JSON.JsonDeserializer;
 
-    const binary = f.binary(),
+    const binary = f._binary(),
           arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY),
           isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary  ||
             isSubtype(f.deserializerType, JsonDeserializer);
@@ -1506,7 +1506,7 @@ enum day       { sunday=0, monday, tuesday, wednesday, thursday, friday, saturda
   proc dateTime.readThis(f) throws {
     import JSON.JsonDeserializer;
 
-    const binary = f.binary(),
+    const binary = f._binary(),
           arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY),
           isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary ||
             isSubtype(f.deserializerType, JsonDeserializer);

--- a/test/deprecated/IO/binaryQuery.chpl
+++ b/test/deprecated/IO/binaryQuery.chpl
@@ -1,0 +1,8 @@
+use IO;
+
+var f = open("binaryQuery.chpl", ioMode.rw),
+    w = f.writer(kind=iokind.native),
+    r = f.reader(kind=iokind.native);
+
+writeln(w.binary());
+writeln(r.binary());

--- a/test/deprecated/IO/binaryQuery.good
+++ b/test/deprecated/IO/binaryQuery.good
@@ -2,7 +2,7 @@ binaryQuery.chpl:4: warning: 'iokind' is deprecated, please use Serializers or D
 binaryQuery.chpl:5: warning: 'iokind' is deprecated, please use Serializers or Deserializers that support endianness instead
 binaryQuery.chpl:4: warning: writer with a 'kind' argument is deprecated, please use Serializers instead
 binaryQuery.chpl:5: warning: reader with a 'kind' argument is deprecated, please use Deserializers instead
-binaryQuery.chpl:7: warning: 'fileWriter.binary()' is deprecated; check whether the fileWriter is configured with a binary serializer instead
-binaryQuery.chpl:8: warning: 'fileReader.binary()' is deprecated; check whether the fileReader is configured with a binary deserializer instead
+binaryQuery.chpl:7: warning: 'fileWriter.binary()' is deprecated; please use 'fileWriter.serializerType' to check for a binary serializer instead
+binaryQuery.chpl:8: warning: 'fileReader.binary()' is deprecated; please use 'fileReader.deserializerType' to check for a binary deserializer instead
 true
 true

--- a/test/deprecated/IO/binaryQuery.good
+++ b/test/deprecated/IO/binaryQuery.good
@@ -1,0 +1,8 @@
+binaryQuery.chpl:4: warning: 'iokind' is deprecated, please use Serializers or Deserializers that support endianness instead
+binaryQuery.chpl:5: warning: 'iokind' is deprecated, please use Serializers or Deserializers that support endianness instead
+binaryQuery.chpl:4: warning: writer with a 'kind' argument is deprecated, please use Serializers instead
+binaryQuery.chpl:5: warning: reader with a 'kind' argument is deprecated, please use Deserializers instead
+binaryQuery.chpl:7: warning: 'fileWriter.binary()' is deprecated; check whether the fileWriter is configured with a binary serializer instead
+binaryQuery.chpl:8: warning: 'fileReader.binary()' is deprecated; check whether the fileReader is configured with a binary deserializer instead
+true
+true

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -1125,7 +1125,6 @@ iter AccumStencilArr.these(param tag: iterKind, followThis, param fast: bool = f
 //
 proc AccumStencilArr.dsiSerialWrite(f) {
   type strType = chpl__signedType(idxType);
-  var binary = f.binary();
   if dom.dsiNumIndices == 0 then return;
   var i : rank*idxType;
   for dim in 0..#rank do
@@ -1133,7 +1132,7 @@ proc AccumStencilArr.dsiSerialWrite(f) {
   label next while true {
     f.write(dsiAccess(i));
     if i(rank) <= (dom.dsiDim(rank).high - dom.dsiDim(rank).stride:strType) {
-      if ! binary then f.write(" ");
+      f.write(" ");
       i(rank) += dom.dsiDim(rank).stride:strType;
     } else {
       for dim in 0..rank-2 by -1 {


### PR DESCRIPTION
Per discussion [here](https://github.com/chapel-lang/chapel/issues/19317) `fileReader.binary` and `fileWriter.binary` are deprecated.

Resolves https://github.com/chapel-lang/chapel/issues/19317

- [x] paratest
- [x] inspected docs