### PR TITLE
Remplace 'complete' with 'init this' in a straggler

### DIFF
--- a/test/functions/vass/ref-intent-bug-2big.chpl
+++ b/test/functions/vass/ref-intent-bug-2big.chpl
@@ -120,7 +120,7 @@ proc GlobalData.init(nameArg: string) {
     datElm = dat;
   }
   this.datas = datasTemp!;
-  this.complete();
+  init this;
 
   /// get and store pointers to neighbor data slices ///
   forall ((ix,iy), dat, inf) in zip(gridDist, datas, WI.infos) {


### PR DESCRIPTION
I missed this straggler because my automatic process did not catch it, and because the test that triggers the bug is skipped under `comm == none`.

Trivial, will not be reviewed.