### PR TITLE
Add ref task intents where needed in gpu tests

### DIFF
--- a/test/gpu/native/multiGPU/worksharing.chpl
+++ b/test/gpu/native/multiGPU/worksharing.chpl
@@ -38,10 +38,10 @@ for i in 1..numIters {
     var gpuChunkSize = (n-cpuSize)/numGPUs;
     const cpuRange = 0..#cpuSize;
 
-    cobegin {
+    cobegin with (ref A) {
       A[cpuRange] = B[cpuRange] + alpha * C[cpuRange];
 
-      coforall (gpu, gpuID) in zip(here.gpus, here.gpus.domain) do on gpu {
+      coforall (gpu, gpuID) in zip(here.gpus, here.gpus.domain) with (ref A) do on gpu {
         const myChunk = cpuSize+gpuID*gpuChunkSize..#gpuChunkSize;
         if debug then writeln(gpuID, ": ", myChunk);
 

--- a/test/gpu/native/multiGPU/worksharingBasic.chpl
+++ b/test/gpu/native/multiGPU/worksharingBasic.chpl
@@ -13,10 +13,10 @@ assert((n/2)%numGPUs == 0);
 
 startGpuDiagnostics();
 
-cobegin {
+cobegin with (ref A) {
   A[0..#cpuSize] += 1;
 
-  coforall (gpu, gpuID) in zip(here.gpus, here.gpus.domain) do on gpu {
+  coforall (gpu, gpuID) in zip(here.gpus, here.gpus.domain) with (ref A) do on gpu {
     const myShare = cpuSize+gpuSize*gpuID..#gpuSize;
 
     var AonThisGPU = A[myShare];

--- a/test/gpu/native/multiLocale/copyToLocaleThenToGpu.chpl
+++ b/test/gpu/native/multiLocale/copyToLocaleThenToGpu.chpl
@@ -9,7 +9,7 @@ B = 1;
 C = 2;
 
 startGpuDiagnostics();
-coforall (l,lid) in zip(Locales, LocaleSpace) do on l {
+coforall (l,lid) in zip(Locales, LocaleSpace) with (ref A) do on l {
   const perLocSize = n/numLocales;
   const locStart = lid*perLocSize;
   const locChunk = locStart..#perLocSize;
@@ -18,7 +18,7 @@ coforall (l,lid) in zip(Locales, LocaleSpace) do on l {
   var Bl = B[locChunk], Cl = C[locChunk];
 
   const numGPUs = here.gpus.size;
-  coforall (g,gid) in zip(here.gpus, here.gpus.domain) do on g {
+  coforall (g,gid) in zip(here.gpus, here.gpus.domain) with (ref A) do on g {
     const perGPUSize = perLocSize/numGPUs;
     const gpuStart = locStart+gid*perGPUSize;
     const gpuChunk = gpuStart..#perGPUSize;

--- a/test/gpu/native/multiLocale/cyclicDist.chpl
+++ b/test/gpu/native/multiLocale/cyclicDist.chpl
@@ -4,7 +4,7 @@ use CyclicDist;
 const Dom = {0..<numLocales} dmapped Cyclic(startIdx=0);
 var A : [Dom] int;
 
-coforall loc in Locales do on loc {
+coforall loc in Locales with (ref A) do on loc {
   on here.gpus[0] {
     var B : [0..10] int;
     foreach i in 0..10 {

--- a/test/gpu/native/multiLocale/directCopyToGpu.chpl
+++ b/test/gpu/native/multiLocale/directCopyToGpu.chpl
@@ -11,7 +11,7 @@ B = 1;
 C = 2;
 
 startGpuDiagnostics();
-coforall (l,lid) in zip(Locales, LocaleSpace) do on l {
+coforall (l,lid) in zip(Locales, LocaleSpace) with (ref A) do on l {
   const perLocSize = n/numLocales;
   const locStart = lid*perLocSize;
   const locChunk = locStart..#perLocSize;
@@ -21,7 +21,7 @@ coforall (l,lid) in zip(Locales, LocaleSpace) do on l {
                                   // sublocale is the sublocale. Should it be?
                                   // Probably. But maybe we need a way to query
                                   // number of siblings from a sublocale
-  coforall (g,gid) in zip(here.gpus, here.gpus.domain) do on g {
+  coforall (g,gid) in zip(here.gpus, here.gpus.domain) with (ref A) do on g {
     const perGPUSize = perLocSize/numGPUs;
     const gpuStart = locStart+gid*perGPUSize;
     const gpuChunk = gpuStart..#perGPUSize;


### PR DESCRIPTION
fixes failing tests by adding `ref` where needed in gpu tests to coforalls and cobegins.

ref-maybe-const task intents were deprecated in #23049.  To modify an array inside a parallel structure like `coforall`, an explicit `ref` must now be supplied.

- [x] Tested with paratest using Nvidia and AMD

[Not reviewed - trivial test changes]
