### PR TITLE
Rename 'divceilpos'/'divfloorpos' calls in multilocale-only tests

### DIFF
--- a/test/optimizations/sungeun/bulk_transfer/assignMultiloc.chpl
+++ b/test/optimizations/sungeun/bulk_transfer/assignMultiloc.chpl
@@ -23,7 +23,7 @@ use Random, Time, Math;
 if numLocales < 3 then halt("numLocales must be >= 3");
 var declLocale = Locales(numLocales-1);
 var putLocale = Locales(0);
-var remoteLocale = Locales(divfloorpos(numLocales, 2));
+var remoteLocale = Locales(divFloorPos(numLocales, 2));
 if printOutput {
   if ttype==testType.localGet then
     writeln("Exercising local get on ", declLocale);

--- a/test/studies/hpcc/HPL/vass/bl.md.chpl
+++ b/test/studies/hpcc/HPL/vass/bl.md.chpl
@@ -44,8 +44,8 @@ config const n = 62,
 
 // The bounding box for the Block distributions.
 // We arbitrarily choose to round up, rather than down.
-const nbb1 = divceilpos(n, blkSize * tl1) * blkSize * tl1, //MBD //BD
-      nbb2 = divceilpos(n, blkSize * tl2) * blkSize * tl2; //MBD //BD
+const nbb1 = divCeilPos(n, blkSize * tl1) * blkSize * tl1, //MBD //BD
+      nbb2 = divCeilPos(n, blkSize * tl2) * blkSize * tl2; //MBD //BD
 
 // The starting indices for the Block-Cyclic distributions.
 //const st1=1, st2=1; //MBC //BC


### PR DESCRIPTION
While sanity checking gasnet testing to make sure I hadn't broken anything in my PR, I caught that these multilocale tests were getting new warnings due to calls to 'divceilpos'/'divfloorpos', which got migration warnings added for them today.