### PR TITLE
Fix some filesystem portability issues in tests

### DIFF
--- a/test/library/standard/IO/nonUTF8/basic.chpl
+++ b/test/library/standard/IO/nonUTF8/basic.chpl
@@ -1,4 +1,4 @@
-use IO, FileSystem;
+use IO, FileSystem, Path;
 use ChplConfig;
 
 config param useNonUTF8 = true;
@@ -15,6 +15,6 @@ const filename1 = s("junkfile1");
 
 var f = open(filename1, ioMode.cw);
 var p = f.path;
-writeln("file.path works: ", p == CHPL_HOME + "/test/library/standard/IO/nonUTF8/" + filename1);
+writeln("file.path works: ", p == realPath(CHPL_HOME) + "/test/library/standard/IO/nonUTF8/" + filename1);
 f.close();
 FileSystem.remove(filename1);

--- a/test/parsing/errors/nameLength/longName.precomp
+++ b/test/parsing/errors/nameLength/longName.precomp
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-NAME_MAX=`getconf NAME_MAX /`
+VAL="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+NAME_MAX=`getconf NAME_MAX $VAL`
 REDUCTIONMAXLENGTH=16
 LIMIT=$((NAME_MAX - REDUCTIONMAXLENGTH))
 OUTOFBOUND=$((LIMIT + 1))
-VAL="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 repeatChar() {
     local input="$1"


### PR DESCRIPTION
Fix nonUTF8/basic.chpl when the test path is a symbolic link by using `realPath` to construct an absolute path to a filename. Instead of manually building a path to a known test location, you could just use `absPath(filename)`, but that I wasn't sure if that would defeat the purpose of the test (if `file.path` uses `absPath` under the covers.)

Also update nameLength/longName.precomp to call `getconf NAME_MAX` on the current directory instead of on `/` since the root filesystem and the current one can have different max name lengths.