### PR TITLE
Remove old `c_sizeof` version with deprecated formal name

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1200,12 +1200,6 @@ module CTypes {
     return CHPL_RT_MD_ARRAY_ELEMENTS - chpl_memhook_md_num();
   }
 
-  pragma "last resort"
-  @deprecated(notes="c_sizeof with argument name 'x' is deprecated; please use c_sizeof(type t) instead")
-  inline proc c_sizeof(type x): c_size_t {
-    return c_sizeof(x);
-  }
-
   /*
     Return the size in bytes of a type, as with the C ``sizeof`` built-in.
 


### PR DESCRIPTION
Remove `c_sizeof(type x)` signature that was deprecated in 1.30 for formal name change from `x`->`t`.

This is my only deprecation from 1.30 per my CHANGES.md for that release.

[trivial, not reviewed]

Testing:
- [x] paratest
- [x] local docs look ok