### PR TITLE
CHANGES.md for Chapel 1.32

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,23 +1,6 @@
 Release Changes List
 ====================
 
-* check sorting of categories
-* check placement of items into categories
-* check for ' vs `
-* fulfill TODOs
-* check man page
-* check test/release/examples
-* check for docs/1.32/ links
-* check forced linebreaks
-o check links
-* check initial '*'
-* check initial 'A-Z'
-* check 'see:'
-* check for double linefeeds
-* check for changes put too far down in file
-* add highlights
-o spellcheck
-
 
 version 1.32.0
 ==============
@@ -63,7 +46,7 @@ Language Feature Improvements
   (e.g., `var A: [1..3] int = 1..3; writeln(A[..2 by 2]);` prints 1)
 * casts between ranges now check the validity of the stride  
   (see https://chapel-lang.org/docs/1.32/language/spec/conversions.html#explicit-range-conversions)
-* enabled assigning and initilizing integral ranges from bool ranges  
+* enabled assigning and initializing integral ranges from bool ranges  
   (e.g., `var r: range(int(8)) = false..true;` is now supported)
 * added a compiler warning when range slicing might halt execution  
   (e.g., `var r1 = 1.. by 2, r2 = 2.. by 2; writeln(r1[r2]);`)
@@ -701,7 +684,7 @@ Bug Fixes
   (e.g., `var d: domain(?) = {1..5}` now works)
 * fixed incorrect scoping of variables in `do`...`while` loops' conditions
 * fixed a bug in which FCPs printed incorrectly with JSON serializers
-* fiexd a bug in which unstable warnings were generated when using `_`
+* fixed a bug in which unstable warnings were generated when using `_`
 * fixed `fifo` guard pages when using `CHPL_MEM=jemalloc` on arm-based macs
 * fixed a bug when using array type expression actuals within loop bodies
 * removed extra borrow when casting from a managed class to an unmanaged class
@@ -758,7 +741,7 @@ Developer-oriented changes: Compiler Flags
 
 Developer-oriented changes: Compiler improvements / changes
 -----------------------------------------------------------
-* added protypical support for LLVM 16
+* added prototypical support for LLVM 16
 * added an experimental driver mode, enabled using `--compiler-driver`  
   (see https://chapel-lang.org/docs/1.32/technotes/driver.html)
 * improved `@deprecated` to handle deprecations from paren-ful to paren-less

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,6 +113,7 @@ Semantic Changes / Changes to the Chapel Language
 
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
+
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
 * marked associative and sparse domains as unstable
 * marked the `dmap` type and `dmapped` keyword as unstable
@@ -141,6 +142,10 @@ Deprecated / Unstable / Removed Language Features
 * marked the `[string|bytes].createBorrowingBuffer` factory method unstable  
   (see https://chapel-lang.org/docs/1.32/language/spec/strings.html#String.string.createBorrowingBuffer  
   and https://chapel-lang.org/docs/1.32/language/spec/bytes.html#Bytes.bytes.createBorrowingBuffer)
+* marked `.localize()` on `string` and `bytes` as being unstable
+* marked `umask()` on `locale` as being unstable
+* deprecated the `c_string` type in favor of `c_ptrConst(c_char)`
+  (see https://chapel-lang.org/docs/1.32/language/evolution.html#c-string-deprecation)
 * deprecated implicit conversions for formals with generic numeric types  
   (e.g., given `proc f(r: real(?w)) {}`, `f(1)` will not compile in the future)
 * deprecated `single` variables
@@ -167,6 +172,9 @@ Namespace Changes
 -----------------
 * moved several automatically-included math symbols from 'AutoMath' to 'Math'
   (e.g., `div[ceil|floor][pos]()`, `nearbyint()`, `rint()`)
+* moved `string.c_str()` and `bytes.c_str()` to `CTypes`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str
+   and https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.bytes.c_str)
 * upgraded `Json` from a package to a standard module, now named `JSON`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/JSON.html)
 * renamed `Yaml` module to `YAML`  
@@ -523,6 +531,7 @@ Language Specification Improvements
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html)
 * added a link between the `%` documentation and `AutoMath.mod()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/expressions.html#modulus-operators)
+* added links to the types discussed in `string` and `bytes` documentation 
 
 Other Documentation Improvements
 --------------------------------
@@ -530,6 +539,8 @@ Other Documentation Improvements
   (see https://chapel-lang.org/docs/1.32/technotes/firstClassProcedures.html)
 * replaced uses of `dmapped` with factory methods throughout the docs  
   (see TODO)
+* added a warning that the result of `.c_str()` may contain mid-buffer NULLs  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
 * added a new section about I/O transactions to the 'IO' module  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#i-o-transactions)
 * improved the clarity of the documentation of `mark()`/`commit()`/`revert()`  
@@ -567,6 +578,7 @@ Other Documentation Improvements
      and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.expm1)
 * refactored and expanded `BigInteger` documentation to be more comprehensive
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html)
+* added a note that `chown()` requires elevated privileges to be successful
 * refactored documentation for `DynamicIters.Method`, and `Subprocess.pipeStyle`
   (see https://chapel-lang.org/docs/1.32/modules/standard/DynamicIters.html#DynamicIters.Method
   and https://chapel-lang.org/docs/1.32/modules/standard/Subprocess.html#Subprocess.pipeStyle)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ Configuration / Build / Packaging Changes
 
 New Language Features
 ---------------------
+* added support for an array creation interface that throws if out of memory  
+  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.tryCreateArray)
 
 Language Feature Improvements
 -----------------------------
@@ -21,6 +23,9 @@ Language Feature Improvements
 
 Syntactic / Naming Changes
 --------------------------
+* renamed `[enter|leave]This()` to `[enter|exit]Context()` for context mgmt  
+  (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement)
+
 
 Semantic Changes / Changes to the Chapel Language
 -------------------------------------------------
@@ -38,6 +43,8 @@ Namespace Changes
 
 Standard Library Modules
 ------------------------
+* added support for casting `bool` values to `bigint`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
 
 Package Modules
 ---------------
@@ -58,6 +65,8 @@ Changes / Feature Improvements in Libraries
 
 Name Changes in Libraries
 -------------------------
+* renamed `map.addOrSet()` to `map.addOrReplace()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.addOrReplace)
 
 Deprecated / Unstable / Removed Library Features
 ------------------------------------------------
@@ -87,6 +96,7 @@ Language Specification Improvements
 
 Other Documentation Improvements
 --------------------------------
+* fixed warnings in 'Map' that incorrectly referred to the `set` type
 
 Example Codes
 -------------
@@ -119,6 +129,7 @@ Error Messages / Semantic Checks
 Bug Fixes
 ---------
 * fixed a bug in which `CHPL_UNWIND` could not be overridden on some platforms
+* fixed a bug in which FCPs printed incorrectly with JSON serializers
 
 Bug Fixes for Build Issues
 --------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,11 +17,16 @@ Configuration / Build / Packaging Changes
 
 New Language Features
 ---------------------
+* added explicit `out` return and yield intents
+  (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-out-return-intent  
+   and https://chapel-lang.org/docs/1.32/language/spec/iterators.html#the-yield-statement)
 * added a user-facing task yield mechanism, `currentTask.yieldExecution()`
   (see https://chapel-lang.org/docs/1.32/language/spec/task-parallelism-and-synchronization.html#yielding-task-execution)
 * added support for declaring that records/classes fulfill a given interface  
   (e.g., `record r: i { ... }` says that `r` implements the `i` interface;  
    see TODO)
+* added `range.tryCast()` to support throwing range casts  
+  (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#ChapelRange.range.tryCast)
 * added support for an array creation interface that throws if out of memory  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.tryCreateArray)
 * added support for applying attributes to loops
@@ -30,15 +35,27 @@ Language Feature Improvements
 -----------------------------
 * added new routines to create multidimensional arrays from C pointers
   (see TODO)
+* casts between ranges now check the validity of the stride  
+  (see https://chapel-lang.org/docs/1.32/language/spec/conversions.html#explicit-range-conversions)
+* added a compiler warning when range slicing might halt execution
+  (e.g., `var r1 = 1.. by 2, r2 = 2.. by 2; writeln(r1[r2]);`)
+* added support for slicing arrays with unaligned ranges
+  (e.g., `var A: [1..3] int = 1..3; writeln(A[..2 by 2]);` prints 1)
+* enabled assigning and initilizing integral ranges from bool ranges  
+  (e.g., `var r: range(int(8)) = false..true;` is now supported)
 * improved handling of intents on array formals in extern functions
 * added promoted casts from array-of-`T` to `T` without a cast from `T` to `T`
 * first-class procedures are now printed similarly to Chapel's syntax
 * added support for a new `bulkAddNoPreserveInds()` method to sparse domains  
-  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html?highlight=bulkadd#ChapelDomain.bulkAddNoPreserveInds)
+  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.bulkAddNoPreserveInds)
 * improved support for casts in formal argument type expressions
 
 Syntactic / Naming Changes
 --------------------------
+* renamed `range.aligned` to `range.isAligned()`
+  (see https://chapel-lang.org/docs/main/language/spec/ranges.html#ChapelRange.range.isAligned)
+* renamed `domain.dist` to `domain.distribution`
+  (see https://chapel-lang.org/docs/main/language/spec/domains.html%20distribution#ChapelDomain.distribution)
 * added a warning when inheriting from a generic class if `(?)` is not used  
   (e.g., `class C: D` must now be written `class C: D(?)` for generic `D`)
 * added warnings for non-fully-defaulted generic types lacking `(?)` when:
@@ -63,10 +80,17 @@ Semantic Changes / Changes to the Chapel Language
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
 * began changing the default receiver intent for records to `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
+* began changing the type of range literals with mixed-type param bounds  
+  (e.g., `0..1:int(8)` is changing from `idxType=int(8)` to `int(64)`)
+* added an error for addition/subtraction of multi-dim. domains and `[u]int`s  
+  (e.g., `{1..2, 1..2} - 1` is now an error)
 * built-in hashing now relies on the `hashable` interface
   (see TODO)
 * context managers now rely on the `contextManager` interface
   (see TODO)
+* `return` statements following a `throw` or `halt()` are now ignored  
+  (see https://chapel-lang.org/docs/1.32/language/spec/error-handling.html#throwing-errors  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.halt)
 * adjusted the deinit point for nested call expressions in `var`/`const` decls
   (see https://chapel-lang.org/docs/1.32/language/spec/variables.html#deinit-points)
 * a call that could refer to a method or a non-method is now an ambiguity
@@ -90,34 +114,54 @@ Semantic Changes / Changes to the Chapel Language
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
+* marked associative and sparse domains as unstable
+* marked the `dmap` type and `dmapped` keyword as unstable
 * marked `scan` unstable due to uncertainty about inclusive/exclusive choice
-* deprecated implicit conversions for formals with generic numeric types  
-  (e.g., given `proc f(r: real(?w)) {}`, `f(1)` will not compile in the future)
+* marked all `.safeCast()` methods unstable
+* marked binary operators between tuples and scalars as unstable
+* marked several binary operators over ranges and integral values as unstable
+  (e.g., `(1..3)*(1..5)` and `(1..3) + 1` are now unstable
+* marked first/last/empty queries on unbounded ranges of bool/enum unstable
+  (e.g., `(false..).last` is now unstable)
+* marked `==` and `!=` between unbounded ranges of bool/enum unstable
+  (e.g., `(false..true) == (false..)` is now `true` and unstable)
+* marked transformational methods on ranges and domains unstable  
+  (e.g., `.translate()`, `.interior()`, `exterior()`, `.expand()`)
+* marked `.orderToIndex()` on domains as unstable
+* marked `.offset()` and `.indexOrder()` on ranges as unstable
+* marked `.hasSingleLocalSubdomain()` and `.localSubdomains()` as unstable
 * marked `compareAndSwap()` on `atomic` variables as unstable
 * marked `sync.[readXX|writeFF|writeXF|reset|isFull]()` unstable
 * marked explicit calls to `this()` methods as unstable
 * marked serial `these()` iterators taking arguments as unstable
 * marked default initialization of low- and high-bounded ranges as unstable
   (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#default-values)
+* marked most built-in `config` constants and params as unstable
 * marked `extern` procedures with array arguments as unstable  
 * marked the `[string|bytes].createBorrowingBuffer` factory method unstable  
   (see https://chapel-lang.org/docs/1.32/language/spec/strings.html#String.string.createBorrowingBuffer  
   and https://chapel-lang.org/docs/1.32/language/spec/bytes.html#Bytes.bytes.createBorrowingBuffer)
+* deprecated implicit conversions for formals with generic numeric types  
+  (e.g., given `proc f(r: real(?w)) {}`, `f(1)` will not compile in the future)
 * deprecated `single` variables
 * deprecated returning `sync`, `single`, or `atomic` by value
 * deprecated relying on default initializers for `sync`, `single`, and `atomic`
 * deprecated the `owned.borrow` type method
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#OwnedObject.owned.borrow)
+* deprecated assignment between unbounded ranges of incompatible `idxtype`
+* deprecated `range.isAmbiguous()` in favor of `!range.isAligned()`
+* deprecated `range.isNaturallyAligned()` and `range.boundsCheck()`
 * deprecated the `.intIdxType` query on ranges, domains, and arrays  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.intIdxType)
 * deprecated the default cast from arrays to `string`
 * deprecated the `useNewArrayFind` config param
+* removed the previously deprecated casts from `string` and `bytes` to `regex`
 * removed support for the deprecated array `.find()` overload
 * removed support for variable-width `bool` types and related queries
 * made importing tertiary methods by naming their type unstable  
   (e.g., `import IO.string;` is no longer stable)
 * removed the `preserveInds` argument to `bulkAdd` on sparse domains  
-  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html?highlight=bulkadd#ChapelDomain.bulkAdd)
+  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.bulkAdd)
 
 Namespace Changes
 -----------------
@@ -166,6 +210,8 @@ Standard Domain Maps (Layouts and Distributions)
   and https://chapel-lang.org/docs/1.32/modules/dists/StencilDist.html#StencilDist.stencilDist.createDomain)
 * marked advanced initializer arguments in `blockDist`/`cyclicDist` unstable  
   (see TODO)
+* disallowed oversubscription in `cyclicDist` and `stencilDist`
+  (e.g., `var c = new cyclicDist(1, [here, here]);` reports an error)
 
 Changes / Feature Improvements in Libraries
 -------------------------------------------
@@ -188,6 +234,10 @@ Changes / Feature Improvements in Libraries
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
 * extended `Math.gcd()` support to include overloads for all integral types  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.gcd)
+* indexing into a `map` with default-initializable values no longer throws  
+  (e.g., `var m = new map(int, int); m[5] = 6;` will not throw errors)
+* `map.values()` is now available for maps with non-nilable `owned` values  
+  (e.g., `var m = new map(int, owned MyClass); for v in m.values() do ...`)
 * made `chpl_library_init()` issue an error if called twice
 * made `chpl_library_finalize()` no longer exit, permitting client to continue
 
@@ -455,6 +505,8 @@ Memory Improvements
 Tool Improvements
 -----------------
 * made `c2chapel` generate `c_ptr[Const]`s for multidimensional arrays
+* `printchplenv` now prints `CHPL_GPU` by default when `CHPL_LOCALE_MODEL=gpu`
+* made `printchplenv` error when using `CHPL_GPU=cpu` and `CHPL_TASKS=fifo`
 * added `:enum[constant]:` to the list of 'chpldoc'-supported inline markup  
   (see https://chapel-lang.org/docs/1.32/tools/chpldoc/chpldoc.html#inline-markup-2)
 
@@ -596,6 +648,8 @@ Bug Fixes for Build Issues
 
 Bug Fixes for GPU Computing
 ---------------------------
+* fixed a bug in which GPU atomic routines returned the wrong values  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/GPU.html?#GPU.gpuAtomicAdd)
 * fixed a bug when accessing `ref`s declared outside of a GPU-eligible loop
 * fixed a bug with `.locale` queries on AMD GPUs or when `--fast` was used
 * fixed an assertion when running GPU programs for AMD w/ `CHPL_DEVELOPER` set
@@ -698,6 +752,8 @@ Developer-oriented changes: Tool Improvements
 
 Developer-oriented changes: Utilities
 -------------------------------------
+* added a utility for batch replacement guided by errors reported by paratest
+  (see https://github.com/chapel-lang/chapel/tree/release/1.32/util/devel/deprecationScript)
 
 
 version 1.31.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,15 @@ Language Feature Improvements
 
 Syntactic / Naming Changes
 --------------------------
+* added a warning when inheriting from a generic class if `(?)` is not used  
+  (e.g., `class C: D` must now be written `class C: D(?)` for generic `D`)
+* added warnings for non-fully-defaulted generic types lacking `(?)` when:
+  - declaring fields or variables
+  - declaring formal arguments
+  - declaring the return type of a routine
+  (e.g., `var t: T;` should be written `var t: T(?);` if `T` is such a type)
+* added a warning for type signatures like 'T()' if 'T' is not fully defaulted
+* added a warning for fields with generic class management to avoid confusion
 * replaced `[this.]complete();` with `init this;` when defining initializers
   (see TODO)
 * `these` is now reserved as a keyword for use as the default iterator method  
@@ -58,11 +67,32 @@ Semantic Changes / Changes to the Chapel Language
   (see TODO)
 * context managers now rely on the `contextManager` interface
   (see TODO)
+* adjusted the deinit point for nested call expressions in `var`/`const` decls
+  (see https://chapel-lang.org/docs/1.32/language/spec/variables.html#deinit-points)
+* a call that could refer to a method or a non-method is now an ambiguity
+  (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#determining-most-specific-functions)
+* methods are no longer included in the more-visible disambiguation check
+  (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#determining-most-specific-functions)
+* declaring a paren-less method with the same name as a field is now an error  
+  (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#methods-without-parentheses)
+* removed some capabilities from records with generic `var`/`const` fields  
+  (e.g., 'record R { var x; }' or 'record S { var y: integral; }')
+  - variables of such types can no longer be default-initialized
+  - type signatures w/ named arguments are no longer supported (`R(x=int)`)  
+    (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fields-without-types)
+* split initialization is now allowed into a `sync` block  
+  (see https://chapel-lang.org/docs/1.32/language/spec/variables.html#split-initialization)
+* numeric `param`s can now be passed to `const ref` formals
+  (e.g. given `proc f(const ref arg)`, `f(1)` is now supported)
+* l-value checking now applies to nested call expressions returning arrays
+  (e.g., 'modifyArray(returnsArray)' will now emit an l-value error)
 
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
 * marked `scan` unstable due to uncertainty about inclusive/exclusive choice
+* deprecated implicit conversions for formals with generic numeric types  
+  (e.g., given `proc f(r: real(?w)) {}`, `f(1)` will not compile in the future)
 * marked `compareAndSwap()` on `atomic` variables as unstable
 * marked `sync.[readXX|writeFF|writeXF|reset|isFull]()` unstable
 * marked explicit calls to `this()` methods as unstable
@@ -417,6 +447,7 @@ Compilation-Time / Generated Code Improvements
 
 Memory Improvements
 -------------------
+* fixed a sporadic memory leak in the 'Futures' package module
 
 Tool Improvements
 -----------------
@@ -519,6 +550,8 @@ Compiler Improvements
 ---------------------
 * added `@llvm.assertVectorized` and `@llvm.metadata` as attributes on loops  
   (see TODO)
+* stopped applying `-Wall` and `Werror` when compiling `extern` blocks
+* improved the behavior of `--mllvm` when it is passed an unknown flag
 
 Compiler Flags
 --------------
@@ -534,6 +567,7 @@ Launchers
 
 Error Messages / Semantic Checks
 --------------------------------
+* shortened paths displayed in some error messages with `$CHPL_HOME`
 * simplified error formatting when compiling C code within an `extern` block
 * improved errors when calling `Reflection.getFieldRef()` on an internal type  
 * fixed incorrect underlining of string literals in detailed error messages
@@ -612,9 +646,12 @@ Developer-oriented changes: Compiler Flags
 
 Developer-oriented changes: Compiler improvements / changes
 -----------------------------------------------------------
+* added protypical support for LLVM 16
 * added an experimental driver mode, enabled using `--compiler-driver`  
   (see TODO)
 * improved `@deprecated` to handle deprecations from paren-ful to paren-less
+* stopped generating LLVM lifetime and invariant hints
+* put and get primitives now assume a `ref` / `const ref` is passed to them
 
 Developer-oriented changes: 'dyno' Compiler improvements / changes
 ------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,13 +20,18 @@ New Language Features
    see TODO)
 * added support for an array creation interface that throws if out of memory  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.tryCreateArray)
+* added support for applying attributes to loops
 
 Language Feature Improvements
 -----------------------------
 * added new routines to create multidimensional arrays from C pointers
   (see TODO)
+* improved handling of intents on array formals in extern functions
 * added promoted casts from array-of-`T` to `T` without a cast from `T` to `T`
 * first-class procedures are now printed similarly to Chapel's syntax
+* added support for a new `bulkAddNoPreserveInds()` method to sparse domains  
+  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html?highlight=bulkadd#ChapelDomain.bulkAddNoPreserveInds)
+* improved support for casts in formal argument type expressions
 
 Syntactic / Naming Changes
 --------------------------
@@ -40,6 +45,10 @@ Syntactic / Naming Changes
 
 Semantic Changes / Changes to the Chapel Language
 -------------------------------------------------
+* began changing the default argument/task intent for arrays to `const`  
+  (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
+* began changing the default receiver intent for records to `const`  
+  (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
 * built-in hashing now relies on the `hashable` interface
   (see TODO)
 * context managers now rely on the `contextManager` interface
@@ -49,8 +58,18 @@ Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
 * marked `scan` unstable due to uncertainty about inclusive/exclusive choice
+* marked explicit calls to `this()` methods as unstable
+* marked serial `these()` iterators taking arguments as unstable
 * marked default initialization of low- and high-bounded ranges as unstable
   (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#default-values)
+* marked `extern` procedures with array arguments as unstable  
+* marked the `[string|bytes].createBorrowingBuffer` factory method unstable  
+  (see https://chapel-lang.org/docs/1.32/language/spec/strings.html#String.string.createBorrowingBuffer  
+  and https://chapel-lang.org/docs/1.32/language/spec/bytes.html#Bytes.bytes.createBorrowingBuffer)
+* deprecated returning `sync`, `single`, or `atomic` by value
+* deprecated relying on default initializers for `sync`, `single`, and `atomic`
+* deprecated the `owned.borrow` type method
+  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#OwnedObject.owned.borrow)
 * deprecated the `.intIdxType` query on ranges, domains, and arrays  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.intIdxType)
 * deprecated the default cast from arrays to `string`
@@ -59,6 +78,8 @@ Deprecated / Unstable / Removed Language Features
 * removed support for variable-width `bool` types and related queries
 * made importing tertiary methods by naming their type unstable  
   (e.g., `import IO.string;` is no longer stable)
+* removed the `preserveInds` argument to `bulkAdd` on sparse domains  
+  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html?highlight=bulkadd#ChapelDomain.bulkAdd)
 
 Namespace Changes
 -----------------
@@ -71,6 +92,7 @@ Namespace Changes
 
 Standard Library Modules
 ------------------------
+* marked the 'Random', 'CommDiagnostics', and 'Communication' modules unstable
 * added `binarySerializer` and `binaryDeserializer` types to the 'IO' module
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binarySerializer
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binaryDeserializer)
@@ -85,12 +107,15 @@ Standard Library Modules
 
 Package Modules
 ---------------
+* marked all package modules as being unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/packages.html)
 * added `isEye` and `isZero()` routines to the 'LinearAlgebra' package module  
   (see https://chapel-lang.org/docs/1.32/modules/packages/LinearAlgebra.html#LinearAlgebra.isEye  
    and https://chapel-lang.org/docs/1.32/modules/packages/LinearAlgebra.html#LinearAlgebra.isZero)
 
 Standard Domain Maps (Layouts and Distributions)
 ------------------------------------------------
+* marked all domain maps other than `blockDist` and `cyclicDist` as unstable
 * converted standard distributions into records, removing the need for `dmap`  
   (e.g., see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html  
    and https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html)
@@ -160,6 +185,42 @@ Name Changes in 'Math'-related Libraries
 * renamed `Math.ln_2` to `Math.ln2` and `Math.ln_10` to `Math.ln10`
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ln2)
 
+Name Changes in the 'BigInteger' module
+---------------------------------------
+* generally unified argument names in these routines to 'x', 'y', ...
+* renamed the enum `round` to `roundingMode`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.roundingMode)
+* renamed `[set|tst|com|clr]bit()` to `[set|get|toggle|clear]Bit()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.bigint.setBit)
+* renamed `divQ()`/`divR()`/`divQR()` to `div()`/`rem()`/`divRem()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.divQ)
+* renamed `divexact()` to `divExact()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.divExact)
+* renamed `scan[0|1]()` to `findNext[0|1]()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.bigint.findNext0)
+* renamed `popcount()` to `popCount()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.bigint.popCount)
+* renamed `ior()` to `or()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.or)
+* renamed `[root|sqrt]rem()` to `[root|sqrt]Rem()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.rootRem
+  and https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.sqrtRem)
+* renamed `[add|sub]mul()` to `[add|sub]Mul()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.addMul
+  and https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.subMul)
+* renamed `hamdist()` to the now unstable `hammingDistance()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.bigint.hammingDistance)
+* renamed `nextprime()` to the now unstable `nextPrime()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.nextPrime)
+* renamed `lucnum[2]()` to the now unstable `lucNum[2]()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.lucNum)
+* renamed `mul_2exp()` to the now unstable `mul2Exp()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.mul2Exp)
+* renamed `divQ2Exp()` to the now unstable `div2Exp()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.div2Exp)
+* renamed `divR2Exp()` to the now unstable `rem2Exp()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.rem2Exp)
+
 Name Changes in Libraries
 -------------------------
 * renamed all serializer/deserializer types to use camelCasing  
@@ -216,6 +277,9 @@ Deprecated / Unstable / Removed 'IO'-related Library Features
 * removed the deprecated `.seek()` method overloads on `file[Reader|Writer]`
 * removed deprecated `%<` and `%>` format specifiers for designating endianness
 * removed the deprecated overload of `file.path` that provided a relative path
+* removed the deprecated `openMemFile()` and `[read|write]Bits()` procedures
+* removed the deprecated `openreader()` and `openwriter()` procedures
+* removed the deprecated types `iomode`, `ioBits`, and `ioChar`
 
 Deprecated / Unstable / Removed 'Math'-related Library Features
 ---------------------------------------------------------------
@@ -289,6 +353,11 @@ Deprecated / Unstable / Removed Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
 * marked `Reflection.getRoutineName()` unstable within first-class procedures
 * deprecated the transitional `BigInteger.bigintInitThrows` config param
+* deprecated `BigInteger.get_str()` in favor of a cast to `string`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
+* marked several 'BigInteger' procedures as unstable
+  (i.e., `jacobi()`, `legendre()`, `kronecker()`, `gcd()`, `lcm()`, `fac()`,
+   `bin()`, `fib()`, `fib2()`, `probablyPrime()`)
 * removed the deprecated `BigInteger.Round` enum
 * removed the deprecated `bigint` initializers that halted/returned error codes
 * removed the deprecated `bigint.mpzStruct()` method
@@ -297,6 +366,10 @@ Deprecated / Unstable / Removed Library Features
 * removed the deprecated `bigint.powm()` method
 * removed the deprecated `bigint.sizeinbase()` and `.size()` methods
 * removed the deprecated `bigint.get_d_2exp()` method
+* removed several deprecated procedures from 'BigInteger'
+  (i.e., `scan0())`, `scan1()`, `divexact()`, qcdext()`, `probab_prime_p()`,
+   `divisible_[2xp_]p()`, `congruent_[2exp_]p()`, `div_r()`, `div_qr()`,
+   `div_[q|r]_2exp()`)
 * removed deprecated `c_sizeof()` signature with formal name `x`
 * removed a `regex.matches()` overload with deprecated arguments
 * removed the deprecated `regex.compile()` type method
@@ -343,6 +416,13 @@ Language Specification Improvements
 -----------------------------------
 * documented the `require` statement  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-require-statement)
+* simplified the explanation of default intents
+  (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
+* adjusted the default type of `owned` and `shared` to be `const`  (TODO: ???)
+  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#owned-default-intent
+  and https://chapel-lang.org/docs/1.32/language/spec/classes.html#shared-default-intent)
+* reformatted the classes section to hide implementation details
+  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html)
 * added a link between the `%` documentation and `AutoMath.mod()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/expressions.html#modulus-operators)
 
@@ -364,6 +444,11 @@ Other Documentation Improvements
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#locking-behavior-of-filereaders-and-filewriters)
 * removed references to file descriptors in `stdin`/`stdout`/`stderr` docs  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.stdin)
+* refactored documentation for `IO.ioMode` and `IO.ioendian`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioMode
+  and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioendian)
+* refactored `where` clauses in `IO` to improve the generated documentation
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html)
 * improved several aspects of the 'Math' module documentation:
   - added missing documentation for arguments of `AutoMath.isClose()`  
     (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
@@ -380,6 +465,13 @@ Other Documentation Improvements
   - added a link between `Math.exp()`/`Math.expm1()` and `Math.e`  
     (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.exp  
      and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.expm1)
+* refactored and expanded `BigInteger` documentation to be more comprehensive
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html)
+* refactored documentation for `DynamicIters.Method`, and `Subprocess.pipeStyle`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/DynamicIters.html#DynamicIters.Method
+  and https://chapel-lang.org/docs/1.32/modules/standard/Subprocess.html#Subprocess.pipeStyle)
+
+
 * fixed warnings in 'Map' that incorrectly referred to the `set` type
 * updated docs to mention `arm64` as a synonym for `aarch64`  
   (see TODO)
@@ -410,6 +502,8 @@ Portability / Platform-specific Improvements
 
 Compiler Improvements
 ---------------------
+* added `@llvm.assertVectorized` and `@llvm.metadata` as attributes on loops  
+  (see TODO)
 
 Compiler Flags
 --------------
@@ -426,6 +520,7 @@ Launchers
 Error Messages / Semantic Checks
 --------------------------------
 * simplified error formatting when compiling C code within an `extern` block
+* improved errors when calling `Reflection.getFieldRef()` on an internal type  
 * fixed incorrect underlining of string literals in detailed error messages
 
 Bug Fixes
@@ -433,9 +528,12 @@ Bug Fixes
 * fixed importing tertiary methods by naming a builtin type like `string`
 * fixed a bug in which `CHPL_UNWIND` could not be overridden on some platforms
 * fixed internal errors when using tuples as formal or return types in FCPs
+* fixed declaring a variable with an explicitly generic type
+  (e.g., `var d: domain(?) = {1..5}` now works)
 * fixed incorrect scoping of variables in `do`...`while` loops' conditions
 * fixed a bug in which FCPs printed incorrectly with JSON serializers
 * fixed a bug when using array type expression actuals within loop bodies
+* removed extra borrow when casting from a managed class to an unmanaged class
 
 Bug Fixes for Build Issues
 --------------------------
@@ -449,13 +547,18 @@ Bug Fixes for GPU Computing
 
 Bug Fixes for Libraries
 -----------------------
+* fixed `regex.split()` when matching to a pattern with an empty group
+* fixed error-checking logic for `regex` that was being optimized away
 * fixed a bug where `%r`/`%n` ignored precision arguments for integer values
 * fixed bug that prevented deserialization of `bytes` in JSON and CHPL formats
 * fixed bug where the `JsonDeserializer` could fail to parse a list
+* removed unintended warning when calling `Types.isCopyableType()` on a `sync`
 
 Bug Fixes for Tools
 -------------------
 * fixed several bugs where `chpldoc` did not handle unstable warnings correctly
+* fixed procedure signatures not rendering correctly in `chpldoc` HTML output
+* fixed documentation-generation script for distributions to preserve warnings
 
 Third-Party Software Changes
 ----------------------------
@@ -473,6 +576,7 @@ Developer-oriented changes: Syntactic / Naming Changes
 
 Developer-oriented changes: Module changes
 ------------------------------------------
+* improved the `BigInteger` module organization to reduce maintenance burden
 
 Developer-oriented changes: Performance improvements
 ----------------------------------------------------
@@ -482,6 +586,10 @@ Developer-oriented changes: Makefile / Build-time changes
 
 Developer-oriented changes: Compiler Flags
 ------------------------------------------
+* added `--llvm-remarks[-function]` to report LLVM optimization information  
+  (see https://chapel-lang.org/docs/1.32/technotes/llvm.html#inspecting-llvm-optimizations)
+* improved `--log-module` to support logging multiple modules at a time
+* removed the broken `--log-node` command
 
 Developer-oriented changes: Compiler improvements / changes
 -----------------------------------------------------------
@@ -519,6 +627,10 @@ Developer-oriented changes: Tool Improvements
 * improved how `chpldoc` generates module documentation:
   - `where`-clauses are now printed out as part of a routine's signature
   - individual constants within an `enum` can now have their own documentation
+* added `:enum[constant]:` to the list of 'chpldoc'-supported inline markup  
+  (see https://chapel-lang.org/docs/1.32/tools/chpldoc/chpldoc.html#inline-markup-2)
+* added support for Chapel AST syntax highlighting
+* added sphinx message filter for `:enumconstant:`
 
 Developer-oriented changes: Utilities
 -------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,9 @@ Namespace Changes
 
 Standard Library Modules
 ------------------------
+* added `binarySerializer` and `binaryDeserializer` types to the 'IO' module
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binarySerializer
+   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binaryDeserializer)
 * added support for casting `bool` values to `bigint`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
 * added a `compiledForSingleLocale()` query to the `ChplConfig` module  
@@ -86,6 +89,8 @@ Standard Domain Maps (Layouts and Distributions)
 
 Changes / Feature Improvements in Libraries
 -------------------------------------------
+* improved support for Serializers and Deserializers  
+  (see https://chapel-lang.org/docs/1.32/technotes/ioSerializers.html)
 * generalized `[read|write]Binary()` to support multi-dimensional arrays  
   (see TODO)
 * made `chpl_library_init()` issue an error if called twice
@@ -102,6 +107,23 @@ Name Changes in Libraries
 
 Deprecated / Unstable / Removed Library Features
 ------------------------------------------------
+* deprecated `[read|write]This()` methods in favor of `[de]serialize()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html#the-readthis-and-writethis-methods  
+   and https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html#the-serialize-and-deserialize-methods
+   TODO: Do we want both?)
+* deprecated `iostyle` and `iokind` in favor of serializers and deserializers  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.iostyle  
+   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.iokind)
+* deprecated `io[dynamic|native|little|big]` module-scope convenience params  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.iokind)
+* deprecated `fileReader.skipField()` in favor of (de)serializers  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#FormattedIO.fileReader.skipField)
+* deprecated `file[Reader|Writer].kind` in favor of (de)serializers
+* deprecated the `kind` argument in various reader/writer routines  
+  (e.g., `open[URL][Reader|Writer]()`, `file.[reader|writer]()`, etc.)
+* deprecated the 'BinaryIO' module  
+  (see https://chapel-lang.org/docs/1.32/modules/packages/BinaryIO.html)
+* deprecated usage of `iokind` in the `Subprocess` module
 * deprecated `c_void_ptr` in favor of now-equivalent `c_ptr(void)`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptr)
 * deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
@@ -286,11 +308,15 @@ Developer-oriented changes: Compiler improvements / changes
 
 Developer-oriented changes: 'dyno' Compiler improvements / changes
 ------------------------------------------------------------------
-* numerous improvements to the 'dyno' resolver:
+* numerous improvements to the 'dyno' resolver for types and calls:
+  - added basic support for 'forwarding' to members in a class or record
+  - added basic support for generic tuple type expressions (e.g. (?, integral))
+  - added basic support for param-folding 'select' statements
   - added support for the `class` typeclass
   - improved handling of control flow when inferring an `iter`'s `yield` type
   - added support for the `c_ptr` type
   - added support for opaque `extern` types
+  - fixed a bug involving recursive type resolution in fields
 
 Developer-oriented changes: Runtime improvements
 ------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -204,7 +204,7 @@ Portability / Platform-specific Improvements
 * added support for processors with heterogeneous processing units  
   (see https://chapel-lang.org/docs/1.32/usingchapel/executing.html#controlling-the-kind-of-processing-units)
 * enabled support for hugepages on the HPE Cray EX platform  
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/platforms/libfabric.html#hugepages-on-cray-xc-and-hpe-cray-ex-systems)
 * improved the landing zone sizing when using `CHPL_COMM=ofi`
 * fixed a linkage issue in which system libraries could override ours
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 Release Changes List
 ====================
 
+o check sorting of categories
+o check placement of items into categories
+o check man page
+o check test/release/examples
+o check for docs/1.32/ links
+o check forced linebreaks
+o check links
+o check initial '*'
+o check initial 'A-Z'
+o check 'see:'
+o check for changes put too far down in file
+o add highlights
+o spellcheck
+
+
 version 1.32.0
 ==============
 
@@ -9,15 +24,9 @@ released September 28, 2023
 Highlights (see subsequent sections for further details)
 --------------------------------------------------------
 
-Configuration / Build / Packaging Changes
------------------------------------------
-* updated arm-based (M1/M2) Macs to default to `CHPL_TASKS=qthreads`
-* updated arm-based (M1/M2) Macs to default to `CHPL_MEM=jemalloc`
-* improved the equivalence of `arm64` and `aarch64` in our scripting
-
 New Language Features
 ---------------------
-* added explicit `out` return and yield intents
+* added explicit `out` return and yield intents  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-out-return-intent  
    and https://chapel-lang.org/docs/1.32/language/spec/iterators.html#the-yield-statement)
 * added a user-facing task yield mechanism, `currentTask.yieldExecution()`
@@ -637,6 +646,9 @@ Portability / Platform-specific Improvements
 --------------------------------------------
 * added support for co-locales to `CHPL_COMM=gasnet` with the `ibv` substrate  
   (see https://chapel-lang.org/docs/1.32/usingchapel/multilocale.html#co-locales)
+* updated arm-based (M1/M2) Macs to default to `CHPL_TASKS=qthreads`
+* updated arm-based (M1/M2) Macs to default to `CHPL_MEM=jemalloc`
+* improved the equivalence of `arm64` and `aarch64` in our scripting
 * resolved sporadic memory consistency issues on ARM processors
 * added support for processors with heterogeneous processing units  
   (see https://chapel-lang.org/docs/1.32/usingchapel/executing.html#controlling-the-kind-of-processing-units)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -159,6 +159,8 @@ Deprecated / Unstable / Removed Language Features
 * deprecated the `.intIdxType` query on ranges, domains, and arrays  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.intIdxType)
 * deprecated the default cast from arrays to `string`
+* deprecated `require` statements for Chapel source files at non-module scope
+  (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-require-statement)
 * deprecated the `useNewArrayFind` config param
 * removed the previously deprecated casts from `string` and `bytes` to `regex`
 * removed support for the deprecated array `.find()` overload

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -561,6 +561,10 @@ Language Specification Improvements
 
 Other Documentation Improvements
 --------------------------------
+* added a new primer providing a deep-dive on Chapel's various loop forms
+  (see https://chapel-lang.org/docs/1.32/primers/loops.html)
+* made a major refresh to the distributions primer  
+  (see https://chapel-lang.org/docs/1.32/primers/distributions.html)
 * updated the first-class procedures technote to reflect the new syntax  
   (see https://chapel-lang.org/docs/1.32/technotes/firstClassProcedures.html)
 * replaced uses of `dmapped` with factory methods throughout the docs  

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ New Language Features
   (see https://chapel-lang.org/docs/1.32/language/spec/task-parallelism-and-synchronization.html#yielding-task-execution)
 * added support for declaring that records/classes fulfill a given interface  
   (e.g., `record r: i { ... }` says that `r` implements the `i` interface;  
-   see TODO)
+   see https://chapel-lang.org/docs/1.32/technotes/interfaces.html)
 * added `range.tryCast()` to support throwing range casts  
   (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#ChapelRange.range.tryCast)
 * added support for an array creation interface that throws if out of memory  
@@ -66,7 +66,7 @@ Syntactic / Naming Changes
 * added a warning for type signatures like 'T()' if 'T' is not fully defaulted
 * added a warning for fields with generic class management to avoid confusion
 * replaced `[this.]complete();` with `init this;` when defining initializers
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#limitations-on-instance-usage-in-initializers)
 * `these` is now reserved as a keyword for use as the default iterator method  
   (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#the-these-method)
 * renamed `[enter|leave]This()` to `[enter|exit]Context()` for context mgmt  
@@ -85,9 +85,11 @@ Semantic Changes / Changes to the Chapel Language
 * added an error for addition/subtraction of multi-dim. domains and `[u]int`s  
   (e.g., `{1..2, 1..2} - 1` is now an error)
 * built-in hashing now relies on the `hashable` interface
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/language/spec/records.html#hashing-a-record
+   and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
 * context managers now rely on the `contextManager` interface
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement
+   and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
 * `return` statements following a `throw` or `halt()` are now ignored  
   (see https://chapel-lang.org/docs/1.32/language/spec/error-handling.html#throwing-errors  
    and https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.halt)
@@ -219,7 +221,8 @@ Standard Domain Maps (Layouts and Distributions)
        https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist.createDomain,  
   and https://chapel-lang.org/docs/1.32/modules/dists/StencilDist.html#StencilDist.stencilDist.createDomain)
 * marked advanced initializer arguments in `blockDist`/`cyclicDist` unstable  
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist
+   and https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist)
 * disallowed oversubscription in `cyclicDist` and `stencilDist`
   (e.g., `var c = new cyclicDist(1, [here, here]);` reports an error)
 
@@ -237,7 +240,8 @@ Changes / Feature Improvements in Libraries
 * added overloads of deserializing methods that take arguments by `ref`  
   (see TODO)
 * generalized `[read|write]Binary()` to support multi-dimensional arrays  
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readBinary
+   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileWriter.writeBinary))
 * added `Math.ln()` to be consistent with the constant names in 'Math'  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ln)
 * limited `AutoMath.isClose()` to only accept `real`/`imag`/`complex` args  
@@ -446,7 +450,8 @@ Deprecated / Unstable / Removed Library Features
 * deprecated `IllegalArgumentError`'s two-argument initializer  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.IllegalArgumentError.init)
 * deprecated `list.first()`/`.last()` in favor of using paren-less methods  
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.first
+   and https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.last)
 * marked all `CHPL_*` params in `ChplConfig` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
 * deprecated `Reflection.numFields()` in favor of `Reflection.getNumFields()`
@@ -490,9 +495,9 @@ GPU Computing
   (see TODO?)
 * generated GPU kernels are now named using their source filename/line number
 * added support for multi-arch GPU executables when targeting NVIDIA GPUs
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#vendor-portability)
 * deprecated `assertOnGpu()` in favor of a new `@assertOnGpu` loop attribute
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#diagnostics-and-utilities)
 
 Performance Optimizations / Improvements
 ----------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -389,7 +389,10 @@ Deprecated / Unstable / Removed Library Features
   (see TODO)
 * marked all `CHPL_*` params in `ChplConfig` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
+* deprecated `Reflection.numFields()` in favor of `Reflection.getNumFields()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Reflection.html#Reflection.getNumFields)
 * marked `Reflection.getRoutineName()` unstable within first-class procedures
+* marked several other 'Reflection' routines as unstable
 * deprecated the transitional `BigInteger.bigintInitThrows` config param
 * deprecated `BigInteger.get_str()` in favor of a cast to `string`
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
@@ -471,6 +474,8 @@ Language Specification Improvements
 
 Other Documentation Improvements
 --------------------------------
+* updated the first-class procedures technote to reflect the new syntax  
+  (see https://chapel-lang.org/docs/1.32/technotes/firstClassProcedures.html)
 * replaced uses of `dmapped` with factory methods throughout the docs  
   (see TODO)
 * added a new section about I/O transactions to the 'IO' module  
@@ -689,6 +694,7 @@ Developer-oriented changes: Tool Improvements
   - individual constants within an `enum` can now have their own documentation
 * added support for Chapel AST syntax highlighting
 * added sphinx message filter for `:enumconstant:`
+* added support for 'Goto Declaration' to the Chapel language server
 
 Developer-oriented changes: Utilities
 -------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ Semantic Changes / Changes to the Chapel Language
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
+* marked `scan` unstable due to uncertainty about inclusive/exclusive choice
 * deprecated the `.intIdxType` query on ranges, domains, and arrays  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.intIdxType)
 * deprecated the `useNewArrayFind` config param
@@ -58,6 +59,8 @@ Deprecated / Unstable / Removed Language Features
 
 Namespace Changes
 -----------------
+* moved several automatically-included math symbols from 'AutoMath' to 'Math'
+  (e.g., `div[ceil|floor][pos]()`, `nearbyint()`, `rint()`)
 
 Standard Library Modules
 ------------------------
@@ -93,8 +96,46 @@ Changes / Feature Improvements in Libraries
   (see https://chapel-lang.org/docs/1.32/technotes/ioSerializers.html)
 * generalized `[read|write]Binary()` to support multi-dimensional arrays  
   (see TODO)
+* added `Math.ln()` to be consistent with the constant names in 'Math'  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ln)
+* limited `AutoMath.isClose()` to only accept `real`/`imag`/`complex` args  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
+* extended `Math.gcd()` support to include overloads for all integral types  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.gcd)
 * made `chpl_library_init()` issue an error if called twice
 * made `chpl_library_finalize()` no longer exit, permitting client to continue
+
+Name Changes in 'Math'-related Libraries
+----------------------------------------
+* unified the argument names in the 'AutoMath' and 'Math' modules
+* renamed `INFINITY` and `NAN` to `inf` and `nan` in the 'AutoMath' module  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.inf  
+   and https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.nan)
+* renamed ``is[finite|inf|nan]()` to `is[Finite|Inf|Nan]` in 'AutoMath'  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isFinite et al.)
+* renamed `AutoMath.conjg()` to `AutoMath.conj()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.conj)
+* renamed `AutoMath.carg()` to `AutoMath.phase()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.phase)
+* renamed `AutoMath.cproj()` to `AutoMath.riemProj()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.riemProj)
+* renamed `div[ceil|floor][pos]()` to `div[Ceil|Floor][Pos]()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divCeil et al.
+* renamed `AutoMath.isclose()` to `AutoMath.isClose()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
+* renamed `tgamma()` and `lgamma()` to `gamma()` and `lnGamma()` in 'Math'  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.gamma  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.lnGamma)
+* renamed `Math.ldexp()` to `Math.ldExp()` and its argument from `n` to `exp`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ldExp)
+* renamed `Math.*_pi` constants to `Math.*Pi` and marked them unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.halfPi et al.)
+* renamed `sqrt_2` and `recipr_sqrt_2` to `sqrt2` and `reciprSqrt2` in 'Math'  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.sqrt2)
+* renamed `Math.log2_e` to `Math.log2E` and `Math.log10_e` to `Math.log10E`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.log2E)
+* renamed `Math.ln_2` to `Math.ln2` and `Math.ln_10` to `Math.ln10`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ln2)
 
 Name Changes in Libraries
 -------------------------
@@ -105,8 +146,10 @@ Name Changes in Libraries
 * replaced `abs(timeDelta)` with a method `timeDelta.abs()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.timeDelta.abs)
 
-Deprecated / Unstable / Removed Library Features
-------------------------------------------------
+Deprecated / Unstable / Removed 'IO'-related Library Features
+-------------------------------------------------------------
+* marked the default-included 'ChapelIO' module name as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html)
 * deprecated `[read|write]This()` methods in favor of `[de]serialize()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html#the-readthis-and-writethis-methods  
    and https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html#the-serialize-and-deserialize-methods
@@ -124,14 +167,43 @@ Deprecated / Unstable / Removed Library Features
 * deprecated the 'BinaryIO' module  
   (see https://chapel-lang.org/docs/1.32/modules/packages/BinaryIO.html)
 * deprecated usage of `iokind` in the `Subprocess` module
-* deprecated `c_void_ptr` in favor of now-equivalent `c_ptr(void)`  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptr)
-* deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
-* marked `c_fn_ptr` unstable
-  (see https://chapel-lang.org/docs/1.32/technotes/extern.html#c-fn-ptr)
-* deprecated `list.first()`/`.last()` in favor of using paren-less methods  
-  (see TODO)
+* deprecated a number of `config param`s in 'IO' used to transition behavior  
+  (e.g., `useNewFileReaderRegionBounds`, `useNewLinesRegionBounds`, etc.)
+* removed the deprecated `IO.open[Reader|tmp|fp|fd]()` routines
+* removed the deprecated `file.reader()` and `.writer()` overloads
+* removed the deprecated `file.check()` and `file.lines()` methods
+* removed the deprecated `fileReader.flush()` method
+* removed the deprecated `.seek()` method overloads on `file[Reader|Writer]`
+
+Deprecated / Unstable / Removed 'Math'-related Library Features
+---------------------------------------------------------------
+* marked the default-included 'AutoMath' module name as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html)
+* marked `AutoMath.signbit()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.signbit)
+* marked `Math.nearbyint()` and `Math.rint()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.nearbyint  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.rint)
+* marked the `log*()` functions with `int` and `uint` arguments as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.log2)
+* marked `Math.logBasePow2()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.logBasePow2)
+* marked `Math.erf()` and `Math.erfc()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.erf)
+* marked the Bessel functions in the 'Math' module as unstable
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.j0 et al.)
+* marked `Math.divCeilPos()` and `Math.divFloorPos()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divCeilPos  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divFloorPos)
+* marked `Math.[half|quarter|recipr|twiceRecipr[Sqrt]Pi` as unstable
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.halfPi et al.)
+* marked `Math.sqrt2` and `.reciprSqrt2` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.sqrt2
+   and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.reciprSqrt2)
+* removed the deprecated Bessel functions that were included by default
+
+Deprecated / Unstable / Removed 'Time' Library Features
+-------------------------------------------------------
 * deprecated the `day` and `isoDayOfWeek` enums in favor of `dayOfWeek`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.day)
 * deprecated `MINYEAR`/`MAXYEAR` in favor of `date.[min|max].year`  
@@ -140,8 +212,6 @@ Deprecated / Unstable / Removed Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.Timezone)
 * deprecated `getCurrentDate()` and `getCurrentDayOfWeek()` in `Time`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.getCurrentDate)
-* marked all `CHPL_*` params in `ChplConfig` as unstable  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
 * marked the default 0-argument initializers for `date` and `dateTime` unstable
 * deprecated `date.createFromTimestamp()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.createFromTimestamp)
@@ -154,7 +224,29 @@ Deprecated / Unstable / Removed Library Features
    and https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.init)
 * deprecated `dateTime.{isoCalendar(), toOrdinal(), weekday(), isoWeekday()}`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.toOrdinal et al.)
+
+
+Deprecated / Unstable / Removed Library Features
+------------------------------------------------
+* deprecated `c_void_ptr` in favor of now-equivalent `c_ptr(void)`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptr)
+* deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
+* marked `c_fn_ptr` unstable
+  (see https://chapel-lang.org/docs/1.32/technotes/extern.html#c-fn-ptr)
+* deprecated `list.first()`/`.last()` in favor of using paren-less methods  
+  (see TODO)
+* marked all `CHPL_*` params in `ChplConfig` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
 * marked `Reflection.getRoutineName()` unstable within first-class procedures
+* deprecated the transitional `BigInteger.bigintInitThrows` config param
+* removed the deprecated `BigInteger.Round` enum
+* removed the deprecated `bigint` initializers that halted/returned error codes
+* removed the deprecated `bigint.mpzStruct()` method
+* removed the deprecated `bigint.div_q()` method
+* removed the deprecated `bigint.powm()` method
+* removed the deprecated `bigint.sizeinbase()` and `.size()` methods
+* removed the deprecated `bigint.get_d_2exp()` method
 * removed deprecated `c_sizeof()` signature with formal name `x`
 * removed a `regex.matches()` overload with deprecated arguments
 * removed the deprecated `regex.compile()` type method
@@ -201,10 +293,29 @@ Language Specification Improvements
 -----------------------------------
 * documented the `require` statement  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-require-statement)
-
+* added a link between the `%` documentation and `AutoMath.mod()`  
+  (see https://chapel-lang.org/docs/1.32/language/spec/expressions.html#modulus-operators)
 
 Other Documentation Improvements
 --------------------------------
+* removed references to file descriptors in `stdin`/`stdout`/`stderr` docs  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.stdin)
+* improved several aspects of the 'Math' module documentation:
+  - added missing documentation for arguments of `AutoMath.isClose()`  
+    (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
+  - removed an incorrect mention of "absolute value" for `Math.tgamma()`  
+    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.tgamma)
+  - improved the description for `Math.ldExp()`  
+    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ldExp)
+  - fixed the documentation for `Math.atan2()` with 32-bit arguments  
+    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.atan2)
+  - extended the documentation for `Math.erf()`  
+    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.erf)
+  - added a link between the `AutoMath.mod()` documentation and `%`  
+    (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.mod)
+  - added a link between `Math.exp()`/`Math.expm1()` and `Math.e`  
+    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.exp  
+     and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.expm1)
 * fixed warnings in 'Map' that incorrectly referred to the `set` type
 * updated docs to mention `arm64` as a synonym for `aarch64`  
   (see TODO)
@@ -277,6 +388,7 @@ Bug Fixes for Libraries
 
 Bug Fixes for Tools
 -------------------
+* fixed several bugs where `chpldoc` did not handle unstable warnings correctly
 
 Third-Party Software Changes
 ----------------------------
@@ -284,6 +396,7 @@ Third-Party Software Changes
 
 Developer-oriented changes: Process
 -----------------------------------
+* moved top-level .gitignore entries to their closest subdirectory
 
 Developer-oriented changes: Documentation
 -----------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Highlights (see subsequent sections for further details)
 
 Configuration / Build / Packaging Changes
 -----------------------------------------
+* improved the equivalence of `arm64` and `aarch64` in our scripting
 
 New Language Features
 ---------------------
@@ -140,6 +141,8 @@ Language Specification Improvements
 Other Documentation Improvements
 --------------------------------
 * fixed warnings in 'Map' that incorrectly referred to the `set` type
+* updated docs to mention `arm64` as a synonym for `aarch64`  
+  (see TODO)
 
 Example Codes
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
 Release Changes List
 ====================
 
-o check sorting of categories
+* check sorting of categories
 o check placement of items into categories
+o check for ' vs `
+o fulfill TODOs
 o check man page
 o check test/release/examples
 o check for docs/1.32/ links
@@ -34,34 +36,38 @@ New Language Features
 * added support for declaring that records/classes fulfill a given interface  
   (e.g., `record r: i { ... }` says that `r` implements the `i` interface;  
    see https://chapel-lang.org/docs/1.32/technotes/interfaces.html)
-* added `range.tryCast()` to support throwing range casts  
+* added `range.tryCast()` to support throwing casts between range types  
   (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#ChapelRange.range.tryCast)
 * added support for an array creation interface that throws if out of memory  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.tryCreateArray)
-* added support for applying attributes to loops
+* added support for applying @attributes to loops
 
 Language Feature Improvements
 -----------------------------
-* added new routines to create multidimensional arrays from C pointers
-  (see TODO)
-* casts between ranges now check the validity of the stride  
-  (see https://chapel-lang.org/docs/1.32/language/spec/conversions.html#explicit-range-conversions)
-* added a compiler warning when range slicing might halt execution
-  (e.g., `var r1 = 1.. by 2, r2 = 2.. by 2; writeln(r1[r2]);`)
 * added support for slicing arrays with unaligned ranges
   (e.g., `var A: [1..3] int = 1..3; writeln(A[..2 by 2]);` prints 1)
+* casts between ranges now check the validity of the stride  
+  (see https://chapel-lang.org/docs/1.32/language/spec/conversions.html#explicit-range-conversions)
 * enabled assigning and initilizing integral ranges from bool ranges  
   (e.g., `var r: range(int(8)) = false..true;` is now supported)
+* added a compiler warning when range slicing might halt execution
+  (e.g., `var r1 = 1.. by 2, r2 = 2.. by 2; writeln(r1[r2]);`)
 * improved handling of intents on array formals in extern functions
 * added promoted casts from array-of-`T` to `T` without a cast from `T` to `T`
-* first-class procedures are now printed similarly to Chapel's syntax
 * added support for a new `bulkAddNoPreserveInds()` method to sparse domains  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.bulkAddNoPreserveInds)
+* first-class procedures are now printed similarly to Chapel's syntax
 * improved support for casts in formal argument type expressions
+* added new routines to create multidimensional arrays from C pointers
 
 Syntactic / Naming Changes
 --------------------------
-* made `init`, `postinit`, `deinit`, `super`, and `range` reserved keywords
+* deprecated support for `$` in identifiers (e.g., `foo$` is deprecated)
+* `these` is now reserved as a keyword for use as the default iterator method  
+  (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#the-these-method)
+* reserved `init`, `postinit`, `deinit`, `super`, and `range` as keywords
+* replaced `[this.]complete();` with `init this;` when defining initializers
+  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#limitations-on-instance-usage-in-initializers)
 * renamed `range.aligned` to `range.isAligned()`
   (see https://chapel-lang.org/docs/main/language/spec/ranges.html#ChapelRange.range.isAligned)
 * renamed `domain.dist` to `domain.distribution`
@@ -76,10 +82,6 @@ Syntactic / Naming Changes
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#marking-generic-types)
 * added a warning for type signatures like 'T()' if 'T' is not fully defaulted
 * added a warning for fields with generic class management to avoid confusion
-* replaced `[this.]complete();` with `init this;` when defining initializers
-  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#limitations-on-instance-usage-in-initializers)
-* `these` is now reserved as a keyword for use as the default iterator method  
-  (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#the-these-method)
 * renamed `[enter|leave]This()` to `[enter|exit]Context()` for context mgmt  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement)
 * renamed `sync` formals from `x: valtype` to `val: valType`
@@ -87,16 +89,16 @@ Syntactic / Naming Changes
 
 Semantic Changes / Changes to the Chapel Language
 -------------------------------------------------
-* began changing the default argument/task intent for arrays to `const`  
+* began transitioning the default argument/task intent for arrays to `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
-* began changing the default receiver intent for records to `const`  
+* began transitioning the default receiver intent for records to `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
 * redefined the `const` intent to enable optimization opportunities  
   - `const` allows implementation to choose `const ref` or `const in`
   - `const` asserts that the value will not be modified by other means
   - `const` for an array now asserts that the domain will not change
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-const-intent)
-* began changing the type of range literals with mixed-type param bounds  
+* began changing the type of range literals with mixed-type `param` bounds  
   (e.g., `0..1:int(8)` is changing from `idxType=int(8)` to `int(64)`)
 * added an error for addition/subtraction of multi-dim. domains and `[u]int`s  
   (e.g., `{1..2, 1..2} - 1` is now an error)
@@ -106,9 +108,11 @@ Semantic Changes / Changes to the Chapel Language
 * context managers now rely on the `contextManager` interface
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement
    and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
-* `return` statements following a `throw` or `halt()` are now ignored  
-  (see https://chapel-lang.org/docs/1.32/language/spec/error-handling.html#throwing-errors  
-   and https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.halt)
+* removed some capabilities from records with generic `var`/`const` fields  
+  (e.g., 'record R { var x; }' or 'record S { var y: integral; }')
+  - variables of such types can no longer be default-initialized
+  - type signatures w/ named arguments are no longer supported (`R(x=int)`)  
+    (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fields-without-types)
 * adjusted the deinit point for nested call expressions in `var`/`const` decls
   (see https://chapel-lang.org/docs/1.32/language/spec/variables.html#deinit-points)
 * a call that could refer to a method or a non-method is now an ambiguity
@@ -117,28 +121,36 @@ Semantic Changes / Changes to the Chapel Language
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#determining-most-specific-functions)
 * declaring a paren-less method with the same name as a field is now an error  
   (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#methods-without-parentheses)
-* removed some capabilities from records with generic `var`/`const` fields  
-  (e.g., 'record R { var x; }' or 'record S { var y: integral; }')
-  - variables of such types can no longer be default-initialized
-  - type signatures w/ named arguments are no longer supported (`R(x=int)`)  
-    (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fields-without-types)
-* split initialization is now allowed into a `sync` block  
-  (see https://chapel-lang.org/docs/1.32/language/spec/variables.html#split-initialization)
 * numeric `param`s can now be passed to `const ref` formals
   (e.g. given `proc f(const ref arg)`, `f(1)` is now supported)
 * l-value checking now applies to nested call expressions returning arrays
   (e.g., 'modifyArray(returnsArray)' will now emit an l-value error)
+* `return` statements following a `throw` or `halt()` are now ignored  
+  (see https://chapel-lang.org/docs/1.32/language/spec/error-handling.html#throwing-errors  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.halt)
+* split initialization is now allowed into a `sync` block  
+  (see https://chapel-lang.org/docs/1.32/language/spec/variables.html#split-initialization)
 
-Deprecated / Unstable / Removed Language Features
--------------------------------------------------
+Unstable Language Features
+--------------------------
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
 * marked associative and sparse domains as unstable
 * marked the `dmap` type and `dmapped` keyword as unstable
-* marked `scan` unstable due to uncertainty about inclusive/exclusive choice
-* marked all `.safeCast()` methods unstable
+* marked `scan` unstable due to uncertainty about inclusive/exclusive behavior
+* made importing tertiary methods by naming their type unstable  
+  (e.g., `import IO.string;` is no longer stable)
+* marked the `[string|bytes].createBorrowingBuffer` factory method unstable  
+  (see https://chapel-lang.org/docs/1.32/language/spec/strings.html#String.string.createBorrowingBuffer  
+  and https://chapel-lang.org/docs/1.32/language/spec/bytes.html#Bytes.bytes.createBorrowingBuffer)
+* marked `.localize()` on `string` and `bytes` as being unstable
+* marked `compareAndSwap()` on `atomic` variables as unstable
+* marked `sync.[readXX|writeFF|writeXF|reset|isFull]()` unstable
+* marked `umask()` on `locale` as being unstable
 * marked binary operators between tuples and scalars as unstable
 * marked several binary operators over ranges and integral values as unstable
   (e.g., `(1..3)*(1..5)` and `(1..3) + 1` are now unstable
+* marked default initialization of partially bounded ranges as unstable  
+  (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#default-values)
 * marked first/last/empty queries on unbounded ranges of bool/enum unstable
   (e.g., `(false..).last` is now unstable)
 * marked `==` and `!=` between unbounded ranges of bool/enum unstable
@@ -148,20 +160,14 @@ Deprecated / Unstable / Removed Language Features
 * marked `.orderToIndex()` on domains as unstable
 * marked `.offset()` and `.indexOrder()` on ranges as unstable
 * marked `.hasSingleLocalSubdomain()` and `.localSubdomains()` as unstable
-* marked `compareAndSwap()` on `atomic` variables as unstable
-* marked `sync.[readXX|writeFF|writeXF|reset|isFull]()` unstable
+* marked all `.safeCast()` methods unstable
 * marked explicit calls to `this()` methods as unstable
 * marked serial `these()` iterators taking arguments as unstable
-* marked default initialization of low- and high-bounded ranges as unstable
-  (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#default-values)
 * marked most built-in `config` constants and params as unstable
 * marked `extern` procedures with array arguments as unstable  
-* marked the `[string|bytes].createBorrowingBuffer` factory method unstable  
-  (see https://chapel-lang.org/docs/1.32/language/spec/strings.html#String.string.createBorrowingBuffer  
-  and https://chapel-lang.org/docs/1.32/language/spec/bytes.html#Bytes.bytes.createBorrowingBuffer)
-* marked `.localize()` on `string` and `bytes` as being unstable
-* marked `umask()` on `locale` as being unstable
-* deprecated support for `$` in identifiers (e.g., `foo$` is deprecated)
+
+Deprecated / Removed Language Features
+--------------------------------------
 * deprecated the `c_string` type in favor of `c_ptrConst(c_char)`
   (see https://chapel-lang.org/docs/1.32/language/evolution.html#c-string-deprecation)
 * deprecated implicit conversions for formals with generic numeric types  
@@ -183,8 +189,6 @@ Deprecated / Unstable / Removed Language Features
 * removed the previously deprecated casts from `string` and `bytes` to `regex`
 * removed support for the deprecated array `.find()` overload
 * removed support for variable-width `bool` types and related queries
-* made importing tertiary methods by naming their type unstable  
-  (e.g., `import IO.string;` is no longer stable)
 * removed the `preserveInds` argument to `bulkAdd` on sparse domains  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.bulkAdd)
 
@@ -193,11 +197,10 @@ Namespace Changes
 * moved several automatically-included math symbols from 'AutoMath' to 'Math'
   (e.g., `div[ceil|floor][pos]()`, `nearbyint()`, `rint()`)
 * moved `string.c_str()` and `bytes.c_str()` to `CTypes`
-  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str
-   and https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.bytes.c_str)
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
 * upgraded `Json` from a package to a standard module, now named `JSON`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/JSON.html)
-* renamed `Yaml` module to `YAML`  
+* renamed the `Yaml` module to `YAML`  
   (see https://chapel-lang.org/docs/1.32/modules/packages/YAML.html)
 
 Standard Library Modules
@@ -206,14 +209,16 @@ Standard Library Modules
 * added `binarySerializer` and `binaryDeserializer` types to the 'IO' module
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binarySerializer
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binaryDeserializer)
+* added new `%<`, `%^`, and `%>` format specifiers for justification  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
 * added support for casting `bool` values to `bigint`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
-* added a `compiledForSingleLocale()` query to the `ChplConfig` module  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.compiledForSingleLocale)
 * began an update to the definition of `dayOfWeek` to use ISO numbering  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.cIsoDayOfWeek)
 * added `date.utcToday` as a UTC version of local-time `date.today`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.utcToday)
+* added a `compiledForSingleLocale()` query to the `ChplConfig` module  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.compiledForSingleLocale)
 
 Package Modules
 ---------------
@@ -227,84 +232,79 @@ Standard Domain Maps (Layouts and Distributions)
 ------------------------------------------------
 * marked all domain maps other than `blockDist` and `cyclicDist` as unstable
 * converted standard distributions into records, removing the need for `dmap`  
-  (e.g., see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html  
-   and https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html)
+  (e.g., see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html)
 * renamed the standard distributions to match their module names  
-  (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.  
-   see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html et al.)
+  (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.)
+  (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html, et al.)
 * unified and extended the factory methods on `[block|cyclic|stencil]Dist`  
   (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist.createDomain,  
-       https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist.createDomain,  
+   https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist.createDomain,  
   and https://chapel-lang.org/docs/1.32/modules/dists/StencilDist.html#StencilDist.stencilDist.createDomain)
+* disallowed oversubscription in `cyclicDist` and `stencilDist`
+  (e.g., `var c = new cyclicDist(1, [here, here]);` now reports an error)
 * marked advanced initializer arguments in `blockDist`/`cyclicDist` unstable  
   (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist
    and https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist)
-* disallowed oversubscription in `cyclicDist` and `stencilDist`
-  (e.g., `var c = new cyclicDist(1, [here, here]);` reports an error)
 
 Changes / Feature Improvements in Libraries
 -------------------------------------------
-* improved support for Serializers and Deserializers  
+* significantly improved support for IO Serializers and Deserializers  
   (see https://chapel-lang.org/docs/1.32/technotes/ioSerializers.html)
-* added new `%<`, `%^`, and `%>` format specifiers for justification  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
-* `%i` and `%u` format specifiers now emit warnings for unused precision args  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
-* made `readLiteral()` and `matchLiteral()` respect leading whitespace  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readLiteral
-   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.matchLiteral)
 * added overloads of deserializing methods that take arguments by `ref`  
   (see https://chapel-lang.org/docs/1.32/technotes/ioSerializers.html#the-user-facing-deserializer-api)
+* `%i` and `%u` format specifiers now emit warnings for unused precision args  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
 * generalized `[read|write]Binary()` to support multi-dimensional arrays  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readBinary
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileWriter.writeBinary))
+* made `readLiteral()` and `matchLiteral()` respect leading whitespace  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readLiteral
+   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.matchLiteral)
 * added `Math.ln()` to be consistent with the constant names in 'Math'  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ln)
 * limited `AutoMath.isClose()` to only accept `real`/`imag`/`complex` args  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
 * extended `Math.gcd()` support to include overloads for all integral types  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.gcd)
-* indexing into a `map` with default-initializable values no longer throws  
-  (e.g., `var m = new map(int, int); m[5] = 6;` will not throw errors)
+* indexing into a `map` with default-initializable values no longer `throws`  
+  (e.g., `var m = new map(int, int); m[5] = 6;` will no longer throw errors)
 * `map.values()` is now available for maps with non-nilable `owned` values  
   (e.g., `var m = new map(int, owned MyClass); for v in m.values() do ...`)
-* made `chpl_library_init()` issue an error if called twice
-* made `chpl_library_finalize()` no longer exit, permitting client to continue
 
-Name Changes in 'Math'-related Libraries
-----------------------------------------
-* unified the argument names in the 'AutoMath' and 'Math' modules
-* renamed `INFINITY` and `NAN` to `inf` and `nan` in the 'AutoMath' module  
+Name Changes in the 'Math' Library
+----------------------------------
+* unified the argument names in 'Math' module routines
+* renamed `INFINITY` to `inf` and `NAN` to `nan`
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.inf  
    and https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.nan)
-* renamed ``is[finite|inf|nan]()` to `is[Finite|Inf|Nan]` in 'AutoMath'  
+* renamed ``is[finite|inf|nan]()` to `is[Finite|Inf|Nan]()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isFinite et al.)
-* renamed `AutoMath.conjg()` to `AutoMath.conj()`
+* renamed `conjg()` to `conj()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.conj)
-* renamed `AutoMath.carg()` to `AutoMath.phase()`
+* renamed `carg()` to `phase()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.phase)
-* renamed `AutoMath.cproj()` to `AutoMath.riemProj()`
+* renamed `cproj()` to `riemProj()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.riemProj)
 * renamed `div[ceil|floor][pos]()` to `div[Ceil|Floor][Pos]()`
-  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divCeil et al.
-* renamed `AutoMath.isclose()` to `AutoMath.isClose()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divCeil et al.)
+* renamed `isclose()` to `isClose()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
-* renamed `tgamma()` and `lgamma()` to `gamma()` and `lnGamma()` in 'Math'  
+* renamed `tgamma()` to `gamma()` and `lgamma()` to `lnGamma()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.gamma  
    and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.lnGamma)
-* renamed `Math.ldexp()` to `Math.ldExp()` and its argument from `n` to `exp`
+* renamed `ldexp()` to `ldExp()` and its argument from `n` to `exp`
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ldExp)
-* renamed `Math.*_pi` constants to `Math.*Pi` and marked them unstable  
+* renamed `*_pi` constants to `*Pi` and marked them unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.halfPi et al.)
-* renamed `sqrt_2` and `recipr_sqrt_2` to `sqrt2` and `reciprSqrt2` in 'Math'  
+* renamed `sqrt_2` to `sqrt2` and `recipr_sqrt_2` to `reciprSqrt2`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.sqrt2)
-* renamed `Math.log2_e` to `Math.log2E` and `Math.log10_e` to `Math.log10E`
+* renamed `log2_e` to `log2E` and `log10_e` to `log10E`
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.log2E)
-* renamed `Math.ln_2` to `Math.ln2` and `Math.ln_10` to `Math.ln10`
+* renamed `ln_2` to `ln2` and `ln_10` to `ln10`
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ln2)
 
-Name Changes in the 'BigInteger' module
----------------------------------------
+Name Changes in the 'BigInteger' Library
+----------------------------------------
 * generally unified argument names in these routines to 'x', 'y', ...
 * renamed the enum `round` to `roundingMode`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.roundingMode)
@@ -339,11 +339,10 @@ Name Changes in the 'BigInteger' module
 * renamed `divR2Exp()` to the now unstable `rem2Exp()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.rem2Exp)
 
-Name Changes in Libraries
--------------------------
-* renamed all serializer/deserializer types to use camelCasing  
-  (e.g., `DefaultSerializer` is now `defaultSerializer`, and similarly for the
-   'binary', 'json', and 'chpl' serializers and deserializers)
+Other Name Changes in Libraries
+-------------------------------
+* renamed the serializer/deserializer types to use camelCasing  
+  (e.g., `DefaultSerializer` is now `defaultSerializer`)
 * renamed `map.addOrSet()` to `map.addOrReplace()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.addOrReplace)
 * renamed `CodepointSplittingError` to `CodepointSplitError`  
@@ -353,32 +352,30 @@ Name Changes in Libraries
 * replaced `abs(timeDelta)` with a method `timeDelta.abs()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.timeDelta.abs)
 
-Deprecated / Unstable / Removed 'IO'-related Library Features
--------------------------------------------------------------
-* marked `fileReader.assertEOF()` as unstable  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.assertEOF)
+Deprecated / Unstable / Removed 'IO' Library Features
+-----------------------------------------------------
 * marked the default-included 'ChapelIO' module name as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html)
+* marked `fileReader.assertEOF()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.assertEOF)
 * deprecated `[read|write]This()` methods in favor of `[de]serialize()`
-  (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html#the-readthis-and-writethis-methods  
-   and https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html#the-serialize-and-deserialize-methods
-   TODO: Do we want both?)
+  (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html#the-serialize-and-deserialize-methods
+* deprecated `fileReader.skipField()` in favor of (de)serializers  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#FormattedIO.fileReader.skipField)
 * deprecated `iostyle` and `iokind` in favor of serializers and deserializers  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.iostyle  
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.iokind)
+* deprecated `file[Reader|Writer].kind` in favor of (de)serializers
+* deprecated the `kind` argument in various reader/writer routines  
+  (e.g., `open[URL][Reader|Writer]()`, `file.[reader|writer]()`, etc.)
+* deprecated `fileReader.binary` in favor of checks for binary [de]serializer  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.binary)
 * deprecated `io[dynamic|native|little|big]` module-scope convenience params  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.iokind)
 * deprecated `fileReader.ioLiteral` in favor `readLiteral()`/`matchLiteral()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioLiteral)
 * deprecated `fileReader.ioNewline` in favor of `[read|match]Newline()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioNewline)
-* deprecated `fileReader.skipField()` in favor of (de)serializers  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#FormattedIO.fileReader.skipField)
-* deprecated `file[Reader|Writer].kind` in favor of (de)serializers
-* deprecated `fileReader.binary` in favor of checks for binary [de]serializer  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.binary)
-* deprecated the `kind` argument in various reader/writer routines  
-  (e.g., `open[URL][Reader|Writer]()`, `file.[reader|writer]()`, etc.)
 * deprecated the 'BinaryIO' module  
   (see https://chapel-lang.org/docs/1.32/modules/packages/BinaryIO.html)
 * deprecated the `%t`, `%jt`, and `%ht` format specifiers in favor of `%?`  
@@ -399,42 +396,42 @@ Deprecated / Unstable / Removed 'IO'-related Library Features
 * removed the deprecated `openreader()` and `openwriter()` procedures
 * removed the deprecated types `iomode`, `ioBits`, and `ioChar`
 
-Deprecated / Unstable / Removed 'Math'-related Library Features
----------------------------------------------------------------
+Deprecated / Unstable / Removed 'Math' Library Features
+-------------------------------------------------------
 * marked the default-included 'AutoMath' module name as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html)
-* marked `AutoMath.signbit()` as unstable  
+* marked `signbit()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.signbit)
-* marked `Math.nearbyint()` and `Math.rint()` as unstable  
+* marked `nearbyint()` and `rint()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.nearbyint  
    and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.rint)
 * marked the `log*()` functions with `int` and `uint` arguments as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.log2)
-* marked `Math.logBasePow2()` as unstable  
+* marked `logBasePow2()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.logBasePow2)
-* marked `Math.erf()` and `Math.erfc()` as unstable  
+* marked `erf()` and `erfc()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.erf)
-* marked the Bessel functions in the 'Math' module as unstable
+* marked the Bessel functions as unstable
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.j0 et al.)
-* marked `Math.divCeilPos()` and `Math.divFloorPos()` as unstable  
+* marked `divCeilPos()` and `divFloorPos()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divCeilPos  
    and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divFloorPos)
-* marked `Math.[half|quarter|recipr|twiceRecipr[Sqrt]Pi` as unstable
+* marked `[half|quarter|recipr|twiceRecipr[Sqrt]Pi` as unstable
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.halfPi et al.)
-* marked `Math.sqrt2` and `.reciprSqrt2` as unstable  
+* marked `sqrt2` and `reciprSqrt2` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.sqrt2
    and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.reciprSqrt2)
 * removed the deprecated Bessel functions that were included by default
 
 Deprecated / Unstable / Removed 'Time' Library Features
 -------------------------------------------------------
+* marked `Timezone` and any `Time` methods using it as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.Timezone)
 * deprecated the `day` and `isoDayOfWeek` enums in favor of `dayOfWeek`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.day)
 * deprecated `MINYEAR`/`MAXYEAR` in favor of `date.[min|max].year`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.MINYEAR)
-* marked `Timezone` and any `Time` methods using it as unstable  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.Timezone)
-* deprecated `getCurrentDate()` and `getCurrentDayOfWeek()` in `Time`  
+* deprecated `getCurrentDate()` and `getCurrentDayOfWeek()` in 'Time'  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.getCurrentDate)
 * marked the default 0-argument initializers for `date` and `dateTime` unstable
 * deprecated `date.createFromTimestamp()`  
@@ -449,37 +446,40 @@ Deprecated / Unstable / Removed 'Time' Library Features
 * deprecated `dateTime.{isoCalendar(), toOrdinal(), weekday(), isoWeekday()}`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.toOrdinal et al.)
 
-Deprecated / Unstable / Removed Library Features
-------------------------------------------------
-* marked `list.sort()` as unstable  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.sort)
+Unstable Library Features
+-------------------------
 * marked `parSafe` as being unstable for `list`, `set`, and `map`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.parSafe,  
-       https://chapel-lang.org/docs/1/32/modules/standard/Set.html#Set.set.parSafe,  
+   https://chapel-lang.org/docs/1/32/modules/standard/Set.html#Set.set.parSafe,  
    and https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.parSafe)
+* marked several 'BigInteger' procedures as unstable
+  (i.e., `jacobi()`, `legendre()`, `kronecker()`, `gcd()`, `lcm()`, `fac()`,
+   `bin()`, `fib()`, `fib2()`, `probablyPrime()`)
+* marked `c_fn_ptr` unstable
+  (see https://chapel-lang.org/docs/1.32/technotes/extern.html#c-fn-ptr)
+* marked `list.sort()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.sort)
+* marked `Reflection.getRoutineName()` unstable within first-class procedures
+* marked several other 'Reflection' routines as unstable
+* marked all `CHPL_*` params in `ChplConfig` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
+
+Deprecated / Removed Library Features
+------------------------------------------------
 * deprecated `c_void_ptr` in favor of now-equivalent `c_ptr(void)`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptr)
 * deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
-* marked `c_fn_ptr` unstable
-  (see https://chapel-lang.org/docs/1.32/technotes/extern.html#c-fn-ptr)
-* deprecated `IllegalArgumentError`'s two-argument initializer  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.IllegalArgumentError.init)
-* deprecated `list.first()`/`.last()` in favor of using paren-less methods  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.first
-   and https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.last)
-* marked all `CHPL_*` params in `ChplConfig` as unstable  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
-* deprecated `Reflection.numFields()` in favor of `Reflection.getNumFields()`
-  (see https://chapel-lang.org/docs/1.32/modules/standard/Reflection.html#Reflection.getNumFields)
-* marked `Reflection.getRoutineName()` unstable within first-class procedures
-* marked several other 'Reflection' routines as unstable
 * deprecated the transitional `BigInteger.bigintInitThrows` config param
 * deprecated `BigInteger.get_str()` in favor of a cast to `string`
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
-* marked several 'BigInteger' procedures as unstable
-  (i.e., `jacobi()`, `legendre()`, `kronecker()`, `gcd()`, `lcm()`, `fac()`,
-   `bin()`, `fib()`, `fib2()`, `probablyPrime()`)
+* deprecated `list.first()`/`.last()` in favor of using paren-less methods  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.first
+   and https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.last)
+* deprecated `IllegalArgumentError`'s two-argument initializer  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.IllegalArgumentError.init)
+* deprecated `Reflection.numFields()` in favor of `Reflection.getNumFields()`
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Reflection.html#Reflection.getNumFields)
 * removed the deprecated `BigInteger.Round` enum
 * removed the deprecated `bigint` initializers that halted/returned error codes
 * removed the deprecated `bigint.mpzStruct()` method
@@ -503,26 +503,24 @@ Deprecated / Unstable / Removed Library Features
 GPU Computing
 -------------
 * significantly improved `array_on_device` performance, making it the default
-  (see TODO)
-* added more math routines when using AMD GPUs
 * improved the performance of math routines in GPU kernels
 * improved performance when using arrays within kernels
+* added more math routines when using AMD GPUs
 * added support for dumping AMD assembly files when using `--savec`
   (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#examining-generated-assembly)
 * started using per-task, per-device streams to enable better overlap
 * CUDA 12 is now supported when using `CHPL_LLVM=bundled`
-  (see TODO?)
 * generated GPU kernels are now named using their source filename/line number
 * added support for multi-arch GPU executables when targeting NVIDIA GPUs
   (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#vendor-portability)
 * added an experimental `--gpu-specialization` optimization
 * deprecated `assertOnGpu()` in favor of a new `@assertOnGpu` loop attribute
   (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#diagnostics-and-utilities)
+* enabled bulk-transfer of Chapel arrays with `c_array` element type
 
 Performance Optimizations / Improvements
 ----------------------------------------
 * optimized the performance of aligned array swaps for `Cyclic` and `Stencil`
-* enabled bulk-transfer of Chapel arrays with `c_array` element type
 
 Platform-specific Performance Optimizations / Improvements
 ----------------------------------------------------------
@@ -542,7 +540,7 @@ Tool Improvements
 * made `c2chapel` generate `c_ptr[Const]`s for multidimensional arrays
 * `printchplenv` now prints `CHPL_GPU` by default when `CHPL_LOCALE_MODEL=gpu`
 * made `printchplenv` error when using `CHPL_GPU=cpu` and `CHPL_TASKS=fifo`
-* added `:enum[constant]:` to the list of 'chpldoc'-supported inline markup  
+* added `:enum[constant]:` to the list of 'chpldoc'-supported inline markups  
   (see https://chapel-lang.org/docs/1.32/tools/chpldoc/chpldoc.html#inline-markup-2)
 
 Language Specification Improvements
@@ -554,7 +552,7 @@ Language Specification Improvements
 * updated the default intent of `owned`/`shared` to reflect that it's `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#owned-default-intent
   and https://chapel-lang.org/docs/1.32/language/spec/classes.html#shared-default-intent)
-* described how uses of generic types can be marked with `(?)`  
+* described how uses of generic types can be decorated with `(?)`  
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#marking-generic-types)
 * added a section describing how fields can be declared with generic type  
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fields-with-generic-types)
@@ -564,22 +562,12 @@ Language Specification Improvements
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#field-accesses)
 * reformatted the classes section to hide implementation details
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html)
-* added a link between the `%` documentation and `AutoMath.mod()`  
+* added a link between the `%` documentation and `mod()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/expressions.html#modulus-operators)
 * added links to the types discussed in `string` and `bytes` documentation 
 
-Other Documentation Improvements
---------------------------------
-* added a new primer providing a deep-dive on Chapel's various loop forms
-  (see https://chapel-lang.org/docs/1.32/primers/loops.html)
-* made a major refresh to the distributions primer  
-  (see https://chapel-lang.org/docs/1.32/primers/distributions.html)
-* updated the first-class procedures technote to reflect the new syntax  
-  (see https://chapel-lang.org/docs/1.32/technotes/firstClassProcedures.html)
-* replaced uses of `dmapped` with factory methods throughout the docs  
-  (e.g., see https://chapel-lang.org/docs/1.32/primers/distributions.html)
-* added a warning that the result of `.c_str()` may contain mid-buffer NULLs  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
+Documentation Improvements for the 'IO' Library
+-----------------------------------------------
 * added a new section about I/O transactions to the 'IO' module  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#i-o-transactions)
 * improved the clarity of the documentation of `mark()`/`commit()`/`revert()`  
@@ -599,48 +587,61 @@ Other Documentation Improvements
   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioendian)
 * refactored `where` clauses in `IO` to improve the generated documentation
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html)
-* improved several aspects of the 'Math' module documentation:
-  - added missing documentation for arguments of `AutoMath.isClose()`  
-    (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
-  - removed an incorrect mention of "absolute value" for `Math.tgamma()`  
-    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.tgamma)
-  - improved the description for `Math.ldExp()`  
-    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ldExp)
-  - fixed the documentation for `Math.atan2()` with 32-bit arguments  
-    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.atan2)
-  - extended the documentation for `Math.erf()`  
-    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.erf)
-  - added a link between the `AutoMath.mod()` documentation and `%`  
-    (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.mod)
-  - added a link between `Math.exp()`/`Math.expm1()` and `Math.e`  
-    (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.exp  
-     and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.expm1)
+
+Documentation Improvements for the 'Math' Library
+-------------------------------------------------
+* added missing documentation for arguments of `isClose()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
+* removed an incorrect mention of "absolute value" for `tgamma()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.tgamma)
+* improved the description for `ldExp()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ldExp)
+* fixed the documentation for `atan2()` with 32-bit arguments  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.atan2)
+* extended the documentation for `erf()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.erf)
+* added a link between the `mod()` documentation and `%`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.mod)
+* added a link between `exp()`/`expm1()` and `e`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.exp  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.expm1)
+
+Other Documentation Improvements
+--------------------------------
+* added a new primer providing a deep-dive into Chapel's various loop forms
+  (see https://chapel-lang.org/docs/1.32/primers/loops.html)
+* made a major refresh to the distributions primer  
+  (see https://chapel-lang.org/docs/1.32/primers/distributions.html)
+* updated the first-class procedures technote to reflect the new syntax  
+  (see https://chapel-lang.org/docs/1.32/technotes/firstClassProcedures.html)
+* replaced uses of `dmapped` with factory methods throughout the docs  
+  (e.g., see https://chapel-lang.org/docs/1.32/primers/distributions.html)
+* added a warning that the result of `.c_str()` may contain mid-buffer NULLs  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
 * refactored and expanded `BigInteger` documentation to be more comprehensive
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html)
 * added a note that `chown()` requires elevated privileges to be successful
-* refactored documentation for `DynamicIters.Method`, and `Subprocess.pipeStyle`
+* refactored documentation for `DynamicIters.Method` and `Subprocess.pipeStyle`
   (see https://chapel-lang.org/docs/1.32/modules/standard/DynamicIters.html#DynamicIters.Method
   and https://chapel-lang.org/docs/1.32/modules/standard/Subprocess.html#Subprocess.pipeStyle)
 * fixed warnings in 'Map' that incorrectly referred to the `set` type
 * updated docs to mention `arm64` as a synonym for `aarch64`  
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/usingchapel/chplenv.html#chpl-host-arch)
 
 Example Codes
 -------------
 * updated sync primer to reflect stable methods and variable naming conventions
   (see https://chapel-lang.org/docs/1.32/primers/syncs.html)
-* removed `fft.chpl` and `hpl.chpl` from the example codes due to immaturity
-
-Syntax Highlighting
--------------------
+* moved `fft.chpl` and `hpl.chpl` out of the release example due to immaturity
+* generally kept example codes up-to-date with respect to language changes
 
 Generated Executable Flags
 --------------------------
 * added co-locale support to the `-nl`/`--numLocales` flag
   (e.g., `-nl 4x2` means run on 4 nodes with 2 locales per node)
   (see https://chapel-lang.org/docs/1.32/usingchapel/multilocale.html#co-locales)
-* unstable `config` variables are now hidden in the `--help` output
-* unstable `config` variables now generate a warning when used on command-line
+* unstable `config` variables are now hidden in the output of `--help`
+* unstable `config`s now generate a warning when set on the command-line
 
 Portability / Platform-specific Improvements
 --------------------------------------------
@@ -648,8 +649,8 @@ Portability / Platform-specific Improvements
   (see https://chapel-lang.org/docs/1.32/usingchapel/multilocale.html#co-locales)
 * updated arm-based (M1/M2) Macs to default to `CHPL_TASKS=qthreads`
 * updated arm-based (M1/M2) Macs to default to `CHPL_MEM=jemalloc`
-* improved the equivalence of `arm64` and `aarch64` in our scripting
 * resolved sporadic memory consistency issues on ARM processors
+* improved the equivalence of `arm64` and `aarch64` in our scripting
 * added support for processors with heterogeneous processing units  
   (see https://chapel-lang.org/docs/1.32/usingchapel/executing.html#controlling-the-kind-of-processing-units)
 * enabled support for hugepages on the HPE Cray EX platform  
@@ -661,15 +662,13 @@ Portability / Platform-specific Improvements
 Compiler Improvements
 ---------------------
 * added `@llvm.assertVectorized` and `@llvm.metadata` as attributes on loops  
-  (see TODO)
 * stopped applying `-Wall` and `Werror` when compiling `extern` blocks
 * improved the behavior of `--mllvm` when it is passed an unknown flag
 
-Compiler Flags
---------------
-
 Runtime Library Changes
 -----------------------
+* made `chpl_library_init()` issue an error if called twice
+* made `chpl_library_finalize()` no longer exit, permitting client to continue
 * removed the ability to override the max # of endpoints with `CHPL_COMM=ofi`
 
 Launchers
@@ -694,7 +693,7 @@ Bug Fixes
 * fixed incorrect scoping of variables in `do`...`while` loops' conditions
 * fixed a bug in which FCPs printed incorrectly with JSON serializers
 * fiexd a bug in which unstable warnings were generated when using `_`
-* fixed `fifo` guard pages when using `jemalloc` allocator on arm-based macs
+* fixed `fifo` guard pages when using `CHPL_MEM=jemalloc` on arm-based macs
 * fixed a bug when using array type expression actuals within loop bodies
 * removed extra borrow when casting from a managed class to an unmanaged class
 * fixed a bug in which unstable warnings were generated for non-user code
@@ -707,8 +706,8 @@ Bug Fixes for GPU Computing
 ---------------------------
 * fixed a bug in which GPU atomic routines returned the wrong values  
   (see https://chapel-lang.org/docs/1.32/modules/standard/GPU.html?#GPU.gpuAtomicAdd)
-* fixed a bug when accessing `ref`s declared outside of a GPU-eligible loop
-* fixed a bug with `.locale` queries on AMD GPUs or when `--fast` was used
+* fixed a bug with accessing `ref`s declared outside of a GPU-eligible loop
+* fixed a bug with `.locale` queries on AMD GPUs, or when `--fast` was used
 * fixed an assertion when running GPU programs for AMD w/ `CHPL_DEVELOPER` set
 
 Bug Fixes for Libraries
@@ -718,7 +717,7 @@ Bug Fixes for Libraries
 * fixed a bug where `%r`/`%n` ignored precision arguments for integer values
 * fixed bug that prevented deserialization of `bytes` in JSON and CHPL formats
 * fixed bug where the `JsonDeserializer` could fail to parse a list
-* fixed incorrect error text when calling `c_ptrTo`/`c_ptrToConst` on a domain
+* fixed incorrect error text when calling `c_ptrTo[Const]()` on a domain
 * removed unintended warning when calling `Types.isCopyableType()` on a `sync`
 
 Bug Fixes for Tools
@@ -738,28 +737,17 @@ Developer-oriented changes: Process
 -----------------------------------
 * moved top-level .gitignore entries to their closest subdirectory
 
-Developer-oriented changes: Documentation
------------------------------------------
-
-Developer-oriented changes: Syntactic / Naming Changes
-------------------------------------------------------
-
 Developer-oriented changes: Module changes
 ------------------------------------------
 * improved the `BigInteger` module organization to reduce maintenance burden
 
-Developer-oriented changes: Performance improvements
-----------------------------------------------------
-
-Developer-oriented changes: Makefile / Build-time changes
----------------------------------------------------------
 
 Developer-oriented changes: Compiler Flags
 ------------------------------------------
 * added `--llvm-remarks[-function]` to report LLVM optimization information  
   (see https://chapel-lang.org/docs/1.32/technotes/llvm.html#inspecting-llvm-optimizations)
 * improved `--log-module` to support logging multiple modules at a time
-* removed the broken `--log-node` command
+* removed the broken `--log-node` flag
 
 Developer-oriented changes: Compiler improvements / changes
 -----------------------------------------------------------
@@ -772,7 +760,7 @@ Developer-oriented changes: Compiler improvements / changes
 
 Developer-oriented changes: 'dyno' Compiler improvements / changes
 ------------------------------------------------------------------
-* numerous improvements to the 'dyno' resolver for types and calls:
+* made numerous improvements to the 'dyno' resolver for types and calls:
   - added basic support for 'forwarding' to members in a class or record
   - added basic support for generic tuple type expressions (e.g. (?, integral))
   - added basic support for param-folding 'select' statements
@@ -786,10 +774,7 @@ Developer-oriented changes: Runtime improvements
 ------------------------------------------------
 * added a new runtime shim for the GASNet-EX API upgrade
 * enabled forceable creation of a fixed heap with `CHPL_COMM=ofi`
-* pinned ofi `fi_getinfo` API version to 1.9
-
-Developer-oriented changes: Platform-specific bug fixes
--------------------------------------------------------
+* pinned the `CHPL_COMM=ofi` `fi_getinfo` API version to 1.9
 
 Developer-oriented changes: Testing System
 ------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -450,9 +450,6 @@ Deprecated / Unstable / Removed 'Time' Library Features
 * deprecated `date.createFromTimestamp()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.createFromTimestamp)
 * deprecated `{date,time,dateTime}.isoFormat()` in favor of casts to strings  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.:,  
-   https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.time.:,  
-   and https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.:)
 * deprecated `dateTime.combine()` in favor of using initializers  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.combine  
    and https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.init)
@@ -463,7 +460,7 @@ Unstable Library Features
 -------------------------
 * marked `parSafe` as being unstable for `list`, `set`, and `map`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.parSafe,  
-   https://chapel-lang.org/docs/1/32/modules/standard/Set.html#Set.set.parSafe,  
+   https://chapel-lang.org/docs/1.32/modules/standard/Set.html#Set.set.parSafe,  
    and https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.parSafe)
 * marked several 'BigInteger' procedures as unstable  
   (i.e., `jacobi()`, `legendre()`, `kronecker()`, `gcd()`, `lcm()`, `fac()`,
@@ -487,12 +484,11 @@ Deprecated / Removed Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
 * deprecated the transitional `BigInteger.bigintInitThrows` config param
 * deprecated `BigInteger.get_str()` in favor of a cast to `string`  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
 * deprecated `list.first()`/`.last()` in favor of using paren-less methods  
   (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.first  
    and https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.last)
-* deprecated `IllegalArgumentError`'s two-argument initializer  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.IllegalArgumentError.init)
+* deprecated `IllegalArgumentError`'s two-argument initializer
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.IllegalArgumentError)
 * deprecated `Reflection.numFields()` in favor of `Reflection.getNumFields()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Reflection.html#Reflection.getNumFields)
 * removed the deprecated `BigInteger.Round` enum
@@ -576,7 +572,6 @@ Language Specification Improvements
 * improved the description of how identifiers are interpreted in methods  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#field-accesses)
 * reformatted the classes section to hide implementation details  
-  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html)
 * added a link between the `%` documentation and `mod()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/expressions.html#modulus-operators)
 * added links to the types discussed in `string` and `bytes` documentation 
@@ -592,7 +587,7 @@ Documentation Improvements for the 'IO' Library
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.advance  
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.seek)
 * added a new section about `file[Reader|Writer]` regions to the 'IO' module  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html##specifying-the-region-of-a-filereader-or-filewriter)
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#specifying-the-region-of-a-filereader-or-filewriter)
 * added new section about `file[Reader|Writer]` locking to the 'IO' module  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#locking-behavior-of-filereaders-and-filewriters)
 * removed references to file descriptors in `stdin`/`stdout`/`stderr` docs  
@@ -601,7 +596,6 @@ Documentation Improvements for the 'IO' Library
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioMode  
   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioendian)
 * refactored `where` clauses to improve the generated documentation  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html)
 
 Documentation Improvements for the 'Math' Library
 -------------------------------------------------
@@ -720,7 +714,6 @@ Bug Fixes for Build Issues
 Bug Fixes for GPU Computing
 ---------------------------
 * fixed a bug in which GPU atomic routines returned the wrong values  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/GPU.html?#GPU.gpuAtomicAdd)
 * fixed a bug with accessing `ref`s declared outside of a GPU-eligible loop
 * fixed a bug with `.locale` queries on AMD GPUs, or when `--fast` was used
 * fixed an assertion when running GPU programs for AMD w/ `CHPL_DEVELOPER` set

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -244,7 +244,7 @@ Changes / Feature Improvements in Libraries
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readLiteral
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.matchLiteral)
 * added overloads of deserializing methods that take arguments by `ref`  
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/technotes/ioSerializers.html#the-user-facing-deserializer-api)
 * generalized `[read|write]Binary()` to support multi-dimensional arrays  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readBinary
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileWriter.writeBinary))
@@ -559,7 +559,7 @@ Other Documentation Improvements
 * updated the first-class procedures technote to reflect the new syntax  
   (see https://chapel-lang.org/docs/1.32/technotes/firstClassProcedures.html)
 * replaced uses of `dmapped` with factory methods throughout the docs  
-  (see TODO)
+  (e.g., see https://chapel-lang.org/docs/1.32/primers/distributions.html)
 * added a warning that the result of `.c_str()` may contain mid-buffer NULLs  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
 * added a new section about I/O transactions to the 'IO' module  

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@ Release Changes List
 ====================
 
 * check sorting of categories
-o check placement of items into categories
-o check for ' vs `
+* check placement of items into categories
+* check for ' vs `
 o fulfill TODOs
 o check man page
 o check test/release/examples
@@ -80,7 +80,7 @@ Syntactic / Naming Changes
   - declaring the return type of a routine
   (e.g., `var t: T;` should be written `var t: T(?);` if `T` is such a type)
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#marking-generic-types)
-* added a warning for type signatures like 'T()' if 'T' is not fully defaulted
+* added a warning for type signatures like `T()` if `T` is not fully defaulted
 * added a warning for fields with generic class management to avoid confusion
 * renamed `[enter|leave]This()` to `[enter|exit]Context()` for context mgmt  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement)
@@ -109,7 +109,7 @@ Semantic Changes / Changes to the Chapel Language
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement
    and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
 * removed some capabilities from records with generic `var`/`const` fields  
-  (e.g., 'record R { var x; }' or 'record S { var y: integral; }')
+  (e.g., `record R { var x; }` or `record S { var y: integral; }`)
   - variables of such types can no longer be default-initialized
   - type signatures w/ named arguments are no longer supported (`R(x=int)`)  
     (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fields-without-types)
@@ -124,7 +124,7 @@ Semantic Changes / Changes to the Chapel Language
 * numeric `param`s can now be passed to `const ref` formals
   (e.g. given `proc f(const ref arg)`, `f(1)` is now supported)
 * l-value checking now applies to nested call expressions returning arrays
-  (e.g., 'modifyArray(returnsArray)' will now emit an l-value error)
+  (e.g., `modifyArray(returnsArray)` will now emit an l-value error)
 * `return` statements following a `throw` or `halt()` are now ignored  
   (see https://chapel-lang.org/docs/1.32/language/spec/error-handling.html#throwing-errors  
    and https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.halt)
@@ -217,7 +217,7 @@ Standard Library Modules
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.cIsoDayOfWeek)
 * added `date.utcToday` as a UTC version of local-time `date.today`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.utcToday)
-* added a `compiledForSingleLocale()` query to the `ChplConfig` module  
+* added a `compiledForSingleLocale()` query to the 'ChplConfig' module  
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.compiledForSingleLocale)
 
 Package Modules
@@ -305,7 +305,7 @@ Name Changes in the 'Math' Library
 
 Name Changes in the 'BigInteger' Library
 ----------------------------------------
-* generally unified argument names in these routines to 'x', 'y', ...
+* generally unified argument names in these routines to `x`, `y`, ...
 * renamed the enum `round` to `roundingMode`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.roundingMode)
 * renamed `[set|tst|com|clr]bit()` to `[set|get|toggle|clear]Bit()`  
@@ -461,7 +461,7 @@ Unstable Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.sort)
 * marked `Reflection.getRoutineName()` unstable within first-class procedures
 * marked several other 'Reflection' routines as unstable
-* marked all `CHPL_*` params in `ChplConfig` as unstable  
+* marked all `CHPL_*` params in 'ChplConfig' as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
 
 Deprecated / Removed Library Features
@@ -497,8 +497,8 @@ Deprecated / Removed Library Features
 * removed the deprecated `regex.compile()` type method
 * removed the deprecated `regex.sub()` and `regex.subn()` methods
 * removed the deprecated `[list|unrolledLinkedList].extend()` methods
-* removed the deprecated `Sys` module
-* removed the deprecated `OrderedSet` and `OrderedMap` package modules
+* removed the deprecated 'Sys' module
+* removed the deprecated 'OrderedSet' and 'OrderedMap' package modules
 
 GPU Computing
 -------------
@@ -520,7 +520,7 @@ GPU Computing
 
 Performance Optimizations / Improvements
 ----------------------------------------
-* optimized the performance of aligned array swaps for `Cyclic` and `Stencil`
+* optimized aligned array swaps for `cyclicDist` and `stencilDist`
 
 Platform-specific Performance Optimizations / Improvements
 ----------------------------------------------------------
@@ -540,7 +540,7 @@ Tool Improvements
 * made `c2chapel` generate `c_ptr[Const]`s for multidimensional arrays
 * `printchplenv` now prints `CHPL_GPU` by default when `CHPL_LOCALE_MODEL=gpu`
 * made `printchplenv` error when using `CHPL_GPU=cpu` and `CHPL_TASKS=fifo`
-* added `:enum[constant]:` to the list of 'chpldoc'-supported inline markups  
+* added `:enum[constant]:` to the list of `chpldoc`-supported inline markups  
   (see https://chapel-lang.org/docs/1.32/tools/chpldoc/chpldoc.html#inline-markup-2)
 
 Language Specification Improvements
@@ -585,7 +585,7 @@ Documentation Improvements for the 'IO' Library
 * refactored documentation for `IO.ioMode` and `IO.ioendian`
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioMode
   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioendian)
-* refactored `where` clauses in `IO` to improve the generated documentation
+* refactored `where` clauses to improve the generated documentation
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html)
 
 Documentation Improvements for the 'Math' Library
@@ -618,7 +618,7 @@ Other Documentation Improvements
   (e.g., see https://chapel-lang.org/docs/1.32/primers/distributions.html)
 * added a warning that the result of `.c_str()` may contain mid-buffer NULLs  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
-* refactored and expanded `BigInteger` documentation to be more comprehensive
+* refactored and expanded 'BigInteger' documentation to be more comprehensive
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html)
 * added a note that `chown()` requires elevated privileges to be successful
 * refactored documentation for `DynamicIters.Method` and `Subprocess.pipeStyle`
@@ -674,7 +674,7 @@ Runtime Library Changes
 Launchers
 ---------
 * added co-locale support to the `[slurm|pbs]-gasnetrun_ibv` launchers
-* updated the `pbs-gasnetrun_ibv` launcher to use 'place/select' qsub syntax
+* updated the `pbs-gasnetrun_ibv` launcher to use `place/select` qsub syntax
 
 Error Messages / Semantic Checks
 --------------------------------
@@ -761,9 +761,9 @@ Developer-oriented changes: Compiler improvements / changes
 Developer-oriented changes: 'dyno' Compiler improvements / changes
 ------------------------------------------------------------------
 * made numerous improvements to the 'dyno' resolver for types and calls:
-  - added basic support for 'forwarding' to members in a class or record
+  - added basic support for `forwarding` to members in a class or record
   - added basic support for generic tuple type expressions (e.g. (?, integral))
-  - added basic support for param-folding 'select' statements
+  - added basic support for param-folding `select` statements
   - added support for the `class` typeclass
   - improved handling of control flow when inferring an `iter`'s `yield` type
   - added support for the `c_ptr` type

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -582,8 +582,6 @@ Other Documentation Improvements
 * refactored documentation for `DynamicIters.Method`, and `Subprocess.pipeStyle`
   (see https://chapel-lang.org/docs/1.32/modules/standard/DynamicIters.html#DynamicIters.Method
   and https://chapel-lang.org/docs/1.32/modules/standard/Subprocess.html#Subprocess.pipeStyle)
-
-
 * fixed warnings in 'Map' that incorrectly referred to the `set` type
 * updated docs to mention `arm64` as a synonym for `aarch64`  
   (see TODO)
@@ -651,6 +649,7 @@ Bug Fixes
   (e.g., `var d: domain(?) = {1..5}` now works)
 * fixed incorrect scoping of variables in `do`...`while` loops' conditions
 * fixed a bug in which FCPs printed incorrectly with JSON serializers
+* fiexd a bug in which unstable warnings were generated when using `_`
 * fixed `fifo` guard pages when using `jemalloc` allocator on arm-based macs
 * fixed a bug when using array type expression actuals within loop bodies
 * removed extra borrow when casting from a managed class to an unmanaged class
@@ -675,6 +674,7 @@ Bug Fixes for Libraries
 * fixed a bug where `%r`/`%n` ignored precision arguments for integer values
 * fixed bug that prevented deserialization of `bytes` in JSON and CHPL formats
 * fixed bug where the `JsonDeserializer` could fail to parse a list
+* fixed incorrect error text when calling `c_ptrTo`/`c_ptrToConst` on a domain
 * removed unintended warning when calling `Types.isCopyableType()` on a `sync`
 
 Bug Fixes for Tools
@@ -721,7 +721,7 @@ Developer-oriented changes: Compiler improvements / changes
 -----------------------------------------------------------
 * added protypical support for LLVM 16
 * added an experimental driver mode, enabled using `--compiler-driver`  
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/technotes/driver.html)
 * improved `@deprecated` to handle deprecations from paren-ful to paren-less
 * stopped generating LLVM lifetime and invariant hints
 * put and get primitives now assume a `ref` / `const ref` is passed to them
@@ -1043,7 +1043,8 @@ Other Documentation Improvements
   (see https://chapel-lang.org/docs/1.31/usingchapel/chplenv.html#chpl-lib-pic)
 * updated an assertion that `fileReader` can produce `EEOF` to `OS.EofError`  
   (see https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.file.reader)
-
+* simplified documentation of `c_ptrTo()` and related procedures' overloads  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptrTo)
 Example Codes
 -------------
 * added a new user's guide example program for promoted procedure calls

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -411,6 +411,8 @@ Memory Improvements
 Tool Improvements
 -----------------
 * made `c2chapel` generate `c_ptr[Const]`s for multidimensional arrays
+* added `:enum[constant]:` to the list of 'chpldoc'-supported inline markup  
+  (see https://chapel-lang.org/docs/1.32/tools/chpldoc/chpldoc.html#inline-markup-2)
 
 Language Specification Improvements
 -----------------------------------
@@ -418,7 +420,7 @@ Language Specification Improvements
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-require-statement)
 * simplified the explanation of default intents
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
-* adjusted the default type of `owned` and `shared` to be `const`  (TODO: ???)
+* updated the default intent of `owned`/`shared` to reflect that it's `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#owned-default-intent
   and https://chapel-lang.org/docs/1.32/language/spec/classes.html#shared-default-intent)
 * reformatted the classes section to hide implementation details
@@ -627,8 +629,6 @@ Developer-oriented changes: Tool Improvements
 * improved how `chpldoc` generates module documentation:
   - `where`-clauses are now printed out as part of a routine's signature
   - individual constants within an `enum` can now have their own documentation
-* added `:enum[constant]:` to the list of 'chpldoc'-supported inline markup  
-  (see https://chapel-lang.org/docs/1.32/tools/chpldoc/chpldoc.html#inline-markup-2)
 * added support for Chapel AST syntax highlighting
 * added sphinx message filter for `:enumconstant:`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,165 @@
 Release Changes List
 ====================
 
+version 1.32.0
+==============
+
+released September 28, 2023
+
+Highlights (see subsequent sections for further details)
+--------------------------------------------------------
+
+Configuration / Build / Packaging Changes
+-----------------------------------------
+
+New Language Features
+---------------------
+
+Language Feature Improvements
+-----------------------------
+
+Syntactic / Naming Changes
+--------------------------
+
+Semantic Changes / Changes to the Chapel Language
+-------------------------------------------------
+
+Deprecated / Unstable / Removed Language Features
+-------------------------------------------------
+
+Namespace Changes
+-----------------
+
+Standard Library Modules
+------------------------
+
+Package Modules
+---------------
+
+Standard Domain Maps (Layouts and Distributions)
+------------------------------------------------
+
+Changes / Feature Improvements in Libraries
+-------------------------------------------
+
+Name Changes in Libraries
+-------------------------
+
+Deprecated / Unstable / Removed Library Features
+------------------------------------------------
+
+GPU Computing
+-------------
+
+Performance Optimizations / Improvements
+----------------------------------------
+
+Platform-specific Performance Optimizations / Improvements
+----------------------------------------------------------
+
+Compilation-Time / Generated Code Improvements
+----------------------------------------------
+
+Memory Improvements
+-------------------
+
+Tool Improvements
+-----------------
+
+Language Specification Improvements
+-----------------------------------
+
+Other Documentation Improvements
+--------------------------------
+
+Example Codes
+-------------
+
+Syntax Highlighting
+-------------------
+
+Portability / Platform-specific Improvements
+--------------------------------------------
+
+Compiler Improvements
+---------------------
+
+Compiler Flags
+--------------
+
+Generated Executable Flags
+--------------------------
+
+Runtime Library Changes
+-----------------------
+
+Launchers
+---------
+
+Error Messages / Semantic Checks
+--------------------------------
+
+Bug Fixes
+---------
+
+Bug Fixes for Build Issues
+--------------------------
+
+Bug Fixes for GPU Computing
+---------------------------
+
+Bug Fixes for Libraries
+-----------------------
+
+Bug Fixes for Tools
+-------------------
+
+Third-Party Software Changes
+----------------------------
+
+Developer-oriented changes: Process
+-----------------------------------
+
+Developer-oriented changes: Documentation
+-----------------------------------------
+
+Developer-oriented changes: Syntactic / Naming Changes
+------------------------------------------------------
+
+Developer-oriented changes: Module changes
+------------------------------------------
+
+Developer-oriented changes: Performance improvements
+----------------------------------------------------
+
+Developer-oriented changes: Makefile / Build-time changes
+---------------------------------------------------------
+
+Developer-oriented changes: Compiler Flags
+------------------------------------------
+
+Developer-oriented changes: Compiler improvements / changes
+-----------------------------------------------------------
+
+Developer-oriented changes: 'dyno' Compiler improvements / changes
+------------------------------------------------------------------
+
+Developer-oriented changes: Runtime improvements
+------------------------------------------------
+
+Developer-oriented changes: Platform-specific bug fixes
+-------------------------------------------------------
+
+Developer-oriented changes: Testing System
+------------------------------------------
+
+Developer-oriented changes: Tool Improvements
+---------------------------------------------
+
+Developer-oriented changes: Utilities
+-------------------------------------~
+
+
 version 1.31.0
 ==============
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -157,7 +157,7 @@ Developer-oriented changes: Tool Improvements
 ---------------------------------------------
 
 Developer-oriented changes: Utilities
--------------------------------------~
+-------------------------------------
 
 
 version 1.31.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,10 @@ Release Changes List
 * check sorting of categories
 * check placement of items into categories
 * check for ' vs `
-o fulfill TODOs
-o check man page
-o check test/release/examples
-o check for docs/1.32/ links
+* fulfill TODOs
+* check man page
+* check test/release/examples
+* check for docs/1.32/ links
 o check forced linebreaks
 o check links
 o check initial '*'
@@ -31,7 +31,7 @@ New Language Features
 * added explicit `out` return and yield intents  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-out-return-intent  
    and https://chapel-lang.org/docs/1.32/language/spec/iterators.html#the-yield-statement)
-* added a user-facing task yield mechanism, `currentTask.yieldExecution()`
+* added a user-facing task yield mechanism, `currentTask.yieldExecution()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/task-parallelism-and-synchronization.html#yielding-task-execution)
 * added support for declaring that records/classes fulfill a given interface  
   (e.g., `record r: i { ... }` says that `r` implements the `i` interface;  
@@ -44,13 +44,13 @@ New Language Features
 
 Language Feature Improvements
 -----------------------------
-* added support for slicing arrays with unaligned ranges
+* added support for slicing arrays with unaligned ranges  
   (e.g., `var A: [1..3] int = 1..3; writeln(A[..2 by 2]);` prints 1)
 * casts between ranges now check the validity of the stride  
   (see https://chapel-lang.org/docs/1.32/language/spec/conversions.html#explicit-range-conversions)
 * enabled assigning and initilizing integral ranges from bool ranges  
   (e.g., `var r: range(int(8)) = false..true;` is now supported)
-* added a compiler warning when range slicing might halt execution
+* added a compiler warning when range slicing might halt execution  
   (e.g., `var r1 = 1.. by 2, r2 = 2.. by 2; writeln(r1[r2]);`)
 * improved handling of intents on array formals in extern functions
 * added promoted casts from array-of-`T` to `T` without a cast from `T` to `T`
@@ -66,19 +66,19 @@ Syntactic / Naming Changes
 * `these` is now reserved as a keyword for use as the default iterator method  
   (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#the-these-method)
 * reserved `init`, `postinit`, `deinit`, `super`, and `range` as keywords
-* replaced `[this.]complete();` with `init this;` when defining initializers
+* replaced `[this.]complete();` with `init this;` when defining initializers  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#limitations-on-instance-usage-in-initializers)
-* renamed `range.aligned` to `range.isAligned()`
-  (see https://chapel-lang.org/docs/main/language/spec/ranges.html#ChapelRange.range.isAligned)
-* renamed `domain.dist` to `domain.distribution`
-  (see https://chapel-lang.org/docs/main/language/spec/domains.html%20distribution#ChapelDomain.distribution)
+* renamed `range.aligned` to `range.isAligned()`  
+  (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#ChapelRange.range.isAligned)
+* renamed `domain.dist` to `domain.distribution`  
+  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html%20distribution#ChapelDomain.distribution)
 * added a warning when inheriting from a generic class if `(?)` is not used  
   (e.g., `class C: D` must now be written `class C: D(?)` for generic `D`)
 * added warnings for non-fully-defaulted generic types lacking `(?)` when:
   - declaring fields or variables
   - declaring formal arguments
-  - declaring the return type of a routine
-  (e.g., `var t: T;` should be written `var t: T(?);` if `T` is such a type)
+  - declaring the return type of a routine  
+  (e.g., `var t: T;` should be written `var t: T(?);` if `T` is such a type)  
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#marking-generic-types)
 * added a warning for type signatures like `T()` if `T` is not fully defaulted
 * added a warning for fields with generic class management to avoid confusion
@@ -96,16 +96,16 @@ Semantic Changes / Changes to the Chapel Language
 * redefined the `const` intent to enable optimization opportunities  
   - `const` allows implementation to choose `const ref` or `const in`
   - `const` asserts that the value will not be modified by other means
-  - `const` for an array now asserts that the domain will not change
+  - `const` for an array now asserts that the domain will not change  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-const-intent)
 * began changing the type of range literals with mixed-type `param` bounds  
   (e.g., `0..1:int(8)` is changing from `idxType=int(8)` to `int(64)`)
 * added an error for addition/subtraction of multi-dim. domains and `[u]int`s  
   (e.g., `{1..2, 1..2} - 1` is now an error)
-* built-in hashing now relies on the `hashable` interface
+* built-in hashing now relies on the `hashable` interface  
   (see https://chapel-lang.org/docs/1.32/language/spec/records.html#hashing-a-record
    and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
-* context managers now rely on the `contextManager` interface
+* context managers now rely on the `contextManager` interface  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement
    and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
 * removed some capabilities from records with generic `var`/`const` fields  
@@ -113,17 +113,17 @@ Semantic Changes / Changes to the Chapel Language
   - variables of such types can no longer be default-initialized
   - type signatures w/ named arguments are no longer supported (`R(x=int)`)  
     (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fields-without-types)
-* adjusted the deinit point for nested call expressions in `var`/`const` decls
+* adjusted the deinit point for nested call expressions in `var`/`const` decls  
   (see https://chapel-lang.org/docs/1.32/language/spec/variables.html#deinit-points)
-* a call that could refer to a method or a non-method is now an ambiguity
+* a call that could refer to a method or a non-method is now an ambiguity  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#determining-most-specific-functions)
-* methods are no longer included in the more-visible disambiguation check
+* methods are no longer included in the more-visible disambiguation check  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#determining-most-specific-functions)
 * declaring a paren-less method with the same name as a field is now an error  
   (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#methods-without-parentheses)
-* numeric `param`s can now be passed to `const ref` formals
+* numeric `param`s can now be passed to `const ref` formals  
   (e.g. given `proc f(const ref arg)`, `f(1)` is now supported)
-* l-value checking now applies to nested call expressions returning arrays
+* l-value checking now applies to nested call expressions returning arrays  
   (e.g., `modifyArray(returnsArray)` will now emit an l-value error)
 * `return` statements following a `throw` or `halt()` are now ignored  
   (see https://chapel-lang.org/docs/1.32/language/spec/error-handling.html#throwing-errors  
@@ -147,13 +147,13 @@ Unstable Language Features
 * marked `sync.[readXX|writeFF|writeXF|reset|isFull]()` unstable
 * marked `umask()` on `locale` as being unstable
 * marked binary operators between tuples and scalars as unstable
-* marked several binary operators over ranges and integral values as unstable
+* marked several binary operators over ranges and integral values as unstable  
   (e.g., `(1..3)*(1..5)` and `(1..3) + 1` are now unstable
 * marked default initialization of partially bounded ranges as unstable  
   (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#default-values)
-* marked first/last/empty queries on unbounded ranges of bool/enum unstable
+* marked first/last/empty queries on unbounded ranges of bool/enum unstable  
   (e.g., `(false..).last` is now unstable)
-* marked `==` and `!=` between unbounded ranges of bool/enum unstable
+* marked `==` and `!=` between unbounded ranges of bool/enum unstable  
   (e.g., `(false..true) == (false..)` is now `true` and unstable)
 * marked transformational methods on ranges and domains unstable  
   (e.g., `.translate()`, `.interior()`, `exterior()`, `.expand()`)
@@ -168,14 +168,14 @@ Unstable Language Features
 
 Deprecated / Removed Language Features
 --------------------------------------
-* deprecated the `c_string` type in favor of `c_ptrConst(c_char)`
+* deprecated the `c_string` type in favor of `c_ptrConst(c_char)`  
   (see https://chapel-lang.org/docs/1.32/language/evolution.html#c-string-deprecation)
 * deprecated implicit conversions for formals with generic numeric types  
   (e.g., given `proc f(r: real(?w)) {}`, `f(1)` will not compile in the future)
 * deprecated `single` variables
 * deprecated returning `sync`, `single`, or `atomic` by value
 * deprecated relying on default initializers for `sync`, `single`, and `atomic`
-* deprecated the `owned.borrow` type method
+* deprecated the `owned.borrow` type method  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#OwnedObject.owned.borrow)
 * deprecated assignment between unbounded ranges of incompatible `idxtype`
 * deprecated `range.isAmbiguous()` in favor of `!range.isAligned()`
@@ -183,7 +183,7 @@ Deprecated / Removed Language Features
 * deprecated the `.intIdxType` query on ranges, domains, and arrays  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.intIdxType)
 * deprecated the default cast from arrays to `string`
-* deprecated `require` statements for Chapel source files at non-module scope
+* deprecated `require` statements for Chapel source files at non-module scope  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-require-statement)
 * deprecated the `useNewArrayFind` config param
 * removed the previously deprecated casts from `string` and `bytes` to `regex`
@@ -194,9 +194,9 @@ Deprecated / Removed Language Features
 
 Namespace Changes
 -----------------
-* moved several automatically-included math symbols from 'AutoMath' to 'Math'
+* moved several automatically-included math symbols from 'AutoMath' to 'Math'  
   (e.g., `div[ceil|floor][pos]()`, `nearbyint()`, `rint()`)
-* moved `string.c_str()` and `bytes.c_str()` to `CTypes`
+* moved `string.c_str()` and `bytes.c_str()` to `CTypes`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
 * upgraded `Json` from a package to a standard module, now named `JSON`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/JSON.html)
@@ -206,7 +206,7 @@ Namespace Changes
 Standard Library Modules
 ------------------------
 * marked the 'Random', 'CommDiagnostics', and 'Communication' modules unstable
-* added `binarySerializer` and `binaryDeserializer` types to the 'IO' module
+* added `binarySerializer` and `binaryDeserializer` types to the 'IO' module  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binarySerializer
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binaryDeserializer)
 * added new `%<`, `%^`, and `%>` format specifiers for justification  
@@ -234,13 +234,13 @@ Standard Domain Maps (Layouts and Distributions)
 * converted standard distributions into records, removing the need for `dmap`  
   (e.g., see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html)
 * renamed the standard distributions to match their module names  
-  (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.)
+  (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.)  
   (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html, et al.)
 * unified and extended the factory methods on `[block|cyclic|stencil]Dist`  
   (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist.createDomain,  
    https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist.createDomain,  
   and https://chapel-lang.org/docs/1.32/modules/dists/StencilDist.html#StencilDist.stencilDist.createDomain)
-* disallowed oversubscription in `cyclicDist` and `stencilDist`
+* disallowed oversubscription in `cyclicDist` and `stencilDist`  
   (e.g., `var c = new cyclicDist(1, [here, here]);` now reports an error)
 * marked advanced initializer arguments in `blockDist`/`cyclicDist` unstable  
   (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist
@@ -274,33 +274,33 @@ Changes / Feature Improvements in Libraries
 Name Changes in the 'Math' Library
 ----------------------------------
 * unified the argument names in 'Math' module routines
-* renamed `INFINITY` to `inf` and `NAN` to `nan`
+* renamed `INFINITY` to `inf` and `NAN` to `nan`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.inf  
    and https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.nan)
-* renamed ``is[finite|inf|nan]()` to `is[Finite|Inf|Nan]()`
+* renamed ``is[finite|inf|nan]()` to `is[Finite|Inf|Nan]()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isFinite et al.)
-* renamed `conjg()` to `conj()`
+* renamed `conjg()` to `conj()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.conj)
-* renamed `carg()` to `phase()`
+* renamed `carg()` to `phase()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.phase)
-* renamed `cproj()` to `riemProj()`
+* renamed `cproj()` to `riemProj()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.riemProj)
-* renamed `div[ceil|floor][pos]()` to `div[Ceil|Floor][Pos]()`
+* renamed `div[ceil|floor][pos]()` to `div[Ceil|Floor][Pos]()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divCeil et al.)
-* renamed `isclose()` to `isClose()`
+* renamed `isclose()` to `isClose()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isClose)
-* renamed `tgamma()` to `gamma()` and `lgamma()` to `lnGamma()`
+* renamed `tgamma()` to `gamma()` and `lgamma()` to `lnGamma()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.gamma  
    and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.lnGamma)
-* renamed `ldexp()` to `ldExp()` and its argument from `n` to `exp`
+* renamed `ldexp()` to `ldExp()` and its argument from `n` to `exp`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ldExp)
 * renamed `*_pi` constants to `*Pi` and marked them unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.halfPi et al.)
 * renamed `sqrt_2` to `sqrt2` and `recipr_sqrt_2` to `reciprSqrt2`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.sqrt2)
-* renamed `log2_e` to `log2E` and `log10_e` to `log10E`
+* renamed `log2_e` to `log2E` and `log10_e` to `log10E`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.log2E)
-* renamed `ln_2` to `ln2` and `ln_10` to `ln10`
+* renamed `ln_2` to `ln2` and `ln_10` to `ln10`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ln2)
 
 Name Changes in the 'BigInteger' Library
@@ -343,7 +343,7 @@ Other Name Changes in Libraries
 -------------------------------
 * renamed the serializer/deserializer types to use camelCasing  
   (e.g., `DefaultSerializer` is now `defaultSerializer`)
-* renamed `map.addOrSet()` to `map.addOrReplace()`
+* renamed `map.addOrSet()` to `map.addOrReplace()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.addOrReplace)
 * renamed `CodepointSplittingError` to `CodepointSplitError`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.CodepointSplitError)
@@ -358,7 +358,7 @@ Deprecated / Unstable / Removed 'IO' Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html)
 * marked `fileReader.assertEOF()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.assertEOF)
-* deprecated `[read|write]This()` methods in favor of `[de]serialize()`
+* deprecated `[read|write]This()` methods in favor of `[de]serialize()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html#the-serialize-and-deserialize-methods
 * deprecated `fileReader.skipField()` in favor of (de)serializers  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#FormattedIO.fileReader.skipField)
@@ -411,12 +411,12 @@ Deprecated / Unstable / Removed 'Math' Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.logBasePow2)
 * marked `erf()` and `erfc()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.erf)
-* marked the Bessel functions as unstable
+* marked the Bessel functions as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.j0 et al.)
 * marked `divCeilPos()` and `divFloorPos()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divCeilPos  
    and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.divFloorPos)
-* marked `[half|quarter|recipr|twiceRecipr[Sqrt]Pi` as unstable
+* marked `[half|quarter|recipr|twiceRecipr[Sqrt]Pi` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.halfPi et al.)
 * marked `sqrt2` and `reciprSqrt2` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.sqrt2
@@ -452,10 +452,10 @@ Unstable Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.parSafe,  
    https://chapel-lang.org/docs/1/32/modules/standard/Set.html#Set.set.parSafe,  
    and https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.parSafe)
-* marked several 'BigInteger' procedures as unstable
+* marked several 'BigInteger' procedures as unstable  
   (i.e., `jacobi()`, `legendre()`, `kronecker()`, `gcd()`, `lcm()`, `fac()`,
    `bin()`, `fib()`, `fib2()`, `probablyPrime()`)
-* marked `c_fn_ptr` unstable
+* marked `c_fn_ptr` unstable  
   (see https://chapel-lang.org/docs/1.32/technotes/extern.html#c-fn-ptr)
 * marked `list.sort()` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.sort)
@@ -471,14 +471,14 @@ Deprecated / Removed Library Features
 * deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
 * deprecated the transitional `BigInteger.bigintInitThrows` config param
-* deprecated `BigInteger.get_str()` in favor of a cast to `string`
+* deprecated `BigInteger.get_str()` in favor of a cast to `string`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
 * deprecated `list.first()`/`.last()` in favor of using paren-less methods  
   (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.first
    and https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.last)
 * deprecated `IllegalArgumentError`'s two-argument initializer  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.IllegalArgumentError.init)
-* deprecated `Reflection.numFields()` in favor of `Reflection.getNumFields()`
+* deprecated `Reflection.numFields()` in favor of `Reflection.getNumFields()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Reflection.html#Reflection.getNumFields)
 * removed the deprecated `BigInteger.Round` enum
 * removed the deprecated `bigint` initializers that halted/returned error codes
@@ -488,7 +488,7 @@ Deprecated / Removed Library Features
 * removed the deprecated `bigint.powm()` method
 * removed the deprecated `bigint.sizeinbase()` and `.size()` methods
 * removed the deprecated `bigint.get_d_2exp()` method
-* removed several deprecated procedures from 'BigInteger'
+* removed several deprecated procedures from 'BigInteger'  
   (i.e., `scan0())`, `scan1()`, `divexact()`, qcdext()`, `probab_prime_p()`,
    `divisible_[2xp_]p()`, `congruent_[2exp_]p()`, `div_r()`, `div_qr()`,
    `div_[q|r]_2exp()`)
@@ -506,15 +506,15 @@ GPU Computing
 * improved the performance of math routines in GPU kernels
 * improved performance when using arrays within kernels
 * added more math routines when using AMD GPUs
-* added support for dumping AMD assembly files when using `--savec`
+* added support for dumping AMD assembly files when using `--savec`  
   (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#examining-generated-assembly)
 * started using per-task, per-device streams to enable better overlap
 * CUDA 12 is now supported when using `CHPL_LLVM=bundled`
 * generated GPU kernels are now named using their source filename/line number
-* added support for multi-arch GPU executables when targeting NVIDIA GPUs
+* added support for multi-arch GPU executables when targeting NVIDIA GPUs  
   (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#vendor-portability)
 * added an experimental `--gpu-specialization` optimization
-* deprecated `assertOnGpu()` in favor of a new `@assertOnGpu` loop attribute
+* deprecated `assertOnGpu()` in favor of a new `@assertOnGpu` loop attribute  
   (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#diagnostics-and-utilities)
 * enabled bulk-transfer of Chapel arrays with `c_array` element type
 
@@ -547,7 +547,7 @@ Language Specification Improvements
 -----------------------------------
 * documented the `require` statement  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-require-statement)
-* simplified the explanation of default intents
+* simplified the explanation of default intents  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
 * updated the default intent of `owned`/`shared` to reflect that it's `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#owned-default-intent
@@ -558,9 +558,9 @@ Language Specification Improvements
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fields-with-generic-types)
 * added a section describing generic types with defaults  
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fully-defaulted-generic-types)
-* improved the description of how identifiers are interpreted in methods
+* improved the description of how identifiers are interpreted in methods  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#field-accesses)
-* reformatted the classes section to hide implementation details
+* reformatted the classes section to hide implementation details  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html)
 * added a link between the `%` documentation and `mod()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/expressions.html#modulus-operators)
@@ -582,10 +582,10 @@ Documentation Improvements for the 'IO' Library
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#locking-behavior-of-filereaders-and-filewriters)
 * removed references to file descriptors in `stdin`/`stdout`/`stderr` docs  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.stdin)
-* refactored documentation for `IO.ioMode` and `IO.ioendian`
+* refactored documentation for `IO.ioMode` and `IO.ioendian`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioMode
   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioendian)
-* refactored `where` clauses to improve the generated documentation
+* refactored `where` clauses to improve the generated documentation  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html)
 
 Documentation Improvements for the 'Math' Library
@@ -608,7 +608,7 @@ Documentation Improvements for the 'Math' Library
 
 Other Documentation Improvements
 --------------------------------
-* added a new primer providing a deep-dive into Chapel's various loop forms
+* added a new primer providing a deep-dive into Chapel's various loop forms  
   (see https://chapel-lang.org/docs/1.32/primers/loops.html)
 * made a major refresh to the distributions primer  
   (see https://chapel-lang.org/docs/1.32/primers/distributions.html)
@@ -618,10 +618,10 @@ Other Documentation Improvements
   (e.g., see https://chapel-lang.org/docs/1.32/primers/distributions.html)
 * added a warning that the result of `.c_str()` may contain mid-buffer NULLs  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
-* refactored and expanded 'BigInteger' documentation to be more comprehensive
+* refactored and expanded 'BigInteger' documentation to be more comprehensive  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html)
 * added a note that `chown()` requires elevated privileges to be successful
-* refactored documentation for `DynamicIters.Method` and `Subprocess.pipeStyle`
+* refactored documentation for `DynamicIters.Method` and `Subprocess.pipeStyle`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/DynamicIters.html#DynamicIters.Method
   and https://chapel-lang.org/docs/1.32/modules/standard/Subprocess.html#Subprocess.pipeStyle)
 * fixed warnings in 'Map' that incorrectly referred to the `set` type
@@ -630,15 +630,15 @@ Other Documentation Improvements
 
 Example Codes
 -------------
-* updated sync primer to reflect stable methods and variable naming conventions
+* updated sync primer to reflect stable methods and variable naming conventions  
   (see https://chapel-lang.org/docs/1.32/primers/syncs.html)
 * moved `fft.chpl` and `hpl.chpl` out of the release example due to immaturity
 * generally kept example codes up-to-date with respect to language changes
 
 Generated Executable Flags
 --------------------------
-* added co-locale support to the `-nl`/`--numLocales` flag
-  (e.g., `-nl 4x2` means run on 4 nodes with 2 locales per node)
+* added co-locale support to the `-nl`/`--numLocales` flag  
+  (e.g., `-nl 4x2` means run on 4 nodes with 2 locales per node)  
   (see https://chapel-lang.org/docs/1.32/usingchapel/multilocale.html#co-locales)
 * unstable `config` variables are now hidden in the output of `--help`
 * unstable `config`s now generate a warning when set on the command-line
@@ -688,7 +688,7 @@ Bug Fixes
 * fixed importing tertiary methods by naming a builtin type like `string`
 * fixed a bug in which `CHPL_UNWIND` could not be overridden on some platforms
 * fixed internal errors when using tuples as formal or return types in FCPs
-* fixed declaring a variable with an explicitly generic type
+* fixed declaring a variable with an explicitly generic type  
   (e.g., `var d: domain(?) = {1..5}` now works)
 * fixed incorrect scoping of variables in `do`...`while` loops' conditions
 * fixed a bug in which FCPs printed incorrectly with JSON serializers
@@ -795,7 +795,7 @@ Developer-oriented changes: Tool Improvements
 
 Developer-oriented changes: Utilities
 -------------------------------------
-* added a utility for batch replacement guided by errors reported by paratest
+* added a utility for batch replacement guided by errors reported by paratest  
   (see https://github.com/chapel-lang/chapel/tree/release/1.32/util/devel/deprecationScript)
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -620,13 +620,14 @@ Generated Executable Flags
 --------------------------
 * added co-locale support to the `-nl`/`--numLocales` flag
   (e.g., `-nl 4x2` means run on 4 nodes with 2 locales per node)
+  (see https://chapel-lang.org/docs/1.32/usingchapel/multilocale.html#co-locales)
 * unstable `config` variables are now hidden in the `--help` output
 * unstable `config` variables now generate a warning when used on command-line
 
 Portability / Platform-specific Improvements
 --------------------------------------------
 * added support for co-locales to `CHPL_COMM=gasnet` with the `ibv` substrate  
-  (see TODO)
+  (see https://chapel-lang.org/docs/1.32/usingchapel/multilocale.html#co-locales)
 * resolved sporadic memory consistency issues on ARM processors
 * added support for processors with heterogeneous processing units  
   (see https://chapel-lang.org/docs/1.32/usingchapel/executing.html#controlling-the-kind-of-processing-units)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,15 +15,21 @@ Configuration / Build / Packaging Changes
 
 New Language Features
 ---------------------
+* added support for declaring that records/classes fulfill a given interface  
+  (e.g., `record r: i { ... }` says that `r` implements the `i` interface;  
+   see TODO)
 * added support for an array creation interface that throws if out of memory  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.tryCreateArray)
 
 Language Feature Improvements
 -----------------------------
 * added promoted casts from array-of-`T` to `T` without a cast from `T` to `T`
+* first-class procedures are now printed similarly to Chapel's syntax
 
 Syntactic / Naming Changes
 --------------------------
+* replaced `[this.]complete();` with `init this;` when defining initializers
+  (see TODO)
 * `these` is now reserved as a keyword for use as the default iterator method  
   (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#the-these-method)
 * renamed `[enter|leave]This()` to `[enter|exit]Context()` for context mgmt  
@@ -32,6 +38,10 @@ Syntactic / Naming Changes
 
 Semantic Changes / Changes to the Chapel Language
 -------------------------------------------------
+* built-in hashing now relies on the `hashable` interface
+  (see TODO)
+* context managers now rely on the `contextManager` interface
+  (see TODO)
 
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
@@ -40,6 +50,8 @@ Deprecated / Unstable / Removed Language Features
 * deprecated the `useNewArrayFind` config param
 * removed support for the deprecated array `.find()` overload
 * removed support for variable-width `bool` types and related queries
+* made importing tertiary methods by naming their type unstable  
+  (e.g., `import IO.string;` is no longer stable)
 
 Namespace Changes
 -----------------
@@ -66,9 +78,13 @@ Standard Domain Maps (Layouts and Distributions)
 * renamed the standard distributions to match their module names  
   (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.  
    see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html et al.)
+* marked advanced initializer arguments in `blockDist`/`cyclicDist` unstable  
+  (see TODO)
 
 Changes / Feature Improvements in Libraries
 -------------------------------------------
+* generalized `[read|write]Binary()` to support multi-dimensional arrays  
+  (see TODO)
 * made `chpl_library_init()` issue an error if called twice
 * made `chpl_library_finalize()` no longer exit, permitting client to continue
 
@@ -89,6 +105,8 @@ Deprecated / Unstable / Removed Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
 * marked `c_fn_ptr` unstable
   (see https://chapel-lang.org/docs/1.32/technotes/extern.html#c-fn-ptr)
+* deprecated `list.first()`/`.last()` in favor of using paren-less methods  
+  (see TODO)
 * deprecated the `day` and `isoDayOfWeek` enums in favor of `dayOfWeek`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.day)
 * deprecated `MINYEAR`/`MAXYEAR` in favor of `date.[min|max].year`  
@@ -111,11 +129,18 @@ Deprecated / Unstable / Removed Library Features
    and https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.init)
 * deprecated `dateTime.{isoCalendar(), toOrdinal(), weekday(), isoWeekday()}`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.toOrdinal et al.)
+* marked `Reflection.getRoutineName()` unstable within first-class procedures
 * removed deprecated `c_sizeof()` signature with formal name `x`
 
 
 GPU Computing
 -------------
+* improved performance when using arrays within kernels
+* generated GPU kernels are now named using their source filename/line number
+* added support for multi-arch GPU executables when targeting NVIDIA GPUs
+  (see TODO)
+* deprecated `assertOnGpu()` in favor of a new `@assertOnGpu` loop attribute
+  (see TODO)
 
 Performance Optimizations / Improvements
 ----------------------------------------
@@ -184,10 +209,14 @@ Launchers
 Error Messages / Semantic Checks
 --------------------------------
 * simplified error formatting when compiling C code within an `extern` block
+* fixed incorrect underlining of string literals in detailed error messages
 
 Bug Fixes
 ---------
+* fixed importing tertiary methods by naming a builtin type like `string`
 * fixed a bug in which `CHPL_UNWIND` could not be overridden on some platforms
+* fixed internal errors when using tuples as formal or return types in FCPs
+* fixed incorrect scoping of variables in `do`...`while` loops' conditions
 * fixed a bug in which FCPs printed incorrectly with JSON serializers
 
 Bug Fixes for Build Issues
@@ -196,6 +225,7 @@ Bug Fixes for Build Issues
 
 Bug Fixes for GPU Computing
 ---------------------------
+* fixed an assertion when running GPU programs for AMD w/ `CHPL_DEVELOPER` set
 
 Bug Fixes for Libraries
 -----------------------
@@ -232,9 +262,15 @@ Developer-oriented changes: Compiler improvements / changes
 -----------------------------------------------------------
 * added an experimental driver mode, enabled using `--compiler-driver`  
   (see TODO)
+* improved `@deprecated` to handle deprecations from paren-ful to paren-less
 
 Developer-oriented changes: 'dyno' Compiler improvements / changes
 ------------------------------------------------------------------
+* numerous improvements to the 'dyno' resolver:
+  - added support for the `class` typeclass
+  - improved handling of control flow when inferring an `iter`'s `yield` type
+  - added support for the `c_ptr` type
+  - added support for opaque `extern` types
 
 Developer-oriented changes: Runtime improvements
 ------------------------------------------------
@@ -249,6 +285,9 @@ Developer-oriented changes: Testing System
 
 Developer-oriented changes: Tool Improvements
 ---------------------------------------------
+* improved how `chpldoc` generates module documentation:
+  - `where`-clauses are now printed out as part of a routine's signature
+  - individual constants within an `enum` can now have their own documentation
 
 Developer-oriented changes: Utilities
 -------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,14 @@ Highlights (see subsequent sections for further details)
 
 Configuration / Build / Packaging Changes
 -----------------------------------------
+* updated arm-based (M1/M2) Macs to default to `CHPL_TASKS=qthreads`
+* updated arm-based (M1/M2) Macs to default to `CHPL_MEM=jemalloc`
 * improved the equivalence of `arm64` and `aarch64` in our scripting
 
 New Language Features
 ---------------------
+* added a user-facing task yield mechanism, `currentTask.yieldExecution()`
+  (see https://chapel-lang.org/docs/1.32/language/spec/task-parallelism-and-synchronization.html#yielding-task-execution)
 * added support for declaring that records/classes fulfill a given interface  
   (e.g., `record r: i { ... }` says that `r` implements the `i` interface;  
    see TODO)
@@ -41,7 +45,8 @@ Syntactic / Naming Changes
   (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#the-these-method)
 * renamed `[enter|leave]This()` to `[enter|exit]Context()` for context mgmt  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement)
-
+* renamed `sync` formals from `x: valtype` to `val: valType`
+* renamed `atomic` formals and formal types from `value: T` to `val: valType`
 
 Semantic Changes / Changes to the Chapel Language
 -------------------------------------------------
@@ -58,6 +63,8 @@ Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
 * marked `scan` unstable due to uncertainty about inclusive/exclusive choice
+* marked `compareAndSwap()` on `atomic` variables as unstable
+* marked `sync.[readXX|writeFF|writeXF|reset|isFull]()` unstable
 * marked explicit calls to `this()` methods as unstable
 * marked serial `these()` iterators taking arguments as unstable
 * marked default initialization of low- and high-bounded ranges as unstable
@@ -66,6 +73,7 @@ Deprecated / Unstable / Removed Language Features
 * marked the `[string|bytes].createBorrowingBuffer` factory method unstable  
   (see https://chapel-lang.org/docs/1.32/language/spec/strings.html#String.string.createBorrowingBuffer  
   and https://chapel-lang.org/docs/1.32/language/spec/bytes.html#Bytes.bytes.createBorrowingBuffer)
+* deprecated `single` variables
 * deprecated returning `sync`, `single`, or `atomic` by value
 * deprecated relying on default initializers for `sync`, `single`, and `atomic`
 * deprecated the `owned.borrow` type method
@@ -400,6 +408,8 @@ Performance Optimizations / Improvements
 
 Platform-specific Performance Optimizations / Improvements
 ----------------------------------------------------------
+* improved the performance of aggregators on HPE Cray EX systems
+* improved task creation and switching performance on ARM processors
 
 Compilation-Time / Generated Code Improvements
 ----------------------------------------------
@@ -480,6 +490,8 @@ Other Documentation Improvements
 
 Example Codes
 -------------
+* updated sync primer to reflect stable methods and variable naming conventions
+  (see https://chapel-lang.org/docs/1.32/primers/syncs.html)
 
 Syntax Highlighting
 -------------------
@@ -495,6 +507,7 @@ Portability / Platform-specific Improvements
 --------------------------------------------
 * added support for co-locales to `CHPL_COMM=gasnet` with the `ibv` substrate  
   (see TODO)
+* resolved sporadic memory consistency issues on ARM processors
 * added support for processors with heterogeneous processing units  
   (see https://chapel-lang.org/docs/1.32/usingchapel/executing.html#controlling-the-kind-of-processing-units)
 * enabled support for hugepages on the HPE Cray EX platform  
@@ -534,6 +547,7 @@ Bug Fixes
   (e.g., `var d: domain(?) = {1..5}` now works)
 * fixed incorrect scoping of variables in `do`...`while` loops' conditions
 * fixed a bug in which FCPs printed incorrectly with JSON serializers
+* fixed `fifo` guard pages when using `jemalloc` allocator on arm-based macs
 * fixed a bug when using array type expression actuals within loop bodies
 * removed extra borrow when casting from a managed class to an unmanaged class
 
@@ -564,7 +578,10 @@ Bug Fixes for Tools
 
 Third-Party Software Changes
 ----------------------------
+* updated the bundled version of GASNet-EX to 2023.3.0
+* updated the bundled version of Qthreads to 1.19
 * updated the bundled version of hwloc to 2.9
+* updated the bundled version of GMP to version 6.3.0
 
 Developer-oriented changes: Process
 -----------------------------------
@@ -613,7 +630,9 @@ Developer-oriented changes: 'dyno' Compiler improvements / changes
 
 Developer-oriented changes: Runtime improvements
 ------------------------------------------------
+* added a new runtime shim for the GASNet-EX API upgrade
 * enabled forceable creation of a fixed heap with `CHPL_COMM=ofi`
+* pinned ofi `fi_getinfo` API version to 1.9
 
 Developer-oriented changes: Platform-specific bug fixes
 -------------------------------------------------------
@@ -623,6 +642,8 @@ Developer-oriented changes: Testing System
 * modified `start_test` to not look for performance keys on a non-zero exit
 * added a warning when a line in a `.graph` file is unrecognized
 * removed email capability from `cron` scripts
+* throttled compile-only tests when the execution limiter is enabled
+* improved `chpl_launchcmd` support for systems with queues and prologues
 
 Developer-oriented changes: Tool Improvements
 ---------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ Syntactic / Naming Changes
   - declaring formal arguments
   - declaring the return type of a routine
   (e.g., `var t: T;` should be written `var t: T(?);` if `T` is such a type)
+  (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#marking-generic-types)
 * added a warning for type signatures like 'T()' if 'T' is not fully defaulted
 * added a warning for fields with generic class management to avoid confusion
 * replaced `[this.]complete();` with `init this;` when defining initializers
@@ -80,6 +81,11 @@ Semantic Changes / Changes to the Chapel Language
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
 * began changing the default receiver intent for records to `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
+* redefined the `const` intent to enable optimization opportunities  
+  - `const` allows implementation to choose `const ref` or `const in`
+  - `const` asserts that the value will not be modified by other means
+  - `const` for an array now asserts that the domain will not change
+  (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-const-intent)
 * began changing the type of range literals with mixed-type param bounds  
   (e.g., `0..1:int(8)` is changing from `idxType=int(8)` to `int(64)`)
 * added an error for addition/subtraction of multi-dim. domains and `[u]int`s  
@@ -534,6 +540,14 @@ Language Specification Improvements
 * updated the default intent of `owned`/`shared` to reflect that it's `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#owned-default-intent
   and https://chapel-lang.org/docs/1.32/language/spec/classes.html#shared-default-intent)
+* described how uses of generic types can be marked with `(?)`  
+  (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#marking-generic-types)
+* added a section describing how fields can be declared with generic type  
+  (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fields-with-generic-types)
+* added a section describing generic types with defaults  
+  (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#fully-defaulted-generic-types)
+* improved the description of how identifiers are interpreted in methods
+  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#field-accesses)
 * reformatted the classes section to hide implementation details
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html)
 * added a link between the `%` documentation and `AutoMath.mod()`  

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ released September 28, 2023
 
 Highlights (see subsequent sections for further details)
 --------------------------------------------------------
-* this release is our new release candidate for Chapel 2.0 — send feedback!
+* Chapel 1.32.0 is a release candidate for Chapel 2.0 — please send feedback!
 * significantly improved overall GPU performance, features, and portability
 * generally improved support for ARM64 in terms of performance and portability
 * added support for co-locales on IB networks and added a new `-nl 8x2` format
@@ -72,15 +72,12 @@ Syntactic / Naming Changes
   (see https://chapel-lang.org/docs/main/language/spec/domains.html#ChapelDomain.distribution)
 * added a warning when inheriting from a generic class if `(?)` is not used  
   (e.g., `class C: D` must now be written `class C: D(?)` for generic `D`)
-* added warnings for non-fully-defaulted generic types lacking `(?)` when:
-  - declaring fields or variables
-  - declaring formal arguments
-  - declaring the return type of a routine  
+* added warnings for non-fully-defaulted generic type constraints w/out `(?)`  
   (e.g., `var t: T;` should be written `var t: T(?);` if `T` is such a type)  
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#marking-generic-types)
 * added a warning for type signatures like `T()` if `T` is not fully defaulted
 * added a warning for fields with generic class management to avoid confusion
-* renamed `[enter|leave]This()` to `[enter|exit]Context()` for context mgmt  
+* renamed context manager `[enter|leave]This()` to `[enter|exit]Context()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement)
 * renamed `sync` formals from `x: valtype` to `val: valType`
 * renamed `atomic` formals and formal types from `value: T` to `val: valType`
@@ -461,8 +458,6 @@ Deprecated / Removed Library Features
 ------------------------------------------------
 * deprecated `c_void_ptr` in favor of now-equivalent `c_ptr(void)`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptr)
-* simplified documentation of `c_ptrTo()` and related procedures' overloads  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptrTo)
 * deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
 * deprecated the transitional `BigInteger.bigintInitThrows` config param
@@ -608,6 +603,8 @@ Other Documentation Improvements
   (see https://chapel-lang.org/docs/1.32/technotes/firstClassProcedures.html)
 * replaced uses of `dmapped` with factory methods throughout the docs  
   (e.g., see https://chapel-lang.org/docs/1.32/primers/distributions.html)
+* simplified documentation of `c_ptrTo()` and related procedures' overloads  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptrTo)
 * added a warning that the result of `.c_str()` may contain mid-buffer NULLs  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.string.c_str)
 * refactored and expanded 'BigInteger' documentation to be more comprehensive  

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -150,8 +150,20 @@ Example Codes
 Syntax Highlighting
 -------------------
 
+Generated Executable Flags
+--------------------------
+* added co-locale support to the `-nl`/`--numLocales` flag
+  (e.g., `-nl 4x2` means run on 4 nodes with 2 locales per node)
+
 Portability / Platform-specific Improvements
 --------------------------------------------
+* added support for co-locales to `CHPL_COMM=gasnet` with the `ibv` substrate  
+  (see TODO)
+* added support for processors with heterogeneous processing units  
+  (see https://chapel-lang.org/docs/1.32/usingchapel/executing.html#controlling-the-kind-of-processing-units)
+* enabled support for hugepages on the HPE Cray EX platform  
+  (see TODO)
+* improved the landing zone sizing when using `CHPL_COMM=ofi`
 * fixed a linkage issue in which system libraries could override ours
 
 Compiler Improvements
@@ -160,14 +172,14 @@ Compiler Improvements
 Compiler Flags
 --------------
 
-Generated Executable Flags
---------------------------
-
 Runtime Library Changes
 -----------------------
+* removed the ability to override the max # of endpoints with `CHPL_COMM=ofi`
 
 Launchers
 ---------
+* added co-locale support to the `[slurm|pbs]-gasnetrun_ibv` launchers
+* updated the `pbs-gasnetrun_ibv` launcher to use 'place/select' qsub syntax
 
 Error Messages / Semantic Checks
 --------------------------------
@@ -180,6 +192,7 @@ Bug Fixes
 
 Bug Fixes for Build Issues
 --------------------------
+* fixed handling of `pkg-config --exists` exit status
 
 Bug Fixes for GPU Computing
 ---------------------------
@@ -192,6 +205,7 @@ Bug Fixes for Tools
 
 Third-Party Software Changes
 ----------------------------
+* updated the bundled version of hwloc to 2.9
 
 Developer-oriented changes: Process
 -----------------------------------
@@ -224,12 +238,14 @@ Developer-oriented changes: 'dyno' Compiler improvements / changes
 
 Developer-oriented changes: Runtime improvements
 ------------------------------------------------
+* enabled forceable creation of a fixed heap with `CHPL_COMM=ofi`
 
 Developer-oriented changes: Platform-specific bug fixes
 -------------------------------------------------------
 
 Developer-oriented changes: Testing System
 ------------------------------------------
+* removed email capability from `cron` scripts
 
 Developer-oriented changes: Tool Improvements
 ---------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@ Language Feature Improvements
 
 Syntactic / Naming Changes
 --------------------------
+* made `init`, `postinit`, `deinit`, `super`, and `range` reserved keywords
 * renamed `range.aligned` to `range.isAligned()`
   (see https://chapel-lang.org/docs/main/language/spec/ranges.html#ChapelRange.range.isAligned)
 * renamed `domain.dist` to `domain.distribution`
@@ -121,7 +122,6 @@ Semantic Changes / Changes to the Chapel Language
 
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
-
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
 * marked associative and sparse domains as unstable
 * marked the `dmap` type and `dmapped` keyword as unstable
@@ -152,6 +152,7 @@ Deprecated / Unstable / Removed Language Features
   and https://chapel-lang.org/docs/1.32/language/spec/bytes.html#Bytes.bytes.createBorrowingBuffer)
 * marked `.localize()` on `string` and `bytes` as being unstable
 * marked `umask()` on `locale` as being unstable
+* deprecated support for `$` in identifiers (e.g., `foo$` is deprecated)
 * deprecated the `c_string` type in favor of `c_ptrConst(c_char)`
   (see https://chapel-lang.org/docs/1.32/language/evolution.html#c-string-deprecation)
 * deprecated implicit conversions for formals with generic numeric types  
@@ -494,14 +495,18 @@ GPU Computing
 -------------
 * significantly improved `array_on_device` performance, making it the default
   (see TODO)
+* added more math routines when using AMD GPUs
 * improved the performance of math routines in GPU kernels
 * improved performance when using arrays within kernels
+* added support for dumping AMD assembly files when using `--savec`
+  (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#examining-generated-assembly)
 * started using per-task, per-device streams to enable better overlap
 * CUDA 12 is now supported when using `CHPL_LLVM=bundled`
   (see TODO?)
 * generated GPU kernels are now named using their source filename/line number
 * added support for multi-arch GPU executables when targeting NVIDIA GPUs
   (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#vendor-portability)
+* added an experimental `--gpu-specialization` optimization
 * deprecated `assertOnGpu()` in favor of a new `@assertOnGpu` loop attribute
   (see https://chapel-lang.org/docs/1.32/technotes/gpu.html#diagnostics-and-utilities)
 
@@ -635,6 +640,7 @@ Portability / Platform-specific Improvements
   (see https://chapel-lang.org/docs/1.32/platforms/libfabric.html#hugepages-on-cray-xc-and-hpe-cray-ex-systems)
 * improved the landing zone sizing when using `CHPL_COMM=ofi`
 * fixed a linkage issue in which system libraries could override ours
+* suppressed invalid gcc 13 "possibly dangling reference" warning
 
 Compiler Improvements
 ---------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ New Language Features
 
 Language Feature Improvements
 -----------------------------
+* added promoted casts from array-of-`T` to `T` without a cast from `T` to `T`
 
 Syntactic / Naming Changes
 --------------------------
@@ -26,6 +27,10 @@ Semantic Changes / Changes to the Chapel Language
 
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
+* deprecated the `.intIdxType` query on ranges, domains, and arrays
+* deprecated the `useNewArrayFind` config param
+* removed support for the deprecated array `.find()` overload
+* removed support for variable-width `bool` types and related queries
 
 Namespace Changes
 -----------------
@@ -38,9 +43,14 @@ Package Modules
 
 Standard Domain Maps (Layouts and Distributions)
 ------------------------------------------------
+* converted standard distributions into records, obviating the need for `dmap`
+* renamed the standard distributions to match their module names
+  (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.)
 
 Changes / Feature Improvements in Libraries
 -------------------------------------------
+* made `chpl_library_initialize()` issue an error if called twice
+* made `chpl_finalize()` no longer exit, permitting user code to clean up
 
 Name Changes in Libraries
 -------------------------
@@ -53,12 +63,14 @@ GPU Computing
 
 Performance Optimizations / Improvements
 ----------------------------------------
+* optimized the performance of aligned array swaps for `Cyclic` and `Stencil`
 
 Platform-specific Performance Optimizations / Improvements
 ----------------------------------------------------------
 
 Compilation-Time / Generated Code Improvements
 ----------------------------------------------
+* improved the preservation of paths in compiler-generated `#line` directives
 
 Memory Improvements
 -------------------
@@ -80,6 +92,7 @@ Syntax Highlighting
 
 Portability / Platform-specific Improvements
 --------------------------------------------
+* fixed a linkage issue in which system libraries could override ours
 
 Compiler Improvements
 ---------------------
@@ -101,6 +114,7 @@ Error Messages / Semantic Checks
 
 Bug Fixes
 ---------
+* fixed a bug in which `CHPL_UNWIND` could not be overridden on some platforms
 
 Bug Fixes for Build Issues
 --------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,13 +8,14 @@ Release Changes List
 * check man page
 * check test/release/examples
 * check for docs/1.32/ links
-o check forced linebreaks
+* check forced linebreaks
 o check links
-o check initial '*'
-o check initial 'A-Z'
-o check 'see:'
-o check for changes put too far down in file
-o add highlights
+* check initial '*'
+* check initial 'A-Z'
+* check 'see:'
+* check for double linefeeds
+* check for changes put too far down in file
+* add highlights
 o spellcheck
 
 
@@ -25,6 +26,20 @@ released September 28, 2023
 
 Highlights (see subsequent sections for further details)
 --------------------------------------------------------
+* this release is our new release candidate for Chapel 2.0 — send feedback!
+* significantly improved overall GPU performance, features, and portability
+* generally improved support for ARM64 in terms of performance and portability
+* added support for co-locales on IB networks and added a new `-nl 8x2` format
+* significantly improved the IO serialization framework and its instantiations
+* improved the features and docs for 'IO, 'Math', 'Time', and 'BigInteger'
+* improved the safety of special methods through reserved words and interfaces
+* began unifying default intents for all non-synchronizing types to `const`
+* added warnings to make uses of incomplete generic types clearer in the code
+* converted all standard distributions to records, avoiding the need for `dmap`
+* scrutinized range, domain, and array features as stable vs. unstable
+* added initial support for array allocations that throw when out of memory
+* made the handling of C pointer types more robust and uniform within Chapel
+* added a new primer providing a deep-dive into Chapel's various loop forms
 
 New Language Features
 ---------------------
@@ -468,6 +483,8 @@ Deprecated / Removed Library Features
 ------------------------------------------------
 * deprecated `c_void_ptr` in favor of now-equivalent `c_ptr(void)`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptr)
+* simplified documentation of `c_ptrTo()` and related procedures' overloads  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptrTo)
 * deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
 * deprecated the transitional `BigInteger.bigintInitThrows` config param
@@ -740,7 +757,6 @@ Developer-oriented changes: Process
 Developer-oriented changes: Module changes
 ------------------------------------------
 * improved the `BigInteger` module organization to reduce maintenance burden
-
 
 Developer-oriented changes: Compiler Flags
 ------------------------------------------
@@ -1072,8 +1088,7 @@ Other Documentation Improvements
   (see https://chapel-lang.org/docs/1.31/usingchapel/chplenv.html#chpl-lib-pic)
 * updated an assertion that `fileReader` can produce `EEOF` to `OS.EofError`  
   (see https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.file.reader)
-* simplified documentation of `c_ptrTo()` and related procedures' overloads  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptrTo)
+
 Example Codes
 -------------
 * added a new user's guide example program for promoted procedure calls

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -199,6 +199,9 @@ Tool Improvements
 
 Language Specification Improvements
 -----------------------------------
+* documented the `require` statement  
+  (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-require-statement)
+
 
 Other Documentation Improvements
 --------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,7 +86,7 @@ Syntactic / Naming Changes
 * renamed `range.aligned` to `range.isAligned()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#ChapelRange.range.isAligned)
 * renamed `domain.dist` to `domain.distribution`  
-  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html%20distribution#ChapelDomain.distribution)
+  (see https://chapel-lang.org/docs/main/language/spec/domains.html#ChapelDomain.distribution)
 * added a warning when inheriting from a generic class if `(?)` is not used  
   (e.g., `class C: D` must now be written `class C: D(?)` for generic `D`)
 * added warnings for non-fully-defaulted generic types lacking `(?)` when:
@@ -107,8 +107,7 @@ Semantic Changes / Changes to the Chapel Language
 * began transitioning the default argument/task intent for arrays to `const`  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
 * began transitioning the default receiver intent for records to `const`  
-  (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
-* redefined the `const` intent to enable optimization opportunities  
+* redefined the `const` intent to enable optimization opportunities
   - `const` allows implementation to choose `const ref` or `const in`
   - `const` asserts that the value will not be modified by other means
   - `const` for an array now asserts that the domain will not change  
@@ -118,10 +117,10 @@ Semantic Changes / Changes to the Chapel Language
 * added an error for addition/subtraction of multi-dim. domains and `[u]int`s  
   (e.g., `{1..2, 1..2} - 1` is now an error)
 * built-in hashing now relies on the `hashable` interface  
-  (see https://chapel-lang.org/docs/1.32/language/spec/records.html#hashing-a-record
+  (see https://chapel-lang.org/docs/1.32/language/spec/records.html#hashing-a-record  
    and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
 * context managers now rely on the `contextManager` interface  
-  (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement
+  (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement  
    and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
 * removed some capabilities from records with generic `var`/`const` fields  
   (e.g., `record R { var x; }` or `record S { var y: integral; }`)
@@ -222,7 +221,7 @@ Standard Library Modules
 ------------------------
 * marked the 'Random', 'CommDiagnostics', and 'Communication' modules unstable
 * added `binarySerializer` and `binaryDeserializer` types to the 'IO' module  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binarySerializer
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binarySerializer  
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.binaryDeserializer)
 * added new `%<`, `%^`, and `%>` format specifiers for justification  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
@@ -258,7 +257,7 @@ Standard Domain Maps (Layouts and Distributions)
 * disallowed oversubscription in `cyclicDist` and `stencilDist`  
   (e.g., `var c = new cyclicDist(1, [here, here]);` now reports an error)
 * marked advanced initializer arguments in `blockDist`/`cyclicDist` unstable  
-  (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist
+  (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist  
    and https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist)
 
 Changes / Feature Improvements in Libraries
@@ -270,10 +269,10 @@ Changes / Feature Improvements in Libraries
 * `%i` and `%u` format specifiers now emit warnings for unused precision args  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
 * generalized `[read|write]Binary()` to support multi-dimensional arrays  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readBinary
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readBinary  
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileWriter.writeBinary))
 * made `readLiteral()` and `matchLiteral()` respect leading whitespace  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readLiteral
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readLiteral  
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.matchLiteral)
 * added `Math.ln()` to be consistent with the constant names in 'Math'  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.ln)
@@ -336,10 +335,10 @@ Name Changes in the 'BigInteger' Library
 * renamed `ior()` to `or()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.or)
 * renamed `[root|sqrt]rem()` to `[root|sqrt]Rem()`  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.rootRem
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.rootRem  
   and https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.sqrtRem)
 * renamed `[add|sub]mul()` to `[add|sub]Mul()`  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.addMul
+  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.addMul  
   and https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.subMul)
 * renamed `hamdist()` to the now unstable `hammingDistance()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.bigint.hammingDistance)
@@ -434,7 +433,7 @@ Deprecated / Unstable / Removed 'Math' Library Features
 * marked `[half|quarter|recipr|twiceRecipr[Sqrt]Pi` as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.halfPi et al.)
 * marked `sqrt2` and `reciprSqrt2` as unstable  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.sqrt2
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.sqrt2  
    and https://chapel-lang.org/docs/1.32/modules/standard/Math.html#Math.reciprSqrt2)
 * removed the deprecated Bessel functions that were included by default
 
@@ -491,7 +490,7 @@ Deprecated / Removed Library Features
 * deprecated `BigInteger.get_str()` in favor of a cast to `string`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
 * deprecated `list.first()`/`.last()` in favor of using paren-less methods  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.first
+  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.first  
    and https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.last)
 * deprecated `IllegalArgumentError`'s two-argument initializer  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.IllegalArgumentError.init)
@@ -567,7 +566,7 @@ Language Specification Improvements
 * simplified the explanation of default intents  
   (see https://chapel-lang.org/docs/1.32/language/spec/procedures.html#the-default-intent)
 * updated the default intent of `owned`/`shared` to reflect that it's `const`  
-  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#owned-default-intent
+  (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#owned-default-intent  
   and https://chapel-lang.org/docs/1.32/language/spec/classes.html#shared-default-intent)
 * described how uses of generic types can be decorated with `(?)`  
   (see https://chapel-lang.org/docs/1.32/language/spec/generics.html#marking-generic-types)
@@ -600,7 +599,7 @@ Documentation Improvements for the 'IO' Library
 * removed references to file descriptors in `stdin`/`stdout`/`stderr` docs  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.stdin)
 * refactored documentation for `IO.ioMode` and `IO.ioendian`  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioMode
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioMode  
   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioendian)
 * refactored `where` clauses to improve the generated documentation  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html)
@@ -639,7 +638,7 @@ Other Documentation Improvements
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html)
 * added a note that `chown()` requires elevated privileges to be successful
 * refactored documentation for `DynamicIters.Method` and `Subprocess.pipeStyle`  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/DynamicIters.html#DynamicIters.Method
+  (see https://chapel-lang.org/docs/1.32/modules/standard/DynamicIters.html#DynamicIters.Method  
   and https://chapel-lang.org/docs/1.32/modules/standard/Subprocess.html#Subprocess.pipeStyle)
 * fixed warnings in 'Map' that incorrectly referred to the `set` type
 * updated docs to mention `arm64` as a synonym for `aarch64`  

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,8 @@ Semantic Changes / Changes to the Chapel Language
 
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
-* deprecated the `.intIdxType` query on ranges, domains, and arrays
+* deprecated the `.intIdxType` query on ranges, domains, and arrays  
+  (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.intIdxType)
 * deprecated the `useNewArrayFind` config param
 * removed support for the deprecated array `.find()` overload
 * removed support for variable-width `bool` types and related queries
@@ -43,14 +44,17 @@ Package Modules
 
 Standard Domain Maps (Layouts and Distributions)
 ------------------------------------------------
-* converted standard distributions into records, obviating the need for `dmap`
-* renamed the standard distributions to match their module names
-  (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.)
+* converted standard distributions into records, removing the need for `dmap`  
+  (e.g., see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html  
+   and https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html)
+* renamed the standard distributions to match their module names  
+  (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.  
+   see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html et al.)
 
 Changes / Feature Improvements in Libraries
 -------------------------------------------
-* made `chpl_library_initialize()` issue an error if called twice
-* made `chpl_finalize()` no longer exit, permitting user code to clean up
+* made `chpl_library_init()` issue an error if called twice
+* made `chpl_library_finalize()` no longer exit, permitting client to continue
 
 Name Changes in Libraries
 -------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Language Feature Improvements
 
 Syntactic / Naming Changes
 --------------------------
+* `these` is now reserved as a keyword for use as the default iterator method  
+  (see https://chapel-lang.org/docs/1.32/language/spec/methods.html#the-these-method)
 * renamed `[enter|leave]This()` to `[enter|exit]Context()` for context mgmt  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement)
 
@@ -45,6 +47,12 @@ Standard Library Modules
 ------------------------
 * added support for casting `bool` values to `bigint`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
+* added a `compiledForSingleLocale()` query to the `ChplConfig` module  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.compiledForSingleLocale)
+* began an update to the definition of `dayOfWeek` to use ISO numbering  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.cIsoDayOfWeek)
+* added `date.utcToday` as a UTC version of local-time `date.today`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.utcToday)
 
 Package Modules
 ---------------
@@ -67,9 +75,43 @@ Name Changes in Libraries
 -------------------------
 * renamed `map.addOrSet()` to `map.addOrReplace()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.addOrReplace)
+* renamed `date.isoCalendar()` to `isoWeekDate()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.isoWeekDate)
+* replaced `abs(timeDelta)` with a method `timeDelta.abs()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.timeDelta.abs)
 
 Deprecated / Unstable / Removed Library Features
 ------------------------------------------------
+* deprecated `c_void_ptr` in favor of now-equivalent `c_ptr(void)`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptr)
+* deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
+* marked `c_fn_ptr` unstable
+  (see https://chapel-lang.org/docs/1.32/technotes/extern.html#c-fn-ptr)
+* deprecated the `day` and `isoDayOfWeek` enums in favor of `dayOfWeek`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.day)
+* deprecated `MINYEAR`/`MAXYEAR` in favor of `date.[min|max].year`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.MINYEAR)
+* marked `Timezone` and any `Time` methods using it as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.Timezone)
+* deprecated `getCurrentDate()` and `getCurrentDayOfWeek()` in `Time`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.getCurrentDate)
+* marked all `CHPL_*` params in `ChplConfig` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/ChplConfig.html#ChplConfig.CHPL_HOME et al.)
+* marked the default 0-argument initializers for `date` and `dateTime` unstable
+* deprecated `date.createFromTimestamp()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.createFromTimestamp)
+* deprecated `{date,time,dateTime}.isoFormat()` in favor of casts to strings  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.:,  
+   https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.time.:,  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.:)
+* deprecated `dateTime.combine()` in favor of using initializers  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.combine  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.init)
+* deprecated `dateTime.{isoCalendar(), toOrdinal(), weekday(), isoWeekday()}`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.toOrdinal et al.)
+* removed deprecated `c_sizeof()` signature with formal name `x`
+
 
 GPU Computing
 -------------
@@ -90,6 +132,7 @@ Memory Improvements
 
 Tool Improvements
 -----------------
+* made `c2chapel` generate `c_ptr[Const]`s for multidimensional arrays
 
 Language Specification Improvements
 -----------------------------------
@@ -125,6 +168,7 @@ Launchers
 
 Error Messages / Semantic Checks
 --------------------------------
+* simplified error formatting when compiling C code within an `extern` block
 
 Bug Fixes
 ---------
@@ -169,6 +213,8 @@ Developer-oriented changes: Compiler Flags
 
 Developer-oriented changes: Compiler improvements / changes
 -----------------------------------------------------------
+* added an experimental driver mode, enabled using `--compiler-driver`  
+  (see TODO)
 
 Developer-oriented changes: 'dyno' Compiler improvements / changes
 ------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,8 +49,11 @@ Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
 * marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
 * marked `scan` unstable due to uncertainty about inclusive/exclusive choice
+* marked default initialization of low- and high-bounded ranges as unstable
+  (see https://chapel-lang.org/docs/1.32/language/spec/ranges.html#default-values)
 * deprecated the `.intIdxType` query on ranges, domains, and arrays  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.intIdxType)
+* deprecated the default cast from arrays to `string`
 * deprecated the `useNewArrayFind` config param
 * removed support for the deprecated array `.find()` overload
 * removed support for variable-width `bool` types and related queries
@@ -61,6 +64,10 @@ Namespace Changes
 -----------------
 * moved several automatically-included math symbols from 'AutoMath' to 'Math'
   (e.g., `div[ceil|floor][pos]()`, `nearbyint()`, `rint()`)
+* upgraded `Json` from a package to a standard module, now named `JSON`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/JSON.html)
+* renamed `Yaml` module to `YAML`  
+  (see https://chapel-lang.org/docs/1.32/modules/packages/YAML.html)
 
 Standard Library Modules
 ------------------------
@@ -78,6 +85,9 @@ Standard Library Modules
 
 Package Modules
 ---------------
+* added `isEye` and `isZero()` routines to the 'LinearAlgebra' package module  
+  (see https://chapel-lang.org/docs/1.32/modules/packages/LinearAlgebra.html#LinearAlgebra.isEye  
+   and https://chapel-lang.org/docs/1.32/modules/packages/LinearAlgebra.html#LinearAlgebra.isZero)
 
 Standard Domain Maps (Layouts and Distributions)
 ------------------------------------------------
@@ -87,6 +97,10 @@ Standard Domain Maps (Layouts and Distributions)
 * renamed the standard distributions to match their module names  
   (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.  
    see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html et al.)
+* unified and extended the factory methods on `[block|cyclic|stencil]Dist`  
+  (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist.createDomain,  
+       https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist.createDomain,  
+  and https://chapel-lang.org/docs/1.32/modules/dists/StencilDist.html#StencilDist.stencilDist.createDomain)
 * marked advanced initializer arguments in `blockDist`/`cyclicDist` unstable  
   (see TODO)
 
@@ -94,6 +108,15 @@ Changes / Feature Improvements in Libraries
 -------------------------------------------
 * improved support for Serializers and Deserializers  
   (see https://chapel-lang.org/docs/1.32/technotes/ioSerializers.html)
+* added new `%<`, `%^`, and `%>` format specifiers for justification  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
+* `%i` and `%u` format specifiers now emit warnings for unused precision args  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
+* made `readLiteral()` and `matchLiteral()` respect leading whitespace  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readLiteral
+   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.matchLiteral)
+* added overloads of deserializing methods that take arguments by `ref`  
+  (see TODO)
 * generalized `[read|write]Binary()` to support multi-dimensional arrays  
   (see TODO)
 * added `Math.ln()` to be consistent with the constant names in 'Math'  
@@ -139,8 +162,13 @@ Name Changes in 'Math'-related Libraries
 
 Name Changes in Libraries
 -------------------------
+* renamed all serializer/deserializer types to use camelCasing  
+  (e.g., `DefaultSerializer` is now `defaultSerializer`, and similarly for the
+   'binary', 'json', and 'chpl' serializers and deserializers)
 * renamed `map.addOrSet()` to `map.addOrReplace()`
   (see https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.addOrReplace)
+* renamed `CodepointSplittingError` to `CodepointSplitError`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.CodepointSplitError)
 * renamed `date.isoCalendar()` to `isoWeekDate()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.date.isoWeekDate)
 * replaced `abs(timeDelta)` with a method `timeDelta.abs()`  
@@ -148,6 +176,8 @@ Name Changes in Libraries
 
 Deprecated / Unstable / Removed 'IO'-related Library Features
 -------------------------------------------------------------
+* marked `fileReader.assertEOF()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.assertEOF)
 * marked the default-included 'ChapelIO' module name as unstable  
   (see https://chapel-lang.org/docs/1.32/modules/standard/ChapelIO.html)
 * deprecated `[read|write]This()` methods in favor of `[de]serialize()`
@@ -159,13 +189,23 @@ Deprecated / Unstable / Removed 'IO'-related Library Features
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.iokind)
 * deprecated `io[dynamic|native|little|big]` module-scope convenience params  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.iokind)
+* deprecated `fileReader.ioLiteral` in favor `readLiteral()`/`matchLiteral()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioLiteral)
+* deprecated `fileReader.ioNewline` in favor of `[read|match]Newline()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.ioNewline)
 * deprecated `fileReader.skipField()` in favor of (de)serializers  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#FormattedIO.fileReader.skipField)
 * deprecated `file[Reader|Writer].kind` in favor of (de)serializers
+* deprecated `fileReader.binary` in favor of checks for binary [de]serializer  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.binary)
 * deprecated the `kind` argument in various reader/writer routines  
   (e.g., `open[URL][Reader|Writer]()`, `file.[reader|writer]()`, etc.)
 * deprecated the 'BinaryIO' module  
   (see https://chapel-lang.org/docs/1.32/modules/packages/BinaryIO.html)
+* deprecated the `%t`, `%jt`, and `%ht` format specifiers in favor of `%?`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#general-conversions)
+* deprecated the `%-` format specifier in favor of `%<`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
 * deprecated usage of `iokind` in the `Subprocess` module
 * deprecated a number of `config param`s in 'IO' used to transition behavior  
   (e.g., `useNewFileReaderRegionBounds`, `useNewLinesRegionBounds`, etc.)
@@ -174,6 +214,8 @@ Deprecated / Unstable / Removed 'IO'-related Library Features
 * removed the deprecated `file.check()` and `file.lines()` methods
 * removed the deprecated `fileReader.flush()` method
 * removed the deprecated `.seek()` method overloads on `file[Reader|Writer]`
+* removed deprecated `%<` and `%>` format specifiers for designating endianness
+* removed the deprecated overload of `file.path` that provided a relative path
 
 Deprecated / Unstable / Removed 'Math'-related Library Features
 ---------------------------------------------------------------
@@ -225,15 +267,22 @@ Deprecated / Unstable / Removed 'Time' Library Features
 * deprecated `dateTime.{isoCalendar(), toOrdinal(), weekday(), isoWeekday()}`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.toOrdinal et al.)
 
-
 Deprecated / Unstable / Removed Library Features
 ------------------------------------------------
+* marked `list.sort()` as unstable  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.sort)
+* marked `parSafe` as being unstable for `list`, `set`, and `map`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/List.html#List.list.parSafe,  
+       https://chapel-lang.org/docs/1/32/modules/standard/Set.html#Set.set.parSafe,  
+   and https://chapel-lang.org/docs/1.32/modules/standard/Map.html#Map.map.parSafe)
 * deprecated `c_void_ptr` in favor of now-equivalent `c_ptr(void)`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.c_ptr)
 * deprecated casts from classes to `c_ptr(void)` in favor of `c_ptrTo()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
 * marked `c_fn_ptr` unstable
   (see https://chapel-lang.org/docs/1.32/technotes/extern.html#c-fn-ptr)
+* deprecated `IllegalArgumentError`'s two-argument initializer  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/Errors.html#Errors.IllegalArgumentError.init)
 * deprecated `list.first()`/`.last()` in favor of using paren-less methods  
   (see TODO)
 * marked all `CHPL_*` params in `ChplConfig` as unstable  
@@ -243,6 +292,7 @@ Deprecated / Unstable / Removed Library Features
 * removed the deprecated `BigInteger.Round` enum
 * removed the deprecated `bigint` initializers that halted/returned error codes
 * removed the deprecated `bigint.mpzStruct()` method
+* removed the deprecated `bigint.fits_*()` methods
 * removed the deprecated `bigint.div_q()` method
 * removed the deprecated `bigint.powm()` method
 * removed the deprecated `bigint.sizeinbase()` and `.size()` methods
@@ -252,8 +302,8 @@ Deprecated / Unstable / Removed Library Features
 * removed the deprecated `regex.compile()` type method
 * removed the deprecated `regex.sub()` and `regex.subn()` methods
 * removed the deprecated `[list|unrolledLinkedList].extend()` methods
+* removed the deprecated `Sys` module
 * removed the deprecated `OrderedSet` and `OrderedMap` package modules
-
 
 GPU Computing
 -------------
@@ -298,6 +348,20 @@ Language Specification Improvements
 
 Other Documentation Improvements
 --------------------------------
+* replaced uses of `dmapped` with factory methods throughout the docs  
+  (see TODO)
+* added a new section about I/O transactions to the 'IO' module  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#i-o-transactions)
+* improved the clarity of the documentation of `mark()`/`commit()`/`revert()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.mark  
+   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileWriter.mark)
+* improved the clarity of the docs for `file[Reader|Writer].[advance|seek]()`  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.advance  
+   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.seek)
+* added a new section about `file[Reader|Writer]` regions to the 'IO' module  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html##specifying-the-region-of-a-filereader-or-filewriter)
+* added new section about `file[Reader|Writer]` locking to the 'IO' module  
+  (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#locking-behavior-of-filereaders-and-filewriters)
 * removed references to file descriptors in `stdin`/`stdout`/`stderr` docs  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.stdin)
 * improved several aspects of the 'Math' module documentation:
@@ -385,6 +449,9 @@ Bug Fixes for GPU Computing
 
 Bug Fixes for Libraries
 -----------------------
+* fixed a bug where `%r`/`%n` ignored precision arguments for integer values
+* fixed bug that prevented deserialization of `bytes` in JSON and CHPL formats
+* fixed bug where the `JsonDeserializer` could fail to parse a list
 
 Bug Fixes for Tools
 -------------------
@@ -443,6 +510,7 @@ Developer-oriented changes: Platform-specific bug fixes
 
 Developer-oriented changes: Testing System
 ------------------------------------------
+* modified `start_test` to not look for performance keys on a non-zero exit
 * added a warning when a line in a `.graph` file is unrecognized
 * removed email capability from `cron` scripts
 
@@ -589,26 +657,26 @@ Changes / Feature Improvements in Libraries
    `[i|x]or()`, `com()`;  
    see https://chapel-lang.org/docs/1.31/modules/standard/BigInteger.html)
 * changed `CTypes.c_ptrTo()` to point to the object for a class variable  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
 * changed `CTypes.c_ptrTo()` to point to the buffer for a `string`/`bytes`  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/CTypes.html#CTypes.cPtrToLogicalValue)
 * added a warning for `c_ptr()` casts that may violate C's aliasing rules  
   (see https://chapel-lang.org/docs/1.31/modules/standard/CTypes.html#CTypes.c_ptr)
 * changed `CTypes.c_FILE` to represent a C `FILE` rather than a `FILE*`  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/CTypes.html#CTypes.cFileTypeHasPointer)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/CTypes.html#CTypes.cFileTypeHasPointer)
 * added support for creating an uninitialized `weak` value for a given class  
   (see https://chapel-lang.org/docs/1.31/builtins/WeakPointer.html#WeakPointer.weak)
 
 Name Changes in Libraries
 -------------------------
 * renamed `list.append()` to `list.pushBack()`  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/List.html#List.list.pushBack)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/List.html#List.list.pushBack)
 * renamed `list.pop()` for the end of a list to `list.popBack()`  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/List.html#List.list.popBack)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/List.html#List.list.popBack)
 * renamed `list.pop()` for a specific index to `list.getAndRemove()`  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/List.html#List.list.getAndRemove)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/List.html#List.list.getAndRemove)
 * renamed `list.set()` to `list.replace()`  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/List.html#List.list.replace)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/List.html#List.list.replace)
 * renamed `BitOps.popcount()` to `BitOps.popCount()`  
   (see https://chapel-lang.org/docs/1.31/modules/standard/BitOps.html#BitOps.popCount)
 * renamed `c_*alloc()` and `c_free()` to `allocate()` and `deallocate()`  
@@ -638,7 +706,7 @@ Deprecated / Unstable / Removed Library Features
 * marked `set.parSafe` as unstable  
   (see https://chapel-lang.org/docs/1.31/modules/standard/Set.html#Set.set.parSafe)
 * marked `readln()` as unstable  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.fileReader.readln)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.fileReader.readln)
 * deprecated `.writing` on `file[Reader|Writer]` in favor of a type query  
   (see https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.fileReader.writing  
    and https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.fileWriter.writing)
@@ -647,7 +715,7 @@ Deprecated / Unstable / Removed Library Features
 * deprecated `.offset` on `fileReader|Writer` automatically taking a lock  
   (see https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.fileOffsetWithoutLocking)
 * marked `readWriteThisFromLocale` as unstable  
-  (see: https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.fileReader.readWriteThisFromLocale)
+  (see https://chapel-lang.org/docs/1.31/modules/standard/IO.html#IO.fileReader.readWriteThisFromLocale)
 * deprecated support for non-reusable barriers from the 'Collectives' module
 * deprecated `barrier.check()` in favor of `barrier.pending()`  
   (see https://chapel-lang.org/docs/1.31/modules/standard/Collectives.html#Collectives.barrier.pending)
@@ -2205,7 +2273,7 @@ Standard Library Modules
 * added a 'defaultHashTableResizeThreshold' config to affect hash table growth  
   (see https://chapel-lang.org/docs/1.27/language/spec/domains.html#ChapelDomain.defaultHashTableResizeThreshold)
 * made `bigint.invert()` throw `InversionError` when an inverse is undefined  
-  (see: https://chapel-lang.org/docs/1.27/modules/standard/BigInteger.html#BigInteger.bigint.invert )
+  (see https://chapel-lang.org/docs/1.27/modules/standard/BigInteger.html#BigInteger.bigint.invert )
 
 Tool Improvements
 -----------------
@@ -4117,7 +4185,7 @@ Package Modules
   (see https://chapel-lang.org/docs/1.23/modules/packages/LinearAlgebra.html#LinearAlgebra.norm)
 * `LinearAlgebra.cholesky()` now halts if matrix is symmetric positive definite
 * added a `blockCyclicChunks()` iterator to the 'RangeChunk' module  
-  (see: https://chapel-lang.org/docs/1.23/modules/packages/RangeChunk.html#RangeChunk.blockCyclicChunks)
+  (see https://chapel-lang.org/docs/1.23/modules/packages/RangeChunk.html#RangeChunk.blockCyclicChunks)
 * updated the 'Sort' module to number parts in `keyPart()` calls from 0  
   (see https://chapel-lang.org/docs/1.23/modules/packages/Sort.html#the-keypart-method)
 * moved 'LinkedLists' from the standard modules to the package modules  
@@ -13055,7 +13123,7 @@ Changes to Chapel Language
 
 Newly Implemented Features
 --------------------------
-- execution using multiple locales (see: doc/README.multilocale)
+- execution using multiple locales (see doc/README.multilocale)
 - use of on clauses taking locale/lvalue expressions to generate remote tasks
   e.g., "on Locales(i) do ...",  "var x = ...;  ...  on x do ..."
 - use of <expression>.locale to query the locale on which an lvalue lives

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -118,10 +118,10 @@ Semantic Changes / Changes to the Chapel Language
   (e.g., `{1..2, 1..2} - 1` is now an error)
 * built-in hashing now relies on the `hashable` interface  
   (see https://chapel-lang.org/docs/1.32/language/spec/records.html#hashing-a-record  
-   and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
+   and https://chapel-lang.org/docs/1.32/technotes/interfaces.html)
 * context managers now rely on the `contextManager` interface  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement  
-   and https://chapel-lang.org/docs/1.32/technotes/interfaces.html))
+   and https://chapel-lang.org/docs/1.32/technotes/interfaces.html)
 * removed some capabilities from records with generic `var`/`const` fields  
   (e.g., `record R { var x; }` or `record S { var y: integral; }`)
   - variables of such types can no longer be default-initialized
@@ -189,7 +189,7 @@ Deprecated / Removed Language Features
 * deprecated `single` variables
 * deprecated returning `sync`, `single`, or `atomic` by value
 * deprecated relying on default initializers for `sync`, `single`, and `atomic`
-* deprecated the `owned.borrow` type method  
+* deprecated the `owned.borrow()` type method  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#OwnedObject.owned.borrow)
 * deprecated assignment between unbounded ranges of incompatible `idxtype`
 * deprecated `range.isAmbiguous()` in favor of `!range.isAligned()`
@@ -226,7 +226,6 @@ Standard Library Modules
 * added new `%<`, `%^`, and `%>` format specifiers for justification  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
 * added support for casting `bool` values to `bigint`  
-  (see https://chapel-lang.org/docs/1.32/modules/standard/BigInteger.html#BigInteger.:)
 * began an update to the definition of `dayOfWeek` to use ISO numbering  
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.cIsoDayOfWeek)
 * added `date.utcToday` as a UTC version of local-time `date.today`  
@@ -246,10 +245,10 @@ Standard Domain Maps (Layouts and Distributions)
 ------------------------------------------------
 * marked all domain maps other than `blockDist` and `cyclicDist` as unstable
 * converted standard distributions into records, removing the need for `dmap`  
-  (e.g., see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html)
+  (e.g., see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist)
 * renamed the standard distributions to match their module names  
   (e.g., `Block` is now `blockDist`, `Cyclic` is now `cyclicDist`, etc.)  
-  (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html, et al.)
+  (e.g., see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist)
 * unified and extended the factory methods on `[block|cyclic|stencil]Dist`  
   (see https://chapel-lang.org/docs/1.32/modules/dists/BlockDist.html#BlockDist.blockDist.createDomain,  
    https://chapel-lang.org/docs/1.32/modules/dists/CyclicDist.html#CyclicDist.cyclicDist.createDomain,  
@@ -270,7 +269,7 @@ Changes / Feature Improvements in Libraries
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO/FormattedIO.html#id1)
 * generalized `[read|write]Binary()` to support multi-dimensional arrays  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readBinary  
-   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileWriter.writeBinary))
+   and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileWriter.writeBinary)
 * made `readLiteral()` and `matchLiteral()` respect leading whitespace  
   (see https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.readLiteral  
    and https://chapel-lang.org/docs/1.32/modules/standard/IO.html#IO.fileReader.matchLiteral)
@@ -291,7 +290,7 @@ Name Changes in the 'Math' Library
 * renamed `INFINITY` to `inf` and `NAN` to `nan`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.inf  
    and https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.nan)
-* renamed ``is[finite|inf|nan]()` to `is[Finite|Inf|Nan]()`  
+* renamed `is[finite|inf|nan]()` to `is[Finite|Inf|Nan]()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.isFinite et al.)
 * renamed `conjg()` to `conj()`  
   (see https://chapel-lang.org/docs/1.32/modules/standard/AutoMath.html#AutoMath.conj)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -580,6 +580,7 @@ Example Codes
 -------------
 * updated sync primer to reflect stable methods and variable naming conventions
   (see https://chapel-lang.org/docs/1.32/primers/syncs.html)
+* removed `fft.chpl` and `hpl.chpl` from the example codes due to immaturity
 
 Syntax Highlighting
 -------------------
@@ -641,6 +642,7 @@ Bug Fixes
 * fixed `fifo` guard pages when using `jemalloc` allocator on arm-based macs
 * fixed a bug when using array type expression actuals within loop bodies
 * removed extra borrow when casting from a managed class to an unmanaged class
+* fixed a bug in which unstable warnings were generated for non-user code
 
 Bug Fixes for Build Issues
 --------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ New Language Features
 
 Language Feature Improvements
 -----------------------------
+* added new routines to create multidimensional arrays from C pointers
+  (see TODO)
 * added promoted casts from array-of-`T` to `T` without a cast from `T` to `T`
 * first-class procedures are now printed similarly to Chapel's syntax
 
@@ -45,6 +47,7 @@ Semantic Changes / Changes to the Chapel Language
 
 Deprecated / Unstable / Removed Language Features
 -------------------------------------------------
+* marked `foreach` loops unstable due to lack of shadowing and `with`-clauses
 * deprecated the `.intIdxType` query on ranges, domains, and arrays  
   (see https://chapel-lang.org/docs/1.32/language/spec/domains.html#ChapelDomain.intIdxType)
 * deprecated the `useNewArrayFind` config param
@@ -131,11 +134,22 @@ Deprecated / Unstable / Removed Library Features
   (see https://chapel-lang.org/docs/1.32/modules/standard/Time.html#Time.dateTime.toOrdinal et al.)
 * marked `Reflection.getRoutineName()` unstable within first-class procedures
 * removed deprecated `c_sizeof()` signature with formal name `x`
+* removed a `regex.matches()` overload with deprecated arguments
+* removed the deprecated `regex.compile()` type method
+* removed the deprecated `regex.sub()` and `regex.subn()` methods
+* removed the deprecated `[list|unrolledLinkedList].extend()` methods
+* removed the deprecated `OrderedSet` and `OrderedMap` package modules
 
 
 GPU Computing
 -------------
+* significantly improved `array_on_device` performance, making it the default
+  (see TODO)
+* improved the performance of math routines in GPU kernels
 * improved performance when using arrays within kernels
+* started using per-task, per-device streams to enable better overlap
+* CUDA 12 is now supported when using `CHPL_LLVM=bundled`
+  (see TODO?)
 * generated GPU kernels are now named using their source filename/line number
 * added support for multi-arch GPU executables when targeting NVIDIA GPUs
   (see TODO)
@@ -145,6 +159,7 @@ GPU Computing
 Performance Optimizations / Improvements
 ----------------------------------------
 * optimized the performance of aligned array swaps for `Cyclic` and `Stencil`
+* enabled bulk-transfer of Chapel arrays with `c_array` element type
 
 Platform-specific Performance Optimizations / Improvements
 ----------------------------------------------------------
@@ -179,6 +194,8 @@ Generated Executable Flags
 --------------------------
 * added co-locale support to the `-nl`/`--numLocales` flag
   (e.g., `-nl 4x2` means run on 4 nodes with 2 locales per node)
+* unstable `config` variables are now hidden in the `--help` output
+* unstable `config` variables now generate a warning when used on command-line
 
 Portability / Platform-specific Improvements
 --------------------------------------------
@@ -218,6 +235,7 @@ Bug Fixes
 * fixed internal errors when using tuples as formal or return types in FCPs
 * fixed incorrect scoping of variables in `do`...`while` loops' conditions
 * fixed a bug in which FCPs printed incorrectly with JSON serializers
+* fixed a bug when using array type expression actuals within loop bodies
 
 Bug Fixes for Build Issues
 --------------------------
@@ -225,6 +243,8 @@ Bug Fixes for Build Issues
 
 Bug Fixes for GPU Computing
 ---------------------------
+* fixed a bug when accessing `ref`s declared outside of a GPU-eligible loop
+* fixed a bug with `.locale` queries on AMD GPUs or when `--fast` was used
 * fixed an assertion when running GPU programs for AMD w/ `CHPL_DEVELOPER` set
 
 Bug Fixes for Libraries
@@ -281,6 +301,7 @@ Developer-oriented changes: Platform-specific bug fixes
 
 Developer-oriented changes: Testing System
 ------------------------------------------
+* added a warning when a line in a `.graph` file is unrecognized
 * removed email capability from `cron` scripts
 
 Developer-oriented changes: Tool Improvements


### PR DESCRIPTION
These are the CHANGES for Chapel 1.32—thanks everyone for all the hard work!

Soo...many...changes...

Top-level CHANGES bullets per release:
1.27: 142
1.28: 158
1.29: 163
1.30: 207
1.31: 186
1.32: **379**

(not to say that "bullets" is the most reasonable unit of measure...)