### PR TITLE
Homebrew formula: use cstdlib and fifo tasks

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -22,8 +22,6 @@ class Chapel < Formula
   depends_on "llvm@14"
   depends_on "python@3.10"
   depends_on "cmake"
-  depends_on "hwloc"
-  depends_on "jemalloc"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -58,8 +58,8 @@ class Chapel < Formula
     (libexec/"chplconfig").write <<~EOS
       CHPL_RE2=bundled
       CHPL_GMP=system
-      CHPL_TARGET_JEMALLOC=system
-      CHPL_HWLOC=system
+      CHPL_MEM=cstdlib
+      CHPL_TASKS=fifo
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none
     EOS


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/23366, I updated the Homebrew formula to use system versions of jemalloc and hwloc.

Unfortunately, this change runs into issues. Some of which may be fixed later by this PR (https://github.com/chapel-lang/chapel/pull/23409#issuecomment-1721704578).

And also this issue about the bundled jemalloc makefile being run and failing despite the fact that we're supposed to be using the system one https://github.com/chapel-lang/chapel/pull/23409#issuecomment-1721704578).

Given all this and how close we are to the release, we decided to have the formula use cstdlib for memory management instead.