### PR TITLE
Switch to using upstream qthreads task reset mechanism

### DIFF
--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -204,7 +204,7 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
     }
 }
 
-#define CHPL_TASK_IMPL_RESET_SPAWN_ORDER() qthread_chpl_reset_spawn_order()
+#define CHPL_TASK_IMPL_RESET_SPAWN_ORDER() qthread_reset_target_shep()
 
 #define CHPL_TASK_IMPL_GET_FIXED_NUM_THREADS() \
     chpl_task_impl_getFixedNumThreads()

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -22,18 +22,15 @@ as follows:
   from us using schedulers that don't support work stealing (nemesis)
   or running with work stealing disabled (distrib w/ QT_STEAL_RATIO=0)
 
-* We added a simple mechanism to reset the automatic task spawning
-  order for better affinity between consecutive parallel loops.
+* Pulled in an upstream fix for resetting task spawn order
+  https://github.com/sandialabs/qthreads/pull/136
 
 * Pulled in an upstream fix for build errors on Alpine linux
   https://github.com/sandialabs/qthreads/pull/105
 
-* We modified the configuration to support the
-  --with-hwloc-get-topology-function argument that specifies a function that
-  qthreads should call to get the hwloc topology, and several files to
-  support this behavior including the Makefile to pass this argument to
-  configure, and binders.c and hwloc.c to call the function.
+* Pulled in an upstream patch to get topology from an external function
+  https://github.com/sandialabs/qthreads/pull/133
 
-* We added --disable-hwloc-configure-checks to disable hwloc link checks,
-  and --disable-hwloc-has-distance to specify whether or not hwloc supports
-  distance information.
+* Pulled in upstream patches to make configure time check of hwloc optional
+  https://github.com/sandialabs/qthreads/pull/131
+  https://github.com/sandialabs/qthreads/pull/132

--- a/third-party/qthread/qthread-src/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.h
@@ -288,8 +288,6 @@ enum _qthread_features {
 #define QTHREAD_SPAWN_LOCAL_PRIORITY (1 << SPAWN_LOCAL_PRIORITY)
 #define QTHREAD_SPAWN_NETWORK (1 << SPAWN_NETWORK)
 
-void qthread_chpl_reset_spawn_order(void);
-
 int qthread_spawn(qthread_f             f,
                   const void           *arg,
                   size_t                arg_size,

--- a/third-party/qthread/qthread-src/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.h
@@ -300,6 +300,9 @@ int qthread_spawn(qthread_f             f,
 /* This is a function to move a thread from one shepherd to another. */
 int qthread_migrate_to(const qthread_shepherd_id_t shepherd);
 
+/* Resets the default shepherd spawn order for tasks that use NO_SHEPHERD */
+void qthread_reset_target_shep(void);
+
 /* This function sets the debug level if debugging has been enabled */
 int qthread_debuglevel(int);
 

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -2990,6 +2990,19 @@ int API_FUNC qthread_migrate_to(const qthread_shepherd_id_t shepherd)
     }
 }                      /*}}} */
 
+void API_FUNC qthread_reset_target_shep(void) {
+    assert(qthread_library_initialized);
+    qthread_t *me = qthread_internal_self();
+
+    if (me) {
+        assert(me->rdata);
+        me->rdata->shepherd_ptr->sched_shepherd = 0;
+    } else {
+        qlib->sched_shepherd = 0;
+        MACHINE_FENCE;
+    }
+}
+
 
 /* These are just accessor functions */
 unsigned int API_FUNC qthread_id(void)

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -2405,19 +2405,6 @@ void API_FUNC qthread_flushsc(void)
  */
 #define QTHREAD_SPAWN_MASK_TEAMS (QTHREAD_SPAWN_NEW_TEAM | QTHREAD_SPAWN_NEW_SUBTEAM)
 
-void API_FUNC qthread_chpl_reset_spawn_order(void) {
-    assert(qthread_library_initialized);
-    qthread_t            *me = qthread_internal_self();
-
-    if (me) {
-        assert(me->rdata);
-        me->rdata->shepherd_ptr->sched_shepherd = 0;
-    } else {
-        qlib->sched_shepherd = 0;
-        MACHINE_FENCE;
-    }
-}
-
 int API_FUNC qthread_spawn(qthread_f             f,
                            const void           *arg,
                            size_t                arg_size,


### PR DESCRIPTION
Switch from our manual patch using `qthread_chpl_reset_spawn_order()` to `qthread_reset_target_shep`, which was upstreamed to qthreads.

Same code/functionality, this just makes it easier to upgrade to the next release.

While here, update README to reflect which patches have been upstreamed