### PR TITLE
Fix performance test failure

### DIFF
--- a/test/npb/ft/npadmana/DistributedFFT.chpl
+++ b/test/npb/ft/npadmana/DistributedFFT.chpl
@@ -360,10 +360,12 @@ prototype module DistributedFFT {
   */
   proc copy(ref dst, const ref src, numBytes: int) {
     use Communication;
+    const dstLocaleId = dst.locale.id;
+    const srcLocaleId = src.locale.id;
     if dst.locale.id == here.id {
-      get(c_ptrTo(dst), c_ptrToConst(src), src.locale.id, numBytes.safeCast(c_size_t));
+      get(c_ptrTo(dst), c_ptrToConst(src), srcLocaleId, numBytes.safeCast(c_size_t));
     } else if src.locale.id == here.id {
-      put(c_ptrTo(dst), c_ptrToConst(src), dst.locale.id, numBytes.safeCast(c_size_t));
+      put(c_ptrTo(dst), c_ptrToConst(src), dstLocaleId, numBytes.safeCast(c_size_t));
     } else {
       halt("Remote src and remote dst not yet supported");
     }


### PR DESCRIPTION
This PR makes minor changes to a performance test. In https://github.com/chapel-lang/chapel/pull/23275 I updated the test to use the `Communication` module instead of calling primitive `get`/`put` routines directly. This caused a failure in the test. After investigating, the suspicion is that there is a bug in code generation that causes the locale numbers to be reset in the generated code. 

The workaround I implemented is to capture the locale numbers in their own variables ahead of the call to the `get`/`put` routines. 

TESTING:

- [x] broken test now runs on Horizon

[test change only - not reviewed]