### PR TITLE
Mark 'these' iterators which take arguments as unstable

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2108,6 +2108,7 @@ const char* astrPostinit = NULL;
 const char* astrBuildTuple = NULL;
 const char* astrTag = NULL;
 const char* astrThis = NULL;
+const char* astrThese = NULL;
 const char* astrSuper = NULL;
 const char* astr_chpl_cname = NULL;
 const char* astr_chpl_forward_tgt = NULL;
@@ -2149,6 +2150,7 @@ void initAstrConsts() {
   astrBuildTuple = astr("_build_tuple");
   astrTag     = astr("tag");
   astrThis    = astr("this");
+  astrThese   = astr("these");
   astrSuper   = astr("super");
   astr_chpl_cname = astr("_chpl_cname");
   astr_chpl_forward_tgt = astr("_chpl_forward_tgt");

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -821,6 +821,7 @@ extern const char* astrPostinit;
 extern const char* astrBuildTuple;
 extern const char* astrTag;
 extern const char* astrThis;
+extern const char* astrThese;
 extern const char* astrSuper;
 extern const char* astr_chpl_cname;
 extern const char* astr_chpl_forward_tgt;

--- a/test/unstable/iterTheseWithArguments.chpl
+++ b/test/unstable/iterTheseWithArguments.chpl
@@ -1,0 +1,304 @@
+config param verbose = false;
+
+proc myLog() do if verbose then writeln();
+proc myLog(args...?k) do if verbose then writeln((...args));
+
+
+//
+// Records
+//
+record RecordTheseWithNoArg {
+  const D: range = 0..10;
+  const elms: [D] int = D*2;
+  iter these() {
+    myLog("serial");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind) where tag == iterKind.standalone {
+    myLog("standalone");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind) where tag == iterKind.leader {
+    myLog("leader");
+    yield (D,);
+  }
+  iter these(param tag: iterKind, followThis) where tag == iterKind.follower {
+    myLog("follower ", followThis);
+    const (followInds,) = followThis;
+    for i in followInds {
+      myLog("follower loop idx ", i);
+      yield elms[i];
+    }
+  }
+}
+record RecordTheseWithArg {
+  const D: range = 0..10;
+  const elms: [D] int = D*2;
+  iter these(n=1) {
+    myLog("serial");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind, n) where tag == iterKind.standalone {
+    myLog("standalone");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind, n) where tag == iterKind.leader {
+    myLog("leader");
+    yield (D,);
+  }
+  iter these(param tag: iterKind, n, followThis) where tag == iterKind.follower {
+    myLog("follower ", followThis);
+    const (followInds,) = followThis;
+    for i in followInds {
+      myLog("follower loop idx ", i);
+      yield elms[i];
+    }
+  }
+}
+record RecordTheseWithDefaultArg {
+  const D: range = 0..10;
+  const elms: [D] int = D*2;
+  iter these(n=1) {
+    myLog("serial");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind, n=1) where tag == iterKind.standalone {
+    myLog("standalone");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind, n=1) where tag == iterKind.leader {
+    myLog("leader");
+    yield (D,);
+  }
+  iter these(param tag: iterKind, n=1, followThis) where tag == iterKind.follower {
+    myLog("follower ", followThis);
+    const (followInds,) = followThis;
+    for i in followInds {
+      myLog("follower loop idx ", i);
+      yield elms[i];
+    }
+  }
+}
+
+//
+// Classes
+//
+class ClassTheseWithNoArg {
+  const D: range = 0..10;
+  const elms: [D] int = D*2;
+  iter these() {
+    myLog("serial");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind) where tag == iterKind.standalone {
+    myLog("standalone");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind) where tag == iterKind.leader {
+    myLog("leader");
+    yield (D,);
+  }
+  iter these(param tag: iterKind, followThis) where tag == iterKind.follower {
+    myLog("follower ", followThis);
+    const (followInds,) = followThis;
+    for i in followInds {
+      myLog("follower loop idx ", i);
+      yield elms[i];
+    }
+  }
+}
+class ClassTheseWithArg {
+  const D: range = 0..10;
+  const elms: [D] int = D*2;
+  iter these(n=1) {
+    myLog("serial");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind, n) where tag == iterKind.standalone {
+    myLog("standalone");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind, n) where tag == iterKind.leader {
+    myLog("leader");
+    yield (D,);
+  }
+  iter these(param tag: iterKind, n, followThis) where tag == iterKind.follower {
+    myLog("follower ", followThis);
+    const (followInds,) = followThis;
+    for i in followInds {
+      myLog("follower loop idx ", i);
+      yield elms[i];
+    }
+  }
+}
+class ClassTheseWithDefaultArg {
+  const D: range = 0..10;
+  const elms: [D] int = D*2;
+  iter these(n=1) {
+    myLog("serial");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind, n=1) where tag == iterKind.standalone {
+    myLog("standalone");
+    for i in elms {
+      yield i;
+    }
+  }
+  iter these(param tag: iterKind, n=1) where tag == iterKind.leader {
+    myLog("leader");
+    yield (D,);
+  }
+  iter these(param tag: iterKind, n=1, followThis) where tag == iterKind.follower {
+    myLog("follower ", followThis);
+    const (followInds,) = followThis;
+    for i in followInds {
+      myLog("follower loop idx ", i);
+      yield elms[i];
+    }
+  }
+}
+
+
+proc testNoArg(type T) {
+
+  var r = new T();
+  const D = r.D;
+
+  myLog("for");
+  for e in r {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall");
+  forall e in r {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall zip first");
+  forall (e,i) in zip(r,D) {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall zip second");
+  forall (i,e) in zip(D,r) {
+    myLog(e);
+  }
+
+  myLog("for");
+  for e in r.these() {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall");
+  forall e in r.these() {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall zip first");
+  forall (e,i) in zip(r.these(),D) {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall zip second");
+  forall (i,e) in zip(D,r.these()) {
+    myLog(e);
+  }
+}
+
+proc testArg(type T) {
+  var r = new T();
+  const D = r.D;
+
+  // cannot invoke 'these' implicitly with arguments
+  // myLog("for");
+  // for e in r(17) {
+  //   myLog(e);
+  // }
+  // myLog();
+
+  // myLog("forall");
+  // forall e in r(17) {
+  //   myLog(e);
+  // }
+  // myLog();
+
+  // myLog("forall zip first");
+  // forall (e,i) in zip(r(17),D) {
+  //   myLog(e);
+  // }
+  // myLog();
+
+  // myLog("forall zip second");
+  // forall (i,e) in zip(D,r(17)) {
+  //   myLog(e);
+  // }
+
+  myLog("for");
+  for e in r.these(17) {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall");
+  forall e in r.these(17) {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall zip first");
+  forall (e,i) in zip(r.these(17),D) {
+    myLog(e);
+  }
+  myLog();
+
+  myLog("forall zip second");
+  forall (i,e) in zip(D,r.these(17)) {
+    myLog(e);
+  }
+}
+
+proc main() {
+
+  testNoArg(RecordTheseWithNoArg);
+  testArg(RecordTheseWithArg);
+
+  testNoArg(RecordTheseWithDefaultArg);
+  testArg(RecordTheseWithDefaultArg);
+
+
+
+  testNoArg(ClassTheseWithNoArg);
+  testArg(ClassTheseWithArg);
+
+  testNoArg(ClassTheseWithDefaultArg);
+  testArg(ClassTheseWithDefaultArg);
+}
+

--- a/test/unstable/iterTheseWithArguments.chpl
+++ b/test/unstable/iterTheseWithArguments.chpl
@@ -8,7 +8,7 @@ proc myLog(args...?k) do if verbose then writeln((...args));
 // Records
 //
 record RecordTheseWithNoArg {
-  const D: range = 0..10;
+  const D = 0..10;
   const elms: [D] int = D*2;
   iter these() {
     myLog("serial");
@@ -36,7 +36,7 @@ record RecordTheseWithNoArg {
   }
 }
 record RecordTheseWithArg {
-  const D: range = 0..10;
+  const D = 0..10;
   const elms: [D] int = D*2;
   iter these(n=1) {
     myLog("serial");
@@ -64,7 +64,7 @@ record RecordTheseWithArg {
   }
 }
 record RecordTheseWithDefaultArg {
-  const D: range = 0..10;
+  const D = 0..10;
   const elms: [D] int = D*2;
   iter these(n=1) {
     myLog("serial");
@@ -96,7 +96,7 @@ record RecordTheseWithDefaultArg {
 // Classes
 //
 class ClassTheseWithNoArg {
-  const D: range = 0..10;
+  const D = 0..10;
   const elms: [D] int = D*2;
   iter these() {
     myLog("serial");
@@ -124,7 +124,7 @@ class ClassTheseWithNoArg {
   }
 }
 class ClassTheseWithArg {
-  const D: range = 0..10;
+  const D = 0..10;
   const elms: [D] int = D*2;
   iter these(n=1) {
     myLog("serial");
@@ -152,7 +152,7 @@ class ClassTheseWithArg {
   }
 }
 class ClassTheseWithDefaultArg {
-  const D: range = 0..10;
+  const D = 0..10;
   const elms: [D] int = D*2;
   iter these(n=1) {
     myLog("serial");

--- a/test/unstable/iterTheseWithArguments.good
+++ b/test/unstable/iterTheseWithArguments.good
@@ -1,0 +1,16 @@
+iterTheseWithArguments.chpl:41: warning: defining a serial 'these' iterator that takes arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:69: warning: defining a serial 'these' iterator that takes arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:129: warning: defining a serial 'these' iterator that takes arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:157: warning: defining a serial 'these' iterator that takes arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:47: warning: defining a parallel 'these' standalone iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:53: warning: defining a parallel 'these' leader iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:57: warning: defining a parallel 'these' follower iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:75: warning: defining a parallel 'these' standalone iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:81: warning: defining a parallel 'these' leader iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:85: warning: defining a parallel 'these' follower iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:135: warning: defining a parallel 'these' standalone iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:141: warning: defining a parallel 'these' leader iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:145: warning: defining a parallel 'these' follower iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:163: warning: defining a parallel 'these' standalone iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:169: warning: defining a parallel 'these' leader iterator that takes extra arguments is unstable and may change in the future
+iterTheseWithArguments.chpl:173: warning: defining a parallel 'these' follower iterator that takes extra arguments is unstable and may change in the future


### PR DESCRIPTION
Marks any `iter these` which takes any extra arguments. For serial iterators, this is any argument. For standalone and leader parallel iterators, this is any argument other than `tag`. For follower parallel iterators, this is any argument other than `tag` and `followThis`.

Based on discussion in #23075

## Summary of changes
- add check in `checkResolved` for `iter these` with extra arguments
  - required some extra logic to not warn for internal iterators like for arrays 
- add new test of unstable warning in `test/unstable/iterTheseWithArguments.chpl`

## Testing
- [x] paratest with future
- [x] paratest with gasnet

[Reveiwed by @riftEmber]