### PR TITLE
Delete unmanaged classes in serializer tests

### DIFF
--- a/test/io/serializers/basic-types.chpl
+++ b/test/io/serializers/basic-types.chpl
@@ -1,6 +1,7 @@
 
 use IO;
 use List;
+use Types;
 
 use JSON;
 use FormatHelper;
@@ -38,6 +39,10 @@ proc test(val, type T = val.type) {
         writeln("FAILURE");
         failures.pushBack(T:string);
       } else writeln("SUCCESS");
+
+      if isUnmanagedClassType(val.type) {
+        delete readVal;
+      }
     }
   } catch e : Error {
     writeln("FAILURE: ", e.message());
@@ -170,7 +175,9 @@ proc main() {
 
   test(new owned Child101());
 
-  test(new unmanaged SimpleChild(5, 42.0));
+  var x = new unmanaged SimpleChild(5, 42.0);
+  test(x);
+  delete x;
 
   if failures.size > 0 {
     writeln("FAILURES:");

--- a/test/io/serializers/deserialize-by-ref.chpl
+++ b/test/io/serializers/deserialize-by-ref.chpl
@@ -174,5 +174,7 @@ proc main() {
   test(new owned DefaultClass(new B((22, 2.2))), dco);
 
   var dcu = new unmanaged DefaultClass();
-  test(new unmanaged DefaultClass(new B((33, 3.3))), dcu);
+  var x = new unmanaged DefaultClass(new B((33, 3.3)));
+  test(x, dcu);
+  delete x, dcu;
 }


### PR DESCRIPTION
Deletes manual or IO-created unmanaged classes that were recently added to these tests.