### PR TITLE
Add note on array formal intents to extern technote

### DIFF
--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -540,7 +540,7 @@ The Chapel compiler will then rewrite any calls to `foo` like this:
 
 The Chapel compiler will also respect intents for the formal.
 The default intent will result in a call to ``c_ptrToConst``
-while an intent like ``ref`` wil result in an call to ``c_ptrTo``.
+while an intent like ``ref`` will result in a call to ``c_ptrTo``.
 
 Note that this same technique won't work for distributed rectangular arrays,
 nor for associative, sparse, or opaque arrays because their data isn't

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -536,7 +536,11 @@ The Chapel compiler will then rewrite any calls to `foo` like this:
 
 .. code-block:: chapel
 
-      foo(x, 10); // -> foo(c_ptrTo(x), 10);
+      foo(x, 10); // -> foo(c_ptrToConst(x), 10);
+
+The Chapel compiler will also respect intents for the formal.
+The default intent will result in a call to ``c_ptrToConst``
+while an intent like ``ref`` wil result in an call to ``c_ptrTo``.
 
 Note that this same technique won't work for distributed rectangular arrays,
 nor for associative, sparse, or opaque arrays because their data isn't


### PR DESCRIPTION
Adds a note about how extern procedures respect intents with regards to `c_ptrTo` and `c_ptrToConst`.

This does not call out that the feature is unstable, as this is tech note and inherently an unstable/experimental feature.

[Reviewed by @arezaii]