### PR TITLE
Initial steps to back context managers by the `contextManager` interface

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -3113,7 +3113,7 @@ void AggregateType::addClassToHierarchy(std::set<AggregateType*>& localSeen) {
 
       auto ifcActuals = new CallExpr(PRIM_ACTUALS_LIST, new SymExpr(implementFor));
       auto istmt = ImplementsStmt::build(isym->name, ifcActuals, nullptr);
-      this->symbol->defPoint->insertAfter(istmt);
+      this->symbol->getModule()->block->insertAtTail(istmt);
 
       expr->remove();
       continue;

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1968,6 +1968,7 @@ static TryStmt* buildTryCatchForManagerBlock(VarSymbol* managerHandle,
 
   {
     TEMP ref manager = PRIM_ADDR_OF(myManager());
+    chpl__verifyTypeContext(manager);
     USER [var/ref/const] myResource = manager.enterContext();
     TEMP errorCaught = false;
 
@@ -1997,7 +1998,10 @@ BlockStmt* buildManagerBlock(Expr* managerExpr, std::set<Flag>* flags,
   auto moveIntoHandle = new CallExpr(PRIM_MOVE, managerHandle, addrOfExpr);
   ret->insertAtTail(moveIntoHandle);
 
-  // Build call to 'enterContext()', but don't insert into the tree yet.
+  auto verifyCall = new CallExpr("chpl__verifyTypeContext", new SymExpr(managerHandle));
+  ret->insertAtTail(verifyCall);
+
+  // Build call to 'enterContext', but don't insert into the tree yet.
   auto seManager = new SymExpr(managerHandle);
   auto enterContext = new CallExpr("enterContext", gMethodToken, seManager);
 

--- a/compiler/AST/interfaces.cpp
+++ b/compiler/AST/interfaces.cpp
@@ -33,6 +33,7 @@
 //
 
 InterfaceSymbol* gHashable = nullptr;
+InterfaceSymbol* gContextManager = nullptr;
 
 static Symbol* isInterfaceFormalSymbol(Symbol* sym) {
   if (TypeSymbol* var = toTypeSymbol(sym))
@@ -71,6 +72,8 @@ DefExpr* InterfaceSymbol::buildDef(const char* name,
 
   if (gHashable == nullptr && name == astr("hashable")) {
     gHashable = isym;
+  } else if (gContextManager == nullptr && name == astr("contextManager")) {
+    gContextManager = isym;
   }
 
   for_alist(formal, formals->argList) {

--- a/compiler/AST/interfaces.cpp
+++ b/compiler/AST/interfaces.cpp
@@ -70,9 +70,9 @@ DefExpr* InterfaceSymbol::buildDef(const char* name,
 {
   InterfaceSymbol* isym = new InterfaceSymbol(name, body);
 
-  if (gHashable == nullptr && name == astr("hashable")) {
+  if (gHashable == nullptr && strcmp("hashable", name) == 0) {
     gHashable = isym;
-  } else if (gContextManager == nullptr && name == astr("contextManager")) {
+  } else if (gContextManager == nullptr && strcmp("contextManager", name) == 0) {
     gContextManager = isym;
   }
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -565,6 +565,11 @@ public:
   //  - to itself, if there is a default implementation
   //  - to gDummyWitness, otherwise
   SymbolMap  requiredFns;
+
+  // Set to true if this interface has an "eny intent" function; such interfaces
+  // cannot be used in CG functions, because the resulting intent of the call to
+  // the witness cannot be known.
+  bool hasAnyIntentFn = false;
 };
 
 extern InterfaceSymbol* gHashable;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -568,6 +568,7 @@ public:
 };
 
 extern InterfaceSymbol* gHashable;
+extern InterfaceSymbol* gContextManager;
 
 /************************************* | **************************************
 *                                                                             *

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -2042,7 +2042,7 @@ static Expr* closestInterestingScopeAnchor(Expr*   callsite,
 }
 
 static bool isAutoImplementInternalInterface(InterfaceSymbol* isym) {
-  return isym == gHashable;
+  return isym == gHashable || isym == gContextManager;
 }
 
 static Expr* anchorPointForAutoImplementInterface(InterfaceSymbol* isym,

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -970,7 +970,6 @@ static bool resolveOneAssocType(InterfaceSymbol* isym,  ImplementsStmt*   istm,
   cleanupHolder(holder);
 
   if (implAT == nullptr && shouldInfer) {
-    debuggerBreakHere();
     Type* inferredAT = inferAssociatedType(isym, istm, fml2act, holder, indent, ifcAT);
     if (!inferredAT && reportIfCannotInfer) {
       USR_FATAL_CONT(istm, "when checking this implements statement");
@@ -990,8 +989,6 @@ static bool resolveOneAssocType(InterfaceSymbol* isym,  ImplementsStmt*   istm,
                      " runtime type '%s', which is currently not implemented",
                      ifcAT->symbol->name, toString(implAT));
   }
-
-  debuggerBreakHere();
 
   return implAT != nullptr;
 }

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -1409,6 +1409,8 @@ static bool checkReturnType(InterfaceSymbol* isym,  ImplementsStmt* istm,
 static bool checkReturnIntent(InterfaceSymbol* isym,  ImplementsStmt* istm,
                               FnSymbol*      target,  FnSymbol*      reqFn,
                               bool   reportErrors) {
+  if (reqFn->hasFlag(FLAG_IFC_ANY_RETURN_INTENT)) return true;
+
   if (target->retTag == reqFn->retTag)
     return true;
 

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -844,7 +844,7 @@ static BlockStmt* createHolderBlock(FnSymbol* wrapFn, ImplementsStmt* istm) {
   return holder;
 }
 
-static bool foundTargetFunctionValid(FnSymbol* tg, bool generatedOnly) {
+static bool targetFunctionIsValid(FnSymbol* tg, bool generatedOnly) {
   // the argument is ignored for now, but in the future should be used
   // in the check below; silence "unused variable" warnings.
   (void) generatedOnly;
@@ -907,7 +907,7 @@ static Type* inferAssociatedType(InterfaceSymbol* isym,  ImplementsStmt*   istm,
   FnSymbol* target = tryResolveCall(enterContextCall);
   callStack.pop();
 
-  if (!foundTargetFunctionValid(target, false)) return nullptr;
+  if (!targetFunctionIsValid(target, false)) return nullptr;
 
   handleContextCallExpr(enterContextCall, RET_REF, target);
   resolveFunction(target); // aborts if there are errors
@@ -1548,7 +1548,7 @@ static bool resolveOneRequiredFn(InterfaceSymbol* isym,  ImplementsStmt*  istm,
   callStack.add(call);
   FnSymbol* target = tryResolveCall(call);
 
-  if (!foundTargetFunctionValid(target, generatedOnly) && addlSite != nullptr) {
+  if (!targetFunctionIsValid(target, generatedOnly) && addlSite != nullptr) {
     // the call did not resolve at this location
     cleanupHolder(holder);
     // try resolving it at 'addlSite'
@@ -1560,7 +1560,7 @@ static bool resolveOneRequiredFn(InterfaceSymbol* isym,  ImplementsStmt*  istm,
   }
 
   // do not allow representatives to help satisfy a constraint
-  if (foundTargetFunctionValid(target, generatedOnly)) {
+  if (targetFunctionIsValid(target, generatedOnly)) {
     INT_ASSERT(target->hasFlag(FLAG_PROMOTION_WRAPPER) ||
                ! target->isGeneric());
 

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -845,7 +845,10 @@ static BlockStmt* createHolderBlock(FnSymbol* wrapFn, ImplementsStmt* istm) {
 }
 
 static bool foundTargetFunctionValid(FnSymbol* tg, bool generatedOnly) {
+  // the argument is ignored for now, but in the future should be used
+  // in the check below; silence "unused variable" warnings.
   (void) generatedOnly;
+
   return tg != NULL &&
 
          // After we switch the "implicit implements" warning to an error,

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -978,9 +978,9 @@ context managers. The syntax of the manage statement is given by
     expression
 
 Classes or records that wish to be used as context managers must
-define two special methods. The code sample below turns a record
-type named ``IntWrapper`` into a context manager and then uses it
-in a manage statement.
+define two special methods, and implement the ``contextManager`` interface.
+The code sample below turns a record type named ``IntWrapper`` into a context
+manager and then uses it in a manage statement.
 
    *Example (manage1.chpl)*.
 
@@ -988,7 +988,7 @@ in a manage statement.
 
    .. code-block:: chapel
 
-      record IntWrapper {
+      record IntWrapper : contextManager {
         var x: int;
       }
 
@@ -1045,7 +1045,7 @@ Resource storage may also be specified explicitly.
 
    .. code-block:: chapel
 
-      record IntWrapper {
+      record IntWrapper : contextManager {
         var x: int;
       }
 
@@ -1112,7 +1112,7 @@ statement.
 
    .. code-block:: chapel
 
-      record IntWrapper {
+      record IntWrapper : contextManager {
         var x: int;
       }
 

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -977,10 +977,11 @@ context managers. The syntax of the manage statement is given by
     expression 'as' identifier
     expression
 
-Classes or records that wish to be used as context managers must
-define two special methods, and implement the ``contextManager`` interface.
-The code sample below turns a record type named ``IntWrapper`` into a context
-manager and then uses it in a manage statement.
+Classes or records that wish to be used as context managers must implement
+the ``contextManager`` interface. This is done by definings two special methods,
+and by adjusting the declaration of the class or record to say that it implements
+``contextManager``. The code sample below declares a context manager record
+type named ``IntWrapper`` and then uses it in a manage statement.
 
    *Example (manage1.chpl)*.
 

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -978,10 +978,11 @@ context managers. The syntax of the manage statement is given by
     expression
 
 Classes or records that wish to be used as context managers must implement
-the ``contextManager`` interface. This is done by definings two special methods,
-and by adjusting the declaration of the class or record to say that it implements
-``contextManager``. The code sample below declares a context manager record
-type named ``IntWrapper`` and then uses it in a manage statement.
+the ``contextManager`` interface. This is done by defining the methods
+``enterContext`` and ``exitContext``, and by adjusting the declaration of the
+class or record to say that it implements ``contextManager``. The code sample
+below declares a context manager record ``IntWrapper`` and then uses it in a
+manage statement.
 
    *Example (manage1.chpl)*.
 

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -303,6 +303,7 @@ PRAGMA(INFER_CUSTOM_TYPE, ypr, "infer custom type", ncm)
 PRAGMA(MANAGER_HANDLE, npr, "manager handle", ncm)
 PRAGMA(MANAGER_RESOURCE_INFER_STORAGE, npr, "manager resource infer storage", ncm)
 
+PRAGMA(IFC_ANY_RETURN_INTENT, ypr, "ifc any return intent", "allow a function with any return intent to be a witness for this interface requirement")
 // This can also mark a temp that serves as an intermediate step of
 // destructuring a tuple-typed INDEX_OF_INTEREST variable
 // into loop index variables.

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1847,7 +1847,7 @@ module ChapelBase {
     var taskInfo: c_ptr(chpl_task_infoChapel_t);
     var prevDiagsDisabledVal: bool;
 
-    inline proc ref enterContext() ref {
+    inline proc ref enterContext() {
       if !commDiagsTrackEndCounts {
         taskInfo = chpl_task_getInfoChapel();
         prevDiagsDisabledVal = chpl_task_data_setCommDiagsTemporarilyDisabled(taskInfo, true);

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1843,14 +1843,16 @@ module ChapelBase {
   config param commDiagsTrackEndCounts = false;
 
   pragma "no default functions"
-  record endCountDiagsManager {
+  record endCountDiagsManager : contextManager {
     var taskInfo: c_ptr(chpl_task_infoChapel_t);
     var prevDiagsDisabledVal: bool;
-    inline proc ref enterContext() : void {
+
+    inline proc ref enterContext() ref {
       if !commDiagsTrackEndCounts {
         taskInfo = chpl_task_getInfoChapel();
         prevDiagsDisabledVal = chpl_task_data_setCommDiagsTemporarilyDisabled(taskInfo, true);
       }
+      return none;
     }
 
     inline proc exitContext(in unused: owned Error?) {

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1852,7 +1852,6 @@ module ChapelBase {
         taskInfo = chpl_task_getInfoChapel();
         prevDiagsDisabledVal = chpl_task_data_setCommDiagsTemporarilyDisabled(taskInfo, true);
       }
-      return none;
     }
 
     inline proc exitContext(in unused: owned Error?) {

--- a/modules/internal/ChapelContext.chpl
+++ b/modules/internal/ChapelContext.chpl
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ChapelContext.chpl
+//
+// library support code for context managers feature
+module ChapelContext {
+  import Errors.Error;
+  use OwnedObject;
+
+  interface contextManager {
+      type contextReturnType;
+
+      proc Self.enterContext() ref : contextReturnType;
+      proc Self.exitContext(in error: owned Error?);
+  }
+
+  proc chpl__verifyTypeContext(x) {
+    if __primitive("implements interface", x, contextManager) == 2 then
+      compilerWarning(x.type:string + " is being used in a 'manage' statement ",
+                      "via its 'enterContext' and 'exitContext' methods. However, " + x.type:string +
+                      " does not implement contextManager. ",
+                      "In the future, this will result in an error.");
+  }
+}

--- a/modules/internal/ChapelContext.chpl
+++ b/modules/internal/ChapelContext.chpl
@@ -28,6 +28,7 @@ module ChapelContext {
   interface contextManager {
       type contextReturnType;
 
+      pragma "ifc any return intent"
       proc Self.enterContext() ref : contextReturnType;
       proc Self.exitContext(in error: owned Error?);
   }

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -1609,7 +1609,7 @@ module ChapelDomain {
       domain will be default-initialized. They can be set to desired
       values as usual, for example using an assignment operator.
     */
-    record unsafeAssignManager {
+    record unsafeAssignManager : contextManager {
       @chpldoc.nodoc
       var _lhsInstance;
 

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -72,6 +72,7 @@ module ChapelStandard {
   public use ExportWrappers;
   public use ChapelAutoAggregation;
   public use ChapelGpuSupport;
+  public use ChapelContext;
 
   // Standard modules.
   public use Types as Types;

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -188,6 +188,8 @@ GPU
   from print-module-resolution.ChapelStandard.ChapelGpuSupport.GPU
 ChapelGpuSupport
   from print-module-resolution.ChapelStandard.ChapelGpuSupport
+ChapelContext
+  from print-module-resolution.ChapelStandard.ChapelContext
 stopInitCommDiags
   from print-module-resolution.ChapelStandard.stopInitCommDiags
 ChapelStandard

--- a/test/constrained-generics/contextManager/PREDIFF
+++ b/test/constrained-generics/contextManager/PREDIFF
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+command='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+cp "$2" $2.tmp
+cat $2.tmp | sed "$command" > $2
+rm $2.tmp
+

--- a/test/constrained-generics/contextManager/PREDIFF
+++ b/test/constrained-generics/contextManager/PREDIFF
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-command='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+command='\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/'
 
 cp "$2" $2.tmp
 cat $2.tmp | sed "$command" > $2

--- a/test/constrained-generics/contextManager/basic-context-mismatch.chpl
+++ b/test/constrained-generics/contextManager/basic-context-mismatch.chpl
@@ -1,0 +1,19 @@
+record myManager : contextManager {
+    var myResource: int;
+
+    proc contextReturnType type do return string;
+
+    proc enterContext() ref {
+        writeln("entering context, resource = ", myResource);
+        return myResource;
+    }
+
+    proc exitContext(in err: owned Error?) {
+        writeln("exiting context, resource = ", myResource);
+    }
+}
+
+manage new myManager() as theResource {
+    writeln("inside the manage statement");
+    theResource = 42;
+}

--- a/test/constrained-generics/contextManager/basic-context-mismatch.chpl
+++ b/test/constrained-generics/contextManager/basic-context-mismatch.chpl
@@ -3,7 +3,7 @@ record myManager : contextManager {
 
     proc contextReturnType type do return string;
 
-    proc enterContext() ref {
+    proc ref enterContext() ref {
         writeln("entering context, resource = ", myResource);
         return myResource;
     }

--- a/test/constrained-generics/contextManager/basic-context-mismatch.good
+++ b/test/constrained-generics/contextManager/basic-context-mismatch.good
@@ -1,0 +1,6 @@
+basic-context-mismatch.chpl:1: In 'implements contextManager' statement:
+basic-context-mismatch.chpl:1: error: when checking this implements statement
+basic-context-mismatch.chpl:6: note: this implementation of the required function enterContext
+basic-context-mismatch.chpl:6: note: has return type 'int(64)'
+$CHPL_HOME/modules/internal/ChapelContext.chpl:31: note: which does not match the expected return type 'string'
+$CHPL_HOME/modules/internal/ChapelContext.chpl:31: note: the required function enterContext in the interface contextManager is declared here

--- a/test/constrained-generics/contextManager/basic-context-mismatch.good
+++ b/test/constrained-generics/contextManager/basic-context-mismatch.good
@@ -2,5 +2,5 @@ basic-context-mismatch.chpl:1: In 'implements contextManager' statement:
 basic-context-mismatch.chpl:1: error: when checking this implements statement
 basic-context-mismatch.chpl:6: note: this implementation of the required function enterContext
 basic-context-mismatch.chpl:6: note: has return type 'int(64)'
-$CHPL_HOME/modules/internal/ChapelContext.chpl:31: note: which does not match the expected return type 'string'
-$CHPL_HOME/modules/internal/ChapelContext.chpl:31: note: the required function enterContext in the interface contextManager is declared here
+$CHPL_HOME/modules/internal/ChapelContext.chpl:nnnn: note: which does not match the expected return type 'string'
+$CHPL_HOME/modules/internal/ChapelContext.chpl:nnnn: note: the required function enterContext in the interface contextManager is declared here

--- a/test/constrained-generics/contextManager/basic-context-throws.chpl
+++ b/test/constrained-generics/contextManager/basic-context-throws.chpl
@@ -1,0 +1,33 @@
+// this test matters because creating wrapper functions around contextManager
+// calls does not work: they may or may not throw. This test makes sure the
+// throwing forms still work.
+
+record myManager : contextManager {
+    var myResource: int;
+
+    proc contextReturnType type do return int;
+
+    proc enterContext() ref {
+        writeln("entering context, resource = ", myResource);
+        return myResource;
+    }
+
+    proc exitContext(in err: owned Error?) throws {
+        writeln("exiting context, resource = ", myResource);
+        if err {
+            writeln("caught an error, will rethrow: ", err);
+            throw err;
+        }
+    }
+}
+
+try {
+    manage new myManager() as theResource {
+        writeln("inside the manage statement");
+        theResource = 42;
+        throw new Error("I'm an error lol. lmao even");
+        theResource = 1337;
+    }
+} catch err {
+    writeln("caught error: ", err);
+}

--- a/test/constrained-generics/contextManager/basic-context-throws.chpl
+++ b/test/constrained-generics/contextManager/basic-context-throws.chpl
@@ -1,6 +1,14 @@
-// this test matters because creating wrapper functions around contextManager
-// calls does not work: they may or may not throw. This test makes sure the
-// throwing forms still work.
+// this test matters because creating wrapper functions analogous to
+// chpl__defaultHashWrapper around enterContext and exitContext, and
+// calling them instead of invoking the methods directly, did not work:
+// some enterContext calls throw, some don't. Thus, a chpl__enterContextWrapper
+// would either not throw (making this test not work), or always throw, requiring
+// catch statements for every manage statement.
+//
+// This test makes sure the throwing forms still work, while the other tests
+// (implicitly) do the same for non-throwing forms. In this way, we ensure that
+// whatever the implementation of context managers is, it doesn't suffer from
+// the throw/no-throw defect of the wrapper function approach.
 
 record myManager : contextManager {
     var myResource: int;

--- a/test/constrained-generics/contextManager/basic-context-throws.chpl
+++ b/test/constrained-generics/contextManager/basic-context-throws.chpl
@@ -7,7 +7,7 @@ record myManager : contextManager {
 
     proc contextReturnType type do return int;
 
-    proc enterContext() ref {
+    proc ref enterContext() ref {
         writeln("entering context, resource = ", myResource);
         return myResource;
     }

--- a/test/constrained-generics/contextManager/basic-context-throws.good
+++ b/test/constrained-generics/contextManager/basic-context-throws.good
@@ -1,0 +1,5 @@
+entering context, resource = 0
+inside the manage statement
+exiting context, resource = 42
+caught an error, will rethrow: Error: I'm an error lol. lmao even
+caught error: Error: I'm an error lol. lmao even

--- a/test/constrained-generics/contextManager/basic-context.chpl
+++ b/test/constrained-generics/contextManager/basic-context.chpl
@@ -1,0 +1,19 @@
+record myManager : contextManager {
+    var myResource: int;
+
+    proc contextReturnType type do return int;
+
+    proc enterContext() ref {
+        writeln("entering context, resource = ", myResource);
+        return myResource;
+    }
+
+    proc exitContext(in err: owned Error?) {
+        writeln("exiting context, resource = ", myResource);
+    }
+}
+
+manage new myManager() as theResource {
+    writeln("inside the manage statement");
+    theResource = 42;
+}

--- a/test/constrained-generics/contextManager/basic-context.chpl
+++ b/test/constrained-generics/contextManager/basic-context.chpl
@@ -3,7 +3,7 @@ record myManager : contextManager {
 
     proc contextReturnType type do return int;
 
-    proc enterContext() ref {
+    proc ref enterContext() ref {
         writeln("entering context, resource = ", myResource);
         return myResource;
     }

--- a/test/constrained-generics/contextManager/basic-context.good
+++ b/test/constrained-generics/contextManager/basic-context.good
@@ -1,0 +1,3 @@
+entering context, resource = 0
+inside the manage statement
+exiting context, resource = 42

--- a/test/constrained-generics/contextManager/infer-return-type-infer-implements.chpl
+++ b/test/constrained-generics/contextManager/infer-return-type-infer-implements.chpl
@@ -1,0 +1,16 @@
+record R {
+  proc enterContext() ref {
+    writeln("entering");
+    return none;
+  }
+
+  proc exitContext(in err: owned Error?) {
+    writeln("exiting");
+  }
+}
+
+var r: R;
+
+manage r {
+  writeln("inside");
+}

--- a/test/constrained-generics/contextManager/infer-return-type-infer-implements.chpl
+++ b/test/constrained-generics/contextManager/infer-return-type-infer-implements.chpl
@@ -1,7 +1,6 @@
 record R {
-  proc enterContext() ref {
+  proc enterContext() {
     writeln("entering");
-    return none;
   }
 
   proc exitContext(in err: owned Error?) {

--- a/test/constrained-generics/contextManager/infer-return-type-infer-implements.good
+++ b/test/constrained-generics/contextManager/infer-return-type-infer-implements.good
@@ -1,0 +1,4 @@
+infer-return-type-infer-implements.chpl:14: warning: R is being used in a 'manage' statement via its 'enterContext' and 'exitContext' methods. However, R does not implement contextManager. In the future, this will result in an error.
+entering
+inside
+exiting

--- a/test/constrained-generics/contextManager/infer-return-type-infer-implements.good
+++ b/test/constrained-generics/contextManager/infer-return-type-infer-implements.good
@@ -1,4 +1,4 @@
-infer-return-type-infer-implements.chpl:14: warning: R is being used in a 'manage' statement via its 'enterContext' and 'exitContext' methods. However, R does not implement contextManager. In the future, this will result in an error.
+infer-return-type-infer-implements.chpl:13: warning: R is being used in a 'manage' statement via its 'enterContext' and 'exitContext' methods. However, R does not implement contextManager. In the future, this will result in an error.
 entering
 inside
 exiting

--- a/test/constrained-generics/contextManager/infer-return-type.chpl
+++ b/test/constrained-generics/contextManager/infer-return-type.chpl
@@ -1,0 +1,16 @@
+record R : contextManager {
+  proc enterContext() ref {
+    writeln("entering");
+    return none;
+  }
+
+  proc exitContext(in err: owned Error?) {
+    writeln("exiting");
+  }
+}
+
+var r: R;
+
+manage r {
+  writeln("inside");
+}

--- a/test/constrained-generics/contextManager/infer-return-type.chpl
+++ b/test/constrained-generics/contextManager/infer-return-type.chpl
@@ -1,5 +1,5 @@
 record R : contextManager {
-  proc enterContext() ref {
+  proc enterContext() {
     writeln("entering");
     return none;
   }

--- a/test/constrained-generics/contextManager/infer-return-type.chpl
+++ b/test/constrained-generics/contextManager/infer-return-type.chpl
@@ -1,7 +1,6 @@
 record R : contextManager {
   proc enterContext() {
     writeln("entering");
-    return none;
   }
 
   proc exitContext(in err: owned Error?) {

--- a/test/constrained-generics/contextManager/infer-return-type.good
+++ b/test/constrained-generics/contextManager/infer-return-type.good
@@ -1,0 +1,3 @@
+entering
+inside
+exiting

--- a/test/constrained-generics/contextManager/nested-context.chpl
+++ b/test/constrained-generics/contextManager/nested-context.chpl
@@ -1,0 +1,22 @@
+record Outer {
+  record Inner : contextManager {
+    var x: int;
+
+    proc enterContext() ref {
+      writeln("entering, x = ", x);
+      return x;
+    }
+    proc exitContext(in err: owned Error?) {
+      writeln("exiting, x = ", x);
+    }
+  }
+
+  proc getInner() {
+    return new Inner();
+  }
+}
+
+var outer: Outer;
+manage outer.getInner() as someResource {
+  someResource = 42;
+}

--- a/test/constrained-generics/contextManager/nested-context.chpl
+++ b/test/constrained-generics/contextManager/nested-context.chpl
@@ -2,7 +2,7 @@ record Outer {
   record Inner : contextManager {
     var x: int;
 
-    proc enterContext() ref {
+    proc ref enterContext() ref {
       writeln("entering, x = ", x);
       return x;
     }

--- a/test/constrained-generics/contextManager/nested-context.good
+++ b/test/constrained-generics/contextManager/nested-context.good
@@ -1,0 +1,2 @@
+entering, x = 0
+exiting, x = 42

--- a/test/constrained-generics/hashable/nested-hash.chpl
+++ b/test/constrained-generics/hashable/nested-hash.chpl
@@ -1,0 +1,19 @@
+use Set;
+
+record Outer {
+    record Inner : hashable {
+        proc hash(): uint {
+            writeln("in hash of Inner record");
+            return 0;
+        }
+    }
+
+    proc getInnerSet() {
+        var mySet: set(Inner);
+        mySet.add(new Inner());
+        return mySet;
+    };
+}
+
+var outer: Outer;
+writeln(outer.getInnerSet());

--- a/test/constrained-generics/hashable/nested-hash.good
+++ b/test/constrained-generics/hashable/nested-hash.good
@@ -1,0 +1,2 @@
+in hash of Inner record
+{()}

--- a/test/library/draft/DistributedMap/DistributedMap.chpl
+++ b/test/library/draft/DistributedMap/DistributedMap.chpl
@@ -186,7 +186,7 @@ record _mapIdxTrivalFilter { //private
 }
 
 // produced by distributedMap.updateManager()
-record distributedMapManager {
+record distributedMapManager : contextManager {
   var   client;
   const locIdx;
   const mapIdx;

--- a/test/library/draft/DistributedMap/v3/DistributedMap.chpl
+++ b/test/library/draft/DistributedMap/v3/DistributedMap.chpl
@@ -355,7 +355,7 @@ module DistributedMap {
         }
     }
 
-    record staticRefsManager {
+    record staticRefsManager : contextManager {
         type dmType;
         var dm: dmType;
 

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -48,6 +48,7 @@ Initializing Modules:
     ChapelUtil
     ExportWrappers
     ChapelGpuSupport
+    ChapelContext
     AlignedTSupport
     CopyAggregation
      AggregationPrimitives

--- a/test/separate_compilation/serialization/testGenLib.MyMod.good
+++ b/test/separate_compilation/serialization/testGenLib.MyMod.good
@@ -40,6 +40,7 @@
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExportWrappers.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl") 
+2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelContext.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/stopInitCommDiags.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocks.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ByteBufferHelpers.chpl") 

--- a/test/separate_compilation/serialization/testGenLib.OtherMod.good
+++ b/test/separate_compilation/serialization/testGenLib.OtherMod.good
@@ -40,6 +40,7 @@
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExportWrappers.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl") 
+2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelContext.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/stopInitCommDiags.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocks.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ByteBufferHelpers.chpl") 

--- a/test/separate_compilation/serialization/testGenLib.both.good
+++ b/test/separate_compilation/serialization/testGenLib.both.good
@@ -40,6 +40,7 @@
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExportWrappers.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl") 
+2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelContext.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/stopInitCommDiags.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocks.chpl") 
 2 { fileTextQuery ("$CHPL_HOME/modules/internal/ByteBufferHelpers.chpl") 

--- a/test/statements/manage/ContextManagerSyntax.chpl
+++ b/test/statements/manage/ContextManagerSyntax.chpl
@@ -23,7 +23,7 @@ var globalRes = new res();
 
 // Multiple overloads of 'enterContext()' can exist, that just means that the
 // resource storage cannot be inferred.
-record man {
+record man : contextManager {
   var x = new r();
 
   proc enterContext() ref {

--- a/test/statements/manage/ExplicitConstRefResourceMutation.chpl
+++ b/test/statements/manage/ExplicitConstRefResourceMutation.chpl
@@ -1,4 +1,4 @@
-record man1 {
+record man1 : contextManager {
   var x = 0;
   proc enterContext() const ref: int { return x; }
   proc exitContext(in err: owned Error?) {
@@ -6,7 +6,7 @@ record man1 {
   }
 }
 
-record man2 {
+record man2 : contextManager {
   var x = 0;
   proc enterContext(): int { return x; }
   proc enterContext() const ref: int { return x; }

--- a/test/statements/manage/InferredConstRefResourceMutation.chpl
+++ b/test/statements/manage/InferredConstRefResourceMutation.chpl
@@ -1,4 +1,4 @@
-record man {
+record man : contextManager {
   var x = 0;
   proc enterContext(): int { return x; }
   proc enterContext() const ref: int { return x; }

--- a/test/statements/manage/InferredRefResourceMutation.chpl
+++ b/test/statements/manage/InferredRefResourceMutation.chpl
@@ -1,4 +1,4 @@
-record man {
+record man : contextManager {
   var x = 0;
   proc ref enterContext() ref: int { return x; }
   proc exitContext(in err: owned Error?) {

--- a/test/statements/manage/InferredResourceMultipleReturnIntents1.chpl
+++ b/test/statements/manage/InferredResourceMultipleReturnIntents1.chpl
@@ -17,7 +17,7 @@ record res {
 
 var globalRes = new res();
 
-record man {
+record man : contextManager {
   var x = new r();
 
   proc enterContext() ref {

--- a/test/statements/manage/InferredResourceStorage.chpl
+++ b/test/statements/manage/InferredResourceStorage.chpl
@@ -12,7 +12,7 @@ record res {
 
 var globalRes = new res();
 
-record man1 {
+record man1 : contextManager {
   var x = new r();
   proc enterContext(): res {
     writeln('proc man1.enterContext(): res'); return new res();
@@ -22,7 +22,7 @@ record man1 {
   }
 }
 
-record man2 {
+record man2 : contextManager {
   var x = new r();
   proc enterContext() ref: res {
     writeln('proc man2.enterContext() ref: res'); return globalRes;
@@ -32,7 +32,7 @@ record man2 {
   }
 }
 
-record man3 {
+record man3 : contextManager {
   var x = new r();
   proc enterContext() const ref: res {
     writeln('proc man3.enterContext() const ref: res'); return globalRes;

--- a/test/statements/manage/SpinlockGuard.chpl
+++ b/test/statements/manage/SpinlockGuard.chpl
@@ -1,7 +1,7 @@
 // TODO: Change me to standard module when we create one.
 use ChapelLocks;
 
-record spinlock {
+record spinlock : contextManager {
   type T;
   var _resource: T;
   var _lock: chpl_LocalSpinlock;

--- a/test/statements/manage/WarnUnstable.chpl
+++ b/test/statements/manage/WarnUnstable.chpl
@@ -1,4 +1,4 @@
-record man {
+record man : contextManager {
   proc enterContext(): int { return 0; }
   proc exitContext(in err: owned Error?) {
     if err then try! { throw err; }


### PR DESCRIPTION
This PR follows up on the work in #22857 to make context managers be backed by a `contextManager` interface. For the time being, we do not want to _require_ the context manager interface, only _warn_ about not implementing it. This is done using the `implements interface` primitive that was added for #22857, and by adding a call to `chpl__verifyTypeContext` with a compiler warning to each context manager expression. 

There is some mismatch between context managers and the design of interfaces as they are today.

1. The first problem is that different context manager `enterContext` methods return different types, depending on the resource being managed. Thus, the interface must have the ability to support all return types gracefully. This is solved in a relatively "canonical" way by using an associated type: each context manager provides a `contextReturnType` parenless type procedure that is used to determine the expected type for `enterContext`. However, the goal is for a warning-only migration, and we don't want to introduce an additional burden on the users; thus, the compiler will automatically infer `contextReturnType` for `contextManager` where it can.
2. The second problem is that the context managers can also return by different intents. Unlike the return type issue, this cannot be solved by an existing interface feature. I therefore introduce a pragma, `ifc any return intent` to allow any return intent to satisfy the interface's witness. This pragma interacts poorly with constraint-generic functions (because those are resolved once, and thus cannot be differentiated based on the return type of the actual witness), and thus `contextManager` is banned as a constraint in CG functions. 

While there, it fixes a bug in which nested aggregate types caused segmentation faults when an `: interface` syntax was used. This was because the `implements` statement for the child class was inserted into the body of the parent class, which only expected definitions (not a statement). Since flattening classes happens pretty early on, and moves child classes into the same scope as the parent class, the solution seemed to simply insert implements statements in module scope, like `FlattenClasses` does. 

It's unclear how the interface will handle the `contextManager` range of features in the long-term, since CM allows return intent overloading and (as described above) differentiated return intents. However, since this isn't strictly necessary for 2.0, maybe that's fine?

Reviewed by @vasslitvinov -- thanks!

## Testing
- [x] paratest