### PR TITLE
Fix links from per-dimension distributions back to DimensionalDist2D

### DIFF
--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -42,7 +42,7 @@ type bcdPosInt = int;
 //
 /*
 This Block-Cyclic dimension specifier is for use with the
-``dimensionalDist2D`` distribution.
+:mod:`dimensionalDist2D <DimensionalDist2D>` distribution.
 
 It specifies the mapping of indices in its dimension
 that would be produced by a 1D :class:`~BlockCycDist.blockCycDist` distribution.

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -27,7 +27,8 @@ private use DimensionalDist2D;
 
 /*
 This Block dimension specifier is for use with the
-``dimensionalDist2D`` distribution.
+:mod:`dimensionalDist2D <DimensionalDist2D>` distribution.
+:mod:`DimensionalDist2D` distribution.
 
 It specifies the mapping of indices in its dimension
 that would be produced by a 1D :class:`~BlockDist.blockDist` distribution.

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -28,7 +28,6 @@ private use DimensionalDist2D;
 /*
 This Block dimension specifier is for use with the
 :mod:`dimensionalDist2D <DimensionalDist2D>` distribution.
-:mod:`DimensionalDist2D` distribution.
 
 It specifies the mapping of indices in its dimension
 that would be produced by a 1D :class:`~BlockDist.blockDist` distribution.

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -30,7 +30,7 @@ import RangeChunk;
 
 /*
 This Replicated dimension specifier is for use with the
-``dimensionalDist2D`` distribution.
+:mod:`dimensionalDist2D <DimensionalDist2D>` distribution.
 
 The dimension of a domain or array for which this specifier is used
 has a *replicand* for each element of ``targetLocales``


### PR DESCRIPTION
I couldn't figure out why these weren't working last night but Jade solved it this morning: Because chpldoc ignores the type of symbol field (e.g., ':class:'), we'd been linking to the module rather than the type in question, and I couldn't link to the type without providing a module path.

After implementing that fix and looking at the resulting docs, I decided that linking to the module itself is the better thing to do since (a) the type's the first/only thing in the module and (b) linking to the type causes things like the instability warning to scroll off the screen.  So here, I kept the link to the module, fixed the white lie that we were relying on before last night's change, and renamed the link to still name the distribution.