### PR TITLE
Skip mandlebrot for pbs- based launchers

### DIFF
--- a/test/release/examples/benchmarks/shootout/mandelbrot-fast.skipif
+++ b/test/release/examples/benchmarks/shootout/mandelbrot-fast.skipif
@@ -1,1 +1,2 @@
 CHPL_LAUNCHER <= lsf-
+CHPL_LAUNCHER <= pbs-

--- a/test/release/examples/benchmarks/shootout/mandelbrot.skipif
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.skipif
@@ -1,1 +1,2 @@
 CHPL_LAUNCHER <= lsf-
+CHPL_LAUNCHER <= pbs-


### PR DESCRIPTION
PBS/qsub add carriage returns and we can't remove them from binary files like we can non-binary files, so just skip mandlebrot.

Similar to 97eb8fbe04