### PR TITLE
Fix `--library-cmakelists` on mac by quoting framework link args

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <cstring>
+#include <regex>
 
 #include "library.h"
 
@@ -313,6 +314,7 @@ static void printCMakeListsIncludes(fileinfo cmakelists, std::string name) {
 static void printCMakeListsLibraries(fileinfo cmakelists, std::string name) {
   std::string varValue = "";
   std::string libraries = getCompilelineOption("libraries");
+  libraries = std::regex_replace(libraries, std::regex("(-framework \\S*)(\\s)"), "\"$1\"$2");
   std::string libname = getLibname(name);
 
   std::string requires_ = getRequireLibraries();


### PR DESCRIPTION
Since #22137, we have frameworks included in system link args on mac when hwloc is used. e.g. `-framework Foundations`. cmake doesn't like frameworks in link args and adjusts it to `-framework -lFoundations`, which isn't valid. Quote the framework args to prevent cmake from adjusting the args.

Testing:
 - [x] std linux paratest
 - [x] `start_test test/interop/C/cmakelists/` on mac (which failed before this change)