### PR TITLE
Co-locales should be explicitly requested

### DIFF
--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -498,19 +498,17 @@ static void partitionResources(void) {
   _DBG_P("numSockets = %d", numSockets);
 
   int numLocalesOnNode = chpl_get_num_locales_on_node();
-  int expectedLocalesOnNode = chpl_env_rt_get_int("LOCALES_PER_NODE", 0);
+  int expectedLocalesOnNode = chpl_env_rt_get_int("LOCALES_PER_NODE", 1);
   chpl_bool useSocket = chpl_env_rt_get_bool("USE_SOCKET", false);
   int rank = chpl_get_local_rank();
   _DBG_P("numLocalesOnNode = %d", numLocalesOnNode);
   _DBG_P("expectedLocalesOnNode = %d", expectedLocalesOnNode);
   _DBG_P("rank = %d", rank);
   _DBG_P("useSocket = %d", useSocket);
-  _DBG_P("cond = %d", (numLocalesOnNode > 1) || (expectedLocalesOnNode > 1) || useSocket);
-  if ((numLocalesOnNode > 1) || (expectedLocalesOnNode > 1) || useSocket) {
-    if (numLocalesOnNode > 1) {
-      oversubscribed = true;
-    }
-
+  if (numLocalesOnNode > 1) {
+    oversubscribed = true;
+  }
+  if ((expectedLocalesOnNode > 1) || useSocket) {
     // We get our own socket if all cores are accessible, we know our local
     // rank, and the number of locales on the node is less than or equal to
     // the number of sockets. It is an error if the number of locales on the


### PR DESCRIPTION
Co-locales should only be created if either CHPL_RT_LOCALES_PER_NODE is greater than 1, or if the -nl argument specifies that there should be more than one locale per node, e.g., -nl 3x2. Previously, the runtime would implicitly assign each locale its own socket if the node had at least as many sockets as locales.

Resolves https://github.com/Cray/chapel-private/issues/5398