### PR TITLE
Remove lustre from the Aux filesystem list for config builds

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -132,7 +132,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         launchers=none,pals,slurm-srun
         substrates=none
         locale_models=flat
-        auxfs=none,lustre
+        auxfs=none
         libpics=none,pic
 
         log_info "Start build_configs $dry_run $verbose # no make target"

--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -131,7 +131,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         launchers=aprun,none,slurm-srun
         substrates=aries,mpi,none
         locale_models=flat
-        auxfs=none,lustre
+        auxfs=none
 
         log_info "Start build_configs $dry_run $verbose # no make target"
 

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -136,7 +136,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         launchers=pbs-aprun,aprun,none,slurm-srun
         substrates=aries,none
         locale_models=flat
-        auxfs=none,lustre
+        auxfs=none
         libpics=none,pic
 
         log_info "Start build_configs $dry_run $verbose # no make target"


### PR DESCRIPTION
This PR removes the automatic building of the lustre auxfs for the Chapel
runtime module builds.   This change should reduce the time for running
the builds. 