### PR TITLE
Deprecate the name cproj and add a new function riemProj to replace it

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -65,7 +65,7 @@ Computations Involving Complex Numbers
 --------------------------------------
 :proc:`carg`
 :proc:`conj`
-:proc:`cproj`
+:proc:`riemProj`
 
 .. _automath-inf-nan:
 
@@ -967,25 +967,10 @@ module AutoMath {
     return conj(z);
   }
 
-  /* Returns the projection of `x` on a Riemann sphere. */
-  inline proc cproj(x: complex(?w)): complex(w) {
-    pragma "fn synchronization free"
-    pragma "codegen for CPU and GPU"
-    extern proc cprojf(x: complex(64)): complex(64);
-    pragma "fn synchronization free"
-    pragma "codegen for CPU and GPU"
-    extern proc cproj(x: complex(128)): complex(128);
-    if w == 64 then
-      return cprojf(x);
-    else
-      return cproj(x);
-  }
-
   /* Returns the projection of `z` on a Riemann sphere. */
-  pragma "last resort"
-  @deprecated("The argument name 'z' is deprecated for 'cproj', please use 'x' instead")
+  @deprecated("'cproj' has been deprecated, please use :proc:`riemProj` instead")
   inline proc cproj(z: complex(?w)): complex(w) {
-    return cproj(z);
+    return riemProj(z);
   }
 
   // When removing this deprecated function, be sure to remove chpl_cos and
@@ -2188,6 +2173,19 @@ module AutoMath {
     return nearbyintf(x);
   }
 
+  /* Returns the projection of `x` on a Riemann sphere. */
+  inline proc riemProj(x: complex(?w)): complex(w) {
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc cprojf(x: complex(64)): complex(64);
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc cproj(x: complex(128)): complex(128);
+    if w == 64 then
+      return cprojf(x);
+    else
+      return cproj(x);
+  }
 
   // When removing this deprecated function, be sure to remove chpl_rint
   // and move its contents into Math.chpl to reduce the symbols living in this

--- a/test/deprecated/Math/argNames/cprojZ.good
+++ b/test/deprecated/Math/argNames/cprojZ.good
@@ -1,4 +1,0 @@
-cprojZ.chpl:2: In function 'testTypes':
-cprojZ.chpl:3: warning: The argument name 'z' is deprecated for 'cproj', please use 'x' instead
-cprojZ.chpl:2: In function 'testTypes':
-cprojZ.chpl:3: warning: The argument name 'z' is deprecated for 'cproj', please use 'x' instead

--- a/test/deprecated/Math/depCproj.chpl
+++ b/test/deprecated/Math/depCproj.chpl
@@ -1,6 +1,6 @@
 // Snippet taken from test/types/complex/diten/cplxMathFnTypes.chpl
 proc testTypes(x: complex(?w)) {
-  const res4 = cproj(z=x);
+  const res4 = cproj(x);
   assert(res4.type == complex(w));
 }
 

--- a/test/deprecated/Math/depCproj.good
+++ b/test/deprecated/Math/depCproj.good
@@ -1,0 +1,4 @@
+depCproj.chpl:2: In function 'testTypes':
+depCproj.chpl:3: warning: 'cproj' has been deprecated, please use riemProj instead
+depCproj.chpl:2: In function 'testTypes':
+depCproj.chpl:3: warning: 'cproj' has been deprecated, please use riemProj instead

--- a/test/types/complex/diten/cplxMathFnTypes.chpl
+++ b/test/types/complex/diten/cplxMathFnTypes.chpl
@@ -10,7 +10,7 @@ proc testTypes(x: complex(?w)) {
   const res3 = conj(x);
   assert(res3.type == complex(w));
 
-  const res4 = cproj(x);
+  const res4 = riemProj(x);
   assert(res4.type == complex(w));
 
   const res5 = exp(x);


### PR DESCRIPTION
Resolves #19011 

Since we'd already deprecated the argument name this release, adjust the
deprecation message to instead talk about the function name and move the
implementation of the replacement so that it's sorted alphabetically after the
rename.  Remove the "last resort" pragma from the deprecated function,
since that was only necessary because the new version had shared the same
name.

Also adjust the quick links at the beginning of the documentation so that they
refer to the new name instead of the deprecated one.

Updates a test that was using the old name to use the new one.

Adjusts the cproj deprecation test to cover the new deprecation.

Passed a full paratest with futures