### PR TITLE
Emit depecation warnings for 'getRoutineName' inside FCFs.

### DIFF
--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -238,6 +238,11 @@ static Expr* postFoldNormal(CallExpr* call) {
     retval = new SymExpr(new_StringSymbol(call->fname()));
     call->replace(retval);
   } else if (fn->hasFlag(FLAG_GET_FUNCTION_NAME)) {
+    if (fWarnUnstable && call->getFunction()->hasFlag(FLAG_ANONYMOUS_FN)) {
+      USR_WARN(call, "using 'getRoutineName' inside first-class procedures is "
+                     "currently unstable");
+    }
+
     retval = new SymExpr(new_StringSymbol(call->getFunction()->name));
     call->replace(retval);
   } else if (fn->hasFlag(FLAG_GET_MODULE_NAME)) {

--- a/test/unstable/fcfProcName.chpl
+++ b/test/unstable/fcfProcName.chpl
@@ -1,0 +1,4 @@
+use Reflection;
+
+const p = proc() { writeln(getRoutineName()); };
+p();

--- a/test/unstable/fcfProcName.good
+++ b/test/unstable/fcfProcName.good
@@ -1,3 +1,3 @@
 fcfProcName.chpl:3: warning: use of routines as values is unstable
-fcfProcName.chpl:3: warning: using 'getRoutineName' inside first-class functions is currently unstable and its behavior might change in the future
+fcfProcName.chpl:3: warning: using 'getRoutineName' inside first-class procedures is currently unstable
 chpl_anon_proc_0

--- a/test/unstable/fcfProcName.good
+++ b/test/unstable/fcfProcName.good
@@ -1,0 +1,3 @@
+fcfProcName.chpl:3: warning: use of routines as values is unstable
+fcfProcName.chpl:3: warning: using 'getRoutineName' inside first-class functions is currently unstable and its behavior might change in the future
+chpl_anon_proc_0


### PR DESCRIPTION
This takes care of the decision in https://github.com/chapel-lang/chapel/issues/22795#issuecomment-1709219214. At the place where the special `getRoutineName` call is replaced with the routine's name, we also emit a warning if the function is first-class.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest