### PR TITLE
Doc changes for range/domain unstable/deprecated

### DIFF
--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -241,6 +241,13 @@ list of index-to-value bindings within square brackets. It is expected
 that the indices in the listing match in type and, likewise, the types
 of values in the listing also match. A trailing comma is allowed.
 
+.. warning::
+
+   Associative domains and arrays are currently unstable.
+   Their functionality is likely to change in the future.
+   Chapel provides stable `map` and `set` data types
+   [see modules :mod:`Set` and :mod:`Map`]
+   that can be used instead in many cases.
 
 
 .. code-block:: syntax
@@ -882,6 +889,13 @@ the *zero value*, but we refer to it as the *implicitly replicated
 value* or *IRV* since it can take on any value of the array’s element
 type in practice including non-zero numeric values, a class reference, a
 record or tuple value, etc.
+
+   .. warning::
+
+      Sparse domains and arrays are currently unstable.
+      Their functionality is likely to change in the future.
+
+
 
 An array declared over a sparse domain can be indexed using any of the
 indices in the sparse domain’s parent domain. If it is read using an

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -181,21 +181,21 @@ where ``named-expression-list`` allows specifying the values of ``rank``,
    *Example (typeFunctionDomain.chpl)*.
 
    The following declarations both create an uninitialized rectangular
-   domain with three dimensions, with ``int`` indices: 
+   domain with three dimensions, with ``int`` indices:
 
    .. code-block:: chapel
 
       var D1 : domain(rank=3, idxType=int, strides=strideKind.one);
       var D2 : domain(3);
 
-   
+
 
    .. BLOCK-test-chapelpost
 
       writeln(D1);
       writeln(D2);
 
-   
+
 
    .. BLOCK-test-chapeloutput
 
@@ -261,7 +261,7 @@ A domain expression may contain bounds which are evaluated at runtime.
 
    *Example*.
 
-   In the code 
+   In the code
 
    .. code-block:: chapel
 
@@ -298,7 +298,7 @@ for type:
           A[i,j] = 7 * i**2 + j;
       writeln(A);
 
-   produces 
+   produces
 
    .. code-block:: printoutput
 
@@ -313,6 +313,16 @@ type and can be used to describe sets or to create dictionary-style
 arrays (hash tables). The type of indices of an associative domain, or
 its ``idxType``, can be any primitive type except ``void`` or any class
 type.
+
+
+   .. warning::
+
+      Associative domains and arrays are currently unstable.
+      Their functionality is likely to change in the future.
+      Chapel provides stable `map` and `set` data types
+      [see modules :mod:`Set` and :mod:`Map`]
+      that can be used instead in many cases.
+
 
 .. _Associative_Domain_Types:
 
@@ -372,7 +382,7 @@ the indices does not match a compiler error will be issued.
    .. note::
 
       *Future*
-      
+
       Due to implementation of ``==`` over arrays it is currently not possible
       to use arrays as indices within an associative domain.
 
@@ -386,14 +396,14 @@ the indices does not match a compiler error will be issued.
    associative domain are iterated is not the same as their
    specification order.
 
-   This code 
+   This code
 
    .. code-block:: chapel
 
       var D : domain(string) = {"bar", "foo"};
       writeln(D);
 
-   produces the output 
+   produces the output
 
    .. code-block:: printoutput
 
@@ -480,6 +490,12 @@ parent domain.
 
 Sparse Subdomain Types and Values
 ---------------------------------
+
+   .. warning::
+
+      Sparse domains and arrays are currently unstable.
+      Their functionality is likely to change in the future.
+
 
 .. code-block:: syntax
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -433,6 +433,15 @@ Range Comparisons
 
 Ranges can be compared using equality and inequality.
 
+.. warning::
+
+   Equality comparisons for ranges over ``enum`` or ``bool`` types
+   when one of the ranges is bounded and the other is unbounded
+   is currently unstable.
+   We currently treat both ranges as being bounded.
+   This functionality is likely to change in the future.
+
+
 .. function:: operator ==(r1: range(?), r2: range(?)): bool
 
    Returns ``true`` if the two ranges have the same represented sequence or

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -426,6 +426,11 @@ Range assignment is legal when:
 -  the ``strides`` parameter of the destination range is the same
    or more permissive than that of the source range.
 
+.. warning::
+
+   The ability to assign between two unbounded ranges with
+   incompatible idxTypes is deprecated.
+
 .. _Range_Comparisons:
 
 Range Comparisons

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -444,7 +444,7 @@ Ranges can be compared using equality and inequality.
    when one of the ranges is bounded and the other is unbounded
    is currently unstable.
    We currently treat both ranges as being bounded.
-   This functionality is likely to change in the future.
+   This might change in the future.
 
 
 .. function:: operator ==(r1: range(?), r2: range(?)): bool

--- a/test/release/examples/primers/associative.chpl
+++ b/test/release/examples/primers/associative.chpl
@@ -8,6 +8,14 @@
   :ref:`domains.chpl <primers-domains>` primers before proceeding if you're not
   already familiar with Chapel's domains and arrays.
 
+  .. warning::
+
+    Associative domains and arrays are currently unstable.
+    Their functionality is likely to change in the future.
+    Chapel provides stable `map` and `set` data types
+    [see modules :mod:`Set` and :mod:`Map`]
+    that can be used instead in many cases.
+
 */
 
 //

--- a/test/release/examples/primers/domains.chpl
+++ b/test/release/examples/primers/domains.chpl
@@ -84,6 +84,13 @@ writeln(RDtrans_n);
 //
 // Create rectangular subdomains.
 //
+/*
+  .. warning::
+
+    Sparse domains and arrays are currently unstable.
+    Their functionality is likely to change in the future.
+
+*/
 var RSD1, RSD2 : subdomain(RD);
 
 // A subdomain is initially empty.

--- a/test/release/examples/primers/sparse.chpl
+++ b/test/release/examples/primers/sparse.chpl
@@ -4,6 +4,12 @@
    This primer shows off some of Chapel's support for sparse domains
    and arrays.
 
+  .. warning::
+
+    Sparse domains and arrays are currently unstable.
+    Their functionality is likely to change in the future.
+
+
 */
 
 


### PR DESCRIPTION
This PR updates documentation for the following changes:
- Sparse Domains were marked unstable. (#22741 )
- Associative Domains were marked unstable. (#23117)
- equality between unbounded ranges over enum's and bools was marked
unstable  (#23036) 
- deprecate assignment between unbounded ranges with incompatible idxtypes(#22823)

