### PR TITLE
Readd XC testing CHPL_TEST_PERF_CONFIG_NAME

### DIFF
--- a/util/cron/test-cray-xc-arkouda.bash
+++ b/util/cron/test-cray-xc-arkouda.bash
@@ -2,6 +2,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
+export CHPL_TEST_PERF_CONFIG_NAME='16-node-xc'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-xc-arkouda"
 
 source $CWD/common.bash

--- a/util/cron/test-cray-xc-arkouda.release.bash
+++ b/util/cron/test-cray-xc-arkouda.release.bash
@@ -2,6 +2,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
+export CHPL_TEST_PERF_CONFIG_NAME='16-node-xc'
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="cray-xc-arkouda.release"
 
 source $CWD/common.bash


### PR DESCRIPTION
When the XC tests were reenabled, they were added just as correctness tests, not as performance tests, so the CHPL_TEST_PERF_CONFIG_NAME was removed. Now that we are running the XC configurations as performance tests again, we need to add that back in.