### PR TITLE
Mark modules with unstable distributions as unstable

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+@unstable("BlockCycDist is unstable and may change in the future")
+prototype module BlockCycDist {
 //
 // BlockCyclic Distribution
 //
@@ -1298,3 +1300,4 @@ proc _computeBlockCyclic(waylo, numelems, lo, wayhi, numblocks, blocknum) {
 
   return (blo, bhi);
 }
+} // BlockCycDist

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -27,6 +27,9 @@
 // * Ensure that reallocation works with block-cyclic 1-d distribution
 //  when the domain's stride changes.
 
+@unstable("DimensionalDist2D is unstable and may change in the future")
+prototype module DimensionalDist2D {
+
 use DSIUtil;
 //use WrapperDist;
 
@@ -1445,3 +1448,5 @@ iter DimensionalArr._dsiIteratorHelper(alDom, (f1, f2)) ref {
         yield lastLocAdesc!.myStorageArr(i1, i2);
       }
 }
+
+} // DimensionalDist2D

--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+@unstable("HashedDist is unstable and may change in the future")
+prototype module HashedDist {
 
 config param debugUserMapAssoc = false;
 
@@ -1072,3 +1074,5 @@ class LocUserMapAssocArr {
     return locDom.myInds.dim(1).boundsCheck(x.dim(1));
   }
 }
+
+} // HashedDist

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+@unstable("PrivateDist is unstable and may change in the future")
+prototype module PrivateDist {
+
 use ChplConfig only compiledForSingleLocale;
 
 //
@@ -357,3 +360,5 @@ record chpl_privateDistCleanupWrapper {
 proc deinit() {
   chpl_privateCW.val = chpl_privateDist;
 }
+
+} // PrivateDist

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -32,6 +32,9 @@
 // - support other kinds of domains
 // - allow run-time change in locales
 
+@unstable("ReplicatedDist is unstable and may change in the future")
+prototype module ReplicatedDist {
+
 use DSIUtil;
 
 // trace certain DSI methods as they are being invoked
@@ -765,3 +768,5 @@ proc ReplicatedArr.dsiLocalSubdomain(loc: locale) {
 proc ReplicatedArr.dsiLocalSlice(ranges) {
   return chpl_myLocArr().arrLocalRep((...ranges));
 }
+
+} // ReplicatedDist

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -33,6 +33,9 @@
 // mapped to by the distribution.
 //
 
+@unstable("StencilDist is unstable and may change in the future")
+prototype module StencilDist {
+
 private use BlockDist;
 private use DSIUtil;
 private use ChapelUtil;
@@ -2504,3 +2507,5 @@ proc StencilArr.doiOptimizedSwap(other) where debugOptimizedSwap {
   writeln("StencilArr doing unoptimized swap. Type mismatch");
   return false;
 }
+
+} // StencilDist

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -96,6 +96,7 @@ module DefaultRectangular {
     return ret;
   }
 
+  @unstable("DefaultDist is unstable and may change in the future")
   class DefaultDist: BaseDist {
     override proc dsiNewRectangularDom(param rank: int, type idxType,
                                        param strides: strideKind, inds) {

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+@unstable("LayoutCS is unstable and may change in the future")
+prototype module LayoutCS {
+
 import RangeChunk;
 
 @chpldoc.nodoc
@@ -747,3 +750,5 @@ class CSArr: BaseSparseArrImpl(?) {
     }
   }
 } // CSArr
+
+} // LayoutCS

--- a/test/unstable/dmapped-sparse.good
+++ b/test/unstable/dmapped-sparse.good
@@ -1,6 +1,8 @@
 dmapped-sparse.chpl:4: warning: sparse domains are unstable, their behavior is likely to change in the future
 dmapped-sparse.chpl:7: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
+dmapped-sparse.chpl:7: warning: DefaultDist is unstable and may change in the future
 dmapped-sparse.chpl:10: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
+dmapped-sparse.chpl:10: warning: DefaultDist is unstable and may change in the future
 dmapped-sparse.chpl:20: In function 'testit':
 dmapped-sparse.chpl:20: warning: the type 'dmap' is unstable, instead please use distribution factory functions when available
 dmapped-sparse.chpl:11: error: done

--- a/test/unstable/unstableDists.chpl
+++ b/test/unstable/unstableDists.chpl
@@ -1,0 +1,9 @@
+import LayoutCS;
+import BlockCycDist;
+import DimensionalDist2D;
+import HashedDist;
+import PrivateDist;
+import ReplicatedDist;
+import StencilDist;
+
+var dd = new DefaultDist();

--- a/test/unstable/unstableDists.good
+++ b/test/unstable/unstableDists.good
@@ -1,0 +1,8 @@
+unstableDists.chpl:1: warning: LayoutCS is unstable and may change in the future
+unstableDists.chpl:2: warning: BlockCycDist is unstable and may change in the future
+unstableDists.chpl:3: warning: DimensionalDist2D is unstable and may change in the future
+unstableDists.chpl:4: warning: HashedDist is unstable and may change in the future
+unstableDists.chpl:5: warning: PrivateDist is unstable and may change in the future
+unstableDists.chpl:6: warning: ReplicatedDist is unstable and may change in the future
+unstableDists.chpl:7: warning: StencilDist is unstable and may change in the future
+unstableDists.chpl:9: warning: DefaultDist is unstable and may change in the future


### PR DESCRIPTION
Mark modules with unstable distributions as unstable for 2.0. To mark these unstable, this PR wraps the existing implicit modules as prototype modules to maintain the error handling behavior.

## Summary of changes
- mark the LayoutCS module as unstable
- mark the BlockCycDist module as unstable
- mark the DimensionalDist2D module as unstable
- mark the HashedDist module as unstable
- mark the PrivateDist module as unstable
- mark the ReplicatedDist module as unstable
- mark the StencilDist module as unstable
- mark the marks DefaultDist as unstable directlly, as this is defined in an internal module
- mark the update `test/unstable/dmapped-sparse.good`

## Testing
- paratest with futures
- paratest with gasnet
- built and checked docs

[Reviewed by @bradcray]

Implements and closes https://github.com/Cray/chapel-private/issues/5393