### PR TITLE
Adjust a multilocale GPU test for AOD runs

### DIFF
--- a/test/gpu/native/multiLocale/onAllGpusOnAllLocales.chpl
+++ b/test/gpu/native/multiLocale/onAllGpusOnAllLocales.chpl
@@ -34,13 +34,16 @@ writeln("here.gpus.size > 1:  ", here.gpus.size > 1);
 var numLaunches = getGpuDiagnostics().kernel_launch;
 writeln("numLaunches.size == Locales.size: ", numLaunches.size == Locales.size);
 
-// We expect the first locale to have 1 more launch than all subsequent locales
-writeln("numLaunches[0] == numLaunches[1] + 1:  ",
-  numLaunches[0] == numLaunches[1] + 1);
+// We expect the first locale to have 2 more launch than all subsequent locales
+// because of array initializations
+writeln("numLaunches[0] == numLaunches[1] + 2:  ",
+  numLaunches[0] == numLaunches[1] + 2);
 
 // We expect the second locale to have launches equal to the number of GPUs per
-// node (we're assuming all nodes have an equal number of GPUs)
-writeln("numLaunches[1] == here.gpus.size:  ", numLaunches[1] == here.gpus.size);
+// node+1 (we're assuming all nodes have an equal number of GPUs), where +1 is
+// for array initialization.
+writeln("numLaunches[1] == here.gpus.size + 1:  ",
+        numLaunches[1] == here.gpus.size + 1);
 
 // Ensure that for all but the first locale the number of kernel launches
 // on each locale matches

--- a/test/gpu/native/multiLocale/onAllGpusOnAllLocales.good
+++ b/test/gpu/native/multiLocale/onAllGpusOnAllLocales.good
@@ -1,6 +1,6 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 here.gpus.size > 1:  true
 numLaunches.size == Locales.size: true
-numLaunches[0] == numLaunches[1] + 1:  true
-numLaunches[1] == here.gpus.size:  true
+numLaunches[0] == numLaunches[1] + 2:  true
+numLaunches[1] == here.gpus.size + 1:  true
 numLaunches[i] == numLaunches[i+1] for all i > 0?:  true


### PR DESCRIPTION
This test locks in number of kernel launches in a custom way and needed adjusting now that `array_on_device` is the default memory strategy.

Test passes under gasnet+gpu configuration.