### PR TITLE
Fix nightly test failure: update test so we can continue to use old perf key ('init', which is now a Chapel keyword)

### DIFF
--- a/test/performance/sungeun/assign_across_locales.chpl
+++ b/test/performance/sungeun/assign_across_locales.chpl
@@ -16,6 +16,15 @@ writeln("n=", n, " m=", m);
 enum testTypes {initial, lhs, rhs, both};
 
 proc dit (ref A, param ttype: testTypes) {
+  // This is a bit of a hack, we used to have this enum value as 'init' back
+  // before that was a Chapel keyword.  We use the names of these enum values
+  // as "perfkeys".  To avoid disrupting the "perfkeys" we will continue to use
+  // 'init' as the string representation for initial. If this really bothers
+  // anyone we could go about properly changing the perfkey label by using the
+  // ` util/devel/updateDatFiles.py` script.
+  var ttypeStr = ttype:string;
+  if ttypeStr == "initial" then ttypeStr = "init";
+
   for loc in Locales do
     on loc {
       var B: [1..n,1..m] real;
@@ -33,7 +42,7 @@ proc dit (ref A, param ttype: testTypes) {
       var dt = timeSinceEpoch().totalSeconds()-st;
       if doCommDiag then stopCommDiagnostics();
       if printOutput {
-        writeln("Remote ", ttype:string, " (Locale ", loc.id, "):");
+        writeln("Remote ", ttypeStr, " (Locale ", loc.id, "):");
         writeln("A:");
         on Locales(0) do writeln(A);
         writeln("B:");
@@ -41,13 +50,13 @@ proc dit (ref A, param ttype: testTypes) {
       }
       if doCommDiag {
         var Diagnostics = getCommDiagnostics();
-        writeln("Remote ", ttype:string, " (Locale ", loc.id,
+        writeln("Remote ", ttypeStr, " (Locale ", loc.id,
                 "): (gets, puts, forks, fast forks, non-blocking forks)");
         for (diagnostics, lid) in zip(Diagnostics,1..) do
           writeln(lid, ": ", diagnostics);
       }
       if printTiming {
-        writeln("Remote ", ttype:string, " (Locale ", loc.id, "): ", dt);
+        writeln("Remote ", ttypeStr, " (Locale ", loc.id, "): ", dt);
       }
       if loc.id != numLocales-1 then
         l[loc.id+1].writeEF(true);

--- a/test/performance/sungeun/assign_across_locales.good
+++ b/test/performance/sungeun/assign_across_locales.good
@@ -1,5 +1,5 @@
 n=5 m=5
-Remote initial (Locale 0):
+Remote init (Locale 0):
 A:
 1.0 1.0 1.0 1.0 1.0
 1.0 1.0 1.0 1.0 1.0


### PR DESCRIPTION
This is a test update needed after merging this PR (https://github.com/chapel-lang/chapel/pull/23025) that deals with treating 'init' as a keyword.

This test used to use 'init' as an enum value and I updated it to use 'initial' instead (since 'init' is now a keyword). The string representation of this enum value is printed to stdout and it is used as part of a perfkey.

This started causing a nightly test failure because in my previous PR I didn't update the `.perfkey` and `.graph` files for this "new" name. There are a couple of things I could do to fix this:

- Properly update the perfkey. This best practice document discusses how this can be done (https://github.hpe.com/hpe/hpc-chapel-docs/blob/main/bestPractices/updatingDatFiles.rst)
- Update the test to print things out using the old representation

I've taken the second approach as it's easier and seems less disruptive/risky but if you find this bothersome speak up and I can try the first approach.

