### PR TITLE
Rewrite a byte buffer operation as a C loop to avoid --baseline failures

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -175,7 +175,17 @@ module BytesStringCommon {
             expectedSize += 2*nInvalidBytes;
             (newBuff, allocSize) = bufferEnsureSize(newBuff, allocSize,
                                                      expectedSize);
-            for i in 0..#nInvalidBytes {
+
+            // TODO: in --baseline, range for loops resolve range._getIterator,
+            // which in turn requires allocations, which leads to decodeByteBuffer...
+            // which would then needs to resolve _getIterator again for this loop
+            // down here. Write it as a primitive loop to avoid the recursive resolution.
+            // This is probably not the ideal solution.
+            var i: int;
+            while __primitive("C for loop",
+                              __primitive( "=", i, 0),
+                              __primitive("<", i, nInvalidBytes),
+                              __primitive("+=", i, 1)) {
               qio_encode_char_buf(newBuff+decodedIdx,
                                   0xdc00+(buff[thisIdx-nInvalidBytes+i]:int(32)));
               decodedIdx += 3;


### PR DESCRIPTION
This works around the bug described in https://github.com/chapel-lang/chapel/issues/23155 which was uncovered / exposed by #22857. Looks like we didn't have baseline tests that required resolving `getHash` on `bytes`, but now all tests resolve `getHash`, so here we are.

To avoid recursive resolution, I've switched one of the simple for-loops to a C-style for loop.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest
- [x] paratest with `--baseline`