### PR TITLE
Fix declaring a variable with an explicit generic type

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -665,7 +665,6 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
   collectCallExprs(base, calls2);
 
   for_vector(CallExpr, call, calls2) {
-    fixupExplicitGenericVariables(call);
     if (partOfNonNormalizableExpr(call->parentExpr)) continue;
     applyGetterTransform(call);
     insertCallTemps(call);
@@ -2997,6 +2996,10 @@ void normalizeVariableDefinition(DefExpr* defExpr) {
   // these might be set by out intent arguments.
   if (foundSplitInit == false && refVar)
     errorIfSplitInitializationRequired(defExpr, prevent);
+
+  if (auto callType = toCallExpr(type)) {
+    fixupExplicitGenericVariables(callType);
+  }
 
   if (requestedSplitInit && foundSplitInit == false) {
     // Create a dummy DEFAULT_INIT_VAR to sort out later in resolution

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -666,9 +666,6 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
 
   for_vector(CallExpr, call, calls2) {
     fixupExplicitGenericVariables(call);
-  }
-
-  for_vector(CallExpr, call, calls2) {
     if (partOfNonNormalizableExpr(call->parentExpr)) continue;
     applyGetterTransform(call);
     insertCallTemps(call);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4884,10 +4884,15 @@ static void fixupExplicitGenericVariables(CallExpr* call) {
   SymExpr* symExpr = nullptr;
   bool actIsQuestion = false;
   if (auto se = toSymExpr(call->baseExpr)) {
-    // for some reason this breaks with ranges, skip since they aren't a problem currently
-    if (!dtRange || se->symbol() != dtRange->symbol) {
-      symExpr = se;
+
+    // only perform this transformation if the generic has no defaults
+    //   this is a workaround for something like `range`, which is generic with
+    //   defaults and which this normalization breaks
+    bool genericWithDefaults = false;
+    if (AggregateType* at = toAggregateType(se->symbol()->type)) {
+      genericWithDefaults = at->isGenericWithDefaults();
     }
+    if (!genericWithDefaults) symExpr = se;
   }
   if (call->numActuals() == 1) {
     if (auto se = toSymExpr(call->get(1))) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -4885,7 +4885,7 @@ static void fixupExplicitGenericVariables(CallExpr* call) {
   bool actIsQuestion = false;
   if (auto se = toSymExpr(call->baseExpr)) {
     // for some reason this breaks with ranges, skip since they aren't a problem currently
-    if (se->symbol() != dtRange->symbol) {
+    if (!dtRange || se->symbol() != dtRange->symbol) {
       symExpr = se;
     }
   }

--- a/test/types/records/generic/generic-with-defaults-q-problem.bad
+++ b/test/types/records/generic/generic-with-defaults-q-problem.bad
@@ -1,4 +1,8 @@
-generic-with-defaults-q-problem.chpl:11: error: unresolved call 'K.init(GRD(int(64)))'
-generic-with-defaults-q-problem.chpl:5: note: this candidate did not match: K.init(myfield: GRD)
-generic-with-defaults-q-problem.chpl:11: note: because actual argument #1 with type 'GRD(int(64))'
-generic-with-defaults-q-problem.chpl:6: note: is passed to formal 'in myfield: GRD'
+generic-with-defaults-q-problem.chpl:11: internal error: RES-FUN-ION-2764 chpl version 1.32.0 pre-release (9228b511ca)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler,
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/types/records/generic/generic-with-defaults-q-problem.bad
+++ b/test/types/records/generic/generic-with-defaults-q-problem.bad
@@ -1,8 +1,4 @@
-generic-with-defaults-q-problem.chpl:11: internal error: RES-FUN-ION-2764 chpl version 1.32.0 pre-release (9228b511ca)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler,
-and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+generic-with-defaults-q-problem.chpl:11: error: unresolved call 'K.init(GRD(int(64)))'
+generic-with-defaults-q-problem.chpl:5: note: this candidate did not match: K.init(myfield: GRD)
+generic-with-defaults-q-problem.chpl:11: note: because actual argument #1 with type 'GRD(int(64))'
+generic-with-defaults-q-problem.chpl:6: note: is passed to formal 'in myfield: GRD'

--- a/test/types/type_variables/ferguson/notGenericQ-var.good
+++ b/test/types/type_variables/ferguson/notGenericQ-var.good
@@ -1,3 +1,1 @@
-notGenericQ-var.chpl:4: error: invalid type specifier 'R(?)'
-notGenericQ-var.chpl:1: note: type 'R' is not generic
-notGenericQ-var.chpl:4: note: did you forget the 'new' keyword?
+notGenericQ-var.chpl:4: error: the variable x is marked generic with (?) but the type 'R' is not generic

--- a/test/variables/declareVariableGenericType.chpl
+++ b/test/variables/declareVariableGenericType.chpl
@@ -1,0 +1,5 @@
+var d1: domain = {1..34};
+writeln(d1);
+
+var d2: domain(?) = {1..34};
+writeln(d2);

--- a/test/variables/declareVariableGenericType.good
+++ b/test/variables/declareVariableGenericType.good
@@ -1,0 +1,3 @@
+declareVariableGenericType.chpl:1: warning: please use 'domain(?)' for the type of a generic variable storing any domain
+{1..34}
+{1..34}


### PR DESCRIPTION
Fixes declaring a variable with an explicit generic type, like `var d: domain(?) = {1..34};`. Prior to this PR, this would result in a seg fault when trying to resolve the runtime type. This seems to be due to a difference in how `domain` and `domain(?)` are handled in normalization. This PR normalizes `domain(?)` into `domain` with the flag `MARKED_GENERIC`.

Tested with paratest with futures and paratest with gasnet.

[Reviewed by @mppf]

Resolves https://github.com/chapel-lang/chapel/issues/23357