### PR TITLE
Fix compilation failures under older GCC versions.

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -388,6 +388,7 @@ class GpuizableLoop {
 public:
   GpuizableLoop(BlockStmt* blk);
   GpuizableLoop(GpuizableLoop&&) = default;
+  GpuizableLoop(const GpuizableLoop&) = default;
 
   static GpuizableLoop fromEligibleClone(BlockStmt* blk) {
     GpuizableLoop loop{blk};


### PR DESCRIPTION
Some older versions require a copy constructor for some reason, but GPU loop does not allow it. Declare a default copy constructor to make those failures go away.

Reviewed by @riftEmber -- thanks!