### PR TITLE
Default to qthreads tasking layer on arm based macs

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -151,12 +151,7 @@ endif
 # immediately fail)
 ifneq (,$(CHPL_QTHREAD_SANITIZER_SUPPORT))
   CHPL_QTHREAD_CFG_OPTIONS += --disable-fastcontext
-endif
-
-# No fastcontext on m1, fallback to ucontext (with _XOPEN_SOURCE to allow it)
-ifeq ($(CHPL_MAKE_TARGET_PLATFORM),darwin)
   ifeq ($(CHPL_MAKE_TARGET_ARCH),arm64)
-    CHPL_QTHREAD_CFG_OPTIONS += --disable-fastcontext
     CFLAGS += -D_XOPEN_SOURCE
   endif
 endif

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -18,9 +18,8 @@ def get():
         cygwin = platform_val.startswith('cygwin')
         bsd = (platform_val.startswith('netbsd') or
                platform_val.startswith('freebsd'))
-        mac_arm = platform_val.startswith('darwin') and arch_val == 'arm64'
 
-        if cygwin or bsd or mac_arm:
+        if cygwin or bsd:
             tasks_val = 'fifo'
         else:
             tasks_val = 'qthreads'

--- a/util/cron/test-darwin-m1.bash
+++ b/util/cron/test-darwin-m1.bash
@@ -9,7 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
 
-# Quiet warnings from defaulting to fifo
-export CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET=yes
-
 $CWD/nightly -cron $(get_nightly_paratest_args)

--- a/util/cron/test-gasnet.darwin-m1.bash
+++ b/util/cron/test-gasnet.darwin-m1.bash
@@ -9,7 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin-m1"
 
-# Quiet warnings from defaulting to fifo
-export CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET=yes
-
 $CWD/nightly -cron -multilocale $(get_nightly_paratest_args)


### PR DESCRIPTION
qthreads 1.19 has mature support for ARM64, including native ARM context switching and bugfixes for ARM memory consistency issues. This significantly improves the stability and performance of qthreads on ARM, especially for arm-based macs where system ucontext switching was slow enough that we defaulted to fifo previously. Qthreads with native asm is now much faster than fifo on arm macs and correctness testing looks stable, so make it the default.

Here's performance for a task creation and switching microbenchmark on a 10 core M1 Pro (8 performance cores, 2 efficiency):

<details>

```chpl
// Small parallel/taskCompare/elliot/{empty-chpl-taskspawn.chpl,chpl-taskyield.chpl}
use Time;

config const trials = 500_000;

var s: stopwatch; s.start();
for 1..trials do
  coforall 1..here.maxTaskPar { }
writef("%i task creation: %.2dr\n", trials*here.maxTaskPar, s.elapsed()); s.clear();

var total: atomic int;
coforall 1..here.maxTaskPar*4 {
  var i: int;
  for 1..trials {
    i += 1;
    currentTask.yieldExecution();
  }
  total.add(i);
}
writef("%i task switching: %.2dr\n", total.read(), s.elapsed()); s.clear();
```

</details>

Task Creation:

| task   | qt no asm | fifo def | qt asm |
| -----: | --------: | -------: | -----: |
| create | 208.61s   | 18.70s   | 0.97s  |
| switch |  29.63s   |  8.85s   | 0.15s  |

So qthreads task creation/switching with fastcontext is ~200x faster than the old ucontext version and over 20x faster than fifo by default. Note that since #22945, we're only using the 8 performance cores for qthreads so it's not an apples-to-apples comparison since fifo doesn't limit, but that's a side benefit of switching to qthreads. Forcing fifo to only use 8 cores lowers the delta between qt asm to only 10x, but that's still a substantial improvements and it's not easy to get fifo to use less cores in general.

<details>

Here's some results with with different cores counts. Fifo with `CHPL_RT_NUM_THREADS_PER_LOCALE={unset,8}` (can lead to deadlock in general) and qthreads with `CHPL_RT_USE_PU_KIND={all,performance}`

| task   | fifo 10c | fifo 8c | qt 10c | qt 8c  |
| -----: | -------: | ------: | -----: | -----: |
| create | 18.70s   | 6.32s   | 1.77s  | 0.97s  |
| switch |  8.85s   | 2.03s   | 0.24s  | 0.15s  |

</details>

Resolves Cray/chapel-private#3531
Resolves #22895