### PR TITLE
Fix fifo guard pages on arm macs when using jemalloc

### DIFF
--- a/runtime/src/threads/pthreads/threads-pthreads.c
+++ b/runtime/src/threads/pthreads/threads-pthreads.c
@@ -187,9 +187,11 @@ void chpl_free_pthread_stack(void* stack){
   page_size = 0;
 
   if(chpl_use_guard_page){
-    free_flag = PROT_READ | PROT_WRITE | PROT_EXEC;
+    free_flag = PROT_READ | PROT_WRITE;
     page_size = chpl_getSysPageSize();
-    mprotect((unsigned char*)stack - page_size, page_size, free_flag);
+    if (mprotect((unsigned char*)stack - page_size, page_size, free_flag) != 0) {
+      chpl_internal_error("mprotect failed");
+    }
     chpl_free((unsigned char*)stack - page_size);
   }
   else


### PR DESCRIPTION
Fifo was setting `PROT_EXEC | PROT_WRITE` when disabling guard pages, but pages aren't allowed to have both on recent macs. From newer darwin `mmap` man pages:

> When the hardened runtime is enabled (See the links in the SEE ALSO
> section), the protections cannot be both PROT_WRITE and PROT_EXEC
> without also having the flag MAP_JIT and the process possessing the
> com.apple.security.cs.allow-jit entitlement

We weren't checking the `mprotect` return code, so we were just silently letting guard pages remain, which led to later segfaults when the program touched that memory. This was causing sporadic segfaults on mac arms when using gasnet+fifo+jemalloc, so we switched to using cstdlib in #20160. This worked around the issues since we happen to disable guard pages on macs with the cstdlib allocator, but wasn't a real fix.

Note that we only saw this for multi-locale since non-0 locales would have their main thread end before user main, but in comm=none no threads are destroyed before program termination.

Fix the underlying issue here by not setting `PROT_EXEC` (not needed anyways) and checking for failures when trying to disable guard pages.

Testing (fifo tasking and jemalloc memory):
 - [x] multi-locale tests for gasnet-udp-everything on m1
 - [x] release/examples for gasnet-udp-fast on m1
 - [x] release/examples for comm=none on m1
 - [x] full test suite for gasnet-udp-everything on linux64
 - [x] full test suite for comm=none on linux64

Properly resolves #17825