### PR TITLE
Add CUDA 12 nightly script

### DIFF
--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# GPU native testing on a Cray EX (using none for CHPL_COMM)
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-native-gpu.bash
+source $CWD/common-hpe-cray-ex.bash
+
+module load cudatoolkit/23.3_12.0  # this is the default on this system
+
+export CHPL_COMM=none
+export CHPL_LOCALE_MODEL=gpu
+export CHPL_LAUNCHER_PARTITION=allgriz
+
+export CHPL_GPU=nvidia  # amd is also detected automatically
+
+export CHPL_NIGHTLY_TEST_DIRS="gpu/native"
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12"
+$CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -8,6 +8,7 @@ source $CWD/common-hpe-cray-ex.bash
 
 module load cudatoolkit/23.3_12.0  # this is the default on this system
 
+export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=allgriz


### PR DESCRIPTION
The script added in this PR is almost identical to `util/cron/test-gpu-ex-cuda-11.bash`. The differences are:

- different cudatoolkit module version
- `CHPL_LLVM=bundled` (we support CUDA 12 only with the bundled LLVM)