### PR TITLE
Use domain and not _domain in new warning

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -216,6 +216,9 @@ const char* toString(Type* type, bool decorateAllClasses) {
       } else if (strncmp(at->symbol->name, drDomName, drDomNameLen) == 0) {
         retval = astr("domain", at->symbol->name + drDomNameLen);
 
+      } else if (startsWith(at->symbol->name, "_domain")) {
+        retval = astr(at->symbol->name + 1); // skip the leading _
+
       } else if (at->symbol->hasFlag(FLAG_FUNCTION_CLASS)) {
         retval = fcfs::functionClassTypeToString(at);
 

--- a/test/arrays/bradc/arrayOfArrayArg.bad
+++ b/test/arrays/bradc/arrayOfArrayArg.bad
@@ -1,6 +1,6 @@
 arrayOfArrayArg.chpl:5: In function 'bar':
 arrayOfArrayArg.chpl:5: error: unresolved call 'chpl__buildArrayRuntimeType(nil, type real(64))'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:453: note: this candidate did not match: chpl__buildArrayRuntimeType(dom: domain, type eltType)
+$CHPL_HOME/modules/internal/ChapelArray.chpl:223: note: this candidate did not match: chpl__buildArrayRuntimeType(dom: domain, type eltType)
 arrayOfArrayArg.chpl:5: note: because actual argument #1 with type 'nil'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:453: note: is passed to formal 'dom: _domain'
+$CHPL_HOME/modules/internal/ChapelArray.chpl:223: note: is passed to formal 'dom: domain'
   arrayOfArrayArg.chpl:1: called as bar(X: [domain(1,int(64),one)] [domain(1,int(64),one)] real(64))

--- a/test/functions/generic/generic-formal-qs.chpl
+++ b/test/functions/generic/generic-formal-qs.chpl
@@ -21,3 +21,10 @@ e(new C(int));
 
 proc f(arg: WR(R)) { }
 f(new WR(R(int)));
+
+
+proc g(arg: domain) { }
+g({1..10});
+
+proc h(arg: domain(?)) { }
+h({1..10});

--- a/test/functions/generic/generic-formal-qs.good
+++ b/test/functions/generic/generic-formal-qs.good
@@ -4,5 +4,7 @@ generic-formal-qs.chpl:22: In function 'f':
 generic-formal-qs.chpl:22: warning: need '(?)' on the type 'R' of the formal 'arg' because this type is generic
 generic-formal-qs.chpl:2: In function 'a':
 generic-formal-qs.chpl:2: warning: need '(?)' on the type 'R' of the formal 'arg' because this type is generic
+generic-formal-qs.chpl:26: In function 'g':
+generic-formal-qs.chpl:26: warning: need '(?)' on the type 'domain' of the formal 'arg' because this type is generic
 generic-formal-qs.chpl:10: In function 'c':
 generic-formal-qs.chpl:10: warning: need '(?)' on the type 'R' of the formal 'arg' because this type is generic

--- a/test/users/kreider/bug_array_of_arrays.bad
+++ b/test/users/kreider/bug_array_of_arrays.bad
@@ -1,7 +1,7 @@
 bug_array_of_arrays.chpl:24: In method 'pass_arrayofarrays':
 bug_array_of_arrays.chpl:24: error: unresolved call 'chpl__buildArrayRuntimeType(nil, type int(64))'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:460: note: this candidate did not match: chpl__buildArrayRuntimeType(dom: domain, type eltType)
+$CHPL_HOME/modules/internal/ChapelArray.chpl:223: note: this candidate did not match: chpl__buildArrayRuntimeType(dom: domain, type eltType)
 bug_array_of_arrays.chpl:24: note: because actual argument #1 with type 'nil'
-$CHPL_HOME/modules/internal/ChapelArray.chpl:460: note: is passed to formal 'dom: _domain'
+$CHPL_HOME/modules/internal/ChapelArray.chpl:223: note: is passed to formal 'dom: domain'
   bug_array_of_arrays.chpl:14: called as (tst(int(64),3)).pass_arrayofarrays(d: [domain(1,int(64),one)] [domain(1,int(64),one)] int(64)) from method 'run_test'
   bug_array_of_arrays.chpl:31: called as (tst(int(64),3)).run_test()


### PR DESCRIPTION
Follow-up to PR #23291. This PR just adjusts `toString` on a `Type*` for `_domain` to print as `domain` rather than `_domain`.

Reviewed by @vasslitvinov and @bradcray - thanks!

- [x] full comm=none testing
- [x] gasnet testing