### PR TITLE
Fixup dedup debugging tests

### DIFF
--- a/test/studies/dedup/PREDIFF
+++ b/test/studies/dedup/PREDIFF
@@ -8,6 +8,10 @@ testBaseName = sys.argv[1]
 testOutput = sys.argv[2]
 goodFile = 'all.good'
 
+if testBaseName == 'dedup-debug-1' or testBaseName == 'dedup-debug-2':
+  print("not processing ", testBaseName)
+  sys.exit()
+
 def readgroups(filename):
 
   curgroup = [ ]

--- a/test/studies/dedup/dedup-debug-1.prediff
+++ b/test/studies/dedup/dedup-debug-1.prediff
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Save away the executable
-cp -ipv dedup-debug-1 dedup-debug-1.gen/
+cp -pv dedup-debug-1 dedup-debug-1.gen/

--- a/test/studies/dedup/dedup-debug-2.prediff
+++ b/test/studies/dedup/dedup-debug-2.prediff
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Save away the executable
-cp -ipv dedup-debug-2 dedup-debug-2.gen/
+cp -pv dedup-debug-2 dedup-debug-2.gen/


### PR DESCRIPTION
This PR removes the `-i` option when saving away the compiled executables in the tests added in #23198. Otherwise it may hang forever if the tests re-run without cleaning up the gen directories. While there, prevent the PREDIFF from mingling these tests' output.

While these tests are no longer needed, I would like to keep them around until we resolve the underlying issue.

Not reviewed.