### PR TITLE
Fix issue with `--verify` and `--warn-unstable` for explicit this

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -1329,3 +1329,11 @@ void convertToQualifiedRefs() {
   }
 #undef fixRefSymbols
 }
+
+bool shouldWarnUnstableFor(BaseAST* ast) {
+  if (auto mod = ast->getModule()) {
+    if (mod->modTag == MOD_INTERNAL) return fWarnUnstableInternal;
+    else if (mod->modTag == MOD_STANDARD) return fWarnUnstableStandard;
+  }
+  return fWarnUnstable;
+}

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -230,4 +230,6 @@ void cleanupAfterTypeRemoval();
 
 void convertToQualifiedRefs();
 
+bool shouldWarnUnstableFor(BaseAST* ast);
+
 #endif

--- a/compiler/passes/checkNormalized.cpp
+++ b/compiler/passes/checkNormalized.cpp
@@ -102,6 +102,12 @@ static void checkExplicitThis() {
   // only do these checks if `--warn-unstable`
   if (!fWarnUnstable) return;
 
+  // keep track of if we have run these checks,
+  // because checkNormalized is called multiple times with `--verify`
+  // and these should only run once
+  static bool hasPerformedChecks = false;
+  if (hasPerformedChecks) return;
+
   for_alive_in_Vec(CallExpr, ce, gCallExprs) {
     if (shouldWarnUnstableFor(ce)) {
       // if there is an explicit method call to `this`, warn unstable
@@ -124,4 +130,5 @@ static void checkExplicitThis() {
                 "and may change in the future");
     }
   }
+  hasPerformedChecks = true;
 }

--- a/compiler/passes/checkNormalized.cpp
+++ b/compiler/passes/checkNormalized.cpp
@@ -102,24 +102,26 @@ static void checkExplicitThis() {
   // only do these checks if `--warn-unstable`
   if (!fWarnUnstable) return;
 
-  forv_Vec(CallExpr, ce, gCallExprs) {
-    // if there is an explicit method call to `this`, warn unstable
-    bool isNamedThis = false;
-    bool isMethod = false;
+  for_alive_in_Vec(CallExpr, ce, gCallExprs) {
+    if (shouldWarnUnstableFor(ce)) {
+      // if there is an explicit method call to `this`, warn unstable
+      bool isNamedThis = false;
+      bool isMethod = false;
 
-    if (UnresolvedSymExpr* methodName = toUnresolvedSymExpr(ce->baseExpr)) {
-      isNamedThis = methodName->unresolved == astrThis;
-    }
-    // cannot use methodTag since we are preResolution
-    if (ce->numActuals() >= 1) {
-      if (SymExpr* firstArg = toSymExpr(ce->get(1))) {
-        isMethod = firstArg->symbol()->type == dtMethodToken;
+      if (UnresolvedSymExpr* methodName = toUnresolvedSymExpr(ce->baseExpr)) {
+        isNamedThis = methodName->unresolved == astrThis;
       }
-    }
+      // cannot use methodTag since we are preResolution
+      if (ce->numActuals() >= 1) {
+        if (SymExpr* firstArg = toSymExpr(ce->get(1))) {
+          isMethod = firstArg->symbol()->type == dtMethodToken;
+        }
+      }
 
-    if (isNamedThis && isMethod)
-      USR_WARN(ce,
-               "calling the 'this' method explicitly is unstable "
-               "and may change in the future");
+      if (isNamedThis && isMethod)
+        USR_WARN(ce,
+                "calling the 'this' method explicitly is unstable "
+                "and may change in the future");
+    }
   }
 }


### PR DESCRIPTION
Fixes an issue that came up in our nightly testing where `--verify --warn-unstable` was over-warning. The primary solution was to change the `forv_Vec` over all `CallExpr` to `for_alive_in_Vec`, since the warnings were occurring for CallExpr not in the tree.

Additionally, adds a check to make sure `checkExplicitThis` is only run once.

Fixes issue introduced in https://github.com/chapel-lang/chapel/pull/23245.

Tested locally on the `test/unstable` directory with `--verify` and with a full `paratest --verify`

[Reviewed by @riftEmber]