### PR TITLE
Exclude the language server from the make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,11 +352,9 @@ add_subdirectory(tools/chpldoc)
 # We are not ready to include 'chpldef' in an official release just yet. This
 # check works because the 'chpldef' source files are currently not included
 # in source releases.
-# message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
-# message(STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tools/chpldef)
-  message(STATUS "Added chpldef subdirectory...")
-  add_subdirectory(tools/chpldef)
+  # Exclude the language server from being included in 'make all'.
+  add_subdirectory(tools/chpldef EXCLUDE_FROM_ALL)
 endif()
 
 # Adjust the install rpath for chpl and chpldoc


### PR DESCRIPTION
This PR prevents the nightly 'make-install-check' job from trying to
build and install the language server.

Unless `EXCLUDE_FROM_ALL` is thrown when adding the language server
to the CMakeLists.txt, the `make install` command will always
attempt to build and install the language server (which currently
fails on `linux64` due to an oversight on my part).

Reviewed by @arezaii. Thanks!