### PR TITLE
Add error for type construction with named argument for non-type non-param

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -980,6 +980,16 @@ AggregateType* AggregateType::generateType(CallExpr* call, const char* callStrin
       } else if (field->hasFlag(FLAG_DEPRECATED)) {
         field->maybeGenerateDeprecationWarning(ne);
       }
+      // don't allow type-constructor calls to use named-argument passing
+      // for a field that isn't 'type' or 'param'
+      if (!field->hasEitherFlag(FLAG_TYPE_VARIABLE, FLAG_PARAM)) {
+        USR_FATAL_CONT(call, "named arguments can only be used in "
+                             "type construction to set "
+                             "'type' or 'param' fields");
+        USR_PRINT(field, "field '%s' declared here is not 'type' or 'param'",
+                  field->name);
+        USR_STOP();
+      }
       map.put(field, toSymExpr(ne->actual)->symbol());
     } else {
       SymExpr* se = toSymExpr(actual);

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -950,8 +950,9 @@ static void checkRangeDeprecations(AggregateType* at, NamedExpr* ne,
   }
 }
 
-AggregateType* AggregateType::generateType(CallExpr* call, const char* callString) {
-
+AggregateType* AggregateType::generateType(CallExpr* call,
+                                           const char* callString,
+                                           bool allowAllNamedArgs) {
   checkNumArgsErrors(this, call, callString);
 
   if (call->numActuals() == 0 && mIsGenericWithDefaults == false) {
@@ -982,7 +983,8 @@ AggregateType* AggregateType::generateType(CallExpr* call, const char* callStrin
       }
       // don't allow type-constructor calls to use named-argument passing
       // for a field that isn't 'type' or 'param'
-      if (!field->hasEitherFlag(FLAG_TYPE_VARIABLE, FLAG_PARAM)) {
+      if (!allowAllNamedArgs &&
+          !field->hasEitherFlag(FLAG_TYPE_VARIABLE, FLAG_PARAM)) {
         USR_FATAL_CONT(call, "named arguments can only be used in "
                              "type construction to set "
                              "'type' or 'param' fields");

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -122,7 +122,8 @@ public:
   AggregateType*              getInstantiationParent(AggregateType* pt);
 
   AggregateType*              generateType(CallExpr* call,
-                                           const char* callString);
+                                           const char* callString,
+                                           bool allowAllNamedArgs=false);
   AggregateType*              generateType(SymbolMap& subs,
                                            CallExpr* call,
                                            const char* callString,

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -580,7 +580,8 @@ static Type* instantiateOneAggregateType(SymbolMap &fml2act,
     genCall->insertAtTail(new NamedExpr(elem.key->name, new SymExpr(instSym)));
   }
 
-  AggregateType* instT = atgen->generateType(genCall, "<internal error>");
+  AggregateType* instT = atgen->generateType(genCall, "<internal error>",
+                                             /* allowAllNamedArgs */ true);
   genCall->remove();
   if (markRm) cgInstantiations.insert(instT);
   fml2act.put(at->symbol, instT->symbol);

--- a/test/types/type_variables/ferguson/error-named-to-value-partial.chpl
+++ b/test/types/type_variables/ferguson/error-named-to-value-partial.chpl
@@ -1,0 +1,6 @@
+record R {
+  var x;
+  var y: integral;
+}
+
+type t2 = R(y=int(8), ?); // error: can't type construct with named argument for a value field

--- a/test/types/type_variables/ferguson/error-named-to-value-partial.good
+++ b/test/types/type_variables/ferguson/error-named-to-value-partial.good
@@ -1,0 +1,2 @@
+error-named-to-value-partial.chpl:6: error: named arguments can only be used in type construction to set 'type' or 'param' fields
+error-named-to-value-partial.chpl:3: note: field 'y' declared here is not 'type' or 'param'

--- a/test/types/type_variables/ferguson/error-named-to-value.chpl
+++ b/test/types/type_variables/ferguson/error-named-to-value.chpl
@@ -1,0 +1,6 @@
+record R {
+  var x;
+  var y: integral;
+}
+
+type t1 = R(x=real, y=int); // error: can't type construct with named argument for a value field

--- a/test/types/type_variables/ferguson/error-named-to-value.good
+++ b/test/types/type_variables/ferguson/error-named-to-value.good
@@ -1,0 +1,2 @@
+error-named-to-value.chpl:6: error: named arguments can only be used in type construction to set 'type' or 'param' fields
+error-named-to-value.chpl:2: note: field 'x' declared here is not 'type' or 'param'

--- a/test/types/type_variables/ferguson/instantiate-non-generic.chpl
+++ b/test/types/type_variables/ferguson/instantiate-non-generic.chpl
@@ -1,0 +1,8 @@
+record S {
+  type t1;
+  type t2;
+  var x: (t1, t2);
+}
+
+type t = S(x=(int, real));
+writeln(t:string);

--- a/test/types/type_variables/ferguson/instantiate-non-generic.good
+++ b/test/types/type_variables/ferguson/instantiate-non-generic.good
@@ -1,0 +1,2 @@
+instantiate-non-generic.chpl:7: error: named arguments can only be used in type construction to set 'type' or 'param' fields
+instantiate-non-generic.chpl:4: note: field 'x' declared here is not 'type' or 'param'


### PR DESCRIPTION
For #21993 
Resolves https://github.com/Cray/chapel-private/issues/5228

This PR adds a compilation error when a type construction call uses named argument passing to set the type of a field that is not a `type` or `param` field. For example:

``` chapel
record R {
  var x;
  var y: integral;
}

type t1 = R(x=real, y=int); // error
```

The reason for this error is twofold:
 1. We have observed some nonsensical programs being able to compile, and this avoids bugs in this area. See below for an example.
 2. We are uncertain if the type of `x` should be named `x` in the type constructor. Perhaps it should have a different name.

Of course, this error can be relaxed in the future as a non-breaking change.

Here is an example program that this PR causes to fail with an error but (nonsensically) compiles and runs before this PR:

``` chapel
record S {
  type t1;
  type t2;
  var x: (t1, t2);
}

type t = S(x=(int, real));
writeln(t:string);
```

- [ ] full comm=none testing
