### PR TITLE
Use gpu arch while compiling extern code, too

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2666,6 +2666,10 @@ static std::string generateClangGpuLangArgs() {
         args += " -lstdc++";
         break;
     }
+
+    if (gpuArches.size() >= 1) {
+      args += " " + std::string("--offload-arch=") + *gpuArches.begin();
+    }
   }
   return args;
 }
@@ -2911,11 +2915,6 @@ void runClang(const char* just_parse_filename) {
     // Need to select CUDA/AMD mode in embedded clang to
     // activate the GPU target
     splitStringWhitespace(generateClangGpuLangArgs(), clangOtherArgs);
-
-    if (gpuArches.size() >= 1) {
-      std::string archFlag = std::string("--offload-arch=") + *gpuArches.begin();
-      clangOtherArgs.push_back(archFlag);
-    }
   }
 
   // Always include sys_basic because it might change the


### PR DESCRIPTION
We have seen some failures in CUDA 12 extern testing last night. It was because we were not passing `--offload-arch` to clang specifically, which was ending up using `sm_35`. My strong guess is that `sm_35` is deprecated with CUDA 12. Because our CUDA 12 support is somewhat half-baked, our bundled clang still used `sm_35` under the hood by default.

This PR adjusts our compilation pipeline to pass `--offload-arch` to clang while using it to compile extern code. We use the same arch as we compile Chapel code.

Test:
- [x] gpu/native/extern passes with CUDA 12
- [x] nvidia (cuda 11)
- [x] amd