### PR TITLE
Allow simple type casts in function formals

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4187,6 +4187,7 @@ static void cloneParameterizedPrimitive(FnSymbol* fn,
 
 static void replaceUsesWithPrimTypeof(FnSymbol* fn, ArgSymbol* formal);
 
+static bool isBorrowedTypeActual(Expr* expr);
 static bool isCastToBorrowedInFormal(ArgSymbol* formal);
 
 static bool isQueryForGenericTypeSpecifier(ArgSymbol* formal);
@@ -4210,7 +4211,7 @@ static void fixupCastFormals(FnSymbol* fn) {
     if (BlockStmt* typeExpr = formal->typeExpr) {
       if(typeExpr->body.length == 1) {
         if(CallExpr* typeCast = toCallExpr(typeExpr->body.tail)) {
-          if(typeCast->isCast()) {
+          if(typeCast->isCast() && isBorrowedTypeActual(typeCast->castTo())) {
             VarSymbol* tmp = newTemp("call_type_tmp");
             tmp->addFlag(FLAG_TYPE_VARIABLE);
             tmp->addFlag(FLAG_MAYBE_TYPE);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4307,7 +4307,7 @@ static void replaceUsesWithPrimTypeof(FnSymbol* fn, ArgSymbol* formal) {
 static bool isBorrowedTypeActual(Expr* expr) {
   if (SymExpr* se = toSymExpr(expr)) {
     if (TypeSymbol* ts = toTypeSymbol(se->symbol())) {
-      auto decoratorType = classTypeDecorator(canonicalClassType(ts->type));
+      auto decoratorType = classTypeDecorator(canonicalDecoratedClassType(ts->type));
       return isDecoratorBorrowed(decoratorType);
     }
   }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4226,9 +4226,13 @@ static void fixupCastFormals(FnSymbol* fn) {
             mod->block->insertAtTail(def);
 
             // insert the move just after we def the fromType
-            if(auto fromType = toSymExpr(typeCast->castFrom())) {
-              Symbol* fromTypeSym = toSymExpr(fromType)->symbol();
-              fromTypeSym->defPoint->insertAfter(move);
+            if(SymExpr* fromType = toSymExpr(typeCast->castFrom())) {
+              if(TypeSymbol* fromTypeSym = toTypeSymbol(fromType->symbol())) {
+                fromTypeSym->defPoint->insertAfter(move);
+              }
+              else {
+                USR_FATAL(formal, "Cannot perform a type cast on a non-type");
+              }
             } else {
               USR_FATAL(formal, "Complex expressions casted to `borrowed` in a formal type are not currently supported, consider using a helper function");
             }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4256,6 +4256,7 @@ static void fixupQueryFormals(FnSymbol* fn) {
 
       } else if (isCastToBorrowedInFormal(formal)) {
         // avoids expandQueryForGenericTypeSpecifier messing up the cast to borrowed
+        // TODO: This will still break for something like `myOwnedType:unmanaged`
       }
       else if (isQueryForGenericTypeSpecifier(formal) == true) {
         if (formal->intent == INTENT_OUT)

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4307,8 +4307,8 @@ static void replaceUsesWithPrimTypeof(FnSymbol* fn, ArgSymbol* formal) {
 static bool isBorrowedTypeActual(Expr* expr) {
   if (SymExpr* se = toSymExpr(expr)) {
     if (TypeSymbol* ts = toTypeSymbol(se->symbol())) {
-      Type* canonicalType = canonicalDecoratedClassType(ts->type);
-      if (canonicalType == dtBorrowed) return true;
+      auto decoratorType = classTypeDecorator(canonicalClassType(ts->type));
+      return isDecoratorBorrowed(decoratorType);
     }
   }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4227,8 +4227,8 @@ static void fixupCastFormals(FnSymbol* fn) {
 
             // insert the move just after we def the fromType
             if(SymExpr* fromType = toSymExpr(typeCast->castFrom())) {
-              if(TypeSymbol* fromTypeSym = toTypeSymbol(fromType->symbol())) {
-                fromTypeSym->defPoint->insertAfter(move);
+              if(fromType->symbol()->hasFlag(FLAG_TYPE_VARIABLE)) {
+                fromType->symbol()->defPoint->insertAfter(move);
               }
               else {
                 USR_FATAL(formal, "Cannot perform a type cast on a non-type");

--- a/test/functions/castFormalType-1.bad
+++ b/test/functions/castFormalType-1.bad
@@ -1,0 +1,1 @@
+castFormalType-1.chpl:7: error: Complex expressions casted to `borrowed` in a formal type are not currently supported, consider using a helper function

--- a/test/functions/castFormalType-1.chpl
+++ b/test/functions/castFormalType-1.chpl
@@ -1,0 +1,13 @@
+class MyClass {
+  var val: int;
+}
+type myOwnedType = owned MyClass;
+proc getType() type do return myOwnedType;
+
+proc bar(x: getType():borrowed) {
+  writeln(x.type:string);
+  return x.val;
+}
+
+var x = new MyClass(17);
+writeln(bar(x));

--- a/test/functions/castFormalType-1.future
+++ b/test/functions/castFormalType-1.future
@@ -1,0 +1,2 @@
+feature request: use an arbitrary cast expression in a formal type
+#22994

--- a/test/functions/castFormalType-1.good
+++ b/test/functions/castFormalType-1.good
@@ -1,0 +1,2 @@
+borrowed MyClass
+17

--- a/test/functions/castFormalType-2.bad
+++ b/test/functions/castFormalType-2.bad
@@ -1,0 +1,1 @@
+castFormalType-2.chpl:7: error: Complex expressions casted to `borrowed` in a formal type are not currently supported, consider using a helper function

--- a/test/functions/castFormalType-2.chpl
+++ b/test/functions/castFormalType-2.chpl
@@ -1,0 +1,13 @@
+class MyClass {
+  var val: int;
+}
+type myOwnedType = owned MyClass;
+proc getType() type do return myOwnedType;
+
+proc bar(x: myOwnedType:shared:borrowed) {
+  writeln(x.type:string);
+  return x.val;
+}
+
+var x = new MyClass(17);
+writeln(bar(x));

--- a/test/functions/castFormalType-2.future
+++ b/test/functions/castFormalType-2.future
@@ -1,0 +1,2 @@
+feature request: use an arbitrary cast expression in a formal type
+#22994

--- a/test/functions/castFormalType-2.good
+++ b/test/functions/castFormalType-2.good
@@ -1,0 +1,2 @@
+borrowed MyClass
+17

--- a/test/functions/castFormalType-3.bad
+++ b/test/functions/castFormalType-3.bad
@@ -1,0 +1,1 @@
+castFormalType-3.chpl:7: error: ':' undeclared (first use this function)

--- a/test/functions/castFormalType-3.bad
+++ b/test/functions/castFormalType-3.bad
@@ -1,1 +1,2 @@
+castFormalType-3.chpl:7: In function 'bar':
 castFormalType-3.chpl:7: error: ':' undeclared (first use this function)

--- a/test/functions/castFormalType-3.chpl
+++ b/test/functions/castFormalType-3.chpl
@@ -9,5 +9,5 @@ proc bar(x: myOwnedType:unmanaged) {
   return x.val;
 }
 
-var x = new MyClass(17);
+var x = new unmanaged MyClass(17);
 writeln(bar(x));

--- a/test/functions/castFormalType-3.chpl
+++ b/test/functions/castFormalType-3.chpl
@@ -1,0 +1,13 @@
+class MyClass {
+  var val: int;
+}
+type myOwnedType = owned MyClass;
+
+// will also fail with `:shared`, `:owned`, or `:MyClass` since all are generic
+proc bar(x: myOwnedType:unmanaged) {
+  writeln(x.type:string);
+  return x.val;
+}
+
+var x = new MyClass(17);
+writeln(bar(x));

--- a/test/functions/castFormalType-3.future
+++ b/test/functions/castFormalType-3.future
@@ -1,0 +1,4 @@
+feature request: use an arbitrary cast expression in a formal type
+#22994
+
+this gets messed up by fixupQueryFormals in normalize.cpp

--- a/test/functions/castFormalType-3.good
+++ b/test/functions/castFormalType-3.good
@@ -1,0 +1,2 @@
+unmanaged MyClass
+17

--- a/test/functions/castFormalType-4.bad
+++ b/test/functions/castFormalType-4.bad
@@ -1,0 +1,1 @@
+castFormalType-4.chpl:7: error: Formal 'x' cannot be declared 'void'. Consider using 'nothing' instead.

--- a/test/functions/castFormalType-4.chpl
+++ b/test/functions/castFormalType-4.chpl
@@ -1,0 +1,13 @@
+class MyClass {
+  var val: int;
+}
+type myOwnedType = owned MyClass;
+proc getType() type do return myOwnedType;
+
+proc bar(x: getType():borrowed) {
+  writeln(x.type:string);
+  return x.val;
+}
+
+var x = new MyClass(17);
+writeln(bar(x));

--- a/test/functions/castFormalType-4.chpl
+++ b/test/functions/castFormalType-4.chpl
@@ -2,9 +2,9 @@ class MyClass {
   var val: int;
 }
 type myOwnedType = owned MyClass;
-proc getType() type do return myOwnedType;
+type myUnmanagedType = unmanaged MyClass;
 
-proc bar(x: getType():borrowed) {
+proc bar(x: myOwnedType:myUnmanagedType) {
   writeln(x.type:string);
   return x.val;
 }

--- a/test/functions/castFormalType-4.future
+++ b/test/functions/castFormalType-4.future
@@ -1,0 +1,4 @@
+feature request: use an arbitrary cast expression in a formal type
+#22994
+
+this gets messed up by fixupQueryFormals in normalize.cpp

--- a/test/functions/castFormalType-4.good
+++ b/test/functions/castFormalType-4.good
@@ -1,0 +1,2 @@
+borrowed MyClass
+17

--- a/test/functions/castFormalType.chpl
+++ b/test/functions/castFormalType.chpl
@@ -1,0 +1,23 @@
+class MyClass {
+  var val: int;
+}
+type myOwnedType = owned MyClass;
+type myBorrowedType = myOwnedType:borrowed;
+proc toBorrow(type x) type do return x:borrowed;
+
+// all of these should result in a borrowed type
+proc foo(a: toBorrow(myOwnedType),
+         b: myBorrowedType,
+         c: myOwnedType:borrowed,
+         d: myOwnedType:borrowed MyClass): myOwnedType {
+  writeln((a, b, c, d));
+  writeln((a.type:string, b.type:string, c.type:string, d.type:string));
+  return new myOwnedType(a.val+b.val+c.val+d.val);
+}
+
+var a = new myOwnedType(1);
+var b = new myOwnedType(2);
+var c = new myOwnedType(3);
+var d = new myOwnedType(4);
+var res = foo(a, b, c, d);
+writeln(res);

--- a/test/functions/castFormalType.good
+++ b/test/functions/castFormalType.good
@@ -1,0 +1,3 @@
+({val = 1}, {val = 2}, {val = 3}, {val = 4})
+(borrowed MyClass, borrowed MyClass, borrowed MyClass, borrowed MyClass)
+{val = 10}

--- a/test/functions/castFormalTypeFromNonType-1.bad
+++ b/test/functions/castFormalTypeFromNonType-1.bad
@@ -1,0 +1,1 @@
+(owned MyClass, owned MyClass)

--- a/test/functions/castFormalTypeFromNonType-1.chpl
+++ b/test/functions/castFormalTypeFromNonType-1.chpl
@@ -1,0 +1,10 @@
+class MyClass {}
+type myBorrowedType = borrowed MyClass;
+
+proc bar(x, y: x) {
+  writeln((x.type:string, y.type:string));
+}
+
+var x = new MyClass();
+var y = new MyClass();
+bar(x, y);

--- a/test/functions/castFormalTypeFromNonType-1.future
+++ b/test/functions/castFormalTypeFromNonType-1.future
@@ -1,0 +1,1 @@
+Bug: should not be able to use non-types as type formals

--- a/test/functions/castFormalTypeFromNonType-1.good
+++ b/test/functions/castFormalTypeFromNonType-1.good
@@ -1,0 +1,1 @@
+castFormalTypeFromNonType-1.chpl:4: error: Cannot perform a type cast on a non-type

--- a/test/functions/castFormalTypeFromNonType-2.bad
+++ b/test/functions/castFormalTypeFromNonType-2.bad
@@ -1,0 +1,1 @@
+(owned MyClass, borrowed MyClass)

--- a/test/functions/castFormalTypeFromNonType-2.chpl
+++ b/test/functions/castFormalTypeFromNonType-2.chpl
@@ -1,0 +1,10 @@
+class MyClass {}
+type myBorrowedType = borrowed MyClass;
+
+proc bar(x, y: x:myBorrowedType) {
+  writeln((x.type:string, y.type:string));
+}
+
+var x = new MyClass();
+var y = new MyClass();
+bar(x, y);

--- a/test/functions/castFormalTypeFromNonType-2.future
+++ b/test/functions/castFormalTypeFromNonType-2.future
@@ -1,0 +1,1 @@
+Bug: should not be able to use non-types as type formals

--- a/test/functions/castFormalTypeFromNonType-2.good
+++ b/test/functions/castFormalTypeFromNonType-2.good
@@ -1,0 +1,1 @@
+castFormalTypeFromNonType-2.chpl:4: error: Cannot perform a type cast on a non-type

--- a/test/functions/castFormalTypeFromNonType-3.chpl
+++ b/test/functions/castFormalTypeFromNonType-3.chpl
@@ -1,0 +1,10 @@
+class MyClass {}
+type myBorrowedType = borrowed MyClass;
+
+proc bar(x, y: x:borrowed) {
+  writeln((x.type:string, y.type:string));
+}
+
+var x = new MyClass();
+var y = new MyClass();
+bar(x, y);

--- a/test/functions/castFormalTypeFromNonType-3.good
+++ b/test/functions/castFormalTypeFromNonType-3.good
@@ -1,0 +1,1 @@
+castFormalTypeFromNonType-3.chpl:4: error: Cannot perform a type cast on a non-type


### PR DESCRIPTION
Allows simple expressions like `myOwnedType:borrowed` to be used in function formals types.

Resolves by extracting the formal type definition to a temporary type variables during normalization. This is somewhat limited and doesn't work for more complex expressions like `getMyOwnedType():borrowed`. However, this adds an error message that should better guide users to a solution.

Added test of feature in `test/functions/castFormalType.chpl`, as well as future tests for more complex expressions

partially fixes #22994 

future work:
- make this more general beyond just simple casts to `borrowed`. For example, this should also support `myOwnedType:unmanaged`.

[Reviewed by @mppf]