### PR TITLE
Fix math in a test validation

### DIFF
--- a/test/gpu/native/multiLocale/onAllGpusOnAllLocales.chpl
+++ b/test/gpu/native/multiLocale/onAllGpusOnAllLocales.chpl
@@ -40,10 +40,10 @@ writeln("numLaunches[0] == numLaunches[1] + 2:  ",
   numLaunches[0] == numLaunches[1] + 2);
 
 // We expect the second locale to have launches equal to the number of GPUs per
-// node+1 (we're assuming all nodes have an equal number of GPUs), where +1 is
+// node*2 (we're assuming all nodes have an equal number of GPUs), where *2 is
 // for array initialization.
-writeln("numLaunches[1] == here.gpus.size + 1:  ",
-        numLaunches[1] == here.gpus.size + 1);
+writeln("numLaunches[1] == here.gpus.size*2:  ",
+        numLaunches[1] == here.gpus.size*2);
 
 // Ensure that for all but the first locale the number of kernel launches
 // on each locale matches

--- a/test/gpu/native/multiLocale/onAllGpusOnAllLocales.good
+++ b/test/gpu/native/multiLocale/onAllGpusOnAllLocales.good
@@ -2,5 +2,5 @@ warning: The prototype GPU support implies --no-checks. This may impact debuggab
 here.gpus.size > 1:  true
 numLaunches.size == Locales.size: true
 numLaunches[0] == numLaunches[1] + 2:  true
-numLaunches[1] == here.gpus.size + 1:  true
+numLaunches[1] == here.gpus.size*2:  true
 numLaunches[i] == numLaunches[i+1] for all i > 0?:  true


### PR DESCRIPTION
I "fixed" this test in https://github.com/chapel-lang/chapel/pull/23197. But kernel launch math was incorrect for systems where there is multiple GPUs per locale.

This PR re-fixes the test, hopefully correctly this time.