### PR TITLE
Ignore unreachable 'return'

### DIFF
--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -454,6 +454,7 @@ static void resolveOverrideAndAdjustMaps(FnSymbol* pfn, FnSymbol* cfn) {
       evaluateWhereClause(cfn) &&
       evaluateWhereClause(pfn)) {
 
+    resolveSpecifiedReturnType(cfn);
     resolveFunction(cfn);
 
     // check to see if we are using defaulted actual fns

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -199,8 +199,6 @@ module ChapelDistribution {
 
     proc dsiMyDist(): unmanaged BaseDist {
       halt("internal error: dsiMyDist is not implemented");
-      pragma "unsafe" var ret: unmanaged BaseDist; // nil
-      return ret;
     }
 
     // default overloads to provide clear compile-time error messages
@@ -451,12 +449,10 @@ module ChapelDistribution {
 
     proc dsiAdd(in x) {
       compilerError("Cannot add indices to a rectangular domain");
-      return 0;
     }
 
     proc dsiRemove(x) {
       compilerError("Cannot remove indices from a rectangular domain");
-      return 0;
     }
   }
 
@@ -482,10 +478,8 @@ module ChapelDistribution {
     }
 
     proc bulkAdd_help(ref inds: [?indsDom] index(rank, idxType),
-        dataSorted=false, isUnique=false, addOn=nilLocale){
+        dataSorted=false, isUnique=false, addOn=nilLocale): int {
       halt("Helper function called on the BaseSparseDomImpl");
-
-      return -1;
     }
 
     // TODO: Would ChapelArray.resizeAllocRange() be too expensive?
@@ -690,7 +684,6 @@ module ChapelDistribution {
         addOn=nilLocale): int {
 
       halt("Bulk addition is not supported by this sparse domain");
-      return 0;
     }
 
     proc dsiBulkAddNoPreserveInds(ref inds: [] index(rank, idxType),
@@ -698,7 +691,6 @@ module ChapelDistribution {
         addOn=nilLocale): int {
 
       halt("Bulk addition is not supported by this sparse domain");
-      return 0;
     }
 
     proc boundsCheck(ind: index(rank, idxType)):void {
@@ -729,15 +721,11 @@ module ChapelDistribution {
     override proc dsiHigh { return parentDom.highBound; }
     override proc dsiStride { return parentDom.stride; }
     override proc dsiAlignment { return parentDom.alignment; }
-    override proc dsiFirst {
+    override proc dsiFirst: rank*idxType {
       halt("dsiFirst is not implemented");
-      const _tmp: rank*idxType;
-      return _tmp;
     }
-    override proc dsiLast {
+    override proc dsiLast: rank*idxType {
       halt("dsiLast not implemented");
-      const _tmp: rank*idxType;
-      return _tmp;
     }
     override proc dsiAlignedLow { return parentDom.low; }
     override proc dsiAlignedHigh { return parentDom.high; }
@@ -762,7 +750,6 @@ module ChapelDistribution {
 
     proc dsiAdd(in idx) {
       compilerError("Index addition is not supported by this domain");
-      return 0;
     }
 
     proc rank param {
@@ -805,8 +792,6 @@ module ChapelDistribution {
 
     proc dsiGetBaseDom(): unmanaged BaseDom {
       halt("internal error: dsiGetBaseDom is not implemented");
-      pragma "unsafe" var ret: unmanaged BaseDom; // nil
-      return ret;
     }
 
     // takes 'rmFromList' which indicates whether the array should
@@ -839,17 +824,14 @@ module ChapelDistribution {
 
     proc chpl_isElementTypeDefaultInitializable(): bool {
       halt("chpl_isElementTypeDefaultInitializable must be defined");
-      return false;
     }
 
     proc chpl_isElementTypeNonNilableClass(): bool {
       halt("chpl_isElementTypeNonNilableClass must be defined");
-      return false;
     }
 
-    proc chpl_unsafeAssignIsClassElementNil(manager, idx) {
+    proc chpl_unsafeAssignIsClassElementNil(manager, idx): bool {
       halt("chpl_unsafeAssignIsClassElementNil must be defined");
-      return false;
     }
 
     proc chpl_unsafeAssignHaltUninitializedElement(idx) {

--- a/modules/internal/ChapelHashtable.chpl
+++ b/modules/internal/ChapelHashtable.chpl
@@ -427,7 +427,6 @@ module ChapelHashtable {
           // the deleted entries & the table should only ever be half
           // full of non-deleted entries.
           halt("couldn't add key -- ", tableNumFullSlots, " / ", tableSize, " taken");
-          return (false, -1);
         }
         return (foundSlot, slotNum);
       }

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -398,23 +398,19 @@ module ChapelLocale {
     // concrete classes.
     proc chpl_id() : int {
       HaltWrappers.pureVirtualMethodHalt();
-      return -1;
     }
 
     proc chpl_localeid() : chpl_localeID_t {
       HaltWrappers.pureVirtualMethodHalt();
-      return chpl_buildLocaleID(-1:chpl_nodeID_t, c_sublocid_none);
     }
 
     proc chpl_name() : string {
       HaltWrappers.pureVirtualMethodHalt();
-      return "";
     }
 
     @chpldoc.nodoc
     proc _getChildCount() : int {
       HaltWrappers.pureVirtualMethodHalt();
-      return 0;
     }
 
 // Part of the required locale interface.

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -583,7 +583,6 @@ module DefaultAssociative {
         return data(slotNum);
       } else {
         halt("array index out of bounds: ", idx);
-        return data(0);
       }
     }
 
@@ -600,7 +599,6 @@ module DefaultAssociative {
         return data(slotNum);
       } else {
         halt("array index out of bounds: ", idx);
-        return data(0);
       }
     }
 

--- a/modules/internal/LocaleModelHelpAPU.chpl
+++ b/modules/internal/LocaleModelHelpAPU.chpl
@@ -61,7 +61,7 @@ module LocaleModelHelpAPU {
   //         chpl_executeOn / chpl_executeOnFast
   //
   export
-  proc chpl_doDirectExecuteOn(loc: chpl_localeID_t // target locale
+  proc chpl_doDirectExecuteOn(const ref loc: chpl_localeID_t // target locale
                              ):bool {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
@@ -83,7 +83,7 @@ module LocaleModelHelpAPU {
   //
   pragma "insert line file info"
   export
-  proc chpl_executeOn(loc: chpl_localeID_t, // target locale
+  proc chpl_executeOn(const ref loc: chpl_localeID_t, // target locale
                       fn: int,              // on-body function idx
                       args: chpl_comm_on_bundle_p,     // function args
                       args_size: c_size_t     // args size
@@ -124,7 +124,7 @@ module LocaleModelHelpAPU {
   //
   pragma "insert line file info"
   export
-  proc chpl_executeOnFast(loc: chpl_localeID_t, // target locale
+  proc chpl_executeOnFast(const ref loc: chpl_localeID_t, // target locale
                           fn: int,              // on-body function idx
                           args: chpl_comm_on_bundle_p,     // function args
                           args_size: c_size_t     // args size
@@ -153,7 +153,7 @@ module LocaleModelHelpAPU {
   //
   pragma "insert line file info"
   export
-  proc chpl_executeOnNB(loc: chpl_localeID_t, // target locale
+  proc chpl_executeOnNB(const ref loc: chpl_localeID_t, // target locale
                         fn: int,              // on-body function idx
                         args: chpl_comm_on_bundle_p,     // function args
                         args_size: c_size_t     // args size

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -53,14 +53,14 @@ module LocaleModel {
 
   class CPULocale : AbstractLocaleModel {
     const sid: chpl_sublocID_t;
-    const name: string;
+    const name_: string;
 
-    override proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
+    override proc chpl_id() do return (parent:LocaleModel)._node_id; // top-level node id
     override proc chpl_localeid() {
       return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
                                 sid);
     }
-    override proc chpl_name() return name;
+    override proc chpl_name() do return name_;
 
     proc init() {
     }
@@ -68,39 +68,37 @@ module LocaleModel {
     proc init(_sid, _parent) {
       super.init(new locale(_parent));
       sid = _sid;
-      name = _parent.chpl_name() + "-CPU" + sid:string;
+      name_ = _parent.chpl_name() + "-CPU" + sid:string;
     }
 
     override proc writeThis(f) throws {
       parent.writeThis(f);
-      f.write('.'+name);
+      f.write('.'+name_);
     }
 
     override proc _getChildCount(): int { return 0; }
 
     iter getChildIndices() : int {
       halt("No children to iterate over.");
-      yield -1;
     }
     proc addChild(loc:locale) {
       halt("Cannot add children to this locale type.");
     }
     override proc _getChild(idx:int) : locale {
       halt("requesting a child from a CPULocale locale");
-      return new locale(this);
     }
   }
 
   class GPULocale : AbstractLocaleModel {
     const sid: chpl_sublocID_t;
-    const name: string;
+    const name_: string;
 
-    override proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
+    override proc chpl_id() do return (parent:LocaleModel)._node_id; // top-level node id
     override proc chpl_localeid() {
       return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
                                 sid);
     }
-    override proc chpl_name() return name;
+    override proc chpl_name() do return name_;
 
     proc init() {
     }
@@ -116,25 +114,23 @@ module LocaleModel {
     proc init(_sid, _parent) {
       super.init(new locale(_parent));
       sid = _sid;
-      name = _parent.chpl_name() + "-GPU" + sid:string;
+      name_ = _parent.chpl_name() + "-GPU" + sid:string;
     }
 
     override proc writeThis(f) throws {
       parent.writeThis(f);
-      f.write('.'+name);
+      f.write('.'+name_);
     }
 
     override proc _getChildCount(): int { return 0; }
     iter getChildIndices() : int {
       halt("No children to iterate over.");
-      yield -1;
     }
     proc addChild(loc:locale) {
       halt("Cannot add children to this locale type.");
     }
     override proc _getChild(idx:int) : locale {
       halt("requesting a child from a GPULocale locale");
-      return new locale(this);
     }
   }
 
@@ -181,18 +177,17 @@ module LocaleModel {
       setup();
     }
 
-    override proc chpl_id() return _node_id;     // top-level locale (node) number
+    override proc chpl_id() do return _node_id;     // top-level locale (node) number
     override proc chpl_localeid() {
       return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_none);
     }
-    override proc chpl_name() return local_name;
+    override proc chpl_name() do return local_name;
 
-    proc getChildSpace() {
+    proc getChildSpace(): domain(1) {
       halt("error!");
-      return {0..#numSublocales};
     }
 
-    override proc _getChildCount() return 0;
+    override proc _getChildCount() do return 0;
 
     iter getChildIndices() : int {
       for idx in {0..#numSublocales} do // chpl_emptyLocaleSpace do
@@ -216,9 +211,8 @@ module LocaleModel {
       }
     }
 
-    proc getChildArray() {
+    proc getChildArray(): chpl_emptyLocales.type {
       halt ("in get child Array");
-      return chpl_emptyLocales;
     }
 
 
@@ -272,35 +266,35 @@ module LocaleModel {
     // We return numLocales for now, since we expect nodes to be
     // numbered less than this.
     // -1 is used in the abstract locale class to specify an invalid node ID.
-    override proc chpl_id() return numLocales;
+    override proc chpl_id() do return numLocales;
     override proc chpl_localeid() {
       return chpl_buildLocaleID(numLocales:chpl_nodeID_t, c_sublocid_none);
     }
-    override proc chpl_name() return local_name();
-    proc local_name() return "rootLocale";
+    override proc chpl_name() do return local_name();
+    proc local_name() do return "rootLocale";
 
     override proc writeThis(f) throws {
       f.write(name);
     }
 
-    override proc _getChildCount() return this.myLocaleSpace.size;
+    override proc _getChildCount() do return this.myLocaleSpace.size;
 
-    proc getChildSpace() return this.myLocaleSpace;
+    proc getChildSpace() do return this.myLocaleSpace;
 
     iter getChildIndices() : int {
       for idx in this.myLocaleSpace do
         yield idx;
     }
 
-    override proc _getChild(idx:int) return this.myLocales[idx];
+    override proc _getChild(idx:int) do return this.myLocales[idx];
 
     iter getChildren() : locale  {
       for loc in this.myLocales do
         yield loc;
     }
 
-    override proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
-    override proc getDefaultLocaleArray() const ref return myLocales;
+    override proc getDefaultLocaleSpace() const ref do return this.myLocaleSpace;
+    override proc getDefaultLocaleArray() const ref do return myLocales;
 
     override proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -109,11 +109,8 @@ module LocaleModel {
         yield idx;
     }
 
-    pragma "unsafe"
     override proc _getChild(idx: int) : locale {
       halt("requesting a child from a flat LocaleModel locale");
-      var tmp:locale; // nil
-      return tmp;
     }
 
     iter getChildren() : locale  {

--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -255,7 +255,6 @@ module LocaleModel {
     }
     override proc _getChild(idx:int) : locale {
       halt("requesting a child from a GPULocale locale");
-      return new locale(this);
     }
 
     override proc isGpu() : bool { return true; }

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -341,7 +341,6 @@ class CSDom: BaseSparseDomImpl(?) {
       }
     }
     halt("Something went wrong in dsiFirst");
-    return (0, 0);
   }
 
   override proc dsiLast {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -422,7 +422,6 @@ module TomlParser {
         // Error
         else {
           throw new owned TomlError("Line "+ debugCounter:string +": Unexpected Token -> " + getToken(source));
-          return new shared Toml(val);
         }
       }
       catch e: IllegalArgumentError {
@@ -1071,7 +1070,6 @@ used to recursively hold tables and respective values
         when fieldDateTime do return val.dt:string;
         otherwise {
           throw new owned TomlError("Error in printing " + val.s);
-          return val.s;
         }
       }
     }
@@ -1112,7 +1110,6 @@ used to recursively hold tables and respective values
         when fieldToml do return 'toml';
         otherwise {
           throw new owned TomlError("Unknown type");
-          return "nil";
         }
       }
     }

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -574,7 +574,6 @@ module Errors {
   proc chpl_enum_cast_error_no_int(enumName: string, constName: string) throws {
     throw new owned IllegalArgumentError("bad cast: enum '" + enumName + "." +
                                           constName + "' has no integer value");
-    return 0;
   }
 
 

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -571,7 +571,7 @@ module Errors {
 
   pragma "insert line file info"
   pragma "always propagate line file info"
-  proc chpl_enum_cast_error_no_int(enumName: string, constName: string) throws {
+  proc chpl_enum_cast_error_no_int(enumName: string, constName: string): int throws {
     throw new owned IllegalArgumentError("bad cast: enum '" + enumName + "." +
                                           constName + "' has no integer value");
   }

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -2152,26 +2152,22 @@ module Time {
     /* The offset from UTC this class represents */
     proc utcOffset(dt: dateTime): timeDelta {
       HaltWrappers.pureVirtualMethodHalt();
-      return new timeDelta();
     }
 
     /* The `timeDelta` for daylight saving time */
     proc dst(dt: dateTime): timeDelta {
       HaltWrappers.pureVirtualMethodHalt();
-      return new timeDelta();
     }
 
     /* The name of this time zone */
     @unstable("'tzname' is unstable")
     proc tzname(dt: dateTime): string {
       HaltWrappers.pureVirtualMethodHalt();
-      return "";
     }
 
     /* Convert a `time` in UTC to this time zone */
     proc fromUtc(dt: dateTime): dateTime {
       HaltWrappers.pureVirtualMethodHalt();
-      return new dateTime(0,0,0);
     }
 
   }
@@ -2467,7 +2463,6 @@ private proc _convert_to_seconds(unit: TimeUnits, us: real) {
   }
 
   HaltWrappers.exhaustiveSelectHalt("unknown timeunits type");
-  return -1.0;
 }
 
 // converts microseconds to another unit
@@ -2482,7 +2477,6 @@ private proc _convert_microseconds(unit: TimeUnits, us: real) {
   }
 
   HaltWrappers.exhaustiveSelectHalt("unknown timeunits type");
-  return -1.0;
 }
 
 }

--- a/test/arrays/bradc/workarounds/fakeSpsArr2.chpl
+++ b/test/arrays/bradc/workarounds/fakeSpsArr2.chpl
@@ -5,7 +5,6 @@ record sps33 {
   proc ref this(i, j) ref {
     if (i == j) {
       halt("Assigning an IRV value");
-      return irv;
     } else if (i==-1) {
       return data(i, j==1);
     } else {

--- a/test/classes/bradc/overloadMethods/v3aoneClassReturnMatch.chpl
+++ b/test/classes/bradc/overloadMethods/v3aoneClassReturnMatch.chpl
@@ -1,7 +1,7 @@
 class C {
-  proc bbox(x: int) {
+  proc bbox(x: int): range(strides=strideKind.negOne) {
     halt("bbox() not implemented for this class");
-    return 0..-1 by -1;
+    // return 0..-1 by -1; // this line would be ignored
   }
 }
 

--- a/test/classes/bradc/overloadMethods/v3oneClassReturnMatch.chpl
+++ b/test/classes/bradc/overloadMethods/v3oneClassReturnMatch.chpl
@@ -1,7 +1,7 @@
 class C {
-  proc bbox(x: int) {
+  proc bbox(x: int): range {
     halt("bbox() not implemented for this class");
-    return 0..-1;
+    // return 0..-1; // this line would be ignored
   }
 }
 

--- a/test/classes/bradc/overloadMethods/v4oneClassReturnNoMatch.chpl
+++ b/test/classes/bradc/overloadMethods/v4oneClassReturnNoMatch.chpl
@@ -1,7 +1,7 @@
 class C {
-  proc bbox(x: int) {
+  proc bbox(x: int): range(strides=strideKind.negOne) {
     halt("bbox() not implemented for this class");
-    return 0..-1 by -1;
+    // return 0..-1 by -1; // this line would be ignored
   }
 }
 

--- a/test/classes/bradc/overloadMethods/v5bothReturnTypes.chpl
+++ b/test/classes/bradc/overloadMethods/v5bothReturnTypes.chpl
@@ -1,7 +1,7 @@
 class C {
-  proc bbox(x: int) {
+  proc bbox(x: int): range {
     halt("bbox() not implemented for this class");
-    return 0..-1 by 1;
+
   }
 }
 

--- a/test/classes/bradc/overloadMethods/virtualIsHalt.chpl
+++ b/test/classes/bradc/overloadMethods/virtualIsHalt.chpl
@@ -1,7 +1,6 @@
 class C {
-  proc bbox(d: int) {
+  proc bbox(d: int): range {
     halt("bbox() is not implemented for this class");
-    return 1..0;
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/fieldDefaultThrows.chpl
+++ b/test/classes/initializers/errors/errHandling/fieldDefaultThrows.chpl
@@ -1,6 +1,6 @@
-proc funcThatThrows() throws {
+proc funcThatThrows(): int throws {
   throw new Error("whee!");
-  return 10;
+  return 10; // note that this line is ignored
 }
 
 class Foo {

--- a/test/constrained-generics/hashtable/MyHashtable.chpl
+++ b/test/constrained-generics/hashtable/MyHashtable.chpl
@@ -542,7 +542,6 @@ implements chpl_Hashtable(chpl__hashtable(string, int));
           // the deleted entries & the table should only ever be half
           // full of non-deleted entries.
           halt("couldn't add key -- ", tableNumFullSlots, " / ", tableSize, " taken");
-          return (false, -1);
         }
         return (foundSlot, slotNum);
       }

--- a/test/errhandling/ferguson/loopexprs-uncaught.chpl
+++ b/test/errhandling/ferguson/loopexprs-uncaught.chpl
@@ -1,7 +1,7 @@
 module CannotThrow {
-  proc willthrow(x: int) throws {
+  proc willthrow(x: int): int throws {
     throw new owned Error();
-    return x;
+
   }
   proc main() throws {
     var array1 = for i in 0..3 do willthrow(i);

--- a/test/errhandling/ferguson/nested-call-expr-var-init-throws.chpl
+++ b/test/errhandling/ferguson/nested-call-expr-var-init-throws.chpl
@@ -9,7 +9,7 @@ record R {
 proc gimmeanr(): R throws {
   var ret: R;
   throw new owned Error();
-  return ret;
+  return ret; // note that this line is ignored
 }
 
 proc testa() throws {

--- a/test/errhandling/iterators/non-equal-lengths-error-array-init.chpl
+++ b/test/errhandling/iterators/non-equal-lengths-error-array-init.chpl
@@ -1,8 +1,8 @@
 config const useInternal = false;
 
-proc willthrow() throws {
+proc willthrow(): bool throws {
   throw new owned Error();
-  return 777;
+  return 777; // note that this line is ignored
 }
 
 var RRR = 0..3;

--- a/test/errhandling/iterators/non-equal-lengths-error.chpl
+++ b/test/errhandling/iterators/non-equal-lengths-error.chpl
@@ -1,6 +1,6 @@
-proc willthrow() throws {
+proc willthrow(): string throws {
   throw new owned Error();
-  return 777;
+  return 777; // note that this line is ignored
 }
 
 var RRR = 0..3;

--- a/test/errhandling/iterators/try-in-yield.chpl
+++ b/test/errhandling/iterators/try-in-yield.chpl
@@ -84,9 +84,9 @@ config const tryBang = true;
 if tryBang {
   writeln("Case 4 - try!");
 
-  proc bar() throws {
+  proc bar(): int throws {
     throw new Error("test");
-    return 0;
+
   }
 
   iter foo() {
@@ -100,9 +100,9 @@ if tryBang {
 else {
   writeln("Case 4 - try");
 
-  proc bar() throws {
+  proc bar(): int throws {
     throw new Error("test");
-    return 0;
+
   }
 
   iter foo() throws { // can throw because can be inlined

--- a/test/errhandling/lydia/tryExpressionDefaultValue.chpl
+++ b/test/errhandling/lydia/tryExpressionDefaultValue.chpl
@@ -6,7 +6,7 @@ record Bar {
 
 proc throwingFunc(x = Bar.defaultVal): Bar throws {
   throw new Error("whatev");
-  return x;
+  return x; // note that this line is ignored
 }
 
 proc callThrowingFunc() {

--- a/test/errhandling/nspark/fn-returns-or-throws.chpl
+++ b/test/errhandling/nspark/fn-returns-or-throws.chpl
@@ -1,7 +1,6 @@
 use ExampleErrors;
 proc oops(): int throws {
   throw new owned StringError("called oops()");
-  return 99;
 }
 
 try {

--- a/test/errhandling/psahabu/cond-throwing.chpl
+++ b/test/errhandling/psahabu/cond-throwing.chpl
@@ -2,7 +2,6 @@ module X {
   proc giveFlag(i: int) throws {
     if i == 1 then return true;
     throw new owned IllegalArgumentError();
-    return false;
   }
 
   try {

--- a/test/errhandling/psahabu/if-expr-throwing.chpl
+++ b/test/errhandling/psahabu/if-expr-throwing.chpl
@@ -2,7 +2,6 @@ module X {
   proc giveFlag(i: int) throws {
     if i == 1 then return true;
     throw new owned IllegalArgumentError();
-    return false;
   }
 
   try {

--- a/test/functions/resolution/ignore-unreachable.chpl
+++ b/test/functions/resolution/ignore-unreachable.chpl
@@ -18,8 +18,10 @@ for param i in 0..<getNumFields(foo.type) {
 
 /////////////////////////////////////////////////////////////////////////////
 
+config param flag = true;
+
 proc p() type {
-  if true then
+  if flag then
     return int;
 
   return string;
@@ -36,6 +38,43 @@ proc p(param flag) {
 
 writeln(p(true));
 writeln(p(false));
+
+/////////////////////////////////////////////////////////////////////////////
+
+class Parent {
+  proc f() throws {
+    return here;
+  }
+  iter itr(): int {
+    if flag then return;
+    yield "hi"; // note that this line is ignored
+  }
+}
+
+class Child: Parent {
+  override proc f(): locale throws {
+    throw new Error("in Child.f()");
+  }
+  override iter itr(): int {
+    if flag then return;
+  }
+}
+
+var obj = new Parent();
+classtest();
+
+obj = new Child();
+classtest();
+
+proc classtest() {
+  try { writeln(obj.f()); }
+  catch e { writeln(e); }
+
+  for idx in obj.itr() {
+    compilerWarning(idx.type:string, 0);
+    writeln(idx);
+  }
+}
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/functions/resolution/ignore-unreachable.good
+++ b/test/functions/resolution/ignore-unreachable.good
@@ -1,9 +1,13 @@
-ignore-unreachable.chpl:28: warning: int(64)
+ignore-unreachable.chpl:30: warning: int(64)
+ignore-unreachable.chpl:69: In function 'classtest':
+ignore-unreachable.chpl:74: warning: int(64)
 hi
 3.5
 bye
+LOCALE0
+Error: in Child.f()
 in t1
 in t1
 7755
 in t2
-ignore-unreachable.chpl:67: error: halt reached - in main
+ignore-unreachable.chpl:106: error: halt reached - in main

--- a/test/library/draft/DataFrames/DataFrames.chpl
+++ b/test/library/draft/DataFrames/DataFrames.chpl
@@ -24,34 +24,29 @@ module DataFrames {
 
   class Index {
     @chpldoc.nodoc
-    proc contains(lab) {
+    proc contains(lab): bool {
       halt("generic Index contains no elements");
-      return false;
     }
 
     @chpldoc.nodoc
     proc uni(lhs: borrowed TypedSeries, rhs: borrowed TypedSeries, unifier:
         borrowed SeriesUnifier): owned Series {
       halt("generic Index cannot be unioned");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
     proc map(s: borrowed TypedSeries, mapper: borrowed SeriesMapper): owned Series {
       halt("generic Index cannot be mapped");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
     proc filter(s: borrowed TypedSeries, filterSeries: borrowed TypedSeries): owned Series {
       halt("generic Index cannot be filtered");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
     proc nrows(): int {
       halt("generic Index cannot be countd");
-      return 0;
     }
 
     @chpldoc.nodoc
@@ -317,87 +312,73 @@ module DataFrames {
     }
 
     @chpldoc.nodoc
-    proc uni(lhs: borrowed TypedSeries, unifier: borrowed SeriesUnifier) {
+    proc uni(lhs: borrowed TypedSeries, unifier: borrowed SeriesUnifier): owned Series {
       halt("generic Series cannot be unioned");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc map(mapper: borrowed SeriesMapper) {
+    proc map(mapper: borrowed SeriesMapper): owned Series {
       halt("generic Series cannot be unioned");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc add(rhs) {
+    proc add(rhs): owned Series {
       halt("generic Series cannot be added");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc add_scalar(n) {
+    proc add_scalar(n): owned Series {
       halt("generic Series cannot be added");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc subtr(rhs) {
+    proc subtr(rhs): owned Series {
       halt("generic Series cannot be subtracted");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc subtr_scalar(n) {
+    proc subtr_scalar(n): owned Series {
       halt("generic Series cannot be subtracted");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc mult(rhs) {
+    proc mult(rhs): owned Series {
       halt("generic Series cannot be multiplied");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc mult_scalar(n) {
+    proc mult_scalar(n): owned Series {
       halt("generic Series cannot be multiplied");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc lt_scalar(n) {
+    proc lt_scalar(n): owned Series {
       halt("generic Series cannot be compared");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc gt_scalar(n) {
+    proc gt_scalar(n): owned Series {
       halt("generic Series cannot be compared");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc eq_scalar(n) {
+    proc eq_scalar(n): owned Series {
       halt("generic Series cannot be compared");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc lteq_scalar(n) {
+    proc lteq_scalar(n): owned Series {
       halt("generic Series cannot be compared");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
-    proc gteq_scalar(n) {
+    proc gteq_scalar(n): owned Series {
       halt("generic Series cannot be compared");
-      return new owned Series();
     }
 
     @chpldoc.nodoc
     proc nrows(): int {
       halt("generic Series cannot be counted");
-      return 0;
     }
 
     @chpldoc.nodoc

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -11,9 +11,8 @@ module Timer {
     proc stop() {
       halt("Called Abstract Base stop method");
     }
-    proc elapsed() {
+    proc elapsed(): real {
       halt("Called Abstract Base elapsed method");
-      return 0.0;
     }
   }
 

--- a/test/studies/adventOfCode/2022/day11/bradc/day11.chpl
+++ b/test/studies/adventOfCode/2022/day11/bradc/day11.chpl
@@ -96,9 +96,8 @@ proc Monkey.processItems(canFinishTurn) {
 
 // This is effectively an abstract base class
 class MathOp {
-  proc apply(item) {
+  proc apply(item): item.type {
     halt("We should never end up calling '.apply' on the base class");
-    return item;
   }
 }
 

--- a/test/studies/adventOfCode/2022/day11/bradc/day11a.chpl
+++ b/test/studies/adventOfCode/2022/day11/bradc/day11a.chpl
@@ -96,9 +96,8 @@ proc Monkey.processItems(canFinishTurn) {
 
 // This is effectively an abstract base class
 class MathOp {
-  proc apply(item) {
+  proc apply(item): item.type {
     halt("We should never end up calling '.apply' on the base class");
-    return item;
   }
 }
 

--- a/test/studies/madness/aniruddha/madchap/AnalyticFcn.chpl
+++ b/test/studies/madness/aniruddha/madchap/AnalyticFcn.chpl
@@ -3,6 +3,5 @@
 class AFcn {
     proc this(x: real): real {
         halt("Fn1d.f() is abstract and should not be called directly");
-        return 0.0;
     }
 }

--- a/test/studies/madness/aniruddha/madchap/recordBug/AnalyticFcn.chpl
+++ b/test/studies/madness/aniruddha/madchap/recordBug/AnalyticFcn.chpl
@@ -3,6 +3,5 @@
 class AFcn {
     proc this(x: real): real {
         halt("Fn1d.f() is abstract and should not be called directly");
-        return 0.0;
     }
 }

--- a/test/studies/madness/common/AnalyticFcn.chpl
+++ b/test/studies/madness/common/AnalyticFcn.chpl
@@ -3,6 +3,5 @@
 class AFcn {
     proc this(x: real): real {
         halt("Fn1d.f() is abstract and should not be called directly");
-        return 0.0;
     }
 }

--- a/test/studies/madness/dinan/mad_chapel/AnalyticFcn.chpl
+++ b/test/studies/madness/dinan/mad_chapel/AnalyticFcn.chpl
@@ -3,6 +3,5 @@
 class AFcn {
     proc this(x: real): real {
         halt("Fn1d.f() is abstract and should not be called directly");
-        return 0.0;
     }
 }

--- a/test/trivial/shannon/condReturn.chpl
+++ b/test/trivial/shannon/condReturn.chpl
@@ -6,13 +6,13 @@ proc buildC() {
   return new owned C();
 }
 
-proc foo(x: int ...?numargs) {
+proc foo(x: int ...?numargs): owned C {
   writeln("In foo()");
   if (numargs > 1) {
     return buildC();
   } else {
     halt("not enough args");
-    return none;
+    return none; // note that this line is ignored
   }
 }
 


### PR DESCRIPTION
Ignore `return` statements that are unreachable because they follow a `throw`, `halt()`, etc. This implements the remaining TODO item from #20497. See #20673 for related design discussion.

This change is implemented by removing the special-case code added in #20497.

That special-case code ensured that unreachable `return`s were not ignored. This was needed due to a bug elsewhere that ignored declared return types in overriding methods. For example:

```chpl
override proc _getChild(idx:int) : locale {
  halt("requesting a child from a GPULocale locale");
  return new locale(this);
}
```

If `return new locale(this);` were ignored, the compiler would consider this overload to return `void` despite the declared return type. This would lead to an error because the parent method returned `locale`.

This PR fixes this bug by adding a call to `resolveSpecifiedReturnType()` in virtualDispatch.cpp.

### Test changes

Added declared return types when needed, now that the return type cannot be defined using a return statement even when it is present.

Removed no-longer-useful `return`s. In a couple of places this allowed me to remove the `unsafe` pragme as well. Tada. Elsewhere I removed `return` after `compilerError()`; there are ignored independent of this PR.

The bug fix is illustrated by an addition to `test/functions/resolution/ignore-unreachable.chpl`.

I left a couple of unreachable `return`s just to illustrate that they are ignored. I annotated each of these with `// note that this line is ignored`.

While there, I brought `apu/LocaleModel.chpl` and `LocaleModelHelpAPU.chpl` up to date with recent language changes.

I left alone `numa/LocaleModel.chpl` because I expect it to continue to work as-is and it is deprecated.