### PR TITLE
Reserve name 'these' for iter methods only

### DIFF
--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -207,6 +207,7 @@ The following identifiers are reserved as keywords:
    subdomain
    sync
    then
+   these
    this
    throw
    throws

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -100,6 +100,7 @@ struct Visitor {
   bool isParentFalseBlock(int depth=0) const;
 
   bool isNamedThisAndNotReceiverOrFunction(const NamedDecl* node);
+  bool isNamedTheseAndNotIterMethod(const NamedDecl* node);
   bool isSpecialMethodKeywordUsedIncorrectly(const NamedDecl *node);
   bool isNameReservedWord(const NamedDecl* node);
   inline bool shouldEmitUnstableWarning(const AstNode* node);
@@ -1052,6 +1053,15 @@ bool Visitor::isNamedThisAndNotReceiverOrFunction(const NamedDecl* node) {
   return true;
 }
 
+bool Visitor::isNamedTheseAndNotIterMethod(const NamedDecl* node) {
+  if (node->name() != USTR("these")) return false;
+  if (auto asFn = node->toFunction())
+    if (asFn->isMethod() && asFn->kind() == Function::Kind::ITER)
+      return false;
+
+  return true;
+}
+
 bool Visitor::isSpecialMethodKeywordUsedIncorrectly(
   const NamedDecl *node)
 {
@@ -1074,6 +1084,7 @@ bool Visitor::isSpecialMethodKeywordUsedIncorrectly(
 bool Visitor::isNameReservedWord(const NamedDecl* node) {
   auto name = node->name();
   if (isNamedThisAndNotReceiverOrFunction(node)) return true;
+  if (isNamedTheseAndNotIterMethod(node)) return true;
   if (isSpecialMethodKeywordUsedIncorrectly(node)) return true;
   if (name == "none") return true;
   if (name == "false") return true;

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1055,9 +1055,20 @@ bool Visitor::isNamedThisAndNotReceiverOrFunction(const NamedDecl* node) {
 
 bool Visitor::isNamedTheseAndNotIterMethod(const NamedDecl* node) {
   if (node->name() != USTR("these")) return false;
-  if (auto asFn = node->toFunction())
-    if (asFn->isMethod() && asFn->kind() == Function::Kind::ITER)
-      return false;
+  if (auto asFn = node->toFunction()) {
+    if (asFn->isMethod()) {
+      if (asFn->kind() == Function::Kind::ITER) {
+        return false;
+      } else if (asFn->kind() == Function::Kind::PROC &&
+                 node->attributeGroup() &&
+                 node->attributeGroup()->hasPragma(
+                     pragmatags::PRAGMA_FN_RETURNS_ITERATOR)) {
+        // also allow proc methods that forward an iterator,
+        // via: pragma "fn returns iterator"
+        return false;
+      }
+    }
+  }
 
   return true;
 }

--- a/test/chpldoc/functions/WhereClause.doc.chpl
+++ b/test/chpldoc/functions/WhereClause.doc.chpl
@@ -49,7 +49,8 @@ module M {
     }
 
     // From CMO_array.chpl
-    iter these(param tag, followThis) ref where tag == iterKind.follower {
+    iter these_example(param tag, followThis) ref
+      where tag == iterKind.follower {
         yield followThis;
     }
 

--- a/test/chpldoc/functions/WhereClause.doc.good
+++ b/test/chpldoc/functions/WhereClause.doc.good
@@ -41,7 +41,7 @@ or
 
 .. function:: operator :(x: c_string, type t: c_ptrConst(?eltType)) where eltType == c_char || eltType == int(8) || eltType == uint(8)
 
-.. iterfunction:: iter these(param tag, followThis) ref where tag == iterKind.follower
+.. iterfunction:: iter these_example(param tag, followThis) ref where tag == iterKind.follower
 
 .. iterfunction:: iter cubeiter(param tag: iterKind, n: int, id: int = 0, off: int = -1): int where tag == iterKind.standalone
 

--- a/test/functions/iterators/bradc/leadFollow/leadNoYield.chpl
+++ b/test/functions/iterators/bradc/leadFollow/leadNoYield.chpl
@@ -3,9 +3,6 @@ class C {
     for i in 1..10 do
       yield i;
   }
-
-  proc these(leader) {
-  }
 }
 
 var myC = new unmanaged C();

--- a/test/functions/iterators/theseKeyword.chpl
+++ b/test/functions/iterators/theseKeyword.chpl
@@ -52,6 +52,18 @@ module Mod9 {
     yield 4;
   }
 }
+module Mod10 {
+  class Foo {
+    // also allow iterator-forwarding proc method
+    pragma "fn returns iterator"
+    proc these() {
+      return this.these();
+    }
+    iter these() {
+      yield 4;
+    }
+  }
+}
 
 // Using illegally-named symbols should not trigger warnings
 module Main {

--- a/test/functions/iterators/theseKeyword.chpl
+++ b/test/functions/iterators/theseKeyword.chpl
@@ -1,0 +1,63 @@
+// Different illegal uses in separate modules to avoid redefinition errors
+module Mod1 {
+  var these : int = 4;
+}
+module Mod2 {
+  proc these() {
+    return "these";
+  }
+}
+module Mod3 {
+  // free iter disallowed
+  iter these() {
+    yield 4;
+  }
+}
+module Mod4 {
+  record these { }
+}
+module Mod5 {
+  class these {
+    // non-iter method disallowed
+    proc these() {
+      return 4;
+    }
+  }
+}
+module Mod6 {
+  module these { }
+}
+module Mod7 {
+  class Foo {
+    // iter method is the only allowed form
+    iter these() {
+      yield 4;
+    }
+  }
+}
+module Mod8 {
+  class Foo { }
+  // secondary method iter also allowed
+  iter Foo.these() {
+    yield 4;
+  }
+}
+module Mod9 {
+  module FooDecl {
+    class Foo { }
+  }
+  // tertiary method iter also allowed
+  import FooDecl.Foo;
+  iter Foo.these() {
+    yield 4;
+  }
+}
+
+// Using illegally-named symbols should not trigger warnings
+module Main {
+  import Mod1;
+
+  proc main() {
+    writeln(Mod1.these);
+  }
+}

--- a/test/functions/iterators/theseKeyword.good
+++ b/test/functions/iterators/theseKeyword.good
@@ -1,0 +1,13 @@
+theseKeyword.chpl:2: In module 'Mod1':
+theseKeyword.chpl:3: error: attempt to redefine reserved word 'these'
+theseKeyword.chpl:5: In module 'Mod2':
+theseKeyword.chpl:6: error: attempt to redefine reserved word 'these'
+theseKeyword.chpl:10: In module 'Mod3':
+theseKeyword.chpl:12: error: attempt to redefine reserved word 'these'
+theseKeyword.chpl:16: In module 'Mod4':
+theseKeyword.chpl:17: error: attempt to redefine reserved word 'these'
+theseKeyword.chpl:19: In module 'Mod5':
+theseKeyword.chpl:20: error: attempt to redefine reserved word 'these'
+theseKeyword.chpl:22: error: attempt to redefine reserved word 'these'
+theseKeyword.chpl:27: In module 'Mod6':
+theseKeyword.chpl:28: error: attempt to redefine reserved word 'these'


### PR DESCRIPTION
Adds a check in `post-parse-checks.cpp` prohibiting identifiers named `these` except for iter methods, and documents `these` as a keyword.

Also allows proc methods named `these` that forward iterators via `pragma "fn returns iterator"`.

Resolves https://github.com/Cray/chapel-private/issues/5317.

[reviewer info placeholder]

Testing:
- [x] local paratest