### PR TITLE
Fix a Python logic bug I introduced in #23270

### DIFF
--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -23,8 +23,8 @@ def get():
                   "\nUse CHPL_UNWIND=system instead.", ValueError)
         elif val == 'system':
             return 'system'
-    elif val != None:
-        return val;
+    if val:
+        return val
     else:
         return 'none'
 


### PR DESCRIPTION
Although #23270 fixed the behavior of the chpl_unwind.py script for non-osx/linux systems, I accidentally broke it for osx/linux systems that did not have an explicit setting made by removing the fall-through logic that defaulted it to 'none', causing the script to return 'None' when none of the other options were hit.  More proof that I should never write Python scripts.

This fixes the error by moving the val or 'none' conditional that I added last night out a level so that it's always used when none of the other cases trigger.  Thanks to @jabraham17 for pointing out the error in my control flow and improving my style to boot.
