### PR TITLE
Update release and main formulas to include settings from last release

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,27 +1,25 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.28.0/chapel-1.28.0.tar.gz"
-  sha256 "64eacfb5915e1b3c487e865f819faf9bb8771c9f83aac6512698ded1baab250e"
+  url "https://github.com/chapel-lang/chapel/releases/download/1.31.0/chapel-1.31.0.tar.gz"
+  sha256 "4b861c9a354f6fcf66081256f7ec703d6dd2cd68ea363b400d10ac00bf308679"
   license "Apache-2.0"
-  revision 1
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   bottle do
-    sha256 arm64_ventura:  "02f2f907d5564b80034d763144584b56c551d3ee6024dba84f77a18e3581dddf"
-    sha256 arm64_monterey: "16e3fd0177ab450a788271b0e38e417ec459fc91d70b8d388a9fe85e78d0291b"
-    sha256 arm64_big_sur:  "c36c6e7cf4b30fefb9fe65aec07a04afdb168765c1a417318f75f65df0b4bd94"
-    sha256 ventura:        "bc45e9b7ea5aa0cc14b1158c4b62f88498f570a682b4128c2c5feee7ef41e9c8"
-    sha256 monterey:       "e2d386f7f931f4c684f5aa325b56c678fc1613935404d40de5d9e09933a3e41b"
-    sha256 big_sur:        "97697fee3e47ad73ad0e2cb80078ea2a7dd1110fa06e297e8b076fff4ec3bc84"
-    sha256 catalina:       "4a588c9b8fdb17f01109be986a3d8df929eb666ddc403499ffdaabd2d174e8e1"
-    sha256 x86_64_linux:   "44e78c563407371437e9cb150ffd1b1f02dfd6f2643ec82d88322ad5665346a1"
+    sha256 arm64_ventura:  "8563f116d96b3c89a6de8316020ab25fd27be13f7641d8f223c7c79770eba8ca"
+    sha256 arm64_monterey: "6f6da8d43cd744b9e6a8f0026962dcb66c86fe4ffb5dc684e5302a58fbd01247"
+    sha256 arm64_big_sur:  "d8e8968e2a6a885e54ae793a64f3c04808325bd9b35544605f39a4402c827a53"
+    sha256 ventura:        "fd44d28f8b6a382bda9e5674751b6a0033b9f5a42ab836ac7b305a9a3ba43167"
+    sha256 monterey:       "5a446383b71d0ceb4dec422970758814f42f938ead19691797cfb8a549e82fcf"
+    sha256 big_sur:        "d0ec7384c879c36473cd676307d4364d4275d3a9153975c1fa0a1c6057bedcec"
+    sha256 x86_64_linux:   "dfbcffa1fa5acc1f8ff983b47a3617c8cdaa40c7a218ab8db24e4b165eeef431"
   end
 
+  depends_on "cmake"
   depends_on "gmp"
   depends_on "llvm@14"
-  depends_on "python@3.10"
-  depends_on "cmake"
+  depends_on "python@3.11"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"
@@ -38,8 +36,8 @@ class Chapel < Formula
 
   def install
     # Always detect Python used as dependency rather than needing aliased Python formula
-    python = "python3.10"
-    # It should be noted that this will expand to: 'for cmd in python3.10 python3 python python2; do'
+    python = "python3.11"
+    # It should be noted that this will expand to: 'for cmd in python3.11 python3 python python2; do'
     # in our find-python.sh script.
     inreplace "util/config/find-python.sh", /^(for cmd in )(python3 )/, "\\1#{python} \\2"
 
@@ -47,10 +45,6 @@ class Chapel < Formula
     # Chapel uses this ENV to work out where to install.
     ENV["CHPL_HOME"] = libexec
     ENV["CHPL_GMP"] = "system"
-    # This enables a workaround for
-    #   https://github.com/llvm/llvm-project/issues/54438
-    ENV["CHPL_HOST_USE_SYSTEM_LIBCXX"] = "yes"
-
     # don't try to set CHPL_LLVM_GCC_PREFIX since the llvm
     # package should be configured to use a reasonable GCC
     (libexec/"chplconfig").write <<~EOS


### PR DESCRIPTION
The homebrew formulas are out of date with what is released on
homebrew-core.   This update brings them back into alignment.   The
chapel-release.rb formula is what is available in homebrew-core, and
the chapel-main.rb will be the formula used for the next Chapel
release.