### PR TITLE
Fix bug in which CHPL_UNWIND could not be overridden for non-linux/osx

### DIFF
--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -23,8 +23,10 @@ def get():
                   "\nUse CHPL_UNWIND=system instead.", ValueError)
         elif val == 'system':
             return 'system'
-    return 'none'
-
+    elif val != None:
+        return val;
+    else:
+        return 'none'
 
 @memoize
 def get_uniq_cfg_path():


### PR DESCRIPTION
This fixes a simple logical error that's been in `chpl_unwind.py` since it was first added in which we returned `none` rather than the value inferred from the environment or chplconfig files when running on non-linux/osx platforms.

Resolves #23262.