### PR TITLE
Restore bool->bool cast

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2168,6 +2168,8 @@ module ChapelBase {
            isIntegralType(t) ||
            isRealType(t);
 
+  inline operator :(x:bool, type t:bool) do
+    return __primitive("cast", t, x);
   inline operator :(x:bool, type t:integral) do
     return __primitive("cast", t, x);
   inline operator :(x:bool, type t:chpl_anyreal) do

--- a/test/arrays/cast/castArrOfBoolToBool.chpl
+++ b/test/arrays/cast/castArrOfBoolToBool.chpl
@@ -1,0 +1,3 @@
+var A = [false, true];
+var B = A: bool;
+writeln(B);

--- a/test/arrays/cast/castArrOfBoolToBool.good
+++ b/test/arrays/cast/castArrOfBoolToBool.good
@@ -1,0 +1,1 @@
+false true


### PR DESCRIPTION
This restores the bool->bool cast that I removed when removing 'bool(w)', thinking it was pointless.  It turns out that it mostly is, except that it was the only thing keeping an Arkouda '(array-of-bool):bool' cast working.

Restore it for now, though I think the more proper thing to do is to add an 'array-of-T:T' cast to handle such patterns in general.  That is, it should not be required to create a self cast in order to do a no-op cast on an array, I think.  Will pursue that question and effort separately.