### PR TITLE
Reenable XC graph generation

### DIFF
--- a/util/cron/test-cray-xc-arkouda.bash
+++ b/util/cron/test-cray-xc-arkouda.bash
@@ -10,8 +10,6 @@ source $CWD/common.bash
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
-export CHPL_TEST_ARKOUDA_PERF=false
-
 module list
 
 # setup for XC perf (ugni, gnu, 28-core broadwell)

--- a/util/cron/test-cray-xc-arkouda.release.bash
+++ b/util/cron/test-cray-xc-arkouda.release.bash
@@ -10,8 +10,6 @@ source $CWD/common.bash
 source $CWD/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
-export CHPL_TEST_ARKOUDA_PERF=false
-
 module list
 
 # setup for XC perf (ugni, gnu, 28-core broadwell)


### PR DESCRIPTION
Now that XC graphs are being synced to an intermediate machine, reenabling performance testing for XC to see if it just falls out or if additional steps are required.