### PR TITLE
Unstabilize Associative  Domains

### DIFF
--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -86,6 +86,7 @@ module ChapelDomain {
   }
 
   pragma "runtime type init fn"
+  @unstable("Associative domains are unstable and their behavior may change in the future")
   proc chpl__buildDomainRuntimeType(dist, type idxType,
                                     param parSafe: bool = true) type {
     if isDomainType(idxType) then
@@ -223,6 +224,7 @@ module ChapelDomain {
   }
 
   // definedConst is added only for interface consistency
+  @unstable("Associative domains are unstable and their behavior may change in the future")
   proc chpl__buildDomainExpr(const keys..., definedConst) {
     param count = keys.size;
     // keyType of string literals is assumed to be type string

--- a/test/unstable/associativeDomain.chpl
+++ b/test/unstable/associativeDomain.chpl
@@ -1,0 +1,18 @@
+var A : domain(int);
+var B : domain(string);
+var C : domain(real);
+
+class X {
+  var x : int;
+}
+var D : domain(borrowed X);
+
+record Y {
+  var y : real;
+}
+var E : domain(Y);
+var y1 = new Y(), y2 = new Y();
+var G = {y1, y2};
+var F : domain(string) = {"bar", "foo"};
+var Days = {"Sunday", "Wednesday", "Saturday"};
+var intSet = {1, 2, 4, 5, 100};

--- a/test/unstable/associativeDomain.good
+++ b/test/unstable/associativeDomain.good
@@ -1,0 +1,10 @@
+associativeDomain.chpl:1: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:2: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:3: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:8: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:13: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:15: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:16: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:16: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:17: warning: Associative domains are unstable and their behavior may change in the future
+associativeDomain.chpl:18: warning: Associative domains are unstable and their behavior may change in the future

--- a/test/unstable/range-domain-binary-ops.good
+++ b/test/unstable/range-domain-binary-ops.good
@@ -5,6 +5,7 @@ range-domain-binary-ops.chpl:12: warning: '-' on ranges is unstable and may chan
 range-domain-binary-ops.chpl:13: warning: '-=' on ranges is unstable and may change in the future
 range-domain-binary-ops.chpl:15: warning: (range * range) is unstable and may change in the future
 range-domain-binary-ops.chpl:16: warning: (range ** integer) is unstable and may change in the future
+range-domain-binary-ops.chpl:22: warning: Associative domains are unstable and their behavior may change in the future
 range-domain-binary-ops.chpl:25: warning: '+' on domains is unstable and may change in the future
 range-domain-binary-ops.chpl:26: warning: '+' on domains is unstable and may change in the future
 range-domain-binary-ops.chpl:27: warning: '+=' on domains is unstable and may change in the future
@@ -15,10 +16,13 @@ range-domain-binary-ops.chpl:31: warning: '-' on domains is unstable and may cha
 range-domain-binary-ops.chpl:32: warning: '+=' on domains is unstable and may change in the future
 range-domain-binary-ops.chpl:33: warning: '-=' on domains is unstable and may change in the future
 range-domain-binary-ops.chpl:34: warning: '-=' on domains is unstable and may change in the future
+range-domain-binary-ops.chpl:35: warning: Associative domains are unstable and their behavior may change in the future
 range-domain-binary-ops.chpl:36: warning: '-' on domains is unstable and may change in the future
+range-domain-binary-ops.chpl:37: warning: Associative domains are unstable and their behavior may change in the future
 range-domain-binary-ops.chpl:37: warning: '-' on domains is unstable and may change in the future
 range-domain-binary-ops.chpl:38: warning: '-=' on domains is unstable and may change in the future
 range-domain-binary-ops.chpl:39: warning: '-=' on domains is unstable and may change in the future
+range-domain-binary-ops.chpl:44: warning: Associative domains are unstable and their behavior may change in the future
 range-domain-binary-ops.chpl:45: warning: '|' on domains is unstable and may change in the future
 range-domain-binary-ops.chpl:46: warning: '|=' on domains is unstable and may change in the future
 range-domain-binary-ops.chpl:47: warning: '&' on domains is unstable and may change in the future


### PR DESCRIPTION
From https://github.com/chapel-lang/chapel/issues/21330, we decided to mark associative domains as unstable due to issues with parallel safety. 
Covers both domain literals (ex: `{"a", "b"}`) and domain types (ex:`domain(string)`)

For stable associative-like functionality use set and map instead.


- [x] paratest
- [x] gasnet paratest