### PR TITLE
Add more tests of Reflection errors for implementation records

### DIFF
--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -45,7 +45,11 @@ private proc checkQueryT(type t) type {
     compilerError(t:string, " is not a class, record, or union type", 2);
 }
 private proc checkValidQueryT(type t) param {
-  if !isClassType(t) && !(isRecordType(t) || isUnionType(t)) then
+  if isClassType(t) then
+    {}
+  else if isRecordType(t) || isUnionType(t) then
+    {}
+  else
     compilerError(t:string, " is not a class, record, or union type", 2);
 }
 

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -44,6 +44,10 @@ private proc checkQueryT(type t) type {
   else
     compilerError(t:string, " is not a class, record, or union type", 2);
 }
+private proc checkValidQueryT(type t) param {
+  if !isClassType(t) && !(isRecordType(t) || isUnionType(t)) then
+    compilerError(t:string, " is not a class, record, or union type", 2);
+}
 
 /* Return the number of fields in a class or record as a param.
    The count of fields includes types and param fields.
@@ -205,8 +209,10 @@ proc getImplementationField(const ref x:?t, param i:int) const ref {
  */
 pragma "unsafe"
 @unstable(reason="'getFieldRef' is unstable")
-inline proc getFieldRef(ref x:?t, param i:int) ref do
+inline proc getFieldRef(ref x:?t, param i:int) ref {
+  checkValidQueryT(t);
   return __primitive("field by num", x, i+1);
+}
 
 /* Get a mutable ref to a field in a class or record by name.
    Will generate a compilation error if a field with that name
@@ -219,6 +225,7 @@ inline proc getFieldRef(ref x:?t, param i:int) ref do
 pragma "unsafe"
 @unstable(reason="'getFieldRef' is unstable")
 proc getFieldRef(ref x:?t, param s:string) ref {
+  checkValidQueryT(t);
   param i = __primitive("field name to num", t, s);
   if i == 0 then
     compilerError("field ", s, " not found in ", t:string);

--- a/test/library/standard/Reflection/cannotInspectBuiltins-array.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins-array.good
@@ -1,0 +1,1 @@
+FILE.chpl:n: error: [domain(1,int(64),one)] int(64) is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins-atomic.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins-atomic.good
@@ -1,0 +1,1 @@
+FILE.chpl:n: error: atomic int(64) is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins-domain.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins-domain.good
@@ -1,0 +1,1 @@
+FILE.chpl:n: error: domain(1,int(64),one) is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins-range.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins-range.good
@@ -1,0 +1,1 @@
+FILE.chpl:n: error: range(int(64),both,one) is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins-string.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins-string.good
@@ -1,0 +1,1 @@
+FILE.chpl:n: error: string is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins-sync.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins-sync.good
@@ -1,0 +1,1 @@
+FILE.chpl:n: error: sync int(64) is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins-tuple.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins-tuple.good
@@ -1,0 +1,1 @@
+FILE.chpl:n: error: 2*int(64) is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins.chpl
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.chpl
@@ -1,0 +1,40 @@
+use Reflection;
+
+config type testType = string;
+config param testNum = 1;
+
+
+if testNum == 1 {
+  getNumFields(testType);
+}
+else if testNum == 2 {
+  getFieldName(testType, 0);
+}
+else if testNum == 3 {
+  var v: testType;
+  getField(v, 0);
+}
+else if testNum == 4 {
+  var v: testType;
+  getField(v, "dummy");
+}
+else if testNum == 5 {
+  var v: testType;
+  getFieldRef(v, 0);
+}
+else if testNum == 6 {
+  var v: testType;
+  getFieldRef(v, "dummy");
+}
+else if testNum == 7 {
+  getFieldIndex(testType, "dummy");
+}
+else if testNum == 8 {
+  hasField(testType, "dummy");
+}
+else if testNum == 9 {
+  isFieldBound(testType, 0);
+}
+else if testNum == 10 {
+  isFieldBound(testType, "dummy");
+}

--- a/test/library/standard/Reflection/cannotInspectBuiltins.compopts
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.compopts
@@ -1,0 +1,70 @@
+-stestNum=1 -stestType=string
+-stestNum=2 -stestType=string
+-stestNum=3 -stestType=string
+-stestNum=4 -stestType=string
+-stestNum=5 -stestType=string
+-stestNum=6 -stestType=string
+-stestNum=7 -stestType=string
+-stestNum=8 -stestType=string
+-stestNum=9 -stestType=string
+-stestNum=10 -stestType=string
+-stestNum=1 -stestType=range
+-stestNum=2 -stestType=range
+-stestNum=3 -stestType=range
+-stestNum=4 -stestType=range
+-stestNum=5 -stestType=range
+-stestNum=6 -stestType=range
+-stestNum=7 -stestType=range
+-stestNum=8 -stestType=range
+-stestNum=9 -stestType=range
+-stestNum=10 -stestType=range
+-stestNum=1 -stestType=domain(1)
+-stestNum=2 -stestType=domain(1)
+-stestNum=3 -stestType=domain(1)
+-stestNum=4 -stestType=domain(1)
+-stestNum=5 -stestType=domain(1)
+-stestNum=6 -stestType=domain(1)
+-stestNum=7 -stestType=domain(1)
+-stestNum=8 -stestType=domain(1)
+-stestNum=9 -stestType=domain(1)
+-stestNum=10 -stestType=domain(1)
+-stestNum=1 -stestType='[1..10] int'
+-stestNum=2 -stestType='[1..10] int'
+-stestNum=3 -stestType='[1..10] int'
+-stestNum=4 -stestType='[1..10] int'
+-stestNum=5 -stestType='[1..10] int'
+-stestNum=6 -stestType='[1..10] int'
+-stestNum=7 -stestType='[1..10] int'
+-stestNum=8 -stestType='[1..10] int'
+-stestNum=9 -stestType='[1..10] int'
+-stestNum=10 -stestType='[1..10] int'
+-stestNum=1 -stestType='sync int'
+-stestNum=2 -stestType='sync int'
+-stestNum=3 -stestType='sync int'
+-stestNum=4 -stestType='sync int'
+-stestNum=5 -stestType='sync int'
+-stestNum=6 -stestType='sync int'
+-stestNum=7 -stestType='sync int'
+-stestNum=8 -stestType='sync int'
+-stestNum=9 -stestType='sync int'
+-stestNum=10 -stestType='sync int'
+-stestNum=1 -stestType='atomic int'
+-stestNum=2 -stestType='atomic int'
+-stestNum=3 -stestType='atomic int'
+-stestNum=4 -stestType='atomic int'
+-stestNum=5 -stestType='atomic int'
+-stestNum=6 -stestType='atomic int'
+-stestNum=7 -stestType='atomic int'
+-stestNum=8 -stestType='atomic int'
+-stestNum=9 -stestType='atomic int'
+-stestNum=10 -stestType='atomic int'
+-stestNum=1 -stestType='(int,int)'
+-stestNum=2 -stestType='(int,int)'
+-stestNum=3 -stestType='(int,int)'
+-stestNum=4 -stestType='(int,int)'
+-stestNum=5 -stestType='(int,int)'
+-stestNum=6 -stestType='(int,int)'
+-stestNum=7 -stestType='(int,int)'
+-stestNum=8 -stestType='(int,int)'
+-stestNum=9 -stestType='(int,int)'
+-stestNum=10 -stestType='(int,int)'

--- a/test/library/standard/Reflection/cannotInspectBuiltins.compopts
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.compopts
@@ -1,70 +1,70 @@
--stestNum=1 -stestType=string
--stestNum=2 -stestType=string
--stestNum=3 -stestType=string
--stestNum=4 -stestType=string
--stestNum=5 -stestType=string
--stestNum=6 -stestType=string
--stestNum=7 -stestType=string
--stestNum=8 -stestType=string
--stestNum=9 -stestType=string
--stestNum=10 -stestType=string
--stestNum=1 -stestType=range
--stestNum=2 -stestType=range
--stestNum=3 -stestType=range
--stestNum=4 -stestType=range
--stestNum=5 -stestType=range
--stestNum=6 -stestType=range
--stestNum=7 -stestType=range
--stestNum=8 -stestType=range
--stestNum=9 -stestType=range
--stestNum=10 -stestType=range
--stestNum=1 -stestType=domain(1)
--stestNum=2 -stestType=domain(1)
--stestNum=3 -stestType=domain(1)
--stestNum=4 -stestType=domain(1)
--stestNum=5 -stestType=domain(1)
--stestNum=6 -stestType=domain(1)
--stestNum=7 -stestType=domain(1)
--stestNum=8 -stestType=domain(1)
--stestNum=9 -stestType=domain(1)
--stestNum=10 -stestType=domain(1)
--stestNum=1 -stestType='[1..10] int'
--stestNum=2 -stestType='[1..10] int'
--stestNum=3 -stestType='[1..10] int'
--stestNum=4 -stestType='[1..10] int'
--stestNum=5 -stestType='[1..10] int'
--stestNum=6 -stestType='[1..10] int'
--stestNum=7 -stestType='[1..10] int'
--stestNum=8 -stestType='[1..10] int'
--stestNum=9 -stestType='[1..10] int'
--stestNum=10 -stestType='[1..10] int'
--stestNum=1 -stestType='sync int'
--stestNum=2 -stestType='sync int'
--stestNum=3 -stestType='sync int'
--stestNum=4 -stestType='sync int'
--stestNum=5 -stestType='sync int'
--stestNum=6 -stestType='sync int'
--stestNum=7 -stestType='sync int'
--stestNum=8 -stestType='sync int'
--stestNum=9 -stestType='sync int'
--stestNum=10 -stestType='sync int'
--stestNum=1 -stestType='atomic int'
--stestNum=2 -stestType='atomic int'
--stestNum=3 -stestType='atomic int'
--stestNum=4 -stestType='atomic int'
--stestNum=5 -stestType='atomic int'
--stestNum=6 -stestType='atomic int'
--stestNum=7 -stestType='atomic int'
--stestNum=8 -stestType='atomic int'
--stestNum=9 -stestType='atomic int'
--stestNum=10 -stestType='atomic int'
--stestNum=1 -stestType='(int,int)'
--stestNum=2 -stestType='(int,int)'
--stestNum=3 -stestType='(int,int)'
--stestNum=4 -stestType='(int,int)'
--stestNum=5 -stestType='(int,int)'
--stestNum=6 -stestType='(int,int)'
--stestNum=7 -stestType='(int,int)'
--stestNum=8 -stestType='(int,int)'
--stestNum=9 -stestType='(int,int)'
--stestNum=10 -stestType='(int,int)'
+-stestNum=1 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=2 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=3 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=4 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=5 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=6 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=7 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=8 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=9 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=10 -stestType=string # cannotInspectBuiltins-string.good
+-stestNum=1 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=2 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=3 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=4 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=5 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=6 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=7 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=8 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=9 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=10 -stestType=range # cannotInspectBuiltins-range.good
+-stestNum=1 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=2 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=3 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=4 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=5 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=6 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=7 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=8 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=9 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=10 -stestType=domain(1) # cannotInspectBuiltins-domain.good
+-stestNum=1 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=2 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=3 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=4 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=5 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=6 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=7 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=8 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=9 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=10 -stestType='[1..10] int' # cannotInspectBuiltins-array.good
+-stestNum=1 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=2 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=3 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=4 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=5 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=6 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=7 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=8 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=9 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=10 -stestType='sync int' # cannotInspectBuiltins-sync.good
+-stestNum=1 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=2 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=3 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=4 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=5 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=6 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=7 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=8 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=9 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=10 -stestType='atomic int' # cannotInspectBuiltins-atomic.good
+-stestNum=1 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=2 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=3 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=4 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=5 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=6 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=7 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=8 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=9 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good
+-stestNum=10 -stestType='(int,int)' # cannotInspectBuiltins-tuple.good

--- a/test/library/standard/Reflection/cannotInspectBuiltins.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.good
@@ -1,1 +1,0 @@
-FILE.chpl:n: error: testType is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.good
@@ -1,0 +1,1 @@
+cannotInspectBuiltins.chpl:n: error: testType is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins.good
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.good
@@ -1,1 +1,1 @@
-cannotInspectBuiltins.chpl:n: error: testType is not a class, record, or union type
+FILE.chpl:n: error: testType is not a class, record, or union type

--- a/test/library/standard/Reflection/cannotInspectBuiltins.prediff
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.prediff
@@ -5,8 +5,14 @@ TESTNAME=$1
 OUTFILE=$2
 TMPFILE=$OUTFILE.prediff.tmp
 
-sed -e 's/\.chpl:[0-9]*:/\.chpl:n:/' < $OUTFILE > $TMPFILE
+sed -E 's/^.+\.chpl:[0-9]*:/FILE.chpl:n:/' < $OUTFILE > $TMPFILE
 mv $TMPFILE $OUTFILE
 
 sed -E 's/error: .+ is not a class, record, or union type/error: testType is not a class, record, or union type/' < $OUTFILE > $TMPFILE
+mv $TMPFILE $OUTFILE
+
+grep -v ' In function ' < $OUTFILE > $TMPFILE
+mv $TMPFILE $OUTFILE
+
+grep -v ' called as ' < $OUTFILE > $TMPFILE
 mv $TMPFILE $OUTFILE

--- a/test/library/standard/Reflection/cannotInspectBuiltins.prediff
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.prediff
@@ -1,0 +1,12 @@
+#!/bin/sh 
+
+# filter out line numbers
+TESTNAME=$1
+OUTFILE=$2
+TMPFILE=$OUTFILE.prediff.tmp
+
+sed -e 's/\.chpl:[0-9]*:/\.chpl:n:/' < $OUTFILE > $TMPFILE
+mv $TMPFILE $OUTFILE
+
+sed -E 's/error: .+ is not a class, record, or union type/error: testType is not a class, record, or union type/' < $OUTFILE > $TMPFILE
+mv $TMPFILE $OUTFILE

--- a/test/library/standard/Reflection/cannotInspectBuiltins.prediff
+++ b/test/library/standard/Reflection/cannotInspectBuiltins.prediff
@@ -5,10 +5,8 @@ TESTNAME=$1
 OUTFILE=$2
 TMPFILE=$OUTFILE.prediff.tmp
 
+# some errors come from cannotInspectBuiltins.chpl and some come from Reflection.chpl
 sed -E 's/^.+\.chpl:[0-9]*:/FILE.chpl:n:/' < $OUTFILE > $TMPFILE
-mv $TMPFILE $OUTFILE
-
-sed -E 's/error: .+ is not a class, record, or union type/error: testType is not a class, record, or union type/' < $OUTFILE > $TMPFILE
 mv $TMPFILE $OUTFILE
 
 grep -v ' In function ' < $OUTFILE > $TMPFILE


### PR DESCRIPTION
Adds more extensive tests of Reflection functions which query the fields of a record. We have a number of internal types which are implemented as records but that should not be visible. 

Added checks to `getFieldRef` to verify that the type was not a implementation record. Other tested functions already had these checks.

tested full paratest with futures

[Reviewed by @lydia-duncan]

closes #14546
closes cray/chapel-private#2829

Future work
- Some of these error messages could be improved to refer to the users code instead of the Reflection module, see #23244