### PR TITLE
Restrict ChapelIO usage in IO module

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -538,7 +538,7 @@ import OS.{errorCode};
 use CTypes;
 public use OS;
 private use Reflection;
-public use ChapelIO;
+public use ChapelIO only write, writeln, writef; 
 
 /*
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -538,7 +538,7 @@ import OS.{errorCode};
 use CTypes;
 public use OS;
 private use Reflection;
-public use ChapelIO only write, writeln, writef; 
+public use ChapelIO only write, writeln, writef;
 
 /*
 

--- a/test/modules/bradc/userInsteadOfStandard/ChapelIO.chpl
+++ b/test/modules/bradc/userInsteadOfStandard/ChapelIO.chpl
@@ -23,6 +23,12 @@ use IO;
     try! stdout.writeln();
   }
 
+  proc writef(fmt:?t, const args ...?k)
+    where isStringType(t) || isBytesType(t)
+  {
+    try! { stdout.writef(fmt, (...args)); }
+  }
+
   //
   // Used by the compiler to support the compiler-generated initializers that
   // accept a 'fileReader'. The type 'fileReader' may not be readily


### PR DESCRIPTION
For what is suspected to be recursive usage of the module, Arkouda was failing with a bus error due to the `public use ChapelIO` in `IO.chpl`. Limiting that use resovles the issue.

Code changes from @lydia-duncan 