### PR TITLE
Skip RandomNumber6 on linux32

### DIFF
--- a/test/exercises/RandomNumber6.skipif
+++ b/test/exercises/RandomNumber6.skipif
@@ -1,2 +1,4 @@
 # The small stack size can be exceeded with baseline
 COMPOPTS <= --baseline
+# Total memory can be exhausted from number of stacks
+CHPL_TARGET_PLATFORM == linux32


### PR DESCRIPTION
#23152 increased the stack task size for RandomNumber6, which caused sporadic OOMs on linux32 depending on how many tasks were live at the same time. Just skip this test under linxu32 instead of trying to find the perfect stack size.