### PR TITLE
Remove extra line from skipif

### DIFF
--- a/test/unstable/packageModules.skipif
+++ b/test/unstable/packageModules.skipif
@@ -1,3 +1,2 @@
 # AtomicObjects fails with non-llvm
 CHPL_LLVM==none
-CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
Removes extra line from a skipif file that is not needed

[Reviewed by @bradcray]