### PR TITLE
Improve performance of readBinary and writeBinary for dense arrays

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8881,7 +8881,10 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
   on this._home {
     try this.lock(); defer { this.unlock(); }
 
-    if data.locale == this._home && data.isDefaultRectangular() && endian == ioendian.native {
+    // Allow either DefaultRectangular arrays or dense slices of DR arrays
+    const denseDR = chpl__isDROrDRView(data) &&
+                    data._value.isDataContiguous(d._value);
+    if data.locale == this._home && denseDR && endian == ioendian.native {
       e = qio_channel_read(false, this._channel_internal, data[d.low], (data.size * c_sizeof(data.eltType)) : c_ssize_t, numRead);
 
       if e != 0 && e != EEOF then throw createSystemOrChplError(e);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8557,7 +8557,10 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
     try this.lock(); defer { this.unlock(); }
     const tSize = c_sizeof(t) : c_ssize_t;
 
-    if endian == ioendian.native && data.locale == this._home && data.isDefaultRectangular() {
+    // Allow either DefaultRectangular arrays or dense slices of DR arrays
+    const denseDR = chpl__isDROrDRView(data) &&
+                    data._value.isDataContiguous(d._value);
+    if endian == ioendian.native && data.locale == this._home && denseDR {
       e = try qio_channel_write_amt(false, this._channel_internal, data[d.low], data.size:c_ssize_t * tSize);
 
       if e != 0 then


### PR DESCRIPTION
This PR updates the "fast path" check in ``readBinary`` and ``writeBinary`` to allow default rectangular arrays _or_ dense slices of default rectangular arrays.

Testing:
- [x] local paratest