### PR TITLE
Patch bundled LLVM to support CUDA 12

### DIFF
--- a/third-party/llvm/llvm-src/tools/clang/lib/Headers/__clang_cuda_texture_intrinsics.h
+++ b/third-party/llvm/llvm-src/tools/clang/lib/Headers/__clang_cuda_texture_intrinsics.h
@@ -666,6 +666,7 @@ __device__ static void __tex_fetch(__T *__ptr, cudaTextureObject_t __handle,
       __tex_fetch_v4<__op>::template __run<__FetchT>(__handle, __args...));
 }
 
+#if CUDA_VERSION < 12000
 // texture<> objects get magically converted into a texture reference.  However,
 // there's no way to convert them to cudaTextureObject_t on C++ level. So, we
 // cheat a bit and use inline assembly to do it. It costs us an extra register
@@ -713,6 +714,7 @@ __tex_fetch(__DataT *, __RetT *__ptr,
       __tex_fetch_v4<__op>::template __run<__FetchT>(
           __tex_handle_to_obj(__handle), __args...));
 }
+#endif // CUDA_VERSION
 } // namespace __cuda_tex
 } // namespace
 #pragma pop_macro("__ASM_OUT")


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/5260
Better fix for now-closed https://github.com/chapel-lang/chapel/issues/22085

This PR pulls the patch in https://github.com/llvm/llvm-project/commit/817340569bf98b696329c53508a0d87cc0daec25 to our bundled LLVM. This enables CUDA 12 support.

Related PRs:
- https://github.com/chapel-lang/chapel/pull/23338 enables scripts to allow CUDA 12 with bundled LLVM
- https://github.com/chapel-lang/chapel/pull/23339 adds the nightly testing script

Test:
- [x] local make check with `CHPL_LLVM=bundled`
- [x] linux64 with `CHPL_LLVM=bundled`
- [x] CUDA 11 spot-check with `CHPL_LLVM=bundled`
- [x] CUDA 12 spot-check with `CHPL_LLVM=bundled`

