### PR TITLE
Increase GASNET_PHYSMEM_MAX for gn-ibv-fast testing

### DIFF
--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.bash
@@ -15,7 +15,7 @@ source $CWD/common-hpe-apollo.bash
 source $CWD/common-perf-hpe-apollo-hdr.bash
 
 export CHPL_GASNET_SEGMENT=fast
-export GASNET_PHYSMEM_MAX=124G
+export GASNET_PHYSMEM_MAX="0.90"
 
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance-description gn-ibv-fast -numtrials 1"


### PR DESCRIPTION
The new apollo system has more memory, so the old 124G is not enough for tests that use a fraction of memory. I stuck with that to try to keep startup times lower, but it wasn't enough so bump here.