### PR TITLE
Fix typos

### DIFF
--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -1376,7 +1376,7 @@ void loopInvariantCodeMotion(void) {
   //
   // Any manipulations on the AST that removes a symbol within a function may
   // invalidate the 'no alias set' primitives (that this transforms adds to the
-  // top of functions). GpuTransfroms is one such transform that does AST
+  // top of functions). GpuTransforms is one such transform that does AST
   // manipulations, so we run computeNoAliasSets after GPUTransforms.
   computeNoAliasSets();
 }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1925,7 +1925,7 @@ static void fixupGenericReturnTypes(FnSymbol* fn) {
     // handle nested cases, e.g. (GenericRecord(?), ) or borrowed GenCls(?)
     propagateMarkedGeneric(fn, fn->retExprType);
 
-    // simpify the simple case
+    // simplify the simple case
     Expr*     tail   = fn->retExprType->body.tail;
     if (CallExpr* call = toCallExpr(tail)) {
       if (call->numActuals() == 1) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -14025,7 +14025,7 @@ void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
       }
 
 
-      // supress the warning for builtin types like
+      // suppress the warning for builtin types like
       // 'integral', 'record', 'borrowed'.
       if (isBuiltinGenericType(declType)) {
         return;
@@ -14037,7 +14037,7 @@ void checkSurprisingGenericDecls(Symbol* sym, Expr* typeExpr,
         return;
 
 
-      // supress the warning for fields within owned/shared
+      // suppress the warning for fields within owned/shared
       // themselves (better to see the warning at uses of owned/shared
       // that create generic owned/shared).
       if (TypeSymbol* ts = toTypeSymbol(sym->defPoint->parentSymbol))

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -1694,7 +1694,7 @@ static void warnForImproperAutomaticImplements(InterfaceSymbol* isym,
         if (!fnWitness->hasFlag(FLAG_COMPILER_GENERATED)) {
           istm->iConstraint->entirelyGenerated = false;
 
-          // If we're speciulating, don't issue the warning.
+          // If we're speculating, don't issue the warning.
           if (tryingToResolve() || tryingToImplementInterface()) continue;
 
           USR_WARN(fnWitness, "automatically implementing interface %s for"

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1025,7 +1025,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
         // implicit interface using user-provided witnesses: bad.
         val = 2;
       } else if (cs.istm->iConstraint->shouldBeGeneratedOnly) {
-        // impliit interface using compiler-provided witnesses; fine.
+        // implicit interface using compiler-provided witnesses; fine.
         val = 1;
       } else {
         // explicit interface.

--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -812,7 +812,7 @@ with the same shape.
 Array Arguments to Functions
 ----------------------------
 
-By default, arrays are passed to function by ``const``, see :ref:`The_Default_Intent`.
+By default, arrays are passed to functions by ``const``, see :ref:`The_Default_Intent`.
 Using the ``ref`` intent allows modification of the array without creating a copy.
 The ``in``, ``inout``, and ``out`` intent can create copies of arrays.
 

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -443,7 +443,7 @@ How should programmers choose among these intents?
  * The ``in`` and ``const in`` intents pass by value and are important
    for transferring a value in to a function, for example, when storing a
    value into a data structure. Using these intents for that use case can
-   help to avoid unnecesary copies.
+   help to avoid unnecessary copies.
 
  * The ``ref`` and ``const ref`` intents pass by reference. The ``ref``
    intent allows modifications of the referred-to value within the

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -436,7 +436,7 @@ Examining Generated Assembly
 While analyzing performance, users might also wish to look at the assembly
 ``chpl`` generates for GPU kernels. To do this pass ``chpl`` ``--savec
 <dirName>`` (replacing ``<dirname>`` with a directory name to contain the
-generate assemly). The Chapel compiler will emit a file ``chpl__gpu.s``, which
+generate assembly). The Chapel compiler will emit a file ``chpl__gpu.s``, which
 contains AMD GCN or NVIDIA PTX instructions as appropriate.
 
 In the generated assembly, kernels are named

--- a/frontend/include/chpl/types/BoolType.h
+++ b/frontend/include/chpl/types/BoolType.h
@@ -58,7 +58,7 @@ class BoolType final : public PrimitiveType {
   static const BoolType* get(Context* context);
 
   int bitwidth() const override {
-    return 8; // Chapel doesn't guarantee this bidwth, so this seems fragile...
+    return 8; // Chapel doesn't guarantee this bitwidth, so this seems fragile...
   }
 
   bool isDefaultWidth() const override {

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -196,7 +196,7 @@ PRAGMA(DEPRECATED, npr,
        "deprecated",
        "applied to symbols that are deprecated")
 PRAGMA(DEPRECATED_IMPLICIT_CONVERSION, npr,
-       "deprecated impliict conversions",
+       "deprecated implicit conversions",
        "implicit conversions when passing to this formal are deprecated")
 PRAGMA(DEPRECATED_PARENFUL, npr,
        "deprecated parenful",
@@ -377,7 +377,7 @@ PRAGMA(MANAGED_POINTER, ypr, "managed pointer", "e.g. Owned and Shared")
 PRAGMA(MANAGED_POINTER_NONNILABLE, npr, "managed pointer nonnilable", "e.g. non-nilable Owned and Shared")
 PRAGMA(MARKED_GENERIC, npr, "marked generic", "marked generic using the type query syntax")
 PRAGMA(RET_TYPE_MARKED_GENERIC, npr, "ret type marked generic", "ret type marked generic with (?)")
-PRAGMA(SUPERCLASS_MARKED_GENERIC, npr, "supreclass marked generic", "superclass is marked generic")
+PRAGMA(SUPERCLASS_MARKED_GENERIC, npr, "superclass marked generic", "superclass is marked generic")
 PRAGMA(MAYBE_ARRAY_TYPE, npr, "maybe array type", "function may be computing array type")
 PRAGMA(MAYBE_COPY_ELIDED, npr, "maybe copy elided", "symbol might be dead early due to copy elision")
 PRAGMA(MAYBE_PARAM, npr, "maybe param", "symbol can resolve to a param")

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1627,7 +1627,7 @@ isMentionOfWarnedTypeInReceiver(Context* context, ID idMention,
 
 void
 reportDeprecationWarningForId(Context* context, ID idMention, ID idTarget) {
-  // skip checks if we have a harcoded deprecation for this symbol
+  // skip checks if we have a hardcoded deprecation for this symbol
   if (hardcodedDeprecationForId(context, idMention, idTarget).empty()) {
     auto attr = parsing::idToAttributeGroup(context, idTarget);
 

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -198,7 +198,7 @@ const CompositeType* helpGetTypeForDecl(Context* context,
   return ret;
 }
 
-// TOOD:
+// TODO:
 // This code will be duplicating a lot of stuff in VarScopeVisitor, but it's
 // different enough that I don't know how to proceed. I'm certain that there's
 // a general way to make all these traversals work.
@@ -210,7 +210,7 @@ struct ReturnInferenceSubFrame {
   // The frame associated with the given AST node.
   owned<ReturnInferenceFrame> frame = nullptr;
   // Whether this sub-frame should be skipped when combining sub-results.
-  // Occurrs in particular when a branch is known statically not to occur.
+  // Occurs in particular when a branch is known statically not to occur.
   bool skip = false;
 
   ReturnInferenceSubFrame(const AstNode* node) : astNode(node) {}
@@ -580,7 +580,7 @@ bool ReturnTypeInferrer::enter(const Return* ret, RV& rv) {
   }
 
   if (functionKind == Function::ITER) {
-    // Plain returns don't count towards type infernence for iterators.
+    // Plain returns don't count towards type inference for iterators.
     return false;
   }
 

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -380,7 +380,7 @@ module ChapelDomain {
 
   //
   // Disallow additions and subtractions to rectangular domains of these types
-  // with a specific message, to avoid surpises.
+  // with a specific message, to avoid surprises.
   // Note: add/sub of a rectangular domain and another type will either
   // produce a generic error message or compile as a promoted expression.
   //

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -337,7 +337,7 @@ module ChapelRange {
       this._stride    = _stride;
       this._alignment =  alignmentValue;
 
-      if boundsChecking then verifyAppropriateStide(strides, _stride);
+      if boundsChecking then verifyAppropriateStride(strides, _stride);
     }
   }
 
@@ -891,7 +891,7 @@ module ChapelRange {
   private proc isNegativeStride(param strides: strideKind, stride) param
     where strides.hasSign() do return strides.isNegative();
 
-  // chpl_strideProduct(s1,s2) returns the strideKind that accomodates
+  // chpl_strideProduct(s1,s2) returns the strideKind that accommodates
   // the product of two strides that fit in 's1' and 's2'
 
   proc chpl_strideProduct(param s1: strideKind, param s2: strideKind) param {
@@ -1056,7 +1056,7 @@ module ChapelRange {
     return !assignmentIsLegal(to, from, boundKind.both);
   }
 
-  private proc verifyAppropriateStide(param strides, stride) {
+  private proc verifyAppropriateStride(param strides, stride) {
     if strides.isPositive() then assert(stride > 0);
     if strides.isNegative() then assert(stride < 0);
   }
@@ -1069,7 +1069,7 @@ module ChapelRange {
     this._low  = chpl__idxToInt(low):  this.chpl_integralIdxType;
     this._high = chpl__idxToInt(high): this.chpl_integralIdxType;
     if this.hasParamStrideAltvalAld() {
-      if boundsChecking then verifyAppropriateStide(this.strides, stride);
+      if boundsChecking then verifyAppropriateStride(this.strides, stride);
     } else {
       this._stride    = stride: this.strType;
       const first     = if this.hasPositiveStride() then low else high;

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -56,7 +56,7 @@ module StringCasts {
     return false;
   }
 
-  // homogenous tuples of primitive type
+  // homogeneous tuples of primitive type
   operator :(x: ?k*?t, type s:string) where isPrimitiveType(t) && isHomogeneousTupleType(x.type) {
     var ret = "(";
     for param i in 0..#k {

--- a/modules/packages/YAML.chpl
+++ b/modules/packages/YAML.chpl
@@ -2052,7 +2052,7 @@ module YAML {
       var count = 0;
       // use to keep track of the current position in a class hierarchy
       //  when child classes are being (de)serialized, the parent classes
-      //  deserializing intializer is also called; however, only one new
+      //  deserializing initializer is also called; however, only one new
       //  mapping should be opened for each class. This counter is used
       //  to prevent multiple mappings from being opened.
       var classDepth = 0;

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -591,7 +591,7 @@ module BigInteger {
 
     .. warning::
        If the resulting exponent from the conversion is too big, the result is
-       system dependant. If supported, an infinity may be returned. A hardware
+       system dependent. If supported, an infinity may be returned. A hardware
        overflow trap may also occur.
 
     .. seealso::

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -65,7 +65,7 @@ module GPU
      size of this buffer.
    */
   proc gpuWrite(const args ...?k) {
-    // Right now this function will only work if passed argumets are of type
+    // Right now this function will only work if passed arguments are of type
     // c_ptrConst(c_char).
     // I would prefer to do some string processing within the
     // function so I could pass in arguments other than C types.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4352,7 +4352,7 @@ record binaryDeserializer {
     /*
       Deserialize ``element`` in-place as an element of the array.
     */
-    proc readElment(ref element) throws {
+    proc readElement(ref element) throws {
       reader.read(element);
     }
 

--- a/runtime/include/qio/qio_style.h
+++ b/runtime/include/qio/qio_style.h
@@ -154,7 +154,7 @@ typedef struct qio_style_s {
                  // 2 == write positive numbers preceded by pad_char
   uint8_t uppercase; // numeric stuff is uppercase
   // control left/center/right justification:
-  //  Right padding is on by default. If leftjustify or centjusify is set to 1,
+  //  Right padding is on by default. If leftjustify or centjustify is set to 1,
   //  left or center justification will be used instead.
   uint8_t leftjustify; // 1 == left, 0 == right || cent
   uint8_t centjustify; // 1 == center, 0 == right || left

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -460,7 +460,7 @@ void chpl_gpu_copy_device_to_device(c_sublocid_t dst_dev, void* dst,
   void* stream = get_stream(dst_dev);
   chpl_gpu_impl_copy_device_to_device(dst, src, n, stream);
   if (dst_dev != src_dev) {
-    // going to a device that maybe used by a different task, synchornize
+    // going to a device that maybe used by a different task, synchronize
     wait_stream(stream);
   }
   else if (chpl_gpu_sync_with_host) {

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -227,7 +227,7 @@ void chpl_rt_init(int argc, char* argv[]) {
 
 
   //
-  // Intialization of the topo, comm, mem, and task layers is tricky because
+  // Initialization of the topo, comm, mem, and task layers is tricky because
   // they have inter-twined dependencies and there isn't a linear ordering
   // in which they can be completely initialized.
   // Here is a general summary of what these functions do, in order:

--- a/test/release/examples/primers/arrays.chpl
+++ b/test/release/examples/primers/arrays.chpl
@@ -130,7 +130,7 @@ writeln("After incrementing B's elements, B is:\n", B, "\n");
 // represent the five values in its initializing expression.
 //
 // The explicit ``ref`` intent is required for ``B`` in the example below
-// because ``B`` is not modifed directly through the loop's index variable (in
+// because ``B`` is not modified directly through the loop's index variable (in
 // this case ``i`` and ``j``).
 //
 // An array's domain can be queried using the ``.domain`` method,


### PR DESCRIPTION
Fix typos in

chpl-init.c chpl-gpu.c qio_style.h
IO.chpl GPU.chpl BigInteger.chpl YAML.chpl
StringCasts.chpl ChapelRange.chpl ChapelDomain.chpl
primers/arrays.chpl
return-type-inference.cpp parsing-queries.cpp PragmaList.h BoolType.h
arrays.rst, procedures.rst, gpu.rst
preFold.cpp interfaceResolution.cpp functionResolution.cpp
normalize.cpp loopInvariantCodeMotion.cpp
