### PR TITLE
Fix rename of shoc-sort in GRAPHFILES

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2423,7 +2423,7 @@ shoc-triad-bw-lg:
   11/10/22:
     - Ensure we time mem transfer in SHOC Triad (#20961)
 
-sort:
+shoc-sort:
   02/24/23:
     - Improve SHOC-Sort implementation (#21610)
 

--- a/test/GPU-GRAPHFILES
+++ b/test/GPU-GRAPHFILES
@@ -5,7 +5,7 @@ gpu/native/studies/shoc/shoc-triad-bw-lg.graph
 gpu/native/studies/shoc/triad2.graph
 gpu/native/studies/shoc/kernel2.graph
 
-gpu/native/studies/shoc/sort.graph
+gpu/native/studies/shoc/shoc-sort.graph
 
 gpu/native/streamPrototype/gpuStream.graph
 gpu/native/studies/multiGpuStream/multiGpuStream.graph


### PR DESCRIPTION
Fixes rename of `sort.chpl` to `shoc-sort.chpl` by making the change in GPU_GRAPHFILES, which was forgotten in #23127. Also renames annotation in ANNOTATIONS.yaml

[Not reviewed - trivial change]