### PR TITLE
Fix prediff for compiler-driver gdb invocation test

### DIFF
--- a/test/compflags/driver/debugger/declint.prediff
+++ b/test/compflags/driver/debugger/declint.prediff
@@ -8,14 +8,5 @@ set tmpfile = $outfile.raw.tmp
 # some gdbs print out extra stuff.  This filters it out
 #
 mv $outfile $tmpfile
-cat $tmpfile | grep -vE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's@(gdb) quit@(gdb) @' > $outfile
+cat $tmpfile | grep -vE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's/(gdb) quit/(gdb) /;s/(gdb) /(gdb) \n/' > $outfile
 rm $tmpfile
-
-#
-# some greps don't add a linefeed onto the end; others do
-# this ensures that a linefeed is added
-#
-set numlines = `wc -l $outfile`
-if ("$numlines" == "0 $outfile") then
-  echo >> $outfile
-endif

--- a/test/compflags/driver/debugger/declint.prediff
+++ b/test/compflags/driver/debugger/declint.prediff
@@ -7,8 +7,9 @@ set tmpfile = $outfile.raw.tmp
 #
 # some gdbs print out extra stuff.  This filters it out
 #
-# the sed command is due to the (gdb) prompt sometimes being followed by a
-# newline, sometimes not, before further program output
+# There is sometimes a newline between the (gdb) prompt and further program
+# output, sometimes not. The sed substitution adding a newline and the final
+# grep for non-empty lines ensures there is always exactly one.
 mv $outfile $tmpfile
-cat $tmpfile | grep -vE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's/(gdb) quit/(gdb) /;s/(gdb) /(gdb) \n/;/^$/d' > $outfile
+cat $tmpfile | grep -vE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's/(gdb) quit/(gdb) /;s/(gdb) /(gdb) \n/' | grep . > $outfile
 rm $tmpfile

--- a/test/compflags/driver/debugger/declint.prediff
+++ b/test/compflags/driver/debugger/declint.prediff
@@ -7,6 +7,8 @@ set tmpfile = $outfile.raw.tmp
 #
 # some gdbs print out extra stuff.  This filters it out
 #
+# the sed command is due to the (gdb) prompt sometimes being followed by a
+# newline, sometimes not, before further program output
 mv $outfile $tmpfile
-cat $tmpfile | grep -vE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's/(gdb) quit/(gdb) /;s/(gdb) /(gdb) \n/' > $outfile
+cat $tmpfile | grep -vE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's/(gdb) quit/(gdb) /;s/(gdb) /(gdb) \n/;/^$/d' > $outfile
 rm $tmpfile


### PR DESCRIPTION
Fix `test/compflags/driver/debugger/declint.prediff` which was not handling `gdb`'s version-dependent newline after prompt behavior.

This was copied in https://github.com/chapel-lang/chapel/pull/21063 from `test/compflags/bradc/gdbddash/declint.prediff`, which _does_ handle this behavior if the prompt is the last thing in program output. Since the driver version expects further output after the prompt, it needed adjustment to still work correctly across testing systems.

[trivial test fix, not reviewed]

Testing:
- [x] test passes on chapdl
- [x] test passes on chapcs (previously failed)