### PR TITLE
Move communication library link args last amongst our main third-party pkgs

### DIFF
--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -147,19 +147,6 @@ def compute_internal_compile_link_args(runtime_subdir):
     extend2(tgt_compile, chpl_hwloc.get_compile_args())
     extend2(tgt_link, chpl_hwloc.get_link_args())
 
-    if chpl_comm.get() == 'ofi':
-        extend2(tgt_compile, chpl_libfabric.get_compile_args())
-        extend2(tgt_link, chpl_libfabric.get_link_args())
-    elif chpl_comm.get() == 'gasnet':
-        extend2(tgt_compile, chpl_gasnet.get_compile_args())
-        extend2(tgt_link, chpl_gasnet.get_link_args())
-    elif chpl_comm.get() == 'ugni':
-        # If there isn't a hugepage module loaded, we need to request
-        # libhugetlbfs ourselves.
-        pe_product_list = os.environ.get('PE_PRODUCT_LIST', None)
-        if pe_product_list and 'HUGETLB' in pe_product_list:
-            tgt_link[1].append('-lhugetlbfs')
-
     if chpl_tasks.get() == 'qthreads':
         extend2(tgt_compile, chpl_qthreads.get_compile_args())
         extend2(tgt_link, chpl_qthreads.get_link_args())
@@ -176,6 +163,19 @@ def compute_internal_compile_link_args(runtime_subdir):
     if chpl_re2.get() != 'none':
         extend2(tgt_compile, chpl_re2.get_compile_args())
         extend2(tgt_link, chpl_re2.get_link_args())
+
+    if chpl_comm.get() == 'ofi':
+        extend2(tgt_compile, chpl_libfabric.get_compile_args())
+        extend2(tgt_link, chpl_libfabric.get_link_args())
+    elif chpl_comm.get() == 'gasnet':
+        extend2(tgt_compile, chpl_gasnet.get_compile_args())
+        extend2(tgt_link, chpl_gasnet.get_link_args())
+    elif chpl_comm.get() == 'ugni':
+        # If there isn't a hugepage module loaded, we need to request
+        # libhugetlbfs ourselves.
+        pe_product_list = os.environ.get('PE_PRODUCT_LIST', None)
+        if pe_product_list and 'HUGETLB' in pe_product_list:
+            tgt_link[1].append('-lhugetlbfs')
 
     aux_filesys = chpl_aux_filesys.get()
     if 'lustre' in aux_filesys:

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -164,6 +164,12 @@ def compute_internal_compile_link_args(runtime_subdir):
         extend2(tgt_compile, chpl_re2.get_compile_args())
         extend2(tgt_link, chpl_re2.get_link_args())
 
+    # The following communication-oriented options have been moved to
+    # the end of this sequence of third-party package options because
+    # GASNet can involve system library paths which we want to come
+    # after all of our bundled/local arguments to avoid conflicts.
+    # See issue #23362 for a potential way to do this in a more
+    # principled way going forward.
     if chpl_comm.get() == 'ofi':
         extend2(tgt_compile, chpl_libfabric.get_compile_args())
         extend2(tgt_link, chpl_libfabric.get_link_args())


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/issues/23282, @razoumov reported that with recent releases he's been having an issue in which a system jemalloc library superceded the one we built due to the ordering of -L flags in our generated code.  Specifically, the order in his link line's -L paths goes something like:

* our general lib/ path
* the bundled GMP path
* the bundled hwloc path
* the bundled gasnet path
* other paths / libraries that we get from GASNet (I believe)
* our bundled qthread path
* our bundled jemalloc path
* our bundled re2 path

The problem is the "other paths ; libraries that we get from GASNet" step, which causes the system library path to precede other bundled library paths, notably the qthreads path.

This PR moves the order of any communication library link paths to the end of the list in order to attempt to move those GASNet-supplied system paths to the end of this list, and specifically after the qthreads step which is causing the problem here.

Notes / Alternatives:

* we could instead just move the GASNet paths to the end of the list since it's the case we're aware of that causes problems, but I liked keeping all the comm libraries together

* we could instead just move jemalloc up in the list, but that seems like it might just potentially cause the problem to happen with other libraries down the road

* nothing about this solves the problem that, in general, other third-party libraries we bundle might add additional paths. However, it doesn't seem like the others do currently (that I'm aware of), and detangling those is a pretty major effort, so I'm not inclined to do it without need.

Resolves #23282 (I think/hope)