### PR TITLE
Fix unstable warning for extern array formals

### DIFF
--- a/compiler/passes/expandExternArrayCalls.cpp
+++ b/compiler/passes/expandExternArrayCalls.cpp
@@ -65,7 +65,7 @@ bool ExpandExternArrayCalls::shouldProcess(FnSymbol* fn) {
 
   for_formals(formal, fn) {
     if (isFormalArray(formal)) {
-      if (fWarnUnstable)
+      if (shouldWarnUnstableFor(formal))
         USR_WARN(fn,
                  "using a Chapel array type in an 'extern proc' is unstable "
                  "and may change in the future");

--- a/test/unstable/externProcArrayFormalStandard.chpl
+++ b/test/unstable/externProcArrayFormalStandard.chpl
@@ -1,0 +1,1 @@
+use LinearAlgebra;

--- a/test/unstable/externProcArrayFormalStandard.compopts
+++ b/test/unstable/externProcArrayFormalStandard.compopts
@@ -1,0 +1,1 @@
+--warn-unstable-standard

--- a/test/unstable/externProcArrayFormalStandard.good
+++ b/test/unstable/externProcArrayFormalStandard.good
@@ -1,0 +1,1 @@
+unstable warning was thrown

--- a/test/unstable/externProcArrayFormalStandard.noexec
+++ b/test/unstable/externProcArrayFormalStandard.noexec
@@ -1,0 +1,1 @@
+use LinearAlgebra;

--- a/test/unstable/externProcArrayFormalStandard.noexec
+++ b/test/unstable/externProcArrayFormalStandard.noexec
@@ -1,1 +1,0 @@
-use LinearAlgebra;

--- a/test/unstable/externProcArrayFormalStandard.prediff
+++ b/test/unstable/externProcArrayFormalStandard.prediff
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+
+TESTNAME=sys.argv[1]
+OUTFILE=sys.argv[2]
+
+hasWarning = False
+with open(OUTFILE, "r") as f:
+  for l in f.readlines():
+    if "warning: using a Chapel array type in an 'extern proc' is unstable and may change in the future" in l:
+      hasWarning = True
+
+if hasWarning:
+  with open(OUTFILE, "w") as f:
+    f.write("unstable warning was thrown\n")


### PR DESCRIPTION
Makes the unstable warning for extern proc array formals respect the `--warn-unstable-internal` and `--warn-unstable-standard` flags.

Added a test for `--warn-unstable-standard` on extern proc array formals

Tested with paratest and paratest with gasnet

[Reviewed by @lydia-duncan ]