### PR TITLE
Deprecate the `carg` function fully, to be replaced by a new function `phase`

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -63,8 +63,8 @@ Rounding
 
 Computations Involving Complex Numbers
 --------------------------------------
-:proc:`carg`
 :proc:`conj`
+:proc:`phase`
 :proc:`riemProj`
 
 .. _automath-inf-nan:
@@ -254,7 +254,7 @@ module AutoMath {
 
   /* Returns the magnitude (often called modulus) of complex `x`.
 
-     In concert with the related :proc:`carg`, the phase (a.k.a. argument)
+     In concert with the related :proc:`phase` (a.k.a. argument)
      of `x`, it can be used to recompute `x`.
 
      :rtype: ``real(w/2)`` when `x` has a type of ``complex(w)``.
@@ -313,7 +313,7 @@ module AutoMath {
 
   /* Returns the magnitude (often called modulus) of complex `z`.
 
-     In concert with the related :proc:`carg`, the phase (a.k.a. argument)
+     In concert with the related :proc:`phase` (a.k.a. argument)
      of `z`, it can be used to recompute `z`.
 
      :rtype: ``real(w/2)`` when `z` has a type of ``complex(w)``.
@@ -324,28 +324,6 @@ module AutoMath {
     return abs(z);
   }
 
-  /* Returns the phase (often called `argument`) of complex `x`, an angle (in
-     radians).
-
-     In concert with the related :proc:`abs`, the magnitude (a.k.a.
-     modulus) of `x`, it can be used to recompute `x`.
-
-     :rtype: ``real(w/2)`` when `x` has a type of ``complex(w)``.
-  */
-
-  inline proc carg(x: complex(?w)): real(w/2) {
-    pragma "fn synchronization free"
-    pragma "codegen for CPU and GPU"
-    extern proc cargf(x: complex(64)): real(32);
-    pragma "fn synchronization free"
-    pragma "codegen for CPU and GPU"
-    extern proc carg(x: complex(128)): real(64);
-    if w == 64 then
-      return cargf(x);
-    else
-      return carg(x);
-  }
-
   /* Returns the phase (often called `argument`) of complex `z`, an angle (in
      radians).
 
@@ -354,10 +332,9 @@ module AutoMath {
 
      :rtype: ``real(w/2)`` when `z` has a type of ``complex(w)``.
   */
-  pragma "last resort"
-  @deprecated("The argument name 'z' is deprecated for 'carg', please use 'x' instead")
+  @deprecated("'carg' is deprecated, please use :proc:`phase` instead")
   inline proc carg(z: complex(?w)): real(w/2) {
-    return carg(z);
+    return phase(z);
   }
 
 
@@ -2171,6 +2148,27 @@ module AutoMath {
     pragma "codegen for CPU and GPU"
     extern proc nearbyintf(x: real(32)): real(32);
     return nearbyintf(x);
+  }
+
+  /* Returns the phase (often called `argument`) of complex `x`, an angle (in
+     radians).
+
+     In concert with the related :proc:`abs`, the magnitude (a.k.a.
+     modulus) of `x`, it can be used to recompute `x`.
+
+     :rtype: ``real(w/2)`` when `x` has a type of ``complex(w)``.
+  */
+  inline proc phase(x: complex(?w)): real(w/2) {
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc cargf(x: complex(64)): real(32);
+    pragma "fn synchronization free"
+    pragma "codegen for CPU and GPU"
+    extern proc carg(x: complex(128)): real(64);
+    if w == 64 then
+      return cargf(x);
+    else
+      return carg(x);
   }
 
   /* Returns the projection of `x` on a Riemann sphere. */

--- a/test/deprecated/Math/argNames/cargZ.good
+++ b/test/deprecated/Math/argNames/cargZ.good
@@ -1,4 +1,0 @@
-cargZ.chpl:2: In function 'testTypes':
-cargZ.chpl:3: warning: The argument name 'z' is deprecated for 'carg', please use 'x' instead
-cargZ.chpl:2: In function 'testTypes':
-cargZ.chpl:3: warning: The argument name 'z' is deprecated for 'carg', please use 'x' instead

--- a/test/deprecated/Math/depCarg.chpl
+++ b/test/deprecated/Math/depCarg.chpl
@@ -1,6 +1,6 @@
 // Note: snippet taken from test/types/complex/diten/cplxMathFnTypes.chpl
 proc testTypes(x: complex(?w)) {
-  const res2 = carg(z=x);
+  const res2 = carg(x);
   assert(res2.type == real(w/2));
 }
 

--- a/test/deprecated/Math/depCarg.good
+++ b/test/deprecated/Math/depCarg.good
@@ -1,0 +1,4 @@
+depCarg.chpl:2: In function 'testTypes':
+depCarg.chpl:3: warning: 'carg' is deprecated, please use phase instead
+depCarg.chpl:2: In function 'testTypes':
+depCarg.chpl:3: warning: 'carg' is deprecated, please use phase instead

--- a/test/types/complex/diten/cplxMathFnTypes.chpl
+++ b/test/types/complex/diten/cplxMathFnTypes.chpl
@@ -4,7 +4,7 @@ proc testTypes(x: complex(?w)) {
   const res1 = abs(x);
   assert(res1.type == real(w/2));
 
-  const res2 = carg(x);
+  const res2 = phase(x);
   assert(res2.type == real(w/2));
 
   const res3 = conj(x);


### PR DESCRIPTION
Resolves #19006 

Since the argument name for the `carg` function had been deprecated this
release, we merely needed to update the deprecation message to include the name,
instead of having multiple deprecated versions around.

Alphabetizes the new version.  Removes the "last resort" pragma from the
deprecated version, as it was only needed when they shared the name function
name.

Updates all the documentation links to refer to the new name instead of the
deprecated version.

Updates a test that was using the old name to refer to the new one.

Adjust the carg deprecation test to handle the new changes.

Passed a full paratest with futures