### PR TITLE
Update spec for deprecated modification of indirect whole array indexing 

### DIFF
--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -426,7 +426,7 @@ destroyed.
       do
         writeln("shadow var: ", tpv.id, "  yield: ", str);
 
-   
+
 
    .. BLOCK-test-chapelprediff
 
@@ -750,6 +750,45 @@ side array expressions alias the left-hand side expression.
    This follows because, in the former code, some of the new values that
    are assigned to ``A`` may be read to compute the sum depending on the
    number of tasks used to implement the data parallel statement.
+
+.. _Indirect_Whole_Array_Indexing:
+
+Indirect Whole Array Indexing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Arrays can be indexed indirectly using an array of indies.
+Given an array ``A`` and an array of indices ``B`` in the domain of ``A``,
+the function call
+
+.. code-block:: chapel
+
+   f(A[B]);
+
+is equivalent to
+
+.. code-block:: chapel
+
+   [b in B] f(A[b]);
+
+This a legal expression only if the result of the promotion ``A[B]`` is not modified.
+The following statement
+
+.. code-block:: chapel
+
+   A[B] += 3;
+
+is equivalent to
+
+.. code-block:: chapel
+
+   [b in B] A[b] += 3;
+
+which is not legal, as ``A`` cannot be modified without an explicit ``ref`` shadow variable.
+To modify the result of the promotion, the equivalent pattern can be used.
+
+.. code-block:: chapel
+
+   [b in B with (ref A)] do A[b] += 3;
 
 .. _Reductions_and_Scans:
 

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -756,7 +756,7 @@ side array expressions alias the left-hand side expression.
 Indirect Whole Array Indexing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Arrays can be indexed indirectly using an array of indies.
+Arrays can be indexed indirectly using an array of indices.
 Given an array ``A`` and an array of indices ``B`` in the domain of ``A``,
 the function call
 
@@ -770,7 +770,7 @@ is equivalent to
 
    [b in B] f(A[b]);
 
-This a legal expression only if the result of the promotion ``A[B]`` is not modified.
+This is a legal expression only if the result of the promotion ``A[B]`` is not modified.
 The following statement
 
 .. code-block:: chapel


### PR DESCRIPTION
Updates the spec on promotion to include a section on indirect whole array indexing. This also calls out the soon-to-be-an-error `A[B] += 3` pattern deprecated in #23208

[Reviewed by @arezaii]