### PR TITLE
Add `skipif` for failing test in non-llvm configuration

### DIFF
--- a/test/unstable/packageModules.skipif
+++ b/test/unstable/packageModules.skipif
@@ -1,0 +1,3 @@
+// AtomicObjects fails with non-llvm
+CHPL_LLVM==none
+CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
Fixes an issue in nightly testing from #23340. `test/unstable/packageModules.chpl` fails if the compiler is not `llvm` or if `chpl` is compiled with `CHPL_LLVM=none`.

Tested locally

[Reviewed by @dlongnecke-cray]