### PR TITLE
Fix links to dimensionalDist2D in per-dimension modules

### DIFF
--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -42,10 +42,10 @@ type bcdPosInt = int;
 //
 /*
 This Block-Cyclic dimension specifier is for use with the
-``dimensionalDist2D`` distribution.
+:record:`~DimensionalDist2D.dimensionalDist2D` distribution.
 
 It specifies the mapping of indices in its dimension
-that would be produced by a 1D :class:`~BlockCycDist.blockCycDist` distribution.
+that would be produced by a 1D :record:`~BlockCycDist.blockCycDist` distribution.
 
 **Initializer Arguments**
 
@@ -66,7 +66,7 @@ The arguments are as follows:
       to be distributed over
   ``lowIdx``, ``blockSize``
       are the counterparts to ``startIdx`` and ``blocksize``
-      in the :class:`~BlockCycDist.blockCycDist` distribution
+      in the :record:`~BlockCycDist.blockCycDist` distribution
   ``cycleSizePos``
       is used internally by the implementation and
       should not be specified by the user code

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -27,10 +27,10 @@ private use DimensionalDist2D;
 
 /*
 This Block dimension specifier is for use with the
-``dimensionalDist2D`` distribution.
+:record:`~DimensionalDist2D.dimensionalDist2D` distribution.
 
 It specifies the mapping of indices in its dimension
-that would be produced by a 1D :class:`~BlockDist.blockDist` distribution.
+that would be produced by a 1D :record:`~BlockDist.blockDist` distribution.
 
 **Initializer Arguments**
 
@@ -58,7 +58,7 @@ which specifies the bounding box in this dimension.
 
 The ``idxType``, whether provided or inferred, must match
 the index type of the domains "dmapped" using the corresponding
-``dimensionalDist2D`` distribution.
+:record:`~DimensionalDist2D.dimensionalDist2D` distribution.
 */
 record BlockDim {
   // the type of bbStart, bbLength

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -30,12 +30,12 @@ import RangeChunk;
 
 /*
 This Replicated dimension specifier is for use with the
-``dimensionalDist2D`` distribution.
+:record:`~DimensionalDist2D.dimensionalDist2D` distribution.
 
 The dimension of a domain or array for which this specifier is used
 has a *replicand* for each element of ``targetLocales``
-in the same dimension. This is similar to the Replicated distribution
-(``Replicated``). The dimension specifies differs
+in the same dimension. This is similar to :record:`~ReplicatedDist.replicatedDist`.
+The dimension specifies differs
 in that it always accesses the local replicand, whereas the Replicated
 distribution accesses all replicands in certain cases, as specified there.
 


### PR DESCRIPTION
Fixes the links to `dimensionalDist2D` from the per-dimension modules (`BlockDim`, `BlockCycDim`, `ReplicatedDim`).

The links stopped working as a side-effect of #23403. Prior to this, the links actually went to the module. But changing the names of the now record meant that the links stopped working. Making the links `` :record:`~DimensionalDist2D.dimensionalDist2D` `` fixes this.

While there, cleaned up some of the other links in these modules.

Tested docs locally

[Reviewed by @]