### PR TITLE
Update to new initialization sequence

### DIFF
--- a/test/runtime/jhh/cpuKinds/cpuKinds.c
+++ b/test/runtime/jhh/cpuKinds/cpuKinds.c
@@ -42,7 +42,8 @@ int main(int argc, char* argv[]) {
 
   chpl__init_cpuKinds(0, 0); // unsure why this is needed
   chpl_set_num_locales_on_node(1);
-  chpl_topo_init(mask);
+  chpl_topo_pre_comm_init(mask);
+  chpl_topo_post_comm_init();
 
   bool physical = false;
   do {


### PR DESCRIPTION
The test harness `cpuKinds.c` needed to be updated to the new way of initializing the topology layer.