### PR TITLE
Unstabilize `range.first` and `range.last` when applied to a range over bool or enum and that side of it is unbounded

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1355,7 +1355,25 @@ module ChapelRange {
      the range has no first index, the behavior is undefined.  See
      also :proc:`range.hasFirst`. */
   inline proc range.first {
+    warnUnstableFirst(this);
     return chpl_intToIdx(this.firstAsInt);
+  }
+
+  private inline proc warnUnstableFirst(r) {
+    if !chpl_warnUnstable || !isFiniteIdxType(r.idxType) then
+      return; // nothing to do
+    if !r.hasLowBound() {
+      if r.strides.isPositive() then
+        compilerWarning("range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound");
+      else if r.hasPositiveStride() then
+        warning("range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound");
+    }
+    if !r.hasHighBound() {
+      if r.strides.isNegative() then
+        compilerWarning("range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound");
+      else if r.hasNegativeStride() then
+        warning("range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound");
+    }
   }
 
   @chpldoc.nodoc
@@ -1409,7 +1427,25 @@ module ChapelRange {
      :proc:`range.hasLast`.
   */
   inline proc range.last {
+    warnUnstableLast(this);
     return chpl_intToIdx(this.lastAsInt);
+  }
+
+  private inline proc warnUnstableLast(r) {
+    if !chpl_warnUnstable || !isFiniteIdxType(r.idxType) then
+      return; // nothing to do
+    if !r.hasLowBound() {
+      if r.strides.isNegative() then
+        compilerWarning("range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound");
+      else if r.hasNegativeStride() then
+        warning("range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound");
+    }
+    if !r.hasHighBound() {
+      if r.strides.isPositive() then
+        compilerWarning("range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound");
+      else if r.hasPositiveStride() then
+        warning("range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound");
+    }
   }
 
   @chpldoc.nodoc

--- a/test/unstable/rangeUnboundedEnumBoolFirstLast.chpl
+++ b/test/unstable/rangeUnboundedEnumBoolFirstLast.chpl
@@ -1,0 +1,73 @@
+enum color {red, green, blue};
+use color;
+
+
+// Cast a range such that the stride is not known at compile time
+proc toAny(r) do return r: range(r.idxType, r.bounds, strideKind.any);
+
+
+inline proc testRange(r){
+  // Test first last of the range
+  // Also test the same range when the stride is not known at compile time
+  writeln(r.first);
+  writeln(r.last);
+  var rAny = toAny(r);
+  writeln(rAny.first);
+  writeln(rAny.last);
+}
+
+var rgb = red..blue;
+var rdd = red..;
+var ddb = ..blue;
+var dd: range(color, boundKind.neither);
+var negrgb = red..blue by -1;
+var negrdd = red.. by -1;
+var negddb = ..blue by -1;
+var negdd = dd by -1;
+var rdd2 = rdd by 2;
+var negrdd2 = rdd by -2;
+var ddb2 = ddb by 2;
+var negddb2 = ddb by -2;
+
+testRange(rgb);
+testRange(rdd);
+testRange(ddb);
+testRange(dd);
+testRange(negrgb);
+testRange(negrdd);
+testRange(negddb);
+testRange(negdd);
+testRange(rdd2);
+testRange(negrdd2);
+testRange(ddb2);
+testRange(negddb2);
+
+{
+var ft = false..true;
+var fdd = false..;
+var ddt = ..true;
+var dd: range(bool, boundKind.neither);
+var negft = false..true by -1;
+var negfdd = false.. by -1;
+var negddt = ..true by -1;
+var negdd = dd by -1;
+var fdd2 = fdd by 2;
+var negfdd2 = fdd by -2;
+var ddt2 = ddt by 2;
+var negddt2 = ddt by -2;
+
+
+testRange(ft);
+testRange(fdd);
+testRange(ddt);
+testRange(dd);
+testRange(negft);
+testRange(negfdd);
+testRange(negddt);
+testRange(negdd);
+testRange(fdd2);
+testRange(negfdd2);
+testRange(ddt2);
+testRange(negddt2);
+
+}

--- a/test/unstable/rangeUnboundedEnumBoolFirstLast.good
+++ b/test/unstable/rangeUnboundedEnumBoolFirstLast.good
@@ -1,0 +1,184 @@
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:33: called as testRange(r: range(color,low,one))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:34: called as testRange(r: range(color,high,one))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:35: called as testRange(r: range(color,neither,one))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:37: called as testRange(r: range(color,low,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:38: called as testRange(r: range(color,high,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:39: called as testRange(r: range(color,neither,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:40: called as testRange(r: range(color,low,positive))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:41: called as testRange(r: range(color,low,negative))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:42: called as testRange(r: range(color,high,positive))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:43: called as testRange(r: range(color,high,negative))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:61: called as testRange(r: range(bool,low,one))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:62: called as testRange(r: range(bool,high,one))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:63: called as testRange(r: range(bool,neither,one))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:65: called as testRange(r: range(bool,low,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:66: called as testRange(r: range(bool,high,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:67: called as testRange(r: range(bool,neither,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:68: called as testRange(r: range(bool,low,positive))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+  rangeUnboundedEnumBoolFirstLast.chpl:69: called as testRange(r: range(bool,low,negative))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:70: called as testRange(r: range(bool,high,positive))
+rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+  rangeUnboundedEnumBoolFirstLast.chpl:71: called as testRange(r: range(bool,high,negative))
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+blue
+red
+red
+blue
+red
+blue
+blue
+red
+blue
+red
+red
+blue
+red
+blue
+blue
+red
+blue
+red
+false
+true
+false
+true
+false
+true
+false
+true
+false
+true
+false
+true
+false
+true
+false
+true
+true
+false
+true
+false
+true
+false
+true
+false
+true
+false
+true
+false
+true
+false
+true
+false
+false
+false
+false
+false
+true
+true
+true
+true
+false
+false
+false
+false
+true
+true
+true
+true
+rangeUnboundedEnumBoolFirstLast.chpl:33: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:34: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:35: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:35: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:37: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:38: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:39: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:39: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:40: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:41: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:42: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:43: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:61: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:62: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:63: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:63: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:65: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:66: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:67: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:67: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:68: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:69: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:70: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:71: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound


### PR DESCRIPTION
From https://github.com/chapel-lang/chapel/issues/20896#issuecomment-1678354784
For `first` and `last`, the name suggests "first/last in the sequence."
Given that the sequence is finite if idxType is finite (i.e. enum or bool),
it makes sense for `first` and `last` to be defined as if the range is bounded,
similarly to iteration.

To be on the safe side, we will mark this behavior as unstable.

- [x] paratest
- [x] gasnet paratest
