### PR TITLE
Warn if there's an invalid key in a graph file

### DIFF
--- a/util/test/genGraphs.py
+++ b/util/test/genGraphs.py
@@ -538,6 +538,8 @@ class GraphStuff:
                 graphs[currgraph].numseries = int(rest.strip())
             elif key == 'sort':
                 graphs[currgraph].sort = rest.lower() in ('true', 't', '1', 'on', 'y', 'yes')
+            else:
+                sys.stdout.write('WARNING: Invalid graph file key {0} in {1}\n'.format(key, fullFname))
 
         try:
             graphs[currgraph].generateGraphData(self, currgraph)


### PR DESCRIPTION
Tonight we see failures in nightlies because of `perfKeys` key instead of `perfkeys` in a graph file. This PR generates a warning to help triage the issue.

Improved logging capabilities have been asked in https://github.com/chapel-lang/chapel/issues/9430. This is a small part of that.