### PR TITLE
Update spec to reflect ref-maybe-const work

### DIFF
--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -803,9 +803,9 @@ with the same shape.
 Array Arguments to Functions
 ----------------------------
 
-By default, arrays are passed to function by ``ref`` or ``const ref``
-depending on whether or not the formal argument is modified. The ``in``,
-``inout``, and ``out`` intent can create copies of arrays.
+By default, arrays are passed to function by ``const``, see :ref:`The_Default_Intent`.
+Using the ``ref`` intent allows modification of the array without creating a copy.
+The ``in``, ``inout``, and ``out`` intent can create copies of arrays.
 
 When a formal argument has array type, the element type of the array can
 be omitted and/or the domain of the array can be queried or omitted. In

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -168,7 +168,7 @@ method-call-expression as specified in :ref:`Method_Calls`.
       var c1: C = new C();
       c1.foo();
 
-   
+
 
    .. BLOCK-test-chapeloutput
 
@@ -194,11 +194,8 @@ receiver argument should be passed to the method.
 When no ``this-intent`` is used, a default this intent applies. For
 methods on classes and other primitive types, the default this intent is
 the same as the default intent for that type. For record methods, the
-intent for the receiver formal argument is ``ref`` or ``const ref``,
-depending on whether the formal argument is modified inside of the
-method. Programmers wishing to be explicit about whether or not record
-methods modify the receiver can explicitly use the ``ref`` or
-``const ref`` ``this-intent``.
+intent for the receiver formal argument is ``const``.
+See :ref:`The_Default_Intent`.
 
 A method whose ``this-intent`` is ``type`` defines a *type method*. It
 can only be called on the type itself rather than on an instance of the
@@ -282,9 +279,7 @@ reference, allowing modifications to ``this``. If ``this-intent`` is
 cannot be modified inside the method. The ``this-intent`` can also
 describe an abstract intent as follows. If it is ``const``, the receiver
 argument will be passed with ``const`` intent. If it is left out
-entirely, the receiver will be passed with a default intent. For
-records, that default intent is ``ref`` if ``this`` is modified within
-the function and ``const ref`` otherwise. For other types, the default
+entirely, the receiver will be passed with a default intent. The default
 ``this`` intent matches the default argument intent described in
 :ref:`The_Default_Intent`.
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -603,13 +603,13 @@ this is ``const`` for most types (as defined by
 from languages where everything is passed by ``in`` or ``ref`` intent
 by default.  Exceptions are made for types where modification is
 considered part of their nature, such as types used for synchronization
-(like ``atomic``) and arrays.
+(like ``atomic`` or ``sync``).
 
 Default argument passing for tuples applies the default
 argument passing strategy to each tuple component as if it
 was passed as a separate argument. See :ref:`Tuple_Argument_Intents`.
 
-The :ref:`Abstract_Intents_Table` that follows defines the default
+The :ref:`Abstract_Intents_Table` that follows defines the default
 intent for each type.
 
 .. _Abstract_Intents_Table:
@@ -623,57 +623,44 @@ type:
 .. table::
     :widths: 28 18 22 32
 
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    |                         | ``const`` intent     |                         |                                                      |
-    | Type                    | meaning              | Default intent meaning  | Notes                                                |
-    +=========================+======================+=========================+======================================================+
-    | scalar types            |  ``const in``        | ``const in``            |                                                      |
-    |                         |                      |                         |                                                      |
-    | (``bool``,              |                      |                         |                                                      |
-    | ``int``, ``uint``,      |                      |                         |                                                      |
-    | ``real``, ``imag``,     |                      |                         |                                                      |
-    | ``complex``)            |                      |                         |                                                      |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | string-like types       | ``const ref``        | ``const ref``           |                                                      |
-    |                         |                      |                         |                                                      |
-    | (``string``, ``bytes``) |                      |                         |                                                      |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | ranges                  | ``const in``         | ``const in``            |                                                      |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | domains / domain maps   | ``const ref``        | ``const ref``           |                                                      |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | arrays                  | ``const ref``        | ``ref`` / ``const ref`` | see :ref:`Default_Intent_for_Arrays_and_Record_this` |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | records                 | ``const ref``        | ``const ref``           | see :ref:`Default_Intent_for_Arrays_and_Record_this` |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | auto-managed classes    | ``const ref``        | ``const ref``           | see :ref:`Default_Intent_for_owned_and_shared`       |
-    | (``owned``, ``shared``) |                      |                         |                                                      |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | non-managed classes     | ``const in``         | ``const in``            |                                                      |
-    |                         |                      |                         |                                                      |
-    | (``borrowed``,          |                      |                         |                                                      |
-    | ``unmanaged``)          |                      |                         |                                                      |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | tuples                  | per-element          | per-element             | see :ref:`Tuple_Argument_Intents`                    |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | unions                  | ``const ref``        | ``const ref``           |                                                      |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-    | synchronization types   | ``const ref``        | ``ref``                 |                                                      |
-    | (``atomic``, ``sync``)  |                      |                         |                                                      |
-    +-------------------------+----------------------+-------------------------+------------------------------------------------------+
-
-.. _Default_Intent_for_Arrays_and_Record_this:
-
-Default Intent for Arrays and Record ’this’
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The default intent for arrays and for a ``this`` argument of record
-type (see :ref:`Method_receiver_and_this`) is ``ref`` or
-``const ref``. It is ``ref`` if the formal argument is modified inside
-the function, otherwise it is ``const ref``. Note that neither of these
-cause an array or record to be copied by default. The choice between
-``ref`` and ``const ref`` is similar to and interacts with return intent
-overloads (see :ref:`Return_Intent_Overloads`).
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    |                         | ``const`` intent | Default intent |                                                |
+    | Type                    | meaning          | meaning        | Notes                                          |
+    +=========================+==================+================+================================================+
+    | scalar types            |  ``const in``    |                |                                                |
+    |                         |                  |                |                                                |
+    | (``bool``,              |                  |                |                                                |
+    | ``int``, ``uint``,      |                  |                |                                                |
+    | ``real``, ``imag``,     |                  |                |                                                |
+    | ``complex``)            |                  |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | string-like types       | ``const ref``    |                |                                                |
+    |                         |                  |                |                                                |
+    | (``string``, ``bytes``) |                  |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | ranges                  | ``const in``     |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | domains / domain maps   | ``const ref``    |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | arrays                  | ``const ref``    |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | records                 | ``const ref``    |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | auto-managed classes    | ``const ref``    |                | see :ref:`Default_Intent_for_owned_and_shared` |
+    | (``owned``, ``shared``) |                  |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | non-managed classes     | ``const in``     |                |                                                |
+    |                         |                  |                |                                                |
+    | (``borrowed``,          |                  |                |                                                |
+    | ``unmanaged``)          |                  |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | tuples                  | per-element      |                | see :ref:`Tuple_Argument_Intents`              |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | unions                  | ``const ref``    |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
+    | synchronization types   | ``const ref``    | ``ref``        |                                                |
+    | (``atomic``, ``sync``)  |                  |                |                                                |
+    +-------------------------+------------------+----------------+------------------------------------------------+
 
 .. _Default_Intent_for_owned_and_shared:
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -617,15 +617,14 @@ When no intent is specified for a formal argument, the *default
 intent* is applied. It is designed to take the most natural/least
 surprising action for the argument, based on its type. In practice,
 this is ``const`` for most types (as defined by
-:ref:`The_Const_Intent`) to avoid surprises for programmers coming
-from languages where everything is passed by ``in`` or ``ref`` intent
-by default. Exceptions are made for types where modification is considered part
-of their nature, such as types used for synchronization
-(like ``atomic`` or ``sync``).
+:ref:`The_Const_Intent`) to avoid surprises for programmers coming from
+languages where everything is passed by ``in`` or ``ref`` intent by default.
 
-For the following types, the default intent is not ``const``:
+Exceptions are made for types where modification is considered part of their nature.
+In particular, the the default intent for the following types is ``ref``:
 
-  * synchronization types (``atomic``, ``sync``) - the default intent is ``ref``
+  * ``atomic``
+  * ``sync``
 
 Default argument passing for tuples applies the default
 argument passing strategy to each tuple component as if it

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -251,7 +251,7 @@ be called without parentheses.
 
    *Example (function-no-parens.chpl)*.
 
-   Given the definitions 
+   Given the definitions
 
    .. code-block:: chapel
 
@@ -265,7 +265,7 @@ be called without parentheses.
       foo;
       bar();
 
-   
+
 
    .. BLOCK-test-chapeloutput
 
@@ -297,7 +297,7 @@ actual argument to a formal argument.
 
    *Example (named-args.chpl)*.
 
-   Running the code 
+   Running the code
 
    .. code-block:: chapel
 
@@ -351,7 +351,7 @@ from the default value expression.
 
    *Example (default-values.chpl)*.
 
-   The code 
+   The code
 
    .. code-block:: chapel
 
@@ -361,7 +361,7 @@ from the default value expression.
       foo(7);
       foo(y=5);
 
-   writes out 
+   writes out
 
    .. code-block:: printoutput
 
@@ -586,9 +586,27 @@ modify the formal argument within its dynamic scope. Whether ``const``
 is interpreted as ``const in`` or ``const ref`` intent depends on the
 argument type.  Generally, small values, such as scalar types, will be
 passed by ``const in``; while larger values, such as domains and
-arrays, will be passed by ``const ref`` intent. The
-:ref:`Abstract_Intents_Table` below lists the meaning of the ``const``
-intent for each type.
+arrays, will be passed by ``const ref`` intent.
+
+For the following types, the ``const`` intent means ``const in``:
+
+  * scalar types (``bool``, ``int``, ``uint``, ``real``, ``imag``, ``complex``)
+  * ranges
+  * non-managed classes (``borrowed``, ``unmanaged``)
+
+For the following types, the ``const`` intent means ``const ref``:
+
+  * string-like types (``string``, ``bytes``)
+  * domains / domain maps
+  * arrays
+  * records
+  * auto-managed classes (``owned``, ``shared``) - see :ref:`Default_Intent_for_owned_and_shared`
+  * unions ``const ref``
+  * synchronization types (``atomic``, ``sync``)
+
+The ``const`` intent for tuples applies the ``const`` intent to each tuple
+component as if it was passed as a separate argument.
+See :ref:`Tuple_Argument_Intents`.
 
 .. _The_Default_Intent:
 
@@ -596,71 +614,22 @@ The Default Intent
 ^^^^^^^^^^^^^^^^^^
 
 When no intent is specified for a formal argument, the *default
-intent* is applied.  It is designed to take the most natural/least
-surprising action for the argument, based on its type.  In practice,
+intent* is applied. It is designed to take the most natural/least
+surprising action for the argument, based on its type. In practice,
 this is ``const`` for most types (as defined by
 :ref:`The_Const_Intent`) to avoid surprises for programmers coming
 from languages where everything is passed by ``in`` or ``ref`` intent
-by default.  Exceptions are made for types where modification is
-considered part of their nature, such as types used for synchronization
+by default. Exceptions are made for types where modification is considered part
+of their nature, such as types used for synchronization
 (like ``atomic`` or ``sync``).
+
+For the following types, the default intent is not ``const``:
+
+  * synchronization types (``atomic``, ``sync``) - the default intent is ``ref``
 
 Default argument passing for tuples applies the default
 argument passing strategy to each tuple component as if it
 was passed as a separate argument. See :ref:`Tuple_Argument_Intents`.
-
-The :ref:`Abstract_Intents_Table` that follows defines the default
-intent for each type.
-
-.. _Abstract_Intents_Table:
-
-Abstract Intents Table
-^^^^^^^^^^^^^^^^^^^^^^
-
-The following table summarizes what these abstract intents mean for each
-type:
-
-.. table::
-    :widths: 28 18 22 32
-
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    |                         | ``const`` intent | Default intent |                                                |
-    | Type                    | meaning          | meaning        | Notes                                          |
-    +=========================+==================+================+================================================+
-    | scalar types            |  ``const in``    |                |                                                |
-    |                         |                  |                |                                                |
-    | (``bool``,              |                  |                |                                                |
-    | ``int``, ``uint``,      |                  |                |                                                |
-    | ``real``, ``imag``,     |                  |                |                                                |
-    | ``complex``)            |                  |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | string-like types       | ``const ref``    |                |                                                |
-    |                         |                  |                |                                                |
-    | (``string``, ``bytes``) |                  |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | ranges                  | ``const in``     |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | domains / domain maps   | ``const ref``    |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | arrays                  | ``const ref``    |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | records                 | ``const ref``    |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | auto-managed classes    | ``const ref``    |                | see :ref:`Default_Intent_for_owned_and_shared` |
-    | (``owned``, ``shared``) |                  |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | non-managed classes     | ``const in``     |                |                                                |
-    |                         |                  |                |                                                |
-    | (``borrowed``,          |                  |                |                                                |
-    | ``unmanaged``)          |                  |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | tuples                  | per-element      |                | see :ref:`Tuple_Argument_Intents`              |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | unions                  | ``const ref``    |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
-    | synchronization types   | ``const ref``    | ``ref``        |                                                |
-    | (``atomic``, ``sync``)  |                  |                |                                                |
-    +-------------------------+------------------+----------------+------------------------------------------------+
 
 .. _Default_Intent_for_owned_and_shared:
 
@@ -724,7 +693,7 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
 
    *Example (varargs.chpl)*.
 
-   The code 
+   The code
 
    .. code-block:: chapel
 
@@ -740,7 +709,7 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
       mywriteln("hi", "there");
       mywriteln(1, 2.0, 3, 4.0);
 
-   
+
 
    .. BLOCK-test-chapeloutput
 
@@ -764,13 +733,13 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
 
    Either or both the number of variable arguments and their types can
    be specified. For example, a basic procedure to sum the values of
-   three integers can be written as 
+   three integers can be written as
 
    .. code-block:: chapel
 
       proc sum(x: int...3) do return x(0) + x(1) + x(2);
 
-   
+
 
    .. BLOCK-test-chapelpost
 
@@ -982,13 +951,13 @@ during compilation and substituted for the call expression.
 
       var x: sumOfSquares(2, 3)*int;
 
-   
+
 
    .. BLOCK-test-chapelpost
 
       writeln(x);
 
-   
+
 
    .. BLOCK-test-chapeloutput
 
@@ -1044,7 +1013,7 @@ with a conditional expression that is not a parameter.
           bt: myType(b);
       writeln((numBits(at.type), numBits(bt.type)));
 
-   
+
 
    .. BLOCK-test-chapeloutput
 
@@ -1106,7 +1075,7 @@ The syntax of the return statement is given by
    *Example (return.chpl)*.
 
    The following code defines a procedure that returns the sum of three
-   integers: 
+   integers:
 
    .. code-block:: chapel
 
@@ -1182,21 +1151,21 @@ resolution.
 
    *Example (whereClause.chpl)*.
 
-   Given two overloaded function definitions 
+   Given two overloaded function definitions
 
    .. code-block:: chapel
 
       proc foo(x) where x.type == int { writeln("int"); }
       proc foo(x) where x.type == real { writeln("real"); }
 
-   
+
 
    .. BLOCK-test-chapelpost
 
       foo(3);
       foo(3.14);
 
-   
+
 
    .. BLOCK-test-chapeloutput
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -251,7 +251,7 @@ be called without parentheses.
 
    *Example (function-no-parens.chpl)*.
 
-   Given the definitions
+   Given the definitions 
 
    .. code-block:: chapel
 
@@ -265,7 +265,7 @@ be called without parentheses.
       foo;
       bar();
 
-
+   
 
    .. BLOCK-test-chapeloutput
 
@@ -297,7 +297,7 @@ actual argument to a formal argument.
 
    *Example (named-args.chpl)*.
 
-   Running the code
+   Running the code 
 
    .. code-block:: chapel
 
@@ -351,7 +351,7 @@ from the default value expression.
 
    *Example (default-values.chpl)*.
 
-   The code
+   The code 
 
    .. code-block:: chapel
 
@@ -361,7 +361,7 @@ from the default value expression.
       foo(7);
       foo(y=5);
 
-   writes out
+   writes out 
 
    .. code-block:: printoutput
 
@@ -693,7 +693,7 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
 
    *Example (varargs.chpl)*.
 
-   The code
+   The code 
 
    .. code-block:: chapel
 
@@ -709,7 +709,7 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
       mywriteln("hi", "there");
       mywriteln(1, 2.0, 3, 4.0);
 
-
+   
 
    .. BLOCK-test-chapeloutput
 
@@ -733,13 +733,13 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
 
    Either or both the number of variable arguments and their types can
    be specified. For example, a basic procedure to sum the values of
-   three integers can be written as
+   three integers can be written as 
 
    .. code-block:: chapel
 
       proc sum(x: int...3) do return x(0) + x(1) + x(2);
 
-
+   
 
    .. BLOCK-test-chapelpost
 
@@ -951,13 +951,13 @@ during compilation and substituted for the call expression.
 
       var x: sumOfSquares(2, 3)*int;
 
-
+   
 
    .. BLOCK-test-chapelpost
 
       writeln(x);
 
-
+   
 
    .. BLOCK-test-chapeloutput
 
@@ -1013,7 +1013,7 @@ with a conditional expression that is not a parameter.
           bt: myType(b);
       writeln((numBits(at.type), numBits(bt.type)));
 
-
+   
 
    .. BLOCK-test-chapeloutput
 
@@ -1075,7 +1075,7 @@ The syntax of the return statement is given by
    *Example (return.chpl)*.
 
    The following code defines a procedure that returns the sum of three
-   integers:
+   integers: 
 
    .. code-block:: chapel
 
@@ -1151,21 +1151,21 @@ resolution.
 
    *Example (whereClause.chpl)*.
 
-   Given two overloaded function definitions
+   Given two overloaded function definitions 
 
    .. code-block:: chapel
 
       proc foo(x) where x.type == int { writeln("int"); }
       proc foo(x) where x.type == real { writeln("real"); }
 
-
+   
 
    .. BLOCK-test-chapelpost
 
       foo(3);
       foo(3.14);
 
-
+   
 
    .. BLOCK-test-chapeloutput
 

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -141,9 +141,9 @@ A record method is a function or iterator that is bound to a record. See
 the methods section :ref:`Chapter-Methods` for more information
 about methods.
 
-Note that the receiver of a record method is passed by ``ref`` or
-``const ref`` intent by default, depending on whether or not ``this`` is
-modified in the body of the method.
+The receiver of a record method is passed by ``const`` intent by default.
+A method that modifies ``this`` must declare an explicit ``this-intent`` of
+``ref``, see :ref:`Method_receiver_and_this`.
 
 .. _Nested_Record_Types:
 
@@ -751,12 +751,9 @@ Assignment of a record to a class variable is not permitted.
 Arguments
 ~~~~~~~~~
 
-Record arguments use the ``const ref`` intent by default - in contrast
-to class arguments which pass by ``const in`` intent by default.
-
-Similarly, the ``this`` receiver argument is passed by ``const in`` by
-default for class methods. In contrast, it is passed by ``ref`` or
-``const ref`` by default for record methods.
+Record arguments use the ``const`` abstract intent by default.
+Similarly, the ``this`` receiver argument is passed by ``const`` by default.
+See :ref:`The_Default_Intent` and :ref:`Method_receiver_and_this`.
 
 No *nil* Value
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Based on https://github.com/chapel-lang/chapel/issues/21398#issuecomment-1654660481, we have deprecated ref-maybe-const. This means that using the default intent no longer allows modification of record receivers or arrays. It also requires task/forall intents to modify them inside of task constructs such as [co]forall and [co]begin. This PR updates the spec to reflect that.

## Summary of changes
- remove the special section on the default intent for arrays and record this
- removes abstract intent table, as the `const` and the default intent are now the same except for `sync` and ``atomic``
  - technically also `single`, but `single` is now deprecated.
- adjust `methods.rst` and `records.rst` to list the default intent for records as `const`.
- adjust `arrays.rst` to list the default intent as `const`.

Note: this PR does not change how the default intent is specified in `tuples.rst`.

Built and checked docs

[Reviewed by @mppf]


closes cray/chapel-private#5343
