### PR TITLE
Use pkg-config to find libcrypo deps for dedup tests

### DIFF
--- a/test/studies/dedup/dedup-extern.compopts
+++ b/test/studies/dedup/dedup-extern.compopts
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+ccflags=$(pkg-config --cflags 'libcrypto >= 1.1')
+ldflags=$(pkg-config --libs 'libcrypto >= 1.1')
+
+echo "${ccflags:+--ccflags '$ccflags'} ${ldflags:+--ldflags '$ldflags'}"

--- a/test/studies/dedup/dedup-externblock.compopts
+++ b/test/studies/dedup/dedup-externblock.compopts
@@ -1,0 +1,1 @@
+dedup-extern.compopts


### PR DESCRIPTION
Previously, these tests just used pkg-config to check if a new enough libcrypto is installed, but then didn't provider any compopts, so essentially assumed it was a system install and that `-l libcrypo` would find the correct one. However, this isn't right since others tools can put things in the pkg-config path in a way that won't be found by default by a compiler.

This resulted in cases where a spack install provides a new enough libcrypto pass the skipif, but then our test was using too old over a system version. Fix that here by using pkg-config to get the include and lib paths.

This should resolve recent failures on valgrind and I believe explains sporadic failures we've seen since the reason we require a newer version is that old versions weren't thread safe and cause sporadic failures.

Resolves Cray/chapel-private#2640