### PR TITLE
Fix a stupid typo in `this.complete()` -> `init this` change.

### DIFF
--- a/modules/internal/localeModels/gpu/LocaleModel.chpl
+++ b/modules/internal/localeModels/gpu/LocaleModel.chpl
@@ -314,7 +314,7 @@ module LocaleModel {
       numSublocales = chpl_gpu_num_devices;
       childSpace = {0..#numSublocales};
 
-      int this;
+      init this;
 
       setup();
     }


### PR DESCRIPTION
It's a typo (`int this` should be `init this`). It wasn't caught by a paratest because it's in GPU module code.

Trivial, probably will not ask for review.