### PR TITLE
Update owned and shared documentation

### DIFF
--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -2141,7 +2141,7 @@ Coercions for `shared`
 ~~~~~~~~~~~~~~~~~~~~~~
 
 As with :type:`~OwnedObject.owned`, :type:`~SharedObject.shared` supports
-coercions to the class type as well as
+coercions to the class type, as well as
 coercions from a ``shared T`` to ``shared U`` where ``T`` is a
 subclass of ``U``.
 

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -1961,7 +1961,7 @@ Owned Objects
 
 Including ``owned`` (or :record:`~SharedObject.shared`) in a class type directs
 the compiler to manage the deallocation of a class instances of that type.
-:record:`~OwnedObject.owned` is meant to be used when only one reference to an
+:type:`~OwnedObject.owned` is meant to be used when only one reference to an
 object needs to manage that object's storage at a time.
 
 Also see the above section on :ref:`Class_Lifetime_and_Borrows`.
@@ -1969,7 +1969,7 @@ Also see the above section on :ref:`Class_Lifetime_and_Borrows`.
 Using `owned`
 ~~~~~~~~~~~~~
 
-The ``new`` keyword allocates :record:`~OwnedObject.owned` classes by default.
+The ``new`` keyword allocates :type:`~OwnedObject.owned` classes by default.
 Additionally, it is possible to explicitly request an ``owned`` class instance
 
 .. code-block:: chapel
@@ -1985,7 +1985,7 @@ be deleted. It is possible to transfer the ownership to another ``owned``
 variable before that happens.
 
 Copy initializing from ``myOwnedObject`` or assigning it to another
-:record:`~OwnedObject.owned` will leave ``myOwnedObject`` storing a nil value
+:type:`~OwnedObject.owned` will leave ``myOwnedObject`` storing a nil value
 and transfer the owned class instance to the other value.
 
 .. code-block:: chapel
@@ -2015,8 +2015,8 @@ Borrowing from `owned`
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The :proc:`~OwnedObject.owned.borrow` method returns the pointer managed by the
-:record:`~OwnedObject.owned`. This pointer is only valid as long as the
-:record:`~OwnedObject.owned` is storing that pointer.
+:type:`~OwnedObject.owned`. This pointer is only valid as long as the
+:type:`~OwnedObject.owned` is storing that pointer.
 
 The compiler includes a component called the lifetime checker that
 can, in many cases, check that a `borrow` does not refer to an object
@@ -2039,7 +2039,7 @@ Coercions for `owned`
 ~~~~~~~~~~~~~~~~~~~~~
 
 The compiler includes support for introducing automatic coercions
-from :record:`~OwnedObject.owned` to the borrow type. This is equivalent
+from :type:`~OwnedObject.owned` to the borrow type. This is equivalent
 to calling the :proc:`~OwnedObject.owned.borrow` method. For example:
 
 .. code-block:: chapel
@@ -2071,7 +2071,7 @@ For example:
 `owned` Default Intent
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The default intent for :record:`~OwnedObject.owned` is ``const ref``.
+The default intent for :type:`~OwnedObject.owned` is ``const ref``.
 See more on argument intents in the :ref:`Procedures Primer <primers-procedures>`
 
 .. _Owned_Methods:
@@ -2088,9 +2088,9 @@ Methods on `owned` Classes
 Shared Objects
 --------------
 
-Including ``shared`` (or :record:`~OwnedObject.owned`) in a class type directs
+Including ``shared`` (or :type:`~OwnedObject.owned`) in a class type directs
 the compiler to manage the deallocation of a class instances of that type.
-:record:`~OwnedObject.owned` is meant to be used when many different references
+:type:`~OwnedObject.owned` is meant to be used when many different references
 will exist to the object at the same time and these references need to keep
 the object alive.
 
@@ -2133,14 +2133,14 @@ The :proc:`~SharedObject.shared.borrow` method returns the pointer managed by
 the :record:`~SharedObject.shared`. This pointer is only valid as long as the
 :record:`~SharedObject.shared` is storing that pointer. The compiler includes
 some checking for errors in this case. In these ways,
-:record:`~SharedObject.shared` is similar to :record:`~OwnedObject.owned`.
+:record:`~SharedObject.shared` is similar to :type:`~OwnedObject.owned`.
 
 See :ref:`about-owned-borrowing` for more details and examples.
 
 Coercions for `shared`
 ~~~~~~~~~~~~~~~~~~~~~~
 
-As with :record:`~OwnedObject.owned`, :record:`~SharedObject.shared` supports
+As with :type:`~OwnedObject.owned`, :record:`~SharedObject.shared` supports
 coercions to the class type as well as
 coercions from a ``shared(T)`` to ``shared(U)`` where ``T`` is a
 subclass of ``U``.

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -2071,8 +2071,9 @@ For example:
 `owned` Default Intent
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The default intent for :type:`~OwnedObject.owned` is ``const ref``.
-See more on argument intents in the :ref:`Procedures Primer <primers-procedures>`
+The default intent for :type:`~OwnedObject.owned` is ``const``. See more on
+argument intents in the :ref:`Procedures Primer <primers-procedures>` and see
+more on the default intent in the :ref:`Default_Intent_for_owned_and_shared`.
 
 .. _Owned_Methods:
 
@@ -2150,8 +2151,9 @@ See :ref:`about-owned-coercions` for more details and examples.
 `shared` Default Intent
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The default intent for :type:`~SharedObject.shared` types is ``const ref``.
-See more on argument intents in the :ref:`Procedures Primer <primers-procedures>`
+The default intent for :type:`~SharedObject.shared` is ``const``. See more on
+argument intents in the :ref:`Procedures Primer <primers-procedures>` and see
+more on the default intent in the :ref:`Default_Intent_for_owned_and_shared`.
 
 .. _Shared_Methods:
 

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -1959,7 +1959,7 @@ the memory.
 Owned Objects
 -------------
 
-Including ``owned`` (or :record:`~SharedObject.shared`) in a class type directs
+Including ``owned`` (or :type:`~SharedObject.shared`) in a class type directs
 the compiler to manage the deallocation of a class instances of that type.
 :type:`~OwnedObject.owned` is meant to be used when only one reference to an
 object needs to manage that object's storage at a time.
@@ -2099,7 +2099,7 @@ Also see the above section on :ref:`Class_Lifetime_and_Borrows`.
 Using `shared`
 ~~~~~~~~~~~~~~
 
-To use :record:`~SharedObject.shared`, allocate a class instance following this
+To use :type:`~SharedObject.shared`, allocate a class instance following this
 pattern:
 
 .. code-block:: chapel
@@ -2130,17 +2130,17 @@ Borrowing from `shared`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The :proc:`~SharedObject.shared.borrow` method returns the pointer managed by
-the :record:`~SharedObject.shared`. This pointer is only valid as long as the
-:record:`~SharedObject.shared` is storing that pointer. The compiler includes
+the :type:`~SharedObject.shared`. This pointer is only valid as long as the
+:type:`~SharedObject.shared` is storing that pointer. The compiler includes
 some checking for errors in this case. In these ways,
-:record:`~SharedObject.shared` is similar to :type:`~OwnedObject.owned`.
+:type:`~SharedObject.shared` is similar to :type:`~OwnedObject.owned`.
 
 See :ref:`about-owned-borrowing` for more details and examples.
 
 Coercions for `shared`
 ~~~~~~~~~~~~~~~~~~~~~~
 
-As with :type:`~OwnedObject.owned`, :record:`~SharedObject.shared` supports
+As with :type:`~OwnedObject.owned`, :type:`~SharedObject.shared` supports
 coercions to the class type as well as
 coercions from a ``shared(T)`` to ``shared(U)`` where ``T`` is a
 subclass of ``U``.
@@ -2150,7 +2150,7 @@ See :ref:`about-owned-coercions` for more details and examples.
 `shared` Default Intent
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The default intent for :record:`~SharedObject.shared` types is ``const ref``.
+The default intent for :type:`~SharedObject.shared` types is ``const ref``.
 See more on argument intents in the :ref:`Procedures Primer <primers-procedures>`
 
 .. _Shared_Methods:

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -24,7 +24,7 @@ to an instance of that class or any of its derived classes.
 
 A class is generic if it has generic fields. A class can also be generic
 if it inherits from a generic class. Generic classes and fields are
-discussed in :ref:`Generic_Types`.
+discussed in :ref:`Generic_Types`.
 
 .. _Class_Declarations:
 
@@ -64,7 +64,7 @@ effect.
 If a class declaration contains a type alias or a parameter field, or it
 contains a variable or constant without a specified type and without an
 initialization expression, then it declares a generic class type.
-Generic classes are described in :ref:`Generic_Types`.
+Generic classes are described in :ref:`Generic_Types`.
 
    .. note::
       *Future:*.
@@ -110,7 +110,7 @@ Additionally, coercions are available that are equivalent to calling the
 
    *Example (borrowing.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 
@@ -220,8 +220,7 @@ It is an error to apply more than one memory management strategy to a
 class type. However, in some cases, generic code needs to compute a
 variant of the class type using a different memory management strategy.
 Casts from the class type to a different memory management strategy are
-available for this purpose
-(see :ref:`Explicit_Class_Conversions`).
+available for this purpose (see :ref:`Explicit_Class_Conversions`).
 
    *Example (duplicate-management.chpl)*.
 
@@ -296,13 +295,13 @@ or ``shared``. If the value is in fact ``nil``, it halts.
 
 An alternative to ``!`` is to use a cast to a non-nilable type. Such a
 cast will throw ``NilClassError`` if the value was in fact ``nil``.
-See :ref:`Explicit_Class_Conversions`.
+See :ref:`Explicit_Class_Conversions`.
 
 Non-nilable class types are implicitly convertible to nilable class
-types. See :ref:`Implicit_Class_Conversions`.
+types. See :ref:`Implicit_Class_Conversions`.
 
 Class methods generally expect a receiver of type ``borrowed C``
-(see :ref:`Class_Methods`). Since such a class method call might
+(see :ref:`Class_Methods`). Since such a class method call might
 involve dynamic dispatch, it is a program error to call a class method
 on a class receiver storing ``nil``. The compiler will not
 resolve calls to class methods if the receiver has nilable type. If the
@@ -440,7 +439,7 @@ Class Methods
 ~~~~~~~~~~~~~
 
 Methods on classes are referred to as *class methods*. They can be
-instance methods or type methods.  See :ref:`Chapter-Methods` for more
+instance methods or type methods.  See :ref:`Chapter-Methods` for more
 information about methods.
 
 Within a class method, the type of ``this`` is generally the non-nilable
@@ -574,7 +573,7 @@ It is possible for a class to inherit from a generic class. Suppose for
 example that a class ``C`` inherits from class ``ParentC``. In this
 situation, ``C`` will have type constructor arguments based upon generic
 fields in the ``ParentC`` as described
-in :ref:`Type_Constructors`. Furthermore, a fully specified ``C``
+in :ref:`Type_Constructors`. Furthermore, a fully specified ``C``
 will be a subclass of a corresponding fully specified ``ParentC``.
 
 .. _The_Root_Class:
@@ -598,7 +597,7 @@ A derived class contains data associated with the fields in its base
 classes. The fields can be accessed in the same way that they are
 accessed in their base class unless a getter method is overridden in the
 derived class, as discussed
-in :ref:`Overriding_Base_Class_Methods`.
+in :ref:`Overriding_Base_Class_Methods`.
 
 .. _Shadowing_Base_Class_Fields:
 
@@ -748,7 +747,7 @@ are initialized must be initialized in declaration order.
 Initializers for generic classes (:ref:`Generic_Types`) handle
 generic fields without default values differently and may need to
 satisfy additional requirements. See
-Section :ref:`Generic_User_Initializers` for details.
+Section :ref:`Generic_User_Initializers` for details.
 
    *Example (simpleInitializers.chpl)*.
 
@@ -1280,7 +1279,7 @@ The order and names of arguments matches the order and names of field
 declarations within the class.
 
 Generic fields are discussed in
-Section :ref:`Generic_Compiler_Generated_Initializers`.
+Section :ref:`Generic_Compiler_Generated_Initializers`.
 
 The compiler-generated initializer will initialize each field to the
 value of the corresponding actual argument.
@@ -1959,10 +1958,10 @@ the memory.
 Owned Objects
 -------------
 
-Including ``owned`` (or :type:`~SharedObject.shared`) in a class type directs
-the compiler to manage the deallocation of a class instances of that type.
-:type:`~OwnedObject.owned` is meant to be used when only one reference to an
-object needs to manage that object's storage at a time.
+Including :type:`~OwnedObject.owned` (or :type:`~SharedObject.shared`) in a
+class type directs the compiler to manage the deallocation of a class instances
+of that type. :type:`~OwnedObject.owned` is meant to be used when only one
+reference to an object needs to manage that object's storage at a time.
 
 Also see the above section on :ref:`Class_Lifetime_and_Borrows`.
 
@@ -1981,8 +1980,8 @@ Additionally, it is possible to explicitly request an ``owned`` class instance
  var myOwnedObject = new owned MyClass();
 
 When ``myOwnedObject`` goes out of scope, the class instance it refers to will
-be deleted. It is possible to transfer the ownership to another ``owned``
-variable before that happens.
+be deleted. It is possible to transfer the ownership to another
+:type:`~OwnedObject.owned` variable before that happens.
 
 Copy initializing from ``myOwnedObject`` or assigning it to another
 :type:`~OwnedObject.owned` will leave ``myOwnedObject`` storing a nil value
@@ -2002,7 +2001,7 @@ and transfer the owned class instance to the other value.
  // when myOwnedObject goes out of scope.
 
 
-``owned`` forms part of a type and can be used in type expressions:
+:type:`~OwnedObject.owned` forms part of a type and can be used in type expressions:
 
 .. code-block:: chapel
 
@@ -2089,11 +2088,11 @@ Methods on `owned` Classes
 Shared Objects
 --------------
 
-Including ``shared`` (or :type:`~OwnedObject.owned`) in a class type directs
-the compiler to manage the deallocation of a class instances of that type.
-:type:`~OwnedObject.owned` is meant to be used when many different references
-will exist to the object at the same time and these references need to keep
-the object alive.
+Including :type:`~SharedObject.shared` (or :type:`~OwnedObject.owned`) in a
+class type directs the compiler to manage the deallocation of a class instances
+of that type. :type:`~SharedObject.shared` is meant to be used when many
+different references will exist to the object at the same time and these
+references need to keep the object alive.
 
 Also see the above section on :ref:`Class_Lifetime_and_Borrows`.
 
@@ -2105,7 +2104,7 @@ pattern:
 
 .. code-block:: chapel
 
- var mySharedObject = new shared MyClass(...));
+ var mySharedObject = new shared MyClass(...);
 
 When ``mySharedObject`` and any copies of it go out of scope, the class
 instance it refers to will be deleted.
@@ -2143,7 +2142,7 @@ Coercions for `shared`
 
 As with :type:`~OwnedObject.owned`, :type:`~SharedObject.shared` supports
 coercions to the class type as well as
-coercions from a ``shared(T)`` to ``shared(U)`` where ``T`` is a
+coercions from a ``shared T`` to ``shared U`` where ``T`` is a
 subclass of ``U``.
 
 See :ref:`about-owned-coercions` for more details and examples.

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -706,6 +706,12 @@ transfer or share ownership if those arguments apply to ``owned`` or
       owned SomeClass
       true
 
+If the default intent or ``const`` intent is used for an ``owned`` or
+``shared`` argument, then the compiler is allowed to optimize the procedure
+assuming that the ``owned`` or ``shared`` actual is not changing. For example,
+the compiler could insert a ``borrowed`` temporary and replace all uses of the
+actual with it.
+
 .. _Variable_Length_Argument_Lists:
 
 Variable Number of Arguments

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -681,13 +681,13 @@ Default Intent for ’owned’ and ’shared’
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default intent for :type:`~OwnedObject.owned` and
-:type:`~SharedObject.shared` arguments is ``const ref``. Arguments can use the
+:type:`~SharedObject.shared` arguments is ``const``. Arguments can use the
 ``in`` or ``const in`` intents to transfer or share ownership if those arguments
 apply to :type:`~OwnedObject.owned` or :type:`~SharedObject.shared` types.
 
    *Example (owned-any-intent.chpl)*.
 
-   
+
 
    .. code-block:: chapel
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -681,9 +681,10 @@ Default Intent for ’owned’ and ’shared’
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default intent for :type:`~OwnedObject.owned` and
-:type:`~SharedObject.shared` arguments is ``const``. Arguments can use the
-``in`` or ``const in`` intents to transfer or share ownership if those arguments
-apply to :type:`~OwnedObject.owned` or :type:`~SharedObject.shared` types.
+:type:`~SharedObject.shared` arguments is ``const``. To transfer the ownership
+from an :type:`~OwnedObject.owned` actual argument or to share the ownership
+with a :type:`~SharedObject.shared` actual argument, the formal argument can use
+the ``in`` or ``const in`` intent.
 
    *Example (owned-any-intent.chpl)*.
 
@@ -708,10 +709,7 @@ apply to :type:`~OwnedObject.owned` or :type:`~SharedObject.shared` types.
 
 If the default intent or ``const`` intent is used for an
 :type:`~OwnedObject.owned` or :type:`~SharedObject.shared` argument, then the
-compiler is allowed to optimize the procedure assuming that the
-:type:`~OwnedObject.owned` or :type:`~SharedObject.shared` actual is not
-changing. For example, the compiler could insert a ``borrowed`` temporary and
-replace all uses of the formal with it.
+actual argument is assumed to remain unchanged during the call.
 
 .. _Variable_Length_Argument_Lists:
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -680,10 +680,10 @@ overloads (see :ref:`Return_Intent_Overloads`).
 Default Intent for ’owned’ and ’shared’
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default intent for ``owned`` and ``shared`` arguments is
-``const ref``. Arguments can use the ``in`` or ``const in`` intents to
-transfer or share ownership if those arguments apply to ``owned`` or
-``shared`` types.
+The default intent for :type:`~OwnedObject.owned` and
+:type:`~SharedObject.shared` arguments is ``const ref``. Arguments can use the
+``in`` or ``const in`` intents to transfer or share ownership if those arguments
+apply to :type:`~OwnedObject.owned` or :type:`~SharedObject.shared` types.
 
    *Example (owned-any-intent.chpl)*.
 
@@ -706,11 +706,12 @@ transfer or share ownership if those arguments apply to ``owned`` or
       owned SomeClass
       true
 
-If the default intent or ``const`` intent is used for an ``owned`` or
-``shared`` argument, then the compiler is allowed to optimize the procedure
-assuming that the ``owned`` or ``shared`` actual is not changing. For example,
-the compiler could insert a ``borrowed`` temporary and replace all uses of the
-actual with it.
+If the default intent or ``const`` intent is used for an
+:type:`~OwnedObject.owned` or :type:`~SharedObject.shared` argument, then the
+compiler is allowed to optimize the procedure assuming that the
+:type:`~OwnedObject.owned` or :type:`~SharedObject.shared` actual is not
+changing. For example, the compiler could insert a ``borrowed`` temporary and
+replace all uses of the formal with it.
 
 .. _Variable_Length_Argument_Lists:
 

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -18,21 +18,19 @@
  * limitations under the License.
  */
 
-
 /*
- */
+  :type:`owned` manages the deletion of a class instance assuming
+  that this :type:`owned` is the only thing responsible for
+  managing the lifetime of the class instance.
+*/
 module OwnedObject {
   use ChapelStandard;
 
-  /*
-     :record:`owned` manages the deletion of a class instance assuming
-     that this :record:`owned` is the only thing responsible for managing
-     the lifetime of the class instance.
-   */
   pragma "no copy"
   pragma "copy mutates"
   pragma "managed pointer"
-  record _owned {
+  @chpldoc.nodoc
+  record _ownedRecord {
     type chpl_t;                // contained type (class type)
 
     // contained pointer (class type)
@@ -42,267 +40,267 @@ module OwnedObject {
 
     // Note that the compiler also allows coercion to the borrow type.
     forwarding borrow();
+  }
 
-    /*
-       Default-initialize a :record:`owned` to store type `chpl_t`
-     */
-    pragma "leaves this nil"
-    proc init(type chpl_t) {
-      if !isClass(chpl_t) then
-        compilerError("owned only works with classes");
+  // This is important to make sure links to `owned` actually work
+  type _owned;
+  _owned = _ownedRecord;
 
-      this.chpl_t = _to_borrowed(chpl_t);
-      this.chpl_p = nil;
-    }
-
-    @chpldoc.nodoc
-    proc init(p:borrowed) {
-      compilerError("cannot initialize owned from a borrow");
-      this.init(_to_unmanaged(p));
-    }
-
-    @chpldoc.nodoc
-    proc init(pragma "nil from arg" p:unmanaged) {
-      this.chpl_t = _to_borrowed(p.type);
-      this.chpl_p = _to_borrowed(p);
-    }
-
-    @chpldoc.nodoc
-    proc init(p:?T) where isClass(T) == false &&
-                          isSubtype(T, _owned) == false  &&
-                          isIterator(p) == false {
+  /*
+    Default-initialize an :type:`owned` to store type `chpl_t`
+  */
+  pragma "leaves this nil"
+  proc _owned.init(type chpl_t) {
+    if !isClass(chpl_t) then
       compilerError("owned only works with classes");
-      this.chpl_t = T;
-      this.chpl_p = p;
-    }
 
-    /*
-       Copy-initializer. Creates a new :record:`owned`
-       that takes over ownership from `src`. `src` will
-       refer to `nil` after this call.
-     */
-    proc init=(pragma "leaves arg nil" pragma "nil from arg" ref src:_owned) {
-      // Use 'this.type.chpl_t' if it is set in case RHS is a subtype
-      this.chpl_t = if this.type.chpl_t != ?
-                    then this.type.chpl_t
-                    else _to_borrowed(src.type);
+    this.chpl_t = _to_borrowed(chpl_t);
+    this.chpl_p = nil;
+  }
 
-      if isCoercible(src.chpl_t, this.type.chpl_t) == false then
-        compilerError("cannot initialize '", this.type:string, "' from a '", src.type:string, "'");
+  @chpldoc.nodoc
+  proc _owned.init(p:borrowed) {
+    compilerError("cannot initialize owned from a borrow");
+    this.init(_to_unmanaged(p));
+  }
 
-      this.chpl_p = owned.release(src);
-      this.complete();
+  @chpldoc.nodoc
+  proc _owned.init(pragma "nil from arg" p:unmanaged) {
+    this.chpl_t = _to_borrowed(p.type);
+    this.chpl_p = _to_borrowed(p);
+  }
 
-      if isNonNilableClass(this.type) && isNilableClass(src) then
-        compilerError("cannot initialize '", this.type:string, "' from a '", src.type:string, "'");
-    }
+  @chpldoc.nodoc
+  proc _owned.init(p:?T) where isClass(T) == false &&
+                        isSubtype(T, _owned) == false  &&
+                        isIterator(p) == false {
+    compilerError("owned only works with classes");
+    this.chpl_t = T;
+    this.chpl_p = p;
+  }
 
-    @chpldoc.nodoc
-    proc init=(src: shared) {
+  /*
+    Copy-initializer. Creates a new :type:`owned` that takes over ownership
+    from `src`. `src` will refer to `nil` after this call.
+  */
+  proc _owned.init=(pragma "leaves arg nil"
+                    pragma "nil from arg" ref src:_owned) {
+    // Use 'this.type.chpl_t' if it is set in case RHS is a subtype
+    this.chpl_t = if this.type.chpl_t != ?
+                  then this.type.chpl_t
+                  else _to_borrowed(src.type);
+
+    if isCoercible(src.chpl_t, this.type.chpl_t) == false then
       compilerError("cannot initialize '", this.type:string, "' from a '", src.type:string, "'");
-      this.chpl_t = if this.type.chpl_t != ?
-                    then this.type.chpl_t
-                    else _to_borrowed(src.type);
-    }
 
-    @chpldoc.nodoc
-    proc init=(src: borrowed) {
+    this.chpl_p = owned.release(src);
+    this.complete();
+
+    if isNonNilableClass(this.type) && isNilableClass(src) then
       compilerError("cannot initialize '", this.type:string, "' from a '", src.type:string, "'");
-      this.chpl_t = if this.type.chpl_t != ?
-                    then this.type.chpl_t
-                    else _to_borrowed(src.type);
-    }
+  }
 
-    @chpldoc.nodoc
-    proc init=(src: unmanaged) {
-      compilerError("cannot initialize '", this.type:string, "' from a '", src.type:string, "'");
-      this.chpl_t = if this.type.chpl_t != ?
-                    then this.type.chpl_t
-                    else _to_borrowed(src.type);
-    }
+  @chpldoc.nodoc
+  proc _owned.init=(src: shared) {
+    compilerError("cannot initialize '", this.type:string, "' from a '", src.type:string, "'");
+    this.chpl_t = if this.type.chpl_t != ?
+                  then this.type.chpl_t
+                  else _to_borrowed(src.type);
+  }
 
-    pragma "leaves this nil"
-    @chpldoc.nodoc
-    proc init=(src : _nilType) {
-      if this.type.chpl_t == ? then
-        compilerError("Cannot establish type of owned when initializing with 'nil'");
+  @chpldoc.nodoc
+  proc _owned.init=(src: borrowed) {
+    compilerError("cannot initialize '", this.type:string, "' from a '", src.type:string, "'");
+    this.chpl_t = if this.type.chpl_t != ?
+                  then this.type.chpl_t
+                  else _to_borrowed(src.type);
+  }
 
-      this.init(this.type.chpl_t);
+  @chpldoc.nodoc
+  proc _owned.init=(src: unmanaged) {
+    compilerError("cannot initialize '", this.type:string, "' from a '", src.type:string, "'");
+    this.chpl_t = if this.type.chpl_t != ?
+                  then this.type.chpl_t
+                  else _to_borrowed(src.type);
+  }
 
-      if isNonNilableClass(chpl_t) then
-        compilerError("cannot initialize '", this.type:string, "' from 'nil'");
-    }
+  pragma "leaves this nil"
+  @chpldoc.nodoc
+  proc _owned.init=(src : _nilType) {
+    if this.type.chpl_t == ? then
+      compilerError("Cannot establish type of owned when initializing with 'nil'");
 
-    // Copy-init implementation to allow for 'new _owned(foo)' in module code
-    @chpldoc.nodoc
-    proc init(pragma "leaves arg nil" pragma "nil from arg" ref src:_owned) {
-      this.chpl_t = src.chpl_t;
-      this.chpl_p = owned.release(src);
-    }
+    this.init(this.type.chpl_t);
 
+    if isNonNilableClass(chpl_t) then
+      compilerError("cannot initialize '", this.type:string, "' from 'nil'");
+  }
 
+  // Copy-init implementation to allow for 'new _owned(foo)' in module code
+  @chpldoc.nodoc
+  proc _owned.init(pragma "leaves arg nil" pragma "nil from arg" ref src:_owned) {
+    this.chpl_t = src.chpl_t;
+    this.chpl_p = owned.release(src);
+  }
 
+  @chpldoc.nodoc
+  proc type _owned.adopt(source) {
+    compilerError("cannot adopt a ", source.type:string);
+  }
 
-    @chpldoc.nodoc
-    proc type adopt(source) {
-      compilerError("cannot adopt a ", source.type:string);
-    }
+  /*
+    Starts managing the argument class instance `obj`
+    using the `owned` memory management strategy.
+    The result type preserves nilability of the argument type.
 
-    /*
-      Starts managing the argument class instance `obj`
+    It is an error to directly delete the class instance
+    after passing it to `owned.adopt()`.
+  */
+  inline proc type _owned.adopt(pragma "nil from arg" in obj: unmanaged) {
+    return new _owned(obj);
+  }
+
+  @chpldoc.nodoc
+  proc type _owned.release(source) {
+    compilerError("cannot release a ", source.type:string);
+  }
+
+  /*
+    Empty `obj` so that it manages `nil` and
+    return the instance previously managed by this owned object.
+
+    If the argument is `nil` it returns `nil`.
+  */
+  inline proc type _owned.release(pragma "leaves arg nil" ref obj: owned) {
+    var oldPtr = obj.chpl_p;
+    type t = obj.chpl_t;
+
+    obj.chpl_p = nil;
+
+    return if _to_nilable(t) == t
+              then _to_unmanaged(oldPtr)
+              else _to_unmanaged(oldPtr!);
+  }
+
+  // Issue a compiler error for illegal uses.
+  @chpldoc.nodoc
+  proc type _owned.create(source) {
+    compilerError("cannot create an 'owned' from ", source.type:string);
+  }
+
+  /*
+    Creates a new `owned` class reference, taking over the ownership
+    of the argument. The result has the same type as the argument.
+    If the argument is non-nilable, it must be recognized by the compiler
+    as an expiring value.
+  */
+  @deprecated(notes="owned.create from an owned is deprecated - please use assignment instead")
+  inline proc type _owned.create(pragma "nil from arg" in take: owned) {
+    return take;
+  }
+
+  /* Starts managing the argument class instance `p`
       using the `owned` memory management strategy.
       The result type preserves nilability of the argument type.
 
       It is an error to directly delete the class instance
-      after passing it to `owned.adopt()`.
-    */
-    inline proc type adopt(pragma "nil from arg" in obj: unmanaged) {
-      return new _owned(obj);
-    }
+      after passing it to `owned.create()`. */
+  pragma "unsafe"
+  @deprecated(notes="owned.create from an unmanaged is deprecated - please use :proc:`owned.adopt` instead")
+  inline proc type _owned.create(pragma "nil from arg" p : unmanaged) {
+    // 'result' may have a non-nilable type
+    var result: (p.type : owned);
+    result.retain(p);
+    return result;
+  }
 
-    @chpldoc.nodoc
-    proc type release(source) {
-      compilerError("cannot release a ", source.type:string);
-    }
-
-    /*
-      Empty `obj` so that it manages `nil` and
-      return the instance previously managed by this owned object.
-
-      If the argument is `nil` it returns `nil`.
-    */
-    inline proc type release(pragma "leaves arg nil" ref obj: owned) {
-      var oldPtr = obj.chpl_p;
-      type t = obj.chpl_t;
-
-      obj.chpl_p = nil;
-
-      return if _to_nilable(t) == t
-                then _to_unmanaged(oldPtr)
-                else _to_unmanaged(oldPtr!);
-    }
-
-
-
-    // Issue a compiler error for illegal uses.
-    @chpldoc.nodoc
-    proc type create(source) {
-      compilerError("cannot create an 'owned' from ", source.type:string);
-    }
-
-    /* Creates a new `owned` class reference, taking over the ownership
-       of the argument. The result has the same type as the argument.
-       If the argument is non-nilable, it must be recognized by the compiler
-       as an expiring value. */
-    @deprecated(notes="owned.create from an owned is deprecated - please use assignment instead")
-    inline proc type create(pragma "nil from arg" in take: owned) {
-      return take;
-    }
-
-    /* Starts managing the argument class instance `p`
-       using the `owned` memory management strategy.
-       The result type preserves nilability of the argument type.
-
-       It is an error to directly delete the class instance
-       after passing it to `owned.create()`. */
-    pragma "unsafe"
-    @deprecated(notes="owned.create from an unmanaged is deprecated - please use :proc:`owned.adopt` instead")
-    inline proc type create(pragma "nil from arg" p : unmanaged) {
-      // 'result' may have a non-nilable type
-      var result: (p.type : owned);
-      result.retain(p);
-      return result;
-    }
-
-    /*
-       The deinitializer for :record:`owned` will destroy the class
-       instance it manages when the :record:`owned` goes out of scope.
-     */
-    proc deinit() {
-      if isClass(chpl_p) { // otherwise, let error happen on init call
-        if chpl_p != nil then
-          delete _to_unmanaged(chpl_p);
-      }
-    }
-
-    /*
-       Empty this :record:`owned` so that it stores `nil`.
-       Deletes the previously managed object, if any.
-     */
-    pragma "leaves this nil"
-    @deprecated(notes="owned.clear is deprecated - please assign `nil` to the owned object instead")
-    proc ref clear() {
-      if chpl_p != nil {
+  /*
+    The deinitializer for :type:`owned` will destroy the class
+    instance it manages when the :type:`owned` goes out of scope.
+  */
+  proc _owned.deinit() {
+    if isClass(chpl_p) { // otherwise, let error happen on init call
+      if chpl_p != nil then
         delete _to_unmanaged(chpl_p);
-        chpl_p = nil;
-      }
-    }
-
-
-    /*
-       Change the instance managed by this class to `newPtr`.
-       If this record was already managing a non-nil instance,
-       that instance will be deleted.
-     */
-    @deprecated(notes="owned.retain is deprecated - please use :proc:`owned.adopt` instead")
-    proc ref retain(pragma "nil from arg" newPtr:unmanaged) {
-      if !isCoercible(newPtr.type, chpl_t) then
-        compilerError("cannot retain '" + newPtr.type:string + "' " +
-                      "(expected '" + _to_unmanaged(chpl_t):string + "')");
-
-      var oldPtr = chpl_p;
-      chpl_p = newPtr;
-      if oldPtr then
-        delete _to_unmanaged(oldPtr);
-    }
-
-    /*
-       Empty this :record:`owned` so that it manages `nil`.
-       Returns the instance previously managed by this :record:`owned`.
-     */
-    pragma "leaves this nil"
-    pragma "nil from this"
-    @deprecated(notes="owned.release is deprecated - please use the :proc:`owned.release` type method instead")
-    proc ref release() {
-      var oldPtr = chpl_p;
-      chpl_p = nil;
-
-      if _to_nilable(chpl_t) == chpl_t {
-        return _to_unmanaged(oldPtr);
-      } else {
-        return _to_unmanaged(oldPtr!);
-      }
-    }
-
-    /*
-       Return the object managed by this :record:`owned` without
-       impacting its lifetime at all. It is an error to use the
-       value returned by this function after the :record:`owned`
-       goes out of scope or deletes the contained class instance
-       for another reason, such as with `=` or ``owned.adopt``.
-       In some cases such errors are caught at compile-time.
-     */
-    pragma "nil from this"
-    proc /*const*/ borrow() {
-      if _to_nilable(chpl_t) == chpl_t {
-        return chpl_p;
-      } else {
-        return chpl_p!;
-      }
-    }
-
-    @deprecated("calling `.borrow()` on an `owned` type is deprecated - please use a cast to `borrowed` instead")
-    proc type borrow() type {
-      if _to_nilable(chpl_t) == chpl_t {
-        return chpl_t;
-      } else {
-        return _to_nonnil(chpl_t);
-      }
     }
   }
 
   /*
-    Assignment between two :record:`owned` transfers ownership of the object
+    Empty this :type:`owned` so that it stores `nil`.
+    Deletes the previously managed object, if any.
+  */
+  pragma "leaves this nil"
+  @deprecated(notes="owned.clear is deprecated - please assign `nil` to the owned object instead")
+  proc ref _owned.clear() {
+    if chpl_p != nil {
+      delete _to_unmanaged(chpl_p);
+      chpl_p = nil;
+    }
+  }
+
+
+  /*
+    Change the instance managed by this class to `newPtr`. If this record was
+    already managing a non-nil instance, that instance will be deleted.
+  */
+  @deprecated(notes="owned.retain is deprecated - please use :proc:`owned.adopt` instead")
+  proc ref _owned.retain(pragma "nil from arg" newPtr:unmanaged) {
+    if !isCoercible(newPtr.type, chpl_t) then
+      compilerError("cannot retain '" + newPtr.type:string + "' " +
+                    "(expected '" + _to_unmanaged(chpl_t):string + "')");
+
+    var oldPtr = chpl_p;
+    chpl_p = newPtr;
+    if oldPtr then
+      delete _to_unmanaged(oldPtr);
+  }
+
+  /*
+    Empty this :type:`owned` so that it manages `nil`.
+    Returns the instance previously managed by this :type:`owned`.
+  */
+  pragma "leaves this nil"
+  pragma "nil from this"
+  @deprecated(notes="owned.release is deprecated - please use the :proc:`owned.release` type method instead")
+  proc ref _owned.release() {
+    var oldPtr = chpl_p;
+    chpl_p = nil;
+
+    if _to_nilable(chpl_t) == chpl_t {
+      return _to_unmanaged(oldPtr);
+    } else {
+      return _to_unmanaged(oldPtr!);
+    }
+  }
+
+  /*
+    Return the object managed by this :type:`owned` without impacting its
+    lifetime at all. It is an error to use the value returned by this function
+    after the :type:`owned` goes out of scope or deletes the contained class
+    instance for another reason, such as with `=` or ``owned.adopt``. In some
+    cases such errors are caught at compile-time.
+  */
+  pragma "nil from this"
+  proc /*const*/ _owned.borrow() {
+    if _to_nilable(chpl_t) == chpl_t {
+      return chpl_p;
+    } else {
+      return chpl_p!;
+    }
+  }
+
+  @deprecated("calling `.borrow()` on an `owned` type is deprecated - please use a cast to `borrowed` instead")
+  proc type _owned.borrow() type {
+    if _to_nilable(chpl_t) == chpl_t {
+      return chpl_t;
+    } else {
+      return _to_nonnil(chpl_t);
+    }
+  }
+
+
+  /*
+    Assignment between two :type:`owned` transfers ownership of the object
     managed by ``rhs`` to ``lhs``. This is done by setting ``rhs`` to `nil` and
     then setting ``lhs`` to point to the object that ``rhs`` managed before,
     if any. After that, it deletes the object previously managed by ``lhs``,
@@ -344,7 +342,7 @@ module OwnedObject {
     delete owned.release(lhs);
   }
   /*
-    Swap two :record:`owned` objects.
+    Swap two :type:`owned` objects.
   */
   operator <=>(ref lhs:_owned, ref rhs:lhs.type) {
     lhs.chpl_p <=> rhs.chpl_p;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -53,6 +53,7 @@ module OwnedObject {
     Default-initialize an :type:`owned` to store type `chpl_t`
   */
   pragma "leaves this nil"
+  @chpldoc.nodoc // hide init/record impl details
   proc _owned.init(type chpl_t) {
     if !isClass(chpl_t) then
       compilerError("owned only works with classes");

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -28,7 +28,7 @@ module OwnedObject {
   // If we one day support :noindexentry:, that could be applied at the module
   //   level (instead of :noindex:)
   // And then we could do :mod:`owned <OwnedObject>`
-  // For now, `fixInternalDocs.sh` will replace `record` with `type` here
+  // For now, `fixInternalDocs.sh` replaces `.. record:: owned` with `.. type:: owned`
   /*
     :type:`owned` manages the deletion of a class instance assuming
     that this :type:`owned` is the only thing responsible for

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -18,19 +18,26 @@
  * limitations under the License.
  */
 
-/*
-  :type:`owned` manages the deletion of a class instance assuming
-  that this :type:`owned` is the only thing responsible for
-  managing the lifetime of the class instance.
-*/
+/* */
 module OwnedObject {
   use ChapelStandard;
 
+  // Ideally, this can be marked with nodoc and the doc put at the module level
+  //   since owned isn't really a 'record' or a 'type'
+  // But that prevents us from referencing a "top-level" owned reference
+  // If we one day support :noindexentry:, that could be applied at the module
+  //   level (instead of :noindex:)
+  // And then we could do :mod:`owned <OwnedObject>`
+  // For now, `fixInternalDocs.sh` will replace `record` with `type` here
+  /*
+    :type:`owned` manages the deletion of a class instance assuming
+    that this :type:`owned` is the only thing responsible for
+    managing the lifetime of the class instance.
+  */
   pragma "no copy"
   pragma "copy mutates"
   pragma "managed pointer"
-  @chpldoc.nodoc
-  record _ownedRecord {
+  record _owned {
     type chpl_t;                // contained type (class type)
 
     // contained pointer (class type)
@@ -41,10 +48,6 @@ module OwnedObject {
     // Note that the compiler also allows coercion to the borrow type.
     forwarding borrow();
   }
-
-  // This is important to make sure links to `owned` actually work
-  type _owned;
-  _owned = _ownedRecord;
 
   /*
     Default-initialize an :type:`owned` to store type `chpl_t`

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -280,7 +280,7 @@ module OwnedObject {
     Return the object managed by this :type:`owned` without impacting its
     lifetime at all. It is an error to use the value returned by this function
     after the :type:`owned` goes out of scope or deletes the contained class
-    instance for another reason, such as with `=` or ``owned.adopt``. In some
+    instance for another reason, such as with `=` or :proc:`owned.adopt`. In some
     cases such errors are caught at compile-time.
   */
   pragma "nil from this"

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -133,6 +133,7 @@ module SharedObject {
 
   /* Default-initialize a :type:`shared`. */
   pragma "leaves this nil"
+  @chpldoc.nodoc // hide init/record impl details
   proc _shared.init(type chpl_t) {
     if !isClass(chpl_t) then
       compilerError("shared only works with classes");
@@ -189,6 +190,8 @@ module SharedObject {
 
     :arg take: the owned value to take ownership from
   */
+  // this init is not user facing
+  @chpldoc.nodoc
   proc _shared.init(pragma "nil from arg" in take:owned) {
     var p = take.release();
     this.chpl_t = if this.type.chpl_t == ? then _to_borrowed(p.type) else this.type.chpl_t;

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -108,7 +108,7 @@ module SharedObject {
   // If we one day support :noindexentry:, that could be applied at the module
   //   level (instead of :noindex:)
   // And then we could do :mod:`shared <SharedObject>`
-  // For now, `fixInternalDocs.sh` will replace `record` with `type` here
+  // For now, `fixInternalDocs.sh` replaces `.. record:: shared` with `.. type:: shared`
   /*
     :type:`shared` manages the deletion of a class instance in a way
     that supports multiple owners of the class instance.
@@ -428,7 +428,7 @@ module SharedObject {
     instance once there are no longer any copies of this
     :type:`shared` that refer to it.
   */
-  proc _shared.deinit() {
+  proc ref _shared.deinit() {
     if isClass(chpl_p) { // otherwise, let error happen on init call
       doClear();
     }

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -178,7 +178,7 @@ module SharedObject {
 
     /*
        Initialize a :record:`shared` taking a pointer from
-       a :record:`~OwnedObject.owned`.
+       a :type:`~OwnedObject.owned`.
 
        This :record:`shared` will take over the deletion of the class
        instance. It is an error to directly delete the class instance
@@ -502,7 +502,7 @@ module SharedObject {
   }
 
   /*
-     Set a :record:`shared` from a :record:`~OwnedObject.owned`.
+     Set a :record:`shared` from a :type:`~OwnedObject.owned`.
      Deletes the object managed by ``lhs`` if there are
      no other :record:`shared` referring to it.
      On return, ``lhs`` will refer to the object previously

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -233,6 +233,7 @@ file=OwnedObject.rst
 removeTitle $file
 replace "_owned" "owned" $file
 replace "chpl_t" "t" $file
+replace ".. record:: owned" ".. type:: owned" $file
 removeUsage $file
 ## End of OwnedObject ##
 

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -243,6 +243,7 @@ removeTitle $file
 replace "_owned" "owned" $file
 replace "_shared" "shared" $file
 replace "chpl_t" "t" $file
+replace ".. record:: shared" ".. type:: shared" $file
 removeUsage $file
 ## End of SharedObject ##
 

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -583,7 +583,7 @@ that can be copy-initialized and ``false`` otherwise.
 
 Note that even if this function returns ``true``, it might be the case that the
 type only supports copy-initialization from mutable values.
-:record:`~OwnedObject.owned` is an example of a type with that behavior.
+:type:`~OwnedObject.owned` is an example of a type with that behavior.
 
 See also the specification section :ref:`Copy_Initialization_of_Records`.
 
@@ -595,7 +595,7 @@ proc isCopyable(e) param do return isCopyableValue(e);
 Returns ``true`` if the argument is a type or an expression of a type
 that can be copy-initialized from a ``const`` value and ``false`` otherwise.
 
-Returns ``false`` for :record:`~OwnedObject.owned` because copy-initialization
+Returns ``false`` for :type:`~OwnedObject.owned` because copy-initialization
 for that type leaves the source argument storing ``nil``.
 
 See also the specification section :ref:`Copy_Initialization_of_Records`.
@@ -610,7 +610,7 @@ can be assigned from another value and ``false`` otherwise.
 
 Note that even if this function returns ``true``, it might be the case that the
 type only supports assignment from mutable values.
-:record:`~OwnedObject.owned` is an example of a type with that behavior.
+:type:`~OwnedObject.owned` is an example of a type with that behavior.
 
 See also the specification section :ref:`Record_Assignment`.
 
@@ -622,7 +622,7 @@ proc isAssignable(e) param do return isCopyableValue(e);
 Returns ``true`` if the argument is a type or expression of a type that
 can be assigned from a ``const`` value and ``false`` otherwise.
 
-Returns ``false`` for  :record:`~OwnedObject.owned` because assignment
+Returns ``false`` for  :type:`~OwnedObject.owned` because assignment
 for that type leaves the source argument storing ``nil``.
 
 See also the specification section :ref:`Record_Assignment`.


### PR DESCRIPTION
Makes a number of updates to the `owned` and `shared` documentation. Listing changes below.

- Rewrite `owned` and `shared` docs to use secondary methods so that the docs better hide the `record` implementation details.
  - closes #15114 
- Tweak default intent in the spec for `owned` and `shared` to reflect cvref changes. The compiler can assume `owned` and `shared` formals will not change during execution of the procedure body.
 
Built docs and reviewed. Ran a paratest to ensure `owned` and `shared` changes did not break anything

[Reviewed by @vasslitvinov]

For example, the `owned` docs now look like this. The `shared` docs are similar.

![Screenshot](https://github.com/chapel-lang/chapel/assets/15747900/0ad168b2-07d9-4810-8184-01a22309168f)

Implements decisions from Cray/chapel-private#5169