### PR TITLE
Fix a memory leak failure due to reckless unmanaged.

### DIFF
--- a/test/constrained-generics/basic/withdecl/withdecl-class-single.chpl
+++ b/test/constrained-generics/basic/withdecl/withdecl-class-single.chpl
@@ -9,4 +9,4 @@ class R: Bla {
 proc f(b: Bla) {
   writeln("The value of the bla is: ", b.bla());
 }
-f(new unmanaged R());
+f(new R());


### PR DESCRIPTION
I don't know why, but I thought we don't care about memory leaks like this in tests. Turns out, we do :)

Fortunately, `unmanaged` wasn't at all essential to this test. Using the default (owned) memory management strategy should stop the failure.

Trivial; not reviewed.