### PR TITLE
Debug dedup failures with additional tests

### DIFF
--- a/test/studies/dedup/dedup-debug-1.chpl
+++ b/test/studies/dedup/dedup-debug-1.chpl
@@ -1,0 +1,1 @@
+dedup-extern.chpl

--- a/test/studies/dedup/dedup-debug-1.compopts
+++ b/test/studies/dedup/dedup-debug-1.compopts
@@ -1,0 +1,1 @@
+--savec dedup-debug-1.gen --no-cpp-lines

--- a/test/studies/dedup/dedup-debug-1.prediff
+++ b/test/studies/dedup/dedup-debug-1.prediff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Save away the executable
+cp -ipv dedup-debug-1 dedup-debug-1.gen/

--- a/test/studies/dedup/dedup-debug-1.skipif
+++ b/test/studies/dedup/dedup-debug-1.skipif
@@ -1,0 +1,3 @@
+# The purpose of this test is to debug the valgrind failure.
+# Skip it for all other configurations.
+CHPL_TEST_VGRND_EXE != on

--- a/test/studies/dedup/dedup-debug-2.chpl
+++ b/test/studies/dedup/dedup-debug-2.chpl
@@ -1,0 +1,1 @@
+dedup-extern.chpl

--- a/test/studies/dedup/dedup-debug-2.compopts
+++ b/test/studies/dedup/dedup-debug-2.compopts
@@ -1,0 +1,1 @@
+--savec dedup-debug-2.gen --no-cpp-lines --devel -g

--- a/test/studies/dedup/dedup-debug-2.prediff
+++ b/test/studies/dedup/dedup-debug-2.prediff
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Save away the executable
+cp -ipv dedup-debug-2 dedup-debug-2.gen/

--- a/test/studies/dedup/dedup-debug-2.skipif
+++ b/test/studies/dedup/dedup-debug-2.skipif
@@ -1,0 +1,3 @@
+# The purpose of this test is to debug the valgrind failure.
+# Skip it for all other configurations.
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
This PR adds clones of the test `studies/dedup/dedup-extern` to debug recent valgrind+ASAN failures and earlier sporadic execution crashes in this test that we have not been able to reproduce in manual runs.

These clones are skipif-ed for non-valgrind configurations. They have `--savec` in compopts, with and without `--devel -g`, to generate persisting artifacts.

They are missing .good files intentionally to draw my intention to them.

Not reviewed.