### PR TITLE
Mark the Random, CommDiagnostics, and Communication modules as unstable

### DIFF
--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -183,6 +183,7 @@
   often necessary to run a small test program twice, once with that
   module present and once without it.
  */
+@unstable("The CommDiagnostics module is unstable and may change in the future")
 module CommDiagnostics
 {
   /*

--- a/modules/standard/Communication.chpl
+++ b/modules/standard/Communication.chpl
@@ -29,6 +29,7 @@
     under any circumstance.
 
 */
+@unstable("The Communication module is unstable and may change in the future")
 module Communication {
   private use CTypes;
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -59,6 +59,7 @@
        change.
 
 */
+@unstable("The Random module is unstable and may change in the future")
 module Random {
 
   public use RandomSupport;

--- a/test/classes/weakPointers/passiveCache.good
+++ b/test/classes/weakPointers/passiveCache.good
@@ -1,3 +1,6 @@
+passiveCache.chpl:4: warning: The Random module is unstable and may change in the future
+passiveCache.chpl:61: In function 'main':
+passiveCache.chpl:72: warning: The Random module is unstable and may change in the future
 passiveCache.chpl:46: In method 'buildAndSave':
 passiveCache.chpl:48: warning: The `weak` type is experimental; expect this API to change in the future.
   passiveCache.chpl:38: called as (PassiveCache(basicClass)).buildAndSave(key: int(64)) from method 'getOrBuild'

--- a/test/library/standard/Random/stonea/fillRandomAssociative.good
+++ b/test/library/standard/Random/stonea/fillRandomAssociative.good
@@ -1,3 +1,3 @@
-$CHPL_HOME/modules/standard/Random.chpl:129: In function 'fillRandom':
-$CHPL_HOME/modules/standard/Random.chpl:136: error: fillRandom does not support non-rectangular arrays
+$CHPL_HOME/modules/standard/Random.chpl:130: In function 'fillRandom':
+$CHPL_HOME/modules/standard/Random.chpl:137: error: fillRandom does not support non-rectangular arrays
   fillRandomAssociative.chpl:5: called as fillRandom(arr: [DefaultAssociativeDom(int(64),true)] real(64), seed: int(64), param algorithm = 1: RNG)

--- a/test/library/standard/Random/stonea/permutationAssociative.good
+++ b/test/library/standard/Random/stonea/permutationAssociative.good
@@ -1,3 +1,3 @@
-$CHPL_HOME/modules/standard/Random.chpl:213: In function 'permutation':
-$CHPL_HOME/modules/standard/Random.chpl:221: error: permutation does not support non-rectangular arrays
+$CHPL_HOME/modules/standard/Random.chpl:214: In function 'permutation':
+$CHPL_HOME/modules/standard/Random.chpl:222: error: permutation does not support non-rectangular arrays
   permutationAssociative.chpl:5: called as permutation(arr: [DefaultAssociativeDom(int(64),true)] real(64), seed: int(64), param algorithm = 1: RNG)

--- a/test/library/standard/Random/stonea/shuffleAssociative.good
+++ b/test/library/standard/Random/stonea/shuffleAssociative.good
@@ -1,3 +1,3 @@
-$CHPL_HOME/modules/standard/Random.chpl:190: In function 'shuffle':
-$CHPL_HOME/modules/standard/Random.chpl:199: error: shuffle does not support non-rectangular arrays
+$CHPL_HOME/modules/standard/Random.chpl:191: In function 'shuffle':
+$CHPL_HOME/modules/standard/Random.chpl:200: error: shuffle does not support non-rectangular arrays
   shuffleAssociative.chpl:5: called as shuffle(arr: [DefaultAssociativeDom(int(64),true)] real(64), seed: int(64), param algorithm = 1: RNG)

--- a/test/unstable/commDiagnosticsModule.chpl
+++ b/test/unstable/commDiagnosticsModule.chpl
@@ -1,0 +1,1 @@
+use CommDiagnostics;

--- a/test/unstable/commDiagnosticsModule.good
+++ b/test/unstable/commDiagnosticsModule.good
@@ -1,0 +1,1 @@
+commDiagnosticsModule.chpl:1: warning: The CommDiagnostics module is unstable and may change in the future

--- a/test/unstable/communicationModule.chpl
+++ b/test/unstable/communicationModule.chpl
@@ -1,0 +1,1 @@
+use Communication;

--- a/test/unstable/communicationModule.good
+++ b/test/unstable/communicationModule.good
@@ -1,0 +1,1 @@
+communicationModule.chpl:1: warning: The Communication module is unstable and may change in the future

--- a/test/unstable/randomModule.chpl
+++ b/test/unstable/randomModule.chpl
@@ -1,0 +1,1 @@
+use Random;

--- a/test/unstable/randomModule.good
+++ b/test/unstable/randomModule.good
@@ -1,0 +1,1 @@
+randomModule.chpl:1: warning: The Random module is unstable and may change in the future


### PR DESCRIPTION
Adds `@unstable` to the `Random`, `CommDiagnostics`, and `Communication` modules to mark them as unstable.

## Summary of changes
- Mark modules as unstable
- Adds test of unstable warning for each of these modules to `test/unstable`
- updated `.good` files of tests which relied on line numbers in `Random`
- updated `test/classes/weakPointers/passiveCache.good` since the test uses `Random` and `--warn-unstable`

# testing
- paratest with futures
- paratest + gasnet
- built and checked docs

[Reviewed by @dlongnecke-cray]