### PR TITLE
Fix nightly failures with INFINITY and NAN

### DIFF
--- a/test/library/packages/LinearAlgebra/correctness/dependencies/testSVD-error.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/dependencies/testSVD-error.chpl
@@ -6,7 +6,7 @@ proc main() throws {
 
   var A = Matrix([1.0, 2.0, 3.0],
                  [3.0, 2.0, 4.0],
-                 [1.0, 2.0, NAN]);
+                 [1.0, 2.0, nan]);
 
   try {
     var (u, s, vt) = svd(A);

--- a/test/optimizations/cache-remote/ferguson/comm_counting/ra_prefetch.chpl
+++ b/test/optimizations/cache-remote/ferguson/comm_counting/ra_prefetch.chpl
@@ -40,7 +40,7 @@ proc test(n_prefetch:int): (int,real) {
   on Locales[1] {
     var clock : stopwatch;
     var sum = 0;
-    var elapsed_time = INFINITY;
+    var elapsed_time = inf;
 
 
     for i in 1..n_experiments {


### PR DESCRIPTION
These two tests aren't run in our regular testing configuration,
so I missed that they needed an update for the new
deprecations.  Rectify that oversight