### PR TITLE
Improve documentation of enums in modules

### DIFF
--- a/doc/rst/tools/chpldoc/chpldoc.rst
+++ b/doc/rst/tools/chpldoc/chpldoc.rst
@@ -505,8 +505,9 @@ a matching identifier is found:
 ``:param:``
 ``:type:``
 ``:enum:``
+``:enumconstant:``
 
-    Reference a module-level variable, constant, compiler param, type, or enum.
+    Reference a module-level variable, constant, compiler param, type, enum, or enum constant.
 
 ``:class:``
 ``:record:``

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -456,33 +456,32 @@ iter adaptive(c:range(?), numTasks:int=0) {
 
 
 // Parallel iterator
-/*
-The enum used to represent adaptive methods.
-
-- ``Whole``
-  Each task without work tries to steal from its neighbor range
-  until it exhausts that range. Then the task continues with the next
-  neighbor range, and so on until there is no more work. This is the default
-  policy.
-
-- ``RoundRobin``
-  Each task without work tries to steal once from its neighbor range, next
-  from the following neighbor range and so on in a round-robin way until
-  there is no more work.
-
-- ``WholeTail``
-  Similar to the ``Whole`` method, but now the splitting in the victim
-  range is performed from its tail.
-*/
+/* The enum used to represent adaptive methods. */
 enum Method {
+  /*
+    Each task without work tries to steal from its neighbor range
+    until it exhausts that range. Then the task continues with the next
+    neighbor range, and so on until there is no more work. This is the default
+    policy.
+  */
   Whole = 0,
+  /*
+    Each task without work tries to steal once from its neighbor range, next
+    from the following neighbor range and so on in a round-robin way until
+    there is no more work.
+  */
   RoundRobin = 1,
+  /*
+    Similar to the :enumconstant:`~Method.Whole` method, but now the splitting
+    in the victim range is performed from its tail.
+  */
   WholeTail = 2
 };
 
 /*
-  Used to select the adaptive stealing method. Defaults to ``Whole``.
-  See :data:`Method` for more information.
+  Used to select the adaptive stealing method.
+  Defaults to :enumconstant:`~Method.Whole`.
+  See :enum:`Method` for more information.
 */
 config param methodStealing = Method.Whole;
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -665,23 +665,17 @@ param iobig = _iokind.big;
 param iolittle = _iokind.little;
 
 /*
-
 The :type:`ioendian` type is an enum. When used as an argument to the
 :record:`fileReader` or :record:`fileWriter` methods, its constants have the
 following meanings:
-
-* ``ioendian.big`` means binary I/O is performed in big-endian byte order.
-
-* ``ioendian.little`` means binary I/O is performed in little-endian byte order.
-
-* ``ioendian.native`` means binary I/O is performed in the byte order that is native
-  to the target platform.
-
 */
-
 enum ioendian {
+  /* ``native`` means binary I/O is performed in the byte order that is native
+  to the target platform. */
   native = 0,
+  /* ``big`` means binary I/O is performed in big-endian byte order.*/
   big = 1,
+  /* ``little`` means binary I/O is performed in little-endian byte order. */
   little = 2
 }
 
@@ -8527,7 +8521,7 @@ proc fileWriter.writeBinary(ptr: c_ptr(void), numBytes: int) throws {
   :arg arg: number to be written
   :arg endian: :type:`ioendian` compile-time argument that specifies the byte
                order in which to write the number. Defaults to
-               ``ioendian.native``.
+               :enumconstant:`ioendian.native`.
 
   :throws EofError: Thrown if the ``fileWriter`` offset was already at EOF.
   :throws UnexpectedEofError: Thrown if the write operation exceeds the
@@ -8673,7 +8667,7 @@ proc fileWriter.writeBinary(b: bytes, size: int = b.size) throws {
   :arg data: an array of numbers to write to the fileWriter
   :arg endian: :type:`ioendian` compile-time argument that specifies the byte
                order in which to read the numbers. Defaults to
-               ``ioendian.native``.
+               :enumconstant:`ioendian.native`.
 
   :throws EofError: Thrown if the ``fileWriter`` offset was already at EOF.
   :throws UnexpectedEofError: Thrown if the write operation exceeds the
@@ -8758,7 +8752,7 @@ proc fileWriter.writeBinary(const ref data: [] ?t, endian:ioendian) throws
   :arg arg: number to be read
   :arg endian: :type:`ioendian` compile-time argument that specifies the byte
                order in which to read the number. Defaults to
-               ``ioendian.native``.
+               :enumconstant:`ioendian.native`.
   :returns: ``true`` if the number was read, and ``false`` otherwise (i.e.,
             the ``fileReader`` was already at EOF).
 
@@ -8996,7 +8990,7 @@ proc fileReader.readBinary(ref data: [] ?t, param endian = ioendian.native): boo
   :arg data: an array to read into – existing values are overwritten.
   :arg endian: :type:`ioendian` compile-time argument that specifies the byte
                order in which to read the numbers in. Defaults to
-               ``ioendian.native``.
+               :enumconstant:`ioendian.native`.
   :returns: the number of values that were read into the array. This can be
             less than ``data.size`` if EOF was reached, or an error occurred,
             before filling the array.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -541,58 +541,45 @@ private use Reflection;
 public use ChapelIO only write, writeln, writef;
 
 /*
-
 The :type:`ioMode` type is an enum. When used as arguments when opening files, its
-constants have the same meaning as the following strings passed to ``fopen()`` in C:
-
-.. list-table::
-   :widths: 8 8 64
-   :header-rows: 1
-
-   * - :type:`ioMode`
-     - ``fopen()`` argument
-     - Description
-   * - ``ioMode.r``
-     - ``"r"``
-     - open an existing file for reading.
-   * - ``ioMode.rw``
-     - ``"r+"``
-     - open an existing file for reading and writing.
-   * - ``ioMode.cw``
-     - ``"w"``
-     - create a new file for writing. If the file already exists, its contents are truncated.
-   * - ``ioMode.cwr``
-     - ``"w+"``
-     - same as ``ioMode.cw``, but reading from the file is also allowed.
-   * - ``ioMode.a``
-     - ``"a"``
-     - open a file for appending, creating it if it does not exist.
-
-.. TODO: Support append / create-exclusive modes:
-   * - ``ioMode.ar``
-     - ``"a+"``
-     - same as ``ioMode.a``, but reading from the file is also allowed.
-   * - ``ioMode.cwx``
-     - ``"wx"``
-     - open a file for writing, throwing an error if it already exists. (The test for file's existence and the file's creation are atomic on POSIX.)
-   * - ``ioMode.cwrx``
-     - ``"w+x"``
-     - same as ``ioMode.cwx``, but reading from the file is also allowed.
-
+constants have the same meaning as the listed strings passed to ``fopen()`` in C.
 However, :proc:`open()` in Chapel does not necessarily invoke ``fopen()`` in C.
-
-.. warning::
-
-   ``ioMode.a`` is unstable and subject to change. It currently only supports
-   one :record:`fileWriter` at a time.
 */
 enum ioMode {
+  /*
+    Open an existing file for reading.
+    (``fopen()`` string is "r")
+  */
   r = 1,
+  /*
+    Create a new file for writing.
+    If the file already exists, its contents are truncated.
+    (``fopen()`` string is "w")
+  */
   cw = 2,
+  /*
+    Open an existing file for reading and writing.
+    (``fopen()`` string is "r+")
+  */
   rw = 3,
+  /*
+    Same as :enumconstant:`ioMode.cw`, but reading from the file is also allowed.
+    (``fopen()`` string is "w+")
+  */
   cwr = 4,
-  @unstable("append mode is unstable")
+  /*
+    Open a file for appending, creating it if it does not exist.
+    (``fopen()`` string is "a")
+  */
+  @unstable(":enumconstant:`ioMode.a` is unstable and subject to change. It currently only supports one :record:`fileWriter` at a time.")
   a = 5,
+  // same as ``ioMode.a``, but reading from the file is also allowed.
+  // ar, "a+"
+  // open a file for writing, throwing an error if it already exists. (The test for file's existence and the file's creation are atomic on POSIX.)
+  // cwx, "wx"
+  // same as ``ioMode.cwx``, but reading from the file is also allowed.
+  // cwrx, w+x
+
 }
 
 @deprecated(notes="enum iomode is deprecated - please use :enum:`ioMode` instead")

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -121,7 +121,7 @@ other task is consuming it.
 
 .. note::
 
-  Creating a subprocess that uses :type:`pipeStyle` ``pipeStyle.pipe`` to
+  Creating a subprocess that uses :enumconstant:`pipeStyle.pipe` to
   provide input or capture output does not work when using the ugni
   communications layer with hugepages enabled and when using more than one
   locale. In this circumstance, the program will halt with an error message.
@@ -317,35 +317,38 @@ module Subprocess {
   private extern const QIO_FD_TO_STDOUT:c_int;
   private extern const QIO_FD_BUFFERED_PIPE:c_int;
 
-  /*
-     Styles of piping to use in a subprocess.
-
-     ``forward`` indicates that the child process should inherit
-     the stdin/stdout/stderr of this process.
-
-     ``close`` indicates that the child process should close
-     its stdin/stdout/stderr.
-
-     ``pipe`` indicates that the spawn operation should set up
-     a pipe between the parent process and the child process
-     so that the parent process can provide input to the
-     child process or capture its output.
-
-     ``stdout`` indicates that the stderr stream of the child process
-     should be forwarded to its stdout stream.
-
-     ``bufferAll`` is the same as pipe, but when used for stdin causes all data
-     to be buffered and sent on the communicate() call. This avoids certain
-     deadlock scenarios where stdout or stderr are ``pipe``. In particular,
-     without ``bufferAll``, the sub-process might block on writing output
-     which will not be consumed until the communicate() call.
-
-   */
+  /* Styles of piping to use in a subprocess. */
   enum pipeStyle {
+    /*
+      ``forward`` indicates that the child process should inherit
+      the stdin/stdout/stderr of this process.
+    */
     forward,
+    /*
+      ``close`` indicates that the child process should close
+      its stdin/stdout/stderr.
+    */
     close,
+    /*
+      ``pipe`` indicates that the spawn operation should set up
+      a pipe between the parent process and the child process
+      so that the parent process can provide input to the
+      child process or capture its output.
+    */
     pipe,
+    /*
+      ``stdout`` indicates that the stderr stream of the child process
+      should be forwarded to its stdout stream.
+    */
     stdout,
+    /*
+      ``bufferAll`` is the same as :enumconstant:`~pipeStyle.pipe`, but when used
+      for stdin causes all data to be buffered and sent on the communicate()
+      call. This avoids certain deadlock scenarios where stdout or stderr are
+      :enumconstant:`~pipeStyle.pipe`. In particular,
+      without ``bufferAll``, the sub-process might block on writing output
+      which will not be consumed until the communicate() call.
+    */
     bufferAll
   }
 
@@ -417,22 +420,22 @@ module Subprocess {
                       found by searching the PATH.
 
      :arg stdin: indicates how the standard input of the child process
-                 should be handled. It could be :type:`pipeStyle`
-                 ``pipeStyle.forward``, ``pipeStyle.close``,
-                 ``pipeStyle.pipe``, or a file descriptor number to use.
-                 Defaults to ``pipeStyle.forward``.
+                 should be handled. It could be
+                 :enumconstant:`pipeStyle.forward`, :enumconstant:`pipeStyle.close`,
+                 :enumconstant:`pipeStyle.pipe`, or a file descriptor number to use.
+                 Defaults to :enumconstant:`pipeStyle.forward`.
 
      :arg stdout: indicates how the standard output of the child process
-                  should be handled. It could be :type:`pipeStyle`
-                  ``pipeStyle.forward``, ``pipeStyle.close``,
-                  ``pipeStyle.pipe``, or a file descriptor number to use.
-                  Defaults to ``pipeStyle.forward``.
+                  should be handled. It could be
+                  :enumconstant:`pipeStyle.forward`, :enumconstant:`pipeStyle.close`,
+                  :enumconstant:`pipeStyle.pipe`, or a file descriptor number to use.
+                  Defaults to :enumconstant:`pipeStyle.forward`.
 
      :arg stderr: indicates how the standard error of the child process
-                  should be handled. It could be :type:`pipeStyle`
-                  ``pipeStyle.forward``, ``pipeStyle.close``,
-                  ``pipeStyle.pipe``, ``pipeStyle.stdout``, or a file
-                  descriptor number to use. Defaults to ``pipeStyle.forward``.
+                  should be handled. It could be
+                  :enumconstant:`pipeStyle.forward`, :enumconstant:`pipeStyle.close`,
+                  :enumconstant:`pipeStyle.pipe`, :enumconstant:`pipeStyle.stdout`, or a file
+                  descriptor number to use. Defaults to :enumconstant:`pipeStyle.forward`.
 
      :arg locking: Should channels created use locking?
                    This argument is used to set :attr:`subprocess.locking`
@@ -655,23 +658,23 @@ module Subprocess {
                process.
 
      :arg stdin: indicates how the standard input of the child process
-                 should be handled. It could be :type:`pipeStyle`
-                 ``pipeStyle.forward``, ``pipeStyle.close``,
-                 ``pipeStyle.pipe``, or a file descriptor number to use.
-                 Defaults to ``pipeStyle.forward``.
+                 should be handled. It could be
+                 :enumconstant:`pipeStyle.forward`, :enumconstant:`pipeStyle.close`,
+                 :enumconstant:`pipeStyle.pipe`, or a file descriptor number to use.
+                 Defaults to :enumconstant:`pipeStyle.forward`.
 
      :arg stdout: indicates how the standard output of the child process
-                  should be handled. It could be :type:`pipeStyle`
-                  ``pipeStyle.forward``, ``pipeStyle.close``,
-                  ``pipeStyle.pipe``, or a file descriptor number to use.
-                  Defaults to ``pipeStyle.forward``.
+                  should be handled. It could be
+                  :enumconstant:`pipeStyle.forward`, :enumconstant:`pipeStyle.close`,
+                  :enumconstant:`pipeStyle.pipe`, or a file descriptor number to use.
+                  Defaults to :enumconstant:`pipeStyle.forward`.
 
      :arg stderr: indicates how the standard error of the child process
-                  should be handled. It could be :type:`pipeStyle`
-                  ``pipeStyle.forward``, ``pipeStyle.close``,
-                  ``pipeStyle.pipe``, ``pipeStyle.stdout``, or a file
+                  should be handled. It could be
+                  :enumconstant:`pipeStyle.forward`, :enumconstant:`pipeStyle.close`,
+                  :enumconstant:`pipeStyle.pipe`, :enumconstant:`pipeStyle.stdout`, or a file
                   descriptor number to use. Defaults to
-                  ``pipeStyle.forward``.
+                  :enumconstant:`pipeStyle.forward`.
 
      :arg executable: By default, the executable argument is "/bin/sh".
                       That directs the subprocess to run the /bin/sh shell
@@ -899,7 +902,7 @@ module Subprocess {
     by the subprocess.
 
     This function handles cases in which stdin, stdout, or stderr
-    for the child process is :type:`pipeStyle` ``pipe`` by writing any
+    for the child process is :enumconstant:`pipeStyle.pipe` by writing any
     input to the child process and buffering up the output
     of the child process as necessary while waiting for
     it to terminate.

--- a/test/unstable/ioModeAppend.good
+++ b/test/unstable/ioModeAppend.good
@@ -1,1 +1,1 @@
-ioModeAppend.chpl:6: warning: append mode is unstable
+ioModeAppend.chpl:6: warning: ioMode.a is unstable and subject to change. It currently only supports one fileWriter at a time.


### PR DESCRIPTION
Using features added in #22750, improves the documentation of enums in our modules. Updated both stable and unstable enums, but left deprecated enums alone. Also updated the docs for `chpldoc` to mention the attribute used (`:enumconstant:`)

## Summary of changes
- Refactor `IO.ioMode`
- Refactor `IO.ioendian`
- Refactor `DynamicIters.Method`
- Refactor `Subprocess.pipeStyle`
- Add small note about `:enumconstant:` to `doc/rst/tools/chpldoc/chpldoc.rst`

## Testing
- built and checked docs
- paratest sanity check

[Reviewed by @dlongnecke-cray]

