### PR TITLE
Adjust gcd implementation and add overloads to return different sized ints/uints

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -2691,11 +2691,11 @@ module AutoMath {
   pragma "last resort"
   @deprecated(notes="In an upcoming release 'gcd' will no longer be included by default, please 'use' or 'import' the :mod:`Math` module to call it")
   proc gcd(in a: int,in b: int): int {
+    (a, b) = (abs(a), abs(b));
     return chpl_gcd(a, b);
   }
 
-  proc chpl_gcd(in a: int,in b: int): int {
-    (a, b) = (abs(a), abs(b));
+  proc chpl_gcd(in a,in b) {
     while(b != 0) {
       (a, b) = (b, a % b);
     }

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -2695,14 +2695,10 @@ module AutoMath {
   }
 
   proc chpl_gcd(in a: int,in b: int): int {
-     a = abs(a);
-     b = abs(b);
-     var r: int;
-     while(b != 0) {
-       r = a % b;
-       a = b;
-       b = r;
-     }
+    (a, b) = (abs(a), abs(b));
+    while(b != 0) {
+      (a, b) = (b, a % b);
+    }
     return a;
   }
 

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -1045,6 +1045,7 @@ module Math {
   /* Returns the greatest common divisor of the integer arguments `x` and
      `y`. */
   proc gcd(in x: int,in y: int): int {
+    (x, y) = (abs(x), abs(y));
     return chpl_gcd(x, y);
   }
 
@@ -1052,66 +1053,45 @@ module Math {
      `y`. */
   proc gcd(in x: int(32),in y: int(32)): int(32) {
     (x, y) = (abs(x), abs(y));
-    while(y != 0) {
-      (x, y) = (y, x % y);
-    }
-    return x;
+    return chpl_gcd(x, y);
   }
 
   /* Returns the greatest common divisor of the integer arguments `x` and
      `y`. */
   proc gcd(in x: int(16),in y: int(16)): int(16) {
     (x, y) = (abs(x), abs(y));
-    while(y != 0) {
-      (x, y) = (y, x % y);
-    }
-    return x;
+    return chpl_gcd(x, y);
   }
 
   /* Returns the greatest common divisor of the integer arguments `x` and
      `y`. */
   proc gcd(in x: int(8),in y: int(8)): int(8) {
     (x, y) = (abs(x), abs(y));
-    while(y != 0) {
-      (x, y) = (y, x % y);
-    }
-    return x;
+    return chpl_gcd(x, y);
   }
 
   /* Returns the greatest common divisor of the unsigned integer arguments `x`
      and `y`. */
   proc gcd(in x: uint(64),in y: uint(64)): uint(64) {
-    while(y != 0) {
-      (x, y) = (y, x % y);
-    }
-    return x;
+    return chpl_gcd(x, y);
   }
 
   /* Returns the greatest common divisor of the unsigned integer arguments `x`
      and `y`. */
   proc gcd(in x: uint(32),in y: uint(32)): uint(32) {
-    while(y != 0) {
-      (x, y) = (y, x % y);
-    }
-    return x;
+    return chpl_gcd(x, y);
   }
 
   /* Returns the greatest common divisor of the unsigned integer arguments `x`
      and `y`. */
   proc gcd(in x: uint(16),in y: uint(16)): uint(16) {
-    while(y != 0) {
-      (x, y) = (y, x % y);
-    }
-    return x;
+    return chpl_gcd(x, y);
   }
 
   /* Returns the greatest common divisor of the unsigned integer arguments `x`
      and `y`. */
   proc gcd(in x: uint(8),in y: uint(8)): uint(8) {
-    while(y != 0) {
-      (x, y) = (y, x % y);
-    }
-    return x;
+    return chpl_gcd(x, y);
   }
 
   /* Returns the Bessel function of the first kind of order `0` of `x`. */

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -1048,6 +1048,72 @@ module Math {
     return chpl_gcd(x, y);
   }
 
+  /* Returns the greatest common divisor of the integer arguments `x` and
+     `y`. */
+  proc gcd(in x: int(32),in y: int(32)): int(32) {
+    (x, y) = (abs(x), abs(y));
+    while(y != 0) {
+      (x, y) = (y, x % y);
+    }
+    return x;
+  }
+
+  /* Returns the greatest common divisor of the integer arguments `x` and
+     `y`. */
+  proc gcd(in x: int(16),in y: int(16)): int(16) {
+    (x, y) = (abs(x), abs(y));
+    while(y != 0) {
+      (x, y) = (y, x % y);
+    }
+    return x;
+  }
+
+  /* Returns the greatest common divisor of the integer arguments `x` and
+     `y`. */
+  proc gcd(in x: int(8),in y: int(8)): int(8) {
+    (x, y) = (abs(x), abs(y));
+    while(y != 0) {
+      (x, y) = (y, x % y);
+    }
+    return x;
+  }
+
+  /* Returns the greatest common divisor of the unsigned integer arguments `x`
+     and `y`. */
+  proc gcd(in x: uint(64),in y: uint(64)): uint(64) {
+    while(y != 0) {
+      (x, y) = (y, x % y);
+    }
+    return x;
+  }
+
+  /* Returns the greatest common divisor of the unsigned integer arguments `x`
+     and `y`. */
+  proc gcd(in x: uint(32),in y: uint(32)): uint(32) {
+    while(y != 0) {
+      (x, y) = (y, x % y);
+    }
+    return x;
+  }
+
+  /* Returns the greatest common divisor of the unsigned integer arguments `x`
+     and `y`. */
+  proc gcd(in x: uint(16),in y: uint(16)): uint(16) {
+    while(y != 0) {
+      (x, y) = (y, x % y);
+    }
+    return x;
+  }
+
+  /* Returns the greatest common divisor of the unsigned integer arguments `x`
+     and `y`. */
+  proc gcd(in x: uint(8),in y: uint(8)): uint(8) {
+    while(y != 0) {
+      (x, y) = (y, x % y);
+    }
+    return x;
+  }
+
   /* Returns the Bessel function of the first kind of order `0` of `x`. */
   @unstable("'j0' is unstable and may be renamed or moved to a different module in the future")
   inline proc j0(x: real(32)): real(32) {

--- a/test/library/standard/Math/testcases_gcd.chpl
+++ b/test/library/standard/Math/testcases_gcd.chpl
@@ -17,3 +17,143 @@ writeln(gcd(0,8));
 writeln(gcd(4,0));
 
 writeln(gcd(0,0));
+
+writeln(gcd(2,8).type : string);
+
+writeln("int(32) tests");
+
+writeln(gcd(4: int(32), 8: int(32)));
+
+writeln(gcd(2: int(32), 8: int(32)));
+
+writeln(gcd(3: int(32), 8: int(32)));
+
+writeln(gcd(5: int(32), 11: int(32)));
+
+writeln(gcd(4: int(32), -8: int(32)));
+
+writeln(gcd(-4: int(32), -8: int(32)));
+
+writeln(gcd(0: int(32), 8: int(32)));
+
+writeln(gcd(4: int(32), 0: int(32)));
+
+writeln(gcd(0: int(32), 0: int(32)));
+
+writeln(gcd(2: int(32), 8: int(32)).type : string);
+
+writeln("int(16) tests");
+
+writeln(gcd(4: int(16), 8: int(16)));
+
+writeln(gcd(2: int(16), 8: int(16)));
+
+writeln(gcd(3: int(16), 8: int(16)));
+
+writeln(gcd(5: int(16), 11: int(16)));
+
+writeln(gcd(4: int(16), -8: int(16)));
+
+writeln(gcd(-4: int(16), -8: int(16)));
+
+writeln(gcd(0: int(16), 8: int(16)));
+
+writeln(gcd(4: int(16), 0: int(16)));
+
+writeln(gcd(0: int(16), 0: int(16)));
+
+writeln(gcd(2: int(16), 8: int(16)).type : string);
+
+writeln("int(8) tests");
+
+writeln(gcd(4: int(8), 8: int(8)));
+
+writeln(gcd(2: int(8), 8: int(8)));
+
+writeln(gcd(3: int(8), 8: int(8)));
+
+writeln(gcd(5: int(8), 11: int(8)));
+
+writeln(gcd(4: int(8), -8: int(8)));
+
+writeln(gcd(-4: int(8), -8: int(8)));
+
+writeln(gcd(0: int(8), 8: int(8)));
+
+writeln(gcd(4: int(8), 0: int(8)));
+
+writeln(gcd(0: int(8), 0: int(8)));
+
+writeln(gcd(2: int(8), 8: int(8)).type : string);
+
+writeln("uint(64) tests");
+
+writeln(gcd(4: uint(64), 8: uint(64)));
+
+writeln(gcd(2: uint(64), 8: uint(64)));
+
+writeln(gcd(3: uint(64), 8: uint(64)));
+
+writeln(gcd(5: uint(64), 11: uint(64)));
+
+writeln(gcd(0: uint(64), 8: uint(64)));
+
+writeln(gcd(4: uint(64), 0: uint(64)));
+
+writeln(gcd(0: uint(64), 0: uint(64)));
+
+writeln(gcd(2: uint(64), 8: uint(64)).type : string);
+
+writeln("uint(32) tests");
+
+writeln(gcd(4: uint(32), 8: uint(32)));
+
+writeln(gcd(2: uint(32), 8: uint(32)));
+
+writeln(gcd(3: uint(32), 8: uint(32)));
+
+writeln(gcd(5: uint(32), 11: uint(32)));
+
+writeln(gcd(0: uint(32), 8: uint(32)));
+
+writeln(gcd(4: uint(32), 0: uint(32)));
+
+writeln(gcd(0: uint(32), 0: uint(32)));
+
+writeln(gcd(2: uint(32), 8: uint(32)).type : string);
+
+writeln("uint(16) tests");
+
+writeln(gcd(4: uint(16), 8: uint(16)));
+
+writeln(gcd(2: uint(16), 8: uint(16)));
+
+writeln(gcd(3: uint(16), 8: uint(16)));
+
+writeln(gcd(5: uint(16), 11: uint(16)));
+
+writeln(gcd(0: uint(16), 8: uint(16)));
+
+writeln(gcd(4: uint(16), 0: uint(16)));
+
+writeln(gcd(0: uint(16), 0: uint(16)));
+
+writeln(gcd(2: uint(16), 8: uint(16)).type : string);
+
+writeln("uint(8) tests");
+
+writeln(gcd(4: uint(8), 8: uint(8)));
+
+writeln(gcd(2: uint(8), 8: uint(8)));
+
+writeln(gcd(3: uint(8), 8: uint(8)));
+
+writeln(gcd(5: uint(8), 11: uint(8)));
+
+writeln(gcd(0: uint(8), 8: uint(8)));
+
+writeln(gcd(4: uint(8), 0: uint(8)));
+
+writeln(gcd(0: uint(8), 0: uint(8)));
+
+writeln(gcd(2: uint(8), 8: uint(8)).type : string);

--- a/test/library/standard/Math/testcases_gcd.good
+++ b/test/library/standard/Math/testcases_gcd.good
@@ -7,3 +7,73 @@
 8
 4
 0
+int(64)
+int(32) tests
+4
+2
+1
+1
+4
+4
+8
+4
+0
+int(32)
+int(16) tests
+4
+2
+1
+1
+4
+4
+8
+4
+0
+int(16)
+int(8) tests
+4
+2
+1
+1
+4
+4
+8
+4
+0
+int(8)
+uint(64) tests
+4
+2
+1
+1
+8
+4
+0
+uint(64)
+uint(32) tests
+4
+2
+1
+1
+8
+4
+0
+uint(32)
+uint(16) tests
+4
+2
+1
+1
+8
+4
+0
+uint(16)
+uint(8) tests
+4
+2
+1
+1
+8
+4
+0
+uint(8)


### PR DESCRIPTION
Resolves #20983

Damian requested a more generic and tighter version of gcd for 32 bit and 16 bit
integers.  While smaller sized ints could be sent to the original implementation
just fine because of coercion, it would always return the default-sized int.

Adjust the implementation for the default version to use his suggested code, and
add explicit overloads for `int(32)`, `int(16)`, `int(8)`, `uint(64)`,
`uint(32)`, `uint(16)`, and `uint(8)`.

Extends the gcd test for the new overloads.  Guarantees that the right type is
returned and that the answers are consistent in all versions.

Passed a full paratest with futures