### PR TITLE
Resolve test failures from deprecating ref-maybe-const forall intents

### DIFF
--- a/test/studies/nbody/md.chpl
+++ b/test/studies/nbody/md.chpl
@@ -35,7 +35,7 @@ proc try1() {
 
   // "forall": parallel, distributed over D_distrib
   // compute all A[i] in parallel
-  forall i in D_distrib {
+  forall i in D_distrib with (ref A) {
 
     // "for": sequential, local; over a privitized copy of D_distrib
     // accumulate into A[i] sequentially


### PR DESCRIPTION
Adds explicit ref forall intents to a test which failed in nightly test configurations

Fixes more fallout from https://github.com/chapel-lang/chapel/pull/23175.

[Not reviewed - trivial]