### PR TITLE
Mark foreach loops as unstable

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -162,6 +162,7 @@ struct Visitor {
 
   // Warnings.
   void warnUnstableUnions(const Union* node);
+  void warnUnstableForeachLoops(const Foreach* node);
   void warnUnstableSymbolNames(const NamedDecl* node);
 
   // Visitors.
@@ -175,6 +176,7 @@ struct Visitor {
   void visit(const Continue* node);
   void visit(const CStringLiteral* node);
   void visit(const ExternBlock* node);
+  void visit(const Foreach* node);
   void visit(const FnCall* node);
   void visit(const Function* node);
   void visit(const FunctionSignature* node);
@@ -1195,6 +1197,12 @@ void Visitor::warnUnstableUnions(const Union* node) {
              "in ways that will break their current uses.");
 }
 
+void Visitor::warnUnstableForeachLoops(const Foreach* node) {
+  if (!shouldEmitUnstableWarning(node)) return;
+  warn(node, "foreach loops are currently unstable and are expected to change "
+             "in ways that may break some of their current uses.");
+}
+
 void Visitor::warnUnstableSymbolNames(const NamedDecl* node) {
   if (!shouldEmitUnstableWarning(node)) return;
   if (!isUserCode()) return;
@@ -1394,6 +1402,10 @@ void Visitor::visit(const FunctionSignature* node) {
 
 void Visitor::visit(const Union* node) {
   warnUnstableUnions(node);
+}
+
+void Visitor::visit(const Foreach* node) {
+  warnUnstableForeachLoops(node);
 }
 
 void Visitor::visit(const Use* node) {

--- a/test/unstable/foreachLoop.chpl
+++ b/test/unstable/foreachLoop.chpl
@@ -1,0 +1,18 @@
+foreach i in 1..10 {
+  writeln(i);
+}
+
+{ // just to be sure
+  forall i in 1..10 {
+    writeln(i);
+  }
+}
+
+{ // just to be sure
+  use BlockDist;
+
+  var D = Block.createDomain(1..10);
+  forall i in D {
+    writeln(i);
+  }
+}

--- a/test/unstable/foreachLoop.compopts
+++ b/test/unstable/foreachLoop.compopts
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/unstable/foreachLoop.compopts
+++ b/test/unstable/foreachLoop.compopts
@@ -1,1 +1,0 @@
---warn-unstable

--- a/test/unstable/foreachLoop.good
+++ b/test/unstable/foreachLoop.good
@@ -1,0 +1,1 @@
+foreachLoop.chpl:1: warning: foreach loops are currently unstable and are expected to change in ways that may break some of their current uses


### PR DESCRIPTION
This PR marks foreach loops as unstable.

First and foremost, we need to implement intents on `foreach` loops, which will have breaking consequences on existing code. Also, we want to gain confidence in our vectorization support and vectorization/GPU portability in general before we can call `foreach` loops stable.

Test
- [x] added test with `--warn-unstable`
- [x] standard with `--warn-unstable`
- [x] standard