### PR TITLE
Mark scans as unstable due to questions about their default behavior

### DIFF
--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -30,6 +30,7 @@ module ChapelReduce {
     return (resType == stateType);
   }
 
+  @unstable("scans are unstable due to questions about exclusive scans and the default behavior.  See issue #20204")
   proc chpl__scanIteratorZip(op, data) {
     compilerWarning("scan has been serialized (see issue #12482)");
     var arr = for d in zip((...data)) do chpl__accumgen(op, d);
@@ -38,6 +39,7 @@ module ChapelReduce {
     return arr;
   }
 
+  @unstable("scans are unstable due to questions about exclusive scans and the default behavior.  See issue #20204")
   proc chpl__scanIterator(op, data) {
     use Reflection;
     param supportsPar = isArray(data) && canResolveMethod(data, "_scan", op);

--- a/test/unstable/unstableScans.chpl
+++ b/test/unstable/unstableScans.chpl
@@ -1,0 +1,12 @@
+var A: [1..10] int = 1..10;
+
+var B = + scan A;
+var C = + scan [a in A] a;
+var D = + scan A[1..10];
+var E = maxloc scan zip(A, A.domain);
+
+writeln(A);
+writeln(B);
+writeln(C);
+writeln(D);
+writeln(E);

--- a/test/unstable/unstableScans.good
+++ b/test/unstable/unstableScans.good
@@ -1,0 +1,11 @@
+unstableScans.chpl:3: warning: scans are unstable due to questions about exclusive scans and the default behavior.  See issue #20204
+unstableScans.chpl:4: warning: scans are unstable due to questions about exclusive scans and the default behavior.  See issue #20204
+unstableScans.chpl:4: warning: scan has been serialized (see issue #12482)
+unstableScans.chpl:5: warning: scans are unstable due to questions about exclusive scans and the default behavior.  See issue #20204
+unstableScans.chpl:6: warning: scans are unstable due to questions about exclusive scans and the default behavior.  See issue #20204
+unstableScans.chpl:6: warning: scan has been serialized (see issue #12482)
+1 2 3 4 5 6 7 8 9 10
+1 3 6 10 15 21 28 36 45 55
+1 3 6 10 15 21 28 36 45 55
+1 3 6 10 15 21 28 36 45 55
+(1, 1) (2, 2) (3, 3) (4, 4) (5, 5) (6, 6) (7, 7) (8, 8) (9, 9) (10, 10)


### PR DESCRIPTION
We currently implement inclusive scans, but there are scenarios where exclusive
scans are valuable and we're not sure if the default of "inclusive scans" is the
right behavior.

All credit goes to Elliot for pointing out the spot to modify and providing an
example test code, making this an almost trivial change.

Add a test locking in the unstable message.

Running a full paratest with futures now