### PR TITLE
Revert changes to coforall in submitted tests

### DIFF
--- a/test/studies/shootout/submitted/fasta5.chpl
+++ b/test/studies/shootout/submitted/fasta5.chpl
@@ -113,7 +113,7 @@ proc randomMake(desc, nuclInfo: [?nuclInds], n) {
   var randGo, outGo: [0..#numTasks] atomic int;
 
   // create tasks to pipeline the RNG, computation, and output
-  coforall tid in 0..#numTasks with (ref outGo, ref randGo) {
+  coforall tid in 0..#numTasks {
     const chunkSize = lineLength*blockSize,
           nextTid = (tid + 1) % numTasks;
 

--- a/test/studies/shootout/submitted/fasta5.good
+++ b/test/studies/shootout/submitted/fasta5.good
@@ -1,6 +1,8 @@
 fasta5.chpl:78: warning: 'iokind' is deprecated, please use Serializers or Deserializers that support endianness instead
 fasta5.chpl:78: warning: openfd is deprecated, please use the file initializer with a 'c_int' argument instead
 fasta5.chpl:78: warning: writer with a 'kind' argument is deprecated, please use Serializers instead
+fasta5.chpl:116: warning: inferring a default intent to be 'ref' is deprecated - please add an explicit 'ref' task intent for 'randGo'
+fasta5.chpl:116: warning: inferring a default intent to be 'ref' is deprecated - please add an explicit 'ref' task intent for 'outGo'
 >ONE Homo sapiens alu
 GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGA
 TCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACT


### PR DESCRIPTION
Revert changes in a submitted test that added explicit ref intents to a coforall loop

Tested locally

[Not reviewed - trivial test change]