### PR TITLE
Add ref to methods missed in ref-maybe-const deprecation

### DIFF
--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -499,7 +499,7 @@ extern record sys_sockaddr_t {
   :type port: `c_uint`
   */
   @chpldoc.nodoc
-  proc set(host: sys_in6_addr_t, port: c_uint) {
+  proc ref set(host: sys_in6_addr_t, port: c_uint) {
     sys_set_sys_sockaddr_in6_t(this, host, port);
   }
 

--- a/test/constrained-generics/basic/set3/hashtable-table.chpl
+++ b/test/constrained-generics/basic/set3/hashtable-table.chpl
@@ -24,7 +24,7 @@ my__hashtable implements chpl_Hashtable;
 proc my__hashtable.tableType type do return _ddata(int);
 
 // We need to support assignment to 'table'.
-proc chpl_Hashtable.updateTable() {
+proc ref chpl_Hashtable.updateTable() {
   var oldTable = table;
   table = oldTable;
 }


### PR DESCRIPTION
Adds ref intent to methods which need it, due to deprecation of ref-maybe-const this-intents in #23060

[Not reviewed]