### PR TITLE
Yet another fix for a multilocale GPU test

### DIFF
--- a/test/gpu/native/multiLocale/onAllGpusOnAllLocales.chpl
+++ b/test/gpu/native/multiLocale/onAllGpusOnAllLocales.chpl
@@ -26,6 +26,9 @@ stopGpuDiagnostics();
 // Some test conditions to verify that we had the number of kernel launches we
 // expected:
 
+// TODO we do mix of things to confirm correct number of launches across
+// multiple locales here. Unify how we do such checks.
+
 // in order for the test to be meaningful we need to run it on a system that has
 // more than 1 GPU per locale:
 writeln("here.gpus.size > 1:  ", here.gpus.size > 1);
@@ -34,16 +37,28 @@ writeln("here.gpus.size > 1:  ", here.gpus.size > 1);
 var numLaunches = getGpuDiagnostics().kernel_launch;
 writeln("numLaunches.size == Locales.size: ", numLaunches.size == Locales.size);
 
-// We expect the first locale to have 2 more launch than all subsequent locales
-// because of array initializations
-writeln("numLaunches[0] == numLaunches[1] + 2:  ",
-  numLaunches[0] == numLaunches[1] + 2);
+use ChplConfig;
 
-// We expect the second locale to have launches equal to the number of GPUs per
-// node*2 (we're assuming all nodes have an equal number of GPUs), where *2 is
-// for array initialization.
-writeln("numLaunches[1] == here.gpus.size*2:  ",
-        numLaunches[1] == here.gpus.size*2);
+if CHPL_GPU_MEM_STRATEGY == "array_on_device" {
+  // We expect the first locale to have 2 more launch than all subsequent
+  // locales because of the explicit launch + array initializations
+  assert(numLaunches[0] == numLaunches[1] + 2);
+
+  // We expect the second locale to have launches equal to the number of GPUs
+  // per node*2 (we're assuming all nodes have an equal number of GPUs), where
+  // *2 is for array initialization.
+  assert(numLaunches[1] == here.gpus.size*2);
+}
+else {
+  // We expect the first locale to have 1 more launch than all subsequent
+  // locales because of the explicit launch
+  assert(numLaunches[0] == numLaunches[1] + 1);
+
+  // We expect the second locale to have launches equal to the number of GPUs
+  // per node (we're assuming all nodes have an equal number of GPUs)
+  assert(numLaunches[1] == here.gpus.size);
+
+}
 
 // Ensure that for all but the first locale the number of kernel launches
 // on each locale matches

--- a/test/gpu/native/multiLocale/onAllGpusOnAllLocales.good
+++ b/test/gpu/native/multiLocale/onAllGpusOnAllLocales.good
@@ -1,6 +1,4 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 here.gpus.size > 1:  true
 numLaunches.size == Locales.size: true
-numLaunches[0] == numLaunches[1] + 2:  true
-numLaunches[1] == here.gpus.size*2:  true
 numLaunches[i] == numLaunches[i+1] for all i > 0?:  true


### PR DESCRIPTION
This puts a bandaid on a test that does a custom kernel launch number assertion.

I am not a big fan of the solution, but it'll keep us going. Ideally we want to improve our `*Here` story in the GpuDiagnostics module and maybe add an `assertGpuDiags` overload for multilocale runs.