### PR TITLE
Add perf annotations for 2023-08-23

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -923,6 +923,8 @@ fasta:
     - Disable enum->int casts for enums without values (#10114)
   07/14/18:
     - Optimize enum->int casts for concrete types (#10308)
+  08/23/23:
+    - Deprecate 'iokind' type and 'kind' field (#23007)
 
 fastaredux:
   01/14/14:


### PR DESCRIPTION
Add annotations for:
- Deprecate 'iokind' type and 'kind' field

There is also an Arkouda in1d performance improvement that went in between the 8th and the 16th, where we don't have data for that that I don't know the cause of yet.