### PR TITLE
Add 'llvm' as a known toolname for an attribute

### DIFF
--- a/frontend/include/chpl/framework/all-global-strings.h
+++ b/frontend/include/chpl/framework/all-global-strings.h
@@ -134,6 +134,7 @@ X(swap           , "<=>")
 X(chplBy         , "chpl_by")
 X(chplAlign      , "chpl_align")
 X(chpldocDot     , "chpldoc.")
+X(llvmDot        , "llvm.")
 X(deprecated     , "deprecated")
 X(unstable       , "unstable")
 

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1258,7 +1258,8 @@ void Visitor::checkAttributeNameRecognizedOrToolSpaced(const Attribute* node) {
       node->name() == USTR("unstable") ||
       node->name() == USTR("stable") ||
       node->name() == USTR("assertOnGpu") ||
-      node->name().startsWith(USTR("chpldoc."))) {
+      node->name().startsWith(USTR("chpldoc.")) ||
+      node->name().startsWith(USTR("llvm."))) {
       // TODO: should we match chpldoc.nodoc or anything toolspaced with chpldoc.?
       return;
   } else if (node->fullyQualifiedAttributeName().find('.') == std::string::npos) {

--- a/test/llvm/assertVectorize/assertVectorized-baseline.good
+++ b/test/llvm/assertVectorize/assertVectorized-baseline.good
@@ -1,9 +1,3 @@
-assertVectorized.chpl:5: In function 'doSum':
-assertVectorized.chpl:7: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:8: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:16: In function 'doSum2':
-assertVectorized.chpl:18: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:19: warning: Unknown attribute tool name 'llvm'
 assertVectorized.chpl:5: warning: loop was marked 'assertVectorized' but did not vectorize
 assertVectorized.chpl:16: warning: loop was marked 'assertVectorized' but did not vectorize
 result 131328

--- a/test/llvm/assertVectorize/assertVectorized-debug.good
+++ b/test/llvm/assertVectorize/assertVectorized-debug.good
@@ -1,9 +1,3 @@
-assertVectorized.chpl:5: In function 'doSum':
-assertVectorized.chpl:7: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:8: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:16: In function 'doSum2':
-assertVectorized.chpl:18: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:19: warning: Unknown attribute tool name 'llvm'
 assertVectorized.chpl:5: warning: loop on line 9 was marked 'assertVectorized' but did not vectorize
 assertVectorized.chpl:16: warning: loop on line 20 was marked 'assertVectorized' but did not vectorize
 result 131328

--- a/test/llvm/assertVectorize/assertVectorized.good
+++ b/test/llvm/assertVectorize/assertVectorized.good
@@ -1,8 +1,2 @@
-assertVectorized.chpl:5: In function 'doSum':
-assertVectorized.chpl:7: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:8: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:16: In function 'doSum2':
-assertVectorized.chpl:18: warning: Unknown attribute tool name 'llvm'
-assertVectorized.chpl:19: warning: Unknown attribute tool name 'llvm'
 result 131328
 result 7734.6

--- a/test/llvm/attributes/paramLoopAttribute.bad
+++ b/test/llvm/attributes/paramLoopAttribute.bad
@@ -1,3 +1,1 @@
-paramLoopAttribute.chpl:4: In function 'doSum':
-paramLoopAttribute.chpl:8: warning: Unknown attribute tool name 'llvm'
 paramLoopAttribute.chpl:8: error: Invalid value for 'llvm.metadata'

--- a/test/unstable/llvmMetadata.good
+++ b/test/unstable/llvmMetadata.good
@@ -1,6 +1,4 @@
 llvmMetadata.chpl:2: In function 'saxpy':
-llvmMetadata.chpl:10: warning: Unknown attribute tool name 'llvm'
 llvmMetadata.chpl:10: warning: 'llvm.assertVectorized' is an unstable attribute
-llvmMetadata.chpl:11: warning: Unknown attribute tool name 'llvm'
 llvmMetadata.chpl:11: warning: 'llvm.metadata' is an unstable attribute
 3.0 6.0 9.0 12.0 15.0 18.0 21.0 24.0 27.0 30.0 33.0 36.0 39.0 42.0 45.0 48.0


### PR DESCRIPTION
Adds `llvm` as known toolname for an attribute. All attributes under it (`assertVectorized` and `metadata`) are still marked unstable for 2.0

Tested with paratest and paratest+gasnet

[Reviewed by @e-kayrakli]

