### PR TITLE
ignore pruned functions in PRIM_GATHER_TESTS

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -802,27 +802,28 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     Type* testType = call->get(1)->getValType();
     forv_Vec(FnSymbol, fn, gFnSymbols) {
       if (fn->throwsError()) {
-        ModuleSymbol *mod = fn->getModule();
-        if (mod->modTag == MOD_USER) {
-          if (fn->numFormals() == 1) {
-            if (fn->instantiatedFrom == NULL && ! fn->isKnownToBeGeneric()) {
-              const char* name = astr(fn->name);
-              resolveSignature(fn);
-              TagGenericResult tagResult = fn->tagIfGeneric(NULL, true);
-              if (tagResult == TGR_TAGGING_ABORTED ||
-                  (tagResult == TGR_NEWLY_TAGGED && fn->isGeneric()))
-                continue;
-              if (isSubtypeOrInstantiation(fn->getFormal(1)->type,
-                                          testType,
-                                          call)) {
-                // TODO: Replace me with a function pointer.
-                auto capture = new CallExpr(PRIM_CAPTURE_FN_TO_CLASS,
-                                            new SymExpr(fn));
-                fn->defPoint->getStmtExpr()->insertAfter(capture);
-                Expr* val = resolveExpr(capture);
-                testCaptureVector.push_back(val);
-                val->remove();
-                testNameIndex[name] = ++totalTest;
+        if (ModuleSymbol *mod = fn->getModule()) {
+          if (mod->modTag == MOD_USER) {
+            if (fn->numFormals() == 1) {
+              if (fn->instantiatedFrom == NULL && ! fn->isKnownToBeGeneric()) {
+                const char* name = astr(fn->name);
+                resolveSignature(fn);
+                TagGenericResult tagResult = fn->tagIfGeneric(NULL, true);
+                if (tagResult == TGR_TAGGING_ABORTED ||
+                    (tagResult == TGR_NEWLY_TAGGED && fn->isGeneric()))
+                  continue;
+                if (isSubtypeOrInstantiation(fn->getFormal(1)->type,
+                                            testType,
+                                            call)) {
+                  // TODO: Replace me with a function pointer.
+                  auto capture = new CallExpr(PRIM_CAPTURE_FN_TO_CLASS,
+                                              new SymExpr(fn));
+                  fn->defPoint->getStmtExpr()->insertAfter(capture);
+                  Expr* val = resolveExpr(capture);
+                  testCaptureVector.push_back(val);
+                  val->remove();
+                  testNameIndex[name] = ++totalTest;
+                }
               }
             }
           }


### PR DESCRIPTION
This PR fixes a compilation error when using the `UnitTest` package with certain code structures and resolves https://github.com/Cray/chapel-private/issues/2300.

The issue stems from reading through `gFnSymbols` and assuming that each function that throws would have a module associated. In the case that a symbol has been pruned from the ast, it will not have a module, the compiler would try to read the empty `mod` variable and crash. 

[reviewed by @dlongnecke-cray - thanks!]

TESTING:

- [X] paratest `[Summary: #Successes = 17088 | #Failures = 0 | #Futures = 920]`
- [x] paratest gasnet `[Summary: #Successes = 17272 | #Failures = 0 | #Futures = 929]`
- [x] paratest C-backend `[Summary: #Successes = 16983 | #Failures = 1 | #Futures = 895]`
```
[Error matching program output for chplenv/chplconfig/warnings/warnings]
```
(same C-backend failure on main)