### PR TITLE
Deprecate array->string cast

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2210,6 +2210,7 @@ module ChapelArray {
 
   // How to cast arrays to strings
   @chpldoc.nodoc
+  @deprecated(notes="casting arrays to string is deprecated; please use 'try! \"%?\".format()' from IO.FormattedIO instead")
   operator :(x: [], type t:string) {
     import IO.FormattedIO.string;
     return try! "%?".format(x);

--- a/test/deprecated/IO/array-string-cast.chpl
+++ b/test/deprecated/IO/array-string-cast.chpl
@@ -1,0 +1,2 @@
+const x: [1..10] int;
+writeln(x:string);

--- a/test/deprecated/IO/array-string-cast.good
+++ b/test/deprecated/IO/array-string-cast.good
@@ -1,0 +1,2 @@
+array-string-cast.chpl:2: warning: casting arrays to string is deprecated; please use 'try! "%?".format()' from IO.FormattedIO instead
+0 0 0 0 0 0 0 0 0 0


### PR DESCRIPTION
Deprecate casting arrays to string. This is a continuation of the deprecation of the universal string cast from [this PR](https://github.com/chapel-lang/chapel/pull/22068).

This deprecation recommends replacing:
```chapel
var s = myArray: string;
```
with:
```chapel
var s = "%?".format(myArray);
```

See https://github.com/chapel-lang/chapel/issues/19893 for more context.

- [ ] paratest