### PR TITLE
Make `c_fn_ptr` unstable

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1189,7 +1189,7 @@ void initPrimitiveTypes() {
   // Map to runtime type 'c_fn_ptr_rehook' to avoid collision with name of
   // symbol in module ('c_fn_ptr'), when using '--no-munge-user-idents' is
   // thrown.
-  dtCFnPtr = createPrimitiveType("chpl__c_fn_ptr", "c_fn_ptr_rehook");
+  dtCFnPtr = createPrimitiveType("chpl_c_fn_ptr", "c_fn_ptr_rehook");
   dtCFnPtr->symbol->addFlag(FLAG_NO_CODEGEN);
   dtCFnPtr->defaultValue = gNil;
 

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1186,7 +1186,10 @@ void initPrimitiveTypes() {
   dtCVoidPtr->symbol->addFlag(FLAG_NO_CODEGEN);
   dtCVoidPtr->defaultValue = gNil;
 
-  dtCFnPtr = createPrimitiveType("chpl__c_fn_ptr", "c_fn_ptr");
+  // Map to runtime type 'c_fn_ptr_rehook' to avoid collision with name of
+  // symbol in module ('c_fn_ptr'), when using '--no-munge-user-idents' is
+  // thrown.
+  dtCFnPtr = createPrimitiveType("chpl__c_fn_ptr", "c_fn_ptr_rehook");
   dtCFnPtr->symbol->addFlag(FLAG_NO_CODEGEN);
   dtCFnPtr->defaultValue = gNil;
 

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -277,6 +277,8 @@ const char* toString(Type* type, bool decorateAllClasses) {
       // de-sugar chpl__c_void_ptr, which is used internally and is a distinct
       // type from c_ptr(void)
       retval = "raw_c_void_ptr";
+    } else if (vt == dtCFnPtr) {
+      retval = "c_fn_ptr";
     } else if (vt == dtStringC) {
       // present dtStringC type as familiar 'c_string' instead of the internal
       // name 'chpl_c_string' or cname, 'c_string_rehook'.

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1184,7 +1184,7 @@ void initPrimitiveTypes() {
   dtCVoidPtr->symbol->addFlag(FLAG_NO_CODEGEN);
   dtCVoidPtr->defaultValue = gNil;
 
-  dtCFnPtr = createPrimitiveType("c_fn_ptr", "c_fn_ptr");
+  dtCFnPtr = createPrimitiveType("chpl__c_fn_ptr", "c_fn_ptr");
   dtCFnPtr->symbol->addFlag(FLAG_NO_CODEGEN);
   dtCFnPtr->defaultValue = gNil;
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -31,6 +31,30 @@ module ChapelBase {
   @deprecated(notes="the type 'c_string' is deprecated; please 'import CTypes' and use 'c_ptrConst(c_char)' instead")
   type c_string = chpl_c_string;
 
+  // c_fn_ptr stuff
+
+  // although it can just be a compiler-inserted primitive,
+  // we declare it so we can mark it unstable
+  @chpldoc.nodoc
+  @unstable("'c_fn_ptr' is unstable, and may be replaced by first-class procedure functionality")
+  type c_fn_ptr = chpl__c_fn_ptr;
+
+  @chpldoc.nodoc
+  @unstable
+  inline operator c_fn_ptr.=(ref a:c_fn_ptr, b:c_fn_ptr) {
+    __primitive("=", a, b);
+  }
+  @chpldoc.nodoc
+  @unstable
+  proc c_fn_ptr.this() {
+    compilerError("Can't call a C function pointer within Chapel");
+  }
+  @chpldoc.nodoc
+  @unstable
+  proc c_fn_ptr.this(args...) {
+    compilerError("Can't call a C function pointer within Chapel");
+  }
+
   pragma "locale private"
   @chpldoc.nodoc
   var rootLocaleInitialized: bool = false;
@@ -3433,19 +3457,5 @@ module ChapelBase {
 
   inline proc chpl_field_gt(a, b) where !isArrayType(a.type) {
     return a > b;
-  }
-
-  // c_fn_ptr stuff
-  @chpldoc.nodoc
-  inline operator c_fn_ptr.=(ref a:c_fn_ptr, b:c_fn_ptr) {
-    __primitive("=", a, b);
-  }
-  @chpldoc.nodoc
-  proc c_fn_ptr.this() {
-    compilerError("Can't call a C function pointer within Chapel");
-  }
-  @chpldoc.nodoc
-  proc c_fn_ptr.this(args...) {
-    compilerError("Can't call a C function pointer within Chapel");
   }
 }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -3307,7 +3307,7 @@ module ChapelBase {
   // Support for module deinit functions.
   class chpl_ModuleDeinit {
     const moduleName: c_ptrConst(c_char); // for debugging; non-null, not owned
-    const deinitFun:  c_fn_ptr;          // module deinit function
+    const deinitFun:  chpl__c_fn_ptr;          // module deinit function
     const prevModule: unmanaged chpl_ModuleDeinit?; // singly-linked list / LIFO queue
     proc writeThis(ch) throws {
       try {

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -37,7 +37,7 @@ module ChapelBase {
   // we declare it so we can mark it unstable
   @chpldoc.nodoc
   @unstable("'c_fn_ptr' is unstable, and may be replaced by first-class procedure functionality")
-  type c_fn_ptr = chpl__c_fn_ptr;
+  type c_fn_ptr = chpl_c_fn_ptr;
 
   @chpldoc.nodoc
   @unstable
@@ -3307,7 +3307,7 @@ module ChapelBase {
   // Support for module deinit functions.
   class chpl_ModuleDeinit {
     const moduleName: c_ptrConst(c_char); // for debugging; non-null, not owned
-    const deinitFun:  chpl__c_fn_ptr;          // module deinit function
+    const deinitFun:  chpl_c_fn_ptr;          // module deinit function
     const prevModule: unmanaged chpl_ModuleDeinit?; // singly-linked list / LIFO queue
     proc writeThis(ch) throws {
       try {

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -208,7 +208,7 @@ module ChapelUtil {
   // Support for module deinit functions.
   config param printModuleDeinitOrder = false;
 
-  proc chpl_addModule(moduleName: chpl_c_string, deinitFun: chpl__c_fn_ptr) {
+  proc chpl_addModule(moduleName: chpl_c_string, deinitFun: chpl_c_fn_ptr) {
     chpl_moduleDeinitFuns =
       new unmanaged chpl_ModuleDeinit(moduleName, deinitFun, chpl_moduleDeinitFuns);
   }
@@ -216,7 +216,7 @@ module ChapelUtil {
   export proc chpl_deinitModules() {
     extern proc printf(fmt:c_ptrConst(c_char));
     extern proc printf(fmt:c_ptrConst(c_char), arg:c_ptrConst(c_char));
-    extern proc chpl_execute_module_deinit(deinitFun:chpl__c_fn_ptr);
+    extern proc chpl_execute_module_deinit(deinitFun:chpl_c_fn_ptr);
 
     if printModuleDeinitOrder then
       printf("Deinitializing Modules:\n");

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -208,7 +208,7 @@ module ChapelUtil {
   // Support for module deinit functions.
   config param printModuleDeinitOrder = false;
 
-  proc chpl_addModule(moduleName: chpl_c_string, deinitFun: c_fn_ptr) {
+  proc chpl_addModule(moduleName: chpl_c_string, deinitFun: chpl__c_fn_ptr) {
     chpl_moduleDeinitFuns =
       new unmanaged chpl_ModuleDeinit(moduleName, deinitFun, chpl_moduleDeinitFuns);
   }
@@ -216,7 +216,7 @@ module ChapelUtil {
   export proc chpl_deinitModules() {
     extern proc printf(fmt:c_ptrConst(c_char));
     extern proc printf(fmt:c_ptrConst(c_char), arg:c_ptrConst(c_char));
-    extern proc chpl_execute_module_deinit(deinitFun:c_fn_ptr);
+    extern proc chpl_execute_module_deinit(deinitFun:chpl__c_fn_ptr);
 
     if printModuleDeinitOrder then
       printf("Deinitializing Modules:\n");

--- a/modules/minimal/internal/ChapelUtil.chpl
+++ b/modules/minimal/internal/ChapelUtil.chpl
@@ -43,7 +43,7 @@ module ChapelUtil {
   export proc chpl_libraryModuleLevelCleanup() {}
 
   // Deinitialization of modules and global variables will not happen.
-  proc chpl_addModule(moduleName, deinitFun: chpl__c_fn_ptr) { }
+  proc chpl_addModule(moduleName, deinitFun: chpl_c_fn_ptr) { }
 
   export proc chpl_deinitModules() { }
 }

--- a/modules/minimal/internal/ChapelUtil.chpl
+++ b/modules/minimal/internal/ChapelUtil.chpl
@@ -43,7 +43,7 @@ module ChapelUtil {
   export proc chpl_libraryModuleLevelCleanup() {}
 
   // Deinitialization of modules and global variables will not happen.
-  proc chpl_addModule(moduleName, deinitFun: c_fn_ptr) { }
+  proc chpl_addModule(moduleName, deinitFun: chpl__c_fn_ptr) { }
 
   export proc chpl_deinitModules() { }
 }

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -60,6 +60,9 @@ typedef float c_float;
 typedef double c_double;
 typedef void* raw_c_void_ptr;
 typedef void* c_fn_ptr;  // a white lie
+// Rehook used for convenience in unstable-izing this soon to be removed symbol,
+// similar to c_string_rehook.
+typedef c_fn_ptr c_fn_ptr_rehook;
 typedef uintptr_t c_uintptr;
 typedef intptr_t c_intptr;
 typedef ptrdiff_t c_ptrdiff;

--- a/test/constrained-generics/hashable/user-hash-no-implements-weird.good
+++ b/test/constrained-generics/hashable/user-hash-no-implements-weird.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/Set.chpl:326: In method '_addElem':
-$CHPL_HOME/modules/standard/Set.chpl:339: warning: 'R' has a hash function that is being used by the standard library. However, 'R' does not implement hashable. In the future, this will result in an error.
-$CHPL_HOME/modules/standard/Set.chpl:339: warning: to make 'R' implement hashable, add the interface to its declaration: 'record R : hashable'
-  $CHPL_HOME/modules/standard/Set.chpl:300: called as (set(R,false))._addElem(elem: R) from method 'init='
-  $CHPL_HOME/modules/internal/ChapelBase.chpl:2461: called as (set(R,false)).init=(other: set(R,false))
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: In method '_addElem':
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: 'R' has a hash function that is being used by the standard library. However, 'R' does not implement hashable. In the future, this will result in an error.
+$CHPL_HOME/modules/standard/Set.chpl:nnnn: warning: to make 'R' implement hashable, add the interface to its declaration: 'record R : hashable'
+  $CHPL_HOME/modules/standard/Set.chpl:nnnn: called as (set(R,false))._addElem(elem: R) from method 'init='
+  $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: called as (set(R,false)).init=(other: set(R,false))

--- a/test/constrained-generics/hashable/user-hash-no-implements-weird.prediff
+++ b/test/constrained-generics/hashable/user-hash-no-implements-weird.prediff
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Remove test sensitivity to line numbers in module files.
+
+TESTNAME=$1
+OUTFILE=$2
+TMPFILE=$OUTFILE.prediff.tmp
+
+# filter out line numbers
+sed -E 's/\.chpl:[0-9]*:/\.chpl:nnnn:/' < $OUTFILE > $TMPFILE
+cat $TMPFILE > $OUTFILE

--- a/test/unstable/c_fn_ptr.chpl
+++ b/test/unstable/c_fn_ptr.chpl
@@ -1,0 +1,1 @@
+var x : c_fn_ptr;

--- a/test/unstable/c_fn_ptr.chpl
+++ b/test/unstable/c_fn_ptr.chpl
@@ -1,1 +1,2 @@
 var x : c_fn_ptr;
+var y : chpl_c_fn_ptr; // expect no warning for compiler-provided symbol

--- a/test/unstable/c_fn_ptr.compopts
+++ b/test/unstable/c_fn_ptr.compopts
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/unstable/c_fn_ptr.compopts
+++ b/test/unstable/c_fn_ptr.compopts
@@ -1,1 +1,0 @@
---warn-unstable

--- a/test/unstable/c_fn_ptr.good
+++ b/test/unstable/c_fn_ptr.good
@@ -1,0 +1,1 @@
+c_fn_ptr.chpl:1: warning: 'c_fn_ptr' is unstable, and may be replaced by first-class procedure functionality


### PR DESCRIPTION
Make `c_fn_ptr` unstable for 2.0, as it will likely be replaced with a better solution (FCPs) soon after 2.0.

This is done by pulling `c_fn_ptr` into `ChapelBase` as a symbol, since it's much simpler to mark as `@unstable` there than modify compiler code to consistently achieve the same effect.

Completes the 2.0 component of https://github.com/chapel-lang/chapel/issues/17994.

[reviewer info placeholder]

Testing:
- [x] local paratest
- [x] C backend paratest
- [x] gasnet paratest