### PR TITLE
Make default initialization of low and high bounded ranges unstable

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -276,6 +276,20 @@ module ChapelRange {
               alignmentValue = 0:chpl__rangeStrideType(idxType));
   }
 
+  // this overload can be removed when the unstable warning in the above overload is removed
+  @chpldoc.nodoc
+  proc range.init(type idxType,
+                  param bounds: boundKind,
+                  param strides: strideKind,
+                  param internal: bool) {
+
+    this.init(idxType, bounds, strides,
+              _low = chpl__defaultLowBound(idxType, bounds),
+              _high = chpl__defaultHighBound(idxType, bounds),
+              _stride = strides.defaultStride():chpl__rangeStrideType(idxType),
+              alignmentValue = 0:chpl__rangeStrideType(idxType));
+  }
+
   // This is an initializer for defining a range value in terms of its
   // internal field values
   //
@@ -1764,7 +1778,7 @@ operator :(r: range(?), type t: range(?)) where chpl_castIsSafe(r, t) {
   checkBounds(t, r);
   checkEnumIdx(t, r);
 
-  var tmp: t;
+  var tmp = new range(t.idxType, t.bounds, t.strides, true);
   type srcType = r.idxType,
        dstType = t.idxType,
     dstIntType = tmp.chpl_integralIdxType;
@@ -1796,7 +1810,7 @@ operator :(r: range(?), type t: range(?)) throws where !chpl_castIsSafe(r, t) {
   checkBounds(t, r);
   checkEnumIdx(t, r);
 
-  var tmp: t;
+  var tmp = new range(t.idxType, t.bounds, t.strides, true);
   type srcType = r.idxType,
        dstType = t.idxType,
     dstIntType = tmp.chpl_integralIdxType;

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -265,6 +265,10 @@ module ChapelRange {
   proc range.init(type idxType,
                   param bounds: boundKind,
                   param strides: strideKind) {
+
+    if chpl_warnUnstable && (bounds == boundKind.low || bounds == boundKind.high)
+      then warning("Default initialization of a range with 'boundKind.low' or 'boundKind.high' is unstable");
+
     this.init(idxType, bounds, strides,
               _low = chpl__defaultLowBound(idxType, bounds),
               _high = chpl__defaultHighBound(idxType, bounds),

--- a/test/unstable/defaultUnboundedRange.chpl
+++ b/test/unstable/defaultUnboundedRange.chpl
@@ -1,0 +1,15 @@
+
+// only low and high default initialization should be unstable
+var drlb: range(int, boundKind.low),
+    drub: range(int, boundKind.high),
+    drnb: range(int, boundKind.neither),
+    drbb: range(int, boundKind.both);
+
+// none of these should produce an unstable warning
+var rlb = 1..,
+    rub = ..0,
+    rnb = ..,
+    rbb = 1..0;
+
+writeln(drlb);
+writeln(drub);

--- a/test/unstable/defaultUnboundedRange.good
+++ b/test/unstable/defaultUnboundedRange.good
@@ -1,0 +1,4 @@
+1..
+..0
+defaultUnboundedRange.chpl:3: warning: Default initialization of a range with 'boundKind.low' or 'boundKind.high' is unstable
+defaultUnboundedRange.chpl:4: warning: Default initialization of a range with 'boundKind.low' or 'boundKind.high' is unstable


### PR DESCRIPTION
Per the discussion [here](https://github.com/chapel-lang/chapel/issues/21474), make default initialization of low and high bounded ranges unstable.

The following will produce ranges with the values `0..` and `..1` respectively; however, we may want to change the default values in the future or make them implementation dependant, so an unstable warning will be emitted for each.

```chapel
var rl: range(int, boundKind.low),
    rh: range(int, boundKind.high);
```

- [x] local paratest
- [x] gasnet paratest