### PR TITLE
warn about new behavior in prim comm_get/put

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -114,6 +114,7 @@ struct Visitor {
   void checkExplicitDeinitCalls(const FnCall* node);
   void checkBorrowFromNew(const FnCall* node);
   void checkSparseKeyword(const FnCall* node);
+  void checkPrimCallInUserCode(const PrimCall* node);
   void checkDmappedKeyword(const OpCall* node);
   void checkConstVarNoInit(const Variable* node);
   void checkConfigVar(const Variable* node);
@@ -182,6 +183,7 @@ struct Visitor {
   void visit(const FunctionSignature* node);
   void visit(const Import* node);
   void visit(const OpCall* node);
+  void visit(const PrimCall* node);
   void visit(const Return* node);
   void visit(const TypeQuery* node);
   void visit(const Union* node);
@@ -664,6 +666,17 @@ void Visitor::checkSparseKeyword(const FnCall* node) {
         if (ident->name() == USTR("sparse"))
           warn(node, "sparse domains are unstable,"
                " their behavior is likely to change in the future.");
+}
+
+// TODO: remove this check and warning after 1.34?
+void Visitor::checkPrimCallInUserCode(const PrimCall* node) {
+  if (isUserCode())
+    if (node->prim() == PrimitiveTag::PRIM_CHPL_COMM_GET ||
+        node->prim() == PrimitiveTag::PRIM_CHPL_COMM_PUT)
+          warn(node, "the primitives 'chpl_comm_get' and 'chpl_comm_put',"
+               " have changed behavior in Chapel 1.32. Please use"
+               " the 'Communication' module's 'get' and 'put' procedures"
+               " as replacements for calling the primitives directly");
 }
 
 void Visitor::checkDmappedKeyword(const OpCall* node) {
@@ -1365,6 +1378,11 @@ void Visitor::visit(const FnCall* node) {
   checkExplicitDeinitCalls(node);
   checkBorrowFromNew(node);
   checkSparseKeyword(node);
+
+}
+
+void Visitor::visit(const PrimCall* node) {
+  checkPrimCallInUserCode(node);
 }
 
 void Visitor::visit(const OpCall* node) {

--- a/test/deprecated/chplCommGetPut.chpl
+++ b/test/deprecated/chplCommGetPut.chpl
@@ -1,0 +1,7 @@
+inline proc GET(addr, node, rAddr, size) {
+  __primitive("chpl_comm_get", addr, node, rAddr, size);
+}
+
+inline proc PUT(addr, node, rAddr, size) {
+  __primitive("chpl_comm_put", addr, node, rAddr, size);
+}

--- a/test/deprecated/chplCommGetPut.good
+++ b/test/deprecated/chplCommGetPut.good
@@ -1,0 +1,4 @@
+chplCommGetPut.chpl:1: In function 'GET':
+chplCommGetPut.chpl:2: warning: the primitives 'chpl_comm_get' and 'chpl_comm_put', have changed behavior in Chapel 1.32. Please use the 'Communication' module's 'get' and 'put' procedures as replacements for calling the primitives directly
+chplCommGetPut.chpl:5: In function 'PUT':
+chplCommGetPut.chpl:6: warning: the primitives 'chpl_comm_get' and 'chpl_comm_put', have changed behavior in Chapel 1.32. Please use the 'Communication' module's 'get' and 'put' procedures as replacements for calling the primitives directly

--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -359,10 +359,11 @@ prototype module DistributedFFT {
       Note that both ``dst`` and ``src`` cannot be remote.
   */
   proc copy(ref dst, const ref src, numBytes: int) {
+    use Communication;
     if dst.locale.id == here.id {
-      __primitive("chpl_comm_get", dst, src.locale.id, src, numBytes.safeCast(c_size_t));
+      get(c_ptrTo(dst), c_ptrToConst(src), src.locale.id, numBytes.safeCast(c_size_t));
     } else if src.locale.id == here.id {
-      __primitive("chpl_comm_put", src, dst.locale.id, dst, numBytes.safeCast(c_size_t));
+      put(c_ptrTo(dst), c_ptrToConst(src), dst.locale.id, numBytes.safeCast(c_size_t));
     } else {
       halt("Remote src and remote dst not yet supported");
     }


### PR DESCRIPTION
This PR adds compiler warnings if we encounter the primitive calls `chpl_comm_get` or `chpl_comm_put` in user code. 

In PRs #22884 and #22622 we changed the behavior of the primitives `chpl_comm_get` and `chpl_comm_put` to expect references instead of `c_ptr`s, a breaking change for places that were previously passing `c_ptr` directly. Because it only affected the primitive calls (which are not intended to be user facing), we deprecated without replacement or warning. 

Since then, we have received at least one user report of test failures due to the change. Out of an abundance of caution we decided it would be good to add a compiler warning about the changed behavior when these primitives are found in user code.

TESTING:

- [x] paratest `[Summary: #Successes = 16810 | #Failures = 0 | #Futures = 917]`
- [x] gasnet paratest `[Summary: #Successes = 16990 | #Failures = 0 | #Futures = 926]`

[reviewed by @mppf - thanks!]
