### PR TITLE
Ignore data movement in `assertGpuDiags` with cpu-as-device mode

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -246,8 +246,11 @@ tests where access to GPUs may be limited. In this mode:
     these warnings. Alternatively, you can pass ``--gpuNoCpuModeWarning`` to your
     application to the same effect.
 
-* Even though the GPU diagnostics are collected, the loop will be executed for
-  correctness testing and there will not be any kernel launch
+* Even though the kernel launches will be registered by GPU diagnostics, the
+  loop will be executed for correctness testing and there will not be any kernel
+  launch
+
+  * GPU diagnostics will not register data movement.
 
 * Advanced features like ``syncThreads`` and ``createSharedArray`` will compile
   and run, but in all likelihood code that uses those features will not

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -238,19 +238,17 @@ tests where access to GPUs may be limited. In this mode:
   outlined under `Diagnostics and Utilities`_ will work as expected.
 
   * For example, :proc:`~GPU.assertOnGpu` will fail at compile time normally.
-    This can allow testing if a loop is GPU-eligible.
+    This can allow testing if a loop is GPU-eligible. It will generate a warning
+    per-iteration at execution time. The ``CHPL_GPU_NO_CPU_MODE_WARNING``
+    environment can be set to suppress these warnings. Alternatively, you can
+    pass ``--gpuNoCpuModeWarning`` to your application to the same effect.
 
-  * It will generate a warning per-iteration at execution time.
-
-  * The ``CHPL_GPU_NO_CPU_MODE_WARNING`` environment can be set to suppress
-    these warnings. Alternatively, you can pass ``--gpuNoCpuModeWarning`` to your
-    application to the same effect.
+  * Note that data movements between device and host will not be captured by the
+    :mod:`GpuDiagnostics` module in this mode.
 
 * Even though the kernel launches will be registered by GPU diagnostics, the
   loop will be executed for correctness testing and there will not be any kernel
   launch
-
-  * GPU diagnostics will not register data movement.
 
 * Advanced features like ``syncThreads`` and ``createSharedArray`` will compile
   and run, but in all likelihood code that uses those features will not

--- a/modules/standard/GpuDiagnostics.chpl
+++ b/modules/standard/GpuDiagnostics.chpl
@@ -46,7 +46,9 @@ module GpuDiagnostics
   param gpuDiagsPrintUnstable = false;
 
   /*
-     Aggregated GPU operation counts.
+     Aggregated GPU operation counts. `host_to_device`, `device_to_host` and
+     `device_to_device` will be non-zero only when
+     `CHPL_GPU_MEM_STRATEGY==array_on_device` and `CHPL_GPU!=cpu`.
    */
   pragma "chpldoc ignore chpl prefix"
   extern record chpl_gpuDiagnostics {
@@ -92,6 +94,7 @@ module GpuDiagnostics
     use ChplConfig;
 
     param isUm = CHPL_GPU_MEM_STRATEGY == "unified_memory";
+    param isCpu = CHPL_GPU == "cpu";
 
     const expectedLaunch;
     if kernel_launch >= 0 {
@@ -107,7 +110,7 @@ module GpuDiagnostics
     const diags = getGpuDiagnostics()[0];
     var success = compare(expectedLaunch, diags.kernel_launch, "launches");
 
-    if !isUm {
+    if !isUm && !isCpu {
       success &= compare(host_to_device, diags.host_to_device,
                          "host to device communication calls");
       success &= compare(device_to_host, diags.device_to_host,

--- a/modules/standard/GpuDiagnostics.chpl
+++ b/modules/standard/GpuDiagnostics.chpl
@@ -46,9 +46,9 @@ module GpuDiagnostics
   param gpuDiagsPrintUnstable = false;
 
   /*
-     Aggregated GPU operation counts. `host_to_device`, `device_to_host` and
-     `device_to_device` will be non-zero only when
-     `CHPL_GPU_MEM_STRATEGY==array_on_device` and `CHPL_GPU!=cpu`.
+     Aggregated GPU operation counts. ``host_to_device``, ``device_to_host`` and
+     ``device_to_device`` will be non-zero only when
+     ``CHPL_GPU_MEM_STRATEGY==array_on_device`` and ``CHPL_GPU!=cpu``.
    */
   pragma "chpldoc ignore chpl prefix"
   extern record chpl_gpuDiagnostics {


### PR DESCRIPTION
It is not easy at all to capture data movement in cpu-as-device mode. This PR makes sure that `assertGpuDiags` ignores data movement similar to `unified_memory` mode. While there, it also adjusts related documentation to mention this limitation.

https://github.com/chapel-lang/chapel/issues/23191 talks about the limitation itself.

Tests that failed because of this pass with after this PR.