### PR TITLE
Mark both versions of signbit unstable

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -2967,7 +2967,8 @@ module AutoMath {
   }
 
   /* Returns true if the sign of `x` is negative, else returns false. It detects
-     the sign bit of zeroes, infinities, and NANs */
+     the sign bit of zeroes, infinities, and nans */
+  @unstable("signbit is unstable and may change its name in the future")
   inline proc signbit(x : real(32)): bool {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"
@@ -2976,7 +2977,8 @@ module AutoMath {
   }
 
   /* Returns true if the sign of `x` is negative, else returns false. It detects
-     the sign bit of zeroes, infinities, and NANs */
+     the sign bit of zeroes, infinities, and nans */
+  @unstable("signbit is unstable and may change its name in the future")
   inline proc signbit(x : real(64)): bool {
     pragma "fn synchronization free"
     pragma "codegen for CPU and GPU"

--- a/test/unstable/Math/unstableSignbit.chpl
+++ b/test/unstable/Math/unstableSignbit.chpl
@@ -1,0 +1,2 @@
+writeln(signbit(4.3));
+writeln(signbit(-7.21));

--- a/test/unstable/Math/unstableSignbit.good
+++ b/test/unstable/Math/unstableSignbit.good
@@ -1,0 +1,4 @@
+unstableSignbit.chpl:1: warning: signbit is unstable and may change its name in the future
+unstableSignbit.chpl:2: warning: signbit is unstable and may change its name in the future
+false
+true


### PR DESCRIPTION
We probably will at least camelcase this name in the future, but we might end up
with a different name or decide it counts as one word instead.  This function
is not a high priority for 2.0 as compared to other things, so for now punt on
discussing it and mark it unstable.

Add a test locking in the unstable warning

Passed a full paratest with futures