### PR TITLE
Super keyword

### DIFF
--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -205,6 +205,7 @@ The following identifiers are reserved as keywords:
    sparse
    string
    subdomain
+   super
    sync
    then
    these

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1100,6 +1100,7 @@ bool Visitor::isNameReservedWord(const NamedDecl* node) {
   if (name == "none") return true;
   if (name == "false") return true;
   if (name == "true") return true;
+  if (name == "super") return true;
   return false;
 }
 

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -2391,7 +2391,7 @@ module HDF5 {
     }
 
     extern record H5F_info2_t {
-      var sup : unnamedStruct1;
+      extern "super" var super_ : unnamedStruct1;
       var free : unnamedStruct2;
       var sohm : unnamedStruct3;
     }

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -2391,7 +2391,7 @@ module HDF5 {
     }
 
     extern record H5F_info2_t {
-      var super : unnamedStruct1;
+      var sup : unnamedStruct1;
       var free : unnamedStruct2;
       var sohm : unnamedStruct3;
     }

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -1016,28 +1016,28 @@ proc isCoercible(type from, type to) param {
   return __primitive("is_coercible", from, to);
 }
 
-/* Returns ``true`` if the type ``sub`` is a subtype of the type ``super``.
+/* Returns ``true`` if the type ``sub`` is a subtype of the type ``sup``.
    See also :ref:`Subtype`.
 
    In particular, returns ``true`` in any of these cases:
 
-     * ``sub`` is the same type as ``super``
-     * ``sub`` is an instantiation of a generic type ``super``
-     * ``sub`` is a class type inheriting from ``super``
-     * ``sub`` is non-nilable class type and ``super`` is the nilable version of the
+     * ``sub`` is the same type as ``sup``
+     * ``sub`` is an instantiation of a generic type ``sup``
+     * ``sub`` is a class type inheriting from ``sup``
+     * ``sub`` is non-nilable class type and ``sup`` is the nilable version of the
        same class type
    */
 pragma "docs only"
-proc isSubtype(type sub, type super) param {
-  return __primitive("is_subtype", super, sub);
+proc isSubtype(type sub, type sup) param {
+  return __primitive("is_subtype", sup, sub);
 }
 
 /* Similar to :proc:`isSubtype` but returns ``false`` if
-   ``sub`` and ``super`` refer to the same type.
+   ``sub`` and ``sup`` refer to the same type.
    */
 pragma "docs only"
-proc isProperSubtype(type sub, type super) param {
-  return __primitive("is_proper_subtype", super, sub);
+proc isProperSubtype(type sub, type sup) param {
+  return __primitive("is_proper_subtype", sup, sub);
 }
 
 /* :returns: isProperSubtype(a,b) */

--- a/test/classes/stonea/superKeyword.chpl
+++ b/test/classes/stonea/superKeyword.chpl
@@ -1,0 +1,8 @@
+module superKeyword {
+  // 'super' should be reserved as a keyword so all of the following should fail:
+  var super = 1;
+  proc super { return 42; }
+  iter super { yield 42; }
+  module super { }
+  proc foo(type super) { return 42 : super; }
+}

--- a/test/classes/stonea/superKeyword.good
+++ b/test/classes/stonea/superKeyword.good
@@ -1,0 +1,6 @@
+superKeyword.chpl:3: error: attempt to redefine reserved word 'super'
+superKeyword.chpl:4: error: attempt to redefine reserved word 'super'
+superKeyword.chpl:5: error: attempt to redefine reserved word 'super'
+superKeyword.chpl:6: error: attempt to redefine reserved word 'super'
+superKeyword.chpl:7: In function 'foo':
+superKeyword.chpl:7: error: attempt to redefine reserved word 'super'

--- a/test/domains/userAPI/contains.chpl
+++ b/test/domains/userAPI/contains.chpl
@@ -40,8 +40,8 @@ proc same(idx, d1, d2) {
   assert(d2.contains(d1));
 }
 
-proc check(idx, super, sub) {
+proc check(idx, sup, sub) {
   writeln(idx);
-  assert(super.contains(sub));
-  assert(!sub.contains(super));
+  assert(sup.contains(sub));
+  assert(!sub.contains(sup));
 }


### PR DESCRIPTION
This PR adds 'super' as a reserved word and updates tests accordingly. 

See the added [test/classes/stonea/superKeyword.chpl](https://github.com/chapel-lang/chapel/compare/main...stonea:chapel:super_keyword#diff-1a0b98eb267b6a66b9dc504a1be697359f7d354154f1325845cf7c6ffeadca2d) test for examples that now fail.

This resolves this issue: https://github.com/chapel-lang/chapel/issues/22058

## TODO:
* [X] Paratests
* [x] Paratests (gasnet)
* [x] Make sure language spec is up-to-date

