### PR TITLE
Adjust dyno to only trigger unstable config warnings when --warn-unstable is set

### DIFF
--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -19,6 +19,7 @@
 
 #include "chpl/uast/Builder.h"
 
+#include "chpl/framework/compiler-configuration.h"
 #include "chpl/framework/Context.h"
 #include "chpl/framework/ErrorMessage.h"
 #include "chpl/framework/ErrorBase.h"
@@ -473,7 +474,8 @@ Builder::lookupConfigSettingsForVar(Variable* var, pathVecT& pathVec,
       if (auto attribs = var->attributeGroup()) {
         if (attribs->isDeprecated())
           generateConfigWarning(varName, "deprecated", attribs->deprecationMessage());
-        if (attribs->isUnstable())
+        if (attribs->isUnstable() &&
+            isCompilerFlagSet(this->context(), CompilerFlags::WARN_UNSTABLE))
           generateConfigWarning(varName, "unstable", attribs->unstableMessage());
       }
       if (!configMatched.first.empty() &&

--- a/test/distributions/bharshbarg/fastFollowerEquality.good
+++ b/test/distributions/bharshbarg/fastFollowerEquality.good
@@ -1,5 +1,3 @@
-warning: The variable 'dataParTasksPerLocale' is unstable and its interface is subject to change in the future
-note: 'dataParTasksPerLocale' was set via a compiler flag
 --- [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64) vs. [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64) ---
 boundingBox = {1..10}
 targetLocDom = {0..3}

--- a/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.comm-none.good
+++ b/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.comm-none.good
@@ -1,5 +1,3 @@
-warning: The variable 'memTrack' is unstable and its interface is subject to change in the future
-note: 'memTrack' was set via a compiler flag
 simple-alias-mem-use.chpl:17: warning: Dist1D is a DefaultDist
 start
 testing on LOCALE0

--- a/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.good
+++ b/test/distributions/robust/arithmetic/reindexing/simple-alias-mem-use.good
@@ -1,5 +1,3 @@
-warning: The variable 'memTrack' is unstable and its interface is subject to change in the future
-note: 'memTrack' was set via a compiler flag
 simple-alias-mem-use.chpl:17: warning: Dist1D is a DefaultDist
 start
 testing on LOCALE0

--- a/test/unstable-keyword/config/paramConfigInCmd.compopts
+++ b/test/unstable-keyword/config/paramConfigInCmd.compopts
@@ -1,1 +1,1 @@
--sconfigParam=10
+-sconfigParam=10 --warn-unstable

--- a/test/unstable-keyword/config/paramConfigInCmd.good
+++ b/test/unstable-keyword/config/paramConfigInCmd.good
@@ -1,3 +1,4 @@
 warning: configParam is unstable.
 note: 'configParam' was set via a compiler flag
+paramConfigInCmd.chpl:XX: warning: configParam is unstable.
 10


### PR DESCRIPTION
Resolves #23248 

The config check wasn't accounting for the presence or absence of the
`--warn-unstable` flag.  Rectify that.

Remove the warnings inserted when Shreyas was marking configs unstable.
Now that the warnings only trigger with the flag, the .good files for these
tests can be restored to their earlier state.

Fix the test of unstable configs.  The test was not throwing
`--warn-unstable`, so when we stopped generating that warning in all
settings, it stopped turning up.  Additionally, by actually throwing
`--warn-unstable`, we discovered that the test needed an additional
warning because it was referencing the config in the body of the program as
well.  (Thanks Daniel for pointing that out!)

Testing:
- [x] full paratest with futures
- [x] full gasnet paratest with futures