### PR TITLE
Fix maxTaskPar test on arm macs under qthreads

### DIFF
--- a/test/localeModels/gbt/maxTaskPar.prediff
+++ b/test/localeModels/gbt/maxTaskPar.prediff
@@ -49,7 +49,13 @@ case $target in
     echo $numCores > $1.good;;
 
   darwin)
-    echo $( sysctl -n hw.physicalcpu ) > $1.good;;
+    case $tasks in
+      qthreads)
+        echo $( sysctl -n hw.perflevel0.physicalcpu 2>/dev/null || sysctl -n hw.physicalcpu ) > $1.good;;
+      *)
+        echo $( sysctl -n hw.physicalcpu ) > $1.good;;
+    esac
+    ;;
 
   *)
     cores_from_lscpu_or_proc_cpuinfo


### PR DESCRIPTION
Since #22945 `here.maxTaskPar` reflects the number of performance cores on mac. Use `sysctl -n hw.perflevel0.physicalcpu` to compute that if it's available, falling back to the current `hw.physicalcpu` if that doesn't exist.