### PR TITLE
Warn for formals that are generic but don't include `(?)`

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -878,7 +878,11 @@ static void checkFormalType(const FnSymbol* enclosingFn, ArgSymbol* formal) {
     if (formal->type->symbol->hasFlag(FLAG_GENERIC) &&
         !formal->hasFlag(FLAG_MARKED_GENERIC) &&
         formal->defPoint->getModule()->modTag == MOD_USER) {
-      USR_WARN(formal, "need ? on generic formal type");
+      if (formal->type->symbol->hasFlag(FLAG_ARRAY)) {
+        // don't worry about it for array types for now
+      } else {
+        USR_WARN(formal, "need ? on generic formal type");
+      }
     }
   }
 }

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -875,7 +875,12 @@ static void checkFormalType(const FnSymbol* enclosingFn, ArgSymbol* formal) {
           "%s is given by non-type function '%s'", formal->name, target->name);
     }
 
+    bool genericWithDefaults = false;
+    if (AggregateType* at = toAggregateType(formal->type))
+      genericWithDefaults = at->isGenericWithDefaults();
+
     if (formal->type->symbol->hasFlag(FLAG_GENERIC) &&
+        !genericWithDefaults &&
         !formal->hasFlag(FLAG_MARKED_GENERIC) &&
         formal->defPoint->getModule()->modTag == MOD_USER) {
       if (formal->type->symbol->hasFlag(FLAG_ARRAY)) {

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -874,6 +874,12 @@ static void checkFormalType(const FnSymbol* enclosingFn, ArgSymbol* formal) {
           USR_FATAL_CONT(typeExp, "The declared type of the formal "
           "%s is given by non-type function '%s'", formal->name, target->name);
     }
+
+    if (formal->type->symbol->hasFlag(FLAG_GENERIC) &&
+        !formal->hasFlag(FLAG_MARKED_GENERIC) &&
+        formal->defPoint->getModule()->modTag == MOD_USER) {
+      USR_WARN(formal, "need ? on generic formal type");
+    }
   }
 }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -3409,7 +3409,6 @@ static void hack_resolve_types(ArgSymbol* arg) {
           se = toSymExpr(arg->defaultExpr->body.tail);
         if (!se || se->symbol() != gTypeDefaultToken) {
           SET_LINENO(arg->defaultExpr);
-          // white lie: `typeExpr` should be a type, not a value
           arg->typeExprFromDefaultExpr = true;
           arg->typeExpr = arg->defaultExpr->copy();
           insert_help(arg->typeExpr, NULL, arg);
@@ -3418,9 +3417,9 @@ static void hack_resolve_types(ArgSymbol* arg) {
     } else {
       INT_ASSERT(arg->typeExpr);
 
-      // If there is a simple type expression, and its type is something more specific than
-      // dtUnknown or dtAny, then replace the type expression with that type.
-      // hilde sez: don't we lose information here?
+      // If there is a simple type expression, and its type is something more
+      // specific than dtUnknown or dtAny, then replace the type expression
+      // with that type.
       if (arg->typeExpr->body.length == 1) {
         Expr* only = arg->typeExpr->body.only();
         Type* type = only->typeInfo();
@@ -3447,6 +3446,13 @@ static void hack_resolve_types(ArgSymbol* arg) {
 
         if (type != dtUnknown && type != dtAny) {
           // This test ensures that we are making progress.
+
+          if (type->symbol->hasFlag(FLAG_GENERIC) &&
+              !arg->hasFlag(FLAG_MARKED_GENERIC) &&
+              arg->defPoint->getModule()->modTag == MOD_USER) {
+            USR_WARN(arg->typeExpr, "need ? on generic formal type");
+          }
+
           arg->type = type;
           arg->typeExpr->remove();
         }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -3450,7 +3450,11 @@ static void hack_resolve_types(ArgSymbol* arg) {
           if (type->symbol->hasFlag(FLAG_GENERIC) &&
               !arg->hasFlag(FLAG_MARKED_GENERIC) &&
               arg->defPoint->getModule()->modTag == MOD_USER) {
-            USR_WARN(arg->typeExpr, "need ? on generic formal type");
+            if (type->symbol->hasFlag(FLAG_ARRAY)) {
+              // don't worry about it for array types for now
+            } else {
+              USR_WARN(arg->typeExpr, "need ? on generic formal type");
+            }
           }
 
           arg->type = type;

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -3447,7 +3447,12 @@ static void hack_resolve_types(ArgSymbol* arg) {
         if (type != dtUnknown && type != dtAny) {
           // This test ensures that we are making progress.
 
+          bool genericWithDefaults = false;
+          if (AggregateType* at = toAggregateType(type))
+            genericWithDefaults = at->isGenericWithDefaults();
+
           if (type->symbol->hasFlag(FLAG_GENERIC) &&
+              !genericWithDefaults &&
               !arg->hasFlag(FLAG_MARKED_GENERIC) &&
               arg->defPoint->getModule()->modTag == MOD_USER) {
             if (type->symbol->hasFlag(FLAG_ARRAY)) {

--- a/test/functions/generic/generic-formal-qs.chpl
+++ b/test/functions/generic/generic-formal-qs.chpl
@@ -1,0 +1,13 @@
+record R { type t; }
+proc a(arg: R) { } // warning asking this to be written as 'arg: R(?)'
+proc b(arg: R(?)) { }
+a(new R(int));
+b(new R(int));
+
+proc getGenericType() type {
+  return R(?);
+}
+proc c(arg: getGenericType()) { }
+proc d(arg: getGenericType()(?)) { }
+c(new R(int));
+d(new R(int));

--- a/test/functions/generic/generic-formal-qs.good
+++ b/test/functions/generic/generic-formal-qs.good
@@ -1,0 +1,3 @@
+generic-formal-qs.chpl:2: In function 'a':
+generic-formal-qs.chpl:2: warning: need ? on generic formal type
+generic-formal-qs.chpl:10: warning: need ? on generic formal type

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -849,7 +849,7 @@ class MyClass {
 
   // We can define an operator on our class as well, but
   // the definition has to be outside the class definition.
-  operator MyClass.+(A : MyClass, B : MyClass) : owned MyClass {
+  operator MyClass.+(A : borrowed MyClass, B : borrowed MyClass) : owned MyClass {
     return
       new MyClass(memberInt = A.getMemberInt() + B.getMemberInt(),
                   memberBool = A.getMemberBool() || B.getMemberBool());

--- a/test/release/examples/primers/specialMethods.chpl
+++ b/test/release/examples/primers/specialMethods.chpl
@@ -157,7 +157,7 @@ use IO; // required for file operations
 
 config const filename = "tempfile.txt";
 
-proc R.writeThis(ch: fileWriter) throws {
+proc R.writeThis(ch: fileWriter(?)) throws {
   ch.write("*", vals, "*");
 }
 
@@ -172,7 +172,7 @@ proc R.writeThis(ch: fileWriter) throws {
 // The ``readThis`` method defines how to read an instance of R from a
 // channel. We'll read the ``vals`` tuple between asterisks like how it
 // was written above.
-proc R.readThis(ch: fileReader) throws {
+proc R.readThis(ch: fileReader(?)) throws {
   ch.readLiteral("*");
   ch.read(vals);
   ch.readLiteral("*");


### PR DESCRIPTION
This Draft PR adds a warning for several of the following cases. 

``` chapel
record R { type t; }
proc a(arg: R) { }    // warning asking this to be written as 'arg: R(?)'
proc b(arg: R(?)) { } // OK
a(new R(int));
b(new R(int));

proc getGenericType() type {
  return R(?);
}
proc c(arg: getGenericType()) { }    // warning
proc d(arg: getGenericType()(?)) { } // OK
c(new R(int));
d(new R(int));
```

For https://github.com/Cray/chapel-private/issues/5229 / https://github.com/Cray/chapel-private/issues/4736#issuecomment-1666320252

This draft PR reflects changes to get test/release/examples/primers working but has not run through full comm=none testing yet.

Future Work:
 * warn for return types that are generic but don't include the `(?)`
 * address problems with `domain(?)` as a formal or return type
 * check if the warning is avoided for nested type queries / types with nested `?` OK

