### PR TITLE
Adjust PRIM_QUERY for fileReader/fileWriter

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2982,7 +2982,19 @@ static Symbol* determineQueriedField(CallExpr* call) {
 
   } else {
     Vec<Symbol*> args;
-    int             position      = var->immediate->int_value();
+    int position = var->immediate->int_value();
+
+    // A couple of variables to help us deal with the deprecated 'kind' field
+    // in fileReader and fileWriter.
+    bool isReaderWriter = false;
+    bool specifiesKind = false;
+
+    {
+      AggregateType* root = at->getRootInstantiation();
+      isReaderWriter = root->getModule() == ioModule &&
+          (strcmp(root->symbol->name, "fileReader") == 0 ||
+           strcmp(root->symbol->name, "fileWriter") == 0);
+    }
 
     if (at->symbol->hasFlag(FLAG_TUPLE)) {
       return at->getField(position);
@@ -3019,12 +3031,23 @@ static Symbol* determineQueriedField(CallExpr* call) {
 
       INT_ASSERT(var->immediate->const_kind == CONST_KIND_STRING);
 
+      if (isReaderWriter &&
+          strcmp("kind", var->immediate->v_string.c_str()) == 0) {
+        specifiesKind = true;
+      }
+
       for (int j = 0; j < args.n; j++) {
         if (args.v[j] != NULL &&
             strcmp(args.v[j]->name, var->immediate->v_string.c_str()) == 0) {
           args.v[j] = NULL;
         }
       }
+    }
+
+    // Need to increment by one so that expressions like 'fileWriter(false)'
+    // match up correctly.
+    if (isReaderWriter && !specifiesKind) {
+      position += 1;
     }
 
     forv_Vec(Symbol, arg, args) {

--- a/test/deprecated/IO/iokind/kind-queries.chpl
+++ b/test/deprecated/IO/iokind/kind-queries.chpl
@@ -1,0 +1,106 @@
+use IO;
+use JSON;
+
+// Part 1: make sure we can specify locking and (de)serializerType
+// positionally.
+
+proc foo(writer: fileWriter(?)) {
+  writeln("foo: fully generic: ", writer.type:string);
+}
+
+proc foo(writer: fileWriter(false, defaultSerializer)) {
+  writeln("foo: fileWriter(false): ", writer.type:string);
+}
+
+proc foo(reader: fileReader(?)) {
+  writeln("foo: fully generic: ", reader.type:string);
+}
+
+proc foo(reader: fileReader(false, defaultDeserializer)) {
+  writeln("foo: fileReader(false): ", reader.type:string);
+}
+
+// Part 2: make sure we can specify kind with a named arg
+
+proc bar(writer: fileWriter(?)) {
+  writeln("bar: fileWriter(?): ", writer.type:string);
+}
+
+proc bar(writer: fileWriter(kind=_iokind.native, ?)) {
+  writeln("bar: fileWriter(kind=iokind.native, ?): ", writer.type:string);
+}
+
+proc bar(reader: fileReader(?)) {
+  writeln("bar: fileReader(?): ", reader.type:string);
+}
+
+proc bar(reader: fileReader(kind=_iokind.native, ?)) {
+  writeln("bar: fileReader(kind=iokind.native, ?): ", reader.type:string);
+}
+
+// Part 3: various actual queries of generic fields
+
+proc query(writer: fileWriter(?L, ?ST)) {
+  writeln("L = ", L:string, " :: ST = ", ST:string);
+}
+
+proc query(reader: fileReader(?L, ?DT)) {
+  writeln("L = ", L:string, " :: DT = ", DT:string);
+}
+
+proc queryNamed(writer: fileWriter(locking=?L, serializerType=?ST)) {
+  writeln("L = ", L:string, " :: ST = ", ST:string);
+}
+
+proc queryNamed(reader: fileReader(locking=?L, deserializerType=?DT)) {
+  writeln("L = ", L:string, " :: DT = ", DT:string);
+}
+
+proc queryKind(writer: fileWriter(kind=?K, ?L, ?ST)) {
+  writeln("L = ", L:string, " :: ST = ", ST:string, " :: K = ", K:string);
+}
+
+proc queryKind(reader: fileReader(kind=?K, ?L, ?DT)) {
+  writeln("L = ", L:string, " :: DT = ", DT:string, " :: K = ", K:string);
+}
+
+proc queryKindLast(writer: fileWriter(?L, ?ST, kind=?K)) {
+  writeln("L = ", L:string, " :: ST = ", ST:string, " :: K = ", K:string);
+}
+
+proc queryKindLast(reader: fileReader(?L, ?DT, kind=?K)) {
+  writeln("L = ", L:string, " :: DT = ", DT:string, " :: K = ", K:string);
+}
+
+proc helper(type channel, param locking: bool, type deserType) {
+  type T = if channel == fileWriter(?) then deserType
+           else if deserType == defaultSerializer then defaultDeserializer
+           else if deserType == jsonSerializer then jsonDeserializer
+           else nothing;
+  var w : channel(locking, T);
+  writeln("----- ", w.type:string, " -----");
+  foo(w);
+  bar(w);
+  query(w);
+  queryNamed(w);
+  queryKind(w);
+  queryKindLast(w);
+  {
+    var nw : channel(_iokind.native, locking, T);
+    bar(nw);
+    queryKind(nw);
+  }
+  writeln();
+}
+
+proc helper(param locking: bool, type deserType) {
+  helper(fileWriter(?), locking, deserType);
+  helper(fileReader(?), locking, deserType);
+}
+
+proc main() {
+  helper(true, defaultSerializer);
+  helper(false, defaultSerializer);
+  helper(true, jsonSerializer);
+  helper(false, jsonSerializer);
+}

--- a/test/deprecated/IO/iokind/kind-queries.good
+++ b/test/deprecated/IO/iokind/kind-queries.good
@@ -1,0 +1,280 @@
+kind-queries.chpl:29: In function 'bar':
+kind-queries.chpl:29: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:75: called as bar(writer: fileWriter(true,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:59: In function 'queryKind':
+kind-queries.chpl:59: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:86: called as queryKind(writer: fileWriter(true,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:67: In function 'queryKindLast':
+kind-queries.chpl:67: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:87: called as queryKindLast(writer: fileWriter(true,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:29: In function 'bar':
+kind-queries.chpl:29: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:90: called as bar(writer: fileWriter(native,true,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:59: In function 'queryKind':
+kind-queries.chpl:59: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:91: called as queryKind(writer: fileWriter(native,true,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:37: In function 'bar':
+kind-queries.chpl:37: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:75: called as bar(reader: fileReader(true,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:63: In function 'queryKind':
+kind-queries.chpl:63: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:86: called as queryKind(reader: fileReader(true,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:71: In function 'queryKindLast':
+kind-queries.chpl:71: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:87: called as queryKindLast(reader: fileReader(true,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:37: In function 'bar':
+kind-queries.chpl:37: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:90: called as bar(reader: fileReader(native,true,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:63: In function 'queryKind':
+kind-queries.chpl:63: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:91: called as queryKind(reader: fileReader(native,true,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:102: called as helper(param locking = true, type deserType = defaultSerializer)
+kind-queries.chpl:29: In function 'bar':
+kind-queries.chpl:29: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:75: called as bar(writer: fileWriter(false,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:59: In function 'queryKind':
+kind-queries.chpl:59: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:86: called as queryKind(writer: fileWriter(false,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:67: In function 'queryKindLast':
+kind-queries.chpl:67: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:87: called as queryKindLast(writer: fileWriter(false,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:29: In function 'bar':
+kind-queries.chpl:29: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:90: called as bar(writer: fileWriter(native,false,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:59: In function 'queryKind':
+kind-queries.chpl:59: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:91: called as queryKind(writer: fileWriter(native,false,defaultSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:37: In function 'bar':
+kind-queries.chpl:37: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:75: called as bar(reader: fileReader(false,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:63: In function 'queryKind':
+kind-queries.chpl:63: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:86: called as queryKind(reader: fileReader(false,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:71: In function 'queryKindLast':
+kind-queries.chpl:71: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:87: called as queryKindLast(reader: fileReader(false,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:37: In function 'bar':
+kind-queries.chpl:37: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:90: called as bar(reader: fileReader(native,false,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:63: In function 'queryKind':
+kind-queries.chpl:63: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:91: called as queryKind(reader: fileReader(native,false,defaultDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = defaultSerializer) from function 'helper'
+  kind-queries.chpl:103: called as helper(param locking = false, type deserType = defaultSerializer)
+kind-queries.chpl:29: In function 'bar':
+kind-queries.chpl:29: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:75: called as bar(writer: fileWriter(true,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:59: In function 'queryKind':
+kind-queries.chpl:59: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:86: called as queryKind(writer: fileWriter(true,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:67: In function 'queryKindLast':
+kind-queries.chpl:67: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:87: called as queryKindLast(writer: fileWriter(true,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:29: In function 'bar':
+kind-queries.chpl:29: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:90: called as bar(writer: fileWriter(native,true,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:59: In function 'queryKind':
+kind-queries.chpl:59: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:91: called as queryKind(writer: fileWriter(native,true,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:37: In function 'bar':
+kind-queries.chpl:37: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:75: called as bar(reader: fileReader(true,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:63: In function 'queryKind':
+kind-queries.chpl:63: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:86: called as queryKind(reader: fileReader(true,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:71: In function 'queryKindLast':
+kind-queries.chpl:71: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:87: called as queryKindLast(reader: fileReader(true,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:37: In function 'bar':
+kind-queries.chpl:37: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:90: called as bar(reader: fileReader(native,true,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:63: In function 'queryKind':
+kind-queries.chpl:63: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:91: called as queryKind(reader: fileReader(native,true,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = true, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:104: called as helper(param locking = true, type deserType = jsonSerializer)
+kind-queries.chpl:29: In function 'bar':
+kind-queries.chpl:29: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:75: called as bar(writer: fileWriter(false,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:59: In function 'queryKind':
+kind-queries.chpl:59: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:86: called as queryKind(writer: fileWriter(false,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:67: In function 'queryKindLast':
+kind-queries.chpl:67: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:87: called as queryKindLast(writer: fileWriter(false,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:29: In function 'bar':
+kind-queries.chpl:29: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:90: called as bar(writer: fileWriter(native,false,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:59: In function 'queryKind':
+kind-queries.chpl:59: warning: 'fileWriter.kind' is deprecated, please use Serializers to configure endianness instead
+  kind-queries.chpl:91: called as queryKind(writer: fileWriter(native,false,jsonSerializer)) from function 'helper'
+  kind-queries.chpl:97: called as helper(type channel = fileWriter, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:37: In function 'bar':
+kind-queries.chpl:37: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:75: called as bar(reader: fileReader(false,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:63: In function 'queryKind':
+kind-queries.chpl:63: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:86: called as queryKind(reader: fileReader(false,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:71: In function 'queryKindLast':
+kind-queries.chpl:71: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:87: called as queryKindLast(reader: fileReader(false,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:37: In function 'bar':
+kind-queries.chpl:37: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:90: called as bar(reader: fileReader(native,false,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+kind-queries.chpl:63: In function 'queryKind':
+kind-queries.chpl:63: warning: 'fileReader.kind' is deprecated, please use Deserializers to configure endianness instead
+  kind-queries.chpl:91: called as queryKind(reader: fileReader(native,false,jsonDeserializer)) from function 'helper'
+  kind-queries.chpl:98: called as helper(type channel = fileReader, param locking = false, type deserType = jsonSerializer) from function 'helper'
+  kind-queries.chpl:105: called as helper(param locking = false, type deserType = jsonSerializer)
+----- fileWriter(true,defaultSerializer) -----
+foo: fully generic: fileWriter(true,defaultSerializer)
+bar: fileWriter(?): fileWriter(true,defaultSerializer)
+L = true :: ST = defaultSerializer
+L = true :: ST = defaultSerializer
+L = true :: ST = defaultSerializer :: K = dynamic
+L = true :: ST = defaultSerializer :: K = dynamic
+bar: fileWriter(kind=iokind.native, ?): fileWriter(native,true,defaultSerializer)
+L = true :: ST = defaultSerializer :: K = native
+
+----- fileReader(true,defaultDeserializer) -----
+foo: fully generic: fileReader(true,defaultDeserializer)
+bar: fileReader(?): fileReader(true,defaultDeserializer)
+L = true :: DT = defaultDeserializer
+L = true :: DT = defaultDeserializer
+L = true :: DT = defaultDeserializer :: K = dynamic
+L = true :: DT = defaultDeserializer :: K = dynamic
+bar: fileReader(kind=iokind.native, ?): fileReader(native,true,defaultDeserializer)
+L = true :: DT = defaultDeserializer :: K = native
+
+----- fileWriter(false,defaultSerializer) -----
+foo: fileWriter(false): fileWriter(false,defaultSerializer)
+bar: fileWriter(?): fileWriter(false,defaultSerializer)
+L = false :: ST = defaultSerializer
+L = false :: ST = defaultSerializer
+L = false :: ST = defaultSerializer :: K = dynamic
+L = false :: ST = defaultSerializer :: K = dynamic
+bar: fileWriter(kind=iokind.native, ?): fileWriter(native,false,defaultSerializer)
+L = false :: ST = defaultSerializer :: K = native
+
+----- fileReader(false,defaultDeserializer) -----
+foo: fileReader(false): fileReader(false,defaultDeserializer)
+bar: fileReader(?): fileReader(false,defaultDeserializer)
+L = false :: DT = defaultDeserializer
+L = false :: DT = defaultDeserializer
+L = false :: DT = defaultDeserializer :: K = dynamic
+L = false :: DT = defaultDeserializer :: K = dynamic
+bar: fileReader(kind=iokind.native, ?): fileReader(native,false,defaultDeserializer)
+L = false :: DT = defaultDeserializer :: K = native
+
+----- fileWriter(true,jsonSerializer) -----
+foo: fully generic: fileWriter(true,jsonSerializer)
+bar: fileWriter(?): fileWriter(true,jsonSerializer)
+L = true :: ST = jsonSerializer
+L = true :: ST = jsonSerializer
+L = true :: ST = jsonSerializer :: K = dynamic
+L = true :: ST = jsonSerializer :: K = dynamic
+bar: fileWriter(kind=iokind.native, ?): fileWriter(native,true,jsonSerializer)
+L = true :: ST = jsonSerializer :: K = native
+
+----- fileReader(true,jsonDeserializer) -----
+foo: fully generic: fileReader(true,jsonDeserializer)
+bar: fileReader(?): fileReader(true,jsonDeserializer)
+L = true :: DT = jsonDeserializer
+L = true :: DT = jsonDeserializer
+L = true :: DT = jsonDeserializer :: K = dynamic
+L = true :: DT = jsonDeserializer :: K = dynamic
+bar: fileReader(kind=iokind.native, ?): fileReader(native,true,jsonDeserializer)
+L = true :: DT = jsonDeserializer :: K = native
+
+----- fileWriter(false,jsonSerializer) -----
+foo: fully generic: fileWriter(false,jsonSerializer)
+bar: fileWriter(?): fileWriter(false,jsonSerializer)
+L = false :: ST = jsonSerializer
+L = false :: ST = jsonSerializer
+L = false :: ST = jsonSerializer :: K = dynamic
+L = false :: ST = jsonSerializer :: K = dynamic
+bar: fileWriter(kind=iokind.native, ?): fileWriter(native,false,jsonSerializer)
+L = false :: ST = jsonSerializer :: K = native
+
+----- fileReader(false,jsonDeserializer) -----
+foo: fully generic: fileReader(false,jsonDeserializer)
+bar: fileReader(?): fileReader(false,jsonDeserializer)
+L = false :: DT = jsonDeserializer
+L = false :: DT = jsonDeserializer
+L = false :: DT = jsonDeserializer :: K = dynamic
+L = false :: DT = jsonDeserializer :: K = dynamic
+bar: fileReader(kind=iokind.native, ?): fileReader(native,false,jsonDeserializer)
+L = false :: DT = jsonDeserializer :: K = native
+


### PR DESCRIPTION
This PR adjusts the implementation of PRIM_QUERY during resolution specifically for the ``fileReader`` and ``fileWriter`` types. While these types have had their ``kind`` field deprecated, it is still technically the first generic field in the type. This PR modifies the PRIM_QUERY implementation to skip the 'kind' field unless it is explicitly specified. A deprecation test is also added exercising various queries.

Note: The production compiler currently inserts PRIM_QUERY calls into a 'where' clause during the ``normalize`` pass even when queries are not present. For example, a type expression like ``R(int)`` would see a where-clause generated comparing ``int`` to the first generic field in ``R``.

Testing:
- [x] local
- [x] gasnet