### PR TITLE
Only attempt to read/write bulk elements if size is non-zero

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1816,20 +1816,21 @@ module DefaultRectangular {
     }
 
     use Reflection;
-    var ptr = c_addrOf(arr.dsiAccess(dom.dsiFirst));
-
-    param canResolveBulkElements = Reflection.canResolveMethod(helper, "writeBulkElements", ptr, 0) ||
-                                   Reflection.canResolveMethod(helper, "readBulkElements", ptr, 0);
+    var dummy : c_ptr(arr.eltType);
+    param canResolveBulkElements = Reflection.canResolveMethod(helper, "writeBulkElements", dummy, 0) ||
+                                   Reflection.canResolveMethod(helper, "readBulkElements", dummy, 0);
     param useBulkElements = canResolveBulkElements &&
                             arr.isDefaultRectangular() &&
                             !chpl__isArrayView(arr) &&
                             _isSimpleIoType(arr.eltType);
 
-    if useBulkElements && arr.isDataContiguous(dom) {
+    const len = dom.dsiNumIndices:int;
+    if useBulkElements && arr.isDataContiguous(dom) && len > 0 {
+      var ptr = c_addrOf(arr.dsiAccess(dom.dsiFirst));
       if f._writing then
-        helper.writeBulkElements(ptr, dom.dsiNumIndices:int);
+        helper.writeBulkElements(ptr, len);
       else
-        helper.readBulkElements(ptr, dom.dsiNumIndices:int);
+        helper.readBulkElements(ptr, len);
     } else {
       // Otherwise, recursively read or write the array
       const zeroTup: rank*idxType;


### PR DESCRIPTION
This PR updates the implementation of ``chpl_serialReadWriteRectangularHelper`` to only attempt calling the "bulk elements" methods of the serialization API when the number of indices is greater than zero. This change was motivated by a testing failure in ``--baseline`` testing where the snippet ``c_addrOf(arr.dsiAccess(dom.dsiFirst))`` incurred a nil-dereference error involving the uninitialized ``shiftedData`` pointer. It's not clear to me why exactly baseline testing ran into this problem, but the simplest option is to simply guard the pointer creation with a check on the domain size.

Testing:
- [x] local
- [x] baseline