### PR TITLE
Docs warning about default initialization of high/low bounded ranges being unstable

### DIFF
--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -378,6 +378,11 @@ the type’s ``bounds`` parameter as follows:
    ``high``-bounded range (or visa versa) produces an empty range,
    matching the default value for a ``both``-bounded range
 
+.. warning::
+
+   Default initialization of ranges with ``boundKind.low`` or
+   ``boundKind.high`` is unstable.
+
 Default values of ranges with boolean ``idxType`` are similar, but
 substituting ``false`` and ``true`` for 0 and 1 above.  Ranges with
 ``enum`` ``idxType`` use the 0th and 1st values in the enumeration in


### PR DESCRIPTION
Update the range spec with a warning to reflect the change made in: https://github.com/chapel-lang/chapel/pull/23299.

- [x] inspected built docs