### PR TITLE
Marking more configs as unstable

### DIFF
--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -23,14 +23,17 @@ module ChapelGpuSupport {
   use ChplConfig;
 
   extern var chpl_gpu_debug : bool;
+  @unstable("The variable 'debugGpu' is unstable and its interface is subject to change in the future")
   config const debugGpu = false;
 
   extern var chpl_gpu_no_cpu_mode_warning: bool;
+  @unstable("The variable 'gpuNoCpuModeWarning' is unstable and its interface is subject to change in the future")
   config const gpuNoCpuModeWarning = isEnvSet("CHPL_GPU_NO_CPU_MODE_WARNING");
 
   /* If true, upon startup, enables peer-to-peer access between all pairs of
      GPUs that are eligible for peer-to-peer access within each locale. */
   @chpldoc.nodoc
+  @unstable("The variable 'enableGpuP2P' is unstable and its interface is subject to change in the future")
   config const enableGpuP2P = false;
 
   extern proc chpl_gpu_support_module_finished_initializing() : void;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -22,9 +22,11 @@
 //
 module DefaultRectangular {
   import HaltWrappers;
-
+  @unstable("The variable 'dataParTasksPerLocale' is unstable and its interface is subject to change in the future")
   config const dataParTasksPerLocale = 0;
+  @unstable("The variable 'dataParIgnoreRunningTasks' is unstable and its interface is subject to change in the future")
   config const dataParIgnoreRunningTasks = false;
+  @unstable("The variable 'dataParMinGranularity' is unstable and its interface is subject to change in the future")
   config const dataParMinGranularity: int = 1;
 
   if dataParTasksPerLocale<0 then halt("dataParTasksPerLocale must be >= 0");

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -24,18 +24,24 @@ module MemTracking
 {
   private use ChapelStandard, CTypes;
 
-  config const
-    memTrack: bool = false,
-    memStats: bool = false,
-    memLeaksByType: bool = false,
-    memLeaks: bool = false,
-    memMax: uint = 0,
-    memThreshold: uint = 0,
-    memLog: string;
+  @unstable("The variable 'memTrack' is unstable and its interface is subject to change in the future")
+  config const memTrack: bool = false;
+  @unstable("The variable 'memStats' is unstable and its interface is subject to change in the future")
+  config const memStats: bool = false;
+  @unstable("The variable 'memLeaksByType' is unstable and its interface is subject to change in the future")
+  config const memLeaksByType: bool = false;
+  @unstable("The variable 'memLeaks' is unstable and its interface is subject to change in the future")
+  config const memLeaks: bool = false;
+  @unstable("The variable 'memMax' is unstable and its interface is subject to change in the future")
+  config const memMax: uint = 0;
+  @unstable("The variable 'memThreshold' is unstable and its interface is subject to change in the future")
+  config const memThreshold: uint = 0;
+  @unstable("The variable 'memLog' is unstable and its interface is subject to change in the future")
+  config const memLog: string;
 
   pragma "no auto destroy"
-  config const
-    memLeaksLog: string;
+  @unstable("The variable 'memLeaksLog' is unstable and its interface is subject to change in the future")
+  config const memLeaksLog: string;
 
   /* Causes the contents of the memory tracking array to be printed at the end
      of the program.
@@ -51,8 +57,8 @@ module MemTracking
      data leaks to be printed.
   */
   pragma "no auto destroy"
-  config const
-    memLeaksByDesc: string;
+  @unstable("The variable 'memLeaksByDesc' is unstable and its interface is subject to change in the future")
+  config const memLeaksByDesc: string;
 
   // Safely cast to c_size_t instances of memMax and memThreshold.
   const cMemMax = memMax.safeCast(c_size_t),

--- a/modules/internal/PrintModuleInitOrder.chpl
+++ b/modules/internal/PrintModuleInitOrder.chpl
@@ -30,6 +30,7 @@ pragma "export init"
 module PrintModuleInitOrder {
   private use ChapelBase, CTypes;
 
+  @unstable("The variable 'printModuleInitOrder' is unstable and its interface is subject to change in the future")
   config const printModuleInitOrder = false;
   pragma "print module init indent level" var moduleInitLevel = 2:int(32);
 

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -559,5 +559,3 @@ chpl_bool chpl_config_has_value(c_string v, c_string m) {
 c_string chpl_config_get_value(c_string v, c_string m) {
   return lookupSetValue(v, m);
 }
-
-

--- a/test/distributions/bharshbarg/fastFollowerEquality.good
+++ b/test/distributions/bharshbarg/fastFollowerEquality.good
@@ -1,3 +1,5 @@
+warning: The variable 'dataParTasksPerLocale' is unstable and its interface is subject to change in the future
+note: 'dataParTasksPerLocale' was set via a compiler flag
 --- [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64) vs. [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64) ---
 boundingBox = {1..10}
 targetLocDom = {0..3}

--- a/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.comm-none.good
+++ b/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.comm-none.good
@@ -1,3 +1,5 @@
+warning: The variable 'memTrack' is unstable and its interface is subject to change in the future
+note: 'memTrack' was set via a compiler flag
 simple-alias-mem-use.chpl:17: warning: Dist1D is a DefaultDist
 start
 testing on LOCALE0

--- a/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.good
+++ b/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.good
@@ -1,3 +1,5 @@
+warning: The variable 'memTrack' is unstable and its interface is subject to change in the future
+note: 'memTrack' was set via a compiler flag
 simple-alias-mem-use.chpl:17: warning: Dist1D is a DefaultDist
 start
 testing on LOCALE0

--- a/test/execflags/configs/privateconfigs-help-set.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help-set.comm-none.good
@@ -6,22 +6,6 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-             printModuleInitOrder: bool
-            dataParTasksPerLocale: int(64)
-        dataParIgnoreRunningTasks: bool
-            dataParMinGranularity: int(64)
-                         memTrack: bool
-                         memStats: bool
-                   memLeaksByType: bool
-                         memLeaks: bool
-                           memMax: uint(64)
-                     memThreshold: uint(64)
-                           memLog: string
-                      memLeaksLog: string
-                   memLeaksByDesc: string
-                         debugGpu: bool
-              gpuNoCpuModeWarning: bool
-                     enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)
 

--- a/test/execflags/configs/privateconfigs-help-set.good
+++ b/test/execflags/configs/privateconfigs-help-set.good
@@ -6,22 +6,6 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-             printModuleInitOrder: bool
-            dataParTasksPerLocale: int(64)
-        dataParIgnoreRunningTasks: bool
-            dataParMinGranularity: int(64)
-                         memTrack: bool
-                         memStats: bool
-                   memLeaksByType: bool
-                         memLeaks: bool
-                           memMax: uint(64)
-                     memThreshold: uint(64)
-                           memLog: string
-                      memLeaksLog: string
-                   memLeaksByDesc: string
-                         debugGpu: bool
-              gpuNoCpuModeWarning: bool
-                     enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64) (configured to 1)
 

--- a/test/execflags/configs/privateconfigs-help.comm-none.good
+++ b/test/execflags/configs/privateconfigs-help.comm-none.good
@@ -6,22 +6,6 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-             printModuleInitOrder: bool
-            dataParTasksPerLocale: int(64)
-        dataParIgnoreRunningTasks: bool
-            dataParMinGranularity: int(64)
-                         memTrack: bool
-                         memStats: bool
-                   memLeaksByType: bool
-                         memLeaks: bool
-                           memMax: uint(64)
-                     memThreshold: uint(64)
-                           memLog: string
-                      memLeaksLog: string
-                   memLeaksByDesc: string
-                         debugGpu: bool
-              gpuNoCpuModeWarning: bool
-                     enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)
 

--- a/test/execflags/configs/privateconfigs-help.good
+++ b/test/execflags/configs/privateconfigs-help.good
@@ -6,22 +6,6 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-             printModuleInitOrder: bool
-            dataParTasksPerLocale: int(64)
-        dataParIgnoreRunningTasks: bool
-            dataParMinGranularity: int(64)
-                         memTrack: bool
-                         memStats: bool
-                   memLeaksByType: bool
-                         memLeaks: bool
-                           memMax: uint(64)
-                     memThreshold: uint(64)
-                           memLog: string
-                      memLeaksLog: string
-                   memLeaksByDesc: string
-                         debugGpu: bool
-              gpuNoCpuModeWarning: bool
-                     enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64) (configured to 1)
 

--- a/test/execflags/ferguson/help2.good
+++ b/test/execflags/ferguson/help2.good
@@ -18,21 +18,5 @@ CONFIG VAR FLAGS:
 
 CONFIG VARS:
 ============
-             printModuleInitOrder: bool
-            dataParTasksPerLocale: int(64)
-        dataParIgnoreRunningTasks: bool
-            dataParMinGranularity: int(64)
-                         memTrack: bool
-                         memStats: bool
-                   memLeaksByType: bool
-                         memLeaks: bool
-                           memMax: uint(64)
-                     memThreshold: uint(64)
-                           memLog: string
-                      memLeaksLog: string
-                   memLeaksByDesc: string
-                         debugGpu: bool
-              gpuNoCpuModeWarning: bool
-                     enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)

--- a/test/execflags/shannon/configs/help/basehelp.txt
+++ b/test/execflags/shannon/configs/help/basehelp.txt
@@ -7,22 +7,5 @@ CONFIG VAR FLAGS:
 CONFIG VARS:
 ============
 Built-in config vars:
-            printModuleInitOrder: bool
-           dataParTasksPerLocale: int(64)
-       dataParIgnoreRunningTasks: bool
-           dataParMinGranularity: int(64)
-                        memTrack: bool
-                        memStats: bool
-                  memLeaksByType: bool
-                        memLeaks: bool
-                          memMax: uint(64)
-                    memThreshold: uint(64)
-                          memLog: string
-                     memLeaksLog: string
-                  memLeaksByDesc: string
-                        debugGpu: bool 
-             gpuNoCpuModeWarning: bool
-                    enableGpuP2P: bool 
  defaultHashTableResizeThreshold: real(64) 
                       numLocales: int(64)
-

--- a/test/execflags/shannon/help.good
+++ b/test/execflags/shannon/help.good
@@ -5,21 +5,5 @@ CONFIG VAR FLAGS:
 
 CONFIG VARS:
 ============
-             printModuleInitOrder: bool
-            dataParTasksPerLocale: int(64)
-        dataParIgnoreRunningTasks: bool
-            dataParMinGranularity: int(64)
-                         memTrack: bool
-                         memStats: bool
-                   memLeaksByType: bool
-                         memLeaks: bool
-                           memMax: uint(64)
-                     memThreshold: uint(64)
-                           memLog: string
-                      memLeaksLog: string
-                   memLeaksByDesc: string
-                         debugGpu: bool
-              gpuNoCpuModeWarning: bool
-                     enableGpuP2P: bool
   defaultHashTableResizeThreshold: real(64)
                        numLocales: int(64)

--- a/test/statements/manage/WarnUnstable.good
+++ b/test/statements/manage/WarnUnstable.good
@@ -1,2 +1,3 @@
 WarnUnstable.chpl:9: warning: manage statements are not stable and may change
 0
+<command-line arg>:1: warning: The variable 'memLeaks' is unstable and its interface is subject to change in the future

--- a/test/unstable/.gitignore
+++ b/test/unstable/.gitignore
@@ -1,1 +1,3 @@
 asserteof.test.nums
+log
+leaklog

--- a/test/unstable/unstableConfigs.chpl
+++ b/test/unstable/unstableConfigs.chpl
@@ -1,0 +1,12 @@
+config var myUserConfig = 0;
+
+@unstable("Hey it's unstable!")
+config var myUnstableConfig = 0;
+
+
+config param myUserParam = 0;
+
+
+writeln(myUserConfig);
+writeln(myUnstableConfig);
+writeln(myUserParam);

--- a/test/unstable/unstableConfigs.cleanfiles
+++ b/test/unstable/unstableConfigs.cleanfiles
@@ -1,0 +1,1 @@
+log leaklog

--- a/test/unstable/unstableConfigs.datapar.good
+++ b/test/unstable/unstableConfigs.datapar.good
@@ -1,0 +1,7 @@
+unstableConfigs.chpl:XX: warning: Hey it's unstable!
+0
+0
+0
+<command-line arg>:1: warning: The variable 'dataParTasksPerLocale' is unstable and its interface is subject to change in the future
+<command-line arg>:2: warning: The variable 'dataParIgnoreRunningTasks' is unstable and its interface is subject to change in the future
+<command-line arg>:3: warning: The variable 'dataParMinGranularity' is unstable and its interface is subject to change in the future

--- a/test/unstable/unstableConfigs.execopts
+++ b/test/unstable/unstableConfigs.execopts
@@ -1,0 +1,2 @@
+--help #unstableConfigs.help.good
+--myUnstableConfig=12 --myUserConfig=1 #unstableConfigs.good

--- a/test/unstable/unstableConfigs.execopts
+++ b/test/unstable/unstableConfigs.execopts
@@ -1,2 +1,6 @@
 --help #unstableConfigs.help.good
 --myUnstableConfig=12 --myUserConfig=1 #unstableConfigs.good
+--printModuleInitOrder=false #unstableConfigs.initorder.good
+--dataParTasksPerLocale=2 --dataParIgnoreRunningTasks=false --dataParMinGranularity=10 #unstableConfigs.datapar.good
+--memTrack=true --memStats=true --memLeaksByType=true --memLeaks=true --memMax=0 --memThreshold=0 --memLog="log" --memLeaksLog="leaklog" --memLeaksByDesc=" " #unstableConfigs.mem.good
+--debugGpu=true --gpuNoCpuModeWarning=true --enableGpuP2P=true #unstableConfigs.gpu.good

--- a/test/unstable/unstableConfigs.good
+++ b/test/unstable/unstableConfigs.good
@@ -1,0 +1,5 @@
+unstableConfigs.chpl:XX: warning: Hey it's unstable!
+1
+12
+0
+<command-line arg>:1: warning: Hey it's unstable!

--- a/test/unstable/unstableConfigs.gpu.good
+++ b/test/unstable/unstableConfigs.gpu.good
@@ -1,0 +1,7 @@
+unstableConfigs.chpl:XX: warning: Hey it's unstable!
+0
+0
+0
+<command-line arg>:1: warning: The variable 'debugGpu' is unstable and its interface is subject to change in the future
+<command-line arg>:2: warning: The variable 'gpuNoCpuModeWarning' is unstable and its interface is subject to change in the future
+<command-line arg>:3: warning: The variable 'enableGpuP2P' is unstable and its interface is subject to change in the future

--- a/test/unstable/unstableConfigs.help.comm-none.good
+++ b/test/unstable/unstableConfigs.help.comm-none.good
@@ -1,6 +1,6 @@
 unstableConfigs.chpl:XX: warning: Hey it's unstable!
 Built-in config vars:
   defaultHashTableResizeThreshold: real(64)
-                       numLocales: int(64) (configured to 1)
+                       numLocales: int(64)
 unstableConfigs config vars:
                      myUserConfig: int(64)

--- a/test/unstable/unstableConfigs.help.good
+++ b/test/unstable/unstableConfigs.help.good
@@ -1,0 +1,6 @@
+unstableConfigs.chpl:XX: warning: Hey it's unstable!
+Built-in config vars:
+  defaultHashTableResizeThreshold: real(64)
+                       numLocales: int(64)
+unstableConfigs config vars:
+                     myUserConfig: int(64)

--- a/test/unstable/unstableConfigs.initorder.good
+++ b/test/unstable/unstableConfigs.initorder.good
@@ -1,0 +1,5 @@
+unstableConfigs.chpl:XX: warning: Hey it's unstable!
+0
+0
+0
+<command-line arg>:1: warning: The variable 'printModuleInitOrder' is unstable and its interface is subject to change in the future

--- a/test/unstable/unstableConfigs.mem.good
+++ b/test/unstable/unstableConfigs.mem.good
@@ -1,0 +1,13 @@
+unstableConfigs.chpl:XX: warning: Hey it's unstable!
+0
+0
+0
+<command-line arg>:1: warning: The variable 'memTrack' is unstable and its interface is subject to change in the future
+<command-line arg>:2: warning: The variable 'memStats' is unstable and its interface is subject to change in the future
+<command-line arg>:3: warning: The variable 'memLeaksByType' is unstable and its interface is subject to change in the future
+<command-line arg>:4: warning: The variable 'memLeaks' is unstable and its interface is subject to change in the future
+<command-line arg>:5: warning: The variable 'memMax' is unstable and its interface is subject to change in the future
+<command-line arg>:6: warning: The variable 'memThreshold' is unstable and its interface is subject to change in the future
+<command-line arg>:7: warning: The variable 'memLog' is unstable and its interface is subject to change in the future
+<command-line arg>:8: warning: The variable 'memLeaksLog' is unstable and its interface is subject to change in the future
+<command-line arg>:9: warning: The variable 'memLeaksByDesc' is unstable and its interface is subject to change in the future

--- a/test/unstable/unstableConfigs.prediff
+++ b/test/unstable/unstableConfigs.prediff
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# filter out irrelevant parts of --help, including empty lines which are
+# inconsistent between gasnet and local builds (probably due to launcher?)
+awk 'BEGIN {write=1;} \
+     /FLAGS:/ {write=0}\
+     /Built-in config vars:/ {write=1} \
+     /unstableConfigs config vars:/ {write=1} \
+     !/^$/ {if(write) print($0)}' <$2 >$2.awked
+
+# filter out line numbers
+sed -E 's/(unstableConfigs.chpl):[[:digit:]]+:(.*)/\1:XX:\2/' <$2.awked >$2
+
+rm -f $2.awked


### PR DESCRIPTION
Based on discussion in #21150, marked the following configs as unstable, and thus prevent them from showing up in `--help`

- printModuleInitOrder (modules/internal/PrintModuleInitOrder.chpl)
- dataPar* (modules/internal/DefaultRectangular.chpl)  <-- 3 configs
- mem* (modules/internal/MemTracking.chpl) <--  9 configs
- debugGpu, enableGpuP2P, gpuNoCpuModeWarning (modules/internal/ChapelGpuSupport.chpl) <-- 3 configs

- [x] paratests
- [x] gasnet paratest 