### PR TITLE
Change location for chapel.rb in homebrew tests

### DIFF
--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -42,7 +42,7 @@ log_info "Building tarball with version: ${version}"
 
 mkdir -p $HOME/test
 git clone git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull) 
-cp $HOME/test/homebrew-core/Formula/chapel.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
+cp $HOME/test/homebrew-core/Formula/c/chapel.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
 
 cd ${CHPL_HOME}/util/packaging/homebrew
 # Get the tarball from the root tar/ directory and replace the url in chapel.rb with the tarball location


### PR DESCRIPTION
Homebrew changed the file layout and now chapel is in the Formula/c directory