### PR TITLE
Add linux64 aarch64 testing

### DIFF
--- a/util/cron/test-linux64-aarch64.bash
+++ b/util/cron/test-linux64-aarch64.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Test default configuration against full suite on aarch64 linux.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+source $CWD/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-aarch64"
+
+$CWD/nightly -cron $(get_nightly_paratest_args)


### PR DESCRIPTION
The recent qthreads 1.19 upgrade provides mature arm support, which is faster and resolves a lot of sporadic issues we've seen. Between that and some recent test fixes we now have clean arm testing and I want to lock that in with a new config.

Resolves Cray/chapel-private#4540
Resolves Cray/chapel-private#5334