### PR TITLE
Fix gasnet-ex Makefile

### DIFF
--- a/runtime/src/comm/gasnet/Makefile.share
+++ b/runtime/src/comm/gasnet/Makefile.share
@@ -16,21 +16,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ifeq ($(CHPL_MAKE_GASNET_VERSION),ex)
+  COMM_SUFFIX=-ex
+endif
+
 COMM_LAUNCHER_SRCS = \
         comm-gasnet-launch.c \
         comm-gasnet-locales.c \
 
 COMM_SRCS = \
+	comm-gasnet$(COMM_SUFFIX).c \
 	comm-gasnet-locales.c \
 
-ifeq ($(CHPL_MAKE_GASNET_VERSION),ex)
-  COMM_SRCS += comm-gasnet-ex.c
-else
-  COMM_SRCS += comm-gasnet.c
-endif
-
 SRCS = \
-  comm-gasnet.c \
+  comm-gasnet$(COMM_SUFFIX).c \
   comm-gasnet-launch.c \
   comm-gasnet-locales.c \
 
@@ -50,6 +49,6 @@ endif
 endif
 endif
 
-$(RUNTIME_OBJ_DIR)/comm-gasnet.o: comm-gasnet.c $(RUNTIME_OBJ_DIR_STAMP)
+$(RUNTIME_OBJ_DIR)/comm-gasnet$(COMM_SUFFIX).o: comm-gasnet$(COMM_SUFFIX).c $(RUNTIME_OBJ_DIR_STAMP)
 	$(CC) -c $(RUNTIME_CFLAGS) $(CHPL_GASNET_CFLAGS) $(RUNTIME_INCLS) -o $@ $<
 


### PR DESCRIPTION
In #23037, I missed updating some Makefile references to the source file, but didn't notice since I wasn't doing a clean build and had leftover .o's from a previous build. Fix that by updating `comm-gasnet.{c,o}` references to use a suffix set by `CHPL_GASNET_VERSION`.