### PR TITLE
Bump new linux64-aarch64 testing nodepara to 3

### DIFF
--- a/util/cron/test-linux64-aarch64.bash
+++ b/util/cron/test-linux64-aarch64.bash
@@ -8,4 +8,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-aarch64"
 
-$CWD/nightly -cron $(get_nightly_paratest_args)
+$CWD/nightly -cron $(get_nightly_paratest_args 3)


### PR DESCRIPTION
Default nodepara 2 is taking over 24 hours, so try 3 to get under.