### PR TITLE
Fix failures under ASAN in convert-uast.cpp

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1565,12 +1565,12 @@ AggregateType* installInternalType(AggregateType* ct, AggregateType* dt) {
   return dt;
 }
 
-DefExpr* buildClassDefExpr(const char*  name,
-                           const char*  cname,
-                           AggregateTag tag,
-                           AList        inherits,
-                           BlockStmt*   decls,
-                           Flag         externFlag) {
+DefExpr* buildClassDefExpr(const char*               name,
+                           const char*               cname,
+                           AggregateTag              tag,
+                           const std::vector<Expr*>& inherits,
+                           BlockStmt*                decls,
+                           Flag                      externFlag) {
   bool isExtern = externFlag == FLAG_EXTERN;
   AggregateType* ct = NULL;
   TypeSymbol* ts = NULL;
@@ -1619,7 +1619,7 @@ DefExpr* buildClassDefExpr(const char*  name,
     ct->defaultValue=NULL;
 
     if (!inherits.empty()) {
-      USR_FATAL_CONT(inherits.first(),
+      USR_FATAL_CONT(inherits.front(),
                      "External types do not currently support inheritance");
     }
   }
@@ -1632,8 +1632,8 @@ DefExpr* buildClassDefExpr(const char*  name,
 
   ct->addDeclarations(decls);
 
-  for_alist(inherit, inherits) {
-    ct->inherits.insertAtTail(inherit->remove());
+  for (auto inherit : inherits) {
+    ct->inherits.insertAtTail(inherit);
   }
   return def;
 }

--- a/compiler/include/build.h
+++ b/compiler/include/build.h
@@ -159,12 +159,12 @@ std::set<Flag>* buildVarDeclFlags(Flag flag1 = FLAG_UNKNOWN,
 BlockStmt* buildVarDecls(BlockStmt* stmts,
                          std::set<Flag>* flags = NULL, Expr* cnameExpr = NULL);
 
-DefExpr*  buildClassDefExpr(const char*   name,
-                            const char*   cname,
-                            AggregateTag  tag,
-                            AList       inherits,
-                            BlockStmt*    decls,
-                            Flag          isExtern);
+DefExpr*  buildClassDefExpr(const char*               name,
+                            const char*               cname,
+                            AggregateTag              tag,
+                            const std::vector<Expr*>& inherits,
+                            BlockStmt*                decls,
+                            Flag                      isExtern);
 
 void setupTypeIntentArg(ArgSymbol* arg);
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3920,18 +3920,18 @@ struct Converter {
   }
 
   template <typename Iterable>
-  AList convertInheritsExprs(const Iterable& iterable, bool& inheritMarkedGeneric) {
-    AList inherits;
+  void convertInheritsExprs(const Iterable& iterable,
+                            std::vector<Expr*>& inherits,
+                            bool& inheritMarkedGeneric) {
     for (auto inheritExpr : iterable) {
       bool thisInheritMarkedGeneric = false;
       const uast::Identifier* ident =
         uast::Class::getInheritExprIdent(inheritExpr, thisInheritMarkedGeneric);
       if (auto converted = convertExprOrNull(ident)) {
-        inherits.insertAtTail(converted);
+        inherits.push_back(converted);
       }
       inheritMarkedGeneric |= thisInheritMarkedGeneric;
     }
-    return inherits;
   }
 
   Expr* convertAggregateDecl(const uast::AggregateDecl* node) {
@@ -3946,11 +3946,11 @@ struct Converter {
     const char* cname = name;
     bool inheritMarkedGeneric = false;
 
-    AList inherits;
+    std::vector<Expr*> inherits;
     if (auto cls = node->toClass()) {
-      inherits = convertInheritsExprs(cls->inheritExprs(), inheritMarkedGeneric);
+      convertInheritsExprs(cls->inheritExprs(), inherits, inheritMarkedGeneric);
     } else if (auto rec = node->toRecord()) {
-      inherits = convertInheritsExprs(rec->interfaceExprs(), inheritMarkedGeneric);
+      convertInheritsExprs(rec->interfaceExprs(), inherits, inheritMarkedGeneric);
     }
 
     if (node->linkageName()) {


### PR DESCRIPTION
I misused `AList` in my `convert-uast` code, and apparently that worked fine despite the obvious bugs. ASAN caught it; the fix was to use a `std::vector`, which is easier to pass around since `Expr`s don't internally store pointers to their container `vector` (but they do store pointers to their parent `AList`!)

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest
- [x] `make check` now works under ASAN 