### PR TITLE
Mark createBorrowingBuffer on string and bytes as unstable

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -60,6 +60,7 @@ module Bytes {
 
     :returns: A new :type:`bytes`
   */
+  @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type bytes.createBorrowingBuffer(x: bytes) : bytes {
     var ret: bytes;
     initWithBorrowedBuffer(ret, x);
@@ -107,6 +108,7 @@ module Bytes {
 
     :returns: A new :type:`bytes`
   */
+  @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type bytes.createBorrowingBuffer(x: c_ptr(?t),
                                                length=strLen(x)) : bytes {
     return bytes.createBorrowingBuffer(x:bufferType, length=length,
@@ -126,6 +128,7 @@ module Bytes {
 
     :returns: A new :type:`bytes`
   */
+  @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type bytes.createBorrowingBuffer(x: c_ptrConst(?t),
                                                length=strLen(x)) : bytes {
     return bytes.createBorrowingBuffer(x:bufferType, length=length,
@@ -184,6 +187,7 @@ module Bytes {
 
      :returns: A new :type:`bytes`
   */
+  @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type bytes.createBorrowingBuffer(x: c_ptr(?t), length: int,
                                                   size: int) : bytes {
     if t != uint(8) && t != int(8) {

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -390,6 +390,7 @@ module String {
 
     :returns: A new `string`
   */
+  @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type string.createBorrowingBuffer(x: string) : string {
     // we don't validate here because `x` must have been validated already
     var ret: string;
@@ -439,6 +440,7 @@ module String {
 
     :returns: A new `string`
   */
+  @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type string.createBorrowingBuffer(x: c_ptr(?t),
                                                 length=strLen(x)) : string throws {
     return string.createBorrowingBuffer(x:bufferType,
@@ -462,6 +464,7 @@ module String {
 
     :returns: A new `string`
   */
+  @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type string.createBorrowingBuffer(x: c_ptrConst(?t),
                                                 length=strLen(x)) : string throws {
     return string.createBorrowingBuffer(x:bufferType,
@@ -539,6 +542,7 @@ module String {
 
      :returns: A new `string`
   */
+  @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   proc type string.createBorrowingBuffer(x: c_ptr(?t),
                                          length: int,
                                          size: int) : string throws {

--- a/test/unstable/c_str.good
+++ b/test/unstable/c_str.good
@@ -1,4 +1,6 @@
 c_str.chpl:4: warning: 'string.c_str()' is unstable and may change in a future release
 c_str.chpl:5: warning: 'bytes.c_str()' is unstable and may change in a future release
+c_str.chpl:7: warning: 'createBorrowingBuffer' is unstable and may change in the future
+c_str.chpl:8: warning: 'createBorrowingBuffer' is unstable and may change in the future
 my string
 my bytes

--- a/test/unstable/createBorrowingBuffer.chpl
+++ b/test/unstable/createBorrowingBuffer.chpl
@@ -1,0 +1,23 @@
+use CTypes;
+config type T = string;
+var helloBytes: [1..6] uint(8) = [104, 101, 108, 108, 111, 0]:uint(8);
+{
+  var s: T = "hello";
+  var s_ = T.createBorrowingBuffer(s);
+  writeln(s_);
+}
+{
+  var b: [1..6] uint(8) = helloBytes;
+  var s_ = T.createBorrowingBuffer(c_ptrTo(b), length=5);
+  writeln(s_);
+}
+{
+  var b: [1..6] uint(8) = helloBytes;
+  var s_ = T.createBorrowingBuffer(c_ptrToConst(b), length=5);
+  writeln(s_);
+}
+{
+  var b: [1..6] uint(8) = helloBytes;
+  var s_ = T.createBorrowingBuffer(c_ptrTo(b), length=5, size=6);
+  writeln(s_);
+}

--- a/test/unstable/createBorrowingBuffer.compopts
+++ b/test/unstable/createBorrowingBuffer.compopts
@@ -1,0 +1,2 @@
+-sT=string
+-sT=bytes

--- a/test/unstable/createBorrowingBuffer.good
+++ b/test/unstable/createBorrowingBuffer.good
@@ -1,0 +1,8 @@
+createBorrowingBuffer.chpl:6: warning: 'createBorrowingBuffer' is unstable and may change in the future
+createBorrowingBuffer.chpl:11: warning: 'createBorrowingBuffer' is unstable and may change in the future
+createBorrowingBuffer.chpl:16: warning: 'createBorrowingBuffer' is unstable and may change in the future
+createBorrowingBuffer.chpl:21: warning: 'createBorrowingBuffer' is unstable and may change in the future
+hello
+hello
+hello
+hello


### PR DESCRIPTION
Marks createBorrowingBuffer on string and bytes as unstable for 2.0

`createBorrowingBuffer` has potentially questionable behavior that we want to discuss further before stabilizing this (see #22269).

Added test `test/unstable/createBorrowingBuffer.chpl`

Tested with paratest + futures

[Reviewed by @riftEmber]