### PR TITLE
Adjust FCF mangled names to not include special characters

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -708,16 +708,20 @@ const char* FunctionType::intentToString(IntentTag intent) {
   return nullptr;
 }
 
-const char* FunctionType::typeToString(Type* t) {
-  auto vt = t->getValType();
+static const char* builtinTypeName(Type* vt) {
   if (vt == dtInt[INT_SIZE_DEFAULT]) return "int";
   if (vt == dtUInt[INT_SIZE_DEFAULT]) return "uint";
   if (vt == dtReal[COMPLEX_SIZE_DEFAULT]) return "real";
   if (vt == dtBools[BOOL_SIZE_DEFAULT]) return "bool";
   if (vt == dtComplex[COMPLEX_SIZE_DEFAULT]) return "complex";
   if (vt == dtImag[FLOAT_SIZE_DEFAULT]) return "imag";
-  auto ret = vt->symbol->name;
-  return ret;
+  return nullptr;
+}
+
+const char* FunctionType::typeToString(Type* t) {
+  auto vt = t->getValType();
+  if (auto builtinName = builtinTypeName(vt)) return builtinName;
+  return vt->symbol->name;
 }
 
 const char* FunctionType::returnIntentToString(RetTag intent) {
@@ -888,6 +892,12 @@ const char* FunctionType::intentTagMnemonicMangled(IntentTag tag) {
   return nullptr;
 }
 
+const char* FunctionType::typeToStringMangled(Type* t) {
+  auto vt = t->getValType();
+  if (auto builtinName = builtinTypeName(vt)) return builtinName;
+  return vt->symbol->cname;
+}
+
 const char* FunctionType::retTagMnemonicMangled(RetTag tag) {
   switch (tag) {
     case RET_VALUE: return "";
@@ -908,7 +918,7 @@ const char* FunctionType::toStringMangledForCodegen() const {
     auto f = this->formal(i);
     bool skip = isIntentSameAsDefault(f->intent, f->type);
     if (!skip) oss << intentTagMnemonicMangled(f->intent);
-    oss << typeToString(f->type) << "_";
+    oss << typeToStringMangled(f->type) << "_";
     if (f->name) oss << f->name;
     oss << "_";
   }
@@ -918,7 +928,7 @@ const char* FunctionType::toStringMangledForCodegen() const {
     oss << retTagMnemonicMangled(returnIntent_) << "_";
   }
 
-  oss << typeToString(returnType_);
+  oss << typeToStringMangled(returnType_);
   if (throws_) oss << "_throws";
 
   auto ret = astr(oss.str());

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -504,6 +504,7 @@ class FunctionType final : public Type {
 
   // Intended for codegen.
   static const char* intentTagMnemonicMangled(IntentTag tag);
+  static const char* typeToStringMangled(Type* t);
   static const char* retTagMnemonicMangled(RetTag tag);
 };
 

--- a/compiler/resolution/fcf-support.cpp
+++ b/compiler/resolution/fcf-support.cpp
@@ -98,6 +98,8 @@ static const char* intentToString(IntentTag tag);
 
 static const char* typeToStringSpecializing(Type* t);
 
+static const char* typeToStringMangledSpecializing(Type* t);
+
 static const char*
 buildUserFacingTypeString(const std::vector<FcfFormalInfo>& formals,
                           RetTag retTag,
@@ -225,6 +227,10 @@ static const char* intentToString(IntentTag tag) {
 
 static const char* typeToStringSpecializing(Type* t) {
   return FunctionType::typeToString(t);
+}
+
+static const char* typeToStringMangledSpecializing(Type* t) {
+  return FunctionType::typeToStringMangled(t);
 }
 
 // TODO: Original intent or concrete intent?
@@ -363,14 +369,14 @@ buildSuperName(const std::vector<FcfFormalInfo>& formals,
   for (auto& info : formals) {
     bool skip = isIntentSameAsDefault(info.intent, info.type);
     if (!skip) oss << intentTagMnemonicMangled(info.intent);
-    oss << typeToStringSpecializing(info.type) << "_";
+    oss << typeToStringMangledSpecializing(info.type) << "_";
     if (info.name) oss << info.name;
     oss << "_";
   }
 
   oss << "_";
   if (retTag != RET_VALUE) oss << retTagMnemonicMangled(retTag) << "_";
-  oss << typeToStringSpecializing(retType);
+  oss << typeToStringMangledSpecializing(retType);
   if (throws) oss << "_throws";
 
   auto ret = astr(oss.str());


### PR DESCRIPTION
PR #23185 introduced a bug that was caused by sharing code for printing types between _user_ strings (which should be pretty-printed) and _mangled_ strnings (which should be valid C identifiers). This PR disentangles the two uses of type printing in FCFs to make both work.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest