### PR TITLE
Prevent qthreads from stealing running tasks

### DIFF
--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -216,7 +216,9 @@ chpl_bool chpl_task_impl_hasFixedNumThreads(void);
 
 #define CHPL_TASK_IMPL_IS_FIXED_THREAD() (qthread_shep() != NO_SHEPHERD)
 
-#define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() CHPL_QTHREAD_TASKS_CAN_MIGRATE_THREADS
+// Even if CHPL_QTHREAD_TASKS_CAN_MIGRATE_THREADS returns true, we mark tasks
+// as unstealable once they've started, so running tasks can't migrate
+#define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() false
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -813,6 +813,9 @@ static aligned_t chapel_wrapper(void *arg)
 
     wrap_callbacks(chpl_task_cb_event_kind_begin, bundle);
 
+    // "Migrate" to ourself to mark the task as unstealable
+    qthread_migrate_to(qthread_shep());
+
     (bundle->requested_fn)(arg);
 
     wrap_callbacks(chpl_task_cb_event_kind_end, bundle);

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -17,11 +17,6 @@ Chapel modifications to Qthreads
 The modifications that we have made to the official Qthreads release are
 as follows:
 
-* We force tasks being woken from sync vars to run on their original
-  shepherd. This is to work around a task serialization bug that stems
-  from us using schedulers that don't support work stealing (nemesis)
-  or running with work stealing disabled (distrib w/ QT_STEAL_RATIO=0)
-
 * Pulled in an upstream fix for resetting task spawn order
   https://github.com/sandialabs/qthreads/pull/136
 

--- a/third-party/qthread/qthread-src/src/feb.c
+++ b/third-party/qthread/qthread-src/src/feb.c
@@ -176,11 +176,7 @@ static inline void qt_feb_schedule(qthread_t          *waiter,
     qthread_debug(FEB_DETAILS, "waiter(%p:%i), shep(%p:%i): setting waiter to 'RUNNING'\n", waiter, (int)waiter->thread_id, shep, (int)shep->shepherd_id);
     waiter->thread_state = QTHREAD_STATE_RUNNING;
     QTPERF_QTHREAD_ENTER_STATE(waiter->rdata->performance_data, QTHREAD_STATE_RUNNING);
-    // Chapel hack -- we either use schedulers that don't support work stealing
-    // (nemesis), or we run with stealing disabled (distrib w/ STEAL_RATIO=0).
-    // Spawning to the current shepherd below serializes execution and relies
-    // on work stealing to redistribute, so just always spawn to the orig shep
-    if (1) { //(waiter->flags & QTHREAD_UNSTEALABLE) && (waiter->rdata->shepherd_ptr != shep)) {
+    if ((waiter->flags & QTHREAD_UNSTEALABLE) && (waiter->rdata->shepherd_ptr != shep)) {
         qthread_debug(FEB_DETAILS, "waiter(%p:%i), shep(%p:%i): enqueueing waiter in target_shep's ready queue (%p:%i)\n", waiter, (int)waiter->thread_id, shep, (int)shep->shepherd_id, waiter->rdata->shepherd_ptr, waiter->rdata->shepherd_ptr->shepherd_id);
         qt_threadqueue_enqueue(waiter->rdata->shepherd_ptr->ready, waiter);
     } else


### PR DESCRIPTION
Disable stealing of running qthreads tasks. We have runtime code that relies on tasks not migrating to different pthreads (cache remote, parts of ofi) so we disable features or fallback to a slower implementation for (non-default) work-stealing qthreads schedulers where tasks can migrate threads. Here as a compromise, prevent stealing of running tasks. This should still allows us to load balance tasks that haven't started when using a work-stealing scheduler.

Note that our default scheduler (nemesis) doesn't support work-stealing, so this really only impacts experimental schedulers like distrib. Even for that we disabled work-stealing in #4505, but in the longer term we'd like work-stealing and I think this is a good compromise.

The current motivator was that this allows us to remove an old patch that forced tasks woken from a blocked sync var to return to the same worker thread, since it was already coded to do that for unstealable tasks. This allows us to stop carrying around an old patch and makes upgrading qthread versions easier.

Part of https://github.com/Cray/chapel-private/issues/5267