### PR TITLE
Fix Curl to use explicit ref intent

### DIFF
--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -329,7 +329,7 @@ module Curl {
 
      :arg str: a string argument to append
     */
-  proc slist.append(str:string) throws {
+  proc ref slist.append(str:string) throws {
     var err: errorCode = 0;
     on this.home {
       this.list = curl_slist_append(this.list, str.localize().c_str());


### PR DESCRIPTION
Adds explicit ref intent to method in `Curl`, which is not tested in our nightly test suite.

[Not reviewed - trivial]