### PR TITLE
Remove typedefs that create a portability problem on Alpine 3.15

### DIFF
--- a/compiler/include/arg-helpers.h
+++ b/compiler/include/arg-helpers.h
@@ -38,11 +38,6 @@
 // in chpldoc; though ideally the common implementation would be shared
 // rather than duplicated.
 
-typedef __uint8_t uint8_t;
-typedef __uint16_t uint16_t;
-typedef __uint32_t uint32_t;
-typedef __uint64_t uint64_t;
-
 bool startsWith(const char* str, const char* prefix);
 void clean_exit(int status);
 std::string findProgramPath(const char* argv0, void* mainAddr);


### PR DESCRIPTION
The typedefs were added in #20546 and don't seem to be necessary.

Reviewed by @arezaii - thanks!

- [x] full comm=none testing