### PR TITLE
Add `c_string` deprecation and `c_fn_ptr` unstable to C Interop technote

### DIFF
--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -17,6 +17,8 @@ expected to change meaning in the future.
 version 1.32, September 2023
 ----------------------------
 
+.. _readme-evolution.c_string-deprecation:
+
 Version 1.32 deprecates the ``c_string`` type in user interfaces. Please
 replace occurrences of ``c_string`` with ``c_ptrConst(c_char)``. Note that you
 need to ``use`` or ``import`` the ``CTypes`` module to have access to

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -222,8 +222,9 @@ called on Chapel strings that are stored on the same locale; calling
 
 .. note::
 
-  ``c_string`` is deprecated in favor of ``c_ptrConst(c_char)``, which can be
-  used with corresponding functions such as ``c_ptrToConst``.
+  ``c_string`` is deprecated in favor of ``c_ptrConst(c_char)``. See
+  :ref:`c_string deprecation <readme-evolution.c_string-deprecation>` for more
+  information.
 
 c_fn_ptr
 ~~~~~~~~

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -212,6 +212,12 @@ Analogously, const ref may be used instead of c_ptrConst(T).
 c_string
 ~~~~~~~~
 
+.. warning::
+
+  ``c_string`` is deprecated in favor of ``c_ptrConst(c_char)``. See
+  :ref:`c_string deprecation <readme-evolution.c_string-deprecation>` for more
+  information.
+
 The c_string type maps to a constant C string (that is, const char*)
 that is intended for use locally. A c_string can be obtained from a
 Chapel string using the method :proc:`~String.string.c_str`. A Chapel string can be
@@ -220,14 +226,13 @@ because c_string is a local-only type, the .c_str() method can only be
 called on Chapel strings that are stored on the same locale; calling
 .c_str() on a non-local string will result in a runtime error.
 
-.. warning::
-
-  ``c_string`` is deprecated in favor of ``c_ptrConst(c_char)``. See
-  :ref:`c_string deprecation <readme-evolution.c_string-deprecation>` for more
-  information.
-
 c_fn_ptr
 ~~~~~~~~
+
+.. warning::
+
+  ``c_fn_ptr`` is unstable and expected to be replaced with more feature-rich
+  functionality in the future.
 
 The c_fn_ptr type is useful for representing arguments to external
 functions that accept function pointers.  At present, there is no way
@@ -251,11 +256,6 @@ that function and pass a Chapel function to it:
 Any calls that foo() makes through its function pointer argument will
 call back to Chapel's bar() routine.  Note that any Chapel functions
 passed as c_fn_ptr arguments cannot be overloaded nor generic.
-
-.. warning::
-
-  ``c_fn_ptr`` is unstable and expected to be replaced with more feature-rich
-  functionality in the future.
 
 .. _readme-extern-extern-declarations:
 

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -220,7 +220,7 @@ because c_string is a local-only type, the .c_str() method can only be
 called on Chapel strings that are stored on the same locale; calling
 .c_str() on a non-local string will result in a runtime error.
 
-.. note::
+.. warning::
 
   ``c_string`` is deprecated in favor of ``c_ptrConst(c_char)``. See
   :ref:`c_string deprecation <readme-evolution.c_string-deprecation>` for more

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -251,6 +251,11 @@ Any calls that foo() makes through its function pointer argument will
 call back to Chapel's bar() routine.  Note that any Chapel functions
 passed as c_fn_ptr arguments cannot be overloaded nor generic.
 
+.. warning::
+
+  ``c_fn_ptr`` is unstable and expected to be replaced with more feature-rich
+  functionality in the future.
+
 .. _readme-extern-extern-declarations:
 
 Support for Extern Declarations

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -222,8 +222,8 @@ called on Chapel strings that are stored on the same locale; calling
 
 .. note::
 
-  ``c_string`` is expected to be deprecated in a future release in favor
-  of instead using ``c_ptr`` types such as ``c_ptrConst(c_char)``.
+  ``c_string`` is deprecated in favor of ``c_ptrConst(c_char)``, which can be
+  used with corresponding functions such as ``c_ptrToConst``.
 
 c_fn_ptr
 ~~~~~~~~


### PR DESCRIPTION
Update the C Interoperability technote to state that `c_string` is deprecated (https://github.com/chapel-lang/chapel/pull/22622) and that `c_fn_ptr` is unstable (https://github.com/chapel-lang/chapel/pull/23072).

[reviewer info placeholder]

Testing:
- [x] locally generated doc looks correct