### PR TITLE
Modify the stdin/stdout/stderr documentation to avoid referencing file descs

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -9591,18 +9591,18 @@ record itemReaderInternal {
 
 // And now, the toplevel items.
 
-/* A :record:`fileReader` instance that reads from standard input. */
+/* A locking :record:`fileReader` instance that reads from standard input. */
 const stdin:fileReader(true);
 stdin = try! (new file(0)).reader();
 
 extern proc chpl_cstdout():chpl_cFilePtr;
-/* A :record:`fileWriter` instance that writes to standard output. */
+/* A locking :record:`fileWriter` instance that writes to standard output. */
 const stdout:fileWriter(true);
 stdout = try! (new file(chpl_cstdout())).writer();
 
 
 extern proc chpl_cstderr():chpl_cFilePtr;
-/* A :record:`fileWriter` instance that writes to standard error. */
+/* A locking :record:`fileWriter` instance that writes to standard error. */
 const stderr:fileWriter(true);
 stderr = try! (new file(chpl_cstderr())).writer();
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -9591,18 +9591,18 @@ record itemReaderInternal {
 
 // And now, the toplevel items.
 
-/* standard input, otherwise known as file descriptor 0 */
+/* A :record:`fileReader` instance that reads from standard input. */
 const stdin:fileReader(true);
 stdin = try! (new file(0)).reader();
 
 extern proc chpl_cstdout():chpl_cFilePtr;
-/* standard output, otherwise known as file descriptor 1 */
+/* A :record:`fileWriter` instance that writes to standard output. */
 const stdout:fileWriter(true);
 stdout = try! (new file(chpl_cstdout())).writer();
 
 
 extern proc chpl_cstderr():chpl_cFilePtr;
-/* standard error, otherwise known as file descriptor 2 */
+/* A :record:`fileWriter` instance that writes to standard error. */
 const stderr:fileWriter(true);
 stderr = try! (new file(chpl_cstderr())).writer();
 


### PR DESCRIPTION
Resolves #20253 

File descriptors should be considered implementation details in Chapel, so we should avoid referencing them in the documentation for these variables

Double checked the built docs and their links worked as expected