### PR TITLE
Add ref task intent to resolve nightly failures

### DIFF
--- a/test/runtime/configMatters/forall-unordered-opt/needsFence.chpl
+++ b/test/runtime/configMatters/forall-unordered-opt/needsFence.chpl
@@ -6,7 +6,7 @@ proc histo_fence() {
   var B: [0..#M] atomic int;
   var rindex: [0..#N] int;
 
-  cobegin {
+  cobegin with (ref A, ref B) {
     {
       on Locales[numLocales-1] {
         forall r in rindex {

--- a/test/studies/nbody/md.chpl
+++ b/test/studies/nbody/md.chpl
@@ -80,7 +80,7 @@ proc try2() {
         const next_loc = (loc_i + loc_j + 1) % numLocales;
         const more_chunks = loc_j < numLocales-1;
 
-        cobegin with (ref next_dom) {
+        cobegin with (ref next_dom, ref next_array) {
 
           // Task 1: prefetch into 'next_array'
           if more_chunks then on Locales[next_loc] {


### PR DESCRIPTION
After deprecating ref-maybe-const for task intents, `ref` must be added explicitly when modifying an array inside of a parallel feature like `cobegin`

test locally

[Not reviewed - trivial test changes]