### PR TITLE
Remove dedup debugging tests

### DIFF
--- a/test/studies/dedup/PREDIFF
+++ b/test/studies/dedup/PREDIFF
@@ -8,10 +8,6 @@ testBaseName = sys.argv[1]
 testOutput = sys.argv[2]
 goodFile = 'all.good'
 
-if testBaseName == 'dedup-debug-1' or testBaseName == 'dedup-debug-2':
-  print("not processing ", testBaseName)
-  sys.exit()
-
 def readgroups(filename):
 
   curgroup = [ ]

--- a/test/studies/dedup/dedup-debug-1.chpl
+++ b/test/studies/dedup/dedup-debug-1.chpl
@@ -1,1 +1,0 @@
-dedup-extern.chpl

--- a/test/studies/dedup/dedup-debug-1.compopts
+++ b/test/studies/dedup/dedup-debug-1.compopts
@@ -1,1 +1,0 @@
---savec dedup-debug-1.gen --no-cpp-lines

--- a/test/studies/dedup/dedup-debug-1.prediff
+++ b/test/studies/dedup/dedup-debug-1.prediff
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Save away the executable
-cp -pv dedup-debug-1 dedup-debug-1.gen/

--- a/test/studies/dedup/dedup-debug-1.skipif
+++ b/test/studies/dedup/dedup-debug-1.skipif
@@ -1,3 +1,0 @@
-# The purpose of this test is to debug the valgrind failure.
-# Skip it for all other configurations.
-CHPL_TEST_VGRND_EXE != on

--- a/test/studies/dedup/dedup-debug-2.chpl
+++ b/test/studies/dedup/dedup-debug-2.chpl
@@ -1,1 +1,0 @@
-dedup-extern.chpl

--- a/test/studies/dedup/dedup-debug-2.compopts
+++ b/test/studies/dedup/dedup-debug-2.compopts
@@ -1,1 +1,0 @@
---savec dedup-debug-2.gen --no-cpp-lines --devel -g

--- a/test/studies/dedup/dedup-debug-2.prediff
+++ b/test/studies/dedup/dedup-debug-2.prediff
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Save away the executable
-cp -pv dedup-debug-2 dedup-debug-2.gen/

--- a/test/studies/dedup/dedup-debug-2.skipif
+++ b/test/studies/dedup/dedup-debug-2.skipif
@@ -1,3 +1,0 @@
-# The purpose of this test is to debug the valgrind failure.
-# Skip it for all other configurations.
-CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
Revert #23200 and #23198.
They are (hopefully) no longer needed, thanks to #23199.

Not reviewed.