### PR TITLE
Skip dependency checking in Arkouda tests

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -25,6 +25,10 @@ fi
 export CHPL_NIGHTLY_TEST_DIRS=studies/arkouda/
 export CHPL_TEST_ARKOUDA=true
 
+# Removing regex.compile caused smoke test failures. As a stopgap measure we are
+# skipping dependency check.
+export ARKOUDA_SKIP_CHECK_DEPS=1
+
 ARKOUDA_DEP_DIR=$COMMON_DIR/arkouda-deps
 if [ -d "$ARKOUDA_DEP_DIR" ]; then
   export ARKOUDA_ARROW_PATH=${ARKOUDA_ARROW_PATH:-$ARKOUDA_DEP_DIR/arrow-install}


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/23395 removed the deprecated `regex.compile`. But that caused failures in dependency checking in Arkouda testing. To avoid failures, this PR avoids that dependency checking. We should update Arkouda to use regex initializers and/or use a compatibility module as the ideal solution.