### PR TITLE
Fix the launch command and the input file path

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -87,7 +87,7 @@ function test_run() {
   local nl=$2
 
   test_start "run $kind"
-  $CHPL_TEST_LAUNCHCMD ./bin/champs_${CHAMPS_VERSION}_$kind -nl $nl -f $CHAMPS_CFG_PATH/$kind.in 2>&1 >$kind.exec.out.tmp
+  eval $CHPL_TEST_LAUNCHCMD ./bin/champs_${CHAMPS_VERSION}_$kind -nl $nl -f $CHAMPS_CFG_PATH/$kind.in 2>&1 >$kind.exec.out.tmp
 
   local status=$?
   cat $kind.exec.out.tmp

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -42,7 +42,6 @@ if [ "${CHPL_LLVM}" != "none" ] ; then
   apply_patch $CHAMPS_PATCH_PATH/optional/llvm.patch
 fi
 
-
 # Compile CHAMPS executables
 test_compile prep
 test_compile flow
@@ -69,8 +68,8 @@ test_compile coloring
 # cp $CHAMPS_DATA_PATH/CRMHL_coarse.cgns $CHAMPS_HOME/
 # test_run prep 1
 
-# as a temporary workaround, copy the prepartitoned grid for 16 locales
-cp $CHAMPS_DATA_PATH/CRMHL_coarse_768B.cgns $CHAMPS_HOME/
+# copy the prepartitoned grid for 16 locales into scratch space
+cp $CHAMPS_DATA_PATH/CRMHL_coarse_1152B.cgns $CHAMPS_HOME/
 test_run flow 16
 
 $CHPL_HOME/util/test/genGraphs --configs $CHPL_TEST_PERF_CONFIGS --annotate $CHPL_HOME/test/ANNOTATIONS.yaml --name $CHPL_TEST_PERF_CONFIG_NAME --perfdir $CHPL_TEST_PERF_DIR --outdir $CHPL_TEST_PERF_DIR/html --graphlist $CHAMPS_GRAPH_PATH/GRAPHLIST --testdir $CHAMPS_GRAPH_PATH --alttitle "CHAMPS Performance Graphs"


### PR DESCRIPTION
The PR has two fixes:

- Uses `eval` to be able to handle `$CHPL_TEST_LAUNCHCMD`
- Fixes the input file's name that I forgot we have in the script