### PR TITLE
Enable CUDA 12 with bundled LLVM

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -241,13 +241,13 @@ def _validate_cuda_version_impl():
         llvm = chpl_llvm.get()
         if llvm == "system":
             llvm_config = chpl_llvm.find_system_llvm_config()
-            llvm_ver_str = chpl_llvm.get_llvm_config_version(llvm_config)
+            llvm_ver_str = chpl_llvm.get_llvm_config_version(llvm_config).strip()
             if is_ver_in_range(llvm_ver_str, "0", "16"):
                 _reportMissingGpuReq(
                         "LLVM versions before 16 do not support CUDA 12. "
                         "Your LLVM (CHPL_LLVM=system) version is {}. "
                         "You can use CUDA 11, or set CHPL_LLVM=bundled to use "
-                        "CUDA 12.".format(llvm_major_ver), suggestNone=False,
+                        "CUDA 12.".format(llvm_ver_str), suggestNone=False,
                         allowExempt=False)
                 return False
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -200,7 +200,7 @@ def _validate_cuda_version_impl():
     """Check that the installed CUDA version is >= MIN_REQ_VERSION and <
        MAX_REQ_VERSION"""
     MIN_REQ_VERSION = "7"
-    MAX_REQ_VERSION = "12"
+    MAX_REQ_VERSION = "13"
 
     chpl_cuda_path = get_sdk_path('nvidia')
     version_file_json = '%s/version.json' % chpl_cuda_path
@@ -235,6 +235,19 @@ def _validate_cuda_version_impl():
             "detected version %s on system." %
             (MIN_REQ_VERSION, MAX_REQ_VERSION, cudaVersion))
       return False
+
+    # CUDA 12 requires the bundled LLVM or the major LLVM version must be >15
+    if is_ver_in_range(cudaVersion, "12", "12"):
+        llvm = chpl_llvm.get()
+        if llvm == system:
+            llvm_ver = chpl_llvm.get_llvm_config_version().strip().split(".")[0]
+            if int(llvm_ver) <= 15:
+                _reportMissingGpuReq(
+                        "LLVM versions before 16 do not support CUDA 12. "
+                        "Your LLVM (CHPL_LLVM=system) version is %s. "
+                        "You can use CUDA 11, or set CHPL_LLVM=bundled to use "
+                        "CUDA 12.".format(llvm_ver))
+                return False
 
     return True
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -237,16 +237,19 @@ def _validate_cuda_version_impl():
       return False
 
     # CUDA 12 requires the bundled LLVM or the major LLVM version must be >15
-    if is_ver_in_range(cudaVersion, "12", "12"):
+    if is_ver_in_range(cudaVersion, "12", "13"):
         llvm = chpl_llvm.get()
-        if llvm == system:
-            llvm_ver = chpl_llvm.get_llvm_config_version().strip().split(".")[0]
-            if int(llvm_ver) <= 15:
+        if llvm == "system":
+            llvm_config = chpl_llvm.find_system_llvm_config()
+            llvm_ver_str = chpl_llvm.get_llvm_config_version(llvm_config)
+            llvm_major_ver = llvm_ver_str.strip().split(".")[0]
+            if int(llvm_major_ver) <= 15:
                 _reportMissingGpuReq(
                         "LLVM versions before 16 do not support CUDA 12. "
-                        "Your LLVM (CHPL_LLVM=system) version is %s. "
+                        "Your LLVM (CHPL_LLVM=system) version is {}. "
                         "You can use CUDA 11, or set CHPL_LLVM=bundled to use "
-                        "CUDA 12.".format(llvm_ver))
+                        "CUDA 12.".format(llvm_major_ver), suggestNone=False,
+                        allowExempt=False)
                 return False
 
     return True

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -242,8 +242,7 @@ def _validate_cuda_version_impl():
         if llvm == "system":
             llvm_config = chpl_llvm.find_system_llvm_config()
             llvm_ver_str = chpl_llvm.get_llvm_config_version(llvm_config)
-            llvm_major_ver = llvm_ver_str.strip().split(".")[0]
-            if int(llvm_major_ver) <= 15:
+            if is_ver_in_range(llvm_ver_str, "0", "16"):
                 _reportMissingGpuReq(
                         "LLVM versions before 16 do not support CUDA 12. "
                         "Your LLVM (CHPL_LLVM=system) version is {}. "


### PR DESCRIPTION
Depends on https://github.com/chapel-lang/chapel/pull/23332.

https://github.com/chapel-lang/chapel/pull/23332 patches our bundled LLVM to be able to build CUDA 12. This PR makes chplenv script changes to let CUDA 12 pass with bundled LLVM.

I tested some combinations manually with a system that has several CUDA 11.x installations and a CUDA 12.0 installation.