### PR TITLE
String/bytes docs update

### DIFF
--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -14,6 +14,36 @@ The purpose of this flag is to identify portions of a program that use a
 language or library feature has recently changed meaning or which is
 expected to change meaning in the future.
 
+version 1.32, September 2023
+----------------------------
+
+Version 1.32 deprecates the ``c_string`` type in user interfaces. Please
+replace occurrences of ``c_string`` with ``c_ptrConst(c_char)``. Note that you
+need to ``use`` or ``import`` the ``CTypes`` module.
+
+Here are some cases where directly replacing ``c_string`` with
+``c_ptrConst(c_char)`` may not work and what to do instead:
+
+=============================== =============================================
+if your code is...              update it to...
+=============================== =============================================
+casting to ``string``           use a ``string.create*ingBuffer()`` method
+casting to ``bytes``            use a ``bytes.create*ingBuffer()`` method
+using ``param c_string``        use ``param string``
+=============================== =============================================
+
+Additionally, several ``c_string`` methods are deprecated without replacement:
+
+- ``.writeThis()``
+- ``.serialize()``
+- ``.readThis()``
+- ``.indexOf()``
+- ``.substring()``
+- ``.size`` *
+
+An equivalent procedure for ``.size`` is the unstable procedure ``strLen(x)``
+in ``CTypes``.
+
 version 1.31, June 2023
 -----------------------
 
@@ -418,7 +448,7 @@ experiences:
   If you have a pattern that you're trying to write in an
   index-neutral style, but can't, don't hesitate to `ask for tips
   <https://chapel-lang.org/community.html>`_.
-        
+
 
 * Some common pitfalls to check for in your code include:
 

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -24,13 +24,17 @@ need to ``use`` or ``import`` the ``CTypes`` module.
 Here are some cases where directly replacing ``c_string`` with
 ``c_ptrConst(c_char)`` may not work and what to do instead:
 
-=============================== =============================================
-if your code is...              update it to...
-=============================== =============================================
-casting to ``string``           use a ``string.create*ingBuffer()`` method
-casting to ``bytes``            use a ``bytes.create*ingBuffer()`` method
-using ``param c_string``        use ``param string``
-=============================== =============================================
+==================================  ============================================
+if your code is...                  update it to...
+==================================  ============================================
+casting ``c_string`` to ``string``  use a ``string.create*Buffer()`` method
+casting ``c_string`` to ``bytes``   use a ``bytes.create*Buffer()`` method
+casting ``c_string`` to other type  create a string and cast it to other type
+casting ``string`` to ``c_string``  replace cast with ``.c_str()``
+casting ``bytes`` to ``c_string``   replace cast with ``.c_str()``
+casting other type to ``c_string``  create a string and call ``.c_str()`` on it
+using ``param c_string``            use ``param string``
+==================================  ============================================
 
 Additionally, several ``c_string`` methods are deprecated without replacement:
 
@@ -41,8 +45,8 @@ Additionally, several ``c_string`` methods are deprecated without replacement:
 - ``.substring()``
 - ``.size`` *
 
-An equivalent procedure for ``.size`` is the unstable procedure ``strLen(x)``
-in ``CTypes``.
+An equivalent for ``.size`` is the unstable procedure ``strLen(x)`` in the
+``CTypes`` module.
 
 version 1.31, June 2023
 -----------------------

--- a/doc/rst/language/spec/strings.rst
+++ b/doc/rst/language/spec/strings.rst
@@ -81,7 +81,7 @@ strategy is similar to Python's "surrogate escapes" and is as follows.
 
 This strategy typically results in storing 3 bytes for each byte in the illegal
 sequence. Similarly escaped strings can also be created with
-:proc:`~String.createStringWithNewBuffer` using a C buffer.
+:proc:`~String.string.createCopyingBuffer` using a C buffer.
 
 An escaped data sequence can be reconstructed with :proc:`~String.string.encode`:
 

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -585,8 +585,8 @@ module Bytes {
 
 
   /*
-    Gets a `c_ptrConst(c_char)` from a :type:`bytes`. The returned `c_ptrConst(c_char)`
-    shares the buffer with the :type:`bytes`.
+    Gets a `c_ptrConst(c_char)` from a :type:`bytes`. The returned
+    `c_ptrConst(c_char)` shares the buffer with the :type:`bytes`.
 
     .. warning::
 
@@ -604,12 +604,12 @@ module Bytes {
           printf("%s", myBytes.localize().c_str());
         }
 
-    :returns: A `c_ptrConst(c_char)` that points to the underlying buffer used by this
-        :type:`bytes`. The returned `c_ptrConst(c_char)` is only valid when used
-        on the same locale as the bytes.
+    :returns: A `c_ptrConst(c_char)` that points to the underlying buffer used
+              by this :type:`bytes`. The returned `c_ptrConst(c_char)` is only
+              valid when used on the same locale as the bytes.
    */
   pragma "last resort"
-  @deprecated("'bytes.c_str()' has moved to 'CTypes'. Please 'use CTypes' to access the replacement")
+  @deprecated("'bytes.c_str()' has moved to 'CTypes'. Please use :proc:`~CTypes.bytes.c_str()`")
   inline proc bytes.c_str(): c_ptrConst(c_char) {
     use CTypes only c_str;
     return this.c_str();

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -117,7 +117,7 @@ module Bytes {
 
   /*
     Creates a new :type:`bytes` which borrows the memory allocated for a
-    `c_ptrConst`. If the buffer is freed before the :type:`bytes` returned
+    :class:`~CTypes.c_ptrConst`. If the buffer is freed before the :type:`bytes` returned
     from this function, accessing it is undefined behavior.
 
     :arg x: `c_ptrConst` to borrow as a buffer
@@ -251,7 +251,7 @@ module Bytes {
 
     /*
     Creates a new :type:`bytes` which takes ownership of the memory
-    allocated for a `c_ptrConst`. The buffer will be freed when the
+    allocated for a :class:`~CTypes.c_ptrConst`. The buffer will be freed when the
     :type:`bytes` is deinitialized.
 
     :arg x: The `c_ptrConst` to take ownership of
@@ -347,7 +347,7 @@ module Bytes {
   /*
     Creates a new :type:`bytes` by creating a copy of a buffer
 
-    :arg x: The `c_ptrConst` to copy
+    :arg x: The :class:`~CTypes.c_ptrConst` to copy
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
     :arg length: Length of buffer `x`, excluding the terminating null byte. Defaults to the number of bytes in x before the terminating null byte.

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -609,7 +609,7 @@ module Bytes {
               valid when used on the same locale as the bytes.
    */
   pragma "last resort"
-  @deprecated("'bytes.c_str()' has moved to 'CTypes'. Please use :proc:`~CTypes.bytes.c_str()`")
+  @deprecated("'bytes.c_str()' has moved to 'CTypes'. Please 'use CTypes' to access ':proc:`~CTypes.bytes.c_str`'")
   inline proc bytes.c_str(): c_ptrConst(c_char) {
     use CTypes only c_str;
     return this.c_str();

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -608,9 +608,11 @@ module Bytes {
         :type:`bytes`. The returned `c_ptrConst(c_char)` is only valid when used
         on the same locale as the bytes.
    */
-  @unstable("'bytes.c_str()' is unstable and may change in a future release")
+  pragma "last resort"
+  @deprecated("'bytes.c_str()' has moved to 'CTypes'. Please 'use CTypes' to access the replacement")
   inline proc bytes.c_str(): c_ptrConst(c_char) {
-    return getCStr(this);
+    use CTypes only c_str;
+    return this.c_str();
   }
 
   /*

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1359,8 +1359,8 @@ module String {
   }
 
   /*
-    Get a `c_ptrConst(c_char)` from a :type:`string`. The returned `c_ptrConst(c_char)`
-    shares the buffer with the :type:`string`.
+    Get a `c_ptrConst(c_char)` from a :type:`string`. The returned
+    `c_ptrConst(c_char)` shares the buffer with the :type:`string`.
 
     .. warning::
 
@@ -1384,7 +1384,7 @@ module String {
         on the same locale as the string.
    */
   pragma "last resort"
-  @deprecated("'string.c_str()'' has moved to 'CTypes'. Please 'use CTypes' to access the replacement")
+  @deprecated("'string.c_str()'' has moved to 'CTypes'. Please use :proc:`~CTypes.string.c_str()`")
   inline proc string.c_str() : c_ptrConst(c_char) {
     use CTypes only c_str;
     return this.c_str();

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1383,9 +1383,11 @@ module String {
         :type:`string`. The returned `c_ptrConst(c_char)` is only valid when used
         on the same locale as the string.
    */
-  @unstable("'string.c_str()' is unstable and may change in a future release")
+  pragma "last resort"
+  @deprecated("'string.c_str()'' has moved to 'CTypes'. Please 'use CTypes' to access the replacement")
   inline proc string.c_str() : c_ptrConst(c_char) {
-    return getCStr(this);
+    use CTypes only c_str;
+    return this.c_str();
   }
 
   /*

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1384,7 +1384,7 @@ module String {
         on the same locale as the string.
    */
   pragma "last resort"
-  @deprecated("'string.c_str()'' has moved to 'CTypes'. Please use :proc:`~CTypes.string.c_str()`")
+  @deprecated("'string.c_str()' has moved to 'CTypes'. Please 'use CTypes' to access ':proc:`~CTypes.string.c_str`'")
   inline proc string.c_str() : c_ptrConst(c_char) {
     use CTypes only c_str;
     return this.c_str();

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -366,14 +366,14 @@ module String {
   //
 
   /*
-    Creates a new string which borrows the internal buffer of another string. If
+    Creates a new :type:`string` which borrows the internal buffer of another string. If
     the buffer is freed before the string returned from this function, accessing
     it is undefined behavior.
 
     :arg x: Object to borrow the buffer from
     :type x: `string`
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   @deprecated("createStringWithBorrowedBuffer is deprecated - please use :proc:`string.createBorrowingBuffer` instead")
   inline proc createStringWithBorrowedBuffer(x: string) : string {
@@ -381,14 +381,14 @@ module String {
   }
 
   /*
-    Creates a new string which borrows the internal buffer of another string. If
+    Creates a new :type:`string` which borrows the internal buffer of another string. If
     the buffer is freed before the string returned from this function, accessing
     it is undefined behavior.
 
     :arg x: Object to borrow the buffer from
     :type x: `string`
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type string.createBorrowingBuffer(x: string) : string {
@@ -400,8 +400,8 @@ module String {
   }
 
   /*
-    Creates a new string which borrows the internal buffer of a `c_string`. If
-    the buffer is freed before the string returned from this function, accessing
+    Creates a new :type:`string` which borrows the internal buffer of a `c_string`. If
+    the buffer is freed before the :type:`string` returned from this function, accessing
     it is undefined behavior.
 
     :arg x: Object to borrow the buffer from
@@ -411,10 +411,10 @@ module String {
                  terminating null byte.
     :type length: `int`
 
-    :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+    :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
       characters.
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   @deprecated("createStringWithBorrowedBuffer is deprecated - please use :proc:`string.createBorrowingBuffer` instead")
   inline proc createStringWithBorrowedBuffer(x: c_string,
@@ -425,20 +425,21 @@ module String {
   }
 
   /*
-    Creates a new string which borrows the memory allocated for a c_ptr. If
-    the buffer is freed before the string returned from this function, accessing
+    Creates a new :type:`string` which borrows the memory allocated for a :class:`~CTypes.c_ptr`. If
+    the buffer is freed before the :type:`string` returned from this function, accessing
     it is undefined behavior.
 
-    :arg x: Buffer to borrow
+    :arg x: The buffer to borrow from
     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
     :arg length: Length of the string stored in `x` in bytes, excluding the
                  terminating null byte.
     :type length: `int`
 
-    :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+    :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     characters.
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type string.createBorrowingBuffer(x: c_ptr(?t),
@@ -449,20 +450,21 @@ module String {
   }
 
   /*
-    Creates a new string which borrows the memory allocated for a c_ptrConst. If
-    the buffer is freed before the string returned from this function, accessing
+    Creates a new :type:`string` which borrows the memory allocated for a :class:`~CTypes.c_ptrConst`. If
+    the buffer is freed before the :type:`string` returned from this function, accessing
     it is undefined behavior.
 
-    :arg x: Buffer to borrow
+    :arg x: The buffer to borrow from
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
     :arg length: Length of the string stored in `x` in bytes, excluding the
                  terminating null byte.
     :type length: `int`
 
-    :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+    :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     characters.
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   inline proc type string.createBorrowingBuffer(x: c_ptrConst(?t),
@@ -496,11 +498,11 @@ module String {
   }
 
   /*
-     Creates a new string which borrows the memory allocated for a `c_ptr`. If
-     the buffer is freed before the string returned from this function,
+     Creates a new :type:`string` which borrows the memory allocated for a :class:`~CTypes.c_ptr`. If
+     the buffer is freed before the :type:`string` returned from this function,
      accessing it is undefined behavior.
 
-     :arg x: Buffer to borrow
+     :arg x: The buffer to borrow from
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
      :arg length: Length of the string stored in `x` in bytes, excluding the
@@ -510,10 +512,10 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
       characters.
 
-     :returns: A new `string`
+     :returns: A new :type:`string`
   */
   @deprecated("createStringWithBorrowedBuffer is deprecated - please use :proc:`string.createBorrowingBuffer` instead")
   inline proc createStringWithBorrowedBuffer(x: c_ptr(?t),
@@ -523,11 +525,11 @@ module String {
   }
 
   /*
-     Creates a new string which borrows the memory allocated for a `c_ptr`. If
-     the buffer is freed before the string returned from this function,
+     Creates a new :type:`string` which borrows the memory allocated for a :class:`~CTypes.c_ptr`. If
+     the buffer is freed before the :type:`string` returned from this function,
      accessing it is undefined behavior.
 
-     :arg x: Buffer to borrow
+     :arg x: The buffer to borrow from
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
      :arg length: Length of the string stored in `x` in bytes, excluding the
@@ -537,10 +539,10 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
       characters.
 
-     :returns: A new `string`
+     :returns: A new :type:`string`
   */
   @unstable("'createBorrowingBuffer' is unstable and may change in the future")
   proc type string.createBorrowingBuffer(x: c_ptr(?t),
@@ -571,8 +573,8 @@ module String {
   }
 
   /*
-    Creates a new string which takes ownership of the internal buffer of a
-    `c_string`. The buffer will be freed when the string is deinitialized.
+    Creates a new :type:`string` which takes ownership of the internal buffer of a
+    `c_string`. The buffer will be freed when the :type:`string` is deinitialized.
 
     :arg x: Object to take ownership of the buffer from
     :type x: `c_string`
@@ -581,10 +583,10 @@ module String {
                  terminating null byte.
     :type length: `int`
 
-    :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
-      characters.
+    :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     characters.
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   @deprecated("createStringWithOwnedBuffer is deprecated - please use :proc:`string.createAdoptingBuffer` instead")
   inline proc createStringWithOwnedBuffer(x: c_string,
@@ -595,19 +597,20 @@ module String {
   }
 
   /*
-    Creates a new string which takes ownership of the memory allocated for a
-    `c_ptr`. The buffer will be freed when the string is deinitialized.
+    Creates a new :type:`string` which takes ownership of the memory allocated for a
+    :class:`~CTypes.c_ptr`. The buffer will be freed when the :type:`string` is deinitialized.
 
-    :arg x: Buffer to take ownership of
+    :arg x: The buffer to take ownership of
     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
     :arg length: Length of the string stored in `x` in bytes, excluding the
                  terminating null byte.
     :type length: `int`
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+    :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     characters.`DecodeError` if `x` contains non-UTF-8 characters.
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   proc type string.createAdoptingBuffer(x: c_ptr(?t),
                                         length=strLen(x)) : string throws {
@@ -626,19 +629,21 @@ module String {
   }
 
     /*
-    Creates a new string which takes ownership of the memory allocated for a
-    `c_ptrConst`. The buffer will be freed when the string is deinitialized.
+    Creates a new :type:`string` which takes ownership of the memory allocated for a
+    :class:`~CTypes.c_ptrConst`. The buffer will be freed when the :type:`string`
+    is deinitialized.
 
-    :arg x: Buffer to take ownership of
+    :arg x: The buffer to take ownership of
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
     :arg length: Length of the string stored in `x` in bytes, excluding the
                  terminating null byte.
     :type length: `int`
 
-     :throws: `DecodeError` if `x` contains non-UTF-8 characters.
+    :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     characters.
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   proc type string.createAdoptingBuffer(x: c_ptrConst(?t),
                                         length=strLen(x)) : string throws {
@@ -648,8 +653,8 @@ module String {
   }
 
   /*
-     Creates a new string which takes ownership of the memory allocated for a
-     `c_ptr`. The buffer will be freed when the string is deinitialized.
+     Creates a new :type:`string` which takes ownership of the memory allocated for a
+     :class:`~CTypes.c_ptr`. The buffer will be freed when the :type:`string` is deinitialized.
 
      :arg x: Object to take ownership of the buffer from
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
@@ -661,10 +666,10 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
       characters.
 
-     :returns: A new `string`
+     :returns: A new :type:`string`
   */
   @deprecated("createStringWithOwnedBuffer is deprecated - please use :proc:`string.createAdoptingBuffer` instead")
   inline proc createStringWithOwnedBuffer(x: c_ptr(?t),
@@ -674,10 +679,10 @@ module String {
   }
 
   /*
-     Creates a new string which takes ownership of the memory allocated for a
-     `c_ptr`. The buffer will be freed when the string is deinitialized.
+     Creates a new :type:`string` which takes ownership of the memory allocated for a
+     :class:`~CTypes.c_ptr`. The buffer will be freed when the :type:`string` is deinitialized.
 
-     :arg x: Buffer to take ownership of
+     :arg x: The buffer to take ownership of
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
      :arg length: Length of the string stored in `x` in bytes, excluding the
@@ -687,10 +692,10 @@ module String {
      :arg size: Size of memory allocated for `x` in bytes
      :type length: `int`
 
-     :throws: Throws a :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
+     :throws: A :class:`~Errors.DecodeError`: if `x` contains non-UTF-8
       characters.
 
-     :returns: A new `string`
+     :returns: A new :type:`string`
   */
   inline proc type string.createAdoptingBuffer(x: c_ptr(?t),
                                                length: int,
@@ -705,14 +710,14 @@ module String {
   }
 
   /*
-    Creates a new string by creating a copy of the buffer of another string.
+    Creates a new :type:`string` by creating a copy of the buffer of another :type:`string`.
 
     :arg x: Object to copy the buffer from
     :type x: `string`
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
-  @deprecated("createStringWithNewBuffer(x: string) is deprecated")
+  @deprecated("createStringWithNewBuffer is deprecated - please use :proc:`string.createCopyingBuffer` instead")
   inline proc createStringWithNewBuffer(x: string) : string {
     // we don't validate here because `x` must have been validated already
     var ret: string;
@@ -722,7 +727,7 @@ module String {
   }
 
   /*
-    Creates a new string by creating a copy of the buffer of a `c_string`.
+    Creates a new :type:`string` by creating a copy of the buffer of a `c_string`.
 
     :arg x: Object to copy the buffer from
     :type x: `c_string`
@@ -738,10 +743,10 @@ module String {
                  - `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-    :throws: Throws a :class:`~Errors.DecodeError`: if `decodePolicy.strict` is
+    :throws: A :class:`~Errors.DecodeError`: if `decodePolicy.strict` is
       passed to the `policy` argument and `x` contains non-UTF-8 characters.
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   @deprecated("createStringWithNewBuffer is deprecated - please use :proc:`string.createCopyingBuffer` instead")
   inline proc createStringWithNewBuffer(x: c_string, length=x.size,
@@ -751,9 +756,9 @@ module String {
 
 
     /*
-    Creates a new string by creating a copy of the memory allocated for a c_ptrConst.
+    Creates a new :type:`string` by creating a copy of the memory allocated for a :class:`~CTypes.c_ptrConst`.
 
-    :arg x: Buffer to copy
+    :arg x: The buffer to copy
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
     :arg length: Length of `x` in bytes, excluding the terminating null byte.
@@ -766,10 +771,10 @@ module String {
                  - `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-    :throws: `DecodeError` if `decodePolicy.strict` is passed to the `policy`
-             argument and `x` contains non-UTF-8 characters.
+    :throws: A :class:`~Errors.DecodeError`: if `decodePolicy.strict` is
+      passed to the `policy` argument and `x` contains non-UTF-8 characters.
 
-    :returns: A new `string`
+    :returns: A new :type:`string`
   */
   inline proc type string.createCopyingBuffer(x: c_ptrConst(?t),
                                               length=strLen(x),
@@ -782,40 +787,7 @@ module String {
   }
 
   /*
-     Creates a new string by creating a copy of a buffer.
-
-     :arg x: Buffer to copy
-     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
-
-     :arg length: Length of the string stored in `x` in bytes, excluding the
-                  terminating null byte.
-     :type length: `int`
-
-     :arg size: Size of memory allocated for `x` in bytes. This argument is
-                ignored by this function.
-     :type size: `int`
-
-      :arg policy: `decodePolicy.strict` raises an error, `decodePolicy.replace`
-                   replaces the malformed character with UTF-8 replacement
-                   character, `decodePolicy.drop` drops the data silently,
-                   `decodePolicy.escape` escapes each illegal byte with private
-                   use codepoints
-
-     :throws: a :class:`~Errors.DecodeError` if `x` contains non-UTF-8
-       characters.
-
-     :returns: A new `string`
-  */
-  @deprecated("createStringWithNewBuffer is deprecated - please use :proc:`string.createCopyingBuffer` instead")
-  inline proc createStringWithNewBuffer(x: c_ptr(?t),
-                                        length: int,
-                                        size=length+1,
-                                        policy=decodePolicy.strict) : string throws {
-    return string.createCopyingBuffer(x, length, size, policy);
-  }
-
-  /*
-     Creates a new string by creating a copy of a buffer.
+     Creates a new :type:`string` by creating a copy of a buffer.
 
      :arg x: The buffer to copy
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
@@ -828,16 +800,49 @@ module String {
                 ignored by this function.
      :type size: `int`
 
-      :arg policy: `decodePolicy.strict` raises an error, `decodePolicy.replace`
+     :arg policy: `decodePolicy.strict` raises an error, `decodePolicy.replace`
                    replaces the malformed character with UTF-8 replacement
                    character, `decodePolicy.drop` drops the data silently,
                    `decodePolicy.escape` escapes each illegal byte with private
                    use codepoints
 
-     :throws: a :class:`~Errors.DecodeError` if `x` contains non-UTF-8
-       characters.
+     :throws: A :class:`~Errors.DecodeError`: if `decodePolicy.strict` is
+      passed to the `policy` argument and `x` contains non-UTF-8 characters.
 
-     :returns: A new `string`
+     :returns: A new :type:`string`
+  */
+  @deprecated("createStringWithNewBuffer is deprecated - please use :proc:`string.createCopyingBuffer` instead")
+  inline proc createStringWithNewBuffer(x: c_ptr(?t),
+                                        length: int,
+                                        size=length+1,
+                                        policy=decodePolicy.strict) : string throws {
+    return string.createCopyingBuffer(x, length, size, policy);
+  }
+
+  /*
+     Creates a new :type:`string` by creating a copy of a buffer.
+
+     :arg x: The buffer to copy
+     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
+
+     :arg length: Length of the string stored in `x` in bytes, excluding the
+                  terminating null byte.
+     :type length: `int`
+
+     :arg size: Size of memory allocated for `x` in bytes. This argument is
+                ignored by this function.
+     :type size: `int`
+
+     :arg policy: `decodePolicy.strict` raises an error, `decodePolicy.replace`
+                   replaces the malformed character with UTF-8 replacement
+                   character, `decodePolicy.drop` drops the data silently,
+                   `decodePolicy.escape` escapes each illegal byte with private
+                   use codepoints
+
+     :throws: A :class:`~Errors.DecodeError`: if `decodePolicy.strict` is
+      passed to the `policy` argument and `x` contains non-UTF-8 characters.
+
+     :returns: A new :type:`string`
   */
   proc type string.createCopyingBuffer(x: c_ptr(?t),
                                        length=strLen(x),
@@ -1285,7 +1290,7 @@ module String {
     }
 
     /*
-      :returns: A new string with the first character in uppercase (if it is a
+      :returns: A new :type:`string` with the first character in uppercase (if it is a
                 case character), and all other case characters in lowercase.
                 Uncased characters are copied with no changes.
     */
@@ -1309,23 +1314,23 @@ module String {
   } // end record string
 
   /*
-    :returns: The number of codepoints in the string.
+    :returns: The number of codepoints in the :type:`string`.
   */
   inline proc const string.size : int do return numCodepoints;
 
   /*
-    :returns: The indices that can be used to index into the string
+    :returns: The indices that can be used to index into the :type:`string`
               (i.e., the range ``0..<this.size``)
   */
   inline proc string.indices : range do return 0..<size;
 
   /*
-    :returns: The number of bytes in the string.
+    :returns: The number of bytes in the :type:`string`.
   */
   inline proc string.numBytes : int do return buffLen;
 
   /*
-    :returns: The number of codepoints in the string, assuming the
+    :returns: The number of codepoints in the :type:`string`, assuming the
               string is correctly-encoded UTF-8.
   */
   inline proc const string.numCodepoints : int {
@@ -1435,7 +1440,7 @@ module String {
   }
 
   /*
-    Iterates over the string character by character.
+    Iterates over the :type:`string` character by character.
 
     For example:
 
@@ -1479,7 +1484,7 @@ module String {
   }
 
   /*
-    Iterates over the string character by character, yielding 1-codepoint
+    Iterates over the :type:`string` character by character, yielding 1-codepoint
     strings. (A synonym for :iter:`string.items`)
 
     For example:
@@ -1504,7 +1509,7 @@ module String {
   }
 
   /*
-    Iterates over the string byte by byte.
+    Iterates over the :type:`string` byte by byte.
   */
   pragma "chpldoc ignore chpl prefix"
   iter string.chpl_bytes() : uint(8) {
@@ -1516,7 +1521,7 @@ module String {
   }
 
   /*
-    Iterates over the string Unicode character by Unicode character.
+    Iterates over the :type:`string` Unicode character by Unicode character.
   */
   iter string.codepoints() : int(32) {
     const localThis = this.localize();
@@ -1527,7 +1532,7 @@ module String {
   }
 
   /*
-    :returns: The value of a single-byte string as an integer.
+    :returns: The value of a single-byte :type:`string` as an integer.
   */
   proc string.toByte() : uint(8) {
     if this.buffLen != 1 then
@@ -1545,7 +1550,7 @@ module String {
   }
 
   /*
-    :returns: The value of a single-codepoint string as an integer.
+    :returns: The value of a single-codepoint :type:`string` as an integer.
    */
   proc string.toCodepoint() : int(32) {
     // TODO: Engin: at least we can check whether the length is less than 4
@@ -1595,7 +1600,7 @@ module String {
           return cp;
         j += 1;
       }
-      // We have reached the end of the string without finding our index.
+      // We have reached the end of the :type:`string` without finding our index.
       if boundsChecking then
         halt("index ", idx, " out of bounds for string with length ", this.size);
       return 0: int(32);
@@ -1603,9 +1608,9 @@ module String {
   }
 
   /*
-    Return the codepoint starting at the `i` th byte in the string
+    Return the codepoint starting at the `i` th byte in the :type:`string`
 
-    :returns: A string with the complete multibyte character starting at the
+    :returns: A new :type:`string` with the complete multibyte character starting at the
               specified byte index from ``0..#string.numBytes``
    */
   proc string.this(i: byteIndex) : string {
@@ -1634,9 +1639,9 @@ module String {
   }
 
   /*
-    Return the `i` th codepoint in the string. (A synonym for :proc:`string.item`)
+    Return the `i` th codepoint in the :type:`string`. (A synonym for :proc:`string.item`)
 
-    :returns: A string with the complete multibyte character starting at the
+    :returns: A new :type:`string` with the complete multibyte character starting at the
               specified codepoint index from ``0..#string.numCodepoints``
    */
   proc string.this(i: codepointIndex) : string {
@@ -1644,9 +1649,9 @@ module String {
   }
 
   /*
-    Return the `i` th codepoint in the string. (A synonym for :proc:`string.item`)
+    Return the `i` th codepoint in the :type:`string`. (A synonym for :proc:`string.item`)
 
-    :returns: A string with the complete multibyte character starting at the
+    :returns: A new :type:`string` with the complete multibyte character starting at the
               specified codepoint index from ``1..string.numCodepoints``
    */
   inline proc string.this(i: int) : string {
@@ -1654,9 +1659,9 @@ module String {
   }
 
   /*
-    Return the `i` th codepoint in the string
+    Return the `i` th codepoint in the :type:`string`
 
-    :returns: A string with the complete multibyte character starting at the
+    :returns: A new :type:`string` with the complete multibyte character starting at the
               specified codepoint index from ``1..string.numCodepoints``
    */
   proc string.item(i: codepointIndex) : string {
@@ -1688,9 +1693,9 @@ module String {
   }
 
   /*
-    Return the `i` th codepoint in the string
+    Return the `i` th codepoint in the :type:`string`
 
-    :returns: A string with the complete multibyte character starting at the
+    :returns: A new :type:`string` with the complete multibyte character starting at the
               specified codepoint index from ``0..#string.numCodepoints``
    */
   inline proc string.item(i: int) : string {
@@ -1698,16 +1703,16 @@ module String {
   }
 
   /*
-    Slice a string. Halts if r is non-empty and not completely inside the
+    Slice a :type:`string`. Halts if r is non-empty and not completely inside the
     range ``0..<string.size`` when compiled with `--checks`. `--fast`
     disables this check.
 
-    :arg r: range of the indices the new string should be made from
+    :arg r: range of the indices the new :type:`string` should be made from
 
     :throws: throws a :class:`~Errors.CodepointSplitError`: if slicing results
       in splitting a multi-byte codepoint.
 
-    :returns: a new string that is a substring within ``0..<string.size``. If
+    :returns: A new :type:`string` that is a substring within ``0..<string.size``. If
               the length of `r` is zero, an empty string is returned.
    */
   inline proc string.this(r: range(?)): string throws where r.idxType == byteIndex {
@@ -1721,7 +1726,7 @@ module String {
   }
 
   /*
-    :returns: * `true`  -- when the string is empty
+    :returns: * `true`  -- when the :type:`string` is empty
               * `false` -- otherwise
    */
   inline proc string.isEmpty() : bool {
@@ -1731,7 +1736,7 @@ module String {
   /*
     :arg patterns: A varargs list of strings to match against.
 
-    :returns: * `true`  -- when the string begins with one or more of the `patterns`
+    :returns: * `true`  -- when the :type:`string` begins with one or more of the `patterns`
               * `false` -- otherwise
    */
   inline proc string.startsWith(patterns: string ...) : bool {
@@ -1741,7 +1746,7 @@ module String {
   /*
     :arg patterns: A varargs list of strings to match against.
 
-    :returns: * `true`  -- when the string ends with one or more of the `patterns`
+    :returns: * `true`  -- when the :type:`string` ends with one or more of the `patterns`
               * `false` -- otherwise
    */
   inline proc string.endsWith(patterns: string ...) : bool {
@@ -1749,13 +1754,13 @@ module String {
   }
 
   /*
-    :arg pattern: the string to search for
+    :arg pattern: the :type:`string` to search for
     :arg indices: an optional range defining the substring to search within,
                  default is the whole string. Halts if the range is not
                  within ``0..<string.size``
 
     :returns: the index of the first occurrence of `pattern` within a
-              string, or -1 if the `pattern` is not in the string.
+              :type:`string`, or -1 if the `pattern` is not in the string.
    */
 
   inline proc string.find(pattern: string,
@@ -1767,7 +1772,7 @@ module String {
   }
 
   /*
-    :arg pattern: the string to search for
+    :arg pattern: the :type:`string` to search for
     :arg indices: an optional range defining the substring to search within,
                  default is the whole string. Halts if the range is not
                  within ``0..<string.size``
@@ -1786,7 +1791,7 @@ module String {
   }
 
   /*
-    :arg pattern: the string to search for
+    :arg pattern: the :type:`string` to search for
     :arg indices: an optional range defining the substring to search within,
                  default is the whole string. Halts if the range is not
                  within ``0..<string.size``
@@ -1802,12 +1807,12 @@ module String {
   }
 
   /*
-    :arg pattern: the string to search for
-    :arg replacement: the string to replace `pattern` with
+    :arg pattern: the :type:`string` to search for
+    :arg replacement: the :type:`string` to replace `pattern` with
     :arg count: an optional integer specifying the number of replacements to
                 make, values less than zero will replace all occurrences
 
-    :returns: a copy of the string where `replacement` replaces `pattern` up
+    :returns: a copy of the :type:`string` where `replacement` replaces `pattern` up
               to `count` times
    */
   inline proc string.replace(pattern: string, replacement: string,
@@ -1816,7 +1821,7 @@ module String {
   }
 
   /*
-    Splits the string on `sep` yielding the substring between each
+    Splits the :type:`string` on `sep` yielding the substring between each
     occurrence, up to `maxsplit` times.
 
     :arg sep: The delimiter used to break the string into chunks.
@@ -1836,7 +1841,7 @@ module String {
   /*
     Works as above, but uses runs of whitespace as the delimiter.
 
-    :arg maxsplit: The number of times to split the string, negative values
+    :arg maxsplit: The number of times to split the :type:`string`, negative values
                    indicate no limit.
    */
   iter string.split(maxsplit: int = -1) : string {
@@ -1860,7 +1865,7 @@ module String {
 
     :arg x: :type:`string` values to be joined
 
-    :returns: A :type:`string`
+    :returns: A new :type:`string`
   */
   inline proc string.join(const ref x: string ...) : string {
     return doJoin(this, x);
@@ -1882,7 +1887,7 @@ module String {
 
     :arg x: An array or tuple of :type:`string` values to be joined
 
-    :returns: A :type:`string`
+    :returns: A new :type:`string`
   */
   inline proc string.join(const ref x) : string {
     // this overload serves as a catch-all for unsupported types.
@@ -1894,14 +1899,14 @@ module String {
 
 
   /*
-    :arg chars: A string containing each character to remove.
+    :arg chars: A :type:`string` containing each character to remove.
                 Defaults to `" \\t\\r\\n"`.
     :arg leading: Indicates if leading occurrences should be removed.
                   Defaults to `true`.
     :arg trailing: Indicates if trailing occurrences should be removed.
                     Defaults to `true`.
 
-    :returns: A new string with `leading` and/or `trailing` occurrences of
+    :returns: A new :type:`string` with `leading` and/or `trailing` occurrences of
               characters in `chars` removed as appropriate.
   */
   proc string.strip(chars: string = " \t\r\n", leading=true,
@@ -1961,7 +1966,7 @@ module String {
   }
 
 
-  /* Remove indentation from each line of string.
+  /* Remove indentation from each line of a :type:`string`.
 
       This can be useful when applied to multi-line strings that are indented
       in the source code, but should not be indented in the output.
@@ -1983,7 +1988,7 @@ module String {
                         common leading whitespace, and make no changes to the
                         first line.
 
-      :returns: A new `string` with indentation removed.
+      :returns: A new :type:`string` with indentation removed.
   */
   @unstable("string.dedent is subject to change in the future.")
   proc string.dedent(columns=0, ignoreFirst=true) : string {
@@ -1991,7 +1996,7 @@ module String {
   }
 
   /*
-    Checks if all the characters in the string are either uppercase (A-Z) or
+    Checks if all the characters in the :type:`string` are either uppercase (A-Z) or
     uncased (not a letter).
 
     :returns: * `true`  -- if the string contains at least one uppercase character and no lowercase characters, ignoring uncased characters.
@@ -2018,7 +2023,7 @@ module String {
   }
 
   /*
-    Checks if all the characters in the string are either lowercase (a-z) or
+    Checks if all the characters in the :type:`string` are either lowercase (a-z) or
     uncased (not a letter).
 
     :returns: * `true`  -- when there are no uppercase characters in the string.
@@ -2045,7 +2050,7 @@ module String {
   }
 
   /*
-    Checks if all the characters in the string are whitespace ('  ', '\\t',
+    Checks if all the characters in the :type:`string` are whitespace ('  ', '\\t',
     '\\n', '\\v', '\\f', '\\r').
 
     :returns: * `true`  -- when all the characters are whitespace.
@@ -2068,7 +2073,7 @@ module String {
   }
 
   /*
-    Checks if all the characters in the string are alphabetic (a-zA-Z).
+    Checks if all the characters in the :type:`string` are alphabetic (a-zA-Z).
 
     :returns: * `true`  -- when the characters are alphabetic.
               * `false` -- otherwise
@@ -2090,7 +2095,7 @@ module String {
   }
 
   /*
-    Checks if all the characters in the string are digits (0-9).
+    Checks if all the characters in the :type:`string` are digits (0-9).
 
     :returns: * `true`  -- when the characters are digits.
               * `false` -- otherwise
@@ -2112,7 +2117,7 @@ module String {
   }
 
   /*
-    Checks if all the characters in the string are alphanumeric (a-zA-Z0-9).
+    Checks if all the characters in the :type:`string` are alphanumeric (a-zA-Z0-9).
 
     :returns: * `true`  -- when the characters are alphanumeric.
               * `false` -- otherwise
@@ -2134,7 +2139,7 @@ module String {
   }
 
   /*
-    Checks if all the characters in the string are printable.
+    Checks if all the characters in the :type:`string` are printable.
 
     :returns: * `true`  -- when the characters are printable.
               * `false` -- otherwise
@@ -2196,7 +2201,7 @@ module String {
   }
 
   /*
-    :returns: A new string with all uppercase characters replaced with their
+    :returns: A new :type:`string` with all uppercase characters replaced with their
               lowercase counterpart.
 
     .. note::
@@ -2220,7 +2225,7 @@ module String {
   }
 
   /*
-    :returns: A new string with all lowercase characters replaced with their
+    :returns: A new :type:`string` with all lowercase characters replaced with their
               uppercase counterpart.
 
     .. note::
@@ -2244,7 +2249,7 @@ module String {
   }
 
   /*
-    :returns: A new string with all cased characters following an uncased
+    :returns: A new :type:`string` with all cased characters following an uncased
               character converted to uppercase, and all cased characters
               following another cased character converted to lowercase.
 
@@ -2315,7 +2320,7 @@ module String {
 
 
   /*
-     Copies the string `rhs` into the string `lhs`.
+     Copies the :type:`string` `rhs` into the :type:`string` `lhs`.
   */
   operator =(ref lhs: string, rhs: string) : void {
     doAssign(lhs, rhs);
@@ -2325,15 +2330,15 @@ module String {
   // Concatenation
   //
   /*
-     :returns: A new string which is the result of concatenating `s0` and `s1`
+     :returns: A new :type:`string` which is the result of concatenating `s0` and `s1`
   */
   operator string.+(s0: string, s1: string) : string {
     return doConcat(s0, s1);
   }
 
   /*
-     :returns: A new string which is the result of repeating `s` `n` times.
-               If `n` is less than or equal to 0, an empty string is returned.
+     :returns: A new :type:`string` which is the result of repeating `s` `n` times.
+               If `n` is less than or equal to 0, an empty :type:`string` is returned.
 
      The operation is commutative.
      For example:
@@ -2571,7 +2576,7 @@ module String {
   }
 
   /*
-     :returns: A string storing the complete multibyte character sequence
+     :returns: A new :type:`string` storing the complete multibyte character sequence
                that corresponds to the codepoint value `i`.
   */
   inline proc codepointToString(i: int(32)) : string {

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1532,7 +1532,7 @@ module CTypes {
 
         This can only be called safely on a :type:`~String.string` whose home is
         the current locale.  This property can be enforced by calling
-        :proc:`~String.string.localize()` before :proc:`~String.string.c_str()`.
+        :proc:`~String.string.localize()` before :proc:`string.c_str()`.
         If the string is remote, the program will halt.
 
     For example:
@@ -1569,7 +1569,7 @@ module CTypes {
 
       This can only be called safely on a :type:`~Bytes.bytes` whose home is
       the current locale.  This property can be enforced by calling
-      :proc:`~Bytes.bytes.localize()` before :proc:`~Bytes.bytes.c_str()`.
+      :proc:`~Bytes.bytes.localize()` before :proc:`bytes.c_str()`.
       If the bytes is remote, the program will halt.
 
     For example:

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1523,4 +1523,66 @@ module CTypes {
   inline proc strLen(x:c_ptrConst(?t)): int {
      return __primitive("string_length_bytes", x).safeCast(int);
   }
+
+  /*
+    Get a `c_ptrConst(c_char)` from a :type:`string`. The returned `c_ptrConst(c_char)`
+    shares the buffer with the :type:`string`.
+
+    .. warning::
+
+        This can only be called safely on a :type:`string` whose home is
+        the current locale.  This property can be enforced by calling
+        :proc:`string.localize()` before :proc:`string.c_str()`. If the
+        string is remote, the program will halt.
+
+    For example:
+
+    .. code-block:: chapel
+
+      var my_string = "Hello!";
+      on different_locale {
+        printf("%s", my_string.localize().c_str());
+      }
+
+    :returns:
+        A `c_ptrConst(c_char)` that points to the underlying buffer used by this
+        :type:`string`. The returned `c_ptrConst(c_char)` is only valid when used
+        on the same locale as the string.
+   */
+  @unstable("'string.c_str()' is unstable and may change in a future release")
+  inline proc string.c_str() : c_ptrConst(c_char) {
+    use BytesStringCommon only getCStr;
+    return getCStr(this);
+  }
+
+ /*
+    Gets a `c_ptrConst(c_char)` from a :type:`bytes`. The returned `c_ptrConst(c_char)`
+    shares the buffer with the :type:`bytes`.
+
+    .. warning::
+
+      This can only be called safely on a :type:`bytes` whose home is
+      the current locale.  This property can be enforced by calling
+      :proc:`bytes.localize()` before :proc:`~bytes.c_str()`. If the
+      bytes is remote, the program will halt.
+
+    For example:
+
+    .. code-block:: chapel
+
+        var myBytes = b"Hello!";
+        on different_locale {
+          printf("%s", myBytes.localize().c_str());
+        }
+
+    :returns: A `c_ptrConst(c_char)` that points to the underlying buffer used by this
+        :type:`bytes`. The returned `c_ptrConst(c_char)` is only valid when used
+        on the same locale as the bytes.
+   */
+  @unstable("'bytes.c_str()' is unstable and may change in a future release")
+  inline proc bytes.c_str(): c_ptrConst(c_char) {
+    use BytesStringCommon only getCStr;
+    return getCStr(this);
+  }
+
 }

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1512,12 +1512,12 @@ module CTypes {
   }
 
   /*
-    Get the number of bytes in a c_ptrConst(int(8)) or c_ptrConst(uint(8)), excluding the
-    terminating null.
+    Get the number of bytes in a c_ptrConst(int(8)) or c_ptrConst(uint(8)),
+    excluding the terminating NULL.
 
     :arg x: c_ptrConst(int(8)) or c_ptrConst(uint(8)) to get length of
 
-    :returns: the number of bytes in x, excluding the terminating null
+    :returns: the number of bytes in x, excluding the terminating NULL
    */
   @unstable("the strLen function is unstable and may change or go away in a future release")
   inline proc strLen(x:c_ptrConst(?t)): int {
@@ -1525,15 +1525,15 @@ module CTypes {
   }
 
   /*
-    Get a `c_ptrConst(c_char)` from a :type:`string`. The returned `c_ptrConst(c_char)`
-    shares the buffer with the :type:`string`.
+    Get a `c_ptrConst(c_char)` from a :type:`~String.string`. The returned
+    `c_ptrConst(c_char)` shares the buffer with the :type:`~String.string`.
 
     .. warning::
 
-        This can only be called safely on a :type:`string` whose home is
+        This can only be called safely on a :type:`~String.string` whose home is
         the current locale.  This property can be enforced by calling
-        :proc:`string.localize()` before :proc:`string.c_str()`. If the
-        string is remote, the program will halt.
+        :proc:`~String.string.localize()` before :proc:`~String.string.c_str()`.
+        If the string is remote, the program will halt.
 
     For example:
 
@@ -1544,10 +1544,16 @@ module CTypes {
         printf("%s", my_string.localize().c_str());
       }
 
+    .. warning::
+
+        Chapel strings are capable of containing NULL bytes, and any C routines
+        relying on NULL terminated buffers may incorrectly process the
+        mid-string NULL as the terminating NULL.
+
     :returns:
         A `c_ptrConst(c_char)` that points to the underlying buffer used by this
-        :type:`string`. The returned `c_ptrConst(c_char)` is only valid when used
-        on the same locale as the string.
+        :type:`~String.string`. The returned `c_ptrConst(c_char)` is only valid
+        when used on the same locale as the string.
    */
   @unstable("'string.c_str()' is unstable and may change in a future release")
   inline proc string.c_str() : c_ptrConst(c_char) {
@@ -1556,15 +1562,15 @@ module CTypes {
   }
 
  /*
-    Gets a `c_ptrConst(c_char)` from a :type:`bytes`. The returned `c_ptrConst(c_char)`
-    shares the buffer with the :type:`bytes`.
+    Gets a `c_ptrConst(c_char)` from a :type:`~Bytes.bytes`. The returned
+    `c_ptrConst(c_char)` shares the buffer with the :type:`~Bytes.bytes`.
 
     .. warning::
 
-      This can only be called safely on a :type:`bytes` whose home is
+      This can only be called safely on a :type:`~Bytes.bytes` whose home is
       the current locale.  This property can be enforced by calling
-      :proc:`bytes.localize()` before :proc:`~bytes.c_str()`. If the
-      bytes is remote, the program will halt.
+      :proc:`~Bytes.bytes.localize()` before :proc:`~Bytes.bytes.c_str()`.
+      If the bytes is remote, the program will halt.
 
     For example:
 
@@ -1575,9 +1581,15 @@ module CTypes {
           printf("%s", myBytes.localize().c_str());
         }
 
-    :returns: A `c_ptrConst(c_char)` that points to the underlying buffer used by this
-        :type:`bytes`. The returned `c_ptrConst(c_char)` is only valid when used
-        on the same locale as the bytes.
+    .. warning::
+
+        Chapel :type:`~Bytes.bytes` are capable of containing NULL bytes, and
+        any C routines relying on NULL terminated buffers may incorrectly
+        process the mid-buffer NULL as the terminating NULL.
+
+    :returns: A `c_ptrConst(c_char)` that points to the underlying buffer used
+              by this :type:`~Bytes.bytes`. The returned `c_ptrConst(c_char)`
+              is only valid when used on the same locale as the bytes.
    */
   @unstable("'bytes.c_str()' is unstable and may change in a future release")
   inline proc bytes.c_str(): c_ptrConst(c_char) {

--- a/modules/standard/HaltWrappers.chpl
+++ b/modules/standard/HaltWrappers.chpl
@@ -94,6 +94,7 @@ module HaltWrappers {
   pragma "function terminates program"
   pragma "always propagate line file info"
   proc outOfMemoryHalt(s:string) {
+    use CTypes only c_str;
     const err = "Out of memory allocating \"" + s + "\"";
     __primitive("chpl_error", err.localize().c_str());
   }

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -12,28 +12,28 @@ OS
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.POSIX.OS
 POSIX
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.POSIX
+CString
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.ByteBufferHelpers.ChplConfig.String.CString
+NVStringFactory
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.ByteBufferHelpers.ChplConfig.String.StringCasts.NVStringFactory
+StringCasts
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.ByteBufferHelpers.ChplConfig.String.StringCasts
+String
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.ByteBufferHelpers.ChplConfig.String
+ChplConfig
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.ByteBufferHelpers.ChplConfig
+Communication
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.ByteBufferHelpers.Communication
+ByteBufferHelpers
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.ByteBufferHelpers
+BytesCasts
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.Bytes.BytesCasts
+Bytes
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon.Bytes
+BytesStringCommon
+  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes.BytesStringCommon
 CTypes
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.CTypes
-Communication
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.ByteBufferHelpers.Communication
-ByteBufferHelpers
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.ByteBufferHelpers
-NVStringFactory
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.BytesStringCommon.NVStringFactory
-BytesCasts
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.BytesStringCommon.Bytes.BytesCasts
-Bytes
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.BytesStringCommon.Bytes
-BytesStringCommon
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.BytesStringCommon
-CString
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.CString
-StringCasts
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String.StringCasts
-String
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig.String
-ChplConfig
-  from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChplConfig
 ChapelTaskData
   from print-module-resolution.ChapelStandard.startInitCommDiags.ChapelBase.ChapelTaskData
 ChapelBase

--- a/test/deprecated/c_str.chpl
+++ b/test/deprecated/c_str.chpl
@@ -1,0 +1,8 @@
+var s = "my string";
+var b = b"my bytes";
+
+var cs= s.c_str();
+var cb = b.c_str();
+
+assert(string.createCopyingBuffer(cs) == s);
+assert(bytes.createCopyingBuffer(cb) == b);

--- a/test/deprecated/c_str.good
+++ b/test/deprecated/c_str.good
@@ -1,0 +1,2 @@
+c_str.chpl:4: warning: 'string.c_str()' has moved to 'CTypes'. Please 'use CTypes' to access 'c_str'
+c_str.chpl:5: warning: 'bytes.c_str()' has moved to 'CTypes'. Please 'use CTypes' to access 'c_str'

--- a/test/deprecated/string-bytes-factoryFunctions.good
+++ b/test/deprecated/string-bytes-factoryFunctions.good
@@ -11,7 +11,7 @@ string-bytes-factoryFunctions.chpl:n: warning: createStringWithBorrowedBuffer is
 string-bytes-factoryFunctions.chpl:n: warning: createStringWithBorrowedBuffer is deprecated - please use string.createBorrowingBuffer instead
 string-bytes-factoryFunctions.chpl:n: warning: createStringWithOwnedBuffer is deprecated - please use string.createAdoptingBuffer instead
 string-bytes-factoryFunctions.chpl:n: warning: createStringWithOwnedBuffer is deprecated - please use string.createAdoptingBuffer instead
-string-bytes-factoryFunctions.chpl:n: warning: createStringWithNewBuffer(x: string) is deprecated
+string-bytes-factoryFunctions.chpl:n: warning: createStringWithNewBuffer is deprecated - please use string.createCopyingBuffer instead
 string-bytes-factoryFunctions.chpl:n: warning: createStringWithNewBuffer is deprecated - please use string.createCopyingBuffer instead
 string-bytes-factoryFunctions.chpl:n: warning: createStringWithNewBuffer is deprecated - please use string.createCopyingBuffer instead
 string-bytes-factoryFunctions.chpl:n: warning: createBytesWithBorrowedBuffer is deprecated - please use bytes.createBorrowingBuffer instead

--- a/test/extern/jjueckstock/types.chpl
+++ b/test/extern/jjueckstock/types.chpl
@@ -27,7 +27,7 @@ module OuterModule {
     typedef int my_int;
   } }
 
-  use C;
+  use C, CTypes;
 
   //NOTE: either C.my_struct or my_struct will work with the use C; statement.
   var strct: C.my_struct = new my_struct(42, "bar");

--- a/test/types/string/dmk/join.chpl
+++ b/test/types/string/dmk/join.chpl
@@ -1,7 +1,7 @@
 // Credit goes to Bryant for this test of a former bug in string.join().
 
 use Random.PCGRandom only PCGRandomStream;
-
+use CTypes only c_str;
 config const count = 100;
 
 proc get_str_with_concat(x: int, y: int): string {

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.chpl
@@ -1,3 +1,4 @@
+use CTypes;
 var s = "0123456789";
 on Locales[numLocales-1] {
   writeln(string.createCopyingBuffer(s.c_str()));

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.good
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_global_string.good
@@ -1,1 +1,1 @@
-c_str_on_remote_global_string.chpl:3: error: halt reached - Cannot call '.c_str()' on a remote string
+c_str_on_remote_global_string.chpl:4: error: halt reached - Cannot call '.c_str()' on a remote string

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.chpl
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.chpl
@@ -1,4 +1,5 @@
 {
+  use CTypes;
   var s : string;
   for i in 0..9 do
     s += i:string;

--- a/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.good
+++ b/test/types/string/sungeun/c_string/multilocale/c_str_on_remote_string.good
@@ -1,1 +1,1 @@
-c_str_on_remote_string.chpl:7: error: halt reached - Cannot call '.c_str()' on a remote string
+c_str_on_remote_string.chpl:8: error: halt reached - Cannot call '.c_str()' on a remote string

--- a/test/unstable/c_str.chpl
+++ b/test/unstable/c_str.chpl
@@ -1,3 +1,4 @@
+use CTypes only c_str;
 var s = "my string";
 var b = b"my bytes";
 

--- a/test/unstable/c_str.good
+++ b/test/unstable/c_str.good
@@ -1,6 +1,6 @@
-c_str.chpl:4: warning: 'string.c_str()' is unstable and may change in a future release
-c_str.chpl:5: warning: 'bytes.c_str()' is unstable and may change in a future release
-c_str.chpl:7: warning: 'createBorrowingBuffer' is unstable and may change in the future
+c_str.chpl:5: warning: 'string.c_str()' is unstable and may change in a future release
+c_str.chpl:6: warning: 'bytes.c_str()' is unstable and may change in a future release
 c_str.chpl:8: warning: 'createBorrowingBuffer' is unstable and may change in the future
+c_str.chpl:9: warning: 'createBorrowingBuffer' is unstable and may change in the future
 my string
 my bytes


### PR DESCRIPTION
This PR updates the documentation in string/bytes and adds a section to the evolution document to describe the deprecation of the `c_string` type, and gives some guidance on replacing it in user code.

- moved `c_str()` from `bytes` and `string` to `CTypes` and deprecated the string/bytes versions
- add new `c_str()` tests for deprecation message and update some other tests to `use CTypes` to access the new `c_str()` location
- `doc/rst/language/spec/strings.rst` needed to be updated to refer to the non-deprecated procedure for creating escaped strings.
- string/bytes includes documentation links to type specifiers instead of just formatting them as italics
- make some wording in string/bytes more consistent, fix long lines in some doc strings
- add warnings about `NULL` bytes in mid-string/bytes to the `.c_str()` docs

TESTING:

- [ ] paratest
- [ ] gasnet paratest
- [ ] manually inspect `string`, `bytes`, and `CTypes` docs