### PR TITLE
Mark extern proc array formals as unstable

### DIFF
--- a/compiler/passes/expandExternArrayCalls.cpp
+++ b/compiler/passes/expandExternArrayCalls.cpp
@@ -64,7 +64,13 @@ bool ExpandExternArrayCalls::shouldProcess(FnSymbol* fn) {
   if (!fn->hasFlag(FLAG_EXTERN)) return false;
 
   for_formals(formal, fn) {
-    if (isFormalArray(formal)) return true;
+    if (isFormalArray(formal)) {
+      if (fWarnUnstable)
+        USR_WARN(fn,
+                 "using a Chapel array type in an 'extern proc' is unstable "
+                 "and may change in the future");
+      return true;
+    }
   }
 
   return false;

--- a/test/unstable/externProcArrayFormal.chpl
+++ b/test/unstable/externProcArrayFormal.chpl
@@ -1,0 +1,6 @@
+extern proc foo(x: [] int, ref y: [] int);
+
+proc main() {
+  var A,B: [1..10] int;
+  foo(A, B);
+}

--- a/test/unstable/externProcArrayFormal.compopts
+++ b/test/unstable/externProcArrayFormal.compopts
@@ -1,0 +1,1 @@
+--no-codegen

--- a/test/unstable/externProcArrayFormal.good
+++ b/test/unstable/externProcArrayFormal.good
@@ -1,0 +1,1 @@
+externProcArrayFormal.chpl:1: warning: using a Chapel array type in an 'extern proc' is unstable and may change in the future


### PR DESCRIPTION
Mark extern array formals as unstable for 2.0. Implements unstable warning for #22957.

The following pattern warns: `extern proc foo(x: [] int)`

Tested with full paratest

[Reviewed by @lydia-duncan]