### PR TITLE
Turn off gpu specialization by default

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -364,7 +364,7 @@ std::vector<std::string> gDynoPrependStandardModulePaths;
 int fGPUBlockSize = 0;
 char fGpuArch[gpuArchNameLen+1] = "";
 bool fGpuPtxasEnforceOpt;
-bool fGpuSpecialization = true;
+bool fGpuSpecialization = false;
 const char* gGpuSdkPath = NULL;
 std::set<std::string> gpuArches;
 

--- a/util/cron/test-gpu-cuda.specialization.bash
+++ b/util/cron/test-gpu-cuda.specialization.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# GPU native testing on a Cray CS (using none for CHPL_COMM)
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-slurm-gasnet-cray-cs.bash
+source $CWD/common-native-gpu.bash
+
+module load cudatoolkit
+
+export CHPL_GPU=nvidia
+export CHPL_COMM=none
+export CHPL_LAUNCHER_PARTITION=stormP100
+
+export CHPL_GPU_SPECIALIZATION=y
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda"
+$CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-cuda.specialization.bash
+++ b/util/cron/test-gpu-cuda.specialization.bash
@@ -14,5 +14,5 @@ export CHPL_LAUNCHER_PARTITION=stormP100
 
 export CHPL_GPU_SPECIALIZATION=y
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda.specialization"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
This PR turns off gpu specialization by default.

We previously thought were going to ship with this on by default for the upcoming release but it has a pretty significant compile-time impact (~30% longer on Jacobi).

So lets leave it off while we continue to investigate and perhaps do additional work to trim down the number of specializations.

This PR also introduces a nightly test with gpu specialization on (so things don't regress in the meantime).