### PR TITLE
Add extra unstable warning to test

### DIFF
--- a/test/unstable/blockDistArgs.good
+++ b/test/unstable/blockDistArgs.good
@@ -1,3 +1,4 @@
+blockDistArgs.chpl:13: warning: DefaultDist is unstable and may change in the future
 blockDistArgs.chpl:8: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable
 blockDistArgs.chpl:9: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable
 blockDistArgs.chpl:10: warning: passing arguments other than 'boundingBox' and 'targetLocales' to 'blockDist' is currently unstable


### PR DESCRIPTION
Adds an extra warning line to `test/unstable/blockDistArgs.good`.

Tested was added in #23345 and warning was added in #23349

Tested locally

[Not reviewed - trivial]