### PR TITLE
Skip studies/ml/ tests for valgrind config

### DIFF
--- a/test/studies/ml/correctness/SKIPIF
+++ b/test/studies/ml/correctness/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_EXE == on

--- a/test/studies/ml/performance/SKIPIF
+++ b/test/studies/ml/performance/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Skip the `studies/ml` tests in the valgrind configuration to avoid testing timeouts.