### PR TITLE
Fix inconsistent local/UTC methods and add to docs

### DIFF
--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -2206,7 +2206,7 @@ proc getCurrentDate() : (int, int, int) {
    :returns: The current day of the week, calculated from UTC time.
    :rtype:   :type:`day`
  */
-@deprecated("`getCurrentDayOfWeek` is deprecated; please use `date.utcToday().weekday()` instead, or `date.today().weekday()` for local wall time")
+@deprecated("'getCurrentDayOfWeek' is deprecated; please use 'date.utcToday().weekday()' instead, or 'date.today().weekday()' for local wall time")
 proc getCurrentDayOfWeek() : day {
   var now = chpl_now_timevalue();
 

--- a/test/deprecated/Time/getCurrentDate.chpl
+++ b/test/deprecated/Time/getCurrentDate.chpl
@@ -1,7 +1,7 @@
 use Time;
 
 var curDateTuple : (int, int, int) = getCurrentDate();
-var today : date = date.today();
+var today : date = date.utcToday();
 writeln(curDateTuple[0] == today.year);
 writeln(curDateTuple[1] == today.month);
 writeln(curDateTuple[2] == today.day);

--- a/test/deprecated/Time/getCurrentDate.good
+++ b/test/deprecated/Time/getCurrentDate.good
@@ -1,4 +1,4 @@
-getCurrentDate.chpl:3: warning: 'getCurrentDate' is deprecated; access the individual fields of 'date.today()' as needed instead
+getCurrentDate.chpl:3: warning: 'getCurrentDate' is deprecated; access the individual fields of 'date.utcToday()' as needed instead, or use 'date.today()' for local wall time
 true
 true
 true

--- a/test/deprecated/Time/getCurrentDayOfWeek.chpl
+++ b/test/deprecated/Time/getCurrentDayOfWeek.chpl
@@ -2,6 +2,10 @@ use Time;
 
 var weekday = getCurrentDayOfWeek():day;
 
+// ensure same behavior as replacement functionality, with adjustment for what
+// day-of-week enum is used
+writeln((((weekday:int + 6) % 7) + 1) : dayOfWeek == date.utcToday().weekday());
+
 select weekday {
     when day.sunday do writeln("Sunday");
     when day.monday do writeln("Monday");

--- a/test/deprecated/Time/getCurrentDayOfWeek.compopts
+++ b/test/deprecated/Time/getCurrentDayOfWeek.compopts
@@ -1,0 +1,1 @@
+-scIsoDayOfWeek=true

--- a/test/deprecated/Time/getCurrentDayOfWeek.good.base
+++ b/test/deprecated/Time/getCurrentDayOfWeek.good.base
@@ -6,5 +6,5 @@ getCurrentDayOfWeek.chpl:13: warning: enum 'day' is deprecated. Please use dayOf
 getCurrentDayOfWeek.chpl:14: warning: enum 'day' is deprecated. Please use dayOfWeek instead
 getCurrentDayOfWeek.chpl:15: warning: enum 'day' is deprecated. Please use dayOfWeek instead
 getCurrentDayOfWeek.chpl:16: warning: enum 'day' is deprecated. Please use dayOfWeek instead
-getCurrentDayOfWeek.chpl:3: warning: `getCurrentDayOfWeek` is deprecated; please use `date.utcToday().weekday()` instead, or `date.today().weekday()` for local wall time
+getCurrentDayOfWeek.chpl:3: warning: 'getCurrentDayOfWeek' is deprecated; please use 'date.utcToday().weekday()' instead, or 'date.today().weekday()' for local wall time
 true

--- a/test/deprecated/Time/getCurrentDayOfWeek.good.base
+++ b/test/deprecated/Time/getCurrentDayOfWeek.good.base
@@ -1,9 +1,10 @@
 getCurrentDayOfWeek.chpl:3: warning: enum 'day' is deprecated. Please use dayOfWeek instead
-getCurrentDayOfWeek.chpl:6: warning: enum 'day' is deprecated. Please use dayOfWeek instead
-getCurrentDayOfWeek.chpl:7: warning: enum 'day' is deprecated. Please use dayOfWeek instead
-getCurrentDayOfWeek.chpl:8: warning: enum 'day' is deprecated. Please use dayOfWeek instead
-getCurrentDayOfWeek.chpl:9: warning: enum 'day' is deprecated. Please use dayOfWeek instead
 getCurrentDayOfWeek.chpl:10: warning: enum 'day' is deprecated. Please use dayOfWeek instead
 getCurrentDayOfWeek.chpl:11: warning: enum 'day' is deprecated. Please use dayOfWeek instead
 getCurrentDayOfWeek.chpl:12: warning: enum 'day' is deprecated. Please use dayOfWeek instead
-getCurrentDayOfWeek.chpl:3: warning: `getCurrentDayOfWeek` is deprecated; please use `date.today().weekday()` instead
+getCurrentDayOfWeek.chpl:13: warning: enum 'day' is deprecated. Please use dayOfWeek instead
+getCurrentDayOfWeek.chpl:14: warning: enum 'day' is deprecated. Please use dayOfWeek instead
+getCurrentDayOfWeek.chpl:15: warning: enum 'day' is deprecated. Please use dayOfWeek instead
+getCurrentDayOfWeek.chpl:16: warning: enum 'day' is deprecated. Please use dayOfWeek instead
+getCurrentDayOfWeek.chpl:3: warning: `getCurrentDayOfWeek` is deprecated; please use `date.utcToday().weekday()` instead, or `date.today().weekday()` for local wall time
+true


### PR DESCRIPTION
Consistently use local/UTC versions of time-querying methods, and clarify differences in documentation.

In the `Time` module we have different versions of some time-querying methods for local vs UTC time (amongst those that do not take a `Timezone` argument and are therefore still naive). This PR resolves inconsistency between the deprecated `getCurrentDate` method, which uses UTC time, and its suggested replacement `date.today` which uses local time.

Changes:
- add a new `date.utcToday` method, paralleling `dateTime.now/utcNow`
- update the `getCurrentDate` deprecation to point users to `date.utcToday` instead of `date.today`
- clarify the difference in functionality between `date.today` and `date.utcToday` in their docs
- add to module-level docs to mention we support both local and UTC timezone-naive queries, which will produce incongruous results if your local time is not UTC
- similarly update `getCurrentDayOfWeek`, a deprecated UTC-time method which pointed to `date.today().weekday()`, to recommend `date.utcToday().weekday()` instead, and check in its deprecation test that the behavior is identical

Thanks to Ben Harshbarger for alerting me to a `getCurrentDate` test failure due to this bug, which was reproducible based on time zone and current time and did not show up in nightly testing.

Follow up to https://github.com/chapel-lang/chapel/pull/23114.

Resolves https://github.com/chapel-lang/chapel/issues/17439.

[reviewer info placeholder]

Testing:
- [x] local paratest