### PR TITLE
Split shootout compatibility module into three — normal, GMP, and RE2

### DIFF
--- a/test/studies/shootout/submitted/Compat.chpl
+++ b/test/studies/shootout/submitted/Compat.chpl
@@ -1,21 +1,6 @@
-use IO, BigInteger, Regex;
+use IO;
 
 @deprecated("openfd is deprecated, please use the file initializer with a 'c_int' argument instead")
 proc openfd(x) {
   return new file(x);
-}
-
-@deprecated("bigint.div_q using Round is deprecated, use the standalone function div with roundingMode instead")
-proc ref bigint.div_q(x, y) {
-  div(this, x, y);
-}
-
-@deprecated("'Regex.compile' is deprecated. Please use 'new regex()' instead.")
-proc compile(x) {
-  return new regex(x);
-}
-
-@deprecated("regex.sub is deprecated. Please use string.replace.")
-proc regex.sub(x, y) {
-  return y.replace(this, x);
 }

--- a/test/studies/shootout/submitted/CompatGMP.chpl
+++ b/test/studies/shootout/submitted/CompatGMP.chpl
@@ -1,0 +1,6 @@
+use BigInteger;
+
+@deprecated("bigint.div_q using Round is deprecated, use the standalone function div with roundingMode instead")
+proc ref bigint.div_q(x, y) {
+  div(this, x, y);
+}

--- a/test/studies/shootout/submitted/CompatGMP.notest
+++ b/test/studies/shootout/submitted/CompatGMP.notest
@@ -1,0 +1,1 @@
+Compatability shim

--- a/test/studies/shootout/submitted/CompatRE2.chpl
+++ b/test/studies/shootout/submitted/CompatRE2.chpl
@@ -1,0 +1,11 @@
+use Regex;
+
+@deprecated("'Regex.compile' is deprecated. Please use 'new regex()' instead.")
+proc compile(x) {
+  return new regex(x);
+}
+
+@deprecated("regex.sub is deprecated. Please use string.replace.")
+proc regex.sub(x, y) {
+  return y.replace(this, x);
+}

--- a/test/studies/shootout/submitted/CompatRE2.notest
+++ b/test/studies/shootout/submitted/CompatRE2.notest
@@ -1,0 +1,1 @@
+Compatability shim

--- a/test/studies/shootout/submitted/pidigits2.chpl
+++ b/test/studies/shootout/submitted/pidigits2.chpl
@@ -68,4 +68,4 @@ iter genDigits(numDigits) {
     numer *= 10;
   }
 }
-use Compat;
+use Compat, CompatGMP;

--- a/test/studies/shootout/submitted/regexredux2.chpl
+++ b/test/studies/shootout/submitted/regexredux2.chpl
@@ -58,4 +58,4 @@ proc main(args: [] string) {
   writeln(data.size);
   writeln(copy.size);
 }
-use Compat;
+use Compat, CompatRE2;

--- a/test/studies/shootout/submitted/regexredux3.chpl
+++ b/test/studies/shootout/submitted/regexredux3.chpl
@@ -59,4 +59,4 @@ proc main(args: [] string) {
   writeln(data.size);
   writeln(copy.size);
 }
-use Compat;
+use Compat, CompatRE2;


### PR DESCRIPTION
In #23428, I failed to recognize the obvious — that in introducing my 'Compat' module, I was infecting all tests that used it with potential dependencies (GMP, RE2) that their skipifs wouldn't skip past.  Here, I'm splitting the Compat module into three so that each test can only bring in those third-party dependencies that it was already expecting to use.
