### PR TITLE
Fix compareExchangeWeak in atomic API tests

### DIFF
--- a/test/runtime/configMatters/comm/AtomicsAPI.chpl
+++ b/test/runtime/configMatters/comm/AtomicsAPI.chpl
@@ -35,7 +35,7 @@ proc testAtomicBool(a, ref i, ref b) {
                 b = a.compareExchange(x, t);                    writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchange(x, t);                    writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchangeWeak(x, f);                writeabx("cmpxchgW", a, b, x);
-             do b = a.compareExchangeWeak(x, f); while n(b);    writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, f); while n(b);    writeab ("cmpxchgW", a, b);
                 b = a.compareAndSwap(t, t);                     writeab ("cas     ", a, b);
                 b = a.compareAndSwap(f, t);                     writeab ("cas     ", a, b);
                 i = a.testAndSet();                             writeai ("test&Set", a, i);
@@ -64,9 +64,10 @@ proc testOrderAtomicBool(a, ref i, ref b, param o: memoryOrder) {
                 b = a.compareExchange(x, f, o, o);                   writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchange(x, f, o, o);                   writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchangeWeak(x, t, o);                  writeabx("cmpxchgW", a, b, x);
-             do b = a.compareExchangeWeak(x, t, o); while n(b);      writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, t, o); while n(b);      writeab ("cmpxchgW", a, b);
+                x = false;
                 b = a.compareExchangeWeak(x, f, o, o);               writeabx("cmpxchgW", a, b, x);
-             do b = a.compareExchangeWeak(x, f, o, o); while n(b);   writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, f, o, o); while n(b);   writeab ("cmpxchgW", a, b);
                 b = a.compareAndSwap(t, t, o);                       writeab ("cas     ", a, b);
                 b = a.compareAndSwap(f, t, o);                       writeab ("cas     ", a, b);
                 i = a.testAndSet(o);                                 writeai ("test&Set", a, i);
@@ -99,7 +100,7 @@ proc testAtomicT(ref a, ref i, ref b) {
                 b = a.compareExchange(x, 4);                    writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchange(x, 4);                    writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchangeWeak(x, 2);                writeabx("cmpxchgW", a, b, x);
-             do b = a.compareExchangeWeak(x, 2); while n(b);    writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, 2); while n(b);    writeab ("cmpxchgW", a, b);
                 b = a.compareAndSwap(1, 5);                     writeab ("cas     ", a, b);
                 b = a.compareAndSwap(2, 5);                     writeab ("cas     ", a, b);
                 i = a.fetchAdd(1);                              writeai ("fetchAdd", a, i);
@@ -141,9 +142,10 @@ proc testOrderAtomicT(ref a, ref i, ref b, param o: memoryOrder) {
                 b = a.compareExchange(x, 2, o, o);                   writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchange(x, 2, o, o);                   writeabx("cmpxchg ", a, b, x);
                 b = a.compareExchangeWeak(x, 4, o, o);               writeabx("cmpxchgW", a, b, x);
-             do b = a.compareExchangeWeak(x, 4, o, o); while n(b);   writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, 4, o, o); while n(b);   writeab ("cmpxchgW", a, b);
+                x = 2:valType;
                 b = a.compareExchangeWeak(x, 2, o);                  writeabx("cmpxchgW", a, b, x);
-             do b = a.compareExchangeWeak(x, 2, o); while n(b);      writeabx("cmpxchgW", a, b, x);
+             do b = a.compareExchangeWeak(x, 2, o); while n(b);      writeab ("cmpxchgW", a, b);
                 b = a.compareAndSwap(1, 5, o);                       writeab ("cas     ", a, b);
                 b = a.compareAndSwap(2, 5, o);                       writeab ("cas     ", a, b);
                 i = a.fetchAdd(1, o);                                writeai ("fetchAdd", a, i);

--- a/test/runtime/configMatters/comm/atomics-api.good
+++ b/test/runtime/configMatters/comm/atomics-api.good
@@ -10,7 +10,7 @@ Testing 'atomic bool':
   cmpxchg     a=false, b=false, x=false
   cmpxchg     a=true, b=true, x=false
   cmpxchgW    a=true, b=false, x=true
-  cmpxchgW    a=false, b=true, x=true
+  cmpxchgW    a=false, b=true
   cas         a=false, b=false
   cas         a=true, b=true
   test&Set    a=true, i=true
@@ -31,9 +31,9 @@ Testing 'atomic bool' with order 'seqCst':
   cmpxchg     a=true, b=false, x=true
   cmpxchg     a=false, b=true, x=true
   cmpxchgW    a=false, b=false, x=false
-  cmpxchgW    a=true, b=true, x=false
+  cmpxchgW    a=true, b=true
   cmpxchgW    a=true, b=false, x=true
-  cmpxchgW    a=false, b=true, x=true
+  cmpxchgW    a=false, b=true
   cas         a=false, b=false
   cas         a=true, b=true
   test&Set    a=true, i=true
@@ -52,7 +52,7 @@ Testing 'atomic int(8)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -81,9 +81,9 @@ Testing 'atomic int(8)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -110,7 +110,7 @@ Testing 'atomic int(16)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -139,9 +139,9 @@ Testing 'atomic int(16)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -168,7 +168,7 @@ Testing 'atomic int(32)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -197,9 +197,9 @@ Testing 'atomic int(32)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -226,7 +226,7 @@ Testing 'atomic int(64)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -255,9 +255,9 @@ Testing 'atomic int(64)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -284,7 +284,7 @@ Testing 'atomic int(64)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -313,9 +313,9 @@ Testing 'atomic int(64)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -342,7 +342,7 @@ Testing 'atomic uint(8)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -371,9 +371,9 @@ Testing 'atomic uint(8)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -400,7 +400,7 @@ Testing 'atomic uint(16)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -429,9 +429,9 @@ Testing 'atomic uint(16)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -458,7 +458,7 @@ Testing 'atomic uint(32)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -487,9 +487,9 @@ Testing 'atomic uint(32)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -516,7 +516,7 @@ Testing 'atomic uint(64)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -545,9 +545,9 @@ Testing 'atomic uint(64)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -574,7 +574,7 @@ Testing 'atomic uint(64)':
   cmpxchg     a=2, b=false, x=2
   cmpxchg     a=4, b=true, x=2
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -603,9 +603,9 @@ Testing 'atomic uint(64)' with order 'seqCst':
   cmpxchg     a=4, b=false, x=4
   cmpxchg     a=2, b=true, x=4
   cmpxchgW    a=2, b=false, x=2
-  cmpxchgW    a=4, b=true, x=2
+  cmpxchgW    a=4, b=true
   cmpxchgW    a=4, b=false, x=4
-  cmpxchgW    a=2, b=true, x=4
+  cmpxchgW    a=2, b=true
   cas         a=2, b=false
   cas         a=5, b=true
   fetchAdd    a=6, i=5
@@ -632,7 +632,7 @@ Testing 'atomic real(32)':
   cmpxchg     a=2.0, b=false, x=2.0
   cmpxchg     a=4.0, b=true, x=2.0
   cmpxchgW    a=4.0, b=false, x=4.0
-  cmpxchgW    a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=true
   cas         a=2.0, b=false
   cas         a=5.0, b=true
   fetchAdd    a=6.0, i=5.0
@@ -655,9 +655,9 @@ Testing 'atomic real(32)' with order 'seqCst':
   cmpxchg     a=4.0, b=false, x=4.0
   cmpxchg     a=2.0, b=true, x=4.0
   cmpxchgW    a=2.0, b=false, x=2.0
-  cmpxchgW    a=4.0, b=true, x=2.0
+  cmpxchgW    a=4.0, b=true
   cmpxchgW    a=4.0, b=false, x=4.0
-  cmpxchgW    a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=true
   cas         a=2.0, b=false
   cas         a=5.0, b=true
   fetchAdd    a=6.0, i=5.0
@@ -678,7 +678,7 @@ Testing 'atomic real(64)':
   cmpxchg     a=2.0, b=false, x=2.0
   cmpxchg     a=4.0, b=true, x=2.0
   cmpxchgW    a=4.0, b=false, x=4.0
-  cmpxchgW    a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=true
   cas         a=2.0, b=false
   cas         a=5.0, b=true
   fetchAdd    a=6.0, i=5.0
@@ -701,9 +701,9 @@ Testing 'atomic real(64)' with order 'seqCst':
   cmpxchg     a=4.0, b=false, x=4.0
   cmpxchg     a=2.0, b=true, x=4.0
   cmpxchgW    a=2.0, b=false, x=2.0
-  cmpxchgW    a=4.0, b=true, x=2.0
+  cmpxchgW    a=4.0, b=true
   cmpxchgW    a=4.0, b=false, x=4.0
-  cmpxchgW    a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=true
   cas         a=2.0, b=false
   cas         a=5.0, b=true
   fetchAdd    a=6.0, i=5.0
@@ -724,7 +724,7 @@ Testing 'atomic real(64)':
   cmpxchg     a=2.0, b=false, x=2.0
   cmpxchg     a=4.0, b=true, x=2.0
   cmpxchgW    a=4.0, b=false, x=4.0
-  cmpxchgW    a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=true
   cas         a=2.0, b=false
   cas         a=5.0, b=true
   fetchAdd    a=6.0, i=5.0
@@ -747,9 +747,9 @@ Testing 'atomic real(64)' with order 'seqCst':
   cmpxchg     a=4.0, b=false, x=4.0
   cmpxchg     a=2.0, b=true, x=4.0
   cmpxchgW    a=2.0, b=false, x=2.0
-  cmpxchgW    a=4.0, b=true, x=2.0
+  cmpxchgW    a=4.0, b=true
   cmpxchgW    a=4.0, b=false, x=4.0
-  cmpxchgW    a=2.0, b=true, x=4.0
+  cmpxchgW    a=2.0, b=true
   cas         a=2.0, b=false
   cas         a=5.0, b=true
   fetchAdd    a=6.0, i=5.0
@@ -767,7 +767,7 @@ Promotion -- Testing 'atomic int(64)':
   cmpxchg     a=2 2 2, b=false false false, x=2 2 2
   cmpxchg     a=4 4 4, b=true true true, x=2 2 2
   cmpxchgW    a=4 4 4, b=false false false, x=4 4 4
-  cmpxchgW    a=2 2 2, b=true true true, x=4 4 4
+  cmpxchgW    a=2 2 2, b=true true true
   cas         a=2 2 2, b=false false false
   cas         a=5 5 5, b=true true true
   fetchAdd    a=6 6 6, i=5 5 5
@@ -793,9 +793,9 @@ Testing 'atomic int(64)' with order 'seqCst':
   cmpxchg     a=4 4 4, b=false false false, x=4 4 4
   cmpxchg     a=2 2 2, b=true true true, x=4 4 4
   cmpxchgW    a=2 2 2, b=false false false, x=2 2 2
-  cmpxchgW    a=4 4 4, b=true true true, x=2 2 2
+  cmpxchgW    a=4 4 4, b=true true true
   cmpxchgW    a=4 4 4, b=false false false, x=4 4 4
-  cmpxchgW    a=2 2 2, b=true true true, x=4 4 4
+  cmpxchgW    a=2 2 2, b=true true true
   cas         a=2 2 2, b=false false false
   cas         a=5 5 5, b=true true true
   fetchAdd    a=6 6 6, i=5 5 5


### PR DESCRIPTION
`compareExchangeWeak` is allowed to spuriously fail even when the `atomic.val == expected`, this means we can't rely on expected not getting updated from spurious failures and need to stop printing it and reset it when it can fail spuriously. We were already looping to handle spurious failures but didn't account for `expected` getting updated.

We haven't see this before because `compareExchangeWeak` doesn't fail spuriously on x86, but I have hit this in some recent arm testing. A sequence of instructions is used to implement `compareExchange*` on arm and this sequence can fail for things like a context switch or if another thread modifies the same cacheline. The atomics-api test was failing for the promoted case where we have multiple tasks/threads doing concurrent `compareExchangeWeak` calls on the same cacheline and causing conflicts for each other. atomics-api would fail 1/10 times before, but passes 10,000 trials on A64FX and ThunderX2 systems now.

Note that `compareExchange` (the strong version that can't spuriously fail) is implemented with a retry loop under the covers and this is the reason `compareExchangeWeak` exists since avoiding that second loop is more efficient on platforms where the instruction sequence can fail.