### PR TITLE
Fix tests that assumed `c_char` was an alias for `int(8)`

### DIFF
--- a/test/arrays/literals/cStringLiteral.chpl
+++ b/test/arrays/literals/cStringLiteral.chpl
@@ -2,6 +2,5 @@ use CTypes;
 var A = [c"hi", c"there", c"everybody"];
 var B = ["hi".c_str(), "there".c_str(), "everybody".c_str()];
 
-writeln(A.type:string);
-
-writeln(B.type:string);
+assert(A.eltType == c_string);
+assert(B.eltType == c_ptrConst(c_char));

--- a/test/arrays/literals/cStringLiteral.good
+++ b/test/arrays/literals/cStringLiteral.good
@@ -1,5 +1,4 @@
 cStringLiteral.chpl:2: warning: the type 'c_string' is deprecated and with it, C string literals; use 'c_ptrToConst("string")' or 'string.c_str()' from the 'CTypes' module instead
 cStringLiteral.chpl:2: warning: the type 'c_string' is deprecated and with it, C string literals; use 'c_ptrToConst("string")' or 'string.c_str()' from the 'CTypes' module instead
 cStringLiteral.chpl:2: warning: the type 'c_string' is deprecated and with it, C string literals; use 'c_ptrToConst("string")' or 'string.c_str()' from the 'CTypes' module instead
-[domain(1,int(64),one)] c_string
-[domain(1,int(64),one)] c_ptrConst(int(8))
+cStringLiteral.chpl:5: warning: the type 'c_string' is deprecated; please 'import CTypes' and use 'c_ptrConst(c_char)' instead

--- a/test/deprecated/IO/localesForRegion.skipif
+++ b/test/deprecated/IO/localesForRegion.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_ARCH == aarch64

--- a/test/interop/fortran/genFortranInterface/unhandledType.chpl
+++ b/test/interop/fortran/genFortranInterface/unhandledType.chpl
@@ -1,9 +1,0 @@
-use CTypes;
-export proc takesCstring(s: c_string) {
-  writeln(string.createCopyingBuffer(s));
-}
-
-export proc takesCptr(s: c_ptrConst(c_char)) {
-  writeln(string.createCopyingBuffer(s));
-}
-

--- a/test/interop/fortran/genFortranInterface/unhandledType.compopts
+++ b/test/interop/fortran/genFortranInterface/unhandledType.compopts
@@ -1,1 +1,0 @@
---library-fortran

--- a/test/interop/fortran/genFortranInterface/unhandledType.good
+++ b/test/interop/fortran/genFortranInterface/unhandledType.good
@@ -1,8 +1,0 @@
-unhandledType.chpl:2: In function 'takesCstring':
-unhandledType.chpl:2: warning: the type 'c_string' is deprecated; please 'import CTypes' and use 'c_ptrConst(c_char)' instead
-unhandledType.chpl:3: warning: the type 'c_string' is deprecated; please use the variant of 'string.createCopyingBuffer' that takes a 'c_ptrConst(c_char)' instead
-unhandledType.chpl:2: warning: Unknown Fortran KIND generating interface for C type: c_string
-unhandledType.chpl:2: warning: Unknown Fortran type generating interface for C type: c_string
-unhandledType.chpl:6: In function 'takesCptr':
-unhandledType.chpl:6: warning: Unknown Fortran KIND generating interface for C type: c_ptrConst_int8_t_chpl
-unhandledType.chpl:6: warning: Unknown Fortran type generating interface for C type: c_ptrConst_int8_t_chpl

--- a/test/interop/fortran/genFortranInterface/unhandledType.noexec
+++ b/test/interop/fortran/genFortranInterface/unhandledType.noexec
@@ -1,1 +1,0 @@
-# This test shouldn't create an executable file

--- a/test/interop/fortran/genFortranInterface/unhandledType.skipif
+++ b/test/interop/fortran/genFortranInterface/unhandledType.skipif
@@ -1,2 +1,0 @@
-# This doesn't play well with multi-locale libraries quite yet.
-CHPL_COMM != none

--- a/test/studies/colostate/util.h
+++ b/test/studies/colostate/util.h
@@ -171,7 +171,7 @@ int parseCmdLineArgs(Params *cmdLineArgs, int argc, char* argv[]){
   cmdLineArgs->tile_len_y = 128; 
 
   // process incoming
-  char c;
+  int c;
   while ((c = getopt (argc, argv, "nc:s:p:T:x:y:a:w:t:hv")) != -1){
     switch( c ) {
       case 'n': // print time

--- a/test/types/string/ferguson/return-coerce-to-c-string.chpl
+++ b/test/types/string/ferguson/return-coerce-to-c-string.chpl
@@ -3,7 +3,8 @@ proc f():c_string {
 }
 
 var x = f();
-writeln(string.createCopyingBuffer(x), " ", x.type:string);
+writeln(string.createCopyingBuffer(x));
+assert(x.type == c_string);
 
 use CTypes;
 proc f_ptr():c_ptrConst(c_char) {
@@ -11,4 +12,5 @@ proc f_ptr():c_ptrConst(c_char) {
 }
 
 var x_ptr = f_ptr();
-writeln(string.createCopyingBuffer(x_ptr), " ", x_ptr.type:string);
+writeln(string.createCopyingBuffer(x_ptr));
+assert(x_ptr.type == c_ptrConst(c_char));

--- a/test/types/string/ferguson/return-coerce-to-c-string.good
+++ b/test/types/string/ferguson/return-coerce-to-c-string.good
@@ -1,5 +1,6 @@
+return-coerce-to-c-string.chpl:7: warning: the type 'c_string' is deprecated; please 'import CTypes' and use 'c_ptrConst(c_char)' instead
 return-coerce-to-c-string.chpl:1: In function 'f':
 return-coerce-to-c-string.chpl:1: warning: the type 'c_string' is deprecated; please 'import CTypes' and use 'c_ptrConst(c_char)' instead
 return-coerce-to-c-string.chpl:6: warning: the type 'c_string' is deprecated; please use the variant of 'string.createCopyingBuffer' that takes a 'c_ptrConst(c_char)' instead
-Hello c_string
-Hello c_ptrConst(int(8))
+Hello
+Hello

--- a/test/types/string/kbrady/c_str_literal.chpl
+++ b/test/types/string/kbrady/c_str_literal.chpl
@@ -1,6 +1,8 @@
+use CTypes;
 var cs = c"foo bar";
 var s = "foo bar";
 var cptr = "foo bar".c_str();
-writeln(cs.type:string);
-writeln(s.type:string);
-writeln(cptr.type:string);
+
+assert(cs.type == c_string);
+assert(s.type == string);
+assert(cptr.type == c_ptrConst(c_char));

--- a/test/types/string/kbrady/c_str_literal.good
+++ b/test/types/string/kbrady/c_str_literal.good
@@ -1,4 +1,2 @@
-c_str_literal.chpl:1: warning: the type 'c_string' is deprecated and with it, C string literals; use 'c_ptrToConst("string")' or 'string.c_str()' from the 'CTypes' module instead
-c_string
-string
-c_ptrConst(int(8))
+c_str_literal.chpl:2: warning: the type 'c_string' is deprecated and with it, C string literals; use 'c_ptrToConst("string")' or 'string.c_str()' from the 'CTypes' module instead
+c_str_literal.chpl:6: warning: the type 'c_string' is deprecated; please 'import CTypes' and use 'c_ptrConst(c_char)' instead


### PR DESCRIPTION
The sign of `char` is implementation defined in C, but in practice is signed on x86 and unsigned for arm (except for mac). We had a few tests that we're baking in the signed type into .good files, which caused failures on some recent arm testing. Fix tests here by:
 - Adjusting c_str_literal, cStringLiteral, and return-coerce-to-c-string to assert the type instead of print
 - Skiping localesForRegion since it's deprecated and going away soon anyways (type is in an error message.)
 - Removing unhandledType since I think unhandledTypeTuple still covers the spirit of the test.
 - Adjusting a C benchmark to use `int` for `getopt` instead of `char`