### PR TITLE
Make a prediff more portable

### DIFF
--- a/test/unstable/packageModules.prediff
+++ b/test/unstable/packageModules.prediff
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed "s/packageModules.chpl:[[:digit:]]\+:/packageModules.chpl:XX:/" $2 > $2.prediffed
+sed "s/packageModules.chpl:[0-9]*:/packageModules.chpl:XX:/" $2 > $2.prediffed
 mv $2.prediffed $2


### PR DESCRIPTION
This prediff was added as part of https://github.com/chapel-lang/chapel/pull/23395. It was not running fine on darwin. This PR adjusts that.

Tested on linux and darwin.