### PR TITLE
Fix some issues with unstable documentation and add a test

### DIFF
--- a/test/chpldoc/unstableSymbols.doc.catfiles
+++ b/test/chpldoc/unstableSymbols.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/unstableSymbols.doc.rst

--- a/test/chpldoc/unstableSymbols.doc.catfiles
+++ b/test/chpldoc/unstableSymbols.doc.catfiles
@@ -1,1 +1,3 @@
 docs/source/modules/unstableSymbols.doc.rst
+docs/source/modules/unstableSymbols.doc/UnstableMod1.rst
+docs/source/modules/unstableSymbols.doc/UnstableMod2.rst

--- a/test/chpldoc/unstableSymbols.doc.chpl
+++ b/test/chpldoc/unstableSymbols.doc.chpl
@@ -1,0 +1,26 @@
+// Checks basic unstable declarations of variables
+@unstable var a: int;
+@unstable "b is unstable, don't use it" var b: int;
+
+// Checks interaction with documentation
+/* There was documentation of this symbol */
+@unstable var c: string;
+/* This symbol was also documented */
+@unstable "d is unstable, don't use it" var d: string;
+
+// Checks interaction when documentation mentions stability in some form
+/* This symbol is unstable */
+@unstable var e: real;
+/* This symbol is also unstable */
+@unstable "f is unstable, don't use it" var f: real;
+/* This symbol is not considered stable */
+@unstable var g: bool;
+/* This symbol is also not considered stable */
+@unstable "h is unstable, don't use it" var h: bool;
+
+// Ensures instability doesn't cause "no doc" symbols to turn up in
+// documentation
+pragma "no doc"
+@unstable var i: int;
+pragma "no doc"
+@unstable "j is unstable, don't use it" var j: int;

--- a/test/chpldoc/unstableSymbols.doc.chpl
+++ b/test/chpldoc/unstableSymbols.doc.chpl
@@ -1,26 +1,26 @@
 // Checks basic unstable declarations of variables
-@unstable var a: int;
-@unstable "b is unstable, don't use it" var b: int;
+@unstable() var a: int;
+@unstable("b is unstable, don't use it") var b: int;
 
 // Checks interaction with documentation
 /* There was documentation of this symbol */
-@unstable var c: string;
+@unstable() var c: string;
 /* This symbol was also documented */
-@unstable "d is unstable, don't use it" var d: string;
+@unstable("d is unstable, don't use it") var d: string;
 
 // Checks interaction when documentation mentions stability in some form
 /* This symbol is unstable */
-@unstable var e: real;
+@unstable() var e: real;
 /* This symbol is also unstable */
-@unstable "f is unstable, don't use it" var f: real;
+@unstable("f is unstable, don't use it") var f: real;
 /* This symbol is not considered stable */
-@unstable var g: bool;
+@unstable() var g: bool;
 /* This symbol is also not considered stable */
-@unstable "h is unstable, don't use it" var h: bool;
+@unstable("h is unstable, don't use it") var h: bool;
 
 // Ensures instability doesn't cause "no doc" symbols to turn up in
 // documentation
-pragma "no doc"
-@unstable var i: int;
-pragma "no doc"
-@unstable "j is unstable, don't use it" var j: int;
+@chpldoc.nodoc
+@unstable() var i: int;
+@chpldoc.nodoc
+@unstable("j is unstable, don't use it") var j: int;

--- a/test/chpldoc/unstableSymbols.doc.chpl
+++ b/test/chpldoc/unstableSymbols.doc.chpl
@@ -1,26 +1,34 @@
 // Checks basic unstable declarations of variables
-@unstable() var a: int;
+@unstable var a: int;
 @unstable("b is unstable, don't use it") var b: int;
 
 // Checks interaction with documentation
 /* There was documentation of this symbol */
-@unstable() var c: string;
+@unstable var c: string;
 /* This symbol was also documented */
 @unstable("d is unstable, don't use it") var d: string;
 
 // Checks interaction when documentation mentions stability in some form
 /* This symbol is unstable */
-@unstable() var e: real;
+@unstable var e: real;
 /* This symbol is also unstable */
 @unstable("f is unstable, don't use it") var f: real;
 /* This symbol is not considered stable */
-@unstable() var g: bool;
+@unstable var g: bool;
 /* This symbol is also not considered stable */
 @unstable("h is unstable, don't use it") var h: bool;
 
 // Ensures instability doesn't cause "no doc" symbols to turn up in
 // documentation
 @chpldoc.nodoc
-@unstable() var i: int;
+@unstable var i: int;
 @chpldoc.nodoc
 @unstable("j is unstable, don't use it") var j: int;
+
+@unstable
+module UnstableMod1 {
+}
+
+@unstable("This module is unstable")
+module UnstableMod2 {
+}

--- a/test/chpldoc/unstableSymbols.doc.good
+++ b/test/chpldoc/unstableSymbols.doc.good
@@ -1,0 +1,71 @@
+.. default-domain:: chpl
+
+.. module:: unstableSymbols.doc
+
+unstableSymbols.doc
+===================
+**Usage**
+
+.. code-block:: chapel
+
+   use unstableSymbols.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import unstableSymbols.doc;
+
+.. data:: var a: int
+
+   .. warning::
+
+      a is unstable
+
+.. data:: var b: int
+
+   .. warning::
+
+      b is unstable, don't use it
+
+.. data:: var c: string
+
+   There was documentation of this symbol 
+
+   .. warning::
+
+      c is unstable
+
+.. data:: var d: string
+
+   This symbol was also documented 
+
+   .. warning::
+
+      d is unstable, don't use it
+
+.. data:: var e: real
+
+   This symbol is unstable 
+
+.. data:: var f: real
+
+   This symbol is also unstable 
+
+.. data:: var g: bool
+
+   This symbol is not considered stable 
+
+   .. warning::
+
+      g is unstable
+
+.. data:: var h: bool
+
+   This symbol is also not considered stable 
+
+   .. warning::
+
+      h is unstable, don't use it
+

--- a/test/chpldoc/unstableSymbols.doc.good
+++ b/test/chpldoc/unstableSymbols.doc.good
@@ -69,3 +69,49 @@ or
 
       h is unstable, don't use it
 
+.. default-domain:: chpl
+
+.. module:: UnstableMod1
+
+UnstableMod1
+============
+**Usage**
+
+.. code-block:: chapel
+
+   use unstableSymbols.doc.UnstableMod1;
+
+
+or
+
+.. code-block:: chapel
+
+   import unstableSymbols.doc.UnstableMod1;
+
+.. warning::
+
+   UnstableMod1 is unstable
+
+.. default-domain:: chpl
+
+.. module:: UnstableMod2
+
+UnstableMod2
+============
+**Usage**
+
+.. code-block:: chapel
+
+   use unstableSymbols.doc.UnstableMod2;
+
+
+or
+
+.. code-block:: chapel
+
+   import unstableSymbols.doc.UnstableMod2;
+
+.. warning::
+
+   This module is unstable
+

--- a/test/chpldoc/unstableSymbols.doc.good
+++ b/test/chpldoc/unstableSymbols.doc.good
@@ -1,3 +1,4 @@
+warning in unstableSymbols.doc.chpl:2: an implicit module named 'unstableSymbols.doc' is being introduced to contain file-scope code
 .. default-domain:: chpl
 
 .. module:: unstableSymbols.doc
@@ -16,6 +17,14 @@ or
 .. code-block:: chapel
 
    import unstableSymbols.doc;
+
+**Submodules**
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   unstableSymbols.doc/*
 
 .. data:: var a: int
 

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1680,8 +1680,7 @@ struct RstResultBuilder {
     if (textOnly_) indentDepth_ --;
     showComment(m, textOnly_);
     showDeprecationMessage(m, false);
-    // TODO: Are we not printing these for modules?
-    // showUnstableWarning(m, false);
+    showUnstableWarning(m, false);
     if (textOnly_) indentDepth_ ++;
 
     visitChildren(m);

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1456,15 +1456,29 @@ struct RstResultBuilder {
   void showUnstableWarning(const Decl* node, bool indentComment=true) {
     if (auto attrs = node->attributeGroup()) {
       if (attrs->isUnstable()) {
-        int commentShift = 0;
+        auto comment = previousComment(context_, node->id());
+        if (comment && !comment->str().empty() &&
+            comment->str().substr(0, 2) == "/*" &&
+            comment->str().find("unstable") != std::string::npos ) {
+          // do nothing because unstable was mentioned in doc comment
+        } else {
+          // write the unstable warning and message
+          int commentShift = 0;
           if (indentComment) {
             indentStream(os_, indentDepth_ * indentPerDepth);
             commentShift = 1;
           }
           os_ << ".. warning::\n\n";
           indentStream(os_, (indentDepth_ + commentShift) * indentPerDepth);
-        os_ << strip(attrs->unstableMessage().c_str());
-        os_ << "\n\n";
+          if (attrs->unstableMessage().isEmpty()) {
+            // write a generic message because there wasn't a specific one
+            os_ << getNodeName((AstNode*) node) << " is unstable";
+          } else {
+            // use the specific unstable message
+            os_ << strip(attrs->unstableMessage().c_str());
+          }
+          os_ << "\n\n";
+        }
       }
     }
   }


### PR DESCRIPTION
Resolves Cray/chapel-private#5352

Ben H had pointed out that unstable modules were failing to generate
unstable warnings in their documentation (the Heap module was
an example of this).  While testing that change, I also noticed that
we were:
- failing to properly generate the message when relying on the
default unstable warning
- and had stopped avoiding generating the message in documentation
when the documentation comment already had the word unstable in it

Fix all three of these problems and add a test locking in the behavior
for all three.

Verified that the generated online documentation for Heap now displayed
the warning appropriately.

Passed a full paratest with futures