### PR TITLE
Have homebrew use system jemalloc and hwloc

### DIFF
--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -2,7 +2,7 @@
 import sys
 
 import chpl_locale_model, chpl_tasks, overrides, third_party_utils
-from utils import error, memoize, warning
+from utils import error, memoize, warning, try_run_command
 
 
 @memoize

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -58,10 +58,7 @@ class Chapel < Formula
     (libexec/"chplconfig").write <<~EOS
       CHPL_RE2=bundled
       CHPL_GMP=system
-      CHPL_MEM=jemalloc
-      CHPL_HOST_MEM=jemalloc
       CHPL_TARGET_JEMALLOC=system
-      CHPL_HOST_JEMALLOC=system
       CHPL_HWLOC=system
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -23,6 +23,7 @@ class Chapel < Formula
   depends_on "python@3.10"
   depends_on "cmake"
   depends_on "hwloc"
+  depends_on "jemalloc"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -22,6 +22,7 @@ class Chapel < Formula
   depends_on "llvm@14"
   depends_on "python@3.10"
   depends_on "cmake"
+  depends_on "hwloc"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"
@@ -56,6 +57,11 @@ class Chapel < Formula
     (libexec/"chplconfig").write <<~EOS
       CHPL_RE2=bundled
       CHPL_GMP=system
+      CHPL_MEM=jemalloc
+      CHPL_HOST_MEM=jemalloc
+      CHPL_TARGET_JEMALLOC=system
+      CHPL_HOST_JEMALLOC=system
+      CHPL_HWLOC=system
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none
     EOS


### PR DESCRIPTION
Our nightly testing is encountering an issue we're linking to a system version of jemalloc despite configuring Chapel to use a bundled version (ultimately resulting in unsightly linker errors):

```
Undefined symbols for architecture arm64:
  "_chpl_je_dallocx", referenced from:
      _chpl_free in chpl__module.o
      _chpl_realloc in chpl__module.o
      _chpl_mem_layerInit in libchpl.a(mem-jemalloc.o)
      _qio_readv in libchpl.a(qio.o)
      _chpl_mem_free in libchpl.a(qio.o)
      _qio_writev in libchpl.a(qio.o)
      _qio_preadv in libchpl.a(qio.o)
```

I believe this is the same issue as: https://github.com/chapel-lang/chapel/issues/18955

In order to get nightly testing back on track I think we should use the system version of jemalloc (and hwloc, which I think would run into a similar issue).