### PR TITLE
update `c_string` to be `c_ptrConst(c_char)`

### DIFF
--- a/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
@@ -6,7 +6,7 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = "fake":chpl_c_string;
+  var filename = "fake":c_ptrConst(c_char);;
   chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }

--- a/test/interop/fortran/fortArrayToDRAutomatic/chapelProcs.chpl
+++ b/test/interop/fortran/fortArrayToDRAutomatic/chapelProcs.chpl
@@ -3,7 +3,7 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = "fake":chpl_c_string;
+  var filename = "fake":c_ptrConst(c_char);
   chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
@@ -3,7 +3,7 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = "fake":chpl_c_string;
+  var filename = "fake":c_ptrConst(c_char);
   chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }

--- a/test/interop/fortran/genFortranInterface/chapelProcs.chpl
+++ b/test/interop/fortran/genFortranInterface/chapelProcs.chpl
@@ -6,7 +6,7 @@ export proc chpl_library_init_ftn() {
 use CTypes;
 
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-  var filename = "fake":chpl_c_string;
+  var filename = "fake":c_ptrConst(c_char);
   chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
   chpl__init_chapelProcs();
 }


### PR DESCRIPTION
This PR updates Fortran interop tests to use the replacement for `c_string`, `c_ptrConst(c_char)`. This change was made possible due to (PR https://github.com/chapel-lang/chapel/pull/23143), which modified the generation of signatures for libraries to treat `c_ptrConst(c_char)` similar to how `c_string` used to work. This resolves a TODO to change the type in the tests, leftover from https://github.com/chapel-lang/chapel/pull/22943.

TESTING:

- [x] paratest `[Summary: #Successes = 16939 | #Failures = 0 | #Futures = 918]`
- [x] paratest w/gasnet `[Summary: #Successes = 17149 | #Failures = 0 | #Futures = 928]`
- [x] paratest w/C backend `[Summary: #Successes = 16866 | #Failures = 9 | #Futures = 894]`
```
[Error matching program output for library/packages/Socket/connectblocking]
[Error matching program output for library/packages/Socket/connecttimeout]
[Error matching program output for library/packages/Socket/ipaddr]
[Error matching program output for library/packages/Socket/ipfamily]
[Error matching program output for library/packages/Socket/listen]
[Error matching program output for library/packages/Socket/networkoptimization]
[Error matching program output for library/packages/Socket/sockaddr]
[Error matching program output for library/packages/Socket/tcpio]
[Error matching program output for library/packages/Socket/udpio_ipv4]
```
failures w/C-backend are same as on `main`

[change to tests only - not reviewed]