### PR TITLE
Fix bug with hasFirst, hasLast, and isEmpty

### DIFF
--- a/test/unstable/rangeUnboundedEnumBoolFirstLast.chpl
+++ b/test/unstable/rangeUnboundedEnumBoolFirstLast.chpl
@@ -9,11 +9,22 @@ proc toAny(r) do return r: range(r.idxType, r.bounds, strideKind.any);
 inline proc testRange(r){
   // Test first last of the range
   // Also test the same range when the stride is not known at compile time
-  writeln(r.first);
-  writeln(r.last);
+  writeln(r);
+  writeln("Has First ", r.hasFirst());
+  writeln("Has Last ", r.hasLast());
+  writeln("Is empty: ", r.isEmpty());
+  if !r.isEmpty() {
+    writeln("First ", r.first);
+    writeln("Last ", r.last);
+  }
   var rAny = toAny(r);
-  writeln(rAny.first);
-  writeln(rAny.last);
+  writeln("Any Has First ", rAny.hasFirst());
+  writeln("Any Has Last ", rAny.hasLast());
+  writeln("Any Is empty: ", rAny.isEmpty());
+  if !r.isEmpty() {
+    writeln("Any First ", rAny.first);
+    writeln("Any Last ", rAny.last);
+  }
 }
 
 var rgb = red..blue;
@@ -28,6 +39,10 @@ var rdd2 = rdd by 2;
 var negrdd2 = rdd by -2;
 var ddb2 = ddb by 2;
 var negddb2 = ddb by -2;
+var bdd2ag = blue.. by 2 align green;
+var ddr2ag = ..red by 2 align green;
+var ddg2ab = ..green by 2 align blue;
+var ddg3ab = ..green by 3 align blue;
 
 testRange(rgb);
 testRange(rdd);
@@ -41,6 +56,11 @@ testRange(rdd2);
 testRange(negrdd2);
 testRange(ddb2);
 testRange(negddb2);
+testRange(bdd2ag);
+testRange(ddr2ag);
+testRange(ddg2ab);
+testRange(ddg3ab);
+
 
 {
 var ft = false..true;
@@ -55,6 +75,8 @@ var fdd2 = fdd by 2;
 var negfdd2 = fdd by -2;
 var ddt2 = ddt by 2;
 var negddt2 = ddt by -2;
+var tdd2af = true .. by 2 align false;
+var ddf2at = ..false by 2 align true;
 
 
 testRange(ft);
@@ -69,5 +91,6 @@ testRange(fdd2);
 testRange(negfdd2);
 testRange(ddt2);
 testRange(negddt2);
-
+testRange(tdd2af);
+testRange(ddf2at);
 }

--- a/test/unstable/rangeUnboundedEnumBoolFirstLast.good
+++ b/test/unstable/rangeUnboundedEnumBoolFirstLast.good
@@ -1,184 +1,533 @@
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:33: called as testRange(r: range(color,low,one))
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:48: called as testRange(r: range(color,low,one))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:34: called as testRange(r: range(color,high,one))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:49: called as testRange(r: range(color,high,one))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:35: called as testRange(r: range(color,neither,one))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:50: called as testRange(r: range(color,neither,one))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:37: called as testRange(r: range(color,low,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:52: called as testRange(r: range(color,low,negOne))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:38: called as testRange(r: range(color,high,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:53: called as testRange(r: range(color,high,negOne))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:39: called as testRange(r: range(color,neither,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:54: called as testRange(r: range(color,neither,negOne))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:40: called as testRange(r: range(color,low,positive))
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:55: called as testRange(r: range(color,low,positive))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:41: called as testRange(r: range(color,low,negative))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:56: called as testRange(r: range(color,low,negative))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:42: called as testRange(r: range(color,high,positive))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:57: called as testRange(r: range(color,high,positive))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:43: called as testRange(r: range(color,high,negative))
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:58: called as testRange(r: range(color,high,negative))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:61: called as testRange(r: range(bool,low,one))
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:83: called as testRange(r: range(bool,low,one))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:62: called as testRange(r: range(bool,high,one))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:84: called as testRange(r: range(bool,high,one))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:63: called as testRange(r: range(bool,neither,one))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:85: called as testRange(r: range(bool,neither,one))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:65: called as testRange(r: range(bool,low,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:87: called as testRange(r: range(bool,low,negOne))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:66: called as testRange(r: range(bool,high,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:88: called as testRange(r: range(bool,high,negOne))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:67: called as testRange(r: range(bool,neither,negOne))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:89: called as testRange(r: range(bool,neither,negOne))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:68: called as testRange(r: range(bool,low,positive))
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:90: called as testRange(r: range(bool,low,positive))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-  rangeUnboundedEnumBoolFirstLast.chpl:69: called as testRange(r: range(bool,low,negative))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:91: called as testRange(r: range(bool,low,negative))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:12: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:70: called as testRange(r: range(bool,high,positive))
+rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:17: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:92: called as testRange(r: range(bool,high,positive))
 rangeUnboundedEnumBoolFirstLast.chpl:9: In function 'testRange':
-rangeUnboundedEnumBoolFirstLast.chpl:13: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-  rangeUnboundedEnumBoolFirstLast.chpl:71: called as testRange(r: range(bool,high,negative))
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-blue
-red
-red
-blue
-red
-blue
-blue
-red
-blue
-red
-red
-blue
-red
-blue
-blue
-red
-blue
-red
-false
-true
-false
-true
-false
-true
-false
-true
-false
-true
-false
-true
-false
-true
-false
-true
-true
-false
-true
-false
-true
-false
-true
-false
-true
-false
-true
-false
-true
-false
-true
-false
-false
-false
-false
-false
-true
-true
-true
-true
-false
-false
-false
-false
-true
-true
-true
-true
-rangeUnboundedEnumBoolFirstLast.chpl:33: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:34: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:35: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:35: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:37: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:38: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:39: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:39: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:40: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:41: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:42: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:43: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:61: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:62: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:63: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:63: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:65: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:66: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:67: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:67: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:68: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:69: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
-rangeUnboundedEnumBoolFirstLast.chpl:70: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
-rangeUnboundedEnumBoolFirstLast.chpl:71: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:14: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:15: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:16: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:18: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:23: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+rangeUnboundedEnumBoolFirstLast.chpl:24: warning: range.isEmpty() is unstable for unbounded ranged over an enum or bool
+  rangeUnboundedEnumBoolFirstLast.chpl:93: called as testRange(r: range(bool,high,negative))
+red..blue
+Has First true
+Has Last true
+Is empty: false
+First red
+Last blue
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First red
+Any Last blue
+red..
+Has First true
+Has Last true
+Is empty: false
+First red
+Last blue
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First red
+Any Last blue
+..blue
+Has First true
+Has Last true
+Is empty: false
+First red
+Last blue
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First red
+Any Last blue
+..
+Has First true
+Has Last true
+Is empty: false
+First red
+Last blue
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First red
+Any Last blue
+red..blue by -1
+Has First true
+Has Last true
+Is empty: false
+First blue
+Last red
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First blue
+Any Last red
+red.. by -1
+Has First true
+Has Last true
+Is empty: false
+First blue
+Last red
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First blue
+Any Last red
+..blue by -1
+Has First true
+Has Last true
+Is empty: false
+First blue
+Last red
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First blue
+Any Last red
+.. by -1
+Has First true
+Has Last true
+Is empty: false
+First blue
+Last red
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First blue
+Any Last red
+red.. by 2
+Has First true
+Has Last true
+Is empty: false
+First red
+Last blue
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First red
+Any Last blue
+red.. by -2 align red
+Has First true
+Has Last true
+Is empty: false
+First blue
+Last red
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First blue
+Any Last red
+..blue by 2 align red
+Has First true
+Has Last true
+Is empty: false
+First red
+Last blue
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First red
+Any Last blue
+..blue by -2
+Has First true
+Has Last true
+Is empty: false
+First blue
+Last red
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First blue
+Any Last red
+blue.. by 2 align green
+Has First false
+Has Last false
+Is empty: true
+Any Has First false
+Any Has Last false
+Any Is empty: true
+..red by 2 align green
+Has First false
+Has Last false
+Is empty: true
+Any Has First false
+Any Has Last false
+Any Is empty: true
+..green by 2 align red
+Has First true
+Has Last true
+Is empty: false
+First red
+Last red
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First red
+Any Last red
+..green by 3 align blue
+Has First false
+Has Last false
+Is empty: true
+Any Has First false
+Any Has Last false
+Any Is empty: true
+false..true
+Has First true
+Has Last true
+Is empty: false
+First false
+Last true
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First false
+Any Last true
+false..
+Has First true
+Has Last true
+Is empty: false
+First false
+Last true
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First false
+Any Last true
+..true
+Has First true
+Has Last true
+Is empty: false
+First false
+Last true
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First false
+Any Last true
+..
+Has First true
+Has Last true
+Is empty: false
+First false
+Last true
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First false
+Any Last true
+false..true by -1
+Has First true
+Has Last true
+Is empty: false
+First true
+Last false
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First true
+Any Last false
+false.. by -1
+Has First true
+Has Last true
+Is empty: false
+First true
+Last false
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First true
+Any Last false
+..true by -1
+Has First true
+Has Last true
+Is empty: false
+First true
+Last false
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First true
+Any Last false
+.. by -1
+Has First true
+Has Last true
+Is empty: false
+First true
+Last false
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First true
+Any Last false
+false.. by 2
+Has First true
+Has Last true
+Is empty: false
+First false
+Last false
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First false
+Any Last false
+false.. by -2 align true
+Has First true
+Has Last true
+Is empty: false
+First true
+Last true
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First true
+Any Last true
+..true by 2 align false
+Has First true
+Has Last true
+Is empty: false
+First false
+Last false
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First false
+Any Last false
+..true by -2
+Has First true
+Has Last true
+Is empty: false
+First true
+Last true
+Any Has First true
+Any Has Last true
+Any Is empty: false
+Any First true
+Any Last true
+true.. by 2 align false
+Has First false
+Has Last false
+Is empty: true
+Any Has First false
+Any Has Last false
+Any Is empty: true
+..false by 2 align true
+Has First false
+Has Last false
+Is empty: true
+Any Has First false
+Any Has Last false
+Any Is empty: true
+rangeUnboundedEnumBoolFirstLast.chpl:48: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:48: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:49: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:49: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:50: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:50: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:50: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:50: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:52: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:52: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:53: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:53: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:54: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:54: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:54: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:54: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:55: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:55: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:56: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:56: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:57: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:57: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:58: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:58: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:59: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:60: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:61: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:61: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:62: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:83: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:83: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:84: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:84: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:85: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:85: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:85: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:85: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:87: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:87: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:88: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:88: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:89: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:89: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:89: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:89: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:90: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:90: warning: range.last is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:91: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:91: warning: range.first is unstable for a range over an enum or bool if it has a negative stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:92: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:92: warning: range.first is unstable for a range over an enum or bool if it has a positive stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:93: warning: range.hasLast() is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:93: warning: range.last is unstable for a range over an enum or bool if it has a negative stride and no low bound
+rangeUnboundedEnumBoolFirstLast.chpl:94: warning: range.hasLast() is unstable for a range over an enum or bool if it has a positive stride and no high bound
+rangeUnboundedEnumBoolFirstLast.chpl:95: warning: range.hasFirst() is unstable for a range over an enum or bool if it has a positive stride and no low bound


### PR DESCRIPTION
These functions on ranges had behavior inconsistent with `range.first` and `range.last` for unbounded ranges over `enum`s/`bool`s We marked `range.first` and `range.last` as unstable over ranges over `enum`s/`bool`s and that side of the range is unbounded. This is because our current working theory is to treat ranges over `enum`s/`bool`s as always representing a bounded range since the types are finite. based on this `hasFirst()`, `hasLast()`, and `isEmpty()` should also be unstable in those cases and follow the correct behavior.

I also replaced internal use of `hasFirst()` with `hasFirstForIter()` and similarly for `hasLast()` with `hasLastForIter()`

Since I marked `hasFirst()` and `hasLast()` as unstable using `compilerWarning`s,
these warnings were causing test failures when the functions were called
internally. And the behavior was also changed the match `range.first` and
`range.last`, which was also causing test failures `hasFirst()` and `hasLast()` no longer imply that a range is bounded.

So I replaced these with their old versions without behavior changes and without warnings under a new name `ForIter`

Here are the cases where we warn for each of the functions:
Given `enum color {red, green, blue};` 

| Case | `hasFirst()` / `first` | `hasLast()` / `last` | `isEmpty()` |
| --- | --- | --- | --- | 
| `red..` |   stable  | unstable  | unstable |
| `..blue` |   unstable | stable | unstable |
| `..` |   unstable | unstable | unstable |
| `red.. by -1` |   unstable | stable | unstable |
| `..blue by -1` |   stable | unstable | unstable |
| `blue.. by 2 align green` |   stable | unstable | unstable |
| `..red by 2 align green` |   unstable | stable | unstable |
| `..green by 2 align blue` |   unstable | stable | unstable |
