### PR TITLE
Remove deprecated flag -- presumably overlooked in #23384?

### DIFF
--- a/test/library/standard/BigInteger/nestedOn.compopts
+++ b/test/library/standard/BigInteger/nestedOn.compopts
@@ -1,1 +1,1 @@
---remote-value-forwarding -sbigintInitThrows=true
+--remote-value-forwarding


### PR DESCRIPTION
[suggested by @jabraham17 ; @lydia-duncan should give this a post-merge review]

Ran into this while testing `main` and branches made from it today.