### PR TITLE
Fix the string literal locations reported by the parser.

### DIFF
--- a/frontend/include/chpl/parsing/parser-error-classes-list.h
+++ b/frontend/include/chpl/parsing/parser-error-classes-list.h
@@ -40,7 +40,7 @@ PARSER_ERROR_CLASS(BisonUnknownError, std::string, std::string)
 // other parser errors
 PARSER_SYNTAX_CLASS(CannotAttachPragmas, const uast::AstNode*)
 PARSER_SYNTAX_CLASS(CommentEOF, Location, Location)
-PARSER_SYNTAX_CLASS(ExceptOnlyInvalidExpr, uast::VisibilityClause::LimitationKind)
+PARSER_SYNTAX_CLASS(ExceptOnlyInvalidExpr, Location, uast::VisibilityClause::LimitationKind)
 PARSER_SYNTAX_CLASS(ExternUnclosedPair, std::string)
 PARSER_SYNTAX_CLASS(InvalidIndexExpr)
 PARSER_SYNTAX_CLASS(InvalidNewForm, const uast::AstNode*)

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -2201,8 +2201,9 @@ buildVisibilityClause(YYLTYPE location, owned<AstNode> symbol,
     if (limitationKind == VisibilityClause::LimitationKind::EXCEPT ||
         limitationKind == VisibilityClause::LimitationKind::ONLY) {
       if (!asExpr) {
+        auto limitationLoc = builder->getLocation(expr.get());
         error = CHPL_PARSER_REPORT(this, ExceptOnlyInvalidExpr, location,
-                                   limitationKind);
+                                   limitationLoc, limitationKind);
       }
     } else if (limitationKind == VisibilityClause::LimitationKind::BRACES) {
       CHPL_ASSERT(isImport && "braces should only be used with import statements");

--- a/frontend/lib/parsing/lexer-help.h
+++ b/frontend/lib/parsing/lexer-help.h
@@ -125,21 +125,23 @@ static int processToken(yyscan_t scanner, int t) {
 
 static std::string eatStringLiteral(yyscan_t scanner,
                                     const char* startChar,
+                                    int nColOffset,
                                     bool& isErroneousOut);
 static std::string eatTripleStringLiteral(yyscan_t scanner,
                                           const char* startChar,
+                                          int nColOffset,
                                           bool& isErroneousOut);
 
 static int processStringLiteral(yyscan_t scanner,
                                 const char* startChar,
                                 int type) {
-  // update the location for the string start (e.g. b" )
+  // figure out the location offset for the string start (e.g. b" )
   const char* pch = yyget_text(scanner);
+  int nColOffset = (int) strlen(pch);
   YYLTYPE* loc = yyget_lloc(scanner);
-  updateLocation(loc, 0, strlen(pch));
 
   bool erroneous = false;
-  std::string value = eatStringLiteral(scanner, startChar, erroneous);
+  std::string value = eatStringLiteral(scanner, startChar, nColOffset, erroneous);
 
   ParserContext* context = yyget_extra(scanner);
   if (context->parseStats)
@@ -181,13 +183,13 @@ static int processStringLiteral(yyscan_t scanner,
 static int processTripleStringLiteral(yyscan_t scanner,
                                       const char* startChar,
                                       int type) {
-  // update the location for the string start (e.g. b" )
+  // figure out the location offset for the string start (e.g. b" )
   const char* pch = yyget_text(scanner);
+  int nColOffset = (int) strlen(pch);
   YYLTYPE* loc = yyget_lloc(scanner);
-  updateLocation(loc, 0, strlen(pch));
 
   bool erroneous = false;
-  std::string value = eatTripleStringLiteral(scanner, startChar, erroneous);
+  std::string value = eatTripleStringLiteral(scanner, startChar, nColOffset, erroneous);
 
   ParserContext* context = yyget_extra(scanner);
   if (context->parseStats)
@@ -265,12 +267,13 @@ static inline SizedStr makeSizedStr(const char* allocatedData, long size) {
 
 static std::string eatStringLiteral(yyscan_t scanner,
                                     const char* startChar,
+                                    int nColOffset,
                                     bool& isErroneousOut) {
   YYLTYPE* loc = yyget_lloc(scanner);
   const char startCh = *startChar;
   int        c       = 0;
   int nLines = 0;
-  int nCols = 0;
+  int nCols = nColOffset;
   std::string s;
 
   isErroneousOut = false;
@@ -386,13 +389,14 @@ static std::string eatStringLiteral(yyscan_t scanner,
 
 static std::string eatTripleStringLiteral(yyscan_t scanner,
                                           const char* startChar,
+                                          int nColOffset,
                                           bool& isErroneousOut) {
   YYLTYPE* loc       = yyget_lloc(scanner);
   const char startCh = *startChar;
   int startChCount   = 0;
   int c              = 0;
   int nLines = 0;
-  int nCols = 0;
+  int nCols = nColOffset;
   std::string s;
 
   isErroneousOut = false;

--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -101,12 +101,13 @@ void ErrorCommentEOF::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorExceptOnlyInvalidExpr::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
+  auto loc = std::get<0>(info);
+  auto limitLoc = std::get<1>(info);
   auto limitationKind = std::get<uast::VisibilityClause::LimitationKind>(info);
   wr.heading(kind_, type_, loc, "incorrect expression in '", limitationKind,
              "' list, identifier expected.");
   wr.message("In the '", limitationKind, "' list here:");
-  wr.code(loc);
+  wr.code<Location>(loc, { limitLoc });
 }
 
 void ErrorExternUnclosedPair::write(ErrorWriterBase& wr) const {

--- a/test/errors/parsing/stringLiteralLocations.1.good
+++ b/test/errors/parsing/stringLiteralLocations.1.good
@@ -1,0 +1,4 @@
+stringLiteralLocations.chpl:4: syntax error: incorrect expression in 'except' list, identifier expected
+stringLiteralLocations.chpl:5: syntax error: incorrect expression in 'except' list, identifier expected
+stringLiteralLocations.chpl:6: syntax error: incorrect expression in 'except' list, identifier expected
+stringLiteralLocations.chpl:7: syntax error: incorrect expression in 'except' list, identifier expected

--- a/test/errors/parsing/stringLiteralLocations.2.good
+++ b/test/errors/parsing/stringLiteralLocations.2.good
@@ -1,0 +1,32 @@
+─── syntax in stringLiteralLocations.chpl:4 [ExceptOnlyInvalidExpr] ───
+  Incorrect expression in 'except' list, identifier expected.
+  In the 'except' list here:
+      |
+    4 | use IO except "hello";
+      |               ⎺⎺⎺⎺⎺⎺⎺
+      |
+
+─── syntax in stringLiteralLocations.chpl:5 [ExceptOnlyInvalidExpr] ───
+  Incorrect expression in 'except' list, identifier expected.
+  In the 'except' list here:
+      |
+    5 | use IO except b"hello";
+      |               ⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+
+─── syntax in stringLiteralLocations.chpl:6 [ExceptOnlyInvalidExpr] ───
+  Incorrect expression in 'except' list, identifier expected.
+  In the 'except' list here:
+      |
+    6 | use IO except """hello""";
+      |               ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+
+─── syntax in stringLiteralLocations.chpl:7 [ExceptOnlyInvalidExpr] ───
+  Incorrect expression in 'except' list, identifier expected.
+  In the 'except' list here:
+      |
+    7 | use IO except b"""hello""";
+      |               ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |
+

--- a/test/errors/parsing/stringLiteralLocations.chpl
+++ b/test/errors/parsing/stringLiteralLocations.chpl
@@ -1,0 +1,7 @@
+// The easiest way to get Dyno to print string literals is to cause an error,
+// in this case by trying to use a string literal in an 'except' clause.
+
+use IO except "hello";
+use IO except b"hello";
+use IO except """hello""";
+use IO except b"""hello""";

--- a/test/parsing/errors/exceptOnlyInvalidExpr-detailed.good
+++ b/test/parsing/errors/exceptOnlyInvalidExpr-detailed.good
@@ -3,5 +3,6 @@
   In the 'except' list here:
       |
     1 | use OS except "not a symbol";
+      |               ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
       |
 

--- a/test/unstable-keyword/deprecated/1.30/noParens-detailed.good
+++ b/test/unstable-keyword/deprecated/1.30/noParens-detailed.good
@@ -3,6 +3,6 @@
   For this attribute:
       |
     1 | @unstable "foo is unstable and may change"
-      |            ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+      |           ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
       |
 


### PR DESCRIPTION
This PR fixes https://github.com/chapel-lang/chapel/issues/20747, in which a string literal's location doesn't include its left quote, but does include its right quote. Example copied fron the issue:

```
--- error in bad.chpl:2 ---
Branches of if-expression have incompatible types.
In the following if-expression:
    |
  2 | var x = if b then """hello""" else 1;
    |                      ────────      ─
    |
the first branch is a param of type 'string', while the second is a param of type 'int(64)'
```

The problem was that we were advancing the (Flex) string location before starting to process the string literal. The proper way is to compute the offset, and then advance the location once, by an amount that includes both the left and right quotes (and the stuff between them).

On the tip of this branch, I get errors that look like this:

<img width="565" alt="Screen Shot 2023-09-11 at 4 22 43 PM" src="https://github.com/chapel-lang/chapel/assets/4361282/98236443-5db9-4b0a-954c-561a574c9bb8">

Reviewed by @mppf -- thanks!


## Testing
- [x] paratest