### PR TITLE
Pin ofi fi_getinfo API version to 1.9

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -102,11 +102,11 @@ int chpl_comm_ofi_abort_on_error;
 //
 
 //
-// This is used to check that the libfabric version the runtime is
-// linked with in a user program is the same one it was compiled
-// against.
+// This is used as the API version to request in fi_getinfo(). We don't support
+// versions older than this and requesting an older version allows using
+// different versions at build and user compile time.
 //
-#define COMM_OFI_FI_VERSION FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
+#define COMM_OFI_FI_VERSION FI_VERSION(1, 9)
 
 
 ////////////////////////////////////////


### PR DESCRIPTION
Previously, we pinned the ofi API version used in `fi_getinfo()` to whatever version we built the runtime with. However, the docs explicitly recommend against this and suggest hard-coding values.

From [`fi_getinfo()`](https://ofiwg.github.io/libfabric/v1.9.1/man/fi_getinfo.3.html)man pages:

> The version parameter is used by the application to request the desired version of the interfaces. The version determines the format of all data structures used by any of the fabric interfaces. Applications should use the FI_VERSION(major, minor) macro to indicate the version, with hard-coded integer values for the major and minor values. The FI_MAJOR_VERSION and FI_MINOR_VERSION enum values defined in fabric.h specify the latest version of the installed library. However, it is recommended that the integer values for FI_MAJOR_VERSION and FI_MINOR_VERSION be used, rather than referencing the enum types in order to ensure compatibility with future versions of the library. This protects against the application being built from source against a newer version of the library that introduces new fields to data structures, which would not be initialized by the application.

Here we decided to use the 1.9 API just to match a version GASNet uses. We probably don't need anything older than 1.12 for SS-10 systems, but I don't think there's any harm in going to 1.9

This effectively reverts 7337a3124c. While I'm always hesitant to revert a Greg commit, the docs are pretty clear and this matches what gasnet and MPI vendors do.

Resolves Cray/chapel-private#5384