### PR TITLE
Followups for CHAMPS nightly script adjustments

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -87,7 +87,7 @@ function test_run() {
   local nl=$2
 
   test_start "run $kind"
-  $CHPL_HOME/util/test/chpl_launchcmd.py ./bin/champs_${CHAMPS_VERSION}_$kind -nl $nl -f $CHAMPS_CFG_PATH/$kind.in 2>&1 >$kind.exec.out.tmp
+  $CHPL_TEST_LAUNCHCMD ./bin/champs_${CHAMPS_VERSION}_$kind -nl $nl -f $CHAMPS_CFG_PATH/$kind.in 2>&1 >$kind.exec.out.tmp
 
   local status=$?
   cat $kind.exec.out.tmp

--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -12,20 +12,35 @@ pushd $CHAMPS_COMMON_DIR
 git pull
 popd
 
-module unload PrgEnv-cray
-
+echo Enabling Cray PE
 source $CRAY_ENABLE_PE
 
 # All CHAMPS testing is currently on a hpe-apollo
+
+echo Initial list of modules:
 module list
 
-source $CWD/common-hpe-apollo.bash
+module purge
+
 source $CWD/common-perf-hpe-apollo-hdr.bash
+
+module list
 
 module load PrgEnv-gnu
 module load cray-pmi
 module load cray-mpich
 module load cray-hdf5-parallel
+
+module list
+
+# note that this part is similar to common-hpe-apollo.bash, but
+# we don't want the module operations in there, nor we can source it
+# earlier. Because if we source load-chpl-deps.bash early, we can't
+# load PrgEnv-gnu
+export CHPL_HOST_PLATFORM=hpe-apollo
+export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
+export CHPL_LAUNCHER_TIMEOUT=pbs
+source $CWD/load-base-deps.bash
 
 module list
 

--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -12,6 +12,8 @@ pushd $CHAMPS_COMMON_DIR
 git pull
 popd
 
+module unload PrgEnv-cray
+
 source $CRAY_ENABLE_PE
 
 # All CHAMPS testing is currently on a hpe-apollo
@@ -20,7 +22,6 @@ module list
 source $CWD/common-hpe-apollo.bash
 source $CWD/common-perf-hpe-apollo-hdr.bash
 
-module unload PrgEnv-cray
 module load PrgEnv-gnu
 module load cray-pmi
 module load cray-mpich

--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -20,6 +20,7 @@ module list
 source $CWD/common-hpe-apollo.bash
 source $CWD/common-perf-hpe-apollo-hdr.bash
 
+module unload PrgEnv-cray
 module load PrgEnv-gnu
 module load cray-pmi
 module load cray-mpich


### PR DESCRIPTION
Follow up from https://github.com/chapel-lang/chapel/pull/23376

For some reason sourcing `common-hpe-apollo` wasn't allowing me to load `PrgEnv-gnu` later on. Could be because it loads `gcc` itself? This PR removes sourcing that, instead does the same stuff in different order.

While there, it also uses `CHPL_TEST_LAUNCHCMD` while running executables.