### PR TITLE
Fix comment in skipif for `test/unstable/packageModules`

### DIFF
--- a/test/unstable/packageModules.skipif
+++ b/test/unstable/packageModules.skipif
@@ -1,3 +1,3 @@
-// AtomicObjects fails with non-llvm
+# AtomicObjects fails with non-llvm
 CHPL_LLVM==none
 CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
Fixes the wrong kind of comment used in a `skipif` file. Added in #23383

[Reviewed by @lydia-duncan]