### PR TITLE
Improve chpl_launchcmd support for systems with queues and prologues

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -105,6 +105,7 @@ class AbstractJob(object):
         self.num_locales = reservation_args.numLocales
         self.walltime = reservation_args.walltime
         self.hostlist = reservation_args.hostlist
+        self.queue = reservation_args.queue
 
         logging.debug('Created instance of: {0}'.format(self))
 
@@ -112,7 +113,7 @@ class AbstractJob(object):
         """Return string representation of this instance."""
         cls_name = str(type(self))
         attrs = ', '.join(map(lambda x: '{0}={1}'.format(x, getattr(self, x, None)),
-                              ['test_command', 'num_locales', 'walltime', 'hostlist']))
+                              ['test_command', 'num_locales', 'walltime', 'hostlist', 'queue']))
         return '{0}({1})'.format(cls_name, attrs)
 
     def full_test_command(self, output_file, error_file):
@@ -253,6 +254,9 @@ class AbstractJob(object):
         """
         submit_command = self._qsub_command_base(output_file, error_file)
 
+        if self.queue is not None:
+            submit_command.append('-q')
+            submit_command.append('{0}'.format(self.queue))
         if self.num_locales >= 0:
             submit_command.append('-l')
             submit_command.append('{0}={1}{2}'.format(
@@ -348,8 +352,8 @@ class AbstractJob(object):
                     sleep_time = 1
                     exec_start_time = time.time()
                 time.sleep(sleep_time)
-                if sleep_time < 60:
-                    sleep_time *= 1.5
+                if sleep_time < 30:
+                    sleep_time *= 1.1
                 status = job_status(job_id, output_file)
 
             exec_time = time.time() - exec_start_time
@@ -386,9 +390,12 @@ class AbstractJob(object):
             with open(error_file, 'rb') as fp:
                 error = fp.read()
 
+            logging.debug('Reading more file.')
             try:
-                with open('{0}.more'.format(error_file), 'rb') as fp:
-                    error += fp.read()
+                with open('{0}.more'.format(error_file), 'r') as fp:
+                    for l in fp:
+                        if "PBS:" in l:
+                            error += py3_compat.str_to_bytes(l)
             except:
                 pass
 
@@ -662,12 +669,19 @@ class AbstractJob(object):
                             help=('Optional hostlist specification for reserving '
                                   'specific nodes. Can also be set with env var '
                                   'CHPL_LAUNCHCMD_HOSTLIST'))
+        parser.add_argument('--CHPL_LAUNCHCMD_QUEUE', dest='queue',
+                            help=('Optional queue specification for reserving '
+                                  'specific queues. Can also be set with env var '
+                                  'CHPL_LAUNCHCMD_QUEUES'))
+
 
         args, unparsed_args = parser.parse_known_args()
 
-        # Allow hostlist to be set in environment variable CHPL_LAUNCHCMD_HOSTLIST.
+        # Allow hostlist/queue to be set in environment variables.
         if args.hostlist is None:
             args.hostlist = os.environ.get('CHPL_LAUNCHCMD_HOSTLIST') or None
+        if args.queue is None:
+            args.queue = os.environ.get('CHPL_LAUNCHCMD_QUEUE') or None
 
         # It is bad form to use a two character argument with only a single
         # dash. Unfortunately, we support it. And unfortunately, python argparse
@@ -909,6 +923,10 @@ class PbsProJob(AbstractJob):
             if self.num_cpus_resource is not None:
                 select_stmt += ':{0}={1}'.format(
                     self.num_cpus_resource, self.num_cpus)
+
+        if self.queue is not None:
+            submit_command.append('-q')
+            submit_command.append('{0}'.format(self.queue))
 
         if select_stmt is not None:
             select_stmt += self.select_suffix


### PR DESCRIPTION
Add support for queues and filter out prologue/epilogue output by throwing away any PBS output that doesn't include the `PBS:` sentinel. This allows us to capture errors (like timeouts or incorrect submission) while ignoring node setup/teardown output.

While here, poll for completion a little more often since it takes a while for us to notice short running jobs have finished.

Part of https://github.com/Cray/chapel-private/issues/5295