### PR TITLE
Issue a warning in chpl_launchcmd for  arguments

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -549,6 +549,7 @@ class AbstractJob(object):
         """
         args, unparsed_args = cls._parse_args()
         cls._setup_logging(args.verbose, args.info)
+        cls._validate_args(args, unparsed_args)
 
         logging.info('Num locales is: {0}'.format(args.numLocales))
         logging.info('Walltime is set to: {0}'.format(args.walltime))
@@ -618,6 +619,16 @@ class AbstractJob(object):
                 pass
 
         raise ValueError('Did not recognize walltime: {0}'.format(walltime_str))
+
+    @classmethod
+    def _validate_args(cls, args, unparsed_args):
+        for arg in unparsed_args:
+            if re.search(r'-nl', arg):
+                # TODO parse this quietly, or turn it into an error?
+                logging.warning('Argument format {} is not supported. '
+                                'Please put a space between "-nl" and number of '
+                                'locales, if that\'s the purpose.'.format(arg))
+
 
     @classmethod
     def _get_test_command(cls, args, unparsed_args):

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -623,7 +623,7 @@ class AbstractJob(object):
     @classmethod
     def _validate_args(cls, args, unparsed_args):
         for arg in unparsed_args:
-            if re.search(r'-nl', arg):
+            if re.search(r'^-nl[0-9]+$', arg):
                 # TODO parse this quietly, or turn it into an error?
                 logging.warning('Argument format {} is not supported. '
                                 'Please put a space between "-nl" and number of '


### PR DESCRIPTION
This PR causes the following warning to be generated when `-nlX` is passed for number of locales to the `chpl_launchcmd`.

```
[chpl_launchcmd] 2023-09-18 11:57:27,200 [WARNING] Argument format -nl4 is not supported. Please put a space between "-nl" and number of locales, if that's the purpose.
```

I think we can make this parse fine, but for the time being I am just issuing a warning to avoid issues in nightly testing.