### PR TITLE
Tighten class casting logic when casting to an `unmanaged`

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3106,8 +3106,12 @@ static void adjustClassCastCall(CallExpr* call)
     // (Note, this assumes that managedType.borrow() does not throw/halt
     //  for nilable managed types storing nil. If that changed, we'd
     //  need another method to call here to get the possibly nil ptr).
+    // This code is important to allow proper borrowing, but without
+    //  `!isDecoratorUnmanaged(d)` it is too eager and is applied where it
+    //  should not be
     if (isDecoratorManaged(valueD) &&
         !isDecoratorManaged(d) &&
+        !isDecoratorUnmanaged(d) &&
         !valueIsType) {
       if (isDecoratorUnknownManagement(d))
         INT_FATAL(call, "actual value has unknown type");

--- a/test/classes/casts/cast-managed-to-unmanaged.chpl
+++ b/test/classes/casts/cast-managed-to-unmanaged.chpl
@@ -1,0 +1,24 @@
+// modified from https://github.com/chapel-lang/chapel/issues/22574
+class MyClass { var field: int; }
+operator MyClass.: (x: MyClass, type t: int) {
+  writeln("In cast to int, x.type is ", x.type:string);
+  return x.field;
+}
+operator MyClass.: (x: MyClass, type t: unmanaged) {
+  writeln("In cast to unmanaged, x.type is ", x.type:string);
+  return x.field;
+}
+proc main() {
+  {
+    var x = new MyClass(1);
+    writeln(x : int);
+    writeln(x : unmanaged);
+    writeln(x : unmanaged class?);
+  }
+  {
+    var x = new shared MyClass(2);
+    writeln(x : int);
+    writeln(x : unmanaged class);
+    writeln(x : unmanaged class?);
+  }
+}

--- a/test/classes/casts/cast-managed-to-unmanaged.good
+++ b/test/classes/casts/cast-managed-to-unmanaged.good
@@ -1,0 +1,12 @@
+In cast to int, x.type is owned MyClass
+1
+In cast to unmanaged, x.type is owned MyClass
+1
+In cast to unmanaged, x.type is owned MyClass
+1
+In cast to int, x.type is shared MyClass
+2
+In cast to unmanaged, x.type is shared MyClass
+2
+In cast to unmanaged, x.type is shared MyClass
+2


### PR DESCRIPTION
Fixes bug when casting to `unmanaged` from a managed class where the compiler would insert an automatic borrow.

If a user wanted to write the following code, the first cast would print the type correctly and the second cast would always print the type of `x` as `owned MyClass`, regardless of the actual argument type.
```chapel
operator :(x: MyClass, type t: int) {
  writeln("x.type is ", x.type:string);
  return x.field;
}
operator :(x: MyClass, type t: unmanaged) {
  writeln("x.type is ", x.type:string);
  return x.field;
}
```

## Summary of changes
- tighten borrowing logic in `adjustClassCastCall` to not borrow from an `unmanaged`
  - removing this logic outright caused ~70 failures in a paratest, but adding this one extra check caused no failures 
- add test case of original bug

## Testing
- paratest with futures
- paratest with gasnet

[Reviewed by @mppf]

resolves #22574
resolves Cray/chapel-private#5345
