### PR TITLE
Add ref task intent to failing GPU test

### DIFF
--- a/test/gpu/native/studies/multiGpuStream/multiGpuStream.chpl
+++ b/test/gpu/native/studies/multiGpuStream/multiGpuStream.chpl
@@ -42,7 +42,7 @@ record times {
 
 var gpuTimes: [here.gpus.domain] times;
 
-coforall (gpu, id) in zip(here.gpus, here.gpus.domain) do on gpu {
+coforall (gpu, id) in zip(here.gpus, here.gpus.domain) with (ref gpuTimes) do on gpu {
   const GpuSpace = {id*perGpuVecSize..#perGpuVecSize};
   var GpuA: [GpuSpace] elemType;
   var gpuTimer: stopwatch;


### PR DESCRIPTION
fixes failing test by adding `ref` where needed in gpu test.

ref-maybe-const task intents were deprecated in #23049.  To modify an array inside a parallel structure like `coforall`, an explicit `ref` must now be supplied.

Tested with `CHPL_GPU=cpu`

[Not reviewed - trivial test change]
