### PR TITLE
Fix memleaks testing warnings for with `--warn-unstable`

### DIFF
--- a/test/statements/manage/WarnUnstable.skipif
+++ b/test/statements/manage/WarnUnstable.skipif
@@ -1,0 +1,3 @@
+# because we already explicitly throw memleaks, we'll get duplicate warnings
+# due to the flag being unstable
+EXECOPTS <= memLeaks

--- a/test/unstable/unstableConfigs.execopts
+++ b/test/unstable/unstableConfigs.execopts
@@ -2,5 +2,4 @@
 --myUnstableConfig=12 --myUserConfig=1 #unstableConfigs.good
 --printModuleInitOrder=false #unstableConfigs.initorder.good
 --dataParTasksPerLocale=2 --dataParIgnoreRunningTasks=false --dataParMinGranularity=10 #unstableConfigs.datapar.good
---memTrack=true --memStats=true --memLeaksByType=true --memLeaks=true --memMax=0 --memThreshold=0 --memLog="log" --memLeaksLog="leaklog" --memLeaksByDesc=" " #unstableConfigs.mem.good
 --debugGpu=true --gpuNoCpuModeWarning=true --enableGpuP2P=true #unstableConfigs.gpu.good

--- a/test/unstable/unstableConfigs.mem.chpl
+++ b/test/unstable/unstableConfigs.mem.chpl
@@ -1,0 +1,12 @@
+config var myUserConfig = 0;
+
+@unstable("Hey it's unstable!")
+config var myUnstableConfig = 0;
+
+
+config param myUserParam = 0;
+
+
+writeln(myUserConfig);
+writeln(myUnstableConfig);
+writeln(myUserParam);

--- a/test/unstable/unstableConfigs.mem.execopts
+++ b/test/unstable/unstableConfigs.mem.execopts
@@ -1,0 +1,1 @@
+--memTrack=true --memStats=true --memLeaksByType=true --memLeaks=true --memMax=0 --memThreshold=0 --memLog="log" --memLeaksLog="leaklog" --memLeaksByDesc=" "

--- a/test/unstable/unstableConfigs.mem.good
+++ b/test/unstable/unstableConfigs.mem.good
@@ -1,4 +1,4 @@
-unstableConfigs.chpl:XX: warning: Hey it's unstable!
+unstableConfigs.mem.chpl:11: warning: Hey it's unstable!
 0
 0
 0

--- a/test/unstable/unstableConfigs.mem.skipif
+++ b/test/unstable/unstableConfigs.mem.skipif
@@ -1,0 +1,3 @@
+# because we already explicitly throw memleaks, we'll get duplicate warnings
+# due to the flag being unstable
+EXECOPTS <= memLeaks

--- a/util/cron/common-memleaks.bash
+++ b/util/cron/common-memleaks.bash
@@ -3,6 +3,7 @@
 # Configure environment for memory leaks testing. This should be sourced by
 # other scripts that wish to make use of the variables set here.
 
+export CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-unstable-memleaks
 export CHPL_NIGHTLY_MEMLEAKS_DIR=${CHPL_NIGHTLY_MEMLEAKS_DIR:-$PERF_LOGDIR_PREFIX/NightlyMemLeaks}
 export MEM_LEAKS_DATE_VAL=$(date '+%Y-%m-%d')
 

--- a/util/test/prediff-for-unstable-memleaks
+++ b/util/test/prediff-for-unstable-memleaks
@@ -9,28 +9,12 @@ import sys
 testname = sys.argv[1]
 outfile = sys.argv[2]
 
-# note: assumes that no `--warn-unstable` test that intentionally throws
-# `--memLeaks` has an unusually-named `.good` file
-goodfile = testname+'.good'
-
 memleaksWarn = "warning: The variable 'memLeaks' is unstable and its interface is subject to change in the future"
 
-foundInGood = False
+with open(outfile, 'r', newline='') as outR:
+     myLines = outR.readlines()
 
-try:
-  with open(goodfile, 'r') as gf:
-     for line in gf.readlines():
-         if line.find(memleaksWarn) != -1:
-            foundInGood = True
-except FileNotFoundError:
-  print("Oops, " + goodfile + " did not exist.  Won't adjust for expected warnings")
-
-# If the .good file we checked already has this message, don't remove it
-if not foundInGood:
-   with open(outfile, 'r', newline='') as outR:
-      myLines = outR.readlines()
-
-   with open(outfile, 'w', newline='') as overwrite:
-        for line in myLines:
-            if line.find(memleaksWarn) == -1:
-               overwrite.write(line)
+with open(outfile, 'w', newline='') as overwrite:
+     for line in myLines:
+         if line.find(memleaksWarn) == -1:
+            overwrite.write(line)

--- a/util/test/prediff-for-unstable-memleaks
+++ b/util/test/prediff-for-unstable-memleaks
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# want to eliminate the message
+# `<command-line arg>:n: warning: The variable 'memLeaks' is unstable and its interface is subject to change in the future`
+# from tests that don't normally provide it when in the general memleaks config
+
+import sys
+
+testname = sys.argv[1]
+outfile = sys.argv[2]
+
+# note: assumes that no `--warn-unstable` test that intentionally throws
+# `--memLeaks` has an unusually-named `.good` file
+goodfile = testname+'.good'
+
+memleaksWarn = "warning: The variable 'memLeaks' is unstable and its interface is subject to change in the future"
+
+foundInGood = False
+
+with open(goodfile, 'r') as gf:
+     for line in gf.readlines():
+         if line.find(memleaksWarn) != -1:
+            foundInGood = True
+
+# If the .good file we checked already has this message, don't remove it
+if not foundInGood:
+   with open(outfile, 'r') as outR:
+      myLines = outR.readlines()
+
+   with open(outfile, 'w') as overwrite:
+        for line in myLines:
+            if line.find(memleaksWarn) == -1:
+               overwrite.write(line)

--- a/util/test/prediff-for-unstable-memleaks
+++ b/util/test/prediff-for-unstable-memleaks
@@ -17,10 +17,13 @@ memleaksWarn = "warning: The variable 'memLeaks' is unstable and its interface i
 
 foundInGood = False
 
-with open(goodfile, 'r') as gf:
+try:
+  with open(goodfile, 'r') as gf:
      for line in gf.readlines():
          if line.find(memleaksWarn) != -1:
             foundInGood = True
+except FileNotFoundError:
+  print("Oops, " + goodfile + " did not exist.  Won't adjust for expected warnings")
 
 # If the .good file we checked already has this message, don't remove it
 if not foundInGood:

--- a/util/test/prediff-for-unstable-memleaks
+++ b/util/test/prediff-for-unstable-memleaks
@@ -27,10 +27,10 @@ except FileNotFoundError:
 
 # If the .good file we checked already has this message, don't remove it
 if not foundInGood:
-   with open(outfile, 'r') as outR:
+   with open(outfile, 'r', newline='') as outR:
       myLines = outR.readlines()
 
-   with open(outfile, 'w') as overwrite:
+   with open(outfile, 'w', newline='') as overwrite:
         for line in myLines:
             if line.find(memleaksWarn) == -1:
                overwrite.write(line)


### PR DESCRIPTION
Because the `--memLeaks` flag is unstable, when we use it in our
nightly memleaks job on tests that use the `--warn-unstable` flag,
extra output is generated.  Fix that

<details>

To fix that, add a prediff script that will be used for the
single locale and multilocale memleaks jobs.  This script will
explicitly remove the memLeaks warning from from tests that
encounter it.

</details>

There are two tests that intentionally throw both of these flags
together normally.  Unfortunately, that means that they would
generate an extra error, which would cause them to fail.  So,
skip them when the flag is thrown generally (which is fine,
because what it would otherwise be testing is already handled
in the default nightly setting, as a result of those flags being
always provided to those tests) - this involved splitting the
memLeaks config test away from the other config tests.

Passed full memleaks testing with futures (aside from some
tests that don't run in nightly memleaks testing), when the
environment variable that nightly will use is set.

- [x] The .good file check is not actually use, as every time it would be included, we would get extra instances of the warning.  Remove it to simplify the script