### PR TITLE
Reenable graph syncing for XC Arkouda tests

### DIFF
--- a/util/cron/test-cray-xc-arkouda.bash
+++ b/util/cron/test-cray-xc-arkouda.bash
@@ -29,3 +29,4 @@ export CHPL_LAUNCHER=slurm-srun
 nightly_args="${nightly_args} -no-buildcheck"
 
 test_nightly
+sync_graphs

--- a/util/cron/test-cray-xc-arkouda.release.bash
+++ b/util/cron/test-cray-xc-arkouda.release.bash
@@ -29,3 +29,4 @@ export CHPL_LAUNCHER=slurm-srun
 nightly_args="${nightly_args} -no-buildcheck"
 
 test_release
+sync_graphs


### PR DESCRIPTION
Arkouda XC tests are running the performance tests and saving the data, but not syncing the graphs, so reverting to the old syncing to see if that works with the new syncing technique that is being used.