### PR TITLE
Fix deprecation of `JsonSerializer` and `JsonDeserializer`

### DIFF
--- a/modules/standard/JSON.chpl
+++ b/modules/standard/JSON.chpl
@@ -359,6 +359,9 @@ module JSON {
     return (m, lastPos);
   }
 
+  @deprecated(notes="'JsonSerializer' is deprecated; please use 'jsonSerializer' instead")
+  type JsonSerializer = jsonSerializer;
+
   /*
     A JSON format deserializer to be used by :record:`~IO.fileReader`.
 
@@ -758,4 +761,7 @@ module JSON {
     }
 
   }
+
+  @deprecated(notes="'JsonDeserializer' is deprecated; please use 'jsonDeserializer' instead")
+  type JsonDeserializer = jsonDeserializer;
 }

--- a/test/deprecated/IO/iokind/printing-iokind-types.good
+++ b/test/deprecated/IO/iokind/printing-iokind-types.good
@@ -2,9 +2,9 @@ printing-iokind-types.chpl:4: In function 'main':
 printing-iokind-types.chpl:5: warning: 'iokind' is deprecated, please use Serializers or Deserializers that support endianness instead
 printing-iokind-types.chpl:6: warning: 'iokind' is deprecated, please use Serializers or Deserializers that support endianness instead
 printing-iokind-types.chpl:9: warning: 'iokind' is deprecated, please use Serializers or Deserializers that support endianness instead
-fileReader(native,false,BinaryDeserializer)
-fileWriter(native,false,BinarySerializer)
-fileReader(false,DefaultDeserializer)
-fileWriter(false,DefaultSerializer)
+fileReader(native,false,binaryDeserializer)
+fileWriter(native,false,binarySerializer)
+fileReader(false,defaultDeserializer)
+fileWriter(false,defaultSerializer)
 subprocess(native,false)
 subprocess(false)

--- a/test/deprecated/IO/jsonSerializer.chpl
+++ b/test/deprecated/IO/jsonSerializer.chpl
@@ -1,0 +1,10 @@
+use IO, JSON;
+
+var f = openMemFile();
+{
+  f.writer(serializer=new JsonSerializer()).write("hello!");
+}
+{
+var s = f.reader(deserializer=new JsonDeserializer()).read(string);
+  writeln(s);
+}

--- a/test/deprecated/IO/jsonSerializer.good
+++ b/test/deprecated/IO/jsonSerializer.good
@@ -1,0 +1,3 @@
+jsonSerializer.chpl:5: warning: 'JsonSerializer' is deprecated; please use 'jsonSerializer' instead
+jsonSerializer.chpl:8: warning: 'JsonDeserializer' is deprecated; please use 'jsonDeserializer' instead
+hello!

--- a/test/io/ferguson/printing-channel-types.good
+++ b/test/io/ferguson/printing-channel-types.good
@@ -1,4 +1,4 @@
 fileReader
-fileReader(false,DefaultDeserializer)
+fileReader(false,defaultDeserializer)
 fileWriter
-fileWriter(false,DefaultSerializer)
+fileWriter(false,defaultSerializer)

--- a/test/library/standard/Map/readMapStringsBytes.chpl
+++ b/test/library/standard/Map/readMapStringsBytes.chpl
@@ -3,4 +3,4 @@ use Map;
 use IO;
 
 var m : map(string, string);
-stdin.withDeserializer(DefaultDeserializer).read(m);
+stdin.withDeserializer(defaultDeserializer).read(m);

--- a/test/library/standard/Map/readMapStringsBytes.good
+++ b/test/library/standard/Map/readMapStringsBytes.good
@@ -1,7 +1,7 @@
 $CHPL_HOME/modules/standard/Map.chpl:nnnn: In method 'deserialize':
 $CHPL_HOME/modules/standard/Map.chpl:nnnn: error: Default IO format for 'map' does not support reading when the key or value type is  'string' or 'bytes'.
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (map(string,string,false)).deserialize(reader: fileReader(false,DefaultDeserializer), deserializer: DefaultDeserializer) from method 'deserializeValue'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as DefaultDeserializer.deserializeValue(reader: fileReader(false,DefaultDeserializer), val: map(string,string,false)) from method '_deserializeOne'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(true,DefaultDeserializer))._deserializeOne(x: map(string,string,false), loc: locale) from method '_readInner'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(true,DefaultDeserializer))._readInner(args(0): map(string,string,false)) from method 'read'
-  readMapStringsBytes.chpl:6: called as (fileReader(true,DefaultDeserializer)).read(args(0): map(string,string,false))
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (map(string,string,false)).deserialize(reader: fileReader(false,defaultDeserializer), deserializer: defaultDeserializer) from method 'deserializeValue'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as defaultDeserializer.deserializeValue(reader: fileReader(false,defaultDeserializer), val: map(string,string,false)) from method '_deserializeOne'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(true,defaultDeserializer))._deserializeOne(x: map(string,string,false), loc: locale) from method '_readInner'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(true,defaultDeserializer))._readInner(args(0): map(string,string,false)) from method 'read'
+  readMapStringsBytes.chpl:6: called as (fileReader(true,defaultDeserializer)).read(args(0): map(string,string,false))


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/23219 replaced `JsonSerializer` and `JsonDeserialier` with camelCase versions without keeping the old versions around as deprecated symbols. This PR properly deprecates them.

- [x] paratest
- [x] inspected docs