### PR TITLE
Unstabilize most args for `cyclicDist` and `blockDist`

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -221,10 +221,7 @@ By default, parallelism within each locale is applied to that locale's
 block of indices by creating a task for each available processor core
 (or the number of local indices if it is less than the number of
 cores). The local domain indices are then statically divided as evenly
-as possible between those tasks.  This default can be modified by
-changing the values of ``dataParTasksPerLocale``,
-``dataParIgnoreRunningTasks``, and ``dataParMinGranularity`` in the
-``blockDist``'s initializer:
+as possible between those tasks.
 
 
 **Initializer Arguments**

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -409,6 +409,8 @@ record blockDist {
 
   forwarding const chpl_distHelp: chpl_PrivatizedDistHelper(unmanaged BlockImpl(rank, idxType, _to_unmanaged(sparseLayoutType)));
 
+  pragma "last resort"
+  @unstable("passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable")
   proc init(boundingBox: domain,
             targetLocales: [] locale = Locales,
             dataParTasksPerLocale=getDataParTasksPerLocale(),
@@ -430,6 +432,16 @@ record blockDist {
                             then _newPrivatizedClass(value)
                             else nullPid,
                           value);
+  }
+
+  proc init(boundingBox: domain,
+            targetLocales: [] locale = Locales)
+  {
+    this.init(boundingBox, targetLocales,
+              /* by specifying even one unstable argument, this should select
+                 the whole unstable constructor, which has defaults for everything
+                 else. */
+              dataParTasksPerLocale=getDataParTasksPerLocale());
   }
 
     proc init(_pid : int, _instance, _unowned : bool) {

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -235,13 +235,7 @@ The ``blockDist`` initializer is defined as follows:
 
     proc blockDist.init(
       boundingBox: domain(?),
-      targetLocales: [] locale  = Locales,
-      dataParTasksPerLocale     = // value of dataParTasksPerLocale config const,
-      dataParIgnoreRunningTasks = // value of dataParIgnoreRunningTasks config const,
-      dataParMinGranularity     = // value of dataParMinGranularity config const,
-      param rank                = boundingBox.rank,
-      type  idxType             = boundingBox.idxType,
-      type  sparseLayoutType    = unmanaged DefaultDist)
+      targetLocales: [] locale  = Locales)
 
 The arguments ``boundingBox`` (a domain) and ``targetLocales`` (an array)
 define the mapping of any index of ``idxType`` type to a locale
@@ -252,25 +246,6 @@ or be ``1``.  If the rank of ``targetLocales`` is ``1``, a greedy
 heuristic is used to reshape the array of target locales so that it
 matches the rank of the distribution and each dimension contains an
 approximately equal number of indices.
-
-The arguments ``dataParTasksPerLocale``,
-``dataParIgnoreRunningTasks``, and ``dataParMinGranularity`` set the
-knobs that are used to control intra-locale data parallelism for
-block-distributed domains and arrays in the same way that the
-like-named config constants control data parallelism for ranges and
-default-distributed domains and arrays.
-
-The ``rank`` and ``idxType`` arguments are inferred from the
-``boundingBox`` argument unless explicitly set.  They must match the
-rank and index type of the domains distributed using the ``blockDist``
-instance. If the ``boundingBox`` argument is a stridable domain, the
-stride information will be ignored and the ``boundingBox`` will only
-use the low and high bounds.
-
-When a ``sparse subdomain`` is created for a ``blockDist`` distributed
-domain, the ``sparseLayoutType`` will be the layout of these sparse
-domains. The default currently uses coordinate storage, but
-:class:`LayoutCS.CS` is an interesting alternative.
 
 **Convenience Factory Methods**
 

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -261,6 +261,8 @@ record cyclicDist {
 
   forwarding const chpl_distHelp: chpl_PrivatizedDistHelper(unmanaged CyclicImpl(rank, idxType));
 
+  pragma "last resort"
+  @unstable("passing arguments other than 'boundingBox' and 'targetLocales' to 'cyclicDist' is currently unstable")
   proc init(startIdx,
             targetLocales: [] locale = Locales,
             dataParTasksPerLocale=getDataParTasksPerLocale(),
@@ -284,6 +286,17 @@ record cyclicDist {
                             then _newPrivatizedClass(value)
                             else nullPid,
                           value);
+  }
+
+  proc init(startIdx,
+            targetLocales: [] locale = Locales)
+    where isTuple(startIdx) || isIntegral(startIdx)
+  {
+    this.init(startIdx, targetLocales,
+              /* by specifying even one unstable argument, this should select
+                 the whole unstable constructor, which has defaults for everything
+                 else. */
+              dataParTasksPerLocale=getDataParTasksPerLocale());
   }
 
     proc init(_pid : int, _instance, _unowned : bool) {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -125,15 +125,11 @@ As demonstrated by the above example, a `forall` loop over a
 ``cyclicDist``-distributed domain or array executes each iteration on
 the locale owning the index in question.
 
-By default, parallelism within each locale is applied to that locale's
+Parallelism within each locale is applied to that locale's
 local, strided block of indices by creating a task for each available
 processor core (or the number of local indices if it is less than the
 number of cores). The local domain indices are then statically divided
-as evenly as possible between those tasks.  This default can be
-modified by changing the values of ``dataParTasksPerLocale``,
-``dataParIgnoreRunningTasks``, and ``dataParMinGranularity`` in the
-``cyclicDist``'s initializer:
-
+as evenly as possible between those tasks.
 
 **Initializer Arguments**
 
@@ -143,12 +139,7 @@ The ``cyclicDist`` initializer is defined as follows:
 
     proc cyclicDist.init(
       startIdx,
-      targetLocales: [] locale = Locales,
-      dataParTasksPerLocale     = // value of  dataParTasksPerLocale      config const,
-      dataParIgnoreRunningTasks = // value of  dataParIgnoreRunningTasks  config const,
-      dataParMinGranularity     = // value of  dataParMinGranularity      config const,
-      param rank: int  = // inferred from startIdx argument,
-      type idxType     = // inferred from startIdx argument )
+      targetLocales: [] locale = Locales)
 
 The argument ``startIdx`` is a tuple of integers defining an index that
 will be distributed to the first locale in ``targetLocales``.
@@ -162,18 +153,6 @@ or be ``1``.  If the rank of ``targetLocales`` is ``1``, a greedy
 heuristic is used to reshape the array of target locales so that it
 matches the rank of the distribution and each dimension contains an
 approximately equal number of indices.
-
-The arguments ``dataParTasksPerLocale``, ``dataParIgnoreRunningTasks``,
-and ``dataParMinGranularity`` set the knobs that are used to
-control intra-locale data parallelism for cyclic-distributed domains
-and arrays in the same way that the like-named config constants
-control data parallelism for ranges and default-distributed domains
-and arrays.
-
-The ``rank`` and ``idxType`` arguments are inferred from the
-``startIdx`` argument unless explicitly set.
-They must match the rank and index type of the domains
-"dmapped" using that Cyclic instance.
 
 **Convenience Factory Methods**
 

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -125,7 +125,7 @@ As demonstrated by the above example, a `forall` loop over a
 ``cyclicDist``-distributed domain or array executes each iteration on
 the locale owning the index in question.
 
-Parallelism within each locale is applied to that locale's
+By default, parallelism within each locale is applied to that locale's
 local, strided block of indices by creating a task for each available
 processor core (or the number of local indices if it is less than the
 number of cores). The local domain indices are then statically divided

--- a/test/unstable/blockDistArgs.chpl
+++ b/test/unstable/blockDistArgs.chpl
@@ -1,0 +1,13 @@
+use DSIUtil;
+use BlockDist;
+
+const Space = {1..100, 1..100};
+
+const validDist = new blockDist(Space, Locales);
+
+const badDist1 = new blockDist(Space, dataParTasksPerLocale=getDataParTasksPerLocale());
+const badDist2 = new blockDist(Space, dataParIgnoreRunningTasks=getDataParIgnoreRunningTasks());
+const badDist3 = new blockDist(Space, dataParMinGranularity=getDataParMinGranularity());
+const badDist4 = new blockDist(Space, rank=Space.rank);
+const badDist5 = new blockDist(Space, idxType=Space.idxType);
+const badDist6 = new blockDist(Space, sparseLayoutType=unmanaged DefaultDist);

--- a/test/unstable/blockDistArgs.good
+++ b/test/unstable/blockDistArgs.good
@@ -1,0 +1,6 @@
+blockDistArgs.chpl:8: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable
+blockDistArgs.chpl:9: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable
+blockDistArgs.chpl:10: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable
+blockDistArgs.chpl:11: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable
+blockDistArgs.chpl:12: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable
+blockDistArgs.chpl:13: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable

--- a/test/unstable/cyclicDistArgs.chpl
+++ b/test/unstable/cyclicDistArgs.chpl
@@ -1,0 +1,10 @@
+use DSIUtil;
+use CyclicDist;
+
+const validDist = new cyclicDist(0, Locales);
+
+const badDist1 = new cyclicDist(0, dataParTasksPerLocale=getDataParTasksPerLocale());
+const badDist2 = new cyclicDist(0, dataParIgnoreRunningTasks=getDataParIgnoreRunningTasks());
+const badDist3 = new cyclicDist(0, dataParMinGranularity=getDataParMinGranularity());
+const badDist4 = new cyclicDist(0, rank=_determineRankFromStartIdx(0));
+const badDist5 = new cyclicDist(0, idxType=_determineIdxTypeFromStartIdx(0));

--- a/test/unstable/cyclicDistArgs.good
+++ b/test/unstable/cyclicDistArgs.good
@@ -1,0 +1,5 @@
+cyclicDistArgs.chpl:6: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'cyclicDist' is currently unstable
+cyclicDistArgs.chpl:7: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'cyclicDist' is currently unstable
+cyclicDistArgs.chpl:8: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'cyclicDist' is currently unstable
+cyclicDistArgs.chpl:9: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'cyclicDist' is currently unstable
+cyclicDistArgs.chpl:10: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'cyclicDist' is currently unstable


### PR DESCRIPTION
This PR unstabilizes all but the first two arguments for the `cyclicDist` and `blockDist` distributions. It does so by creating a new overload of the function that _doesn't_ have these arguments, making it the "canonical" way to construct the two distributions. The original constructor, with the unstable arguments, is kept, and marked "last resort". This original constructor is annotated with `@unstable`.

The PR also removes the documentation of the unstable arguments from the module docs.

Reviewed by @bradcray -- thanks!

## Testing
- [x] paratest