### PR TITLE
Add missing unstable warning for foreach loop to .good file

### DIFF
--- a/test/unstable/llvmMetadata.good
+++ b/test/unstable/llvmMetadata.good
@@ -1,4 +1,5 @@
 llvmMetadata.chpl:2: In function 'saxpy':
+llvmMetadata.chpl:12: warning: foreach loops are currently unstable and are expected to change in ways that may break some of their current uses
 llvmMetadata.chpl:10: warning: 'llvm.assertVectorized' is an unstable attribute
 llvmMetadata.chpl:11: warning: 'llvm.metadata' is an unstable attribute
 3.0 6.0 9.0 12.0 15.0 18.0 21.0 24.0 27.0 30.0 33.0 36.0 39.0 42.0 45.0 48.0


### PR DESCRIPTION
Heading off a failure in nightly testing that I caught while double-checking my own PR.